### PR TITLE
fix(pb): defensive deletion migration for fresh databases

### DIFF
--- a/pocketbase/pb_migrations/1769104316_deleted_division_attendees.js
+++ b/pocketbase/pb_migrations/1769104316_deleted_division_attendees.js
@@ -1,8 +1,14 @@
 /// <reference path="../pb_data/types.d.ts" />
 migrate((app) => {
-  const collection = app.findCollectionByNameOrId("col_div_attendees");
-
-  return app.delete(collection);
+  // Defensive: collection may not exist on fresh databases
+  try {
+    const collection = app.findCollectionByNameOrId("col_div_attendees");
+    if (collection) {
+      app.delete(collection);
+    }
+  } catch (e) {
+    // Collection doesn't exist - nothing to delete
+  }
 }, (app) => {
   const collection = new Collection({
     "createRule": "@request.auth.id != \"\"",


### PR DESCRIPTION
## Summary
- Fixed division_attendees deletion migration that failed on fresh CI databases
- The collection `col_div_attendees` was never created by any migration (created manually in dev)
- Added try/catch to handle "collection not found" gracefully

## Root Cause
The CD build failed because `1769104316_deleted_division_attendees.js` tried to delete a collection that doesn't exist on fresh databases. The `findCollectionByNameOrId()` call throws "sql: no rows in result set" when the collection isn't found.

## Test plan
- [ ] CI passes
- [ ] CD build succeeds (will verify after merge)