### PR TITLE
fix(frontend): restore null-safety for config metadata preventing admin crash

### DIFF
--- a/frontend/src/components/admin/ConfigInputs.tsx
+++ b/frontend/src/components/admin/ConfigInputs.tsx
@@ -236,7 +236,7 @@ export function formatDuration(seconds?: number): string {
 export interface ImpactBadgeProps {
   scaleType: ScaleType
   value: number
-  metadata?: Record<string, unknown>
+  metadata?: Record<string, unknown> | null
 }
 
 export function ImpactBadge({ scaleType, value, metadata }: ImpactBadgeProps) {
@@ -255,7 +255,7 @@ export function ImpactBadge({ scaleType, value, metadata }: ImpactBadgeProps) {
 export interface ScaleContextBarProps {
   scaleType: ScaleType
   value: number
-  metadata?: Record<string, unknown>
+  metadata?: Record<string, unknown> | null
 }
 
 export function ScaleContextBar({ scaleType, value, metadata }: ScaleContextBarProps) {
@@ -368,7 +368,7 @@ export function PortalTooltip({ children, content, className = 'w-64' }: PortalT
 export interface ScaleTooltipProps {
   scaleType: ScaleType
   value: number
-  metadata?: Record<string, unknown>
+  metadata?: Record<string, unknown> | null
 }
 
 export function ScaleTooltip({ scaleType, value, metadata }: ScaleTooltipProps) {

--- a/frontend/src/components/admin/ConfigTab.tsx
+++ b/frontend/src/components/admin/ConfigTab.tsx
@@ -31,7 +31,7 @@ export function ConfigTab() {
       const configsByCategory: Record<string, typeof section.configs> = {}
 
       section.configs.forEach((config) => {
-        const businessCategory = (config.metadata['business_category'] as string) || 'solver'
+        const businessCategory = (config.metadata?.['business_category'] as string) || 'solver'
         configsByCategory[businessCategory] ??= []
         configsByCategory[businessCategory].push(config)
       })
@@ -61,7 +61,7 @@ export function ConfigTab() {
         ...section,
         configs: section.configs.filter(
           (config) =>
-            (config.metadata.friendly_name?.toLowerCase().includes(term) ?? false) ||
+            (config.metadata?.friendly_name?.toLowerCase().includes(term) ?? false) ||
             (config.description?.toLowerCase().includes(term) ?? false) ||
             config.config_key.toLowerCase().includes(term)
         ),

--- a/frontend/src/components/admin/SectionCard.tsx
+++ b/frontend/src/components/admin/SectionCard.tsx
@@ -36,16 +36,20 @@ export function SectionCard({
     const numericValue = parseFloat(currentValue)
 
     // Use metadata component_type or infer from value
-    let componentType = item.metadata['component_type']
+    let componentType = item.metadata?.['component_type']
     componentType ??= inferComponentType(item.value, item.config_key)
 
     // Merge component_config with metadata min/max
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime fallback: `as` cast may be undefined at runtime
-    const baseConfig = (item.metadata['component_config'] as Record<string, unknown>) || {}
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime fallback: cast hides nullability from ESLint
+    const baseConfig = (item.metadata?.['component_config'] as Record<string, unknown>) || {}
     const componentConfig: Record<string, unknown> = {
       ...baseConfig,
-      ...(item.metadata['min_value'] != null ? { min: item.metadata['min_value'] as number } : {}),
-      ...(item.metadata['max_value'] != null ? { max: item.metadata['max_value'] as number } : {}),
+      ...(item.metadata?.['min_value'] != null
+        ? { min: item.metadata['min_value'] as number }
+        : {}),
+      ...(item.metadata?.['max_value'] != null
+        ? { max: item.metadata['max_value'] as number }
+        : {}),
     }
     const Component = COMPONENT_MAP[componentType as string] ?? TextInput
 
@@ -67,14 +71,14 @@ export function SectionCard({
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center gap-2">
               <span className="text-foreground text-base font-medium">
-                {item.metadata.friendly_name ?? item.config_key}
+                {item.metadata?.friendly_name ?? item.config_key}
               </span>
               {/* Impact badge for numeric values */}
               {showScaleContext && (
                 <ImpactBadge scaleType={scaleType} value={numericValue} metadata={item.metadata} />
               )}
               {/* Existing tooltip */}
-              {item.metadata.tooltip && (
+              {item.metadata?.tooltip && (
                 <PortalTooltip
                   content={
                     <div className="bg-popover text-popover-foreground border-border rounded-lg border p-3 text-sm leading-relaxed shadow-lg">

--- a/frontend/src/hooks/useSolverConfig.ts
+++ b/frontend/src/hooks/useSolverConfig.ts
@@ -11,7 +11,7 @@ export interface ConfigWithMetadata extends ConfigRecord {
     section?: string
     display_order?: number
     [key: string]: unknown
-  }
+  } | null
 }
 
 export interface ConfigSection {
@@ -71,7 +71,7 @@ export function useSolverConfig() {
 
       // Add configs to their sections
       configs.forEach((config) => {
-        const sectionKey = config.metadata.section
+        const sectionKey = config.metadata?.section
         if (sectionKey && sectionMap.has(sectionKey)) {
           const section = sectionMap.get(sectionKey)
           if (section) {
@@ -100,8 +100,8 @@ export function useSolverConfig() {
       // Sort configs within each section by display_order
       sectionMap.forEach((section) => {
         section.configs.sort((a, b) => {
-          const orderA = a.metadata.display_order ?? 999
-          const orderB = b.metadata.display_order ?? 999
+          const orderA = a.metadata?.display_order ?? 999
+          const orderB = b.metadata?.display_order ?? 999
           return orderA - orderB
         })
       })

--- a/frontend/src/hooks/useSolverConfigMutation.ts
+++ b/frontend/src/hooks/useSolverConfigMutation.ts
@@ -70,7 +70,7 @@ export function useResetSolverConfig() {
 
       // Reset each to default value if it exists in metadata
       const updates = configs.map((config) => {
-        const defaultValue = config.metadata['default_value']
+        const defaultValue = config.metadata?.['default_value']
         if (defaultValue !== undefined && defaultValue !== null) {
           return pb.collection<ConfigWithMetadata>('config').update(config.id, {
             value: defaultValue,

--- a/frontend/src/utils/scaleContext.ts
+++ b/frontend/src/utils/scaleContext.ts
@@ -343,7 +343,7 @@ export const SCALE_DEFINITIONS: Record<ScaleType, ScaleDefinition> = {
 export function inferScaleType(
   configKey: string,
   value: number,
-  metadata?: Record<string, unknown>
+  metadata?: Record<string, unknown> | null
 ): ScaleType {
   const key = configKey.toLowerCase()
 
@@ -400,7 +400,7 @@ export function inferScaleType(
 export function getImpactLevel(
   scaleType: ScaleType,
   value: number,
-  metadata?: Record<string, unknown>
+  metadata?: Record<string, unknown> | null
 ): { label: string; color: string; bgColor: string } | null {
   const scale = SCALE_DEFINITIONS[scaleType]
   if (scale.levels.length === 0) return null


### PR DESCRIPTION
## Summary
- **Bug**: `/admin/config/solver` crashes with "Failed to load configuration" — `ConfigWithMetadata.metadata` was typed as required but PocketBase returns `null` for 33 config records
- **Root cause**: ESLint cleanup (51e66525) removed optional chaining (`?.`) because the TypeScript type override hid runtime nullability
- **Fix**: Make `metadata` type honest (`| null`), restore `?.` on all 10 access sites, propagate nullability through downstream function signatures

## Changes
| File | What |
|------|------|
| `useSolverConfig.ts` | Type fix (`\| null`), 3 crash sites |
| `useSolverConfigMutation.ts` | 1 crash site |
| `ConfigTab.tsx` | 2 crash sites |
| `SectionCard.tsx` | 4 crash sites + eslint-disable update |
| `ConfigInputs.tsx` | 3 prop interfaces accept `\| null` |
| `scaleContext.ts` | 2 function signatures accept `\| null` |

## Prevention
ESLint will now **require** optional chaining on metadata access (instead of telling you to remove it), because the type honestly includes `null`.

## Test plan
- [x] TypeScript compiles clean (0 errors)
- [x] ESLint passes (0 errors/warnings)
- [x] All 264 frontend tests pass
- [x] Full pre-push suite passes (Go, Python, frontend, linters)
- [ ] Verify `/admin/config/solver` loads at campvite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced configuration metadata handling to safely manage null or undefined values, improving robustness of the admin configuration panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->