### PR TITLE
fix(sync): add status_id=1 (None) to attendee status mapping

### DIFF
--- a/docs/api/external/campminder/response-examples.md
+++ b/docs/api/external/campminder/response-examples.md
@@ -906,7 +906,7 @@ curl --request PATCH \
 
 **Field Notes:**
 - `SessionProgramStatus`: Array of session/program enrollments for this person
-  - `StatusID`: 2=Enrolled, 4=Applied, 8=WaitList
+  - `StatusID`: 1=None, 2=Enrolled, 4=Applied, 8=WaitList, 16=LeftEarly, 32=Cancelled, 64=Dismissed, 128=Inquiry, 256=Withdrawn, 512=Incomplete
   - `Memo`: Additional notes about the enrollment
   - `PostDate`: When the status was posted
   - `EffectiveDate`: When the status becomes effective
@@ -947,7 +947,7 @@ curl --request PATCH \
 **Field Notes:**
 - Returns attendees for a specific session
 - `PersonsStatus`: Array of person enrollment statuses
-- Status codes: 0=Pending, 1=Waitlisted, 2=Enrolled, 3=Cancelled, 4=Applied, 8=WaitList
+- Status codes: 1=None, 2=Enrolled, 4=Applied, 8=WaitList, 16=LeftEarly, 32=Cancelled, 64=Dismissed, 128=Inquiry, 256=Withdrawn, 512=Incomplete
 
 ## Bunk Plans API
 

--- a/docs/api/external/campminder/specs/sessions.yaml
+++ b/docs/api/external/campminder/specs/sessions.yaml
@@ -818,15 +818,17 @@ components:
           example: 4
           description: >-
             The status of the attendee as it relates to the sessionprogram.
-            Enrolled = 2, Applied = 4, WaitList = 8,LeftEarly = 16, Cancelled =
-            32, Dismissed = 64, Inquiry = 128, Withdrawn = 256, Incomplete = 512
+            None = 1, Enrolled = 2, Applied = 4, WaitList = 8, LeftEarly = 16,
+            Cancelled = 32, Dismissed = 64, Inquiry = 128, Withdrawn = 256,
+            Incomplete = 512
         StatusName:
           type: string
           example: Applied
           description: >-
             The status of the attendee as it relates to the sessionprogram.
-            Enrolled = 2, Applied = 4, WaitList = 8,LeftEarly = 16, Cancelled =
-            32, Dismissed = 64, Inquiry = 128, Withdrawn = 256, Incomplete = 512
+            None = 1, Enrolled = 2, Applied = 4, WaitList = 8, LeftEarly = 16,
+            Cancelled = 32, Dismissed = 64, Inquiry = 128, Withdrawn = 256,
+            Incomplete = 512
         Memo:
           type: string
           description: A field to capture a memo regarding this session assignment.
@@ -989,15 +991,17 @@ components:
           example: 2
           description: >-
             The status of the attendee as it relates to the sessionprogram.
-            Enrolled = 2, Applied = 4, WaitList = 8,LeftEarly = 16, Cancelled =
-            32, Dismissed = 64, Inquiry = 128, Withdrawn = 256, Incomplete = 512
+            None = 1, Enrolled = 2, Applied = 4, WaitList = 8, LeftEarly = 16,
+            Cancelled = 32, Dismissed = 64, Inquiry = 128, Withdrawn = 256,
+            Incomplete = 512
         StatusName:
           type: string
           example: Enrolled
           description: >-
             The status of the attendee as it relates to the sessionprogram.
-            Enrolled = 2, Applied = 4, WaitList = 8,LeftEarly = 16, Cancelled =
-            32, Dismissed = 64, Inquiry = 128, Withdrawn = 256, Incomplete = 512
+            None = 1, Enrolled = 2, Applied = 4, WaitList = 8, LeftEarly = 16,
+            Cancelled = 32, Dismissed = 64, Inquiry = 128, Withdrawn = 256,
+            Incomplete = 512
         Memo:
           type: string
           example: first session

--- a/docs/reference/tables.md
+++ b/docs/reference/tables.md
@@ -304,7 +304,7 @@ Links persons to camp sessions with enrollment status.
 | `person` | relation | Link to persons |
 | `session` | relation | Link to camp_sessions |
 | `status` | select | enrolled/applied/waitlisted/cancelled/etc. |
-| `status_id` | number | CampMinder status ID |
+| `status_id` | number | CampMinder status ID (1=None, 2=Enrolled, 4=Applied, 8=WaitList, 16=LeftEarly, 32=Cancelled, 64=Dismissed, 128=Inquiry, 256=Withdrawn, 512=Incomplete) |
 | `enrollment_date` | date | Enrollment date |
 | `is_active` | bool | Active enrollment |
 | `year` | number | Camp year |

--- a/pocketbase/pb_migrations/1500000040_attendees_add_none_status.js
+++ b/pocketbase/pb_migrations/1500000040_attendees_add_none_status.js
@@ -1,0 +1,57 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: Add "none" status to attendees collection
+ *
+ * CampMinder status_id = 1 means "None". This adds it to the allowed values.
+ */
+
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("attendees");
+
+  // Find the status field and update its values
+  for (let i = 0; i < collection.fields.length; i++) {
+    const field = collection.fields.getByIndex(i);
+    if (field.name === "status") {
+      field.values = [
+        "none",
+        "enrolled",
+        "applied",
+        "waitlisted",
+        "left_early",
+        "cancelled",
+        "dismissed",
+        "inquiry",
+        "withdrawn",
+        "incomplete",
+        "unknown"
+      ];
+      break;
+    }
+  }
+
+  app.save(collection);
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("attendees");
+
+  // Rollback: remove "none" from values
+  for (let i = 0; i < collection.fields.length; i++) {
+    const field = collection.fields.getByIndex(i);
+    if (field.name === "status") {
+      field.values = [
+        "enrolled",
+        "applied",
+        "waitlisted",
+        "left_early",
+        "cancelled",
+        "dismissed",
+        "inquiry",
+        "withdrawn",
+        "incomplete",
+        "unknown"
+      ];
+      break;
+    }
+  }
+
+  app.save(collection);
+});

--- a/pocketbase/sync/attendees.go
+++ b/pocketbase/sync/attendees.go
@@ -228,6 +228,7 @@ func (s *AttendeesSync) processEnrollment(
 
 	// Map StatusID to our status values
 	statusMap := map[int]string{
+		1:   "none",
 		2:   "enrolled",
 		4:   "applied",
 		8:   "waitlisted",


### PR DESCRIPTION
## Summary
- Add `status_id = 1` ("None") to the attendee status mapping throughout the codebase
- CampMinder confirmed that `status_id = 1` means "None" - previously unmapped and labeled "unknown"
- Attendees with this status will now correctly have `status = "none"` and `is_active = false`

## Changes
- **Go sync**: Add `1: "none"` to statusMap in `attendees.go`
- **PB migration**: Add "none" to attendees status enum
- **API specs**: Update `sessions.yaml` with complete status enumeration
- **Docs**: Fix incorrect status codes in `response-examples.md` and expand `tables.md`

## Test plan
- [x] `go build .` passes in pocketbase/
- [x] `npm run build` passes in frontend/
- [x] `uv run pytest tests/` - 1909 tests pass
- [ ] Manual: Sync attendees with status_id=1 → verify status="none"

🤖 Generated with [Claude Code](https://claude.ai/code)