### PR TITLE
feat(graph): social graph polish — SVG gender icons, edge colors, compound layout fixes

### DIFF
--- a/api/routers/social_graph.py
+++ b/api/routers/social_graph.py
@@ -214,6 +214,7 @@ async def get_session_social_graph(
                         reciprocal=graph.has_edge(target, source),
                         confidence=data.get("confidence"),
                         priority=data.get("priority"),
+                        request_type=data.get("request_type"),
                         metadata=data.get("metadata", {}),
                     )
                 )
@@ -487,6 +488,7 @@ async def get_bunk_social_graph(
                         reciprocal=is_reciprocal,
                         confidence=data.get("confidence") if primary_type == "request" else None,
                         priority=data.get("priority") if primary_type == "request" else None,
+                        request_type=data.get("request_type") if primary_type == "request" else None,
                     )
                 )
 
@@ -533,6 +535,7 @@ async def get_bunk_social_graph(
                         reciprocal=is_reciprocal,
                         confidence=data.get("confidence"),
                         priority=data.get("priority"),
+                        request_type=data.get("request_type"),
                     )
                 )
 
@@ -711,6 +714,7 @@ async def get_person_ego_network(
                     reciprocal=ego_graph.has_edge(target, source),
                     confidence=data.get("confidence"),
                     priority=data.get("priority"),
+                    request_type=data.get("request_type"),
                 )
             )
 

--- a/api/schemas/social_graph.py
+++ b/api/schemas/social_graph.py
@@ -35,6 +35,7 @@ class SocialGraphEdge(BaseModel):
     reciprocal: bool = False
     confidence: float | None = None  # AI confidence score for request edges
     priority: int | None = None  # Priority level for request edges
+    request_type: str | None = None  # 'bunk_with' | 'not_bunk_with' for type='request' edges
     metadata: dict[str, Any] = {}  # Additional edge metadata (e.g., location for classmate edges)
 
 

--- a/bunking/graph/optimized_graph_builder.py
+++ b/bunking/graph/optimized_graph_builder.py
@@ -148,9 +148,16 @@ class OptimizedSocialGraphBuilder(SocialGraphBuilder):
         self.graph.add_nodes_from(node_data)
         logger.debug(f"Added {len(node_data)} nodes to graph")
 
-        # Prepare batch edge data
+        # Prepare batch edge data.
+        #
+        # We intentionally do NOT collapse same-type mutuals into a single
+        # edge with reciprocal=True. Cytoscape renders two opposite-direction
+        # edges as two separate curves (one per direction), which makes per-
+        # direction state visually obvious — e.g. when A requests B but B
+        # requests _not_ with A, the asymmetry shows as two distinct curves.
+        # Collapsing would force a double-headed arrow on a single line that
+        # can't represent that asymmetry.
         edge_data = []
-        processed_pairs = set()  # Track processed pairs to avoid duplicates
 
         # Process all requests (using requestee_id field for target person)
         for person_id, person_requests in requests_by_person.items():
@@ -163,16 +170,9 @@ class OptimizedSocialGraphBuilder(SocialGraphBuilder):
                 if requestee not in self.graph:
                     continue
 
