### PR TITLE
fix(frontend): repair empty scenario creation and scenario copy

### DIFF
--- a/frontend/src/contexts/ScenarioContext.tsx
+++ b/frontend/src/contexts/ScenarioContext.tsx
@@ -4,35 +4,11 @@ import { ScenarioContext, type Scenario, type ScenarioContextType } from '../hoo
 import { useSavedScenarios } from '../hooks/useSavedScenarios'
 import { useCreateScenario, useDeleteScenario } from '../hooks/useSavedScenariosMutation'
 import { useUpdateScenario, useClearScenario } from '../hooks/useScenarioOperations'
-import type { SavedScenario } from '../types/app-types'
 import { useYear } from '../hooks/useCurrentYear'
+import { savedScenarioToScenario } from './scenarioTransform'
 
 interface ScenarioProviderProps {
   children: ReactNode
-}
-
-// Convert SavedScenario to Scenario format
-// Exported for direct unit testing. Must tolerate records created without
-// `{ expand: 'session' }` (e.g. older flows) — missing expand must not throw.
-// eslint-disable-next-line react-refresh/only-export-components
-export function savedScenarioToScenario(saved: SavedScenario): Scenario {
-  // Get the session CM ID from the expanded relation if available.
-  // Defensive: the generated PB type declares `expand` as required, but the
-  // runtime record omits it when callers didn't pass `{ expand: 'session' }`
-  // to the request. Treat as possibly-undefined so we fall back to 0 instead
-  // of throwing "Cannot read properties of undefined (reading 'session')".
-  const expand = saved.expand as { session?: { cm_id?: number } } | undefined
-  const sessionCmId = expand?.session?.cm_id ?? 0
-
-  return {
-    id: saved.id,
-    name: saved.name,
-    session_cm_id: sessionCmId,
-    created: saved.created,
-    updated: saved.updated,
-    is_active: saved.is_active,
-    description: saved.description || '',
-  }
 }
 
 export const ScenarioProvider: FC<ScenarioProviderProps> = ({ children }) => {

--- a/frontend/src/contexts/ScenarioContext.tsx
+++ b/frontend/src/contexts/ScenarioContext.tsx
@@ -12,9 +12,17 @@ interface ScenarioProviderProps {
 }
 
 // Convert SavedScenario to Scenario format
-function savedScenarioToScenario(saved: SavedScenario): Scenario {
-  // Get the session CM ID from the expanded relation if available
-  const sessionCmId = saved.expand.session?.cm_id ?? 0
+// Exported for direct unit testing. Must tolerate records created without
+// `{ expand: 'session' }` (e.g. older flows) — missing expand must not throw.
+// eslint-disable-next-line react-refresh/only-export-components
+export function savedScenarioToScenario(saved: SavedScenario): Scenario {
+  // Get the session CM ID from the expanded relation if available.
+  // Defensive: the generated PB type declares `expand` as required, but the
+  // runtime record omits it when callers didn't pass `{ expand: 'session' }`
+  // to the request. Treat as possibly-undefined so we fall back to 0 instead
+  // of throwing "Cannot read properties of undefined (reading 'session')".
+  const expand = saved.expand as { session?: { cm_id?: number } } | undefined
+  const sessionCmId = expand?.session?.cm_id ?? 0
 
   return {
     id: saved.id,

--- a/frontend/src/contexts/scenarioTransform.test.ts
+++ b/frontend/src/contexts/scenarioTransform.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { savedScenarioToScenario } from './scenarioTransform'
+import type { SavedScenario } from '../types/app-types'
+
+describe('savedScenarioToScenario', () => {
+  it('handles a record with no expand property', () => {
+    // This simulates the record PocketBase returns from create() when no expand is requested
+    const recordWithoutExpand = {
+      id: 'scenario-xyz',
+      name: 'Empty',
+      session: 'pb-session-1',
+      year: 2025,
+      is_active: true,
+      created: '2026-04-23T00:00:00Z',
+      updated: '2026-04-23T00:00:00Z',
+      description: '',
+      // no expand field at all
+    } as unknown as SavedScenario
+
+    // Must not throw "Cannot read properties of undefined (reading 'session')"
+    expect(() => savedScenarioToScenario(recordWithoutExpand)).not.toThrow()
+    const scenario = savedScenarioToScenario(recordWithoutExpand)
+    expect(scenario.id).toBe('scenario-xyz')
+    expect(scenario.session_cm_id).toBe(0) // fallback when expand missing
+    expect(scenario.name).toBe('Empty')
+  })
+
+  it('extracts session_cm_id when expand.session is present', () => {
+    const record = {
+      id: 'scenario-2',
+      name: 'With Expand',
+      session: 'pb-session-1',
+      year: 2025,
+      is_active: true,
+      created: '2026-04-23T00:00:00Z',
+      updated: '2026-04-23T00:00:00Z',
+      description: '',
+      expand: { session: { cm_id: 1000042 } },
+    } as unknown as SavedScenario
+
+    const scenario = savedScenarioToScenario(record)
+    expect(scenario.session_cm_id).toBe(1000042)
+  })
+})

--- a/frontend/src/contexts/scenarioTransform.ts
+++ b/frontend/src/contexts/scenarioTransform.ts
@@ -1,0 +1,25 @@
+import type { Scenario } from '../hooks/useScenario'
+import type { SavedScenario } from '../types/app-types'
+
+// Convert SavedScenario to Scenario format.
+// Must tolerate records created without `{ expand: 'session' }` (e.g. older
+// flows) — missing expand must not throw.
+export function savedScenarioToScenario(saved: SavedScenario): Scenario {
+  // Get the session CM ID from the expanded relation if available.
+  // Defensive: the generated PB type declares `expand` as required, but the
+  // runtime record omits it when callers didn't pass `{ expand: 'session' }`
+  // to the request. Treat as possibly-undefined so we fall back to 0 instead
+  // of throwing "Cannot read properties of undefined (reading 'session')".
+  const expand = saved.expand as { session?: { cm_id?: number } } | undefined
+  const sessionCmId = expand?.session?.cm_id ?? 0
+
+  return {
+    id: saved.id,
+    name: saved.name,
+    session_cm_id: sessionCmId,
+    created: saved.created,
+    updated: saved.updated,
+    is_active: saved.is_active,
+    description: saved.description || '',
+  }
+}

--- a/frontend/src/hooks/useSavedScenariosMutation.test.ts
+++ b/frontend/src/hooks/useSavedScenariosMutation.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { createElement } from 'react'
+
+// Mock pocketbase lib before importing hook
+vi.mock('../lib/pocketbase', () => {
+  const collections: Record<string, unknown> = {}
+  return {
+    pb: {
+      collection: vi.fn((name: string) => {
+        collections[name] ??= {
+          getFullList: vi.fn(),
+          create: vi.fn(),
+          delete: vi.fn(),
+        }
+        return collections[name]
+      }),
+    },
+    getCurrentUser: vi.fn(() => ({ id: 'user-1', email: 'user@example.com' })),
+  }
+})
+
+import { pb } from '../lib/pocketbase'
+import { useCreateScenario } from './useSavedScenariosMutation'
+import { savedScenarioToScenario } from '../contexts/ScenarioContext'
+import type { SavedScenario } from '../types/app-types'
+
+function createWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  })
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children)
+}
+
+interface CollectionMock {
+  getFullList: Mock
+  create: Mock
+  delete: Mock
+}
+
+function getCollection(name: string): CollectionMock {
+  return (pb.collection as Mock)(name) as CollectionMock
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// Bug A (#17A): Empty scenario "undefined.session" error
+// ---------------------------------------------------------------------------
+
+describe('Bug A: empty scenario does not trigger undefined.session error', () => {
+  it('useCreateScenario passes expand: session to create() so returned record has expand.session', async () => {
+    // Arrange
+    const campSessions = getCollection('camp_sessions')
+    campSessions.getFullList.mockResolvedValueOnce([
+      { id: 'pb-session-1', cm_id: 1000001, year: 2025 },
+    ])
+
+    const savedScenarios = getCollection('saved_scenarios')
+    const createdRecord = {
+      id: 'scenario-abc',
+      name: 'My Empty Scenario',
+      session: 'pb-session-1',
+      year: 2025,
+      is_active: true,
+      created: '2026-04-23T00:00:00Z',
+      updated: '2026-04-23T00:00:00Z',
+      expand: { session: { cm_id: 1000001 } },
+    } as unknown as SavedScenario
+    savedScenarios.create.mockResolvedValueOnce(createdRecord)
+
+    const { result } = renderHook(() => useCreateScenario(), { wrapper: createWrapper() })
+
+    // Act
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: 'My Empty Scenario',
+        session_cm_id: 1000001,
+        year: 2025,
+        // no copyOptions => empty scenario
+      })
+    })
+
+    // Assert: create() must be called with the { expand: 'session' } option
+    expect(savedScenarios.create).toHaveBeenCalledTimes(1)
+    const createCall = savedScenarios.create.mock.calls[0]
+    const createOptions = createCall?.[1]
+    expect(createOptions).toMatchObject({ expand: 'session' })
+  })
+
+  it('savedScenarioToScenario handles a record with no expand property', () => {
+    // This simulates the record PocketBase returns from create() when no expand is requested
+    const recordWithoutExpand = {
+      id: 'scenario-xyz',
+      name: 'Empty',
+      session: 'pb-session-1',
+      year: 2025,
+      is_active: true,
+      created: '2026-04-23T00:00:00Z',
+      updated: '2026-04-23T00:00:00Z',
+      description: '',
+      // no expand field at all
+    } as unknown as SavedScenario
+
+    // Must not throw "Cannot read properties of undefined (reading 'session')"
+    expect(() => savedScenarioToScenario(recordWithoutExpand)).not.toThrow()
+    const scenario = savedScenarioToScenario(recordWithoutExpand)
+    expect(scenario.id).toBe('scenario-xyz')
+    expect(scenario.session_cm_id).toBe(0) // fallback when expand missing
+    expect(scenario.name).toBe('Empty')
+  })
+
+  it('savedScenarioToScenario extracts session_cm_id when expand.session is present', () => {
+    const record = {
+      id: 'scenario-2',
+      name: 'With Expand',
+      session: 'pb-session-1',
+      year: 2025,
+      is_active: true,
+      created: '2026-04-23T00:00:00Z',
+      updated: '2026-04-23T00:00:00Z',
+      description: '',
+      expand: { session: { cm_id: 1000042 } },
+    } as unknown as SavedScenario
+
+    const scenario = savedScenarioToScenario(record)
+    expect(scenario.session_cm_id).toBe(1000042)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Bug B (#17B): Copy scenario drops ~1/3 of campers
+// ---------------------------------------------------------------------------
+
+describe('Bug B: copyScenarioToScenario copies ALL source assignments without loss', () => {
+  it('copies all 50 source assignments sequentially (no Promise.all concurrency)', async () => {
+    const SOURCE_COUNT = 50
+
+    // Arrange: camp_sessions lookup + scenario create
+    const campSessions = getCollection('camp_sessions')
+    campSessions.getFullList.mockResolvedValueOnce([
+      { id: 'pb-session-1', cm_id: 1000001, year: 2025 },
+    ])
+
+    const savedScenarios = getCollection('saved_scenarios')
+    savedScenarios.create.mockResolvedValueOnce({
+      id: 'new-scenario-id',
+      name: 'Copied',
+      session: 'pb-session-1',
+      year: 2025,
+      is_active: true,
+      created: '2026-04-23T00:00:00Z',
+      updated: '2026-04-23T00:00:00Z',
+      expand: { session: { cm_id: 1000001 } },
+    })
+
+    // Arrange: source scenario has SOURCE_COUNT draft assignments
+    const sourceAssignments = Array.from({ length: SOURCE_COUNT }, (_, i) => ({
+      id: `draft-src-${i}`,
+      person: `person-${i}`,
+      bunk: `bunk-${i % 14}`,
+      session: 'pb-session-1',
+      bunk_plan: `plan-${i % 14}`,
+      year: 2025,
+      assignment_locked: false,
+    }))
+
+    const draftCollection = getCollection('bunk_assignments_draft')
+    draftCollection.getFullList.mockResolvedValueOnce(sourceAssignments)
+
+    // Track concurrency: reject if more than one create is in flight at a time
+    let inFlight = 0
+    let maxInFlight = 0
+    draftCollection.create.mockImplementation(async () => {
+      inFlight++
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      // yield so a naive Promise.all would show concurrency
+      await new Promise((r) => setTimeout(r, 1))
+      inFlight--
+      return { id: `new-draft-${Math.random()}` }
+    })
+
+    const { result } = renderHook(() => useCreateScenario(), { wrapper: createWrapper() })
+
+    // Act
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: 'Copied',
+        session_cm_id: 1000001,
+        year: 2025,
+        copyOptions: { fromScenario: 'source-scenario-id' },
+      })
+    })
+
+    // Assert: every source assignment was written
+    expect(draftCollection.create).toHaveBeenCalledTimes(SOURCE_COUNT)
+
+    // Assert: sequential — never more than 1 create in flight at once
+    expect(maxInFlight).toBe(1)
+  })
+
+  it('accumulates errors across a batch and throws after the loop (all non-failing items still persisted)', async () => {
+    const campSessions = getCollection('camp_sessions')
+    campSessions.getFullList.mockResolvedValueOnce([
+      { id: 'pb-session-1', cm_id: 1000001, year: 2025 },
+    ])
+
+    const savedScenarios = getCollection('saved_scenarios')
+    savedScenarios.create.mockResolvedValueOnce({
+      id: 'new-scenario-id',
+      name: 'Copied',
+      session: 'pb-session-1',
+      year: 2025,
+      is_active: true,
+      created: '2026-04-23T00:00:00Z',
+      updated: '2026-04-23T00:00:00Z',
+      expand: { session: { cm_id: 1000001 } },
+    })
+
+    const sourceAssignments = Array.from({ length: 10 }, (_, i) => ({
+      id: `draft-src-${i}`,
+      person: `person-${i}`,
+      bunk: `bunk-${i}`,
+      session: 'pb-session-1',
+      bunk_plan: `plan-${i}`,
+      year: 2025,
+      assignment_locked: false,
+    }))
+
+    const draftCollection = getCollection('bunk_assignments_draft')
+    draftCollection.getFullList.mockResolvedValueOnce(sourceAssignments)
+
+    let callIndex = 0
+    draftCollection.create.mockImplementation(async () => {
+      const i = callIndex++
+      // Fail every 3rd call
+      if (i % 3 === 0) {
+        throw new Error(`simulated failure ${i}`)
+      }
+      return { id: `new-draft-${i}` }
+    })
+
+    const { result } = renderHook(() => useCreateScenario(), { wrapper: createWrapper() })
+
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync({
+          name: 'Copied',
+          session_cm_id: 1000001,
+          year: 2025,
+          copyOptions: { fromScenario: 'source-scenario-id' },
+        })
+      ).rejects.toThrow(/Failed to copy/)
+    })
+
+    // Critical: all 10 creates attempted, not short-circuited like Promise.all would
+    expect(draftCollection.create).toHaveBeenCalledTimes(10)
+
+    await waitFor(() => {
+      // mutation is settled
+      expect(result.current.isError).toBe(true)
+    })
+  })
+})

