### PR TITLE
docs(docs): update issue triage after Group 5 completion

### DIFF
--- a/docs/reference/issue-triage.md
+++ b/docs/reference/issue-triage.md
@@ -1,7 +1,7 @@
 # Issue Triage
 
 Open issues grouped by code area with dependencies and suggested attack order.
-Last updated: 2026-03-13 (35 open issues).
+Last updated: 2026-03-13 (34 open issues).
 
 ---
 
@@ -50,19 +50,6 @@ Last updated: 2026-03-13 (35 open issues).
 
 ---
 
-## Group 5: Sync / Go Backend *(in progress)*
-
-**Priority: High** — Data integrity bugs
-
-| # | Title | Type |
-|---|-------|------|
-| 484 | Validate CAMPMINDER_SEASON_ID instead of defaulting to 2025 | bug |
-| 504 | Standardize source_field comparisons to use SourceField constants | tech-debt |
-
-**Interplay:** Independent. #484 is a data integrity risk, #504 prevents future normalization bugs.
-
----
-
 ## Group 8: Frontend — General Refactors & Quality
 
 **Priority: Low** — Independent quick wins
@@ -88,6 +75,7 @@ Last updated: 2026-03-13 (35 open issues).
 
 | # | Title | Type |
 |---|-------|------|
+| 546 | Solver stat/multiplier lookups use snake_case keys against canonical source_field values | bug |
 | 535 | Guard against `started_at` KeyError in solver_runner failure path | bug |
 | 487 | Extract shared session resolution function | refactor |
 | 486 | Extract PocketBase collection names into constants | tech-debt |
@@ -95,7 +83,7 @@ Last updated: 2026-03-13 (35 open issues).
 | 441 | Use existing `build_ag_parent_map` utility in registration service | refactor |
 | 423 | Hoist inline ForecastService imports in metrics.py | refactor |
 
-**Interplay:** #535 is a quick bug fix in `solver_runner.py`. #486 is foundational — makes other refactors safer. Good for parallel agents.
+**Interplay:** #546 is a pre-existing solver scoring bug surfaced during #504 review — `solution.py`, `score_evaluator.py`, `direct_solver.py` use snake_case keys that never match canonical `source_field` values. #535 is a quick bug fix in `solver_runner.py`. #486 is foundational — makes other refactors safer. Good for parallel agents.
 
 ---
 
@@ -119,7 +107,7 @@ Last updated: 2026-03-13 (35 open issues).
 
 1. ~~**Group 1**~~ — ✅ Complete (PR #530)
 2. ~~**Group 7**~~ — ✅ Complete (PR #539)
-3. **Group 5** — Sync bugs *(in progress)* — #484 is data integrity
+3. ~~**Group 5**~~ — ✅ Complete (PRs #540, #544)
 4. ~~**Group 6**~~ — ✅ Complete (PR #534)
 5. **Group 2** — Velocity backend (bigger scope, #456 correctness bug first)
 6. **Group 9** — API refactors (#535 bug first, rest are low-risk DRY)
@@ -136,3 +124,4 @@ Last updated: 2026-03-13 (35 open issues).
 | Stale sync issues (#471, #497, #517) | — | 2026-03-13 | Closed as already fixed |
 | Group 6: Solver (#500, #493, #494, #483) | #534 | 2026-03-13 | Spawned #535, #536, #537 during review |
 | Group 7: Geo frontend (#518, #519, #520, #521) | #539 | 2026-03-13 | Bug + a11y + test + QueryGuard migration |
+| Group 5: Sync / Go backend (#484, #504) | #540, #544 | 2026-03-13 | Spawned #546 (solver snake_case lookup bug) |


### PR DESCRIPTION
## Summary
- Mark Group 5 (Sync / Go Backend) as complete — #484 (PR #540) and #504 (PR #544) merged
- Add #546 (solver snake_case lookup bug, spawned during #504 code review) to Group 9
- Update open issue count: 35 → 34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated issue triage documentation to reflect current progress and tracking status
  * Marked Group 5 work as completed with associated pull requests documented
  * Added documentation for new Solver-related issue and its impact across components
  * Reduced total open issue count from 35 to 34

<!-- end of auto-generated comment: release notes by coderabbit.ai -->