### PR TITLE
fix(frontend): tolerate bunk-graph response in cache size estimator

### DIFF
--- a/frontend/src/services/GraphCacheService.test.ts
+++ b/frontend/src/services/GraphCacheService.test.ts
@@ -222,6 +222,37 @@ describe('GraphCacheService bunk graph (scenario-aware)', () => {
     expect(fetcher).toHaveBeenCalledTimes(1)
   })
 
+  it('tolerates bunk graph responses that omit `communities` (the live bunk endpoint shape)', async () => {
+    // The /api/bunks/{id}/social-graph endpoint returns BunkGraphResponse,
+    // which does NOT include a `communities` field — only the session-level
+    // endpoint does. estimateSize must not throw when storing such a response.
+    const bunkShape = {
+      nodes: [
+        {
+          id: 1,
+          name: 'A',
+          grade: null,
+          bunk_cm_id: null,
+          centrality: 0,
+          clustering: 0,
+          community: null,
+        },
+      ],
+      edges: [],
+      metrics: {
+        density: 0,
+        average_clustering: 0,
+        number_of_components: 0,
+        average_degree: 0,
+      },
+      // no `communities` — matches BunkGraphResponse
+    } as unknown as GraphData
+
+    const fetcher = vi.fn().mockResolvedValue(bunkShape)
+
+    await expect(service.getBunkGraph(202, 42, fetcher, 2026, 'scn_x')).resolves.toBe(bunkShape)
+  })
+
   it('invalidate(sessionCmId) wipes prod and scenario bunk caches for that session', async () => {
     const prod = makeGraph('bunk-prod')
     const scenario = makeGraph('bunk-scn')

--- a/frontend/src/services/GraphCacheService.ts
+++ b/frontend/src/services/GraphCacheService.ts
@@ -261,20 +261,14 @@ export class GraphCacheService {
   }
 
   private estimateSize(data: GraphData): number {
-    // Rough estimation of object size in memory
     let size = 0
 
-    // Nodes
-    size += data.nodes.length * 200 // Estimate ~200 bytes per node
-
-    // Edges
-    size += data.edges.length * 100 // Estimate ~100 bytes per edge
-
-    // Metrics
+    size += data.nodes.length * 200
+    size += data.edges.length * 100
     size += Object.keys(data.metrics).length * 50
 
-    // Communities
-    const communityEntries = Object.entries(data.communities)
+    // `communities` is session-only; the bunk endpoint omits it.
+    const communityEntries = Object.entries(data.communities ?? {})
     size += communityEntries.reduce((acc, [_, members]) => acc + members.length * 8, 0)
 
     return size

--- a/frontend/src/types/graph.ts
+++ b/frontend/src/types/graph.ts
@@ -46,7 +46,9 @@ export interface GraphData {
   nodes: GraphNode[]
   edges: GraphEdge[]
   metrics: GraphMetrics
-  communities: Record<number, number[]>
+  // Session-level only. The bunk-graph endpoint (BunkGraphResponse) does not
+  // emit this field, and the same GraphCacheService stores both shapes.
+  communities?: Record<number, number[]>
   warnings?: string[]
   layout_positions?: Record<number, [number, number]>
   edge_type_counts?: Record<string, number>


### PR DESCRIPTION
## Summary
- Cabin-level social graph modal showed *"no social network available"* for every bunk because `GraphCacheService.estimateSize()` threw `TypeError: Cannot convert undefined or null to object` on `Object.entries(data.communities)`. The bunk-graph endpoint returns `BunkGraphResponse`, which omits the session-only `communities` field; both shapes share one cache helper.
- The `|| {}` fallbacks that previously masked this were dropped by the eslint-warning sweep (51e6525) because the declared `GraphData` type lied about `communities` being required.
- Fix the type instead of working around it: mark `communities` optional and guard the one access site. `nodes` / `edges` / `metrics` are present in both shapes and stay non-optional.

## Test plan
- [x] Added failing test `tolerates bunk graph responses that omit communities` (mirrors live `BunkGraphResponse`); verified red against current main, green after fix.
- [x] All 11 `GraphCacheService` tests pass.
- [x] `tsc --noEmit` clean.
- [x] eslint clean.
- [ ] Manual: open the bunk graph modal on `/summer/session/2/bunks` in scenario mode — should now render nodes/edges instead of the empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)