### PR TITLE
Merge sync fixes (PRs 181-188) with dependabot updates

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,7 +1,7 @@
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import reactHooks from 'eslint-plugin-react-hooks';
-import reactRefresh from 'eslint-plugin-react-refresh';
+import { reactRefresh } from 'eslint-plugin-react-refresh';
 
 export default tseslint.config(
   // Base ESLint recommended rules
@@ -11,7 +11,10 @@ export default tseslint.config(
   ...tseslint.configs.recommended,
   // Add strict rules for TypeScript 5.8
   ...tseslint.configs.strict,
-  
+
+  // React Refresh Vite preset
+  reactRefresh.configs.vite({ allowConstantExport: true }),
+
   // Ignore patterns
   {
     ignores: ['dist/**', 'node_modules/**', '*.cjs']
@@ -50,7 +53,6 @@ export default tseslint.config(
     },
     plugins: {
       'react-hooks': reactHooks,
-      'react-refresh': reactRefresh,
     },
     rules: {
       // React Hooks rules - core rules as errors, compiler rules as warnings
@@ -64,12 +66,6 @@ export default tseslint.config(
       'react-hooks/refs': 'warn',
       'react-hooks/purity': 'warn',
 
-      // React Refresh rules
-      'react-refresh/only-export-components': [
-        'warn',
-        { allowConstantExport: true }
-      ],
-      
       // TypeScript rules
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unused-vars': [

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from 'react';
-import React, { Component } from 'react';
+import type { ReactNode, ErrorInfo } from 'react';
+import { Component } from 'react';
 import { AlertTriangle, RefreshCw } from 'lucide-react';
 import { isChunkLoadError } from '../utils/chunkLoadError';
 import { shouldAutoReload, autoReload } from '../utils/autoReload';
@@ -25,7 +25,7 @@ export class ErrorBoundary extends Component<Props, State> {
     return { hasError: true, error };
   }
 
-  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     // Auto-reload for chunk load errors (stale deployment)
     if (isChunkLoadError(error)) {
       if (shouldAutoReload()) {
@@ -120,17 +120,4 @@ export class ErrorBoundary extends Component<Props, State> {
 
     return this.props.children;
   }
-}
-
-// Hook for using error boundary programmatically
-export function useErrorHandler() {
-  const [error, setError] = React.useState<Error | null>(null);
-
-  React.useEffect(() => {
-    if (error) {
-      throw error;
-    }
-  }, [error]);
-
-  return setError;
 }

--- a/frontend/src/components/admin/SyncTab.tsx
+++ b/frontend/src/components/admin/SyncTab.tsx
@@ -406,7 +406,7 @@ export function SyncTab() {
                       year: syncYear,
                       service: syncService,
                       includeCustomValues: shouldIncludeCustomValues,
-                      debug: shouldIncludeCustomValues && syncDebug,
+                      debug: syncDebug,
                     });
                   }}
                   disabled={unifiedSync.isPending}

--- a/frontend/src/hooks/useErrorHandler.ts
+++ b/frontend/src/hooks/useErrorHandler.ts
@@ -1,0 +1,14 @@
+import { useState, useEffect } from 'react';
+
+// Hook for using error boundary programmatically
+export function useErrorHandler() {
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (error) {
+      throw error;
+    }
+  }, [error]);
+
+  return setError;
+}

--- a/pocketbase/pb_migrations/1500000041_household_demographics.js
+++ b/pocketbase/pb_migrations/1500000041_household_demographics.js
@@ -214,7 +214,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 50,
+        max: 200,
         pattern: ""
       },
       {
@@ -223,7 +223,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 20,
+        max: 100,
         pattern: ""
       },
       {
@@ -232,7 +232,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 20,
+        max: 100,
         pattern: ""
       },
 

--- a/pocketbase/pb_migrations/1500000045_quest_registrations.js
+++ b/pocketbase/pb_migrations/1500000045_quest_registrations.js
@@ -476,7 +476,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 50,
+        max: 200,
         pattern: ""
       },
       {
@@ -503,7 +503,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 50,
+        max: 200,
         pattern: ""
       },
 

--- a/pocketbase/sync/api.go
+++ b/pocketbase/sync/api.go
@@ -413,6 +413,20 @@ func handleIndividualSync(e *core.RequestEvent, scheduler *Scheduler, syncType s
 		})
 	}
 
+	// Parse debug parameter
+	debugParam := e.Request.URL.Query().Get("debug")
+	debug := debugParam == boolTrueStr || debugParam == "1"
+
+	// If debug is enabled, set it on the service (if it supports Debuggable interface)
+	if debug {
+		if service := orchestrator.GetService(syncType); service != nil {
+			if debuggable, ok := service.(Debuggable); ok {
+				debuggable.SetDebug(true)
+				slog.Info("Debug logging enabled for sync", "syncType", syncType)
+			}
+		}
+	}
+
 	// Get current year from environment
 	currentYear := time.Now().Year()
 	if yearStr := os.Getenv("CAMPMINDER_SEASON_ID"); yearStr != "" {
@@ -427,9 +441,13 @@ func handleIndividualSync(e *core.RequestEvent, scheduler *Scheduler, syncType s
 		requestedBy = e.Auth.GetString("email")
 	}
 
-	// Check if any sync sequence is running - if so, queue instead of running immediately
+	// Check if any sync should cause queueing:
+	// 1. Sequence flags (daily/weekly/historical/custom-values) - cover the window between
+	//    sequence start and first job execution (before runningJobs is populated)
+	// 2. IsAnyJobRunning() - covers individual jobs that were started outside a sequence
 	if orchestrator.IsDailySyncRunning() || orchestrator.IsWeeklySyncRunning() ||
-		orchestrator.IsHistoricalSyncRunning() || orchestrator.IsCustomValuesSyncRunning() {
+		orchestrator.IsHistoricalSyncRunning() || orchestrator.IsCustomValuesSyncRunning() ||
+		orchestrator.IsAnyJobRunning() {
 		// Queue the individual sync
 		qs, err := orchestrator.EnqueueIndividualSync(currentYear, syncType, nil, requestedBy)
 		if err != nil {
@@ -445,6 +463,7 @@ func handleIndividualSync(e *core.RequestEvent, scheduler *Scheduler, syncType s
 			"queue_id": qs.ID,
 			"position": position,
 			"syncType": syncType,
+			"debug":    debug,
 		})
 	}
 
@@ -459,6 +478,15 @@ func handleIndividualSync(e *core.RequestEvent, scheduler *Scheduler, syncType s
 			e.App.Logger().Error("Individual sync failed", "syncType", syncType, "error", err)
 		}
 
+		// Reset debug flag after sync completes
+		if debug {
+			if service := orchestrator.GetService(syncType); service != nil {
+				if debuggable, ok := service.(Debuggable); ok {
+					debuggable.SetDebug(false)
+				}
+			}
+		}
+
 		// Process queue after individual sync completes
 		processQueuedSyncs(orchestrator)
 	}()
@@ -467,6 +495,7 @@ func handleIndividualSync(e *core.RequestEvent, scheduler *Scheduler, syncType s
 		"message":  fmt.Sprintf("%s sync started", syncType),
 		"status":   "started",
 		"syncType": syncType,
+		"debug":    debug,
 	})
 }
 
@@ -2149,10 +2178,28 @@ func handleRunPhase(e *core.RequestEvent, scheduler *Scheduler) error {
 			default:
 			}
 
+			// Set debug on the service if requested
+			if debug {
+				if svc := orchestrator.GetService(jobID); svc != nil {
+					if debuggable, ok := svc.(Debuggable); ok {
+						debuggable.SetDebug(true)
+					}
+				}
+			}
+
 			slog.Info("Running phase job", "phase", phase, "job", jobID)
 			if err := orchestrator.runSyncAndWait(ctx, jobID); err != nil {
 				slog.Error("Phase job failed", "phase", phase, "job", jobID, "error", err)
 				// Continue with next job even if one fails
+			}
+
+			// Clear debug after job completes
+			if debug {
+				if svc := orchestrator.GetService(jobID); svc != nil {
+					if debuggable, ok := svc.(Debuggable); ok {
+						debuggable.SetDebug(false)
+					}
+				}
 			}
 		}
 

