### PR TITLE
refactor(api): remove dead legacy selected_person_id field (#944)

### DIFF
--- a/bunking/sync/bunk_request_processor/integration/ai_schemas.py
+++ b/bunking/sync/bunk_request_processor/integration/ai_schemas.py
@@ -162,9 +162,6 @@ class AIDisambiguationResponse(BaseModel):
     no_match_reason: str = ""
     """Explanation for no_match."""
 
-    selected_person_id: int | None = None
-    """Legacy: AI's selected person ID. Superseded by ranked_selections."""
-
     confidence: float = Field(default=0.0, ge=0.0, le=1.0)
     """Confidence in the selection (0.0 to 1.0)."""
 
@@ -173,13 +170,7 @@ class AIDisambiguationResponse(BaseModel):
 
     @model_validator(mode="after")
     def normalize_exclusive_fields(self) -> AIDisambiguationResponse:
-        """Reconcile ranked_selections with legacy fields; see #925."""
-        if self.ranked_selections:
-            if self.no_match:
-                raise ValueError("ranked_selections and no_match=True are mutually exclusive")
-            if self.selected_person_id is not None:
-                raise ValueError("ranked_selections and selected_person_id are mutually exclusive")
-            return self
-        if self.no_match and self.selected_person_id is not None:
-            raise ValueError("no_match=True and selected_person_id are mutually exclusive")
+        """ranked_selections and no_match are mutually exclusive terminal states."""
+        if self.ranked_selections and self.no_match:
+            raise ValueError("ranked_selections and no_match=True are mutually exclusive")
         return self

--- a/bunking/sync/bunk_request_processor/integration/openai_provider.py
+++ b/bunking/sync/bunk_request_processor/integration/openai_provider.py
@@ -548,7 +548,6 @@ class OpenAIProvider(AIProvider):
 
             # Update parsed request with disambiguation result
             if isinstance(response, AIDisambiguationResponse):
-                # New ranked path
                 if response.ranked_selections:
                     parsed_request.metadata["ranked_selections"] = [c.model_dump() for c in response.ranked_selections]
                     # Use top pick for backward compat fields
@@ -561,15 +560,9 @@ class OpenAIProvider(AIProvider):
                     parsed_request.metadata["no_match"] = True
                     parsed_request.metadata["no_match_reason"] = response.no_match_reason
                     parsed_request.confidence = 0.0
-                elif response.selected_person_id:
-                    # Legacy single-selection fallback
-                    parsed_request.metadata["target_person_id"] = response.selected_person_id
-                    parsed_request.confidence = response.confidence
-                    parsed_request.metadata["disambiguation_method"] = "ai_phase3"
-                    parsed_request.metadata["disambiguation_reasoning"] = response.reasoning
                 else:
                     logger.debug(
-                        f"Disambiguation response had no ranked_selections, no_match, or selected_person_id "
+                        f"Disambiguation response had no ranked_selections or no_match "
                         f"for target '{parsed_request.target_name}'"
                     )
 

--- a/bunking/sync/bunk_request_processor/services/phase3_disambiguation_service.py
+++ b/bunking/sync/bunk_request_processor/services/phase3_disambiguation_service.py
@@ -248,8 +248,7 @@ class Phase3DisambiguationService:
           1. Validates non-empty result (else records "No result from AI")
           2. Tries the JW re-ranker path for ParsedResponse metadata signals
              (ranked_selections or no_match); short-circuits if handled
-          3. Extracts canonical (selected_id, confidence, reason) fields
-          4. Applies legacy selected_person_id validation & recording
+          3. Otherwise records invalid_ai_output status
         """
         for idx, result in enumerate(results):
             if idx not in case_mapping:
@@ -267,10 +266,8 @@ class Phase3DisambiguationService:
                 if self._try_reranker_path(case, ambiguous_idx, resolution, result):
                     continue
 
-                selected_person_id, ai_confidence, ai_reason = self._extract_ai_result_fields(result)
-                self._apply_legacy_selection(
-                    case, ambiguous_idx, resolution, result, selected_person_id, ai_confidence, ai_reason
-                )
+                # AI returned no ranked_selections and no no_match signal — unparseable output.
+                self._record_invalid_ai_output(case, ambiguous_idx, resolution, result)
 
             except Exception as e:
                 req_info = (
@@ -283,34 +280,6 @@ class Phase3DisambiguationService:
                 )
                 self._set_meta(case, "errors", dict[int, str]())[ambiguous_idx] = str(e)
 
-    def _extract_ai_result_fields(self, result: Any) -> tuple[int | None, float, str | None]:
-        """Unwrap an AI result into canonical (selected_person_id, ai_confidence, ai_reason).
-
-        ParsedResponse: reads target_person_id / reason from result.requests[0].metadata
-        and takes confidence from the response itself.
-        Legacy AIDisambiguationResponse: reads selected_person_id / confidence / reason
-        attributes directly.
-        Unknown shapes: returns (None, 0.8, None).
-        """
-        selected_person_id: int | None = None
-        ai_confidence: float = 0.8
-        ai_reason: str | None = None
-
-        if isinstance(result, ParsedResponse):
-            ai_confidence = result.confidence
-            if result.requests:
-                req_metadata = result.requests[0].metadata or {}
-                selected_person_id = req_metadata.get("target_person_id")
-                ai_reason = req_metadata.get("reason")
-        elif hasattr(result, "selected_person_id"):
-            selected_person_id = result.selected_person_id
-            ai_confidence = getattr(result, "confidence", 0.8)
-            ai_reason = getattr(result, "reason", None)
-        elif result:
-            logger.warning(f"Phase 3 unexpected result type: {type(result).__name__}")
-
-        return selected_person_id, ai_confidence, ai_reason
-
     def _try_reranker_path(
         self,
         case: DisambiguationCase,
@@ -321,7 +290,7 @@ class Phase3DisambiguationService:
         """Handle ParsedResponse metadata signals (ranked_selections / no_match).
 
         Returns True iff the result was fully handled (success or no_match recorded)
-        and the caller should skip the legacy selected_person_id path.
+        and the caller should skip the invalid_ai_output fallback.
         """
         if not isinstance(result, ParsedResponse) or not result.requests:
             return False
@@ -386,76 +355,24 @@ class Phase3DisambiguationService:
 
         return False
 
-    def _apply_legacy_selection(
+    def _record_invalid_ai_output(
         self,
         case: DisambiguationCase,
         ambiguous_idx: int,
         resolution: ResolutionResult,
         result: Any,
-        selected_person_id: int | None,
-        ai_confidence: float,
-        ai_reason: str | None,
     ) -> None:
-        """Apply the legacy selected_person_id path.
+        """Record invalid_ai_output status when AI returns no actionable signal.
 
-        Validates that the AI-selected person exists in the resolution's candidate
-        list, and records one of: success / no_match (unknown id or legacy
-        `no_match` attr) / invalid_ai_output (no selection, no no_match signal).
+        Reached when `_try_reranker_path` returned False — i.e. the AI produced
+        neither `ranked_selections` nor `no_match`. Treat as unparseable output.
         """
-        if selected_person_id:
-            # AI selected a specific person — find them in candidates
-            selected_person = None
-            if resolution.candidates:
-                for candidate in resolution.candidates[:10]:  # Top 10
-                    if candidate.cm_id == selected_person_id:
-                        selected_person = candidate
-                        break
-
-            if selected_person:
-                # Create disambiguated result
-                num_candidates = len(resolution.candidates or [])
-                result_metadata: dict[str, Any] = {
-                    "ai_confidence": ai_confidence,
-                    "disambiguation_reason": ai_reason,
-                    "original_method": resolution.method,
-                    "candidates_considered": num_candidates,
-                }
-                case.disambiguated_results[ambiguous_idx] = ResolutionResult(
-                    person=selected_person,
-                    confidence=ai_confidence,
-                    method="ai_disambiguation",
-                    candidates=(resolution.candidates or [])[:10],
-                    metadata=result_metadata,
-                )
-                self._set_meta(case, "status", dict[int, str]())[ambiguous_idx] = "success"
-                logger.debug(
-                    f"Phase 3 disambiguated '{resolution.target_name}' → "
-                    f"{selected_person.first_name} {selected_person.last_name} "
-                    f"(cm_id={selected_person_id}, confidence={ai_confidence:.2f})"
-                )
-            else:
-                # AI selected unknown person (not in candidates)
-                self._set_meta(case, "status", dict[int, str]())[ambiguous_idx] = "no_match"
-                self._set_meta(case, "selected_ids", dict[int, int]())[ambiguous_idx] = selected_person_id
-                logger.debug(
-                    f"Phase 3 no match for '{resolution.target_name}' — "
-                    f"AI selected cm_id={selected_person_id} not in candidates"
-                )
-
-        elif getattr(result, "no_match", False):
-            # AI explicitly said no match (legacy path)
-            self._set_meta(case, "status", dict[int, str]())[ambiguous_idx] = "no_match"
-            self._set_meta(case, "reasons", dict[int, str]())[ambiguous_idx] = getattr(
-                result, "reason", "No suitable match"
-            )
-
-        else:
-            # No selection and no legacy no_match flag — AI output was invalid/unparseable
-            self._set_meta(case, "status", dict[int, str]())[ambiguous_idx] = "invalid_ai_output"
-            self._set_meta(case, "reasons", dict[int, str]())[ambiguous_idx] = ai_reason or "No suitable match"
-            logger.debug(
-                f"Phase 3 invalid AI output for '{resolution.target_name}' — {ai_reason or 'AI returned no selection'}"
-            )
+        self._set_meta(case, "status", dict[int, str]())[ambiguous_idx] = "invalid_ai_output"
+        self._set_meta(case, "reasons", dict[int, str]())[ambiguous_idx] = "No suitable match"
+        logger.debug(
+            f"Phase 3 invalid AI output for '{resolution.target_name}' — "
+            f"AI returned no ranked_selections or no_match (result type: {type(result).__name__})"
+        )
 
     def _build_final_results(
         self,

--- a/tests/unit/sync/bunk_request_processor/integration/test_ai_schemas.py
+++ b/tests/unit/sync/bunk_request_processor/integration/test_ai_schemas.py
@@ -82,11 +82,13 @@ class TestSourceFragmentMaxLength:
 
 
 class TestAIDisambiguationResponseValidator:
-    """The validator should normalize (not reject) when ranked_selections is populated
-    alongside the default values for legacy fields (no_match=False, selected_person_id=None).
+    """The validator should normalize (not reject) when ranked_selections is populated.
+
+    After #944, `selected_person_id` has been removed from the schema; ranked_selections
+    is the canonical path, with no_match as the alternative terminal state.
     """
 
-    def test_ranked_selections_with_default_legacy_fields_is_accepted(self) -> None:
+    def test_ranked_selections_with_default_fields_is_accepted(self) -> None:
         # Regression for #925.
         response = AIDisambiguationResponse(
             ranked_selections=[
@@ -96,7 +98,6 @@ class TestAIDisambiguationResponseValidator:
         )
         assert len(response.ranked_selections) == 2
         assert response.no_match is False
-        assert response.selected_person_id is None
 
     def test_ranked_selections_with_explicit_no_match_true_raises(self) -> None:
         with pytest.raises(ValidationError):
@@ -105,31 +106,16 @@ class TestAIDisambiguationResponseValidator:
                 no_match=True,
             )
 
-    def test_ranked_selections_with_explicit_selected_person_id_raises(self) -> None:
-        with pytest.raises(ValidationError):
-            AIDisambiguationResponse(
-                ranked_selections=[AIDisambiguationCandidate(person_id=111)],
-                selected_person_id=222,
-            )
-
-    def test_legacy_path_selected_person_id_only_still_works(self) -> None:
-        response = AIDisambiguationResponse(selected_person_id=333, confidence=0.8)
-        assert response.selected_person_id == 333
-        assert response.ranked_selections == []
-        assert response.no_match is False
-
     def test_no_match_only_still_works(self) -> None:
         response = AIDisambiguationResponse(no_match=True, no_match_reason="no plausible match")
         assert response.no_match is True
-        assert response.selected_person_id is None
         assert response.ranked_selections == []
-
-    def test_no_match_true_with_selected_person_id_raises(self) -> None:
-        with pytest.raises(ValidationError):
-            AIDisambiguationResponse(no_match=True, selected_person_id=444)
 
     def test_empty_response_all_defaults_is_accepted(self) -> None:
         response = AIDisambiguationResponse()
         assert response.ranked_selections == []
         assert response.no_match is False
-        assert response.selected_person_id is None
+
+    def test_schema_has_no_selected_person_id_field(self) -> None:
+        """#944: selected_person_id was removed from the schema as dead legacy."""
+        assert "selected_person_id" not in AIDisambiguationResponse.model_fields

--- a/tests/unit/sync/bunk_request_processor/integration/test_batch_processor_disambiguate.py
+++ b/tests/unit/sync/bunk_request_processor/integration/test_batch_processor_disambiguate.py
@@ -54,7 +54,7 @@ class TestBatchProcessorDisambiguate:
     async def test_disambiguate_calls_disambiguate_not_parse_request(self):
         """batch_disambiguate must call ai_provider.disambiguate(), not parse_request()."""
         mock_response = MagicMock()
-        mock_response.selected_person_id = 12345
+        mock_response.ranked_selections = []
         mock_response.confidence = 0.8
         mock_response.reasoning = "Best match"
 
@@ -88,7 +88,8 @@ class TestBatchProcessorDisambiguate:
     async def test_disambiguate_does_not_crash_on_real_context(self):
         """Regression: old code converted AIRequestContext to dict, causing AttributeError."""
         mock_response = MagicMock()
-        mock_response.selected_person_id = None
+        mock_response.ranked_selections = []
+        mock_response.no_match = True
         mock_response.confidence = 0.0
         mock_response.reasoning = "No match"
 

--- a/tests/unit/sync/bunk_request_processor/integration/test_sdk_ai_provider.py
+++ b/tests/unit/sync/bunk_request_processor/integration/test_sdk_ai_provider.py
@@ -97,7 +97,6 @@ class TestAISchemas:
         """Disambiguation confidence must be between 0 and 1."""
         # Valid
         response = AIDisambiguationResponse(
-            selected_person_id=12345,
             confidence=0.85,
             reasoning="High confidence match",
         )
@@ -348,9 +347,9 @@ class TestReasoningEffort:
 
         mock_openai_client.responses.parse.return_value = self._mock_response(
             AIDisambiguationResponse(
-                selected_person_id=999,
-                confidence=0.9,
-                reasoning="Strong match",
+                ranked_selections=[
+                    AIDisambiguationCandidate(person_id=999, confidence=0.9, reasoning="Strong match"),
+                ],
             )
         )
 
@@ -516,9 +515,9 @@ class TestReasoningOutputParsing:
         reasoning_item = MagicMock(spec=[])
 
         mock_parsed = AIDisambiguationResponse(
-            selected_person_id=999,
-            confidence=0.9,
-            reasoning="Strong match",
+            ranked_selections=[
+                AIDisambiguationCandidate(person_id=999, confidence=0.9, reasoning="Strong match"),
+            ],
         )
         mock_text = MagicMock()
         mock_text.parsed = mock_parsed
@@ -643,9 +642,9 @@ class TestReasoningOutputParsing:
         reasoning_item.summary = [reasoning_summary]
 
         mock_parsed = AIDisambiguationResponse(
-            selected_person_id=999,
-            confidence=0.9,
-            reasoning="Same school",
+            ranked_selections=[
+                AIDisambiguationCandidate(person_id=999, confidence=0.9, reasoning="Same school"),
+            ],
         )
         mock_text = MagicMock()
         mock_text.parsed = mock_parsed
@@ -792,23 +791,8 @@ class TestAIDisambiguationRankedSchema:
         assert response.ranked_selections == []
         assert response.no_match is False
         assert response.no_match_reason == ""
-        assert response.selected_person_id is None
         assert response.confidence == 0.0
         assert response.reasoning == ""
-
-    def test_backward_compat_selected_person_id(self):
-        """Legacy selected_person_id / confidence / reasoning fields still work."""
-        response = AIDisambiguationResponse(
-            selected_person_id=5555,
-            confidence=0.75,
-            reasoning="Legacy single selection",
-        )
-        assert response.selected_person_id == 5555
-        assert response.confidence == 0.75
-        assert response.reasoning == "Legacy single selection"
-        # New fields default correctly
-        assert response.ranked_selections == []
-        assert response.no_match is False
 
     def test_ranked_and_no_match_mutually_exclusive(self):
         """Cannot set ranked_selections AND no_match=True simultaneously."""
@@ -819,27 +803,6 @@ class TestAIDisambiguationRankedSchema:
                 ],
                 no_match=True,
                 no_match_reason="contradictory",
-            )
-
-    def test_ranked_and_selected_person_id_mutually_exclusive(self):
-        """Cannot set ranked_selections AND selected_person_id simultaneously."""
-        with pytest.raises(ValueError, match="mutually exclusive"):
-            AIDisambiguationResponse(
-                ranked_selections=[
-                    AIDisambiguationCandidate(person_id=1001, confidence=0.90, reasoning="test"),
-                ],
-                selected_person_id=1001,
-                confidence=0.90,
-            )
-
-    def test_no_match_and_selected_person_id_mutually_exclusive(self):
-        """Cannot set no_match=True AND selected_person_id simultaneously."""
-        with pytest.raises(ValueError, match="mutually exclusive"):
-            AIDisambiguationResponse(
-                no_match=True,
-                no_match_reason="no match",
-                selected_person_id=1001,
-                confidence=0.90,
             )
 
 

