### PR TITLE
chore(docs): overhaul README, add modernization backlog, align version pins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,7 @@ Format: `2026-01-06T14:05:52Z [source] LEVEL message key=value...`
 
 ## Important Development Notes
 
-1. **Language Versions** - Python 3.12+, Go 1.24+, Node 22+, TypeScript 5.8+/ES2022
+1. **Language Versions** - Python 3.14+, Go 1.26+, Node 22+, TypeScript 5.8+/ES2022
 2. **Use uv** - `uv sync` to install, `uv run <cmd>` to execute
 3. **CampMinder IDs** - All relationships use CM IDs, never PocketBase IDs
 4. **Sync order matters** - sessions → attendees → persons → bunks → plans → assignments → requests

--- a/README.md
+++ b/README.md
@@ -1,144 +1,196 @@
 # Kindred
 
-Kindred finds campers who belong together and places them in the right cabins.
+**Kindred finds campers who belong together and places them in the right cabins** — and gives camps the analytics to understand their enrollment, retention, and community at a depth spreadsheets can't reach.
 
-A cabin assignment system that puts relationships first. Using constraint satisfaction and social network analysis, it finds campers who are kindred — compatible, connected, belonging together — and builds cabin communities where friendships thrive.
+A relationship-first cabin assignment platform for summer camps, built on a constraint solver, a CampMinder data integration, and a full analytics suite.
 
