### PR TITLE
fix(frontend): label sync timestamps as "synced" and rename upload tooltip

### DIFF
--- a/frontend/src/components/BunkRequestsUpload.test.tsx
+++ b/frontend/src/components/BunkRequestsUpload.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+vi.mock('../hooks/useApiWithAuth', () => ({
+  useApiWithAuth: () => ({ fetchWithAuth: vi.fn() }),
+}))
+
+vi.mock('../hooks/useCurrentYear', () => ({
+  useCurrentYear: () => ({ currentYear: 2026 }),
+}))
+
+vi.mock('../services/sync', () => ({
+  syncService: {
+    uploadBunkRequestsCSV: vi.fn(),
+  },
+}))
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const BunkRequestsUpload = (await import('./BunkRequestsUpload')).default
+
+function renderUpload() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <BunkRequestsUpload />
+    </QueryClientProvider>
+  )
+}
+
+describe('BunkRequestsUpload floatover/tooltip', () => {
+  it('upload button tooltip reads "Camper report: API Bunking Info"', () => {
+    renderUpload()
+    // The upload button has a title attribute acting as the floatover/tooltip.
+    const btn = screen.getByRole('button', { name: /Upload/i })
+    expect(btn.getAttribute('title')).toBe('Camper report: API Bunking Info')
+  })
+})

--- a/frontend/src/components/BunkRequestsUpload.tsx
+++ b/frontend/src/components/BunkRequestsUpload.tsx
@@ -93,7 +93,7 @@ export default function BunkRequestsUpload({ compact = false }: BunkRequestsUplo
         className={
           compact ? 'btn-secondary px-3 py-1.5' : 'btn-secondary nav-btn-icon-only px-4 py-2'
         }
-        title="Upload Bunk Requests CSV"
+        title="Camper report: API Bunking Info"
       >
         <Upload className="h-4 w-4 flex-shrink-0" />
         {compact ? (

--- a/frontend/src/layouts/AppLayout.test.tsx
+++ b/frontend/src/layouts/AppLayout.test.tsx
@@ -38,7 +38,7 @@ vi.mock('../contexts/ProgramContext', () => ({
 }))
 
 // Spy so tests can assert on what args AppLayout passes
-const syncStatusSpy = vi.fn((_opts?: unknown) => ({ data: null }))
+const syncStatusSpy = vi.fn<(opts?: unknown) => { data: unknown }>(() => ({ data: null }))
 vi.mock('../hooks/useSyncStatusAPI', () => ({
   useSyncStatusAPI: (...args: unknown[]) => syncStatusSpy(...args),
 }))
@@ -220,5 +220,54 @@ describe('AppLayout sync-status polling', () => {
     renderAppLayout()
     const lastCall = syncStatusSpy.mock.calls.at(-1)
     expect(lastCall?.[0]).toEqual({ enabled: true })
+  })
+})
+
+describe('AppLayout sync-status labels', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPerms = {
+      hasPermission: (p: string) => p === 'bunking.manage',
+      isAdmin: false,
+    }
+    const iso = '2026-04-22T12:00:00.000Z' // in the past relative to any test run
+    syncStatusSpy.mockImplementation(() => ({
+      data: {
+        bunk_assignments: {
+          status: 'success',
+          end_time: iso,
+          start_time: iso,
+          summary: { created: 1, updated: 2, skipped: 0, errors: 0 },
+        },
+        bunk_requests: {
+          status: 'success',
+          end_time: iso,
+          start_time: iso,
+          summary: { created: 3, updated: 4, skipped: 1, errors: 0 },
+        },
+      },
+    }))
+  })
+
+  it('renders "Assignments synced ..." label with lowercase synced', () => {
+    renderAppLayout()
+    // The label should read "Assignments synced <relative time>"
+    expect(screen.getByText(/Assignments synced/)).toBeInTheDocument()
+  })
+
+  it('renders "Requests synced ..." label with lowercase synced', () => {
+    renderAppLayout()
+    expect(screen.getByText(/Requests synced/)).toBeInTheDocument()
+  })
+
+  it('Requests sync label exposes richer detail via tooltip on hover', () => {
+    renderAppLayout()
+    const requestsLabel = screen.getByText(/Requests synced/)
+    // Find the nearest element carrying the tooltip (title attribute)
+    const tooltipHost = requestsLabel.closest('[title]') as HTMLElement | null
+    expect(tooltipHost).not.toBeNull()
+    const title = tooltipHost?.getAttribute('title') ?? ''
+    // Tooltip should contain an exact timestamp (ISO-ish) for richer sync detail
+    expect(title).toMatch(/2026-04-22/)
   })
 })

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -39,6 +39,28 @@ import { MANAGE_TABS } from '../config/manageTabs'
 import { PROGRAM_BUTTONS } from '../config/programButtons'
 import { useTour } from '../hooks/useTour'
 import { FeedbackModal } from '../components/FeedbackModal'
