### PR TITLE
fix(ci): add git-crypt to CD smoke test job

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -220,6 +220,22 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
+    - name: Install git-crypt
+      run: sudo apt-get update && sudo apt-get install -y git-crypt
+
+    - name: Unlock git-crypt
+      env:
+        GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+      run: |
+        if [ -n "$GIT_CRYPT_KEY" ]; then
+          echo "$GIT_CRYPT_KEY" | base64 -d > /tmp/git-crypt-key
+          git-crypt unlock /tmp/git-crypt-key
+          rm /tmp/git-crypt-key
+          echo "✅ git-crypt unlocked"
+        else
+          echo "⚠️ GIT_CRYPT_KEY not set"
+        fi
+
     - name: Setup Python
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
## Summary
- Added git-crypt install and unlock steps to the CD smoke test job
- Fixes TypeScript compilation failure when encrypted config files can't be read

## Test plan
- [x] CI passes on this PR
- [ ] After merge, trigger CD workflow for v1.0.0