### PR TITLE
feat(sync): wire up full Google Sheets export

### DIFF
--- a/pocketbase/pb_migrations/1500000015_persons.js
+++ b/pocketbase/pb_migrations/1500000015_persons.js
@@ -104,7 +104,6 @@ migrate((app) => {
         presentable: false,
         min: null,
         max: null,
-        onlyInt: true
       },
       {
         name: "school",


### PR DESCRIPTION
## Summary
- Update `Sync()` to delegate to `SyncGlobalsOnly()` and `SyncDailyOnly()` for full 10-table export
- Add `GetAllExportSheetNames()` helper function
- Remove dead code (old hardcoded 2-tab export)
- Fix migration: remove `onlyInt` from persons grade field

## Tables Exported
**Year-specific (6):** attendees, persons, sessions, staff, bunk-assignments, financial-transactions
**Global (4):** tag-definitions, custom-field-definitions, financial-categories, staff-positions

## Test Plan
- [x] `go test ./sync/...` passes
- [ ] Click "Export to Sheets" in Metrics UI, verify all 10 tabs appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)