### PR TITLE
Revert tooltip onMouseMove removal

### DIFF
--- a/frontend/src/components/metrics/SessionBunkHeatmap.tsx
+++ b/frontend/src/components/metrics/SessionBunkHeatmap.tsx
@@ -61,6 +61,14 @@ function BunkHeatmapTable({ title, sessions, bunks, lookup, bunkStaff }: BunkHea
     setTooltipPos({ x: e.clientX + 10, y: e.clientY + 10 })
   }, [])
 
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (!hoveredCell) return
+      setTooltipPos({ x: e.clientX + 10, y: e.clientY + 10 })
+    },
+    [hoveredCell]
+  )
+
   const handleMouseLeave = useCallback(() => {
     setHoveredCell(null)
   }, [])
@@ -119,6 +127,7 @@ function BunkHeatmapTable({ title, sessions, bunks, lookup, bunkStaff }: BunkHea
                       role="cell"
                       className={cellClass}
                       onMouseEnter={(e) => handleMouseEnter(session, bunk, e)}
+                      onMouseMove={handleMouseMove}
                       onMouseLeave={handleMouseLeave}
                     >
                       {pct}%

--- a/frontend/src/pages/metrics/retention/StaffCabinAnalysisPage.tsx
+++ b/frontend/src/pages/metrics/retention/StaffCabinAnalysisPage.tsx
@@ -85,6 +85,15 @@ export default function StaffCabinAnalysisPage() {
     []
   )
 
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (hoveredCell) {
+        setTooltipPos({ x: e.clientX + 10, y: e.clientY + 10 })
+      }
+    },
+    [hoveredCell]
+  )
+
   const handleMouseLeave = useCallback(() => {
     setHoveredCell(null)
   }, [])
@@ -220,6 +229,7 @@ export default function StaffCabinAnalysisPage() {
                             onMouseEnter={(e) =>
                               handleMouseEnter(e, row.personId, session, data.bunkName)
                             }
+                            onMouseMove={handleMouseMove}
                             onMouseLeave={handleMouseLeave}
                           >
                             <div className="text-[10px] leading-tight opacity-80">
@@ -234,6 +244,7 @@ export default function StaffCabinAnalysisPage() {
                         onMouseEnter={(e) =>
                           handleMouseEnter(e, row.personId, '__overall__', 'Overall')
                         }
+                        onMouseMove={handleMouseMove}
                         onMouseLeave={handleMouseLeave}
                       >
                         {Math.round(row.overallRetention * 100)}%


### PR DESCRIPTION
## Summary
- Reverts #281 — the tooltip felt stagnant/chunky without cursor-following
- The lag was likely caused by dev server CPU load, not the onMouseMove re-renders
- Restores `handleMouseMove` in both `StaffCabinAnalysisPage` and `BunkHeatmapTable`

## Test plan
- [x] Pre-push hooks pass
- [ ] Manual: tooltips follow cursor smoothly again in both views