### PR TITLE
fix(metrics): show 'Grade X' in retention by grade tooltip

### DIFF
--- a/frontend/src/components/metrics/RetentionRateLineChart.tsx
+++ b/frontend/src/components/metrics/RetentionRateLineChart.tsx
@@ -23,6 +23,7 @@ interface RetentionRateLineChartProps {
   data: RetentionRateBarItem[]
   title: string
   height?: number
+  tooltipLabelPrefix?: string
 }
 
 interface ChartItem {
@@ -32,7 +33,12 @@ interface ChartItem {
   returnedCount: number
 }
 
-export function RetentionRateLineChart({ data, title, height = 250 }: RetentionRateLineChartProps) {
+export function RetentionRateLineChart({
+  data,
+  title,
+  height = 250,
+  tooltipLabelPrefix,
+}: RetentionRateLineChartProps) {
   if (data.length === 0) {
     return (
       <div className="card-lodge p-4">
@@ -65,7 +71,9 @@ export function RetentionRateLineChart({ data, title, height = 250 }: RetentionR
       const item = payload[0].payload
       return (
         <div className="bg-card border-border rounded-lg border p-3 shadow-lg">
-          <p className="text-foreground font-medium">{item.name}</p>
+          <p className="text-foreground font-medium">
+            {tooltipLabelPrefix ? `${tooltipLabelPrefix}${item.name}` : item.name}
+          </p>
           <p className="text-muted-foreground text-sm">
             Retention: <span className="text-primary font-semibold">{item.rate}%</span>
           </p>

--- a/frontend/src/pages/metrics/retention/RetentionOverview.tsx
+++ b/frontend/src/pages/metrics/retention/RetentionOverview.tsx
@@ -123,7 +123,11 @@ export default function RetentionOverview() {
           <RetentionRateBarChart data={genderBars} title="Retention by Gender" />
         )}
         {gradeBars.length > 0 && (
-          <RetentionRateLineChart data={gradeBars} title="Retention by Grade" />
+          <RetentionRateLineChart
+            data={gradeBars}
+            title="Retention by Grade"
+            tooltipLabelPrefix="Grade "
+          />
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- Added `tooltipLabelPrefix` prop to `RetentionRateLineChart` component
- Retention by Grade chart tooltip now shows "Grade 3" instead of just "3"

## Test plan
- [ ] Hover over dots on Retention by Grade chart — tooltip should show "Grade X"
- [ ] Other line charts unaffected (no prefix passed)