### PR TITLE
fix(scripts): consolidate git hooks and add prettier to pre-commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,42 +1,44 @@
 #!/bin/bash
-# Pre-commit hook: Warns early if main is behind origin
-# Catches Dependabot divergence at FIRST commit, not after hours of work
+# Pre-commit hook: runs quick checks + warns if main is behind origin
 #
-# This is the early warning. Pre-push is the backup safety net.
+# Install: git config core.hooksPath .githooks
+# Or run: ./scripts/setup-git-hooks.sh
 
 set -e
 
-# Only check on main branch
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+
+# --- Quick lint/format checks ---
+if [ -f "$PROJECT_ROOT/scripts/ci/quick_check.sh" ]; then
+    echo "Running pre-commit checks..."
+    "$PROJECT_ROOT/scripts/ci/quick_check.sh"
+fi
+
+# --- Behind-origin check (main branch only) ---
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [ "$BRANCH" != "main" ]; then
     exit 0
 fi
 
-# Fetch latest (silently, allow offline)
 git fetch origin main --quiet 2>/dev/null || exit 0
 
 LOCAL=$(git rev-parse HEAD)
 REMOTE=$(git rev-parse origin/main 2>/dev/null || echo "")
 BASE=$(git merge-base HEAD origin/main 2>/dev/null || echo "")
 
-# Can't determine state - allow commit
 [ -z "$REMOTE" ] || [ -z "$BASE" ] && exit 0
 
-# Check if behind
 if [ "$LOCAL" != "$REMOTE" ] && [ "$LOCAL" = "$BASE" ]; then
     BEHIND_COUNT=$(git rev-list --count HEAD..origin/main)
-
     echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    echo "  ⚠️  HEADS UP: main is ${BEHIND_COUNT} commit(s) behind origin"
+    echo "  WARNING: main is ${BEHIND_COUNT} commit(s) behind origin"
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo ""
-    echo "You're about to commit on main while behind. Recent upstream:"
+    echo "Recent upstream commits:"
     git log --oneline HEAD..origin/main | head -3
     echo ""
-    echo "Options:"
-    echo "  1. Pull first (recommended):  git pull --rebase origin main"
-    echo "  2. Continue anyway:           git commit --no-verify"
+    echo "Run: git pull --rebase origin main"
     echo ""
     exit 1
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,132 +1,43 @@
 #!/bin/bash
-# Pre-push hook: Runs linting and prevents pushing when behind origin
+# Pre-push hook: blocks pushing main when behind origin
+#
+# All linting/formatting checks run at pre-commit via scripts/ci/quick_check.sh.
+# This hook only guards against diverged main branches.
 #
 # Install: git config core.hooksPath .githooks
 # Or run: ./scripts/setup-git-hooks.sh
 
 set -e
 
-# Colors
 RED='\033[0;31m'
-YELLOW='\033[1;33m'
 GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
 NC='\033[0m'
