### PR TITLE
fix(api,frontend): source social graph from active scenario and cache per-scenario

### DIFF
--- a/api/routers/social_graph.py
+++ b/api/routers/social_graph.py
@@ -59,6 +59,10 @@ async def get_session_social_graph(
     include_historical: Annotated[bool, Query(description="Include historical data")] = False,
     layout: Annotated[str, Query(description="Layout algorithm: force, circle, hierarchical")] = "force",
     edge_types: Annotated[str | None, Query(description="Comma-separated edge types to include")] = None,
+    scenario_id: Annotated[
+        str | None,
+        Query(description="Scenario ID — when set, source bunk assignments from bunk_assignments_draft"),
+    ] = None,
     user: AuthUser = Depends(get_current_user),
 ) -> SocialGraphResponse:
     """Get the full social graph for a session using NetworkX analysis.
@@ -77,10 +81,16 @@ async def get_session_social_graph(
         if year is None:
             year = datetime.now(tz=UTC).year
 
-        logger.info(f"Building social graph for session {session_cm_id}, year {year}")
+        logger.info(
+            f"Building social graph for session {session_cm_id}, year {year}"
+            + (f", scenario {scenario_id}" if scenario_id else "")
+        )
 
-        # Check cache first
-        cached_graph = graph_cache.get_session_graph(session_cm_id, year)
+        # Check cache first. Skip the in-memory session-graph cache when a
+        # scenario_id is supplied — the cache key does not include scenario,
+        # so reusing it would leak CampMinder (production) assignments into a
+        # scenario view (or vice versa).
+        cached_graph = None if scenario_id else graph_cache.get_session_graph(session_cm_id, year)
         if cached_graph:
             logger.info(f"Using cached graph for session {session_cm_id}")
             graph = cached_graph
@@ -120,11 +130,13 @@ async def get_session_social_graph(
             # Use optimized builder with centralized random seed setting
             builder = OptimizedSocialGraphBuilder(pb, random_seed=GRAPH_RANDOM_SEED)
 
-            # Build the graph
-            graph = builder.build_social_network(year, session_cm_id)
+            # Build the graph — pass scenario_id so bunk assignments are sourced
+            # from bunk_assignments_draft when a scenario is active.
+            graph = builder.build_social_network(year, session_cm_id, scenario_id=scenario_id)
 
-            # Cache it
-            graph_cache.cache_session_graph(session_cm_id, year, graph)
+            # Cache only the production (no-scenario) variant — see note above.
+            if not scenario_id:
+                graph_cache.cache_session_graph(session_cm_id, year, graph)
 
         # Convert to response format
         nodes = []

--- a/api/routers/social_graph.py
+++ b/api/routers/social_graph.py
@@ -86,11 +86,10 @@ async def get_session_social_graph(
             + (f", scenario {scenario_id}" if scenario_id else "")
         )
 
-        # Check cache first. Skip the in-memory session-graph cache when a
-        # scenario_id is supplied — the cache key does not include scenario,
-        # so reusing it would leak CampMinder (production) assignments into a
-        # scenario view (or vice versa).
-        cached_graph = None if scenario_id else graph_cache.get_session_graph(session_cm_id, year)
+        # Check cache first. The cache key is scoped by scenario_id so that
+        # production and scenario graphs are cached independently and cannot
+        # leak into one another.
+        cached_graph = graph_cache.get_session_graph(session_cm_id, year, scenario_id=scenario_id)
         if cached_graph:
             logger.info(f"Using cached graph for session {session_cm_id}")
             graph = cached_graph
@@ -134,9 +133,9 @@ async def get_session_social_graph(
             # from bunk_assignments_draft when a scenario is active.
             graph = builder.build_social_network(year, session_cm_id, scenario_id=scenario_id)
 
-            # Cache only the production (no-scenario) variant — see note above.
-            if not scenario_id:
-                graph_cache.cache_session_graph(session_cm_id, year, graph)
+            # Cache under a scenario-scoped key so production and scenario
+            # graphs are stored independently.
+            graph_cache.cache_session_graph(session_cm_id, year, graph, scenario_id=scenario_id)
 
         # Convert to response format
         nodes = []

--- a/api/routers/social_graph.py
+++ b/api/routers/social_graph.py
@@ -83,7 +83,7 @@ async def get_session_social_graph(
 
         logger.info(
             f"Building social graph for session {session_cm_id}, year {year}"
-            + (f", scenario {scenario_id}" if scenario_id else "")
+            f"{f', scenario {scenario_id}' if scenario_id else ''}"
         )
 
         # Check cache first. The cache key is scoped by scenario_id so that
@@ -344,7 +344,7 @@ async def get_bunk_social_graph(
 
         logger.info(
             f"Building bunk social graph for bunk {bunk_cm_id}, session {session_cm_id}, year {year}"
-            + (f", scenario {scenario_id}" if scenario_id else "")
+            f"{f', scenario {scenario_id}' if scenario_id else ''}"
         )
 
         # Get bunk details first

--- a/api/routers/social_graph.py
+++ b/api/routers/social_graph.py
@@ -317,6 +317,10 @@ async def get_bunk_social_graph(
     bunk_cm_id: int,
     session_cm_id: int,
     year: int | None = None,
+    scenario_id: Annotated[
+        str | None,
+        Query(description="Scenario ID — when set, source bunk membership from bunk_assignments_draft"),
+    ] = None,
     user: AuthUser = Depends(get_current_user),
 ) -> BunkGraphResponse:
     """Get the social subgraph for a specific bunk.
