### PR TITLE
style(frontend): remove unused eslint-disable directives

### DIFF
--- a/frontend/src/components/SplitRequestModal.tsx
+++ b/frontend/src/components/SplitRequestModal.tsx
@@ -67,7 +67,6 @@ export default function SplitRequestModal({
         .filter((link) => !link.is_primary)
         .map((link) => link.original_request_id)
 
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- Valid pattern: reset state when modal opens
       setSelectedSources(new Set(nonPrimarySources))
 
       const defaultTypes: Record<string, BunkRequestsRequestTypeOptions> = {}

--- a/frontend/src/components/admin/ConfigInputs.tsx
+++ b/frontend/src/components/admin/ConfigInputs.tsx
@@ -319,7 +319,6 @@ export function PortalTooltip({ children, content, className = 'w-64' }: PortalT
   // useLayoutEffect for synchronous DOM measurements before paint
   useLayoutEffect(() => {
     if (isVisible) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- DOM measurement requires sync state update
       updatePosition()
     }
   }, [isVisible, updatePosition])
@@ -402,7 +401,6 @@ export function ScaleTooltip({ scaleType, value, metadata }: ScaleTooltipProps) 
   // useLayoutEffect for synchronous DOM measurements before paint
   useLayoutEffect(() => {
     if (scaleType === 'unknown' || !isVisible) return
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- DOM measurement requires sync state update
     updatePosition()
   }, [isVisible, scale, scaleType, updatePosition])
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -77,7 +77,6 @@ const LoginPage = () => {
     // Auto-login if there's only one provider and we haven't tried yet
     if (providers.length === 1 && !autoLoginAttemptedRef.current && !error && providers[0]) {
       autoLoginAttemptedRef.current = true
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional one-time auto-login action
       void handleProviderLogin(providers[0])
     }
   }, [user, navigate, from, providers, error, handleProviderLogin])


### PR DESCRIPTION
The react-hooks/set-state-in-effect rule no longer triggers (recent eslint-plugin bump), so the existing disable-next-line directives are now reported as unused and error in CI. Removes the stale directives; no runtime/behavior change.