### PR TITLE
Fix region detail list click interaction

### DIFF
--- a/frontend/src/components/metrics/geo/GeoDetailList.tsx
+++ b/frontend/src/components/metrics/geo/GeoDetailList.tsx
@@ -120,17 +120,19 @@ export function GeoDetailList({
                   return (
                     <Fragment key={item.name}>
                       <tr
-                        onClick={() => {
-                          onItemClick?.(item.name)
-                          if (category !== 'region') {
-                            onDrilldown?.({
-                              type: category,
-                              value: item.name,
-                              label: item.name,
-                            })
-                          }
-                        }}
-                        className={`border-border cursor-pointer border-t transition-colors ${isSelected ? 'bg-primary/10' : 'hover:bg-muted/30'} `}
+                        onClick={
+                          category !== 'region'
+                            ? () => {
+                                onItemClick?.(item.name)
+                                onDrilldown?.({
+                                  type: category,
+                                  value: item.name,
+                                  label: item.name,
+                                })
+                              }
+                            : undefined
+                        }
+                        className={`border-border border-t transition-colors ${category !== 'region' ? 'cursor-pointer' : ''} ${isSelected ? 'bg-primary/10' : category !== 'region' ? 'hover:bg-muted/30' : ''} `}
                       >
                         <td className="text-foreground px-4 py-2">
                           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Disable cursor-pointer and click handler on region detail list rows
- Regions are a derived frontend aggregation with no backend drilldown filter
- Rows were appearing clickable but doing nothing on click

## Test plan
- [ ] Region rows in Geographic Analysis don't show pointer cursor
- [ ] City/school/synagogue rows still drilldown on click
- [ ] npm run lint, build, test all pass