### PR TITLE
feat(metrics): inline geographic retention outliers alongside charts

### DIFF
--- a/frontend/src/components/metrics/RetentionNotableOutliers.tsx
+++ b/frontend/src/components/metrics/RetentionNotableOutliers.tsx
@@ -3,6 +3,7 @@
  * with retention rates notably above or below the overall average.
  */
 
+import { TrendingUp, TrendingDown } from 'lucide-react'
 import type { RetentionOutlier } from '../../utils/retentionTransforms'
 
 interface RetentionNotableOutliersProps {
@@ -12,49 +13,39 @@ interface RetentionNotableOutliersProps {
   maxPerCategory?: number
 }
 
-function OutlierSection({
-  label,
-  outliers,
-  max,
-}: {
-  label: string
-  outliers: RetentionOutlier[]
-  max: number
-}) {
+export function OutlierSection({ outliers, max }: { outliers: RetentionOutlier[]; max: number }) {
   if (outliers.length === 0) return null
 
   return (
-    <div className="space-y-1">
-      <h4 className="text-muted-foreground text-xs font-medium tracking-wide uppercase">{label}</h4>
-      <ul className="space-y-0.5">
+    <div className="card-lodge p-4">
+      <h3 className="text-foreground text-base font-semibold">Notable Changes</h3>
+      <ul className="divide-border mt-2 divide-y">
         {outliers.slice(0, max).map((o) => {
           const rate = Math.round(o.retentionRate * 100)
           const isAbove = o.deviation > 0
+          const Icon = isAbove ? TrendingUp : TrendingDown
           return (
-            <li key={o.name} className="text-sm">
-              <span className="text-foreground font-medium">{o.name}:</span>{' '}
-              <span className="text-muted-foreground">
-                {rate}% ({o.returnedCount}/{o.baseCount})
-              </span>{' '}
+            <li key={o.name} className="flex items-start justify-between gap-2 py-2">
+              <div className="min-w-0">
+                <div className="flex items-baseline gap-1.5">
+                  <span className="text-foreground truncate text-sm font-medium">{o.name}</span>
+                  <span className="text-muted-foreground text-sm">{rate}%</span>
+                </div>
+                <p className="text-muted-foreground text-xs">
+                  {o.returnedCount} of {o.baseCount} returned
+                </p>
+              </div>
               <span
-                className={
+                className={`inline-flex shrink-0 items-center gap-0.5 rounded-full px-2 py-0.5 text-xs font-medium ${
                   isAbove
-                    ? 'text-emerald-600 dark:text-emerald-400'
-                    : 'text-red-600 dark:text-red-400'
-                }
+                    ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-300'
+                    : 'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-300'
+                }`}
               >
+                <Icon className="h-3 w-3" />
                 {isAbove ? '+' : ''}
-                {o.deviation}pp {isAbove ? 'above' : 'below'} avg
+                {o.deviation}%
               </span>
-              {(() => {
-                const diff = Math.abs(o.returnedCount - o.expectedCount)
-                if (diff === 0) return null
-                return (
-                  <span className="text-muted-foreground ml-1 text-xs">
-                    (~{diff} {isAbove ? 'more' : 'fewer'} than expected)
-                  </span>
-                )
-              })()}
             </li>
           )
         })}
@@ -77,9 +68,9 @@ export function RetentionNotableOutliers({
     <div className="card-lodge p-4">
       <h3 className="text-foreground mb-3 text-base font-semibold">Notable Outliers</h3>
       <div className="space-y-3">
-        <OutlierSection label="City" outliers={cityOutliers} max={maxPerCategory} />
-        <OutlierSection label="School" outliers={schoolOutliers} max={maxPerCategory} />
-        <OutlierSection label="Synagogue" outliers={synagogueOutliers} max={maxPerCategory} />
+        <OutlierSection outliers={cityOutliers} max={maxPerCategory} />
+        <OutlierSection outliers={schoolOutliers} max={maxPerCategory} />
+        <OutlierSection outliers={synagogueOutliers} max={maxPerCategory} />
       </div>
     </div>
   )

--- a/frontend/src/components/metrics/RetentionRateBarChart.tsx
+++ b/frontend/src/components/metrics/RetentionRateBarChart.tsx
@@ -155,7 +155,7 @@ export function RetentionRateBarChart({
       <div className="card-lodge p-4">
         <h3 className="text-foreground mb-4 text-base font-semibold">{title}</h3>
         <ResponsiveContainer width="100%" height={chartHeight}>
-          <BarChart data={chartData} margin={{ top: 5, right: 20, left: 0, bottom: 60 }}>
+          <BarChart data={chartData} margin={{ top: 20, right: 20, left: 0, bottom: 60 }}>
             <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
             <XAxis dataKey="name" className="text-xs" interval={0} tick={RotatedTick} />
             <YAxis

--- a/frontend/src/pages/metrics/retention/RetentionOverview.tsx
+++ b/frontend/src/pages/metrics/retention/RetentionOverview.tsx
@@ -30,7 +30,7 @@ import {
   computeRetentionOutliers,
 } from '../../../utils/retentionTransforms'
 import { buildSessionDateLookup, sortSessionDataByDate } from '../../../utils/sessionUtils'
-import { RetentionNotableOutliers } from '../../../components/metrics/RetentionNotableOutliers'
+import { OutlierSection } from '../../../components/metrics/RetentionNotableOutliers'
 import { SectionDivider } from '../../../components/metrics/SectionDivider'
 import type { DrilldownFilter } from '../../../types/metrics'
 import { Loader2, AlertCircle } from 'lucide-react'
@@ -201,48 +201,56 @@ export default function RetentionOverview() {
 
       <SectionDivider label="Geographic Retention" />
 
-      {/* Row 5: City + School */}
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        {cityBars.length > 0 && (
-          <RetentionRateBarChart
-            data={cityBars}
-            title="Retention by City (Top 15)"
-            topN={15}
-            sortBy="count"
-            showCounts
-            onBarClick={(item) => setFilter(makeRetentionFilter('city', item))}
-          />
-        )}
-        {schoolBars.length > 0 && (
-          <RetentionRateBarChart
-            data={schoolBars}
-            title="Retention by School (Top 15)"
-            topN={15}
-            sortBy="count"
-            showCounts
-            onBarClick={(item) => setFilter(makeRetentionFilter('school', item))}
-          />
-        )}
-      </div>
-
-      {/* Row 6: Synagogue */}
-      {synagogueBars.length > 0 && (
-        <RetentionRateBarChart
-          data={synagogueBars}
-          title="Retention by Synagogue (Top 15)"
-          topN={15}
-          sortBy="count"
-          showCounts
-          onBarClick={(item) => setFilter(makeRetentionFilter('synagogue', item))}
-        />
+      {/* Row 5: City chart + outliers */}
+      {cityBars.length > 0 && (
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+          <div className={cityOutliers.length > 0 ? 'lg:col-span-2' : 'lg:col-span-3'}>
+            <RetentionRateBarChart
+              data={cityBars}
+              title="Retention by City (Top 15)"
+              topN={15}
+              sortBy="count"
+              layout="vertical"
+              onBarClick={(item) => setFilter(makeRetentionFilter('city', item))}
+            />
+          </div>
+          <OutlierSection outliers={cityOutliers} max={5} />
+        </div>
       )}
 
-      {/* Notable Outliers */}
-      <RetentionNotableOutliers
-        cityOutliers={cityOutliers}
-        schoolOutliers={schoolOutliers}
-        synagogueOutliers={synagogueOutliers}
-      />
+      {/* Row 6: School chart + outliers */}
+      {schoolBars.length > 0 && (
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+          <div className={schoolOutliers.length > 0 ? 'lg:col-span-2' : 'lg:col-span-3'}>
+            <RetentionRateBarChart
+              data={schoolBars}
+              title="Retention by School (Top 15)"
+              topN={15}
+              sortBy="count"
+              layout="vertical"
+              onBarClick={(item) => setFilter(makeRetentionFilter('school', item))}
+            />
+          </div>
+          <OutlierSection outliers={schoolOutliers} max={5} />
+        </div>
+      )}
+
+      {/* Row 7: Synagogue chart + outliers */}
+      {synagogueBars.length > 0 && (
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+          <div className={synagogueOutliers.length > 0 ? 'lg:col-span-2' : 'lg:col-span-3'}>
+            <RetentionRateBarChart
+              data={synagogueBars}
+              title="Retention by Synagogue (Top 15)"
+              topN={15}
+              sortBy="count"
+              layout="vertical"
+              onBarClick={(item) => setFilter(makeRetentionFilter('synagogue', item))}
+            />
+          </div>
+          <OutlierSection outliers={synagogueOutliers} max={5} />
+        </div>
+      )}
 
       {/* Drilldown Modal */}
       <DrilldownModal />


### PR DESCRIPTION
## Summary
- Redesign geographic retention section to place outlier cards inline beside each chart (city, school, synagogue) in a 3-column grid layout instead of a consolidated block at the bottom
- OutlierSection uses badge-style deviation pills with TrendingUp/TrendingDown icons for clearer visual hierarchy
- Fix vertical bar chart top margin clipping (5px → 20px)

## Test plan
- [x] `npm run lint` — 0 errors (111 pre-existing warnings)
- [x] `npm run test` — all 1281 tests pass across 89 files
- [ ] Visual check: each geographic chart has outlier card beside it on wide screens, stacks on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)