### PR TITLE
feat(api): enrich Phase 3 candidates_sent with per-candidate AI confidence

### DIFF
--- a/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
@@ -1481,7 +1481,7 @@ class RequestOrchestrator:
                 # Build candidates sent to AI from the ResolutionResult's candidate list
                 ranked_sel = rr_meta.get("ranked_selections", [])
                 ranked_lookup: dict[int, float] = {
-                    s["person_id"]: s["confidence"] for s in ranked_sel if "person_id" in s
+                    s["person_id"]: s["confidence"] for s in ranked_sel if "person_id" in s and "confidence" in s
                 }
                 candidates_sent = (
                     [

--- a/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
@@ -1479,15 +1479,18 @@ class RequestOrchestrator:
             for intent_idx, rr in enumerate(res_list):
                 rr_meta = rr.metadata or {}
                 # Build candidates sent to AI from the ResolutionResult's candidate list
-                ranked_sel = rr_meta.get("ranked_selections", [])
+                ranked_sel = rr_meta.get("ranked_selections") or []
                 ranked_lookup: dict[int, float] = {
-                    s["person_id"]: s["confidence"] for s in ranked_sel if "person_id" in s and "confidence" in s
+                    s["person_id"]: s["confidence"]
+                    for s in ranked_sel
+                    if isinstance(s, dict) and "person_id" in s and "confidence" in s
                 }
                 candidates_sent = (
                     [
                         {
                             "person_cm_id": c.cm_id,
                             "name": c.full_name if hasattr(c, "full_name") else f"{c.first_name} {c.last_name}",
+                            **({"grade": c.grade} if hasattr(c, "grade") and c.grade is not None else {}),
                             **({"ai_confidence": ranked_lookup[c.cm_id]} if c.cm_id in ranked_lookup else {}),
                         }
                         for c in (rr.candidates or [])

--- a/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
@@ -1479,11 +1479,16 @@ class RequestOrchestrator:
             for intent_idx, rr in enumerate(res_list):
                 rr_meta = rr.metadata or {}
                 # Build candidates sent to AI from the ResolutionResult's candidate list
+                ranked_sel = rr_meta.get("ranked_selections", [])
+                ranked_lookup: dict[int, float] = {
+                    s["person_id"]: s["confidence"] for s in ranked_sel if "person_id" in s
+                }
                 candidates_sent = (
                     [
                         {
                             "person_cm_id": c.cm_id,
                             "name": c.full_name if hasattr(c, "full_name") else f"{c.first_name} {c.last_name}",
+                            **({"ai_confidence": ranked_lookup[c.cm_id]} if c.cm_id in ranked_lookup else {}),
                         }
                         for c in (rr.candidates or [])
                     ]

--- a/bunking/sync/bunk_request_processor/services/phase3_disambiguation_service.py
+++ b/bunking/sync/bunk_request_processor/services/phase3_disambiguation_service.py
@@ -292,7 +292,7 @@ class Phase3DisambiguationService:
                                     person=reranked.person,
                                     confidence=reranked.confidence,
                                     method="ai_disambiguation",
-                                    candidates=resolution.candidates,
+                                    candidates=(resolution.candidates or [])[:10],
                                     metadata=result_metadata,
                                 )
                                 case.disambiguation_metadata.setdefault("status", {})[ambiguous_idx] = "success"
@@ -355,7 +355,7 @@ class Phase3DisambiguationService:
                             person=selected_person,
                             confidence=ai_confidence,
                             method="ai_disambiguation",
-                            candidates=resolution.candidates,
+                            candidates=(resolution.candidates or [])[:10],
                             metadata=result_metadata,
                         )
                         case.disambiguation_metadata.setdefault("status", {})[ambiguous_idx] = "success"

--- a/bunking/sync/bunk_request_processor/services/phase3_disambiguation_service.py
+++ b/bunking/sync/bunk_request_processor/services/phase3_disambiguation_service.py
@@ -286,11 +286,13 @@ class Phase3DisambiguationService:
                                     "candidates_considered": num_candidates,
                                     "reranked": True,
                                     "jw_score": reranked.jw_score,
+                                    "ranked_selections": ranked_selections,
                                 }
                                 case.disambiguated_results[ambiguous_idx] = ResolutionResult(
                                     person=reranked.person,
                                     confidence=reranked.confidence,
                                     method="ai_disambiguation",
+                                    candidates=resolution.candidates,
                                     metadata=result_metadata,
                                 )
                                 case.disambiguation_metadata.setdefault("status", {})[ambiguous_idx] = "success"
@@ -353,6 +355,7 @@ class Phase3DisambiguationService:
                             person=selected_person,
                             confidence=ai_confidence,
                             method="ai_disambiguation",
+                            candidates=resolution.candidates,
                             metadata=result_metadata,
                         )
                         case.disambiguation_metadata.setdefault("status", {})[ambiguous_idx] = "success"

--- a/frontend/src/components/pipeline-debug/panels/DetailPanels.test.tsx
+++ b/frontend/src/components/pipeline-debug/panels/DetailPanels.test.tsx
@@ -527,11 +527,23 @@ describe('Phase3Detail', () => {
   it('renders per-candidate ai_confidence when available', () => {
     const withScores: Phase3IntentTrace[] = [
       {
-        ...phase3Reranked[0],
+        target_name: 'Emma Johnson',
+        ran: true,
         candidates_sent: [
           { person_cm_id: 67890, name: 'Emma Johnson', grade: 5, ai_confidence: 0.9 },
           { person_cm_id: 67892, name: 'Emma Johns', grade: 6, ai_confidence: 0.65 },
         ],
+        ai_context: { session: '1', requester_grade: '5' },
+        ai_selection: 67890,
+        ai_reasoning: 'Best match based on session and grade proximity',
+        ai_reasoning_summary: 'Chain-of-thought reasoning from model',
+        result: 'resolved',
+        confidence_before: 0.5,
+        confidence_after: 0.85,
+        reranked: true,
+        jw_score: 0.92,
+        ai_confidence: 0.9,
+        no_match_signal: false,
       },
     ]
     render(<Phase3Detail data={withScores} {...defaultActions} />)

--- a/frontend/src/components/pipeline-debug/panels/DetailPanels.test.tsx
+++ b/frontend/src/components/pipeline-debug/panels/DetailPanels.test.tsx
@@ -514,7 +514,7 @@ describe('Phase3Detail', () => {
     expect(screen.queryByText('JW Score')).not.toBeInTheDocument()
   })
 
-  it('renders structured candidate cards with name and cm_id', () => {
+  it('renders structured candidate cards with name, cm_id, and grade', () => {
     render(<Phase3Detail data={phase3Reranked} {...defaultActions} />)
     // CollapsibleSection button includes the count in the title
     const toggle = screen.getByRole('button', { name: /Candidates Sent/i })
@@ -522,6 +522,8 @@ describe('Phase3Detail', () => {
     // Name appears multiple times (Target row + candidate card) — getAllByText is intentional
     expect(screen.getAllByText('Emma Johnson').length).toBeGreaterThanOrEqual(1)
     expect(screen.getByText('#67890')).toBeInTheDocument()
+    expect(screen.getByText('Grade: 5')).toBeInTheDocument()
+    expect(screen.getByText('Grade: 6')).toBeInTheDocument()
   })
 
   it('renders per-candidate ai_confidence when available', () => {

--- a/frontend/src/components/pipeline-debug/panels/DetailPanels.test.tsx
+++ b/frontend/src/components/pipeline-debug/panels/DetailPanels.test.tsx
@@ -5,7 +5,7 @@
  * multi-intent tabs (P2, P3, Post), action buttons, and confirmation dialog.
  */
 
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi } from 'vitest'
 import { PrePhase1Detail } from './PrePhase1Detail'
@@ -512,6 +512,42 @@ describe('Phase3Detail', () => {
     render(<Phase3Detail data={phase3Intents} {...defaultActions} />)
     expect(screen.queryByText('Reranked')).not.toBeInTheDocument()
     expect(screen.queryByText('JW Score')).not.toBeInTheDocument()
+  })
+
+  it('renders structured candidate cards with name and cm_id', () => {
+    render(<Phase3Detail data={phase3Reranked} {...defaultActions} />)
+    // CollapsibleSection button includes the count in the title
+    const toggle = screen.getByRole('button', { name: /Candidates Sent/i })
+    fireEvent.click(toggle)
+    // Name appears multiple times (Target row + candidate card) — getAllByText is intentional
+    expect(screen.getAllByText('Emma Johnson').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('#67890')).toBeInTheDocument()
+  })
+
+  it('renders per-candidate ai_confidence when available', () => {
+    const withScores: Phase3IntentTrace[] = [
+      {
+        ...phase3Reranked[0],
+        candidates_sent: [
+          { person_cm_id: 67890, name: 'Emma Johnson', grade: 5, ai_confidence: 0.9 },
+          { person_cm_id: 67892, name: 'Emma Johns', grade: 6, ai_confidence: 0.65 },
+        ],
+      },
+    ]
+    render(<Phase3Detail data={withScores} {...defaultActions} />)
+    const toggle = screen.getByRole('button', { name: /Candidates Sent/i })
+    fireEvent.click(toggle)
+    expect(screen.getByText('AI: 0.90')).toBeInTheDocument()
+    expect(screen.getByText('AI: 0.65')).toBeInTheDocument()
+  })
+
+  it('renders candidate cards without scores for legacy traces', () => {
+    render(<Phase3Detail data={phase3Intents} {...defaultActions} />)
+    const toggle = screen.getByRole('button', { name: /Candidates Sent/i })
+    fireEvent.click(toggle)
+    // Name appears multiple times (Target row + candidate card) — getAllByText is intentional
+    expect(screen.getAllByText('Emma Johnson').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('#67890')).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/components/pipeline-debug/panels/DetailPanels.test.tsx
+++ b/frontend/src/components/pipeline-debug/panels/DetailPanels.test.tsx
@@ -532,7 +532,7 @@ describe('Phase3Detail', () => {
         candidates_sent: [
           { person_cm_id: 67890, name: 'Emma Johnson', grade: 5, ai_confidence: 0.9 },
           { person_cm_id: 67892, name: 'Emma Johns', grade: 6, ai_confidence: 0.65 },
-        ],
+        ] as Array<Record<string, unknown>>,
         ai_context: { session: '1', requester_grade: '5' },
         ai_selection: 67890,
         ai_reasoning: 'Best match based on session and grade proximity',

--- a/frontend/src/components/pipeline-debug/panels/Phase3Detail.tsx
+++ b/frontend/src/components/pipeline-debug/panels/Phase3Detail.tsx
@@ -105,9 +105,31 @@ function IntentPanel({ intent }: { intent: Phase3IntentTrace }) {
             {intent.candidates_sent.length === 0 ? (
               <p className="text-muted-foreground text-xs">No candidates</p>
             ) : (
-              <pre className="text-foreground max-h-48 overflow-auto text-xs">
-                {JSON.stringify(intent.candidates_sent, null, 2)}
-              </pre>
+              <div className="space-y-2">
+                {intent.candidates_sent.map((c, idx) => {
+                  const cmId = c.person_cm_id as number
+                  const name = c.name as string
+                  const grade = c.grade as number | undefined
+                  const aiConf = c.ai_confidence as number | undefined
+                  const isSelected = cmId === intent.ai_selection
+                  return (
+                    <div
+                      key={idx}
+                      className={`rounded border p-2 text-xs ${isSelected ? 'border-blue-300 bg-blue-50 dark:border-blue-700 dark:bg-blue-900/20' : 'border-border'}`}
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className="text-foreground font-medium">{name}</span>
+                        <span className="text-muted-foreground">#{cmId}</span>
+                        {isSelected && <Badge label="Selected" color="blue" />}
+                      </div>
+                      <div className="text-muted-foreground mt-1 flex flex-wrap gap-2">
+                        {grade != null && <span>Grade: {grade}</span>}
+                        {aiConf != null && <span>AI: {aiConf.toFixed(2)}</span>}
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
             )}
           </CollapsibleSection>
 

--- a/frontend/src/components/pipeline-debug/panels/Phase3Detail.tsx
+++ b/frontend/src/components/pipeline-debug/panels/Phase3Detail.tsx
@@ -107,10 +107,10 @@ function IntentPanel({ intent }: { intent: Phase3IntentTrace }) {
             ) : (
               <div className="space-y-2">
                 {intent.candidates_sent.map((c, idx) => {
-                  const cmId = c.person_cm_id as number
-                  const name = c.name as string
-                  const grade = c.grade as number | undefined
-                  const aiConf = c.ai_confidence as number | undefined
+                  const cmId = c['person_cm_id'] as number
+                  const name = c['name'] as string
+                  const grade = c['grade'] as number | undefined
+                  const aiConf = c['ai_confidence'] as number | undefined
                   const isSelected = cmId === intent.ai_selection
                   return (
                     <div

--- a/frontend/src/components/pipeline-debug/panels/Phase3Detail.tsx
+++ b/frontend/src/components/pipeline-debug/panels/Phase3Detail.tsx
@@ -110,7 +110,8 @@ function IntentPanel({ intent }: { intent: Phase3IntentTrace }) {
                   const cmId = c['person_cm_id'] as number
                   const name = c['name'] as string
                   const grade = c['grade'] as number | undefined
-                  const aiConf = c['ai_confidence'] as number | undefined
+                  const aiConf =
+                    typeof c['ai_confidence'] === 'number' ? c['ai_confidence'] : undefined
                   const isSelected = cmId === intent.ai_selection
                   return (
                     <div

--- a/tests/unit/sync/bunk_request_processor/orchestrator/test_phase3_trace_result.py
+++ b/tests/unit/sync/bunk_request_processor/orchestrator/test_phase3_trace_result.py
@@ -95,11 +95,14 @@ def _run_current_trace_logic(
         pre_confs = pre_phase3_confidences.get(trace_key, [])
         for intent_idx, rr in enumerate(res_list):
             rr_meta = rr.metadata or {}
+            ranked_sel = rr_meta.get("ranked_selections", [])
+            ranked_lookup: dict[int, float] = {s["person_id"]: s["confidence"] for s in ranked_sel if "person_id" in s}
             candidates_sent = (
                 [
                     {
                         "person_cm_id": c.cm_id,
                         "name": (c.full_name if hasattr(c, "full_name") else f"{c.first_name} {c.last_name}"),
+                        **({"ai_confidence": ranked_lookup[c.cm_id]} if c.cm_id in ranked_lookup else {}),
                     }
                     for c in (rr.candidates or [])
                 ]
@@ -318,3 +321,63 @@ class TestPhase3TraceRerankerFields:
         assert traces[0].jw_score is None
         assert traces[0].ai_confidence is None
         assert traces[0].no_match_signal is False
+
+    def test_candidates_sent_enriched_with_ai_confidence(self):
+        """When ranked_selections is in metadata, candidates_sent should include ai_confidence."""
+        mock_person_1 = MagicMock()
+        mock_person_1.cm_id = 67890
+        mock_person_1.full_name = "Olivia Chen"
+
+        mock_person_2 = MagicMock()
+        mock_person_2.cm_id = 67892
+        mock_person_2.full_name = "Olivia Chang"
+
+        rr = ResolutionResult(
+            person=mock_person_1,
+            confidence=0.85,
+            method="ai_disambiguation",
+            target_name="Olivia Chen",
+            candidates=[mock_person_1, mock_person_2],
+            metadata={
+                "reranked": True,
+                "jw_score": 0.92,
+                "ai_confidence": 0.90,
+                "ranked_selections": [
+                    {"person_id": 67890, "confidence": 0.90, "reasoning": "Best match"},
+                    {"person_id": 67892, "confidence": 0.65, "reasoning": "Similar name"},
+                ],
+            },
+        )
+
+        traces = _run_current_trace_logic(rr)
+
+        assert len(traces) == 1
+        cs = traces[0].candidates_sent
+        assert len(cs) == 2
+        assert cs[0]["person_cm_id"] == 67890
+        assert cs[0]["ai_confidence"] == 0.90
+        assert cs[1]["person_cm_id"] == 67892
+        assert cs[1]["ai_confidence"] == 0.65
+
+    def test_candidates_sent_no_enrichment_without_ranked_selections(self):
+        """Without ranked_selections, candidates_sent should only have cm_id and name."""
+        mock_person = MagicMock()
+        mock_person.cm_id = 67890
+        mock_person.full_name = "Olivia Chen"
+
+        rr = ResolutionResult(
+            person=mock_person,
+            confidence=0.90,
+            method="ai_disambiguation",
+            target_name="Olivia Chen",
+            candidates=[mock_person],
+            metadata={"ai_confidence": 0.90},
+        )
+
+        traces = _run_current_trace_logic(rr)
+
+        assert len(traces) == 1
+        cs = traces[0].candidates_sent
+        assert len(cs) == 1
+        assert cs[0]["person_cm_id"] == 67890
+        assert "ai_confidence" not in cs[0]

--- a/tests/unit/sync/bunk_request_processor/orchestrator/test_phase3_trace_result.py
+++ b/tests/unit/sync/bunk_request_processor/orchestrator/test_phase3_trace_result.py
@@ -96,7 +96,9 @@ def _run_current_trace_logic(
         for intent_idx, rr in enumerate(res_list):
             rr_meta = rr.metadata or {}
             ranked_sel = rr_meta.get("ranked_selections", [])
-            ranked_lookup: dict[int, float] = {s["person_id"]: s["confidence"] for s in ranked_sel if "person_id" in s}
+            ranked_lookup: dict[int, float] = {
+                s["person_id"]: s["confidence"] for s in ranked_sel if "person_id" in s and "confidence" in s
+            }
             candidates_sent = (
                 [
                     {

--- a/tests/unit/sync/bunk_request_processor/orchestrator/test_phase3_trace_result.py
+++ b/tests/unit/sync/bunk_request_processor/orchestrator/test_phase3_trace_result.py
@@ -95,15 +95,18 @@ def _run_current_trace_logic(
         pre_confs = pre_phase3_confidences.get(trace_key, [])
         for intent_idx, rr in enumerate(res_list):
             rr_meta = rr.metadata or {}
-            ranked_sel = rr_meta.get("ranked_selections", [])
+            ranked_sel = rr_meta.get("ranked_selections") or []
             ranked_lookup: dict[int, float] = {
-                s["person_id"]: s["confidence"] for s in ranked_sel if "person_id" in s and "confidence" in s
+                s["person_id"]: s["confidence"]
+                for s in ranked_sel
+                if isinstance(s, dict) and "person_id" in s and "confidence" in s
             }
             candidates_sent = (
                 [
                     {
                         "person_cm_id": c.cm_id,
                         "name": (c.full_name if hasattr(c, "full_name") else f"{c.first_name} {c.last_name}"),
+                        **({"grade": c.grade} if hasattr(c, "grade") and c.grade is not None else {}),
                         **({"ai_confidence": ranked_lookup[c.cm_id]} if c.cm_id in ranked_lookup else {}),
                     }
                     for c in (rr.candidates or [])
@@ -325,14 +328,16 @@ class TestPhase3TraceRerankerFields:
         assert traces[0].no_match_signal is False
 
     def test_candidates_sent_enriched_with_ai_confidence(self):
-        """When ranked_selections is in metadata, candidates_sent should include ai_confidence."""
+        """When ranked_selections is in metadata, candidates_sent should include ai_confidence and grade."""
         mock_person_1 = MagicMock()
         mock_person_1.cm_id = 67890
         mock_person_1.full_name = "Olivia Chen"
+        mock_person_1.grade = 7
 
         mock_person_2 = MagicMock()
         mock_person_2.cm_id = 67892
         mock_person_2.full_name = "Olivia Chang"
+        mock_person_2.grade = 8
 
         rr = ResolutionResult(
             person=mock_person_1,
@@ -358,14 +363,17 @@ class TestPhase3TraceRerankerFields:
         assert len(cs) == 2
         assert cs[0]["person_cm_id"] == 67890
         assert cs[0]["ai_confidence"] == 0.90
+        assert cs[0]["grade"] == 7
         assert cs[1]["person_cm_id"] == 67892
         assert cs[1]["ai_confidence"] == 0.65
+        assert cs[1]["grade"] == 8
 
     def test_candidates_sent_no_enrichment_without_ranked_selections(self):
-        """Without ranked_selections, candidates_sent should only have cm_id and name."""
+        """Without ranked_selections, candidates_sent should only have cm_id, name, and grade."""
         mock_person = MagicMock()
         mock_person.cm_id = 67890
         mock_person.full_name = "Olivia Chen"
+        mock_person.grade = 6
 
         rr = ResolutionResult(
             person=mock_person,
@@ -382,4 +390,5 @@ class TestPhase3TraceRerankerFields:
         cs = traces[0].candidates_sent
         assert len(cs) == 1
         assert cs[0]["person_cm_id"] == 67890
+        assert cs[0]["grade"] == 6
         assert "ai_confidence" not in cs[0]


### PR DESCRIPTION
## Summary

- Pass `ranked_selections` through `rr.metadata` from disambiguation service so per-candidate AI confidence is available at trace emission time
- Preserve `candidates` on disambiguated `ResolutionResult` objects (previously dropped, leaving `candidates_sent` empty in traces)
- Enrich `candidates_sent` dicts with `ai_confidence` per candidate when `ranked_selections` is present
- Replace raw `JSON.stringify` dump in Phase3Detail with structured candidate cards (name, #cm_id, grade, AI confidence, selected highlight)
- Guard `ranked_lookup` comprehension with both `person_id` and `confidence` key checks

Closes the remaining gaps from #882 that PR #883 left unaddressed (per-candidate score enrichment + structured candidate display).

## Test plan

- [x] 12/12 Phase3 trace result tests pass (2 new: enriched candidates, no-enrichment backward compat)
- [x] 36/36 frontend DetailPanels tests pass (3 new: structured cards, ai_confidence display, legacy trace compat)
- [x] ruff format/check clean
- [x] TypeScript `tsc --noEmit` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phase 3 debug panel now shows candidates as individual cards (name, ID, conditional grade and AI confidence), highlights the selected candidate, and displays up to the top 10 candidates.

* **Tests**
  * Added tests covering candidate rendering, conditional AI confidence/grade display, and legacy (non-scored) behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->