### PR TITLE
fix(frontend): hide session charts when single session selected

### DIFF
--- a/frontend/src/pages/metrics/registration/RegistrationOverview.tsx
+++ b/frontend/src/pages/metrics/registration/RegistrationOverview.tsx
@@ -231,30 +231,32 @@ export default function RegistrationOverview() {
         />
       </div>
 
-      {/* Charts Row 3: Session, Session Length */}
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <BreakdownChart
-          title="Enrollment by Session"
-          data={sessionChartData}
-          type="bar"
-          height={350}
-          breakdownType="session"
-          onSegmentClick={setFilter}
-        />
-        <SessionLengthBySessionChart
-          data={data.by_session_length_by_session ?? []}
-          title="Enrollment by Session Length"
-          height={350}
-          sessionDateLookup={sessionDateLookup}
-          onCategoryClick={(lengthCategory) =>
-            setFilter({
-              type: 'session_length',
-              value: lengthCategory,
-              label: `${lengthCategory} Sessions`,
-            })
-          }
-        />
-      </div>
+      {/* Charts Row 3: Session, Session Length (hidden when single session selected) */}
+      {!selectedSessionCmId && (
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <BreakdownChart
+            title="Enrollment by Session"
+            data={sessionChartData}
+            type="bar"
+            height={350}
+            breakdownType="session"
+            onSegmentClick={setFilter}
+          />
+          <SessionLengthBySessionChart
+            data={data.by_session_length_by_session ?? []}
+            title="Enrollment by Session Length"
+            height={350}
+            sessionDateLookup={sessionDateLookup}
+            onCategoryClick={(lengthCategory) =>
+              setFilter({
+                type: 'session_length',
+                value: lengthCategory,
+                label: `${lengthCategory} Sessions`,
+              })
+            }
+          />
+        </div>
+      )}
 
       {/* Charts Row 4: Years at Camp, First Summer Year */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">


### PR DESCRIPTION
## Summary
- Hide "Enrollment by Session" and "Enrollment by Session Length" charts when a specific session is selected from the dropdown
- These charts only provide value in the "All Sessions" view — showing a single bar is redundant

## Test plan
- [ ] Select "All Sessions" → both charts visible in Row 3
- [ ] Select a specific session → Row 3 charts hidden
- [ ] Switch back to "All Sessions" → charts reappear