### PR TITLE
fix(sync): check all sync flags in handleUnifiedSync to prevent race conditions

### DIFF
--- a/pocketbase/sync/api.go
+++ b/pocketbase/sync/api.go
@@ -907,8 +907,11 @@ func handleUnifiedSync(e *core.RequestEvent, scheduler *Scheduler) error {
 	}
 
 	// Get orchestrator and check if any sync is already running
+	// Check all sync flags to prevent race conditions (e.g., when global sync triggers first)
 	orchestrator := scheduler.GetOrchestrator()
-	if orchestrator.IsDailySyncRunning() || orchestrator.IsHistoricalSyncRunning() {
+	if orchestrator.IsDailySyncRunning() || orchestrator.IsWeeklySyncRunning() ||
+		orchestrator.IsHistoricalSyncRunning() || orchestrator.IsCustomValuesSyncRunning() ||
+		orchestrator.IsAnyJobRunning() {
 		// Sync is running - try to enqueue
 		qs, err := orchestrator.EnqueueUnifiedSync(year, service, includeCustomValues, debug, requestedBy)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Fixed race condition where global sync jobs didn't properly block the queue
- `handleUnifiedSync` now checks all 5 sync flags (matching `handleIndividualSync`)

## Problem
When triggering syncs on a fresh database:
1. Current year sync detects empty global tables → calls `RunWeeklySync()`
2. While globals are running, user triggers historical sync
3. Historical sync starts **simultaneously** instead of queueing

Root cause: `handleUnifiedSync` only checked `IsDailySyncRunning` and `IsHistoricalSyncRunning`, missing `IsWeeklySyncRunning`, `IsCustomValuesSyncRunning`, and `IsAnyJobRunning`.

## Test plan
- [x] `go build .` passes
- [x] `go test ./sync/...` passes
- [ ] CI passes