### PR TITLE
fix(frontend): update scenario modal labels for clarity

### DIFF
--- a/frontend/src/components/NewScenarioModal.tsx
+++ b/frontend/src/components/NewScenarioModal.tsx
@@ -107,7 +107,7 @@ export default function NewScenarioModal({
                 onChange={(e) => setCopyFrom(e.target.value)}
                 className="text-primary focus:ring-primary h-4 w-4 focus:ring-2"
               />
-              <span className="text-sm">Start with empty assignments</span>
+              <span className="text-sm">Start with empty bunks</span>
             </label>
 
             <label className="flex cursor-pointer items-center space-x-2">
@@ -121,7 +121,7 @@ export default function NewScenarioModal({
               />
               <span className="flex items-center gap-2 text-sm">
                 <Package className="text-primary h-4 w-4" />
-                Copy from Production
+                Copy from CampMinder
               </span>
             </label>
 


### PR DESCRIPTION
## Summary
- "Copy from Production" → "Copy from CampMinder" 
- "Start with empty assignments" → "Start with empty bunks"

## Test plan
- [ ] Open new scenario modal and verify updated labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Updates**
  * Updated labels in the New Scenario modal for improved clarity: "empty assignments" is now "empty bunks" and "Copy from Production" is now "Copy from CampMinder".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->