### PR TITLE
fix(scripts): filter duplicate commits in git-cliff changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -16,17 +16,36 @@ repo = "kindred"
 [git]
 conventional_commits = true
 filter_unconventional = true
+# Parser order matters - first match wins.
+# Strategy: Include PR-referenced commits (#NNN), skip duplicates from merged branches.
+# This works because GitHub appends (#NNN) to merge/squash/rebase commits.
 commit_parsers = [
+    # Skip merge commits (both "Merge pull request" and "Merge branch" styles)
     { message = "^Merge", skip = true },
-    { message = "^feat", group = "Features" },
-    { message = "^fix", group = "Bug Fixes" },
-    { message = "^perf", group = "Performance" },
-    { message = "^refactor", group = "Refactoring" },
-    { message = "^docs", group = "Documentation" },
-    { message = "^style", group = "Styling" },
-    { message = "^test", group = "Testing" },
-    { message = "^build", group = "Build" },
-    { message = "^config", group = "Configuration" },
+
+    # PR-referenced commits (prioritized - these are the "final" versions)
+    { message = "^feat.*\\(#\\d+\\)", group = "Features" },
+    { message = "^fix.*\\(#\\d+\\)", group = "Bug Fixes" },
+    { message = "^perf.*\\(#\\d+\\)", group = "Performance" },
+    { message = "^refactor.*\\(#\\d+\\)", group = "Refactoring" },
+    { message = "^docs.*\\(#\\d+\\)", group = "Documentation" },
+    { message = "^style.*\\(#\\d+\\)", group = "Styling" },
+    { message = "^test.*\\(#\\d+\\)", group = "Testing" },
+    { message = "^build.*\\(#\\d+\\)", group = "Build" },
+    { message = "^config.*\\(#\\d+\\)", group = "Configuration" },
+
+    # Skip non-PR conventional commits (duplicates from feature branches)
+    { message = "^feat", skip = true },
+    { message = "^fix", skip = true },
+    { message = "^perf", skip = true },
+    { message = "^refactor", skip = true },
+    { message = "^docs", skip = true },
+    { message = "^style", skip = true },
+    { message = "^test", skip = true },
+    { message = "^build", skip = true },
+    { message = "^config", skip = true },
+
+    # Always skip these regardless of PR reference
     { message = "^chore", skip = true },
     { message = "^ci", skip = true },
 ]


### PR DESCRIPTION
## Summary
- Fixes duplicate changelog entries when using merge commits (not squash)
- Prioritizes PR-referenced commits (`#NNN` suffix) over original branch commits
- Uses first-match-wins parser ordering to filter duplicates

## Details
When merge commits are enabled, git-cliff was including both:
- Original commits from feature branches (e.g., `90a217c8 fix(sync): ...`)
- Merge commits with PR reference (e.g., `b692eb0a fix(sync): ... (#27)`)

Fix uses commit parser ordering:
1. PR-referenced patterns match first → included
2. Non-PR patterns match second → skipped as duplicates

Works with all GitHub merge strategies (merge, squash, rebase).

## Test plan
- [x] Verified `npx git-cliff v1.1.3..HEAD` shows single entry per change
- [ ] Verify release.sh preview shows no duplicates (investigating discrepancy)