--- a/tests/unit/sync/bunk_request_processor/services/test_phase3_disambiguation_service.py
+++ b/tests/unit/sync/bunk_request_processor/services/test_phase3_disambiguation_service.py
@@ -156,6 +156,48 @@ def _create_ambiguous_resolution(
     )
 
 
+def _create_ranked_ai_response(
+    target_name: str = "Sarah Smith",
+    ranked: list[tuple[int, float]] | None = None,
+    no_match: bool = False,
+    no_match_reason: str = "",
+    confidence: float = 0.85,
+) -> Any:
+    """Create a ParsedResponse as if returned by openai_provider.disambiguate().
+
+    `ranked` is a list of (person_id, confidence) pairs that will be serialized
+    into metadata["ranked_selections"]. If `no_match` is True, writes no_match
+    metadata instead.
+    """
+    from bunking.sync.bunk_request_processor.integration.ai_types import ParsedResponse
+
+    metadata: dict[str, Any] = {}
+    if ranked:
+        metadata["ranked_selections"] = [{"person_id": pid, "confidence": c, "reasoning": ""} for pid, c in ranked]
+        metadata["target_person_id"] = ranked[0][0]
+    if no_match:
+        metadata["no_match"] = True
+        metadata["no_match_reason"] = no_match_reason
+
+    return ParsedResponse(
+        requests=[
+            ParsedRequest(
+                raw_text=f"bunk with {target_name}",
+                request_type=RequestType.BUNK_WITH,
+                target_name=target_name,
+                age_preference=None,
+                source_field="share_bunk_with",
+                source=RequestSource.FAMILY,
+                confidence=confidence,
+                csv_position=0,
+                metadata=metadata,
+            )
+        ],
+        confidence=confidence,
+        metadata={},
+    )
+
+
 class TestPhase3DisambiguationServiceInit:
     """Tests for Phase3DisambiguationService initialization"""
 
