### PR TITLE
fix(rbac): repair corrupted role permissions from JSVM byte array bug

### DIFF
--- a/pocketbase/pb_migrations/1500000082_rbac_manage_permissions.js
+++ b/pocketbase/pb_migrations/1500000082_rbac_manage_permissions.js
@@ -13,12 +13,23 @@
 migrate((app) => {
   const rolesCol = app.findCollectionByNameOrId("roles")
 
+  // PocketBase JSVM returns JSON fields as raw byte arrays, not parsed JS arrays.
+  // Array.from() on bytes yields [91, 34, 98, ...] (char codes) instead of strings.
+  // This helper converts bytes → string → parsed array.
+  function parsePerms(raw) {
+    if (!raw) return []
+    if (Array.isArray(raw) && (raw.length === 0 || typeof raw[0] === "string")) return raw
+    const bytes = Array.from(raw)
+    const str = bytes.map((b) => String.fromCharCode(b)).join("")
+    try { return JSON.parse(str) } catch (_e) { return [] }
+  }
+
   // Helper: add a permission to a role if not present
   function addPermToRole(slug, perm) {
     const records = app.findRecordsByFilter(rolesCol.id, `slug = "${slug}"`, "", 1, 0)
     if (records.length === 0) return null
     const role = records[0]
-    const perms = Array.from(role.get("permissions") || [])
+    const perms = parsePerms(role.get("permissions"))
     if (!perms.includes(perm)) {
       role.set("permissions", [...perms, perm])
       app.save(role)
@@ -50,7 +61,7 @@ migrate((app) => {
       const permSet = new Set()
       for (const aur of allUserRoles) {
         const role = app.findRecordById(rolesCol.id, aur.get("role"))
-        for (const p of Array.from(role.get("permissions") || [])) {
+        for (const p of parsePerms(role.get("permissions"))) {
           permSet.add(p)
         }
       }
@@ -81,12 +92,20 @@ migrate((app) => {
   // Revert: remove new permissions from roles, restore strict admin rules
   const rolesCol = app.findCollectionByNameOrId("roles")
 
+  function parsePerms(raw) {
+    if (!raw) return []
+    if (Array.isArray(raw) && (raw.length === 0 || typeof raw[0] === "string")) return raw
+    const bytes = Array.from(raw)
+    const str = bytes.map((b) => String.fromCharCode(b)).join("")
+    try { return JSON.parse(str) } catch (_e) { return [] }
+  }
+
   // Helper: remove a permission from a role
   function removePermFromRole(slug, perm) {
     const records = app.findRecordsByFilter(rolesCol.id, `slug = "${slug}"`, "", 1, 0)
     if (records.length === 0) return
     const role = records[0]
-    const perms = Array.from(role.get("permissions") || []).filter((p) => p !== perm)
+    const perms = parsePerms(role.get("permissions")).filter((p) => p !== perm)
     role.set("permissions", perms)
     app.save(role)
   }

--- a/pocketbase/pb_migrations/1500000083_fix_role_permissions_corruption.js
+++ b/pocketbase/pb_migrations/1500000083_fix_role_permissions_corruption.js
@@ -1,0 +1,100 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: Repair corrupted role permissions from 1500000082
+ *
+ * The original migration used Array.from() on PocketBase JSON fields, which
+ * returns byte values instead of parsed arrays in the JSVM. This corrupted
+ * the permissions field on 3 system roles (bunking-staff, finance, registrar)
+ * and the cached_permissions field on any users assigned those roles.
+ *
+ * This migration:
+ * 1. Sets each affected role's permissions to the known-correct values
+ * 2. Recomputes cached_permissions for all users with role assignments
+ *
+ * Idempotent: safe to run on databases where 1500000082 was already fixed.
+ */
+
+migrate((app) => {
+  const rolesCol = app.findCollectionByNameOrId("roles")
+
+  // PocketBase JSVM returns JSON fields as raw byte arrays, not parsed JS arrays.
+  // This helper safely parses them regardless of format.
+  function parsePerms(raw) {
+    if (!raw) return []
+    if (Array.isArray(raw) && (raw.length === 0 || typeof raw[0] === "string")) return raw
+    const bytes = Array.from(raw)
+    const str = bytes.map((b) => String.fromCharCode(b)).join("")
+    try { return JSON.parse(str) } catch (_e) { return [] }
+  }
+
+  // 1. Fix role permissions — set to known-correct values
+  const correctPerms = {
+    "bunking-staff": ["bunking.manage", "sheets.export"],
+    "finance": ["metrics.financial", "sheets.export"],
+    "registrar": ["metrics.geo", "registration.manage"],
+  }
+
+  for (const [slug, perms] of Object.entries(correctPerms)) {
+    try {
+      const records = app.findRecordsByFilter(rolesCol.id, `slug = "${slug}"`, "", 1, 0)
+      if (records.length === 0) continue
+      const role = records[0]
+      const current = parsePerms(role.get("permissions"))
+
+      // Skip if already correct (idempotent)
+      if (
+        current.length === perms.length &&
+        perms.every((p) => current.includes(p))
+      ) {
+        continue
+      }
+
+      role.set("permissions", perms)
+      app.save(role)
+    } catch (_e) {
+      // Role may not exist in this environment
+    }
+  }
+
+  // 2. Recompute cached_permissions for all users with role assignments
+  const usersCol = app.findCollectionByNameOrId("_pb_users_auth_")
+  const userRolesCol = app.findCollectionByNameOrId("user_roles")
+
+  // Find all users who have at least one role
+  const allUserRoles = app.findRecordsByFilter(userRolesCol.id, "1 = 1", "", 10000, 0)
+  const userIds = [...new Set(allUserRoles.map((ur) => ur.get("user")))]
+
+  for (const userId of userIds) {
+    try {
+      const urs = app.findRecordsByFilter(userRolesCol.id, `user = "${userId}"`, "", 100, 0)
+      const permSet = new Set()
+      for (const ur of urs) {
+        const role = app.findRecordById(rolesCol.id, ur.get("role"))
+        for (const p of parsePerms(role.get("permissions"))) {
+          permSet.add(p)
+        }
+      }
+
+      const user = app.findRecordById(usersCol.id, userId)
+      const newPerms = [...permSet].sort()
+      const currentCached = user.get("cached_permissions") || []
+
+      // Skip if already correct
+      if (
+        Array.isArray(currentCached) &&
+        currentCached.length === newPerms.length &&
+        newPerms.every((p) => currentCached.includes(p))
+      ) {
+        continue
+      }
+
+      user.set("cached_permissions", newPerms)
+      app.save(user)
+    } catch (_e) {
+      // User may have been deleted
+    }
+  }
+}, (_app) => {
+  // No-op: the repair migration only fixes corrupted data to correct state.
+  // Rolling back would re-corrupt it, which is never desired.
+})


### PR DESCRIPTION
## Summary
- **Root cause**: Migration `1500000082` used `Array.from()` on PocketBase JSON fields, which in the JSVM returns raw byte arrays — producing arrays of ASCII char codes (`[91, 34, 98, ...]`) instead of string arrays (`["bunking.manage"]`)
- **Fix `1500000082` in-place**: Replace `Array.from()` with a `parsePerms()` helper that detects byte arrays and converts them properly (for fresh databases)
- **New repair migration `1500000083`**: Sets the 3 affected roles to their known-correct permissions and recomputes `cached_permissions` for all users with role assignments (for databases that already ran the broken migration). Idempotent — no-op on fresh databases.

## Affected roles
| Role | Corrupted state | Correct state |
|------|----------------|---------------|
| bunking-staff | `[91, 34, 98, ..., 93, "sheets.export"]` | `["bunking.manage", "sheets.export"]` |
| finance | `[91, 34, 109, ..., 93, "sheets.export"]` | `["metrics.financial", "sheets.export"]` |
| registrar | `[91, 34, 109, ..., 93, "registration.manage"]` | `["metrics.geo", "registration.manage"]` |

## Test plan
- [ ] Fresh worktree: delete `pb_data`, start PocketBase, verify roles have correct string arrays
- [ ] Existing database: start PocketBase, verify `1500000083` repairs corrupted permissions
- [ ] Verify `cached_permissions` on users with role assignments contain only string values
- [ ] Verify role assignment UI shows permission names (not byte codes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue causing role permissions to become corrupted in the system
* Recalculated user permissions to ensure accurate access levels are enforced across all roles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->