### PR TITLE
fix(pb): use null instead of 0 for unlimited max on number fields

### DIFF
--- a/pocketbase/pb_migrations/1500000040_camper_history_v2.js
+++ b/pocketbase/pb_migrations/1500000040_camper_history_v2.js
@@ -58,7 +58,7 @@ migrate((app) => {
     required: true,
     presentable: false,
     min: 1,
-    max: 0,  // 0 = unlimited
+    max: null,  // null = unlimited
     onlyInt: true
   }));
 
@@ -122,8 +122,8 @@ migrate((app) => {
     name: "bunk_cm_id",
     required: false,
     presentable: false,
-    min: 0,
-    max: 0,  // 0 = unlimited
+    min: null,
+    max: null,  // null = unlimited
     onlyInt: true
   }));
 


### PR DESCRIPTION
## Summary
- Fixed PocketBase v0.23+ migration issue where `max: 0` on number fields is interpreted as "must be less than 0" instead of unlimited
- Changed `session_cm_id` and `bunk_cm_id` fields to use `max: null` for unlimited values

## Problem
Error when creating camper_history records:
```
session_cm_id: Must be less than 0.000000
```

## Test plan
- [ ] Drop dev database and reload
- [ ] Run unified sync for 2026
- [ ] Verify camper_history sync completes without errors