### PR TITLE
fix(ci): fix git add in dependabot lockfile fixup workflow

### DIFF
--- a/.github/workflows/dependabot-lockfile-fixup.yml
+++ b/.github/workflows/dependabot-lockfile-fixup.yml
@@ -88,7 +88,17 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git add -A '*.lock' '**/package-lock.json'
+          # Stage each lock file individually — git add fails entirely if any
+          # pathspec doesn't match, so we can't combine them in one command
+          git add uv.lock 2>/dev/null || true
+          git add package-lock.json 2>/dev/null || true
+          git add */package-lock.json 2>/dev/null || true
+
+          # Safety: exit cleanly if nothing was staged despite detection
+          if git diff --cached --quiet; then
+            echo "No lock file changes to commit"
+            exit 0
+          fi
           git commit -m "fix(deps): regenerate lock files for consistency
 
           Dependabot updated direct dependencies but the lock file's transitive


### PR DESCRIPTION
## Summary
- Fixes the lock file fixup workflow that was supposed to auto-heal Dependabot PRs with stale transitive dependencies (added in #758)
- `git add -A '*.lock' '**/package-lock.json'` fails entirely when any pathspec has no matches — on npm-only PRs, `*.lock` matches nothing, so the regenerated `package-lock.json` is never staged
- Split into individual `git add` commands so each lock file type is staged independently

## Root cause
`git add` treats all arguments as pathspecs and fails atomically if any one doesn't match. On PR #761 (npm-only), `*.lock` had no match → entire add failed → nothing staged → commit failed → workflow reported failure.

## Test plan
- [x] Verified `git add */package-lock.json` correctly stages `frontend/package-lock.json` when run separately
- [ ] After merge, Dependabot recreates #761 → fixup workflow should auto-heal the lock file

Closes #766

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal dependency lock file handling in automated workflows to ensure reliable staging of lock file changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->