### PR TITLE
fix(docker): include branding.local.json in frontend build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,10 @@ COPY frontend/package*.json ./
 RUN npm ci
 COPY frontend/ ./
 # Copy branding config so Vite can inject it (vite.config.local.ts loads from ../config/)
-# Note: branding.local.json is NOT copied here - it's a symlink to kindred-local repo
-# For local builds: run scripts/build/docker-build.sh (handles symlinks)
-# For CI: workflow copies files from kindred-local before build
-COPY config/branding.json ../config/
+# Wildcard copies branding.json (default) + branding.local.json (camp-specific) when available
+# For local builds: run scripts/build/docker-build.sh (resolves symlinks before build)
+# For CI: workflow copies real files from kindred-local before build
+COPY config/branding*.json ../config/
 RUN npm run build
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Fixed missing camp-specific branding in Docker builds
- Changed `COPY config/branding.json` → `COPY config/branding*.json` to include local overrides
- Verified locally: "Camp Tawonga" branding now appears in frontend bundle

## Root Cause
The Dockerfile only copied `branding.json` to the frontend build stage, ignoring `branding.local.json` from kindred-local. The CD workflow correctly loaded private config files, but the Dockerfile didn't pick up the local branding overrides.

## Test plan
- [x] Local build: `./scripts/build/docker-build.sh` succeeds
- [x] Verified branding in bundle: `docker run --rm --entrypoint sh kindred:local -c 'grep camp_name /pb_public/assets/*.js'` shows "Camp Tawonga"
- [ ] CD dry-run passes
- [ ] Production deploy shows correct branding