### PR TITLE
fix(frontend): handle recharts 3.7.0 stricter TypeScript types

### DIFF
--- a/frontend/src/components/metrics/BreakdownChart.tsx
+++ b/frontend/src/components/metrics/BreakdownChart.tsx
@@ -106,7 +106,7 @@ export function BreakdownChart({
               labelLine={false}
             >
               {data.map((_, index) => (
-                <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length] ?? '#00b36b'} />
               ))}
             </Pie>
             <Tooltip content={<CustomTooltip />} />


### PR DESCRIPTION
## Summary
- Fixes TypeScript error in `BreakdownChart.tsx` caused by recharts 3.7.0's stricter type requirements
- The `Cell` component's `fill` prop now requires a definite `string`, not `string | undefined`
- Added nullish coalescing fallback for array access to satisfy `exactOptionalPropertyTypes`

## Test plan
- [x] `npm run lint` passes in frontend/
- [ ] CI passes

🔗 Unblocks PR #100 (dependabot npm minor updates)