### PR TITLE
feat(frontend): approve/reject popover anchored to buttons

### DIFF
--- a/frontend/src/components/ConfirmActionPopover.test.tsx
+++ b/frontend/src/components/ConfirmActionPopover.test.tsx
@@ -103,4 +103,57 @@ describe('ConfirmActionPopover', () => {
     expect(popover.style.top).toBeTruthy()
     expect(popover.style.left).toBeTruthy()
   })
+
+  it('focuses the confirm button when the dialog opens', () => {
+    render(<ConfirmActionPopover {...defaultProps} />)
+    const confirmBtn = screen.getByRole('button', { name: /confirm/i })
+    expect(document.activeElement).toBe(confirmBtn)
+  })
+
+  it('restores focus to the previously focused element when closed via onCancel', () => {
+    const trigger = document.createElement('button')
+    document.body.appendChild(trigger)
+    trigger.focus()
+    expect(document.activeElement).toBe(trigger)
+
+    const onCancel = vi.fn()
+    const { rerender } = render(<ConfirmActionPopover {...defaultProps} onCancel={onCancel} />)
+
+    // Close the popover
+    rerender(<ConfirmActionPopover {...defaultProps} onCancel={onCancel} isOpen={false} />)
+    expect(document.activeElement).toBe(trigger)
+
+    document.body.removeChild(trigger)
+  })
+
+  it('has aria-modal="true" on the dialog', () => {
+    render(<ConfirmActionPopover {...defaultProps} />)
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true')
+  })
+
+  it('cycles focus forward with Tab key', () => {
+    render(<ConfirmActionPopover {...defaultProps} />)
+    const confirmBtn = screen.getByRole('button', { name: /confirm/i })
+    const cancelBtn = screen.getByRole('button', { name: /cancel/i })
+
+    // Auto-focused on confirm (last button); Tab should wrap to first (cancel)
+    expect(document.activeElement).toBe(confirmBtn)
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: false })
+    expect(document.activeElement).toBe(cancelBtn)
+
+    // Tab again wraps back to confirm
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: false })
+    expect(document.activeElement).toBe(confirmBtn)
+  })
+
+  it('cycles focus backward with Shift+Tab', () => {
+    render(<ConfirmActionPopover {...defaultProps} />)
+    const confirmBtn = screen.getByRole('button', { name: /confirm/i })
+    const cancelBtn = screen.getByRole('button', { name: /cancel/i })
+
+    // Auto-focused on confirm; Shift+Tab should wrap backward to cancel
+    expect(document.activeElement).toBe(confirmBtn)
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(cancelBtn)
+  })
 })

