### PR TITLE
fix(api): scope debug by-camper endpoint to year via attendees

### DIFF
--- a/api/routers/debug.py
+++ b/api/routers/debug.py
@@ -536,14 +536,21 @@ async def list_original_requests_by_camper(
 ) -> OriginalRequestsListResponse:
     """List original_bunk_requests for a specific camper by CampMinder ID.
 
-    Queries PocketBase directly for the camper's requests, avoiding loading all records.
-    Used by the pipeline debug tool to inspect a single camper's raw requests.
+    Looks up the camper via attendees (enrollment is the source of truth,
+    scoped by year) rather than persons directly. This ensures the correct
+    year's person PB record is used for the original_bunk_requests join.
     """
-    # Look up the person's PB record ID from their CM ID
-    persons = pb.collection("persons").get_list(1, 1, query_params={"filter": f"cm_id = {cm_id}"})
-    if not persons.items:
+    # Look up via attendees — enrollment is the source of truth (year-scoped)
+    attendee_filter = f"year = {year} && is_active = 1 && status_id = 2 && person.cm_id = {cm_id}"
+    attendees = pb.collection("attendees").get_list(1, 1, query_params={"filter": attendee_filter, "expand": "person"})
+    if not attendees.items:
         return OriginalRequestsListResponse(items=[], total=0)
-    person_pb_id = persons.items[0].id
+
+    expand = getattr(attendees.items[0], "expand", {}) or {}
+    person = expand.get("person") if isinstance(expand, dict) else getattr(expand, "person", None)
+    if not person:
+        return OriginalRequestsListResponse(items=[], total=0)
+    person_pb_id = person.id
 
     # Query original_bunk_requests directly by requester relation + year
     pb_filter = f'requester = "{person_pb_id}" && year = {year}'

