### PR TITLE
fix(frontend): eliminate derived configId state in SessionBudgetConfig

### DIFF
--- a/frontend/src/components/admin/SessionBudgetConfig.test.tsx
+++ b/frontend/src/components/admin/SessionBudgetConfig.test.tsx
@@ -422,9 +422,9 @@ describe('SessionBudgetConfig', () => {
     })
 
     // Re-make the change (rows were rebuilt from fresh data)
-    const selectsAfter = screen.getAllByRole('spinbutton')
-    await user.clear(selectsAfter[0]!)
-    await user.type(selectsAfter[0]!, '180')
+    const inputsAfter = screen.getAllByRole('spinbutton')
+    await user.clear(inputsAfter[0]!)
+    await user.type(inputsAfter[0]!, '180')
 
     const saveButton = screen.getByText(/save/i)
     await user.click(saveButton)

--- a/frontend/src/components/admin/SessionBudgetConfig.tsx
+++ b/frontend/src/components/admin/SessionBudgetConfig.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { DollarSign, Loader2, Save } from 'lucide-react'
 import toast from 'react-hot-toast'
@@ -134,13 +134,13 @@ export function SessionBudgetConfig() {
     )
   }
 
-  const hasChanges = (() => {
+  const hasChanges = useMemo(() => {
     const origRows = buildRows(sessions, configRecords)
     return rows.some((r) => {
       const orig = origRows.find((o) => o.cm_id === r.cm_id)
       return r.participant_goal !== orig?.participant_goal || r.session_fee !== orig.session_fee
     })
-  })()
+  }, [buildRows, sessions, configRecords, rows])
 
   const handleSave = async () => {
     setIsSaving(true)


### PR DESCRIPTION
## Summary
- Remove stale `configId` from row objects in `SessionBudgetConfig`
- Look up config record IDs fresh from query data at save time
- Matches the pattern established in `GradeEligibilityConfig` (PR #663)

Closes #666

## Test plan
- [x] New tests verify fresh ID lookup at save time
- [x] Existing SessionBudgetConfig tests still pass
- [x] Full frontend test suite passes (2401 tests)
- [x] ESLint + TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for session budget configuration save flow, ensuring updates target the correct existing record and that refreshed/changed records are handled correctly.

* **Refactor**
  * Improved internal handling of session budget configuration detection and save logic for more reliable update vs. create behavior and better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->