### PR TITLE
fix(ci): allow lockfile fixup on manually rebased dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-lockfile-fixup.yml
+++ b/.github/workflows/dependabot-lockfile-fixup.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   fixup:
     name: Fix Lock Files
-    if: github.actor == 'dependabot[bot]'
+    if: github.actor == 'dependabot[bot]' || startsWith(github.head_ref, 'dependabot/')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Dependabot branch


### PR DESCRIPTION
## Summary
- Adds branch name check (`startsWith(github.head_ref, 'dependabot/')`) to the lockfile fixup workflow's `if` condition
- Previously only checked `github.actor == 'dependabot[bot]'`, which skipped the job when a human rebased a Dependabot PR

## Test plan
- [ ] Manually rebase a Dependabot PR → workflow should now run instead of skipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)