### PR TITLE
fix(solver,sync): post-#812 scan fixes — multi-session, double-conflict, purge stats

### DIFF
--- a/bunking/sync/bunk_request_processor/conflict/conflict_detector.py
+++ b/bunking/sync/bunk_request_processor/conflict/conflict_detector.py
@@ -128,13 +128,14 @@ class ConflictDetector:
         conflicts.extend(inactive_conflicts)
         inactive_indices = {idx for c in inactive_conflicts for idx in c.affected_request_indices}
 
-        # Detect inactive requesters (cancelled/dismissed/withdrawn)
-        requester_conflicts = self._detect_inactive_requesters(resolved_requests, session_maps)
+        # Detect inactive requesters (cancelled/dismissed/withdrawn) — skip already-flagged
+        target_skip_indices = not_enrolled_indices | inactive_indices
+        requester_conflicts = self._detect_inactive_requesters(resolved_requests, session_maps, target_skip_indices)
         conflicts.extend(requester_conflicts)
         requester_inactive_indices = {idx for c in requester_conflicts for idx in c.affected_request_indices}
 
         # Combined skip set for session conflict detection
-        skip_indices = not_enrolled_indices | inactive_indices | requester_inactive_indices
+        skip_indices = target_skip_indices | requester_inactive_indices
 
         # Detect session mismatches (BUNK_WITH) — skip already-declined
         session_conflicts = self._detect_session_conflicts(resolved_requests, session_maps, skip_indices)
@@ -316,7 +317,10 @@ class ConflictDetector:
         return conflicts
 
     def _detect_inactive_requesters(
-        self, resolved_requests: list[tuple[ParsedRequest, dict[str, Any]]], maps: dict[str, Any]
+        self,
+        resolved_requests: list[tuple[ParsedRequest, dict[str, Any]]],
+        maps: dict[str, Any],
+        skip_indices: set[int] | None = None,
     ) -> list[V2Conflict]:
         """Detect requests where requester has inactive enrollment (cancelled/dismissed/withdrawn)."""
         conflicts: list[V2Conflict] = []
@@ -328,6 +332,8 @@ class ConflictDetector:
 
         for request_map_key in ("positive_requests", "negative_requests"):
             for (requester, target), (idx, session_info) in maps[request_map_key].items():
+                if skip_indices and idx in skip_indices:
+                    continue
                 if requester in inactive:
                     info = requester_enrollment.get(requester)
                     status_id = info.status_id if info else None

--- a/bunking/sync/bunk_request_processor/resolution/resolution_pipeline.py
+++ b/bunking/sync/bunk_request_processor/resolution/resolution_pipeline.py
@@ -252,7 +252,10 @@ class ResolutionPipeline:
                 for person_id, session_id in person_sessions_from_db.items():
                     attendee_info_by_person_year[(person_id, year)] = session_id
                     if person_id not in attendee_info:
-                        attendee_info[person_id] = {"session_cm_id": session_id}
+                        attendee_info[person_id] = {
+                            "session_cm_id": session_id,
+                            "session_cm_ids": [session_id],
+                        }
 
         # Add person details (school, grade, city, state) from loaded Person objects
         for cm_id, person in all_persons_by_cm_id.items():

--- a/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
@@ -471,10 +471,15 @@ class ExactMatchStrategy(BaseMatchStrategy):
                 metadata={"ambiguity_reason": "multiple_matches_no_session", "match_count": len(matches)},
             )
 
-        # Filter by same session using pre-loaded data
-        same_session_matches = [
-            m for m in matches if attendee_info.get(m.cm_id, {}).get("session_cm_id") == session_cm_id
-        ]
+        # Filter by same session using pre-loaded data (check session_cm_ids first for multi-enrolled)
+        def _is_same_session(m: Person) -> bool:
+            info = attendee_info.get(m.cm_id, {})
+            match_sessions = info.get("session_cm_ids", [])
+            if match_sessions:
+                return session_cm_id in match_sessions
+            return info.get("session_cm_id") == session_cm_id
+
+        same_session_matches = [m for m in matches if _is_same_session(m)]
 
         if len(same_session_matches) == 1:
             # Unique match in same session

