### PR TITLE
fix(scripts): worktree start.sh cd runs in wrong shell

### DIFF
--- a/scripts/worktree/new.sh
+++ b/scripts/worktree/new.sh
@@ -210,9 +210,8 @@ for port in $POCKETBASE_PORT $VITE_PORT $FASTAPI_PORT $CADDY_PORT; do
 done
 
 # Start PocketBase
-cd pocketbase && ./pocketbase serve --http=0.0.0.0:$POCKETBASE_PORT &
+(cd pocketbase && ./pocketbase serve --http=0.0.0.0:$POCKETBASE_PORT) &
 PB_PID=$!
-cd ..
 sleep 3
 
 # Start FastAPI


### PR DESCRIPTION
## Summary
- Worktree `start.sh` backgrounded `cd pocketbase && ./pocketbase serve &` which runs the `cd` in a subshell, leaving the parent shell unchanged. The subsequent `cd ..` then moved the parent up from the worktree root, breaking uvicorn, frontend build, and caddy.
- Wrapped in explicit subshell `(cd pocketbase && ...) &` and removed the stale `cd ..`.

## Test plan
- [ ] Create a new worktree with `./scripts/worktree/new.sh test-fix` and verify the generated `start.sh` has the parenthesized form
- [ ] Run `start.sh` in an existing worktree and confirm all services start