@@ -375,11 +417,8 @@ class TestPhase3DisambiguationServiceResultHandling:
 
         selected_person = _create_person(cm_id=111)
 
-        # AI returns a result selecting person 111
-        ai_result = Mock()
-        ai_result.selected_person_id = 111
-        ai_result.confidence = 0.85
-        ai_result.reason = "Best match based on context"
+        # AI returns a ranked_selections result picking person 111
+        ai_result = _create_ranked_ai_response(ranked=[(111, 0.85)], confidence=0.85)
 
         batch_processor = Mock()
         batch_processor.batch_disambiguate = AsyncMock(return_value=[ai_result])
@@ -412,11 +451,8 @@ class TestPhase3DisambiguationServiceResultHandling:
         context_builder = Mock()
         context_builder.build_disambiguation_context.return_value = _create_mock_context()
 
-        # AI returns no selection (no person selected, no explicit no_match)
-        ai_result = Mock()
-        ai_result.selected_person_id = None
-        ai_result.no_match = False
-        ai_result.reason = "Could not distinguish between candidates"
+        # AI returns ParsedResponse with no ranked_selections and no no_match
+        ai_result = _create_ranked_ai_response()
 
         batch_processor = Mock()
         batch_processor.batch_disambiguate = AsyncMock(return_value=[ai_result])
