### PR TITLE
feat(frontend): restore last active scenario on bunking board refresh

### DIFF
--- a/frontend/src/contexts/ScenarioContext.restore.test.tsx
+++ b/frontend/src/contexts/ScenarioContext.restore.test.tsx
@@ -1,0 +1,267 @@
+/**
+ * Integration tests for ScenarioContext — last-active-scenario localStorage restore.
+ *
+ * Covers scoreboard item #49: the bunking board must restore the last active scenario
+ * on mount/refresh rather than defaulting to CampMinder source-of-truth.
+ *
+ * Scenarios tested:
+ *  1. Stored scenario id exists and matches a loaded scenario → auto-select it
+ *  2. Stored scenario id no longer exists (deleted) → fall back to production mode,
+ *     clear the stale key
+ *  3. No stored id → stay in production mode
+ *  4. Selecting a scenario writes it to localStorage
+ *  5. Switching to production mode (null) clears the key for that session
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ScenarioProvider } from './ScenarioContext'
+import { useScenario } from '../hooks/useScenario'
+
+// ---------------------------------------------------------------------------
+// Mock scenarioStorage so we control what's "in localStorage" without needing
+// a real browser localStorage (the setup.ts stub uses non-functional vi.fn()s).
+// ---------------------------------------------------------------------------
+const mockGetStoredScenarioId = vi.fn<(sessionCmId: number) => string | null>()
+const mockSetStoredScenarioId = vi.fn<(sessionCmId: number, scenarioId: string) => void>()
+const mockClearStoredScenarioId = vi.fn<(sessionCmId: number) => void>()
+
+vi.mock('../utils/scenarioStorage', () => ({
+  SCENARIO_STORAGE_KEY: 'kindred.scenarioBySession',
+  getStoredScenarioId: (id: number) => mockGetStoredScenarioId(id),
+  setStoredScenarioId: (id: number, sid: string) => mockSetStoredScenarioId(id, sid),
+  clearStoredScenarioId: (id: number) => mockClearStoredScenarioId(id),
+}))
+
+// ---------------------------------------------------------------------------
+// Mock pocketbase + auth so useSavedScenarios and useAuth don't blow up
+// ---------------------------------------------------------------------------
+vi.mock('../lib/pocketbase', () => ({
+  pb: {
+    authStore: { isValid: true, token: 'tok', model: { id: 'u1' } },
+    collection: vi.fn(),
+  },
+}))
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ isLoading: false, isAuthenticated: true, user: { id: 'u1' } }),
+}))
+
+vi.mock('../hooks/useCurrentYear', () => ({
+  useYear: () => 2025,
+}))
+
+// We'll control what useSavedScenarios returns from the test
+const mockSavedScenarios = vi.fn()
+vi.mock('../hooks/useSavedScenarios', () => ({
+  useSavedScenarios: () => mockSavedScenarios(),
+}))
+
+// Stub out the mutation hooks — they're not exercised in these tests
+vi.mock('../hooks/useSavedScenariosMutation', () => ({
+  useCreateScenario: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
+  useDeleteScenario: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
+}))
+vi.mock('../hooks/useScenarioOperations', () => ({
+  useUpdateScenario: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
+  useClearScenario: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeScenario(id: string, sessionCmId = 1001) {
+  return {
+    id,
+    collectionId: 'saved_scenarios',
+    collectionName: 'saved_scenarios',
+    name: `Scenario ${id}`,
+    session: 'pb-session-1',
+    year: 2025,
+    is_active: true,
+    session_cm_id: sessionCmId,
+    created: '2025-01-01T00:00:00Z',
+    updated: '2025-01-01T00:00:00Z',
+    description: '',
+    expand: { session: { cm_id: sessionCmId } },
+  }
+}
+
+function createQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={createQueryClient()}>
+      <ScenarioProvider>{children}</ScenarioProvider>
+    </QueryClientProvider>
+  )
+}
+
+/** Consumer that exposes context state and lets us call selectScenario / loadScenarios */
+function ScenarioConsumer({
+  onSelectScenario,
+}: {
+  onSelectScenario?: (fn: (id: string | null) => void) => void
+}) {
+  const { currentScenario, isProductionMode, loadScenarios, selectScenario } = useScenario()
+
+  // Expose selectScenario to the test via callback ref
+  if (onSelectScenario) onSelectScenario(selectScenario)
+
+  return (
+    <div>
+      <div data-testid="scenario-id">{currentScenario?.id ?? 'none'}</div>
+      <div data-testid="production-mode">{isProductionMode ? 'production' : 'scenario'}</div>
+      <button onClick={() => void loadScenarios(1001)}>Load session 1001</button>
+      <button onClick={() => selectScenario('scenario-alpha')}>Select alpha</button>
+      <button onClick={() => selectScenario(null)}>Select production</button>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('ScenarioContext — last-active-scenario restore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Default: nothing stored in localStorage
+    mockGetStoredScenarioId.mockReturnValue(null)
+  })
+
+  it('restores the stored scenario when it matches a loaded scenario (happy path)', async () => {
+    // Simulate: user had scenario-alpha active for session 1001 on last visit
+    mockGetStoredScenarioId.mockImplementation((sessionId) =>
+      sessionId === 1001 ? 'scenario-alpha' : null
+    )
+
+    const scenarioAlpha = makeScenario('scenario-alpha')
+    mockSavedScenarios.mockReturnValue({
+      data: [scenarioAlpha],
+      isLoading: false,
+      error: null,
+    })
+
+    render(<ScenarioConsumer />, { wrapper: Wrapper })
+
+    // loadScenarios sets currentSessionId → triggers scenario restoration
+    await act(async () => {
+      screen.getByText('Load session 1001').click()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scenario-id').textContent).toBe('scenario-alpha')
+      expect(screen.getByTestId('production-mode').textContent).toBe('scenario')
+    })
+  })
+
+  it('falls back to production mode when stored scenario id is not in the loaded list (deleted)', async () => {
+    // Stale id — scenario was deleted on the server
+    mockGetStoredScenarioId.mockImplementation((sessionId) =>
+      sessionId === 1001 ? 'scenario-deleted' : null
+    )
+
+    mockSavedScenarios.mockReturnValue({
+      data: [makeScenario('scenario-alpha')], // 'scenario-deleted' is NOT in this list
+      isLoading: false,
+      error: null,
+    })
+
+    render(<ScenarioConsumer />, { wrapper: Wrapper })
+
+    await act(async () => {
+      screen.getByText('Load session 1001').click()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scenario-id').textContent).toBe('none')
+      expect(screen.getByTestId('production-mode').textContent).toBe('production')
+    })
+
+    // The stale key should have been cleared
+    expect(mockClearStoredScenarioId).toHaveBeenCalledWith(1001)
+  })
+
+  it('stays in production mode when no scenario is stored for the session', async () => {
+    // mockGetStoredScenarioId returns null (set in beforeEach)
+    mockSavedScenarios.mockReturnValue({
+      data: [makeScenario('scenario-alpha')],
+      isLoading: false,
+      error: null,
+    })
+
+    render(<ScenarioConsumer />, { wrapper: Wrapper })
+
+    await act(async () => {
+      screen.getByText('Load session 1001').click()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scenario-id').textContent).toBe('none')
+      expect(screen.getByTestId('production-mode').textContent).toBe('production')
+    })
+  })
+
+  it('writes the selected scenario id to localStorage when a scenario is chosen', async () => {
+    mockSavedScenarios.mockReturnValue({
+      data: [makeScenario('scenario-alpha')],
+      isLoading: false,
+      error: null,
+    })
+
+    render(<ScenarioConsumer />, { wrapper: Wrapper })
+
+    await act(async () => {
+      screen.getByText('Load session 1001').click()
+    })
+
+    await act(async () => {
+      screen.getByText('Select alpha').click()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scenario-id').textContent).toBe('scenario-alpha')
+    })
+
+    expect(mockSetStoredScenarioId).toHaveBeenCalledWith(1001, 'scenario-alpha')
+  })
+
+  it('clears the localStorage key for the session when switching back to production mode', async () => {
+    // Simulate stored scenario for session 1001
+    mockGetStoredScenarioId.mockImplementation((sessionId) =>
+      sessionId === 1001 ? 'scenario-alpha' : null
+    )
+
+    mockSavedScenarios.mockReturnValue({
+      data: [makeScenario('scenario-alpha')],
+      isLoading: false,
+      error: null,
+    })
+
+    render(<ScenarioConsumer />, { wrapper: Wrapper })
+
+    await act(async () => {
+      screen.getByText('Load session 1001').click()
+    })
+
+    // Wait for restore
+    await waitFor(() => {
+      expect(screen.getByTestId('scenario-id').textContent).toBe('scenario-alpha')
+    })
+
+    // Now switch back to production
+    await act(async () => {
+      screen.getByText('Select production').click()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('production-mode').textContent).toBe('production')
+    })
+
+    // clearStoredScenarioId should have been called for session 1001
+    expect(mockClearStoredScenarioId).toHaveBeenCalledWith(1001)
+  })
+})