+import type { SyncStatus } from '../hooks/useSyncStatusAPI'
+
+/**
+ * Build a tooltip string exposing richer sync detail:
+ * exact end timestamp, status, and key counts when available.
+ */
+function buildSyncTooltip(kind: string, status: SyncStatus): string {
+  const parts = [`Last ${kind} sync`]
+  if (status.end_time) {
+    parts.push(new Date(status.end_time).toISOString())
+  }
+  if (status.status) {
+    parts.push(`status: ${status.status}`)
+  }
+  const s = status.summary
+  if (s) {
+    parts.push(
+      `created ${s.created}, updated ${s.updated}, skipped ${s.skipped}, errors ${s.errors}`
+    )
+  }
+  return parts.join(' • ')
+}
 
 export const AppLayout = () => {
   const location = useLocation()
@@ -692,19 +714,22 @@ export const AppLayout = () => {
                     {syncStatus.bunk_assignments.end_time && (
                       <span
                         className="flex items-center gap-1.5"
-                        title="Last bunk assignments sync"
+                        title={buildSyncTooltip('bunk assignments', syncStatus.bunk_assignments)}
                       >
                         <Home className="h-3 w-3" />
-                        Assignments{' '}
+                        Assignments synced{' '}
                         {formatDistanceToNow(new Date(syncStatus.bunk_assignments.end_time), {
                           addSuffix: true,
                         })}
                       </span>
                     )}
                     {syncStatus.bunk_requests.end_time && (
-                      <span className="flex items-center gap-1.5" title="Last bunk requests sync">
+                      <span
+                        className="flex items-center gap-1.5"
+                        title={buildSyncTooltip('bunk requests', syncStatus.bunk_requests)}
+                      >
                         <Clock className="h-3 w-3" />
-                        Requests{' '}
+                        Requests synced{' '}
                         {formatDistanceToNow(new Date(syncStatus.bunk_requests.end_time), {
                           addSuffix: true,
                         })}


### PR DESCRIPTION
## Summary

Three small staff-facing copy fixes from the staff testing feedback round:

- **#1** — Assignments page now labels its sync timestamp as `Assignments synced <relative time>` (lowercase `synced`). Previously the label read like a vague "about 1 hour ago" without context.
- **#2** — Requests page gets the same `Requests synced <relative time>` treatment, plus a mouseover tooltip exposing exact end_time and summary counts (created / updated / skipped / errors).
- **#3** — The Upload Bunk Requests button tooltip renamed to `API Bunking Info` to match what the report is actually called in CampMinder, so staff recognize it.

## Test plan

- [ ] Open Assignments — label reads "Assignments synced …"
- [ ] Open Requests — label reads "Requests synced …"
- [ ] Hover the Requests sync label — tooltip shows timestamp + summary counts
- [ ] Hover the Upload Requests button — tooltip reads "API Bunking Info"

🤖 Generated with [Claude Code](https://claude.com/claude-code)