--- a/pocketbase/sync/bunk_requests.go
+++ b/pocketbase/sync/bunk_requests.go
@@ -391,6 +391,8 @@ func (s *BunkRequestsSync) purgeOrphanedRequests(year int) error {
 		}
 	}
 
+	s.Stats.Deleted += totalOBRs + totalBRs
+
 	slog.Info("Purged orphaned requests",
 		"persons", len(orphanedIDs),
 		"obrs_deleted", totalOBRs,

--- a/tests/unit/sync/bunk_request_processor/conflict/test_conflict_detector.py
+++ b/tests/unit/sync/bunk_request_processor/conflict/test_conflict_detector.py
@@ -881,7 +881,7 @@ class TestEnrollmentAwareConflicts:
         assert len(requester_conflicts) == 0
 
     def test_ghost_record_both_sides_not_attending(self):
-        """Neither requester nor target enrolled -> both conflict types fire."""
+        """Neither requester nor target enrolled -> target conflict wins, no double-conflict."""
         from bunking.sync.bunk_request_processor.core.models import EnrollmentInfo
 
         enrollment_map = {
@@ -907,5 +907,6 @@ class TestEnrollmentAwareConflicts:
 
         requester_conflicts = [c for c in result.conflicts if c.conflict_type == ConflictType.REQUESTER_NOT_ATTENDING]
         target_conflicts = [c for c in result.conflicts if c.conflict_type == ConflictType.TARGET_NOT_ATTENDING]
-        assert len(requester_conflicts) == 1
+        # Target is detected first, so requester detection skips this already-flagged index
         assert len(target_conflicts) == 1
+        assert len(requester_conflicts) == 0

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
@@ -216,6 +216,35 @@ class TestExactMatchStrategy:
         # Lower confidence without year context
         assert result.confidence == 0.90
 
+    def test_multi_match_disambiguation_uses_session_cm_ids(self, strategy):
+        """Multi-match disambiguation should check session_cm_ids, not just session_cm_id."""
+        target_a = Person(cm_id=2000001, first_name="Erez", last_name="Costello")
+        target_b = Person(cm_id=2000002, first_name="Erez", last_name="Costello")
+        attendee_info = {
+            1000001: {"session_cm_id": 1000010},
+            2000001: {
+                "session_cm_id": 1000020,
+                "session_cm_ids": [1000020, 1000010],
+            },
+            2000002: {
+                "session_cm_id": 1000030,
+                "session_cm_ids": [1000030],
+            },
+        }
+
+        result = strategy.resolve_with_context(
+            name="Erez Costello",
+            requester_cm_id=1000001,
+            session_cm_id=1000010,
+            year=2026,
+            candidates=[target_a, target_b],
+            attendee_info=attendee_info,
+        )
+
+        assert result.confidence == 0.95
+        assert result.person.cm_id == 2000001
+        assert result.metadata.get("session_match") == "exact"
+
 
 class TestExactMatchParentSurname:
     """Test parent surname matching in ExactMatchStrategy"""


### PR DESCRIPTION
## Summary

Four fixes from code review scan of PR #812:

- **Multi-match disambiguation checks `session_cm_ids`**: `_disambiguate_with_context` in `exact_match.py` now checks `session_cm_ids` (list) with fallback to `session_cm_id` (singular), matching the single-match path behavior
- **DB fallback populates `session_cm_ids`**: `resolution_pipeline.py` DB fallback path now sets `session_cm_ids: [session_id]` for consistency with orchestrator path
- **No double-conflict for ghost records**: `_detect_inactive_requesters` skips already-flagged indices to prevent double-conflict when both requester and target are inactive
- **Purge updates `Stats.Deleted`**: `purgeOrphanedRequests` now increments `Stats.Deleted` counter so sync summary reflects total deletions

## Test plan

- [x] 1582 Python bunk request processor tests pass (0 failures)
- [x] 1978 Go sync tests pass
- [x] ruff check + format clean
- [x] New test: multi-match disambiguation with `session_cm_ids`
- [x] Updated test: ghost record double-conflict now expects single conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevented duplicate conflict detection when targets are inactive or not enrolled, reducing false-positive conflict reports
  * Fixed deletion statistics to correctly count orphaned request removals

* **Improvements**
  * Enhanced session matching to better support attendees enrolled in multiple sessions during conflict resolution and disambiguation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->