### PR TITLE
feat(frontend): pin-to-switch for camper requests panel

### DIFF
--- a/frontend/src/components/BunkRequestRow.test.tsx
+++ b/frontend/src/components/BunkRequestRow.test.tsx
@@ -283,6 +283,52 @@ describe('BunkRequestRow', () => {
     expect(screen.queryByRole('button', { name: /bunk with.*olivia chen/i })).toBeNull()
   })
 
+  it('does NOT nest the row in a native <button> when onSelect is provided', () => {
+    // Invalid HTML: CamperLink renders an <a>, which cannot be nested inside <button>.
+    // Outer clickable should be a div[role=button] instead.
+    const { container } = render(
+      <BunkRequestRow
+        request={makeRequest({ id: 'req-a', requestee_id: 200 })}
+        targetPerson={makePerson()}
+        onSelect={() => {}}
+      />
+    )
+    const row = container.firstElementChild as HTMLElement
+    expect(row.tagName).toBe('DIV')
+    expect(row.getAttribute('role')).toBe('button')
+    expect(row.getAttribute('tabindex')).toBe('0')
+  })
+
+  it('fires onSelect when Enter is pressed on the focusable row', async () => {
+    const onSelect = vi.fn()
+    render(
+      <BunkRequestRow
+        request={makeRequest({ id: 'req-a', requestee_id: 200 })}
+        targetPerson={makePerson()}
+        onSelect={onSelect}
+      />
+    )
+    const row = screen.getByRole('button', { name: /bunk with.*olivia chen/i })
+    row.focus()
+    await userEvent.keyboard('{Enter}')
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires onSelect when Space is pressed on the focusable row', async () => {
+    const onSelect = vi.fn()
+    render(
+      <BunkRequestRow
+        request={makeRequest({ id: 'req-a', requestee_id: 200 })}
+        targetPerson={makePerson()}
+        onSelect={onSelect}
+      />
+    )
+    const row = screen.getByRole('button', { name: /bunk with.*olivia chen/i })
+    row.focus()
+    await userEvent.keyboard(' ')
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+
   it('renders the supplied badge node after the mutual badge', () => {
     render(
       <BunkRequestRow

--- a/frontend/src/components/BunkRequestRow.test.tsx
+++ b/frontend/src/components/BunkRequestRow.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '../test/testUtils'
+import userEvent from '@testing-library/user-event'
 import { BunkRequestRow } from './BunkRequestRow'
 import type { BunkRequestsResponse, PersonsResponse } from '../types/pocketbase-types'
 
@@ -255,5 +256,44 @@ describe('BunkRequestRow', () => {
   it('falls back to "Unknown" when neither person nor name is provided', () => {
     render(<BunkRequestRow request={makeRequest({ status: 'pending' })} />)
     expect(screen.getByText(/Unknown/)).toBeInTheDocument()
+  })
+
+  it('renders as a <button> row when onSelect is provided and fires on click', async () => {
+    const onSelect = vi.fn()
+    render(
+      <BunkRequestRow
+        request={makeRequest({ id: 'req-a', requestee_id: 200 })}
+        targetPerson={makePerson()}
+        onSelect={onSelect}
+      />
+    )
+
+    const row = screen.getByRole('button', { name: /bunk with.*olivia chen/i })
+    await userEvent.click(row)
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not render as a <button> when onSelect is omitted', () => {
+    render(
+      <BunkRequestRow
+        request={makeRequest({ id: 'req-a', requestee_id: 200 })}
+        targetPerson={makePerson()}
+      />
+    )
+    expect(screen.queryByRole('button', { name: /bunk with.*olivia chen/i })).toBeNull()
+  })
+
+  it('renders the supplied badge node after the mutual badge', () => {
+    render(
+      <BunkRequestRow
+        request={makeRequest({ id: 'req-a', requestee_id: 200, is_reciprocal: true })}
+        targetPerson={makePerson()}
+        badge={<span data-testid="current-badge">Current request</span>}
+      />
+    )
+    const mutual = screen.getByText('mutual')
+    const current = screen.getByTestId('current-badge')
+
+    expect(mutual.compareDocumentPosition(current) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 })

--- a/frontend/src/components/BunkRequestRow.tsx
+++ b/frontend/src/components/BunkRequestRow.tsx
@@ -115,16 +115,24 @@ export function BunkRequestRow({
     )
     if (onSelect) {
       return (
-        <button
-          type="button"
+        <div
+          role="button"
+          tabIndex={0}
           className={clsx(rowClass, 'text-muted-foreground text-xs')}
           onClick={(e) => {
             e.stopPropagation()
             onSelect()
           }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              e.stopPropagation()
+              onSelect()
+            }
+          }}
         >
           {ageChildren}
-        </button>
+        </div>
       )
     }
     return <div className={clsx(rowClass, 'text-muted-foreground text-xs')}>{ageChildren}</div>
@@ -179,16 +187,24 @@ export function BunkRequestRow({
 
   if (onSelect) {
     return (
-      <button
-        type="button"
+      <div
+        role="button"
+        tabIndex={0}
         className={rowClass}
         onClick={(e) => {
           e.stopPropagation()
           onSelect()
         }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            e.stopPropagation()
+            onSelect()
+          }
+        }}
       >
         {children}
-      </button>
+      </div>
     )
   }
 

--- a/frontend/src/components/BunkRequestRow.tsx
+++ b/frontend/src/components/BunkRequestRow.tsx
@@ -27,12 +27,12 @@ export interface BunkRequestRowProps {
    * When provided, renders the row as a <button> and calls this on click.
    * The click event stops propagation so the surrounding expanded-row toggler is not fired.
    */
-  onSelect?: () => void
+  onSelect?: (() => void) | undefined
   /**
    * Optional badge rendered immediately after the mutual badge. Used by the
    * camper-requests panel to inject the "Current request" chip.
    */
-  badge?: React.ReactNode
+  badge?: React.ReactNode | undefined
 }
 
 function statusIcon(status: string) {

--- a/frontend/src/components/BunkRequestRow.tsx
+++ b/frontend/src/components/BunkRequestRow.tsx
@@ -1,3 +1,4 @@
+import type React from 'react'
 import { CheckCircle, XCircle, Clock, Sparkles } from 'lucide-react'
 import clsx from 'clsx'
 import CamperLink from './CamperLink'
@@ -22,6 +23,16 @@ export interface BunkRequestRowProps {
   satisfactionLoading?: boolean
   /** Optional detail text for the satisfaction tooltip. */
   satisfactionDetail?: string | undefined
+  /**
+   * When provided, renders the row as a <button> and calls this on click.
+   * The click event stops propagation so the surrounding expanded-row toggler is not fired.
+   */
+  onSelect?: () => void
+  /**
+   * Optional badge rendered immediately after the mutual badge. Used by the
+   * camper-requests panel to inject the "Current request" chip.
+   */
+  badge?: React.ReactNode
 }
 
 function statusIcon(status: string) {
@@ -71,23 +82,28 @@ export function BunkRequestRow({
   showSatisfaction = false,
   satisfactionLoading = false,
   satisfactionDetail,
+  onSelect,
+  badge,
 }: BunkRequestRowProps) {
   const rowClass = clsx(
     'flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm transition-colors',
-    isCurrent ? 'ring-primary/40 bg-primary/5 ring-1' : 'hover:bg-muted/50'
+    isCurrent ? 'ring-primary/40 bg-primary/5 ring-1' : 'hover:bg-muted/50',
+    onSelect &&
+      'cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50'
   )
 
   // Age preference variant
   if (request.request_type === 'age_preference') {
     const prefersOlder = request.age_preference_target === 'older'
-    return (
-      <div className={clsx(rowClass, 'text-muted-foreground text-xs')}>
+    const ageChildren = (
+      <>
         <Sparkles className="h-3 w-3 flex-shrink-0 text-amber-500" />
         <span>
           Prefers bunking with{' '}
           <span className="text-foreground font-medium">{prefersOlder ? 'older' : 'younger'}</span>{' '}
           campers
         </span>
+        {badge}
         {showSatisfaction && (
           <SatisfactionIcon
             satisfaction={satisfaction}
@@ -95,8 +111,23 @@ export function BunkRequestRow({
             satisfactionDetail={satisfactionDetail}
           />
         )}
-      </div>
+      </>
     )
+    if (onSelect) {
+      return (
+        <button
+          type="button"
+          className={clsx(rowClass, 'text-muted-foreground text-xs')}
+          onClick={(e) => {
+            e.stopPropagation()
+            onSelect()
+          }}
+        >
+          {ageChildren}
+        </button>
+      )
+    }
+    return <div className={clsx(rowClass, 'text-muted-foreground text-xs')}>{ageChildren}</div>
   }
 
   const isBunkWith = request.request_type === 'bunk_with'
@@ -106,8 +137,8 @@ export function BunkRequestRow({
   const resolvedName = targetPerson ? `${targetPerson.first_name} ${targetPerson.last_name}` : null
   const displayName = resolvedName ?? request.requested_person_name ?? 'Unknown'
 
-  return (
-    <div className={rowClass}>
+  const children = (
+    <>
       {/* Status indicator */}
       {statusIcon(request.status)}
 
@@ -132,6 +163,9 @@ export function BunkRequestRow({
       {/* Reciprocal badge - only if reciprocal */}
       {request.is_reciprocal && <span className={MUTUAL_BADGE_CLASSES}>mutual</span>}
 
+      {/* Optional badge slot (e.g. "Current request", "Pinned") */}
+      {badge}
+
       {/* Satisfaction - concise icon only */}
       {showSatisfaction && (
         <SatisfactionIcon
@@ -140,6 +174,23 @@ export function BunkRequestRow({
           satisfactionDetail={satisfactionDetail}
         />
       )}
-    </div>
+    </>
   )
+
+  if (onSelect) {
+    return (
+      <button
+        type="button"
+        className={rowClass}
+        onClick={(e) => {
+          e.stopPropagation()
+          onSelect()
+        }}
+      >
+        {children}
+      </button>
+    )
+  }
+
+  return <div className={rowClass}>{children}</div>
 }

--- a/frontend/src/components/BunkRequestRow.tsx
+++ b/frontend/src/components/BunkRequestRow.tsx
@@ -1,4 +1,4 @@
-import type React from 'react'
+import type { ReactNode } from 'react'
 import { CheckCircle, XCircle, Clock, Sparkles } from 'lucide-react'
 import clsx from 'clsx'
 import CamperLink from './CamperLink'
@@ -32,7 +32,39 @@ export interface BunkRequestRowProps {
    * Optional badge rendered immediately after the mutual badge. Used by the
    * camper-requests panel to inject the "Current request" chip.
    */
-  badge?: React.ReactNode | undefined
+  badge?: ReactNode | undefined
+}
+
+function ClickableRow({
+  className,
+  onSelect,
+  children,
+}: {
+  className: string
+  onSelect?: (() => void) | undefined
+  children: ReactNode
+}) {
+  if (!onSelect) return <div className={className}>{children}</div>
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className={className}
+      onClick={(e) => {
+        e.stopPropagation()
+        onSelect()
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          e.stopPropagation()
+          onSelect()
+        }
+      }}
+    >
+      {children}
+    </div>
+  )
 }
 
 function statusIcon(status: string) {
@@ -113,29 +145,11 @@ export function BunkRequestRow({
         )}
       </>
     )
-    if (onSelect) {
-      return (
-        <div
-          role="button"
-          tabIndex={0}
-          className={clsx(rowClass, 'text-muted-foreground text-xs')}
-          onClick={(e) => {
-            e.stopPropagation()
-            onSelect()
-          }}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault()
-              e.stopPropagation()
-              onSelect()
-            }
-          }}
-        >
-          {ageChildren}
-        </div>
-      )
-    }
-    return <div className={clsx(rowClass, 'text-muted-foreground text-xs')}>{ageChildren}</div>
+    return (
+      <ClickableRow className={clsx(rowClass, 'text-muted-foreground text-xs')} onSelect={onSelect}>
+        {ageChildren}
+      </ClickableRow>
+    )
   }
 
   const isBunkWith = request.request_type === 'bunk_with'
@@ -185,28 +199,9 @@ export function BunkRequestRow({
     </>
   )
 
-  if (onSelect) {
-    return (
-      <div
-        role="button"
-        tabIndex={0}
-        className={rowClass}
-        onClick={(e) => {
-          e.stopPropagation()
-          onSelect()
-        }}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            e.stopPropagation()
-            onSelect()
-          }
-        }}
-      >
-        {children}
-      </div>
-    )
-  }
-
-  return <div className={rowClass}>{children}</div>
+  return (
+    <ClickableRow className={rowClass} onSelect={onSelect}>
+      {children}
+    </ClickableRow>
+  )
 }

--- a/frontend/src/components/CamperRequestSummary.test.tsx
+++ b/frontend/src/components/CamperRequestSummary.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '../test/testUtils'
+import userEvent from '@testing-library/user-event'
 import type { BunkRequestsResponse } from '../types/pocketbase-types'
 
 // Mock pocketbase
@@ -181,5 +182,51 @@ describe('CamperRequestSummary', () => {
     await waitFor(() => {
       expect(screen.getByText(/Failed to load requests/)).toBeInTheDocument()
     })
+  })
+
+  it('renders the "Requests from this camper" heading', async () => {
+    mockFetch()
+    render(<CamperRequestSummary requesterCmId={100} year={2025} currentRequestId="req1" />)
+    expect(await screen.findByText(/^Requests from this camper$/i)).toBeInTheDocument()
+  })
+
+  it('shows a "Current request" badge only on the current row', async () => {
+    mockFetch()
+    render(<CamperRequestSummary requesterCmId={100} year={2025} currentRequestId="req1" />)
+    await screen.findByText('Olivia Chen')
+    const badges = screen.getAllByText(/current request/i)
+    expect(badges).toHaveLength(1)
+  })
+
+  it('calls onSelect with the clicked row id for a non-current row', async () => {
+    mockFetch()
+    const onSelect = vi.fn()
+    render(
+      <CamperRequestSummary
+        requesterCmId={100}
+        year={2025}
+        currentRequestId="req1"
+        onSelect={onSelect}
+      />
+    )
+    const otherRow = await screen.findByRole('button', { name: /Liam Garcia/ })
+    await userEvent.click(otherRow)
+    expect(onSelect).toHaveBeenCalledWith('req2')
+  })
+
+  it('does not wire onSelect on the current row', async () => {
+    mockFetch()
+    const onSelect = vi.fn()
+    render(
+      <CamperRequestSummary
+        requesterCmId={100}
+        year={2025}
+        currentRequestId="req1"
+        onSelect={onSelect}
+      />
+    )
+    const currentText = await screen.findByText('Olivia Chen')
+    const clickable = currentText.closest('button')
+    expect(clickable).toBeNull()
   })
 })

--- a/frontend/src/components/CamperRequestSummary.tsx
+++ b/frontend/src/components/CamperRequestSummary.tsx
@@ -5,12 +5,15 @@ import { pb } from '../lib/pocketbase'
 import { useAuth } from '../contexts/AuthContext'
 import { BunkRequestRow } from './BunkRequestRow'
 import { queryKeys } from '../utils/queryKeys'
+import { CURRENT_REQUEST_BADGE_CLASSES } from '../utils/dispositionColors'
 import type { BunkRequestsResponse, PersonsResponse } from '../types/pocketbase-types'
 
 interface CamperRequestSummaryProps {
   requesterCmId: number
   year: number
   currentRequestId: string
+  /** When provided, non-current rows become clickable and fire this callback with their id. */
+  onSelect?: (requestId: string) => void
 }
 
 /**
@@ -23,6 +26,7 @@ export function CamperRequestSummary({
   requesterCmId,
   year,
   currentRequestId,
+  onSelect,
 }: CamperRequestSummaryProps) {
   const { user } = useAuth()
 
@@ -105,18 +109,25 @@ export function CamperRequestSummary({
   return (
     <div className="space-y-1">
       <div className="text-muted-foreground mb-1 text-xs font-semibold tracking-wide uppercase">
-        Other requests from this camper
+        Requests from this camper
       </div>
       {nonAgeRequests.map((request) => {
         const targetPerson = request.requestee_id
           ? (personMap.get(request.requestee_id) ?? null)
           : null
+        const isCurrent = request.id === currentRequestId
         return (
           <div key={request.id} data-testid={`request-row-${request.id}`}>
             <BunkRequestRow
               request={request}
               targetPerson={targetPerson}
-              isCurrent={request.id === currentRequestId}
+              isCurrent={isCurrent}
+              onSelect={isCurrent || !onSelect ? undefined : () => onSelect(request.id)}
+              badge={
+                isCurrent ? (
+                  <span className={CURRENT_REQUEST_BADGE_CLASSES}>Current request</span>
+                ) : undefined
+              }
             />
           </div>
         )

--- a/frontend/src/components/RequestReviewPanel.pin.test.tsx
+++ b/frontend/src/components/RequestReviewPanel.pin.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { MemoryRouter, Routes, Route } from 'react-router'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router'
 import RequestReviewPanel from './RequestReviewPanel'
 
 // Mock pb so we control what each collection returns.
@@ -48,7 +48,9 @@ vi.mock('../lib/pocketbase', () => ({
       getFullList: async () => (name === 'bunk_requests' ? requestsInList : persons),
       getOne: async (id: string) => {
         if (id === 'req-pinned') return pinnedHiddenRequest
-        throw new Error('not found')
+        const err = new Error('not found') as Error & { status: number }
+        err.status = 404
+        throw err
       },
       update: async () => ({}),
     }),
@@ -62,11 +64,24 @@ function renderPanel(initialUrl = '/requests') {
     <QueryClientProvider client={client}>
       <MemoryRouter initialEntries={[initialUrl]}>
         <Routes>
-          <Route path="/requests" element={<RequestReviewPanel sessionId={1} year={2026} />} />
+          <Route
+            path="/requests"
+            element={
+              <>
+                <LocationProbe />
+                <RequestReviewPanel sessionId={1} year={2026} />
+              </>
+            }
+          />
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>
   )
+}
+
+function LocationProbe() {
+  const location = useLocation()
+  return <div data-testid="current-search">{location.search}</div>
 }
 
 describe('RequestReviewPanel pinned row', () => {
@@ -82,6 +97,16 @@ describe('RequestReviewPanel pinned row', () => {
     await screen.findAllByTestId('pinned-badge')
     // Olivia Chen is the requestee of the pinned (normally-filtered-out) row.
     await screen.findAllByText(/Olivia Chen/)
+  })
+
+  it('clears the pin from the URL when the pinned id 404s', async () => {
+    renderPanel('/requests?pin=does-not-exist')
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('current-search').textContent).not.toContain('pin=does-not-exist')
+      },
+      { timeout: 2000 }
+    )
   })
 
   it('does not show the pinned badge for non-pinned rows', async () => {

--- a/frontend/src/components/RequestReviewPanel.pin.test.tsx
+++ b/frontend/src/components/RequestReviewPanel.pin.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Routes, Route } from 'react-router'
+import RequestReviewPanel from './RequestReviewPanel'
+
+// Mock pb so we control what each collection returns.
+const requestsInList = [
+  // A pending request matching the default filter.
+  {
+    id: 'req-visible',
+    requester_id: 42,
+    requestee_id: 100,
+    request_type: 'bunk_with',
+    year: 2026,
+    session_id: 1,
+    status: 'pending',
+    is_reciprocal: false,
+    merged_into: '',
+    priority: 1,
+    confidence_score: 0.5,
+    disposition_reason: '',
+  },
+]
+const pinnedHiddenRequest = {
+  id: 'req-pinned',
+  requester_id: 42,
+  requestee_id: 101,
+  request_type: 'bunk_with',
+  year: 2026,
+  session_id: 1,
+  status: 'resolved',
+  is_reciprocal: false,
+  merged_into: '',
+  priority: 1,
+  confidence_score: 1.0,
+  disposition_reason: 'exact_match',
+}
+const persons = [
+  { cm_id: 42, first_name: 'Emma', last_name: 'Johnson', year: 2026 },
+  { cm_id: 100, first_name: 'Liam', last_name: 'Garcia', year: 2026 },
+  { cm_id: 101, first_name: 'Olivia', last_name: 'Chen', year: 2026 },
+]
+
+vi.mock('../lib/pocketbase', () => ({
+  pb: {
+    collection: (name: string) => ({
+      getFullList: async () => (name === 'bunk_requests' ? requestsInList : persons),
+      getOne: async (id: string) => {
+        if (id === 'req-pinned') return pinnedHiddenRequest
+        throw new Error('not found')
+      },
+      update: async () => ({}),
+    }),
+  },
+}))
+vi.mock('../contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: 'u1' } }) }))
+
+function renderPanel(initialUrl = '/requests') {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[initialUrl]}>
+        <Routes>
+          <Route path="/requests" element={<RequestReviewPanel sessionId={1} year={2026} />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe('RequestReviewPanel pinned row', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Clear localStorage so filter/sort state from other tests doesn't leak in.
+    localStorage.clear()
+  })
+
+  it('shows the pinned row with a Pinned badge even when filters would hide it', async () => {
+    renderPanel('/requests?pin=req-pinned')
+    // Pinned row is rendered despite default filter statuses=['pending'] and the pinned one is resolved.
+    await screen.findAllByTestId('pinned-badge')
+    // Olivia Chen is the requestee of the pinned (normally-filtered-out) row.
+    await screen.findAllByText(/Olivia Chen/)
+  })
+
+  it('does not show the pinned badge for non-pinned rows', async () => {
+    renderPanel('/requests?pin=req-pinned')
+    await waitFor(() => expect(screen.getAllByText(/Liam Garcia/).length).toBeGreaterThan(0))
+    // Desktop and mobile variants both render the badge, but only once per rendered breakpoint.
+    // We accept at least one and ensure it's only on the pinned row by checking no extra
+    // Pinned badge belongs to req-visible (which contains Liam Garcia).
+    const badges = screen.getAllByTestId('pinned-badge')
+    expect(badges.length).toBeGreaterThanOrEqual(1)
+    // Every pinned badge must live inside a row tagged data-request-row-id="req-pinned".
+    for (const badge of badges) {
+      const row = badge.closest('[data-request-row-id]') as HTMLElement | null
+      expect(row?.getAttribute('data-request-row-id')).toBe('req-pinned')
+    }
+  })
+})

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -230,6 +230,19 @@ export default function RequestReviewPanel({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [storageKey])
 
+  // Clear any pin when filters/sort change — the new view is the user's
+  // explicit choice and should not keep an implicitly-pinned row alive.
+  const isInitialFilterMount = useRef(true)
+  useEffect(() => {
+    if (isInitialFilterMount.current) {
+      isInitialFilterMount.current = false
+      return
+    }
+    if (pinnedId) setPinnedId(null)
+    // pinnedId/setPinnedId are intentionally not deps — only filter/sort changes trigger unpin.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filters, sortBy, sortOrder])
+
   // Query key only includes server-side filters (sent to PocketBase).
   // Client-side filters (search) are applied in filteredRequests memo.
   const queryKeyFilters = useMemo(
@@ -661,7 +674,11 @@ export default function RequestReviewPanel({
           next.delete(id)
           // Clear the expanded merged request when collapsing
           setExpandedMergedRequestId((currentId) => (currentId === id ? null : currentId))
+          // Collapsing the pinned row unpins it.
+          if (pinnedId === id) setPinnedId(null)
         } else {
+          // Expanding a different row unpins — pin follows the currently-focused row.
+          if (pinnedId && pinnedId !== id) setPinnedId(null)
           next.add(id)
           // Trigger lazy loading for merged requests
           if (request && hasMultipleSources(request)) {
@@ -671,7 +688,7 @@ export default function RequestReviewPanel({
         return next
       })
     },
-    [hasMultipleSources]
+    [hasMultipleSources, pinnedId, setPinnedId]
   )
 
   /**

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -731,7 +731,7 @@ export default function RequestReviewPanel({
       const el = document.querySelector<HTMLElement>(
         `[data-request-row-id="${CSS.escape(pinnedId)}"]`
       )
-      el?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+      el?.scrollIntoView?.({ block: 'nearest', behavior: 'smooth' })
     }, 50)
     return () => window.clearTimeout(t)
   }, [pinnedId])

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -37,6 +37,7 @@ import {
   CONFIDENCE_RESOLVED,
   MUTUAL_BADGE_CLASSES,
 } from '../utils/dispositionColors'
+import { usePinnedRequest } from '../hooks/usePinnedRequest'
 import EditableRequestType from './EditableRequestType'
 import EditableRequestTarget from './EditableRequestTarget'
 import EditablePriority from './EditablePriority'
@@ -72,6 +73,8 @@ export default function RequestReviewPanel({
 }: RequestReviewPanelProps) {
   const queryClient = useQueryClient()
   const { user } = useAuth()
+  // setPinnedId is wired in Task 9; pinnedId is used by the pinned-row merge in this task.
+  const { pinnedId } = usePinnedRequest()
 
   // Task 7: Default filter/sort constants and localStorage persistence
   const storageKey = `kindred-requests-filters-${sessionId}`
@@ -268,6 +271,26 @@ export default function RequestReviewPanel({
     enabled: !!user,
   })
 
+  // Fetch the pinned request separately when the current filter/session combo excludes it,
+  // so the pinned row stays visible even if its status/type was filtered out.
+  const pinnedPresentInRequests = useMemo(
+    () => (pinnedId ? requests.some((r: BunkRequestsResponse) => r.id === pinnedId) : true),
+    [requests, pinnedId]
+  )
+  const { data: pinnedExtraRequest = null } = useQuery({
+    queryKey: ['bunk-request-pinned', pinnedId],
+    queryFn: async () => {
+      if (!pinnedId) return null
+      try {
+        return await pb.collection<BunkRequestsResponse>('bunk_requests').getOne(pinnedId)
+      } catch {
+        return null
+      }
+    },
+    enabled: !!user && !!pinnedId && !pinnedPresentInRequests,
+    staleTime: 30000,
+  })
+
   // Fetch person data for display - use string-based key for stability
   const personIds = useMemo(() => {
     const ids = new Set<number>()
@@ -428,6 +451,11 @@ export default function RequestReviewPanel({
   const sortedRequests = useMemo(() => {
     let filtered = [...requests]
 
+    // Include the pinned request even when filters would exclude it from the main query.
+    if (pinnedExtraRequest && !filtered.some((r) => r.id === pinnedExtraRequest.id)) {
+      filtered.push(pinnedExtraRequest)
+    }
+
     // Search filtering using already-fetched personMap
     if (filters.searchQuery && personMap.size > 0) {
       const searchLower = filters.searchQuery.toLowerCase()
@@ -504,7 +532,7 @@ export default function RequestReviewPanel({
     })
 
     return sorted
-  }, [requests, sortBy, sortOrder, personMap, filters.searchQuery])
+  }, [requests, sortBy, sortOrder, personMap, filters.searchQuery, pinnedExtraRequest])
 
   // Check if merge is possible: 2+ requests selected with same requester and session
   const mergeEligibility = useMemo(() => {

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -39,6 +39,8 @@ import {
   PINNED_BADGE_CLASSES,
 } from '../utils/dispositionColors'
 import { usePinnedRequest } from '../hooks/usePinnedRequest'
+import { queryKeys } from '../utils/queryKeys'
+import { positionPinnedAdjacent } from '../utils/positionPinnedAdjacent'
 import EditableRequestType from './EditableRequestType'
 import EditableRequestTarget from './EditableRequestTarget'
 import EditablePriority from './EditablePriority'
@@ -75,6 +77,12 @@ export default function RequestReviewPanel({
   const queryClient = useQueryClient()
   const { user } = useAuth()
   const { pinnedId, setPinnedId } = usePinnedRequest()
+  // Remembers the row the user was on when the pin was set, so the pinned
+  // row can render directly adjacent to it instead of at its natural sort slot.
+  const [pinOriginatorId, setPinOriginatorId] = useState<string | null>(null)
+  useEffect(() => {
+    if (!pinnedId) setPinOriginatorId(null)
+  }, [pinnedId])
 
   // Task 7: Default filter/sort constants and localStorage persistence
   const storageKey = `kindred-requests-filters-${sessionId}`
@@ -290,19 +298,21 @@ export default function RequestReviewPanel({
     () => (pinnedId ? requests.some((r: BunkRequestsResponse) => r.id === pinnedId) : true),
     [requests, pinnedId]
   )
-  const { data: pinnedExtraRequest = null } = useQuery({
-    queryKey: ['bunk-request-pinned', pinnedId],
-    queryFn: async () => {
-      if (!pinnedId) return null
-      try {
-        return await pb.collection<BunkRequestsResponse>('bunk_requests').getOne(pinnedId)
-      } catch {
-        return null
-      }
-    },
+  const { data: pinnedExtraRequest = null, error: pinnedExtraError } = useQuery({
+    queryKey: queryKeys.bunkRequestPinned(pinnedId),
+    queryFn: async () =>
+      pinnedId ? await pb.collection<BunkRequestsResponse>('bunk_requests').getOne(pinnedId) : null,
     enabled: !!user && !!pinnedId && !pinnedPresentInRequests,
     staleTime: 30000,
+    retry: false,
   })
+
+  // Clear stale pin (request deleted or invalid id) from the URL on 404.
+  useEffect(() => {
+    if (pinnedExtraError && (pinnedExtraError as { status?: number }).status === 404) {
+      setPinnedId(null)
+    }
+  }, [pinnedExtraError, setPinnedId])
 
   // Fetch person data for display - use string-based key for stability
   const personIds = useMemo(() => {
@@ -544,8 +554,17 @@ export default function RequestReviewPanel({
       }
     })
 
-    return sorted
-  }, [requests, sortBy, sortOrder, personMap, filters.searchQuery, pinnedExtraRequest])
+    return positionPinnedAdjacent(sorted, pinnedId, pinOriginatorId)
+  }, [
+    requests,
+    sortBy,
+    sortOrder,
+    personMap,
+    filters.searchQuery,
+    pinnedExtraRequest,
+    pinnedId,
+    pinOriginatorId,
+  ])
 
   // Check if merge is possible: 2+ requests selected with same requester and session
   const mergeEligibility = useMemo(() => {
@@ -698,7 +717,12 @@ export default function RequestReviewPanel({
    */
   const pinAndExpand = useCallback(
     (id: string) => {
-      setExpandedRows(new Set([id]))
+      setExpandedRows((prev) => {
+        const first = [...prev][0]
+        const originator = first && first !== id ? first : null
+        setPinOriginatorId(originator)
+        return new Set([id])
+      })
       setPinnedId(id)
     },
     [setPinnedId]

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -294,15 +294,11 @@ export default function RequestReviewPanel({
 
   // Fetch the pinned request separately when the current filter/session combo excludes it,
   // so the pinned row stays visible even if its status/type was filtered out.
-  const pinnedPresentInRequests = useMemo(
-    () => (pinnedId ? requests.some((r: BunkRequestsResponse) => r.id === pinnedId) : true),
-    [requests, pinnedId]
-  )
   const { data: pinnedExtraRequest = null, error: pinnedExtraError } = useQuery({
     queryKey: queryKeys.bunkRequestPinned(pinnedId),
-    queryFn: async () =>
-      pinnedId ? await pb.collection<BunkRequestsResponse>('bunk_requests').getOne(pinnedId) : null,
-    enabled: !!user && !!pinnedId && !pinnedPresentInRequests,
+    queryFn: () =>
+      pinnedId ? pb.collection<BunkRequestsResponse>('bunk_requests').getOne(pinnedId) : null,
+    enabled: !!user && !!pinnedId && !requests.some((r) => r.id === pinnedId),
     staleTime: 30000,
     retry: false,
   })
@@ -1432,7 +1428,7 @@ export default function RequestReviewPanel({
                                 requesterCmId={request.requester_id}
                                 year={year}
                                 currentRequestId={request.id}
-                                onSelect={(id) => pinAndExpand(id)}
+                                onSelect={pinAndExpand}
                               />
                             </div>
                           </div>
@@ -1859,7 +1855,7 @@ export default function RequestReviewPanel({
                                   requesterCmId={request.requester_id}
                                   year={year}
                                   currentRequestId={request.id}
-                                  onSelect={(id) => pinAndExpand(id)}
+                                  onSelect={pinAndExpand}
                                 />
                               </div>
                             </div>

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -36,6 +36,7 @@ import {
   CONFIDENCE_AUTO_ACCEPT,
   CONFIDENCE_RESOLVED,
   MUTUAL_BADGE_CLASSES,
+  PINNED_BADGE_CLASSES,
 } from '../utils/dispositionColors'
 import { usePinnedRequest } from '../hooks/usePinnedRequest'
 import EditableRequestType from './EditableRequestType'
@@ -73,8 +74,7 @@ export default function RequestReviewPanel({
 }: RequestReviewPanelProps) {
   const queryClient = useQueryClient()
   const { user } = useAuth()
-  // setPinnedId is wired in Task 9; pinnedId is used by the pinned-row merge in this task.
-  const { pinnedId } = usePinnedRequest()
+  const { pinnedId, setPinnedId } = usePinnedRequest()
 
   // Task 7: Default filter/sort constants and localStorage persistence
   const storageKey = `kindred-requests-filters-${sessionId}`
@@ -674,6 +674,31 @@ export default function RequestReviewPanel({
     [hasMultipleSources]
   )
 
+  /**
+   * Pin a request and collapse any other expanded rows. Used by the
+   * "Requests from this camper" panel so clicking another row swaps focus
+   * to the clicked request and records it in the URL via `?pin=<id>`.
+   */
+  const pinAndExpand = useCallback(
+    (id: string) => {
+      setExpandedRows(new Set([id]))
+      setPinnedId(id)
+    },
+    [setPinnedId]
+  )
+
+  // Scroll the pinned row into view when it changes to a new non-null id.
+  useEffect(() => {
+    if (!pinnedId) return
+    const t = window.setTimeout(() => {
+      const el = document.querySelector<HTMLElement>(
+        `[data-request-row-id="${CSS.escape(pinnedId)}"]`
+      )
+      el?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+    }, 50)
+    return () => window.clearTimeout(t)
+  }, [pinnedId])
+
   const toggleRequestSelection = useCallback((id: string) => {
     setSelectedRequests((prev) => {
       const next = new Set(prev)
@@ -1152,7 +1177,7 @@ export default function RequestReviewPanel({
                     const isExpanded = expandedRows.has(request.id)
 
                     return (
-                      <div key={request.id}>
+                      <div key={request.id} data-request-row-id={request.id}>
                         <div
                           className="request-card-mobile hover:bg-muted/50 cursor-pointer transition-colors"
                           onClick={() => toggleRowExpansion(request.id, request)}
@@ -1188,6 +1213,11 @@ export default function RequestReviewPanel({
                               </button>
                               {request.is_reciprocal && (
                                 <span className={MUTUAL_BADGE_CLASSES}>mutual</span>
+                              )}
+                              {request.id === pinnedId && (
+                                <span data-testid="pinned-badge" className={PINNED_BADGE_CLASSES}>
+                                  Pinned
+                                </span>
                               )}
                             </div>
                             <div className="text-muted-foreground mt-0.5 text-xs">
@@ -1361,6 +1391,7 @@ export default function RequestReviewPanel({
                                 requesterCmId={request.requester_id}
                                 year={year}
                                 currentRequestId={request.id}
+                                onSelect={(id) => pinAndExpand(id)}
                               />
                             </div>
                           </div>
@@ -1379,6 +1410,7 @@ export default function RequestReviewPanel({
                     return (
                       <div
                         key={request.id}
+                        data-request-row-id={request.id}
                         className={clsx(
                           'cursor-pointer border-b transition-colors',
                           selectedRequests.has(request.id)
@@ -1419,6 +1451,11 @@ export default function RequestReviewPanel({
                             </button>
                             {request.is_reciprocal && (
                               <span className={MUTUAL_BADGE_CLASSES}>mutual</span>
+                            )}
+                            {request.id === pinnedId && (
+                              <span data-testid="pinned-badge" className={PINNED_BADGE_CLASSES}>
+                                Pinned
+                              </span>
                             )}
                           </div>
                           <div
@@ -1781,6 +1818,7 @@ export default function RequestReviewPanel({
                                   requesterCmId={request.requester_id}
                                   year={year}
                                   currentRequestId={request.id}
+                                  onSelect={(id) => pinAndExpand(id)}
                                 />
                               </div>
                             </div>

--- a/frontend/src/hooks/usePinnedRequest.test.tsx
+++ b/frontend/src/hooks/usePinnedRequest.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { MemoryRouter, useLocation } from 'react-router'
+import { usePinnedRequest } from './usePinnedRequest'
+import type { ReactNode } from 'react'
+
+function wrap(initialEntries: string[] = ['/']) {
+  return ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+  )
+}
+
+describe('usePinnedRequest', () => {
+  it('returns null when ?pin= is absent', () => {
+    const { result } = renderHook(() => usePinnedRequest(), { wrapper: wrap(['/requests']) })
+    expect(result.current.pinnedId).toBeNull()
+  })
+
+  it('reads the pin id from the URL', () => {
+    const { result } = renderHook(() => usePinnedRequest(), {
+      wrapper: wrap(['/requests?pin=abc123']),
+    })
+    expect(result.current.pinnedId).toBe('abc123')
+  })
+
+  it('setPinnedId("xyz") sets ?pin=xyz without pushing history', () => {
+    let latestSearch = ''
+    function Probe() {
+      const loc = useLocation()
+      latestSearch = loc.search
+      return null
+    }
+    const { result } = renderHook(
+      () => {
+        Probe()
+        return usePinnedRequest()
+      },
+      { wrapper: wrap(['/requests']) }
+    )
+    act(() => result.current.setPinnedId('xyz'))
+    expect(latestSearch).toBe('?pin=xyz')
+  })
+
+  it('setPinnedId(null) removes the pin param', () => {
+    const { result } = renderHook(() => usePinnedRequest(), {
+      wrapper: wrap(['/requests?pin=abc123']),
+    })
+    act(() => result.current.setPinnedId(null))
+    expect(result.current.pinnedId).toBeNull()
+  })
+
+  it('preserves other query params when setting/clearing pin', () => {
+    let latestSearch = ''
+    function Probe() {
+      const loc = useLocation()
+      latestSearch = loc.search
+      return null
+    }
+    const { result } = renderHook(
+      () => {
+        Probe()
+        return usePinnedRequest()
+      },
+      { wrapper: wrap(['/requests?year=2026&tab=requests']) }
+    )
+    act(() => result.current.setPinnedId('abc'))
+    expect(new URLSearchParams(latestSearch).get('pin')).toBe('abc')
+    expect(new URLSearchParams(latestSearch).get('year')).toBe('2026')
+    expect(new URLSearchParams(latestSearch).get('tab')).toBe('requests')
+  })
+})

--- a/frontend/src/hooks/usePinnedRequest.ts
+++ b/frontend/src/hooks/usePinnedRequest.ts
@@ -1,0 +1,36 @@
+import { useCallback } from 'react'
+import { useSearchParams } from 'react-router'
+
+/**
+ * Reads and writes the `?pin=<requestId>` URL query parameter.
+ *
+ * Used by the Bunk Requests review panel to keep a chosen request visible
+ * and highlighted, even if active filters would otherwise hide it.
+ */
+export function usePinnedRequest(): {
+  pinnedId: string | null
+  setPinnedId: (id: string | null) => void
+} {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const pinnedId = searchParams.get('pin')
+
+  const setPinnedId = useCallback(
+    (id: string | null) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev)
+          if (id) {
+            next.set('pin', id)
+          } else {
+            next.delete('pin')
+          }
+          return next
+        },
+        { replace: true }
+      )
+    },
+    [setSearchParams]
+  )
+
+  return { pinnedId, setPinnedId }
+}

--- a/frontend/src/utils/dispositionColors.ts
+++ b/frontend/src/utils/dispositionColors.ts
@@ -71,6 +71,14 @@ export function getConfidenceClasses(confidence: number): string {
 export const MUTUAL_BADGE_CLASSES =
   'bg-forest-100 dark:bg-forest-900/50 text-forest-700 dark:text-forest-300 flex-shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium'
 
+/** Tailwind classes for the "Current request" badge shown on the currently expanded row in the camper-requests panel. */
+export const CURRENT_REQUEST_BADGE_CLASSES =
+  'bg-primary/15 text-primary flex-shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium'
+
+/** Tailwind classes for the "Pinned" badge shown when a request is pinned via the URL. */
+export const PINNED_BADGE_CLASSES =
+  'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 flex-shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium'
+
 /** Friendly display names for disposition reasons. */
 const DISPOSITION_DISPLAY_NAMES: Record<string, string> = {
   // Resolved

--- a/frontend/src/utils/positionPinnedAdjacent.test.ts
+++ b/frontend/src/utils/positionPinnedAdjacent.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { positionPinnedAdjacent } from './positionPinnedAdjacent'
+
+const items = [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }, { id: 'e' }]
+
+describe('positionPinnedAdjacent', () => {
+  it('returns the list unchanged when no pin is set', () => {
+    expect(positionPinnedAdjacent(items, null, null)).toEqual(items)
+  })
+
+  it('returns the list unchanged when originator is not known', () => {
+    expect(positionPinnedAdjacent(items, 'd', null)).toEqual(items)
+  })
+
+  it('returns the list unchanged when pinned === originator', () => {
+    expect(positionPinnedAdjacent(items, 'c', 'c')).toEqual(items)
+  })
+
+  it('returns the list unchanged when originator is not in the list', () => {
+    expect(positionPinnedAdjacent(items, 'd', 'missing')).toEqual(items)
+  })
+
+  it('returns the list unchanged when pinned is not in the list', () => {
+    expect(positionPinnedAdjacent(items, 'missing', 'b')).toEqual(items)
+  })
+
+  it('moves a pinned item from a later slot to directly after its originator', () => {
+    // originator: b (index 1), pinned: e (index 4) -> expect b, e, c, d
+    expect(positionPinnedAdjacent(items, 'e', 'b').map((r) => r.id)).toEqual([
+      'a',
+      'b',
+      'e',
+      'c',
+      'd',
+    ])
+  })
+
+  it('moves a pinned item from an earlier slot to directly after its originator', () => {
+    // originator: d (index 3), pinned: a (index 0) -> expect b, c, d, a, e
+    expect(positionPinnedAdjacent(items, 'a', 'd').map((r) => r.id)).toEqual([
+      'b',
+      'c',
+      'd',
+      'a',
+      'e',
+    ])
+  })
+
+  it('is a no-op when pinned is already directly after originator', () => {
+    expect(positionPinnedAdjacent(items, 'c', 'b')).toEqual(items)
+  })
+
+  it('does not mutate the input array', () => {
+    const input = [...items]
+    positionPinnedAdjacent(input, 'e', 'a')
+    expect(input).toEqual(items)
+  })
+})

--- a/frontend/src/utils/positionPinnedAdjacent.ts
+++ b/frontend/src/utils/positionPinnedAdjacent.ts
@@ -9,21 +9,21 @@
  * Returns the input unchanged when no repositioning is needed.
  */
 export function positionPinnedAdjacent<T extends { id: string }>(
-  sorted: readonly T[],
+  sorted: T[],
   pinnedId: string | null,
   pinOriginatorId: string | null
 ): T[] {
   if (!pinnedId || !pinOriginatorId || pinnedId === pinOriginatorId) {
-    return sorted as T[]
+    return sorted
   }
   const originatorIdx = sorted.findIndex((r) => r.id === pinOriginatorId)
   const pinnedIdx = sorted.findIndex((r) => r.id === pinnedId)
-  if (originatorIdx < 0 || pinnedIdx < 0) return sorted as T[]
-  if (pinnedIdx === originatorIdx + 1) return sorted as T[]
+  if (originatorIdx < 0 || pinnedIdx < 0) return sorted
+  if (pinnedIdx === originatorIdx + 1) return sorted
 
   const result = [...sorted]
   const [pinned] = result.splice(pinnedIdx, 1)
-  if (!pinned) return sorted as T[]
+  if (!pinned) return sorted
   // Indices shift left only when we removed an item before the originator.
   const insertIdx = pinnedIdx < originatorIdx ? originatorIdx : originatorIdx + 1
   result.splice(insertIdx, 0, pinned)

--- a/frontend/src/utils/positionPinnedAdjacent.ts
+++ b/frontend/src/utils/positionPinnedAdjacent.ts
@@ -1,0 +1,31 @@
+/**
+ * Re-orders a sorted list so the pinned item sits directly after its
+ * "originator" — the row the user was on when they triggered the pin.
+ *
+ * When the pin is set via clicking a sibling request in an expanded camper
+ * panel, the originator is the currently-expanded row (same requester). Placing
+ * the pinned row adjacent keeps related requests clustered visually.
+ *
+ * Returns the input unchanged when no repositioning is needed.
+ */
+export function positionPinnedAdjacent<T extends { id: string }>(
+  sorted: readonly T[],
+  pinnedId: string | null,
+  pinOriginatorId: string | null
+): T[] {
+  if (!pinnedId || !pinOriginatorId || pinnedId === pinOriginatorId) {
+    return sorted as T[]
+  }
+  const originatorIdx = sorted.findIndex((r) => r.id === pinOriginatorId)
+  const pinnedIdx = sorted.findIndex((r) => r.id === pinnedId)
+  if (originatorIdx < 0 || pinnedIdx < 0) return sorted as T[]
+  if (pinnedIdx === originatorIdx + 1) return sorted as T[]
+
+  const result = [...sorted]
+  const [pinned] = result.splice(pinnedIdx, 1)
+  if (!pinned) return sorted as T[]
+  // Indices shift left only when we removed an item before the originator.
+  const insertIdx = pinnedIdx < originatorIdx ? originatorIdx : originatorIdx + 1
+  result.splice(insertIdx, 0, pinned)
+  return result
+}

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -51,6 +51,7 @@ export const queryKeys = {
 
   // Bunk Requests (Tier 2 - user data)
   bunkRequests: (sessionId: string, year: number) => ['bunk-requests', sessionId, year] as const,
+  bunkRequestPinned: (id: string | null) => ['bunk-request-pinned', id] as const,
 
   // Locked Groups (Tier 2 - user data)
   lockedGroups: (scenarioId: string, sessionId: string, year: number) =>


### PR DESCRIPTION
## Summary
- Rename the right-hand panel to **Requests from this camper** and add a **Current request** chip to the row matching the currently-expanded request
- Non-current rows in that panel are now clickable — clicking pins the target via `?pin=<id>` and expands it in the main table
- The pinned row stays visible in the table even when active filters would hide it, with a **Pinned** chip; pin clears on collapse, cross-row expansion, filter/sort change, or explicit pin swap
- Pin state lives in the URL only — no localStorage, no server state — so a refresh with `?pin=<id>` restores the expanded + pinned view

## Implementation
- New hook `usePinnedRequest` wraps `useSearchParams` for read/write of `?pin=`
- `BunkRequestRow` gains optional `onSelect` + `badge` props so the panel can render rows as buttons with accessory badges
- `RequestReviewPanel` merges the pinned request into its visible list (lazy-fetched via `getOne` when the existing filtered query excludes it) and scrolls it into view on pin change
- Tests: `usePinnedRequest` hook unit tests (5), `BunkRequestRow` click + badge tests (3), `CamperRequestSummary` heading + onSelect tests (4), `RequestReviewPanel.pin` integration test (2). Full vitest suite 2701/2701 green.

## Test plan
- [x] Hook + component unit tests
- [x] Integration test: pinned row survives filter exclusion
- [ ] Manual: click-to-switch across the panel, confirm scroll + Pinned chip, exercise each unpin trigger, refresh with \`?pin=<id>\` to confirm restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Pin requests to maintain visibility when adjusting filters or sort order
- "Current request" badge clearly identifies the active request in request lists
- "Pinned" badge provides visual indication of pinned requests
- Request rows are now selectable, allowing users to pin and navigate between multiple requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->