-[![CI](https://github.com/adamflagg/kindred/actions/workflows/ci.yml/badge.svg)](https://github.com/adamflagg/kindred/actions/workflows/ci.yml)
-[![CD](https://github.com/adamflagg/kindred/actions/workflows/cd.yml/badge.svg?event=release)](https://github.com/adamflagg/kindred/actions/workflows/cd.yml)
-[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/adamflagg/kindred?utm_source=oss&utm_medium=github&utm_campaign=adamflagg%2Fkindred&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://coderabbit.ai)
+<!-- TODO: hero screenshot — bunking UI with social graph overlay or scenario comparison -->
+<!-- ![Kindred](docs/assets/hero.png) -->
+
+---
+
+## What Kindred Does
+
+Kindred is organized into two main areas of the app:
+
+### Summer Bunking
+
+The core cabin assignment workflow for the main summer season.
+
+- **Constraint solver** (Google OR-Tools) — respects age, grade, gender, cabin capacity, friend requests, and custom staff preferences
+- **Drag-and-drop UI** — move campers between cabins with real-time validation, lock groups, and visual indicators for conflicts
+- **Scenario planning & comparison** — fork the current assignment, experiment, and compare scenarios side-by-side before committing
+- **Social network graph** — interactive Cytoscape visualization of friend requests across the camper population, by session/bunk/age group
+- **Bunk request pipeline** — CSV upload → AI parsing (GPT-5-nano) → name disambiguation → reviewable request queue, with full pipeline debug traces and a prompt editor for tuning
+
+<!-- TODO: screenshot — summer bunking drag-and-drop + social graph -->
+<!-- ![Summer Bunking](docs/assets/summer-bunking.png) -->
+
+### Camp Analytics
+
+A full analytics dashboard for year-over-year operational insight. Organized into three sections:
+
+- **Registration** — Overview, geography (heatmaps + drill-down by region/school), waitlist analysis, session availability, enrollment forecasting vs. budget goals, cancellations, and Day 1 readiness
+- **Retention** — Returning-camper rates, session-flow Sankey diagrams, per-bunk retention, per-staff cabin cohort analysis
+- **Trends** — Enrollment velocity week-over-week, cancellation velocity, phase-based progress tracking against prior years
+
+<!-- TODO: screenshot — analytics forecast page or Sankey flow -->
+<!-- ![Camp Analytics](docs/assets/analytics.png) -->
+
+---
+
+## Architecture
+
+```
+CampMinder API  ──►  Go Sync Services  ──┐
+                                         │
+         React Frontend  ◄──────────────►│──►  4 Docker Containers
+                                         │
+                OR-Tools Solver  ◄───────┘
+```
+
+| Container | Port | Stack | Purpose |
+|-----------|------|-------|---------|
+| `kindred-caddy` | 8080 | Caddy + static build | Reverse proxy, frontend serving, TLS |
+| `kindred-pocketbase` | 8090 | Go + SQLite | Database, auth (OIDC), CampMinder sync, RBAC |
+| `kindred-api` | 8000 | Python 3.14 + FastAPI | Solver, analytics, social graph, scenarios |
+| `kindred-init` | — | Go + shell | One-shot admin/OIDC bootstrap |
+
+**Routing** follows an inverse pattern: Caddy routes explicit PocketBase paths (`/api/collections/*`, `/api/files/*`, `/api/realtime`, `/api/custom/*`, `/api/oauth2-redirect`); all other `/api/*` traffic goes to FastAPI. New FastAPI endpoints work automatically without Caddy config changes.
+
+**Data integrity**: Cross-table relationships use PocketBase expandable relations (`expand=person,session,bunk`) for efficient joins, with CampMinder IDs retained alongside for sync lookups. Every CampMinder-sourced record is year-scoped so reused session IDs across years can never contaminate each other.
+
+**Production deployment**: In production we put Caddy behind a separate edge proxy (Traefik + CrowdSec) that handles TLS, rate limiting, bot/WAF rules, and IP reputation. Caddy's role is reduced to internal routing; see [docs/guides/docker-deployment.md](docs/guides/docker-deployment.md).
+
+---
+
+## Tech Stack
+
+- **Frontend**: React 19, TypeScript 5.8, Vite, Tailwind CSS, React Query, @dnd-kit, Cytoscape.js
+- **Backend API**: Python 3.14+, FastAPI, Google OR-Tools, Pydantic v2
+- **Database & Auth**: PocketBase (Go 1.26+) on SQLite (WAL), OIDC auto-discovery for SSO
+- **Sync & Integrations**: Go services for CampMinder, Google Sheets/Drive, OpenAI (GPT-5-nano for bunk request parsing)
+- **Infrastructure**: Docker, Caddy, GitHub Actions CI/CD, Trivy security scanning
+- **Dev tooling**: `uv` for Python, `lefthook` for git hooks, ruff / mypy / golangci-lint / eslint / prettier
+
+---
 
 ## Quick Start
 
 ```bash
 git clone https://github.com/adamflagg/kindred.git
 cd kindred
+cp .env.example .env        # fill in credentials (see Configuration below)
 ./scripts/start_dev.sh
 ```
 
-- App: http://localhost:8080 (via Caddy)
-- PocketBase Admin: http://localhost:8080/_/
-- Vite Dev Server: http://localhost:3000 (HMR)
+Once services are up:
 
-## Features
+- **App**: http://localhost:8080 (Caddy, production-like routing)
+- **Vite dev server**: http://localhost:3000 (HMR for frontend development)
+- **PocketBase Admin**: http://localhost:8080/_/
 
-- **Constraint solver**: OR-Tools optimization respecting age, grade, and friend requests
-- **Drag-and-drop interface**: Visual cabin management
-- **Scenario planning**: Test changes before applying
-- **CampMinder sync**: Automated data synchronization
-- **Historical data**: View past years for returning campers
-
-## Architecture
-
-```
-CampMinder API → Go Sync → PocketBase ← React Frontend
-                               ↓
-                         FastAPI Solver
-```
-
-| Component | Technology |
-|-----------|------------|
-| Database | PocketBase (Go + SQLite) |
-| Solver | FastAPI + Google OR-Tools |
-| Frontend | React 19, TypeScript, Tailwind |
-| Sync | Go services with layered dependencies |
-
-## Requirements
-
-- Python 3.12+
-- Node.js 22+
-- Go 1.24+
-- Ubuntu 24.04 LTS (or compatible)
-
-## Development
+Trigger a CampMinder sync:
 
 ```bash
-# Start services
-./scripts/start_dev.sh
-
-# Quick checks before commit
-lefthook run pre-commit                                   # Formatters (staged files)
-lefthook run pre-push                                     # Full lint + test suite
-
-# Full test suite
-./scripts/ci/run_all_tests.sh
-
-# Frontend
-cd frontend && npm run dev
-
-# Sync data
-curl -X POST http://localhost:8090/api/custom/sync/daily
+curl -X POST "http://localhost:8090/api/custom/sync/run?year=2025&service=all"
 ```
+
+---
 
 ## Configuration
 
-Copy `.env.example` to `.env` and configure:
+Environment variables live in `.env` (see `.env.example` for the full list):
 
 ```bash
-# CampMinder API (required for sync)
-CAMPMINDER_API_KEY=your-api-key
-CAMPMINDER_PRIMARY_KEY=your-subscription-key
-CAMPMINDER_CLIENT_ID=your-client-id
-CAMPMINDER_SEASON_ID=2025
-
-# PocketBase admin
+# PocketBase admin bootstrap
 POCKETBASE_ADMIN_EMAIL=admin@camp.local
 POCKETBASE_ADMIN_PASSWORD=your-password
 
-# AI parsing (required for bunk requests)
+# AI (bunk request parsing & disambiguation)
 AI_API_KEY=your-openai-key
+AI_MODEL=gpt-5-nano
+AI_PROVIDER=openai
 
-# OIDC auth (production)
+# SSO (any OIDC provider: Pocket ID, Authentik, Auth0, Keycloak, etc.)
 OIDC_ISSUER=https://your-oidc-provider.com
 OIDC_CLIENT_ID=your-client-id
 OIDC_CLIENT_SECRET=your-secret
+
+# CampMinder sync
+CAMPMINDER_SEASON_ID=2025
+# (CampMinder API credentials as documented in .env.example)
 ```
 
-See `.env.example` for full configuration options.
+Operational config (solver weights, AI thresholds, session hierarchy, budget goals) lives in the PocketBase `config` collection and is editable through the **Admin → Config** UI — not through static files.
+
+---
 
 ## Testing
 
 ```bash
 # Python
-pytest tests/
+uv run pytest tests/
+uv run pytest tests/ -k "keyword"
 
 # Go
 cd pocketbase && go test ./...
 
 # Frontend
-cd frontend && npm test
+cd frontend && npx vitest run
 ```
 
-CI runs linting and tests on every push. CD builds Docker images on version tags (`v*`).
+Pre-push hooks (via `lefthook`) run type checks, linters, and fast unit tests. Run `./scripts/setup-git-hooks.sh` once after cloning to install them.
+
+---
 
 ## Deployment
 
-Release via GitHub Actions: **Actions → Release → Run workflow**. Uses [git-cliff](https://git-cliff.org/) for auto-versioning.
+Production runs the four containers behind Traefik/CrowdSec. CI runs on every push (~2–3 min); CD builds and pushes Docker images on every merge to `main` (~10–15 min), tagged `latest` and `sha-<commit>`.
+
+Releases are cut through **GitHub Actions → Release → Run workflow** — the workflow promotes existing `sha-<commit>` images to a version tag (e.g. `v1.2.0`), creates the git tag, and publishes a GitHub release. Auto-versioning uses [git-cliff](https://git-cliff.org/); an explicit version can be entered to override.
+
+Pulling the latest images into a running deployment:
 
 ```bash
-# After CD workflow completes (~15 min):
 docker compose pull && docker compose up -d
 ```
 
+See [docs/guides/docker-deployment.md](docs/guides/docker-deployment.md) for full production setup, including OIDC, reverse-proxy, and backup configuration.
+
+---
+
 ## Documentation
 
-- [Development Guide](docs/guides/development.md)
-- [Architecture Overview](docs/architecture/overview.md)
-- [Sync Operations](docs/guides/sync-operations.md)
-- [CLI Reference](docs/reference/cli-commands.md)
-- [Full Index](docs/README.md)
+- [Full documentation index](docs/README.md)
+- [Modernization backlog](docs/reference/modernization-backlog.md) — what language/tooling features we're not yet using
+- [Data model](docs/architecture/data-model.md)
+- [Sync layer architecture](docs/architecture/sync-layer.md)
+- [Bunk request pipeline](docs/architecture/bunk-request-pipeline.md)
+- [Metrics module](docs/architecture/metrics-module.md)
+- [Session types & bunking structure](docs/architecture/session-types.md)
+- [Staff guides](docs/guides/staff/)
+- [Solver configuration](docs/guides/solver-configuration.md)
+- [CSV preparation](docs/guides/csv-preparation.md)
+- [CLI reference](docs/reference/cli-commands.md)
+- [Troubleshooting](docs/guides/troubleshooting.md)
+- [CLAUDE.md](CLAUDE.md) — primary developer reference (architecture, conventions, quality standards)
+
+---
 
 ## Contributing
 
-1. Follow the [Development Guide](docs/guides/development.md)
-2. Write tests for new features
-3. Run `./scripts/setup-git-hooks.sh` once to install lefthook (auto-runs on commit/push)
-4. Submit pull requests for review
+1. Read [CLAUDE.md](CLAUDE.md) for conventions (commit scopes, TDD, worktree workflow)
+2. Run `./scripts/setup-git-hooks.sh` once to install lefthook
+3. Create a feature branch (or a worktree via `./scripts/worktree/new.sh <name>`)
+4. Write tests first, then implementation
+5. Open a pull request — CI must pass before merge (squash-only, no direct pushes to `main`)
+
+---
 
 ## License
 
-AGPL-3.0-or-later — See [LICENSE](LICENSE) for details.
+**AGPL-3.0-or-later** — see [LICENSE](LICENSE).
 
-**Nonprofits and educational institutions:** Free to use.
-
-**Commercial licensing:** Contact kindred@flagg.moi
+- **Nonprofits and educational institutions**: free to use.
+- **Commercial licensing**: contact kindred@flagg.moi

--- a/api/routers/debug.py
+++ b/api/routers/debug.py
@@ -1150,7 +1150,7 @@ def _parse_pb_datetime(value: Any) -> datetime | None:
         return None
     try:
         return datetime.fromisoformat(str(value))
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         return None
 
 

--- a/api/services/cancellation_service.py
+++ b/api/services/cancellation_service.py
@@ -366,7 +366,7 @@ class CancellationService:
             return None
         try:
             return datetime.strptime(str(value)[:10], "%Y-%m-%d")
-        except (ValueError, IndexError):
+        except ValueError, IndexError:
             return None
 
     @staticmethod

--- a/api/services/drilldown_service.py
+++ b/api/services/drilldown_service.py
@@ -1018,7 +1018,7 @@ class DrilldownService:
         parts = breakdown_value.split(":")
         try:
             target_session = int(parts[0])
-        except (ValueError, IndexError):
+        except ValueError, IndexError:
             return []
         target_gender = parts[1] if len(parts) > 1 and parts[1] else None
         target_grade = int(parts[2]) if len(parts) > 2 and parts[2] else None

--- a/api/services/metrics_repository.py
+++ b/api/services/metrics_repository.py
@@ -426,7 +426,7 @@ class MetricsRepository:
                         value = getattr(r, "value", {})
                         if isinstance(value, dict):
                             result[cm_id] = value
-                    except (ValueError, TypeError):
+                    except ValueError, TypeError:
                         pass
             return result
         except Exception as e:

--- a/api/services/metrics_sql_repository.py
+++ b/api/services/metrics_sql_repository.py
@@ -355,7 +355,7 @@ class MetricsSQLRepository:
                 raw = rows[0]["value"]
                 parsed = json.loads(raw) if isinstance(raw, str) else raw
                 return int(parsed)
-            except (ValueError, TypeError, json.JSONDecodeError):
+            except ValueError, TypeError, json.JSONDecodeError:
                 pass
         return 12
 
@@ -670,7 +670,7 @@ class MetricsSQLRepository:
                         parsed = json.loads(value)
                         if isinstance(parsed, dict):
                             result[cm_id] = parsed
-                except (ValueError, TypeError, json.JSONDecodeError):
+                except ValueError, TypeError, json.JSONDecodeError:
                     pass
         return result
 

--- a/api/services/session_availability_service.py
+++ b/api/services/session_availability_service.py
@@ -223,7 +223,7 @@ class SessionAvailabilityService:
                 continue
             try:
                 cm_id = int(key)
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 continue
             if isinstance(value, dict):
                 result[cm_id] = value

--- a/api/services/waitlist_service.py
+++ b/api/services/waitlist_service.py
@@ -353,7 +353,7 @@ class WaitlistService:
             return None
         try:
             return datetime.strptime(str(value)[:10], "%Y-%m-%d")
-        except (ValueError, IndexError):
+        except ValueError, IndexError:
             return None
 
     @classmethod

--- a/api/settings.py
+++ b/api/settings.py
@@ -25,7 +25,7 @@ def _is_docker_environment() -> bool:
     try:
         with open("/proc/1/cgroup") as f:
             return "docker" in f.read()
-    except (FileNotFoundError, PermissionError):
+    except FileNotFoundError, PermissionError:
         pass
     return False
 

--- a/api/utils/session_metrics.py
+++ b/api/utils/session_metrics.py
@@ -224,7 +224,7 @@ def get_session_length_category(start_date: str, end_date: str) -> str:
             return "3-week"
         else:
             return "4-week+"
-    except (ValueError, AttributeError):
+    except ValueError, AttributeError:
         return "unknown"
 
 
@@ -312,7 +312,7 @@ def compute_summer_metrics(
                     try:
                         year_str = str(start_date).split("-")[0]
                         years.add(int(year_str))
-                    except (ValueError, IndexError):
+                    except ValueError, IndexError:
                         pass
 
         summer_years_by_person[pid] = len(years)

--- a/api/utils/session_swap.py
+++ b/api/utils/session_swap.py
@@ -20,7 +20,7 @@ def _parse_date(date_str: str | None) -> datetime | None:
     # Try ISO date first (YYYY-MM-DD)
     try:
         return datetime.strptime(date_str[:10], "%Y-%m-%d")
-    except (ValueError, IndexError):
+    except ValueError, IndexError:
         return None
 
 

--- a/bunking/auth_middleware.py
+++ b/bunking/auth_middleware.py
@@ -37,7 +37,7 @@ def _is_docker_environment() -> bool:
     try:
         with open("/proc/1/cgroup") as f:
             return "docker" in f.read()
-    except (FileNotFoundError, PermissionError):
+    except FileNotFoundError, PermissionError:
         pass
     return False
 

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -382,7 +382,7 @@ class BunkingValidator:
                 if isinstance(ai_reasoning, str):
                     try:
                         ai_reasoning = json.loads(ai_reasoning)
-                    except (json.JSONDecodeError, ValueError):
+                    except json.JSONDecodeError, ValueError:
                         ai_reasoning = {}
 
                 if isinstance(ai_reasoning, dict):
@@ -396,7 +396,7 @@ class BunkingValidator:
                 if isinstance(ai_reasoning, str):
                     try:
                         ai_reasoning = json.loads(ai_reasoning)
-                    except (json.JSONDecodeError, ValueError):
+                    except json.JSONDecodeError, ValueError:
                         ai_reasoning = {}
 
                 if isinstance(ai_reasoning, dict):
@@ -675,7 +675,7 @@ class BunkingValidator:
                 if hasattr(person, "grade") and person.grade is not None:
                     try:
                         grades.append(int(person.grade))
-                    except (ValueError, TypeError):
+                    except ValueError, TypeError:
                         continue
 
             # Calculate age spread in months
@@ -821,7 +821,7 @@ class BunkingValidator:
                 if person and hasattr(person, "grade") and person.grade is not None:
                     try:
                         grades.append(int(person.grade))
-                    except (ValueError, TypeError):
+                    except ValueError, TypeError:
                         continue
 
             if len(grades) < 2:

--- a/bunking/config/loader.py
+++ b/bunking/config/loader.py
@@ -314,7 +314,7 @@ class ConfigLoader:
         """Get an integer config value."""
         try:
             return cast(int, self.get(key))
-        except (MissingKeyError, UnknownKeyError):
+        except MissingKeyError, UnknownKeyError:
             if default is not None:
                 return default
             raise
@@ -323,7 +323,7 @@ class ConfigLoader:
         """Get a float config value."""
         try:
             return cast(float, self.get(key))
-        except (MissingKeyError, UnknownKeyError):
+        except MissingKeyError, UnknownKeyError:
             if default is not None:
                 return default
             raise
@@ -332,7 +332,7 @@ class ConfigLoader:
         """Get a boolean config value."""
         try:
             return cast(bool, self.get(key))
-        except (MissingKeyError, UnknownKeyError):
+        except MissingKeyError, UnknownKeyError:
             if default is not None:
                 return default
             raise
@@ -341,7 +341,7 @@ class ConfigLoader:
         """Get a string config value."""
         try:
             return cast(str, self.get(key))
-        except (MissingKeyError, UnknownKeyError):
+        except MissingKeyError, UnknownKeyError:
             if default is not None:
                 return default
             raise

--- a/bunking/sync/bunk_request_processor/conflict/conflict_detector.py
+++ b/bunking/sync/bunk_request_processor/conflict/conflict_detector.py
@@ -224,7 +224,7 @@ class ConflictDetector:
                 maps["pending_enrollment_targets"] = {
                     cm_id for cm_id, info in enrollment_info.items() if info.is_pending_enrollment
                 }
-            except (AttributeError, TypeError):
+            except AttributeError, TypeError:
                 logger.debug("bulk_get_enrollment_for_persons not available; skipping enrollment-aware detection")
 
         # Enrich requester enrollment status
@@ -245,7 +245,7 @@ class ConflictDetector:
                 maps["inactive_requesters"] = {
                     cm_id for cm_id, info in requester_enrollment.items() if info.is_inactive
                 }
-            except (AttributeError, TypeError):
+            except AttributeError, TypeError:
                 logger.debug("bulk_get_enrollment_for_persons not available; skipping requester enrollment check")
 
         return maps

--- a/bunking/sync/bunk_request_processor/core/models.py
+++ b/bunking/sync/bunk_request_processor/core/models.py
@@ -189,7 +189,7 @@ class Person:
 
             parsed = json.loads(self.parent_names)
             return parsed if isinstance(parsed, list) else []
-        except (json.JSONDecodeError, TypeError):
+        except json.JSONDecodeError, TypeError:
             return []
 
     @property

--- a/bunking/sync/bunk_request_processor/data/repositories/person_repository.py
+++ b/bunking/sync/bunk_request_processor/data/repositories/person_repository.py
@@ -487,7 +487,7 @@ class PersonRepository(Repository):
             if hasattr(db_record, "age") and db_record.age:
                 try:
                     cm_age = float(db_record.age)
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     pass  # Invalid age value, leave as None
 
             # Get parent_names JSON (for name resolution via parent surnames)
@@ -500,7 +500,7 @@ class PersonRepository(Repository):
             if hasattr(db_record, "household_id") and db_record.household_id:
                 try:
                     household_id = int(db_record.household_id)
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     pass
 
             # Promote gender and congregation to first-class fields

--- a/bunking/sync/bunk_request_processor/debug/trace_collector.py
+++ b/bunking/sync/bunk_request_processor/debug/trace_collector.py
@@ -312,7 +312,7 @@ class TraceCollector:
                         if oldest.tzinfo is None:
                             oldest = oldest.replace(tzinfo=UTC)
                         needs_cleanup = oldest < datetime.now(UTC) - timedelta(days=MAX_AGE_DAYS)
-                    except (ValueError, TypeError):
+                    except ValueError, TypeError:
                         pass
             if needs_cleanup:
                 await asyncio.to_thread(cleanup_old_runs, pb_client)

--- a/bunking/sync/bunk_request_processor/integration/original_requests_loader.py
+++ b/bunking/sync/bunk_request_processor/integration/original_requests_loader.py
@@ -361,7 +361,7 @@ class OriginalRequestsLoader:
                 if isinstance(val, str):
                     try:
                         return datetime.fromisoformat(val)
-                    except (ValueError, TypeError):
+                    except ValueError, TypeError:
                         return None
                 return None
 

--- a/bunking/sync/bunk_request_processor/name_resolution/filters/spread_filter.py
+++ b/bunking/sync/bunk_request_processor/name_resolution/filters/spread_filter.py
@@ -67,7 +67,7 @@ class SpreadFilter:
                     years = int(person.campminder_age.years)
                     months = getattr(person.campminder_age, "months", 0)
                     return years * 12 + months
-            except (AttributeError, ValueError, TypeError):
+            except AttributeError, ValueError, TypeError:
                 pass
 
         return None

--- a/bunking/sync/bunk_request_processor/resolution/strategies/fuzzy_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/fuzzy_match.py
@@ -459,7 +459,7 @@ class FuzzyMatchStrategy(BaseMatchStrategy):
                     parent_last = parent.get("last", "")
                     if parent_last and parent_last.lower() == surname_lower:
                         return True
-        except (json.JSONDecodeError, TypeError):
+        except json.JSONDecodeError, TypeError:
             return False
 
         return False

--- a/bunking/sync/bunk_request_processor/services/phase2_resolution_service.py
+++ b/bunking/sync/bunk_request_processor/services/phase2_resolution_service.py
@@ -971,12 +971,12 @@ class Phase2ResolutionService:
                 if cm_id:
                     try:
                         clean_candidate_ids.append(int(cm_id))
-                    except (ValueError, TypeError):
+                    except ValueError, TypeError:
                         logger.warning(f"Invalid candidate ID in dict: {cm_id}")
             elif isinstance(candidate, (int, str)):
                 try:
                     clean_candidate_ids.append(int(candidate))
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     logger.warning(f"Invalid candidate ID format: {candidate}")
             else:
                 logger.warning(f"Unexpected candidate format: {type(candidate)}")
@@ -1037,7 +1037,7 @@ class Phase2ResolutionService:
                         # grade_diff == 2: no adjustment
                         factors["grade"] = 0.0
                     grade_used = True
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     pass
 
             # Only used when grades not available

--- a/bunking/sync/conflict_detector.py
+++ b/bunking/sync/conflict_detector.py
@@ -141,7 +141,7 @@ class ConflictDetector:
                     reasoning = json.loads(request["ai_reasoning"])
                     if reasoning.get("notes"):
                         all_notes.append(reasoning["notes"])
-                except (KeyError, TypeError):
+                except KeyError, TypeError:
                     pass
 
         # Look for resolution patterns

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,8 @@ docs/
 ├── reference/
 │   ├── cli-commands.md         # Command reference
 │   ├── configuration.md        # Env vars and config
-│   └── issue-triage.md         # Open issue groups & attack order
+│   ├── issue-triage.md         # Open issue groups & attack order
+│   └── modernization-backlog.md # Language/tooling features not yet adopted
 ├── features/
     ├── request-types-specification.md  # Business rules
     └── bunk_request_business_rules.md  # (needs update)
@@ -38,3 +39,4 @@ docs/
 - **Production deployment** → [docker-deployment.md](./guides/docker-deployment.md)
 - **Troubleshooting** → [troubleshooting.md](./guides/troubleshooting.md)
 - **Staff guides** → [guides/staff/](./guides/staff/)
+- **Modernization backlog** → [reference/modernization-backlog.md](./reference/modernization-backlog.md)

--- a/docs/reference/modernization-backlog.md
+++ b/docs/reference/modernization-backlog.md
@@ -1,0 +1,259 @@
+# Modernization Backlog
+
+Reference audit of modern language/tooling features available to Kindred but not yet adopted. Generated from a comprehensive audit across Python, Go, TypeScript/React, and infrastructure layers.
+
+**Status legend:** HIGH = real behavioral/robustness benefit, MEDIUM = readability/consistency win, LOW = polish / defer.
+
+**Execution model:** Work this backlog one layer at a time (one PR per language/concept) rather than a single mega-PR. Each section below is a candidate PR.
+
+---
+
+## 0. Fixed in the PR carrying this doc
+
+- **`CLAUDE.md` language versions** — `Python 3.12+, Go 1.24+` → `Python 3.14+, Go 1.26+` (matches `.python-version` and `pocketbase/go.mod`)
+- **`README.md`** — rewritten to include Camp Analytics (metrics module), architecture diagram, Python 3.14 / Go 1.26 pins, production-deployment note about Traefik/CrowdSec fronting Caddy
+
+### Deferred to its own PR
+
+- **`ruff.toml:21`** — `target-version` is still `py312` despite `pyproject.toml` requiring `>=3.14`. Bumping to `py314` activates rules (UP037 quoted annotations, UP043 unnecessary `Generator[..., None, None]` defaults) that fire on ~30+ existing test files. This should be done as **the first follow-up PR** (bump + `ruff check --fix` in one commit). Kept separate so the docs PR stays docs-only.
+
+### Outstanding quick check
+
+- **`ortools` on PyPI** — `9.15.6755` is published with wheels for cp310–cp313 only. **No cp314 wheel yet.** The GitHub-release URL pin in `pyproject.toml:37` is correct; revisit monthly. Switch back to `ortools>=9.15` on PyPI once Google publishes cp314 wheels.
+
+---
+
+## 1. Python (project is on 3.14)
+
+Baseline is strong: Pydantic v2 everywhere, `datetime.UTC` adopted, modern generics (`dict[str, X]`), f-strings clean, mypy `strict = true`. The real gaps are concurrency idioms and version-specific polish.
+
+| Impact | Feature | Where | Count | Notes |
+|--------|---------|-------|-------|-------|
+| **HIGH** | `asyncio.TaskGroup` replacing `asyncio.gather` | `api/services/` — `geo_service.py`, `drilldown_service.py`, `forecast_service.py`, `historical_service.py`, `session_availability_service.py`, `validation.py`, `batch_processor.py` | ~35 callsites | Real robustness win: TaskGroup aggregates exceptions via ExceptionGroup instead of silently dropping sibling tasks on partial failure. Pattern change, not mechanical. |
+| **HIGH** | Drop `from __future__ import annotations` | repo-wide | ~250 files | PEP 649 makes deferred annotation evaluation the default in 3.14 — the import is dead weight. Fully mechanical (regex + ruff autofix). |
+| **MEDIUM** | `itertools.batched` replacing `range(0, len(x), n)` chunking | `validation.py:185`, `batch_processor.py`, `metrics_repository.py`, `geo_service.py`, `data_fetcher.py`, `drilldown_service.py`, `optimized_graph_builder.py`, `debug_parse_repository.py` | 11 | 3.12+. Drops the manual index arithmetic. |
+| **MEDIUM** | `match` statement for isinstance chains | `debug.py:188`, `requests.py`, `session_availability.py`, `metrics_repository.py` | ~15–20 | Readability only. Target chains with >2 branches. |
+| **LOW** | Residual `Optional[X]` → `X \| None` | `tests/test_ranked_candidate_passthrough.py:65,67` | 3 | Mostly already modernized — last few leftovers. |
+| **LOW** | `@override` decorator (from `typing`) | (unused) | 0 | Catches rename bugs in overrides. 3.12+. |
+| **LOW** | PEP 695 generic syntax (`def foo[T](x: T)`) | `phase3_disambiguation_service.py:6,20` | 1 | Single TypeVar in the codebase — not worth a campaign on its own. |
+| **LOW** | `@dataclass(slots=True, kw_only=True, frozen=True)` defaults | 41 `@dataclass` files | — | Mostly small DTOs, not hot paths. Apply opportunistically. |
+| **LOW** | `typing.TypeIs` (replaces `TypeGuard`) / `typing.ReadOnly` TypedDict fields | `geo_normalizer/normalizer.py:20` for ReadOnly; no `TypeGuard` in codebase | 1 | 3.13+. Low leverage here. |
+| **LOW** | `copy.replace()` | (unused; no `dataclasses.replace` callsites either) | 0 | 3.13+. No current use case. |
+
+### Not applicable / already adopted
+
+- `Union[X, Y]` → `X \| Y` — no `Union` imports found ✓
+- `Dict`/`List`/`Tuple` from typing — only in docstrings/comments ✓
+- `datetime.UTC` — already used in 17+ files ✓
+- `tomllib` — no TOML parsing in the codebase ✓
+- PEP 750 t-strings — no SQL/HTML template builders that would benefit
+- `compression.zstd` — no zstandard dependency
+- Pydantic v1 legacy patterns — none found ✓
+
+### Recommended Python PR order
+
+1. `chore(ci): ruff target-version py314` — already in this PR
+2. `chore(py): drop redundant __future__ annotations import` — mechanical, repo-wide
+3. `refactor(api): adopt asyncio.TaskGroup in metrics services` — focused, ~35 callsites, behavioral improvement
+4. `refactor(api): use itertools.batched for chunking` — 11 callsites
+5. `refactor(api): convert isinstance chains to match` — small, optional
+
+---
+
+## 2. Go (project is on 1.26)
+
+Baseline is excellent: 784 `slog` uses, 395 `fmt.Errorf("%w", ...)` wrappings, no `ioutil`. The dominant gap is an `interface{}` → `any` codemod the codebase never got.
+
+| Impact | Feature | Where | Count | Notes |
+|--------|---------|-------|-------|-------|
+| **HIGH** | `interface{}` → `any` | `sync/api.go` (108 occurrences), `sync/base_sync.go` (42), `sync/households.go` (35+), widespread | **744** | Single mechanical pass. Alias since Go 1.18. |
+| **HIGH** | `map[string]interface{}` → `map[string]any` | same hotspots | **603** | Same PR as the `any` codemod. |
+| **HIGH** | `fmt.Sprintf` inside `slog` call sites | `campminder/client.go:1008`, `sync/financial_transactions.go:106`, `sync/orchestrator.go:784,844` | 4 | Defeats structured logging — pass raw values as key/value attrs instead. |
+| **HIGH** | String-based error matching | `sync/rate_limited_sheets_writer.go` (`strings.Contains(err.Error(), "googleapi: Error 429")`), `sync/scheduler_test.go`, `workbook_manager_test.go`, `orchestrator_test.go` | 4 | Define sentinel errors (e.g. `ErrRateLimited`) and use `errors.Is` / `errors.As`. The Google 429 detection is the production-impact one. |
+| **MEDIUM** | `sort.Slice` → `slices.SortFunc` (Go 1.21) | `sync/normalize_geographic_test.go`, `sync/workbook_manager.go`, `sync/multi_workbook_ordering.go` (2×) | 3 | |
+| **MEDIUM** | `sort.Strings` → `slices.Sort` (Go 1.21) | `rbac/hooks.go`, `sync/base_sync.go` (2×), `sync/multi_workbook_ordering.go` (2×), `sync/table_exporter.go` | 6 | |
+| **MEDIUM** | Classic `for i := 0; i < len(...)` → `for i := range slice` (Go 1.22) | `sync/households.go`, `sync/staff_skills.go`, `sync/session_resolver.go`, `sync/sessions.go`, `sync/camper_history.go`, `sync/rate_limited_sheets_writer.go`, test files | 26 | Not all applicable — some use custom increments (`i += batchSize`) that still need the classic form. |
+| **MEDIUM** | Manual map-clear loop → `clear()` builtin (Go 1.21) | `sync/base_sync.go:122–125, 130–133` (`ClearProcessedKeys`, `ClearFieldDiffStats`) | 2 | Trivial. |
+| **LOW** | Mixed `log` + `log/slog` in one file | `campminder/client.go:11` (`log.Printf` for rate-limit warnings alongside `slog`) | 1 file | Consolidate on `slog`. |
+| **LOW** | `strings.Index() != -1` anti-pattern | `sync/base_sync.go` | 1 | Use `strings.Contains`. |
+| **?** | `time.After` in retry loop | `sync/rate_limited_sheets_writer.go:194` | 1 | Creates a new timer per retry — fine in practice unless the loop becomes hot. |
+
+### Unexplored / no concrete opportunities identified
+
+- Go 1.23 range-over-func iterators — no strong candidates surfaced in the audit
+- Go 1.24 generic type aliases — no existing generic patterns that would benefit
+- `context.WithoutCancel` / `context.AfterFunc` — only `WithCancel` in tests, production context propagation looks fine
+
+### Recommended Go PR order
+
+1. `refactor(pb): interface{} → any codemod` — single bulk PR, ~1,347 replacements, purely mechanical
+2. `fix(sync): replace string-based error matching with sentinel errors` — behavioral (Google 429 detection), smaller PR
+3. `refactor(sync): use slices package helpers and clear() builtin` — bundle the Medium items together
+4. `chore(logging): consolidate campminder client on slog` — small cleanup
+
+---
+
+## 3. Frontend — React 19, TypeScript 5.8, Node 22
+
+`tsconfig.json` is already modern (ES2022, bundler resolution, `verbatimModuleSyntax`, `noImplicitOverride`, `erasableSyntaxOnly`). The misses are idiomatic — code predating React 19 and ES2023 adoption.
+
+| Impact | Feature | Where | Count | Notes |
+|--------|---------|-------|-------|-------|
+| **HIGH** | `Array.prototype.toSorted()` vs `[...arr].sort()` | 24 files incl. `StaffCabinAnalysisPage.tsx`, `utils/retentionTransforms.ts:36`, `components/SessionList.tsx`, `utils/enrollmentSort.test.ts` | 24 | ES2023. Cheapest win. |
+| **HIGH** | React 19 `use()` hook for contexts | 9 context files + 100+ `useContext` consumers (`AuthContext`, `ProgramContext`, `ScenarioContext`, `LockGroupContext`, etc.) | 100+ | Eliminates the "`useX()` wrapper that throws on missing provider" pattern. |
+| **HIGH** | React Query v5: `queryOptions`, `skipToken`, `useSuspenseQuery`, `combine` | 30+ `useQuery`, 20+ `useMutation` callsites; none use these | 50+ | `queryOptions` gives type-safe shared query definitions; `skipToken` replaces conditional `enabled` logic. |
+| **HIGH** | Error cause chaining (`new Error(msg, { cause })`) | 140+ `throw` statements; only `hooks/session/useCamperMovement.ts` uses `cause` | 139 | Much better stack-trace fidelity when wrapping API errors. |
+| **MEDIUM** | `<Context.Provider>` → `<Context>` shorthand (React 19) | 25 providers | 25 | Cosmetic but clean. |
+| **MEDIUM** | `satisfies` operator | 4 files use it (velocity/cancellation pages); ~1,800 `as const` sites don't | 1,800 | Don't convert blindly — target config objects and route/feature maps where shape matters. |
+| **MEDIUM** | `Object.groupBy()` (ES2024) | `components/LockGroupPanel.tsx`, `contexts/LockGroupContext.tsx`, `providers/BunkRequestProvider.tsx:57` | 5–8 | Replaces manual `reduce((acc, x) => ...)` groupBy patterns. |
+| **MEDIUM** | `React.lazy` + `Suspense` for large modals | Only `RightPanelContainer.tsx` and `BunkingBoardByArea.tsx` currently lazy-load. Candidates: `MetricsLayout`, `CamperDetailsPanel`, `RequestReviewPanel`, scenario comparison modals | 5–10 candidates | Direct bundle-size impact on the initial load. |
+| **MEDIUM** | `readonly` modifiers on Record/interfaces | 9 files use `readonly`; ~240 type definitions (cache/store shapes, API response types) don't | 240 | Prevents accidental mutations. Apply to types that represent persisted / cached shape. |
+| **LOW** | React 19 `useActionState` / `useFormStatus` | 150+ `useState` sites for form submission state | 150 | Only worth doing if adopting Server Actions pattern broadly. |
+| **LOW** | `findLast` / `findLastIndex`, `structuredClone`, Temporal, `Intl.Segmenter`, regex `v` flag | — | — | No clear use cases surfaced. |
+| **?** | Tailwind 4 migration | `frontend/package.json` | — | Confirm current version; Tailwind 4 (2025) ships the Oxide engine + CSS-first config, but it's a real migration, not a drop-in. |
+
+### Recommended frontend PR order
+
+1. `refactor(frontend): Array.toSorted + Object.groupBy` — 24 + 5–8 callsites, mechanical, great cleanup
+2. `refactor(frontend): error cause chaining on API/service throws` — behavioral (debugging quality)
+3. `refactor(frontend): adopt React 19 use() for contexts` — larger touch, own PR
+4. `refactor(frontend): React Query queryOptions + skipToken` — affects hook shapes, own PR
+5. `perf(frontend): lazy-load large modals` — bundle-size focus, own PR
+6. `refactor(frontend): readonly on cache/store types` — type-level only, low-risk
+7. Separate investigation: Tailwind 4 upgrade feasibility
+
+---
+
+## 4. Infrastructure + Caddy production hardening
+
+Exceptional baseline: Chainguard/Wolfi + distroless final images, `COPY --link` + numeric `--chown`, healthchecks in every Dockerfile, concurrency groups in CI/CD, path-filtered rebuilds, Trivy scanning, `uv` with `[dependency-groups]` (PEP 735), commitlint, git-cliff.
+
+### 4a. Caddy hardening (production priority)
+
+**Context:** In production, Kindred is deployed behind Traefik + CrowdSec. Those handle TLS, rate limiting, bot/WAF rules, CORS, and IP reputation. Caddy's role is reduced to internal routing — but it should still do the minimum to prevent internal misbehavior from causing problems (OOM from rogue uploads, socket exhaustion from hung upstreams, missing access-log trail when debugging multi-container issues).
+
+**Current state:** Both `docker/Caddyfile` and `frontend/Caddyfile` are minimal reverse proxies — no timeouts, body-size caps, security headers, or access logs.
+
+**Minimum hardened Caddy config (safe behind Traefik/CrowdSec):**
+
+```caddyfile
+{
+    admin localhost:2019
+    timeouts {
+        request_read 30s
+        request_body 30s
+    }
+    log {
+        format json { time_format iso8601 }
+        level INFO
+    }
+}
+
+:{$CADDY_PORT:8080} {
+    # Defense-in-depth headers (Traefik can still override at the edge)
+    header {
+        X-Content-Type-Options "nosniff"
+        X-Frame-Options "DENY"
+        Referrer-Policy "strict-origin-when-cross-origin"
+        Permissions-Policy "interest-cohort=()"
+        -Server
+    }
+
+    # Request body cap — tune to max upload (CSVs, photos, etc.)
+    request_body {
+        max_size 50MB
+    }
+
+    # Access log (JSON, stdout → Docker log driver)
+    log {
+        format json
+        output stdout
+    }
+
+    # ... existing handle blocks (PocketBase routing, /api, static) ...
+
+    handle /api/internal/* {
+        respond 403
+    }
+
+    handle {
+        root * /pb_public
+        try_files {path} /index.html
+        file_server {
+            precompressed br gzip
+        }
+    }
+}
+```
+
+**Edge responsibilities (keep at Traefik/CrowdSec):** TLS termination, HSTS, rate limiting, bot detection, WAF rules, CORS policy, IP reputation, access log shipping.
+
+### 4b. Other infrastructure gaps
+
+| Impact | Finding | File | Fix |
+|--------|---------|------|-----|
+| **HIGH** | `kindred-caddy` isn't rebuilt/pushed on every CD run — only during release promotion | `.github/workflows/cd.yml` (around line 412) | Add `kindred-caddy` to `IMAGES[]` and `docker/Dockerfile.caddy` to `DOCKERFILES[]` so security patches ship with every merge to main |
+| **MEDIUM** | Release workflow has no `concurrency:` group | `.github/workflows/release.yml` | Add `concurrency: { group: release, cancel-in-progress: false }` so two manual dispatches can't race |
+| **MEDIUM** | `pytest-xdist` not enabled | `pyproject.toml` | Add `pytest-xdist` to dev group + `-n auto` in addopts → ~3–4× CI speedup |
+| **MEDIUM** | CodeQL (SAST) not enabled | `.github/workflows/` | Add `codeql.yml` for Python + JavaScript |
+| **LOW** | GitHub Dependency Review not gating PRs | `ci.yml` | Complements Dependabot by blocking vulnerable deps at PR time |
+| **LOW** | No ARM64 multi-arch builds | `cd.yml` | Only matters if deploying to Pi / Apple Silicon |
+| **LOW** | Caddy base image unpinned (`dhi.io/caddy:2`) | `docker/Dockerfile.caddy` | Pin to minor (e.g. `:2.8`) |
+| **LOW** | No SBOM/provenance attestation, no cosign image signing | `cd.yml` | Supply-chain nice-to-have |
+
+### Already adopted (no action)
+
+- `COPY --link` used across all Dockerfiles ✓
+- `HEALTHCHECK` in every Dockerfile ✓
+- Multi-stage builds in all 4 Dockerfiles ✓
+- Wolfi/distroless final images (api on `chainguard/wolfi-base`, pocketbase + caddy on `chainguard/static`) ✓
+- Concurrency groups on CI and CD ✓
+- Path filters in CD PR validation ✓
+- Least-privilege `permissions: contents: read` on CI ✓
+- Trivy scanning with weekly schedule + SARIF upload ✓
+- `uv` + PEP 735 `[dependency-groups]` ✓
+- mypy `strict = true` ✓
+- Ruff as single linter (no black/autopep8 conflict) ✓
+- commitlint enforced on PRs ✓
+- git-cliff changelog in release workflow ✓
+- Gitleaks secret scanning in CI ✓
+
+### Recommended infrastructure PR order
+
+1. `fix(ci): add caddy to CD build+push pipeline` + `build(docker): pin caddy base image` — combined, ships Caddy patches continuously
+2. `build(caddy): minimum hardened config behind Traefik` — the config block above, applied to both Caddyfiles
+3. `ci: add release workflow concurrency group`
+4. `perf(ci): enable pytest-xdist`
+5. `ci: add CodeQL + dependency-review workflows`
+6. Optional: ARM64 multi-arch, SBOM/cosign — only if there's a concrete driver
+
+---
+
+## Suggested overall PR order
+
+One PR per row, roughly in this sequence:
+
+1. **This PR** — `chore(docs): comprehensive modernization backlog + README overhaul` (ships with `CLAUDE.md` pin fixes)
+2. `chore(ci): ruff target-version py314 + autofix UP037/UP043 cascade`
+3. `chore(py): drop redundant __future__ annotations import`
+4. `refactor(pb): interface{} → any codemod`
+4. `refactor(api): adopt asyncio.TaskGroup in metrics services`
+5. `fix(sync): replace string-based error matching with sentinel errors`
+6. `refactor(frontend): Array.toSorted + Object.groupBy`
+7. `refactor(frontend): error cause chaining`
+8. `fix(ci): rebuild caddy on every CD run + pin base image`
+9. `build(caddy): minimum hardened production config`
+10. `refactor(api): itertools.batched for chunking`
+11. `refactor(pb): slices package helpers + clear() builtin`
+12. `refactor(frontend): adopt React 19 use() for contexts`
+13. `refactor(frontend): React Query queryOptions + skipToken`
+14. `perf(frontend): lazy-load large modals`
+15. `perf(ci): enable pytest-xdist`
+16. `ci: add CodeQL + dependency-review`
+17. Remaining LOW items opportunistically
+
+---
+
+## Review cadence
+
+Revisit this doc quarterly or when bumping a major language/framework version. Keep the "already adopted" lists in each section so future audits don't rediscover the same wins.

--- a/ruff.toml
+++ b/ruff.toml
@@ -17,8 +17,8 @@ exclude = [
     "docs/reference/skeleton-*.py",  # Documentation skeletons, not meant to run
 ]
 
-# Target Python 3.12+
-target-version = "py312"
+# Target Python 3.14+
+target-version = "py314"
 
 # Line length
 line-length = 120

--- a/scripts/data/seed_city_coords.py
+++ b/scripts/data/seed_city_coords.py
@@ -48,7 +48,7 @@ def generate(csv_path: Path) -> None:
         try:
             lat = float(row["lat"])
             lng = float(row["lng"])
-        except (ValueError, KeyError):
+        except ValueError, KeyError:
             continue
 
         canonical = f"{name}, {state}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,7 +100,7 @@ def mock_all_external_services():
             with patch("scripts.services.config_service.PocketBase") as mock_config_pb:
                 mock_config_pb.return_value = mock_pb
                 yield {"pocketbase": mock_pb}
-        except (ImportError, ModuleNotFoundError, AttributeError):
+        except ImportError, ModuleNotFoundError, AttributeError:
             yield {"pocketbase": mock_pb}
 
 

--- a/tests/frontend_import_tests/test_helpers/mock_factory.py
+++ b/tests/frontend_import_tests/test_helpers/mock_factory.py
@@ -179,7 +179,7 @@ class MockFactory:
         return MockFactory.create_pocketbase_record("friend_groups", defaults)
 
     @staticmethod
-    def create_solver_camper(camper_id: str = "1", **kwargs: Any) -> "Camper":
+    def create_solver_camper(camper_id: str = "1", **kwargs: Any) -> Camper:
         """Create a mock Camper object for solver"""
         # Import here to avoid circular imports
         from bunking.models import Camper
@@ -196,7 +196,7 @@ class MockFactory:
         return Camper(**defaults)
 
     @staticmethod
-    def create_solver_cabin(cabin_id: str = "1", **kwargs: Any) -> "Cabin":
+    def create_solver_cabin(cabin_id: str = "1", **kwargs: Any) -> Cabin:
         """Create a mock Cabin object for solver"""
         # Import here to avoid circular imports
         from bunking.models import Cabin

--- a/tests/performance/load_test.py
+++ b/tests/performance/load_test.py
@@ -86,7 +86,7 @@ class LoadTester:
                     if "Processed" in line and "requests" in line:
                         try:
                             records_processed = int(line.split()[1])
-                        except (ValueError, IndexError):
+                        except ValueError, IndexError:
                             pass
 
                 self.results["sync_performance"].append(

--- a/tests/performance/profile_solver_simple.py
+++ b/tests/performance/profile_solver_simple.py
@@ -61,7 +61,7 @@ def run_single_scenario(profiler, name, num_campers=500, num_cabins=42, cabin_ca
         elif "objective:" in line and objective is None:
             try:
                 objective = int(line.split("objective:")[1].strip())
-            except (ValueError, IndexError):
+            except ValueError, IndexError:
                 pass
 
     # Update result with parsed info

--- a/tests/unit/api/routers/test_debug_original_requests_by_camper.py
+++ b/tests/unit/api/routers/test_debug_original_requests_by_camper.py
@@ -72,7 +72,7 @@ def mock_pb() -> MagicMock:
 
 
 @pytest.fixture
-def client_with_mock_pb(mock_pb: MagicMock) -> Generator[tuple[TestClient, MagicMock], None, None]:
+def client_with_mock_pb(mock_pb: MagicMock) -> Generator[tuple[TestClient, MagicMock]]:
     """Create test client with mocked PB client."""
     with patch("api.routers.debug.pb", mock_pb):
         from api.routers.debug import router

--- a/tests/unit/api/routers/test_debug_run_full_trace_trace_id.py
+++ b/tests/unit/api/routers/test_debug_run_full_trace_trace_id.py
@@ -72,7 +72,7 @@ def mock_pb() -> MagicMock:
 
 
 @pytest.fixture
-def client_with_mock_pb(mock_pb: MagicMock) -> Generator[tuple[TestClient, MagicMock], None, None]:
+def client_with_mock_pb(mock_pb: MagicMock) -> Generator[tuple[TestClient, MagicMock]]:
     """Create test client with mocked PB client."""
     with patch("api.routers.debug.pb", mock_pb):
         from api.routers.debug import router

--- a/tests/unit/api/routers/test_debug_search_persons.py
+++ b/tests/unit/api/routers/test_debug_search_persons.py
@@ -65,7 +65,7 @@ def mock_pb() -> MagicMock:
 
 
 @pytest.fixture
-def client_with_mock_pb(mock_pb: MagicMock) -> Generator[tuple[TestClient, MagicMock], None, None]:
+def client_with_mock_pb(mock_pb: MagicMock) -> Generator[tuple[TestClient, MagicMock]]:
     """Create test client with mocked PB client."""
     with patch("api.routers.debug.pb", mock_pb):
         from api.routers.debug import router

--- a/tests/unit/api/test_debug_endpoints.py
+++ b/tests/unit/api/test_debug_endpoints.py
@@ -49,9 +49,7 @@ class TestListParseAnalysisEndpoint:
         }
 
     @pytest.fixture
-    def client_with_mocks(
-        self, mock_repos: dict[str, Mock]
-    ) -> Generator[tuple[TestClient, dict[str, Mock]], None, None]:
+    def client_with_mocks(self, mock_repos: dict[str, Mock]) -> Generator[tuple[TestClient, dict[str, Mock]]]:
         """Create test client with mocked repositories."""
         with patch("api.routers.debug.get_debug_parse_repository") as mock_get_debug_repo:
             with patch("api.routers.debug.get_session_repository") as mock_get_session_repo:
@@ -181,9 +179,7 @@ class TestGetParseAnalysisDetailEndpoint:
         return {"debug_repo": Mock()}
 
     @pytest.fixture
-    def client_with_mocks(
-        self, mock_repos: dict[str, Mock]
-    ) -> Generator[tuple[TestClient, dict[str, Mock]], None, None]:
+    def client_with_mocks(self, mock_repos: dict[str, Mock]) -> Generator[tuple[TestClient, dict[str, Mock]]]:
         """Create test client with mocked repositories."""
         with patch("api.routers.debug.get_debug_parse_repository") as mock_get_debug_repo:
             mock_get_debug_repo.return_value = mock_repos["debug_repo"]
@@ -241,9 +237,7 @@ class TestPhase1OnlyEndpoint:
         return {"debug_service": AsyncMock()}
 
     @pytest.fixture
-    def client_with_mocks(
-        self, mock_services: dict[str, Mock]
-    ) -> Generator[tuple[TestClient, dict[str, Mock]], None, None]:
+    def client_with_mocks(self, mock_services: dict[str, Mock]) -> Generator[tuple[TestClient, dict[str, Mock]]]:
         """Create test client with mocked services."""
         with patch("api.routers.debug.get_phase1_debug_service") as mock_get_service:
             mock_get_service.return_value = mock_services["debug_service"]
@@ -344,9 +338,7 @@ class TestClearParseAnalysisEndpoint:
         return {"debug_repo": Mock()}
 
     @pytest.fixture
-    def client_with_mocks(
-        self, mock_repos: dict[str, Mock]
-    ) -> Generator[tuple[TestClient, dict[str, Mock]], None, None]:
+    def client_with_mocks(self, mock_repos: dict[str, Mock]) -> Generator[tuple[TestClient, dict[str, Mock]]]:
         """Create test client with mocked repositories."""
         with patch("api.routers.debug.get_debug_parse_repository") as mock_get_debug_repo:
             mock_get_debug_repo.return_value = mock_repos["debug_repo"]
@@ -393,7 +385,7 @@ class TestListOriginalRequestsEndpoint:
         return Mock()
 
     @pytest.fixture
-    def client_with_mocks(self, mock_loader: Mock) -> Generator[tuple[TestClient, Mock], None, None]:
+    def client_with_mocks(self, mock_loader: Mock) -> Generator[tuple[TestClient, Mock]]:
         """Create test client with mocked dependencies."""
         # Patch the OriginalRequestsLoader class since impl instantiates it directly
         with patch("api.routers.debug.OriginalRequestsLoader") as MockLoaderClass:
@@ -731,7 +723,7 @@ class TestListOriginalRequestsWithParseStatusEndpoint:
     @pytest.fixture
     def client_with_mocks(
         self, mock_repos: dict[str, Mock], mock_loader: Mock
-    ) -> Generator[tuple[TestClient, dict[str, Mock], Mock], None, None]:
+    ) -> Generator[tuple[TestClient, dict[str, Mock], Mock]]:
         """Create test client with mocked dependencies."""
         with patch("api.routers.debug.get_debug_parse_repository") as mock_get_debug_repo:
             with patch("api.routers.debug.get_session_repository") as mock_get_session_repo:
@@ -827,9 +819,7 @@ class TestGetParseResultWithFallbackEndpoint:
         }
 
     @pytest.fixture
-    def client_with_mocks(
-        self, mock_deps: dict[str, Mock]
-    ) -> Generator[tuple[TestClient, dict[str, Mock]], None, None]:
+    def client_with_mocks(self, mock_deps: dict[str, Mock]) -> Generator[tuple[TestClient, dict[str, Mock]]]:
         """Create test client with mocked dependencies."""
         with patch("api.routers.debug.get_debug_parse_repository") as mock_get_debug_repo:
             with patch("api.routers.debug.get_original_requests_loader") as mock_get_loader:
@@ -1016,9 +1006,7 @@ class TestGetParseResultAlwaysIncludesOriginal:
         }
 
     @pytest.fixture
-    def client_with_mocks(
-        self, mock_deps: dict[str, Mock]
-    ) -> Generator[tuple[TestClient, dict[str, Mock]], None, None]:
+    def client_with_mocks(self, mock_deps: dict[str, Mock]) -> Generator[tuple[TestClient, dict[str, Mock]]]:
         """Create test client with mocked dependencies."""
         with patch("api.routers.debug.get_debug_parse_repository") as mock_get_debug_repo:
             with patch("api.routers.debug.get_original_requests_loader") as mock_get_loader:
@@ -1202,7 +1190,7 @@ class TestBatchParseStatusEndpoint:
     @pytest.fixture
     def client_with_mocks(
         self, mock_deps: dict[str, Mock], mock_loader: Mock
-    ) -> Generator[tuple[TestClient, dict[str, Mock], Mock], None, None]:
+    ) -> Generator[tuple[TestClient, dict[str, Mock], Mock]]:
         """Create test client with mocked dependencies."""
         with patch("api.routers.debug.get_debug_parse_repository") as mock_get_debug_repo:
             with patch("api.routers.debug.OriginalRequestsLoader") as MockLoaderClass:
@@ -1287,7 +1275,7 @@ class TestGroupedByCamperEndpoint:
     @pytest.fixture
     def client_with_mocks(
         self, mock_deps: dict[str, Mock], mock_loader: Mock
-    ) -> Generator[tuple[TestClient, dict[str, Mock], Mock], None, None]:
+    ) -> Generator[tuple[TestClient, dict[str, Mock], Mock]]:
         """Create test client with mocked dependencies."""
         with patch("api.routers.debug.get_debug_parse_repository") as mock_get_debug_repo:
             with patch("api.routers.debug.OriginalRequestsLoader") as MockLoaderClass:
@@ -1445,9 +1433,7 @@ class TestClearSingleDebugResultEndpoint:
         return {"debug_repo": Mock()}
 
     @pytest.fixture
-    def client_with_mocks(
-        self, mock_repos: dict[str, Mock]
-    ) -> Generator[tuple[TestClient, dict[str, Mock]], None, None]:
+    def client_with_mocks(self, mock_repos: dict[str, Mock]) -> Generator[tuple[TestClient, dict[str, Mock]]]:
         """Create test client with mocked repositories."""
         with patch("api.routers.debug.get_debug_parse_repository") as mock_get_debug_repo:
             mock_get_debug_repo.return_value = mock_repos["debug_repo"]
@@ -1501,9 +1487,7 @@ class TestScopedClearEndpoint:
         }
 
     @pytest.fixture
-    def client_with_mocks(
-        self, mock_repos: dict[str, Mock]
-    ) -> Generator[tuple[TestClient, dict[str, Mock]], None, None]:
+    def client_with_mocks(self, mock_repos: dict[str, Mock]) -> Generator[tuple[TestClient, dict[str, Mock]]]:
         """Create test client with mocked repositories."""
         with patch("api.routers.debug.get_debug_parse_repository") as mock_get_debug_repo:
             with patch("api.routers.debug.get_session_repository") as mock_get_session_repo:
@@ -1616,9 +1600,7 @@ class TestProductionRequestsEndpoint:
         }
 
     @pytest.fixture
-    def client_with_mocks(
-        self, mock_deps: dict[str, Mock]
-    ) -> Generator[tuple[TestClient, dict[str, Mock]], None, None]:
+    def client_with_mocks(self, mock_deps: dict[str, Mock]) -> Generator[tuple[TestClient, dict[str, Mock]]]:
         """Create test client with mocked dependencies."""
         with patch("api.routers.debug.get_bunk_requests_repository") as mock_get_bunk_repo:
             with patch("api.routers.debug.get_session_repository") as mock_get_session_repo:
@@ -1802,9 +1784,7 @@ class TestProductionRequestsResponseSchema:
         }
 
     @pytest.fixture
-    def client_with_mocks(
-        self, mock_deps: dict[str, Mock]
-    ) -> Generator[tuple[TestClient, dict[str, Mock]], None, None]:
+    def client_with_mocks(self, mock_deps: dict[str, Mock]) -> Generator[tuple[TestClient, dict[str, Mock]]]:
         """Create test client with mocked dependencies."""
         with patch("api.routers.debug.get_bunk_requests_repository") as mock_get_bunk_repo:
             mock_get_bunk_repo.return_value = mock_deps["bunk_requests_repo"]

--- a/tests/unit/api/test_debug_phase_run_endpoints.py
+++ b/tests/unit/api/test_debug_phase_run_endpoints.py
@@ -108,7 +108,7 @@ def mock_phase_runner() -> MagicMock:
 @pytest.fixture
 def client_with_mocks(
     mock_pb: MagicMock, mock_phase_runner: MagicMock
-) -> Generator[tuple[TestClient, MagicMock, MagicMock], None, None]:
+) -> Generator[tuple[TestClient, MagicMock, MagicMock]]:
     """Create test client with mocked PB client and PhaseRunner."""
     with patch("api.routers.debug.pb", mock_pb):
         with patch("api.routers.debug._create_phase_runner", return_value=mock_phase_runner):

