### PR TITLE
ci(ci): enforce conventional commit format on PR titles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,55 @@ jobs:
           fi
         fi
 
+  # Validate PR title follows conventional commit format
+  # This is the actual gate that matters since squash merge uses the PR title
+  pr-title-lint:
+    name: PR Title Lint
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+    - uses: amannn/action-semantic-pull-request@v5
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        types: |
+          feat
+          fix
+          perf
+          refactor
+          docs
+          style
+          test
+          build
+          config
+          chore
+          ci
+          revert
+        scopes: |
+          frontend
+          api
+          sync
+          pb
+          solver
+          docker
+          ci
+          auth
+          google
+          security
+          logging
+          release
+          config
+          deps
+          tests
+          scripts
+          docs
+          metrics
+          graph
+          data
+        requireScope: true
+        subjectPattern: ^.+$
+        subjectPatternError: "PR title must follow: type(scope): description"
+
   # Detect what changed to optimize CI runs
   detect-changes:
     name: Detect Changed Files
@@ -500,15 +549,21 @@ jobs:
   # Summary job - gate for PR merges
   summary:
     name: CI Summary
-    needs: [commit-lint, detect-changes, secret-scan, python-lint, go-lint, frontend-lint, docker-lint, tests, dependency-submission]
+    needs: [commit-lint, pr-title-lint, detect-changes, secret-scan, python-lint, go-lint, frontend-lint, docker-lint, tests, dependency-submission]
     if: always()
     runs-on: ubuntu-latest
     steps:
     - name: Check status
       run: |
-        # commit-lint: advisory only — still runs as a visible check but doesn't block merges/CD
+        # commit-lint: blocking — non-conventional commits break changelog generation
         if [ "${{ needs.commit-lint.result }}" != "success" ] && [ "${{ needs.commit-lint.result }}" != "skipped" ]; then
-          echo "::warning::Commit message format issue detected. Use: type(scope): description"
+          echo "::error::Commit message format issue detected. Use: type(scope): description"
+          exit 1
+        fi
+        # pr-title-lint: blocking — squash merge uses PR title as commit message on main
+        if [ "${{ needs.pr-title-lint.result }}" != "success" ] && [ "${{ needs.pr-title-lint.result }}" != "skipped" ]; then
+          echo "::error::PR title must follow conventional commit format: type(scope): description"
+          exit 1
         fi
         if [ "${{ needs.secret-scan.result }}" != "success" ]; then
           echo "❌ Secret scanning failed! Check for leaked credentials."

--- a/cliff.toml
+++ b/cliff.toml
@@ -15,7 +15,7 @@ repo = "kindred"
 
 [git]
 conventional_commits = true
-filter_unconventional = true
+filter_unconventional = false
 # Parser order matters - first match wins.
 # Include all conventional commits - works for squash merge, rebase merge, and direct commits.
 commit_parsers = [
@@ -39,6 +39,10 @@ commit_parsers = [
     # Always skip these
     { message = "^chore", skip = true },
     { message = "^ci", skip = true },
+
+    # Catch-all for non-conventional commits (safety net so they appear under "Other"
+    # instead of being silently dropped from changelog)
+    { message = ".*", group = "Other" },
 ]
 tag_pattern = "v[0-9].*"
 


### PR DESCRIPTION
## Summary
- Add PR title validation job using `amannn/action-semantic-pull-request` — validates PR titles against the same conventional commit types/scopes we use for branch commits. This is the real gate since squash merge uses the PR title as the commit message on main.
- Make `commit-lint` blocking again in CI Summary (was advisory-only, letting non-conventional commits slip through)
- Add catch-all parser in `cliff.toml` so non-conventional commits already on main appear under "Other" in the next changelog instead of being silently dropped

## Context
14 of the last 20 merged PRs have non-conventional titles. Since we squash merge, those PR titles became the commit messages on main and will be excluded from the next `release.sh` changelog (`filter_unconventional = true` was dropping them silently). The cliff.toml catch-all ensures those 14 commits show up under "Other" in the next release notes.

## Test plan
- [ ] This PR's own CI run validates the new `pr-title-lint` job works (it should pass since the title follows `type(scope): description`)
- [ ] Verify `commit-lint` and `pr-title-lint` both appear in the CI Summary `needs` array
- [ ] Run `npx git-cliff@latest --unreleased` locally to confirm previously-dropped commits now appear under "Other"