### PR TITLE
chore(docs): gitignore docs/plans directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -299,6 +299,7 @@ CLAUDE.local.md
 scripts/vault.config
 frontend/vite.config.local.ts
 docs/camp
+docs/plans
 
 # Worktree-specific files
 start.sh


### PR DESCRIPTION
## Summary
- Adds `docs/plans/` to `.gitignore` to keep local planning documents out of version control

## Test plan
- [x] Verify `docs/plans/` files no longer show in `git status`