### PR TITLE
fix(pb): move bunk_requests list/view rules to bunking.view permission

### DIFF
--- a/pocketbase/pb_migrations/1500000096_bunk_requests_list_view_bunking_view.js
+++ b/pocketbase/pb_migrations/1500000096_bunk_requests_list_view_bunking_view.js
@@ -1,0 +1,37 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: Move bunk_requests list/view rules from bunking.manage to bunking.view
+ *
+ * bunk_requests holds finalized bunk request data (status, notes, disposition).
+ * It is NOT raw CSV/AI trace data (that's in original_bunk_requests).
+ * Read access should be available to bunking.view users so they can see
+ * the Bunking Status table on the camper detail page and pop-in modal.
+ * Writes (create, update, delete) remain bunking.manage.
+ *
+ * Fixes: #899
+ */
+
+migrate((app) => {
+  const bunkingView = '@request.auth.is_admin = true || @request.auth.cached_permissions ~ "bunking.view"'
+  const bunkingManage = '@request.auth.is_admin = true || @request.auth.cached_permissions ~ "bunking.manage"'
+
+  const col = app.findCollectionByNameOrId("bunk_requests")
+  col.listRule = bunkingView
+  col.viewRule = bunkingView
+  col.createRule = bunkingManage
+  col.updateRule = bunkingManage
+  col.deleteRule = bunkingManage
+  app.save(col)
+
+}, (app) => {
+  // Rollback: restore list/view to bunking.manage
+  const bunkingManage = '@request.auth.is_admin = true || @request.auth.cached_permissions ~ "bunking.manage"'
+
+  const col = app.findCollectionByNameOrId("bunk_requests")
+  col.listRule = bunkingManage
+  col.viewRule = bunkingManage
+  col.createRule = bunkingManage
+  col.updateRule = bunkingManage
+  col.deleteRule = bunkingManage
+  app.save(col)
+});


### PR DESCRIPTION
## Summary

Users with `bunking.view` permission saw empty "Bunking Status" tables on camper detail pages because `bunk_requests` required `bunking.manage` for reads.

- Moves `listRule` and `viewRule` on `bunk_requests` collection to `bunking.view`
- `createRule`, `updateRule`, `deleteRule` remain at `bunking.manage`
- Rollback (migrate down) restores all five rules to `bunking.manage`

## Why

`bunk_requests` contains finalized bunk request data (status, notes, disposition). Raw CSV and AI trace data live in `original_bunk_requests`, which stays at `bunking.manage`. Read-only users should be able to see what bunk requests exist.

## Test plan

- [x] Migration lints clean (pb-js-lint)
- [x] Rule expressions copied verbatim from `1500000074_rbac_tier1_rules.js`
- [ ] Manually verify `bunking.view` user can read bunk_requests after running migration (local)

Closes #899

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Database migration: Refined the access control structure for bunk requests. Viewing and listing bunk requests now requires only view-level permissions instead of manage-level permissions, enabling finer-grained access control. Creating, modifying, and deleting requests continue to require manage-level permissions for security purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->