--- a/tests/unit/api/test_debug_pipeline_endpoints.py
+++ b/tests/unit/api/test_debug_pipeline_endpoints.py
@@ -141,7 +141,7 @@ def mock_pb() -> MagicMock:
 
 
 @pytest.fixture
-def client_with_mock_pb(mock_pb: MagicMock) -> Generator[tuple[TestClient, MagicMock], None, None]:
+def client_with_mock_pb(mock_pb: MagicMock) -> Generator[tuple[TestClient, MagicMock]]:
     """Create test client with mocked PB client.
 
     Patches the pb module-level variable in the debug router so all

--- a/tests/unit/api/test_requests_merge.py
+++ b/tests/unit/api/test_requests_merge.py
@@ -105,7 +105,7 @@ class TestMergeEndpointSuccess:
         return mock_request_repo, mock_source_link_repo
 
     @pytest.fixture
-    def client_with_mocks(self, mock_repos: tuple[Mock, Mock]) -> Generator[tuple[TestClient, Mock, Mock], None, None]:
+    def client_with_mocks(self, mock_repos: tuple[Mock, Mock]) -> Generator[tuple[TestClient, Mock, Mock]]:
         """Create test client with mocked repositories."""
         mock_request_repo, mock_source_link_repo = mock_repos
 
@@ -343,7 +343,7 @@ class TestMergeEndpointErrors:
         return mock_request_repo, mock_source_link_repo
 
     @pytest.fixture
-    def client_with_mocks(self, mock_repos: tuple[Mock, Mock]) -> Generator[tuple[TestClient, Mock, Mock], None, None]:
+    def client_with_mocks(self, mock_repos: tuple[Mock, Mock]) -> Generator[tuple[TestClient, Mock, Mock]]:
         """Create test client with mocked repositories."""
         mock_request_repo, mock_source_link_repo = mock_repos
 

--- a/tests/unit/api/test_requests_soft_delete.py
+++ b/tests/unit/api/test_requests_soft_delete.py
@@ -259,7 +259,7 @@ class TestMergeEndpointSoftDelete:
         return mock_request_repo, mock_source_link_repo
 
     @pytest.fixture
-    def client_with_mocks(self, mock_repos: tuple[Mock, Mock]) -> Generator[tuple[TestClient, Mock, Mock], None, None]:
+    def client_with_mocks(self, mock_repos: tuple[Mock, Mock]) -> Generator[tuple[TestClient, Mock, Mock]]:
         """Create test client with mocked repositories."""
         mock_request_repo, mock_source_link_repo = mock_repos
 
@@ -389,7 +389,7 @@ class TestSplitEndpointRestore:
         return mock_request_repo, mock_source_link_repo
 
     @pytest.fixture
-    def client_with_mocks(self, mock_repos: tuple[Mock, Mock]) -> Generator[tuple[TestClient, Mock, Mock], None, None]:
+    def client_with_mocks(self, mock_repos: tuple[Mock, Mock]) -> Generator[tuple[TestClient, Mock, Mock]]:
         """Create test client with mocked repositories."""
         mock_request_repo, mock_source_link_repo = mock_repos
 

--- a/tests/unit/api/test_requests_split.py
+++ b/tests/unit/api/test_requests_split.py
@@ -100,7 +100,7 @@ class TestSplitEndpointSuccess:
         return mock_request_repo, mock_source_link_repo
 
     @pytest.fixture
-    def client_with_mocks(self, mock_repos: tuple[Mock, Mock]) -> Generator[tuple[TestClient, Mock, Mock], None, None]:
+    def client_with_mocks(self, mock_repos: tuple[Mock, Mock]) -> Generator[tuple[TestClient, Mock, Mock]]:
         """Create test client with mocked repositories."""
         mock_request_repo, mock_source_link_repo = mock_repos
 
@@ -245,7 +245,7 @@ class TestSplitEndpointErrors:
         return mock_request_repo, mock_source_link_repo
 
     @pytest.fixture
-    def client_with_mocks(self, mock_repos: tuple[Mock, Mock]) -> Generator[tuple[TestClient, Mock, Mock], None, None]:
+    def client_with_mocks(self, mock_repos: tuple[Mock, Mock]) -> Generator[tuple[TestClient, Mock, Mock]]:
         """Create test client with mocked repositories."""
         mock_request_repo, mock_source_link_repo = mock_repos
 
@@ -361,7 +361,7 @@ class TestSplitEndpointPrimaryValidation:
         return mock_request_repo, mock_source_link_repo
 
     @pytest.fixture
-    def client_with_mocks(self, mock_repos: tuple[Mock, Mock]) -> Generator[tuple[TestClient, Mock, Mock], None, None]:
+    def client_with_mocks(self, mock_repos: tuple[Mock, Mock]) -> Generator[tuple[TestClient, Mock, Mock]]:
         """Create test client with mocked repositories."""
         mock_request_repo, mock_source_link_repo = mock_repos
 
@@ -457,7 +457,7 @@ class TestSplitEndpointMergedFromUpdate:
         return mock_request_repo, mock_source_link_repo
 
     @pytest.fixture
-    def client_with_mocks(self, mock_repos: tuple[Mock, Mock]) -> Generator[tuple[TestClient, Mock, Mock], None, None]:
+    def client_with_mocks(self, mock_repos: tuple[Mock, Mock]) -> Generator[tuple[TestClient, Mock, Mock]]:
         """Create test client with mocked repositories."""
         mock_request_repo, mock_source_link_repo = mock_repos
 

--- a/tests/unit/sync/bunk_request_processor/data/repositories/test_debug_parse_repository.py
+++ b/tests/unit/sync/bunk_request_processor/data/repositories/test_debug_parse_repository.py
@@ -35,7 +35,7 @@ class TestDebugParseRepositorySaveResult:
         return mock_client, mock_collection
 
     @pytest.fixture
-    def repository(self, mock_pb_client: tuple[Mock, Mock]) -> "DebugParseRepository":
+    def repository(self, mock_pb_client: tuple[Mock, Mock]) -> DebugParseRepository:
         """Create a DebugParseRepository with mocked client."""
         from bunking.sync.bunk_request_processor.data.repositories.debug_parse_repository import (
             DebugParseRepository,
@@ -45,7 +45,7 @@ class TestDebugParseRepositorySaveResult:
         return DebugParseRepository(mock_client)
 
     def test_save_result_creates_record_with_all_fields(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that save_result creates a record with all required fields."""
         _, mock_collection = mock_pb_client
