### PR TITLE
fix(ci): force full lockfile regeneration in dependabot fixup workflow

### DIFF
--- a/.github/workflows/dependabot-lockfile-fixup.yml
+++ b/.github/workflows/dependabot-lockfile-fixup.yml
@@ -49,9 +49,11 @@ jobs:
 
             echo "=== Checking $dir ==="
 
-            # Resolve the full dependency tree (no downloads) and check if
-            # the lock file changed — lighter than npm ci which installs everything
-            (cd "$dir" && npm install --package-lock-only --ignore-scripts)
+            # npm install --package-lock-only doesn't always catch transitive
+            # version mismatches (e.g., react-query@5.94 wanting query-core@5.94
+            # but lockfile still pinning query-core@5.90). Delete and regenerate
+            # from scratch to guarantee a fully resolved tree.
+            (cd "$dir" && rm package-lock.json && npm install --package-lock-only --ignore-scripts)
             if git diff --quiet -- "$lockfile"; then
               echo "✅ $dir: lock file is consistent"
             else


### PR DESCRIPTION
## Summary
- Deletes `package-lock.json` before running `npm install --package-lock-only` in the dependabot lockfile fixup workflow
- `npm install --package-lock-only` on an existing lockfile doesn't always detect transitive version mismatches (e.g., `react-query@5.94.5` requiring `query-core@5.94.5` but the lockfile still resolving `query-core@5.90.13`)
- Deleting first forces npm to build the full dependency tree from scratch, catching these mismatches

## Context
PR #761 (dependabot npm bump) is failing because `@tanstack/react-query@5.94.5` imports `environmentManager` from `@tanstack/query-core`, but the lockfile resolved `query-core@5.90.13` which doesn't have that export. The fixup workflow ran and reported "consistent" — this fix ensures it catches the mismatch.

## Test plan
- [ ] Merge this, then rebase #761 to trigger the fixup workflow
- [ ] Verify the fixup workflow detects the stale `query-core` and regenerates the lockfile
- [ ] Verify CI passes on #761 after regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)