### PR TITLE
refactor(frontend): extract approve/reject handlers and remove localStorage shim

### DIFF
--- a/frontend/src/components/RequestReviewPanel.test.tsx
+++ b/frontend/src/components/RequestReviewPanel.test.tsx
@@ -1158,47 +1158,153 @@ describe('RequestReviewPanel', () => {
    * Regression tests for #918 (handleApprove / handleReject extraction).
    *
    * The refactor is a pure extraction of handler functions from inline
-   * mutate calls — behavior must not change. These tests document the
-   * expected mutation payload shape for approve and reject actions.
+   * mutate calls — behavior must not change. These tests render the
+   * panel, click the row-level approve/reject button, confirm via the
+   * popover, and assert on the payload passed to
+   * pb.collection('bunk_requests').update(...). This exercises the
+   * real handleApprove / handleReject code paths rather than just
+   * asserting on a literal object shape.
    */
   describe('Approve / Reject mutation payloads (#918)', () => {
-    it('approve produces mutation payload with status=resolved and request_locked=true', () => {
-      // handleApprove(id) should fire updateRequestMutation.mutate with:
-      //   { id, updates: { status: 'resolved', request_locked: true } }
-      const id = 'req-123'
-      const approvePayload = {
-        id,
-        updates: { status: 'resolved' as const, request_locked: true },
+    it('approve button fires update with status=resolved and request_locked=true', async () => {
+      const { screen, fireEvent } = await import('@testing-library/react')
+      const userEventModule = await import('@testing-library/user-event')
+      const user = userEventModule.default.setup()
+
+      // Fresh mock for this test — mocked pb module was set up at top of file.
+      const { pb } = (await import('../lib/pocketbase')) as unknown as {
+        pb: {
+          collection: ReturnType<typeof vi.fn>
+        }
       }
 
-      expect(approvePayload.id).toBe('req-123')
-      expect(approvePayload.updates['status']).toBe('resolved')
-      expect(approvePayload.updates['request_locked']).toBe(true)
-    })
-
-    it('reject produces mutation payload with status=declined and request_locked=false', () => {
-      // handleReject(id) should fire updateRequestMutation.mutate with:
-      //   { id, updates: { status: 'declined', request_locked: false } }
-      const id = 'req-456'
-      const rejectPayload = {
-        id,
-        updates: { status: 'declined' as const, request_locked: false },
+      const updateSpy = vi.fn().mockResolvedValue({})
+      const pendingRequest: Partial<BunkRequestsResponse> = {
+        id: 'req-approve-1',
+        requester_id: 100,
+        requestee_id: 101,
+        session_id: 1001,
+        year: 2025,
+        status: 'pending',
+        request_type: 'bunk_with',
+        confidence_score: 0.9,
+        priority: 1,
+        request_locked: false,
       }
 
-      expect(rejectPayload.id).toBe('req-456')
-      expect(rejectPayload.updates['status']).toBe('declined')
-      expect(rejectPayload.updates['request_locked']).toBe(false)
-    })
+      pb.collection.mockImplementation((name: string) => {
+        if (name === 'bunk_requests') {
+          return {
+            getFullList: vi.fn().mockResolvedValue([pendingRequest]),
+            getList: vi.fn().mockResolvedValue({ items: [pendingRequest], totalItems: 1 }),
+            update: updateSpy,
+          }
+        }
+        return {
+          getFullList: vi.fn().mockResolvedValue([]),
+          getList: vi.fn().mockResolvedValue({ items: [], totalItems: 0 }),
+          update: vi.fn().mockResolvedValue({}),
+        }
+      })
 
-    it('approve and reject payloads have inverse request_locked values', () => {
-      // Approve locks the request (request_locked: true)
-      // Reject unlocks the request (request_locked: false)
-      const approveLocked = true
-      const rejectLocked = false
+      render(<RequestReviewPanel sessionId={1001} year={2025} />)
 
-      expect(approveLocked).toBe(true)
-      expect(rejectLocked).toBe(false)
-      expect(approveLocked).not.toBe(rejectLocked)
-    })
+      // Wait for at least one row-level Approve button to appear
+      // (both mobile and desktop markup render in jsdom — take the first).
+      const approveButton = await waitFor(
+        () => {
+          const buttons = screen.getAllByTitle('Approve')
+          const first = buttons[0]
+          if (!first) throw new Error('no Approve button yet')
+          return first
+        },
+        { timeout: 3000 }
+      )
+
+      // fireEvent.click (not userEvent) because the onClick handler reads
+      // e.currentTarget.getBoundingClientRect() which jsdom + userEvent
+      // does not populate reliably.
+      fireEvent.click(approveButton)
+
+      // Popover portal renders "Confirm" button
+      const confirmButton = await screen.findByRole('button', { name: 'Confirm' })
+      await user.click(confirmButton)
+
+      await waitFor(() => {
+        expect(updateSpy).toHaveBeenCalledTimes(1)
+      })
+
+      expect(updateSpy).toHaveBeenCalledWith('req-approve-1', {
+        status: 'resolved',
+        request_locked: true,
+      })
+    }, 10000)
+
+    it('reject button fires update with status=declined and request_locked=false', async () => {
+      const { screen, fireEvent } = await import('@testing-library/react')
+      const userEventModule = await import('@testing-library/user-event')
+      const user = userEventModule.default.setup()
+
+      const { pb } = (await import('../lib/pocketbase')) as unknown as {
+        pb: {
+          collection: ReturnType<typeof vi.fn>
+        }
+      }
+
+      const updateSpy = vi.fn().mockResolvedValue({})
+      const pendingRequest: Partial<BunkRequestsResponse> = {
+        id: 'req-reject-1',
+        requester_id: 200,
+        requestee_id: 201,
+        session_id: 1001,
+        year: 2025,
+        status: 'pending',
+        request_type: 'bunk_with',
+        confidence_score: 0.5,
+        priority: 1,
+        request_locked: false,
+      }
+
+      pb.collection.mockImplementation((name: string) => {
+        if (name === 'bunk_requests') {
+          return {
+            getFullList: vi.fn().mockResolvedValue([pendingRequest]),
+            getList: vi.fn().mockResolvedValue({ items: [pendingRequest], totalItems: 1 }),
+            update: updateSpy,
+          }
+        }
+        return {
+          getFullList: vi.fn().mockResolvedValue([]),
+          getList: vi.fn().mockResolvedValue({ items: [], totalItems: 0 }),
+          update: vi.fn().mockResolvedValue({}),
+        }
+      })
+
+      render(<RequestReviewPanel sessionId={1001} year={2025} />)
+
+      const rejectButton = await waitFor(
+        () => {
+          const buttons = screen.getAllByTitle('Reject')
+          const first = buttons[0]
+          if (!first) throw new Error('no Reject button yet')
+          return first
+        },
+        { timeout: 3000 }
+      )
+
+      fireEvent.click(rejectButton)
+
+      const confirmButton = await screen.findByRole('button', { name: 'Confirm' })
+      await user.click(confirmButton)
+
+      await waitFor(() => {
+        expect(updateSpy).toHaveBeenCalledTimes(1)
+      })
+
+      expect(updateSpy).toHaveBeenCalledWith('req-reject-1', {
+        status: 'declined',
+        request_locked: false,
+      })
+    }, 10000)
   })
 })

--- a/frontend/src/components/RequestReviewPanel.test.tsx
+++ b/frontend/src/components/RequestReviewPanel.test.tsx
@@ -10,9 +10,56 @@
  * 3. Filter and sort functionality
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { render, waitFor } from '../test/testUtils'
 import RequestReviewPanel from './RequestReviewPanel'
 import type { BunkRequestsResponse } from '../types/pocketbase-types'
+
+/**
+ * Helper for the approve/reject handler tests: sets up the pb mock with a
+ * single pending request, renders the panel, and returns the spy + a helper
+ * to find the row-level action button by title.
+ */
+async function renderPanelWithRequest(request: Partial<BunkRequestsResponse>) {
+  const { pb } = (await import('../lib/pocketbase')) as unknown as {
+    pb: {
+      collection: ReturnType<typeof vi.fn>
+    }
+  }
+
+  const updateSpy = vi.fn().mockResolvedValue({})
+
+  pb.collection.mockImplementation((name: string) => {
+    if (name === 'bunk_requests') {
+      return {
+        getFullList: vi.fn().mockResolvedValue([request]),
+        getList: vi.fn().mockResolvedValue({ items: [request], totalItems: 1 }),
+        update: updateSpy,
+      }
+    }
+    return {
+      getFullList: vi.fn().mockResolvedValue([]),
+      getList: vi.fn().mockResolvedValue({ items: [], totalItems: 0 }),
+      update: vi.fn().mockResolvedValue({}),
+    }
+  })
+
+  render(<RequestReviewPanel sessionId={1001} year={2025} />)
+
+  const findButtonByTitle = (title: string) =>
+    waitFor(
+      () => {
+        const buttons = screen.getAllByTitle(title)
+        const first = buttons[0]
+        if (!first) throw new Error(`no ${title} button yet`)
+        return first
+      },
+      { timeout: 3000 }
+    )
+
+  return { updateSpy, findButtonByTitle, user: userEvent.setup() }
+}
 
 // Mock the pocketbase module
 vi.mock('../lib/pocketbase', () => ({
@@ -1167,19 +1214,7 @@ describe('RequestReviewPanel', () => {
    */
   describe('Approve / Reject mutation payloads (#918)', () => {
     it('approve button fires update with status=resolved and request_locked=true', async () => {
-      const { screen, fireEvent } = await import('@testing-library/react')
-      const userEventModule = await import('@testing-library/user-event')
-      const user = userEventModule.default.setup()
-
-      // Fresh mock for this test — mocked pb module was set up at top of file.
-      const { pb } = (await import('../lib/pocketbase')) as unknown as {
-        pb: {
-          collection: ReturnType<typeof vi.fn>
-        }
-      }
-
-      const updateSpy = vi.fn().mockResolvedValue({})
-      const pendingRequest: Partial<BunkRequestsResponse> = {
+      const { updateSpy, findButtonByTitle, user } = await renderPanelWithRequest({
         id: 'req-approve-1',
         requester_id: 100,
         requestee_id: 101,
@@ -1190,36 +1225,11 @@ describe('RequestReviewPanel', () => {
         confidence_score: 0.9,
         priority: 1,
         request_locked: false,
-      }
-
-      pb.collection.mockImplementation((name: string) => {
-        if (name === 'bunk_requests') {
-          return {
-            getFullList: vi.fn().mockResolvedValue([pendingRequest]),
-            getList: vi.fn().mockResolvedValue({ items: [pendingRequest], totalItems: 1 }),
-            update: updateSpy,
-          }
-        }
-        return {
-          getFullList: vi.fn().mockResolvedValue([]),
-          getList: vi.fn().mockResolvedValue({ items: [], totalItems: 0 }),
-          update: vi.fn().mockResolvedValue({}),
-        }
       })
-
-      render(<RequestReviewPanel sessionId={1001} year={2025} />)
 
       // Wait for at least one row-level Approve button to appear
       // (both mobile and desktop markup render in jsdom — take the first).
-      const approveButton = await waitFor(
-        () => {
-          const buttons = screen.getAllByTitle('Approve')
-          const first = buttons[0]
-          if (!first) throw new Error('no Approve button yet')
-          return first
-        },
-        { timeout: 3000 }
-      )
+      const approveButton = await findButtonByTitle('Approve')
 
       // fireEvent.click (not userEvent) because the onClick handler reads
       // e.currentTarget.getBoundingClientRect() which jsdom + userEvent
@@ -1241,18 +1251,7 @@ describe('RequestReviewPanel', () => {
     }, 10000)
 
     it('reject button fires update with status=declined and request_locked=false', async () => {
-      const { screen, fireEvent } = await import('@testing-library/react')
-      const userEventModule = await import('@testing-library/user-event')
-      const user = userEventModule.default.setup()
-
-      const { pb } = (await import('../lib/pocketbase')) as unknown as {
-        pb: {
-          collection: ReturnType<typeof vi.fn>
-        }
-      }
-
-      const updateSpy = vi.fn().mockResolvedValue({})
-      const pendingRequest: Partial<BunkRequestsResponse> = {
+      const { updateSpy, findButtonByTitle, user } = await renderPanelWithRequest({
         id: 'req-reject-1',
         requester_id: 200,
         requestee_id: 201,
@@ -1263,35 +1262,13 @@ describe('RequestReviewPanel', () => {
         confidence_score: 0.5,
         priority: 1,
         request_locked: false,
-      }
-
-      pb.collection.mockImplementation((name: string) => {
-        if (name === 'bunk_requests') {
-          return {
-            getFullList: vi.fn().mockResolvedValue([pendingRequest]),
-            getList: vi.fn().mockResolvedValue({ items: [pendingRequest], totalItems: 1 }),
-            update: updateSpy,
-          }
-        }
-        return {
-          getFullList: vi.fn().mockResolvedValue([]),
-          getList: vi.fn().mockResolvedValue({ items: [], totalItems: 0 }),
-          update: vi.fn().mockResolvedValue({}),
-        }
       })
 
-      render(<RequestReviewPanel sessionId={1001} year={2025} />)
+      const rejectButton = await findButtonByTitle('Reject')
 
-      const rejectButton = await waitFor(
-        () => {
-          const buttons = screen.getAllByTitle('Reject')
-          const first = buttons[0]
-          if (!first) throw new Error('no Reject button yet')
-          return first
-        },
-        { timeout: 3000 }
-      )
-
+      // fireEvent.click (not userEvent) because the onClick handler reads
+      // e.currentTarget.getBoundingClientRect() which jsdom + userEvent
+      // does not populate reliably.
       fireEvent.click(rejectButton)
 
       const confirmButton = await screen.findByRole('button', { name: 'Confirm' })

--- a/frontend/src/components/RequestReviewPanel.test.tsx
+++ b/frontend/src/components/RequestReviewPanel.test.tsx
@@ -1153,4 +1153,52 @@ describe('RequestReviewPanel', () => {
       })
     })
   })
+
+  /**
+   * Regression tests for #918 (handleApprove / handleReject extraction).
+   *
+   * The refactor is a pure extraction of handler functions from inline
+   * mutate calls — behavior must not change. These tests document the
+   * expected mutation payload shape for approve and reject actions.
+   */
+  describe('Approve / Reject mutation payloads (#918)', () => {
+    it('approve produces mutation payload with status=resolved and request_locked=true', () => {
+      // handleApprove(id) should fire updateRequestMutation.mutate with:
+      //   { id, updates: { status: 'resolved', request_locked: true } }
+      const id = 'req-123'
+      const approvePayload = {
+        id,
+        updates: { status: 'resolved' as const, request_locked: true },
+      }
+
+      expect(approvePayload.id).toBe('req-123')
+      expect(approvePayload.updates['status']).toBe('resolved')
+      expect(approvePayload.updates['request_locked']).toBe(true)
+    })
+
+    it('reject produces mutation payload with status=declined and request_locked=false', () => {
+      // handleReject(id) should fire updateRequestMutation.mutate with:
+      //   { id, updates: { status: 'declined', request_locked: false } }
+      const id = 'req-456'
+      const rejectPayload = {
+        id,
+        updates: { status: 'declined' as const, request_locked: false },
+      }
+
+      expect(rejectPayload.id).toBe('req-456')
+      expect(rejectPayload.updates['status']).toBe('declined')
+      expect(rejectPayload.updates['request_locked']).toBe(false)
+    })
+
+    it('approve and reject payloads have inverse request_locked values', () => {
+      // Approve locks the request (request_locked: true)
+      // Reject unlocks the request (request_locked: false)
+      const approveLocked = true
+      const rejectLocked = false
+
+      expect(approveLocked).toBe(true)
+      expect(rejectLocked).toBe(false)
+      expect(approveLocked).not.toBe(rejectLocked)
+    })
+  })
 })

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -612,8 +612,6 @@ export default function RequestReviewPanel({
     },
   })
 
-  // Approve/reject action handlers — extracted from inline mutate calls
-  // to consolidate the mutation payload shape in one place.
   const handleApprove = (id: string) =>
     updateRequestMutation.mutate({
       id,

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -612,6 +612,20 @@ export default function RequestReviewPanel({
     },
   })
 
+  // Approve/reject action handlers — extracted from inline mutate calls
+  // to consolidate the mutation payload shape in one place.
+  const handleApprove = (id: string) =>
+    updateRequestMutation.mutate({
+      id,
+      updates: { status: 'resolved' as BunkRequestsStatusOptions, request_locked: true },
+    })
+
+  const handleReject = (id: string) =>
+    updateRequestMutation.mutate({
+      id,
+      updates: { status: 'declined' as BunkRequestsStatusOptions, request_locked: false },
+    })
+
   // Handlers
   const toggleRowExpansion = useCallback(
     (id: string, request?: BunkRequestsResponse) => {
@@ -1983,13 +1997,11 @@ export default function RequestReviewPanel({
         onConfirm={() => {
           if (!confirmPopover) return
           const { action, requestId } = confirmPopover
-          updateRequestMutation.mutate({
-            id: requestId,
-            updates:
-              action === 'approve'
-                ? { status: 'resolved' as BunkRequestsStatusOptions, request_locked: true }
-                : { status: 'declined' as BunkRequestsStatusOptions },
-          })
+          if (action === 'approve') {
+            handleApprove(requestId)
+          } else {
+            handleReject(requestId)
+          }
           setConfirmPopover(null)
         }}
         onCancel={() => setConfirmPopover(null)}

--- a/frontend/src/contexts/ProgramContext.test.tsx
+++ b/frontend/src/contexts/ProgramContext.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Tests for ProgramContext - verifying that the legacy localStorage migration
+ * shim has been removed. Old stored values ('family', 'metrics') must NOT be
+ * translated to new values ('weekend', 'analytics') — they should be treated
+ * as invalid and fall back to null.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ProgramProvider, useProgram } from './ProgramContext'
+
+function ProgramConsumer() {
+  const { currentProgram } = useProgram()
+  return <div data-testid="current-program">{currentProgram ?? 'null'}</div>
+}
+
+describe('ProgramContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('localStorage migration shim removal', () => {
+    it('does NOT translate old "family" value to "weekend"', () => {
+      vi.mocked(window.localStorage.getItem).mockReturnValue('family')
+
+      render(
+        <ProgramProvider>
+          <ProgramConsumer />
+        </ProgramProvider>
+      )
+
+      const current = screen.getByTestId('current-program').textContent
+      expect(current).not.toBe('weekend')
+      expect(current).toBe('null')
+    })
+
+    it('does NOT translate old "metrics" value to "analytics"', () => {
+      vi.mocked(window.localStorage.getItem).mockReturnValue('metrics')
+
+      render(
+        <ProgramProvider>
+          <ProgramConsumer />
+        </ProgramProvider>
+      )
+
+      const current = screen.getByTestId('current-program').textContent
+      expect(current).not.toBe('analytics')
+      expect(current).toBe('null')
+    })
+
+    it('accepts current valid "summer" value', () => {
+      vi.mocked(window.localStorage.getItem).mockReturnValue('summer')
+
+      render(
+        <ProgramProvider>
+          <ProgramConsumer />
+        </ProgramProvider>
+      )
+
+      expect(screen.getByTestId('current-program').textContent).toBe('summer')
+    })
+
+    it('accepts current valid "weekend" value', () => {
+      vi.mocked(window.localStorage.getItem).mockReturnValue('weekend')
+
+      render(
+        <ProgramProvider>
+          <ProgramConsumer />
+        </ProgramProvider>
+      )
+
+      expect(screen.getByTestId('current-program').textContent).toBe('weekend')
+    })
+
+    it('accepts current valid "analytics" value', () => {
+      vi.mocked(window.localStorage.getItem).mockReturnValue('analytics')
+
+      render(
+        <ProgramProvider>
+          <ProgramConsumer />
+        </ProgramProvider>
+      )
+
+      expect(screen.getByTestId('current-program').textContent).toBe('analytics')
+    })
+
+    it('returns null when localStorage is empty', () => {
+      vi.mocked(window.localStorage.getItem).mockReturnValue(null)
+
+      render(
+        <ProgramProvider>
+          <ProgramConsumer />
+        </ProgramProvider>
+      )
+
+      expect(screen.getByTestId('current-program').textContent).toBe('null')
+    })
+
+    it('returns null for unknown stored values', () => {
+      vi.mocked(window.localStorage.getItem).mockReturnValue('unknown-program')
+
+      render(
+        <ProgramProvider>
+          <ProgramConsumer />
+        </ProgramProvider>
+      )
+
+      expect(screen.getByTestId('current-program').textContent).toBe('null')
+    })
+  })
+})

--- a/frontend/src/contexts/ProgramContext.test.tsx
+++ b/frontend/src/contexts/ProgramContext.test.tsx
@@ -13,6 +13,15 @@ function ProgramConsumer() {
   return <div data-testid="current-program">{currentProgram ?? 'null'}</div>
 }
 
+function renderWithStored(value: string | null) {
+  vi.mocked(window.localStorage.getItem).mockReturnValue(value)
+  return render(
+    <ProgramProvider>
+      <ProgramConsumer />
+    </ProgramProvider>
+  )
+}
+
 describe('ProgramContext', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -20,13 +29,7 @@ describe('ProgramContext', () => {
 
   describe('localStorage migration shim removal', () => {
     it('does NOT translate old "family" value to "weekend"', () => {
-      vi.mocked(window.localStorage.getItem).mockReturnValue('family')
-
-      render(
-        <ProgramProvider>
-          <ProgramConsumer />
-        </ProgramProvider>
-      )
+      renderWithStored('family')
 
       const current = screen.getByTestId('current-program').textContent
       expect(current).not.toBe('weekend')
@@ -34,13 +37,7 @@ describe('ProgramContext', () => {
     })
 
     it('does NOT translate old "metrics" value to "analytics"', () => {
-      vi.mocked(window.localStorage.getItem).mockReturnValue('metrics')
-
-      render(
-        <ProgramProvider>
-          <ProgramConsumer />
-        </ProgramProvider>
-      )
+      renderWithStored('metrics')
 
       const current = screen.getByTestId('current-program').textContent
       expect(current).not.toBe('analytics')
@@ -48,61 +45,31 @@ describe('ProgramContext', () => {
     })
 
     it('accepts current valid "summer" value', () => {
-      vi.mocked(window.localStorage.getItem).mockReturnValue('summer')
-
-      render(
-        <ProgramProvider>
-          <ProgramConsumer />
-        </ProgramProvider>
-      )
+      renderWithStored('summer')
 
       expect(screen.getByTestId('current-program').textContent).toBe('summer')
     })
 
     it('accepts current valid "weekend" value', () => {
-      vi.mocked(window.localStorage.getItem).mockReturnValue('weekend')
-
-      render(
-        <ProgramProvider>
-          <ProgramConsumer />
-        </ProgramProvider>
-      )
+      renderWithStored('weekend')
 
       expect(screen.getByTestId('current-program').textContent).toBe('weekend')
     })
 
     it('accepts current valid "analytics" value', () => {
-      vi.mocked(window.localStorage.getItem).mockReturnValue('analytics')
-
-      render(
-        <ProgramProvider>
-          <ProgramConsumer />
-        </ProgramProvider>
-      )
+      renderWithStored('analytics')
 
       expect(screen.getByTestId('current-program').textContent).toBe('analytics')
     })
 
     it('returns null when localStorage is empty', () => {
-      vi.mocked(window.localStorage.getItem).mockReturnValue(null)
-
-      render(
-        <ProgramProvider>
-          <ProgramConsumer />
-        </ProgramProvider>
-      )
+      renderWithStored(null)
 
       expect(screen.getByTestId('current-program').textContent).toBe('null')
     })
 
     it('returns null for unknown stored values', () => {
-      vi.mocked(window.localStorage.getItem).mockReturnValue('unknown-program')
-
-      render(
-        <ProgramProvider>
-          <ProgramConsumer />
-        </ProgramProvider>
-      )
+      renderWithStored('unknown-program')
 
       expect(screen.getByTestId('current-program').textContent).toBe('null')
     })

--- a/frontend/src/contexts/ProgramContext.tsx
+++ b/frontend/src/contexts/ProgramContext.tsx
@@ -12,19 +12,13 @@ const ProgramContext = createContext<ProgramContextType | undefined>(undefined)
 
 const STORAGE_KEY = 'bunking-program-selection'
 
-// Migrate old stored values to new program names
-function migrateStoredProgram(stored: string | null): Program | null {
-  if (stored === 'family') return 'weekend'
-  if (stored === 'metrics') return 'analytics'
-  if (stored === 'summer' || stored === 'weekend' || stored === 'analytics') {
-    return stored
-  }
-  return null
-}
-
 export function ProgramProvider({ children }: { children: ReactNode }) {
   const [currentProgram, setCurrentProgram] = useState<Program | null>(() => {
-    return migrateStoredProgram(localStorage.getItem(STORAGE_KEY))
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored === 'summer' || stored === 'weekend' || stored === 'analytics') {
+      return stored
+    }
+    return null
   })
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Two small frontend cleanups:

- **#918** — Extract `handleApprove(id)` / `handleReject(id)` consts in `RequestReviewPanel`. Most button sites route through \`openConfirmPopover\`, so only the \`ConfirmActionPopover.onConfirm\` call site was consolidated. \`handleBulkApprove\`/\`handleBulkReject\` use a separate \`bulkUpdateMutation\` and were left unchanged.
- **#796** — Remove \`migrateStoredProgram()\` localStorage shim added after PR #795 renamed program IDs (\`'family'\` → \`'weekend'\`, \`'metrics'\` → \`'analytics'\`). Initializer now validates directly against the current \`'summer' | 'weekend' | 'analytics'\` types.

### Minor behavior note
Reject payload now explicitly sets \`request_locked: false\`. Original code sent only \`{ status: 'declined' }\`. No-op in practice (UI only allows locking \`resolved\` requests), but making it explicit for defensive consistency.

## Test plan

- [x] 3 regression tests for \`handleApprove\`/\`handleReject\` payload shape
- [x] 7 tests for ProgramContext — old localStorage values (\`'family'\`, \`'metrics'\`) no longer migrate, fall back to default
- [x] \`npx vitest run\` — 2687 pass
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run lint\` — 0 errors

**Merge timing:** #796 should merge after 2026-05-26 to ensure all returning users have been auto-migrated.

Closes #918
Closes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Request review actions now correctly persist both the request status and lock state when approving or rejecting.
  * Program context no longer auto-migrates legacy stored preference values; invalid or unsupported values reset to default instead of being remapped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->