### PR TITLE
chore(docs): gitignore superpowers docs folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,7 @@ coverage.xml
 .playwright-mcp/
 .claude/
 .superpowers
+docs/superpowers/
 
 # =============================================================================
 # Jupyter Notebooks


### PR DESCRIPTION
## Summary
- Add `docs/superpowers/` to `.gitignore` to prevent plans and specs from being tracked

## Test plan
- [x] Verify `docs/superpowers/` files no longer show in `git status`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration to ignore additional directories in the project structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->