### PR TITLE
fix(metrics): change drilldown age field from int to float

### DIFF
--- a/api/schemas/metrics.py
+++ b/api/schemas/metrics.py
@@ -496,7 +496,7 @@ class DrilldownAttendee(BaseModel):
     preferred_name: str | None = Field(None, description="Preferred name if set")
     grade: int | None = Field(None, description="Grade level")
     gender: str | None = Field(None, description="Gender (M, F, or other)")
-    age: int | None = Field(None, description="Age")
+    age: float | None = Field(None, description="Age in years")
     school: str | None = Field(None, description="School name")
     city: str | None = Field(None, description="City (parsed from address)")
     years_at_camp: int | None = Field(None, description="Years at camp")


### PR DESCRIPTION
## Summary
- Fix 500 error when clicking chart segments in metrics drilldown modal
- Change `DrilldownAttendee.age` field type from `int` to `float` to match database storage

## Problem
The database stores age as a decimal (e.g., `11.09` for 11 years, 1 month). Pydantic 2.x rejects floats with fractional parts for int fields, causing validation errors:

```
Input should be a valid integer, got a number with a fractional part
[type=int_from_float, input_value=11.09, input_type=float]
```

## Test plan
- [x] `uv run pytest api/services/test_drilldown_service.py -v` - all 14 tests pass
- [ ] Manual test: Click grade chart segment → modal should open with camper list