### PR TITLE
refactor(frontend): remove as-any casts from camper hooks

### DIFF
--- a/frontend/src/components/CamperDetail.tsx
+++ b/frontend/src/components/CamperDetail.tsx
@@ -225,12 +225,10 @@ export default function CamperDetail() {
     person?.address_state
   )
   const pronouns = formatPronouns(camper)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const sessionShortName = getSessionShortName(camper.expand?.session as any)
+  const sessionShortName = getSessionShortName(camper.expand?.session ?? undefined)
   const allSessionNames =
     enrolledCampers.length > 1
-      ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        enrolledCampers.map((c) => getSessionShortName(c.expand?.session as any))
+      ? enrolledCampers.map((c) => getSessionShortName(c.expand?.session ?? undefined))
       : undefined
   const agePreferenceRequests = allBunkRequests.filter((r) => r.request_type === 'age_preference')
 

--- a/frontend/src/hooks/camper/useCamperHistory.ts
+++ b/frontend/src/hooks/camper/useCamperHistory.ts
@@ -5,9 +5,13 @@
 
 import { useQuery } from '@tanstack/react-query'
 import { pb } from '../../lib/pocketbase'
-import { VALID_SUMMER_SESSION_TYPES } from '../../constants/sessionTypes'
+import { isValidSummerSession } from '../../constants/sessionTypes'
 import type { Camper } from '../../types/app-types'
-import type { BunkAssignmentsResponse } from '../../types/pocketbase-types'
+import type {
+  BunkAssignmentsResponse,
+  CampSessionsResponse,
+  BunksResponse,
+} from '../../types/pocketbase-types'
 import type { HistoricalRecord } from './types'
 
 export interface UseCamperHistoryResult {
@@ -51,10 +55,8 @@ export function useCamperHistory(
 
         for (const enrolled of enrollments) {
           if (enrolled.expand?.session) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const session = enrolled.expand.session as any
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const assignedBunk = enrolled.expand?.assigned_bunk as any
+            const session = enrolled.expand.session
+            const assignedBunk = enrolled.expand?.assigned_bunk
             allHistory.push({
               year: currentYear,
               sessionName: session.name || 'Unknown',
@@ -71,8 +73,10 @@ export function useCamperHistory(
         // (Person records are created per-year to preserve historical school info)
         const historicalFilter = `person.cm_id = ${personCmId} && year < ${currentYear}`
         const historicalAssignments = await pb
-          .collection<BunkAssignmentsResponse>('bunk_assignments')
-          .getFullList({
+          .collection('bunk_assignments')
+          .getFullList<
+            BunkAssignmentsResponse<{ session?: CampSessionsResponse; bunk?: BunksResponse }>
+          >({
             filter: historicalFilter,
             expand: 'session,bunk',
             sort: '-year',
@@ -83,12 +87,10 @@ export function useCamperHistory(
         const yearMap = new Map<number, HistoricalRecord>()
 
         for (const assignment of historicalAssignments) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const session = (assignment.expand as any)?.session
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const bunk = (assignment.expand as any)?.bunk
+          const session = assignment.expand?.session
+          const bunk = assignment.expand?.bunk
 
-          if (session && VALID_SUMMER_SESSION_TYPES.includes(session.session_type)) {
+          if (session && isValidSummerSession(session.session_type)) {
             const year = assignment.year
 
             // Format session name based on type
@@ -129,10 +131,8 @@ export function useCamperHistory(
         const fallback: HistoricalRecord[] = []
         for (const enrolled of fallbackEnrollments) {
           if (enrolled.expand?.session) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const session = enrolled.expand.session as any
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const assignedBunk = enrolled.expand?.assigned_bunk as any
+            const session = enrolled.expand.session
+            const assignedBunk = enrolled.expand?.assigned_bunk
             fallback.push({
               year: currentYear,
               sessionName: session.name || 'Unknown',


### PR DESCRIPTION
## Summary
- Remove 8 `as any` casts and their `eslint-disable` comments from `useCamperHistory.ts` and `CamperDetail.tsx`
- Add explicit expand generics to the historical `bunk_assignments` query so `session` and `bunk` fields are properly typed
- Use `isValidSummerSession()` helper instead of raw `VALID_SUMMER_SESSION_TYPES.includes()` to handle enum-to-string type narrowing
- Use `?? undefined` to convert `null` to `undefined` where `getSessionShortName()` expects `undefined`

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] `npm run lint` passes with zero errors (186 pre-existing warnings unchanged)
- [x] `npm run test -- --run` passes all 1328 tests across 91 files
- [x] All pre-push hooks pass (ruff, mypy, go build, golangci-lint, prettier, eslint)