### PR TITLE
refactor(solver): update test fixtures to use RequestType enum values

### DIFF
--- a/tests/unit/bunking/solver/conftest.py
+++ b/tests/unit/bunking/solver/conftest.py
@@ -12,6 +12,7 @@ from typing import Any, cast
 import pytest
 from ortools.sat.python import cp_model
 
+from bunking.models import RequestType
 from bunking.models_v2 import (
     DirectBunk,
     DirectBunkRequest,
@@ -146,7 +147,7 @@ def create_request(
     request_id: str,
     requester_cm_id: int,
     requested_cm_id: int | None,
-    request_type: str,
+    request_type: RequestType,
     session_cm_id: int = 1000,
     priority: int = 5,
 ) -> DirectBunkRequest:
@@ -155,7 +156,7 @@ def create_request(
         id=request_id,
         requester_person_cm_id=requester_cm_id,
         requested_person_cm_id=requested_cm_id,
-        request_type=request_type,
+        request_type=request_type.value,
         priority=priority,
         session_cm_id=session_cm_id,
         year=2025,

--- a/tests/unit/bunking/solver/constraints/test_bunk_requests.py
+++ b/tests/unit/bunking/solver/constraints/test_bunk_requests.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from ortools.sat.python import cp_model
 
+from bunking.models import RequestType
 from bunking.solver.constraints.bunk_requests import add_bunk_request_satisfaction_vars
 
 from ..conftest import build_solver_context, create_bunk, create_person, create_request, is_optimal_or_feasible
@@ -32,7 +33,7 @@ class TestBunkWithSatisfaction:
             request_id="req-1",
             requester_cm_id=1001,
             requested_cm_id=1002,
-            request_type="bunk_with",
+            request_type=RequestType.BUNK_WITH,
         )
 
         ctx = build_solver_context(
@@ -73,7 +74,7 @@ class TestBunkWithSatisfaction:
             request_id="req-1",
             requester_cm_id=1001,
             requested_cm_id=1002,
-            request_type="bunk_with",
+            request_type=RequestType.BUNK_WITH,
         )
 
         ctx = build_solver_context(
@@ -118,7 +119,7 @@ class TestBunkWithSatisfaction:
             request_id="req-1",
             requester_cm_id=1001,
             requested_cm_id=9999,  # Not in context
-            request_type="bunk_with",
+            request_type=RequestType.BUNK_WITH,
         )
 
         ctx = build_solver_context(
@@ -149,7 +150,7 @@ class TestNotBunkWithSatisfaction:
             request_id="req-1",
             requester_cm_id=1001,
             requested_cm_id=1002,
-            request_type="not_bunk_with",
+            request_type=RequestType.NOT_BUNK_WITH,
         )
 
         ctx = build_solver_context(
@@ -191,7 +192,7 @@ class TestNotBunkWithSatisfaction:
             request_id="req-1",
             requester_cm_id=1001,
             requested_cm_id=1002,
-            request_type="not_bunk_with",
+            request_type=RequestType.NOT_BUNK_WITH,
         )
 
         ctx = build_solver_context(
@@ -231,13 +232,13 @@ class TestMultipleRequests:
             request_id="req-1",
             requester_cm_id=1001,
             requested_cm_id=1002,
-            request_type="bunk_with",
+            request_type=RequestType.BUNK_WITH,
         )
         request2 = create_request(
             request_id="req-2",
             requester_cm_id=1001,
             requested_cm_id=1003,
-            request_type="bunk_with",
+            request_type=RequestType.BUNK_WITH,
         )
 
         ctx = build_solver_context(
@@ -267,13 +268,13 @@ class TestMultipleRequests:
             request_id="req-1",
             requester_cm_id=1001,
             requested_cm_id=1002,
-            request_type="bunk_with",
+            request_type=RequestType.BUNK_WITH,
         )
         request2 = create_request(
             request_id="req-2",
             requester_cm_id=1001,
             requested_cm_id=1003,
-            request_type="not_bunk_with",
+            request_type=RequestType.NOT_BUNK_WITH,
         )
 
         ctx = build_solver_context(
@@ -325,7 +326,7 @@ class TestRequestEdgeCases:
             request_id="req-1",
             requester_cm_id=1001,
             requested_cm_id=None,  # No target
-            request_type="bunk_with",
+            request_type=RequestType.BUNK_WITH,
         )
 
         ctx = build_solver_context(
@@ -350,7 +351,7 @@ class TestRequestEdgeCases:
             request_id="req-1",
             requester_cm_id=9999,  # Not in context
             requested_cm_id=1001,
-            request_type="bunk_with",
+            request_type=RequestType.BUNK_WITH,
         )
 
         ctx = build_solver_context(


### PR DESCRIPTION
Closes #864

Mechanical string-to-enum replacement in solver test fixtures for consistency with production code after PR #862.

## Summary
- Added `RequestType` import to `tests/unit/bunking/solver/conftest.py` and `tests/unit/bunking/solver/constraints/test_bunk_requests.py`
- Changed `create_request()` helper signature from `request_type: str` to `request_type: RequestType`
- Updated all 11 call sites in `test_bunk_requests.py` from `request_type="bunk_with"` / `"not_bunk_with"` to `request_type=RequestType.BUNK_WITH` / `RequestType.NOT_BUNK_WITH`
- The helper passes `request_type.value` to `DirectBunkRequest` (which expects `str`)

## Test plan
- [x] All 80 solver unit tests pass before and after the change
- [x] `ruff check` and `ruff format --check` pass with no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved type safety in test utilities by using enumerated request types instead of string values for better test reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->