### PR TITLE
fix(frontend): link footer version to GitHub release

### DIFF
--- a/frontend/src/components/VersionInfo.tsx
+++ b/frontend/src/components/VersionInfo.tsx
@@ -6,8 +6,7 @@ interface VersionInfoProps {
 
 const GITHUB_REPO_URL = 'https://github.com/adamflagg/kindred'
 
-const getReleaseUrl = (version: string) =>
-  `${GITHUB_REPO_URL}/releases/tag/${version}`
+const getReleaseUrl = (version: string) => `${GITHUB_REPO_URL}/releases/tag/${version}`
 
 const GitHubIcon: FC<{ size?: number }> = ({ size = 14 }) => (
   <svg


### PR DESCRIPTION
## Summary
- Version text + GitHub icon in the footer now link to the specific release page (`/releases/tag/vX.Y.Z`) instead of the repo root
- Replaced deprecated `Github` import from lucide-react with inline SVG (brand icons being removed in lucide v1.0)

## Test plan
- [ ] Verify footer version link points to `/releases/tag/<version>` in production
- [ ] Verify GitHub icon renders identically to before