### PR TITLE
feat(docker): harden Caddy for VPS (CF Tunnel + Access)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,7 +106,13 @@ ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
 # Regex form of ALLOWED_ORIGINS for Caddy's CORS matcher.
 # Pipe-separated, regex-escaped; case-insensitive match is applied by Caddy.
 # Empty = CORS off in Caddy (FastAPI still applies its own CORS from ALLOWED_ORIGINS).
-# Example: ALLOWED_ORIGINS_REGEX=https://camp\.flagg\.cloud|https://.*\.dadtired\.blog|chrome-extension://abcd1234
+#
+# WARNING: Caddy's CORS snippet pairs Allow-Credentials: true with the
+# reflected Origin on any match. NEVER use a catch-all pattern (e.g. .*) —
+# combined with credentialed reflection, that's a CORS vulnerability. List
+# explicit origins only.
+#
+# Example: ALLOWED_ORIGINS_REGEX=https://app\.yourdomain\.com|https://admin\.yourdomain\.com
 ALLOWED_ORIGINS_REGEX=
 
 # Session Configuration

--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,12 @@ ADMIN_GROUP_NAME=admin
 # Example: https://bunking.yourdomain.com,https://app.yourdomain.com
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
 
+# Regex form of ALLOWED_ORIGINS for Caddy's CORS matcher.
+# Pipe-separated, regex-escaped; case-insensitive match is applied by Caddy.
+# Empty = CORS off in Caddy (FastAPI still applies its own CORS from ALLOWED_ORIGINS).
+# Example: ALLOWED_ORIGINS_REGEX=https://camp\.flagg\.cloud|https://.*\.dadtired\.blog|chrome-extension://abcd1234
+ALLOWED_ORIGINS_REGEX=
+
 # Session Configuration
 # Generate a secure random string for SESSION_SECRET in production
 SESSION_SECRET=your-secure-session-secret-here

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         persist-credentials: false
 
     - name: Setup Node.js
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version: '22'
 
@@ -259,7 +259,7 @@ jobs:
         persist-credentials: false
 
     - name: Setup Node.js
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version: '22'
         cache: 'npm'
@@ -345,7 +345,7 @@ jobs:
         persist-credentials: false
 
     - name: Setup Node.js
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version: '22'
         cache: 'npm'
@@ -392,7 +392,8 @@ jobs:
           docker run --rm -i -v "$PWD/.hadolint.yaml:/.hadolint.yaml" hadolint/hadolint < "$df"
         done
 
-    # Caddyfile validation (stdin, no mounts - avoids self-hosted runner volume mount issues)
+    # Caddyfile validation (stdin, no mounts - avoids self-hosted runner volume mount issues).
+    # Both Caddyfiles use only stock directives now (rate-limit delegated to Traefik).
     - name: Caddyfile validation
       run: |
         docker run --rm -i caddy:2 caddy adapt --adapter caddyfile --config - < docker/Caddyfile > /dev/null
@@ -447,7 +448,7 @@ jobs:
         enable-cache: true
 
     - name: Setup Node.js
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version: '22'
         cache: 'npm'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,6 +126,12 @@ services:
     environment:
       - POCKETBASE_HOST=${POCKETBASE_HOST:-pocketbase}
       - API_HOST=${API_HOST:-api}
+      # Required by docker/Caddyfile's (cors) snippet. Without propagation here
+      # the placeholder substitutes empty, the regex becomes ^(?i)()$, no Origin
+      # matches, and Caddy's CORS layer is silently inert. FastAPI still applies
+      # its own CORS, so the app isn't broken — but the defense-in-depth Caddy
+      # layer never fires. Set in .env (see .env.example).
+      - ALLOWED_ORIGINS_REGEX=${ALLOWED_ORIGINS_REGEX:-}
     tmpfs:
       - /tmp:size=8m,uid=65532,gid=65532
       - /app/.config/caddy:size=8m,uid=65532,gid=65532

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,8 +1,16 @@
-# Production Caddyfile for multi-container deployment
+# Production Caddyfile for multi-container deployment.
+# Sits behind Traefik on the VPS (and historically behind Traefik on Unraid).
+# Traefik terminates TLS, runs WAF/rate-limit, and forwards over the local
+# Docker network. Cloudflare Tunnel + Access front Traefik at the edge.
+#
 # Routes to upstream services via env vars (with defaults for compose service names):
 #   POCKETBASE_HOST (default: pocketbase) → port 8090
 #   API_HOST (default: api) → port 8000
-# Frontend static files served directly by Caddy from /pb_public
+#
+# Transport-layer concerns kept here (rest delegated to Traefik / CF):
+#   - trusted_proxies private_ranges  → real client IP from X-Forwarded-For
+#   - security_headers snippet        → defense-in-depth; harmless if Traefik also sets them
+#   - cors snippet                    → app-layer; lives near the API/PB split
 #
 # Note on logging:
 # - Console format: TIMESTAMP LEVEL LOGGER MESSAGE (Caddy's fixed format)
