### PR TITLE
fix(sync): extract city and state from persons.address JSON

### DIFF
--- a/pocketbase/pb_migrations/1500000033_camper_history.js
+++ b/pocketbase/pb_migrations/1500000033_camper_history.js
@@ -158,6 +158,15 @@ migrate((app) => {
         pattern: ""
       },
       {
+        type: "text",
+        name: "state",
+        required: false,
+        presentable: false,
+        min: 0,
+        max: 50,
+        pattern: ""
+      },
+      {
         type: "number",
         name: "grade",
         required: false,

--- a/pocketbase/sync/camper_history.go
+++ b/pocketbase/sync/camper_history.go
@@ -80,6 +80,7 @@ type personDemographics struct {
 	lastName     string
 	school       string
 	city         string
+	state        string
 	grade        int
 	age          float64 // CampMinder's age value (can be decimal)
 	householdID  int     // CampMinder household ID
@@ -270,6 +271,7 @@ func (c *CamperHistorySync) Sync(ctx context.Context) error {
 			"last_name":           demo.lastName,
 			"school":              demo.school,
 			"city":                demo.city,
+			"state":               demo.state,
 			"is_returning_summer": isReturningSummer,
 			"is_returning_family": isReturningFamily,
 			"years_at_camp":       yearsAtCamp,
@@ -558,12 +560,25 @@ func (c *CamperHistorySync) loadPersonDemographics(
 				yearsAtCamp = int(yac)
 			}
 
+			// Extract city and state from address JSON field
+			city := ""
+			state := ""
+			if address, ok := record.Get("address").(map[string]interface{}); ok && address != nil {
+				if c, ok := address["city"].(string); ok {
+					city = c
+				}
+				if s, ok := address["state"].(string); ok {
+					state = s
+				}
+			}
+
 			result[cmID] = personDemographics{
 				pbID:        record.Id,
 				firstName:   record.GetString("first_name"),
 				lastName:    record.GetString("last_name"),
 				school:      record.GetString("school"),
-				city:        record.GetString("city"),
+				city:        city,
+				state:       state,
 				grade:       grade,
 				age:         age,
 				householdID: householdID,

--- a/pocketbase/sync/table_exporter.go
+++ b/pocketbase/sync/table_exporter.go
@@ -744,6 +744,7 @@ func GetReadableYearExports() []ExportConfig {
 				{Field: "bunk_cm_id", Header: "Bunk CM ID", Type: FieldTypeNumber},
 				{Field: "school", Header: "School", Type: FieldTypeText},
 				{Field: "city", Header: "City", Type: FieldTypeText},
+				{Field: "state", Header: "State", Type: FieldTypeText},
 				{Field: "grade", Header: "Grade", Type: FieldTypeNumber},
 				{Field: "age", Header: "Age", Type: FieldTypeNumber},
 				{Field: "is_returning_summer", Header: "Returning Summer", Type: FieldTypeBool},


### PR DESCRIPTION
## Summary
- Fix city field not being populated in camper_history - was looking for top-level `city` field but persons table stores it inside `address` JSON
- Add state field to camper_history schema and sync
- Extract both city and state from the address JSON field in loadPersonDemographics()
- Add state column to Google Sheets export config

## Test plan
- [ ] Delete pb_data and restart services to apply migration
- [ ] Run sync: `curl -X POST "http://127.0.0.1:8090/api/custom/sync/camper-history?year=2025"`
- [ ] Query camper_history to verify city and state are populated:
  ```sql
  SELECT first_name, last_name, city, state FROM camper_history WHERE city != '' LIMIT 10;
  ```