### PR TITLE
fix(solver): include requested_cm_id in dedup trace key (#788)

### DIFF
--- a/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
@@ -1506,7 +1506,7 @@ class RequestOrchestrator:
         resolved_requests = self.conflict_detector.apply_conflict_resolution(resolved_requests, conflict_result)
 
         # Create bunk requests (skipped in dry_run mode)
-        deduped_keys: set[tuple[int, str]] = set()
+        deduped_keys: set[tuple[int, int | None, str]] = set()
         if dry_run:
             logger.info("=== Skipping Bunk Request Creation (dry_run=True) ===")
             created_requests: list[Any] = []
@@ -1516,10 +1516,11 @@ class RequestOrchestrator:
         self._stats["requests_created"] = len(created_requests)
 
         # --- Trace: Post-Pipeline results ---
-        # Build a map from (requester_cm_id, target_name) to created BunkRequest for trace linking
-        created_by_key: dict[tuple[int, str], Any] = {}
+        # Build a map from (requester_cm_id, requested_cm_id, target_name) to created BunkRequest for trace linking
+        # Key includes requested_cm_id to avoid collisions when different targets share the same name (#788)
+        created_by_key: dict[tuple[int, int | None, str], Any] = {}
         for req in created_requests:
-            req_key = (req.requester_cm_id, getattr(req, "requested_name", "") or "")
+            req_key = (req.requester_cm_id, req.requested_cm_id, getattr(req, "requested_name", "") or "")
             created_by_key.setdefault(req_key, req)
 
         for pr, res_list in resolution_results:
@@ -1536,7 +1537,8 @@ class RequestOrchestrator:
             for req_idx, (parsed_req, rr) in enumerate(zip(pr.parsed_requests, res_list, strict=False)):
                 # Find the matching created BunkRequest (if any)
                 target_name = parsed_req.target_name or ""
-                matched_br = created_by_key.get((requester_cm_id, target_name))
+                resolved_cm_id = rr.person.cm_id if rr.person else None
+                matched_br = created_by_key.get((requester_cm_id, resolved_cm_id, target_name))
                 br_meta = matched_br.metadata if matched_br and hasattr(matched_br, "metadata") else {}
                 br_meta = br_meta or {}
 
@@ -1548,9 +1550,10 @@ class RequestOrchestrator:
                     reciprocal_pair_cm_id = matched_br.requested_cm_id if matched_br else None
 
                 # Check if this request was removed by deduplication
-                # Use resolved name to match deduped_keys (built from BunkRequest.requested_name)
+                # Key includes requested_cm_id to avoid collisions when different targets share the
+                # same name (#788) — without it, a surviving request could be marked as DEDUPED
                 resolved_name = rr.person.full_name if rr.person and hasattr(rr.person, "full_name") else target_name
-                is_deduped = (requester_cm_id, resolved_name or "") in deduped_keys
+                is_deduped = (requester_cm_id, resolved_cm_id, resolved_name or "") in deduped_keys
                 if is_deduped:
                     any_dedup = True
 
@@ -2174,7 +2177,7 @@ class RequestOrchestrator:
 
     async def _create_bunk_requests(
         self, resolved_requests: list[tuple[ParsedRequest, dict[str, Any]]]
-    ) -> tuple[list[BunkRequest], set[tuple[int, str]]]:
+    ) -> tuple[list[BunkRequest], set[tuple[int, int | None, str]]]:
         """Create bunk request records in the database.
 
         This method:
@@ -2184,13 +2187,15 @@ class RequestOrchestrator:
 
         Returns:
             Tuple of (saved_requests, deduped_keys) where deduped_keys is a set of
-            (requester_cm_id, requested_name) tuples for requests removed by dedup.
+            (requester_cm_id, requested_cm_id, requested_name) tuples for requests
+            removed by dedup. Includes requested_cm_id to avoid trace key collisions
+            when different targets share the same name (#788).
         """
         # Build BunkRequest objects using the request builder
         pending_requests = self.request_builder.build_requests(resolved_requests)
 
         # Apply validation pipeline to all requests
-        deduped_keys: set[tuple[int, str]] = set()
+        deduped_keys: set[tuple[int, int | None, str]] = set()
         if pending_requests:
             logger.info(f"=== Applying Validation Pipeline to {len(pending_requests)} requests ===")
             validated_requests, deduped_keys = self._apply_validation_pipeline(pending_requests)
