### PR TITLE
fix(sync): improve queue duplicate detection and add cancel support

### DIFF
--- a/frontend/src/components/admin/SyncTab.tsx
+++ b/frontend/src/components/admin/SyncTab.tsx
@@ -22,6 +22,7 @@ import { useProcessRequests } from '../../hooks/useProcessRequests';
 import { useCamperHistorySync } from '../../hooks/useCamperHistorySync';
 import { useFamilyCampDerivedSync } from '../../hooks/useFamilyCampDerivedSync';
 import { useCancelQueuedSync } from '../../hooks/useCancelQueuedSync';
+import { useCancelRunningSync } from '../../hooks/useCancelRunningSync';
 import { StatusIcon, formatDuration } from './ConfigInputs';
 import { clearCache } from '../../utils/queryClient';
 import ProcessRequestOptions, { type ProcessRequestOptionsState } from './ProcessRequestOptions';
@@ -54,6 +55,7 @@ export function SyncTab() {
   const camperHistorySync = useCamperHistorySync();
   const familyCampDerivedSync = useFamilyCampDerivedSync();
   const cancelQueuedSync = useCancelQueuedSync();
+  const cancelRunningSync = useCancelRunningSync();
 
   // Get queue from status
   const queue: QueuedSyncItem[] = syncStatus?._queue || [];
@@ -158,7 +160,21 @@ export function SyncTab() {
             )}
 
             {/* Action Group */}
-            <div className="lg:ml-auto">
+            <div className="lg:ml-auto flex gap-2">
+              {(syncStatus?._daily_sync_running || syncStatus?._historical_sync_running) && (
+                <button
+                  onClick={() => cancelRunningSync.mutate()}
+                  disabled={cancelRunningSync.isPending}
+                  className="btn-secondary w-full lg:w-auto"
+                  title="Cancel the currently running sync"
+                >
+                  {cancelRunningSync.isPending ? (
+                    <><Loader2 className="w-5 h-5 animate-spin" /></>
+                  ) : (
+                    <><X className="w-5 h-5" /> Cancel</>
+                  )}
+                </button>
+              )}
               <button
                 onClick={() => {
                   const shouldIncludeCustomValues = includeCustomValues &&
@@ -206,6 +222,7 @@ export function SyncTab() {
                     <div>
                       <span className="font-medium text-sm">
                         {item.year} - {item.service === 'all' ? 'All Services' : item.service}
+                        {item.include_custom_values && ' (+CV)'}
                       </span>
                       <div className="text-xs text-muted-foreground flex items-center gap-1">
                         <Clock className="w-3 h-3" />

--- a/frontend/src/hooks/useCancelRunningSync.ts
+++ b/frontend/src/hooks/useCancelRunningSync.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { pb } from '../lib/pocketbase';
+import toast from 'react-hot-toast';
+
+/**
+ * Hook for canceling the currently running sync.
+ */
+export function useCancelRunningSync() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async () => {
+      return await pb.send('/api/custom/sync/running', { method: 'DELETE' });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['sync-status-api'] });
+      toast.success('Sync canceled', { duration: 3000 });
+    },
+    onError: (error) => {
+      // Extract error message
+      let errorMessage = 'Unknown error';
+      if (error instanceof Error) {
+        errorMessage = error.message;
+      }
+      const pbError = error as { response?: { data?: { error?: string }; message?: string } };
+      if (pbError?.response?.data?.error) {
+        errorMessage = pbError.response.data.error;
+      }
+
+      toast.error(`Failed to cancel sync: ${errorMessage}`, { duration: 5000 });
+    },
+  });
+}

--- a/frontend/src/hooks/useSyncStatusAPI.ts
+++ b/frontend/src/hooks/useSyncStatusAPI.ts
@@ -15,6 +15,7 @@ export interface QueuedSyncItem {
   id: string;
   year: number;
   service: string;
+  include_custom_values?: boolean;
   position: number;
   queued_at: string;
 }

--- a/pocketbase/sync/orchestrator_test.go
+++ b/pocketbase/sync/orchestrator_test.go
@@ -1393,14 +1393,14 @@ func TestEnqueueUnifiedSyncPosition(t *testing.T) {
 func TestEnqueueUnifiedSyncDuplicateDetection(t *testing.T) {
 	o := NewOrchestrator(nil)
 
-	// Enqueue first item
+	// Enqueue first item (without custom values)
 	qs1, err := o.EnqueueUnifiedSync(2025, "all", false, false, "user1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Try to enqueue duplicate (same year + service)
-	qs2, err := o.EnqueueUnifiedSync(2025, "all", true, true, "user2") // Different options
+	// Try to enqueue duplicate (same year + service + includeCustomValues)
+	qs2, err := o.EnqueueUnifiedSync(2025, "all", false, true, "user2") // Same includeCustomValues, different debug
 	if err != nil {
 		t.Fatalf("unexpected error for duplicate: %v", err)
 	}
@@ -1414,6 +1414,23 @@ func TestEnqueueUnifiedSyncDuplicateDetection(t *testing.T) {
 	queue := o.GetQueuedSyncs()
 	if len(queue) != 1 {
 		t.Errorf("expected 1 item in queue after duplicate, got %d", len(queue))
+	}
+
+	// Now enqueue with different includeCustomValues - should create new item
+	qs3, err := o.EnqueueUnifiedSync(2025, "all", true, false, "user3") // Different includeCustomValues
+	if err != nil {
+		t.Fatalf("unexpected error for different includeCustomValues: %v", err)
+	}
+
+	// Should create a new item
+	if qs3.ID == qs1.ID {
+		t.Error("expected different includeCustomValues to create new item, got same ID")
+	}
+
+	// Queue should now have 2 items
+	queue = o.GetQueuedSyncs()
+	if len(queue) != 2 {
+		t.Errorf("expected 2 items in queue after different includeCustomValues, got %d", len(queue))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fix sync queue duplicate detection to include `includeCustomValues` in uniqueness check - allows queueing same year+service with different custom values settings
- Add `include_custom_values` field to queue status API response 
- Display (+CV) indicator next to queued items in the admin sync panel
- Add cancel running sync feature with new DELETE endpoint and Cancel button
- Add panic recovery for sync goroutines to clear flags on crash

## Test plan
- [ ] Queue sync without custom values, then queue same year+service WITH custom values - both should be queued (not deduplicated)
- [ ] Verify (+CV) indicator appears for queued items with custom values enabled
- [ ] Start a sync, verify Cancel button appears and works
- [ ] Build verification passes for Go and frontend