### PR TITLE
feat(frontend): two-column expanded row with requester's other requests

### DIFF
--- a/frontend/src/components/BunkRequestRow.test.tsx
+++ b/frontend/src/components/BunkRequestRow.test.tsx
@@ -1,0 +1,259 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '../test/testUtils'
+import { BunkRequestRow } from './BunkRequestRow'
+import type { BunkRequestsResponse, PersonsResponse } from '../types/pocketbase-types'
+
+function makeRequest(overrides: Partial<BunkRequestsResponse> = {}): BunkRequestsResponse {
+  return {
+    id: 'req1',
+    request_type: 'bunk_with',
+    status: 'resolved',
+    requester_id: 100,
+    session_id: 1001,
+    year: 2025,
+    source_field: 'friend_request',
+    created: '2025-01-01',
+    updated: '2025-01-01',
+    ...overrides,
+  } as unknown as BunkRequestsResponse
+}
+
+function makePerson(overrides: Partial<PersonsResponse> = {}): PersonsResponse {
+  return {
+    id: 'p1',
+    cm_id: 200,
+    first_name: 'Olivia',
+    last_name: 'Chen',
+    year: 2025,
+    created: '2025-01-01',
+    updated: '2025-01-01',
+    ...overrides,
+  } as unknown as PersonsResponse
+}
+
+describe('BunkRequestRow', () => {
+  it('renders a resolved status with a green check icon', () => {
+    const { container } = render(
+      <BunkRequestRow
+        request={makeRequest({ status: 'resolved', requestee_id: 200 })}
+        targetPerson={makePerson()}
+      />
+    )
+    // CheckCircle for resolved - forest-600
+    expect(container.querySelector('.text-forest-600')).toBeTruthy()
+  })
+
+  it('renders a pending status with an amber clock icon', () => {
+    const { container } = render(
+      <BunkRequestRow
+        request={makeRequest({ status: 'pending', requested_person_name: 'Liam Garcia' })}
+      />
+    )
+    expect(container.querySelector('.text-amber-500')).toBeTruthy()
+  })
+
+  it('renders a declined status with a bark X icon', () => {
+    const { container } = render(
+      <BunkRequestRow
+        request={makeRequest({ status: 'declined', requested_person_name: 'Noah Smith' })}
+      />
+    )
+    expect(container.querySelector('.text-bark-600')).toBeTruthy()
+  })
+
+  it('renders "Bunk with" label for bunk_with requests', () => {
+    render(
+      <BunkRequestRow
+        request={makeRequest({ request_type: 'bunk_with', requestee_id: 200 })}
+        targetPerson={makePerson()}
+      />
+    )
+    expect(screen.getByText('Bunk with')).toBeInTheDocument()
+  })
+
+  it('renders "Not bunk with" label in red for not_bunk_with requests', () => {
+    render(
+      <BunkRequestRow
+        request={makeRequest({ request_type: 'not_bunk_with', requestee_id: 200 })}
+        targetPerson={makePerson()}
+      />
+    )
+    const label = screen.getByText('Not bunk with')
+    expect(label).toBeInTheDocument()
+    expect(label.className).toMatch(/text-red-600/)
+  })
+
+  it('renders target name via CamperLink when requestee_id set and resolved', () => {
+    render(
+      <BunkRequestRow
+        request={makeRequest({
+          status: 'resolved',
+          requestee_id: 200,
+          requested_person_name: 'Olivia Chen',
+        })}
+        targetPerson={makePerson({ first_name: 'Olivia', last_name: 'Chen' })}
+      />
+    )
+    // Resolved + requestee_id → CamperLink renders link
+    expect(screen.getByText(/Olivia Chen/)).toBeInTheDocument()
+  })
+
+  it('renders mutual badge with MUTUAL_BADGE_CLASSES when is_reciprocal is true', () => {
+    render(
+      <BunkRequestRow
+        request={makeRequest({
+          status: 'resolved',
+          requestee_id: 200,
+          is_reciprocal: true,
+        })}
+        targetPerson={makePerson()}
+      />
+    )
+    const badge = screen.getByText('mutual')
+    expect(badge).toBeInTheDocument()
+    expect(badge.className).toMatch(/bg-forest-100/)
+  })
+
+  it('does not render mutual badge when is_reciprocal is false', () => {
+    render(
+      <BunkRequestRow
+        request={makeRequest({
+          status: 'resolved',
+          requestee_id: 200,
+          is_reciprocal: false,
+        })}
+        targetPerson={makePerson()}
+      />
+    )
+    expect(screen.queryByText('mutual')).not.toBeInTheDocument()
+  })
+
+  it('renders satisfaction check when showSatisfaction and satisfied', () => {
+    render(
+      <BunkRequestRow
+        request={makeRequest({ status: 'resolved', requestee_id: 200 })}
+        targetPerson={makePerson()}
+        showSatisfaction={true}
+        satisfaction="satisfied"
+      />
+    )
+    expect(screen.getByText('✓')).toBeInTheDocument()
+  })
+
+  it('renders satisfaction X when showSatisfaction and not_satisfied', () => {
+    render(
+      <BunkRequestRow
+        request={makeRequest({ status: 'resolved', requestee_id: 200 })}
+        targetPerson={makePerson()}
+        showSatisfaction={true}
+        satisfaction="not_satisfied"
+      />
+    )
+    expect(screen.getByText('✗')).toBeInTheDocument()
+  })
+
+  it('renders satisfaction ? when showSatisfaction and unknown', () => {
+    render(
+      <BunkRequestRow
+        request={makeRequest({ status: 'resolved', requestee_id: 200 })}
+        targetPerson={makePerson()}
+        showSatisfaction={true}
+        satisfaction="unknown"
+      />
+    )
+    expect(screen.getByText('?')).toBeInTheDocument()
+  })
+
+  it('does not render satisfaction icons when showSatisfaction is false', () => {
+    render(
+      <BunkRequestRow
+        request={makeRequest({ status: 'resolved', requestee_id: 200 })}
+        targetPerson={makePerson()}
+        showSatisfaction={false}
+        satisfaction="satisfied"
+      />
+    )
+    expect(screen.queryByText('✓')).not.toBeInTheDocument()
+  })
+
+  it('renders "Prefers bunking with older campers" for age_preference request', () => {
+    render(
+      <BunkRequestRow
+        request={makeRequest({
+          request_type: 'age_preference',
+          age_preference_target: 'older',
+        })}
+      />
+    )
+    expect(screen.getByText(/Prefers bunking with/)).toBeInTheDocument()
+    expect(screen.getByText(/older/)).toBeInTheDocument()
+  })
+
+  it('renders "Prefers bunking with younger campers" for age_preference request', () => {
+    render(
+      <BunkRequestRow
+        request={makeRequest({
+          request_type: 'age_preference',
+          age_preference_target: 'younger',
+        })}
+      />
+    )
+    expect(screen.getByText(/Prefers bunking with/)).toBeInTheDocument()
+    expect(screen.getByText(/younger/)).toBeInTheDocument()
+  })
+
+  it('renders Sparkles icon for age preference', () => {
+    const { container } = render(
+      <BunkRequestRow
+        request={makeRequest({
+          request_type: 'age_preference',
+          age_preference_target: 'older',
+        })}
+      />
+    )
+    // Sparkles lucide-react icon has class lucide-sparkles
+    expect(container.querySelector('.lucide-sparkles')).toBeTruthy()
+  })
+
+  it('adds ring/highlight classes when isCurrent is true', () => {
+    const { container } = render(
+      <BunkRequestRow
+        request={makeRequest({ status: 'resolved', requestee_id: 200 })}
+        targetPerson={makePerson()}
+        isCurrent={true}
+      />
+    )
+    const row = container.firstElementChild as HTMLElement
+    expect(row.className).toMatch(/ring-primary\/40/)
+    expect(row.className).toMatch(/bg-primary\/5/)
+    expect(row.className).toMatch(/ring-1/)
+  })
+
+  it('does NOT render ring when isCurrent is false or omitted', () => {
+    const { container } = render(
+      <BunkRequestRow
+        request={makeRequest({ status: 'resolved', requestee_id: 200 })}
+        targetPerson={makePerson()}
+      />
+    )
+    const row = container.firstElementChild as HTMLElement
+    expect(row.className).not.toMatch(/ring-primary\/40/)
+  })
+
+  it('shows (unresolved) on target name when not confirmed but has a name', () => {
+    render(
+      <BunkRequestRow
+        request={makeRequest({
+          status: 'pending',
+          requested_person_name: 'Liam Garcia',
+        })}
+      />
+    )
+    expect(screen.getByText(/Liam Garcia/)).toBeInTheDocument()
+  })
+
+  it('falls back to "Unknown" when neither person nor name is provided', () => {
+    render(<BunkRequestRow request={makeRequest({ status: 'pending' })} />)
+    expect(screen.getByText(/Unknown/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/BunkRequestRow.tsx
+++ b/frontend/src/components/BunkRequestRow.tsx
@@ -2,6 +2,7 @@ import { CheckCircle, XCircle, Clock, Sparkles } from 'lucide-react'
 import clsx from 'clsx'
 import CamperLink from './CamperLink'
 import { MUTUAL_BADGE_CLASSES } from '../utils/dispositionColors'
+import { isConfirmedRequest } from '../utils/bunkRequest'
 import type { BunkRequestsResponse, PersonsResponse } from '../types/pocketbase-types'
 
 export type SatisfactionStatus = 'satisfied' | 'not_satisfied' | 'unknown' | 'checking'
@@ -21,6 +22,40 @@ export interface BunkRequestRowProps {
   satisfactionLoading?: boolean
   /** Optional detail text for the satisfaction tooltip. */
   satisfactionDetail?: string | undefined
+}
+
+function statusIcon(status: string) {
+  if (status === 'resolved')
+    return <CheckCircle className="text-forest-600 dark:text-forest-400 h-4 w-4 flex-shrink-0" />
+  if (status === 'declined')
+    return <XCircle className="text-bark-600 dark:text-bark-400 h-4 w-4 flex-shrink-0" />
+  return <Clock className="h-4 w-4 flex-shrink-0 text-amber-500" />
+}
+
+const SATISFACTION_ICONS = {
+  satisfied: <span className="sat-icon sat-icon-met">✓</span>,
+  not_satisfied: <span className="sat-icon sat-icon-unmet">✗</span>,
+  unknown: <span className="sat-icon sat-icon-unknown">?</span>,
+}
+
+function SatisfactionIcon({
+  satisfaction,
+  satisfactionLoading,
+  satisfactionDetail,
+}: {
+  satisfaction: SatisfactionStatus | null
+  satisfactionLoading: boolean
+  satisfactionDetail?: string | undefined
+}) {
+  return (
+    <span className="ml-auto" title={satisfactionDetail}>
+      {satisfactionLoading ? (
+        <span className="sat-spinner" />
+      ) : satisfaction ? (
+        (SATISFACTION_ICONS[satisfaction as keyof typeof SATISFACTION_ICONS] ?? null)
+      ) : null}
+    </span>
+  )
 }
 
 /**
@@ -54,26 +89,18 @@ export function BunkRequestRow({
           campers
         </span>
         {showSatisfaction && (
-          <span className="ml-auto" title={satisfactionDetail}>
-            {satisfactionLoading ? (
-              <span className="sat-spinner" />
-            ) : satisfaction === 'satisfied' ? (
-              <span className="sat-icon sat-icon-met">✓</span>
-            ) : satisfaction === 'not_satisfied' ? (
-              <span className="sat-icon sat-icon-unmet">✗</span>
-            ) : satisfaction === 'unknown' ? (
-              <span className="sat-icon sat-icon-unknown">?</span>
-            ) : null}
-          </span>
+          <SatisfactionIcon
+            satisfaction={satisfaction}
+            satisfactionLoading={satisfactionLoading}
+            satisfactionDetail={satisfactionDetail}
+          />
         )}
       </div>
     )
   }
 
   const isBunkWith = request.request_type === 'bunk_with'
-  const isConfirmed = Boolean(
-    request.status === 'resolved' && request.requestee_id && request.requestee_id > 0
-  )
+  const isConfirmed = isConfirmedRequest(request)
 
   // Prefer resolved person name if we have it; fall back to requested_person_name.
   const resolvedName = targetPerson ? `${targetPerson.first_name} ${targetPerson.last_name}` : null
@@ -82,13 +109,7 @@ export function BunkRequestRow({
   return (
     <div className={rowClass}>
       {/* Status indicator */}
-      {request.status === 'resolved' ? (
-        <CheckCircle className="text-forest-600 dark:text-forest-400 h-4 w-4 flex-shrink-0" />
-      ) : request.status === 'declined' ? (
-        <XCircle className="text-bark-600 dark:text-bark-400 h-4 w-4 flex-shrink-0" />
-      ) : (
-        <Clock className="h-4 w-4 flex-shrink-0 text-amber-500" />
-      )}
+      {statusIcon(request.status)}
 
       {/* Type label */}
       <span
@@ -113,17 +134,11 @@ export function BunkRequestRow({
 
       {/* Satisfaction - concise icon only */}
       {showSatisfaction && (
-        <span className="ml-auto" title={satisfactionDetail}>
-          {satisfactionLoading ? (
-            <span className="sat-spinner" />
-          ) : satisfaction === 'satisfied' ? (
-            <span className="sat-icon sat-icon-met">✓</span>
-          ) : satisfaction === 'not_satisfied' ? (
-            <span className="sat-icon sat-icon-unmet">✗</span>
-          ) : satisfaction === 'unknown' ? (
-            <span className="sat-icon sat-icon-unknown">?</span>
-          ) : null}
-        </span>
+        <SatisfactionIcon
+          satisfaction={satisfaction}
+          satisfactionLoading={satisfactionLoading}
+          satisfactionDetail={satisfactionDetail}
+        />
       )}
     </div>
   )

--- a/frontend/src/components/BunkRequestRow.tsx
+++ b/frontend/src/components/BunkRequestRow.tsx
@@ -1,0 +1,130 @@
+import { CheckCircle, XCircle, Clock, Sparkles } from 'lucide-react'
+import clsx from 'clsx'
+import CamperLink from './CamperLink'
+import { MUTUAL_BADGE_CLASSES } from '../utils/dispositionColors'
+import type { BunkRequestsResponse, PersonsResponse } from '../types/pocketbase-types'
+
+export type SatisfactionStatus = 'satisfied' | 'not_satisfied' | 'unknown' | 'checking'
+
+export interface BunkRequestRowProps {
+  /** The bunk request record to render. */
+  request: BunkRequestsResponse
+  /** Resolved target person (from cm_id lookup). If provided and request is resolved, displayName will use first_name + last_name. */
+  targetPerson?: PersonsResponse | null
+  /** When true, renders a "you are here" highlight ring. */
+  isCurrent?: boolean
+  /** Satisfaction status — only rendered when `showSatisfaction` is true. */
+  satisfaction?: SatisfactionStatus | null
+  /** Whether to render the satisfaction icon (typically true for confirmed rows in the modal). */
+  showSatisfaction?: boolean
+  /** Whether satisfaction is still being checked (shows spinner). */
+  satisfactionLoading?: boolean
+  /** Optional detail text for the satisfaction tooltip. */
+  satisfactionDetail?: string | undefined
+}
+
+/**
+ * Renders a single bunk request as a compact row. Used by both the camper
+ * side-panel (CamperDetailsPanel) and the expanded row requester summary
+ * (CamperRequestSummary) so the two surfaces render identically.
+ */
+export function BunkRequestRow({
+  request,
+  targetPerson,
+  isCurrent = false,
+  satisfaction = null,
+  showSatisfaction = false,
+  satisfactionLoading = false,
+  satisfactionDetail,
+}: BunkRequestRowProps) {
+  const rowClass = clsx(
+    'flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm transition-colors',
+    isCurrent ? 'ring-primary/40 bg-primary/5 ring-1' : 'hover:bg-muted/50'
+  )
+
+  // Age preference variant
+  if (request.request_type === 'age_preference') {
+    const prefersOlder = request.age_preference_target === 'older'
+    return (
+      <div className={clsx(rowClass, 'text-muted-foreground text-xs')}>
+        <Sparkles className="h-3 w-3 flex-shrink-0 text-amber-500" />
+        <span>
+          Prefers bunking with{' '}
+          <span className="text-foreground font-medium">{prefersOlder ? 'older' : 'younger'}</span>{' '}
+          campers
+        </span>
+        {showSatisfaction && (
+          <span className="ml-auto" title={satisfactionDetail}>
+            {satisfactionLoading ? (
+              <span className="sat-spinner" />
+            ) : satisfaction === 'satisfied' ? (
+              <span className="sat-icon sat-icon-met">✓</span>
+            ) : satisfaction === 'not_satisfied' ? (
+              <span className="sat-icon sat-icon-unmet">✗</span>
+            ) : satisfaction === 'unknown' ? (
+              <span className="sat-icon sat-icon-unknown">?</span>
+            ) : null}
+          </span>
+        )}
+      </div>
+    )
+  }
+
+  const isBunkWith = request.request_type === 'bunk_with'
+  const isConfirmed = Boolean(
+    request.status === 'resolved' && request.requestee_id && request.requestee_id > 0
+  )
+
+  // Prefer resolved person name if we have it; fall back to requested_person_name.
+  const resolvedName = targetPerson ? `${targetPerson.first_name} ${targetPerson.last_name}` : null
+  const displayName = resolvedName ?? request.requested_person_name ?? 'Unknown'
+
+  return (
+    <div className={rowClass}>
+      {/* Status indicator */}
+      {request.status === 'resolved' ? (
+        <CheckCircle className="text-forest-600 dark:text-forest-400 h-4 w-4 flex-shrink-0" />
+      ) : request.status === 'declined' ? (
+        <XCircle className="text-bark-600 dark:text-bark-400 h-4 w-4 flex-shrink-0" />
+      ) : (
+        <Clock className="h-4 w-4 flex-shrink-0 text-amber-500" />
+      )}
+
+      {/* Type label */}
+      <span
+        className={clsx('text-muted-foreground', !isBunkWith && 'text-red-600 dark:text-red-400')}
+      >
+        {isBunkWith ? 'Bunk with' : 'Not bunk with'}
+      </span>
+
+      {/* Arrow */}
+      <span className="text-muted-foreground">→</span>
+
+      {/* Target - clickable if confirmed */}
+      <CamperLink
+        personCmId={request.requestee_id}
+        displayName={displayName}
+        isConfirmed={isConfirmed}
+        showUnresolved={!isConfirmed && !!request.requested_person_name}
+      />
+
+      {/* Reciprocal badge - only if reciprocal */}
+      {request.is_reciprocal && <span className={MUTUAL_BADGE_CLASSES}>mutual</span>}
+
+      {/* Satisfaction - concise icon only */}
+      {showSatisfaction && (
+        <span className="ml-auto" title={satisfactionDetail}>
+          {satisfactionLoading ? (
+            <span className="sat-spinner" />
+          ) : satisfaction === 'satisfied' ? (
+            <span className="sat-icon sat-icon-met">✓</span>
+          ) : satisfaction === 'not_satisfied' ? (
+            <span className="sat-icon sat-icon-unmet">✗</span>
+          ) : satisfaction === 'unknown' ? (
+            <span className="sat-icon sat-icon-unknown">?</span>
+          ) : null}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -5,9 +5,6 @@ import {
   X,
   Calendar,
   Heart,
-  CheckCircle,
-  XCircle,
-  Clock,
   ChevronDown,
   ChevronRight,
   FileText,
@@ -16,7 +13,6 @@ import {
   Home,
   Users,
   ExternalLink,
-  Sparkles,
 } from 'lucide-react'
 import { pb } from '../lib/pocketbase'
 import { StatusBadge } from './StatusBadge'
@@ -43,11 +39,10 @@ import { isAgePreferenceSatisfied } from '../utils/agePreferenceSatisfaction'
 import { useYear } from '../hooks/useCurrentYear'
 import { getDisplayAgeForYear } from '../utils/displayAge'
 import { CampMinderIcon } from './icons'
-import CamperLink from './CamperLink'
 import { getAvatarColor, getInitial } from '../utils/avatarUtils'
 import { getLocationDisplay } from '../utils/addressUtils'
 import { sortEnrolledFirst } from '../utils/enrollmentSort'
-import { MUTUAL_BADGE_CLASSES } from '../utils/dispositionColors'
+import { BunkRequestRow } from './BunkRequestRow'
 import {
   getStatusIndicator,
   filterEnrollmentsByStatus,
@@ -351,6 +346,7 @@ export default function CamperDetailsPanel({
               req.requested_person_name
               ? `${req.requested_person_name} (unresolved)`
               : undefined,
+          targetPerson: person ?? null,
           metadata: req.metadata ?? ({} as Record<string, unknown>),
         }
       })
@@ -889,68 +885,24 @@ export default function CamperDetailsPanel({
               <div className="mt-2 space-y-1">
                 {bunkRequests
                   .filter((r) => r.request_type !== 'age_preference')
-                  .map((request, idx) => {
+                  .map((request) => {
                     const isConfirmed = Boolean(
                       request.status === 'resolved' &&
                       request.requestee_id &&
                       request.requestee_id > 0
                     )
-                    const isBunkWith = request.request_type === 'bunk_with'
                     const satisfaction = satisfactionData[request.id]
-                    const showSatisfaction = isConfirmed
 
                     return (
-                      <div
-                        key={idx}
-                        className="hover:bg-muted/50 flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm transition-colors"
-                      >
-                        {/* Status indicator */}
-                        {request.status === 'resolved' ? (
-                          <CheckCircle className="text-forest-600 dark:text-forest-400 h-4 w-4 flex-shrink-0" />
-                        ) : request.status === 'declined' ? (
-                          <XCircle className="text-bark-600 dark:text-bark-400 h-4 w-4 flex-shrink-0" />
-                        ) : (
-                          <Clock className="h-4 w-4 flex-shrink-0 text-amber-500" />
-                        )}
-
-                        {/* Type label */}
-                        <span
-                          className={`text-muted-foreground ${!isBunkWith ? 'text-red-600 dark:text-red-400' : ''}`}
-                        >
-                          {isBunkWith ? 'Bunk with' : 'Not bunk with'}
-                        </span>
-
-                        {/* Arrow */}
-                        <span className="text-muted-foreground">→</span>
-
-                        {/* Target - clickable if confirmed */}
-                        <CamperLink
-                          personCmId={request.requestee_id}
-                          displayName={request.requestedPersonName ?? 'Unknown'}
-                          isConfirmed={isConfirmed}
-                          showUnresolved={!isConfirmed && !!request.requestedPersonName}
-                        />
-
-                        {/* Reciprocal badge - only if reciprocal */}
-                        {request.is_reciprocal && (
-                          <span className={MUTUAL_BADGE_CLASSES}>mutual</span>
-                        )}
-
-                        {/* Satisfaction - concise icon only */}
-                        {showSatisfaction && (
-                          <span className="ml-auto" title={satisfaction?.detail}>
-                            {satisfactionLoading ? (
-                              <span className="sat-spinner" />
-                            ) : satisfaction?.status === 'satisfied' ? (
-                              <span className="sat-icon sat-icon-met">✓</span>
-                            ) : satisfaction?.status === 'not_satisfied' ? (
-                              <span className="sat-icon sat-icon-unmet">✗</span>
-                            ) : satisfaction?.status === 'unknown' ? (
-                              <span className="sat-icon sat-icon-unknown">?</span>
-                            ) : null}
-                          </span>
-                        )}
-                      </div>
+                      <BunkRequestRow
+                        key={request.id}
+                        request={request}
+                        targetPerson={request.targetPerson ?? null}
+                        showSatisfaction={isConfirmed}
+                        satisfaction={satisfaction?.status ?? null}
+                        satisfactionLoading={satisfactionLoading}
+                        satisfactionDetail={satisfaction?.detail}
+                      />
                     )
                   })}
 
@@ -958,35 +910,20 @@ export default function CamperDetailsPanel({
                 {agePreferenceRequest?.age_preference_target &&
                   (() => {
                     const ageSatisfaction = satisfactionData[agePreferenceRequest.id]
-                    const prefersOlder = agePreferenceRequest.age_preference_target === 'older'
                     const hasOtherRequests =
                       bunkRequests.filter((r) => r.request_type !== 'age_preference').length > 0
 
                     return (
                       <div
-                        className={`text-muted-foreground flex items-center gap-2 px-2 text-xs ${hasOtherRequests ? 'border-border/50 mt-3 border-t pt-2' : ''}`}
+                        className={hasOtherRequests ? 'border-border/50 mt-3 border-t pt-2' : ''}
                       >
-                        <Sparkles className="h-3 w-3 flex-shrink-0 text-amber-500" />
-                        <span>
-                          Prefers bunking with{' '}
-                          <span className="text-foreground font-medium">
-                            {prefersOlder ? 'older' : 'younger'}
-                          </span>{' '}
-                          campers
-                        </span>
-
-                        {/* Satisfaction icon */}
-                        <span className="ml-auto" title={ageSatisfaction?.detail}>
-                          {satisfactionLoading ? (
-                            <span className="sat-spinner" />
-                          ) : ageSatisfaction?.status === 'satisfied' ? (
-                            <span className="sat-icon sat-icon-met">✓</span>
-                          ) : ageSatisfaction?.status === 'not_satisfied' ? (
-                            <span className="sat-icon sat-icon-unmet">✗</span>
-                          ) : ageSatisfaction?.status === 'unknown' ? (
-                            <span className="sat-icon sat-icon-unknown">?</span>
-                          ) : null}
-                        </span>
+                        <BunkRequestRow
+                          request={agePreferenceRequest}
+                          showSatisfaction={true}
+                          satisfaction={ageSatisfaction?.status ?? null}
+                          satisfactionLoading={satisfactionLoading}
+                          satisfactionDetail={ageSatisfaction?.detail}
+                        />
                       </div>
                     )
                   })()}

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -36,6 +36,7 @@ import type {
 import { Collections } from '../types/pocketbase-types'
 import { toAppCamper } from '../utils/transforms'
 import { isAgePreferenceSatisfied } from '../utils/agePreferenceSatisfaction'
+import { isConfirmedRequest } from '../utils/bunkRequest'
 import { useYear } from '../hooks/useCurrentYear'
 import { getDisplayAgeForYear } from '../utils/displayAge'
 import { CampMinderIcon } from './icons'
@@ -883,50 +884,33 @@ export default function CamperDetailsPanel({
             />
             {expandedSections.requests && (
               <div className="mt-2 space-y-1">
-                {bunkRequests
-                  .filter((r) => r.request_type !== 'age_preference')
-                  .map((request) => {
-                    const isConfirmed = Boolean(
-                      request.status === 'resolved' &&
-                      request.requestee_id &&
-                      request.requestee_id > 0
-                    )
-                    const satisfaction = satisfactionData[request.id]
-
-                    return (
-                      <BunkRequestRow
-                        key={request.id}
-                        request={request}
-                        targetPerson={request.targetPerson ?? null}
-                        showSatisfaction={isConfirmed}
-                        satisfaction={satisfaction?.status ?? null}
-                        satisfactionLoading={satisfactionLoading}
-                        satisfactionDetail={satisfaction?.detail}
-                      />
-                    )
-                  })}
+                {nonAgeRequests.map((request) => {
+                  const satisfaction = satisfactionData[request.id]
+                  return (
+                    <BunkRequestRow
+                      key={request.id}
+                      request={request}
+                      targetPerson={request.targetPerson ?? null}
+                      showSatisfaction={isConfirmedRequest(request)}
+                      satisfaction={satisfaction?.status ?? null}
+                      satisfactionLoading={satisfactionLoading}
+                      satisfactionDetail={satisfaction?.detail}
+                    />
+                  )
+                })}
 
                 {/* Age preference - subtle at bottom with satisfaction */}
-                {agePreferenceRequest?.age_preference_target &&
-                  (() => {
-                    const ageSatisfaction = satisfactionData[agePreferenceRequest.id]
-                    const hasOtherRequests =
-                      bunkRequests.filter((r) => r.request_type !== 'age_preference').length > 0
-
-                    return (
-                      <div
-                        className={hasOtherRequests ? 'border-border/50 mt-3 border-t pt-2' : ''}
-                      >
-                        <BunkRequestRow
-                          request={agePreferenceRequest}
-                          showSatisfaction={true}
-                          satisfaction={ageSatisfaction?.status ?? null}
-                          satisfactionLoading={satisfactionLoading}
-                          satisfactionDetail={ageSatisfaction?.detail}
-                        />
-                      </div>
-                    )
-                  })()}
+                {agePreferenceRequest?.age_preference_target && (
+                  <div className={hasOtherRequests ? 'border-border/50 mt-3 border-t pt-2' : ''}>
+                    <BunkRequestRow
+                      request={agePreferenceRequest}
+                      showSatisfaction={true}
+                      satisfaction={ageSatisfaction?.status ?? null}
+                      satisfactionLoading={satisfactionLoading}
+                      satisfactionDetail={ageSatisfaction?.detail}
+                    />
+                  </div>
+                )}
               </div>
             )}
           </section>
@@ -1268,6 +1252,13 @@ export default function CamperDetailsPanel({
       </div>
     )
   }
+
+  // Derived request lists (used in the bunk requests section of the render)
+  const nonAgeRequests = bunkRequests.filter((r) => r.request_type !== 'age_preference')
+  const hasOtherRequests = nonAgeRequests.length > 0
+  const ageSatisfaction = agePreferenceRequest
+    ? satisfactionData[agePreferenceRequest.id]
+    : undefined
 
   // Slide-in panel with semi-transparent backdrop for click-outside close
   // Uses CSS animations instead of transitions for React Compiler compatibility

--- a/frontend/src/components/CamperRequestSummary.test.tsx
+++ b/frontend/src/components/CamperRequestSummary.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '../test/testUtils'
+import type { BunkRequestsResponse } from '../types/pocketbase-types'
 
 // Mock pocketbase
 const mockGetFullList = vi.fn()
@@ -25,7 +26,7 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
-const mockRequests = [
+const mockRequests: BunkRequestsResponse[] = [
   {
     id: 'req1',
     requester_id: 100,
@@ -39,7 +40,7 @@ const mockRequests = [
     is_reciprocal: false,
     confidence_score: 0.95,
     created: '2025-01-01',
-  },
+  } as unknown as BunkRequestsResponse,
   {
     id: 'req2',
     requester_id: 100,
@@ -53,7 +54,7 @@ const mockRequests = [
     is_reciprocal: false,
     confidence_score: 0.88,
     created: '2025-01-01',
-  },
+  } as unknown as BunkRequestsResponse,
   {
     id: 'req3',
     requester_id: 100,
@@ -67,7 +68,7 @@ const mockRequests = [
     is_reciprocal: false,
     confidence_score: 0.9,
     created: '2025-01-01',
-  },
+  } as unknown as BunkRequestsResponse,
 ]
 
 const mockPersons = [
@@ -148,7 +149,7 @@ describe('CamperRequestSummary', () => {
     })
   })
 
-  it('filters out age_preference requests', async () => {
+  it('renders age_preference requests with "Prefers bunking with" text', async () => {
     mockFetch([
       ...mockRequests,
       {
@@ -156,6 +157,7 @@ describe('CamperRequestSummary', () => {
         requester_id: 100,
         requestee_id: 0,
         request_type: 'age_preference',
+        age_preference_target: 'older',
         status: 'pending',
         priority: 0,
         requested_person_name: '',
@@ -164,12 +166,20 @@ describe('CamperRequestSummary', () => {
         is_reciprocal: false,
         confidence_score: 1,
         created: '2025-01-01',
-      } as unknown as (typeof mockRequests)[number],
+      } as unknown as BunkRequestsResponse,
     ])
     render(<CamperRequestSummary requesterCmId={100} year={2025} currentRequestId="req1" />)
     await waitFor(() => {
       expect(screen.getByText('Olivia Chen')).toBeInTheDocument()
     })
-    expect(screen.queryByText(/Prefers bunking with/)).not.toBeInTheDocument()
+    expect(screen.getByText(/Prefers bunking with/)).toBeInTheDocument()
+  })
+
+  it('shows an error state when request fetch fails', async () => {
+    mockGetFullList.mockRejectedValue(new Error('Network error'))
+    render(<CamperRequestSummary requesterCmId={100} year={2025} currentRequestId="req1" />)
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load requests/)).toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/components/CamperRequestSummary.test.tsx
+++ b/frontend/src/components/CamperRequestSummary.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '../test/testUtils'
+
+// Mock pocketbase
+const mockGetFullList = vi.fn()
+vi.mock('../lib/pocketbase', () => ({
+  pb: {
+    collection: vi.fn(() => ({
+      getFullList: mockGetFullList,
+    })),
+  },
+}))
+
+// Mock useAuth
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'test-user', email: 'test@example.com' },
+    isLoading: false,
+  }),
+}))
+
+const { CamperRequestSummary } = await import('./CamperRequestSummary')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+const mockRequests = [
+  {
+    id: 'req1',
+    requester_id: 100,
+    requestee_id: 201,
+    request_type: 'bunk_with',
+    status: 'resolved',
+    priority: 1,
+    requested_person_name: 'Olivia Chen',
+    year: 2025,
+    session_id: 1001,
+    is_reciprocal: false,
+    confidence_score: 0.95,
+    created: '2025-01-01',
+  },
+  {
+    id: 'req2',
+    requester_id: 100,
+    requestee_id: 202,
+    request_type: 'not_bunk_with',
+    status: 'pending',
+    priority: 2,
+    requested_person_name: 'Liam Garcia',
+    year: 2025,
+    session_id: 1001,
+    is_reciprocal: false,
+    confidence_score: 0.88,
+    created: '2025-01-01',
+  },
+  {
+    id: 'req3',
+    requester_id: 100,
+    requestee_id: 203,
+    request_type: 'bunk_with',
+    status: 'declined',
+    priority: 3,
+    requested_person_name: 'Noah Smith',
+    year: 2025,
+    session_id: 1001,
+    is_reciprocal: false,
+    confidence_score: 0.9,
+    created: '2025-01-01',
+  },
+]
+
+const mockPersons = [
+  { id: 'p1', cm_id: 201, first_name: 'Olivia', last_name: 'Chen', year: 2025 },
+  { id: 'p2', cm_id: 202, first_name: 'Liam', last_name: 'Garcia', year: 2025 },
+  { id: 'p3', cm_id: 203, first_name: 'Noah', last_name: 'Smith', year: 2025 },
+]
+
+function mockFetch(requests: typeof mockRequests = mockRequests) {
+  mockGetFullList.mockImplementation((opts: { filter?: string }) => {
+    const filter = opts?.filter ?? ''
+    if (filter.includes('requester_id')) {
+      return Promise.resolve(requests)
+    }
+    if (filter.includes('cm_id')) {
+      return Promise.resolve(mockPersons)
+    }
+    return Promise.resolve([])
+  })
+}
+
+describe('CamperRequestSummary', () => {
+  it('renders a list of other requests for the requester', async () => {
+    mockFetch()
+    render(<CamperRequestSummary requesterCmId={100} year={2025} currentRequestId="req2" />)
+    await waitFor(() => {
+      expect(screen.getByText('Olivia Chen')).toBeInTheDocument()
+    })
+    expect(screen.getAllByText(/Liam Garcia/i).length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText(/Noah Smith/)).toBeInTheDocument()
+  })
+
+  it('highlights the current request with a ring', async () => {
+    mockFetch()
+    render(<CamperRequestSummary requesterCmId={100} year={2025} currentRequestId="req1" />)
+    await waitFor(() => {
+      expect(screen.getByText('Olivia Chen')).toBeInTheDocument()
+    })
+    const currentRow = screen.getByTestId('request-row-req1')
+    // The inner div produced by BunkRequestRow is a direct child
+    const inner = currentRow.firstElementChild as HTMLElement
+    expect(inner.className).toMatch(/ring-primary\/40/)
+    expect(inner.className).toMatch(/bg-primary\/5/)
+  })
+
+  it('does not highlight non-current requests', async () => {
+    mockFetch()
+    render(<CamperRequestSummary requesterCmId={100} year={2025} currentRequestId="req1" />)
+    await waitFor(() => {
+      expect(screen.getByText('Olivia Chen')).toBeInTheDocument()
+    })
+    const otherRow = screen.getByTestId('request-row-req2')
+    const inner = otherRow.firstElementChild as HTMLElement
+    expect(inner.className).not.toMatch(/ring-primary\/40/)
+  })
+
+  it('shows "Not bunk with" label in red for not_bunk_with requests', async () => {
+    mockFetch()
+    render(<CamperRequestSummary requesterCmId={100} year={2025} currentRequestId="req1" />)
+    await waitFor(() => {
+      expect(screen.getByText('Olivia Chen')).toBeInTheDocument()
+    })
+    const notBunk = screen.getByText('Not bunk with')
+    expect(notBunk.className).toMatch(/text-red-600/)
+  })
+
+  it('shows a loading indicator while requests load', () => {
+    mockGetFullList.mockReturnValue(new Promise(() => {})) // never resolves
+    render(<CamperRequestSummary requesterCmId={100} year={2025} currentRequestId="req1" />)
+    expect(screen.getByText(/Loading requests/)).toBeInTheDocument()
+  })
+
+  it('shows an empty state when there are no other requests', async () => {
+    mockFetch([])
+    render(<CamperRequestSummary requesterCmId={100} year={2025} currentRequestId="req1" />)
+    await waitFor(() => {
+      expect(screen.getByText(/No other requests/)).toBeInTheDocument()
+    })
+  })
+
+  it('filters out age_preference requests', async () => {
+    mockFetch([
+      ...mockRequests,
+      {
+        id: 'req4',
+        requester_id: 100,
+        requestee_id: 0,
+        request_type: 'age_preference',
+        status: 'pending',
+        priority: 0,
+        requested_person_name: '',
+        year: 2025,
+        session_id: 1001,
+        is_reciprocal: false,
+        confidence_score: 1,
+        created: '2025-01-01',
+      } as unknown as (typeof mockRequests)[number],
+    ])
+    render(<CamperRequestSummary requesterCmId={100} year={2025} currentRequestId="req1" />)
+    await waitFor(() => {
+      expect(screen.getByText('Olivia Chen')).toBeInTheDocument()
+    })
+    expect(screen.queryByText(/Prefers bunking with/)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/CamperRequestSummary.tsx
+++ b/frontend/src/components/CamperRequestSummary.tsx
@@ -1,0 +1,114 @@
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Loader2 } from 'lucide-react'
+import { pb } from '../lib/pocketbase'
+import { useAuth } from '../contexts/AuthContext'
+import { BunkRequestRow } from './BunkRequestRow'
+import type { BunkRequestsResponse, PersonsResponse } from '../types/pocketbase-types'
+
+interface CamperRequestSummaryProps {
+  requesterCmId: number
+  year: number
+  currentRequestId: string
+}
+
+/**
+ * Renders the full set of bunk requests submitted by a given requester
+ * (other than age_preference rows), used in the expanded request row so
+ * reviewers can see all asks from a single camper at a glance. The
+ * `currentRequestId` row gets a "you are here" ring highlight.
+ */
+export function CamperRequestSummary({
+  requesterCmId,
+  year,
+  currentRequestId,
+}: CamperRequestSummaryProps) {
+  const { user } = useAuth()
+
+  const { data: requests = [], isLoading: isLoadingRequests } = useQuery({
+    queryKey: ['camper-request-summary', requesterCmId, year],
+    queryFn: async () => {
+      return pb.collection<BunkRequestsResponse>('bunk_requests').getFullList({
+        filter: `requester_id = ${requesterCmId} && year = ${year} && (merged_into = "" || merged_into = null)`,
+        sort: '-priority,request_type',
+      })
+    },
+    staleTime: 30000,
+    enabled: !!user && requesterCmId > 0,
+  })
+
+  const requesteeIds = useMemo(() => {
+    const ids = new Set<number>()
+    requests.forEach((r) => {
+      if (r.requestee_id && r.requestee_id > 0) {
+        ids.add(r.requestee_id)
+      }
+    })
+    return Array.from(ids).sort((a, b) => a - b)
+  }, [requests])
+
+  const requesteeIdsKey = useMemo(() => requesteeIds.join(','), [requesteeIds])
+
+  const { data: persons = [], isLoading: isLoadingPersons } = useQuery({
+    queryKey: ['camper-request-summary-persons', requesteeIdsKey, year],
+    queryFn: async () => {
+      if (requesteeIds.length === 0) return []
+      const chunks: number[][] = []
+      for (let i = 0; i < requesteeIds.length; i += 50) {
+        chunks.push(requesteeIds.slice(i, i + 50))
+      }
+      const results = await Promise.all(
+        chunks.map((chunk) =>
+          pb.collection<PersonsResponse>('persons').getFullList({
+            filter: `(${chunk.map((id) => `cm_id = ${id}`).join(' || ')}) && year = ${year}`,
+          })
+        )
+      )
+      return results.flat()
+    },
+    enabled: !!user && requesteeIds.length > 0,
+    staleTime: 30000,
+  })
+
+  const personMap = useMemo(() => new Map(persons.map((p) => [p.cm_id, p])), [persons])
+
+  const isLoading = isLoadingRequests || (requesteeIds.length > 0 && isLoadingPersons)
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 py-4 text-sm">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        <span className="text-muted-foreground">Loading requests...</span>
+      </div>
+    )
+  }
+
+  // Filter to only show non-age_preference requests (consistent with CamperDetailsPanel)
+  const displayRequests = requests.filter((r) => r.request_type !== 'age_preference')
+
+  if (displayRequests.length === 0) {
+    return <div className="text-muted-foreground py-2 text-sm italic">No other requests</div>
+  }
+
+  return (
+    <div className="space-y-1">
+      <div className="text-muted-foreground mb-1 text-xs font-semibold tracking-wide uppercase">
+        Other requests from this camper
+      </div>
+      {displayRequests.map((request) => {
+        const targetPerson = request.requestee_id
+          ? (personMap.get(request.requestee_id) ?? null)
+          : null
+        return (
+          <div key={request.id} data-testid={`request-row-${request.id}`}>
+            <BunkRequestRow
+              request={request}
+              targetPerson={targetPerson}
+              isCurrent={request.id === currentRequestId}
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/CamperRequestSummary.tsx
+++ b/frontend/src/components/CamperRequestSummary.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Loader2 } from 'lucide-react'
+import { Loader2, AlertCircle } from 'lucide-react'
 import { pb } from '../lib/pocketbase'
 import { useAuth } from '../contexts/AuthContext'
 import { BunkRequestRow } from './BunkRequestRow'
+import { queryKeys } from '../utils/queryKeys'
 import type { BunkRequestsResponse, PersonsResponse } from '../types/pocketbase-types'
 
 interface CamperRequestSummaryProps {
@@ -25,8 +26,12 @@ export function CamperRequestSummary({
 }: CamperRequestSummaryProps) {
   const { user } = useAuth()
 
-  const { data: requests = [], isLoading: isLoadingRequests } = useQuery({
-    queryKey: ['camper-request-summary', requesterCmId, year],
+  const {
+    data: requests = [],
+    isLoading: isLoadingRequests,
+    isError: isErrorRequests,
+  } = useQuery({
+    queryKey: queryKeys.camperRequestSummary(requesterCmId, year),
     queryFn: async () => {
       return pb.collection<BunkRequestsResponse>('bunk_requests').getFullList({
         filter: `requester_id = ${requesterCmId} && year = ${year} && (merged_into = "" || merged_into = null)`,
@@ -47,10 +52,8 @@ export function CamperRequestSummary({
     return Array.from(ids).sort((a, b) => a - b)
   }, [requests])
 
-  const requesteeIdsKey = useMemo(() => requesteeIds.join(','), [requesteeIds])
-
   const { data: persons = [], isLoading: isLoadingPersons } = useQuery({
-    queryKey: ['camper-request-summary-persons', requesteeIdsKey, year],
+    queryKey: queryKeys.camperRequestSummaryPersons(requesteeIds, year),
     queryFn: async () => {
       if (requesteeIds.length === 0) return []
       const chunks: number[][] = []
@@ -72,7 +75,7 @@ export function CamperRequestSummary({
 
   const personMap = useMemo(() => new Map(persons.map((p) => [p.cm_id, p])), [persons])
 
-  const isLoading = isLoadingRequests || (requesteeIds.length > 0 && isLoadingPersons)
+  const isLoading = isLoadingRequests || isLoadingPersons
 
   if (isLoading) {
     return (
@@ -83,10 +86,19 @@ export function CamperRequestSummary({
     )
   }
 
-  // Filter to only show non-age_preference requests (consistent with CamperDetailsPanel)
-  const displayRequests = requests.filter((r) => r.request_type !== 'age_preference')
+  if (isErrorRequests) {
+    return (
+      <div className="text-destructive flex items-center gap-2 py-2 text-sm">
+        <AlertCircle className="h-4 w-4 flex-shrink-0" />
+        Failed to load requests
+      </div>
+    )
+  }
 
-  if (displayRequests.length === 0) {
+  const nonAgeRequests = requests.filter((r) => r.request_type !== 'age_preference')
+  const agePreferenceRequest = requests.find((r) => r.request_type === 'age_preference')
+
+  if (nonAgeRequests.length === 0 && !agePreferenceRequest) {
     return <div className="text-muted-foreground py-2 text-sm italic">No other requests</div>
   }
 
@@ -95,7 +107,7 @@ export function CamperRequestSummary({
       <div className="text-muted-foreground mb-1 text-xs font-semibold tracking-wide uppercase">
         Other requests from this camper
       </div>
-      {displayRequests.map((request) => {
+      {nonAgeRequests.map((request) => {
         const targetPerson = request.requestee_id
           ? (personMap.get(request.requestee_id) ?? null)
           : null
@@ -109,6 +121,14 @@ export function CamperRequestSummary({
           </div>
         )
       })}
+      {agePreferenceRequest?.age_preference_target && (
+        <div
+          className={nonAgeRequests.length > 0 ? 'border-border/50 mt-3 border-t pt-2' : ''}
+          data-testid={`request-row-${agePreferenceRequest.id}`}
+        >
+          <BunkRequestRow request={agePreferenceRequest} />
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -1307,6 +1307,13 @@ export default function RequestReviewPanel({
                                 </div>
                               )}
                             </div>
+                            <div className="mt-3 border-t pt-3">
+                              <CamperRequestSummary
+                                requesterCmId={request.requester_id}
+                                year={year}
+                                currentRequestId={request.id}
+                              />
+                            </div>
                           </div>
                         )}
                       </div>
@@ -1571,7 +1578,9 @@ export default function RequestReviewPanel({
                                                   )}
                                                 </div>
                                                 <p className="text-muted-foreground text-sm">
-                                                  {source.original_content ?? (
+                                                  {source.original_content?.trim() ? (
+                                                    source.original_content
+                                                  ) : (
                                                     <span className="italic">No original text</span>
                                                   )}
                                                 </p>
@@ -1579,7 +1588,9 @@ export default function RequestReviewPanel({
                                                   <span className="font-medium">
                                                     AI Intent Notes:
                                                   </span>{' '}
-                                                  {source.parse_notes ?? (
+                                                  {source.parse_notes?.trim() ? (
+                                                    source.parse_notes
+                                                  ) : (
                                                     <span className="italic">
                                                       No AI intent notes
                                                     </span>

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -41,6 +41,7 @@ import EditableRequestTarget from './EditableRequestTarget'
 import EditablePriority from './EditablePriority'
 import CreateRequestModal from './CreateRequestModal'
 import CamperDetailsPanel from './CamperDetailsPanel'
+import { CamperRequestSummary } from './CamperRequestSummary'
 import MergeRequestsModal from './MergeRequestsModal'
 import SplitRequestModal from './SplitRequestModal'
 import { useOptimisticValidation } from '../hooks/useOptimisticValidation'
@@ -1530,199 +1531,214 @@ export default function RequestReviewPanel({
                             className="bg-parchment-50/50 dark:bg-forest-950/20 border-border border-t px-4 py-4"
                             onClick={(e) => e.stopPropagation()}
                           >
-                            <div className="ml-10 max-w-3xl space-y-3">
-                              {/* Merged Request: Show individual sources */}
-                              {hasMultipleSources(request) &&
-                              expandedMergedRequestId === request.id ? (
-                                <>
-                                  <div>
-                                    <h4 className="text-foreground mb-2 text-sm font-semibold">
-                                      Contributing Sources
-                                    </h4>
-                                    {isLoadingExpandedSourceLinks ? (
-                                      <div className="text-muted-foreground flex items-center gap-2 text-sm">
-                                        <Loader2 className="h-4 w-4 animate-spin" />
-                                        Loading source details...
-                                      </div>
-                                    ) : expandedSourceLinks.length > 0 ? (
-                                      <div className="space-y-3">
-                                        {expandedSourceLinks.map((source, idx) => {
-                                          return (
-                                            <div
-                                              key={source.original_request_id || idx}
-                                              className={clsx(
-                                                'rounded-lg border p-3',
-                                                source.is_primary
-                                                  ? 'border-primary/30 bg-primary/5'
-                                                  : 'border-border bg-muted/20'
-                                              )}
-                                            >
-                                              <div className="mb-1 flex items-center gap-2">
-                                                <span className="text-sm font-medium">
-                                                  {formatSourceField(source.source_field)}
-                                                </span>
-                                                {source.is_primary && (
-                                                  <span className="bg-primary/10 text-primary inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium">
-                                                    <Star className="h-3 w-3" />
-                                                    Primary
+                            <div className="ml-10 grid max-w-6xl grid-cols-1 gap-6 lg:grid-cols-2">
+                              <div className="max-w-3xl space-y-3">
+                                {/* Merged Request: Show individual sources */}
+                                {hasMultipleSources(request) &&
+                                expandedMergedRequestId === request.id ? (
+                                  <>
+                                    <div>
+                                      <h4 className="text-foreground mb-2 text-sm font-semibold">
+                                        Contributing Sources
+                                      </h4>
+                                      {isLoadingExpandedSourceLinks ? (
+                                        <div className="text-muted-foreground flex items-center gap-2 text-sm">
+                                          <Loader2 className="h-4 w-4 animate-spin" />
+                                          Loading source details...
+                                        </div>
+                                      ) : expandedSourceLinks.length > 0 ? (
+                                        <div className="space-y-3">
+                                          {expandedSourceLinks.map((source, idx) => {
+                                            return (
+                                              <div
+                                                key={source.original_request_id || idx}
+                                                className={clsx(
+                                                  'rounded-lg border p-3',
+                                                  source.is_primary
+                                                    ? 'border-primary/30 bg-primary/5'
+                                                    : 'border-border bg-muted/20'
+                                                )}
+                                              >
+                                                <div className="mb-1 flex items-center gap-2">
+                                                  <span className="text-sm font-medium">
+                                                    {formatSourceField(source.source_field)}
                                                   </span>
-                                                )}
+                                                  {source.is_primary && (
+                                                    <span className="bg-primary/10 text-primary inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium">
+                                                      <Star className="h-3 w-3" />
+                                                      Primary
+                                                    </span>
+                                                  )}
+                                                </div>
+                                                <p className="text-muted-foreground text-sm">
+                                                  {source.original_content ?? (
+                                                    <span className="italic">No original text</span>
+                                                  )}
+                                                </p>
+                                                <p className="text-muted-foreground bg-muted/50 mt-1.5 rounded px-2 py-1 text-xs">
+                                                  <span className="font-medium">
+                                                    AI Intent Notes:
+                                                  </span>{' '}
+                                                  {source.parse_notes ?? (
+                                                    <span className="italic">
+                                                      No AI intent notes
+                                                    </span>
+                                                  )}
+                                                </p>
                                               </div>
-                                              <p className="text-muted-foreground text-sm">
-                                                {source.original_content ?? (
-                                                  <span className="italic">No original text</span>
-                                                )}
-                                              </p>
-                                              <p className="text-muted-foreground bg-muted/50 mt-1.5 rounded px-2 py-1 text-xs">
-                                                <span className="font-medium">
-                                                  AI Intent Notes:
-                                                </span>{' '}
-                                                {source.parse_notes ?? (
-                                                  <span className="italic">No AI intent notes</span>
-                                                )}
-                                              </p>
-                                            </div>
-                                          )
-                                        })}
-                                      </div>
-                                    ) : (
-                                      // Fallback to request-level data if no source links found
-                                      <p className="text-muted-foreground text-sm italic">
-                                        Source details not available
-                                      </p>
-                                    )}
-                                  </div>
-                                </>
-                              ) : (
-                                <>
-                                  {/* Single Source Request: Original display */}
-                                  <div>
-                                    <h4 className="text-foreground mb-1 text-sm font-semibold">
-                                      Notes from Bunk Requests Form
-                                    </h4>
-                                    {(() => {
-                                      // Get field name(s) with proper fallback chain:
-                                      // 1. source_fields (for merged requests - array)
-                                      // 2. source_field (single field)
-                                      // 3. ai_p1_reasoning.csv_source_field (AI processing)
-                                      interface AiReasoningWithField {
-                                        csv_source_field?: string
-                                      }
-
-                                      const sourceFields = request.source_fields
-                                      const singleField = request.source_field
-                                      const aiField =
-                                        request.ai_p1_reasoning &&
-                                        typeof request.ai_p1_reasoning === 'object' &&
-                                        'csv_source_field' in request.ai_p1_reasoning
-                                          ? ((request.ai_p1_reasoning as AiReasoningWithField)
-                                              .csv_source_field ?? '')
-                                          : ''
-
-                                      // Determine display field name
-                                      let fieldName: string
-                                      if (Array.isArray(sourceFields) && sourceFields.length > 1) {
-                                        // Merged request: show all source fields combined
-                                        fieldName = sourceFields
-                                          .map((f) => formatSourceField(f))
-                                          .join(' + ')
-                                      } else {
-                                        // Single source: use first available field
-                                        const firstSourceField = Array.isArray(sourceFields)
-                                          ? sourceFields[0]
-                                          : undefined
-                                        const field =
-                                          (firstSourceField ?? singleField) || aiField || ''
-                                        fieldName = field
-                                          ? formatSourceField(field)
-                                          : 'Unknown Field'
-                                      }
-
-                                      return (
-                                        <p className="text-sm">
-                                          <span className="font-medium">{fieldName}:</span>{' '}
-                                          <span className="text-muted-foreground">
-                                            {request.original_text || (
-                                              <span className="italic">No original text</span>
-                                            )}
-                                          </span>
+                                            )
+                                          })}
+                                        </div>
+                                      ) : (
+                                        // Fallback to request-level data if no source links found
+                                        <p className="text-muted-foreground text-sm italic">
+                                          Source details not available
                                         </p>
-                                      )
-                                    })()}
-                                  </div>
-
-                                  {/* AI Intent Notes - always show for single source */}
-                                  <div>
-                                    <h4 className="text-foreground mb-1 text-sm font-semibold">
-                                      AI Intent Notes
-                                    </h4>
-                                    <p className="text-muted-foreground text-sm">
-                                      {request.parse_notes || (
-                                        <span className="italic">No AI intent notes</span>
                                       )}
-                                    </p>
-                                  </div>
-                                </>
-                              )}
+                                    </div>
+                                  </>
+                                ) : (
+                                  <>
+                                    {/* Single Source Request: Original display */}
+                                    <div>
+                                      <h4 className="text-foreground mb-1 text-sm font-semibold">
+                                        Notes from Bunk Requests Form
+                                      </h4>
+                                      {(() => {
+                                        // Get field name(s) with proper fallback chain:
+                                        // 1. source_fields (for merged requests - array)
+                                        // 2. source_field (single field)
+                                        // 3. ai_p1_reasoning.csv_source_field (AI processing)
+                                        interface AiReasoningWithField {
+                                          csv_source_field?: string
+                                        }
 
-                              {/* Type (moved from column) */}
-                              <div className="flex items-center gap-2 text-sm">
-                                <span className="font-medium">Type:</span>
-                                <EditableRequestType
-                                  value={request.request_type}
-                                  onChange={(newType) => {
-                                    const updates: Partial<BunkRequestsResponse> = {
-                                      request_type: newType as BunkRequestsResponse['request_type'],
-                                    }
-                                    // Explicit clear values (not delete) so PocketBase clears the field.
-                                    // Use null (not 0) to properly clear the field — 0 causes
-                                    // unique constraint violations when multiple requests exist.
-                                    if (newType === 'age_preference') {
-                                      updates.requestee_id = null as unknown as number
-                                    } else {
-                                      updates.age_preference_target = ''
-                                    }
-                                    handleValidatedUpdate(request, updates)
-                                  }}
-                                  disabled={request.request_locked || false}
-                                />
-                              </div>
+                                        const sourceFields = request.source_fields
+                                        const singleField = request.source_field
+                                        const aiField =
+                                          request.ai_p1_reasoning &&
+                                          typeof request.ai_p1_reasoning === 'object' &&
+                                          'csv_source_field' in request.ai_p1_reasoning
+                                            ? ((request.ai_p1_reasoning as AiReasoningWithField)
+                                                .csv_source_field ?? '')
+                                            : ''
 
-                              {/* Metadata */}
-                              <div className="text-muted-foreground flex flex-wrap items-center gap-3 text-xs">
-                                <span>Source: {request.source}</span>
-                                {request.disposition_reason && (
-                                  <span
-                                    className={clsx(
-                                      'rounded px-1.5 py-0.5 text-[10px] font-semibold',
-                                      getDispositionClasses(request.disposition_reason)
-                                    )}
-                                  >
-                                    {formatDispositionReason(request.disposition_reason)}
-                                  </span>
+                                        // Determine display field name
+                                        let fieldName: string
+                                        if (
+                                          Array.isArray(sourceFields) &&
+                                          sourceFields.length > 1
+                                        ) {
+                                          // Merged request: show all source fields combined
+                                          fieldName = sourceFields
+                                            .map((f) => formatSourceField(f))
+                                            .join(' + ')
+                                        } else {
+                                          // Single source: use first available field
+                                          const firstSourceField = Array.isArray(sourceFields)
+                                            ? sourceFields[0]
+                                            : undefined
+                                          const field =
+                                            (firstSourceField ?? singleField) || aiField || ''
+                                          fieldName = field
+                                            ? formatSourceField(field)
+                                            : 'Unknown Field'
+                                        }
+
+                                        return (
+                                          <p className="text-sm">
+                                            <span className="font-medium">{fieldName}:</span>{' '}
+                                            <span className="text-muted-foreground">
+                                              {request.original_text || (
+                                                <span className="italic">No original text</span>
+                                              )}
+                                            </span>
+                                          </p>
+                                        )
+                                      })()}
+                                    </div>
+
+                                    {/* AI Intent Notes - always show for single source */}
+                                    <div>
+                                      <h4 className="text-foreground mb-1 text-sm font-semibold">
+                                        AI Intent Notes
+                                      </h4>
+                                      <p className="text-muted-foreground text-sm">
+                                        {request.parse_notes || (
+                                          <span className="italic">No AI intent notes</span>
+                                        )}
+                                      </p>
+                                    </div>
+                                  </>
                                 )}
-                                {request.resolution_method && (
-                                  <span>
-                                    via{' '}
-                                    <span className="font-medium">
-                                      {request.resolution_method.replace(/_/g, ' ')}
+
+                                {/* Type (moved from column) */}
+                                <div className="flex items-center gap-2 text-sm">
+                                  <span className="font-medium">Type:</span>
+                                  <EditableRequestType
+                                    value={request.request_type}
+                                    onChange={(newType) => {
+                                      const updates: Partial<BunkRequestsResponse> = {
+                                        request_type:
+                                          newType as BunkRequestsResponse['request_type'],
+                                      }
+                                      // Explicit clear values (not delete) so PocketBase clears the field.
+                                      // Use null (not 0) to properly clear the field — 0 causes
+                                      // unique constraint violations when multiple requests exist.
+                                      if (newType === 'age_preference') {
+                                        updates.requestee_id = null as unknown as number
+                                      } else {
+                                        updates.age_preference_target = ''
+                                      }
+                                      handleValidatedUpdate(request, updates)
+                                    }}
+                                    disabled={request.request_locked || false}
+                                  />
+                                </div>
+
+                                {/* Metadata */}
+                                <div className="text-muted-foreground flex flex-wrap items-center gap-3 text-xs">
+                                  <span>Source: {request.source}</span>
+                                  {request.disposition_reason && (
+                                    <span
+                                      className={clsx(
+                                        'rounded px-1.5 py-0.5 text-[10px] font-semibold',
+                                        getDispositionClasses(request.disposition_reason)
+                                      )}
+                                    >
+                                      {formatDispositionReason(request.disposition_reason)}
                                     </span>
-                                  </span>
-                                )}
-                                <span>
-                                  Created: {new Date(request.created).toLocaleDateString()}
-                                </span>
-                              </div>
-
-                              {/* Protection status - show when applicable */}
-                              {request.request_locked && request.status === 'resolved' && (
-                                <div className="flex items-center gap-4 text-xs">
-                                  <span className="text-primary flex items-center gap-1.5 font-medium">
-                                    <Shield className="h-3 w-3" />
-                                    Protected due to manual approval
+                                  )}
+                                  {request.resolution_method && (
+                                    <span>
+                                      via{' '}
+                                      <span className="font-medium">
+                                        {request.resolution_method.replace(/_/g, ' ')}
+                                      </span>
+                                    </span>
+                                  )}
+                                  <span>
+                                    Created: {new Date(request.created).toLocaleDateString()}
                                   </span>
                                 </div>
-                              )}
+
+                                {/* Protection status - show when applicable */}
+                                {request.request_locked && request.status === 'resolved' && (
+                                  <div className="flex items-center gap-4 text-xs">
+                                    <span className="text-primary flex items-center gap-1.5 font-medium">
+                                      <Shield className="h-3 w-3" />
+                                      Protected due to manual approval
+                                    </span>
+                                  </div>
+                                )}
+                              </div>
+                              <div className="max-w-xl">
+                                <CamperRequestSummary
+                                  requesterCmId={request.requester_id}
+                                  year={year}
+                                  currentRequestId={request.id}
+                                />
+                              </div>
                             </div>
                           </div>
                         )}

--- a/frontend/src/utils/bunkRequest.ts
+++ b/frontend/src/utils/bunkRequest.ts
@@ -1,0 +1,10 @@
+/**
+ * Returns true when a bunk request has been resolved and has a confirmed
+ * requestee — i.e., the requested camper is in the same bunk.
+ */
+export function isConfirmedRequest(request: {
+  status: string
+  requestee_id?: number | null
+}): boolean {
+  return Boolean(request.status === 'resolved' && request.requestee_id && request.requestee_id > 0)
+}

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -221,6 +221,12 @@ export const queryKeys = {
   ) => ['metrics', 'forecast', year, sessionTypes, sessionCmId, dayOffset, duration] as const,
   forecastWeekOptions: (year: number) => ['metrics', 'forecast', 'week-options', year] as const,
 
+  // Camper Request Summary (Tier 2 - user data, used in expanded row)
+  camperRequestSummary: (requesterCmId: number, year: number) =>
+    ['camper-request-summary', requesterCmId, year] as const,
+  camperRequestSummaryPersons: (requesteeIds: number[], year: number) =>
+    ['camper-request-summary-persons', requesteeIds, year] as const,
+
   // Social Graph (Tier 1 - sync data)
   socialGraph: (sessionCmId: number, year: number) => ['social-graph', sessionCmId, year] as const,
 


### PR DESCRIPTION
## Summary

- Splits the expanded bunk request row into two columns — existing source/parse detail on the left, requester's other bunk requests on the right
- Lets staff see the full set of asks from a requester without having to open the camper side-modal
- Extracts a new shared `<BunkRequestRow />` component used by both the camper modal and the expanded row; the two views now render identically by construction
- Expanded-row rendering passes `isCurrent` to add a "you are here" ring on the request being expanded

Addresses feedback item #11 from the wife feedback session.

## Test plan

- [ ] Expand any pending request row — right column shows the requester's other requests (same styling as the camper modal)
- [ ] Currently-expanded request has a subtle ring in the right column list
- [ ] Mutual badge, satisfaction icons, and clickable names match the camper modal exactly
- [ ] Age preference rows render correctly ("Prefers older/younger campers")
- [ ] Columns stack on mobile (< lg breakpoint), side-by-side on desktop
- [ ] Camper modal still renders correctly (no visual regression from the extraction)
- [ ] `npx vitest run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified bunk request row display component across the application
  * Added camper request summary showing other bunk requests
  * Improved request review layout with two-column responsive design

* **Refactor**
  * Consolidated bunk request rendering logic for consistency

* **Tests**
  * Added comprehensive test coverage for new request display components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->