### PR TITLE
fix(google): use shared folder for spreadsheet creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -197,11 +197,13 @@ APPDATA_DIR=/path/to/persistent/storage
 # ====================
 
 # Enable Google Sheets export for data warehouse sync
-# When enabled, attendee and session data syncs to a Google Sheet after daily sync
+# When enabled, attendee and session data syncs to Google Sheets after daily sync
 GOOGLE_SHEETS_ENABLED=false
 
-# Target spreadsheet ID (from URL: docs.google.com/spreadsheets/d/{THIS_PART}/edit)
-GOOGLE_SHEETS_SPREADSHEET_ID=
+# Folder ID where new spreadsheets will be created (Shared Drive folder recommended)
+# Required for multi-workbook export - service accounts can't create in their own Drive
+# Get folder ID from URL: https://drive.google.com/drive/folders/{THIS_PART}
+GOOGLE_DRIVE_FOLDER_ID=
 
 # Service account credentials file path
 # Docker: /config/google_sheets.json (default, place file in config volume)
@@ -219,5 +221,6 @@ GOOGLE_SHEETS_SPREADSHEET_ID=
 # 4. Create key and download JSON
 # 5. Docker: Place file as ${APPDATA_DIR}/bunking/config/google_sheets.json
 #    Local: Save as ./google_sheets.json and set GOOGLE_SERVICE_ACCOUNT_KEY_FILE=./google_sheets.json
-# 6. Create spreadsheet and share with service account email (Editor access)
-# 7. Copy spreadsheet ID from URL to GOOGLE_SHEETS_SPREADSHEET_ID
+# 6. Create a folder in Google Drive (Shared Drive recommended)
+# 7. Share folder with service account email (Editor access)
+# 8. Copy folder ID from URL to GOOGLE_DRIVE_FOLDER_ID

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - AI_MODEL=${AI_MODEL:-}
       # Google Sheets (optional)
       - GOOGLE_SHEETS_ENABLED=${GOOGLE_SHEETS_ENABLED:-false}
-      - GOOGLE_SHEETS_SPREADSHEET_ID=${GOOGLE_SHEETS_SPREADSHEET_ID:-}
+      - GOOGLE_DRIVE_FOLDER_ID=${GOOGLE_DRIVE_FOLDER_ID:-}
       - GOOGLE_SERVICE_ACCOUNT_KEY_FILE=${GOOGLE_SERVICE_ACCOUNT_KEY_FILE:-/config/google_sheets.json}
       # System
       - TZ=${TZ:-America/Los_Angeles}

--- a/pocketbase/google/client.go
+++ b/pocketbase/google/client.go
@@ -15,7 +15,7 @@ import (
 const (
 	envEnabled     = "GOOGLE_SHEETS_ENABLED"
 	envKeyFile     = "GOOGLE_SERVICE_ACCOUNT_KEY_FILE"
-	envSpreadsheet = "GOOGLE_SHEETS_SPREADSHEET_ID"
+	envFolderID    = "GOOGLE_DRIVE_FOLDER_ID"
 	defaultKeyFile = "/config/google_sheets.json" // Docker: /config volume, Dev: set via env
 )
 
@@ -25,9 +25,9 @@ func IsEnabled() bool {
 	return val == "true" || val == "1"
 }
 
-// GetSpreadsheetID returns the configured Google Sheets spreadsheet ID
-func GetSpreadsheetID() string {
-	return strings.TrimSpace(os.Getenv(envSpreadsheet))
+// GetFolderID returns the configured Google Drive folder ID for creating spreadsheets
+func GetFolderID() string {
+	return strings.TrimSpace(os.Getenv(envFolderID))
 }
 
 // getAuthenticatedHTTPClient creates an authenticated HTTP client for the given scope.

--- a/pocketbase/google/client_test.go
+++ b/pocketbase/google/client_test.go
@@ -78,24 +78,24 @@ func TestNewSheetsClient_ValidInlineJSON(t *testing.T) {
 	}
 }
 
-func TestGetSpreadsheetID(t *testing.T) {
+func TestGetFolderID(t *testing.T) {
 	tests := []struct {
 		name     string
 		envValue string
 		want     string
 	}{
 		{"Empty", "", ""},
-		{"Simple ID", "abc123def456", "abc123def456"},
-		{"With spaces trimmed", "  abc123  ", "abc123"},
+		{"Simple ID", "1ABC-xyz_123", "1ABC-xyz_123"},
+		{"With spaces trimmed", "  1ABC-xyz  ", "1ABC-xyz"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("GOOGLE_SHEETS_SPREADSHEET_ID", tt.envValue)
+			t.Setenv("GOOGLE_DRIVE_FOLDER_ID", tt.envValue)
 
-			got := GetSpreadsheetID()
+			got := GetFolderID()
 			if got != tt.want {
-				t.Errorf("GetSpreadsheetID() = %q, want %q", got, tt.want)
+				t.Errorf("GetFolderID() = %q, want %q", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Service accounts cannot create spreadsheets in their own Drive space (403 forbidden)
- Replace `GOOGLE_SHEETS_SPREADSHEET_ID` with `GOOGLE_DRIVE_FOLDER_ID` env var
- Rewrite `CreateSpreadsheet()` to use Drive API with folder parent instead of Sheets API
- Add `SupportsAllDrives(true)` flag for Shared Drive compatibility

## Setup

1. Create a folder in Google Drive (Shared Drive recommended)
2. Share folder with service account email (Editor access)
3. Set `GOOGLE_DRIVE_FOLDER_ID=<folder_id>` in `.env`

## Test plan

- [ ] Set `GOOGLE_DRIVE_FOLDER_ID` to a shared folder
- [ ] Run multi-workbook export: `curl -X POST "http://localhost:8090/api/custom/sync/multi-workbook-export?year=2025"`
- [ ] Verify spreadsheet created in the shared folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)