### PR TITLE
feat(frontend): add disposition friendly labels and move reciprocal badge

### DIFF
--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -47,6 +47,7 @@ import CamperLink from './CamperLink'
 import { getAvatarColor, getInitial } from '../utils/avatarUtils'
 import { getLocationDisplay } from '../utils/addressUtils'
 import { sortEnrolledFirst } from '../utils/enrollmentSort'
+import { MUTUAL_BADGE_CLASSES } from '../utils/dispositionColors'
 import {
   getStatusIndicator,
   filterEnrollmentsByStatus,
@@ -932,9 +933,7 @@ export default function CamperDetailsPanel({
 
                         {/* Reciprocal badge - only if reciprocal */}
                         {request.is_reciprocal && (
-                          <span className="bg-forest-100 dark:bg-forest-900/50 text-forest-700 dark:text-forest-300 flex-shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium">
-                            mutual
-                          </span>
+                          <span className={MUTUAL_BADGE_CLASSES}>mutual</span>
                         )}
 
                         {/* Satisfaction - concise icon only */}

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -34,6 +34,7 @@ import {
   formatDispositionReason,
   CONFIDENCE_AUTO_ACCEPT,
   CONFIDENCE_RESOLVED,
+  MUTUAL_BADGE_CLASSES,
 } from '../utils/dispositionColors'
 import EditableRequestType from './EditableRequestType'
 import EditableRequestTarget from './EditableRequestTarget'
@@ -1122,9 +1123,7 @@ export default function RequestReviewPanel({
                                 )}
                               </button>
                               {request.is_reciprocal && (
-                                <span className="bg-forest-100 dark:bg-forest-900/50 text-forest-700 dark:text-forest-300 flex-shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium">
-                                  mutual
-                                </span>
+                                <span className={MUTUAL_BADGE_CLASSES}>mutual</span>
                               )}
                             </div>
                             <div className="text-muted-foreground mt-0.5 text-xs">
@@ -1362,9 +1361,7 @@ export default function RequestReviewPanel({
                               )}
                             </button>
                             {request.is_reciprocal && (
-                              <span className="bg-forest-100 dark:bg-forest-900/50 text-forest-700 dark:text-forest-300 flex-shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium">
-                                mutual
-                              </span>
+                              <span className={MUTUAL_BADGE_CLASSES}>mutual</span>
                             )}
                           </div>
                           <div
@@ -1773,9 +1770,7 @@ export default function RequestReviewPanel({
                       </span>
                     )
                   )}
-                  <span className="bg-forest-100 dark:bg-forest-900/50 text-forest-700 dark:text-forest-300 rounded-full px-1.5 py-0.5 text-[10px] font-medium">
-                    mutual
-                  </span>
+                  <span className={MUTUAL_BADGE_CLASSES}>mutual</span>
                 </div>
               </div>
               <div>

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -1104,22 +1104,29 @@ export default function RequestReviewPanel({
 
                           {/* Main info: Requester name and type */}
                           <div className="card-main">
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation()
-                                setSelectedCamperId(String(request.requester_id))
-                              }}
-                              className="hover:text-primary text-left font-medium transition-colors hover:underline"
-                            >
-                              {requester
-                                ? `${requester.first_name || ''} ${requester.last_name || ''}`
-                                : `Person ${request.requester_id}`}
-                              {requester?.grade != null && requester.grade > 0 && (
-                                <span className="text-muted-foreground ml-1 text-xs font-normal">
-                                  ({formatGradeOrdinal(requester.grade)})
+                            <div className="flex items-center gap-1.5">
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  setSelectedCamperId(String(request.requester_id))
+                                }}
+                                className="hover:text-primary text-left font-medium transition-colors hover:underline"
+                              >
+                                {requester
+                                  ? `${requester.first_name || ''} ${requester.last_name || ''}`
+                                  : `Person ${request.requester_id}`}
+                                {requester?.grade != null && requester.grade > 0 && (
+                                  <span className="text-muted-foreground ml-1 text-xs font-normal">
+                                    ({formatGradeOrdinal(requester.grade)})
+                                  </span>
+                                )}
+                              </button>
+                              {request.is_reciprocal && (
+                                <span className="bg-forest-100 dark:bg-forest-900/50 text-forest-700 dark:text-forest-300 flex-shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium">
+                                  mutual
                                 </span>
                               )}
-                            </button>
+                            </div>
                             <div className="text-muted-foreground mt-0.5 text-xs">
                               {getRequestTypeLabel(request.request_type)}
                             </div>
@@ -1336,7 +1343,7 @@ export default function RequestReviewPanel({
                               className="rounded"
                             />
                           </div>
-                          <div className="flex items-center px-4 py-3">
+                          <div className="flex items-center gap-1.5 px-4 py-3">
                             <button
                               onClick={(e) => {
                                 e.stopPropagation()
@@ -1354,6 +1361,11 @@ export default function RequestReviewPanel({
                                 </span>
                               )}
                             </button>
+                            {request.is_reciprocal && (
+                              <span className="bg-forest-100 dark:bg-forest-900/50 text-forest-700 dark:text-forest-300 flex-shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium">
+                                mutual
+                              </span>
+                            )}
                           </div>
                           <div
                             className="flex items-center px-4 py-3"
@@ -1418,11 +1430,6 @@ export default function RequestReviewPanel({
                               </span>
                             ) : (
                               <span className="text-muted-foreground text-xs">—</span>
-                            )}
-                            {request.is_reciprocal && (
-                              <span className="rounded bg-sky-100 px-1 py-0.5 text-[9px] font-bold text-sky-700 dark:bg-sky-900/40 dark:text-sky-400">
-                                Recip
-                              </span>
                             )}
                           </div>
                           <div
@@ -1687,11 +1694,6 @@ export default function RequestReviewPanel({
                               {/* Metadata */}
                               <div className="text-muted-foreground flex flex-wrap items-center gap-3 text-xs">
                                 <span>Source: {request.source}</span>
-                                {request.is_reciprocal && (
-                                  <span className="rounded bg-sky-100 px-1.5 py-0.5 text-[10px] font-bold text-sky-700 dark:bg-sky-900/40 dark:text-sky-400">
-                                    Reciprocal
-                                  </span>
-                                )}
                                 {request.disposition_reason && (
                                   <span
                                     className={clsx(
@@ -1771,8 +1773,8 @@ export default function RequestReviewPanel({
                       </span>
                     )
                   )}
-                  <span className="rounded bg-sky-100 px-1 py-0.5 text-[9px] font-bold text-sky-700 dark:bg-sky-900/40 dark:text-sky-400">
-                    Recip
+                  <span className="bg-forest-100 dark:bg-forest-900/50 text-forest-700 dark:text-forest-300 rounded-full px-1.5 py-0.5 text-[10px] font-medium">
+                    mutual
                   </span>
                 </div>
               </div>

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -1104,13 +1104,13 @@ export default function RequestReviewPanel({
 
                           {/* Main info: Requester name and type */}
                           <div className="card-main">
-                            <div className="flex items-center gap-1.5">
+                            <div className="flex min-w-0 items-center gap-1.5">
                               <button
                                 onClick={(e) => {
                                   e.stopPropagation()
                                   setSelectedCamperId(String(request.requester_id))
                                 }}
-                                className="hover:text-primary text-left font-medium transition-colors hover:underline"
+                                className="hover:text-primary min-w-0 text-left font-medium transition-colors hover:underline"
                               >
                                 {requester
                                   ? `${requester.first_name || ''} ${requester.last_name || ''}`
@@ -1343,7 +1343,7 @@ export default function RequestReviewPanel({
                               className="rounded"
                             />
                           </div>
-                          <div className="flex items-center gap-1.5 px-4 py-3">
+                          <div className="flex min-w-0 items-center gap-1.5 px-4 py-3">
                             <button
                               onClick={(e) => {
                                 e.stopPropagation()

--- a/frontend/src/utils/dispositionColors.test.ts
+++ b/frontend/src/utils/dispositionColors.test.ts
@@ -155,12 +155,42 @@ describe('getDispositionSortRank', () => {
 })
 
 describe('formatDispositionReason', () => {
-  it('replaces underscores with spaces', () => {
-    expect(formatDispositionReason('exact_match')).toBe('exact match')
-    expect(formatDispositionReason('target_not_attending')).toBe('target not attending')
+  describe('resolved reasons', () => {
+    it.each([
+      ['exact_match', 'Matched'],
+      ['high_confidence_match', 'Matched'],
+      ['auto_resolved', 'Matched'],
+      ['reciprocal_match', 'Mutual match'],
+      ['cross_session_satisfied', 'Different sessions (neg)'],
+      ['directional_preference', 'Age preference'],
+    ])('maps %s to "%s"', (reason, expected) => {
+      expect(formatDispositionReason(reason)).toBe(expected)
+    })
   })
 
-  it('returns single-word reasons unchanged', () => {
+  describe('pending reasons', () => {
+    it.each([
+      ['needs_review', 'Needs review'],
+      ['target_waitlisted', 'Waitlisted'],
+      ['undirected_preference', 'Unclear age preference'],
+    ])('maps %s to "%s"', (reason, expected) => {
+      expect(formatDispositionReason(reason)).toBe(expected)
+    })
+  })
+
+  describe('declined reasons', () => {
+    it.each([
+      ['session_mismatch', 'Different sessions'],
+      ['target_not_attending', 'Not attending'],
+      ['target_not_enrolled', 'Not enrolled'],
+      ['requester_not_attending', 'Requester not attending'],
+    ])('maps %s to "%s"', (reason, expected) => {
+      expect(formatDispositionReason(reason)).toBe(expected)
+    })
+  })
+
+  it('falls back to underscore replacement for unknown values', () => {
+    expect(formatDispositionReason('some_unknown_reason')).toBe('some unknown reason')
     expect(formatDispositionReason('other')).toBe('other')
   })
 })

--- a/frontend/src/utils/dispositionColors.test.ts
+++ b/frontend/src/utils/dispositionColors.test.ts
@@ -193,6 +193,15 @@ describe('formatDispositionReason', () => {
     expect(formatDispositionReason('some_unknown_reason')).toBe('some unknown reason')
     expect(formatDispositionReason('other')).toBe('other')
   })
+
+  it('has an explicit display name for every known disposition reason', () => {
+    const allReasons = [...RESOLVED_REASONS, ...PENDING_REASONS, ...DECLINED_REASONS]
+    for (const reason of allReasons) {
+      const display = formatDispositionReason(reason)
+      const fallback = reason.replace(/_/g, ' ')
+      expect(display, `${reason} is missing from DISPOSITION_DISPLAY_NAMES`).not.toBe(fallback)
+    }
+  })
 })
 
 describe('confidence constants', () => {

--- a/frontend/src/utils/dispositionColors.ts
+++ b/frontend/src/utils/dispositionColors.ts
@@ -67,6 +67,10 @@ export function getConfidenceClasses(confidence: number): string {
   return BADGE_COLORS.danger
 }
 
+/** Tailwind classes for the "mutual" reciprocal badge. */
+export const MUTUAL_BADGE_CLASSES =
+  'bg-forest-100 dark:bg-forest-900/50 text-forest-700 dark:text-forest-300 flex-shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium'
+
 /** Friendly display names for disposition reasons. */
 const DISPOSITION_DISPLAY_NAMES: Record<string, string> = {
   // Resolved

--- a/frontend/src/utils/dispositionColors.ts
+++ b/frontend/src/utils/dispositionColors.ts
@@ -67,9 +67,29 @@ export function getConfidenceClasses(confidence: number): string {
   return BADGE_COLORS.danger
 }
 
-/** Format a snake_case disposition reason for display. */
+/** Friendly display names for disposition reasons. */
+const DISPOSITION_DISPLAY_NAMES: Record<string, string> = {
+  // Resolved
+  exact_match: 'Matched',
+  high_confidence_match: 'Matched',
+  auto_resolved: 'Matched',
+  reciprocal_match: 'Mutual match',
+  cross_session_satisfied: 'Different sessions (neg)',
+  directional_preference: 'Age preference',
+  // Pending
+  needs_review: 'Needs review',
+  target_waitlisted: 'Waitlisted',
+  undirected_preference: 'Unclear age preference',
+  // Declined
+  session_mismatch: 'Different sessions',
+  target_not_attending: 'Not attending',
+  target_not_enrolled: 'Not enrolled',
+  requester_not_attending: 'Requester not attending',
+}
+
+/** Format a disposition reason for display using friendly names. */
 export function formatDispositionReason(reason: string): string {
-  return reason.replace(/_/g, ' ')
+  return DISPOSITION_DISPLAY_NAMES[reason] ?? reason.replace(/_/g, ' ')
 }
 
 /** Sort rank for disposition reasons: declined (0) < pending (1) < resolved (2) < unknown (3). */


### PR DESCRIPTION
## Summary

- Add a `formatDispositionReason()` mapping utility that converts internal snake_case disposition values to user-friendly display labels (e.g. `exact_match` → "Matched", `target_waitlisted` → "Waitlisted", `session_mismatch` → "Different sessions")
- Move the reciprocal badge from the disposition column to next to the requester name, rendering as a green "mutual" pill — matching the existing pattern in CamperDetailsPanel
- Update the help legend badge to match the new "mutual" style

## Test plan

- [x] 40 unit tests pass for `dispositionColors.ts` — covers all 13 disposition mappings, fallback behavior, sort ranking, color classes, and reason sets
- [x] TypeScript compilation passes with no errors
- [ ] Visual check: disposition column shows friendly labels instead of raw snake_case
- [ ] Visual check: "mutual" badge appears next to requester name (not in disposition column) for reciprocal requests
- [ ] Visual check: help legend shows updated "mutual" pill style

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Updates**
  * Redesigned and repositioned the "mutual" badge across mobile and desktop request cards for consistent placement; removed several legacy reciprocal badges and added a persistent mutual indicator on the main card.

* **Improvements**
  * Disposition reasons now use friendly, human-readable labels (e.g., "Mutual match") with a sensible fallback to underscore-to-space formatting for unknown values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->