### PR TITLE
fix(frontend): use ts-ignore for local config import

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -266,7 +266,8 @@ let localConfig: UserConfig = {}
 if (existsSync(localConfigPath)) {
   try {
     // Dynamic import is async, but Vite supports top-level await in config
-    // @ts-expect-error - File is gitignored; runtime handles missing file gracefully
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore - File is gitignored; may not exist at compile time
     const { localConfig: imported } = await import('./vite.config.local')
     localConfig = imported
     console.log('✓ Loaded local Vite configuration from vite.config.local.ts')


### PR DESCRIPTION
## Summary
- The ts-expect-error directive fails in CI where the local config file exists (cloned from private repo)
- TypeScript doesn't error on the import when the file exists, so the directive is "unused"
- Using ts-ignore with ESLint disable works in both environments

## Test plan
- [x] `npm run type-check` passes locally
- [x] `npm run lint` passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)