### PR TITLE
fix(ci): make CI/CD resilient to detect-changes failures

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -323,16 +323,22 @@ jobs:
     - name: Check if build needed
       id: check
       env:
+        DETECT_RESULT: ${{ needs.detect-changes.result }}
         CHANGES_API: ${{ needs.detect-changes.outputs.api }}
         CHANGES_DOCKER: ${{ needs.detect-changes.outputs.docker }}
         CHANGES_INITIAL: ${{ needs.detect-changes.outputs.initial_commit }}
         EVENT_NAME: ${{ github.event_name }}
       run: |
-        if [ "$CHANGES_API" == "true" ] || \
-           [ "$EVENT_NAME" == "workflow_dispatch" ] || \
-           [ "$EVENT_NAME" == "schedule" ] || \
-           [ "$CHANGES_DOCKER" == "true" ] || \
-           [ "$CHANGES_INITIAL" == "true" ]; then
+        # If detect-changes failed, outputs are empty — build everything as safety fallback.
+        # Worst case: an unnecessary rebuild. Previous worst case: 5 PRs with no images deployed.
+        if [ "$DETECT_RESULT" != "success" ]; then
+          echo "::warning::Change detection failed — building all images as safety fallback"
+          echo "build=true" >> $GITHUB_OUTPUT
+        elif [ "$CHANGES_API" == "true" ] || \
+             [ "$EVENT_NAME" == "workflow_dispatch" ] || \
+             [ "$EVENT_NAME" == "schedule" ] || \
+             [ "$CHANGES_DOCKER" == "true" ] || \
+             [ "$CHANGES_INITIAL" == "true" ]; then
           echo "build=true" >> $GITHUB_OUTPUT
         else
           echo "build=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -606,6 +606,7 @@ jobs:
     steps:
     - name: Check status
       env:
+        DETECT_CHANGES: ${{ needs.detect-changes.result }}
         COMMIT_LINT: ${{ needs.commit-lint.result }}
         PR_TITLE_LINT: ${{ needs.pr-title-lint.result }}
         SECRET_SCAN: ${{ needs.secret-scan.result }}
@@ -617,6 +618,12 @@ jobs:
         TESTS: ${{ needs.tests.result }}
         DEP_SUBMISSION: ${{ needs.dependency-submission.result }}
       run: |
+        # detect-changes: blocking — if this fails, all conditional jobs are skipped
+        # and CI passes with zero validation (the paths-filter incident of March 2026)
+        if [ "$DETECT_CHANGES" != "success" ]; then
+          echo "::error::Change detection failed — no lint or test jobs ran. Check paths-filter action."
+          exit 1
+        fi
         # commit-lint: blocking — non-conventional commits break changelog generation
         if [ "$COMMIT_LINT" != "success" ] && [ "$COMMIT_LINT" != "skipped" ]; then
           echo "::error::Commit message format issue detected. Use: type(scope): description"


### PR DESCRIPTION
## Summary

- **CI Summary** now explicitly checks `detect-changes` result — if it fails, CI fails instead of silently passing with zero validation
- **CD build-test-push** defaults to building all images when `detect-changes` fails, instead of silently skipping the build entirely

## Context

The `step-security/paths-filter` swap in #480 broke change detection in both CI and CD. CI Summary didn't check `detect-changes` status, so when all conditional jobs were skipped (due to empty outputs), they counted as "skipped = OK" and CI passed with zero lint, zero tests. Meanwhile CD read empty outputs as "no changes" and skipped all Docker builds. Result: 5 PRs merged with no validation and no images deployed.

## Changes

| File | Change |
|------|--------|
| `ci.yml` | CI Summary fails if `detect-changes` errored (not just skipped) |
| `cd.yml` | `build-test-push` builds everything when `detect-changes` fails (safe fallback) |

## Test plan

- [x] Verify CI Summary checks `detect-changes` result before all other checks
- [x] Verify CD defaults to `build=true` when `detect-changes` fails
- [ ] CI passes on this PR (meta-validation: detect-changes succeeds, CI Summary evaluates it)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Improved CI/CD pipeline reliability with enhanced build detection and safety fallback mechanisms.
* Added blocking validation checks to prevent incomplete deployments when change detection fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->