--- a/frontend/src/hooks/useSavedScenariosMutation.test.ts
+++ b/frontend/src/hooks/useSavedScenariosMutation.test.ts
@@ -24,7 +24,6 @@ vi.mock('../lib/pocketbase', () => {
 
 import { pb } from '../lib/pocketbase'
 import { useCreateScenario } from './useSavedScenariosMutation'
-import { savedScenarioToScenario } from '../contexts/ScenarioContext'
 import type { SavedScenario } from '../types/app-types'
 
 function createWrapper() {
@@ -91,45 +90,6 @@ describe('Bug A: empty scenario does not trigger undefined.session error', () =>
     const createCall = savedScenarios.create.mock.calls[0]
     const createOptions = createCall?.[1]
     expect(createOptions).toMatchObject({ expand: 'session' })
-  })
-
-  it('savedScenarioToScenario handles a record with no expand property', () => {
-    // This simulates the record PocketBase returns from create() when no expand is requested
-    const recordWithoutExpand = {
-      id: 'scenario-xyz',
-      name: 'Empty',
-      session: 'pb-session-1',
-      year: 2025,
-      is_active: true,
-      created: '2026-04-23T00:00:00Z',
-      updated: '2026-04-23T00:00:00Z',
-      description: '',
-      // no expand field at all
-    } as unknown as SavedScenario
-
-    // Must not throw "Cannot read properties of undefined (reading 'session')"
-    expect(() => savedScenarioToScenario(recordWithoutExpand)).not.toThrow()
-    const scenario = savedScenarioToScenario(recordWithoutExpand)
-    expect(scenario.id).toBe('scenario-xyz')
-    expect(scenario.session_cm_id).toBe(0) // fallback when expand missing
-    expect(scenario.name).toBe('Empty')
-  })
-
-  it('savedScenarioToScenario extracts session_cm_id when expand.session is present', () => {
-    const record = {
-      id: 'scenario-2',
-      name: 'With Expand',
-      session: 'pb-session-1',
-      year: 2025,
-      is_active: true,
-      created: '2026-04-23T00:00:00Z',
-      updated: '2026-04-23T00:00:00Z',
-      description: '',
-      expand: { session: { cm_id: 1000042 } },
-    } as unknown as SavedScenario
-
-    const scenario = savedScenarioToScenario(record)
-    expect(scenario.session_cm_id).toBe(1000042)
   })
 })
 

