### PR TITLE
feat(frontend): add escape key support to close modals

### DIFF
--- a/frontend/src/components/metrics/DrillDownModal.test.tsx
+++ b/frontend/src/components/metrics/DrillDownModal.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DrillDownModal } from './DrillDownModal';
+
+// Mock the auth-dependent hook
+vi.mock('../../hooks/useDrilldownAttendees', () => ({
+  useDrilldownAttendees: () => ({
+    data: [],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+// Wrap component with QueryClient for React Query
+function renderWithClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+describe('DrillDownModal', () => {
+  const defaultProps = {
+    year: 2025,
+    filter: { type: 'grade' as const, value: '6', label: 'Grade 6' },
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('keyboard accessibility', () => {
+    it('calls onClose when Escape key is pressed', () => {
+      const onClose = vi.fn();
+      renderWithClient(<DrillDownModal {...defaultProps} onClose={onClose} />);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClose for other keys', () => {
+      const onClose = vi.fn();
+      renderWithClient(<DrillDownModal {...defaultProps} onClose={onClose} />);
+
+      fireEvent.keyDown(document, { key: 'Enter' });
+      fireEvent.keyDown(document, { key: 'Tab' });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when filter is null', () => {
+    it('renders nothing', () => {
+      const { container } = renderWithClient(
+        <DrillDownModal {...defaultProps} filter={null} />
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('does not respond to Escape key', () => {
+      const onClose = vi.fn();
+      renderWithClient(<DrillDownModal {...defaultProps} filter={null} onClose={onClose} />);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('basic rendering', () => {
+    it('renders header with filter label', () => {
+      renderWithClient(<DrillDownModal {...defaultProps} />);
+
+      expect(screen.getByText(/Grade 6/)).toBeInTheDocument();
+    });
+
+    it('calls onClose when close button is clicked', () => {
+      const onClose = vi.fn();
+      renderWithClient(<DrillDownModal {...defaultProps} onClose={onClose} />);
+
+      // The X button doesn't have an accessible name, find by parent structure
+      const closeButtons = screen.getAllByRole('button');
+      const closeButton = closeButtons.find((btn) =>
+        btn.querySelector('svg.lucide-x')
+      );
+
+      if (closeButton) {
+        fireEvent.click(closeButton);
+      } else {
+        // Alternative: find the button with just the X icon (last one in header area)
+        const buttons = screen.getAllByRole('button');
+        const lastButton = buttons[buttons.length - 1];
+        if (lastButton) {
+          fireEvent.click(lastButton);
+        }
+      }
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/components/metrics/DrillDownModal.tsx
+++ b/frontend/src/components/metrics/DrillDownModal.tsx
@@ -8,7 +8,7 @@
  * - CSV export
  */
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { X, Download, Search, ArrowUpDown, ArrowUp, ArrowDown, Loader2 } from 'lucide-react';
 import { useDrilldownAttendees } from '../../hooks/useDrilldownAttendees';
 import type { DrilldownFilter } from '../../types/metrics';
@@ -44,6 +44,19 @@ export function DrillDownModal({
     sessionTypes,
     statusFilter,
   });
+
+  // Handle escape key to close modal
+  useEffect(() => {
+    if (!filter) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [filter, onClose]);
 
   // Filter attendees by search term
   const filteredAttendees = useMemo(() => {

--- a/frontend/src/components/ui/Modal.test.tsx
+++ b/frontend/src/components/ui/Modal.test.tsx
@@ -157,6 +157,55 @@ describe('Modal', () => {
       const closeButton = screen.getByRole('button', { name: /close/i });
       expect(closeButton).toBeInTheDocument();
     });
+
+    it('calls onClose when Escape key is pressed', () => {
+      const onClose = vi.fn();
+      render(
+        <Modal isOpen={true} onClose={onClose}>
+          <p>Modal content</p>
+        </Modal>
+      );
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClose for other keys', () => {
+      const onClose = vi.fn();
+      render(
+        <Modal isOpen={true} onClose={onClose}>
+          <p>Modal content</p>
+        </Modal>
+      );
+
+      fireEvent.keyDown(document, { key: 'Enter' });
+      fireEvent.keyDown(document, { key: 'Tab' });
+      fireEvent.keyDown(document, { key: 'a' });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('removes event listener when modal closes', () => {
+      const onClose = vi.fn();
+      const { rerender } = render(
+        <Modal isOpen={true} onClose={onClose}>
+          <p>Modal content</p>
+        </Modal>
+      );
+
+      // Close the modal
+      rerender(
+        <Modal isOpen={false} onClose={onClose}>
+          <p>Modal content</p>
+        </Modal>
+      );
+
+      // Escape key should not trigger onClose after modal is closed
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
   });
 
   describe('custom header slot', () => {

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,4 +1,5 @@
 import { X } from 'lucide-react';
+import { useEffect } from 'react';
 import type { ReactNode } from 'react';
 
 interface ModalProps {
@@ -55,6 +56,18 @@ export function Modal({
   noPadding = false,
   scrollable = false,
 }: ModalProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
   if (!isOpen) return null;
 
   // Determine if we're using custom header or simple title mode


### PR DESCRIPTION
## Summary
- Add consistent Escape key handling to close all modals
- Modal.tsx: Add useEffect hook to listen for Escape key (covers 12+ modals using shared component)
- DrillDownModal.tsx: Add escape key handling for metrics drilldown modal
- Add comprehensive tests for keyboard accessibility

## Test plan
- [x] All 950 frontend tests pass
- [x] TypeScript compiles cleanly
- [x] ESLint passes (no new errors)
- [ ] Manual: Open any modal → press Escape → modal closes
- [ ] Manual: Open DrillDownModal from metrics chart → press Escape → modal closes