@@ -2355,7 +2360,9 @@ class RequestOrchestrator:
 
         return self._save_new_request_with_source_link(request)
 
-    def _apply_validation_pipeline(self, requests: list[BunkRequest]) -> tuple[list[BunkRequest], set[tuple[int, str]]]:
+    def _apply_validation_pipeline(
+        self, requests: list[BunkRequest]
+    ) -> tuple[list[BunkRequest], set[tuple[int, int | None, str]]]:
         """Apply the validation pipeline to a list of BunkRequest objects.
 
         This pipeline runs in order:
@@ -2367,7 +2374,9 @@ class RequestOrchestrator:
 
         Returns:
             Tuple of (validated_requests, deduped_keys) where deduped_keys is a set of
-            (requester_cm_id, requested_name) tuples for requests removed by dedup.
+            (requester_cm_id, requested_cm_id, requested_name) tuples for requests
+            removed by dedup. Includes requested_cm_id to avoid trace key collisions
+            when different targets share the same name (#788).
         """
         if not requests:
             return requests, set()
@@ -2409,10 +2418,12 @@ class RequestOrchestrator:
         deduplicated_requests = dedup_result.kept_requests
 
         # Build set of deduped-out request keys for trace accuracy
-        deduped_keys: set[tuple[int, str]] = set()
+        # Key includes requested_cm_id to avoid collisions when different targets
+        # share the same name (#788)
+        deduped_keys: set[tuple[int, int | None, str]] = set()
         for group in dedup_result.duplicate_groups:
             for dup in group.duplicates:
-                deduped_keys.add((dup.requester_cm_id, dup.requested_name or ""))
+                deduped_keys.add((dup.requester_cm_id, dup.requested_cm_id, dup.requested_name or ""))
 
         duplicates_removed = dedup_result.statistics.get("duplicates_removed", 0)
         self._stats["duplicates_removed"] = duplicates_removed

--- a/tests/unit/sync/bunk_request_processor/test_orchestrator_validation_pipeline.py
+++ b/tests/unit/sync/bunk_request_processor/test_orchestrator_validation_pipeline.py
@@ -357,6 +357,126 @@ class TestOrchestratorValidationPipelineIntegration:
         assert self_ref.confidence_score == 0.0
 
 
