### PR TITLE
fix(scripts): improve release.sh error detection and remove deprecated deps

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -17,35 +17,23 @@ repo = "kindred"
 conventional_commits = true
 filter_unconventional = true
 # Parser order matters - first match wins.
-# Strategy: Include PR-referenced commits (#NNN), skip duplicates from merged branches.
-# This works because GitHub appends (#NNN) to merge/squash/rebase commits.
+# Include all conventional commits - works for squash merge, rebase merge, and direct commits.
 commit_parsers = [
     # Skip merge commits (both "Merge pull request" and "Merge branch" styles)
     { message = "^Merge", skip = true },
 
-    # PR-referenced commits (prioritized - these are the "final" versions)
-    { message = "^feat.*\\(#\\d+\\)", group = "Features" },
-    { message = "^fix.*\\(#\\d+\\)", group = "Bug Fixes" },
-    { message = "^perf.*\\(#\\d+\\)", group = "Performance" },
-    { message = "^refactor.*\\(#\\d+\\)", group = "Refactoring" },
-    { message = "^docs.*\\(#\\d+\\)", group = "Documentation" },
-    { message = "^style.*\\(#\\d+\\)", group = "Styling" },
-    { message = "^test.*\\(#\\d+\\)", group = "Testing" },
-    { message = "^build.*\\(#\\d+\\)", group = "Build" },
-    { message = "^config.*\\(#\\d+\\)", group = "Configuration" },
+    # All conventional commits by type
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing" },
+    { message = "^build", group = "Build" },
+    { message = "^config", group = "Configuration" },
 
-    # Skip non-PR conventional commits (duplicates from feature branches)
-    { message = "^feat", skip = true },
-    { message = "^fix", skip = true },
-    { message = "^perf", skip = true },
-    { message = "^refactor", skip = true },
-    { message = "^docs", skip = true },
-    { message = "^style", skip = true },
-    { message = "^test", skip = true },
-    { message = "^build", skip = true },
-    { message = "^config", skip = true },
-
-    # Always skip these regardless of PR reference
+    # Always skip these
     { message = "^chore", skip = true },
     { message = "^ci", skip = true },
 ]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -49,7 +49,6 @@
         "@testing-library/jest-dom": "^6.2.0",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.5.2",
-        "@types/cytoscape": "^3.31.0",
         "@types/node": "^25.0.9",
         "@types/react": "^19.2.8",
         "@types/react-dom": "^19.1.0",
@@ -2267,17 +2266,6 @@
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
-      }
-    },
-    "node_modules/@types/cytoscape": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/@types/cytoscape/-/cytoscape-3.31.0.tgz",
-      "integrity": "sha512-EXHOHxqQjGxLDEh5cP4te6J0bi7LbCzmZkzsR6f703igUac8UGMdEohMyU3GHAayCTZrLQOMnaE/lqB2Ekh8Ww==",
-      "deprecated": "This is a stub types definition. cytoscape provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cytoscape": "*"
       }
     },
     "node_modules/@types/d3-array": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,7 +66,6 @@
     "@testing-library/jest-dom": "^6.2.0",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.5.2",
-    "@types/cytoscape": "^3.31.0",
     "@types/node": "^25.0.9",
     "@types/react": "^19.2.8",
     "@types/react-dom": "^19.1.0",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -514,7 +514,9 @@ else
 fi
 
 # Check if git-cliff output is valid (contains actual content)
-if [[ -z "$CHANGELOG" ]] || echo "$CHANGELOG" | grep -q "panicked\|Error\|error"; then
+# Match only "error:" or "Error:" at start of line or "panicked" anywhere (actual failures)
+# Don't match "error" in commit messages like "fix: auto-reload on chunk load errors"
+if [[ -z "$CHANGELOG" ]] || echo "$CHANGELOG" | grep -qE "^(error:|Error:)|panicked"; then
     echo -e "${YELLOW}  git-cliff failed, generating formatted notes from commits...${NC}"
     # Fallback: generate notes matching git-cliff format (without PR/author attribution)
     # Format: * FULL_HASH: type(scope): message


### PR DESCRIPTION
## Summary
- Fix error detection regex to not match "error" in commit messages (e.g., "fix: auto-reload on chunk load errors" no longer triggers fallback)
- Simplify cliff.toml to include all conventional commits (not just PR-referenced)
- Remove deprecated @types/cytoscape (cytoscape ships its own types)

## Test plan
- [x] Verified error detection regex with test cases
- [x] Verified `npm run type-check` passes without @types/cytoscape
- [x] Tested `./scripts/release.sh --dry-run --allow-dirty` runs without triggering fallback