### PR TITLE
fix(pb): increase camper_transportation field limits

### DIFF
--- a/pocketbase/pb_migrations/1500000043_camper_transportation.js
+++ b/pocketbase/pb_migrations/1500000043_camper_transportation.js
@@ -88,7 +88,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 200,
+        max: 500,
         pattern: ""
       },
       {
@@ -97,7 +97,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 50,
+        max: 200,
         pattern: ""
       },
       {
@@ -106,7 +106,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 100,
+        max: 200,
         pattern: ""
       },
 
@@ -117,7 +117,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 200,
+        max: 500,
         pattern: ""
       },
       {
@@ -126,7 +126,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 50,
+        max: 200,
         pattern: ""
       },
       {
@@ -135,7 +135,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 100,
+        max: 200,
         pattern: ""
       },
 
@@ -146,7 +146,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 200,
+        max: 500,
         pattern: ""
       },
       {
@@ -155,7 +155,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 50,
+        max: 200,
         pattern: ""
       },
       {
@@ -164,7 +164,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 100,
+        max: 200,
         pattern: ""
       },
 
@@ -175,7 +175,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 200,
+        max: 500,
         pattern: ""
       },
       {
@@ -184,7 +184,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 50,
+        max: 200,
         pattern: ""
       },
 


### PR DESCRIPTION
## Summary
- Raise limits on name, phone, and relationship fields to handle CampMinder data with multiple contacts/numbers in single fields
- `*_name` fields: 200 → 500
- `*_phone` fields: 50 → 200  
- `*_relationship` fields: 100 → 200

## Test plan
- [ ] CI passes
- [ ] Re-run camper_transportation sync after schema update
- [ ] Verify 76 errors are resolved