### PR TITLE
fix(ci): POSIX post-merge hook and smart pre-push glob filtering

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -71,35 +71,62 @@ pre-push:
   parallel: true
   commands:
     ruff-check:
+      glob:
+        - "**/*.py"
+        - "ruff.toml"
+        - "pyproject.toml"
       run: uv run ruff check .
 
     mypy:
+      glob:
+        - "**/*.py"
+        - "pyproject.toml"
       run: uv run mypy . --explicit-package-bases
 
     eslint:
       root: "frontend/"
+      glob:
+        - "frontend/**/*.{ts,tsx,js,jsx}"
+        - "frontend/eslint.config.js"
       run: npm run lint
 
     type-check:
       root: "frontend/"
+      glob:
+        - "frontend/**/*.{ts,tsx}"
+        - "frontend/tsconfig.json"
+        - "frontend/tsconfig.node.json"
       run: npm run type-check
 
     golangci-lint:
       root: "pocketbase/"
+      glob:
+        - "pocketbase/*.go"
+        - "pocketbase/**/*.go"
+        - ".golangci.yml"
       run: golangci-lint run --config ../.golangci.yml
       skip:
         - run: "! command -v golangci-lint >/dev/null 2>&1"
 
     go-build:
       root: "pocketbase/"
+      glob:
+        - "pocketbase/*.go"
+        - "pocketbase/**/*.go"
+        - "pocketbase/go.mod"
+        - "pocketbase/go.sum"
       run: go build .
 
     shellcheck:
+      glob: "**/*.sh"
       run: find scripts/ docker/ frontend/ tests/shell/ -maxdepth 3 -name '*.sh' 2>/dev/null | xargs shellcheck --severity=warning
       skip:
         - run: "! command -v shellcheck >/dev/null 2>&1"
 
     hadolint:
+      glob:
+        - "docker/Dockerfile.*"
+        - ".hadolint.yaml"
       run: |
         for df in docker/Dockerfile.*; do
           [ -f "$df" ] || continue
@@ -111,6 +138,9 @@ pre-push:
         - run: "! command -v docker >/dev/null 2>&1"
 
     caddy-validate:
+      glob:
+        - "docker/Caddyfile"
+        - "frontend/Caddyfile"
       run: |
         caddy validate --config docker/Caddyfile 2>&1 && \
         caddy validate --config frontend/Caddyfile 2>&1
@@ -119,17 +149,30 @@ pre-push:
 
     pb-js-lint:
       root: "pocketbase/"
+      glob:
+        - "pocketbase/pb_migrations/*.js"
+        - "pocketbase/pb_hooks/*.js"
+        - "pocketbase/package.json"
       run: npm run lint
 
     pytest:
+      glob:
+        - "**/*.py"
+        - "pyproject.toml"
       run: uv run pytest tests/unit/ -v --tb=short
 
     go-test:
       root: "pocketbase/"
+      glob:
+        - "pocketbase/*.go"
+        - "pocketbase/**/*.go"
       run: go test -race ./... -v
 
     vitest:
       root: "frontend/"
+      glob:
+        - "frontend/**/*.{ts,tsx,js,jsx}"
+        - "frontend/vitest.config.ts"
       run: npx vitest run
 
     behind-origin:


### PR DESCRIPTION
## Summary
- Fix post-merge worktree-cleanup hook that used bash arrays (`MERGED=()`, `${#MERGED[@]}`) but lefthook runs with `sh` — caused `Syntax error: "(" unexpected` on every `git pull`
- Add glob filters to all pre-push commands so they skip when pushed files don't match, turning a ~2.5min full suite into instant skips for docs/config-only pushes

## How glob filtering works
Lefthook checks `{push_files}` against each command's `glob`. If no files match, the command is skipped entirely. When files do match, the full command runs as-is (e.g., `ruff check .` still checks everything). Each glob includes relevant config files so config changes still trigger checks.

## Pre-push skip matrix

| Command | Glob triggers |
|---------|--------------|
| ruff-check | `**/*.py`, `ruff.toml`, `pyproject.toml` |
| mypy | `**/*.py`, `pyproject.toml` |
| eslint | `frontend/**/*.{ts,tsx,js,jsx}`, `frontend/eslint.config.js` |
| type-check | `frontend/**/*.{ts,tsx}`, `frontend/tsconfig*.json` |
| golangci-lint | `pocketbase/*.go`, `pocketbase/**/*.go`, `.golangci.yml` |
| go-build | `pocketbase/*.go`, `pocketbase/**/*.go`, `pocketbase/go.{mod,sum}` |
| go-test | `pocketbase/*.go`, `pocketbase/**/*.go` |
| pytest | `**/*.py`, `pyproject.toml` |
| vitest | `frontend/**/*.{ts,tsx,js,jsx}`, `frontend/vitest.config.ts` |
| pb-js-lint | `pocketbase/pb_{migrations,hooks}/*.js`, `pocketbase/package.json` |
| shellcheck | `**/*.sh` |
| hadolint | `docker/Dockerfile.*`, `.hadolint.yaml` |
| caddy-validate | `docker/Caddyfile`, `frontend/Caddyfile` |
| behind-origin | no glob (always runs) |

## Test plan
- [x] `lefthook validate` passes
- [x] `lefthook run post-merge` succeeds (no sh syntax error)
- [x] `lefthook run pre-push` all checks pass
- [ ] Push a docs-only change — expensive checks should show `(skip)` in lefthook output