### PR TITLE
docs(config): add metrics module architecture to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,8 +64,11 @@ Format: `type(scope): description` — Breaking changes: `feat(api)!: descriptio
 ./scripts/start_dev.sh                                    # Start all services
 curl -X POST "http://localhost:8090/api/custom/sync/run?year=2025&service=all" # Trigger sync
 uv run pytest tests/                                      # Python tests
+uv run pytest tests/path/test_file.py::test_name          # Single Python test
+uv run pytest tests/ -k "keyword"                         # Python tests by keyword
 cd pocketbase && go test ./...                            # Go tests
-cd frontend && npm run test                               # Frontend tests
+cd frontend && npx vitest run                             # Frontend tests (one-shot)
+cd frontend && npx vitest run src/path/file.test.ts       # Single frontend test
 ```
 
 Full reference: `/docs/reference/cli-commands.md`
@@ -352,6 +355,83 @@ Checklist:
 - [ ] Step/hint descriptions match current behavior
 - [ ] Bump `version` if steps changed (triggers re-play for returning users)
 
+## Metrics Module
+
+Analytics dashboard for camp enrollment, retention, and trends. Separate from the bunking/solver pipeline.
+
+### Architecture
+
+```
+Frontend Pages → React Query hooks → FastAPI Router → Domain Services → MetricsRepository → PocketBase
+```
+
+**Backend** (`api/`):
+- **Router**: `routers/metrics.py` — single router at `/api/metrics` with 10 endpoints
+- **Services**: One per metric domain, receive `MetricsRepository` via constructor injection
+- **Repository**: `services/metrics_repository.py` — all PocketBase access, returns dicts keyed by `cm_id`
+- **Schemas**: `schemas/metrics.py`, `schemas/velocity.py` — Pydantic response models
+
+| Service | Endpoint | Purpose |
+|---------|----------|---------|
+| `retention_service.py` | `/retention` | Two-year comparison, all demographic breakdowns |
+| `registration_service.py` | `/registration` | Single-year enrollment by gender, grade, session, demographics |
+| `velocity_service.py` | `/velocity` | Week-over-week enrollment curves with prior year overlay |
+| `forecast_service.py` | `/forecast` | Budget goals, capacity, revenue projections |
+| `cancellation_service.py` | `/cancellations` | Prior status + re-enrollment analysis |
+| `waitlist_service.py` | `/waitlist` | Four-category waitlist analysis |
+| `historical_service.py` | `/historical` | Multi-year trends (default 5 years) |
+| `retention_trends_service.py` | `/retention-trends` | 3-year retention transitions |
+| `drilldown_service.py` | `/drilldown` | Chart click-through to attendee lists |
+| `comparison_service.py` | `/comparison` | Year-over-year summary |
+| `session_availability_service.py` | (separate router) | Per-session capacity vs enrollment |
+
+**Shared utilities**: `breakdown_calculator.py` (generic retention/registration aggregation), `extractors.py` (demographic field extraction), `session_context.py` / `session_utils.py` (session type filtering)
+
+### Frontend (`frontend/src/pages/metrics/`)
+
+Three sections via `MetricsLayout.tsx` with sticky two-level navigation:
+
+| Section | Pages |
+|---------|-------|
+| **Registration** | RegistrationOverview, GeoAnalysis, WaitlistAnalysis, SessionAvailability, ForecastPage, CancellationAnalysis |
+| **Retention** | RetentionOverview, SessionFlowPage (Sankey), BunkRetentionPage (heatmap), StaffCabinAnalysisPage |
+| **Trends** | TrendsOverview (multi-year), VelocityPage, CancellationVelocityPage |
+
+**State management**: `MetricsSessionContext` uses URL search params (`session`, `view`, `compare`) for session filtering across all tabs. View modes: `sessions` (default, camp types), `quests`, `all`.
+
+**Hooks**: `hooks/useMetrics.ts` — one hook per endpoint (`useRetentionMetrics`, `useRegistrationMetrics`, `useVelocity`, etc.). All use React Query with `keepPreviousData` for smooth filter transitions.
+
+**Components**: `components/metrics/` — `MetricCard`, `BreakdownChart`, `RetentionRateBarChart`, `RetentionRateLineChart`, `DrilldownModal`, `ComparisonSummaryTable`, etc.
+
+### Key Data Dependencies
+
+| Metric | Source Tables |
+|--------|--------------|
+| Retention | `attendees` + `persons` + `bunk_assignments` + `camp_sessions` |
+| Registration | `attendees` + `persons` + `camper_history` + `bunk_plans` |
+| Velocity | `enrollment_snapshots` (fast path) or reconstructed from `attendees.enrollment_date` |
+| Waitlist/Cancellations | `attendee_status_history` + `attendees` |
+| Forecast | `attendees` + `bunk_plans` + `config` (budget goals, session fees) |
+
+### Metrics-Specific Patterns
+
+- **Parallel fetches**: Services use `asyncio.gather()` for all independent repository calls; repository uses `asyncio.to_thread()` for synchronous PocketBase SDK
+- **Batched queries**: Large person ID sets split into `BATCH_SIZE = 100` to avoid oversized PocketBase filter strings
+- **Session type constants**: `DISPLAY_SESSION_TYPES` (main, embedded, ag, quest), `BUNK_SESSION_TYPES` (main, embedded, ag — cabin heatmaps only), `SUMMER_PROGRAM_SESSION_TYPES` (counts toward years at camp)
+- **Aged-out logic**: Grade >= 10 excluded from retention base (no eligible session to return to)
+- **Demographics**: Use normalized fields when available (`normalized_school`, `normalized_city`, `normalized_congregation`), fall back to raw fields
+- **AG sessions**: Linked to parent via `parent_id`; metrics for AG fold into parent main session
+
+### Adding a New Metric
+
+1. Add Pydantic response model in `api/schemas/metrics.py`
+2. Create service in `api/services/` following existing pattern (constructor takes `MetricsRepository`)
+3. Add endpoint in `api/routers/metrics.py` with standard query params (`year`, `session_types`, `session_cm_id`)
+4. Add React Query hook in `frontend/src/hooks/useMetrics.ts`
+5. Create page in appropriate `frontend/src/pages/metrics/` subsection
+6. Register in `metricsNav.ts` for navigation
+7. Service tests: mock `MetricsRepository` with `AsyncMock`
+
 ## Configuration Locations
 
 | File | Purpose |
