### PR TITLE
fix(ci): use --unreleased flag for release notes generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Generate changelog
       id: changelog
       run: |
-        git cliff --latest --strip header > RELEASE_NOTES.md
+        git cliff --unreleased --strip header > RELEASE_NOTES.md
         echo "### Release Notes" >> "$GITHUB_STEP_SUMMARY"
         echo '```' >> "$GITHUB_STEP_SUMMARY"
         cat RELEASE_NOTES.md >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Fix `git cliff --latest` → `git cliff --unreleased` in release workflow
- `--latest` generates changelog for the most recent existing tag, not unreleased commits
- This caused v2.6.0's release to show v2.5.0's changelog instead

## Test plan
- [ ] Run Release workflow via GitHub Actions after merge
- [ ] Verify release notes contain commits since last tag, not the last tag's changelog