### PR TITLE
fix(frontend): use session.cm_id relation filter on attendees

### DIFF
--- a/frontend/src/components/ManualResolutionModal.tsx
+++ b/frontend/src/components/ManualResolutionModal.tsx
@@ -47,7 +47,7 @@ export default function ManualResolutionModal({
     queryKey: ['session-campers', sessionId, year],
     queryFn: async () => {
       // Get attendees for this specific session
-      const attendeeFilter = `session_id = ${sessionId} && status = "enrolled" && year = ${year}`
+      const attendeeFilter = `session.cm_id = ${sessionId} && status = "enrolled" && year = ${year}`
       const attendees = await pb
         .collection('attendees')
         .getFullList<AttendeesResponse>({ filter: attendeeFilter })

--- a/frontend/src/hooks/useSessionCamperPersons.ts
+++ b/frontend/src/hooks/useSessionCamperPersons.ts
@@ -20,7 +20,7 @@ export function useSessionCamperPersons(
     queryKey: queryKeys.sessionCampers(sessionId, year),
     queryFn: async () => {
       const attendees = await pb.collection<AttendeesResponse>('attendees').getFullList({
-        filter: `session_id = ${sessionId} && year = ${year} && status = "enrolled"`,
+        filter: `session.cm_id = ${sessionId} && year = ${year} && status = "enrolled"`,
         expand: 'person',
       })
 


### PR DESCRIPTION
## Summary
- Fixes prod 400s on attendees queries introduced by #895
- `attendees` has no scalar `session_id` field — only a `session` relation. Server-side filters using `session_id = <cmId>` were rejected
- Switches to `session.cm_id = <cmId>` back-relation filter so queries stay server-side but target an existing field

## Affected callsites
- `frontend/src/hooks/useSessionCamperPersons.ts` — 400s on all session camper lookups (hit from `SessionView`, `CreateRequestModal`, `EditableRequestTarget`)
- `frontend/src/components/ManualResolutionModal.tsx` — 400s when listing attendee candidates

## Test plan
- [ ] Manual: open a session, click a requestee target, confirm attendee list loads without 400
- [ ] Manual: manual resolution modal loads candidate attendees
- [x] `tsc --noEmit` clean
- [x] `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)