### PR TITLE
fix(api): count reranker path wins in Phase 3 stats (#942)

### DIFF
--- a/bunking/sync/bunk_request_processor/services/phase3_disambiguation_service.py
+++ b/bunking/sync/bunk_request_processor/services/phase3_disambiguation_service.py
@@ -500,37 +500,56 @@ class Phase3DisambiguationService:
         return results
 
     def _update_stats(self, cases: list[DisambiguationCase]) -> None:
-        """Update disambiguation statistics"""
-        # Count total ambiguous resolutions processed, not just cases
-        total_ambiguous = sum(len(case.disambiguation_indices) for case in cases)
-        self._stats["total_processed"] += total_ambiguous
+        """Update disambiguation statistics.
+
+        Mirrors ``debug_pipeline_traces.phase3_disambiguation[].result`` so the
+        ``Phase 3 complete`` log line matches the trace (issue #942).
+
+        The orchestrator records a Phase 3 trace row per intent with ``ran=True``
+        for every intent in a ParseResult that had any unresolved intent — this
+        includes Phase-2-resolved intents that rode along on the ParseResult.
+        Stats therefore count **every** intent across every case, not just
+        those in ``disambiguation_indices``.
+
+        Per-intent outcome mirrors the trace's ``result`` field:
+          - ``rr.is_resolved``                          -> ``successfully_disambiguated``
+          - ``disambiguation_status == "no_match"``     -> ``no_match``
+          - ``disambiguation_status == "invalid_ai_output"`` -> ``invalid_ai_output``
+          - ``disambiguation_status == "failed"``       -> ``failed``
+          - anything else                                -> ``still_ambiguous``
+        """
+        # total_processed == count of trace rows with ran=True (every intent in
+        # every case that entered Phase 3).
+        total_ran = sum(len(case.resolution_results) for case in cases)
+        self._stats["total_processed"] += total_ran
 
         for case in cases:
-            # Count successful disambiguations per resolution
-            for idx in case.disambiguation_indices:
-                if idx < len(case.disambiguated_results):
-                    result = case.disambiguated_results[idx]
+            statuses = case.disambiguation_metadata.get("status", {})
+            for idx, original_rr in enumerate(case.resolution_results):
+                # Prefer the disambiguated result when Phase 3 produced one;
+                # fall back to the original resolution (Phase 2 win or
+                # not-needed slot).
+                disambig_rr = case.disambiguated_results[idx] if idx < len(case.disambiguated_results) else None
+                final_rr = disambig_rr if disambig_rr is not None else original_rr
+
+                if final_rr is not None and final_rr.is_resolved:
+                    self._stats["successfully_disambiguated"] += 1
+                    continue
+
+                # Not resolved. Classify by disambiguation_status, mirroring the
+                # trace's fallback: rr_meta.get("disambiguation_status", "still_ambiguous").
+                status = statuses.get(idx, "")
+                if not status and final_rr is not None and final_rr.metadata:
+                    status = final_rr.metadata.get("disambiguation_status", "")
+
+                if status == "no_match":
+                    self._stats["no_match"] += 1
+                elif status == "invalid_ai_output":
+                    self._stats["invalid_ai_output"] += 1
+                elif status == "failed":
+                    self._stats["failed"] += 1
                 else:
-                    result = None
-                if result is not None:
-                    if result.is_resolved:
-                        self._stats["successfully_disambiguated"] += 1
-                    elif result.metadata and result.metadata.get("no_match"):
-                        self._stats["no_match"] += 1
-                    else:
-                        # Reached when Phase 3 returns a non-resolved ResolutionResult
-                        # (e.g. candidates present but no match selected by AI)
-                        self._stats["still_ambiguous"] += 1
-                else:
-                    # Check disambiguation metadata for specific status
-                    statuses = case.disambiguation_metadata.get("status", {})
-                    status = statuses.get(idx, "")
-                    if status == "no_match":
-                        self._stats["no_match"] += 1
-                    elif status == "invalid_ai_output":
-                        self._stats["invalid_ai_output"] += 1
-                    else:
-                        self._stats["failed"] += 1
+                    self._stats["still_ambiguous"] += 1
 
     def get_stats(self) -> dict[str, Any]:
         """Get disambiguation statistics"""

--- a/bunking/sync/bunk_request_processor/services/phase3_disambiguation_service.py
+++ b/bunking/sync/bunk_request_processor/services/phase3_disambiguation_service.py
@@ -7,7 +7,7 @@ from typing import Any, TypeVar
 
 from bunking.logging_config import get_logger
 
-from ..core.models import ParsedRequest, ParseResult
+from ..core.models import ParsedRequest, ParseResult, RequestType
 from ..integration.ai_service import AIProvider, AIRequestContext
 from ..integration.ai_types import ParsedResponse
 from ..integration.batch_processor import BatchProcessor
@@ -113,6 +113,9 @@ class Phase3DisambiguationService:
 
         if not cases:
             logger.info("Phase 3: No ambiguous cases to disambiguate")
+            # Still count every incoming intent — the orchestrator trace has
+            # ran=True for these (no-candidate ParseResults).
+            self._update_stats(ambiguous_cases, cases)
             return ambiguous_cases
 
         # Count total ambiguous resolutions across all cases
@@ -126,6 +129,7 @@ class Phase3DisambiguationService:
 
         if not disambiguation_requests:
             logger.info("Phase 3: No disambiguation requests to process")
+            self._update_stats(ambiguous_cases, cases)
             return ambiguous_cases
 
         # Use batch processor for AI disambiguation
@@ -145,10 +149,15 @@ class Phase3DisambiguationService:
                     errors[idx] = str(e)
 
         # Build final results
+        # Ordering invariant: _build_final_results MUST run before _update_stats.
+        # _build_final_results writes metadata["disambiguation_status"] = "failed"
+        # on exception-path intents that have no per-index status; _update_stats
+        # then reads that status. Swapping these would misclassify exception-path
+        # intents from "failed" to "still_ambiguous".
         results = self._build_final_results(ambiguous_cases, cases)
 
         # Update statistics
-        self._update_stats(cases)
+        self._update_stats(ambiguous_cases, cases)
 
         logger.info(
             f"Phase 3 complete: "
@@ -499,7 +508,11 @@ class Phase3DisambiguationService:
 
         return results
 
-    def _update_stats(self, cases: list[DisambiguationCase]) -> None:
+    def _update_stats(
+        self,
+        ambiguous_cases: list[tuple[ParseResult, list[ResolutionResult]]],
+        cases: list[DisambiguationCase],
+    ) -> None:
         """Update disambiguation statistics.
 
         Mirrors ``debug_pipeline_traces.phase3_disambiguation[].result`` so the
@@ -507,9 +520,11 @@ class Phase3DisambiguationService:
 
         The orchestrator records a Phase 3 trace row per intent with ``ran=True``
         for every intent in a ParseResult that had any unresolved intent — this
-        includes Phase-2-resolved intents that rode along on the ParseResult.
-        Stats therefore count **every** intent across every case, not just
-        those in ``disambiguation_indices``.
+        includes Phase-2-resolved intents that rode along on the ParseResult
+        **and** ParseResults whose unresolved intents have zero candidates
+        (which the service skips from ``cases`` but the trace still records).
+        Stats therefore count **every** intent across every ``ambiguous_cases``
+        entry, even ones we filtered out of ``cases``.
 
         Per-intent outcome mirrors the trace's ``result`` field:
           - ``rr.is_resolved``                          -> ``successfully_disambiguated``
@@ -517,39 +532,69 @@ class Phase3DisambiguationService:
           - ``disambiguation_status == "invalid_ai_output"`` -> ``invalid_ai_output``
           - ``disambiguation_status == "failed"``       -> ``failed``
           - anything else                                -> ``still_ambiguous``
+
+        No-candidate intents (unresolved, method != AGE_PREFERENCE, no candidates)
+        are classified as ``no_match`` — there was nothing to match against.
         """
         # total_processed == count of trace rows with ran=True (every intent in
-        # every case that entered Phase 3).
-        total_ran = sum(len(case.resolution_results) for case in cases)
+        # every ParseResult that entered Phase 3, including no-candidate ones
+        # that were filtered out of `cases`).
+        total_ran = sum(len(resolution_list) for _pr, resolution_list in ambiguous_cases)
         self._stats["total_processed"] += total_ran
 
-        for case in cases:
-            statuses = case.disambiguation_metadata.get("status", {})
-            for idx, original_rr in enumerate(case.resolution_results):
-                # Prefer the disambiguated result when Phase 3 produced one;
-                # fall back to the original resolution (Phase 2 win or
-                # not-needed slot).
-                disambig_rr = case.disambiguated_results[idx] if idx < len(case.disambiguated_results) else None
-                final_rr = disambig_rr if disambig_rr is not None else original_rr
+        # Index cases by the id() of the ParseResult so we can match a case back
+        # to its original ambiguous_cases entry. ParseResult is a @dataclass so
+        # identity comparison is stable here (the service holds the same
+        # objects end-to-end).
+        case_by_parse_result_id = {id(case.parse_result): case for case in cases}
 
-                if final_rr is not None and final_rr.is_resolved:
-                    self._stats["successfully_disambiguated"] += 1
-                    continue
+        for parse_result, resolution_list in ambiguous_cases:
+            case = case_by_parse_result_id.get(id(parse_result))
+            if case is None:
+                # No-candidate ParseResult: DisambiguationCase filtered every
+                # unresolved intent out of disambiguation_indices (truthy
+                # candidates check). Classify per intent: resolved (Phase 2
+                # win) stays successfully_disambiguated; unresolved with no
+                # candidates is no_match; anything else (should be rare —
+                # e.g. age_preference) is still_ambiguous.
+                for rr in resolution_list:
+                    if rr.is_resolved:
+                        self._stats["successfully_disambiguated"] += 1
+                    elif not rr.candidates and rr.method != RequestType.AGE_PREFERENCE.value:
+                        self._stats["no_match"] += 1
+                    else:
+                        self._stats["still_ambiguous"] += 1
+                continue
 
-                # Not resolved. Classify by disambiguation_status, mirroring the
-                # trace's fallback: rr_meta.get("disambiguation_status", "still_ambiguous").
-                status = statuses.get(idx, "")
-                if not status and final_rr is not None and final_rr.metadata:
-                    status = final_rr.metadata.get("disambiguation_status", "")
+            self._classify_case(case)
 
-                if status == "no_match":
-                    self._stats["no_match"] += 1
-                elif status == "invalid_ai_output":
-                    self._stats["invalid_ai_output"] += 1
-                elif status == "failed":
-                    self._stats["failed"] += 1
-                else:
-                    self._stats["still_ambiguous"] += 1
+    def _classify_case(self, case: DisambiguationCase) -> None:
+        """Classify every intent in a DisambiguationCase into the stats buckets."""
+        statuses = case.disambiguation_metadata.get("status", {})
+        for idx, original_rr in enumerate(case.resolution_results):
+            # Prefer the disambiguated result when Phase 3 produced one; fall
+            # back to the original resolution (Phase 2 win or not-needed slot).
+            disambig_rr = case.disambiguated_results[idx] if idx < len(case.disambiguated_results) else None
+            final_rr = disambig_rr if disambig_rr is not None else original_rr
+
+            if final_rr is not None and final_rr.is_resolved:
+                self._stats["successfully_disambiguated"] += 1
+                continue
+
+            # Not resolved. Classify by disambiguation_status, mirroring the
+            # trace's fallback: rr_meta.get("disambiguation_status", "still_ambiguous").
+            status = statuses.get(idx, "")
+            if not status and final_rr is not None and final_rr.metadata:
+                status = final_rr.metadata.get("disambiguation_status", "")
+
+            if status == "no_match":
+                self._stats["no_match"] += 1
+            elif status == "invalid_ai_output":
+                self._stats["invalid_ai_output"] += 1
+            elif status == "failed":
+                self._stats["failed"] += 1
+            else:
+                self._stats["still_ambiguous"] += 1
 
     def get_stats(self) -> dict[str, Any]:
         """Get disambiguation statistics"""

--- a/tests/unit/sync/bunk_request_processor/services/test_phase3_disambiguation_service.py
+++ b/tests/unit/sync/bunk_request_processor/services/test_phase3_disambiguation_service.py
@@ -1324,3 +1324,176 @@ class TestApplyLegacySelection:
         service._apply_legacy_selection(case, 0, resolution, result, None, 0.8, "some reason")
         assert case.disambiguation_metadata["status"][0] == "invalid_ai_output"
         assert case.disambiguation_metadata["reasons"][0] == "some reason"
+
+
+class TestPhase3StatsMatchTrace:
+    """Regression tests for issue #942: Phase 3 stats must mirror trace's result field.
+
+    Acceptance criteria:
+    - Sum of (disambiguated + still_ambiguous + no_match + invalid_ai_output + failed)
+      equals the count of Phase 3 trace rows with ran=true.
+    - Reranker-resolved cases are counted in successfully_disambiguated.
+
+    The trace's result is computed per-intent in the orchestrator as:
+      - "resolved" if rr.is_resolved
+      - "not_needed" if ran_phase3 is False
+      - Otherwise rr.metadata.get("disambiguation_status", "still_ambiguous")
+
+    A trace row has ran=true for every intent in a ParseResult that had any
+    unresolved intent. Therefore stats must count ALL intents in cases that
+    entered Phase 3, not just those in disambiguation_indices.
+    """
+
+    @pytest.mark.asyncio
+    async def test_reranker_resolved_case_counted_in_successfully_disambiguated(self):
+        """A reranker-resolved case (ParsedResponse with ranked_selections) must
+        increment successfully_disambiguated."""
+        from bunking.sync.bunk_request_processor.integration.ai_types import ParsedResponse
+
+        ai_provider = Mock()
+        context_builder = Mock()
+        context_builder.build_disambiguation_context.return_value = _create_mock_context()
+
+        # ParsedResponse with ranked_selections — the reranker path will consume this
+        # and successfully pick a candidate because the target name matches.
+        ai_result = ParsedResponse(
+            requests=[
+                ParsedRequest(
+                    raw_text="Sarah Smith",
+                    request_type=RequestType.BUNK_WITH,
+                    target_name="Sarah Smith",
+                    age_preference=None,
+                    source_field="share_bunk_with",
+                    source=RequestSource.FAMILY,
+                    confidence=0.9,
+                    csv_position=0,
+                    metadata={
+                        "ranked_selections": [
+                            {"person_id": 111, "confidence": 0.95},
+                            {"person_id": 222, "confidence": 0.4},
+                        ],
+                    },
+                )
+            ],
+            confidence=0.9,
+            metadata={},
+        )
+
+        batch_processor = Mock()
+        batch_processor.batch_disambiguate = AsyncMock(return_value=[ai_result])
+
+        service = Phase3DisambiguationService(
+            ai_provider=ai_provider,
+            context_builder=context_builder,
+            batch_processor=batch_processor,
+        )
+
+        candidates = [
+            _create_person(cm_id=111, first_name="Sarah", last_name="Smith"),
+            _create_person(cm_id=222, first_name="Sarah", last_name="Jones"),
+        ]
+        ambiguous = _create_ambiguous_resolution(candidates=candidates)
+        ambiguous.target_name = "Sarah Smith"
+        parse_result = _create_parse_result()
+
+        await service.batch_disambiguate([(parse_result, [ambiguous])])
+
+        stats = service.get_stats()
+        assert stats["successfully_disambiguated"] == 1, (
+            f"Reranker-resolved case should count as successfully_disambiguated, got stats: {stats}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stats_sum_equals_trace_ran_rows(self):
+        """Sum of all outcome stats must equal the count of trace rows with ran=true.
+
+        Simulates the orchestrator's trace computation: every intent in a
+        ParseResult that entered Phase 3 has ran=True in the trace. The stats
+        must mirror that — counting every intent, including Phase 2 wins in
+        the same ParseResult.
+        """
+        from bunking.sync.bunk_request_processor.integration.ai_types import ParsedResponse
+
+        ai_provider = Mock()
+        context_builder = Mock()
+        context_builder.build_disambiguation_context.return_value = _create_mock_context()
+
+        # Reranker-resolved result for the one ambiguous intent in the mixed case.
+        reranker_success = ParsedResponse(
+            requests=[
+                ParsedRequest(
+                    raw_text="Sarah Smith",
+                    request_type=RequestType.BUNK_WITH,
+                    target_name="Sarah Smith",
+                    age_preference=None,
+                    source_field="share_bunk_with",
+                    source=RequestSource.FAMILY,
+                    confidence=0.9,
+                    csv_position=0,
+                    metadata={
+                        "ranked_selections": [
+                            {"person_id": 111, "confidence": 0.95},
+                        ],
+                    },
+                )
+            ],
+            confidence=0.9,
+            metadata={},
+        )
+
+        batch_processor = Mock()
+        batch_processor.batch_disambiguate = AsyncMock(return_value=[reranker_success])
+
+        service = Phase3DisambiguationService(
+            ai_provider=ai_provider,
+            context_builder=context_builder,
+            batch_processor=batch_processor,
+        )
+
+        # Mixed ParseResult: one Phase-2-resolved intent, one ambiguous intent
+        # that will be resolved via the reranker path.
+        resolved_candidate = _create_person(cm_id=111, first_name="Sarah", last_name="Smith")
+        ambiguous = _create_ambiguous_resolution(
+            candidates=[
+                resolved_candidate,
+                _create_person(cm_id=222, first_name="Sarah", last_name="Jones"),
+            ]
+        )
+        ambiguous.target_name = "Sarah Smith"
+
+        phase2_resolved = _create_resolution_result(
+            person=_create_person(cm_id=333, first_name="Liam", last_name="Garcia"),
+            confidence=0.95,
+            method="exact",
+        )
+
+        parse_result = _create_parse_result(
+            parsed_requests=[
+                _create_parsed_request(target_name="Liam Garcia"),
+                _create_parsed_request(target_name="Sarah Smith"),
+            ]
+        )
+
+        await service.batch_disambiguate([(parse_result, [phase2_resolved, ambiguous])])
+
+        stats = service.get_stats()
+
+        # Per orchestrator: every intent in a ParseResult with any unresolved
+        # has ran=True. So both intents here should be ran=True → total 2.
+        expected_ran_count = 2
+        stats_sum = (
+            stats["successfully_disambiguated"]
+            + stats["still_ambiguous"]
+            + stats["no_match"]
+            + stats["invalid_ai_output"]
+            + stats["failed"]
+        )
+        assert stats_sum == expected_ran_count, (
+            f"Stats sum ({stats_sum}) must equal count of trace ran=True rows ({expected_ran_count}). Stats: {stats}"
+        )
+
+        # Both intents end up resolved (Phase 2 win + reranker win).
+        assert stats["successfully_disambiguated"] == 2, (
+            f"Both intents are resolved (Phase 2 win + reranker win), "
+            f"expected successfully_disambiguated=2, got stats: {stats}"
+        )

--- a/tests/unit/sync/bunk_request_processor/services/test_phase3_disambiguation_service.py
+++ b/tests/unit/sync/bunk_request_processor/services/test_phase3_disambiguation_service.py
@@ -1497,3 +1497,207 @@ class TestPhase3StatsMatchTrace:
             f"Both intents are resolved (Phase 2 win + reranker win), "
             f"expected successfully_disambiguated=2, got stats: {stats}"
         )
+
+    @pytest.mark.asyncio
+    async def test_batch_processor_exception_increments_failed_and_preserves_sum(self):
+        """When batch_processor.batch_disambiguate raises, every intent in every
+        case that entered Phase 3 must be classified as `failed`, and the sum of
+        outcome buckets must still equal the count of trace rows with ran=True.
+
+        Regression pin for the exception path — guards against future refactors
+        that might reorder `_build_final_results` / `_update_stats` or drop the
+        per-case error propagation in the except block.
+        """
+        ai_provider = Mock()
+        context_builder = Mock()
+        context_builder.build_disambiguation_context.return_value = _create_mock_context()
+
+        batch_processor = Mock()
+        batch_processor.batch_disambiguate = AsyncMock(side_effect=RuntimeError("AI provider down"))
+
+        service = Phase3DisambiguationService(
+            ai_provider=ai_provider,
+            context_builder=context_builder,
+            batch_processor=batch_processor,
+        )
+
+        # Two ambiguous ParseResults, each with one ambiguous intent.
+        candidates_a = [
+            _create_person(cm_id=111, first_name="Sarah", last_name="Smith"),
+            _create_person(cm_id=222, first_name="Sarah", last_name="Jones"),
+        ]
+        candidates_b = [
+            _create_person(cm_id=333, first_name="Liam", last_name="Garcia"),
+            _create_person(cm_id=444, first_name="Liam", last_name="Chen"),
+        ]
+        ambiguous_a = _create_ambiguous_resolution(candidates=candidates_a)
+        ambiguous_b = _create_ambiguous_resolution(candidates=candidates_b)
+        parse_result_a = _create_parse_result()
+        parse_result_b = _create_parse_result()
+
+        await service.batch_disambiguate(
+            [
+                (parse_result_a, [ambiguous_a]),
+                (parse_result_b, [ambiguous_b]),
+            ]
+        )
+
+        stats = service.get_stats()
+
+        # Orchestrator trace: every intent in each ParseResult that entered
+        # Phase 3 has ran=True. Two ParseResults × one intent each = 2.
+        expected_ran_count = 2
+        stats_sum = (
+            stats["successfully_disambiguated"]
+            + stats["still_ambiguous"]
+            + stats["no_match"]
+            + stats["invalid_ai_output"]
+            + stats["failed"]
+        )
+        assert stats_sum == expected_ran_count, (
+            f"Stats sum ({stats_sum}) must equal count of trace ran=True rows ({expected_ran_count}). Stats: {stats}"
+        )
+        assert stats["failed"] == 2, (
+            f"Both intents should be classified as failed when the AI call raises, got stats: {stats}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_candidate_parse_result_counted_in_stats(self):
+        """A ParseResult whose only unresolved intent has zero candidates must
+        still be counted in `_stats`.
+
+        The orchestrator records ran=True for every intent in any ParseResult
+        with any unresolved intent (via `needs_phase3`, which doesn't check
+        candidates). If the service silently drops no-candidate ParseResults,
+        the stats sum undercounts vs. the trace.
+        """
+        ai_provider = Mock()
+        context_builder = Mock()
+        context_builder.build_disambiguation_context.return_value = _create_mock_context()
+
+        batch_processor = Mock()
+        # No candidates anywhere -> batch_processor should not be called, but
+        # AsyncMock keeps it safe if the implementation changes.
+        batch_processor.batch_disambiguate = AsyncMock(return_value=[])
+
+        service = Phase3DisambiguationService(
+            ai_provider=ai_provider,
+            context_builder=context_builder,
+            batch_processor=batch_processor,
+        )
+
+        # A ParseResult with one unresolved intent and zero candidates
+        # (e.g. name not found in CampMinder at all).
+        no_candidate_rr = _create_resolution_result(
+            person=None,
+            confidence=0.0,
+            method="no_match",
+            candidates=[],
+        )
+        parse_result = _create_parse_result()
+
+        await service.batch_disambiguate([(parse_result, [no_candidate_rr])])
+
+        stats = service.get_stats()
+
+        # Orchestrator trace: the single intent has ran=True.
+        expected_ran_count = 1
+        stats_sum = (
+            stats["successfully_disambiguated"]
+            + stats["still_ambiguous"]
+            + stats["no_match"]
+            + stats["invalid_ai_output"]
+            + stats["failed"]
+        )
+        assert stats_sum == expected_ran_count, (
+            f"Stats sum ({stats_sum}) must equal count of trace ran=True rows "
+            f"({expected_ran_count}). {expected_ran_count} rows in trace but only "
+            f"{stats_sum} in stats. Stats: {stats}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_candidate_mixed_with_ambiguous_case_all_counted(self):
+        """With a mix of no-candidate ParseResults and ambiguous ParseResults,
+        stats sum must still equal the count of trace rows with ran=True.
+        """
+        from bunking.sync.bunk_request_processor.integration.ai_types import ParsedResponse
+
+        ai_provider = Mock()
+        context_builder = Mock()
+        context_builder.build_disambiguation_context.return_value = _create_mock_context()
+
+        # Reranker success for the one ambiguous case the batch processor sees.
+        reranker_success = ParsedResponse(
+            requests=[
+                ParsedRequest(
+                    raw_text="Sarah Smith",
+                    request_type=RequestType.BUNK_WITH,
+                    target_name="Sarah Smith",
+                    age_preference=None,
+                    source_field="share_bunk_with",
+                    source=RequestSource.FAMILY,
+                    confidence=0.9,
+                    csv_position=0,
+                    metadata={
+                        "ranked_selections": [
+                            {"person_id": 111, "confidence": 0.95},
+                        ],
+                    },
+                )
+            ],
+            confidence=0.9,
+            metadata={},
+        )
+
+        batch_processor = Mock()
+        batch_processor.batch_disambiguate = AsyncMock(return_value=[reranker_success])
+
+        service = Phase3DisambiguationService(
+            ai_provider=ai_provider,
+            context_builder=context_builder,
+            batch_processor=batch_processor,
+        )
+
+        # Case 1: no candidates (unresolved, nothing to disambiguate).
+        no_candidate_rr = _create_resolution_result(
+            person=None,
+            confidence=0.0,
+            method="no_match",
+            candidates=[],
+        )
+        parse_result_nc = _create_parse_result()
+
+        # Case 2: an ambiguous case the reranker will resolve.
+        ambiguous_candidates = [
+            _create_person(cm_id=111, first_name="Sarah", last_name="Smith"),
+            _create_person(cm_id=222, first_name="Sarah", last_name="Jones"),
+        ]
+        ambiguous = _create_ambiguous_resolution(candidates=ambiguous_candidates)
+        ambiguous.target_name = "Sarah Smith"
+        parse_result_amb = _create_parse_result()
+
+        await service.batch_disambiguate(
+            [
+                (parse_result_nc, [no_candidate_rr]),
+                (parse_result_amb, [ambiguous]),
+            ]
+        )
+
+        stats = service.get_stats()
+
+        # Two intents total; both have ran=True in the trace.
+        expected_ran_count = 2
+        stats_sum = (
+            stats["successfully_disambiguated"]
+            + stats["still_ambiguous"]
+            + stats["no_match"]
+            + stats["invalid_ai_output"]
+            + stats["failed"]
+        )
+        assert stats_sum == expected_ran_count, (
+            f"Stats sum ({stats_sum}) must equal count of trace ran=True rows ({expected_ran_count}). Stats: {stats}"
+        )
+        # Reranker success on the ambiguous case.
+        assert stats["successfully_disambiguated"] == 1, stats
+        # No-candidate intent should land in no_match (nothing to match against).
+        assert stats["no_match"] == 1, stats


### PR DESCRIPTION
## Problem

`Phase3DisambiguationService._update_stats` reported heavily undercounted totals in the `Phase 3 complete: ...` log line — e.g., a production run logged

```
Phase 3 complete: 20 disambiguated, 0 still ambiguous, 83 no match, 66 invalid AI output, 0 failed
```

(sum = 169), while `debug_pipeline_traces.phase3_disambiguation[].result` recorded 242 resolved / 93 still_ambiguous / 83 no_match / 66 invalid_ai_output (484). `disambiguated` (20 vs 242) and `still_ambiguous` (0 vs 93) were dramatically off.

## Root cause

The old `_update_stats` iterated only `case.disambiguation_indices` — the intents that actually needed Phase 3 disambiguation. But the orchestrator records a Phase 3 trace row per **intent**, with `ran=True` for **every** intent in a ParseResult that had *any* unresolved intent. Phase-2-resolved intents riding along in a Phase 3 ParseResult were counted by the trace as `result="resolved"` but never entered the stats counter loop.

The reranker path (`_try_reranker_path`, lines 305–378) itself was already writing `case.disambiguated_results[ambiguous_idx]` correctly — the undercount wasn't actually a reranker vs. legacy path issue, it was a resolution-indices-vs-all-intents mismatch. Either way, the trace is the source of truth the user sees, so the stats must mirror it.

## Fix (Option 2 from the issue)

Rewrite `_update_stats` to iterate every `resolution_result` in every case and classify each intent the same way the trace computes its `result` field:

- `rr.is_resolved` -> `successfully_disambiguated`
- `disambiguation_status == "no_match"` -> `no_match`
- `disambiguation_status == "invalid_ai_output"` -> `invalid_ai_output`
- `disambiguation_status == "failed"` -> `failed`
- otherwise -> `still_ambiguous`

`total_processed` now equals the count of trace rows with `ran=True` (= total intents in all cases that entered Phase 3).

## Tests (TDD)

Added `TestPhase3StatsMatchTrace` in `test_phase3_disambiguation_service.py`:

1. `test_reranker_resolved_case_counted_in_successfully_disambiguated` — a `ParsedResponse` with `ranked_selections` drives the reranker path to a successful pick; asserts `successfully_disambiguated == 1`.
2. `test_stats_sum_equals_trace_ran_rows` — mixed ParseResult with a Phase-2 win + an ambiguous intent resolved via the reranker; asserts stats sum equals the 2 trace rows that would be `ran=True`, and that both are counted as `successfully_disambiguated`.

Verified failing first on the old implementation, passing after the fix. All 1734 tests in `tests/unit/sync/bunk_request_processor/` pass.

Closes #942