### PR TITLE
feat(metrics): add inline labels to all chart types

### DIFF
--- a/frontend/src/components/metrics/BreakdownChart.tsx
+++ b/frontend/src/components/metrics/BreakdownChart.tsx
@@ -14,6 +14,7 @@ import {
   Pie,
   Cell,
   Legend,
+  LabelList,
 } from 'recharts';
 import type { PieLabelRenderProps } from 'recharts';
 
@@ -97,11 +98,15 @@ export function BreakdownChart({
               cy="50%"
               outerRadius={80}
               label={(props: PieLabelRenderProps) => {
-                const pct = (props.payload as ChartData).percentage;
+                const item = props.payload as ChartData;
+                const pct = item.percentage;
+                const count = item.value;
                 const labelName = props.name ?? '';
-                return showPercentage && pct !== undefined
-                  ? `${labelName} (${pct.toFixed(0)}%)`
-                  : labelName;
+                // Show count always, percentage conditionally
+                if (showPercentage && pct !== undefined) {
+                  return `${labelName}: ${count} (${pct.toFixed(0)}%)`;
+                }
+                return `${labelName}: ${count}`;
               }}
               labelLine={false}
             >
@@ -125,7 +130,14 @@ export function BreakdownChart({
               tickFormatter={(value: string) => value.length > 14 ? `${value.slice(0, 12)}…` : value}
             />
             <Tooltip content={<CustomTooltip />} />
-            <Bar dataKey="value" fill={COLORS[0]} radius={[0, 4, 4, 0]} />
+            <Bar dataKey="value" fill={COLORS[0]} radius={[0, 4, 4, 0]}>
+              <LabelList
+                dataKey="value"
+                position="right"
+                className="text-xs"
+                fill="hsl(var(--muted-foreground))"
+              />
+            </Bar>
           </BarChart>
         )}
       </ResponsiveContainer>

--- a/frontend/src/components/metrics/ComparisonBreakdownChart.tsx
+++ b/frontend/src/components/metrics/ComparisonBreakdownChart.tsx
@@ -16,6 +16,7 @@ import {
   Pie,
   Cell,
   Legend,
+  LabelList,
 } from 'recharts';
 import type { PieLabelRenderProps } from 'recharts';
 
@@ -148,15 +149,18 @@ export function ComparisonBreakdownChart({
               cy="50%"
               outerRadius={80}
               label={(props: PieLabelRenderProps) => {
-                const pct = (props.payload as ChartDataItem).percentage;
+                const item = props.payload as ChartDataItem;
+                const pct = item.percentage;
+                const count = item.value;
                 const labelName = props.name ?? '';
                 const comparePct = activeComparisonYear && comparisonData?.[activeComparisonYear]
                   ? comparisonData[activeComparisonYear].find(c => c.name === labelName)?.percentage
                   : undefined;
 
-                let label = labelName;
+                // Show count always, percentage conditionally
+                let label = `${labelName}: ${count}`;
                 if (showPercentage && pct !== undefined) {
-                  label = `${labelName} (${pct.toFixed(0)}%)`;
+                  label = `${labelName}: ${count} (${pct.toFixed(0)}%)`;
                   if (comparePct !== undefined) {
                     const delta = pct - comparePct;
                     const sign = delta >= 0 ? '+' : '';
@@ -187,7 +191,14 @@ export function ComparisonBreakdownChart({
               tickFormatter={(value: string) => value.length > 14 ? `${value.slice(0, 12)}...` : value}
             />
             <Tooltip content={<CustomTooltip />} />
-            <Bar dataKey="value" name={String(currentYear)} fill={COLORS[0]} radius={[0, 4, 4, 0]} />
+            <Bar dataKey="value" name={String(currentYear)} fill={COLORS[0]} radius={[0, 4, 4, 0]}>
+              <LabelList
+                dataKey="value"
+                position="right"
+                className="text-xs"
+                fill="hsl(var(--muted-foreground))"
+              />
+            </Bar>
             {activeComparisonYear && (
               <Bar
                 dataKey={`value_${activeComparisonYear}`}

--- a/frontend/src/components/metrics/GenderByGradeChart.tsx
+++ b/frontend/src/components/metrics/GenderByGradeChart.tsx
@@ -14,6 +14,7 @@ import {
   Tooltip,
   ResponsiveContainer,
   Legend,
+  LabelList,
 } from 'recharts';
 import type { GenderByGradeBreakdown } from '../../types/metrics';
 
@@ -135,7 +136,14 @@ export function GenderByGradeChart({
             stackId="gender"
             fill={COLORS.other}
             radius={[4, 4, 0, 0]}
-          />
+          >
+            <LabelList
+              dataKey="total"
+              position="top"
+              className="text-xs"
+              fill="hsl(var(--muted-foreground))"
+            />
+          </Bar>
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/frontend/src/components/metrics/RetentionRateLine.tsx
+++ b/frontend/src/components/metrics/RetentionRateLine.tsx
@@ -13,6 +13,7 @@ import {
   Tooltip,
   ResponsiveContainer,
   ReferenceLine,
+  LabelList,
 } from 'recharts';
 import type { RetentionTrendYear } from '../../types/metrics';
 
@@ -114,7 +115,15 @@ export function RetentionRateLine({
             strokeWidth={3}
             dot={{ fill: 'hsl(160, 100%, 35%)', r: 6 }}
             activeDot={{ r: 8 }}
-          />
+          >
+            <LabelList
+              dataKey="retentionRate"
+              position="top"
+              className="text-xs"
+              fill="hsl(var(--muted-foreground))"
+              formatter={(value) => `${value}%`}
+            />
+          </Line>
         </LineChart>
       </ResponsiveContainer>
     </div>

--- a/frontend/src/components/metrics/TrendLineChart.tsx
+++ b/frontend/src/components/metrics/TrendLineChart.tsx
@@ -11,6 +11,7 @@ import {
   Tooltip,
   ResponsiveContainer,
   Legend,
+  LabelList,
 } from 'recharts';
 import type { YearMetrics } from '../../types/metrics';
 
@@ -129,7 +130,15 @@ export function TrendLineChart({
               strokeWidth={2}
               dot={{ fill: COLORS.total, strokeWidth: 2 }}
               activeDot={{ r: 6 }}
-            />
+            >
+              <LabelList
+                dataKey="total"
+                position="top"
+                className="text-xs"
+                fill="hsl(var(--muted-foreground))"
+                formatter={(value) => typeof value === 'number' ? value.toLocaleString() : String(value ?? '')}
+              />
+            </Line>
           )}
 
           {metric === 'new_vs_returning' && (
@@ -142,7 +151,15 @@ export function TrendLineChart({
                 strokeWidth={2}
                 dot={{ fill: COLORS.new, strokeWidth: 2 }}
                 activeDot={{ r: 6 }}
-              />
+              >
+                <LabelList
+                  dataKey="new"
+                  position="top"
+                  className="text-xs"
+                  fill="hsl(var(--muted-foreground))"
+                  formatter={(value) => typeof value === 'number' ? value.toLocaleString() : String(value ?? '')}
+                />
+              </Line>
               <Line
                 type="monotone"
                 dataKey="returning"
@@ -151,7 +168,15 @@ export function TrendLineChart({
                 strokeWidth={2}
                 dot={{ fill: COLORS.returning, strokeWidth: 2 }}
                 activeDot={{ r: 6 }}
-              />
+              >
+                <LabelList
+                  dataKey="returning"
+                  position="bottom"
+                  className="text-xs"
+                  fill="hsl(var(--muted-foreground))"
+                  formatter={(value) => typeof value === 'number' ? value.toLocaleString() : String(value ?? '')}
+                />
+              </Line>
             </>
           )}
 
@@ -165,7 +190,15 @@ export function TrendLineChart({
                 strokeWidth={2}
                 dot={{ fill: COLORS.male, strokeWidth: 2 }}
                 activeDot={{ r: 6 }}
-              />
+              >
+                <LabelList
+                  dataKey="male"
+                  position="top"
+                  className="text-xs"
+                  fill="hsl(var(--muted-foreground))"
+                  formatter={(value) => typeof value === 'number' ? value.toLocaleString() : String(value ?? '')}
+                />
+              </Line>
               <Line
                 type="monotone"
                 dataKey="female"
@@ -174,7 +207,15 @@ export function TrendLineChart({
                 strokeWidth={2}
                 dot={{ fill: COLORS.female, strokeWidth: 2 }}
                 activeDot={{ r: 6 }}
-              />
+              >
+                <LabelList
+                  dataKey="female"
+                  position="bottom"
+                  className="text-xs"
+                  fill="hsl(var(--muted-foreground))"
+                  formatter={(value) => typeof value === 'number' ? value.toLocaleString() : String(value ?? '')}
+                />
+              </Line>
             </>
           )}
         </LineChart>


### PR DESCRIPTION
## Summary

- Add unobtrusive value labels to all metric chart types for at-a-glance reading
- Pie charts now show count + percentage (e.g., "Grade 5: 42 (24%)")
- Bar charts display values at bar end
- Stacked bars show totals on top of each column  
- Line charts show values at data points

## Test plan

- [ ] Verify pie chart labels show count and percentage
- [ ] Verify horizontal bar chart labels appear at bar end
- [ ] Verify stacked bar chart totals appear above columns
- [ ] Verify line chart data point labels are visible
- [ ] Verify dark mode compatibility
- [ ] Run frontend tests: `cd frontend && npm run test`