### PR TITLE
fix(sync): correct phase ordering and conditional transform logic

### DIFF
--- a/pocketbase/sync/api.go
+++ b/pocketbase/sync/api.go
@@ -2042,26 +2042,19 @@ func handleRunPhase(e *core.RequestEvent, scheduler *Scheduler) error {
 	debugParam := e.Request.URL.Query().Get("debug")
 	debug := debugParam == boolTrueStr || debugParam == "1"
 
-	// Get current year from environment
-	currentYear := time.Now().Year()
-	if yearStr := os.Getenv("CAMPMINDER_SEASON_ID"); yearStr != "" {
-		if cy, err := strconv.Atoi(yearStr); err == nil {
-			currentYear = cy
-		}
-	}
-
 	// Get user info for queue tracking
 	requestedBy := ""
 	if e.Auth != nil {
 		requestedBy = e.Auth.GetString("email")
 	}
 
-	// Check for warning: Transform phase on historical year without custom values
+	// Check for warning: Transform phase without custom values
 	var warning string
-	if phase == PhaseTransform && year != currentYear {
+	if phase == PhaseTransform {
 		// Check if custom values exist for this year
 		if !checkCustomValuesExist(scheduler.app, year) {
-			warning = "Transform phase may have incomplete data: Custom Values not synced for this year"
+			warning = "Transform phase requires Custom Values phase to have run first. " +
+				"4 of 5 transform jobs depend on custom values data and will produce incomplete results without it."
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes critical phase ordering and dependency issues in the sync system that were causing transform jobs to run with stale or missing custom values data.

## The Problem

### Issue 1: Phase Ordering Bug
Custom values (phase 2) were running AFTER transform (phase 3), but 4 of 5 transform jobs depend on custom values data.

**Before**: Source → Transform → Process → CV → Export (phases 1 → 3 → 4 → 2 → 5)
**After**: Source → CV → Transform → Process → Export (phases 1 → 2 → 3 → 4 → 5)

### Issue 2: Transform Phase Always Ran
Transform phase ran unconditionally in `RunSyncWithOptions`, even when `IncludeCustomValues=false`. This caused jobs to run with stale or missing CV data.

### Issue 3: Daily Sync Included Transform
Daily sync included all 5 transform jobs, but custom values don't run daily (only weekly). Transform jobs were using stale CV data from the last weekly sync.

## Changes

### 1. Fixed Phase Ordering (`orchestrator.go:896-912`)
- Moved custom values append BEFORE transform append
- Custom values phase (2) now runs before transform phase (3)

### 2. Conditional Transform Logic (`orchestrator.go:896-912`)
- Wrapped transform phase in `if opts.IncludeCustomValues { ... }`
- Transform jobs only run when CV phase runs
- Entire transform phase treated as a unit with CV phase

### 3. Removed Transform from Daily Sync (`orchestrator.go:503-520`)
- Removed all 5 transform jobs from daily sync orderedJobs
- Added comment explaining why transform is excluded
- Transform now runs only via:
  - Weekly custom values sync (includes CV + transform)
  - Manual unified sync with `includeCustomValues=true`
  - Manual phase sync for transform phase

### 4. Updated Phase Sync Warning (`api.go:2051-2058`)
- Warning now applies to ANY year running transform without CV (not just historical)
- Clarified message to explain CV dependency

### 5. Added Comprehensive Tests (`orchestrator_test.go:2318-2507`)
- `TestDailySyncDoesNotIncludeTransformPhase`: Documents daily sync exclusions
- `TestRunSyncWithOptionsPhaseOrdering`: Verifies correct phase execution order
- `TestRunSyncWithOptionsTransformDependsOnCV`: Documents CV dependencies (4 of 5 jobs)
- `TestRunSyncWithOptionsHistoricalMode`: Documents historical sync behavior

## Transform Job Dependencies

| Job | CV-Dependent | Dependencies |
|-----|--------------|--------------|
| `camper_history` | ❌ | attendees, persons, sessions |
| `family_camp_derived` | ✅ | person_custom_values + household_custom_values |
| `staff_skills` | ✅ | person_custom_values (Skills- fields) |
| `financial_aid_applications` | ✅ | person_custom_values (FA- fields) |
| `household_demographics` | ✅ | household_custom_values (HH- fields) |

**Result**: 4 of 5 transform jobs depend on custom values

## Expected Behavior After Fix

| Sync Mode | includeCustomValues | Phases Run |
|-----------|---------------------|------------|
| **Current year** | true | Source → CV → Transform → Process → Export |
| **Current year** | false | Source → Process → Export |
| **Historical year** | true | Source → CV → Transform → Export |
| **Historical year** | false | Source → Export |
| **Daily sync** | N/A (always false) | Source → Process → Export |

## Testing

- ✅ All sync tests pass (3.764s)
- ✅ Go build succeeds
- ✅ golangci-lint passes (0 issues)
- ✅ Pre-push hooks pass

## Files Modified

- `pocketbase/sync/orchestrator.go` - Phase ordering and conditional logic
- `pocketbase/sync/api.go` - Warning message
- `pocketbase/sync/orchestrator_test.go` - Test coverage