### PR TITLE
chore(data): remove unused SCHEMA_VERSION from pipeline traces

### DIFF
--- a/api/routers/debug.py
+++ b/api/routers/debug.py
@@ -1209,7 +1209,6 @@ def _pb_record_to_trace_item(record: Any) -> PipelineTraceItem:
         source_field=getattr(record, "source_field", ""),
         trace_data=getattr(record, "trace_data", {}) or {},
         pinned=getattr(record, "pinned", False),
-        schema_version=getattr(record, "schema_version", 1),
         created=_parse_pb_datetime(getattr(record, "created", None)),
     )
 

--- a/api/schemas/pipeline_debug.py
+++ b/api/schemas/pipeline_debug.py
@@ -107,7 +107,6 @@ class PipelineTraceItem(BaseModel):
     source_field: str = Field(default="", description="Source field")
     trace_data: dict[str, Any] = Field(default_factory=dict, description="Full trace JSON")
     pinned: bool = Field(default=False, description="Whether this trace is pinned")
-    schema_version: int = Field(default=1, description="Trace schema version")
     created: datetime | None = Field(default=None, description="When captured")
 
 

--- a/bunking/sync/bunk_request_processor/debug/trace_collector.py
+++ b/bunking/sync/bunk_request_processor/debug/trace_collector.py
@@ -11,7 +11,6 @@ from typing import Any
 from bunking.logging_config import get_logger
 
 from .trace_models import (
-    SCHEMA_VERSION,
     HistoricalVerificationTrace,
     Phase1Trace,
     Phase2IntentTrace,
@@ -236,7 +235,6 @@ class TraceCollector:
                 "source_field": meta.get("source_field", ""),
                 "trace_data": trace_data.model_dump(),
                 "pinned": False,
-                "schema_version": SCHEMA_VERSION,
             }
             record = await asyncio.to_thread(pb_client.collection("debug_pipeline_traces").create, data)
             return key, record.id

--- a/bunking/sync/bunk_request_processor/debug/trace_models.py
+++ b/bunking/sync/bunk_request_processor/debug/trace_models.py
@@ -10,8 +10,6 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-SCHEMA_VERSION = 1
-
 
 class RequesterInfo(BaseModel):
     cm_id: int = 0

--- a/frontend/src/components/pipeline-debug/types.ts
+++ b/frontend/src/components/pipeline-debug/types.ts
@@ -239,7 +239,6 @@ export interface PipelineTrace {
   source_field: string
   trace_data: TraceData
   pinned: boolean
-  schema_version: number
   created: string
 }
 

--- a/frontend/src/types/pocketbase-types.ts
+++ b/frontend/src/types/pocketbase-types.ts
@@ -604,7 +604,6 @@ export type DebugPipelineTracesRecord<Ttrace_data = unknown> = {
   pinned?: boolean
   requester_cm_id?: number
   run_id: string
-  schema_version?: number
   session_cm_id?: number
   source_field?: string
   trace_data?: null | Ttrace_data

--- a/pocketbase/pb_migrations/1500000094_remove_trace_schema_version.js
+++ b/pocketbase/pb_migrations/1500000094_remove_trace_schema_version.js
@@ -1,0 +1,22 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: Remove schema_version from debug_pipeline_traces
+ *
+ * The schema_version field was written but never read for migration or
+ * conditional logic. Removing dead weight from the debug trace schema.
+ * Closes #839.
+ */
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("debug_pipeline_traces");
+  collection.fields.removeByName("schema_version");
+  app.save(collection);
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("debug_pipeline_traces");
+  collection.fields.add(new Field({
+    type: "number",
+    name: "schema_version",
+    required: false,
+    presentable: false
+  }));
+  app.save(collection);
+});

--- a/tests/unit/api/test_debug_phase_run_endpoints.py
+++ b/tests/unit/api/test_debug_phase_run_endpoints.py
@@ -82,7 +82,6 @@ def _make_trace_record_with_data() -> MagicMock:
             ],
         },
         pinned=False,
-        schema_version=1,
         created="2025-06-15T10:00:00Z",
     )
 

--- a/tests/unit/api/test_debug_pipeline_endpoints.py
+++ b/tests/unit/api/test_debug_pipeline_endpoints.py
@@ -130,7 +130,6 @@ def _make_pb_trace_record(
         source_field="bunk_with",
         trace_data=trace_data or {"pre_phase1": {"action": "parsed"}},
         pinned=False,
-        schema_version=1,
         created="2025-06-15T10:00:00Z",
     )
 

--- a/tests/unit/sync/bunk_request_processor/debug/test_trace_models.py
+++ b/tests/unit/sync/bunk_request_processor/debug/test_trace_models.py
@@ -1,7 +1,6 @@
 """Tests for pipeline debug trace data models."""
 
 from bunking.sync.bunk_request_processor.debug.trace_models import (
-    SCHEMA_VERSION,
     FinalBunkRequestTrace,
     HistoricalVerificationTrace,
     Phase1Trace,
@@ -58,9 +57,6 @@ class TestTraceData:
         d = td.model_dump()
         assert d["pre_phase1"]["action"] == "parsed"
         assert d["phase1_parse"]["ran"] is True
-
-    def test_schema_version(self):
-        assert SCHEMA_VERSION == 1
 
 
 class TestFinalBunkRequestTraceDispositionFields:


### PR DESCRIPTION
## Summary
- Remove `SCHEMA_VERSION` constant, field references, and PB column from debug pipeline traces
- The field was written to every trace record but never read for migration, conditional parsing, or compatibility checks
- Touches 9 files across Python (models, collector, API schema, router), frontend (types), tests, and a new PB migration

## Test plan
- [x] All 3509 Python unit tests pass
- [x] Frontend type-check and lint pass
- [x] Go tests pass
- [x] PB migration lint passes
- [x] Zero remaining `schema_version`/`SCHEMA_VERSION` references in application code

Closes #839

🤖 Generated with [Claude Code](https://claude.com/claude-code)