-
-REPO_ROOT="$(git rev-parse --show-toplevel)"
-cd "$REPO_ROOT"
-
-# =============================================================================
-# LINTING (runs on all branches)
-# =============================================================================
-
-echo -e "${CYAN}Running pre-push checks...${NC}"
-
-# Shell linting
-echo -e "${CYAN}  shellcheck...${NC}"
-shellcheck --severity=warning scripts/*.sh scripts/**/*.sh .githooks/* 2>/dev/null || {
-    echo -e "${RED}❌ shellcheck failed${NC}"
-    exit 1
-}
-
-# Python linting
-echo -e "${CYAN}  ruff check...${NC}"
-uv run ruff check . || {
-    echo -e "${RED}❌ ruff check failed${NC}"
-    exit 1
-}
-
-echo -e "${CYAN}  ruff format...${NC}"
-uv run ruff format --check . || {
-    echo -e "${RED}❌ ruff format failed (run 'uv run ruff format .' to fix)${NC}"
-    exit 1
-}
-
-echo -e "${CYAN}  mypy...${NC}"
-uv run mypy . --explicit-package-bases || {
-    echo -e "${RED}❌ mypy failed${NC}"
-    exit 1
-}
-
-# Go build
-echo -e "${CYAN}  go build...${NC}"
-(cd pocketbase && go build .) || {
-    echo -e "${RED}❌ go build failed${NC}"
-    exit 1
-}
-
-# Go linting (matches CI)
-echo -e "${CYAN}  golangci-lint...${NC}"
-if command -v golangci-lint &> /dev/null; then
-    (cd pocketbase && golangci-lint run --config ../.golangci.yml) || {
-        echo -e "${RED}❌ golangci-lint failed${NC}"
-        exit 1
-    }
-else
-    echo -e "${YELLOW}  ⚠️  golangci-lint not installed, skipping (install: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest)${NC}"
-fi
-
-# Frontend formatting check
-echo -e "${CYAN}  prettier...${NC}"
-(cd frontend && npm run format:check) || {
-    echo -e "${RED}❌ prettier failed (run 'cd frontend && npm run format' to fix)${NC}"
-    exit 1
-}
-
-# Frontend linting
-echo -e "${CYAN}  eslint...${NC}"
-(cd frontend && npm run lint) || {
-    echo -e "${RED}❌ eslint failed${NC}"
-    exit 1
-}
-
-# Dockerfile chmod check (prevent chmod +x on scripts, must use chmod 755)
-echo -e "${CYAN}  dockerfile chmod...${NC}"
-for df in docker/Dockerfile.*; do
-    if [ -f "$df" ] && grep -qE 'chmod \+x.*/.*\.(sh|bash)' "$df"; then
-        echo -e "${RED}❌ $df uses 'chmod +x' on shell scripts${NC}"
-        echo "   Use 'chmod 755' for explicit world-readable permissions"
-        exit 1
-    fi
-done
-
-echo -e "${GREEN}✓ All linting passed${NC}"
-
-# =============================================================================
-# BEHIND ORIGIN CHECK (main branch only)
-# =============================================================================
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [ "$BRANCH" != "main" ]; then
     exit 0
 fi
 
-# Fetch latest from origin (silently)
+# Fetch latest from origin
 git fetch origin main --quiet 2>/dev/null || {
-    echo -e "${YELLOW}⚠️  Could not fetch from origin (offline?)${NC}"
-    exit 0  # Allow push if can't fetch (might be offline)
+    echo -e "${YELLOW}Could not fetch from origin (offline?)${NC}"
+    exit 0
 }
 
 LOCAL=$(git rev-parse HEAD)
 REMOTE=$(git rev-parse origin/main 2>/dev/null || echo "")
 BASE=$(git merge-base HEAD origin/main 2>/dev/null || echo "")
 
-# If we can't determine remote state, allow push
-if [ -z "$REMOTE" ] || [ -z "$BASE" ]; then
-    exit 0
-fi
+[ -z "$REMOTE" ] || [ -z "$BASE" ] && exit 0
 
-# Check relationship between local and remote
 if [ "$LOCAL" = "$REMOTE" ]; then
-    # Up to date
     exit 0
 elif [ "$REMOTE" = "$BASE" ]; then
-    # Local is ahead of remote - normal push
     exit 0
 elif [ "$LOCAL" = "$BASE" ]; then
-    # Local is behind remote - BLOCK
     BEHIND_COUNT=$(git rev-list --count HEAD..origin/main)
-
     echo ""
     echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo -e "${RED}  PUSH BLOCKED: Local main is ${BEHIND_COUNT} commit(s) behind origin${NC}"
@@ -135,17 +46,12 @@ elif [ "$LOCAL" = "$BASE" ]; then
     echo -e "${CYAN}Recent commits on origin/main that you're missing:${NC}"
     git log --oneline HEAD..origin/main | head -5
     echo ""
