### PR TITLE
fix(api): teach Phase 1 prompt to prefer FirstName LastName for two-word targets

### DIFF
--- a/config/prompts/parse_request.txt
+++ b/config/prompts/parse_request.txt
@@ -56,6 +56,29 @@ Split multi-name requests into separate entries:
 - "wants to be with Mia, Ava, and Lily" becomes 3 separate bunk_with requests
 - Use list_position to track order (0, 1, 2...)
 
+=== TWO-WORD TARGETS (NO DELIMITERS) ===
+
+When a target is EXACTLY TWO words separated by a single space, with NO comma,
+"and", "&", "or", "+", or other conjunction:
+
+  PREFER: treat as a single "FirstName LastName" target (one request).
+  SPLIT ONLY IF: surrounding context makes it clear they are two distinct
+  people (e.g., "bunk with Sam or Jordan" — "or" is an explicit signal).
+
+Why this is the safer default:
+- Splitting two words that are both plausible first names produces two wrong
+  matches: one unresolved, and one false-positive where the second word
+  fuzzy-matches someone's preferred_name.
+- Combined as "FirstName LastName", a no-match simply falls through to normal
+  disambiguation — which is a recoverable state — instead of silently
+  mis-assigning to the wrong camper.
+
+Examples:
+- "bunk with Riley Sam"     → ONE bunk_with request, target_name="Riley Sam"
+- "wants Emma and Liam"     → TWO bunk_with requests (conjunction present)
+- "bunk with Olivia, Noah"  → TWO bunk_with requests (comma present)
+- "bunk with Jordan Parker" → ONE bunk_with request, target_name="Jordan Parker"
+
 === INVALID TARGETS (DO NOT EXTRACT) ===
 
 - Physical preferences: "upper bunk", "near window", "bottom bed"

--- a/docs/reference/issue-triage.md
+++ b/docs/reference/issue-triage.md
@@ -1,146 +1,74 @@
 # Issue Triage
 
 Open issues grouped by code area with dependencies and suggested attack order.
