### PR TITLE
fix(sync): suppress misspell lint for CampMinder status value

### DIFF
--- a/pocketbase/sync/attendees.go
+++ b/pocketbase/sync/attendees.go
@@ -232,7 +232,7 @@ func (s *AttendeesSync) processEnrollment(
 		4:   "applied",
 		8:   "waitlisted",
 		16:  "left_early",
-		32:  "cancelled",
+		32:  "cancelled", //nolint:misspell // CampMinder status value
 		64:  "dismissed",
 		128: "inquiry",
 		256: "withdrawn",


### PR DESCRIPTION
## Summary
- Add `//nolint:misspell` directive to suppress lint warning on `"cancelled"` status value
- This is a CampMinder database enum value (StatusID 32), not a spelling error

## Test plan
- [x] Verified `golangci-lint run` passes without misspell errors
- [x] Pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)