### PR TITLE
fix(scripts): remove branch name check from release.sh

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -135,15 +135,7 @@ else
     echo -e "${GREEN}✓ Working tree clean${NC}"
 fi
 
-# Check on main branch (handle both "main" and "heads/main" formats)
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [[ "$CURRENT_BRANCH" != "main" && "$CURRENT_BRANCH" != "heads/main" ]]; then
-    echo -e "${RED}✗ Not on main branch (on: $CURRENT_BRANCH)${NC}"
-    exit 1
-fi
-echo -e "${GREEN}✓ On main branch${NC}"
-
-# Check up to date with remote
+# Check up to date with remote (branch name doesn't matter, only commit equality)
 git fetch origin main --quiet
 LOCAL=$(git rev-parse HEAD)
 REMOTE=$(git rev-parse origin/main)


### PR DESCRIPTION
## Summary
- Removes redundant branch name check from release.sh
- The script already verifies `HEAD == origin/main`, which is the actual requirement
- Allows valid releases from detached HEAD or any branch at the same commit as origin/main

## Motivation
The branch name check forced users to checkout `main` before releasing, even though the commit equality check (`HEAD == origin/main`) is what actually matters for release integrity. This change provides better separation of concerns between `git sync` (fetch/update) and `release.sh` (verify correct commit).

## Test plan
- [ ] Run `./scripts/release.sh --dry-run` from main branch (should work)
- [ ] Run from detached HEAD at origin/main: `git checkout origin/main && ./scripts/release.sh --dry-run` (now works)
- [ ] Run from feature branch with commits ahead of main (should still fail on commit mismatch)