### PR TITLE
docs(metrics): add missing duration parameter docstrings

### DIFF
--- a/api/services/historical_service.py
+++ b/api/services/historical_service.py
@@ -53,6 +53,8 @@ class HistoricalService:
             session_types: Optional list of session types to filter.
             session_cm_id: Optional session CampMinder ID to filter by.
                 When provided, filters to sessions with the same NAME across years.
+            duration: Optional duration category (e.g., "1-week", "2-week") to filter
+                sessions by length.
 
         Returns:
             HistoricalTrendsResponse with trend data.

--- a/api/services/registration_service.py
+++ b/api/services/registration_service.py
@@ -77,6 +77,8 @@ class RegistrationService:
             session_types: Optional list of session types to filter.
             status_filter: Optional status filter (default: enrolled).
             session_cm_id: Optional specific session ID to filter.
+            duration: Optional duration category (e.g., "1-week", "2-week") to filter
+                sessions by length.
 
         Returns:
             RegistrationMetricsResponse with all breakdown metrics.

--- a/api/services/retention_service.py
+++ b/api/services/retention_service.py
@@ -71,6 +71,8 @@ class RetentionService:
             compare_year: The comparison year (e.g., 2026).
             session_types: Optional list of session types to filter.
             session_cm_id: Optional specific session ID to filter.
+            duration: Optional duration category (e.g., "1-week", "2-week") to filter
+                sessions by length.
 
         Returns:
             RetentionMetricsResponse with all breakdown metrics.

--- a/api/services/retention_trends_service.py
+++ b/api/services/retention_trends_service.py
@@ -69,6 +69,8 @@ class RetentionTrendsService:
             num_years: Number of year-to-year transitions to include (default: 3).
             session_types: Optional list of session types to filter.
             session_cm_id: Optional specific session ID to filter.
+            duration: Optional duration category (e.g., "1-week", "2-week") to filter
+                sessions by length.
 
         Returns:
             RetentionTrendsResponse with trend data.

--- a/api/utils/session_metrics.py
+++ b/api/utils/session_metrics.py
@@ -137,6 +137,9 @@ def filter_attendees_by_session(
         session_types: Session types to include (None = all).
         session_cm_id: Specific session to filter to (None = all).
         ag_session_ids: AG sessions that belong to the parent session.
+        session_cm_ids: Optional set of session cm_ids to restrict to (e.g., from
+            duration filtering via resolve_duration_sessions). AG children of
+            matching sessions are also allowed through.
 
     Returns:
         Filtered list of attendees.

--- a/frontend/src/contexts/MetricsSessionContext.tsx
+++ b/frontend/src/contexts/MetricsSessionContext.tsx
@@ -8,6 +8,10 @@
  * View mode (?view=quests) switches between camp sessions and quest sessions.
  * Default (no view param) shows camp sessions only.
  *
+ * Duration filter (?duration=<category>) filters sessions by length category
+ * (e.g., "1-week", "2-week"). Mutually exclusive with session selection --
+ * setting one clears the other.
+ *
  * Pattern: Similar to CurrentYearContext - provider here, hook in useMetricsSession.ts
  */
 import { type ReactNode, useCallback, useMemo, useState } from 'react'

--- a/frontend/src/hooks/useMetricsSession.ts
+++ b/frontend/src/hooks/useMetricsSession.ts
@@ -24,7 +24,7 @@ export interface MetricsSessionContextType {
   clearSession: () => void
   /** Current view mode: 'sessions' (camp) or 'quests' */
   viewMode: MetricsViewMode
-  /** Set the view mode and clear session selection */
+  /** Set the view mode, clearing both session selection and duration filter */
   setViewMode: (mode: MetricsViewMode) => void
   /** Active session types derived from viewMode + selectedSessionCmId */
   activeSessionTypes: readonly string[]


### PR DESCRIPTION
## Summary
- Add `duration` parameter documentation to existing `Args:` sections across metrics service methods (`calculate_registration`, `calculate_retention`, `calculate_retention_trends`, `calculate_historical_trends`)
- Document `session_cm_ids` parameter in `filter_attendees_by_session` docstring
- Document `?duration` URL param in `MetricsSessionContext.tsx` file-level docstring
- Update `setViewMode` JSDoc in `useMetricsSession.ts` to mention duration clearing

Closes #435

## Test plan
- [x] Documentation-only changes, no behavioral impact
- [x] Python tests pass (2978 passed)
- [x] Frontend tests pass (2265 passed, 1 pre-existing timeout in unrelated ResolveDialog)
- [x] All pre-push hooks pass (ruff, mypy, eslint, vitest, pytest, go-test, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added duration-based filtering capability for session metrics, enabling users to filter analytics by session length (e.g., "1-week", "2-week" sessions) across retention, registration, and historical trend calculations.

* **Documentation**
  * Enhanced documentation across service layers to clarify duration filtering parameters and behavior for better user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->