### PR TITLE
docs(docs): add commit type rubric and semantic PR title workflow

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,64 @@
+name: Semantic PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            docs
+            style
+            test
+            build
+            config
+            chore
+            ci
+            revert
+          scopes: |
+            frontend
+            api
+            sync
+            pb
+            solver
+            docker
+            ci
+            auth
+            google
+            security
+            logging
+            release
+            config
+            deps
+            deps-dev
+            tests
+            scripts
+            docs
+            metrics
+            graph
+            data
+            rbac
+          requireScope: true
+          subjectPattern: ^[A-Za-z].+$
+          subjectPatternError: |
+            The subject "{subject}" must start with an uppercase or lowercase
+            letter and contain at least two characters.
+          validateSingleCommit: false

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,7 +1,7 @@
 name: Semantic PR Title
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -10,13 +10,14 @@ on:
 
 permissions:
   pull-requests: read
+  statuses: write
 
 jobs:
   lint-title:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,39 @@ Format: `type(scope): description` — Breaking changes: `feat(api)!: descriptio
 | `rbac` | Roles, permissions, access control |
 | `data` | Data models, schema changes |
 
+## Commit Types
+
+Pick the most specific type before defaulting to `feat`/`fix`. The release
+changelog groups by type, so mis-typing hides work (e.g. `chore` and `ci` are
+skipped from the changelog entirely).
+
+**Decision order — use the first that matches:**
+
+1. Diff touches only `.github/workflows/` → `ci`
+2. Diff touches only `docs/` or top-level markdown → `docs`
+3. Diff touches only `tests/` or `*_test.*` / `*.test.*` files → `test`
+4. Diff touches only Dockerfiles, `docker-compose.*`, `pyproject.toml`
+   build config, or `package.json` dep pins → `build`
+5. Diff touches only formatting (prettier, ruff format, whitespace) → `style`
+6. Measurable performance improvement with no behavior change → `perf`
+7. Code restructure with no behavior change (extract helper, rename, move) → `refactor`
+8. Fixes a bug that was previously broken → `fix`
+9. Adds new user-visible functionality or endpoint → `feat`
+10. Reverts a prior commit → `revert`
+11. Config files (env schema, settings) that aren't build tooling → `config`
+12. Pure maintenance (dep bumps, internal tooling) with no user impact → `chore`
+
+**Common mis-types to avoid:**
+- Refactor that moves code but doesn't add features → `refactor`, not `feat`
+- Test-only additions or fixes → `test`, not `feat`/`fix`
+- Perf improvement (caching, memoization, algorithm change) → `perf`, not `refactor`
+- Dockerfile change → `build`, not `ci`
+- GitHub Actions change → `ci`, not `build`
+
+**When unsure between two types**, pick the one whose *primary effect* dominates
+the diff — e.g. a refactor that happens to fix one minor bug is still
+`refactor` if restructuring is the point.
+
 ## Quick Development Commands
 
 ```bash


### PR DESCRIPTION
## Summary

Two levers to reduce `feat`/`fix` overuse (recent main log is ~80% those two types):

- **CLAUDE.md**: new "Commit Types" section with a decision rubric (diff shape → type), sibling to the existing Commit Scopes table. Lists common mis-types to avoid.
- **.github/workflows/semantic-pr.yml**: validates PR titles against the same type-enum / scope-enum as `commitlint.config.js` on open/edit/synchronize. Catches bad titles before merge (squash-merge uses PR title as the commit message).

## Why this matters

`cliff.toml` skips `chore` and `ci` from the changelog, so mis-typing literally hides work from release notes. `feat` always bumps minor, so over-using `feat` inflates version numbers.

## Post-merge follow-up

To make the new workflow a required status check, add "Validate PR title" to the branch ruleset on `main`:
- Settings → Rules → Rulesets → `main` → edit → Required status checks → add "Validate PR title"

(Not done in this PR because rulesets are UI-managed.)

## Test plan

- [ ] After merge, open a test PR with a bad title (e.g. `add thing`) — the workflow should fail
- [ ] Open a test PR with a good title — workflow should pass
- [ ] Verify my next PR title reflects the rubric

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated semantic PR title validation to ensure consistent contribution quality standards.
  * Added standardized commit type guidelines for improved development consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->