### PR TITLE
feat(metrics): frontend prefetching for instant tab switches

### DIFF
--- a/frontend/src/hooks/useMetricsPrefetch.test.ts
+++ b/frontend/src/hooks/useMetricsPrefetch.test.ts
@@ -80,7 +80,10 @@ describe('useMetricsPrefetch', () => {
     vi.clearAllMocks()
     // Make fetchWithAuth return a successful response by default
     mockFetchWithAuth.mockResolvedValue(
-      new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
     )
   })
 

--- a/frontend/src/hooks/useMetricsPrefetch.ts
+++ b/frontend/src/hooks/useMetricsPrefetch.ts
@@ -1,0 +1,77 @@
+/**
+ * Prefetches the 3 primary metrics tab datasets (registration, retention, historical)
+ * when the user enters the metrics section. This ensures tab switches are instant
+ * since data is already in the React Query cache.
+ *
+ * Called from MetricsLayout.tsx (inside MetricsSessionProvider).
+ * Query functions mirror those in useMetrics.ts.
+ */
+
+import { useEffect } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { useApiWithAuth } from './useApiWithAuth'
+import { useCurrentYear } from './useCurrentYear'
+import { useMetricsSession } from './useMetricsSession'
+import { queryKeys, syncDataOptions } from '../utils/queryKeys'
+
+export function useMetricsPrefetch() {
+  const queryClient = useQueryClient()
+  const { fetchWithAuth } = useApiWithAuth()
+  const { currentYear } = useCurrentYear()
+  const { sessionTypesParam, selectedSessionCmId } = useMetricsSession()
+
+  useEffect(() => {
+    if (currentYear <= 0) return
+
+    const sessionCmId = selectedSessionCmId ?? undefined
+
+    // Registration (mirrors useRegistrationMetrics in useMetrics.ts)
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.registration(currentYear, sessionTypesParam, 'enrolled', sessionCmId),
+      queryFn: async () => {
+        const params = new URLSearchParams({ year: currentYear.toString() })
+        if (sessionTypesParam) params.set('session_types', sessionTypesParam)
+        params.set('statuses', 'enrolled')
+        if (sessionCmId !== undefined) params.set('session_cm_id', sessionCmId.toString())
+        const response = await fetchWithAuth(`/api/metrics/registration?${params}`)
+        if (!response.ok) throw new Error('Failed to prefetch registration metrics')
+        return response.json()
+      },
+      ...syncDataOptions,
+    })
+
+    // Retention (mirrors useRetentionMetrics in useMetrics.ts)
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.retention(currentYear - 1, currentYear, sessionTypesParam, sessionCmId),
+      queryFn: async () => {
+        const params = new URLSearchParams({
+          base_year: (currentYear - 1).toString(),
+          compare_year: currentYear.toString(),
+        })
+        if (sessionTypesParam) params.set('session_types', sessionTypesParam)
+        if (sessionCmId !== undefined) params.set('session_cm_id', sessionCmId.toString())
+        const response = await fetchWithAuth(`/api/metrics/retention?${params}`)
+        if (!response.ok) throw new Error('Failed to prefetch retention metrics')
+        return response.json()
+      },
+      ...syncDataOptions,
+    })
+
+    // Historical (mirrors useHistoricalTrends in useMetrics.ts)
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.historical(undefined, sessionTypesParam, sessionCmId),
+      queryFn: async () => {
+        const params = new URLSearchParams()
+        if (sessionTypesParam) params.set('session_types', sessionTypesParam)
+        if (sessionCmId !== undefined) params.set('session_cm_id', sessionCmId.toString())
+        const url = params.toString()
+          ? `/api/metrics/historical?${params}`
+          : '/api/metrics/historical'
+        const response = await fetchWithAuth(url)
+        if (!response.ok) throw new Error('Failed to prefetch historical metrics')
+        return response.json()
+      },
+      ...syncDataOptions,
+    })
+  }, [currentYear, sessionTypesParam, selectedSessionCmId, queryClient, fetchWithAuth])
+}

--- a/frontend/src/pages/metrics/MetricsLayout.test.tsx
+++ b/frontend/src/pages/metrics/MetricsLayout.test.tsx
@@ -30,6 +30,14 @@ vi.mock('../../hooks/useMetricsSessions', () => ({
   })),
 }))
 
