### PR TITLE
fix(api): wire historical verification into phase_runner phase2 cascade

### DIFF
--- a/bunking/sync/bunk_request_processor/debug/phase_runner.py
+++ b/bunking/sync/bunk_request_processor/debug/phase_runner.py
@@ -189,15 +189,10 @@ class PhaseRunner:
             if stop_at_phase == "historical":
                 return result
 
-            # Continue to Phase 3 with ambiguous cases (post-historical-boost).
-            # Exclude age-preference entries — mirrors orchestrator.py:1280-1282.
-            from bunking.sync.bunk_request_processor.core.models import RequestType
+            # Continue to Phase 3 with unresolved, non-age-preference cases.
+            from bunking.sync.bunk_request_processor.orchestrator.orchestrator import needs_phase3
 
-            ambiguous = [
-                (pr, rr_list)
-                for pr, rr_list in historical_results
-                if any(not rr.is_resolved and rr.method != RequestType.AGE_PREFERENCE.value for rr in rr_list)
-            ]
+            ambiguous = [(pr, rr_list) for pr, rr_list in historical_results if any(needs_phase3(rr) for rr in rr_list)]
             if ambiguous:
                 phase3_results = await self.run_phase3(ambiguous)
                 result["phase3_results"] = phase3_results

--- a/bunking/sync/bunk_request_processor/debug/phase_runner.py
+++ b/bunking/sync/bunk_request_processor/debug/phase_runner.py
@@ -189,9 +189,14 @@ class PhaseRunner:
             if stop_at_phase == "historical":
                 return result
 
-            # Continue to Phase 3 with ambiguous cases (post-historical-boost)
+            # Continue to Phase 3 with ambiguous cases (post-historical-boost).
+            # Exclude age-preference entries — mirrors orchestrator.py:1280-1282.
+            from bunking.sync.bunk_request_processor.core.models import RequestType
+
             ambiguous = [
-                (pr, rr_list) for pr, rr_list in historical_results if any(not rr.is_resolved for rr in rr_list)
+                (pr, rr_list)
+                for pr, rr_list in historical_results
+                if any(not rr.is_resolved and rr.method != RequestType.AGE_PREFERENCE.value for rr in rr_list)
             ]
             if ambiguous:
                 phase3_results = await self.run_phase3(ambiguous)

--- a/bunking/sync/bunk_request_processor/debug/phase_runner.py
+++ b/bunking/sync/bunk_request_processor/debug/phase_runner.py
@@ -180,11 +180,19 @@ class PhaseRunner:
             if stop_at_phase == "phase2":
                 return result
 
+            # Phase 2.5: Historical Group Verification. Delegates to the shared
+            # orchestrator method so debug cascades emit identical traces and
+            # confidence boosts as the full pipeline.
+            historical_results = await self._orch.run_historical_verification(phase2_results)
+            result["historical_results"] = historical_results
+
             if stop_at_phase == "historical":
                 return result
 
-            # Continue to Phase 3 with ambiguous cases
-            ambiguous = [(pr, rr_list) for pr, rr_list in phase2_results if any(not rr.is_resolved for rr in rr_list)]
+            # Continue to Phase 3 with ambiguous cases (post-historical-boost)
+            ambiguous = [
+                (pr, rr_list) for pr, rr_list in historical_results if any(not rr.is_resolved for rr in rr_list)
+            ]
             if ambiguous:
                 phase3_results = await self.run_phase3(ambiguous)
                 result["phase3_results"] = phase3_results

--- a/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
@@ -980,6 +980,7 @@ class RequestOrchestrator:
 
         Args:
             resolution_results: Phase 2 output (parse result + candidate list pairs).
+                An empty list is a no-op (returns immediately with no side effects).
 
         Returns:
             Resolution results with historical boosts applied.
@@ -1000,7 +1001,7 @@ class RequestOrchestrator:
             trace_key = _get_trace_key(pr)
             if not trace_key:
                 continue
