### PR TITLE
refactor(sync): clear() builtin + modernization framework expansion

### DIFF
--- a/docs/reference/modernization-backlog.md
+++ b/docs/reference/modernization-backlog.md
@@ -62,34 +62,78 @@ Baseline is strong: Pydantic v2 everywhere, `datetime.UTC` adopted, modern gener
 
 ## 2. Go (project is on 1.26)
 
-Baseline is excellent: 784 `slog` uses, 395 `fmt.Errorf("%w", ...)` wrappings, no `ioutil`. The dominant gap is an `interface{}` → `any` codemod the codebase never got.
+**Toolchain:** `pocketbase/go.mod` declares `go 1.26.0`; locally installed `go1.26.0`. 1.26 is the current stable as of April 2026 — already on latest, no version bump pending.
 
-| Impact | Feature | Where | Count | Notes |
-|--------|---------|-------|-------|-------|
-| **HIGH** | `interface{}` → `any` | `sync/api.go` (108 occurrences), `sync/base_sync.go` (42), `sync/households.go` (35+), widespread | **744** | Single mechanical pass. Alias since Go 1.18. |
-| **HIGH** | `map[string]interface{}` → `map[string]any` | same hotspots | **603** | Same PR as the `any` codemod. |
-| **HIGH** | `fmt.Sprintf` inside `slog` call sites | `campminder/client.go:1008`, `sync/financial_transactions.go:106`, `sync/orchestrator.go:784,844` | 4 | Defeats structured logging — pass raw values as key/value attrs instead. |
-| **HIGH** | String-based error matching | `sync/rate_limited_sheets_writer.go` (`strings.Contains(err.Error(), "googleapi: Error 429")`), `sync/scheduler_test.go`, `workbook_manager_test.go`, `orchestrator_test.go` | 4 | Define sentinel errors (e.g. `ErrRateLimited`) and use `errors.Is` / `errors.As`. The Google 429 detection is the production-impact one. |
-| **MEDIUM** | `sort.Slice` → `slices.SortFunc` (Go 1.21) | `sync/normalize_geographic_test.go`, `sync/workbook_manager.go`, `sync/multi_workbook_ordering.go` (2×) | 3 | |
-| **MEDIUM** | `sort.Strings` → `slices.Sort` (Go 1.21) | `rbac/hooks.go`, `sync/base_sync.go` (2×), `sync/multi_workbook_ordering.go` (2×), `sync/table_exporter.go` | 6 | |
-| **MEDIUM** | Classic `for i := 0; i < len(...)` → `for i := range slice` (Go 1.22) | `sync/households.go`, `sync/staff_skills.go`, `sync/session_resolver.go`, `sync/sessions.go`, `sync/camper_history.go`, `sync/rate_limited_sheets_writer.go`, test files | 26 | Not all applicable — some use custom increments (`i += batchSize`) that still need the classic form. |
-| **MEDIUM** | Manual map-clear loop → `clear()` builtin (Go 1.21) | `sync/base_sync.go:122–125, 130–133` (`ClearProcessedKeys`, `ClearFieldDiffStats`) | 2 | Trivial. |
-| **LOW** | Mixed `log` + `log/slog` in one file | `campminder/client.go:11` (`log.Printf` for rate-limit warnings alongside `slog`) | 1 file | Consolidate on `slog`. |
-| **LOW** | `strings.Index() != -1` anti-pattern | `sync/base_sync.go` | 1 | Use `strings.Contains`. |
-| **?** | `time.After` in retry loop | `sync/rate_limited_sheets_writer.go:194` | 1 | Creates a new timer per retry — fine in practice unless the loop becomes hot. |
+**Idiom level:** the compiler is 1.26 but the codebase mixes idiom from pre-1.18 through ~1.21. Baseline is otherwise excellent: 784 `slog` uses, 395 `fmt.Errorf("%w", ...)` wrappings, no `ioutil`, `math/rand/v2` already adopted. The dominant gap is an `interface{}` → `any` codemod the codebase never got.
 
-### Unexplored / no concrete opportunities identified
+### How to read these tables
 
-- Go 1.23 range-over-func iterators — no strong candidates surfaced in the audit
-- Go 1.24 generic type aliases — no existing generic patterns that would benefit
-- `context.WithoutCancel` / `context.AfterFunc` — only `WithCancel` in tests, production context propagation looks fine
+The first table lists rewrites with both a **`from` works since** column (oldest Go that accepts the current idiom — usually `1.0`) and a **`to` available since** column (when the target idiom became available). The codebase's effective idiom level is roughly *the highest "from works since" we still depend on*, which is `1.0` everywhere — i.e. our code reads like Go 1.0–1.18 even though we build on 1.26.
 
-### Recommended Go PR order
+The second table is an honest accounting of where the original audit *stopped looking*, with survey results filled in.
 