@@ -445,11 +481,10 @@ class TestPhase3DisambiguationServiceResultHandling:
         context_builder = Mock()
         context_builder.build_disambiguation_context.return_value = _create_mock_context()
 
-        # AI returns no_match
-        ai_result = Mock()
-        ai_result.selected_person_id = None
-        ai_result.no_match = True
-        ai_result.reason = "None of the candidates match the request"
+        # AI returns no_match in ParsedResponse metadata
+        ai_result = _create_ranked_ai_response(
+            no_match=True, no_match_reason="None of the candidates match the request"
+        )
 
         batch_processor = Mock()
         batch_processor.batch_disambiguate = AsyncMock(return_value=[ai_result])
@@ -538,17 +573,14 @@ class TestPhase3DisambiguationServiceConfidencePassthrough:
 
     @pytest.mark.asyncio
     async def test_ai_confidence_preserved(self):
-        """AI-reported confidence is used directly without rescoring."""
+        """AI-reported confidence flows through the reranker into the final resolution."""
         ai_provider = Mock()
         context_builder = Mock()
         context_builder.build_disambiguation_context.return_value = _create_mock_context()
 
         selected_person = _create_person(cm_id=111)
 
-        ai_result = Mock()
-        ai_result.selected_person_id = 111
-        ai_result.confidence = 0.85
-        ai_result.reason = "Best match"
+        ai_result = _create_ranked_ai_response(ranked=[(111, 0.85)], confidence=0.85)
 
         batch_processor = Mock()
         batch_processor.batch_disambiguate = AsyncMock(return_value=[ai_result])
