### PR TITLE
fix(docker): drop wget and procps to reduce CVE surface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ FROM python:3.14-slim
 # hadolint ignore=DL3008
 RUN groupadd -r -g 1000 kindred && useradd -r -g kindred -u 1000 kindred \
     && apt-get update && apt-get install -y --no-install-recommends \
-       curl wget supervisor procps \
+       curl supervisor \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /pb_data/bunk_requests /app/logs /app/csv_history /config \
                /app/.config/caddy /app/.local/share/caddy \

--- a/docker/combined-entrypoint.sh
+++ b/docker/combined-entrypoint.sh
@@ -40,7 +40,7 @@ if [ ! -f "/pb_data/.initialized" ]; then
     # Wait for PocketBase to be ready
     log_info "Waiting for PocketBase to start..."
     for i in $(seq 1 30); do
-        if wget -q --spider http://127.0.0.1:8091/api/health 2>/dev/null; then
+        if curl -sf http://127.0.0.1:8091/api/health >/dev/null 2>&1; then
             log_info "PocketBase is ready"
             break
         fi
@@ -73,7 +73,7 @@ if [ ! -f "/pb_data/.initialized" ]; then
         DISCOVERY_URL="${OIDC_ISSUER%/}/.well-known/openid-configuration"
         log_info "Discovering OIDC endpoints from: $DISCOVERY_URL"
 
-        DISCOVERY_RESPONSE=$(wget -q -O - "$DISCOVERY_URL" 2>/dev/null || echo "")
+        DISCOVERY_RESPONSE=$(curl -sf "$DISCOVERY_URL" 2>/dev/null || echo "")
 
         if [ -z "$DISCOVERY_RESPONSE" ]; then
             log_error "Failed to fetch OIDC discovery document from $DISCOVERY_URL"
@@ -99,8 +99,9 @@ if [ ! -f "/pb_data/.initialized" ]; then
         log_info "Discovered OIDC endpoints: auth=${OIDC_AUTH_URL} token=${OIDC_TOKEN_URL} userinfo=${OIDC_USERINFO_URL}"
 
         # Login as admin to get token
-        AUTH_RESPONSE=$(wget -q -O - --post-data "{\"identity\":\"${POCKETBASE_ADMIN_EMAIL}\",\"password\":\"${POCKETBASE_ADMIN_PASSWORD}\"}" \
-            --header="Content-Type: application/json" \
+        AUTH_RESPONSE=$(curl -s -X POST \
+            -H "Content-Type: application/json" \
+            -d "{\"identity\":\"${POCKETBASE_ADMIN_EMAIL}\",\"password\":\"${POCKETBASE_ADMIN_PASSWORD}\"}" \
             "http://127.0.0.1:8091/api/collections/_superusers/auth-with-password" 2>/dev/null || echo "")
 
         TOKEN=$(echo "$AUTH_RESPONSE" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
@@ -109,7 +110,7 @@ if [ ! -f "/pb_data/.initialized" ]; then
             # Build OAuth2 config JSON with discovered endpoints
             OAUTH_CONFIG="{\"oauth2\":{\"enabled\":true,\"providers\":[{\"name\":\"oidc\",\"displayName\":\"Pocket ID\",\"clientId\":\"${OIDC_CLIENT_ID}\",\"clientSecret\":\"${OIDC_CLIENT_SECRET}\",\"authURL\":\"${OIDC_AUTH_URL}\",\"tokenURL\":\"${OIDC_TOKEN_URL}\",\"userURL\":\"${OIDC_USERINFO_URL}\",\"pkce\":true,\"enabled\":true,\"scopes\":[\"openid\",\"email\",\"profile\"]}]}}"
 
-            # Update users collection with OAuth2 config (curl required - BusyBox wget doesn't support PATCH)
+            # Update users collection with OAuth2 config
             HTTP_CODE=$(curl -s -o /tmp/oauth_response.txt -w "%{http_code}" \
                 -X PATCH \
                 -H "Authorization: $TOKEN" \


### PR DESCRIPTION
## Summary

- Remove `wget` and `procps` from Dockerfile runtime `apt-get install` — neither is used at runtime
- Replace 3 `wget` calls in `combined-entrypoint.sh` with `curl` equivalents (health check, OIDC discovery, admin login)
- Remove stale comment about BusyBox wget not supporting PATCH

Eliminates ~15-25 transitive OS packages (GnuTLS, libnettle, libpsl, libidn2, libncurses, libproc2, libsystemd0, etc.) that are the source of the majority of Trivy code scanning alerts.

## Test plan

- [x] shellcheck passes on entrypoint
- [x] hadolint passes on Dockerfile
- [ ] Docker build succeeds without wget/procps
- [ ] Fresh container start exercises full first-run init path (health polling, admin creation)
- [ ] Container healthcheck passes post-build
- [ ] OIDC config path works with curl (if credentials available)