### PR TITLE
feat(solver): upgrade to GPT-5-nano with reasoning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,7 +47,7 @@ POCKETBASE_ADMIN_PASSWORD=your-secure-password-here
 # Supported providers: openai, anthropic, ollama
 AI_PROVIDER=openai
 AI_API_KEY=your_ai_api_key_here
-AI_MODEL=gpt-4.1-nano
+AI_MODEL=gpt-5-nano
 
 # ====================
 # API Service Configuration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,7 +185,7 @@ Format: `2026-01-06T14:05:52Z [source] LEVEL message key=value...`
 4. **Sync order matters** - sessions → attendees → persons → bunks → plans → assignments → requests
 5. **Family camps excluded** in syncs for performance
 6. **Config is database-driven** - PocketBase `config` table, not JSON files. AI settings via env vars (`AI_API_KEY`, `AI_MODEL`, `AI_PROVIDER`)
-7. **AI model** - GPT-4.1-nano via `AI_MODEL` env var ($0.10/$0.40 per M tokens)
+7. **AI model** - GPT-5-nano via `AI_MODEL` env var ($0.05/$0.40 per M tokens, reasoning enabled)
 8. **CSV history tracking** - `csv_history/` tracks changes, 30-day auto-cleanup, saves 70-90% AI costs
 9. **Token caching** - CampMinder JWT cached in `~/.campminder_token_cache.json`
 10. **Year-aware syncs** - Uses `season_id` from config; ready for new year with config update

--- a/bunking/config/loader.py
+++ b/bunking/config/loader.py
@@ -487,7 +487,7 @@ class ConfigLoader:
         config: dict[str, Any] = {
             "provider": os.getenv("AI_PROVIDER", "openai"),
             "api_key": os.getenv("AI_API_KEY"),
-            "model": os.getenv("AI_MODEL", "gpt-4o-mini"),
+            "model": os.getenv("AI_MODEL", "gpt-5-nano"),
             "temperature": 0.1,
             "max_tokens": 2000,
             "batch_processing": {"enabled": True, "batch_size": 10, "max_concurrent_batches": 3},

--- a/bunking/sync/bunk_request_processor/integration/openai_provider.py
+++ b/bunking/sync/bunk_request_processor/integration/openai_provider.py
@@ -1,7 +1,7 @@
 """V2 AI Provider - OpenAI SDK with Pydantic structured outputs.
 
 Uses the Responses API for schema-enforced structured outputs.
-GPT-4.1 models fully support structured outputs via this API.
+GPT-4.1 and GPT-5 models fully support structured outputs via this API.
 """
 
 from __future__ import annotations
@@ -10,6 +10,7 @@ import logging
 from typing import Any
 
 from openai import AsyncOpenAI
+from openai.types.shared_params import Reasoning, ReasoningEffort
 
 from ..core.models import (
     AgePreference,
@@ -48,7 +49,7 @@ class OpenAIProvider(AIProvider):
 
         Args:
             api_key: OpenAI API key
-            model: Model name (e.g., 'gpt-4.1-nano')
+            model: Model name (e.g., 'gpt-5-nano')
             base_url: Optional custom API base URL
             timeout: Request timeout in seconds
             debug: Enable verbose AI parse logging
@@ -184,17 +185,23 @@ class OpenAIProvider(AIProvider):
         self,
         prompt: str,
         response_model: type[AIParseResponse] | type[AIDisambiguationResponse],
+        reasoning_effort: ReasoningEffort = "low",
     ) -> AIParseResponse | AIDisambiguationResponse:
         """Call OpenAI with Pydantic structured output.
 
         Uses the Responses API for schema-enforced output.
         The model is constrained to output valid schema-conforming JSON.
+
+        Args:
+            reasoning_effort: Reasoning level for GPT-5 models.
+                "low" for Phase 1 parsing, "medium" for Phase 3 disambiguation.
         """
         response = await self.client.responses.parse(
             model=self.model,
             input=prompt,
             text_format=response_model,
             instructions="You are an expert at parsing summer camp bunk requests.",
+            reasoning=Reasoning(effort=reasoning_effort),
         )
 
         # Update token usage
@@ -394,6 +401,9 @@ class OpenAIProvider(AIProvider):
             "gpt-4.1-nano": (0.10, 0.40),
             "gpt-4.1-mini": (0.40, 1.60),
             "gpt-4.1": (2.0, 8.0),
+            "gpt-5-nano": (0.05, 0.40),
+            "gpt-5-mini": (0.25, 2.0),
+            "gpt-5": (2.0, 8.0),
         }
 
         input_price, output_price = 0.0, 0.0
@@ -434,6 +444,7 @@ class OpenAIProvider(AIProvider):
             response = await self._call_with_structured_output(
                 prompt=prompt,
                 response_model=AIDisambiguationResponse,
+                reasoning_effort="medium",
             )
 
             # Update parsed request with disambiguation result

--- a/tests/unit/sync/bunk_request_processor/integration/test_sdk_ai_provider.py
+++ b/tests/unit/sync/bunk_request_processor/integration/test_sdk_ai_provider.py
@@ -337,7 +337,7 @@ class TestReasoningEffort:
 
         call_kwargs = mock_openai_client.responses.parse.call_args.kwargs
         assert "reasoning" in call_kwargs
-        assert call_kwargs["reasoning"] == {"effort": "low"}
+        assert call_kwargs["reasoning"]["effort"] == "low"
 
     @pytest.mark.asyncio
     async def test_disambiguate_passes_medium_reasoning(self, mock_openai_client):
@@ -382,7 +382,7 @@ class TestReasoningEffort:
 
         call_kwargs = mock_openai_client.responses.parse.call_args.kwargs
         assert "reasoning" in call_kwargs
-        assert call_kwargs["reasoning"] == {"effort": "medium"}
+        assert call_kwargs["reasoning"]["effort"] == "medium"
 
     def test_gpt5_nano_pricing(self):
         """GPT-5-nano pricing is registered in cost calculation."""


### PR DESCRIPTION
## Summary
- Upgrade default AI model from GPT-4.1-nano to GPT-5-nano ($0.05/$0.40 per M tokens)
- Enable reasoning on structured output calls: `low` for Phase 1 parsing, `medium` for Phase 3 disambiguation
- Add GPT-5-nano/mini/full pricing to cost calculation

## Test plan
- [x] 4 new tests: reasoning effort passed correctly per phase, pricing entries for gpt-5-nano and gpt-5-mini
- [x] All 17 provider tests pass
- [x] Full bunk_request_processor suite passes (1191 tests)
- [ ] Deploy with `AI_MODEL=gpt-5-nano` and run a sync to verify live parse quality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GPT-5 models (gpt-5-nano, gpt-5-mini, gpt-5) with configurable reasoning capabilities and adjustable effort levels.
  * Updated default AI model to gpt-5-nano with revised pricing.

* **Documentation**
  * Updated configuration documentation and examples for new models and pricing.

* **Tests**
  * Added reasoning effort and pricing validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->