-    echo -e "${YELLOW}To sync your local branch:${NC}"
-    echo -e "  ${GREEN}git pull --rebase origin main${NC}"
-    echo ""
-    echo -e "${YELLOW}Then retry your push.${NC}"
+    echo -e "${YELLOW}To sync:${NC} ${GREEN}git pull --rebase origin main${NC}"
     echo ""
     exit 1
 else
-    # Branches have diverged - BLOCK
     BEHIND_COUNT=$(git rev-list --count HEAD..origin/main)
     AHEAD_COUNT=$(git rev-list --count origin/main..HEAD)
-
     echo ""
     echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo -e "${RED}  PUSH BLOCKED: Local and origin/main have diverged${NC}"
@@ -156,11 +62,7 @@ else
     echo -e "${CYAN}Commits on origin/main that you're missing:${NC}"
     git log --oneline HEAD..origin/main | head -5
     echo ""
-    echo -e "${YELLOW}To sync your local branch:${NC}"
-    echo -e "  ${GREEN}git pull --rebase origin main${NC}"
-    echo ""
-    echo -e "${YELLOW}If you have conflicts, resolve them, then:${NC}"
-    echo -e "  ${GREEN}git rebase --continue${NC}"
+    echo -e "${YELLOW}To sync:${NC} ${GREEN}git pull --rebase origin main${NC}"
     echo ""
     exit 1
 fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,15 +328,18 @@ After `git pull`, the `post-merge` hook detects merged worktree branches and sug
 - Never push without user consent
 - Never add others' changes to your commits (check `git status` first)
 
-## Pre-Push Checklist
-The pre-push hook runs these automatically. To run manually:
+## Pre-Commit Checklist
+The pre-commit hook (`scripts/ci/quick_check.sh`) runs these automatically. To run manually:
 ```bash
-shellcheck scripts/*.sh scripts/**/*.sh .githooks/*  # Shell linting
-uv run ruff check --fix .      # Python linting (auto-fix)
-uv run ruff format .           # Python formatting (auto-fix)
-uv run mypy bunking api        # Type checking
-cd pocketbase && go build .    # Go build
-cd frontend && npm run lint    # Frontend linting
+uv run ruff check --fix .                  # Python linting (auto-fix)
+uv run ruff format .                       # Python formatting (auto-fix)
+uv run mypy . --explicit-package-bases     # Python type checking
+cd frontend && npm run type-check          # TypeScript type checking
+cd frontend && npm run lint                # ESLint
+cd frontend && npm run format              # Prettier (auto-fix)
+cd pocketbase && go vet ./...              # Go static analysis
+gofmt -w pocketbase                        # Go formatting (auto-fix)
+shellcheck scripts/*.sh .githooks/*        # Shell linting
 ```
 
 ## 🚨 CRITICAL: Development Quality Standards

--- a/scripts/ci/quick_check.sh
+++ b/scripts/ci/quick_check.sh
@@ -33,7 +33,7 @@ FAILED=0
 
 # 1. Python formatting with ruff
 echo -n "Python formatting (ruff format)... "
-if uv run ruff format --check . --exclude="docs/,drive/" > /tmp/ruff_format_output.txt 2>&1; then
+if uv run ruff format --check . > /tmp/ruff_format_output.txt 2>&1; then
     echo -e "${GREEN}✓${NC}"
 else
     echo -e "${RED}✗${NC}"
@@ -46,7 +46,7 @@ fi
 
 # 2. Python linting with ruff (includes import sorting via 'I' in ruff.toml)
 echo -n "Python linting (ruff)... "
-if uv run ruff check . --exclude="docs/,drive/" > /tmp/ruff_output.txt 2>&1; then
+if uv run ruff check . > /tmp/ruff_output.txt 2>&1; then
     echo -e "${GREEN}✓${NC}"
 else
     echo -e "${RED}✗${NC}"
@@ -89,6 +89,19 @@ else
     echo -e "${RED}✗${NC}"
     echo "ESLint errors:"
     head -30 /tmp/eslint_output.txt
