### PR TITLE
fix(docker): use node:22-slim instead of alpine for glibc compat

### DIFF
--- a/docker/Dockerfile.caddy
+++ b/docker/Dockerfile.caddy
@@ -1,7 +1,7 @@
 # =============================================================================
 # Stage 1: Frontend build
 # =============================================================================
-FROM node:22-alpine AS frontend-builder
+FROM node:22-slim AS frontend-builder
 
 ARG VERSION=dev
 ARG BUILD_DATE


### PR DESCRIPTION
## Summary
- Switch `docker/Dockerfile.caddy` frontend builder from `node:22-alpine` to `node:22-slim`
- Fixes the remaining CD failure after #632 (node version pin)

## Root Cause
The `package-lock.json` is generated on glibc Linux (dev machine). Alpine Linux uses musl libc. npm 10's `npm ci` silently skips optional deps that aren't resolved in the lockfile for the current platform. This means `@rolldown/binding-linux-x64-musl` (needed by Vite 8's Rolldown bundler) doesn't get installed, causing `npm run build` to fail with "Cannot find native binding".

Using `node:22-slim` (Debian/glibc) matches the dev environment. Image size is irrelevant since this is a multi-stage build — only the `dist/` output goes to the final distroless stage.

## Test plan
- [ ] CI passes
- [ ] CD "Build, Test & Push" passes (the step that was failing)
- [ ] After merge, verify CD completes successfully on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build environment base image for the frontend builder stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->