### PR TITLE
refactor(frontend): eliminate derived configId state in GradeEligibilityConfig rows

### DIFF
--- a/frontend/src/components/admin/GradeEligibilityConfig.test.tsx
+++ b/frontend/src/components/admin/GradeEligibilityConfig.test.tsx
@@ -358,6 +358,125 @@ describe('GradeEligibilityConfig', () => {
     })
   })
 
+  it('calls update (not create) for config row when record exists', async () => {
+    const user = userEvent.setup()
+    // Config record exists for session 1001 with id 'cfg1'
+    mockGetFullList
+      .mockResolvedValueOnce(mockSessions)
+      .mockResolvedValueOnce(mockConfigRecords) // cfg1 for session 1001
+      .mockResolvedValueOnce([])
+
+    mockUpdate.mockResolvedValue({})
+    mockCreate.mockResolvedValue({})
+
+    renderWithProviders(<GradeEligibilityConfig />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Taste of Camp')).toBeInTheDocument()
+    })
+
+    // Change min_grade for Taste of Camp (session 1001, has existing config 'cfg1')
+    const selects = screen.getAllByRole('combobox')
+    await user.selectOptions(selects[0]!, '3') // change min_grade from 2 to 3
+
+    const saveButton = screen.getByText(/save/i)
+    await user.click(saveButton)
+
+    await waitFor(() => {
+      // Config for session 1001 should have been UPDATED with record ID 'cfg1'
+      const updateCalls = mockUpdate.mock.calls
+      const configUpdate = updateCalls.find((call) => call[0] === 'cfg1')
+      expect(configUpdate).toBeDefined()
+      expect((configUpdate![1] as Record<string, unknown>)['config_key']).toBe('1001')
+    })
+
+    // Verify create was NOT called for session 1001
+    const configCreate = mockCreate.mock.calls.find(
+      (call) => (call[0] as Record<string, unknown>)['config_key'] === '1001'
+    )
+    expect(configCreate).toBeUndefined()
+  })
+
+  it('looks up configId from query data at save time, not stale row state', async () => {
+    const user = userEvent.setup()
+    const queryClient = createTestQueryClient()
+
+    // Initial load: config record exists with id 'cfg1'
+    mockGetFullList
+      .mockResolvedValueOnce(mockSessions)
+      .mockResolvedValueOnce(mockConfigRecords)
+      .mockResolvedValueOnce([])
+
+    mockUpdate.mockResolvedValue({})
+    mockCreate.mockResolvedValue({})
+
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <GradeEligibilityConfig />
+      </QueryClientProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Taste of Camp')).toBeInTheDocument()
+    })
+
+    // Make a change to trigger save button
+    const selects = screen.getAllByRole('combobox')
+    await user.selectOptions(selects[0]!, '3')
+
+    // Simulate config records refetch with a NEW record ID (as if record was recreated)
+    const updatedConfigRecords = [
+      {
+        id: 'cfg1-recreated',
+        category: 'session_availability',
+        subcategory: '2026',
+        config_key: '1001',
+        value: {
+          min_grade: 2,
+          max_grade: 6,
+          capacity_override: null,
+        },
+      },
+    ]
+    mockGetFullList
+      .mockResolvedValueOnce(mockSessions)
+      .mockResolvedValueOnce(updatedConfigRecords)
+      .mockResolvedValueOnce([])
+
+    // Invalidate to trigger refetch with new config record ID
+    await queryClient.invalidateQueries()
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <GradeEligibilityConfig />
+      </QueryClientProvider>
+    )
+
+    // Wait for refetch to complete
+    await waitFor(() => {
+      expect(screen.getByText('Taste of Camp')).toBeInTheDocument()
+    })
+
+    // Re-make the change (rows were rebuilt from fresh data)
+    const selectsAfter = screen.getAllByRole('combobox')
+    await user.selectOptions(selectsAfter[0]!, '4')
+
+    const saveButton = screen.getByText(/save/i)
+    await user.click(saveButton)
+
+    await waitFor(() => {
+      // Should use the NEW record ID 'cfg1-recreated' from fresh query data,
+      // not the old 'cfg1' that might be stuck in stale row state
+      const updateCalls = mockUpdate.mock.calls
+      const freshUpdate = updateCalls.find((call) => call[0] === 'cfg1-recreated')
+      expect(freshUpdate).toBeDefined()
+      expect((freshUpdate![1] as Record<string, unknown>)['config_key']).toBe('1001')
+    })
+
+    // Verify the stale ID was NOT used
+    const staleUpdate = mockUpdate.mock.calls.find((call) => call[0] === 'cfg1')
+    expect(staleUpdate).toBeUndefined()
+  })
+
   it('calls update (not create) for threshold when record exists', async () => {
     const user = userEvent.setup()
     // Threshold record exists with id 'thr1'

--- a/frontend/src/components/admin/GradeEligibilityConfig.tsx
+++ b/frontend/src/components/admin/GradeEligibilityConfig.tsx
@@ -19,7 +19,6 @@ interface SessionRow {
   cm_id: number
   name: string
   session_type: string
-  configId: string | undefined
   config: SessionConfig
 }
 
@@ -86,7 +85,6 @@ export function GradeEligibilityConfig() {
           cm_id: cmId,
           name,
           session_type: sType,
-          configId: existing?.id,
           config: val
             ? {
                 min_grade: val.min_grade ?? null,
@@ -142,14 +140,15 @@ export function GradeEligibilityConfig() {
     setIsSaving(true)
     try {
       for (const row of rows) {
+        const existingConfig = configRecords?.find((r) => r.config_key === String(row.cm_id))
         const payload = {
           category: 'session_availability',
           subcategory: String(currentYear),
           config_key: String(row.cm_id),
           value: row.config,
         }
-        if (row.configId) {
-          await pb.collection('config').update(row.configId, payload)
+        if (existingConfig?.id) {
+          await pb.collection('config').update(existingConfig.id, payload)
         } else {
           await pb.collection('config').create(payload)
         }


### PR DESCRIPTION
## Summary
- Remove `configId` from `SessionRow` interface and `buildRows` function
- In `handleSave`, look up each row's config record ID directly from `configRecords` query data at save time instead of reading from stale row state
- Add 2 regression tests: one verifying update-vs-create for existing config records, one verifying the config record ID is read from fresh query data

This is the same fix pattern applied to `thresholdId` in PR #652 (#616/#617). Eliminates the stale-state window where `configId` embedded in rows could point to deleted/recreated records.

Closes #654

## Test plan
- [x] All 16 GradeEligibilityConfig tests pass (12 existing + 2 new regression tests + 2 existing threshold tests)
- [x] New regression test verifies config update uses correct record ID and create is NOT called
- [x] New regression test verifies config record ID is read from fresh query data after refetch
- [x] Full frontend suite passes (2399 tests)
- [x] TypeScript compiles with no errors
- [x] ESLint: no new warnings
- [x] All 12 pre-push checks pass (eslint segfault is pre-existing)
- [ ] Manual: open Session Availability admin page, change a grade select for existing config → save updates (not creates)
- [ ] Manual: save config for a session with no existing record → creates new record

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed grade eligibility configuration save logic to properly update existing configurations instead of creating duplicates. The system now checks for existing configurations and updates them when applicable.

* **Tests**
  * Added test coverage for configuration update scenarios, including verification of proper update behavior and handling of refreshed configuration data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->