@@ -566,8 +598,10 @@ class TestPhase3DisambiguationServiceConfidencePassthrough:
         results = await service.batch_disambiguate([(parse_result, [ambiguous])])
 
         _, resolution_list = results[0]
-        # Should use AI confidence (0.85 or 0.8 default)
-        assert resolution_list[0].confidence in [0.85, 0.8]
+        # Final confidence is the reranker output: min(ai_confidence, max(0.3, jw_score)).
+        # Verify the resolution carries the AI confidence through metadata.
+        assert resolution_list[0].metadata is not None
+        assert resolution_list[0].metadata["ai_confidence"] == pytest.approx(0.85)
 
 
 class TestPhase3DisambiguationServiceStatistics:
@@ -580,9 +614,7 @@ class TestPhase3DisambiguationServiceStatistics:
         context_builder = Mock()
         context_builder.build_disambiguation_context.return_value = _create_mock_context()
 
-        ai_result = Mock()
-        ai_result.selected_person_id = 111
-        ai_result.confidence = 0.85
+        ai_result = _create_ranked_ai_response(ranked=[(111, 0.85)], confidence=0.85)
 
         batch_processor = Mock()
         batch_processor.batch_disambiguate = AsyncMock(return_value=[ai_result])
@@ -613,16 +645,11 @@ class TestPhase3DisambiguationServiceStatistics:
         context_builder = Mock()
         context_builder.build_disambiguation_context.return_value = _create_mock_context()
 
-        # First result: success
-        success_result = Mock()
-        success_result.selected_person_id = 111
-        success_result.confidence = 0.85
+        # First result: success via ranked_selections
+        success_result = _create_ranked_ai_response(ranked=[(111, 0.85)], confidence=0.85)
 
-        # Second result: AI returned no selection and no no_match flag — invalid_ai_output
-        ambiguous_result = Mock()
-        ambiguous_result.selected_person_id = None
-        ambiguous_result.no_match = False
-        ambiguous_result.reason = "Could not decide"
+        # Second result: AI returned no ranked_selections and no no_match — invalid_ai_output
+        ambiguous_result = _create_ranked_ai_response()
 
         batch_processor = Mock()
         batch_processor.batch_disambiguate = AsyncMock(return_value=[success_result, ambiguous_result])
@@ -650,7 +677,7 @@ class TestPhase3DisambiguationServiceStatistics:
 
         stats = service.get_stats()
         assert stats["successfully_disambiguated"] == 1
-        # When AI returns no selected_person_id and no_match=False, it's counted as "invalid_ai_output"
+        # When AI returns no ranked_selections and no_match=False, it's counted as "invalid_ai_output"
         assert stats["invalid_ai_output"] == 1
         assert stats["failed"] == 0
 
@@ -768,38 +795,22 @@ class TestPhase3ReturnTypeUnwrapping:
     """Tests that Phase 3 correctly unwraps ParsedResponse objects from the AI provider.
 
     The AI provider's disambiguate() method returns ParsedResponse (not AIDisambiguationResponse).
-    The selected person ID is in result.requests[0].metadata["target_person_id"], not
-    result.selected_person_id. These tests verify the unwrapping logic.
+    Canonical path post #944: ranked_selections in result.requests[0].metadata.
     """
 
     @pytest.mark.asyncio
