### PR TITLE
ci(ci): replace release.sh with GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version override (leave empty for auto-bump from git-cliff)'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.RELEASE_TOKEN }}
+
+    - uses: kenji-miyake/setup-git-cliff@v2
+
+    - name: Calculate version
+      id: version
+      run: |
+        # Get last tag
+        LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+        if [ -n "${{ inputs.version }}" ]; then
+          # Custom version — normalize v prefix
+          VER="${{ inputs.version }}"
+          [[ "$VER" != v* ]] && VER="v$VER"
+        else
+          # Auto-bump via git-cliff
+          VER=$(git cliff --bumped-version 2>/dev/null | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          [[ -z "$VER" ]] && { echo "::error::git-cliff could not determine version"; exit 1; }
+          [[ "$VER" != v* ]] && VER="v$VER"
+        fi
+
+        # Check tag doesn't already exist
+        if git rev-parse "$VER" &>/dev/null; then
+          echo "::error::Tag $VER already exists"
+          exit 1
+        fi
+
+        # Check for release-worthy commits (skip if only docs/test/refactor)
+        if [ -z "${{ inputs.version }}" ]; then
+          RANGE="${LAST_TAG:+$LAST_TAG..HEAD}"
+          RANGE="${RANGE:-HEAD}"
+          WORTHY=$(git log $RANGE --oneline | grep -cE '^[a-f0-9]+ (feat|fix|perf)(\(.+\))?(!)?:' || true)
+          if [ "$WORTHY" -eq 0 ]; then
+            echo "::error::No release-worthy commits (feat/fix/perf) since $LAST_TAG. Use version override to force."
+            exit 1
+          fi
+        fi
+
+        echo "version=$VER" >> "$GITHUB_OUTPUT"
+        echo "### Version: $VER" >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Generate changelog
+      id: changelog
+      run: |
+        git cliff --latest --strip header > RELEASE_NOTES.md
+        echo "### Release Notes" >> "$GITHUB_STEP_SUMMARY"
+        echo '```' >> "$GITHUB_STEP_SUMMARY"
+        cat RELEASE_NOTES.md >> "$GITHUB_STEP_SUMMARY"
+        echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Create tag and release
+      env:
+        GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      run: |
+        VERSION="${{ steps.version.outputs.version }}"
+
+        # Create annotated tag
+        git tag -a "$VERSION" -m "$(cat RELEASE_NOTES.md)"
+        git push origin "$VERSION"
+
+        # Create GitHub release
+        gh release create "$VERSION" --title "$VERSION" --notes-file RELEASE_NOTES.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -775,10 +775,13 @@ cd frontend && npm run lint    # Frontend linting
 ### Version Tags
 - Semantic versioning: `v0.1.0`, `v0.2.0`, `v1.0.0`
 - Only `v*` tags trigger CD workflow
-- Deploy: `git tag -a v0.1.1 -m "message" && git push --tags`
 
 ### Release Workflow
-Use `./scripts/release.sh` to create releases (run `--help` for options). Uses git-cliff for changelog generation.
+Release via GitHub Actions: **Actions → Release → Run workflow**. Leave version empty for auto-bump (git-cliff), or enter a version to override. The workflow creates the tag and GitHub release, which triggers CD automatically.
+
+Requires `RELEASE_TOKEN` repo secret (fine-grained PAT with `contents: write`).
+
+`scripts/release.sh` is retained for re-releases only.
 
 ### GitHub Repository Rules (Branch Protection)
 
@@ -801,7 +804,7 @@ The `main` branch is protected by a GitHub **Ruleset** (not legacy branch protec
 2. Push and create PR: `gh pr create`
 3. Wait for CI to pass
 4. Merge via GitHub UI (squash merge)
-5. Create release tag: `./scripts/release.sh --version X.Y.Z`
+5. GitHub → Actions → Release → Run workflow (auto-bump or enter version)
 
 ## 🚨 CRITICAL: Test-Driven Development (TDD) Requirements
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-# Release orchestration script for kindred project
+# DEPRECATED: Use the GitHub Actions "Release" workflow instead.
+# GitHub → Actions → Release → Run workflow
+#
+# This script is retained for re-releases and edge cases only.
 # Uses git-cliff for changelog generation and semver recommendations
 
 set -e


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` release workflow that auto-bumps version via git-cliff, creates annotated tag, and publishes GitHub release
- Uses `RELEASE_TOKEN` PAT so tag push triggers CD naturally (zero changes to CD workflow)
- Deprecates `scripts/release.sh` (retained for re-releases only)
- Updates CLAUDE.md release documentation

## Test plan
- [ ] Verify workflow appears in Actions tab
- [ ] Trigger with version override on test branch to validate end-to-end
- [ ] Confirm tag push triggers CD workflow
- [ ] Confirm GitHub release created with correct changelog