### PR TITLE
fix(frontend): restructure forecast page totals logic

### DIFF
--- a/frontend/src/pages/metrics/registration/ForecastPage.test.tsx
+++ b/frontend/src/pages/metrics/registration/ForecastPage.test.tsx
@@ -136,8 +136,16 @@ describe('ForecastPage', () => {
   // ---------- section headings ----------
 
   it('shows section headings when both camp and quest sessions present', async () => {
-    const campSession = session({ session_cm_id: 1001, session_name: 'Session 1', session_type: 'main' })
-    const questSession = session({ session_cm_id: 2001, session_name: 'Teen Quests', session_type: 'quest' })
+    const campSession = session({
+      session_cm_id: 1001,
+      session_name: 'Session 1',
+      session_type: 'main',
+    })
+    const questSession = session({
+      session_cm_id: 2001,
+      session_name: 'Teen Quests',
+      session_type: 'quest',
+    })
     setupMockFetch(mockResponse([campSession, questSession]))
 
     renderWithProviders(<ForecastPage />)
@@ -149,7 +157,11 @@ describe('ForecastPage', () => {
   })
 
   it('hides section headings when only camp sessions present', async () => {
-    const campSession = session({ session_cm_id: 1001, session_name: 'Session 1', session_type: 'main' })
+    const campSession = session({
+      session_cm_id: 1001,
+      session_name: 'Session 1',
+      session_type: 'main',
+    })
     setupMockFetch(mockResponse([campSession]))
 
     renderWithProviders(<ForecastPage />)
@@ -163,7 +175,11 @@ describe('ForecastPage', () => {
   })
 
   it('hides section headings when only quest sessions present', async () => {
-    const questSession = session({ session_cm_id: 2001, session_name: 'Teen Quests', session_type: 'quest' })
+    const questSession = session({
+      session_cm_id: 2001,
+      session_name: 'Teen Quests',
+      session_type: 'quest',
+    })
     setupMockFetch(mockResponse([questSession]))
 
     renderWithProviders(<ForecastPage />)
@@ -183,7 +199,11 @@ describe('ForecastPage', () => {
   // ---------- empty sections ----------
 
   it('does not render a table for an empty section', async () => {
-    const campSession = session({ session_cm_id: 1001, session_name: 'Session 1', session_type: 'main' })
+    const campSession = session({
+      session_cm_id: 1001,
+      session_name: 'Session 1',
+      session_type: 'main',
+    })
     setupMockFetch(mockResponse([campSession]))
 
     renderWithProviders(<ForecastPage />)
@@ -200,8 +220,18 @@ describe('ForecastPage', () => {
   // ---------- section totals ----------
 
   it('shows section total when section has 2+ rows', async () => {
-    const s1 = session({ session_cm_id: 1001, session_name: 'Session 1', session_type: 'main', enrolled: 50 })
-    const s2 = session({ session_cm_id: 1002, session_name: 'Session 2', session_type: 'main', enrolled: 80 })
+    const s1 = session({
+      session_cm_id: 1001,
+      session_name: 'Session 1',
+      session_type: 'main',
+      enrolled: 50,
+    })
+    const s2 = session({
+      session_cm_id: 1002,
+      session_name: 'Session 2',
+      session_type: 'main',
+      enrolled: 80,
+    })
     setupMockFetch(mockResponse([s1, s2]))
 
     renderWithProviders(<ForecastPage />)
@@ -262,8 +292,18 @@ describe('ForecastPage', () => {
   // ---------- grand total ----------
 
   it('shows grand total when 2+ sections visible', async () => {
-    const campSession = session({ session_cm_id: 1001, session_name: 'Session 1', session_type: 'main', enrolled: 80 })
-    const questSession = session({ session_cm_id: 2001, session_name: 'Teen Quests', session_type: 'quest', enrolled: 20 })
+    const campSession = session({
+      session_cm_id: 1001,
+      session_name: 'Session 1',
+      session_type: 'main',
+      enrolled: 80,
+    })
+    const questSession = session({
+      session_cm_id: 2001,
+      session_name: 'Teen Quests',
+      session_type: 'quest',
+      enrolled: 20,
+    })
     setupMockFetch(mockResponse([campSession, questSession], { enrolled: 100 }))
 
     renderWithProviders(<ForecastPage />)
@@ -278,8 +318,18 @@ describe('ForecastPage', () => {
   })
 
   it('hides grand total when only 1 section visible', async () => {
-    const s1 = session({ session_cm_id: 1001, session_name: 'Session 1', session_type: 'main', enrolled: 50 })
-    const s2 = session({ session_cm_id: 1002, session_name: 'Session 2', session_type: 'main', enrolled: 80 })
+    const s1 = session({
+      session_cm_id: 1001,
+      session_name: 'Session 1',
+      session_type: 'main',
+      enrolled: 50,
+    })
+    const s2 = session({
+      session_cm_id: 1002,
+      session_name: 'Session 2',
+      session_type: 'main',
+      enrolled: 80,
+    })
     setupMockFetch(mockResponse([s1, s2], { enrolled: 130 }))
 
     renderWithProviders(<ForecastPage />)
@@ -298,8 +348,16 @@ describe('ForecastPage', () => {
       selectedSessionCmId: 1001,
     })
 
-    const campSession = session({ session_cm_id: 1001, session_name: 'Session 1', session_type: 'main' })
-    const questSession = session({ session_cm_id: 2001, session_name: 'Teen Quests', session_type: 'quest' })
+    const campSession = session({
+      session_cm_id: 1001,
+      session_name: 'Session 1',
+      session_type: 'main',
+    })
+    const questSession = session({
+      session_cm_id: 2001,
+      session_name: 'Teen Quests',
+      session_type: 'quest',
+    })
     setupMockFetch(mockResponse([campSession, questSession]))
 
     renderWithProviders(<ForecastPage />)

--- a/frontend/src/pages/metrics/registration/ForecastPage.tsx
+++ b/frontend/src/pages/metrics/registration/ForecastPage.tsx
@@ -10,6 +10,7 @@ import {
   sortSessionDataByCampThenQuest,
 } from '../../../utils/sessionUtils'
 import { shortenSessionName } from '../../../utils/sessionDisplay'
+import { buildForecastSections } from '../../../utils/forecastUtils'
 import type { SessionForecast } from '../../../types/forecast'
 
 function pctColor(pct: number | null): string {
@@ -192,6 +193,11 @@ export default function ForecastPage() {
 
   const { grand_total } = data
 
+  const sections = buildForecastSections(campSessions, questSessions)
+  const isSingleSession = selectedSessionCmId !== null
+  const showSectionHeadings = sections.length >= 2
+  const showGrandTotal = sections.length >= 2 && !isSingleSession
+
   return (
     <div className="space-y-6">
       <div>
@@ -245,36 +251,44 @@ export default function ForecastPage() {
         />
       </div>
 
-      {/* Camp sessions table (main + embedded + AG) */}
-      <div className="border-border overflow-x-auto rounded-xl border">
-        <table className="w-full border-collapse">
-          <ForecastTableHeader />
-          <tbody>
-            {campSessions.map((session) => (
-              <SessionRow key={session.session_cm_id} session={session} />
-            ))}
-          </tbody>
-          <tfoot>
-            <SessionRow session={grand_total} isTotal />
-          </tfoot>
-        </table>
-      </div>
-
-      {/* Quest sessions table */}
-      {questSessions.length > 0 && (
-        <>
-          <h3 className="text-muted-foreground text-sm font-semibold uppercase">Quests</h3>
-          <div className="border-border overflow-x-auto rounded-xl border">
-            <table className="w-full border-collapse">
-              <ForecastTableHeader />
-              <tbody>
-                {questSessions.map((session) => (
-                  <SessionRow key={session.session_cm_id} session={session} />
-                ))}
-              </tbody>
-            </table>
+      {/* Section tables */}
+      {sections.map((section) => {
+        const showSectionTotal = section.sessions.length >= 2 && !isSingleSession
+        return (
+          <div key={section.key}>
+            {showSectionHeadings && (
+              <h3 className="text-muted-foreground mb-2 text-sm font-semibold uppercase">
+                {section.label}
+              </h3>
+            )}
+            <div className="border-border overflow-x-auto rounded-xl border">
+              <table className="w-full border-collapse">
+                <ForecastTableHeader />
+                <tbody>
+                  {section.sessions.map((s) => (
+                    <SessionRow key={s.session_cm_id} session={s} />
+                  ))}
+                </tbody>
+                {showSectionTotal && (
+                  <tfoot>
+                    <SessionRow session={section.total} isTotal />
+                  </tfoot>
+                )}
+              </table>
+            </div>
           </div>
-        </>
+        )
+      })}
+
+      {/* Grand total (standalone row when 2+ sections visible) */}
+      {showGrandTotal && (
+        <div className="border-border overflow-x-auto rounded-xl border">
+          <table className="w-full border-collapse">
+            <tbody>
+              <SessionRow session={grand_total} isTotal />
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   )

--- a/frontend/src/utils/forecastUtils.test.ts
+++ b/frontend/src/utils/forecastUtils.test.ts
@@ -156,10 +156,7 @@ describe('computeSectionTotal', () => {
   })
 
   it('returns null for pct_of_goal when total goal is 0', () => {
-    const total = computeSectionTotal(
-      [session({ enrolled: 50, participant_goal: 0 })],
-      'Total'
-    )
+    const total = computeSectionTotal([session({ enrolled: 50, participant_goal: 0 })], 'Total')
     expect(total.pct_of_goal).toBeNull()
   })
 
@@ -170,10 +167,7 @@ describe('computeSectionTotal', () => {
 
   it('computes utilization_pct when capacity is available and > 0', () => {
     const total = computeSectionTotal(
-      [
-        session({ enrolled: 50, capacity: 60 }),
-        session({ enrolled: 40, capacity: 60 }),
-      ],
+      [session({ enrolled: 50, capacity: 60 }), session({ enrolled: 40, capacity: 60 })],
       'Total'
     )
     // 90 / 120 * 100 = 75.0
@@ -186,10 +180,7 @@ describe('computeSectionTotal', () => {
   })
 
   it('returns null for utilization_pct when total capacity is 0', () => {
-    const total = computeSectionTotal(
-      [session({ enrolled: 50, capacity: 0 })],
-      'Total'
-    )
+    const total = computeSectionTotal([session({ enrolled: 50, capacity: 0 })], 'Total')
     expect(total.utilization_pct).toBeNull()
   })
 

--- a/frontend/src/utils/forecastUtils.ts
+++ b/frontend/src/utils/forecastUtils.ts
@@ -15,10 +15,7 @@ export interface ForecastSection {
  *   return null if ALL sessions have null, otherwise sum treating null as 0
  * - derived fields (percentages, deltas) are computed from the aggregated totals
  */
-export function computeSectionTotal(
-  sessions: SessionForecast[],
-  label: string
-): SessionForecast {
+export function computeSectionTotal(sessions: SessionForecast[], label: string): SessionForecast {
   const totalEnrolled = sessions.reduce((sum, s) => sum + s.enrolled, 0)
   const totalWaitlisted = sessions.reduce((sum, s) => sum + s.waitlisted, 0)
 


### PR DESCRIPTION
## Summary
- Add `forecastUtils.ts` with `computeSectionTotal` and `buildForecastSections` for frontend-side section total computation
- Restructure ForecastPage to render sections dynamically instead of hardcoded camp/quest table blocks
- Section headings ("At Camp", "Quests") only appear when 2+ sections are visible
- Section totals shown only when section has 2+ rows and not in single-session view
- Grand total rendered as standalone row only when multiple sections are visible
- Summary cards continue using backend's `grand_total` (unchanged)

## Test plan
- [x] `forecastUtils` unit tests pass (39 tests)
- [x] `ForecastPage` component tests pass (11 tests)
- [x] Full frontend test suite passes (1738 tests)
- [x] Frontend build succeeds
- [ ] Manual: default view shows camp table with section total, no grand total
- [ ] Manual: "Quests" view shows quest table only
- [ ] Manual: "All Summer" shows both tables with section totals + grand total
- [ ] Manual: single session dropdown shows one row, no totals