### PR TITLE
refactor(api): remove post-V2 dead code

### DIFF
--- a/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
@@ -60,7 +60,6 @@ from ..services.staff_name_detector import StaffNameDetector
 from ..services.staff_note_parser import parse_multi_staff_notes
 from ..shared.constants import (
     ALL_PROCESSING_FIELDS,
-    FIELDS_TO_CHECK,
     UNIT_NAMES,
     UNRESOLVED_ID_DEFAULT,
     UNRESOLVED_ID_MAX,
@@ -1668,7 +1667,7 @@ class RequestOrchestrator:
             requester_grade = str(row.get("Grade", 0))
 
             # Extract request texts from various fields (defined in constants.py)
-            for field_name in FIELDS_TO_CHECK:
+            for field_name in ALL_PROCESSING_FIELDS:
                 total_fields_checked += 1
                 request_text = row.get(field_name, "").strip()
 
@@ -2025,7 +2024,6 @@ class RequestOrchestrator:
 
         # Track source fields to clear per person
         # person_cm_id -> set of source_field values
-        _all_fields = set(ALL_PROCESSING_FIELDS)
         person_source_fields: dict[int, set[str]] = {}
 
         for row in raw_requests:
@@ -2041,7 +2039,7 @@ class RequestOrchestrator:
             # Method 1: Check _original_request_ids (from original_requests_loader)
             original_ids = row.get("_original_request_ids", {})
             for field_name in original_ids:
-                if field_name in _all_fields:
+                if field_name in ALL_PROCESSING_FIELDS:
                     person_source_fields[person_id].add(field_name)
 
             # Method 2: Check which data fields are present in the row

--- a/bunking/sync/bunk_request_processor/shared/constants.py
+++ b/bunking/sync/bunk_request_processor/shared/constants.py
@@ -71,17 +71,6 @@ SOURCE_FIELD_TO_CONFIG_KEY: dict[str, str] = {
     SourceField.SOCIALIZE_WITH: "socialize_preference",
 }
 
-# Ordered list of V2 field names for iteration
-# Used in _prepare_parse_requests to check fields in consistent order
-FIELDS_TO_CHECK: list[str] = [
-    SourceField.BUNK_WITH,
-    SourceField.NOT_BUNK_WITH,
-    SourceField.BUNKING_NOTES,
-    SourceField.INTERNAL_NOTES,
-    SourceField.SOCIALIZE_WITH,
-]
-
-
 # =============================================================================
 # Field Groupings
 # =============================================================================

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -256,9 +256,6 @@ export function getIssueTypeLabel(type: string): string {
   return labels[type] ?? type.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase())
 }
 
