### PR TITLE
feat(sync): add transform phase to daily sync and remove CV warning toast

### DIFF
--- a/frontend/src/hooks/useRunPhaseSync.ts
+++ b/frontend/src/hooks/useRunPhaseSync.ts
@@ -19,7 +19,6 @@ interface PhaseSyncResponse {
   // Queue fields (for 202 Accepted)
   queue_id?: string
   position?: number
-  warning?: string
 }
 
 // Human-readable names for phases
@@ -73,14 +72,6 @@ export function useRunPhaseSync() {
       } else {
         toast.success(`${phaseName} phase started (${jobCount} jobs)`, {
           duration: 4000,
-        })
-      }
-
-      // Show warning if present (e.g., Transform without CV)
-      if (data.warning) {
-        toast(data.warning, {
-          icon: '⚠️',
-          duration: 6000,
         })
       }
 

--- a/pocketbase/sync/api.go
+++ b/pocketbase/sync/api.go
@@ -2201,16 +2201,6 @@ func handleRunPhase(e *core.RequestEvent, scheduler *Scheduler) error {
 		requestedBy = e.Auth.GetString("email")
 	}
 
-	// Check for warning: Transform phase without custom values
-	var warning string
-	if phase == PhaseTransform {
-		// Check if custom values exist for this year
-		if !checkCustomValuesExist(scheduler.app, year) {
-			warning = "Transform phase requires Custom Values phase to have run first. " +
-				"4 of 5 transform jobs depend on custom values data and will produce incomplete results without it."
-		}
-	}
-
 	// Check if any sync is already running (must match handleIndividualSync check)
 	if orchestrator.IsDailySyncRunning() || orchestrator.IsWeeklySyncRunning() ||
 		orchestrator.IsHistoricalSyncRunning() || orchestrator.IsCustomValuesSyncRunning() ||
@@ -2232,9 +2222,6 @@ func handleRunPhase(e *core.RequestEvent, scheduler *Scheduler) error {
 			"phase":    string(phase),
 			"year":     year,
 			"jobs":     jobs,
-		}
-		if warning != "" {
-			response["warning"] = warning
 		}
 		return e.JSON(http.StatusAccepted, response)
 	}
@@ -2316,23 +2303,7 @@ func handleRunPhase(e *core.RequestEvent, scheduler *Scheduler) error {
 		"jobs":    jobs,
 		"debug":   debug,
 	}
-	if warning != "" {
-		response["warning"] = warning
-	}
 	return e.JSON(http.StatusOK, response)
-}
-
-// checkCustomValuesExist checks if custom values have been synced for a given year
-func checkCustomValuesExist(app core.App, year int) bool {
-	// Check for at least one person_custom_values record for this year
-	records, err := app.FindRecordsByFilter(
-		"person_custom_values",
-		fmt.Sprintf("year = %d", year),
-		"",
-		1,
-		0,
-	)
-	return err == nil && len(records) > 0
 }
 
 // handleCamperDietarySync handles the camper dietary extraction endpoint

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -588,12 +588,20 @@ func (o *Orchestrator) RunDailySync(ctx context.Context) error {
 		"bunk_assignments",       // Depends on sessions, persons, bunks
 		"staff",                  // Staff sync: depends on divisions, bunks, persons
 		"financial_transactions", // Source data: depends on sessions, persons, households, divisions
-		// Note: Transform phase (derived tables) is NOT included in daily sync
-		// Transform jobs require fresh custom values data, but custom values only run weekly
-		// (they are expensive - 1 API call per entity). Transform jobs run as part of:
-		// - Weekly custom values sync (includes CV + transform)
-		// - Manual unified sync with includeCustomValues=true
-		// - Manual phase sync for transform phase (will use existing CV data)
+		// Transform phase: derived tables run daily using latest source data
+		// and existing custom values from the most recent weekly sync.
+		// New enrollments, session changes, etc. are reflected immediately.
+		"camper_history",
+		"family_camp_derived",
+		"staff_skills",
+		"financial_aid_applications",
+		"household_demographics",
+		"camper_dietary",
+		"camper_transportation",
+		"quest_registrations",
+		"staff_applications",
+		"staff_vehicle_info",
+		"normalize_geographic",
 		"bunk_requests", // CSV import, depends on persons
 	}
 


### PR DESCRIPTION
## Summary
- Add all 11 transform phase jobs to the daily sync, running after source data syncs and before bunk_requests. Derived tables now stay fresh daily using existing custom values from the most recent weekly sync.
- Remove the "Transform phase requires Custom Values" warning toast from both backend (`checkCustomValuesExist` function) and frontend (`useRunPhaseSync` hook) since transforms work fine with stale CV data.

## Test plan
- [ ] `go build .` passes in pocketbase/
- [ ] `npm run build` passes in frontend/
- [ ] `go test ./...` passes in pocketbase/
- [ ] Trigger daily sync and confirm transform jobs appear in the run sequence
- [ ] Run Transform phase manually from UI and confirm no warning toast appears