### PR TITLE
feat(frontend): add dismiss button to toast notifications

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense } from 'react'
 import { BrowserRouter, Routes, Route, Navigate, useParams } from 'react-router'
 import { QueryClientProvider } from '@tanstack/react-query'
-import { Toaster } from 'react-hot-toast'
+import { Toaster, ToastBar, toast } from 'react-hot-toast'
 import { ThemeProvider } from './contexts/ThemeContext'
 import { AuthProvider } from './contexts/AuthContext'
 import { CurrentYearProvider } from './contexts/CurrentYearContext'
@@ -644,7 +644,40 @@ function App() {
                   },
                 },
               }}
-            />
+            >
+              {(t) => (
+                <ToastBar toast={t}>
+                  {({ icon, message }) => (
+                    <>
+                      {icon}
+                      {message}
+                      {t.type !== 'loading' && (
+                        <button
+                          onClick={() => toast.dismiss(t.id)}
+                          className="ml-1 flex-shrink-0 rounded p-0.5 opacity-40 transition-opacity hover:opacity-100"
+                          aria-label="Dismiss"
+                        >
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="14"
+                            height="14"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          >
+                            <line x1="18" y1="6" x2="6" y2="18" />
+                            <line x1="6" y1="6" x2="18" y2="18" />
+                          </svg>
+                        </button>
+                      )}
+                    </>
+                  )}
+                </ToastBar>
+              )}
+            </Toaster>
           </ProgramProvider>
         </AuthProvider>
       </QueryClientProvider>


### PR DESCRIPTION
## Summary
- Adds an ✕ button to all non-loading toasts so users can dismiss immediately
- Loading toasts (sync in progress) are excluded — dismissing mid-sync would be confusing
- Uses react-hot-toast's `ToastBar` children API, centralized in one place in `App.tsx`

## Test plan
- [ ] Trigger a sync on `/admin/sync` — success/error toasts have an ✕ in the top-right
- [ ] Clicking ✕ dismisses the toast immediately
- [ ] In-progress sync loading toasts have no ✕ button
- [ ] Toasts still auto-dismiss after timeout if not manually closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dismiss button to toast notifications for easier control.

* **Style**
  * Enhanced visual presentation and layout of notification display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->