### PR TITLE
feat(api): add top-level OBR->BR reconciliation summary log (#943)

### DIFF
--- a/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
@@ -75,6 +75,7 @@ from ..social.adapters import SocialGraphSignalsAdapter
 from ..social.social_graph import SocialGraph
 from ..validation.request_type_validator import validate_request_type_for_field
 from ..validation.rules.self_reference import SelfReferenceRule
+from .reconciliation import log_obr_reconciliation
 
 logger = get_logger(__name__)
 
@@ -281,7 +282,15 @@ class RequestOrchestrator:
             "duplicates_removed": 0,
             "reciprocal_pairs": 0,
             "no_preference_skipped": 0,
+            "no_preference_only": 0,  # #943: subset of no_preference_skipped from BUNK_WITH only
+            "na_only": 0,  # #943: "N/A" sole-content rows (distinct from na_prefix_stripped)
             "na_prefix_stripped": 0,
+            # #943: top-level OBR -> BR reconciliation counters
+            "obr_input": 0,
+            "skipped_empty_field": 0,
+            "ai_parse_requests": 0,
+            "direct_mapped": 0,
+            "pre_dedup_requests": 0,
             "hallucination_rejected": 0,
             "unit_name_rejected": 0,
             "status_resolved": 0,
@@ -946,6 +955,9 @@ class RequestOrchestrator:
             Processing results with statistics
         """
         logger.info(f"Starting three-phase processing for {len(raw_requests)} requests")
+
+        # #943: capture OBR input count for the end-of-pipeline reconciliation log
+        self._stats["obr_input"] = len(raw_requests)
 
         # First pass: detect staff names from all records BEFORE processing
         # This builds a global set for filtering during resolution
@@ -1660,6 +1672,10 @@ class RequestOrchestrator:
                 f"manual_review={self._stats['ai_manual_review']}"
             )
 
+        # #943: emit a single top-level OBR -> BR reconciliation line so the
+        # full pipeline math is verifiable from the log alone.
+        log_obr_reconciliation(self._stats)
+
         # Log cache statistics if monitor is available
         if self.cache_monitor:
             self.cache_monitor.log_statistics()
@@ -1794,6 +1810,7 @@ class RequestOrchestrator:
                     # Check for "no preference" indicators before processing
                     if self._is_no_preference(request_text):
                         self._stats["no_preference_skipped"] += 1
+                        self._stats["no_preference_only"] += 1  # #943: split out NA-only
                         if trace_key:
                             self.trace_collector.record_pre_phase1(
                                 key=trace_key,
@@ -1819,6 +1836,7 @@ class RequestOrchestrator:
                     elif re.match(r"^n/?a[\s\W]*$", request_text, re.IGNORECASE):
                         # N/A with only punctuation/whitespace after (e.g., "N/A -", "NA.")
                         self._stats["no_preference_skipped"] += 1
+                        self._stats["na_only"] += 1  # #943: split out from no_preference
                         if trace_key:
                             self.trace_collector.record_pre_phase1(
                                 key=trace_key,
@@ -1998,6 +2016,11 @@ class RequestOrchestrator:
             f"parse_requests={len(parse_requests)}, "
             f"pre_parsed={len(pre_parsed_results)}"
         )
+
+        # #943: capture top-level reconciliation counters for the end-of-pipeline log
+        self._stats["skipped_empty_field"] = skipped_no_text
+        self._stats["ai_parse_requests"] = len(parse_requests)
+        self._stats["direct_mapped"] = len(pre_parsed_results)
 
         return parse_requests, pre_parsed_results
 
@@ -2184,6 +2207,9 @@ class RequestOrchestrator:
         """
         # Build BunkRequest objects using the request builder
         pending_requests = self.request_builder.build_requests(resolved_requests)
+
+        # #943: capture pre-dedup count for the end-of-pipeline reconciliation log
+        self._stats["pre_dedup_requests"] = len(pending_requests)
 
         # Apply validation pipeline to all requests
         deduped_keys: set[tuple[int, int | None, str]] = set()

--- a/bunking/sync/bunk_request_processor/orchestrator/reconciliation.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/reconciliation.py
@@ -54,7 +54,7 @@ def format_obr_reconciliation(stats: dict[str, Any]) -> str:
         Single-line string prefixed with "OBR reconciliation:" and sectioned
         by "|" separators so it survives grep/tail on a single log line.
     """
-    s = {k: int(stats.get(k, 0) or 0) for k in _RECONCILIATION_KEYS}
+    s = {k: stats.get(k, 0) for k in _RECONCILIATION_KEYS}
 
     return (
         f"OBR reconciliation: {s['obr_input']} input"

--- a/bunking/sync/bunk_request_processor/orchestrator/reconciliation.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/reconciliation.py
@@ -1,0 +1,80 @@
+"""Top-level OBR->BR pipeline reconciliation summary (issue #943).
+
+Emits a single INFO line at the end of the pipeline so operators can verify
+the full math - how many original_bunk_requests went in, where they were
+filtered out, and how many bunk_requests came out - without querying
+`debug_pipeline_traces` in SQL.
+
+The line is additive: it supplements (does not replace) the existing
+"Processing complete:" summary and per-phase reconciliation logs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bunking.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+# Keys consumed by the formatter. All default to 0 if absent from the stats
+# dict, so the call can never crash the pipeline on a missing counter.
+_RECONCILIATION_KEYS = (
+    "obr_input",
+    "skipped_empty_field",
+    "no_preference_only",
+    "na_only",
+    "ai_parse_requests",
+    "phase1_successful",
+    "phase1_failed",
+    "direct_mapped",
+    "pre_dedup_requests",
+    "duplicates_removed",
+    "self_referential_filtered",
+    "requests_created",
+    "status_resolved",
+    "status_pending",
+    "status_declined",
+)
+
+
+def format_obr_reconciliation(stats: dict[str, Any]) -> str:
+    """Build the reconciliation log line from pipeline stats.
+
+    Pure function (no side effects) to keep it trivially unit-testable.
+    Missing keys are treated as 0 so the formatter is safe to call even when
+    a phase is skipped.
+
+    Args:
+        stats: Orchestrator `_stats`-shaped dict. See `_RECONCILIATION_KEYS`
+            for the counters consumed.
+
+    Returns:
+        Single-line string prefixed with "OBR reconciliation:" and sectioned
+        by "|" separators so it survives grep/tail on a single log line.
+    """
+    s = {k: int(stats.get(k, 0) or 0) for k in _RECONCILIATION_KEYS}
+
+    return (
+        f"OBR reconciliation: {s['obr_input']} input"
+        f" | {s['skipped_empty_field']} empty-field"
+        f" + {s['no_preference_only']} no-preference"
+        f" + {s['na_only']} NA-only skipped (pre-phase1)"
+        f" | {s['ai_parse_requests']} AI-parsed"
+        f" ({s['phase1_successful']} success,"
+        f" {s['phase1_failed']} permanent parse failures)"
+        f" + {s['direct_mapped']} direct-mapped"
+        f" | {s['pre_dedup_requests']} pre-dedup requests"
+        f" -> {s['duplicates_removed']} dedup"
+        f" + {s['self_referential_filtered']} self-referential kept for review"
+        f" | {s['requests_created']} BRs created"
+        f" ({s['status_resolved']} resolved"
+        f" / {s['status_pending']} pending"
+        f" / {s['status_declined']} declined)"
+    )
+
+
+def log_obr_reconciliation(stats: dict[str, Any]) -> None:
+    """Emit the reconciliation line at INFO level."""
+    logger.info(format_obr_reconciliation(stats))

--- a/tests/unit/sync/bunk_request_processor/orchestrator/test_obr_reconciliation_log.py
+++ b/tests/unit/sync/bunk_request_processor/orchestrator/test_obr_reconciliation_log.py
@@ -1,0 +1,126 @@
+"""Test top-level OBR->BR reconciliation summary log (issue #943).
+
+TDD Red Phase: Verifies the reconciliation formatter produces a single log
+line that allows an operator to reconcile the math from the log alone
+without opening `debug_pipeline_traces`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from bunking.sync.bunk_request_processor.orchestrator.reconciliation import (
+    format_obr_reconciliation,
+    log_obr_reconciliation,
+)
+
+
+class TestFormatObrReconciliation:
+    """The pure formatter produces a predictable, grep-able reconciliation line."""
+
+    def test_format_matches_proposed_shape_from_issue_943(self) -> None:
+        """Counts from the issue body must render exactly as specified."""
+        stats = {
+            "obr_input": 1610,
+            "skipped_empty_field": 3430,
+            "no_preference_only": 57,
+            "na_only": 1,
+            "ai_parse_requests": 1016,
+            "phase1_successful": 948,
+            "phase1_failed": 68,
+            "direct_mapped": 537,
+            "pre_dedup_requests": 2397,
+            "duplicates_removed": 94,
+            "self_referential_filtered": 3,
+            "requests_created": 2303,
+            "status_resolved": 1909,
+            "status_pending": 242,
+            "status_declined": 152,
+        }
+
+        line = format_obr_reconciliation(stats)
+
+        expected = (
+            "OBR reconciliation: 1610 input"
+            " | 3430 empty-field + 57 no-preference + 1 NA-only skipped (pre-phase1)"
+            " | 1016 AI-parsed (948 success, 68 permanent parse failures) + 537 direct-mapped"
+            " | 2397 pre-dedup requests -> 94 dedup + 3 self-referential kept for review"
+            " | 2303 BRs created (1909 resolved / 242 pending / 152 declined)"
+        )
+        assert line == expected
+
+    def test_format_handles_zeros_cleanly(self) -> None:
+        """All-zeros stats still render without crashing (first-run / dry-run case)."""
+        stats = dict.fromkeys(
+            (
+                "obr_input",
+                "skipped_empty_field",
+                "no_preference_only",
+                "na_only",
+                "ai_parse_requests",
+                "phase1_successful",
+                "phase1_failed",
+                "direct_mapped",
+                "pre_dedup_requests",
+                "duplicates_removed",
+                "self_referential_filtered",
+                "requests_created",
+                "status_resolved",
+                "status_pending",
+                "status_declined",
+            ),
+            0,
+        )
+
+        line = format_obr_reconciliation(stats)
+
+        assert line.startswith("OBR reconciliation: 0 input")
+        assert "0 BRs created (0 resolved / 0 pending / 0 declined)" in line
+
+    def test_format_tolerates_missing_keys_as_zero(self) -> None:
+        """Missing keys default to 0 so the log line can never crash the pipeline."""
+        # Only provide the bare minimum
+        stats = {"obr_input": 5, "requests_created": 2}
+
+        line = format_obr_reconciliation(stats)
+
+        assert "5 input" in line
+        assert "2 BRs created" in line
+        # Unspecified counts render as 0
+        assert "0 empty-field" in line
+
+
+class TestLogObrReconciliation:
+    """The log emitter writes a single INFO line prefixed with the reconciliation tag."""
+
+    def test_emits_single_info_log_line(self, caplog: pytest.LogCaptureFixture) -> None:
+        stats = {
+            "obr_input": 1610,
+            "skipped_empty_field": 3430,
+            "no_preference_only": 57,
+            "na_only": 1,
+            "ai_parse_requests": 1016,
+            "phase1_successful": 948,
+            "phase1_failed": 68,
+            "direct_mapped": 537,
+            "pre_dedup_requests": 2397,
+            "duplicates_removed": 94,
+            "self_referential_filtered": 3,
+            "requests_created": 2303,
+            "status_resolved": 1909,
+            "status_pending": 242,
+            "status_declined": 152,
+        }
+
+        with caplog.at_level(logging.INFO, logger="bunking.sync.bunk_request_processor.orchestrator.reconciliation"):
+            log_obr_reconciliation(stats)
+
+        reconciliation_logs = [r for r in caplog.records if r.message.startswith("OBR reconciliation:")]
+        assert len(reconciliation_logs) == 1, (
+            f"Expected exactly 1 reconciliation log line, got {len(reconciliation_logs)}"
+        )
+        assert reconciliation_logs[0].levelno == logging.INFO
+        assert "1610 input" in reconciliation_logs[0].message
+        assert "2303 BRs created" in reconciliation_logs[0].message


### PR DESCRIPTION
## Summary

Adds a single INFO log line at the end of the OBR->BR pipeline so operators can verify the full math from the log alone, without running SQL against `debug_pipeline_traces`.

## Problem (from #943)

The existing "Processing complete" log uses AI-only denominators, making it impossible to explain e.g. `1610 OBRs input -> 2303 BRs output`. The missing counts (empty-field skips, no-preference, NA-only, direct-mapped, pre-dedup, self-referential kept) are only visible in `debug_pipeline_traces`.

## Format shipped

Single greppable line (sections separated by `|`):

```
OBR reconciliation: 1610 input | 3430 empty-field + 57 no-preference + 1 NA-only skipped (pre-phase1) | 1016 AI-parsed (948 success, 68 permanent parse failures) + 537 direct-mapped | 2397 pre-dedup requests -> 94 dedup + 3 self-referential kept for review | 2303 BRs created (1909 resolved / 242 pending / 152 declined)
```

### Deviations from the issue's proposed format

- Single-line joined with ` | ` separators (not 5 visually-wrapped lines) so it survives `grep`/`tail`/log collectors as one record. All sections and counts from the proposal are preserved.
- Arrows use ASCII `->` instead of `→` so the log stays ASCII-safe for log shippers.

## Implementation

- **New pure formatter** `format_obr_reconciliation(stats)` in `bunking/sync/bunk_request_processor/orchestrator/reconciliation.py`. Trivially unit-testable; missing keys default to 0 so the formatter can never crash the pipeline.
- **`log_obr_reconciliation(stats)`** called once at the end of `_execute_pipeline` after the existing "Processing complete" / "Status breakdown" / "Type breakdown" / "AI quality" logs. Existing logs are untouched.
- **New `_stats` counters** populated where the data naturally flows:
  - `obr_input` - set at orchestrator entry (`len(raw_requests)`)
  - `skipped_empty_field`, `ai_parse_requests`, `direct_mapped` - set at end of `_prepare_parse_requests`
  - `pre_dedup_requests` - set before the validation pipeline
  - `no_preference_only` + `na_only` - new split of the old merged `no_preference_skipped` counter, preserving the existing field for back-compat

## Test plan

- [x] Unit tests for the pure formatter (exact match against issue's proposed counts, zeros, missing keys)
- [x] Unit test for the log emitter (single INFO line at the right level)
- [x] TDD: tests written first, verified failing (`ModuleNotFoundError`), then implemented to green
- [x] Full processor test suite: 1736 passed, 1 skipped (no regressions)
- [x] `ruff format`, `ruff check`, `mypy` all clean on touched paths
- [x] Pre-push hooks (`ruff-check`, `mypy`, `go-build`, `shellcheck`, `pb-js-lint`, `type-check`) all green

Closes #943

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>