### PR TITLE
perf(frontend): remove onMouseMove from tooltip handlers

### DIFF
--- a/frontend/src/components/metrics/SessionBunkHeatmap.tsx
+++ b/frontend/src/components/metrics/SessionBunkHeatmap.tsx
@@ -61,14 +61,6 @@ function BunkHeatmapTable({ title, sessions, bunks, lookup, bunkStaff }: BunkHea
     setTooltipPos({ x: e.clientX + 10, y: e.clientY + 10 })
   }, [])
 
-  const handleMouseMove = useCallback(
-    (e: React.MouseEvent) => {
-      if (!hoveredCell) return
-      setTooltipPos({ x: e.clientX + 10, y: e.clientY + 10 })
-    },
-    [hoveredCell]
-  )
-
   const handleMouseLeave = useCallback(() => {
     setHoveredCell(null)
   }, [])
@@ -127,7 +119,6 @@ function BunkHeatmapTable({ title, sessions, bunks, lookup, bunkStaff }: BunkHea
                       role="cell"
                       className={cellClass}
                       onMouseEnter={(e) => handleMouseEnter(session, bunk, e)}
-                      onMouseMove={handleMouseMove}
                       onMouseLeave={handleMouseLeave}
                     >
                       {pct}%

--- a/frontend/src/pages/metrics/retention/StaffCabinAnalysisPage.tsx
+++ b/frontend/src/pages/metrics/retention/StaffCabinAnalysisPage.tsx
@@ -85,15 +85,6 @@ export default function StaffCabinAnalysisPage() {
     []
   )
 
-  const handleMouseMove = useCallback(
-    (e: React.MouseEvent) => {
-      if (hoveredCell) {
-        setTooltipPos({ x: e.clientX + 10, y: e.clientY + 10 })
-      }
-    },
-    [hoveredCell]
-  )
-
   const handleMouseLeave = useCallback(() => {
     setHoveredCell(null)
   }, [])
@@ -229,7 +220,6 @@ export default function StaffCabinAnalysisPage() {
                             onMouseEnter={(e) =>
                               handleMouseEnter(e, row.personId, session, data.bunkName)
                             }
-                            onMouseMove={handleMouseMove}
                             onMouseLeave={handleMouseLeave}
                           >
                             <div className="text-[10px] leading-tight opacity-80">
@@ -244,7 +234,6 @@ export default function StaffCabinAnalysisPage() {
                         onMouseEnter={(e) =>
                           handleMouseEnter(e, row.personId, '__overall__', 'Overall')
                         }
-                        onMouseMove={handleMouseMove}
                         onMouseLeave={handleMouseLeave}
                       >
                         {Math.round(row.overallRetention * 100)}%


### PR DESCRIPTION
## Summary
- Removed `handleMouseMove` callbacks and `onMouseMove` props from `StaffCabinAnalysisPage` and `BunkHeatmapTable`
- Tooltip position now set on `mouseEnter` only, eliminating ~60 re-renders/sec while hovering within a cell
- Cells are small enough that entry-point position works well; tooltip repositions naturally on each new cell entry

## Test plan
- [x] All 99 test files (1398 tests) pass
- [x] ESLint clean
- [x] Build succeeds
- [ ] Manual: hover cells in Staff Cabin Analysis tab — tooltip appears promptly without lag
- [ ] Manual: hover cells in Bunk Retention heatmap — same behavior