### PR TITLE
chore(ci): update SHA-pinned actions and remove node20 dependency-submission

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -113,7 +113,7 @@ jobs:
         fi
 
     - name: Check for file changes
-      uses: dorny/paths-filter@ce10459c8b92cd8901166c0a222fbb033ef39365 # master (node24, post-v3.0.2)
+      uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c # v4
       id: filter
       with:
         base: ${{ steps.get-base-sha.outputs.base_sha }}
@@ -280,7 +280,7 @@ jobs:
         python-version: '3.14'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7
+      uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7
 
     - name: Setup Node.js
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         persist-credentials: false
 
     - name: Check for file changes
-      uses: dorny/paths-filter@ce10459c8b92cd8901166c0a222fbb033ef39365 # master (node24, post-v3.0.2)
+      uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c # v4
       id: filter
       with:
         filters: |
@@ -209,7 +209,7 @@ jobs:
         python-version: '3.14'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7
+      uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7
       with:
         enable-cache: true
 
@@ -436,7 +436,7 @@ jobs:
         python-version: '3.14'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7
+      uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7
       with:
         enable-cache: true
 
@@ -578,29 +578,10 @@ jobs:
       working-directory: ./frontend
       run: npm run test -- --run
 
-  # Submit dependencies to GitHub's dependency graph
-  # Non-blocking: informational only, GitHub API errors shouldn't fail CI
-  dependency-submission:
-    name: Dependency Submission
-    runs-on: ubuntu-latest
-    # Only submit on main branch pushes (not PRs, not other branches)
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    continue-on-error: true
-    permissions:
-      contents: write  # Required for dependency submission API
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      with:
-        persist-credentials: false
-
-    - name: Submit dependencies
-      uses: advanced-security/component-detection-dependency-submission-action@9c110eb34dee187cd9eca76a652b9f6a0ed22927 # v0.1.1
-
   # Summary job - gate for PR merges
   summary:
     name: CI Summary
-    needs: [commit-lint, pr-title-lint, detect-changes, secret-scan, python-lint, go-lint, frontend-lint, docker-lint, security-lint, tests, dependency-submission]
+    needs: [commit-lint, pr-title-lint, detect-changes, secret-scan, python-lint, go-lint, frontend-lint, docker-lint, security-lint, tests]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -616,7 +597,6 @@ jobs:
         DOCKER_LINT: ${{ needs.docker-lint.result }}
         SECURITY_LINT: ${{ needs.security-lint.result }}
         TESTS: ${{ needs.tests.result }}
-        DEP_SUBMISSION: ${{ needs.dependency-submission.result }}
       run: |
         # detect-changes: blocking — if this fails, all conditional jobs are skipped
         # and CI passes with zero validation (the paths-filter incident of March 2026)
@@ -663,9 +643,5 @@ jobs:
         if [ "$TESTS" != "success" ] && [ "$TESTS" != "skipped" ]; then
           echo "Tests failed!"
           exit 1
-        fi
-        # dependency-submission is non-blocking (informational only)
-        if [ "$DEP_SUBMISSION" == "failure" ]; then
-          echo "Dependency submission failed (non-blocking)"
         fi
         echo "All CI checks passed!"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44 # v1
+        uses: anthropics/claude-code-action@5d0cc745cd0cce4c0e9e0b3511de26c3bc285eb5 # v1
         with:
           # Using Claude Max OAuth token
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- **dorny/paths-filter**: pin to v4.0.0 release tag (was pinned to untagged master commit, invisible to Dependabot)
- **astral-sh/setup-uv**: v7.3.1 → v7.5.0
- **anthropics/claude-code-action**: v1.0.70 → v1.0.71
- **Remove `advanced-security/component-detection-dependency-submission-action`**: stuck on node20 with no updates planned; redundant since GitHub natively detects 1,302 packages from lockfiles (npm: 1114, pypi: 111, golang: 60, actions: 16)

## Context
Audited all 16 SHA-pinned actions across 7 workflows. Two node20 actions (`dependabot/fetch-metadata`, `kenji-miyake/setup-git-cliff`) are left as-is — their maintainers will release node24 versions, and Dependabot will propose the SHA bump when they do.

## Test plan
- [ ] CI passes (actionlint + zizmor validate workflow syntax)
- [ ] Dependency graph still populated (verify at Settings → Code security → Dependency graph)
- [ ] Dependabot can track dorny/paths-filter now that it has a `# v4` tag comment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions references to newer versions across CI/CD workflows: paths-filter (v4), setup-uv (v7), and Claude Code Action to latest version for improved compatibility and stability.
  * Removed non-blocking dependency submission workflow from CI pipeline to streamline the continuous integration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->