### PR TITLE
feat(frontend): sortable column headers on pipeline debug table

### DIFF
--- a/frontend/src/components/pipeline-debug/PipelineBatchList.tsx
+++ b/frontend/src/components/pipeline-debug/PipelineBatchList.tsx
@@ -13,7 +13,11 @@ import { ArrowDown, ArrowUp, ArrowUpDown, Loader2, Search } from 'lucide-react'
 import type { PipelineSummaryItem, PipelineSummaryFilters } from './types'
 
 /** Column definitions for sortable headers. */
-const SORTABLE_COLUMNS: Array<{ label: string; field: string; hiddenClass?: string }> = [
+const SORTABLE_COLUMNS: Array<{
+  label: string
+  field: keyof PipelineSummaryItem
+  hiddenClass?: string
+}> = [
   { label: 'Camper', field: 'requester_name' },
   { label: 'Target', field: 'target_name' },
   { label: 'Source', field: 'source_field' },


### PR DESCRIPTION
## Summary
- All 8 column headers (Camper, Target, Source, Status, Confidence, Method, P3, Reasoning) are now clickable to sort
- Cycles through ascending → descending → clear on each click, with arrow indicators
- Uses the existing PocketBase `sort` parameter already wired through the filter/API layer — no backend changes needed

## Test plan
- [ ] Navigate to `/summer/debug/pipeline`, select a run
- [ ] Click each column header — verify sort indicator appears (↑ asc, ↓ desc)
- [ ] Click again to cycle: asc → desc → clear
- [ ] Verify data re-fetches and reorders on each sort change
- [ ] Verify filters still work independently of sort

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pipeline table columns are now sortable. Click any column header to cycle ascending, descending, or cleared sort. Active sort shows an up/down arrow indicating direction; inactive headers show a muted indicator that brightens on hover.
  * Column visibility/responsive behavior is preserved when headers are generated dynamically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->