### PR TITLE
feat(sync): implement session type date overlap detection

### DIFF
--- a/pocketbase/sync/camper_history_test.go
+++ b/pocketbase/sync/camper_history_test.go
@@ -1302,7 +1302,7 @@ func TestCamperHistorySessionTypesFilteringSummerOnly(t *testing.T) {
 
 	// Verify family camp is excluded
 	for _, r := range filtered {
-		if r.SessionTypes == "family" {
+		if r.SessionTypes == sessionTypeFamily {
 			t.Error("family session type should be excluded")
 		}
 	}

--- a/pocketbase/sync/sessions.go
+++ b/pocketbase/sync/sessions.go
@@ -15,9 +15,10 @@ import (
 
 // Session type constants
 const (
-	sessionTypeMain   = "main"
-	sessionTypeAdult  = "adult"
-	sessionTypeFamily = "family"
+	sessionTypeMain     = "main"
+	sessionTypeAdult    = "adult"
+	sessionTypeFamily   = "family"
+	sessionTypeEmbedded = "embedded"
 )
 
 // Service name constant
@@ -453,7 +454,7 @@ func (s *SessionsSync) reclassifyOverlappingSessions(
 		// AG, family, and other types are exempt
 		var candidates []*sessionOverlapInfo
 		for _, info := range sessions {
-			if info.sessionType == "main" || info.sessionType == "embedded" {
+			if info.sessionType == sessionTypeMain || info.sessionType == sessionTypeEmbedded {
 				candidates = append(candidates, info)
 			}
 		}
@@ -468,11 +469,11 @@ func (s *SessionsSync) reclassifyOverlappingSessions(
 
 		// First candidate is the primary (stays or becomes main)
 		primary := candidates[0]
-		correctedTypes[primary.cmID] = "main"
+		correctedTypes[primary.cmID] = sessionTypeMain
 
 		// All others become embedded with parent_id pointing to primary
 		for _, info := range candidates[1:] {
-			correctedTypes[info.cmID] = "embedded"
+			correctedTypes[info.cmID] = sessionTypeEmbedded
 			parentIDs[info.cmID] = primary.cmID
 		}
 	}
@@ -531,7 +532,7 @@ func (s *SessionsSync) getSessionTypeFromName(sessionName string) string {
 
 	// Embedded sessions (e.g., "Session 2a", "Session 3b")
 	if matched, _ := regexp.MatchString(`session \d[ab]`, nameLower); matched {
-		return "embedded"
+		return sessionTypeEmbedded
 	}
 
 	// All-gender sessions


### PR DESCRIPTION
## Summary

- Add `reclassifyOverlappingSessions()` to detect when multiple sessions share a start_date or end_date
- Reclassify shorter sessions as "embedded" with parent_id pointing to the primary (longest) session
- Fix "Taste of Camp 2" being incorrectly classified as "main" instead of "embedded"

**Business rule**: When multiple non-AG sessions share a start_date OR end_date:
1. The longest duration session stays "main"
2. If durations equal, alphabetically first name wins
3. Others become "embedded" with parent_id set to primary's cm_id

## Test plan

- [x] All 8 reclassification test cases pass
- [x] All existing session tests pass
- [x] Go build succeeds
- [ ] Trigger session sync and verify:
  - Session 2 is `main`
  - "Taste of Camp 2" is `embedded` with `parent_id` = Session 2's cm_id
  - AG sessions unchanged
- [ ] Frontend landing page shows ToC2 nested under Session 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)