### PR TITLE
refactor(api): delete OptimizedSocialGraphBuilder _calculate_node_metrics override

### DIFF
--- a/bunking/graph/optimized_graph_builder.py
+++ b/bunking/graph/optimized_graph_builder.py
@@ -283,18 +283,6 @@ class OptimizedSocialGraphBuilder(SocialGraphBuilder):
 
         return sibling_edges
 
-    def _calculate_node_metrics(self) -> None:
-        """Calculate centrality and clustering coefficients with rounding."""
-        # Calculate degree centrality
-        centrality = nx.degree_centrality(self.graph)
-        for node in self.graph.nodes():
-            self.graph.nodes[node]["centrality"] = round(centrality.get(node, 0.0), 2)
-
-        # Calculate clustering coefficient
-        clustering = nx.clustering(self.graph.to_undirected())
-        for node in self.graph.nodes():
-            self.graph.nodes[node]["clustering"] = round(clustering.get(node, 0.0), 2)
-
     def update_node_position(
         self, person_cm_id: int, new_bunk_cm_id: int, session_cm_id: int, year: int
     ) -> dict[str, Any]:

--- a/bunking/graph/social_graph_builder.py
+++ b/bunking/graph/social_graph_builder.py
@@ -816,8 +816,15 @@ class SocialGraphBuilder:
         clustering = nx.clustering(self.graph)
         nx.set_node_attributes(self.graph, clustering, "clustering")
 
-        # Connected component size
-        components = list(nx.connected_components(self.graph))
+        # Connected component size — use weakly_connected_components for directed graphs
+        # (OptimizedSocialGraphBuilder uses nx.DiGraph; the parent path uses nx.Graph).
+        # Without this branch, nx.connected_components raises NetworkXNotImplemented on
+        # DiGraph inputs and the satisfaction_status loop below never runs — leaving every
+        # node's status null and every frontend border falling back to the default color.
+        if self.graph.is_directed():
+            components = list(nx.weakly_connected_components(self.graph))
+        else:
+            components = list(nx.connected_components(self.graph))
         component_map = {}
         for _i, component in enumerate(components):
             for node in component:

--- a/tests/unit/bunking/graph/test_satisfaction_status.py
+++ b/tests/unit/bunking/graph/test_satisfaction_status.py
@@ -17,11 +17,16 @@ from unittest.mock import MagicMock
 
 import networkx as nx
 
+from bunking.graph.optimized_graph_builder import OptimizedSocialGraphBuilder
 from bunking.graph.social_graph_builder import SocialGraphBuilder
 
 
 def _make_builder() -> SocialGraphBuilder:
     return SocialGraphBuilder(pb=MagicMock())
