### PR TITLE
feat(frontend): approve/decline actions in all-requests modal

### DIFF
--- a/docs/reference/issue-triage.md
+++ b/docs/reference/issue-triage.md
@@ -1,17 +1,27 @@
 # Issue Triage
 
 Open issues grouped by code area with dependencies and suggested attack order.
-Last updated: 2026-04-15 (3 open issues, 10 closed since last update).
+Last updated: 2026-04-16 (6 open issues — #933 closed; 4 new issues #941–#944 from 2026-04-15 production-run forensics, all grouped under Phase 3 / OBR pipeline).
 
 ---
 
 ## Remaining Open Issues
 
+### Group 32: Phase 3 / OBR Pipeline Observability & Cleanup
+
+All surfaced from the 2026-04-15 production run. Cohesive because they share the same pipeline code and the same motivating dataset (1610 OBRs → 2303 BRs).
+
+| # | Title | Type | Priority | Status |
+|---|-------|------|----------|--------|
+| 944 | refactor(api): remove dead legacy field `selected_person_id` from `AIDisambiguationResponse` | refactor | Medium | Ready — follow-up cleanup after PR #928 tactical fix; scope is schema + provider + service + ~6 tests |
+| 943 | feat(api): add top-level OBR→BR reconciliation summary to pipeline logs | feat | Medium | Ready — additive log line, pulls from existing trace data |
+| 942 | fix(api): Phase 3 stats undercount — reranker path wins not counted in `_update_stats` | fix | Medium | Ready — log-only cosmetic bug, but masks reranker health; prefer single-source-of-truth rewrite from trace |
+| 941 | fix(frontend): `manual_review_reason` is saved but never rendered in UI | fix | Medium | Ready — self-referential "kept for review" markers invisible to staff; smallest option is to fold into existing `disposition_reason` / Status column |
+
 ### Standalone Issues
 
 | # | Title | Type | Priority | Status |
 |---|-------|------|----------|--------|
-| 933 | test(sync): `test_analyze_group_cohesion` segfaults under Python 3.14 (networkx C extension) | bug | Medium | Ready — quick fix: `skipif sys.version_info >= (3, 14)`; longer-term upstream fix |
 | 919 | chore: improve Python docstring coverage (~57% → 80%) | chore | Low | Background / incremental |
 
 ### Blocked
@@ -24,7 +34,11 @@ Last updated: 2026-04-15 (3 open issues, 10 closed since last update).
 
 ## Suggested Attack Order
 
-1. **#933** — Unblocks clean local pre-push runs; one-line `skipif` mitigation is low risk
+1. **Group 32** — Four tightly-related issues from the same production run, all ready
+   - **#942 first** — fixes the measurement before making further observability decisions (its fix validates the trace-as-source-of-truth approach that #943 also leans on)
+   - **#943 next** — reuses the trace-driven counts #942 establishes
+   - **#944 parallel** — independent of #942/#943; can be done in a parallel worktree
+   - **#941 parallel** — frontend-only; independent of the backend three
 2. **#919** — Background docstring coverage, incremental
 3. **#697** — Blocked externally
 

--- a/frontend/src/components/AllCamperRequestsModal.test.tsx
+++ b/frontend/src/components/AllCamperRequestsModal.test.tsx
@@ -1,16 +1,31 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AllCamperRequestsModal } from './AllCamperRequestsModal'
 
 // Fixture arrays mutated per-test
 let bunkRequestsFixture: Array<Record<string, unknown>> = []
 let personsFixture: Array<Record<string, unknown>> = []
+const updateMock = vi.fn()
+const toastSuccessMock = vi.fn()
+const toastErrorMock = vi.fn()
+
+vi.mock('react-hot-toast', () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccessMock(...args),
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
+  default: Object.assign(vi.fn(), {
+    success: (...args: unknown[]) => toastSuccessMock(...args),
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  }),
+}))
 
 vi.mock('../lib/pocketbase', () => ({
   pb: {
     collection: (name: string) => ({
       getFullList: () => Promise.resolve(name === 'persons' ? personsFixture : bunkRequestsFixture),
+      update: (...args: unknown[]) => updateMock(...args),
     }),
   },
 }))
