### PR TITLE
Sort waitlist drilldown by registration date

### DIFF
--- a/api/schemas/metrics.py
+++ b/api/schemas/metrics.py
@@ -634,6 +634,7 @@ class DrilldownAttendee(BaseModel):
     city: str | None = Field(None, description="City (parsed from address)")
     state: str | None = Field(None, description="State abbreviation (parsed from address)")
     years_at_camp: int | None = Field(None, description="Years at camp")
+    enrollment_date: str | None = Field(None, description="Enrollment date for waitlist ordering")
     session_name: str = Field(description="Session name")
     session_cm_id: int = Field(description="Session CampMinder ID")
     status: str = Field(description="Enrollment status")

--- a/api/services/drilldown_service.py
+++ b/api/services/drilldown_service.py
@@ -65,6 +65,12 @@ WAITLIST_BREAKDOWNS = frozenset(
 )
 
 
+def _get_str_attr(obj: Any, attr: str) -> str | None:
+    """Get a string attribute, returning None for empty/non-string values."""
+    val = getattr(obj, attr, None)
+    return val if isinstance(val, str) and val else None
+
+
 class DrilldownService:
     """Business logic for drilldown - fully testable with mocked repository."""
 
@@ -640,6 +646,7 @@ class DrilldownService:
                     city=getattr(person, "normalized_city", None) or city,
                     state=state,
                     years_at_camp=years_at_camp,
+                    enrollment_date=_get_str_attr(a, "enrollment_date"),
                     session_name=session_name,
                     session_cm_id=session_cm_id,
                     status=getattr(a, "status", "enrolled"),
@@ -708,10 +715,23 @@ class DrilldownService:
 
         effective_types = session_types or list(SUMMER_SESSION_TYPES)
 
