### PR TITLE
docs(solver): document missing-target impossible case in _validate_requests

### DIFF
--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -196,6 +196,8 @@ class DirectBunkingSolver:
         - bunk_with targeting a person in a different session (session boundaries
           prevent sharing a bunk). not_bunk_with across sessions is still possible
           since separation is guaranteed by session boundaries.
+        - bunk_with or not_bunk_with request with no requested_person_cm_id
+          (malformed request)
         """
         person_by_cm_id = self.input.person_by_cm_id
         total_requests = 0
@@ -245,7 +247,7 @@ class DirectBunkingSolver:
         if impossible_count > 0:
             logger.warning(
                 f"Request validation: {impossible_count} of {total_requests} requests "
-                f"are infeasible (person not in solver or in a different session)"
+                f"are infeasible (person not in solver, in a different session, or missing target)"
             )
             logger.warning(f"Affected campers: {len(affected_campers)}")
 


### PR DESCRIPTION
## Summary
- Add third impossible case to `_validate_requests` docstring: requests with no `requested_person_cm_id` (malformed requests)
- Update warning log message to mention "or missing target" alongside existing reasons

Closes #552

## Test plan
- [x] Docstring-only + log message change, no behavioral impact
- [x] Existing solver tests pass (2978 unit tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced request validation to properly identify and classify malformed requests when required fields are missing, improving error detection accuracy.
  * Expanded error messaging to provide more comprehensive failure diagnostics, now including missing target information along with other validation failure conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->