+// Mock useApiWithAuth for useMetricsPrefetch
+vi.mock('../../hooks/useApiWithAuth', () => ({
+  useApiWithAuth: () => ({
+    fetchWithAuth: vi.fn().mockResolvedValue(new Response('{}', { status: 200 })),
+    isAuthenticated: true,
+  }),
+}))
+
 const TestChild = ({ text }: { text: string }) => <div data-testid="child">{text}</div>
 
 const renderWithRouter = (initialPath: string, childText = 'Child Content') => {

--- a/frontend/src/pages/metrics/MetricsLayout.tsx
+++ b/frontend/src/pages/metrics/MetricsLayout.tsx
@@ -8,10 +8,22 @@ import MetricsTypeTabs from '../../components/metrics/MetricsTypeTabs'
 import MetricsSubNav from '../../components/metrics/MetricsSubNav'
 import type { SubNavItem } from '../../components/metrics/MetricsSubNav'
 import { MetricsSessionProvider } from '../../contexts/MetricsSessionContext'
+import { useMetricsPrefetch } from '../../hooks/useMetricsPrefetch'
 import { RETENTION_SUB_NAV, REGISTRATION_SUB_NAV, TRENDS_SUB_NAV } from './metricsNav'
 
 export default function MetricsLayout() {
+  return (
+    <MetricsSessionProvider>
+      <MetricsLayoutContent />
+    </MetricsSessionProvider>
+  )
+}
+
+function MetricsLayoutContent() {
   const location = useLocation()
+
+  // Prefetch primary tab datasets so tab switches are instant
+  useMetricsPrefetch()
 
   // Determine which sub-nav to show based on current section
   const getSubNavItems = (): SubNavItem[] => {
@@ -48,27 +60,25 @@ export default function MetricsLayout() {
   const header = getHeader()
 
   return (
-    <MetricsSessionProvider>
-      <div className="bg-background min-h-screen">
-        <div className="mx-auto max-w-7xl px-4 pt-4 pb-8 sm:px-6 lg:px-8">
-          {/* Header */}
-          <div className="mb-6">
-            <h1 className="text-foreground text-2xl font-bold">{header.title}</h1>
-            <p className="text-muted-foreground mt-1">{header.subtitle}</p>
-          </div>
+    <div className="bg-background min-h-screen">
+      <div className="mx-auto max-w-7xl px-4 pt-4 pb-8 sm:px-6 lg:px-8">
+        {/* Header */}
+        <div className="mb-6">
+          <h1 className="text-foreground text-2xl font-bold">{header.title}</h1>
+          <p className="text-muted-foreground mt-1">{header.subtitle}</p>
+        </div>
 
-          {/* Sticky Navigation */}
-          <div className="bg-background/95 sticky top-0 z-10 backdrop-blur-sm">
-            <MetricsTypeTabs />
-            {subNavItems.length > 0 && <MetricsSubNav items={subNavItems} />}
-          </div>
+        {/* Sticky Navigation */}
+        <div className="bg-background/95 sticky top-0 z-10 backdrop-blur-sm">
+          <MetricsTypeTabs />
+          {subNavItems.length > 0 && <MetricsSubNav items={subNavItems} />}
+        </div>
 
-          {/* Page Content */}
-          <div className="mt-6">
-            <Outlet />
-          </div>
+        {/* Page Content */}
+        <div className="mt-6">
+          <Outlet />
         </div>
       </div>
-    </MetricsSessionProvider>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- Adds `useMetricsPrefetch` hook that fires `queryClient.prefetchQuery()` for the 3 primary metrics tabs (registration, retention, historical) when entering the metrics section
- Tab switches are now instant since data is already in the React Query cache
- Re-prefetches when session filter, year, or view mode changes
- `MetricsLayout` extracts content to `MetricsLayoutContent` so the prefetch hook runs inside `MetricsSessionProvider` context

Tier 2 of metrics performance work (Tier 1: server-side cache in #344).

## Test plan
- [x] `useMetricsPrefetch.test.ts` — 6 tests covering mount behavior, year guard, session filter changes, query key correctness, and syncDataOptions usage
- [x] `MetricsLayout.test.tsx` — All 14 existing tests still pass with mock for `useApiWithAuth`
- [x] Full frontend test suite — 130 files, 1792 tests passing
- [ ] Manual: Open DevTools Network tab, navigate to `/metrics/registration`, observe 3 parallel prefetch requests
- [ ] Manual: Click Retention tab — should render instantly from cache
- [ ] Manual: Change session filter — observe new prefetch requests fire