### PR TITLE
refactor(graph): simplify nested try/catch in bunk bubble rendering

### DIFF
--- a/frontend/src/components/graph/bubbleRenderer.ts
+++ b/frontend/src/components/graph/bubbleRenderer.ts
@@ -257,34 +257,34 @@ export function drawBunkBubbles(
       const bunkName = bunksData?.[parseInt(bunkId, 10)] ?? `Bunk ${bunkId}`
       const bunkColor = getBunkColor(parseInt(bunkId, 10))
 
-      try {
-  const nodeIds = nodes.map((n) => `#${n.id()}`).join(', ')
-  const nodeCollection = cy.$(nodeIds)
+   try {
+        const nodeIds = nodes.map((n) => `#${n.id()}`).join(', ')
+        const nodeCollection = cy.$(nodeIds)
 
-  const path = addPath(
-    nodeCollection,
-    cy.collection(),
-    cy.collection(),
-    {
-      style: {
-        fill: bunkColor,
-        fillOpacity: 0.25,
-        stroke: bunkColor,
-        strokeOpacity: 0.8,
-        strokeWidth: 3,
-      },
-      ...BASE_BUBBLE_OPTIONS,
-      morphBuffer: 35,
-    }
-  )
+        const path = addPath(
+          nodeCollection,
+          cy.collection(),
+          cy.collection(),
+          {
+            style: {
+              fill: bunkColor,
+              fillOpacity: 0.25,
+              stroke: bunkColor,
+              strokeOpacity: 0.8,
+              strokeWidth: 3,
+            },
+            ...BASE_BUBBLE_OPTIONS,
+            morphBuffer: 35,
+          }
+        )
 
-  renderedBunks.push(`${bunkId} (${bunkName})`)
-  pathsRef.current.push(path)
+        renderedBunks.push(`${bunkId} (${bunkName})`)
+        pathsRef.current.push(path)
 
-} catch (error) {
-  console.error(`Error creating bubble for bunk ${bunkId}:`, error)
-  failedBunks.push(`${bunkId} (${bunkName}) - Error: ${String(error)}`)
-}
+      } catch (error) {
+        console.error(`Error creating bubble for bunk ${bunkId}:`, error)
+        failedBunks.push(`${bunkId} (${bunkName}) - Error: ${String(error)}`)
+      }
   // Update UI state with rendering status (only when showBunks — the !showBunks
   // branch already reported zero rendered above)
   if (showBunks && updateStatus) {

--- a/frontend/src/components/graph/bubbleRenderer.ts
+++ b/frontend/src/components/graph/bubbleRenderer.ts
@@ -258,46 +258,33 @@ export function drawBunkBubbles(
       const bunkColor = getBunkColor(parseInt(bunkId, 10))
 
       try {
-        // Create a bubble path for this bunk
-        const nodeIds = nodes.map((n) => `#${n.id()}`).join(', ')
-        const nodeCollection = cy.$(nodeIds)
+  const nodeIds = nodes.map((n) => `#${n.id()}`).join(', ')
+  const nodeCollection = cy.$(nodeIds)
 
-        // Add path to the single bubbleset instance
-        let path
-        try {
-          path = addPath(
-            nodeCollection, // Nodes to include in the bubble
-            cy.collection(), // Empty edge collection
-            cy.collection(), // No avoid nodes needed - compound layout separates bunks
-            {
-              style: {
-                fill: bunkColor,
-                fillOpacity: 0.25,
-                stroke: bunkColor,
-                strokeOpacity: 0.8,
-                strokeWidth: 3,
-              },
-              ...BASE_BUBBLE_OPTIONS,
-              morphBuffer: 35,
-            }
-          )
+  const path = addPath(
+    nodeCollection,
+    cy.collection(),
+    cy.collection(),
+    {
+      style: {
+        fill: bunkColor,
+        fillOpacity: 0.25,
+        stroke: bunkColor,
+        strokeOpacity: 0.8,
+        strokeWidth: 3,
+      },
+      ...BASE_BUBBLE_OPTIONS,
+      morphBuffer: 35,
+    }
+  )
 
-          renderedBunks.push(`${bunkId} (${bunkName})`)
-        } catch (pathError) {
-          console.error(`Error creating path for bunk ${bunkId}:`, pathError)
-          failedBunks.push(`${bunkId} (${bunkName}) - Error: ${String(pathError)}`)
-          return
-        }
+  renderedBunks.push(`${bunkId} (${bunkName})`)
+  pathsRef.current.push(path)
 
-        // Store the path reference with metadata
-        pathsRef.current.push(path)
-      } catch (error) {
-        console.error(`Error creating bubble for bunk ${bunkId}:`, error)
-        failedBunks.push(`${bunkId} (${bunkName}) - Error: ${String(error)}`)
-      }
-    })
-  }
-
+} catch (error) {
+  console.error(`Error creating bubble for bunk ${bunkId}:`, error)
+  failedBunks.push(`${bunkId} (${bunkName}) - Error: ${String(error)}`)
+}
   // Update UI state with rendering status (only when showBunks — the !showBunks
   // branch already reported zero rendered above)
   if (showBunks && updateStatus) {


### PR DESCRIPTION
- Removed redundant nested try/catch in drawBunkBubbles
- Simplified error handling to a single try/catch block
- Preserved existing error tracking with failedBunks

Improves readability and aligns with unit bubble pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified bubble rendering flow with centralized error handling, improving robustness of visual rendering and ensuring failed items are logged and tracked rather than aborting individual render attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->