### PR TITLE
fix(sync): add per-run token to prevent runSyncAndWait cross-run confusion

### DIFF
--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -198,7 +198,8 @@ type Status struct {
 	EndTime   *time.Time `json:"end_time,omitempty"`
 	Error     string     `json:"error,omitempty"`
 	Summary   Stats      `json:"summary"`
-	Year      int        `json:"year,omitempty"` // Year being synced (0 = current year)
+	Year      int        `json:"year,omitempty"`      // Year being synced (0 = current year)
+	RunToken  string     `json:"run_token,omitempty"` // Unique token per run to prevent cross-run confusion
 }
 
 // QueuedSync represents a sync request waiting in the queue
@@ -489,12 +490,19 @@ func (o *Orchestrator) RunSingleSync(parentCtx context.Context, syncType string)
 		return fmt.Errorf("sync service not found: %s", syncType)
 	}
 
+	// Generate a unique token for this run
+	runToken := fmt.Sprintf("%d", time.Now().UnixNano())
+
 	// Check if status was pre-marked by MarkSyncRunning
 	// If so, reuse it; otherwise create a new status
 	var status *Status
 	if existingStatus != nil {
 		// Reuse pre-marked status (set by MarkSyncRunning before goroutine started)
 		status = existingStatus
+		// Overwrite the token so runSyncAndWait can track this specific execution
+		o.mu.Lock()
+		status.RunToken = runToken
+		o.mu.Unlock()
 	} else {
 		// No pre-marked status - check if something else is running
 		if o.IsRunning(syncType) {
@@ -508,6 +516,7 @@ func (o *Orchestrator) RunSingleSync(parentCtx context.Context, syncType string)
 			StartTime: time.Now(),
 			Summary:   Stats{},
 			Year:      o.currentSyncYear,
+			RunToken:  runToken,
 		}
 
 		o.mu.Lock()
@@ -606,13 +615,14 @@ func (o *Orchestrator) MarkSyncRunning(syncType string) error {
 		return fmt.Errorf("sync already in progress: %s", syncType)
 	}
 
-	// Create status entry
+	// Create status entry with a unique run token
 	status := &Status{
 		Type:      syncType,
 		Status:    statusRunning,
 		StartTime: time.Now(),
 		Summary:   Stats{},
 		Year:      o.currentSyncYear,
+		RunToken:  fmt.Sprintf("%d", time.Now().UnixNano()),
 	}
 
 	o.mu.Lock()
@@ -913,6 +923,16 @@ func (o *Orchestrator) runSyncAndWait(ctx context.Context, syncType string) erro
 		return err
 	}
 
+	// Capture the token for THIS run so we only unblock on its completion,
+	// not on a stale or different run's completed status.
+	o.mu.RLock()
+	runningStatus := o.runningJobs[syncType]
+	var expectedToken string
+	if runningStatus != nil {
+		expectedToken = runningStatus.RunToken
+	}
+	o.mu.RUnlock()
+
 	// Wait for completion
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
@@ -923,15 +943,18 @@ func (o *Orchestrator) runSyncAndWait(ctx context.Context, syncType string) erro
 			return ctx.Err()
 		case <-ticker.C:
 			if !o.IsRunning(syncType) {
-				// Check final status
+				// Check final status — only accept if the token matches this run
 				o.mu.RLock()
 				status := o.lastCompletedStatus[syncType]
 				o.mu.RUnlock()
 
-				if status != nil && status.Status == statusFailed {
-					return fmt.Errorf("%s", status.Error)
+				if status != nil && status.RunToken == expectedToken {
+					if status.Status == statusFailed {
+						return fmt.Errorf("%s", status.Error)
+					}
+					return nil
 				}
-				return nil
+				// Token doesn't match — a stale completion; keep waiting
 			}
 		}
 	}

--- a/pocketbase/sync/orchestrator_test.go
+++ b/pocketbase/sync/orchestrator_test.go
@@ -3048,3 +3048,149 @@ func TestRunSingleSyncAtomicStatusTransition(t *testing.T) {
 		t.Errorf("detected %d inconsistent status reads", inconsistent)
 	}
 }
