### PR TITLE
fix(frontend): rename parse notes label and age-group row styling

### DIFF
--- a/frontend/src/components/AllCamperRequestsModal.tsx
+++ b/frontend/src/components/AllCamperRequestsModal.tsx
@@ -60,9 +60,7 @@ function RequestCard({
   const hasResolvedTarget = !!(request.requestee_id && request.requestee_id > 0 && targetName)
 
   return (
-    <article
-      className={`border-border bg-card overflow-hidden rounded-xl border ${isCurrent ? 'ring-forest-500 dark:ring-forest-400 ring-2' : ''}`}
-    >
+    <article className="border-border bg-card overflow-hidden rounded-xl border">
       <header className="border-border/60 from-forest-50/50 dark:from-forest-900/10 grid grid-cols-[auto_1fr_auto] items-center gap-3 border-b bg-gradient-to-b to-transparent px-4 py-3">
         <span
           className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ${typeChipClass}`}
@@ -154,7 +152,7 @@ function RequestCard({
         </section>
         <section className="p-4">
           <h4 className="text-muted-foreground mb-2 font-mono text-[10.5px] font-medium tracking-[0.14em] uppercase">
-            Processing Notes
+            Processing Notes (AI Generated)
           </h4>
           <div className="text-foreground text-sm leading-relaxed">
             {request.parse_notes || <span className="text-muted-foreground italic">None.</span>}

--- a/frontend/src/components/BunkRequestRow.tsx
+++ b/frontend/src/components/BunkRequestRow.tsx
@@ -146,7 +146,13 @@ export function BunkRequestRow({
       </>
     )
     return (
-      <ClickableRow className={clsx(rowClass, 'text-muted-foreground text-xs')} onSelect={onSelect}>
+      <ClickableRow
+        className={clsx(
+          rowClass,
+          'text-muted-foreground text-xs ring-1 ring-amber-300/60 dark:ring-amber-700/40'
+        )}
+        onSelect={onSelect}
+      >
         {ageChildren}
       </ClickableRow>
     )

--- a/frontend/src/components/RequestReviewPanel.test.tsx
+++ b/frontend/src/components/RequestReviewPanel.test.tsx
@@ -963,25 +963,25 @@ describe('RequestReviewPanel', () => {
       })
     })
 
-    describe('Task 3: Rename parse notes to "Processing Notes" (#5)', () => {
-      it('should use "Processing Notes" as heading for single source', () => {
-        const expectedLabel = 'Processing Notes'
+    describe('Task 3: Rename parse notes to "Processing Notes (AI Generated)" (#5)', () => {
+      it('should use "Processing Notes (AI Generated)" as heading for single source', () => {
+        const expectedLabel = 'Processing Notes (AI Generated)'
         expect(expectedLabel).not.toBe('Parse Notes')
-        expect(expectedLabel).toBe('Processing Notes')
+        expect(expectedLabel).toBe('Processing Notes (AI Generated)')
       })
 
-      it('should use "Processing Notes" label in contributing sources view', () => {
-        // In the merged sources dropdown, parse notes label should also read "Processing Notes"
-        const expectedLabel = 'Processing Notes:'
+      it('should use "Processing Notes (AI Generated)" label in contributing sources view', () => {
+        // In the merged sources dropdown, parse notes label should also read "Processing Notes (AI Generated)"
+        const expectedLabel = 'Processing Notes (AI Generated):'
         expect(expectedLabel).not.toContain('Parse notes')
-        expect(expectedLabel).toBe('Processing Notes:')
+        expect(expectedLabel).toBe('Processing Notes (AI Generated):')
       })
 
-      it('labels the inferred-notes block as "Processing Notes"', () => {
-        const expectedLabel = 'Processing Notes'
+      it('labels the inferred-notes block as "Processing Notes (AI Generated)"', () => {
+        const expectedLabel = 'Processing Notes (AI Generated)'
         expect(expectedLabel).not.toBe('AI Intent Notes')
         expect(expectedLabel).not.toBe('AI Parse Notes')
-        expect(expectedLabel).toBe('Processing Notes')
+        expect(expectedLabel).toBe('Processing Notes (AI Generated)')
       })
     })
 

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -1605,7 +1605,7 @@ export default function RequestReviewPanel({
                                                 </p>
                                                 <p className="text-muted-foreground bg-muted/50 mt-1.5 rounded px-2 py-1 text-xs">
                                                   <span className="font-medium">
-                                                    Processing Notes:
+                                                    Processing Notes (AI Generated):
                                                   </span>{' '}
                                                   {source.parse_notes?.trim() ? (
                                                     source.parse_notes
@@ -1692,7 +1692,7 @@ export default function RequestReviewPanel({
                                     {/* Processing Notes - always show for single source */}
                                     <div>
                                       <h4 className="text-foreground mb-1 text-sm font-semibold">
-                                        Processing Notes
+                                        Processing Notes (AI Generated)
                                       </h4>
                                       <p className="text-muted-foreground text-sm">
                                         {request.parse_notes || (


### PR DESCRIPTION
## Summary
- Rename "Processing Notes" → "Processing Notes (AI Generated)" in RequestReviewPanel and AllCamperRequestsModal
- Add amber ring indicator to age-group bunk request rows in BunkRequestRow
- Remove isCurrent ring highlight from AllCamperRequestsModal card
- Update tests to match new label text

## Test plan
- [ ] Verify "Processing Notes (AI Generated)" label appears in request review panel
- [ ] Verify amber ring on age-group rows in bunk request list
- [ ] Frontend tests pass (`npx vitest run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)