### PR TITLE
fix(sync): wait for bunk_requests to complete before running process_requests

### DIFF
--- a/pocketbase/sync/api.go
+++ b/pocketbase/sync/api.go
@@ -588,8 +588,8 @@ func handleBunkRequestsUpload(e *core.RequestEvent, scheduler *Scheduler) error 
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 				defer cancel()
 
-				// Run bunk_requests sync first
-				syncErr := orchestrator.RunSingleSync(ctx, "bunk_requests")
+				// Run bunk_requests sync first and wait for completion
+				syncErr := orchestrator.runSyncAndWait(ctx, "bunk_requests")
 				if syncErr != nil {
 					slog.Warn("Error running bunk_requests sync", "error", syncErr)
 					return // Don't run process_requests if sync failed


### PR DESCRIPTION
## Summary
- Fix race condition when uploading CSV via bunk requests upload button
- `process_requests` was starting before `bunk_requests` completed because `RunSingleSync` spawns a goroutine and returns immediately
- Use `runSyncAndWait` instead, which polls for completion every 500ms

## Root Cause
`pocketbase/sync/api.go:592` called `orchestrator.RunSingleSync()`, which spawns a goroutine internally (at `orchestrator.go:254`) and returns immediately without waiting for completion.

## Test plan
- [ ] Upload a CSV via the bunk requests upload button
- [ ] Check logs for correct ordering:
  - "Starting bunk requests sync from CSV" first
  - "Bunk requests sync complete" second
  - "Chaining process_requests after bunk_requests sync" third
  - "Starting request processing via Python" fourth