### PR TITLE
fix(frontend): show 'skip' instead of 'done' for already-processed sync stats

### DIFF
--- a/frontend/src/components/admin/SyncTab.tsx
+++ b/frontend/src/components/admin/SyncTab.tsx
@@ -237,7 +237,7 @@ export function SyncTab() {
                 )}
                 {(status.summary.already_processed ?? 0) > 0 && (
                   <span className="text-muted-foreground">
-                    {status.summary.already_processed} done
+                    {status.summary.already_processed} skip
                   </span>
                 )}
                 {(status.summary.skipped || 0) > 0 && (


### PR DESCRIPTION
## Summary

- One-line label change: `already_processed` count in SyncTab showed "done" instead of "skip", inconsistent with other sync job stats

Trivial fix, no tests needed.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated status label in sync operations from "done" to "skip" when displaying the count of already-processed items, improving terminology clarity in the admin interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->