### PR TITLE
Remove section subheadings from overview pages

### DIFF
--- a/frontend/src/pages/metrics/registration/RegistrationOverview.tsx
+++ b/frontend/src/pages/metrics/registration/RegistrationOverview.tsx
@@ -33,8 +33,7 @@ import {
   transformFirstSummerYearData,
   transformNewVsReturningData,
 } from '../../../utils/metricsTransforms'
-import { SectionHeader } from '../../../components/metrics/SectionHeader'
-import { Loader2, AlertCircle, Users, UserPlus, Calendar, Clock } from 'lucide-react'
+import { Loader2, AlertCircle } from 'lucide-react'
 
 export default function RegistrationOverview() {
   const { currentYear } = useCurrentYear()
@@ -191,12 +190,6 @@ export default function RegistrationOverview() {
         />
       </div>
 
-      <SectionHeader
-        icon={Users}
-        title="Demographics"
-        description="Gender and grade distribution"
-      />
-
       {/* Charts Row 1: Gender */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         <BreakdownChart
@@ -216,12 +209,6 @@ export default function RegistrationOverview() {
           onBarClick={setFilter}
         />
       </div>
-
-      <SectionHeader
-        icon={UserPlus}
-        title="Camper Mix"
-        description="New vs returning enrollment breakdown"
-      />
 
       {/* Charts Row 2: New vs Returning, Grade */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
@@ -247,12 +234,6 @@ export default function RegistrationOverview() {
           onSegmentClick={setFilter}
         />
       </div>
-
-      <SectionHeader
-        icon={Calendar}
-        title="Session Enrollment"
-        description="Enrollment across sessions and lengths"
-      />
 
       {/* Charts Row 3: Session, Session Length (hidden when single session selected) */}
       {!selectedSessionCmId && (
@@ -281,12 +262,6 @@ export default function RegistrationOverview() {
           />
         </div>
       )}
-
-      <SectionHeader
-        icon={Clock}
-        title="Camper History"
-        description="Summers at camp and tenure analysis"
-      />
 
       {/* Charts Row 4: Years at Camp, First Summer Year */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">

--- a/frontend/src/pages/metrics/retention/RetentionOverview.tsx
+++ b/frontend/src/pages/metrics/retention/RetentionOverview.tsx
@@ -36,9 +36,8 @@ import {
   sortPriorSessionDataByDate,
 } from '../../../utils/sessionUtils'
 import { OutlierSection } from '../../../components/metrics/RetentionNotableOutliers'
-import { SectionHeader } from '../../../components/metrics/SectionHeader'
 import type { DrilldownFilter } from '../../../types/metrics'
-import { Loader2, AlertCircle, Users, Calendar, Clock, MapPin } from 'lucide-react'
+import { Loader2, AlertCircle } from 'lucide-react'
 
 export default function RetentionOverview() {
   const { currentYear } = useCurrentYear()
@@ -193,12 +192,6 @@ export default function RetentionOverview() {
         </p>
       )}
 
-      <SectionHeader
-        icon={Users}
-        title="Camper Demographics"
-        description="Retention rates by gender and grade"
-      />
-
       {/* Row 1: Gender + Grade side by side */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         {genderBars.length > 0 && (
@@ -219,12 +212,6 @@ export default function RetentionOverview() {
           />
         )}
       </div>
-
-      <SectionHeader
-        icon={Calendar}
-        title="Session Analysis"
-        description="How retention varies across sessions"
-      />
 
       {/* Row 2: Session charts side by side */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
@@ -247,12 +234,6 @@ export default function RetentionOverview() {
         )}
       </div>
 
-      <SectionHeader
-        icon={Clock}
-        title="Camper Tenure"
-        description="Retention by camp experience level"
-      />
-
       {/* Row 3: Summers at Camp + First Summer Year side by side */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         {summerYearsBars.length > 0 && (
@@ -270,12 +251,6 @@ export default function RetentionOverview() {
           />
         )}
       </div>
-
-      <SectionHeader
-        icon={MapPin}
-        title="Geographic Retention"
-        description="Retention patterns by location"
-      />
 
       {/* Row 5: City chart + outliers */}
       {cityBars.length > 0 && (

--- a/frontend/src/pages/metrics/trends/TrendsOverview.tsx
+++ b/frontend/src/pages/metrics/trends/TrendsOverview.tsx
@@ -23,8 +23,7 @@ import { RetentionRateLine } from '../../../components/metrics/RetentionRateLine
 import { GenderStackedChart } from '../../../components/metrics/GenderStackedChart'
 import { GradeEnrollmentChart } from '../../../components/metrics/GradeEnrollmentChart'
 import { MultiYearBreakdownChart } from '../../../components/metrics/MultiYearBreakdownChart'
-import { SectionHeader } from '../../../components/metrics/SectionHeader'
-import { Loader2, AlertCircle, PieChart, Globe } from 'lucide-react'
+import { Loader2, AlertCircle } from 'lucide-react'
 
 export default function TrendsOverview() {
   const { selectedSessionCmId, sessionTypesParam, expandedRetention } = useMetricsSession()
@@ -220,13 +219,6 @@ export default function TrendsOverview() {
         </div>
       </div>
 
-      {/* ─── Enrollment Composition (from retention-trends endpoint) ─── */}
-      <SectionHeader
-        icon={PieChart}
-        title="Enrollment Composition"
-        description={`Gender, grade, and tenure trends over ${numYearsDisplay} years`}
-      />
-
       {/* Retention Rate Trend Line */}
       {retentionYears.length > 0 && (
         <RetentionRateLine
@@ -278,13 +270,6 @@ export default function TrendsOverview() {
           height={300}
         />
       )}
-
-      {/* ─── Geographic Distribution (from retention-trends endpoint) ─── */}
-      <SectionHeader
-        icon={Globe}
-        title="Geographic Distribution"
-        description={`City, school, and synagogue trends over ${numYearsDisplay} years`}
-      />
 
       {/* City Distribution */}
       {enrollmentData.some((y) => (y.by_city?.length ?? 0) > 0) && (


### PR DESCRIPTION
## Summary
- Remove SectionHeader h2 dividers from RetentionOverview, TrendsOverview, and RegistrationOverview
- Keep page-specific h1 titles on sub-pages and MetricsLayout h1 titles
- space-y-6 wrapper provides natural section spacing

## Test plan
- [ ] Verify RetentionOverview flows cleanly without section headers
- [ ] Verify TrendsOverview flows cleanly without section headers
- [ ] Verify RegistrationOverview flows cleanly without section headers
- [ ] npm run lint passes (no unused imports)
- [ ] npm run build passes
- [ ] npm run test passes