@@ -89,7 +89,7 @@ class TestDebugParseRepositorySaveResult:
         assert create_args["is_valid"] is True
 
     def test_save_result_handles_empty_session(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that save_result handles None session gracefully."""
         _, mock_collection = mock_pb_client
@@ -109,7 +109,7 @@ class TestDebugParseRepositorySaveResult:
         assert create_args.get("session", "") == ""
 
     def test_save_result_stores_error_for_failed_parse(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that save_result stores error message for failed parses."""
         _, mock_collection = mock_pb_client
@@ -129,7 +129,7 @@ class TestDebugParseRepositorySaveResult:
         assert create_args["error_message"] == "AI parsing failed: rate limit exceeded"
 
     def test_save_result_returns_none_on_error(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that save_result returns None on database error."""
         _, mock_collection = mock_pb_client
@@ -158,7 +158,7 @@ class TestDebugParseRepositoryGetByOriginalRequest:
         return mock_client, mock_collection
 
     @pytest.fixture
-    def repository(self, mock_pb_client: tuple[Mock, Mock]) -> "DebugParseRepository":
+    def repository(self, mock_pb_client: tuple[Mock, Mock]) -> DebugParseRepository:
         """Create a DebugParseRepository with mocked client."""
         from bunking.sync.bunk_request_processor.data.repositories.debug_parse_repository import (
             DebugParseRepository,
@@ -168,7 +168,7 @@ class TestDebugParseRepositoryGetByOriginalRequest:
         return DebugParseRepository(mock_client)
 
     def test_get_by_original_request_returns_cached_result(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that get_by_original_request returns cached debug result."""
         _, mock_collection = mock_pb_client
@@ -201,7 +201,7 @@ class TestDebugParseRepositoryGetByOriginalRequest:
         assert 'original_request = "orig_req_456"' in filter_str
 
     def test_get_by_original_request_returns_none_when_not_found(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that get_by_original_request returns None when no cached result."""
         _, mock_collection = mock_pb_client
@@ -215,7 +215,7 @@ class TestDebugParseRepositoryGetByOriginalRequest:
         assert result is None
 
     def test_get_by_original_request_returns_most_recent(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that get_by_original_request returns the most recent result."""
         _, mock_collection = mock_pb_client
@@ -262,7 +262,7 @@ class TestDebugParseRepositoryListWithOriginals:
         return mock_client, mock_collection
 
     @pytest.fixture
-    def repository(self, mock_pb_client: tuple[Mock, Mock]) -> "DebugParseRepository":
+    def repository(self, mock_pb_client: tuple[Mock, Mock]) -> DebugParseRepository:
         """Create a DebugParseRepository with mocked client."""
         from bunking.sync.bunk_request_processor.data.repositories.debug_parse_repository import (
             DebugParseRepository,
@@ -272,7 +272,7 @@ class TestDebugParseRepositoryListWithOriginals:
         return DebugParseRepository(mock_client)
 
     def test_list_with_originals_expands_relations(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that list_with_originals expands original_request and person."""
         _, mock_collection = mock_pb_client
@@ -326,7 +326,7 @@ class TestDebugParseRepositoryListWithOriginals:
         assert "original_request.requester" in expand_str
 
     def test_list_with_originals_filters_by_session(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that list_with_originals filters by session when provided."""
         _, mock_collection = mock_pb_client
@@ -343,7 +343,7 @@ class TestDebugParseRepositoryListWithOriginals:
         assert 'session = "sess_789"' in filter_str
 
     def test_list_with_originals_filters_by_source_field(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that list_with_originals filters by source field when provided."""
         _, mock_collection = mock_pb_client
@@ -360,7 +360,7 @@ class TestDebugParseRepositoryListWithOriginals:
         assert 'original_request.field = "bunking_notes"' in filter_str
 
     def test_list_with_originals_applies_pagination(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that list_with_originals applies limit and offset."""
         _, mock_collection = mock_pb_client
@@ -389,7 +389,7 @@ class TestDebugParseRepositoryClearAll:
         return mock_client, mock_collection
 
     @pytest.fixture
-    def repository(self, mock_pb_client: tuple[Mock, Mock]) -> "DebugParseRepository":
+    def repository(self, mock_pb_client: tuple[Mock, Mock]) -> DebugParseRepository:
         """Create a DebugParseRepository with mocked client."""
         from bunking.sync.bunk_request_processor.data.repositories.debug_parse_repository import (
             DebugParseRepository,
@@ -399,7 +399,7 @@ class TestDebugParseRepositoryClearAll:
         return DebugParseRepository(mock_client)
 
     def test_clear_all_deletes_all_records(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that clear_all deletes all debug records."""
         _, mock_collection = mock_pb_client
@@ -429,7 +429,7 @@ class TestDebugParseRepositoryClearAll:
         mock_collection.delete.assert_any_call("debug_2")
 
     def test_clear_all_returns_zero_when_empty(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that clear_all returns 0 when no records exist."""
         _, mock_collection = mock_pb_client
@@ -444,7 +444,7 @@ class TestDebugParseRepositoryClearAll:
         mock_collection.delete.assert_not_called()
 
     def test_clear_all_returns_negative_on_error(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that clear_all returns -1 on error."""
         _, mock_collection = mock_pb_client
@@ -468,7 +468,7 @@ class TestDebugParseRepositoryDeleteByOriginalRequest:
         return mock_client, mock_collection
 
     @pytest.fixture
-    def repository(self, mock_pb_client: tuple[Mock, Mock]) -> "DebugParseRepository":
+    def repository(self, mock_pb_client: tuple[Mock, Mock]) -> DebugParseRepository:
         """Create a DebugParseRepository with mocked client."""
         from bunking.sync.bunk_request_processor.data.repositories.debug_parse_repository import (
             DebugParseRepository,
@@ -478,7 +478,7 @@ class TestDebugParseRepositoryDeleteByOriginalRequest:
         return DebugParseRepository(mock_client)
 
     def test_delete_by_original_request_removes_cached_result(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that delete_by_original_request removes cached debug result."""
         _, mock_collection = mock_pb_client
@@ -496,7 +496,7 @@ class TestDebugParseRepositoryDeleteByOriginalRequest:
         mock_collection.delete.assert_called_once_with("debug_123")
 
     def test_delete_by_original_request_returns_false_when_not_found(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that delete_by_original_request returns False when no result."""
         _, mock_collection = mock_pb_client
@@ -523,7 +523,7 @@ class TestDebugParseRepositoryGetProductionFallback:
         return mock_client, mock_collection
 
     @pytest.fixture
-    def repository(self, mock_pb_client: tuple[Mock, Mock]) -> "DebugParseRepository":
+    def repository(self, mock_pb_client: tuple[Mock, Mock]) -> DebugParseRepository:
         """Create a DebugParseRepository with mocked client."""
         from bunking.sync.bunk_request_processor.data.repositories.debug_parse_repository import (
             DebugParseRepository,
@@ -533,7 +533,7 @@ class TestDebugParseRepositoryGetProductionFallback:
         return DebugParseRepository(mock_client)
 
     def test_get_production_fallback_returns_bunk_request_data(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that get_production_fallback returns data from bunk_requests."""
         mock_client, _ = mock_pb_client
@@ -586,7 +586,7 @@ class TestDebugParseRepositoryGetProductionFallback:
         assert result["parsed_intents"][0]["target_name"] == "Emma Johnson"
 
     def test_get_production_fallback_returns_none_when_no_sources(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that get_production_fallback returns None when no bunk_request_sources exist."""
         mock_client, _ = mock_pb_client
@@ -609,7 +609,7 @@ class TestDebugParseRepositoryGetProductionFallback:
         assert result is None
 
     def test_get_production_fallback_returns_none_when_no_ai_reasoning(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that get_production_fallback returns None when bunk_request has no ai_p1_reasoning."""
         mock_client, _ = mock_pb_client
@@ -639,7 +639,7 @@ class TestDebugParseRepositoryGetProductionFallback:
         assert result is None
 
     def test_get_production_fallback_aggregates_multiple_bunk_requests(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that get_production_fallback aggregates intents from multiple bunk_requests."""
         mock_client, _ = mock_pb_client
@@ -697,7 +697,7 @@ class TestDebugParseRepositoryGetProductionFallback:
         assert "Mia" in target_names
 
     def test_get_production_fallback_handles_db_error(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that get_production_fallback returns None on database error."""
         mock_client, _ = mock_pb_client
@@ -727,7 +727,7 @@ class TestDebugParseRepositoryCheckParseStatus:
         return mock_client, mock_collection
 
     @pytest.fixture
-    def repository(self, mock_pb_client: tuple[Mock, Mock]) -> "DebugParseRepository":
+    def repository(self, mock_pb_client: tuple[Mock, Mock]) -> DebugParseRepository:
         """Create a DebugParseRepository with mocked client."""
         from bunking.sync.bunk_request_processor.data.repositories.debug_parse_repository import (
             DebugParseRepository,
@@ -737,7 +737,7 @@ class TestDebugParseRepositoryCheckParseStatus:
         return DebugParseRepository(mock_client)
 
     def test_check_parse_status_detects_debug_result(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that check_parse_status correctly detects debug results exist."""
         mock_client, _ = mock_pb_client
@@ -777,7 +777,7 @@ class TestDebugParseRepositoryCheckParseStatus:
         assert has_production is False
 
     def test_check_parse_status_detects_production_result(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that check_parse_status correctly detects production results exist."""
         mock_client, _ = mock_pb_client
@@ -817,7 +817,7 @@ class TestDebugParseRepositoryCheckParseStatus:
         assert has_production is True
 
     def test_check_parse_status_detects_both(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that check_parse_status detects when both debug and production exist."""
         mock_client, _ = mock_pb_client
@@ -857,7 +857,7 @@ class TestDebugParseRepositoryCheckParseStatus:
         assert has_production is True
 
     def test_check_parse_status_detects_neither(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that check_parse_status correctly detects when no parse results exist."""
         mock_client, _ = mock_pb_client
@@ -916,7 +916,7 @@ class TestDebugParseRepositoryAiP1ReasoningBugs:
         return mock_client, mock_collection
 
     @pytest.fixture
-    def repository(self, mock_pb_client: tuple[Mock, Mock]) -> "DebugParseRepository":
+    def repository(self, mock_pb_client: tuple[Mock, Mock]) -> DebugParseRepository:
         """Create a DebugParseRepository with mocked client."""
         from bunking.sync.bunk_request_processor.data.repositories.debug_parse_repository import (
             DebugParseRepository,
@@ -926,7 +926,7 @@ class TestDebugParseRepositoryAiP1ReasoningBugs:
         return DebugParseRepository(mock_client)
 
     def test_get_production_fallback_reads_ai_p1_reasoning_column(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that get_production_fallback reads reasoning from ai_p1_reasoning column.
 
@@ -991,7 +991,7 @@ class TestDebugParseRepositoryAiP1ReasoningBugs:
         )
 
     def test_get_results_batch_reads_ai_p1_reasoning_column(
-        self, repository: "DebugParseRepository", mock_pb_client: tuple[Mock, Mock]
+        self, repository: DebugParseRepository, mock_pb_client: tuple[Mock, Mock]
     ) -> None:
         """Test that get_results_batch code path uses ai_p1_reasoning column.
 

--- a/tests/unit/sync/bunk_request_processor/prompts/test_parse_prompts_no_group.py
+++ b/tests/unit/sync/bunk_request_processor/prompts/test_parse_prompts_no_group.py
@@ -41,7 +41,7 @@ PARSE_PROMPT_NAMES = (
 
 
 @pytest.fixture(autouse=True)
-def _reset_prompt_cache() -> Generator[None, None, None]:
+def _reset_prompt_cache() -> Generator[None]:
     # Ensure every test reads the current on-disk prompt, not a cached copy
     # left behind by another test.
     clear_cache()

--- a/tests/unit/sync/bunk_request_processor/prompts/test_parse_request_two_word_rule.py
+++ b/tests/unit/sync/bunk_request_processor/prompts/test_parse_request_two_word_rule.py
@@ -21,7 +21,7 @@ from bunking.sync.bunk_request_processor.prompts.loader import (
 
 
 @pytest.fixture(autouse=True)
-def _reset_prompt_cache() -> Generator[None, None, None]:
+def _reset_prompt_cache() -> Generator[None]:
     clear_cache()
     yield
     clear_cache()

--- a/tests/unit/sync/bunk_request_processor/services/test_phase1_debug_service.py
+++ b/tests/unit/sync/bunk_request_processor/services/test_phase1_debug_service.py
@@ -42,7 +42,7 @@ class TestPhase1DebugServiceParseSelectedRecords:
         }
 
     @pytest.fixture
-    def debug_service(self, mock_dependencies: dict[str, Mock]) -> "Phase1DebugService":
+    def debug_service(self, mock_dependencies: dict[str, Mock]) -> Phase1DebugService:
         """Create a Phase1DebugService with mocked dependencies."""
         from bunking.sync.bunk_request_processor.services.phase1_debug_service import (
             Phase1DebugService,
@@ -56,7 +56,7 @@ class TestPhase1DebugServiceParseSelectedRecords:
 
     @pytest.mark.asyncio
     async def test_parse_selected_records_loads_and_parses(
-        self, debug_service: "Phase1DebugService", mock_dependencies: dict[str, Mock]
+        self, debug_service: Phase1DebugService, mock_dependencies: dict[str, Mock]
     ) -> None:
         """Test that parse_selected_records loads records and runs Phase 1."""
         # Mock no cached result (returns None, not a Mock)
@@ -126,7 +126,7 @@ class TestPhase1DebugServiceParseSelectedRecords:
 
     @pytest.mark.asyncio
     async def test_parse_selected_records_skips_cached_when_not_force(
-        self, debug_service: "Phase1DebugService", mock_dependencies: dict[str, Mock]
+        self, debug_service: Phase1DebugService, mock_dependencies: dict[str, Mock]
     ) -> None:
         """Test that cached results are returned when force_reparse=False."""
         # Mock cached result exists
@@ -149,7 +149,7 @@ class TestPhase1DebugServiceParseSelectedRecords:
 
     @pytest.mark.asyncio
     async def test_parse_selected_records_reparses_when_force(
-        self, debug_service: "Phase1DebugService", mock_dependencies: dict[str, Mock]
+        self, debug_service: Phase1DebugService, mock_dependencies: dict[str, Mock]
     ) -> None:
         """Test that records are reparsed when force_reparse=True."""
         # Mock cached result exists
@@ -190,7 +190,7 @@ class TestPhase1DebugServiceParseSelectedRecords:
 
     @pytest.mark.asyncio
     async def test_parse_selected_records_handles_mixed_cached_and_new(
-        self, debug_service: "Phase1DebugService", mock_dependencies: dict[str, Mock]
+        self, debug_service: Phase1DebugService, mock_dependencies: dict[str, Mock]
     ) -> None:
         """Test handling mix of cached and new records."""
 
@@ -233,7 +233,7 @@ class TestPhase1DebugServiceParseSelectedRecords:
 
     @pytest.mark.asyncio
     async def test_parse_selected_records_returns_empty_for_empty_input(
-        self, debug_service: "Phase1DebugService", mock_dependencies: dict[str, Mock]
+        self, debug_service: Phase1DebugService, mock_dependencies: dict[str, Mock]
     ) -> None:
         """Test that empty input returns empty results."""
         results = await debug_service.parse_selected_records([])
@@ -259,7 +259,7 @@ class TestPhase1DebugServiceParseByFilter:
         }
 
     @pytest.fixture
-    def debug_service(self, mock_dependencies: dict[str, Mock]) -> "Phase1DebugService":
+    def debug_service(self, mock_dependencies: dict[str, Mock]) -> Phase1DebugService:
         """Create a Phase1DebugService with mocked dependencies."""
         from bunking.sync.bunk_request_processor.services.phase1_debug_service import (
             Phase1DebugService,
@@ -273,7 +273,7 @@ class TestPhase1DebugServiceParseByFilter:
 
     @pytest.mark.asyncio
     async def test_parse_by_filter_filters_by_session(
-        self, debug_service: "Phase1DebugService", mock_dependencies: dict[str, Mock]
+        self, debug_service: Phase1DebugService, mock_dependencies: dict[str, Mock]
     ) -> None:
         """Test that parse_by_filter applies session filter."""
         mock_dependencies["original_requests_loader"].load_by_filter.return_value = []
@@ -287,7 +287,7 @@ class TestPhase1DebugServiceParseByFilter:
 
     @pytest.mark.asyncio
     async def test_parse_by_filter_filters_by_source_field(
-        self, debug_service: "Phase1DebugService", mock_dependencies: dict[str, Mock]
+        self, debug_service: Phase1DebugService, mock_dependencies: dict[str, Mock]
     ) -> None:
         """Test that parse_by_filter applies source field filter."""
         mock_dependencies["original_requests_loader"].load_by_filter.return_value = []
@@ -301,7 +301,7 @@ class TestPhase1DebugServiceParseByFilter:
 
     @pytest.mark.asyncio
     async def test_parse_by_filter_respects_limit(
-        self, debug_service: "Phase1DebugService", mock_dependencies: dict[str, Mock]
+        self, debug_service: Phase1DebugService, mock_dependencies: dict[str, Mock]
     ) -> None:
         """Test that parse_by_filter respects the limit parameter."""
         mock_dependencies["original_requests_loader"].load_by_filter.return_value = []
@@ -326,7 +326,7 @@ class TestPhase1DebugServiceConvertToParseRequest:
         }
 
     @pytest.fixture
-    def debug_service(self, mock_dependencies: dict[str, Mock]) -> "Phase1DebugService":
+    def debug_service(self, mock_dependencies: dict[str, Mock]) -> Phase1DebugService:
         """Create a Phase1DebugService with mocked dependencies."""
         from bunking.sync.bunk_request_processor.services.phase1_debug_service import (
             Phase1DebugService,
@@ -338,7 +338,7 @@ class TestPhase1DebugServiceConvertToParseRequest:
             phase1_service=mock_dependencies["phase1_service"],
         )
 
-    def test_convert_extracts_requester_info(self, debug_service: "Phase1DebugService") -> None:
+    def test_convert_extracts_requester_info(self, debug_service: Phase1DebugService) -> None:
         """Test that conversion extracts requester name and cm_id."""
         mock_original = Mock()
         mock_original.id = "orig_req_1"
@@ -366,7 +366,7 @@ class TestPhase1DebugServiceConvertToParseRequest:
         assert parse_request.request_text == "With Emma"
         assert parse_request.field_name == SourceField.BUNK_WITH
 
-    def test_convert_uses_first_name_when_no_preferred(self, debug_service: "Phase1DebugService") -> None:
+    def test_convert_uses_first_name_when_no_preferred(self, debug_service: Phase1DebugService) -> None:
         """Test that first_name is used when preferred_name is None."""
         mock_original = Mock()
         mock_original.id = "orig_req_1"
@@ -404,7 +404,7 @@ class TestPhase1DebugServiceFormatResults:
         }
 
     @pytest.fixture
-    def debug_service(self, mock_dependencies: dict[str, Mock]) -> "Phase1DebugService":
+    def debug_service(self, mock_dependencies: dict[str, Mock]) -> Phase1DebugService:
         """Create a Phase1DebugService with mocked dependencies."""
         from bunking.sync.bunk_request_processor.services.phase1_debug_service import (
             Phase1DebugService,
@@ -416,7 +416,7 @@ class TestPhase1DebugServiceFormatResults:
             phase1_service=mock_dependencies["phase1_service"],
         )
 
-    def test_format_results_includes_all_intent_fields(self, debug_service: "Phase1DebugService") -> None:
+    def test_format_results_includes_all_intent_fields(self, debug_service: Phase1DebugService) -> None:
         """Test that formatted results include all required intent fields."""
         from bunking.sync.bunk_request_processor.core.models import (
             ParsedRequest,
@@ -481,7 +481,7 @@ class TestPhase1DebugServiceFormatResults:
         assert intent_1["target_name"] == "Mia"
         assert intent_1["list_position"] == 1
 
-    def test_format_results_handles_failed_parse(self, debug_service: "Phase1DebugService") -> None:
+    def test_format_results_handles_failed_parse(self, debug_service: Phase1DebugService) -> None:
         """Test that failed parse results are formatted correctly."""
         from bunking.sync.bunk_request_processor.core.models import ParseResult
 
@@ -511,7 +511,7 @@ class TestPhase1DebugServiceGetPromptVersion:
         }
 
     @pytest.fixture
-    def debug_service(self, mock_dependencies: dict[str, Mock]) -> "Phase1DebugService":
+    def debug_service(self, mock_dependencies: dict[str, Mock]) -> Phase1DebugService:
         """Create a Phase1DebugService with mocked dependencies."""
         from bunking.sync.bunk_request_processor.services.phase1_debug_service import (
             Phase1DebugService,
@@ -524,7 +524,7 @@ class TestPhase1DebugServiceGetPromptVersion:
             prompt_version="v1.2.0",
         )
 
-    def test_prompt_version_included_in_results(self, debug_service: "Phase1DebugService") -> None:
+    def test_prompt_version_included_in_results(self, debug_service: Phase1DebugService) -> None:
         """Test that prompt version is included in formatted results."""
         from bunking.sync.bunk_request_processor.core.models import ParseResult
 


### PR DESCRIPTION
## Summary

- Rewrite the main `README.md` (which was corrupted / missing the entire analytics surface) into a comprehensive overview covering **Summer Bunking** and **Camp Analytics**, with an architecture diagram, tech stack, quick start, configuration, deployment, screenshot placeholders, and a production note about Caddy running behind Traefik/CrowdSec.
- Add `docs/reference/modernization-backlog.md` — a full audit of modern language/tooling features not yet adopted across Python, Go, Frontend (React 19 / TS 5.8), and Infrastructure. Each section has impact ratings, `file:line` references, rough counts, and a recommended PR order so follow-up work can ship one layer at a time.
- Includes the "minimum hardened Caddy config" recommendation for the edge-behind-Traefik deployment model (timeouts, body-size cap, defensive headers, JSON access log).
- Link the new backlog from `docs/README.md`.

## Version-pin corrections (bundled)

- `ruff.toml` — `target-version = "py312"` → `"py314"` (matches `pyproject.toml` `requires-python = ">=3.14"`)
- `CLAUDE.md` — language pins `Python 3.12+ / Go 1.24+` → `Python 3.14+ / Go 1.26+` (matches `.python-version` and `pocketbase/go.mod`)
- **84 ruff UP037/UP043 autofixes** across `api/`, `bunking/`, `tests/`, `scripts/` — surfaced directly by the py314 target bump. All purely mechanical (quoted type annotations removed, unnecessary default type arguments removed). No logic changes.

## `ortools` on PyPI

Checked during audit — PyPI's `ortools` 9.15.6755 ships cp310–cp313 wheels only; no cp314 yet. The GitHub-release URL pin in `pyproject.toml:37` stays correct; the `# TODO` comment there is accurate. Revisit monthly.

## Why

The README failed to represent what Kindred actually is — it omitted the entire metrics module (retention, registration, forecasting, velocity, cancellations, waitlists), the bunk request AI pipeline, scenario comparison, and the social graph. The backlog doc captures an otherwise-ephemeral four-agent audit so the modernization work can proceed as a series of focused PRs rather than disappearing into chat history.

## What's NOT in this PR

This is pure docs + version-alignment. The actual modernization work (TaskGroup adoption, `interface{}→any` codemod, React 19 `use()` migration, Caddy hardening, etc.) is broken into per-layer PRs per the schedule in the backlog doc.

## Files changed

- `README.md` — comprehensive rewrite
- `docs/reference/modernization-backlog.md` — new 255-line reference doc
- `docs/README.md` — index entry for the new doc
- `CLAUDE.md` — language version pins
- `ruff.toml` — target-version bump
- 41 files autofixed by ruff (quoted type annotations + default type args; mechanical)

## Test plan

- [ ] README renders correctly on GitHub (TOC, placeholders, tables)
- [ ] `docs/reference/modernization-backlog.md` renders correctly
- [ ] All doc cross-links resolve
- [ ] CI passes (ruff + mypy + tests) with new py314 target

## Follow-up PRs (from the backlog)

1. `chore(py): drop redundant __future__ annotations import` (~250 files, mechanical)
2. `refactor(pb): interface{} → any codemod` (~1,347 replacements, mechanical)
3. `fix(sync): replace string-based error matching with sentinel errors`
4. `refactor(api): adopt asyncio.TaskGroup in metrics services`
5. `refactor(frontend): Array.toSorted + Object.groupBy + error cause chaining`
6. `build(caddy): minimum hardened config behind Traefik`
7. `fix(ci): rebuild caddy on every CD run + pin base image`
8. …see `docs/reference/modernization-backlog.md` for the full sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)