--- a/pocketbase/sync/attendees.go
+++ b/pocketbase/sync/attendees.go
@@ -176,6 +176,7 @@ func (s *AttendeesSync) processAttendee(
 	sessionStatuses, ok := attendeeData["SessionProgramStatus"].([]interface{})
 	if !ok || len(sessionStatuses) == 0 {
 		// No enrollments for this person
+		s.DebugLog("Skipping attendee: no session enrollments", "person_cm_id", personCMID)
 		s.Stats.Skipped++
 		return nil
 	}
@@ -212,6 +213,9 @@ func (s *AttendeesSync) processEnrollment(
 	// Check if session exists
 	if !s.sessionCMIDs[strconv.Itoa(sessionCMID)] {
 		// Session doesn't exist in PocketBase, skip
+		s.DebugLog("Skipping enrollment: session not in PocketBase",
+			"person_cm_id", personCMID,
+			"session_cm_id", sessionCMID)
 		s.Stats.Skipped++
 		return nil
 	}

--- a/pocketbase/sync/base_sync.go
+++ b/pocketbase/sync/base_sync.go
@@ -44,6 +44,7 @@ type BaseSyncService struct {
 	SyncSuccessful bool            // Track if the main sync operation succeeded
 	ProcessedKeys  map[string]bool // Track processed composite keys for orphan detection
 	FieldDiffStats map[string]int  // Track which fields cause updates (for debugging)
+	Debug          bool            // Enable verbose debug logging
 }
 
 // NewBaseSyncService creates a new base sync service
@@ -102,6 +103,18 @@ func (b *BaseSyncService) LogSyncCompleteWithExpansion(
 // GetStats returns the current stats for the sync service
 func (b *BaseSyncService) GetStats() Stats {
 	return b.Stats
+}
+
+// SetDebug enables or disables debug logging
+func (b *BaseSyncService) SetDebug(debug bool) {
+	b.Debug = debug
+}
+
+// DebugLog logs a message at INFO level only when Debug is enabled
+func (b *BaseSyncService) DebugLog(msg string, args ...any) {
+	if b.Debug {
+		slog.Info("[DEBUG] "+msg, args...)
+	}
 }
 
 // ClearProcessedKeys resets the processed keys tracker

--- a/pocketbase/sync/bunk_plans.go
+++ b/pocketbase/sync/bunk_plans.go
@@ -282,6 +282,11 @@ func (s *BunkPlansSync) processBunkPlan(planData map[string]interface{}) (int, e
 	assignmentsCreated := 0
 
 	if len(bunkIDs) == 0 || len(sessionIDs) == 0 {
+		s.DebugLog("Skipping bunk plan template: empty bunkIDs or sessionIDs",
+			"plan_id", int(planID),
+			"name", name,
+			"bunk_count", len(bunkIDs),
+			"session_count", len(sessionIDs))
 		s.Stats.Skipped++
 		return 0, nil
 	}
@@ -300,6 +305,9 @@ func (s *BunkPlansSync) processBunkPlan(planData map[string]interface{}) (int, e
 
 		// Validate bunk exists
 		if !s.validBunkCMIDs[bunkCMID] {
+			s.DebugLog("Skipping bunk plan: bunk not in PocketBase",
+				"plan_id", int(planID),
+				"bunk_cm_id", bunkCMID)
 			s.Stats.Skipped++
 			continue
 		}
@@ -323,6 +331,10 @@ func (s *BunkPlansSync) processBunkPlan(planData map[string]interface{}) (int, e
 
 			// Validate session exists
 			if !s.validSessionCMIDs[sessionCMID] {
+				s.DebugLog("Skipping bunk plan: session not in PocketBase",
+					"plan_id", int(planID),
+					"bunk_cm_id", bunkCMID,
+					"session_cm_id", sessionCMID)
 				s.Stats.Skipped++
 				continue
 			}

--- a/pocketbase/sync/camper_dietary.go
+++ b/pocketbase/sync/camper_dietary.go
@@ -39,6 +39,7 @@ type CamperDietarySync struct {
 	App            core.App
 	Year           int
 	DryRun         bool
+	Debug          bool
 	Stats          Stats
 	SyncSuccessful bool
 }
@@ -60,6 +61,18 @@ func (s *CamperDietarySync) Name() string {
 // GetStats returns the current stats
 func (s *CamperDietarySync) GetStats() Stats {
 	return s.Stats
+}
+
+// SetDebug enables or disables debug logging
+func (s *CamperDietarySync) SetDebug(debug bool) {
+	s.Debug = debug
+}
+
+// DebugLog logs a message at INFO level only when Debug is enabled
+func (s *CamperDietarySync) DebugLog(msg string, args ...any) {
+	if s.Debug {
+		slog.Info(msg, args...)
+	}
 }
 
 // camperDietaryRecord holds the extracted dietary info for a camper
@@ -102,6 +115,7 @@ func (s *CamperDietarySync) Sync(ctx context.Context) error {
 	slog.Info("Starting camper dietary extraction",
 		"year", year,
 		"dry_run", s.DryRun,
+		"debug", s.Debug,
 	)
 
 	// Step 1: Build field name mapping (field_definition PB ID -> field name)
@@ -142,9 +156,10 @@ func (s *CamperDietarySync) Sync(ctx context.Context) error {
 	slog.Info("Loaded existing records", "count", len(existingRecords))
 
 	// Step 5: Upsert records
-	created, updated, errors := s.upsertRecords(ctx, records, existingRecords, year)
+	created, updated, skipped, errors := s.upsertRecords(ctx, records, existingRecords, year)
 	s.Stats.Created = created
 	s.Stats.Updated = updated
+	s.Stats.Skipped = skipped
 	s.Stats.Errors = errors
 
 	// Step 6: Delete orphans
@@ -163,6 +178,7 @@ func (s *CamperDietarySync) Sync(ctx context.Context) error {
 		"year", year,
 		"created", s.Stats.Created,
 		"updated", s.Stats.Updated,
+		"skipped", s.Stats.Skipped,
 		"deleted", s.Stats.Deleted,
 		"errors", s.Stats.Errors,
 	)
@@ -259,6 +275,9 @@ func (s *CamperDietarySync) loadPersonCustomValues(
 	// Collect all values first
 	var entries []dietaryValueEntry
 
+	// Cache for person PB ID -> CM ID lookups
+	personCache := make(map[string]int)
+
 	filter := fmt.Sprintf("year = %d", year)
 	page := 1
 	perPage := 500
@@ -282,7 +301,27 @@ func (s *CamperDietarySync) loadPersonCustomValues(
 				continue // Not a dietary field
 			}
 
-			personID := record.GetInt("person_id")
+			// person_custom_values has "person" relation field (PB ID), not "person_id"
+			personPBID := record.GetString("person")
+			if personPBID == "" {
+				continue
+			}
+
+			// Look up CM ID from cache or persons table
+			personID := 0
+			if cached, ok := personCache[personPBID]; ok {
+				personID = cached
+			} else {
+				personFilter := fmt.Sprintf("id = '%s'", personPBID)
+				persons, err := s.App.FindRecordsByFilter("persons", personFilter, "", 1, 0)
+				if err == nil && len(persons) > 0 {
+					if cmID, ok := persons[0].Get("cm_id").(float64); ok {
+						personID = int(cmID)
+						personCache[personPBID] = personID
+					}
+				}
+			}
+
 			value := record.GetString("value")
 
 			if personID > 0 && value != "" {
@@ -386,6 +425,63 @@ func makeCamperDietaryKey(personID, year int) string {
 	return fmt.Sprintf("%d|%d", personID, year)
 }
 
+// fieldEquals compares two field values for equality, handling type conversions.
+// This mirrors the centralized BaseSyncService.FieldEquals logic.
+func (s *CamperDietarySync) fieldEquals(existing, newVal any) bool {
+	// Handle nil vs empty string
+	if (existing == nil && newVal == "") || (existing == "" && newVal == nil) {
+		return true
+	}
+	// Handle nil vs false (for boolean fields)
+	if existing == nil && newVal == false {
+		return true
+	}
+	if existing == false && newVal == nil {
+		return true
+	}
+	// Handle nil vs 0
+	if existing == nil && newVal == 0 {
+		return true
+	}
+	if existing == 0 && newVal == nil {
+		return true
+	}
+	// Handle float64 vs int (JSON unmarshals numbers as float64)
+	if existFloat, ok := existing.(float64); ok {
+		if newInt, ok := newVal.(int); ok {
+			return int(existFloat) == newInt
+		}
+	}
+	if existInt, ok := existing.(int); ok {
+		if newFloat, ok := newVal.(float64); ok {
+			return existInt == int(newFloat)
+		}
+	}
+	// Handle bool comparison (PocketBase may return bool, we may pass bool)
+	if existBool, ok := existing.(bool); ok {
+		if newBool, ok := newVal.(bool); ok {
+			return existBool == newBool
+		}
+	}
+
+	// String comparison as fallback
+	return fmt.Sprintf("%v", existing) == fmt.Sprintf("%v", newVal)
+}
+
+// recordNeedsUpdate checks if any field differs between existing record and new data
+func (s *CamperDietarySync) recordNeedsUpdate(record *core.Record, data map[string]any) bool {
+	skipFields := map[string]bool{"id": true, "created": true, "updated": true}
+	for field, newValue := range data {
+		if skipFields[field] {
+			continue
+		}
+		if !s.fieldEquals(record.Get(field), newValue) {
+			return true
+		}
+	}
+	return false
+}
+
 // loadExistingRecords loads existing camper_dietary records for a year
 func (s *CamperDietarySync) loadExistingRecords(ctx context.Context, year int) (map[string]string, error) {
 	result := make(map[string]string) // compositeKey -> PB ID
@@ -427,22 +523,34 @@ func (s *CamperDietarySync) upsertRecords(
 	records map[string]*camperDietaryRecord,
 	existingRecords map[string]string,
 	year int,
-) (created, updated, errors int) {
+) (created, updated, skipped, errors int) {
 	col, err := s.App.FindCollectionByNameOrId("camper_dietary")
 	if err != nil {
 		slog.Error("Error finding camper_dietary collection", "error", err)
-		return 0, 0, len(records)
+		return 0, 0, 0, len(records)
 	}
 
 	for _, rec := range records {
 		select {
 		case <-ctx.Done():
-			return created, updated, errors
+			return created, updated, skipped, errors
 		default:
 		}
 
 		key := makeCamperDietaryKey(rec.personID, year)
 		existingID, exists := existingRecords[key]
+
+		// Build data map for comparison
+		data := map[string]any{
+			"attendee":            rec.attendeeID,
+			"person_id":           rec.personID,
+			"year":                rec.year,
+			"has_dietary_needs":   rec.hasDietaryNeeds,
+			"dietary_explanation": rec.dietaryExplanation,
+			"has_allergies":       rec.hasAllergies,
+			"allergy_info":        rec.allergyInfo,
+			"additional_medical":  rec.additionalMedical,
+		}
 
 		var record *core.Record
 		if exists {
@@ -452,19 +560,22 @@ func (s *CamperDietarySync) upsertRecords(
 				errors++
 				continue
 			}
+
+			// Check if update is actually needed
+			if !s.recordNeedsUpdate(record, data) {
+				s.DebugLog("Skipping unchanged dietary record", "person_id", rec.personID, "year", year)
+				skipped++
+				continue
+			}
+			s.DebugLog("Updating dietary record", "person_id", rec.personID, "year", year)
 		} else {
 			record = core.NewRecord(col)
 		}
 
 		// Set all fields
-		record.Set("attendee", rec.attendeeID)
-		record.Set("person_id", rec.personID)
-		record.Set("year", rec.year)
-		record.Set("has_dietary_needs", rec.hasDietaryNeeds)
-		record.Set("dietary_explanation", rec.dietaryExplanation)
-		record.Set("has_allergies", rec.hasAllergies)
-		record.Set("allergy_info", rec.allergyInfo)
-		record.Set("additional_medical", rec.additionalMedical)
+		for field, value := range data {
+			record.Set(field, value)
+		}
 
 		if err := s.App.Save(record); err != nil {
 			slog.Error("Error saving camper_dietary record",
@@ -483,7 +594,7 @@ func (s *CamperDietarySync) upsertRecords(
 		}
 	}
 
-	return created, updated, errors
+	return created, updated, skipped, errors
 }
 
 // deleteOrphans removes records that exist in DB but not in computed set

--- a/pocketbase/sync/camper_history.go
+++ b/pocketbase/sync/camper_history.go
@@ -35,6 +35,7 @@ type CamperHistorySync struct {
 	App            core.App
 	Year           int  // Year to compute history for (0 = current year from env)
 	DryRun         bool // Dry run mode (compute but don't write)
+	Debug          bool // Enable verbose debug logging
 	Stats          Stats
 	SyncSuccessful bool
 	ProcessedKeys  map[string]bool // Track processed composite keys for orphan detection
@@ -58,6 +59,18 @@ func (c *CamperHistorySync) Name() string {
 // GetStats returns the current stats
 func (c *CamperHistorySync) GetStats() Stats {
 	return c.Stats
+}
+
+// SetDebug enables or disables debug logging
+func (c *CamperHistorySync) SetDebug(debug bool) {
+	c.Debug = debug
+}
+
+// DebugLog logs a message at INFO level only when Debug is enabled
+func (c *CamperHistorySync) DebugLog(msg string, args ...any) {
+	if c.Debug {
+		slog.Info(msg, args...)
+	}
 }
 
 // attendeeRecord holds raw attendee data from the database

--- a/pocketbase/sync/camper_transportation.go
+++ b/pocketbase/sync/camper_transportation.go
@@ -50,6 +50,7 @@ type CamperTransportationSync struct {
 	App            core.App
 	Year           int
 	DryRun         bool
+	Debug          bool
 	Stats          Stats
 	SyncSuccessful bool
 }
@@ -71,6 +72,18 @@ func (s *CamperTransportationSync) Name() string {
 // GetStats returns the current stats
 func (s *CamperTransportationSync) GetStats() Stats {
 	return s.Stats
+}
+
+// SetDebug enables or disables debug logging
+func (s *CamperTransportationSync) SetDebug(debug bool) {
+	s.Debug = debug
+}
+
+// DebugLog logs a message at INFO level only when Debug is enabled
+func (s *CamperTransportationSync) DebugLog(msg string, args ...any) {
+	if s.Debug {
+		slog.Info(msg, args...)
+	}
 }
 
 // camperTransportationRecord holds the extracted transportation info for a camper-session
@@ -123,6 +136,7 @@ func (s *CamperTransportationSync) Sync(ctx context.Context) error {
 	slog.Info("Starting camper transportation extraction",
 		"year", year,
 		"dry_run", s.DryRun,
+		"debug", s.Debug,
 	)
 
 	// Step 1: Build field name mapping (field_definition PB ID -> field name)
@@ -205,6 +219,7 @@ func (s *CamperTransportationSync) loadFieldDefinitions(_ context.Context) (map[
 		name := record.GetString("name")
 		if isCamperTransportationField(name) {
 			result[record.Id] = name
+			s.DebugLog("Found transportation field definition", "name", name, "pb_id", record.Id)
 		}
 	}
 
@@ -291,6 +306,9 @@ func (s *CamperTransportationSync) loadPersonCustomValues(
 	// Collect all values first
 	var entries []transportValueEntry
 
+	// Cache for person PB ID -> CM ID lookups
+	personCache := make(map[string]int)
+
 	filter := fmt.Sprintf("year = %d", year)
 	page := 1
 	perPage := 500
@@ -314,7 +332,27 @@ func (s *CamperTransportationSync) loadPersonCustomValues(
 				continue // Not a transportation field
 			}
 
-			personID := record.GetInt("person_id")
+			// person_custom_values has "person" relation field (PB ID), not "person_id"
+			personPBID := record.GetString("person")
+			if personPBID == "" {
+				continue
+			}
+
+			// Look up CM ID from cache or persons table
+			personID := 0
+			if cached, ok := personCache[personPBID]; ok {
+				personID = cached
+			} else {
+				personFilter := fmt.Sprintf("id = '%s'", personPBID)
+				persons, err := s.App.FindRecordsByFilter("persons", personFilter, "", 1, 0)
+				if err == nil && len(persons) > 0 {
+					if cmID, ok := persons[0].Get("cm_id").(float64); ok {
+						personID = int(cmID)
+						personCache[personPBID] = personID
+					}
+				}
+			}
+
 			value := record.GetString("value")
 
 			if personID > 0 && value != "" {

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -25,16 +25,25 @@ type FamilyCampDerivedSync struct {
 	App            core.App
 	Year           int  // Year to compute for (0 = current year from env)
 	DryRun         bool // Dry run mode (compute but don't write)
+	Debug          bool // Enable verbose debug logging
 	Stats          Stats
 	SyncSuccessful bool
+
+	// Track processed keys for orphan detection
+	ProcessedAdultKeys   map[string]bool
+	ProcessedRegKeys     map[string]bool
+	ProcessedMedicalKeys map[string]bool
 }
 
 // NewFamilyCampDerivedSync creates a new family camp derived sync service
 func NewFamilyCampDerivedSync(app core.App) *FamilyCampDerivedSync {
 	return &FamilyCampDerivedSync{
-		App:    app,
-		Year:   0,
-		DryRun: false,
+		App:                  app,
+		Year:                 0,
+		DryRun:               false,
+		ProcessedAdultKeys:   make(map[string]bool),
+		ProcessedRegKeys:     make(map[string]bool),
+		ProcessedMedicalKeys: make(map[string]bool),
 	}
 }
 
@@ -46,6 +55,18 @@ func (s *FamilyCampDerivedSync) Name() string {
 // GetStats returns the current stats
 func (s *FamilyCampDerivedSync) GetStats() Stats {
 	return s.Stats
+}
+
+// SetDebug enables or disables debug logging
+func (s *FamilyCampDerivedSync) SetDebug(debug bool) {
+	s.Debug = debug
+}
+
+// DebugLog logs a message at INFO level only when Debug is enabled
+func (s *FamilyCampDerivedSync) DebugLog(msg string, args ...any) {
+	if s.Debug {
+		slog.Info(msg, args...)
+	}
 }
 
 // adultData holds extracted adult information
@@ -91,6 +112,9 @@ type medicalData struct {
 func (s *FamilyCampDerivedSync) Sync(ctx context.Context) error {
 	s.Stats = Stats{}
 	s.SyncSuccessful = false
+	s.ProcessedAdultKeys = make(map[string]bool)
+	s.ProcessedRegKeys = make(map[string]bool)
+	s.ProcessedMedicalKeys = make(map[string]bool)
 
 	// Determine year
 	year := s.Year
@@ -167,40 +191,66 @@ func (s *FamilyCampDerivedSync) Sync(ctx context.Context) error {
 		return nil
 	}
 
-	// Step 8: Clear existing records
-	deleted, err := s.clearExistingRecords(ctx, year)
+	// Step 8: Preload existing records for upsert
+	existingAdults, err := s.preloadExistingAdults(year)
 	if err != nil {
-		return fmt.Errorf("clearing existing records: %w", err)
+		return fmt.Errorf("preloading existing adults: %w", err)
 	}
-	s.Stats.Deleted = deleted
-	slog.Info("Cleared existing records", "deleted", deleted)
+	existingRegs, err := s.preloadExistingRegistrations(year)
+	if err != nil {
+		return fmt.Errorf("preloading existing registrations: %w", err)
+	}
+	existingMedical, err := s.preloadExistingMedical(year)
+	if err != nil {
+		return fmt.Errorf("preloading existing medical: %w", err)
+	}
+	slog.Info("Preloaded existing records",
+		"adults", len(existingAdults),
+		"registrations", len(existingRegs),
+		"medical", len(existingMedical),
+	)
 
-	// Step 9: Write adults
-	created, errors := s.writeAdults(ctx, adults, year)
+	// Step 9: Upsert adults
+	created, updated, skipped, errors := s.upsertAdults(ctx, adults, year, existingAdults)
 	s.Stats.Created += created
+	s.Stats.Updated += updated
+	s.Stats.Skipped += skipped
 	s.Stats.Errors += errors
 
-	// Step 10: Write registrations
-	created, errors = s.writeRegistrations(ctx, registrations, year)
+	// Step 10: Upsert registrations
+	created, updated, skipped, errors = s.upsertRegistrations(ctx, registrations, year, existingRegs)
 	s.Stats.Created += created
+	s.Stats.Updated += updated
+	s.Stats.Skipped += skipped
 	s.Stats.Errors += errors
 
-	// Step 11: Write medical
-	created, errors = s.writeMedical(ctx, medical, year)
+	// Step 11: Upsert medical
+	created, updated, skipped, errors = s.upsertMedical(ctx, medical, year, existingMedical)
 	s.Stats.Created += created
+	s.Stats.Updated += updated
+	s.Stats.Skipped += skipped
 	s.Stats.Errors += errors
+
+	// Mark sync as successful before orphan deletion
+	s.SyncSuccessful = true
+
+	// Step 12: Delete orphaned records (no longer in source data)
+	s.Stats.Deleted += s.deleteOrphanedAdults(existingAdults)
+	s.Stats.Deleted += s.deleteOrphanedRegistrations(existingRegs)
+	s.Stats.Deleted += s.deleteOrphanedMedical(existingMedical)
 
 	// WAL checkpoint
-	if s.Stats.Created > 0 || s.Stats.Deleted > 0 {
+	if s.Stats.Created > 0 || s.Stats.Updated > 0 || s.Stats.Deleted > 0 {
 		if err := s.forceWALCheckpoint(); err != nil {
 			slog.Warn("WAL checkpoint failed", "error", err)
 		}
 	}
 
-	s.SyncSuccessful = true
 	slog.Info("Family camp derived computation completed",
 		"year", year,
 		"created", s.Stats.Created,
+		"updated", s.Stats.Updated,
+		"skipped", s.Stats.Skipped,
 		"deleted", s.Stats.Deleted,
 		"errors", s.Stats.Errors,
 	)
@@ -637,170 +687,6 @@ func (s *FamilyCampDerivedSync) processMedical(personValues []customValueEntry) 
 	return result
 }
 
-// clearExistingRecords deletes all family camp derived records for a year
-func (s *FamilyCampDerivedSync) clearExistingRecords(ctx context.Context, year int) (int, error) {
-	deleted := 0
-
-	tables := []string{"family_camp_adults", "family_camp_registrations", "family_camp_medical"}
-	filter := fmt.Sprintf("year = %d", year)
-
-	for _, table := range tables {
-		for {
-			select {
-			case <-ctx.Done():
-				return deleted, ctx.Err()
-			default:
-			}
-
-			records, err := s.App.FindRecordsByFilter(table, filter, "", 100, 0)
-			if err != nil {
-				return deleted, fmt.Errorf("querying %s: %w", table, err)
-			}
-
-			if len(records) == 0 {
-				break
-			}
-
-			for _, record := range records {
-				if err := s.App.Delete(record); err != nil {
-					slog.Error("Error deleting record", "table", table, "id", record.Id, "error", err)
-					continue
-				}
-				deleted++
-			}
-		}
-	}
-
-	return deleted, nil
-}
-
-// writeAdults writes adult records to the database
-func (s *FamilyCampDerivedSync) writeAdults(ctx context.Context, adults []*adultData, year int) (created, errors int) {
-	created = 0
-	errors = 0
-
-	col, err := s.App.FindCollectionByNameOrId("family_camp_adults")
-	if err != nil {
-		slog.Error("Error finding family_camp_adults collection", "error", err)
-		return 0, len(adults)
-	}
-
-	for _, adult := range adults {
-		select {
-		case <-ctx.Done():
-			return created, errors
-		default:
-		}
-
-		record := core.NewRecord(col)
-		record.Set("household", adult.householdPBID)
-		record.Set("year", year)
-		record.Set("adult_number", adult.adultNumber)
-		record.Set("name", adult.name)
-		record.Set("first_name", adult.firstName)
-		record.Set("last_name", adult.lastName)
-		record.Set("email", adult.email)
-		record.Set("pronouns", adult.pronouns)
-		record.Set("gender", adult.gender)
-		record.Set("date_of_birth", adult.dateOfBirth)
-		record.Set("relationship_to_camper", adult.relationship)
-
-		if err := s.App.Save(record); err != nil {
-			slog.Error("Error creating adult record", "household", adult.householdPBID, "error", err)
-			errors++
-			continue
-		}
-		created++
-	}
-
-	return created, errors
-}
-
-// writeRegistrations writes registration records to the database
-func (s *FamilyCampDerivedSync) writeRegistrations(
-	ctx context.Context, registrations []*registrationData, year int,
-) (created, errors int) {
-	created = 0
-	errors = 0
-
-	col, err := s.App.FindCollectionByNameOrId("family_camp_registrations")
-	if err != nil {
-		slog.Error("Error finding family_camp_registrations collection", "error", err)
-		return 0, len(registrations)
-	}
-
-	for _, reg := range registrations {
-		select {
-		case <-ctx.Done():
-			return created, errors
-		default:
-		}
-
-		record := core.NewRecord(col)
-		record.Set("household", reg.householdPBID)
-		record.Set("year", year)
-		record.Set("cabin_assignment", reg.cabinAssignment)
-		record.Set("share_cabin_preference", reg.shareCabinPreference)
-		record.Set("shared_cabin_with", reg.sharedCabinWith)
-		record.Set("arrival_eta", reg.arrivalETA)
-		record.Set("special_occasions", reg.specialOccasions)
-		record.Set("goals", reg.goals)
-		record.Set("notes", reg.notes)
-		record.Set("needs_accommodation", reg.needsAccommodation)
-		record.Set("opt_out_vip", reg.optOutVIP)
-
-		if err := s.App.Save(record); err != nil {
-			slog.Error("Error creating registration record", "household", reg.householdPBID, "error", err)
-			errors++
-			continue
-		}
-		created++
-	}
-
-	return created, errors
-}
-
-// writeMedical writes medical records to the database
-func (s *FamilyCampDerivedSync) writeMedical(
-	ctx context.Context, medical []*medicalData, year int,
-) (created, errors int) {
-	created = 0
-	errors = 0
-
-	col, err := s.App.FindCollectionByNameOrId("family_camp_medical")
-	if err != nil {
-		slog.Error("Error finding family_camp_medical collection", "error", err)
-		return 0, len(medical)
-	}
-
-	for _, med := range medical {
-		select {
-		case <-ctx.Done():
-			return created, errors
-		default:
-		}
-
-		record := core.NewRecord(col)
-		record.Set("household", med.householdPBID)
-		record.Set("year", year)
-		record.Set("cpap_info", med.cpapInfo)
-		record.Set("physician_info", med.physicianInfo)
-		record.Set("special_needs_info", med.specialNeedsInfo)
-		record.Set("allergy_info", med.allergyInfo)
-		record.Set("dietary_info", med.dietaryInfo)
-		record.Set("additional_info", med.additionalInfo)
-
-		if err := s.App.Save(record); err != nil {
-			slog.Error("Error creating medical record", "household", med.householdPBID, "error", err)
-			errors++
-			continue
-		}
-		created++
-	}
-
-	return created, errors
-}
-
 // forceWALCheckpoint forces a SQLite WAL checkpoint
 func (s *FamilyCampDerivedSync) forceWALCheckpoint() error {
 	db := s.App.DB()
@@ -857,4 +743,450 @@ func extractAdultNumberFromField(fieldName string) int {
 func parseBoolFieldValue(value string) bool {
 	lower := strings.ToLower(strings.TrimSpace(value))
 	return lower == boolYes || lower == boolTrueStr || lower == "1"
+}
+
+// ============================================================================
+// Upsert helpers: preload existing records
+// ============================================================================
+
+// preloadExistingAdults loads all existing family_camp_adults records for the year
+// Returns a map keyed by "householdPBID:year:adultNumber"
+func (s *FamilyCampDerivedSync) preloadExistingAdults(year int) (map[string]*core.Record, error) {
+	result := make(map[string]*core.Record)
+	filter := fmt.Sprintf("year = %d", year)
+	page := 1
+	perPage := 500
+
+	for {
+		records, err := s.App.FindRecordsByFilter("family_camp_adults", filter, "", perPage, (page-1)*perPage)
+		if err != nil {
+			return nil, fmt.Errorf("querying family_camp_adults page %d: %w", page, err)
+		}
+
+		for _, record := range records {
+			householdID := record.GetString("household")
+			adultNum := 0
+			if num, ok := record.Get("adult_number").(float64); ok {
+				adultNum = int(num)
+			}
+			if householdID != "" && adultNum > 0 {
+				key := fmt.Sprintf("%s:%d:%d", householdID, year, adultNum)
+				result[key] = record
+			}
+		}
+
+		if len(records) < perPage {
+			break
+		}
+		page++
+	}
+
+	return result, nil
+}
+
+// preloadExistingRegistrations loads all existing family_camp_registrations records for the year
+// Returns a map keyed by "householdPBID:year"
+func (s *FamilyCampDerivedSync) preloadExistingRegistrations(year int) (map[string]*core.Record, error) {
+	result := make(map[string]*core.Record)
+	filter := fmt.Sprintf("year = %d", year)
+	page := 1
+	perPage := 500
+
+	for {
+		records, err := s.App.FindRecordsByFilter("family_camp_registrations", filter, "", perPage, (page-1)*perPage)
+		if err != nil {
+			return nil, fmt.Errorf("querying family_camp_registrations page %d: %w", page, err)
+		}
+
+		for _, record := range records {
+			householdID := record.GetString("household")
+			if householdID != "" {
+				key := fmt.Sprintf("%s:%d", householdID, year)
+				result[key] = record
+			}
+		}
+
+		if len(records) < perPage {
+			break
+		}
+		page++
+	}
+
+	return result, nil
+}
+
+// preloadExistingMedical loads all existing family_camp_medical records for the year
+// Returns a map keyed by "householdPBID:year"
+func (s *FamilyCampDerivedSync) preloadExistingMedical(year int) (map[string]*core.Record, error) {
+	result := make(map[string]*core.Record)
+	filter := fmt.Sprintf("year = %d", year)
+	page := 1
+	perPage := 500
+
+	for {
+		records, err := s.App.FindRecordsByFilter("family_camp_medical", filter, "", perPage, (page-1)*perPage)
+		if err != nil {
+			return nil, fmt.Errorf("querying family_camp_medical page %d: %w", page, err)
+		}
+
+		for _, record := range records {
+			householdID := record.GetString("household")
+			if householdID != "" {
+				key := fmt.Sprintf("%s:%d", householdID, year)
+				result[key] = record
+			}
+		}
+
+		if len(records) < perPage {
+			break
+		}
+		page++
+	}
+
+	return result, nil
+}
+
+// ============================================================================
+// Upsert helpers: comparison functions
+// ============================================================================
+
+// adultNeedsUpdate checks if an adult record needs updating
+func (s *FamilyCampDerivedSync) adultNeedsUpdate(existing *core.Record, adult *adultData) bool {
+	return existing.GetString("name") != adult.name ||
+		existing.GetString("first_name") != adult.firstName ||
+		existing.GetString("last_name") != adult.lastName ||
+		existing.GetString("email") != adult.email ||
+		existing.GetString("pronouns") != adult.pronouns ||
+		existing.GetString("gender") != adult.gender ||
+		existing.GetString("date_of_birth") != adult.dateOfBirth ||
+		existing.GetString("relationship_to_camper") != adult.relationship
+}
+
+// registrationNeedsUpdate checks if a registration record needs updating
+func (s *FamilyCampDerivedSync) registrationNeedsUpdate(existing *core.Record, reg *registrationData) bool {
+	return existing.GetString("cabin_assignment") != reg.cabinAssignment ||
+		existing.GetString("share_cabin_preference") != reg.shareCabinPreference ||
+		existing.GetString("shared_cabin_with") != reg.sharedCabinWith ||
+		existing.GetString("arrival_eta") != reg.arrivalETA ||
+		existing.GetString("special_occasions") != reg.specialOccasions ||
+		existing.GetString("goals") != reg.goals ||
+		existing.GetString("notes") != reg.notes ||
+		existing.GetBool("needs_accommodation") != reg.needsAccommodation ||
+		existing.GetBool("opt_out_vip") != reg.optOutVIP
+}
+
+// medicalNeedsUpdate checks if a medical record needs updating
+func (s *FamilyCampDerivedSync) medicalNeedsUpdate(existing *core.Record, med *medicalData) bool {
+	return existing.GetString("cpap_info") != med.cpapInfo ||
+		existing.GetString("physician_info") != med.physicianInfo ||
+		existing.GetString("special_needs_info") != med.specialNeedsInfo ||
+		existing.GetString("allergy_info") != med.allergyInfo ||
+		existing.GetString("dietary_info") != med.dietaryInfo ||
+		existing.GetString("additional_info") != med.additionalInfo
+}
+
+// ============================================================================
+// Upsert functions
+// ============================================================================
+
+// upsertAdults performs upsert for adult records
+func (s *FamilyCampDerivedSync) upsertAdults(
+	ctx context.Context, adults []*adultData, year int, existing map[string]*core.Record,
+) (created, updated, skipped, errors int) {
+	col, err := s.App.FindCollectionByNameOrId("family_camp_adults")
+	if err != nil {
+		slog.Error("Error finding family_camp_adults collection", "error", err)
+		return 0, 0, 0, len(adults)
+	}
+
+	for _, adult := range adults {
+		select {
+		case <-ctx.Done():
+			return created, updated, skipped, errors
+		default:
+		}
+
+		key := fmt.Sprintf("%s:%d:%d", adult.householdPBID, year, adult.adultNumber)
+		s.ProcessedAdultKeys[key] = true
+
+		if existingRecord, ok := existing[key]; ok {
+			// Record exists - check if update needed
+			if s.adultNeedsUpdate(existingRecord, adult) {
+				existingRecord.Set("name", adult.name)
+				existingRecord.Set("first_name", adult.firstName)
+				existingRecord.Set("last_name", adult.lastName)
+				existingRecord.Set("email", adult.email)
+				existingRecord.Set("pronouns", adult.pronouns)
+				existingRecord.Set("gender", adult.gender)
+				existingRecord.Set("date_of_birth", adult.dateOfBirth)
+				existingRecord.Set("relationship_to_camper", adult.relationship)
+
+				if err := s.App.Save(existingRecord); err != nil {
+					slog.Error("Error updating adult record", "household", adult.householdPBID, "error", err)
+					errors++
+					continue
+				}
+				updated++
+			} else {
+				skipped++
+			}
+		} else {
+			// New record - create
+			record := core.NewRecord(col)
+			record.Set("household", adult.householdPBID)
+			record.Set("year", year)
+			record.Set("adult_number", adult.adultNumber)
+			record.Set("name", adult.name)
+			record.Set("first_name", adult.firstName)
+			record.Set("last_name", adult.lastName)
+			record.Set("email", adult.email)
+			record.Set("pronouns", adult.pronouns)
+			record.Set("gender", adult.gender)
+			record.Set("date_of_birth", adult.dateOfBirth)
+			record.Set("relationship_to_camper", adult.relationship)
+
+			if err := s.App.Save(record); err != nil {
+				slog.Error("Error creating adult record", "household", adult.householdPBID, "error", err)
+				errors++
+				continue
+			}
+			created++
+		}
+	}
+
+	return created, updated, skipped, errors
+}
+
+// upsertRegistrations performs upsert for registration records
+func (s *FamilyCampDerivedSync) upsertRegistrations(
+	ctx context.Context, registrations []*registrationData, year int, existing map[string]*core.Record,
+) (created, updated, skipped, errors int) {
+	col, err := s.App.FindCollectionByNameOrId("family_camp_registrations")
+	if err != nil {
+		slog.Error("Error finding family_camp_registrations collection", "error", err)
+		return 0, 0, 0, len(registrations)
+	}
+
+	for _, reg := range registrations {
+		select {
+		case <-ctx.Done():
+			return created, updated, skipped, errors
+		default:
+		}
+
+		key := fmt.Sprintf("%s:%d", reg.householdPBID, year)
+		s.ProcessedRegKeys[key] = true
+
+		if existingRecord, ok := existing[key]; ok {
+			// Record exists - check if update needed
+			if s.registrationNeedsUpdate(existingRecord, reg) {
+				existingRecord.Set("cabin_assignment", reg.cabinAssignment)
+				existingRecord.Set("share_cabin_preference", reg.shareCabinPreference)
+				existingRecord.Set("shared_cabin_with", reg.sharedCabinWith)
+				existingRecord.Set("arrival_eta", reg.arrivalETA)
+				existingRecord.Set("special_occasions", reg.specialOccasions)
+				existingRecord.Set("goals", reg.goals)
+				existingRecord.Set("notes", reg.notes)
+				existingRecord.Set("needs_accommodation", reg.needsAccommodation)
+				existingRecord.Set("opt_out_vip", reg.optOutVIP)
+
+				if err := s.App.Save(existingRecord); err != nil {
+					slog.Error("Error updating registration record", "household", reg.householdPBID, "error", err)
+					errors++
+					continue
+				}
+				updated++
+			} else {
+				skipped++
+			}
+		} else {
+			// New record - create
+			record := core.NewRecord(col)
+			record.Set("household", reg.householdPBID)
+			record.Set("year", year)
+			record.Set("cabin_assignment", reg.cabinAssignment)
+			record.Set("share_cabin_preference", reg.shareCabinPreference)
+			record.Set("shared_cabin_with", reg.sharedCabinWith)
+			record.Set("arrival_eta", reg.arrivalETA)
+			record.Set("special_occasions", reg.specialOccasions)
+			record.Set("goals", reg.goals)
+			record.Set("notes", reg.notes)
+			record.Set("needs_accommodation", reg.needsAccommodation)
+			record.Set("opt_out_vip", reg.optOutVIP)
+
+			if err := s.App.Save(record); err != nil {
+				slog.Error("Error creating registration record", "household", reg.householdPBID, "error", err)
+				errors++
+				continue
+			}
+			created++
+		}
+	}
+
+	return created, updated, skipped, errors
+}
+
+// upsertMedical performs upsert for medical records
+func (s *FamilyCampDerivedSync) upsertMedical(
+	ctx context.Context, medical []*medicalData, year int, existing map[string]*core.Record,
+) (created, updated, skipped, errors int) {
+	col, err := s.App.FindCollectionByNameOrId("family_camp_medical")
+	if err != nil {
+		slog.Error("Error finding family_camp_medical collection", "error", err)
+		return 0, 0, 0, len(medical)
+	}
+
+	for _, med := range medical {
+		select {
+		case <-ctx.Done():
+			return created, updated, skipped, errors
+		default:
+		}
+
+		key := fmt.Sprintf("%s:%d", med.householdPBID, year)
+		s.ProcessedMedicalKeys[key] = true
+
+		if existingRecord, ok := existing[key]; ok {
+			// Record exists - check if update needed
+			if s.medicalNeedsUpdate(existingRecord, med) {
+				existingRecord.Set("cpap_info", med.cpapInfo)
+				existingRecord.Set("physician_info", med.physicianInfo)
+				existingRecord.Set("special_needs_info", med.specialNeedsInfo)
+				existingRecord.Set("allergy_info", med.allergyInfo)
+				existingRecord.Set("dietary_info", med.dietaryInfo)
+				existingRecord.Set("additional_info", med.additionalInfo)
+
+				if err := s.App.Save(existingRecord); err != nil {
+					slog.Error("Error updating medical record", "household", med.householdPBID, "error", err)
+					errors++
+					continue
+				}
+				updated++
+			} else {
+				skipped++
+			}
+		} else {
+			// New record - create
+			record := core.NewRecord(col)
+			record.Set("household", med.householdPBID)
+			record.Set("year", year)
+			record.Set("cpap_info", med.cpapInfo)
+			record.Set("physician_info", med.physicianInfo)
+			record.Set("special_needs_info", med.specialNeedsInfo)
+			record.Set("allergy_info", med.allergyInfo)
+			record.Set("dietary_info", med.dietaryInfo)
+			record.Set("additional_info", med.additionalInfo)
+
+			if err := s.App.Save(record); err != nil {
+				slog.Error("Error creating medical record", "household", med.householdPBID, "error", err)
+				errors++
+				continue
+			}
+			created++
+		}
+	}
+
+	return created, updated, skipped, errors
+}
+
+// ============================================================================
+// Orphan deletion functions
+// ============================================================================
+
+// deleteOrphanedAdults removes adult records that weren't processed
+func (s *FamilyCampDerivedSync) deleteOrphanedAdults(existing map[string]*core.Record) int {
+	if !s.SyncSuccessful {
+		slog.Info("Skipping orphan deletion for adults due to sync failure")
+		return 0
+	}
+
+	orphanCount := 0
+	for key, record := range existing {
+		if s.ProcessedAdultKeys[key] {
+			continue
+		}
+
+		householdID := record.GetString("household")
+		adultNum := record.Get("adult_number")
+		slog.Info("Deleting orphaned family_camp_adults record",
+			"household", householdID,
+			"adult_number", adultNum)
+
+		if err := s.App.Delete(record); err != nil {
+			slog.Error("Error deleting orphan adult", "id", record.Id, "error", err)
+			s.Stats.Errors++
+			continue
+		}
+		orphanCount++
+	}
+
+	if orphanCount > 0 {
+		slog.Info("Deleted orphaned family_camp_adults records", "count", orphanCount)
+	}
+
+	return orphanCount
+}
+
+// deleteOrphanedRegistrations removes registration records that weren't processed
+func (s *FamilyCampDerivedSync) deleteOrphanedRegistrations(existing map[string]*core.Record) int {
+	if !s.SyncSuccessful {
+		slog.Info("Skipping orphan deletion for registrations due to sync failure")
+		return 0
+	}
+
+	orphanCount := 0
+	for key, record := range existing {
+		if s.ProcessedRegKeys[key] {
+			continue
+		}
+
+		householdID := record.GetString("household")
+		slog.Info("Deleting orphaned family_camp_registrations record",
+			"household", householdID)
+
+		if err := s.App.Delete(record); err != nil {
+			slog.Error("Error deleting orphan registration", "id", record.Id, "error", err)
+			s.Stats.Errors++
+			continue
+		}
+		orphanCount++
+	}
+
+	if orphanCount > 0 {
+		slog.Info("Deleted orphaned family_camp_registrations records", "count", orphanCount)
+	}
+
+	return orphanCount
+}
+
+// deleteOrphanedMedical removes medical records that weren't processed
+func (s *FamilyCampDerivedSync) deleteOrphanedMedical(existing map[string]*core.Record) int {
+	if !s.SyncSuccessful {
+		slog.Info("Skipping orphan deletion for medical due to sync failure")
+		return 0
+	}
+
+	orphanCount := 0
+	for key, record := range existing {
+		if s.ProcessedMedicalKeys[key] {
+			continue
+		}
+
+		householdID := record.GetString("household")
+		slog.Info("Deleting orphaned family_camp_medical record",
+			"household", householdID)
+
+		if err := s.App.Delete(record); err != nil {
+			slog.Error("Error deleting orphan medical", "id", record.Id, "error", err)
+			s.Stats.Errors++
+			continue
+		}
+		orphanCount++
+	}
+
+	if orphanCount > 0 {
+		slog.Info("Deleted orphaned family_camp_medical records", "count", orphanCount)
+	}
+
+	return orphanCount
 }

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 	"testing"
@@ -753,6 +754,510 @@ func parseBoolField(value string) bool {
 	lower := strings.ToLower(strings.TrimSpace(value))
 	return lower == boolYes || lower == boolTrueStr || lower == "1"
 }
+
+// ============================================================================
+// Idempotency Tests - Define expected upsert behavior
+// ============================================================================
+
+// TestUpsertAdultsIdempotency verifies that running the sync twice with unchanged data
+// results in all records being skipped (not created) on the second run.
+func TestUpsertAdultsIdempotency(t *testing.T) {
+	// Simulate computed adults from source data
+	adults := []*testAdult{
+		{HouseholdCMID: 100, AdultNumber: 1, FirstName: "John", LastName: "Smith", Email: "john@example.com"},
+		{HouseholdCMID: 100, AdultNumber: 2, FirstName: "Jane", LastName: "Smith", Email: "jane@example.com"},
+		{HouseholdCMID: 200, AdultNumber: 1, FirstName: "Bob", LastName: "Jones", Email: "bob@example.com"},
+	}
+
+	// Simulate first run: no existing records
+	existing1 := make(map[string]*testAdultRecord)
+	stats1 := simulateUpsertAdults(adults, existing1, 2025)
+
+	// First run should create all records
+	if stats1.Created != 3 {
+		t.Errorf("first run: expected Created=3, got %d", stats1.Created)
+	}
+	if stats1.Skipped != 0 {
+		t.Errorf("first run: expected Skipped=0, got %d", stats1.Skipped)
+	}
+	if stats1.Updated != 0 {
+		t.Errorf("first run: expected Updated=0, got %d", stats1.Updated)
+	}
+
+	// Simulate second run: existing records match computed data (from first run)
+	existing2 := buildExistingAdultsMap(adults, 2025)
+	stats2 := simulateUpsertAdults(adults, existing2, 2025)
+
+	// Second run should skip all records (no changes)
+	if stats2.Created != 0 {
+		t.Errorf("second run: expected Created=0, got %d", stats2.Created)
+	}
+	if stats2.Skipped != 3 {
+		t.Errorf("second run: expected Skipped=3, got %d", stats2.Skipped)
+	}
+	if stats2.Updated != 0 {
+		t.Errorf("second run: expected Updated=0, got %d", stats2.Updated)
+	}
+}
+
+// TestUpsertAdultsUpdateDetection verifies that modified source data results in
+// the Updated stat being incremented, not Created.
+func TestUpsertAdultsUpdateDetection(t *testing.T) {
+	// Existing records in database (from previous sync)
+	existingAdults := []*testAdult{
+		{HouseholdCMID: 100, AdultNumber: 1, FirstName: "John", LastName: "Smith", Email: "john@example.com"},
+		{HouseholdCMID: 100, AdultNumber: 2, FirstName: "Jane", LastName: "Smith", Email: "jane@example.com"},
+	}
+	existing := buildExistingAdultsMap(existingAdults, 2025)
+
+	// New computed data with one change: John's email updated
+	newAdults := []*testAdult{
+		// Changed email
+		{HouseholdCMID: 100, AdultNumber: 1, FirstName: "John", LastName: "Smith", Email: "john.smith@newdomain.com"},
+		// Unchanged
+		{HouseholdCMID: 100, AdultNumber: 2, FirstName: "Jane", LastName: "Smith", Email: "jane@example.com"},
+	}
+
+	stats := simulateUpsertAdults(newAdults, existing, 2025)
+
+	// Should update 1 record (John's email changed) and skip 1 (Jane unchanged)
+	if stats.Updated != 1 {
+		t.Errorf("expected Updated=1, got %d", stats.Updated)
+	}
+	if stats.Skipped != 1 {
+		t.Errorf("expected Skipped=1, got %d", stats.Skipped)
+	}
+	if stats.Created != 0 {
+		t.Errorf("expected Created=0, got %d", stats.Created)
+	}
+}
+
+// TestUpsertAdultsOrphanDeletion verifies that records removed from source data
+// are deleted (orphan cleanup).
+func TestUpsertAdultsOrphanDeletion(t *testing.T) {
+	// Existing records in database (from previous sync)
+	existingAdults := []*testAdult{
+		{HouseholdCMID: 100, AdultNumber: 1, FirstName: "John", LastName: "Smith", Email: "john@example.com"},
+		{HouseholdCMID: 100, AdultNumber: 2, FirstName: "Jane", LastName: "Smith", Email: "jane@example.com"},
+		// Will be orphaned
+		{HouseholdCMID: 200, AdultNumber: 1, FirstName: "Bob", LastName: "Jones", Email: "bob@example.com"},
+	}
+	existing := buildExistingAdultsMap(existingAdults, 2025)
+
+	// New computed data: household 200 is no longer in source (unenrolled from family camp)
+	newAdults := []*testAdult{
+		{HouseholdCMID: 100, AdultNumber: 1, FirstName: "John", LastName: "Smith", Email: "john@example.com"},
+		{HouseholdCMID: 100, AdultNumber: 2, FirstName: "Jane", LastName: "Smith", Email: "jane@example.com"},
+	}
+
+	// Track processed keys
+	processedKeys := make(map[string]bool)
+	stats := simulateUpsertAdultsWithTracking(newAdults, existing, 2025, processedKeys)
+
+	// Should skip 2 records (unchanged)
+	if stats.Skipped != 2 {
+		t.Errorf("expected Skipped=2, got %d", stats.Skipped)
+	}
+
+	// Simulate orphan deletion
+	orphanCount := countOrphans(existing, processedKeys)
+	if orphanCount != 1 {
+		t.Errorf("expected 1 orphan (Bob Jones), got %d", orphanCount)
+	}
+}
+
+// TestUpsertRegistrationsIdempotency verifies registration upsert idempotency
+func TestUpsertRegistrationsIdempotency(t *testing.T) {
+	registrations := []*testRegistration{
+		{HouseholdCMID: 100, CabinAssignment: "Cabin 12", ShareCabinPreference: "Yes"},
+		{HouseholdCMID: 200, CabinAssignment: "Cabin 14", Goals: "Family bonding"},
+	}
+
+	// First run
+	existing1 := make(map[string]*testRegRecord)
+	stats1 := simulateUpsertRegistrations(registrations, existing1, 2025)
+
+	if stats1.Created != 2 {
+		t.Errorf("first run: expected Created=2, got %d", stats1.Created)
+	}
+
+	// Second run (unchanged)
+	existing2 := buildExistingRegistrationsMap(registrations, 2025)
+	stats2 := simulateUpsertRegistrations(registrations, existing2, 2025)
+
+	if stats2.Skipped != 2 {
+		t.Errorf("second run: expected Skipped=2, got %d", stats2.Skipped)
+	}
+	if stats2.Created != 0 {
+		t.Errorf("second run: expected Created=0, got %d", stats2.Created)
+	}
+}
+
+// TestUpsertMedicalIdempotency verifies medical upsert idempotency
+func TestUpsertMedicalIdempotency(t *testing.T) {
+	medical := []*testMedical{
+		{HouseholdCMID: 100, AllergyInfo: "Peanuts", DietaryInfo: "Vegetarian"},
+		{HouseholdCMID: 200, CPAPInfo: "Yes; needs outlet"},
+	}
+
+	// First run
+	existing1 := make(map[string]*testMedRecord)
+	stats1 := simulateUpsertMedical(medical, existing1, 2025)
+
+	if stats1.Created != 2 {
+		t.Errorf("first run: expected Created=2, got %d", stats1.Created)
+	}
+
+	// Second run (unchanged)
+	existing2 := buildExistingMedicalMap(medical, 2025)
+	stats2 := simulateUpsertMedical(medical, existing2, 2025)
+
+	if stats2.Skipped != 2 {
+		t.Errorf("second run: expected Skipped=2, got %d", stats2.Skipped)
+	}
+	if stats2.Created != 0 {
+		t.Errorf("second run: expected Created=0, got %d", stats2.Created)
+	}
+}
+
+// TestCompositeKeyFormats verifies the composite key format for each table
+func TestCompositeKeyFormats(t *testing.T) {
+	tests := []struct {
+		name        string
+		tableName   string
+		householdID string
+		year        int
+		adultNumber int // Only for adults table
+		expectedKey string
+	}{
+		{
+			name:        "adults key format",
+			tableName:   "family_camp_adults",
+			householdID: "pb_household_123",
+			year:        2025,
+			adultNumber: 1,
+			expectedKey: "pb_household_123:2025:1",
+		},
+		{
+			name:        "adults key with different adult number",
+			tableName:   "family_camp_adults",
+			householdID: "pb_household_456",
+			year:        2025,
+			adultNumber: 3,
+			expectedKey: "pb_household_456:2025:3",
+		},
+		{
+			name:        "registrations key format",
+			tableName:   "family_camp_registrations",
+			householdID: "pb_household_123",
+			year:        2025,
+			expectedKey: "pb_household_123:2025",
+		},
+		{
+			name:        "medical key format",
+			tableName:   "family_camp_medical",
+			householdID: "pb_household_789",
+			year:        2024,
+			expectedKey: "pb_household_789:2024",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var key string
+			if tt.tableName == "family_camp_adults" {
+				key = buildAdultCompositeKey(tt.householdID, tt.year, tt.adultNumber)
+			} else {
+				key = buildHouseholdCompositeKey(tt.householdID, tt.year)
+			}
+
+			if key != tt.expectedKey {
+				t.Errorf("expected key %q, got %q", tt.expectedKey, key)
+			}
+		})
+	}
+}
+
+// ============================================================================
+// Test helper types for upsert simulation
+// ============================================================================
+
+// testUpsertStats mirrors the Stats struct for test verification
+type testUpsertStats struct {
+	Created int
+	Updated int
+	Skipped int
+	Deleted int
+	Errors  int
+}
+
+// testAdultRecord simulates a PocketBase record for adults
+type testAdultRecord struct {
+	HouseholdPBID string
+	Year          int
+	AdultNumber   int
+	FirstName     string
+	LastName      string
+	Email         string
+	Pronouns      string
+	Gender        string
+	DateOfBirth   string
+	Relationship  string
+}
+
+// testRegRecord simulates a PocketBase record for registrations
+type testRegRecord struct {
+	HouseholdPBID        string
+	Year                 int
+	CabinAssignment      string
+	ShareCabinPreference string
+	SharedCabinWith      string
+	ArrivalETA           string
+	SpecialOccasions     string
+	Goals                string
+	Notes                string
+	NeedsAccommodation   bool
+	OptOutVIP            bool
+}
+
+// testMedRecord simulates a PocketBase record for medical
+type testMedRecord struct {
+	HouseholdPBID    string
+	Year             int
+	CPAPInfo         string
+	PhysicianInfo    string
+	SpecialNeedsInfo string
+	AllergyInfo      string
+	DietaryInfo      string
+	AdditionalInfo   string
+}
+
+// ============================================================================
+// Test helper functions for upsert simulation
+// ============================================================================
+
+// buildAdultCompositeKey builds the composite key for family_camp_adults
+func buildAdultCompositeKey(householdPBID string, year, adultNumber int) string {
+	return fmt.Sprintf("%s:%d:%d", householdPBID, year, adultNumber)
+}
+
+// buildHouseholdCompositeKey builds the composite key for registrations/medical
+func buildHouseholdCompositeKey(householdPBID string, year int) string {
+	return fmt.Sprintf("%s:%d", householdPBID, year)
+}
+
+// buildExistingAdultsMap creates a map of existing adult records (simulates preload)
+func buildExistingAdultsMap(adults []*testAdult, year int) map[string]*testAdultRecord {
+	result := make(map[string]*testAdultRecord)
+	for _, a := range adults {
+		// Use household CM ID as PB ID for test purposes
+		pbID := fmt.Sprintf("pb_household_%d", a.HouseholdCMID)
+		key := buildAdultCompositeKey(pbID, year, a.AdultNumber)
+		result[key] = &testAdultRecord{
+			HouseholdPBID: pbID,
+			Year:          year,
+			AdultNumber:   a.AdultNumber,
+			FirstName:     a.FirstName,
+			LastName:      a.LastName,
+			Email:         a.Email,
+			Pronouns:      a.Pronouns,
+			Gender:        a.Gender,
+			DateOfBirth:   a.DateOfBirth,
+			Relationship:  a.Relationship,
+		}
+	}
+	return result
+}
+
+// adultNeedsUpdate checks if an adult record needs updating
+func adultNeedsUpdate(existing *testAdultRecord, newAdult *testAdult) bool {
+	return existing.FirstName != newAdult.FirstName ||
+		existing.LastName != newAdult.LastName ||
+		existing.Email != newAdult.Email ||
+		existing.Pronouns != newAdult.Pronouns ||
+		existing.Gender != newAdult.Gender ||
+		existing.DateOfBirth != newAdult.DateOfBirth ||
+		existing.Relationship != newAdult.Relationship
+}
+
+// simulateUpsertAdults simulates the upsert logic for adults
+func simulateUpsertAdults(adults []*testAdult, existing map[string]*testAdultRecord, year int) testUpsertStats {
+	stats := testUpsertStats{}
+
+	for _, a := range adults {
+		pbID := fmt.Sprintf("pb_household_%d", a.HouseholdCMID)
+		key := buildAdultCompositeKey(pbID, year, a.AdultNumber)
+
+		if existingRecord, ok := existing[key]; ok {
+			if adultNeedsUpdate(existingRecord, a) {
+				stats.Updated++
+			} else {
+				stats.Skipped++
+			}
+		} else {
+			stats.Created++
+		}
+	}
+
+	return stats
+}
+
+// simulateUpsertAdultsWithTracking simulates upsert with key tracking for orphan detection
+func simulateUpsertAdultsWithTracking(
+	adults []*testAdult,
+	existing map[string]*testAdultRecord,
+	year int,
+	processedKeys map[string]bool,
+) testUpsertStats {
+	stats := testUpsertStats{}
+
+	for _, a := range adults {
+		pbID := fmt.Sprintf("pb_household_%d", a.HouseholdCMID)
+		key := buildAdultCompositeKey(pbID, year, a.AdultNumber)
+		processedKeys[key] = true
+
+		if existingRecord, ok := existing[key]; ok {
+			if adultNeedsUpdate(existingRecord, a) {
+				stats.Updated++
+			} else {
+				stats.Skipped++
+			}
+		} else {
+			stats.Created++
+		}
+	}
+
+	return stats
+}
+
+// countOrphans counts records in existing that weren't processed
+func countOrphans(existing map[string]*testAdultRecord, processedKeys map[string]bool) int {
+	count := 0
+	for key := range existing {
+		if !processedKeys[key] {
+			count++
+		}
+	}
+	return count
+}
+
+// buildExistingRegistrationsMap creates a map of existing registration records
+func buildExistingRegistrationsMap(regs []*testRegistration, year int) map[string]*testRegRecord {
+	result := make(map[string]*testRegRecord)
+	for _, r := range regs {
+		pbID := fmt.Sprintf("pb_household_%d", r.HouseholdCMID)
+		key := buildHouseholdCompositeKey(pbID, year)
+		result[key] = &testRegRecord{
+			HouseholdPBID:        pbID,
+			Year:                 year,
+			CabinAssignment:      r.CabinAssignment,
+			ShareCabinPreference: r.ShareCabinPreference,
+			SharedCabinWith:      r.SharedCabinWith,
+			ArrivalETA:           r.ArrivalETA,
+			SpecialOccasions:     r.SpecialOccasions,
+			Goals:                r.Goals,
+			Notes:                r.Notes,
+			NeedsAccommodation:   r.NeedsAccommodation,
+			OptOutVIP:            r.OptOutVIP,
+		}
+	}
+	return result
+}
+
+// regNeedsUpdate checks if a registration record needs updating
+func regNeedsUpdate(existing *testRegRecord, newReg *testRegistration) bool {
+	return existing.CabinAssignment != newReg.CabinAssignment ||
+		existing.ShareCabinPreference != newReg.ShareCabinPreference ||
+		existing.SharedCabinWith != newReg.SharedCabinWith ||
+		existing.ArrivalETA != newReg.ArrivalETA ||
+		existing.SpecialOccasions != newReg.SpecialOccasions ||
+		existing.Goals != newReg.Goals ||
+		existing.Notes != newReg.Notes ||
+		existing.NeedsAccommodation != newReg.NeedsAccommodation ||
+		existing.OptOutVIP != newReg.OptOutVIP
+}
+
+// simulateUpsertRegistrations simulates the upsert logic for registrations
+func simulateUpsertRegistrations(
+	regs []*testRegistration,
+	existing map[string]*testRegRecord,
+	year int,
+) testUpsertStats {
+	stats := testUpsertStats{}
+
+	for _, r := range regs {
+		pbID := fmt.Sprintf("pb_household_%d", r.HouseholdCMID)
+		key := buildHouseholdCompositeKey(pbID, year)
+
+		if existingRecord, ok := existing[key]; ok {
+			if regNeedsUpdate(existingRecord, r) {
+				stats.Updated++
+			} else {
+				stats.Skipped++
+			}
+		} else {
+			stats.Created++
+		}
+	}
+
+	return stats
+}
+
+// buildExistingMedicalMap creates a map of existing medical records
+func buildExistingMedicalMap(medical []*testMedical, year int) map[string]*testMedRecord {
+	result := make(map[string]*testMedRecord)
+	for _, m := range medical {
+		pbID := fmt.Sprintf("pb_household_%d", m.HouseholdCMID)
+		key := buildHouseholdCompositeKey(pbID, year)
+		result[key] = &testMedRecord{
+			HouseholdPBID:    pbID,
+			Year:             year,
+			CPAPInfo:         m.CPAPInfo,
+			PhysicianInfo:    m.PhysicianInfo,
+			SpecialNeedsInfo: m.SpecialNeedsInfo,
+			AllergyInfo:      m.AllergyInfo,
+			DietaryInfo:      m.DietaryInfo,
+			AdditionalInfo:   m.AdditionalInfo,
+		}
+	}
+	return result
+}
+
+// medNeedsUpdate checks if a medical record needs updating
+func medNeedsUpdate(existing *testMedRecord, newMed *testMedical) bool {
+	return existing.CPAPInfo != newMed.CPAPInfo ||
+		existing.PhysicianInfo != newMed.PhysicianInfo ||
+		existing.SpecialNeedsInfo != newMed.SpecialNeedsInfo ||
+		existing.AllergyInfo != newMed.AllergyInfo ||
+		existing.DietaryInfo != newMed.DietaryInfo ||
+		existing.AdditionalInfo != newMed.AdditionalInfo
+}
+
+// simulateUpsertMedical simulates the upsert logic for medical
+func simulateUpsertMedical(medical []*testMedical, existing map[string]*testMedRecord, year int) testUpsertStats {
+	stats := testUpsertStats{}
+
+	for _, m := range medical {
+		pbID := fmt.Sprintf("pb_household_%d", m.HouseholdCMID)
+		key := buildHouseholdCompositeKey(pbID, year)
+
+		if existingRecord, ok := existing[key]; ok {
+			if medNeedsUpdate(existingRecord, m) {
+				stats.Updated++
+			} else {
+				stats.Skipped++
+			}
+		} else {
+			stats.Created++
+		}
+	}
+
+	return stats
+}
+
+// ============================================================================
+// Original test helpers (unchanged)
+// ============================================================================
 
 // extractRegistrationsFromHouseholds extracts registration info from household custom values
 func extractRegistrationsFromHouseholds(values []testHouseholdCustomValue) map[int]*testRegistration {

--- a/pocketbase/sync/financial_aid_applications.go
+++ b/pocketbase/sync/financial_aid_applications.go
@@ -37,6 +37,7 @@ type FinancialAidApplicationsSync struct {
 	App            core.App
 	Year           int  // Year to compute for (0 = current year from env)
 	DryRun         bool // Dry run mode (compute but don't write)
+	Debug          bool // Enable verbose debug logging
 	Stats          Stats
 	SyncSuccessful bool
 }
@@ -58,6 +59,18 @@ func (s *FinancialAidApplicationsSync) Name() string {
 // GetStats returns the current stats
 func (s *FinancialAidApplicationsSync) GetStats() Stats {
 	return s.Stats
+}
+
+// SetDebug enables or disables debug logging
+func (s *FinancialAidApplicationsSync) SetDebug(debug bool) {
+	s.Debug = debug
+}
+
+// DebugLog logs a message at INFO level only when Debug is enabled
+func (s *FinancialAidApplicationsSync) DebugLog(msg string, args ...any) {
+	if s.Debug {
+		slog.Info(msg, args...)
+	}
 }
 
 // faApplicationData holds extracted financial aid application information
@@ -793,6 +806,9 @@ func (s *FinancialAidApplicationsSync) upsertApplications(
 	}
 	slog.Info("Loaded existing applications", "count", len(existingMap))
 
+	// Fields to skip during idempotency comparison (always update these)
+	skipFields := map[string]bool{"year": true}
+
 	for _, app := range applications {
 		select {
 		case <-ctx.Done():
@@ -800,135 +816,158 @@ func (s *FinancialAidApplicationsSync) upsertApplications(
 		default:
 		}
 
+		// Convert application data to map
+		recordData := app.toRecordData(year)
+
 		// Check if record exists (keyed by person PB ID)
 		existingRecord := existingMap[app.personPBID]
 
-		var record *core.Record
-		isUpdate := false
 		if existingRecord != nil {
-			record = existingRecord
-			isUpdate = true
+			// Convert existing record to map for comparison
+			existingData := s.recordToMap(existingRecord)
+
+			// Check if update is needed
+			if s.recordNeedsUpdate(existingData, recordData, skipFields) {
+				// Update existing record
+				for field, value := range recordData {
+					existingRecord.Set(field, value)
+				}
+				if err := s.App.Save(existingRecord); err != nil {
+					slog.Error("Error updating application record",
+						"person", app.personPBID,
+						"error", err,
+					)
+					errors++
+					continue
+				}
+				updated++
+			} else {
+				s.Stats.Skipped++
+			}
 		} else {
-			record = core.NewRecord(col)
-		}
-
-		// Set all fields
-		record.Set("person", app.personPBID)
-		record.Set("household", app.householdPBID)
-		record.Set("person_id", app.personCMID)
-		record.Set("year", year)
-
-		// Interest indicators
-		record.Set("interest_expressed", app.interestExpressed)
-		record.Set("donation_preference", app.donationPreference)
-		record.Set("donation_other", app.donationOther)
-		record.Set("amount_awarded", app.amountAwarded)
-
-		// Contact Parent 1
-		record.Set("contact_first_name", app.contactFirstName)
-		record.Set("contact_last_name", app.contactLastName)
-		record.Set("contact_email", app.contactEmail)
-		record.Set("contact_phone", app.contactPhone)
-		record.Set("contact_address", app.contactAddress)
-		record.Set("contact_city", app.contactCity)
-		record.Set("contact_state", app.contactState)
-		record.Set("contact_zip", app.contactZip)
-		record.Set("contact_country", app.contactCountry)
-		record.Set("contact_marital_status", app.contactMaritalStatus)
-		record.Set("contact_jewish", app.contactJewish)
-
-		// Parent 2
-		record.Set("parent_2_name", app.parent2Name)
-		record.Set("parent_2_marital_status", app.parent2MaritalStatus)
-		record.Set("parent_2_jewish", app.parent2Jewish)
-
-		// Financial - Income
-		record.Set("total_gross_income", app.totalGrossIncome)
-		record.Set("expected_gross_income", app.expectedGrossIncome)
-		record.Set("total_adjusted_income", app.totalAdjustedIncome)
-		record.Set("total_exemptions", app.totalExemptions)
-		record.Set("unemployment", app.unemployment)
-		record.Set("still_unemployed", app.stillUnemployed)
-
-		// Financial - Assets
-		record.Set("non_retirement_savings", app.nonRetirementSavings)
-		record.Set("retirement_accounts", app.retirementAccounts)
-		record.Set("student_debt", app.studentDebt)
-		record.Set("owns_home", app.ownsHome)
-
-		// Financial - Expenses
-		record.Set("total_medical_expenses", app.totalMedicalExpenses)
-		record.Set("total_edu_expenses", app.totalEduExpenses)
-		record.Set("total_housing_expenses", app.totalHousingExpenses)
-		record.Set("total_rent", app.totalRent)
-
-		// Family Info
-		record.Set("num_children", app.numChildren)
-		record.Set("single_parent", app.singleParent)
-		record.Set("camper_name", app.camperName)
-		record.Set("special_circumstances", app.specialCircumstances)
-
-		// Jewish Affiliations
-		record.Set("affiliated_jcc", app.affiliatedJCC)
-		record.Set("child_affiliated_synagogue", app.childAffiliatedSynagogue)
-		record.Set("children_jewish_day_school", app.childrenJewishDaySchool)
-		record.Set("russian_speaking", app.russianSpeaking)
-
-		// Government/External Aid
-		record.Set("gov_subsidies", app.govSubsidies)
-		record.Set("gov_subsidies_detail", app.govSubsidiesDetail)
-		record.Set("synagogue_grant", app.synagogueGrant)
-		record.Set("one_happy_camper", app.oneHappyCamper)
-		record.Set("other_financial_support", app.otherFinancialSupport)
-		record.Set("other_support_amount", app.otherSupportAmount)
-		record.Set("other_support_expectations", app.otherSupportExpectations)
-		record.Set("financial_support", app.financialSupport)
-
-		// Program Requests
-		record.Set("summer_program", app.summerProgram)
-		record.Set("summer_amount_requested", app.summerAmountRequested)
-		record.Set("fc_program", app.fcProgram)
-		record.Set("fc_amount_requested", app.fcAmountRequested)
-		record.Set("tbm_program", app.tbmProgram)
-		record.Set("tbm_amount_requested", app.tbmAmountRequested)
-		record.Set("num_programs", app.numPrograms)
-		record.Set("num_sessions", app.numSessions)
-		record.Set("amount_requested", app.amountRequested)
-
-		// COVID/Disaster
-		record.Set("covid_childcare", app.covidChildcare)
-		record.Set("covid_childcare_amount", app.covidChildcareAmount)
-		record.Set("covid_expenses", app.covidExpenses)
-		record.Set("covid_expenses_additional", app.covidExpensesAdditional)
-		record.Set("covid_expenses_amount", app.covidExpensesAmount)
-		record.Set("fire", app.fire)
-		record.Set("fire_affected", app.fireAffected)
-		record.Set("fire_detail", app.fireDetail)
-
-		// Admin/Status
-		record.Set("deposit_paid", app.depositPaid)
-		record.Set("deposit_paid_adult", app.depositPaidAdult)
-		record.Set("applicant_signature", app.applicantSignature)
-		record.Set("income_confirmed", app.incomeConfirmed)
-		record.Set("amount_confirmed", app.amountConfirmed)
-
-		if err := s.App.Save(record); err != nil {
-			slog.Error("Error saving application record",
-				"person", app.personPBID,
-				"error", err,
-			)
-			errors++
-			continue
-		}
-
-		if isUpdate {
-			updated++
-		} else {
+			// Create new record
+			record := core.NewRecord(col)
+			for field, value := range recordData {
+				record.Set(field, value)
+			}
+			if err := s.App.Save(record); err != nil {
+				slog.Error("Error creating application record",
+					"person", app.personPBID,
+					"error", err,
+				)
+				errors++
+				continue
+			}
 			created++
 		}
 	}
 
 	return created, updated, errors
+}
+
+// recordToMap converts a PocketBase record to a map for comparison
+func (s *FinancialAidApplicationsSync) recordToMap(record *core.Record) map[string]interface{} {
+	return map[string]interface{}{
+		// Core identifiers
+		"person":    record.GetString("person"),
+		"household": record.GetString("household"),
+		"person_id": record.Get("person_id"),
+		"year":      record.Get("year"),
+
+		// Interest indicators
+		"interest_expressed":  record.GetBool("interest_expressed"),
+		"donation_preference": record.GetString("donation_preference"),
+		"donation_other":      record.GetString("donation_other"),
+		"amount_awarded":      record.Get("amount_awarded"),
+
+		// Contact Parent 1
+		"contact_first_name":     record.GetString("contact_first_name"),
+		"contact_last_name":      record.GetString("contact_last_name"),
+		"contact_email":          record.GetString("contact_email"),
+		"contact_phone":          record.GetString("contact_phone"),
+		"contact_address":        record.GetString("contact_address"),
+		"contact_city":           record.GetString("contact_city"),
+		"contact_state":          record.GetString("contact_state"),
+		"contact_zip":            record.GetString("contact_zip"),
+		"contact_country":        record.GetString("contact_country"),
+		"contact_marital_status": record.GetString("contact_marital_status"),
+		"contact_jewish":         record.GetString("contact_jewish"),
+
+		// Parent 2
+		"parent_2_name":           record.GetString("parent_2_name"),
+		"parent_2_marital_status": record.GetString("parent_2_marital_status"),
+		"parent_2_jewish":         record.GetString("parent_2_jewish"),
+
+		// Financial - Income
+		"total_gross_income":    record.Get("total_gross_income"),
+		"expected_gross_income": record.Get("expected_gross_income"),
+		"total_adjusted_income": record.Get("total_adjusted_income"),
+		"total_exemptions":      record.Get("total_exemptions"),
+		"unemployment":          record.GetBool("unemployment"),
+		"still_unemployed":      record.GetBool("still_unemployed"),
+
+		// Financial - Assets
+		"non_retirement_savings": record.Get("non_retirement_savings"),
+		"retirement_accounts":    record.Get("retirement_accounts"),
+		"student_debt":           record.Get("student_debt"),
+		"owns_home":              record.GetBool("owns_home"),
+
+		// Financial - Expenses
+		"total_medical_expenses": record.Get("total_medical_expenses"),
+		"total_edu_expenses":     record.Get("total_edu_expenses"),
+		"total_housing_expenses": record.Get("total_housing_expenses"),
+		"total_rent":             record.Get("total_rent"),
+
+		// Family Info
+		"num_children":          record.Get("num_children"),
+		"single_parent":         record.GetBool("single_parent"),
+		"camper_name":           record.GetString("camper_name"),
+		"special_circumstances": record.GetString("special_circumstances"),
+
+		// Jewish Affiliations
+		"affiliated_jcc":             record.GetBool("affiliated_jcc"),
+		"child_affiliated_synagogue": record.GetString("child_affiliated_synagogue"),
+		"children_jewish_day_school": record.GetString("children_jewish_day_school"),
+		"russian_speaking":           record.GetBool("russian_speaking"),
+
+		// Government/External Aid
+		"gov_subsidies":              record.GetBool("gov_subsidies"),
+		"gov_subsidies_detail":       record.GetString("gov_subsidies_detail"),
+		"synagogue_grant":            record.GetString("synagogue_grant"),
+		"one_happy_camper":           record.GetString("one_happy_camper"),
+		"other_financial_support":    record.GetString("other_financial_support"),
+		"other_support_amount":       record.Get("other_support_amount"),
+		"other_support_expectations": record.GetString("other_support_expectations"),
+		"financial_support":          record.GetString("financial_support"),
+
+		// Program Requests
+		"summer_program":          record.GetString("summer_program"),
+		"summer_amount_requested": record.Get("summer_amount_requested"),
+		"fc_program":              record.GetString("fc_program"),
+		"fc_amount_requested":     record.Get("fc_amount_requested"),
+		"tbm_program":             record.GetString("tbm_program"),
+		"tbm_amount_requested":    record.Get("tbm_amount_requested"),
+		"num_programs":            record.Get("num_programs"),
+		"num_sessions":            record.Get("num_sessions"),
+		"amount_requested":        record.Get("amount_requested"),
+
+		// COVID/Disaster
+		"covid_childcare":           record.GetBool("covid_childcare"),
+		"covid_childcare_amount":    record.Get("covid_childcare_amount"),
+		"covid_expenses":            record.GetString("covid_expenses"),
+		"covid_expenses_additional": record.GetString("covid_expenses_additional"),
+		"covid_expenses_amount":     record.Get("covid_expenses_amount"),
+		"fire":                      record.GetString("fire"),
+		"fire_affected":             record.GetBool("fire_affected"),
+		"fire_detail":               record.GetString("fire_detail"),
+
+		// Admin/Status
+		"deposit_paid":        record.Get("deposit_paid"),
+		"deposit_paid_adult":  record.Get("deposit_paid_adult"),
+		"applicant_signature": record.GetString("applicant_signature"),
+		"income_confirmed":    record.GetBool("income_confirmed"),
+		"amount_confirmed":    record.GetBool("amount_confirmed"),
+	}
 }
 
 // loadExistingApplications loads existing application records for the year
@@ -982,4 +1021,169 @@ func (s *FinancialAidApplicationsSync) forceWALCheckpoint() error {
 	}
 
 	return nil
+}
+
+// toRecordData converts faApplicationData to a map for database operations
+func (app *faApplicationData) toRecordData(year int) map[string]interface{} {
+	return map[string]interface{}{
+		// Core identifiers
+		"person":    app.personPBID,
+		"household": app.householdPBID,
+		"person_id": app.personCMID,
+		"year":      year,
+
+		// Interest indicators
+		"interest_expressed":  app.interestExpressed,
+		"donation_preference": app.donationPreference,
+		"donation_other":      app.donationOther,
+		"amount_awarded":      app.amountAwarded,
+
+		// Contact Parent 1
+		"contact_first_name":     app.contactFirstName,
+		"contact_last_name":      app.contactLastName,
+		"contact_email":          app.contactEmail,
+		"contact_phone":          app.contactPhone,
+		"contact_address":        app.contactAddress,
+		"contact_city":           app.contactCity,
+		"contact_state":          app.contactState,
+		"contact_zip":            app.contactZip,
+		"contact_country":        app.contactCountry,
+		"contact_marital_status": app.contactMaritalStatus,
+		"contact_jewish":         app.contactJewish,
+
+		// Parent 2
+		"parent_2_name":           app.parent2Name,
+		"parent_2_marital_status": app.parent2MaritalStatus,
+		"parent_2_jewish":         app.parent2Jewish,
+
+		// Financial - Income
+		"total_gross_income":    app.totalGrossIncome,
+		"expected_gross_income": app.expectedGrossIncome,
+		"total_adjusted_income": app.totalAdjustedIncome,
+		"total_exemptions":      app.totalExemptions,
+		"unemployment":          app.unemployment,
+		"still_unemployed":      app.stillUnemployed,
+
+		// Financial - Assets
+		"non_retirement_savings": app.nonRetirementSavings,
+		"retirement_accounts":    app.retirementAccounts,
+		"student_debt":           app.studentDebt,
+		"owns_home":              app.ownsHome,
+
+		// Financial - Expenses
+		"total_medical_expenses": app.totalMedicalExpenses,
+		"total_edu_expenses":     app.totalEduExpenses,
+		"total_housing_expenses": app.totalHousingExpenses,
+		"total_rent":             app.totalRent,
+
+		// Family Info
+		"num_children":          float64(app.numChildren),
+		"single_parent":         app.singleParent,
+		"camper_name":           app.camperName,
+		"special_circumstances": app.specialCircumstances,
+
+		// Jewish Affiliations
+		"affiliated_jcc":             app.affiliatedJCC,
+		"child_affiliated_synagogue": app.childAffiliatedSynagogue,
+		"children_jewish_day_school": app.childrenJewishDaySchool,
+		"russian_speaking":           app.russianSpeaking,
+
+		// Government/External Aid
+		"gov_subsidies":              app.govSubsidies,
+		"gov_subsidies_detail":       app.govSubsidiesDetail,
+		"synagogue_grant":            app.synagogueGrant,
+		"one_happy_camper":           app.oneHappyCamper,
+		"other_financial_support":    app.otherFinancialSupport,
+		"other_support_amount":       app.otherSupportAmount,
+		"other_support_expectations": app.otherSupportExpectations,
+		"financial_support":          app.financialSupport,
+
+		// Program Requests
+		"summer_program":          app.summerProgram,
+		"summer_amount_requested": app.summerAmountRequested,
+		"fc_program":              app.fcProgram,
+		"fc_amount_requested":     app.fcAmountRequested,
+		"tbm_program":             app.tbmProgram,
+		"tbm_amount_requested":    app.tbmAmountRequested,
+		"num_programs":            float64(app.numPrograms),
+		"num_sessions":            float64(app.numSessions),
+		"amount_requested":        app.amountRequested,
+
+		// COVID/Disaster
+		"covid_childcare":           app.covidChildcare,
+		"covid_childcare_amount":    app.covidChildcareAmount,
+		"covid_expenses":            app.covidExpenses,
+		"covid_expenses_additional": app.covidExpensesAdditional,
+		"covid_expenses_amount":     app.covidExpensesAmount,
+		"fire":                      app.fire,
+		"fire_affected":             app.fireAffected,
+		"fire_detail":               app.fireDetail,
+
+		// Admin/Status
+		"deposit_paid":        app.depositPaid,
+		"deposit_paid_adult":  app.depositPaidAdult,
+		"applicant_signature": app.applicantSignature,
+		"income_confirmed":    app.incomeConfirmed,
+		"amount_confirmed":    app.amountConfirmed,
+	}
+}
+
+// fieldEquals compares two field values for equality, handling type conversions
+func (s *FinancialAidApplicationsSync) fieldEquals(existing, newVal interface{}) bool {
+	// Handle nil vs empty string
+	if (existing == nil && newVal == "") || (existing == "" && newVal == nil) {
+		return true
+	}
+	// Handle nil vs 0
+	if existing == nil && newVal == 0 {
+		return true
+	}
+	if existing == nil && newVal == 0.0 {
+		return true
+	}
+	if existing == 0 && newVal == nil {
+		return true
+	}
+	if existing == 0.0 && newVal == nil {
+		return true
+	}
+	// Handle float64 vs int (PocketBase stores numbers as float64)
+	if existingFloat, ok := existing.(float64); ok {
+		if newInt, ok := newVal.(int); ok {
+			// Only equal if the float is exactly representable as the int
+			return existingFloat == float64(newInt)
+		}
+		if newFloat, ok := newVal.(float64); ok {
+			return existingFloat == newFloat
+		}
+	}
+	if existingInt, ok := existing.(int); ok {
+		if newFloat, ok := newVal.(float64); ok {
+			// Only equal if the float is exactly representable as the int
+			return float64(existingInt) == newFloat
+		}
+	}
+	// Handle bool
+	if existingBool, ok := existing.(bool); ok {
+		if newBool, ok := newVal.(bool); ok {
+			return existingBool == newBool
+		}
+	}
+	// Direct comparison
+	return existing == newVal
+}
+
+// recordNeedsUpdate checks if any field differs between existing record and new data
+func (s *FinancialAidApplicationsSync) recordNeedsUpdate(
+	existing map[string]interface{}, newData map[string]interface{}, skipFields map[string]bool,
+) bool {
+	for field, newValue := range newData {
+		if skipFields != nil && skipFields[field] {
+			continue
+		}
+		if !s.fieldEquals(existing[field], newValue) {
+			return true
+		}
+	}
+	return false
 }

--- a/pocketbase/sync/financial_aid_applications_test.go
+++ b/pocketbase/sync/financial_aid_applications_test.go
@@ -823,3 +823,254 @@ func isFANumberColumn(column string) bool {
 	}
 	return numberColumns[column]
 }
+
+// ============================================================================
+// Idempotency Tests
+// ============================================================================
+
+// TestFAFieldEquals tests field equality comparisons for idempotency checking
+func TestFAFieldEquals(t *testing.T) {
+	s := &FinancialAidApplicationsSync{}
+
+	tests := []struct {
+		name     string
+		existing interface{}
+		newVal   interface{}
+		expected bool
+	}{
+		// nil vs empty string equivalence
+		{"nil vs empty string", nil, "", true},
+		{"empty string vs nil", "", nil, true},
+
+		// nil vs zero equivalence
+		{"nil vs 0 int", nil, 0, true},
+		{"nil vs 0.0 float", nil, 0.0, true},
+
+		// float64 vs int comparison (PocketBase stores numbers as float64)
+		{"float64 100 vs int 100", float64(100), 100, true},
+		{"float64 100.5 vs int 100", float64(100.5), 100, false},
+		{"float64 vs float64 equal", float64(50000.50), float64(50000.50), true},
+		{"float64 vs float64 different", float64(50000.50), float64(50000.51), false},
+
+		// int vs float64 comparison
+		{"int 100 vs float64 100.0", 100, float64(100.0), true},
+		{"int 100 vs float64 100.5", 100, float64(100.5), false},
+
+		// bool comparisons
+		{"bool true vs true", true, true, true},
+		{"bool false vs false", false, false, true},
+		{"bool true vs false", true, false, false},
+
+		// string comparisons
+		{"equal strings", "test", "test", true},
+		{"different strings", "test", "other", false},
+		{"empty strings", "", "", true},
+
+		// Same type different values
+		{"different ints", 100, 200, false},
+		{"same ints", 100, 100, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := s.fieldEquals(tt.existing, tt.newVal)
+			if result != tt.expected {
+				t.Errorf("fieldEquals(%v, %v) = %v, want %v",
+					tt.existing, tt.newVal, result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestFARecordNeedsUpdate tests the record comparison logic for idempotency
+func TestFARecordNeedsUpdate(t *testing.T) {
+	s := &FinancialAidApplicationsSync{}
+
+	tests := []struct {
+		name       string
+		existing   map[string]interface{}
+		newData    map[string]interface{}
+		skipFields map[string]bool
+		expected   bool
+	}{
+		{
+			name: "no changes - should not need update",
+			existing: map[string]interface{}{
+				"contact_first_name": "John",
+				"contact_email":      "john@example.com",
+				"total_gross_income": float64(100000),
+				"interest_expressed": true,
+				"year":               float64(2025),
+			},
+			newData: map[string]interface{}{
+				"contact_first_name": "John",
+				"contact_email":      "john@example.com",
+				"total_gross_income": float64(100000),
+				"interest_expressed": true,
+				"year":               2025,
+			},
+			skipFields: map[string]bool{"year": true},
+			expected:   false,
+		},
+		{
+			name: "string field changed - should need update",
+			existing: map[string]interface{}{
+				"contact_first_name": "John",
+				"contact_email":      "john@example.com",
+			},
+			newData: map[string]interface{}{
+				"contact_first_name": "John",
+				"contact_email":      "john.new@example.com",
+			},
+			skipFields: nil,
+			expected:   true,
+		},
+		{
+			name: "number field changed - should need update",
+			existing: map[string]interface{}{
+				"total_gross_income": float64(100000),
+			},
+			newData: map[string]interface{}{
+				"total_gross_income": float64(120000),
+			},
+			skipFields: nil,
+			expected:   true,
+		},
+		{
+			name: "bool field changed - should need update",
+			existing: map[string]interface{}{
+				"interest_expressed": false,
+			},
+			newData: map[string]interface{}{
+				"interest_expressed": true,
+			},
+			skipFields: nil,
+			expected:   true,
+		},
+		{
+			name: "only skipped field changed - should not need update",
+			existing: map[string]interface{}{
+				"contact_first_name": "John",
+				"year":               float64(2024),
+			},
+			newData: map[string]interface{}{
+				"contact_first_name": "John",
+				"year":               2025,
+			},
+			skipFields: map[string]bool{"year": true},
+			expected:   false,
+		},
+		{
+			name: "nil vs empty string - should not need update",
+			existing: map[string]interface{}{
+				"contact_first_name": nil,
+			},
+			newData: map[string]interface{}{
+				"contact_first_name": "",
+			},
+			skipFields: nil,
+			expected:   false,
+		},
+		{
+			name: "float64 vs int same value - should not need update",
+			existing: map[string]interface{}{
+				"num_children": float64(3),
+			},
+			newData: map[string]interface{}{
+				"num_children": 3,
+			},
+			skipFields: nil,
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := s.recordNeedsUpdate(tt.existing, tt.newData, tt.skipFields)
+			if result != tt.expected {
+				t.Errorf("recordNeedsUpdate() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestFAApplicationToRecordData tests conversion of faApplicationData to map
+func TestFAApplicationToRecordData(t *testing.T) {
+	app := &faApplicationData{
+		personPBID:        "person123",
+		householdPBID:     "household456",
+		personCMID:        12345,
+		interestExpressed: true,
+		contactFirstName:  "John",
+		contactLastName:   "Doe",
+		contactEmail:      "john@example.com",
+		totalGrossIncome:  100000.50,
+		numChildren:       3,
+	}
+
+	data := app.toRecordData(2025)
+
+	// Verify key fields are present and correct
+	tests := []struct {
+		field    string
+		expected interface{}
+	}{
+		{"person", "person123"},
+		{"household", "household456"},
+		{"person_id", 12345},
+		{"year", 2025},
+		{"interest_expressed", true},
+		{"contact_first_name", "John"},
+		{"contact_last_name", "Doe"},
+		{"contact_email", "john@example.com"},
+		{"total_gross_income", 100000.50},
+		{"num_children", float64(3)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			if data[tt.field] != tt.expected {
+				t.Errorf("toRecordData()[%q] = %v, want %v", tt.field, data[tt.field], tt.expected)
+			}
+		})
+	}
+}
+
+// TestFAUpsertIdempotencyBehavior tests that unchanged records are skipped
+// This documents the expected behavior for the idempotency fix
+func TestFAUpsertIdempotencyBehavior(t *testing.T) {
+	// Document the expected behavior:
+	// 1. New records → Stats.Created++
+	// 2. Existing records with no changes → Stats.Skipped++
+	// 3. Existing records with changes → Stats.Updated++
+
+	// Test the helper methods that enable this behavior
+	s := &FinancialAidApplicationsSync{}
+
+	// Scenario 1: Record data matches existing - should skip
+	existingData := map[string]interface{}{
+		"contact_first_name": "John",
+		"contact_email":      "john@example.com",
+		"total_gross_income": float64(100000),
+	}
+	newDataSame := map[string]interface{}{
+		"contact_first_name": "John",
+		"contact_email":      "john@example.com",
+		"total_gross_income": float64(100000),
+	}
+
+	if s.recordNeedsUpdate(existingData, newDataSame, nil) {
+		t.Error("Expected no update needed for identical data")
+	}
+
+	// Scenario 2: Record data differs - should update
+	newDataDifferent := map[string]interface{}{
+		"contact_first_name": "John",
+		"contact_email":      "john.updated@example.com", // Changed
+		"total_gross_income": float64(100000),
+	}
+
+	if !s.recordNeedsUpdate(existingData, newDataDifferent, nil) {
+		t.Error("Expected update needed for different data")
+	}
+}

--- a/pocketbase/sync/household_custom_field_values.go
+++ b/pocketbase/sync/household_custom_field_values.go
@@ -21,7 +21,6 @@ const serviceNameHouseholdCustomValues = "household_custom_values"
 type HouseholdCustomFieldValuesSync struct {
 	BaseSyncService
 	Session     string                 // Session filter: "all", "1", "2", "2a", "3", "4", etc.
-	Debug       bool                   // Enable debug logging
 	rateLimiter *ratelimit.RateLimiter // Rate limiter for API calls
 }
 
@@ -30,7 +29,6 @@ func NewHouseholdCustomFieldValuesSync(app core.App, client *campminder.Client) 
 	return &HouseholdCustomFieldValuesSync{
 		BaseSyncService: NewBaseSyncService(app, client),
 		Session:         DefaultSession, // Default to all sessions
-		Debug:           false,
 		rateLimiter: ratelimit.NewRateLimiter(&ratelimit.Config{
 			APIDelay:          300 * time.Millisecond, // ~3 req/sec
 			BackoffMultiplier: 2.0,
@@ -48,11 +46,6 @@ func (s *HouseholdCustomFieldValuesSync) Name() string {
 // SetSession sets the session filter for this sync (e.g., "1", "2", "2a", "all")
 func (s *HouseholdCustomFieldValuesSync) SetSession(session string) {
 	s.Session = session
-}
-
-// SetDebug enables or disables debug logging
-func (s *HouseholdCustomFieldValuesSync) SetDebug(debug bool) {
-	s.Debug = debug
 }
 
 // Sync performs the household custom field values sync
@@ -201,9 +194,7 @@ func (s *HouseholdCustomFieldValuesSync) preloadHouseholdMapping(year int) (map[
 		}
 	}
 
-	if s.Debug {
-		slog.Debug("Preloaded household mapping", "count", len(mapping))
-	}
+	s.DebugLog("Preloaded household mapping", "count", len(mapping))
 
 	return mapping, nil
 }
@@ -223,9 +214,7 @@ func (s *HouseholdCustomFieldValuesSync) preloadFieldDefMapping() (map[int]strin
 		}
 	}
 
-	if s.Debug {
-		slog.Debug("Preloaded field definition mapping", "count", len(mapping))
-	}
+	s.DebugLog("Preloaded field definition mapping", "count", len(mapping))
 
 	return mapping, nil
 }
@@ -240,12 +229,10 @@ func (s *HouseholdCustomFieldValuesSync) getHouseholdIDsToSync(year int) ([]int,
 			return nil, err
 		}
 
-		if s.Debug {
-			slog.Debug("Resolved session to household IDs",
-				"session", s.Session,
-				"count", len(householdIDs),
-				"year", year)
-		}
+		s.DebugLog("Resolved session to household IDs",
+			"session", s.Session,
+			"count", len(householdIDs),
+			"year", year)
 
 		return householdIDs, nil
 	}
@@ -264,11 +251,9 @@ func (s *HouseholdCustomFieldValuesSync) getHouseholdIDsToSync(year int) ([]int,
 		}
 	}
 
-	if s.Debug {
-		slog.Debug("Getting all households for year",
-			"count", len(householdIDs),
-			"year", year)
-	}
+	s.DebugLog("Getting all households for year",
+		"count", len(householdIDs),
+		"year", year)
 
 	return householdIDs, nil
 }
@@ -320,11 +305,9 @@ func (s *HouseholdCustomFieldValuesSync) syncHouseholdCustomFieldValues(
 			fieldDefPBId, found := fieldDefMapping[fieldCMID]
 			if !found {
 				// Field definition not synced, skip
-				if s.Debug {
-					slog.Debug("Field definition not found, skipping",
-						"field_cm_id", fieldCMID,
-						"household_cm_id", householdCMID)
-				}
+				s.DebugLog("Field definition not found, skipping",
+					"field_cm_id", fieldCMID,
+					"household_cm_id", householdCMID)
 				continue
 			}
 

--- a/pocketbase/sync/household_demographics.go
+++ b/pocketbase/sync/household_demographics.go
@@ -29,6 +29,7 @@ type HouseholdDemographicsSync struct {
 	App            core.App
 	Year           int  // Year to compute for (0 = current year from env)
 	DryRun         bool // Dry run mode (compute but don't write)
+	Debug          bool // Enable verbose debug logging
 	Stats          Stats
 	SyncSuccessful bool
 }
@@ -50,6 +51,61 @@ func (s *HouseholdDemographicsSync) Name() string {
 // GetStats returns the current stats
 func (s *HouseholdDemographicsSync) GetStats() Stats {
 	return s.Stats
+}
+
+// SetDebug enables or disables debug logging
+func (s *HouseholdDemographicsSync) SetDebug(debug bool) {
+	s.Debug = debug
+}
+
+// DebugLog logs a message at INFO level only when Debug is enabled
+func (s *HouseholdDemographicsSync) DebugLog(msg string, args ...any) {
+	if s.Debug {
+		slog.Info("[DEBUG] "+msg, args...)
+	}
+}
+
+// fieldEquals compares two field values for equality, handling type conversions.
+// This mirrors the centralized BaseSyncService.FieldEquals logic.
+func (s *HouseholdDemographicsSync) fieldEquals(existing, newVal any) bool {
+	// Handle nil vs empty string
+	if (existing == nil && newVal == "") || (existing == "" && newVal == nil) {
+		return true
+	}
+	// Handle nil vs false (for boolean fields)
+	if existing == nil && newVal == false {
+		return true
+	}
+	if existing == false && newVal == nil {
+		return true
+	}
+	// Handle nil vs 0
+	if existing == nil && newVal == 0 {
+		return true
+	}
+	if existing == 0 && newVal == nil {
+		return true
+	}
+	// Handle float64 vs int (JSON unmarshals numbers as float64)
+	if existFloat, ok := existing.(float64); ok {
+		if newInt, ok := newVal.(int); ok {
+			return int(existFloat) == newInt
+		}
+	}
+	if existInt, ok := existing.(int); ok {
+		if newFloat, ok := newVal.(float64); ok {
+			return existInt == int(newFloat)
+		}
+	}
+	// Handle bool comparison
+	if existBool, ok := existing.(bool); ok {
+		if newBool, ok := newVal.(bool); ok {
+			return existBool == newBool
+		}
+	}
+
+	// String comparison as fallback
+	return fmt.Sprintf("%v", existing) == fmt.Sprintf("%v", newVal)
 }
 
 // householdDemographicsRecord holds the computed demographics for a household
@@ -174,9 +230,10 @@ func (s *HouseholdDemographicsSync) Sync(ctx context.Context) error {
 	slog.Info("Loaded existing records", "count", len(existingRecords))
 
 	// Step 7: Upsert records
-	created, updated, errors := s.upsertRecords(ctx, records, existingRecords, year)
+	created, updated, skipped, errors := s.upsertRecords(ctx, records, existingRecords, year)
 	s.Stats.Created = created
 	s.Stats.Updated = updated
+	s.Stats.Skipped = skipped
 	s.Stats.Errors = errors
 
 	// Step 8: Delete orphans (records in DB but not in computed set)
@@ -666,22 +723,50 @@ func (s *HouseholdDemographicsSync) upsertRecords(
 	records map[string]*householdDemographicsRecord,
 	existingRecords map[string]string,
 	year int,
-) (created, updated, errors int) {
+) (created, updated, skipped, errors int) {
 	col, err := s.App.FindCollectionByNameOrId("household_demographics")
 	if err != nil {
 		slog.Error("Error finding household_demographics collection", "error", err)
-		return 0, 0, len(records)
+		return 0, 0, 0, len(records)
 	}
 
 	for _, rec := range records {
 		select {
 		case <-ctx.Done():
-			return created, updated, errors
+			return created, updated, skipped, errors
 		default:
 		}
 
 		key := MakeCompositeKey(rec.householdPBID, year)
 		existingID, exists := existingRecords[key]
+
+		// Build data map for comparison and setting
+		data := map[string]any{
+			"household":                  rec.householdPBID,
+			"year":                       rec.year,
+			"family_description":         rec.familyDescription,
+			"family_description_other":   rec.familyDescriptionOther,
+			"jewish_affiliation":         rec.jewishAffiliation,
+			"jewish_affiliation_other":   rec.jewishAffiliationOther,
+			"jewish_identities":          rec.jewishIdentities,
+			"congregation_summer":        rec.congregationSummer,
+			"congregation_family":        rec.congregationFamily,
+			"jcc_summer":                 rec.jccSummer,
+			"jcc_family":                 rec.jccFamily,
+			"military_family":            rec.militaryFamily,
+			"parent_immigrant":           rec.parentImmigrant,
+			"parent_immigrant_origin":    rec.parentImmigrantOrigin,
+			"custody_summer":             rec.custodySummer,
+			"custody_family":             rec.custodyFamily,
+			"has_custody_considerations": rec.hasCustodyConsiderations,
+			"away_during_camp":           rec.awayDuringCamp,
+			"away_location":              rec.awayLocation,
+			"away_phone":                 rec.awayPhone,
+			"away_from_date":             rec.awayFromDate,
+			"away_return_date":           rec.awayReturnDate,
+			"form_filler":                rec.formFiller,
+			"board_member":               rec.boardMember,
+		}
 
 		var record *core.Record
 		if exists {
@@ -692,36 +777,33 @@ func (s *HouseholdDemographicsSync) upsertRecords(
 				errors++
 				continue
 			}
+
+			// Check if update is needed
+			needsUpdate := false
+			skipFields := map[string]bool{"id": true, "created": true, "updated": true, "household": true, "year": true}
+			for field, newValue := range data {
+				if skipFields[field] {
+					continue
+				}
+				if !s.fieldEquals(record.Get(field), newValue) {
+					needsUpdate = true
+					break
+				}
+			}
+
+			if !needsUpdate {
+				skipped++
+				continue
+			}
 		} else {
 			// Create new record
 			record = core.NewRecord(col)
 		}
 
 		// Set all fields
-		record.Set("household", rec.householdPBID)
-		record.Set("year", rec.year)
-		record.Set("family_description", rec.familyDescription)
-		record.Set("family_description_other", rec.familyDescriptionOther)
-		record.Set("jewish_affiliation", rec.jewishAffiliation)
-		record.Set("jewish_affiliation_other", rec.jewishAffiliationOther)
-		record.Set("jewish_identities", rec.jewishIdentities)
-		record.Set("congregation_summer", rec.congregationSummer)
-		record.Set("congregation_family", rec.congregationFamily)
-		record.Set("jcc_summer", rec.jccSummer)
-		record.Set("jcc_family", rec.jccFamily)
-		record.Set("military_family", rec.militaryFamily)
-		record.Set("parent_immigrant", rec.parentImmigrant)
-		record.Set("parent_immigrant_origin", rec.parentImmigrantOrigin)
-		record.Set("custody_summer", rec.custodySummer)
-		record.Set("custody_family", rec.custodyFamily)
-		record.Set("has_custody_considerations", rec.hasCustodyConsiderations)
-		record.Set("away_during_camp", rec.awayDuringCamp)
-		record.Set("away_location", rec.awayLocation)
-		record.Set("away_phone", rec.awayPhone)
-		record.Set("away_from_date", rec.awayFromDate)
-		record.Set("away_return_date", rec.awayReturnDate)
-		record.Set("form_filler", rec.formFiller)
-		record.Set("board_member", rec.boardMember)
+		for field, value := range data {
+			record.Set(field, value)
+		}
 
 		if err := s.App.Save(record); err != nil {
 			slog.Error("Error saving household_demographics record",
@@ -740,7 +822,7 @@ func (s *HouseholdDemographicsSync) upsertRecords(
 		}
 	}
 
-	return created, updated, errors
+	return created, updated, skipped, errors
 }
 
 // deleteOrphans removes records that exist in DB but not in computed set

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -132,6 +132,11 @@ type Service interface {
 	GetStats() Stats
 }
 
+// Debuggable is an optional interface for services that support debug logging
+type Debuggable interface {
+	SetDebug(debug bool)
+}
+
 // Status represents the status of a sync operation
 type Status struct {
 	Type      string     `json:"type"`
@@ -317,6 +322,19 @@ func (o *Orchestrator) IsCustomValuesSyncRunning() bool {
 	o.mu.RLock()
 	defer o.mu.RUnlock()
 	return o.customValuesSyncRunning
+}
+
+// IsAnyJobRunning returns true if any sync job is currently running.
+// This is used to queue individual sync requests when another job is already active.
+func (o *Orchestrator) IsAnyJobRunning() bool {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	for _, status := range o.runningJobs {
+		if status.Status == statusRunning {
+			return true
+		}
+	}
+	return false
 }
 
 // GetWeeklySyncJobs returns the list of services that run in the weekly sync.
@@ -1084,6 +1102,27 @@ func (o *Orchestrator) RunSyncWithOptions(ctx context.Context, opts Options) err
 		// Run concurrently (for future implementation)
 		// For now, fall back to sequential
 		slog.Info("Concurrent sync not yet implemented, running sequentially")
+	}
+
+	// Apply debug flag to all services if enabled
+	if opts.Debug {
+		for _, serviceName := range servicesToRun {
+			if svc := o.GetService(serviceName); svc != nil {
+				if debuggable, ok := svc.(Debuggable); ok {
+					debuggable.SetDebug(true)
+				}
+			}
+		}
+		// Reset debug flag after sync completes
+		defer func() {
+			for _, serviceName := range servicesToRun {
+				if svc := o.GetService(serviceName); svc != nil {
+					if debuggable, ok := svc.(Debuggable); ok {
+						debuggable.SetDebug(false)
+					}
+				}
+			}
+		}()
 	}
 
 	// Run sequentially - custom values syncs run in order to prevent context deadline issues

--- a/pocketbase/sync/orchestrator_test.go
+++ b/pocketbase/sync/orchestrator_test.go
@@ -170,6 +170,60 @@ func TestGetStatus(t *testing.T) {
 	}
 }
 
+// TestIsAnyJobRunning tests checking if any sync job is currently running
+func TestIsAnyJobRunning(t *testing.T) {
+	t.Run("returns false when no jobs", func(t *testing.T) {
+		o := NewOrchestrator(nil)
+		if o.IsAnyJobRunning() {
+			t.Error("expected false when runningJobs is empty")
+		}
+	})
+
+	t.Run("returns true when job is running", func(t *testing.T) {
+		o := NewOrchestrator(nil)
+		o.mu.Lock()
+		o.runningJobs["test_job"] = &Status{Status: statusRunning}
+		o.mu.Unlock()
+		if !o.IsAnyJobRunning() {
+			t.Error("expected true when a job has statusRunning")
+		}
+	})
+
+	t.Run("returns false when job is completed", func(t *testing.T) {
+		o := NewOrchestrator(nil)
+		o.mu.Lock()
+		o.runningJobs["test_job"] = &Status{Status: statusCompleted}
+		o.mu.Unlock()
+		if o.IsAnyJobRunning() {
+			t.Error("expected false when job is completed, not running")
+		}
+	})
+
+	t.Run("returns true if any one of multiple jobs is running", func(t *testing.T) {
+		o := NewOrchestrator(nil)
+		o.mu.Lock()
+		o.runningJobs["job1"] = &Status{Status: statusCompleted}
+		o.runningJobs["job2"] = &Status{Status: statusRunning}
+		o.runningJobs["job3"] = &Status{Status: statusFailed}
+		o.mu.Unlock()
+		if !o.IsAnyJobRunning() {
+			t.Error("expected true when at least one job is running")
+		}
+	})
+
+	t.Run("returns false when all jobs are completed or failed", func(t *testing.T) {
+		o := NewOrchestrator(nil)
+		o.mu.Lock()
+		o.runningJobs["job1"] = &Status{Status: statusCompleted}
+		o.runningJobs["job2"] = &Status{Status: statusFailed}
+		o.runningJobs["job3"] = &Status{Status: statusCompleted}
+		o.mu.Unlock()
+		if o.IsAnyJobRunning() {
+			t.Error("expected false when no job has statusRunning")
+		}
+	})
+}
+
 // TestGetRunningJobs tests getting list of running jobs
 func TestGetRunningJobs(t *testing.T) {
 	o := NewOrchestrator(nil)

--- a/pocketbase/sync/person_custom_field_values.go
+++ b/pocketbase/sync/person_custom_field_values.go
@@ -21,7 +21,6 @@ const serviceNamePersonCustomValues = "person_custom_values"
 type PersonCustomFieldValuesSync struct {
 	BaseSyncService
 	Session     string                 // Session filter: "all", "1", "2", "2a", "3", "4", etc.
-	Debug       bool                   // Enable debug logging
 	rateLimiter *ratelimit.RateLimiter // Rate limiter for API calls
 }
 
@@ -30,7 +29,6 @@ func NewPersonCustomFieldValuesSync(app core.App, client *campminder.Client) *Pe
 	return &PersonCustomFieldValuesSync{
 		BaseSyncService: NewBaseSyncService(app, client),
 		Session:         DefaultSession, // Default to all sessions
-		Debug:           false,
 		rateLimiter: ratelimit.NewRateLimiter(&ratelimit.Config{
 			APIDelay:          300 * time.Millisecond, // ~3 req/sec
 			BackoffMultiplier: 2.0,
@@ -48,11 +46,6 @@ func (s *PersonCustomFieldValuesSync) Name() string {
 // SetSession sets the session filter for this sync (e.g., "1", "2", "2a", "all")
 func (s *PersonCustomFieldValuesSync) SetSession(session string) {
 	s.Session = session
-}
-
-// SetDebug enables or disables debug logging
-func (s *PersonCustomFieldValuesSync) SetDebug(debug bool) {
-	s.Debug = debug
 }
 
 // Sync performs the person custom field values sync
@@ -201,9 +194,7 @@ func (s *PersonCustomFieldValuesSync) preloadPersonMapping(year int) (map[int]st
 		}
 	}
 
-	if s.Debug {
-		slog.Debug("Preloaded person mapping", "count", len(mapping))
-	}
+	s.DebugLog("Preloaded person mapping", "count", len(mapping))
 
 	return mapping, nil
 }
@@ -223,9 +214,7 @@ func (s *PersonCustomFieldValuesSync) preloadFieldDefMapping() (map[int]string, 
 		}
 	}
 
-	if s.Debug {
-		slog.Debug("Preloaded field definition mapping", "count", len(mapping))
-	}
+	s.DebugLog("Preloaded field definition mapping", "count", len(mapping))
 
 	return mapping, nil
 }
@@ -240,12 +229,10 @@ func (s *PersonCustomFieldValuesSync) getPersonIDsToSync(year int) ([]int, error
 			return nil, err
 		}
 
-		if s.Debug {
-			slog.Debug("Resolved session to person IDs",
-				"session", s.Session,
-				"count", len(personIDs),
-				"year", year)
-		}
+		s.DebugLog("Resolved session to person IDs",
+			"session", s.Session,
+			"count", len(personIDs),
+			"year", year)
 
 		return personIDs, nil
 	}
@@ -264,11 +251,9 @@ func (s *PersonCustomFieldValuesSync) getPersonIDsToSync(year int) ([]int, error
 		}
 	}
 
-	if s.Debug {
-		slog.Debug("Getting all persons for year",
-			"count", len(personIDs),
-			"year", year)
-	}
+	s.DebugLog("Getting all persons for year",
+		"count", len(personIDs),
+		"year", year)
 
 	return personIDs, nil
 }
@@ -321,11 +306,9 @@ func (s *PersonCustomFieldValuesSync) syncPersonCustomFieldValues(
 			fieldDefPBId, found := fieldDefMapping[fieldCMID]
 			if !found {
 				// Field definition not synced, skip
-				if s.Debug {
-					slog.Debug("Field definition not found, skipping",
-						"field_cm_id", fieldCMID,
-						"person_cm_id", personCMID)
-				}
+				s.DebugLog("Field definition not found, skipping",
+					"field_cm_id", fieldCMID,
+					"person_cm_id", personCMID)
 				continue
 			}
 

--- a/pocketbase/sync/quest_registrations.go
+++ b/pocketbase/sync/quest_registrations.go
@@ -41,6 +41,7 @@ type QuestRegistrationsSync struct {
 	App            core.App
 	Year           int
 	DryRun         bool
+	Debug          bool
 	Stats          Stats
 	SyncSuccessful bool
 }
@@ -62,6 +63,18 @@ func (s *QuestRegistrationsSync) Name() string {
 // GetStats returns the current stats
 func (s *QuestRegistrationsSync) GetStats() Stats {
 	return s.Stats
+}
+
+// SetDebug enables or disables debug logging
+func (s *QuestRegistrationsSync) SetDebug(debug bool) {
+	s.Debug = debug
+}
+
+// DebugLog logs a message at INFO level only when Debug is enabled
+func (s *QuestRegistrationsSync) DebugLog(msg string, args ...any) {
+	if s.Debug {
+		slog.Info(msg, args...)
+	}
 }
 
 // questRegistrationRecord holds the extracted Quest info for a participant
@@ -309,6 +322,9 @@ func (s *QuestRegistrationsSync) loadPersonCustomValues(
 ) (map[string]*questRegistrationRecord, error) {
 	var entries []questValueEntry
 
+	// Cache for person PB ID -> CM ID lookups
+	personCache := make(map[string]int)
+
 	filter := fmt.Sprintf("year = %d", year)
 	page := 1
 	perPage := 500
@@ -332,7 +348,27 @@ func (s *QuestRegistrationsSync) loadPersonCustomValues(
 				continue
 			}
 
-			personID := record.GetInt("person_id")
+			// person_custom_values has "person" relation field (PB ID), not "person_id"
+			personPBID := record.GetString("person")
+			if personPBID == "" {
+				continue
+			}
+
+			// Look up CM ID from cache or persons table
+			personID := 0
+			if cached, ok := personCache[personPBID]; ok {
+				personID = cached
+			} else {
+				personFilter := fmt.Sprintf("id = '%s'", personPBID)
+				persons, err := s.App.FindRecordsByFilter("persons", personFilter, "", 1, 0)
+				if err == nil && len(persons) > 0 {
+					if cmID, ok := persons[0].Get("cm_id").(float64); ok {
+						personID = int(cmID)
+						personCache[personPBID] = personID
+					}
+				}
+			}
+
 			value := record.GetString("value")
 
 			if personID > 0 && value != "" {

--- a/pocketbase/sync/staff_applications.go
+++ b/pocketbase/sync/staff_applications.go
@@ -26,6 +26,7 @@ type StaffApplicationsSync struct {
 	App            core.App
 	Year           int
 	DryRun         bool
+	Debug          bool
 	Stats          Stats
 	SyncSuccessful bool
 }
@@ -47,6 +48,18 @@ func (s *StaffApplicationsSync) Name() string {
 // GetStats returns the current stats
 func (s *StaffApplicationsSync) GetStats() Stats {
 	return s.Stats
+}
+
+// SetDebug enables or disables debug logging
+func (s *StaffApplicationsSync) SetDebug(debug bool) {
+	s.Debug = debug
+}
+
+// DebugLog logs a message at INFO level only when Debug is enabled
+func (s *StaffApplicationsSync) DebugLog(msg string, args ...any) {
+	if s.Debug {
+		slog.Info(msg, args...)
+	}
 }
 
 // staffApplicationRecord holds the extracted application info for a staff member
@@ -290,6 +303,9 @@ func (s *StaffApplicationsSync) loadPersonCustomValues(
 ) (map[string]*staffApplicationRecord, error) {
 	var entries []appValueEntry
 
+	// Cache for person PB ID -> CM ID lookups
+	personCache := make(map[string]int)
+
 	filter := fmt.Sprintf("year = %d", year)
 	page := 1
 	perPage := 500
@@ -313,7 +329,27 @@ func (s *StaffApplicationsSync) loadPersonCustomValues(
 				continue
 			}
 
-			personID := record.GetInt("person_id")
+			// person_custom_values has "person" relation field (PB ID), not "person_id"
+			personPBID := record.GetString("person")
+			if personPBID == "" {
+				continue
+			}
+
+			// Look up CM ID from cache or persons table
+			personID := 0
+			if cached, ok := personCache[personPBID]; ok {
+				personID = cached
+			} else {
+				personFilter := fmt.Sprintf("id = '%s'", personPBID)
+				persons, err := s.App.FindRecordsByFilter("persons", personFilter, "", 1, 0)
+				if err == nil && len(persons) > 0 {
+					if cmID, ok := persons[0].Get("cm_id").(float64); ok {
+						personID = int(cmID)
+						personCache[personPBID] = personID
+					}
+				}
+			}
+
 			value := record.GetString("value")
 
 			if personID > 0 && value != "" {

--- a/pocketbase/sync/staff_skills.go
+++ b/pocketbase/sync/staff_skills.go
@@ -28,6 +28,7 @@ type StaffSkillsSync struct {
 	App            core.App
 	Year           int
 	DryRun         bool
+	Debug          bool
 	Stats          Stats
 	SyncSuccessful bool
 	ProcessedKeys  map[string]bool
@@ -51,6 +52,18 @@ func (s *StaffSkillsSync) Name() string {
 // GetStats returns the current stats
 func (s *StaffSkillsSync) GetStats() Stats {
 	return s.Stats
+}
+
+// SetDebug enables or disables debug logging
+func (s *StaffSkillsSync) SetDebug(debug bool) {
+	s.Debug = debug
+}
+
+// DebugLog logs a message at INFO level only when Debug is enabled
+func (s *StaffSkillsSync) DebugLog(msg string, args ...any) {
+	if s.Debug {
+		slog.Info(msg, args...)
+	}
 }
 
 // skillDefinition holds a skill field definition
@@ -97,6 +110,7 @@ func (s *StaffSkillsSync) Sync(ctx context.Context) error {
 	slog.Info("Starting staff skills extraction",
 		"year", year,
 		"dry_run", s.DryRun,
+		"debug", s.Debug,
 	)
 
 	// Step 1: Load Skills- field definitions with Staff partition
@@ -319,6 +333,7 @@ func (s *StaffSkillsSync) loadSkillDefinitions(_ context.Context) ([]skillDefini
 			name:  name,
 			skill: skillName,
 		})
+		s.DebugLog("Found staff skill definition", "name", name, "skill", skillName, "cm_id", cmID)
 	}
 
 	return result, nil

--- a/pocketbase/sync/staff_vehicle_info.go
+++ b/pocketbase/sync/staff_vehicle_info.go
@@ -31,6 +31,7 @@ type StaffVehicleInfoSync struct {
 	App            core.App
 	Year           int
 	DryRun         bool
+	Debug          bool
 	Stats          Stats
 	SyncSuccessful bool
 }
@@ -52,6 +53,18 @@ func (s *StaffVehicleInfoSync) Name() string {
 // GetStats returns the current stats
 func (s *StaffVehicleInfoSync) GetStats() Stats {
 	return s.Stats
+}
+
+// SetDebug enables or disables debug logging
+func (s *StaffVehicleInfoSync) SetDebug(debug bool) {
+	s.Debug = debug
+}
+
+// DebugLog logs a message at INFO level only when Debug is enabled
+func (s *StaffVehicleInfoSync) DebugLog(msg string, args ...any) {
+	if s.Debug {
+		slog.Info(msg, args...)
+	}
 }
 
 // staffVehicleInfoRecord holds the extracted vehicle info for a staff member
@@ -242,6 +255,9 @@ func (s *StaffVehicleInfoSync) loadPersonCustomValues(
 ) (map[string]*staffVehicleInfoRecord, error) {
 	var entries []sviValueEntry
 
+	// Cache for person PB ID -> CM ID lookups
+	personCache := make(map[string]int)
+
 	filter := fmt.Sprintf("year = %d", year)
 	page := 1
 	perPage := 500
@@ -265,7 +281,27 @@ func (s *StaffVehicleInfoSync) loadPersonCustomValues(
 				continue
 			}
 
-			personID := record.GetInt("person_id")
+			// person_custom_values has "person" relation field (PB ID), not "person_id"
+			personPBID := record.GetString("person")
+			if personPBID == "" {
+				continue
+			}
+
+			// Look up CM ID from cache or persons table
+			personID := 0
+			if cached, ok := personCache[personPBID]; ok {
+				personID = cached
+			} else {
+				personFilter := fmt.Sprintf("id = '%s'", personPBID)
+				persons, err := s.App.FindRecordsByFilter("persons", personFilter, "", 1, 0)
+				if err == nil && len(persons) > 0 {
+					if cmID, ok := persons[0].Get("cm_id").(float64); ok {
+						personID = int(cmID)
+						personCache[personPBID] = personID
+					}
+				}
+			}
+
 			value := record.GetString("value")
 
 			if personID > 0 && value != "" {


### PR DESCRIPTION
## Summary
- Consolidates all sync fixes from PRs #181-#188 that were merged locally during GitHub Actions downtime
- Merges with dependabot updates from PRs #175, #176, #189
- Includes ESLint fix from PR #190

## Included Changes

### Sync Fixes (PRs 181-188)
- **#181**: Queue individual syncs behind any running job (IsAnyJobRunning fix)
- **#182**: Make family_camp_derived idempotent
- **#183**: Add idempotency to financial aid applications sync
- **#184**: DRY debug logging via BaseSyncService
- **#185**: Resolve zero-record syncs by reading person relation correctly
- **#186**: Debug propagation, dietary idempotency, phone field size
- **#187**: Enable debug flag for transform services
- **#188**: Final debug/idempotency fixes

### Frontend Fix (PR 190)
- **#190**: Update eslint-plugin-react-refresh to Vite preset (fixes ErrorBoundary export warning)

### Dependabot Updates (merged from origin/main)
- **#175**: Bump @types/react
- **#176**: Bump build-tools
- **#189**: Bump pip dependencies

## Context
These changes were merged locally because GitHub Actions was unavailable. The stacked PRs (181-188) have been closed as their commits are included here.

## Test plan
- [ ] CI passes
- [ ] Sync operations work correctly
- [ ] ESLint warnings reduced (ErrorBoundary export warning gone)