### PR TITLE
fix(ci): mount .hadolint.yaml in CI instead of hardcoding flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,13 +376,13 @@ jobs:
       with:
         persist-credentials: false
 
-    # Dockerfile linting (stdin, no mounts - avoids self-hosted runner volume mount issues)
+    # Dockerfile linting — mounts .hadolint.yaml so CI matches local (lefthook) config
     # Each file needs its own docker run because hadolint reads from stdin (< "$df")
     - name: Dockerfile linting (hadolint)
       run: |
         for df in docker/Dockerfile.api docker/Dockerfile.caddy docker/Dockerfile.pocketbase docker/Dockerfile.init; do
           echo "=== Linting $df ==="
-          docker run --rm -i hadolint/hadolint /bin/hadolint --ignore DL3008 --failure-threshold error - < "$df"
+          docker run --rm -i -v "$PWD/.hadolint.yaml:/.hadolint.yaml" hadolint/hadolint < "$df"
         done
 
     # Caddyfile validation (stdin, no mounts - avoids self-hosted runner volume mount issues)


### PR DESCRIPTION
## Summary
- Mounts `.hadolint.yaml` config file in CI hadolint step instead of hardcoding `--ignore DL3008 --failure-threshold error` inline
- Aligns CI with local lefthook config, eliminating config drift between local and CI linting

Closes #528

## Test plan
- [x] Pre-push hooks pass (hadolint included)
- [ ] CI hadolint step passes with mounted config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI configuration to align Dockerfile linting behavior between local development and automated pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->