### PR TITLE
fix(metrics): sort sessions in logical order on metrics tabs

### DIFF
--- a/frontend/src/pages/metrics/RegistrationTab.tsx
+++ b/frontend/src/pages/metrics/RegistrationTab.tsx
@@ -17,6 +17,7 @@ import { DemographicBreakdowns } from '../../components/metrics/DemographicBreak
 import { RegistrationSessionSelector } from '../../components/metrics/RegistrationSessionSelector';
 import { GenderByGradeChart } from '../../components/metrics/GenderByGradeChart';
 import { getSessionChartLabel } from '../../utils/sessionDisplay';
+import { sortSessionDataByName } from '../../utils/sessionUtils';
 import { Loader2, AlertCircle } from 'lucide-react';
 
 interface RegistrationTabProps {
@@ -84,7 +85,10 @@ export function RegistrationTab({ year, sessionTypes }: RegistrationTabProps) {
     percentage: g.percentage,
   }));
 
-  const sessionChartData = data.by_session.map((s) => ({
+  // Sort sessions in logical order (Taste, 2, 2a, 2b, 3, 3a, 4)
+  const sortedBySession = sortSessionDataByName(data.by_session);
+
+  const sessionChartData = sortedBySession.map((s) => ({
     name: getSessionChartLabel(s.session_name),
     value: s.count,
     percentage: s.utilization ?? 0,
@@ -254,7 +258,7 @@ export function RegistrationTab({ year, sessionTypes }: RegistrationTabProps) {
               </tr>
             </thead>
             <tbody>
-              {data.by_session.map((session, index) => (
+              {sortedBySession.map((session, index) => (
                 <tr key={index} className="border-b border-border last:border-0 hover:bg-muted/20 transition-colors">
                   <td className="px-4 py-3 font-medium text-foreground">{getSessionChartLabel(session.session_name)}</td>
                   <td className="px-4 py-3 text-right text-foreground">{session.count}</td>

--- a/frontend/src/pages/metrics/RetentionTab.tsx
+++ b/frontend/src/pages/metrics/RetentionTab.tsx
@@ -21,6 +21,7 @@ import { GenderStackedChart } from '../../components/metrics/GenderStackedChart'
 import { GradeEnrollmentChart } from '../../components/metrics/GradeEnrollmentChart';
 import { DemographicTable } from '../../components/metrics/DemographicTable';
 import { getSessionChartLabel } from '../../utils/sessionDisplay';
+import { sortSessionDataByName, sortPriorSessionData } from '../../utils/sessionUtils';
 import { Loader2, AlertCircle, TrendingUp, TrendingDown, Minus } from 'lucide-react';
 
 interface RetentionTabProps {
@@ -112,8 +113,9 @@ export function RetentionTab({ currentYear, sessionTypes }: RetentionTabProps) {
     }
   };
 
-  // Transform detailed session data for charts (from the detailed retention response)
-  const sessionChartData = (detailedData?.by_session ?? []).map((s) => ({
+  // Sort and transform detailed session data for charts (from the detailed retention response)
+  const sortedBySession = sortSessionDataByName(detailedData?.by_session ?? []);
+  const sessionChartData = sortedBySession.map((s) => ({
     name: getSessionChartLabel(s.session_name),
     value: s.returned_count,
     percentage: s.retention_rate * 100,
@@ -133,8 +135,9 @@ export function RetentionTab({ currentYear, sessionTypes }: RetentionTabProps) {
     percentage: y.retention_rate * 100,
   }));
 
-  // Prior year session breakdown
-  const priorSessionChartData = (detailedData?.by_prior_session ?? []).map((s) => ({
+  // Prior year session breakdown (sorted)
+  const sortedByPriorSession = sortPriorSessionData(detailedData?.by_prior_session ?? []);
+  const priorSessionChartData = sortedByPriorSession.map((s) => ({
     name: getSessionChartLabel(s.prior_session),
     value: s.returned_count,
     percentage: s.retention_rate * 100,
@@ -294,7 +297,7 @@ export function RetentionTab({ currentYear, sessionTypes }: RetentionTabProps) {
               </tr>
             </thead>
             <tbody>
-              {(detailedData?.by_session ?? []).map((session, index) => (
+              {sortedBySession.map((session, index) => (
                 <tr key={index} className="border-b border-border last:border-0 hover:bg-muted/20 transition-colors">
                   <td className="px-4 py-3 font-medium text-foreground">{getSessionChartLabel(session.session_name)}</td>
                   <td className="px-4 py-3 text-right text-foreground">{session.base_count}</td>

--- a/frontend/src/utils/sessionUtils.ts
+++ b/frontend/src/utils/sessionUtils.ts
@@ -115,3 +115,29 @@ export function filterSelectableSessions<
     (s) => s.session_type === 'main' || s.session_type === 'embedded'
   );
 }
+
+/**
+ * Sort session data (from API) in logical order by session_name field.
+ * Works with API response types that have session_name field.
+ */
+export function sortSessionDataByName<T extends { session_name: string }>(data: T[]): T[] {
+  return [...data].sort((a, b) => {
+    const [numA, suffixA] = parseSessionName(a.session_name);
+    const [numB, suffixB] = parseSessionName(b.session_name);
+    if (numA !== numB) return numA - numB;
+    return suffixA.localeCompare(suffixB);
+  });
+}
+
+/**
+ * Sort prior session data in logical order by prior_session field.
+ * Works with retention API response that has prior_session field.
+ */
+export function sortPriorSessionData<T extends { prior_session: string }>(data: T[]): T[] {
+  return [...data].sort((a, b) => {
+    const [numA, suffixA] = parseSessionName(a.prior_session);
+    const [numB, suffixB] = parseSessionName(b.prior_session);
+    if (numA !== numB) return numA - numB;
+    return suffixA.localeCompare(suffixB);
+  });
+}


### PR DESCRIPTION
## Summary
- Fix session ordering in metrics tab to display in logical date order instead of CM ID order
- Add `sortSessionDataByName()` and `sortPriorSessionData()` utilities to sessionUtils.ts
- Add comprehensive tests for existing `parseSessionName` and `sortSessionsLogically` functions
- Apply sorting to RegistrationTab (chart + table) and RetentionTab (charts + table)

## Test plan
- [x] All 824 frontend tests pass
- [x] TypeScript build succeeds
- [x] ESLint passes
- [ ] Manual verification: Registration tab "Enrollment by Session" chart shows correct order
- [ ] Manual verification: Registration tab "Session Details" table shows correct order
- [ ] Manual verification: Retention tab session breakdown charts show correct order
- [ ] Manual verification: Retention tab "Retention Details by Session" table shows correct order

**Expected order**: Taste of Camp → Session 2 → Session 2a → Session 2b → Session 3 → Session 3a → Session 4