### PR TITLE
fix(security): temporarily ignore CVE-2026-33186 to unblock CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -589,11 +589,11 @@ jobs:
 
           # Generate SARIF report (HIGH + CRITICAL, non-blocking)
           trivy image --format sarif --output "trivy-results-${IMAGE}.sarif" \
-            --severity CRITICAL,HIGH --exit-code 0 "$FULL_REF"
+            --severity CRITICAL,HIGH --exit-code 0 --ignorefile .trivyignore "$FULL_REF"
 
           # Check for CRITICAL vulnerabilities (scan all images before failing)
           if ! trivy image --format table --severity CRITICAL --exit-code 1 \
-               --skip-db-update "$FULL_REF"; then
+               --skip-db-update --ignorefile .trivyignore "$FULL_REF"; then
             echo "^^^ CRITICAL vulnerabilities found in ${IMAGE}!"
             HAS_CRITICAL=true
           fi

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,6 @@
+# Temporary CVE ignores for Trivy security scanning
+# Remove entries once upstream packages ship fixes
+#
+# Format: CVE-ID  # reason — added YYYY-MM-DD, remove by YYYY-MM-DD
+
+CVE-2026-33186  # grpc-go auth bypass in caddy binary — waiting on upstream caddy rebuild with grpc v1.79.3 — added 2026-03-19, remove by 2026-04-19


### PR DESCRIPTION
## Summary
- CD has been blocked for 5 consecutive runs by a CRITICAL Trivy finding: **CVE-2026-33186** (gRPC-Go authorization bypass via missing leading slash in `:path`)
- The vuln is in `dhi.io/caddy:2` which ships `google.golang.org/grpc v1.79.1` — fix is in `v1.79.3` but upstream Caddy hasn't rebuilt yet
- Adds `.trivyignore` targeting only this single CVE, with a 30-day expiry note for cleanup
- Wires `--ignorefile .trivyignore` into both Trivy scan commands in the CD workflow

## Why not fix the dependency directly?
The vulnerable gRPC is compiled into the Caddy binary from DHI's pre-built image. DHI uses Wolfi packages under the hood, and both ship the identical caddy build (Mar 5). Neither has rebuilt with the patched gRPC yet. We don't control when upstream rebuilds.

## Test plan
- [ ] CI passes (no Trivy changes in CI, only CD)
- [ ] CD Trivy scan skips CVE-2026-33186 and proceeds to push
- [ ] Verify `.trivyignore` only ignores this one CVE, not all criticals
- [ ] Remove `.trivyignore` entry once upstream caddy ships grpc >= 1.79.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration in the deployment pipeline to manage known vulnerability exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->