### PR TITLE
fix(ci): make dependency-submission non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,11 +472,13 @@ jobs:
       run: npm run test -- --run
 
   # Submit dependencies to GitHub's dependency graph
+  # Non-blocking: informational only, GitHub API errors shouldn't fail CI
   dependency-submission:
     name: Dependency Submission
     runs-on: ubuntu-latest
     # Only submit on main branch pushes (not PRs, not other branches)
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    continue-on-error: true
     permissions:
       contents: write  # Required for dependency submission API
     steps:
@@ -527,9 +529,8 @@ jobs:
           echo "❌ Tests failed!"
           exit 1
         fi
-        # dependency-submission only runs on main pushes, skipped on PRs
-        if [ "${{ needs.dependency-submission.result }}" != "success" ] && [ "${{ needs.dependency-submission.result }}" != "skipped" ]; then
-          echo "❌ Dependency submission failed!"
-          exit 1
+        # dependency-submission is non-blocking (informational only)
+        if [ "${{ needs.dependency-submission.result }}" == "failure" ]; then
+          echo "⚠️ Dependency submission failed (non-blocking)"
         fi
         echo "✅ All CI checks passed!"


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to the dependency-submission job
- Change summary to log warning instead of failing when dependency submission fails

## Motivation
GitHub's dependency submission API occasionally returns 500 server errors (as seen in CI run #21295454601). This is informational metadata for the dependency graph, not critical for code quality - shouldn't fail CI.

## Test plan
- [ ] CI passes on this PR
- [ ] If dependency submission fails, CI summary shows warning but still passes