### PR TITLE
refactor(api): standardize expand extraction with shared utility (#625)

### DIFF
--- a/api/routers/debug.py
+++ b/api/routers/debug.py
@@ -88,6 +88,7 @@ from ..schemas.pipeline_debug import (
 )
 from ..settings import get_settings
 from ..utils.pb_filters import pb_escape
+from ..utils.session_metrics import get_person_from_expand, get_session_from_expand
 
 logger = get_logger(__name__)
 
@@ -544,8 +545,7 @@ async def list_original_requests_by_camper(
     if not attendees.items:
         return OriginalRequestsListResponse(items=[], total=0)
 
-    expand = getattr(attendees.items[0], "expand", {}) or {}
-    person = expand.get("person") if isinstance(expand, dict) else getattr(expand, "person", None)
+    person = get_person_from_expand(attendees.items[0])
     if not person:
         return OriginalRequestsListResponse(items=[], total=0)
     person_pb_id = person.id
@@ -610,9 +610,8 @@ async def search_persons(
     # Group by person cm_id, collecting session CM IDs
     person_data: dict[int, PersonSearchItem] = {}
     for att in attendees:
-        expand = getattr(att, "expand", {}) or {}
-        person = expand.get("person") if isinstance(expand, dict) else getattr(expand, "person", None)
-        session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+        person = get_person_from_expand(att)
+        session = get_session_from_expand(att)
         if not person:
             continue
 

--- a/api/routers/scenarios.py
+++ b/api/routers/scenarios.py
@@ -43,6 +43,7 @@ from ..constants.collections import (
 from ..dependencies import pb, solver_runs
 from ..services.session_context import build_session_context
 from ..services.solver_runner import run_solver_task_v2
+from ..utils.session_metrics import get_person_from_expand, get_session_from_expand
 
 logger = get_logger(__name__)
 
@@ -125,16 +126,8 @@ async def create_scenario(
             for assignment in copy_source_assignments:
                 if request.should_copy_from_production and not request.copy_from_scenario:
                     assign_expand = getattr(assignment, "expand", {}) or {}
-                    person_data = (
-                        assign_expand.get("person")
-                        if isinstance(assign_expand, dict)
-                        else getattr(assign_expand, "person", None)
-                    )
-                    session_data = (
-                        assign_expand.get("session")
-                        if isinstance(assign_expand, dict)
-                        else getattr(assign_expand, "session", None)
-                    )
+                    person_data = get_person_from_expand(assignment)
+                    session_data = get_session_from_expand(assignment)
                     bunk_data = (
                         assign_expand.get("bunk")
                         if isinstance(assign_expand, dict)
@@ -317,7 +310,7 @@ async def evaluate_score(
         assignment_map: dict[int, int] = {}
         for a in assignments_raw:
             expand = getattr(a, "expand", {}) or {}
-            person_data = expand.get("person") if isinstance(expand, dict) else getattr(expand, "person", None)
+            person_data = get_person_from_expand(a)
             bunk_data = expand.get("bunk") if isinstance(expand, dict) else getattr(expand, "bunk", None)
 
             if person_data and bunk_data:

--- a/api/routers/solver.py
+++ b/api/routers/solver.py
@@ -49,6 +49,7 @@ from ..schemas import (
 )
 from ..services.session_context import build_session_context
 from ..services.solver_runner import run_solver_task_v2
+from ..utils.session_metrics import get_session_from_expand
 
 logger = get_logger(__name__)
 
@@ -168,19 +169,17 @@ async def pre_validate_solver(
         person_session_type: dict[int, str] = {}
         for attendee in attendees:
             person_id = getattr(attendee, "person_id", None)
-            if person_id and hasattr(attendee, "expand") and attendee.expand:
-                session = attendee.expand.get("session")
-                if session:
-                    session_type: str = str(getattr(session, "type", None) or getattr(session, "session_type", "main"))
-                    person_session_type[person_id] = session_type
+            session = get_session_from_expand(attendee)
+            if person_id and session:
+                session_type: str = str(getattr(session, "type", None) or getattr(session, "session_type", "main"))
+                person_session_type[person_id] = session_type
 
         # Count attendees by session for breakdown
         attendees_by_session: defaultdict[int, int] = defaultdict(int)
         for attendee in attendees:
-            if hasattr(attendee, "expand") and attendee.expand:
-                session = attendee.expand.get("session")
-                if session and hasattr(session, "cm_id"):
-                    attendees_by_session[session.cm_id] += 1
+            session = get_session_from_expand(attendee)
+            if session and hasattr(session, "cm_id"):
+                attendees_by_session[session.cm_id] += 1
 
         # Fetch persons to get names (with year filter for data integrity)
         persons_dict: dict[int, Any] = {}
@@ -565,12 +564,7 @@ async def apply_solver_results(
                     )
                     continue
 
-                attendee_expand = getattr(attendees[0], "expand", {}) or {}
-                session_data = (
-                    attendee_expand.get("session")
-                    if isinstance(attendee_expand, dict)
-                    else getattr(attendee_expand, "session", None)
-                )
+                session_data = get_session_from_expand(attendees[0])
                 actual_session_cm_id_val = (
                     session_data.cm_id if session_data and hasattr(session_data, "cm_id") else None
                 )
@@ -618,12 +612,7 @@ async def apply_solver_results(
                     )
                     continue
 
-                attendee_expand = getattr(attendees[0], "expand", {}) or {}
-                session_data = (
-                    attendee_expand.get("session")
-                    if isinstance(attendee_expand, dict)
-                    else getattr(attendee_expand, "session", None)
-                )
+                session_data = get_session_from_expand(attendees[0])
                 actual_session_cm_id_raw = (
                     session_data.cm_id if session_data and hasattr(session_data, "cm_id") else None
                 )

--- a/api/routers/validation.py
+++ b/api/routers/validation.py
@@ -43,6 +43,7 @@ from ..constants.filters import ACTIVE_ENROLLED_FILTER
 from ..dependencies import pb
 from ..schemas import ValidateBunkingRequest
 from ..services.session_context import build_session_context
+from ..utils.session_metrics import get_person_from_expand, get_session_from_expand
 
 logger = get_logger(__name__)
 
@@ -245,8 +246,8 @@ async def validate_bunking(
         assignments = []
         for assignment_data in assignments_data:
             expand = getattr(assignment_data, "expand", {}) or {}
-            person_data = expand.get("person") if isinstance(expand, dict) else getattr(expand, "person", None)
-            session_data = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            person_data = get_person_from_expand(assignment_data)
+            session_data = get_session_from_expand(assignment_data)
             bunk_data = expand.get("bunk") if isinstance(expand, dict) else getattr(expand, "bunk", None)
 
             person_cm_id = person_data.cm_id if person_data and hasattr(person_data, "cm_id") else None
@@ -321,7 +322,7 @@ async def validate_bunking(
         for plan in bunk_plans_data:
             expand = getattr(plan, "expand", {}) or {}
             bunk_data = expand.get("bunk") if isinstance(expand, dict) else getattr(expand, "bunk", None)
-            session_data = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            session_data = get_session_from_expand(plan)
             bunk_cm_id = bunk_data.cm_id if bunk_data and hasattr(bunk_data, "cm_id") else None
             session_cm_id_val = session_data.cm_id if session_data and hasattr(session_data, "cm_id") else None
             if bunk_cm_id and session_cm_id_val:
@@ -332,8 +333,7 @@ async def validate_bunking(
         attendees_for_validator = []
         for attendee in attendees_data:
             person_cm_id = getattr(attendee, "person_id", None)
-            expand = getattr(attendee, "expand", {}) or {}
-            session_data = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            session_data = get_session_from_expand(attendee)
             session_cm_id_val = session_data.cm_id if session_data and hasattr(session_data, "cm_id") else None
             if person_cm_id and session_cm_id_val:
                 att = AttendeeData(person_cm_id=person_cm_id, session_cm_id=session_cm_id_val)
@@ -353,9 +353,9 @@ async def validate_bunking(
             )
             for hist in historical_data:
                 expand = getattr(hist, "expand", {}) or {}
-                person_data = expand.get("person") if isinstance(expand, dict) else getattr(expand, "person", None)
+                person_data = get_person_from_expand(hist)
                 bunk_data = expand.get("bunk") if isinstance(expand, dict) else getattr(expand, "bunk", None)
-                session_data = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+                session_data = get_session_from_expand(hist)
 
                 person_cm_id = person_data.cm_id if person_data and hasattr(person_data, "cm_id") else None
                 bunk_name = bunk_data.name if bunk_data and hasattr(bunk_data, "name") else None

--- a/api/services/comparison_service.py
+++ b/api/services/comparison_service.py
@@ -16,6 +16,7 @@ from api.schemas.metrics import (
     GradeBreakdown,
     YearSummary,
 )
+from api.utils.session_metrics import get_session_from_expand
 
 from .breakdown_calculator import calculate_percentage, compute_registration_breakdown
 from .extractors import extract_gender, extract_grade
@@ -109,8 +110,7 @@ class ComparisonService:
         """
         filtered = []
         for a in attendees:
-            expand = getattr(a, "expand", {}) or {}
-            session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            session = get_session_from_expand(a)
             session_type = getattr(session, "session_type", None) if session else None
             if session_type in session_types:
                 filtered.append(a)

--- a/api/services/data_fetcher.py
+++ b/api/services/data_fetcher.py
@@ -15,6 +15,7 @@ from typing import Any
 from fastapi import HTTPException
 from pocketbase.client import ClientResponseError  # type: ignore[attr-defined]
 
+from api.utils.session_metrics import get_person_from_expand, get_session_from_expand
 from bunking.direct_solver import (
     DirectBunk,
     DirectBunkAssignment,
@@ -72,11 +73,7 @@ async def fetch_session_data_v2(
         # Log attendee counts by session
         attendees_by_session: defaultdict[int, int] = defaultdict(int)
         for attendee in attendees:
-            session_cm_id_val = (
-                getattr(attendee.expand.get("session"), "cm_id", None)
-                if hasattr(attendee, "expand") and attendee.expand
-                else None
-            )
+            session_cm_id_val = getattr(get_session_from_expand(attendee), "cm_id", None)
             if session_cm_id_val:
                 attendees_by_session[session_cm_id_val] += 1
         logger.info(f"Fetched {len(attendees)} total attendees: {dict(attendees_by_session)}")
@@ -209,7 +206,7 @@ async def fetch_historical_bunking(
             expand = getattr(assignment, "expand", {}) or {}
 
             # Get person cm_id from expanded relation
-            person_data = expand.get("person") if isinstance(expand, dict) else getattr(expand, "person", None)
+            person_data = get_person_from_expand(assignment)
             person_cm_id = person_data.cm_id if person_data and hasattr(person_data, "cm_id") else None
 
             # Get bunk name from expanded relation
@@ -345,14 +342,7 @@ def prepare_direct_solver_input(
     person_cm_id_set = set()
 
     for attendee in attendees:
-        expand = getattr(attendee, "expand", {}) or {}
-
-        # Handle expand as either dict or object
-        person = None
-        if isinstance(expand, dict) and "person" in expand:
-            person = expand["person"]
-        elif hasattr(expand, "person"):
-            person = expand.person
+        person = get_person_from_expand(attendee)
 
         if not person:
             logger.warning(f"Attendee {attendee.id} missing person data")
@@ -366,10 +356,8 @@ def prepare_direct_solver_input(
         person_cm_id_set.add(person_cm_id)
 
         # Get session cm_id from expanded session relation
-        session_cm_id_val = None
-        session_data = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
-        if session_data and hasattr(session_data, "cm_id"):
-            session_cm_id_val = session_data.cm_id
+        session_data = get_session_from_expand(attendee)
+        session_cm_id_val = session_data.cm_id if session_data and hasattr(session_data, "cm_id") else None
 
         direct_person = DirectPerson(
             campminder_person_id=person_cm_id,
@@ -387,8 +375,7 @@ def prepare_direct_solver_input(
     session_ids_in_data = set()
     ag_session_ids = set()
     for attendee in attendees:
-        expand = getattr(attendee, "expand", {}) or {}
-        session_data = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+        session_data = get_session_from_expand(attendee)
         if session_data and hasattr(session_data, "cm_id"):
             session_ids_in_data.add(session_data.cm_id)
             session_type = getattr(session_data, "session_type", "")
@@ -404,7 +391,7 @@ def prepare_direct_solver_input(
         expand = getattr(plan, "expand", {}) or {}
         bunk_data = expand.get("bunk") if isinstance(expand, dict) else getattr(expand, "bunk", None)
         bunk_cm_id = bunk_data.cm_id if bunk_data and hasattr(bunk_data, "cm_id") else None
-        session_data = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+        session_data = get_session_from_expand(plan)
         session_cm_id_val = session_data.cm_id if session_data and hasattr(session_data, "cm_id") else None
         if bunk_cm_id and session_cm_id_val:
             if bunk_cm_id not in bunk_to_session:
@@ -467,9 +454,9 @@ def prepare_direct_solver_input(
     direct_assignments = []
     for assignment in assignments:
         expand = getattr(assignment, "expand", {}) or {}
-        person_data = expand.get("person") if isinstance(expand, dict) else getattr(expand, "person", None)
+        person_data = get_person_from_expand(assignment)
         person_cm_id = person_data.cm_id if person_data and hasattr(person_data, "cm_id") else None
-        session_data = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+        session_data = get_session_from_expand(assignment)
         session_cm_id_val = session_data.cm_id if session_data and hasattr(session_data, "cm_id") else None
         bunk_data = expand.get("bunk") if isinstance(expand, dict) else getattr(expand, "bunk", None)
         bunk_cm_id = bunk_data.cm_id if bunk_data and hasattr(bunk_data, "cm_id") else None

--- a/api/services/day1_service.py
+++ b/api/services/day1_service.py
@@ -19,6 +19,7 @@ from api.schemas.day1 import (
 from api.services.camp_calendar import REGISTRATION_TIERS, day1_window
 from api.services.metrics_repository import MetricsRepository
 from api.services.reconstruction import ENROLLMENT_STATUSES, parse_date_only
+from api.utils.session_metrics import get_session_from_expand
 from bunking.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -94,8 +95,7 @@ class Day1Service:
             eff_date_str = parse_date_only(eff_str)
 
             # Determine session type once per attendee
-            expand = getattr(att, "expand", {}) or {}
-            session = expand.get("session") if isinstance(expand, dict) else None
+            session = get_session_from_expand(att)
             sid = int(session.cm_id) if session else 0
             stype = session_type_map.get(sid, "")
 

--- a/api/services/drilldown_service.py
+++ b/api/services/drilldown_service.py
@@ -15,6 +15,7 @@ from api.utils.session_metrics import (
     compute_summer_metrics,
     filter_attendees_by_session,
     find_ag_sessions_for_parent,
+    get_person_from_expand,
     get_session_from_expand,
     get_session_length_category,
     resolve_duration_sessions,
@@ -329,8 +330,7 @@ class DrilldownService:
         """
         if not session_types:
             return True
-        expand = getattr(attendee, "expand", {}) or {}
-        session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+        session = get_session_from_expand(attendee)
         if not session:
             return False
         return getattr(session, "session_type", None) in session_types
@@ -370,8 +370,7 @@ class DrilldownService:
             person_id = getattr(a, "person_id", None)
             person = persons.get(person_id) if person_id else None
 
-            expand = getattr(a, "expand", {}) or {}
-            session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            session = get_session_from_expand(a)
 
             if breakdown_type == "gender":
                 if person and getattr(person, "gender", None) == breakdown_value:
@@ -528,8 +527,7 @@ class DrilldownService:
             returned_person_ids.add(pid_int)
             if self._matches_session_types(a, session_types):
                 enrolled_attendee_groups.setdefault(pid_int, []).append(a)
-            expand = getattr(a, "expand", {}) or {}
-            session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            session = get_session_from_expand(a)
             if session:
                 sid = getattr(session, "cm_id", None)
                 if sid is not None and int(sid) == target_session_cm_id:
@@ -680,8 +678,7 @@ class DrilldownService:
             if not person:
                 continue
 
-            expand = getattr(a, "expand", {}) or {}
-            session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            session = get_session_from_expand(a)
             if not session:
                 continue
 
@@ -702,10 +699,7 @@ class DrilldownService:
             sessions_list: list[DrilldownSession] = []
             if person_attendee_groups and person_id in person_attendee_groups:
                 for group_a in person_attendee_groups[person_id]:
-                    g_expand = getattr(group_a, "expand", {}) or {}
-                    g_session = (
-                        g_expand.get("session") if isinstance(g_expand, dict) else getattr(g_expand, "session", None)
-                    )
+                    g_session = get_session_from_expand(group_a)
                     if g_session:
                         sessions_list.append(
                             DrilldownSession(
@@ -720,10 +714,7 @@ class DrilldownService:
             enrolled_sessions_list: list[DrilldownSession] = []
             if enrolled_attendee_groups and person_id in enrolled_attendee_groups:
                 for enrolled_a in enrolled_attendee_groups[person_id]:
-                    e_expand = getattr(enrolled_a, "expand", {}) or {}
-                    e_session = (
-                        e_expand.get("session") if isinstance(e_expand, dict) else getattr(e_expand, "session", None)
-                    )
+                    e_session = get_session_from_expand(enrolled_a)
                     if e_session:
                         enrolled_sessions_list.append(
                             DrilldownSession(
@@ -880,10 +871,7 @@ class DrilldownService:
             # Build enrolled_sessions for this person
             enrolled_sessions_list: list[DrilldownSession] = []
             for enrolled_a in enrolled_attendee_groups.get(pid, []):
-                e_expand = getattr(enrolled_a, "expand", {}) or {}
-                e_session = (
-                    e_expand.get("session") if isinstance(e_expand, dict) else getattr(e_expand, "session", None)
-                )
+                e_session = get_session_from_expand(enrolled_a)
                 if e_session:
                     enrolled_sessions_list.append(
                         DrilldownSession(
@@ -1051,9 +1039,8 @@ class DrilldownService:
         # Build enrolled sessions lookup: person_id -> list of enrolled summer session names
         enrolled_by_person: dict[int, list[DrilldownSession]] = {}
         for att in enrolled_attendees:
-            expand = getattr(att, "expand", {}) or {}
-            person = expand.get("person") if isinstance(expand, dict) else getattr(expand, "person", None)
-            session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            person = get_person_from_expand(att)
+            session = get_session_from_expand(att)
             if not person or not session:
                 continue
             scmid = int(getattr(session, "cm_id", 0))
@@ -1072,9 +1059,8 @@ class DrilldownService:
         # Build waitlisted sessions lookup: person_id -> summer sessions they're waitlisted for
         waitlisted_by_person: dict[int, list[DrilldownSession]] = {}
         for att in waitlisted_attendees:
-            expand = getattr(att, "expand", {}) or {}
-            person = expand.get("person") if isinstance(expand, dict) else getattr(expand, "person", None)
-            session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            person = get_person_from_expand(att)
+            session = get_session_from_expand(att)
             if not person or not session:
                 continue
             scmid = int(getattr(session, "cm_id", 0))
@@ -1094,9 +1080,8 @@ class DrilldownService:
         results = []
         seen_persons: set[int] = set()
         for att in waitlisted_attendees:
-            expand = getattr(att, "expand", {}) or {}
-            person = expand.get("person") if isinstance(expand, dict) else getattr(expand, "person", None)
-            session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            person = get_person_from_expand(att)
+            session = get_session_from_expand(att)
             if not person or not session:
                 continue
 

--- a/api/services/forecast_service.py
+++ b/api/services/forecast_service.py
@@ -20,6 +20,7 @@ from api.services.reconstruction import (
 from api.utils.session_aliases import resolve_session_alias
 from api.utils.session_metrics import (
     build_ag_parent_map,
+    get_person_from_expand,
     get_session_from_expand,
     resolve_duration_sessions,
 )
@@ -314,8 +315,7 @@ class ForecastService:
             att_cm_id = getattr(session, "cm_id", None)
             if att_cm_id == session_cm_id or att_cm_id in ag_children:
                 count += 1
-                expand = getattr(a, "expand", {}) or {}
-                person = expand.get("person") if isinstance(expand, dict) else None
+                person = get_person_from_expand(a)
                 gender = getattr(person, "gender", None) if person else None
                 if gender is not None:
                     has_gender = True

--- a/api/services/id_cache.py
+++ b/api/services/id_cache.py
@@ -15,6 +15,7 @@ from api.constants.collections import (
     CAMP_SESSIONS,
     PERSONS,
 )
+from api.utils.session_metrics import get_person_from_expand
 from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
@@ -148,8 +149,8 @@ class IDLookupCache:
                 query_params={"filter": f"session_cm_id = {session_cm_id} && year = {year}", "expand": "person"},
             )
             for attendee in attendees:
-                if hasattr(attendee, "expand") and attendee.expand and "person" in attendee.expand:
-                    person = attendee.expand["person"]
+                person = get_person_from_expand(attendee)
+                if person:
                     self._person_cm_to_pb[person.cm_id] = person.id
                     self._person_pb_to_cm[person.id] = person.cm_id
             logger.info(f"Batch loaded {len(self._person_cm_to_pb)} person mappings for session {session_cm_id}")

--- a/api/services/reconstruction.py
+++ b/api/services/reconstruction.py
@@ -18,6 +18,8 @@ from collections import defaultdict
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
+from api.utils.session_metrics import get_person_from_expand, get_session_from_expand
+
 if TYPE_CHECKING:
     from api.schemas.velocity import DailyDataPoint
     from api.services.metrics_repository import MetricsRepository
@@ -71,8 +73,7 @@ def _reconstruct_core(
     session_has_gender: set[int] = set()
 
     for att in attendees:
-        expand = getattr(att, "expand", {}) or {}
-        session = expand.get("session") if isinstance(expand, dict) else None
+        session = get_session_from_expand(att)
         if not session:
             continue
 
@@ -84,7 +85,7 @@ def _reconstruct_core(
         effective_sid = ag_parent_map.get(raw_sid, raw_sid) if ag_parent_map is not None else raw_sid
 
         # Get gender from person expand (may be absent)
-        person = expand.get("person") if isinstance(expand, dict) else None
+        person = get_person_from_expand(att)
         gender = getattr(person, "gender", None) if person else None
         if gender is not None:
             session_has_gender.add(effective_sid)
@@ -210,9 +211,7 @@ def reconstruct_daily(
     sessions_with_gender: set[int] = set()
 
     for att in attendees:
-        # Access session via expand dict — matches _reconstruct_core pattern
-        expand = getattr(att, "expand", {}) or {}
-        session = expand.get("session") if isinstance(expand, dict) else None
+        session = get_session_from_expand(att)
         if not session:
             continue
         sid = int(session.cm_id)
@@ -233,8 +232,8 @@ def reconstruct_daily(
         if sid not in sessions:
             continue
 
-        # Gender — access via expand dict, matching _reconstruct_core
-        person = expand.get("person") if isinstance(expand, dict) else None
+        # Gender
+        person = get_person_from_expand(att)
         gender = getattr(person, "gender", None) if person else None
         if gender is not None:
             sessions_with_gender.add(sid)

--- a/api/services/registration_service.py
+++ b/api/services/registration_service.py
@@ -33,6 +33,7 @@ from api.utils.session_metrics import (
     compute_summer_metrics,
     filter_attendees_by_session,
     find_ag_sessions_for_parent,
+    get_session_from_expand,
     get_session_length_category,
     resolve_duration_sessions,
 )
@@ -252,8 +253,7 @@ class RegistrationService:
         """
         session_counts: dict[int, int] = {}
         for a in attendees:
-            expand = getattr(a, "expand", {}) or {}
-            session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            session = get_session_from_expand(a)
             attendee_session_cm_id = getattr(session, "cm_id", None) if session else None
             if attendee_session_cm_id:
                 sid_int = int(attendee_session_cm_id)
@@ -421,8 +421,7 @@ class RegistrationService:
         """Compute session length breakdown."""
         length_counts: dict[str, int] = {}
         for a in attendees:
-            expand = getattr(a, "expand", {}) or {}
-            session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            session = get_session_from_expand(a)
             if session:
                 start_date = getattr(session, "start_date", "") or ""
                 end_date = getattr(session, "end_date", "") or ""
@@ -556,8 +555,7 @@ class RegistrationService:
         # Step 1: Count attendees by session (same as _compute_session_breakdown)
         session_counts: dict[int, int] = {}
         for a in attendees:
-            expand = getattr(a, "expand", {}) or {}
-            session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            session = get_session_from_expand(a)
             if not session:
                 continue
             session_cm_id = getattr(session, "cm_id", None)
@@ -663,8 +661,7 @@ class RegistrationService:
         # Collect unique person IDs per length category
         length_persons: dict[str, set[int]] = {}
         for a in attendees:
-            expand = getattr(a, "expand", {}) or {}
-            session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            session = get_session_from_expand(a)
             if not session:
                 continue
 

--- a/api/services/retention_service.py
+++ b/api/services/retention_service.py
@@ -27,6 +27,8 @@ from api.utils.session_metrics import (
     BUNK_SESSION_TYPES,
     DISPLAY_SESSION_TYPES,
     compute_summer_metrics,
+    get_person_from_expand,
+    get_session_from_expand,
     resolve_duration_sessions,
 )
 
@@ -310,8 +312,7 @@ class RetentionService:
                 continue
 
             # Get session from expand
-            expand = getattr(a, "expand", {}) or {}
-            session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            session = get_session_from_expand(a)
             attendee_session_cm_id = getattr(session, "cm_id", None) if session else None
 
             # Filter by session type if specified
@@ -575,8 +576,7 @@ class RetentionService:
             if pid is None or pid in _aged_out:
                 continue
 
-            expand = getattr(a, "expand", {}) or {}
-            session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            session = get_session_from_expand(a)
             if not session:
                 continue
 
@@ -763,17 +763,15 @@ class RetentionService:
         session_bunk_stats: dict[tuple[str, str], dict[str, int]] = {}
 
         for record in bunk_assignments:
-            expand = getattr(record, "expand", {}) or {}
-
             # Extract person cm_id
-            person_data = expand.get("person") if isinstance(expand, dict) else getattr(expand, "person", None)
+            person_data = get_person_from_expand(record)
             pid = getattr(person_data, "cm_id", None) if person_data else None
             if pid is None or int(pid) not in person_ids:
                 continue
             pid = int(pid)
 
             # Extract session info
-            session_data = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            session_data = get_session_from_expand(record)
             if not session_data:
                 continue
             session_name = getattr(session_data, "name", "") or ""
@@ -792,6 +790,7 @@ class RetentionService:
                         session_name = getattr(parent_session, "name", session_name)
 
             # Extract bunk name
+            expand = getattr(record, "expand", {}) or {}
             bunk_data = expand.get("bunk") if isinstance(expand, dict) else getattr(expand, "bunk", None)
             bunk_name = getattr(bunk_data, "name", "") if bunk_data else ""
 

--- a/api/services/retention_trends_service.py
+++ b/api/services/retention_trends_service.py
@@ -26,6 +26,7 @@ from api.schemas.metrics import (
 from api.utils.session_metrics import (
     compute_summer_metrics,
     filter_attendees_by_session,
+    get_session_from_expand,
     resolve_duration_sessions,
 )
 
@@ -187,8 +188,7 @@ class RetentionTrendsService:
         """
         filtered = []
         for a in attendees:
-            expand = getattr(a, "expand", {}) or {}
-            session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            session = get_session_from_expand(a)
             if session and getattr(session, "session_type", None) in session_types:
                 filtered.append(a)
         return filtered
@@ -209,8 +209,7 @@ class RetentionTrendsService:
         """
         filtered = []
         for a in attendees:
-            expand = getattr(a, "expand", {}) or {}
-            session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            session = get_session_from_expand(a)
             if session and getattr(session, "cm_id", None) == session_cm_id:
                 filtered.append(a)
         return filtered

--- a/api/services/session_availability_service.py
+++ b/api/services/session_availability_service.py
@@ -22,7 +22,7 @@ from api.schemas.session_availability import (
     SessionAvailabilityResponse,
     WaitlistedPerson,
 )
-from api.utils.session_metrics import resolve_duration_sessions
+from api.utils.session_metrics import get_person_from_expand, get_session_from_expand, resolve_duration_sessions
 
 logger = get_logger(__name__)
 
@@ -332,9 +332,8 @@ class SessionAvailabilityService:
         waitlist_grouped: dict[int, dict[str, list[dict[str, Any]]]] = {}
 
         for att in attendees:
-            expand = getattr(att, "expand", {}) or {}
-            person = expand.get("person") if isinstance(expand, dict) else getattr(expand, "person", None)
-            session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            person = get_person_from_expand(att)
+            session = get_session_from_expand(att)
             if not person or not session:
                 continue
 

--- a/api/services/velocity_service.py
+++ b/api/services/velocity_service.py
@@ -31,7 +31,12 @@ from api.services.reconstruction import (
     parse_date_only,
     reconstruct_daily,
 )
-from api.utils.session_metrics import build_ag_parent_map, get_session_from_expand, resolve_duration_sessions
+from api.utils.session_metrics import (
+    build_ag_parent_map,
+    get_person_from_expand,
+    get_session_from_expand,
+    resolve_duration_sessions,
+)
 from api.utils.session_swap import detect_session_swaps
 
 if TYPE_CHECKING:
@@ -1286,8 +1291,7 @@ class VelocityService:
         total_cancellation_count = 0
 
         for att in attendees:
-            expand = getattr(att, "expand", {}) or {}
-            session = expand.get("session") if isinstance(expand, dict) else None
+            session = get_session_from_expand(att)
             if not session:
                 continue
 
@@ -1454,8 +1458,7 @@ class VelocityService:
         )
 
         for att in attendees:
-            expand = getattr(att, "expand", {}) or {}
-            session = expand.get("session") if isinstance(expand, dict) else None
+            session = get_session_from_expand(att)
             if not session:
                 continue
 
@@ -1466,7 +1469,7 @@ class VelocityService:
             raw_sid = int(session.cm_id)
             effective_sid = ag_parent_map.get(raw_sid, raw_sid)
 
-            person = expand.get("person") if isinstance(expand, dict) else None
+            person = get_person_from_expand(att)
             gender = extract_gender(person) if person else "Unknown"
             if gender not in ("M", "F"):
                 continue
@@ -1826,8 +1829,7 @@ class VelocityService:
         total_count = 0
 
         for cancel in cancellations:
-            expand = getattr(cancel, "expand", {}) or {}
-            session = expand.get("session") if isinstance(expand, dict) else None
+            session = get_session_from_expand(cancel)
             if not session:
                 continue
             raw_sid = int(session.cm_id)
@@ -1946,8 +1948,7 @@ class VelocityService:
         session_gender_totals: dict[int, dict[str, int]] = defaultdict(lambda: {"M": 0, "F": 0})
 
         for cancel in cancellations:
-            expand = getattr(cancel, "expand", {}) or {}
-            session = expand.get("session") if isinstance(expand, dict) else None
+            session = get_session_from_expand(cancel)
             if not session:
                 continue
 
@@ -1958,7 +1959,7 @@ class VelocityService:
             if session_cm_id is not None and effective_sid != session_cm_id:
                 continue
 
-            person = expand.get("person") if isinstance(expand, dict) else None
+            person = get_person_from_expand(cancel)
             gender = extract_gender(person) if person else "Unknown"
             if gender not in ("M", "F"):
                 continue

--- a/api/utils/session_metrics.py
+++ b/api/utils/session_metrics.py
@@ -276,8 +276,7 @@ def compute_summer_metrics(
             continue
 
         # Filter to summer session types
-        expand = getattr(record, "expand", {}) or {}
-        session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+        session = get_session_from_expand(record)
         if not session:
             continue
 
@@ -304,8 +303,7 @@ def compute_summer_metrics(
                 continue
 
             # Fall back to session start_date
-            expand = getattr(r, "expand", {}) or {}
-            session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+            session = get_session_from_expand(r)
             if session:
                 start_date = getattr(session, "start_date", None)
                 if start_date:

--- a/bunking/graph/social_graph_builder.py
+++ b/bunking/graph/social_graph_builder.py
@@ -14,6 +14,7 @@ import community as community_louvain
 import networkx as nx
 
 from api.constants.collections import ATTENDEES, BUNK_ASSIGNMENTS, BUNK_REQUESTS, BUNKS, CAMP_SESSIONS, PERSONS
+from api.utils.session_metrics import get_person_from_expand, get_session_from_expand
 from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
@@ -120,8 +121,7 @@ class SocialGraphBuilder:
             )
             # Extract person cm_ids from expanded relation
             for a in assignments:
-                expand = getattr(a, "expand", {}) or {}
-                person_data = expand.get("person") if isinstance(expand, dict) else getattr(expand, "person", None)
+                person_data = get_person_from_expand(a)
                 if person_data and hasattr(person_data, "cm_id"):
                     bunk_members.append(person_data.cm_id)
             logger.info(f"Found {len(bunk_members)} members in bunk {bunk_cm_id} for session {session_cm_id}")
@@ -153,10 +153,7 @@ class SocialGraphBuilder:
                     # Group by session to find which session has assignments
                     session_counts: dict[int, int] = {}
                     for assignment in all_assignments:
-                        expand = getattr(assignment, "expand", {}) or {}
-                        session_data = (
-                            expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
-                        )
+                        session_data = get_session_from_expand(assignment)
                         sess_id = session_data.cm_id if session_data and hasattr(session_data, "cm_id") else None
                         if sess_id:
                             session_counts[sess_id] = session_counts.get(sess_id, 0) + 1
@@ -169,13 +166,8 @@ class SocialGraphBuilder:
 
                         # Get assignments from the best session and extract person cm_ids
                         for a in all_assignments:
-                            expand = getattr(a, "expand", {}) or {}
-                            session_data = (
-                                expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
-                            )
-                            person_data = (
-                                expand.get("person") if isinstance(expand, dict) else getattr(expand, "person", None)
-                            )
+                            session_data = get_session_from_expand(a)
+                            person_data = get_person_from_expand(a)
                             sess_id = session_data.cm_id if session_data and hasattr(session_data, "cm_id") else None
                             if sess_id == best_session[0] and person_data and hasattr(person_data, "cm_id"):
                                 bunk_members.append(person_data.cm_id)
@@ -204,7 +196,7 @@ class SocialGraphBuilder:
                     )
                     # Access expanded data safely
                     expand = getattr(historical, "expand", {}) or {}
-                    session_data = expand.get("session")
+                    session_data = get_session_from_expand(historical)
                     bunk_data = expand.get("bunk")
 
                     # Only include if it's a valid session type

--- a/bunking/sync/bunk_request_processor/data/cache/temporal_name_cache.py
+++ b/bunking/sync/bunk_request_processor/data/cache/temporal_name_cache.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from api.utils.session_metrics import get_person_from_expand, get_session_from_expand
 from bunking.logging_config import get_logger
 
 from ...core.models import Person
@@ -157,9 +158,8 @@ class TemporalNameCache:
 
                 # Get session CM ID from expanded relation or direct field
                 session_cm_id = None
-                expand = getattr(attendee, "expand", None) or {}
-                if expand and "session" in expand:
-                    session_data = expand["session"]
+                session_data = get_session_from_expand(attendee)
+                if session_data:
                     session_cm_id = getattr(session_data, "cm_id", None) or getattr(session_data, "campminder_id", None)
                 if not session_cm_id:
                     session_cm_id = getattr(attendee, "session_cm_id", None)
@@ -212,9 +212,9 @@ class TemporalNameCache:
 
             for assignment in assignments:
                 expand = getattr(assignment, "expand", {}) or {}
-                person_data = expand.get("person")
+                person_data = get_person_from_expand(assignment)
                 bunk_data = expand.get("bunk")
-                session_data = expand.get("session")
+                session_data = get_session_from_expand(assignment)
 
                 if not person_data:
                     continue

--- a/bunking/sync/bunk_request_processor/data/repositories/attendee_repository.py
+++ b/bunking/sync/bunk_request_processor/data/repositories/attendee_repository.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
+from api.utils.session_metrics import get_person_from_expand, get_session_from_expand
 from pocketbase import PocketBase
 
 from ...core.models import Person
@@ -142,11 +143,10 @@ class AttendeeRepository:
 
     def _get_session_cm_id(self, attendee: Any) -> int | None:
         """Extract session CM ID from expanded relation"""
-        if hasattr(attendee, "expand") and attendee.expand:
-            session = attendee.expand.get("session")
-            if session and hasattr(session, "cm_id"):
-                result: int = session.cm_id
-                return result
+        session = get_session_from_expand(attendee)
+        if session and hasattr(session, "cm_id"):
+            result: int = session.cm_id
+            return result
         return None
 
     def get_age_filtered_session_peers(
@@ -254,8 +254,7 @@ class AttendeeRepository:
                     continue
 
                 # Filter by session type — only bunking-relevant sessions
-                expand = getattr(item, "expand", None)
-                session = expand.get("session") if expand else None
+                session = get_session_from_expand(item)
                 session_type = getattr(session, "session_type", None) if session else None
                 if session_type not in VALID_BUNKING_SESSION_TYPES:
                     continue
@@ -353,8 +352,7 @@ class AttendeeRepository:
             # Extract bunkmate CM IDs (excluding requester)
             bunkmate_cm_ids = []
             for assignment in bunkmates:
-                assign_expand = getattr(assignment, "expand", {}) or {}
-                person_data = assign_expand.get("person")
+                person_data = get_person_from_expand(assignment)
                 if person_data:
                     cm_id = getattr(person_data, "cm_id", None)
                     if cm_id and cm_id != requester_cm_id:
@@ -429,11 +427,8 @@ class AttendeeRepository:
             prev_year_count = 0
 
             for attendee in attendees:
-                if not hasattr(attendee, "expand") or not attendee.expand:
-                    continue
-
-                person = attendee.expand.get("person")
-                session = attendee.expand.get("session")
+                person = get_person_from_expand(attendee)
+                session = get_session_from_expand(attendee)
 
                 if not person or not session:
                     continue

--- a/bunking/sync/bunk_request_processor/data/repositories/person_repository.py
+++ b/bunking/sync/bunk_request_processor/data/repositories/person_repository.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING, Any
 
+from api.utils.session_metrics import get_session_from_expand
 from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
@@ -257,9 +258,9 @@ class PersonRepository(Repository):
             person_cm_ids = []
             for a in attendees:
                 # Get session CM ID from expanded relation
-                if hasattr(a, "expand") and a.expand:
-                    session = a.expand.get("session")
-                    if session and session.cm_id == session_cm_id:
+                session = get_session_from_expand(a)
+                if session:
+                    if session.cm_id == session_cm_id:
                         # person_id is a direct field with CM ID
                         if hasattr(a, "person_id") and a.person_id:
                             person_cm_ids.append(a.person_id)

--- a/bunking/sync/bunk_request_processor/integration/original_requests_loader.py
+++ b/bunking/sync/bunk_request_processor/integration/original_requests_loader.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from api.utils.session_metrics import get_person_from_expand, get_session_from_expand
 from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
@@ -145,11 +146,8 @@ class OriginalRequestsLoader:
             prev_year_count = 0
 
             for attendee in attendees:
-                if not hasattr(attendee, "expand") or not attendee.expand:
-                    continue
-
-                person = attendee.expand.get("person")
-                session = attendee.expand.get("session")
+                person = get_person_from_expand(attendee)
+                session = get_session_from_expand(attendee)
                 attendee_year = attendee.year  # type: ignore[attr-defined]
 
                 if person:

--- a/bunking/sync/bunk_request_processor/social/social_graph.py
+++ b/bunking/sync/bunk_request_processor/social/social_graph.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import networkx as nx
 
+from api.utils.session_metrics import get_person_from_expand, get_session_from_expand
 from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
@@ -186,14 +187,12 @@ class SocialGraph:
 
             for attendee in attendees:
                 # Filter by session CM ID (check expanded session)
-                if not hasattr(attendee, "expand") or not attendee.expand:
-                    continue
-                session = attendee.expand.get("session")
+                session = get_session_from_expand(attendee)
                 if not session or session.cm_id != session_cm_id:
                     continue
 
                 # Get person CM ID from expanded person
-                person = attendee.expand.get("person")
+                person = get_person_from_expand(attendee)
                 if not person:
                     continue
                 person_cm_id = person.cm_id
@@ -290,7 +289,7 @@ class SocialGraph:
             year_bunk_members: dict[tuple[int, str], set[int]] = {}
             for assignment in all_assignments:
                 expand = getattr(assignment, "expand", {}) or {}
-                person_data = expand.get("person")
+                person_data = get_person_from_expand(assignment)
                 bunk_data = expand.get("bunk")
 
                 if not person_data or not bunk_data:


### PR DESCRIPTION
## Summary
- Replace all hand-rolled `expand.get("session")` and `expand.get("person")` patterns with the shared `get_session_from_expand` / `get_person_from_expand` utilities from `api/utils/session_metrics.py`
- 23 files changed across `api/` and `bunking/` — purely mechanical cleanup, no behavior change
- Net reduction of 69 lines of boilerplate

Closes #625

## Test plan
- [x] All existing tests pass (3186 passed, 0 new failures)
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy clean (0 issues in 234 source files)

### Patterns NOT replaced (intentionally left as-is)
- **Write patterns**: `expand["person"] = ...` (constructing expand dicts, not reading)
- **Bunk extraction**: `expand.get("bunk")` — no shared utility exists for bunk
- **Test files**: Mock setup code that constructs expand dicts
- **metrics_sql_repository.py**: Constructs `SimpleNamespace` objects with expand dicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized extraction of person and session data from database expand payloads across multiple services and repositories using shared helper functions, reducing code duplication and improving maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->