### PR TITLE
feat(api): parent/staff request taxonomy — Stage 1 foundation

### DIFF
--- a/api/routers/validation.py
+++ b/api/routers/validation.py
@@ -290,6 +290,7 @@ async def validate_bunking(
                 status=getattr(request_data, "status", "pending"),
                 session_cm_id=str(getattr(request_data, "session_id", "")),
                 year=getattr(request_data, "year", ctx.year),
+                source=getattr(request_data, "source", None),
                 source_field=getattr(request_data, "source_field", None),
                 ai_reasoning=getattr(request_data, "ai_reasoning", None),
                 ai_p1_reasoning=getattr(request_data, "ai_p1_reasoning", None),

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -513,13 +513,14 @@ class BunkingValidator:
                 if is_explicit:
                     explicit_requests_by_person[requester_id].append(request)
 
-                # Bin by RequestSource (parent vs staff) for Stage 1 breakdown stats.
-                # Parent: bunk_with + socialize_with (RequestSource.FAMILY / "family").
-                # Staff: not_bunk_with + bunking_notes + internal_notes (RequestSource.STAFF / "staff").
-                request_source = getattr(request, "source", None)
-                if request_source == RequestSource.FAMILY or request_source == RequestSource.FAMILY.value:
+                # Bin by request.source (RequestSource enum value) for Stage 1
+                # breakdown stats. Production stores `source` as the enum's str
+                # value ("family" / "staff"); requests with source=None or any
+                # unrecognized value fall through both branches and are counted
+                # only in the aggregate total/satisfied stats.
+                if request.source == RequestSource.FAMILY.value:
                     parent_requests_by_person[requester_id].append(request)
-                elif request_source == RequestSource.STAFF or request_source == RequestSource.STAFF.value:
+                elif request.source == RequestSource.STAFF.value:
                     staff_requests_by_person[requester_id].append(request)
 
                 # Update field stats (only for known fields)
@@ -533,9 +534,9 @@ class BunkingValidator:
                     satisfied_requests_by_person[requester_id].append(request)
                     if is_explicit:
                         satisfied_explicit_by_person[requester_id].append(request)
-                    if request_source == RequestSource.FAMILY or request_source == RequestSource.FAMILY.value:
+                    if request.source == RequestSource.FAMILY.value:
                         satisfied_parent_by_person[requester_id].append(request)
-                    elif request_source == RequestSource.STAFF or request_source == RequestSource.STAFF.value:
+                    elif request.source == RequestSource.STAFF.value:
                         satisfied_staff_by_person[requester_id].append(request)
 
                     # Update satisfied field stats (only for known fields)

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -135,8 +135,9 @@ class ValidationStatistics(BaseModel):
     parent_request_satisfaction_rate: float = 0.0
     campers_with_unsatisfied_parent_requests: int = 0
 
-    # Staff-source request tracking (not_bunk_with + bunking_notes + internal_notes,
-    # per RequestSource.STAFF). Tracked separately because they don't satisfy the
+    # Staff-source request tracking, per RequestSource.STAFF. Source fields:
+    # SourceField.NOT_BUNK_WITH (stats key "do_not_share_with"), BUNKING_NOTES,
+    # INTERNAL_NOTES. Tracked separately because they don't satisfy the
     # "every camper gets one parent request" rule that Stage 4 will enforce.
     staff_requests: int = 0
     satisfied_staff_requests: int = 0

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -516,8 +516,9 @@ class BunkingValidator:
                 # Bin by request.source (RequestSource enum value) for Stage 1
                 # breakdown stats. Production stores `source` as the enum's str
                 # value ("family" / "staff"); requests with source=None or any
-                # unrecognized value fall through both branches and are counted
-                # only in the aggregate total/satisfied stats.
+                # unrecognized value (notably the legacy "notes" enum value still
+                # permitted by the bunk_requests schema) fall through both branches
+                # and are counted only in the aggregate total/satisfied stats.
                 if request.source == RequestSource.FAMILY.value:
                     parent_requests_by_person[requester_id].append(request)
                 elif request.source == RequestSource.STAFF.value:
@@ -653,14 +654,10 @@ class BunkingValidator:
             stats.staff_request_satisfaction_rate = stats.satisfied_staff_requests / stats.staff_requests
 
         stats.campers_with_unsatisfied_parent_requests = sum(
-            1
-            for requester_id, reqs in parent_requests_by_person.items()
-            if reqs and not satisfied_parent_by_person.get(requester_id)
+            1 for requester_id in parent_requests_by_person if not satisfied_parent_by_person.get(requester_id)
         )
         stats.campers_with_unsatisfied_staff_requests = sum(
-            1
-            for requester_id, reqs in staff_requests_by_person.items()
-            if reqs and not satisfied_staff_by_person.get(requester_id)
+            1 for requester_id in staff_requests_by_person if not satisfied_staff_by_person.get(requester_id)
         )
 
         # Add summary issue if there are campers with unsatisfied valid requests

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 from bunking.logging_config import get_logger
 from bunking.models import Bunk, BunkAssignment, BunkRequest, FriendGroup, Person, Session
 from bunking.solver.constraints.helpers import extract_bunk_level, get_level_order
+from bunking.sync.bunk_request_processor.core.models import RequestSource
 from bunking.sync.bunk_request_processor.shared.constants import (
     SOURCE_FIELD_TO_CONFIG_KEY,
     SourceField,
@@ -373,6 +374,10 @@ class BunkingValidator:
         satisfied_requests_by_person = defaultdict(list)
         explicit_requests_by_person = defaultdict(list)
         satisfied_explicit_by_person = defaultdict(list)
+        parent_requests_by_person = defaultdict(list)
+        satisfied_parent_by_person = defaultdict(list)
+        staff_requests_by_person = defaultdict(list)
+        satisfied_staff_by_person = defaultdict(list)
 
         def normalize_source_field(raw_field: str) -> str | None:
             """Normalize database source_field values to consistent snake_case keys.
@@ -508,6 +513,15 @@ class BunkingValidator:
                 if is_explicit:
                     explicit_requests_by_person[requester_id].append(request)
 
+                # Bin by RequestSource (parent vs staff) for Stage 1 breakdown stats.
+                # Parent: bunk_with + socialize_with (RequestSource.FAMILY / "family").
+                # Staff: not_bunk_with + bunking_notes + internal_notes (RequestSource.STAFF / "staff").
+                request_source = getattr(request, "source", None)
+                if request_source == RequestSource.FAMILY or request_source == RequestSource.FAMILY.value:
+                    parent_requests_by_person[requester_id].append(request)
+                elif request_source == RequestSource.STAFF or request_source == RequestSource.STAFF.value:
+                    staff_requests_by_person[requester_id].append(request)
+
                 # Update field stats (only for known fields)
                 for field in source_fields:
                     if field in stats.field_stats:
@@ -519,6 +533,10 @@ class BunkingValidator:
                     satisfied_requests_by_person[requester_id].append(request)
                     if is_explicit:
                         satisfied_explicit_by_person[requester_id].append(request)
+                    if request_source == RequestSource.FAMILY or request_source == RequestSource.FAMILY.value:
+                        satisfied_parent_by_person[requester_id].append(request)
+                    elif request_source == RequestSource.STAFF or request_source == RequestSource.STAFF.value:
+                        satisfied_staff_by_person[requester_id].append(request)
 
                     # Update satisfied field stats (only for known fields)
                     for field in source_fields:
@@ -621,6 +639,28 @@ class BunkingValidator:
                 stats.satisfied_explicit_csv_requests / stats.explicit_csv_requests
             )
         stats.campers_with_unsatisfied_explicit_requests = len(campers_with_unsatisfied_explicit_requests)
+
+        # Stage 1 parent/staff breakdown stats (RequestSource-driven).
+        stats.parent_requests = sum(len(reqs) for reqs in parent_requests_by_person.values())
+        stats.satisfied_parent_requests = sum(len(reqs) for reqs in satisfied_parent_by_person.values())
+        if stats.parent_requests > 0:
+            stats.parent_request_satisfaction_rate = stats.satisfied_parent_requests / stats.parent_requests
+
+        stats.staff_requests = sum(len(reqs) for reqs in staff_requests_by_person.values())
+        stats.satisfied_staff_requests = sum(len(reqs) for reqs in satisfied_staff_by_person.values())
+        if stats.staff_requests > 0:
+            stats.staff_request_satisfaction_rate = stats.satisfied_staff_requests / stats.staff_requests
+
+        stats.campers_with_unsatisfied_parent_requests = sum(
+            1
+            for requester_id, reqs in parent_requests_by_person.items()
+            if reqs and not satisfied_parent_by_person.get(requester_id)
+        )
+        stats.campers_with_unsatisfied_staff_requests = sum(
+            1
+            for requester_id, reqs in staff_requests_by_person.items()
+            if reqs and not satisfied_staff_by_person.get(requester_id)
+        )
 
         # Add summary issue if there are campers with unsatisfied valid requests
         if campers_with_unsatisfied_valid_requests:

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -128,6 +128,21 @@ class ValidationStatistics(BaseModel):
     explicit_csv_request_satisfaction_rate: float = 0.0
     campers_with_unsatisfied_explicit_requests: int = 0
 
+    # Parent-source request tracking (bunk_with + socialize_with, per RequestSource.FAMILY).
+    # Stage 1 emits these alongside explicit_csv_* for future UI consumption; no UI consumer yet.
+    parent_requests: int = 0
+    satisfied_parent_requests: int = 0
+    parent_request_satisfaction_rate: float = 0.0
+    campers_with_unsatisfied_parent_requests: int = 0
+
+    # Staff-source request tracking (not_bunk_with + bunking_notes + internal_notes,
+    # per RequestSource.STAFF). Tracked separately because they don't satisfy the
+    # "every camper gets one parent request" rule that Stage 4 will enforce.
+    staff_requests: int = 0
+    satisfied_staff_requests: int = 0
+    staff_request_satisfaction_rate: float = 0.0
+    campers_with_unsatisfied_staff_requests: int = 0
+
     # Level progression stats (comparing to prior year)
     level_progression: dict[str, int] = Field(
         default_factory=lambda: {

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -519,9 +519,11 @@ class BunkingValidator:
                 # unrecognized value (notably the legacy "notes" enum value still
                 # permitted by the bunk_requests schema) fall through both branches
                 # and are counted only in the aggregate total/satisfied stats.
-                if request.source == RequestSource.FAMILY.value:
+                is_family = request.source == RequestSource.FAMILY.value
+                is_staff = request.source == RequestSource.STAFF.value
+                if is_family:
                     parent_requests_by_person[requester_id].append(request)
-                elif request.source == RequestSource.STAFF.value:
+                elif is_staff:
                     staff_requests_by_person[requester_id].append(request)
 
                 # Update field stats (only for known fields)
@@ -535,9 +537,9 @@ class BunkingValidator:
                     satisfied_requests_by_person[requester_id].append(request)
                     if is_explicit:
                         satisfied_explicit_by_person[requester_id].append(request)
-                    if request.source == RequestSource.FAMILY.value:
+                    if is_family:
                         satisfied_parent_by_person[requester_id].append(request)
-                    elif request.source == RequestSource.STAFF.value:
+                    elif is_staff:
                         satisfied_staff_by_person[requester_id].append(request)
 
                     # Update satisfied field stats (only for known fields)

--- a/bunking/sync/bunk_request_processor/processing/deduplicator.py
+++ b/bunking/sync/bunk_request_processor/processing/deduplicator.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 
 from ..core.models import BunkRequest, RequestSource, RequestType
 from ..data.repositories.request_repository import RequestRepository
+from ..shared.constants import SourceField
 
 # Source priority order (higher number = higher priority)
 # Used for deduplication tiebreaker only - staff validates family input
@@ -122,10 +123,15 @@ class Deduplicator:
                 # No duplicates in batch
                 kept_requests.append(group_requests[0])
             else:
-                # Sort by source priority (descending) then confidence (descending)
-                sorted_requests = sorted(
-                    group_requests, key=lambda r: (SOURCE_PRIORITY.get(r.source, 0), r.confidence_score), reverse=True
-                )
+                # Tiebreak order (descending): SOURCE_PRIORITY, then bunk_with-source
+                # preference for parent age_pref dedupe (Stage 1 fix), then confidence.
+                # The bunk_with bias only fires for parent-vs-parent age_pref ties; for
+                # any other source pairing, SOURCE_PRIORITY decides first.
+                def _sort_key(r: BunkRequest) -> tuple[int, int, float]:
+                    is_bunk_with = 1 if r.source_field == SourceField.BUNK_WITH else 0
+                    return (SOURCE_PRIORITY.get(r.source, 0), is_bunk_with, r.confidence_score)
+
+                sorted_requests = sorted(group_requests, key=_sort_key, reverse=True)
 
                 primary = sorted_requests[0]
                 duplicates = sorted_requests[1:]

--- a/bunking/sync/bunk_request_processor/processing/deduplicator.py
+++ b/bunking/sync/bunk_request_processor/processing/deduplicator.py
@@ -124,9 +124,10 @@ class Deduplicator:
                 kept_requests.append(group_requests[0])
             else:
                 # Tiebreak order (descending): SOURCE_PRIORITY, then bunk_with-source
-                # preference for parent age_pref dedupe (Stage 1 fix), then confidence.
-                # The bunk_with bias only fires for parent-vs-parent age_pref ties; for
-                # any other source pairing, SOURCE_PRIORITY decides first.
+                # preference (Stage 1 fix for parent age_pref dedupe), then confidence.
+                # SOURCE_PRIORITY dominates first, so the bunk_with bias only changes
+                # outcomes within same-source ties — most commonly parent-vs-parent
+                # age_pref (where bunk_with prose beats the socialize_with checkbox).
                 def _sort_key(r: BunkRequest) -> tuple[int, int, float]:
                     is_bunk_with = 1 if r.source_field == SourceField.BUNK_WITH else 0
                     return (SOURCE_PRIORITY.get(r.source, 0), is_bunk_with, r.confidence_score)

--- a/bunking/sync/bunk_request_processor/processing/deduplicator.py
+++ b/bunking/sync/bunk_request_processor/processing/deduplicator.py
@@ -128,11 +128,15 @@ class Deduplicator:
                 # SOURCE_PRIORITY dominates first, so the bunk_with bias only changes
                 # outcomes within same-source ties — most commonly parent-vs-parent
                 # age_pref (where bunk_with prose beats the socialize_with checkbox).
-                def _sort_key(r: BunkRequest) -> tuple[int, int, float]:
-                    is_bunk_with = 1 if r.source_field == SourceField.BUNK_WITH else 0
-                    return (SOURCE_PRIORITY.get(r.source, 0), is_bunk_with, r.confidence_score)
-
-                sorted_requests = sorted(group_requests, key=_sort_key, reverse=True)
+                sorted_requests = sorted(
+                    group_requests,
+                    key=lambda r: (
+                        SOURCE_PRIORITY.get(r.source, 0),
+                        1 if r.source_field == SourceField.BUNK_WITH else 0,
+                        r.confidence_score,
+                    ),
+                    reverse=True,
+                )
 
                 primary = sorted_requests[0]
                 duplicates = sorted_requests[1:]

--- a/bunking/sync/bunk_request_processor/processing/priority_calculator.py
+++ b/bunking/sync/bunk_request_processor/processing/priority_calculator.py
@@ -124,6 +124,11 @@ class PriorityCalculator:
         """
         has_other_requests = len(all_requests_for_person) > 1
 
+        # Stage 1 fix (#18c foundation): socialize_with should be sole-promoted
+        # when the parent submitted no bunk_with text — staff requests don't
+        # count as "other requests" for this purpose since they're not parent input.
+        has_parent_bunk_with = any(r.source_field == SourceField.BUNK_WITH for r in all_requests_for_person)
+
         # Memoize the per-list family_bunk_requests scan to avoid O(N^2) work
         # when this method is invoked once per request for the same list (#923).
         any_family_request_has_priority = self._any_family_request_has_priority(all_requests_for_person)
@@ -160,7 +165,7 @@ class PriorityCalculator:
         # Parent age preference from socialize_with
         if parsed.source_field == SourceField.SOCIALIZE_WITH:
             if parsed.request_type == RequestType.AGE_PREFERENCE:
-                if not has_other_requests:
+                if not has_parent_bunk_with:
                     return self._get_rule_priority("age_preference_sole")  # priority 4
                 return self._get_rule_priority("parent_age_preference")  # priority 1
 

--- a/bunking/sync/bunk_request_processor/processing/priority_calculator.py
+++ b/bunking/sync/bunk_request_processor/processing/priority_calculator.py
@@ -66,6 +66,7 @@ class PriorityCalculator:
         # and each iteration passes the same list. A weak key would be nicer, but
         # id() suffices while the calculator is short-lived per batch.
         self._family_priority_cache: dict[int, bool] = {}
+        self._parent_bunk_with_cache: dict[int, bool] = {}
 
     def _load_keywords(self) -> list[str]:
         """Load priority keywords from config or use defaults"""
@@ -129,10 +130,8 @@ class PriorityCalculator:
         # count as "other requests" for this purpose since they're not parent input.
         # Gate explicitly on RequestSource.FAMILY so a future misclassified staff
         # record on the bunk_with source_field can't suppress the promotion.
-        has_parent_bunk_with = any(
-            r.source == RequestSource.FAMILY and r.source_field == SourceField.BUNK_WITH
-            for r in all_requests_for_person
-        )
+        # Memoized via the same id(list) pattern as _any_family_request_has_priority (#923).
+        has_parent_bunk_with = self._has_parent_bunk_with(all_requests_for_person)
 
         # Memoize the per-list family_bunk_requests scan to avoid O(N^2) work
         # when this method is invoked once per request for the same list (#923).
@@ -188,6 +187,24 @@ class PriorityCalculator:
             return False
         text_lower = text.lower()
         return any(keyword in text_lower for keyword in self._keywords)
+
+    def _has_parent_bunk_with(self, all_requests_for_person: list[ParsedRequest]) -> bool:
+        """Return True if the parent submitted any bunk_with text for this person.
+
+        Memoized by id(list) so the per-request inner loop scans this list only
+        once per person (matches the #923 pattern for _any_family_request_has_priority).
+        """
+        cache_key = id(all_requests_for_person)
+        cached = self._parent_bunk_with_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        result = any(
+            r.source == RequestSource.FAMILY and r.source_field == SourceField.BUNK_WITH
+            for r in all_requests_for_person
+        )
+        self._parent_bunk_with_cache[cache_key] = result
+        return result
 
     def _any_family_request_has_priority(self, all_requests_for_person: list[ParsedRequest]) -> bool:
         """Return True if any bunk_with family request has a priority keyword.

--- a/bunking/sync/bunk_request_processor/processing/priority_calculator.py
+++ b/bunking/sync/bunk_request_processor/processing/priority_calculator.py
@@ -10,7 +10,7 @@ from typing import Any
 from bunking.logging_config import get_logger
 
 from ..core.constants import PRIORITY_KEYWORDS
-from ..core.models import ParsedRequest, RequestType
+from ..core.models import ParsedRequest, RequestSource, RequestType
 from ..shared.constants import SourceField
 
 logger = get_logger(__name__)
@@ -127,7 +127,12 @@ class PriorityCalculator:
         # Stage 1 fix (#18c foundation): socialize_with should be sole-promoted
         # when the parent submitted no bunk_with text — staff requests don't
         # count as "other requests" for this purpose since they're not parent input.
-        has_parent_bunk_with = any(r.source_field == SourceField.BUNK_WITH for r in all_requests_for_person)
+        # Gate explicitly on RequestSource.FAMILY so a future misclassified staff
+        # record on the bunk_with source_field can't suppress the promotion.
+        has_parent_bunk_with = any(
+            r.source == RequestSource.FAMILY and r.source_field == SourceField.BUNK_WITH
+            for r in all_requests_for_person
+        )
 
         # Memoize the per-list family_bunk_requests scan to avoid O(N^2) work
         # when this method is invoked once per request for the same list (#923).

--- a/tests/unit/sync/bunk_request_processor/processing/test_deduplicator.py
+++ b/tests/unit/sync/bunk_request_processor/processing/test_deduplicator.py
@@ -1052,5 +1052,110 @@ class TestAgePreferenceDeduplication:
         assert result.kept_requests[0].source == RequestSource.STAFF
 
 
+class TestParentAgePreferenceDeduplication:
+    """Test Stage 1 parent-paramount fix: bunk_with source wins parent-vs-parent age_pref dedupe.
+
+    When a parent submits an age preference both via bunk_with prose AND the
+    socialize_with checkbox, both become RequestSource.FAMILY with the same dedupe key.
+    The old sort was (SOURCE_PRIORITY, confidence_score) — the socialize_with dropdown
+    gets a deterministic confidence=1.0 which beat the AI-parsed bunk_with at 0.85-0.95,
+    so the wrong request was kept as primary.
+
+    Stage 1 fix: insert bunk_with-source preference between SOURCE_PRIORITY and
+    confidence_score so the prose-derived request wins.
+    """
+
+    @pytest.fixture
+    def deduplicator(self):
+        """Create a Deduplicator without repository (batch-only dedup)"""
+        return Deduplicator()
+
+    def _age_pref(
+        self,
+        source_field: str,
+        confidence: float,
+        source: RequestSource = RequestSource.FAMILY,
+        requester_cm_id: int = 1001,
+        year: int = 2025,
+        session_cm_id: int = 1000001,
+    ) -> BunkRequest:
+        return BunkRequest(
+            requester_cm_id=requester_cm_id,
+            requested_cm_id=None,
+            request_type=RequestType.AGE_PREFERENCE,
+            session_cm_id=session_cm_id,
+            priority=1,
+            confidence_score=confidence,
+            source=source,
+            source_field=source_field,
+            csv_position=0,
+            year=year,
+            status=RequestStatus.RESOLVED,
+            is_placeholder=True,
+            metadata={},
+        )
+
+    def test_dedupe_prefers_bunk_with_over_socialize_with_on_parent_age_pref_tie(self, deduplicator):
+        """When a parent submits an age preference both via bunk_with prose AND the
+        socialize_with checkbox, dedupe must keep the bunk_with-derived request as
+        primary — the prose carries richer signal than a binary checkbox tick.
+
+        Without this fix, confidence_score tiebreaks (checkbox=1.0 > AI parse=0.92)
+        pick the wrong winner.
+        """
+        bunk_with_req = self._age_pref(SourceField.BUNK_WITH, confidence=0.92)
+        socialize_req = self._age_pref(SourceField.SOCIALIZE_WITH, confidence=1.0)
+
+        result = deduplicator.deduplicate_batch([socialize_req, bunk_with_req])
+
+        assert len(result.kept_requests) == 1
+        primary = result.kept_requests[0]
+        assert primary.source_field == SourceField.BUNK_WITH, (
+            f"Expected bunk_with to win parent-vs-parent age_pref dedupe; got {primary.source_field}"
+        )
+        assert len(result.duplicate_groups) == 1
+        assert result.duplicate_groups[0].duplicates[0].source_field == SourceField.SOCIALIZE_WITH
+
+    def test_bunk_with_wins_even_when_listed_second(self, deduplicator):
+        """Input order must not affect outcome — bunk_with wins regardless of position."""
+        bunk_with_req = self._age_pref(SourceField.BUNK_WITH, confidence=0.88)
+        socialize_req = self._age_pref(SourceField.SOCIALIZE_WITH, confidence=1.0)
+
+        # bunk_with listed second
+        result = deduplicator.deduplicate_batch([socialize_req, bunk_with_req])
+        assert result.kept_requests[0].source_field == SourceField.BUNK_WITH
+
+        # bunk_with listed first
+        result2 = deduplicator.deduplicate_batch([bunk_with_req, socialize_req])
+        assert result2.kept_requests[0].source_field == SourceField.BUNK_WITH
+
+    def test_staff_over_family_still_wins_before_bunk_with_bias(self, deduplicator):
+        """SOURCE_PRIORITY (staff > family) must dominate the bunk_with tiebreaker.
+
+        A FAMILY bunk_with request must NOT beat a STAFF socialize_with request —
+        the bunk_with bias only fires for same-source (parent-vs-parent) ties.
+        """
+        family_bunk_with = self._age_pref(SourceField.BUNK_WITH, confidence=0.92, source=RequestSource.FAMILY)
+        staff_socialize = self._age_pref(SourceField.SOCIALIZE_WITH, confidence=0.80, source=RequestSource.STAFF)
+
+        result = deduplicator.deduplicate_batch([family_bunk_with, staff_socialize])
+
+        assert len(result.kept_requests) == 1
+        assert result.kept_requests[0].source == RequestSource.STAFF, (
+            "Staff source must still win over family bunk_with; bunk_with bias must not override SOURCE_PRIORITY"
+        )
+
+    def test_confidence_still_tiebreaks_when_both_non_bunk_with(self, deduplicator):
+        """When neither request is from bunk_with, confidence remains the final tiebreaker."""
+        high_conf = self._age_pref(SourceField.SOCIALIZE_WITH, confidence=1.0)
+        low_conf = self._age_pref(SourceField.BUNKING_NOTES, confidence=0.75)
+
+        result = deduplicator.deduplicate_batch([low_conf, high_conf])
+
+        assert len(result.kept_requests) == 1
+        # Neither is bunk_with → confidence decides (1.0 beats 0.75)
+        assert result.kept_requests[0].source_field == SourceField.SOCIALIZE_WITH
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/sync/bunk_request_processor/processing/test_priority_calculator.py
+++ b/tests/unit/sync/bunk_request_processor/processing/test_priority_calculator.py
@@ -629,6 +629,41 @@ class TestSocializeWithParentParamountStage1:
             "guards against accidental any→all rewrite"
         )
 
+    def test_socialize_with_sole_promoted_with_only_other_family_socialize_with(self, calculator):
+        """Two FAMILY socialize_with siblings (no bunk_with text anywhere) should
+        still sole-promote to priority 4. Regression guard against a future
+        misread of 'has_parent_bunk_with' that might count any FAMILY entry."""
+        socialize_a = ParsedRequest(
+            raw_text="younger",
+            request_type=RequestType.AGE_PREFERENCE,
+            target_name=None,
+            age_preference=AgePreference.YOUNGER,
+            source_field=SourceField.SOCIALIZE_WITH,
+            source=RequestSource.FAMILY,
+            confidence=1.0,
+            csv_position=0,
+            metadata={},
+        )
+        socialize_b = ParsedRequest(
+            raw_text="older",
+            request_type=RequestType.AGE_PREFERENCE,
+            target_name=None,
+            age_preference=AgePreference.OLDER,
+            source_field=SourceField.SOCIALIZE_WITH,
+            source=RequestSource.FAMILY,
+            confidence=1.0,
+            csv_position=1,
+            metadata={},
+        )
+        all_for_person = [socialize_a, socialize_b]
+
+        priority = calculator.calculate_priority(socialize_a, all_for_person)
+
+        assert priority == 4, (
+            "socialize_with should sole-promote to priority 4 even with another "
+            "FAMILY socialize_with sibling, since no bunk_with text exists"
+        )
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/sync/bunk_request_processor/processing/test_priority_calculator.py
+++ b/tests/unit/sync/bunk_request_processor/processing/test_priority_calculator.py
@@ -583,6 +583,52 @@ class TestSocializeWithParentParamountStage1:
             "socialize_with should stay at parent_age_preference priority (1) when any bunk_with parent input exists"
         )
 
+    def test_socialize_with_low_priority_when_multiple_bunk_with_exist(self, calculator):
+        """Regression guard: the suppression rule is `any` (at least one bunk_with),
+        not `all` or `exactly one`. Multiple bunk_with siblings still suppress
+        socialize_with to priority 1."""
+        socialize_req = ParsedRequest(
+            raw_text="younger",
+            request_type=RequestType.AGE_PREFERENCE,
+            target_name=None,
+            age_preference=AgePreference.YOUNGER,
+            source_field=SourceField.SOCIALIZE_WITH,
+            source=RequestSource.FAMILY,
+            confidence=1.0,
+            csv_position=0,
+            metadata={},
+        )
+        bunk_with_one = ParsedRequest(
+            raw_text="wants to bunk with Liam",
+            request_type=RequestType.BUNK_WITH,
+            target_name="Liam Garcia",
+            age_preference=None,
+            source_field=SourceField.BUNK_WITH,
+            source=RequestSource.FAMILY,
+            confidence=0.95,
+            csv_position=1,
+            metadata={},
+        )
+        bunk_with_two = ParsedRequest(
+            raw_text="also Olivia",
+            request_type=RequestType.BUNK_WITH,
+            target_name="Olivia Chen",
+            age_preference=None,
+            source_field=SourceField.BUNK_WITH,
+            source=RequestSource.FAMILY,
+            confidence=0.95,
+            csv_position=2,
+            metadata={},
+        )
+        all_for_person = [socialize_req, bunk_with_one, bunk_with_two]
+
+        priority = calculator.calculate_priority(socialize_req, all_for_person)
+
+        assert priority == 1, (
+            "Two or more bunk_with requests must still suppress socialize_with — "
+            "guards against accidental any→all rewrite"
+        )
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/sync/bunk_request_processor/processing/test_priority_calculator.py
+++ b/tests/unit/sync/bunk_request_processor/processing/test_priority_calculator.py
@@ -210,14 +210,23 @@ class TestPriorityCalculator:
         assert priority == 4, "Sole age_preference from socialize_with should get priority 4"
 
     def test_age_preference_from_socialize_with_with_other_requests(self, calculator):
-        """age_preference from socialize_with with other requests gets priority 1"""
+        """age_preference from socialize_with with other non-bunk_with requests still
+        gets promoted to priority 4.
+
+        Updated per Stage 1 fix: staff requests (and other non-bunk_with source_field
+        requests) no longer suppress socialize_with sole-promote. Only a request with
+        source_field=BUNK_WITH (parent bunk_with text) suppresses the promotion.
+
+        The 'other' request here is a BUNK_WITH type but from source_field=SOCIALIZE_WITH,
+        meaning it's not a parent bunk_with field submission — so promotion still applies.
+        """
         requests = [
             ParsedRequest(
                 raw_text="Emma Johnson",
                 request_type=RequestType.BUNK_WITH,
                 target_name="Emma Johnson",
                 age_preference=None,
-                source_field=SourceField.SOCIALIZE_WITH,
+                source_field=SourceField.SOCIALIZE_WITH,  # NOT source_field BUNK_WITH
                 source=RequestSource.FAMILY,
                 confidence=0.95,
                 csv_position=1,
@@ -237,7 +246,12 @@ class TestPriorityCalculator:
         ]
 
         priority = calculator.calculate_priority(requests[1], requests)
-        assert priority == 1, "age_preference from socialize_with with other requests should stay priority 1"
+        # Updated per Stage 1 fix: no bunk_with source_field request exists,
+        # so socialize_with is still the "sole" parent input — priority 4.
+        assert priority == 4, (
+            "age_preference from socialize_with should be priority 4 when no "
+            "source_field=BUNK_WITH request exists (only non-bunk_with source requests)"
+        )
 
     def test_staff_notes_request(self, calculator):
         """Any request from staff notes gets priority 2"""
@@ -487,6 +501,87 @@ class TestConfigDrivenPriorityCalculator:
 
         priority = calculator.calculate_priority(request, [request])
         assert priority == 4, "Default keywords should work when config only overrides rules"
+
+
+class TestSocializeWithParentParamountStage1:
+    """Stage 1 fix: staff requests don't suppress socialize_with sole-promote.
+
+    Per the parent-paramount taxonomy: socialize_with is sole parent input when
+    no bunk_with request exists. Staff requests (internal_notes, bunking_notes,
+    not_bunk_with) are not parent input and must not suppress the promotion.
+    """
+
+    @pytest.fixture
+    def calculator(self):
+        return PriorityCalculator()
+
+    def test_socialize_with_sole_promoted_when_bunk_with_empty_even_with_staff_notes(self, calculator):
+        """Per parent-paramount rule: socialize_with is the sole parent input when
+        no bunk_with request exists, and gets priority 4. Staff notes don't suppress
+        this — they're not parent input."""
+        socialize_req = ParsedRequest(
+            raw_text="younger",
+            request_type=RequestType.AGE_PREFERENCE,
+            target_name=None,
+            age_preference=AgePreference.YOUNGER,
+            source_field=SourceField.SOCIALIZE_WITH,
+            source=RequestSource.FAMILY,
+            confidence=1.0,
+            csv_position=0,
+            metadata={},
+        )
+        staff_note_req = ParsedRequest(
+            raw_text="keep away from Liam",
+            request_type=RequestType.NOT_BUNK_WITH,
+            target_name="Liam Garcia",
+            age_preference=None,
+            source_field=SourceField.INTERNAL_NOTES,
+            source=RequestSource.STAFF,
+            confidence=0.9,
+            csv_position=0,
+            metadata={},
+        )
+        all_for_person = [socialize_req, staff_note_req]
+
+        priority = calculator.calculate_priority(socialize_req, all_for_person)
+
+        assert priority == 4, (
+            "socialize_with should be sole-promoted to priority 4 when no bunk_with "
+            "exists for the camper, regardless of staff requests"
+        )
+
+    def test_socialize_with_low_priority_when_bunk_with_exists(self, calculator):
+        """Counterpart: when a parent submitted bunk_with text, socialize_with stays
+        at priority 1 because the parent has a higher-priority input."""
+        socialize_req = ParsedRequest(
+            raw_text="younger",
+            request_type=RequestType.AGE_PREFERENCE,
+            target_name=None,
+            age_preference=AgePreference.YOUNGER,
+            source_field=SourceField.SOCIALIZE_WITH,
+            source=RequestSource.FAMILY,
+            confidence=1.0,
+            csv_position=0,
+            metadata={},
+        )
+        bunk_with_req = ParsedRequest(
+            raw_text="wants to bunk with Liam",
+            request_type=RequestType.BUNK_WITH,
+            target_name="Liam Garcia",
+            age_preference=None,
+            source_field=SourceField.BUNK_WITH,
+            source=RequestSource.FAMILY,
+            confidence=0.95,
+            csv_position=1,
+            metadata={},
+        )
+        all_for_person = [socialize_req, bunk_with_req]
+
+        priority = calculator.calculate_priority(socialize_req, all_for_person)
+
+        assert priority == 1, (
+            "socialize_with should stay at parent_age_preference priority (1) when any bunk_with parent input exists"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -58,6 +58,7 @@ class MockBunkRequest:
     status: str = "resolved"
     priority: int = 5
     source_field: str | None = None
+    source: str | None = None  # "family" or "staff" (RequestSource enum value)
     ai_p1_reasoning: dict[str, Any] | None = None
     age_preference_target: str | None = None
 
@@ -746,3 +747,110 @@ def test_validation_statistics_has_parent_staff_breakdown_fields():
     assert stats.satisfied_staff_requests == 0
     assert stats.staff_request_satisfaction_rate == 0.0
     assert stats.campers_with_unsatisfied_staff_requests == 0
+
+
+# Helpers for RequestSource binning tests
+# Use numeric string IDs per existing fixture convention
+
+
+def _mock_person(cm_id: str, grade: int = 5) -> MockPerson:
+    return MockPerson(campminder_id=cm_id, name=f"Camper{cm_id}", grade=grade)
+
+
+def _mock_bunk(cm_id: str, max_size: int = 8) -> MockBunk:
+    return MockBunk(campminder_id=cm_id, name=f"Bunk-{cm_id}", max_size=max_size)
+
+
+def _mock_assignment(person_cm_id: str, bunk_cm_id: str) -> MockBunkAssignment:
+    return MockBunkAssignment(person_cm_id=person_cm_id, bunk_cm_id=bunk_cm_id)
+
+
+def _mock_request(
+    requester: str,
+    target: str | None,
+    source_field: str,
+    source: str,  # "family" or "staff" — the RequestSource enum value
+    request_type: str = "bunk_with",
+    status: str = "resolved",
+) -> MockBunkRequest:
+    return MockBunkRequest(
+        requester_person_cm_id=requester,
+        requested_person_cm_id=target,
+        request_type=request_type,
+        status=status,
+        source_field=source_field,
+        source=source,
+    )
+
+
+def test_validator_bins_parent_requests_separately_from_staff():
+    """Parent-source requests count in parent_* stats; staff-source in staff_*. No overlap."""
+    session = MockSession(campminder_id="10000001", name="Test Session")
+    persons = [_mock_person("20001"), _mock_person("20002")]
+    bunks = [_mock_bunk("30001")]
+    assignments = [
+        _mock_assignment("20001", "30001"),
+        _mock_assignment("20002", "30001"),
+    ]
+    requests = [
+        # Parent: 20001 wants to bunk with 20002 — satisfied (both in 30001)
+        _mock_request("20001", "20002", "bunk_with", "family"),
+        # Staff: 20002 has an internal note not_bunk_with 20003 (20003 not present)
+        _mock_request("20002", "20003", "not_bunk_with", "staff", request_type="not_bunk_with"),
+    ]
+
+    validator = BunkingValidator()
+    result = validator.validate_bunking(
+        session=session,
+        bunks=bunks,
+        assignments=assignments,
+        persons=persons,
+        requests=requests,
+    )
+    stats = result.statistics
+
+    assert stats.parent_requests == 1
+    assert stats.satisfied_parent_requests == 1
+    assert stats.parent_request_satisfaction_rate == 1.0
+    assert stats.staff_requests == 1
+    assert stats.satisfied_staff_requests == 1
+    assert stats.staff_request_satisfaction_rate == 1.0
+    assert stats.campers_with_unsatisfied_parent_requests == 0
+    assert stats.campers_with_unsatisfied_staff_requests == 0
+
+
+def test_validator_flags_camper_with_unsatisfied_parent_but_satisfied_staff():
+    """A camper with a parent request unsatisfied but staff requests satisfied
+    should appear in campers_with_unsatisfied_parent_requests but NOT in the
+    staff equivalent. Stage 4 uses this binning for the solver minimum-one rule."""
+    session = MockSession(campminder_id="10000001", name="Test Session")
+    persons = [_mock_person("20001"), _mock_person("20002"), _mock_person("20003")]
+    bunks = [_mock_bunk("30001"), _mock_bunk("30002")]
+    assignments = [
+        _mock_assignment("20001", "30001"),
+        _mock_assignment("20002", "30002"),  # NOT in 20001's bunk
+        _mock_assignment("20003", "30002"),
+    ]
+    requests = [
+        # Parent: 20001 wants to bunk with 20002 — UNSATISFIED (20002 is in 30002)
+        _mock_request("20001", "20002", "bunk_with", "family"),
+        # Staff: 20001 should not bunk with 20003 — SATISFIED (20003 in 30002, 20001 in 30001)
+        _mock_request("20001", "20003", "internal_notes", "staff", request_type="not_bunk_with"),
+    ]
+
+    validator = BunkingValidator()
+    result = validator.validate_bunking(
+        session=session,
+        bunks=bunks,
+        assignments=assignments,
+        persons=persons,
+        requests=requests,
+    )
+    stats = result.statistics
+
+    assert stats.parent_requests == 1
+    assert stats.satisfied_parent_requests == 0
+    assert stats.staff_requests == 1
+    assert stats.satisfied_staff_requests == 1
+    assert stats.campers_with_unsatisfied_parent_requests == 1  # 20001
+    assert stats.campers_with_unsatisfied_staff_requests == 0  # 20001's staff is satisfied

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -769,7 +769,7 @@ def _mock_request(
     requester: str,
     target: str | None,
     source_field: str,
-    source: str,  # "family" or "staff" — the RequestSource enum value
+    source: str | None,  # "family", "staff", or None — RequestSource enum value
     request_type: str = "bunk_with",
     status: str = "resolved",
 ) -> MockBunkRequest:
@@ -854,3 +854,37 @@ def test_validator_flags_camper_with_unsatisfied_parent_but_satisfied_staff():
     assert stats.satisfied_staff_requests == 1
     assert stats.campers_with_unsatisfied_parent_requests == 1  # 20001
     assert stats.campers_with_unsatisfied_staff_requests == 0  # 20001's staff is satisfied
+
+
+def test_validator_skips_binning_for_requests_with_null_source():
+    """Requests with source=None (legacy records or unset) count toward
+    total_requests but fall through both parent and staff bins. Stage 1 silently
+    excludes them from breakdown stats."""
+    session = MockSession(campminder_id="1", name="Test")
+    persons = [_mock_person("20001"), _mock_person("20002")]
+    bunks = [_mock_bunk("30001")]
+    assignments = [
+        _mock_assignment("20001", "30001"),
+        _mock_assignment("20002", "30001"),
+    ]
+    requests = [
+        # Source-less request — satisfied (both in 30001) but binned nowhere
+        _mock_request("20001", "20002", "bunk_with", None),
+    ]
+
+    validator = BunkingValidator()
+    result = validator.validate_bunking(
+        session=session,
+        bunks=bunks,
+        assignments=assignments,
+        persons=persons,
+        requests=requests,
+    )
+    stats = result.statistics
+
+    assert stats.total_requests == 1
+    assert stats.satisfied_requests == 1
+    assert stats.parent_requests == 0
+    assert stats.staff_requests == 0
+    assert stats.campers_with_unsatisfied_parent_requests == 0
+    assert stats.campers_with_unsatisfied_staff_requests == 0

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -12,6 +12,7 @@ from bunking.bunking_validator import (
     HistoricalBunkingRecord,
     ValidationResult,
     ValidationSeverity,
+    ValidationStatistics,
 )
 from bunking.sync.bunk_request_processor.shared.constants import SourceField
 
@@ -730,11 +731,8 @@ class TestNormalizeSourceField:
             assert field_data["total"] == 0
 
 
-from bunking.bunking_validator import ValidationStatistics
-
-
 def test_validation_statistics_has_parent_staff_breakdown_fields():
-    """ValidationStatistics must expose parent/staff breakdown fields with safe defaults."""
+    """ValidationStatistics declares parent/staff breakdown fields defaulting to 0/0.0."""
     stats = ValidationStatistics()
 
     # Parent breakdown — campers with parent-source requests (bunk_with or socialize_with)

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -753,26 +753,35 @@ def test_validation_statistics_has_parent_staff_breakdown_fields():
 # Use numeric string IDs per existing fixture convention
 
 
-def _mock_person(cm_id: str, grade: int = 5) -> MockPerson:
+# Return types omitted intentionally — these helpers feed into validate_bunking()
+# which expects the real Session/Bunk/Person/BunkAssignment/BunkRequest Pydantic
+# models. The pre-existing class-level fixtures (basic_session, basic_bunks, etc.)
+# also omit annotations for the same reason; mypy can't narrow the return and
+# treats it as Any-ish at the call site, mirroring the existing test convention.
+def _mock_session(cm_id="1", name="Test"):
+    return MockSession(campminder_id=cm_id, name=name)
+
+
+def _mock_person(cm_id, grade=5):
     return MockPerson(campminder_id=cm_id, name=f"Camper{cm_id}", grade=grade)
 
 
-def _mock_bunk(cm_id: str, max_size: int = 8) -> MockBunk:
+def _mock_bunk(cm_id, max_size=8):
     return MockBunk(campminder_id=cm_id, name=f"Bunk-{cm_id}", max_size=max_size)
 
 
-def _mock_assignment(person_cm_id: str, bunk_cm_id: str) -> MockBunkAssignment:
+def _mock_assignment(person_cm_id, bunk_cm_id):
     return MockBunkAssignment(person_cm_id=person_cm_id, bunk_cm_id=bunk_cm_id)
 
 
 def _mock_request(
-    requester: str,
-    target: str | None,
-    source_field: str,
-    source: str | None,  # "family", "staff", or None — RequestSource enum value
-    request_type: str = "bunk_with",
-    status: str = "resolved",
-) -> MockBunkRequest:
+    requester,
+    target,
+    source_field,
+    source,  # "family", "staff", or None — RequestSource enum value
+    request_type="bunk_with",
+    status="resolved",
+):
     return MockBunkRequest(
         requester_person_cm_id=requester,
         requested_person_cm_id=target,
@@ -785,7 +794,7 @@ def _mock_request(
 
 def test_validator_bins_parent_requests_separately_from_staff():
     """Parent-source requests count in parent_* stats; staff-source in staff_*. No overlap."""
-    session = MockSession(campminder_id="10000001", name="Test Session")
+    session = _mock_session(cm_id="10000001", name="Test Session")
     persons = [_mock_person("20001"), _mock_person("20002")]
     bunks = [_mock_bunk("30001")]
     assignments = [
@@ -823,7 +832,7 @@ def test_validator_flags_camper_with_unsatisfied_parent_but_satisfied_staff():
     """A camper with a parent request unsatisfied but staff requests satisfied
     should appear in campers_with_unsatisfied_parent_requests but NOT in the
     staff equivalent. Stage 4 uses this binning for the solver minimum-one rule."""
-    session = MockSession(campminder_id="10000001", name="Test Session")
+    session = _mock_session(cm_id="10000001", name="Test Session")
     persons = [_mock_person("20001"), _mock_person("20002"), _mock_person("20003")]
     bunks = [_mock_bunk("30001"), _mock_bunk("30002")]
     assignments = [
@@ -860,7 +869,7 @@ def test_validator_skips_binning_for_requests_with_null_source():
     """Requests with source=None (legacy records or unset) count toward
     total_requests but fall through both parent and staff bins. Stage 1 silently
     excludes them from breakdown stats."""
-    session = MockSession(campminder_id="1", name="Test")
+    session = _mock_session()
     persons = [_mock_person("20001"), _mock_person("20002")]
     bunks = [_mock_bunk("30001")]
     assignments = [

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -728,3 +728,23 @@ class TestNormalizeSourceField:
 
         for field_data in result.statistics.field_stats.values():
             assert field_data["total"] == 0
+
+
+from bunking.bunking_validator import ValidationStatistics
+
+
+def test_validation_statistics_has_parent_staff_breakdown_fields():
+    """ValidationStatistics must expose parent/staff breakdown fields with safe defaults."""
+    stats = ValidationStatistics()
+
+    # Parent breakdown — campers with parent-source requests (bunk_with or socialize_with)
+    assert stats.parent_requests == 0
+    assert stats.satisfied_parent_requests == 0
+    assert stats.parent_request_satisfaction_rate == 0.0
+    assert stats.campers_with_unsatisfied_parent_requests == 0
+
+    # Staff breakdown — campers with staff-source requests (not_bunk_with, bunking_notes, internal_notes)
+    assert stats.staff_requests == 0
+    assert stats.satisfied_staff_requests == 0
+    assert stats.staff_request_satisfaction_rate == 0.0
+    assert stats.campers_with_unsatisfied_staff_requests == 0

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -897,3 +897,36 @@ def test_validator_skips_binning_for_requests_with_null_source():
     assert stats.staff_requests == 0
     assert stats.campers_with_unsatisfied_parent_requests == 0
     assert stats.campers_with_unsatisfied_staff_requests == 0
+
+
+def test_validator_skips_binning_for_legacy_notes_source_value():
+    """The bunk_requests schema permits a legacy source="notes" value not present
+    in the RequestSource enum. Such rows count toward total_requests but fall
+    through both parent and staff bins. Pins the documented behavior."""
+    session = _mock_session()
+    persons = [_mock_person("20001"), _mock_person("20002")]
+    bunks = [_mock_bunk("30001")]
+    assignments = [
+        _mock_assignment("20001", "30001"),
+        _mock_assignment("20002", "30001"),
+    ]
+    requests = [
+        _mock_request("20001", "20002", "bunk_with", "notes"),
+    ]
+
+    validator = BunkingValidator()
+    result = validator.validate_bunking(
+        session=session,
+        bunks=bunks,
+        assignments=assignments,
+        persons=persons,
+        requests=requests,
+    )
+    stats = result.statistics
+
+    assert stats.total_requests == 1
+    assert stats.satisfied_requests == 1
+    assert stats.parent_requests == 0
+    assert stats.staff_requests == 0
+    assert stats.campers_with_unsatisfied_parent_requests == 0
+    assert stats.campers_with_unsatisfied_staff_requests == 0


### PR DESCRIPTION
## Summary

Stage 1 of a four-stage refactor introducing parent-vs-staff request taxonomy throughout Kindred. Backend-only — no UI changes.

- **Adds parent/staff breakdown stats** to \`ValidationStatistics\`: \`parent_requests\`, \`satisfied_parent_requests\`, \`parent_request_satisfaction_rate\`, \`campers_with_unsatisfied_parent_requests\` and the staff_* mirror set. Populated via the existing \`RequestSource\` enum (\`FAMILY\` = bunk_with + socialize_with; \`STAFF\` = not_bunk_with + bunking_notes + internal_notes).
- **Fixes priority_calculator gap**: \`socialize_with\` now sole-promotes to priority 4 when no parent \`bunk_with\` text exists for the camper, regardless of staff notes. Previously any other request (including staff internal_notes) suppressed the promotion.
- **Fixes deduplicator gap**: when a parent submits an age preference both as bunk_with prose AND a socialize_with checkbox tick, the bunk_with-derived request now wins parent-vs-parent dedupe. Previously the deterministic checkbox confidence (1.0) beat the AI-parsed bunk_with confidence (~0.92), hiding the parent's prose intent.

## Out of scope (deferred to later stages)

- The legacy \`explicit_csv_fields\` set in \`bunking_validator.py\` still misclassifies sources (lumps \`not_bunk_with\`, \`bunking_notes\`, \`internal_notes\` into a 'parent' bucket). Stage 1 leaves it intact for UI backwards compatibility — Stage 2 retires it once the frontend reads the new \`parent_*\` / \`staff_*\` fields.
- Frontend \`BunkRequestProvider\`, graph \`satisfaction_status\`, and ScenarioComparisonPage's mislabeled 'Parent Requests' badge — Stage 2.
- Pre-check / post-validate / camper-modal source breakouts — Stage 3.
- Solver weight rebalancing + \"every camper gets one parent request\" rule — Stage 4.

## Notes for reviewers

- **\`campers_with_unsatisfied_parent_requests\` semantics**: counts campers with zero satisfied parent requests (not campers with any unsatisfied parent request). Mirrors the pre-existing \`campers_with_unsatisfied_explicit_requests\` field; deliberate alignment with Stage 4's minimum-one-parent-satisfied rule.
- **Multi-bunk_with regression guard test** in \`test_priority_calculator.py\` is intentional — protects against a future \`any\` → \`all\` rewrite of the suppression check.
- **Source comparison uses \`.value\`**: \`request.source == RequestSource.FAMILY.value\` rather than enum-instance comparison because production stores \`source\` as \`str\`. Plain \`Enum\` (not \`StrEnum\`) means enum-instance comparison would always fail.

## Manual validation (dev/preview)

**This PR ships no UI changes.** The new \`parent_*\` and \`staff_*\` fields are populated by the validator but no consumer renders them yet. Validation focuses on confirming the new data is correct without breaking existing surfaces.

1. **No UI regressions** — load the bunking board and scenario-compare page in dev. The orange triangle / 'Parent Requests' stat / camper modal request lists should look identical to before this PR. (Anything visibly different is a bug.)
2. **Pipeline still processes requests cleanly** — trigger \`POST /api/custom/sync/process-requests?session=0&force=true\` and confirm no errors in PocketBase or API logs.
3. **New stats are populated** — query the validation API directly:
   \`\`\`bash
   curl -s 'http://127.0.0.1:8000/api/scenarios/compare?left=campminder&right=<scenario_id>' \\
     | jq '.left.statistics | {explicit_csv_requests, parent_requests, staff_requests, satisfied_parent_requests, satisfied_staff_requests}'
   \`\`\`
   Expected: \`parent_requests + staff_requests\` ≤ \`total_requests\` (some requests filter out as invalid statuses); \`explicit_csv_*\` values unchanged from pre-PR baseline.
4. **socialize_with sole-promote** — pick a camper known to have ONLY a socialize_with checkbox + a staff internal_notes (no bunk_with prose). Their socialize_with row in \`bunk_requests\` should now have \`priority=4\` (was 1 if anything else existed).
5. **Parent age_pref dedupe winner** — pick a camper who submitted both bunk_with prose with age preference language AND ticked the socialize_with checkbox. Confirm the kept request after dedupe has \`source_field='bunk_with'\` (was \`'socialize_with'\` before this PR).

## Test plan

- [x] 30 validator tests pass (27 pre-existing + 3 new: parent/staff fields exist with defaults, parent/staff binning, source=None fall-through, parent-unsatisfied + staff-satisfied)
- [x] 21 priority_calculator tests pass (18 pre-existing + 3 new: socialize_with sole-promote with staff noise, low-priority when bunk_with exists, multi-bunk_with regression guard)
- [x] 28 deduplicator tests pass (24 pre-existing + 4 new: bunk_with beats socialize_with, list-order independence, staff still wins over family, confidence still tiebreaks when neither is bunk_with)
- [x] Full Python suite: 3655 passed, 14 skipped (pre-existing skips for tests requiring a running PocketBase)
- [x] Pre-push hooks all green: ruff-check, go-build, shellcheck, mypy, pb-js-lint, type-check
- [ ] Manual validation per the section above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tracks parent/family vs. staff requests separately with satisfaction rates and counts of campers with unsatisfied requests.

* **Improvements**
  * Deduplication now favors bunk-with pairings when choosing a primary request.
  * Age-preference prioritization now respects parent bunk-with inputs when promoting socialize-with requests.
  * Request records now carry a source field used during validation.

* **Tests**
  * Added tests covering source-specific tracking, dedupe, and priority logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->