### PR TITLE
fix(frontend): allow enqueueing syncs while others are running

### DIFF
--- a/frontend/src/components/admin/SyncTab.tsx
+++ b/frontend/src/components/admin/SyncTab.tsx
@@ -55,10 +55,6 @@ export function SyncTab() {
   const familyCampDerivedSync = useFamilyCampDerivedSync();
   const cancelQueuedSync = useCancelQueuedSync();
 
-  const hasRunningSyncs = syncStatus && Object.values(syncStatus).some(
-    (status: SyncStatus) => status.status === 'running'
-  );
-
   // Get queue from status
   const queue: QueuedSyncItem[] = syncStatus?._queue || [];
   const hasQueuedItems = queue.length > 0;
@@ -174,7 +170,7 @@ export function SyncTab() {
                     debug: shouldIncludeCustomValues && syncDebug,
                   });
                 }}
-                disabled={unifiedSync.isPending || hasRunningSyncs}
+                disabled={unifiedSync.isPending}
                 className="btn-primary w-full lg:w-auto min-w-[130px]"
               >
                 {unifiedSync.isPending ? (


### PR DESCRIPTION
## Summary
- Fixes sync queue enqueue button being incorrectly disabled when any sync is running
- Button now only disabled during mutation in-flight (prevents double-submit)
- Queue-full scenario (max 5) already handled via 409 response and toast

## Test plan
- [ ] Start a long-running sync (e.g., unified sync for all services)
- [ ] While running, click "Run Sync" again - button should be clickable
- [ ] Verify sync gets enqueued and toast shows queue position
- [ ] Fill queue to max 5 items
- [ ] Verify 6th attempt shows "queue is full" error toast
- [ ] Cancel a queued item and verify new sync can be enqueued

🤖 Generated with [Claude Code](https://claude.ai/code)