### PR TITLE
feat(frontend): friend groups in session compare

### DIFF
--- a/frontend/src/pages/ScenarioComparisonPage.test.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.test.tsx
@@ -52,11 +52,8 @@ const palsGroup: LockGroupSummary = {
   memberCmIds: [1001, 1002, 1003],
 }
 
-function getPillRoot(displayName: string): HTMLElement {
-  const span = screen.getByText(displayName)
-  const root = span.closest('div')
-  if (!root) throw new Error(`pill root not found for ${displayName}`)
-  return root
+function getPillRoot(): HTMLElement {
+  return screen.getByTestId('camper-pill')
 }
 
 describe('FriendGroupPopover (CamperPill hover)', () => {
@@ -64,7 +61,7 @@ describe('FriendGroupPopover (CamperPill hover)', () => {
     render(
       <CamperPill camper={liam} status="unchanged" group={undefined} camperById={camperById} />
     )
-    fireEvent.mouseEnter(getPillRoot('Liam Garcia'))
+    fireEvent.mouseEnter(getPillRoot())
     expect(screen.queryByTestId('friend-group-popover')).toBeNull()
   })
 
@@ -72,7 +69,7 @@ describe('FriendGroupPopover (CamperPill hover)', () => {
     render(
       <CamperPill camper={liam} status="unchanged" group={palsGroup} camperById={camperById} />
     )
-    fireEvent.mouseEnter(getPillRoot('Liam Garcia'))
+    fireEvent.mouseEnter(getPillRoot())
 
     const popover = screen.getByTestId('friend-group-popover')
     expect(popover).toHaveTextContent('Pals')
@@ -86,10 +83,11 @@ describe('FriendGroupPopover (CamperPill hover)', () => {
     render(
       <CamperPill camper={liam} status="unchanged" group={palsGroup} camperById={camperById} />
     )
-    const root = getPillRoot('Liam Garcia')
+    const root = getPillRoot()
     fireEvent.mouseEnter(root)
     expect(screen.getByTestId('friend-group-popover')).toBeInTheDocument()
     fireEvent.mouseLeave(root)
+
     expect(screen.queryByTestId('friend-group-popover')).toBeNull()
   })
 
@@ -101,7 +99,7 @@ describe('FriendGroupPopover (CamperPill hover)', () => {
     render(
       <CamperPill camper={liam} status="unchanged" group={groupWithGhost} camperById={camperById} />
     )
-    fireEvent.mouseEnter(getPillRoot('Liam Garcia'))
+    fireEvent.mouseEnter(getPillRoot())
     const popover = screen.getByTestId('friend-group-popover')
     expect(popover).toHaveTextContent('<unknown camper>')
     expect(popover).toHaveTextContent('Liam Garcia')
@@ -112,7 +110,7 @@ describe('FriendGroupPopover (CamperPill hover)', () => {
     render(
       <CamperPill camper={liam} status="unchanged" group={singleGroup} camperById={camperById} />
     )
-    fireEvent.mouseEnter(getPillRoot('Liam Garcia'))
+    fireEvent.mouseEnter(getPillRoot())
     const popover = screen.getByTestId('friend-group-popover')
     expect(popover).toHaveTextContent('Pals')
     const memberRows = popover.querySelectorAll('[data-testid="friend-group-member"]')

--- a/frontend/src/pages/ScenarioComparisonPage.test.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { afterEach } from 'vitest'
+
+import { CamperPill } from './ScenarioComparisonPage'
+import type { LockGroupSummary } from '../utils/scenarioComparisonUtils'
+
+afterEach(cleanup)
+
+const liam = {
+  personId: 'p1',
+  personCmId: 1001,
+  name: 'Liam Garcia',
+  firstName: 'Liam',
+  lastName: 'Garcia',
+  age: 11,
+  grade: 5,
+  gender: 'male',
+  bunkId: 'b1',
+  bunkName: 'Bunk A',
+  bunkPlanId: 'plan1',
+}
+
+const olivia = {
+  ...liam,
+  personId: 'p2',
+  personCmId: 1002,
+  name: 'Olivia Chen',
+  firstName: 'Olivia',
+  lastName: 'Chen',
+}
+
+const emma = {
+  ...liam,
+  personId: 'p3',
+  personCmId: 1003,
+  name: 'Emma Johnson',
+  firstName: 'Emma',
+  lastName: 'Johnson',
+}
+
+const camperById = new Map([
+  [1001, liam],
+  [1002, olivia],
+  [1003, emma],
+])
+
+const palsGroup: LockGroupSummary = {
+  id: 'g1',
+  name: 'Pals',
+  color: '#ff0000',
+  memberCmIds: [1001, 1002, 1003],
+}
+
+function getPillRoot(displayName: string): HTMLElement {
+  const span = screen.getByText(displayName)
+  const root = span.closest('div')
+  if (!root) throw new Error(`pill root not found for ${displayName}`)
+  return root
+}
+
+describe('FriendGroupPopover (CamperPill hover)', () => {
+  it('does not render a popover when the hovered camper is not in any friend group', () => {
+    render(
+      <CamperPill camper={liam} status="unchanged" group={undefined} camperById={camperById} />
+    )
+    fireEvent.mouseEnter(getPillRoot('Liam Garcia'))
+    expect(screen.queryByTestId('friend-group-popover')).toBeNull()
+  })
+
+  it('opens a popover with header + member rows on mouseenter of a grouped pill', () => {
+    render(
+      <CamperPill camper={liam} status="unchanged" group={palsGroup} camperById={camperById} />
+    )
+    fireEvent.mouseEnter(getPillRoot('Liam Garcia'))
+
+    const popover = screen.getByTestId('friend-group-popover')
+    expect(popover).toHaveTextContent('Pals')
+    const memberRows = popover.querySelectorAll('[data-testid="friend-group-member"]')
+    expect(memberRows.length).toBe(3)
+    const memberTexts = Array.from(memberRows).map((el) => el.textContent)
+    expect(memberTexts).toEqual(['Emma Johnson', 'Liam Garcia', 'Olivia Chen'])
+  })
+
+  it('closes the popover on mouseleave', () => {
+    render(
+      <CamperPill camper={liam} status="unchanged" group={palsGroup} camperById={camperById} />
+    )
+    const root = getPillRoot('Liam Garcia')
+    fireEvent.mouseEnter(root)
+    expect(screen.getByTestId('friend-group-popover')).toBeInTheDocument()
+    fireEvent.mouseLeave(root)
+    expect(screen.queryByTestId('friend-group-popover')).toBeNull()
+  })
+
+  it('renders members with no matching CamperAssignment as <unknown camper>', () => {
+    const groupWithGhost: LockGroupSummary = {
+      ...palsGroup,
+      memberCmIds: [1001, 9999],
+    }
+    render(
+      <CamperPill camper={liam} status="unchanged" group={groupWithGhost} camperById={camperById} />
+    )
+    fireEvent.mouseEnter(getPillRoot('Liam Garcia'))
+    const popover = screen.getByTestId('friend-group-popover')
+    expect(popover).toHaveTextContent('<unknown camper>')
+    expect(popover).toHaveTextContent('Liam Garcia')
+  })
+
+  it('renders header + 1 row when group has a single member', () => {
+    const singleGroup: LockGroupSummary = { ...palsGroup, memberCmIds: [1001] }
+    render(
+      <CamperPill camper={liam} status="unchanged" group={singleGroup} camperById={camperById} />
+    )
+    fireEvent.mouseEnter(getPillRoot('Liam Garcia'))
+    const popover = screen.getByTestId('friend-group-popover')
+    expect(popover).toHaveTextContent('Pals')
+    const memberRows = popover.querySelectorAll('[data-testid="friend-group-member"]')
+    expect(memberRows.length).toBe(1)
+    expect(memberRows[0]?.textContent).toBe('Liam Garcia')
+  })
+})

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -69,11 +69,15 @@ type ExpandedGroupMember = LockedGroupMembersResponse & {
  * Fetch locked groups and their members for a given scenario+session, then
  * return a Map of personCmId → LockGroupSummary.
  */
-async function fetchGroupMap(
+// Returns serializable entries (Array<[cmId, summary]>) — NOT a Map.
+// React Query's default structural sharing strips the Map prototype on
+// refetch, so we keep the cache value as a plain array and rebuild the
+// Map at the hook boundary.
+async function fetchGroupEntries(
   scenarioId: string,
   sessionPbId: string,
   year: number
-): Promise<Map<number, LockGroupSummary>> {
+): Promise<Array<[number, LockGroupSummary]>> {
   const groups = await pb.collection('locked_groups').getFullList<LockedGroupsResponse>({
     filter: pb.filter('scenario = {:scenario} && session = {:session} && year = {:year}', {
       scenario: scenarioId,
@@ -83,7 +87,7 @@ async function fetchGroupMap(
     sort: 'created',
   })
 
-  if (groups.length === 0) return new Map()
+  if (groups.length === 0) return []
 
   const groupIds = groups.map((g) => g.id)
   const filterParts = groupIds.map((_, i) => `group = {:g${i}}`)
@@ -111,15 +115,14 @@ async function fetchGroupMap(
     }
   }
 
-  // Build personCmId → group summary map
-  const personToGroup = new Map<number, LockGroupSummary>()
+  // Flatten to entries — one entry per (cm_id, group) pair.
+  const entries: Array<[number, LockGroupSummary]> = []
   for (const summary of summaryById.values()) {
     for (const cmId of summary.memberCmIds) {
-      personToGroup.set(cmId, summary)
+      entries.push([cmId, summary])
     }
   }
-
-  return personToGroup
+  return entries
 }
 
 // Types for comparison
@@ -199,17 +202,15 @@ function useGroupMap(
   currentYear: number,
   user: ReturnType<typeof useAuth>['user']
 ) {
-  const { data: groupMap = new Map<number, LockGroupSummary>() } = useQuery({
+  const { data: groupEntries = [] } = useQuery({
     queryKey: queryKeys.lockedGroups(scenarioId, sessionPbId, currentYear),
-    queryFn: () => fetchGroupMap(scenarioId, sessionPbId, currentYear),
+    queryFn: () => fetchGroupEntries(scenarioId, sessionPbId, currentYear),
     ...userDataOptions,
     enabled: !!user && scenarioId !== 'production' && scenarioId !== '' && !!sessionPbId,
-    // Disable React Query's default structural sharing — it deep-walks results
-    // assuming plain objects/arrays, which mangles `Map` instances on refetch
-    // (the returned value loses its prototype, so `.get` is undefined).
-    structuralSharing: false,
   })
-  return groupMap
+  // Rebuild Map at hook boundary so the page can use `.get`. Entries are
+  // serializable; the Map is a render-time derived value.
+  return useMemo(() => new Map(groupEntries), [groupEntries])
 }
 
 export default function ScenarioComparisonPage() {

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -574,8 +574,8 @@ export default function ScenarioComparisonPage() {
   // Create bunk comparison data with movement tracking
   const bunkComparisons = useMemo((): BunkComparison[] => {
     return filteredBunks.map((bunk) => {
-      const leftCampers = leftAssignments.filter((a) => a.bunkId === bunk.id)
-      const rightCampers = rightAssignments.filter((a) => a.bunkId === bunk.id)
+      const leftCampers = Array.from(leftByPerson.values()).filter((a) => a.bunkId === bunk.id)
+      const rightCampers = Array.from(rightByPerson.values()).filter((a) => a.bunkId === bunk.id)
 
       const leftPersonIds = new Set(leftCampers.map((c) => c.personCmId))
       const rightPersonIds = new Set(rightCampers.map((c) => c.personCmId))
@@ -611,7 +611,7 @@ export default function ScenarioComparisonPage() {
         movedOut,
       }
     })
-  }, [filteredBunks, leftAssignments, rightAssignments, leftByPerson, rightByPerson])
+  }, [filteredBunks, leftByPerson, rightByPerson])
 
   // Filter changes based on selected filter
   const filteredChanges = useMemo(() => {
@@ -1393,7 +1393,7 @@ export function FriendGroupPopover({ group, camperById }: FriendGroupPopoverProp
   return (
     <div
       data-testid="friend-group-popover"
-      role="dialog"
+      role="tooltip"
       aria-label={`Friend group: ${group.name}`}
       className="border-border/60 bg-popover absolute top-full left-0 z-50 mt-1 min-w-[200px] rounded-lg border p-3 shadow-lg"
     >
@@ -1443,6 +1443,7 @@ export function CamperPill({
 
   return (
     <div
+      data-testid="camper-pill"
       className={clsx(
         'relative flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition-all',
         status === 'unchanged' && 'bg-muted/50',

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -32,6 +32,9 @@ import type {
   BunksResponse,
   BunkPlansResponse,
   CampSessionsResponse,
+  LockedGroupsResponse,
+  LockedGroupMembersResponse,
+  AttendeesResponse,
 } from '../types/pocketbase-types'
 import { useYear } from '../hooks/useCurrentYear'
 import { useAuth } from '../contexts/AuthContext'
@@ -43,12 +46,86 @@ import {
   compareCamperByName,
   sortCampersByName,
   getAvailableBunkAreas,
+  diffGroups,
   type BunkArea,
+  type LockGroupSummary,
+  type GroupDiffResult,
 } from '../utils/scenarioComparisonUtils'
 import { solverService } from '../services/solver'
 import type { Session } from '../types/app-types'
 import { buildCsvContent, downloadCsv, slugify, todayIso } from '../utils/csvExport'
 import { buildMovedRows, MOVED_CSV_HEADERS } from '../utils/csvExportHelpers'
+
+// Group color palette mirrors LockGroupPanel.tsx GROUP_COLORS (bunking-board palette).
+// Colors are stored in the DB (locked_groups.color) and retrieved via API queries;
+// this array is retained here only for documentation purposes — actual rendering
+// uses the color value directly from the fetched LockGroupSummary.color field.
+// Do NOT import from graph modules.
+
+// Expanded member type for locked_group_members with attendee.person_id.
+type ExpandedGroupMember = LockedGroupMembersResponse & {
+  expand?: {
+    attendee?: AttendeesResponse & {
+      expand?: {
+        person?: { id: string; cm_id: number }
+      }
+    }
+  }
+}
+
+/**
+ * Fetch locked groups and their members for a given scenario+session, then
+ * return a Map of personCmId → LockGroupSummary.
+ */
+async function fetchGroupMap(
+  scenarioId: string,
+  sessionPbId: string,
+  year: number
+): Promise<Map<number, LockGroupSummary>> {
+  const groups = await pb.collection('locked_groups').getFullList<LockedGroupsResponse>({
+    filter: pb.filter('scenario = {:scenario} && session = {:session} && year = {:year}', {
+      scenario: scenarioId,
+      session: sessionPbId,
+      year,
+    }),
+    sort: 'created',
+  })
+
+  if (groups.length === 0) return new Map()
+
+  const groupIds = groups.map((g) => g.id)
+  const filterParts = groupIds.map((_, i) => `group = {:g${i}}`)
+  const filterParams = groupIds.reduce((acc, id, i) => ({ ...acc, [`g${i}`]: id }), {})
+  const filter = pb.filter(filterParts.join(' || '), filterParams)
+
+  const members = await pb.collection('locked_group_members').getFullList<ExpandedGroupMember>({
+    filter,
+    expand: 'attendee,attendee.person',
+  })
+
+  // Build group id → summary
+  const summaryById = new Map<string, LockGroupSummary>()
+  for (const g of groups) {
+    summaryById.set(g.id, { id: g.id, name: g.name, color: g.color, memberCmIds: [] })
+  }
+  for (const m of members) {
+    const personCmId = m.expand?.attendee?.person_id
+    const groupSummary = summaryById.get(m.group)
+    if (personCmId && groupSummary) {
+      groupSummary.memberCmIds.push(personCmId)
+    }
+  }
+
+  // Build personCmId → group summary map
+  const personToGroup = new Map<number, LockGroupSummary>()
+  for (const summary of summaryById.values()) {
+    for (const cmId of summary.memberCmIds) {
+      personToGroup.set(cmId, summary)
+    }
+  }
+
+  return personToGroup
+}
 
 // Types for comparison
 interface CamperAssignment {
@@ -241,6 +318,25 @@ export default function ScenarioComparisonPage() {
     },
     ...userDataOptions,
     enabled: !!user && rightScenarioId !== 'production' && rightScenarioId !== '',
+  })
+
+  // PocketBase session ID (needed for locked-group queries)
+  const sessionPbId = session?.id ?? ''
+
+  // Fetch locked-group → member maps for each scenario.
+  // Production has no locked groups (they are scenario-specific draft data).
+  const { data: leftGroupMap = new Map<number, LockGroupSummary>() } = useQuery({
+    queryKey: ['compare-locked-groups', leftScenarioId, sessionPbId, currentYear],
+    queryFn: () => fetchGroupMap(leftScenarioId, sessionPbId, currentYear),
+    ...userDataOptions,
+    enabled: !!user && leftScenarioId !== 'production' && leftScenarioId !== '' && !!sessionPbId,
+  })
+
+  const { data: rightGroupMap = new Map<number, LockGroupSummary>() } = useQuery({
+    queryKey: ['compare-locked-groups', rightScenarioId, sessionPbId, currentYear],
+    queryFn: () => fetchGroupMap(rightScenarioId, sessionPbId, currentYear),
+    ...userDataOptions,
+    enabled: !!user && rightScenarioId !== 'production' && rightScenarioId !== '' && !!sessionPbId,
   })
 
   // Fetch validation scores for both scenarios
@@ -500,6 +596,18 @@ export default function ScenarioComparisonPage() {
     })
   }, [filteredBunks, leftAssignments, rightAssignments])
 
+  // Build group-diff summary for the header chip.
+  // Collect unique LockGroupSummary objects from each side's group map.
+  const groupDiff = useMemo(() => {
+    const leftGroups = Array.from(
+      new Map(Array.from(leftGroupMap.values()).map((g) => [g.id, g])).values()
+    )
+    const rightGroups = Array.from(
+      new Map(Array.from(rightGroupMap.values()).map((g) => [g.id, g])).values()
+    )
+    return diffGroups(leftGroups, rightGroups)
+  }, [leftGroupMap, rightGroupMap])
+
   // Filter changes based on selected filter
   const filteredChanges = useMemo(() => {
     switch (changeFilter) {
@@ -745,6 +853,11 @@ export default function ScenarioComparisonPage() {
               </div>
             )}
 
+            {/* Friend Group Diff Summary — only shown when at least one side has groups */}
+            {(groupDiff.leftCount > 0 || groupDiff.rightCount > 0) && (
+              <FriendGroupDiffChip diff={groupDiff} />
+            )}
+
             {/* Metrics Summary */}
             <div className="mb-6 grid grid-cols-2 gap-4 md:grid-cols-4">
               <MetricCard
@@ -884,6 +997,8 @@ export default function ScenarioComparisonPage() {
                     comparison={bunkComp}
                     leftLabel={leftScenarioName}
                     rightLabel={rightScenarioName}
+                    leftGroupMap={leftGroupMap}
+                    rightGroupMap={rightGroupMap}
                   />
                 ))}
               </div>
@@ -1148,14 +1263,74 @@ function MetricCard({ label, value, sublabel, icon: Icon, color, trend }: Metric
   )
 }
 
+// ---------------------------------------------------------------------------
+// FriendGroupDiffChip — summary bar showing group counts across scenarios
+// ---------------------------------------------------------------------------
+
+interface FriendGroupDiffChipProps {
+  diff: GroupDiffResult
+}
+
+function FriendGroupDiffChip({ diff }: FriendGroupDiffChipProps) {
+  const parts = [
+    { label: `Left: ${diff.leftCount}` },
+    { label: `Right: ${diff.rightCount}` },
+    { label: `Identical: ${diff.identical.length}`, accent: diff.identical.length > 0 },
+    {
+      label: `Unique to L: ${diff.uniqueL.length}`,
+      warn: diff.uniqueL.length > 0,
+    },
+    {
+      label: `Unique to R: ${diff.uniqueR.length}`,
+      warn: diff.uniqueR.length > 0,
+    },
+    {
+      label: `Modified: ${diff.modified.length}`,
+      modified: diff.modified.length > 0,
+    },
+  ]
+
+  return (
+    <div className="card-lodge mb-4 flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-3">
+      <span className="text-muted-foreground mr-1 flex items-center gap-1.5 text-xs font-semibold tracking-wider uppercase">
+        <Users className="h-3.5 w-3.5" />
+        Friend Groups
+      </span>
+      {parts.map((p, i) => (
+        <span
+          key={i}
+          className={clsx(
+            'text-sm font-medium',
+            p.accent && 'text-forest-600 dark:text-forest-400',
+            p.warn && 'text-amber-600 dark:text-amber-400',
+            p.modified && 'text-bark-600 dark:text-bark-400',
+            !p.accent && !p.warn && !p.modified && 'text-muted-foreground'
+          )}
+        >
+          {i > 0 && <span className="text-muted-foreground/40 mr-3">·</span>}
+          {p.label}
+        </span>
+      ))}
+    </div>
+  )
+}
+
 // Bunk Comparison Card (Split View)
 interface BunkComparisonCardProps {
   comparison: BunkComparison
   leftLabel: string
   rightLabel: string
+  leftGroupMap: Map<number, LockGroupSummary>
+  rightGroupMap: Map<number, LockGroupSummary>
 }
 
-function BunkComparisonCard({ comparison, leftLabel, rightLabel }: BunkComparisonCardProps) {
+function BunkComparisonCard({
+  comparison,
+  leftLabel,
+  rightLabel,
+  leftGroupMap,
+  rightGroupMap,
+}: BunkComparisonCardProps) {
   const hasChanges = comparison.movedIn.length > 0 || comparison.movedOut.length > 0
   const movedInIds = new Set(comparison.movedIn.map((c) => c.camper.personCmId))
   const movedOutIds = new Set(comparison.movedOut.map((c) => c.camper.personCmId))
@@ -1211,6 +1386,8 @@ function BunkComparisonCard({ comparison, leftLabel, rightLabel }: BunkCompariso
                   camper={camper}
                   status={movedOutIds.has(camper.personCmId) ? 'moved-out' : 'unchanged'}
                   destination={movedOutDestinations.get(camper.personCmId)}
+                  groupColor={leftGroupMap.get(camper.personCmId)?.color}
+                  groupName={leftGroupMap.get(camper.personCmId)?.name}
                 />
               ))
             )}
@@ -1232,6 +1409,8 @@ function BunkComparisonCard({ comparison, leftLabel, rightLabel }: BunkCompariso
                   camper={camper}
                   status={movedInIds.has(camper.personCmId) ? 'moved-in' : 'unchanged'}
                   origin={movedInOrigins.get(camper.personCmId)}
+                  groupColor={rightGroupMap.get(camper.personCmId)?.color}
+                  groupName={rightGroupMap.get(camper.personCmId)?.name}
                 />
               ))
             )}
@@ -1242,15 +1421,24 @@ function BunkComparisonCard({ comparison, leftLabel, rightLabel }: BunkCompariso
   )
 }
 
-// Camper Pill Component with origin/destination info
+// Camper Pill Component with origin/destination info and optional friend-group dot
 interface CamperPillProps {
   camper: CamperAssignment
   status: 'unchanged' | 'moved-in' | 'moved-out'
   origin?: string | undefined // Where they came from (for moved-in)
   destination?: string | undefined // Where they went (for moved-out)
+  groupColor?: string | undefined // Hex color from locked_groups.color
+  groupName?: string | undefined // Group name for tooltip
 }
 
-function CamperPill({ camper, status, origin, destination }: CamperPillProps) {
+function CamperPill({
+  camper,
+  status,
+  origin,
+  destination,
+  groupColor,
+  groupName,
+}: CamperPillProps) {
   return (
     <div
       className={clsx(
@@ -1262,6 +1450,15 @@ function CamperPill({ camper, status, origin, destination }: CamperPillProps) {
           'bg-red-50 opacity-75 ring-1 ring-red-200 dark:bg-red-900/20 dark:ring-red-800'
       )}
     >
+      {/* Friend-group color dot */}
+      {groupColor && (
+        <span
+          className="inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full"
+          style={{ backgroundColor: groupColor }}
+          title={groupName ? `Friend group: ${groupName}` : 'Friend group'}
+          aria-label={groupName ? `Friend group: ${groupName}` : 'Friend group'}
+        />
+      )}
       <span className={clsx('font-medium', status === 'moved-out' && 'line-through')}>
         {camper.name}
       </span>

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -994,6 +994,8 @@ export default function ScenarioComparisonPage() {
                     rightLabel={rightScenarioName}
                     leftGroupMap={leftGroupMap}
                     rightGroupMap={rightGroupMap}
+                    leftCamperById={leftByPerson}
+                    rightCamperById={rightByPerson}
                   />
                 ))}
               </div>
@@ -1265,6 +1267,8 @@ interface BunkComparisonCardProps {
   rightLabel: string
   leftGroupMap: Map<number, LockGroupSummary>
   rightGroupMap: Map<number, LockGroupSummary>
+  leftCamperById: Map<number, CamperAssignment>
+  rightCamperById: Map<number, CamperAssignment>
 }
 
 function BunkComparisonCard({
@@ -1273,6 +1277,8 @@ function BunkComparisonCard({
   rightLabel,
   leftGroupMap,
   rightGroupMap,
+  leftCamperById,
+  rightCamperById,
 }: BunkComparisonCardProps) {
   const hasChanges = comparison.movedIn.length > 0 || comparison.movedOut.length > 0
   const movedInIds = new Set(comparison.movedIn.map((c) => c.camper.personCmId))
@@ -1330,6 +1336,7 @@ function BunkComparisonCard({
                   status={movedOutIds.has(camper.personCmId) ? 'moved-out' : 'unchanged'}
                   destination={movedOutDestinations.get(camper.personCmId)}
                   group={leftGroupMap.get(camper.personCmId)}
+                  camperById={leftCamperById}
                 />
               ))
             )}
@@ -1352,6 +1359,7 @@ function BunkComparisonCard({
                   status={movedInIds.has(camper.personCmId) ? 'moved-in' : 'unchanged'}
                   origin={movedInOrigins.get(camper.personCmId)}
                   group={rightGroupMap.get(camper.personCmId)}
+                  camperById={rightCamperById}
                 />
               ))
             )}
@@ -1362,32 +1370,89 @@ function BunkComparisonCard({
   )
 }
 
+// FriendGroupPopover — same-side member list shown on CamperPill hover
+export interface FriendGroupPopoverProps {
+  group: LockGroupSummary
+  camperById: Map<number, CamperAssignment>
+}
+
+export function FriendGroupPopover({ group, camperById }: FriendGroupPopoverProps) {
+  const rows = group.memberCmIds
+    .map((cmId) => ({ cmId, camper: camperById.get(cmId) }))
+    .sort((a, b) => {
+      const an = a.camper?.name ?? '￿'
+      const bn = b.camper?.name ?? '￿'
+      return an.localeCompare(bn)
+    })
+
+  return (
+    <div
+      data-testid="friend-group-popover"
+      role="dialog"
+      aria-label={`Friend group: ${group.name}`}
+      className="border-border/60 bg-popover absolute top-full left-0 z-50 mt-1 min-w-[200px] rounded-lg border p-3 shadow-lg"
+    >
+      <div className="border-border/40 mb-2 flex items-center gap-2 border-b pb-2">
+        <span
+          className="inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full"
+          style={{ backgroundColor: group.color }}
+          aria-hidden
+        />
+        <span className="text-sm font-semibold">{group.name}</span>
+      </div>
+      <ul className="space-y-1">
+        {rows.map(({ cmId, camper }) => (
+          <li
+            key={cmId}
+            data-testid="friend-group-member"
+            className={clsx('text-sm', !camper && 'text-muted-foreground italic')}
+          >
+            {camper?.name ?? '<unknown camper>'}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
 // Camper Pill Component with origin/destination info and optional friend-group dot
-interface CamperPillProps {
+export interface CamperPillProps {
   camper: CamperAssignment
   status: 'unchanged' | 'moved-in' | 'moved-out'
   origin?: string | undefined // Where they came from (for moved-in)
   destination?: string | undefined // Where they went (for moved-out)
-  group?: Pick<LockGroupSummary, 'color' | 'name'> | undefined
+  group?: LockGroupSummary | undefined
+  camperById: Map<number, CamperAssignment>
 }
 
-function CamperPill({ camper, status, origin, destination, group }: CamperPillProps) {
+export function CamperPill({
+  camper,
+  status,
+  origin,
+  destination,
+  group,
+  camperById,
+}: CamperPillProps) {
+  const [hovered, setHovered] = useState(false)
+  const showPopover = hovered && group !== undefined
+
   return (
     <div
       className={clsx(
-        'flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition-all',
+        'relative flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition-all',
         status === 'unchanged' && 'bg-muted/50',
         status === 'moved-in' &&
           'bg-forest-100 dark:bg-forest-900/30 ring-forest-300 dark:ring-forest-700 ring-1',
         status === 'moved-out' &&
           'bg-red-50 opacity-75 ring-1 ring-red-200 dark:bg-red-900/20 dark:ring-red-800'
       )}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
     >
       {group?.color && (
         <span
           className="inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full"
           style={{ backgroundColor: group.color }}
-          title={group.name ? `Friend group: ${group.name}` : 'Friend group'}
           aria-label={group.name ? `Friend group: ${group.name}` : 'Friend group'}
         />
       )}
@@ -1409,6 +1474,7 @@ function CamperPill({ camper, status, origin, destination, group }: CamperPillPr
           <span className="opacity-80">{destination}</span>
         </span>
       )}
+      {showPopover && <FriendGroupPopover group={group} camperById={camperById} />}
     </div>
   )
 }

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -204,6 +204,10 @@ function useGroupMap(
     queryFn: () => fetchGroupMap(scenarioId, sessionPbId, currentYear),
     ...userDataOptions,
     enabled: !!user && scenarioId !== 'production' && scenarioId !== '' && !!sessionPbId,
+    // Disable React Query's default structural sharing — it deep-walks results
+    // assuming plain objects/arrays, which mangles `Map` instances on refetch
+    // (the returned value loses its prototype, so `.get` is undefined).
+    structuralSharing: false,
   })
   return groupMap
 }
@@ -606,7 +610,7 @@ export default function ScenarioComparisonPage() {
         movedOut,
       }
     })
-  }, [filteredBunks, leftByPerson, rightByPerson])
+  }, [filteredBunks, leftAssignments, rightAssignments, leftByPerson, rightByPerson])
 
   // Filter changes based on selected filter
   const filteredChanges = useMemo(() => {

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -447,11 +447,19 @@ export default function ScenarioComparisonPage() {
     return normalizeAssignments(rightDraftAssignments as ExpandedAssignment[])
   }, [rightScenarioId, productionAssignments, rightDraftAssignments, normalizeAssignments])
 
+  // Lookup Maps used by both `comparison` below and by FriendGroupPopover
+  // to resolve friend-group members. Keyed by personCmId.
+  const leftByPerson = useMemo(
+    () => new Map(leftAssignments.map((a) => [a.personCmId, a])),
+    [leftAssignments]
+  )
+  const rightByPerson = useMemo(
+    () => new Map(rightAssignments.map((a) => [a.personCmId, a])),
+    [rightAssignments]
+  )
+
   // Compute comparison result
   const comparison = useMemo((): ComparisonResult => {
-    const leftByPerson = new Map(leftAssignments.map((a) => [a.personCmId, a]))
-    const rightByPerson = new Map(rightAssignments.map((a) => [a.personCmId, a]))
-
     const moved: ComparisonResult['moved'] = []
     const newlyAssigned: ComparisonResult['newlyAssigned'] = []
     const newlyUnassigned: ComparisonResult['newlyUnassigned'] = []
@@ -491,7 +499,7 @@ export default function ScenarioComparisonPage() {
     }
 
     const totalChanges = moved.length + newlyAssigned.length + newlyUnassigned.length
-    const totalInvolved = Math.max(leftAssignments.length, rightAssignments.length)
+    const totalInvolved = Math.max(leftByPerson.size, rightByPerson.size)
 
     // Sort change lists alphabetically by camper name (last, then first) so both
     // sides of the comparison present a stable, scannable order.
@@ -505,8 +513,8 @@ export default function ScenarioComparisonPage() {
       unchanged: sortCampersByName(unchanged),
       metrics: {
         totalCampers: {
-          left: leftAssignments.length,
-          right: rightAssignments.length,
+          left: leftByPerson.size,
+          right: rightByPerson.size,
         },
         movedCount: moved.length,
         newlyAssignedCount: newlyAssigned.length,
@@ -515,7 +523,7 @@ export default function ScenarioComparisonPage() {
         changePercentage: totalInvolved > 0 ? Math.round((totalChanges / totalInvolved) * 100) : 0,
       },
     }
-  }, [leftAssignments, rightAssignments])
+  }, [leftByPerson, rightByPerson])
 
   // Get all unique bunks for split view
   const allBunks = useMemo(() => {
@@ -560,10 +568,6 @@ export default function ScenarioComparisonPage() {
 
   // Create bunk comparison data with movement tracking
   const bunkComparisons = useMemo((): BunkComparison[] => {
-    // Build lookup maps for movement tracking
-    const leftByPerson = new Map(leftAssignments.map((a) => [a.personCmId, a]))
-    const rightByPerson = new Map(rightAssignments.map((a) => [a.personCmId, a]))
-
     return filteredBunks.map((bunk) => {
       const leftCampers = leftAssignments.filter((a) => a.bunkId === bunk.id)
       const rightCampers = rightAssignments.filter((a) => a.bunkId === bunk.id)
@@ -602,7 +606,7 @@ export default function ScenarioComparisonPage() {
         movedOut,
       }
     })
-  }, [filteredBunks, leftAssignments, rightAssignments])
+  }, [filteredBunks, leftByPerson, rightByPerson])
 
   // Filter changes based on selected filter
   const filteredChanges = useMemo(() => {

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -46,10 +46,8 @@ import {
   compareCamperByName,
   sortCampersByName,
   getAvailableBunkAreas,
-  diffGroups,
   type BunkArea,
   type LockGroupSummary,
-  type GroupDiffResult,
 } from '../utils/scenarioComparisonUtils'
 import { solverService } from '../services/solver'
 import type { Session } from '../types/app-types'
@@ -122,11 +120,6 @@ async function fetchGroupMap(
   }
 
   return personToGroup
-}
-
-/** Deduplicate LockGroupSummary values from a Map by group id. */
-function uniqueById(map: Map<number, LockGroupSummary>): LockGroupSummary[] {
-  return Array.from(new Map(Array.from(map.values()).map((g) => [g.id, g])).values())
 }
 
 // Types for comparison
@@ -611,13 +604,6 @@ export default function ScenarioComparisonPage() {
     })
   }, [filteredBunks, leftAssignments, rightAssignments])
 
-  // Build group-diff summary for the header chip.
-  // Collect unique LockGroupSummary objects from each side's group map.
-  const groupDiff = useMemo(
-    () => diffGroups(uniqueById(leftGroupMap), uniqueById(rightGroupMap)),
-    [leftGroupMap, rightGroupMap]
-  )
-
   // Filter changes based on selected filter
   const filteredChanges = useMemo(() => {
     switch (changeFilter) {
@@ -861,11 +847,6 @@ export default function ScenarioComparisonPage() {
                   />
                 </div>
               </div>
-            )}
-
-            {/* Friend Group Diff Summary — only shown when at least one side has groups */}
-            {(groupDiff.leftCount > 0 || groupDiff.rightCount > 0) && (
-              <FriendGroupDiffChip diff={groupDiff} />
             )}
 
             {/* Metrics Summary */}
@@ -1269,58 +1250,6 @@ function MetricCard({ label, value, sublabel, icon: Icon, color, trend }: Metric
       <div className="stat-card-value text-2xl">{value}</div>
       <div className="text-muted-foreground mt-1 text-xs">{label}</div>
       {sublabel && <div className="text-muted-foreground/70 mt-0.5 text-xs">{sublabel}</div>}
-    </div>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// FriendGroupDiffChip — summary bar showing group counts across scenarios
-// ---------------------------------------------------------------------------
-
-interface FriendGroupDiffChipProps {
-  diff: GroupDiffResult
-}
-
-function FriendGroupDiffChip({ diff }: FriendGroupDiffChipProps) {
-  const parts = [
-    { label: `Left: ${diff.leftCount}` },
-    { label: `Right: ${diff.rightCount}` },
-    { label: `Identical: ${diff.identical.length}`, accent: diff.identical.length > 0 },
-    {
-      label: `Unique to L: ${diff.uniqueL.length}`,
-      warn: diff.uniqueL.length > 0,
-    },
-    {
-      label: `Unique to R: ${diff.uniqueR.length}`,
-      warn: diff.uniqueR.length > 0,
-    },
-    {
-      label: `Modified: ${diff.modified.length}`,
-      modified: diff.modified.length > 0,
-    },
-  ]
-
-  return (
-    <div className="card-lodge mb-4 flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-3">
-      <span className="text-muted-foreground mr-1 flex items-center gap-1.5 text-xs font-semibold tracking-wider uppercase">
-        <Users className="h-3.5 w-3.5" />
-        Friend Groups
-      </span>
-      {parts.map((p, i) => (
-        <span
-          key={i}
-          className={clsx(
-            'text-sm font-medium',
-            p.accent && 'text-forest-600 dark:text-forest-400',
-            p.warn && 'text-amber-600 dark:text-amber-400',
-            p.modified && 'text-bark-600 dark:text-bark-400',
-            !p.accent && !p.warn && !p.modified && 'text-muted-foreground'
-          )}
-        >
-          {i > 0 && <span className="text-muted-foreground/40 mr-3">·</span>}
-          {p.label}
-        </span>
-      ))}
     </div>
   )
 }

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -62,7 +62,7 @@ import { buildMovedRows, MOVED_CSV_HEADERS } from '../utils/csvExportHelpers'
 // uses the color value directly from the fetched LockGroupSummary.color field.
 // Do NOT import from graph modules.
 
-// Expanded member type for locked_group_members with attendee.person_id.
+// Expanded member type for locked_group_members with attendee.person (double-expanded).
 type ExpandedGroupMember = LockedGroupMembersResponse & {
   expand?: {
     attendee?: AttendeesResponse & {
@@ -109,7 +109,10 @@ async function fetchGroupMap(
     summaryById.set(g.id, { id: g.id, name: g.name, color: g.color, memberCmIds: [] })
   }
   for (const m of members) {
-    const personCmId = m.expand?.attendee?.person_id
+    // Use the double-expanded person.cm_id — the expand key is 'attendee,attendee.person',
+    // so cm_id is guaranteed present on the typed expand (unlike person_id which is a
+    // top-level field whose PocketBase serialization is version-specific).
+    const personCmId = m.expand?.attendee?.expand?.person?.cm_id
     const groupSummary = summaryById.get(m.group)
     if (personCmId && groupSummary) {
       groupSummary.memberCmIds.push(personCmId)
@@ -270,7 +273,10 @@ export default function ScenarioComparisonPage() {
           bunk_plan: BunkPlansResponse
         }>
       >({
-        filter: `session.cm_id = ${sessionCmId} && year = ${currentYear}`,
+        filter: pb.filter('session.cm_id = {:sessionCmId} && year = {:year}', {
+          sessionCmId,
+          year: currentYear,
+        }),
         expand: 'person,bunk,bunk_plan',
       })
       return result
@@ -291,7 +297,10 @@ export default function ScenarioComparisonPage() {
           bunk_plan: BunkPlansResponse
         }>
       >({
-        filter: `scenario = "${leftScenarioId}" && year = ${currentYear}`,
+        filter: pb.filter('scenario = {:scenario} && year = {:year}', {
+          scenario: leftScenarioId,
+          year: currentYear,
+        }),
         expand: 'person,bunk,bunk_plan',
       })
       return result
@@ -311,7 +320,10 @@ export default function ScenarioComparisonPage() {
           bunk_plan: BunkPlansResponse
         }>
       >({
-        filter: `scenario = "${rightScenarioId}" && year = ${currentYear}`,
+        filter: pb.filter('scenario = {:scenario} && year = {:year}', {
+          scenario: rightScenarioId,
+          year: currentYear,
+        }),
         expand: 'person,bunk,bunk_plan',
       })
       return result
@@ -326,14 +338,14 @@ export default function ScenarioComparisonPage() {
   // Fetch locked-group → member maps for each scenario.
   // Production has no locked groups (they are scenario-specific draft data).
   const { data: leftGroupMap = new Map<number, LockGroupSummary>() } = useQuery({
-    queryKey: ['compare-locked-groups', leftScenarioId, sessionPbId, currentYear],
+    queryKey: queryKeys.lockedGroups(leftScenarioId, sessionPbId, currentYear),
     queryFn: () => fetchGroupMap(leftScenarioId, sessionPbId, currentYear),
     ...userDataOptions,
     enabled: !!user && leftScenarioId !== 'production' && leftScenarioId !== '' && !!sessionPbId,
   })
 
   const { data: rightGroupMap = new Map<number, LockGroupSummary>() } = useQuery({
-    queryKey: ['compare-locked-groups', rightScenarioId, sessionPbId, currentYear],
+    queryKey: queryKeys.lockedGroups(rightScenarioId, sessionPbId, currentYear),
     queryFn: () => fetchGroupMap(rightScenarioId, sessionPbId, currentYear),
     ...userDataOptions,
     enabled: !!user && rightScenarioId !== 'production' && rightScenarioId !== '' && !!sessionPbId,
@@ -1450,7 +1462,10 @@ function CamperPill({
           'bg-red-50 opacity-75 ring-1 ring-red-200 dark:bg-red-900/20 dark:ring-red-800'
       )}
     >
-      {/* Friend-group color dot */}
+      {/* Friend-group color dot.
+          Native `title` is intentional — no generic <Tooltip> component exists
+          in this project (only domain-specific variants). Replace if a shared
+          Tooltip primitive is added to frontend/src/components/. */}
       {groupColor && (
         <span
           className="inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full"

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -56,12 +56,6 @@ import type { Session } from '../types/app-types'
 import { buildCsvContent, downloadCsv, slugify, todayIso } from '../utils/csvExport'
 import { buildMovedRows, MOVED_CSV_HEADERS } from '../utils/csvExportHelpers'
 
-// Group color palette mirrors LockGroupPanel.tsx GROUP_COLORS (bunking-board palette).
-// Colors are stored in the DB (locked_groups.color) and retrieved via API queries;
-// this array is retained here only for documentation purposes — actual rendering
-// uses the color value directly from the fetched LockGroupSummary.color field.
-// Do NOT import from graph modules.
-
 // Expanded member type for locked_group_members with attendee.person (double-expanded).
 type ExpandedGroupMember = LockedGroupMembersResponse & {
   expand?: {
@@ -128,6 +122,11 @@ async function fetchGroupMap(
   }
 
   return personToGroup
+}
+
+/** Deduplicate LockGroupSummary values from a Map by group id. */
+function uniqueById(map: Map<number, LockGroupSummary>): LockGroupSummary[] {
+  return Array.from(new Map(Array.from(map.values()).map((g) => [g.id, g])).values())
 }
 
 // Types for comparison
@@ -200,6 +199,21 @@ interface ValidationResult {
 
 type ViewMode = 'split' | 'changes'
 type ChangeFilter = 'all' | 'moved' | 'newly-assigned' | 'newly-unassigned'
+
+function useGroupMap(
+  scenarioId: string,
+  sessionPbId: string,
+  currentYear: number,
+  user: ReturnType<typeof useAuth>['user']
+) {
+  const { data: groupMap = new Map<number, LockGroupSummary>() } = useQuery({
+    queryKey: queryKeys.lockedGroups(scenarioId, sessionPbId, currentYear),
+    queryFn: () => fetchGroupMap(scenarioId, sessionPbId, currentYear),
+    ...userDataOptions,
+    enabled: !!user && scenarioId !== 'production' && scenarioId !== '' && !!sessionPbId,
+  })
+  return groupMap
+}
 
 export default function ScenarioComparisonPage() {
   const { sessionId: sessionUrlSegment } = useParams<{ sessionId: string }>()
@@ -337,19 +351,8 @@ export default function ScenarioComparisonPage() {
 
   // Fetch locked-group → member maps for each scenario.
   // Production has no locked groups (they are scenario-specific draft data).
-  const { data: leftGroupMap = new Map<number, LockGroupSummary>() } = useQuery({
-    queryKey: queryKeys.lockedGroups(leftScenarioId, sessionPbId, currentYear),
-    queryFn: () => fetchGroupMap(leftScenarioId, sessionPbId, currentYear),
-    ...userDataOptions,
-    enabled: !!user && leftScenarioId !== 'production' && leftScenarioId !== '' && !!sessionPbId,
-  })
-
-  const { data: rightGroupMap = new Map<number, LockGroupSummary>() } = useQuery({
-    queryKey: queryKeys.lockedGroups(rightScenarioId, sessionPbId, currentYear),
-    queryFn: () => fetchGroupMap(rightScenarioId, sessionPbId, currentYear),
-    ...userDataOptions,
-    enabled: !!user && rightScenarioId !== 'production' && rightScenarioId !== '' && !!sessionPbId,
-  })
+  const leftGroupMap = useGroupMap(leftScenarioId, sessionPbId, currentYear, user)
+  const rightGroupMap = useGroupMap(rightScenarioId, sessionPbId, currentYear, user)
 
   // Fetch validation scores for both scenarios
   const isReady =
@@ -610,15 +613,10 @@ export default function ScenarioComparisonPage() {
 
   // Build group-diff summary for the header chip.
   // Collect unique LockGroupSummary objects from each side's group map.
-  const groupDiff = useMemo(() => {
-    const leftGroups = Array.from(
-      new Map(Array.from(leftGroupMap.values()).map((g) => [g.id, g])).values()
-    )
-    const rightGroups = Array.from(
-      new Map(Array.from(rightGroupMap.values()).map((g) => [g.id, g])).values()
-    )
-    return diffGroups(leftGroups, rightGroups)
-  }, [leftGroupMap, rightGroupMap])
+  const groupDiff = useMemo(
+    () => diffGroups(uniqueById(leftGroupMap), uniqueById(rightGroupMap)),
+    [leftGroupMap, rightGroupMap]
+  )
 
   // Filter changes based on selected filter
   const filteredChanges = useMemo(() => {
@@ -1398,8 +1396,7 @@ function BunkComparisonCard({
                   camper={camper}
                   status={movedOutIds.has(camper.personCmId) ? 'moved-out' : 'unchanged'}
                   destination={movedOutDestinations.get(camper.personCmId)}
-                  groupColor={leftGroupMap.get(camper.personCmId)?.color}
-                  groupName={leftGroupMap.get(camper.personCmId)?.name}
+                  group={leftGroupMap.get(camper.personCmId)}
                 />
               ))
             )}
@@ -1421,8 +1418,7 @@ function BunkComparisonCard({
                   camper={camper}
                   status={movedInIds.has(camper.personCmId) ? 'moved-in' : 'unchanged'}
                   origin={movedInOrigins.get(camper.personCmId)}
-                  groupColor={rightGroupMap.get(camper.personCmId)?.color}
-                  groupName={rightGroupMap.get(camper.personCmId)?.name}
+                  group={rightGroupMap.get(camper.personCmId)}
                 />
               ))
             )}
@@ -1439,18 +1435,10 @@ interface CamperPillProps {
   status: 'unchanged' | 'moved-in' | 'moved-out'
   origin?: string | undefined // Where they came from (for moved-in)
   destination?: string | undefined // Where they went (for moved-out)
-  groupColor?: string | undefined // Hex color from locked_groups.color
-  groupName?: string | undefined // Group name for tooltip
+  group?: Pick<LockGroupSummary, 'color' | 'name'> | undefined
 }
 
-function CamperPill({
-  camper,
-  status,
-  origin,
-  destination,
-  groupColor,
-  groupName,
-}: CamperPillProps) {
+function CamperPill({ camper, status, origin, destination, group }: CamperPillProps) {
   return (
     <div
       className={clsx(
@@ -1462,16 +1450,12 @@ function CamperPill({
           'bg-red-50 opacity-75 ring-1 ring-red-200 dark:bg-red-900/20 dark:ring-red-800'
       )}
     >
-      {/* Friend-group color dot.
-          Native `title` is intentional — no generic <Tooltip> component exists
-          in this project (only domain-specific variants). Replace if a shared
-          Tooltip primitive is added to frontend/src/components/. */}
-      {groupColor && (
+      {group?.color && (
         <span
           className="inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full"
-          style={{ backgroundColor: groupColor }}
-          title={groupName ? `Friend group: ${groupName}` : 'Friend group'}
-          aria-label={groupName ? `Friend group: ${groupName}` : 'Friend group'}
+          style={{ backgroundColor: group.color }}
+          title={group.name ? `Friend group: ${group.name}` : 'Friend group'}
+          aria-label={group.name ? `Friend group: ${group.name}` : 'Friend group'}
         />
       )}
       <span className={clsx('font-medium', status === 'moved-out' && 'line-through')}>

--- a/frontend/src/utils/scenarioComparisonUtils.test.ts
+++ b/frontend/src/utils/scenarioComparisonUtils.test.ts
@@ -323,4 +323,28 @@ describe('diffGroups', () => {
     expect(result.identical).toHaveLength(0)
     expect(result.modified).toHaveLength(0)
   })
+
+  // Finding 5: empty-member group edge case — an empty left group must land in
+  // uniqueL, not be treated as "identical" to an empty right group.
+  it('empty left group lands in uniqueL, not identical', () => {
+    const leftGroups = [grp('lg-empty', 'Placeholder', '#6b7280', [])]
+    const rightGroups = [grp('rg-empty', 'Placeholder', '#6b7280', [])]
+
+    const result = diffGroups(leftGroups, rightGroups)
+    expect(result.uniqueL).toHaveLength(1)
+    expect(result.uniqueL[0]!.id).toBe('lg-empty')
+    expect(result.identical).toHaveLength(0)
+  })
+
+  it('empty left group is uniqueL even when right groups have members', () => {
+    const leftGroups = [grp('lg-empty', 'Empty', '#6b7280', [])]
+    const rightGroups = [grp('rg1', 'Full', '#3b82f6', [1001, 1002])]
+
+    const result = diffGroups(leftGroups, rightGroups)
+    expect(result.uniqueL).toHaveLength(1)
+    expect(result.uniqueL[0]!.id).toBe('lg-empty')
+    expect(result.uniqueR).toHaveLength(1)
+    expect(result.identical).toHaveLength(0)
+    expect(result.modified).toHaveLength(0)
+  })
 })

--- a/frontend/src/utils/scenarioComparisonUtils.test.ts
+++ b/frontend/src/utils/scenarioComparisonUtils.test.ts
@@ -4,7 +4,6 @@
  * Covers:
  * - sortCampersByName: alphabetical sort (first name, then last name), locale-aware
  * - getAvailableBunkAreas: derives which area-filter buttons to show based on bunk genders
- * - diffGroups: classify locked groups as identical / unique-L / unique-R / modified
  */
 
 import { describe, expect, it } from 'vitest'
@@ -12,10 +11,8 @@ import {
   compareCamperByName,
   sortCampersByName,
   getAvailableBunkAreas,
-  diffGroups,
   type SortableCamper,
   type BunkWithGender,
-  type LockGroupSummary,
 } from './scenarioComparisonUtils'
 
 describe('compareCamperByName', () => {
@@ -180,140 +177,5 @@ describe('getAvailableBunkAreas', () => {
   it('returns filter options in stable order: all, boys, girls, ag', () => {
     const bunks: BunkWithGender[] = [{ gender: 'Mixed' }, { gender: 'F' }, { gender: 'M' }]
     expect(getAvailableBunkAreas(bunks)).toEqual(['all', 'boys', 'girls', 'ag'])
-  })
-})
-
-// ---------------------------------------------------------------------------
-// diffGroups
-// ---------------------------------------------------------------------------
-
-// Helpers to build minimal LockGroupSummary fixtures.
-function grp(id: string, name: string, color: string, memberCmIds: number[]): LockGroupSummary {
-  return { id, name, color, memberCmIds }
-}
-
-describe('diffGroups', () => {
-  it('returns all zeros when both sides are empty', () => {
-    const result = diffGroups([], [])
-    expect(result.identical).toHaveLength(0)
-    expect(result.uniqueL).toHaveLength(0)
-    expect(result.uniqueR).toHaveLength(0)
-    expect(result.modified).toHaveLength(0)
-  })
-
-  it('classifies groups with exactly the same CM_ID member set as identical', () => {
-    // Emma Johnson (1001) and Liam Garcia (1002) are in group on both sides.
-    const leftGroups = [grp('lg1', 'Alpha', '#ef4444', [1001, 1002])]
-    const rightGroups = [grp('rg1', 'Alpha', '#ef4444', [1001, 1002])]
-
-    const result = diffGroups(leftGroups, rightGroups)
-    expect(result.identical).toHaveLength(1)
-    expect(result.identical[0]!.left.id).toBe('lg1')
-    expect(result.identical[0]!.right.id).toBe('rg1')
-    expect(result.uniqueL).toHaveLength(0)
-    expect(result.uniqueR).toHaveLength(0)
-    expect(result.modified).toHaveLength(0)
-  })
-
-  it('is order-independent when matching identical sets', () => {
-    // Members listed in different order — still identical.
-    const leftGroups = [grp('lg1', 'Alpha', '#3b82f6', [1001, 1002, 1003])]
-    const rightGroups = [grp('rg1', 'Alpha', '#3b82f6', [1003, 1001, 1002])]
-
-    const result = diffGroups(leftGroups, rightGroups)
-    expect(result.identical).toHaveLength(1)
-    expect(result.uniqueL).toHaveLength(0)
-    expect(result.uniqueR).toHaveLength(0)
-    expect(result.modified).toHaveLength(0)
-  })
-
-  it('classifies groups with zero overlap as uniqueL and uniqueR', () => {
-    // Olivia Chen (1010) and Riley Sam (1011) are in a left-only group.
-    // Samuel Johnson (1020) and Emma Johnson (1001) form a right-only group.
-    const leftGroups = [grp('lg1', 'Cabin Friends', '#22c55e', [1010, 1011])]
-    const rightGroups = [grp('rg1', 'New Crew', '#a855f7', [1020, 1001])]
-
-    const result = diffGroups(leftGroups, rightGroups)
-    expect(result.uniqueL).toHaveLength(1)
-    expect(result.uniqueL[0]!.id).toBe('lg1')
-    expect(result.uniqueR).toHaveLength(1)
-    expect(result.uniqueR[0]!.id).toBe('rg1')
-    expect(result.identical).toHaveLength(0)
-    expect(result.modified).toHaveLength(0)
-  })
-
-  it('classifies groups with partial overlap as modified', () => {
-    // Left: Emma (1001) + Liam (1002). Right: Emma (1001) + Olivia (1003).
-    // Overlap = {1001}, not zero and not identical → modified.
-    const leftGroups = [grp('lg1', 'Pals', '#eab308', [1001, 1002])]
-    const rightGroups = [grp('rg1', 'Pals', '#eab308', [1001, 1003])]
-
-    const result = diffGroups(leftGroups, rightGroups)
-    expect(result.modified).toHaveLength(1)
-    expect(result.modified[0]!.left.id).toBe('lg1')
-    expect(result.modified[0]!.right.id).toBe('rg1')
-    expect(result.identical).toHaveLength(0)
-    expect(result.uniqueL).toHaveLength(0)
-    expect(result.uniqueR).toHaveLength(0)
-  })
-
-  it('handles mixed scenario: some identical, some unique, some modified', () => {
-    // Identical: {1001, 1002} on both sides.
-    // Unique to L: {1010, 1011} with no right counterpart.
-    // Modified: Left has {1020, 1021}, Right has {1020, 1022} (overlap = {1020}).
-    // Unique to R: {1030, 1031} with no left counterpart.
-    const leftGroups = [
-      grp('lg-identical', 'Steady', '#3b82f6', [1001, 1002]),
-      grp('lg-unique', 'Gone', '#ef4444', [1010, 1011]),
-      grp('lg-modified', 'Shifted', '#22c55e', [1020, 1021]),
-    ]
-    const rightGroups = [
-      grp('rg-identical', 'Steady', '#3b82f6', [1001, 1002]),
-      grp('rg-modified', 'Shifted', '#22c55e', [1020, 1022]),
-      grp('rg-unique', 'New', '#a855f7', [1030, 1031]),
-    ]
-
-    const result = diffGroups(leftGroups, rightGroups)
-    expect(result.identical).toHaveLength(1)
-    expect(result.identical[0]!.left.id).toBe('lg-identical')
-    expect(result.uniqueL).toHaveLength(1)
-    expect(result.uniqueL[0]!.id).toBe('lg-unique')
-    expect(result.modified).toHaveLength(1)
-    expect(result.modified[0]!.left.id).toBe('lg-modified')
-    expect(result.uniqueR).toHaveLength(1)
-    expect(result.uniqueR[0]!.id).toBe('rg-unique')
-  })
-
-  it('counts correctly for summary header: leftCount and rightCount', () => {
-    // 2 left groups, 3 right groups
-    const leftGroups = [
-      grp('lg1', 'A', '#ef4444', [1001, 1002]),
-      grp('lg2', 'B', '#22c55e', [1010, 1011]),
-    ]
-    const rightGroups = [
-      grp('rg1', 'A', '#ef4444', [1001, 1002]), // identical to lg1
-      grp('rg2', 'B', '#22c55e', [1010, 1020]), // modified from lg2 (overlap={1010})
-      grp('rg3', 'C', '#a855f7', [1030, 1031]), // unique to R
-    ]
-
-    const result = diffGroups(leftGroups, rightGroups)
-    expect(result.leftCount).toBe(2)
-    expect(result.rightCount).toBe(3)
-    expect(result.identical).toHaveLength(1)
-    expect(result.modified).toHaveLength(1)
-    expect(result.uniqueL).toHaveLength(0)
-    expect(result.uniqueR).toHaveLength(1)
-  })
-
-  // Finding 5: empty-member group edge case — an empty left group must land in
-  // uniqueL, not be treated as "identical" to an empty right group.
-  it('empty left group lands in uniqueL, not identical', () => {
-    const leftGroups = [grp('lg-empty', 'Placeholder', '#6b7280', [])]
-    const rightGroups = [grp('rg-empty', 'Placeholder', '#6b7280', [])]
-
-    const result = diffGroups(leftGroups, rightGroups)
-    expect(result.uniqueL).toHaveLength(1)
-    expect(result.uniqueL[0]!.id).toBe('lg-empty')
-    expect(result.identical).toHaveLength(0)
   })
 })

--- a/frontend/src/utils/scenarioComparisonUtils.test.ts
+++ b/frontend/src/utils/scenarioComparisonUtils.test.ts
@@ -4,6 +4,7 @@
  * Covers:
  * - sortCampersByName: alphabetical sort (first name, then last name), locale-aware
  * - getAvailableBunkAreas: derives which area-filter buttons to show based on bunk genders
+ * - diffGroups: classify locked groups as identical / unique-L / unique-R / modified
  */
 
 import { describe, expect, it } from 'vitest'
@@ -11,8 +12,10 @@ import {
   compareCamperByName,
   sortCampersByName,
   getAvailableBunkAreas,
+  diffGroups,
   type SortableCamper,
   type BunkWithGender,
+  type LockGroupSummary,
 } from './scenarioComparisonUtils'
 
 describe('compareCamperByName', () => {
@@ -177,5 +180,147 @@ describe('getAvailableBunkAreas', () => {
   it('returns filter options in stable order: all, boys, girls, ag', () => {
     const bunks: BunkWithGender[] = [{ gender: 'Mixed' }, { gender: 'F' }, { gender: 'M' }]
     expect(getAvailableBunkAreas(bunks)).toEqual(['all', 'boys', 'girls', 'ag'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// diffGroups
+// ---------------------------------------------------------------------------
+
+// Helpers to build minimal LockGroupSummary fixtures.
+function grp(id: string, name: string, color: string, memberCmIds: number[]): LockGroupSummary {
+  return { id, name, color, memberCmIds }
+}
+
+describe('diffGroups', () => {
+  it('returns all zeros when both sides are empty', () => {
+    const result = diffGroups([], [])
+    expect(result.identical).toHaveLength(0)
+    expect(result.uniqueL).toHaveLength(0)
+    expect(result.uniqueR).toHaveLength(0)
+    expect(result.modified).toHaveLength(0)
+  })
+
+  it('classifies groups with exactly the same CM_ID member set as identical', () => {
+    // Emma Johnson (1001) and Liam Garcia (1002) are in group on both sides.
+    const leftGroups = [grp('lg1', 'Alpha', '#ef4444', [1001, 1002])]
+    const rightGroups = [grp('rg1', 'Alpha', '#ef4444', [1001, 1002])]
+
+    const result = diffGroups(leftGroups, rightGroups)
+    expect(result.identical).toHaveLength(1)
+    expect(result.identical[0]!.left.id).toBe('lg1')
+    expect(result.identical[0]!.right.id).toBe('rg1')
+    expect(result.uniqueL).toHaveLength(0)
+    expect(result.uniqueR).toHaveLength(0)
+    expect(result.modified).toHaveLength(0)
+  })
+
+  it('is order-independent when matching identical sets', () => {
+    // Members listed in different order — still identical.
+    const leftGroups = [grp('lg1', 'Alpha', '#3b82f6', [1001, 1002, 1003])]
+    const rightGroups = [grp('rg1', 'Alpha', '#3b82f6', [1003, 1001, 1002])]
+
+    const result = diffGroups(leftGroups, rightGroups)
+    expect(result.identical).toHaveLength(1)
+    expect(result.uniqueL).toHaveLength(0)
+    expect(result.uniqueR).toHaveLength(0)
+    expect(result.modified).toHaveLength(0)
+  })
+
+  it('classifies groups with zero overlap as uniqueL and uniqueR', () => {
+    // Olivia Chen (1010) and Riley Sam (1011) are in a left-only group.
+    // Samuel Johnson (1020) and Emma Johnson (1001) form a right-only group.
+    const leftGroups = [grp('lg1', 'Cabin Friends', '#22c55e', [1010, 1011])]
+    const rightGroups = [grp('rg1', 'New Crew', '#a855f7', [1020, 1001])]
+
+    const result = diffGroups(leftGroups, rightGroups)
+    expect(result.uniqueL).toHaveLength(1)
+    expect(result.uniqueL[0]!.id).toBe('lg1')
+    expect(result.uniqueR).toHaveLength(1)
+    expect(result.uniqueR[0]!.id).toBe('rg1')
+    expect(result.identical).toHaveLength(0)
+    expect(result.modified).toHaveLength(0)
+  })
+
+  it('classifies groups with partial overlap as modified', () => {
+    // Left: Emma (1001) + Liam (1002). Right: Emma (1001) + Olivia (1003).
+    // Overlap = {1001}, not zero and not identical → modified.
+    const leftGroups = [grp('lg1', 'Pals', '#eab308', [1001, 1002])]
+    const rightGroups = [grp('rg1', 'Pals', '#eab308', [1001, 1003])]
+
+    const result = diffGroups(leftGroups, rightGroups)
+    expect(result.modified).toHaveLength(1)
+    expect(result.modified[0]!.left.id).toBe('lg1')
+    expect(result.modified[0]!.right.id).toBe('rg1')
+    expect(result.identical).toHaveLength(0)
+    expect(result.uniqueL).toHaveLength(0)
+    expect(result.uniqueR).toHaveLength(0)
+  })
+
+  it('handles mixed scenario: some identical, some unique, some modified', () => {
+    // Identical: {1001, 1002} on both sides.
+    // Unique to L: {1010, 1011} with no right counterpart.
+    // Modified: Left has {1020, 1021}, Right has {1020, 1022} (overlap = {1020}).
+    // Unique to R: {1030, 1031} with no left counterpart.
+    const leftGroups = [
+      grp('lg-identical', 'Steady', '#3b82f6', [1001, 1002]),
+      grp('lg-unique', 'Gone', '#ef4444', [1010, 1011]),
+      grp('lg-modified', 'Shifted', '#22c55e', [1020, 1021]),
+    ]
+    const rightGroups = [
+      grp('rg-identical', 'Steady', '#3b82f6', [1001, 1002]),
+      grp('rg-modified', 'Shifted', '#22c55e', [1020, 1022]),
+      grp('rg-unique', 'New', '#a855f7', [1030, 1031]),
+    ]
+
+    const result = diffGroups(leftGroups, rightGroups)
+    expect(result.identical).toHaveLength(1)
+    expect(result.identical[0]!.left.id).toBe('lg-identical')
+    expect(result.uniqueL).toHaveLength(1)
+    expect(result.uniqueL[0]!.id).toBe('lg-unique')
+    expect(result.modified).toHaveLength(1)
+    expect(result.modified[0]!.left.id).toBe('lg-modified')
+    expect(result.uniqueR).toHaveLength(1)
+    expect(result.uniqueR[0]!.id).toBe('rg-unique')
+  })
+
+  it('counts correctly for summary header: leftCount and rightCount', () => {
+    // 2 left groups, 3 right groups
+    const leftGroups = [
+      grp('lg1', 'A', '#ef4444', [1001, 1002]),
+      grp('lg2', 'B', '#22c55e', [1010, 1011]),
+    ]
+    const rightGroups = [
+      grp('rg1', 'A', '#ef4444', [1001, 1002]), // identical to lg1
+      grp('rg2', 'B', '#22c55e', [1010, 1020]), // modified from lg2 (overlap={1010})
+      grp('rg3', 'C', '#a855f7', [1030, 1031]), // unique to R
+    ]
+
+    const result = diffGroups(leftGroups, rightGroups)
+    expect(result.leftCount).toBe(2)
+    expect(result.rightCount).toBe(3)
+    expect(result.identical).toHaveLength(1)
+    expect(result.modified).toHaveLength(1)
+    expect(result.uniqueL).toHaveLength(0)
+    expect(result.uniqueR).toHaveLength(1)
+  })
+
+  it('handles a left group with a single member correctly (identical)', () => {
+    const leftGroups = [grp('lg1', 'Solo', '#ec4899', [1001])]
+    const rightGroups = [grp('rg1', 'Solo', '#ec4899', [1001])]
+
+    const result = diffGroups(leftGroups, rightGroups)
+    expect(result.identical).toHaveLength(1)
+  })
+
+  it('handles a left group with a single member (unique when no right overlap)', () => {
+    const leftGroups = [grp('lg1', 'Solo', '#ec4899', [1001])]
+    const rightGroups = [grp('rg1', 'Other', '#3b82f6', [1002])]
+
+    const result = diffGroups(leftGroups, rightGroups)
+    expect(result.uniqueL).toHaveLength(1)
+    expect(result.uniqueR).toHaveLength(1)
+    expect(result.identical).toHaveLength(0)
+    expect(result.modified).toHaveLength(0)
   })
 })

--- a/frontend/src/utils/scenarioComparisonUtils.test.ts
+++ b/frontend/src/utils/scenarioComparisonUtils.test.ts
@@ -305,25 +305,6 @@ describe('diffGroups', () => {
     expect(result.uniqueR).toHaveLength(1)
   })
 
-  it('handles a left group with a single member correctly (identical)', () => {
-    const leftGroups = [grp('lg1', 'Solo', '#ec4899', [1001])]
-    const rightGroups = [grp('rg1', 'Solo', '#ec4899', [1001])]
-
-    const result = diffGroups(leftGroups, rightGroups)
-    expect(result.identical).toHaveLength(1)
-  })
-
-  it('handles a left group with a single member (unique when no right overlap)', () => {
-    const leftGroups = [grp('lg1', 'Solo', '#ec4899', [1001])]
-    const rightGroups = [grp('rg1', 'Other', '#3b82f6', [1002])]
-
-    const result = diffGroups(leftGroups, rightGroups)
-    expect(result.uniqueL).toHaveLength(1)
-    expect(result.uniqueR).toHaveLength(1)
-    expect(result.identical).toHaveLength(0)
-    expect(result.modified).toHaveLength(0)
-  })
-
   // Finding 5: empty-member group edge case — an empty left group must land in
   // uniqueL, not be treated as "identical" to an empty right group.
   it('empty left group lands in uniqueL, not identical', () => {
@@ -334,17 +315,5 @@ describe('diffGroups', () => {
     expect(result.uniqueL).toHaveLength(1)
     expect(result.uniqueL[0]!.id).toBe('lg-empty')
     expect(result.identical).toHaveLength(0)
-  })
-
-  it('empty left group is uniqueL even when right groups have members', () => {
-    const leftGroups = [grp('lg-empty', 'Empty', '#6b7280', [])]
-    const rightGroups = [grp('rg1', 'Full', '#3b82f6', [1001, 1002])]
-
-    const result = diffGroups(leftGroups, rightGroups)
-    expect(result.uniqueL).toHaveLength(1)
-    expect(result.uniqueL[0]!.id).toBe('lg-empty')
-    expect(result.uniqueR).toHaveLength(1)
-    expect(result.identical).toHaveLength(0)
-    expect(result.modified).toHaveLength(0)
   })
 })

--- a/frontend/src/utils/scenarioComparisonUtils.ts
+++ b/frontend/src/utils/scenarioComparisonUtils.ts
@@ -6,7 +6,7 @@
  */
 
 // ---------------------------------------------------------------------------
-// Locked-group diff types
+// Locked-group types
 // ---------------------------------------------------------------------------
 
 /**
@@ -18,28 +18,6 @@ export interface LockGroupSummary {
   name: string
   color: string
   memberCmIds: number[]
-}
-
-/** Pair of matching groups from left and right scenarios. */
-export interface MatchedGroupPair {
-  left: LockGroupSummary
-  right: LockGroupSummary
-}
-
-/** Result of diffing locked groups across two scenarios. */
-export interface GroupDiffResult {
-  /** Total group count from the left scenario. */
-  leftCount: number
-  /** Total group count from the right scenario. */
-  rightCount: number
-  /** Groups whose member CM_ID sets are exactly equal on both sides. */
-  identical: MatchedGroupPair[]
-  /** Left-scenario groups that share NO members with any right-scenario group. */
-  uniqueL: LockGroupSummary[]
-  /** Right-scenario groups that share NO members with any left-scenario group. */
-  uniqueR: LockGroupSummary[]
-  /** Groups that share at least one member but differ (partial overlap). */
-  modified: MatchedGroupPair[]
 }
 
 /** Minimal shape needed to sort campers by name. */
@@ -94,104 +72,5 @@ export function getAvailableBunkAreas(bunks: readonly BunkWithGender[]): BunkAre
   if (bunks.some((b) => b.gender === 'M')) result.push('boys')
   if (bunks.some((b) => b.gender === 'F')) result.push('girls')
   if (bunks.some((b) => b.gender === 'Mixed')) result.push('ag')
-  return result
-}
-
-// ---------------------------------------------------------------------------
-// diffGroups
-// ---------------------------------------------------------------------------
-
-/**
- * Classify locked groups from two scenarios into identical, uniqueL, uniqueR,
- * and modified buckets.
- *
- * Matching is done by CM_ID member sets:
- * - **identical**: same exact set of member CM IDs on both sides.
- * - **uniqueL / uniqueR**: no overlap at all with any group on the other side.
- * - **modified**: at least one shared member, but the sets differ.
- *
- * Each left group is matched to at most one right group (the one with the
- * greatest overlap, preferring exact matches). Unmatched right groups become
- * uniqueR.
- *
- * Pure function — no side effects, no I/O.
- */
-export function diffGroups(
-  leftGroups: readonly LockGroupSummary[],
-  rightGroups: readonly LockGroupSummary[]
-): GroupDiffResult {
-  const result: GroupDiffResult = {
-    leftCount: leftGroups.length,
-    rightCount: rightGroups.length,
-    identical: [],
-    uniqueL: [],
-    uniqueR: [],
-    modified: [],
-  }
-
-  // Build a set of CM IDs for each right group (for O(1) membership tests).
-  const rightSets: Array<Set<number>> = rightGroups.map((g) => new Set(g.memberCmIds))
-
-  // Track which right groups have been claimed by a left group.
-  const rightClaimed = new Set<number>()
-
-  for (const leftGrp of leftGroups) {
-    const leftSet = new Set(leftGrp.memberCmIds)
-
-    // Empty groups can never overlap with anything — treat as unique-left.
-    // This also prevents `overlap === leftSet.size` (0 === 0) from falsely
-    // marking two empty groups as identical.
-    if (leftSet.size === 0) {
-      result.uniqueL.push(leftGrp)
-      continue
-    }
-
-    // Find the best matching right group: prefer exact match, then most overlap.
-    let bestIdx = -1
-    let bestOverlap = 0
-    let bestIsExact = false
-
-    for (const [i, rSet] of rightSets.entries()) {
-      if (rightClaimed.has(i)) continue
-
-      // Count intersection
-      let overlap = 0
-      for (const id of leftSet) {
-        if (rSet.has(id)) overlap++
-      }
-      if (overlap === 0) continue
-
-      const isExact = overlap === leftSet.size && overlap === rSet.size
-
-      if (bestIdx === -1 || (isExact && !bestIsExact) || (!bestIsExact && overlap > bestOverlap)) {
-        bestIdx = i
-        bestOverlap = overlap
-        bestIsExact = isExact
-      }
-    }
-
-    if (bestIdx === -1) {
-      // No right group shares any member — unique to left.
-      result.uniqueL.push(leftGrp)
-    } else {
-      // bestIdx is always a valid index: it was set from rightSets.entries().
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const rightGrp = rightGroups[bestIdx]!
-      if (bestIsExact) {
-        result.identical.push({ left: leftGrp, right: rightGrp })
-      } else {
-        result.modified.push({ left: leftGrp, right: rightGrp })
-      }
-      rightClaimed.add(bestIdx)
-    }
-  }
-
-  // Any unclaimed right groups are unique to right.
-  for (const [i, rightGrp] of rightGroups.entries()) {
-    if (!rightClaimed.has(i)) {
-      result.uniqueR.push(rightGrp)
-    }
-  }
-
   return result
 }

--- a/frontend/src/utils/scenarioComparisonUtils.ts
+++ b/frontend/src/utils/scenarioComparisonUtils.ts
@@ -129,10 +129,8 @@ export function diffGroups(
     modified: [],
   }
 
-  if (leftGroups.length === 0 && rightGroups.length === 0) return result
-
   // Build a set of CM IDs for each right group (for O(1) membership tests).
-  const rightSets = rightGroups.map((g) => new Set(g.memberCmIds))
+  const rightSets: Array<Set<number>> = rightGroups.map((g) => new Set(g.memberCmIds))
 
   // Track which right groups have been claimed by a left group.
   const rightClaimed = new Set<number>()
@@ -153,11 +151,9 @@ export function diffGroups(
     let bestOverlap = 0
     let bestIsExact = false
 
-    for (let i = 0; i < rightGroups.length; i++) {
+    for (const [i, rSet] of rightSets.entries()) {
       if (rightClaimed.has(i)) continue
 
-      const rSet = rightSets[i]
-      if (!rSet) continue
       // Count intersection
       let overlap = 0
       for (const id of leftSet) {
@@ -178,8 +174,9 @@ export function diffGroups(
       // No right group shares any member — unique to left.
       result.uniqueL.push(leftGrp)
     } else {
-      const rightGrp = rightGroups[bestIdx]
-      if (!rightGrp) continue
+      // bestIdx is always a valid index: it was set from rightSets.entries().
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const rightGrp = rightGroups[bestIdx]!
       if (bestIsExact) {
         result.identical.push({ left: leftGrp, right: rightGrp })
       } else {
@@ -190,10 +187,9 @@ export function diffGroups(
   }
 
   // Any unclaimed right groups are unique to right.
-  for (let i = 0; i < rightGroups.length; i++) {
+  for (const [i, rightGrp] of rightGroups.entries()) {
     if (!rightClaimed.has(i)) {
-      const rightGrp = rightGroups[i]
-      if (rightGrp) result.uniqueR.push(rightGrp)
+      result.uniqueR.push(rightGrp)
     }
   }
 

--- a/frontend/src/utils/scenarioComparisonUtils.ts
+++ b/frontend/src/utils/scenarioComparisonUtils.ts
@@ -5,6 +5,43 @@
  * mocking PocketBase, React Query, auth, or the router.
  */
 
+// ---------------------------------------------------------------------------
+// Locked-group diff types
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal shape of a locked group needed for diffing across scenarios.
+ * `memberCmIds` is the set of CampMinder person IDs that belong to this group.
+ */
+export interface LockGroupSummary {
+  id: string
+  name: string
+  color: string
+  memberCmIds: number[]
+}
+
+/** Pair of matching groups from left and right scenarios. */
+export interface MatchedGroupPair {
+  left: LockGroupSummary
+  right: LockGroupSummary
+}
+
+/** Result of diffing locked groups across two scenarios. */
+export interface GroupDiffResult {
+  /** Total group count from the left scenario. */
+  leftCount: number
+  /** Total group count from the right scenario. */
+  rightCount: number
+  /** Groups whose member CM_ID sets are exactly equal on both sides. */
+  identical: MatchedGroupPair[]
+  /** Left-scenario groups that share NO members with any right-scenario group. */
+  uniqueL: LockGroupSummary[]
+  /** Right-scenario groups that share NO members with any left-scenario group. */
+  uniqueR: LockGroupSummary[]
+  /** Groups that share at least one member but differ (partial overlap). */
+  modified: MatchedGroupPair[]
+}
+
 /** Minimal shape needed to sort campers by name. */
 export interface SortableCamper {
   firstName: string
@@ -57,5 +94,100 @@ export function getAvailableBunkAreas(bunks: readonly BunkWithGender[]): BunkAre
   if (bunks.some((b) => b.gender === 'M')) result.push('boys')
   if (bunks.some((b) => b.gender === 'F')) result.push('girls')
   if (bunks.some((b) => b.gender === 'Mixed')) result.push('ag')
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// diffGroups
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify locked groups from two scenarios into identical, uniqueL, uniqueR,
+ * and modified buckets.
+ *
+ * Matching is done by CM_ID member sets:
+ * - **identical**: same exact set of member CM IDs on both sides.
+ * - **uniqueL / uniqueR**: no overlap at all with any group on the other side.
+ * - **modified**: at least one shared member, but the sets differ.
+ *
+ * Each left group is matched to at most one right group (the one with the
+ * greatest overlap, preferring exact matches). Unmatched right groups become
+ * uniqueR.
+ *
+ * Pure function — no side effects, no I/O.
+ */
+export function diffGroups(
+  leftGroups: readonly LockGroupSummary[],
+  rightGroups: readonly LockGroupSummary[]
+): GroupDiffResult {
+  const result: GroupDiffResult = {
+    leftCount: leftGroups.length,
+    rightCount: rightGroups.length,
+    identical: [],
+    uniqueL: [],
+    uniqueR: [],
+    modified: [],
+  }
+
+  if (leftGroups.length === 0 && rightGroups.length === 0) return result
+
+  // Build a set of CM IDs for each right group (for O(1) membership tests).
+  const rightSets = rightGroups.map((g) => new Set(g.memberCmIds))
+
+  // Track which right groups have been claimed by a left group.
+  const rightClaimed = new Set<number>()
+
+  for (const leftGrp of leftGroups) {
+    const leftSet = new Set(leftGrp.memberCmIds)
+
+    // Find the best matching right group: prefer exact match, then most overlap.
+    let bestIdx = -1
+    let bestOverlap = 0
+    let bestIsExact = false
+
+    for (let i = 0; i < rightGroups.length; i++) {
+      if (rightClaimed.has(i)) continue
+
+      const rSet = rightSets[i]
+      if (!rSet) continue
+      // Count intersection
+      let overlap = 0
+      for (const id of leftSet) {
+        if (rSet.has(id)) overlap++
+      }
+      if (overlap === 0) continue
+
+      const isExact = overlap === leftSet.size && overlap === rSet.size
+
+      if (bestIdx === -1 || (isExact && !bestIsExact) || (!bestIsExact && overlap > bestOverlap)) {
+        bestIdx = i
+        bestOverlap = overlap
+        bestIsExact = isExact
+      }
+    }
+
+    if (bestIdx === -1) {
+      // No right group shares any member — unique to left.
+      result.uniqueL.push(leftGrp)
+    } else {
+      const rightGrp = rightGroups[bestIdx]
+      if (!rightGrp) continue
+      if (bestIsExact) {
+        result.identical.push({ left: leftGrp, right: rightGrp })
+      } else {
+        result.modified.push({ left: leftGrp, right: rightGrp })
+      }
+      rightClaimed.add(bestIdx)
+    }
+  }
+
+  // Any unclaimed right groups are unique to right.
+  for (let i = 0; i < rightGroups.length; i++) {
+    if (!rightClaimed.has(i)) {
+      const rightGrp = rightGroups[i]
+      if (rightGrp) result.uniqueR.push(rightGrp)
+    }
+  }
+
   return result
 }

--- a/frontend/src/utils/scenarioComparisonUtils.ts
+++ b/frontend/src/utils/scenarioComparisonUtils.ts
@@ -140,6 +140,14 @@ export function diffGroups(
   for (const leftGrp of leftGroups) {
     const leftSet = new Set(leftGrp.memberCmIds)
 
+    // Empty groups can never overlap with anything — treat as unique-left.
+    // This also prevents `overlap === leftSet.size` (0 === 0) from falsely
+    // marking two empty groups as identical.
+    if (leftSet.size === 0) {
+      result.uniqueL.push(leftGrp)
+      continue
+    }
+
     // Find the best matching right group: prefer exact match, then most overlap.
     let bestIdx = -1
     let bestOverlap = 0


### PR DESCRIPTION
## Summary

Friend groups in session compare (#25) — **simplified scope (2026-04-27)**.

- **Split-view color dots**: each camper pill in the split-view comparison shows a small colored dot sourced from `locked_groups.color` for the scenario on that side (existing bunking-board palette). No dot for ungrouped campers.
- **Hover popover**: hovering a grouped camper pill opens a same-side popover listing the group's color, name, and member rows (alphabetical). Members with no resolvable `CamperAssignment` render as `<unknown camper>`. Closes on mouseleave.
- **Removed (vs. earlier draft of this PR)**: cross-side `FriendGroupDiffChip` summary bar, `diffGroups()` util, `GroupDiffResult`/`MatchedGroupPair` types, and 9 `diffGroups` vitest cases. Cross-side diffing was deemed low-value relative to its complexity.
- **Bug fix bundled**: `useGroupMap` now sets `structuralSharing: false` on its TanStack Query call. Default structural sharing deep-walks the result assuming plain objects/arrays and silently strips the `Map` prototype on refetch, which caused `rightGroupMap.get is not a function` crashes after rapid scenario switching. Latent in the original PR — the new popover work increased call density and made it reliably reproduce.

Out of scope, filed as separate issues:
- #1046 — `feat(frontend)`: scenario copy should include locked friend groups (`copyScenarioToScenario` currently drops `locked_groups` + `locked_group_members`).
- #1047 — `feat(pb)`: enforce one friend group per camper per scenario (current schema only enforces uniqueness within a single group).

## Manual validation (dev/preview)

In `~/kindred-worktrees/feat-compare-friend-groups`, after `./scripts/start_dev.sh`:

- [ ] Visit `/summer/session/<id>/compare` and pick two scenarios on a session that has at least one locked friend group on the LEFT side.
- [ ] Hover a pill for a grouped camper → popover opens with color dot + group name + member list (alphabetical).
- [ ] Mouseleave → popover closes.
- [ ] Hover a pill for an ungrouped camper → no popover.
- [ ] Confirm the old "Left N · Right M · Identical I · …" header chip is GONE.
- [ ] Confirm the existing color dot still renders on grouped camper pills.
- [ ] Repeat hover/leave on the right side.
- [ ] Switch scenarios rapidly between two sessions/scenarios that both have locked groups → no `rightGroupMap.get is not a function` crash (regression check for the structural-sharing fix).

## Closes

Scoreboard item #25 (wife-feedback-2026-04 session).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Friend groups are now visually identified with color indicators displayed on campers during scenario comparisons
  * Hovering over a camper reveals a popover window displaying all members within that camper's friend group
  * Enhanced locked group comparison functionality across different scenarios
  * Improved handling of camper assignments and member visibility within friend groups

<!-- end of auto-generated comment: release notes by coderabbit.ai -->