### PR TITLE
fix(frontend): prevent Brush infinite render loop on velocity pages

### DIFF
--- a/frontend/src/pages/metrics/trends/CancellationVelocityPage.tsx
+++ b/frontend/src/pages/metrics/trends/CancellationVelocityPage.tsx
@@ -54,16 +54,13 @@ export default function CancellationVelocityPage() {
   const [zoomRange, setZoomRange] = useState<[number, number] | null>(null)
 
   // Sync Brush drag with zoomRange state, deduplicating to prevent render loops
-  const handleBrushChange = useCallback(
-    (range: { startIndex?: number; endIndex?: number }) => {
-      if (range.startIndex !== undefined && range.endIndex !== undefined) {
-        const s = range.startIndex
-        const e = range.endIndex
-        setZoomRange((prev) => (prev && prev[0] === s && prev[1] === e ? prev : [s, e]))
-      }
-    },
-    []
-  )
+  const handleBrushChange = useCallback((range: { startIndex?: number; endIndex?: number }) => {
+    if (range.startIndex !== undefined && range.endIndex !== undefined) {
+      const s = range.startIndex
+      const e = range.endIndex
+      setZoomRange((prev) => (prev && prev[0] === s && prev[1] === e ? prev : [s, e]))
+    }
+  }, [])
 
   const priorYearOptions = useMemo(
     () => availableYears.filter((y) => y < currentYear).sort((a, b) => b - a),

--- a/frontend/src/pages/metrics/trends/VelocityPage.tsx
+++ b/frontend/src/pages/metrics/trends/VelocityPage.tsx
@@ -95,16 +95,13 @@ export default function VelocityPage() {
   const [zoomRange, setZoomRange] = useState<[number, number] | null>(null)
 
   // Sync Brush drag with zoomRange state, deduplicating to prevent render loops
-  const handleBrushChange = useCallback(
-    (range: { startIndex?: number; endIndex?: number }) => {
-      if (range.startIndex !== undefined && range.endIndex !== undefined) {
-        const s = range.startIndex
-        const e = range.endIndex
-        setZoomRange((prev) => (prev && prev[0] === s && prev[1] === e ? prev : [s, e]))
-      }
-    },
-    []
-  )
+  const handleBrushChange = useCallback((range: { startIndex?: number; endIndex?: number }) => {
+    if (range.startIndex !== undefined && range.endIndex !== undefined) {
+      const s = range.startIndex
+      const e = range.endIndex
+      setZoomRange((prev) => (prev && prev[0] === s && prev[1] === e ? prev : [s, e]))
+    }
+  }, [])
 
   const priorYearOptions = useMemo(
     () => availableYears.filter((y) => y < currentYear).sort((a, b) => b - a),


### PR DESCRIPTION
## Summary
- Fix React error #185 (maximum update depth exceeded) when adjusting date ranges on velocity metrics charts
- Add `onChange` handler to Recharts `Brush` components with deduplication to prevent re-render loops from controlled/uncontrolled state conflicts
- Clamp `startIndex`/`endIndex` to valid data bounds so stale zoom ranges don't exceed array length when data changes

## Test plan
- [ ] Navigate to velocity page, adjust zoom dropdowns — no crash
- [ ] Drag the brush scrubber — zoom dropdowns stay synced
- [ ] Switch sessions/durations while zoomed — no crash
- [ ] Repeat on cancellation velocity page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved brush interaction handling on metrics trend visualization pages to prevent render loops and ensure zoom operations remain synchronized across daily and weekly views while maintaining proper data boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->