### PR TITLE
fix(sync): add missing sync types to status endpoint and increase field lengths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,7 @@ After implementation, verify ALL of these work:
 | Mistake | Consequence | Prevention |
 |---------|-------------|------------|
 | Service registered but not in `orderedJobs` | Won't run in daily sync | Always add to both places |
+| Missing from `handleSyncStatus()` syncTypes | GUI never shows stats (always "idle") | Add to syncTypes array in api.go:711 |
 | Year-param endpoint without custom hook | Frontend errors on "Run" button | Check if API handler has `year` query param |
 | Missing historical re-registration | Won't run in historical imports | Add `NewXxxSync()` call in `RunSyncWithOptions()` block |
 | Derived table before dependencies | Empty results, relation errors | Map dependency chain, place after deps in orderedJobs |

--- a/pocketbase/pb_migrations/1500000036_financial_aid_applications.js
+++ b/pocketbase/pb_migrations/1500000036_financial_aid_applications.js
@@ -94,7 +94,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 1000,
+        max: 2000,
         pattern: ""
       },
       {
@@ -440,7 +440,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 1000,
+        max: 2000,
         pattern: ""
       },
       {
@@ -467,7 +467,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 1000,
+        max: 2000,
         pattern: ""
       },
       {

--- a/pocketbase/pb_migrations/1500000041_household_demographics.js
+++ b/pocketbase/pb_migrations/1500000041_household_demographics.js
@@ -61,7 +61,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 1000,
+        max: 2000,
         pattern: ""
       },
       {
@@ -70,7 +70,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 500,
+        max: 1000,
         pattern: ""
       },
 
@@ -81,7 +81,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 200,
+        max: 500,
         pattern: ""
       },
       {
@@ -90,7 +90,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 200,
+        max: 500,
         pattern: ""
       },
       {
@@ -99,7 +99,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 1000,
+        max: 2000,
         pattern: ""
       },
 
@@ -162,7 +162,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 200,
+        max: 1000,
         pattern: ""
       },
 

--- a/pocketbase/sync/api.go
+++ b/pocketbase/sync/api.go
@@ -723,10 +723,13 @@ func handleSyncStatus(e *core.RequestEvent, scheduler *Scheduler) error {
 		"bunks",
 		"bunk_plans",
 		"bunk_assignments",
-		"staff",                  // Year-scoped staff records (depends on divisions, bunks, persons)
-		"camper_history",         // Computed camper denorm with retention metrics
-		"financial_transactions", // Year-scoped financial data (depends on sessions, persons, households)
-		"family_camp_derived",    // Computed from custom values (depends on person_custom_values, household_custom_values)
+		"staff",                      // Year-scoped staff records (depends on divisions, bunks, persons)
+		"camper_history",             // Computed camper denorm with retention metrics
+		"financial_transactions",     // Year-scoped financial data (depends on sessions, persons, households)
+		"family_camp_derived",        // Computed from person_custom_values, household_custom_values
+		"staff_skills",               // Derived: staff skills extraction
+		"financial_aid_applications", // Derived: FA applications computation
+		"household_demographics",     // Derived: household demographics computation
 		"bunk_requests",
 		"process_requests",
 		"multi_workbook_export",


### PR DESCRIPTION
## Summary
- Adds `staff_skills`, `financial_aid_applications`, and `household_demographics` to the `handleSyncStatus()` syncTypes array so their stats are reported to the GUI
- Increases field length limits in migrations to prevent truncation errors (e.g., `parent_immigrant_origin` 200→1000)
- Documents the `handleSyncStatus()` registration requirement in CLAUDE.md common mistakes table

## Test plan
- [ ] Run `go build .` in pocketbase/ - verifies Go changes compile
- [ ] Load fresh database with updated migrations
- [ ] Run individual sync for `staff_skills`, `financial_aid_applications`, `household_demographics`
- [ ] Verify toasts show "started" immediately and completion stats after
- [ ] Run `household_demographics` sync and verify no field truncation errors