### PR TITLE
fix(ci): configure git identity for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,11 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.RELEASE_TOKEN }}
 
+    - name: Configure git identity
+      run: |
+        git config user.name "adamflagg"
+        git config user.email "115844481+adamflagg@users.noreply.github.com"
+
     - uses: kenji-miyake/setup-git-cliff@v2
 
     - name: Calculate version


### PR DESCRIPTION
## Summary
- Configures git user.name/email on the Actions runner so annotated tag creation succeeds
- Uses the PAT owner's GitHub identity

## Test plan
- [ ] Trigger Release workflow after merge and confirm tag + release created successfully