### PR TITLE
fix(api): use getattr on expanded Record in by-camper endpoint

### DIFF
--- a/api/routers/debug.py
+++ b/api/routers/debug.py
@@ -560,9 +560,10 @@ async def list_original_requests_by_camper(
 
     items = []
     for record in records:
-        expanded = getattr(record, "expand", {}).get("requester", {})
-        first = expanded.get("preferred_name") or expanded.get("first_name", "")
-        last = expanded.get("last_name", "")
+        expand = getattr(record, "expand", {})
+        expanded = expand.get("requester") if isinstance(expand, dict) else None
+        first = (getattr(expanded, "preferred_name", None) or getattr(expanded, "first_name", "")) if expanded else ""
+        last = getattr(expanded, "last_name", "") if expanded else ""
         requester_name = f"{first} {last}".strip()
 
         items.append(

--- a/tests/unit/api/routers/test_debug_original_requests_by_camper.py
+++ b/tests/unit/api/routers/test_debug_original_requests_by_camper.py
@@ -43,20 +43,25 @@ def _make_mock_pb_record(
     year: int = 2025,
     processed: str | None = None,
 ) -> MagicMock:
-    """Create a mock PocketBase record for original_bunk_requests with expand."""
+    """Create a mock PocketBase record for original_bunk_requests with expand.
+
+    expand is a dict (matching PocketBase SDK Record.expand: dict[str, Any]),
+    but expanded values are Record objects with attribute access, not dicts.
+    """
+    # Requester is a Record object — attributes, not dict keys
+    requester = MagicMock(spec=[])  # spec=[] removes default MagicMock methods like .get()
+    requester.first_name = first_name
+    requester.last_name = last_name
+    requester.preferred_name = preferred_name
+
     record = MagicMock()
     record.id = record_id
     record.field = field
     record.content = content
     record.year = year
     record.processed = processed
-    record.expand = {
-        "requester": {
-            "first_name": first_name,
-            "last_name": last_name,
-            "preferred_name": preferred_name,
-        }
-    }
+    # expand is a dict, but values are Record objects (not dicts)
+    record.expand = {"requester": requester}
     return record
 
 
@@ -86,7 +91,10 @@ def _make_mock_attendee(
     last_name: str = "Johnson",
     preferred_name: str | None = None,
 ) -> MagicMock:
-    """Create a mock PocketBase attendee record with expanded person."""
+    """Create a mock PocketBase attendee record with expanded person.
+
+    expand is a dict (matching PocketBase SDK), values are Record objects.
+    """
     person = MagicMock()
     person.id = person_id
     person.cm_id = person_cm_id


### PR DESCRIPTION
## Summary
- PocketBase SDK's `Record.expand` is a dict, but the expanded values within it are `Record` objects with attribute access — not dicts
- The by-camper endpoint called `.get()` on the expanded requester Record, causing `AttributeError: 'Record' object has no attribute 'get'` in production
- Fixed to use `getattr()` for accessing Record attributes, matching the pattern used elsewhere in the codebase
- Updated test mocks to use `MagicMock(spec=[])` for expanded Records (no `.get()` method), so this class of bug is caught by tests

## Test plan
- [x] Updated test mock `_make_mock_pb_record` to use Record-like objects (no `.get()`) for expanded values
- [x] Verified tests fail before fix (red), pass after fix (green)
- [x] Confirmed no other code in the codebase chains `.get()` on expanded Record values
- [ ] Verify in production that searching a camper by name and viewing their requests works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal request data processing with enhanced error handling for edge cases.

* **Tests**
  * Updated test mocks to align with current system data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->