### PR TITLE
refactor(sync): standardize on compareFields for idempotency checks

### DIFF
--- a/pocketbase/sync/base_sync.go
+++ b/pocketbase/sync/base_sync.go
@@ -745,6 +745,68 @@ func (b *BaseSyncService) getRecordName(record *core.Record, entityType string) 
 	return fmt.Sprintf("ID: %s", record.Id)
 }
 
+// compareFieldEquals compares two field values for equality, handling type conversions.
+// This is the shared implementation used by derived-table sync services (camper_dietary,
+// camper_history, staff_skills) for their compareFields-based idempotency checks.
+func compareFieldEquals(existing, newVal any) bool {
+	// Handle nil vs empty string
+	if (existing == nil && newVal == "") || (existing == "" && newVal == nil) {
+		return true
+	}
+	// Handle nil vs false (for boolean fields)
+	if existing == nil && newVal == false {
+		return true
+	}
+	if existing == false && newVal == nil {
+		return true
+	}
+	// Handle nil vs 0
+	if existing == nil && newVal == 0 {
+		return true
+	}
+	if existing == 0 && newVal == nil {
+		return true
+	}
+	// Handle float64 vs int (JSON unmarshals numbers as float64)
+	if existFloat, ok := existing.(float64); ok {
+		if newInt, ok := newVal.(int); ok {
+			return int(existFloat) == newInt
+		}
+		if newFloat, ok := newVal.(float64); ok {
+			return existFloat == newFloat
+		}
+	}
+	if existInt, ok := existing.(int); ok {
+		if newFloat, ok := newVal.(float64); ok {
+			return existInt == int(newFloat)
+		}
+	}
+	// Handle bool comparison
+	if existBool, ok := existing.(bool); ok {
+		if newBool, ok := newVal.(bool); ok {
+			return existBool == newBool
+		}
+	}
+
+	// String comparison as fallback
+	return fmt.Sprintf("%v", existing) == fmt.Sprintf("%v", newVal)
+}
+
+// compareRecordNeedsUpdate checks if any compared field differs between an existing
+// record and new data. Uses compareFields (inclusion list): only the listed fields
+// are checked for changes. This is the shared implementation used by derived-table
+// sync services.
+func compareRecordNeedsUpdate(existing *core.Record, newData map[string]any, compareFields []string) bool {
+	for _, field := range compareFields {
+		if value, exists := newData[field]; exists {
+			if !compareFieldEquals(existing.Get(field), value) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // CompositeKey creates a year-scoped key for record lookups
 // This ensures year isolation by making the year part of the record's identity
 func CompositeKey(id interface{}, year int) string {

--- a/pocketbase/sync/camper_dietary.go
+++ b/pocketbase/sync/camper_dietary.go
@@ -433,60 +433,11 @@ func makeCamperDietaryKey(personID, year int) string {
 	return fmt.Sprintf("%d|%d", personID, year)
 }
 
-// fieldEquals compares two field values for equality, handling type conversions.
-// This mirrors the centralized BaseSyncService.FieldEquals logic.
-func (s *CamperDietarySync) fieldEquals(existing, newVal any) bool {
-	// Handle nil vs empty string
-	if (existing == nil && newVal == "") || (existing == "" && newVal == nil) {
-		return true
-	}
-	// Handle nil vs false (for boolean fields)
-	if existing == nil && newVal == false {
-		return true
-	}
-	if existing == false && newVal == nil {
-		return true
-	}
-	// Handle nil vs 0
-	if existing == nil && newVal == 0 {
-		return true
-	}
-	if existing == 0 && newVal == nil {
-		return true
-	}
-	// Handle float64 vs int (JSON unmarshals numbers as float64)
-	if existFloat, ok := existing.(float64); ok {
-		if newInt, ok := newVal.(int); ok {
-			return int(existFloat) == newInt
-		}
-	}
-	if existInt, ok := existing.(int); ok {
-		if newFloat, ok := newVal.(float64); ok {
-			return existInt == int(newFloat)
-		}
-	}
-	// Handle bool comparison (PocketBase may return bool, we may pass bool)
-	if existBool, ok := existing.(bool); ok {
-		if newBool, ok := newVal.(bool); ok {
-			return existBool == newBool
-		}
-	}
-
-	// String comparison as fallback
-	return fmt.Sprintf("%v", existing) == fmt.Sprintf("%v", newVal)
-}
-
 // recordNeedsUpdate checks if any compared field differs between existing record and new data.
 // Uses compareFields (inclusion list): only the listed fields are checked for changes.
-func (s *CamperDietarySync) recordNeedsUpdate(record *core.Record, data map[string]any) bool {
-	for _, field := range camperDietaryCompareFields {
-		if value, exists := data[field]; exists {
-			if !s.fieldEquals(record.Get(field), value) {
-				return true
-			}
-		}
-	}
-	return false
+// Delegates to the shared compareRecordNeedsUpdate in base_sync.go.
+func (s *CamperDietarySync) recordNeedsUpdate(record *core.Record, data map[string]any, compareFields []string) bool {
+	return compareRecordNeedsUpdate(record, data, compareFields)
 }
 
 // loadExistingRecords loads existing camper_dietary records for a year
@@ -569,7 +520,7 @@ func (s *CamperDietarySync) upsertRecords(
 			}
 
 			// Check if update is actually needed
-			if !s.recordNeedsUpdate(record, data) {
+			if !s.recordNeedsUpdate(record, data, camperDietaryCompareFields) {
 				s.DebugLog("Skipping unchanged dietary record", "person_id", rec.personID, "year", year)
 				skipped++
 				continue

--- a/pocketbase/sync/camper_dietary_test.go
+++ b/pocketbase/sync/camper_dietary_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
 )
 
 // TestCamperDietarySync_Name verifies the service name is correct
@@ -376,39 +378,72 @@ func TestCamperDietaryCompareFields(t *testing.T) {
 }
 
 // TestCamperDietaryRecordNeedsUpdateUsesCompareFields verifies that recordNeedsUpdate
-// uses the compareFields (inclusion list) pattern, not skipFields (exclusion list).
+// correctly detects when fields match (no update) and when they differ (needs update).
 func TestCamperDietaryRecordNeedsUpdateUsesCompareFields(t *testing.T) {
 	s := &CamperDietarySync{}
 
-	// Build test data
-	newData := map[string]any{
-		"attendee":            "abc123",
-		"person_id":           12345,
-		"year":                2025,
-		"has_dietary_needs":   true,
-		"dietary_explanation": "Vegetarian",
-		"has_allergies":       false,
-		"allergy_info":        "",
-		"additional_medical":  "",
-	}
+	// Create a minimal collection with the fields used in comparison
+	col := core.NewBaseCollection("test_camper_dietary")
+	col.Fields.Add(&core.TextField{Name: "attendee"})
+	col.Fields.Add(&core.NumberField{Name: "person_id"})
+	col.Fields.Add(&core.NumberField{Name: "year"})
+	col.Fields.Add(&core.BoolField{Name: "has_dietary_needs"})
+	col.Fields.Add(&core.TextField{Name: "dietary_explanation"})
+	col.Fields.Add(&core.BoolField{Name: "has_allergies"})
+	col.Fields.Add(&core.TextField{Name: "allergy_info"})
+	col.Fields.Add(&core.TextField{Name: "additional_medical"})
 
-	// mockGet simulates an existing record where all compareFields match
-	mockGet := func(field string) any {
-		return newData[field]
-	}
+	t.Run("no update when all fields match", func(t *testing.T) {
+		existing := core.NewRecord(col)
+		existing.Set("attendee", "abc123")
+		existing.Set("person_id", 12345)
+		existing.Set("year", 2025)
+		existing.Set("has_dietary_needs", true)
+		existing.Set("dietary_explanation", "Vegetarian")
+		existing.Set("has_allergies", false)
+		existing.Set("allergy_info", "")
+		existing.Set("additional_medical", "")
 
-	// Verify: when all compareFields match, no update needed
-	needsUpdate := false
-	for _, field := range camperDietaryCompareFields {
-		if value, exists := newData[field]; exists {
-			if !s.fieldEquals(mockGet(field), value) {
-				needsUpdate = true
-				break
-			}
+		newData := map[string]any{
+			"attendee":            "abc123",
+			"person_id":           12345,
+			"year":                2025,
+			"has_dietary_needs":   true,
+			"dietary_explanation": "Vegetarian",
+			"has_allergies":       false,
+			"allergy_info":        "",
+			"additional_medical":  "",
 		}
-	}
 
-	if needsUpdate {
-		t.Error("expected no update needed when all compareFields match")
-	}
+		if s.recordNeedsUpdate(existing, newData, camperDietaryCompareFields) {
+			t.Error("expected no update needed when all compareFields match")
+		}
+	})
+
+	t.Run("needs update when a compare field differs", func(t *testing.T) {
+		existing := core.NewRecord(col)
+		existing.Set("attendee", "abc123")
+		existing.Set("person_id", 12345)
+		existing.Set("year", 2025)
+		existing.Set("has_dietary_needs", true)
+		existing.Set("dietary_explanation", "Vegetarian")
+		existing.Set("has_allergies", false)
+		existing.Set("allergy_info", "")
+		existing.Set("additional_medical", "")
+
+		newData := map[string]any{
+			"attendee":            "abc123",
+			"person_id":           12345,
+			"year":                2025,
+			"has_dietary_needs":   true,
+			"dietary_explanation": "Vegan",
+			"has_allergies":       false,
+			"allergy_info":        "",
+			"additional_medical":  "",
+		}
+
+		if !s.recordNeedsUpdate(existing, newData, camperDietaryCompareFields) {
+			t.Error("expected update needed when dietary_explanation differs")
+		}
+	})
 }

--- a/pocketbase/sync/camper_history.go
+++ b/pocketbase/sync/camper_history.go
@@ -1116,55 +1116,13 @@ func (c *CamperHistorySync) preloadExistingRecords(year int) (map[string]*core.R
 }
 
 // fieldEquals compares two values for equality, handling type conversions
-func (c *CamperHistorySync) fieldEquals(existing, newVal interface{}) bool {
-	// Handle nil vs empty string
-	if (existing == nil && newVal == "") || (existing == "" && newVal == nil) {
-		return true
-	}
-	// Handle nil vs 0
-	if existing == nil && newVal == 0 {
-		return true
-	}
-	if existing == 0 && newVal == nil {
-		return true
-	}
-	// Handle float64 vs int
-	if existingFloat, ok := existing.(float64); ok {
-		if newInt, ok := newVal.(int); ok {
-			return int(existingFloat) == newInt
-		}
-		if newFloat, ok := newVal.(float64); ok {
-			return existingFloat == newFloat
-		}
-	}
-	if existingInt, ok := existing.(int); ok {
-		if newFloat, ok := newVal.(float64); ok {
-			return existingInt == int(newFloat)
-		}
-	}
-	// Handle bool
-	if existingBool, ok := existing.(bool); ok {
-		if newBool, ok := newVal.(bool); ok {
-			return existingBool == newBool
-		}
-	}
-	// Direct comparison
-	return existing == newVal
-}
-
 // recordNeedsUpdate checks if any compared field differs between existing record and new data.
 // Uses compareFields (inclusion list): only the listed fields are checked for changes.
+// Delegates to the shared compareRecordNeedsUpdate in base_sync.go.
 func (c *CamperHistorySync) recordNeedsUpdate(
 	existing *core.Record, newData map[string]interface{}, compareFields []string,
 ) bool {
-	for _, field := range compareFields {
-		if value, exists := newData[field]; exists {
-			if !c.fieldEquals(existing.Get(field), value) {
-				return true
-			}
-		}
-	}
-	return false
+	return compareRecordNeedsUpdate(existing, newData, compareFields)
 }
 
 // deleteOrphans removes records that weren't processed (campers unenrolled from sessions)

--- a/pocketbase/sync/camper_history_test.go
+++ b/pocketbase/sync/camper_history_test.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
 )
 
 // Test constants for fictional data
@@ -2376,43 +2378,142 @@ func TestCamperHistoryCompareFields(t *testing.T) {
 }
 
 // TestCamperHistoryRecordNeedsUpdateUsesCompareFields verifies that recordNeedsUpdate
-// uses the compareFields (inclusion list) pattern, not skipFields (exclusion list).
+// correctly detects when fields match (no update) and when they differ (needs update).
 func TestCamperHistoryRecordNeedsUpdateUsesCompareFields(t *testing.T) {
 	c := &CamperHistorySync{}
 
-	// Build test data
-	newData := map[string]interface{}{
-		"person_id":           1001,
-		"session_cm_id":       100,
-		"year":                2025,
-		"session_name":        "Session 1",
-		"first_name":          testFirstName,
-		"last_name":           "Garcia",
-		"school":              "Riverside Elementary",
-		"city":                "Portland",
-		"state":               "OR",
-		"is_returning_summer": true,
-		"is_returning_family": false,
-		"years_at_camp":       3,
-	}
+	// Create a minimal collection with the fields used in comparison
+	col := core.NewBaseCollection("test_camper_history")
+	col.Fields.Add(&core.TextField{Name: "session_name"})
+	col.Fields.Add(&core.TextField{Name: "first_name"})
+	col.Fields.Add(&core.TextField{Name: "last_name"})
+	col.Fields.Add(&core.TextField{Name: "school"})
+	col.Fields.Add(&core.TextField{Name: "city"})
+	col.Fields.Add(&core.TextField{Name: "state"})
+	col.Fields.Add(&core.BoolField{Name: "is_returning_summer"})
+	col.Fields.Add(&core.BoolField{Name: "is_returning_family"})
+	col.Fields.Add(&core.NumberField{Name: "years_at_camp"})
+	col.Fields.Add(&core.TextField{Name: "person"})
+	col.Fields.Add(&core.TextField{Name: "session"})
+	col.Fields.Add(&core.TextField{Name: "session_type"})
+	col.Fields.Add(&core.TextField{Name: "gender"})
+	col.Fields.Add(&core.NumberField{Name: "grade"})
+	col.Fields.Add(&core.NumberField{Name: "age"})
+	col.Fields.Add(&core.NumberField{Name: "household_id"})
+	col.Fields.Add(&core.TextField{Name: "division_name"})
+	col.Fields.Add(&core.TextField{Name: "status"})
+	col.Fields.Add(&core.TextField{Name: "enrollment_date"})
+	col.Fields.Add(&core.TextField{Name: "bunk_name"})
+	col.Fields.Add(&core.NumberField{Name: "bunk_cm_id"})
+	col.Fields.Add(&core.TextField{Name: "synagogue"})
 
-	// mockGet simulates an existing record where all compareFields match
-	mockGet := func(field string) interface{} {
-		return newData[field]
-	}
+	t.Run("no update when all fields match", func(t *testing.T) {
+		existing := core.NewRecord(col)
+		existing.Set("session_name", "Session 1")
+		existing.Set("first_name", testFirstName)
+		existing.Set("last_name", "Garcia")
+		existing.Set("school", "Riverside Elementary")
+		existing.Set("city", "Portland")
+		existing.Set("state", "OR")
+		existing.Set("is_returning_summer", true)
+		existing.Set("is_returning_family", false)
+		existing.Set("years_at_camp", 3)
+		existing.Set("person", "pb_person1")
+		existing.Set("session", "pb_session1")
+		existing.Set("session_type", "main")
+		existing.Set("gender", "M")
+		existing.Set("grade", 5)
+		existing.Set("age", 11)
+		existing.Set("household_id", 5001)
+		existing.Set("division_name", "Division A")
+		existing.Set("status", "enrolled")
+		existing.Set("enrollment_date", "2025-01-15")
+		existing.Set("bunk_name", "Cabin 7")
+		existing.Set("bunk_cm_id", 200)
+		existing.Set("synagogue", testSynagogue)
 
-	// Verify: when all compareFields match, no update needed
-	needsUpdate := false
-	for _, field := range camperHistoryCompareFields {
-		if value, exists := newData[field]; exists {
-			if !c.fieldEquals(mockGet(field), value) {
-				needsUpdate = true
-				break
-			}
+		newData := map[string]interface{}{
+			"session_name":        "Session 1",
+			"first_name":          testFirstName,
+			"last_name":           "Garcia",
+			"school":              "Riverside Elementary",
+			"city":                "Portland",
+			"state":               "OR",
+			"is_returning_summer": true,
+			"is_returning_family": false,
+			"years_at_camp":       3,
+			"person":              "pb_person1",
+			"session":             "pb_session1",
+			"session_type":        "main",
+			"gender":              "M",
+			"grade":               5,
+			"age":                 11,
+			"household_id":        5001,
+			"division_name":       "Division A",
+			"status":              "enrolled",
+			"enrollment_date":     "2025-01-15",
+			"bunk_name":           "Cabin 7",
+			"bunk_cm_id":          200,
+			"synagogue":           testSynagogue,
 		}
-	}
 
-	if needsUpdate {
-		t.Error("expected no update needed when all compareFields match")
-	}
+		if c.recordNeedsUpdate(existing, newData, camperHistoryCompareFields) {
+			t.Error("expected no update needed when all compareFields match")
+		}
+	})
+
+	t.Run("needs update when a compare field differs", func(t *testing.T) {
+		existing := core.NewRecord(col)
+		existing.Set("session_name", "Session 1")
+		existing.Set("first_name", testFirstName)
+		existing.Set("last_name", "Garcia")
+		existing.Set("school", "Riverside Elementary")
+		existing.Set("city", "Portland")
+		existing.Set("state", "OR")
+		existing.Set("is_returning_summer", true)
+		existing.Set("is_returning_family", false)
+		existing.Set("years_at_camp", 3)
+		existing.Set("person", "pb_person1")
+		existing.Set("session", "pb_session1")
+		existing.Set("session_type", "main")
+		existing.Set("gender", "M")
+		existing.Set("grade", 5)
+		existing.Set("age", 11)
+		existing.Set("household_id", 5001)
+		existing.Set("division_name", "Division A")
+		existing.Set("status", "enrolled")
+		existing.Set("enrollment_date", "2025-01-15")
+		existing.Set("bunk_name", "Cabin 7")
+		existing.Set("bunk_cm_id", 200)
+		existing.Set("synagogue", testSynagogue)
+
+		newData := map[string]interface{}{
+			"session_name":        "Session 1",
+			"first_name":          testFirstName,
+			"last_name":           "Garcia",
+			"school":              "Oak Valley Middle",
+			"city":                "Portland",
+			"state":               "OR",
+			"is_returning_summer": true,
+			"is_returning_family": false,
+			"years_at_camp":       3,
+			"person":              "pb_person1",
+			"session":             "pb_session1",
+			"session_type":        "main",
+			"gender":              "M",
+			"grade":               5,
+			"age":                 11,
+			"household_id":        5001,
+			"division_name":       "Division A",
+			"status":              "enrolled",
+			"enrollment_date":     "2025-01-15",
+			"bunk_name":           "Cabin 7",
+			"bunk_cm_id":          200,
+			"synagogue":           testSynagogue,
+		}
+
+		if !c.recordNeedsUpdate(existing, newData, camperHistoryCompareFields) {
+			t.Error("expected update needed when school differs")
+		}
+	})
 }

--- a/pocketbase/sync/staff_skills.go
+++ b/pocketbase/sync/staff_skills.go
@@ -629,51 +629,13 @@ func (s *StaffSkillsSync) preloadExistingRecords(year int) (map[string]*core.Rec
 	return result, nil
 }
 
-// fieldEquals compares two values for equality
-func (s *StaffSkillsSync) fieldEquals(existing, newVal interface{}) bool {
-	if (existing == nil && newVal == "") || (existing == "" && newVal == nil) {
-		return true
-	}
-	if existing == nil && newVal == 0 {
-		return true
-	}
-	if existing == 0 && newVal == nil {
-		return true
-	}
-	if existingFloat, ok := existing.(float64); ok {
-		if newInt, ok := newVal.(int); ok {
-			return int(existingFloat) == newInt
-		}
-		if newFloat, ok := newVal.(float64); ok {
-			return existingFloat == newFloat
-		}
-	}
-	if existingInt, ok := existing.(int); ok {
-		if newFloat, ok := newVal.(float64); ok {
-			return existingInt == int(newFloat)
-		}
-	}
-	if existingBool, ok := existing.(bool); ok {
-		if newBool, ok := newVal.(bool); ok {
-			return existingBool == newBool
-		}
-	}
-	return existing == newVal
-}
-
 // recordNeedsUpdate checks if any compared field differs between existing record and new data.
 // Uses compareFields (inclusion list): only the listed fields are checked for changes.
+// Delegates to the shared compareRecordNeedsUpdate in base_sync.go.
 func (s *StaffSkillsSync) recordNeedsUpdate(
 	existing *core.Record, newData map[string]interface{}, compareFields []string,
 ) bool {
-	for _, field := range compareFields {
-		if value, exists := newData[field]; exists {
-			if !s.fieldEquals(existing.Get(field), value) {
-				return true
-			}
-		}
-	}
-	return false
+	return compareRecordNeedsUpdate(existing, newData, compareFields)
 }
 
 // deleteOrphans removes records that weren't processed

--- a/pocketbase/sync/staff_skills_test.go
+++ b/pocketbase/sync/staff_skills_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
 )
 
 // testLastName is a standard test last name (testFirstName is defined in persons_test.go)
@@ -833,43 +835,77 @@ func TestStaffSkillsCompareFields(t *testing.T) {
 }
 
 // TestStaffSkillsRecordNeedsUpdateUsesCompareFields verifies that recordNeedsUpdate
-// uses the compareFields (inclusion list) pattern, not skipFields (exclusion list).
+// correctly detects when fields match (no update) and when they differ (needs update).
 func TestStaffSkillsRecordNeedsUpdateUsesCompareFields(t *testing.T) {
 	s := &StaffSkillsSync{}
 
-	// Build test data where only a non-compared field differs
-	newData := map[string]interface{}{
-		"person_id":       12345,
-		"skill_cm_id":     100,
-		"year":            2025,
-		"skill_name":      "Archery",
-		"is_intermediate": true,
-		"is_experienced":  false,
-		"can_teach":       false,
-		"is_certified":    false,
-		"raw_value":       "Int.",
-		"first_name":      testFirstName,
-		"last_name":       testLastName,
-	}
+	// Create a minimal collection with the fields used in comparison
+	col := core.NewBaseCollection("test_staff_skills")
+	col.Fields.Add(&core.TextField{Name: "skill_name"})
+	col.Fields.Add(&core.BoolField{Name: "is_intermediate"})
+	col.Fields.Add(&core.BoolField{Name: "is_experienced"})
+	col.Fields.Add(&core.BoolField{Name: "can_teach"})
+	col.Fields.Add(&core.BoolField{Name: "is_certified"})
+	col.Fields.Add(&core.TextField{Name: "raw_value"})
+	col.Fields.Add(&core.TextField{Name: "first_name"})
+	col.Fields.Add(&core.TextField{Name: "last_name"})
+	col.Fields.Add(&core.TextField{Name: "person"})
 
-	// mockGet simulates an existing record where all compareFields match
-	mockGet := func(field string) interface{} {
-		return newData[field]
-	}
+	t.Run("no update when all fields match", func(t *testing.T) {
+		existing := core.NewRecord(col)
+		existing.Set("skill_name", "Archery")
+		existing.Set("is_intermediate", true)
+		existing.Set("is_experienced", false)
+		existing.Set("can_teach", false)
+		existing.Set("is_certified", false)
+		existing.Set("raw_value", "Int.")
+		existing.Set("first_name", testFirstName)
+		existing.Set("last_name", testLastName)
+		existing.Set("person", "pb_abc123")
 
-	// Verify: when all compareFields match, recordNeedsUpdate should return false
-	// This test exercises the compareFields signature (not skipFields)
-	needsUpdate := false
-	for _, field := range staffSkillsCompareFields {
-		if value, exists := newData[field]; exists {
-			if !s.fieldEquals(mockGet(field), value) {
-				needsUpdate = true
-				break
-			}
+		newData := map[string]interface{}{
+			"skill_name":      "Archery",
+			"is_intermediate": true,
+			"is_experienced":  false,
+			"can_teach":       false,
+			"is_certified":    false,
+			"raw_value":       "Int.",
+			"first_name":      testFirstName,
+			"last_name":       testLastName,
+			"person":          "pb_abc123",
 		}
-	}
 
-	if needsUpdate {
-		t.Error("expected no update needed when all compareFields match")
-	}
+		if s.recordNeedsUpdate(existing, newData, staffSkillsCompareFields) {
+			t.Error("expected no update needed when all compareFields match")
+		}
+	})
+
+	t.Run("needs update when a compare field differs", func(t *testing.T) {
+		existing := core.NewRecord(col)
+		existing.Set("skill_name", "Archery")
+		existing.Set("is_intermediate", true)
+		existing.Set("is_experienced", false)
+		existing.Set("can_teach", false)
+		existing.Set("is_certified", false)
+		existing.Set("raw_value", "Int.")
+		existing.Set("first_name", testFirstName)
+		existing.Set("last_name", testLastName)
+		existing.Set("person", "pb_abc123")
+
+		newData := map[string]interface{}{
+			"skill_name":      "Archery",
+			"is_intermediate": true,
+			"is_experienced":  true,
+			"can_teach":       false,
+			"is_certified":    false,
+			"raw_value":       "Int.|Exp.",
+			"first_name":      testFirstName,
+			"last_name":       testLastName,
+			"person":          "pb_abc123",
+		}
+
+		if !s.recordNeedsUpdate(existing, newData, staffSkillsCompareFields) {
+			t.Error("expected update needed when is_experienced differs")
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- Convert `staff_skills`, `camper_history`, and `camper_dietary` sync services from `skipFields` (exclusion map) to `compareFields` (inclusion list) pattern
- Aligns with existing convention in `persons`, `divisions`, and `bunks` services
- Inclusion lists are safer: new fields are NOT compared by default, preventing unnecessary updates

Closes #733

## Test plan
- [x] 2 new tests per converted service (6 total) verifying field lists and comparison logic
- [x] All Go sync tests passing
- [x] `go vet` and `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved record synchronization logic to more reliably detect when updates are needed across dietary records, history records, and staff skills data.

* **Tests**
  * Added comprehensive test coverage for synchronization field comparison logic to ensure data consistency and prevent unnecessary record updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->