### PR TITLE
fix(frontend): sort comparison campers and hide empty AG filter

### DIFF
--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -38,6 +38,11 @@ import { useApiWithAuth } from '../hooks/useApiWithAuth'
 import { queryKeys, userDataOptions, syncDataOptions } from '../utils/queryKeys'
 import { formatGradeOrdinal } from '../utils/gradeUtils'
 import { findSessionByUrlSegment } from '../utils/sessionUtils'
+import {
+  sortCampersByName,
+  getAvailableBunkAreas,
+  type BunkArea,
+} from '../utils/scenarioComparisonUtils'
 import { solverService } from '../services/solver'
 import type { Session } from '../types/app-types'
 
@@ -46,6 +51,8 @@ interface CamperAssignment {
   personId: string
   personCmId: number
   name: string
+  firstName: string
+  lastName: string
   grade: number
   gender: string
   bunkId: string
@@ -121,7 +128,7 @@ export default function ScenarioComparisonPage() {
   const [rightScenarioId, setRightScenarioId] = useState<string>('')
   const [viewMode, setViewMode] = useState<ViewMode>('split')
   const [changeFilter, setChangeFilter] = useState<ChangeFilter>('all')
-  const [selectedBunkArea, setSelectedBunkArea] = useState<'all' | 'boys' | 'girls' | 'ag'>('all')
+  const [selectedBunkArea, setSelectedBunkArea] = useState<BunkArea>('all')
 
   // Fetch all sessions for the current year to resolve the URL segment
   const { data: allSessions = [] } = useQuery({
@@ -298,10 +305,13 @@ export default function ScenarioComparisonPage() {
             // This should never happen due to the filter above, but TypeScript needs the guard
             throw new Error('Missing expand data')
           }
+          const firstName = person.preferred_name || person.first_name
           return {
             personId: person.id,
             personCmId: person.cm_id,
-            name: `${person.preferred_name || person.first_name} ${person.last_name}`,
+            name: `${firstName} ${person.last_name}`,
+            firstName,
+            lastName: person.last_name,
             grade: person.grade,
             gender: person.gender,
             bunkId: bunk.id,
@@ -374,11 +384,24 @@ export default function ScenarioComparisonPage() {
     const totalChanges = moved.length + newlyAssigned.length + newlyUnassigned.length
     const totalInvolved = Math.max(leftAssignments.length, rightAssignments.length)
 
+    // Sort change lists alphabetically by camper name (last, then first) so both
+    // sides of the comparison present a stable, scannable order.
+    const sortByCamper = <T extends { camper: CamperAssignment }>(arr: T[]): T[] =>
+      arr.slice().sort((a, b) => {
+        const lastCmp = a.camper.lastName.localeCompare(b.camper.lastName, undefined, {
+          sensitivity: 'base',
+        })
+        if (lastCmp !== 0) return lastCmp
+        return a.camper.firstName.localeCompare(b.camper.firstName, undefined, {
+          sensitivity: 'base',
+        })
+      })
+
     return {
-      moved,
-      newlyAssigned,
-      newlyUnassigned,
-      unchanged,
+      moved: sortByCamper(moved),
+      newlyAssigned: sortByCamper(newlyAssigned),
+      newlyUnassigned: sortByCamper(newlyUnassigned),
+      unchanged: sortCampersByName(unchanged),
       metrics: {
         totalCampers: {
           left: leftAssignments.length,
@@ -413,15 +436,26 @@ export default function ScenarioComparisonPage() {
     return Array.from(bunkMap.values()).sort((a, b) => a.name.localeCompare(b.name))
   }, [leftAssignments, rightAssignments])
 
+  // Determine which area-filter buttons are meaningful given the bunks in scope.
+  // Hides "ag" entirely when no AG (Mixed-gender) cabins are present (#24).
+  const availableBunkAreas = useMemo(() => getAvailableBunkAreas(allBunks), [allBunks])
+
+  // If the persisted selection is no longer valid (e.g. a data refresh removed
+  // all AG bunks while "ag" was active), treat it as "all" for this render.
+  // Computing during render avoids the setState-in-effect anti-pattern.
+  const effectiveBunkArea: BunkArea = availableBunkAreas.includes(selectedBunkArea)
+    ? selectedBunkArea
+    : 'all'
+
   // Filter bunks by selected area
   const filteredBunks = useMemo(() => {
     return allBunks.filter((bunk) => {
-      if (selectedBunkArea === 'all') return true
-      if (selectedBunkArea === 'boys') return bunk.gender === 'M'
-      if (selectedBunkArea === 'girls') return bunk.gender === 'F'
+      if (effectiveBunkArea === 'all') return true
+      if (effectiveBunkArea === 'boys') return bunk.gender === 'M'
+      if (effectiveBunkArea === 'girls') return bunk.gender === 'F'
       return bunk.gender === 'Mixed'
     })
-  }, [allBunks, selectedBunkArea])
+  }, [allBunks, effectiveBunkArea])
 
   // Create bunk comparison data with movement tracking
   const bunkComparisons = useMemo((): BunkComparison[] => {
@@ -461,8 +495,8 @@ export default function ScenarioComparisonPage() {
       return {
         bunkId: bunk.id,
         bunkName: bunk.name,
-        leftCampers,
-        rightCampers,
+        leftCampers: sortCampersByName(leftCampers),
+        rightCampers: sortCampersByName(rightCampers),
         movedIn,
         movedOut,
         unchanged: rightCampers.filter((c) => leftPersonIds.has(c.personCmId)),
@@ -756,13 +790,13 @@ export default function ScenarioComparisonPage() {
               <div className="mb-4 flex items-center gap-2">
                 <Filter className="text-muted-foreground h-4 w-4" />
                 <span className="text-muted-foreground mr-2 text-sm">Area:</span>
-                {['all', 'boys', 'girls', 'ag'].map((area) => (
+                {availableBunkAreas.map((area) => (
                   <button
                     key={area}
-                    onClick={() => setSelectedBunkArea(area as typeof selectedBunkArea)}
+                    onClick={() => setSelectedBunkArea(area)}
                     className={clsx(
                       'rounded-lg px-3 py-1.5 text-sm font-medium transition-all',
-                      selectedBunkArea === area
+                      effectiveBunkArea === area
                         ? 'bg-primary text-primary-foreground'
                         : 'bg-muted/50 text-muted-foreground hover:bg-muted'
                     )}

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -93,7 +93,6 @@ interface BunkComparison {
   rightCampers: CamperAssignment[]
   movedIn: Array<{ camper: CamperAssignment; fromBunk: string }>
   movedOut: Array<{ camper: CamperAssignment; toBunk: string }>
-  unchanged: CamperAssignment[]
 }
 
 // Validation score types
@@ -492,7 +491,6 @@ export default function ScenarioComparisonPage() {
         rightCampers: sortCampersByName(rightCampers),
         movedIn,
         movedOut,
-        unchanged: rightCampers.filter((c) => leftPersonIds.has(c.personCmId)),
       }
     })
   }, [filteredBunks, leftAssignments, rightAssignments])

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -39,6 +39,7 @@ import { queryKeys, userDataOptions, syncDataOptions } from '../utils/queryKeys'
 import { formatGradeOrdinal } from '../utils/gradeUtils'
 import { findSessionByUrlSegment } from '../utils/sessionUtils'
 import {
+  compareCamperByName,
   sortCampersByName,
   getAvailableBunkAreas,
   type BunkArea,
@@ -387,15 +388,7 @@ export default function ScenarioComparisonPage() {
     // Sort change lists alphabetically by camper name (last, then first) so both
     // sides of the comparison present a stable, scannable order.
     const sortByCamper = <T extends { camper: CamperAssignment }>(arr: T[]): T[] =>
-      arr.slice().sort((a, b) => {
-        const lastCmp = a.camper.lastName.localeCompare(b.camper.lastName, undefined, {
-          sensitivity: 'base',
-        })
-        if (lastCmp !== 0) return lastCmp
-        return a.camper.firstName.localeCompare(b.camper.firstName, undefined, {
-          sensitivity: 'base',
-        })
-      })
+      arr.slice().sort((a, b) => compareCamperByName(a.camper, b.camper))
 
     return {
       moved: sortByCamper(moved),

--- a/frontend/src/utils/scenarioComparisonUtils.test.ts
+++ b/frontend/src/utils/scenarioComparisonUtils.test.ts
@@ -140,27 +140,17 @@ describe('getAvailableBunkAreas', () => {
   })
 
   it('omits "ag" when no AG (Mixed-gender) bunks are present', () => {
-    const bunks: BunkWithGender[] = [
-      { name: 'B-Cedar', gender: 'M' },
-      { name: 'G-Oak', gender: 'F' },
-    ]
+    const bunks: BunkWithGender[] = [{ gender: 'M' }, { gender: 'F' }]
     expect(getAvailableBunkAreas(bunks)).toEqual(['all', 'boys', 'girls'])
   })
 
   it('includes "ag" when at least one AG bunk is present', () => {
-    const bunks: BunkWithGender[] = [
-      { name: 'B-Cedar', gender: 'M' },
-      { name: 'G-Oak', gender: 'F' },
-      { name: 'AG-Maple', gender: 'Mixed' },
-    ]
+    const bunks: BunkWithGender[] = [{ gender: 'M' }, { gender: 'F' }, { gender: 'Mixed' }]
     expect(getAvailableBunkAreas(bunks)).toEqual(['all', 'boys', 'girls', 'ag'])
   })
 
   it('omits "boys" when no male-gender bunks are present', () => {
-    const bunks: BunkWithGender[] = [
-      { name: 'G-Oak', gender: 'F' },
-      { name: 'AG-Maple', gender: 'Mixed' },
-    ]
+    const bunks: BunkWithGender[] = [{ gender: 'F' }, { gender: 'Mixed' }]
     const areas = getAvailableBunkAreas(bunks)
     expect(areas).toContain('all')
     expect(areas).toContain('girls')
@@ -169,10 +159,7 @@ describe('getAvailableBunkAreas', () => {
   })
 
   it('omits "girls" when no female-gender bunks are present', () => {
-    const bunks: BunkWithGender[] = [
-      { name: 'B-Cedar', gender: 'M' },
-      { name: 'AG-Maple', gender: 'Mixed' },
-    ]
+    const bunks: BunkWithGender[] = [{ gender: 'M' }, { gender: 'Mixed' }]
     const areas = getAvailableBunkAreas(bunks)
     expect(areas).toContain('all')
     expect(areas).toContain('boys')
@@ -181,17 +168,13 @@ describe('getAvailableBunkAreas', () => {
   })
 
   it('always keeps "all" as the first option', () => {
-    const bunks: BunkWithGender[] = [{ name: 'AG-Maple', gender: 'Mixed' }]
+    const bunks: BunkWithGender[] = [{ gender: 'Mixed' }]
     const areas = getAvailableBunkAreas(bunks)
     expect(areas[0]).toBe('all')
   })
 
   it('returns filter options in stable order: all, boys, girls, ag', () => {
-    const bunks: BunkWithGender[] = [
-      { name: 'AG-Maple', gender: 'Mixed' },
-      { name: 'G-Oak', gender: 'F' },
-      { name: 'B-Cedar', gender: 'M' },
-    ]
+    const bunks: BunkWithGender[] = [{ gender: 'Mixed' }, { gender: 'F' }, { gender: 'M' }]
     expect(getAvailableBunkAreas(bunks)).toEqual(['all', 'boys', 'girls', 'ag'])
   })
 })

--- a/frontend/src/utils/scenarioComparisonUtils.test.ts
+++ b/frontend/src/utils/scenarioComparisonUtils.test.ts
@@ -2,7 +2,7 @@
  * Tests for scenario comparison page helpers.
  *
  * Covers:
- * - sortCampersByName: alphabetical sort (last name, then first name), locale-aware
+ * - sortCampersByName: alphabetical sort (first name, then last name), locale-aware
  * - getAvailableBunkAreas: derives which area-filter buttons to show based on bunk genders
  */
 
@@ -16,15 +16,15 @@ import {
 } from './scenarioComparisonUtils'
 
 describe('compareCamperByName', () => {
-  it('sorts by last name first', () => {
-    const a: SortableCamper = { firstName: 'Zed', lastName: 'Adams' }
-    const b: SortableCamper = { firstName: 'Ada', lastName: 'Zimmerman' }
+  it('sorts by first name first', () => {
+    const a: SortableCamper = { firstName: 'Ada', lastName: 'Zimmerman' }
+    const b: SortableCamper = { firstName: 'Zed', lastName: 'Adams' }
     expect(compareCamperByName(a, b)).toBeLessThan(0)
     expect(compareCamperByName(b, a)).toBeGreaterThan(0)
   })
 
-  it('breaks ties by first name', () => {
-    const a: SortableCamper = { firstName: 'Adam', lastName: 'Johnson' }
+  it('breaks ties by last name', () => {
+    const a: SortableCamper = { firstName: 'Emma', lastName: 'Chen' }
     const b: SortableCamper = { firstName: 'Emma', lastName: 'Johnson' }
     expect(compareCamperByName(a, b)).toBeLessThan(0)
     expect(compareCamperByName(b, a)).toBeGreaterThan(0)
@@ -54,7 +54,7 @@ describe('compareCamperByName', () => {
 })
 
 describe('sortCampersByName', () => {
-  it('sorts campers alphabetically by last name then first name', () => {
+  it('sorts campers alphabetically by first name then last name', () => {
     const campers: SortableCamper[] = [
       { firstName: 'Liam', lastName: 'Garcia' },
       { firstName: 'Emma', lastName: 'Johnson' },
@@ -63,10 +63,10 @@ describe('sortCampersByName', () => {
     ]
     const sorted = sortCampersByName(campers)
     expect(sorted.map((c) => `${c.firstName} ${c.lastName}`)).toEqual([
-      'Olivia Chen',
-      'Liam Garcia',
       'Adam Johnson',
       'Emma Johnson',
+      'Liam Garcia',
+      'Olivia Chen',
     ])
   })
 
@@ -105,17 +105,18 @@ describe('sortCampersByName', () => {
       { firstName: 'Emma', lastName: 'Johnson', personCmId: 1, bunkName: 'G-Oak' },
     ]
     const sorted = sortCampersByName(campers)
+    // First-name primary: Emma (E) sorts before Liam (L)
     expect(sorted[0]).toEqual({
-      firstName: 'Liam',
-      lastName: 'Garcia',
-      personCmId: 2,
-      bunkName: 'B-Cedar',
-    })
-    expect(sorted[1]).toEqual({
       firstName: 'Emma',
       lastName: 'Johnson',
       personCmId: 1,
       bunkName: 'G-Oak',
+    })
+    expect(sorted[1]).toEqual({
+      firstName: 'Liam',
+      lastName: 'Garcia',
+      personCmId: 2,
+      bunkName: 'B-Cedar',
     })
   })
 

--- a/frontend/src/utils/scenarioComparisonUtils.test.ts
+++ b/frontend/src/utils/scenarioComparisonUtils.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for scenario comparison page helpers.
+ *
+ * Covers:
+ * - sortCampersByName: alphabetical sort (last name, then first name), locale-aware
+ * - getAvailableBunkAreas: derives which area-filter buttons to show based on bunk genders
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  sortCampersByName,
+  getAvailableBunkAreas,
+  type SortableCamper,
+  type BunkWithGender,
+} from './scenarioComparisonUtils'
+
+describe('sortCampersByName', () => {
+  it('sorts campers alphabetically by last name then first name', () => {
+    const campers: SortableCamper[] = [
+      { firstName: 'Liam', lastName: 'Garcia' },
+      { firstName: 'Emma', lastName: 'Johnson' },
+      { firstName: 'Olivia', lastName: 'Chen' },
+      { firstName: 'Adam', lastName: 'Johnson' },
+    ]
+    const sorted = sortCampersByName(campers)
+    expect(sorted.map((c) => `${c.firstName} ${c.lastName}`)).toEqual([
+      'Olivia Chen',
+      'Liam Garcia',
+      'Adam Johnson',
+      'Emma Johnson',
+    ])
+  })
+
+  it('is case-insensitive (locale-aware compare)', () => {
+    const campers: SortableCamper[] = [
+      { firstName: 'Emma', lastName: 'johnson' },
+      { firstName: 'Adam', lastName: 'Johnson' },
+      { firstName: 'Bob', lastName: 'JOHNSON' },
+    ]
+    const sorted = sortCampersByName(campers)
+    // All three have same last name (case-insensitive); first names Adam < Bob < Emma
+    expect(sorted.map((c) => c.firstName)).toEqual(['Adam', 'Bob', 'Emma'])
+  })
+
+  it('is a pure function (does not mutate input)', () => {
+    const campers: SortableCamper[] = [
+      { firstName: 'Zed', lastName: 'Zimmerman' },
+      { firstName: 'Ada', lastName: 'Adams' },
+    ]
+    const original = campers.slice()
+    sortCampersByName(campers)
+    expect(campers).toEqual(original)
+  })
+
+  it('returns empty array when given empty input', () => {
+    expect(sortCampersByName([])).toEqual([])
+  })
+
+  it('preserves unrelated fields on sorted output', () => {
+    interface Extended extends SortableCamper {
+      personCmId: number
+      bunkName: string
+    }
+    const campers: Extended[] = [
+      { firstName: 'Liam', lastName: 'Garcia', personCmId: 2, bunkName: 'B-Cedar' },
+      { firstName: 'Emma', lastName: 'Johnson', personCmId: 1, bunkName: 'G-Oak' },
+    ]
+    const sorted = sortCampersByName(campers)
+    expect(sorted[0]).toEqual({
+      firstName: 'Liam',
+      lastName: 'Garcia',
+      personCmId: 2,
+      bunkName: 'B-Cedar',
+    })
+    expect(sorted[1]).toEqual({
+      firstName: 'Emma',
+      lastName: 'Johnson',
+      personCmId: 1,
+      bunkName: 'G-Oak',
+    })
+  })
+
+  it('produces the same order regardless of input order (deterministic)', () => {
+    const a: SortableCamper[] = [
+      { firstName: 'Emma', lastName: 'Johnson' },
+      { firstName: 'Olivia', lastName: 'Chen' },
+      { firstName: 'Liam', lastName: 'Garcia' },
+    ]
+    const b: SortableCamper[] = [
+      { firstName: 'Liam', lastName: 'Garcia' },
+      { firstName: 'Emma', lastName: 'Johnson' },
+      { firstName: 'Olivia', lastName: 'Chen' },
+    ]
+    expect(sortCampersByName(a)).toEqual(sortCampersByName(b))
+  })
+})
+
+describe('getAvailableBunkAreas', () => {
+  it('returns only "all" when there are no bunks', () => {
+    expect(getAvailableBunkAreas([])).toEqual(['all'])
+  })
+
+  it('omits "ag" when no AG (Mixed-gender) bunks are present', () => {
+    const bunks: BunkWithGender[] = [
+      { name: 'B-Cedar', gender: 'M' },
+      { name: 'G-Oak', gender: 'F' },
+    ]
+    expect(getAvailableBunkAreas(bunks)).toEqual(['all', 'boys', 'girls'])
+  })
+
+  it('includes "ag" when at least one AG bunk is present', () => {
+    const bunks: BunkWithGender[] = [
+      { name: 'B-Cedar', gender: 'M' },
+      { name: 'G-Oak', gender: 'F' },
+      { name: 'AG-Maple', gender: 'Mixed' },
+    ]
+    expect(getAvailableBunkAreas(bunks)).toEqual(['all', 'boys', 'girls', 'ag'])
+  })
+
+  it('omits "boys" when no male-gender bunks are present', () => {
+    const bunks: BunkWithGender[] = [
+      { name: 'G-Oak', gender: 'F' },
+      { name: 'AG-Maple', gender: 'Mixed' },
+    ]
+    const areas = getAvailableBunkAreas(bunks)
+    expect(areas).toContain('all')
+    expect(areas).toContain('girls')
+    expect(areas).toContain('ag')
+    expect(areas).not.toContain('boys')
+  })
+
+  it('omits "girls" when no female-gender bunks are present', () => {
+    const bunks: BunkWithGender[] = [
+      { name: 'B-Cedar', gender: 'M' },
+      { name: 'AG-Maple', gender: 'Mixed' },
+    ]
+    const areas = getAvailableBunkAreas(bunks)
+    expect(areas).toContain('all')
+    expect(areas).toContain('boys')
+    expect(areas).toContain('ag')
+    expect(areas).not.toContain('girls')
+  })
+
+  it('always keeps "all" as the first option', () => {
+    const bunks: BunkWithGender[] = [{ name: 'AG-Maple', gender: 'Mixed' }]
+    const areas = getAvailableBunkAreas(bunks)
+    expect(areas[0]).toBe('all')
+  })
+
+  it('returns filter options in stable order: all, boys, girls, ag', () => {
+    const bunks: BunkWithGender[] = [
+      { name: 'AG-Maple', gender: 'Mixed' },
+      { name: 'G-Oak', gender: 'F' },
+      { name: 'B-Cedar', gender: 'M' },
+    ]
+    expect(getAvailableBunkAreas(bunks)).toEqual(['all', 'boys', 'girls', 'ag'])
+  })
+})

--- a/frontend/src/utils/scenarioComparisonUtils.test.ts
+++ b/frontend/src/utils/scenarioComparisonUtils.test.ts
@@ -8,11 +8,50 @@
 
 import { describe, expect, it } from 'vitest'
 import {
+  compareCamperByName,
   sortCampersByName,
   getAvailableBunkAreas,
   type SortableCamper,
   type BunkWithGender,
 } from './scenarioComparisonUtils'
+
+describe('compareCamperByName', () => {
+  it('sorts by last name first', () => {
+    const a: SortableCamper = { firstName: 'Zed', lastName: 'Adams' }
+    const b: SortableCamper = { firstName: 'Ada', lastName: 'Zimmerman' }
+    expect(compareCamperByName(a, b)).toBeLessThan(0)
+    expect(compareCamperByName(b, a)).toBeGreaterThan(0)
+  })
+
+  it('breaks ties by first name', () => {
+    const a: SortableCamper = { firstName: 'Adam', lastName: 'Johnson' }
+    const b: SortableCamper = { firstName: 'Emma', lastName: 'Johnson' }
+    expect(compareCamperByName(a, b)).toBeLessThan(0)
+    expect(compareCamperByName(b, a)).toBeGreaterThan(0)
+  })
+
+  it('returns 0 for identical names', () => {
+    const a: SortableCamper = { firstName: 'Olivia', lastName: 'Chen' }
+    const b: SortableCamper = { firstName: 'Olivia', lastName: 'Chen' }
+    expect(compareCamperByName(a, b)).toBe(0)
+  })
+
+  it('is locale-aware and case-insensitive (accented chars collate correctly)', () => {
+    // 'Álvarez' should sort after 'Alvarez' in locale-aware compare (or at least
+    // not throw; sensitivity:'base' treats them as equal)
+    const base: SortableCamper = { firstName: 'Liam', lastName: 'Alvarez' }
+    const accented: SortableCamper = { firstName: 'Liam', lastName: 'Álvarez' }
+    // sensitivity:'base' treats base and accented as equal → result is 0
+    expect(compareCamperByName(base, accented)).toBe(0)
+  })
+
+  it('handles empty strings without throwing', () => {
+    const a: SortableCamper = { firstName: '', lastName: '' }
+    const b: SortableCamper = { firstName: 'Emma', lastName: 'Johnson' }
+    expect(() => compareCamperByName(a, b)).not.toThrow()
+    expect(() => compareCamperByName(b, a)).not.toThrow()
+  })
+})
 
 describe('sortCampersByName', () => {
   it('sorts campers alphabetically by last name then first name', () => {

--- a/frontend/src/utils/scenarioComparisonUtils.ts
+++ b/frontend/src/utils/scenarioComparisonUtils.ts
@@ -13,7 +13,6 @@ export interface SortableCamper {
 
 /** Minimal bunk shape used to decide which area-filter buttons to render. */
 export interface BunkWithGender {
-  name: string
   gender: string
 }
 

--- a/frontend/src/utils/scenarioComparisonUtils.ts
+++ b/frontend/src/utils/scenarioComparisonUtils.ts
@@ -21,6 +21,17 @@ export interface BunkWithGender {
 export type BunkArea = 'all' | 'boys' | 'girls' | 'ag'
 
 /**
+ * Compare two campers by name (last name, then first name).
+ * Locale-aware and case-insensitive. Returns negative / 0 / positive,
+ * suitable for use directly as an Array.sort comparator.
+ */
+export function compareCamperByName(a: SortableCamper, b: SortableCamper): number {
+  const lastCmp = a.lastName.localeCompare(b.lastName, undefined, { sensitivity: 'base' })
+  if (lastCmp !== 0) return lastCmp
+  return a.firstName.localeCompare(b.firstName, undefined, { sensitivity: 'base' })
+}
+
+/**
  * Sort campers alphabetically by last name, then first name.
  * Locale-aware and case-insensitive — matches the convention used elsewhere
  * in the app (see DrillDownModal, ManualResolutionModal).
@@ -28,11 +39,7 @@ export type BunkArea = 'all' | 'boys' | 'girls' | 'ag'
  * Returns a new array; does not mutate the input.
  */
 export function sortCampersByName<T extends SortableCamper>(campers: readonly T[]): T[] {
-  return campers.slice().sort((a, b) => {
-    const lastCmp = a.lastName.localeCompare(b.lastName, undefined, { sensitivity: 'base' })
-    if (lastCmp !== 0) return lastCmp
-    return a.firstName.localeCompare(b.firstName, undefined, { sensitivity: 'base' })
-  })
+  return campers.slice().sort(compareCamperByName)
 }
 
 /**

--- a/frontend/src/utils/scenarioComparisonUtils.ts
+++ b/frontend/src/utils/scenarioComparisonUtils.ts
@@ -20,20 +20,20 @@ export interface BunkWithGender {
 export type BunkArea = 'all' | 'boys' | 'girls' | 'ag'
 
 /**
- * Compare two campers by name (last name, then first name).
+ * Compare two campers by name (first name, then last name).
  * Locale-aware and case-insensitive. Returns negative / 0 / positive,
  * suitable for use directly as an Array.sort comparator.
  */
 export function compareCamperByName(a: SortableCamper, b: SortableCamper): number {
-  const lastCmp = a.lastName.localeCompare(b.lastName, undefined, { sensitivity: 'base' })
-  if (lastCmp !== 0) return lastCmp
-  return a.firstName.localeCompare(b.firstName, undefined, { sensitivity: 'base' })
+  const firstCmp = a.firstName.localeCompare(b.firstName, undefined, { sensitivity: 'base' })
+  if (firstCmp !== 0) return firstCmp
+  return a.lastName.localeCompare(b.lastName, undefined, { sensitivity: 'base' })
 }
 
 /**
- * Sort campers alphabetically by last name, then first name.
- * Locale-aware and case-insensitive — matches the convention used elsewhere
- * in the app (see DrillDownModal, ManualResolutionModal).
+ * Sort campers alphabetically by first name, then last name.
+ * Locale-aware and case-insensitive — staff scan by first name when
+ * reconciling cabin rosters.
  *
  * Returns a new array; does not mutate the input.
  */

--- a/frontend/src/utils/scenarioComparisonUtils.ts
+++ b/frontend/src/utils/scenarioComparisonUtils.ts
@@ -1,0 +1,55 @@
+/**
+ * Helpers for the scenario comparison page (ScenarioComparisonPage.tsx).
+ *
+ * Kept as pure, dependency-free functions so they can be unit tested without
+ * mocking PocketBase, React Query, auth, or the router.
+ */
+
+/** Minimal shape needed to sort campers by name. */
+export interface SortableCamper {
+  firstName: string
+  lastName: string
+}
+
+/** Minimal bunk shape used to decide which area-filter buttons to render. */
+export interface BunkWithGender {
+  name: string
+  gender: string
+}
+
+/** Area-filter values rendered as toggle buttons on the comparison page. */
+export type BunkArea = 'all' | 'boys' | 'girls' | 'ag'
+
+/**
+ * Sort campers alphabetically by last name, then first name.
+ * Locale-aware and case-insensitive — matches the convention used elsewhere
+ * in the app (see DrillDownModal, ManualResolutionModal).
+ *
+ * Returns a new array; does not mutate the input.
+ */
+export function sortCampersByName<T extends SortableCamper>(campers: readonly T[]): T[] {
+  return campers.slice().sort((a, b) => {
+    const lastCmp = a.lastName.localeCompare(b.lastName, undefined, { sensitivity: 'base' })
+    if (lastCmp !== 0) return lastCmp
+    return a.firstName.localeCompare(b.firstName, undefined, { sensitivity: 'base' })
+  })
+}
+
+/**
+ * Given the bunks present in the comparison scope, return the list of area
+ * filter options that should actually be rendered.
+ *
+ * - "all" is always included.
+ * - "boys" / "girls" / "ag" appear only when at least one bunk of that gender
+ *   exists in the scope. This hides filters that would produce an empty view.
+ *
+ * AG bunks are identified by `gender === "Mixed"` (see session-types.md:
+ * AG bunks are co-ed and distinguished by gender="Mixed" and an "AG-" name prefix).
+ */
+export function getAvailableBunkAreas(bunks: readonly BunkWithGender[]): BunkArea[] {
+  const result: BunkArea[] = ['all']
+  if (bunks.some((b) => b.gender === 'M')) result.push('boys')
+  if (bunks.some((b) => b.gender === 'F')) result.push('girls')
+  if (bunks.some((b) => b.gender === 'Mixed')) result.push('ag')
+  return result
+}


### PR DESCRIPTION
## Summary

Two small fixes to the scenario comparison page from staff-testing feedback.

- **#23 — Sort campers alphabetically across both sides.** Camper lists in both the split-view (per-bunk left/right lanes) and the changes view (moved, newly-assigned, newly-unassigned) are now sorted alphabetically by first name then last name, locale-aware (case-insensitive). Both sides use the same ordering for consistent scanning — first name is what staff scan for when reconciling cabin rosters.
- **#24 — Hide AG filter when no AG campers in scope.** The "AG" area-filter button is now removed from the DOM when no AG (Mixed-gender) cabins are in the comparison scope, instead of being rendered as a no-op. The same applies to "Boys" / "Girls" when no bunks of that gender are present. If a persisted selection becomes invalid after a data refresh, filtering falls back to "all" for that render (no `setState`-in-effect cascade).

Logic is extracted into pure helpers in `utils/scenarioComparisonUtils.ts` with unit tests so this is testable without mocking PocketBase / React Query.

## Files changed

- `frontend/src/utils/scenarioComparisonUtils.ts` (new) — `sortCampersByName`, `getAvailableBunkAreas`, `BunkArea`
- `frontend/src/utils/scenarioComparisonUtils.test.ts` (new) — 18 unit tests
- `frontend/src/pages/ScenarioComparisonPage.tsx` — wire in the helpers, add `firstName` / `lastName` to `CamperAssignment`, compute `effectiveBunkArea` during render

## Manual validation (dev/preview)

- [x] `npx vitest run src/utils/scenarioComparisonUtils.test.ts` — 18 tests pass
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on new files; only pre-existing warnings on `ScenarioComparisonPage.tsx`
- [x] `prettier --check` clean
- [ ] Manually verify on `/summer/session/<id>/scenarios/compare`: campers appear alphabetized by first name on both sides; AG filter hidden when comparing a session with no Mixed-gender cabins; AG filter visible when comparing a session that has them

## Not included (separate work)

Friend-group comparison (#25), CSV export (#28), impacted-cabins header (#26), parent-vs-all-requests labeling (#27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bunk area filtering options (Boys, Girls, AG) to the scenario comparison view for targeted camper review
  * Implemented consistent alphabetical sorting of campers by last name, then first name across all comparison lists

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