--- a/frontend/src/hooks/useSavedScenariosMutation.test.ts
+++ b/frontend/src/hooks/useSavedScenariosMutation.test.ts
@@ -48,10 +48,6 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
-// ---------------------------------------------------------------------------
-// Bug A (#17A): Empty scenario "undefined.session" error
-// ---------------------------------------------------------------------------
-
 describe('Bug A: empty scenario does not trigger undefined.session error', () => {
   it('useCreateScenario passes expand: session to create() so returned record has expand.session', async () => {
     // Arrange
@@ -92,10 +88,6 @@ describe('Bug A: empty scenario does not trigger undefined.session error', () =>
     expect(createOptions).toMatchObject({ expand: 'session' })
   })
 })
-
-// ---------------------------------------------------------------------------
-// Bug B (#17B): Copy scenario drops ~1/3 of campers
-// ---------------------------------------------------------------------------
 
 describe('Bug B: copyScenarioToScenario copies ALL source assignments without loss', () => {
   it('copies all 50 source assignments sequentially (no Promise.all concurrency)', async () => {

--- a/frontend/src/hooks/useSavedScenariosMutation.ts
+++ b/frontend/src/hooks/useSavedScenariosMutation.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { pb, getCurrentUser } from '../lib/pocketbase'
 import type { SavedScenario } from '../types/app-types'
+import type { BunkAssignmentsDraftRecord } from '../types/pocketbase-types'
 
 interface CreateScenarioParams {
   name: string
@@ -8,6 +9,16 @@ interface CreateScenarioParams {
   year: number
   description?: string
   copyOptions?: { fromProduction: boolean } | { fromScenario: string }
+}
+
+interface AssignmentError {
+  assignment: unknown
+  error: unknown
+}
+
+interface PbLooseError {
+  response?: { data?: unknown }
+  message?: string
 }
 
 export function useCreateScenario() {
@@ -92,10 +103,6 @@ async function copyProductionToScenario(sessionCmId: number, scenarioId: string,
   console.log(`Copying ${filteredAssignments.length} assignments to scenario ${scenarioId}`)
 
   // Create draft assignments one at a time with error handling
-  interface AssignmentError {
-    assignment: unknown
-    error: unknown
-  }
   const errors: AssignmentError[] = []
 
   for (const assignment of filteredAssignments) {
@@ -116,10 +123,7 @@ async function copyProductionToScenario(sessionCmId: number, scenarioId: string,
     try {
       await pb.collection('bunk_assignments_draft').create(draftData)
     } catch (error) {
-      const pbError = error as {
-        response?: { data?: unknown }
-        message?: string
-      }
+      const pbError = error as PbLooseError
       console.error('Failed to create draft assignment:', {
         draftData,
         originalAssignment: assignment,
@@ -148,33 +152,22 @@ async function copyScenarioToScenario(fromScenarioId: string, toScenarioId: stri
   // Get source scenario assignments for the specific year.
   // The stored fields on bunk_assignments_draft are already relation IDs
   // (person, bunk, session, bunk_plan), so no expand is needed here.
-  const sourceAssignments = await pb.collection('bunk_assignments_draft').getFullList({
-    filter: `scenario = "${fromScenarioId}" && year = ${year}`,
-  })
-
-  interface DraftAssignment {
-    person?: string
-    bunk?: string
-    session?: string
-    bunk_plan?: string
-    assignment_locked?: boolean
-  }
+  const sourceAssignments = await pb
+    .collection<BunkAssignmentsDraftRecord>('bunk_assignments_draft')
+    .getFullList({
+      filter: `scenario = "${fromScenarioId}" && year = ${year}`,
+    })
 
   console.log(`Copying ${sourceAssignments.length} assignments to scenario ${toScenarioId}`)
 
-  interface AssignmentError {
-    assignment: unknown
-    error: unknown
-  }
   const errors: AssignmentError[] = []
 
-  for (const assignment of sourceAssignments) {
-    const source = assignment as DraftAssignment
+  for (const source of sourceAssignments) {
     const draftData: Record<string, unknown> = {
-      scenario: toScenarioId, // PocketBase relation to saved_scenarios
-      person: source.person, // Keep the PocketBase relation ID
-      bunk: source.bunk, // Keep the PocketBase relation ID
-      session: source.session, // Keep the PocketBase relation ID
+      scenario: toScenarioId,
+      person: source.person,
+      bunk: source.bunk,
+      session: source.session,
       year: year,
       assignment_locked: source.assignment_locked,
     }
@@ -187,16 +180,13 @@ async function copyScenarioToScenario(fromScenarioId: string, toScenarioId: stri
     try {
       await pb.collection('bunk_assignments_draft').create(draftData)
     } catch (error) {
-      const pbError = error as {
-        response?: { data?: unknown }
-        message?: string
-      }
+      const pbError = error as PbLooseError
       console.error('Failed to create draft assignment:', {
         draftData,
-        originalAssignment: assignment,
+        originalAssignment: source,
         error: pbError.response?.data ?? pbError.message ?? error,
       })
-      errors.push({ assignment, error })
+      errors.push({ assignment: source, error })
     }
   }
 

--- a/frontend/src/hooks/useSavedScenariosMutation.ts
+++ b/frontend/src/hooks/useSavedScenariosMutation.ts
@@ -39,8 +39,12 @@ export function useCreateScenario() {
         ...(params.description && { description: params.description }),
       }
 
-      // Create the scenario
-      const scenario = await pb.collection<SavedScenario>('saved_scenarios').create(scenarioData)
+      // Create the scenario — request expand on `session` so downstream
+      // consumers (e.g. savedScenarioToScenario) can read `expand.session.cm_id`
+      // without tripping on a missing `expand` property.
+      const scenario = await pb
+        .collection<SavedScenario>('saved_scenarios')
+        .create(scenarioData, { expand: 'session' })
 
       // Handle copying data if requested
       if (params.copyOptions) {
@@ -131,14 +135,23 @@ async function copyProductionToScenario(sessionCmId: number, scenarioId: string,
   }
 }
 
-// Helper function to copy assignments from one scenario to another
+// Helper function to copy assignments from one scenario to another.
+//
+// Historically this fired all creates concurrently via `Promise.all`, which
+// meant ~147 simultaneous POSTs fought for the same SQLite writer lock.
+// Some creates succeeded before a failed one rejected Promise.all, leaving
+// the destination scenario with only ~2/3 of the source assignments and
+// no clear error surface. Mirrors `copyProductionToScenario` below:
+// sequential `for..of await`, per-item try/catch, accumulated errors,
+// aggregate throw at the end.
 async function copyScenarioToScenario(fromScenarioId: string, toScenarioId: string, year: number) {
-  // Get source scenario assignments for the specific year
+  // Get source scenario assignments for the specific year.
+  // The stored fields on bunk_assignments_draft are already relation IDs
+  // (person, bunk, session, bunk_plan), so no expand is needed here.
   const sourceAssignments = await pb.collection('bunk_assignments_draft').getFullList({
     filter: `scenario = "${fromScenarioId}" && year = ${year}`,
   })
 
-  // Create draft assignments for the new scenario
   interface DraftAssignment {
     person?: string
     bunk?: string
@@ -147,22 +160,50 @@ async function copyScenarioToScenario(fromScenarioId: string, toScenarioId: stri
     assignment_locked?: boolean
   }
 
-  const createPromises = sourceAssignments.map((assignment) => {
+  console.log(`Copying ${sourceAssignments.length} assignments to scenario ${toScenarioId}`)
+
+  interface AssignmentError {
+    assignment: unknown
+    error: unknown
+  }
+  const errors: AssignmentError[] = []
+
+  for (const assignment of sourceAssignments) {
     const source = assignment as DraftAssignment
     const draftData: Record<string, unknown> = {
       scenario: toScenarioId, // PocketBase relation to saved_scenarios
       person: source.person, // Keep the PocketBase relation ID
       bunk: source.bunk, // Keep the PocketBase relation ID
       session: source.session, // Keep the PocketBase relation ID
-      bunk_plan: source.bunk_plan, // Keep the PocketBase relation ID if exists
       year: year,
       assignment_locked: source.assignment_locked,
     }
 
-    return pb.collection('bunk_assignments_draft').create(draftData)
-  })
+    // Only include bunk_plan if it exists (mirrors copyProductionToScenario)
+    if (source.bunk_plan) {
+      draftData['bunk_plan'] = source.bunk_plan
+    }
 
-  await Promise.all(createPromises)
+    try {
+      await pb.collection('bunk_assignments_draft').create(draftData)
+    } catch (error) {
+      const pbError = error as {
+        response?: { data?: unknown }
+        message?: string
+      }
+      console.error('Failed to create draft assignment:', {
+        draftData,
+        originalAssignment: assignment,
+        error: pbError.response?.data ?? pbError.message ?? error,
+      })
+      errors.push({ assignment, error })
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error(`Failed to copy ${errors.length}/${sourceAssignments.length} assignments`)
+    throw new Error(`Failed to copy ${errors.length} assignments. Check console for details.`)
+  }
 }
 
 export function useDeleteScenario() {


### PR DESCRIPTION
## Summary
- **#17A** — "Start empty scenario" threw `Cannot read properties of undefined (reading 'session')`. Root cause: `pb.collection('saved_scenarios').create()` wasn't fetching the `session` expand, but `savedScenarioToScenario()` assumed `expand.session` existed. Fix: pass `{ expand: 'session' }` on create **and** harden the transform to tolerate missing expand (defense in depth).
- **#17B** — Copying a scenario produced an error and only persisted ~2/3 of the assignments (verified via local DB: a test scenario had 97/147 assignments = 66%, with loss uniform across every bunk and bunk_plan — not a filter bug). Root cause: `copyScenarioToScenario` fired all creates in parallel via `Promise.all(createPromises)` — SQLite write contention caused ~50 creates to fail before `Promise.all` rejected, with the earlier successes already persisted. Fix: rewrote to mirror the existing `copyProductionToScenario` pattern in the same file — sequential `for...of await`, per-item try/catch, error accumulator, aggregate throw.
- **Refactor** — Extracted `savedScenarioToScenario` to its own module (`frontend/src/contexts/scenarioTransform.ts`) so the context file contains only the React component, removing an `eslint-disable react-refresh/only-export-components` workaround.

## Test plan
- [ ] Start an empty scenario — no error thrown, scenario loads
- [ ] Copy a scenario with 100+ campers — all assignments persist, no error
- [ ] Compare row counts in `bunk_assignments_draft` for source vs copy — should match exactly
- [ ] Existing scenario flows (start from CampMinder production) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
