### PR TITLE
refactor(frontend): use centralized queryKeys in useSyncStatusAPI

### DIFF
--- a/frontend/src/hooks/useCamperDietarySync.ts
+++ b/frontend/src/hooks/useCamperDietarySync.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { pb } from '../lib/pocketbase'
+import { queryKeys } from '../utils/queryKeys'
 import toast from 'react-hot-toast'
 
 /**
@@ -28,7 +29,7 @@ export function useCamperDietarySync() {
         })
       }
       // Invalidate sync status to show it's running
-      void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() })
     },
     onError: (error) => {
       let errorMessage = error instanceof Error ? error.message : 'Unknown error'

--- a/frontend/src/hooks/useCamperHistorySync.ts
+++ b/frontend/src/hooks/useCamperHistorySync.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { pb } from '../lib/pocketbase'
+import { queryKeys } from '../utils/queryKeys'
 import toast from 'react-hot-toast'
 
 /**
@@ -28,7 +29,7 @@ export function useCamperHistorySync() {
         })
       }
       // Invalidate sync status to show it's running
-      void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() })
     },
     onError: (error) => {
       let errorMessage = error instanceof Error ? error.message : 'Unknown error'

--- a/frontend/src/hooks/useCamperTransportationSync.ts
+++ b/frontend/src/hooks/useCamperTransportationSync.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { pb } from '../lib/pocketbase'
+import { queryKeys } from '../utils/queryKeys'
 import toast from 'react-hot-toast'
 
 /**
@@ -28,7 +29,7 @@ export function useCamperTransportationSync() {
         })
       }
       // Invalidate sync status to show it's running
-      void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() })
     },
     onError: (error) => {
       let errorMessage = error instanceof Error ? error.message : 'Unknown error'

--- a/frontend/src/hooks/useCancelQueuedSync.ts
+++ b/frontend/src/hooks/useCancelQueuedSync.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { pb } from '../lib/pocketbase'
+import { queryKeys } from '../utils/queryKeys'
 import toast from 'react-hot-toast'
 
 /**
@@ -15,7 +16,7 @@ export function useCancelQueuedSync() {
       })
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() })
       toast.success('Queued sync canceled', { duration: 3000 })
     },
     onError: (error) => {

--- a/frontend/src/hooks/useCancelRunningSync.ts
+++ b/frontend/src/hooks/useCancelRunningSync.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { pb } from '../lib/pocketbase'
+import { queryKeys } from '../utils/queryKeys'
 import toast from 'react-hot-toast'
 
 /**
@@ -13,7 +14,7 @@ export function useCancelRunningSync() {
       return await pb.send('/api/custom/sync/running', { method: 'DELETE' })
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() })
       toast.success('Sync canceled', { duration: 3000 })
     },
     onError: (error) => {

--- a/frontend/src/hooks/useFamilyCampDerivedSync.ts
+++ b/frontend/src/hooks/useFamilyCampDerivedSync.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { pb } from '../lib/pocketbase'
+import { queryKeys } from '../utils/queryKeys'
 import toast from 'react-hot-toast'
 
 /**
@@ -28,7 +29,7 @@ export function useFamilyCampDerivedSync() {
         })
       }
       // Invalidate sync status to show it's running
-      void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() })
     },
     onError: (error) => {
       let errorMessage = error instanceof Error ? error.message : 'Unknown error'

--- a/frontend/src/hooks/useFinancialAidApplicationsSync.ts
+++ b/frontend/src/hooks/useFinancialAidApplicationsSync.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { pb } from '../lib/pocketbase'
+import { queryKeys } from '../utils/queryKeys'
 import toast from 'react-hot-toast'
 
 /**
@@ -28,7 +29,7 @@ export function useFinancialAidApplicationsSync() {
         })
       }
       // Invalidate sync status to show it's running
-      void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() })
     },
     onError: (error) => {
       let errorMessage = error instanceof Error ? error.message : 'Unknown error'

--- a/frontend/src/hooks/useHouseholdDemographicsSync.ts
+++ b/frontend/src/hooks/useHouseholdDemographicsSync.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { pb } from '../lib/pocketbase'
+import { queryKeys } from '../utils/queryKeys'
 import toast from 'react-hot-toast'
 
 /**
@@ -28,7 +29,7 @@ export function useHouseholdDemographicsSync() {
         })
       }
       // Invalidate sync status to show it's running
-      void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() })
     },
     onError: (error) => {
       let errorMessage = error instanceof Error ? error.message : 'Unknown error'

--- a/frontend/src/hooks/useProcessRequests.ts
+++ b/frontend/src/hooks/useProcessRequests.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { pb } from '../lib/pocketbase'
+import { queryKeys } from '../utils/queryKeys'
 import toast from 'react-hot-toast'
 import type { ProcessRequestOptionsState } from '../components/admin/ProcessRequestOptions'
 
@@ -123,7 +124,7 @@ export function useProcessRequests() {
       })
 
       // Invalidate sync status to show it's running
-      void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() })
     },
     onError: (error) => {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error'

--- a/frontend/src/hooks/useQuestRegistrationsSync.ts
+++ b/frontend/src/hooks/useQuestRegistrationsSync.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { pb } from '../lib/pocketbase'
+import { queryKeys } from '../utils/queryKeys'
 import toast from 'react-hot-toast'
 
 /**
@@ -28,7 +29,7 @@ export function useQuestRegistrationsSync() {
         })
       }
       // Invalidate sync status to show it's running
-      void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() })
     },
     onError: (error) => {
       let errorMessage = error instanceof Error ? error.message : 'Unknown error'

--- a/frontend/src/hooks/useRunIndividualSync.ts
+++ b/frontend/src/hooks/useRunIndividualSync.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { pb } from '../lib/pocketbase'
+import { queryKeys } from '../utils/queryKeys'
 import toast from 'react-hot-toast'
 
 // Map of sync types to their display names
@@ -138,7 +139,7 @@ export function useRunIndividualSync() {
       }
 
       // Invalidate sync status to show it's running
-      void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() })
     },
     onError: (error, syncType) => {
       const displayName = SYNC_TYPE_NAMES[syncType] ?? syncType

--- a/frontend/src/hooks/useRunOnDemandSync.ts
+++ b/frontend/src/hooks/useRunOnDemandSync.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { pb } from '../lib/pocketbase'
+import { queryKeys } from '../utils/queryKeys'
 import toast from 'react-hot-toast'
 import { SYNC_TYPE_NAMES } from './useRunIndividualSync'
 
@@ -60,7 +61,7 @@ export function useRunOnDemandSync() {
       }
 
       // Invalidate sync status to show it's running
-      void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() })
     },
     onError: (error, { syncType }) => {
       const displayName = SYNC_TYPE_NAMES[syncType] ?? syncType

--- a/frontend/src/hooks/useRunPhaseSync.ts
+++ b/frontend/src/hooks/useRunPhaseSync.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { pb } from '../lib/pocketbase'
+import { queryKeys } from '../utils/queryKeys'
 import toast from 'react-hot-toast'
 import type { SyncPhase } from '../components/admin/syncTypes'
 
@@ -58,7 +59,7 @@ export function useRunPhaseSync() {
       })
     },
     onSuccess: (data, variables) => {
-      void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() })
 
       const phaseName = PHASE_NAMES[variables.phase]
       const jobCount = data.jobs?.length ?? 0
@@ -76,7 +77,10 @@ export function useRunPhaseSync() {
       }
 
       // Invalidate again after a delay for quick syncs
-      setTimeout(() => void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] }), 2000)
+      setTimeout(
+        () => void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() }),
+        2000
+      )
     },
     onError: (error, variables) => {
       const phaseName = PHASE_NAMES[variables.phase]

--- a/frontend/src/hooks/useSheetsWorkbooks.ts
+++ b/frontend/src/hooks/useSheetsWorkbooks.ts
@@ -4,6 +4,7 @@
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { pb } from '../lib/pocketbase'
+import { queryKeys } from '../utils/queryKeys'
 import toast from 'react-hot-toast'
 
 /**
@@ -86,7 +87,7 @@ export function useMultiWorkbookExport() {
       }
       // Invalidate workbooks to show status change
       void queryClient.invalidateQueries({ queryKey: ['sheets-workbooks'] })
-      void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() })
     },
     onError: (error) => {
       let errorMessage = error instanceof Error ? error.message : 'Unknown error'

--- a/frontend/src/hooks/useStaffApplicationsSync.ts
+++ b/frontend/src/hooks/useStaffApplicationsSync.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { pb } from '../lib/pocketbase'
+import { queryKeys } from '../utils/queryKeys'
 import toast from 'react-hot-toast'
 
 /**
@@ -28,7 +29,7 @@ export function useStaffApplicationsSync() {
         })
       }
       // Invalidate sync status to show it's running
-      void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() })
     },
     onError: (error) => {
       let errorMessage = error instanceof Error ? error.message : 'Unknown error'

--- a/frontend/src/hooks/useStaffSkillsSync.ts
+++ b/frontend/src/hooks/useStaffSkillsSync.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { pb } from '../lib/pocketbase'
+import { queryKeys } from '../utils/queryKeys'
 import toast from 'react-hot-toast'
 
 /**
@@ -28,7 +29,7 @@ export function useStaffSkillsSync() {
         })
       }
       // Invalidate sync status to show it's running
-      void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() })
     },
     onError: (error) => {
       let errorMessage = error instanceof Error ? error.message : 'Unknown error'

--- a/frontend/src/hooks/useStaffVehicleInfoSync.ts
+++ b/frontend/src/hooks/useStaffVehicleInfoSync.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { pb } from '../lib/pocketbase'
+import { queryKeys } from '../utils/queryKeys'
 import toast from 'react-hot-toast'
 
 /**
@@ -28,7 +29,7 @@ export function useStaffVehicleInfoSync() {
         })
       }
       // Invalidate sync status to show it's running
-      void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() })
     },
     onError: (error) => {
       let errorMessage = error instanceof Error ? error.message : 'Unknown error'

--- a/frontend/src/hooks/useSyncStatusAPI.test.ts
+++ b/frontend/src/hooks/useSyncStatusAPI.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Tests for useSyncStatusAPI - verifies centralized queryKeys usage
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('useSyncStatusAPI', () => {
+  const sourceCode = readFileSync(resolve(__dirname, 'useSyncStatusAPI.ts'), 'utf-8')
+
+  it('should import queryKeys from centralized utils', () => {
+    expect(sourceCode).toMatch(/import.*queryKeys.*from.*['"]\.\.\/utils\/queryKeys['"]/)
+  })
+
+  it('should NOT use hardcoded sync-status-api query key', () => {
+    expect(sourceCode).not.toContain("'sync-status-api'")
+    expect(sourceCode).not.toContain('"sync-status-api"')
+  })
+
+  it('should use queryKeys.syncStatus() for the query key', () => {
+    expect(sourceCode).toContain('queryKeys.syncStatus()')
+  })
+})

--- a/frontend/src/hooks/useSyncStatusAPI.ts
+++ b/frontend/src/hooks/useSyncStatusAPI.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useAuth } from '../contexts/AuthContext'
 import { pb } from '../lib/pocketbase'
+import { queryKeys } from '../utils/queryKeys'
 
 // Sub-entity stats for combined syncs (e.g., persons includes households)
 export interface SubStats {
@@ -102,7 +103,7 @@ export function useSyncStatusAPI() {
   const { isLoading } = useAuth()
 
   return useQuery({
-    queryKey: ['sync-status-api'],
+    queryKey: queryKeys.syncStatus(),
     queryFn: async (): Promise<SyncStatusResponse> => {
       const response = await pb.send('/api/custom/sync/status', {
         method: 'GET',

--- a/frontend/src/hooks/useUnifiedSync.ts
+++ b/frontend/src/hooks/useUnifiedSync.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { pb } from '../lib/pocketbase'
+import { queryKeys } from '../utils/queryKeys'
 import toast from 'react-hot-toast'
 
 interface UnifiedSyncParams {
@@ -51,7 +52,7 @@ export function useUnifiedSync() {
       })
     },
     onSuccess: (data, variables) => {
-      void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() })
 
       // Check if sync was queued (202 response)
       if (data.status === 'queued') {
@@ -63,7 +64,10 @@ export function useUnifiedSync() {
       }
 
       // Also invalidate after delay for quick syncs
-      setTimeout(() => void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] }), 2000)
+      setTimeout(
+        () => void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() }),
+        2000
+      )
     },
     onError: (error, variables) => {
       const serviceDisplay = variables.service === 'all' ? 'all services' : variables.service

--- a/frontend/src/utils/queryClient.ts
+++ b/frontend/src/utils/queryClient.ts
@@ -93,7 +93,6 @@ export const invalidateSyncData = () => {
   // Metrics (depends on synced data)
   void queryClient.invalidateQueries({ queryKey: ['metrics'] })
 
-  // Sync status
+  // Sync status (prefix match covers both syncStatus and syncStatusForService)
   void queryClient.invalidateQueries({ queryKey: ['sync-status'] })
-  void queryClient.invalidateQueries({ queryKey: ['sync-status-api'] })
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded `['sync-status-api']` query key with `queryKeys.syncStatus()` from centralized registry in `useSyncStatusAPI.ts` and all 18 sync-related hooks that invalidate it
- Remove duplicate `['sync-status-api']` invalidation line in `queryClient.ts` (now unified under `['sync-status']` prefix)
- Add test verifying the hook uses the centralized query key

Closes #687

## Test plan
- [x] New test `useSyncStatusAPI.test.ts` verifies centralized import and key usage
- [x] All 280 hooks tests pass
- [x] All 2386 frontend tests pass (2 pre-existing timeout failures unrelated)
- [x] ESLint and Prettier checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized sync status cache management across all synchronization operations (dietary data, transportation, staff applications, financial aid, and more) to use a centralized query key generator, ensuring consistent cache invalidation behavior throughout the application.

* **Tests**
  * Added validation tests to verify proper implementation of the centralized sync status cache key system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->