### PR TITLE
fix(docker): add --link to pocketbase/init COPY layers

### DIFF
--- a/docker/Dockerfile.init
+++ b/docker/Dockerfile.init
@@ -19,8 +19,8 @@ FROM chainguard/wolfi-base:latest
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl
 
-COPY --from=go-builder /build/pocketbase /usr/local/bin/pocketbase
-COPY --chmod=755 docker/init-entrypoint.sh /init-entrypoint.sh
+COPY --link --from=go-builder /build/pocketbase /usr/local/bin/pocketbase
+COPY --link --chmod=755 docker/init-entrypoint.sh /init-entrypoint.sh
 
 USER nonroot
 

--- a/docker/Dockerfile.pocketbase
+++ b/docker/Dockerfile.pocketbase
@@ -36,11 +36,11 @@ RUN mkdir -p /pb_data && chown 65532:65532 /pb_data
 FROM chainguard/static:latest
 
 # /pb_data owned by nonroot — Docker named volumes inherit this ownership
-COPY --from=dirs /pb_data /pb_data
-COPY --from=go-builder /build/pocketbase /usr/local/bin/pocketbase
-COPY --from=healthcheck-builder /build/healthcheck /usr/local/bin/healthcheck
-COPY pocketbase/pb_hooks /pb_hooks
-COPY pocketbase/pb_migrations /pb_migrations
+COPY --link --from=dirs /pb_data /pb_data
+COPY --link --from=go-builder /build/pocketbase /usr/local/bin/pocketbase
+COPY --link --from=healthcheck-builder /build/healthcheck /usr/local/bin/healthcheck
+COPY --link pocketbase/pb_hooks /pb_hooks
+COPY --link pocketbase/pb_migrations /pb_migrations
 
 VOLUME /pb_data
 


### PR DESCRIPTION
## Summary
- Adds `--link` flag to all `COPY` instructions in the final stages of `Dockerfile.pocketbase` (5) and `Dockerfile.init` (2)
- Without `--link`, layer digests depend on parent layers, so identical content gets different digests between version tags — forcing a full pull on every upgrade
- The API image already uses `--link` and was the only one sharing layers between 3.9.0 → 3.10.0

## Test plan
- [ ] CD workflow builds all images successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image build configuration to optimize layer copying across container initialization and runtime stages, improving build efficiency while maintaining unchanged runtime behavior and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->