### PR TITLE
refactor(metrics): make _get_enrollment_date public across modules

### DIFF
--- a/api/services/metrics_repository.py
+++ b/api/services/metrics_repository.py
@@ -449,7 +449,7 @@ class MetricsRepository:
     async def has_pre_anchor_enrollments(self, year: int, anchor_date: str) -> bool:
         """Check if any attendees have enrollment dates before the anchor.
 
-        Mirrors _get_enrollment_date priority: effective_date first, then
+        Mirrors get_enrollment_date priority: effective_date first, then
         enrollment_date only when effective_date is empty.  This prevents
         false positives from cancelled attendees whose enrollment_date is
         the cancel PostDate rather than the original registration date.

--- a/api/services/reconstruction.py
+++ b/api/services/reconstruction.py
@@ -106,7 +106,7 @@ def parse_date_only(value: str) -> str:
     return value.split("T")[0].split(" ")[0]
 
 
-def _get_enrollment_date(att: Any) -> str | None:
+def get_enrollment_date(att: Any) -> str | None:
     """Get the enrollment date for an attendee, preferring effective_date over enrollment_date."""
     ed = getattr(att, "effective_date", "") or ""
     if ed:
@@ -167,7 +167,7 @@ def _reconstruct_core(
             session_has_gender.add(effective_sid)
 
         # Enrollment event: use effective_date (original registration date)
-        enroll_date_str = _get_enrollment_date(att)
+        enroll_date_str = get_enrollment_date(att)
         if enroll_date_str:
             dt = datetime.strptime(enroll_date_str, "%Y-%m-%d")
             if (lower_bound is None or lower_bound <= dt.date()) and dt.date() <= cutoff_date:
@@ -404,7 +404,7 @@ def reconstruct_daily_multi(
                 per_session_has_gender[sid] = True
 
         # Enrollment event
-        enroll_date_str = _get_enrollment_date(att)
+        enroll_date_str = get_enrollment_date(att)
         if enroll_date_str:
             enroll_day = parse_date_only(enroll_date_str)
 

--- a/api/services/velocity_service.py
+++ b/api/services/velocity_service.py
@@ -26,7 +26,7 @@ from api.services.camp_calendar import REGISTRATION_TIERS, SEASON_WEEKS, format_
 from api.services.extractors import extract_gender
 from api.services.reconstruction import (
     ENROLLMENT_STATUSES,
-    _get_enrollment_date,
+    get_enrollment_date,
     reconstruct_daily_multi,
 )
 from api.utils.session_metrics import (
@@ -1622,7 +1622,7 @@ class VelocityService:
             if gender not in ("M", "F"):
                 continue
 
-            enroll_date_str = _get_enrollment_date(att)
+            enroll_date_str = get_enrollment_date(att)
             if not enroll_date_str:
                 continue
             dt = datetime.strptime(enroll_date_str, "%Y-%m-%d")

--- a/tests/unit/metrics/test_get_enrollment_date_public.py
+++ b/tests/unit/metrics/test_get_enrollment_date_public.py
@@ -1,0 +1,37 @@
+"""Test that get_enrollment_date is publicly importable from reconstruction module.
+
+TDD: This test is written BEFORE the rename to verify the public API contract.
+"""
+
+from types import SimpleNamespace
+
+
+def test_get_enrollment_date_is_public_import():
+    """get_enrollment_date (no underscore) should be importable from reconstruction."""
+    from api.services.reconstruction import get_enrollment_date
+
+    assert callable(get_enrollment_date)
+
+
+def test_get_enrollment_date_prefers_effective_date():
+    """get_enrollment_date should prefer effective_date over enrollment_date."""
+    from api.services.reconstruction import get_enrollment_date
+
+    att = SimpleNamespace(effective_date="2025-06-01T00:00:00Z", enrollment_date="2025-01-15")
+    assert get_enrollment_date(att) == "2025-06-01"
+
+
+def test_get_enrollment_date_falls_back_to_enrollment_date():
+    """get_enrollment_date should fall back to enrollment_date when effective_date is empty."""
+    from api.services.reconstruction import get_enrollment_date
+
+    att = SimpleNamespace(effective_date="", enrollment_date="2025-01-15T10:30:00Z")
+    assert get_enrollment_date(att) == "2025-01-15"
+
+
+def test_get_enrollment_date_returns_none_when_both_empty():
+    """get_enrollment_date should return None when both dates are empty."""
+    from api.services.reconstruction import get_enrollment_date
+
+    att = SimpleNamespace(effective_date="", enrollment_date="")
+    assert get_enrollment_date(att) is None


### PR DESCRIPTION
## Summary
- Rename `_get_enrollment_date` to `get_enrollment_date` in `api/services/reconstruction.py` since it is imported cross-module by `velocity_service.py`
- Update all call sites in `reconstruction.py` and `velocity_service.py`, and the docstring reference in `metrics_repository.py`
- Add unit tests verifying the public import and behavior of `get_enrollment_date`

Closes #770

## Test plan
- [x] New tests verify `get_enrollment_date` is importable (no underscore prefix)
- [x] New tests verify effective_date preference, enrollment_date fallback, and None return
- [x] All 186 existing reconstruction/velocity tests pass
- [x] ruff check and format pass
- [x] All pre-push hooks pass (mypy, tsc, go-build, ruff, shellcheck, eslint)

🤖 Generated with [Claude Code](https://claude.ai/code)