### PR TITLE
fix(scripts): remove duplicate PR references in changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -3,7 +3,7 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | striptags | trim | upper_first }}
 {% for commit in commits -%}
-* {{ commit.id }}: {{ commit.raw_message | split(pat="\n") | first | trim }}{% if commit.remote.pr_number %} (#{{ commit.remote.pr_number }}){% endif %}{% if commit.remote.username %} (@{{ commit.remote.username }}){% endif %}
+* {{ commit.id }}: {{ commit.raw_message | split(pat="\n") | first | trim }}{% if commit.remote.username %} (@{{ commit.remote.username }}){% endif %}
 {% endfor %}
 {% endfor %}
 """


### PR DESCRIPTION
## Summary
- Fix duplicate PR references in git-cliff changelog output (e.g., `(#8) (#8)`)
- GitHub squash merges already include PR numbers in commit messages
- Removed redundant `{% if commit.remote.pr_number %}` append from cliff.toml template

## Test plan
- [x] Run `./scripts/release.sh --dry-run` and verify PR numbers appear once