### PR TITLE
fix(ci): ignore CVE-2026-30836 in Caddy, add early CD health check to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,36 @@ jobs:
 
     - uses: kenji-miyake/setup-git-cliff@2778609c643a39a2576c4bae2e493b855eb4aee8 # v2
 
+    - name: Check CD health (early warning)
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        # Fail fast if CD has been consistently broken — saves waiting 15 min at "Ensure CD passed on HEAD"
+        # Gets last 5 completed (non-cancelled) CD runs on main
+        RUNS=$(gh run list \
+          --workflow cd.yml \
+          --branch main \
+          --limit 10 \
+          --json conclusion,status \
+          --jq '[.[] | select(.status == "completed" and (.conclusion == "success" or .conclusion == "failure"))][:5]')
+
+        TOTAL=$(echo "$RUNS" | jq 'length')
+        FAILURES=$(echo "$RUNS" | jq '[.[] | select(.conclusion == "failure")] | length')
+
+        echo "CD health: $FAILURES failures in last $TOTAL completed non-cancelled runs"
+
+        if [ "$TOTAL" -gt 0 ] && [ "$FAILURES" -ge 3 ]; then
+          echo "::error::CD is unhealthy — $FAILURES/$TOTAL recent runs failed. Fix CD before releasing."
+          echo "The release would fail anyway at 'Ensure CD passed on HEAD'. Check the CD workflow logs first."
+          exit 1
+        fi
+
+        if [ "$FAILURES" -ge 1 ]; then
+          echo "::warning::CD has $FAILURES/$TOTAL recent failures. Proceeding — 'Ensure CD passed on HEAD' will gate this."
+        else
+          echo "CD health OK"
+        fi
+
     - name: Calculate version
       id: version
       env:

--- a/.trivyignore
+++ b/.trivyignore
@@ -3,4 +3,5 @@
 #
 # Format: CVE-ID  # reason — added YYYY-MM-DD, remove by YYYY-MM-DD
 
-CVE-2026-33186  # grpc-go auth bypass in caddy binary — waiting on upstream caddy rebuild with grpc v1.79.3 — added 2026-03-19, remove by 2026-04-19
+CVE-2026-33186  # grpc-go auth bypass in caddy binary — waiting on upstream caddy rebuild with grpc v1.79.3 — added 2026-03-19, remove by 2026-05-19
+CVE-2026-30836  # smallstep/certificates SCEP vuln in caddy binary — we don't use Caddy's ACME/PKI server — added 2026-04-06, remove by 2026-07-06


### PR DESCRIPTION
## Summary

- Adds `CVE-2026-30836` to `.trivyignore` — `github.com/smallstep/certificates v0.30.0-rc4` is a transitive dep of Caddy's built-in PKI/ACME module. The SCEP Update Request auth bypass is not exploitable here since we don't use Caddy's ACME server, only its reverse proxy functionality. Also extends the existing `CVE-2026-33186` ignore expiry (grpc-go, same root cause — upstream Caddy rebuild needed).
- Adds an early CD health check at the start of the release workflow — if 3+ of the last 5 completed CD runs have failed, the release fails fast with a clear message instead of waiting 15 min at "Ensure CD passed on HEAD".

## Context

CD has been failing for several days due to this CVE being added to the Trivy DB. The two recent "successful" CD runs (Dependabot workflow bumps today) skipped the Docker build, so prod `latest` is from the last actual build before the failures started.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, CD should pass (CVE ignored, build proceeds)
- [ ] Release workflow "Check CD health" step visible in next release run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release process reliability by adding an early validation check that detects deployment pipeline issues and prevents releases when critical failures occur.
  * Updated security vulnerability exemption entries with extended removal dates and added a new exemption for ongoing compliance tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->