### PR TITLE
fix(frontend): portal friend-group popover so it isn't clipped by bunk card

### DIFF
--- a/frontend/src/pages/ScenarioComparisonPage.test.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.test.tsx
@@ -117,4 +117,14 @@ describe('FriendGroupPopover (CamperPill hover)', () => {
     expect(memberRows.length).toBe(1)
     expect(memberRows[0]?.textContent).toBe('Liam Garcia')
   })
+
+  it('renders the popover via a portal (attached to document.body) so it escapes overflow-hidden bunk cards', () => {
+    render(
+      <CamperPill camper={liam} status="unchanged" group={palsGroup} camperById={camperById} />
+    )
+    fireEvent.mouseEnter(getPillRoot())
+    const popover = screen.getByTestId('friend-group-popover')
+    expect(popover.parentElement).toBe(document.body)
+    expect(popover.closest('[data-testid="camper-pill"]')).toBeNull()
+  })
 })

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -1,4 +1,5 @@
-import { useState, useMemo, useCallback } from 'react'
+import { useState, useMemo, useCallback, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import { useParams, Link } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import {
@@ -1378,13 +1379,16 @@ function BunkComparisonCard({
   )
 }
 
-// FriendGroupPopover — same-side member list shown on CamperPill hover
+// FriendGroupPopover — same-side member list shown on CamperPill hover.
+// Rendered via createPortal to document.body so it isn't clipped by the bunk
+// card's overflow-hidden wrapper when the pill is near the bottom of the list.
 export interface FriendGroupPopoverProps {
   group: LockGroupSummary
   camperById: Map<number, CamperAssignment>
+  anchorRect: { top: number; left: number; bottom: number } | null
 }
 
-export function FriendGroupPopover({ group, camperById }: FriendGroupPopoverProps) {
+export function FriendGroupPopover({ group, camperById, anchorRect }: FriendGroupPopoverProps) {
   const rows = group.memberCmIds
     .map((cmId) => ({ cmId, camper: camperById.get(cmId) }))
     .sort((a, b) => {
@@ -1393,12 +1397,17 @@ export function FriendGroupPopover({ group, camperById }: FriendGroupPopoverProp
       return an.localeCompare(bn)
     })
 
-  return (
+  const style: React.CSSProperties = anchorRect
+    ? { top: `${anchorRect.bottom + 4}px`, left: `${anchorRect.left}px` }
+    : {}
+
+  return createPortal(
     <div
       data-testid="friend-group-popover"
       role="tooltip"
       aria-label={`Friend group: ${group.name}`}
-      className="border-border/60 bg-popover absolute top-full left-0 z-50 mt-1 min-w-[200px] rounded-lg border p-3 shadow-lg"
+      className="border-border/60 bg-popover pointer-events-none fixed z-[100] min-w-[200px] rounded-lg border p-3 shadow-lg"
+      style={style}
     >
       <div className="border-border/40 mb-2 flex items-center gap-2 border-b pb-2">
         <span
@@ -1419,7 +1428,8 @@ export function FriendGroupPopover({ group, camperById }: FriendGroupPopoverProp
           </li>
         ))}
       </ul>
-    </div>
+    </div>,
+    document.body
   )
 }
 
@@ -1441,11 +1451,26 @@ export function CamperPill({
   group,
   camperById,
 }: CamperPillProps) {
-  const [hovered, setHovered] = useState(false)
-  const showPopover = hovered && group !== undefined
+  const pillRef = useRef<HTMLDivElement | null>(null)
+  const [anchorRect, setAnchorRect] = useState<{
+    top: number
+    left: number
+    bottom: number
+  } | null>(null)
+  const showPopover = anchorRect !== null && group !== undefined
+
+  const handleMouseEnter = () => {
+    const rect = pillRef.current?.getBoundingClientRect()
+    if (rect) {
+      setAnchorRect({ top: rect.top, left: rect.left, bottom: rect.bottom })
+    } else {
+      setAnchorRect({ top: 0, left: 0, bottom: 0 })
+    }
+  }
 
   return (
     <div
+      ref={pillRef}
       data-testid="camper-pill"
       className={clsx(
         'relative flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition-all',
@@ -1455,8 +1480,8 @@ export function CamperPill({
         status === 'moved-out' &&
           'bg-red-50 opacity-75 ring-1 ring-red-200 dark:bg-red-900/20 dark:ring-red-800'
       )}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={() => setAnchorRect(null)}
     >
       {group?.color && (
         <span
@@ -1483,7 +1508,9 @@ export function CamperPill({
           <span className="opacity-80">{destination}</span>
         </span>
       )}
-      {showPopover && <FriendGroupPopover group={group} camperById={camperById} />}
+      {showPopover && (
+        <FriendGroupPopover group={group} camperById={camperById} anchorRect={anchorRect} />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- The friend-group hover popover in scenario compare was an `absolute`-positioned descendant of the bunk card, which has `overflow-hidden`. When the hovered camper was near the bottom of the bunk's list, the popover got cut off by the card's bottom edge (and rendered under sibling bunk cards).
- Render `FriendGroupPopover` via `createPortal` to `document.body` with `position: fixed` and `z-[100]`, anchored to the pill's `getBoundingClientRect()`, so it escapes the overflow-hidden ancestor and is no longer clipped.
- `CamperPill` now captures the rect on `mouseEnter` and passes it to the popover as `anchorRect`.

## Test plan
- [x] Vitest: 6/6 popover tests pass, including a new portal test asserting `popover.parentElement === document.body`
- [ ] Manual: hover a friend-group member near the bottom of a bunk in scenario compare — popover renders fully above the card edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)