@@ -11,6 +19,18 @@
 # - TZ=UTC in Dockerfile ensures UTC timestamps
 {
 	admin off
+
+	# Traefik (or cloudflared in legacy deploys) is the immediate upstream on
+	# the local Docker network. Trust private ranges so {client_ip} and logs
+	# reflect the real origin IP from X-Forwarded-For, not the proxy peer.
+	# Safe because the VPS is port-closed with ufw; there is no untrusted
+	# internal network. Required for downstream features (e.g. /_/ IP gate)
+	# that key on {client_ip}.
+	servers {
+		trusted_proxies static private_ranges
+		client_ip_headers X-Forwarded-For
+	}
+
 	log {
 		format console {
 			time_format iso8601
@@ -19,7 +39,42 @@
 	}
 }
 
+# Traefik's secure-headers middleware equivalent. X-XSS-Protection is omitted
+# on purpose — modern browsers ignore the legacy header. Server response
+# header is stripped so we don't leak the upstream identity.
+(security_headers) {
+	header {
+		Strict-Transport-Security "max-age=63072000; includeSubDomains"
+		X-Frame-Options "SAMEORIGIN"
+		X-Content-Type-Options "nosniff"
+		Referrer-Policy "same-origin"
+		Permissions-Policy "accelerometer=(),camera=(),geolocation=(self),gyroscope=(),magnetometer=(),microphone=(),payment=(),usb=()"
+		X-Robots-Tag "none,noarchive,nosnippet,notranslate,noimageindex"
+		-Server
+	}
+}
+
+# CORS layer on top of whatever the upstream sets. Matches the request Origin
+# against ALLOWED_ORIGINS_REGEX (pipe-separated, regex-escaped). Empty env
+# var = no origin matches = CORS effectively off in Caddy. FastAPI continues
+# to read ALLOWED_ORIGINS independently for its own CORS needs.
+(cors) {
+	@cors_origin header_regexp Origin ^(?i)({$ALLOWED_ORIGINS_REGEX})$
+	header @cors_origin {
+		Access-Control-Allow-Origin "{http.request.header.Origin}"
+		Access-Control-Allow-Credentials "true"
+		Vary "Origin"
+	}
+}
+
 :8080 {
+	import security_headers
+	import cors
+
+	# Compression and rate-limiting are handled by Traefik upstream of this
+	# Caddy. Adding them here would double-count rate-limit buckets and
+	# duplicate Traefik's compression for no gain.
+
 	# PocketBase-specific patterns (explicit)
 	# These /api/* routes go to PocketBase (port 8090)
 	# Note: Must include both root paths and wildcards (e.g., /api/collections AND /api/collections/*)

--- a/docker/Dockerfile.caddy
+++ b/docker/Dockerfile.caddy
@@ -30,6 +30,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o healthcheck .
 # =============================================================================
 # Stage 3: Distroless runtime
 # =============================================================================
+# Stock Caddy binary — no custom modules required (rate-limiting is delegated
+# to Traefik upstream).
 FROM chainguard/static:latest
 
 COPY --from=dhi.io/caddy:2 /usr/local/bin/caddy /usr/local/bin/caddy


### PR DESCRIPTION
## Summary

Adds the bits of transport-layer config that need to live at Caddy when the stack runs behind Traefik on the VPS:

- `trusted_proxies static private_ranges` + `client_ip_headers X-Forwarded-For` so `{client_ip}` and logs reflect the real origin IP (Traefik forwards from the local Docker network). Required by downstream features that key on `{client_ip}` — e.g. the `/_/*` IP gate in #1139.
- Standard security response headers (HSTS `max-age=2y; includeSubDomains` without `preload`, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, X-Robots-Tag) and stripped `Server`. Defense-in-depth — harmless if Traefik also sets them.
- CORS layer driven by a new `ALLOWED_ORIGINS_REGEX` env var (pipe-separated, regex-escaped; empty = CORS off in Caddy; the API keeps its own `ALLOWED_ORIGINS`).

## What's intentionally NOT here

Edge concerns are delegated to Traefik (which sits between CF Tunnel and this Caddy on the VPS):

- **Rate limiting** — Traefik already enforces it; doing it here too would double-count buckets against the same client.
- **Compression (`encode zstd gzip`)** — Traefik handles it upstream.
- **WAF / IP allowlists / ForwardAuth** — handled at Cloudflare and Traefik.

Because rate-limiting is gone, the xcaddy build is also gone; the Caddy image is back to stock `caddy:2`.

## Deploy-time requirement

The production host must keep external inbound closed at the firewall — the `private_ranges` trust assumes Traefik on the local Docker network is the only ingress. If that ever changes, revisit `trusted_proxies`.

## Stacked PR

#1139 (OAuth2 redirect rewrite + `/_/*` IP gate, closes #1100) is stacked on this branch and depends on the `client_ip_headers` config landed here.

## Test plan

- [ ] CI passes (Caddyfile validation now uses stock `caddy:2` for both files)
- [ ] After deploy: `curl -I` against the public URL shows the 6 hardening headers and no `Server:`
- [ ] After deploy: access logs show real client IPs (not Traefik's docker-net peer IP)
- [ ] After deploy: CORS works for browser clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)