### PR TITLE
feat(frontend): CSV upload progress indicator (#52)

### DIFF
--- a/frontend/src/components/BunkRequestsUpload.test.tsx
+++ b/frontend/src/components/BunkRequestsUpload.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 vi.mock('../hooks/useApiWithAuth', () => ({
@@ -16,11 +16,13 @@ vi.mock('../services/sync', () => ({
   },
 }))
 
+const mockToast = {
+  success: vi.fn(),
+  error: vi.fn(),
+}
+
 vi.mock('react-hot-toast', () => ({
-  default: {
-    success: vi.fn(),
-    error: vi.fn(),
-  },
+  default: mockToast,
 }))
 
 const BunkRequestsUpload = (await import('./BunkRequestsUpload')).default
@@ -40,5 +42,44 @@ describe('BunkRequestsUpload floatover/tooltip', () => {
     // The upload button has a title attribute acting as the floatover/tooltip.
     const btn = screen.getByRole('button', { name: /Upload/i })
     expect(btn.getAttribute('title')).toBe('Camper report: API Bunking Info')
+  })
+})
+
+describe('BunkRequestsUpload upload success toast', () => {
+  beforeEach(() => {
+    mockToast.success.mockClear()
+    mockToast.error.mockClear()
+  })
+
+  it('shows the locked toast copy on successful upload', async () => {
+    const { syncService } = await import('../services/sync')
+    vi.mocked(syncService.uploadBunkRequestsCSV).mockResolvedValueOnce({
+      filename: 'test.csv',
+      process_requests_started: true,
+    } as never)
+
+    renderUpload()
+
+    // Find the hidden file input and simulate selecting a CSV file (this opens the modal).
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement
+    expect(fileInput).toBeTruthy()
+
+    const file = new File(['name,target\nEmma,Liam'], 'test.csv', { type: 'text/csv' })
+    fireEvent.change(fileInput, { target: { files: [file] } })
+
+    // The modal opens with a confirmation Upload button. Click it to fire the mutation.
+    // There are now multiple "Upload" buttons (the original trigger + the confirm button in modal).
+    const uploadButtons = await screen.findAllByRole('button', { name: /Upload/i })
+    // The confirm button is the last one rendered (inside the modal).
+    const confirmBtn = uploadButtons[uploadButtons.length - 1]
+    expect(confirmBtn).toBeDefined()
+    fireEvent.click(confirmBtn!)
+
+    await waitFor(() => {
+      expect(mockToast.success).toHaveBeenCalledWith(
+        expect.stringContaining('Importing CSV — this may take a few minutes'),
+        expect.objectContaining({ duration: 6000 })
+      )
+    })
   })
 })

--- a/frontend/src/components/BunkRequestsUpload.tsx
+++ b/frontend/src/components/BunkRequestsUpload.tsx
@@ -20,20 +20,19 @@ export default function BunkRequestsUpload({ compact = false }: BunkRequestsUplo
 
   const uploadMutation = useMutation({
     mutationFn: (file: File) => syncService.uploadBunkRequestsCSV(file, fetchWithAuth, currentYear),
-    onSuccess: (data) => {
-      const message = data.process_requests_started
-        ? `CSV uploaded - syncing and processing requests...`
-        : `CSV uploaded successfully: ${data.filename}`
-      toast.success(message, {
-        duration: 4000,
-      })
+    onSuccess: () => {
+      toast.success(
+        "Importing CSV — this may take a few minutes. The icon next to the Upload Requests button will update when it's done.",
+        { duration: 6000 }
+      )
       setShowModal(false)
       setSelectedFile(null)
       if (fileInputRef.current) {
         fileInputRef.current.value = ''
       }
-      // Invalidate sync status
+      // Invalidate sync status and csv pipeline status
       void queryClient.invalidateQueries({ queryKey: ['sync-status'] })
+      void queryClient.invalidateQueries({ queryKey: ['csv-pipeline-status'] })
     },
     onError: (error: UploadError) => {
       if (error.missing_columns) {

--- a/frontend/src/components/BunkRequestsUpload.tsx
+++ b/frontend/src/components/BunkRequestsUpload.tsx
@@ -5,6 +5,7 @@ import { syncService, type UploadError } from '../services/sync'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import toast from 'react-hot-toast'
 import { useCurrentYear } from '../hooks/useCurrentYear'
+import { queryKeys } from '../utils/queryKeys'
 
 interface BunkRequestsUploadProps {
   compact?: boolean
@@ -31,8 +32,8 @@ export default function BunkRequestsUpload({ compact = false }: BunkRequestsUplo
         fileInputRef.current.value = ''
       }
       // Invalidate sync status and csv pipeline status
-      void queryClient.invalidateQueries({ queryKey: ['sync-status'] })
-      void queryClient.invalidateQueries({ queryKey: ['csv-pipeline-status'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.csvPipelineStatus() })
     },
     onError: (error: UploadError) => {
       if (error.missing_columns) {

--- a/frontend/src/components/CsvPipelineIndicator.test.tsx
+++ b/frontend/src/components/CsvPipelineIndicator.test.tsx
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import CsvPipelineIndicator from './CsvPipelineIndicator'
+import type { PipelinePhase } from '../services/csvPipelineStatus'
+
+const mockToast = { success: vi.fn() }
+vi.mock('react-hot-toast', () => ({
+  default: { success: (...args: unknown[]) => mockToast.success(...args) },
+}))
+
+const mockUseStatus = vi.fn()
+vi.mock('../hooks/useCsvPipelineStatus', () => ({
+  useCsvPipelineStatus: () =>
+    mockUseStatus() as { data: PipelinePhase | undefined; isLoading: boolean; isError: boolean },
+}))
+
+// Use real localStorage for these tests (the global setup mocks it with vi.fn())
+const realLocalStorage = (() => {
+  const store = new Map<string, string>()
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value)
+    },
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => {
+      store.clear()
+    },
+    length: 0,
+    key: vi.fn(),
+  }
+})()
+
+beforeAll(() => {
+  vi.stubGlobal('localStorage', realLocalStorage)
+})
+
+afterAll(() => {
+  vi.unstubAllGlobals()
+})
+
+beforeEach(() => {
+  mockUseStatus.mockReset()
+  mockToast.success.mockReset()
+  localStorage.clear()
+})
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+function setData(data: PipelinePhase | undefined): void {
+  mockUseStatus.mockReturnValue({ data, isLoading: false, isError: false })
+}
+
+describe('CsvPipelineIndicator', () => {
+  it('renders nothing when phase is idle', () => {
+    setData({ phase: 'idle' })
+    const { container } = render(<CsvPipelineIndicator />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when data is undefined (initial load)', () => {
+    setData(undefined)
+    const { container } = render(<CsvPipelineIndicator />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders importing label with spinner', () => {
+    setData({ phase: 'importing', startedAt: new Date().toISOString() })
+    render(<CsvPipelineIndicator />)
+    expect(screen.getByText(/Loading new or updated requests from CSV/i)).toBeInTheDocument()
+  })
+
+  it('renders matching label with spinner', () => {
+    setData({ phase: 'matching', startedAt: new Date().toISOString() })
+    render(<CsvPipelineIndicator />)
+    expect(screen.getByText(/Resolving camper names and calculating requests/i)).toBeInTheDocument()
+  })
+
+  it('renders done state with mapped counts', () => {
+    setData({
+      phase: 'done',
+      runId: 'r1',
+      finishedAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+      counts: { total: 28, autoMatched: 22, needReview: 6 },
+    })
+    render(<CsvPipelineIndicator />)
+    expect(
+      screen.getByText(/Done .*: 28 new or updated requests, 22 auto-matched, 6 need review/)
+    ).toBeInTheDocument()
+  })
+
+  it('renders error state with click-for-details copy', () => {
+    setData({
+      phase: 'error',
+      finishedAt: new Date().toISOString(),
+      message: 'context deadline exceeded',
+    })
+    render(<CsvPipelineIndicator />)
+    expect(screen.getByText(/Import failed/i)).toBeInTheDocument()
+  })
+
+  it('fires completion toast exactly once per runId', () => {
+    setData({
+      phase: 'done',
+      runId: 'r1',
+      finishedAt: new Date().toISOString(),
+      counts: { total: 10, autoMatched: 8, needReview: 2 },
+    })
+    const { rerender } = render(<CsvPipelineIndicator />)
+    expect(mockToast.success).toHaveBeenCalledTimes(1)
+    expect(mockToast.success).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Import complete: 10 new or updated requests, 8 auto-matched, 2 need review'
+      ),
+      expect.any(Object)
+    )
+    // Re-render with same data — should NOT toast again
+    rerender(<CsvPipelineIndicator />)
+    expect(mockToast.success).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires a fresh toast when runId changes', () => {
+    setData({
+      phase: 'done',
+      runId: 'r1',
+      finishedAt: new Date().toISOString(),
+      counts: { total: 1, autoMatched: 1, needReview: 0 },
+    })
+    const { rerender } = render(<CsvPipelineIndicator />)
+    expect(mockToast.success).toHaveBeenCalledTimes(1)
+    setData({
+      phase: 'done',
+      runId: 'r2',
+      finishedAt: new Date().toISOString(),
+      counts: { total: 5, autoMatched: 5, needReview: 0 },
+    })
+    rerender(<CsvPipelineIndicator />)
+    expect(mockToast.success).toHaveBeenCalledTimes(2)
+  })
+
+  it('hides indicator when dismissed runId matches current done runId', () => {
+    localStorage.setItem('csvProgressDismissedRunId', 'r1')
+    setData({
+      phase: 'done',
+      runId: 'r1',
+      finishedAt: new Date().toISOString(),
+      counts: { total: 1, autoMatched: 1, needReview: 0 },
+    })
+    const { container } = render(<CsvPipelineIndicator />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('still renders when dismissed runId differs from current done runId', () => {
+    localStorage.setItem('csvProgressDismissedRunId', 'r1')
+    setData({
+      phase: 'done',
+      runId: 'r2',
+      finishedAt: new Date().toISOString(),
+      counts: { total: 1, autoMatched: 1, needReview: 0 },
+    })
+    render(<CsvPipelineIndicator />)
+    expect(screen.getByText(/Done .*: 1 new or updated requests/)).toBeInTheDocument()
+  })
+
+  it('clicking × stores current runId in dismissed-key and hides indicator', () => {
+    setData({
+      phase: 'done',
+      runId: 'r3',
+      finishedAt: new Date().toISOString(),
+      counts: { total: 1, autoMatched: 1, needReview: 0 },
+    })
+    render(<CsvPipelineIndicator />)
+    const dismissBtn = screen.getByRole('button', { name: /dismiss/i })
+    fireEvent.click(dismissBtn)
+    expect(localStorage.getItem('csvProgressDismissedRunId')).toBe('r3')
+    // After dismiss, component should render null on next mount with same data
+    setData({
+      phase: 'done',
+      runId: 'r3',
+      finishedAt: new Date().toISOString(),
+      counts: { total: 1, autoMatched: 1, needReview: 0 },
+    })
+    const { container: c2 } = render(<CsvPipelineIndicator />)
+    expect(c2.firstChild).toBeNull()
+  })
+
+  it('clicking the main button toggles a popover', () => {
+    setData({ phase: 'importing', startedAt: new Date().toISOString() })
+    render(<CsvPipelineIndicator />)
+    const btn = screen.getByRole('button', { name: /CSV pipeline status/i })
+    fireEvent.click(btn)
+    expect(screen.getByRole('region', { name: /pipeline detail/i })).toBeInTheDocument()
+    fireEvent.click(btn)
+    expect(screen.queryByRole('region', { name: /pipeline detail/i })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/CsvPipelineIndicator.test.tsx
+++ b/frontend/src/components/CsvPipelineIndicator.test.tsx
@@ -93,6 +93,35 @@ describe('CsvPipelineIndicator', () => {
     ).toBeInTheDocument()
   })
 
+  it('omits "need review" from button label when needReview is zero', () => {
+    setData({
+      phase: 'done',
+      runId: 'r-zero',
+      finishedAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+      counts: { total: 22, autoMatched: 22, needReview: 0 },
+    })
+    render(<CsvPipelineIndicator />)
+    expect(
+      screen.getByText(/Done .*: 22 new or updated requests, 22 auto-matched$/)
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/need review/i)).not.toBeInTheDocument()
+  })
+
+  it('omits "need review" from completion toast when needReview is zero', () => {
+    setData({
+      phase: 'done',
+      runId: 'r-zero-toast',
+      finishedAt: new Date().toISOString(),
+      counts: { total: 22, autoMatched: 22, needReview: 0 },
+    })
+    render(<CsvPipelineIndicator />)
+    expect(mockToast.success).toHaveBeenCalledTimes(1)
+    expect(mockToast.success).toHaveBeenCalledWith(
+      'Import complete: 22 new or updated requests, 22 auto-matched.',
+      expect.any(Object)
+    )
+  })
+
   it('renders error state with click-for-details copy', () => {
     setData({
       phase: 'error',
@@ -100,7 +129,7 @@ describe('CsvPipelineIndicator', () => {
       message: 'context deadline exceeded',
     })
     render(<CsvPipelineIndicator />)
-    expect(screen.getByText(/Import failed/i)).toBeInTheDocument()
+    expect(screen.getByText(/Import failed\. Click for details\./i)).toBeInTheDocument()
   })
 
   it('fires completion toast exactly once per runId', () => {

--- a/frontend/src/components/CsvPipelineIndicator.test.tsx
+++ b/frontend/src/components/CsvPipelineIndicator.test.tsx
@@ -226,4 +226,27 @@ describe('CsvPipelineIndicator', () => {
     fireEvent.click(btn)
     expect(screen.queryByRole('region', { name: /pipeline detail/i })).not.toBeInTheDocument()
   })
+
+  it('closes the popover on outside mousedown', () => {
+    setData({ phase: 'importing', startedAt: new Date().toISOString() })
+    render(
+      <div>
+        <CsvPipelineIndicator />
+        <button type="button">outside</button>
+      </div>
+    )
+    fireEvent.click(screen.getByRole('button', { name: /CSV pipeline status/i }))
+    expect(screen.getByRole('region', { name: /pipeline detail/i })).toBeInTheDocument()
+    fireEvent.mouseDown(screen.getByRole('button', { name: /outside/i }))
+    expect(screen.queryByRole('region', { name: /pipeline detail/i })).not.toBeInTheDocument()
+  })
+
+  it('closes the popover when Escape is pressed', () => {
+    setData({ phase: 'importing', startedAt: new Date().toISOString() })
+    render(<CsvPipelineIndicator />)
+    fireEvent.click(screen.getByRole('button', { name: /CSV pipeline status/i }))
+    expect(screen.getByRole('region', { name: /pipeline detail/i })).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('region', { name: /pipeline detail/i })).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/CsvPipelineIndicator.tsx
+++ b/frontend/src/components/CsvPipelineIndicator.tsx
@@ -18,7 +18,7 @@ export default function CsvPipelineIndicator() {
   useEffect(() => {
     if (data?.phase === 'done' && data.runId !== lastSeenRef.current) {
       const review = data.counts.needReview
-      const reviewLabel = `, ${review} need review`
+      const reviewLabel = review > 0 ? `, ${review} need review` : ''
       toast.success(
         `Import complete: ${data.counts.total} new or updated requests, ${data.counts.autoMatched} auto-matched${reviewLabel}.`,
         { duration: 6000 }
@@ -63,7 +63,8 @@ export default function CsvPipelineIndicator() {
             <CheckCircle className="h-4 w-4 text-green-600" aria-hidden="true" />
             <span>
               Done {formatTimestamp(data.finishedAt)}: {data.counts.total} new or updated requests,{' '}
-              {data.counts.autoMatched} auto-matched, {data.counts.needReview} need review
+              {data.counts.autoMatched} auto-matched
+              {data.counts.needReview > 0 ? `, ${data.counts.needReview} need review` : ''}
             </span>
           </>
         )}
@@ -104,7 +105,7 @@ export default function CsvPipelineIndicator() {
               <ul className="list-disc pl-5">
                 <li>{data.counts.total} new or updated requests</li>
                 <li>{data.counts.autoMatched} auto-matched</li>
-                <li>{data.counts.needReview} need review</li>
+                {data.counts.needReview > 0 && <li>{data.counts.needReview} need review</li>}
               </ul>
               <p className="text-xs text-gray-600">{formatTimestamp(data.finishedAt)}</p>
             </div>

--- a/frontend/src/components/CsvPipelineIndicator.tsx
+++ b/frontend/src/components/CsvPipelineIndicator.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Loader2, CheckCircle, AlertCircle, X } from 'lucide-react'
 import toast from 'react-hot-toast'
 import { useCsvPipelineStatus } from '../hooks/useCsvPipelineStatus'
+import { useClickOutside } from '../hooks/useClickOutside'
 import { formatTimestamp } from '../utils/formatTimestamp'
 
 const DISMISSED_KEY = 'csvProgressDismissedRunId'
@@ -16,22 +17,15 @@ export default function CsvPipelineIndicator() {
   const lastSeenRef = useRef<string | null>(localStorage.getItem(LAST_SEEN_KEY))
   const wrapperRef = useRef<HTMLDivElement | null>(null)
 
+  useClickOutside(wrapperRef, () => setPopoverOpen(false), popoverOpen)
+
   useEffect(() => {
     if (!popoverOpen) return
-    const handleMouseDown = (event: MouseEvent) => {
-      if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) {
-        setPopoverOpen(false)
-      }
-    }
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') setPopoverOpen(false)
     }
-    document.addEventListener('mousedown', handleMouseDown)
     document.addEventListener('keydown', handleKeyDown)
-    return () => {
-      document.removeEventListener('mousedown', handleMouseDown)
-      document.removeEventListener('keydown', handleKeyDown)
-    }
+    return () => document.removeEventListener('keydown', handleKeyDown)
   }, [popoverOpen])
 
   useEffect(() => {

--- a/frontend/src/components/CsvPipelineIndicator.tsx
+++ b/frontend/src/components/CsvPipelineIndicator.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef, useState } from 'react'
+import { Loader2, CheckCircle, AlertCircle, X } from 'lucide-react'
+import toast from 'react-hot-toast'
+import { useCsvPipelineStatus } from '../hooks/useCsvPipelineStatus'
+import { formatTimestamp } from '../utils/formatTimestamp'
+
+const DISMISSED_KEY = 'csvProgressDismissedRunId'
+const LAST_SEEN_KEY = 'csvProgressLastSeenRunId'
+
+export default function CsvPipelineIndicator() {
+  const { data } = useCsvPipelineStatus()
+  const [popoverOpen, setPopoverOpen] = useState(false)
+  const [dismissedRunId, setDismissedRunId] = useState<string | null>(() =>
+    localStorage.getItem(DISMISSED_KEY)
+  )
+  const lastSeenRef = useRef<string | null>(localStorage.getItem(LAST_SEEN_KEY))
+
+  useEffect(() => {
+    if (data?.phase === 'done' && data.runId !== lastSeenRef.current) {
+      const review = data.counts.needReview
+      const reviewLabel = `, ${review} need review`
+      toast.success(
+        `Import complete: ${data.counts.total} new or updated requests, ${data.counts.autoMatched} auto-matched${reviewLabel}.`,
+        { duration: 6000 }
+      )
+      lastSeenRef.current = data.runId
+      localStorage.setItem(LAST_SEEN_KEY, data.runId)
+    }
+  }, [data])
+
+  if (!data || data.phase === 'idle') return null
+  if (data.phase === 'done' && dismissedRunId === data.runId) return null
+
+  const handleDismiss = () => {
+    if (data.phase !== 'done') return
+    localStorage.setItem(DISMISSED_KEY, data.runId)
+    setDismissedRunId(data.runId)
+    setPopoverOpen(false)
+  }
+
+  return (
+    <div className="relative flex items-center">
+      <button
+        type="button"
+        onClick={() => setPopoverOpen((v) => !v)}
+        className="flex items-center gap-1.5 rounded px-2 py-1 text-sm hover:bg-gray-100"
+        aria-label="CSV pipeline status"
+      >
+        {data.phase === 'importing' && (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin text-blue-600" aria-hidden="true" />
+            <span>Loading new or updated requests from CSV</span>
+          </>
+        )}
+        {data.phase === 'matching' && (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin text-blue-600" aria-hidden="true" />
+            <span>Resolving camper names and calculating requests</span>
+          </>
+        )}
+        {data.phase === 'done' && (
+          <>
+            <CheckCircle className="h-4 w-4 text-green-600" aria-hidden="true" />
+            <span>
+              Done {formatTimestamp(data.finishedAt)}: {data.counts.total} new or updated requests,{' '}
+              {data.counts.autoMatched} auto-matched, {data.counts.needReview} need review
+            </span>
+          </>
+        )}
+        {data.phase === 'error' && (
+          <>
+            <AlertCircle className="h-4 w-4 text-red-600" aria-hidden="true" />
+            <span>Import failed. Click for details.</span>
+          </>
+        )}
+      </button>
+      {data.phase === 'done' && (
+        <button
+          type="button"
+          onClick={handleDismiss}
+          className="ml-1 rounded p-0.5 hover:bg-gray-200"
+          aria-label="Dismiss"
+        >
+          <X className="h-3 w-3" aria-hidden="true" />
+        </button>
+      )}
+      {popoverOpen && (
+        <div
+          role="region"
+          aria-label="Pipeline detail"
+          className="absolute top-full right-0 z-50 mt-1 w-72 rounded border bg-white p-3 shadow-lg"
+        >
+          {data.phase === 'importing' && (
+            <p className="text-sm">Phase 1 of 2 — reading the CSV and adding new request rows.</p>
+          )}
+          {data.phase === 'matching' && (
+            <p className="text-sm">
+              Phase 2 of 2 — resolving camper names and calculating requests.
+            </p>
+          )}
+          {data.phase === 'done' && (
+            <div className="space-y-2 text-sm">
+              <p className="font-medium">Import complete</p>
+              <ul className="list-disc pl-5">
+                <li>{data.counts.total} new or updated requests</li>
+                <li>{data.counts.autoMatched} auto-matched</li>
+                <li>{data.counts.needReview} need review</li>
+              </ul>
+              <p className="text-xs text-gray-600">{formatTimestamp(data.finishedAt)}</p>
+            </div>
+          )}
+          {data.phase === 'error' && (
+            <div className="space-y-1 text-sm">
+              <p className="font-medium text-red-700">Import failed</p>
+              <p className="text-xs text-gray-700">{data.message}</p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/CsvPipelineIndicator.tsx
+++ b/frontend/src/components/CsvPipelineIndicator.tsx
@@ -14,6 +14,25 @@ export default function CsvPipelineIndicator() {
     localStorage.getItem(DISMISSED_KEY)
   )
   const lastSeenRef = useRef<string | null>(localStorage.getItem(LAST_SEEN_KEY))
+  const wrapperRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!popoverOpen) return
+    const handleMouseDown = (event: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) {
+        setPopoverOpen(false)
+      }
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setPopoverOpen(false)
+    }
+    document.addEventListener('mousedown', handleMouseDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [popoverOpen])
 
   useEffect(() => {
     if (data?.phase === 'done' && data.runId !== lastSeenRef.current) {
@@ -39,7 +58,7 @@ export default function CsvPipelineIndicator() {
   }
 
   return (
-    <div className="relative flex items-center">
+    <div ref={wrapperRef} className="relative flex items-center">
       <button
         type="button"
         onClick={() => setPopoverOpen((v) => !v)}

--- a/frontend/src/hooks/useCsvPipelineStatus.test.tsx
+++ b/frontend/src/hooks/useCsvPipelineStatus.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
-import { useCsvPipelineStatus } from './useCsvPipelineStatus'
+import { useCsvPipelineStatus, pollIntervalForPhase } from './useCsvPipelineStatus'
 
 vi.mock('./useApiWithAuth', () => ({
   useApiWithAuth: () => ({
@@ -13,9 +13,10 @@ vi.mock('./useApiWithAuth', () => ({
 
 function makeWrapper() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  return function Wrapper({ children }: { children: ReactNode }) {
+  function Wrapper({ children }: { children: ReactNode }) {
     return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
   }
+  return Wrapper
 }
 
 beforeEach(() => {
@@ -99,5 +100,39 @@ describe('useCsvPipelineStatus', () => {
     ;(globalThis as any).__mockFetch = vi.fn(async () => ({ ok: false, status: 500 }) as Response)
     const { result } = renderHook(() => useCsvPipelineStatus(), { wrapper: makeWrapper() })
     await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+
+  it('still derives phase from sync when debug fetch fails', async () => {
+    const startedAt = new Date(Date.now() - 5 * 60_000).toISOString()
+    const finishedAt = new Date(Date.now() - 3 * 60_000).toISOString()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(globalThis as any).__mockFetch = vi.fn(async (url: string) => {
+      if (url.includes('sync/status')) {
+        return {
+          ok: true,
+          json: async () => ({
+            bunk_requests: {
+              type: 'bunk_requests',
+              status: 'completed',
+              start_time: startedAt,
+              end_time: finishedAt,
+            },
+          }),
+        } as Response
+      }
+      return { ok: false, status: 500 } as Response
+    })
+    const { result } = renderHook(() => useCsvPipelineStatus(), { wrapper: makeWrapper() })
+    await waitFor(() => expect(result.current.data?.phase).toBe('matching'))
+  })
+
+  it.each([
+    ['idle', false],
+    ['importing', 2000],
+    ['matching', 2000],
+    ['done', false],
+    ['error', false],
+  ] as const)('pollIntervalForPhase(%s) returns %s', (phase, expected) => {
+    expect(pollIntervalForPhase(phase)).toBe(expected)
   })
 })

--- a/frontend/src/hooks/useCsvPipelineStatus.test.tsx
+++ b/frontend/src/hooks/useCsvPipelineStatus.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { useCsvPipelineStatus } from './useCsvPipelineStatus'
+
+vi.mock('./useApiWithAuth', () => ({
+  useApiWithAuth: () => ({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fetchWithAuth: (globalThis as any).__mockFetch,
+  }),
+}))
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  }
+}
+
+beforeEach(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(globalThis as any).__mockFetch = undefined
+})
+
+describe('useCsvPipelineStatus', () => {
+  it('returns idle phase when both sources are empty', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(globalThis as any).__mockFetch = vi.fn(async (url: string) => {
+      if (url.includes('sync/status')) {
+        return { ok: true, json: async () => ({ _daily_sync_running: false }) } as Response
+      }
+      return { ok: true, json: async () => ({ items: [] }) } as Response
+    })
+    const { result } = renderHook(() => useCsvPipelineStatus(), { wrapper: makeWrapper() })
+    await waitFor(() => expect(result.current.data?.phase).toBe('idle'))
+  })
+
+  it('returns importing phase when bunk_requests is running', async () => {
+    const startedAt = new Date().toISOString()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(globalThis as any).__mockFetch = vi.fn(async (url: string) => {
+      if (url.includes('sync/status')) {
+        return {
+          ok: true,
+          json: async () => ({
+            bunk_requests: { type: 'bunk_requests', status: 'running', start_time: startedAt },
+          }),
+        } as Response
+      }
+      return { ok: true, json: async () => ({ items: [] }) } as Response
+    })
+    const { result } = renderHook(() => useCsvPipelineStatus(), { wrapper: makeWrapper() })
+    await waitFor(() => expect(result.current.data?.phase).toBe('importing'))
+  })
+
+  it('returns done phase with mapped counts when fresh debug row exists', async () => {
+    const startedAt = new Date(Date.now() - 5 * 60_000).toISOString()
+    const finishedAt = new Date(Date.now() - 3 * 60_000).toISOString()
+    const debugCreated = new Date(Date.now() - 1 * 60_000).toISOString()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(globalThis as any).__mockFetch = vi.fn(async (url: string) => {
+      if (url.includes('sync/status')) {
+        return {
+          ok: true,
+          json: async () => ({
+            bunk_requests: {
+              type: 'bunk_requests',
+              status: 'completed',
+              start_time: startedAt,
+              end_time: finishedAt,
+            },
+          }),
+        } as Response
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              run_id: 'r-done',
+              created: debugCreated,
+              status_breakdown: { status_resolved: 18, status_pending: 4, status_declined: 2 },
+            },
+          ],
+        }),
+      } as Response
+    })
+    const { result } = renderHook(() => useCsvPipelineStatus(), { wrapper: makeWrapper() })
+    await waitFor(() => expect(result.current.data?.phase).toBe('done'))
+    expect(result.current.data).toMatchObject({
+      runId: 'r-done',
+      counts: { total: 24, autoMatched: 20, needReview: 4 },
+    })
+  })
+
+  it('exposes errors from fetchers via React Query error state', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(globalThis as any).__mockFetch = vi.fn(async () => ({ ok: false, status: 500 }) as Response)
+    const { result } = renderHook(() => useCsvPipelineStatus(), { wrapper: makeWrapper() })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})

--- a/frontend/src/hooks/useCsvPipelineStatus.ts
+++ b/frontend/src/hooks/useCsvPipelineStatus.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query'
+import { useApiWithAuth } from './useApiWithAuth'
+import {
+  derivePhase,
+  fetchLatestDebugRun,
+  fetchSyncStatus,
+  type PipelinePhase,
+} from '../services/csvPipelineStatus'
+import { queryKeys } from '../utils/queryKeys'
+
+const ACTIVE_POLL_MS = 2000
+const STALE_TIME_MS = 1500
+
+export function useCsvPipelineStatus() {
+  const { fetchWithAuth } = useApiWithAuth()
+
+  return useQuery<PipelinePhase>({
+    queryKey: queryKeys.csvPipelineStatus(),
+    queryFn: async () => {
+      const [sync, debug] = await Promise.all([
+        fetchSyncStatus(fetchWithAuth),
+        fetchLatestDebugRun(fetchWithAuth),
+      ])
+      return derivePhase(sync, debug)
+    },
+    refetchInterval: (q) => {
+      const phase = q.state.data?.phase
+      return phase === 'importing' || phase === 'matching' ? ACTIVE_POLL_MS : false
+    },
+    staleTime: STALE_TIME_MS,
+  })
+}

--- a/frontend/src/hooks/useCsvPipelineStatus.ts
+++ b/frontend/src/hooks/useCsvPipelineStatus.ts
@@ -11,22 +11,25 @@ import { queryKeys } from '../utils/queryKeys'
 const ACTIVE_POLL_MS = 2000
 const STALE_TIME_MS = 1500
 
+export function pollIntervalForPhase(phase: PipelinePhase['phase'] | undefined): number | false {
+  return phase === 'importing' || phase === 'matching' ? ACTIVE_POLL_MS : false
+}
+
 export function useCsvPipelineStatus() {
   const { fetchWithAuth } = useApiWithAuth()
 
   return useQuery<PipelinePhase>({
     queryKey: queryKeys.csvPipelineStatus(),
     queryFn: async () => {
-      const [sync, debug] = await Promise.all([
+      const [syncResult, debugResult] = await Promise.allSettled([
         fetchSyncStatus(fetchWithAuth),
         fetchLatestDebugRun(fetchWithAuth),
       ])
-      return derivePhase(sync, debug)
+      if (syncResult.status === 'rejected') throw syncResult.reason
+      const debug = debugResult.status === 'fulfilled' ? debugResult.value : null
+      return derivePhase(syncResult.value, debug)
     },
-    refetchInterval: (q) => {
-      const phase = q.state.data?.phase
-      return phase === 'importing' || phase === 'matching' ? ACTIVE_POLL_MS : false
-    },
+    refetchInterval: (q) => pollIntervalForPhase(q.state.data?.phase),
     staleTime: STALE_TIME_MS,
   })
 }

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -25,6 +25,7 @@ import toast from 'react-hot-toast'
 import YearSelector from '../components/YearSelector'
 import CacheStatus from '../components/CacheStatus'
 import BunkRequestsUpload from '../components/BunkRequestsUpload'
+import CsvPipelineIndicator from '../components/CsvPipelineIndicator'
 import { BrandedLogo } from '../components/BrandedLogo'
 import { useYear } from '../hooks/useCurrentYear'
 import { usePermissions } from '../hooks/usePermissions'
@@ -652,6 +653,7 @@ export const AppLayout = () => {
                 {/* Summer-only: Bunking controls (manage permission required) */}
                 {activeProgram === 'summer' && hasPermission(Permission.BUNKING_MANAGE) && (
                   <>
+                    <CsvPipelineIndicator />
                     <BunkRequestsUpload />
                     <button
                       onClick={() => {
@@ -739,6 +741,7 @@ export const AppLayout = () => {
             <div className="flex items-center gap-2">
               {activeProgram === 'summer' && hasPermission(Permission.BUNKING_MANAGE) && (
                 <>
+                  <CsvPipelineIndicator />
                   <BunkRequestsUpload />
                   <button
                     onClick={() => {

--- a/frontend/src/services/csvPipelineStatus.test.ts
+++ b/frontend/src/services/csvPipelineStatus.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest'
+import { derivePhase, type SyncJobStatus, type DebugPipelineRun } from './csvPipelineStatus'
+
+const ago = (mins: number) => new Date(Date.now() - mins * 60_000).toISOString()
+
+describe('derivePhase', () => {
+  it('returns idle when nothing has ever run', () => {
+    expect(derivePhase(null, null)).toEqual({ phase: 'idle' })
+  })
+
+  it('returns importing when bunk_requests sync is running', () => {
+    const sync: SyncJobStatus = { name: 'bunk_requests', status: 'running', startedAt: ago(1) }
+    expect(derivePhase(sync, null).phase).toBe('importing')
+  })
+
+  it('returns matching when sync completed but no debug row yet', () => {
+    const sync: SyncJobStatus = {
+      name: 'bunk_requests',
+      status: 'completed',
+      startedAt: ago(5),
+      finishedAt: ago(2),
+    }
+    expect(derivePhase(sync, null).phase).toBe('matching')
+  })
+
+  it('returns matching when debug row exists but is older than current sync', () => {
+    const sync: SyncJobStatus = {
+      name: 'bunk_requests',
+      status: 'completed',
+      startedAt: ago(5),
+      finishedAt: ago(2),
+    }
+    const stale: DebugPipelineRun = {
+      run_id: 'old',
+      created: ago(60),
+      status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
+    }
+    expect(derivePhase(sync, stale).phase).toBe('matching')
+  })
+
+  it('returns done with counts when fresh debug row exists', () => {
+    const sync: SyncJobStatus = {
+      name: 'bunk_requests',
+      status: 'completed',
+      startedAt: ago(5),
+      finishedAt: ago(3),
+    }
+    const fresh: DebugPipelineRun = {
+      run_id: 'r1',
+      created: ago(1),
+      status_breakdown: { status_resolved: 20, status_pending: 6, status_declined: 2 },
+    }
+    const result = derivePhase(sync, fresh)
+    expect(result.phase).toBe('done')
+    expect(result).toMatchObject({
+      counts: { total: 28, autoMatched: 22, needReview: 6 },
+      runId: 'r1',
+    })
+  })
+
+  it('returns error on failed sync with no orphan grace recovery', () => {
+    const sync: SyncJobStatus = {
+      name: 'bunk_requests',
+      status: 'failed',
+      startedAt: ago(60),
+      finishedAt: ago(40),
+      error: 'context deadline exceeded',
+    }
+    expect(derivePhase(sync, null).phase).toBe('error')
+  })
+
+  it('recovers as done when orphan python finishes within 30-min grace window', () => {
+    const sync: SyncJobStatus = {
+      name: 'bunk_requests',
+      status: 'failed',
+      startedAt: ago(60),
+      finishedAt: ago(40),
+      error: 'context deadline exceeded',
+    }
+    const orphan: DebugPipelineRun = {
+      run_id: 'r2',
+      created: ago(20),
+      status_breakdown: { status_resolved: 5, status_pending: 1, status_declined: 0 },
+    }
+    expect(derivePhase(sync, orphan).phase).toBe('done')
+  })
+
+  it('keeps error when debug row is outside the 30-min grace window', () => {
+    const sync: SyncJobStatus = {
+      name: 'bunk_requests',
+      status: 'failed',
+      startedAt: ago(120),
+      finishedAt: ago(100),
+      error: 'context deadline exceeded',
+    }
+    const tooLate: DebugPipelineRun = {
+      run_id: 'r3',
+      created: ago(50),
+      status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
+    }
+    expect(derivePhase(sync, tooLate).phase).toBe('error')
+  })
+
+  it('handles all-zeros (csv-history dedup re-upload) as done', () => {
+    const sync: SyncJobStatus = {
+      name: 'bunk_requests',
+      status: 'completed',
+      startedAt: ago(2),
+      finishedAt: ago(1),
+    }
+    const dedup: DebugPipelineRun = {
+      run_id: 'r4',
+      created: ago(0.5),
+      status_breakdown: { status_resolved: 0, status_pending: 0, status_declined: 0 },
+    }
+    const result = derivePhase(sync, dedup)
+    expect(result.phase).toBe('done')
+    expect(result).toMatchObject({ counts: { total: 0, autoMatched: 0, needReview: 0 } })
+  })
+})

--- a/frontend/src/services/csvPipelineStatus.test.ts
+++ b/frontend/src/services/csvPipelineStatus.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest'
-import { derivePhase, type SyncJobStatus, type DebugPipelineRun } from './csvPipelineStatus'
+import { describe, it, expect, vi } from 'vitest'
+import {
+  derivePhase,
+  fetchSyncStatus,
+  fetchLatestDebugRun,
+  type SyncJobStatus,
+  type DebugPipelineRun,
+} from './csvPipelineStatus'
 
 const ago = (mins: number) => new Date(Date.now() - mins * 60_000).toISOString()
 
@@ -153,9 +159,6 @@ describe('derivePhase', () => {
   })
 })
 
-import { vi } from 'vitest'
-import { fetchSyncStatus, fetchLatestDebugRun } from './csvPipelineStatus'
-
 describe('fetchSyncStatus', () => {
   it('returns the bunk_requests entry mapped to camelCase', async () => {
     const mock = vi.fn().mockResolvedValue({
@@ -233,6 +236,36 @@ describe('fetchSyncStatus', () => {
   it('throws on non-ok response', async () => {
     const mock = vi.fn().mockResolvedValue({ ok: false, status: 500 } as Response)
     await expect(fetchSyncStatus(mock)).rejects.toThrow()
+  })
+
+  it('warns when bunk_requests status is unrecognized but still returns null gracefully', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const mock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        bunk_requests: {
+          type: 'bunk_requests',
+          status: 'cancelled',
+          start_time: '2026-04-27T19:00:00Z',
+        },
+      }),
+    } as Response)
+    expect(await fetchSyncStatus(mock)).toBeNull()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unknown sync status: cancelled'))
+    warnSpy.mockRestore()
+  })
+
+  it('returns null silently when status is queued and start_time is absent', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const mock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        bunk_requests: { type: 'bunk_requests', status: 'pending' },
+      }),
+    } as Response)
+    expect(await fetchSyncStatus(mock)).toBeNull()
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
   })
 })
 

--- a/frontend/src/services/csvPipelineStatus.test.ts
+++ b/frontend/src/services/csvPipelineStatus.test.ts
@@ -91,6 +91,25 @@ describe('derivePhase', () => {
     expect(derivePhase(sync, orphan).phase).toBe('done')
   })
 
+  it('keeps error when debug row predates finishedAt (negative grace delta is rejected)', () => {
+    // Sync started 60 min ago, debug created at 50 min ago, sync finished 40 min ago.
+    // debugIsFresh is true (debug.created >= startedAt) but debug.created < finishedAt,
+    // so delta is negative — must NOT be treated as orphan recovery.
+    const sync: SyncJobStatus = {
+      name: 'bunk_requests',
+      status: 'failed',
+      startedAt: ago(60),
+      finishedAt: ago(40),
+      error: 'context deadline exceeded',
+    }
+    const stale: DebugPipelineRun = {
+      run_id: 'r-stale',
+      created: ago(50),
+      status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
+    }
+    expect(derivePhase(sync, stale).phase).toBe('error')
+  })
+
   it('keeps error when debug row is outside the 30-min grace window', () => {
     const sync: SyncJobStatus = {
       name: 'bunk_requests',

--- a/frontend/src/services/csvPipelineStatus.test.ts
+++ b/frontend/src/services/csvPipelineStatus.test.ts
@@ -152,3 +152,126 @@ describe('derivePhase', () => {
     expect(result).toMatchObject({ counts: { total: 0, autoMatched: 0, needReview: 0 } })
   })
 })
+
+import { vi } from 'vitest'
+import { fetchSyncStatus, fetchLatestDebugRun } from './csvPipelineStatus'
+
+describe('fetchSyncStatus', () => {
+  it('returns the bunk_requests entry mapped to camelCase', async () => {
+    const mock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        bunk_requests: {
+          type: 'bunk_requests',
+          status: 'completed',
+          start_time: '2026-04-27T19:00:00Z',
+          end_time: '2026-04-27T19:02:00Z',
+        },
+        process_requests: { status: 'idle' },
+        _daily_sync_running: false,
+      }),
+    } as Response)
+    const res = await fetchSyncStatus(mock)
+    expect(res).toEqual({
+      name: 'bunk_requests',
+      status: 'completed',
+      startedAt: '2026-04-27T19:00:00Z',
+      finishedAt: '2026-04-27T19:02:00Z',
+    })
+  })
+
+  it('treats "success" status as equivalent to "completed"', async () => {
+    const mock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        bunk_requests: {
+          type: 'bunk_requests',
+          status: 'success',
+          start_time: '2026-04-27T19:00:00Z',
+          end_time: '2026-04-27T19:02:00Z',
+        },
+      }),
+    } as Response)
+    const res = await fetchSyncStatus(mock)
+    expect(res?.status).toBe('completed')
+  })
+
+  it('preserves error message on failed status', async () => {
+    const mock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        bunk_requests: {
+          type: 'bunk_requests',
+          status: 'failed',
+          start_time: '2026-04-27T19:00:00Z',
+          end_time: '2026-04-27T19:02:00Z',
+          error: 'context deadline exceeded',
+        },
+      }),
+    } as Response)
+    const res = await fetchSyncStatus(mock)
+    expect(res?.status).toBe('failed')
+    expect(res?.error).toBe('context deadline exceeded')
+  })
+
+  it('returns null when bunk_requests entry is idle', async () => {
+    const mock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ bunk_requests: { status: 'idle' } }),
+    } as Response)
+    expect(await fetchSyncStatus(mock)).toBeNull()
+  })
+
+  it('returns null when bunk_requests entry is missing entirely', async () => {
+    const mock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ _daily_sync_running: false }),
+    } as Response)
+    expect(await fetchSyncStatus(mock)).toBeNull()
+  })
+
+  it('throws on non-ok response', async () => {
+    const mock = vi.fn().mockResolvedValue({ ok: false, status: 500 } as Response)
+    await expect(fetchSyncStatus(mock)).rejects.toThrow()
+  })
+})
+
+describe('fetchLatestDebugRun', () => {
+  it('extracts run_id, created, status_breakdown from items[0]', async () => {
+    const mock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            id: 'pb-id',
+            run_id: 'run-abc',
+            created: '2026-04-27T19:05:00Z',
+            status_breakdown: { status_resolved: 5, status_pending: 1, status_declined: 0 },
+            year: 2026,
+            trace_count: 6,
+          },
+        ],
+        totalItems: 1,
+      }),
+    } as Response)
+    const res = await fetchLatestDebugRun(mock)
+    expect(res).toEqual({
+      run_id: 'run-abc',
+      created: '2026-04-27T19:05:00Z',
+      status_breakdown: { status_resolved: 5, status_pending: 1, status_declined: 0 },
+    })
+  })
+
+  it('returns null when items array is empty', async () => {
+    const mock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [] }),
+    } as Response)
+    expect(await fetchLatestDebugRun(mock)).toBeNull()
+  })
+
+  it('throws on non-ok response', async () => {
+    const mock = vi.fn().mockResolvedValue({ ok: false, status: 500 } as Response)
+    await expect(fetchLatestDebugRun(mock)).rejects.toThrow()
+  })
+})

--- a/frontend/src/services/csvPipelineStatus.test.ts
+++ b/frontend/src/services/csvPipelineStatus.test.ts
@@ -101,6 +101,40 @@ describe('derivePhase', () => {
     expect(derivePhase(sync, tooLate).phase).toBe('error')
   })
 
+  it('treats exactly 30-min delta as done (inclusive boundary)', () => {
+    // finishedAt 60 min ago, debug created 30 min ago → delta = 30 min
+    const sync: SyncJobStatus = {
+      name: 'bunk_requests',
+      status: 'failed',
+      startedAt: ago(90),
+      finishedAt: ago(60),
+      error: 'context deadline exceeded',
+    }
+    const debug: DebugPipelineRun = {
+      run_id: 'r-boundary',
+      created: ago(30),
+      status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
+    }
+    expect(derivePhase(sync, debug).phase).toBe('done')
+  })
+
+  it('treats just past 30-min delta as error (exclusive past boundary)', () => {
+    // finishedAt 60 min ago, debug created 29.99 min ago → delta = 30.01 min
+    const sync: SyncJobStatus = {
+      name: 'bunk_requests',
+      status: 'failed',
+      startedAt: ago(90),
+      finishedAt: ago(60),
+      error: 'context deadline exceeded',
+    }
+    const debug: DebugPipelineRun = {
+      run_id: 'r-just-past',
+      created: new Date(Date.now() - 29.99 * 60_000).toISOString(),
+      status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
+    }
+    expect(derivePhase(sync, debug).phase).toBe('error')
+  })
+
   it('handles all-zeros (csv-history dedup re-upload) as done', () => {
     const sync: SyncJobStatus = {
       name: 'bunk_requests',

--- a/frontend/src/services/csvPipelineStatus.ts
+++ b/frontend/src/services/csvPipelineStatus.ts
@@ -50,7 +50,8 @@ export function derivePhase(
     if (debugIsFresh && debug && sync.finishedAt) {
       const finishedAt = new Date(sync.finishedAt).getTime()
       const debugAt = new Date(debug.created).getTime()
-      if (debugAt - finishedAt <= GRACE_WINDOW_MS) return doneFromDebug(debug)
+      const delta = debugAt - finishedAt
+      if (delta >= 0 && delta <= GRACE_WINDOW_MS) return doneFromDebug(debug)
     }
     return {
       phase: 'error',

--- a/frontend/src/services/csvPipelineStatus.ts
+++ b/frontend/src/services/csvPipelineStatus.ts
@@ -13,7 +13,6 @@ export type DebugPipelineRun = {
     status_resolved: number
     status_pending: number
     status_declined: number
-    [k: string]: number
   }
 }
 

--- a/frontend/src/services/csvPipelineStatus.ts
+++ b/frontend/src/services/csvPipelineStatus.ts
@@ -143,10 +143,6 @@ export async function fetchLatestDebugRun(
   return {
     run_id: first.run_id,
     created: first.created,
-    status_breakdown: {
-      status_resolved: first.status_breakdown.status_resolved,
-      status_pending: first.status_breakdown.status_pending,
-      status_declined: first.status_breakdown.status_declined,
-    },
+    status_breakdown: first.status_breakdown,
   }
 }

--- a/frontend/src/services/csvPipelineStatus.ts
+++ b/frontend/src/services/csvPipelineStatus.ts
@@ -91,6 +91,8 @@ function normalizeStatus(raw: string | undefined): SyncJobStatus['status'] | nul
   if (raw === 'completed' || raw === 'success') return 'completed'
   if (raw === 'failed') return 'failed'
   if (raw === 'pending') return 'queued'
+  if (raw === 'idle' || raw === undefined) return null
+  console.warn(`[csvPipelineStatus] unknown sync status: ${raw}`)
   return null
 }
 
@@ -103,7 +105,12 @@ export async function fetchSyncStatus(fetchWithAuth: FetchWithAuth): Promise<Syn
   const sync = entry as RawSyncEntry
   const normalized = normalizeStatus(sync.status)
   if (normalized === null) return null
-  if (!sync.start_time) return null
+  if (!sync.start_time) {
+    if (normalized !== 'queued') {
+      console.warn(`[csvPipelineStatus] sync entry has status "${normalized}" but no start_time`)
+    }
+    return null
+  }
   const result: SyncJobStatus = {
     name: 'bunk_requests',
     status: normalized,

--- a/frontend/src/services/csvPipelineStatus.ts
+++ b/frontend/src/services/csvPipelineStatus.ts
@@ -74,7 +74,7 @@ function doneFromDebug(d: DebugPipelineRun): PipelinePhase {
   }
 }
 
-export type FetchWithAuth = (input: RequestInfo, init?: RequestInit) => Promise<Response>
+export type FetchWithAuth = (url: string, options?: RequestInit) => Promise<Response>
 
 type RawSyncEntry = {
   type?: string

--- a/frontend/src/services/csvPipelineStatus.ts
+++ b/frontend/src/services/csvPipelineStatus.ts
@@ -1,0 +1,76 @@
+export type SyncJobStatus = {
+  name: string
+  status: 'running' | 'completed' | 'failed' | 'queued'
+  startedAt: string
+  finishedAt?: string
+  error?: string
+}
+
+export type DebugPipelineRun = {
+  run_id: string
+  created: string
+  status_breakdown: {
+    status_resolved: number
+    status_pending: number
+    status_declined: number
+    [k: string]: number
+  }
+}
+
+export type PipelinePhase =
+  | { phase: 'idle' }
+  | { phase: 'importing'; startedAt: string }
+  | { phase: 'matching'; startedAt: string }
+  | {
+      phase: 'done'
+      runId: string
+      finishedAt: string
+      counts: { total: number; autoMatched: number; needReview: number }
+    }
+  | { phase: 'error'; finishedAt: string; message: string }
+
+const GRACE_WINDOW_MS = 30 * 60_000
+
+export function derivePhase(
+  sync: SyncJobStatus | null,
+  debug: DebugPipelineRun | null
+): PipelinePhase {
+  if (!sync) return { phase: 'idle' }
+
+  const debugIsFresh =
+    debug !== null && new Date(debug.created).getTime() >= new Date(sync.startedAt).getTime()
+
+  if (sync.status === 'running') return { phase: 'importing', startedAt: sync.startedAt }
+
+  if (sync.status === 'completed') {
+    if (debugIsFresh && debug) return doneFromDebug(debug)
+    return { phase: 'matching', startedAt: sync.startedAt }
+  }
+
+  if (sync.status === 'failed') {
+    if (debugIsFresh && debug && sync.finishedAt) {
+      const finishedAt = new Date(sync.finishedAt).getTime()
+      const debugAt = new Date(debug.created).getTime()
+      if (debugAt - finishedAt <= GRACE_WINDOW_MS) return doneFromDebug(debug)
+    }
+    return {
+      phase: 'error',
+      finishedAt: sync.finishedAt ?? sync.startedAt,
+      message: sync.error ?? 'Unknown error',
+    }
+  }
+
+  return { phase: 'idle' }
+}
+
+function doneFromDebug(d: DebugPipelineRun): PipelinePhase {
+  const { status_resolved, status_pending, status_declined } = d.status_breakdown
+  const autoMatched = status_resolved + status_declined
+  const needReview = status_pending
+  return {
+    phase: 'done',
+    runId: d.run_id,
+    finishedAt: d.created,
+    counts: { total: autoMatched + needReview, autoMatched, needReview },
+  }
+}

--- a/frontend/src/services/csvPipelineStatus.ts
+++ b/frontend/src/services/csvPipelineStatus.ts
@@ -73,3 +73,72 @@ function doneFromDebug(d: DebugPipelineRun): PipelinePhase {
     counts: { total: autoMatched + needReview, autoMatched, needReview },
   }
 }
+
+export type FetchWithAuth = (input: RequestInfo, init?: RequestInit) => Promise<Response>
+
+type RawSyncEntry = {
+  type?: string
+  status?: string
+  start_time?: string
+  end_time?: string
+  error?: string
+}
+
+type RawSyncStatusResponse = Record<string, RawSyncEntry | boolean | string | number>
+
+function normalizeStatus(raw: string | undefined): SyncJobStatus['status'] | null {
+  if (raw === 'running') return 'running'
+  if (raw === 'completed' || raw === 'success') return 'completed'
+  if (raw === 'failed') return 'failed'
+  if (raw === 'pending') return 'queued'
+  return null
+}
+
+export async function fetchSyncStatus(fetchWithAuth: FetchWithAuth): Promise<SyncJobStatus | null> {
+  const res = await fetchWithAuth('/api/custom/sync/status')
+  if (!res.ok) throw new Error(`sync status: ${res.status}`)
+  const data = (await res.json()) as RawSyncStatusResponse
+  const entry = data['bunk_requests']
+  if (!entry || typeof entry !== 'object' || !('status' in entry)) return null
+  const sync = entry as RawSyncEntry
+  const normalized = normalizeStatus(sync.status)
+  if (normalized === null) return null
+  if (!sync.start_time) return null
+  const result: SyncJobStatus = {
+    name: 'bunk_requests',
+    status: normalized,
+    startedAt: sync.start_time,
+  }
+  if (sync.end_time) result.finishedAt = sync.end_time
+  if (sync.error) result.error = sync.error
+  return result
+}
+
+type RawDebugListResponse = {
+  items: Array<{
+    run_id: string
+    created: string
+    status_breakdown: { status_resolved: number; status_pending: number; status_declined: number }
+  }>
+}
+
+export async function fetchLatestDebugRun(
+  fetchWithAuth: FetchWithAuth
+): Promise<DebugPipelineRun | null> {
+  const res = await fetchWithAuth(
+    '/api/collections/debug_pipeline_runs/records?sort=-created&perPage=1&fields=run_id,created,status_breakdown'
+  )
+  if (!res.ok) throw new Error(`debug runs: ${res.status}`)
+  const data = (await res.json()) as RawDebugListResponse
+  const first = data.items[0]
+  if (!first) return null
+  return {
+    run_id: first.run_id,
+    created: first.created,
+    status_breakdown: {
+      status_resolved: first.status_breakdown.status_resolved,
+      status_pending: first.status_breakdown.status_pending,
+      status_declined: first.status_breakdown.status_declined,
+    },
+  }
+}

--- a/frontend/src/utils/formatTimestamp.test.ts
+++ b/frontend/src/utils/formatTimestamp.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { formatTimestamp } from './formatTimestamp'
+
+const NOW = new Date('2026-04-27T19:00:00Z')
+
+describe('formatTimestamp', () => {
+  it('returns "just now" when delta is under 1 minute', () => {
+    const t = new Date(NOW.getTime() - 30_000).toISOString()
+    expect(formatTimestamp(t, NOW)).toBe('just now')
+  })
+
+  it('returns "{n} minutes ago" for sub-hour deltas', () => {
+    const t = new Date(NOW.getTime() - 12 * 60_000).toISOString()
+    expect(formatTimestamp(t, NOW)).toBe('12 minutes ago')
+  })
+
+  it('uses singular "1 minute ago" at exactly 1 minute', () => {
+    const t = new Date(NOW.getTime() - 60_000).toISOString()
+    expect(formatTimestamp(t, NOW)).toBe('1 minute ago')
+  })
+
+  it('returns "{n} hours ago" for sub-day deltas', () => {
+    const t = new Date(NOW.getTime() - 5 * 60 * 60_000).toISOString()
+    expect(formatTimestamp(t, NOW)).toBe('5 hours ago')
+  })
+
+  it('uses singular "1 hour ago" at exactly 1 hour', () => {
+    const t = new Date(NOW.getTime() - 60 * 60_000).toISOString()
+    expect(formatTimestamp(t, NOW)).toBe('1 hour ago')
+  })
+
+  it('returns absolute "Apr 25 at 2:32 PM" form for >=24h deltas', () => {
+    const t = new Date('2026-04-25T14:32:00').toISOString()
+    const result = formatTimestamp(t, NOW)
+    expect(result).toMatch(/Apr 25 at 2:32 PM/)
+  })
+})

--- a/frontend/src/utils/formatTimestamp.test.ts
+++ b/frontend/src/utils/formatTimestamp.test.ts
@@ -29,6 +29,13 @@ describe('formatTimestamp', () => {
     expect(formatTimestamp(t, NOW)).toBe('1 hour ago')
   })
 
+  it('stays in relative "X hours ago" form just under 24h, even when minutes round up', () => {
+    // 23h31m: Math.round(1411/60) = 24 would have flipped to absolute date.
+    // hoursFloor must keep this in the relative branch.
+    const t = new Date(NOW.getTime() - (23 * 60 + 31) * 60_000).toISOString()
+    expect(formatTimestamp(t, NOW)).toMatch(/hours ago$/)
+  })
+
   it('returns absolute "Apr 25 at 2:32 PM" form for >=24h deltas', () => {
     const t = new Date('2026-04-25T14:32:00').toISOString()
     const result = formatTimestamp(t, NOW)

--- a/frontend/src/utils/formatTimestamp.ts
+++ b/frontend/src/utils/formatTimestamp.ts
@@ -1,0 +1,17 @@
+export function formatTimestamp(iso: string, now: Date = new Date()): string {
+  const then = new Date(iso)
+  const deltaMs = now.getTime() - then.getTime()
+  const minutesFloor = Math.floor(deltaMs / 60_000)
+  if (minutesFloor < 1) return 'just now'
+  const minutes = Math.round(deltaMs / 60_000)
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`
+  const hours = Math.round(minutes / 60)
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`
+  const formatted = then.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+  return formatted.replace(', ', ' at ')
+}

--- a/frontend/src/utils/formatTimestamp.ts
+++ b/frontend/src/utils/formatTimestamp.ts
@@ -5,8 +5,11 @@ export function formatTimestamp(iso: string, now: Date = new Date()): string {
   if (minutesFloor < 1) return 'just now'
   const minutes = Math.round(deltaMs / 60_000)
   if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`
-  const hours = Math.round(minutes / 60)
-  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`
+  const hoursFloor = Math.floor(deltaMs / (60 * 60_000))
+  if (hoursFloor < 24) {
+    const hours = Math.max(1, Math.round(minutes / 60))
+    return `${hours} hour${hours === 1 ? '' : 's'} ago`
+  }
   const formatted = then.toLocaleString('en-US', {
     month: 'short',
     day: 'numeric',

--- a/frontend/src/utils/formatTimestamp.ts
+++ b/frontend/src/utils/formatTimestamp.ts
@@ -1,8 +1,7 @@
 export function formatTimestamp(iso: string, now: Date = new Date()): string {
   const then = new Date(iso)
   const deltaMs = now.getTime() - then.getTime()
-  const minutesFloor = Math.floor(deltaMs / 60_000)
-  if (minutesFloor < 1) return 'just now'
+  if (deltaMs < 60_000) return 'just now'
   const minutes = Math.round(deltaMs / 60_000)
   if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`
   const hoursFloor = Math.floor(deltaMs / (60 * 60_000))

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -63,6 +63,7 @@ export const queryKeys = {
   // Sync Status (Tier 2 - frequently updated)
   syncStatus: () => ['sync-status'] as const,
   syncStatusForService: (service: string) => ['sync-status', service] as const,
+  csvPipelineStatus: () => ['csv-pipeline-status'] as const,
 
   // Users (Tier 2 - user data)
   users: () => ['users'] as const,


### PR DESCRIPTION
## Summary
- Adds a live progress indicator + completion summary for CSV bunk-request uploads, replacing today's black-box UX. Item #52 from the wife-feedback scoreboard.
- Frontend-composed status: polls `/api/custom/sync/status` (Go orchestrator) + `debug_pipeline_runs` PocketBase collection at 2s while active, idle otherwise. No new backend endpoints, no new schema.
- Indicator mounts next to the existing Upload Requests button in `AppLayout`. Inherits `BUNKING_MANAGE` RBAC from that block.
- Spec locked in `docs/plans/wife-feedback-52-csv-progress.md` (local).

## Architecture
- `derivePhase` pure function — 5-state machine (idle / importing / matching / done / error) with a 30-min orphan-recovery grace window for the known Go-timeout / Python-orphan landmine.
- `fetchSyncStatus` + `fetchLatestDebugRun` — wire-shape adapters; gracefully degrade on PocketBase 500 (sync-only failure still surfaces).
- `useCsvPipelineStatus` — React Query hook with conditional 2s polling.
- `CsvPipelineIndicator` — visual states + popover + dismiss button + completion-toast deduplication via `localStorage[csvProgressLastSeenRunId]` and `csvProgressDismissedRunId`.
- `formatTimestamp` — relative <24h ("12 minutes ago" / "3 hours ago"), absolute ≥24h ("Apr 25 at 2:32 PM").

## Locked copy
| Surface | Copy |
|---|---|
| Upload toast | "Importing CSV — this may take a few minutes. The icon next to the Upload Requests button will update when it's done." |
| Phase 1 label | "Loading new or updated requests from CSV" |
| Phase 2 label | "Resolving camper names and calculating requests" |
| Done | "Done {timestamp}: X new or updated requests, Y auto-matched[, Z need review]" (review clause omitted when 0) |
| Completion toast | "Import complete: X new or updated requests, Y auto-matched[, Z need review]." (review clause omitted when 0) |
| Error | "Import failed. Click for details." |

`Y auto-matched = status_resolved + status_declined` (declined is high-confidence cross-session reject — no staff action needed).

## Test coverage
- 22 service tests (state machine + fetchers, including 30-min boundary at the inclusive/exclusive edges)
- 10 hook tests (idle, importing, done with mapped counts, sync-only failure surfacing, debug-fetch resilience, parametrized polling-predicate)
- 14 indicator tests (every phase variant, toast deduplication, dismiss persistence, popover toggle, zero-review-omission)
- 6 timestamp tests
- Full suite: 3054 tests passing locally.

## Manual validation (dev/preview)
- [ ] Upload a fresh CSV. Toast appears: "Importing CSV — this may take a few minutes…"
- [ ] Spinner appears next to Upload Requests button with label "Loading new or updated requests from CSV"
- [ ] Within ~30s, label transitions to "Resolving camper names and calculating requests"
- [ ] When phase 2 completes, indicator becomes green check + "Done {time}: X new or updated requests, Y auto-matched, Z need review"
- [ ] Completion toast fires once when state flips to done (does NOT re-fire on tab refresh / route change)
- [ ] Click the green check — popover shows phase-appropriate detail
- [ ] Navigate to `/scenarios` and back — terminal state persists across the route change
- [ ] Wait long enough (or test with mock data) that an old "Done" timestamp formats as absolute "Done Apr 25 at 2:32 PM"
- [ ] Upload a second CSV — indicator switches back to spinner; old terminal state replaced; completion toast fires for the new run only
- [ ] Re-upload the SAME CSV (csv_history dedup case) — indicator runs phases, ends with all-zero counts; copy reads "Done … 0 new or updated requests, 0 auto-matched" (the "need review" clause is omitted because it's zero)
- [ ] Click the "×" dismiss button on a Done indicator — terminal state hides; stays hidden until a new upload starts
- [ ] Log in as a non-bunking-staff user — indicator does not render (the entire `BUNKING_MANAGE`-gated block, including this indicator, is hidden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CSV import status indicator with importing, matching, and completed states and a details popover.
  * Completion summary shows total, auto-matched, and need-review counts; can be dismissed to hide that run.
  * Improved relative timestamp formatting for status display.

* **Bug Fixes / UX**
  * Consistent “Importing CSV — this may take a few minutes” success notification with extended display time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->