--- a/tests/unit/api/routers/test_debug_original_requests_by_camper.py
+++ b/tests/unit/api/routers/test_debug_original_requests_by_camper.py
@@ -60,13 +60,6 @@ def _make_mock_pb_record(
     return record
 
 
-def _make_mock_person(person_id: str = "pb_person_1") -> MagicMock:
-    """Create a mock PocketBase person record."""
-    person = MagicMock()
-    person.id = person_id
-    return person
-
-
 @pytest.fixture
 def mock_pb() -> MagicMock:
     """Create a mock PocketBase client."""
@@ -86,23 +79,94 @@ def client_with_mock_pb(mock_pb: MagicMock) -> Generator[tuple[TestClient, Magic
         yield TestClient(app), mock_pb
 
 
-def _setup_person_lookup(mock_pb: MagicMock, person_id: str = "pb_person_1") -> None:
-    """Set up mock PB to return a person record for cm_id lookup."""
-    person = _make_mock_person(person_id)
-    persons_result = MagicMock()
-    persons_result.items = [person]
-    mock_pb.collection.return_value.get_list.return_value = persons_result
+def _make_mock_attendee(
+    person_id: str = "pb_person_1",
+    person_cm_id: int = 12345,
+    first_name: str = "Emma",
+    last_name: str = "Johnson",
+    preferred_name: str | None = None,
+) -> MagicMock:
+    """Create a mock PocketBase attendee record with expanded person."""
+    person = MagicMock()
+    person.id = person_id
+    person.cm_id = person_cm_id
+    person.first_name = first_name
+    person.last_name = last_name
+    person.preferred_name = preferred_name
+
+    attendee = MagicMock()
+    attendee.expand = {"person": person}
+    return attendee
 
 
-def _setup_no_person(mock_pb: MagicMock) -> None:
-    """Set up mock PB to return no person for cm_id lookup."""
-    persons_result = MagicMock()
-    persons_result.items = []
-    mock_pb.collection.return_value.get_list.return_value = persons_result
+def _setup_attendee_lookup(
+    mock_pb: MagicMock,
+    attendees: list[MagicMock] | None = None,
+    person_id: str = "pb_person_1",
+    person_cm_id: int = 12345,
+) -> dict[str, MagicMock]:
+    """Set up mock PB to route attendees.get_list and original_bunk_requests.get_full_list.
+
+    Returns a dict of collection mocks keyed by collection name for assertions.
+    """
+    if attendees is None:
+        attendees = [_make_mock_attendee(person_id=person_id, person_cm_id=person_cm_id)]
+
+    attendee_result = MagicMock()
+    attendee_result.items = attendees
+
+    # Create per-collection mocks
+    attendees_col = MagicMock()
+    attendees_col.get_list.return_value = attendee_result
+
+    orig_requests_col = MagicMock()
+    orig_requests_col.get_full_list.return_value = []
+
+    collections = {
+        "attendees": attendees_col,
+        "original_bunk_requests": orig_requests_col,
+    }
+
+    def route_collection(name: str) -> MagicMock:
+        return collections.get(name, MagicMock())
+
+    mock_pb.collection.side_effect = route_collection
+    return collections
 
 
 class TestOriginalRequestsByCamper:
     """Test GET /api/debug/original-requests/by-camper/{cm_id} endpoint."""
+
+    def test_queries_attendees_not_persons(self, client_with_mock_pb: tuple[TestClient, MagicMock]) -> None:
+        """Endpoint must look up camper via attendees (year-scoped enrollment), not persons."""
+        client, mock_pb = client_with_mock_pb
+
+        _setup_attendee_lookup(mock_pb)
+
+        response = client.get("/api/debug/original-requests/by-camper/12345", params={"year": 2025})
+
+        assert response.status_code == 200
+        # Verify attendees was queried, not persons
+        mock_pb.collection.assert_any_call("attendees")
+        call_args_list = [str(c) for c in mock_pb.collection.call_args_list]
+        assert not any("persons" in c for c in call_args_list), "Should query attendees, not persons"
+
+    def test_attendee_filter_includes_year_and_enrollment(
+        self, client_with_mock_pb: tuple[TestClient, MagicMock]
+    ) -> None:
+        """Attendee query must filter by year, is_active, status_id, and person.cm_id."""
+        client, mock_pb = client_with_mock_pb
+
+        collections = _setup_attendee_lookup(mock_pb)
+
+        response = client.get("/api/debug/original-requests/by-camper/12345", params={"year": 2025})
+
+        assert response.status_code == 200
+        filter_str = collections["attendees"].get_list.call_args[1]["query_params"]["filter"]
+        assert "year = 2025" in filter_str
+        assert "is_active = 1" in filter_str
+        assert "status_id = 2" in filter_str
+        assert "person.cm_id = 12345" in filter_str
 
     def test_returns_requests_for_camper(self, client_with_mock_pb: tuple[TestClient, MagicMock]) -> None:
         """Returns original requests filtered to the specified camper's cm_id."""
@@ -111,8 +175,8 @@ class TestOriginalRequestsByCamper:
         record1 = _make_mock_pb_record(record_id="rec_1")
         record2 = _make_mock_pb_record(record_id="rec_2", field="not_bunk_with", content="Not with Olivia Chen")
 
-        _setup_person_lookup(mock_pb)
-        mock_pb.collection.return_value.get_full_list.return_value = [record1, record2]
+        collections = _setup_attendee_lookup(mock_pb)
+        collections["original_bunk_requests"].get_full_list.return_value = [record1, record2]
 
         response = client.get("/api/debug/original-requests/by-camper/12345", params={"year": 2025})
 
@@ -123,11 +187,11 @@ class TestOriginalRequestsByCamper:
         assert data["items"][0]["source_field"] == "bunk_with"
         assert data["items"][1]["source_field"] == "not_bunk_with"
 
-    def test_returns_empty_for_unknown_camper(self, client_with_mock_pb: tuple[TestClient, MagicMock]) -> None:
-        """Returns empty list when person not found by cm_id."""
+    def test_returns_empty_for_unenrolled_camper(self, client_with_mock_pb: tuple[TestClient, MagicMock]) -> None:
+        """Returns empty list when camper has no active enrollment for the year."""
         client, mock_pb = client_with_mock_pb
 
-        _setup_no_person(mock_pb)
+        _setup_attendee_lookup(mock_pb, attendees=[])
 
         response = client.get("/api/debug/original-requests/by-camper/12345", params={"year": 2025})
 
@@ -155,8 +219,8 @@ class TestOriginalRequestsByCamper:
             last_name="Johnson",
         )
 
-        _setup_person_lookup(mock_pb)
-        mock_pb.collection.return_value.get_full_list.return_value = [record]
+        collections = _setup_attendee_lookup(mock_pb)
+        collections["original_bunk_requests"].get_full_list.return_value = [record]
 
         response = client.get("/api/debug/original-requests/by-camper/12345", params={"year": 2025})
 
@@ -171,8 +235,8 @@ class TestOriginalRequestsByCamper:
         unprocessed = _make_mock_pb_record(record_id="rec_1", processed=None)
         processed = _make_mock_pb_record(record_id="rec_2", processed="2025-06-15T10:00:00Z")
 
-        _setup_person_lookup(mock_pb)
-        mock_pb.collection.return_value.get_full_list.return_value = [unprocessed, processed]
+        collections = _setup_attendee_lookup(mock_pb)
+        collections["original_bunk_requests"].get_full_list.return_value = [unprocessed, processed]
 
         response = client.get("/api/debug/original-requests/by-camper/12345", params={"year": 2025})
 


### PR DESCRIPTION
## Summary
- The `GET /api/debug/original-requests/by-camper/{cm_id}` endpoint queried the `persons` collection without a year filter, grabbing the wrong year's PB record when a camper exists in multiple years (e.g., 2025 and 2026)
- This broke both "Search by Name" and "Paste CM ID" tabs in the New Trace modal — the camper was found but their bunk requests showed as empty
- Switched to querying `attendees` (enrollment = source of truth) with `year`, `is_active`, and `status_id` filters, matching the pattern already used by the `search-persons` endpoint

Closes the issue where searching for a camper like Zelena Katz (CM ID 3458569) returned "No original requests found" despite having 2026 bunk requests.

## Test plan
- [x] Updated unit tests to assert `attendees` collection is queried (not `persons`)
- [x] Tests verify filter includes `year`, `is_active = 1`, `status_id = 2`, and `person.cm_id`
- [x] All 1039 API unit tests pass
- [ ] Manual: search for Zelena Katz in pipeline debug → verify requests load
- [ ] Manual: paste CM ID 3458569 → verify requests load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Refined camper data lookup methodology for more reliable and accurate results
  * Enhanced handling of inactive or missing camper records in queries
  * Improved year-scoped filtering logic for camper information retrieval

* **Tests**
  * Updated comprehensive test coverage to verify refined data retrieval behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->