### PR TITLE
docs(docs): streamline TDD rules — workflow over commit granularity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,12 +401,13 @@ The `main` branch is protected by a GitHub **Ruleset** (not legacy branch protec
 **You MUST follow TDD methodology for all new feature development:**
 
 1. **Write Tests FIRST**: Create failing tests that define the expected behavior
-2. **Commit Tests Separately**: Tests must be committed BEFORE implementation
+2. **Verify Tests Fail**: Run tests to confirm they fail before writing implementation (red phase)
 3. **Implement to Pass Tests**: Write minimal code to make tests pass
 4. **Never Modify Tests to Match Implementation**: Tests define the spec, not the other way around
 
+Tests and implementation may be in the same commit — PRs are squash-merged so commit granularity doesn't matter. What matters is the **workflow discipline**: tests are written first and verified failing before implementation begins.
+
 ### Anti-Patterns to AVOID
-- ❌ Creating tests and implementation in the same commit
 - ❌ Writing tests after implementation
 - ❌ Modifying tests to match implementation behavior
 - ❌ Skipping the "red" phase (tests must fail first)


### PR DESCRIPTION
## Summary
- Removed commit-separation requirement from TDD rules — tests and implementation may be in the same commit since PRs are squash-merged
- Kept the core TDD discipline: write tests first, verify they fail (red phase), then implement
- Removed "Creating tests and implementation in the same commit" anti-pattern that was generating noisy code review findings

## Test plan
- [x] Docs-only change, no functional impact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development workflow documentation to clarify test verification procedures as a required first step, with refined guidance on commit practices and workflow discipline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->