+
+// TestRunTokenPopulated tests that RunSingleSync populates RunToken on the status
+func TestRunTokenPopulated(t *testing.T) {
+	o := NewOrchestrator(nil)
+
+	mock := &MockService{name: "test_service", delay: 50 * time.Millisecond}
+	o.RegisterService("test", mock)
+
+	ctx := context.Background()
+	err := o.RunSingleSync(ctx, "test")
+	if err != nil {
+		t.Fatalf("RunSingleSync failed: %v", err)
+	}
+
+	// While running, status should have a non-empty RunToken
+	o.mu.RLock()
+	status := o.runningJobs["test"]
+	o.mu.RUnlock()
+
+	if status == nil {
+		t.Fatal("expected running status")
+		return
+	}
+
+	if status.RunToken == "" {
+		t.Error("expected RunToken to be populated, got empty string")
+	}
+
+	// Wait for completion
+	time.Sleep(100 * time.Millisecond)
+
+	// Completed status should also have the token
+	o.mu.RLock()
+	completed := o.lastCompletedStatus["test"]
+	o.mu.RUnlock()
+
+	if completed == nil {
+		t.Fatal("expected completed status")
+		return
+	}
+
+	if completed.RunToken == "" {
+		t.Error("expected completed status to preserve RunToken")
+	}
+
+	if completed.RunToken != status.RunToken {
+		t.Errorf("RunToken mismatch: running=%q completed=%q", status.RunToken, completed.RunToken)
+	}
+}
+
+// TestRunTokenPreservedByFinalizeSyncStatus tests that FinalizeSyncStatus preserves
+// the RunToken from the running status
+func TestRunTokenPreservedByFinalizeSyncStatus(t *testing.T) {
+	o := NewOrchestrator(nil)
+
+	mock := &MockService{name: "test_service"}
+	o.RegisterService("test", mock)
+
+	// Mark as running
+	err := o.MarkSyncRunning("test")
+	if err != nil {
+		t.Fatalf("MarkSyncRunning failed: %v", err)
+	}
+
+	// MarkSyncRunning should also set a RunToken
+	o.mu.RLock()
+	runningStatus := o.runningJobs["test"]
+	token := runningStatus.RunToken
+	o.mu.RUnlock()
+
+	if token == "" {
+		t.Fatal("expected MarkSyncRunning to set RunToken")
+	}
+
+	// Finalize the status
+	o.FinalizeSyncStatus("test", Stats{Created: 5}, nil)
+
+	// Check that the token is preserved
+	o.mu.RLock()
+	completed := o.lastCompletedStatus["test"]
+	o.mu.RUnlock()
+
+	if completed == nil {
+		t.Fatal("expected completed status")
+		return
+	}
+
+	if completed.RunToken != token {
+		t.Errorf("FinalizeSyncStatus did not preserve RunToken: expected %q, got %q", token, completed.RunToken)
+	}
+}
+
+// TestRunSyncAndWaitMatchesToken tests the core race condition fix:
+// runSyncAndWait should only unblock when the completed status has a matching token,
+// not when a different run of the same syncType completes.
+func TestRunSyncAndWaitMatchesToken(t *testing.T) {
+	o := NewOrchestrator(nil)
+
+	// Register a slow service
+	mock := &MockService{name: "test_service", delay: 200 * time.Millisecond}
+	o.RegisterService("test", mock)
+
+	// Simulate the race condition:
+	// 1. Pre-populate lastCompletedStatus with a STALE token from a previous run
+	o.mu.Lock()
+	staleToken := "stale-run-token"
+	o.lastCompletedStatus["test"] = &Status{
+		Type:     "test",
+		Status:   statusSuccess,
+		RunToken: staleToken,
+	}
+	o.mu.Unlock()
+
+	// 2. Start runSyncAndWait - it should NOT unblock on the stale completed status
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- o.runSyncAndWait(ctx, "test")
+	}()
+
+	// 3. Wait for it to complete - it should wait for the NEW run, not return immediately
+	//    from seeing the stale completed status
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("runSyncAndWait returned error: %v", err)
+		}
+		// Verify it actually ran the sync (didn't just return from stale status)
+		if mock.GetCallCount() != 1 {
+			t.Errorf("expected service to be called once, got %d", mock.GetCallCount())
+		}
+
+		// Verify the completed status has a NEW token, not the stale one
+		o.mu.RLock()
+		completed := o.lastCompletedStatus["test"]
+		o.mu.RUnlock()
+
+		if completed.RunToken == staleToken {
+			t.Error("runSyncAndWait unblocked on stale token - race condition not fixed")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("runSyncAndWait timed out")
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes #759: `runSyncAndWait` could unblock on a different run's completion because `lastCompletedStatus` is keyed only by `syncType`
- Adds a `RunToken` field to the `Status` struct, populated with a unique nanosecond timestamp on each `RunSingleSync` or `MarkSyncRunning` call
- `runSyncAndWait` now captures the token after starting a sync and only unblocks when the completed status carries the matching token, preventing cross-run confusion

## Changes
- `Status` struct: added `RunToken string` field
- `RunSingleSync`: generates token, sets it on both new and pre-marked statuses
- `MarkSyncRunning`: generates token when creating status
- `runSyncAndWait`: captures expected token, matches against completed status before unblocking
- `FinalizeSyncStatus`: token is automatically preserved via the existing struct copy

## Test plan
- [x] `TestRunTokenPopulated` — verifies `RunSingleSync` populates `RunToken` and it survives completion
- [x] `TestRunTokenPreservedByFinalizeSyncStatus` — verifies `FinalizeSyncStatus` preserves the token
- [x] `TestRunSyncAndWaitMatchesToken` — reproduces the race condition with a stale token and verifies the fix
- [x] Full Go test suite passes (`go test ./...`)
- [x] Linting passes (`golangci-lint run ./...`)

Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved synchronization reliability by preventing stale completion results from being incorrectly reused across sync operations.

* **Tests**
  * Added test coverage for synchronization token tracking and matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->