### PR TITLE
fix(frontend): remove 4 defensive eslint-disable comments #619

### DIFF
--- a/frontend/src/hooks/useVelocityChartData.test.ts
+++ b/frontend/src/hooks/useVelocityChartData.test.ts
@@ -370,7 +370,7 @@ describe('useVelocityChartData', () => {
             phase: 'open',
             date: '2024-11-01',
             label: 'Open Reg',
-            week_number: null as unknown as number,
+            week_number: null,
           },
         ],
       })

--- a/frontend/src/hooks/useVelocityChartData.ts
+++ b/frontend/src/hooks/useVelocityChartData.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import type { VelocityResponse } from '../types/velocity'
+import type { PhaseMarker, VelocityResponse } from '../types/velocity'
 import { resolveSessionAlias } from '../utils/sessionAliases'
 import {
   sortSessionDataByCampThenQuest,
@@ -308,15 +308,14 @@ export function useVelocityChartData(
   // Phase lines with week_number for X-axis positioning
   const phaseLines = useMemo(() => {
     if (!data?.phase_markers) return []
-    return (
-      data.phase_markers
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- week_number may be null at runtime despite Required<> type; defensive guard
-        .filter((marker) => marker.week_number != null)
-        .map((marker) => ({
-          ...marker,
-          weekNumber: marker.week_number,
-        }))
-    )
+    return data.phase_markers
+      .filter(
+        (marker): marker is PhaseMarker & { week_number: number } => marker.week_number != null
+      )
+      .map((marker) => ({
+        ...marker,
+        weekNumber: marker.week_number,
+      }))
   }, [data?.phase_markers])
 
   // Phase day offsets for ReferenceArea bands on daily cumulative charts

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -731,11 +731,10 @@ export const AppLayout = () => {
                 <YearSelector />
               </div>
               {activeProgram === 'summer' &&
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- syncStatus may be undefined before query resolves; defensive guard
-                (syncStatus?.bunk_assignments?.end_time ?? syncStatus?.bunk_requests?.end_time) && (
+                syncStatus &&
+                (syncStatus.bunk_assignments.end_time ?? syncStatus.bunk_requests.end_time) && (
                   <div className="text-muted-foreground flex items-center gap-3 text-xs">
-                    {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- syncStatus may be undefined before query resolves; defensive guard */}
-                    {syncStatus?.bunk_assignments?.end_time && (
+                    {syncStatus.bunk_assignments.end_time && (
                       <span
                         className="flex items-center gap-1.5"
                         title="Last bunk assignments sync"
@@ -747,8 +746,7 @@ export const AppLayout = () => {
                         })}
                       </span>
                     )}
-                    {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- syncStatus may be undefined before query resolves; defensive guard */}
-                    {syncStatus?.bunk_requests?.end_time && (
+                    {syncStatus.bunk_requests.end_time && (
                       <span className="flex items-center gap-1.5" title="Last bunk requests sync">
                         <Clock className="h-3 w-3" />
                         Requests{' '}

--- a/frontend/src/types/velocity.ts
+++ b/frontend/src/types/velocity.ts
@@ -55,7 +55,7 @@ export interface PhaseMarker {
   phase: string
   date: string
   label: string
-  week_number: number
+  week_number: number | null
 }
 
 export interface SessionGenderBreakdown {


### PR DESCRIPTION
## Summary
- Remove 3 `@typescript-eslint/no-unnecessary-condition` disable comments in `AppLayout.tsx` by adding an explicit `syncStatus &&` loading guard, replacing optional chaining with safe direct property access after type narrowing
- Remove 1 `@typescript-eslint/no-unnecessary-condition` disable comment in `useVelocityChartData.ts` by making `PhaseMarker.week_number` nullable (`number | null`) to match runtime API behavior, with a type predicate filter to narrow back to `number`
- Clean up test cast (`null as unknown as number` -> `null`) now that the type correctly allows null

## Test plan
- [x] All 2397 frontend tests pass (`npx vitest run`)
- [x] ESLint passes with no new warnings (`npx eslint src/`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Pre-push hooks pass (ruff, eslint, tsc, vitest, go, etc.)

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)