-    async def test_unwraps_parsed_response_with_target_person_id(self):
-        """ParsedResponse with target_person_id in metadata is correctly unwrapped to a successful disambiguation."""
-        from bunking.sync.bunk_request_processor.integration.ai_types import ParsedResponse
-
+    async def test_unwraps_parsed_response_with_ranked_selections(self):
+        """ParsedResponse with ranked_selections in metadata is resolved via reranker path."""
         ai_provider = Mock()
         context_builder = Mock()
         context_builder.build_disambiguation_context.return_value = _create_mock_context()
 
         selected_person = _create_person(cm_id=111, first_name="Sarah", last_name="Smith")
 
-        # Real ParsedResponse as returned by the AI provider
-        ai_result = ParsedResponse(
-            requests=[
-                ParsedRequest(
-                    raw_text="Sarah Smith",
-                    request_type=RequestType.BUNK_WITH,
-                    target_name="Sarah Smith",
-                    age_preference=None,
-                    source_field="share_bunk_with",
-                    source=RequestSource.FAMILY,
-                    confidence=0.9,
-                    csv_position=0,
-                    metadata={"target_person_id": 111},
-                )
-            ],
+        ai_result = _create_ranked_ai_response(
+            target_name="Sarah Smith",
+            ranked=[(111, 0.9), (222, 0.3)],
             confidence=0.9,
-            metadata={},
         )
 
         batch_processor = Mock()
@@ -818,7 +829,7 @@ class TestPhase3ReturnTypeUnwrapping:
         results = await service.batch_disambiguate([(parse_result, [ambiguous])])
 
         _, resolution_list = results[0]
-        assert resolution_list[0].is_resolved, "ParsedResponse with target_person_id should resolve successfully"
+        assert resolution_list[0].is_resolved, "ParsedResponse with ranked_selections should resolve successfully"
         assert resolution_list[0].person is not None
         assert resolution_list[0].person.cm_id == 111
         assert resolution_list[0].method == "ai_disambiguation"
@@ -875,30 +886,16 @@ class TestPhase3ReturnTypeUnwrapping:
 
     @pytest.mark.asyncio
     async def test_unwraps_parsed_response_unknown_person_id(self):
-        """ParsedResponse with target_person_id not in candidates results in no_match."""
-        from bunking.sync.bunk_request_processor.integration.ai_types import ParsedResponse
-
+        """ParsedResponse with ranked_selections whose ids aren't in candidates → rejected by reranker (no_match)."""
         ai_provider = Mock()
         context_builder = Mock()
         context_builder.build_disambiguation_context.return_value = _create_mock_context()
 
-        # AI selects person 999 which is NOT in the candidate list
-        ai_result = ParsedResponse(
-            requests=[
-                ParsedRequest(
-                    raw_text="Sarah Smith",
-                    request_type=RequestType.BUNK_WITH,
-                    target_name="Sarah Smith",
-                    age_preference=None,
-                    source_field="share_bunk_with",
-                    source=RequestSource.FAMILY,
-                    confidence=0.85,
-                    csv_position=0,
-                    metadata={"target_person_id": 999},  # Not in candidates
-                )
-            ],
+        # AI ranks person 999 — NOT in the candidate list. Reranker rejects it.
+        ai_result = _create_ranked_ai_response(
+            target_name="Sarah Smith",
+            ranked=[(999, 0.85)],
             confidence=0.85,
-            metadata={},
         )
 
         batch_processor = Mock()
@@ -929,16 +926,13 @@ class TestPhase3InvalidAIOutput:
 
     @pytest.mark.asyncio
     async def test_catch_all_path_sets_invalid_ai_output_status(self):
-        """When AI returns no selected_person_id and no no_match flag, status is invalid_ai_output."""
+        """When AI returns no ranked_selections and no no_match flag, status is invalid_ai_output."""
         ai_provider = Mock()
         context_builder = Mock()
         context_builder.build_disambiguation_context.return_value = _create_mock_context()
 
-        # Legacy Mock path: no person selected, no explicit no_match — the catch-all else branch
-        ai_result = Mock()
-        ai_result.selected_person_id = None
-        ai_result.no_match = False
-        ai_result.reason = "Could not distinguish between candidates"
+        # ParsedResponse with empty metadata — no ranked_selections, no no_match
+        ai_result = _create_ranked_ai_response()
 
         batch_processor = Mock()
         batch_processor.batch_disambiguate = AsyncMock(return_value=[ai_result])
@@ -1019,79 +1013,6 @@ class TestSetMetaHelper:
         assert case.disambiguation_metadata["reasons"] == {0: "good reason"}
 
 
-class TestExtractAiResultFields:
-    """Tests for the _extract_ai_result_fields helper.
-
-    Unwraps various AI result shapes into a canonical (selected_person_id,
-    ai_confidence, ai_reason) triple. ParsedResponse reads metadata from
-    result.requests[0].metadata; legacy objects read attributes directly.
-    """
-
-    def _make_service(self) -> Phase3DisambiguationService:
-        return Phase3DisambiguationService(
-            ai_provider=Mock(),
-            context_builder=Mock(),
-        )
-
-    def test_extract_from_parsed_response_with_target_person_id(self):
-        """ParsedResponse with target_person_id in metadata yields that id, response confidence, and reason."""
-        from bunking.sync.bunk_request_processor.integration.ai_types import ParsedResponse
-
-        service = self._make_service()
-        result = ParsedResponse(
-            requests=[
-                ParsedRequest(
-                    raw_text="Sarah Smith",
-                    request_type=RequestType.BUNK_WITH,
-                    target_name="Sarah Smith",
-                    age_preference=None,
-                    source_field="share_bunk_with",
-                    source=RequestSource.FAMILY,
-                    confidence=0.92,
-                    csv_position=0,
-                    metadata={"target_person_id": 111, "reason": "last-name match"},
-                )
-            ],
-            confidence=0.92,
-            metadata={},
-        )
-        selected_id, ai_confidence, ai_reason = service._extract_ai_result_fields(result)
-        assert selected_id == 111
-        assert ai_confidence == 0.92
-        assert ai_reason == "last-name match"
-
-    def test_extract_from_parsed_response_with_empty_requests(self):
-        """ParsedResponse with no requests yields (None, response.confidence, None)."""
-        from bunking.sync.bunk_request_processor.integration.ai_types import ParsedResponse
-
-        service = self._make_service()
-        result = ParsedResponse(requests=[], confidence=0.5, metadata={})
-        selected_id, ai_confidence, ai_reason = service._extract_ai_result_fields(result)
-        assert selected_id is None
-        assert ai_confidence == 0.5
-        assert ai_reason is None
-
-    def test_extract_from_legacy_response_reads_attributes(self):
-        """Legacy AIDisambiguationResponse (has selected_person_id attribute) is read directly."""
-        service = self._make_service()
-        legacy = Mock(spec=["selected_person_id", "confidence", "reason"])
-        legacy.selected_person_id = 222
-        legacy.confidence = 0.77
-        legacy.reason = "legacy pick"
-        selected_id, ai_confidence, ai_reason = service._extract_ai_result_fields(legacy)
-        assert selected_id == 222
-        assert ai_confidence == 0.77
-        assert ai_reason == "legacy pick"
-
-    def test_extract_from_unknown_type_returns_defaults(self):
-        """An unknown result type yields default (None, 0.8, None)."""
-        service = self._make_service()
-        selected_id, ai_confidence, ai_reason = service._extract_ai_result_fields(object())
-        assert selected_id is None
-        assert ai_confidence == 0.8
-        assert ai_reason is None
-
-
 class TestTryRerankerPath:
     """Tests for the _try_reranker_path helper.
 
@@ -1116,12 +1037,10 @@ class TestTryRerankerPath:
         return case, ambiguous
 
     def test_returns_false_for_non_parsed_response(self):
-        """Legacy / non-ParsedResponse results are not handled by the re-ranker path."""
+        """Non-ParsedResponse results are not handled by the re-ranker path."""
         service = self._make_service()
         case, resolution = self._make_case()
-        legacy = Mock(spec=["selected_person_id"])
-        legacy.selected_person_id = 111
-        assert service._try_reranker_path(case, 0, resolution, legacy) is False
+        assert service._try_reranker_path(case, 0, resolution, object()) is False
 
     def test_returns_false_for_parsed_response_without_signals(self):
         """ParsedResponse without ranked_selections or no_match does not short-circuit."""
@@ -1257,11 +1176,11 @@ class TestTryRerankerPath:
         assert case.disambiguated_results[0] is None
 
 
-class TestApplyLegacySelection:
-    """Tests for the _apply_legacy_selection helper.
+class TestRecordInvalidAiOutput:
+    """Tests for the _record_invalid_ai_output helper.
 
-    Validates the selected_person_id candidate match (success/no_match) and
-    the legacy `no_match` attribute / invalid_ai_output fallbacks.
+    Called when _try_reranker_path returns False — no ranked_selections and no no_match
+    metadata in the AI result. Records invalid_ai_output status on the case.
     """
 
     def _make_service(self) -> Phase3DisambiguationService:
@@ -1279,51 +1198,13 @@ class TestApplyLegacySelection:
         case = DisambiguationCase(_create_parse_result(), [ambiguous])
         return case, ambiguous
 
-    def test_success_when_selected_id_matches_candidate(self):
-        """selected_person_id matching a candidate records success + ResolutionResult."""
+    def test_records_invalid_ai_output_status(self):
+        """_record_invalid_ai_output writes invalid_ai_output status and reason."""
         service = self._make_service()
         case, resolution = self._make_case()
-        result = Mock()  # Not used for successful matches
-        service._apply_legacy_selection(case, 0, resolution, result, 111, 0.88, "good match")
-        disambig = case.disambiguated_results[0]
-        assert disambig is not None
-        assert disambig.person is not None
-        assert disambig.person.cm_id == 111
-        assert disambig.confidence == 0.88
-        assert disambig.method == "ai_disambiguation"
-        assert disambig.metadata is not None
-        assert disambig.metadata["disambiguation_reason"] == "good match"
-        assert case.disambiguation_metadata["status"][0] == "success"
-
-    def test_no_match_when_selected_id_not_in_candidates(self):
-        """selected_person_id absent from candidates records no_match + selected_ids."""
-        service = self._make_service()
-        case, resolution = self._make_case()
-        result = Mock()
-        service._apply_legacy_selection(case, 0, resolution, result, 999, 0.5, None)
-        assert case.disambiguation_metadata["status"][0] == "no_match"
-        assert case.disambiguation_metadata["selected_ids"][0] == 999
-
-    def test_legacy_no_match_attribute_records_no_match(self):
-        """When selected_id is None but result.no_match is truthy, records no_match."""
-        service = self._make_service()
-        case, resolution = self._make_case()
-        result = Mock(spec=["no_match", "reason"])
-        result.no_match = True
-        result.reason = "legacy no match"
-        service._apply_legacy_selection(case, 0, resolution, result, None, 0.8, None)
-        assert case.disambiguation_metadata["status"][0] == "no_match"
-        assert case.disambiguation_metadata["reasons"][0] == "legacy no match"
-
-    def test_invalid_ai_output_when_no_selection_and_no_no_match(self):
-        """No selection and no legacy no_match flag yields invalid_ai_output status."""
-        service = self._make_service()
-        case, resolution = self._make_case()
-        # Use an object without a no_match attribute to test the invalid_ai_output branch.
-        result = object()
-        service._apply_legacy_selection(case, 0, resolution, result, None, 0.8, "some reason")
+        service._record_invalid_ai_output(case, 0, resolution, object())
         assert case.disambiguation_metadata["status"][0] == "invalid_ai_output"
-        assert case.disambiguation_metadata["reasons"][0] == "some reason"
+        assert case.disambiguation_metadata["reasons"][0] == "No suitable match"
 
 
 class TestPhase3StatsMatchTrace:

--- a/tests/unit/sync/bunk_request_processor/services/test_phase3_disambiguation_wiring.py
+++ b/tests/unit/sync/bunk_request_processor/services/test_phase3_disambiguation_wiring.py
@@ -69,11 +69,12 @@ class TestBatchProcessorDisambiguation:
         mock_provider.parse_request.assert_not_called()
 
 
-class TestPhase3FieldNameFix:
-    """phase3_disambiguation_service reads selected_person_id, not person_cm_id."""
+class TestPhase3ResponseFields:
+    """AIDisambiguationResponse field shape. Post #944: ranked_selections is canonical."""
 
-    def test_disambiguation_response_uses_selected_person_id(self):
-        """AIDisambiguationResponse has selected_person_id field."""
-        response = AIDisambiguationResponse(selected_person_id=1001, confidence=0.85, reasoning="test")
-        assert response.selected_person_id == 1001
+    def test_response_has_ranked_selections_not_person_cm_id(self):
+        """AIDisambiguationResponse exposes ranked_selections (not legacy person_cm_id)."""
+        response = AIDisambiguationResponse()
+        assert hasattr(response, "ranked_selections")
         assert not hasattr(response, "person_cm_id")
+        assert not hasattr(response, "selected_person_id")


### PR DESCRIPTION
## Summary

Removes the dead `AIDisambiguationResponse.selected_person_id` legacy
single-pick field. The prompt (`config/prompts/disambiguate.txt`) only
asks for `ranked_selections` and `no_match`, so the legacy path never
fired in production. Fully expressible as
`ranked_selections=[{person_id, confidence, reasoning}]`.

### Removed
- `selected_person_id: int | None = None` from `AIDisambiguationResponse`
- Two validator clauses in `normalize_exclusive_fields` that referenced it
- `elif response.selected_person_id:` branch in `openai_provider.disambiguate()`
- `_extract_ai_result_fields` helper — only purpose was unwrapping the dead legacy attribute path
- `_apply_legacy_selection` helper — reachable only via the now-removed legacy path; replaced with a 6-line `_record_invalid_ai_output` that records fallback status when `_try_reranker_path` returns False
- Backward-compat tests covering the removed field (`test_backward_compat_selected_person_id`, `test_ranked_and_selected_person_id_mutually_exclusive`, `test_no_match_and_selected_person_id_mutually_exclusive`, entire `TestExtractAiResultFields` and `TestApplyLegacySelection` classes)

### Kept
- `ranked_selections`, `no_match`, `no_match_reason`, `confidence`, `reasoning` — the canonical fields exercised by the reranker path

### Verification
- Net diff: -400 / +133 (267-line net reduction)
- `uv run ruff format .` — clean
- `uv run ruff check .` — all checks passed
- `uv run mypy bunking/` — 0 issues across 159 source files
- `uv run pytest tests/unit/sync/bunk_request_processor/` — 1720 passed, 1 skipped
- `uv run pytest tests/ --ignore=tests/integration` — 3652 passed, 17 skipped
- Added `test_schema_has_no_selected_person_id_field` guard to prevent regression

`_apply_legacy_selection` was **removed** (not renamed) as per the issue's guidance: it only covered the now-dead legacy path, and its sole remaining responsibility (recording `invalid_ai_output` when the reranker can't handle the result) is now a 6-line helper.

Closes #944

## Test plan
- [x] Unit tests pass for Phase 3 disambiguation service, AI schemas, OpenAI provider, batch processor
- [x] Schema guard test asserts `selected_person_id` is no longer a field of `AIDisambiguationResponse`
- [x] ranked_selections-only path verified end-to-end at schema + provider + phase3 service layers
- [x] mypy / ruff clean across full backend

Generated with [Claude Code](https://claude.com/claude-code)