### PR TITLE
fix(sync): export to Google Sheets on full sync and obfuscate IDs

### DIFF
--- a/pocketbase/sync/google_sheets.go
+++ b/pocketbase/sync/google_sheets.go
@@ -332,7 +332,7 @@ func (g *GoogleSheetsExport) Name() string {
 func (g *GoogleSheetsExport) Sync(ctx context.Context) error {
 	startTime := time.Now()
 	slog.Info("Starting Google Sheets full export",
-		"spreadsheet_id", g.spreadsheetID,
+		"spreadsheet_id", "configured",
 		"year", g.year,
 		"expected_tabs", len(GetAllExportSheetNames(g.year)),
 	)

--- a/pocketbase/sync/sheets_scheduling.go
+++ b/pocketbase/sync/sheets_scheduling.go
@@ -28,7 +28,7 @@ func NewGoogleSheetsExportOptions() *GoogleSheetsExportOptions {
 // This is designed for weekly scheduled exports
 func (g *GoogleSheetsExport) SyncGlobalsOnly(ctx context.Context) error {
 	slog.Info("Starting Google Sheets globals-only export",
-		"spreadsheet_id", g.spreadsheetID,
+		"spreadsheet_id", "configured",
 	)
 
 	// Get global export configs
@@ -90,7 +90,7 @@ func (g *GoogleSheetsExport) SyncDailyOnly(ctx context.Context) error {
 // If includeGlobals is true, global tables are also exported (once, before year data)
 func (g *GoogleSheetsExport) SyncForYears(ctx context.Context, years []int, includeGlobals bool) error {
 	slog.Info("Starting Google Sheets historical export",
-		"spreadsheet_id", g.spreadsheetID,
+		"spreadsheet_id", "configured",
 		"years", years,
 		"includeGlobals", includeGlobals,
 	)
@@ -145,7 +145,7 @@ func (g *GoogleSheetsExport) syncYearData(ctx context.Context, year int) error {
 	g.year = year
 
 	slog.Info("Exporting year-specific data",
-		"spreadsheet_id", g.spreadsheetID,
+		"spreadsheet_id", "configured",
 		"year", year,
 	)
 


### PR DESCRIPTION
## Summary
- Always trigger Google Sheets export when unified sync completes (previously only historical syncs triggered export)
- Obfuscate spreadsheet IDs in logs - show "configured" instead of actual ID

## Test plan
- [x] `go build .` passes
- [x] `go test ./sync/...` passes
- [ ] Run current year unified sync → verify logs show export messages
- [ ] Verify spreadsheet has updated data
- [ ] Grep logs for spreadsheet ID pattern → should only find `spreadsheet_id=configured`

🤖 Generated with [Claude Code](https://claude.com/claude-code)