### PR TITLE
fix(frontend): invalidate tab-badge request count on mutations

### DIFF
--- a/frontend/src/hooks/session/useSessionData.test.ts
+++ b/frontend/src/hooks/session/useSessionData.test.ts
@@ -5,7 +5,9 @@ import {
   deduplicateBunksByName,
   mergeCampers,
   buildBunkRequestsFilter,
+  BUNK_REQUESTS_COUNT_KEY_PREFIX,
 } from './useSessionData'
+import { queryKeys } from '../../utils/queryKeys'
 
 describe('extractBunkIds', () => {
   it('extracts unique bunk IDs, filtering nulls', () => {
@@ -94,5 +96,31 @@ describe('buildBunkRequestsFilter', () => {
     expect(filter).toMatch(/session_id = 999/)
     expect(filter).toMatch(/year = 2026/)
     expect(filter).not.toMatch(/session_id=|year=/)
+  })
+})
+
+// ============================================================================
+// Tab badge key alignment: count query must share prefix with list query
+// ============================================================================
+// Regression test for: "Requests tab number is stale without refresh"
+// Root cause: useBunkRequestsCount used a separate top-level key
+// ('bunk-requests-count') that was never invalidated when request
+// mutations fired invalidateQueries({ queryKey: ['bunk-requests'] }).
+// Fix: the count key must start with 'bunk-requests' so React Query
+// prefix-matching picks it up in every existing invalidation.
+
+describe('bunk-requests-count query key alignment', () => {
+  it('BUNK_REQUESTS_COUNT_KEY_PREFIX equals "bunk-requests" so mutations invalidate the count', () => {
+    expect(BUNK_REQUESTS_COUNT_KEY_PREFIX).toBe('bunk-requests')
+  })
+
+  it('queryKeys.bunkRequestsCount starts with "bunk-requests"', () => {
+    const key = queryKeys.bunkRequestsCount('1000001', 2025)
+    expect(key[0]).toBe('bunk-requests')
+  })
+
+  it('queryKeys.bunkRequestsCount second element is "count" to distinguish from list query', () => {
+    const key = queryKeys.bunkRequestsCount('1000001', 2025)
+    expect(key[1]).toBe('count')
   })
 })

--- a/frontend/src/hooks/session/useSessionData.test.ts
+++ b/frontend/src/hooks/session/useSessionData.test.ts
@@ -110,8 +110,11 @@ describe('buildBunkRequestsFilter', () => {
 // prefix-matching picks it up in every existing invalidation.
 
 describe('bunk-requests-count query key alignment', () => {
-  it('BUNK_REQUESTS_COUNT_KEY_PREFIX equals "bunk-requests" so mutations invalidate the count', () => {
-    expect(BUNK_REQUESTS_COUNT_KEY_PREFIX).toBe('bunk-requests')
+  it('BUNK_REQUESTS_COUNT_KEY_PREFIX is derived from queryKeys.bunkRequestsCount factory prefix (not a separate hardcoded string)', () => {
+    // This is the invariant that matters: the constant must equal the first element
+    // of the factory key so React Query prefix-match invalidation covers the count.
+    // If either the factory prefix or the constant drifts, this test will catch it.
+    expect(BUNK_REQUESTS_COUNT_KEY_PREFIX).toBe(queryKeys.bunkRequestsCount('session_x', 2026)[0])
   })
 
   it('queryKeys.bunkRequestsCount starts with "bunk-requests"', () => {

--- a/frontend/src/hooks/session/useSessionData.ts
+++ b/frontend/src/hooks/session/useSessionData.ts
@@ -11,7 +11,7 @@ import { queryKeys } from '../../utils/queryKeys'
 
 // Exported so tests can assert this key shares a prefix with ['bunk-requests']
 // mutations, ensuring React Query prefix-match invalidation covers the count.
-export const BUNK_REQUESTS_COUNT_KEY_PREFIX = 'bunk-requests'
+export const BUNK_REQUESTS_COUNT_KEY_PREFIX = queryKeys.bunkRequestsCount('', 0)[0]
 
 // ============================================================================
 // Types

--- a/frontend/src/hooks/session/useSessionData.ts
+++ b/frontend/src/hooks/session/useSessionData.ts
@@ -7,6 +7,11 @@ import { useQuery } from '@tanstack/react-query'
 import type { Session, Camper, BunkRequest, Bunk } from '../../types/app-types'
 import { pb } from '../../lib/pocketbase'
 import { fetchCampersForSession } from '../../utils/pocketbaseDataFetchers'
+import { queryKeys } from '../../utils/queryKeys'
+
+// Exported so tests can assert this key shares a prefix with ['bunk-requests']
+// mutations, ensuring React Query prefix-match invalidation covers the count.
+export const BUNK_REQUESTS_COUNT_KEY_PREFIX = 'bunk-requests'
 
 // ============================================================================
 // Types
@@ -266,13 +271,12 @@ export function useBunkRequestsCount({
   agSessions,
 }: UseBunkRequestsCountOptions) {
   return useQuery({
-    queryKey: [
-      'bunk-requests-count',
-      selectedSession,
+    queryKey: queryKeys.bunkRequestsCount(
+      selectedSession ?? '',
       currentYear,
       subSessions.map((s) => s.cm_id).sort(),
-      agSessions.map((s) => s.cm_id).sort(),
-    ],
+      agSessions.map((s) => s.cm_id).sort()
+    ),
     queryFn: async (): Promise<number> => {
       if (!selectedSession) return 0
 

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -51,6 +51,10 @@ export const queryKeys = {
 
   // Bunk Requests (Tier 2 - user data)
   bunkRequests: (sessionId: string, year: number) => ['bunk-requests', sessionId, year] as const,
+  // Count uses same 'bunk-requests' prefix so invalidateQueries({ queryKey: ['bunk-requests'] })
+  // automatically invalidates the tab-badge count without additional call sites.
+  bunkRequestsCount: (selectedSession: string, year: number, ...rest: unknown[]) =>
+    ['bunk-requests', 'count', selectedSession, year, ...rest] as const,
 
   // Locked Groups (Tier 2 - user data)
   lockedGroups: (scenarioId: string, sessionId: string, year: number) =>


### PR DESCRIPTION
## Summary

- **Bug**: The Requests tab count badge showed a stale number after creating, updating, or deleting bunk requests — it only refreshed on manual page reload
- **Root cause**: `useBunkRequestsCount` used query key `['bunk-requests-count', ...]` while all mutations called `invalidateQueries({ queryKey: ['bunk-requests'] })`. React Query prefix matching never reached the count key
- **Fix**: Renamed count key to `['bunk-requests', 'count', ...]` so every existing invalidation automatically flushes the badge via prefix match — zero new call sites needed
- Added `queryKeys.bunkRequestsCount()` factory to `queryKeys.ts` and `BUNK_REQUESTS_COUNT_KEY_PREFIX` export for testability; the campers tab was unaffected (its count derives directly from the campers list query, not a separate count query)

Closes feedback item #13: "Requests tab number is stale without refresh"

## Test plan

- [x] Three regression tests in `useSessionData.test.ts` assert the count key starts with `'bunk-requests'` — verified red before implementation, green after
- [x] `npx vitest run` — 2795 tests pass (200 test files)
- [x] `tsc --noEmit` — no type errors
- [x] `eslint` — no new errors (warnings pre-existing)
- [x] `prettier` — no formatting changes

## Manual validation (dev/preview)

Scoreboard item covered: **#13** — Requests tab badge stale

- [ ] Open the Requests tab; note the current count badge.
- [ ] Create a new bunk request. Badge increments without a page refresh.
- [ ] Approve / resolve a request. Badge decrements without a page refresh.
- [ ] Decline a request. Badge updates without a page refresh.
- [ ] Delete (or cancel) a request if the UI allows it. Badge updates without a page refresh.
- [ ] Switch to another tab and back. Badge remains correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage to enforce consistency between bunk requests list and count query cache keys.

* **Refactor**
  * Improved internal query cache key management for bunk requests count queries to enable more efficient cache invalidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->