### PR TITLE
fix(pb): add OIDC groups scope to fix RBAC admin detection

### DIFF
--- a/pocketbase/main.go
+++ b/pocketbase/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/plugins/jsvm"
 	"github.com/pocketbase/pocketbase/plugins/migratecmd"
+	"github.com/pocketbase/pocketbase/tools/auth"
 	"github.com/pocketbase/pocketbase/tools/hook"
 
 	// Import our packages
@@ -22,6 +23,19 @@ import (
 	"github.com/camp/kindred/pocketbase/rbac"
 	"github.com/camp/kindred/pocketbase/sync"
 )
+
+func init() {
+	// Override the OIDC provider factories to include the "groups" scope.
+	// PocketBase's OAuth2ProviderConfig has no scopes field, so the only way
+	// to request additional scopes is to replace the provider factory.
+	for _, name := range []string{auth.NameOIDC, auth.NameOIDC + "2", auth.NameOIDC + "3"} {
+		auth.Providers[name] = func() auth.Provider {
+			p := auth.NewOIDCProvider()
+			p.SetScopes([]string{"openid", "email", "profile", "groups"})
+			return p
+		}
+	}
+}
 
 func main() {
 	// Initialize unified logging format

--- a/scripts/setup/configure_pocketbase_oauth.py
+++ b/scripts/setup/configure_pocketbase_oauth.py
@@ -197,7 +197,7 @@ def configure_oauth2(token: str, endpoints: dict[str, str]) -> bool:
                 "userURL": endpoints["userinfo_url"],
                 "pkce": True,
                 "enabled": True,
-                "scopes": ["openid", "email", "profile"],
+                "scopes": ["openid", "email", "profile", "groups"],
             }
         ],
     }


### PR DESCRIPTION
## Summary

- Override PocketBase OIDC provider factory to include `groups` scope — PB's `OAuth2ProviderConfig` has no `scopes` field, so scopes set via the API are silently dropped
- Update local dev OAuth config script to include `groups` scope for consistency

## Root Cause

PocketBase hardcodes OIDC scopes as `["openid", "email", "profile"]` in `NewOIDCProvider()`. The `OAuth2ProviderConfig` struct has no `scopes` field, so any scopes passed via the collection config API (including from the init container) are silently ignored. Without `groups`, Pocket ID never returns group membership in the userinfo/ID token, so the OIDC admin sync hook can't detect admin group membership → `is_admin` stays `false` → padlocks on Summer/Metrics.

## Fix

Override `auth.Providers["oidc"]` (and oidc2/oidc3) factory in `init()` to create providers with `groups` in the default scopes. This runs before any provider initialization.

## Test plan

- [x] Go build passes
- [x] RBAC unit tests pass
- [x] Pre-commit hooks pass (all 12 checks)
- [x] Verified locally: login now returns `groups` claim with correct group membership
- [x] Verified locally: `is_admin=true` set on user record after OIDC login
- [x] Verified locally: padlocks removed from Summer/Metrics pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth2/OIDC authentication now requests user group information from identity providers, enabling access to group membership data for enhanced access control and organizational user management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->