### PR TITLE
fix(docker): use fixed UID/GID for non-root user

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -492,7 +492,10 @@ jobs:
         AUTH_MODE=bypass
         EOF
 
-        mkdir -p ${CI_DIR}/kindred/pocketbase
+        # Create directory matching docker-compose volume mount path
+        mkdir -p ${CI_DIR}/bunking/pocketbase
+        # Set ownership to match container user (1000:1000)
+        sudo chown -R 1000:1000 ${CI_DIR}/bunking/pocketbase
 
     - name: Create test network
       run: docker network create app-bridge-${{ github.run_id }} || true
@@ -578,6 +581,22 @@ jobs:
         test_endpoint "http://${KINDRED_IP}:8080/api/collections/_superusers/records" "PocketBase collections" || exit 1
 
         echo "✅ All integration tests passed!"
+
+    - name: Verify non-root user and write permissions
+      run: |
+        CONTAINER_NAME="kindred-ci-${{ github.run_id }}-kindred-1"
+
+        # Verify container runs as non-root
+        CONTAINER_USER=$(docker exec ${CONTAINER_NAME} id -u)
+        if [ "$CONTAINER_USER" = "0" ]; then
+          echo "❌ Container is running as root!"
+          exit 1
+        fi
+        echo "✓ Container running as UID: $CONTAINER_USER"
+
+        # Verify database is writable (migration already proved this, but explicit test)
+        docker exec ${CONTAINER_NAME} sh -c "touch /pb_data/write_test && rm /pb_data/write_test"
+        echo "✓ Database directory is writable by non-root user"
 
     - name: Show logs on failure
       if: failure()

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Stage 4: Final runtime image - Combined Caddy + PocketBase + FastAPI
 # =============================================================================
 FROM python:3.13-slim
-RUN groupadd -r kindred && useradd -r -g kindred kindred
+# Use fixed UID/GID 1000 (standard first non-root user) for predictable volume permissions
+# Can be overridden via docker-compose user: directive with PUID/PGID env vars
+RUN groupadd -r -g 1000 kindred && useradd -r -g kindred -u 1000 kindred
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     image: ghcr.io/adamflagg/kindred:${IMAGE_TAG:-latest}
     container_name: kindred
     restart: unless-stopped
+    user: "${PUID:-1000}:${PGID:-1000}"
     volumes:
       - ${APPDATA_DIR}/bunking/pocketbase:/pb_data
     environment:


### PR DESCRIPTION
## Summary
- Set kindred user to UID/GID 1000 (standard first non-root user)
- Add `user:` directive to docker-compose.yml with PUID/PGID env var support
- Fix CD integration test volume path (`bunking/` not `kindred/`)
- Add explicit non-root and write permission verification in CD

## Problem
Production deployment failed after security hardening with:
```
attempt to write a readonly database (1544)
```

The dynamically-assigned UID/GID for the `kindred` user didn't match the host volume ownership.

## Solution
- Use fixed UID 1000/GID 1000 (standard first non-root user on most Linux systems)
- Allow override via `PUID`/`PGID` environment variables in docker-compose

## Deployment Note
For existing deployments, run:
```bash
sudo chown -R 1000:1000 ${APPDATA_DIR}/bunking/pocketbase
```
Or set `PUID`/`PGID` in `.env` to match existing volume ownership.

## Test plan
- [x] CI passes with new permission verification step
- [ ] Local docker build works with bind mount
- [ ] Production deployment succeeds after chown