### PR TITLE
fix(frontend): cap scenario name width in action-bar header with ellipsis + tooltip

### DIFF
--- a/frontend/src/components/session/SessionHeader.test.tsx
+++ b/frontend/src/components/session/SessionHeader.test.tsx
@@ -3,7 +3,119 @@
  * Following TDD - tests written first, implementation follows
  */
 
+import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
+import { MemoryRouter } from 'react-router'
+
+// ---------------------------------------------------------------------------
+// Mocks for SessionHeader's heavy deps (DOM rendering tests)
+// ---------------------------------------------------------------------------
+vi.mock('../PreValidateRequestsButton', () => ({
+  default: () => <button>Pre-check</button>,
+}))
+vi.mock('../ValidateBunkingButton', () => ({
+  default: () => <button>Validate Bunking</button>,
+}))
+vi.mock('../BunkingLegend', () => ({
+  BunkingLegendButton: () => <button>Legend</button>,
+}))
+vi.mock('../ModeBadge', () => ({
+  default: ({ isProductionMode }: { isProductionMode: boolean }) => (
+    <span>{isProductionMode ? 'Live' : 'Draft'}</span>
+  ),
+}))
+vi.mock('../OptimizeBunksButton', () => ({
+  default: () => <button>Optimize Bunks</button>,
+}))
+vi.mock('../../utils/sessionDisplay', () => ({
+  getFormattedSessionName: () => 'Session 1',
+}))
+vi.mock('../../utils/sessionUtils', () => ({
+  sessionNameToUrl: (n: string) => n.toLowerCase().replace(/\s+/g, '-'),
+  sortSessionsByDate: (s: unknown[]) => s,
+  filterSelectableSessions: (s: unknown[]) => s,
+}))
+
+import SessionHeader from './SessionHeader'
+import type { SessionHeaderProps } from './SessionHeader'
+
+const LONG_SCENARIO_NAME =
+  'copy scenario test to scenario copy scenario very long name that overflows'
+
+import type { Session } from '../../types/app-types'
+
+const mockSession = {
+  id: 's1',
+  cm_id: 1001,
+  name: 'Session 1',
+  session_type: 'main',
+  start_date: '',
+  end_date: '',
+  year: 2026,
+} as unknown as Session
+
+const defaultProps: SessionHeaderProps = {
+  session: mockSession,
+  allSessions: [mockSession],
+  currentYear: 2026,
+  isProductionMode: false,
+  currentScenario: { id: 'sc1', name: LONG_SCENARIO_NAME },
+  scenarios: [{ id: 'sc1', name: LONG_SCENARIO_NAME }],
+  scenarioLoading: false,
+  isSolving: false,
+  isApplyingResults: false,
+  capturedScenarioId: null,
+  onSessionChange: vi.fn(),
+  onRunSolver: vi.fn(),
+  respectLocks: false,
+  onRespectLocksChange: vi.fn(),
+  onShowClearDialog: vi.fn(),
+  onShowNewScenarioModal: vi.fn(),
+  onShowScenarioManagement: vi.fn(),
+  onSelectScenario: vi.fn(),
+  canManage: true,
+}
+
+function renderSessionHeader(overrides: Partial<SessionHeaderProps> = {}) {
+  const props = { ...defaultProps, ...overrides }
+  return render(
+    <MemoryRouter>
+      <SessionHeader {...props} />
+    </MemoryRouter>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// DOM rendering tests — scenario name truncation (feedback item #53)
+// ---------------------------------------------------------------------------
+describe('SessionHeader scenario name truncation', () => {
+  it('scenario dropdown button has a title attribute containing the full scenario name', () => {
+    renderSessionHeader()
+    // The ListboxButton renders as a <button> containing the scenario name text
+    // We find it by its text content
+    const button = screen.getByRole('button', { name: new RegExp(LONG_SCENARIO_NAME.slice(0, 20)) })
+    expect(button).toHaveAttribute('title', LONG_SCENARIO_NAME)
+  })
+
+  it('scenario dropdown button has a max-width class to prevent unbounded growth', () => {
+    renderSessionHeader()
+    const button = screen.getByRole('button', { name: new RegExp(LONG_SCENARIO_NAME.slice(0, 20)) })
+    // Should contain a Tailwind max-w-* class
+    expect(button.className).toMatch(/max-w-/)
+  })
+
+  it('scenario name span has truncate class to clip overflow text with ellipsis', () => {
+    renderSessionHeader()
+    const button = screen.getByRole('button', { name: new RegExp(LONG_SCENARIO_NAME.slice(0, 20)) })
+    // The inner span should carry the truncate utility
+    const nameSpan = button.querySelector('span.truncate')
+    expect(nameSpan).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Logic-only tests (no DOM) — existing coverage
+// ---------------------------------------------------------------------------
 
 // Test the logic that should be in the component
 describe('SessionHeader', () => {

--- a/frontend/src/components/session/SessionHeader.test.tsx
+++ b/frontend/src/components/session/SessionHeader.test.tsx
@@ -100,8 +100,8 @@ describe('SessionHeader scenario name truncation', () => {
   it('scenario dropdown button has a max-width class to prevent unbounded growth', () => {
     renderSessionHeader()
     const button = screen.getByRole('button', { name: new RegExp(LONG_SCENARIO_NAME.slice(0, 20)) })
-    // Should contain a Tailwind max-w-* class
-    expect(button.className).toMatch(/max-w-/)
+    // Should contain a Tailwind max-w-* class clamped to ~130px (matching action button width)
+    expect(button.className).toMatch(/max-w-\[130px\]/)
   })
 
   it('scenario name span has truncate class to clip overflow text with ellipsis', () => {
@@ -110,6 +110,20 @@ describe('SessionHeader scenario name truncation', () => {
     // The inner span should carry the truncate utility
     const nameSpan = button.querySelector('span.truncate')
     expect(nameSpan).toBeInTheDocument()
+  })
+
+  it('short scenario name is fully present in the DOM without being cut', () => {
+    const SHORT_NAME = 'Default'
+    renderSessionHeader({
+      currentScenario: { id: 'sc1', name: SHORT_NAME },
+      scenarios: [{ id: 'sc1', name: SHORT_NAME }],
+    })
+    // The title attribute must match the full name (tooltip fallback for truncation)
+    const button = screen.getByRole('button', { name: new RegExp(SHORT_NAME) })
+    expect(button).toHaveAttribute('title', SHORT_NAME)
+    // The inner span must contain the full text — no visual clipping of short names
+    const nameSpan = button.querySelector('span.truncate')
+    expect(nameSpan?.textContent).toBe(SHORT_NAME)
   })
 })
 

--- a/frontend/src/components/session/SessionHeader.tsx
+++ b/frontend/src/components/session/SessionHeader.tsx
@@ -134,7 +134,7 @@ export default function SessionHeader({
                   disabled={scenarioLoading || isSolving || isApplyingResults}
                 >
                   <ListboxButton
-                    className="listbox-button-compact max-w-[200px] min-w-[130px]"
+                    className="listbox-button-compact max-w-[130px] min-w-[130px]"
                     title={currentScenario?.name ?? 'CampMinder'}
                   >
                     <span className="flex-1 truncate text-left">

--- a/frontend/src/components/session/SessionHeader.tsx
+++ b/frontend/src/components/session/SessionHeader.tsx
@@ -133,7 +133,10 @@ export default function SessionHeader({
                   onChange={handleScenarioChange}
                   disabled={scenarioLoading || isSolving || isApplyingResults}
                 >
-                  <ListboxButton className="listbox-button-compact min-w-[130px]">
+                  <ListboxButton
+                    className="listbox-button-compact max-w-[200px] min-w-[130px]"
+                    title={currentScenario?.name ?? 'CampMinder'}
+                  >
                     <span className="flex-1 truncate text-left">
                       {currentScenario?.name ?? 'CampMinder'}
                     </span>


### PR DESCRIPTION
## Summary

Resolves feedback item **#53** — "Long scenario names squish the action-bar buttons."

The scenario action bar's header ribbon gave the scenario-name element unbounded width in a flex row, so any long name (e.g. "copy scenario test to scenario") pushed the pre-check / validate-bunking buttons onto a second row. Adds `truncate` + `max-w-[130px] min-w-[130px]` (fixed 130px width) + `title={name}` so the displayed name clamps with ellipsis and the full name is visible on hover. The 130px clamp matches the natural width of the sibling action buttons (Pre-check, Check Bunking, etc. at `px-3 py-2 text-sm`), so the scenario-name button never widens past its neighbours. Buttons stay on one line at realistic viewport widths.

## Manual validation (dev/preview)

- [ ] Go to a scenario and rename it to something long: "copy scenario test to scenario copy scenario".
- [ ] The action bar shows the name truncated with "…" and the pre-check / validate-bunking / other action buttons remain on a single line.
- [ ] Hover the scenario name — full text appears as a browser tooltip.
- [ ] Create a scenario with a short name (e.g. "Test") — no ellipsis, no layout weirdness.
- [ ] At laptop viewport (≥1280px), layout is unchanged for short/medium names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