-1. `refactor(pb): interface{} → any codemod` — single bulk PR, ~1,347 replacements, purely mechanical
-2. `fix(sync): replace string-based error matching with sentinel errors` — behavioral (Google 429 detection), smaller PR
-3. `refactor(sync): use slices package helpers and clear() builtin` — bundle the Medium items together
-4. `chore(logging): consolidate campminder client on slog` — small cleanup
+### 2a. Concrete rewrites (current targets)
+
+| From (current idiom) | To (modern equivalent) | `from` works since | `to` available since | Impact | Where | Count |
+|---|---|---|---|---|---|---|
+| `interface{}` | `any` | 1.0 | 1.18 | **HIGH** | `sync/api.go` (108), `sync/base_sync.go` (42), `sync/households.go` (35+), widespread | 744 |
+| `map[string]interface{}` | `map[string]any` | 1.0 | 1.18 | **HIGH** | same hotspots | 603 |
+| `fmt.Sprintf(...)` inside `slog.Info(...)` etc. | raw key/value attrs | n/a | 1.21 (`log/slog`) | **HIGH** | `campminder/client.go:1008`, `sync/financial_transactions.go:106`, `sync/orchestrator.go:784,844` | 4 |
+| `strings.Contains(err.Error(), "...")` | sentinel errors + `errors.Is` / `errors.As` | 1.0 | 1.13 | **HIGH** | `sync/rate_limited_sheets_writer.go` (Google 429), `scheduler_test.go`, `workbook_manager_test.go`, `orchestrator_test.go` | 4 |
+| `sort.Slice(s, less)` | `slices.SortFunc(s, cmp)` | 1.0 (`sort.Slice` since 1.8) | 1.21 | **MEDIUM** | `sync/normalize_geographic_test.go`, `sync/workbook_manager.go`, `sync/multi_workbook_ordering.go` (2×) | 3 |
+| `sort.Strings(s)` | `slices.Sort(s)` | 1.0 | 1.21 | **MEDIUM** | `rbac/hooks.go`, `sync/base_sync.go` (2×), `sync/multi_workbook_ordering.go` (2×), `sync/table_exporter.go` | 6 |
+| `for i := 0; i < len(s); i++` | `for i := range s` | 1.0 | 1.22 (loop-var semantics) | **MEDIUM** | `sync/households.go`, `staff_skills.go`, `session_resolver.go`, `sessions.go`, `camper_history.go`, `rate_limited_sheets_writer.go`, tests | 26 |
+| manual map-clear loop | `clear(m)` | 1.0 | 1.21 | **MEDIUM** | `sync/base_sync.go:122–125, 130–133` | 2 |
+| Mixed `log` + `log/slog` in one file | consolidate on `slog` | n/a | 1.21 (`log/slog`) | **LOW** | `campminder/client.go:11` | 1 file |
+| ~~`strings.Index(x, y) != -1`~~ | ~~`strings.Contains(x, y)`~~ | — | — | **FALSE POSITIVE** | ~~`sync/base_sync.go:1084`~~ | ~~1~~ |
+| `time.After` in retry loop | reuse `time.NewTimer` | 1.0 | 1.0 | **?** | `sync/rate_limited_sheets_writer.go:194` | 1 |
+
+**Notes on caveats:**
+- `for i := 0; i < len(s); i++` → `for i := range s` was syntactically valid before 1.22; the reason it's now *preferred* is that 1.22 made the loop variable per-iteration scoped, which makes `i`-capture in closures/goroutines safe.
+- Some of the 26 `for i := 0; …` callsites use `i += batchSize` — those still need the classic form (or migrate to `slices.Chunk`, see survey table below).
+- **`strings.Index` row was a false positive.** The original audit pattern-matched `Index(...) != -1` without inspecting the body. The single hit at `sync/base_sync.go:1084` uses `idx` as a *slice boundary* (`result[:idx] + result[endIdx:]`), not just as a presence check, so `strings.Contains` would discard the offset that the next 7 lines depend on. **Lesson: every audit row must be confirmed against the surrounding code before claiming it's a candidate, not just against the regex.**
+
+### 2b. Survey status of features ≥ 1.22
+
+The original audit was scoped to "features the existing code visibly avoids," so library-level wins from 1.22 onward were under-surveyed. Findings below were filled in via this PR's discovery pass.
+
+| Feature | Since | Survey status | Findings | Notes |
+|---|---|---|---|---|
+| `min` / `max` builtins | 1.21 | surveyed | ~10 manual `if a > b` ternaries (`sync/orchestrator.go:565`, `sync/rate_limited_sheets_writer.go:211`, `sync/sheets_scheduling.go:60,63`, `sync/persons.go:637, 1029`, `ratelimit/ratelimit.go:85`, `sync/feedback/handler.go:104`) + 1 `math.Min` (`ratelimit/ratelimit.go:78`) | Drops a few `math` imports if all converted. **MEDIUM**. |
+| `cmp.Or` (first non-zero) | 1.22 | surveyed | ~5 chained-nonzero patterns (`sync/normalize_geographic.go:487`, `sync/table_exporter.go:262, 358`, `sync/camper_transportation_test.go:296`, `sync/camper_history_test.go:1045`) | Readability only. **LOW–MEDIUM**. |
+| `math/rand/v2` | 1.22 | **already adopted** | `sync/orchestrator.go:9` already imports `math/rand/v2`; `sync/rate_limited_sheets_writer.go` correctly uses `crypto/rand` for jitter | No work — confirms 1.22 idiom is partially adopted. ✓ |
+| `slices.Concat` | 1.22 | surveyed | 3 trivial `append(x, y...)` callsites (`sync/multi_workbook_ordering.go:39`, `sync/persons.go:1429`, `campminder/client.go:1020`) | Marginal. **LOW**. |
+| `slices.Chunk` | 1.23 | surveyed | 6 manual `for i := 0; i < len(x); i += batchSize` chunkers (`sync/households.go:104`, `staff_skills.go:541`, `session_resolver.go:188`, `camper_history.go:1042`, `persons.go:283`, plus `camper_history_test.go:529`) | **MEDIUM** — strictly better than the for-range rewrite for these specific loops. Replaces the "still needs classic form for `i += batchSize`" caveat above. |
+| Range-over-func iterators (`for x := range fn`) | 1.23 | surveyed | No callback-iteration patterns (`func(...) bool` only appears as `sort.Slice` less-funcs, which are migrating to `slices.SortFunc` anyway) | No candidates. ✓ |
+| Generic type aliases (`type Set[T] = map[T]struct{}`) | 1.24 | surveyed | No generic functions in the codebase (`func Foo[T ...]` returned 0 hits) | N/A — no generics to alias. ✓ |
+| `os.Root` (rooted FS, anti-traversal) | 1.24 | surveyed | All `os.ReadFile`/`os.WriteFile` use trusted internal paths (`s.App.DataDir()`, env-driven config paths, all already nolint'd as G304). No untrusted-input file ops. | Not security-relevant here. **LOW** value. |
+| `testing/synctest` (virtualized time in tests) | 1.24 (experiment) / 1.25 (GA) | surveyed | Real candidates: `sync/orchestrator_test.go` (~10 `time.Sleep`s, total real-time ~1.5s+), `sync/scheduler_test.go` (300ms+200ms sleeps), `sync/rate_limited_sheets_writer_test.go:387`, `rbac/config_hooks_test.go:74,84` | **MEDIUM** — would speed up test suite and remove flake risk. |
+| `encoding/json/v2` | 1.25 | surveyed | `campminder/client.go` is the hot path (33 callsites); `sync/base_sync.go` (8), `sync/normalize_geographic_test.go` (10) | Opt-in; v2 is a real API change, not a drop-in. Defer until 1.25 ships and v2 is GA. **DEFER**. |
+| `context.WithoutCancel` / `context.AfterFunc` | 1.21 / 1.21 | surveyed | Only `WithCancel` in tests; no production patterns where a derived context needs to outlive its parent | No candidates. ✓ |
+
+### 2c. Execution order (easiest → hardest)
+
+This is the operational ranking driving the row-by-row PR loop in `modernization-execution-prompt.md`. Items 1–5 of the original ranking (already-done / N/A survey rows) have been removed. Renumbered 1–17. **Item #1 was retired as a false positive after verification** (see annotation in §2a) — the loop picks up at #2.
+
+| Rank | Status | Item | Where | Count | Bundle |
+|---|---|---|---|---|---|
+| ~~1~~ | ~~`strings.Index() != -1` → `Contains`~~ | **FALSE POSITIVE** — `idx` used as slice boundary; see §2a annotation | `sync/base_sync.go:1084` | ~~1~~ | — |
+| 2 | next | manual map-clear → `clear()` builtin | `sync/base_sync.go:122–125, 130–133` | 2 | — |
+| 3 | | `sort.Strings` → `slices.Sort` | `rbac/hooks.go`, `sync/base_sync.go` (2×), `multi_workbook_ordering.go` (2×), `table_exporter.go` | 6 | bundle w/ #4 |
+| 4 | | `sort.Slice` → `slices.SortFunc` | `sync/normalize_geographic_test.go`, `workbook_manager.go`, `multi_workbook_ordering.go` (2×) | 3 | bundle w/ #3 |
+| 5 | | `append(x, y...)` → `slices.Concat` | `sync/multi_workbook_ordering.go:39`, `persons.go:1429`, `campminder/client.go:1020` | 3 | — |
+| 6 | | `min` / `max` builtins | `sync/orchestrator.go:565`, `rate_limited_sheets_writer.go:211`, `sheets_scheduling.go:60,63`, `persons.go:637, 1029`, `ratelimit/ratelimit.go:78,85`, `feedback/handler.go:104` | ~11 | bundle w/ #7 |
+| 7 | | `cmp.Or` (first non-zero) | `sync/normalize_geographic.go:487`, `table_exporter.go:262, 358` | ~5 | bundle w/ #6 |
+| 8 | | `map[string]interface{}` → `map[string]any` | hotspots | 603 | bundle w/ #9 (single codemod) |
+| 9 | | `interface{}` → `any` | `sync/api.go` (108), `base_sync.go` (42), `households.go` (35+), widespread | 744 | bundle w/ #8 |
+| 10 | | log/slog consolidation | `campminder/client.go:11` (`log.Printf` alongside `slog`) | 1 file | — |
+| 11 | | manual chunkers → `slices.Chunk` | `sync/households.go:104`, `staff_skills.go:541`, `session_resolver.go:188`, `camper_history.go:1042`, `persons.go:283`, plus test | 6 | should land before #12 |
+| 12 | | `for i := 0; …` → `for i := range s` | `sync/households.go`, `staff_skills.go`, `session_resolver.go`, `sessions.go`, `camper_history.go`, `rate_limited_sheets_writer.go`, tests | 26 (− #11 subset) | after #11 |
+| 13 | | `fmt.Sprintf` inside `slog` | `campminder/client.go:1008`, `sync/financial_transactions.go:106`, `sync/orchestrator.go:784,844` | 4 | — |
+| 14 | | `time.After` in retry loop | `sync/rate_limited_sheets_writer.go:194` | 1 | — |
+| 15 | | string error matching → sentinels | `sync/rate_limited_sheets_writer.go` (Google 429), `scheduler_test.go`, `workbook_manager_test.go`, `orchestrator_test.go` | 4 | behavioral |
+| 16 | gated | `testing/synctest` for time-based tests | `orchestrator_test.go`, `scheduler_test.go`, `rate_limited_sheets_writer_test.go`, `rbac/config_hooks_test.go` | 10+ sleeps | gated on Go 1.25 GA in toolchain |
+| 17 | deferred | `encoding/json/v2` | `campminder/client.go` (33), `sync/base_sync.go` (8) | hot path | defer until v2 GA + ecosystem signal |
 
 ---
 

--- a/docs/reference/modernization-backlog.md
+++ b/docs/reference/modernization-backlog.md
@@ -4,7 +4,11 @@ Reference audit of modern language/tooling features available to Kindred but not
 
 **Status legend:** HIGH = real behavioral/robustness benefit, MEDIUM = readability/consistency win, LOW = polish / defer.
 
-**Execution model:** Work this backlog one layer at a time (one PR per language/concept) rather than a single mega-PR. Each section below is a candidate PR.
+**Execution model:** Work this backlog one layer at a time (one PR per language/concept) rather than a single mega-PR. Each section governs its own execution order; there is no global cross-section ordering — pick which language to work on based on real-world signals (active PRs, blast radius, idle slot).
+
+**Section format:** §2 (Go) was rewritten to a §a/§b/§c structure (concrete rewrites with two version columns, honest survey-status table, ranked execution order). §1 (Python), §3 (Frontend), and §4 (Infrastructure) are still in the older single-table format and will be migrated when each section is next picked up — see `modernization-prompts.md` Part A. **§4 is a hardening checklist, not a language-version audit; the §a/§b/§c structure does not apply.**
+
+**Companion docs:** Ship rows by following `modernization-prompts.md` (Part B for execution, Part A for re-running an audit). The prompt doc names the false-positive lesson explicitly — every grep hit must be inspected with surrounding context before it lands in §2a.
 
 ---
 
@@ -24,6 +28,8 @@ Reference audit of modern language/tooling features available to Kindred but not
 ---
 
 ## 1. Python (project is on 3.14)
+
+> **Format note:** This section predates the §2 redo (toolchain/idiom-floor preamble + §a/§b/§c). Migrate to the new format on the next pickup — re-run `modernization-prompts.md` Part A in upgrade-in-place mode.
 
 Baseline is strong: Pydantic v2 everywhere, `datetime.UTC` adopted, modern generics (`dict[str, X]`), f-strings clean, mypy `strict = true`. The real gaps are concurrency idioms and version-specific polish.
 
@@ -107,37 +113,46 @@ The original audit was scoped to "features the existing code visibly avoids," so
 | Range-over-func iterators (`for x := range fn`) | 1.23 | surveyed | No callback-iteration patterns (`func(...) bool` only appears as `sort.Slice` less-funcs, which are migrating to `slices.SortFunc` anyway) | No candidates. ✓ |
 | Generic type aliases (`type Set[T] = map[T]struct{}`) | 1.24 | surveyed | No generic functions in the codebase (`func Foo[T ...]` returned 0 hits) | N/A — no generics to alias. ✓ |
 | `os.Root` (rooted FS, anti-traversal) | 1.24 | surveyed | All `os.ReadFile`/`os.WriteFile` use trusted internal paths (`s.App.DataDir()`, env-driven config paths, all already nolint'd as G304). No untrusted-input file ops. | Not security-relevant here. **LOW** value. |
-| `testing/synctest` (virtualized time in tests) | 1.24 (experiment) / 1.25 (GA) | surveyed | Real candidates: `sync/orchestrator_test.go` (~10 `time.Sleep`s, total real-time ~1.5s+), `sync/scheduler_test.go` (300ms+200ms sleeps), `sync/rate_limited_sheets_writer_test.go:387`, `rbac/config_hooks_test.go:74,84` | **MEDIUM** — would speed up test suite and remove flake risk. |
-| `encoding/json/v2` | 1.25 | surveyed | `campminder/client.go` is the hot path (33 callsites); `sync/base_sync.go` (8), `sync/normalize_geographic_test.go` (10) | Opt-in; v2 is a real API change, not a drop-in. Defer until 1.25 ships and v2 is GA. **DEFER**. |
+| `testing/synctest` (virtualized time in tests) | 1.24 (experiment) / 1.25 (GA) | **ungated** | Real candidates: `sync/orchestrator_test.go` (~10 `time.Sleep`s, total real-time ~1.5s+), `sync/scheduler_test.go` (300ms+200ms sleeps), `sync/rate_limited_sheets_writer_test.go:387`, `rbac/config_hooks_test.go:74,84` | **MEDIUM**. 1.25 GA shipped, toolchain is 1.26 — no longer gated. Would speed up test suite and remove flake risk. |
+| `encoding/json/v2` | 1.25 | surveyed | `campminder/client.go` is the hot path (33 callsites); `sync/base_sync.go` (8), `sync/normalize_geographic_test.go` (10) | Opt-in; v2 is a real API change, not a drop-in. **DEFER until ecosystem signal** — i.e. until logging/observability libs in our dep graph (or other packages we marshal *to*/from) accept v2 marshalers, so we don't have to wrap every boundary. The Go-stdlib gate is no longer the blocker (1.25 has shipped). |
 | `context.WithoutCancel` / `context.AfterFunc` | 1.21 / 1.21 | surveyed | Only `WithCancel` in tests; no production patterns where a derived context needs to outlive its parent | No candidates. ✓ |
 
 ### 2c. Execution order (easiest → hardest)
 
-This is the operational ranking driving the row-by-row PR loop in `modernization-execution-prompt.md`. Items 1–5 of the original ranking (already-done / N/A survey rows) have been removed. Renumbered 1–17. **Item #1 was retired as a false positive after verification** (see annotation in §2a) — the loop picks up at #2.
+Operational ranking driving the row-by-row PR loop in `modernization-prompts.md` Part B.
+
+#### Retired
+
+| Item | Where | Reason |
+|---|---|---|
+| `strings.Index() != -1` → `strings.Contains(...)` | `sync/base_sync.go:1084` | **FALSE POSITIVE** — `idx` is used as a slice boundary (`result[:idx] + result[endIdx:]`), not just as a presence check; `strings.Contains` would discard the offset. See §2a annotation. *Lesson: always inspect surrounding code before adding to §2a.* |
+
+#### Live (renumbered after retired and already-done/N/A items removed)
 
 | Rank | Status | Item | Where | Count | Bundle |
 |---|---|---|---|---|---|
-| ~~1~~ | ~~`strings.Index() != -1` → `Contains`~~ | **FALSE POSITIVE** — `idx` used as slice boundary; see §2a annotation | `sync/base_sync.go:1084` | ~~1~~ | — |
-| 2 | next | manual map-clear → `clear()` builtin | `sync/base_sync.go:122–125, 130–133` | 2 | — |
-| 3 | | `sort.Strings` → `slices.Sort` | `rbac/hooks.go`, `sync/base_sync.go` (2×), `multi_workbook_ordering.go` (2×), `table_exporter.go` | 6 | bundle w/ #4 |
-| 4 | | `sort.Slice` → `slices.SortFunc` | `sync/normalize_geographic_test.go`, `workbook_manager.go`, `multi_workbook_ordering.go` (2×) | 3 | bundle w/ #3 |
-| 5 | | `append(x, y...)` → `slices.Concat` | `sync/multi_workbook_ordering.go:39`, `persons.go:1429`, `campminder/client.go:1020` | 3 | — |
-| 6 | | `min` / `max` builtins | `sync/orchestrator.go:565`, `rate_limited_sheets_writer.go:211`, `sheets_scheduling.go:60,63`, `persons.go:637, 1029`, `ratelimit/ratelimit.go:78,85`, `feedback/handler.go:104` | ~11 | bundle w/ #7 |
-| 7 | | `cmp.Or` (first non-zero) | `sync/normalize_geographic.go:487`, `table_exporter.go:262, 358` | ~5 | bundle w/ #6 |
-| 8 | | `map[string]interface{}` → `map[string]any` | hotspots | 603 | bundle w/ #9 (single codemod) |
-| 9 | | `interface{}` → `any` | `sync/api.go` (108), `base_sync.go` (42), `households.go` (35+), widespread | 744 | bundle w/ #8 |
-| 10 | | log/slog consolidation | `campminder/client.go:11` (`log.Printf` alongside `slog`) | 1 file | — |
-| 11 | | manual chunkers → `slices.Chunk` | `sync/households.go:104`, `staff_skills.go:541`, `session_resolver.go:188`, `camper_history.go:1042`, `persons.go:283`, plus test | 6 | should land before #12 |
-| 12 | | `for i := 0; …` → `for i := range s` | `sync/households.go`, `staff_skills.go`, `session_resolver.go`, `sessions.go`, `camper_history.go`, `rate_limited_sheets_writer.go`, tests | 26 (− #11 subset) | after #11 |
-| 13 | | `fmt.Sprintf` inside `slog` | `campminder/client.go:1008`, `sync/financial_transactions.go:106`, `sync/orchestrator.go:784,844` | 4 | — |
-| 14 | | `time.After` in retry loop | `sync/rate_limited_sheets_writer.go:194` | 1 | — |
-| 15 | | string error matching → sentinels | `sync/rate_limited_sheets_writer.go` (Google 429), `scheduler_test.go`, `workbook_manager_test.go`, `orchestrator_test.go` | 4 | behavioral |
-| 16 | gated | `testing/synctest` for time-based tests | `orchestrator_test.go`, `scheduler_test.go`, `rate_limited_sheets_writer_test.go`, `rbac/config_hooks_test.go` | 10+ sleeps | gated on Go 1.25 GA in toolchain |
-| 17 | deferred | `encoding/json/v2` | `campminder/client.go` (33), `sync/base_sync.go` (8) | hot path | defer until v2 GA + ecosystem signal |
+| 1 | ✓ shipped #1066 | manual map-clear → `clear()` builtin | `sync/base_sync.go:121, 1416` | 2 | — |
+| 2 | next | `sort.Strings` → `slices.Sort` | `rbac/hooks.go`, `sync/base_sync.go` (2×), `multi_workbook_ordering.go` (2×), `table_exporter.go` | 6 | bundle w/ #3 |
+| 3 | | `sort.Slice` → `slices.SortFunc` | `sync/normalize_geographic_test.go`, `workbook_manager.go`, `multi_workbook_ordering.go` (2×) | 3 | bundle w/ #2 |
+| 4 | | `append(x, y...)` → `slices.Concat` | `sync/multi_workbook_ordering.go:39`, `persons.go:1429`, `campminder/client.go:1020` | 3 | — |
+| 5 | | `min` / `max` builtins | `sync/orchestrator.go:565`, `rate_limited_sheets_writer.go:211`, `sheets_scheduling.go:60,63`, `persons.go:637, 1029`, `ratelimit/ratelimit.go:78,85`, `feedback/handler.go:104` | ~11 | bundle w/ #6 |
+| 6 | | `cmp.Or` (first non-zero) | `sync/normalize_geographic.go:487`, `table_exporter.go:262, 358` | ~5 | bundle w/ #5 |
+| 7 | | `map[string]interface{}` → `map[string]any` | hotspots | 603 | bundle w/ #8 (single codemod) |
+| 8 | | `interface{}` → `any` | `sync/api.go` (108), `base_sync.go` (42), `households.go` (35+), widespread | 744 | bundle w/ #7 |
+| 9 | | log/slog consolidation | `campminder/client.go:11` (`log.Printf` alongside `slog`) | 1 file | — |
+| 10 | | manual chunkers → `slices.Chunk` | `sync/households.go:104`, `staff_skills.go:541`, `session_resolver.go:188`, `camper_history.go:1042`, `persons.go:283`, plus test | 6 | land before #11 |
+| 11 | | `for i := 0; …` → `for i := range s` | `sync/households.go`, `staff_skills.go`, `session_resolver.go`, `sessions.go`, `camper_history.go`, `rate_limited_sheets_writer.go`, tests | 26 (− #10 subset) | after #10 |
+| 12 | | `fmt.Sprintf` inside `slog` | `campminder/client.go:1008`, `sync/financial_transactions.go:106`, `sync/orchestrator.go:784,844` | 4 | — |
+| 13 | | `time.After` in retry loop | `sync/rate_limited_sheets_writer.go:194` | 1 | — |
+| 14 | | string error matching → sentinels | `sync/rate_limited_sheets_writer.go` (Google 429), `scheduler_test.go`, `workbook_manager_test.go`, `orchestrator_test.go` | 4 | behavioral |
+| 15 | | `testing/synctest` for time-based tests | `orchestrator_test.go`, `scheduler_test.go`, `rate_limited_sheets_writer_test.go`, `rbac/config_hooks_test.go` | 10+ sleeps | 1.25 GA shipped, toolchain is 1.26 — no longer gated |
+| 16 | deferred | `encoding/json/v2` | `campminder/client.go` (33), `sync/base_sync.go` (8) | hot path | defer until ecosystem signal (deps accept v2 marshalers) |
 
 ---
 
 ## 3. Frontend — React 19, TypeScript 5.8, Node 22
+
+> **Format note:** This section predates the §2 redo (toolchain/idiom-floor preamble + §a/§b/§c). Migrate to the new format on the next pickup — re-run `modernization-prompts.md` Part A in upgrade-in-place mode.
 
 `tsconfig.json` is already modern (ES2022, bundler resolution, `verbatimModuleSyntax`, `noImplicitOverride`, `erasableSyntaxOnly`). The misses are idiomatic — code predating React 19 and ES2023 adoption.
 
@@ -169,6 +184,8 @@ This is the operational ranking driving the row-by-row PR loop in `modernization
 ---
 
 ## 4. Infrastructure + Caddy production hardening
+
+> **Different artifact:** §4 is a hardening / CI gap checklist, not a language-version audit. The §a/§b/§c framing (idiom-floor, two-version columns, survey-status) does not apply — there is no compiler version, no idiom regression, no past-vs-modern axis to score against. Treat each item as a standalone task.
 
 Exceptional baseline: Chainguard/Wolfi + distroless final images, `COPY --link` + numeric `--chown`, healthchecks in every Dockerfile, concurrency groups in CI/CD, path-filtered rebuilds, Trivy scanning, `uv` with `[dependency-groups]` (PEP 735), commitlint, git-cliff.
 
@@ -270,31 +287,6 @@ Exceptional baseline: Chainguard/Wolfi + distroless final images, `COPY --link` 
 4. `perf(ci): enable pytest-xdist`
 5. `ci: add CodeQL + dependency-review workflows`
 6. Optional: ARM64 multi-arch, SBOM/cosign — only if there's a concrete driver
-
----
-
-## Suggested overall PR order
-
-One PR per row, roughly in this sequence:
-
-1. **This PR** — `chore(docs): comprehensive modernization backlog + README overhaul` (ships with `CLAUDE.md` pin fixes)
-2. `chore(ci): ruff target-version py314 + autofix UP037/UP043 cascade`
-3. `chore(py): drop redundant __future__ annotations import`
-4. `refactor(pb): interface{} → any codemod`
-4. `refactor(api): adopt asyncio.TaskGroup in metrics services`
-5. `fix(sync): replace string-based error matching with sentinel errors`
-6. `refactor(frontend): Array.toSorted + Object.groupBy`
-7. `refactor(frontend): error cause chaining`
-8. `fix(ci): rebuild caddy on every CD run + pin base image`
-9. `build(caddy): minimum hardened production config`
-10. `refactor(api): itertools.batched for chunking`
-11. `refactor(pb): slices package helpers + clear() builtin`
-12. `refactor(frontend): adopt React 19 use() for contexts`
-13. `refactor(frontend): React Query queryOptions + skipToken`
-14. `perf(frontend): lazy-load large modals`
-15. `perf(ci): enable pytest-xdist`
-16. `ci: add CodeQL + dependency-review`
-17. Remaining LOW items opportunistically
 
 ---
 

--- a/docs/reference/modernization-backlog.md
+++ b/docs/reference/modernization-backlog.md
@@ -132,9 +132,10 @@ Operational ranking driving the row-by-row PR loop in `modernization-prompts.md`
 | Rank | Status | Item | Where | Count | Bundle |
 |---|---|---|---|---|---|
 | 1 | ✓ shipped #1066 | manual map-clear → `clear()` builtin | `sync/base_sync.go:121, 1416` | 2 | — |
-| 2 | next | `sort.Strings` → `slices.Sort` | `rbac/hooks.go`, `sync/base_sync.go` (2×), `multi_workbook_ordering.go` (2×), `table_exporter.go` | 6 | may bundle w/ #3 |
-| 3 | | `sort.Slice` → `slices.SortFunc` | `sync/normalize_geographic_test.go`, `workbook_manager.go`, `multi_workbook_ordering.go` (2×) | 3 | may bundle w/ #2 |
-| 4 | | `append(x, y...)` → `slices.Concat` | `sync/multi_workbook_ordering.go:39`, `persons.go:1429`, `campminder/client.go:1020` | 3 | — |
+| 2 | ✓ shipped #1066 | `sort.Strings` → `slices.Sort` | `rbac/hooks.go`, `sync/base_sync.go` (2×), `camper_history_test.go`, `multi_workbook_ordering.go` (2×), `table_exporter.go` (2×) | 8 | bundled w/ #3; drift +`camper_history_test.go:546` (audit miss) |
+| 3 | ✓ shipped #1066 | `sort.Slice` → `slices.SortFunc` | `sync/normalize_geographic_test.go`, `base_sync.go:1402`, `workbook_manager.go` | 3 | bundled w/ #2 |
+| — | ✓ shipped #1066 | `sort.Ints` → `slices.Sort` (drift, audit miss) | `sync/family_camp_derived_test.go:163` | 1 | included in #2/#3 bundle to drop `"sort"` import package-wide |
+| 4 | next | `append(x, y...)` → `slices.Concat` | `sync/multi_workbook_ordering.go:39`, `persons.go:1429`, `campminder/client.go:1020` | 3 | — |
 | 5 | | `min` / `max` builtins | `sync/orchestrator.go:565`, `rate_limited_sheets_writer.go:211`, `sheets_scheduling.go:60,63`, `persons.go:637, 1029`, `ratelimit/ratelimit.go:78,85`, `feedback/handler.go:104` | ~11 | may bundle w/ #6 |
 | 6 | | `cmp.Or` (first non-zero) | `sync/normalize_geographic.go:487`, `table_exporter.go:262, 358` | ~5 | may bundle w/ #5 |
 | 7 | | `map[string]interface{}` → `map[string]any` | hotspots | 603 | may bundle w/ #8 (single codemod) |

--- a/docs/reference/modernization-backlog.md
+++ b/docs/reference/modernization-backlog.md
@@ -119,7 +119,7 @@ The original audit was scoped to "features the existing code visibly avoids," so
 
 ### 2c. Execution order (easiest → hardest)
 
-Operational ranking driving the row-by-row PR loop in `modernization-prompts.md` Part B.
+Operational ranking driving the row-by-row PR loop in `modernization-prompts.md` Part B. **Pick rule: status `next` first, else lowest-numbered live row.** Bundle hints in the table are guidance for the brief, not a directive to skip — never re-rank based on a bundle hint.
 
 #### Retired
 
@@ -132,13 +132,13 @@ Operational ranking driving the row-by-row PR loop in `modernization-prompts.md`
 | Rank | Status | Item | Where | Count | Bundle |
 |---|---|---|---|---|---|
 | 1 | ✓ shipped #1066 | manual map-clear → `clear()` builtin | `sync/base_sync.go:121, 1416` | 2 | — |
-| 2 | next | `sort.Strings` → `slices.Sort` | `rbac/hooks.go`, `sync/base_sync.go` (2×), `multi_workbook_ordering.go` (2×), `table_exporter.go` | 6 | bundle w/ #3 |
-| 3 | | `sort.Slice` → `slices.SortFunc` | `sync/normalize_geographic_test.go`, `workbook_manager.go`, `multi_workbook_ordering.go` (2×) | 3 | bundle w/ #2 |
+| 2 | next | `sort.Strings` → `slices.Sort` | `rbac/hooks.go`, `sync/base_sync.go` (2×), `multi_workbook_ordering.go` (2×), `table_exporter.go` | 6 | may bundle w/ #3 |
+| 3 | | `sort.Slice` → `slices.SortFunc` | `sync/normalize_geographic_test.go`, `workbook_manager.go`, `multi_workbook_ordering.go` (2×) | 3 | may bundle w/ #2 |
 | 4 | | `append(x, y...)` → `slices.Concat` | `sync/multi_workbook_ordering.go:39`, `persons.go:1429`, `campminder/client.go:1020` | 3 | — |
-| 5 | | `min` / `max` builtins | `sync/orchestrator.go:565`, `rate_limited_sheets_writer.go:211`, `sheets_scheduling.go:60,63`, `persons.go:637, 1029`, `ratelimit/ratelimit.go:78,85`, `feedback/handler.go:104` | ~11 | bundle w/ #6 |
-| 6 | | `cmp.Or` (first non-zero) | `sync/normalize_geographic.go:487`, `table_exporter.go:262, 358` | ~5 | bundle w/ #5 |
-| 7 | | `map[string]interface{}` → `map[string]any` | hotspots | 603 | bundle w/ #8 (single codemod) |
-| 8 | | `interface{}` → `any` | `sync/api.go` (108), `base_sync.go` (42), `households.go` (35+), widespread | 744 | bundle w/ #7 |
+| 5 | | `min` / `max` builtins | `sync/orchestrator.go:565`, `rate_limited_sheets_writer.go:211`, `sheets_scheduling.go:60,63`, `persons.go:637, 1029`, `ratelimit/ratelimit.go:78,85`, `feedback/handler.go:104` | ~11 | may bundle w/ #6 |
+| 6 | | `cmp.Or` (first non-zero) | `sync/normalize_geographic.go:487`, `table_exporter.go:262, 358` | ~5 | may bundle w/ #5 |
+| 7 | | `map[string]interface{}` → `map[string]any` | hotspots | 603 | may bundle w/ #8 (single codemod) |
+| 8 | | `interface{}` → `any` | `sync/api.go` (108), `base_sync.go` (42), `households.go` (35+), widespread | 744 | may bundle w/ #7 |
 | 9 | | log/slog consolidation | `campminder/client.go:11` (`log.Printf` alongside `slog`) | 1 file | — |
 | 10 | | manual chunkers → `slices.Chunk` | `sync/households.go:104`, `staff_skills.go:541`, `session_resolver.go:188`, `camper_history.go:1042`, `persons.go:283`, plus test | 6 | land before #11 |
 | 11 | | `for i := 0; …` → `for i := range s` | `sync/households.go`, `staff_skills.go`, `session_resolver.go`, `sessions.go`, `camper_history.go`, `rate_limited_sheets_writer.go`, tests | 26 (− #10 subset) | after #10 |

--- a/docs/reference/modernization-backlog.md
+++ b/docs/reference/modernization-backlog.md
@@ -136,9 +136,9 @@ Operational ranking driving the row-by-row PR loop in `modernization-prompts.md`
 | 2 | ✓ shipped #1066 | `sort.Strings` → `slices.Sort` | `rbac/hooks.go`, `sync/base_sync.go` (2×), `camper_history_test.go`, `multi_workbook_ordering.go` (2×), `table_exporter.go` (2×) | 8 | bundled w/ #3; drift +`camper_history_test.go:546` (audit miss) |
 | 3 | ✓ shipped #1066 | `sort.Slice` → `slices.SortFunc` | `sync/normalize_geographic_test.go`, `base_sync.go:1402`, `workbook_manager.go` | 3 | bundled w/ #2 |
 | — | ✓ shipped #1066 | `sort.Ints` → `slices.Sort` (drift, audit miss) | `sync/family_camp_derived_test.go:163` | 1 | included in #2/#3 bundle to drop `"sort"` import package-wide |
-| 4 | next | `min` / `max` builtins | `sync/orchestrator.go:565`, `rate_limited_sheets_writer.go:211`, `sheets_scheduling.go:60,63`, `persons.go:637, 1029`, `ratelimit/ratelimit.go:78,85`, `feedback/handler.go:104` | ~11 | may bundle w/ #5 |
-| 5 | | `cmp.Or` (first non-zero) | `sync/normalize_geographic.go:487`, `table_exporter.go:262, 358` | ~5 | may bundle w/ #4 |
-| 6 | | `map[string]interface{}` → `map[string]any` | hotspots | 603 | may bundle w/ #7 (single codemod) |
+| 4 | ✓ shipped #1070 | `min` / `max` builtins | `sync/orchestrator.go:565`, `rate_limited_sheets_writer.go:211`, `persons.go:637`, `ratelimit/ratelimit.go:78` | 4 | bundled w/ #5; ~7 audit entries retired as false positives (early-return validators in `sheets_scheduling.go:60,63` & `persons.go:1029`, side-effecting if in `ratelimit.go:85`, error-size check in `feedback/handler.go:104`) |
+| 5 | ✓ shipped #1070 | `cmp.Or` (first non-zero) | `sync/table_exporter.go:262` | 1 | bundled w/ #4; ~4 audit entries retired as false positives (`normalize_geographic.go:487`, `table_exporter.go:358` — "if non-empty, do X" patterns rather than first-non-zero fallbacks) |
+| 6 | next | `map[string]interface{}` → `map[string]any` | hotspots | 603 | may bundle w/ #7 (single codemod) |
 | 7 | | `interface{}` → `any` | `sync/api.go` (108), `base_sync.go` (42), `households.go` (35+), widespread | 744 | may bundle w/ #6 |
 | 8 | | log/slog consolidation | `campminder/client.go:11` (`log.Printf` alongside `slog`) | 1 file | — |
 | 9 | | manual chunkers → `slices.Chunk` | `sync/households.go:104`, `staff_skills.go:541`, `session_resolver.go:188`, `camper_history.go:1042`, `persons.go:283`, plus test | 6 | land before #10 |

--- a/docs/reference/modernization-backlog.md
+++ b/docs/reference/modernization-backlog.md
@@ -108,7 +108,7 @@ The original audit was scoped to "features the existing code visibly avoids," so
 | `min` / `max` builtins | 1.21 | surveyed | ~10 manual `if a > b` ternaries (`sync/orchestrator.go:565`, `sync/rate_limited_sheets_writer.go:211`, `sync/sheets_scheduling.go:60,63`, `sync/persons.go:637, 1029`, `ratelimit/ratelimit.go:85`, `sync/feedback/handler.go:104`) + 1 `math.Min` (`ratelimit/ratelimit.go:78`) | Drops a few `math` imports if all converted. **MEDIUM**. |
 | `cmp.Or` (first non-zero) | 1.22 | surveyed | ~5 chained-nonzero patterns (`sync/normalize_geographic.go:487`, `sync/table_exporter.go:262, 358`, `sync/camper_transportation_test.go:296`, `sync/camper_history_test.go:1045`) | Readability only. **LOW–MEDIUM**. |
 | `math/rand/v2` | 1.22 | **already adopted** | `sync/orchestrator.go:9` already imports `math/rand/v2`; `sync/rate_limited_sheets_writer.go` correctly uses `crypto/rand` for jitter | No work — confirms 1.22 idiom is partially adopted. ✓ |
-| `slices.Concat` | 1.22 | surveyed | 3 trivial `append(x, y...)` callsites (`sync/multi_workbook_ordering.go:39`, `sync/persons.go:1429`, `campminder/client.go:1020`) | Marginal. **LOW**. |
+| `slices.Concat` | 1.22 | **retired (false positive)** | 3 `append(x, y...)` callsites (`sync/multi_workbook_ordering.go:39`, `sync/persons.go:1429`, `campminder/client.go:1020`) — but 2 are loop accumulators where `slices.Concat` would lose `append`'s growth amortization, and the 3rd rewrite is no clearer than the original | See Retired subsection in §2c. |
 | `slices.Chunk` | 1.23 | surveyed | 6 manual `for i := 0; i < len(x); i += batchSize` chunkers (`sync/households.go:104`, `staff_skills.go:541`, `session_resolver.go:188`, `camper_history.go:1042`, `persons.go:283`, plus `camper_history_test.go:529`) | **MEDIUM** — strictly better than the for-range rewrite for these specific loops. Replaces the "still needs classic form for `i += batchSize`" caveat above. |
 | Range-over-func iterators (`for x := range fn`) | 1.23 | surveyed | No callback-iteration patterns (`func(...) bool` only appears as `sort.Slice` less-funcs, which are migrating to `slices.SortFunc` anyway) | No candidates. ✓ |
 | Generic type aliases (`type Set[T] = map[T]struct{}`) | 1.24 | surveyed | No generic functions in the codebase (`func Foo[T ...]` returned 0 hits) | N/A — no generics to alias. ✓ |
@@ -126,6 +126,7 @@ Operational ranking driving the row-by-row PR loop in `modernization-prompts.md`
 | Item | Where | Reason |
 |---|---|---|
 | `strings.Index() != -1` → `strings.Contains(...)` | `sync/base_sync.go:1084` | **FALSE POSITIVE** — `idx` is used as a slice boundary (`result[:idx] + result[endIdx:]`), not just as a presence check; `strings.Contains` would discard the offset. See §2a annotation. *Lesson: always inspect surrounding code before adding to §2a.* |
+| `append(x, y...)` → `slices.Concat` | `sync/multi_workbook_ordering.go:39`, `sync/persons.go:1429`, `campminder/client.go:1020` | **FALSE POSITIVE** — 2 of 3 callsites are loop accumulators (`persons.go:1429` inside `for status { for page {…} }`; `client.go:1020` inside `for month := 1; month <= 12 {…}`) where `slices.Concat` would lose `append`'s growth-amortized capacity and allocate fresh on every iteration. The 3rd site (`multi_workbook_ordering.go:39`) is a single conditional concat where the rewrite is no clearer than the current 5 lines. *Lesson: filter `append(x, y...)` candidates for non-loop context — the spread-append regex matches accumulator anti-patterns where `slices.Concat` is actively wrong.* |
 
 #### Live (renumbered after retired and already-done/N/A items removed)
 
@@ -135,19 +136,18 @@ Operational ranking driving the row-by-row PR loop in `modernization-prompts.md`
 | 2 | ✓ shipped #1066 | `sort.Strings` → `slices.Sort` | `rbac/hooks.go`, `sync/base_sync.go` (2×), `camper_history_test.go`, `multi_workbook_ordering.go` (2×), `table_exporter.go` (2×) | 8 | bundled w/ #3; drift +`camper_history_test.go:546` (audit miss) |
 | 3 | ✓ shipped #1066 | `sort.Slice` → `slices.SortFunc` | `sync/normalize_geographic_test.go`, `base_sync.go:1402`, `workbook_manager.go` | 3 | bundled w/ #2 |
 | — | ✓ shipped #1066 | `sort.Ints` → `slices.Sort` (drift, audit miss) | `sync/family_camp_derived_test.go:163` | 1 | included in #2/#3 bundle to drop `"sort"` import package-wide |
-| 4 | next | `append(x, y...)` → `slices.Concat` | `sync/multi_workbook_ordering.go:39`, `persons.go:1429`, `campminder/client.go:1020` | 3 | — |
-| 5 | | `min` / `max` builtins | `sync/orchestrator.go:565`, `rate_limited_sheets_writer.go:211`, `sheets_scheduling.go:60,63`, `persons.go:637, 1029`, `ratelimit/ratelimit.go:78,85`, `feedback/handler.go:104` | ~11 | may bundle w/ #6 |
-| 6 | | `cmp.Or` (first non-zero) | `sync/normalize_geographic.go:487`, `table_exporter.go:262, 358` | ~5 | may bundle w/ #5 |
-| 7 | | `map[string]interface{}` → `map[string]any` | hotspots | 603 | may bundle w/ #8 (single codemod) |
-| 8 | | `interface{}` → `any` | `sync/api.go` (108), `base_sync.go` (42), `households.go` (35+), widespread | 744 | may bundle w/ #7 |
-| 9 | | log/slog consolidation | `campminder/client.go:11` (`log.Printf` alongside `slog`) | 1 file | — |
-| 10 | | manual chunkers → `slices.Chunk` | `sync/households.go:104`, `staff_skills.go:541`, `session_resolver.go:188`, `camper_history.go:1042`, `persons.go:283`, plus test | 6 | land before #11 |
-| 11 | | `for i := 0; …` → `for i := range s` | `sync/households.go`, `staff_skills.go`, `session_resolver.go`, `sessions.go`, `camper_history.go`, `rate_limited_sheets_writer.go`, tests | 26 (− #10 subset) | after #10 |
-| 12 | | `fmt.Sprintf` inside `slog` | `campminder/client.go:1008`, `sync/financial_transactions.go:106`, `sync/orchestrator.go:784,844` | 4 | — |
-| 13 | | `time.After` in retry loop | `sync/rate_limited_sheets_writer.go:194` | 1 | — |
-| 14 | | string error matching → sentinels | `sync/rate_limited_sheets_writer.go` (Google 429), `scheduler_test.go`, `workbook_manager_test.go`, `orchestrator_test.go` | 4 | behavioral |
-| 15 | | `testing/synctest` for time-based tests | `orchestrator_test.go`, `scheduler_test.go`, `rate_limited_sheets_writer_test.go`, `rbac/config_hooks_test.go` | 10+ sleeps | 1.25 GA shipped, toolchain is 1.26 — no longer gated |
-| 16 | deferred | `encoding/json/v2` | `campminder/client.go` (33), `sync/base_sync.go` (8) | hot path | defer until ecosystem signal (deps accept v2 marshalers) |
+| 4 | next | `min` / `max` builtins | `sync/orchestrator.go:565`, `rate_limited_sheets_writer.go:211`, `sheets_scheduling.go:60,63`, `persons.go:637, 1029`, `ratelimit/ratelimit.go:78,85`, `feedback/handler.go:104` | ~11 | may bundle w/ #5 |
+| 5 | | `cmp.Or` (first non-zero) | `sync/normalize_geographic.go:487`, `table_exporter.go:262, 358` | ~5 | may bundle w/ #4 |
+| 6 | | `map[string]interface{}` → `map[string]any` | hotspots | 603 | may bundle w/ #7 (single codemod) |
+| 7 | | `interface{}` → `any` | `sync/api.go` (108), `base_sync.go` (42), `households.go` (35+), widespread | 744 | may bundle w/ #6 |
+| 8 | | log/slog consolidation | `campminder/client.go:11` (`log.Printf` alongside `slog`) | 1 file | — |
+| 9 | | manual chunkers → `slices.Chunk` | `sync/households.go:104`, `staff_skills.go:541`, `session_resolver.go:188`, `camper_history.go:1042`, `persons.go:283`, plus test | 6 | land before #10 |
+| 10 | | `for i := 0; …` → `for i := range s` | `sync/households.go`, `staff_skills.go`, `session_resolver.go`, `sessions.go`, `camper_history.go`, `rate_limited_sheets_writer.go`, tests | 26 (− #9 subset) | after #9 |
+| 11 | | `fmt.Sprintf` inside `slog` | `campminder/client.go:1008`, `sync/financial_transactions.go:106`, `sync/orchestrator.go:784,844` | 4 | — |
+| 12 | | `time.After` in retry loop | `sync/rate_limited_sheets_writer.go:194` | 1 | — |
+| 13 | | string error matching → sentinels | `sync/rate_limited_sheets_writer.go` (Google 429), `scheduler_test.go`, `workbook_manager_test.go`, `orchestrator_test.go` | 4 | behavioral |
+| 14 | | `testing/synctest` for time-based tests | `orchestrator_test.go`, `scheduler_test.go`, `rate_limited_sheets_writer_test.go`, `rbac/config_hooks_test.go` | 10+ sleeps | 1.25 GA shipped, toolchain is 1.26 — no longer gated |
+| 15 | deferred | `encoding/json/v2` | `campminder/client.go` (33), `sync/base_sync.go` (8) | hot path | defer until ecosystem signal (deps accept v2 marshalers) |
 
 ---
 

--- a/docs/reference/modernization-prompts.md
+++ b/docs/reference/modernization-prompts.md
@@ -9,6 +9,24 @@ Run Part A rarely (once per language, then again on toolchain bumps). Run Part B
 
 ---
 
+## Front door: which section?
+
+If you were invoked with this prompt and no language/section specified, do **not** guess. List the section headings from `modernization-backlog.md` and ask the user to pick one. Default options:
+
+> The modernization backlog has these sections:
+> - §1 Python (3.14)
+> - §2 Go (1.26) — uses §a/§b/§c structure
+> - §3 Frontend (React 19, TypeScript 5.8, Node 22)
+> - §4 Infrastructure + Caddy (hardening checklist, different artifact)
+>
+> Which section should I work in? And do you want **Part A** (re-run / upgrade the audit for that section) or **Part B** (execute the next row)?
+
+Once the user picks, proceed to Part A or Part B as instructed below.
+
+If the user named a section or row in their original invocation, skip this step and go straight to the named work.
+
+---
+
 ## Rules that apply to both parts
 
 These are load-bearing. Every section that has skipped them has produced bugs or stale docs.

--- a/docs/reference/modernization-prompts.md
+++ b/docs/reference/modernization-prompts.md
@@ -1,0 +1,282 @@
+# Modernization Prompts
+
+Companion to `modernization-backlog.md`. Two prompts, one workflow:
+
+- **Part A** — *Build* (or upgrade) a language section of the backlog.
+- **Part B** — *Execute* a section row-by-row, one tiny PR at a time.
+
+Run Part A rarely (once per language, then again on toolchain bumps). Run Part B constantly.
+
+---
+
+## Rules that apply to both parts
+
+These are load-bearing. Every section that has skipped them has produced bugs or stale docs.
+
+### Rule 1: Verify in context, not against the regex
+
+A grep hit is a *candidate*, not evidence. Every match must be inspected with surrounding lines (`rg -A2 -B2`, or by reading the function body) before being added to §a or claimed for a PR.
+
+The backlog's first version had `strings.Index() != -1` → `strings.Contains` listed as a row. The single match in `sync/base_sync.go:1084` looked like a presence check to the regex, but the function body uses `idx` as a slice boundary 7 lines later. `strings.Contains` would discard a value the next 7 lines depend on. The row was retired as a false positive on first inspection.
+
+**Lesson:** if your audit is just `grep | wc -l`, you will produce false positives. The cost of inspecting each candidate's surrounding code is small; the cost of pushing a broken refactor and reverting is large.
+
+### Rule 2: Three independent versions
+
+Every modernization decision touches three versions:
+
+1. **Toolchain version** — what the compiler/runtime accepts (`go.mod`, `pyproject.toml`'s `requires-python`, `package.json`'s `engines.node`, `tsconfig.json`'s `target`).
+2. **Installed version** — what's actually on the developer machine and in CI.
+3. **Idiom level** — the *highest* language version any line of code idiomatically requires. Usually far below (1) and (2). Code written in 2018-style still compiles on a 2026 toolchain.
+
+The audit's job is to surface (3) and propose moving it closer to (1). Don't go past (1). Don't hand-wave at "no candidates surfaced" — see Rule 1.
+
+### Rule 3: Tests are the spec
+
+For **behavioral** rows (sentinel errors, retry-loop changes, log format changes), follow CLAUDE.md TDD: write a failing test first.
+
+For **pure-rewrite** rows (`clear()`, `slices.Sort`, `interface{}` → `any`, `min`/`max`), the existing tests are the spec. Run them before and after; both must pass. If no existing test covers the rewritten function, write a small spec-lock test (it'll pass on the old code too — that's fine, it locks the contract for the future). Do not invent failing-then-passing tests for code that is bit-equivalent.
+
+`lefthook run pre-push` is the verification gate either way. No "I claim it works" without it.
+
+---
+
+## Part A — Building (or upgrading) a section
+
+Use this when adding a new language to the backlog or when a toolchain bump invalidates the existing section.
+
+The output looks like §2 (Go) of `modernization-backlog.md`: a toolchain-versions preamble, §a (concrete rewrites with two version columns), §b (honest survey-status table), §c (ranked execution order). The process is what produces them honestly.
+
+### Step 0: Establish the three versions explicitly
+
+Open the section with one paragraph that names all three. For Go this looks like:
+
+> Toolchain: `go.mod` declares `go 1.26.0`; locally installed `go1.26.0`. 1.26 is the current stable as of April 2026. Idiom: code mixes pre-1.18 through ~1.21 patterns.
+
+Commands per language:
+
+| Language | Toolchain pin | Installed | Latest stable check |
+|---|---|---|---|
+| Go | `grep -E '^(go\|toolchain) ' go.mod` | `go version` | go.dev/doc/devel/release |
+| Python | `grep requires-python pyproject.toml` + `cat .python-version` | `python --version` | python.org/downloads |
+| Node | `jq .engines package.json` + `cat .nvmrc` | `node -v` | nodejs.org |
+| TypeScript | `cd frontend && jq .compilerOptions.target tsconfig.json` | `cd frontend && npx tsc -v` | typescriptlang.org |
+
+If toolchain < latest, decide explicitly whether bumping is in scope. If toolchain > installed, flag the dev-env drift separately.
+
+### Step 1: Establish the idiom floor
+
+The codebase reads like *the highest* language version any line still requires idiomatically. To find it, walk the per-language version-feature checklist (appendix below) from oldest to newest. The first feature where the legacy pattern is present is the floor.
+
+Example for Go:
+- `interface{}` present → idiom floor < 1.18
+- `sort.Slice` present → idiom floor < 1.21
+- `for i := 0; i < len(s); i++` present → idiom floor < 1.22
+
+**Floor = lowest of the matches, not highest.** That's the oldest version of the language the codebase still relies on idiomatically.
+
+### Step 2: Build §a — concrete rewrites (current targets)
+
+For every `from → to` candidate found in Step 1, capture:
+
+| Column | What it means | Source |
+|---|---|---|
+| **From (current idiom)** | What's in code today | grep result |
+| **To (modern equivalent)** | The modern target | language reference |
+| **`from` works since** | Oldest version that accepts the legacy pattern | usually 1.0 / language birth |
+| **`to` available since** | Version the modern target became available | release notes |
+| **Impact** | HIGH (behavioral/robustness) / MEDIUM (readability/consistency) / LOW (polish) | judgment |
+| **Where** | File paths with line numbers, hotspots first | `grep -n` |
+| **Count** | Total occurrences | `wc -l` |
+
+**Why two version columns:** the original audit had one ("available since"). It hid the question "is the legacy form even still recommended, or has it been quietly superseded by something newer?" Two columns make this obvious. If `from works since` ≥ `to available since`, the rewrite is purely stylistic (no compile error pressure). If a newer modern target has appeared (e.g. `slices.Chunk` post-1.23 partially obsoletes `for i := range`), note it as a caveat or split the row.
+
+**Apply Rule 1 here.** Every grep hit must be inspected before it lands in this table. If the candidate uses the matched value beyond the literal predicate, it is not a §a row.
+
+### Step 3: Build §b — survey status of features ≥ N
+
+Where N is the version *after* whatever the original audit covered. The original Go audit stopped at ~1.21 features and said "no strong candidates surfaced" for 1.22+ — that's the failure mode this step exists to prevent.
+
+For each post-N feature in the appendix, set status to one of:
+
+- **already adopted** — found existing imports/usage; record the file
+- **surveyed** — actually grepped and document the findings (even if zero)
+- **dismissed** — surveyed and confirmed no candidates, with the search expression
+- **deferred** — real candidates exist, blocked on toolchain bump or ecosystem signal
+- **not surveyed** — be honest if you stopped looking
+
+**Never put a feature in §b without including the search expression for the dismissed/surveyed status.** That's how the next audit knows where you stopped looking.
+
+### Step 4: Build §c — ranked execution order
+
+Drop already-adopted / N/A rows. Sort the remaining §a + §b rows by the ranking criteria in Part B's "Ranking criteria" section. Bundle adjacent rows only when they share a file or are both <10 callsites.
+
+The §c table has a "Status" column with values: blank (default, ready), `next` (whoever picks up the loop starts here), `✓ shipped #NNNN`, `skipped (reason)`, `deferred`, `gated (...)`. As rows ship or are skipped, update the status in place — don't delete rows; the audit trail is the value.
+
+If a §a row is retired as a false positive after verification, move it to a "Retired" subsection above the live table with the reason captured. Renumber live items so the loop picks up at #1.
+
+### Step 5: Honesty pass
+
+Before declaring the section done, re-read it and ask:
+
+- Is every "no candidates" claim backed by a search expression?
+- Did I conflate "feature added in version X" with "feature is the right choice for our codebase"? (e.g. `encoding/json/v2` is real but a hot-path migration, not a drop-in — call that out.)
+- Is anything in §a superseded by something in §b? (For Go: `for i := range s` is partially superseded by `slices.Chunk` for the `i += batchSize` subset. Note it.)
+- Did I close any "deferred" rows whose gate has shifted? (E.g. `testing/synctest` was gated on Go 1.25 GA; once 1.25 ships, ungate.)
+
+### Step 6: Close with a survey scope statement
+
+End the section with one line stating the version range covered:
+
+> Survey scope: features added in Go 1.18–1.26. Re-run after toolchain bumps to Go 1.27+.
+
+That way the next audit knows what was already covered.
+
+### Upgrade-in-place mode (when re-running on an existing section)
+
+If a section already has §a/§b/§c (e.g. Go after PR #1066), **do not replace it wholesale**. Walk these explicit preserve rules:
+
+- Preserve `✓ shipped #NNNN` markers in §c
+- Preserve "Retired" subsection (false-positive history is load-bearing)
+- Preserve `skipped (reason)` rows
+- Preserve survey-status entries that still hold (don't redo the grep if the toolchain hasn't moved)
+- Update only: rows whose toolchain gate has shifted, rows with new findings from extended grep, rows superseded by features in newer versions
+
+If the section is in pre-redo single-table format (no §a/§b/§c), wholesale replacement is fine.
+
+### How to invoke Part A
+
+> Build (or upgrade) the {language} section of `docs/reference/modernization-backlog.md` following Part A of `docs/reference/modernization-prompts.md`. {Build mode | Upgrade-in-place mode}. Use real grep results, not "no candidates surfaced." Output the new section and the list of survey commands run (so the audit is reproducible).
+
+---
+
+## Part B — Executing a section row-by-row
+
+### Loop
+
+1. **Read** `docs/reference/modernization-backlog.md` §c for the active language section.
+2. **Pick the next row** by status `next`, falling through to the lowest-numbered live row. If §c isn't ranked yet (pre-redo section), generate a ranking via the criteria below and present it for approval before starting work.
+3. **For the chosen row, write a brief.** Include:
+   - **Where:** exact file paths and counts (re-verify with grep — counts decay)
+   - **What it does:** describe the rewrite in plain English; show before/after if non-obvious
+   - **Why do it:** real benefit (correctness, performance, readability, lint-clean)
+   - **Why not:** honest counter-arguments (diff churn, semantic risk, low value)
+   - **Alternatives:** any competing modern target (e.g. `slices.Chunk` vs `for i := range`)
+   - **My call:** a recommendation, framed so the user can override
+4. **Wait for the user's call.** Do not start the PR until they say go.
+5. **When go is given:** create a worktree per CLAUDE.md if one isn't already in use, write a failing test if behavioral (per Rule 3), implement, run `lefthook run pre-push`, push, open a tiny focused PR.
+6. **After merge:** mark the row `✓ shipped #NNNN` in §c. Return to step 2.
+7. **If user rejects the row:** mark it `skipped (reason)` in §c with one-line reason. Return to step 2.
+
+### Section-done criterion
+
+A section is done when every live row in §c is either `✓ shipped`, `skipped (reason)`, or `deferred` with a recorded gate. Trigger a fresh Part A pass when:
+
+- The toolchain bumps to a new minor version (new features available)
+- A `deferred` row's gate flips (ecosystem signal arrives)
+- "Review cadence" in the backlog says it's time
+
+### Ranking criteria (easiest → hardest)
+
+Score each row by these axes; lower total = easier:
+
+| Axis | 1 (easy) | 2 | 3 (hard) |
+|---|---|---|---|
+| Scope | 1–3 callsites | 4–20 | 20+ or repo-wide |
+| Mechanical vs semantic | pure renames | signature change | behavioral / contract change |
+| Test surface | no tests touched | a few tests adjusted | new tests required |
+| Blast radius | one file | one package | cross-package |
+| Toolchain prereq | none | feature already in use | requires version bump |
+
+**Tie-breaker:** prefer items that *unblock* a later item (e.g. `slices.Chunk` subsumes part of `for i := range` — do `slices.Chunk` first).
+
+### PR sizing rules
+
+- One row per PR by default.
+- Bundle two rows only if both are <10 callsites *and* touch the same file(s).
+- Title: conventional commit (`refactor(sync):`, `fix(sync):`, etc., per CLAUDE.md scopes).
+- Body: link the backlog row by `#` and quote the "what it does" + "why" lines from the brief.
+- For codemods (e.g. `interface{}` → `any`), include the exact `gofmt -r` / `sed` / autofix command in the PR body so the change is reproducible.
+
+### Verification before claiming done
+
+Run `lefthook run pre-push`, plus targeted package tests for the touched code. For behavioral changes, re-run the failing test from step 5 to confirm it passes after the implementation. **Never claim "done" before pre-push is green.**
+
+### What this loop does NOT do
+
+- Plan multiple rows in parallel — one PR at a time keeps reviews fast.
+- Skip the user-decision step — each row is a small bet; the user makes the call after seeing the brief.
+- Update §a or §b retroactively — if a finding goes stale, run Part A in upgrade-in-place mode instead.
+
+### How to invoke Part B
+
+> Resume modernization-backlog execution per Part B of `docs/reference/modernization-prompts.md`. Read `docs/reference/modernization-backlog.md` §{N}c for the active language, identify the next row (status `next`, else lowest-numbered live row, last shipped: #N), and present its brief.
+
+---
+
+## Appendix — per-language version-feature checklists
+
+These are the lookup tables used by Part A Steps 1–3. Each row says "if you find pattern X, you've found a candidate for feature Y added in version Z." Add new rows as language versions ship.
+
+### Go (post-1.18 features)
+
+| Since | Feature | Search expression |
+|---|---|---|
+| 1.18 | `any` alias | `grep -rn 'interface{}'` |
+| 1.18 | generics | `grep -rn 'func [A-Za-z]*\[[A-Z]'` |
+| 1.20 | `errors.Join` | `grep -rn 'errors.Join'` (and chained `fmt.Errorf` with `%w` repeated) |
+| 1.21 | `slices`, `maps`, `cmp` packages | `grep -rln '"sort"'` (legacy users) |
+| 1.21 | `clear()` builtin | manual map-clear loops |
+| 1.21 | `min`/`max` builtins | manual `if a > b` ternaries, `math.Min/Max` for ints |
+| 1.21 | `log/slog` | `grep -rn 'log.Print'` (legacy users) |
+| 1.22 | `cmp.Or` | chained `if x != "" { return x }` patterns |
+| 1.22 | `math/rand/v2` | `grep -rn '"math/rand"'` |
+| 1.22 | loop-var per-iteration scoping | `for i := 0; i < len(s); i++` (closure-capture safety) |
+| 1.22 | `slices.Concat` | `append(x, y...)` |
+| 1.23 | range-over-func | callback-iter patterns (`func(...) bool`) |
+| 1.23 | `slices.Chunk` | `for i := 0; i < len(x); i += batchSize` |
+| 1.24 | generic type aliases | repeated generic instantiations |
+| 1.24 | `os.Root` | untrusted-input file ops |
+| 1.25 | `testing/synctest` (GA) | `time.Sleep` in tests |
+| 1.25 | `encoding/json/v2` | `json.Marshal/Unmarshal` hot paths |
+
+### Python (post-3.10 features, when running on 3.14)
+
+| Since | Feature | Search expression |
+|---|---|---|
+| 3.10 | `match` statement | long isinstance chains |
+| 3.10 | `X \| Y` unions | `from typing import Union` |
+| 3.11 | `tomllib` | `tomli`/`toml` usage |
+| 3.11 | `Self` type | `TypeVar.*Self`, awkward forward refs |
+| 3.11 | `ExceptionGroup` / `except*` | manual exception aggregation |
+| 3.11 | `asyncio.TaskGroup` | `asyncio.gather` |
+| 3.12 | PEP 695 generic syntax | `TypeVar(...)` declarations |
+| 3.12 | `@override` decorator | inheritance hierarchies without it |
+| 3.12 | `itertools.batched` | `range(0, len(x), n)` chunking |
+| 3.12 | `from __future__ import annotations` | now redundant under PEP 649 (3.14) |
+| 3.13 | `typing.TypeIs` | `TypeGuard` users |
+| 3.13 | `typing.ReadOnly` | TypedDict mutation concerns |
+| 3.13 | `copy.replace()` | `dataclasses.replace` |
+| 3.14 | PEP 649 deferred annotations | drop `from __future__ import annotations` |
+| 3.14 | PEP 750 t-strings | SQL/HTML template builders |
+| 3.14 | `compression.zstd` | zstandard dependency |
+
+### TypeScript / JS (post-ES2020 features)
+
+| Since | Feature | Search expression |
+|---|---|---|
+| ES2020 | optional chaining `?.` | nested `&&` access |
+| ES2020 | nullish coalescing `??` | `\|\|` for default-when-null |
+| ES2021 | `String.replaceAll` | `.replace(/.../g, ...)` |
+| ES2022 | `Array.prototype.at(-1)` | `arr[arr.length - 1]` |
+| ES2022 | `structuredClone` | `JSON.parse(JSON.stringify(x))` |
+| ES2022 | error `cause` chaining | `throw new Error(...)` without `cause` |
+| ES2023 | `Array.prototype.toSorted/toReversed` | `[...arr].sort()`, `[...arr].reverse()` |
+| ES2023 | `Array.findLast` | `.reverse().find()` |
+| ES2024 | `Object.groupBy` | `reduce` groupBy patterns |
+| ES2025 | `Promise.try` | sync-or-async wrapper logic |
+| TS 5.0 | `const` type params | `as const` overuse |
+| TS 5.0 | decorators (stage 3) | legacy decorators |
+| React 19 | `use()` hook | `useContext` consumers + provider wrappers |
+| React 19 | `<Context>` shorthand | `<Context.Provider>` |
+| React 19 | `useActionState` / `useFormStatus` | form-submission `useState` |

--- a/docs/reference/modernization-prompts.md
+++ b/docs/reference/modernization-prompts.md
@@ -75,7 +75,7 @@ Commands per language:
 
 | Language | Toolchain pin | Installed | Latest stable check |
 |---|---|---|---|
-| Go | `grep -E '^(go\|toolchain) ' go.mod` | `go version` | go.dev/doc/devel/release |
+| Go | `grep -E '^(go|toolchain) ' go.mod` | `go version` | go.dev/doc/devel/release |
 | Python | `grep requires-python pyproject.toml` + `cat .python-version` | `python --version` | python.org/downloads |
 | Node | `jq .engines package.json` + `cat .nvmrc` | `node -v` | nodejs.org |
 | TypeScript | `cd frontend && jq .compilerOptions.target tsconfig.json` | `cd frontend && npx tsc -v` | typescriptlang.org |

--- a/pocketbase/rbac/hooks.go
+++ b/pocketbase/rbac/hooks.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
-	"sort"
 
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/apis"
@@ -27,7 +26,7 @@ func flattenPermissions(rolePermissions [][]string) []string {
 	for p := range seen {
 		result = append(result, p)
 	}
-	sort.Strings(result)
+	slices.Sort(result)
 	return result
 }
 

--- a/pocketbase/sync/base_sync.go
+++ b/pocketbase/sync/base_sync.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -1060,8 +1060,8 @@ func (b *BaseSyncService) FieldEquals(existingValue, newValue interface{}) bool 
 			newSlice := normalizeToStringSlice(newValue)
 			if existingSlice != nil && newSlice != nil {
 				// Sort both slices for order-independent comparison
-				sort.Strings(existingSlice)
-				sort.Strings(newSlice)
+				slices.Sort(existingSlice)
+				slices.Sort(newSlice)
 				return reflect.DeepEqual(existingSlice, newSlice)
 			}
 			// Fall back to direct comparison if normalization failed
@@ -1399,8 +1399,8 @@ func (b *BaseSyncService) LogFieldDiffSummary() {
 	for field, count := range b.FieldDiffStats {
 		counts = append(counts, fieldCount{field, count})
 	}
-	sort.Slice(counts, func(i, j int) bool {
-		return counts[i].count > counts[j].count
+	slices.SortFunc(counts, func(a, b fieldCount) int {
+		return b.count - a.count
 	})
 
 	slog.Debug("Field diff summary (fields causing updates)",

--- a/pocketbase/sync/base_sync.go
+++ b/pocketbase/sync/base_sync.go
@@ -119,9 +119,7 @@ func (b *BaseSyncService) DebugLog(msg string, args ...any) {
 
 // ClearProcessedKeys resets the processed keys tracker
 func (b *BaseSyncService) ClearProcessedKeys() {
-	for k := range b.ProcessedKeys {
-		delete(b.ProcessedKeys, k)
-	}
+	clear(b.ProcessedKeys)
 }
 
 // TrackProcessedKey adds a composite key to the processed keys map
@@ -1414,9 +1412,7 @@ func (b *BaseSyncService) LogFieldDiffSummary() {
 
 // ClearFieldDiffStats resets the field diff statistics
 func (b *BaseSyncService) ClearFieldDiffStats() {
-	for k := range b.FieldDiffStats {
-		delete(b.FieldDiffStats, k)
-	}
+	clear(b.FieldDiffStats)
 }
 
 // formatFieldValue formats a field value for logging, truncating long values

--- a/pocketbase/sync/base_sync_test.go
+++ b/pocketbase/sync/base_sync_test.go
@@ -74,6 +74,61 @@ func TestBaseSyncService_TrackProcessedCompositeKey(t *testing.T) {
 	}
 }
 
+func TestBaseSyncService_ClearProcessedKeys(t *testing.T) {
+	service := BaseSyncService{
+		ProcessedKeys: make(map[string]bool),
+	}
+
+	service.TrackProcessedKey(12345, 2025)
+	service.TrackProcessedKey("abc", 2024)
+	if len(service.ProcessedKeys) != 2 {
+		t.Fatalf("setup: expected 2 tracked keys, got %d", len(service.ProcessedKeys))
+	}
+
+	service.ClearProcessedKeys()
+
+	if len(service.ProcessedKeys) != 0 {
+		t.Errorf("after Clear: expected 0 keys, got %d", len(service.ProcessedKeys))
+	}
+	if service.ProcessedKeys == nil {
+		t.Error("after Clear: map must not be nil (must remain reusable)")
+	}
+
+	// Map must remain reusable after clear (re-track + re-lookup must work)
+	service.TrackProcessedKey(99999, 2026)
+	if !service.IsKeyProcessed(99999, 2026) {
+		t.Error("after Clear: tracking a new key after clear must still work")
+	}
+
+	// Clearing an already-empty map must be a no-op (no panic)
+	service.ClearProcessedKeys()
+	service.ClearProcessedKeys()
+	if len(service.ProcessedKeys) != 0 {
+		t.Errorf("repeat Clear: expected 0 keys, got %d", len(service.ProcessedKeys))
+	}
+}
+
+func TestBaseSyncService_ClearFieldDiffStats(t *testing.T) {
+	service := BaseSyncService{
+		FieldDiffStats: map[string]int{"name": 3, "email": 5},
+	}
+
+	service.ClearFieldDiffStats()
+
+	if len(service.FieldDiffStats) != 0 {
+		t.Errorf("after Clear: expected 0 entries, got %d", len(service.FieldDiffStats))
+	}
+	if service.FieldDiffStats == nil {
+		t.Error("after Clear: map must not be nil (must remain reusable)")
+	}
+
+	// Map must remain reusable after clear
+	service.FieldDiffStats["new_field"] = 1
+	if service.FieldDiffStats["new_field"] != 1 {
+		t.Error("after Clear: writing to map after clear must still work")
+	}
+}
+
 func TestBaseSyncService_FindOrphansFromPreloaded(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/pocketbase/sync/camper_history_test.go
+++ b/pocketbase/sync/camper_history_test.go
@@ -2,7 +2,7 @@ package sync
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 
@@ -543,7 +543,7 @@ func joinSorted(strs []string) string {
 	}
 	sorted := make([]string, len(strs))
 	copy(sorted, strs)
-	sort.Strings(sorted)
+	slices.Sort(sorted)
 	result := sorted[0]
 	for i := 1; i < len(sorted); i++ {
 		result += ", " + sorted[i]

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -2,7 +2,7 @@ package sync
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -160,7 +160,7 @@ func TestMultipleAdultsPerHousehold(t *testing.T) {
 	for i, a := range adults {
 		adultNums[i] = a.AdultNumber
 	}
-	sort.Ints(adultNums)
+	slices.Sort(adultNums)
 	expected := []int{1, 2, 3, 5}
 	if len(adultNums) != len(expected) {
 		t.Errorf("expected adult numbers %v, got %v", expected, adultNums)

--- a/pocketbase/sync/multi_workbook_ordering.go
+++ b/pocketbase/sync/multi_workbook_ordering.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -29,7 +29,7 @@ func SortGlobalsWorkbookTabs(tabs []string) []string {
 	}
 
 	// Sort other tabs alphabetically
-	sort.Strings(otherTabs)
+	slices.Sort(otherTabs)
 
 	// Build result: Index first, then alphabetized
 	result := make([]string, 0, len(tabs))
@@ -46,7 +46,7 @@ func SortGlobalsWorkbookTabs(tabs []string) []string {
 func SortYearWorkbookTabs(tabs []string) []string {
 	sorted := make([]string, len(tabs))
 	copy(sorted, tabs)
-	sort.Strings(sorted)
+	slices.Sort(sorted)
 	return sorted
 }
 

--- a/pocketbase/sync/normalize_geographic_test.go
+++ b/pocketbase/sync/normalize_geographic_test.go
@@ -1,11 +1,12 @@
 package sync
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -1841,8 +1842,8 @@ func TestBuildContextValuesFromMap(t *testing.T) {
 	}
 
 	// Sort for deterministic comparison
-	sort.Slice(contextValues, func(i, j int) bool {
-		return contextValues[i].Value < contextValues[j].Value
+	slices.SortFunc(contextValues, func(a, b valueWithContext) int {
+		return cmp.Compare(a.Value, b.Value)
 	})
 
 	// London should be first (alphabetical)

--- a/pocketbase/sync/table_exporter.go
+++ b/pocketbase/sync/table_exporter.go
@@ -3,7 +3,7 @@ package sync
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -361,7 +361,7 @@ func (r *FieldResolver) resolveMultiRelation(value interface{}, col *ColumnConfi
 	}
 
 	// Sort for consistent output
-	sort.Strings(values)
+	slices.Sort(values)
 	return strings.Join(values, ", ")
 }
 
@@ -389,7 +389,7 @@ func (r *FieldResolver) resolveMultiSelect(value interface{}) string {
 		return ""
 	}
 
-	sort.Strings(values)
+	slices.Sort(values)
 	return strings.Join(values, ", ")
 }
 

--- a/pocketbase/sync/workbook_manager.go
+++ b/pocketbase/sync/workbook_manager.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/camp/kindred/pocketbase/google"
@@ -417,16 +417,18 @@ func BuildIndexSheetData(workbooks []WorkbookRecord) [][]interface{} {
 	// Sort workbooks: globals first, then years descending
 	sorted := make([]WorkbookRecord, len(workbooks))
 	copy(sorted, workbooks)
-	sort.Slice(sorted, func(i, j int) bool {
+	slices.SortFunc(sorted, func(a, b WorkbookRecord) int {
 		// Globals always first
-		if sorted[i].WorkbookType == workbookTypeGlobals {
-			return true
+		aGlobal := a.WorkbookType == workbookTypeGlobals
+		bGlobal := b.WorkbookType == workbookTypeGlobals
+		if aGlobal && !bGlobal {
+			return -1
 		}
-		if sorted[j].WorkbookType == workbookTypeGlobals {
-			return false
+		if !aGlobal && bGlobal {
+			return 1
 		}
 		// Years in descending order
-		return sorted[i].Year > sorted[j].Year
+		return b.Year - a.Year
 	})
 
 	// Preallocate data with header row + one row per workbook


### PR DESCRIPTION
## Summary

Two related changes shipped together. The first commit implements rank #1 of the Go modernization execution order; the second commit applies a review pass on the modernization framework itself (backlog + prompt docs) — same files, tightly coupled.

## Commit 1: `clear()` builtin refactor

Implements rank #1 of `docs/reference/modernization-backlog.md` §2c.

```go
// Before
for k := range b.ProcessedKeys {
    delete(b.ProcessedKeys, k)
}

// After
clear(b.ProcessedKeys)
```

Same semantics, one runtime intrinsic instead of N hash lookups. Adds locking tests for both `ClearProcessedKeys` and `ClearFieldDiffStats` (no prior coverage). Tests written first, verified passing on the old implementation, re-verified after the rewrite.

Also annotates the `strings.Index() != -1 → strings.Contains` row in §2a as a **FALSE POSITIVE** — the audit pattern-matched on the regex without inspecting the body, but the single hit at `sync/base_sync.go:1084` uses `idx` as a slice boundary 7 lines later. `strings.Contains` would discard a value the next 7 lines depend on.

## Commit 2: modernization framework review fixes

Applies 14 findings from a review pass on the framework docs:

**Backlog edits** (`modernization-backlog.md`):
- Execution-model preamble: each section governs its own order; no cross-section ranking
- Format-note banners on §1 (Python), §3 (Frontend) noting they predate the §a/§b/§c redo
- Note on §4 (Infrastructure): hardening checklist, not a language-version audit
- §2b: ungate `testing/synctest` (1.25 GA shipped, toolchain is 1.26); rephrase `encoding/json/v2` gate to "ecosystem signal"
- §2c: extract retired false-positive to its own subsection; renumber live items 1–16; mark #1 (`clear()`) as ✓ shipped; ungate #15 (synctest); reword #16 gate
- Drop "Suggested overall PR order" (conflicted with §2c, had a dual-`4.` numbering bug)

**Prompt consolidation** — replaces `modernization-coverage-prompt.md` + `modernization-execution-prompt.md` with a single `modernization-prompts.md`:
- Two parts (A: build/upgrade a section, B: execute row-by-row), shared rules section, per-language version-feature appendix
- Promotes the false-positive lesson out of a footnote into "Rule 1: Verify in context, not against the regex"
- Adds "Rule 2: Three independent versions" (toolchain/installed/idiom triad) and "Rule 3: Tests are the spec" (TDD clarified per row: behavioral rows = failing test first; pure rewrites = existing tests + pre-push)
- Reorganizes Part A so the version-feature appendix is the *tool* used by Steps 1–3, not an afterthought
- Adds upgrade-in-place mode with explicit preserve rules (✓ shipped markers, retired subsection, skipped reasons) replacing the destructive "replace it" instruction
- Adds `skipped (reason)` row state and section-done criterion to Part B
- Fixes `npx tsc -v` → `cd frontend && npx tsc -v`

## Test plan

- [x] `go test ./sync/ -run 'TestBaseSyncService_Clear' -v` — 2 passed
- [x] `go test ./sync/` — 1995 passed
- [x] `lefthook run pre-push` (clear() commit) — ruff-check, shellcheck, pb-js-lint, go-build, mypy, type-check all green
- [x] `lefthook run pre-push` (docs commit) — all hooks correctly skipped (no code-triggering files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reworked the modernization backlog to use per-section execution ordering, reorganized the Go rewrite matrix, added precision for artifact types, and removed the global PR-order list.
  * Added a new modernization guidance page detailing an end-to-end process, audit rules, execution loop, PR conventions, and language-specific checklists.

* **Refactor**
  * Simplified internal map-reset implementation to a clearer reset behavior.

* **Tests**
  * Added tests verifying map-reset behavior remains safe and reusable after clearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->