+    FAILED=1
+fi
+
+# 4c. Frontend formatting with Prettier
+echo -n "Frontend formatting (Prettier)... "
+if (cd frontend && npm run format:check > /tmp/prettier_output.txt 2>&1); then
+    echo -e "${GREEN}✓${NC}"
+else
+    echo -e "${RED}✗${NC}"
+    echo "Prettier formatting issues:"
+    head -20 /tmp/prettier_output.txt
+    echo ""
+    echo "Tip: Run 'cd frontend && npm run format' to auto-format"
     FAILED=1
 fi
 

--- a/scripts/setup-git-hooks.sh
+++ b/scripts/setup-git-hooks.sh
@@ -16,6 +16,12 @@ echo -e "${YELLOW}Setting up git hooks...${NC}"
 # Configure git to use .githooks directory
 git config core.hooksPath .githooks
 
+# Remove stale .git/hooks/pre-commit if it exists (legacy, replaced by .githooks/)
+if [ -f "$PROJECT_ROOT/.git/hooks/pre-commit" ] && [ ! -L "$PROJECT_ROOT/.git/hooks/pre-commit" ]; then
+    rm -f "$PROJECT_ROOT/.git/hooks/pre-commit"
+    echo -e "${YELLOW}Removed stale .git/hooks/pre-commit (replaced by .githooks/pre-commit)${NC}"
+fi
+
 echo -e "${GREEN}✓ Git hooks configured${NC}"
 echo ""
 echo "Active hooks:"
@@ -25,6 +31,6 @@ echo -e "${GREEN}Done!${NC} Git will now use hooks from .githooks/"
 echo ""
 echo "Hooks installed:"
 echo "  • commit-msg: Validates commit message format (type(scope): description)"
-echo "  • pre-commit: Blocks commits on main if behind origin (early warning)"
-echo "  • pre-push: Runs linting (shellcheck, ruff, mypy, go build, eslint) + blocks if behind origin"
+echo "  • pre-commit: Runs linting/formatting (quick_check.sh) + behind-origin warning"
+echo "  • pre-push: Blocks pushing main when behind origin"
 echo "  • post-merge: Notifies when worktree branches are merged (auto-cleanup reminder)"

--- a/scripts/worktree/new.sh
+++ b/scripts/worktree/new.sh
@@ -147,6 +147,9 @@ WORKTREE_NAME=$FEATURE_NAME
 EOF
 fi
 
+# Point git hooks to the checked-in .githooks directory
+git config core.hooksPath .githooks
+
 # Install dependencies (fast with caching)
 echo -e "${BLUE}Installing dependencies...${NC}"
 uv sync --frozen &


### PR DESCRIPTION
## Summary

- Adds prettier (`format:check`) to the pre-commit checks in `quick_check.sh` — it was the only formatter running in CI but never locally
- Consolidates two conflicting hooks directories (`.git/hooks/` vs `.githooks/`) into a single source of truth (`.githooks/`)
- Removes ruff `--exclude` CLI overrides from `quick_check.sh` so local and CI use the same excludes from `ruff.toml`
- Simplifies `.githooks/pre-push` to behind-origin guard only (all linting now runs at pre-commit)
- Adds `core.hooksPath` setup to worktree creation so new worktrees get the right hooks
- Updates `setup-git-hooks.sh` to clean stale `.git/hooks/pre-commit`

## What was broken

`core.hooksPath` pointed to `.git/hooks/` which had a `pre-commit` calling `quick_check.sh` but **no `pre-push`**. The `.githooks/pre-push` (which had prettier, golangci-lint, etc.) was dead — never executed. Prettier failures were only caught in CI.

## Test plan

- [x] `quick_check.sh` runs all checks including prettier
- [ ] Verify CI passes (same checks, no ruff exclude drift)
- [ ] After merge, run `./scripts/setup-git-hooks.sh` to activate `.githooks/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pre-commit hook now runs linting and formatting checks before committing code.

* **Chores**
  * Simplified pre-push hook to focus on main branch synchronization validation.
  * Updated git hook installation messages and documentation for improved developer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->