### PR TITLE
fix(sync): use status_id instead of is_active in bunk_assignments attendee filter

### DIFF
--- a/pocketbase/sync/bunk_assignments.go
+++ b/pocketbase/sync/bunk_assignments.go
@@ -266,7 +266,7 @@ func (s *BunkAssignmentsSync) loadMappings() error {
 
 	// Load person enrollments: personCMID -> list of sessionCMIDs they're enrolled in
 	// This is the source of truth for which session a person belongs to
-	attendeeFilter := fmt.Sprintf("year = %d && is_active = true", year)
+	attendeeFilter := fmt.Sprintf("year = %d && status_id = 2", year)
 	if err := s.PaginateRecords("attendees", attendeeFilter, func(record *core.Record) error {
 		personCMID := 0
 		sessionCMID := 0


### PR DESCRIPTION
## Summary
- Replace `is_active = true` with `status_id = 2` in bunk_assignments sync attendee filter
- The attendee sync no longer sets `is_active` (PR #671), so newly synced attendees have `is_active = 0` despite being enrolled

Closes #679

## Test plan
- [x] Go build + tests pass
- [x] One-line filter change, no behavior change for existing data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected attendee enrollment status identification to ensure accurate session associations based on current enrollment state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->