### PR TITLE
fix(frontend): update bunking board legend to cover current icons

### DIFF
--- a/frontend/src/components/BunkingLegend.test.tsx
+++ b/frontend/src/components/BunkingLegend.test.tsx
@@ -51,10 +51,7 @@ describe('BunkingLegend', () => {
       render(<BunkingLegend isOpen={true} onClose={() => {}} />)
       // CamperCard applies blue/pink/purple background from getGenderColorClasses()
       // Must have a dedicated heading entry — not just a passing mention
-      const matches = screen.getAllByText(
-        /card color|gender.*(color|background|blue|pink|purple)|color.*gender/i
-      )
-      expect(matches.length).toBeGreaterThan(0)
+      expect(screen.getByText('Gender Card Color')).toBeInTheDocument()
     })
 
     it('documents the last-year history indicator', () => {

--- a/frontend/src/components/BunkingLegend.test.tsx
+++ b/frontend/src/components/BunkingLegend.test.tsx
@@ -57,8 +57,7 @@ describe('BunkingLegend', () => {
     it('documents the last-year history indicator', () => {
       render(<BunkingLegend isOpen={true} onClose={() => {}} />)
       // CamperCard shows historyDisplay text (e.g. "S1 B-4") when getLastYearHistory returns data
-      const matches = screen.getAllByText(/prior.year|last.year|previous.year|history/i)
-      expect(matches.length).toBeGreaterThan(0)
+      expect(screen.getByText('Prior-Year History')).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/components/BunkingLegend.test.tsx
+++ b/frontend/src/components/BunkingLegend.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Tests for BunkingLegend component.
+ *
+ * Pins the contract between what the bunking board renders and what the legend
+ * documents. Each icon-key that CamperCard or BunkCard can render must have a
+ * corresponding entry in the legend. This test fails if someone adds a new
+ * indicator without updating the legend.
+ */
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import BunkingLegend from './BunkingLegend'
+
+describe('BunkingLegend', () => {
+  it('renders when open', () => {
+    render(<BunkingLegend isOpen={true} onClose={() => {}} />)
+    expect(screen.getByText('Visual Guide')).toBeInTheDocument()
+  })
+
+  it('does not render when closed', () => {
+    render(<BunkingLegend isOpen={false} onClose={() => {}} />)
+    expect(screen.queryByText('Visual Guide')).not.toBeInTheDocument()
+  })
+
+  describe('Camper card indicators — must match CamperCard.tsx rendering', () => {
+    it('documents the unfulfilled-request warning (orange triangle)', () => {
+      render(<BunkingLegend isOpen={true} onClose={() => {}} />)
+      // CamperCard shows AlertTriangle when totalRequests > 0 && satisfiedCount === 0
+      expect(screen.getByText(/unsatisfied requests/i)).toBeInTheDocument()
+    })
+
+    it('documents the friend-group lock icon with count', () => {
+      render(<BunkingLegend isOpen={true} onClose={() => {}} />)
+      // CamperCard shows Lock + group size when lockState === 'locked'
+      // Use getAllByText since "friend group" appears in both heading and description
+      expect(screen.getAllByText(/friend group/i).length).toBeGreaterThan(0)
+    })
+
+    it('documents the pending-selection amber glow', () => {
+      render(<BunkingLegend isOpen={true} onClose={() => {}} />)
+      // CamperCard applies pending-lock-glow + border-amber-400 when lockState === 'pending'
+      expect(screen.getByText(/pending selection/i)).toBeInTheDocument()
+    })
+
+    it('documents the group name glow', () => {
+      render(<BunkingLegend isOpen={true} onClose={() => {}} />)
+      // CamperCard applies text-shadow glow to camper name when in a locked group
+      expect(screen.getByText(/group name glow/i)).toBeInTheDocument()
+    })
+
+    it('documents gender-coded card backgrounds', () => {
+      render(<BunkingLegend isOpen={true} onClose={() => {}} />)
+      // CamperCard applies blue/pink/purple background from getGenderColorClasses()
+      // Must have a dedicated heading entry — not just a passing mention
+      const matches = screen.getAllByText(
+        /card color|gender.*(color|background|blue|pink|purple)|color.*gender/i
+      )
+      expect(matches.length).toBeGreaterThan(0)
+    })
+
+    it('documents the last-year history indicator', () => {
+      render(<BunkingLegend isOpen={true} onClose={() => {}} />)
+      // CamperCard shows historyDisplay text (e.g. "S1 B-4") when getLastYearHistory returns data
+      const matches = screen.getAllByText(/prior.year|last.year|previous.year|history/i)
+      expect(matches.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('Bunk card indicators — must match BunkCard.tsx rendering', () => {
+    it('documents the capacity utilization bar', () => {
+      render(<BunkingLegend isOpen={true} onClose={() => {}} />)
+      // BunkCard renders BunkUtilizationBar with green/yellow/orange/red colors
+      expect(screen.getByText(/capacity bar/i)).toBeInTheDocument()
+    })
+
+    it('documents the social graph button', () => {
+      render(<BunkingLegend isOpen={true} onClose={() => {}} />)
+      // BunkCard renders Network icon button when onShowSocialGraph is provided
+      expect(screen.getByText(/social graph/i)).toBeInTheDocument()
+    })
+
+    it('documents bunk warning indicators', () => {
+      render(<BunkingLegend isOpen={true} onClose={() => {}} />)
+      // BunkCard shows red border + ⚠️ on ageGapWarning, gradeRatioWarning, etc.
+      expect(screen.getByText(/bunk warnings/i)).toBeInTheDocument()
+    })
+
+    it('documents the invalid drop target grey-out', () => {
+      render(<BunkingLegend isOpen={true} onClose={() => {}} />)
+      // BunkCard applies opacity-40 when dropDisabled && activeDragCamper
+      expect(screen.getByText(/invalid drop target/i)).toBeInTheDocument()
+    })
+
+    it('documents the active drop target highlight', () => {
+      render(<BunkingLegend isOpen={true} onClose={() => {}} />)
+      // BunkCard applies ring-primary ring-2 when isOver (camper being dragged over bunk)
+      // Must have a dedicated entry describing the highlighted / hover state
+      expect(
+        screen.getByText(
+          /active drop|drop.*highlight|highlighted.*bunk|hover.*bunk|dragging.*over/i
+        )
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('Working modes', () => {
+    it('documents draft scenario mode', () => {
+      render(<BunkingLegend isOpen={true} onClose={() => {}} />)
+      expect(screen.getByText(/scenario mode/i)).toBeInTheDocument()
+    })
+
+    it('documents production / live mode', () => {
+      render(<BunkingLegend isOpen={true} onClose={() => {}} />)
+      expect(screen.getByText(/production mode/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/components/BunkingLegend.tsx
+++ b/frontend/src/components/BunkingLegend.tsx
@@ -1,5 +1,15 @@
 import { useState } from 'react'
-import { HelpCircle, X, Lock, AlertTriangle, Users, Home, Network, Layers } from 'lucide-react'
+import {
+  HelpCircle,
+  X,
+  Lock,
+  AlertTriangle,
+  Users,
+  Home,
+  Network,
+  Layers,
+  History,
+} from 'lucide-react'
 
 interface BunkingLegendProps {
   isOpen: boolean
@@ -96,6 +106,36 @@ export default function BunkingLegend({ isOpen, onClose }: BunkingLegendProps) {
                   </p>
                 </div>
               </div>
+
+              {/* Gender Card Color */}
+              <div className="flex items-start gap-4">
+                <div className="flex w-12 flex-shrink-0 items-center justify-center gap-1">
+                  <div className="h-5 w-3 rounded border-2 border-blue-300 bg-blue-100 dark:border-blue-700 dark:bg-blue-900/30" />
+                  <div className="h-5 w-3 rounded border-2 border-pink-300 bg-pink-100 dark:border-pink-700 dark:bg-pink-900/30" />
+                  <div className="h-5 w-3 rounded border-2 border-purple-300 bg-purple-100 dark:border-purple-700 dark:bg-purple-900/30" />
+                </div>
+                <div>
+                  <p className="text-foreground font-medium">Gender Card Color</p>
+                  <p className="text-muted-foreground text-sm">
+                    Card background color reflects gender identity: blue = boy/man, pink =
+                    girl/woman, purple = all other identities
+                  </p>
+                </div>
+              </div>
+
+              {/* Prior Year History */}
+              <div className="flex items-start gap-4">
+                <div className="flex w-12 flex-shrink-0 justify-center">
+                  <History className="text-muted-foreground h-5 w-5" />
+                </div>
+                <div>
+                  <p className="text-foreground font-medium">Prior-Year History</p>
+                  <p className="text-muted-foreground text-sm">
+                    Dim text on the right of the card shows where this camper bunked last year
+                    (e.g.&nbsp;"S1 B-4"). Blank if this is the camper's first year.
+                  </p>
+                </div>
+              </div>
             </div>
           </section>
 
@@ -168,7 +208,7 @@ export default function BunkingLegend({ isOpen, onClose }: BunkingLegendProps) {
                   <ul className="text-muted-foreground space-y-1 text-sm">
                     <li className="flex items-center gap-2">
                       <span className="bg-muted-foreground h-1 w-1 rounded-full" />
-                      Over capacity (more than 12 campers)
+                      Over capacity (exceeds bunk's configured capacity)
                     </li>
                     <li className="flex items-center gap-2">
                       <span className="bg-muted-foreground h-1 w-1 rounded-full" />
@@ -183,6 +223,20 @@ export default function BunkingLegend({ isOpen, onClose }: BunkingLegendProps) {
                       More than 2 different grades in bunk
                     </li>
                   </ul>
+                </div>
+              </div>
+
+              {/* Active Drop Target */}
+              <div className="flex items-start gap-4">
+                <div className="flex w-12 flex-shrink-0 justify-center">
+                  <div className="ring-primary bg-primary/5 h-8 w-10 rounded-lg ring-2" />
+                </div>
+                <div>
+                  <p className="text-foreground font-medium">Active Drop Target</p>
+                  <p className="text-muted-foreground text-sm">
+                    Blue ring highlights the bunk currently being dragged over, showing it will
+                    accept the camper on release
+                  </p>
                 </div>
               </div>
 

--- a/frontend/src/components/BunkingLegend.tsx
+++ b/frontend/src/components/BunkingLegend.tsx
@@ -16,6 +16,25 @@ interface BunkingLegendProps {
   onClose: () => void
 }
 
+interface LegendEntryProps {
+  icon: React.ReactNode
+  title: string
+  children: React.ReactNode
+  iconClass?: string
+}
+
+function LegendEntry({ icon, title, children, iconClass }: LegendEntryProps) {
+  return (
+    <div className="flex items-start gap-4">
+      <div className={`flex w-12 flex-shrink-0 justify-center ${iconClass ?? ''}`}>{icon}</div>
+      <div>
+        <p className="text-foreground font-medium">{title}</p>
+        {children}
+      </div>
+    </div>
+  )
+}
+
 export default function BunkingLegend({ isOpen, onClose }: BunkingLegendProps) {
   if (!isOpen) return null
 
@@ -42,100 +61,85 @@ export default function BunkingLegend({ isOpen, onClose }: BunkingLegendProps) {
               Camper Indicators
             </h3>
             <div className="space-y-4">
-              {/* Unsatisfied Warning */}
-              <div className="flex items-start gap-4">
-                <div className="flex w-12 flex-shrink-0 justify-center">
-                  <AlertTriangle className="h-5 w-5 text-orange-500" />
-                </div>
-                <div>
-                  <p className="text-foreground font-medium">Unsatisfied Requests</p>
-                  <p className="text-muted-foreground text-sm">
-                    Orange triangle indicates this camper has bunk requests but none are satisfied
-                    in their current placement
-                  </p>
-                </div>
-              </div>
+              <LegendEntry
+                icon={<AlertTriangle className="h-5 w-5 text-orange-500" />}
+                title="Unsatisfied Requests"
+              >
+                <p className="text-muted-foreground text-sm">
+                  Orange triangle indicates this camper has bunk requests but none are satisfied in
+                  their current placement
+                </p>
+              </LegendEntry>
 
-              {/* Friend Group Lock */}
-              <div className="flex items-start gap-4">
-                <div className="flex w-12 flex-shrink-0 justify-center">
+              <LegendEntry
+                icon={
                   <span className="inline-flex items-center gap-0.5 text-amber-500">
                     <span className="text-xs font-semibold">3</span>
                     <Lock className="h-4 w-4" />
                   </span>
-                </div>
-                <div>
-                  <p className="text-foreground font-medium">Friend Group</p>
-                  <p className="text-muted-foreground text-sm">
-                    Lock icon with number shows camper is in a friend group. The number indicates
-                    group size. Color matches the group's assigned color.
-                  </p>
-                </div>
-              </div>
+                }
+                title="Friend Group"
+              >
+                <p className="text-muted-foreground text-sm">
+                  Lock icon with number shows camper is in a friend group. The number indicates
+                  group size. Color matches the group's assigned color.
+                </p>
+              </LegendEntry>
 
-              {/* Pending Selection */}
-              <div className="flex items-start gap-4">
-                <div className="flex w-12 flex-shrink-0 justify-center">
+              <LegendEntry
+                icon={
                   <div className="pending-lock-glow h-6 w-10 rounded-lg border-2 border-amber-400 bg-amber-400/10" />
-                </div>
-                <div>
-                  <p className="text-foreground font-medium">Pending Selection</p>
-                  <p className="text-muted-foreground text-sm">
-                    Amber glowing border indicates camper is selected for a new friend group. Use
-                    Ctrl+Click to add more campers.
-                  </p>
-                </div>
-              </div>
+                }
+                title="Pending Selection"
+              >
+                <p className="text-muted-foreground text-sm">
+                  Amber glowing border indicates camper is selected for a new friend group. Use
+                  Ctrl+Click to add more campers.
+                </p>
+              </LegendEntry>
 
-              {/* Name Glow */}
-              <div className="flex items-start gap-4">
-                <div className="flex w-12 flex-shrink-0 justify-center">
+              <LegendEntry
+                icon={
                   <span
                     className="text-sm font-medium"
-                    style={{
-                      textShadow: '0 0 8px #10b981, 0 0 12px #10b98180',
-                    }}
+                    style={{ textShadow: '0 0 8px #10b981, 0 0 12px #10b98180' }}
                   >
                     Name
                   </span>
-                </div>
-                <div>
-                  <p className="text-foreground font-medium">Group Name Glow</p>
-                  <p className="text-muted-foreground text-sm">
-                    Camper names glow in their friend group's color for easy visual identification
-                  </p>
-                </div>
-              </div>
+                }
+                title="Group Name Glow"
+              >
+                <p className="text-muted-foreground text-sm">
+                  Camper names glow in their friend group's color for easy visual identification
+                </p>
+              </LegendEntry>
 
-              {/* Gender Card Color */}
-              <div className="flex items-start gap-4">
-                <div className="flex w-12 flex-shrink-0 items-center justify-center gap-1">
-                  <div className="h-5 w-3 rounded border-2 border-blue-300 bg-blue-100 dark:border-blue-700 dark:bg-blue-900/30" />
-                  <div className="h-5 w-3 rounded border-2 border-pink-300 bg-pink-100 dark:border-pink-700 dark:bg-pink-900/30" />
-                  <div className="h-5 w-3 rounded border-2 border-purple-300 bg-purple-100 dark:border-purple-700 dark:bg-purple-900/30" />
-                </div>
-                <div>
-                  <p className="text-foreground font-medium">Gender Card Color</p>
-                  <p className="text-muted-foreground text-sm">
-                    Card background color reflects gender identity: blue = boy/man, pink =
-                    girl/woman, purple = all other identities
-                  </p>
-                </div>
-              </div>
+              <LegendEntry
+                icon={
+                  <>
+                    <div className="h-5 w-3 rounded border-2 border-blue-300 bg-blue-100 dark:border-blue-700 dark:bg-blue-900/30" />
+                    <div className="h-5 w-3 rounded border-2 border-pink-300 bg-pink-100 dark:border-pink-700 dark:bg-pink-900/30" />
+                    <div className="h-5 w-3 rounded border-2 border-purple-300 bg-purple-100 dark:border-purple-700 dark:bg-purple-900/30" />
+                  </>
+                }
+                title="Gender Card Color"
+                iconClass="items-center gap-1"
+              >
+                <p className="text-muted-foreground text-sm">
+                  Card background color reflects gender identity: blue = boy/man, pink = girl/woman,
+                  purple = all other identities
+                </p>
+              </LegendEntry>
 
-              {/* Prior Year History */}
-              <div className="flex items-start gap-4">
-                <div className="flex w-12 flex-shrink-0 justify-center">
-                  <History className="text-muted-foreground h-5 w-5" />
-                </div>
-                <div>
-                  <p className="text-foreground font-medium">Prior-Year History</p>
-                  <p className="text-muted-foreground text-sm">
-                    Dim text on the right of the card shows where this camper bunked last year
-                    (e.g.&nbsp;"S1 B-4"). Blank if this is the camper's first year.
-                  </p>
-                </div>
-              </div>
+              <LegendEntry
+                icon={<History className="text-muted-foreground h-5 w-5" />}
+                title="Prior-Year History"
+              >
+                <p className="text-muted-foreground text-sm">
+                  Dim text on the right of the card shows where this camper bunked last year
+                  (e.g.&nbsp;"S1 B-4"). Blank if this is the camper's first year.
+                </p>
+              </LegendEntry>
             </div>
           </section>
 
@@ -146,113 +150,100 @@ export default function BunkingLegend({ isOpen, onClose }: BunkingLegendProps) {
               Bunk Indicators
             </h3>
             <div className="space-y-4">
-              {/* Capacity Bar */}
-              <div className="flex items-start gap-4">
-                <div className="flex w-12 flex-shrink-0 justify-center pt-1">
+              <LegendEntry
+                icon={
                   <div className="bg-muted h-2 w-10 overflow-hidden rounded-full">
                     <div className="bg-primary h-2 rounded-full" style={{ width: '60%' }} />
                   </div>
+                }
+                title="Capacity Bar"
+                iconClass="pt-1"
+              >
+                <p className="text-muted-foreground mb-2 text-sm">
+                  Shows beds filled with color-coded status:
+                </p>
+                <div className="flex flex-wrap gap-3 text-xs">
+                  <span className="inline-flex items-center gap-1.5">
+                    <span className="bg-primary h-2.5 w-2.5 rounded-full" />
+                    <span className="text-muted-foreground">&lt;70%</span>
+                  </span>
+                  <span className="inline-flex items-center gap-1.5">
+                    <span className="h-2.5 w-2.5 rounded-full bg-yellow-500" />
+                    <span className="text-muted-foreground">70-90%</span>
+                  </span>
+                  <span className="inline-flex items-center gap-1.5">
+                    <span className="h-2.5 w-2.5 rounded-full bg-orange-500" />
+                    <span className="text-muted-foreground">90-100%</span>
+                  </span>
+                  <span className="inline-flex items-center gap-1.5">
+                    <span className="bg-destructive h-2.5 w-2.5 rounded-full" />
+                    <span className="text-muted-foreground">Over</span>
+                  </span>
                 </div>
-                <div>
-                  <p className="text-foreground font-medium">Capacity Bar</p>
-                  <p className="text-muted-foreground mb-2 text-sm">
-                    Shows beds filled with color-coded status:
-                  </p>
-                  <div className="flex flex-wrap gap-3 text-xs">
-                    <span className="inline-flex items-center gap-1.5">
-                      <span className="bg-primary h-2.5 w-2.5 rounded-full" />
-                      <span className="text-muted-foreground">&lt;70%</span>
-                    </span>
-                    <span className="inline-flex items-center gap-1.5">
-                      <span className="h-2.5 w-2.5 rounded-full bg-yellow-500" />
-                      <span className="text-muted-foreground">70-90%</span>
-                    </span>
-                    <span className="inline-flex items-center gap-1.5">
-                      <span className="h-2.5 w-2.5 rounded-full bg-orange-500" />
-                      <span className="text-muted-foreground">90-100%</span>
-                    </span>
-                    <span className="inline-flex items-center gap-1.5">
-                      <span className="bg-destructive h-2.5 w-2.5 rounded-full" />
-                      <span className="text-muted-foreground">Over</span>
-                    </span>
-                  </div>
-                </div>
-              </div>
+              </LegendEntry>
 
-              {/* Social Graph Button */}
-              <div className="flex items-start gap-4">
-                <div className="flex w-12 flex-shrink-0 justify-center">
+              <LegendEntry
+                icon={
                   <div className="bg-muted flex h-8 w-8 items-center justify-center rounded-lg">
                     <Network className="text-muted-foreground h-4 w-4" />
                   </div>
-                </div>
-                <div>
-                  <p className="text-foreground font-medium">Social Graph</p>
-                  <p className="text-muted-foreground text-sm">
-                    Opens a network visualization showing friendship requests between campers in
-                    this bunk. Green edges = mutual requests, amber = one-way.
-                  </p>
-                </div>
-              </div>
+                }
+                title="Social Graph"
+              >
+                <p className="text-muted-foreground text-sm">
+                  Opens a network visualization showing friendship requests between campers in this
+                  bunk. Green edges = mutual requests, amber = one-way.
+                </p>
+              </LegendEntry>
 
-              {/* Bunk Warnings */}
-              <div className="flex items-start gap-4">
-                <div className="flex w-12 flex-shrink-0 justify-center">
+              <LegendEntry
+                icon={
                   <div className="border-destructive/50 bg-destructive/5 flex h-8 w-10 items-center justify-center rounded-lg border-2">
                     <span className="text-sm">⚠️</span>
                   </div>
-                </div>
-                <div>
-                  <p className="text-foreground font-medium">Bunk Warnings</p>
-                  <p className="text-muted-foreground mb-2 text-sm">Red border indicates issues:</p>
-                  <ul className="text-muted-foreground space-y-1 text-sm">
-                    <li className="flex items-center gap-2">
-                      <span className="bg-muted-foreground h-1 w-1 rounded-full" />
-                      Over capacity (exceeds bunk's configured capacity)
-                    </li>
-                    <li className="flex items-center gap-2">
-                      <span className="bg-muted-foreground h-1 w-1 rounded-full" />
-                      Age spread exceeds 24 months
-                    </li>
-                    <li className="flex items-center gap-2">
-                      <span className="bg-muted-foreground h-1 w-1 rounded-full" />
-                      Grade ratio exceeds 67% from one grade
-                    </li>
-                    <li className="flex items-center gap-2">
-                      <span className="bg-muted-foreground h-1 w-1 rounded-full" />
-                      More than 2 different grades in bunk
-                    </li>
-                  </ul>
-                </div>
-              </div>
+                }
+                title="Bunk Warnings"
+              >
+                <p className="text-muted-foreground mb-2 text-sm">Red border indicates issues:</p>
+                <ul className="text-muted-foreground space-y-1 text-sm">
+                  <li className="flex items-center gap-2">
+                    <span className="bg-muted-foreground h-1 w-1 rounded-full" />
+                    Over capacity (exceeds bunk's configured capacity)
+                  </li>
+                  <li className="flex items-center gap-2">
+                    <span className="bg-muted-foreground h-1 w-1 rounded-full" />
+                    Age spread exceeds 24 months
+                  </li>
+                  <li className="flex items-center gap-2">
+                    <span className="bg-muted-foreground h-1 w-1 rounded-full" />
+                    Grade ratio exceeds 67% from one grade
+                  </li>
+                  <li className="flex items-center gap-2">
+                    <span className="bg-muted-foreground h-1 w-1 rounded-full" />
+                    More than 2 different grades in bunk
+                  </li>
+                </ul>
+              </LegendEntry>
 
-              {/* Active Drop Target */}
-              <div className="flex items-start gap-4">
-                <div className="flex w-12 flex-shrink-0 justify-center">
-                  <div className="ring-primary bg-primary/5 h-8 w-10 rounded-lg ring-2" />
-                </div>
-                <div>
-                  <p className="text-foreground font-medium">Active Drop Target</p>
-                  <p className="text-muted-foreground text-sm">
-                    Primary-colored ring highlights the bunk currently being dragged over, showing
-                    it will accept the camper on release
-                  </p>
-                </div>
-              </div>
+              <LegendEntry
+                icon={<div className="ring-primary bg-primary/5 h-8 w-10 rounded-lg ring-2" />}
+                title="Active Drop Target"
+              >
+                <p className="text-muted-foreground text-sm">
+                  Primary-colored ring highlights the bunk currently being dragged over, showing it
+                  will accept the camper on release
+                </p>
+              </LegendEntry>
 
-              {/* Invalid Drop Target */}
-              <div className="flex items-start gap-4">
-                <div className="flex w-12 flex-shrink-0 justify-center">
-                  <div className="bg-muted/50 h-8 w-10 rounded-lg opacity-40" />
-                </div>
-                <div>
-                  <p className="text-foreground font-medium">Invalid Drop Target</p>
-                  <p className="text-muted-foreground text-sm">
-                    Grayed out bunks cannot accept the camper being dragged (wrong gender or grade
-                    mismatch for AG sessions)
-                  </p>
-                </div>
-              </div>
+              <LegendEntry
+                icon={<div className="bg-muted/50 h-8 w-10 rounded-lg opacity-40" />}
+                title="Invalid Drop Target"
+              >
+                <p className="text-muted-foreground text-sm">
+                  Grayed out bunks cannot accept the camper being dragged (wrong gender or grade
+                  mismatch for AG sessions)
+                </p>
+              </LegendEntry>
             </div>
           </section>
 
@@ -263,37 +254,33 @@ export default function BunkingLegend({ isOpen, onClose }: BunkingLegendProps) {
               Working Modes
             </h3>
             <div className="space-y-4">
-              {/* Scenario Badge */}
-              <div className="flex items-start gap-4">
-                <div className="flex w-12 flex-shrink-0 justify-center">
+              <LegendEntry
+                icon={
                   <span className="inline-flex items-center gap-1 rounded-lg border border-emerald-300 bg-emerald-100 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:border-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300">
                     Draft
                   </span>
-                </div>
-                <div>
-                  <p className="text-foreground font-medium">Scenario Mode</p>
-                  <p className="text-muted-foreground text-sm">
-                    Working in a draft scenario. Drag-and-drop is enabled. Changes won't affect live
-                    assignments until published.
-                  </p>
-                </div>
-              </div>
+                }
+                title="Scenario Mode"
+              >
+                <p className="text-muted-foreground text-sm">
+                  Working in a draft scenario. Drag-and-drop is enabled. Changes won't affect live
+                  assignments until published.
+                </p>
+              </LegendEntry>
 
-              {/* Production Mode */}
-              <div className="flex items-start gap-4">
-                <div className="flex w-12 flex-shrink-0 justify-center">
+              <LegendEntry
+                icon={
                   <span className="inline-flex items-center gap-1 rounded-lg border border-amber-300 bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700 dark:border-amber-700 dark:bg-amber-950/50 dark:text-amber-300">
                     Live
                   </span>
-                </div>
-                <div>
-                  <p className="text-foreground font-medium">Production Mode</p>
-                  <p className="text-muted-foreground text-sm">
-                    Viewing live CampMinder data. Drag-and-drop is disabled. Select a scenario or
-                    create a new one to make edits.
-                  </p>
-                </div>
-              </div>
+                }
+                title="Production Mode"
+              >
+                <p className="text-muted-foreground text-sm">
+                  Viewing live CampMinder data. Drag-and-drop is disabled. Select a scenario or
+                  create a new one to make edits.
+                </p>
+              </LegendEntry>
             </div>
           </section>
         </div>

--- a/frontend/src/components/BunkingLegend.tsx
+++ b/frontend/src/components/BunkingLegend.tsx
@@ -234,8 +234,8 @@ export default function BunkingLegend({ isOpen, onClose }: BunkingLegendProps) {
                 <div>
                   <p className="text-foreground font-medium">Active Drop Target</p>
                   <p className="text-muted-foreground text-sm">
-                    Blue ring highlights the bunk currently being dragged over, showing it will
-                    accept the camper on release
+                    Primary-colored ring highlights the bunk currently being dragged over, showing
+                    it will accept the camper on release
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

- **Added**: Gender-coded card backgrounds entry (blue = boy/man, pink = girl/woman, purple = other identities) — `CamperCard` applies these from `getGenderColorClasses()` but the legend had no entry for them
- **Added**: Prior-Year History indicator entry — `CamperCard` renders last year's session/bunk (e.g. "S1 B-4") as dim trailing text but the legend never documented it
- **Added**: Active Drop Target highlight entry — `BunkCard` shows a blue ring (`ring-primary ring-2`) when a camper is dragged over it; only the *invalid* (greyed-out) state was documented, not the *valid* hover state
- **Fixed**: Bunk Warnings copy said "more than 12 campers" — capacity is configurable, not hardcoded; changed to "exceeds bunk's configured capacity"
- **Added**: `BunkingLegend.test.tsx` — smoke test that asserts every icon-key the board renders has a legend entry; fails if someone adds a new indicator without updating the legend (15 tests, all pass)

## Gap analysis method

Read `CamperCard.tsx`, `BunkCard.tsx`, `BunkUtilizationBar.tsx`, `BunkWarnings.tsx`, and `genderUtils.ts` end-to-end; compared every conditional render against legend entries.

## Test plan

- [x] `npx vitest run src/components/BunkingLegend.test.tsx` — 15 tests, all pass
- [x] `tsc --noEmit` — no type errors
- [x] ESLint (`node_modules/.bin/eslint`) — no warnings
- [x] Pre-push verification script — all checks pass

## Manual validation (dev/preview)

Scoreboard item covered: **#20** — Bunking board legend audit

- [ ] Open the Bunking Board. Click the Legend (info) icon.
- [ ] Verify legend has entries for: Gender Card Color (blue / pink / purple), Prior-Year History, Active Drop Target, Invalid Drop Target.
- [ ] Verify the Bunk Warnings entry reads "exceeds bunk's configured capacity" (not a hardcoded "12").
- [ ] Drag a camper card over a valid bunk: a primary-colored ring appears on the target. Legend's "Active Drop Target" entry describes this.
- [ ] Drag a camper card over an invalid bunk: it's greyed out. Legend's "Invalid Drop Target" entry describes this.
- [ ] Close and reopen the legend — no layout regressions, all entries still render.