### PR TITLE
fix(frontend): redesign SheetsTab workbooks list as unified table

### DIFF
--- a/frontend/src/components/admin/SheetsTab.tsx
+++ b/frontend/src/components/admin/SheetsTab.tsx
@@ -5,116 +5,90 @@ import { useYear } from '../../hooks/useCurrentYear';
 /**
  * SheetsTab - Google Sheets Workbooks Management Tab
  *
- * Displays all Google Sheets workbooks with links, status, and export controls.
+ * Displays all Google Sheets workbooks in a unified table with links, status, and export controls.
  * Uses the multi-workbook architecture where:
  * - Globals workbook contains non-year-specific data + master index
  * - Per-year workbooks contain year-specific data
  */
 
-function WorkbookCard({ workbook }: { workbook: SheetsWorkbook }) {
-  const getStatusIcon = () => {
-    switch (workbook.status) {
-      case 'ok':
-        return <CheckCircle className="w-4 h-4 text-emerald-600 dark:text-emerald-400" />;
-      case 'syncing':
-        return <Clock className="w-4 h-4 text-amber-600 dark:text-amber-400 animate-pulse" />;
-      case 'error':
-        return <AlertTriangle className="w-4 h-4 text-red-600 dark:text-red-400" />;
-      default:
-        return null;
-    }
-  };
+function StatusBadge({ status, errorMessage }: { status: SheetsWorkbook['status']; errorMessage?: string }) {
+  const config = {
+    ok: {
+      icon: CheckCircle,
+      label: 'OK',
+      classes: 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300',
+    },
+    syncing: {
+      icon: Clock,
+      label: 'Syncing',
+      classes: 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300',
+      iconClass: 'animate-pulse',
+    },
+    error: {
+      icon: AlertTriangle,
+      label: 'Error',
+      classes: 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300',
+    },
+  }[status];
 
-  const getStatusBadge = () => {
-    switch (workbook.status) {
-      case 'ok':
-        return (
-          <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300">
-            {getStatusIcon()}
-            <span>OK</span>
-          </span>
-        );
-      case 'syncing':
-        return (
-          <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300">
-            {getStatusIcon()}
-            <span>Syncing</span>
-          </span>
-        );
-      case 'error':
-        return (
-          <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300">
-            {getStatusIcon()}
-            <span>Error</span>
-          </span>
-        );
-      default:
-        return null;
-    }
-  };
+  if (!config) return null;
 
-  const formatDate = (dateStr: string) => {
-    if (!dateStr) return 'Never';
-    try {
-      const date = new Date(dateStr);
-      return date.toLocaleDateString(undefined, {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-      });
-    } catch {
-      return dateStr;
-    }
-  };
+  const Icon = config.icon;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full ${config.classes}`}
+      title={status === 'error' && errorMessage ? errorMessage : undefined}
+    >
+      <Icon className={`w-3 h-3 ${config.iconClass || ''}`} />
+      <span>{config.label}</span>
+    </span>
+  );
+}
 
-  const yearDisplay = workbook.workbook_type === 'globals' ? 'Globals' : workbook.year;
-  // Extract short name from title (e.g., "Kindred 2026" -> "2026", "Kindred Globals" -> "Globals")
-  const shortName = workbook.workbook_type === 'globals' ? 'Globals' : String(workbook.year);
+function formatDate(dateStr: string) {
+  if (!dateStr) return 'Never';
+  try {
+    const date = new Date(dateStr);
+    return date.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return dateStr;
+  }
+}
+
+/** Mobile card view for small screens */
+function WorkbookMobileCard({ workbook }: { workbook: SheetsWorkbook }) {
+  const isGlobals = workbook.workbook_type === 'globals';
+  const name = isGlobals ? 'Globals' : String(workbook.year);
 
   return (
-    <div className="bg-card rounded-xl border border-border p-3 sm:p-4 hover:border-primary/30 transition-colors">
-      <div className="flex items-start justify-between gap-2 mb-2">
-        <div className="flex items-center gap-2 min-w-0">
-          <div className="p-1 bg-primary/10 rounded-md flex-shrink-0">
-            <FileSpreadsheet className="h-3.5 w-3.5 text-primary" />
-          </div>
-          <div className="min-w-0">
-            <h3 className="text-sm font-medium text-foreground">{shortName}</h3>
-            <p className="text-xs text-muted-foreground truncate" title={workbook.title}>
-              {yearDisplay === 'Globals' ? 'Global definitions + Index' : `Year data`}
-            </p>
-          </div>
+    <a
+      href={workbook.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`block p-3 rounded-lg border transition-colors hover:border-primary/50 ${
+        isGlobals
+          ? 'border-l-2 border-l-amber-500 border-border bg-amber-50/30 dark:bg-amber-950/10'
+          : 'border-border bg-card'
+      }`}
+    >
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-sm">{name}</span>
+          <ExternalLink className="w-3 h-3 text-muted-foreground" />
         </div>
-        {getStatusBadge()}
+        <StatusBadge status={workbook.status} errorMessage={workbook.error_message} />
       </div>
-
-      {/* Stats Row */}
-      <div className="flex items-center justify-between text-xs text-muted-foreground mb-3 px-1">
+      <div className="flex items-center gap-4 text-xs text-muted-foreground">
         <span>{workbook.tab_count} tabs</span>
         <span className="tabular-nums">{workbook.total_records.toLocaleString()} records</span>
-        <span className="text-right">{formatDate(workbook.last_sync)}</span>
+        <span className="ml-auto">{formatDate(workbook.last_sync)}</span>
       </div>
-
-      {/* Error Message */}
-      {workbook.status === 'error' && workbook.error_message && (
-        <div className="mb-2 p-1.5 bg-red-50 dark:bg-red-950/30 rounded text-xs text-red-600 dark:text-red-400 truncate" title={workbook.error_message}>
-          {workbook.error_message}
-        </div>
-      )}
-
-      {/* Open Button */}
-      <a
-        href={workbook.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="w-full inline-flex items-center justify-center gap-1.5 px-3 py-1.5 bg-primary/10 hover:bg-primary/20 text-primary rounded-md text-xs font-medium transition-colors"
-      >
-        <span>Open</span>
-        <ExternalLink className="w-3 h-3" />
-      </a>
-    </div>
+    </a>
   );
 }
 
@@ -131,9 +105,12 @@ export function SheetsTab() {
     multiExport.mutate({ years: [year], includeGlobals: false });
   };
 
-  // Separate globals and year workbooks
-  const globalsWorkbook = workbooks?.find((w) => w.workbook_type === 'globals');
-  const yearWorkbooks = workbooks?.filter((w) => w.workbook_type === 'year').sort((a, b) => b.year - a.year) || [];
+  // Combine all workbooks: globals first, then years descending
+  const sortedWorkbooks = [...(workbooks || [])].sort((a, b) => {
+    if (a.workbook_type === 'globals') return -1;
+    if (b.workbook_type === 'globals') return 1;
+    return b.year - a.year;
+  });
 
   if (error) {
     return (
@@ -150,20 +127,31 @@ export function SheetsTab() {
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      {/* Header with Export Button */}
+      {/* Header with Export Buttons */}
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-base font-semibold text-foreground">Google Sheets</h2>
           <p className="text-xs text-muted-foreground">Export data to workbooks</p>
         </div>
-        <button
-          onClick={handleFullExport}
-          disabled={multiExport.isPending}
-          className="flex items-center gap-1.5 px-3 py-1.5 bg-primary hover:bg-primary/90 disabled:opacity-50 text-primary-foreground rounded-md text-xs font-medium transition-colors"
-        >
-          <RefreshCw className={`w-3.5 h-3.5 ${multiExport.isPending ? 'animate-spin' : ''}`} />
-          <span>{multiExport.isPending ? 'Exporting...' : 'Full Export'}</span>
-        </button>
+        <div className="flex items-center gap-2">
+          {currentYear && sortedWorkbooks.some((w) => w.year === currentYear) && (
+            <button
+              onClick={() => handleYearExport(currentYear)}
+              disabled={multiExport.isPending}
+              className="text-xs text-primary hover:text-primary/80 font-medium"
+            >
+              Export {currentYear}
+            </button>
+          )}
+          <button
+            onClick={handleFullExport}
+            disabled={multiExport.isPending}
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-primary hover:bg-primary/90 disabled:opacity-50 text-primary-foreground rounded-md text-xs font-medium transition-colors"
+          >
+            <RefreshCw className={`w-3.5 h-3.5 ${multiExport.isPending ? 'animate-spin' : ''}`} />
+            <span>{multiExport.isPending ? 'Exporting...' : 'Full Export'}</span>
+          </button>
+        </div>
       </div>
 
       {/* Loading State */}
@@ -188,46 +176,71 @@ export function SheetsTab() {
         </div>
       )}
 
-      {/* Globals Workbook */}
-      {globalsWorkbook && (
-        <section>
-          <h3 className="text-xs font-medium text-muted-foreground mb-2">
-            Global Data
-          </h3>
-          <div className="max-w-xs">
-            <WorkbookCard workbook={globalsWorkbook} />
-          </div>
-        </section>
-      )}
+      {/* Workbooks Table (Desktop) */}
+      {!isLoading && sortedWorkbooks.length > 0 && (
+        <>
+          {/* Desktop table view */}
+          <div className="hidden sm:block overflow-auto rounded-lg border border-border">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50">
+                <tr className="border-b border-border">
+                  <th className="text-left py-2 px-3 font-medium text-muted-foreground">Workbook</th>
+                  <th className="text-right py-2 px-3 font-medium text-muted-foreground">Tabs</th>
+                  <th className="text-right py-2 px-3 font-medium text-muted-foreground">Records</th>
+                  <th className="text-right py-2 px-3 font-medium text-muted-foreground">Last Sync</th>
+                  <th className="text-center py-2 px-3 font-medium text-muted-foreground">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedWorkbooks.map((workbook) => {
+                  const isGlobals = workbook.workbook_type === 'globals';
+                  const name = isGlobals ? 'Globals' : String(workbook.year);
 
-      {/* Year Workbooks */}
-      {yearWorkbooks.length > 0 && (
-        <section>
-          <div className="flex items-center justify-between mb-2">
-            <h3 className="text-xs font-medium text-muted-foreground">
-              Year Workbooks
-            </h3>
-            {currentYear && (
-              <button
-                onClick={() => handleYearExport(currentYear)}
-                disabled={multiExport.isPending}
-                className="text-xs text-primary hover:text-primary/80 font-medium"
-              >
-                Export {currentYear} Only
-              </button>
-            )}
+                  return (
+                    <tr
+                      key={workbook.id}
+                      className={`border-b border-border last:border-0 cursor-pointer transition-colors hover:bg-muted/30 ${
+                        isGlobals ? 'border-l-2 border-l-amber-500 bg-amber-50/30 dark:bg-amber-950/10' : ''
+                      }`}
+                      onClick={() => window.open(workbook.url, '_blank', 'noopener,noreferrer')}
+                    >
+                      <td className="py-2.5 px-3">
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium">{name}</span>
+                          <ExternalLink className="w-3 h-3 text-muted-foreground" />
+                        </div>
+                      </td>
+                      <td className="text-right py-2.5 px-3 tabular-nums text-muted-foreground">
+                        {workbook.tab_count}
+                      </td>
+                      <td className="text-right py-2.5 px-3 tabular-nums text-muted-foreground">
+                        {workbook.total_records.toLocaleString()}
+                      </td>
+                      <td className="text-right py-2.5 px-3 text-muted-foreground">
+                        {formatDate(workbook.last_sync)}
+                      </td>
+                      <td className="text-center py-2.5 px-3">
+                        <StatusBadge status={workbook.status} errorMessage={workbook.error_message} />
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
-            {yearWorkbooks.map((workbook) => (
-              <WorkbookCard key={workbook.id} workbook={workbook} />
+
+          {/* Mobile card view */}
+          <div className="sm:hidden space-y-2">
+            {sortedWorkbooks.map((workbook) => (
+              <WorkbookMobileCard key={workbook.id} workbook={workbook} />
             ))}
           </div>
-        </section>
+        </>
       )}
 
       {/* Help Text */}
       <p className="text-xs text-muted-foreground">
-        <span className="font-medium">Full Export</span> updates all workbooks. Global workbook includes an Index with links to all sheets.
+        <span className="font-medium">Full Export</span> updates all workbooks. Click any row to open in Google Sheets.
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
- Replace card-based grid layout with clean table for all workbooks
- Globals and year workbooks in single sorted list (globals first, then years desc)
- Clickable rows open workbook in new tab
- Amber left border distinguishes Globals row
- Mobile responsive card fallback for small screens
- Error tooltips on hover for failed syncs
- Moved "Export {year}" button to header

## Test plan
- [ ] Navigate to Admin → Sheets tab
- [ ] Verify table displays all workbooks in unified list
- [ ] Verify Globals appears first with amber left border
- [ ] Click any row → opens workbook in new tab
- [ ] Verify status badges show correctly (OK/Syncing/Error)
- [ ] Hover over error status → shows error message tooltip
- [ ] Test Export buttons still work
- [ ] Resize to mobile width → cards display instead of table

🤖 Generated with [Claude Code](https://claude.ai/code)