### PR TITLE
perf(docker): optimize layer caching with --link and consolidated RUN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,17 +74,14 @@ FROM python:3.14-slim
 
 # Single system-setup layer: user, packages, directories, ownership
 # hadolint ignore=DL3008
-RUN <<EOF
-  set -e
-  groupadd -r -g 1000 kindred && useradd -r -g kindred -u 1000 kindred
-  apt-get update && apt-get install -y --no-install-recommends \
-    curl wget supervisor procps \
-    && rm -rf /var/lib/apt/lists/*
-  mkdir -p /pb_data/bunk_requests /app/logs /app/csv_history /config \
-           /app/.config/caddy /app/.local/share/caddy \
-           /pb_public /pb_hooks /pb_migrations
-  chown -R kindred:kindred /pb_data /app /config /pb_public /pb_hooks /pb_migrations
-EOF
+RUN groupadd -r -g 1000 kindred && useradd -r -g kindred -u 1000 kindred \
+    && apt-get update && apt-get install -y --no-install-recommends \
+       curl wget supervisor procps \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /pb_data/bunk_requests /app/logs /app/csv_history /config \
+               /app/.config/caddy /app/.local/share/caddy \
+               /pb_public /pb_hooks /pb_migrations \
+    && chown -R kindred:kindred /pb_data /app /config /pb_public /pb_hooks /pb_migrations
 WORKDIR /app
 
 # Stable binaries (--link = content-addressable, survives across code-only releases)


### PR DESCRIPTION
## Summary
- Add `COPY --link` to all 14 COPY instructions in Stage 4, making each layer content-addressable and independently cacheable across builds
- Consolidate 5 separate RUN commands (user creation, apt-get, mkdir, chmod x2) into a single heredoc layer
- Replace `RUN chmod` commands with `COPY --chmod`, eliminating ~40MB of duplicate layers (PocketBase binary + entrypoint)
- Remove `RUN caddy validate` (validates on startup anyway) to enable `--link` on Caddyfile COPY
- Reorder instructions: stable binaries first, volatile source code last

## Expected Impact
| Metric | Before | After |
|--------|--------|-------|
| Stage 4 layers | ~17 | ~16 |
| Layers pulled on code-only release | ~22 | 2-4 |
| Data pulled on code-only release | ~450MB | ~5-8MB |
| Wasted chmod duplicate data | ~40MB | 0 |

## Test plan
- [ ] `docker build -t kindred:test .` succeeds
- [ ] Container starts and healthcheck passes
- [ ] CI passes (linting, type checks, unit tests)
- [ ] After two builds with only source changes, stable layers (venv, caddy, pocketbase) show "Already exists" on pull