@@ -29,6 +44,10 @@ vi.mock('react-router', () => ({
 beforeEach(() => {
   bunkRequestsFixture = []
   personsFixture = []
+  updateMock.mockReset()
+  updateMock.mockResolvedValue({})
+  toastSuccessMock.mockReset()
+  toastErrorMock.mockReset()
 })
 
 function renderModal(overrides: Partial<React.ComponentProps<typeof AllCamperRequestsModal>> = {}) {
@@ -223,5 +242,201 @@ describe('AllCamperRequestsModal cards', () => {
     // use the <strong> element which is the age preference target display.
     const ageCard = screen.getByText('older', { selector: 'strong' })
     expect(divider.compareDocumentPosition(ageCard) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+})
+
+describe('AllCamperRequestsModal framing (no read-only language)', () => {
+  it('does not mention "read-only" anywhere', async () => {
+    bunkRequestsFixture = [
+      {
+        id: 'req1',
+        request_type: 'bunk_with',
+        requestee_id: 1000002,
+        requested_person_name: 'Liam Garcia',
+        status: 'pending',
+        priority: 4,
+        confidence_score: 0.98,
+        source_field: 'bunk_with',
+        source_fragment: 'Liam Garcia',
+        parse_notes: 'n',
+        year: 2026,
+      },
+    ]
+    personsFixture = [{ cm_id: 1000002, first_name: 'Liam', last_name: 'Garcia', year: 2026 }]
+    const { container } = renderModal()
+    await screen.findByRole('button', { name: /^approve$/i })
+    expect(container.textContent?.toLowerCase()).not.toContain('read-only')
+    expect(container.textContent?.toLowerCase()).not.toContain('read only')
+    expect(container.textContent?.toLowerCase()).not.toContain('use the main table to take actions')
+  })
+})
+
+describe('AllCamperRequestsModal inline actions', () => {
+  const pendingBunkWith = {
+    id: 'req1',
+    request_type: 'bunk_with',
+    requestee_id: 1000002,
+    requested_person_name: 'Liam Garcia',
+    status: 'pending',
+    priority: 4,
+    confidence_score: 0.98,
+    source_field: 'bunk_with',
+    source_fragment: 'Liam Garcia',
+    parse_notes: 'n',
+    is_reciprocal: false,
+    year: 2026,
+  }
+
+  it('renders an Approve button per card', async () => {
+    bunkRequestsFixture = [pendingBunkWith]
+    personsFixture = [{ cm_id: 1000002, first_name: 'Liam', last_name: 'Garcia', year: 2026 }]
+    renderModal()
+    expect(await screen.findByRole('button', { name: /^approve$/i })).toBeTruthy()
+  })
+
+  it('renders a Decline button per card', async () => {
+    bunkRequestsFixture = [pendingBunkWith]
+    personsFixture = [{ cm_id: 1000002, first_name: 'Liam', last_name: 'Garcia', year: 2026 }]
+    renderModal()
+    expect(await screen.findByRole('button', { name: /^decline$/i })).toBeTruthy()
+  })
+
+  it('clicking Approve opens a confirmation popover', async () => {
+    bunkRequestsFixture = [pendingBunkWith]
+    personsFixture = [{ cm_id: 1000002, first_name: 'Liam', last_name: 'Garcia', year: 2026 }]
+    renderModal()
+    fireEvent.click(await screen.findByRole('button', { name: /^approve$/i }))
+    expect(screen.getByText(/approve this request\?/i)).toBeTruthy()
+  })
+
+  it('confirming Approve calls pb.update with status=resolved and request_locked=true', async () => {
+    bunkRequestsFixture = [pendingBunkWith]
+    personsFixture = [{ cm_id: 1000002, first_name: 'Liam', last_name: 'Garcia', year: 2026 }]
+    renderModal()
+    fireEvent.click(await screen.findByRole('button', { name: /^approve$/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /^confirm$/i }))
+    await waitFor(() =>
+      expect(updateMock).toHaveBeenCalledWith('req1', {
+        status: 'resolved',
+        request_locked: true,
+      })
+    )
+  })
+
+  it('confirming Decline calls pb.update with status=declined and request_locked=false', async () => {
+    bunkRequestsFixture = [pendingBunkWith]
+    personsFixture = [{ cm_id: 1000002, first_name: 'Liam', last_name: 'Garcia', year: 2026 }]
+    renderModal()
+    fireEvent.click(await screen.findByRole('button', { name: /^decline$/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /^confirm$/i }))
+    await waitFor(() =>
+      expect(updateMock).toHaveBeenCalledWith('req1', {
+        status: 'declined',
+        request_locked: false,
+      })
+    )
+  })
+
+  it('shows a success toast and closes the popover after successful approve', async () => {
+    bunkRequestsFixture = [pendingBunkWith]
+    personsFixture = [{ cm_id: 1000002, first_name: 'Liam', last_name: 'Garcia', year: 2026 }]
+    renderModal()
+    fireEvent.click(await screen.findByRole('button', { name: /^approve$/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /^confirm$/i }))
+    await waitFor(() => expect(toastSuccessMock).toHaveBeenCalled())
+    await waitFor(() => expect(screen.queryByText(/approve this request\?/i)).toBeNull())
+  })
+
+  it('shows an error toast and keeps the popover open when the mutation fails', async () => {
+    updateMock.mockReset()
+    updateMock.mockRejectedValue(new Error('network down'))
+    bunkRequestsFixture = [pendingBunkWith]
+    personsFixture = [{ cm_id: 1000002, first_name: 'Liam', last_name: 'Garcia', year: 2026 }]
+    renderModal()
+    fireEvent.click(await screen.findByRole('button', { name: /^approve$/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /^confirm$/i }))
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalled())
+    // Popover should still be visible so the user can retry or cancel.
+    expect(screen.getByText(/approve this request\?/i)).toBeTruthy()
+  })
+})
+
+describe('AllCamperRequestsModal status counts', () => {
+  it('renders accurate resolved/pending/declined counts in the header', async () => {
+    bunkRequestsFixture = [
+      {
+        id: 'r1',
+        request_type: 'bunk_with',
+        requestee_id: 1000002,
+        requested_person_name: 'Liam Garcia',
+        status: 'resolved',
+        priority: 4,
+        confidence_score: 0.9,
+        year: 2026,
+      },
+      {
+        id: 'r2',
+        request_type: 'bunk_with',
+        requestee_id: 1000002,
+        requested_person_name: 'Liam Garcia',
+        status: 'resolved',
+        priority: 4,
+        confidence_score: 0.9,
+        year: 2026,
+      },
+      {
+        id: 'r3',
+        request_type: 'bunk_with',
+        requestee_id: 1000002,
+        requested_person_name: 'Liam Garcia',
+        status: 'pending',
+        priority: 4,
+        confidence_score: 0.9,
+        year: 2026,
+      },
+      {
+        id: 'r4',
+        request_type: 'not_bunk_with',
+        requestee_id: 1000002,
+        requested_person_name: 'Liam Garcia',
+        status: 'declined',
+        priority: 4,
+        confidence_score: 0.9,
+        year: 2026,
+      },
+    ]
+    personsFixture = [{ cm_id: 1000002, first_name: 'Liam', last_name: 'Garcia', year: 2026 }]
+    renderModal()
+    // Scope to the header counts row (identified by the "4 requests" label)
+    // so we don't match status words that also appear on card pills.
+    const countsRow = (await screen.findByText(/4 requests/i)).parentElement!
+    expect(countsRow.textContent).toMatch(/2\s+resolved/)
+    expect(countsRow.textContent).toMatch(/1\s+pending/)
+    expect(countsRow.textContent).toMatch(/1\s+declined/)
+  })
+})
+
+describe('AllCamperRequestsModal accessibility', () => {
+  it('labels the dialog with the rendered heading via aria-labelledby', async () => {
+    bunkRequestsFixture = [
+      {
+        id: 'r1',
+        request_type: 'bunk_with',
+        requestee_id: 1000002,
+        requested_person_name: 'Liam Garcia',
+        status: 'pending',
+        priority: 4,
+        confidence_score: 0.9,
+        year: 2026,
+      },
+    ]
+    personsFixture = [{ cm_id: 1000002, first_name: 'Liam', last_name: 'Garcia', year: 2026 }]
+    renderModal()
+    const dialog = await screen.findByRole('dialog')
+    const labelledBy = dialog.getAttribute('aria-labelledby')
+    expect(labelledBy).toBeTruthy()
+    const labelEl = document.getElementById(labelledBy!)
+    expect(labelEl).not.toBeNull()
+    expect(labelEl!.textContent).toMatch(/Emma Johnson/)
   })
 })

--- a/frontend/src/components/AllCamperRequestsModal.tsx
+++ b/frontend/src/components/AllCamperRequestsModal.tsx
@@ -1,14 +1,21 @@
-import { useMemo } from 'react'
-import { useQuery } from '@tanstack/react-query'
-import { Loader2 } from 'lucide-react'
+import { useId, useMemo, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'react-hot-toast'
+import { CheckCircle, Loader2, XCircle } from 'lucide-react'
 import Modal from './ui/Modal'
 import CamperLink from './CamperLink'
+import { ConfirmActionPopover } from './ConfirmActionPopover'
 import { pb } from '../lib/pocketbase'
 import { useAuth } from '../contexts/AuthContext'
 import { queryKeys } from '../utils/queryKeys'
 import { formatSourceField } from '../utils/formatSourceField'
 import { formatReason, MUTUAL_BADGE_CLASSES } from '../utils/dispositionColors'
-import type { BunkRequestsResponse, PersonsResponse } from '../types/pocketbase-types'
+import { highlightSourceText } from '../utils/highlightSourceText'
+import type {
+  BunkRequestsResponse,
+  BunkRequestsStatusOptions,
+  PersonsResponse,
+} from '../types/pocketbase-types'
 
 export interface AllCamperRequestsModalProps {
   isOpen: boolean
@@ -36,10 +43,16 @@ function RequestCard({
   request,
   targetName,
   isCurrent = false,
+  onAction,
 }: {
   request: BunkRequestsResponse
   targetName: string | null
   isCurrent?: boolean
+  onAction?: (
+    e: React.MouseEvent<HTMLButtonElement>,
+    action: 'approve' | 'decline',
+    requestId: string
+  ) => void
 }) {
   const isBunk = request.request_type === 'bunk_with'
   const isNot = request.request_type === 'not_bunk_with'
@@ -86,12 +99,36 @@ function RequestCard({
             </span>
           )}
         </span>
-        <span
-          className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-semibold capitalize ${statusBadgeClass(request.status)}`}
-        >
-          {request.status}
-          {request.disposition_reason ? ` · ${formatReason(request.disposition_reason)}` : ''}
-        </span>
+        <div className="flex items-center gap-2">
+          <span
+            className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-semibold capitalize ${statusBadgeClass(request.status)}`}
+          >
+            {request.status}
+            {request.disposition_reason ? ` · ${formatReason(request.disposition_reason)}` : ''}
+          </span>
+          {onAction && (
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                aria-label="Approve"
+                title="Approve"
+                onClick={(e) => onAction(e, 'approve', request.id)}
+                className="hover:bg-forest-100 dark:hover:bg-forest-900/30 text-forest-600 dark:text-forest-400 touch-manipulation rounded-lg p-1.5 transition-colors"
+              >
+                <CheckCircle className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                aria-label="Decline"
+                title="Decline"
+                onClick={(e) => onAction(e, 'decline', request.id)}
+                className="hover:bg-destructive/10 text-destructive touch-manipulation rounded-lg p-1.5 transition-colors"
+              >
+                <XCircle className="h-4 w-4" />
+              </button>
+            </div>
+          )}
+        </div>
       </header>
       <div className="grid grid-cols-1 md:grid-cols-2">
         <section className="border-border/60 border-b p-4 md:border-r md:border-b-0">
@@ -103,13 +140,19 @@ function RequestCard({
               </span>
             )}
           </h4>
-          {request.source_fragment || request.source_detail || request.original_text ? (
-            <blockquote className="border-forest-400 bg-muted/50 text-bark-800 dark:text-bark-200 rounded-r-lg border-l-4 p-3 text-sm leading-relaxed">
-              {request.source_fragment || request.source_detail || request.original_text}
-            </blockquote>
-          ) : (
-            <div className="text-muted-foreground text-sm italic">No source text captured.</div>
-          )}
+          {(() => {
+            const body = request.original_text || request.source_detail || request.source_fragment
+            if (!body) {
+              return (
+                <div className="text-muted-foreground text-sm italic">No source text captured.</div>
+              )
+            }
+            return (
+              <blockquote className="border-forest-400 bg-bark-50 text-bark-800 dark:bg-bark-900/30 dark:text-bark-200 rounded-r-lg border-l-[3px] p-3 text-sm leading-relaxed whitespace-pre-wrap">
+                {highlightSourceText(body, request.source_fragment)}
+              </blockquote>
+            )
+          })()}
         </section>
         <section className="p-4">
           <h4 className="text-muted-foreground mb-2 font-mono text-[10.5px] font-medium tracking-[0.14em] uppercase">
@@ -128,12 +171,6 @@ function RequestCard({
         <span className="font-mono text-[11px]">
           {((request.confidence_score ?? 0) * 100).toFixed(0)}%
         </span>
-        {request.csv_position != null && (
-          <>
-            <span>·</span>
-            <span className="font-mono text-[11px]">csv_position {request.csv_position}</span>
-          </>
-        )}
       </footer>
     </article>
   )
@@ -148,6 +185,43 @@ export function AllCamperRequestsModal({
   currentRequestId,
 }: AllCamperRequestsModalProps) {
   const { user } = useAuth()
+  const queryClient = useQueryClient()
+  const headingId = useId()
+
+  const [confirmPopover, setConfirmPopover] = useState<{
+    action: 'approve' | 'decline'
+    anchorRect: Pick<DOMRect, 'top' | 'left' | 'width' | 'height'>
+    requestId: string
+  } | null>(null)
+
+  const updateRequestMutation = useMutation({
+    mutationFn: async ({ id, updates }: { id: string; updates: Partial<BunkRequestsResponse> }) =>
+      pb.collection('bunk_requests').update(id, updates),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.camperRequestSummary(requesterCmId, year),
+      })
+      void queryClient.invalidateQueries({ queryKey: ['bunk-requests'] })
+      toast.success('Request updated')
+      setConfirmPopover(null)
+    },
+    onError: () => {
+      toast.error('Failed to update request')
+    },
+  })
+
+  function handleAction(
+    e: React.MouseEvent<HTMLButtonElement>,
+    action: 'approve' | 'decline',
+    requestId: string
+  ) {
+    e.stopPropagation()
+    setConfirmPopover({
+      action,
+      anchorRect: e.currentTarget.getBoundingClientRect(),
+      requestId,
+    })
+  }
 
   const {
     data: requests = [],
@@ -194,6 +268,16 @@ export function AllCamperRequestsModal({
 
   const personMap = useMemo(() => new Map(persons.map((p) => [p.cm_id, p])), [persons])
 
+  const statusCounts = useMemo(() => {
+    const counts = { resolved: 0, pending: 0, declined: 0 }
+    for (const r of requests) {
+      if (r.status === 'resolved') counts.resolved++
+      else if (r.status === 'pending') counts.pending++
+      else if (r.status === 'declined') counts.declined++
+    }
+    return counts
+  }, [requests])
+
   if (!isOpen) return null
 
   const nonAge = requests.filter((r) => r.request_type !== 'age_preference')
@@ -201,11 +285,19 @@ export function AllCamperRequestsModal({
   const isEmpty = !isLoading && !isError && nonAge.length === 0 && !agePref
 
   const campMinderUrl = `https://system.campminder.com/ui/person/Record#${requesterCmId}:${year}`
+  const totalRequests = requests.length
+  const requestsLabel = `${totalRequests} ${totalRequests === 1 ? 'request' : 'requests'}`
 
   const header = (
-    <div>
-      <div className="text-forest-600 flex items-center gap-3 font-mono text-[10.5px] font-medium tracking-[0.16em] uppercase">
-        All requests · read-only
+    <div
+      className="border-border/60 border-b pt-[22px] pr-16 pb-[18px] pl-7"
+      style={{
+        backgroundImage:
+          'radial-gradient(120% 160% at 0% 0%, color-mix(in oklch, var(--color-forest-50, oklch(97% 0.01 145)) 85%, transparent) 0%, transparent 60%)',
+      }}
+    >
+      <div className="text-forest-700 dark:text-forest-300 flex items-center gap-3 font-mono text-[10.5px] font-medium tracking-[0.16em] uppercase">
+        All requests
         <a
           href={campMinderUrl}
           target="_blank"
@@ -216,15 +308,53 @@ export function AllCamperRequestsModal({
           CampMinder ↗
         </a>
       </div>
-      <h2 className="font-display text-foreground mt-1 text-2xl font-semibold tracking-tight">
-        Requests from <em className="text-forest-600 not-italic">{requesterName}</em>
+      <h2
+        id={headingId}
+        className="font-display text-foreground mt-1 text-[26px] leading-tight font-semibold tracking-tight"
+      >
+        Requests from{' '}
+        <em className="text-forest-600 dark:text-forest-300 font-medium italic">{requesterName}</em>
       </h2>
+      {totalRequests > 0 && (
+        <div className="text-muted-foreground mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+          <span className="font-mono">{year}</span>
+          <span className="text-border">·</span>
+          <span>{requestsLabel}</span>
+          <span className="text-border">·</span>
+          <span>
+            <span className="text-bark-800 dark:text-bark-200">{statusCounts.resolved}</span>{' '}
+            resolved
+          </span>
+          <span className="text-border">·</span>
+          <span>
+            <span className="text-bark-800 dark:text-bark-200">{statusCounts.pending}</span> pending
+          </span>
+          <span className="text-border">·</span>
+          <span>
+            <span className="text-bark-800 dark:text-bark-200">{statusCounts.declined}</span>{' '}
+            declined
+          </span>
+        </div>
+      )}
     </div>
   )
 
+  const footer = (
+    <div className="bg-muted/40 border-border/60 border-t px-7 py-3" aria-hidden="true" />
+  )
+
   return (
-    <Modal isOpen={isOpen} onClose={onClose} header={header} size="xl" scrollable noPadding>
-      <div className="p-6">
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      header={header}
+      footer={footer}
+      size="xl"
+      scrollable
+      noPadding
+      ariaLabelledBy={headingId}
+    >
+      <div className="px-7 pt-5 pb-6">
         {isLoading && (
           <div className="text-muted-foreground flex items-center justify-center gap-2 py-12">
             <Loader2 className="h-4 w-4 animate-spin" />
@@ -255,6 +385,7 @@ export function AllCamperRequestsModal({
                   request={req}
                   targetName={targetName}
                   isCurrent={req.id === currentRequestId}
+                  onAction={handleAction}
                 />
               )
             })}
@@ -271,12 +402,36 @@ export function AllCamperRequestsModal({
                   request={agePref}
                   targetName={null}
                   isCurrent={agePref.id === currentRequestId}
+                  onAction={handleAction}
                 />
               </>
             )}
           </div>
         )}
       </div>
+      <ConfirmActionPopover
+        isOpen={confirmPopover !== null}
+        anchorRect={confirmPopover?.anchorRect ?? { top: 0, left: 0, width: 0, height: 0 }}
+        action={confirmPopover?.action ?? 'approve'}
+        onConfirm={() => {
+          if (!confirmPopover) return
+          const { action, requestId } = confirmPopover
+          updateRequestMutation.mutate({
+            id: requestId,
+            updates:
+              action === 'approve'
+                ? {
+                    status: 'resolved' as BunkRequestsStatusOptions,
+                    request_locked: true,
+                  }
+                : {
+                    status: 'declined' as BunkRequestsStatusOptions,
+                    request_locked: false,
+                  },
+          })
+        }}
+        onCancel={() => setConfirmPopover(null)}
+      />
     </Modal>
   )
 }

--- a/frontend/src/components/CamperRequestSummary.test.tsx
+++ b/frontend/src/components/CamperRequestSummary.test.tsx
@@ -213,7 +213,7 @@ describe('CamperRequestSummary', () => {
     expect(badges).toHaveLength(1)
   })
 
-  it('shows a "View all" button that opens the modal', async () => {
+  it('shows a "Manage this camper\'s requests" button that opens the modal', async () => {
     mockFetch()
     render(
       <CamperRequestSummary
@@ -223,7 +223,7 @@ describe('CamperRequestSummary', () => {
         requesterName="Emma Johnson"
       />
     )
-    const btn = await screen.findByRole('button', { name: /view all/i })
+    const btn = await screen.findByRole('button', { name: /manage this camper's requests/i })
     fireEvent.click(btn)
     expect(await screen.findByRole('dialog')).toBeTruthy()
   })

--- a/frontend/src/components/CamperRequestSummary.tsx
+++ b/frontend/src/components/CamperRequestSummary.tsx
@@ -117,9 +117,9 @@ export function CamperRequestSummary({
           type="button"
           onClick={() => setModalOpen(true)}
           className="bg-forest-50 text-forest-600 border-forest-300/40 hover:bg-forest-100 dark:bg-forest-900/30 inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold transition"
-          aria-label="View all requests from this camper"
+          aria-label="Manage this camper's requests"
         >
-          View all
+          Manage this camper's requests
           <ArrowRight className="h-3 w-3" />
         </button>
       </div>

--- a/frontend/src/components/ConfirmActionPopover.test.tsx
+++ b/frontend/src/components/ConfirmActionPopover.test.tsx
@@ -156,4 +156,13 @@ describe('ConfirmActionPopover', () => {
     fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
     expect(document.activeElement).toBe(cancelBtn)
   })
+
+  it('calls onCancel when a scroll event fires anywhere in the document', () => {
+    const onCancel = vi.fn()
+    render(<ConfirmActionPopover {...defaultProps} onCancel={onCancel} />)
+
+    // Scroll would desync the popover from its captured anchor; dismiss instead.
+    fireEvent.scroll(document, {})
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
 })

--- a/frontend/src/components/ConfirmActionPopover.tsx
+++ b/frontend/src/components/ConfirmActionPopover.tsx
@@ -56,12 +56,22 @@ export function ConfirmActionPopover({
       }
     }
 
+    // The popover is positioned using a rect captured at click-time, so any
+    // scroll desyncs it from its anchor button. Dismissing on scroll avoids
+    // a floating, orphaned popover. capture:true catches scrolls on any
+    // scrollable ancestor (e.g. modal body), which don't bubble.
+    function handleScroll() {
+      onCancelRef.current()
+    }
+
     document.addEventListener('keydown', handleKeyDown)
     document.addEventListener('mousedown', handleMouseDown)
+    document.addEventListener('scroll', handleScroll, true)
 
     return () => {
       document.removeEventListener('keydown', handleKeyDown)
       document.removeEventListener('mousedown', handleMouseDown)
+      document.removeEventListener('scroll', handleScroll, true)
       previouslyFocused?.focus()
     }
   }, [isOpen])

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -12,6 +12,11 @@ interface ModalProps {
   size?: 'sm' | 'md' | 'lg' | 'xl'
   noPadding?: boolean // Remove default padding for complex layouts
   scrollable?: boolean // Make content area scrollable
+  // Accessibility: callers using the custom `header` slot should thread
+  // either an id referencing the heading element, or a literal label, so
+  // screen readers have a name for the dialog.
+  ariaLabelledBy?: string
+  ariaLabel?: string
 }
 
 const sizeClasses = {
@@ -55,6 +60,8 @@ export function Modal({
   size = 'md',
   noPadding = false,
   scrollable = false,
+  ariaLabelledBy,
+  ariaLabel,
 }: ModalProps) {
   useEffect(() => {
     if (!isOpen) return
@@ -74,17 +81,21 @@ export function Modal({
   const hasCustomHeader = header !== undefined
   const hasSimpleTitle = !hasCustomHeader && title !== undefined
 
+  const resolvedLabelledBy = ariaLabelledBy ?? (hasSimpleTitle ? 'modal-title' : undefined)
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center"
       role="dialog"
       aria-modal="true"
-      aria-labelledby={hasSimpleTitle ? 'modal-title' : undefined}
+      aria-labelledby={resolvedLabelledBy}
+      aria-label={!resolvedLabelledBy ? ariaLabel : undefined}
     >
       {/* Backdrop */}
       <div
         data-testid="modal-backdrop"
-        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        className="absolute inset-0 backdrop-blur"
+        style={{ backgroundColor: 'rgba(17, 26, 22, 0.42)' }}
         onClick={onClose}
         aria-hidden="true"
       />
@@ -92,7 +103,11 @@ export function Modal({
       {/* Modal content */}
       <div
         data-testid="modal-content"
-        className={`bg-card border-border relative overflow-hidden rounded-xl border shadow-xl ${noPadding ? '' : 'p-6'} ${sizeClasses[size]} mx-4 w-full`}
+        className={`bg-card border-border relative overflow-hidden rounded-2xl border ${noPadding ? '' : 'p-6'} ${sizeClasses[size]} mx-4 w-full`}
+        style={{
+          boxShadow:
+            '0 24px 60px -24px rgba(7, 20, 14, 0.35), 0 8px 24px -12px rgba(7, 20, 14, 0.18)',
+        }}
         onClick={(e) => e.stopPropagation()}
       >
         {/* Custom header mode - header spans full width, close button floats on top */}
@@ -101,7 +116,7 @@ export function Modal({
             {header}
             <button
               onClick={onClose}
-              className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2 rounded-lg p-2 transition-colors hover:bg-black/10"
+              className="text-muted-foreground hover:text-foreground absolute top-4 right-4 rounded-lg p-2 transition-colors hover:bg-black/10"
               aria-label="Close modal"
             >
               <X className="h-5 w-5" />


### PR DESCRIPTION
## Summary

- **All-requests modal is now interactive**: approve/decline buttons on each request card trigger a `ConfirmActionPopover` before mutating (approve → `status=resolved` + `request_locked=true`; decline → `status=declined` + `request_locked=false`). Query cache is invalidated on success so the camper summary and bunk-request views update live.
- **Header now shows request count with resolved/pending/declined breakdown** — staff can see at a glance how many of a camper's requests are still outstanding.
- **Source text highlighting** — the matched fragment is bolded/highlighted within the full source body when both are present.
- **"View all" → "Manage this camper's requests"** in `CamperRequestSummary` button label (better reflects the modal now having actions).
- **`ConfirmActionPopover` scroll-dismiss** — capture-phase scroll listener dismisses the popover when any ancestor scrolls; prevents the orphaned-floating-popover bug that appeared when scrolling inside the modal body.
- **`Modal` accessibility + visual polish** — new `ariaLabelledBy`/`ariaLabel` props; backdrop uses custom rgba instead of Tailwind `bg-black/50`; custom box-shadow; `rounded-2xl`.

## Test plan

- [ ] Approve a pending request — verify it transitions to `resolved` and `request_locked=true` in PocketBase; toast appears; modal updates
- [ ] Decline a pending request — verify `declined` / `request_locked=false`; toast appears
- [ ] Confirm popover appears anchored to the button; confirm scroll inside modal body dismisses it
- [ ] Modal header counts update after approve/decline
- [ ] Existing unit tests pass: `npx vitest run src/components/AllCamperRequestsModal.test.tsx src/components/ConfirmActionPopover.test.tsx src/components/CamperRequestSummary.test.tsx`
- [ ] Regression: existing ConfirmActionPopover keyboard/mouse-dismiss still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)