### PR TITLE
fix(pb): enable cascadeDelete on derived table relations

### DIFF
--- a/pocketbase/pb_migrations/1500000059_cascade_delete_derived_relations.js
+++ b/pocketbase/pb_migrations/1500000059_cascade_delete_derived_relations.js
@@ -1,0 +1,162 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: Enable cascadeDelete on derived table relations
+ *
+ * When persons/households sync deletes orphaned records (no longer in
+ * CampMinder), PocketBase blocks the delete because derived tables have
+ * required relations with cascadeDelete=false.
+ *
+ * These tables are all computed/regenerated from custom values syncs.
+ * If the source person/household is gone, derived data should cascade-delete.
+ *
+ * Affected relations:
+ * - financial_aid_applications.person -> persons
+ * - household_demographics.household -> households
+ * - family_camp_adults.household -> households
+ * - family_camp_registrations.household -> households
+ * - family_camp_medical.household -> households
+ */
+
+migrate((app) => {
+  const personsCol = app.findCollectionByNameOrId("persons");
+  const householdsCol = app.findCollectionByNameOrId("households");
+
+  // 1. financial_aid_applications.person
+  const faApps = app.findCollectionByNameOrId("financial_aid_applications");
+  faApps.fields.add(new Field({
+    type: "relation",
+    name: "person",
+    required: true,
+    presentable: true,
+    collectionId: personsCol.id,
+    cascadeDelete: true,
+    minSelect: null,
+    maxSelect: 1
+  }));
+  app.save(faApps);
+
+  // 2. household_demographics.household
+  const hhDemo = app.findCollectionByNameOrId("household_demographics");
+  hhDemo.fields.add(new Field({
+    type: "relation",
+    name: "household",
+    required: true,
+    presentable: false,
+    collectionId: householdsCol.id,
+    cascadeDelete: true,
+    minSelect: null,
+    maxSelect: 1
+  }));
+  app.save(hhDemo);
+
+  // 3. family_camp_adults.household
+  const fcAdults = app.findCollectionByNameOrId("family_camp_adults");
+  fcAdults.fields.add(new Field({
+    type: "relation",
+    name: "household",
+    required: true,
+    presentable: false,
+    collectionId: householdsCol.id,
+    cascadeDelete: true,
+    minSelect: null,
+    maxSelect: 1
+  }));
+  app.save(fcAdults);
+
+  // 4. family_camp_registrations.household
+  const fcRegs = app.findCollectionByNameOrId("family_camp_registrations");
+  fcRegs.fields.add(new Field({
+    type: "relation",
+    name: "household",
+    required: true,
+    presentable: false,
+    collectionId: householdsCol.id,
+    cascadeDelete: true,
+    minSelect: null,
+    maxSelect: 1
+  }));
+  app.save(fcRegs);
+
+  // 5. family_camp_medical.household
+  const fcMed = app.findCollectionByNameOrId("family_camp_medical");
+  fcMed.fields.add(new Field({
+    type: "relation",
+    name: "household",
+    required: true,
+    presentable: false,
+    collectionId: householdsCol.id,
+    cascadeDelete: true,
+    minSelect: null,
+    maxSelect: 1
+  }));
+  app.save(fcMed);
+
+}, (app) => {
+  const personsCol = app.findCollectionByNameOrId("persons");
+  const householdsCol = app.findCollectionByNameOrId("households");
+
+  const faApps = app.findCollectionByNameOrId("financial_aid_applications");
+  faApps.fields.add(new Field({
+    type: "relation",
+    name: "person",
+    required: true,
+    presentable: true,
+    collectionId: personsCol.id,
+    cascadeDelete: false,
+    minSelect: null,
+    maxSelect: 1
+  }));
+  app.save(faApps);
+
+  const hhDemo = app.findCollectionByNameOrId("household_demographics");
+  hhDemo.fields.add(new Field({
+    type: "relation",
+    name: "household",
+    required: true,
+    presentable: false,
+    collectionId: householdsCol.id,
+    cascadeDelete: false,
+    minSelect: null,
+    maxSelect: 1
+  }));
+  app.save(hhDemo);
+
+  const fcAdults = app.findCollectionByNameOrId("family_camp_adults");
+  fcAdults.fields.add(new Field({
+    type: "relation",
+    name: "household",
+    required: true,
+    presentable: false,
+    collectionId: householdsCol.id,
+    cascadeDelete: false,
+    minSelect: null,
+    maxSelect: 1
+  }));
+  app.save(fcAdults);
+
+  const fcRegs = app.findCollectionByNameOrId("family_camp_registrations");
+  fcRegs.fields.add(new Field({
+    type: "relation",
+    name: "household",
+    required: true,
+    presentable: false,
+    collectionId: householdsCol.id,
+    cascadeDelete: false,
+    minSelect: null,
+    maxSelect: 1
+  }));
+  app.save(fcRegs);
+
+  const fcMed = app.findCollectionByNameOrId("family_camp_medical");
+  fcMed.fields.add(new Field({
+    type: "relation",
+    name: "household",
+    required: true,
+    presentable: false,
+    collectionId: householdsCol.id,
+    cascadeDelete: false,
+    minSelect: null,
+    maxSelect: 1
+  }));
+  app.save(fcMed);
+});


### PR DESCRIPTION
## Summary
- Orphaned person/household deletion during sync was blocked because derived tables (`financial_aid_applications`, `household_demographics`, `family_camp_*`) had required relations with `cascadeDelete=false`
- Enables `cascadeDelete=true` on 5 derived table relations so orphaned source records can be cleanly removed
- All affected tables are computed/regenerated from custom values syncs — no irreplaceable data is lost

## Test plan
- [ ] `go build .` passes in pocketbase/
- [ ] Run sync — orphan deletion no longer errors on financial_aid_applications or household_demographics
- [ ] Spot-check PB admin that cascadeDelete=true on the 5 relations