--- a/frontend/src/components/ConfirmActionPopover.test.tsx
+++ b/frontend/src/components/ConfirmActionPopover.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { ConfirmActionPopover } from './ConfirmActionPopover'
+
+describe('ConfirmActionPopover', () => {
+  const defaultProps = {
+    isOpen: true,
+    anchorRect: { top: 200, left: 300, width: 40, height: 40 },
+    action: 'approve' as const,
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+  }
+
+  it('renders nothing when isOpen is false', () => {
+    render(<ConfirmActionPopover {...defaultProps} isOpen={false} />)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders popover with approve message when action is approve', () => {
+    render(<ConfirmActionPopover {...defaultProps} action="approve" />)
+    expect(screen.getByText(/Approve this request\?/)).toBeInTheDocument()
+  })
+
+  it('renders popover with decline message when action is decline', () => {
+    render(<ConfirmActionPopover {...defaultProps} action="decline" />)
+    expect(screen.getByText(/Decline this request\?/)).toBeInTheDocument()
+  })
+
+  it('calls onConfirm when confirm button is clicked', () => {
+    const onConfirm = vi.fn()
+    render(<ConfirmActionPopover {...defaultProps} onConfirm={onConfirm} />)
+
+    const confirmBtn = screen.getByRole('button', { name: /confirm/i })
+    fireEvent.click(confirmBtn)
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onCancel when cancel button is clicked', () => {
+    const onCancel = vi.fn()
+    render(<ConfirmActionPopover {...defaultProps} onCancel={onCancel} />)
+
+    const cancelBtn = screen.getByRole('button', { name: /cancel/i })
+    fireEvent.click(cancelBtn)
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onCancel when Escape key is pressed', () => {
+    const onCancel = vi.fn()
+    render(<ConfirmActionPopover {...defaultProps} onCancel={onCancel} />)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onCancel when clicking outside the popover', () => {
+    const onCancel = vi.fn()
+    render(<ConfirmActionPopover {...defaultProps} onCancel={onCancel} />)
+
+    // Click on document body (outside the popover)
+    fireEvent.mouseDown(document.body)
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call onCancel when clicking inside the popover', () => {
+    const onCancel = vi.fn()
+    render(<ConfirmActionPopover {...defaultProps} onCancel={onCancel} />)
+
+    const popover = screen.getByRole('dialog')
+    fireEvent.mouseDown(popover)
+    expect(onCancel).not.toHaveBeenCalled()
+  })
+
+  it('has green confirm button for approve action', () => {
+    render(<ConfirmActionPopover {...defaultProps} action="approve" />)
+    const confirmBtn = screen.getByRole('button', { name: /confirm/i })
+    // Check for forest/green classes
+    expect(confirmBtn.className).toMatch(/forest|green/)
+  })
+
+  it('has red confirm button for decline action', () => {
+    render(<ConfirmActionPopover {...defaultProps} action="decline" />)
+    const confirmBtn = screen.getByRole('button', { name: /confirm/i })
+    // Check for red/destructive classes
+    expect(confirmBtn.className).toMatch(/red|destructive/)
+  })
+
+  it('renders as a portal (attached to document.body)', () => {
+    render(<ConfirmActionPopover {...defaultProps} />)
+    // The popover should be a direct child of body (via createPortal)
+    const popover = screen.getByRole('dialog')
+    expect(popover.parentElement).toBe(document.body)
+  })
+
+  it('positions the popover near the anchor', () => {
+    render(
+      <ConfirmActionPopover
+        {...defaultProps}
+        anchorRect={{ top: 100, left: 200, width: 40, height: 40 }}
+      />
+    )
+    const popover = screen.getByRole('dialog')
+    // Should have style with top/left set from anchor position
+    expect(popover.style.top).toBeTruthy()
+    expect(popover.style.left).toBeTruthy()
+  })
+})