-// Format field names using shared utility
-const formatFieldName = formatSourceField
-
 // Satisfaction ring component - the visual centerpiece
 function SatisfactionRing({ rate, size = 120 }: { rate: number; size?: number }) {
   const percentage = Math.round(rate * 100)
@@ -745,7 +742,7 @@ export default function PostValidationResultsModal({
                   >
                     <div className="flex items-center gap-3">
                       <span className="text-foreground text-sm font-medium">
-                        {formatFieldName(fieldName)}
+                        {formatSourceField(fieldName)}
                       </span>
                       <span className="text-muted-foreground text-xs">
                         {stats.satisfied}/{stats.total}

--- a/frontend/src/components/camper/ParsedRequestsPanel.tsx
+++ b/frontend/src/components/camper/ParsedRequestsPanel.tsx
@@ -6,18 +6,6 @@ import { Users, ChevronDown, ChevronRight, Hash, Zap } from 'lucide-react'
 import type { EnhancedBunkRequest } from '../../hooks/camper/useAllBunkRequests'
 import { formatSourceField } from '../../utils/formatSourceField'
 
-// Source field normalization - maps CSV column names to normalized keys
-const normalizeSourceField = (field: string): string => {
-  const normalized = field.toLowerCase().trim()
-  if (normalized.includes('share bunk with') && !normalized.includes('do not')) return 'bunk_with'
-  if (normalized.includes('do not share') || normalized.includes('not_bunk')) return 'not_bunk_with'
-  if (normalized.includes('bunkingnotes') || normalized.includes('bunking_notes'))
-    return 'bunking_notes'
-  if (normalized.includes('internal')) return 'internal_notes'
-  if (normalized.includes('socialize')) return 'socialize_with'
-  return field // Return original if no match
-}
-
 // Source field colors (matches debug page style)
 const SOURCE_FIELD_COLORS: Record<string, string> = {
   bunk_with: 'bg-forest-100 text-forest-700 dark:bg-forest-900/40 dark:text-forest-400',
@@ -223,10 +211,9 @@ function ConfidenceBadge({ score }: { score: number }) {
 function SourceFieldBadge({ sourceField }: { sourceField: string | undefined }) {
   if (!sourceField) return null
 
-  const normalized = normalizeSourceField(sourceField)
-  const label = formatSourceField(normalized)
+  const label = formatSourceField(sourceField)
   const colorClass =
-    SOURCE_FIELD_COLORS[normalized] ??
+    SOURCE_FIELD_COLORS[sourceField] ??
     'bg-bark-100 text-bark-600 dark:bg-bark-800 dark:text-bark-400'
 
   return (

--- a/tests/unit/sync/bunk_request_processor/shared/test_constants_v2.py
+++ b/tests/unit/sync/bunk_request_processor/shared/test_constants_v2.py
@@ -20,7 +20,6 @@ _spec.loader.exec_module(_mod)  # type: ignore[union-attr]
 
 SourceField = _mod.SourceField
 ALL_PROCESSING_FIELDS = _mod.ALL_PROCESSING_FIELDS
-FIELDS_TO_CHECK = _mod.FIELDS_TO_CHECK
 SOURCE_FIELD_TO_CONFIG_KEY = _mod.SOURCE_FIELD_TO_CONFIG_KEY
 
 
@@ -33,16 +32,11 @@ def test_source_field_values_are_v2():
     assert SourceField.SOCIALIZE_WITH == "socialize_with"
 
 
-def test_fields_to_check_is_v2_list():
-    """FIELDS_TO_CHECK should be a flat list of V2 names."""
-    assert isinstance(FIELDS_TO_CHECK, list)
-    assert all(isinstance(f, str) for f in FIELDS_TO_CHECK)
-    assert FIELDS_TO_CHECK == ["bunk_with", "not_bunk_with", "bunking_notes", "internal_notes", "socialize_with"]
-
-
-def test_fields_to_check_matches_all_processing():
-    """FIELDS_TO_CHECK should contain the same fields as ALL_PROCESSING_FIELDS."""
-    assert set(FIELDS_TO_CHECK) == set(ALL_PROCESSING_FIELDS)
+def test_all_processing_fields_is_v2_list():
+    """ALL_PROCESSING_FIELDS should be a flat list of V2 names."""
+    assert isinstance(ALL_PROCESSING_FIELDS, list)
+    assert all(isinstance(f, str) for f in ALL_PROCESSING_FIELDS)
+    assert ALL_PROCESSING_FIELDS == ["bunk_with", "not_bunk_with", "bunking_notes", "internal_notes", "socialize_with"]
 
 
 def test_source_field_to_config_key_uses_v2():
@@ -77,3 +71,4 @@ def test_deleted_v1_mappings():
     assert not hasattr(_mod, "FIELD_TO_SOURCE_FIELD"), "FIELD_TO_SOURCE_FIELD should be deleted"
     assert not hasattr(_mod, "CSV_KEY_TO_SOURCE_FIELD"), "CSV_KEY_TO_SOURCE_FIELD should be deleted"
     assert not hasattr(_mod, "ALL_FIELD_TO_SOURCE_FIELD"), "ALL_FIELD_TO_SOURCE_FIELD should be deleted"
+    assert not hasattr(_mod, "FIELDS_TO_CHECK"), "FIELDS_TO_CHECK should be deleted (use ALL_PROCESSING_FIELDS)"


### PR DESCRIPTION
## Summary

- Delete `FIELDS_TO_CHECK` (now identical to `ALL_PROCESSING_FIELDS` after V2 standardization)
- Remove dead `normalizeSourceField()` V1-to-V2 mapper from `ParsedRequestsPanel.tsx`
- Remove `const formatFieldName = formatSourceField` alias from `PostValidationResultsModal.tsx`
- Remove `_all_fields = set(ALL_PROCESSING_FIELDS)` per-call allocation in orchestrator

Follow-up to #681 — these simplifications were identified during code review but missed the squash merge window.

## Test plan

- [x] 2496 Python tests pass
- [x] 2429 frontend tests pass
- [x] Pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified internal field processing logic by consolidating field iteration and removal of redundant constants.
  * Cleaned up component implementations to remove intermediate utility functions and streamline data handling.
  * Updated test coverage to reflect internal restructuring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->