### PR TITLE
chore(api): migrate logging.getLogger to get_logger from bunking.logging_config

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -11,17 +11,17 @@ This module provides:
 from __future__ import annotations
 
 import asyncio
-import logging
 from typing import Any
 
 from bunking.graph.graph_cache_manager import GraphCacheManager
+from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
 from .services.id_cache import IDLookupCache
 from .services.metrics_cache import MetricsCache
 from .settings import get_settings
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # ========================================
 # PocketBase Client

--- a/api/routers/debug.py
+++ b/api/routers/debug.py
@@ -6,7 +6,6 @@ AI intent parsing without running the full 3-phase pipeline.
 
 from __future__ import annotations
 
-import logging
 import re
 from collections import defaultdict
 from datetime import UTC, datetime
@@ -16,6 +15,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from bunking.auth_middleware import AuthUser
+from bunking.logging_config import get_logger
 from bunking.rbac.dependencies import require_admin
 from bunking.sync.bunk_request_processor.data.repositories.debug_parse_repository import (
     DebugParseRepository,
@@ -63,7 +63,7 @@ from ..schemas.debug import (
 )
 from ..settings import get_settings
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 router = APIRouter(prefix="/api/debug", tags=["debug"])
 

--- a/api/routers/requests.py
+++ b/api/routers/requests.py
@@ -6,13 +6,13 @@ This router provides endpoints for merging and splitting bunk_requests.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, field_validator
 
 from bunking.auth_middleware import AuthUser
+from bunking.logging_config import get_logger
 from bunking.rbac.dependencies import require_permission
 from bunking.rbac.permissions import Permission
 from bunking.sync.bunk_request_processor.core.models import (
@@ -32,7 +32,7 @@ from ..dependencies import pb
 # Reverse mapping: source_field ("Share Bunk With") -> field enum ("bunk_with")
 SOURCE_FIELD_TO_DB_FIELD = {v: k for k, v in FIELD_TO_SOURCE_FIELD.items()}
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 router = APIRouter(prefix="/api", tags=["requests"])
 

--- a/api/routers/scenarios.py
+++ b/api/routers/scenarios.py
@@ -11,7 +11,6 @@ This router handles:
 from __future__ import annotations
 
 import asyncio
-import logging
 from datetime import UTC, datetime
 from typing import Annotated, Any
 from uuid import uuid4
@@ -20,6 +19,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Path, Qu
 from pocketbase.client import ClientResponseError  # type: ignore[attr-defined]
 
 from bunking.auth_middleware import AuthUser
+from bunking.logging_config import get_logger
 from bunking.models import (
     ClearScenarioRequest,
     CreateScenarioRequest,
@@ -35,7 +35,7 @@ from ..dependencies import pb, solver_runs
 from ..services.session_context import build_session_context
 from ..services.solver_runner import run_solver_task_v2
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 router = APIRouter(prefix="/api/scenarios", tags=["scenarios"])
 

--- a/api/routers/session_availability.py
+++ b/api/routers/session_availability.py
@@ -2,18 +2,18 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from api.utils.validators import check_duration_session_exclusive
 from bunking.auth_middleware import AuthUser, get_current_user
+from bunking.logging_config import get_logger
 
 from ..dependencies import pb
 from ..schemas.session_availability import SessionAvailabilityResponse
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 router = APIRouter(prefix="/api/metrics", tags=["metrics"])
 

--- a/api/routers/social_graph.py
+++ b/api/routers/social_graph.py
@@ -11,7 +11,6 @@ This router handles:
 from __future__ import annotations
 
 import asyncio
-import logging
 from datetime import UTC, datetime
 from typing import Annotated
 
@@ -20,6 +19,7 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from bunking.auth_middleware import AuthUser, get_current_user
 from bunking.graph.optimized_graph_builder import OptimizedSocialGraphBuilder
 from bunking.graph.social_graph_builder import SocialGraphBuilder
+from bunking.logging_config import get_logger
 from bunking.rbac.dependencies import require_permission
 from bunking.rbac.permissions import Permission
 
@@ -36,7 +36,7 @@ from ..schemas import (
 )
 from ..settings import get_settings
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Load settings for graph algorithm configuration
 _settings = get_settings()

--- a/api/routers/solver.py
+++ b/api/routers/solver.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 from collections import defaultdict
 from datetime import UTC, datetime
 from pathlib import Path
@@ -27,6 +26,7 @@ from pocketbase.client import ClientResponseError  # type: ignore[attr-defined]
 
 from bunking.auth_middleware import AuthUser
 from bunking.config import ConfigLoader
+from bunking.logging_config import get_logger
 from bunking.rbac.dependencies import require_permission
 from bunking.rbac.permissions import Permission
 
@@ -40,7 +40,7 @@ from ..schemas import (
 from ..services.session_context import build_session_context
 from ..services.solver_runner import run_solver_task_v2
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 router = APIRouter(prefix="/api", tags=["solver"])
 

--- a/api/routers/validation.py
+++ b/api/routers/validation.py
@@ -8,7 +8,6 @@ against constraints and rules.
 from __future__ import annotations
 
 import asyncio
-import logging
 import os
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -19,6 +18,7 @@ from pocketbase.client import ClientResponseError  # type: ignore[attr-defined]
 
 from bunking.auth_middleware import AuthUser
 from bunking.bunking_validator import BunkingValidator, HistoricalBunkingRecord
+from bunking.logging_config import get_logger
 from bunking.models import (
     Bunk,
     BunkAssignment,
@@ -33,7 +33,7 @@ from ..dependencies import pb
 from ..schemas import ValidateBunkingRequest
 from ..services.session_context import build_session_context
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 router = APIRouter(prefix="/api", tags=["validation"])
 

--- a/api/services/cancellation_service.py
+++ b/api/services/cancellation_service.py
@@ -9,7 +9,6 @@ Analyzes cancelled/withdrawn/dismissed attendees to understand:
 
 from __future__ import annotations
 
-import logging
 from collections import defaultdict
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
@@ -26,11 +25,12 @@ from api.services.breakdown_calculator import calculate_percentage, compute_regi
 from api.services.extractors import extract_gender, extract_grade
 from api.utils.session_metrics import build_ag_parent_map, get_session_from_expand, resolve_duration_sessions
 from api.utils.session_swap import detect_session_swaps
+from bunking.logging_config import get_logger
 
 if TYPE_CHECKING:
     from .metrics_repository import MetricsRepository
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Summer session types to include in analysis
 SUMMER_SESSION_TYPES = ("main", "embedded", "ag", "quest")

--- a/api/services/data_fetcher.py
+++ b/api/services/data_fetcher.py
@@ -9,7 +9,6 @@ This service handles:
 from __future__ import annotations
 
 import asyncio
-import logging
 from collections import defaultdict
 from typing import Any
 
@@ -24,12 +23,13 @@ from bunking.direct_solver import (
     DirectSolverInput,
     HistoricalBunkingRecord,
 )
+from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
 from ..dependencies import pb
 from .session_context import SessionContext, build_session_context
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 async def fetch_session_data_v2(

--- a/api/services/day1_service.py
+++ b/api/services/day1_service.py
@@ -7,7 +7,6 @@ by matching attendee effective_date against tier opening dates.
 from __future__ import annotations
 
 import asyncio
-import logging
 from datetime import date, datetime
 
 from api.schemas.day1 import (
@@ -20,8 +19,9 @@ from api.schemas.day1 import (
 from api.services.camp_calendar import REGISTRATION_TIERS, day1_window
 from api.services.metrics_repository import MetricsRepository
 from api.services.reconstruction import ENROLLMENT_STATUSES, parse_date_only
+from bunking.logging_config import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 AT_CAMP_TYPES = {"main", "embedded", "ag"}
 QUEST_TYPES = {"quest"}

--- a/api/services/forecast_service.py
+++ b/api/services/forecast_service.py
@@ -7,7 +7,6 @@ and revenue projections.
 from __future__ import annotations
 
 import asyncio
-import logging
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -24,11 +23,12 @@ from api.utils.session_metrics import (
     get_session_from_expand,
     resolve_duration_sessions,
 )
+from bunking.logging_config import get_logger
 
 if TYPE_CHECKING:
     from api.services.metrics_repository import MetricsRepository
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class ForecastService:

--- a/api/services/id_cache.py
+++ b/api/services/id_cache.py
@@ -7,11 +7,11 @@ Provides efficient CM ID <-> PB ID translations with caching.
 from __future__ import annotations
 
 import asyncio
-import logging
 
+from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class IDLookupCache:

--- a/api/services/metrics_cache.py
+++ b/api/services/metrics_cache.py
@@ -7,12 +7,13 @@ Thread-safe via RLock, modeled after bunking/graph/graph_cache_manager.py.
 
 from __future__ import annotations
 
-import logging
 import threading
 import time
 from typing import Any
 
-logger = logging.getLogger(__name__)
+from bunking.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 
 class MetricsCache:

--- a/api/services/metrics_repository.py
+++ b/api/services/metrics_repository.py
@@ -7,15 +7,15 @@ enabling dependency injection and testability.
 from __future__ import annotations
 
 import asyncio
-import logging
 from typing import TYPE_CHECKING, Any
 
 from api.services.reconstruction import parse_date_only
+from bunking.logging_config import get_logger
 
 if TYPE_CHECKING:
     from pocketbase import PocketBase
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class MetricsRepository:

--- a/api/services/metrics_sql_connection.py
+++ b/api/services/metrics_sql_connection.py
@@ -6,11 +6,12 @@ WAL mode for safe concurrent reads while PocketBase writes.
 
 from __future__ import annotations
 
-import logging
 import sqlite3
 from pathlib import Path
 
-logger = logging.getLogger(__name__)
+from bunking.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 _connection: sqlite3.Connection | None = None
 

--- a/api/services/metrics_sql_repository.py
+++ b/api/services/metrics_sql_repository.py
@@ -8,12 +8,13 @@ service-layer code expects.
 from __future__ import annotations
 
 import json
-import logging
 import sqlite3
 from types import SimpleNamespace
 from typing import Any
 
-logger = logging.getLogger(__name__)
+from bunking.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 
 class MetricsSQLRepository:

--- a/api/services/session_availability_service.py
+++ b/api/services/session_availability_service.py
@@ -7,8 +7,9 @@ enrollment counts, capacity, and status (open/limited/waitlist).
 from __future__ import annotations
 
 import asyncio
-import logging
 from typing import TYPE_CHECKING, Any, ClassVar
+
+from bunking.logging_config import get_logger
 
 if TYPE_CHECKING:
     from api.services.metrics_repository import MetricsRepository
@@ -21,7 +22,7 @@ from api.schemas.session_availability import (
 )
 from api.utils.session_metrics import resolve_duration_sessions
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class SessionAvailabilityService:

--- a/api/services/session_context.py
+++ b/api/services/session_context.py
@@ -17,17 +17,17 @@ Usage:
 from __future__ import annotations
 
 import asyncio
-import logging
 from dataclasses import dataclass
 
 from fastapi import HTTPException
 
+from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
 from .id_cache import IDLookupCache
 from .session_utils import get_related_session_ids
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @dataclass(frozen=True)

--- a/api/services/session_utils.py
+++ b/api/services/session_utils.py
@@ -7,13 +7,13 @@ This module provides session-related utility functions used across multiple rout
 from __future__ import annotations
 
 import asyncio
-import logging
 
+from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
 from ..dependencies import pb
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 async def get_related_session_ids(session_cm_id: int, year: int, pb_client: PocketBase | None = None) -> list[int]:

--- a/api/services/solver_runner.py
+++ b/api/services/solver_runner.py
@@ -9,12 +9,12 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 from datetime import UTC, datetime
 from typing import Any
 
 from bunking.config import ConfigLoader
 from bunking.direct_solver import DirectBunkingSolver
+from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
 from ..constants.collections import SOLVER_RUNS, SUPERUSERS
@@ -27,7 +27,7 @@ from .data_fetcher import (
     prepare_direct_solver_input,
 )
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 async def run_solver_task_v2(

--- a/api/services/waitlist_service.py
+++ b/api/services/waitlist_service.py
@@ -9,7 +9,6 @@ Implements four use cases:
 
 from __future__ import annotations
 
-import logging
 from collections import defaultdict
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
@@ -24,11 +23,12 @@ from api.schemas.metrics import (
 from api.services.breakdown_calculator import calculate_percentage, compute_registration_breakdown
 from api.services.extractors import extract_gender, extract_grade
 from api.utils.session_metrics import build_ag_parent_map, get_session_from_expand, resolve_duration_sessions
+from bunking.logging_config import get_logger
 
 if TYPE_CHECKING:
     from .metrics_repository import MetricsRepository
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Summer session types to include in analysis
 SUMMER_SESSION_TYPES = ("main", "embedded", "ag", "quest")

--- a/api/settings.py
+++ b/api/settings.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from bunking.logging_config import get_logger
+
 
 def _is_docker_environment() -> bool:
     """Detect if running inside a Docker container."""
@@ -107,9 +109,7 @@ class Settings(BaseSettings):
         """Validate admin password is set and not using insecure defaults."""
         insecure_defaults = {"campbunking123", "password", "admin", "123456", ""}
         if v in insecure_defaults:
-            import logging
-
-            logger = logging.getLogger(__name__)
+            logger = get_logger(__name__)
             logger.warning(
                 "SECURITY WARNING: POCKETBASE_ADMIN_PASSWORD is not set or uses an insecure default. "
                 "Set a strong password in your .env file for production use."

--- a/bunking/auth_middleware.py
+++ b/bunking/auth_middleware.py
@@ -5,7 +5,6 @@ Authentication middleware v2 - supports both JWT validation and legacy modes.
 from __future__ import annotations
 
 import json
-import logging
 import os
 import time
 from pathlib import Path
@@ -19,10 +18,11 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.responses import JSONResponse, Response
 
 from api.settings import _allow_auth_bypass
+from bunking.logging_config import get_logger
 
 from .jwt_auth import JWTValidator, PocketBaseTokenValidator, extract_bearer_token
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def _is_docker_environment() -> bool:

--- a/bunking/branding.py
+++ b/bunking/branding.py
@@ -14,12 +14,13 @@ Usage:
 from __future__ import annotations
 
 import json
-import logging
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-logger = logging.getLogger(__name__)
+from bunking.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 # Config file paths relative to project root
 CONFIG_DIR = Path(__file__).parent.parent / "config"

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -5,7 +5,6 @@ Bunking validation system to analyze assignments and report issues.
 from __future__ import annotations
 
 import json
-import logging
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from datetime import datetime
@@ -14,6 +13,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from bunking.logging_config import get_logger
 from bunking.models import Bunk, BunkAssignment, BunkRequest, FriendGroup, Person, Session
 from bunking.solver.constraints.helpers import extract_bunk_level, get_level_order
 from bunking.sync.bunk_request_processor.shared.constants import (
@@ -67,7 +67,7 @@ class HistoricalBunkingRecord:
     session_cm_id: int | None = None  # For same-session regression comparison
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class ValidationSeverity(str, Enum):

--- a/bunking/config/loader.py
+++ b/bunking/config/loader.py
@@ -8,13 +8,13 @@ No silent fallbacks - fails immediately on missing/invalid config.
 
 from __future__ import annotations
 
-import logging
 import os
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, cast
 
+from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
 from .errors import (
@@ -30,7 +30,7 @@ from .types import ConfigType
 if TYPE_CHECKING:
     pass
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class ConfigLoader:

--- a/bunking/graph/graph_cache_manager.py
+++ b/bunking/graph/graph_cache_manager.py
@@ -7,14 +7,15 @@ Thread-safe implementation for concurrent access.
 
 from __future__ import annotations
 
-import logging
 import threading
 import time
 from typing import Any
 
 import networkx as nx
 
-logger = logging.getLogger(__name__)
+from bunking.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 
 class GraphCacheManager:

--- a/bunking/graph/optimized_graph_builder.py
+++ b/bunking/graph/optimized_graph_builder.py
@@ -7,16 +7,17 @@ while maintaining all data fields and readability.
 
 from __future__ import annotations
 
-import logging
 import time
 from collections import defaultdict
 from typing import Any
 
 import networkx as nx
 
+from bunking.logging_config import get_logger
+
 from .social_graph_builder import SocialGraphBuilder
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class OptimizedSocialGraphBuilder(SocialGraphBuilder):

--- a/bunking/graph/social_graph_builder.py
+++ b/bunking/graph/social_graph_builder.py
@@ -13,9 +13,10 @@ from typing import Any
 import community as community_louvain
 import networkx as nx
 
+from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Create dedicated logger for self-referential detection
 self_ref_logger = logging.getLogger("self_referential")

--- a/bunking/jwt_auth.py
+++ b/bunking/jwt_auth.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
-import logging
 import time
 from typing import Any, cast
 
@@ -16,7 +15,9 @@ import jwt
 from jwt import PyJWK
 from jwt.exceptions import ExpiredSignatureError, InvalidTokenError
 
-logger = logging.getLogger(__name__)
+from bunking.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 
 def _decode_jwt_claims_unsafe(token: str) -> dict[str, Any]:

--- a/bunking/solver/callbacks.py
+++ b/bunking/solver/callbacks.py
@@ -4,14 +4,15 @@ Solver Callbacks - Progress monitoring for OR-Tools CP-SAT solver.
 
 from __future__ import annotations
 
-import logging
 from datetime import UTC, datetime
 
 from ortools.sat.python import cp_model
 
+from bunking.logging_config import get_logger
+
 from .logging import ConstraintLogger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class SolverProgressCallback(cp_model.CpSolverSolutionCallback):  # type: ignore[misc]

--- a/bunking/solver/constraints/age_grade_flow.py
+++ b/bunking/solver/constraints/age_grade_flow.py
@@ -17,13 +17,15 @@ import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
+from bunking.logging_config import get_logger
+
 from ..bunk_ordering import get_bunk_rank
 from .base import SolverContext
 
 if TYPE_CHECKING:
     from bunking.models_v2 import DirectBunk
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def add_age_grade_flow_objective(ctx: SolverContext, objective_terms: list[Any]) -> None:

--- a/bunking/solver/constraints/age_preference.py
+++ b/bunking/solver/constraints/age_preference.py
@@ -16,17 +16,18 @@ are determined by the solver at solve time, not when created.
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any
 
 from ortools.sat.python import cp_model
+
+from bunking.logging_config import get_logger
 
 from .base import SolverContext
 
 if TYPE_CHECKING:
     from bunking.models_v2 import DirectBunkRequest
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def add_age_preference_satisfaction_vars(

--- a/bunking/solver/constraints/age_spread.py
+++ b/bunking/solver/constraints/age_spread.py
@@ -8,12 +8,12 @@ Uses TRUE min/max aggregation to reduce constraint count from O(n²) to O(bunks)
 
 from __future__ import annotations
 
-import logging
+from bunking.logging_config import get_logger
 
 from .base import SolverContext
 from .helpers import get_eligible_campers_for_bunk, is_ag_session_bunk
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def _age_to_months(age: float) -> int:

--- a/bunking/solver/constraints/bunk_requests.py
+++ b/bunking/solver/constraints/bunk_requests.py
@@ -12,17 +12,18 @@ This module handles the MECHANICS of request satisfaction:
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
 from ortools.sat.python import cp_model
+
+from bunking.logging_config import get_logger
 
 from .base import SolverContext
 
 if TYPE_CHECKING:
     from bunking.models_v2 import DirectBunkRequest
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def add_bunk_request_satisfaction_vars(

--- a/bunking/solver/constraints/cabin_capacity.py
+++ b/bunking/solver/constraints/cabin_capacity.py
@@ -11,8 +11,9 @@ capacity, the first N overflows are exempt from penalty (where N = campers - cap
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any
+
+from bunking.logging_config import get_logger
 
 from .base import SolverContext
 from .helpers import is_ag_session_bunk
@@ -20,7 +21,7 @@ from .helpers import is_ag_session_bunk
 if TYPE_CHECKING:
     pass
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def add_cabin_capacity_constraints(ctx: SolverContext) -> None:

--- a/bunking/solver/constraints/cabin_occupancy.py
+++ b/bunking/solver/constraints/cabin_occupancy.py
@@ -9,15 +9,16 @@ Staff never put fewer than ~8 campers in a cabin. This module adds:
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from ortools.sat.python import cp_model
 
+from bunking.logging_config import get_logger
+
 from .base import SolverContext
 from .helpers import is_ag_session_bunk
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def add_cabin_minimum_occupancy_constraints(

--- a/bunking/solver/constraints/gender.py
+++ b/bunking/solver/constraints/gender.py
@@ -9,11 +9,11 @@ CRITICAL SAFETY CONSTRAINT:
 
 from __future__ import annotations
 
-import logging
+from bunking.logging_config import get_logger
 
 from .base import SolverContext
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def add_gender_constraints(ctx: SolverContext) -> None:

--- a/bunking/solver/constraints/grade_adjacency.py
+++ b/bunking/solver/constraints/grade_adjacency.py
@@ -21,10 +21,12 @@ from __future__ import annotations
 
 import logging
 
+from bunking.logging_config import get_logger
+
 from .base import SolverContext
 from .helpers import get_eligible_campers_for_bunk, is_ag_session_bunk
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 # =============================================================================

--- a/bunking/solver/constraints/grade_ratio.py
+++ b/bunking/solver/constraints/grade_ratio.py
@@ -7,15 +7,16 @@ makes up more than the configured percentage (default 67%) of the cabin.
 
 from __future__ import annotations
 
-import logging
 from collections import defaultdict
 
 from ortools.sat.python import cp_model
 
+from bunking.logging_config import get_logger
+
 from .base import SolverContext
 from .helpers import get_eligible_campers_for_bunk, is_ag_session_bunk, should_exempt_edge_bunk_from_ratio
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def add_grade_ratio_constraints(ctx: SolverContext) -> None:

--- a/bunking/solver/constraints/grade_spread.py
+++ b/bunking/solver/constraints/grade_spread.py
@@ -10,13 +10,14 @@ This helps maintain age-appropriate groupings within each bunk.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
+
+from bunking.logging_config import get_logger
 
 from .base import SolverContext
 from .helpers import get_eligible_campers_for_bunk, is_ag_session_bunk
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def add_grade_spread_constraints(ctx: SolverContext) -> None:

--- a/bunking/solver/constraints/group_locks.py
+++ b/bunking/solver/constraints/group_locks.py
@@ -7,11 +7,11 @@ to any cabin, but must stay together.
 
 from __future__ import annotations
 
-import logging
+from bunking.logging_config import get_logger
 
 from .base import SolverContext
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def add_group_lock_constraints(ctx: SolverContext) -> None:

--- a/bunking/solver/constraints/level_progression.py
+++ b/bunking/solver/constraints/level_progression.py
@@ -7,12 +7,12 @@ Soft incentive: Prefer moving campers up levels (handled in objective function)
 
 from __future__ import annotations
 
-import logging
+from bunking.logging_config import get_logger
 
 from .base import SolverContext
 from .helpers import extract_bunk_level, get_level_order
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def add_level_progression_constraints(ctx: SolverContext) -> None:

--- a/bunking/solver/constraints/must_satisfy.py
+++ b/bunking/solver/constraints/must_satisfy.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from bunking.logging_config import get_logger
+
 from .age_preference import add_age_preference_satisfaction_vars
 from .base import SolverContext
 from .bunk_requests import add_bunk_request_satisfaction_vars
@@ -29,7 +31,7 @@ if TYPE_CHECKING:
 
 from bunking.sync.bunk_request_processor.shared.constants import SourceField
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Source fields that contain explicit camper requests (not inferred preferences)
 EXPLICIT_SOURCE_FIELDS = {

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -5,7 +5,6 @@ No transformation needed.
 
 from __future__ import annotations
 
-import logging
 import os
 from collections import defaultdict
 from typing import Any
@@ -13,6 +12,7 @@ from typing import Any
 from ortools.sat.python import cp_model
 
 from bunking.config import ConfigLoader
+from bunking.logging_config import get_logger
 from bunking.models_v2 import (
     DirectBunkAssignment,
     DirectBunkRequest,
@@ -43,7 +43,7 @@ from .feasibility import find_infeasibility_cause as _find_infeasibility_cause
 from .logging import ConstraintLogger
 from .solution import analyze_solution, calculate_satisfied_requests
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class DirectBunkingSolver:

--- a/bunking/solver/feasibility.py
+++ b/bunking/solver/feasibility.py
@@ -6,18 +6,19 @@ Pre-solve checks to identify potential issues before running the solver.
 
 from __future__ import annotations
 
-import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 from ortools.sat.python import cp_model
+
+from bunking.logging_config import get_logger
 
 if TYPE_CHECKING:
     from bunking.config import ConfigLoader
     from bunking.models_v2 import DirectBunk, DirectBunkRequest, DirectSolverInput
     from bunking.solver.logging import ConstraintLogger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def check_feasibility(

--- a/bunking/solver/logging.py
+++ b/bunking/solver/logging.py
@@ -7,13 +7,14 @@ Tracks constraints added, violations, and solver progress.
 from __future__ import annotations
 
 import json
-import logging
 from collections import defaultdict
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-logger = logging.getLogger(__name__)
+from bunking.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 
 class ConstraintLogger:

--- a/bunking/solver/objective_evaluator.py
+++ b/bunking/solver/objective_evaluator.py
@@ -17,16 +17,16 @@ Components evaluated:
 
 from __future__ import annotations
 
-import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Any
 
 from bunking.config import ConfigLoader
+from bunking.logging_config import get_logger
 from bunking.solver.bunk_ordering import get_bunk_rank
 from bunking.sync.bunk_request_processor.shared.constants import SourceField
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @dataclass

--- a/bunking/solver/score_evaluator.py
+++ b/bunking/solver/score_evaluator.py
@@ -14,16 +14,16 @@ The scoring logic mirrors the solver's objective function:
 
 from __future__ import annotations
 
-import logging
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any
 
 from bunking.config import ConfigLoader
+from bunking.logging_config import get_logger
 from bunking.sync.bunk_request_processor.shared.constants import SourceField
 from bunking.utils.age_preference import is_age_preference_satisfied
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @dataclass

--- a/bunking/sync/bunk_request_processor/confidence/confidence_scorer.py
+++ b/bunking/sync/bunk_request_processor/confidence/confidence_scorer.py
@@ -5,15 +5,16 @@ that works directly with V2 models and data structures."""
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from typing import Any
+
+from bunking.logging_config import get_logger
 
 from ..core.models import ParsedRequest, RequestSource, RequestType
 from ..resolution.interfaces import ResolutionResult
 from .social_graph_signals import SocialGraphSignals
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @dataclass

--- a/bunking/sync/bunk_request_processor/conflict/conflict_detector.py
+++ b/bunking/sync/bunk_request_processor/conflict/conflict_detector.py
@@ -6,14 +6,15 @@ parsing and resolution, not constraint satisfaction."""
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
+from bunking.logging_config import get_logger
+
 from ..core.models import ParsedRequest, RequestType
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class ConflictType(Enum):

--- a/bunking/sync/bunk_request_processor/data/cache/cache_manager.py
+++ b/bunking/sync/bunk_request_processor/data/cache/cache_manager.py
@@ -5,12 +5,13 @@ and separate caches for different phases of processing."""
 
 from __future__ import annotations
 
-import logging
 import time
 from collections import OrderedDict
 from typing import Any
 
-logger = logging.getLogger(__name__)
+from bunking.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 
 class CacheEntry:

--- a/bunking/sync/bunk_request_processor/data/cache/cache_monitor.py
+++ b/bunking/sync/bunk_request_processor/data/cache/cache_monitor.py
@@ -5,14 +5,15 @@ Provides periodic logging of cache statistics and performance metrics."""
 from __future__ import annotations
 
 import json
-import logging
 import threading
 import time
 from typing import Any
 
+from bunking.logging_config import get_logger
+
 from .cache_manager import CacheManager
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class CacheMonitor:

--- a/bunking/sync/bunk_request_processor/data/cache/temporal_name_cache.py
+++ b/bunking/sync/bunk_request_processor/data/cache/temporal_name_cache.py
@@ -11,14 +11,15 @@ This eliminates SQL queries for name resolution and fixes the apostrophe bug
 
 from __future__ import annotations
 
-import logging
 from typing import Any
+
+from bunking.logging_config import get_logger
 
 from ...core.models import Person
 from ...shared import parse_date
 from ...shared.name_utils import normalize_name
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class TemporalNameCache:

--- a/bunking/sync/bunk_request_processor/data/connection_manager.py
+++ b/bunking/sync/bunk_request_processor/data/connection_manager.py
@@ -7,18 +7,18 @@ for isolated connections when needed (e.g., concurrent operations).
 
 from __future__ import annotations
 
-import logging
 import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from bunking.logging_config import get_logger
 from bunking.sync.bunk_request_processor.data.pocketbase_wrapper import PocketBaseWrapper
 from pocketbase import PocketBase
 
 if TYPE_CHECKING:
     pass
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @dataclass

--- a/bunking/sync/bunk_request_processor/data/data_access_context.py
+++ b/bunking/sync/bunk_request_processor/data/data_access_context.py
@@ -7,9 +7,9 @@ handling initialization and cleanup automatically.
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any
 
+from bunking.logging_config import get_logger
 from bunking.sync.bunk_request_processor.data.connection_manager import (
     ConnectionConfig,
     ConnectionManager,
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     )
     from pocketbase import PocketBase
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class DataAccessContext:

--- a/bunking/sync/bunk_request_processor/data/pocketbase_wrapper.py
+++ b/bunking/sync/bunk_request_processor/data/pocketbase_wrapper.py
@@ -6,17 +6,16 @@ are URL-encoded with '+' for spaces, but PocketBase server expects
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from pocketbase.models.utils.list_result import ListResult
 from pocketbase.services.record_service import RecordService
 
 # Import TRACE constant and ensure trace method is available
-from bunking.logging_config import TRACE
+from bunking.logging_config import TRACE, get_logger
 from pocketbase import PocketBase
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class WrappedRecordService(RecordService):

--- a/bunking/sync/bunk_request_processor/data/repositories/debug_parse_repository.py
+++ b/bunking/sync/bunk_request_processor/data/repositories/debug_parse_repository.py
@@ -6,9 +6,9 @@ Phase 1 parsing output separately from production bunk_requests.
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any
 
+from bunking.logging_config import get_logger
 from bunking.sync.bunk_request_processor.services.staff_note_parser import (
     extract_staff_pattern,
 )
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
     from ..pocketbase_wrapper import PocketBaseWrapper
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Maximum IDs per query to avoid URL length limits
 # Each ID adds ~40 chars to filter, 50 IDs keeps URLs under 2KB

--- a/bunking/sync/bunk_request_processor/data/repositories/person_repository.py
+++ b/bunking/sync/bunk_request_processor/data/repositories/person_repository.py
@@ -5,10 +5,10 @@ When a TemporalNameCache is provided, uses O(1) cache lookups instead of DB quer
 
 from __future__ import annotations
 
-import logging
 import warnings
 from typing import TYPE_CHECKING, Any
 
+from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
 from ...core.interfaces import Repository
@@ -20,7 +20,7 @@ from ..pocketbase_wrapper import PocketBaseWrapper
 if TYPE_CHECKING:
     from ..cache.temporal_name_cache import TemporalNameCache
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def _escape_filter_value(value: str) -> str:

--- a/bunking/sync/bunk_request_processor/data/repositories/request_repository.py
+++ b/bunking/sync/bunk_request_processor/data/repositories/request_repository.py
@@ -5,9 +5,9 @@ Handles all database operations related to BunkRequest records."""
 from __future__ import annotations
 
 import json
-import logging
 from typing import Any
 
+from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
 from ...core.models import (
@@ -18,7 +18,7 @@ from ...core.models import (
 )
 from ..pocketbase_wrapper import PocketBaseWrapper
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class RequestRepository:

--- a/bunking/sync/bunk_request_processor/data/repositories/session_repository.py
+++ b/bunking/sync/bunk_request_processor/data/repositories/session_repository.py
@@ -4,16 +4,16 @@ Provides methods to query camp session data and find related sessions."""
 
 from __future__ import annotations
 
-import logging
 import re
 from typing import TYPE_CHECKING, Any
 
+from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
 if TYPE_CHECKING:
     from ..pocketbase_wrapper import PocketBaseWrapper
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Valid session types for bunking
 VALID_BUNKING_SESSION_TYPES = {"main", "embedded", "ag"}

--- a/bunking/sync/bunk_request_processor/data/repositories/source_link_repository.py
+++ b/bunking/sync/bunk_request_processor/data/repositories/source_link_repository.py
@@ -9,16 +9,17 @@ original_bunk_requests. Enables:
 
 from __future__ import annotations
 
-import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING
+
+from bunking.logging_config import get_logger
 
 if TYPE_CHECKING:
     from pocketbase import PocketBase
 
     from ..pocketbase_wrapper import PocketBaseWrapper
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 COLLECTION_NAME = "bunk_request_sources"
 

--- a/bunking/sync/bunk_request_processor/data/repository_factory.py
+++ b/bunking/sync/bunk_request_processor/data/repository_factory.py
@@ -7,9 +7,9 @@ ensuring all repositories share the same PocketBase client and caches.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
+from bunking.logging_config import get_logger
 from bunking.sync.bunk_request_processor.data.cache.temporal_name_cache import (
     TemporalNameCache,
 )
@@ -30,7 +30,7 @@ from bunking.sync.bunk_request_processor.data.repositories.session_repository im
 )
 from pocketbase import PocketBase
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class RepositoryFactory:

--- a/bunking/sync/bunk_request_processor/integration/ai_service.py
+++ b/bunking/sync/bunk_request_processor/integration/ai_service.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
-import logging
 from collections.abc import Callable
+
+from bunking.logging_config import get_logger
 
 # Import types from ai_types to avoid circular imports
 from .ai_types import (
@@ -31,7 +32,7 @@ __all__ = [
     "TokenUsage",
 ]
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class AIService:

--- a/bunking/sync/bunk_request_processor/integration/batch_processor.py
+++ b/bunking/sync/bunk_request_processor/integration/batch_processor.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
-import logging
 import random
 import time
 from collections.abc import Callable
@@ -23,11 +22,13 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
+from bunking.logging_config import get_logger
+
 from ..core.models import ParsedRequest, ParseRequest, ParseResult
 from ..shared.constants import VALID_PLACEHOLDERS as _VALID_PLACEHOLDERS
 from .ai_service import AIProvider, AIRequestContext, ParsedResponse
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # ============================================================================
 # HARDCODED TECHNICAL CONSTANTS

--- a/bunking/sync/bunk_request_processor/integration/openai_provider.py
+++ b/bunking/sync/bunk_request_processor/integration/openai_provider.py
@@ -6,11 +6,12 @@ GPT-4.1 and GPT-5 models fully support structured outputs via this API.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from openai import AsyncOpenAI
 from openai.types.shared_params import Reasoning, ReasoningEffort
+
+from bunking.logging_config import get_logger
 
 from ..core.models import (
     AgePreference,
@@ -28,7 +29,7 @@ from .ai_schemas import (
 )
 from .ai_types import AIProvider, AIRequestContext, ParsedResponse, TokenUsage
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class OpenAIProvider(AIProvider):

--- a/bunking/sync/bunk_request_processor/integration/original_requests_loader.py
+++ b/bunking/sync/bunk_request_processor/integration/original_requests_loader.py
@@ -17,11 +17,11 @@ The original_bunk_requests table structure (from Go import):
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
 if TYPE_CHECKING:
@@ -34,7 +34,7 @@ from ..shared.constants import (
     FIELD_TO_SOURCE_FIELD,
 )
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @dataclass

--- a/bunking/sync/bunk_request_processor/integration/provider_factory.py
+++ b/bunking/sync/bunk_request_processor/integration/provider_factory.py
@@ -4,9 +4,10 @@ Supports OpenAI (with SDK structured outputs) and Mock providers."""
 
 from __future__ import annotations
 
-import logging
 import os
 import re
+
+from bunking.logging_config import get_logger
 
 from ..core.models import (
     ParsedRequest,
@@ -21,7 +22,7 @@ from .ai_types import (
     TokenUsage,
 )
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class MockProvider(AIProvider):

--- a/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import hashlib
-import logging
 import re
 import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from bunking.config.loader import ConfigLoader
+from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
 if TYPE_CHECKING:
@@ -66,7 +66,7 @@ from ..social.social_graph import SocialGraph
 from ..validation.request_type_validator import validate_request_type_for_field
 from ..validation.rules.self_reference import SelfReferenceRule
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def generate_unresolved_person_id(name_text: str) -> int:

--- a/bunking/sync/bunk_request_processor/process_requests.py
+++ b/bunking/sync/bunk_request_processor/process_requests.py
@@ -13,6 +13,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from bunking.logging_config import get_logger
+
 # Add parent directories to path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 
@@ -25,7 +27,7 @@ from .orchestrator import RequestOrchestrator
 from .shared.constants import ALL_PROCESSING_FIELDS, validate_source_fields
 
 # Setup logging
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def load_configuration() -> dict[str, Any]:

--- a/bunking/sync/bunk_request_processor/processing/partial_invalidation.py
+++ b/bunking/sync/bunk_request_processor/processing/partial_invalidation.py
@@ -8,15 +8,16 @@ Handles the case when an original_bunk_request's content changes (hash differs):
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
+
+from bunking.logging_config import get_logger
 
 if TYPE_CHECKING:
     from ..data.repositories.request_repository import RequestRepository
     from ..data.repositories.source_link_repository import SourceLinkRepository
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @dataclass

--- a/bunking/sync/bunk_request_processor/resolution/resolution_pipeline.py
+++ b/bunking/sync/bunk_request_processor/resolution/resolution_pipeline.py
@@ -5,14 +5,15 @@ handling caching, fallbacks, and ambiguous results."""
 
 from __future__ import annotations
 
-import logging
 from typing import Any
+
+from bunking.logging_config import get_logger
 
 from ..data.repositories import AttendeeRepository, PersonRepository
 from ..name_resolution.filters.spread_filter import SpreadFilter
 from .interfaces import ResolutionResult, ResolutionStrategy
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class ResolutionPipeline:

--- a/bunking/sync/bunk_request_processor/security/input_sanitizer.py
+++ b/bunking/sync/bunk_request_processor/security/input_sanitizer.py
@@ -5,14 +5,15 @@ potentially malicious input before sending to AI providers."""
 
 from __future__ import annotations
 
-import logging
 import re
 import unicodedata
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, ClassVar
 
-logger = logging.getLogger(__name__)
+from bunking.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 
 class RiskLevel(Enum):

--- a/bunking/sync/bunk_request_processor/services/context_builder.py
+++ b/bunking/sync/bunk_request_processor/services/context_builder.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
+
+from bunking.logging_config import get_logger
 
 from ..core.models import Person
 from ..integration.ai_service import AIRequestContext
@@ -14,7 +15,7 @@ from ..shared.nickname_groups import find_nickname_variations
 if TYPE_CHECKING:
     from ..data.repositories import AttendeeRepository, PersonRepository
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class ContextBuilder:

--- a/bunking/sync/bunk_request_processor/services/historical_verification_service.py
+++ b/bunking/sync/bunk_request_processor/services/historical_verification_service.py
@@ -7,8 +7,9 @@ in the same bunk together, boosting confidence when verified.
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any
+
+from bunking.logging_config import get_logger
 
 from ..resolution.interfaces import ResolutionResult
 
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
     from ..core.models import ParseResult
     from ..data.cache.temporal_name_cache import TemporalNameCache
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class HistoricalVerificationService:

--- a/bunking/sync/bunk_request_processor/services/phase1_debug_service.py
+++ b/bunking/sync/bunk_request_processor/services/phase1_debug_service.py
@@ -9,9 +9,10 @@ This service wraps Phase1ParseService to enable:
 
 from __future__ import annotations
 
-import logging
 import time
 from typing import TYPE_CHECKING, Any
+
+from bunking.logging_config import get_logger
 
 from ..core.models import ParseRequest, ParseResult, RequestType
 from ..shared.constants import FIELD_TO_SOURCE_FIELD
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
     from ..integration.original_requests_loader import OriginalRequest, OriginalRequestsLoader
     from .phase1_parse_service import Phase1ParseService
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class Phase1DebugService:

--- a/bunking/sync/bunk_request_processor/services/phase1_parse_service.py
+++ b/bunking/sync/bunk_request_processor/services/phase1_parse_service.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Callable
 from dataclasses import replace
 from typing import Any
+
+from bunking.logging_config import get_logger
 
 from ..core.models import ParseRequest, ParseResult
 from ..integration.ai_service import AIProvider, AIRequestContext
@@ -13,7 +14,7 @@ from ..integration.batch_processor import BatchProcessor
 from ..security import RiskLevel, SecureSanitizer, create_secure_sanitizer
 from .context_builder import ContextBuilder
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class Phase1ParseService:

--- a/bunking/sync/bunk_request_processor/services/phase2_resolution_service.py
+++ b/bunking/sync/bunk_request_processor/services/phase2_resolution_service.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Callable
 from typing import Any
+
+from bunking.logging_config import get_logger
 
 from ..confidence.confidence_scorer import ConfidenceScorer
 from ..core.models import ParsedRequest, ParseResult, Person, RequestType
@@ -14,7 +15,7 @@ from ..shared.constants import LAST_YEAR_BUNKMATES_PLACEHOLDER, SIBLING_PLACEHOL
 from ..shared.name_utils import normalize_name
 from ..shared.nickname_groups import names_match_via_nicknames
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class ResolutionCase:

--- a/bunking/sync/bunk_request_processor/services/phase3_disambiguation_service.py
+++ b/bunking/sync/bunk_request_processor/services/phase3_disambiguation_service.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Callable
 from typing import Any
+
+from bunking.logging_config import get_logger
 
 from ..confidence.confidence_scorer import ConfidenceScorer
 from ..core.models import ParsedRequest, ParseResult
@@ -13,7 +14,7 @@ from ..integration.batch_processor import BatchProcessor
 from ..resolution.interfaces import ResolutionResult
 from .context_builder import ContextBuilder
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class DisambiguationCase:

--- a/bunking/sync/bunk_request_processor/services/placeholder_expander.py
+++ b/bunking/sync/bunk_request_processor/services/placeholder_expander.py
@@ -11,8 +11,9 @@ Supported placeholders:
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any
+
+from bunking.logging_config import get_logger
 
 from ..core.models import (
     ParsedRequest,
@@ -27,7 +28,7 @@ if TYPE_CHECKING:
     from ..data.repositories.attendee_repository import AttendeeRepository
     from ..data.repositories.person_repository import PersonRepository
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class PlaceholderExpander:

--- a/bunking/sync/bunk_request_processor/services/request_builder.py
+++ b/bunking/sync/bunk_request_processor/services/request_builder.py
@@ -6,8 +6,9 @@ Extracted from orchestrator to reduce class size and improve testability.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
+
+from bunking.logging_config import get_logger
 
 from ..core.models import (
     BunkRequest,
@@ -16,7 +17,7 @@ from ..core.models import (
     RequestType,
 )
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class RequestBuilder:

--- a/bunking/sync/bunk_request_processor/services/staff_name_detector.py
+++ b/bunking/sync/bunk_request_processor/services/staff_name_detector.py
@@ -12,12 +12,13 @@ This service:
 from __future__ import annotations
 
 import json
-import logging
 import re
 from pathlib import Path
 from typing import Any, ClassVar
 
-logger = logging.getLogger(__name__)
+from bunking.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 # Default path for staff list config
 DEFAULT_STAFF_LIST_PATH = Path(__file__).parent.parent.parent.parent.parent / "config" / "staff_list.json"

--- a/bunking/sync/bunk_request_processor/social/social_graph.py
+++ b/bunking/sync/bunk_request_processor/social/social_graph.py
@@ -6,19 +6,19 @@ confidence scoring and name disambiguation, not for creating new requests."""
 
 from __future__ import annotations
 
-import logging
 from enum import Enum
 from typing import Any
 
 import networkx as nx
 
+from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
 from ..core.models import Person
 from ..data.repositories.session_repository import SessionRepository
 from ..resolution.interfaces import ResolutionResult
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class RelationshipType(Enum):

--- a/bunking/sync/bunk_request_processor/validation/request_type_validator.py
+++ b/bunking/sync/bunk_request_processor/validation/request_type_validator.py
@@ -8,12 +8,12 @@ If AI returns the wrong type for a strict field, this validator corrects it."""
 
 from __future__ import annotations
 
-import logging
+from bunking.logging_config import get_logger
 
 from ..core.models import ParsedRequest, RequestType
 from ..shared.constants import SourceField
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 # Fields with strict type requirements

--- a/bunking/sync/conflict_detector.py
+++ b/bunking/sync/conflict_detector.py
@@ -6,13 +6,14 @@ Identifies opposing directional requests and other conflicts that require manual
 
 from __future__ import annotations
 
-import logging
 import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
-logger = logging.getLogger(__name__)
+from bunking.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Migrate all `logging.getLogger(__name__)` calls in `api/` and `bunking/` to use `get_logger(__name__)` from `bunking.logging_config`
- Aligns with CLAUDE.md logging standard: `from bunking.logging_config import configure_logging, get_logger`
- `get_logger` is a thin wrapper around `logging.getLogger` with no functional difference — pure conventions alignment
- Keep `import logging` where modules use logging constants (e.g., `logging.DEBUG`)
- Skip `logging_config.py` (defines `get_logger`) and `uvicorn_logging.py` (configures uvicorn internals)
- 86 files migrated across `api/` and `bunking/`

Closes #495

## Test plan
- [x] All Python linters pass (ruff check, ruff format, mypy)
- [x] All unit tests pass (2978 passed, 14 skipped)
- [x] Verified zero remaining `logging.getLogger(__name__)` in api/ and bunking/
- [x] No behavioral change — `get_logger` wraps `logging.getLogger`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized logging configuration by implementing a unified logger utility across the application. This improves logging consistency and maintainability while preserving existing logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->