+
+
+def _make_optimized_builder() -> OptimizedSocialGraphBuilder:
+    return OptimizedSocialGraphBuilder(pb=MagicMock())
 
 
 def _populate(
@@ -87,25 +92,27 @@ def test_no_request_edges_and_fully_isolated_node_marks_no_requests() -> None:
     assert builder.graph.nodes[1]["satisfaction_status"] == "no_requests"
 
 
-def test_calculate_node_metrics_on_digraph_sets_satisfaction_status() -> None:
-    """Regression: OptimizedSocialGraphBuilder uses nx.DiGraph; satisfaction_status must
-    still be populated on every node. Prior bug: nx.connected_components raised
-    NetworkXNotImplemented on DiGraph, aborting before the satisfaction loop and leaving
-    satisfaction_status=None on every node — causing all graph node borders to fall back
-    to the same color in the frontend."""
-    builder = _make_builder()
+def test_optimized_builder_sets_satisfaction_status() -> None:
+    """Regression: OptimizedSocialGraphBuilder is the GUI path (3 of 4 production
+    callers in api/routers/social_graph.py — the friends page hits it). Prior bug:
+    OptimizedSocialGraphBuilder._calculate_node_metrics overrode the parent and
+    silently dropped the satisfaction loop, leaving satisfaction_status absent on
+    every node and forcing every frontend border to fall back to a default color."""
+    builder = _make_optimized_builder()
     _populate(builder, nodes={1: 100, 2: 100, 3: 200}, request_edges=[(1, 2), (1, 3)], graph_type=nx.DiGraph)
     builder._calculate_node_metrics()
     for node_id in (1, 2, 3):
         assert "satisfaction_status" in builder.graph.nodes[node_id], (
-            f"node {node_id} missing satisfaction_status — _calculate_node_metrics bailed early"
+            f"node {node_id} missing satisfaction_status — OptimizedSocialGraphBuilder "
+            f"override is dropping the satisfaction loop"
         )
         assert builder.graph.nodes[node_id]["satisfaction_status"] is not None
 
 
-def test_calculate_node_metrics_on_digraph_classifies_correctly() -> None:
-    """Same node membership semantics on DiGraph as on Graph."""
-    builder = _make_builder()
+def test_optimized_builder_classifies_correctly() -> None:
+    """OptimizedSocialGraphBuilder must produce the same satisfaction labels as the
+    parent on the same logical graph (just expressed as a DiGraph)."""
+    builder = _make_optimized_builder()
     # 1 → 2 (same bunk, satisfied), 3 → 4 (different bunks, isolated), 5 alone (no_requests)
     _populate(
         builder,
@@ -117,3 +124,18 @@ def test_calculate_node_metrics_on_digraph_classifies_correctly() -> None:
     assert builder.graph.nodes[1]["satisfaction_status"] == "satisfied"
     assert builder.graph.nodes[3]["satisfaction_status"] == "isolated"
     assert builder.graph.nodes[5]["satisfaction_status"] == "no_requests"
+
+
+def test_parent_builder_on_digraph_still_works() -> None:
+    """Defensive: even though parent SocialGraphBuilder always builds nx.Graph in
+    practice, _calculate_node_metrics must remain DiGraph-safe so nothing regresses
+    if the parent is ever invoked on a directed graph."""
+    builder = _make_builder()
+    _populate(
+        builder,
+        nodes={1: 100, 2: 100, 3: 200},
+        request_edges=[(1, 2), (1, 3)],
+        graph_type=nx.DiGraph,
+    )
+    builder._calculate_node_metrics()
+    assert builder.graph.nodes[1]["satisfaction_status"] == "satisfied"

--- a/tests/unit/bunking/graph/test_satisfaction_status.py
+++ b/tests/unit/bunking/graph/test_satisfaction_status.py
@@ -29,9 +29,14 @@ def _populate(
     nodes: dict[int, int | None],
     request_edges: list[tuple[int, int]],
     other_edges: list[tuple[int, int]] | None = None,
+    graph_type: type = nx.Graph,
 ) -> None:
-    """Populate builder.graph with nodes (id → bunk_cm_id) and edges."""
-    builder.graph = nx.Graph()
+    """Populate builder.graph with nodes (id → bunk_cm_id) and edges.
+
+    graph_type defaults to nx.Graph; pass nx.DiGraph to mirror what
+    OptimizedSocialGraphBuilder uses.
+    """
+    builder.graph = graph_type()
     for node_id, bunk_cm_id in nodes.items():
         builder.graph.add_node(node_id, bunk_cm_id=bunk_cm_id)
     for u, v in request_edges:
@@ -82,19 +87,6 @@ def test_no_request_edges_and_fully_isolated_node_marks_no_requests() -> None:
     assert builder.graph.nodes[1]["satisfaction_status"] == "no_requests"
 
 
-def _populate_digraph(
-    builder: SocialGraphBuilder,
-    nodes: dict[int, int | None],
-    request_edges: list[tuple[int, int]],
-) -> None:
-    """Same as _populate but uses nx.DiGraph — what the OptimizedSocialGraphBuilder uses."""
-    builder.graph = nx.DiGraph()
-    for node_id, bunk_cm_id in nodes.items():
-        builder.graph.add_node(node_id, bunk_cm_id=bunk_cm_id)
-    for u, v in request_edges:
-        builder.graph.add_edge(u, v, edge_type="request")
-
-
 def test_calculate_node_metrics_on_digraph_sets_satisfaction_status() -> None:
     """Regression: OptimizedSocialGraphBuilder uses nx.DiGraph; satisfaction_status must
     still be populated on every node. Prior bug: nx.connected_components raised
@@ -102,7 +94,7 @@ def test_calculate_node_metrics_on_digraph_sets_satisfaction_status() -> None:
     satisfaction_status=None on every node — causing all graph node borders to fall back
     to the same color in the frontend."""
     builder = _make_builder()
-    _populate_digraph(builder, nodes={1: 100, 2: 100, 3: 200}, request_edges=[(1, 2), (1, 3)])
+    _populate(builder, nodes={1: 100, 2: 100, 3: 200}, request_edges=[(1, 2), (1, 3)], graph_type=nx.DiGraph)
     builder._calculate_node_metrics()
     for node_id in (1, 2, 3):
         assert "satisfaction_status" in builder.graph.nodes[node_id], (
@@ -115,10 +107,11 @@ def test_calculate_node_metrics_on_digraph_classifies_correctly() -> None:
     """Same node membership semantics on DiGraph as on Graph."""
     builder = _make_builder()
     # 1 → 2 (same bunk, satisfied), 3 → 4 (different bunks, isolated), 5 alone (no_requests)
-    _populate_digraph(
+    _populate(
         builder,
         nodes={1: 100, 2: 100, 3: 200, 4: 300, 5: 400},
         request_edges=[(1, 2), (3, 4)],
+        graph_type=nx.DiGraph,
     )
     builder._calculate_node_metrics()
     assert builder.graph.nodes[1]["satisfaction_status"] == "satisfied"

--- a/tests/unit/bunking/graph/test_satisfaction_status.py
+++ b/tests/unit/bunking/graph/test_satisfaction_status.py
@@ -80,3 +80,47 @@ def test_no_request_edges_and_fully_isolated_node_marks_no_requests() -> None:
     _populate(builder, nodes={1: 100}, request_edges=[])
     builder._calculate_node_metrics()
     assert builder.graph.nodes[1]["satisfaction_status"] == "no_requests"
+
+
+def _populate_digraph(
+    builder: SocialGraphBuilder,
+    nodes: dict[int, int | None],
+    request_edges: list[tuple[int, int]],
+) -> None:
+    """Same as _populate but uses nx.DiGraph — what the OptimizedSocialGraphBuilder uses."""
+    builder.graph = nx.DiGraph()
+    for node_id, bunk_cm_id in nodes.items():
+        builder.graph.add_node(node_id, bunk_cm_id=bunk_cm_id)
+    for u, v in request_edges:
+        builder.graph.add_edge(u, v, edge_type="request")
+
+
+def test_calculate_node_metrics_on_digraph_sets_satisfaction_status() -> None:
+    """Regression: OptimizedSocialGraphBuilder uses nx.DiGraph; satisfaction_status must
+    still be populated on every node. Prior bug: nx.connected_components raised
+    NetworkXNotImplemented on DiGraph, aborting before the satisfaction loop and leaving
+    satisfaction_status=None on every node — causing all graph node borders to fall back
+    to the same color in the frontend."""
+    builder = _make_builder()
+    _populate_digraph(builder, nodes={1: 100, 2: 100, 3: 200}, request_edges=[(1, 2), (1, 3)])
+    builder._calculate_node_metrics()
+    for node_id in (1, 2, 3):
+        assert "satisfaction_status" in builder.graph.nodes[node_id], (
+            f"node {node_id} missing satisfaction_status — _calculate_node_metrics bailed early"
+        )
+        assert builder.graph.nodes[node_id]["satisfaction_status"] is not None
+
+
+def test_calculate_node_metrics_on_digraph_classifies_correctly() -> None:
+    """Same node membership semantics on DiGraph as on Graph."""
+    builder = _make_builder()
+    # 1 → 2 (same bunk, satisfied), 3 → 4 (different bunks, isolated), 5 alone (no_requests)
+    _populate_digraph(
+        builder,
+        nodes={1: 100, 2: 100, 3: 200, 4: 300, 5: 400},
+        request_edges=[(1, 2), (3, 4)],
+    )
+    builder._calculate_node_metrics()
+    assert builder.graph.nodes[1]["satisfaction_status"] == "satisfied"
+    assert builder.graph.nodes[3]["satisfaction_status"] == "isolated"
+    assert builder.graph.nodes[5]["satisfaction_status"] == "no_requests"


### PR DESCRIPTION
## Summary

`OptimizedSocialGraphBuilder._calculate_node_metrics` overrode the parent and silently dropped the **component-size** and **satisfaction-status** phases since the initial commit. The override only added `round(centrality, 2)` (cosmetic — sub-pixel size delta in the frontend; no consumer depends on the rounding) and `nx.clustering(graph.to_undirected())` (no consumer reads the `clustering` field — declared in TS but never rendered or used in logic).

Meanwhile `OptimizedSocialGraphBuilder` is the GUI path: 3 of 4 production callers in `api/routers/social_graph.py` instantiate it (the friends-page social graph endpoint among them). The parent is only invoked from the ego-network endpoint, which doesn't surface `satisfaction_status` to the frontend at all.

Net effect: `satisfaction_status` was never populated on any node the GUI rendered, and every border fell back to a single default color.

This PR **deletes the override**. The optimized class now inherits the parent's full four-phase metric calculation. The parent retains its defensive `is_directed()` branch (using `nx.weakly_connected_components` for directed graphs) so it remains DiGraph-safe for any future direct caller.

## What changed vs the original diagnosis

The first attempt at this fix (earlier commits on this branch) patched the parent's `_calculate_node_metrics` to handle directed graphs, on the theory that `nx.connected_components` was raising and the exception was being swallowed. That was wrong — no exception ever fired on the GUI path because the override never invoked the parent body. The parent fix is still useful as defense in depth, but the actual user-visible bug needed the override deleted.

## Why no override is needed

- **Rounding**: frontend uses `centrality` only as `10 + centrality * 40` for node-pixel size. Full-precision floats produce visually indistinguishable sizes (sub-pixel delta).
- **`to_undirected()` clustering**: `clustering` is declared on the TS type but no UI element reads it. The directed-vs-undirected formula difference is invisible.

The override was solving a problem nobody had while inadvertently creating the satisfaction-status bug.

## TDD

Tests in `tests/unit/bunking/graph/test_satisfaction_status.py` were retargeted at `OptimizedSocialGraphBuilder` directly so the regression anchor exercises the actual production class:

- `test_optimized_builder_sets_satisfaction_status` — every node gets a non-null `satisfaction_status` on the optimized builder.
- `test_optimized_builder_classifies_correctly` — same `satisfied` / `isolated` / `no_requests` semantics on the DiGraph as the parent produces on a Graph.
- `test_parent_builder_on_digraph_still_works` — defensive: the parent's directed-graph branch stays covered.

Red phase verified: `test_optimized_builder_sets_satisfaction_status` failed before the override was deleted with `'satisfaction_status' missing — OptimizedSocialGraphBuilder override is dropping the satisfaction loop`.

Full unit-test sweep: **3687 passed, 23 skipped (all pre-existing skip reasons)**.

## Manual validation (dev/preview)

Spin up the worktree's dev server (`cd ~/kindred-worktrees/fix-graph-satisfaction-payload && ./scripts/start_dev.sh`) and walk through:

1. Open the friends graph for any session that has bunk requests.
2. **Expected before**: every node border renders the same dark navy color.
3. **Expected after**: borders differentiate per the legend — green for `satisfied` (≥1 request landed in the cabin), red for `isolated` (has requests, none satisfied), gray for `no_requests` (no request edges at all).
4. Switch sessions; legend should match the borders.
5. Move a camper into the same cabin as their requestee → after the existing #1017 invalidation fires, the border should flip color (unrelated to this fix but confirms staleness path still works).
6. Layout, node positions, sizes, and edges should be unchanged compared to current main — only border colors change.

Closes scoreboard #36 / issue #1040.

🤖 Generated with [Claude Code](https://claude.com/claude-code)