--- a/frontend/src/contexts/ScenarioContext.restore.test.tsx
+++ b/frontend/src/contexts/ScenarioContext.restore.test.tsx
@@ -116,6 +116,7 @@ function ScenarioConsumer({
       <div data-testid="scenario-id">{currentScenario?.id ?? 'none'}</div>
       <div data-testid="production-mode">{isProductionMode ? 'production' : 'scenario'}</div>
       <button onClick={() => void loadScenarios(1001)}>Load session 1001</button>
+      <button onClick={() => void loadScenarios(1002)}>Load session 1002</button>
       <button onClick={() => selectScenario('scenario-alpha')}>Select alpha</button>
       <button onClick={() => selectScenario(null)}>Select production</button>
     </div>
@@ -263,5 +264,183 @@ describe('ScenarioContext — last-active-scenario restore', () => {
 
     // clearStoredScenarioId should have been called for session 1001
     expect(mockClearStoredScenarioId).toHaveBeenCalledWith(1001)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Finding 1 (critical) + Finding 4 (high): race condition — persist effect
+  // clears localStorage before restore effect can read it.
+  //
+  // Sequence that triggers the bug on the original code:
+  //   1. Initial mount with currentSessionId=undefined → useSavedScenarios returns []
+  //      → Effect 2 (restore) fires, sets restoreCompletedRef.current=true
+  //   2. loadScenarios(1001) → currentSessionId=1001
+  //   3. useSavedScenarios(1001) first returns [] (loading phase)
+  //      → Effect 1 (persist) fires: currentScenario=null, restoreCompletedRef.current=true
+  //        → clearStoredScenarioId(1001) is called — key is WIPED before restore reads it
+  //   4. Scenarios arrive → restore fires but key is already gone → stays production mode
+  //
+  // The fix tracks which session completed restore (restoreCompletedForSessionRef stores
+  // the sessionId, not a boolean). Persist only clears when
+  // restoreCompletedForSessionRef.current === sessionId, so a prior session's restore
+  // completion cannot unlock the new session's clear.
+  // ---------------------------------------------------------------------------
+  it('does not clear localStorage before restore runs (async useSavedScenarios path)', async () => {
+    // User had scenario-alpha active for session 1001 on last visit
+    mockGetStoredScenarioId.mockImplementation((sessionId) =>
+      sessionId === 1001 ? 'scenario-alpha' : null
+    )
+
+    const scenarioAlpha = makeScenario('scenario-alpha')
+
+    // Phase 1: initial mount (currentSessionId=undefined) — return empty list
+    // Phase 2: immediately after loadScenarios(1001) — still loading, return empty list
+    // This simulates the window where React Query hasn't fetched for session 1001 yet.
+    // In this window the bug fires: persist effect sees restoreCompleted=true + null scenario
+    // → clears the key for session 1001 before restore can read it.
+    let scenariosPhase: 'loading' | 'loaded' = 'loading'
+    mockSavedScenarios.mockImplementation(() => {
+      if (scenariosPhase === 'loading') {
+        return { data: [], isLoading: true, error: null }
+      }
+      return { data: [scenarioAlpha], isLoading: false, error: null }
+    })
+
+    render(<ScenarioConsumer />, { wrapper: Wrapper })
+
+    // Initial mount: currentSessionId=undefined, useSavedScenarios returns [].
+    // Effect 2 runs → sets restoreCompletedRef.current=true (buggy) or
+    // restoreCompletedForSessionRef.current=undefined (fixed).
+    await act(async () => {
+      // let initial effects settle
+    })
+
+    // loadScenarios(1001): currentSessionId becomes 1001.
+    // Both effects fire. Persist effect runs first.
+    // BUG: sees restoreCompleted=true + null scenario → clears key for 1001.
+    // FIX: restoreCompletedForSessionRef.current=undefined ≠ 1001 → skips clear.
+    await act(async () => {
+      screen.getByText('Load session 1001').click()
+    })
+
+    // Key assertion: the bug calls clearStoredScenarioId(1001) immediately here
+    // because the restore phase (from the initial mount) was marked complete.
+    // After the fix it must NOT be called for session 1001 at this point.
+    expect(mockClearStoredScenarioId).not.toHaveBeenCalledWith(1001)
+
+    // Now simulate scenarios arriving (React Query resolves) by switching to a
+    // session with data available immediately. This verifies the restore path works
+    // once the race condition no longer clears the key prematurely.
+    scenariosPhase = 'loaded'
+    mockSavedScenarios.mockReturnValue({
+      data: [scenarioAlpha],
+      isLoading: false,
+      error: null,
+    })
+
+    // Load another session ID and back to force a state-change re-render that
+    // picks up the new mockSavedScenarios return value.
+    await act(async () => {
+      screen.getByText('Load session 1002').click()
+    })
+    await act(async () => {
+      screen.getByText('Load session 1001').click()
+    })
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('scenario-id').textContent).toBe('scenario-alpha')
+      },
+      { timeout: 2000 }
+    )
+
+    // Clear was never called for session 1001 throughout the whole flow
+    expect(mockClearStoredScenarioId).not.toHaveBeenCalledWith(1001)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Finding 2 (high): persist effect writes scenarioA's id under sessionB's key.
+  //
+  // Sequence that triggers the bug:
+  //   1. Session 1001 is active with scenario-alpha selected
+  //   2. loadScenarios(1002) fires → currentSessionId=1002
+  //   3. Effect 1 (persist) fires: currentSessionId=1002 but currentScenario=scenario-alpha
+  //      → setStoredScenarioId(1002, 'scenario-alpha') — cross-session write!
+  //
+  // The fix gates persist on scenario.sessionId === currentSessionId, preventing
+  // cross-session writes when currentScenario hasn't cleared yet.
+  // ---------------------------------------------------------------------------
+  it('does not write scenario from session A under session B key when switching sessions', async () => {
+    // Session 1001 is active and scenario-alpha (belonging to 1001) is selected
+    mockGetStoredScenarioId.mockImplementation((sessionId) =>
+      sessionId === 1001 ? 'scenario-alpha' : null
+    )
+
+    const scenarioAlpha = makeScenario('scenario-alpha', 1001)
+    const scenarioBeta = makeScenario('scenario-beta', 1002)
+
+    // We use a ref-based approach: first loadScenarios(1001) triggers restore,
+    // then loadScenarios(1002) switches sessions.
+    // Track calls by which session is being queried.
+    mockSavedScenarios.mockImplementation(() => {
+      // Return based on what was last set as currentSessionId.
+      // Since we can't easily inspect that here, we rely on call order:
+      // the test drives scenario data via external state.
+      return { data: [scenarioAlpha], isLoading: false, error: null }
+    })
+
+    const TestConsumer = () => {
+      const { currentScenario, isProductionMode, loadScenarios } = useScenario()
+      return (
+        <div>
+          <div data-testid="scenario-id">{currentScenario?.id ?? 'none'}</div>
+          <div data-testid="production-mode">{isProductionMode ? 'production' : 'scenario'}</div>
+          <button onClick={() => void loadScenarios(1001)}>Load session 1001</button>
+          <button onClick={() => void loadScenarios(1002)}>Load session 1002</button>
+        </div>
+      )
+    }
+
+    function TestWrapper({ children }: { children: ReactNode }) {
+      return (
+        <QueryClientProvider client={createQueryClient()}>
+          <ScenarioProvider>{children}</ScenarioProvider>
+        </QueryClientProvider>
+      )
+    }
+
+    render(<TestConsumer />, { wrapper: TestWrapper })
+
+    // Step 1: load session 1001 and wait for scenario-alpha to be restored
+    await act(async () => {
+      screen.getByText('Load session 1001').click()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scenario-id').textContent).toBe('scenario-alpha')
+    })
+
+    // Clear call records from the restore phase so we can inspect only what happens
+    // during the session switch.
+    mockSetStoredScenarioId.mockClear()
+
+    // Step 2: switch to session 1002
+    // Now useSavedScenarios returns session 1002 scenarios
+    mockSavedScenarios.mockReturnValue({
+      data: [scenarioBeta],
+      isLoading: false,
+      error: null,
+    })
+
+    await act(async () => {
+      screen.getByText('Load session 1002').click()
+    })
+
+    // The bug: setStoredScenarioId(1002, 'scenario-alpha') would be called here
+    // because currentScenario is still scenario-alpha when the persist effect fires.
+    // After the fix: no cross-session write for scenario-alpha under session 1002.
+    const crossSessionWrites = mockSetStoredScenarioId.mock.calls.filter(
+      ([sessionId, scenarioId]) => sessionId === 1002 && scenarioId === 'scenario-alpha'
+    )
+    expect(crossSessionWrites).toHaveLength(0)
   })
 })

--- a/frontend/src/contexts/ScenarioContext.restore.test.tsx
+++ b/frontend/src/contexts/ScenarioContext.restore.test.tsx
@@ -267,22 +267,9 @@ describe('ScenarioContext — last-active-scenario restore', () => {
   })
 
   // ---------------------------------------------------------------------------
-  // Finding 1 (critical) + Finding 4 (high): race condition — persist effect
-  // clears localStorage before restore effect can read it.
-  //
-  // Sequence that triggers the bug on the original code:
-  //   1. Initial mount with currentSessionId=undefined → useSavedScenarios returns []
-  //      → Effect 2 (restore) fires, sets restoreCompletedRef.current=true
-  //   2. loadScenarios(1001) → currentSessionId=1001
-  //   3. useSavedScenarios(1001) first returns [] (loading phase)
-  //      → Effect 1 (persist) fires: currentScenario=null, restoreCompletedRef.current=true
-  //        → clearStoredScenarioId(1001) is called — key is WIPED before restore reads it
-  //   4. Scenarios arrive → restore fires but key is already gone → stays production mode
-  //
-  // The fix tracks which session completed restore (restoreCompletedForSessionRef stores
-  // the sessionId, not a boolean). Persist only clears when
-  // restoreCompletedForSessionRef.current === sessionId, so a prior session's restore
-  // completion cannot unlock the new session's clear.
+  // Finding 1 (critical): race condition — persist clears localStorage before
+  // restore runs. Fixed by tracking per-session restore completion (sessionId,
+  // not boolean) so a prior session's restore can't unlock the new session's clear.
   // ---------------------------------------------------------------------------
   it('does not clear localStorage before restore runs (async useSavedScenarios path)', async () => {
     // User had scenario-alpha active for session 1001 on last visit
@@ -337,8 +324,7 @@ describe('ScenarioContext — last-active-scenario restore', () => {
       error: null,
     })
 
-    // Load another session ID and back to force a state-change re-render that
-    // picks up the new mockSavedScenarios return value.
+    // Bounce through session 1002 → 1001 to force a re-render with the new mock data.
     await act(async () => {
       screen.getByText('Load session 1002').click()
     })
@@ -388,27 +374,7 @@ describe('ScenarioContext — last-active-scenario restore', () => {
       return { data: [scenarioAlpha], isLoading: false, error: null }
     })
 
-    const TestConsumer = () => {
-      const { currentScenario, isProductionMode, loadScenarios } = useScenario()
-      return (
-        <div>
-          <div data-testid="scenario-id">{currentScenario?.id ?? 'none'}</div>
-          <div data-testid="production-mode">{isProductionMode ? 'production' : 'scenario'}</div>
-          <button onClick={() => void loadScenarios(1001)}>Load session 1001</button>
-          <button onClick={() => void loadScenarios(1002)}>Load session 1002</button>
-        </div>
-      )
-    }
-
-    function TestWrapper({ children }: { children: ReactNode }) {
-      return (
-        <QueryClientProvider client={createQueryClient()}>
-          <ScenarioProvider>{children}</ScenarioProvider>
-        </QueryClientProvider>
-      )
-    }
-
-    render(<TestConsumer />, { wrapper: TestWrapper })
+    render(<ScenarioConsumer />, { wrapper: Wrapper })
 
     // Step 1: load session 1001 and wait for scenario-alpha to be restored
     await act(async () => {

--- a/frontend/src/contexts/ScenarioContext.tsx
+++ b/frontend/src/contexts/ScenarioContext.tsx
@@ -141,23 +141,34 @@ export const ScenarioProvider: FC<ScenarioProviderProps> = ({ children }) => {
     [clearScenarioMutation]
   )
 
-  // Track whether the restore phase has completed for the current session.
-  // Until restore runs, we must not write null to localStorage (which would
-  // delete the stored key before we've had a chance to read it back).
-  const restoreCompletedRef = useRef(false)
+  // Track which session has completed its restore phase.
+  // We store the sessionId (not just a boolean) so the persist effect can check
+  // "has restore run for THIS session?" rather than "has restore ever run?".
+  // This prevents two races:
+  //   1. (Finding 1) On session switch, persist fires before restore — the boolean-only
+  //      guard would be true from the previous session's restore, causing a premature clear.
+  //   2. (Finding 4) Same root cause as Finding 1; covered by the same fix.
+  const restoreCompletedForSessionRef = useRef<number | undefined>(undefined)
 
   // Persist current scenario selection to localStorage (per session).
-  // Uses useEffectEvent so currentSessionId is always fresh without being a dep.
+  // Uses useEffectEvent so currentSessionId / currentScenario are always fresh without
+  // being reactive dependencies (which would cause double-fire loops).
   const persistScenarioSelection = useEffectEvent(
     (sessionId: number | undefined, scenarioId: string | null) => {
       if (!sessionId) return
 
       if (scenarioId) {
+        // Finding 2 fix: only write if the scenario actually belongs to this session.
+        // When the user switches sessions, currentScenario still holds the previous
+        // session's scenario for one render cycle. Writing it under the new session key
+        // would corrupt that session's stored selection.
+        if (currentScenario && currentScenario.session_cm_id !== sessionId) return
         setStoredScenarioId(sessionId, scenarioId)
-      } else if (restoreCompletedRef.current) {
-        // Only clear the key once the restore phase is done. If we're still
-        // in the initial mount cycle (restore hasn't run yet), the null is the
-        // default React state — not an intentional "switch to production" action.
+      } else if (restoreCompletedForSessionRef.current === sessionId) {
+        // Only clear the key once the restore phase for THIS session is done.
+        // If we're still in the session-switch cycle (restore hasn't run yet for
+        // sessionId), the null is the default React state — not an intentional
+        // "switch to production" action.
         clearStoredScenarioId(sessionId)
       }
     }
@@ -222,8 +233,11 @@ export const ScenarioProvider: FC<ScenarioProviderProps> = ({ children }) => {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: syncs scenario state when external data (scenarios list, session) changes; useEffectEvent prevents re-run loops
       setCurrentScenario(validatedResult)
     }
-    // Mark restore phase complete so subsequent null writes can clear localStorage.
-    restoreCompletedRef.current = true
+    // Mark restore phase complete for this specific session.
+    // Using the sessionId (not a boolean) prevents Finding 1: the persist effect
+    // checks restoreCompletedForSessionRef.current === sessionId, so a prior
+    // session's completion can't unlock writes for the new session.
+    restoreCompletedForSessionRef.current = currentSessionId
   }, [scenarios, currentSessionId])
 
   const value: ScenarioContextType = {

--- a/frontend/src/contexts/ScenarioContext.tsx
+++ b/frontend/src/contexts/ScenarioContext.tsx
@@ -1,11 +1,16 @@
 import type { ReactNode } from 'react'
-import { type FC, useState, useEffect, useCallback, useMemo, useEffectEvent } from 'react'
+import { type FC, useState, useEffect, useCallback, useMemo, useEffectEvent, useRef } from 'react'
 import { ScenarioContext, type Scenario, type ScenarioContextType } from '../hooks/useScenario'
 import { useSavedScenarios } from '../hooks/useSavedScenarios'
 import { useCreateScenario, useDeleteScenario } from '../hooks/useSavedScenariosMutation'
 import { useUpdateScenario, useClearScenario } from '../hooks/useScenarioOperations'
 import { useYear } from '../hooks/useCurrentYear'
 import { savedScenarioToScenario } from './scenarioTransform'
+import {
+  getStoredScenarioId,
+  setStoredScenarioId,
+  clearStoredScenarioId,
+} from '../utils/scenarioStorage'
 
 interface ScenarioProviderProps {
   children: ReactNode
@@ -136,83 +141,89 @@ export const ScenarioProvider: FC<ScenarioProviderProps> = ({ children }) => {
     [clearScenarioMutation]
   )
 
-  // Stable localStorage sync using useEffectEvent
-  // Stores scenario selection PER SESSION so switching sessions doesn't lose your choice
-  const syncToLocalStorage = useEffectEvent(
+  // Track whether the restore phase has completed for the current session.
+  // Until restore runs, we must not write null to localStorage (which would
+  // delete the stored key before we've had a chance to read it back).
+  const restoreCompletedRef = useRef(false)
+
+  // Persist current scenario selection to localStorage (per session).
+  // Uses useEffectEvent so currentSessionId is always fresh without being a dep.
+  const persistScenarioSelection = useEffectEvent(
     (sessionId: number | undefined, scenarioId: string | null) => {
       if (!sessionId) return
 
-      // Get existing per-session storage
-      const stored = localStorage.getItem('scenarioBySession')
-      const scenarioBySession: Record<string, string> = stored ? JSON.parse(stored) : {}
-
       if (scenarioId) {
-        scenarioBySession[sessionId] = scenarioId
-      } else {
-        // Use Reflect.deleteProperty to satisfy no-dynamic-delete rule
-        Reflect.deleteProperty(scenarioBySession, String(sessionId))
+        setStoredScenarioId(sessionId, scenarioId)
+      } else if (restoreCompletedRef.current) {
+        // Only clear the key once the restore phase is done. If we're still
+        // in the initial mount cycle (restore hasn't run yet), the null is the
+        // default React state — not an intentional "switch to production" action.
+        clearStoredScenarioId(sessionId)
       }
-
-      localStorage.setItem('scenarioBySession', JSON.stringify(scenarioBySession))
     }
   )
 
-  // Store current scenario in localStorage for persistence (per session)
+  // Write to localStorage whenever the selected scenario changes.
+  // Depends on currentScenario?.id so it fires on user-driven scenario changes.
   useEffect(() => {
-    syncToLocalStorage(currentSessionId, currentScenario?.id ?? null)
+    persistScenarioSelection(currentSessionId, currentScenario?.id ?? null)
   }, [currentScenario?.id, currentSessionId])
 
-  // Pure function to determine validated scenario state
+  // Restore the last active scenario for the session when scenarios first load.
   // Uses useEffectEvent to read currentScenario without adding it as a dependency
-  // Returns the scenario to set (or null to clear), or undefined if no change needed
+  // (which would cause an infinite re-run loop).
+  // Returns the scenario to set (or null to clear), or undefined if no change needed.
   const getValidatedScenario = useEffectEvent(
     (availableScenarios: Scenario[]): Scenario | null | undefined => {
-      // Get stored scenario for THIS session
-      const stored = localStorage.getItem('scenarioBySession')
-      const scenarioBySession: Record<string, string> = stored ? JSON.parse(stored) : {}
-      const storedScenarioId = currentSessionId ? scenarioBySession[currentSessionId] : null
+      const storedScenarioId = currentSessionId ? getStoredScenarioId(currentSessionId) : null
 
-      // If we have a current scenario, check if it exists in the new session's scenarios
+      // If we already have a current scenario, verify it still exists in this session.
       if (currentScenario) {
         const stillExists = availableScenarios.find((s) => s.id === currentScenario.id)
         if (!stillExists) {
-          // Current scenario doesn't exist in this session - try to restore this session's saved scenario
+          // Current scenario was deleted or doesn't belong here — try stored fallback.
           if (storedScenarioId) {
             const savedScenario = availableScenarios.find((s) => s.id === storedScenarioId)
             if (savedScenario) {
               return savedScenario
             }
           }
-          // No saved scenario for this session - reset to production
+          // No valid scenario for this session — reset to production mode.
           return null
         }
-        // Current scenario is valid, no change needed
+        // Current scenario is valid; no change needed.
         return undefined
       }
 
-      // No current scenario - try to restore from localStorage for this session
+      // No current scenario yet — attempt to restore from localStorage.
       if (storedScenarioId && availableScenarios.length > 0) {
         const scenario = availableScenarios.find((s) => s.id === storedScenarioId)
         if (scenario) {
           return scenario
         }
+        // Stored id doesn't match any loaded scenario (was deleted) — clear stale key.
+        if (currentSessionId) {
+          clearStoredScenarioId(currentSessionId)
+        }
       }
 
-      // No restoration possible, stay as-is
+      // No restoration possible; stay in production mode.
       return undefined
     }
   )
 
-  // Validate scenario exists when scenarios list or session changes
-  // Only depends on scenarios + currentSessionId, not currentScenario (avoids re-run loop)
-  // setState is called here, not inside useEffectEvent
+  // Validate / restore scenario when the scenarios list or session changes.
+  // Only depends on scenarios + currentSessionId, not currentScenario (avoids re-run loop).
+  // setState is called here, not inside useEffectEvent.
   useEffect(() => {
     const validatedResult = getValidatedScenario(scenarios)
-    // undefined means no change needed, null/Scenario means update
+    // undefined means no change needed; null or a Scenario means update state.
     if (validatedResult !== undefined) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: syncs scenario state when external data (scenarios list, session) changes; useEffectEvent prevents re-run loops
       setCurrentScenario(validatedResult)
     }
+    // Mark restore phase complete so subsequent null writes can clear localStorage.
+    restoreCompletedRef.current = true
   }, [scenarios, currentSessionId])
 
   const value: ScenarioContextType = {

--- a/frontend/src/contexts/ScenarioContext.tsx
+++ b/frontend/src/contexts/ScenarioContext.tsx
@@ -141,13 +141,8 @@ export const ScenarioProvider: FC<ScenarioProviderProps> = ({ children }) => {
     [clearScenarioMutation]
   )
 
-  // Track which session has completed its restore phase.
-  // We store the sessionId (not just a boolean) so the persist effect can check
-  // "has restore run for THIS session?" rather than "has restore ever run?".
-  // This prevents two races:
-  //   1. (Finding 1) On session switch, persist fires before restore — the boolean-only
-  //      guard would be true from the previous session's restore, causing a premature clear.
-  //   2. (Finding 4) Same root cause as Finding 1; covered by the same fix.
+  // Tracks the sessionId whose restore phase has completed; prevents persist effect from
+  // clearing the stored key before restore runs.
   const restoreCompletedForSessionRef = useRef<number | undefined>(undefined)
 
   // Persist current scenario selection to localStorage (per session).
@@ -158,17 +153,13 @@ export const ScenarioProvider: FC<ScenarioProviderProps> = ({ children }) => {
       if (!sessionId) return
 
       if (scenarioId) {
-        // Finding 2 fix: only write if the scenario actually belongs to this session.
-        // When the user switches sessions, currentScenario still holds the previous
-        // session's scenario for one render cycle. Writing it under the new session key
-        // would corrupt that session's stored selection.
+        // Only write if the scenario belongs to this session — on session switch,
+        // currentScenario still holds the previous session's value for one render cycle.
         if (currentScenario && currentScenario.session_cm_id !== sessionId) return
         setStoredScenarioId(sessionId, scenarioId)
       } else if (restoreCompletedForSessionRef.current === sessionId) {
-        // Only clear the key once the restore phase for THIS session is done.
-        // If we're still in the session-switch cycle (restore hasn't run yet for
-        // sessionId), the null is the default React state — not an intentional
-        // "switch to production" action.
+        // Only clear once restore has run for this session; null before that is
+        // default React state, not a user "switch to production" action.
         clearStoredScenarioId(sessionId)
       }
     }
@@ -188,37 +179,33 @@ export const ScenarioProvider: FC<ScenarioProviderProps> = ({ children }) => {
     (availableScenarios: Scenario[]): Scenario | null | undefined => {
       const storedScenarioId = currentSessionId ? getStoredScenarioId(currentSessionId) : null
 
-      // If we already have a current scenario, verify it still exists in this session.
       if (currentScenario) {
         const stillExists = availableScenarios.find((s) => s.id === currentScenario.id)
         if (!stillExists) {
-          // Current scenario was deleted or doesn't belong here — try stored fallback.
           if (storedScenarioId) {
             const savedScenario = availableScenarios.find((s) => s.id === storedScenarioId)
             if (savedScenario) {
               return savedScenario
             }
           }
-          // No valid scenario for this session — reset to production mode.
           return null
         }
-        // Current scenario is valid; no change needed.
+        // undefined = no change needed
         return undefined
       }
 
-      // No current scenario yet — attempt to restore from localStorage.
       if (storedScenarioId && availableScenarios.length > 0) {
         const scenario = availableScenarios.find((s) => s.id === storedScenarioId)
         if (scenario) {
           return scenario
         }
-        // Stored id doesn't match any loaded scenario (was deleted) — clear stale key.
+        // Stale key — stored scenario was deleted; clear it.
         if (currentSessionId) {
           clearStoredScenarioId(currentSessionId)
         }
       }
 
-      // No restoration possible; stay in production mode.
+      // undefined = no change needed
       return undefined
     }
   )

--- a/frontend/src/utils/scenarioStorage.test.ts
+++ b/frontend/src/utils/scenarioStorage.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for scenarioStorage utility — localStorage persistence for last active scenario.
+ *
+ * Covers scoreboard item #49: bunking board should restore the last active scenario
+ * on refresh/mount instead of defaulting to CampMinder source-of-truth.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  getStoredScenarioId,
+  setStoredScenarioId,
+  clearStoredScenarioId,
+  SCENARIO_STORAGE_KEY,
+} from './scenarioStorage'
+
+// Use a real in-memory localStorage so read/write/clear actually work.
+function makeLocalStorageMock() {
+  let store: Record<string, string> = {}
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value
+    }),
+    removeItem: vi.fn((key: string) => {
+      Reflect.deleteProperty(store, key)
+    }),
+    clear: vi.fn(() => {
+      store = {}
+    }),
+    length: 0,
+    key: vi.fn(),
+  }
+}
+
+describe('scenarioStorage', () => {
+  beforeEach(() => {
+    const mock = makeLocalStorageMock()
+    Object.defineProperty(window, 'localStorage', { value: mock, writable: true })
+  })
+
+  describe('getStoredScenarioId', () => {
+    it('returns null when nothing is stored for the session', () => {
+      expect(getStoredScenarioId(1001)).toBeNull()
+    })
+
+    it('returns the stored scenario id for the given session', () => {
+      localStorage.setItem(SCENARIO_STORAGE_KEY, JSON.stringify({ '1001': 'scenario-abc' }))
+      expect(getStoredScenarioId(1001)).toBe('scenario-abc')
+    })
+
+    it('returns null when a different session is stored but not this one', () => {
+      localStorage.setItem(SCENARIO_STORAGE_KEY, JSON.stringify({ '9999': 'scenario-xyz' }))
+      expect(getStoredScenarioId(1001)).toBeNull()
+    })
+
+    it('returns null when localStorage contains invalid JSON', () => {
+      localStorage.setItem(SCENARIO_STORAGE_KEY, 'not-valid-json')
+      expect(getStoredScenarioId(1001)).toBeNull()
+    })
+
+    it('returns null when sessionId is falsy', () => {
+      localStorage.setItem(SCENARIO_STORAGE_KEY, JSON.stringify({ '0': 'scenario-abc' }))
+      expect(getStoredScenarioId(0)).toBeNull()
+    })
+  })
+
+  describe('setStoredScenarioId', () => {
+    it('stores the scenario id under the session key', () => {
+      setStoredScenarioId(1001, 'scenario-abc')
+      const stored = JSON.parse(localStorage.getItem(SCENARIO_STORAGE_KEY) ?? '{}')
+      expect(stored['1001']).toBe('scenario-abc')
+    })
+
+    it('preserves existing entries for other sessions', () => {
+      localStorage.setItem(SCENARIO_STORAGE_KEY, JSON.stringify({ '9999': 'scenario-xyz' }))
+      setStoredScenarioId(1001, 'scenario-abc')
+      const stored = JSON.parse(localStorage.getItem(SCENARIO_STORAGE_KEY) ?? '{}')
+      expect(stored['9999']).toBe('scenario-xyz')
+      expect(stored['1001']).toBe('scenario-abc')
+    })
+
+    it('does nothing when sessionId is falsy', () => {
+      setStoredScenarioId(0, 'scenario-abc')
+      expect(localStorage.getItem(SCENARIO_STORAGE_KEY)).toBeNull()
+    })
+  })
+
+  describe('clearStoredScenarioId', () => {
+    it('removes the scenario entry for the given session', () => {
+      localStorage.setItem(SCENARIO_STORAGE_KEY, JSON.stringify({ '1001': 'scenario-abc' }))
+      clearStoredScenarioId(1001)
+      const stored = JSON.parse(localStorage.getItem(SCENARIO_STORAGE_KEY) ?? '{}')
+      expect(stored['1001']).toBeUndefined()
+    })
+
+    it('leaves other session entries intact', () => {
+      localStorage.setItem(
+        SCENARIO_STORAGE_KEY,
+        JSON.stringify({ '1001': 'scenario-abc', '9999': 'scenario-xyz' })
+      )
+      clearStoredScenarioId(1001)
+      const stored = JSON.parse(localStorage.getItem(SCENARIO_STORAGE_KEY) ?? '{}')
+      expect(stored['9999']).toBe('scenario-xyz')
+    })
+
+    it('does nothing when sessionId is falsy', () => {
+      localStorage.setItem(SCENARIO_STORAGE_KEY, JSON.stringify({ '1001': 'scenario-abc' }))
+      clearStoredScenarioId(0)
+      // nothing removed
+      expect(JSON.parse(localStorage.getItem(SCENARIO_STORAGE_KEY) ?? '{}')).toEqual({
+        '1001': 'scenario-abc',
+      })
+    })
+  })
+})

--- a/frontend/src/utils/scenarioStorage.test.ts
+++ b/frontend/src/utils/scenarioStorage.test.ts
@@ -4,7 +4,7 @@
  * Covers scoreboard item #49: bunking board should restore the last active scenario
  * on refresh/mount instead of defaulting to CampMinder source-of-truth.
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import {
   getStoredScenarioId,
   setStoredScenarioId,
@@ -12,7 +12,8 @@ import {
   SCENARIO_STORAGE_KEY,
 } from './scenarioStorage'
 
-// Use a real in-memory localStorage so read/write/clear actually work.
+// The global test setup stubs localStorage with non-functional vi.fn()s.
+// Override with a real in-memory implementation so read/write/clear actually work.
 function makeLocalStorageMock() {
   let store: Record<string, string> = {}
   return {
@@ -35,6 +36,10 @@ describe('scenarioStorage', () => {
   beforeEach(() => {
     const mock = makeLocalStorageMock()
     Object.defineProperty(window, 'localStorage', { value: mock, writable: true })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   describe('getStoredScenarioId', () => {
@@ -114,20 +119,17 @@ describe('scenarioStorage', () => {
     // Finding 3: write-side error handling — clearStoredScenarioId must not throw
     it('does not throw when localStorage.setItem throws SecurityError', () => {
       localStorage.setItem(SCENARIO_STORAGE_KEY, JSON.stringify({ '1001': 'scenario-abc' }))
-      const originalSetItem = localStorage.setItem.bind(localStorage)
-      localStorage.setItem = vi.fn(() => {
+      vi.spyOn(localStorage, 'setItem').mockImplementationOnce(() => {
         throw new DOMException('SecurityError', 'SecurityError')
       })
       expect(() => clearStoredScenarioId(1001)).not.toThrow()
-      // Restore
-      localStorage.setItem = originalSetItem
     })
   })
 
   // Finding 3: write-side error handling for setStoredScenarioId
   describe('setStoredScenarioId — error handling', () => {
     it('does not throw when localStorage.setItem throws QuotaExceededError', () => {
-      localStorage.setItem = vi.fn(() => {
+      vi.spyOn(localStorage, 'setItem').mockImplementationOnce(() => {
         const err = new DOMException('QuotaExceededError')
         Object.defineProperty(err, 'name', { value: 'QuotaExceededError' })
         throw err
@@ -136,7 +138,7 @@ describe('scenarioStorage', () => {
     })
 
     it('does not throw when localStorage.setItem throws SecurityError', () => {
-      localStorage.setItem = vi.fn(() => {
+      vi.spyOn(localStorage, 'setItem').mockImplementationOnce(() => {
         throw new DOMException('SecurityError', 'SecurityError')
       })
       expect(() => setStoredScenarioId(1001, 'scenario-abc')).not.toThrow()

--- a/frontend/src/utils/scenarioStorage.test.ts
+++ b/frontend/src/utils/scenarioStorage.test.ts
@@ -110,5 +110,36 @@ describe('scenarioStorage', () => {
         '1001': 'scenario-abc',
       })
     })
+
+    // Finding 3: write-side error handling — clearStoredScenarioId must not throw
+    it('does not throw when localStorage.setItem throws SecurityError', () => {
+      localStorage.setItem(SCENARIO_STORAGE_KEY, JSON.stringify({ '1001': 'scenario-abc' }))
+      const originalSetItem = localStorage.setItem.bind(localStorage)
+      localStorage.setItem = vi.fn(() => {
+        throw new DOMException('SecurityError', 'SecurityError')
+      })
+      expect(() => clearStoredScenarioId(1001)).not.toThrow()
+      // Restore
+      localStorage.setItem = originalSetItem
+    })
+  })
+
+  // Finding 3: write-side error handling for setStoredScenarioId
+  describe('setStoredScenarioId — error handling', () => {
+    it('does not throw when localStorage.setItem throws QuotaExceededError', () => {
+      localStorage.setItem = vi.fn(() => {
+        const err = new DOMException('QuotaExceededError')
+        Object.defineProperty(err, 'name', { value: 'QuotaExceededError' })
+        throw err
+      })
+      expect(() => setStoredScenarioId(1001, 'scenario-abc')).not.toThrow()
+    })
+
+    it('does not throw when localStorage.setItem throws SecurityError', () => {
+      localStorage.setItem = vi.fn(() => {
+        throw new DOMException('SecurityError', 'SecurityError')
+      })
+      expect(() => setStoredScenarioId(1001, 'scenario-abc')).not.toThrow()
+    })
   })
 })

--- a/frontend/src/utils/scenarioStorage.ts
+++ b/frontend/src/utils/scenarioStorage.ts
@@ -36,7 +36,12 @@ export function setStoredScenarioId(sessionCmId: number, scenarioId: string): vo
   if (!sessionCmId) return
   const store = readStore()
   store[String(sessionCmId)] = scenarioId
-  localStorage.setItem(SCENARIO_STORAGE_KEY, JSON.stringify(store))
+  try {
+    localStorage.setItem(SCENARIO_STORAGE_KEY, JSON.stringify(store))
+  } catch {
+    // Swallow storage errors (QuotaExceededError, SecurityError, etc.).
+    // Persistence is best-effort; the app continues without it.
+  }
 }
 
 /**
@@ -46,5 +51,10 @@ export function clearStoredScenarioId(sessionCmId: number): void {
   if (!sessionCmId) return
   const store = readStore()
   Reflect.deleteProperty(store, String(sessionCmId))
-  localStorage.setItem(SCENARIO_STORAGE_KEY, JSON.stringify(store))
+  try {
+    localStorage.setItem(SCENARIO_STORAGE_KEY, JSON.stringify(store))
+  } catch {
+    // Swallow storage errors (QuotaExceededError, SecurityError, etc.).
+    // Persistence is best-effort; the app continues without it.
+  }
 }

--- a/frontend/src/utils/scenarioStorage.ts
+++ b/frontend/src/utils/scenarioStorage.ts
@@ -1,0 +1,50 @@
+/**
+ * localStorage helpers for last-active-scenario persistence.
+ *
+ * Stores scenario selections per session so:
+ *  - switching sessions doesn't lose your choice for another session
+ *  - refreshing the page restores the last selected scenario
+ *
+ * Storage format: { [sessionCmId: string]: scenarioId }
+ * Key: SCENARIO_STORAGE_KEY
+ */
+
+export const SCENARIO_STORAGE_KEY = 'kindred.scenarioBySession'
+
+function readStore(): Record<string, string> {
+  try {
+    const raw = localStorage.getItem(SCENARIO_STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as Record<string, string>) : {}
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Returns the stored scenario id for the given session, or null if none.
+ */
+export function getStoredScenarioId(sessionCmId: number): string | null {
+  if (!sessionCmId) return null
+  const store = readStore()
+  return store[String(sessionCmId)] ?? null
+}
+
+/**
+ * Persists the selected scenario id for the given session.
+ */
+export function setStoredScenarioId(sessionCmId: number, scenarioId: string): void {
+  if (!sessionCmId) return
+  const store = readStore()
+  store[String(sessionCmId)] = scenarioId
+  localStorage.setItem(SCENARIO_STORAGE_KEY, JSON.stringify(store))
+}
+
+/**
+ * Removes the stored scenario id for the given session (user switched to production mode).
+ */
+export function clearStoredScenarioId(sessionCmId: number): void {
+  if (!sessionCmId) return
+  const store = readStore()
+  Reflect.deleteProperty(store, String(sessionCmId))
+  localStorage.setItem(SCENARIO_STORAGE_KEY, JSON.stringify(store))
+}

--- a/frontend/src/utils/scenarioStorage.ts
+++ b/frontend/src/utils/scenarioStorage.ts
@@ -1,14 +1,4 @@
-/**
- * localStorage helpers for last-active-scenario persistence.
- *
- * Stores scenario selections per session so:
- *  - switching sessions doesn't lose your choice for another session
- *  - refreshing the page restores the last selected scenario
- *
- * Storage format: { [sessionCmId: string]: scenarioId }
- * Key: SCENARIO_STORAGE_KEY
- */
-
+// Storage format: { [sessionCmId]: scenarioId }
 export const SCENARIO_STORAGE_KEY = 'kindred.scenarioBySession'
 
 function readStore(): Record<string, string> {
@@ -20,41 +10,31 @@ function readStore(): Record<string, string> {
   }
 }
 
-/**
- * Returns the stored scenario id for the given session, or null if none.
- */
+function writeStore(store: Record<string, string>): void {
+  try {
+    localStorage.setItem(SCENARIO_STORAGE_KEY, JSON.stringify(store))
+  } catch {
+    // Swallow storage errors (QuotaExceededError, SecurityError, etc.).
+    // Persistence is best-effort; the app continues without it.
+  }
+}
+
 export function getStoredScenarioId(sessionCmId: number): string | null {
   if (!sessionCmId) return null
   const store = readStore()
   return store[String(sessionCmId)] ?? null
 }
 
-/**
- * Persists the selected scenario id for the given session.
- */
 export function setStoredScenarioId(sessionCmId: number, scenarioId: string): void {
   if (!sessionCmId) return
   const store = readStore()
   store[String(sessionCmId)] = scenarioId
-  try {
-    localStorage.setItem(SCENARIO_STORAGE_KEY, JSON.stringify(store))
-  } catch {
-    // Swallow storage errors (QuotaExceededError, SecurityError, etc.).
-    // Persistence is best-effort; the app continues without it.
-  }
+  writeStore(store)
 }
 
-/**
- * Removes the stored scenario id for the given session (user switched to production mode).
- */
 export function clearStoredScenarioId(sessionCmId: number): void {
   if (!sessionCmId) return
   const store = readStore()
   Reflect.deleteProperty(store, String(sessionCmId))
-  try {
-    localStorage.setItem(SCENARIO_STORAGE_KEY, JSON.stringify(store))
-  } catch {
-    // Swallow storage errors (QuotaExceededError, SecurityError, etc.).
-    // Persistence is best-effort; the app continues without it.
-  }
+  writeStore(store)
 }


### PR DESCRIPTION
## Summary

- Adds `scenarioStorage.ts` utility with `getStoredScenarioId` / `setStoredScenarioId` / `clearStoredScenarioId` (key: `kindred.scenarioBySession`, format: `{sessionCmId: scenarioId}`)
- Fixes a race condition in `ScenarioContext`: the old sync effect deleted the stored scenario key from localStorage on the initial mount (when `currentScenario` is null) **before** the restore logic had a chance to read it back. A new `restoreCompletedRef` gates the delete path so it only fires after the first restore attempt has completed for the session.
- On mount, if localStorage has a scenario id for the current session and that scenario still exists on the server, the context auto-selects it — no CampMinder source-of-truth default.

## Manual validation (dev/preview)

1. Log in and navigate to the bunking board for any session.
2. Select any named scenario from the scenario picker in the action bar.
3. Note the scenario name shown in the action bar.
4. Hard-refresh the page (Ctrl+Shift+R / Cmd+Shift+R).
5. **Expect**: the same scenario is still selected after reload — not production (CampMinder) view.
6. Open DevTools → Application → Local Storage → look for `kindred.scenarioBySession`; confirm the session's id maps to the chosen scenario id.
7. Delete the scenario via Scenario Management (or via API), then refresh.
8. **Expect**: the board falls back to production mode, and the stale key is removed from localStorage.
9. Switch to a different session, pick a scenario there, switch back to the first session.
10. **Expect**: each session independently remembers its last selected scenario.

## Closes

Scoreboard item #49 (`docs/plans/wife-feedback-2026-04-scoreboard.md` line 34) — bunking board restores last active scenario on refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Centralized scenario selection storage logic for improved clarity and maintainability
  * Enhanced scenario restoration to validate stored data before applying

* **Tests**
  * Added comprehensive test coverage for scenario storage operations
  * Added comprehensive test coverage for scenario context restoration behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->