### PR TITLE
fix(solver): classify cross-session bunk_with requests as impossible

### DIFF
--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -187,7 +187,14 @@ class DirectBunkingSolver:
         return valid_bunks
 
     def _validate_requests(self) -> None:
-        """Validate requests and categorize as possible (can be satisfied) or impossible (reference out-of-session people)."""
+        """Validate requests and categorize as possible or impossible.
+
+        Impossible cases:
+        - Requested person is not in the solver at all
+        - bunk_with targeting a person in a different session (session boundaries
+          prevent sharing a bunk). not_bunk_with across sessions is still possible
+          since separation is guaranteed by session boundaries.
+        """
         person_by_cm_id = self.input.person_by_cm_id
         total_requests = 0
         impossible_count = 0

--- a/tests/unit/solver/test_validate_requests.py
+++ b/tests/unit/solver/test_validate_requests.py
@@ -13,12 +13,22 @@ from bunking.config import ConfigLoader
 from bunking.models_v2 import DirectBunk, DirectBunkRequest, DirectPerson, DirectSolverInput
 from bunking.solver.direct_solver import DirectBunkingSolver
 
+_FICTIONAL_NAMES = [
+    ("Emma", "Johnson"),
+    ("Liam", "Garcia"),
+    ("Olivia", "Chen"),
+    ("Noah", "Williams"),
+    ("Ava", "Martinez"),
+    ("Ethan", "Brown"),
+]
+
 
 def _make_person(cm_id: int, session: int, *, gender: str = "F") -> DirectPerson:
+    first, last = _FICTIONAL_NAMES[cm_id % len(_FICTIONAL_NAMES)]
     return DirectPerson(
         campminder_person_id=cm_id,
-        first_name="Test",
-        last_name=f"Person{cm_id}",
+        first_name=first,
+        last_name=last,
         grade=6,
         birthdate="2014-03-15",
         gender=gender,


### PR DESCRIPTION
## Summary
- `_validate_requests()` now checks session compatibility for `bunk_with` requests, not just solver membership
- Cross-session `bunk_with` requests are classified as impossible — session boundary constraints make them structurally unsatisfiable
- Cross-session `not_bunk_with` requests remain possible (trivially satisfied by session boundaries)
- Prevents the 100k must-satisfy-one soft penalty from firing on requests that can never be fulfilled

## Test plan
- [x] Unit tests for all cross-session classification scenarios (8 tests)
- [x] Existing solver test suite passes (71 tests, 0 regressions)
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of bunking requests to mark requests impossible when the requested camper is missing or in a different session; preserved non-bunk-with and age-preference behavior
  * Clarified warning/debug messages to state infeasibility reasons and affected IDs

* **Tests**
  * Added unit tests covering cross-session, missing-camper, mixed, and request-summary scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->