--- a/frontend/src/components/ConfirmActionPopover.tsx
+++ b/frontend/src/components/ConfirmActionPopover.tsx
@@ -1,9 +1,9 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 
 export interface ConfirmActionPopoverProps {
   isOpen: boolean
-  anchorRect: { top: number; left: number; width: number; height: number }
+  anchorRect: Pick<DOMRect, 'top' | 'left' | 'width' | 'height'>
   action: 'approve' | 'decline'
   onConfirm: () => void
   onCancel: () => void
@@ -16,20 +16,43 @@ export function ConfirmActionPopover({
   onConfirm,
   onCancel,
 }: ConfirmActionPopoverProps) {
+  const popoverRef = useRef<HTMLDivElement>(null)
+  const confirmButtonRef = useRef<HTMLButtonElement>(null)
+  // Stable ref so the keydown/mousedown handlers never go stale,
+  // keeping isOpen as the sole dep and avoiding listener churn on parent re-renders.
+  const onCancelRef = useRef(onCancel)
+  useEffect(() => {
+    onCancelRef.current = onCancel
+  })
+
   useEffect(() => {
     if (!isOpen) return
 
+    const previouslyFocused = document.activeElement as HTMLElement | null
+    confirmButtonRef.current?.focus()
+
     function handleKeyDown(e: KeyboardEvent) {
       if (e.key === 'Escape') {
-        onCancel()
+        onCancelRef.current()
+      } else if (e.key === 'Tab') {
+        const buttons = popoverRef.current
+          ? Array.from(popoverRef.current.querySelectorAll<HTMLElement>('button'))
+          : []
+        if (buttons.length === 0) return
+        e.preventDefault()
+        const idx = buttons.indexOf(document.activeElement as HTMLElement)
+        if (e.shiftKey) {
+          buttons[idx <= 0 ? buttons.length - 1 : idx - 1]?.focus()
+        } else {
+          buttons[idx >= buttons.length - 1 ? 0 : idx + 1]?.focus()
+        }
       }
     }
 
     function handleMouseDown(e: MouseEvent) {
       const target = e.target as Node
-      const popover = document.getElementById('confirm-action-popover')
-      if (popover && !popover.contains(target)) {
-        onCancel()
+      if (popoverRef.current && !popoverRef.current.contains(target)) {
+        onCancelRef.current()
       }
     }
 
@@ -39,12 +62,14 @@ export function ConfirmActionPopover({
     return () => {
       document.removeEventListener('keydown', handleKeyDown)
       document.removeEventListener('mousedown', handleMouseDown)
+      previouslyFocused?.focus()
     }
-  }, [isOpen, onCancel])
+  }, [isOpen])
 
   if (!isOpen) return null
 
   const popoverWidth = 220
+  // Estimated: ~2 lines of text + padding; update if layout changes
   const popoverHeight = 90
   const padding = 10
 
@@ -68,13 +93,14 @@ export function ConfirmActionPopover({
   }
 
   const isApprove = action === 'approve'
-  const message = isApprove ? 'Approve this request?' : 'Decline this request?'
+  const displayMessage = isApprove ? 'Approve this request?' : 'Decline this request?'
 
   return createPortal(
     <div
-      id="confirm-action-popover"
+      ref={popoverRef}
       role="dialog"
-      aria-label={message}
+      aria-modal="true"
+      aria-label={displayMessage}
       className="bg-popover fixed z-[200] rounded-lg border p-3 shadow-lg"
       style={{
         top: `${top}px`,
@@ -82,7 +108,7 @@ export function ConfirmActionPopover({
         width: `${popoverWidth}px`,
       }}
     >
-      <p className="text-foreground mb-3 text-sm font-medium">{message}</p>
+      <p className="text-foreground mb-3 text-sm font-medium">{displayMessage}</p>
       <div className="flex items-center justify-end gap-2">
         <button
           type="button"
@@ -93,6 +119,7 @@ export function ConfirmActionPopover({
           Cancel
         </button>
         <button
+          ref={confirmButtonRef}
           type="button"
           aria-label="Confirm"
           onClick={onConfirm}

--- a/frontend/src/components/ConfirmActionPopover.tsx
+++ b/frontend/src/components/ConfirmActionPopover.tsx
@@ -1,0 +1,111 @@
+import { useEffect } from 'react'
+import { createPortal } from 'react-dom'
+
+export interface ConfirmActionPopoverProps {
+  isOpen: boolean
+  anchorRect: { top: number; left: number; width: number; height: number }
+  action: 'approve' | 'decline'
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ConfirmActionPopover({
+  isOpen,
+  anchorRect,
+  action,
+  onConfirm,
+  onCancel,
+}: ConfirmActionPopoverProps) {
+  useEffect(() => {
+    if (!isOpen) return
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        onCancel()
+      }
+    }
+
+    function handleMouseDown(e: MouseEvent) {
+      const target = e.target as Node
+      const popover = document.getElementById('confirm-action-popover')
+      if (popover && !popover.contains(target)) {
+        onCancel()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    document.addEventListener('mousedown', handleMouseDown)
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      document.removeEventListener('mousedown', handleMouseDown)
+    }
+  }, [isOpen, onCancel])
+
+  if (!isOpen) return null
+
+  const popoverWidth = 220
+  const popoverHeight = 90
+  const padding = 10
+
+  // Position below the anchor by default
+  let top = anchorRect.top + anchorRect.height + 8
+  let left = anchorRect.left + anchorRect.width / 2 - popoverWidth / 2
+
+  // Flip above anchor if clipped at bottom
+  if (top + popoverHeight > window.innerHeight - padding) {
+    top = Math.max(padding, anchorRect.top - popoverHeight - 8)
+  }
+
+  // Shift left if clipped at right
+  if (left + popoverWidth > window.innerWidth - padding) {
+    left = Math.max(padding, window.innerWidth - popoverWidth - padding)
+  }
+
+  // Ensure not off-screen left
+  if (left < padding) {
+    left = padding
+  }
+
+  const isApprove = action === 'approve'
+  const message = isApprove ? 'Approve this request?' : 'Decline this request?'
+
+  return createPortal(
+    <div
+      id="confirm-action-popover"
+      role="dialog"
+      aria-label={message}
+      className="bg-popover fixed z-[200] rounded-lg border p-3 shadow-lg"
+      style={{
+        top: `${top}px`,
+        left: `${left}px`,
+        width: `${popoverWidth}px`,
+      }}
+    >
+      <p className="text-foreground mb-3 text-sm font-medium">{message}</p>
+      <div className="flex items-center justify-end gap-2">
+        <button
+          type="button"
+          aria-label="Cancel"
+          onClick={onCancel}
+          className="text-muted-foreground hover:bg-muted rounded px-3 py-1.5 text-xs font-medium transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          aria-label="Confirm"
+          onClick={onConfirm}
+          className={
+            isApprove
+              ? 'bg-forest-600 hover:bg-forest-700 dark:bg-forest-700 dark:hover:bg-forest-600 rounded px-3 py-1.5 text-xs font-medium text-white transition-colors'
+              : 'rounded bg-red-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-red-700 dark:bg-red-700 dark:hover:bg-red-600'
+          }
+        >
+          {isApprove ? 'Approve' : 'Decline'}
+        </button>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -117,9 +117,35 @@ export default function RequestReviewPanel({
   const [selectedCamperId, setSelectedCamperId] = useState<string | null>(null)
   const [confirmPopover, setConfirmPopover] = useState<{
     action: 'approve' | 'decline'
-    anchorRect: { top: number; left: number; width: number; height: number }
+    anchorRect: Pick<DOMRect, 'top' | 'left' | 'width' | 'height'>
     requestId: string
   } | null>(null)
+  const [bulkConfirm, setBulkConfirm] = useState<{
+    action: 'approve' | 'decline'
+    count: number
+  } | null>(null)
+  const bulkConfirmRef = useRef<HTMLDivElement>(null)
+  const bulkConfirmPreviousFocusRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    if (bulkConfirm) {
+      bulkConfirmPreviousFocusRef.current = document.activeElement as HTMLElement | null
+      const buttons = bulkConfirmRef.current?.querySelectorAll<HTMLElement>('button')
+      buttons?.[buttons.length - 1]?.focus()
+    } else {
+      bulkConfirmPreviousFocusRef.current?.focus()
+      bulkConfirmPreviousFocusRef.current = null
+    }
+  }, [bulkConfirm])
+
+  function openConfirmPopover(
+    e: React.MouseEvent<HTMLButtonElement>,
+    action: 'approve' | 'decline',
+    requestId: string
+  ): void {
+    e.stopPropagation()
+    setConfirmPopover({ action, anchorRect: e.currentTarget.getBoundingClientRect(), requestId })
+  }
   const [filters, setFilters] = useState<FilterState>(() => {
     try {
       const stored = localStorage.getItem(storageKey)
@@ -637,22 +663,12 @@ export default function RequestReviewPanel({
 
   const handleBulkApprove = () => {
     if (selectedRequests.size === 0) return
-    bulkUpdateMutation.mutate({
-      ids: Array.from(selectedRequests),
-      updates: {
-        status: 'resolved' as BunkRequestsStatusOptions,
-        request_locked: true,
-      },
-    })
+    setBulkConfirm({ action: 'approve', count: selectedRequests.size })
   }
 
   const handleBulkReject = () => {
     if (selectedRequests.size === 0) return
-    if (!confirm(`Are you sure you want to reject ${selectedRequests.size} requests?`)) return
-    bulkUpdateMutation.mutate({
-      ids: Array.from(selectedRequests),
-      updates: { status: 'declined' as BunkRequestsStatusOptions },
-    })
+    setBulkConfirm({ action: 'decline', count: selectedRequests.size })
   }
 
   // Validated update handler - checks for conflicts before applying
@@ -1238,40 +1254,14 @@ export default function RequestReviewPanel({
                               </button>
                             )}
                             <button
-                              onClick={(e) => {
-                                e.stopPropagation()
-                                const rect = e.currentTarget.getBoundingClientRect()
-                                setConfirmPopover({
-                                  action: 'approve',
-                                  anchorRect: {
-                                    top: rect.top,
-                                    left: rect.left,
-                                    width: rect.width,
-                                    height: rect.height,
-                                  },
-                                  requestId: request.id,
-                                })
-                              }}
+                              onClick={(e) => openConfirmPopover(e, 'approve', request.id)}
                               className="hover:bg-forest-100 dark:hover:bg-forest-900/30 text-forest-600 dark:text-forest-400 touch-manipulation rounded-lg p-2 transition-colors"
                               title="Approve"
                             >
                               <CheckCircle className="h-5 w-5" />
                             </button>
                             <button
-                              onClick={(e) => {
-                                e.stopPropagation()
-                                const rect = e.currentTarget.getBoundingClientRect()
-                                setConfirmPopover({
-                                  action: 'decline',
-                                  anchorRect: {
-                                    top: rect.top,
-                                    left: rect.left,
-                                    width: rect.width,
-                                    height: rect.height,
-                                  },
-                                  requestId: request.id,
-                                })
-                              }}
+                              onClick={(e) => openConfirmPopover(e, 'decline', request.id)}
                               className="hover:bg-destructive/10 text-destructive touch-manipulation rounded-lg p-2 transition-colors"
                               title="Reject"
                             >
@@ -1507,40 +1497,14 @@ export default function RequestReviewPanel({
                                 </button>
                               )}
                               <button
-                                onClick={(e) => {
-                                  e.stopPropagation()
-                                  const rect = e.currentTarget.getBoundingClientRect()
-                                  setConfirmPopover({
-                                    action: 'approve',
-                                    anchorRect: {
-                                      top: rect.top,
-                                      left: rect.left,
-                                      width: rect.width,
-                                      height: rect.height,
-                                    },
-                                    requestId: request.id,
-                                  })
-                                }}
+                                onClick={(e) => openConfirmPopover(e, 'approve', request.id)}
                                 className="hover:bg-forest-100 dark:hover:bg-forest-900/30 text-forest-600 dark:text-forest-400 rounded-lg p-1.5 opacity-80 transition-colors hover:opacity-100"
                                 title="Approve"
                               >
                                 <CheckCircle className="h-4 w-4" />
                               </button>
                               <button
-                                onClick={(e) => {
-                                  e.stopPropagation()
-                                  const rect = e.currentTarget.getBoundingClientRect()
-                                  setConfirmPopover({
-                                    action: 'decline',
-                                    anchorRect: {
-                                      top: rect.top,
-                                      left: rect.left,
-                                      width: rect.width,
-                                      height: rect.height,
-                                    },
-                                    requestId: request.id,
-                                  })
-                                }}
+                                onClick={(e) => openConfirmPopover(e, 'decline', request.id)}
                                 className="hover:bg-destructive/10 text-destructive rounded-lg p-1.5 opacity-80 transition-colors hover:opacity-100"
                                 title="Reject"
                               >
@@ -1980,7 +1944,6 @@ export default function RequestReviewPanel({
         </div>
       </div>
 
-      {/* Confirm Approve/Reject Popover (anchored near action button) */}
       <ConfirmActionPopover
         isOpen={!!confirmPopover}
         anchorRect={confirmPopover?.anchorRect ?? { top: 0, left: 0, width: 0, height: 0 }}
@@ -1992,18 +1955,81 @@ export default function RequestReviewPanel({
             id: requestId,
             updates:
               action === 'approve'
-                ? {
-                    status: 'resolved' as BunkRequestsStatusOptions,
-                    request_locked: true,
-                  }
-                : {
-                    status: 'declined' as BunkRequestsStatusOptions,
-                  },
+                ? { status: 'resolved' as BunkRequestsStatusOptions, request_locked: true }
+                : { status: 'declined' as BunkRequestsStatusOptions },
           })
           setConfirmPopover(null)
         }}
         onCancel={() => setConfirmPopover(null)}
       />
+
+      {bulkConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div className="absolute inset-0 bg-black/50" onClick={() => setBulkConfirm(null)} />
+          <div
+            ref={bulkConfirmRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="bulk-confirm-label"
+            className="bg-card border-border relative mx-4 w-full max-w-sm rounded-xl border p-6 shadow-xl"
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                setBulkConfirm(null)
+                return
+              }
+              if (e.key === 'Tab') {
+                const buttons = Array.from(
+                  bulkConfirmRef.current?.querySelectorAll<HTMLElement>('button') ?? []
+                )
+                if (buttons.length === 0) return
+                e.preventDefault()
+                const idx = buttons.indexOf(document.activeElement as HTMLElement)
+                if (e.shiftKey) {
+                  buttons[idx <= 0 ? buttons.length - 1 : idx - 1]?.focus()
+                } else {
+                  buttons[idx >= buttons.length - 1 ? 0 : idx + 1]?.focus()
+                }
+              }
+            }}
+          >
+            <p id="bulk-confirm-label" className="text-foreground mb-5 text-base font-medium">
+              {bulkConfirm.action === 'approve'
+                ? `Confirm approving ${bulkConfirm.count} request${bulkConfirm.count === 1 ? '' : 's'}?`
+                : `Confirm declining ${bulkConfirm.count} request${bulkConfirm.count === 1 ? '' : 's'}?`}
+            </p>
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setBulkConfirm(null)}
+                className="text-muted-foreground hover:bg-muted rounded-lg px-4 py-2 text-sm font-medium transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  const ids = Array.from(selectedRequests)
+                  bulkUpdateMutation.mutate({
+                    ids,
+                    updates:
+                      bulkConfirm.action === 'approve'
+                        ? { status: 'resolved' as BunkRequestsStatusOptions, request_locked: true }
+                        : { status: 'declined' as BunkRequestsStatusOptions },
+                  })
+                  setBulkConfirm(null)
+                }}
+                className={
+                  bulkConfirm.action === 'approve'
+                    ? 'bg-forest-600 hover:bg-forest-700 dark:bg-forest-700 dark:hover:bg-forest-600 rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors'
+                    : 'rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 dark:bg-red-700 dark:hover:bg-red-600'
+                }
+              >
+                {bulkConfirm.action === 'approve' ? 'Approve' : 'Decline'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </>
   )
 }

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -43,6 +43,7 @@ import CreateRequestModal from './CreateRequestModal'
 import CamperDetailsPanel from './CamperDetailsPanel'
 import MergeRequestsModal from './MergeRequestsModal'
 import SplitRequestModal from './SplitRequestModal'
+import { ConfirmActionPopover } from './ConfirmActionPopover'
 import { useOptimisticValidation } from '../hooks/useOptimisticValidation'
 import { formatGradeOrdinal } from '../utils/gradeUtils'
 
@@ -114,6 +115,11 @@ export default function RequestReviewPanel({
   const [showSplitModal, setShowSplitModal] = useState(false)
   const [requestToSplit, setRequestToSplit] = useState<BunkRequestsResponse | null>(null)
   const [selectedCamperId, setSelectedCamperId] = useState<string | null>(null)
+  const [confirmPopover, setConfirmPopover] = useState<{
+    action: 'approve' | 'decline'
+    anchorRect: { top: number; left: number; width: number; height: number }
+    requestId: string
+  } | null>(null)
   const [filters, setFilters] = useState<FilterState>(() => {
     try {
       const stored = localStorage.getItem(storageKey)
@@ -1232,30 +1238,39 @@ export default function RequestReviewPanel({
                               </button>
                             )}
                             <button
-                              onClick={() =>
-                                updateRequestMutation.mutate({
-                                  id: request.id,
-                                  updates: {
-                                    status: 'resolved' as BunkRequestsStatusOptions,
-                                    request_locked: true,
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                const rect = e.currentTarget.getBoundingClientRect()
+                                setConfirmPopover({
+                                  action: 'approve',
+                                  anchorRect: {
+                                    top: rect.top,
+                                    left: rect.left,
+                                    width: rect.width,
+                                    height: rect.height,
                                   },
+                                  requestId: request.id,
                                 })
-                              }
+                              }}
                               className="hover:bg-forest-100 dark:hover:bg-forest-900/30 text-forest-600 dark:text-forest-400 touch-manipulation rounded-lg p-2 transition-colors"
                               title="Approve"
                             >
                               <CheckCircle className="h-5 w-5" />
                             </button>
                             <button
-                              onClick={() => {
-                                if (confirm('Reject this request?')) {
-                                  updateRequestMutation.mutate({
-                                    id: request.id,
-                                    updates: {
-                                      status: 'declined' as BunkRequestsStatusOptions,
-                                    },
-                                  })
-                                }
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                const rect = e.currentTarget.getBoundingClientRect()
+                                setConfirmPopover({
+                                  action: 'decline',
+                                  anchorRect: {
+                                    top: rect.top,
+                                    left: rect.left,
+                                    width: rect.width,
+                                    height: rect.height,
+                                  },
+                                  requestId: request.id,
+                                })
                               }}
                               className="hover:bg-destructive/10 text-destructive touch-manipulation rounded-lg p-2 transition-colors"
                               title="Reject"
@@ -1492,30 +1507,39 @@ export default function RequestReviewPanel({
                                 </button>
                               )}
                               <button
-                                onClick={() =>
-                                  updateRequestMutation.mutate({
-                                    id: request.id,
-                                    updates: {
-                                      status: 'resolved' as BunkRequestsStatusOptions,
-                                      request_locked: true,
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  const rect = e.currentTarget.getBoundingClientRect()
+                                  setConfirmPopover({
+                                    action: 'approve',
+                                    anchorRect: {
+                                      top: rect.top,
+                                      left: rect.left,
+                                      width: rect.width,
+                                      height: rect.height,
                                     },
+                                    requestId: request.id,
                                   })
-                                }
+                                }}
                                 className="hover:bg-forest-100 dark:hover:bg-forest-900/30 text-forest-600 dark:text-forest-400 rounded-lg p-1.5 opacity-80 transition-colors hover:opacity-100"
                                 title="Approve"
                               >
                                 <CheckCircle className="h-4 w-4" />
                               </button>
                               <button
-                                onClick={() => {
-                                  if (confirm('Are you sure you want to reject this request?')) {
-                                    updateRequestMutation.mutate({
-                                      id: request.id,
-                                      updates: {
-                                        status: 'declined' as BunkRequestsStatusOptions,
-                                      },
-                                    })
-                                  }
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  const rect = e.currentTarget.getBoundingClientRect()
+                                  setConfirmPopover({
+                                    action: 'decline',
+                                    anchorRect: {
+                                      top: rect.top,
+                                      left: rect.left,
+                                      width: rect.width,
+                                      height: rect.height,
+                                    },
+                                    requestId: request.id,
+                                  })
                                 }}
                                 className="hover:bg-destructive/10 text-destructive rounded-lg p-1.5 opacity-80 transition-colors hover:opacity-100"
                                 title="Reject"
@@ -1955,6 +1979,31 @@ export default function RequestReviewPanel({
           </div>
         </div>
       </div>
+
+      {/* Confirm Approve/Reject Popover (anchored near action button) */}
+      <ConfirmActionPopover
+        isOpen={!!confirmPopover}
+        anchorRect={confirmPopover?.anchorRect ?? { top: 0, left: 0, width: 0, height: 0 }}
+        action={confirmPopover?.action ?? 'approve'}
+        onConfirm={() => {
+          if (!confirmPopover) return
+          const { action, requestId } = confirmPopover
+          updateRequestMutation.mutate({
+            id: requestId,
+            updates:
+              action === 'approve'
+                ? {
+                    status: 'resolved' as BunkRequestsStatusOptions,
+                    request_locked: true,
+                  }
+                : {
+                    status: 'declined' as BunkRequestsStatusOptions,
+                  },
+          })
+          setConfirmPopover(null)
+        }}
+        onCancel={() => setConfirmPopover(null)}
+      />
     </>
   )
 }


### PR DESCRIPTION
## Summary

- Replaces native `window.confirm()` with a portal-based popover anchored to the approve/reject action buttons
- Uses the already-built `ConfirmActionPopover` component (follows `WaitlistGradePopover` pattern: portal rendering, smart positioning with flip/shift, escape/click-outside to close)
- Same popover handles both approve (green) and decline (red) variants
- Fires from both mobile and desktop button locations in RequestReviewPanel

Addresses feedback item #15 from the wife feedback session.

## Test plan

- [ ] Click approve on a pending request — green popover anchors near button
- [ ] Click decline on a pending request — red popover anchors near button
- [ ] Click outside popover or press Escape — popover closes without mutation
- [ ] Click Confirm — request status updates, toast appears
- [ ] Verify on both mobile (narrow) and desktop (wide) viewport
- [ ] `npx vitest run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a confirmation popover dialog for request approvals and rejections with context-specific messaging, replacing browser confirmation dialogs
  * Integrated popover into request review workflow with support for keyboard and click-away dismissal

* **Tests**
  * Added comprehensive test suite for the confirmation popover covering interaction scenarios, visual states, and button styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->