-            boost_applied = any(rr.metadata.get("historical_verified") if rr.metadata else False for rr in res_list)
+            boost_applied = any(rr.metadata and rr.metadata.get("historical_verified") is True for rr in res_list)
             pre_confs = pre_historical_confidences.get(trace_key, [])
             original_conf = max(pre_confs) if pre_confs else None
             boosted_conf = max(rr.confidence for rr in res_list) if res_list else None

--- a/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
@@ -964,6 +964,56 @@ class RequestOrchestrator:
             dry_run=dry_run,
         )
 
+    async def run_historical_verification(
+        self,
+        resolution_results: list[tuple[ParseResult, list[ResolutionResult]]],
+    ) -> list[tuple[ParseResult, list[ResolutionResult]]]:
+        """Phase 2.5: Historical Group Verification.
+
+        Snapshots pre-verification confidences, runs the verification service,
+        and records per-request trace events (boost applied, original and boosted
+        confidences). Shared by the full pipeline and PhaseRunner debug cascades
+        so both paths produce identical traces and confidence values.
+
+        Boosts confidence by +0.10 (capped at 0.95) for targets verified to have
+        been in the same bunk in a prior year.
+
+        Args:
+            resolution_results: Phase 2 output (parse result + candidate list pairs).
+
+        Returns:
+            Resolution results with historical boosts applied.
+        """
+        logger.info("=== Phase 2.5: Historical Group Verification ===")
+
+        # Snapshot confidence values before historical verification for trace comparison
+        pre_historical_confidences: dict[str, list[float]] = {}
+        for pr, res_list in resolution_results:
+            trace_key = _get_trace_key(pr)
+            if trace_key:
+                pre_historical_confidences[trace_key] = [rr.confidence for rr in res_list]
+
+        verified_results = await self.historical_verification_service.verify(resolution_results)
+
+        # --- Trace: Historical verification results ---
+        for pr, res_list in verified_results:
+            trace_key = _get_trace_key(pr)
+            if not trace_key:
+                continue
+            boost_applied = any(rr.metadata.get("historical_verified") if rr.metadata else False for rr in res_list)
+            pre_confs = pre_historical_confidences.get(trace_key, [])
+            original_conf = max(pre_confs) if pre_confs else None
+            boosted_conf = max(rr.confidence for rr in res_list) if res_list else None
+            self.trace_collector.record_historical(
+                key=trace_key,
+                ran=True,
+                boost_applied=boost_applied,
+                original_confidence=original_conf if boost_applied else None,
+                boosted_confidence=boosted_conf if boost_applied else None,
+            )
+
+        return verified_results
+
     async def _execute_pipeline(
         self,
         parse_requests: list[ParseRequest],
@@ -1185,38 +1235,7 @@ class RequestOrchestrator:
         if stop_at_phase == "phase2":
             return {"dry_run": dry_run, "phase": "phase2"}
 
-        # Phase 2.5: Historical Group Verification
-        # Verify that multiple targets for same historical year were actually in same bunk
-        # Boost confidence by +0.10 for verified groups (capped at 0.95)
-        logger.info("=== Phase 2.5: Historical Group Verification ===")
-
-        # Snapshot confidence values before historical verification for trace comparison
-        pre_historical_confidences: dict[str, list[float]] = {}
-        for pr, res_list in resolution_results:
-            trace_key = _get_trace_key(pr)
-            if trace_key:
-                pre_historical_confidences[trace_key] = [rr.confidence for rr in res_list]
-
-        resolution_results = await self.historical_verification_service.verify(resolution_results)
-
-        # --- Trace: Historical verification results ---
-        for pr, res_list in resolution_results:
-            trace_key = _get_trace_key(pr)
-            if not trace_key:
-                continue
-            # Check if any historical boost was applied
-            boost_applied = any(rr.metadata.get("historical_verified") if rr.metadata else False for rr in res_list)
-            pre_confs = pre_historical_confidences.get(trace_key, [])
-            # Find the max confidence change to report as the boost
-            original_conf = max(pre_confs) if pre_confs else None
-            boosted_conf = max(rr.confidence for rr in res_list) if res_list else None
-            self.trace_collector.record_historical(
-                key=trace_key,
-                ran=True,
-                boost_applied=boost_applied,
-                original_confidence=original_conf if boost_applied else None,
-                boosted_confidence=boosted_conf if boost_applied else None,
-            )
+        resolution_results = await self.run_historical_verification(resolution_results)
 
         if stop_at_phase == "historical":
             return {"dry_run": dry_run, "phase": "historical"}

--- a/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
@@ -123,6 +123,14 @@ def generate_unresolved_person_id(name_text: str) -> int:
     return unresolved_id
 
 
+def needs_phase3(rr: ResolutionResult) -> bool:
+    """Return True if this resolution result should proceed to Phase 3 disambiguation.
+
+    Age-preference requests are excluded — they are staff-reviewed, not AI-resolved.
+    """
+    return not rr.is_resolved and rr.method != RequestType.AGE_PREFERENCE.value
+
+
 class RequestOrchestrator:
     """Main orchestrator for the three-phase bunk request processing.
 
@@ -1264,9 +1272,7 @@ class RequestOrchestrator:
         # Debug logging for Phase 3 decision
         total_unresolved = 0
         for idx, (pr, resolution_list) in enumerate(resolution_results):
-            unresolved_in_this = sum(
-                1 for rr in resolution_list if not rr.is_resolved and rr.method != RequestType.AGE_PREFERENCE.value
-            )
+            unresolved_in_this = sum(1 for rr in resolution_list if needs_phase3(rr))
             if unresolved_in_this > 0:
                 total_unresolved += unresolved_in_this
                 logger.debug(f"ParseResult {idx} has {unresolved_in_this} unresolved requests")
@@ -1278,9 +1284,7 @@ class RequestOrchestrator:
         for idx, (pr, resolution_list) in enumerate(resolution_results):
             # Check if any resolutions in this ParseResult are unresolved
             # Skip pre-parsed requests (like age preferences from dropdowns)
-            has_unresolved = any(
-                not rr.is_resolved and rr.method != RequestType.AGE_PREFERENCE.value for rr in resolution_list
-            )
+            has_unresolved = any(needs_phase3(rr) for rr in resolution_list)
             if has_unresolved:
                 unresolved_cases.append((pr, resolution_list))
                 unresolved_indices.append(idx)

--- a/tests/unit/sync/bunk_request_processor/debug/test_phase_runner.py
+++ b/tests/unit/sync/bunk_request_processor/debug/test_phase_runner.py
@@ -35,6 +35,9 @@ def _make_mock_orchestrator() -> MagicMock:
     orch.phase3_service = MagicMock()
     orch.phase3_service.batch_disambiguate = AsyncMock(return_value=[])
 
+    # Phase 2.5 historical verification (shared with full pipeline)
+    orch.run_historical_verification = AsyncMock(side_effect=lambda results: results)
+
     # Temporal name cache (needed for phase 2 init)
     orch.temporal_name_cache = MagicMock()
     orch.temporal_name_cache.initialize = MagicMock()

--- a/tests/unit/sync/bunk_request_processor/debug/test_phase_runner_stop_at.py
+++ b/tests/unit/sync/bunk_request_processor/debug/test_phase_runner_stop_at.py
@@ -248,8 +248,7 @@ class TestStopAtPhase:
         orch.run_historical_verification.assert_called_once_with(phase2_out)
         # phase3 must be called with the VERIFIED results, not the raw phase2 output
         call_args = orch.phase3_service.batch_disambiguate.call_args
-        phase3_input = call_args.args[0] if call_args.args else call_args.kwargs.get("ambiguous_cases")
-        assert phase3_input == verified_out, "phase3 must receive historical-verified results, not raw phase2"
+        assert call_args.args[0] == verified_out, "phase3 must receive historical-verified results, not raw phase2"
 
     @pytest.mark.anyio
     async def test_run_from_phase2_with_stop_at_phase2_does_not_run_historical(self):
@@ -288,6 +287,53 @@ class TestStopAtPhase:
 
         orch.phase2_service.batch_resolve.assert_called_once()
         orch.run_historical_verification.assert_not_called()
+        orch.phase3_service.batch_disambiguate.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_run_from_phase2_age_preference_excluded_from_phase3(self):
+        """Unresolved age-preference RRs must NOT be fed to phase3 disambiguation.
+
+        Regression guard: the ambiguous filter must mirror orchestrator.py:1280-1282,
+        which excludes AGE_PREFERENCE entries from phase3. Passing them through would
+        cause debug/full pipeline divergence for age-preference requests.
+        """
+        orch = MagicMock()
+
+        pr = MagicMock()
+        age_pref_rr = MagicMock()
+        age_pref_rr.is_resolved = False
+        age_pref_rr.method = "age_preference"
+        phase2_out = [(pr, [age_pref_rr])]
+        verified_out = [(pr, [age_pref_rr])]
+
+        orch.phase2_service = MagicMock()
+        orch.phase2_service.batch_resolve = AsyncMock(return_value=phase2_out)
+        orch.run_historical_verification = AsyncMock(return_value=verified_out)
+        orch.phase3_service = MagicMock()
+        orch.phase3_service.batch_disambiguate = AsyncMock(return_value=[])
+        orch.temporal_name_cache = MagicMock()
+        orch.temporal_name_cache.is_initialized = MagicMock(return_value=True)
+
+        runner = PhaseRunner(orch)
+
+        from bunking.sync.bunk_request_processor.debug.trace_models import (
+            Phase1Trace,
+            PrePhase1Trace,
+            TraceData,
+        )
+
+        trace_data = TraceData(
+            pre_phase1=PrePhase1Trace(action="parsed", original_text="bunk with Emma age older"),
+            phase1_parse=Phase1Trace(
+                ran=True,
+                parsed_intents=[{"target_name": "Emma", "request_type": "AGE_PREFERENCE", "confidence": 0.95}],
+                is_valid=True,
+            ),
+        )
+
+        await runner.run_from_phase("phase2", trace_data=trace_data, dry_run=True, stop_at_phase="phase3")
+
+        # Age-preference entries must not reach phase3 disambiguation
         orch.phase3_service.batch_disambiguate.assert_not_called()
 
     @pytest.mark.anyio

--- a/tests/unit/sync/bunk_request_processor/debug/test_phase_runner_stop_at.py
+++ b/tests/unit/sync/bunk_request_processor/debug/test_phase_runner_stop_at.py
@@ -147,6 +147,150 @@ class TestStopAtPhase:
         )
 
     @pytest.mark.anyio
+    async def test_run_from_phase2_with_stop_at_historical_runs_verify(self):
+        """stop_at_phase='historical' from phase2 entry must run historical verification.
+
+        Regression test for #921: phase2 branch returned early on 'historical' without
+        ever calling historical_verification_service.verify().
+        """
+        orch = MagicMock()
+
+        # Phase 2 returns an ambiguous result
+        pr = MagicMock()
+        raw_rr = MagicMock()
+        raw_rr.is_resolved = False
+        raw_rr.confidence = 0.70
+        phase2_out = [(pr, [raw_rr])]
+
+        # Verified (post-historical) returns a boosted version
+        boosted_rr = MagicMock()
+        boosted_rr.is_resolved = False
+        boosted_rr.confidence = 0.80
+        verified_out = [(pr, [boosted_rr])]
+
+        orch.phase2_service = MagicMock()
+        orch.phase2_service.batch_resolve = AsyncMock(return_value=phase2_out)
+        orch.run_historical_verification = AsyncMock(return_value=verified_out)
+        orch.phase3_service = MagicMock()
+        orch.phase3_service.batch_disambiguate = AsyncMock(return_value=[])
+        orch.temporal_name_cache = MagicMock()
+        orch.temporal_name_cache.is_initialized = MagicMock(return_value=True)
+
+        runner = PhaseRunner(orch)
+
+        from bunking.sync.bunk_request_processor.debug.trace_models import (
+            Phase1Trace,
+            PrePhase1Trace,
+            TraceData,
+        )
+
+        trace_data = TraceData(
+            pre_phase1=PrePhase1Trace(action="parsed", original_text="bunk with Emma"),
+            phase1_parse=Phase1Trace(
+                ran=True,
+                parsed_intents=[{"target_name": "Emma", "request_type": "BUNK_WITH", "confidence": 0.95}],
+                is_valid=True,
+            ),
+        )
+
+        result = await runner.run_from_phase("phase2", trace_data=trace_data, dry_run=True, stop_at_phase="historical")
+
+        orch.phase2_service.batch_resolve.assert_called_once()
+        orch.run_historical_verification.assert_called_once_with(phase2_out)
+        orch.phase3_service.batch_disambiguate.assert_not_called()
+        assert result["historical_results"] == verified_out
+
+    @pytest.mark.anyio
+    async def test_run_from_phase2_with_stop_at_phase3_feeds_historical_into_phase3(self):
+        """stop_at_phase='phase3' from phase2 entry must feed VERIFIED results into phase3.
+
+        Regression test for #922: phase2 branch used to cascade raw phase2 output into
+        phase3, skipping the historical boost entirely.
+        """
+        orch = MagicMock()
+
+        pr = MagicMock()
+        raw_rr = MagicMock()
+        raw_rr.is_resolved = False
+        phase2_out = [(pr, [raw_rr])]
+
+        boosted_rr = MagicMock()
+        boosted_rr.is_resolved = False  # still ambiguous so phase3 runs
+        verified_out = [(pr, [boosted_rr])]
+
+        orch.phase2_service = MagicMock()
+        orch.phase2_service.batch_resolve = AsyncMock(return_value=phase2_out)
+        orch.run_historical_verification = AsyncMock(return_value=verified_out)
+        orch.phase3_service = MagicMock()
+        orch.phase3_service.batch_disambiguate = AsyncMock(return_value=verified_out)
+        orch.temporal_name_cache = MagicMock()
+        orch.temporal_name_cache.is_initialized = MagicMock(return_value=True)
+
+        runner = PhaseRunner(orch)
+
+        from bunking.sync.bunk_request_processor.debug.trace_models import (
+            Phase1Trace,
+            PrePhase1Trace,
+            TraceData,
+        )
+
+        trace_data = TraceData(
+            pre_phase1=PrePhase1Trace(action="parsed", original_text="bunk with Emma"),
+            phase1_parse=Phase1Trace(
+                ran=True,
+                parsed_intents=[{"target_name": "Emma", "request_type": "BUNK_WITH", "confidence": 0.95}],
+                is_valid=True,
+            ),
+        )
+
+        await runner.run_from_phase("phase2", trace_data=trace_data, dry_run=True, stop_at_phase="phase3")
+
+        orch.run_historical_verification.assert_called_once_with(phase2_out)
+        # phase3 must be called with the VERIFIED results, not the raw phase2 output
+        call_args = orch.phase3_service.batch_disambiguate.call_args
+        phase3_input = call_args.args[0] if call_args.args else call_args.kwargs.get("ambiguous_cases")
+        assert phase3_input == verified_out, "phase3 must receive historical-verified results, not raw phase2"
+
+    @pytest.mark.anyio
+    async def test_run_from_phase2_with_stop_at_phase2_does_not_run_historical(self):
+        """stop_at_phase='phase2' must NOT trigger historical verification."""
+        orch = MagicMock()
+
+        mock_rr = MagicMock()
+        mock_rr.is_resolved = False
+        mock_pr = MagicMock()
+        orch.phase2_service = MagicMock()
+        orch.phase2_service.batch_resolve = AsyncMock(return_value=[(mock_pr, [mock_rr])])
+        orch.run_historical_verification = AsyncMock()
+        orch.phase3_service = MagicMock()
+        orch.phase3_service.batch_disambiguate = AsyncMock(return_value=[])
+        orch.temporal_name_cache = MagicMock()
+        orch.temporal_name_cache.is_initialized = MagicMock(return_value=True)
+
+        runner = PhaseRunner(orch)
+
+        from bunking.sync.bunk_request_processor.debug.trace_models import (
+            Phase1Trace,
+            PrePhase1Trace,
+            TraceData,
+        )
+
+        trace_data = TraceData(
+            pre_phase1=PrePhase1Trace(action="parsed", original_text="bunk with Emma"),
+            phase1_parse=Phase1Trace(
+                ran=True,
+                parsed_intents=[{"target_name": "Emma", "request_type": "BUNK_WITH", "confidence": 0.95}],
+                is_valid=True,
+            ),
+        )
+
+        await runner.run_from_phase("phase2", trace_data=trace_data, dry_run=True, stop_at_phase="phase2")
+
+        orch.phase2_service.batch_resolve.assert_called_once()
+        orch.run_historical_verification.assert_not_called()
+        orch.phase3_service.batch_disambiguate.assert_not_called()
+
+    @pytest.mark.anyio
     async def test_stop_at_same_as_start_runs_only_that_phase(self):
         """run_from_phase with stop_at_phase == start phase runs only that phase."""
         orch = MagicMock()


### PR DESCRIPTION
## Summary

- Extracts the orchestrator's inline historical-verification block (snapshot → `verify()` → trace recording) into a shared `run_historical_verification` method on `RequestOrchestrator`.
- `PhaseRunner.run_from_phase(phase="phase2", ...)` now calls this shared method before the `"historical"` early return and feeds its output into the phase3 cascade.
- Debug and full-pipeline paths now produce identical traces and confidence values.

Fixes #921, fixes #922.

## Why

Previously, `PhaseRunner` phase2 branch called only `phase2_service.batch_resolve()` and returned. The full pipeline's historical verification (the +0.10 boost, capped at 0.95) lived inline in `orchestrator.process_from_parse_requests` and was never invoked from the debug path.

Concretely, from phase2 entry:
- `stop_at_phase="historical"` returned raw phase2 results — no boost, no historical trace events.
- `stop_at_phase="phase3"` cascaded raw phase2 into phase3 — disambiguation operated on un-boosted confidences.

Debug results therefore disagreed with full-pipeline results on any record whose confidence would be boosted by historical group verification.

## Approach

Rather than duplicate the inline logic in `PhaseRunner` (drift risk), extract it once:

```python
async def run_historical_verification(self, resolution_results):
    # snapshot pre-historical confidences
    # call self.historical_verification_service.verify(...)
    # record self.trace_collector.record_historical(...) per parse_result
    # return verified results
```

Both the full pipeline and `PhaseRunner` call this method — same code path = same behavior = same traces.

## Test plan

- [x] Added 3 tests to `test_phase_runner_stop_at.py`:
  - `test_run_from_phase2_with_stop_at_historical_runs_verify` — regression guard for #921
  - `test_run_from_phase2_with_stop_at_phase3_feeds_historical_into_phase3` — regression guard for #922
  - `test_run_from_phase2_with_stop_at_phase2_does_not_run_historical` — confirms stop_at=phase2 still skips verification
- [x] Updated `test_phase_runner.py` shared mock fixture to mock `run_historical_verification`
- [x] All 1689 `bunking/sync/bunk_request_processor/` unit tests pass (existing orchestrator trace tests unchanged and passing — validates refactor didn't break trace recording)
- [x] Pre-push verification (ruff, mypy, full unit suite) passes

## Out of scope

- Renaming `stop_at_phase="historical"` sentinel (option 2 in #921 — rejected in favor of running the stage before the early return)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal request processing pipeline to better isolate historical verification as a distinct processing step.

* **Tests**
  * Added comprehensive test coverage ensuring proper integration of historical verification across different processing phases and stop points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->