@@ -325,6 +329,11 @@ async def get_bunk_social_graph(
         bunk_cm_id: CampMinder bunk ID
         session_cm_id: CampMinder session ID (required)
         year: Year (defaults to current year)
+        scenario_id: When provided, source bunk membership from the scenario's
+            draft assignments so the bunk subgraph matches the active scenario.
+            When absent, production (CampMinder) data is used. Cache entries
+            are keyed separately per scenario so scenario and production graphs
+            never collide.
 
     Returns:
         Bunk subgraph with health metrics and improvement suggestions
@@ -333,7 +342,10 @@ async def get_bunk_social_graph(
         if year is None:
             year = datetime.now(tz=UTC).year
 
-        logger.info(f"Building bunk social graph for bunk {bunk_cm_id}, session {session_cm_id}, year {year}")
+        logger.info(
+            f"Building bunk social graph for bunk {bunk_cm_id}, session {session_cm_id}, year {year}"
+            + (f", scenario {scenario_id}" if scenario_id else "")
+        )
 
         # Get bunk details first
         try:
@@ -342,8 +354,9 @@ async def get_bunk_social_graph(
         except Exception:
             bunk_name = f"Bunk {bunk_cm_id}"
 
-        # Check cache first
-        cached_graph = graph_cache.get_bunk_graph(bunk_cm_id, session_cm_id, year)
+        # Check cache first — scoped by scenario so production and scenario
+        # graphs occupy distinct cache slots for the same bunk+session+year.
+        cached_graph = graph_cache.get_bunk_graph(bunk_cm_id, session_cm_id, year, scenario_id=scenario_id)
         if cached_graph:
             logger.info(f"Using cached graph for bunk {bunk_cm_id}")
             bunk_graph = cached_graph
@@ -351,12 +364,14 @@ async def get_bunk_social_graph(
             # Use optimized builder with centralized random seed setting
             builder = OptimizedSocialGraphBuilder(pb, random_seed=GRAPH_RANDOM_SEED)
 
-            # Build bunk-specific graph with only request and sibling edges
-            bunk_graph = builder.build_bunk_graph(year, bunk_cm_id, session_cm_id)
+            # Build bunk-specific graph with only request and sibling edges.
+            # Pass scenario_id so membership is sourced from the scenario's
+            # draft assignments when active.
+            bunk_graph = builder.build_bunk_graph(year, bunk_cm_id, session_cm_id, scenario_id=scenario_id)
 
             # Cache it if not empty
             if bunk_graph.number_of_nodes() > 0:
-                graph_cache.cache_bunk_graph(bunk_cm_id, session_cm_id, year, bunk_graph)
+                graph_cache.cache_bunk_graph(bunk_cm_id, session_cm_id, year, bunk_graph, scenario_id=scenario_id)
 
         if bunk_graph.number_of_nodes() == 0:
             logger.info(f"No members found in bunk {bunk_cm_id}, returning empty graph")

--- a/bunking/graph/graph_cache_manager.py
+++ b/bunking/graph/graph_cache_manager.py
@@ -39,13 +39,28 @@ class GraphCacheManager:
 
         logger.info(f"GraphCacheManager initialized with TTL={ttl_seconds}s, max_size={max_cache_size}")
 
-    def get_session_graph(self, session_cm_id: int, year: int) -> nx.DiGraph | None:
+    @staticmethod
+    def _scenario_slug(scenario_id: str | None) -> str:
+        """Normalize scenario_id into a cache-key segment.
+
+        The production path is stored under the literal ``"prod"`` slug so
+        that ``None`` and any scenario id land in distinct keyspaces and the
+        prefix match in ``invalidate_session`` is unambiguous.
+        """
+        return scenario_id or "prod"
+
+    def get_session_graph(self, session_cm_id: int, year: int, scenario_id: str | None = None) -> nx.DiGraph | None:
         """Get cached session graph if available and not expired.
 
+        Args:
+            session_cm_id: Session ID
+            year: Year
+            scenario_id: Optional scenario id; ``None`` selects the production cache.
+
         Returns:
             Cached graph copy or None if not found/expired
         """
-        cache_key = f"session_{session_cm_id}_{year}"
+        cache_key = f"session_{session_cm_id}_{year}_{self._scenario_slug(scenario_id)}"
 
         with self._lock:
             if cache_key in self._cache:
@@ -68,13 +83,25 @@ class GraphCacheManager:
             logger.debug(f"Cache miss for {cache_key}")
             return None
 
-    def get_bunk_graph(self, bunk_cm_id: int, session_cm_id: int, year: int) -> nx.DiGraph | None:
+    def get_bunk_graph(
+        self,
+        bunk_cm_id: int,
+        session_cm_id: int,
+        year: int,
+        scenario_id: str | None = None,
+    ) -> nx.DiGraph | None:
         """Get cached bunk graph if available and not expired.
 
+        Args:
+            bunk_cm_id: Bunk ID
+            session_cm_id: Session ID
+            year: Year
+            scenario_id: Optional scenario id; ``None`` selects the production cache.
+
         Returns:
             Cached graph copy or None if not found/expired
         """
-        cache_key = f"bunk_{bunk_cm_id}_{session_cm_id}_{year}"
+        cache_key = f"bunk_{bunk_cm_id}_{session_cm_id}_{year}_{self._scenario_slug(scenario_id)}"
 
         with self._lock:
             if cache_key in self._cache:
@@ -97,15 +124,22 @@ class GraphCacheManager:
             logger.debug(f"Cache miss for {cache_key}")
             return None
 
-    def cache_session_graph(self, session_cm_id: int, year: int, graph: nx.DiGraph) -> None:
+    def cache_session_graph(
+        self,
+        session_cm_id: int,
+        year: int,
+        graph: nx.DiGraph,
+        scenario_id: str | None = None,
+    ) -> None:
         """Cache a session graph.
 
         Args:
             session_cm_id: Session ID
             year: Year
             graph: NetworkX graph to cache
+            scenario_id: Optional scenario id; ``None`` stores under the production cache.
         """
-        cache_key = f"session_{session_cm_id}_{year}"
+        cache_key = f"session_{session_cm_id}_{year}_{self._scenario_slug(scenario_id)}"
 
         with self._lock:
             # Evict LRU if at capacity
@@ -119,7 +153,14 @@ class GraphCacheManager:
 
             logger.debug(f"Cached session graph {cache_key} with {graph.number_of_nodes()} nodes")
 
-    def cache_bunk_graph(self, bunk_cm_id: int, session_cm_id: int, year: int, graph: nx.DiGraph) -> None:
+    def cache_bunk_graph(
+        self,
+        bunk_cm_id: int,
+        session_cm_id: int,
+        year: int,
+        graph: nx.DiGraph,
+        scenario_id: str | None = None,
+    ) -> None:
         """Cache a bunk graph.
 
         Args:
@@ -127,8 +168,9 @@ class GraphCacheManager:
             session_cm_id: Session ID
             year: Year
             graph: NetworkX graph to cache
+            scenario_id: Optional scenario id; ``None`` stores under the production cache.
         """
-        cache_key = f"bunk_{bunk_cm_id}_{session_cm_id}_{year}"
+        cache_key = f"bunk_{bunk_cm_id}_{session_cm_id}_{year}_{self._scenario_slug(scenario_id)}"
 
         with self._lock:
             # Evict LRU if at capacity

--- a/bunking/graph/graph_cache_manager.py
+++ b/bunking/graph/graph_cache_manager.py
@@ -215,9 +215,22 @@ class GraphCacheManager:
         """
         with self._lock:
             session_prefix = f"session_{session_cm_id}_{year}"
-            keys_to_remove = [
-                key for key in self._cache if key.startswith(session_prefix) or f"_{session_cm_id}_{year}" in key
-            ]
+            session_str = str(session_cm_id)
+            year_str = str(year)
+            keys_to_remove: list[str] = []
+            for key in self._cache:
+                if key.startswith(session_prefix):
+                    keys_to_remove.append(key)
+                    continue
+                # Bunk keys are ``bunk_{bunk_id}_{session_id}_{year}_{slug}``.
+                # Parse positionally so we don't false-match a bunk whose
+                # bunk_cm_id coincidentally equals the session_cm_id (e.g. key
+                # ``bunk_5_2025_2025_prod`` should NOT match session 5 in
+                # year 2025 – the real session there is 2025).
+                if key.startswith("bunk_"):
+                    parts = key.split("_")
+                    if len(parts) >= 5 and parts[2] == session_str and parts[3] == year_str:
+                        keys_to_remove.append(key)
 
             for key in keys_to_remove:
                 self._evict(key)

--- a/bunking/graph/optimized_graph_builder.py
+++ b/bunking/graph/optimized_graph_builder.py
@@ -16,7 +16,6 @@ import networkx as nx
 from api.constants.collections import (
     ATTENDEES,
     BUNK_ASSIGNMENTS,
-    BUNK_ASSIGNMENTS_DRAFT,
     BUNK_REQUESTS,
     BUNKS,
     PERSONS,
@@ -115,15 +114,10 @@ class OptimizedSocialGraphBuilder(SocialGraphBuilder):
             # bunk_assignments_draft collection (scenario data); otherwise use the
             # production bunk_assignments collection (CampMinder sync data).
             bunk_cm_id = None
-            if scenario_id:
-                assignment_collection = BUNK_ASSIGNMENTS_DRAFT
-                assignment_filter = (
-                    f"person.cm_id = {person.cm_id} && session.cm_id = {session_cm_id} "
-                    f'&& year = {year} && scenario = "{scenario_id}"'
-                )
-            else:
-                assignment_collection = BUNK_ASSIGNMENTS
-                assignment_filter = f"person.cm_id = {person.cm_id} && session.cm_id = {session_cm_id} && year = {year}"
+            assignment_collection, scenario_clause = self._assignment_source(scenario_id)
+            assignment_filter = (
+                f"person.cm_id = {person.cm_id} && session.cm_id = {session_cm_id} && year = {year}{scenario_clause}"
+            )
             try:
                 assignment = self.pb.collection(assignment_collection).get_first_list_item(
                     assignment_filter,

--- a/bunking/graph/optimized_graph_builder.py
+++ b/bunking/graph/optimized_graph_builder.py
@@ -13,7 +13,14 @@ from typing import Any
 
 import networkx as nx
 
-from api.constants.collections import ATTENDEES, BUNK_ASSIGNMENTS, BUNK_REQUESTS, BUNKS, PERSONS
+from api.constants.collections import (
+    ATTENDEES,
+    BUNK_ASSIGNMENTS,
+    BUNK_ASSIGNMENTS_DRAFT,
+    BUNK_REQUESTS,
+    BUNKS,
+    PERSONS,
+)
 from bunking.logging_config import get_logger
 
 from .social_graph_builder import SocialGraphBuilder
@@ -24,8 +31,21 @@ logger = get_logger(__name__)
 class OptimizedSocialGraphBuilder(SocialGraphBuilder):
     """Performance-optimized social graph builder using batch operations."""
 
-    def build_social_network(self, year: int, session_cm_id: int) -> nx.DiGraph:
+    def build_social_network(
+        self,
+        year: int,
+        session_cm_id: int,
+        scenario_id: str | None = None,
+    ) -> nx.DiGraph:
         """Build social network with performance optimizations.
+
+        Args:
+            year: Camp year.
+            session_cm_id: CampMinder session ID.
+            scenario_id: Optional PocketBase ID of a saved scenario. When provided,
+                bunk assignments are sourced from the ``bunk_assignments_draft``
+                collection filtered by scenario. When absent, assignments come
+                from the production ``bunk_assignments`` collection (CampMinder).
 
         Optimizations:
         - Batch node/edge operations
@@ -33,7 +53,10 @@ class OptimizedSocialGraphBuilder(SocialGraphBuilder):
         - Efficient edge deduplication
         - Rounded decimal values
         """
-        logger.info(f"Building optimized social graph for session {session_cm_id}, year {year}")
+        logger.info(
+            f"Building optimized social graph for session {session_cm_id}, year {year}"
+            + (f", scenario {scenario_id}" if scenario_id else "")
+        )
         start_time = time.perf_counter()
 
         # Initialize graph
@@ -88,11 +111,22 @@ class OptimizedSocialGraphBuilder(SocialGraphBuilder):
                 logger.warning(f"Person {person_id} not found, skipping")
                 continue
 
-            # Get bunk assignment (bunk_assignments uses person/session/bunk relations)
+            # Get bunk assignment. When scenario_id is provided, source from the
+            # bunk_assignments_draft collection (scenario data); otherwise use the
+            # production bunk_assignments collection (CampMinder sync data).
             bunk_cm_id = None
+            if scenario_id:
+                assignment_collection = BUNK_ASSIGNMENTS_DRAFT
+                assignment_filter = (
+                    f"person.cm_id = {person.cm_id} && session.cm_id = {session_cm_id} "
+                    f'&& year = {year} && scenario = "{scenario_id}"'
+                )
+            else:
+                assignment_collection = BUNK_ASSIGNMENTS
+                assignment_filter = f"person.cm_id = {person.cm_id} && session.cm_id = {session_cm_id} && year = {year}"
             try:
-                assignment = self.pb.collection(BUNK_ASSIGNMENTS).get_first_list_item(
-                    f"person.cm_id = {person.cm_id} && session.cm_id = {session_cm_id} && year = {year}",
+                assignment = self.pb.collection(assignment_collection).get_first_list_item(
+                    assignment_filter,
                     query_params={"expand": "bunk"},
                 )
                 # Get bunk cm_id from expanded relation

--- a/bunking/graph/social_graph_builder.py
+++ b/bunking/graph/social_graph_builder.py
@@ -62,6 +62,23 @@ class SocialGraphBuilder:
         self.attendee_cache: dict[int, list[dict[str, Any]]] = {}
         self.random_seed = random_seed
 
+    @staticmethod
+    def _assignment_source(scenario_id: str | None) -> tuple[str, str]:
+        """Pick the bunk assignment collection and scenario filter clause.
+
+        When a scenario is active, bunk membership lives in
+        ``bunk_assignments_draft`` filtered by ``scenario``. Otherwise the
+        production ``bunk_assignments`` collection is used. Returned tuple:
+
+        * collection name to query
+        * scenario clause to AND into the caller's base filter (empty when
+          no scenario is active). The leading ``&&`` and surrounding space
+          are included so callers can append it directly.
+        """
+        if scenario_id:
+            return BUNK_ASSIGNMENTS_DRAFT, f' && scenario = "{scenario_id}"'
+        return BUNK_ASSIGNMENTS, ""
+
     def build_session_graph(self, year: int, session_cm_id: int) -> nx.Graph:
         """Build complete social graph for a session
 
@@ -133,15 +150,10 @@ class SocialGraphBuilder:
         # Route the membership query to the scenario's draft collection when a
         # scenario is active; otherwise hit the production (CampMinder-sourced)
         # collection. Production path behavior is unchanged.
-        if scenario_id:
-            assignment_collection = BUNK_ASSIGNMENTS_DRAFT
-            primary_filter = (
-                f"bunk.cm_id = {bunk_cm_id} && year = {year} "
-                f'&& session.cm_id = {session_cm_id} && scenario = "{scenario_id}"'
-            )
-        else:
-            assignment_collection = BUNK_ASSIGNMENTS
-            primary_filter = f"bunk.cm_id = {bunk_cm_id} && year = {year} && session.cm_id = {session_cm_id}"
+        assignment_collection, scenario_clause = self._assignment_source(scenario_id)
+        primary_filter = (
+            f"bunk.cm_id = {bunk_cm_id} && year = {year} && session.cm_id = {session_cm_id}{scenario_clause}"
+        )
 
         # Get all members of this bunk for the specific session (uses relations)
         bunk_members = []

--- a/bunking/graph/social_graph_builder.py
+++ b/bunking/graph/social_graph_builder.py
@@ -12,7 +12,15 @@ from typing import Any
 import community as community_louvain
 import networkx as nx
 
-from api.constants.collections import ATTENDEES, BUNK_ASSIGNMENTS, BUNK_REQUESTS, BUNKS, CAMP_SESSIONS, PERSONS
+from api.constants.collections import (
+    ATTENDEES,
+    BUNK_ASSIGNMENTS,
+    BUNK_ASSIGNMENTS_DRAFT,
+    BUNK_REQUESTS,
+    BUNKS,
+    CAMP_SESSIONS,
+    PERSONS,
+)
 from api.utils.session_metrics import get_person_from_expand, get_session_from_expand
 from bunking.logging_config import get_logger
 from pocketbase import PocketBase
@@ -95,19 +103,52 @@ class SocialGraphBuilder:
 
         return self.graph
 
-    def build_bunk_graph(self, year: int, bunk_cm_id: int, session_cm_id: int) -> nx.DiGraph:
-        """Build a graph specifically for a single bunk with only request and sibling edges"""
-        logger.info(f"Building bunk-specific graph for bunk {bunk_cm_id} in session {session_cm_id}, year {year}")
+    def build_bunk_graph(
+        self,
+        year: int,
+        bunk_cm_id: int,
+        session_cm_id: int,
+        scenario_id: str | None = None,
+    ) -> nx.DiGraph:
+        """Build a graph specifically for a single bunk with only request and sibling edges.
+
+        Args:
+            year: Camp year.
+            bunk_cm_id: CampMinder bunk ID.
+            session_cm_id: CampMinder session ID.
+            scenario_id: Optional PocketBase scenario record ID. When provided,
+                bunk membership is sourced from ``bunk_assignments_draft``
+                filtered by the scenario; otherwise the production
+                ``bunk_assignments`` collection is used. This mirrors
+                ``OptimizedSocialGraphBuilder.build_social_network``.
+        """
+        logger.info(
+            f"Building bunk-specific graph for bunk {bunk_cm_id} in session {session_cm_id}, year {year}"
+            + (f" (scenario={scenario_id})" if scenario_id else "")
+        )
 
         # Create new DIRECTED graph for this bunk to preserve edge directionality
         bunk_graph = nx.DiGraph()
 
+        # Route the membership query to the scenario's draft collection when a
+        # scenario is active; otherwise hit the production (CampMinder-sourced)
+        # collection. Production path behavior is unchanged.
+        if scenario_id:
+            assignment_collection = BUNK_ASSIGNMENTS_DRAFT
+            primary_filter = (
+                f"bunk.cm_id = {bunk_cm_id} && year = {year} "
+                f'&& session.cm_id = {session_cm_id} && scenario = "{scenario_id}"'
+            )
+        else:
+            assignment_collection = BUNK_ASSIGNMENTS
+            primary_filter = f"bunk.cm_id = {bunk_cm_id} && year = {year} && session.cm_id = {session_cm_id}"
+
         # Get all members of this bunk for the specific session (uses relations)
         bunk_members = []
         try:
-            assignments = self.pb.collection(BUNK_ASSIGNMENTS).get_full_list(
+            assignments = self.pb.collection(assignment_collection).get_full_list(
                 query_params={
-                    "filter": f"bunk.cm_id = {bunk_cm_id} && year = {year} && session.cm_id = {session_cm_id}",
+                    "filter": primary_filter,
                     "expand": "person,bunk,session",
                 }
             )
@@ -134,10 +175,16 @@ class SocialGraphBuilder:
                 if "AG" in bunk_name or bunk_name.startswith("AG"):
                     logger.info(f"AG bunk detected: {bunk_name}, checking all sessions for assignments")
 
-                    # Find all sessions this bunk is assigned to (uses relations)
-                    all_assignments = self.pb.collection(BUNK_ASSIGNMENTS).get_full_list(
+                    # Find all sessions this bunk is assigned to (uses relations).
+                    # Stay on the same source (draft vs prod) as the primary
+                    # lookup above so scenario and production data never mix.
+                    if scenario_id:
+                        ag_filter = f'bunk.cm_id = {bunk_cm_id} && year = {year} && scenario = "{scenario_id}"'
+                    else:
+                        ag_filter = f"bunk.cm_id = {bunk_cm_id} && year = {year}"
+                    all_assignments = self.pb.collection(assignment_collection).get_full_list(
                         query_params={
-                            "filter": f"bunk.cm_id = {bunk_cm_id} && year = {year}",
+                            "filter": ag_filter,
                             "expand": "person,session",
                         }
                     )

--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -30,6 +30,7 @@ import { useApiWithAuth } from '../hooks/useApiWithAuth'
 import { useScenario } from '../hooks/useScenario'
 import CamperDetailsPanel from './CamperDetailsPanel'
 import { pb } from '../lib/pocketbase'
+import { queryKeys } from '../utils/queryKeys'
 import type { Bunk, Session } from '../types/app-types'
 
 // Register extensions
@@ -124,7 +125,7 @@ export default function BunkSocialGraphModal({
   // Fetch bunk graph data. The query key and in-memory graph cache both
   // include scenarioId so scenario-sourced and production graphs never collide.
   const { data: graphData, isLoading } = useQuery<BunkGraphData>({
-    queryKey: ['bunk-social-graph', bunkCmId, sessionCmId, year, scenarioId],
+    queryKey: queryKeys.bunkSocialGraph(bunkCmId, sessionCmId, year, scenarioId),
     queryFn: async () => {
       const data = await graphCacheService.getBunkGraph(
         bunkCmId,

--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -25,7 +25,9 @@ import clsx from 'clsx'
 import { formatGradeOrdinal } from '../utils/gradeUtils'
 import { getSessionShorthand } from '../utils/sessionDisplay'
 import { socialGraphService } from '../services/socialGraph'
+import { graphCacheService } from '../services/GraphCacheService'
 import { useApiWithAuth } from '../hooks/useApiWithAuth'
+import { useScenario } from '../hooks/useScenario'
 import CamperDetailsPanel from './CamperDetailsPanel'
 import { pb } from '../lib/pocketbase'
 import type { Bunk, Session } from '../types/app-types'
@@ -110,6 +112,8 @@ export default function BunkSocialGraphModal({
   const cyRef = useRef<Core | null>(null)
   const layoutRef = useRef<cytoscape.Layouts | null>(null)
   const { fetchWithAuth } = useApiWithAuth()
+  const { currentScenario } = useScenario()
+  const scenarioId = currentScenario?.id ?? null
   const [selectedCamperId, setSelectedCamperId] = useState<string | null>(null)
   const [currentBunkIndex, setCurrentBunkIndex] = useState<number>(0)
   const [sessionBunks, setSessionBunks] = useState<
@@ -117,15 +121,25 @@ export default function BunkSocialGraphModal({
   >([])
   const [showLegend, setShowLegend] = useState<boolean>(false)
 
-  // Fetch bunk graph data
+  // Fetch bunk graph data. The query key and in-memory graph cache both
+  // include scenarioId so scenario-sourced and production graphs never collide.
   const { data: graphData, isLoading } = useQuery<BunkGraphData>({
-    queryKey: ['bunk-social-graph', bunkCmId, sessionCmId, year],
+    queryKey: ['bunk-social-graph', bunkCmId, sessionCmId, year, scenarioId],
     queryFn: async () => {
-      const data = await socialGraphService.getBunkSocialGraph(
+      const data = await graphCacheService.getBunkGraph(
         bunkCmId,
         sessionCmId,
+        async () => {
+          return socialGraphService.getBunkSocialGraph(
+            bunkCmId,
+            sessionCmId,
+            year,
+            fetchWithAuth,
+            scenarioId
+          )
+        },
         year,
-        fetchWithAuth
+        scenarioId
       )
       return data as unknown as BunkGraphData
     },

--- a/frontend/src/hooks/useSocialGraphData.ts
+++ b/frontend/src/hooks/useSocialGraphData.ts
@@ -28,23 +28,21 @@ export function useSocialGraphData(sessionCmId: number) {
     queryKey: queryKeys.socialGraph(sessionCmId, currentYear, scenarioId),
     enabled: !isAuthLoading,
     queryFn: async () => {
-      // Bypass the long-lived in-memory graph cache for scenario views — the
-      // cache is keyed only by session+year, so a scenario graph would be
-      // served to a later production-mode view (or vice versa).
-      if (scenarioId) {
-        return socialGraphService.getSessionSocialGraph(
-          sessionCmId,
-          currentYear,
-          fetchWithAuth,
-          scenarioId
-        )
-      }
+      // The in-memory graph cache is keyed by (session, year, scenario) so
+      // scenario and production graphs are stored independently and cannot
+      // leak into one another.
       return graphCacheService.getSessionGraph(
         sessionCmId,
         async () => {
-          return socialGraphService.getSessionSocialGraph(sessionCmId, currentYear, fetchWithAuth)
+          return socialGraphService.getSessionSocialGraph(
+            sessionCmId,
+            currentYear,
+            fetchWithAuth,
+            scenarioId
+          )
         },
-        currentYear
+        currentYear,
+        scenarioId
       )
     },
   })

--- a/frontend/src/hooks/useSocialGraphData.ts
+++ b/frontend/src/hooks/useSocialGraphData.ts
@@ -9,19 +9,36 @@ import type { GraphData } from '../types/graph'
 import { queryKeys } from '../utils/queryKeys'
 import { useYear } from './useCurrentYear'
 import { useApiWithAuth } from './useApiWithAuth'
+import { useScenario } from './useScenario'
 
 /**
- * Fetch social network graph data for a session
- * Uses the graph cache service for performance
+ * Fetch social network graph data for a session.
+ *
+ * When a scenario is active (from ScenarioContext), the request includes the
+ * scenario ID so the backend sources bunk assignments from that scenario's
+ * draft data instead of CampMinder production assignments.
  */
 export function useSocialGraphData(sessionCmId: number) {
   const currentYear = useYear()
   const { fetchWithAuth, isAuthLoading } = useApiWithAuth()
+  const { currentScenario } = useScenario()
+  const scenarioId = currentScenario?.id ?? null
 
   return useQuery<GraphData>({
-    queryKey: queryKeys.socialGraph(sessionCmId, currentYear),
+    queryKey: queryKeys.socialGraph(sessionCmId, currentYear, scenarioId),
     enabled: !isAuthLoading,
     queryFn: async () => {
+      // Bypass the long-lived in-memory graph cache for scenario views — the
+      // cache is keyed only by session+year, so a scenario graph would be
+      // served to a later production-mode view (or vice versa).
+      if (scenarioId) {
+        return socialGraphService.getSessionSocialGraph(
+          sessionCmId,
+          currentYear,
+          fetchWithAuth,
+          scenarioId
+        )
+      }
       return graphCacheService.getSessionGraph(
         sessionCmId,
         async () => {

--- a/frontend/src/hooks/useSocialGraphData.ts
+++ b/frontend/src/hooks/useSocialGraphData.ts
@@ -28,9 +28,6 @@ export function useSocialGraphData(sessionCmId: number) {
     queryKey: queryKeys.socialGraph(sessionCmId, currentYear, scenarioId),
     enabled: !isAuthLoading,
     queryFn: async () => {
-      // The in-memory graph cache is keyed by (session, year, scenario) so
-      // scenario and production graphs are stored independently and cannot
-      // leak into one another.
       return graphCacheService.getSessionGraph(
         sessionCmId,
         async () => {

--- a/frontend/src/services/GraphCacheService.test.ts
+++ b/frontend/src/services/GraphCacheService.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { GraphCacheService } from './GraphCacheService'
+import type { GraphData } from '../types/graph'
+
+/**
+ * Build a minimal GraphData shape that the cache can store / size-estimate.
+ */
+let nextId = 1
+function makeGraph(tag: string): GraphData {
+  return {
+    nodes: [
+      {
+        id: nextId++,
+        name: `${tag}-node`,
+        grade: null,
+        bunk_cm_id: null,
+        centrality: 0,
+        clustering: 0,
+        community: null,
+      },
+    ],
+    edges: [],
+    metrics: {
+      density: 0,
+      average_clustering: 0,
+      number_of_components: 0,
+      average_degree: 0,
+    },
+    communities: {},
+    warnings: [],
+    layout_positions: {},
+  }
+}
+
+describe('GraphCacheService (scenario-aware)', () => {
+  let service: GraphCacheService
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    service = new GraphCacheService()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('stores and retrieves a prod graph under the prod key', async () => {
+    const prod = makeGraph('prod')
+    const fetcher = vi.fn().mockResolvedValue(prod)
+
+    const first = await service.getSessionGraph(42, fetcher, 2026)
+    const second = await service.getSessionGraph(42, fetcher, 2026)
+
+    expect(first).toBe(prod)
+    expect(second).toBe(prod)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT collide prod and scenario graphs for the same session+year', async () => {
+    const prod = makeGraph('prod')
+    const scenarioA = makeGraph('scnA')
+
+    const prodFetcher = vi.fn().mockResolvedValue(prod)
+    const scenarioFetcher = vi.fn().mockResolvedValue(scenarioA)
+
+    // Cache the prod graph first
+    const prodResult = await service.getSessionGraph(42, prodFetcher, 2026)
+    expect(prodResult).toBe(prod)
+
+    // A scenario lookup for the same session+year must NOT hit the prod cache —
+    // it must call the scenario fetcher and return the scenario graph.
+    const scnResult = await service.getSessionGraph(42, scenarioFetcher, 2026, 'scn_abc')
+    expect(scnResult).toBe(scenarioA)
+    expect(scenarioFetcher).toHaveBeenCalledTimes(1)
+
+    // And a subsequent prod lookup must still return the prod graph (not the
+    // scenario one overwriting it).
+    const prodAgain = await service.getSessionGraph(42, prodFetcher, 2026)
+    expect(prodAgain).toBe(prod)
+    expect(prodFetcher).toHaveBeenCalledTimes(1) // still just the initial call
+  })
+
+  it('treats two different scenarios as distinct caches', async () => {
+    const scenarioA = makeGraph('scnA')
+    const scenarioB = makeGraph('scnB')
+
+    const fetcherA = vi.fn().mockResolvedValue(scenarioA)
+    const fetcherB = vi.fn().mockResolvedValue(scenarioB)
+
+    const a = await service.getSessionGraph(7, fetcherA, 2026, 'scn_a')
+    const b = await service.getSessionGraph(7, fetcherB, 2026, 'scn_b')
+
+    expect(a).toBe(scenarioA)
+    expect(b).toBe(scenarioB)
+    expect(fetcherA).toHaveBeenCalledTimes(1)
+    expect(fetcherB).toHaveBeenCalledTimes(1)
+
+    // Each scenario lookup should hit its own cache on repeat.
+    const aAgain = await service.getSessionGraph(7, fetcherA, 2026, 'scn_a')
+    const bAgain = await service.getSessionGraph(7, fetcherB, 2026, 'scn_b')
+
+    expect(aAgain).toBe(scenarioA)
+    expect(bAgain).toBe(scenarioB)
+    expect(fetcherA).toHaveBeenCalledTimes(1)
+    expect(fetcherB).toHaveBeenCalledTimes(1)
+  })
+
+  it('invalidate(sessionCmId) wipes both prod and scenario caches for that session', async () => {
+    const prod = makeGraph('prod')
+    const scenario = makeGraph('scn')
+
+    await service.getSessionGraph(99, vi.fn().mockResolvedValue(prod), 2026)
+    await service.getSessionGraph(99, vi.fn().mockResolvedValue(scenario), 2026, 'scn_x')
+
+    service.invalidate(99)
+
+    // After invalidation, both lookups must miss and call their fetchers.
+    const newProd = makeGraph('prod2')
+    const newScenario = makeGraph('scn2')
+
+    const prodFetcher = vi.fn().mockResolvedValue(newProd)
+    const scenarioFetcher = vi.fn().mockResolvedValue(newScenario)
+
+    const prodResult = await service.getSessionGraph(99, prodFetcher, 2026)
+    const scnResult = await service.getSessionGraph(99, scenarioFetcher, 2026, 'scn_x')
+
+    expect(prodResult).toBe(newProd)
+    expect(scnResult).toBe(newScenario)
+    expect(prodFetcher).toHaveBeenCalledTimes(1)
+    expect(scenarioFetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('passing null/undefined scenarioId behaves the same as omitting it (prod path)', async () => {
+    const prod = makeGraph('prod')
+    const fetcher = vi.fn().mockResolvedValue(prod)
+
+    await service.getSessionGraph(5, fetcher, 2026)
+    await service.getSessionGraph(5, fetcher, 2026, null)
+    await service.getSessionGraph(5, fetcher, 2026, undefined)
+
+    // All three calls should hit the same prod cache key — only one fetch.
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/services/GraphCacheService.test.ts
+++ b/frontend/src/services/GraphCacheService.test.ts
@@ -142,3 +142,107 @@ describe('GraphCacheService (scenario-aware)', () => {
     expect(fetcher).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('GraphCacheService bunk graph (scenario-aware)', () => {
+  let service: GraphCacheService
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    service = new GraphCacheService()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('stores and retrieves a prod bunk graph under the prod key', async () => {
+    const prod = makeGraph('bunk-prod')
+    const fetcher = vi.fn().mockResolvedValue(prod)
+
+    const first = await service.getBunkGraph(101, 42, fetcher, 2026)
+    const second = await service.getBunkGraph(101, 42, fetcher, 2026)
+
+    expect(first).toBe(prod)
+    expect(second).toBe(prod)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT collide prod and scenario bunk graphs for the same bunk+session+year', async () => {
+    const prod = makeGraph('bunk-prod')
+    const scenarioA = makeGraph('bunk-scnA')
+
+    const prodFetcher = vi.fn().mockResolvedValue(prod)
+    const scenarioFetcher = vi.fn().mockResolvedValue(scenarioA)
+
+    const prodResult = await service.getBunkGraph(101, 42, prodFetcher, 2026)
+    expect(prodResult).toBe(prod)
+
+    const scnResult = await service.getBunkGraph(101, 42, scenarioFetcher, 2026, 'scn_abc')
+    expect(scnResult).toBe(scenarioA)
+    expect(scenarioFetcher).toHaveBeenCalledTimes(1)
+
+    // prod still intact
+    const prodAgain = await service.getBunkGraph(101, 42, prodFetcher, 2026)
+    expect(prodAgain).toBe(prod)
+    expect(prodFetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats two different bunk scenarios as distinct caches', async () => {
+    const scenarioA = makeGraph('bunk-scnA')
+    const scenarioB = makeGraph('bunk-scnB')
+
+    const fetcherA = vi.fn().mockResolvedValue(scenarioA)
+    const fetcherB = vi.fn().mockResolvedValue(scenarioB)
+
+    const a = await service.getBunkGraph(101, 42, fetcherA, 2026, 'scn_a')
+    const b = await service.getBunkGraph(101, 42, fetcherB, 2026, 'scn_b')
+
+    expect(a).toBe(scenarioA)
+    expect(b).toBe(scenarioB)
+    expect(fetcherA).toHaveBeenCalledTimes(1)
+    expect(fetcherB).toHaveBeenCalledTimes(1)
+
+    const aAgain = await service.getBunkGraph(101, 42, fetcherA, 2026, 'scn_a')
+    const bAgain = await service.getBunkGraph(101, 42, fetcherB, 2026, 'scn_b')
+
+    expect(aAgain).toBe(scenarioA)
+    expect(bAgain).toBe(scenarioB)
+    expect(fetcherA).toHaveBeenCalledTimes(1)
+    expect(fetcherB).toHaveBeenCalledTimes(1)
+  })
+
+  it('passing null/undefined scenarioId behaves the same as omitting it (prod path) for bunks', async () => {
+    const prod = makeGraph('bunk-prod')
+    const fetcher = vi.fn().mockResolvedValue(prod)
+
+    await service.getBunkGraph(9, 42, fetcher, 2026)
+    await service.getBunkGraph(9, 42, fetcher, 2026, null)
+    await service.getBunkGraph(9, 42, fetcher, 2026, undefined)
+
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('invalidate(sessionCmId) wipes prod and scenario bunk caches for that session', async () => {
+    const prod = makeGraph('bunk-prod')
+    const scenario = makeGraph('bunk-scn')
+
+    await service.getBunkGraph(101, 42, vi.fn().mockResolvedValue(prod), 2026)
+    await service.getBunkGraph(101, 42, vi.fn().mockResolvedValue(scenario), 2026, 'scn_x')
+
+    service.invalidate(42)
+
+    const newProd = makeGraph('bunk-prod2')
+    const newScenario = makeGraph('bunk-scn2')
+
+    const prodFetcher = vi.fn().mockResolvedValue(newProd)
+    const scenarioFetcher = vi.fn().mockResolvedValue(newScenario)
+
+    const prodResult = await service.getBunkGraph(101, 42, prodFetcher, 2026)
+    const scnResult = await service.getBunkGraph(101, 42, scenarioFetcher, 2026, 'scn_x')
+
+    expect(prodResult).toBe(newProd)
+    expect(scnResult).toBe(newScenario)
+    expect(prodFetcher).toHaveBeenCalledTimes(1)
+    expect(scenarioFetcher).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/services/GraphCacheService.ts
+++ b/frontend/src/services/GraphCacheService.ts
@@ -50,6 +50,15 @@ export class GraphCacheService {
   }
 
   /**
+   * Build the scenario slug used in cache keys. Mirrors
+   * `GraphCacheManager._scenario_slug` on the Python side so the two caches
+   * stay aligned.
+   */
+  private scenarioSlug(scenarioId?: string | null): string {
+    return scenarioId ? `scenario-${scenarioId}` : 'prod'
+  }
+
+  /**
    * Get cached session graph or fetch new data.
    *
    * The cache key is scoped by scenario so a scenario-sourced graph never
@@ -64,8 +73,7 @@ export class GraphCacheService {
   ): Promise<GraphData> {
     let key: GraphCacheKey
     if (year !== undefined) {
-      const slug = scenarioId ? `scenario-${scenarioId}` : 'prod'
-      key = `session-${sessionCmId}-${year}-${slug}` as GraphCacheKey
+      key = `session-${sessionCmId}-${year}-${this.scenarioSlug(scenarioId)}` as GraphCacheKey
     } else {
       // Legacy callers without a year: keep the original key so existing
       // cached entries and invalidation prefix matching still work.
@@ -92,8 +100,8 @@ export class GraphCacheService {
   ): Promise<GraphData> {
     let key: GraphCacheKey
     if (year !== undefined) {
-      const slug = scenarioId ? `scenario-${scenarioId}` : 'prod'
-      key = `bunk-${bunkCmId}-${sessionCmId}-${year}-${slug}` as GraphCacheKey
+      key =
+        `bunk-${bunkCmId}-${sessionCmId}-${year}-${this.scenarioSlug(scenarioId)}` as GraphCacheKey
     } else {
       // Legacy callers without a year: keep the original key so existing
       // cached entries and invalidation suffix matching still work.

--- a/frontend/src/services/GraphCacheService.ts
+++ b/frontend/src/services/GraphCacheService.ts
@@ -17,6 +17,8 @@ interface CacheMetrics {
 type GraphCacheKey =
   | `session-${number}`
   | `session-${number}-${number}`
+  | `session-${number}-${number}-prod`
+  | `session-${number}-${number}-scenario-${string}`
   | `bunk-${number}-${number}`
   | `ego-${number}`
 
@@ -46,14 +48,27 @@ export class GraphCacheService {
   }
 
   /**
-   * Get cached session graph or fetch new data
+   * Get cached session graph or fetch new data.
+   *
+   * The cache key is scoped by scenario so a scenario-sourced graph never
+   * collides with the production (CampMinder) graph for the same session+year.
+   * When `scenarioId` is null/undefined the prod slot is used.
    */
   async getSessionGraph(
     sessionCmId: number,
     fetcher: () => Promise<GraphData>,
-    year?: number
+    year?: number,
+    scenarioId?: string | null
   ): Promise<GraphData> {
-    const key: GraphCacheKey = year ? `session-${sessionCmId}-${year}` : `session-${sessionCmId}`
+    let key: GraphCacheKey
+    if (year !== undefined) {
+      const slug = scenarioId ? `scenario-${scenarioId}` : 'prod'
+      key = `session-${sessionCmId}-${year}-${slug}` as GraphCacheKey
+    } else {
+      // Legacy callers without a year: keep the original key so existing
+      // cached entries and invalidation prefix matching still work.
+      key = `session-${sessionCmId}`
+    }
     return this.getOrFetch(key, fetcher)
   }
 

--- a/frontend/src/services/GraphCacheService.ts
+++ b/frontend/src/services/GraphCacheService.ts
@@ -20,6 +20,8 @@ type GraphCacheKey =
   | `session-${number}-${number}-prod`
   | `session-${number}-${number}-scenario-${string}`
   | `bunk-${number}-${number}`
+  | `bunk-${number}-${number}-${number}-prod`
+  | `bunk-${number}-${number}-${number}-scenario-${string}`
   | `ego-${number}`
 
 /**
@@ -73,14 +75,30 @@ export class GraphCacheService {
   }
 
   /**
-   * Get cached bunk graph or fetch new data
+   * Get cached bunk graph or fetch new data.
+   *
+   * The cache key is scoped by scenario so a scenario-sourced bunk graph
+   * never collides with the production (CampMinder) bunk graph for the same
+   * bunk+session+year. When `scenarioId` is null/undefined the prod slot is
+   * used. Legacy callers that omit `year` continue to use the original
+   * `bunk-{bunkId}-{sessionCmId}` key for backwards compatibility.
    */
   async getBunkGraph(
     bunkCmId: number,
     sessionCmId: number,
-    fetcher: () => Promise<GraphData>
+    fetcher: () => Promise<GraphData>,
+    year?: number,
+    scenarioId?: string | null
   ): Promise<GraphData> {
-    const key: GraphCacheKey = `bunk-${bunkCmId}-${sessionCmId}`
+    let key: GraphCacheKey
+    if (year !== undefined) {
+      const slug = scenarioId ? `scenario-${scenarioId}` : 'prod'
+      key = `bunk-${bunkCmId}-${sessionCmId}-${year}-${slug}` as GraphCacheKey
+    } else {
+      // Legacy callers without a year: keep the original key so existing
+      // cached entries and invalidation suffix matching still work.
+      key = `bunk-${bunkCmId}-${sessionCmId}`
+    }
     return this.getOrFetch(key, fetcher)
   }
 
@@ -97,17 +115,31 @@ export class GraphCacheService {
    */
   invalidate(sessionCmId: number): void {
     // Remove all session and bunk graphs for this session.
-    // Session entries may be keyed as `session-{id}` or `session-{id}-{year}`.
+    // Session entries may be keyed as `session-{id}`, `session-{id}-{year}`,
+    // `session-{id}-{year}-prod`, or `session-{id}-{year}-scenario-{id}`.
+    // Bunk entries may be keyed as `bunk-{bunkId}-{sessionCmId}` (legacy) or
+    // `bunk-{bunkId}-{sessionCmId}-{year}-{slug}` (scenario-aware).
     const sessionPrefix = `session-${sessionCmId}`
-    const bunkSuffix = `-${sessionCmId}`
+    const legacyBunkSuffix = `-${sessionCmId}`
 
     for (const key of this.cache.keys()) {
       if (key === sessionPrefix || key.startsWith(`${sessionPrefix}-`)) {
-        // Matches session-{id} and session-{id}-{year}
+        // Matches session-{id}, session-{id}-{year}, and scenario-suffixed forms
         this.removeEntry(key)
-      } else if (key.startsWith('bunk-') && key.endsWith(bunkSuffix)) {
-        // Matches bunk-{bunkId}-{sessionCmId}
-        this.removeEntry(key)
+      } else if (key.startsWith('bunk-')) {
+        if (key.endsWith(legacyBunkSuffix)) {
+          // Legacy bunk-{bunkId}-{sessionCmId}
+          this.removeEntry(key)
+          continue
+        }
+        // Scenario-aware bunk-{bunkId}-{sessionCmId}-{year}-{slug}:
+        // parse the session segment by position so we don't match the
+        // sessionCmId accidentally appearing inside the bunkId.
+        const segments = key.split('-')
+        // segments = ['bunk', bunkId, sessionCmId, year, ...slug]
+        if (segments.length >= 5 && segments[2] === String(sessionCmId)) {
+          this.removeEntry(key)
+        }
       }
     }
 
@@ -120,8 +152,16 @@ export class GraphCacheService {
    * Invalidate cached data for a specific bunk
    */
   invalidateBunk(bunkCmId: number, sessionCmId: number): void {
-    const bunkKey: GraphCacheKey = `bunk-${bunkCmId}-${sessionCmId}`
-    this.removeEntry(bunkKey)
+    // Remove legacy key and any scenario-aware keys for this bunk+session.
+    const legacyKey: GraphCacheKey = `bunk-${bunkCmId}-${sessionCmId}`
+    this.removeEntry(legacyKey)
+
+    const scenarioPrefix = `bunk-${bunkCmId}-${sessionCmId}-`
+    for (const key of this.cache.keys()) {
+      if (key.startsWith(scenarioPrefix)) {
+        this.removeEntry(key)
+      }
+    }
 
     // Also invalidate the session graph as it includes this bunk
     this.invalidate(sessionCmId)

--- a/frontend/src/services/socialGraph.test.ts
+++ b/frontend/src/services/socialGraph.test.ts
@@ -51,4 +51,55 @@ describe('socialGraphService', () => {
       expect(calledUrl).not.toContain('scenario_id')
     })
   })
+
+  describe('getBunkSocialGraph', () => {
+    const makeFetchMock = () =>
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: async () => '',
+        json: async () => ({
+          bunk_cm_id: 555,
+          bunk_name: 'Cabin 1',
+          nodes: [],
+          edges: [],
+          metrics: {
+            cohesion_score: 0,
+            average_degree: 0,
+            density: 0,
+            isolated_count: 0,
+            suggestions: [],
+          },
+          health_score: 0,
+        }),
+      })
+
+    it('appends scenario_id query param when provided', async () => {
+      const fetchWithAuth = makeFetchMock()
+
+      await socialGraphService.getBunkSocialGraph(555, 123, 2026, fetchWithAuth, 'scn_abc123')
+
+      const calledUrl = String(fetchWithAuth.mock.calls[0]?.[0])
+      expect(calledUrl).toContain('scenario_id=scn_abc123')
+      expect(calledUrl).toContain('session_cm_id=123')
+      expect(calledUrl).toContain('year=2026')
+    })
+
+    it('does NOT include scenario_id when not provided', async () => {
+      const fetchWithAuth = makeFetchMock()
+
+      await socialGraphService.getBunkSocialGraph(555, 123, 2026, fetchWithAuth)
+
+      const calledUrl = String(fetchWithAuth.mock.calls[0]?.[0])
+      expect(calledUrl).not.toContain('scenario_id')
+    })
+
+    it('does NOT include scenario_id when null/undefined is passed', async () => {
+      const fetchWithAuth = makeFetchMock()
+
+      await socialGraphService.getBunkSocialGraph(555, 123, 2026, fetchWithAuth, null)
+
+      const calledUrl = String(fetchWithAuth.mock.calls[0]?.[0])
+      expect(calledUrl).not.toContain('scenario_id')
+    })
+  })
 })

--- a/frontend/src/services/socialGraph.test.ts
+++ b/frontend/src/services/socialGraph.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for socialGraph service
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { socialGraphService } from './socialGraph'
+
+describe('socialGraphService', () => {
+  describe('getSessionSocialGraph', () => {
+    const makeFetchMock = () =>
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(''),
+        json: () =>
+          Promise.resolve({
+            nodes: [],
+            edges: [],
+            metrics: {},
+            communities: {},
+            warnings: [],
+            layout_positions: {},
+          }),
+      })
+
+    it('appends scenario_id query param when provided', async () => {
+      const fetchWithAuth = makeFetchMock()
+
+      await socialGraphService.getSessionSocialGraph(123, 2026, fetchWithAuth, 'scn_abc123')
+
+      expect(fetchWithAuth).toHaveBeenCalledWith(expect.stringContaining('scenario_id=scn_abc123'))
+      // Should still include year and include_metrics
+      const calledUrl = String(fetchWithAuth.mock.calls[0]?.[0])
+      expect(calledUrl).toContain('year=2026')
+      expect(calledUrl).toContain('include_metrics=true')
+    })
+
+    it('does NOT include scenario_id when not provided (backwards compatible)', async () => {
+      const fetchWithAuth = makeFetchMock()
+
+      await socialGraphService.getSessionSocialGraph(123, 2026, fetchWithAuth)
+
+      const calledUrl = String(fetchWithAuth.mock.calls[0]?.[0])
+      expect(calledUrl).not.toContain('scenario_id')
+    })
+
+    it('does NOT include scenario_id when null/undefined is passed', async () => {
+      const fetchWithAuth = makeFetchMock()
+
+      await socialGraphService.getSessionSocialGraph(123, 2026, fetchWithAuth, null)
+
+      const calledUrl = String(fetchWithAuth.mock.calls[0]?.[0])
+      expect(calledUrl).not.toContain('scenario_id')
+    })
+  })
+})

--- a/frontend/src/services/socialGraph.ts
+++ b/frontend/src/services/socialGraph.ts
@@ -36,16 +36,26 @@ export const socialGraphService = {
   },
 
   /**
-   * Fetch social network graph data for a specific bunk
+   * Fetch social network graph data for a specific bunk.
+   * When `scenarioId` is provided, the backend sources bunk membership from
+   * the scenario's draft assignments instead of the production (CampMinder) data.
    */
   async getBunkSocialGraph(
     bunkCmId: number,
     sessionCmId: number,
     year: number,
-    fetchWithAuth: (url: string, options?: RequestInit) => Promise<Response>
+    fetchWithAuth: (url: string, options?: RequestInit) => Promise<Response>,
+    scenarioId?: string | null
   ): Promise<GraphData> {
+    const params = new URLSearchParams({
+      session_cm_id: String(sessionCmId),
+      year: String(year),
+    })
+    if (scenarioId) {
+      params.set('scenario_id', scenarioId)
+    }
     const response = await fetchWithAuth(
-      `${API_BASE}/bunks/${bunkCmId}/social-graph?session_cm_id=${sessionCmId}&year=${year}`
+      `${API_BASE}/bunks/${bunkCmId}/social-graph?${params.toString()}`
     )
     if (!response.ok) {
       const errorText = await response.text()

--- a/frontend/src/services/socialGraph.ts
+++ b/frontend/src/services/socialGraph.ts
@@ -8,15 +8,25 @@ const API_BASE = '/api'
 
 export const socialGraphService = {
   /**
-   * Fetch social network graph data for a session
+   * Fetch social network graph data for a session.
+   * When `scenarioId` is provided, the backend sources bunk assignments from
+   * the scenario's draft assignments instead of the production (CampMinder) data.
    */
   async getSessionSocialGraph(
     sessionCmId: number,
     year: number,
-    fetchWithAuth: (url: string, options?: RequestInit) => Promise<Response>
+    fetchWithAuth: (url: string, options?: RequestInit) => Promise<Response>,
+    scenarioId?: string | null
   ): Promise<GraphData> {
+    const params = new URLSearchParams({
+      year: String(year),
+      include_metrics: 'true',
+    })
+    if (scenarioId) {
+      params.set('scenario_id', scenarioId)
+    }
     const response = await fetchWithAuth(
-      `${API_BASE}/sessions/${sessionCmId}/social-graph?year=${year}&include_metrics=true`
+      `${API_BASE}/sessions/${sessionCmId}/social-graph?${params.toString()}`
     )
     if (!response.ok) {
       const errorText = await response.text()

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -228,7 +228,8 @@ export const queryKeys = {
     ['camper-request-summary-persons', requesteeIds, year] as const,
 
   // Social Graph (Tier 1 - sync data)
-  socialGraph: (sessionCmId: number, year: number) => ['social-graph', sessionCmId, year] as const,
+  socialGraph: (sessionCmId: number, year: number, scenarioId: string | null = null) =>
+    ['social-graph', sessionCmId, year, scenarioId] as const,
 
   // Staff (Tier 1 - sync data)
   bunkStaff: (year: number) => ['bunk-staff', year] as const,

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -230,6 +230,12 @@ export const queryKeys = {
   // Social Graph (Tier 1 - sync data)
   socialGraph: (sessionCmId: number, year: number, scenarioId: string | null = null) =>
     ['social-graph', sessionCmId, year, scenarioId] as const,
+  bunkSocialGraph: (
+    bunkCmId: number,
+    sessionCmId: number,
+    year: number,
+    scenarioId: string | null = null
+  ) => ['bunk-social-graph', bunkCmId, sessionCmId, year, scenarioId] as const,
 
   // Staff (Tier 1 - sync data)
   bunkStaff: (year: number) => ['bunk-staff', year] as const,

--- a/tests/unit/bunking/graph/test_optimized_graph_builder_scenario.py
+++ b/tests/unit/bunking/graph/test_optimized_graph_builder_scenario.py
@@ -135,3 +135,110 @@ def test_build_social_network_accepts_scenario_id_kwarg(
     # Must not raise TypeError
     builder.build_social_network(year=2026, session_cm_id=999, scenario_id=None)
     builder.build_social_network(year=2026, session_cm_id=999, scenario_id="abc")
+
+
+# --- build_bunk_graph scenario threading tests -----------------------------------
+
+
+def _seed_bunk_fixtures(capture: _CollectionCapture) -> None:
+    """Seed get_full_list so build_bunk_graph sees no members (short-circuits after
+    hitting the expected assignment collection)."""
+    # All queries return empty lists -> bunk_graph built with 0 members, early return.
+    for cname in (
+        "bunk_assignments",
+        "bunk_assignments_draft",
+        "bunk_requests",
+        "persons",
+        "bunks",
+    ):
+        if cname not in capture._collections:
+            capture.make_collection(cname)
+
+
+def test_build_bunk_graph_with_scenario_id_queries_draft_collection(
+    capturing_pb: tuple[MagicMock, _CollectionCapture],
+) -> None:
+    """When scenario_id is provided, bunk membership must come from bunk_assignments_draft."""
+    pb, capture = capturing_pb
+    _seed_bunk_fixtures(capture)
+
+    # Track the filter strings passed to get_full_list per collection as well.
+    assignments_filters: list[str] = []
+    draft_filters: list[str] = []
+
+    def _capture_get_full_list_bunk(*args: object, **kwargs: object) -> list[object]:
+        params = kwargs.get("query_params") or (args[0] if args else {})
+        if isinstance(params, dict):
+            flt = params.get("filter", "")
+            assignments_filters.append(str(flt))
+        return []
+
+    def _capture_get_full_list_draft(*args: object, **kwargs: object) -> list[object]:
+        params = kwargs.get("query_params") or (args[0] if args else {})
+        if isinstance(params, dict):
+            flt = params.get("filter", "")
+            draft_filters.append(str(flt))
+        return []
+
+    capture._collections["bunk_assignments"].get_full_list.side_effect = _capture_get_full_list_bunk
+    capture._collections["bunk_assignments_draft"].get_full_list.side_effect = _capture_get_full_list_draft
+
+    builder = OptimizedSocialGraphBuilder(pb, random_seed=42)
+    builder.build_bunk_graph(year=2026, bunk_cm_id=555, session_cm_id=999, scenario_id="scn_xyz")
+
+    # Draft must have been queried
+    assert draft_filters, (
+        f"Expected bunk_assignments_draft query when scenario_id set. "
+        f"Draft filters: {draft_filters}, prod filters: {assignments_filters}"
+    )
+    # Draft filter must include the scenario clause
+    assert any('scenario = "scn_xyz"' in f for f in draft_filters), (
+        f"Expected scenario filter in draft query, got: {draft_filters}"
+    )
+
+
+def test_build_bunk_graph_without_scenario_preserves_prod_collection(
+    capturing_pb: tuple[MagicMock, _CollectionCapture],
+) -> None:
+    """Without scenario_id, bunk membership must come from bunk_assignments (prod)."""
+    pb, capture = capturing_pb
+    _seed_bunk_fixtures(capture)
+
+    prod_calls: list[str] = []
+    draft_calls: list[str] = []
+
+    def _capture_prod(*args: object, **kwargs: object) -> list[object]:
+        params = kwargs.get("query_params") or (args[0] if args else {})
+        if isinstance(params, dict):
+            prod_calls.append(str(params.get("filter", "")))
+        return []
+
+    def _capture_draft(*args: object, **kwargs: object) -> list[object]:
+        params = kwargs.get("query_params") or (args[0] if args else {})
+        if isinstance(params, dict):
+            draft_calls.append(str(params.get("filter", "")))
+        return []
+
+    capture._collections["bunk_assignments"].get_full_list.side_effect = _capture_prod
+    capture._collections["bunk_assignments_draft"].get_full_list.side_effect = _capture_draft
+
+    builder = OptimizedSocialGraphBuilder(pb, random_seed=42)
+    builder.build_bunk_graph(year=2026, bunk_cm_id=555, session_cm_id=999)
+
+    assert prod_calls, (
+        f"Expected bunk_assignments query when scenario_id absent. prod: {prod_calls}, draft: {draft_calls}"
+    )
+    assert not draft_calls, f"Must not query bunk_assignments_draft without scenario_id. draft: {draft_calls}"
+
+
+def test_build_bunk_graph_accepts_scenario_id_kwarg(
+    capturing_pb: tuple[MagicMock, _CollectionCapture],
+) -> None:
+    """Signature must accept scenario_id as keyword arg (backwards-compatible)."""
+    pb, capture = capturing_pb
+    _seed_bunk_fixtures(capture)
+    builder = OptimizedSocialGraphBuilder(pb, random_seed=42)
+
+    # Must not raise TypeError
+    builder.build_bunk_graph(year=2026, bunk_cm_id=555, session_cm_id=999, scenario_id=None)
+    builder.build_bunk_graph(year=2026, bunk_cm_id=555, session_cm_id=999, scenario_id="abc")

--- a/tests/unit/bunking/graph/test_optimized_graph_builder_scenario.py
+++ b/tests/unit/bunking/graph/test_optimized_graph_builder_scenario.py
@@ -1,0 +1,137 @@
+"""Tests for OptimizedSocialGraphBuilder scenario-aware data sourcing.
+
+Verifies that when scenario_id is provided, bunk assignments are sourced
+from bunk_assignments_draft (scenario data) instead of bunk_assignments
+(CampMinder production data).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from bunking.graph.optimized_graph_builder import OptimizedSocialGraphBuilder
+
+
+class _CollectionCapture:
+    """Simple capture of .collection(name) -> mock chain.
+
+    Tracks which collection was accessed and what filter string was passed to
+    get_first_list_item so tests can assert on data source and scenario filter.
+    """
+
+    def __init__(self) -> None:
+        self.accessed: list[str] = []
+        self.filters: dict[str, list[str]] = {}
+        # Map collection_name -> mock collection object
+        self._collections: dict[str, MagicMock] = {}
+
+    def make_collection(self, name: str) -> MagicMock:
+        mock = MagicMock()
+
+        # Default: get_full_list returns empty list, get_first_list_item raises
+        mock.get_full_list.return_value = []
+
+        def _first_list_item(filter_str: str, *_a: object, **_kw: object) -> object:
+            self.filters.setdefault(name, []).append(filter_str)
+            raise RuntimeError("no record")  # bubbles up, caller catches
+
+        mock.get_first_list_item.side_effect = _first_list_item
+        self._collections[name] = mock
+        return mock
+
+    def __call__(self, name: str) -> MagicMock:
+        self.accessed.append(name)
+        return self._collections.get(name) or self.make_collection(name)
+
+
+@pytest.fixture
+def capturing_pb() -> tuple[MagicMock, _CollectionCapture]:
+    pb = MagicMock()
+    capture = _CollectionCapture()
+
+    # Pre-seed common collections so get_full_list returns empty
+    for cname in (
+        "attendees",
+        "bunk_requests",
+        "persons",
+        "bunk_assignments",
+        "bunk_assignments_draft",
+    ):
+        capture.make_collection(cname)
+
+    # Attendees: return one active attendee so the loop executes
+    attendee = SimpleNamespace(person_id=111, division="A", year=2026)
+    capture._collections["attendees"].get_full_list.return_value = [attendee]
+
+    # persons: return one person for the attendee
+    person = SimpleNamespace(
+        cm_id=111,
+        first_name="Emma",
+        last_name="Johnson",
+        grade=7,
+        gender="F",
+        age=12,
+        years_at_camp=2,
+        family_id=1,
+    )
+    capture._collections["persons"].get_full_list.return_value = [person]
+
+    pb.collection.side_effect = capture
+    return pb, capture
+
+
+def test_scenario_id_routes_assignment_query_to_draft_collection(
+    capturing_pb: tuple[MagicMock, _CollectionCapture],
+) -> None:
+    """When scenario_id is provided, bunk assignment lookup must hit bunk_assignments_draft."""
+    pb, capture = capturing_pb
+    builder = OptimizedSocialGraphBuilder(pb, random_seed=42)
+
+    builder.build_social_network(year=2026, session_cm_id=999, scenario_id="scn_xyz")
+
+    # The draft collection MUST have been queried for assignments
+    assert "bunk_assignments_draft" in capture.filters, (
+        f"Expected bunk_assignments_draft query when scenario_id set. Filters seen: {capture.filters}"
+    )
+    # Production bunk_assignments MUST NOT be queried for assignments
+    assert "bunk_assignments" not in capture.filters, (
+        f"Must not query bunk_assignments when scenario_id is set. Filters seen: {capture.filters}"
+    )
+
+    # The draft filter must include the scenario clause
+    draft_filters = capture.filters["bunk_assignments_draft"]
+    assert any('scenario = "scn_xyz"' in f for f in draft_filters), (
+        f"Expected scenario filter in draft query, got: {draft_filters}"
+    )
+
+
+def test_no_scenario_id_preserves_production_query(
+    capturing_pb: tuple[MagicMock, _CollectionCapture],
+) -> None:
+    """When scenario_id is None/absent, assignments come from bunk_assignments (CampMinder)."""
+    pb, capture = capturing_pb
+    builder = OptimizedSocialGraphBuilder(pb, random_seed=42)
+
+    builder.build_social_network(year=2026, session_cm_id=999)
+
+    assert "bunk_assignments" in capture.filters, (
+        f"Expected bunk_assignments query when scenario_id is absent. Filters seen: {capture.filters}"
+    )
+    assert "bunk_assignments_draft" not in capture.filters, (
+        f"Must not query bunk_assignments_draft without scenario_id. Filters seen: {capture.filters}"
+    )
+
+
+def test_build_social_network_accepts_scenario_id_kwarg(
+    capturing_pb: tuple[MagicMock, _CollectionCapture],
+) -> None:
+    """Signature must accept scenario_id as keyword arg (backwards-compatible default)."""
+    pb, _ = capturing_pb
+    builder = OptimizedSocialGraphBuilder(pb, random_seed=42)
+
+    # Must not raise TypeError
+    builder.build_social_network(year=2026, session_cm_id=999, scenario_id=None)
+    builder.build_social_network(year=2026, session_cm_id=999, scenario_id="abc")

--- a/tests/unit/sync/test_graph_cache_manager.py
+++ b/tests/unit/sync/test_graph_cache_manager.py
@@ -347,5 +347,72 @@ class TestGraphCacheManagerScenario(unittest.TestCase):
         assert stats["miss_count"] == 0
 
 
+class TestGraphCacheManagerBunkScenario(unittest.TestCase):
+    """Scenario-aware caching for bunk graphs must not collide with prod."""
+
+    def setUp(self):
+        self.cache = GraphCacheManager(ttl_seconds=60, max_cache_size=10)
+
+        self.prod_graph = nx.DiGraph()
+        self.prod_graph.add_nodes_from([1, 2, 3])
+        self.prod_graph.add_edges_from([(1, 2), (2, 3)])
+
+        self.scenario_graph = nx.DiGraph()
+        self.scenario_graph.add_nodes_from([10, 11, 12])
+        self.scenario_graph.add_edges_from([(10, 11), (11, 12)])
+
+        self.other_scenario_graph = nx.DiGraph()
+        self.other_scenario_graph.add_nodes_from([20, 21])
+        self.other_scenario_graph.add_edge(20, 21)
+
+    def test_bunk_prod_and_scenario_are_distinct_keys(self):
+        """Caching a bunk graph under a scenario must not overwrite the prod bunk graph."""
+        self.cache.cache_bunk_graph(101, 12345, 2025, self.prod_graph)
+        self.cache.cache_bunk_graph(101, 12345, 2025, self.scenario_graph, scenario_id="scn_abc")
+
+        # Prod lookup returns prod graph
+        prod = self.cache.get_bunk_graph(101, 12345, 2025)
+        assert prod is not None
+        assert set(prod.nodes()) == {1, 2, 3}
+
+        # Scenario lookup returns scenario graph
+        scn = self.cache.get_bunk_graph(101, 12345, 2025, scenario_id="scn_abc")
+        assert scn is not None
+        assert set(scn.nodes()) == {10, 11, 12}
+
+        # A second scenario must be independent
+        self.cache.cache_bunk_graph(101, 12345, 2025, self.other_scenario_graph, scenario_id="scn_xyz")
+        other = self.cache.get_bunk_graph(101, 12345, 2025, scenario_id="scn_xyz")
+        assert other is not None
+        assert set(other.nodes()) == {20, 21}
+
+        # Previously cached entries still intact
+        prod_again = self.cache.get_bunk_graph(101, 12345, 2025)
+        assert prod_again is not None
+        assert set(prod_again.nodes()) == {1, 2, 3}
+
+        scn_again = self.cache.get_bunk_graph(101, 12345, 2025, scenario_id="scn_abc")
+        assert scn_again is not None
+        assert set(scn_again.nodes()) == {10, 11, 12}
+
+    def test_bunk_scenario_miss_is_distinct_from_prod(self):
+        """A scenario bunk lookup with no scenario cache must miss even if prod is cached."""
+        self.cache.cache_bunk_graph(101, 12345, 2025, self.prod_graph)
+
+        miss = self.cache.get_bunk_graph(101, 12345, 2025, scenario_id="scn_abc")
+        assert miss is None
+
+        hit = self.cache.get_bunk_graph(101, 12345, 2025)
+        assert hit is not None
+        assert set(hit.nodes()) == {1, 2, 3}
+
+    def test_bunk_none_scenario_id_equals_prod(self):
+        """Passing scenario_id=None explicitly must match the default (prod) key."""
+        self.cache.cache_bunk_graph(101, 12345, 2025, self.prod_graph, scenario_id=None)
+
+        assert self.cache.get_bunk_graph(101, 12345, 2025) is not None
+        assert self.cache.get_bunk_graph(101, 12345, 2025, scenario_id=None) is not None
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/sync/test_graph_cache_manager.py
+++ b/tests/unit/sync/test_graph_cache_manager.py
@@ -301,12 +301,12 @@ class TestGraphCacheManagerScenario(unittest.TestCase):
         assert set(other.nodes()) == {20, 21}
 
         # Previously cached entries still intact
-        assert set(self.cache.get_session_graph(12345, 2025).nodes()) == {1, 2, 3}
-        assert set(self.cache.get_session_graph(12345, 2025, scenario_id="scn_abc").nodes()) == {
-            10,
-            11,
-            12,
-        }
+        prod_again = self.cache.get_session_graph(12345, 2025)
+        assert prod_again is not None
+        assert set(prod_again.nodes()) == {1, 2, 3}
+        scn_again = self.cache.get_session_graph(12345, 2025, scenario_id="scn_abc")
+        assert scn_again is not None
+        assert set(scn_again.nodes()) == {10, 11, 12}
 
         stats = self.cache.get_stats()
         assert stats["cache_size"] == 3

--- a/tests/unit/sync/test_graph_cache_manager.py
+++ b/tests/unit/sync/test_graph_cache_manager.py
@@ -132,6 +132,53 @@ class TestGraphCacheManager(unittest.TestCase):
         assert self.cache.get_bunk_graph(101, 12345, 2025) is None
         assert self.cache.get_session_graph(99999, 2025) is not None
 
+    def test_invalidate_session_does_not_match_bunk_when_year_appears_as_session_id(self):
+        """Regression: invalidate_session must not falsely match a bunk cache
+        key whose real session_cm_id equals the year.
+
+        Bunk cache key format: ``bunk_{bunk_cm_id}_{session_cm_id}_{year}_{slug}``.
+        Before the fix, ``invalidate_session`` used the broad substring match
+        ``f"_{session_cm_id}_{year}" in key``. For ``invalidate_session(5, 2025)``
+        the target substring is ``_5_2025`` — which also appears inside the key
+        ``bunk_5_2025_2025_prod`` (bunk cm_id 5, session cm_id 2025, year 2025)
+        and caused a false invalidation. After the fix we parse session and
+        year positionally so this no longer matches.
+        """
+        # Session 5, year 2025 – target of invalidation.
+        self.cache.cache_session_graph(5, 2025, self.graph1)
+        # Bunk cm_id 5 that belongs to session 2025 (rare but legal: a camp
+        # could reuse numeric ids across table namespaces). Key has the
+        # substring ``_5_2025`` even though the real session is 2025.
+        self.cache.cache_bunk_graph(5, 2025, 2025, self.graph2)
+        # Bunk that really belongs to session 5 – must be invalidated.
+        self.cache.cache_bunk_graph(50, 5, 2025, self.graph2)
+
+        invalidated = self.cache.invalidate_session(5, 2025)
+
+        # Session_5_2025_prod + bunk_50_5_2025_prod = 2
+        assert invalidated == 2
+        assert self.cache.get_session_graph(5, 2025) is None
+        assert self.cache.get_bunk_graph(50, 5, 2025) is None
+        # The cross-session bunk must survive
+        assert self.cache.get_bunk_graph(5, 2025, 2025) is not None
+
+    def test_invalidate_session_matches_scenario_bunks(self):
+        """Scenario-slug bunks for the target session must still be invalidated."""
+        # Session 12, year 2025
+        self.cache.cache_session_graph(12, 2025, self.graph1)
+        # Scenario bunks for session 12 – must be invalidated
+        self.cache.cache_bunk_graph(11, 12, 2025, self.graph2, scenario_id="s1")
+        self.cache.cache_bunk_graph(12, 12, 2025, self.graph2, scenario_id="s2")
+        # Bunk in a different session – must survive
+        self.cache.cache_bunk_graph(11, 99, 2025, self.graph2)
+
+        invalidated = self.cache.invalidate_session(12, 2025)
+
+        assert invalidated == 3
+        assert self.cache.get_bunk_graph(11, 12, 2025, scenario_id="s1") is None
+        assert self.cache.get_bunk_graph(12, 12, 2025, scenario_id="s2") is None
+        assert self.cache.get_bunk_graph(11, 99, 2025) is not None
+
     def test_lru_eviction(self):
         """Test LRU eviction when cache is full."""
         # Fill cache to capacity (5 items)

--- a/tests/unit/sync/test_graph_cache_manager.py
+++ b/tests/unit/sync/test_graph_cache_manager.py
@@ -261,5 +261,91 @@ class TestGraphCacheManager(unittest.TestCase):
         assert stats["cache_size"] == 0
 
 
+class TestGraphCacheManagerScenario(unittest.TestCase):
+    """Test scenario-aware caching — production and scenario graphs must not collide."""
+
+    def setUp(self):
+        self.cache = GraphCacheManager(ttl_seconds=60, max_cache_size=10)
+
+        self.prod_graph = nx.DiGraph()
+        self.prod_graph.add_nodes_from([1, 2, 3])
+        self.prod_graph.add_edges_from([(1, 2), (2, 3)])
+
+        self.scenario_graph = nx.DiGraph()
+        self.scenario_graph.add_nodes_from([10, 11, 12])
+        self.scenario_graph.add_edges_from([(10, 11), (11, 12)])
+
+        self.other_scenario_graph = nx.DiGraph()
+        self.other_scenario_graph.add_nodes_from([20, 21])
+        self.other_scenario_graph.add_edge(20, 21)
+
+    def test_prod_and_scenario_are_distinct_keys(self):
+        """Caching under a scenario must not overwrite or serve the prod graph."""
+        self.cache.cache_session_graph(12345, 2025, self.prod_graph)
+        self.cache.cache_session_graph(12345, 2025, self.scenario_graph, scenario_id="scn_abc")
+
+        # Prod lookup returns prod graph
+        prod = self.cache.get_session_graph(12345, 2025)
+        assert prod is not None
+        assert set(prod.nodes()) == {1, 2, 3}
+
+        # Scenario lookup returns scenario graph
+        scn = self.cache.get_session_graph(12345, 2025, scenario_id="scn_abc")
+        assert scn is not None
+        assert set(scn.nodes()) == {10, 11, 12}
+
+        # Should be three distinct-capable entries once we add another scenario
+        self.cache.cache_session_graph(12345, 2025, self.other_scenario_graph, scenario_id="scn_xyz")
+        other = self.cache.get_session_graph(12345, 2025, scenario_id="scn_xyz")
+        assert other is not None
+        assert set(other.nodes()) == {20, 21}
+
+        # Previously cached entries still intact
+        assert set(self.cache.get_session_graph(12345, 2025).nodes()) == {1, 2, 3}
+        assert set(self.cache.get_session_graph(12345, 2025, scenario_id="scn_abc").nodes()) == {
+            10,
+            11,
+            12,
+        }
+
+        stats = self.cache.get_stats()
+        assert stats["cache_size"] == 3
+
+    def test_scenario_miss_is_distinct_from_prod(self):
+        """A scenario lookup with no scenario cache must miss even if prod is cached."""
+        self.cache.cache_session_graph(12345, 2025, self.prod_graph)
+
+        # Only prod is cached — scenario lookup misses
+        miss = self.cache.get_session_graph(12345, 2025, scenario_id="scn_abc")
+        assert miss is None
+
+        # And prod lookup still hits
+        hit = self.cache.get_session_graph(12345, 2025)
+        assert hit is not None
+        assert set(hit.nodes()) == {1, 2, 3}
+
+    def test_none_scenario_id_equals_prod(self):
+        """Passing scenario_id=None explicitly must behave the same as omitting it."""
+        self.cache.cache_session_graph(12345, 2025, self.prod_graph, scenario_id=None)
+
+        assert self.cache.get_session_graph(12345, 2025) is not None
+        assert self.cache.get_session_graph(12345, 2025, scenario_id=None) is not None
+
+    def test_repeated_scenario_lookup_hits_cache(self):
+        """Same (cm_id, year, scenario_id) tuple returns cached value on repeat."""
+        self.cache.cache_session_graph(42, 2026, self.scenario_graph, scenario_id="scn_xyz")
+
+        first = self.cache.get_session_graph(42, 2026, scenario_id="scn_xyz")
+        second = self.cache.get_session_graph(42, 2026, scenario_id="scn_xyz")
+
+        assert first is not None
+        assert second is not None
+        assert set(first.nodes()) == set(second.nodes()) == {10, 11, 12}
+
+        stats = self.cache.get_stats()
+        assert stats["hit_count"] == 2
+        assert stats["miss_count"] == 0
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- **#30** — The social-network graph was always rendering CampMinder production bunk/session assignments, ignoring the active scenario. When viewing a scenario with campers bunked but no corresponding production assignments, the graph rendered nothing.
- **Root cause:** `useSocialGraphData` → `socialGraph` service → `GET /api/sessions/{id}/social-graph` → `OptimizedSocialGraphBuilder` all operated without a `scenario_id`. The builder hardcoded its query to the `bunk_assignments` (CampMinder) collection.
- **Fix (commit 1):** Thread `scenario_id` end-to-end. The hook pulls `currentScenario` from `ScenarioContext` (same pattern as `ValidateBunkingButton`). When `scenario_id` is present, the builder queries `bunk_assignments_draft` filtered by scenario. Production path is unchanged when no scenario is active.
- **Per-scenario caching (commit 2):** The prior commit bypassed both `GraphCacheManager` (backend) and `GraphCacheService` (frontend) when a scenario was active, because those caches were keyed only by `(session_cm_id, year)` and would otherwise mix prod/scenario results. Re-keyed both caches with a `scenario_id` slug (`"prod"` for production, scenario id otherwise). Existing prefix-based invalidation in both caches handles the new keys without modification.

## Test plan
- [ ] Open a scenario that has campers bunked (and where production has nobody bunked for the same session) — graph renders using the scenario's assignments
- [ ] Switch between two scenarios repeatedly — second and subsequent views hit the cache (no full rebuild)
- [ ] Production graph (no scenario active) still renders exactly as before
- [ ] Moving a camper invalidates both prod and scenario cache entries for that session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Social graph endpoints now accept optional scenario parameters to reflect draft bunking assignments
  * Frontend social graph components automatically incorporate active scenario context when fetching and caching data

* **Tests**
  * Added comprehensive test coverage for scenario-aware caching, data sourcing validation, and cache invalidation across both frontend and backend

<!-- end of auto-generated comment: release notes by coderabbit.ai -->