### PR TITLE
fix(ci): attribute Trivy SARIF to main branch and add weekly scan

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,10 @@
 name: CD - Build & Deploy Docker Images
 
 on:
+  # Weekly Trivy scan to catch new CVEs even without releases
+  schedule:
+    - cron: '0 6 * * 1'  # Every Monday at 6 AM UTC
+
   # Manual trigger - use dry_run to test without pushing
   workflow_dispatch:
     inputs:
@@ -133,7 +137,7 @@ jobs:
   verify-ci:
     name: Verify CI Passed
     needs: detect-changes
-    if: github.event_name != 'workflow_dispatch'
+    if: github.event_name != 'workflow_dispatch' && github.event_name != 'schedule'
     runs-on: ubuntu-latest
     permissions:
       checks: read
@@ -379,6 +383,7 @@ jobs:
         # Standard change detection for non-tag pushes or when image doesn't exist
         if [ "${{ matrix.changed }}" == "true" ] || \
            [ "${{ github.event_name }}" == "workflow_dispatch" ] || \
+           [ "${{ github.event_name }}" == "schedule" ] || \
            [[ "${{ github.ref }}" == refs/tags/* ]] || \
            [ "${{ needs.detect-changes.outputs.docker }}" == "true" ] || \
            [ "${{ needs.detect-changes.outputs.initial_commit }}" == "true" ]; then
@@ -645,6 +650,11 @@ jobs:
       uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: 'trivy-results-${{ matrix.image }}.sarif'
+        # Tag-push refs (refs/tags/v*) are invisible in GitHub's Security tab,
+        # which only shows results for the default branch (refs/heads/main).
+        # Override ref/sha so tag-triggered scans update the security tab.
+        ref: ${{ startsWith(github.ref, 'refs/tags/') && 'refs/heads/main' || github.ref }}
+        sha: ${{ github.sha }}
 
     # === Push to Registry (only if tests pass and not dry-run/PR) ===
     # Tag and push the already-built :test image instead of rebuilding (~3-5 min savings)


### PR DESCRIPTION
## Summary
- Override `ref` and `sha` on `upload-sarif` so tag-push scans are attributed to `refs/heads/main` instead of `refs/tags/v*`, making them visible in the GitHub Security tab
- Add weekly Monday 6 AM UTC cron schedule to catch new CVEs between releases
- Add `schedule` event to build-needed conditions and skip CI verification for cron runs

## Root cause
GitHub's Security tab only displays code scanning results for the default branch (`refs/heads/main`). When CD runs on tag pushes, `upload-sarif` defaults to `ref: refs/tags/v*`, which is invisible in the security tab. Last visible update was Feb 20.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, manually trigger CD with `dry_run: true` to verify SARIF uploads
- [ ] Check Security tab updates: `gh api repos/adamflagg/kindred/code-scanning/analyses --jq '.[0:3]'`
- [ ] Verify Monday schedule fires the following week