### PR TITLE
fix(docker): CI network override and local build major tags

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -22,6 +22,6 @@ networks:
   kindred-ci:
     driver: bridge
   # Override web-proxy from base file to not be external
-  # (Docker Compose merges network definitions, so we must override it)
+  # Must explicitly set external: false (compose merges properties, not replaces)
   web-proxy:
-    driver: bridge
+    external: false

--- a/scripts/docker/build_and_push.sh
+++ b/scripts/docker/build_and_push.sh
@@ -41,11 +41,14 @@ IMAGE_TAG="${IMAGE_TAG:-$(date +%Y.%m.%d)}"
 # Handle semver tags (v0.7.0 -> 0.7.0)
 DOCKER_TAG="$IMAGE_TAG"
 MINOR_TAG=""
+MAJOR_TAG=""
 if [[ "$IMAGE_TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+ ]]; then
     # Strip v prefix for Docker tag
     DOCKER_TAG="${IMAGE_TAG#v}"
-    # Extract minor version (0.7 from 0.7.0)
+    # Extract minor version (1.1 from 1.1.1)
     MINOR_TAG=$(echo "$DOCKER_TAG" | cut -d. -f1-2)
+    # Extract major version (1 from 1.1.1)
+    MAJOR_TAG=$(echo "$DOCKER_TAG" | cut -d. -f1)
 fi
 
 if [[ "$BUILD_ONLY" == "true" ]]; then
@@ -57,6 +60,9 @@ echo "Registry: $REGISTRY/$USERNAME"
 echo "Tag: $DOCKER_TAG"
 if [[ -n "$MINOR_TAG" && "$MINOR_TAG" != "$DOCKER_TAG" ]]; then
     echo "Minor tag: $MINOR_TAG"
+fi
+if [[ -n "$MAJOR_TAG" && "$MAJOR_TAG" != "$MINOR_TAG" ]]; then
+    echo "Major tag: $MAJOR_TAG"
 fi
 echo ""
 
@@ -86,6 +92,11 @@ if [[ -n "$MINOR_TAG" && "$MINOR_TAG" != "$DOCKER_TAG" ]]; then
     docker tag "$REGISTRY/$USERNAME/kindred:$DOCKER_TAG" "$REGISTRY/$USERNAME/kindred:$MINOR_TAG"
 fi
 
+# Add major version tag if semver
+if [[ -n "$MAJOR_TAG" && "$MAJOR_TAG" != "$MINOR_TAG" ]]; then
+    docker tag "$REGISTRY/$USERNAME/kindred:$DOCKER_TAG" "$REGISTRY/$USERNAME/kindred:$MAJOR_TAG"
+fi
+
 # Push images (unless --build-only)
 if [[ "$BUILD_ONLY" == "true" ]]; then
     echo ""
@@ -95,6 +106,9 @@ if [[ "$BUILD_ONLY" == "true" ]]; then
     echo "  - $REGISTRY/$USERNAME/kindred:$DOCKER_TAG"
     if [[ -n "$MINOR_TAG" && "$MINOR_TAG" != "$DOCKER_TAG" ]]; then
         echo "  - $REGISTRY/$USERNAME/kindred:$MINOR_TAG"
+    fi
+    if [[ -n "$MAJOR_TAG" && "$MAJOR_TAG" != "$MINOR_TAG" ]]; then
+        echo "  - $REGISTRY/$USERNAME/kindred:$MAJOR_TAG"
     fi
     echo "  - $REGISTRY/$USERNAME/kindred:latest"
 else
@@ -109,6 +123,11 @@ else
         docker push "$REGISTRY/$USERNAME/kindred:$MINOR_TAG"
     fi
 
+    if [[ -n "$MAJOR_TAG" && "$MAJOR_TAG" != "$MINOR_TAG" ]]; then
+        echo "Pushing kindred:$MAJOR_TAG..."
+        docker push "$REGISTRY/$USERNAME/kindred:$MAJOR_TAG"
+    fi
+
     echo "Pushing kindred:latest..."
     docker push "$REGISTRY/$USERNAME/kindred:latest"
 
@@ -119,6 +138,9 @@ else
     echo "  - $REGISTRY/$USERNAME/kindred:$DOCKER_TAG"
     if [[ -n "$MINOR_TAG" && "$MINOR_TAG" != "$DOCKER_TAG" ]]; then
         echo "  - $REGISTRY/$USERNAME/kindred:$MINOR_TAG"
+    fi
+    if [[ -n "$MAJOR_TAG" && "$MAJOR_TAG" != "$MINOR_TAG" ]]; then
+        echo "  - $REGISTRY/$USERNAME/kindred:$MAJOR_TAG"
     fi
     echo "  - $REGISTRY/$USERNAME/kindred:latest"
 fi


### PR DESCRIPTION
## Summary
- Fix CD integration test failure: `external: false` properly overrides base file's `external: true`
- Add major version tag to local build script for parity with CD workflow

## Test plan
- [ ] CD workflow integration tests pass (no "network web-proxy not found" error)
- [ ] Local build with `--local-build` creates major tag (e.g., `kindred:1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)