### PR TITLE
fix(frontend): make geo detail list sticky headers opaque

### DIFF
--- a/frontend/src/components/metrics/geo/GeoComparisonDetailList.tsx
+++ b/frontend/src/components/metrics/geo/GeoComparisonDetailList.tsx
@@ -99,7 +99,7 @@ export function GeoComparisonDetailList({
         <div className="border-border border-t">
           <div className="max-h-80 overflow-y-auto">
             <table className="w-full text-sm">
-              <thead className="bg-muted/30 sticky top-0 z-10">
+              <thead className="bg-muted sticky top-0 z-10">
                 <tr className="border-border border-b">
                   <th className="text-muted-foreground px-4 py-2 text-left font-medium">
                     {CATEGORY_PLURALS[category].slice(0, -1)}

--- a/frontend/src/components/metrics/geo/GeoDetailList.tsx
+++ b/frontend/src/components/metrics/geo/GeoDetailList.tsx
@@ -113,7 +113,7 @@ export function GeoDetailList({
         <div className="border-border border-t">
           <div className="max-h-80 overflow-y-auto">
             <table className="w-full text-sm">
-              <thead className="bg-muted/30 sticky top-0 z-10">
+              <thead className="bg-muted sticky top-0 z-10">
                 <tr className="border-border border-b">
                   <th className="text-muted-foreground px-4 py-2 text-left font-medium">
                     {CATEGORY_LABELS[category]}


### PR DESCRIPTION
## Summary
- Changed `bg-muted/30` (semi-transparent) to `bg-muted` (opaque) on sticky `<thead>` in both `GeoDetailList` and `GeoComparisonDetailList`
- Fixes scrolling content bleeding through the name/count/% subheader

## Test plan
- [ ] Open Registration > Geographic page
- [ ] Expand a category (cities, schools, etc.) and scroll down
- [ ] Verify content scrolls cleanly under the sticky header without showing through

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated table header background styling in geographic metrics views for improved visual prominence and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->