### PR TITLE
fix(security): use IS_DOCKER instead of NODE_ENV for auth build guard

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -156,10 +156,10 @@ function transformBrandingHtml(): Plugin {
 // Build-time Defines
 // =============================================================================
 
-// Security: Block VITE_DISABLE_AUTH in production builds to prevent credential leakage
-if (process.env.VITE_DISABLE_AUTH === 'true' && process.env.NODE_ENV === 'production') {
+// Security: Block VITE_DISABLE_AUTH in Docker builds to prevent credential leakage
+if (process.env.VITE_DISABLE_AUTH === 'true' && process.env.IS_DOCKER === 'true') {
   throw new Error(
-    'SECURITY ERROR: VITE_DISABLE_AUTH=true is not allowed in production builds. ' +
+    'SECURITY ERROR: VITE_DISABLE_AUTH=true is not allowed in Docker builds. ' +
     'Admin credentials would be embedded in the JavaScript bundle.'
   )
 }


### PR DESCRIPTION
## Summary
- The VITE_DISABLE_AUTH build guard from #327 checked `NODE_ENV=production`, but Vite sets that for **all** builds including local dev — breaking `start_dev.sh` and worktree `new.sh`
- Changed condition to check `IS_DOCKER=true` instead, which only the Dockerfile sets
- Local dev builds work again; Docker production builds remain protected

## Test plan
- [x] `VITE_DISABLE_AUTH=true npm run build` succeeds (local dev)
- [x] `VITE_DISABLE_AUTH=true IS_DOCKER=true npm run build` errors with security message