### PR TITLE
fix(frontend): add aria-labels to SessionConfigTable form controls

### DIFF
--- a/frontend/src/components/admin/SessionConfigTable.test.tsx
+++ b/frontend/src/components/admin/SessionConfigTable.test.tsx
@@ -808,6 +808,74 @@ describe('SessionConfigTable', () => {
     expect(staleUpdate).toBeUndefined()
   })
 
+  describe('accessibility: aria-labels on form controls', () => {
+    beforeEach(() => {
+      mockGetFullList
+        .mockResolvedValueOnce(mockSessions)
+        .mockResolvedValueOnce(mockGradeConfigRecords)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce(mockBudgetConfigRecords)
+    })
+
+    it('column headers have id attributes', async () => {
+      renderWithProviders(<SessionConfigTable />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Taste of Camp')).toBeInTheDocument()
+      })
+
+      expect(document.getElementById('col-min-grade')).toHaveTextContent('Min Grade')
+      expect(document.getElementById('col-max-grade')).toHaveTextContent('Max Grade')
+      expect(document.getElementById('col-cap-override')).toHaveTextContent('Cap. Override')
+      expect(document.getElementById('col-participant-goal')).toHaveTextContent('Participant Goal')
+      expect(document.getElementById('col-session-fee')).toHaveTextContent('Session Fee')
+    })
+
+    it('session name cells are row headers with id attributes', async () => {
+      renderWithProviders(<SessionConfigTable />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Taste of Camp')).toBeInTheDocument()
+      })
+
+      const rowHeaders = screen.getAllByRole('rowheader')
+      expect(rowHeaders.length).toBeGreaterThanOrEqual(5) // all 5 sessions
+
+      // Check that each session name cell has an id
+      const tasteHeader = rowHeaders.find((h) => h.textContent === 'Taste of Camp')
+      expect(tasteHeader).toBeDefined()
+      expect(tasteHeader!.id).toBe('session-1001')
+    })
+
+    it('selects have aria-labelledby referencing row and column headers', async () => {
+      renderWithProviders(<SessionConfigTable />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Taste of Camp')).toBeInTheDocument()
+      })
+
+      const selects = screen.getAllByRole('combobox')
+      // First two selects belong to first session (Taste of Camp, cm_id=1001)
+      expect(selects[0]).toHaveAttribute('aria-labelledby', 'session-1001 col-min-grade')
+      expect(selects[1]).toHaveAttribute('aria-labelledby', 'session-1001 col-max-grade')
+    })
+
+    it('number inputs have aria-labelledby referencing row and column headers', async () => {
+      renderWithProviders(<SessionConfigTable />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Taste of Camp')).toBeInTheDocument()
+      })
+
+      const inputs = screen.getAllByRole('spinbutton')
+      // inputs[0] = threshold (has its own label), then per row: cap override, participant goal, session fee
+      // First row (Taste of Camp, cm_id=1001): inputs[1], inputs[2], inputs[3]
+      expect(inputs[1]).toHaveAttribute('aria-labelledby', 'session-1001 col-cap-override')
+      expect(inputs[2]).toHaveAttribute('aria-labelledby', 'session-1001 col-participant-goal')
+      expect(inputs[3]).toHaveAttribute('aria-labelledby', 'session-1001 col-session-fee')
+    })
+  })
+
   it('renders error state when a query fails', async () => {
     mockGetFullList
       .mockResolvedValueOnce(mockSessions)

--- a/frontend/src/components/admin/SessionConfigTable.tsx
+++ b/frontend/src/components/admin/SessionConfigTable.tsx
@@ -293,11 +293,14 @@ export function SessionConfigTable() {
 
   const renderRow = (row: SessionRow) => (
     <tr key={row.cm_id} className="border-border border-b">
-      <td className="py-2 pr-4 font-medium">{row.name}</td>
+      <th scope="row" id={`session-${row.cm_id}`} className="py-2 pr-4 text-left font-medium">
+        {row.name}
+      </th>
       <td className="px-2 py-2">
         <select
           value={row.min_grade ?? ''}
           onChange={(e) => handleChange(row.cm_id, 'min_grade', e.target.value)}
+          aria-labelledby={`session-${row.cm_id} col-min-grade`}
           className="bg-muted/30 dark:bg-muted/50 border-border w-20 rounded border px-1 py-1 text-center text-sm"
         >
           <option value="" />
@@ -312,6 +315,7 @@ export function SessionConfigTable() {
         <select
           value={row.max_grade ?? ''}
           onChange={(e) => handleChange(row.cm_id, 'max_grade', e.target.value)}
+          aria-labelledby={`session-${row.cm_id} col-max-grade`}
           className="bg-muted/30 dark:bg-muted/50 border-border w-20 rounded border px-1 py-1 text-center text-sm"
         >
           <option value="" />
@@ -328,6 +332,7 @@ export function SessionConfigTable() {
           min={0}
           value={row.capacity_override ?? ''}
           onChange={(e) => handleChange(row.cm_id, 'capacity_override', e.target.value)}
+          aria-labelledby={`session-${row.cm_id} col-cap-override`}
           className="bg-muted/30 dark:bg-muted/50 border-border w-16 rounded border px-2 py-1 text-center text-sm"
         />
       </td>
@@ -337,6 +342,7 @@ export function SessionConfigTable() {
           min={0}
           value={row.participant_goal ?? ''}
           onChange={(e) => handleChange(row.cm_id, 'participant_goal', e.target.value)}
+          aria-labelledby={`session-${row.cm_id} col-participant-goal`}
           className="bg-muted/30 dark:bg-muted/50 border-border w-24 rounded border px-2 py-1 text-center text-sm"
         />
       </td>
@@ -349,6 +355,7 @@ export function SessionConfigTable() {
             step={0.01}
             value={row.session_fee ?? ''}
             onChange={(e) => handleChange(row.cm_id, 'session_fee', e.target.value)}
+            aria-labelledby={`session-${row.cm_id} col-session-fee`}
             className="bg-muted/30 dark:bg-muted/50 border-border w-24 rounded border px-2 py-1 text-center text-sm"
           />
         </div>
@@ -390,11 +397,21 @@ export function SessionConfigTable() {
           <thead>
             <tr className="border-border border-b">
               <th className="py-2 pr-4 text-left font-medium">Session</th>
-              <th className="px-2 py-2 text-center font-medium">Min Grade</th>
-              <th className="px-2 py-2 text-center font-medium">Max Grade</th>
-              <th className="px-2 py-2 text-center font-medium">Cap. Override</th>
-              <th className="px-2 py-2 text-center font-medium">Participant Goal</th>
-              <th className="px-2 py-2 text-center font-medium">Session Fee</th>
+              <th id="col-min-grade" className="px-2 py-2 text-center font-medium">
+                Min Grade
+              </th>
+              <th id="col-max-grade" className="px-2 py-2 text-center font-medium">
+                Max Grade
+              </th>
+              <th id="col-cap-override" className="px-2 py-2 text-center font-medium">
+                Cap. Override
+              </th>
+              <th id="col-participant-goal" className="px-2 py-2 text-center font-medium">
+                Participant Goal
+              </th>
+              <th id="col-session-fee" className="px-2 py-2 text-center font-medium">
+                Session Fee
+              </th>
             </tr>
           </thead>
           <tbody>


### PR DESCRIPTION
## Summary
- Add `id` attributes to column `<th>` elements (`col-min-grade`, `col-max-grade`, `col-cap-override`, `col-participant-goal`, `col-session-fee`)
- Change session name `<td>` to `<th scope="row" id="session-{cm_id}">` for proper row headers
- Add `aria-labelledby` to all `<select>` and `<input>` elements referencing both the row header and column header

Screen readers can now identify which session and column each form control belongs to.

Closes #688

## Test plan
- [x] 4 new accessibility tests added (column header IDs, row headers, select labels, input labels)
- [x] All 28 existing + new tests pass
- [ ] Verify no visual regression in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added accessibility tests for SessionConfigTable validating header associations and screen reader compatibility.

* **Bug Fixes**
  * Improved SessionConfigTable with semantic HTML enhancements and accessibility attributes for table structure and form controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->