### PR TITLE
feat(ci): enable continuous delivery on every merge to main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,9 +31,10 @@ on:
       - 'docker-compose*.yml'
       - '.github/workflows/cd.yml'
 
-  # On version tags only (semver pattern)
-  # Use: git tag -a v0.1.0 -m "Release message" && git push --tags
+  # Continuous delivery: build and push on every merge to main
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 
@@ -133,8 +134,9 @@ jobs:
             - 'docker-compose*.yml'
             - '.dockerignore'
 
-  # Verify CI and docs checks passed for tag pushes
-  # This reuses results from the branch push - no duplicate runs
+  # Verify CI passed before building/pushing images
+  # For branch pushes: CI runs concurrently, this polls until it completes
+  # For tag pushes: reuses CI results from the branch push
   verify-ci:
     name: Verify CI Passed
     needs: detect-changes
@@ -742,7 +744,7 @@ jobs:
         else
           echo "Dry-run mode - images built and tested but NOT pushed"
         fi
-        echo "   To push, trigger manually without dry_run or create a release tag"
+        echo "   To push, trigger manually without dry_run or merge to main"
 
   # Summary job
   summary:
@@ -773,7 +775,7 @@ jobs:
           echo "- Integration tests passed (multi-container stack)"
           echo "- Security scan completed"
           echo ""
-          echo "Images will be pushed when this PR merges and a release is created."
+          echo "Images will be pushed when this PR merges to main."
         elif [ "$DRY_RUN" == "true" ]; then
           echo "CD dry-run passed (no push)"
           echo ""
@@ -782,7 +784,7 @@ jobs:
           echo "- Integration tests passed (multi-container stack)"
           echo "- Security scan completed"
           echo ""
-          echo "To push, run again without dry_run or create a release tag."
+          echo "To push, run again without dry_run or merge to main."
         else
           echo "All CD checks passed successfully!"
           echo ""


### PR DESCRIPTION
## Summary
- CD now triggers on every push to `main`, building and pushing `:latest` images to GHCR automatically
- Version tags (`v*`) still trigger CD with semver Docker tags for milestone releases
- Updated comments and user-facing messages to reflect delivery decoupled from releases

## What changes
| Before | After |
|--------|-------|
| CD only runs on `v*` tags | CD runs on every merge to main + tags |
| Must create a release to push images | Images push automatically on merge |
| Tags = deployment gate | Tags = optional milestone markers |

## What doesn't change
- Change detection still skips builds for docs-only/CI-only changes
- `verify-ci` still ensures CI passes before building
- PR dry-run validation still works
- Trivy scanning, integration tests, distroless checks all unchanged
- `create-release` job still runs on tags for changelogs

## Test plan
- [ ] Merge this PR and verify CD triggers automatically
- [ ] Verify `:latest` images are pushed to GHCR
- [ ] Verify docs-only PRs don't trigger a build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous delivery workflow to enable automatic deployments on merges to the main branch.
  * Refined deployment verification process to optimize CI resource utilization based on deployment trigger type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->