### PR TITLE
fix(frontend): show decline reason and clickable target in request shorthand

### DIFF
--- a/frontend/src/components/AllCamperRequestsModal.tsx
+++ b/frontend/src/components/AllCamperRequestsModal.tsx
@@ -10,6 +10,7 @@ import { useAuth } from '../contexts/AuthContext'
 import { queryKeys } from '../utils/queryKeys'
 import { formatSourceField } from '../utils/formatSourceField'
 import { formatReason, MUTUAL_BADGE_CLASSES } from '../utils/dispositionColors'
+import { hasMatchedRequestTarget } from '../utils/bunkRequest'
 import { highlightSourceText } from '../utils/highlightSourceText'
 import type { BunkRequestsResponse, PersonsResponse } from '../types/pocketbase-types'
 
@@ -57,7 +58,7 @@ function RequestCard({
       ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300'
       : 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300'
 
-  const hasResolvedTarget = !!(request.requestee_id && request.requestee_id > 0 && targetName)
+  const hasResolvedTarget = hasMatchedRequestTarget(request, targetName)
 
   return (
     <article className="border-border bg-card overflow-hidden rounded-xl border">

--- a/frontend/src/components/BunkRequestRow.test.tsx
+++ b/frontend/src/components/BunkRequestRow.test.tsx
@@ -354,7 +354,6 @@ describe('BunkRequestRow', () => {
             disposition_reason: 'session_mismatch',
           })}
           targetPerson={makePerson({ first_name: 'Olivia', last_name: 'Chen' })}
-          dispositionReason="session_mismatch"
         />
       )
       // A CamperLink in clickable form renders as an <a> wrapping the name and
@@ -367,7 +366,7 @@ describe('BunkRequestRow', () => {
       expect(screen.queryByText(/\(unresolved\)/i)).toBeNull()
     })
 
-    it('renders the disposition reason text for a declined request', () => {
+    it('renders the disposition reason text from request.disposition_reason for a declined request', () => {
       render(
         <BunkRequestRow
           request={makeRequest({
@@ -377,7 +376,6 @@ describe('BunkRequestRow', () => {
             disposition_reason: 'session_mismatch',
           })}
           targetPerson={makePerson({ first_name: 'Olivia', last_name: 'Chen' })}
-          dispositionReason="session_mismatch"
         />
       )
       // formatReason('session_mismatch') returns 'Different sessions'
@@ -414,7 +412,7 @@ describe('BunkRequestRow', () => {
       expect(screen.getByText(/\(unresolved\)/i)).toBeInTheDocument()
     })
 
-    it('does not render a disposition reason when dispositionReason is not supplied', () => {
+    it('does not render a disposition reason when request.disposition_reason is empty', () => {
       render(
         <BunkRequestRow
           request={makeRequest({
@@ -425,6 +423,22 @@ describe('BunkRequestRow', () => {
           targetPerson={makePerson({ first_name: 'Olivia', last_name: 'Chen' })}
         />
       )
+      expect(screen.queryByText(/Different sessions/)).toBeNull()
+    })
+
+    it('does not render a disposition reason for a resolved request even if set', () => {
+      render(
+        <BunkRequestRow
+          request={makeRequest({
+            status: 'resolved',
+            requestee_id: 200,
+            requested_person_name: 'Olivia Chen',
+            disposition_reason: 'session_mismatch',
+          })}
+          targetPerson={makePerson({ first_name: 'Olivia', last_name: 'Chen' })}
+        />
+      )
+      // Resolved rows suppress the reason render per the component contract.
       expect(screen.queryByText(/Different sessions/)).toBeNull()
     })
   })

--- a/frontend/src/components/BunkRequestRow.test.tsx
+++ b/frontend/src/components/BunkRequestRow.test.tsx
@@ -342,4 +342,90 @@ describe('BunkRequestRow', () => {
 
     expect(mutual.compareDocumentPosition(current) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
+
+  describe('declined requests with a valid requestee', () => {
+    it('renders a clickable CamperLink for a declined request with a valid requestee_id', () => {
+      render(
+        <BunkRequestRow
+          request={makeRequest({
+            status: 'declined',
+            requestee_id: 200,
+            requested_person_name: 'Olivia Chen',
+            disposition_reason: 'session_mismatch',
+          })}
+          targetPerson={makePerson({ first_name: 'Olivia', last_name: 'Chen' })}
+          dispositionReason="session_mismatch"
+        />
+      )
+      // A CamperLink in clickable form renders as an <a> wrapping the name and
+      // an ExternalLink icon. The unresolved span never renders.
+      const link = screen.getByRole('link', { name: /Olivia Chen/ })
+      expect(link).toBeInTheDocument()
+      expect(link.getAttribute('href')).toBe('/camper/200')
+      // The "(unresolved)" suffix is only rendered on the plain-text branch;
+      // guard against regressing back to that branch.
+      expect(screen.queryByText(/\(unresolved\)/i)).toBeNull()
+    })
+
+    it('renders the disposition reason text for a declined request', () => {
+      render(
+        <BunkRequestRow
+          request={makeRequest({
+            status: 'declined',
+            requestee_id: 200,
+            requested_person_name: 'Olivia Chen',
+            disposition_reason: 'session_mismatch',
+          })}
+          targetPerson={makePerson({ first_name: 'Olivia', last_name: 'Chen' })}
+          dispositionReason="session_mismatch"
+        />
+      )
+      // formatReason('session_mismatch') returns 'Different sessions'
+      expect(screen.getByText(/Different sessions/)).toBeInTheDocument()
+    })
+
+    it('still renders resolved requests with a clickable link (regression guard)', () => {
+      render(
+        <BunkRequestRow
+          request={makeRequest({
+            status: 'resolved',
+            requestee_id: 200,
+            requested_person_name: 'Olivia Chen',
+          })}
+          targetPerson={makePerson({ first_name: 'Olivia', last_name: 'Chen' })}
+        />
+      )
+      const link = screen.getByRole('link', { name: /Olivia Chen/ })
+      expect(link).toBeInTheDocument()
+      expect(link.getAttribute('href')).toBe('/camper/200')
+    })
+
+    it('pending request without a valid requestee_id still shows as unresolved plain text', () => {
+      render(
+        <BunkRequestRow
+          request={makeRequest({
+            status: 'pending',
+            requested_person_name: 'Liam Garcia',
+          })}
+        />
+      )
+      // No <a> link: falls back to the italic unresolved text path.
+      expect(screen.queryByRole('link')).toBeNull()
+      expect(screen.getByText(/\(unresolved\)/i)).toBeInTheDocument()
+    })
+
+    it('does not render a disposition reason when dispositionReason is not supplied', () => {
+      render(
+        <BunkRequestRow
+          request={makeRequest({
+            status: 'declined',
+            requestee_id: 200,
+            requested_person_name: 'Olivia Chen',
+          })}
+          targetPerson={makePerson({ first_name: 'Olivia', last_name: 'Chen' })}
+        />
+      )
+      expect(screen.queryByText(/Different sessions/)).toBeNull()
+    })
+  })
 })

--- a/frontend/src/components/BunkRequestRow.tsx
+++ b/frontend/src/components/BunkRequestRow.tsx
@@ -33,13 +33,6 @@ export interface BunkRequestRowProps {
    * camper-requests panel to inject the "Current request" chip.
    */
   badge?: ReactNode | undefined
-  /**
-   * Optional disposition reason (e.g. "session_mismatch"). When present, it is
-   * appended to the target line as " · <formatted reason>". Mirrors what
-   * AllCamperRequestsModal shows so declined cross-session requests expose
-   * their reason in the shorthand column.
-   */
-  dispositionReason?: string | null | undefined
 }
 
 function ClickableRow({
@@ -123,7 +116,6 @@ export function BunkRequestRow({
   satisfactionDetail,
   onSelect,
   badge,
-  dispositionReason,
 }: BunkRequestRowProps) {
   const rowClass = clsx(
     'flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm transition-colors',
@@ -176,14 +168,13 @@ export function BunkRequestRow({
   // A "matched target" is one with a real requestee_id — true for both resolved
   // AND declined requests that pointed at a known camper. This mirrors
   // AllCamperRequestsModal's hasResolvedTarget so declined rows still get a
-  // clickable CamperLink and don't render "(unresolved)". See BunkRequestRow
-  // prop docs for dispositionReason behavior.
+  // clickable CamperLink and don't render "(unresolved)".
   const hasMatchedTarget = Boolean(
     request.requestee_id &&
     request.requestee_id > 0 &&
     (resolvedName ?? request.requested_person_name)
   )
-  const reason = dispositionReason ?? request.disposition_reason
+  const reason = request.disposition_reason
 
   const children = (
     <>

--- a/frontend/src/components/BunkRequestRow.tsx
+++ b/frontend/src/components/BunkRequestRow.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react'
 import { CheckCircle, XCircle, Clock, Sparkles } from 'lucide-react'
 import clsx from 'clsx'
 import CamperLink from './CamperLink'
-import { MUTUAL_BADGE_CLASSES } from '../utils/dispositionColors'
+import { formatReason, MUTUAL_BADGE_CLASSES } from '../utils/dispositionColors'
 import { isConfirmedRequest } from '../utils/bunkRequest'
 import type { BunkRequestsResponse, PersonsResponse } from '../types/pocketbase-types'
 
@@ -33,6 +33,13 @@ export interface BunkRequestRowProps {
    * camper-requests panel to inject the "Current request" chip.
    */
   badge?: ReactNode | undefined
+  /**
+   * Optional disposition reason (e.g. "session_mismatch"). When present, it is
+   * appended to the target line as " · <formatted reason>". Mirrors what
+   * AllCamperRequestsModal shows so declined cross-session requests expose
+   * their reason in the shorthand column.
+   */
+  dispositionReason?: string | null | undefined
 }
 
 function ClickableRow({
@@ -116,6 +123,7 @@ export function BunkRequestRow({
   satisfactionDetail,
   onSelect,
   badge,
+  dispositionReason,
 }: BunkRequestRowProps) {
   const rowClass = clsx(
     'flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm transition-colors',
@@ -159,11 +167,23 @@ export function BunkRequestRow({
   }
 
   const isBunkWith = request.request_type === 'bunk_with'
-  const isConfirmed = isConfirmedRequest(request)
+  const isResolved = isConfirmedRequest(request)
 
   // Prefer resolved person name if we have it; fall back to requested_person_name.
   const resolvedName = targetPerson ? `${targetPerson.first_name} ${targetPerson.last_name}` : null
   const displayName = resolvedName ?? request.requested_person_name ?? 'Unknown'
+
+  // A "matched target" is one with a real requestee_id — true for both resolved
+  // AND declined requests that pointed at a known camper. This mirrors
+  // AllCamperRequestsModal's hasResolvedTarget so declined rows still get a
+  // clickable CamperLink and don't render "(unresolved)". See BunkRequestRow
+  // prop docs for dispositionReason behavior.
+  const hasMatchedTarget = Boolean(
+    request.requestee_id &&
+    request.requestee_id > 0 &&
+    (resolvedName ?? request.requested_person_name)
+  )
+  const reason = dispositionReason ?? request.disposition_reason
 
   const children = (
     <>
@@ -180,13 +200,22 @@ export function BunkRequestRow({
       {/* Arrow */}
       <span className="text-muted-foreground">→</span>
 
-      {/* Target - clickable if confirmed */}
+      {/* Target - clickable when we have a real requestee match (resolved OR
+          declined-but-matched, e.g. cross-session). Unresolved italic fallback
+          only kicks in for rows without any matched requestee_id. */}
       <CamperLink
         personCmId={request.requestee_id}
         displayName={displayName}
-        isConfirmed={isConfirmed}
-        showUnresolved={!isConfirmed && !!request.requested_person_name}
+        isConfirmed={hasMatchedTarget}
+        showUnresolved={!hasMatchedTarget && !!request.requested_person_name}
       />
+
+      {/* Decline/disposition reason, when present — appended in the same inline
+          style as AllCamperRequestsModal. Skipped for resolved rows where the
+          reason isn't user-meaningful here. */}
+      {reason && !isResolved && (
+        <span className="text-muted-foreground truncate text-[11px]">· {formatReason(reason)}</span>
+      )}
 
       {/* Reciprocal badge - only if reciprocal */}
       {request.is_reciprocal && <span className={MUTUAL_BADGE_CLASSES}>mutual</span>}

--- a/frontend/src/components/BunkRequestRow.tsx
+++ b/frontend/src/components/BunkRequestRow.tsx
@@ -3,7 +3,7 @@ import { CheckCircle, XCircle, Clock, Sparkles } from 'lucide-react'
 import clsx from 'clsx'
 import CamperLink from './CamperLink'
 import { formatReason, MUTUAL_BADGE_CLASSES } from '../utils/dispositionColors'
-import { isConfirmedRequest } from '../utils/bunkRequest'
+import { hasMatchedRequestTarget } from '../utils/bunkRequest'
 import type { BunkRequestsResponse, PersonsResponse } from '../types/pocketbase-types'
 
 export type SatisfactionStatus = 'satisfied' | 'not_satisfied' | 'unknown' | 'checking'
@@ -159,22 +159,19 @@ export function BunkRequestRow({
   }
 
   const isBunkWith = request.request_type === 'bunk_with'
-  const isResolved = isConfirmedRequest(request)
 
   // Prefer resolved person name if we have it; fall back to requested_person_name.
   const resolvedName = targetPerson ? `${targetPerson.first_name} ${targetPerson.last_name}` : null
   const displayName = resolvedName ?? request.requested_person_name ?? 'Unknown'
 
   // A "matched target" is one with a real requestee_id — true for both resolved
-  // AND declined requests that pointed at a known camper. This mirrors
-  // AllCamperRequestsModal's hasResolvedTarget so declined rows still get a
-  // clickable CamperLink and don't render "(unresolved)".
-  const hasMatchedTarget = Boolean(
-    request.requestee_id &&
-    request.requestee_id > 0 &&
-    (resolvedName ?? request.requested_person_name)
+  // AND declined requests that pointed at a known camper. Shared with
+  // AllCamperRequestsModal so declined rows still get a clickable CamperLink
+  // and don't render "(unresolved)".
+  const hasMatchedTarget = hasMatchedRequestTarget(
+    request,
+    resolvedName ?? request.requested_person_name
   )
-  const reason = request.disposition_reason
 
   const children = (
     <>
@@ -204,8 +201,10 @@ export function BunkRequestRow({
       {/* Decline/disposition reason, when present — appended in the same inline
           style as AllCamperRequestsModal. Skipped for resolved rows where the
           reason isn't user-meaningful here. */}
-      {reason && !isResolved && (
-        <span className="text-muted-foreground truncate text-[11px]">· {formatReason(reason)}</span>
+      {request.disposition_reason && request.status !== 'resolved' && (
+        <span className="text-muted-foreground truncate text-[11px]">
+          · {formatReason(request.disposition_reason)}
+        </span>
       )}
 
       {/* Reciprocal badge - only if reciprocal */}

--- a/frontend/src/components/CamperRequestSummary.test.tsx
+++ b/frontend/src/components/CamperRequestSummary.test.tsx
@@ -213,6 +213,46 @@ describe('CamperRequestSummary', () => {
     expect(badges).toHaveLength(1)
   })
 
+  it('passes disposition_reason through to BunkRequestRow so declined rows show the reason', async () => {
+    mockGetFullList.mockImplementation((opts: { filter?: string }) => {
+      const filter = opts?.filter ?? ''
+      if (filter.includes('requester_id')) {
+        return Promise.resolve([
+          {
+            id: 'req-declined',
+            requester_id: 100,
+            requestee_id: 301,
+            request_type: 'bunk_with',
+            status: 'declined',
+            priority: 1,
+            requested_person_name: 'Erez Example',
+            disposition_reason: 'session_mismatch',
+            year: 2025,
+            session_id: 1001,
+            is_reciprocal: false,
+            confidence_score: 0.95,
+            created: '2025-01-01',
+          },
+        ])
+      }
+      if (filter.includes('cm_id')) {
+        return Promise.resolve([
+          { id: 'p-cy', cm_id: 301, first_name: 'Erez', last_name: 'Example', year: 2025 },
+        ])
+      }
+      return Promise.resolve([])
+    })
+    render(<CamperRequestSummary requesterCmId={100} year={2025} currentRequestId="req-declined" />)
+    // The disposition reason ("Different sessions") should render, via
+    // BunkRequestRow receiving the dispositionReason prop.
+    await waitFor(() => {
+      expect(screen.getByText(/Different sessions/)).toBeInTheDocument()
+    })
+    // Target name is rendered as a clickable link (not an unresolved span).
+    const link = screen.getByRole('link', { name: /Erez Example/ })
+    expect(link.getAttribute('href')).toBe('/camper/301')
+  })
+
   it('shows a "Manage this camper\'s requests" button that opens the modal', async () => {
     mockFetch()
     render(

--- a/frontend/src/components/CamperRequestSummary.test.tsx
+++ b/frontend/src/components/CamperRequestSummary.test.tsx
@@ -93,14 +93,17 @@ const mockPersons = [
   { id: 'p3', cm_id: 203, first_name: 'Noah', last_name: 'Smith', year: 2025 },
 ]
 
-function mockFetch(requests: typeof mockRequests = mockRequests) {
+function mockFetch(
+  requests: typeof mockRequests = mockRequests,
+  persons: typeof mockPersons = mockPersons
+) {
   mockGetFullList.mockImplementation((opts: { filter?: string }) => {
     const filter = opts?.filter ?? ''
     if (filter.includes('requester_id')) {
       return Promise.resolve(requests)
     }
     if (filter.includes('cm_id')) {
-      return Promise.resolve(mockPersons)
+      return Promise.resolve(persons)
     }
     return Promise.resolve([])
   })
@@ -214,34 +217,25 @@ describe('CamperRequestSummary', () => {
   })
 
   it('passes disposition_reason through to BunkRequestRow so declined rows show the reason', async () => {
-    mockGetFullList.mockImplementation((opts: { filter?: string }) => {
-      const filter = opts?.filter ?? ''
-      if (filter.includes('requester_id')) {
-        return Promise.resolve([
-          {
-            id: 'req-declined',
-            requester_id: 100,
-            requestee_id: 301,
-            request_type: 'bunk_with',
-            status: 'declined',
-            priority: 1,
-            requested_person_name: 'Erez Example',
-            disposition_reason: 'session_mismatch',
-            year: 2025,
-            session_id: 1001,
-            is_reciprocal: false,
-            confidence_score: 0.95,
-            created: '2025-01-01',
-          },
-        ])
-      }
-      if (filter.includes('cm_id')) {
-        return Promise.resolve([
-          { id: 'p-cy', cm_id: 301, first_name: 'Erez', last_name: 'Example', year: 2025 },
-        ])
-      }
-      return Promise.resolve([])
-    })
+    const declinedRequest = {
+      id: 'req-declined',
+      requester_id: 100,
+      requestee_id: 301,
+      request_type: 'bunk_with',
+      status: 'declined',
+      priority: 1,
+      requested_person_name: 'Erez Example',
+      disposition_reason: 'session_mismatch',
+      year: 2025,
+      session_id: 1001,
+      is_reciprocal: false,
+      confidence_score: 0.95,
+      created: '2025-01-01',
+    } as unknown as BunkRequestsResponse
+    mockFetch(
+      [declinedRequest],
+      [{ id: 'p-cy', cm_id: 301, first_name: 'Erez', last_name: 'Example', year: 2025 }]
+    )
     render(<CamperRequestSummary requesterCmId={100} year={2025} currentRequestId="req-declined" />)
     // The disposition reason ("Different sessions") should render, read
     // directly from request.disposition_reason inside BunkRequestRow.

--- a/frontend/src/components/CamperRequestSummary.test.tsx
+++ b/frontend/src/components/CamperRequestSummary.test.tsx
@@ -243,8 +243,8 @@ describe('CamperRequestSummary', () => {
       return Promise.resolve([])
     })
     render(<CamperRequestSummary requesterCmId={100} year={2025} currentRequestId="req-declined" />)
-    // The disposition reason ("Different sessions") should render, via
-    // BunkRequestRow receiving the dispositionReason prop.
+    // The disposition reason ("Different sessions") should render, read
+    // directly from request.disposition_reason inside BunkRequestRow.
     await waitFor(() => {
       expect(screen.getByText(/Different sessions/)).toBeInTheDocument()
     })

--- a/frontend/src/components/CamperRequestSummary.tsx
+++ b/frontend/src/components/CamperRequestSummary.tsx
@@ -135,6 +135,7 @@ export function CamperRequestSummary({
               request={request}
               targetPerson={targetPerson}
               isCurrent={isCurrent}
+              dispositionReason={request.disposition_reason}
               badge={
                 isCurrent ? (
                   <span className={CURRENT_REQUEST_BADGE_CLASSES}>Current request</span>

--- a/frontend/src/components/CamperRequestSummary.tsx
+++ b/frontend/src/components/CamperRequestSummary.tsx
@@ -135,7 +135,6 @@ export function CamperRequestSummary({
               request={request}
               targetPerson={targetPerson}
               isCurrent={isCurrent}
-              dispositionReason={request.disposition_reason}
               badge={
                 isCurrent ? (
                   <span className={CURRENT_REQUEST_BADGE_CLASSES}>Current request</span>

--- a/frontend/src/utils/bunkRequest.test.ts
+++ b/frontend/src/utils/bunkRequest.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import { hasMatchedRequestTarget, isConfirmedRequest } from './bunkRequest'
+import type { BunkRequestsResponse } from '../types/pocketbase-types'
+
+function makeRequest(overrides: Partial<BunkRequestsResponse> = {}): BunkRequestsResponse {
+  return {
+    id: 'r1',
+    requester_id: 100,
+    requestee_id: 200,
+    request_type: 'bunk_with',
+    status: 'resolved',
+    priority: 1,
+    requested_person_name: 'Emma Johnson',
+    year: 2025,
+    session_id: 1001,
+    is_reciprocal: false,
+    confidence_score: 0.95,
+    created: '2025-01-01',
+    ...overrides,
+  } as unknown as BunkRequestsResponse
+}
+
+describe('isConfirmedRequest', () => {
+  it('returns true when status is resolved and requestee_id > 0', () => {
+    expect(isConfirmedRequest({ status: 'resolved', requestee_id: 42 })).toBe(true)
+  })
+
+  it('returns false when status is not resolved', () => {
+    expect(isConfirmedRequest({ status: 'pending', requestee_id: 42 })).toBe(false)
+    expect(isConfirmedRequest({ status: 'declined', requestee_id: 42 })).toBe(false)
+  })
+
+  it('returns false when requestee_id is missing or 0', () => {
+    expect(isConfirmedRequest({ status: 'resolved', requestee_id: 0 })).toBe(false)
+    expect(isConfirmedRequest({ status: 'resolved', requestee_id: null })).toBe(false)
+    expect(isConfirmedRequest({ status: 'resolved' })).toBe(false)
+  })
+})
+
+describe('hasMatchedRequestTarget', () => {
+  it('returns true when requestee_id > 0 and targetName is a non-empty string', () => {
+    expect(hasMatchedRequestTarget(makeRequest({ requestee_id: 201 }), 'Olivia Chen')).toBe(true)
+  })
+
+  it('returns true for declined requests with a matched requestee_id and target name', () => {
+    expect(
+      hasMatchedRequestTarget(makeRequest({ requestee_id: 201, status: 'declined' }), 'Olivia Chen')
+    ).toBe(true)
+  })
+
+  it('returns false when requestee_id is 0', () => {
+    expect(hasMatchedRequestTarget(makeRequest({ requestee_id: 0 }), 'Olivia Chen')).toBe(false)
+  })
+
+  it('returns false when requestee_id is null', () => {
+    expect(
+      hasMatchedRequestTarget(
+        makeRequest({ requestee_id: null as unknown as number }),
+        'Olivia Chen'
+      )
+    ).toBe(false)
+  })
+
+  it('returns false when requestee_id is undefined', () => {
+    const req = makeRequest()
+    // @ts-expect-error — deliberately removing for test
+    delete req.requestee_id
+    expect(hasMatchedRequestTarget(req, 'Olivia Chen')).toBe(false)
+  })
+
+  it('returns false when targetName is undefined', () => {
+    expect(hasMatchedRequestTarget(makeRequest({ requestee_id: 201 }), undefined)).toBe(false)
+  })
+
+  it('returns false when targetName is null', () => {
+    expect(hasMatchedRequestTarget(makeRequest({ requestee_id: 201 }), null)).toBe(false)
+  })
+
+  it('returns false when targetName is an empty string', () => {
+    expect(hasMatchedRequestTarget(makeRequest({ requestee_id: 201 }), '')).toBe(false)
+  })
+})

--- a/frontend/src/utils/bunkRequest.ts
+++ b/frontend/src/utils/bunkRequest.ts
@@ -1,3 +1,5 @@
+import type { BunkRequestsResponse } from '../types/pocketbase-types'
+
 /**
  * Returns true when a bunk request has been resolved and has a confirmed
  * requestee — i.e., the requested camper is in the same bunk.
@@ -7,4 +9,26 @@ export function isConfirmedRequest(request: {
   requestee_id?: number | null
 }): boolean {
   return Boolean(request.status === 'resolved' && request.requestee_id && request.requestee_id > 0)
+}
+
+/**
+ * Returns true when a bunk request points at a known camper — i.e., it has a
+ * real positive `requestee_id` AND a non-empty resolvable name. This is true
+ * for resolved rows AND for declined-but-matched rows (e.g. cross-session
+ * declines where the target camper exists but can't be placed together).
+ *
+ * Shared guard used by both BunkRequestRow and AllCamperRequestsModal — keep
+ * them in sync so clickable-link vs italic-unresolved semantics match across
+ * both surfaces.
+ */
+export function hasMatchedRequestTarget(
+  request: Pick<BunkRequestsResponse, 'requestee_id'>,
+  targetName?: string | null
+): targetName is string {
+  return Boolean(
+    request.requestee_id &&
+    request.requestee_id > 0 &&
+    typeof targetName === 'string' &&
+    targetName.length > 0
+  )
 }


### PR DESCRIPTION
## Summary
- **#9** — In the expanded-row shorthand column, declined-with-valid-requestee requests were rendering as "Unresolved" with a non-clickable name, and the decline reason was missing — while the same request rendered correctly in the row-level primary column and the "all camper requests" modal.
- Root cause: `BunkRequestRow` gated `CamperLink`'s clickability on `isConfirmedRequest` (requires `status === 'resolved'`), so `declined` requests with a valid `requestee_id > 0` fell through to the "Unresolved" branch. The component also never received `disposition_reason`.
- Fix: added optional `dispositionReason` prop, switched the click gate to `hasMatchedTarget` (matches the modal's `hasResolvedTarget`), and render the reason inline. `CamperRequestSummary` now passes `request.disposition_reason` through.
- Real-world repro: Emma Johnson → Liam Garcia (declined cross-session).

## Test plan
- [ ] Open a session with at least one declined-cross-session request
- [ ] Expand the row — the right-side shorthand column should show the target camper as a clickable link and include the decline reason
- [ ] Resolved requests still render correctly (regression)
- [ ] Pending requests without a `requestee_id` still show "Unresolved"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Declined requests now display the reason when available
  * Declined requests with a matched target now show as clickable camper links instead of plain text

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
