### PR TITLE
fix(ci): replace deprecated dorny/paths-filter with step-security fork

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -113,7 +113,7 @@ jobs:
         fi
 
     - name: Check for file changes
-      uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+      uses: step-security/paths-filter@6eee183b0d2fd101d3f8ee2935c127bca14c5625 # v3.0.5
       id: filter
       with:
         base: ${{ steps.get-base-sha.outputs.base_sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         persist-credentials: false
 
     - name: Check for file changes
-      uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+      uses: step-security/paths-filter@6eee183b0d2fd101d3f8ee2935c127bca14c5625 # v3.0.5
       id: filter
       with:
         filters: |


### PR DESCRIPTION
## Summary
- Replace abandoned `dorny/paths-filter` (last updated March 2024, Node.js 20) with actively maintained `step-security/paths-filter@v3.0.5` in both CI and CD workflows
- Drop-in replacement — no config changes needed
- Resolves GitHub Actions Node.js 20 deprecation warning (forced migration to Node 24 on June 2, 2026)

## Test plan
- [ ] CI passes with the new action
- [ ] CD passes with the new action
- [ ] Path filtering still correctly detects changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline infrastructure with refined GitHub Actions tooling to enhance workflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->