### PR TITLE
fix(frontend): extract sync type constants for HMR compatibility

### DIFF
--- a/frontend/src/components/admin/SyncTab.tsx
+++ b/frontend/src/components/admin/SyncTab.tsx
@@ -3,15 +3,7 @@ import { format } from 'date-fns';
 import {
   Play,
   Loader2,
-  Calendar,
-  Users,
-  User,
-  Home,
-  Layout,
-  UserCheck,
-  FileText,
   Clock3,
-  Brain,
   Zap,
   RefreshCw,
   Settings2,
@@ -28,27 +20,7 @@ import { useProcessRequests } from '../../hooks/useProcessRequests';
 import { StatusIcon, formatDuration } from './ConfigInputs';
 import { clearCache } from '../../utils/queryClient';
 import ProcessRequestOptions, { type ProcessRequestOptionsState } from './ProcessRequestOptions';
-
-// Sync type configuration
-export const SYNC_TYPES = [
-  { id: 'sessions', name: 'Sessions', icon: Calendar, color: 'text-sky-600' },
-  { id: 'attendees', name: 'Attendees', icon: Users, color: 'text-emerald-600' },
-  { id: 'persons', name: 'Persons', icon: User, color: 'text-violet-600' },
-  { id: 'bunks', name: 'Bunks', icon: Home, color: 'text-amber-600' },
-  { id: 'bunk_plans', name: 'Bunk Plans', icon: Layout, color: 'text-rose-600' },
-  { id: 'bunk_assignments', name: 'Assignments', icon: UserCheck, color: 'text-indigo-600' },
-  { id: 'bunk_requests', name: 'Requests', icon: FileText, color: 'text-orange-600' },
-  { id: 'process_requests', name: 'Process', icon: Brain, color: 'text-teal-600' },
-] as const;
-
-export const HISTORICAL_SYNC_TYPES = [
-  { id: 'sessions', name: 'Sessions' },
-  { id: 'attendees', name: 'Attendees' },
-  { id: 'persons', name: 'Persons' },
-  { id: 'bunks', name: 'Bunks' },
-  { id: 'bunk_plans', name: 'Bunk Plans' },
-  { id: 'bunk_assignments', name: 'Assignments' },
-] as const;
+import { SYNC_TYPES, HISTORICAL_SYNC_TYPES } from './syncTypes';
 
 // Run all syncs mutation
 function useRunAllSyncs() {

--- a/frontend/src/components/admin/index.ts
+++ b/frontend/src/components/admin/index.ts
@@ -1,7 +1,8 @@
 // Admin component exports
 // Re-export components for external use
 
-export { SyncTab, SYNC_TYPES, HISTORICAL_SYNC_TYPES } from './SyncTab';
+export { SyncTab } from './SyncTab';
+export { SYNC_TYPES, HISTORICAL_SYNC_TYPES } from './syncTypes';
 export { ConfigTab, CATEGORIES } from './ConfigTab';
 export { SectionCard, type SectionCardProps } from './SectionCard';
 export { ScaleGuideSidebar, type ScaleGuideSidebarProps } from './ScaleGuideSidebar';

--- a/frontend/src/components/admin/syncTypes.ts
+++ b/frontend/src/components/admin/syncTypes.ts
@@ -1,0 +1,32 @@
+import {
+  Calendar,
+  Users,
+  User,
+  Home,
+  Layout,
+  UserCheck,
+  FileText,
+  Brain,
+} from 'lucide-react';
+
+// Sync type configuration for the sync status grid
+export const SYNC_TYPES = [
+  { id: 'sessions', name: 'Sessions', icon: Calendar, color: 'text-sky-600' },
+  { id: 'attendees', name: 'Attendees', icon: Users, color: 'text-emerald-600' },
+  { id: 'persons', name: 'Persons', icon: User, color: 'text-violet-600' },
+  { id: 'bunks', name: 'Bunks', icon: Home, color: 'text-amber-600' },
+  { id: 'bunk_plans', name: 'Bunk Plans', icon: Layout, color: 'text-rose-600' },
+  { id: 'bunk_assignments', name: 'Assignments', icon: UserCheck, color: 'text-indigo-600' },
+  { id: 'bunk_requests', name: 'Requests', icon: FileText, color: 'text-orange-600' },
+  { id: 'process_requests', name: 'Process', icon: Brain, color: 'text-teal-600' },
+] as const;
+
+// Subset of sync types available for historical import
+export const HISTORICAL_SYNC_TYPES = [
+  { id: 'sessions', name: 'Sessions' },
+  { id: 'attendees', name: 'Attendees' },
+  { id: 'persons', name: 'Persons' },
+  { id: 'bunks', name: 'Bunks' },
+  { id: 'bunk_plans', name: 'Bunk Plans' },
+  { id: 'bunk_assignments', name: 'Assignments' },
+] as const;


### PR DESCRIPTION
## Summary
- Extracts `SYNC_TYPES` and `HISTORICAL_SYNC_TYPES` constants to new `syncTypes.ts` file
- Fixes Vite HMR warning: "Could not Fast Refresh ('HISTORICAL_SYNC_TYPES' export is incompatible)"
- Component files must only export React components for Fast Refresh to work

## Test plan
- [ ] Start dev server, navigate to Admin page
- [ ] Modify SyncTab.tsx and verify HMR works without full reload
- [ ] No console warning about incompatible exports