### PR TITLE
fix(google): use orange for CM-sourced sheets, improve SheetsTab UI

### DIFF
--- a/frontend/src/components/admin/SheetsTab.tsx
+++ b/frontend/src/components/admin/SheetsTab.tsx
@@ -70,44 +70,37 @@ function WorkbookCard({ workbook }: { workbook: SheetsWorkbook }) {
   };
 
   const yearDisplay = workbook.workbook_type === 'globals' ? 'Globals' : workbook.year;
+  // Extract short name from title (e.g., "Kindred 2026" -> "2026", "Kindred Globals" -> "Globals")
+  const shortName = workbook.workbook_type === 'globals' ? 'Globals' : String(workbook.year);
 
   return (
-    <div className="bg-card rounded-xl border border-border p-4 sm:p-5 hover:border-primary/30 transition-colors">
-      <div className="flex items-start justify-between gap-3 mb-3">
-        <div className="flex items-center gap-2.5 min-w-0">
-          <div className="p-1.5 bg-primary/10 rounded-lg flex-shrink-0">
-            <FileSpreadsheet className="h-4 w-4 text-primary" />
+    <div className="bg-card rounded-xl border border-border p-3 sm:p-4 hover:border-primary/30 transition-colors">
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <div className="p-1 bg-primary/10 rounded-md flex-shrink-0">
+            <FileSpreadsheet className="h-3.5 w-3.5 text-primary" />
           </div>
           <div className="min-w-0">
-            <h3 className="font-semibold text-foreground truncate">{workbook.title}</h3>
-            <p className="text-sm text-muted-foreground">
-              {yearDisplay === 'Globals' ? 'Global Data + Index' : `Year ${yearDisplay}`}
+            <h3 className="text-sm font-medium text-foreground">{shortName}</h3>
+            <p className="text-xs text-muted-foreground truncate" title={workbook.title}>
+              {yearDisplay === 'Globals' ? 'Global definitions + Index' : `Year data`}
             </p>
           </div>
         </div>
         {getStatusBadge()}
       </div>
 
-      {/* Stats Grid */}
-      <div className="grid grid-cols-3 gap-4 mb-4">
-        <div className="text-center">
-          <p className="text-xs text-muted-foreground uppercase tracking-wide">Tabs</p>
-          <p className="text-lg font-semibold tabular-nums">{workbook.tab_count}</p>
-        </div>
-        <div className="text-center">
-          <p className="text-xs text-muted-foreground uppercase tracking-wide">Records</p>
-          <p className="text-lg font-semibold tabular-nums">{workbook.total_records.toLocaleString()}</p>
-        </div>
-        <div className="text-center">
-          <p className="text-xs text-muted-foreground uppercase tracking-wide">Last Sync</p>
-          <p className="text-sm font-medium">{formatDate(workbook.last_sync)}</p>
-        </div>
+      {/* Stats Row */}
+      <div className="flex items-center justify-between text-xs text-muted-foreground mb-3 px-1">
+        <span>{workbook.tab_count} tabs</span>
+        <span className="tabular-nums">{workbook.total_records.toLocaleString()} records</span>
+        <span className="text-right">{formatDate(workbook.last_sync)}</span>
       </div>
 
       {/* Error Message */}
       {workbook.status === 'error' && workbook.error_message && (
-        <div className="mb-3 p-2 bg-red-50 dark:bg-red-950/30 rounded-lg border border-red-200 dark:border-red-800">
-          <p className="text-xs text-red-600 dark:text-red-400">{workbook.error_message}</p>
+        <div className="mb-2 p-1.5 bg-red-50 dark:bg-red-950/30 rounded text-xs text-red-600 dark:text-red-400 truncate" title={workbook.error_message}>
+          {workbook.error_message}
         </div>
       )}
 
@@ -116,10 +109,10 @@ function WorkbookCard({ workbook }: { workbook: SheetsWorkbook }) {
         href={workbook.url}
         target="_blank"
         rel="noopener noreferrer"
-        className="w-full inline-flex items-center justify-center gap-2 px-4 py-2 bg-primary/10 hover:bg-primary/20 text-primary rounded-lg font-medium text-sm transition-colors"
+        className="w-full inline-flex items-center justify-center gap-1.5 px-3 py-1.5 bg-primary/10 hover:bg-primary/20 text-primary rounded-md text-xs font-medium transition-colors"
       >
-        <span>Open in Google Sheets</span>
-        <ExternalLink className="w-4 h-4" />
+        <span>Open</span>
+        <ExternalLink className="w-3 h-3" />
       </a>
     </div>
   );
@@ -144,15 +137,12 @@ export function SheetsTab() {
 
   if (error) {
     return (
-      <div className="bg-red-50 dark:bg-red-950/30 rounded-xl border border-red-200 dark:border-red-800 p-4 sm:p-6">
-        <div className="flex items-start gap-3">
-          <AlertCircle className="w-5 h-5 text-red-600 dark:text-red-400 mt-0.5 flex-shrink-0" />
-          <div>
-            <h3 className="font-display font-bold text-red-800 dark:text-red-200">Failed to load workbooks</h3>
-            <p className="text-red-600 dark:text-red-400 mt-1 text-sm">
-              {error instanceof Error ? error.message : 'Unknown error'}
-            </p>
-          </div>
+      <div className="bg-red-50 dark:bg-red-950/30 rounded-lg border border-red-200 dark:border-red-800 p-3">
+        <div className="flex items-center gap-2">
+          <AlertCircle className="w-4 h-4 text-red-600 dark:text-red-400 flex-shrink-0" />
+          <p className="text-sm text-red-600 dark:text-red-400">
+            Failed to load workbooks: {error instanceof Error ? error.message : 'Unknown error'}
+          </p>
         </div>
       </div>
     );
@@ -161,21 +151,17 @@ export function SheetsTab() {
   return (
     <div className="space-y-4 sm:space-y-6">
       {/* Header with Export Button */}
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+      <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-lg font-display font-bold text-foreground">
-            Google Sheets Workbooks
-          </h2>
-          <p className="text-muted-foreground text-sm">
-            Export data to multiple Google Sheets workbooks
-          </p>
+          <h2 className="text-base font-semibold text-foreground">Google Sheets</h2>
+          <p className="text-xs text-muted-foreground">Export data to workbooks</p>
         </div>
         <button
           onClick={handleFullExport}
           disabled={multiExport.isPending}
-          className="flex items-center justify-center gap-2 px-4 py-2 bg-primary hover:bg-primary/90 disabled:opacity-50 text-primary-foreground rounded-lg font-medium text-sm transition-colors"
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-primary hover:bg-primary/90 disabled:opacity-50 text-primary-foreground rounded-md text-xs font-medium transition-colors"
         >
-          <RefreshCw className={`w-4 h-4 ${multiExport.isPending ? 'animate-spin' : ''}`} />
+          <RefreshCw className={`w-3.5 h-3.5 ${multiExport.isPending ? 'animate-spin' : ''}`} />
           <span>{multiExport.isPending ? 'Exporting...' : 'Full Export'}</span>
         </button>
       </div>
@@ -189,16 +175,13 @@ export function SheetsTab() {
 
       {/* No Workbooks State */}
       {!isLoading && workbooks?.length === 0 && (
-        <div className="bg-card rounded-xl border border-border p-8 text-center">
-          <FileSpreadsheet className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
-          <h3 className="font-display font-bold text-lg mb-2">No Workbooks Found</h3>
-          <p className="text-muted-foreground text-sm mb-4">
-            Run a full export to create workbooks for your data.
-          </p>
+        <div className="bg-card rounded-lg border border-border p-6 text-center">
+          <FileSpreadsheet className="w-8 h-8 text-muted-foreground mx-auto mb-2" />
+          <p className="text-sm text-muted-foreground mb-3">No workbooks yet</p>
           <button
             onClick={handleFullExport}
             disabled={multiExport.isPending}
-            className="btn btn-primary"
+            className="px-3 py-1.5 bg-primary hover:bg-primary/90 text-primary-foreground rounded-md text-xs font-medium"
           >
             {multiExport.isPending ? 'Creating...' : 'Create Workbooks'}
           </button>
@@ -208,10 +191,10 @@ export function SheetsTab() {
       {/* Globals Workbook */}
       {globalsWorkbook && (
         <section>
-          <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-3">
-            Master Index & Global Data
+          <h3 className="text-xs font-medium text-muted-foreground mb-2">
+            Global Data
           </h3>
-          <div className="max-w-md">
+          <div className="max-w-xs">
             <WorkbookCard workbook={globalsWorkbook} />
           </div>
         </section>
@@ -220,8 +203,8 @@ export function SheetsTab() {
       {/* Year Workbooks */}
       {yearWorkbooks.length > 0 && (
         <section>
-          <div className="flex items-center justify-between mb-3">
-            <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="text-xs font-medium text-muted-foreground">
               Year Workbooks
             </h3>
             {currentYear && (
@@ -234,7 +217,7 @@ export function SheetsTab() {
               </button>
             )}
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
             {yearWorkbooks.map((workbook) => (
               <WorkbookCard key={workbook.id} workbook={workbook} />
             ))}
@@ -243,15 +226,9 @@ export function SheetsTab() {
       )}
 
       {/* Help Text */}
-      <div className="bg-muted/50 dark:bg-muted rounded-lg p-4 text-sm text-muted-foreground">
-        <p>
-          <strong>Full Export</strong> creates/updates all workbooks: one for global data (Tag Definitions, Divisions, etc.)
-          and one for each year&apos;s data (Attendees, Persons, etc.).
-        </p>
-        <p className="mt-2">
-          The Globals workbook includes an <strong>Index</strong> sheet with links to all workbooks.
-        </p>
-      </div>
+      <p className="text-xs text-muted-foreground">
+        <span className="font-medium">Full Export</span> updates all workbooks. Global workbook includes an Index with links to all sheets.
+      </p>
     </div>
   );
 }

--- a/pocketbase/sync/multi_workbook_ordering.go
+++ b/pocketbase/sync/multi_workbook_ordering.go
@@ -52,68 +52,57 @@ func SortYearWorkbookTabs(tabs []string) []string {
 
 // =============================================================================
 // Multi-Workbook Tab Colors
-// Category-based coloring for readable tab names (no year prefixes)
+// Orange for CampMinder-sourced tables, grey for globals and derived tables
 // =============================================================================
 
-// Category-based tab colors for multi-workbook architecture
+// Tab colors for multi-workbook architecture
 var (
 	// TabColorIndex is gold for the master Index sheet
 	TabColorIndex = TabColor{R: 1.0, G: 0.84, B: 0.0}
 
-	// TabColorCore is blue for core people tables (Attendees, Persons, Households)
-	TabColorCore = TabColor{R: 0.53, G: 0.81, B: 0.92}
+	// TabColorCMSourced is orange for CampMinder-sourced tables in year workbooks
+	TabColorCMSourced = TabColor{R: 1.0, G: 0.65, B: 0.0}
 
-	// TabColorAssignments is green for assignment tables (Staff, Bunks, Bunk Assignments)
-	TabColorAssignments = TabColor{R: 0.56, G: 0.93, B: 0.56}
+	// TabColorDerived is grey for derived/computed tables (not directly from CM)
+	TabColorDerived = TabColor{R: 0.85, G: 0.85, B: 0.85}
 
-	// TabColorFinancial is teal for financial tables
-	TabColorFinancial = TabColor{R: 0.0, G: 0.81, B: 0.82}
+	// derivedTables lists tables that are computed/derived, not directly from CampMinder
+	derivedTables = map[string]bool{
+		"Camper History": true,
+	}
 
-	// TabColorCustomValues is purple for custom values tables
-	TabColorCustomValues = TabColor{R: 0.73, G: 0.33, B: 0.83}
-
-	// tabCategoryMap maps tab names to their color category
-	tabCategoryMap = map[string]TabColor{
-		// Index
-		indexSheetName: TabColorIndex,
-
-		// Core people tables (blue)
-		"Attendees":  TabColorCore,
-		"Persons":    TabColorCore,
-		"Households": TabColorCore,
-
-		// Assignment tables (green)
-		"Bunk Assignments": TabColorAssignments,
-		"Staff":            TabColorAssignments,
-		"Bunks":            TabColorAssignments,
-
-		// Financial tables (teal)
-		"Financial Transactions": TabColorFinancial,
-		"Financial Categories":   TabColorFinancial,
-
-		// Custom values (purple)
-		"Person Custom Values":    TabColorCustomValues,
-		"Household Custom Values": TabColorCustomValues,
-
-		// Global tables (light blue - using existing TabColorGlobal)
-		"Tag Definitions":          TabColorGlobal,
-		"Custom Field Definitions": TabColorGlobal,
-		"Divisions":                TabColorGlobal,
-
-		// Session-related (use core color)
-		"Sessions":       TabColorCore,
-		"Session Groups": TabColorCore,
-		"Camper History": TabColorCore,
+	// globalTables lists tables in the globals workbook (all get grey)
+	globalTables = map[string]bool{
+		"Tag Definitions":          true,
+		"Custom Field Definitions": true,
+		"Financial Categories":     true,
+		"Divisions":                true,
 	}
 )
 
 // GetMultiWorkbookTabColor returns the color for a tab in multi-workbook mode.
-// Uses category-based coloring for readable tab names.
+// - Index sheet: gold
+// - Global tables: grey
+// - Derived tables (Camper History): grey
+// - CampMinder-sourced tables: orange
 func GetMultiWorkbookTabColor(tabName string) TabColor {
-	if color, ok := tabCategoryMap[tabName]; ok {
-		return color
+	// Index sheet gets gold
+	if tabName == indexSheetName {
+		return TabColorIndex
 	}
-	return TabColorDefault
+
+	// Global tables get grey
+	if globalTables[tabName] {
+		return TabColorDerived
+	}
+
+	// Derived/computed tables get grey
+	if derivedTables[tabName] {
+		return TabColorDerived
+	}
+
+	// All other year workbook tables are CM-sourced, get orange
+	return TabColorCMSourced
 }
 
 // =============================================================================

--- a/pocketbase/sync/multi_workbook_ordering_test.go
+++ b/pocketbase/sync/multi_workbook_ordering_test.go
@@ -109,7 +109,7 @@ func TestSortYearWorkbookTabs_Alphabetized(t *testing.T) {
 
 // =============================================================================
 // Multi-Workbook Tab Color Tests
-// Category-based coloring for readable tab names
+// Orange for CM-sourced, grey for globals and derived
 // =============================================================================
 
 func TestGetMultiWorkbookTabColor_Index(t *testing.T) {
@@ -121,82 +121,59 @@ func TestGetMultiWorkbookTabColor_Index(t *testing.T) {
 	}
 }
 
-func TestGetMultiWorkbookTabColor_CoreTables(t *testing.T) {
-	// Core tables (Persons, Attendees) should be blue
-	coreTabs := []string{testTabNameAttendees, "Persons", "Households"}
-
-	for _, tab := range coreTabs {
-		t.Run(tab, func(t *testing.T) {
-			color := GetMultiWorkbookTabColor(tab)
-			if color != TabColorCore {
-				t.Errorf("GetMultiWorkbookTabColor(%q) = %v, want TabColorCore", tab, color)
-			}
-		})
+func TestGetMultiWorkbookTabColor_CMSourcedTables(t *testing.T) {
+	// CampMinder-sourced tables should be orange
+	cmTabs := []string{
+		testTabNameAttendees, "Persons", "Households",
+		"Bunk Assignments", "Staff", "Bunks",
+		"Financial Transactions", "Sessions", "Session Groups",
+		"Person Custom Values", "Household Custom Values",
 	}
-}
 
-func TestGetMultiWorkbookTabColor_Assignments(t *testing.T) {
-	// Assignment tables should be green
-	assignmentTabs := []string{"Bunk Assignments", "Staff", "Bunks"}
-
-	for _, tab := range assignmentTabs {
+	for _, tab := range cmTabs {
 		t.Run(tab, func(t *testing.T) {
 			color := GetMultiWorkbookTabColor(tab)
-			if color != TabColorAssignments {
-				t.Errorf("GetMultiWorkbookTabColor(%q) = %v, want TabColorAssignments", tab, color)
-			}
-		})
-	}
-}
-
-func TestGetMultiWorkbookTabColor_Financial(t *testing.T) {
-	// Financial tables should be teal
-	financialTabs := []string{"Financial Transactions", "Financial Categories"}
-
-	for _, tab := range financialTabs {
-		t.Run(tab, func(t *testing.T) {
-			color := GetMultiWorkbookTabColor(tab)
-			if color != TabColorFinancial {
-				t.Errorf("GetMultiWorkbookTabColor(%q) = %v, want TabColorFinancial", tab, color)
-			}
-		})
-	}
-}
-
-func TestGetMultiWorkbookTabColor_CustomValues(t *testing.T) {
-	// Custom values tables should be purple
-	cvTabs := []string{"Person Custom Values", "Household Custom Values"}
-
-	for _, tab := range cvTabs {
-		t.Run(tab, func(t *testing.T) {
-			color := GetMultiWorkbookTabColor(tab)
-			if color != TabColorCustomValues {
-				t.Errorf("GetMultiWorkbookTabColor(%q) = %v, want TabColorCustomValues", tab, color)
+			if color != TabColorCMSourced {
+				t.Errorf("GetMultiWorkbookTabColor(%q) = %v, want TabColorCMSourced (orange)", tab, color)
 			}
 		})
 	}
 }
 
 func TestGetMultiWorkbookTabColor_GlobalTables(t *testing.T) {
-	// Global tables should be light blue
-	globalTabs := []string{"Tag Definitions", "Custom Field Definitions", "Divisions"}
+	// Global tables should be grey
+	globalTabsList := []string{"Tag Definitions", "Custom Field Definitions", "Divisions", "Financial Categories"}
 
-	for _, tab := range globalTabs {
+	for _, tab := range globalTabsList {
 		t.Run(tab, func(t *testing.T) {
 			color := GetMultiWorkbookTabColor(tab)
-			if color != TabColorGlobal {
-				t.Errorf("GetMultiWorkbookTabColor(%q) = %v, want TabColorGlobal", tab, color)
+			if color != TabColorDerived {
+				t.Errorf("GetMultiWorkbookTabColor(%q) = %v, want TabColorDerived (grey)", tab, color)
+			}
+		})
+	}
+}
+
+func TestGetMultiWorkbookTabColor_DerivedTables(t *testing.T) {
+	// Derived/computed tables should be grey
+	derivedTabsList := []string{"Camper History"}
+
+	for _, tab := range derivedTabsList {
+		t.Run(tab, func(t *testing.T) {
+			color := GetMultiWorkbookTabColor(tab)
+			if color != TabColorDerived {
+				t.Errorf("GetMultiWorkbookTabColor(%q) = %v, want TabColorDerived (grey)", tab, color)
 			}
 		})
 	}
 }
 
 func TestGetMultiWorkbookTabColor_Unknown(t *testing.T) {
-	// Unknown tabs should get default color
-	color := GetMultiWorkbookTabColor("Unknown Tab")
+	// Unknown tabs in year workbook default to CM-sourced (orange)
+	color := GetMultiWorkbookTabColor("New CM Table")
 
-	if color != TabColorDefault {
-		t.Errorf("GetMultiWorkbookTabColor('Unknown Tab') = %v, want TabColorDefault", color)
+	if color != TabColorCMSourced {
+		t.Errorf("GetMultiWorkbookTabColor('New CM Table') = %v, want TabColorCMSourced (orange)", color)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Sheet tab colors now correctly differentiate data sources: orange for CampMinder-sourced tables, grey for globals and derived tables
- SheetsTab admin UI is now more compact with smaller fonts, no uppercase headers, and better grid layout

## Test plan
- [ ] Run full Google Sheets export and verify tab colors: orange for CM data, grey for globals/Camper History, gold for Index
- [ ] Check Admin > Sheets tab UI renders correctly with compact cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)