+class TestDedupTraceKeyCollision:
+    """Tests for dedup trace key collision fix (issue #788).
+
+    The dedup trace key must include requested_cm_id to distinguish
+    requests for different targets who share the same name. Without it,
+    (requester_cm_id, requested_name) can collide when two different
+    cm_ids resolve to the same display name, causing the surviving
+    request to be incorrectly marked as DEDUPED.
+    """
+
+    @pytest.mark.asyncio
+    @patch("bunking.sync.bunk_request_processor.orchestrator.orchestrator.ProviderFactory")
+    @patch("bunking.sync.bunk_request_processor.orchestrator.orchestrator.SocialGraph")
+    async def test_deduped_keys_include_requested_cm_id(self, mock_social_graph, mock_factory):
+        """deduped_keys must use (requester_cm_id, requested_cm_id, name) not just (requester_cm_id, name).
+
+        When two requests from the same requester target different people who share a name,
+        only the actual duplicate should appear in deduped_keys — not the distinct request.
+        """
+        from bunking.sync.bunk_request_processor.orchestrator.orchestrator import (
+            RequestOrchestrator,
+        )
+
+        mock_factory.return_value.create.return_value = Mock()
+        mock_social_graph_instance = Mock()
+        mock_social_graph_instance.initialize = AsyncMock()
+        mock_social_graph.return_value = mock_social_graph_instance
+
+        pb = _create_mock_pocketbase()
+        orchestrator = RequestOrchestrator(pb=pb, year=2025)
+
+        # Same requester, same name, DIFFERENT cm_ids — these are distinct people
+        # Emma Johnson (cm_id=200) and Emma Johnson (cm_id=201) are different campers
+        req_a = _create_bunk_request(
+            requester_cm_id=100,
+            requested_cm_id=200,
+            source=RequestSource.FAMILY,
+            confidence=0.95,
+        )
+        req_a.requested_name = "Emma Johnson"
+
+        req_b = _create_bunk_request(
+            requester_cm_id=100,
+            requested_cm_id=201,
+            source=RequestSource.FAMILY,
+            confidence=0.90,
+        )
+        req_b.requested_name = "Emma Johnson"
+
+        validated, deduped_keys = orchestrator._apply_validation_pipeline([req_a, req_b])
+
+        # Both should be kept — different targets (different cm_ids)
+        assert len(validated) == 2
+        # No duplicates removed — these are distinct requests
+        assert len(deduped_keys) == 0
+
+    @pytest.mark.asyncio
+    @patch("bunking.sync.bunk_request_processor.orchestrator.orchestrator.ProviderFactory")
+    @patch("bunking.sync.bunk_request_processor.orchestrator.orchestrator.SocialGraph")
+    async def test_deduped_keys_distinguish_same_name_different_target(self, mock_social_graph, mock_factory):
+        """When a true duplicate exists alongside a distinct same-name request,
+        only the duplicate's key should be in deduped_keys.
+
+        Setup: requester 100 requests both Emma Johnson (cm_id=200) twice
+        and Emma Johnson (cm_id=201) once. The duplicate pair (cm_id=200)
+        should produce a deduped_keys entry for cm_id=200 only.
+        """
+        from bunking.sync.bunk_request_processor.orchestrator.orchestrator import (
+            RequestOrchestrator,
+        )
+
+        mock_factory.return_value.create.return_value = Mock()
+        mock_social_graph_instance = Mock()
+        mock_social_graph_instance.initialize = AsyncMock()
+        mock_social_graph.return_value = mock_social_graph_instance
+
+        pb = _create_mock_pocketbase()
+        orchestrator = RequestOrchestrator(pb=pb, year=2025)
+
+        # Two requests for Emma Johnson (cm_id=200) — true duplicates
+        dup_1 = _create_bunk_request(
+            requester_cm_id=100,
+            requested_cm_id=200,
+            source=RequestSource.FAMILY,
+            confidence=0.95,
+        )
+        dup_1.requested_name = "Emma Johnson"
+
+        dup_2 = _create_bunk_request(
+            requester_cm_id=100,
+            requested_cm_id=200,
+            source=RequestSource.FAMILY,
+            confidence=0.80,
+        )
+        dup_2.requested_name = "Emma Johnson"
+
+        # One request for different Emma Johnson (cm_id=201) — NOT a duplicate
+        distinct = _create_bunk_request(
+            requester_cm_id=100,
+            requested_cm_id=201,
+            source=RequestSource.FAMILY,
+            confidence=0.90,
+        )
+        distinct.requested_name = "Emma Johnson"
+
+        validated, deduped_keys = orchestrator._apply_validation_pipeline([dup_1, dup_2, distinct])
+
+        # 2 kept: one from the (200) duplicate pair + the distinct (201) request
+        assert len(validated) == 2
+
+        # deduped_keys should contain an entry for cm_id=200 (the removed duplicate)
+        # but NOT for cm_id=201 (the distinct request that was never duplicated)
+        assert len(deduped_keys) == 1
+
+        # The key must include requested_cm_id so we can tell WHICH Emma Johnson was deduped
+        deduped_key = next(iter(deduped_keys))
+        assert 200 in deduped_key, "deduped key must contain the duplicated target's cm_id (200)"
+        assert 201 not in deduped_key, "deduped key must NOT contain the distinct target's cm_id (201)"
+
+
 # =============================================================================
 # Parity Tracker Gap: Line 233 (Known Intentional Differences)
 # =============================================================================


### PR DESCRIPTION
## Summary
- Fixed dedup trace key collision where `(requester_cm_id, requested_name)` could match both kept and removed requests when two different targets share the same display name but have different CampMinder IDs
- Changed trace key to `(requester_cm_id, requested_cm_id, requested_name)` across `deduped_keys`, `created_by_key`, and `is_deduped` lookups in `orchestrator.py`
- Trace-only correctness fix — actual dedup behavior is unchanged

## Test plan
- [x] Two new tests in `TestDedupTraceKeyCollision` verify the fix:
  - `test_deduped_keys_include_requested_cm_id` — distinct targets with same name are not falsely marked as deduped
  - `test_deduped_keys_distinguish_same_name_different_target` — true duplicates produce keyed entries that don't collide with distinct same-name requests
- [x] All 9 validation pipeline tests pass
- [x] Full test suite: 3554 passed, 23 skipped
- [x] ruff format/check clean
- [x] mypy passes (160 source files, no issues)

Closes #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deduplication logic to correctly handle requests targeting entities with identical names but different identifiers, preventing incorrect duplicate detection.

* **Tests**
  * Added comprehensive test coverage for deduplication validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->