### PR TITLE
fix(sync): propagate year to services in handleRunPhase

### DIFF
--- a/pocketbase/sync/api.go
+++ b/pocketbase/sync/api.go
@@ -2233,16 +2233,21 @@ func handleRunPhase(e *core.RequestEvent, scheduler *Scheduler) error {
 			default:
 			}
 
-			// Set debug on the service if requested
-			if debug {
-				if svc := orchestrator.GetService(jobID); svc != nil {
+			// Set year and debug on the service before running
+			if svc := orchestrator.GetService(jobID); svc != nil {
+				// Set year so service queries correct year's data
+				if yearSetter, ok := svc.(YearSetter); ok {
+					yearSetter.SetYear(year)
+				}
+				// Set debug if requested
+				if debug {
 					if debuggable, ok := svc.(Debuggable); ok {
 						debuggable.SetDebug(true)
 					}
 				}
 			}
 
-			slog.Info("Running phase job", "phase", phase, "job", jobID)
+			slog.Info("Running phase job", "phase", phase, "job", jobID, "year", year)
 			if err := orchestrator.runSyncAndWait(ctx, jobID); err != nil {
 				slog.Error("Phase job failed", "phase", phase, "job", jobID, "error", err)
 				// Continue with next job even if one fails

--- a/pocketbase/sync/api_test.go
+++ b/pocketbase/sync/api_test.go
@@ -1751,3 +1751,33 @@ func TestRunPhaseYearNotSetBugExplanation(t *testing.T) {
 	t.Log("Bug: handleRunPhase parses year parameter but never sets currentSyncYear")
 	t.Log("Fix: Set currentSyncYear inside goroutine before job loop, reset in defer")
 }
+
+// TestRunPhaseYearMustPropagateToServices tests that handleRunPhase must set
+// the year on each service instance, not just on orchestrator.currentSyncYear.
+// BUG: currentSyncYear only affects status.Year, NOT what year the services query.
+// Services read their own .Year field which defaults to env var CAMPMINDER_SEASON_ID.
+func TestRunPhaseYearMustPropagateToServices(t *testing.T) {
+	// This test demonstrates that YearSetter interface is needed.
+	// Services have .Year field that controls which year's data they query.
+	// Setting orchestrator.currentSyncYear does NOT set service.Year.
+
+	// Example service pattern (from staff_applications.go):
+	//   year := s.Year
+	//   if year == 0 {
+	//       yearStr := os.Getenv("CAMPMINDER_SEASON_ID")  // Falls back to env var!
+	//       ...
+	//   }
+
+	// The fix requires:
+	// 1. YearSetter interface: type YearSetter interface { SetYear(year int) }
+	// 2. Services implement SetYear() to set their internal .Year field
+	// 3. handleRunPhase calls SetYear(year) on each service before running
+
+	// Verify that YearSetter interface exists (compilation will fail if not)
+	var _ YearSetter = (*CamperHistorySync)(nil)
+	var _ YearSetter = (*StaffApplicationsSync)(nil)
+	var _ YearSetter = (*StaffVehicleInfoSync)(nil)
+	var _ YearSetter = (*QuestRegistrationsSync)(nil)
+
+	t.Log("YearSetter interface is implemented by year-aware services")
+}

--- a/pocketbase/sync/camper_dietary.go
+++ b/pocketbase/sync/camper_dietary.go
@@ -68,6 +68,11 @@ func (s *CamperDietarySync) SetDebug(debug bool) {
 	s.Debug = debug
 }
 
+// SetYear sets the year for this sync service
+func (s *CamperDietarySync) SetYear(year int) {
+	s.Year = year
+}
+
 // DebugLog logs a message at INFO level only when Debug is enabled
 func (s *CamperDietarySync) DebugLog(msg string, args ...any) {
 	if s.Debug {

--- a/pocketbase/sync/camper_history.go
+++ b/pocketbase/sync/camper_history.go
@@ -66,6 +66,11 @@ func (c *CamperHistorySync) SetDebug(debug bool) {
 	c.Debug = debug
 }
 
+// SetYear sets the year for this sync service
+func (c *CamperHistorySync) SetYear(year int) {
+	c.Year = year
+}
+
 // DebugLog logs a message at INFO level only when Debug is enabled
 func (c *CamperHistorySync) DebugLog(msg string, args ...any) {
 	if c.Debug {

--- a/pocketbase/sync/camper_transportation.go
+++ b/pocketbase/sync/camper_transportation.go
@@ -79,6 +79,11 @@ func (s *CamperTransportationSync) SetDebug(debug bool) {
 	s.Debug = debug
 }
 
+// SetYear sets the year for this sync service
+func (s *CamperTransportationSync) SetYear(year int) {
+	s.Year = year
+}
+
 // DebugLog logs a message at INFO level only when Debug is enabled
 func (s *CamperTransportationSync) DebugLog(msg string, args ...any) {
 	if s.Debug {

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -62,6 +62,11 @@ func (s *FamilyCampDerivedSync) SetDebug(debug bool) {
 	s.Debug = debug
 }
 
+// SetYear sets the year for this sync service
+func (s *FamilyCampDerivedSync) SetYear(year int) {
+	s.Year = year
+}
+
 // DebugLog logs a message at INFO level only when Debug is enabled
 func (s *FamilyCampDerivedSync) DebugLog(msg string, args ...any) {
 	if s.Debug {

--- a/pocketbase/sync/financial_aid_applications.go
+++ b/pocketbase/sync/financial_aid_applications.go
@@ -66,6 +66,11 @@ func (s *FinancialAidApplicationsSync) SetDebug(debug bool) {
 	s.Debug = debug
 }
 
+// SetYear sets the year for this sync service
+func (s *FinancialAidApplicationsSync) SetYear(year int) {
+	s.Year = year
+}
+
 // DebugLog logs a message at INFO level only when Debug is enabled
 func (s *FinancialAidApplicationsSync) DebugLog(msg string, args ...any) {
 	if s.Debug {

--- a/pocketbase/sync/household_demographics.go
+++ b/pocketbase/sync/household_demographics.go
@@ -58,6 +58,11 @@ func (s *HouseholdDemographicsSync) SetDebug(debug bool) {
 	s.Debug = debug
 }
 
+// SetYear sets the year for this sync service
+func (s *HouseholdDemographicsSync) SetYear(year int) {
+	s.Year = year
+}
+
 // DebugLog logs a message at INFO level only when Debug is enabled
 func (s *HouseholdDemographicsSync) DebugLog(msg string, args ...any) {
 	if s.Debug {

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -137,6 +137,13 @@ type Debuggable interface {
 	SetDebug(debug bool)
 }
 
+// YearSetter is an optional interface for services that need year configuration.
+// Services that query year-scoped data should implement this to receive the
+// correct year from handleRunPhase before execution.
+type YearSetter interface {
+	SetYear(year int)
+}
+
 // Status represents the status of a sync operation
 type Status struct {
 	Type      string     `json:"type"`

--- a/pocketbase/sync/quest_registrations.go
+++ b/pocketbase/sync/quest_registrations.go
@@ -70,6 +70,11 @@ func (s *QuestRegistrationsSync) SetDebug(debug bool) {
 	s.Debug = debug
 }
 
+// SetYear sets the year for this sync service
+func (s *QuestRegistrationsSync) SetYear(year int) {
+	s.Year = year
+}
+
 // DebugLog logs a message at INFO level only when Debug is enabled
 func (s *QuestRegistrationsSync) DebugLog(msg string, args ...any) {
 	if s.Debug {

--- a/pocketbase/sync/staff_applications.go
+++ b/pocketbase/sync/staff_applications.go
@@ -55,6 +55,11 @@ func (s *StaffApplicationsSync) SetDebug(debug bool) {
 	s.Debug = debug
 }
 
+// SetYear sets the year for this sync service
+func (s *StaffApplicationsSync) SetYear(year int) {
+	s.Year = year
+}
+
 // DebugLog logs a message at INFO level only when Debug is enabled
 func (s *StaffApplicationsSync) DebugLog(msg string, args ...any) {
 	if s.Debug {

--- a/pocketbase/sync/staff_skills.go
+++ b/pocketbase/sync/staff_skills.go
@@ -62,6 +62,11 @@ func (s *StaffSkillsSync) SetDebug(debug bool) {
 	s.Debug = debug
 }
 
+// SetYear sets the year for this sync service
+func (s *StaffSkillsSync) SetYear(year int) {
+	s.Year = year
+}
+
 // DebugLog logs a message at INFO level only when Debug is enabled
 func (s *StaffSkillsSync) DebugLog(msg string, args ...any) {
 	if s.Debug {

--- a/pocketbase/sync/staff_vehicle_info.go
+++ b/pocketbase/sync/staff_vehicle_info.go
@@ -60,6 +60,11 @@ func (s *StaffVehicleInfoSync) SetDebug(debug bool) {
 	s.Debug = debug
 }
 
+// SetYear sets the year for this sync service
+func (s *StaffVehicleInfoSync) SetYear(year int) {
+	s.Year = year
+}
+
 // DebugLog logs a message at INFO level only when Debug is enabled
 func (s *StaffVehicleInfoSync) DebugLog(msg string, args ...any) {
 	if s.Debug {


### PR DESCRIPTION
## Summary

- PR #193 fixed `status.Year` reporting but services still used their internal `.Year` field which defaults to `CAMPMINDER_SEASON_ID` env var
- This caused phase syncs to query the wrong year's data (2026 instead of the requested year), resulting in 0 records processed for all transform jobs

## Root Cause

`handleRunPhase` set `orchestrator.currentSyncYear = year` but this only affects the Status struct's Year field. The actual sync services read their internal `.Year` property which was never set, so they fell back to the env var (2026).

## Changes

- Add `YearSetter` interface for services that need year configuration
- Add `SetYear()` method to all 10 transform services
- Call `SetYear(year)` on services in `handleRunPhase` before running
- Add test verifying `YearSetter` interface implementation

## Test plan

- [x] `go build .` passes
- [x] `go test ./sync/...` passes
- [ ] Run phase 4 (transform) sync for year 2025
- [ ] Verify stats show actual created/updated counts instead of all zeros