### PR TITLE
refactor(sync): adopt min/max builtins and cmp.Or

### DIFF
--- a/pocketbase/ratelimit/ratelimit.go
+++ b/pocketbase/ratelimit/ratelimit.go
@@ -75,7 +75,7 @@ func (r *RateLimiter) HandleError(err error) (shouldRetry bool, waitTime time.Du
 		r.consecutiveErrors++
 
 		// Calculate exponential backoff
-		waitTime = time.Duration(math.Min(
+		waitTime = time.Duration(min(
 			float64(r.currentDelay)*math.Pow(r.config.BackoffMultiplier, float64(r.consecutiveErrors-1)),
 			float64(r.config.MaxDelay),
 		))

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -562,9 +562,7 @@ func (o *Orchestrator) runSingleSyncInternal(parentCtx context.Context, syncType
 		timeout := 2 * time.Hour
 		if parentDeadline, hasDeadline := parentCtx.Deadline(); hasDeadline {
 			remaining := time.Until(parentDeadline)
-			if remaining > timeout {
-				timeout = remaining
-			}
+			timeout = max(timeout, remaining)
 		}
 		syncCtx, cancel = context.WithTimeout(context.Background(), timeout)
 		defer cancel()

--- a/pocketbase/sync/persons.go
+++ b/pocketbase/sync/persons.go
@@ -634,11 +634,7 @@ func (s *PersonsSync) transformPersonToPB(
 
 	// Cap last_year_attended at current year (since we only sync enrolled attendees)
 	lastYear := s.getInt(camperDetails, "LastYearAttended", 0)
-	if lastYear > year {
-		pbData["last_year_attended"] = year
-	} else {
-		pbData["last_year_attended"] = lastYear
-	}
+	pbData["last_year_attended"] = min(lastYear, year)
 
 	// Gender identity and pronouns
 	pbData["gender_identity_id"] = s.getInt(cmPerson, "GenderIdentityID", 0)

--- a/pocketbase/sync/rate_limited_sheets_writer.go
+++ b/pocketbase/sync/rate_limited_sheets_writer.go
@@ -208,9 +208,7 @@ func (w *RateLimitedSheetsWriter) executeWithRetry(
 
 		// Exponential backoff with cap
 		backoff = time.Duration(float64(backoff) * w.config.BackoffMultiplier)
-		if backoff > w.config.MaxBackoff {
-			backoff = w.config.MaxBackoff
-		}
+		backoff = min(backoff, w.config.MaxBackoff)
 	}
 
 	slog.Error("Google Sheets rate limit retries exhausted",

--- a/pocketbase/sync/table_exporter.go
+++ b/pocketbase/sync/table_exporter.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"sort"
@@ -255,11 +256,8 @@ func (r *FieldResolver) ResolveValue(value interface{}, col *ColumnConfig) inter
 		if pbID == "" {
 			return ""
 		}
-		resolved := r.LookupValue(col.RelatedCol, pbID)
-		if resolved != "" {
-			return resolved
-		}
-		return pbID // Fallback to raw ID
+		// Fallback to raw ID if no display value resolves
+		return cmp.Or(r.LookupValue(col.RelatedCol, pbID), pbID)
 
 	case FieldTypeMultiRelation:
 		// Multi-relation - lookup all values and join with comma


### PR DESCRIPTION
## Summary

Modernization backlog §2c rows #4–5 (renumbered after PR #1066 lands). Pure rewrites — existing tests are the spec, all sync/ + ratelimit/ package tests (2016 cases) pass.

## Changes

**\`min\` / \`max\` (Go 1.21):**
- \`sync/orchestrator.go:565\` — \`timeout = max(timeout, remaining)\`
- \`sync/rate_limited_sheets_writer.go:211\` — \`backoff = min(backoff, w.config.MaxBackoff)\`
- \`sync/persons.go:637–641\` — collapse 5-line if/else to \`pbData["last_year_attended"] = min(lastYear, year)\`
- \`ratelimit/ratelimit.go:78\` — \`math.Min(float64(…), float64(…))\` → \`min(…)\` (\`math.Pow\` keeps the import)

**\`cmp.Or\` (Go 1.22):**
- \`sync/table_exporter.go:262\` — \`if resolved != "" { return resolved } return pbID\` → \`cmp.Or(r.LookupValue(…), pbID)\`

## Audit hygiene

The original §2c audit listed ~11 \`min\`/\`max\` candidates and ~5 \`cmp.Or\` candidates. Per-site verification (Rule 1 in \`docs/reference/modernization-prompts.md\`) found 7 + 4 false positives:

- \`sheets_scheduling.go:60,63\`, \`persons.go:1029\`, \`feedback/handler.go:104\` — early-return validators (\`if x > N { return error }\`); \`min\`/\`max\` doesn't apply
- \`ratelimit/ratelimit.go:85\` — \`if\` body has side effects (\`SetLimit(...)\`)
- \`normalize_geographic.go:487\`, \`table_exporter.go:358\` — "if non-empty, do X" patterns (not first-non-zero fallbacks)

§2c will be narrowed and marked shipped on PR #1066's branch (which currently owns the audit-trail table).

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./sync/... ./ratelimit/...\` — 2016 tests pass
- [x] \`lefthook run pre-push\` — all gates green (ruff, eslint, shellcheck, go-build, tsc, mypy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Internal code optimizations and simplifications to improve maintainability without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->