### PR TITLE
fix(rbac): allow admins to assign roles to any user

### DIFF
--- a/frontend/src/components/Users.tsx
+++ b/frontend/src/components/Users.tsx
@@ -50,7 +50,7 @@ export default function Users() {
     queryKey: queryKeys.users(),
     queryFn: async () => {
       const result = await pb.collection('users').getList<RecordModel>(1, 1000, {
-        sort: '-created',
+        sort: 'name',
         requestKey: null,
       })
       return result.items
@@ -199,7 +199,7 @@ export default function Users() {
             <div className="bg-card border-border divide-border divide-y overflow-hidden rounded-xl border shadow-sm">
               {users.map((user, index) => {
                 const userRoleBadges = getRoleBadges(user.id)
-                const isAdmin = Boolean(user['is_admin'])
+                const userIsAdmin = Boolean(user['is_admin'])
                 const email = (user['email'] as string) || ''
                 const name = (user['name'] as string) || ''
                 const avatar = user['avatar'] as string | undefined
@@ -239,7 +239,7 @@ export default function Users() {
                           <span className="text-foreground truncate text-sm font-medium sm:text-base">
                             {name || email.split('@')[0]}
                           </span>
-                          {isAdmin && (
+                          {userIsAdmin && (
                             <span className="rounded-md bg-purple-100 px-1.5 py-0.5 text-xs font-medium text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">
                               Admin
                             </span>


### PR DESCRIPTION
## Summary
- **Fix variable shadowing bug**: `isAdmin` from `usePermissions()` was shadowed by a local `const isAdmin = Boolean(user['is_admin'])` inside the user list map callback — admins could only click users who were already admins (i.e., themselves)
- **Sort users by name** instead of creation date for easier lookup

## Test plan
- [ ] Log in as admin, go to System Access → Users tab
- [ ] Verify users are sorted alphabetically by name
- [ ] Click a non-admin user — roles panel should open
- [ ] Toggle a role on/off and verify it persists