### PR TITLE
fix(scripts): detect stale node_modules in start_dev.sh

### DIFF
--- a/scripts/start_dev.sh
+++ b/scripts/start_dev.sh
@@ -110,11 +110,13 @@ else
     echo -e "${GREEN}PocketBase already initialized, skipping admin creation${NC}"
 fi
 
-# Check if frontend dependencies are installed
-if [ ! -d "$PROJECT_ROOT/frontend/node_modules" ]; then
+# Install frontend dependencies if needed (missing or outdated)
+cd "$PROJECT_ROOT/frontend"
+if [ ! -d "node_modules" ] || [ "package-lock.json" -nt "node_modules/.package-lock.json" ]; then
     echo -e "${YELLOW}Installing frontend dependencies...${NC}"
-    cd "$PROJECT_ROOT/frontend"
     npm install
+else
+    echo -e "${GREEN}Frontend dependencies up to date${NC}"
 fi
 
 # Install Python dependencies using uv (creates .venv automatically, smart caching)


### PR DESCRIPTION
## Summary
- `start_dev.sh` only ran `npm install` when `node_modules/` was completely missing
- After pulling commits that add new npm dependencies (e.g. `driver.js` from #271), the directory existed but was stale, causing TypeScript build failures
- Now compares `package-lock.json` mtime against `node_modules/.package-lock.json` to detect when deps need updating, matching how `uv sync` already handles Python deps

## Test plan
- [ ] Pull a branch that adds a new npm dependency, verify `start_dev.sh` runs `npm install`
- [ ] Run `start_dev.sh` with up-to-date deps, verify it prints "Frontend dependencies up to date" and skips install