### PR TITLE
fix(deps): declare tzdata directly to unblock CD

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "ortools @ https://github.com/google/or-tools/releases/download/v9.15/ortools-9.15.6755-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
     # Data processing
     "pandas>=3.0.2",
+    "tzdata>=2026.1",
     "numpy>=1.26.0",
     "networkx>=3.0",
     "python-louvain>=0.16",

--- a/uv.lock
+++ b/uv.lock
@@ -677,6 +677,7 @@ dependencies = [
     { name = "rich" },
     { name = "tqdm" },
     { name = "typer" },
+    { name = "tzdata" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -727,6 +728,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0.0" },
     { name = "tqdm", specifier = ">=4.65.0" },
     { name = "typer", specifier = ">=0.12.0" },
+    { name = "tzdata", specifier = ">=2026.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.44.0" },
 ]
 


### PR DESCRIPTION
## Summary
- `pandas>=3.0.2` (#963) scoped its `tzdata` dep to `sys_platform == 'emscripten' or sys_platform == 'win32'`, so `tzdata` stopped being installed on Linux.
- The Wolfi-based `kindred-api` image has no OS-level tzdata either, so `ZoneInfo("America/Los_Angeles")` in `api/services/camp_calendar.py:18` raises `ZoneInfoNotFoundError` at import time.
- The container healthcheck then fails, the CD smoke-up step times out, and main CD has been red since #963 landed — blocking releases.
- Fix: declare `tzdata>=2026.1` as a direct runtime dependency.

## Test plan
- [ ] CD green on this branch
- [ ] `kindred-api` container reaches healthy state in CD smoke-up