### PR TITLE
fix(ci): add domain scopes to commitlint config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,9 @@ Format: `type(scope): description` — Breaking changes: `feat(api)!: descriptio
 | `deps` | Dependencies |
 | `docs` | Documentation |
 | `security` | Security hardening, CVE fixes |
+| `metrics` | Analytics, dashboards, statistics |
+| `graph` | Social network graph features |
+| `data` | Data models, schema changes |
 
 ## Quick Development Commands
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -9,6 +9,7 @@ module.exports = {
 
     // Define allowed scopes (matches CLAUDE.md documentation)
     'scope-enum': [2, 'always', [
+      // Technical areas
       'frontend',  // React components, hooks, pages, styles
       'api',       // FastAPI endpoints, Python backend logic
       'sync',      // Go sync services, CampMinder integration
@@ -25,6 +26,10 @@ module.exports = {
       'tests',     // Test infrastructure (not test: type)
       'scripts',   // Development and utility scripts
       'docs',      // Documentation files in docs/
+      // Domain features (cross-cutting)
+      'metrics',   // Analytics, dashboards, statistics
+      'graph',     // Social network graph features
+      'data',      // Data models, schema changes
     ]],
 
     // Allowed types (must match cliff.toml commit_parsers)


### PR DESCRIPTION
## Summary
- Add `metrics`, `graph`, `data` scopes to commitlint config
- Update CLAUDE.md to document new scopes
- Fixes CI failure from #117 squash merge using `feat(metrics)` scope

## Context
The v1.8.0 release failed because the squash merge commit `feat(metrics): enhanced registration metrics...` used a scope not in the allowed list.

## Test plan
- [ ] CI passes with new scope configuration