### PR TITLE
feat(metrics): add staff cabin analysis tab

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,9 @@ const WaitlistAnalysis = lazy(() => import('./pages/metrics/registration/Waitlis
 const RetentionOverview = lazy(() => import('./pages/metrics/retention/RetentionOverview'))
 const SessionFlowPage = lazy(() => import('./pages/metrics/retention/SessionFlowPage'))
 const BunkRetentionPage = lazy(() => import('./pages/metrics/retention/BunkRetentionPage'))
+const StaffCabinAnalysisPage = lazy(
+  () => import('./pages/metrics/retention/StaffCabinAnalysisPage')
+)
 const TrendsOverview = lazy(() => import('./pages/metrics/trends/TrendsOverview'))
 
 // Loading skeleton component for route transitions
@@ -249,6 +252,14 @@ function App() {
                                 element={
                                   <Suspense fallback={<PageSkeleton />}>
                                     <BunkRetentionPage />
+                                  </Suspense>
+                                }
+                              />
+                              <Route
+                                path="retention/staff"
+                                element={
+                                  <Suspense fallback={<PageSkeleton />}>
+                                    <StaffCabinAnalysisPage />
                                   </Suspense>
                                 }
                               />

--- a/frontend/src/components/metrics/MetricsTypeTabs.tsx
+++ b/frontend/src/components/metrics/MetricsTypeTabs.tsx
@@ -75,8 +75,10 @@ export default function MetricsTypeTabs() {
           })}
         </div>
 
-        {/* Right side controls — hidden on bunk retention tab (unfiltered data) */}
-        {location.pathname !== RETENTION_SUB_NAV.find((item) => item.id === 'bunks')?.path && (
+        {/* Right side controls — hidden on tabs that use unfiltered data */}
+        {!RETENTION_SUB_NAV.filter((item) => item.id === 'bunks' || item.id === 'staff').some(
+          (item) => item.path === location.pathname
+        ) && (
           <div className="flex items-center gap-3">
             {activeTab === 'trends' && (
               <label className="flex cursor-pointer items-center gap-1.5 text-sm">

--- a/frontend/src/components/metrics/SessionBunkHeatmap.tsx
+++ b/frontend/src/components/metrics/SessionBunkHeatmap.tsx
@@ -15,13 +15,7 @@ import type { SessionDateLookup } from '../../utils/sessionUtils'
 import { compareByDateThenName } from '../../utils/sessionUtils'
 import type { BunkStaffInfo } from '../../hooks/useBunkStaff'
 import { BunkCellTooltip } from './BunkStaffTooltip'
-
-function getCellColor(rate: number): string {
-  const pct = Math.round(rate * 100)
-  if (pct >= 60) return 'bg-emerald-600/80 text-white'
-  if (pct >= 40) return 'bg-amber-500/80 text-white'
-  return 'bg-red-600/80 text-white'
-}
+import { getRetentionCellColor as getCellColor } from '../../utils/retentionColors'
 
 type BunkCategory = 'boys' | 'girls' | 'ag'
 

--- a/frontend/src/hooks/useStaffRetentionData.test.ts
+++ b/frontend/src/hooks/useStaffRetentionData.test.ts
@@ -21,7 +21,13 @@ describe('buildStaffRetentionData', () => {
     it('should return empty when bunkStaff is empty', () => {
       const bunkStaff = new Map<string, BunkStaffInfo[]>()
       const retention: RetentionBySessionBunk[] = [
-        { session: 'Session 1', bunk: 'B-1', base_count: 10, returned_count: 6, retention_rate: 0.6 },
+        {
+          session: 'Session 1',
+          bunk: 'B-1',
+          base_count: 10,
+          returned_count: 6,
+          retention_rate: 0.6,
+        },
       ]
 
       const result = buildStaffRetentionData(bunkStaff, retention)
@@ -47,7 +53,13 @@ describe('buildStaffRetentionData', () => {
         ['Session 1|B-1', [{ name: 'Emma Johnson', personId: '101' }]],
       ])
       const retention: RetentionBySessionBunk[] = [
-        { session: 'Session 1', bunk: 'B-1', base_count: 10, returned_count: 7, retention_rate: 0.7 },
+        {
+          session: 'Session 1',
+          bunk: 'B-1',
+          base_count: 10,
+          returned_count: 7,
+          retention_rate: 0.7,
+        },
       ]
 
       const result = buildStaffRetentionData(bunkStaff, retention)
@@ -65,7 +77,13 @@ describe('buildStaffRetentionData', () => {
         ['Session 1|B-1', [{ name: 'Emma Johnson', personId: '101' }]],
       ])
       const retention: RetentionBySessionBunk[] = [
-        { session: 'Session 1', bunk: 'B-1', base_count: 10, returned_count: 7, retention_rate: 0.7 },
+        {
+          session: 'Session 1',
+          bunk: 'B-1',
+          base_count: 10,
+          returned_count: 7,
+          retention_rate: 0.7,
+        },
       ]
 
       const result = buildStaffRetentionData(bunkStaff, retention)
@@ -86,8 +104,20 @@ describe('buildStaffRetentionData', () => {
         ['Session 2|B-5', [{ name: 'Liam Garcia', personId: '102' }]],
       ])
       const retention: RetentionBySessionBunk[] = [
-        { session: 'Session 1', bunk: 'B-3', base_count: 10, returned_count: 8, retention_rate: 0.8 },
-        { session: 'Session 2', bunk: 'B-5', base_count: 20, returned_count: 10, retention_rate: 0.5 },
+        {
+          session: 'Session 1',
+          bunk: 'B-3',
+          base_count: 10,
+          returned_count: 8,
+          retention_rate: 0.8,
+        },
+        {
+          session: 'Session 2',
+          bunk: 'B-5',
+          base_count: 20,
+          returned_count: 10,
+          retention_rate: 0.5,
+        },
       ]
 
       const result = buildStaffRetentionData(bunkStaff, retention)
@@ -106,8 +136,20 @@ describe('buildStaffRetentionData', () => {
         ['Session 3|G-4', [{ name: 'Olivia Chen', personId: '103' }]],
       ])
       const retention: RetentionBySessionBunk[] = [
-        { session: 'Session 1', bunk: 'G-2', base_count: 12, returned_count: 9, retention_rate: 0.75 },
-        { session: 'Session 3', bunk: 'G-4', base_count: 8, returned_count: 2, retention_rate: 0.25 },
+        {
+          session: 'Session 1',
+          bunk: 'G-2',
+          base_count: 12,
+          returned_count: 9,
+          retention_rate: 0.75,
+        },
+        {
+          session: 'Session 3',
+          bunk: 'G-4',
+          base_count: 8,
+          returned_count: 2,
+          retention_rate: 0.25,
+        },
       ]
 
       const result = buildStaffRetentionData(bunkStaff, retention)
@@ -126,8 +168,20 @@ describe('buildStaffRetentionData', () => {
         ['Session 1|G-1', [{ name: 'Olivia Chen', personId: '103' }]],
       ])
       const retention: RetentionBySessionBunk[] = [
-        { session: 'Session 1', bunk: 'B-1', base_count: 10, returned_count: 7, retention_rate: 0.7 },
-        { session: 'Session 1', bunk: 'G-1', base_count: 12, returned_count: 6, retention_rate: 0.5 },
+        {
+          session: 'Session 1',
+          bunk: 'B-1',
+          base_count: 10,
+          returned_count: 7,
+          retention_rate: 0.7,
+        },
+        {
+          session: 'Session 1',
+          bunk: 'G-1',
+          base_count: 12,
+          returned_count: 6,
+          retention_rate: 0.5,
+        },
       ]
 
       const result = buildStaffRetentionData(bunkStaff, retention)
@@ -148,7 +202,13 @@ describe('buildStaffRetentionData', () => {
         ],
       ])
       const retention: RetentionBySessionBunk[] = [
-        { session: 'Session 1', bunk: 'B-1', base_count: 10, returned_count: 7, retention_rate: 0.7 },
+        {
+          session: 'Session 1',
+          bunk: 'B-1',
+          base_count: 10,
+          returned_count: 7,
+          retention_rate: 0.7,
+        },
       ]
 
       const result = buildStaffRetentionData(bunkStaff, retention)
@@ -169,7 +229,13 @@ describe('buildStaffRetentionData', () => {
         ['Session 1 AG|AG-8', [{ name: 'Noah Williams', personId: '104' }]],
       ])
       const retention: RetentionBySessionBunk[] = [
-        { session: 'Session 1', bunk: 'AG-8', base_count: 6, returned_count: 4, retention_rate: 0.667 },
+        {
+          session: 'Session 1',
+          bunk: 'AG-8',
+          base_count: 6,
+          returned_count: 4,
+          retention_rate: 0.667,
+        },
       ]
 
       const result = buildStaffRetentionData(bunkStaff, retention)
@@ -194,7 +260,13 @@ describe('buildStaffRetentionData', () => {
           returned_count: 4,
           retention_rate: 0.667,
         },
-        { session: 'Session 1', bunk: 'AG-8', base_count: 10, returned_count: 5, retention_rate: 0.5 },
+        {
+          session: 'Session 1',
+          bunk: 'AG-8',
+          base_count: 10,
+          returned_count: 5,
+          retention_rate: 0.5,
+        },
       ]
 
       const result = buildStaffRetentionData(bunkStaff, retention)
@@ -213,9 +285,27 @@ describe('buildStaffRetentionData', () => {
         ['Session 2|G-1', [{ name: 'Olivia Chen', personId: '103' }]],
       ])
       const retention: RetentionBySessionBunk[] = [
-        { session: 'Session 3', bunk: 'B-1', base_count: 10, returned_count: 6, retention_rate: 0.6 },
-        { session: 'Session 1', bunk: 'B-2', base_count: 10, returned_count: 8, retention_rate: 0.8 },
-        { session: 'Session 2', bunk: 'G-1', base_count: 10, returned_count: 5, retention_rate: 0.5 },
+        {
+          session: 'Session 3',
+          bunk: 'B-1',
+          base_count: 10,
+          returned_count: 6,
+          retention_rate: 0.6,
+        },
+        {
+          session: 'Session 1',
+          bunk: 'B-2',
+          base_count: 10,
+          returned_count: 8,
+          retention_rate: 0.8,
+        },
+        {
+          session: 'Session 2',
+          bunk: 'G-1',
+          base_count: 10,
+          returned_count: 5,
+          retention_rate: 0.5,
+        },
       ]
 
       const result = buildStaffRetentionData(bunkStaff, retention)
@@ -229,8 +319,20 @@ describe('buildStaffRetentionData', () => {
         ['Session 1 AG|AG-8', [{ name: 'Noah Williams', personId: '104' }]],
       ])
       const retention: RetentionBySessionBunk[] = [
-        { session: 'Session 1', bunk: 'B-1', base_count: 10, returned_count: 6, retention_rate: 0.6 },
-        { session: 'Session 1', bunk: 'AG-8', base_count: 6, returned_count: 4, retention_rate: 0.667 },
+        {
+          session: 'Session 1',
+          bunk: 'B-1',
+          base_count: 10,
+          returned_count: 6,
+          retention_rate: 0.6,
+        },
+        {
+          session: 'Session 1',
+          bunk: 'AG-8',
+          base_count: 6,
+          returned_count: 4,
+          retention_rate: 0.667,
+        },
       ]
 
       const result = buildStaffRetentionData(bunkStaff, retention)
@@ -247,7 +349,13 @@ describe('buildStaffRetentionData', () => {
         ['Session 1|B-99', [{ name: 'Liam Garcia', personId: '102' }]], // no retention data for B-99
       ])
       const retention: RetentionBySessionBunk[] = [
-        { session: 'Session 1', bunk: 'B-1', base_count: 10, returned_count: 6, retention_rate: 0.6 },
+        {
+          session: 'Session 1',
+          bunk: 'B-1',
+          base_count: 10,
+          returned_count: 6,
+          retention_rate: 0.6,
+        },
       ]
 
       const result = buildStaffRetentionData(bunkStaff, retention)

--- a/frontend/src/hooks/useStaffRetentionData.ts
+++ b/frontend/src/hooks/useStaffRetentionData.ts
@@ -1,0 +1,152 @@
+/**
+ * useStaffRetentionData - Joins bunkStaff data with retention metrics
+ * to produce a staff-centric view of cabin retention rates.
+ *
+ * Inverts the bunkStaff map (session|bunk -> staff[]) to get
+ * staffPerson -> [{session, bunk}], joins with retention data,
+ * and computes per-staff overall weighted retention.
+ *
+ * Exports a pure function buildStaffRetentionData for testability.
+ */
+import { useMemo } from 'react'
+import { useRetentionMetrics } from './useMetrics'
+import { useBunkStaff } from './useBunkStaff'
+import type { BunkStaffInfo } from './useBunkStaff'
+import type { RetentionBySessionBunk } from '../types/metrics'
+
+export interface StaffSessionData {
+  bunkName: string
+  baseCount: number
+  returnedCount: number
+  retentionRate: number
+}
+
+export interface StaffRetentionRow {
+  personId: string
+  name: string
+  sessionData: Map<string, StaffSessionData> // sessionName -> data
+  overallRetention: number // weighted avg by base_count
+  totalBaseCount: number
+  totalReturnedCount: number
+}
+
+interface BuildResult {
+  staffRows: StaffRetentionRow[]
+  sessions: string[]
+}
+
+/**
+ * Pure function that builds staff retention data from bunkStaff map and retention metrics.
+ * Exported for direct testing.
+ */
+export function buildStaffRetentionData(
+  bunkStaff: Map<string, BunkStaffInfo[]>,
+  retention: RetentionBySessionBunk[]
+): BuildResult {
+  if (bunkStaff.size === 0 || retention.length === 0) {
+    return { staffRows: [], sessions: [] }
+  }
+
+  // Build retention lookup: "session|bunk" -> RetentionBySessionBunk
+  const retentionLookup = new Map<string, RetentionBySessionBunk>()
+  for (const item of retention) {
+    retentionLookup.set(`${item.session}|${item.bunk}`, item)
+  }
+
+  // Invert: staffPerson -> [{sessionName, bunkName, retentionData}]
+  const staffEntries = new Map<
+    string,
+    { name: string; entries: Array<{ sessionName: string; retention: RetentionBySessionBunk }> }
+  >()
+
+  for (const [key, staffList] of bunkStaff) {
+    const [sessionName, bunkName] = key.split('|')
+    if (!sessionName || !bunkName) continue
+
+    // Look up retention data - try direct match first
+    let retentionItem = retentionLookup.get(key)
+
+    // AG fallback: if bunk is AG-* and no direct match, try stripping " AG" suffix from session name
+    if (!retentionItem && bunkName.startsWith('AG-')) {
+      const parentSession = sessionName.replace(/ AG$/, '')
+      if (parentSession !== sessionName) {
+        retentionItem = retentionLookup.get(`${parentSession}|${bunkName}`)
+      }
+    }
+
+    if (!retentionItem) continue
+
+    for (const staff of staffList) {
+      let entry = staffEntries.get(staff.personId)
+      if (!entry) {
+        entry = { name: staff.name, entries: [] }
+        staffEntries.set(staff.personId, entry)
+      }
+      entry.entries.push({ sessionName, retention: retentionItem })
+    }
+  }
+
+  // Build rows with weighted averages
+  const sessionsSet = new Set<string>()
+  const staffRows: StaffRetentionRow[] = []
+
+  for (const [personId, { name, entries }] of staffEntries) {
+    const sessionData = new Map<string, StaffSessionData>()
+    let totalBase = 0
+    let totalReturned = 0
+
+    for (const { sessionName, retention: r } of entries) {
+      sessionData.set(sessionName, {
+        bunkName: r.bunk,
+        baseCount: r.base_count,
+        returnedCount: r.returned_count,
+        retentionRate: r.retention_rate,
+      })
+      totalBase += r.base_count
+      totalReturned += r.returned_count
+      sessionsSet.add(sessionName)
+    }
+
+    staffRows.push({
+      personId,
+      name,
+      sessionData,
+      overallRetention: totalBase > 0 ? totalReturned / totalBase : 0,
+      totalBaseCount: totalBase,
+      totalReturnedCount: totalReturned,
+    })
+  }
+
+  const sessions = [...sessionsSet].sort()
+
+  return { staffRows, sessions }
+}
+
+/**
+ * Hook that fetches bunkStaff and retention data, then builds staff retention rows.
+ */
+export function useStaffRetentionData(priorYear: number, currentYear: number) {
+  const {
+    data: retentionData,
+    isLoading: retLoading,
+    error: retError,
+  } = useRetentionMetrics(priorYear, currentYear)
+  const {
+    data: bunkStaffData,
+    isLoading: staffLoading,
+    error: staffError,
+  } = useBunkStaff(priorYear)
+
+  const result = useMemo(() => {
+    if (!bunkStaffData || !retentionData?.by_session_bunk) {
+      return { staffRows: [], sessions: [] }
+    }
+    return buildStaffRetentionData(bunkStaffData, retentionData.by_session_bunk)
+  }, [bunkStaffData, retentionData])
+
+  return {
+    ...result,
+    isLoading: retLoading || staffLoading,
+    error: retError || staffError,
+  }
+}

--- a/frontend/src/pages/metrics/metricsNav.ts
+++ b/frontend/src/pages/metrics/metricsNav.ts
@@ -2,7 +2,7 @@
  * Shared navigation configuration for metrics module.
  * Single source of truth for sub-nav items used by MetricsLayout and MetricsTypeTabs.
  */
-import { LayoutDashboard, Globe, Clock, GitBranch, Grid2x2 } from 'lucide-react'
+import { LayoutDashboard, Globe, Clock, GitBranch, Grid2x2, Users } from 'lucide-react'
 import type { SubNavItem } from '../../components/metrics/MetricsSubNav'
 
 /** Sub-nav items for retention section */
@@ -24,6 +24,12 @@ export const RETENTION_SUB_NAV: SubNavItem[] = [
     label: 'Bunk Analysis',
     icon: Grid2x2,
     path: '/metrics/retention/bunks',
+  },
+  {
+    id: 'staff',
+    label: 'Staff Analysis',
+    icon: Users,
+    path: '/metrics/retention/staff',
   },
 ]
 

--- a/frontend/src/pages/metrics/retention/StaffCabinAnalysisPage.test.tsx
+++ b/frontend/src/pages/metrics/retention/StaffCabinAnalysisPage.test.tsx
@@ -48,7 +48,9 @@ function renderPage() {
   )
 }
 
-function makeRow(overrides: Partial<StaffRetentionRow> & { personId: string; name: string }): StaffRetentionRow {
+function makeRow(
+  overrides: Partial<StaffRetentionRow> & { personId: string; name: string }
+): StaffRetentionRow {
   return {
     sessionData: new Map(),
     overallRetention: 0,
@@ -115,7 +117,10 @@ describe('StaffCabinAnalysisPage', () => {
             totalBaseCount: 10,
             totalReturnedCount: 7,
             sessionData: new Map([
-              ['Session 1', { bunkName: 'B-1', baseCount: 10, returnedCount: 7, retentionRate: 0.7 }],
+              [
+                'Session 1',
+                { bunkName: 'B-1', baseCount: 10, returnedCount: 7, retentionRate: 0.7 },
+              ],
             ]),
           }),
         ],
@@ -234,22 +239,29 @@ describe('StaffCabinAnalysisPage', () => {
             personId: '101',
             name: 'Emma Johnson',
             overallRetention: 0.7,
-            totalBaseCount: 10,
-            totalReturnedCount: 7,
+            totalBaseCount: 30,
+            totalReturnedCount: 21,
             sessionData: new Map([
-              ['Session 1', { bunkName: 'B-1', baseCount: 10, returnedCount: 7, retentionRate: 0.7 }],
+              [
+                'Session 1',
+                { bunkName: 'B-1', baseCount: 10, returnedCount: 7, retentionRate: 0.7 },
+              ],
+              [
+                'Session 2',
+                { bunkName: 'B-3', baseCount: 20, returnedCount: 14, retentionRate: 0.7 },
+              ],
             ]),
           }),
         ],
-        sessions: ['Session 1'],
+        sessions: ['Session 1', 'Session 2'],
         isLoading: false,
         error: null,
       })
 
       renderPage()
 
-      // The "Overall" cell for 70% should have emerald/green styling
-      const overallCell = screen.getByText('70%')
+      // The overall cell has unique return counts (aggregated across sessions)
+      const overallCell = screen.getByTitle('21 of 30 returned')
       expect(overallCell.className).toMatch(/emerald/)
     })
 
@@ -260,21 +272,28 @@ describe('StaffCabinAnalysisPage', () => {
             personId: '102',
             name: 'Liam Garcia',
             overallRetention: 0.3,
-            totalBaseCount: 10,
-            totalReturnedCount: 3,
+            totalBaseCount: 30,
+            totalReturnedCount: 9,
             sessionData: new Map([
-              ['Session 1', { bunkName: 'G-1', baseCount: 10, returnedCount: 3, retentionRate: 0.3 }],
+              [
+                'Session 1',
+                { bunkName: 'G-1', baseCount: 10, returnedCount: 3, retentionRate: 0.3 },
+              ],
+              [
+                'Session 2',
+                { bunkName: 'G-3', baseCount: 20, returnedCount: 6, retentionRate: 0.3 },
+              ],
             ]),
           }),
         ],
-        sessions: ['Session 1'],
+        sessions: ['Session 1', 'Session 2'],
         isLoading: false,
         error: null,
       })
 
       renderPage()
 
-      const overallCell = screen.getByText('30%')
+      const overallCell = screen.getByTitle('9 of 30 returned')
       expect(overallCell.className).toMatch(/red/)
     })
   })
