### PR TITLE
fix(frontend): restore sync-label copy and tooltip lost in #1009

### DIFF
--- a/frontend/src/layouts/AppLayout.test.tsx
+++ b/frontend/src/layouts/AppLayout.test.tsx
@@ -227,6 +227,53 @@ describe('AppLayout sync-status polling', () => {
   })
 })
 
+describe('AppLayout sync-status labels', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPerms = {
+      hasPermission: (p: string) => p === 'bunking.manage',
+      isAdmin: false,
+    }
+    const iso = '2026-04-22T12:00:00.000Z'
+    syncStatusSpy.mockImplementation(() => ({
+      data: {
+        bunk_assignments: {
+          status: 'success',
+          end_time: iso,
+          start_time: iso,
+          summary: { created: 1, updated: 2, skipped: 0, errors: 0 },
+        },
+        bunk_requests: {
+          status: 'success',
+          end_time: iso,
+          start_time: iso,
+          summary: { created: 3, updated: 4, skipped: 1, errors: 0 },
+        },
+      } as SyncStatusResponse,
+    }))
+  })
+
+  it('renders "Assignments synced ..." label with lowercase synced', () => {
+    renderAppLayout()
+    expect(screen.getByText(/Assignments synced/)).toBeInTheDocument()
+  })
+
+  it('renders "Requests synced ..." label with lowercase synced', () => {
+    renderAppLayout()
+    expect(screen.getByText(/Requests synced/)).toBeInTheDocument()
+  })
+
+  it('Requests sync label exposes richer detail via tooltip on hover', () => {
+    renderAppLayout()
+    const requestsLabel = screen.getByText(/Requests synced/)
+    const tooltipHost = requestsLabel.closest('[title]') as HTMLElement | null
+    expect(tooltipHost).not.toBeNull()
+    const title = tooltipHost?.getAttribute('title') ?? ''
+    expect(title).toMatch(/2026-04-22/)
+    expect(title).toMatch(/created 3, updated 4, skipped 1, errors 0/)
+  })
+})
+
 // Regression boundary: sentinel shape returned on 401, not the full
 // pb.afterSend async-redirect race. See #1011 for the discriminated-union fix.
 describe('AppLayout fresh-login crash guard', () => {

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -39,6 +39,24 @@ import { MANAGE_TABS } from '../config/manageTabs'
 import { PROGRAM_BUTTONS } from '../config/programButtons'
 import { useTour } from '../hooks/useTour'
 import { FeedbackModal } from '../components/FeedbackModal'
+import type { SyncStatus } from '../hooks/useSyncStatusAPI'
+
+function buildSyncTooltip(kind: string, status: SyncStatus): string {
+  const parts = [`Last ${kind} sync`]
+  if (status.end_time) {
+    parts.push(new Date(status.end_time).toISOString())
+  }
+  if (status.status) {
+    parts.push(`status: ${status.status}`)
+  }
+  const s = status.summary
+  if (s) {
+    parts.push(
+      `created ${s.created}, updated ${s.updated}, skipped ${s.skipped}, errors ${s.errors}`
+    )
+  }
+  return parts.join(' • ')
+}
 
 export const AppLayout = () => {
   const location = useLocation()
@@ -692,19 +710,22 @@ export const AppLayout = () => {
                     {syncStatus.bunk_assignments?.end_time && (
                       <span
                         className="flex items-center gap-1.5"
-                        title="Last bunk assignments sync"
+                        title={buildSyncTooltip('bunk assignments', syncStatus.bunk_assignments)}
                       >
                         <Home className="h-3 w-3" />
-                        Assignments{' '}
+                        Assignments synced{' '}
                         {formatDistanceToNow(new Date(syncStatus.bunk_assignments.end_time), {
                           addSuffix: true,
                         })}
                       </span>
                     )}
                     {syncStatus.bunk_requests?.end_time && (
-                      <span className="flex items-center gap-1.5" title="Last bunk requests sync">
+                      <span
+                        className="flex items-center gap-1.5"
+                        title={buildSyncTooltip('bunk requests', syncStatus.bunk_requests)}
+                      >
                         <Clock className="h-3 w-3" />
-                        Requests{' '}
+                        Requests synced{' '}
                         {formatDistanceToNow(new Date(syncStatus.bunk_requests.end_time), {
                           addSuffix: true,
                         })}


### PR DESCRIPTION
## Summary

PR #985 (sync-label copy + rich tooltip) shipped on `2026-04-24 20:27Z`. Two hours later, PR #1009 (fresh-login crash guard, `?.` on sync-status reads) merged on top — and silently reverted three of #985's changes:

| What #985 added | What #1009 reverted it to |
|---|---|
| `Assignments synced <time>` | `Assignments <time>` |
| `Requests synced <time>` | `Requests <time>` |
| Rich `buildSyncTooltip()` (timestamp + status + created/updated/skipped/errors) | Plain `title="Last bunk assignments sync"` |

#1009 also deleted #985's `AppLayout sync-status labels` test block, which is why CI didn't catch the regression.

This PR restores all three on top of #1009's optional-chaining safety, plus the deleted tests.

The third part of #985 (the `BunkRequestsUpload` "API Bunking Info" tooltip) was untouched by #1009 and is unaffected here.

## Test plan

- [ ] Open Assignments — label reads "Assignments synced …"
- [ ] Open Requests — label reads "Requests synced …"
- [ ] Hover the Requests sync label — tooltip shows ISO timestamp + `created N, updated N, skipped N, errors N`
- [ ] Fresh-login crash guard from #1009 still holds (no TypeError on `bunk_assignments?.end_time`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sync status indicators now display "Assignments synced" and "Requests synced" labels.
  * Enhanced sync status tooltips with detailed information including timestamps, status, and operation summaries (created, updated, skipped, errors).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->