### PR TITLE
feat(frontend): cohort drill-down — keep panel unblurred, show bunks, sort by grade

### DIFF
--- a/frontend/src/components/CamperCohortsSection.tsx
+++ b/frontend/src/components/CamperCohortsSection.tsx
@@ -8,9 +8,10 @@
  * Each row is a button that opens CohortDrillDownModal listing the matched
  * campers (already gender-scoped + same-session by useCamperCohorts).
  */
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Users } from 'lucide-react'
 import { useCamperCohorts } from '../hooks/useCamperCohorts'
+import { useCohortBunkAssignments } from '../hooks/useCohortBunkAssignments'
 import { useCohortRequestRelations } from '../hooks/useCohortRequestRelations'
 import { CohortDrillDownModal, type CohortKind } from './CohortDrillDownModal'
 
@@ -33,6 +34,19 @@ export function CamperCohortsSection({
   const { cohorts, isLoading } = useCamperCohorts(personCmId, sessionCmId, year)
   const { relations } = useCohortRequestRelations(personCmId, sessionCmId, year)
   const [openKind, setOpenKind] = useState<CohortKind | null>(null)
+
+  // Union of every cohort's matched person ids — feeds the bunk lookup so
+  // switching between school/congregation/city tabs reuses the same query.
+  const allCohortPersonIds = useMemo(() => {
+    if (!cohorts) return [] as number[]
+    const ids = new Set<number>()
+    for (const kind of KINDS) {
+      for (const a of cohorts[kind]?.attendees ?? []) ids.add(a.personCmId)
+    }
+    return [...ids]
+  }, [cohorts])
+
+  const { bunkByPerson } = useCohortBunkAssignments(allCohortPersonIds, sessionCmId, year)
 
   if (isLoading || !cohorts) return null
 
@@ -77,6 +91,7 @@ export function CamperCohortsSection({
           allGenders={cohorts.allGenders}
           attendees={openEntry.attendees}
           requestRelations={relations}
+          bunkByPerson={bunkByPerson}
           onClose={() => setOpenKind(null)}
         />
       )}

--- a/frontend/src/components/CohortDrillDownModal.test.tsx
+++ b/frontend/src/components/CohortDrillDownModal.test.tsx
@@ -272,4 +272,76 @@ describe('CohortDrillDownModal', () => {
     )
     expect(container.firstChild).toBeNull()
   })
+
+  describe('current bunk display', () => {
+    it('renders the bunk inline with grade when assignment is provided', () => {
+      const bunkByPerson = new Map<number, string | null>([[1000002, 'Bunk 4']])
+      render(
+        <CohortDrillDownModal
+          selfDisplayName="Emma"
+          open
+          kind="school"
+          label="Riverside Elementary"
+          attendees={[makeMatch({ personCmId: 1000002, grade: 5 })]}
+          bunkByPerson={bunkByPerson}
+          onClose={() => {}}
+        />
+      )
+      // "5th grade · Bunk 4" rendered as a single inline line.
+      const row = screen.getByTestId('cohort-modal-row')
+      expect(row.textContent).toContain('5th grade')
+      expect(row.textContent).toContain('Bunk 4')
+    })
+
+    it('renders "Unassigned" when the lookup returns null', () => {
+      const bunkByPerson = new Map<number, string | null>([[1000002, null]])
+      render(
+        <CohortDrillDownModal
+          selfDisplayName="Emma"
+          open
+          kind="school"
+          label="Riverside Elementary"
+          attendees={[makeMatch({ personCmId: 1000002, grade: 5 })]}
+          bunkByPerson={bunkByPerson}
+          onClose={() => {}}
+        />
+      )
+      const row = screen.getByTestId('cohort-modal-row')
+      expect(row.textContent).toContain('Unassigned')
+    })
+
+    it('renders just the bunk (no separator) when grade is null', () => {
+      const bunkByPerson = new Map<number, string | null>([[1000002, 'Bunk 9']])
+      render(
+        <CohortDrillDownModal
+          selfDisplayName="Emma"
+          open
+          kind="school"
+          label="Riverside Elementary"
+          attendees={[makeMatch({ personCmId: 1000002, grade: null })]}
+          bunkByPerson={bunkByPerson}
+          onClose={() => {}}
+        />
+      )
+      const row = screen.getByTestId('cohort-modal-row')
+      expect(row.textContent).toContain('Bunk 9')
+      // No grade line and no orphan separator before "Bunk 9".
+      expect(row.textContent).not.toMatch(/·\s*Bunk 9/)
+    })
+
+    it('omits the bunk line entirely when bunkByPerson prop is absent', () => {
+      render(
+        <CohortDrillDownModal
+          selfDisplayName="Emma"
+          open
+          kind="school"
+          label="Riverside Elementary"
+          attendees={[makeMatch({ personCmId: 1000002, grade: 5 })]}
+          onClose={() => {}}
+        />
+      )
+      // Without the prop the modal must not invent an "Unassigned" line.
+      expect(screen.queryByText(/Unassigned/)).not.toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/src/components/CohortDrillDownModal.tsx
+++ b/frontend/src/components/CohortDrillDownModal.tsx
@@ -33,6 +33,13 @@ interface CohortDrillDownModalProps {
   allGenders?: boolean
   /** Confirmed incoming bunk_with / not_bunk_with requests targeting the source camper. */
   requestRelations?: CohortRelationsMap
+  /**
+   * Map of personCmId → current bunk name (or null when unassigned). Sourced
+   * from the active scenario's drafts or production assignments by the
+   * parent. When omitted entirely, the modal hides the bunk line — that
+   * keeps tests and standalone usage from inventing an "Unassigned" label.
+   */
+  bunkByPerson?: Map<number, string | null>
   onClose: () => void
 }
 
@@ -113,6 +120,7 @@ export function CohortDrillDownModal({
   selfDisplayName,
   allGenders,
   requestRelations,
+  bunkByPerson,
   onClose,
 }: CohortDrillDownModalProps) {
   const count = attendees.length
@@ -143,6 +151,9 @@ export function CohortDrillDownModal({
       size="lg"
       noPadding
       scrollable
+      // Match CamperDetailsPanel width so the panel stays unblurred — staff
+      // want to keep referencing the source camper while the cohort opens.
+      backdropInsetRight="28rem"
     >
       {count === 0 ? (
         <p className="text-muted-foreground p-6 text-sm">No other campers in this session match.</p>
@@ -151,6 +162,17 @@ export function CohortDrillDownModal({
           {attendees.map((a) => {
             const relation = requestRelations?.get(a.personCmId)
             const relationBadge = getRelationBadge(relation?.type, selfDisplayName)
+            // The hook returns the key with `null` for unassigned campers,
+            // and is omitted entirely from the prop when callers don't
+            // want the bunk line. Distinguish the two:
+            //  - prop absent → no metadata line at all when grade is also null
+            //  - prop present, value null → render "Unassigned"
+            const hasBunkLookup = bunkByPerson?.has(a.personCmId) ?? false
+            const bunkName = hasBunkLookup ? (bunkByPerson?.get(a.personCmId) ?? null) : null
+            const gradeText = a.grade != null ? `${formatGradeOrdinal(a.grade)} grade` : null
+            const bunkText = hasBunkLookup ? (bunkName ?? 'Unassigned') : null
+            const metaText =
+              gradeText && bunkText ? `${gradeText} · ${bunkText}` : (gradeText ?? bunkText)
             return (
               <li
                 key={a.attendeeId}
@@ -166,11 +188,7 @@ export function CohortDrillDownModal({
                   >
                     {displayName(a)}
                   </Link>
-                  {a.grade != null && (
-                    <div className="text-muted-foreground text-xs">
-                      {formatGradeOrdinal(a.grade)} grade
-                    </div>
-                  )}
+                  {metaText && <div className="text-muted-foreground text-xs">{metaText}</div>}
                 </div>
                 <div className="flex items-center gap-2">
                   {relationBadge && (

--- a/frontend/src/components/ui/Modal.test.tsx
+++ b/frontend/src/components/ui/Modal.test.tsx
@@ -283,6 +283,43 @@ describe('Modal', () => {
     })
   })
 
+  describe('backdropInsetRight option', () => {
+    it('insets the backdrop from the right when set', () => {
+      render(
+        <Modal isOpen={true} onClose={() => {}} backdropInsetRight="28rem">
+          <p>Content</p>
+        </Modal>
+      )
+
+      const backdrop = screen.getByTestId('modal-backdrop')
+      expect(backdrop).toHaveStyle({ right: '28rem' })
+    })
+
+    it('does not inset by default', () => {
+      render(
+        <Modal isOpen={true} onClose={() => {}}>
+          <p>Content</p>
+        </Modal>
+      )
+
+      const backdrop = screen.getByTestId('modal-backdrop')
+      // No explicit right offset → backdrop spans the full viewport.
+      expect(backdrop.style.right).toBe('')
+    })
+
+    it('shifts the modal centering wrapper by the same offset', () => {
+      render(
+        <Modal isOpen={true} onClose={() => {}} backdropInsetRight="28rem">
+          <p>Content</p>
+        </Modal>
+      )
+
+      // The modal centers within the unblurred space, not the full viewport.
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveStyle({ right: '28rem' })
+    })
+  })
+
   describe('scrollable option', () => {
     it('applies overflow-y-auto when scrollable is true', () => {
       render(

--- a/frontend/src/components/ui/Modal.test.tsx
+++ b/frontend/src/components/ui/Modal.test.tsx
@@ -284,7 +284,24 @@ describe('Modal', () => {
   })
 
   describe('backdropInsetRight option', () => {
-    it('insets the backdrop from the right when set', () => {
+    it('shifts the dialog wrapper by the offset (single source of truth)', () => {
+      // The backdrop and the centered modal are both children of the dialog
+      // wrapper with `absolute inset-0`, so insetting the wrapper alone
+      // shrinks both — applying the offset to the backdrop too would
+      // double-inset it relative to the already-shrunk wrapper.
+      render(
+        <Modal isOpen={true} onClose={() => {}} backdropInsetRight="28rem">
+          <p>Content</p>
+        </Modal>
+      )
+
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveStyle({ right: '28rem' })
+    })
+
+    it('leaves the backdrop without its own right offset', () => {
+      // Regression guard for the double-inset bug: the backdrop must rely on
+      // its parent's positioning, not duplicate the inset.
       render(
         <Modal isOpen={true} onClose={() => {}} backdropInsetRight="28rem">
           <p>Content</p>
@@ -292,31 +309,18 @@ describe('Modal', () => {
       )
 
       const backdrop = screen.getByTestId('modal-backdrop')
-      expect(backdrop).toHaveStyle({ right: '28rem' })
+      expect(backdrop.style.right).toBe('')
     })
 
-    it('does not inset by default', () => {
+    it('does not inset the wrapper by default', () => {
       render(
         <Modal isOpen={true} onClose={() => {}}>
           <p>Content</p>
         </Modal>
       )
 
-      const backdrop = screen.getByTestId('modal-backdrop')
-      // No explicit right offset → backdrop spans the full viewport.
-      expect(backdrop.style.right).toBe('')
-    })
-
-    it('shifts the modal centering wrapper by the same offset', () => {
-      render(
-        <Modal isOpen={true} onClose={() => {}} backdropInsetRight="28rem">
-          <p>Content</p>
-        </Modal>
-      )
-
-      // The modal centers within the unblurred space, not the full viewport.
       const dialog = screen.getByRole('dialog')
-      expect(dialog).toHaveStyle({ right: '28rem' })
+      expect(dialog.style.right).toBe('')
     })
   })
 

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -98,14 +98,12 @@ export function Modal({
       aria-label={!resolvedLabelledBy ? ariaLabel : undefined}
       style={backdropInsetRight ? { right: backdropInsetRight } : undefined}
     >
-      {/* Backdrop */}
+      {/* Backdrop — fills the (already-inset) dialog wrapper via inset-0,
+          so the wrapper's right offset is the single source of truth. */}
       <div
         data-testid="modal-backdrop"
         className="absolute inset-0 backdrop-blur"
-        style={{
-          backgroundColor: 'rgba(17, 26, 22, 0.42)',
-          ...(backdropInsetRight ? { right: backdropInsetRight } : {}),
-        }}
+        style={{ backgroundColor: 'rgba(17, 26, 22, 0.42)' }}
         onClick={onClose}
         aria-hidden="true"
       />

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -17,6 +17,11 @@ interface ModalProps {
   // screen readers have a name for the dialog.
   ariaLabelledBy?: string
   ariaLabel?: string
+  // CSS length (e.g. "28rem") that insets BOTH the blurred backdrop and the
+  // modal-centering wrapper from the viewport's right edge. Used when the
+  // modal opens on top of a right-side slide-out panel — the panel area
+  // stays unblurred and the modal centers in the remaining space.
+  backdropInsetRight?: string
 }
 
 const sizeClasses = {
@@ -62,6 +67,7 @@ export function Modal({
   scrollable = false,
   ariaLabelledBy,
   ariaLabel,
+  backdropInsetRight,
 }: ModalProps) {
   useEffect(() => {
     if (!isOpen) return
@@ -90,12 +96,16 @@ export function Modal({
       aria-modal="true"
       aria-labelledby={resolvedLabelledBy}
       aria-label={!resolvedLabelledBy ? ariaLabel : undefined}
+      style={backdropInsetRight ? { right: backdropInsetRight } : undefined}
     >
       {/* Backdrop */}
       <div
         data-testid="modal-backdrop"
         className="absolute inset-0 backdrop-blur"
-        style={{ backgroundColor: 'rgba(17, 26, 22, 0.42)' }}
+        style={{
+          backgroundColor: 'rgba(17, 26, 22, 0.42)',
+          ...(backdropInsetRight ? { right: backdropInsetRight } : {}),
+        }}
         onClick={onClose}
         aria-hidden="true"
       />

--- a/frontend/src/hooks/useCamperCohorts.test.ts
+++ b/frontend/src/hooks/useCamperCohorts.test.ts
@@ -554,4 +554,161 @@ describe('useCamperCohorts', () => {
     // city: only a2 matches Springfield → count 1
     expect(result.current.cohorts?.city).toMatchObject({ label: 'Springfield', count: 1 })
   })
+
+  describe('attendee sort order', () => {
+    it('sorts matched attendees by grade ascending, then first name ascending', async () => {
+      // Self camper (1000001) is graded 5 at Riverside Elementary; matched
+      // cohort spans grades 4–7 with two graders sharing grade 5 to verify
+      // the first-name tiebreaker.
+      mockGetFullList.mockResolvedValue([
+        makeAttendee({
+          id: 'self',
+          person_id: 1000001,
+          status_id: 2,
+          firstName: 'Self',
+          grade: 5,
+          normalizedSchool: 'Riverside Elementary',
+          sessionType: 'ag',
+        }),
+        makeAttendee({
+          id: 'a1',
+          person_id: 2000001,
+          status_id: 2,
+          firstName: 'Olivia',
+          grade: 7,
+          normalizedSchool: 'Riverside Elementary',
+          sessionType: 'ag',
+        }),
+        makeAttendee({
+          id: 'a2',
+          person_id: 2000002,
+          status_id: 2,
+          firstName: 'Emma',
+          grade: 5,
+          normalizedSchool: 'Riverside Elementary',
+          sessionType: 'ag',
+        }),
+        makeAttendee({
+          id: 'a3',
+          person_id: 2000003,
+          status_id: 2,
+          firstName: 'Liam',
+          grade: 4,
+          normalizedSchool: 'Riverside Elementary',
+          sessionType: 'ag',
+        }),
+        makeAttendee({
+          id: 'a4',
+          person_id: 2000004,
+          status_id: 2,
+          firstName: 'Aiden',
+          grade: 5,
+          normalizedSchool: 'Riverside Elementary',
+          sessionType: 'ag',
+        }),
+      ])
+
+      const { result } = renderHook(() => useCamperCohorts(1000001, 201, 2025), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+      const ids = (result.current.cohorts?.school?.attendees ?? []).map((a) => a.personCmId)
+      // grade 4 (Liam) → grade 5 (Aiden, Emma — alphabetical) → grade 7 (Olivia)
+      expect(ids).toEqual([2000003, 2000004, 2000002, 2000001])
+    })
+
+    it('places ungraded campers at the bottom regardless of name', async () => {
+      mockGetFullList.mockResolvedValue([
+        makeAttendee({
+          id: 'self',
+          person_id: 1000001,
+          status_id: 2,
+          firstName: 'Self',
+          grade: 6,
+          normalizedSchool: 'Hillcrest High',
+          sessionType: 'ag',
+        }),
+        makeAttendee({
+          id: 'a1',
+          person_id: 2000001,
+          status_id: 2,
+          firstName: 'Aaron', // alphabetically first BUT ungraded
+          grade: null,
+          normalizedSchool: 'Hillcrest High',
+          sessionType: 'ag',
+        }),
+        makeAttendee({
+          id: 'a2',
+          person_id: 2000002,
+          status_id: 2,
+          firstName: 'Riley',
+          grade: 8,
+          normalizedSchool: 'Hillcrest High',
+          sessionType: 'ag',
+        }),
+      ])
+
+      const { result } = renderHook(() => useCamperCohorts(1000001, 201, 2025), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+      const ids = (result.current.cohorts?.school?.attendees ?? []).map((a) => a.personCmId)
+      // Riley (grade 8) before Aaron (ungraded) — ungraded sinks despite name.
+      expect(ids).toEqual([2000002, 2000001])
+    })
+
+    it('tiebreaks by first name when grades are equal (case-insensitive)', async () => {
+      mockGetFullList.mockResolvedValue([
+        makeAttendee({
+          id: 'self',
+          person_id: 1000001,
+          status_id: 2,
+          firstName: 'Self',
+          grade: 3,
+          normalizedSchool: 'Oak Valley Middle',
+          sessionType: 'ag',
+        }),
+        makeAttendee({
+          id: 'a1',
+          person_id: 2000001,
+          status_id: 2,
+          firstName: 'beatrice', // lowercase — should still sort before 'Charlie'
+          grade: 3,
+          normalizedSchool: 'Oak Valley Middle',
+          sessionType: 'ag',
+        }),
+        makeAttendee({
+          id: 'a2',
+          person_id: 2000002,
+          status_id: 2,
+          firstName: 'Charlie',
+          grade: 3,
+          normalizedSchool: 'Oak Valley Middle',
+          sessionType: 'ag',
+        }),
+        makeAttendee({
+          id: 'a3',
+          person_id: 2000003,
+          status_id: 2,
+          firstName: 'Anna',
+          grade: 3,
+          normalizedSchool: 'Oak Valley Middle',
+          sessionType: 'ag',
+        }),
+      ])
+
+      const { result } = renderHook(() => useCamperCohorts(1000001, 201, 2025), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+      const ids = (result.current.cohorts?.school?.attendees ?? []).map((a) => a.personCmId)
+      expect(ids).toEqual([2000003, 2000001, 2000002]) // Anna, beatrice, Charlie
+    })
+  })
 })

--- a/frontend/src/hooks/useCamperCohorts.ts
+++ b/frontend/src/hooks/useCamperCohorts.ts
@@ -143,6 +143,23 @@ export function useCamperCohorts(
             gender: p.gender ?? null,
           }
         })
+        // Sort youngest-first with first-name tiebreaker — same convention the
+        // requests-tab uses by default. Ungraded campers (null/0) sink to the
+        // bottom regardless of name so the graded group reads cleanly.
+        attendees.sort((a, b) => {
+          const aGrade = a.grade && a.grade > 0 ? a.grade : null
+          const bGrade = b.grade && b.grade > 0 ? b.grade : null
+          if (aGrade !== bGrade) {
+            if (aGrade === null) return 1
+            if (bGrade === null) return -1
+            return aGrade - bGrade
+          }
+          const aFirst = a.firstName.toLowerCase()
+          const bFirst = b.firstName.toLowerCase()
+          if (aFirst < bFirst) return -1
+          if (aFirst > bFirst) return 1
+          return 0
+        })
         return { label: selfValue, count: attendees.length, attendees }
       }
 

--- a/frontend/src/hooks/useCohortBunkAssignments.test.ts
+++ b/frontend/src/hooks/useCohortBunkAssignments.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for useCohortBunkAssignments hook.
+ *
+ * The cohort drill-down modal shows each camper's current bunk inline next
+ * to their grade. Source of truth depends on scenario state:
+ *  - Scenario active → bunk_assignments_draft filtered by scenario id
+ *  - Production mode (currentScenario === null) → bunk_assignments
+ *
+ * TDD: tests written BEFORE implementation.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '../test/testUtils'
+import { useCohortBunkAssignments } from './useCohortBunkAssignments'
+
+const mockGetFullList = vi.fn()
+const collectionSpy = vi.fn((_name: string) => ({ getFullList: mockGetFullList }))
+vi.mock('../lib/pocketbase', () => ({
+  pb: {
+    collection: (name: string) => collectionSpy(name),
+  },
+}))
+
+// The hook reads ScenarioContext via useContext. We provide a controllable
+// mock so each test can flip between production and a specific scenario.
+const mockScenarioContext: { currentScenario: { id: string } | null } = {
+  currentScenario: null,
+}
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react')
+  return {
+    ...actual,
+    useContext: (ctx: unknown) => {
+      // Identify our ScenarioContext by displayName-style marker on the mock.
+      if ((ctx as { __isScenarioContext__?: boolean }).__isScenarioContext__) {
+        return mockScenarioContext
+      }
+      return actual.useContext(ctx as Parameters<typeof actual.useContext>[0])
+    },
+  }
+})
+vi.mock('./useScenario', () => ({
+  ScenarioContext: { __isScenarioContext__: true },
+}))
+
+interface AssignmentFixture {
+  bunkName: string | null
+  personCmId: number
+}
+
+// Builds a record matching what we expand from PocketBase. Both the prod
+// (`bunk_assignments`) and scenario (`bunk_assignments_draft`) collections
+// have identical relation shapes for our purposes.
+function makeAssignment({ bunkName, personCmId }: AssignmentFixture) {
+  return {
+    id: `assign-${personCmId}`,
+    expand: {
+      person: { cm_id: personCmId },
+      bunk: bunkName ? { name: bunkName } : null,
+    },
+  }
+}
+
+describe('useCohortBunkAssignments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockScenarioContext.currentScenario = null
+  })
+
+  it('returns an empty map when given no person ids', async () => {
+    const { result } = renderHook(() => useCohortBunkAssignments([], 201, 2025), {
+      wrapper: createWrapper(),
+    })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.bunkByPerson.size).toBe(0)
+    // No need to hit PocketBase when there are no campers to look up.
+    expect(mockGetFullList).not.toHaveBeenCalled()
+  })
+
+  it('reads bunk_assignments in production mode (no scenario active)', async () => {
+    mockScenarioContext.currentScenario = null
+    mockGetFullList.mockResolvedValue([
+      makeAssignment({ personCmId: 2000001, bunkName: 'Bunk 4' }),
+      makeAssignment({ personCmId: 2000002, bunkName: 'Bunk 7' }),
+    ])
+
+    const { result } = renderHook(() => useCohortBunkAssignments([2000001, 2000002], 201, 2025), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(collectionSpy).toHaveBeenCalledWith('bunk_assignments')
+    expect(result.current.bunkByPerson.get(2000001)).toBe('Bunk 4')
+    expect(result.current.bunkByPerson.get(2000002)).toBe('Bunk 7')
+  })
+
+  it('reads bunk_assignments_draft when a scenario is active', async () => {
+    mockScenarioContext.currentScenario = { id: 'scen-abc' }
+    mockGetFullList.mockResolvedValue([
+      makeAssignment({ personCmId: 2000003, bunkName: 'Bunk 12' }),
+    ])
+
+    const { result } = renderHook(() => useCohortBunkAssignments([2000003], 201, 2025), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(collectionSpy).toHaveBeenCalledWith('bunk_assignments_draft')
+    // Filter must scope to the active scenario or we'd leak draft rows.
+    const callOpts = mockGetFullList.mock.calls[0]?.[0] as { filter: string } | undefined
+    expect(callOpts?.filter).toContain('scenario = "scen-abc"')
+    expect(result.current.bunkByPerson.get(2000003)).toBe('Bunk 12')
+  })
+
+  it('returns null for campers without an assignment row', async () => {
+    mockScenarioContext.currentScenario = null
+    // Only 2000001 is assigned; 2000002 is in the cohort but unbunked.
+    mockGetFullList.mockResolvedValue([makeAssignment({ personCmId: 2000001, bunkName: 'Bunk 4' })])
+
+    const { result } = renderHook(() => useCohortBunkAssignments([2000001, 2000002], 201, 2025), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.bunkByPerson.get(2000001)).toBe('Bunk 4')
+    // Hook returns the key with a null value (not a missing key) so consumers
+    // can render "Unassigned" without juggling has() vs get().
+    expect(result.current.bunkByPerson.has(2000002)).toBe(true)
+    expect(result.current.bunkByPerson.get(2000002)).toBeNull()
+  })
+
+  it('returns null when the assignment exists but bunk relation is missing', async () => {
+    mockScenarioContext.currentScenario = null
+    mockGetFullList.mockResolvedValue([makeAssignment({ personCmId: 2000004, bunkName: null })])
+
+    const { result } = renderHook(() => useCohortBunkAssignments([2000004], 201, 2025), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.bunkByPerson.get(2000004)).toBeNull()
+  })
+})

--- a/frontend/src/hooks/useCohortBunkAssignments.ts
+++ b/frontend/src/hooks/useCohortBunkAssignments.ts
@@ -1,0 +1,79 @@
+/**
+ * Hook returning the current bunk for each cohort camper.
+ *
+ * The cohort drill-down modal shows "5th grade · Bunk 4" inline next to
+ * each camper. The source of truth follows the active scenario:
+ *  - currentScenario === null → bunk_assignments  (production)
+ *  - currentScenario set       → bunk_assignments_draft scoped by scenario
+ *
+ * The returned Map always contains an entry for every requested personCmId
+ * (null when no assignment exists), so render-time logic can branch on the
+ * value rather than juggling has() vs get().
+ */
+import { useContext } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { pb } from '../lib/pocketbase'
+import { ScenarioContext } from './useScenario'
+import { queryKeys, userDataOptions } from '../utils/queryKeys'
+
+interface AssignmentExpand {
+  expand?: {
+    person?: { cm_id?: number }
+    bunk?: { name?: string } | null
+  }
+}
+
+export interface UseCohortBunkAssignmentsResult {
+  bunkByPerson: Map<number, string | null>
+  isLoading: boolean
+}
+
+export function useCohortBunkAssignments(
+  personCmIds: number[],
+  sessionCmId: number,
+  year: number
+): UseCohortBunkAssignmentsResult {
+  // Consume ScenarioContext directly (rather than the throwing useScenario
+  // helper) so this hook degrades to production mode when rendered outside a
+  // provider — matters for tests of the parent section, and for any future
+  // consumer that lives outside the bunking-board tree.
+  const scenarioCtx = useContext(ScenarioContext)
+  const scenarioId = scenarioCtx?.currentScenario?.id ?? null
+  const enabled = personCmIds.length > 0 && sessionCmId > 0
+
+  const { data, isLoading } = useQuery({
+    queryKey: queryKeys.cohortBunkAssignments(scenarioId, sessionCmId, year, personCmIds),
+    queryFn: async (): Promise<Map<number, string | null>> => {
+      const collection = scenarioId ? 'bunk_assignments_draft' : 'bunk_assignments'
+      const baseFilter = scenarioId
+        ? `scenario = "${scenarioId}" && year = ${year}`
+        : `session.cm_id = ${sessionCmId} && year = ${year}`
+      const rows = await pb.collection(collection).getFullList<AssignmentExpand>({
+        filter: baseFilter,
+        expand: 'person,bunk',
+      })
+
+      // Pre-seed every requested camper to null so consumers can render
+      // "Unassigned" off a single map lookup. Then overwrite where we
+      // actually have data.
+      const map = new Map<number, string | null>()
+      for (const cmId of personCmIds) map.set(cmId, null)
+
+      const wanted = new Set(personCmIds)
+      for (const row of rows) {
+        const cmId = row.expand?.person?.cm_id
+        if (cmId == null || !wanted.has(cmId)) continue
+        const name = row.expand?.bunk?.name ?? null
+        map.set(cmId, name)
+      }
+      return map
+    },
+    enabled,
+    ...userDataOptions,
+  })
+
+  return {
+    bunkByPerson: data ?? new Map<number, string | null>(),
+    isLoading: enabled ? isLoading : false,
+  }
+}

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -232,6 +232,15 @@ export const queryKeys = {
   // Cohort Request Relations (Tier 2 - user-editable, drives modal badges)
   cohortRequestRelations: (personCmId: number | null, sessionCmId: number, year: number) =>
     ['cohort-request-relations', personCmId, sessionCmId, year] as const,
+  // Cohort Bunk Assignments (Tier 2 — scenario or production assignments
+  // shown inline next to each row). Keyed by scenarioId so production view
+  // (null) and each scenario gets its own cache entry.
+  cohortBunkAssignments: (
+    scenarioId: string | null,
+    sessionCmId: number,
+    year: number,
+    personCmIds: number[]
+  ) => ['cohort-bunk-assignments', scenarioId, sessionCmId, year, [...personCmIds].sort()] as const,
 
   // Camper Request Summary (Tier 2 - user data, used in expanded row)
   camperRequestSummary: (requesterCmId: number, year: number) =>


### PR DESCRIPTION
## Summary

Fast follow to #1015 (cohort drill-down on the camper detail panel):

- **Modal blur scoped to the unblurred panel.** Adds a `backdropInsetRight` prop on `ui/Modal.tsx` that insets the dialog wrapper (and therefore the centered modal + the backdrop that fills it) from the right edge. `CohortDrillDownModal` passes \`28rem\` so the slide-out \`CamperDetailsPanel\` stays crisp while the rest of the bunking board blurs behind the cohort modal.
- **Inline current bunk per row.** New \`useCohortBunkAssignments\` hook reads \`bunk_assignments_draft\` when a scenario is active, otherwise \`bunk_assignments\` (production). Each modal row renders \`5th grade · Bunk 4\` or \`5th grade · Unassigned\`; with no grade it renders just the bunk text.
- **Sorted by grade, then first name.** \`useCamperCohorts\` now sorts each cohort's matched attendees ascending by grade with a first-name tiebreaker; ungraded campers sink to the bottom — matches the requests-tab default.

## Decisions

- **Single source of truth for the inset.** Initial implementation applied \`right: 28rem\` to both the dialog wrapper AND the backdrop; since the backdrop is \`absolute inset-0\` inside the wrapper, that double-applied the offset and left a strip of bunking board adjacent to the panel unblurred. Now only the wrapper carries the inset and the backdrop fills it via \`inset-0\`. Test guards against regression.
- **Tolerant ScenarioContext consumption.** \`useCohortBunkAssignments\` reads \`ScenarioContext\` directly via \`useContext\` rather than the throwing \`useScenario\` helper, so it degrades to production mode when rendered outside a provider — needed for existing \`CamperCohortsSection\` tests and any future consumer that lives outside the bunking board tree.
- **Empty key-with-null in the bunk map.** The hook seeds every requested \`personCmId\` with \`null\` and overwrites where assignments exist. The modal distinguishes \`prop omitted\` (hide the bunk line entirely) from \`prop present, value null\` (render \"Unassigned\") via \`has()\` rather than \`get()\`, so callers without the prop don't get a phantom \"Unassigned\" label.

## Manual validation

1. Bunking board → click a camper → expand the camper detail panel.
2. Click a cohort row (\"Also from {school}: N campers\").
3. Confirm: only the bunking board area is blurred; the slide-out panel stays crisp; the modal centers within the unblurred area (not behind the panel).
4. Confirm each row reads \`Nth grade · {Bunk Name}\` or \`Nth grade · Unassigned\`.
5. Confirm rows are ordered youngest-first; ungraded campers sit at the bottom.
6. Switch to a scenario in the scenario picker → reopen the cohort modal → confirm bunks reflect the scenario draft.

## Test plan

- [x] \`Modal\` test — wrapper inset applied; backdrop has no inline \`right\` (regression guard for the double-inset bug)
- [x] \`useCamperCohorts\` test — three new sort cases (grade asc, ungraded last, case-insensitive name tiebreak)
- [x] \`useCohortBunkAssignments\` test — production branch, scenario branch with filter scoping, missing assignment, missing bunk relation, empty input shortcut
- [x] \`CohortDrillDownModal\` test — bunk inline with grade, \"Unassigned\" when null, bunk alone when grade is null, no bunk line when prop omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)