### PR TITLE
fix(sync): add 5 new sync jobs to status endpoint

### DIFF
--- a/pocketbase/sync/api.go
+++ b/pocketbase/sync/api.go
@@ -765,6 +765,11 @@ func handleSyncStatus(e *core.RequestEvent, scheduler *Scheduler) error {
 		"staff_skills",               // Derived: staff skills extraction
 		"financial_aid_applications", // Derived: FA applications computation
 		"household_demographics",     // Derived: household demographics computation
+		"camper_dietary",             // Derived: camper dietary extraction
+		"camper_transportation",      // Derived: camper transportation extraction
+		"quest_registrations",        // Derived: Quest program registration extraction
+		"staff_applications",         // Derived: staff applications extraction
+		"staff_vehicle_info",         // Derived: staff vehicle info extraction
 		"bunk_requests",
 		"process_requests",
 		"multi_workbook_export",


### PR DESCRIPTION
## Summary
- Add `camper_dietary`, `camper_transportation`, `quest_registrations`, `staff_applications`, and `staff_vehicle_info` to the `syncTypes` array in `handleSyncStatus()`
- Fixes frontend always showing "idle" status for these 5 new sync jobs from PR #170

## Test plan
- [ ] Verify Go builds successfully
- [ ] Trigger one of the 5 sync jobs and confirm frontend shows running status and stats