### PR TITLE
fix(sync): always include transform phase in unified sync

### DIFF
--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -1013,46 +1013,9 @@ func (o *Orchestrator) RunSyncWithOptions(ctx context.Context, opts Options) err
 	// Determine which services to run
 	servicesToRun := opts.Services
 	if len(servicesToRun) == 0 {
-		// Run all services in dependency order
-		// Note: person_tag_defs, custom_field_defs, and divisions are NOT included here -
-		// they run in the weekly sync since they're global definitions that rarely change.
-		// They can still be run explicitly via opts.Services if needed.
-		// Note: "persons" is a combined sync that populates persons and households
-		servicesToRun = []string{
-			"session_groups",
-			"sessions",
-			// Note: divisions is global (no year field) - runs in weekly sync
-			"attendees",
-			"persons", // Combined sync: persons + households
-			"bunks",
-			"bunk_plans",
-			"bunk_assignments",
-			"staff",                  // Staff sync: depends on divisions, bunks, persons
-			"financial_transactions", // Source data: depends on sessions, persons, households
-		}
-
-		// Include custom field values if requested (expensive API calls - 1 call per entity)
-		// These must run BEFORE transform phase since 4 of 5 transform jobs depend on custom values
-		if opts.IncludeCustomValues {
-			// Transform phase: Only run when custom values phase runs
-			// Most transform jobs depend on custom values data:
-			// - family_camp_derived: requires person_custom_values + household_custom_values
-			// - staff_skills: requires person_custom_values (Skills- fields)
-			// - financial_aid_applications: requires person_custom_values (FA- fields)
-			// - household_demographics: requires household_custom_values (HH- fields)
-			// - camper_dietary: requires person_custom_values (Family Medical-* fields)
-			// - camper_transportation: requires person_custom_values (BUS-* fields)
-			// - quest_registrations: requires person_custom_values (Quest-*/Q-* fields)
-			// - staff_applications: requires person_custom_values (App-* fields)
-			// - staff_vehicle_info: requires person_custom_values (SVI-* fields)
-			// Only camper_history is CV-independent, but we run entire phase as a unit
-			servicesToRun = append(servicesToRun,
-				"person_custom_values", "household_custom_values",
-				"camper_history", "family_camp_derived", "staff_skills",
-				"financial_aid_applications", "household_demographics",
-				"camper_dietary", "camper_transportation", "quest_registrations",
-				"staff_applications", "staff_vehicle_info", "normalize_geographic")
-		}
+		// Run all services in dependency order (source → [CV] → transform)
+		// Same order as RunDailySync, with optional CV phase inserted before transform
+		servicesToRun = GetDefaultUnifiedSyncJobs(opts.IncludeCustomValues)
 
 		// Only include bunk_requests and process_requests for current year syncs (not historical)
 		// Bunk requests are populated during the current year's processing

--- a/pocketbase/sync/orchestrator_test.go
+++ b/pocketbase/sync/orchestrator_test.go
@@ -2563,23 +2563,6 @@ func TestRunSyncWithOptionsHistoricalMode(t *testing.T) {
 	})
 }
 
-func getPhaseNameForTest(phase Phase) string {
-	switch phase {
-	case PhaseSource:
-		return "Source"
-	case PhaseExpensive:
-		return "Expensive (CV)"
-	case PhaseTransform:
-		return "Transform"
-	case PhaseProcess:
-		return "Process"
-	case PhaseExport:
-		return "Export"
-	default:
-		return "Unknown"
-	}
-}
-
 // =============================================================================
 // Debug Flag Propagation Tests
 // =============================================================================


### PR DESCRIPTION
## Summary
- Transform phase jobs (camper_history, staff_skills, etc.) now always run during unified sync from the admin panel, regardless of whether "Include CV" is checked
- Previously these were only included when `IncludeCustomValues=true`, creating a gap where the admin panel's full sync skipped all derived table computation
- Extracted `GetDefaultUnifiedSyncJobs()` helper to keep job ordering in sync between `RunDailySync` and `RunSyncWithOptions`

## Test plan
- [x] New tests assert transform phase always present in unified sync job list
- [x] Tests verify ordering matches daily sync (source -> transform)
- [x] Tests verify CV flag only affects `person_custom_values`/`household_custom_values`
- [ ] Manual: Run full sync from admin panel without "Include CV" and verify transform jobs execute