### PR TITLE
fix(google): recover globals workbook from Drive during master index update

### DIFF
--- a/pocketbase/sync/workbook_manager.go
+++ b/pocketbase/sync/workbook_manager.go
@@ -361,10 +361,18 @@ func (m *WorkbookManager) GetOrCreateYearWorkbook(ctx context.Context, year int)
 
 // UpdateMasterIndex updates the Index sheet in the globals workbook.
 func (m *WorkbookManager) UpdateMasterIndex(ctx context.Context) error {
-	// Get globals workbook
+	// Get or recover globals workbook (uses driveSearcher to find existing workbooks in Drive)
+	// This is important for historical syncs where the database might not have the record
+	// but the workbook exists in Google Drive
+	_, err := m.GetOrCreateGlobalsWorkbook(ctx)
+	if err != nil {
+		return fmt.Errorf("globals workbook not found: %w", err)
+	}
+
+	// Now get the full record for spreadsheet ID access
 	globals, err := m.GetWorkbookByType(ctx, workbookTypeGlobals, 0)
 	if err != nil || globals == nil {
-		return fmt.Errorf("globals workbook not found")
+		return fmt.Errorf("globals workbook record not found after recovery")
 	}
 
 	// Get all workbooks


### PR DESCRIPTION
## Summary

- Fix "globals workbook not found" error during historical syncs
- Use `GetOrCreateGlobalsWorkbook` in `UpdateMasterIndex` to leverage Drive search capability
- Allows recovery when database is missing the workbook record but workbook exists in Google Drive

## Problem

Historical syncs call `SyncForYears` with `includeGlobals=false`, which skips `SyncGlobalsOnly`. When `UpdateMasterIndex` is called afterward, it only checks the database via `GetWorkbookByType`. If the database doesn't have the globals workbook record (e.g., fresh DB, cleared data), the master index update fails even though the workbook exists in Drive.

## Solution

Call `GetOrCreateGlobalsWorkbook` first in `UpdateMasterIndex`, which uses `driveSearcher` to find and link existing workbooks from Drive before falling back to creation.

## Test plan

- [x] Existing workbook manager tests pass
- [x] Multi-workbook export tests pass
- [x] Go build succeeds
- [ ] Manual verification: Clear `sheets_workbooks` table, run historical sync, verify globals workbook is detected from Drive