### PR TITLE
fix(frontend): unify metrics grid visual styling

### DIFF
--- a/frontend/src/components/metrics/SessionBunkHeatmap.tsx
+++ b/frontend/src/components/metrics/SessionBunkHeatmap.tsx
@@ -79,12 +79,12 @@ function BunkHeatmapTable({ title, sessions, bunks, lookup, bunkStaff }: BunkHea
 
   return (
     <div data-section>
-      <h4 className="text-muted-foreground mb-2 text-sm font-semibold">{title}</h4>
+      <h4 className="text-muted-foreground mb-3 text-sm font-semibold">{title}</h4>
       <div className="overflow-x-auto">
-        <table className="w-full border-collapse text-xs">
+        <table className="w-full border-separate border-spacing-0 text-xs">
           <thead>
             <tr>
-              <th className="bg-muted/50 text-muted-foreground sticky left-0 z-10 px-3 py-2 text-left font-medium" />
+              <th className="bg-muted text-muted-foreground sticky left-0 z-10 px-3 py-2 text-left font-medium" />
               {bunks.map((bunk) => (
                 <th key={bunk} className="text-muted-foreground px-2 py-2 text-center font-medium">
                   {bunk}
@@ -97,7 +97,7 @@ function BunkHeatmapTable({ title, sessions, bunks, lookup, bunkStaff }: BunkHea
               <tr key={session}>
                 <th
                   scope="row"
-                  className="bg-muted/50 text-foreground sticky left-0 z-10 px-3 py-2 text-left text-xs font-semibold whitespace-nowrap"
+                  className="bg-muted text-foreground border-border/50 sticky left-0 z-10 border px-3 py-2 text-left text-xs font-semibold whitespace-nowrap"
                 >
                   {session}
                 </th>
@@ -109,7 +109,7 @@ function BunkHeatmapTable({ title, sessions, bunks, lookup, bunkStaff }: BunkHea
                       <td
                         key={bunk}
                         role="cell"
-                        className="bg-muted/30 text-muted-foreground min-w-[2.5rem] px-2 py-2 text-center"
+                        className="bg-muted/30 text-muted-foreground border-border/50 min-w-[2.5rem] border px-2 py-2 text-center"
                       >
                         —
                       </td>
@@ -117,7 +117,7 @@ function BunkHeatmapTable({ title, sessions, bunks, lookup, bunkStaff }: BunkHea
                   }
                   const pct = Math.round(item.retention_rate * 100)
                   const cellClass = [
-                    'min-w-[2.5rem] px-2 py-2 text-center font-medium',
+                    'min-w-[2.5rem] border border-border/50 px-2 py-2 text-center font-medium',
                     getCellColor(item.retention_rate),
                     hasStaff ? 'cursor-help' : 'cursor-default',
                   ].join(' ')

--- a/frontend/src/pages/metrics/registration/SessionAvailability.tsx
+++ b/frontend/src/pages/metrics/registration/SessionAvailability.tsx
@@ -101,24 +101,24 @@ function AGSessionRow({ session }: { session: AGSessionAvailabilityData }) {
 function Legend() {
   return (
     <div className="mt-4 flex items-center gap-3 text-xs">
-      <div className="flex items-center gap-2">
-        <div className="border-border/50 h-5 w-5 rounded border bg-emerald-100 dark:bg-emerald-900/40" />
-        <span>Open Space</span>
-      </div>
-      <div className="flex items-center gap-2">
-        <div className="border-border/50 h-5 w-5 rounded border bg-amber-200 dark:bg-amber-800/50" />
-        <span>Limited Space</span>
-      </div>
-      <div className="flex items-center gap-2">
-        <div className="border-border/50 flex h-5 w-5 items-center justify-center rounded border bg-red-200 text-[10px] font-bold dark:bg-red-900/50">
+      <span className="flex items-center gap-1">
+        <span className="border-border/50 h-5 w-5 rounded border bg-emerald-100 dark:bg-emerald-900/40" />
+        Open Space
+      </span>
+      <span className="flex items-center gap-1">
+        <span className="border-border/50 h-5 w-5 rounded border bg-amber-200 dark:bg-amber-800/50" />
+        Limited Space
+      </span>
+      <span className="flex items-center gap-1">
+        <span className="border-border/50 flex h-5 w-5 items-center justify-center rounded border bg-red-200 text-[10px] font-bold dark:bg-red-900/50">
           WL
-        </div>
-        <span>Waitlist</span>
-      </div>
-      <div className="flex items-center gap-2">
-        <div className="border-border/50 h-5 w-5 rounded border bg-neutral-200 dark:bg-neutral-700" />
-        <span>N/A</span>
-      </div>
+        </span>
+        Waitlist
+      </span>
+      <span className="flex items-center gap-1">
+        <span className="border-border/50 h-5 w-5 rounded border bg-neutral-200 dark:bg-neutral-700" />
+        N/A
+      </span>
     </div>
   )
 }
@@ -126,7 +126,7 @@ function Legend() {
 function SessionsTable({ sessions }: { sessions: SessionAvailabilityData[] }) {
   return (
     <div className="overflow-x-auto">
-      <table className="w-full border-collapse text-xs">
+      <table className="w-full border-separate border-spacing-0 text-xs">
         <thead>
           <tr>
             <th
@@ -170,7 +170,7 @@ function SessionsTable({ sessions }: { sessions: SessionAvailabilityData[] }) {
         </thead>
         <tbody>
           {sessions.map((session) => (
-            <tr key={session.session_cm_id} className="border-border border-b last:border-b-0">
+            <tr key={session.session_cm_id}>
               <td className="bg-muted/50 text-foreground border-border sticky left-0 z-10 border-r px-3 py-2 text-xs font-semibold whitespace-nowrap">
                 {session.session_name}
               </td>
@@ -223,7 +223,7 @@ export default function SessionAvailability() {
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-lg font-semibold">Session Availability</h2>
+        <h2 className="text-foreground text-lg font-semibold">Session Availability</h2>
         <p className="text-muted-foreground text-sm">
           Grade-level availability by session and gender for {currentYear}
         </p>
@@ -237,11 +237,9 @@ export default function SessionAvailability() {
           {/* AG Sessions */}
           {ag_sessions.length > 0 && (
             <div>
-              <h3 className="text-muted-foreground mb-3 text-sm font-semibold uppercase">
-                AG Sessions
-              </h3>
+              <h4 className="text-muted-foreground mb-3 text-sm font-semibold">AG Sessions</h4>
               <div className="overflow-x-auto">
-                <table className="w-full border-collapse text-xs">
+                <table className="w-full border-separate border-spacing-0 text-xs">
                   <thead>
                     <tr>
                       <th className="bg-muted/50 text-muted-foreground border-border sticky left-0 z-10 border-r border-b px-3 py-2 text-left font-medium">
@@ -259,10 +257,7 @@ export default function SessionAvailability() {
                   </thead>
                   <tbody>
                     {ag_sessions.map((session) => (
-                      <tr
-                        key={session.session_cm_id}
-                        className="border-border border-b last:border-b-0"
-                      >
+                      <tr key={session.session_cm_id}>
                         <td className="bg-muted/50 text-foreground border-border sticky left-0 z-10 border-r px-3 py-2 text-xs font-semibold whitespace-nowrap">
                           {session.session_name}
                         </td>
@@ -278,7 +273,7 @@ export default function SessionAvailability() {
           {/* Quest sessions */}
           {questSessions.length > 0 && (
             <div>
-              <h3 className="text-muted-foreground mb-3 text-sm font-semibold uppercase">Quests</h3>
+              <h4 className="text-muted-foreground mb-3 text-sm font-semibold">Quests</h4>
               <SessionsTable sessions={questSessions} />
             </div>
           )}

--- a/frontend/src/pages/metrics/retention/BunkRetentionPage.tsx
+++ b/frontend/src/pages/metrics/retention/BunkRetentionPage.tsx
@@ -36,11 +36,11 @@ export default function BunkRetentionPage() {
       {/* Header */}
       <div className="flex items-start justify-between">
         <div>
-          <h1 className="text-foreground flex items-center gap-2 text-2xl font-bold">
-            <BedDouble className="text-primary h-6 w-6" />
+          <h2 className="text-foreground flex items-center gap-2 text-lg font-semibold">
+            <BedDouble className="text-primary h-5 w-5" />
             Returning Campers by {priorYear} Bunk
-          </h1>
-          <p className="text-muted-foreground mt-1">
+          </h2>
+          <p className="text-muted-foreground mt-1 text-sm">
             Percentage of campers from each bunk who returned to camp in any form
           </p>
         </div>

--- a/frontend/src/pages/metrics/retention/StaffCabinAnalysisPage.tsx
+++ b/frontend/src/pages/metrics/retention/StaffCabinAnalysisPage.tsx
@@ -157,11 +157,11 @@ export default function StaffCabinAnalysisPage() {
       {/* Header */}
       <div className="flex items-start justify-between">
         <div>
-          <h1 className="text-foreground flex items-center gap-2 text-2xl font-bold">
-            <Users className="text-primary h-6 w-6" />
+          <h2 className="text-foreground flex items-center gap-2 text-lg font-semibold">
+            <Users className="text-primary h-5 w-5" />
             Staff Cabin Analysis ({priorYear})
-          </h1>
-          <p className="text-muted-foreground mt-1">
+          </h2>
+          <p className="text-muted-foreground mt-1 text-sm">
             Retention rates by staff member across their cabin assignments
           </p>
         </div>
@@ -184,7 +184,7 @@ export default function StaffCabinAnalysisPage() {
         {() => (
           <div className="card-lodge p-4" data-tour="retention-staff-table">
             <div className="overflow-x-auto">
-              <table className="w-full border-collapse text-xs" role="table">
+              <table className="w-full border-separate border-spacing-0 text-xs" role="table">
                 <thead>
                   <tr>
                     <th
@@ -234,7 +234,7 @@ export default function StaffCabinAnalysisPage() {
                           return (
                             <td
                               key={session}
-                              className="bg-muted/30 text-muted-foreground min-w-[2.5rem] px-2 py-2 text-center"
+                              className="bg-muted/30 text-muted-foreground border-border/50 min-w-[2.5rem] border px-2 py-2 text-center"
                             >
                               ---
                             </td>
@@ -244,7 +244,7 @@ export default function StaffCabinAnalysisPage() {
                         return (
                           <td
                             key={session}
-                            className={`min-w-[2.5rem] cursor-help px-2 py-2 text-center ${getRetentionCellColor(data.retentionRate)}`}
+                            className={`border-border/50 min-w-[2.5rem] cursor-help border px-2 py-2 text-center ${getRetentionCellColor(data.retentionRate)}`}
                             onMouseEnter={(e) =>
                               handleMouseEnter(e, row.personId, session, data.bunkName)
                             }
@@ -259,7 +259,7 @@ export default function StaffCabinAnalysisPage() {
                         )
                       })}
                       <td
-                        className={`sticky right-0 z-10 cursor-help px-3 py-2 text-center font-bold ${getRetentionCellColor(row.overallRetention)}`}
+                        className={`border-border/50 sticky right-0 z-10 cursor-help border px-3 py-2 text-center font-bold ${getRetentionCellColor(row.overallRetention)}`}
                         onMouseEnter={(e) =>
                           handleMouseEnter(e, row.personId, '__overall__', 'Overall')
                         }


### PR DESCRIPTION
## Summary
- Shrink retention page headers (h1→h2) and descriptions (text-sm) to match availability
- Fix sub-section headers: h3→h4 removes serif font (Fraunces), drop uppercase for title case
- Switch all three metric tables to `border-separate border-spacing-0` so sticky row headers fully cover scrolling content (fixes border bleed-through on bunk heatmap)
- Make bunk heatmap sticky headers opaque (`bg-muted` instead of `bg-muted/50`)
- Normalize legend spacing in availability to match retention pattern

## Test plan
- [ ] Visual check: page headers same size across staff, bunk, and availability pages
- [ ] Visual check: sub-section labels (Boys/Girls/AG Cabins, AG Sessions, Quests) are sans-serif title case
- [ ] Visual check: horizontally scroll Girls Cabins on bunk retention — session names fully cover cells behind them
- [ ] Visual check: legend swatches render correctly on all three pages