### PR TITLE
feat(ci): promote latest images on release instead of rebuilding

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -348,40 +348,15 @@ jobs:
         CHANGES_INITIAL: ${{ needs.detect-changes.outputs.initial_commit }}
         EVENT_NAME: ${{ github.event_name }}
       run: |
-        # For tag pushes, try to promote existing images instead of rebuilding.
-        # Flow: already tagged? → skip | same SHA as latest? → promote | else → full build
+        # For tag pushes, check if we can promote existing images instead of rebuilding.
+        # Main pushes create a sha-<commit> tag; releases promote from that immutable ref.
         if [[ "$GH_REF" == refs/tags/v* ]]; then
           TAG_NAME=${GITHUB_REF#refs/tags/}
           DOCKER_TAG=${TAG_NAME#v}
           MINOR_TAG=$(echo "$DOCKER_TAG" | cut -d. -f1-2)
-          ALL_EXIST=true
+          SHA_TAG="sha-$(echo "$GH_SHA" | cut -c1-7)"
 
-          for IMAGE in kindred-caddy kindred-pocketbase kindred-api kindred-init; do
-            echo "Checking if ${IMAGE}:${DOCKER_TAG} already exists..."
-            if gh api "/users/${GH_USERNAME}/packages/container/${IMAGE}/versions" \
-                 --jq ".[] | select(.metadata.container.tags[] == \"${DOCKER_TAG}\") | .id" \
-                 > /tmp/existing_id 2>/dev/null; then
-              EXISTING=$(head -1 /tmp/existing_id)
-            else
-              EXISTING=""
-            fi
-
-            if [ -z "$EXISTING" ]; then
-              ALL_EXIST=false
-              echo "  ${IMAGE}:${DOCKER_TAG} not found"
-            else
-              echo "  ${IMAGE}:${DOCKER_TAG} exists"
-            fi
-          done
-
-          if [ "$ALL_EXIST" = "true" ]; then
-            echo "build=false" >> $GITHUB_OUTPUT
-            echo "promote=false" >> $GITHUB_OUTPUT
-            echo "All images already tagged with ${DOCKER_TAG} - skipping"
-            exit 0
-          fi
-
-          # Check if latest was built from this same SHA (promote instead of rebuild)
+          # Check if the SHA-tagged images exist (pushed by the main CD run)
           LAST_CD_SHA=$(gh run list \
             --workflow cd.yml \
             --branch main \
@@ -395,11 +370,12 @@ jobs:
             echo "promote=true" >> $GITHUB_OUTPUT
             echo "docker_tag=$DOCKER_TAG" >> $GITHUB_OUTPUT
             echo "minor_tag=$MINOR_TAG" >> $GITHUB_OUTPUT
-            echo "Latest images were built from this same SHA ($GH_SHA) - promoting instead of rebuilding"
+            echo "sha_tag=$SHA_TAG" >> $GITHUB_OUTPUT
+            echo "Images from SHA $GH_SHA exist as :${SHA_TAG} - promoting instead of rebuilding"
             exit 0
           fi
 
-          echo "Latest was built from ${LAST_CD_SHA:-unknown}, not $GH_SHA - full build required"
+          echo "Last main CD was ${LAST_CD_SHA:-unknown}, not $GH_SHA - full build required"
         fi
 
         # Standard change detection
@@ -509,8 +485,12 @@ jobs:
       env:
         INPUT_TAG: ${{ github.event.inputs.tag }}
         GH_REF: ${{ github.ref }}
+        GH_SHA: ${{ github.sha }}
       run: |
         TAG_SUFFIXES="latest"
+        # Add immutable SHA tag so releases can promote from it
+        SHA_TAG="sha-$(echo "$GH_SHA" | cut -c1-7)"
+        TAG_SUFFIXES="${TAG_SUFFIXES},${SHA_TAG}"
         if [ -n "$INPUT_TAG" ]; then
           TAG_SUFFIXES="${TAG_SUFFIXES},${INPUT_TAG}"
         fi
@@ -773,20 +753,22 @@ jobs:
         fi
         echo "   To push, trigger manually without dry_run or merge to main"
 
-    # === Promote Path (tag push, same SHA as latest) ===
-    # Re-tag existing latest images with version tags at the registry level.
-    # No build, test, or scan needed — those already passed on the main push.
-    - name: Promote latest to release tags
+    # === Promote Path (tag push, same SHA already built on main) ===
+    # Re-tag existing sha-<commit> images with version tags at the registry level.
+    # Uses the immutable SHA tag (not :latest) to guarantee we promote the exact
+    # image that was built and tested, even if another main push lands concurrently.
+    - name: Promote to release tags
       if: steps.check.outputs.promote == 'true'
       env:
         DOCKER_TAG: ${{ steps.check.outputs.docker_tag }}
         MINOR_TAG: ${{ steps.check.outputs.minor_tag }}
+        SHA_TAG: ${{ steps.check.outputs.sha_tag }}
       run: |
         IMAGES=("kindred-caddy" "kindred-pocketbase" "kindred-api" "kindred-init")
 
         for IMAGE in "${IMAGES[@]}"; do
-          SRC="${REGISTRY}/${USERNAME}/${IMAGE}:latest"
-          echo "Promoting ${IMAGE}: latest → ${DOCKER_TAG}, ${MINOR_TAG}"
+          SRC="${REGISTRY}/${USERNAME}/${IMAGE}:${SHA_TAG}"
+          echo "Promoting ${IMAGE}: ${SHA_TAG} → ${DOCKER_TAG}, ${MINOR_TAG}"
           docker buildx imagetools create "$SRC" \
             --tag "${REGISTRY}/${USERNAME}/${IMAGE}:${DOCKER_TAG}" \
             --tag "${REGISTRY}/${USERNAME}/${IMAGE}:${MINOR_TAG}"


### PR DESCRIPTION
## Summary
- On release tag push, checks if the last successful main CD run was for the same SHA
- If match, uses `docker buildx imagetools create` to re-tag `latest` with version tags at the registry level (no pull/push of layers)
- Falls back to full build+test+scan if SHA doesn't match (e.g., release on older commit, failed CD)
- Adds `promoted` output to build-test-push job so the summary reports the promotion path

## Why
Image promotion is better governance than rebuilding — the released artifact is byte-for-byte identical to what was integration-tested. Also saves ~10 minutes of build/test/scan time on releases.

## Flow
```
Tag push (same SHA as latest main CD)
  → verify-ci (reuses existing CI results)
  → build-test-push:
      check → promote=true, build=false
      GHCR login
      docker buildx imagetools create (seconds, registry-side only)
  → create-release (changelog + GitHub release)
```

## Test plan
- [ ] Merge this PR → CD runs on main, pushes `latest`
- [ ] Run Release workflow → tag push triggers CD, verify it takes the promote path (no full build)
- [ ] Verify version-tagged images exist in GHCR with correct manifests
- [ ] Test fallback: manual `workflow_dispatch` with a tag still does full build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds SHA-based promotion so already-built images can be re-tagged to release versions (no rebuild).
  * Introduces a dedicated "Promote to release tags" flow and clearer promoted-image reporting.

* **Chores**
  * Propagates promoted status to the release summary and improves visibility of which images were promoted.
  * Adjusts login/flow conditions to run promotion and build paths as needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->