-        history, enrolled_attendees = await asyncio.gather(
+        all_relevant_statuses = list(DECLINED_STATUSES) + ["enrolled", "waitlisted"]
+
+        history, enrolled_attendees, all_attendees = await asyncio.gather(
             self.repo.fetch_status_history(year, old_status="waitlisted", new_statuses=new_statuses),
             self.repo.fetch_attendees(year, ["enrolled"]),
+            self.repo.fetch_attendees(year, all_relevant_statuses),
         )
+
+        # Build person_id -> earliest enrollment_date lookup
+        enrollment_date_lookup: dict[int, str] = {}
+        for att in all_attendees:
+            pid = getattr(att, "person_id", None)
+            edate = _get_str_attr(att, "enrollment_date")
+            if pid is not None and edate:
+                pid_int = int(pid)
+                if pid_int not in enrollment_date_lookup or edate < enrollment_date_lookup[pid_int]:
+                    enrollment_date_lookup[pid_int] = edate
 
         # Build enrolled groups for enrolled_sessions population
         enrolled_attendee_groups: dict[int, list[Any]] = {}
@@ -780,6 +800,7 @@ class DrilldownService:
                     city=getattr(person, "normalized_city", None) or city,
                     state=state,
                     years_at_camp=years_at_camp,
+                    enrollment_date=enrollment_date_lookup.get(pid),
                     session_name=session_name,
                     session_cm_id=session_cmid,
                     status=getattr(record, "new_status", "unknown"),

--- a/frontend/src/components/metrics/DrillDownModal.tsx
+++ b/frontend/src/components/metrics/DrillDownModal.tsx
@@ -78,6 +78,7 @@ type SortField =
   | 'years'
   | 'enrolled'
   | 'enrolled_current'
+  | 'registration'
 type SortDirection = 'asc' | 'desc'
 
 export function DrillDownModal({
@@ -88,12 +89,14 @@ export function DrillDownModal({
   statusFilter,
   onClose,
 }: DrillDownModalProps) {
-  const [searchTerm, setSearchTerm] = useState('')
-  const [sortField, setSortField] = useState<SortField>('name')
-  const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
-
   const isWaitlistDrilldown =
     (filter?.type?.startsWith('waitlist_') || filter?.waitlistContext) ?? false
+
+  const [searchTerm, setSearchTerm] = useState('')
+  const [sortField, setSortField] = useState<SortField>(
+    isWaitlistDrilldown ? 'registration' : 'name'
+  )
+  const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
   const isRetentionDrilldown = !!filter?.retentionContext
 
   const {
@@ -187,8 +190,18 @@ export function DrillDownModal({
           aVal = getEnrolledDisplay(a).toLowerCase()
           bVal = getEnrolledDisplay(b).toLowerCase()
           break
+        case 'registration':
+          aVal = a.enrollment_date ?? ''
+          bVal = b.enrollment_date ?? ''
+          break
       }
 
+      // Nulls/empty last for registration sort
+      if (sortField === 'registration') {
+        if (!aVal && bVal) return 1
+        if (aVal && !bVal) return -1
+      }
+      if (aVal == null || bVal == null) return 0
       if (aVal < bVal) return sortDirection === 'asc' ? -1 : 1
       if (aVal > bVal) return sortDirection === 'asc' ? 1 : -1
       return 0
@@ -218,6 +231,7 @@ export function DrillDownModal({
           'State',
           'Waitlisted For',
           'Enrolled In',
+          'Registered',
           'Years at Camp',
           'Status',
           'Returning',
@@ -266,6 +280,7 @@ export function DrillDownModal({
             a.state ?? '',
             getSessionDisplay(a),
             getEnrolledDisplay(a),
+            a.enrollment_date ? new Date(a.enrollment_date).toLocaleDateString() : '',
             a.years_at_camp ?? '',
             a.status,
             a.is_returning ? 'Yes' : 'No',
@@ -454,6 +469,16 @@ export function DrillDownModal({
                     </div>
                   </th>
                 )}
+                {isWaitlistDrilldown && (
+                  <th
+                    onClick={() => handleSort('registration')}
+                    className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-left font-medium"
+                  >
+                    <div className="flex items-center gap-1">
+                      Registered <SortIcon field="registration" />
+                    </div>
+                  </th>
+                )}
                 {isRetentionDrilldown && (
                   <th
                     onClick={() => handleSort('enrolled_current')}
@@ -559,6 +584,13 @@ export function DrillDownModal({
                         title={getEnrolledDisplay(attendee)}
                       >
                         {getEnrolledDisplay(attendee)}
+                      </td>
+                    )}
+                    {isWaitlistDrilldown && (
+                      <td className="text-foreground px-4 py-3 whitespace-nowrap">
+                        {attendee.enrollment_date
+                          ? new Date(attendee.enrollment_date).toLocaleDateString()
+                          : '—'}
                       </td>
                     )}
                     {isRetentionDrilldown && (

--- a/frontend/src/types/metrics.ts
+++ b/frontend/src/types/metrics.ts
@@ -420,6 +420,7 @@ export interface DrilldownAttendee {
   city?: string
   state?: string
   years_at_camp?: number
+  enrollment_date?: string
   session_name: string
   session_cm_id: number
   status: string

--- a/tests/unit/api/test_drilldown_service.py
+++ b/tests/unit/api/test_drilldown_service.py
@@ -3838,9 +3838,7 @@ class TestEnrollmentDatePopulation:
 
         # Status history: Emma was waitlisted, then accepted (enrolled)
         history = [
-            create_mock_status_history(
-                101, session1, persons[101], old_status="waitlisted", new_status="enrolled"
-            ),
+            create_mock_status_history(101, session1, persons[101], old_status="waitlisted", new_status="enrolled"),
         ]
 
         # Attendee record with enrollment_date
@@ -3879,9 +3877,7 @@ class TestEnrollmentDatePopulation:
 
         # Status history: Liam was waitlisted, then cancelled
         history = [
-            create_mock_status_history(
-                102, session1, persons[102], old_status="waitlisted", new_status="cancelled"
-            ),
+            create_mock_status_history(102, session1, persons[102], old_status="waitlisted", new_status="cancelled"),
         ]
 
         # Attendee record with enrollment_date
@@ -3919,9 +3915,7 @@ class TestEnrollmentDatePopulation:
         session1 = sessions[1001]
 
         history = [
-            create_mock_status_history(
-                103, session1, persons[103], old_status="waitlisted", new_status="enrolled"
-            ),
+            create_mock_status_history(103, session1, persons[103], old_status="waitlisted", new_status="enrolled"),
         ]
 
         mock_repository.fetch_sessions.return_value = sessions
@@ -3958,9 +3952,7 @@ class TestEnrollmentDatePopulation:
         session2 = sessions[1002]
 
         history = [
-            create_mock_status_history(
-                101, session1, persons[101], old_status="waitlisted", new_status="enrolled"
-            ),
+            create_mock_status_history(101, session1, persons[101], old_status="waitlisted", new_status="enrolled"),
         ]
 
         # Two attendee records with different enrollment dates


### PR DESCRIPTION
## Summary
- Add `enrollment_date` field to `DrilldownAttendee` schema and populate it from attendee records in both standard and UC3/UC4 waitlist history paths
- Waitlist drilldown modals now default-sort by registration date (earliest first) with a visible "Registered" column
- Registration date included in CSV export for waitlist drilldowns
- Non-waitlist drilldowns keep their existing name-based default sort

## Test plan
- [x] `uv run pytest tests/unit/api/test_drilldown_service.py` — 88 tests pass (7 new)
- [x] `npx tsc --noEmit` — no errors
- [x] `npm run lint` — 0 errors (reduced warnings from 26→22)
- [ ] Open a waitlist drilldown modal — campers sorted by registration date (earliest first)
- [ ] Click "Registered" column header to toggle sort direction
- [ ] Download CSV — includes "Registered" column
- [ ] Open a non-waitlist drilldown — still defaults to name sort, no "Registered" column