### PR TITLE
fix(frontend): add missing user/users routes for metrics program

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -157,6 +157,8 @@ function App() {
                               <RegistrationMetricsPage />
                             </Suspense>
                           } />
+                          <Route path="user" element={<User />} />
+                          <Route path="users" element={<Users />} />
                         </Route>
 
                         {/* Family Camp routes - with app layout */}


### PR DESCRIPTION
## Summary
- Adds missing `/metrics/user` and `/metrics/users` routes to the router
- Fixes navigation to Users page when in Metrics program

## Test plan
- [ ] Switch to Metrics program
- [ ] Click "Users" in the nav bar
- [ ] Verify the Users page loads correctly