### PR TITLE
feat(frontend,api): pipeline debug search, pagination, reprocess, and [object Object] fix

### DIFF
--- a/api/routers/debug.py
+++ b/api/routers/debug.py
@@ -1624,7 +1624,10 @@ async def run_from_phase(
 ) -> PhaseRunResponse:
     """Cascade from a specified phase through all remaining phases.
 
-    Supports dry_run (default True). When dry_run=False, writes to production.
+    Dry-run only; production writes are supported exclusively via
+    ``/run-full-trace``. ``body.dry_run`` is accepted for API compatibility
+    and forwarded to the runner, but this endpoint does not write to
+    production regardless of its value.
     """
     if phase not in VALID_CASCADE_PHASES:
         raise HTTPException(

--- a/api/routers/debug.py
+++ b/api/routers/debug.py
@@ -1330,9 +1330,16 @@ def get_pipeline_run_summary(
     max_confidence: float | None = Query(default=None, ge=0.0, le=1.0),
     sort: str = Query(default="-final_confidence"),
     search: str | None = Query(default=None, max_length=100),
+    fetch_all: bool = Query(default=False),
     user: AuthUser = Depends(require_admin),
 ) -> PipelineSummaryResponse:
-    """Get summary rows for a run with PB-native filtering/sort/pagination."""
+    """Get summary rows for a run with PB-native filtering/sort/pagination.
+
+    When ``fetch_all=true``, returns every row for the run in a single
+    response using PocketBase's ``get_full_list``, bypassing ``page`` and
+    ``per_page``. This powers the client-side filter/sort/virtualized-scroll
+    batch list UI (see PipelineBatchList.tsx).
+    """
     _validate_run_id(run_id)
     filter_parts = [f'run_id = "{run_id}"']
 
@@ -1363,6 +1370,18 @@ def get_pipeline_run_summary(
             filter_parts.append(f'(requester_name ~ "{safe_search}" || target_name ~ "{safe_search}")')
 
     filter_str = " && ".join(filter_parts)
+
+    if fetch_all:
+        records = pb.collection(DEBUG_PIPELINE_SUMMARY).get_full_list(
+            query_params={"filter": filter_str, "sort": sort},
+        )
+        items = [_pb_record_to_summary_item(r) for r in records]
+        return PipelineSummaryResponse(
+            items=items,
+            total=len(items),
+            page=1,
+            per_page=len(items) or 1,
+        )
 
     result = pb.collection(DEBUG_PIPELINE_SUMMARY).get_list(
         page=page,

--- a/api/routers/debug.py
+++ b/api/routers/debug.py
@@ -1328,17 +1328,17 @@ def get_pipeline_run_summary(
     session_cm_id: int | None = Query(default=None, ge=1),
     min_confidence: float | None = Query(default=None, ge=0.0, le=1.0),
     max_confidence: float | None = Query(default=None, ge=0.0, le=1.0),
-    sort: str = Query(default="-final_confidence"),
     search: str | None = Query(default=None, max_length=100),
     fetch_all: bool = Query(default=False),
     user: AuthUser = Depends(require_admin),
 ) -> PipelineSummaryResponse:
-    """Get summary rows for a run with PB-native filtering/sort/pagination.
+    """Get summary rows for a run with PB-native filtering/pagination.
 
     When ``fetch_all=true``, returns every row for the run in a single
     response using PocketBase's ``get_full_list``, bypassing ``page`` and
     ``per_page``. This powers the client-side filter/sort/virtualized-scroll
-    batch list UI (see PipelineBatchList.tsx).
+    batch list UI (see PipelineBatchList.tsx). Server-side sort is fixed
+    (``-final_confidence``) since the client re-sorts in memory anyway.
     """
     _validate_run_id(run_id)
     filter_parts = [f'run_id = "{run_id}"']
@@ -1373,7 +1373,7 @@ def get_pipeline_run_summary(
 
     if fetch_all:
         records = pb.collection(DEBUG_PIPELINE_SUMMARY).get_full_list(
-            query_params={"filter": filter_str, "sort": sort},
+            query_params={"filter": filter_str, "sort": "-final_confidence"},
         )
         items = [_pb_record_to_summary_item(r) for r in records]
         return PipelineSummaryResponse(
@@ -1386,7 +1386,7 @@ def get_pipeline_run_summary(
     result = pb.collection(DEBUG_PIPELINE_SUMMARY).get_list(
         page=page,
         per_page=per_page,
-        query_params={"filter": filter_str, "sort": sort},
+        query_params={"filter": filter_str, "sort": "-final_confidence"},
     )
 
     items = [_pb_record_to_summary_item(r) for r in result.items]

--- a/api/routers/debug.py
+++ b/api/routers/debug.py
@@ -1319,7 +1319,7 @@ def toggle_pipeline_run_pin(
 def get_pipeline_run_summary(
     run_id: str,
     page: int = Query(default=1, ge=1),
-    per_page: int = Query(default=50, ge=1, le=200),
+    per_page: int = Query(default=50, ge=1, le=500),
     final_status: str | None = Query(default=None),
     resolution_method: str | None = Query(default=None),
     source_field: str | None = Query(default=None),
@@ -1329,6 +1329,7 @@ def get_pipeline_run_summary(
     min_confidence: float | None = Query(default=None, ge=0.0, le=1.0),
     max_confidence: float | None = Query(default=None, ge=0.0, le=1.0),
     sort: str = Query(default="-final_confidence"),
+    search: str | None = Query(default=None, max_length=100),
     user: AuthUser = Depends(require_admin),
 ) -> PipelineSummaryResponse:
     """Get summary rows for a run with PB-native filtering/sort/pagination."""
@@ -1355,6 +1356,11 @@ def get_pipeline_run_summary(
         filter_parts.append(f"final_confidence >= {min_confidence}")
     if max_confidence is not None:
         filter_parts.append(f"final_confidence <= {max_confidence}")
+    if search:
+        # Sanitize: strip quotes to prevent PB filter injection
+        safe_search = search.replace('"', "").replace("'", "").strip()
+        if safe_search:
+            filter_parts.append(f'(requester_name ~ "{safe_search}" || target_name ~ "{safe_search}")')
 
     filter_str = " && ".join(filter_parts)
 

--- a/bunking/sync/bunk_request_processor/debug/phase_runner.py
+++ b/bunking/sync/bunk_request_processor/debug/phase_runner.py
@@ -130,11 +130,17 @@ class PhaseRunner:
         Loads prior phase outputs from trace_data for upstream phases,
         runs the specified phase and all downstream phases.
 
+        Dry-run only — production writes are exclusively handled by
+        ``run_full_trace`` (via ``RequestOrchestrator``). The ``dry_run``
+        parameter is retained for API compatibility and is forwarded to
+        downstream phases, but this method never writes to production.
+
         Args:
             phase: Phase to start from ("phase1", "phase2", "phase3").
             trace_data: Existing trace data with upstream phase results.
             parse_requests: Parse requests for phase1 start (if phase="phase1").
-            dry_run: If True (default), do not write to production.
+            dry_run: Forwarded to downstream phases; this method does not write
+                to production regardless.
             stop_at_phase: If set, stop after this phase completes. Must be at or
                 after the start phase in PHASE_ORDER. None runs all remaining phases.
 
@@ -197,13 +203,6 @@ class PhaseRunner:
             phase3_input = self._reconstruct_ambiguous_from_trace(trace_data)
             phase3_results = await self.run_phase3(phase3_input)
             result["phase3_results"] = phase3_results
-
-        # Production write mode (only for cascades, not single-phase)
-        if not dry_run:
-            logger.info("PhaseRunner: production write mode — saving results")
-            # This would call _save_bunk_requests and mark_as_processed
-            # Implementation deferred to when request building is wired up
-            result["production_write"] = True
 
         return result
 

--- a/frontend/src/components/pipeline-debug/PipelineBatchList.test.tsx
+++ b/frontend/src/components/pipeline-debug/PipelineBatchList.test.tsx
@@ -421,7 +421,7 @@ describe('PipelineBatchList', () => {
       expect(searchInput).toBeInTheDocument()
     })
 
-    it('calls onFiltersChange with search value on input change', async () => {
+    it('calls onFiltersChange with search value on input change (2+ chars)', async () => {
       vi.useFakeTimers({ shouldAdvanceTime: true })
       try {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
@@ -439,6 +439,22 @@ describe('PipelineBatchList', () => {
         vi.useRealTimers()
       }
     })
+
+    it('does NOT trigger search for single character input', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true })
+      try {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+        render(<PipelineBatchList {...defaultProps} />)
+        const searchInput = screen.getByPlaceholderText(/search/i)
+        await user.type(searchInput, 'a')
+        // Advance past the 300ms debounce
+        await vi.advanceTimersByTimeAsync(350)
+        // Should NOT have called onFiltersChange — single char is below threshold
+        expect(defaultProps.onFiltersChange).not.toHaveBeenCalled()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
   })
 
   describe('Pagination controls', () => {
@@ -447,22 +463,17 @@ describe('PipelineBatchList', () => {
       expect(screen.getByText(/showing/i)).toBeInTheDocument()
     })
 
-    it('renders a load-more button when more items available', () => {
+    it('renders infinite scroll sentinel when more items available', () => {
       render(<PipelineBatchList {...defaultProps} total={150} />)
-      expect(screen.getByRole('button', { name: /load more/i })).toBeInTheDocument()
-    })
-
-    it('does not render load-more when all items shown', () => {
-      render(<PipelineBatchList {...defaultProps} total={3} />)
+      // Sentinel is a hidden div for IntersectionObserver — no load-more button
       expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument()
     })
 
-    it('calls onLoadMore when load-more is clicked', async () => {
-      const user = userEvent.setup()
-      const onLoadMore = vi.fn()
-      render(<PipelineBatchList {...defaultProps} total={150} onLoadMore={onLoadMore} />)
-      await user.click(screen.getByRole('button', { name: /load more/i }))
-      expect(onLoadMore).toHaveBeenCalled()
+    it('does not render sentinel when all items shown', () => {
+      const { container } = render(<PipelineBatchList {...defaultProps} total={3} />)
+      // When total equals items.length, no sentinel is rendered
+      const sentinels = container.querySelectorAll('[aria-hidden="true"].h-1')
+      expect(sentinels.length).toBe(0)
     })
   })
 })

--- a/frontend/src/components/pipeline-debug/PipelineBatchList.test.tsx
+++ b/frontend/src/components/pipeline-debug/PipelineBatchList.test.tsx
@@ -14,9 +14,46 @@
 
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
 import { PipelineBatchList } from './PipelineBatchList'
 import type { PipelineSummaryItem, PipelineSummaryFilters } from './types'
+
+// jsdom returns 0 for getBoundingClientRect / offsetHeight, which starves
+// @tanstack/react-virtual's viewport size and leaves it rendering zero rows.
+// Stub non-zero dimensions so the virtualizer renders our rows in tests.
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    value: 600,
+  })
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    value: 1024,
+  })
+  const original = Element.prototype.getBoundingClientRect
+  Element.prototype.getBoundingClientRect = function (): DOMRect {
+    const rect = original.call(this)
+    // Only inflate the virtualizer's scroll parent — leave untouched rects
+    // alone if they aren't zero.
+    if (rect.width === 0 && rect.height === 0) {
+      return {
+        ...rect,
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 1024,
+        bottom: 600,
+        width: 1024,
+        height: 600,
+        toJSON() {
+          return {}
+        },
+      } as DOMRect
+    }
+    return rect
+  }
+})
 
 const mockItems: PipelineSummaryItem[] = [
   {
@@ -90,7 +127,6 @@ const mockItems: PipelineSummaryItem[] = [
 describe('PipelineBatchList', () => {
   const defaultProps = {
     items: mockItems,
-    total: mockItems.length,
     filters: {} as PipelineSummaryFilters,
     onFiltersChange: vi.fn(),
     onRowClick: vi.fn(),
@@ -283,13 +319,13 @@ describe('PipelineBatchList', () => {
 
   describe('Empty and loading states', () => {
     it('shows loading state', () => {
-      render(<PipelineBatchList {...defaultProps} isLoading={true} items={[]} total={0} />)
+      render(<PipelineBatchList {...defaultProps} isLoading={true} items={[]} />)
 
       expect(screen.getByText(/loading/i)).toBeInTheDocument()
     })
 
     it('shows empty state when no items', () => {
-      render(<PipelineBatchList {...defaultProps} items={[]} total={0} />)
+      render(<PipelineBatchList {...defaultProps} items={[]} />)
 
       expect(screen.getByText(/no results/i)).toBeInTheDocument()
     })
@@ -307,12 +343,12 @@ describe('PipelineBatchList', () => {
     })
   })
 
-  describe('Total count', () => {
-    it('shows total result count', () => {
-      render(<PipelineBatchList {...defaultProps} total={42} />)
+  describe('Result count', () => {
+    it('shows visible row count derived from items', () => {
+      render(<PipelineBatchList {...defaultProps} />)
 
-      // Total count appears in both the header ("42 results") and pagination ("Showing 3 of 42")
-      expect(screen.getAllByText(/42/).length).toBeGreaterThanOrEqual(1)
+      // 3 mock items -> "3 results"
+      expect(screen.getByText(/3 results/i)).toBeInTheDocument()
     })
   })
 
@@ -343,20 +379,23 @@ describe('PipelineBatchList', () => {
       expect(defaultProps.onRowClick).toHaveBeenCalledWith(expect.any(String))
     })
 
-    it('triggers sort on Enter key on sortable header', async () => {
+    it('toggles sort indicator on Enter key on sortable header', async () => {
       render(<PipelineBatchList {...defaultProps} />)
       const sortableHeader = document.querySelector('thead th[tabindex]') as HTMLElement
       sortableHeader.focus()
       await userEvent.keyboard('{Enter}')
-      expect(defaultProps.onFiltersChange).toHaveBeenCalled()
+      // Sorting is now client-side; aria-sort on the header reflects the applied order
+      const ariaSort = sortableHeader.getAttribute('aria-sort') ?? ''
+      expect(['ascending', 'descending']).toContain(ariaSort)
     })
 
-    it('triggers sort on Space key on sortable header', async () => {
+    it('toggles sort indicator on Space key on sortable header', async () => {
       render(<PipelineBatchList {...defaultProps} />)
       const sortableHeader = document.querySelector('thead th[tabindex]') as HTMLElement
       sortableHeader.focus()
       await userEvent.keyboard(' ')
-      expect(defaultProps.onFiltersChange).toHaveBeenCalled()
+      const ariaSort = sortableHeader.getAttribute('aria-sort') ?? ''
+      expect(['ascending', 'descending']).toContain(ariaSort)
     })
   })
 
@@ -414,66 +453,150 @@ describe('PipelineBatchList', () => {
     })
   })
 
-  describe('Search input', () => {
+  describe('Search input (client-side)', () => {
     it('renders a search input field', () => {
       render(<PipelineBatchList {...defaultProps} />)
       const searchInput = screen.getByPlaceholderText(/search/i)
       expect(searchInput).toBeInTheDocument()
     })
 
-    it('calls onFiltersChange with search value on input change (2+ chars)', async () => {
-      vi.useFakeTimers({ shouldAdvanceTime: true })
-      try {
-        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-        render(<PipelineBatchList {...defaultProps} />)
-        const searchInput = screen.getByPlaceholderText(/search/i)
-        await user.type(searchInput, 'Emma')
-        // Advance past the 300ms debounce
-        await vi.advanceTimersByTimeAsync(350)
-        // Should have called onFiltersChange with a search value
-        const calls = defaultProps.onFiltersChange.mock.calls
-        expect(calls.length).toBeGreaterThan(0)
-        const lastCall = calls[calls.length - 1]!
-        expect(lastCall[0]).toHaveProperty('search', 'Emma')
-      } finally {
-        vi.useRealTimers()
-      }
+    it('filters the visible list by requester_name as the user types', async () => {
+      const user = userEvent.setup()
+      render(<PipelineBatchList {...defaultProps} />)
+
+      // All 3 rows visible at start
+      expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
+      expect(screen.getByText('Olivia Chen')).toBeInTheDocument()
+      expect(screen.getByText('Sophia Martinez')).toBeInTheDocument()
+
+      const searchInput = screen.getByPlaceholderText(/search/i)
+      await user.type(searchInput, 'Emma')
+
+      // Only Emma's row should remain visible
+      expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
+      expect(screen.queryByText('Olivia Chen')).not.toBeInTheDocument()
+      expect(screen.queryByText('Sophia Martinez')).not.toBeInTheDocument()
     })
 
-    it('does NOT trigger search for single character input', async () => {
-      vi.useFakeTimers({ shouldAdvanceTime: true })
-      try {
-        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-        render(<PipelineBatchList {...defaultProps} />)
-        const searchInput = screen.getByPlaceholderText(/search/i)
-        await user.type(searchInput, 'a')
-        // Advance past the 300ms debounce
-        await vi.advanceTimersByTimeAsync(350)
-        // Should NOT have called onFiltersChange — single char is below threshold
-        expect(defaultProps.onFiltersChange).not.toHaveBeenCalled()
-      } finally {
-        vi.useRealTimers()
-      }
+    it('filters the visible list by target_name as the user types', async () => {
+      const user = userEvent.setup()
+      render(<PipelineBatchList {...defaultProps} />)
+
+      const searchInput = screen.getByPlaceholderText(/search/i)
+      await user.type(searchInput, 'Noah')
+
+      // Noah Williams is the target of Olivia Chen's request
+      expect(screen.getByText('Olivia Chen')).toBeInTheDocument()
+      expect(screen.queryByText('Emma Johnson')).not.toBeInTheDocument()
+      expect(screen.queryByText('Sophia Martinez')).not.toBeInTheDocument()
+    })
+
+    it('is case-insensitive', async () => {
+      const user = userEvent.setup()
+      render(<PipelineBatchList {...defaultProps} />)
+
+      const searchInput = screen.getByPlaceholderText(/search/i)
+      await user.type(searchInput, 'emma')
+
+      expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
+      expect(screen.queryByText('Olivia Chen')).not.toBeInTheDocument()
+    })
+
+    it('does NOT call onFiltersChange when the user types (client-side)', async () => {
+      const user = userEvent.setup()
+      render(<PipelineBatchList {...defaultProps} />)
+
+      const searchInput = screen.getByPlaceholderText(/search/i)
+      await user.type(searchInput, 'Emma')
+
+      // Typing must not cause a network round-trip — onFiltersChange is for
+      // server-roundtrip filters only. Client-side search stays local.
+      expect(defaultProps.onFiltersChange).not.toHaveBeenCalled()
+    })
+
+    it('filters instantly on a single character (no minimum length)', async () => {
+      const user = userEvent.setup()
+      render(<PipelineBatchList {...defaultProps} />)
+
+      const searchInput = screen.getByPlaceholderText(/search/i)
+      await user.type(searchInput, 'E')
+
+      // Single char still filters; "E" matches "Emma" (requester) only (O/S are upper but 'E' not in Olivia/Sophia)
+      expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
     })
   })
 
-  describe('Pagination controls', () => {
-    it('renders showing count text', () => {
-      render(<PipelineBatchList {...defaultProps} total={150} />)
-      expect(screen.getByText(/showing/i)).toBeInTheDocument()
+  describe('Client-side filtering', () => {
+    it('filters rows by final_status from filters prop without a network call', () => {
+      render(
+        <PipelineBatchList
+          {...defaultProps}
+          filters={{ final_status: 'RESOLVED' } as PipelineSummaryFilters}
+        />
+      )
+
+      expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
+      expect(screen.queryByText('Olivia Chen')).not.toBeInTheDocument()
+      expect(screen.queryByText('Sophia Martinez')).not.toBeInTheDocument()
     })
 
-    it('renders infinite scroll sentinel when more items available', () => {
-      render(<PipelineBatchList {...defaultProps} total={150} />)
-      // Sentinel is a hidden div for IntersectionObserver — no load-more button
-      expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument()
+    it('filters rows by source_field from filters prop', () => {
+      render(
+        <PipelineBatchList
+          {...defaultProps}
+          filters={{ source_field: 'not_bunk_with' } as PipelineSummaryFilters}
+        />
+      )
+
+      expect(screen.getByText('Olivia Chen')).toBeInTheDocument()
+      expect(screen.queryByText('Emma Johnson')).not.toBeInTheDocument()
+      expect(screen.queryByText('Sophia Martinez')).not.toBeInTheDocument()
     })
 
-    it('does not render sentinel when all items shown', () => {
-      const { container } = render(<PipelineBatchList {...defaultProps} total={3} />)
-      // When total equals items.length, no sentinel is rendered
-      const sentinels = container.querySelectorAll('[aria-hidden="true"].h-1')
-      expect(sentinels.length).toBe(0)
+    it('filters rows by phase3_triggered from filters prop', () => {
+      render(
+        <PipelineBatchList
+          {...defaultProps}
+          filters={{ phase3_triggered: true } as PipelineSummaryFilters}
+        />
+      )
+
+      // Only Olivia's row has phase3_triggered=true
+      expect(screen.getByText('Olivia Chen')).toBeInTheDocument()
+      expect(screen.queryByText('Emma Johnson')).not.toBeInTheDocument()
+      expect(screen.queryByText('Sophia Martinez')).not.toBeInTheDocument()
+    })
+
+    it('filters rows by min_confidence from filters prop', () => {
+      render(
+        <PipelineBatchList
+          {...defaultProps}
+          filters={{ min_confidence: 0.8 } as PipelineSummaryFilters}
+        />
+      )
+
+      // Only Emma (0.95) meets >= 0.80 — Olivia (0.72) and Sophia (0.35) excluded
+      expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
+      expect(screen.queryByText('Olivia Chen')).not.toBeInTheDocument()
+      expect(screen.queryByText('Sophia Martinez')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Client-side sorting', () => {
+    it('sorts ascending on first header click', async () => {
+      const user = userEvent.setup()
+      render(<PipelineBatchList {...defaultProps} />)
+
+      const camperHeader = screen
+        .getAllByRole('columnheader')
+        .find((h) => String(h.textContent).trim().startsWith('Camper'))!
+      await user.click(camperHeader)
+
+      // Sort is now applied client-side; first row should be Emma (alphabetical)
+      const rows = document.querySelectorAll('tbody tr')
+      expect((rows[0] as Element).textContent).toContain('Emma Johnson')
+      expect((rows[1] as Element).textContent).toContain('Olivia Chen')
+      expect((rows[2] as Element).textContent).toContain('Sophia Martinez')
     })
   })
 })

--- a/frontend/src/components/pipeline-debug/PipelineBatchList.test.tsx
+++ b/frontend/src/components/pipeline-debug/PipelineBatchList.test.tsx
@@ -256,7 +256,7 @@ describe('PipelineBatchList', () => {
       const user = userEvent.setup()
       render(<PipelineBatchList {...defaultProps} />)
 
-      const row = screen.getByText('Emma Johnson').closest('tr')!
+      const row = screen.getByText('Emma Johnson').closest('[role="row"]') as HTMLElement
       await user.click(row)
 
       expect(defaultProps.onRowClick).toHaveBeenCalledWith('trace-001')
@@ -265,7 +265,7 @@ describe('PipelineBatchList', () => {
     it('shows clickable cursor on rows', () => {
       render(<PipelineBatchList {...defaultProps} />)
 
-      const row = screen.getByText('Emma Johnson').closest('tr')!
+      const row = screen.getByText('Emma Johnson').closest('[role="row"]') as HTMLElement
       expect(row.className).toMatch(/cursor-pointer/)
     })
   })
@@ -333,13 +333,13 @@ describe('PipelineBatchList', () => {
     it('renders error state when error prop is provided', () => {
       render(<PipelineBatchList {...defaultProps} error={new Error('Network failure')} />)
       expect(screen.getByText(/failed to load pipeline data/i)).toBeInTheDocument()
-      expect(screen.queryByRole('table')).not.toBeInTheDocument()
+      expect(document.querySelectorAll('[role="row"]').length).toBe(0)
     })
 
     it('does not render error state when error is null', () => {
       render(<PipelineBatchList {...defaultProps} error={null} />)
       expect(screen.queryByText(/failed to load pipeline data/i)).not.toBeInTheDocument()
-      expect(screen.getByRole('table')).toBeInTheDocument()
+      expect(document.querySelectorAll('[role="row"]').length).toBeGreaterThan(0)
     })
   })
 
@@ -355,17 +355,17 @@ describe('PipelineBatchList', () => {
   describe('Keyboard accessibility', () => {
     it('rows are keyboard-focusable with role=button', () => {
       render(<PipelineBatchList {...defaultProps} />)
-      const rows = document.querySelectorAll('tbody tr')
+      const rows = document.querySelectorAll('[role="rowgroup"] [role="row"]')
       expect(rows.length).toBeGreaterThan(0)
       rows.forEach((row) => {
         expect(row).toHaveAttribute('tabindex', '0')
-        expect(row).toHaveAttribute('role', 'button')
+        expect(row).toHaveAttribute('role', 'row')
       })
     })
 
     it('triggers row click on Enter key', async () => {
       render(<PipelineBatchList {...defaultProps} />)
-      const firstRow = document.querySelector('tbody tr') as HTMLElement
+      const firstRow = document.querySelector('[role="rowgroup"] [role="row"]') as HTMLElement
       firstRow.focus()
       await userEvent.keyboard('{Enter}')
       expect(defaultProps.onRowClick).toHaveBeenCalledWith(expect.any(String))
@@ -373,7 +373,7 @@ describe('PipelineBatchList', () => {
 
     it('triggers row click on Space key', async () => {
       render(<PipelineBatchList {...defaultProps} />)
-      const firstRow = document.querySelector('tbody tr') as HTMLElement
+      const firstRow = document.querySelector('[role="rowgroup"] [role="row"]') as HTMLElement
       firstRow.focus()
       await userEvent.keyboard(' ')
       expect(defaultProps.onRowClick).toHaveBeenCalledWith(expect.any(String))
@@ -381,7 +381,9 @@ describe('PipelineBatchList', () => {
 
     it('toggles sort indicator on Enter key on sortable header', async () => {
       render(<PipelineBatchList {...defaultProps} />)
-      const sortableHeader = document.querySelector('thead th[tabindex]') as HTMLElement
+      const sortableHeader = document.querySelector(
+        '[role="columnheader"][tabindex]'
+      ) as HTMLElement
       sortableHeader.focus()
       await userEvent.keyboard('{Enter}')
       // Sorting is now client-side; aria-sort on the header reflects the applied order
@@ -391,7 +393,9 @@ describe('PipelineBatchList', () => {
 
     it('toggles sort indicator on Space key on sortable header', async () => {
       render(<PipelineBatchList {...defaultProps} />)
-      const sortableHeader = document.querySelector('thead th[tabindex]') as HTMLElement
+      const sortableHeader = document.querySelector(
+        '[role="columnheader"][tabindex]'
+      ) as HTMLElement
       sortableHeader.focus()
       await userEvent.keyboard(' ')
       const ariaSort = sortableHeader.getAttribute('aria-sort') ?? ''
@@ -402,7 +406,7 @@ describe('PipelineBatchList', () => {
   describe('disposition columns', () => {
     it('renders disposition_reason column with color-coded badges', () => {
       render(<PipelineBatchList {...defaultProps} />)
-      const rows = document.querySelectorAll('tbody tr')
+      const rows = document.querySelectorAll('[role="rowgroup"] [role="row"]')
 
       // Helper: find the inner badge span (leaf node, exact text match)
       const findBadge = (row: Element, text: string): Element | null => {
@@ -433,21 +437,18 @@ describe('PipelineBatchList', () => {
 
     it('renders is_reciprocal indicator when true', () => {
       render(<PipelineBatchList {...defaultProps} />)
-      const rows = document.querySelectorAll('tbody tr')
+      const rows = document.querySelectorAll('[role="rowgroup"] [role="row"]')
 
       // First row has is_reciprocal=true — should show "Recip" badge
       expect((rows[0] as Element).textContent).toMatch(/recip/i)
 
-      // Second row has is_reciprocal=false — no "recip" indicator
-      const secondRowRecip = Array.from((rows[1] as Element).querySelectorAll('td')).find((td) =>
-        String(td.textContent).toLowerCase().includes('recip')
-      )
-      expect(secondRowRecip).toBeFalsy()
+      // Second row has is_reciprocal=false — no "recip" indicator inside row's direct children
+      expect((rows[1] as Element).textContent?.toLowerCase()).not.toMatch(/recip/)
     })
 
     it('renders Reason column header', () => {
       render(<PipelineBatchList {...defaultProps} />)
-      const headers = document.querySelectorAll('thead th')
+      const headers = document.querySelectorAll('[role="columnheader"]')
       const headerTexts = Array.from(headers).map((h) => String(h.textContent).trim())
       expect(headerTexts).toContain('Reason')
     })
@@ -593,7 +594,7 @@ describe('PipelineBatchList', () => {
       await user.click(camperHeader)
 
       // Sort is now applied client-side; first row should be Emma (alphabetical)
-      const rows = document.querySelectorAll('tbody tr')
+      const rows = document.querySelectorAll('[role="rowgroup"] [role="row"]')
       expect((rows[0] as Element).textContent).toContain('Emma Johnson')
       expect((rows[1] as Element).textContent).toContain('Olivia Chen')
       expect((rows[2] as Element).textContent).toContain('Sophia Martinez')

--- a/frontend/src/components/pipeline-debug/PipelineBatchList.test.tsx
+++ b/frontend/src/components/pipeline-debug/PipelineBatchList.test.tsx
@@ -311,7 +311,8 @@ describe('PipelineBatchList', () => {
     it('shows total result count', () => {
       render(<PipelineBatchList {...defaultProps} total={42} />)
 
-      expect(screen.getByText(/42/)).toBeInTheDocument()
+      // Total count appears in both the header ("42 results") and pagination ("Showing 3 of 42")
+      expect(screen.getAllByText(/42/).length).toBeGreaterThanOrEqual(1)
     })
   })
 
@@ -410,6 +411,58 @@ describe('PipelineBatchList', () => {
       const headers = document.querySelectorAll('thead th')
       const headerTexts = Array.from(headers).map((h) => String(h.textContent).trim())
       expect(headerTexts).toContain('Reason')
+    })
+  })
+
+  describe('Search input', () => {
+    it('renders a search input field', () => {
+      render(<PipelineBatchList {...defaultProps} />)
+      const searchInput = screen.getByPlaceholderText(/search/i)
+      expect(searchInput).toBeInTheDocument()
+    })
+
+    it('calls onFiltersChange with search value on input change', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true })
+      try {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+        render(<PipelineBatchList {...defaultProps} />)
+        const searchInput = screen.getByPlaceholderText(/search/i)
+        await user.type(searchInput, 'Emma')
+        // Advance past the 300ms debounce
+        await vi.advanceTimersByTimeAsync(350)
+        // Should have called onFiltersChange with a search value
+        const calls = defaultProps.onFiltersChange.mock.calls
+        expect(calls.length).toBeGreaterThan(0)
+        const lastCall = calls[calls.length - 1]!
+        expect(lastCall[0]).toHaveProperty('search', 'Emma')
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
+
+  describe('Pagination controls', () => {
+    it('renders showing count text', () => {
+      render(<PipelineBatchList {...defaultProps} total={150} />)
+      expect(screen.getByText(/showing/i)).toBeInTheDocument()
+    })
+
+    it('renders a load-more button when more items available', () => {
+      render(<PipelineBatchList {...defaultProps} total={150} />)
+      expect(screen.getByRole('button', { name: /load more/i })).toBeInTheDocument()
+    })
+
+    it('does not render load-more when all items shown', () => {
+      render(<PipelineBatchList {...defaultProps} total={3} />)
+      expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument()
+    })
+
+    it('calls onLoadMore when load-more is clicked', async () => {
+      const user = userEvent.setup()
+      const onLoadMore = vi.fn()
+      render(<PipelineBatchList {...defaultProps} total={150} onLoadMore={onLoadMore} />)
+      await user.click(screen.getByRole('button', { name: /load more/i }))
+      expect(onLoadMore).toHaveBeenCalled()
     })
   })
 })

--- a/frontend/src/components/pipeline-debug/PipelineBatchList.tsx
+++ b/frontend/src/components/pipeline-debug/PipelineBatchList.tsx
@@ -103,58 +103,45 @@ export function PipelineBatchList({
 
   // Apply all filters + search + sort client-side over the full in-memory list.
   const visibleItems = useMemo(() => {
-    let out = items
-
-    // Search (case-insensitive, requester_name OR target_name)
     const q = searchText.trim().toLowerCase()
-    if (q) {
-      out = out.filter(
-        (item) =>
-          item.requester_name.toLowerCase().includes(q) ||
-          item.target_name.toLowerCase().includes(q)
-      )
-    }
+    const filtered = items.filter((item) => {
+      if (
+        q &&
+        !item.requester_name.toLowerCase().includes(q) &&
+        !item.target_name.toLowerCase().includes(q)
+      ) {
+        return false
+      }
+      if (filters.final_status && item.final_status !== filters.final_status) return false
+      if (filters.source_field && item.source_field !== filters.source_field) return false
+      if (filters.resolution_method && item.resolution_method !== filters.resolution_method) {
+        return false
+      }
+      if (filters.session_cm_id !== undefined && item.session_cm_id !== filters.session_cm_id) {
+        return false
+      }
+      if (
+        filters.phase3_triggered !== undefined &&
+        item.phase3_triggered !== filters.phase3_triggered
+      ) {
+        return false
+      }
+      if (filters.pre_p1_action && item.pre_p1_action !== filters.pre_p1_action) return false
+      if (filters.min_confidence !== undefined && item.final_confidence < filters.min_confidence) {
+        return false
+      }
+      if (filters.max_confidence !== undefined && item.final_confidence > filters.max_confidence) {
+        return false
+      }
+      return true
+    })
 
-    // Structural filters (previously server-side)
-    if (filters.final_status) {
-      out = out.filter((item) => item.final_status === filters.final_status)
-    }
-    if (filters.source_field) {
-      out = out.filter((item) => item.source_field === filters.source_field)
-    }
-    if (filters.resolution_method) {
-      out = out.filter((item) => item.resolution_method === filters.resolution_method)
-    }
-    if (filters.session_cm_id !== undefined) {
-      out = out.filter((item) => item.session_cm_id === filters.session_cm_id)
-    }
-    if (filters.phase3_triggered !== undefined) {
-      out = out.filter((item) => item.phase3_triggered === filters.phase3_triggered)
-    }
-    if (filters.pre_p1_action) {
-      out = out.filter((item) => item.pre_p1_action === filters.pre_p1_action)
-    }
-    if (filters.min_confidence !== undefined) {
-      const min = filters.min_confidence
-      out = out.filter((item) => item.final_confidence >= min)
-    }
-    if (filters.max_confidence !== undefined) {
-      const max = filters.max_confidence
-      out = out.filter((item) => item.final_confidence <= max)
-    }
-
-    // Sort
-    if (sort) {
-      const { field, desc } = sort
-      out = [...out].sort((a, b) => {
-        const av = a[field]
-        const bv = b[field]
-        const cmp = compareValues(av, bv)
-        return desc ? -cmp : cmp
-      })
-    }
-
-    return out
+    if (!sort) return filtered
+    const { field, desc } = sort
+    return [...filtered].sort((a, b) => {
+      const cmp = compareValues(a[field], b[field])
+      return desc ? -cmp : cmp
+    })
   }, [items, filters, searchText, sort])
 
   // Always instantiate the virtualizer (hooks order must be stable). It's

--- a/frontend/src/components/pipeline-debug/PipelineBatchList.tsx
+++ b/frontend/src/components/pipeline-debug/PipelineBatchList.tsx
@@ -24,7 +24,7 @@ import {
 import { useVirtualTable } from '../../hooks/useVirtualTable'
 
 /** Fixed height for the virtualized scroll viewport. */
-const VIRTUAL_VIEWPORT_HEIGHT = 600
+const VIRTUAL_VIEWPORT_HEIGHT = 696
 
 /** Column definitions for sortable headers. */
 const SORTABLE_COLUMNS: Array<{
@@ -40,8 +40,15 @@ const SORTABLE_COLUMNS: Array<{
   { label: 'Confidence', field: 'final_confidence' },
   { label: 'Method', field: 'resolution_method' },
   { label: 'P3', field: 'phase3_triggered' },
-  { label: 'Reasoning', field: 'ai_reasoning_summary', hiddenClass: 'hidden lg:table-cell' },
+  { label: 'Reasoning', field: 'ai_reasoning_summary', hiddenClass: 'hidden lg:block' },
 ]
+
+/** Shared CSS grid template for header + rows so columns stay aligned.
+ *  Small screens: 8 columns (Reasoning cell uses `hidden`, removed from flow).
+ *  lg+: 9 columns including Reasoning. */
+const PIPELINE_GRID_COLS =
+  'grid-cols-[minmax(120px,1.5fr)_minmax(120px,1.5fr)_130px_90px_140px_80px_minmax(110px,1fr)_56px] ' +
+  'lg:grid-cols-[minmax(120px,1.5fr)_minmax(120px,1.5fr)_130px_90px_140px_80px_minmax(110px,1fr)_56px_minmax(140px,2fr)]'
 
 /** Local sort state: field + direction. */
 type SortState = { field: keyof PipelineSummaryItem; desc: boolean } | null
@@ -155,7 +162,7 @@ export function PipelineBatchList({
   const { parentRef, rowVirtualizer } = useVirtualTable({
     data: visibleItems,
     height: VIRTUAL_VIEWPORT_HEIGHT,
-    rowHeightPreset: 'normal',
+    rowHeightPreset: 'compact',
     overscan: 15,
   })
 
@@ -335,7 +342,8 @@ export function PipelineBatchList({
         </div>
       </div>
 
-      {/* Table */}
+      {/* Grid-based virtualized list (not HTML table — avoids table/tbody
+          display-mode foot-guns when combined with absolute-positioned rows). */}
       {visibleItems.length === 0 ? (
         <div className="card-lodge bg-parchment-100/30 dark:bg-bark-900/20 flex h-48 flex-col items-center justify-center gap-3">
           <Search className="text-bark-400 h-8 w-8" />
@@ -343,153 +351,144 @@ export function PipelineBatchList({
         </div>
       ) : (
         <div className="card-lodge overflow-hidden">
-          {/* Single table with sticky header; the scroll parent is the div. */}
           <div
             ref={parentRef}
             className="overflow-auto"
             style={{ height: `${VIRTUAL_VIEWPORT_HEIGHT}px` }}
           >
-            <table className="w-full text-sm" style={{ tableLayout: 'fixed' }}>
-              <thead className="bg-bark-50 dark:bg-bark-800/50 sticky top-0 z-10">
-                <tr className="border-bark-200 dark:border-bark-700 border-b">
-                  {SORTABLE_COLUMNS.map((col) => {
-                    const isActive = sort?.field === col.field
-                    const isDesc = isActive && sort.desc
-                    return (
-                      <th
-                        key={col.field}
-                        tabIndex={0}
-                        aria-sort={
-                          sort?.field === col.field
-                            ? sort.desc
-                              ? 'descending'
-                              : 'ascending'
-                            : undefined
-                        }
-                        onClick={() => toggleSort(col.field)}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault()
-                            toggleSort(col.field)
-                          }
-                        }}
-                        className={`text-muted-foreground hover:text-foreground group focus-visible:ring-forest-500 cursor-pointer px-3 py-2 text-left text-xs font-medium select-none focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset ${col.hiddenClass ?? ''}`}
-                      >
-                        <span className="inline-flex items-center gap-1">
-                          {col.label}
-                          {isActive ? (
-                            isDesc ? (
-                              <ArrowDown className="h-3 w-3" />
-                            ) : (
-                              <ArrowUp className="h-3 w-3" />
-                            )
-                          ) : (
-                            <ArrowUpDown className="h-3 w-3 opacity-0 group-hover:opacity-100" />
-                          )}
-                        </span>
-                      </th>
-                    )
-                  })}
-                </tr>
-              </thead>
-              <tbody
-                className="divide-bark-100 dark:divide-bark-700/50 relative divide-y"
-                style={{
-                  height: `${rowVirtualizer.getTotalSize()}px`,
-                  display: 'block',
-                }}
-              >
-                {rowVirtualizer.getVirtualItems().map((virtualRow) => {
-                  const item = visibleItems[virtualRow.index]
-                  if (!item) return null
-                  return (
-                    <tr
-                      key={item.id}
-                      tabIndex={0}
-                      role="button"
-                      data-index={virtualRow.index}
-                      onClick={() => onRowClick(item.trace_id)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault()
-                          onRowClick(item.trace_id)
-                        }
-                      }}
-                      style={{
-                        position: 'absolute',
-                        top: 0,
-                        left: 0,
-                        width: '100%',
-                        height: `${virtualRow.size}px`,
-                        transform: `translateY(${virtualRow.start}px)`,
-                        display: 'table',
-                        tableLayout: 'fixed',
-                      }}
-                      className="hover:bg-parchment-100/50 dark:hover:bg-bark-800/30 focus-visible:ring-forest-500 cursor-pointer transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset"
-                    >
-                      <td className="text-foreground px-3 py-2 font-medium">
-                        {item.requester_name}
-                      </td>
-                      <td className="text-foreground px-3 py-2">{item.target_name}</td>
-                      <td className="px-3 py-2">
-                        <span
-                          className={`inline-flex rounded px-1.5 py-0.5 text-[10px] font-semibold ${getSourceFieldClasses(item.source_field)}`}
-                        >
-                          {formatSourceField(item.source_field)}
-                        </span>
-                      </td>
-                      <td className="px-3 py-2">
-                        <span
-                          className={`inline-flex rounded-md px-2 py-0.5 text-xs font-semibold ${getStatusClasses(item.final_status)}`}
-                        >
-                          {item.final_status}
-                        </span>
-                      </td>
-                      <td className="px-3 py-2">
-                        <span className="inline-flex items-center gap-1">
-                          {item.disposition_reason ? (
-                            <span
-                              className={`inline-flex rounded px-1.5 py-0.5 text-[10px] font-semibold ${getDispositionClasses(item.disposition_reason)}`}
-                            >
-                              {item.disposition_reason}
-                            </span>
-                          ) : (
-                            <span className="text-muted-foreground text-xs">{'\u2014'}</span>
-                          )}
-                          {item.is_reciprocal && (
-                            <span className="rounded bg-sky-100 px-1 py-0.5 text-[9px] font-bold text-sky-700 dark:bg-sky-900/40 dark:text-sky-400">
-                              Recip
-                            </span>
-                          )}
-                        </span>
-                      </td>
-                      <td className="px-3 py-2">
-                        <span
-                          className={`inline-flex rounded-md px-2 py-0.5 text-xs font-semibold tabular-nums ${getConfidenceClasses(item.final_confidence)}`}
-                        >
-                          {item.final_confidence.toFixed(2)}
-                        </span>
-                      </td>
-                      <td className="text-muted-foreground px-3 py-2 text-xs">
-                        {item.resolution_method || '\u2014'}
-                      </td>
-                      <td className="px-3 py-2 text-xs">
-                        {item.phase3_triggered ? (
-                          <span className="font-medium text-amber-600 dark:text-amber-400">
-                            Yes
-                          </span>
+            {/* Sticky header row */}
+            <div
+              role="row"
+              className={`bg-bark-50 dark:bg-bark-800/50 border-bark-200 dark:border-bark-700 sticky top-0 z-10 grid border-b ${PIPELINE_GRID_COLS}`}
+            >
+              {SORTABLE_COLUMNS.map((col) => {
+                const isActive = sort?.field === col.field
+                const isDesc = isActive && sort.desc
+                return (
+                  <div
+                    key={col.field}
+                    role="columnheader"
+                    tabIndex={0}
+                    aria-sort={isActive ? (sort?.desc ? 'descending' : 'ascending') : undefined}
+                    onClick={() => toggleSort(col.field)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        toggleSort(col.field)
+                      }
+                    }}
+                    className={`text-muted-foreground hover:text-foreground group focus-visible:ring-forest-500 cursor-pointer px-3 py-2 text-left text-xs font-medium select-none focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset ${col.hiddenClass ?? ''}`}
+                  >
+                    <span className="inline-flex items-center gap-1">
+                      {col.label}
+                      {isActive ? (
+                        isDesc ? (
+                          <ArrowDown className="h-3 w-3" />
                         ) : (
-                          <span className="text-muted-foreground">No</span>
-                        )}
-                      </td>
-                      <td className="text-muted-foreground hidden max-w-[200px] truncate px-3 py-2 text-xs lg:table-cell">
-                        {item.ai_reasoning_summary || '\u2014'}
-                      </td>
-                    </tr>
-                  )
-                })}
-              </tbody>
-            </table>
+                          <ArrowUp className="h-3 w-3" />
+                        )
+                      ) : (
+                        <ArrowUpDown className="h-3 w-3 opacity-0 group-hover:opacity-100" />
+                      )}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+
+            {/* Virtualized body — a relatively-positioned spacer whose height
+                represents all rows; each row is absolutely positioned. */}
+            <div
+              role="rowgroup"
+              className="divide-bark-100 dark:divide-bark-700/50 relative"
+              style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
+            >
+              {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                const item = visibleItems[virtualRow.index]
+                if (!item) return null
+                return (
+                  <div
+                    key={item.id}
+                    role="row"
+                    tabIndex={0}
+                    data-index={virtualRow.index}
+                    onClick={() => onRowClick(item.trace_id)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        onRowClick(item.trace_id)
+                      }
+                    }}
+                    style={{
+                      position: 'absolute',
+                      top: 0,
+                      left: 0,
+                      width: '100%',
+                      height: `${virtualRow.size}px`,
+                      transform: `translateY(${virtualRow.start}px)`,
+                    }}
+                    className={`hover:bg-parchment-100/50 dark:hover:bg-bark-800/30 focus-visible:ring-forest-500 border-bark-100 dark:border-bark-700/50 grid cursor-pointer items-center border-b transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset ${PIPELINE_GRID_COLS}`}
+                  >
+                    <div className="text-foreground truncate px-3 py-2 text-sm font-medium">
+                      {item.requester_name}
+                    </div>
+                    <div className="text-foreground truncate px-3 py-2 text-sm">
+                      {item.target_name}
+                    </div>
+                    <div className="px-3 py-2">
+                      <span
+                        className={`inline-flex rounded px-1.5 py-0.5 text-[10px] font-semibold ${getSourceFieldClasses(item.source_field)}`}
+                      >
+                        {formatSourceField(item.source_field)}
+                      </span>
+                    </div>
+                    <div className="px-3 py-2">
+                      <span
+                        className={`inline-flex rounded-md px-2 py-0.5 text-xs font-semibold ${getStatusClasses(item.final_status)}`}
+                      >
+                        {item.final_status}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1 px-3 py-2">
+                      {item.disposition_reason ? (
+                        <span
+                          className={`inline-flex rounded px-1.5 py-0.5 text-[10px] font-semibold ${getDispositionClasses(item.disposition_reason)}`}
+                        >
+                          {item.disposition_reason}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground text-xs">{'\u2014'}</span>
+                      )}
+                      {item.is_reciprocal && (
+                        <span className="rounded bg-sky-100 px-1 py-0.5 text-[9px] font-bold text-sky-700 dark:bg-sky-900/40 dark:text-sky-400">
+                          Recip
+                        </span>
+                      )}
+                    </div>
+                    <div className="px-3 py-2">
+                      <span
+                        className={`inline-flex rounded-md px-2 py-0.5 text-xs font-semibold tabular-nums ${getConfidenceClasses(item.final_confidence)}`}
+                      >
+                        {item.final_confidence.toFixed(2)}
+                      </span>
+                    </div>
+                    <div className="text-muted-foreground truncate px-3 py-2 text-xs">
+                      {item.resolution_method || '\u2014'}
+                    </div>
+                    <div className="px-3 py-2 text-xs">
+                      {item.phase3_triggered ? (
+                        <span className="font-medium text-amber-600 dark:text-amber-400">Yes</span>
+                      ) : (
+                        <span className="text-muted-foreground">No</span>
+                      )}
+                    </div>
+                    <div className="text-muted-foreground hidden truncate px-3 py-2 text-xs lg:block">
+                      {item.ai_reasoning_summary || '\u2014'}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
           </div>
         </div>
       )}

--- a/frontend/src/components/pipeline-debug/PipelineBatchList.tsx
+++ b/frontend/src/components/pipeline-debug/PipelineBatchList.tsx
@@ -9,6 +9,7 @@
  * to drill-down.
  */
 
+import { useState, useRef } from 'react'
 import { AlertCircle, ArrowDown, ArrowUp, ArrowUpDown, Loader2, Search } from 'lucide-react'
 import type { PipelineSummaryItem, PipelineSummaryFilters } from './types'
 import { formatSourceField } from '../../utils/formatSourceField'
@@ -52,6 +53,10 @@ interface PipelineBatchListProps {
   onRowClick: (traceId: string) => void
   isLoading: boolean
   error?: Error | null
+  /** Called when user clicks "Load more" to fetch next page */
+  onLoadMore?: () => void
+  /** Whether more pages are being fetched */
+  isLoadingMore?: boolean
 }
 
 export function PipelineBatchList({
@@ -62,7 +67,23 @@ export function PipelineBatchList({
   onRowClick,
   isLoading,
   error,
+  onLoadMore,
+  isLoadingMore,
 }: PipelineBatchListProps) {
+  const [searchText, setSearchText] = useState('')
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(null)
+
+  /** Debounced search handler — updates filters after 300ms of inactivity. */
+  function handleSearchChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const value = e.target.value
+    setSearchText(value)
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      const { search: _, ...rest } = filters
+      onFiltersChange(value ? { ...rest, search: value, page: 1 } : { ...rest, page: 1 })
+    }, 300)
+  }
+
   /** Update a single filter value and notify parent. */
   function updateFilter<K extends keyof PipelineSummaryFilters>(
     key: K,
@@ -112,6 +133,18 @@ export function PipelineBatchList({
       {/* Filter bar */}
       <div className="card-lodge bg-parchment-100/30 dark:bg-bark-900/20 p-3">
         <div className="flex flex-wrap items-center gap-3">
+          {/* Name search */}
+          <div className="relative">
+            <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2 h-3.5 w-3.5 -translate-y-1/2" />
+            <input
+              type="text"
+              placeholder="Search names..."
+              value={searchText}
+              onChange={handleSearchChange}
+              className="border-bark-300 bg-parchment-50 text-foreground dark:border-bark-600 dark:bg-bark-800 w-44 rounded-md border py-1 pr-2 pl-7 text-xs focus:ring-1 focus:ring-amber-500/50 focus:outline-none"
+            />
+          </div>
+
           {/* Status filter */}
           <div className="flex items-center gap-1.5">
             <label htmlFor="filter-status" className="text-muted-foreground text-xs font-medium">
@@ -255,126 +288,155 @@ export function PipelineBatchList({
           <p className="text-muted-foreground text-sm">No results found. Try adjusting filters.</p>
         </div>
       ) : (
-        <div className="card-lodge overflow-hidden">
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-bark-200 dark:border-bark-700 bg-bark-50 dark:bg-bark-800/50 border-b">
-                  {SORTABLE_COLUMNS.map((col) => {
-                    const isActive = currentSort?.field === col.field
-                    const isDesc = isActive && currentSort.desc
-                    return (
-                      <th
-                        key={col.field}
-                        tabIndex={0}
-                        aria-sort={
-                          currentSort?.field === col.field
-                            ? currentSort.desc
-                              ? 'descending'
-                              : 'ascending'
-                            : undefined
-                        }
-                        onClick={() => toggleSort(col.field)}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault()
-                            toggleSort(col.field)
+        <>
+          <div className="card-lodge overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-bark-200 dark:border-bark-700 bg-bark-50 dark:bg-bark-800/50 border-b">
+                    {SORTABLE_COLUMNS.map((col) => {
+                      const isActive = currentSort?.field === col.field
+                      const isDesc = isActive && currentSort.desc
+                      return (
+                        <th
+                          key={col.field}
+                          tabIndex={0}
+                          aria-sort={
+                            currentSort?.field === col.field
+                              ? currentSort.desc
+                                ? 'descending'
+                                : 'ascending'
+                              : undefined
                           }
-                        }}
-                        className={`text-muted-foreground hover:text-foreground group focus-visible:ring-forest-500 cursor-pointer px-3 py-2 text-left text-xs font-medium select-none focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset ${col.hiddenClass ?? ''}`}
-                      >
-                        <span className="inline-flex items-center gap-1">
-                          {col.label}
-                          {isActive ? (
-                            isDesc ? (
-                              <ArrowDown className="h-3 w-3" />
+                          onClick={() => toggleSort(col.field)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault()
+                              toggleSort(col.field)
+                            }
+                          }}
+                          className={`text-muted-foreground hover:text-foreground group focus-visible:ring-forest-500 cursor-pointer px-3 py-2 text-left text-xs font-medium select-none focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset ${col.hiddenClass ?? ''}`}
+                        >
+                          <span className="inline-flex items-center gap-1">
+                            {col.label}
+                            {isActive ? (
+                              isDesc ? (
+                                <ArrowDown className="h-3 w-3" />
+                              ) : (
+                                <ArrowUp className="h-3 w-3" />
+                              )
                             ) : (
-                              <ArrowUp className="h-3 w-3" />
-                            )
+                              <ArrowUpDown className="h-3 w-3 opacity-0 group-hover:opacity-100" />
+                            )}
+                          </span>
+                        </th>
+                      )
+                    })}
+                  </tr>
+                </thead>
+                <tbody className="divide-bark-100 dark:divide-bark-700/50 divide-y">
+                  {items.map((item) => (
+                    <tr
+                      key={item.id}
+                      tabIndex={0}
+                      role="button"
+                      onClick={() => onRowClick(item.trace_id)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault()
+                          onRowClick(item.trace_id)
+                        }
+                      }}
+                      className="hover:bg-parchment-100/50 dark:hover:bg-bark-800/30 focus-visible:ring-forest-500 cursor-pointer transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset"
+                    >
+                      <td className="text-foreground px-3 py-2 font-medium">
+                        {item.requester_name}
+                      </td>
+                      <td className="text-foreground px-3 py-2">{item.target_name}</td>
+                      <td className="px-3 py-2">
+                        <span
+                          className={`inline-flex rounded px-1.5 py-0.5 text-[10px] font-semibold ${getSourceFieldClasses(item.source_field)}`}
+                        >
+                          {formatSourceField(item.source_field)}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2">
+                        <span
+                          className={`inline-flex rounded-md px-2 py-0.5 text-xs font-semibold ${getStatusClasses(item.final_status)}`}
+                        >
+                          {item.final_status}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2">
+                        <span className="inline-flex items-center gap-1">
+                          {item.disposition_reason ? (
+                            <span
+                              className={`inline-flex rounded px-1.5 py-0.5 text-[10px] font-semibold ${getDispositionClasses(item.disposition_reason)}`}
+                            >
+                              {item.disposition_reason}
+                            </span>
                           ) : (
-                            <ArrowUpDown className="h-3 w-3 opacity-0 group-hover:opacity-100" />
+                            <span className="text-muted-foreground text-xs">{'\u2014'}</span>
+                          )}
+                          {item.is_reciprocal && (
+                            <span className="rounded bg-sky-100 px-1 py-0.5 text-[9px] font-bold text-sky-700 dark:bg-sky-900/40 dark:text-sky-400">
+                              Recip
+                            </span>
                           )}
                         </span>
-                      </th>
-                    )
-                  })}
-                </tr>
-              </thead>
-              <tbody className="divide-bark-100 dark:divide-bark-700/50 divide-y">
-                {items.map((item) => (
-                  <tr
-                    key={item.id}
-                    tabIndex={0}
-                    role="button"
-                    onClick={() => onRowClick(item.trace_id)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault()
-                        onRowClick(item.trace_id)
-                      }
-                    }}
-                    className="hover:bg-parchment-100/50 dark:hover:bg-bark-800/30 focus-visible:ring-forest-500 cursor-pointer transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset"
-                  >
-                    <td className="text-foreground px-3 py-2 font-medium">{item.requester_name}</td>
-                    <td className="text-foreground px-3 py-2">{item.target_name}</td>
-                    <td className="px-3 py-2">
-                      <span
-                        className={`inline-flex rounded px-1.5 py-0.5 text-[10px] font-semibold ${getSourceFieldClasses(item.source_field)}`}
-                      >
-                        {formatSourceField(item.source_field)}
-                      </span>
-                    </td>
-                    <td className="px-3 py-2">
-                      <span
-                        className={`inline-flex rounded-md px-2 py-0.5 text-xs font-semibold ${getStatusClasses(item.final_status)}`}
-                      >
-                        {item.final_status}
-                      </span>
-                    </td>
-                    <td className="px-3 py-2">
-                      <span className="inline-flex items-center gap-1">
-                        {item.disposition_reason ? (
-                          <span
-                            className={`inline-flex rounded px-1.5 py-0.5 text-[10px] font-semibold ${getDispositionClasses(item.disposition_reason)}`}
-                          >
-                            {item.disposition_reason}
+                      </td>
+                      <td className="px-3 py-2">
+                        <span
+                          className={`inline-flex rounded-md px-2 py-0.5 text-xs font-semibold tabular-nums ${getConfidenceClasses(item.final_confidence)}`}
+                        >
+                          {item.final_confidence.toFixed(2)}
+                        </span>
+                      </td>
+                      <td className="text-muted-foreground px-3 py-2 text-xs">
+                        {item.resolution_method || '\u2014'}
+                      </td>
+                      <td className="px-3 py-2 text-xs">
+                        {item.phase3_triggered ? (
+                          <span className="font-medium text-amber-600 dark:text-amber-400">
+                            Yes
                           </span>
                         ) : (
-                          <span className="text-muted-foreground text-xs">{'\u2014'}</span>
+                          <span className="text-muted-foreground">No</span>
                         )}
-                        {item.is_reciprocal && (
-                          <span className="rounded bg-sky-100 px-1 py-0.5 text-[9px] font-bold text-sky-700 dark:bg-sky-900/40 dark:text-sky-400">
-                            Recip
-                          </span>
-                        )}
-                      </span>
-                    </td>
-                    <td className="px-3 py-2">
-                      <span
-                        className={`inline-flex rounded-md px-2 py-0.5 text-xs font-semibold tabular-nums ${getConfidenceClasses(item.final_confidence)}`}
-                      >
-                        {item.final_confidence.toFixed(2)}
-                      </span>
-                    </td>
-                    <td className="text-muted-foreground px-3 py-2 text-xs">
-                      {item.resolution_method || '\u2014'}
-                    </td>
-                    <td className="px-3 py-2 text-xs">
-                      {item.phase3_triggered ? (
-                        <span className="font-medium text-amber-600 dark:text-amber-400">Yes</span>
-                      ) : (
-                        <span className="text-muted-foreground">No</span>
-                      )}
-                    </td>
-                    <td className="text-muted-foreground hidden max-w-[200px] truncate px-3 py-2 text-xs lg:table-cell">
-                      {item.ai_reasoning_summary || '\u2014'}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+                      </td>
+                      <td className="text-muted-foreground hidden max-w-[200px] truncate px-3 py-2 text-xs lg:table-cell">
+                        {item.ai_reasoning_summary || '\u2014'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
-        </div>
+
+          {/* Pagination: showing count + load more */}
+          <div className="flex items-center justify-between px-3 py-2">
+            <span className="text-muted-foreground text-xs">
+              Showing {items.length} of {total}
+            </span>
+            {items.length < total && (
+              <button
+                onClick={onLoadMore}
+                disabled={isLoadingMore}
+                className="inline-flex items-center gap-1.5 rounded-md border border-amber-300 bg-amber-50 px-3 py-1 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-100 disabled:opacity-50 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-300 dark:hover:bg-amber-900/40"
+              >
+                {isLoadingMore ? (
+                  <>
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                    Loading...
+                  </>
+                ) : (
+                  'Load more'
+                )}
+              </button>
+            )}
+          </div>
+        </>
       )}
     </div>
   )

--- a/frontend/src/components/pipeline-debug/PipelineBatchList.tsx
+++ b/frontend/src/components/pipeline-debug/PipelineBatchList.tsx
@@ -1,15 +1,17 @@
 /**
  * PipelineBatchList - Summary table for pipeline debug batch overview.
  *
- * Displays a table of summary rows with columns for camper name, target name,
- * source field, status, confidence, resolution method, Phase 3 triggered, and
- * AI reasoning excerpt. Includes filters for status, source field, resolution
- * method, confidence range, session, and Phase 3. Color coding for status
- * (green/amber/red) and confidence (gradient by value). Click row navigates
- * to drill-down.
+ * Receives the full row set for a run in `items` and performs all filtering,
+ * sorting and searching in-memory. The search input is local-only and never
+ * triggers a network round-trip. Scrolling is virtualized with
+ * `useVirtualTable` so thousands of rows stay smooth.
+ *
+ * Columns: camper name, target name, source field, status, disposition/
+ * reason, confidence, resolution method, Phase 3 triggered, AI reasoning.
+ * Status / disposition / confidence are color-coded.
  */
 
-import { useState, useRef, useEffect } from 'react'
+import { useMemo, useState } from 'react'
 import { AlertCircle, ArrowDown, ArrowUp, ArrowUpDown, Loader2, Search } from 'lucide-react'
 import type { PipelineSummaryItem, PipelineSummaryFilters } from './types'
 import { formatSourceField } from '../../utils/formatSourceField'
@@ -19,9 +21,10 @@ import {
   getStatusClasses,
   getConfidenceClasses,
 } from '../../utils/dispositionColors'
+import { useVirtualTable } from '../../hooks/useVirtualTable'
 
-/** Minimum characters before triggering a search API call. */
-const MIN_SEARCH_LENGTH = 2
+/** Fixed height for the virtualized scroll viewport. */
+const VIRTUAL_VIEWPORT_HEIGHT = 600
 
 /** Column definitions for sortable headers. */
 const SORTABLE_COLUMNS: Array<{
@@ -40,98 +43,39 @@ const SORTABLE_COLUMNS: Array<{
   { label: 'Reasoning', field: 'ai_reasoning_summary', hiddenClass: 'hidden lg:table-cell' },
 ]
 
-/** Parse PocketBase sort string (e.g. "-final_confidence") into field + direction. */
-function parseSort(sort?: string): { field: string; desc: boolean } | null {
-  if (!sort) return null
-  if (sort.startsWith('-')) return { field: sort.slice(1), desc: true }
-  if (sort.startsWith('+')) return { field: sort.slice(1), desc: false }
-  return { field: sort, desc: false }
-}
-
-/**
- * Invisible sentinel element that triggers onLoadMore when scrolled into view.
- * Uses IntersectionObserver for efficient scroll-based pagination.
- */
-function InfiniteScrollSentinel({
-  onLoadMore,
-  isLoading = false,
-}: {
-  onLoadMore: () => void
-  isLoading?: boolean
-}) {
-  const sentinelRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    const el = sentinelRef.current
-    if (!el || !onLoadMore) return
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        // Only trigger when becoming visible and not already loading
-        if (entries[0]?.isIntersecting && !isLoading) {
-          onLoadMore()
-        }
-      },
-      { rootMargin: '200px' }
-    )
-
-    observer.observe(el)
-    return () => observer.disconnect()
-  }, [onLoadMore, isLoading])
-
-  return <div ref={sentinelRef} className="h-1" aria-hidden="true" />
-}
+/** Local sort state: field + direction. */
+type SortState = { field: keyof PipelineSummaryItem; desc: boolean } | null
 
 interface PipelineBatchListProps {
+  /** ALL rows for the selected run. Filtering/sorting/search happen client-side. */
   items: PipelineSummaryItem[]
-  total: number
+  /**
+   * Server-roundtrip filters (status, source_field, session, etc.) — still
+   * applied client-side but owned by the parent so state survives nav. The
+   * `search` / `page` / `sort` / `per_page` fields are no longer used and are
+   * tolerated for backward compatibility.
+   */
   filters: PipelineSummaryFilters
   onFiltersChange: (filters: PipelineSummaryFilters) => void
   onRowClick: (traceId: string) => void
   isLoading: boolean
   error?: Error | null
-  /** Called when user clicks "Load more" to fetch next page */
-  onLoadMore?: () => void
-  /** Whether more pages are being fetched */
-  isLoadingMore?: boolean
 }
 
 export function PipelineBatchList({
   items,
-  total,
   filters,
   onFiltersChange,
   onRowClick,
   isLoading,
   error,
-  onLoadMore,
-  isLoadingMore,
 }: PipelineBatchListProps) {
-  const [searchText, setSearchText] = useState(filters.search ?? '')
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(null)
+  // Local, never-leaves-the-component search text — no debounce, no min char.
+  const [searchText, setSearchText] = useState('')
 
-  // Sync search text when filters.search changes externally (e.g., from "View all traces")
-  useEffect(() => {
-    setSearchText(filters.search ?? '')
-  }, [filters.search])
-
-  /** Debounced search handler — requires MIN_SEARCH_LENGTH chars before triggering API call. */
-  function handleSearchChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const value = e.target.value
-    setSearchText(value)
-    if (debounceRef.current) clearTimeout(debounceRef.current)
-    debounceRef.current = setTimeout(() => {
-      const trimmed = value.trim()
-      const { search: _, ...rest } = filters
-      // Only search if we have enough characters, or if clearing
-      if (trimmed.length >= MIN_SEARCH_LENGTH) {
-        onFiltersChange({ ...rest, search: trimmed, page: 1 })
-      } else if (filters.search) {
-        // Had a previous search, now clearing it
-        onFiltersChange({ ...rest, page: 1 })
-      }
-    }, 300)
-  }
+  // Local sort state — initialized from filters.sort for back-compat, but
+  // all toggles stay client-side (never calls onFiltersChange).
+  const [sort, setSort] = useState<SortState>(() => parseSortFilter(filters.sort))
 
   /** Update a single filter value and notify parent. */
   function updateFilter<K extends keyof PipelineSummaryFilters>(
@@ -142,20 +86,78 @@ export function PipelineBatchList({
   }
 
   /** Toggle sort on a column: none → asc → desc → none. */
-  function toggleSort(field: string) {
-    const current = parseSort(filters.sort)
-    let next: string | undefined
-    if (current?.field !== field) {
-      next = field // ascending (no prefix)
-    } else if (!current.desc) {
-      next = `-${field}` // descending
-    } else {
-      next = undefined // clear sort
-    }
-    updateFilter('sort', next)
+  function toggleSort(field: keyof PipelineSummaryItem) {
+    setSort((current) => {
+      if (current?.field !== field) return { field, desc: false }
+      if (!current.desc) return { field, desc: true }
+      return null
+    })
   }
 
-  const currentSort = parseSort(filters.sort)
+  // Apply all filters + search + sort client-side over the full in-memory list.
+  const visibleItems = useMemo(() => {
+    let out = items
+
+    // Search (case-insensitive, requester_name OR target_name)
+    const q = searchText.trim().toLowerCase()
+    if (q) {
+      out = out.filter(
+        (item) =>
+          item.requester_name.toLowerCase().includes(q) ||
+          item.target_name.toLowerCase().includes(q)
+      )
+    }
+
+    // Structural filters (previously server-side)
+    if (filters.final_status) {
+      out = out.filter((item) => item.final_status === filters.final_status)
+    }
+    if (filters.source_field) {
+      out = out.filter((item) => item.source_field === filters.source_field)
+    }
+    if (filters.resolution_method) {
+      out = out.filter((item) => item.resolution_method === filters.resolution_method)
+    }
+    if (filters.session_cm_id !== undefined) {
+      out = out.filter((item) => item.session_cm_id === filters.session_cm_id)
+    }
+    if (filters.phase3_triggered !== undefined) {
+      out = out.filter((item) => item.phase3_triggered === filters.phase3_triggered)
+    }
+    if (filters.pre_p1_action) {
+      out = out.filter((item) => item.pre_p1_action === filters.pre_p1_action)
+    }
+    if (filters.min_confidence !== undefined) {
+      const min = filters.min_confidence
+      out = out.filter((item) => item.final_confidence >= min)
+    }
+    if (filters.max_confidence !== undefined) {
+      const max = filters.max_confidence
+      out = out.filter((item) => item.final_confidence <= max)
+    }
+
+    // Sort
+    if (sort) {
+      const { field, desc } = sort
+      out = [...out].sort((a, b) => {
+        const av = a[field]
+        const bv = b[field]
+        const cmp = compareValues(av, bv)
+        return desc ? -cmp : cmp
+      })
+    }
+
+    return out
+  }, [items, filters, searchText, sort])
+
+  // Always instantiate the virtualizer (hooks order must be stable). It's
+  // fine if the result isn't rendered because of loading/empty/error states.
+  const { parentRef, rowVirtualizer } = useVirtualTable({
+    data: visibleItems,
+    height: VIRTUAL_VIEWPORT_HEIGHT,
+    rowHeightPreset: 'normal',
+    overscan: 15,
+  })
 
   if (isLoading) {
     return (
@@ -187,9 +189,9 @@ export function PipelineBatchList({
             <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2 h-3.5 w-3.5 -translate-y-1/2" />
             <input
               type="text"
-              placeholder={`Search names (${MIN_SEARCH_LENGTH}+ chars)...`}
+              placeholder="Search names..."
               value={searchText}
-              onChange={handleSearchChange}
+              onChange={(e) => setSearchText(e.target.value)}
               className="border-bark-300 bg-parchment-50 text-foreground dark:border-bark-600 dark:bg-bark-800 w-52 rounded-md border py-1 pr-2 pl-7 text-xs focus:ring-1 focus:ring-amber-500/50 focus:outline-none"
             />
           </div>
@@ -325,76 +327,103 @@ export function PipelineBatchList({
 
           {/* Result count */}
           <div className="text-muted-foreground ml-auto text-xs">
-            {total} {total === 1 ? 'result' : 'results'}
+            {visibleItems.length} {visibleItems.length === 1 ? 'result' : 'results'}
+            {visibleItems.length !== items.length && (
+              <span className="text-muted-foreground/70"> of {items.length}</span>
+            )}
           </div>
         </div>
       </div>
 
       {/* Table */}
-      {items.length === 0 ? (
+      {visibleItems.length === 0 ? (
         <div className="card-lodge bg-parchment-100/30 dark:bg-bark-900/20 flex h-48 flex-col items-center justify-center gap-3">
           <Search className="text-bark-400 h-8 w-8" />
           <p className="text-muted-foreground text-sm">No results found. Try adjusting filters.</p>
         </div>
       ) : (
-        <>
-          <div className="card-lodge overflow-hidden">
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-bark-200 dark:border-bark-700 bg-bark-50 dark:bg-bark-800/50 border-b">
-                    {SORTABLE_COLUMNS.map((col) => {
-                      const isActive = currentSort?.field === col.field
-                      const isDesc = isActive && currentSort.desc
-                      return (
-                        <th
-                          key={col.field}
-                          tabIndex={0}
-                          aria-sort={
-                            currentSort?.field === col.field
-                              ? currentSort.desc
-                                ? 'descending'
-                                : 'ascending'
-                              : undefined
+        <div className="card-lodge overflow-hidden">
+          {/* Single table with sticky header; the scroll parent is the div. */}
+          <div
+            ref={parentRef}
+            className="overflow-auto"
+            style={{ height: `${VIRTUAL_VIEWPORT_HEIGHT}px` }}
+          >
+            <table className="w-full text-sm" style={{ tableLayout: 'fixed' }}>
+              <thead className="bg-bark-50 dark:bg-bark-800/50 sticky top-0 z-10">
+                <tr className="border-bark-200 dark:border-bark-700 border-b">
+                  {SORTABLE_COLUMNS.map((col) => {
+                    const isActive = sort?.field === col.field
+                    const isDesc = isActive && sort.desc
+                    return (
+                      <th
+                        key={col.field}
+                        tabIndex={0}
+                        aria-sort={
+                          sort?.field === col.field
+                            ? sort.desc
+                              ? 'descending'
+                              : 'ascending'
+                            : undefined
+                        }
+                        onClick={() => toggleSort(col.field)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault()
+                            toggleSort(col.field)
                           }
-                          onClick={() => toggleSort(col.field)}
-                          onKeyDown={(e) => {
-                            if (e.key === 'Enter' || e.key === ' ') {
-                              e.preventDefault()
-                              toggleSort(col.field)
-                            }
-                          }}
-                          className={`text-muted-foreground hover:text-foreground group focus-visible:ring-forest-500 cursor-pointer px-3 py-2 text-left text-xs font-medium select-none focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset ${col.hiddenClass ?? ''}`}
-                        >
-                          <span className="inline-flex items-center gap-1">
-                            {col.label}
-                            {isActive ? (
-                              isDesc ? (
-                                <ArrowDown className="h-3 w-3" />
-                              ) : (
-                                <ArrowUp className="h-3 w-3" />
-                              )
+                        }}
+                        className={`text-muted-foreground hover:text-foreground group focus-visible:ring-forest-500 cursor-pointer px-3 py-2 text-left text-xs font-medium select-none focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset ${col.hiddenClass ?? ''}`}
+                      >
+                        <span className="inline-flex items-center gap-1">
+                          {col.label}
+                          {isActive ? (
+                            isDesc ? (
+                              <ArrowDown className="h-3 w-3" />
                             ) : (
-                              <ArrowUpDown className="h-3 w-3 opacity-0 group-hover:opacity-100" />
-                            )}
-                          </span>
-                        </th>
-                      )
-                    })}
-                  </tr>
-                </thead>
-                <tbody className="divide-bark-100 dark:divide-bark-700/50 divide-y">
-                  {items.map((item) => (
+                              <ArrowUp className="h-3 w-3" />
+                            )
+                          ) : (
+                            <ArrowUpDown className="h-3 w-3 opacity-0 group-hover:opacity-100" />
+                          )}
+                        </span>
+                      </th>
+                    )
+                  })}
+                </tr>
+              </thead>
+              <tbody
+                className="divide-bark-100 dark:divide-bark-700/50 relative divide-y"
+                style={{
+                  height: `${rowVirtualizer.getTotalSize()}px`,
+                  display: 'block',
+                }}
+              >
+                {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                  const item = visibleItems[virtualRow.index]
+                  if (!item) return null
+                  return (
                     <tr
                       key={item.id}
                       tabIndex={0}
                       role="button"
+                      data-index={virtualRow.index}
                       onClick={() => onRowClick(item.trace_id)}
                       onKeyDown={(e) => {
                         if (e.key === 'Enter' || e.key === ' ') {
                           e.preventDefault()
                           onRowClick(item.trace_id)
                         }
+                      }}
+                      style={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        width: '100%',
+                        height: `${virtualRow.size}px`,
+                        transform: `translateY(${virtualRow.start}px)`,
+                        display: 'table',
+                        tableLayout: 'fixed',
                       }}
                       className="hover:bg-parchment-100/50 dark:hover:bg-bark-800/30 focus-visible:ring-forest-500 cursor-pointer transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset"
                     >
@@ -457,30 +486,34 @@ export function PipelineBatchList({
                         {item.ai_reasoning_summary || '\u2014'}
                       </td>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+                  )
+                })}
+              </tbody>
+            </table>
           </div>
-
-          {/* Pagination: showing count + infinite scroll sentinel */}
-          <div className="flex items-center justify-between px-3 py-2">
-            <span className="text-muted-foreground text-xs">
-              Showing {items.length} of {total}
-            </span>
-            {isLoadingMore && (
-              <span className="inline-flex items-center gap-1.5 text-xs text-amber-600 dark:text-amber-400">
-                <Loader2 className="h-3 w-3 animate-spin" />
-                Loading more...
-              </span>
-            )}
-          </div>
-          {/* Infinite scroll sentinel — triggers onLoadMore when scrolled into view */}
-          {items.length < total && onLoadMore && (
-            <InfiniteScrollSentinel onLoadMore={onLoadMore} isLoading={isLoadingMore ?? false} />
-          )}
-        </>
+        </div>
       )}
     </div>
   )
+}
+
+/** Parse a PB-style sort string (e.g. "-final_confidence") into local SortState. */
+function parseSortFilter(sort?: string): SortState {
+  if (!sort) return null
+  const desc = sort.startsWith('-')
+  const field = sort.startsWith('-') || sort.startsWith('+') ? sort.slice(1) : sort
+  // Best-effort narrow to a known PipelineSummaryItem key
+  return { field: field as keyof PipelineSummaryItem, desc }
+}
+
+/** Compare two values of possibly heterogeneous types for sort. */
+function compareValues(a: unknown, b: unknown): number {
+  if (a === b) return 0
+  if (a == null) return 1
+  if (b == null) return -1
+  if (typeof a === 'number' && typeof b === 'number') return a - b
+  if (typeof a === 'boolean' && typeof b === 'boolean') {
+    return a === b ? 0 : a ? -1 : 1
+  }
+  return String(a).localeCompare(String(b))
 }

--- a/frontend/src/components/pipeline-debug/PipelineBatchList.tsx
+++ b/frontend/src/components/pipeline-debug/PipelineBatchList.tsx
@@ -9,7 +9,7 @@
  * to drill-down.
  */
 
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { AlertCircle, ArrowDown, ArrowUp, ArrowUpDown, Loader2, Search } from 'lucide-react'
 import type { PipelineSummaryItem, PipelineSummaryFilters } from './types'
 import { formatSourceField } from '../../utils/formatSourceField'
@@ -19,6 +19,9 @@ import {
   getStatusClasses,
   getConfidenceClasses,
 } from '../../utils/dispositionColors'
+
+/** Minimum characters before triggering a search API call. */
+const MIN_SEARCH_LENGTH = 2
 
 /** Column definitions for sortable headers. */
 const SORTABLE_COLUMNS: Array<{
@@ -43,6 +46,40 @@ function parseSort(sort?: string): { field: string; desc: boolean } | null {
   if (sort.startsWith('-')) return { field: sort.slice(1), desc: true }
   if (sort.startsWith('+')) return { field: sort.slice(1), desc: false }
   return { field: sort, desc: false }
+}
+
+/**
+ * Invisible sentinel element that triggers onLoadMore when scrolled into view.
+ * Uses IntersectionObserver for efficient scroll-based pagination.
+ */
+function InfiniteScrollSentinel({
+  onLoadMore,
+  isLoading = false,
+}: {
+  onLoadMore: () => void
+  isLoading?: boolean
+}) {
+  const sentinelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = sentinelRef.current
+    if (!el || !onLoadMore) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        // Only trigger when becoming visible and not already loading
+        if (entries[0]?.isIntersecting && !isLoading) {
+          onLoadMore()
+        }
+      },
+      { rootMargin: '200px' }
+    )
+
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [onLoadMore, isLoading])
+
+  return <div ref={sentinelRef} className="h-1" aria-hidden="true" />
 }
 
 interface PipelineBatchListProps {
@@ -70,17 +107,29 @@ export function PipelineBatchList({
   onLoadMore,
   isLoadingMore,
 }: PipelineBatchListProps) {
-  const [searchText, setSearchText] = useState('')
+  const [searchText, setSearchText] = useState(filters.search ?? '')
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null)
 
-  /** Debounced search handler — updates filters after 300ms of inactivity. */
+  // Sync search text when filters.search changes externally (e.g., from "View all traces")
+  useEffect(() => {
+    setSearchText(filters.search ?? '')
+  }, [filters.search])
+
+  /** Debounced search handler — requires MIN_SEARCH_LENGTH chars before triggering API call. */
   function handleSearchChange(e: React.ChangeEvent<HTMLInputElement>) {
     const value = e.target.value
     setSearchText(value)
     if (debounceRef.current) clearTimeout(debounceRef.current)
     debounceRef.current = setTimeout(() => {
+      const trimmed = value.trim()
       const { search: _, ...rest } = filters
-      onFiltersChange(value ? { ...rest, search: value, page: 1 } : { ...rest, page: 1 })
+      // Only search if we have enough characters, or if clearing
+      if (trimmed.length >= MIN_SEARCH_LENGTH) {
+        onFiltersChange({ ...rest, search: trimmed, page: 1 })
+      } else if (filters.search) {
+        // Had a previous search, now clearing it
+        onFiltersChange({ ...rest, page: 1 })
+      }
     }, 300)
   }
 
@@ -138,10 +187,10 @@ export function PipelineBatchList({
             <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2 h-3.5 w-3.5 -translate-y-1/2" />
             <input
               type="text"
-              placeholder="Search names..."
+              placeholder={`Search names (${MIN_SEARCH_LENGTH}+ chars)...`}
               value={searchText}
               onChange={handleSearchChange}
-              className="border-bark-300 bg-parchment-50 text-foreground dark:border-bark-600 dark:bg-bark-800 w-44 rounded-md border py-1 pr-2 pl-7 text-xs focus:ring-1 focus:ring-amber-500/50 focus:outline-none"
+              className="border-bark-300 bg-parchment-50 text-foreground dark:border-bark-600 dark:bg-bark-800 w-52 rounded-md border py-1 pr-2 pl-7 text-xs focus:ring-1 focus:ring-amber-500/50 focus:outline-none"
             />
           </div>
 
@@ -414,28 +463,22 @@ export function PipelineBatchList({
             </div>
           </div>
 
-          {/* Pagination: showing count + load more */}
+          {/* Pagination: showing count + infinite scroll sentinel */}
           <div className="flex items-center justify-between px-3 py-2">
             <span className="text-muted-foreground text-xs">
               Showing {items.length} of {total}
             </span>
-            {items.length < total && (
-              <button
-                onClick={onLoadMore}
-                disabled={isLoadingMore}
-                className="inline-flex items-center gap-1.5 rounded-md border border-amber-300 bg-amber-50 px-3 py-1 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-100 disabled:opacity-50 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-300 dark:hover:bg-amber-900/40"
-              >
-                {isLoadingMore ? (
-                  <>
-                    <Loader2 className="h-3 w-3 animate-spin" />
-                    Loading...
-                  </>
-                ) : (
-                  'Load more'
-                )}
-              </button>
+            {isLoadingMore && (
+              <span className="inline-flex items-center gap-1.5 text-xs text-amber-600 dark:text-amber-400">
+                <Loader2 className="h-3 w-3 animate-spin" />
+                Loading more...
+              </span>
             )}
           </div>
+          {/* Infinite scroll sentinel — triggers onLoadMore when scrolled into view */}
+          {items.length < total && onLoadMore && (
+            <InfiniteScrollSentinel onLoadMore={onLoadMore} isLoading={isLoadingMore ?? false} />
+          )}
         </>
       )}
     </div>

--- a/frontend/src/components/pipeline-debug/PipelineDetailPanel.tsx
+++ b/frontend/src/components/pipeline-debug/PipelineDetailPanel.tsx
@@ -24,8 +24,8 @@ interface PipelineDetailPanelProps {
   traceData: TraceData
   activeIntentIndex: number
   onTabChange: (idx: number) => void
-  onRunAgain: (phase: PipelinePhase) => void
-  onRunFromHere: (phase: PipelinePhase, writeToProduction: boolean) => void
+  onRerunPhase: (phase: PipelinePhase) => void
+  onRunFromHere: (phase: PipelinePhase) => void
   isRunning?: boolean
 }
 
@@ -34,15 +34,15 @@ export function PipelineDetailPanel({
   traceData,
   activeIntentIndex,
   onTabChange,
-  onRunAgain,
+  onRerunPhase,
   onRunFromHere,
   isRunning,
 }: PipelineDetailPanelProps) {
   const parentPhase = STAGE_TO_PHASE[selectedStage]
 
   const sharedProps = {
-    onRunAgain: () => onRunAgain(parentPhase),
-    onRunFromHere: (writeToProduction: boolean) => onRunFromHere(parentPhase, writeToProduction),
+    onRerunPhase: () => onRerunPhase(parentPhase),
+    onRunFromHere: () => onRunFromHere(parentPhase),
     ...(isRunning !== undefined ? { isRunning } : {}),
   }
 

--- a/frontend/src/components/pipeline-debug/PipelineSidebar.tsx
+++ b/frontend/src/components/pipeline-debug/PipelineSidebar.tsx
@@ -8,6 +8,12 @@ interface PipelineSidebarProps {
   onStageSelect: (stage: PipelineStage) => void
   stalePhases: Set<PipelinePhase>
   activeIntentIndex: number
+  /** Callback when user clicks "View all traces" for the requester. */
+  onViewAllTraces?: (cmId: number) => void
+  /** Callback to reprocess from source for this camper. */
+  onReprocess?: () => void
+  /** Whether a reprocess operation is in progress. */
+  isReprocessing?: boolean
 }
 
 export function PipelineSidebar({
@@ -16,10 +22,19 @@ export function PipelineSidebar({
   onStageSelect,
   stalePhases,
   activeIntentIndex,
+  onViewAllTraces,
+  onReprocess,
+  isReprocessing,
 }: PipelineSidebarProps) {
   return (
     <aside className="bg-card border-border shadow-lodge-sm flex w-[220px] shrink-0 flex-col gap-4 overflow-y-auto rounded-2xl border-2 p-3">
-      <RequestContext traceData={traceData} activeIntentIndex={activeIntentIndex} />
+      <RequestContext
+        traceData={traceData}
+        activeIntentIndex={activeIntentIndex}
+        {...(onViewAllTraces ? { onViewAllTraces } : {})}
+        {...(onReprocess ? { onReprocess } : {})}
+        {...(isReprocessing !== undefined ? { isReprocessing } : {})}
+      />
       <div className="border-border border-t pt-2">
         <StageNav
           traceData={traceData}

--- a/frontend/src/components/pipeline-debug/panels/ActionButtons.test.tsx
+++ b/frontend/src/components/pipeline-debug/panels/ActionButtons.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Tests for ActionButtons — dry-run-only phase replay buttons.
+ *
+ * Verifies:
+ * - Renders "Rerun this phase" (not "Run Again")
+ * - Does NOT render a "Write to production" checkbox or confirmation dialog
+ * - Clicking "Rerun this phase" calls onRerunPhase exactly once
+ * - Clicking "Run From Here" calls onRunFromHere with no arguments
+ */
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { ActionButtons } from './ActionButtons'
+
+describe('ActionButtons', () => {
+  it('renders "Rerun this phase" button (not "Run Again")', () => {
+    render(<ActionButtons onRerunPhase={vi.fn()} onRunFromHere={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /rerun this phase/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^run again$/i })).not.toBeInTheDocument()
+  })
+
+  it('renders "Run From Here" button', () => {
+    render(<ActionButtons onRerunPhase={vi.fn()} onRunFromHere={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /run from here/i })).toBeInTheDocument()
+  })
+
+  it('does NOT render a "Write to production" checkbox', () => {
+    render(<ActionButtons onRerunPhase={vi.fn()} onRunFromHere={vi.fn()} />)
+    expect(screen.queryByLabelText(/write to production/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/write to production/i)).not.toBeInTheDocument()
+  })
+
+  it('does NOT render a confirmation dialog', () => {
+    render(<ActionButtons onRerunPhase={vi.fn()} onRunFromHere={vi.fn()} />)
+    expect(screen.queryByText(/confirm production write/i)).not.toBeInTheDocument()
+  })
+
+  it('clicking "Rerun this phase" calls onRerunPhase exactly once', async () => {
+    const onRerunPhase = vi.fn()
+    const user = userEvent.setup()
+    render(<ActionButtons onRerunPhase={onRerunPhase} onRunFromHere={vi.fn()} />)
+    await user.click(screen.getByRole('button', { name: /rerun this phase/i }))
+    expect(onRerunPhase).toHaveBeenCalledTimes(1)
+  })
+
+  it('clicking "Run From Here" calls onRunFromHere exactly once (no writeToProduction arg)', async () => {
+    const onRunFromHere = vi.fn()
+    const user = userEvent.setup()
+    render(<ActionButtons onRerunPhase={vi.fn()} onRunFromHere={onRunFromHere} />)
+    await user.click(screen.getByRole('button', { name: /run from here/i }))
+    expect(onRunFromHere).toHaveBeenCalledTimes(1)
+    // The handler must no longer forward a writeToProduction boolean.
+    const firstArg = onRunFromHere.mock.calls[0]?.[0]
+    expect(typeof firstArg).not.toBe('boolean')
+  })
+
+  it('disables both buttons when isRunning=true', () => {
+    render(<ActionButtons onRerunPhase={vi.fn()} onRunFromHere={vi.fn()} isRunning={true} />)
+    expect(screen.getByRole('button', { name: /rerun this phase/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /run from here/i })).toBeDisabled()
+  })
+})

--- a/frontend/src/components/pipeline-debug/panels/ActionButtons.tsx
+++ b/frontend/src/components/pipeline-debug/panels/ActionButtons.tsx
@@ -1,64 +1,43 @@
 /**
- * ActionButtons - Shared "Run Again" and "Run From Here" buttons for detail panels.
+ * ActionButtons - Shared phase-replay buttons for detail panels.
  *
- * "Run Again" is always dry-run only.
- * "Run From Here" supports opt-in production write with confirmation dialog.
+ * Both buttons are dry-run-only developer/staff iteration tools. Production
+ * writes are exclusively handled by "Reprocess from source" (run-full-trace).
+ *
+ * - "Rerun this phase": isolated single-phase execution (uses stop_at_phase
+ *   on the backend). Downstream phases are unchanged. Useful for prompt
+ *   engineering or A/B testing a single phase's logic.
+ * - "Run From Here": cascade from this phase through the end of the pipeline.
+ *   Useful for vetting how a logic change ripples through downstream phases.
  */
 
-import { useState } from 'react'
-import { Play, FastForward, AlertTriangle } from 'lucide-react'
+import { Play, FastForward } from 'lucide-react'
 
 export interface ActionButtonsProps {
-  onRunAgain: () => void
-  onRunFromHere: (writeToProduction: boolean) => void
-  /** Number of bunk_requests that would be written if production write is enabled */
-  productionWriteCount?: number
-  /** Number of original_requests that would be marked processed */
-  processedCount?: number
+  onRerunPhase: () => void
+  onRunFromHere: () => void
   isRunning?: boolean | undefined
 }
 
 export function ActionButtons({
-  onRunAgain,
+  onRerunPhase,
   onRunFromHere,
-  productionWriteCount = 0,
-  processedCount = 0,
   isRunning = false,
 }: ActionButtonsProps) {
-  const [writeToProduction, setWriteToProduction] = useState(false)
-  const [showConfirmation, setShowConfirmation] = useState(false)
-
-  function handleRunFromHere() {
-    if (writeToProduction) {
-      setShowConfirmation(true)
-    } else {
-      onRunFromHere(false)
-    }
-  }
-
-  function handleConfirm() {
-    setShowConfirmation(false)
-    onRunFromHere(true)
-  }
-
-  function handleCancel() {
-    setShowConfirmation(false)
-  }
-
   return (
     <div className="border-border flex flex-wrap items-center gap-3 border-t pt-4">
       <button
-        onClick={onRunAgain}
+        onClick={onRerunPhase}
         disabled={isRunning}
         className="inline-flex items-center gap-1.5 rounded-lg bg-blue-50 px-3 py-1.5 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-100 disabled:opacity-50 dark:bg-blue-900/30 dark:text-blue-300 dark:hover:bg-blue-900/50"
-        aria-label="Run Again"
+        aria-label="Rerun this phase"
       >
         <Play className="h-3.5 w-3.5" />
-        Run Again
+        Rerun this phase
       </button>
 
       <button
-        onClick={handleRunFromHere}
+        onClick={onRunFromHere}
         disabled={isRunning}
         className="inline-flex items-center gap-1.5 rounded-lg bg-amber-50 px-3 py-1.5 text-sm font-medium text-amber-700 transition-colors hover:bg-amber-100 disabled:opacity-50 dark:bg-amber-900/30 dark:text-amber-300 dark:hover:bg-amber-900/50"
         aria-label="Run From Here"
@@ -66,49 +45,6 @@ export function ActionButtons({
         <FastForward className="h-3.5 w-3.5" />
         Run From Here
       </button>
-
-      <label className="text-muted-foreground inline-flex items-center gap-2 text-sm">
-        <input
-          type="checkbox"
-          checked={writeToProduction}
-          onChange={(e) => setWriteToProduction(e.target.checked)}
-          className="border-border rounded text-amber-500 focus:ring-amber-500"
-          aria-label="Write to production"
-        />
-        Write to production
-      </label>
-
-      {/* Confirmation dialog overlay */}
-      {showConfirmation && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-          <div className="bg-card shadow-lodge-lg mx-4 max-w-md rounded-xl p-6">
-            <div className="mb-4 flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/40">
-                <AlertTriangle className="h-5 w-5 text-amber-600 dark:text-amber-400" />
-              </div>
-              <h3 className="text-foreground text-lg font-semibold">Confirm Production Write</h3>
-            </div>
-            <p className="text-muted-foreground mb-6 text-sm">
-              This will write {productionWriteCount} bunk_requests to production and mark{' '}
-              {processedCount} original requests as processed. Proceed?
-            </p>
-            <div className="flex justify-end gap-3">
-              <button
-                onClick={handleCancel}
-                className="muted-foreground hover:bg-muted rounded-lg px-4 py-2 text-sm font-medium"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleConfirm}
-                className="rounded-lg bg-amber-500 px-4 py-2 text-sm font-medium text-white hover:bg-amber-600"
-              >
-                Confirm
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   )
 }

--- a/frontend/src/components/pipeline-debug/panels/BatchSignalsDetail.tsx
+++ b/frontend/src/components/pipeline-debug/panels/BatchSignalsDetail.tsx
@@ -4,14 +4,14 @@ import { DataRow, Badge, PanelSection } from './DataRow'
 
 interface BatchSignalsDetailProps {
   data: PostPipelineTrace
-  onRunAgain: () => void
-  onRunFromHere: (writeToProduction: boolean) => void
+  onRerunPhase: () => void
+  onRunFromHere: () => void
   isRunning?: boolean
 }
 
 export function BatchSignalsDetail({
   data,
-  onRunAgain,
+  onRerunPhase,
   onRunFromHere,
   isRunning,
 }: BatchSignalsDetailProps) {
@@ -70,7 +70,11 @@ export function BatchSignalsDetail({
         </PanelSection>
       )}
 
-      <ActionButtons onRunAgain={onRunAgain} onRunFromHere={onRunFromHere} isRunning={isRunning} />
+      <ActionButtons
+        onRerunPhase={onRerunPhase}
+        onRunFromHere={onRunFromHere}
+        isRunning={isRunning}
+      />
     </div>
   )
 }

--- a/frontend/src/components/pipeline-debug/panels/ConflictDetail.tsx
+++ b/frontend/src/components/pipeline-debug/panels/ConflictDetail.tsx
@@ -1,6 +1,7 @@
 import type { PostPipelineTrace } from '../types'
 import { ActionButtons } from './ActionButtons'
 import { Badge, PanelSection } from './DataRow'
+import { renderUnknownValue } from './panelUtils'
 
 interface ConflictDetailProps {
   data: PostPipelineTrace
@@ -41,14 +42,22 @@ export function ConflictDetail({
           </p>
         ) : (
           <div className="space-y-2">
-            {conflict_detection.details.map((detail, idx) => (
-              <div
-                key={idx}
-                className="rounded-lg bg-amber-50 px-3 py-2 text-sm text-amber-700 dark:bg-amber-900/20 dark:text-amber-300"
-              >
-                {String(detail)}
-              </div>
-            ))}
+            {conflict_detection.details.map((detail, idx) => {
+              const text = renderUnknownValue(detail)
+              const isObject = typeof detail === 'object' && detail !== null
+              return (
+                <div
+                  key={idx}
+                  className="rounded-lg bg-amber-50 px-3 py-2 text-sm text-amber-700 dark:bg-amber-900/20 dark:text-amber-300"
+                >
+                  {isObject ? (
+                    <pre className="font-mono text-xs whitespace-pre-wrap">{text}</pre>
+                  ) : (
+                    text
+                  )}
+                </div>
+              )
+            })}
           </div>
         )}
       </PanelSection>

--- a/frontend/src/components/pipeline-debug/panels/ConflictDetail.tsx
+++ b/frontend/src/components/pipeline-debug/panels/ConflictDetail.tsx
@@ -5,14 +5,14 @@ import { renderUnknownValue } from './panelUtils'
 
 interface ConflictDetailProps {
   data: PostPipelineTrace
-  onRunAgain: () => void
-  onRunFromHere: (writeToProduction: boolean) => void
+  onRerunPhase: () => void
+  onRunFromHere: () => void
   isRunning?: boolean
 }
 
 export function ConflictDetail({
   data,
-  onRunAgain,
+  onRerunPhase,
   onRunFromHere,
   isRunning,
 }: ConflictDetailProps) {
@@ -62,7 +62,11 @@ export function ConflictDetail({
         )}
       </PanelSection>
 
-      <ActionButtons onRunAgain={onRunAgain} onRunFromHere={onRunFromHere} isRunning={isRunning} />
+      <ActionButtons
+        onRerunPhase={onRerunPhase}
+        onRunFromHere={onRunFromHere}
+        isRunning={isRunning}
+      />
     </div>
   )
 }

--- a/frontend/src/components/pipeline-debug/panels/DedupDetail.tsx
+++ b/frontend/src/components/pipeline-debug/panels/DedupDetail.tsx
@@ -4,12 +4,12 @@ import { DataRow, Badge, PanelSection } from './DataRow'
 
 interface DedupDetailProps {
   data: PostPipelineTrace
-  onRunAgain: () => void
-  onRunFromHere: (writeToProduction: boolean) => void
+  onRerunPhase: () => void
+  onRunFromHere: () => void
   isRunning?: boolean
 }
 
-export function DedupDetail({ data, onRunAgain, onRunFromHere, isRunning }: DedupDetailProps) {
+export function DedupDetail({ data, onRerunPhase, onRunFromHere, isRunning }: DedupDetailProps) {
   const { deduplication, self_reference, final_bunk_requests } = data
 
   return (
@@ -49,10 +49,8 @@ export function DedupDetail({ data, onRunAgain, onRunFromHere, isRunning }: Dedu
       </PanelSection>
 
       <ActionButtons
-        onRunAgain={onRunAgain}
+        onRerunPhase={onRerunPhase}
         onRunFromHere={onRunFromHere}
-        productionWriteCount={final_bunk_requests.length}
-        processedCount={1}
         isRunning={isRunning}
       />
     </div>

--- a/frontend/src/components/pipeline-debug/panels/DetailPanels.test.tsx
+++ b/frontend/src/components/pipeline-debug/panels/DetailPanels.test.tsx
@@ -32,7 +32,7 @@ import type {
 
 // Common action callbacks
 const defaultActions = {
-  onRunAgain: vi.fn(),
+  onRerunPhase: vi.fn(),
   onRunFromHere: vi.fn(),
   activeTab: 0,
   onTabChange: vi.fn(),
@@ -329,7 +329,7 @@ describe('PrePhase1Detail', () => {
 
   it('renders action buttons', () => {
     render(<PrePhase1Detail data={prePhase1} {...defaultActions} />)
-    expect(screen.getByRole('button', { name: /run again/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /rerun this phase/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /run from here/i })).toBeInTheDocument()
   })
 })
@@ -626,7 +626,7 @@ describe('BatchSignalsDetail', () => {
 
   it('renders action buttons', () => {
     render(<BatchSignalsDetail data={postPipeline} {...defaultActions} />)
-    expect(screen.getByRole('button', { name: /run again/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /rerun this phase/i })).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/components/pipeline-debug/panels/DetailPanels.test.tsx
+++ b/frontend/src/components/pipeline-debug/panels/DetailPanels.test.tsx
@@ -379,6 +379,27 @@ describe('ValidationDetail', () => {
     render(<ValidationDetail data={validation} {...defaultActions} />)
     expect(screen.getByText(/1 filtered/i)).toBeInTheDocument()
   })
+
+  it('renders object rejected items without [object Object]', () => {
+    const withObjectRejections: ValidationTrace = {
+      type_validation: {
+        passed: false,
+        rejected: [
+          { field: 'target_name', reason: 'Invalid type for field' },
+          'Simple string rejection',
+        ],
+      },
+      temporal_conflicts: {
+        filtered: 1,
+        details: [{ type: 'superseded', original: 'old request', replacement: 'new request' }],
+      },
+      source_text_validation: { rejected: 0, hallucinated_names: [], unit_names: [] },
+    }
+    render(<ValidationDetail data={withObjectRejections} {...defaultActions} />)
+    expect(screen.queryByText('[object Object]')).not.toBeInTheDocument()
+    expect(screen.getByText('Simple string rejection')).toBeInTheDocument()
+    expect(screen.getByText(/Invalid type for field/)).toBeInTheDocument()
+  })
 })
 
 // =============================================================================
@@ -439,6 +460,35 @@ describe('ExpansionDetail', () => {
   it('renders expanded target names', () => {
     render(<ExpansionDetail data={expansion} {...defaultActions} />)
     expect(screen.getByText(/Olivia Chen/)).toBeInTheDocument()
+  })
+
+  it('renders object targets without [object Object]', () => {
+    const withObjectTargets: PlaceholderExpansionTrace = {
+      triggered: true,
+      type: 'bunkmates',
+      expanded_count: 2,
+      expanded_targets: [
+        { cm_id: 1001, name: 'Emma Johnson' },
+        { cm_id: 1002, first_name: 'Liam', last_name: 'Garcia' },
+      ],
+    }
+    render(<ExpansionDetail data={withObjectTargets} {...defaultActions} />)
+    expect(screen.queryByText('[object Object]')).not.toBeInTheDocument()
+    // First target has a name field
+    expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
+    // Second target has no name field but should still render readably
+    expect(screen.getByText(/Liam/)).toBeInTheDocument()
+  })
+
+  it('renders primitive targets directly', () => {
+    const withStringTargets: PlaceholderExpansionTrace = {
+      triggered: true,
+      type: 'siblings',
+      expanded_count: 1,
+      expanded_targets: ['Emma Johnson' as unknown as Record<string, unknown>],
+    }
+    render(<ExpansionDetail data={withStringTargets} {...defaultActions} />)
+    expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
   })
 })
 
@@ -584,6 +634,51 @@ describe('ConflictDetail', () => {
   it('renders clean state when no conflicts', () => {
     render(<ConflictDetail data={postPipeline} {...defaultActions} />)
     expect(screen.getByText(/no enrollment/i)).toBeInTheDocument()
+  })
+
+  it('renders object details without [object Object]', () => {
+    const withConflicts: PostPipelineTrace = {
+      ...postPipeline,
+      conflict_detection: {
+        has_conflict: true,
+        details: [
+          { type: 'enrollment', message: 'Not enrolled in session' },
+          'Simple string conflict',
+        ],
+      },
+    }
+    render(<ConflictDetail data={withConflicts} {...defaultActions} />)
+    // Object should be serialized readably, not as [object Object]
+    expect(screen.queryByText('[object Object]')).not.toBeInTheDocument()
+    // The string detail should render directly
+    expect(screen.getByText('Simple string conflict')).toBeInTheDocument()
+    // The object detail should show its contents
+    expect(screen.getByText(/Not enrolled in session/)).toBeInTheDocument()
+  })
+
+  it('renders null and undefined details gracefully', () => {
+    const withNullDetails: PostPipelineTrace = {
+      ...postPipeline,
+      conflict_detection: {
+        has_conflict: true,
+        details: [null, undefined, ''],
+      },
+    }
+    render(<ConflictDetail data={withNullDetails} {...defaultActions} />)
+    expect(screen.queryByText('[object Object]')).not.toBeInTheDocument()
+  })
+
+  it('renders array details without [object Object]', () => {
+    const withArrayDetails: PostPipelineTrace = {
+      ...postPipeline,
+      conflict_detection: {
+        has_conflict: true,
+        details: [['nested', 'array', 'values']],
+      },
+    }
+    render(<ConflictDetail data={withArrayDetails} {...defaultActions} />)
+    expect(screen.queryByText('[object Object]')).not.toBeInTheDocument()
+    expect(screen.getByText(/nested/)).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/components/pipeline-debug/panels/DispositionDetail.tsx
+++ b/frontend/src/components/pipeline-debug/panels/DispositionDetail.tsx
@@ -4,8 +4,8 @@ import { Badge, PanelSection } from './DataRow'
 
 interface DispositionDetailProps {
   data: PostPipelineTrace
-  onRunAgain: () => void
-  onRunFromHere: (writeToProduction: boolean) => void
+  onRerunPhase: () => void
+  onRunFromHere: () => void
   isRunning?: boolean
 }
 
@@ -24,7 +24,7 @@ function statusColor(status: string): 'green' | 'amber' | 'red' | 'gray' {
 
 export function DispositionDetail({
   data,
-  onRunAgain,
+  onRerunPhase,
   onRunFromHere,
   isRunning,
 }: DispositionDetailProps) {
@@ -80,7 +80,11 @@ export function DispositionDetail({
         )}
       </PanelSection>
 
-      <ActionButtons onRunAgain={onRunAgain} onRunFromHere={onRunFromHere} isRunning={isRunning} />
+      <ActionButtons
+        onRerunPhase={onRerunPhase}
+        onRunFromHere={onRunFromHere}
+        isRunning={isRunning}
+      />
     </div>
   )
 }

--- a/frontend/src/components/pipeline-debug/panels/ExpansionDetail.tsx
+++ b/frontend/src/components/pipeline-debug/panels/ExpansionDetail.tsx
@@ -10,6 +10,7 @@ import type { PlaceholderExpansionTrace } from '../types'
 import { ActionButtons } from './ActionButtons'
 import { DataRow, Badge, PanelSection } from './DataRow'
 import { PhaseHeader } from './PhaseHeader'
+import { renderUnknownValue } from './panelUtils'
 
 interface ExpansionDetailProps {
   data: PlaceholderExpansionTrace
@@ -56,13 +57,40 @@ export function ExpansionDetail({
           <p className="text-muted-foreground text-sm italic">No expansion performed</p>
         ) : (
           <div className="space-y-1">
-            {data.expanded_targets.map((target, idx) => (
-              <div key={idx} className="bg-muted text-foreground rounded-md px-3 py-1.5 text-sm">
-                {String(
-                  (target as Record<string, string | undefined>)['name'] ?? JSON.stringify(target)
-                )}
-              </div>
-            ))}
+            {data.expanded_targets.map((target, idx) => {
+              // Primitives: render directly
+              if (typeof target !== 'object' || target === null) {
+                return (
+                  <div
+                    key={idx}
+                    className="bg-muted text-foreground rounded-md px-3 py-1.5 text-sm"
+                  >
+                    {renderUnknownValue(target)}
+                  </div>
+                )
+              }
+              // Objects: prefer name field, fall back to JSON
+              const obj = target as Record<string, unknown>
+              const name = obj['name'] ?? obj['first_name']
+              if (typeof name === 'string') {
+                const lastName = typeof obj['last_name'] === 'string' ? ` ${obj['last_name']}` : ''
+                return (
+                  <div
+                    key={idx}
+                    className="bg-muted text-foreground rounded-md px-3 py-1.5 text-sm"
+                  >
+                    {name + lastName}
+                  </div>
+                )
+              }
+              return (
+                <div key={idx} className="bg-muted text-foreground rounded-md px-3 py-1.5 text-sm">
+                  <pre className="font-mono text-xs whitespace-pre-wrap">
+                    {JSON.stringify(target, null, 2)}
+                  </pre>
+                </div>
+              )
+            })}
           </div>
         )}
       </PanelSection>

--- a/frontend/src/components/pipeline-debug/panels/ExpansionDetail.tsx
+++ b/frontend/src/components/pipeline-debug/panels/ExpansionDetail.tsx
@@ -14,14 +14,14 @@ import { renderUnknownValue } from './panelUtils'
 
 interface ExpansionDetailProps {
   data: PlaceholderExpansionTrace
-  onRunAgain: () => void
-  onRunFromHere: (writeToProduction: boolean) => void
+  onRerunPhase: () => void
+  onRunFromHere: () => void
   isRunning?: boolean | undefined
 }
 
 export function ExpansionDetail({
   data,
-  onRunAgain,
+  onRerunPhase,
   onRunFromHere,
   isRunning,
 }: ExpansionDetailProps) {
@@ -95,7 +95,11 @@ export function ExpansionDetail({
         )}
       </PanelSection>
 
-      <ActionButtons onRunAgain={onRunAgain} onRunFromHere={onRunFromHere} isRunning={isRunning} />
+      <ActionButtons
+        onRerunPhase={onRerunPhase}
+        onRunFromHere={onRunFromHere}
+        isRunning={isRunning}
+      />
     </div>
   )
 }

--- a/frontend/src/components/pipeline-debug/panels/HistoricalDetail.tsx
+++ b/frontend/src/components/pipeline-debug/panels/HistoricalDetail.tsx
@@ -13,14 +13,14 @@ import { PhaseHeader } from './PhaseHeader'
 
 interface HistoricalDetailProps {
   data: HistoricalVerificationTrace
-  onRunAgain: () => void
-  onRunFromHere: (writeToProduction: boolean) => void
+  onRerunPhase: () => void
+  onRunFromHere: () => void
   isRunning?: boolean | undefined
 }
 
 export function HistoricalDetail({
   data,
-  onRunAgain,
+  onRerunPhase,
   onRunFromHere,
   isRunning,
 }: HistoricalDetailProps) {
@@ -89,7 +89,11 @@ export function HistoricalDetail({
         )}
       </PanelSection>
 
-      <ActionButtons onRunAgain={onRunAgain} onRunFromHere={onRunFromHere} isRunning={isRunning} />
+      <ActionButtons
+        onRerunPhase={onRerunPhase}
+        onRunFromHere={onRunFromHere}
+        isRunning={isRunning}
+      />
     </div>
   )
 }

--- a/frontend/src/components/pipeline-debug/panels/Phase1Detail.tsx
+++ b/frontend/src/components/pipeline-debug/panels/Phase1Detail.tsx
@@ -15,12 +15,12 @@ import { confidenceColor } from './panelUtils'
 
 interface Phase1DetailProps {
   data: Phase1Trace
-  onRunAgain: () => void
-  onRunFromHere: (writeToProduction: boolean) => void
+  onRerunPhase: () => void
+  onRunFromHere: () => void
   isRunning?: boolean | undefined
 }
 
-export function Phase1Detail({ data, onRunAgain, onRunFromHere, isRunning }: Phase1DetailProps) {
+export function Phase1Detail({ data, onRerunPhase, onRunFromHere, isRunning }: Phase1DetailProps) {
   const status = !data.ran ? 'not_run' : data.is_valid ? 'ran' : 'error'
 
   return (
@@ -135,7 +135,11 @@ export function Phase1Detail({ data, onRunAgain, onRunFromHere, isRunning }: Pha
         </pre>
       </CollapsibleSection>
 
-      <ActionButtons onRunAgain={onRunAgain} onRunFromHere={onRunFromHere} isRunning={isRunning} />
+      <ActionButtons
+        onRerunPhase={onRerunPhase}
+        onRunFromHere={onRunFromHere}
+        isRunning={isRunning}
+      />
     </div>
   )
 }

--- a/frontend/src/components/pipeline-debug/panels/Phase2Detail.tsx
+++ b/frontend/src/components/pipeline-debug/panels/Phase2Detail.tsx
@@ -18,8 +18,8 @@ interface Phase2DetailProps {
   data: Phase2IntentTrace[]
   activeTab: number
   onTabChange: (idx: number) => void
-  onRunAgain: () => void
-  onRunFromHere: (writeToProduction: boolean) => void
+  onRerunPhase: () => void
+  onRunFromHere: () => void
   isRunning?: boolean | undefined
 }
 
@@ -192,7 +192,7 @@ export function Phase2Detail({
   data,
   activeTab,
   onTabChange,
-  onRunAgain,
+  onRerunPhase,
   onRunFromHere,
   isRunning,
 }: Phase2DetailProps) {
@@ -223,7 +223,11 @@ export function Phase2Detail({
         </>
       )}
 
-      <ActionButtons onRunAgain={onRunAgain} onRunFromHere={onRunFromHere} isRunning={isRunning} />
+      <ActionButtons
+        onRerunPhase={onRerunPhase}
+        onRunFromHere={onRunFromHere}
+        isRunning={isRunning}
+      />
     </div>
   )
 }

--- a/frontend/src/components/pipeline-debug/panels/Phase3Detail.tsx
+++ b/frontend/src/components/pipeline-debug/panels/Phase3Detail.tsx
@@ -17,8 +17,8 @@ interface Phase3DetailProps {
   data: Phase3IntentTrace[]
   activeTab: number
   onTabChange: (idx: number) => void
-  onRunAgain: () => void
-  onRunFromHere: (writeToProduction: boolean) => void
+  onRerunPhase: () => void
+  onRunFromHere: () => void
   isRunning?: boolean | undefined
 }
 
@@ -151,7 +151,7 @@ export function Phase3Detail({
   data,
   activeTab,
   onTabChange,
-  onRunAgain,
+  onRerunPhase,
   onRunFromHere,
   isRunning,
 }: Phase3DetailProps) {
@@ -183,7 +183,11 @@ export function Phase3Detail({
         </>
       )}
 
-      <ActionButtons onRunAgain={onRunAgain} onRunFromHere={onRunFromHere} isRunning={isRunning} />
+      <ActionButtons
+        onRerunPhase={onRerunPhase}
+        onRunFromHere={onRunFromHere}
+        isRunning={isRunning}
+      />
     </div>
   )
 }

--- a/frontend/src/components/pipeline-debug/panels/PrePhase1Detail.tsx
+++ b/frontend/src/components/pipeline-debug/panels/PrePhase1Detail.tsx
@@ -14,14 +14,14 @@ import { CollapsibleSection } from './CollapsibleSection'
 
 interface PrePhase1DetailProps {
   data: PrePhase1Trace
-  onRunAgain: () => void
-  onRunFromHere: (writeToProduction: boolean) => void
+  onRerunPhase: () => void
+  onRunFromHere: () => void
   isRunning?: boolean | undefined
 }
 
 export function PrePhase1Detail({
   data,
-  onRunAgain,
+  onRerunPhase,
   onRunFromHere,
   isRunning,
 }: PrePhase1DetailProps) {
@@ -78,7 +78,11 @@ export function PrePhase1Detail({
         </CollapsibleSection>
       )}
 
-      <ActionButtons onRunAgain={onRunAgain} onRunFromHere={onRunFromHere} isRunning={isRunning} />
+      <ActionButtons
+        onRerunPhase={onRerunPhase}
+        onRunFromHere={onRunFromHere}
+        isRunning={isRunning}
+      />
     </div>
   )
 }

--- a/frontend/src/components/pipeline-debug/panels/ValidationDetail.tsx
+++ b/frontend/src/components/pipeline-debug/panels/ValidationDetail.tsx
@@ -14,14 +14,14 @@ import { renderUnknownValue } from './panelUtils'
 
 interface ValidationDetailProps {
   data: ValidationTrace
-  onRunAgain: () => void
-  onRunFromHere: (writeToProduction: boolean) => void
+  onRerunPhase: () => void
+  onRunFromHere: () => void
   isRunning?: boolean | undefined
 }
 
 export function ValidationDetail({
   data,
-  onRunAgain,
+  onRerunPhase,
   onRunFromHere,
   isRunning,
 }: ValidationDetailProps) {
@@ -170,7 +170,11 @@ export function ValidationDetail({
         )}
       </PanelSection>
 
-      <ActionButtons onRunAgain={onRunAgain} onRunFromHere={onRunFromHere} isRunning={isRunning} />
+      <ActionButtons
+        onRerunPhase={onRerunPhase}
+        onRunFromHere={onRunFromHere}
+        isRunning={isRunning}
+      />
     </div>
   )
 }

--- a/frontend/src/components/pipeline-debug/panels/ValidationDetail.tsx
+++ b/frontend/src/components/pipeline-debug/panels/ValidationDetail.tsx
@@ -10,6 +10,7 @@ import type { ValidationTrace } from '../types'
 import { ActionButtons } from './ActionButtons'
 import { DataRow, Badge, PanelSection } from './DataRow'
 import { PhaseHeader } from './PhaseHeader'
+import { renderUnknownValue } from './panelUtils'
 
 interface ValidationDetailProps {
   data: ValidationTrace
@@ -63,9 +64,19 @@ export function ValidationDetail({
           </div>
           {data.type_validation.rejected.length > 0 && (
             <ul className="mt-1 list-inside list-disc text-sm text-red-700 dark:text-red-300">
-              {data.type_validation.rejected.map((item, idx) => (
-                <li key={idx}>{String(item)}</li>
-              ))}
+              {data.type_validation.rejected.map((item, idx) => {
+                const text = renderUnknownValue(item)
+                const isObject = typeof item === 'object' && item !== null
+                return (
+                  <li key={idx}>
+                    {isObject ? (
+                      <pre className="inline font-mono text-xs whitespace-pre-wrap">{text}</pre>
+                    ) : (
+                      text
+                    )}
+                  </li>
+                )
+              })}
             </ul>
           )}
         </div>
@@ -81,9 +92,19 @@ export function ValidationDetail({
           </div>
           {data.temporal_conflicts.details.length > 0 && (
             <ul className="text-foreground mt-1 list-inside list-disc text-sm">
-              {data.temporal_conflicts.details.map((detail, idx) => (
-                <li key={idx}>{String(detail)}</li>
-              ))}
+              {data.temporal_conflicts.details.map((detail, idx) => {
+                const text = renderUnknownValue(detail)
+                const isObject = typeof detail === 'object' && detail !== null
+                return (
+                  <li key={idx}>
+                    {isObject ? (
+                      <pre className="inline font-mono text-xs whitespace-pre-wrap">{text}</pre>
+                    ) : (
+                      text
+                    )}
+                  </li>
+                )
+              })}
             </ul>
           )}
         </div>

--- a/frontend/src/components/pipeline-debug/panels/panelUtils.ts
+++ b/frontend/src/components/pipeline-debug/panels/panelUtils.ts
@@ -6,3 +6,21 @@ export function confidenceColor(c: number): 'green' | 'amber' | 'red' {
   if (c >= 0.5) return 'amber'
   return 'red'
 }
+
+/**
+ * Safely render an unknown value as a human-readable string.
+ * Prevents `[object Object]` from appearing in the UI by serializing
+ * objects/arrays with JSON.stringify and passing through primitives.
+ */
+export function renderUnknownValue(value: unknown): string {
+  if (value === null) return 'null'
+  if (value === undefined) return ''
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  // Objects, arrays, etc.
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}

--- a/frontend/src/components/pipeline-debug/sidebar/RequestContext.test.tsx
+++ b/frontend/src/components/pipeline-debug/sidebar/RequestContext.test.tsx
@@ -2,6 +2,7 @@
  * Tests for RequestContext sidebar component.
  */
 
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { RequestContext } from './RequestContext'
@@ -16,7 +17,7 @@ const minimalTraceData: TraceData = {
     na_prefix_stripped: false,
     skip_reason: null,
     socialize_mapped_value: null,
-    requester_info: { name: 'Liam Garcia', cm_id: 12345, grade: 5 },
+    requester_info: { name: 'Liam Garcia', cm_id: 12345, grade: '5' },
     session_cm_ids: [1000001],
     staff_metadata: null,
   },
@@ -30,13 +31,14 @@ const minimalTraceData: TraceData = {
         confidence: 0.9,
         keywords_found: [],
         needs_clarification: false,
-        reasoning: null,
+        reasoning: '',
         ai_reasoning_summary: null,
-        parse_notes: null,
+        parse_notes: '',
         temporal_info: null,
+        csv_position: 0,
       },
     ],
-    ai_raw_response: null,
+    ai_raw_response: {},
     parse_request: {},
     error_message: null,
     ai_reasoning_summary: null,
@@ -106,12 +108,16 @@ const minimalTraceData: TraceData = {
     },
     final_bunk_requests: [
       {
+        bunk_request_id: null,
+        requester_cm_id: 12345,
+        requested_cm_id: 54321,
         requested_name: 'Emma Johnson',
-        target_cm_id: 54321,
+        request_type: 'BUNK_WITH',
         status: 'RESOLVED',
         priority: 1,
         confidence: 0.95,
         resolution_method: 'exact_match',
+        is_placeholder: false,
         declined_reason: '',
         disposition_reason: '',
         is_reciprocal: false,

--- a/frontend/src/components/pipeline-debug/sidebar/RequestContext.test.tsx
+++ b/frontend/src/components/pipeline-debug/sidebar/RequestContext.test.tsx
@@ -184,7 +184,7 @@ describe('RequestContext', () => {
     )
     await user.click(screen.getByRole('button', { name: /reprocess/i }))
     // Should show confirmation dialog with the camper's name in context
-    expect(screen.getByText(/replace all processed requests/i)).toBeInTheDocument()
+    expect(screen.getByText(/regenerate all parsed requests/i)).toBeInTheDocument()
     // The name appears both in sidebar and dialog; just verify the dialog text exists
     expect(screen.getByRole('button', { name: /confirm/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
@@ -221,6 +221,6 @@ describe('RequestContext', () => {
     await user.click(screen.getByRole('button', { name: /cancel/i }))
     expect(onReprocess).not.toHaveBeenCalled()
     // Dialog should be dismissed
-    expect(screen.queryByText(/replace all processed requests/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/regenerate all parsed requests/i)).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/pipeline-debug/sidebar/RequestContext.test.tsx
+++ b/frontend/src/components/pipeline-debug/sidebar/RequestContext.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * Tests for RequestContext sidebar component.
+ */
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RequestContext } from './RequestContext'
+import type { TraceData } from '../types'
+
+const minimalTraceData: TraceData = {
+  pre_phase1: {
+    original_text: 'I want to bunk with Emma Johnson',
+    cleaned_text: 'I want to bunk with Emma Johnson',
+    field_path: 'bunk_with',
+    action: 'parsed',
+    na_prefix_stripped: false,
+    skip_reason: null,
+    socialize_mapped_value: null,
+    requester_info: { name: 'Liam Garcia', cm_id: 12345, grade: 5 },
+    session_cm_ids: [1000001],
+    staff_metadata: null,
+  },
+  phase1_parse: {
+    ran: true,
+    is_valid: true,
+    parsed_intents: [
+      {
+        target_name: 'Emma Johnson',
+        request_type: 'BUNK_WITH',
+        confidence: 0.9,
+        keywords_found: [],
+        needs_clarification: false,
+        reasoning: null,
+        ai_reasoning_summary: null,
+        parse_notes: null,
+        temporal_info: null,
+      },
+    ],
+    ai_raw_response: null,
+    parse_request: {},
+    error_message: null,
+    ai_reasoning_summary: null,
+    token_count: null,
+    processing_time_ms: null,
+    sanitization: {
+      is_suspicious: false,
+      risk_level: null,
+      confidence_penalty: 0,
+    },
+  },
+  validation: {
+    type_validation: { passed: true, rejected: [] },
+    temporal_conflicts: { filtered: 0, details: [] },
+    source_text_validation: { rejected: 0, hallucinated_names: [], unit_names: [] },
+  },
+  phase2_resolution: [
+    {
+      target_name: 'Emma Johnson',
+      fast_path_tried: [],
+      fast_path_result: null,
+      pipeline_strategies_tried: [],
+      final_result: {
+        person_name: 'Emma Johnson',
+        person_cm_id: 54321,
+        confidence: 0.95,
+        method: 'exact_match',
+        is_resolved: true,
+        is_ambiguous: false,
+        confidence_factors: {},
+      },
+      all_candidates: [],
+      social_graph_details: {
+        enhanced: false,
+        connection_strength: null,
+        shared_friends: null,
+        smart_resolved: false,
+        candidates_reranked: false,
+      },
+      staff_filtered: false,
+      hallucination_detected: false,
+      spread_filter_applied: false,
+    },
+  ],
+  placeholder_expansion: {
+    triggered: false,
+    type: null,
+    expanded_count: 0,
+    expanded_targets: [],
+  },
+  historical_verification: {
+    ran: false,
+    boost_applied: false,
+    original_confidence: null,
+    boosted_confidence: null,
+  },
+  phase3_disambiguation: [],
+  post_pipeline: {
+    conflict_detection: { has_conflict: false, details: [] },
+    self_reference: { detected: false },
+    deduplication: { was_duplicate: false, kept_over: null },
+    reciprocal: {
+      detected: false,
+      pair_cm_id: null,
+      boost_applied: false,
+      boost_amount: null,
+    },
+    final_bunk_requests: [
+      {
+        requested_name: 'Emma Johnson',
+        target_cm_id: 54321,
+        status: 'RESOLVED',
+        priority: 1,
+        confidence: 0.95,
+        resolution_method: 'exact_match',
+        declined_reason: '',
+        disposition_reason: '',
+        is_reciprocal: false,
+      },
+    ],
+  },
+}
+
+describe('RequestContext', () => {
+  it('renders requester name and CM ID', () => {
+    render(<RequestContext traceData={minimalTraceData} activeIntentIndex={0} />)
+    expect(screen.getByText('Liam Garcia')).toBeInTheDocument()
+    expect(screen.getByText(/CM 12345/)).toBeInTheDocument()
+  })
+
+  it('renders "View all traces" button with camper CM ID', () => {
+    const onViewAllTraces = vi.fn()
+    render(
+      <RequestContext
+        traceData={minimalTraceData}
+        activeIntentIndex={0}
+        onViewAllTraces={onViewAllTraces}
+      />
+    )
+    const btn = screen.getByRole('button', { name: /all traces/i })
+    expect(btn).toBeInTheDocument()
+  })
+
+  it('calls onViewAllTraces with requester cm_id when button clicked', async () => {
+    const user = userEvent.setup()
+    const onViewAllTraces = vi.fn()
+    render(
+      <RequestContext
+        traceData={minimalTraceData}
+        activeIntentIndex={0}
+        onViewAllTraces={onViewAllTraces}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /all traces/i }))
+    expect(onViewAllTraces).toHaveBeenCalledWith(12345)
+  })
+
+  it('renders "Reprocess" button when onReprocess callback is provided', () => {
+    const onReprocess = vi.fn()
+    render(
+      <RequestContext
+        traceData={minimalTraceData}
+        activeIntentIndex={0}
+        onReprocess={onReprocess}
+      />
+    )
+    expect(screen.getByRole('button', { name: /reprocess/i })).toBeInTheDocument()
+  })
+
+  it('shows confirmation dialog when Reprocess is clicked', async () => {
+    const user = userEvent.setup()
+    const onReprocess = vi.fn()
+    render(
+      <RequestContext
+        traceData={minimalTraceData}
+        activeIntentIndex={0}
+        onReprocess={onReprocess}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /reprocess/i }))
+    // Should show confirmation dialog with the camper's name in context
+    expect(screen.getByText(/replace all processed requests/i)).toBeInTheDocument()
+    // The name appears both in sidebar and dialog; just verify the dialog text exists
+    expect(screen.getByRole('button', { name: /confirm/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it('calls onReprocess when confirmation is accepted', async () => {
+    const user = userEvent.setup()
+    const onReprocess = vi.fn()
+    render(
+      <RequestContext
+        traceData={minimalTraceData}
+        activeIntentIndex={0}
+        onReprocess={onReprocess}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /reprocess/i }))
+    // Click the confirm button in the dialog
+    await user.click(screen.getByRole('button', { name: /confirm/i }))
+    expect(onReprocess).toHaveBeenCalled()
+  })
+
+  it('does not call onReprocess when confirmation is cancelled', async () => {
+    const user = userEvent.setup()
+    const onReprocess = vi.fn()
+    render(
+      <RequestContext
+        traceData={minimalTraceData}
+        activeIntentIndex={0}
+        onReprocess={onReprocess}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /reprocess/i }))
+    // Click the cancel button in the dialog
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onReprocess).not.toHaveBeenCalled()
+    // Dialog should be dismissed
+    expect(screen.queryByText(/replace all processed requests/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/pipeline-debug/sidebar/RequestContext.tsx
+++ b/frontend/src/components/pipeline-debug/sidebar/RequestContext.tsx
@@ -165,11 +165,13 @@ export function RequestContext({
           <div className="bg-card shadow-lodge-lg mx-4 max-w-sm rounded-xl p-5">
             <div className="mb-3 flex items-center gap-2">
               <AlertTriangle className="h-5 w-5 text-amber-500" />
-              <h3 className="text-foreground text-sm font-semibold">Confirm Reprocess</h3>
+              <h3 className="text-foreground text-sm font-semibold">Reprocess from Source</h3>
             </div>
             <p className="text-muted-foreground mb-4 text-xs">
-              This will replace all processed requests for{' '}
-              <span className="text-foreground font-medium">{requester_info.name}</span>. Continue?
+              Re-run the full pipeline for{' '}
+              <span className="text-foreground font-medium">{requester_info.name}</span>&apos;s
+              original bunk request text. This will regenerate all parsed requests from the source
+              CSV row and write them to production.
             </p>
             <div className="flex justify-end gap-2">
               <button

--- a/frontend/src/components/pipeline-debug/sidebar/RequestContext.tsx
+++ b/frontend/src/components/pipeline-debug/sidebar/RequestContext.tsx
@@ -1,9 +1,17 @@
+import { useState } from 'react'
+import { History, RotateCcw, AlertTriangle } from 'lucide-react'
 import type { TraceData } from '../types'
 
 interface RequestContextProps {
   traceData: TraceData
   /** Currently selected intent index (from IntentTabs in Phase2/Phase3 detail panels). */
   activeIntentIndex: number
+  /** Callback when user clicks "View all traces" for the requester. Receives requester CM ID. */
+  onViewAllTraces?: (cmId: number) => void
+  /** Callback to reprocess from source for this camper. */
+  onReprocess?: () => void
+  /** Whether a reprocess operation is in progress. */
+  isReprocessing?: boolean
 }
 
 /** Source field display names. */
@@ -31,7 +39,14 @@ function statusColor(status: string): string {
   }
 }
 
-export function RequestContext({ traceData, activeIntentIndex }: RequestContextProps) {
+export function RequestContext({
+  traceData,
+  activeIntentIndex,
+  onViewAllTraces,
+  onReprocess,
+  isReprocessing,
+}: RequestContextProps) {
+  const [showReprocessConfirm, setShowReprocessConfirm] = useState(false)
   const { requester_info, original_text, field_path } = traceData.pre_phase1
   const intents = traceData.phase1_parse.parsed_intents
   const totalIntents = intents.length
@@ -116,6 +131,64 @@ export function RequestContext({ traceData, activeIntentIndex }: RequestContextP
             activeBR.disposition_reason !== activeBR.resolution_method && (
               <p className="text-muted-foreground text-[10px]">{activeBR.disposition_reason}</p>
             )}
+        </div>
+      )}
+
+      {/* Action buttons */}
+      {(onViewAllTraces || onReprocess) && (
+        <div className="border-border flex flex-col gap-1.5 border-t pt-2">
+          {onViewAllTraces && (
+            <button
+              onClick={() => onViewAllTraces(requester_info.cm_id)}
+              className="text-primary hover:text-primary/80 inline-flex items-center gap-1 text-xs font-medium transition-colors"
+            >
+              <History className="h-3 w-3" />
+              View all traces
+            </button>
+          )}
+          {onReprocess && (
+            <button
+              onClick={() => setShowReprocessConfirm(true)}
+              disabled={isReprocessing}
+              className="inline-flex items-center gap-1 text-xs font-medium text-amber-600 transition-colors hover:text-amber-700 disabled:opacity-50 dark:text-amber-400 dark:hover:text-amber-300"
+            >
+              <RotateCcw className={`h-3 w-3 ${isReprocessing ? 'animate-spin' : ''}`} />
+              {isReprocessing ? 'Reprocessing...' : 'Reprocess from source'}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Reprocess confirmation dialog */}
+      {showReprocessConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="bg-card shadow-lodge-lg mx-4 max-w-sm rounded-xl p-5">
+            <div className="mb-3 flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-amber-500" />
+              <h3 className="text-foreground text-sm font-semibold">Confirm Reprocess</h3>
+            </div>
+            <p className="text-muted-foreground mb-4 text-xs">
+              This will replace all processed requests for{' '}
+              <span className="text-foreground font-medium">{requester_info.name}</span>. Continue?
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setShowReprocessConfirm(false)}
+                className="text-muted-foreground hover:bg-muted rounded-md px-3 py-1.5 text-xs font-medium"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => {
+                  setShowReprocessConfirm(false)
+                  onReprocess?.()
+                }}
+                className="rounded-md bg-amber-500 px-3 py-1.5 text-xs font-medium text-white hover:bg-amber-600"
+              >
+                Confirm
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/components/pipeline-debug/types.ts
+++ b/frontend/src/components/pipeline-debug/types.ts
@@ -296,6 +296,8 @@ export interface PipelineSummaryFilters {
   page?: number
   per_page?: number
   sort?: string
+  /** Free-text search across requester_name and target_name. */
+  search?: string
 }
 
 // =============================================================================

--- a/frontend/src/hooks/usePipelineSummary.ts
+++ b/frontend/src/hooks/usePipelineSummary.ts
@@ -1,25 +1,27 @@
 /**
  * React Query hook for pipeline debug summary (batch list).
+ *
+ * Fetches ALL rows for a run in a single request (`fetch_all=true`). The
+ * queryKey is intentionally stable — only `(runId)` — so the list isn't
+ * refetched when the user types in the search box, sorts, or changes a
+ * filter. Filtering/sorting/searching happen client-side in
+ * `PipelineBatchList`.
  */
 
 import { useQuery } from '@tanstack/react-query'
 import { useApiWithAuth } from './useApiWithAuth'
 import { queryKeys, userDataOptions } from '../utils/queryKeys'
 import { pipelineDebugService } from '../services/pipelineDebug'
-import type { PipelineSummaryFilters } from '../components/pipeline-debug/types'
 
-/**
- * Hook to fetch summary rows for a specific pipeline run.
- * Supports PB-native filtering, sorting, and pagination.
- */
-export function usePipelineSummary(runId: string | null, filters: PipelineSummaryFilters = {}) {
+/** Hook to fetch every summary row for a pipeline run. */
+export function usePipelineSummary(runId: string | null) {
   const { fetchWithAuth, isAuthenticated } = useApiWithAuth()
 
   return useQuery({
-    queryKey: queryKeys.pipelineSummary(runId ?? '', filters as Record<string, unknown>),
+    queryKey: queryKeys.pipelineSummary(runId ?? ''),
     queryFn: () => {
       if (!runId) throw new Error('Run ID is required')
-      return pipelineDebugService.fetchPipelineSummary(runId, filters, fetchWithAuth)
+      return pipelineDebugService.fetchPipelineSummary(runId, fetchWithAuth)
     },
     enabled: isAuthenticated && !!runId,
     ...userDataOptions,

--- a/frontend/src/pages/summer/PipelineDebugPage.tsx
+++ b/frontend/src/pages/summer/PipelineDebugPage.tsx
@@ -25,7 +25,6 @@ import { usePipelineSummary } from '../../hooks/usePipelineSummary'
 import { usePipelineTrace } from '../../hooks/usePipelineTrace'
 import { useRunFromPhase, useRunFullTrace } from '../../hooks/useRunPhase'
 import {
-  PHASE_ORDER,
   STAGE_ORDER,
   type PipelineSummaryFilters,
   type PipelinePhase,
@@ -84,14 +83,13 @@ export default function PipelineDebugPage() {
     setActiveIntentIndex(0)
   }, [])
 
-  /** Run Again: re-run from phase, cascading through all remaining phases (always dry-run). */
-  const handleRunAgain = useCallback(
+  /** Rerun this phase: isolated single-phase execution (dry-run). */
+  const handleRerunPhase = useCallback(
     (phase: PipelinePhase) => {
       if (!traceId) return
-      // Mark all downstream phases as stale
-      const phaseIdx = PHASE_ORDER.indexOf(phase)
-      const downstream = new Set<PipelinePhase>(PHASE_ORDER.filter((_, idx) => idx > phaseIdx))
-      setStalePhases(downstream)
+      // Only this phase is re-executed — downstream phases are left unchanged,
+      // so we do not mark them stale.
+      setStalePhases(new Set())
 
       const trace = traceQuery.data
       runFromPhase.mutate(
@@ -102,6 +100,7 @@ export default function PipelineDebugPage() {
             year: trace?.year ?? 0,
             session_cm_ids: trace?.session_cm_id ? [trace.session_cm_id] : [],
             dry_run: true,
+            stop_at_phase: phase,
           },
         },
         {
@@ -116,9 +115,9 @@ export default function PipelineDebugPage() {
     [traceId, traceQuery.data, runFromPhase, navigate]
   )
 
-  /** Run From Here: cascade from phase through remaining phases. */
+  /** Run From Here: cascade from phase through remaining phases (dry-run only). */
   const handleRunFromHere = useCallback(
-    (phase: PipelinePhase, writeToProduction: boolean) => {
+    (phase: PipelinePhase) => {
       if (!traceId) return
       setStalePhases(new Set()) // Clear stale since we're re-running everything downstream
 
@@ -130,7 +129,7 @@ export default function PipelineDebugPage() {
             trace_id: traceId,
             year: trace?.year ?? 0,
             session_cm_ids: trace?.session_cm_id ? [trace.session_cm_id] : [],
-            dry_run: !writeToProduction,
+            dry_run: true,
           },
         },
         {
@@ -233,7 +232,7 @@ export default function PipelineDebugPage() {
                   traceData={trace.trace_data}
                   activeIntentIndex={activeIntentIndex}
                   onTabChange={setActiveIntentIndex}
-                  onRunAgain={handleRunAgain}
+                  onRerunPhase={handleRerunPhase}
                   onRunFromHere={handleRunFromHere}
                   isRunning={runFromPhase.isPending}
                 />

--- a/frontend/src/pages/summer/PipelineDebugPage.tsx
+++ b/frontend/src/pages/summer/PipelineDebugPage.tsx
@@ -246,27 +246,16 @@ export default function PipelineDebugPage() {
                 stalePhases={stalePhases}
                 activeIntentIndex={activeIntentIndex}
                 onViewAllTraces={() => {
-                  // Navigate back to batch list. `search` is client-side only —
-                  // the user can re-enter the name in the search box (clearing
-                  // server-filters is enough).
                   setFilters({})
                   void navigate('/summer/debug/pipeline')
                 }}
                 onReprocess={() => {
-                  runFullTrace.mutate(
-                    {
-                      original_request_ids: [trace.original_request_id],
-                      year: trace.year,
-                      session_cm_ids: [trace.session_cm_id],
-                      dry_run: false,
-                    },
-                    {
-                      onSuccess: () => {
-                        // No page/accumulation state — React Query will
-                        // invalidate on refetch. Nothing to reset here.
-                      },
-                    }
-                  )
+                  runFullTrace.mutate({
+                    original_request_ids: [trace.original_request_id],
+                    year: trace.year,
+                    session_cm_ids: [trace.session_cm_id],
+                    dry_run: false,
+                  })
                 }}
                 isReprocessing={runFullTrace.isPending}
               />

--- a/frontend/src/pages/summer/PipelineDebugPage.tsx
+++ b/frontend/src/pages/summer/PipelineDebugPage.tsx
@@ -7,7 +7,7 @@
  * Route: /summer/debug/pipeline (batch) or /summer/debug/pipeline/:traceId (drill-down)
  */
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router'
 import { Link } from 'react-router'
 import { Bug, GitGraph, ArrowLeft, Loader2, FileText, Plus } from 'lucide-react'
@@ -28,6 +28,7 @@ import {
   PHASE_ORDER,
   STAGE_ORDER,
   type PipelineSummaryFilters,
+  type PipelineSummaryItem,
   type PipelinePhase,
   type PipelineStage,
 } from '../../components/pipeline-debug/types'
@@ -49,6 +50,10 @@ export default function PipelineDebugPage() {
   const [activeIntentIndex, setActiveIntentIndex] = useState(0)
   const [stalePhases, setStalePhases] = useState<Set<PipelinePhase>>(new Set())
 
+  // Accumulated pagination state for "load more" pattern
+  const [accumulatedItems, setAccumulatedItems] = useState<PipelineSummaryItem[]>([])
+  const prevFiltersRef = useRef(filters)
+
   // Data fetching
   const runsQuery = usePipelineRuns()
   const togglePin = useToggleRunPin()
@@ -57,9 +62,32 @@ export default function PipelineDebugPage() {
   const runFromPhase = useRunFromPhase()
   const runFullTrace = useRunFullTrace()
 
+  // Accumulate items across pages; reset on filter/run changes
+  useEffect(() => {
+    if (!summaryQuery.data) return
+    const currentPage = filters.page ?? 1
+    const filtersChanged =
+      JSON.stringify({ ...prevFiltersRef.current, page: undefined }) !==
+      JSON.stringify({ ...filters, page: undefined })
+    if (currentPage === 1 || filtersChanged) {
+      // Reset: new filter/sort/search or first page
+      setAccumulatedItems(summaryQuery.data.items)
+    } else {
+      // Append: loading next page
+      setAccumulatedItems((prev) => [...prev, ...summaryQuery.data!.items])
+    }
+    prevFiltersRef.current = filters
+  }, [summaryQuery.data, filters])
+
+  const handleLoadMore = useCallback(() => {
+    const currentPage = filters.page ?? 1
+    setFilters((prev) => ({ ...prev, page: currentPage + 1 }))
+  }, [filters])
+
   const handleSelectRun = useCallback((runId: string | null) => {
     setSelectedRunId(runId)
     setFilters({}) // Reset filters when switching runs
+    setAccumulatedItems([]) // Reset accumulated pages
   }, [])
 
   const handleTogglePin = useCallback(
@@ -243,6 +271,31 @@ export default function PipelineDebugPage() {
                 onStageSelect={handleStageSelect}
                 stalePhases={stalePhases}
                 activeIntentIndex={activeIntentIndex}
+                onViewAllTraces={() => {
+                  // Navigate back to batch list filtered by this camper's name
+                  const requesterName = trace.trace_data.pre_phase1.requester_info.name
+                  setFilters({ search: requesterName })
+                  setAccumulatedItems([])
+                  void navigate('/summer/debug/pipeline')
+                }}
+                onReprocess={() => {
+                  runFullTrace.mutate(
+                    {
+                      original_request_ids: [trace.original_request_id],
+                      year: trace.year,
+                      session_cm_ids: [trace.session_cm_id],
+                      dry_run: false,
+                    },
+                    {
+                      onSuccess: () => {
+                        // Refresh the batch list after reprocessing
+                        setAccumulatedItems([])
+                        setFilters((prev) => ({ ...prev, page: 1 }))
+                      },
+                    }
+                  )
+                }}
+                isReprocessing={runFullTrace.isPending}
               />
             </div>
           )}
@@ -320,21 +373,32 @@ export default function PipelineDebugPage() {
       {/* Summary table — only show when a run is selected */}
       {selectedRunId && (
         <QueryGuard
-          isLoading={summaryQuery.isLoading}
+          isLoading={summaryQuery.isLoading && (filters.page ?? 1) === 1}
           error={summaryQuery.error}
-          data={summaryQuery.data}
+          data={accumulatedItems.length > 0 ? summaryQuery.data : summaryQuery.data}
           label="pipeline summary"
           emptyMessage="No summary data for this run."
         >
           {(summaryData) => (
             <PipelineBatchList
-              items={summaryData.items}
+              items={accumulatedItems.length > 0 ? accumulatedItems : summaryData.items}
               total={summaryData.total}
               filters={filters}
-              onFiltersChange={setFilters}
+              onFiltersChange={(newFilters) => {
+                // If non-page filter changed, reset page to 1
+                const pageOnly =
+                  JSON.stringify({ ...newFilters, page: undefined }) ===
+                  JSON.stringify({ ...filters, page: undefined })
+                if (!pageOnly) {
+                  setAccumulatedItems([])
+                }
+                setFilters(newFilters)
+              }}
               onRowClick={handleRowClick}
               isLoading={false}
               error={summaryQuery.error}
+              onLoadMore={handleLoadMore}
+              isLoadingMore={summaryQuery.isFetching && (filters.page ?? 1) > 1}
             />
           )}
         </QueryGuard>

--- a/frontend/src/pages/summer/PipelineDebugPage.tsx
+++ b/frontend/src/pages/summer/PipelineDebugPage.tsx
@@ -7,7 +7,7 @@
  * Route: /summer/debug/pipeline (batch) or /summer/debug/pipeline/:traceId (drill-down)
  */
 
-import { useState, useCallback, useEffect, useRef } from 'react'
+import { useState, useCallback } from 'react'
 import { useParams, useNavigate } from 'react-router'
 import { Link } from 'react-router'
 import { Bug, GitGraph, ArrowLeft, Loader2, FileText, Plus } from 'lucide-react'
@@ -28,7 +28,6 @@ import {
   PHASE_ORDER,
   STAGE_ORDER,
   type PipelineSummaryFilters,
-  type PipelineSummaryItem,
   type PipelinePhase,
   type PipelineStage,
 } from '../../components/pipeline-debug/types'
@@ -50,44 +49,20 @@ export default function PipelineDebugPage() {
   const [activeIntentIndex, setActiveIntentIndex] = useState(0)
   const [stalePhases, setStalePhases] = useState<Set<PipelinePhase>>(new Set())
 
-  // Accumulated pagination state for "load more" pattern
-  const [accumulatedItems, setAccumulatedItems] = useState<PipelineSummaryItem[]>([])
-  const prevFiltersRef = useRef(filters)
-
-  // Data fetching
+  // Data fetching — the summary query fetches all rows for the run in a
+  // single request. Filtering/sorting/searching happen client-side in
+  // PipelineBatchList, so the queryKey is stable and typing/scrolling never
+  // trigger a refetch.
   const runsQuery = usePipelineRuns()
   const togglePin = useToggleRunPin()
-  const summaryQuery = usePipelineSummary(selectedRunId, filters)
+  const summaryQuery = usePipelineSummary(selectedRunId)
   const traceQuery = usePipelineTrace(traceId ?? null)
   const runFromPhase = useRunFromPhase()
   const runFullTrace = useRunFullTrace()
 
-  // Accumulate items across pages; reset on filter/run changes
-  useEffect(() => {
-    if (!summaryQuery.data) return
-    const currentPage = filters.page ?? 1
-    const filtersChanged =
-      JSON.stringify({ ...prevFiltersRef.current, page: undefined }) !==
-      JSON.stringify({ ...filters, page: undefined })
-    if (currentPage === 1 || filtersChanged) {
-      // Reset: new filter/sort/search or first page
-      setAccumulatedItems(summaryQuery.data.items)
-    } else {
-      // Append: loading next page
-      setAccumulatedItems((prev) => [...prev, ...summaryQuery.data!.items])
-    }
-    prevFiltersRef.current = filters
-  }, [summaryQuery.data, filters])
-
-  const handleLoadMore = useCallback(() => {
-    const currentPage = filters.page ?? 1
-    setFilters((prev) => ({ ...prev, page: currentPage + 1 }))
-  }, [filters])
-
   const handleSelectRun = useCallback((runId: string | null) => {
     setSelectedRunId(runId)
     setFilters({}) // Reset filters when switching runs
-    setAccumulatedItems([]) // Reset accumulated pages
   }, [])
 
   const handleTogglePin = useCallback(
@@ -272,10 +247,10 @@ export default function PipelineDebugPage() {
                 stalePhases={stalePhases}
                 activeIntentIndex={activeIntentIndex}
                 onViewAllTraces={() => {
-                  // Navigate back to batch list filtered by this camper's name
-                  const requesterName = trace.trace_data.pre_phase1.requester_info.name
-                  setFilters({ search: requesterName })
-                  setAccumulatedItems([])
+                  // Navigate back to batch list. `search` is client-side only —
+                  // the user can re-enter the name in the search box (clearing
+                  // server-filters is enough).
+                  setFilters({})
                   void navigate('/summer/debug/pipeline')
                 }}
                 onReprocess={() => {
@@ -288,9 +263,8 @@ export default function PipelineDebugPage() {
                     },
                     {
                       onSuccess: () => {
-                        // Refresh the batch list after reprocessing
-                        setAccumulatedItems([])
-                        setFilters((prev) => ({ ...prev, page: 1 }))
+                        // No page/accumulation state — React Query will
+                        // invalidate on refetch. Nothing to reset here.
                       },
                     }
                   )
@@ -370,35 +344,28 @@ export default function PipelineDebugPage() {
         )}
       </QueryGuard>
 
-      {/* Summary table — only show when a run is selected */}
+      {/* Summary table — only show when a run is selected.
+          The query fetches ALL rows for the run in one shot; filtering /
+          sorting / searching happen client-side inside PipelineBatchList.
+          Because the queryKey is stable per run, the QueryGuard only
+          shows the loading skeleton on the first load, never on keystrokes
+          or scroll. */}
       {selectedRunId && (
         <QueryGuard
-          isLoading={summaryQuery.isLoading && (filters.page ?? 1) === 1}
+          isLoading={summaryQuery.isLoading}
           error={summaryQuery.error}
-          data={accumulatedItems.length > 0 ? summaryQuery.data : summaryQuery.data}
+          data={summaryQuery.data}
           label="pipeline summary"
           emptyMessage="No summary data for this run."
         >
           {(summaryData) => (
             <PipelineBatchList
-              items={accumulatedItems.length > 0 ? accumulatedItems : summaryData.items}
-              total={summaryData.total}
+              items={summaryData.items}
               filters={filters}
-              onFiltersChange={(newFilters) => {
-                // If non-page filter changed, reset page to 1
-                const pageOnly =
-                  JSON.stringify({ ...newFilters, page: undefined }) ===
-                  JSON.stringify({ ...filters, page: undefined })
-                if (!pageOnly) {
-                  setAccumulatedItems([])
-                }
-                setFilters(newFilters)
-              }}
+              onFiltersChange={setFilters}
               onRowClick={handleRowClick}
               isLoading={false}
               error={summaryQuery.error}
-              onLoadMore={handleLoadMore}
-              isLoadingMore={summaryQuery.isFetching && (filters.page ?? 1) > 1}
             />
           )}
         </QueryGuard>

--- a/frontend/src/services/pipelineDebug.ts
+++ b/frontend/src/services/pipelineDebug.ts
@@ -7,7 +7,6 @@
 
 import type {
   PipelineRunsResponse,
-  PipelineSummaryFilters,
   PipelineSummaryResponse,
   PipelineTrace,
   PipelineTracesResponse,
@@ -58,37 +57,17 @@ export const pipelineDebugService = {
   },
 
   /**
-   * Fetch summary rows for a specific run with PB-native filtering and pagination.
+   * Fetch ALL summary rows for a run in a single request.
+   *
+   * Filtering, sorting, and searching are performed client-side in
+   * `PipelineBatchList`. This keeps the React Query cache stable so typing
+   * in the search box and scrolling never trigger a re-fetch.
    */
   async fetchPipelineSummary(
     runId: string,
-    filters: PipelineSummaryFilters,
     fetchWithAuth: (url: string, options?: RequestInit) => Promise<Response>
   ): Promise<PipelineSummaryResponse> {
-    const params = new URLSearchParams()
-    if (filters.final_status) params.set('final_status', filters.final_status)
-    if (filters.resolution_method) params.set('resolution_method', filters.resolution_method)
-    if (filters.source_field) params.set('source_field', filters.source_field)
-    if (filters.session_cm_id !== undefined) {
-      params.set('session_cm_id', String(filters.session_cm_id))
-    }
-    if (filters.phase3_triggered !== undefined) {
-      params.set('phase3_triggered', String(filters.phase3_triggered))
-    }
-    if (filters.pre_p1_action) params.set('pre_p1_action', filters.pre_p1_action)
-    if (filters.min_confidence !== undefined) {
-      params.set('min_confidence', String(filters.min_confidence))
-    }
-    if (filters.max_confidence !== undefined) {
-      params.set('max_confidence', String(filters.max_confidence))
-    }
-    if (filters.page !== undefined) params.set('page', String(filters.page))
-    if (filters.per_page !== undefined) params.set('per_page', String(filters.per_page))
-    if (filters.sort) params.set('sort', filters.sort)
-    if (filters.search) params.set('search', filters.search)
-
-    const queryString = params.toString()
-    const url = `${API_BASE}/pipeline-runs/${encodeURIComponent(runId)}/summary${queryString ? `?${queryString}` : ''}`
+    const url = `${API_BASE}/pipeline-runs/${encodeURIComponent(runId)}/summary?fetch_all=true`
     const response = await fetchWithAuth(url)
 
     if (!response.ok) {

--- a/frontend/src/services/pipelineDebug.ts
+++ b/frontend/src/services/pipelineDebug.ts
@@ -85,6 +85,7 @@ export const pipelineDebugService = {
     if (filters.page !== undefined) params.set('page', String(filters.page))
     if (filters.per_page !== undefined) params.set('per_page', String(filters.per_page))
     if (filters.sort) params.set('sort', filters.sort)
+    if (filters.search) params.set('search', filters.search)
 
     const queryString = params.toString()
     const url = `${API_BASE}/pipeline-runs/${encodeURIComponent(runId)}/summary${queryString ? `?${queryString}` : ''}`

--- a/tests/unit/api/test_debug_pipeline_endpoints.py
+++ b/tests/unit/api/test_debug_pipeline_endpoints.py
@@ -292,6 +292,46 @@ class TestGetPipelineRunSummary:
 
         assert response.status_code == 200
 
+    def test_fetch_all_returns_full_list(self, client_with_mock_pb: tuple[TestClient, MagicMock]) -> None:
+        """fetch_all=true should return all rows past the 500 cap via get_full_list."""
+        client, mock_pb = client_with_mock_pb
+
+        # Simulate 1,200 rows (well past the 500 per_page cap)
+        all_records = [_make_pb_summary_record(record_id=f"rec_sum_{i}") for i in range(1200)]
+        mock_collection = mock_pb.collection.return_value
+        mock_collection.get_full_list.return_value = all_records
+
+        response = client.get(
+            "/api/debug/pipeline-runs/a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6/summary",
+            params={"fetch_all": "true"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) == 1200
+        assert data["total"] == 1200
+        # Should use get_full_list (un-paged) not get_list
+        mock_collection.get_full_list.assert_called_once()
+
+    def test_fetch_all_ignores_page_and_per_page(self, client_with_mock_pb: tuple[TestClient, MagicMock]) -> None:
+        """When fetch_all=true, page/per_page params should be ignored."""
+        client, mock_pb = client_with_mock_pb
+
+        all_records = [_make_pb_summary_record(record_id=f"rec_sum_{i}") for i in range(600)]
+        mock_collection = mock_pb.collection.return_value
+        mock_collection.get_full_list.return_value = all_records
+
+        response = client.get(
+            "/api/debug/pipeline-runs/a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6/summary",
+            params={"fetch_all": "true", "page": 2, "per_page": 10},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        # All 600 records returned regardless of page/per_page
+        assert len(data["items"]) == 600
+        assert data["total"] == 600
+
 
 class TestGetPipelineTrace:
     """Test GET /api/debug/pipeline-traces/{trace_id} endpoint."""

--- a/tests/unit/api/test_debug_pipeline_endpoints.py
+++ b/tests/unit/api/test_debug_pipeline_endpoints.py
@@ -249,6 +249,49 @@ class TestGetPipelineRunSummary:
 
         assert response.status_code == 200
 
+    def test_search_parameter_adds_name_filter(self, client_with_mock_pb: tuple[TestClient, MagicMock]) -> None:
+        """Search param should filter on requester_name and target_name."""
+        client, mock_pb = client_with_mock_pb
+
+        mock_collection = mock_pb.collection.return_value
+        result_list = MagicMock()
+        result_list.items = []
+        result_list.total_items = 0
+        result_list.page = 1
+        result_list.per_page = 50
+        mock_collection.get_list.return_value = result_list
+
+        response = client.get(
+            "/api/debug/pipeline-runs/a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6/summary",
+            params={"search": "Emma"},
+        )
+
+        assert response.status_code == 200
+        # Verify the PB filter includes the search term on both name columns
+        call_args = mock_collection.get_list.call_args
+        filter_str = call_args.kwargs.get("query_params", {}).get("filter", "")
+        assert 'requester_name ~ "Emma"' in filter_str or "requester_name ~" in filter_str
+        assert 'target_name ~ "Emma"' in filter_str or "target_name ~" in filter_str
+
+    def test_per_page_allows_up_to_500(self, client_with_mock_pb: tuple[TestClient, MagicMock]) -> None:
+        """per_page cap should be raised from 200 to 500 for the summary endpoint."""
+        client, mock_pb = client_with_mock_pb
+
+        mock_collection = mock_pb.collection.return_value
+        result_list = MagicMock()
+        result_list.items = []
+        result_list.total_items = 0
+        result_list.page = 1
+        result_list.per_page = 500
+        mock_collection.get_list.return_value = result_list
+
+        response = client.get(
+            "/api/debug/pipeline-runs/a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6/summary",
+            params={"per_page": 500},
+        )
+
+        assert response.status_code == 200
+
 
 class TestGetPipelineTrace:
     """Test GET /api/debug/pipeline-traces/{trace_id} endpoint."""


### PR DESCRIPTION
## Summary

- **Search**: Instant client-side name search across requester and target columns — no debounce, no network round-trip per keystroke
- **Filtering/sorting**: All filters (status, source field, resolution method, confidence, phase3) and column sort are client-side — zero re-fetch on change
- **Scrolling**: Virtualized scroll via `useVirtualTable` (same pattern as `/campers`) — no pagination UI, no flashing mid-scroll
- **One-shot fetch**: New `?fetch_all=true` mode on `/pipeline-runs/{run_id}/summary` returns all rows for the selected run in a single query with stable `queryKey`
- **View all traces**: "View all traces" button in sidebar clears filters and navigates back to batch list
- **Reprocess**: "Reprocess from source" button with confirmation dialog — the **only** path that writes to production
- **Rename**: "Run Again" → **"Rerun this phase"** (now wires `stop_at_phase` for true single-phase execution); "Run From Here" cascades through the end. Both are **dry-run only**.
- **Removed**: "Write to production" checkbox on Run From Here (was a silent no-op — the `run_from_phase` runner never actually wrote). Dead production-write stub in `phase_runner.py` deleted.
- **[object Object] fix**: New `renderUnknownValue()` utility in `panelUtils.ts` fixes raw object rendering in ConflictDetail, ValidationDetail, and ExpansionDetail panels

## Test plan

- [ ] Select a pipeline run — batch list populates in one fetch, no subsequent flashes
- [ ] Type rapidly in the search box — filters per-keystroke with no focus loss and no network activity
- [ ] Toggle status / source / phase3 filters — instant, no fetch
- [ ] Scroll through a large run (>500 rows) — smooth, no loading skeleton
- [ ] Click a row → drill into detail → "View all traces" returns to batch list without re-fetching
- [ ] "Rerun this phase" button runs only that phase (passes `stop_at_phase`), dry-run
- [ ] "Run From Here" cascades, dry-run only — no write-to-prod checkbox present
- [ ] "Reprocess from source" shows confirmation dialog before executing (only prod-write path)
- [ ] Detail panels no longer show `[object Object]` for nested data
- [ ] `npx vitest run` — all tests green (RequestContext, PipelineBatchList, ActionButtons, DetailPanels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)