@@ -373,7 +453,7 @@ Format: `2026-01-06T14:05:52Z [source] LEVEL message key=value...`
 
 ## Important Development Notes
 
-1. **Language Versions** - Python 3.12+, Go 1.24+, TypeScript 5.8+/ES2022
+1. **Language Versions** - Python 3.12+, Go 1.24+, Node 22+, TypeScript 5.8+/ES2022
 2. **Use uv** - `uv sync` to install, `uv run <cmd>` to execute
 3. **CampMinder IDs** - All relationships use CM IDs, never PocketBase IDs
 4. **Sync order matters** - sessions → attendees → persons → bunks → plans → assignments → requests
@@ -391,6 +471,8 @@ Format: `2026-01-06T14:05:52Z [source] LEVEL message key=value...`
 16. **React Query keys** - Use centralized keys from `frontend/src/utils/queryKeys.ts`
 17. **Attendee filtering** - Solver uses `is_active = 1 AND status_id = 2` for active enrollees
 18. **Git hooks** - Run `./scripts/setup-git-hooks.sh` once; validates commits, blocks if behind origin
+19. **Python line length** - 120 chars (configured in `ruff.toml`), enforced by ruff format
+20. **Frontend tests** - Vitest (not Jest); `npm run test` for watch mode, `npx vitest run` for one-shot
 
 ## Session Types and Bunking Structure
 


### PR DESCRIPTION
## Summary
- Add comprehensive Metrics Module section to CLAUDE.md covering architecture, services, frontend pages, data dependencies, and patterns
- Add single-test commands for Python (pytest -k, ::test_name) and frontend (vitest run)
- Note Node 22+ requirement, Python 120-char line length, Vitest runner

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub