### PR TITLE
fix(ci): revert paths-filter from step-security to dorny

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -113,7 +113,7 @@ jobs:
         fi
 
     - name: Check for file changes
-      uses: dorny/paths-filter@ce10459c8b1c138d55cb87ae5c3cf5d74afbc93f # master (node24, post-v3.0.2)
+      uses: dorny/paths-filter@ce10459c8b92cd8901166c0a222fbb033ef39365 # master (node24, post-v3.0.2)
       id: filter
       with:
         base: ${{ steps.get-base-sha.outputs.base_sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         persist-credentials: false
 
     - name: Check for file changes
-      uses: dorny/paths-filter@ce10459c8b1c138d55cb87ae5c3cf5d74afbc93f # master (node24, post-v3.0.2)
+      uses: dorny/paths-filter@ce10459c8b92cd8901166c0a222fbb033ef39365 # master (node24, post-v3.0.2)
       id: filter
       with:
         filters: |


### PR DESCRIPTION
## Summary
- step-security/paths-filter requires a paid subscription, failing CI with `Subscription is not valid` error
- Reverts to dorny/paths-filter pinned to latest master commit (`ce10459c8b`) which includes node24 support (merged 2026-03-11)
- Will update pin to a release tag once dorny cuts a new release

## Test plan
- [ ] CI detect-changes job passes (no subscription error)
- [ ] CD detect-changes job passes
- [ ] Downstream jobs still receive correct filter outputs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use a maintained alternative for file-change detection, improving long-term compatibility and maintenance of the development pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->