### PR TITLE
feat(frontend): drop Disposition col, add Request Type col, fold reason into Status

### DIFF
--- a/frontend/src/components/RequestReviewPanel.status.test.tsx
+++ b/frontend/src/components/RequestReviewPanel.status.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Routes, Route } from 'react-router'
+import RequestReviewPanel from './RequestReviewPanel'
+
+const requests = [
+  {
+    id: 'r-resolved',
+    requester_id: 42,
+    requestee_id: 100,
+    request_type: 'bunk_with',
+    year: 2026,
+    session_id: 1,
+    status: 'resolved',
+    is_reciprocal: false,
+    merged_into: '',
+    priority: 1,
+    confidence_score: 1.0,
+    disposition_reason: 'exact_match',
+  },
+  {
+    id: 'r-declined',
+    requester_id: 42,
+    requestee_id: 101,
+    request_type: 'bunk_with',
+    year: 2026,
+    session_id: 1,
+    status: 'declined',
+    is_reciprocal: false,
+    merged_into: '',
+    priority: 1,
+    confidence_score: 0.0,
+    disposition_reason: 'session_mismatch',
+  },
+  {
+    id: 'r-pending-triage',
+    requester_id: 43,
+    requestee_id: 102,
+    request_type: 'bunk_with',
+    year: 2026,
+    session_id: 1,
+    status: 'pending',
+    is_reciprocal: false,
+    merged_into: '',
+    priority: 1,
+    confidence_score: 0.5,
+    disposition_reason: 'target_waitlisted',
+  },
+  {
+    id: 'r-pending-plain',
+    requester_id: 44,
+    requestee_id: 103,
+    request_type: 'bunk_with',
+    year: 2026,
+    session_id: 1,
+    status: 'pending',
+    is_reciprocal: false,
+    merged_into: '',
+    priority: 1,
+    confidence_score: 0.9,
+    disposition_reason: '',
+  },
+]
+const persons = [42, 43, 44, 100, 101, 102, 103].map((cm_id) => ({
+  cm_id,
+  first_name: `P${cm_id}`,
+  last_name: 'Test',
+  year: 2026,
+}))
+
+vi.mock('../lib/pocketbase', () => ({
+  pb: {
+    collection: (name: string) => ({
+      getFullList: async () => (name === 'bunk_requests' ? requests : persons),
+      getOne: async () => ({}),
+      update: async () => ({}),
+    }),
+  },
+}))
+vi.mock('../contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: 'u1' } }) }))
+
+function renderPanel() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  // Default filter is statuses: ['pending']; override via localStorage so all rows show.
+  localStorage.setItem(
+    'kindred-requests-filters-1',
+    JSON.stringify({ filters: { requestTypes: [], statuses: [], searchQuery: '' } })
+  )
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/requests']}>
+        <Routes>
+          <Route path="/requests" element={<RequestReviewPanel sessionId={1} year={2026} />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe('RequestReviewPanel Status cell reason line', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('resolved rows show only the status chip, no reason line', async () => {
+    renderPanel()
+    // Both the desktop row and mobile card render the badge — 2 matches.
+    await waitFor(() => expect(screen.getAllByText('Resolved').length).toBeGreaterThan(0))
+    // The reason-line span is only emitted with text-[11px] styling. The legend uses
+    // text-[10px] font-semibold. Confirm no muted 11px reason line is emitted for
+    // the resolved row.
+    const reasonLines = Array.from(document.querySelectorAll('span.text-muted-foreground'))
+      .filter((el) => /matched/i.test(el.textContent ?? ''))
+      .filter((el) => el.className.includes('text-[11px]'))
+    expect(reasonLines.length).toBe(0)
+  })
+
+  it('declined rows show the reason line under the chip', async () => {
+    renderPanel()
+    await waitFor(() => expect(screen.getAllByText('Declined').length).toBeGreaterThan(0))
+    // "Different sessions" reason appears in both desktop + mobile — at least 1.
+    expect(screen.getAllByText(/different sessions/i).length).toBeGreaterThan(0)
+  })
+
+  it('pending rows with a triage reason show it; plain pending rows do not', async () => {
+    renderPanel()
+    // 2 pending rows × (desktop + mobile) = 4 Pending chips in DOM.
+    await waitFor(() => expect(screen.getAllByText('Pending').length).toBeGreaterThanOrEqual(2))
+    // "Waitlisted" appears as a reason line under the Pending chip (triage row).
+    const waitlistedReasonLines = Array.from(
+      document.querySelectorAll('span.text-muted-foreground')
+    )
+      .filter((el) => /waitlisted/i.test(el.textContent ?? ''))
+      .filter((el) => el.className.includes('text-[11px]'))
+    expect(waitlistedReasonLines.length).toBeGreaterThan(0)
+    // The plain pending row has no reason — no reason line should render with text
+    // matching "needs review" (legend uses text-[10px], not text-[11px]).
+    const needsReviewReasonLines = Array.from(
+      document.querySelectorAll('span.text-muted-foreground')
+    )
+      .filter((el) => /needs review/i.test(el.textContent ?? ''))
+      .filter((el) => el.className.includes('text-[11px]'))
+    expect(needsReviewReasonLines.length).toBe(0)
+  })
+
+  it('no row renders a standalone Disposition column cell', async () => {
+    renderPanel()
+    await waitFor(() => expect(screen.getAllByText('Declined').length).toBeGreaterThan(0))
+    // The old header text must be gone.
+    expect(screen.queryByText(/^disposition$/i)).toBeNull()
+    // The new Type header must be present.
+    expect(screen.getAllByText(/^type$/i).length).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/components/RequestReviewPanel.status.test.tsx
+++ b/frontend/src/components/RequestReviewPanel.status.test.tsx
@@ -101,20 +101,16 @@ function renderPanel() {
 describe('RequestReviewPanel Status cell reason line', () => {
   beforeEach(() => {
     localStorage.clear()
-    vi.clearAllMocks()
   })
 
   it('resolved rows show only the status chip, no reason line', async () => {
     renderPanel()
     // Both the desktop row and mobile card render the badge — 2 matches.
     await waitFor(() => expect(screen.getAllByText('Resolved').length).toBeGreaterThan(0))
-    // The reason-line span is only emitted with text-[11px] styling. The legend uses
-    // text-[10px] font-semibold. Confirm no muted 11px reason line is emitted for
-    // the resolved row.
-    const reasonLines = Array.from(document.querySelectorAll('span.text-muted-foreground'))
+    const matchedReasonLines = screen
+      .queryAllByTestId('status-reason-line')
       .filter((el) => /matched/i.test(el.textContent ?? ''))
-      .filter((el) => el.className.includes('text-[11px]'))
-    expect(reasonLines.length).toBe(0)
+    expect(matchedReasonLines.length).toBe(0)
   })
 
   it('declined rows show the reason line under the chip', async () => {
@@ -128,21 +124,11 @@ describe('RequestReviewPanel Status cell reason line', () => {
     renderPanel()
     // 2 pending rows × (desktop + mobile) = 4 Pending chips in DOM.
     await waitFor(() => expect(screen.getAllByText('Pending').length).toBeGreaterThanOrEqual(2))
-    // "Waitlisted" appears as a reason line under the Pending chip (triage row).
-    const waitlistedReasonLines = Array.from(
-      document.querySelectorAll('span.text-muted-foreground')
-    )
-      .filter((el) => /waitlisted/i.test(el.textContent ?? ''))
-      .filter((el) => el.className.includes('text-[11px]'))
-    expect(waitlistedReasonLines.length).toBeGreaterThan(0)
-    // The plain pending row has no reason — no reason line should render with text
-    // matching "needs review" (legend uses text-[10px], not text-[11px]).
-    const needsReviewReasonLines = Array.from(
-      document.querySelectorAll('span.text-muted-foreground')
-    )
-      .filter((el) => /needs review/i.test(el.textContent ?? ''))
-      .filter((el) => el.className.includes('text-[11px]'))
-    expect(needsReviewReasonLines.length).toBe(0)
+    const reasonLines = screen.queryAllByTestId('status-reason-line')
+    expect(
+      reasonLines.filter((el) => /waitlisted/i.test(el.textContent ?? '')).length
+    ).toBeGreaterThan(0)
+    expect(reasonLines.filter((el) => /needs review/i.test(el.textContent ?? '')).length).toBe(0)
   })
 
   it('no row renders a standalone Disposition column cell', async () => {

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -1153,7 +1153,7 @@ export default function RequestReviewPanel({
                                   }
                                   handleValidatedUpdate(request, updates)
                                 }}
-                                disabled={request.request_locked || false}
+                                disabled={request.request_locked}
                               />
                             </div>
                           </div>
@@ -1175,7 +1175,10 @@ export default function RequestReviewPanel({
                                 request.status,
                                 request.disposition_reason
                               ) && (
-                                <span className="text-muted-foreground max-w-[8rem] truncate text-right text-[11px]">
+                                <span
+                                  data-testid="status-reason-line"
+                                  className="text-muted-foreground max-w-[8rem] truncate text-right text-[11px]"
+                                >
                                   {formatReason(request.disposition_reason)}
                                 </span>
                               )}
@@ -1209,7 +1212,7 @@ export default function RequestReviewPanel({
                                 }
                                 handleValidatedUpdate(request, pbUpdates)
                               }}
-                              disabled={request.request_locked || false}
+                              disabled={request.request_locked}
                               originalText={request.original_text}
                               requestedPersonName={request.requested_person_name}
                               parseNotes={request.parse_notes}
@@ -1401,7 +1404,7 @@ export default function RequestReviewPanel({
                                 }
                                 handleValidatedUpdate(request, updates)
                               }}
-                              disabled={request.request_locked || false}
+                              disabled={request.request_locked}
                             />
                           </div>
                           <div
@@ -1434,7 +1437,7 @@ export default function RequestReviewPanel({
                                 }
                                 handleValidatedUpdate(request, pbUpdates)
                               }}
-                              disabled={request.request_locked || false}
+                              disabled={request.request_locked}
                               originalText={request.original_text}
                               requestedPersonName={request.requested_person_name}
                               parseNotes={request.parse_notes}
@@ -1486,7 +1489,10 @@ export default function RequestReviewPanel({
                               request.status,
                               request.disposition_reason
                             ) && (
-                              <span className="text-muted-foreground max-w-full truncate text-[11px]">
+                              <span
+                                data-testid="status-reason-line"
+                                className="text-muted-foreground max-w-full truncate text-[11px]"
+                              >
                                 {formatReason(request.disposition_reason)}
                               </span>
                             )}

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -1374,6 +1374,26 @@ export default function RequestReviewPanel({
                             className="flex items-center px-4 py-3"
                             onClick={(e) => e.stopPropagation()}
                           >
+                            <EditableRequestType
+                              value={request.request_type}
+                              onChange={(newType) => {
+                                const updates: Partial<BunkRequestsResponse> = {
+                                  request_type: newType as BunkRequestsResponse['request_type'],
+                                }
+                                if (newType === 'age_preference') {
+                                  updates.requestee_id = null as unknown as number
+                                } else {
+                                  updates.age_preference_target = ''
+                                }
+                                handleValidatedUpdate(request, updates)
+                              }}
+                              disabled={request.request_locked || false}
+                            />
+                          </div>
+                          <div
+                            className="flex items-center px-4 py-3"
+                            onClick={(e) => e.stopPropagation()}
+                          >
                             <EditableRequestTarget
                               requestType={request.request_type}
                               currentPersonId={request.requestee_id}
@@ -1420,21 +1440,6 @@ export default function RequestReviewPanel({
                               ) : null
                             })()}
                           </div>
-                          <div className="flex items-center gap-1 px-4 py-3">
-                            {request.disposition_reason ? (
-                              <span
-                                className={clsx(
-                                  'inline-flex rounded px-1.5 py-0.5 text-[10px] font-semibold',
-                                  getDispositionClasses(request.disposition_reason)
-                                )}
-                                title={request.disposition_reason}
-                              >
-                                {formatDispositionReason(request.disposition_reason)}
-                              </span>
-                            ) : (
-                              <span className="text-muted-foreground text-xs">—</span>
-                            )}
-                          </div>
                           <div
                             className="flex items-center justify-center px-4 py-3"
                             onClick={(e) => e.stopPropagation()}
@@ -1461,8 +1466,16 @@ export default function RequestReviewPanel({
                               {(request.confidence_score * 100).toFixed(0)}%
                             </span>
                           </div>
-                          <div className="flex items-center justify-center px-4 py-3">
+                          <div className="flex flex-col items-center justify-center gap-0.5 px-4 py-3">
                             {getStatusBadge(request.status)}
+                            {shouldShowReasonInStatus(
+                              request.status,
+                              request.disposition_reason
+                            ) && (
+                              <span className="text-muted-foreground max-w-full truncate text-[11px]">
+                                {formatReason(request.disposition_reason)}
+                              </span>
+                            )}
                           </div>
                           <div
                             className="flex items-center justify-end px-4 py-3"

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -31,8 +31,9 @@ import type {
 import clsx from 'clsx'
 import {
   getDispositionClasses,
-  getDispositionSortRank,
   formatDispositionReason,
+  formatReason,
+  shouldShowReasonInStatus,
   CONFIDENCE_AUTO_ACCEPT,
   CONFIDENCE_RESOLVED,
   MUTUAL_BADGE_CLASSES,
@@ -62,7 +63,7 @@ interface FilterState {
   searchQuery: string
 }
 
-type SortColumn = 'requester' | 'request' | 'disposition' | 'priority' | 'confidence' | 'status'
+type SortColumn = 'requester' | 'request' | 'priority' | 'confidence' | 'status'
 
 export default function RequestReviewPanel({
   sessionId,
@@ -93,7 +94,8 @@ export default function RequestReviewPanel({
       const stored = localStorage.getItem(storageKey)
       if (stored) {
         const parsed = JSON.parse(stored)
-        if (parsed?.sort?.sortBy) return parsed.sort.sortBy as SortColumn
+        const loaded = parsed?.sort?.sortBy
+        if (loaded && loaded !== 'disposition') return loaded as SortColumn
       }
     } catch {
       // Ignore
@@ -207,7 +209,8 @@ export default function RequestReviewPanel({
         } else {
           setFilters(defaultFilters)
         }
-        if (parsed?.sort?.sortBy) setSortBy(parsed.sort.sortBy as SortColumn)
+        const loadedSortBy = parsed?.sort?.sortBy
+        if (loadedSortBy && loadedSortBy !== 'disposition') setSortBy(loadedSortBy as SortColumn)
         else setSortBy(defaultSortBy)
         if (parsed?.sort?.sortOrder) setSortOrder(parsed.sort.sortOrder as 'asc' | 'desc')
         else setSortOrder(defaultSortOrder)
@@ -466,18 +469,6 @@ export default function RequestReviewPanel({
           bValue = bRequested
             ? `${bRequested.first_name || ''} ${bRequested.last_name || ''}`
             : b.parse_notes || ''
-          break
-        }
-        case 'disposition': {
-          const aRank = getDispositionSortRank(a.disposition_reason ?? '')
-          const bRank = getDispositionSortRank(b.disposition_reason ?? '')
-          if (aRank !== bRank) {
-            aValue = aRank
-            bValue = bRank
-          } else {
-            aValue = a.disposition_reason ?? ''
-            bValue = b.disposition_reason ?? ''
-          }
           break
         }
         case 'priority':

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -1692,43 +1692,9 @@ export default function RequestReviewPanel({
                                   </>
                                 )}
 
-                                {/* Type (moved from column) */}
-                                <div className="flex items-center gap-2 text-sm">
-                                  <span className="font-medium">Type:</span>
-                                  <EditableRequestType
-                                    value={request.request_type}
-                                    onChange={(newType) => {
-                                      const updates: Partial<BunkRequestsResponse> = {
-                                        request_type:
-                                          newType as BunkRequestsResponse['request_type'],
-                                      }
-                                      // Explicit clear values (not delete) so PocketBase clears the field.
-                                      // Use null (not 0) to properly clear the field — 0 causes
-                                      // unique constraint violations when multiple requests exist.
-                                      if (newType === 'age_preference') {
-                                        updates.requestee_id = null as unknown as number
-                                      } else {
-                                        updates.age_preference_target = ''
-                                      }
-                                      handleValidatedUpdate(request, updates)
-                                    }}
-                                    disabled={request.request_locked || false}
-                                  />
-                                </div>
-
                                 {/* Metadata */}
                                 <div className="text-muted-foreground flex flex-wrap items-center gap-3 text-xs">
                                   <span>Source: {request.source}</span>
-                                  {request.disposition_reason && (
-                                    <span
-                                      className={clsx(
-                                        'rounded px-1.5 py-0.5 text-[10px] font-semibold',
-                                        getDispositionClasses(request.disposition_reason)
-                                      )}
-                                    >
-                                      {formatDispositionReason(request.disposition_reason)}
-                                    </span>
-                                  )}
                                   {request.resolution_method && (
                                     <span>
                                       via{' '}

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -1139,8 +1139,22 @@ export default function RequestReviewPanel({
                                 <span className={MUTUAL_BADGE_CLASSES}>mutual</span>
                               )}
                             </div>
-                            <div className="text-muted-foreground mt-0.5 text-xs">
-                              {getRequestTypeLabel(request.request_type)}
+                            <div className="mt-0.5" onClick={(e) => e.stopPropagation()}>
+                              <EditableRequestType
+                                value={request.request_type}
+                                onChange={(newType) => {
+                                  const updates: Partial<BunkRequestsResponse> = {
+                                    request_type: newType as BunkRequestsResponse['request_type'],
+                                  }
+                                  if (newType === 'age_preference') {
+                                    updates.requestee_id = null as unknown as number
+                                  } else {
+                                    updates.age_preference_target = ''
+                                  }
+                                  handleValidatedUpdate(request, updates)
+                                }}
+                                disabled={request.request_locked || false}
+                              />
                             </div>
                           </div>
 
@@ -1155,17 +1169,17 @@ export default function RequestReviewPanel({
                               {getConfidenceIndicator(request.confidence_score)}
                               {(request.confidence_score * 100).toFixed(0)}%
                             </span>
-                            {getStatusBadge(request.status)}
-                            {request.disposition_reason && (
-                              <span
-                                className={clsx(
-                                  'rounded px-1.5 py-0.5 text-[10px] font-semibold',
-                                  getDispositionClasses(request.disposition_reason)
-                                )}
-                              >
-                                {formatDispositionReason(request.disposition_reason)}
-                              </span>
-                            )}
+                            <div className="flex flex-col items-end gap-0.5">
+                              {getStatusBadge(request.status)}
+                              {shouldShowReasonInStatus(
+                                request.status,
+                                request.disposition_reason
+                              ) && (
+                                <span className="text-muted-foreground max-w-[8rem] truncate text-right text-[11px]">
+                                  {formatReason(request.disposition_reason)}
+                                </span>
+                              )}
+                            </div>
                           </div>
 
                           {/* Request target info */}

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -982,6 +982,9 @@ export default function RequestReviewPanel({
                   )}
                 </div>
               </div>
+              <div className="text-muted-foreground px-4 py-3 text-left text-sm font-medium">
+                Type
+              </div>
               <div
                 className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-left text-sm font-medium"
                 onClick={() => handleSort('request')}
@@ -989,23 +992,6 @@ export default function RequestReviewPanel({
                 <div className="flex items-center gap-1">
                   Request
                   {sortBy === 'request' && (
-                    <span className="text-primary">
-                      {sortOrder === 'asc' ? (
-                        <ChevronUp className="h-3 w-3" />
-                      ) : (
-                        <ChevronDown className="h-3 w-3" />
-                      )}
-                    </span>
-                  )}
-                </div>
-              </div>
-              <div
-                className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-left text-sm font-medium"
-                onClick={() => handleSort('disposition')}
-              >
-                <div className="flex items-center gap-1">
-                  Disposition
-                  {sortBy === 'disposition' && (
                     <span className="text-primary">
                       {sortOrder === 'asc' ? (
                         <ChevronUp className="h-3 w-3" />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1224,9 +1224,9 @@
    ============================================ */
 .request-table-grid {
   display: grid;
-  /* Columns: checkbox+expand | requester | request | disposition | priority | confidence | status | actions */
-  grid-template-columns: 64px 240px 260px 200px 80px 100px 100px 120px;
-  min-width: 1064px;
+  /* Columns: checkbox+expand | requester | type | request | priority | confidence | status | actions */
+  grid-template-columns: 64px 240px 160px 260px 80px 100px 140px 120px;
+  min-width: 1164px;
 }
 
 /* Mobile card layout for request review panel */

--- a/frontend/src/utils/dispositionColors.test.ts
+++ b/frontend/src/utils/dispositionColors.test.ts
@@ -10,6 +10,8 @@ import {
   getConfidenceClasses,
   getDispositionSortRank,
   formatDispositionReason,
+  formatReason,
+  shouldShowReasonInStatus,
   RESOLVED_REASONS,
   PENDING_REASONS,
   DECLINED_REASONS,
@@ -201,6 +203,60 @@ describe('formatDispositionReason', () => {
       const fallback = reason.replace(/_/g, ' ')
       expect(display, `${reason} is missing from DISPOSITION_DISPLAY_NAMES`).not.toBe(fallback)
     }
+  })
+})
+
+describe('shouldShowReasonInStatus', () => {
+  it('returns false when status is resolved regardless of reason', () => {
+    expect(shouldShowReasonInStatus('resolved', 'exact_match')).toBe(false)
+    expect(shouldShowReasonInStatus('resolved', 'reciprocal_match')).toBe(false)
+    expect(shouldShowReasonInStatus('RESOLVED', 'exact_match')).toBe(false)
+  })
+
+  it('returns true for declined rows with any non-empty reason', () => {
+    expect(shouldShowReasonInStatus('declined', 'session_mismatch')).toBe(true)
+    expect(shouldShowReasonInStatus('declined', 'target_not_attending')).toBe(true)
+    expect(shouldShowReasonInStatus('declined', 'requester_not_attending')).toBe(true)
+    expect(shouldShowReasonInStatus('DECLINED', 'session_mismatch')).toBe(true)
+  })
+
+  it('returns false for declined rows with no reason', () => {
+    expect(shouldShowReasonInStatus('declined', '')).toBe(false)
+    expect(shouldShowReasonInStatus('declined', null)).toBe(false)
+    expect(shouldShowReasonInStatus('declined', undefined)).toBe(false)
+  })
+
+  it('returns true for pending rows with a triage reason', () => {
+    expect(shouldShowReasonInStatus('pending', 'needs_review')).toBe(true)
+    expect(shouldShowReasonInStatus('pending', 'target_waitlisted')).toBe(true)
+    expect(shouldShowReasonInStatus('pending', 'undirected_preference')).toBe(true)
+    expect(shouldShowReasonInStatus('PENDING', 'needs_review')).toBe(true)
+  })
+
+  it('returns false for pending rows with a non-triage reason', () => {
+    expect(shouldShowReasonInStatus('pending', 'exact_match')).toBe(false)
+    expect(shouldShowReasonInStatus('pending', 'session_mismatch')).toBe(false)
+    expect(shouldShowReasonInStatus('pending', 'random_unknown')).toBe(false)
+  })
+
+  it('returns false for unknown status', () => {
+    expect(shouldShowReasonInStatus('queued', 'needs_review')).toBe(false)
+    expect(shouldShowReasonInStatus('', 'needs_review')).toBe(false)
+  })
+
+  it('returns false when reason is missing regardless of status', () => {
+    expect(shouldShowReasonInStatus('pending', null)).toBe(false)
+    expect(shouldShowReasonInStatus('pending', undefined)).toBe(false)
+    expect(shouldShowReasonInStatus('pending', '')).toBe(false)
+  })
+})
+
+describe('formatReason', () => {
+  it('is an alias of formatDispositionReason', () => {
+    expect(formatReason('exact_match')).toBe(formatDispositionReason('exact_match'))
+    expect(formatReason('session_mismatch')).toBe(formatDispositionReason('session_mismatch'))
+    expect(formatReason('needs_review')).toBe(formatDispositionReason('needs_review'))
+    expect(formatReason('unknown_x')).toBe(formatDispositionReason('unknown_x'))
   })
 })
 

--- a/frontend/src/utils/dispositionColors.ts
+++ b/frontend/src/utils/dispositionColors.ts
@@ -103,3 +103,26 @@ export function getDispositionSortRank(reason: string): number {
   if (RESOLVED_REASONS.has(reason)) return 2
   return 3
 }
+
+/** Alias of `formatDispositionReason` used by the new Status-cell reason line. */
+export const formatReason = formatDispositionReason
+
+/**
+ * Whether the Status cell should render a reason line under the chip.
+ *
+ * - Resolved rows: never (chip alone; mutual-match badge lives elsewhere).
+ * - Declined rows: whenever a reason is present.
+ * - Pending rows: only for triage reasons (needs_review, target_waitlisted,
+ *   undirected_preference). Other pending rows stay chip-only.
+ */
+export function shouldShowReasonInStatus(
+  status: string,
+  reason: string | null | undefined
+): boolean {
+  if (!reason) return false
+  const normalized = status.toLowerCase()
+  if (normalized === 'resolved') return false
+  if (normalized === 'declined') return true
+  if (normalized === 'pending') return PENDING_REASONS.has(reason)
+  return false
+}


### PR DESCRIPTION
## Summary
- Drop the standalone **Disposition** column from the bunk requests table (desktop + mobile)
- Fold the useful reason text into the **Status** cell as a small muted sub-line — shown only on declined rows and on the three triage-worthy pending reasons (`needs_review`, `target_waitlisted`, `undirected_preference`); resolved rows stay chip-only
- Add a new **Request Type** column between Requester and Request, editable inline via the existing `EditableRequestType` control
- Remove the now-duplicate **Type:** field and disposition chip from the expanded row

## Implementation
- New helper \`shouldShowReasonInStatus(status, reason)\` + \`formatReason\` alias in \`utils/dispositionColors.ts\`
- Desktop CSS grid re-shaped: \`64 240 160 260 80 100 140 120\` (lost 200px disposition, gained 160px type, widened status 100 → 140)
- \`SortColumn\` narrowed — \`'disposition'\` removed from the union, its sort case deleted, and a stale-localStorage guard added so users with \`sortBy: 'disposition'\` persisted fall back to the default
- Server-side \`disposition_reason\` API field unchanged; this is purely a rename + reshuffle on the frontend
- Tests: \`shouldShowReasonInStatus\` + \`formatReason\` unit tests, status-cell integration test covering all four render rules. Full vitest suite 2701/2701 green.

## Test plan
- [x] Helper unit tests
- [x] Integration test: Status cell renders reason line only per spec
- [ ] Manual: edit request type inline, verify Target cell re-renders (age_preference ↔ person); declined + triage-pending rows show reason; resolved rows stay chip-only; expanded row no longer duplicates Type/disposition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Request type is now editable inline in the request table.

* **Improvements**
  * Status display logic refined with conditional reason information based on request status.
  * Request table layout updated: disposition column removed and type column added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->