### PR TITLE
chore(ci): bump Trivy scanner to v0.68.2

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -610,6 +610,7 @@ jobs:
       uses: aquasecurity/trivy-action@0.33.1
       with:
         image-ref: ${{ env.REGISTRY }}/${{ env.USERNAME }}/${{ matrix.image }}:test
+        version: 'v0.68.2'
         format: 'sarif'
         output: 'trivy-results-${{ matrix.image }}.sarif'
         severity: 'CRITICAL,HIGH'


### PR DESCRIPTION
## Summary
- Bump Trivy scanner from v0.68.1 (action default) to v0.68.2
- Overrides `aquasecurity/trivy-action@0.33.1` default version

## Test plan
- [ ] CI passes with new Trivy version
- [ ] Security scan still uploads SARIF results to GitHub Security tab