### PR TITLE
fix(ci): update Trivy to v0.69.3 — v0.62.1 has no release binaries

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -633,7 +633,7 @@ jobs:
       if: steps.check.outputs.build == 'true'
       run: |
         # Install Trivy CLI
-        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.62.1
+        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.69.3
         trivy version
 
         IMAGES=("kindred-caddy" "kindred-pocketbase" "kindred-api" "kindred-init")


### PR DESCRIPTION
## Summary

- **Trivy v0.62.1 has zero release assets** — the tag exists on GitHub but no binaries were published
- The install script finds the tag, tries to download, and exits 1
- This silently skips all security scans, SARIF files are never generated, and the upload steps fail with "Path does not exist"
- Updates to **v0.69.3** (latest stable with 47 release assets)

This broke CD on v3.0.2 (which has been deleted and will be re-released after this fix).

## Test plan
- [ ] CI passes
- [ ] CD dry-run: Trivy installs and scans complete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning tool version in the deployment pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->