### PR TITLE
feat(sync): enable historical bunk request processing

### DIFF
--- a/frontend/src/components/admin/syncTypes.ts
+++ b/frontend/src/components/admin/syncTypes.ts
@@ -46,9 +46,9 @@ export const YEAR_SYNC_TYPES = [
   { id: 'financial_transactions', name: 'Financial Transactions', icon: Receipt, color: 'text-green-600' },
   { id: 'camper_history', name: 'Camper History', icon: History, color: 'text-cyan-600' },
   { id: 'family_camp_derived', name: 'Family Camp', icon: Home, color: 'text-orange-500' },
-  // Current year only - these don't make sense for historical data
-  { id: 'bunk_requests', name: 'Intake Requests', icon: FileText, color: 'text-orange-600', currentYearOnly: true },
-  { id: 'process_requests', name: 'Process Requests', icon: Brain, color: 'text-teal-600', currentYearOnly: true },
+  // Bunk request processing - available for all years (historical CSV import)
+  { id: 'bunk_requests', name: 'Intake Requests', icon: FileText, color: 'text-orange-600' },
+  { id: 'process_requests', name: 'Process Requests', icon: Brain, color: 'text-teal-600' },
 ] as const;
 
 // Combined sync types for backward compatibility

--- a/pocketbase/sync/api.go
+++ b/pocketbase/sync/api.go
@@ -722,13 +722,6 @@ func handleUnifiedSync(e *core.RequestEvent, scheduler *Scheduler) error {
 		}
 	}
 
-	// Validate: bunk_requests and process_requests only for current year
-	if year != currentYear && (service == "bunk_requests" || service == "process_requests") {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
-			"error": fmt.Sprintf("%s is only available for current year syncs", service),
-		})
-	}
-
 	// Get orchestrator and check if any sync is already running
 	orchestrator := scheduler.GetOrchestrator()
 	if orchestrator.IsDailySyncRunning() || orchestrator.IsHistoricalSyncRunning() {


### PR DESCRIPTION
## Summary
- Remove API validation that blocked bunk_requests/process_requests syncs for non-current years
- Remove `currentYearOnly` flags from frontend sync types
- Enables one-time import of historical bunk request CSVs (2022-2025) for AI parsing

## Test plan
- [ ] Select 2022 from year dropdown
- [ ] Upload historical CSV → should succeed
- [ ] Check `original_bunk_requests` table for year=2022 records
- [ ] Check `bunk_requests` table for year=2022 parsed records

🤖 Generated with [Claude Code](https://claude.com/claude-code)