@@ -376,7 +395,10 @@ describe('StaffCabinAnalysisPage', () => {
             totalBaseCount: 10,
             totalReturnedCount: 7,
             sessionData: new Map([
-              ['Session 1', { bunkName: 'B-1', baseCount: 10, returnedCount: 7, retentionRate: 0.7 }],
+              [
+                'Session 1',
+                { bunkName: 'B-1', baseCount: 10, returnedCount: 7, retentionRate: 0.7 },
+              ],
             ]),
           }),
         ],
@@ -387,10 +409,10 @@ describe('StaffCabinAnalysisPage', () => {
 
       renderPage()
 
-      expect(screen.getByText(/retention/i)).toBeInTheDocument()
-      expect(screen.getByText(/low/i)).toBeInTheDocument()
-      expect(screen.getByText(/mid/i)).toBeInTheDocument()
-      expect(screen.getByText(/high/i)).toBeInTheDocument()
+      expect(screen.getByText('Retention:')).toBeInTheDocument()
+      expect(screen.getByText(/Low \(/)).toBeInTheDocument()
+      expect(screen.getByText(/Mid \(/)).toBeInTheDocument()
+      expect(screen.getByText(/High \(/)).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/pages/metrics/retention/StaffCabinAnalysisPage.tsx
+++ b/frontend/src/pages/metrics/retention/StaffCabinAnalysisPage.tsx
@@ -1,0 +1,186 @@
+/**
+ * StaffCabinAnalysisPage - Staff-centric view of cabin retention rates.
+ *
+ * Table layout: rows = staff members, columns = sessions, cells = bunk name + retention %.
+ * Overall column shows weighted average retention across all sessions.
+ * Sortable by staff name or overall retention.
+ */
+
+import { useState, useMemo } from 'react'
+import { Users, ArrowUp, ArrowDown } from 'lucide-react'
+import { useCurrentYear } from '../../../hooks/useCurrentYear'
+import { useStaffRetentionData } from '../../../hooks/useStaffRetentionData'
+import type { StaffRetentionRow } from '../../../hooks/useStaffRetentionData'
+import { MetricsQueryGuard } from '../../../components/metrics/MetricsQueryGuard'
+import { getRetentionCellColor } from '../../../utils/retentionColors'
+
+type SortField = 'name' | 'overall'
+type SortDir = 'asc' | 'desc'
+
+function sortRows(rows: StaffRetentionRow[], field: SortField, dir: SortDir): StaffRetentionRow[] {
+  return [...rows].sort((a, b) => {
+    let cmp: number
+    if (field === 'name') {
+      cmp = a.name.localeCompare(b.name)
+    } else {
+      cmp = a.overallRetention - b.overallRetention
+    }
+    return dir === 'desc' ? -cmp : cmp
+  })
+}
+
+export default function StaffCabinAnalysisPage() {
+  const { currentYear } = useCurrentYear()
+  const priorYear = currentYear - 1
+
+  const { staffRows, sessions, isLoading, error } = useStaffRetentionData(priorYear, currentYear)
+
+  const [sortField, setSortField] = useState<SortField>('name')
+  const [sortDir, setSortDir] = useState<SortDir>('asc')
+
+  const sortedRows = useMemo(
+    () => sortRows(staffRows, sortField, sortDir),
+    [staffRows, sortField, sortDir]
+  )
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortField(field)
+      setSortDir(field === 'overall' ? 'desc' : 'asc')
+    }
+  }
+
+  const SortIcon = ({ field }: { field: SortField }) => {
+    if (sortField !== field) return null
+    return sortDir === 'asc' ? (
+      <ArrowUp className="inline h-3 w-3" />
+    ) : (
+      <ArrowDown className="inline h-3 w-3" />
+    )
+  }
+
+  // Wrap data for MetricsQueryGuard: it needs a truthy data object
+  const guardData = staffRows.length > 0 ? { staffRows, sessions } : undefined
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-foreground flex items-center gap-2 text-2xl font-bold">
+          <Users className="text-primary h-6 w-6" />
+          Staff Cabin Analysis ({priorYear})
+        </h1>
+        <p className="text-muted-foreground mt-1">
+          Retention rates by staff member across their cabin assignments
+        </p>
+      </div>
+
+      <MetricsQueryGuard
+        isLoading={isLoading}
+        error={error}
+        data={guardData}
+        label="staff retention"
+        emptyMessage="No staff retention data available"
+      >
+        {() => (
+          <div className="card-lodge p-4">
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse text-xs" role="table">
+                <thead>
+                  <tr>
+                    <th
+                      role="columnheader"
+                      className="bg-muted/50 text-muted-foreground sticky left-0 z-10 cursor-pointer px-3 py-2 text-left font-medium select-none"
+                      onClick={() => handleSort('name')}
+                    >
+                      Staff <SortIcon field="name" />
+                    </th>
+                    {sessions.map((session) => (
+                      <th
+                        key={session}
+                        role="columnheader"
+                        className="text-muted-foreground px-2 py-2 text-center font-medium"
+                      >
+                        {session}
+                      </th>
+                    ))}
+                    <th
+                      role="columnheader"
+                      className="bg-muted/50 text-muted-foreground sticky right-0 z-10 cursor-pointer px-3 py-2 text-center font-medium select-none"
+                      onClick={() => handleSort('overall')}
+                    >
+                      Overall <SortIcon field="overall" />
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sortedRows.map((row) => (
+                    <tr key={row.personId}>
+                      <th
+                        scope="row"
+                        className="bg-muted/50 text-foreground sticky left-0 z-10 px-3 py-2 text-left text-xs font-semibold whitespace-nowrap"
+                      >
+                        {row.name}
+                      </th>
+                      {sessions.map((session) => {
+                        const data = row.sessionData.get(session)
+                        if (!data) {
+                          return (
+                            <td
+                              key={session}
+                              className="bg-muted/30 text-muted-foreground px-2 py-2 text-center"
+                            >
+                              ---
+                            </td>
+                          )
+                        }
+                        const pct = Math.round(data.retentionRate * 100)
+                        return (
+                          <td
+                            key={session}
+                            className={`px-2 py-2 text-center ${getRetentionCellColor(data.retentionRate)}`}
+                            title={`${data.returnedCount} of ${data.baseCount} returned`}
+                          >
+                            <div className="text-[10px] leading-tight opacity-80">
+                              {data.bunkName}
+                            </div>
+                            <div className="font-bold">{pct}%</div>
+                          </td>
+                        )
+                      })}
+                      <td
+                        className={`sticky right-0 z-10 px-3 py-2 text-center font-bold ${getRetentionCellColor(row.overallRetention)}`}
+                        title={`${row.totalReturnedCount} of ${row.totalBaseCount} returned`}
+                      >
+                        {Math.round(row.overallRetention * 100)}%
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {/* Legend */}
+            <div className="mt-4 flex items-center gap-3 text-xs">
+              <span className="text-muted-foreground">Retention:</span>
+              <span className="flex items-center gap-1">
+                <span className="inline-block h-3 w-3 rounded bg-red-600/80" />
+                Low (&lt;40%)
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="inline-block h-3 w-3 rounded bg-amber-500/80" />
+                Mid (40-60%)
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="inline-block h-3 w-3 rounded bg-emerald-600/80" />
+                High (&ge;60%)
+              </span>
+            </div>
+          </div>
+        )}
+      </MetricsQueryGuard>
+    </div>
+  )
+}

--- a/frontend/src/utils/retentionColors.ts
+++ b/frontend/src/utils/retentionColors.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared retention color coding used by SessionBunkHeatmap and StaffCabinAnalysisPage.
+ *
+ * Green (>=60%), amber (40-60%), red (<40%).
+ */
+export function getRetentionCellColor(rate: number): string {
+  const pct = Math.round(rate * 100)
+  if (pct >= 60) return 'bg-emerald-600/80 text-white'
+  if (pct >= 40) return 'bg-amber-500/80 text-white'
+  return 'bg-red-600/80 text-white'
+}


### PR DESCRIPTION
## Summary
- Adds a new "Staff Analysis" tab under Retention that shows each bunk staff member's cabin assignments across sessions with retention rates and a weighted overall average
- Pure frontend feature: joins existing `useBunkStaff` and `useRetentionMetrics` data with no backend changes
- Extracts shared `getRetentionCellColor` utility from `SessionBunkHeatmap` for reuse

## Details
**New files:**
- `retentionColors.ts` — shared color thresholds (green >=60%, amber 40-60%, red <40%)
- `useStaffRetentionData.ts` — hook + exported pure `buildStaffRetentionData()` function
- `StaffCabinAnalysisPage.tsx` — sortable table with color-coded cells, sticky columns, legend

**Wiring:**
- Route added at `/metrics/retention/staff`
- Nav item with Users icon in retention sub-nav
- Session selector hidden on this tab (uses unfiltered data like Bunk Analysis)
- `SessionBunkHeatmap` refactored to import shared color utility

**AG session handling:** When bunk name starts with `AG-` and no direct key match, strips ` AG` suffix from session name to match retention data (which merges AG into parent sessions).

## Test plan
- [x] 36 tests pass (18 hook + 18 component)
- [x] Full test suite: 1388 tests pass
- [x] ESLint clean, Prettier clean, build succeeds
- [ ] Visual: Navigate to Retention > Staff Analysis tab
- [ ] Visual: Verify table renders with staff rows, color coding, and bunk names
- [ ] Visual: Verify sort toggles work (Staff name, Overall)
- [ ] Visual: Verify horizontal scroll with sticky columns
- [ ] Visual: Verify session selector is hidden on this tab