-Last updated: 2026-04-03 (20 open issues, excluding 6 PR #823 follow-ups).
+Last updated: 2026-04-14 (10 open issues, 19 closed since last update).
 
 ---
 
 ## Remaining Open Issues
 
-### Group 25: Sync Fixes (#806, #807, #791)
+### Group 30: Phase Runner Historical Verification Bugs (#921, #922)
 
-**Priority: Medium** — One bug fix, two cleanup refactors
-
-| # | Title | Type | Status |
-|---|-------|------|--------|
-| 806 | fix(sync): normalize session "0" → "all" in Go process-requests handler | bug | Ready — one-liner fix |
-| 807 | refactor(sync): update session_resolver.go to use cm_ids instead of friendly names | enhancement | Ready |
-| 791 | refactor(sync): extract shared generateRunToken helper | refactor | Ready |
-
-**Interplay:** Independent. #806 is a trivial consistency fix (other endpoints already handle "0"). #807 and #791 are standalone refactors.
-
-### Group 26: Solver Bugs & Performance (#788, #792, #809)
-
-**Priority: Medium** — Trace correctness + query optimization
+**Priority: High** — Debug pipeline disagrees with production pipeline
 
 | # | Title | Type | Status |
 |---|-------|------|--------|
-| 788 | fix(solver): dedup trace key collision — (requester_cm_id, target_name) can match both kept and removed requests | bug | Ready — trace-only impact |
-| 792 | perf(solver): cache PersonRepository.bulk_find_by_cm_ids to avoid redundant DB fetches | performance | Ready |
-| 809 | perf(solver): skip get_related_session_ids query for embedded sessions | performance | Ready |
+| 921 | fix(api): phase_runner `stop_at_phase=historical` short-circuits before historical verification | bug | Ready — staleness confirmed in code at phase_runner.py:183-184 |
+| 922 | fix(api): phase_runner skips historical verification when starting from phase2 | bug | Ready — same root cause as #921 |
 
-**Interplay:** Independent. #788 is trace-correctness only (no impact on actual bunk requests). #792 and #809 are independent perf optimizations.
+**Interplay:** Both bugs live in the same `phase2` branch of `PhaseRunner.run_from_phase` and have the same fix — wire `historical_verification_service.verify(...)` into the phase2 cascade before the `stop_at_phase == "historical"` early return. Single PR.
 
-### Group 27: Solver Logging Cleanup (#787, #815)
+### Group 31: AI Disambiguation & Trace Pipeline (#877, #880, #881, #923)
 
-**Priority: Low** — Log level adjustments
-
-| # | Title | Type | Status |
-|---|-------|------|--------|
-| 787 | fix(solver): move camper name/ID logging from INFO to DEBUG | cleanup | Ready |
-| 815 | fix(solver): move AI prompt/response text from DEBUG to TRACE | cleanup | Ready |
-
-**Interplay:** Independent. Both are log-level changes, no functional impact.
-
-### Group 28: Metrics Tech Debt (#770, #771, #772, #773)
-
-**Priority: Low** — Date-stripping deduplication and helper extraction
+**Priority: Medium** — Refactor cluster + perf win in the same code area
 
 | # | Title | Type | Status |
 |---|-------|------|--------|
-| 770 | refactor(metrics): make _get_enrollment_date public across modules | tech-debt | Ready |
-| 771 | refactor(metrics): replace 13 inline date-stripping patterns with parse_date_only in velocity_service.py | tech-debt | Ready |
-| 772 | refactor(metrics): replace inline date-stripping in session_metrics.py with parse_date_only | tech-debt | Ready |
-| 773 | refactor(metrics): extract shared bucket-write helper in reconstruct_daily_multi | tech-debt | Ready |
+| 880 | refactor(api): extract setdefault helper for disambiguation metadata | refactor | Ready — foundational helper |
+| 881 | refactor(api): decompose `_process_individual_disambiguation_results` | refactor | Ready — depends on #880 |
+| 877 | refactor(api): split PostPipelineTrace into granular sub-stage traces | refactor | Ready |
+| 923 | perf(api): gate trace-collector work and cache `_get_trace_key` in orchestrator | performance | Ready — pairs naturally with #877 |
 
-**Interplay:** #770 should land first (makes helper public), then #771/#772 consume it. #773 is independent.
-
-### Group 29: Frontend Cleanup (#796, #797, #798, #808, #810)
-
-**Priority: Low** — Dead code removal, deduplication, config updates
-
-| # | Title | Type | Status |
-|---|-------|------|--------|
-| 796 | chore(frontend): remove localStorage program migration shim | cleanup | Ready |
-| 797 | chore(frontend): clean up dead export getAnalyticsUrl and inconsistent trailing-slash handling | cleanup | Ready |
-| 798 | refactor(frontend): data-drive program switcher buttons in AppLayout | refactor | Ready |
-| 808 | refactor(frontend): deduplicate SOURCE_FIELD_OPTIONS and fieldLabels | cleanup | Ready |
-| 810 | cleanup(frontend): update SESSION_NAME_TO_URL for Taste of Camp 1/2 | cleanup | Ready |
-
-**Interplay:** Independent. All are safe standalone changes.
+**Interplay:** #880 → #881 → #877 → #923 as a chain in one worktree. All touch the post-pipeline trace / disambiguation code.
 
 ### Standalone Issues
 
 | # | Title | Type | Priority | Status |
 |---|-------|------|----------|--------|
-| 754 | feat(solver): support manual pairing of AG cabins across years | enhancement | Medium | Needs design decisions |
-| 801 | fix(ci): add explicit --platform linux/amd64 to CD docker buildx build | bug | Low | Ready — no functional impact today |
+| 896 | Phase 1 AI prompt splits "FirstName LastName" into two separate first names | bug | High | Ready — external contributor posted root cause + one-line prompt fix |
+| 899 | RBAC: bunk_requests collection too restrictive for read access | bug | Medium | Ready — PocketBase collection rule tweak |
+| 918 | refactor(frontend): extract approve/reject handlers in RequestReviewPanel | refactor | Low | Ready |
+| 796 | chore(frontend): remove localStorage program migration shim | cleanup | Low | Ready |
+| 919 | chore: improve Python docstring coverage (~57% → 80%) | chore | Low | Background / incremental |
 
-### Frontend Tech Debt (Remnants of Group 23)
-
-**Priority: Low** — No behavior change, cleanup/upstream tasks
-
-| # | Title | Type | Status |
-|---|-------|------|--------|
-| 604 | Leverage recharts 3.8 typed generics, niceTicks, and coordinate hooks | enhancement | Needs design decisions |
-| 697 | Switch pocketbase-typegen back to upstream once --use-const is merged | chore | Blocked on upstream |
-
-**Interplay:** Independent. #697 blocked externally. #604 needs design decisions on which recharts 3.8 APIs to adopt.
-
----
-
-## Excluded from Triage
-
-| # | Reason |
-|---|--------|
-| 824–829 | Follow-ups from PR #823 (scoring reform phase 2) — triaged separately |
-
----
-
-## Blocked
+### Blocked
 
 | # | Title | Blocked on |
 |---|-------|------------|
-| 697 | Switch pocketbase-typegen to upstream | External upstream merge of --use-const flag |
+| 697 | Switch pocketbase-typegen to upstream | External upstream merge of `--use-const` flag |
 
 ---
 
 ## Suggested Attack Order
 
-1–24. ~~**Groups 1–24**~~ — All complete (see completed groups below)
-25. **Group 25** (#806, #807, #791) — Sync fixes, includes a bug
-26. **Group 26** (#788, #792, #809) — Solver trace bug + perf wins
-27. **#754** — AG cabin pairing feature (needs design)
-28. **Group 27** (#787, #815) — Solver log cleanup, quick
-29. **Group 28** (#770–773) — Metrics date-stripping dedup (do #770 first)
-30. **Group 29** (#796–798, #808, #810) — Frontend cleanup batch
-31. **#801** — CI platform flag, low priority
-32. **#604** — recharts 3.8 adoption, needs design decisions
-33. **#697** — Blocked on upstream `--use-const` merge
+1. **Group 30** (#921, #922) — Phase runner bug pair, single PR, staleness confirmed
+2. **#896** — AI prompt fix, externally root-caused, one-line prompt change
+3. **Group 31** (#880 → #881 → #877 → #923) — Disambiguation + trace cluster
+4. **#899** — RBAC rule fix
+5. **#918 + #796** — Frontend cleanup batch
+6. **#919** — Background docstring coverage
+7. **#697** — Blocked externally
 
 ## Completed Groups (recent)
 
-See git history for full completion log (Groups 1–16, scripts, Vite 8, etc.).
-
-| Group | PR | Date | Notes |
-|-------|-----|------|-------|
-| Group 16: Waitlist & session availability | #622 | 2026-03-17 | #593 closed (not-a-bug → #620); spawned #624, #625 |
-| Group 17: Solver pipeline optimization (#615) | #635 | 2026-03-18 | Phase skipping for direct-mapped socialize requests |
-| Group 19: Sync bugs (#639, #642) | #644 | 2026-03-18 | Mutex race + force+limit over-clear; spawned #645 |
-| Standalone: #648 duplicate React key | #651 | 2026-03-18 | TOC value '1'→'toc' + dedup in ProcessRequestOptions |
-| Standalone: #619, #654, #658 tech-debt | #660 | 2026-03-18 | eslint-disables, derived configId, expand null-safety |
-| Group 8: Frontend blocked tech debt (#377) | #692 | 2026-03-19 | erasableSyntaxOnly via as-const typegen |
-| Group 14: Metrics hook API (#567, #562) | #671+ | 2026-03-19 | Mutual exclusivity + hook migration evaluation |
-| Bulk close: #594, #620–#630, #640, #641, #653, #623 | Multiple | 2026-03-19 | 14 issues resolved across Groups 15, 18, and standalone |
-| Group 18: API Tech Debt (#625) | #704 | 2026-03-19 | Expand extraction standardized via shared utility |
-| Group 20: Metrics bugs (#708) | #713 | 2026-03-19 | Per-session daily merge + schema fix |
-| Group 21: Auth/frontend fixes (#703, #687) | #710, #711 | 2026-03-19 | FeedbackModal auth gate + queryKeys centralization |
-| is_active cleanup (#620 remnants) | #712 | 2026-03-19 | Test filters, SQL cleanup, docs updated |
-| Test pruning phase 3 | #714 | 2026-03-19 | Parametrize and consolidate medium/low findings |
-| Group 22: Frontend Test Fixes (#720, #721) | #725 | 2026-03-19 | Static imports in chart tests + sibling cleanup |
-| Group 23: Frontend Tech Debt (#715, #717) | #727 | 2026-03-19 | Query key centralization + sync mutation factory |
-| Group 24: API Tech Debt (#716, #718) | #726 | 2026-03-19 | Single-pass daily reconstruction + SQL dedup |
-| Standalone: #699 cancel velocity positive | #724 | 2026-03-19 | Weekly cancelled as positive values in delta chart |
-| Standalone: #705 OIDC hook save failures | — | 2026-03-19 | Closed as won't-fix (single admin, low risk) |
-| Standalone: #453 geo overrides promotion | #729 | 2026-03-20 | Carry forward geo overrides across years |
-| Standalone: #728 remove reconstruct_daily | #731 | 2026-03-20 | Deleted dead code, kept only reconstruct_daily_multi |
+| Group | PR / Date | Notes |
+|-------|-----------|-------|
+| Groups 1–24 | Various | See git history |
+| Group 25: Sync fixes (#806, #807, #791) | Closed 2026-04-04 | |
+| Group 26: Solver bugs & perf (#788, #792, #809) | Closed 2026-04-05 | |
+| Group 27: Solver log cleanup (#787, #815) | Closed 2026-04-04 | |
+| Group 28: Metrics date-stripping (#770, #771, #772, #773) | Closed 2026-04-05 | |
+| Group 29: Frontend cleanup (#797, #798, #808, #810) | Closed 2026-04-05 | #796 remains open |
+| Standalone: #754 AG cabin pairing | Closed 2026-04-05 | |
+| Standalone: #801 CI platform flag | Closed 2026-04-04 | |
+| Standalone: #604 recharts 3.8 | Closed | |

--- a/tests/unit/sync/bunk_request_processor/prompts/test_parse_request_two_word_rule.py
+++ b/tests/unit/sync/bunk_request_processor/prompts/test_parse_request_two_word_rule.py
@@ -1,0 +1,53 @@
+"""Regression guard for #896: parse_request prompt must teach the AI to prefer
+treating a two-word space-separated target as a single "FirstName LastName"
+rather than splitting into two separate first-name requests.
+
+Without this rule, input like "Riley Sam" parses as two bunk_with requests
+("Riley" → unresolved, "Sam" → fuzzy-matches anyone with preferred_name
+"Sam"). The combined-name interpretation is the safer default: a no-match
+falls through to normal disambiguation instead of silently mis-assigning.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+
+from bunking.sync.bunk_request_processor.prompts.loader import (
+    clear_cache,
+    load_prompt,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_prompt_cache() -> Generator[None, None, None]:
+    clear_cache()
+    yield
+    clear_cache()
+
+
+class TestParseRequestTwoWordRule:
+    """parse_request.txt must instruct the AI on two-word target handling."""
+
+    def test_prompt_has_two_word_section(self) -> None:
+        text = load_prompt("parse_request")
+        # Section header — the AI's attention is cued by the === block convention.
+        assert "TWO-WORD TARGET" in text.upper(), (
+            "parse_request.txt must include a TWO-WORD TARGETS section teaching "
+            "'FirstName LastName' as the default interpretation (#896)."
+        )
+
+    def test_prompt_teaches_firstname_lastname_preference(self) -> None:
+        text = load_prompt("parse_request").lower()
+        # The rule must reference both the combined interpretation and the
+        # conditions under which splitting is allowed.
+        assert "firstname" in text, "parse_request.txt must mention 'FirstName' (#896)."
+        assert "lastname" in text, "parse_request.txt must mention 'LastName' (#896)."
+
+    def test_prompt_references_comma_or_conjunction_as_split_signal(self) -> None:
+        text = load_prompt("parse_request").lower()
+        # Splitting should be gated on explicit delimiters, not default behavior.
+        assert "comma" in text or '","' in text, (
+            "parse_request.txt must tell the AI to split only on explicit delimiters (#896)."
+        )


### PR DESCRIPTION
## Summary

- Adds a **TWO-WORD TARGETS (NO DELIMITERS)** section to `config/prompts/parse_request.txt` teaching the AI to treat exactly-two-word targets as a single `FirstName LastName` by default, only splitting when an explicit delimiter is present (comma, "and", "&", "or", "+").
- Adds a regression-guard test (`test_parse_request_two_word_rule.py`) asserting the section and its key phrases are present in the rendered prompt.

Fixes #896.

## Why

When a parent writes a single camper name like "Riley Sam" (first + last name) without commas, the Phase 1 AI parser previously split it into two separate first-name requests:
- First word → goes to disambiguation (unresolved, pending)
- Second word → fuzzy-matches anyone whose `preferred_name` is that token → silent mis-assignment to the wrong camper

The existing prompt only had a `MULTI-PERSON SPLITTING` section that showed splitting examples (all with commas or "and"). With no rule for the no-delimiter case, the model defaulted to splitting.

## Approach

The new section is **additive** — it doesn't modify the existing `MULTI-PERSON SPLITTING` section, and all existing comma/conjunction splitting examples continue to work. It adds four examples covering both the combined-name default and the explicit-delimiter splitting cases so the model can ground its behavior.

Why combined-first-then-split is the safer default:
- Splitting two words that are both plausible first names produces two wrong matches.
- Combined as `FirstName LastName`, a no-match simply falls through to normal disambiguation (recoverable) instead of silently mis-assigning.

## Test plan

- [x] Regression-guard test asserts the new section header and key phrases are in the rendered prompt.
- [x] Existing `test_parse_prompts_no_group.py` still passes (new section doesn't reintroduce forbidden group-expansion vocabulary).
- [x] All 20 `bunking/sync/bunk_request_processor/prompts/` tests pass.
- [x] Pre-push verification (ruff, mypy, full unit suite) passes.

Manual QA should confirm against real parent input that bare two-word names now parse as a single full-name target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)