-                # Create edge key for deduplication
-                edge_key = (min(person_id, requestee), max(person_id, requestee))
-
-                # Skip if we've already processed this pair
-                if edge_key in processed_pairs and request.request_type != "not_bunk_with":
-                    continue
-
-                processed_pairs.add(edge_key)
-
-                # Check for reciprocal request
+                # Reciprocal stays as metadata (not used to dedup any more).
+                # Treated as same-type mutual: A → B exists with the same
+                # request_type as the reverse B → A.
                 reciprocal = any(
                     getattr(r, "requester_id", None) == requestee
                     and getattr(r, "requestee_id", None) == person_id

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -364,7 +364,9 @@ export default function SessionView() {
         {/* Friends Tab - preserves group selection state */}
         <Activity mode={activeTab === 'friends' ? 'visible' : 'hidden'}>
           {selectedSession && !isNaN(parseInt(selectedSession, 10)) ? (
-            <FriendGroupsView sessionCmId={parseInt(selectedSession, 10)} />
+            <BunkRequestProvider sessionCmId={parseInt(selectedSession, 10)}>
+              <FriendGroupsView sessionCmId={parseInt(selectedSession, 10)} />
+            </BunkRequestProvider>
           ) : (
             <div className="text-muted-foreground text-center">Loading session data...</div>
           )}

--- a/frontend/src/components/SocialNetworkGraph.test.ts
+++ b/frontend/src/components/SocialNetworkGraph.test.ts
@@ -14,6 +14,25 @@ describe('SocialNetworkGraph safety guards', () => {
     expect(source).toContain('cancelled = true')
   })
 
+  it('terminates the layout worker in the init-effect cleanup so each rebuild gets a fresh PRNG', () => {
+    // fcose with `randomize: true` is sensitive to the JS engine's Math.random
+    // state. The worker is long-lived (`layoutWorkerRef.current ??= new Worker(...)`)
+    // so back-to-back layouts (e.g. switching scenarios after a prod load) reuse
+    // a worker whose PRNG has already been advanced by the prior fcose run. On
+    // some seeds this collapses the second layout to a near-line — fixed only
+    // by a page refresh, which spins up a fresh worker.
+    //
+    // The init effect's cleanup must therefore terminate the worker and null
+    // the ref, so the next runLayout creates a brand-new worker (and a fresh
+    // PRNG state) for each graphData change.
+    const cleanupBlock = source.match(
+      /return\s*\(\s*\)\s*=>\s*\{[\s\S]*?cleanupCytoscape\([\s\S]*?\}/
+    )
+    expect(cleanupBlock).not.toBeNull()
+    expect(cleanupBlock?.[0]).toMatch(/layoutWorkerRef\.current\?\.\s*terminate\(\)/)
+    expect(cleanupBlock?.[0]).toMatch(/layoutWorkerRef\.current\s*=\s*null/)
+  })
+
   it('restores bubbles after layout completes when showBubbles is enabled', () => {
     // When the graph rebuilds (data/viewMode change) and showBubbles is on,
     // onLayoutComplete must redraw bubbles on the new Cytoscape instance.

--- a/frontend/src/components/SocialNetworkGraph.tsx
+++ b/frontend/src/components/SocialNetworkGraph.tsx
@@ -62,6 +62,7 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
   const bubblesetsRef = useRef<unknown | null>(null)
   const pathsRef = useRef<SVGElement[]>([])
   const poppersRef = useRef<PopperRef[]>([])
+  const poppersListenerRef = useRef<((evt?: unknown) => void) | null>(null)
   const layoutWorkerRef = useRef<Worker | null>(null)
   // First-run guard for the resize-on-expand effect: the init effect's
   // onLayoutComplete already calls cy.resize() + cy.fit(), so the
@@ -75,7 +76,10 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
   useYear() // Ensure year context is available
 
   // Create refs object for bubble rendering - memoized to avoid recreation on every render
-  const bubbleRefs = useMemo(() => ({ bubblesetsRef, pathsRef, poppersRef, containerRef }), [])
+  const bubbleRefs = useMemo(
+    () => ({ bubblesetsRef, pathsRef, poppersRef, containerRef, poppersListenerRef }),
+    []
+  )
 
   const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null)
   const [showLabels, setShowLabels] = useState(true)
@@ -333,10 +337,8 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
       | ((event: MessageEvent<LayoutWorkerOutput & { token?: number }>) => void)
       | null = null
 
-    // Start staged addition
     void addAllElements().then(() => {
       if (cancelled || !cyRef.current || cyRef.current !== cy || cy.destroyed()) return
-      // Run layout after all elements are added
       runLayout()
     })
 
@@ -408,14 +410,16 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
       cy.resize()
       cy.fit(undefined, 50)
     }
-    const r1 = requestAnimationFrame(() => {
-      const r2 = requestAnimationFrame(() => {
-        const r3 = requestAnimationFrame(fitNow)
-        rafIds.push(r3)
+    const rafIds: number[] = []
+    rafIds.push(
+      requestAnimationFrame(() => {
+        rafIds.push(
+          requestAnimationFrame(() => {
+            rafIds.push(requestAnimationFrame(fitNow))
+          })
+        )
       })
-      rafIds.push(r2)
-    })
-    const rafIds: number[] = [r1]
+    )
 
     return () => {
       cancelled = true
@@ -490,16 +494,6 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
     }
   }, [showLabels])
 
-  // Cleanup worker on unmount
-  useEffect(() => {
-    return () => {
-      if (layoutWorkerRef.current) {
-        layoutWorkerRef.current.terminate()
-        layoutWorkerRef.current = null
-      }
-    }
-  }, [])
-
   const handleZoomIn = () => {
     cyRef.current?.zoom(cyRef.current.zoom() * ZOOM_SETTINGS.inMultiplier)
   }
@@ -523,13 +517,7 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
 
   const toggleLabels = () => {
     setShowLabels(!showLabels)
-    if (cyRef.current) {
-      cyRef.current
-        .style()
-        .selector('node')
-        .style('label', !showLabels ? 'data(label)' : '')
-        .update()
-    }
+    // The useEffect on [showLabels] handles the cy.style update.
   }
 
   return (

--- a/frontend/src/components/SocialNetworkGraph.tsx
+++ b/frontend/src/components/SocialNetworkGraph.tsx
@@ -319,8 +319,6 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
         const layout = cy.layout(layoutOpts as cytoscape.LayoutOptions)
         layoutRef.current = layout
         layout.on('layoutstop', () => {
-          // Match the worker path: install handlers after layout completes
-          // so the heavy zoom listener doesn't fire mid-fit.
           setupGraphEventHandlers(cy, {
             onNodeSelect: (nodeId) => setSelectedNodeId(nodeId),
             onClearSelection: () => setSelectedNodeId(null),
@@ -354,6 +352,12 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
         layoutWorkerRef.current.removeEventListener('message', pendingWorkerListener)
         pendingWorkerListener = null
       }
+      // Tear down the worker between layout jobs so each rebuild starts with
+      // fresh fcose state. The worker module persists otherwise, and on this
+      // codebase that has historically caused the second layout to crash
+      // ("Cannot read properties of undefined") in fcose internals.
+      layoutWorkerRef.current?.terminate()
+      layoutWorkerRef.current = null
       cleanupCytoscape(cyRef, layoutRef, bubblesetsRef, poppersRef)
     }
     // showBubbles intentionally excluded: toggling bubbles is handled by the

--- a/frontend/src/components/SocialNetworkGraph.tsx
+++ b/frontend/src/components/SocialNetworkGraph.tsx
@@ -24,10 +24,10 @@ import {
   createGraphElements,
   prepareWorkerInput,
   setupGraphEventHandlers,
-  getLayoutOptions,
+  getFcoseOptions,
   type PopperRef,
 } from './graph'
-import { batchElements, cleanupPoppers, cleanupCytoscape } from '../hooks/graph'
+import { cleanupPoppers, cleanupCytoscape } from '../hooks/graph'
 
 // Register extensions only once (survives HMR reloads)
 // Use a symbol on globalThis to track registration across module reloads
@@ -63,12 +63,11 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
   const pathsRef = useRef<SVGElement[]>([])
   const poppersRef = useRef<PopperRef[]>([])
   const layoutWorkerRef = useRef<Worker | null>(null)
-  // First-run guards: the init effect handles initial fit + bubble draw, so
-  // the resize-on-expand and bubble-toggle effects must skip their first run
-  // to avoid duplicating that work (which causes the graph to visibly settle
-  // into a new position shortly after labels appear).
+  // First-run guard for the resize-on-expand effect: the init effect's
+  // onLayoutComplete already calls cy.resize() + cy.fit(), so the
+  // expand/collapse effect must skip its first run to avoid re-fitting
+  // 200ms later against a possibly-different container size.
   const hasMountedExpandRef = useRef(false)
-  const hasMountedBubblesRef = useRef(false)
   /** Monotonically-increasing token issued per layout job.
    *  The worker echoes it back; stale responses (old token ≠ current) are dropped
    *  before they can call cy.batch() on a destroyed instance. */
@@ -122,10 +121,12 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
     const targetContainer = containerRef.current
     if (!targetContainer || !graphData) return
 
-    // Wait for bunk names to load before rendering
-    if (!bunksData && graphData.nodes.some((n) => n.bunk_cm_id)) {
-      return
-    }
+    // Note: we no longer wait for bunksData here. Parent (bunk) compound nodes
+    // are created with placeholder labels (`Bunk {id}`) and patched in a
+    // separate effect once bunksData arrives. This avoids a full graph
+    // rebuild + worker re-run when bunk names finish loading after the
+    // graph data — a major source of stale-token spinner stalls under
+    // StrictMode (where each effect already double-invokes).
 
     // Destroy existing instance when switching views
     if (cyRef.current) {
@@ -159,35 +160,22 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
       SHOW_EDGES
     )
 
-    // Staged rendering for smoother loading
-    const stageElements = async (
-      elements: cytoscape.ElementDefinition[],
-      batchSize: number = 50
-    ) => {
-      const batches = batchElements(elements, batchSize)
-      for (const batch of batches) {
-        await new Promise<void>((resolve) => {
-          requestAnimationFrame(() => {
-            cy.add(batch)
-            resolve()
-          })
-        })
-      }
-    }
-
-    // Add elements in stages
-    const addElementsStaged = async () => {
-      // Add parent (bunk) nodes - required for compound layout grouping
-      await stageElements(parentNodes as cytoscape.ElementDefinition[], 20)
-
-      // Add child (camper) nodes
-      await stageElements(nodes as cytoscape.ElementDefinition[], 30)
-
-      // Apply edge visibility before adding edges
-      updateEdgeVisibility(cy, SHOW_EDGES)
-
-      // Add edges last in larger batches
-      await stageElements(edges as cytoscape.ElementDefinition[], 50)
+    // Single-shot batched add. The previous RAF-chunked staging approach added
+    // ~500-800ms of pre-layout overhead (one RAF per 20-50 elements × N batches)
+    // and forced cytoscape to re-run style application on every cy.add() call.
+    // cy.batch() suppresses notifications/restyle until the end so a bulk add
+    // is dramatically faster than incremental adds.
+    const addAllElements = async () => {
+      cy.batch(() => {
+        // Order matters: parent compound nodes before children, edges last.
+        cy.add(parentNodes as cytoscape.ElementDefinition[])
+        cy.add(nodes as cytoscape.ElementDefinition[])
+        updateEdgeVisibility(cy, SHOW_EDGES)
+        cy.add(edges as cytoscape.ElementDefinition[])
+      })
+      // Yield once so React can paint a "Computing layout..." state before
+      // the worker blocks the worker thread.
+      await new Promise<void>((r) => requestAnimationFrame(() => r()))
     }
 
     const runLayout = () => {
@@ -236,21 +224,42 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
         // message arrives, the stale token prevents cy.batch() from running
         // against a destroyed instance (avoiding the endBatch → null.notify crash).
         layoutTokenRef.current = makeLayoutToken()
+        // Capture our token in closure so we react only to OUR reply. The
+        // worker is shared/long-lived across effect runs and fires every
+        // response to ALL attached listeners; without this, an older listener
+        // would inspect a newer listener's response (or vice versa), see the
+        // wrong token, and detach itself — leaving no handler when the right
+        // response finally arrives, which is what was stranding the spinner.
+        const myToken = layoutTokenRef.current
 
         // Handle worker response
         const handleMessage = (event: MessageEvent<LayoutWorkerOutput & { token?: number }>) => {
           const { type, positions, error } = event.data
           const messageToken = event.data.token
 
-          // Stale-guard: drop responses for a cy that has been replaced. Without
-          // this, late worker messages call cy.batch() on a destroyed instance
-          // (endBatch → null.notify crash) — see layoutWorkerGuards.ts.
-          if (isStaleLayoutMessage(messageToken, layoutTokenRef.current)) {
-            worker.removeEventListener('message', handleMessage)
+          // Not our reply — another listener will handle it. Do NOT detach.
+          if (messageToken !== myToken) return
+
+          // It's our reply — detach now whatever happens next.
+          worker.removeEventListener('message', handleMessage)
+
+          // Our reply, but a newer layout job was issued before we came back.
+          // Don't overwrite the newer state; the newer handler will clear the
+          // spinner.
+          if (isStaleLayoutMessage(myToken, layoutTokenRef.current)) {
+            console.log(
+              `[SocialNetworkGraph] our reply (token=${myToken}) superseded, current=${layoutTokenRef.current}`
+            )
             return
           }
           if (cy.destroyed()) {
-            worker.removeEventListener('message', handleMessage)
+            // Spinner safety net: cy was torn down between postMessage and reply
+            // (StrictMode double-invoke or rapid effect re-runs). Clear the overlay
+            // so the user isn't stuck on "Computing layout..." forever.
+            console.log(
+              `[SocialNetworkGraph] worker response arrived for destroyed cy (token=${messageToken}); clearing spinner`
+            )
+            setIsComputingLayout(false)
             return
           }
 
@@ -270,49 +279,70 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
             // the resize effect later fires (e.g. on first checkbox toggle).
             cy.resize()
             cy.fit(undefined, 50)
-            // Adjust node-label positions synchronously after fit so labels are
-            // at their final positions on first paint (no visible settle).
-            adjustLabelPositions(cy)
+            // Adjust node-label positions synchronously after fit. Wrapped in a
+            // batch so per-node text-margin-y mutations don't each trigger an
+            // individual style recompute.
+            cy.batch(() => {
+              adjustLabelPositions(cy)
+            })
+            // Install graph event handlers AFTER the initial fit. The zoom
+            // handler iterates every node and walks neighborhoods on each
+            // event; if installed earlier, fit()'s zoom emission triggers it
+            // mid-load and stacks on top of the post-layout work.
+            setupGraphEventHandlers(cy, {
+              onNodeSelect: (nodeId) => setSelectedNodeId(nodeId),
+              onClearSelection: () => setSelectedNodeId(null),
+            })
             onLayoutComplete()
           } else if (type === 'error') {
             console.error('[SocialNetworkGraph] Worker error:', error)
             runFallbackLayout()
           }
-
-          // Remove listener after handling
-          worker.removeEventListener('message', handleMessage)
         }
 
         worker.addEventListener('message', handleMessage)
+        // Stash the listener so the effect cleanup can detach it if the
+        // component unmounts (or the effect re-runs) before our reply arrives.
+        // Otherwise the shared worker keeps a closure ref to a dead cy.
+        pendingWorkerListener = handleMessage
         worker.postMessage({ ...workerInput, token: layoutTokenRef.current })
       } catch (error) {
         console.warn('[SocialNetworkGraph] WebWorker failed, using main thread:', error)
         runFallbackLayout()
       }
 
-      // Fallback layout on main thread (if worker fails)
+      // Fallback layout on main thread (if worker fails). Uses the same
+      // single-source-of-truth options as the worker path so layouts match.
       function runFallbackLayout() {
         const hasCompound = parentNodes.length > 0
-        const layoutOpts = getLayoutOptions({ hasCompoundNodes: hasCompound })
+        const layoutOpts = getFcoseOptions({ hasCompoundNodes: hasCompound })
         const layout = cy.layout(layoutOpts as cytoscape.LayoutOptions)
         layoutRef.current = layout
-        layout.on('layoutstop', onLayoutComplete)
+        layout.on('layoutstop', () => {
+          // Match the worker path: install handlers after layout completes
+          // so the heavy zoom listener doesn't fire mid-fit.
+          setupGraphEventHandlers(cy, {
+            onNodeSelect: (nodeId) => setSelectedNodeId(nodeId),
+            onClearSelection: () => setSelectedNodeId(null),
+          })
+          onLayoutComplete()
+        })
         layout.run()
       }
-
-      // Setup event handlers using extracted utility
-      setupGraphEventHandlers(cy, {
-        onNodeSelect: (nodeId) => setSelectedNodeId(nodeId),
-        onClearSelection: () => setSelectedNodeId(null),
-      })
     } // End of runLayout function
 
     // Cancellation guard: prevent stale async work from applying to a newer graph
     // instance after this effect is cleaned up (e.g., deps change mid-build).
     let cancelled = false
+    // Tracks the worker message listener for THIS effect's pending layout job.
+    // Detached on cleanup so the long-lived shared worker doesn't keep a
+    // closure reference to a destroyed cy.
+    let pendingWorkerListener:
+      | ((event: MessageEvent<LayoutWorkerOutput & { token?: number }>) => void)
+      | null = null
 
     // Start staged addition
-    void addElementsStaged().then(() => {
+    void addAllElements().then(() => {
       if (cancelled || !cyRef.current || cyRef.current !== cy || cy.destroyed()) return
       // Run layout after all elements are added
       runLayout()
@@ -320,14 +350,41 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
 
     return () => {
       cancelled = true
+      if (pendingWorkerListener && layoutWorkerRef.current) {
+        layoutWorkerRef.current.removeEventListener('message', pendingWorkerListener)
+        pendingWorkerListener = null
+      }
       cleanupCytoscape(cyRef, layoutRef, bubblesetsRef, poppersRef)
     }
     // showBubbles intentionally excluded: toggling bubbles is handled by the
     // resize/bubble effect below, avoiding a full graph rebuild + worker restart.
     // The closure reads showBubbles at effect-creation time to restore bubbles
     // after graph rebuilds triggered by other deps.
+    //
+    // bunksData intentionally excluded: it only supplies display names for
+    // parent (bunk) compound nodes. A separate effect patches those labels
+    // in place once bunksData arrives, avoiding a full graph rebuild +
+    // worker re-run that previously caused stale-token spinner stalls.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [graphData, bunksData, showLabels, bubbleRefs])
+  }, [graphData, showLabels, bubbleRefs])
+
+  // Patch parent (bunk) compound node labels when bunksData arrives, without
+  // tearing down the cytoscape instance or restarting the layout. Parent nodes
+  // are initially created with `Bunk {id}` placeholders in createGraphElements;
+  // here we replace those with real bunk names.
+  useEffect(() => {
+    const cy = cyRef.current
+    if (!cy || cy.destroyed() || !bunksData) return
+    cy.batch(() => {
+      cy.nodes()
+        .filter((n) => n.data('isBunkParent'))
+        .forEach((node) => {
+          const bunkId = node.data('bunk_cm_id')
+          const name = bunksData[bunkId]
+          if (name) node.data('label', name)
+        })
+    })
+  }, [bunksData])
 
   // Handle resize when expanding/collapsing - container stays the same, just resizes
   useEffect(() => {
@@ -354,19 +411,18 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
     return () => clearTimeout(timeoutId)
   }, [isExpanded])
 
-  // Bubble draw/clear when toggling Bunks/Units checkboxes.
-  // Skip first run on initial mount — the init effect's onLayoutComplete
-  // (500ms after the worker returns) handles the initial draw. Without this
-  // guard, bubbles get drawn at t=200ms then cleared+redrawn at t=550ms,
-  // which is visible as labels jumping during initial render.
+  // Bubble draw/clear when toggling Bunks/Units checkboxes OR when bunksData
+  // first arrives. The init effect's onLayoutComplete only draws bubbles if
+  // bunksData was already present at layout time; when bunksData arrives
+  // after layout (the common case now that the init effect no longer waits
+  // on it), this effect is the authority for drawing the initial bubbles.
+  // drawBunkBubbles is idempotent (clearBubbles runs first), so even if init
+  // already drew, the worst case is one redraw 200ms later — preferable to
+  // the previous regression where bubbles silently never appeared until a
+  // checkbox toggle.
   useEffect(() => {
     const cy = cyRef.current
     if (!cy || cy.destroyed() || !bunksData) return
-
-    if (!hasMountedBubblesRef.current) {
-      hasMountedBubblesRef.current = true
-      return
-    }
 
     const timeoutId = setTimeout(() => {
       if (!cy.destroyed()) {

--- a/frontend/src/components/SocialNetworkGraph.tsx
+++ b/frontend/src/components/SocialNetworkGraph.tsx
@@ -247,18 +247,12 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
           // Don't overwrite the newer state; the newer handler will clear the
           // spinner.
           if (isStaleLayoutMessage(myToken, layoutTokenRef.current)) {
-            console.log(
-              `[SocialNetworkGraph] our reply (token=${myToken}) superseded, current=${layoutTokenRef.current}`
-            )
             return
           }
           if (cy.destroyed()) {
             // Spinner safety net: cy was torn down between postMessage and reply
             // (StrictMode double-invoke or rapid effect re-runs). Clear the overlay
             // so the user isn't stuck on "Computing layout..." forever.
-            console.log(
-              `[SocialNetworkGraph] worker response arrived for destroyed cy (token=${messageToken}); clearing spinner`
-            )
             setIsComputingLayout(false)
             return
           }

--- a/frontend/src/components/SocialNetworkGraph.tsx
+++ b/frontend/src/components/SocialNetworkGraph.tsx
@@ -390,30 +390,75 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
     })
   }, [bunksData])
 
-  // Handle resize when expanding/collapsing - container stays the same, just resizes
+  // Resize+fit the graph whenever the user toggles fullscreen. The init
+  // effect's worker handler already does the initial resize+fit on first
+  // load, so we skip the very first run of THIS effect (which fires on
+  // mount alongside the init effect) — but every subsequent isExpanded
+  // change runs a fresh resize+fit chained across three animation frames
+  // so React's commit, the browser's CSS layout pass, and the paint all
+  // settle before cytoscape reads the new container dimensions. Without
+  // the multi-frame chain, toggling fullscreen immediately after initial
+  // load could measure the still-transitioning container and leave the
+  // graph laid out for the pre-fullscreen size (small, upper-left).
   useEffect(() => {
-    const cy = cyRef.current
-    if (!cy || cy.destroyed()) return
-
-    // Skip first run on initial mount — the init effect's worker handler
-    // already does cy.resize() + cy.fit(). Without this guard, we re-fit
-    // 200ms later against a possibly-different container size and the graph
-    // visibly "settles" into a new spot after labels render.
     if (!hasMountedExpandRef.current) {
       hasMountedExpandRef.current = true
       return
     }
 
-    // Longer delay to allow CSS layout to stabilize in expanded mode
-    const timeoutId = setTimeout(() => {
-      if (!cy.destroyed()) {
+    let cancelled = false
+    const fitNow = () => {
+      if (cancelled) return
+      const cy = cyRef.current
+      if (!cy || cy.destroyed()) return
+      cy.resize()
+      cy.fit(undefined, 50)
+    }
+    const r1 = requestAnimationFrame(() => {
+      const r2 = requestAnimationFrame(() => {
+        const r3 = requestAnimationFrame(fitNow)
+        rafIds.push(r3)
+      })
+      rafIds.push(r2)
+    })
+    const rafIds: number[] = [r1]
+
+    return () => {
+      cancelled = true
+      rafIds.forEach(cancelAnimationFrame)
+    }
+  }, [isExpanded])
+
+  // Separately, observe the container for non-toggle reflows (window
+  // resize, sidebar open/close, devtools panel) so the graph stays fitted
+  // even when isExpanded hasn't changed. Reads cyRef inline so a graph
+  // rebuild swap doesn't leave a stale closure.
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    let rafId = 0
+    let isInitialObservation = true
+    const observer = new ResizeObserver(() => {
+      if (isInitialObservation) {
+        // Drop the initial observation (it fires synchronously when we
+        // attach with the current size — that's not a "change").
+        isInitialObservation = false
+        return
+      }
+      cancelAnimationFrame(rafId)
+      rafId = requestAnimationFrame(() => {
+        const cy = cyRef.current
+        if (!cy || cy.destroyed()) return
         cy.resize()
         cy.fit(undefined, 50)
-      }
-    }, 200)
-
-    return () => clearTimeout(timeoutId)
-  }, [isExpanded])
+      })
+    })
+    observer.observe(container)
+    return () => {
+      cancelAnimationFrame(rafId)
+      observer.disconnect()
+    }
+  }, [])
 
   // Bubble draw/clear when toggling Bunks/Units checkboxes OR when bunksData
   // first arrives. The init effect's onLayoutComplete only draws bubbles if
@@ -470,7 +515,12 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
   }
 
   const handleFit = () => {
-    cyRef.current?.fit()
+    // Match the 50px padding the auto-fit (initial load + fullscreen
+    // toggle) uses. Calling cy.fit() with no padding lets nodes hug the
+    // container edges, where labels and bubbles get clipped under the
+    // header divider, and the legend / controls overlap the corners of
+    // the graph area.
+    cyRef.current?.fit(undefined, 50)
   }
 
   const handleExpandToggle = () => {

--- a/frontend/src/components/graph/EdgeFilters.test.tsx
+++ b/frontend/src/components/graph/EdgeFilters.test.tsx
@@ -13,7 +13,6 @@ describe('getEdgeLabel utility', () => {
   it('maps known edge types to display labels', () => {
     expect(getEdgeLabel('request')).toBe('Requests')
     expect(getEdgeLabel('sibling')).toBe('Siblings')
-    expect(getEdgeLabel('historical')).toBe('Historical')
   })
 
   it('falls back to the raw type for unknown edge types', () => {

--- a/frontend/src/components/graph/EdgeFilters.test.tsx
+++ b/frontend/src/components/graph/EdgeFilters.test.tsx
@@ -14,7 +14,6 @@ describe('getEdgeLabel utility', () => {
     expect(getEdgeLabel('request')).toBe('Requests')
     expect(getEdgeLabel('sibling')).toBe('Siblings')
     expect(getEdgeLabel('historical')).toBe('Historical')
-    expect(getEdgeLabel('school')).toBe('Classmates')
   })
 
   it('falls back to the raw type for unknown edge types', () => {

--- a/frontend/src/components/graph/GraphLegend.test.tsx
+++ b/frontend/src/components/graph/GraphLegend.test.tsx
@@ -88,4 +88,15 @@ describe('GraphLegend rendering', () => {
     expect(screen.getByText('No requests')).toBeInTheDocument()
     expect(screen.getByText('0 satisfied requests')).toBeInTheDocument()
   })
+
+  it('renders a "Don\'t Bunk With" edge entry distinct from "Bunk Request"', () => {
+    render(<GraphLegend />)
+    expect(screen.getByText('Bunk Request')).toBeInTheDocument()
+    expect(screen.getByText("Don't Bunk With")).toBeInTheDocument()
+  })
+
+  it('renders a "Sibling" edge entry', () => {
+    render(<GraphLegend />)
+    expect(screen.getByText('Sibling')).toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/graph/GraphLegend.tsx
+++ b/frontend/src/components/graph/GraphLegend.tsx
@@ -21,7 +21,7 @@ export default function GraphLegend({
   existingGrades,
 }: GraphLegendProps) {
   return (
-    <div className="bg-card/95 border-border shadow-lodge-sm absolute right-4 bottom-4 space-y-2 rounded-xl border p-3 text-xs backdrop-blur-sm">
+    <div className="bg-card/95 border-border shadow-lodge-sm absolute right-4 bottom-4 z-10 space-y-2 rounded-xl border p-3 text-xs backdrop-blur-sm">
       {/* Edge Types */}
       <div>
         <div className="mb-1 font-medium">Edge Types</div>
@@ -29,6 +29,10 @@ export default function GraphLegend({
           <div className="flex items-center gap-2">
             <div className="h-0.5 w-4" style={{ backgroundColor: edgeColors['request'] }} />
             <span>Bunk Request</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="h-0.5 w-4" style={{ backgroundColor: edgeColors['not_bunk_with'] }} />
+            <span>Don't Bunk With</span>
           </div>
           <div className="flex items-center gap-2">
             <div className="h-0.5 w-4" style={{ backgroundColor: edgeColors['sibling'] }} />

--- a/frontend/src/components/graph/bubbleRenderer.test.ts
+++ b/frontend/src/components/graph/bubbleRenderer.test.ts
@@ -2,7 +2,7 @@
  * Tests for bubbleRenderer — unit/bunk label DOM construction.
  */
 import { describe, it, expect, beforeEach } from 'vitest'
-import { buildUnitLabel, getLabelParent } from './bubbleRenderer'
+import { buildUnitLabel, buildBunkLabel, getLabelParent } from './bubbleRenderer'
 
 describe('buildUnitLabel', () => {
   it('renders the unit name as text', () => {
@@ -35,6 +35,24 @@ describe('buildUnitLabel', () => {
     expect(svg?.getAttribute('stroke')).toBe('#aabbcc')
     // The label inner text wrapper should also color-match.
     expect((el.querySelector('div') as HTMLElement | null)?.style.color).toBe('rgb(170, 187, 204)')
+  })
+})
+
+describe('buildBunkLabel', () => {
+  it('renders the bunk name as text', () => {
+    const el = buildBunkLabel('B-5', '#aabbcc')
+    expect(el.textContent).toContain('B-5')
+  })
+
+  it('uses the bunk color as the background of the inner pill', () => {
+    const el = buildBunkLabel('B-5', '#aabbcc')
+    const inner = el.querySelector('div') as HTMLElement | null
+    expect(inner?.style.backgroundColor).toBe('rgb(170, 187, 204)')
+  })
+
+  it('applies the .bunk-label-popper class to the outer wrapper', () => {
+    const el = buildBunkLabel('B-5', '#aabbcc')
+    expect(el.classList.contains('bunk-label-popper')).toBe(true)
   })
 })
 

--- a/frontend/src/components/graph/bubbleRenderer.test.ts
+++ b/frontend/src/components/graph/bubbleRenderer.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for bubbleRenderer — unit/bunk label DOM construction.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { buildUnitLabel, getLabelParent } from './bubbleRenderer'
+
+describe('buildUnitLabel', () => {
+  it('renders the unit name as text', () => {
+    const el = buildUnitLabel('Galil', 'B', '#aabbcc')
+    expect(el.textContent).toContain('Galil')
+  })
+
+  it('emits an SVG icon (mars/venus) instead of unicode text for the gender marker', () => {
+    const boys = buildUnitLabel('Galil', 'B', '#aabbcc')
+    const girls = buildUnitLabel('Galil', 'G', '#aabbcc')
+
+    // Each label should contain at least one inline <svg> for the gender marker —
+    // unicode glyphs (♂ / ♀) render too thin against the unit color stroke.
+    expect(boys.querySelector('svg')).toBeTruthy()
+    expect(girls.querySelector('svg')).toBeTruthy()
+    // And the literal unicode glyphs must NOT appear.
+    expect(boys.textContent).not.toContain('♂')
+    expect(girls.textContent).not.toContain('♀')
+  })
+
+  it('marks boys vs girls icons distinctly so they are not interchangeable', () => {
+    const boys = buildUnitLabel('Galil', 'B', '#aabbcc')
+    const girls = buildUnitLabel('Galil', 'G', '#aabbcc')
+    expect(boys.querySelector('svg')?.outerHTML).not.toBe(girls.querySelector('svg')?.outerHTML)
+  })
+
+  it('uses the unit color for both text and SVG stroke', () => {
+    const el = buildUnitLabel('Galil', 'B', '#aabbcc')
+    const svg = el.querySelector('svg')
+    expect(svg?.getAttribute('stroke')).toBe('#aabbcc')
+    // The label inner text wrapper should also color-match.
+    expect((el.querySelector('div') as HTMLElement | null)?.style.color).toBe('rgb(170, 187, 204)')
+  })
+})
+
+describe('getLabelParent', () => {
+  let container: HTMLDivElement | null
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  it('returns the graph container when one is provided so labels are clipped + visible in fullscreen', () => {
+    const parent = getLabelParent({ current: container })
+    expect(parent).toBe(container)
+    expect(parent).not.toBe(document.body)
+  })
+
+  it('falls back to document.body when no container ref is provided so labels still render', () => {
+    const parent = getLabelParent({ current: null })
+    expect(parent).toBe(document.body)
+  })
+})

--- a/frontend/src/components/graph/bubbleRenderer.ts
+++ b/frontend/src/components/graph/bubbleRenderer.ts
@@ -8,10 +8,16 @@ import { createPopper } from '@popperjs/core'
 import { getUnitSideForBunk, type UnitSide } from '../../utils/unitMapping'
 import { getUnitColorForBunk, getUnitColorByName } from '../../utils/graphColorUtils'
 
-/** Display marker shown next to the unit name on the visual bubble label. */
-const SIDE_MARKER: Record<Exclude<UnitSide, null>, string> = {
-  B: '♂', // ♂
-  G: '♀', // ♀
+/** Lucide-derived path data for the gender side markers. Keeping the SVG
+ *  inline (rather than rendering React lucide-react components) avoids
+ *  spinning up a React tree just to extract markup for these DOM-based
+ *  popper labels. The unicode glyphs (♂ / ♀) we used previously rendered
+ *  too thin against the unit color stroke. */
+const SIDE_MARKER_PATHS: Record<Exclude<UnitSide, null>, string> = {
+  // Mars (♂): circle + diagonal arrow up-right
+  B: '<path d="M16 3h5v5"/><path d="M21 3l-6.75 6.75"/><circle cx="10" cy="14" r="6"/>',
+  // Venus (♀): circle + cross below
+  G: '<path d="M12 16v6"/><path d="M9 19h6"/><circle cx="12" cy="9" r="6"/>',
 }
 
 /** Shared config for bubbleset path rendering (unit and bunk bubbles) */
@@ -96,6 +102,65 @@ const UNIT_LABEL_FONT = {
 } as const
 
 /**
+ * Build the DOM for a unit label ("Galil" + ♂/♀ icon). Extracted as a
+ * pure helper so the SVG-icon swap can be unit-tested without spinning
+ * up a Cytoscape instance.
+ */
+export function buildUnitLabel(
+  unit: string,
+  side: Exclude<UnitSide, null>,
+  unitColor: string
+): HTMLElement {
+  const labelEl = document.createElement('div')
+  labelEl.className = 'unit-label-popper'
+  labelEl.style.position = 'absolute'
+
+  Object.assign(labelEl.style, {
+    backgroundColor: 'rgba(255,255,255,0.85)',
+    padding: '2px 10px',
+    borderRadius: '10px',
+    whiteSpace: 'nowrap',
+    border: `2px solid ${unitColor}`,
+    display: 'flex',
+    alignItems: 'center',
+    gap: '4px',
+  })
+
+  const innerDiv = document.createElement('div')
+  Object.assign(innerDiv.style, UNIT_LABEL_FONT)
+  innerDiv.style.color = unitColor
+  innerDiv.textContent = unit
+  labelEl.appendChild(innerDiv)
+
+  // Inline SVG so the marker paints with the same stroke color as the
+  // unit border — no font-rendering anti-aliasing thinning the glyph.
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+  svg.setAttribute('width', '14')
+  svg.setAttribute('height', '14')
+  svg.setAttribute('viewBox', '0 0 24 24')
+  svg.setAttribute('fill', 'none')
+  svg.setAttribute('stroke', unitColor)
+  svg.setAttribute('stroke-width', '2.5')
+  svg.setAttribute('stroke-linecap', 'round')
+  svg.setAttribute('stroke-linejoin', 'round')
+  svg.innerHTML = SIDE_MARKER_PATHS[side]
+  labelEl.appendChild(svg)
+
+  return labelEl
+}
+
+/**
+ * Pick the DOM parent for popper labels. Appending into the graph
+ * container (instead of document.body) lets overflow:hidden clip labels
+ * cleanly under the card header — and keeps them visible inside the
+ * fixed-positioned card in fullscreen mode, where body-level labels
+ * would be hidden behind the modal.
+ */
+export function getLabelParent(containerRef: { current: HTMLElement | null }): HTMLElement {
+  return containerRef.current ?? document.body
+}
+
+/**
  * Returns the bubbleset path style for a unit boundary bubble.
  * The fill is intentionally 'none' — the boundary is shown by stroke only
  * (#32: fillOpacity: 0 makes any fill color invisible; 'none' is explicit).
@@ -157,7 +222,11 @@ function createPopperLabel(
     }
   })
 
-  document.body.appendChild(labelEl)
+  // Append into the graph container when one is available so the label
+  // is clipped by overflow:hidden (slides cleanly under the card header)
+  // and stays visible inside the fixed-positioned card in fullscreen
+  // mode. Falls back to document.body only if the container isn't ready.
+  getLabelParent(containerRef as { current: HTMLElement | null }).appendChild(labelEl)
 
   // Create virtual element for Popper that tracks the node position
   const virtualElement = {
@@ -186,11 +255,19 @@ function createPopperLabel(
     },
   }
 
+  const boundary = containerRef.current ?? 'viewport'
   const popperInstance = createPopper(virtualElement as unknown as Element, labelEl, {
     placement: 'top',
     modifiers: [
       { name: 'offset', options: { offset: [0, offsetY] } },
-      { name: 'preventOverflow', options: { boundary: containerRef.current ?? 'viewport' } },
+      // Both flip and preventOverflow default to viewport boundary. In
+      // fullscreen the card fills nearly the whole viewport, so viewport-
+      // bound flipping would only trigger once the label crossed the
+      // viewport edge — long past the header divider. Pinning both to the
+      // graph container makes the label flip to below-the-node as soon as
+      // there's no room above, matching the non-fullscreen behavior.
+      { name: 'flip', options: { boundary, fallbackPlacements: ['bottom'] } },
+      { name: 'preventOverflow', options: { boundary, altAxis: true } },
       {
         name: 'hideOutsideContainer',
         enabled: true,
@@ -200,11 +277,16 @@ function createPopperLabel(
           if (!container) return
           const containerRect = container.getBoundingClientRect()
           const popperRect = state.elements.popper.getBoundingClientRect()
+          // Hide the moment the popper crosses any container edge — not
+          // only when fully outside. With overflow:hidden on the container
+          // a partially-outside label is already visually clipped at the
+          // boundary; making it disappear cleanly avoids the half-cut
+          // remnant peeking past the header divider in fullscreen.
           const isOutside =
-            popperRect.bottom < containerRect.top ||
-            popperRect.top > containerRect.bottom ||
-            popperRect.right < containerRect.left ||
-            popperRect.left > containerRect.right
+            popperRect.top < containerRect.top ||
+            popperRect.bottom > containerRect.bottom ||
+            popperRect.left < containerRect.left ||
+            popperRect.right > containerRect.right
           state.elements.popper.style.visibility = isOutside ? 'hidden' : 'visible'
         },
       },
@@ -417,27 +499,7 @@ export function drawBunkBubbles(
       if (nodes.length === 0) return
 
       const unitColor = getUnitColorByName(unit)
-
-      const labelEl = document.createElement('div')
-      labelEl.className = 'unit-label-popper'
-      labelEl.style.position = 'absolute'
-      labelEl.style.zIndex = '1'
-      const innerDiv = document.createElement('div')
-
-      Object.assign(labelEl.style, {
-        backgroundColor: 'rgba(255,255,255,0.85)',
-        padding: '2px 10px',
-        borderRadius: '10px',
-        whiteSpace: 'nowrap',
-        border: `2px solid ${unitColor}`,
-      })
-
-      Object.assign(innerDiv.style, UNIT_LABEL_FONT)
-      innerDiv.style.color = unitColor
-
-      innerDiv.textContent = `${unit} ${SIDE_MARKER[side]}`
-      labelEl.appendChild(innerDiv)
-
+      const labelEl = buildUnitLabel(unit, side, unitColor)
       createPopperLabel(nodes, labelEl, containerRef, poppersRef, 30)
     })
   }

--- a/frontend/src/components/graph/bubbleRenderer.ts
+++ b/frontend/src/components/graph/bubbleRenderer.ts
@@ -5,8 +5,14 @@
 import type { Core, NodeSingular } from 'cytoscape'
 import type { Instance as PopperInstance } from '@popperjs/core'
 import { createPopper } from '@popperjs/core'
-import { getUnitForBunk } from '../../utils/unitMapping'
+import { getUnitSideForBunk, type UnitSide } from '../../utils/unitMapping'
 import { getUnitColorForBunk, getUnitColorByName } from '../../utils/graphColorUtils'
+
+/** Display marker shown next to the unit name on the visual bubble label. */
+const SIDE_MARKER: Record<Exclude<UnitSide, null>, string> = {
+  B: '♂', // ♂
+  G: '♀', // ♀
+}
 
 /** Shared config for bubbleset path rendering (unit and bunk bubbles) */
 const BASE_BUBBLE_OPTIONS = {
@@ -240,7 +246,7 @@ export function drawBunkBubbles(
   // Group nodes by bunk (excluding label nodes and parent compound nodes)
   const bunkGroups: Record<number, NodeSingular[] | undefined> = {}
   cy.nodes()
-    .filter((n) => !n.data('isBunkLabel') && !n.data('isBunkParent'))
+    .filter((n) => !n.data('isBunkLabel') && !n.data('isBunkParent') && !n.data('isUnitParent'))
     .forEach((node) => {
       const bunkId = node.data('bunk_cm_id')
       if (bunkId) {
@@ -265,8 +271,16 @@ export function drawBunkBubbles(
   // deterministic color assignment (#31, #33): same bunk set → same colors.
   const allBunkNames: string[] = bunksData ? Object.values(bunksData) : []
 
-  // Collect unit grouping data (needed for both bubble paths and labels)
-  const unitGroups: Record<string, NodeSingular[]> = {}
+  // Collect unit grouping data (needed for both bubble paths and labels).
+  // Keyed by `${unit}-${side}` so each unit gets two visual bubbles — boys
+  // and girls — matching the layout split. AG and unprefixed Aleph/Bet have
+  // side=null and don't appear in any unit bubble (free-floating).
+  interface UnitSideEntry {
+    unit: string
+    side: 'B' | 'G'
+    nodes: NodeSingular[]
+  }
+  const unitGroups: Record<string, UnitSideEntry> = {}
 
   if (showUnits && bunksData) {
     cy.nodes()
@@ -276,26 +290,24 @@ export function drawBunkBubbles(
         if (!bunkId) return
         const bunkName = bunksData[bunkId]
         if (!bunkName) return
-        const unit = getUnitForBunk(bunkName)
-        if (!unit) return
-        const group = (unitGroups[unit] ??= [])
-        group.push(node)
+        const unitSide = getUnitSideForBunk(bunkName)
+        if (!unitSide?.side) return
+        const key = `${unitSide.unit}-${unitSide.side}`
+        const entry = (unitGroups[key] ??= { unit: unitSide.unit, side: unitSide.side, nodes: [] })
+        entry.nodes.push(node)
       })
   }
 
   // --- Draw order: unit bubbles FIRST (behind), then bunk bubbles ON TOP ---
 
-  // Build sorted unit list from present groups for deterministic palette (#33)
-  // Hoisted: shared by both unit-bubble drawing (step 1) and unit-label drawing (step 3)
-  const presentUnits = Object.keys(unitGroups)
-
   // 1. Add unit bubble paths first so they render behind bunk bubbles
   if (showUnits && bunksData) {
-    Object.entries(unitGroups).forEach(([unitName, nodes]) => {
+    Object.entries(unitGroups).forEach(([key, { unit, nodes }]) => {
       if (nodes.length === 0) return
 
-      // #31/#33: deterministic unit color — same unit always gets the same hue
-      const unitColor = getUnitColorByName(unitName, presentUnits)
+      // #31/#33: color depends ONLY on unit name, so Galil-B and Galil-G
+      // share Galil's hue — the side split is for layout/labeling only.
+      const unitColor = getUnitColorByName(unit)
 
       try {
         const nodeIds = nodes.map((n) => `#${n.id()}`).join(', ')
@@ -307,7 +319,7 @@ export function drawBunkBubbles(
         })
         pathsRef.current.push(path)
       } catch (error) {
-        console.error(`Error creating unit bubble for ${unitName}:`, error)
+        console.error(`Error creating unit bubble for ${key}:`, error)
       }
     })
   }
@@ -399,12 +411,12 @@ export function drawBunkBubbles(
   // --- Labels: unit labels first (higher offset), then bunk labels ---
 
   // 3. Add unit labels — solid color matching the unit bubble (#40: no gradient)
+  // One label per (unit, side): "Galil ♂" / "Galil ♀".
   if (showUnits && bunksData) {
-    Object.entries(unitGroups).forEach(([unitName, nodes]) => {
+    Object.values(unitGroups).forEach(({ unit, side, nodes }) => {
       if (nodes.length === 0) return
 
-      // #40: use the same deterministic solid color as the unit bubble, no gradient
-      const unitColor = getUnitColorByName(unitName, presentUnits)
+      const unitColor = getUnitColorByName(unit)
 
       const labelEl = document.createElement('div')
       labelEl.className = 'unit-label-popper'
@@ -412,7 +424,6 @@ export function drawBunkBubbles(
       labelEl.style.zIndex = '1'
       const innerDiv = document.createElement('div')
 
-      // Pill styling with solid unit color border
       Object.assign(labelEl.style, {
         backgroundColor: 'rgba(255,255,255,0.85)',
         padding: '2px 10px',
@@ -421,11 +432,10 @@ export function drawBunkBubbles(
         border: `2px solid ${unitColor}`,
       })
 
-      // Font + color — solid, no gradient
       Object.assign(innerDiv.style, UNIT_LABEL_FONT)
       innerDiv.style.color = unitColor
 
-      innerDiv.textContent = unitName
+      innerDiv.textContent = `${unit} ${SIDE_MARKER[side]}`
       labelEl.appendChild(innerDiv)
 
       createPopperLabel(nodes, labelEl, containerRef, poppersRef, 30)

--- a/frontend/src/components/graph/bubbleRenderer.ts
+++ b/frontend/src/components/graph/bubbleRenderer.ts
@@ -161,6 +161,31 @@ export function getLabelParent(containerRef: { current: HTMLElement | null }): H
 }
 
 /**
+ * Build the DOM for a bunk label (pill with bunk name, colored by unit).
+ * Extracted for parity with buildUnitLabel and to enable unit testing.
+ */
+export function buildBunkLabel(bunkName: string, bunkColor: string): HTMLElement {
+  const labelEl = document.createElement('div')
+  labelEl.className = 'bunk-label-popper'
+  labelEl.style.position = 'absolute'
+  labelEl.style.zIndex = '1'
+  const innerDiv = document.createElement('div')
+  Object.assign(innerDiv.style, {
+    backgroundColor: bunkColor,
+    color: 'white',
+    padding: '4px 12px',
+    borderRadius: '16px',
+    fontSize: '12px',
+    fontWeight: '600',
+    boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
+    whiteSpace: 'nowrap',
+  })
+  innerDiv.textContent = bunkName
+  labelEl.appendChild(innerDiv)
+  return labelEl
+}
+
+/**
  * Returns the bubbleset path style for a unit boundary bubble.
  * The fill is intentionally 'none' — the boundary is shown by stroke only
  * (#32: fillOpacity: 0 makes any fill color invisible; 'none' is explicit).
@@ -197,6 +222,10 @@ export interface BubbleRenderRefs {
   pathsRef: { current: SVGElement[] }
   poppersRef: { current: PopperRef[] }
   containerRef: { current: HTMLDivElement | null }
+  /** Tracks the cy `pan zoom resize` listener installed by drawBunkBubbles
+   *  so a redraw can detach the previous one before attaching a new one.
+   *  Without this, every checkbox toggle stacks another listener on cy. */
+  poppersListenerRef: { current: ((evt?: unknown) => void) | null }
 }
 
 /**
@@ -307,12 +336,23 @@ export function drawBunkBubbles(
   showUnits: boolean = false,
   showBunks: boolean = true
 ): void {
-  const { bubblesetsRef, pathsRef, poppersRef, containerRef } = refs
+  const { bubblesetsRef, pathsRef, poppersRef, containerRef, poppersListenerRef } = refs
 
   // Check if cy is valid before doing anything
   if (cy.destroyed()) {
     console.error('Cytoscape instance is not valid, cannot create bubbles')
     return
+  }
+
+  // Detach previous pan/zoom/resize listener before re-attaching below.
+  // Each call creates a new updatePoppers closure; without an off() the
+  // listeners stack on every checkbox toggle and bunksData arrival.
+  if (poppersListenerRef.current) {
+    ;(cy as unknown as { off: (events: string, handler: (evt?: unknown) => void) => void }).off(
+      'pan zoom resize',
+      poppersListenerRef.current
+    )
+    poppersListenerRef.current = null
   }
 
   // Clear any existing bubblesets
@@ -420,9 +460,7 @@ export function drawBunkBubbles(
         failed: 0,
       })
     }
-  }
-
-  if (showBunks) {
+  } else {
     Object.entries(bunkGroups).forEach(([bunkId, nodes]) => {
       if (!nodes || nodes.length === 0) return // Skip empty bunks
 
@@ -469,16 +507,12 @@ export function drawBunkBubbles(
     })
   }
 
-  // Force bubbleset to recompute paths
+  // Force bubbleset to recompute paths. updateBubbles(true) triggers its
+  // own redraw of the bubble overlay; no separate cy.forceRender() needed.
   try {
     updateBubbles(true)
   } catch (updateError) {
     console.error('Error calling bb.update(true):', updateError)
-  }
-
-  // Force Cytoscape repaint
-  if (!cy.destroyed()) {
-    cy.forceRender()
   }
 
   // Clean up existing popper instances
@@ -513,24 +547,7 @@ export function drawBunkBubbles(
       // #31/#33: bunk label uses the same deterministic unit color as its bubble
       const bunkColor = getUnitColorForBunk(bunkName, allBunkNames)
 
-      const labelEl = document.createElement('div')
-      labelEl.className = 'bunk-label-popper'
-      labelEl.style.position = 'absolute'
-      labelEl.style.zIndex = '1'
-      const innerDiv = document.createElement('div')
-      Object.assign(innerDiv.style, {
-        backgroundColor: bunkColor,
-        color: 'white',
-        padding: '4px 12px',
-        borderRadius: '16px',
-        fontSize: '12px',
-        fontWeight: '600',
-        boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
-        whiteSpace: 'nowrap',
-      })
-      innerDiv.textContent = bunkName
-      labelEl.appendChild(innerDiv)
-
+      const labelEl = buildBunkLabel(bunkName, bunkColor)
       createPopperLabel(nodes, labelEl, containerRef, poppersRef, 10)
     })
   }
@@ -543,6 +560,7 @@ export function drawBunkBubbles(
   }
 
   cy.on('pan zoom resize', updatePoppers)
+  poppersListenerRef.current = updatePoppers
 
   // Initial visibility prime: Popper.js positions elements asynchronously
   // (its first layout runs on the next animation frame), so the visibility
@@ -560,7 +578,7 @@ export function drawBunkBubbles(
  * Clear all bubble-related resources
  */
 export function clearBubbles(refs: BubbleRenderRefs): void {
-  const { bubblesetsRef, pathsRef, poppersRef } = refs
+  const { bubblesetsRef, pathsRef, poppersRef, poppersListenerRef } = refs
 
   if (bubblesetsRef.current) {
     ;(bubblesetsRef.current as { destroy: () => void }).destroy()
@@ -575,4 +593,8 @@ export function clearBubbles(refs: BubbleRenderRefs): void {
     })
     poppersRef.current = []
   }
+
+  // Null the listener ref. The next drawBunkBubbles call won't attempt to
+  // off() a stale function reference against a (possibly-fresh) cy instance.
+  poppersListenerRef.current = null
 }

--- a/frontend/src/components/graph/constants.ts
+++ b/frontend/src/components/graph/constants.ts
@@ -20,12 +20,20 @@ export const GRADE_COLORS: Record<number, string> = {
 }
 
 // Edge type colors
+//
+// `request` is the positive bunk-with edge (blue). `not_bunk_with` is the
+// negative request keyed off `request_type` since the API ships both as
+// type='request' (the negative edge differs only by request_type). Sibling
+// is intentionally green so it doesn't share a hue with the negative
+// request — when both render in the same graph they need to be visually
+// distinct at a glance.
 export const EDGE_COLORS: Record<string, string> = {
   request: '#3498db',
+  not_bunk_with: '#e74c3c',
   historical: '#95a5a6',
-  sibling: '#e74c3c',
+  sibling: '#2ecc71',
   school: '#2ecc71',
-  bundled: '#9b59b6', // Purple for bundled edges
+  bundled: '#9b59b6',
 }
 
 // Node satisfaction status colors (for borders).

--- a/frontend/src/components/graph/constants.ts
+++ b/frontend/src/components/graph/constants.ts
@@ -32,7 +32,6 @@ export const EDGE_COLORS: Record<string, string> = {
   not_bunk_with: '#e74c3c',
   historical: '#95a5a6',
   sibling: '#2ecc71',
-  school: '#2ecc71',
   bundled: '#9b59b6',
 }
 
@@ -54,7 +53,6 @@ export const EDGE_LABELS: Record<string, string> = {
   request: 'Requests',
   historical: 'Historical',
   sibling: 'Siblings',
-  school: 'Classmates',
 }
 
 /**

--- a/frontend/src/components/graph/constants.ts
+++ b/frontend/src/components/graph/constants.ts
@@ -30,7 +30,6 @@ export const GRADE_COLORS: Record<number, string> = {
 export const EDGE_COLORS: Record<string, string> = {
   request: '#3498db',
   not_bunk_with: '#e74c3c',
-  historical: '#95a5a6',
   sibling: '#2ecc71',
   bundled: '#9b59b6',
 }
@@ -51,7 +50,6 @@ export const STATUS_COLORS: Record<string, string> = {
 // Edge type display labels
 export const EDGE_LABELS: Record<string, string> = {
   request: 'Requests',
-  historical: 'Historical',
   sibling: 'Siblings',
 }
 

--- a/frontend/src/components/graph/cytoscapeStyles.test.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.test.ts
@@ -106,10 +106,38 @@ describe('createGraphElements', () => {
       sibling: true,
       school: true,
     })
-    expect(parentNodes).toHaveLength(1)
-    const parent = expectDefined(parentNodes[0], 'parent node')
-    expect(parent.data.id).toBe('bunk-100')
-    expect(parent.data.label).toBe('Cabin A')
+    const bunkParent = expectDefined(
+      parentNodes.find((p) => p.data.id === 'bunk-100'),
+      'bunk parent'
+    )
+    expect(bunkParent.data.label).toBe('Cabin A')
+  })
+
+  // Layout-level unit-side compounds were tried (parent: unit-{name}-{side}
+  // on each bunk) but fcose crashes — `addNodeToGrid → Cannot read properties
+  // of undefined` — on the doubly-nested compound topology this produces with
+  // a real session's mix of unit-parented bunks, AG bunks, and orphan
+  // campers. Visual unit boundaries are still drawn by bubbleRenderer keyed
+  // off bunk names, so unit grouping remains visible without breaking layout.
+  it('does not emit unit-side compound parents (fcose-incompatible)', () => {
+    const camper = (id: number, bunkId: number): GraphNodeData => ({
+      id,
+      name: `c${id}`,
+      grade: 5,
+      centrality: 0.5,
+      clustering: 0,
+      satisfaction_status: 'satisfied',
+      bunk_cm_id: bunkId,
+      community: 1,
+    })
+    const { parentNodes } = createGraphElements(
+      [camper(1, 100), camper(2, 101), camper(3, 102), camper(4, 103)],
+      [],
+      { 100: 'B-1', 101: 'B-2', 102: 'G-1', 103: 'G-2' },
+      { request: true, historical: true, sibling: true, school: true }
+    )
+    expect(parentNodes.every((p) => p.data.isBunkParent)).toBe(true)
+    expect(parentNodes.every((p) => p.data.id.startsWith('bunk-'))).toBe(true)
   })
 
   it('creates camper nodes with correct data', () => {

--- a/frontend/src/components/graph/cytoscapeStyles.test.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.test.ts
@@ -8,6 +8,7 @@ import {
   type GraphNodeData,
   type GraphEdgeData,
 } from './cytoscapeStyles'
+import { EDGE_COLORS } from './constants'
 import { expectDefined } from '../../test/testUtils'
 
 describe('getCytoscapeStyles', () => {
@@ -219,5 +220,174 @@ describe('createGraphElements', () => {
     expect(requestEdge.data.target).toBe('2')
     expect(requestEdge.data.confidence).toBe(0.9)
     expect(requestEdge.data.is_reciprocal).toBe(true)
+  })
+
+  it('flags edges as multi when the unordered pair has 2+ relationships', () => {
+    const edges: GraphEdgeData[] = [
+      // pair (1,2): one bunk_with each direction → 2 edges → multi
+      {
+        source: 1,
+        target: 2,
+        type: 'request',
+        priority: 1,
+        confidence: 0.9,
+        reciprocal: true,
+        request_type: 'bunk_with',
+      },
+      {
+        source: 2,
+        target: 1,
+        type: 'request',
+        priority: 1,
+        confidence: 0.9,
+        reciprocal: true,
+        request_type: 'bunk_with',
+      },
+      // pair (2,3): single sibling edge → 1 edge → not multi
+      { source: 2, target: 3, type: 'sibling', priority: 0, confidence: 1, reciprocal: false },
+    ]
+    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
+      request: true,
+      historical: true,
+      sibling: true,
+      school: true,
+    })
+    const between12 = out.filter(
+      (e) =>
+        (e.data.source === '1' && e.data.target === '2') ||
+        (e.data.source === '2' && e.data.target === '1')
+    )
+    expect(between12).toHaveLength(2)
+    expect(between12.every((e) => e.data.multi === true)).toBe(true)
+
+    const between23 = expectDefined(
+      out.find((e) => e.data.source === '2' && e.data.target === '3'),
+      '2-3 edge'
+    )
+    expect(between23.data.multi).toBeUndefined()
+  })
+
+  it('treats sibling+request between the same pair as multi (different types still counts)', () => {
+    const edges: GraphEdgeData[] = [
+      {
+        source: 1,
+        target: 2,
+        type: 'request',
+        priority: 1,
+        confidence: 0.9,
+        reciprocal: false,
+        request_type: 'bunk_with',
+      },
+      { source: 1, target: 2, type: 'sibling', priority: 0, confidence: 1, reciprocal: false },
+    ]
+    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
+      request: true,
+      historical: true,
+      sibling: true,
+      school: true,
+    })
+    expect(out).toHaveLength(2)
+    expect(out.every((e) => e.data.multi === true)).toBe(true)
+  })
+
+  it('passes request_type from edge data to EdgeElement so styles can color negative requests differently', () => {
+    const edges: GraphEdgeData[] = [
+      {
+        source: 1,
+        target: 2,
+        type: 'request',
+        priority: 1,
+        confidence: 0.9,
+        reciprocal: false,
+        request_type: 'not_bunk_with',
+      },
+      {
+        source: 2,
+        target: 3,
+        type: 'request',
+        priority: 1,
+        confidence: 0.9,
+        reciprocal: true,
+        request_type: 'bunk_with',
+      },
+    ]
+    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
+      request: true,
+      historical: true,
+      sibling: true,
+      school: true,
+    })
+    expect(out).toHaveLength(2)
+    const negative = expectDefined(
+      out.find((e) => e.data.source === '1' && e.data.target === '2'),
+      'negative edge'
+    )
+    expect(negative.data.request_type).toBe('not_bunk_with')
+    const positive = expectDefined(
+      out.find((e) => e.data.source === '2' && e.data.target === '3'),
+      'positive edge'
+    )
+    expect(positive.data.request_type).toBe('bunk_with')
+  })
+})
+
+describe('EDGE_COLORS constant', () => {
+  it('keeps bunk_with (positive) requests blue', () => {
+    expect(EDGE_COLORS['request']).toBe('#3498db')
+  })
+
+  it('uses red for not_bunk_with (negative) requests', () => {
+    expect(EDGE_COLORS['not_bunk_with']).toBe('#e74c3c')
+  })
+
+  it('uses green for sibling edges (was previously red)', () => {
+    expect(EDGE_COLORS['sibling']).toBe('#2ecc71')
+  })
+})
+
+describe('edge curve rendering', () => {
+  it('renders single relationships as straight lines (not curved)', () => {
+    // A pair with only one edge between them gets a plain directional
+    // arrow — easier to read than a slight curve. Curving is reserved for
+    // pairs with 2+ relationships.
+    const styles = getCytoscapeStyles({ showLabels: true })
+    const edgeStyle = styles.find((s) => s.selector === 'edge')
+    expect(edgeStyle).toBeDefined()
+    const styleObj = edgeStyle?.style as unknown as Record<string, unknown>
+    expect(styleObj['curve-style']).toBe('straight')
+    // No double-headed arrowing — each edge owns its own one-way arrow.
+    expect(styleObj['source-arrow-shape']).toBeUndefined()
+  })
+
+  it('overrides curve-style to unbundled-bezier on edges flagged with multi', () => {
+    const styles = getCytoscapeStyles({ showLabels: true })
+    const multiStyle = styles.find((s) => s.selector === 'edge[?multi]')
+    expect(multiStyle).toBeDefined()
+    const styleObj = multiStyle?.style as unknown as Record<string, unknown>
+    expect(styleObj['curve-style']).toBe('unbundled-bezier')
+  })
+
+  it('does not register a legacy edge[?is_reciprocal] override (per-edge rendering, not per-pair)', () => {
+    const styles = getCytoscapeStyles({ showLabels: true })
+    expect(styles.find((s) => s.selector === 'edge[?is_reciprocal]')).toBeUndefined()
+  })
+
+  it('colors not_bunk_with request edges using EDGE_COLORS["not_bunk_with"]', () => {
+    // The base edge selector uses a function for line-color that consults
+    // request_type — verified by checking that edges with request_type
+    // 'not_bunk_with' resolve to the negative color, not the positive one.
+    const styles = getCytoscapeStyles({ showLabels: true })
+    const edgeStyle = styles.find((s) => s.selector === 'edge')
+    expect(edgeStyle).toBeDefined()
+    const styleObj = edgeStyle?.style as unknown as Record<string, unknown>
+    const lineColor = styleObj['line-color']
+    expect(typeof lineColor).toBe('function')
+
+    const fakeEdge = {
+      data: (key: string) =>
+        key === 'edge_type' ? 'request' : key === 'request_type' ? 'not_bunk_with' : null,
+    }
+    const color = (lineColor as (e: unknown) => string)(fakeEdge)
+    expect(color).toBe('#e74c3c')
   })
 })

--- a/frontend/src/components/graph/cytoscapeStyles.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.ts
@@ -52,7 +52,7 @@ function resolveEdgeColor(ele: { data: (key: string) => unknown }): string {
   const edgeType = ele.data('edge_type') as string
   if (edgeType === 'request') {
     const requestType = ele.data('request_type') as string | null | undefined
-    if (requestType === 'not_bunk_with') return EDGE_COLORS['not_bunk_with'] ?? '#e74c3c'
+    if (requestType === 'not_bunk_with') return EDGE_COLORS['not_bunk_with'] ?? '#95a5a6'
   }
   return EDGE_COLORS[edgeType] ?? '#95a5a6'
 }

--- a/frontend/src/components/graph/cytoscapeStyles.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.ts
@@ -26,6 +26,8 @@ export interface GraphEdgeData {
   priority: number
   confidence: number
   reciprocal: boolean
+  /** For type='request' edges: 'bunk_with' or 'not_bunk_with'. */
+  request_type?: string
 }
 
 /** Edge visibility settings */
@@ -38,6 +40,21 @@ export interface ShowEdgesSettings {
 /** Options for getCytoscapeStyles */
 export interface CytoscapeStyleOptions {
   showLabels: boolean
+}
+
+/**
+ * Map a Cytoscape edge to its color. The negative bunk request
+ * ('not_bunk_with') ships from the API with edge_type='request' — same as
+ * the positive 'bunk_with' — so we have to consult request_type to pick
+ * the right hue.
+ */
+function resolveEdgeColor(ele: { data: (key: string) => unknown }): string {
+  const edgeType = ele.data('edge_type') as string
+  if (edgeType === 'request') {
+    const requestType = ele.data('request_type') as string | null | undefined
+    if (requestType === 'not_bunk_with') return EDGE_COLORS['not_bunk_with'] ?? '#e74c3c'
+  }
+  return EDGE_COLORS[edgeType] ?? '#95a5a6'
 }
 
 /**
@@ -92,17 +109,27 @@ export function getCytoscapeStyles({ showLabels }: CytoscapeStyleOptions): Style
       selector: 'edge',
       style: {
         width: 2,
-        'line-color': (ele: EdgeSingular) => {
-          const edgeType = ele.data('edge_type')
-          return EDGE_COLORS[edgeType] ?? '#95a5a6'
-        },
+        'line-color': (ele: EdgeSingular) => resolveEdgeColor(ele),
         'target-arrow-shape': 'triangle',
-        'target-arrow-color': (ele: EdgeSingular) => {
-          const edgeType = ele.data('edge_type')
-          return EDGE_COLORS[edgeType] ?? '#95a5a6'
-        },
-        'curve-style': 'bezier',
+        'target-arrow-color': (ele: EdgeSingular) => resolveEdgeColor(ele),
+        // Default: a single relationship between two campers renders as a
+        // plain straight directional arrow. Pairs with 2+ relationships
+        // (mutual same-type, asymmetric, or sibling+request combinations)
+        // pick up the `multi` data flag in createGraphElements and switch
+        // to unbundled-bezier below so each direction is its own curve.
+        'curve-style': 'straight',
         'overlay-padding': '2px',
+      },
+    },
+    {
+      selector: 'edge[?multi]',
+      style: {
+        // Splay each edge of a multi-relationship pair onto its own curve.
+        // Distance/weight are intentionally moderate so two curves don't
+        // overlap each other yet stay close enough to read as a related pair.
+        'curve-style': 'unbundled-bezier',
+        'control-point-distances': [40],
+        'control-point-weights': [0.5],
       },
     },
     {
@@ -216,6 +243,10 @@ export interface EdgeElement {
     priority: number
     confidence: number
     is_reciprocal: boolean
+    request_type?: string
+    /** True when this pair of campers has 2+ relationships (any combination
+     *  of bunk_with, not_bunk_with, sibling). Drives the curved-bezier style. */
+    multi?: boolean
   }
 }
 
@@ -282,22 +313,35 @@ export function createGraphElements(
   }))
 
   // Filter and create edges based on visibility settings
-  const edges: EdgeElement[] = edgeData
-    .filter((edge) => {
-      const edgeType = edge.type as keyof ShowEdgesSettings
-      return showEdges[edgeType] !== false
-    })
-    .map((edge, index) => ({
-      data: {
-        id: `edge-${index}`,
-        source: edge.source.toString(),
-        target: edge.target.toString(),
-        edge_type: edge.type,
-        priority: edge.priority,
-        confidence: edge.confidence,
-        is_reciprocal: edge.reciprocal,
-      },
-    }))
+  const visibleEdges = edgeData.filter((edge) => {
+    const edgeType = edge.type as keyof ShowEdgesSettings
+    return showEdges[edgeType] !== false
+  })
+
+  // Count relationships per unordered pair so the renderer can curve only
+  // when there are 2+ edges between the same two campers (mutuals, mixed
+  // bunk_with/not_bunk_with, sibling-and-request combinations). Single-
+  // edge pairs stay straight, which the user finds easier to read.
+  const pairCounts = new Map<string, number>()
+  const pairKey = (a: number, b: number) => (a < b ? `${a}-${b}` : `${b}-${a}`)
+  visibleEdges.forEach((e) => {
+    const k = pairKey(e.source, e.target)
+    pairCounts.set(k, (pairCounts.get(k) ?? 0) + 1)
+  })
+
+  const edges: EdgeElement[] = visibleEdges.map((edge, index) => ({
+    data: {
+      id: `edge-${index}`,
+      source: edge.source.toString(),
+      target: edge.target.toString(),
+      edge_type: edge.type,
+      priority: edge.priority,
+      confidence: edge.confidence,
+      is_reciprocal: edge.reciprocal,
+      ...(edge.request_type ? { request_type: edge.request_type } : {}),
+      ...((pairCounts.get(pairKey(edge.source, edge.target)) ?? 0) >= 2 ? { multi: true } : {}),
+    },
+  }))
 
   return { parentNodes, nodes, edges }
 }

--- a/frontend/src/components/graph/cytoscapeStyles.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.ts
@@ -180,13 +180,13 @@ export function getCytoscapeStyles({ showLabels }: CytoscapeStyleOptions): Style
   ]
 }
 
-/** Cytoscape element for parent (bunk) node */
+/** Cytoscape element for parent (bunk) compound node */
 export interface ParentNodeElement {
   data: {
     id: string
     label: string
-    isBunkParent: boolean
-    bunk_cm_id: number
+    isBunkParent?: boolean
+    bunk_cm_id?: number
   }
 }
 
@@ -246,13 +246,19 @@ export function createGraphElements(
     }
   })
 
-  // Create parent nodes for each bunk (compound layout grouping only)
+  // Create a flat compound parent for each bunk. We do NOT nest bunks inside
+  // unit-side compounds at the layout level: fcose crashes
+  // (`addNodeToGrid → Cannot read properties of undefined`) on doubly-nested
+  // compound graphs with this dataset. The visual unit bubble is drawn by
+  // bubbleRenderer keyed off bunk names, so unit grouping is still visible
+  // even though it's not a layout constraint.
   const parentNodes: ParentNodeElement[] = Object.keys(bunkGroups).map((bunkIdStr) => {
     const bunkId = parseInt(bunkIdStr, 10)
+    const bunkName = bunksData?.[bunkId] ?? `Bunk ${bunkId}`
     return {
       data: {
         id: `bunk-${bunkId}`,
-        label: bunksData?.[bunkId] ?? `Bunk ${bunkId}`,
+        label: bunkName,
         isBunkParent: true,
         bunk_cm_id: bunkId,
       },

--- a/frontend/src/components/graph/graphLayout.test.ts
+++ b/frontend/src/components/graph/graphLayout.test.ts
@@ -1,34 +1,91 @@
 /**
- * Tests for graph layout utilities
- * Covers layout spacing logic for compound vs non-compound graphs
+ * Tests for graph layout utilities — single source of truth for fcose config.
  */
 import { describe, it, expect } from 'vitest'
-import { FCOSE_LAYOUT_OPTIONS, getLayoutOptions } from './graphLayout'
+import { getFcoseOptions, prepareWorkerInput } from './graphLayout'
+import type { ParentNodeElement, CamperNodeElement, EdgeElement } from './cytoscapeStyles'
 
-describe('FCOSE_LAYOUT_OPTIONS', () => {
-  it('has expected default values', () => {
-    expect(FCOSE_LAYOUT_OPTIONS.nodeSeparation).toBe(200)
-    expect(FCOSE_LAYOUT_OPTIONS.componentSpacing).toBe(200)
+describe('getFcoseOptions', () => {
+  it('returns base spacing when compound nodes exist', () => {
+    const opts = getFcoseOptions({ hasCompoundNodes: true })
+    expect(opts.name).toBe('fcose')
+    expect(opts.nodeSeparation).toBeGreaterThan(0)
+    expect(opts.componentSpacing).toBeGreaterThan(0)
+  })
+
+  it('expands spacing when no compound nodes exist', () => {
+    const tight = getFcoseOptions({ hasCompoundNodes: true })
+    const loose = getFcoseOptions({ hasCompoundNodes: false })
+    expect(loose.nodeSeparation).toBeGreaterThan(tight.nodeSeparation)
+    expect(loose.componentSpacing).toBeGreaterThan(tight.componentSpacing)
+  })
+
+  it('preserves shared layout properties across both branches', () => {
+    const opts = getFcoseOptions({ hasCompoundNodes: true })
+    expect(opts.numIter).toBeGreaterThan(0)
+    expect(opts.fit).toBe(true)
+    expect(opts.gravityCompound).toBeGreaterThan(0)
+  })
+
+  it('returns serializable options (no function values)', () => {
+    const opts = getFcoseOptions({ hasCompoundNodes: true })
+    for (const [key, value] of Object.entries(opts)) {
+      expect(typeof value, `${key} must be serializable for postMessage`).not.toBe('function')
+    }
+  })
+
+  // Layout-quality lock: 'draft' skips fcose's spectral pre-layout and on
+  // this dataset (with strong gravityCompound) collapsed the graph to a
+  // line. 'default' is required for a coherent initial spread.
+  it("uses quality: 'default' for spectral pre-layout (draft collapses graph)", () => {
+    expect(getFcoseOptions({ hasCompoundNodes: true }).quality).toBe('default')
+  })
+
+  it('caps numIter at 300 (force-directed phase converges before 1000)', () => {
+    expect(getFcoseOptions({ hasCompoundNodes: true }).numIter).toBeLessThanOrEqual(300)
+  })
+
+  // Spacing lock: tightened from 200 → 130 (#user-feedback: graph required
+  // constant zoom-in; cross-unit same-gender request stretching addressed
+  // via the unit gender-side split).
+  it('uses tightened compound-graph spacing (≤140 to keep graph compact)', () => {
+    const opts = getFcoseOptions({ hasCompoundNodes: true })
+    expect(opts.nodeSeparation).toBeLessThanOrEqual(140)
+    expect(opts.componentSpacing).toBeLessThanOrEqual(140)
   })
 })
 
-describe('getLayoutOptions', () => {
-  it('returns default spacing when compound nodes exist', () => {
-    const options = getLayoutOptions({ hasCompoundNodes: true })
-    expect(options.nodeSeparation).toBe(200)
-    expect(options.componentSpacing).toBe(200)
+describe('prepareWorkerInput', () => {
+  const parentNodes: ParentNodeElement[] = [
+    { data: { id: 'bunk-1', label: 'B-1', isBunkParent: true } },
+  ]
+  const nodes: CamperNodeElement[] = [
+    {
+      data: {
+        id: '1',
+        label: 'A',
+        name: 'A',
+        grade: 5,
+        centrality: 0.5,
+        clustering: 0,
+        satisfaction_status: 'satisfied',
+        bunk_cm_id: 1,
+        community: 1,
+        parent: 'bunk-1',
+      },
+    },
+  ]
+  const edges: EdgeElement[] = []
+
+  it('attaches the full fcose options object derived from getFcoseOptions', () => {
+    const input = prepareWorkerInput(parentNodes, nodes, edges)
+    const expected = getFcoseOptions({ hasCompoundNodes: true })
+    expect(input.options).toEqual(expected)
   })
 
-  it('returns expanded spacing when no compound nodes exist', () => {
-    const options = getLayoutOptions({ hasCompoundNodes: false })
-    expect(options.nodeSeparation).toBe(400)
-    expect(options.componentSpacing).toBe(400)
-  })
-
-  it('preserves other layout properties', () => {
-    const options = getLayoutOptions({ hasCompoundNodes: false })
-    expect(options.name).toBe('fcose')
-    expect(options.numIter).toBe(1000)
-    expect(options.fit).toBe(true)
+  it('uses no-compound spacing when there are no parent nodes', () => {
+    const input = prepareWorkerInput([], nodes, edges)
+    const expected = getFcoseOptions({ hasCompoundNodes: false })
+    expect(input.options).toEqual(expected)
   })
 })

--- a/frontend/src/components/graph/graphLayout.ts
+++ b/frontend/src/components/graph/graphLayout.ts
@@ -6,56 +6,71 @@ import type { Core, NodeSingular } from 'cytoscape'
 import type { LayoutWorkerInput } from '../../workers/layoutWorker'
 import type { ParentNodeElement, CamperNodeElement, EdgeElement } from './cytoscapeStyles'
 
-/**
- * FCOSE layout options for force-directed graph layout
- */
-export const FCOSE_LAYOUT_OPTIONS = {
-  name: 'fcose',
-  numIter: 1000,
-  packComponents: true,
-  componentSpacing: 200,
-  nodeSeparation: 200,
-  uniformNodeDimensions: false,
-  nodeOverlap: 120,
-  fit: true,
-  padding: 80,
-  gravityCompound: 1.0,
-  gravityRangeCompound: 1.5,
-  nestingFactor: 0.1,
-  tilingPaddingVertical: 30,
-  tilingPaddingHorizontal: 30,
-} as const
-
-/** Expanded spacing for graphs without compound (bunk) parent nodes */
-const NO_COMPOUND_OVERRIDES = {
-  nodeSeparation: 400,
-  componentSpacing: 400,
-} as const
-
-export interface LayoutOptionsParams {
+export interface FcoseOptionsParams {
   hasCompoundNodes: boolean
 }
 
 /**
- * Get layout options with spacing adjusted for compound vs non-compound graphs.
- * When no bunk parent nodes exist, nodes clump too tightly with default spacing.
+ * Single source of truth for fcose layout configuration. Both the worker
+ * and the main-thread fallback path use this so layouts are identical.
+ *
+ * Returned object is fully serializable (no functions) so it can cross the
+ * postMessage boundary into the layout worker. Non-serializable extras like
+ * `idealEdgeLength` (a function) are added at the cy.layout() call site.
  */
-/** Widened type so overrides don't clash with `as const` literal types */
-type FcoseLayoutConfig = {
-  [K in keyof typeof FCOSE_LAYOUT_OPTIONS]: K extends 'nodeSeparation' | 'componentSpacing'
-    ? number
-    : (typeof FCOSE_LAYOUT_OPTIONS)[K]
-}
-
-export function getLayoutOptions(params: LayoutOptionsParams): FcoseLayoutConfig {
-  if (params.hasCompoundNodes) {
-    return FCOSE_LAYOUT_OPTIONS
+export function getFcoseOptions(params: FcoseOptionsParams) {
+  // Tightened from the previous 200 → less whitespace between bunks and
+  // between unit halves so the whole graph fits without constant zooming.
+  // Without compound (bunk) parents, fcose packs nodes too tightly — keep
+  // expanded spacing for unparented camper-only graphs.
+  const compound = {
+    nodeSeparation: 130,
+    componentSpacing: 130,
   }
-  return { ...FCOSE_LAYOUT_OPTIONS, ...NO_COMPOUND_OVERRIDES }
+  const noCompound = {
+    nodeSeparation: 400,
+    componentSpacing: 400,
+  }
+  const spacing = params.hasCompoundNodes ? compound : noCompound
+
+  return {
+    name: 'fcose',
+    animate: false,
+    // 300 iters: empirically converges on this graph size; fcose default is
+    // 2500 (way overkill for our N). Quality-neutral perf knob.
+    numIter: 300,
+    // Keep at default — disabling triggers fcose internals that are less
+    // battle-tested and can throw on graphs with mixed unparented/parented
+    // compound structures (e.g. AG bunks with no unit parent alongside
+    // unit-side compounds).
+    packComponents: true,
+    nodeSeparation: spacing.nodeSeparation,
+    componentSpacing: spacing.componentSpacing,
+    uniformNodeDimensions: false,
+    nodeOverlap: 120,
+    fit: true,
+    padding: 80,
+    // Higher gravityCompound pulls children toward their compound centroid;
+    // bumped from 1.0 so unit clusters stay tight when request edges
+    // would otherwise scatter cross-unit bunks.
+    gravityCompound: 2.0,
+    gravityRangeCompound: 1.5,
+    nestingFactor: 0.1,
+    tilingPaddingVertical: 30,
+    tilingPaddingHorizontal: 30,
+    // 'default' runs fcose's spectral pre-layout for good initial spread;
+    // 'draft' collapsed the graph to a line on this dataset (paired with
+    // strong gravityCompound, the force phase alone could not recover
+    // from a random seed).
+    quality: 'default' as const,
+    randomize: true,
+  }
 }
 
 /**
- * Prepare graph elements for the layout worker
+ * Prepare graph elements for the layout worker.
+ * Ships full fcose options derived from getFcoseOptions so the worker is
+ * a passthrough and both paths produce identical layouts.
  */
 export function prepareWorkerInput(
   parentNodes: ParentNodeElement[],
@@ -84,17 +99,13 @@ export function prepareWorkerInput(
       target: e.data.target,
       edge_type: e.data.edge_type,
       priority: e.data.priority,
-    } as Record<string, unknown>,
+    },
   }))
 
   return {
     nodes: workerNodes as LayoutWorkerInput['nodes'],
-    edges: workerEdges as LayoutWorkerInput['edges'],
-    options: {
-      numIter: 1000,
-      componentSpacing: 200,
-      nodeSeparation: 200,
-    },
+    edges: workerEdges,
+    options: getFcoseOptions({ hasCompoundNodes: parentNodes.length > 0 }),
   }
 }
 

--- a/frontend/src/components/graph/index.ts
+++ b/frontend/src/components/graph/index.ts
@@ -46,9 +46,9 @@ export {
 
 // Graph layout utilities
 export {
-  FCOSE_LAYOUT_OPTIONS,
-  getLayoutOptions,
+  getFcoseOptions,
   prepareWorkerInput,
   setupGraphEventHandlers,
+  type FcoseOptionsParams,
   type SetupEventHandlersOptions,
 } from './graphLayout'

--- a/frontend/src/types/graph.ts
+++ b/frontend/src/types/graph.ts
@@ -26,6 +26,7 @@ export interface GraphEdge {
   weight: number
   type: string
   reciprocal: boolean
+  request_type?: string // 'bunk_with' | 'not_bunk_with' for type='request' edges
   confidence?: number // AI confidence score for request edges
   priority?: number // Priority level for request edges
   metadata?: Record<string, unknown> // Additional edge metadata (e.g., location for classmate edges)

--- a/frontend/src/utils/unitMapping.test.ts
+++ b/frontend/src/utils/unitMapping.test.ts
@@ -3,7 +3,7 @@
  * Maps bunk names (e.g. "B-1", "G-12", "Aleph") to unit names
  */
 import { describe, it, expect } from 'vitest'
-import { getUnitForBunk, UNIT_COLORS } from './unitMapping'
+import { getUnitForBunk, getUnitSideForBunk, UNIT_COLORS } from './unitMapping'
 
 describe('getUnitForBunk', () => {
   describe('Nitzanim unit (Aleph, Bet)', () => {
@@ -157,6 +157,52 @@ describe('getUnitForBunk', () => {
       expect(getUnitForBunk('b-aleph')).toBe('Nitzanim')
       expect(getUnitForBunk('g-bet')).toBe('Nitzanim')
     })
+  })
+})
+
+describe('getUnitSideForBunk', () => {
+  it('returns boys side for B- prefix', () => {
+    expect(getUnitSideForBunk('B-5')).toEqual({ unit: 'Eilat', side: 'B' })
+  })
+
+  it('returns girls side for G- prefix', () => {
+    expect(getUnitSideForBunk('G-5')).toEqual({ unit: 'Eilat', side: 'G' })
+  })
+
+  it('returns null side for AG- prefix (free-floating)', () => {
+    expect(getUnitSideForBunk('AG-5')).toEqual({ unit: 'Eilat', side: null })
+  })
+
+  it('returns boys side for B-Aleph', () => {
+    expect(getUnitSideForBunk('B-Aleph')).toEqual({ unit: 'Nitzanim', side: 'B' })
+  })
+
+  it('returns girls side for G-Bet', () => {
+    expect(getUnitSideForBunk('G-Bet')).toEqual({ unit: 'Nitzanim', side: 'G' })
+  })
+
+  it('returns null side for unprefixed Aleph (ambiguous → float)', () => {
+    expect(getUnitSideForBunk('Aleph')).toEqual({ unit: 'Nitzanim', side: null })
+  })
+
+  it('returns null side for unprefixed Bet (ambiguous → float)', () => {
+    expect(getUnitSideForBunk('Bet')).toEqual({ unit: 'Nitzanim', side: null })
+  })
+
+  it('handles trailing letter sub-bunk variants', () => {
+    expect(getUnitSideForBunk('B-3A')).toEqual({ unit: 'Galil', side: 'B' })
+    expect(getUnitSideForBunk('G-12b')).toEqual({ unit: 'Chalutzim 2', side: 'G' })
+  })
+
+  it('is case-insensitive on prefix', () => {
+    expect(getUnitSideForBunk('b-5')).toEqual({ unit: 'Eilat', side: 'B' })
+    expect(getUnitSideForBunk('g-Bet')).toEqual({ unit: 'Nitzanim', side: 'G' })
+  })
+
+  it('returns null for unrecognized names', () => {
+    expect(getUnitSideForBunk('Unknown')).toBeNull()
+    expect(getUnitSideForBunk('')).toBeNull()
+    expect(getUnitSideForBunk('Bunk 12345')).toBeNull()
   })
 })
 

--- a/frontend/src/utils/unitMapping.ts
+++ b/frontend/src/utils/unitMapping.ts
@@ -44,8 +44,11 @@ const SPECIAL_NAME_TO_UNIT: Record<string, string> = {
   'g-bet': 'Nitzanim',
 }
 
-/** Regex to extract cabin number from gendered bunk names (B-5, G-12, AG-3, B-5A) */
-const BUNK_NUMBER_REGEX = /^(?:B|G|AG)-(\d+)[A-Za-z]?$/i
+/** Regex to extract prefix + cabin number from gendered bunk names (B-5, G-12, AG-3, B-5A) */
+const BUNK_NUMBER_REGEX = /^(B|G|AG)-(\d+)[A-Za-z]?$/i
+
+/** Regex to extract prefix from prefixed Nitzanim names (B-Aleph, G-Bet) */
+const PREFIXED_NITZANIM_REGEX = /^(B|G)-(?:aleph|bet)$/i
 
 /** Muted colors for unit-level grouping (distinct from bunk bubble colors) */
 export const UNIT_COLORS: Record<string, string> = {
@@ -87,9 +90,51 @@ export function getUnitForBunk(bunkName: string): string | null {
 
   // Try to extract cabin number from gendered pattern
   const match = bunkName.match(BUNK_NUMBER_REGEX)
-  if (match?.[1]) {
-    const cabinNumber = parseInt(match[1], 10)
+  if (match?.[2]) {
+    const cabinNumber = parseInt(match[2], 10)
     return CABIN_NUMBER_TO_UNIT[cabinNumber] ?? null
+  }
+
+  return null
+}
+
+/** Side of a unit a bunk belongs to. AG and unprefixed Aleph/Bet float (null). */
+export type UnitSide = 'B' | 'G' | null
+
+/**
+ * Get the unit and gender side for a bunk name. Used to split each unit
+ * compound into a boys half and a girls half so cross-unit same-gender
+ * requests don't have to fight unit gravity to pull halves together.
+ *
+ * AG- bunks return side=null (free-floating — no unit parent assigned),
+ * and unprefixed Aleph/Bet are ambiguous so they also float.
+ */
+export function getUnitSideForBunk(bunkName: string): { unit: string; side: UnitSide } | null {
+  if (!bunkName) return null
+
+  const lower = bunkName.toLowerCase().trim()
+
+  // Prefixed Nitzanim variants (B-Aleph, G-Bet) carry side in the prefix
+  const nitzanimMatch = lower.match(PREFIXED_NITZANIM_REGEX)
+  if (nitzanimMatch?.[1]) {
+    const side = nitzanimMatch[1].toUpperCase() as 'B' | 'G'
+    return { unit: 'Nitzanim', side }
+  }
+
+  // Unprefixed Aleph/Bet — unit known, side ambiguous → float
+  if (lower === 'aleph' || lower === 'bet') {
+    return { unit: 'Nitzanim', side: null }
+  }
+
+  // Gendered cabin pattern (B-5, G-12A, AG-3)
+  const match = bunkName.match(BUNK_NUMBER_REGEX)
+  if (match?.[1] && match[2]) {
+    const prefix = match[1].toUpperCase()
+    const cabinNumber = parseInt(match[2], 10)
+    const unit = CABIN_NUMBER_TO_UNIT[cabinNumber]
+    if (!unit) return null
+    if (prefix === 'AG') return { unit, side: null }
+    return { unit, side: prefix as 'B' | 'G' }
   }
 
   return null

--- a/frontend/src/workers/layoutWorker.ts
+++ b/frontend/src/workers/layoutWorker.ts
@@ -26,12 +26,9 @@ export interface LayoutWorkerInput {
       [key: string]: unknown
     }
   }>
-  options?: {
-    numIter?: number
-    nodeSeparation?: number
-    componentSpacing?: number
-    hasCompoundNodes?: boolean
-  }
+  /** Full serializable fcose options from getFcoseOptions(). Worker is a
+   *  passthrough — non-serializable extras (idealEdgeLength fn) added below. */
+  options: Record<string, unknown>
   /** Instance token issued by the main thread; echoed back in the response so
    *  stale results from a previous cy instance can be discarded. */
   token?: number
@@ -53,7 +50,7 @@ self.onmessage = (event: MessageEvent<LayoutWorkerInput>) => {
   const token: number | undefined = event.data.token
 
   try {
-    const { nodes, edges, options = {} } = event.data
+    const { nodes, edges, options } = event.data
 
     // Create headless Cytoscape instance
     const cy = cytoscape({
@@ -65,41 +62,9 @@ self.onmessage = (event: MessageEvent<LayoutWorkerInput>) => {
       },
     })
 
-    // Detect compound nodes if not explicitly passed
-    const hasCompound = options.hasCompoundNodes ?? nodes.some((n) => n.data.parent !== undefined)
-
-    // Use expanded spacing when no compound nodes exist
-    const defaultNodeSep = hasCompound ? 200 : 400
-    const defaultCompSpacing = hasCompound ? 200 : 400
-
-    // Run fcose layout with compound node support
-    const layout = cy.layout({
-      name: 'fcose',
-      animate: false,
-      // Performance tuning - can be adjusted via options
-      numIter: options.numIter ?? 1000,
-      packComponents: true,
-      componentSpacing: options.componentSpacing ?? defaultCompSpacing,
-      nodeSeparation: options.nodeSeparation ?? defaultNodeSep,
-      uniformNodeDimensions: false,
-      nodeOverlap: 120,
-      fit: true,
-      padding: 80,
-      // Compound node options - keeps bunk members grouped
-      gravityCompound: 1.0,
-      gravityRangeCompound: 1.5,
-      nestingFactor: 0.1,
-      tilingPaddingVertical: 30,
-      tilingPaddingHorizontal: 30,
-      // Quality settings
-      quality: 'default',
-      randomize: true,
-      // Edge length based on weight for better clustering
-      idealEdgeLength: (edge: cytoscape.EdgeSingular) => {
-        const weight = edge.data('weight') ?? 1
-        return 100 / Math.sqrt(weight)
-      },
-    } as cytoscape.LayoutOptions)
+    // Worker is a pure passthrough — main thread owns the full fcose config
+    // via getFcoseOptions(). All options are serializable; no extras injected.
+    const layout = cy.layout(options as unknown as cytoscape.LayoutOptions)
 
     // Run layout synchronously (we're in a worker, blocking is fine)
     layout.run()


### PR DESCRIPTION
## Summary

- **SVG gender icons**: Swap thin unicode ♂/♀ markers in unit labels for inline Lucide-derived Mars/Venus SVGs painted with the unit color stroke
- **Popper labels in container**: Append popper labels (unit/bunk) to the graph container instead of `document.body` — clipped under the header divider and visible in fullscreen; pin flip/preventOverflow to container boundary
- **`not_bunk_with` edges render red**: Plumb `request_type` through `SocialGraphEdge` → frontend so negative requests are visually distinct from positive (blue) ones
- **Sibling edges recolored green**: Was red, which conflicted with the new red negative-request color
- **Multi-edge curves**: Stop deduping same-type mutuals in `OptimizedSocialGraphBuilder` — pairs with 2+ relationships render as two separate unbundled-bezier curves; singles stay straight one-way arrows; `multi: true` tag drives the curve-style switch
- **GraphLegend "Don't Bunk With" entry**: Added red entry; bumped legend to `z-10` so bunk labels don't paint over it
- **Fullscreen resize fix**: Replace flaky 200ms timeout with a 3-rAF chain on `isExpanded` change so React commit, CSS layout, and paint all settle before `cy.resize()+cy.fit()`
- **ResizeObserver**: Handles non-toggle reflows (window resize, sidebar open/close)
- **Manual Fit button**: Now uses the same 50px padding as auto-fit
- **Drop layout-level unit-side compounds**: `fcose` crashes with `addNodeToGrid → Cannot read properties of undefined` on real-session data with mixed unit-parented bunks, AG bunks, and orphan campers. Drop the layout-level compound nesting — the visual unit bubble (drawn by `bubbleRenderer`) is unaffected and still groups same-unit bunks visibly. Also terminate the layout worker in cleanup so each graph rebuild starts with fresh `fcose` state.
- **Unstick "Computing layout" spinner**: Fix StrictMode double-mount causing the spinner to stick

## Test plan

- [ ] Social graph renders with SVG Mars/Venus icons in unit labels
- [ ] Popper labels stay inside the graph card in both normal and fullscreen modes
- [ ] `not_bunk_with` edges appear red; `bunk_with` blue; sibling green
- [ ] Camper pairs with mutual requests show two curved edges
- [ ] Switching scenarios doesn't crash fcose (previously crashed on real session data)
- [ ] Fullscreen toggle resizes and fits graph correctly without clipping
- [ ] "Computing layout" spinner clears after layout completes (no StrictMode sticky spinner)
- [ ] GraphLegend shows "Don't Bunk With" entry and isn't obscured by bunk labels