### PR TITLE
fix(ci): update cliff.toml repo name to kindred

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -11,7 +11,7 @@ trim = true
 
 [remote.github]
 owner = "adamflagg"
-repo = "bunking"
+repo = "kindred"
 
 [git]
 conventional_commits = true


### PR DESCRIPTION
Updates repo name from 'bunking' to 'kindred' for changelog generation.