### PR TITLE
fix(frontend): surface resolved request targets and decline reasons in sidebar modal

### DIFF
--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '../test/testUtils'
 import CamperDetailsPanel from './CamperDetailsPanel'
+import { mockPerson } from '../test/mockData'
 
 // Configurable per-collection mock factories
 const mockGetFullListPersons = vi.fn()
@@ -59,23 +60,10 @@ vi.mock('../hooks/useCurrentYear', () => ({
 // ---------------------------------------------------------------------------
 
 /** A minimal persons record for Emma Johnson, cm_id=100 */
-const EMMA: Record<string, unknown> = {
-  id: 'pb-emma',
-  cm_id: 100,
-  first_name: 'Emma',
-  last_name: 'Johnson',
-  gender: 'F',
-  grade: 6,
-  year: 2025,
-  household_id: 0,
-  collectionId: 'persons',
-  collectionName: 'persons',
-  created: '2025-01-01T00:00:00Z',
-  updated: '2025-01-01T00:00:00Z',
-}
+const EMMA = mockPerson({ id: 'pb-emma', cm_id: 100, grade: 6, year: 2025, household_id: 0 })
 
 /** Liam Garcia is the bunk-request target (different session, so declined) */
-const LIAM: Record<string, unknown> = {
+const LIAM = mockPerson({
   id: 'pb-liam',
   cm_id: 201,
   first_name: 'Liam',
@@ -84,11 +72,7 @@ const LIAM: Record<string, unknown> = {
   grade: 6,
   year: 2025,
   household_id: 0,
-  collectionId: 'persons',
-  collectionName: 'persons',
-  created: '2025-01-01T00:00:00Z',
-  updated: '2025-01-01T00:00:00Z',
-}
+})
 
 /** Emma's declined bunk-with request targeting Liam Garcia (different session) */
 const DECLINED_REQUEST: Record<string, unknown> = {
@@ -144,11 +128,9 @@ function setupDeclinedRequestMocks() {
   // Second call: look up requestees by cm_id (filter includes requestee cm_id list)
   mockGetFullListPersons.mockImplementation((opts: { filter?: string }) => {
     const filter = opts.filter ?? ''
-    if (filter.includes('cm_id = 201')) {
-      // requestee lookup
+    if (filter.includes(`cm_id = ${LIAM.cm_id}`)) {
       return Promise.resolve([LIAM])
     }
-    // main camper lookup
     return Promise.resolve([EMMA])
   })
   mockGetFullListAttendees.mockResolvedValue([EMMA_ATTENDEE])

--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -13,7 +13,7 @@ const mockGetFullListPersons = vi.fn()
 const mockGetFullListAttendees = vi.fn()
 const mockGetFullListBunkAssignments = vi.fn()
 const mockGetFullListBunkRequests = vi.fn()
-const mockGetFullListOriginalBunkRequests = vi.fn()
+const mockGetListOriginalBunkRequests = vi.fn()
 const mockGetListPersons = vi.fn()
 
 // Mock the pocketbase module with per-collection dispatch
@@ -33,7 +33,7 @@ vi.mock('../lib/pocketbase', () => ({
         case 'bunk_requests':
           return { getFullList: mockGetFullListBunkRequests }
         case 'original_bunk_requests':
-          return { getList: mockGetFullListOriginalBunkRequests }
+          return { getList: mockGetListOriginalBunkRequests }
         default:
           return {
             getFullList: vi.fn().mockResolvedValue([]),
@@ -143,7 +143,7 @@ function setupDeclinedRequestMocks() {
   // First call: look up the main camper by cm_id (filter includes person cm_id)
   // Second call: look up requestees by cm_id (filter includes requestee cm_id list)
   mockGetFullListPersons.mockImplementation((opts: { filter?: string }) => {
-    const filter = opts?.filter ?? ''
+    const filter = opts.filter ?? ''
     if (filter.includes('cm_id = 201')) {
       // requestee lookup
       return Promise.resolve([LIAM])
@@ -155,7 +155,7 @@ function setupDeclinedRequestMocks() {
   mockGetFullListBunkAssignments.mockResolvedValue([])
   mockGetFullListBunkRequests.mockResolvedValue([DECLINED_REQUEST])
   mockGetListPersons.mockResolvedValue({ items: [], totalItems: 0 })
-  mockGetFullListOriginalBunkRequests.mockResolvedValue({ items: [], totalItems: 0 })
+  mockGetListOriginalBunkRequests.mockResolvedValue({ items: [], totalItems: 0 })
 }
 
 describe('CamperDetailsPanel', () => {
@@ -169,7 +169,7 @@ describe('CamperDetailsPanel', () => {
     mockGetFullListBunkAssignments.mockResolvedValue([])
     mockGetFullListBunkRequests.mockResolvedValue([])
     mockGetListPersons.mockResolvedValue({ items: [], totalItems: 0 })
-    mockGetFullListOriginalBunkRequests.mockResolvedValue({ items: [], totalItems: 0 })
+    mockGetListOriginalBunkRequests.mockResolvedValue({ items: [], totalItems: 0 })
   })
 
   describe('Loading and Error States', () => {
@@ -308,7 +308,7 @@ describe('CamperDetailsPanel', () => {
 
       // formatReason('session_mismatch') === 'Different sessions'
       await waitFor(() => {
-        expect(screen.getByText(/Different sessions/i)).toBeInTheDocument()
+        expect(screen.getByText(/·\s*Different sessions$/)).toBeInTheDocument()
       })
     })
 

--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -8,13 +8,39 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '../test/testUtils'
 import CamperDetailsPanel from './CamperDetailsPanel'
 
-// Mock the pocketbase module
+// Configurable per-collection mock factories
+const mockGetFullListPersons = vi.fn()
+const mockGetFullListAttendees = vi.fn()
+const mockGetFullListBunkAssignments = vi.fn()
+const mockGetFullListBunkRequests = vi.fn()
+const mockGetFullListOriginalBunkRequests = vi.fn()
+const mockGetListPersons = vi.fn()
+
+// Mock the pocketbase module with per-collection dispatch
 vi.mock('../lib/pocketbase', () => ({
   pb: {
-    collection: vi.fn(() => ({
-      getFullList: vi.fn().mockResolvedValue([]),
-      getList: vi.fn().mockResolvedValue({ items: [], totalItems: 0 }),
-    })),
+    collection: vi.fn((name: string) => {
+      switch (name) {
+        case 'persons':
+          return {
+            getFullList: mockGetFullListPersons,
+            getList: mockGetListPersons,
+          }
+        case 'attendees':
+          return { getFullList: mockGetFullListAttendees }
+        case 'bunk_assignments':
+          return { getFullList: mockGetFullListBunkAssignments }
+        case 'bunk_requests':
+          return { getFullList: mockGetFullListBunkRequests }
+        case 'original_bunk_requests':
+          return { getList: mockGetFullListOriginalBunkRequests }
+        default:
+          return {
+            getFullList: vi.fn().mockResolvedValue([]),
+            getList: vi.fn().mockResolvedValue({ items: [], totalItems: 0 }),
+          }
+      }
+    }),
     authStore: {
       isValid: true,
       token: 'mock-token',
@@ -28,11 +54,122 @@ vi.mock('../hooks/useCurrentYear', () => ({
   useYear: () => 2025,
 }))
 
+// ---------------------------------------------------------------------------
+// Shared fixture data (fictional names per CLAUDE.md)
+// ---------------------------------------------------------------------------
+
+/** A minimal persons record for Emma Johnson, cm_id=100 */
+const EMMA: Record<string, unknown> = {
+  id: 'pb-emma',
+  cm_id: 100,
+  first_name: 'Emma',
+  last_name: 'Johnson',
+  gender: 'F',
+  grade: 6,
+  year: 2025,
+  household_id: 0,
+  collectionId: 'persons',
+  collectionName: 'persons',
+  created: '2025-01-01T00:00:00Z',
+  updated: '2025-01-01T00:00:00Z',
+}
+
+/** Liam Garcia is the bunk-request target (different session, so declined) */
+const LIAM: Record<string, unknown> = {
+  id: 'pb-liam',
+  cm_id: 201,
+  first_name: 'Liam',
+  last_name: 'Garcia',
+  gender: 'M',
+  grade: 6,
+  year: 2025,
+  household_id: 0,
+  collectionId: 'persons',
+  collectionName: 'persons',
+  created: '2025-01-01T00:00:00Z',
+  updated: '2025-01-01T00:00:00Z',
+}
+
+/** Emma's declined bunk-with request targeting Liam Garcia (different session) */
+const DECLINED_REQUEST: Record<string, unknown> = {
+  id: 'req-declined-1',
+  requester_id: 100,
+  requestee_id: 201,
+  request_type: 'bunk_with',
+  status: 'declined',
+  priority: 1,
+  requested_person_name: 'Liam Garcia',
+  disposition_reason: 'session_mismatch',
+  year: 2025,
+  session_id: 1001,
+  is_reciprocal: false,
+  confidence_score: 0.92,
+  source_field: 'share_bunk_with',
+  created: '2025-01-01T00:00:00Z',
+  updated: '2025-01-01T00:00:00Z',
+  collectionId: 'bunk_requests',
+  collectionName: 'bunk_requests',
+  metadata: {},
+}
+
+/** A minimal attendee record for Emma */
+const EMMA_ATTENDEE: Record<string, unknown> = {
+  id: 'att-emma',
+  person: 'pb-emma',
+  person_id: 100,
+  session: 'sess-1',
+  status: 'enrolled',
+  status_id: 2,
+  year: 2025,
+  collectionId: 'attendees',
+  collectionName: 'attendees',
+  created: '2025-01-01T00:00:00Z',
+  updated: '2025-01-01T00:00:00Z',
+  expand: {
+    session: {
+      id: 'sess-1',
+      cm_id: 1001,
+      name: 'Session 1',
+      session_type: 'main',
+    },
+  },
+}
+
+/**
+ * Set up per-collection mocks for a camper (Emma) with one declined request.
+ * Persons is called twice: first for the main camper, then for the requestees.
+ */
+function setupDeclinedRequestMocks() {
+  // First call: look up the main camper by cm_id (filter includes person cm_id)
+  // Second call: look up requestees by cm_id (filter includes requestee cm_id list)
+  mockGetFullListPersons.mockImplementation((opts: { filter?: string }) => {
+    const filter = opts?.filter ?? ''
+    if (filter.includes('cm_id = 201')) {
+      // requestee lookup
+      return Promise.resolve([LIAM])
+    }
+    // main camper lookup
+    return Promise.resolve([EMMA])
+  })
+  mockGetFullListAttendees.mockResolvedValue([EMMA_ATTENDEE])
+  mockGetFullListBunkAssignments.mockResolvedValue([])
+  mockGetFullListBunkRequests.mockResolvedValue([DECLINED_REQUEST])
+  mockGetListPersons.mockResolvedValue({ items: [], totalItems: 0 })
+  mockGetFullListOriginalBunkRequests.mockResolvedValue({ items: [], totalItems: 0 })
+}
+
 describe('CamperDetailsPanel', () => {
   const mockOnClose = vi.fn()
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // Default: empty responses for all collections
+    mockGetFullListPersons.mockResolvedValue([])
+    mockGetFullListAttendees.mockResolvedValue([])
+    mockGetFullListBunkAssignments.mockResolvedValue([])
+    mockGetFullListBunkRequests.mockResolvedValue([])
+    mockGetListPersons.mockResolvedValue({ items: [], totalItems: 0 })
+    mockGetFullListOriginalBunkRequests.mockResolvedValue({ items: [], totalItems: 0 })
   })
 
   describe('Loading and Error States', () => {
@@ -142,6 +279,63 @@ describe('CamperDetailsPanel', () => {
       // Escape should not trigger close in embedded mode
       fireEvent.keyDown(document, { key: 'Escape' })
       expect(mockOnClose).not.toHaveBeenCalled()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Regression: sidebar (embedded) panel shows resolved target + decline reason
+  // Spec item #50 — previously the embedded code path hit a temporal-dead-zone
+  // ReferenceError on `nonAgeRequests` because it was declared after the early
+  // embedded-mode `return`. The fix moves those declarations up.
+  // ---------------------------------------------------------------------------
+  describe('Bunk request display in embedded (sidebar) mode', () => {
+    it('renders the target camper name (not "Unknown") for a declined request in embedded mode', async () => {
+      setupDeclinedRequestMocks()
+
+      render(<CamperDetailsPanel camperId="100" onClose={mockOnClose} embedded={true} />)
+
+      // Wait for camper data to load and the requests section to appear
+      await waitFor(() => {
+        // "Liam Garcia" is the requestee — should be visible, not "Unknown"
+        expect(screen.getByText('Liam Garcia')).toBeInTheDocument()
+      })
+    })
+
+    it('renders the human-readable decline reason for a declined request in embedded mode', async () => {
+      setupDeclinedRequestMocks()
+
+      render(<CamperDetailsPanel camperId="100" onClose={mockOnClose} embedded={true} />)
+
+      // formatReason('session_mismatch') === 'Different sessions'
+      await waitFor(() => {
+        expect(screen.getByText(/Different sessions/i)).toBeInTheDocument()
+      })
+    })
+
+    it('does not show "Unknown" as the target name for a declined request in embedded mode', async () => {
+      setupDeclinedRequestMocks()
+
+      render(<CamperDetailsPanel camperId="100" onClose={mockOnClose} embedded={true} />)
+
+      // The panel must load first — wait for the camper's name to appear.
+      // The h2 renders first_name and last_name as separate text nodes so we
+      // use a heading role matcher to find the element.
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Emma/i })).toBeInTheDocument()
+      })
+
+      // "Unknown" must not appear as a camper-name stand-in
+      expect(screen.queryByText('Unknown')).not.toBeInTheDocument()
+    })
+
+    it('renders the bunk-with request label alongside the target in embedded mode', async () => {
+      setupDeclinedRequestMocks()
+
+      render(<CamperDetailsPanel camperId="100" onClose={mockOnClose} embedded={true} />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Bunk with')).toBeInTheDocument()
+      })
     })
   })
 })

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -690,6 +690,15 @@ export default function CamperDetailsPanel({
     }
   )
 
+  // Derived request lists — declared here so renderContent() (defined below)
+  // and the embedded early-return both see them. Previously these were declared
+  // after the embedded-mode return, causing a TDZ ReferenceError in that path.
+  const nonAgeRequests = bunkRequests.filter((r) => r.request_type !== 'age_preference')
+  const hasOtherRequests = nonAgeRequests.length > 0
+  const ageSatisfaction = agePreferenceRequest
+    ? satisfactionData[agePreferenceRequest.id]
+    : undefined
+
   // Loading state
   if (camperLoading) {
     return embedded ? (
@@ -1254,13 +1263,6 @@ export default function CamperDetailsPanel({
       </div>
     )
   }
-
-  // Derived request lists (used in the bunk requests section of the render)
-  const nonAgeRequests = bunkRequests.filter((r) => r.request_type !== 'age_preference')
-  const hasOtherRequests = nonAgeRequests.length > 0
-  const ageSatisfaction = agePreferenceRequest
-    ? satisfactionData[agePreferenceRequest.id]
-    : undefined
 
   // Slide-in panel with semi-transparent backdrop for click-outside close
   // Uses CSS animations instead of transitions for React Compiler compatibility


### PR DESCRIPTION
## Summary

Resolves feedback item **#50** — "Camper sidebar modal shows stale request-target data."

The embedded (sidebar) code path in `CamperDetailsPanel` called `renderContent()` before `nonAgeRequests`, `hasOtherRequests`, and `ageSatisfaction` were declared. These three variables were declared after the early embedded-mode `return`, so the function hit a JavaScript temporal-dead-zone `ReferenceError` and rendered a blank requests section when the panel was in embedded/sidebar mode.

Root cause: same underlying data as #9 / PR #975 — the fix there landed for `BunkRequestRow` and `CamperRequestSummary`, but the embedded sidebar was silently broken by the variable-ordering bug.

Fix: moves those three declarations above the embedded early-return (right after the `satisfactionData` query) so both the slide-in panel and the embedded sidebar see them. No logic changed — just hoisting declarations to fix ordering.

Result: the sidebar now uses the same `BunkRequestRow` + `hasMatchedRequestTarget` code path introduced in PR #975, so declined requests show the resolved target camper's name (not "Unknown") and the human-readable decline reason (e.g. "Different sessions"), matching the full-page behavior.

## Manual validation (dev/preview)

- [ ] Open the bunking board and click a camper who has bunk-with requests that resolve to "different session" (look for a camper with any declined cross-session request).
- [ ] In the **right-panel sidebar** (Details tab), expand the Bunking Preferences section.
- [ ] Each declined request shows the resolved target camper's name as a clickable link (not "Unknown") AND the human-readable decline reason (e.g. "Different sessions", "Not enrolled").
- [ ] Open the same camper's full-page view (`/camper/<id>`); request rendering matches the sidebar.
- [ ] Resolved requests still render correctly (regression check — name + no decline reason).
- [ ] Pending requests without a `requestee_id` still show as italic unresolved (regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed embedded-mode rendering of declined bunk requests so the target camper name, human-readable decline reason ("Different sessions"), and "Bunk with" label display correctly.

* **Tests**
  * Added regression tests and richer fixtures for declined bunk scenarios, introduced more granular mocks and setup helpers, and ensured mocks are reset between tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->