### PR TITLE
refactor(metrics): replace inline date-stripping with parse_date_only in session_metrics

### DIFF
--- a/api/utils/session_metrics.py
+++ b/api/utils/session_metrics.py
@@ -203,12 +203,14 @@ def get_session_length_category(start_date: str, end_date: str) -> str:
     """
     from datetime import datetime
 
+    from api.services.reconstruction import parse_date_only
+
     if not start_date or not end_date:
         return "unknown"
 
     try:
-        start_str = start_date.split(" ")[0].split("T")[0]
-        end_str = end_date.split(" ")[0].split("T")[0]
+        start_str = parse_date_only(start_date)
+        end_str = parse_date_only(end_date)
 
         start = datetime.strptime(start_str, "%Y-%m-%d")
         end = datetime.strptime(end_str, "%Y-%m-%d")

--- a/tests/unit/api/test_session_metrics.py
+++ b/tests/unit/api/test_session_metrics.py
@@ -741,6 +741,27 @@ class TestGetSessionLengthCategory:
 
         assert get_session_length_category("", "") == "unknown"
 
+    def test_uses_parse_date_only_for_date_stripping(self) -> None:
+        """get_session_length_category should delegate to parse_date_only, not inline date-stripping."""
+        from unittest.mock import patch
+
+        from api.utils.session_metrics import get_session_length_category
+
+        with patch(
+            "api.services.reconstruction.parse_date_only", side_effect=lambda v: v.split("T")[0].split(" ")[0]
+        ) as mock_parse:
+            result = get_session_length_category("2025-06-01T00:00:00Z", "2025-06-14T23:59:59Z")
+            assert result == "2-week"
+            assert mock_parse.call_count == 2
+            mock_parse.assert_any_call("2025-06-01T00:00:00Z")
+            mock_parse.assert_any_call("2025-06-14T23:59:59Z")
+
+    def test_handles_datetime_with_space_via_parse_date_only(self) -> None:
+        """Datetime strings with spaces (e.g. '2025-06-01 00:00:00') should work via parse_date_only."""
+        from api.utils.session_metrics import get_session_length_category
+
+        assert get_session_length_category("2025-06-01 00:00:00", "2025-06-07 23:59:59") == "1-week"
+
 
 # ============================================================================
 # resolve_duration_sessions() Tests


### PR DESCRIPTION
## Summary
- Replaced 2 inline date-stripping patterns (`start_date.split(" ")[0].split("T")[0]`) in `get_session_length_category` with calls to `parse_date_only()` from `api.services.reconstruction`
- Used a lazy import inside the function to avoid a circular import (`session_metrics -> reconstruction -> services.__init__ -> id_cache -> session_metrics`)
- Added 2 new tests: one verifying delegation to `parse_date_only` via mock, one verifying space-separated datetime handling

Closes #772

## Test plan
- [x] New test verifies `parse_date_only` is called for both start and end dates (mock-based)
- [x] New test verifies space-separated datetime strings work correctly
- [x] All 76 existing session_metrics tests pass
- [x] `ruff check` and `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)