### PR TITLE
Registration dates config for velocity analysis

### DIFF
--- a/frontend/src/components/admin/ConfigTab.tsx
+++ b/frontend/src/components/admin/ConfigTab.tsx
@@ -10,12 +10,14 @@ import {
   Sliders,
   Database,
   Workflow,
+  CalendarDays,
 } from 'lucide-react'
 import toast from 'react-hot-toast'
 import { useSolverConfig, type ConfigSection } from '../../hooks/useSolverConfig'
 import { useUpdateSolverConfig, useResetSolverConfig } from '../../hooks/useSolverConfigMutation'
 import { SectionCard } from './SectionCard'
 import { ScaleGuideSidebar } from './ScaleGuideSidebar'
+import { RegistrationDatesConfig } from './RegistrationDatesConfig'
 
 // Category definitions - these IDs match the business_category values in config metadata
 interface CategoryDef {
@@ -45,6 +47,12 @@ export const CATEGORIES: CategoryDef[] = [
     icon: Database,
     description: 'Historical context & tracking',
   },
+  {
+    id: 'registration',
+    name: 'Registration',
+    icon: CalendarDays,
+    description: 'Registration phase dates',
+  },
 ]
 
 export function ConfigTab() {
@@ -64,6 +72,7 @@ export function ConfigTab() {
       solver: [],
       processing: [],
       history: [],
+      registration: [],
     }
 
     sections.forEach((section) => {
@@ -274,24 +283,28 @@ export function ConfigTab() {
         </div>
 
         {/* Sections */}
-        <div className="space-y-4">
-          {filteredSections.map((section, index) => (
-            <SectionCard
-              key={section.id}
-              section={section}
-              editedValues={editedValues}
-              onValueChange={handleValueChange}
-              defaultExpanded={index < 3}
-            />
-          ))}
+        {activeCategory === 'registration' ? (
+          <RegistrationDatesConfig />
+        ) : (
+          <div className="space-y-4">
+            {filteredSections.map((section, index) => (
+              <SectionCard
+                key={section.id}
+                section={section}
+                editedValues={editedValues}
+                onValueChange={handleValueChange}
+                defaultExpanded={index < 3}
+              />
+            ))}
 
-          {filteredSections.length === 0 && (
-            <div className="text-muted-foreground py-12 text-center">
-              <Search className="mx-auto mb-3 h-10 w-10 opacity-50" />
-              <p className="text-base">No settings found</p>
-            </div>
-          )}
-        </div>
+            {filteredSections.length === 0 && (
+              <div className="text-muted-foreground py-12 text-center">
+                <Search className="mx-auto mb-3 h-10 w-10 opacity-50" />
+                <p className="text-base">No settings found</p>
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Floating Action Buttons */}

--- a/frontend/src/components/admin/RegistrationDatesConfig.test.tsx
+++ b/frontend/src/components/admin/RegistrationDatesConfig.test.tsx
@@ -53,12 +53,7 @@ const createWrapper = (year = 2026) => {
 }
 
 // Helper to build config records matching PocketBase shape
-const makeConfigRecord = (
-  year: number,
-  key: string,
-  value: string,
-  id = `rec_${year}_${key}`
-) => ({
+const makeConfigRecord = (year: number, key: string, value: string, id = `rec_${year}_${key}`) => ({
   id,
   category: 'registration',
   subcategory: String(year),
@@ -159,9 +154,12 @@ describe('RegistrationDatesConfig', () => {
     await user.click(saveButton)
 
     await waitFor(() => {
-      expect(mockUpdate).toHaveBeenCalledWith('existing_1', expect.objectContaining({
-        value: '2025-11-09',
-      }))
+      expect(mockUpdate).toHaveBeenCalledWith(
+        'existing_1',
+        expect.objectContaining({
+          value: '2025-11-09',
+        })
+      )
     })
   })
 

--- a/frontend/src/components/admin/RegistrationDatesConfig.tsx
+++ b/frontend/src/components/admin/RegistrationDatesConfig.tsx
@@ -1,0 +1,182 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { CalendarDays, Loader2, Save } from 'lucide-react'
+import toast from 'react-hot-toast'
+import { pb } from '../../lib/pocketbase'
+import { useCurrentYear } from '../../hooks/useCurrentYear'
+import { queryKeys, userDataOptions } from '../../utils/queryKeys'
+import type { ConfigRecord } from '../../types/pocketbase-types'
+
+interface RegDateConfig {
+  id: string | undefined
+  key: string
+  label: string
+  description: string
+  value: string
+}
+
+const REG_DATE_FIELDS: Omit<RegDateConfig, 'id' | 'value'>[] = [
+  {
+    key: 'priority_reg_date',
+    label: 'Priority Registration',
+    description: 'When priority/alumni registration opens',
+  },
+  {
+    key: 'early_reg_date',
+    label: 'Early Registration',
+    description: 'When early registration opens',
+  },
+  {
+    key: 'open_reg_date',
+    label: 'Open Registration',
+    description: 'When open/general registration opens',
+  },
+]
+
+function useRegistrationDates(year: number) {
+  return useQuery({
+    queryKey: queryKeys.registrationDatesConfig(year),
+    ...userDataOptions,
+    queryFn: async () => {
+      const records = await pb.collection('config').getFullList<ConfigRecord>({
+        filter: `category = "registration" && subcategory = "${year}"`,
+        sort: 'config_key',
+      })
+      return records
+    },
+  })
+}
+
+export function RegistrationDatesConfig() {
+  const { currentYear } = useCurrentYear()
+  const queryClient = useQueryClient()
+  const { data: configRecords, isLoading } = useRegistrationDates(currentYear)
+
+  const [dates, setDates] = useState<RegDateConfig[]>([])
+  const [isSaving, setIsSaving] = useState(false)
+
+  // Sync local state when data loads or year changes
+  const buildDatesFromRecords = useCallback((records: ConfigRecord[] | undefined) => {
+    return REG_DATE_FIELDS.map((field) => {
+      const existing = records?.find((r) => r.config_key === field.key)
+      return {
+        ...field,
+        id: existing?.id,
+        value: (existing?.value as string) ?? '',
+      }
+    })
+  }, [])
+
+  useEffect(() => {
+    setDates(buildDatesFromRecords(configRecords))
+  }, [configRecords, buildDatesFromRecords])
+
+  const handleDateChange = (key: string, value: string) => {
+    setDates((prev) => prev.map((d) => (d.key === key ? { ...d, value } : d)))
+  }
+
+  const handleSave = async () => {
+    setIsSaving(true)
+    try {
+      for (const date of dates) {
+        if (!date.value) continue
+
+        const payload = {
+          category: 'registration',
+          subcategory: String(currentYear),
+          config_key: date.key,
+          value: date.value,
+          metadata: {
+            business_category: 'registration',
+            component_type: 'date',
+            friendly_name: date.label,
+            source: 'default_config',
+          },
+          description: date.description,
+        }
+
+        if (date.id) {
+          await pb.collection('config').update(date.id, payload)
+        } else {
+          await pb.collection('config').create(payload)
+        }
+      }
+
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.registrationDatesConfig(currentYear),
+      })
+      toast.success('Registration dates saved')
+    } catch (error) {
+      toast.error(`Failed to save: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
+        <span className="text-muted-foreground ml-2 text-sm">Loading registration dates...</span>
+      </div>
+    )
+  }
+
+  const hasChanges = dates.some((d) => {
+    const original = configRecords?.find((r) => r.config_key === d.key)
+    const originalValue = (original?.value as string) ?? ''
+    return d.value !== originalValue
+  })
+
+  return (
+    <div className="border-border rounded-xl border p-4 sm:p-6">
+      <div className="mb-4 flex items-center gap-3">
+        <CalendarDays className="text-forest-600 dark:text-forest-400 h-5 w-5" />
+        <div>
+          <h3 className="text-base font-semibold">Registration Dates — {currentYear}</h3>
+          <p className="text-muted-foreground text-sm">
+            Set when each registration phase opens. Used for velocity analysis.
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        {dates.map((date) => (
+          <div key={date.key} className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-4">
+            <label htmlFor={date.key} className="text-sm font-medium sm:w-48">
+              {date.label}
+            </label>
+            <input
+              id={date.key}
+              type="date"
+              value={date.value}
+              onChange={(e) => handleDateChange(date.key, e.target.value)}
+              className="bg-muted/30 dark:bg-muted/50 border-border focus:border-forest-500 focus:ring-forest-500 rounded-lg border px-3 py-2 text-sm focus:ring-1 focus:outline-none"
+            />
+            <span className="text-muted-foreground text-xs">{date.description}</span>
+          </div>
+        ))}
+      </div>
+
+      {hasChanges && (
+        <div className="mt-4 flex justify-end">
+          <button
+            onClick={handleSave}
+            disabled={isSaving}
+            className="bg-forest-600 hover:bg-forest-700 flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-semibold text-white transition-colors"
+          >
+            {isSaving ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" /> Saving...
+              </>
+            ) : (
+              <>
+                <Save className="h-4 w-4" /> Save Dates
+              </>
+            )}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/admin/index.ts
+++ b/frontend/src/components/admin/index.ts
@@ -4,6 +4,7 @@
 export { SyncTab } from './SyncTab'
 export { SYNC_TYPES, YEAR_SYNC_TYPES, getYearSyncTypes } from './syncTypes'
 export { ConfigTab, CATEGORIES } from './ConfigTab'
+export { RegistrationDatesConfig } from './RegistrationDatesConfig'
 export { SectionCard, type SectionCardProps } from './SectionCard'
 export { ScaleGuideSidebar, type ScaleGuideSidebarProps } from './ScaleGuideSidebar'
 export {

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -156,6 +156,9 @@ export const queryKeys = {
       compareYear,
     ] as const,
 
+  // Registration Config (Tier 2 - user data)
+  registrationDatesConfig: (year: number) => ['registration-dates-config', year] as const,
+
   // Staff (Tier 1 - sync data)
   bunkStaff: (year: number) => ['bunk-staff', year] as const,
 


### PR DESCRIPTION
## Summary
- Add RegistrationDatesConfig component with date picker inputs for priority, early, and open registration phase dates per year
- Add Registration tab to Admin > Config page
- No seed data — staff enters dates manually per year going back to 2017

## Test plan
- [x] Frontend tests pass (7 new tests, 1486 total)
- [x] `go build` passes
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [ ] Manual: Navigate to Admin > Config > Registration tab
- [ ] Manual: Enter dates for a year, verify save/load