### PR TITLE
fix(pb): fix attendee_status_history person_id validation preventing saves

### DIFF
--- a/pocketbase/pb_migrations/1500000057_attendee_status_history.js
+++ b/pocketbase/pb_migrations/1500000057_attendee_status_history.js
@@ -40,8 +40,8 @@ migrate((app) => {
         name: "person_id",
         required: true,
         presentable: false,
-        min: 0,
-        max: 0,
+        min: null,
+        max: null,
         onlyInt: true
       },
       {

--- a/pocketbase/pb_migrations/1500000058_fix_status_history_person_id.js
+++ b/pocketbase/pb_migrations/1500000058_fix_status_history_person_id.js
@@ -1,0 +1,39 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+/**
+ * Migration: Fix attendee_status_history person_id field constraint
+ *
+ * The original migration (1500000057) used min: 0, max: 0 for person_id.
+ * PocketBase interprets max: 0 as a literal maximum of 0, not "unlimited",
+ * causing all saves with positive CampMinder person IDs to fail with:
+ *   "person_id: Must be less than 0.000000."
+ */
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("attendee_status_history");
+
+  collection.fields.add(new Field({
+    type: "number",
+    name: "person_id",
+    required: true,
+    presentable: false,
+    min: null,
+    max: null,
+    onlyInt: true
+  }));
+
+  app.save(collection);
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("attendee_status_history");
+
+  collection.fields.add(new Field({
+    type: "number",
+    name: "person_id",
+    required: true,
+    presentable: false,
+    min: 0,
+    max: 0,
+    onlyInt: true
+  }));
+
+  app.save(collection);
+});


### PR DESCRIPTION
## Summary
- The `attendee_status_history` table has been empty since launch (~5 days) because every save fails with `person_id: Must be less than 0.000000`
- Root cause: migration used `min: 0, max: 0` for `person_id` — PocketBase treats `max: 0` as a literal max of 0, not "unlimited"
- Adds new migration (1500000058) to fix the constraint on existing DBs, and fixes the original migration (1500000057) for fresh installs

## Test plan
- [ ] `go build .` passes (verified locally)
- [ ] Restart PocketBase so migration 1500000058 runs
- [ ] Trigger attendees sync and verify `attendee_status_history` gets populated
- [ ] Logs show `INFO Recorded status change` instead of `WARN Failed to log status change`