### PR TITLE
refactor(sync): map[string]interface{} → any codemod

### DIFF
--- a/pocketbase/campminder/client.go
+++ b/pocketbase/campminder/client.go
@@ -131,7 +131,7 @@ func (c *Client) authenticate() error {
 		}
 
 		if decoded, err := base64.StdEncoding.DecodeString(payload); err == nil {
-			var claims map[string]interface{}
+			var claims map[string]any
 			if err := json.Unmarshal(decoded, &claims); err == nil {
 				if exp, ok := claims["exp"].(float64); ok {
 					c.tokenExpiry = time.Unix(int64(exp), 0)
@@ -282,7 +282,7 @@ func (c *Client) makeRequest(method, endpoint string, params map[string]string) 
 // GetSessions retrieves all sessions for the configured season
 //
 //nolint:dupl // Similar pattern to GetSessionGroups, intentional for different endpoints
-func (c *Client) GetSessions() ([]map[string]interface{}, error) {
+func (c *Client) GetSessions() ([]map[string]any, error) {
 	params := map[string]string{
 		"clientid":   c.clientID,
 		"seasonid":   strconv.Itoa(c.seasonID),
@@ -296,8 +296,8 @@ func (c *Client) GetSessions() ([]map[string]interface{}, error) {
 	}
 
 	var response struct {
-		TotalCount int                      `json:"TotalCount"`
-		Results    []map[string]interface{} `json:"Results"`
+		TotalCount int              `json:"TotalCount"`
+		Results    []map[string]any `json:"Results"`
 	}
 
 	if err := json.Unmarshal(body, &response); err != nil {
@@ -308,7 +308,7 @@ func (c *Client) GetSessions() ([]map[string]interface{}, error) {
 }
 
 // GetAttendeesPage retrieves attendees with pagination
-func (c *Client) GetAttendeesPage(page, pageSize int) (results []map[string]interface{}, hasMore bool, err error) {
+func (c *Client) GetAttendeesPage(page, pageSize int) (results []map[string]any, hasMore bool, err error) {
 	params := map[string]string{
 		"clientid":   c.clientID,
 		"seasonid":   strconv.Itoa(c.seasonID),
@@ -322,9 +322,9 @@ func (c *Client) GetAttendeesPage(page, pageSize int) (results []map[string]inte
 	}
 
 	var response struct {
-		TotalCount int                      `json:"TotalCount"`
-		Next       *string                  `json:"Next"`
-		Results    []map[string]interface{} `json:"Results"`
+		TotalCount int              `json:"TotalCount"`
+		Next       *string          `json:"Next"`
+		Results    []map[string]any `json:"Results"`
 	}
 
 	if err := json.Unmarshal(body, &response); err != nil {
@@ -336,7 +336,7 @@ func (c *Client) GetAttendeesPage(page, pageSize int) (results []map[string]inte
 }
 
 // GetPersons retrieves person records by IDs
-func (c *Client) GetPersons(personIDs []int) ([]map[string]interface{}, error) {
+func (c *Client) GetPersons(personIDs []int) ([]map[string]any, error) {
 	if len(personIDs) == 0 {
 		return nil, nil
 	}
@@ -383,8 +383,8 @@ func (c *Client) GetPersons(personIDs []int) ([]map[string]interface{}, error) {
 	}
 
 	var response struct {
-		TotalCount int                      `json:"TotalCount"`
-		Results    []map[string]interface{} `json:"Results"`
+		TotalCount int              `json:"TotalCount"`
+		Results    []map[string]any `json:"Results"`
 	}
 
 	if err := json.Unmarshal(body, &response); err != nil {
@@ -395,7 +395,7 @@ func (c *Client) GetPersons(personIDs []int) ([]map[string]interface{}, error) {
 }
 
 // GetPersonsPage retrieves all persons with pagination (no seasonid for latest data)
-func (c *Client) GetPersonsPage(page, pageSize int) (results []map[string]interface{}, hasMore bool, err error) {
+func (c *Client) GetPersonsPage(page, pageSize int) (results []map[string]any, hasMore bool, err error) {
 	params := map[string]string{
 		"clientid":                c.clientID,
 		"pagenumber":              strconv.Itoa(page),
@@ -415,9 +415,9 @@ func (c *Client) GetPersonsPage(page, pageSize int) (results []map[string]interf
 	}
 
 	var response struct {
-		TotalCount int                      `json:"TotalCount"`
-		Next       *string                  `json:"Next"`
-		Results    []map[string]interface{} `json:"Results"`
+		TotalCount int              `json:"TotalCount"`
+		Next       *string          `json:"Next"`
+		Results    []map[string]any `json:"Results"`
 	}
 
 	if err := json.Unmarshal(body, &response); err != nil {
@@ -439,7 +439,7 @@ func (c *Client) GetClientID() string {
 }
 
 // GetBunks retrieves all bunks for the configured season
-func (c *Client) GetBunks() ([]map[string]interface{}, error) {
+func (c *Client) GetBunks() ([]map[string]any, error) {
 	params := map[string]string{
 		"clientid":       c.clientID,
 		"seasonid":       strconv.Itoa(c.seasonID),
@@ -455,8 +455,8 @@ func (c *Client) GetBunks() ([]map[string]interface{}, error) {
 	}
 
 	var response struct {
-		Results []map[string]interface{} `json:"Results"`
-		Count   int                      `json:"count"`
+		Results []map[string]any `json:"Results"`
+		Count   int              `json:"count"`
 	}
 
 	if err := json.Unmarshal(body, &response); err != nil {
@@ -467,7 +467,7 @@ func (c *Client) GetBunks() ([]map[string]interface{}, error) {
 }
 
 // GetBunkPlansPage retrieves a page of bunk plans
-func (c *Client) GetBunkPlansPage(page, pageSize int) (results []map[string]interface{}, hasMore bool, err error) {
+func (c *Client) GetBunkPlansPage(page, pageSize int) (results []map[string]any, hasMore bool, err error) {
 	params := map[string]string{
 		"clientid":       c.clientID,
 		"seasonid":       strconv.Itoa(c.seasonID),
@@ -482,9 +482,9 @@ func (c *Client) GetBunkPlansPage(page, pageSize int) (results []map[string]inte
 	}
 
 	var response struct {
-		Results []map[string]interface{} `json:"Results"`
-		Count   int                      `json:"count"`
-		Next    *string                  `json:"next"`
+		Results []map[string]any `json:"Results"`
+		Count   int              `json:"count"`
+		Next    *string          `json:"next"`
 	}
 
 	if err := json.Unmarshal(body, &response); err != nil {
@@ -496,7 +496,7 @@ func (c *Client) GetBunkPlansPage(page, pageSize int) (results []map[string]inte
 }
 
 // GetBunkAssignments retrieves bunk assignments for specified bunk plans and bunks
-func (c *Client) GetBunkAssignments(bunkPlanIDs, bunkIDs []int, page, pageSize int) ([]map[string]interface{}, error) {
+func (c *Client) GetBunkAssignments(bunkPlanIDs, bunkIDs []int, page, pageSize int) ([]map[string]any, error) {
 	// Build URL with multiple ID parameters
 	assignURL := fmt.Sprintf("%s/bunks/assignments", baseURL)
 
@@ -526,8 +526,8 @@ func (c *Client) GetBunkAssignments(bunkPlanIDs, bunkIDs []int, page, pageSize i
 	}
 
 	var response struct {
-		Results []map[string]interface{} `json:"Results"`
-		Count   int                      `json:"count"`
+		Results []map[string]any `json:"Results"`
+		Count   int              `json:"count"`
 	}
 
 	if err := json.Unmarshal(body, &response); err != nil {
@@ -578,7 +578,7 @@ func (c *Client) parseRateLimitSeconds(body string) int {
 // GetSessionGroups retrieves session groupings for the configured season
 //
 //nolint:dupl // Similar pattern to GetSessions, intentional for different endpoints
-func (c *Client) GetSessionGroups() ([]map[string]interface{}, error) {
+func (c *Client) GetSessionGroups() ([]map[string]any, error) {
 	params := map[string]string{
 		"clientid":   c.clientID,
 		"seasonid":   strconv.Itoa(c.seasonID),
@@ -592,8 +592,8 @@ func (c *Client) GetSessionGroups() ([]map[string]interface{}, error) {
 	}
 
 	var response struct {
-		TotalCount int                      `json:"TotalCount"`
-		Results    []map[string]interface{} `json:"Results"`
+		TotalCount int              `json:"TotalCount"`
+		Results    []map[string]any `json:"Results"`
 	}
 
 	if err := json.Unmarshal(body, &response); err != nil {
@@ -607,7 +607,7 @@ func (c *Client) GetSessionGroups() ([]map[string]interface{}, error) {
 // Endpoint: /persons/tags
 // Returns: array of tag definitions with Name, IsSeasonal, IsHidden, LastUpdatedUTC
 // Note: This endpoint returns a raw array, not a paginated response
-func (c *Client) GetPersonTagDefinitions() ([]map[string]interface{}, error) {
+func (c *Client) GetPersonTagDefinitions() ([]map[string]any, error) {
 	params := map[string]string{
 		"clientid": c.clientID,
 	}
@@ -618,7 +618,7 @@ func (c *Client) GetPersonTagDefinitions() ([]map[string]interface{}, error) {
 	}
 
 	// This endpoint returns a raw array, not a paginated response
-	var results []map[string]interface{}
+	var results []map[string]any
 	if err := json.Unmarshal(body, &results); err != nil {
 		return nil, fmt.Errorf("decode person tag definitions response: %w", err)
 	}
@@ -631,7 +631,7 @@ func (c *Client) GetPersonTagDefinitions() ([]map[string]interface{}, error) {
 // Returns: array of custom field definitions with Id, Name, DataType, Partition, IsSeasonal, IsArray, IsActive
 func (c *Client) GetCustomFieldDefinitionsPage(
 	page, pageSize int,
-) (results []map[string]interface{}, hasMore bool, err error) {
+) (results []map[string]any, hasMore bool, err error) {
 	params := map[string]string{
 		"clientid":   c.clientID,
 		"pagenumber": strconv.Itoa(page),
@@ -646,9 +646,9 @@ func (c *Client) GetCustomFieldDefinitionsPage(
 	// CampMinder uses inconsistent casing across endpoints
 	// /persons/custom-fields uses camelCase: totalCount, next, result
 	var response struct {
-		TotalCount int                      `json:"totalCount"`
-		Next       *string                  `json:"next"`
-		Result     []map[string]interface{} `json:"result"`
+		TotalCount int              `json:"totalCount"`
+		Next       *string          `json:"next"`
+		Result     []map[string]any `json:"result"`
 	}
 
 	if err := json.Unmarshal(body, &response); err != nil {
@@ -667,7 +667,7 @@ func (c *Client) GetCustomFieldDefinitionsPage(
 //nolint:dupl // Similar pattern to GetHouseholdCustomFieldValuesPage, intentional for person variant
 func (c *Client) GetPersonCustomFieldValuesPage(
 	personID, page, pageSize int,
-) (results []map[string]interface{}, hasMore bool, err error) {
+) (results []map[string]any, hasMore bool, err error) {
 	endpoint := fmt.Sprintf("persons/%d/custom-fields", personID)
 	params := map[string]string{
 		"clientid":   c.clientID,
@@ -683,9 +683,9 @@ func (c *Client) GetPersonCustomFieldValuesPage(
 
 	// CampMinder uses camelCase for custom field endpoints
 	var response struct {
-		TotalCount int                      `json:"totalCount"`
-		Next       *string                  `json:"next"`
-		Result     []map[string]interface{} `json:"result"`
+		TotalCount int              `json:"totalCount"`
+		Next       *string          `json:"next"`
+		Result     []map[string]any `json:"result"`
 	}
 
 	if err := json.Unmarshal(body, &response); err != nil {
@@ -704,7 +704,7 @@ func (c *Client) GetPersonCustomFieldValuesPage(
 //nolint:dupl // Similar pattern to GetPersonCustomFieldValuesPage, intentional for household variant
 func (c *Client) GetHouseholdCustomFieldValuesPage(
 	householdID, page, pageSize int,
-) (results []map[string]interface{}, hasMore bool, err error) {
+) (results []map[string]any, hasMore bool, err error) {
 	// Verified via API testing: custom-fields (with hyphen) is the correct format
 	endpoint := fmt.Sprintf("persons/households/%d/custom-fields", householdID)
 	params := map[string]string{
@@ -721,9 +721,9 @@ func (c *Client) GetHouseholdCustomFieldValuesPage(
 
 	// CampMinder uses camelCase for custom field endpoints
 	var response struct {
-		TotalCount int                      `json:"totalCount"`
-		Next       *string                  `json:"next"`
-		Result     []map[string]interface{} `json:"result"`
+		TotalCount int              `json:"totalCount"`
+		Next       *string          `json:"next"`
+		Result     []map[string]any `json:"result"`
 	}
 
 	if err := json.Unmarshal(body, &response); err != nil {
@@ -738,7 +738,7 @@ func (c *Client) GetHouseholdCustomFieldValuesPage(
 // Endpoint: GET /divisions
 // Returns: array of divisions with ID, Name, Description, GradeRange, GenderID, Capacity, etc.
 // Note: Divisions are global (not year-specific) - they define age/gender groups
-func (c *Client) GetDivisions() ([]map[string]interface{}, error) {
+func (c *Client) GetDivisions() ([]map[string]any, error) {
 	params := map[string]string{
 		"clientid":   c.clientID,
 		"pagenumber": "1",
@@ -751,8 +751,8 @@ func (c *Client) GetDivisions() ([]map[string]interface{}, error) {
 	}
 
 	var response struct {
-		TotalCount int                      `json:"TotalCount"`
-		Results    []map[string]interface{} `json:"Results"`
+		TotalCount int              `json:"TotalCount"`
+		Results    []map[string]any `json:"Results"`
 	}
 
 	if err := json.Unmarshal(body, &response); err != nil {
@@ -766,7 +766,7 @@ func (c *Client) GetDivisions() ([]map[string]interface{}, error) {
 // Endpoint: GET /staff/programareas
 // Returns: array of program areas with ID, Name
 // Note: Global lookup table (not year-specific)
-func (c *Client) GetStaffProgramAreas() ([]map[string]interface{}, error) {
+func (c *Client) GetStaffProgramAreas() ([]map[string]any, error) {
 	params := map[string]string{
 		"clientid":   c.clientID,
 		"pagenumber": "1",
@@ -779,8 +779,8 @@ func (c *Client) GetStaffProgramAreas() ([]map[string]interface{}, error) {
 	}
 
 	var response struct {
-		TotalCount int                      `json:"TotalCount"`
-		Results    []map[string]interface{} `json:"Results"`
+		TotalCount int              `json:"TotalCount"`
+		Results    []map[string]any `json:"Results"`
 	}
 
 	if err := json.Unmarshal(body, &response); err != nil {
@@ -794,7 +794,7 @@ func (c *Client) GetStaffProgramAreas() ([]map[string]interface{}, error) {
 // Endpoint: GET /staff/organizationalcategories
 // Returns: array of org categories with ID, Name
 // Note: Global lookup table (not year-specific)
-func (c *Client) GetStaffOrgCategories() ([]map[string]interface{}, error) {
+func (c *Client) GetStaffOrgCategories() ([]map[string]any, error) {
 	params := map[string]string{
 		"clientid":   c.clientID,
 		"pagenumber": "1",
@@ -807,8 +807,8 @@ func (c *Client) GetStaffOrgCategories() ([]map[string]interface{}, error) {
 	}
 
 	var response struct {
-		TotalCount int                      `json:"TotalCount"`
-		Results    []map[string]interface{} `json:"Results"`
+		TotalCount int              `json:"TotalCount"`
+		Results    []map[string]any `json:"Results"`
 	}
 
 	if err := json.Unmarshal(body, &response); err != nil {
@@ -822,7 +822,7 @@ func (c *Client) GetStaffOrgCategories() ([]map[string]interface{}, error) {
 // Endpoint: GET /staff/positions
 // Returns: array of positions with ID, Name, ProgramAreaID, ProgramAreaName
 // Note: Global lookup table (not year-specific)
-func (c *Client) GetStaffPositions() ([]map[string]interface{}, error) {
+func (c *Client) GetStaffPositions() ([]map[string]any, error) {
 	params := map[string]string{
 		"clientid":   c.clientID,
 		"pagenumber": "1",
@@ -835,8 +835,8 @@ func (c *Client) GetStaffPositions() ([]map[string]interface{}, error) {
 	}
 
 	var response struct {
-		TotalCount int                      `json:"TotalCount"`
-		Results    []map[string]interface{} `json:"Results"`
+		TotalCount int              `json:"TotalCount"`
+		Results    []map[string]any `json:"Results"`
 	}
 
 	if err := json.Unmarshal(body, &response); err != nil {
@@ -850,7 +850,7 @@ func (c *Client) GetStaffPositions() ([]map[string]interface{}, error) {
 // Endpoint: GET /staff
 // Parameters: seasonid (year), status (1=Active, 2=Resigned, 3=Dismissed, 4=Canceled)
 // Returns: array of staff with PersonID, StatusID, Position1ID, Position2ID, BunkAssignments, etc.
-func (c *Client) GetStaffPage(status, page, pageSize int) (results []map[string]interface{}, hasMore bool, err error) {
+func (c *Client) GetStaffPage(status, page, pageSize int) (results []map[string]any, hasMore bool, err error) {
 	params := map[string]string{
 		"clientid":   c.clientID,
 		"seasonid":   strconv.Itoa(c.seasonID),
@@ -865,9 +865,9 @@ func (c *Client) GetStaffPage(status, page, pageSize int) (results []map[string]
 	}
 
 	var response struct {
-		TotalCount int                      `json:"TotalCount"`
-		Next       *string                  `json:"Next"`
-		Results    []map[string]interface{} `json:"Results"`
+		TotalCount int              `json:"TotalCount"`
+		Next       *string          `json:"Next"`
+		Results    []map[string]any `json:"Results"`
 	}
 
 	if err := json.Unmarshal(body, &response); err != nil {
@@ -882,7 +882,7 @@ func (c *Client) GetStaffPage(status, page, pageSize int) (results []map[string]
 // Endpoint: GET /financials/financialcategories
 // Returns: array of categories with id, name, isArchived
 // Note: Global lookup table (not year-specific)
-func (c *Client) GetFinancialCategories(includeArchived bool) ([]map[string]interface{}, error) {
+func (c *Client) GetFinancialCategories(includeArchived bool) ([]map[string]any, error) {
 	params := map[string]string{
 		"clientid":        c.clientID,
 		"includeArchived": strconv.FormatBool(includeArchived),
@@ -898,8 +898,8 @@ func (c *Client) GetFinancialCategories(includeArchived bool) ([]map[string]inte
 	// CampMinder uses inconsistent casing across endpoints
 	// Try PascalCase paginated response first (TotalCount, Results)
 	var pascalResponse struct {
-		TotalCount int                      `json:"TotalCount"`
-		Results    []map[string]interface{} `json:"Results"`
+		TotalCount int              `json:"TotalCount"`
+		Results    []map[string]any `json:"Results"`
 	}
 	if err := json.Unmarshal(body, &pascalResponse); err == nil && pascalResponse.Results != nil {
 		return pascalResponse.Results, nil
@@ -907,8 +907,8 @@ func (c *Client) GetFinancialCategories(includeArchived bool) ([]map[string]inte
 
 	// Try camelCase paginated response (totalCount, result - singular like custom fields)
 	var camelResponse struct {
-		TotalCount int                      `json:"totalCount"`
-		Result     []map[string]interface{} `json:"result"`
+		TotalCount int              `json:"totalCount"`
+		Result     []map[string]any `json:"result"`
 	}
 	if err := json.Unmarshal(body, &camelResponse); err == nil && camelResponse.Result != nil {
 		return camelResponse.Result, nil
@@ -916,15 +916,15 @@ func (c *Client) GetFinancialCategories(includeArchived bool) ([]map[string]inte
 
 	// Try camelCase with plural results
 	var camelPluralResponse struct {
-		TotalCount int                      `json:"totalCount"`
-		Results    []map[string]interface{} `json:"results"`
+		TotalCount int              `json:"totalCount"`
+		Results    []map[string]any `json:"results"`
 	}
 	if err := json.Unmarshal(body, &camelPluralResponse); err == nil && camelPluralResponse.Results != nil {
 		return camelPluralResponse.Results, nil
 	}
 
 	// Fall back to raw array response (API may return either)
-	var results []map[string]interface{}
+	var results []map[string]any
 	if err := json.Unmarshal(body, &results); err != nil {
 		return nil, fmt.Errorf("decode financial categories response: %w", err)
 	}
@@ -936,7 +936,7 @@ func (c *Client) GetFinancialCategories(includeArchived bool) ([]map[string]inte
 // Endpoint: GET /financials/paymentmethods
 // Returns: array of methods with id, name
 // Note: Global lookup table (not year-specific)
-func (c *Client) GetPaymentMethods() ([]map[string]interface{}, error) {
+func (c *Client) GetPaymentMethods() ([]map[string]any, error) {
 	// This endpoint doesn't take any parameters per the OpenAPI spec
 	body, err := c.makeRequest("GET", "financials/paymentmethods", nil)
 	if err != nil {
@@ -946,8 +946,8 @@ func (c *Client) GetPaymentMethods() ([]map[string]interface{}, error) {
 	// CampMinder uses inconsistent casing - try paginated responses first
 	// Try PascalCase
 	var pascalResponse struct {
-		TotalCount int                      `json:"TotalCount"`
-		Results    []map[string]interface{} `json:"Results"`
+		TotalCount int              `json:"TotalCount"`
+		Results    []map[string]any `json:"Results"`
 	}
 	if err := json.Unmarshal(body, &pascalResponse); err == nil && pascalResponse.Results != nil {
 		return pascalResponse.Results, nil
@@ -955,8 +955,8 @@ func (c *Client) GetPaymentMethods() ([]map[string]interface{}, error) {
 
 	// Try camelCase with singular result
 	var camelResponse struct {
-		TotalCount int                      `json:"totalCount"`
-		Result     []map[string]interface{} `json:"result"`
+		TotalCount int              `json:"totalCount"`
+		Result     []map[string]any `json:"result"`
 	}
 	if err := json.Unmarshal(body, &camelResponse); err == nil && camelResponse.Result != nil {
 		return camelResponse.Result, nil
@@ -964,15 +964,15 @@ func (c *Client) GetPaymentMethods() ([]map[string]interface{}, error) {
 
 	// Try camelCase with plural results
 	var camelPluralResponse struct {
-		TotalCount int                      `json:"totalCount"`
-		Results    []map[string]interface{} `json:"results"`
+		TotalCount int              `json:"totalCount"`
+		Results    []map[string]any `json:"results"`
 	}
 	if err := json.Unmarshal(body, &camelPluralResponse); err == nil && camelPluralResponse.Results != nil {
 		return camelPluralResponse.Results, nil
 	}
 
 	// Fall back to raw array response
-	var results []map[string]interface{}
+	var results []map[string]any
 	if err := json.Unmarshal(body, &results); err != nil {
 		return nil, fmt.Errorf("decode payment methods response: %w", err)
 	}
@@ -987,8 +987,8 @@ func (c *Client) GetPaymentMethods() ([]map[string]interface{}, error) {
 // Note: Year-scoped data - uses seasonID
 // Note: This endpoint doesn't support pagination, so we fetch by month chunks
 // to avoid timeouts on large datasets (10,000+ transactions)
-func (c *Client) GetTransactionDetails(season int, includeReversals bool) ([]map[string]interface{}, error) {
-	var allResults []map[string]interface{}
+func (c *Client) GetTransactionDetails(season int, includeReversals bool) ([]map[string]any, error) {
+	var allResults []map[string]any
 
 	// Fetch transactions month by month to avoid timeout on large datasets
 	// Camp season typically runs Jan-Dec, so we cover the full year
@@ -1029,11 +1029,11 @@ func (c *Client) GetTransactionDetails(season int, includeReversals bool) ([]map
 
 // parseTransactionResponse parses the transaction details API response
 // CampMinder uses inconsistent casing across endpoints
-func (c *Client) parseTransactionResponse(body []byte) ([]map[string]interface{}, error) {
+func (c *Client) parseTransactionResponse(body []byte) ([]map[string]any, error) {
 	// Try PascalCase paginated response
 	var pascalResponse struct {
-		TotalCount int                      `json:"TotalCount"`
-		Results    []map[string]interface{} `json:"Results"`
+		TotalCount int              `json:"TotalCount"`
+		Results    []map[string]any `json:"Results"`
 	}
 	if err := json.Unmarshal(body, &pascalResponse); err == nil && pascalResponse.Results != nil {
 		return pascalResponse.Results, nil
@@ -1041,8 +1041,8 @@ func (c *Client) parseTransactionResponse(body []byte) ([]map[string]interface{}
 
 	// Try camelCase with singular result
 	var camelResponse struct {
-		TotalCount int                      `json:"totalCount"`
-		Result     []map[string]interface{} `json:"result"`
+		TotalCount int              `json:"totalCount"`
+		Result     []map[string]any `json:"result"`
 	}
 	if err := json.Unmarshal(body, &camelResponse); err == nil && camelResponse.Result != nil {
 		return camelResponse.Result, nil
@@ -1050,15 +1050,15 @@ func (c *Client) parseTransactionResponse(body []byte) ([]map[string]interface{}
 
 	// Try camelCase with plural results
 	var camelPluralResponse struct {
-		TotalCount int                      `json:"totalCount"`
-		Results    []map[string]interface{} `json:"results"`
+		TotalCount int              `json:"totalCount"`
+		Results    []map[string]any `json:"results"`
 	}
 	if err := json.Unmarshal(body, &camelPluralResponse); err == nil && camelPluralResponse.Results != nil {
 		return camelPluralResponse.Results, nil
 	}
 
 	// Fall back to raw array response
-	var results []map[string]interface{}
+	var results []map[string]any
 	if err := json.Unmarshal(body, &results); err != nil {
 		return nil, fmt.Errorf("decode transaction details response: %w", err)
 	}

--- a/pocketbase/feedback/github.go
+++ b/pocketbase/feedback/github.go
@@ -63,7 +63,7 @@ func (c *GitHubClient) apiURL(path string) string {
 // httpClient is used for all GitHub API requests with an explicit timeout.
 var httpClient = &http.Client{Timeout: 30 * time.Second}
 
-func (c *GitHubClient) doRequest(method, url string, body interface{}) (*http.Response, error) {
+func (c *GitHubClient) doRequest(method, url string, body any) (*http.Response, error) {
 	var reqBody io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
@@ -93,7 +93,7 @@ func (c *GitHubClient) doRequest(method, url string, body interface{}) (*http.Re
 func (c *GitHubClient) CreateIssue(params *IssueParams) error {
 	url := c.apiURL(fmt.Sprintf("/repos/%s/issues", c.Repo))
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"title":  buildIssueTitle(params.Category, params.Description),
 		"body":   buildIssueBody(params),
 		"labels": []string{params.Category},

--- a/pocketbase/feedback/github_test.go
+++ b/pocketbase/feedback/github_test.go
@@ -135,7 +135,7 @@ func TestBuildIssueBodyWithScreenshot(t *testing.T) {
 }
 
 func TestCreateIssue(t *testing.T) {
-	var receivedBody map[string]interface{}
+	var receivedBody map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.URL.Path; got != "/repos/org/feedback/issues" {
 			t.Errorf("expected issues endpoint, got %s", got)
@@ -186,7 +186,7 @@ func TestCreateIssue(t *testing.T) {
 		t.Errorf("title = %q, want %q", title, "[Bug] Test issue")
 	}
 
-	labels, _ := receivedBody["labels"].([]interface{})
+	labels, _ := receivedBody["labels"].([]any)
 	if len(labels) != 1 || labels[0] != "bug" {
 		t.Errorf("labels = %v, want [bug]", labels)
 	}
@@ -226,7 +226,7 @@ func TestUploadScreenshot(t *testing.T) {
 			t.Errorf("expected PUT, got %s", r.Method)
 		}
 
-		var body map[string]interface{}
+		var body map[string]any
 		bodyBytes, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(bodyBytes, &body)
 

--- a/pocketbase/sync/api.go
+++ b/pocketbase/sync/api.go
@@ -171,7 +171,7 @@ func InitializeSyncService(app *pocketbase.PocketBase, e *core.ServeEvent) error
 						continue
 					}
 					if !validFields[f] {
-						return e.JSON(http.StatusBadRequest, map[string]interface{}{
+						return e.JSON(http.StatusBadRequest, map[string]any{
 							"error": fmt.Sprintf(
 								"Invalid source_field: %s. Valid options: "+
 									"bunk_with, not_bunk_with, bunking_notes, internal_notes, socialize_with", f),
@@ -188,7 +188,7 @@ func InitializeSyncService(app *pocketbase.PocketBase, e *core.ServeEvent) error
 				if l, err := strconv.Atoi(limitParam); err == nil && l > 0 {
 					limit = l
 				} else {
-					return e.JSON(http.StatusBadRequest, map[string]interface{}{
+					return e.JSON(http.StatusBadRequest, map[string]any{
 						"error": "Invalid limit parameter. Must be a positive integer.",
 					})
 				}
@@ -485,7 +485,7 @@ func handleIndividualSync(e *core.RequestEvent, scheduler *Scheduler, syncType s
 
 	// Check if already running
 	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]interface{}{
+		return e.JSON(http.StatusConflict, map[string]any{
 			"error":    "Sync already in progress",
 			"status":   "running",
 			"syncType": syncType,
@@ -509,7 +509,7 @@ func handleIndividualSync(e *core.RequestEvent, scheduler *Scheduler, syncType s
 	// Get current year from environment
 	currentYear, err := ParseSeasonYear()
 	if err != nil {
-		return e.JSON(http.StatusInternalServerError, map[string]interface{}{"error": err.Error()})
+		return e.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error()})
 	}
 
 	// Get user info for queue tracking
@@ -528,14 +528,14 @@ func handleIndividualSync(e *core.RequestEvent, scheduler *Scheduler, syncType s
 		// Queue the individual sync with debug flag
 		qs, err := orchestrator.EnqueueIndividualSync(currentYear, syncType, nil, debug, requestedBy)
 		if err != nil {
-			return e.JSON(http.StatusConflict, map[string]interface{}{
+			return e.JSON(http.StatusConflict, map[string]any{
 				"error": err.Error(),
 			})
 		}
 
 		// Successfully queued - return 202 Accepted
 		position := orchestrator.GetQueuePositionByID(qs.ID)
-		return e.JSON(http.StatusAccepted, map[string]interface{}{
+		return e.JSON(http.StatusAccepted, map[string]any{
 			"status":   "queued",
 			"queue_id": qs.ID,
 			"position": position,
@@ -568,7 +568,7 @@ func handleIndividualSync(e *core.RequestEvent, scheduler *Scheduler, syncType s
 		processQueuedSyncs(orchestrator)
 	}()
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message":  fmt.Sprintf("%s sync started", syncType),
 		"status":   "started",
 		"syncType": syncType,
@@ -583,7 +583,7 @@ func handleRefreshBunking(e *core.RequestEvent, scheduler *Scheduler) error {
 	// Check if any bunking-related sync is already running
 	for _, job := range GetRefreshBunkingJobs() {
 		if orchestrator.IsRunning(job) {
-			return e.JSON(http.StatusConflict, map[string]interface{}{
+			return e.JSON(http.StatusConflict, map[string]any{
 				"error":  "Bunking sync already in progress",
 				"status": "running",
 			})
@@ -600,7 +600,7 @@ func handleRefreshBunking(e *core.RequestEvent, scheduler *Scheduler) error {
 		}
 	}()
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message": "Bunking refresh started (bunks, plans, assignments)",
 		"status":  "started",
 	})
@@ -739,20 +739,20 @@ func saveCSVWithBackup(csvDir string, uploadYear int, csvData []byte) (string, e
 func handleBunkRequestsUpload(e *core.RequestEvent, scheduler *Scheduler) error {
 	form, err := e.Request.MultipartReader()
 	if err != nil {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{"error": "Invalid multipart form"})
+		return e.JSON(http.StatusBadRequest, map[string]any{"error": "Invalid multipart form"})
 	}
 
 	// Read and validate CSV from form
 	uploadResult, err := readCSVFromMultipart(form)
 	if err != nil {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{"error": err.Error()})
+		return e.JSON(http.StatusBadRequest, map[string]any{"error": err.Error()})
 	}
 
 	// Parse and validate CSV headers
 	headers, err := parseAndValidateCSV(uploadResult.data)
 	if err != nil {
 		slog.Error("CSV parsing error", "error", err)
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error":     err.Error(),
 			"details":   "Please ensure the file is a valid CSV with comma-separated values",
 			"file_size": len(uploadResult.data),
@@ -763,7 +763,7 @@ func handleBunkRequestsUpload(e *core.RequestEvent, scheduler *Scheduler) error 
 	// Check required columns
 	requiredColumns := []string{"PersonID", "Last Name", "First Name"}
 	if missing := findMissingColumns(headers, requiredColumns); len(missing) > 0 {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error":            "Missing required columns",
 			"missing_columns":  missing,
 			"found_columns":    headers,
@@ -774,18 +774,18 @@ func handleBunkRequestsUpload(e *core.RequestEvent, scheduler *Scheduler) error 
 	// Determine upload year and save file
 	uploadYear, err := determineUploadYear(e.Request.URL.Query().Get("year"))
 	if err != nil {
-		return e.JSON(http.StatusInternalServerError, map[string]interface{}{"error": err.Error()})
+		return e.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error()})
 	}
 	csvDir := filepath.Join(scheduler.app.DataDir(), "bunk_requests")
 
 	latestPath, err := saveCSVWithBackup(csvDir, uploadYear, uploadResult.data)
 	if err != nil {
-		return e.JSON(http.StatusInternalServerError, map[string]interface{}{"error": err.Error()})
+		return e.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error()})
 	}
 	slog.Info("CSV file saved", "year", uploadYear, "path", latestPath)
 
 	// Update metadata
-	metadata := map[string]interface{}{
+	metadata := map[string]any{
 		"filename":     uploadResult.filename,
 		"uploaded_at":  time.Now().Format(time.RFC3339),
 		"size":         len(uploadResult.data),
@@ -855,7 +855,7 @@ func handleBunkRequestsUpload(e *core.RequestEvent, scheduler *Scheduler) error 
 		}
 	}
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message":                  "CSV uploaded successfully",
 		"filename":                 uploadResult.filename,
 		"header_count":             len(headers),
@@ -910,7 +910,7 @@ func handleSyncStatus(e *core.RequestEvent, scheduler *Scheduler) error {
 		"household_custom_values",
 	}
 
-	statuses := make(map[string]interface{})
+	statuses := make(map[string]any)
 	for _, syncType := range syncTypes {
 		if status := orchestrator.GetStatus(syncType); status != nil {
 			statuses[syncType] = status
@@ -942,9 +942,9 @@ func handleSyncStatus(e *core.RequestEvent, scheduler *Scheduler) error {
 
 	// Add queue info
 	queue := orchestrator.GetQueuedSyncs()
-	queueInfo := make([]map[string]interface{}, len(queue))
+	queueInfo := make([]map[string]any, len(queue))
 	for i, qs := range queue {
-		queueInfo[i] = map[string]interface{}{
+		queueInfo[i] = map[string]any{
 			"id":                    qs.ID,
 			"year":                  qs.Year,
 			"type":                  qs.Type, // "unified", "phase", "individual"
@@ -960,7 +960,7 @@ func handleSyncStatus(e *core.RequestEvent, scheduler *Scheduler) error {
 	// Add current run progress (remaining jobs in current sequence)
 	runType, remaining, total, completed := orchestrator.GetCurrentRunProgress()
 	if runType != "" {
-		statuses["_current_run"] = map[string]interface{}{
+		statuses["_current_run"] = map[string]any{
 			"type":           runType,
 			"total_jobs":     total,
 			"completed_jobs": completed,
@@ -979,14 +979,14 @@ func handleUnifiedSync(e *core.RequestEvent, scheduler *Scheduler) error {
 	// Parse required year parameter
 	yearStr := e.Request.URL.Query().Get("year")
 	if yearStr == "" {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Missing required year parameter",
 		})
 	}
 
 	year, err := strconv.Atoi(yearStr)
 	if err != nil || year < 2017 {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Invalid year parameter. Must be 2017 or later.",
 		})
 	}
@@ -1000,7 +1000,7 @@ func handleUnifiedSync(e *core.RequestEvent, scheduler *Scheduler) error {
 	// Get current year from environment
 	currentYear, yerr := ParseSeasonYear()
 	if yerr != nil {
-		return e.JSON(http.StatusInternalServerError, map[string]interface{}{"error": yerr.Error()})
+		return e.JSON(http.StatusInternalServerError, map[string]any{"error": yerr.Error()})
 	}
 
 	// Parse optional query parameters
@@ -1026,14 +1026,14 @@ func handleUnifiedSync(e *core.RequestEvent, scheduler *Scheduler) error {
 		qs, err := orchestrator.EnqueueUnifiedSync(year, service, includeCustomValues, debug, requestedBy)
 		if err != nil {
 			// Queue is full
-			return e.JSON(http.StatusConflict, map[string]interface{}{
+			return e.JSON(http.StatusConflict, map[string]any{
 				"error": err.Error(),
 			})
 		}
 
 		// Successfully queued - return 202 Accepted
 		position := orchestrator.GetQueuePositionByID(qs.ID)
-		return e.JSON(http.StatusAccepted, map[string]interface{}{
+		return e.JSON(http.StatusAccepted, map[string]any{
 			"status":              "queued",
 			"queue_id":            qs.ID,
 			"position":            position,
@@ -1101,7 +1101,7 @@ func handleUnifiedSync(e *core.RequestEvent, scheduler *Scheduler) error {
 		processQueuedSyncs(orchestrator)
 	}()
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message":             "Sync started",
 		"year":                year,
 		"service":             service,
@@ -1289,7 +1289,7 @@ func handleCancelQueuedSync(e *core.RequestEvent, scheduler *Scheduler) error {
 	// Get the queue ID from path parameter
 	id := e.Request.PathValue("id")
 	if id == "" {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Missing queue ID",
 		})
 	}
@@ -1298,13 +1298,13 @@ func handleCancelQueuedSync(e *core.RequestEvent, scheduler *Scheduler) error {
 
 	// Try to cancel the queued sync
 	if !orchestrator.CancelQueuedSync(id) {
-		return e.JSON(http.StatusNotFound, map[string]interface{}{
+		return e.JSON(http.StatusNotFound, map[string]any{
 			"error": "Queued sync not found",
 			"id":    id,
 		})
 	}
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message": "Queued sync canceled",
 		"id":      id,
 	})
@@ -1316,12 +1316,12 @@ func handleCancelRunningSync(e *core.RequestEvent, scheduler *Scheduler) error {
 
 	// Try to cancel the running sync
 	if !orchestrator.CancelRunningSync() {
-		return e.JSON(http.StatusNotFound, map[string]interface{}{
+		return e.JSON(http.StatusNotFound, map[string]any{
 			"error": "No sync currently running",
 		})
 	}
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message": "Running sync canceled",
 	})
 }
@@ -1330,7 +1330,7 @@ func handleCancelRunningSync(e *core.RequestEvent, scheduler *Scheduler) error {
 func handleHourlySync(e *core.RequestEvent, scheduler *Scheduler) error {
 	// Check if hourly sync is already running
 	if scheduler.IsHourlySyncRunning() {
-		return e.JSON(http.StatusConflict, map[string]interface{}{
+		return e.JSON(http.StatusConflict, map[string]any{
 			"error": "Hourly sync already in progress",
 		})
 	}
@@ -1338,7 +1338,7 @@ func handleHourlySync(e *core.RequestEvent, scheduler *Scheduler) error {
 	// Trigger hourly sync
 	scheduler.TriggerHourlySync()
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message": "Hourly sync triggered",
 	})
 }
@@ -1347,7 +1347,7 @@ func handleHourlySync(e *core.RequestEvent, scheduler *Scheduler) error {
 func handleWeeklySync(e *core.RequestEvent, scheduler *Scheduler) error {
 	// Check if weekly sync is already running
 	if scheduler.IsWeeklySyncRunning() {
-		return e.JSON(http.StatusConflict, map[string]interface{}{
+		return e.JSON(http.StatusConflict, map[string]any{
 			"error": "Weekly sync already in progress",
 		})
 	}
@@ -1355,7 +1355,7 @@ func handleWeeklySync(e *core.RequestEvent, scheduler *Scheduler) error {
 	// Trigger weekly sync
 	scheduler.TriggerWeeklySync()
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Weekly sync triggered",
 		"services": GetWeeklySyncJobs(),
 	})
@@ -1367,7 +1367,7 @@ func handleCustomValuesSync(e *core.RequestEvent, scheduler *Scheduler) error {
 
 	// Check if custom values sync is already running
 	if orchestrator.IsRunning("person_custom_values") || orchestrator.IsRunning("household_custom_values") {
-		return e.JSON(http.StatusConflict, map[string]interface{}{
+		return e.JSON(http.StatusConflict, map[string]any{
 			"error": "Custom values sync already in progress",
 		})
 	}
@@ -1375,7 +1375,7 @@ func handleCustomValuesSync(e *core.RequestEvent, scheduler *Scheduler) error {
 	// Trigger custom values sync
 	scheduler.TriggerCustomValuesSync()
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Custom values sync triggered",
 		"services": GetCustomValuesSyncJobs(),
 	})
@@ -1394,7 +1394,7 @@ func handleGetAvailableYears(e *core.RequestEvent, app *pocketbase.PocketBase) e
 	`).Column(&years)
 
 	if err != nil {
-		return e.JSON(http.StatusInternalServerError, map[string]interface{}{
+		return e.JSON(http.StatusInternalServerError, map[string]any{
 			"error": "Failed to query available years",
 		})
 	}
@@ -1405,7 +1405,7 @@ func handleGetAvailableYears(e *core.RequestEvent, app *pocketbase.PocketBase) e
 		currentYear = time.Now().Year()
 	}
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"current":   currentYear,
 		"available": years,
 	})
@@ -1417,7 +1417,7 @@ func handleTestConnection(e *core.RequestEvent, scheduler *Scheduler) error {
 
 	// Get the base client
 	if orchestrator.baseClient == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]interface{}{
+		return e.JSON(http.StatusInternalServerError, map[string]any{
 			"error": "CampMinder client not initialized",
 			"hint":  "Check that CAMPMINDER_API_KEY, CAMPMINDER_CLIENT_ID, and CAMPMINDER_SEASON_ID are set",
 		})
@@ -1427,11 +1427,11 @@ func handleTestConnection(e *core.RequestEvent, scheduler *Scheduler) error {
 	// We'll use GetSessions as it's a read-only operation
 	sessions, err := orchestrator.baseClient.GetSessions()
 	if err != nil {
-		return e.JSON(http.StatusInternalServerError, map[string]interface{}{
+		return e.JSON(http.StatusInternalServerError, map[string]any{
 			"error":   "CampMinder connection failed",
 			"details": err.Error(),
 			"hint":    "Check API credentials and network connectivity",
-			"config": map[string]interface{}{
+			"config": map[string]any{
 				"client_id": orchestrator.baseClient.GetClientID(),
 				"season_id": orchestrator.baseClient.GetSeasonID(),
 			},
@@ -1439,10 +1439,10 @@ func handleTestConnection(e *core.RequestEvent, scheduler *Scheduler) error {
 	}
 
 	// Success - return connection info
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"status":  "connected",
 		"message": "CampMinder client connection successful",
-		"config": map[string]interface{}{
+		"config": map[string]any{
 			"client_id":      orchestrator.baseClient.GetClientID(),
 			"season_id":      orchestrator.baseClient.GetSeasonID(),
 			"sessions_found": len(sessions),
@@ -1458,7 +1458,7 @@ func handleTestConnection(e *core.RequestEvent, scheduler *Scheduler) error {
 func handleMultiWorkbookExport(e *core.RequestEvent, scheduler *Scheduler) error {
 	// Check if Google Sheets is configured
 	if !google.IsEnabled() {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Google Sheets export is not enabled",
 			"hint":  "Set GOOGLE_SHEETS_ENABLED=true and configure credentials",
 		})
@@ -1468,7 +1468,7 @@ func handleMultiWorkbookExport(e *core.RequestEvent, scheduler *Scheduler) error
 	yearsParam := e.Request.URL.Query().Get("years")
 	years, err := ParseExportYearsParam(yearsParam)
 	if err != nil {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": fmt.Sprintf("Invalid years parameter: %v", err),
 		})
 	}
@@ -1485,7 +1485,7 @@ func handleMultiWorkbookExport(e *core.RequestEvent, scheduler *Scheduler) error
 	if len(years) > 0 {
 		currentYear := time.Now().Year()
 		if err := ValidateExportYears(years, currentYear); err != nil {
-			return e.JSON(http.StatusBadRequest, map[string]interface{}{
+			return e.JSON(http.StatusBadRequest, map[string]any{
 				"error": err.Error(),
 			})
 		}
@@ -1495,7 +1495,7 @@ func handleMultiWorkbookExport(e *core.RequestEvent, scheduler *Scheduler) error
 
 	// Check if already running
 	if orchestrator.IsRunning("multi_workbook_export") {
-		return e.JSON(http.StatusConflict, map[string]interface{}{
+		return e.JSON(http.StatusConflict, map[string]any{
 			"error":    "Multi-workbook export already in progress",
 			"status":   "running",
 			"syncType": "multi_workbook_export",
@@ -1506,7 +1506,7 @@ func handleMultiWorkbookExport(e *core.RequestEvent, scheduler *Scheduler) error
 	service := orchestrator.GetService("multi_workbook_export")
 	multiExport, ok := service.(*MultiWorkbookExport)
 	if !ok || multiExport == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]interface{}{
+		return e.JSON(http.StatusInternalServerError, map[string]any{
 			"error": "Multi-workbook export service not available",
 			"hint":  "Ensure GOOGLE_SHEETS_ENABLED=true and credentials are configured",
 		})
@@ -1536,7 +1536,7 @@ func handleMultiWorkbookExport(e *core.RequestEvent, scheduler *Scheduler) error
 	}()
 
 	// Build response
-	response := map[string]interface{}{
+	response := map[string]any{
 		"message":  "Multi-workbook export started",
 		"status":   "started",
 		"syncType": "multi_workbook_export",
@@ -1565,7 +1565,7 @@ func handlePersonCustomFieldValuesSync(e *core.RequestEvent, scheduler *Schedule
 
 	// Validate session parameter
 	if !IsValidSession(session) {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Invalid session parameter. Must be 'all' or a numeric session cm_id.",
 		})
 	}
@@ -1577,7 +1577,7 @@ func handlePersonCustomFieldValuesSync(e *core.RequestEvent, scheduler *Schedule
 	// Get the service and set options
 	service, ok := orchestrator.GetService(syncType).(*PersonCustomFieldValuesSync)
 	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]interface{}{
+		return e.JSON(http.StatusInternalServerError, map[string]any{
 			"error": "Person custom field values sync service not found",
 		})
 	}
@@ -1587,7 +1587,7 @@ func handlePersonCustomFieldValuesSync(e *core.RequestEvent, scheduler *Schedule
 	// Mark as running BEFORE starting goroutine to prevent race condition
 	// This ensures the first frontend poll sees the sync as active
 	if err := orchestrator.MarkSyncRunning(syncType); err != nil {
-		return e.JSON(http.StatusConflict, map[string]interface{}{
+		return e.JSON(http.StatusConflict, map[string]any{
 			"error":    err.Error(),
 			"status":   "running",
 			"syncType": syncType,
@@ -1616,7 +1616,7 @@ func handlePersonCustomFieldValuesSync(e *core.RequestEvent, scheduler *Schedule
 		}
 	}()
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message":  fmt.Sprintf("%s sync started", syncType),
 		"status":   "started",
 		"syncType": syncType,
@@ -1641,7 +1641,7 @@ func handleHouseholdCustomFieldValuesSync(e *core.RequestEvent, scheduler *Sched
 
 	// Validate session parameter
 	if !IsValidSession(session) {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Invalid session parameter. Must be 'all' or a numeric session cm_id.",
 		})
 	}
@@ -1653,7 +1653,7 @@ func handleHouseholdCustomFieldValuesSync(e *core.RequestEvent, scheduler *Sched
 	// Get the service and set options
 	service, ok := orchestrator.GetService(syncType).(*HouseholdCustomFieldValuesSync)
 	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]interface{}{
+		return e.JSON(http.StatusInternalServerError, map[string]any{
 			"error": "Household custom field values sync service not found",
 		})
 	}
@@ -1663,7 +1663,7 @@ func handleHouseholdCustomFieldValuesSync(e *core.RequestEvent, scheduler *Sched
 	// Mark as running BEFORE starting goroutine to prevent race condition
 	// This ensures the first frontend poll sees the sync as active
 	if err := orchestrator.MarkSyncRunning(syncType); err != nil {
-		return e.JSON(http.StatusConflict, map[string]interface{}{
+		return e.JSON(http.StatusConflict, map[string]any{
 			"error":    err.Error(),
 			"status":   "running",
 			"syncType": syncType,
@@ -1692,7 +1692,7 @@ func handleHouseholdCustomFieldValuesSync(e *core.RequestEvent, scheduler *Sched
 		}
 	}()
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message":  fmt.Sprintf("%s sync started", syncType),
 		"status":   "started",
 		"syncType": syncType,
@@ -1709,7 +1709,7 @@ func handleFinancialTransactionsSync(e *core.RequestEvent, scheduler *Scheduler)
 
 	// Check if already running
 	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]interface{}{
+		return e.JSON(http.StatusConflict, map[string]any{
 			"error":    "Sync already in progress",
 			"status":   "running",
 			"syncType": syncType,
@@ -1723,7 +1723,7 @@ func handleFinancialTransactionsSync(e *core.RequestEvent, scheduler *Scheduler)
 		if y, err := strconv.Atoi(yearParam); err == nil && y >= 2017 && y <= time.Now().Year() {
 			year = y
 		} else {
-			return e.JSON(http.StatusBadRequest, map[string]interface{}{
+			return e.JSON(http.StatusBadRequest, map[string]any{
 				"error": "Invalid year parameter. Must be between 2017 and current year.",
 			})
 		}
@@ -1762,7 +1762,7 @@ func handleFinancialTransactionsSync(e *core.RequestEvent, scheduler *Scheduler)
 			}
 		}()
 
-		return e.JSON(http.StatusOK, map[string]interface{}{
+		return e.JSON(http.StatusOK, map[string]any{
 			"message":  "Financial transactions historical sync started",
 			"status":   "started",
 			"syncType": syncType,
@@ -1792,7 +1792,7 @@ func handleFinancialTransactionsSync(e *core.RequestEvent, scheduler *Scheduler)
 		}
 	}()
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Financial transactions sync started",
 		"status":   "started",
 		"syncType": syncType,
@@ -1807,7 +1807,7 @@ func handleCamperHistorySync(e *core.RequestEvent, scheduler *Scheduler) error {
 
 	// Check if already running
 	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]interface{}{
+		return e.JSON(http.StatusConflict, map[string]any{
 			"error":    "Camper history computation already in progress",
 			"status":   "running",
 			"syncType": syncType,
@@ -1817,14 +1817,14 @@ func handleCamperHistorySync(e *core.RequestEvent, scheduler *Scheduler) error {
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Missing required year parameter. Use ?year=YYYY",
 		})
 	}
 
 	year, err := strconv.Atoi(yearParam)
 	if err != nil || year < 2017 || year > 2050 {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Invalid year parameter. Must be between 2017 and 2050.",
 		})
 	}
@@ -1836,7 +1836,7 @@ func handleCamperHistorySync(e *core.RequestEvent, scheduler *Scheduler) error {
 	// Get the service and set options
 	service, ok := orchestrator.GetService(syncType).(*CamperHistorySync)
 	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]interface{}{
+		return e.JSON(http.StatusInternalServerError, map[string]any{
 			"error": "Camper history sync service not found",
 		})
 	}
@@ -1865,7 +1865,7 @@ func handleCamperHistorySync(e *core.RequestEvent, scheduler *Scheduler) error {
 		}
 	}()
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Camper history computation started",
 		"status":   "started",
 		"syncType": syncType,
@@ -1882,7 +1882,7 @@ func handleFamilyCampDerivedSync(e *core.RequestEvent, scheduler *Scheduler) err
 
 	// Check if already running
 	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]interface{}{
+		return e.JSON(http.StatusConflict, map[string]any{
 			"error":    "Family camp derived computation already in progress",
 			"status":   "running",
 			"syncType": syncType,
@@ -1892,14 +1892,14 @@ func handleFamilyCampDerivedSync(e *core.RequestEvent, scheduler *Scheduler) err
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Missing required year parameter. Use ?year=YYYY",
 		})
 	}
 
 	year, err := strconv.Atoi(yearParam)
 	if err != nil || year < 2017 || year > 2050 {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Invalid year parameter. Must be between 2017 and 2050.",
 		})
 	}
@@ -1911,7 +1911,7 @@ func handleFamilyCampDerivedSync(e *core.RequestEvent, scheduler *Scheduler) err
 	// Get the service and set options
 	service, ok := orchestrator.GetService(syncType).(*FamilyCampDerivedSync)
 	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]interface{}{
+		return e.JSON(http.StatusInternalServerError, map[string]any{
 			"error": "Family camp derived sync service not found",
 		})
 	}
@@ -1940,7 +1940,7 @@ func handleFamilyCampDerivedSync(e *core.RequestEvent, scheduler *Scheduler) err
 		}
 	}()
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Family camp derived computation started",
 		"status":   "started",
 		"syncType": syncType,
@@ -1957,7 +1957,7 @@ func handleStaffSkillsSync(e *core.RequestEvent, scheduler *Scheduler) error {
 
 	// Check if already running
 	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]interface{}{
+		return e.JSON(http.StatusConflict, map[string]any{
 			"error":    "Staff skills sync already in progress",
 			"status":   "running",
 			"syncType": syncType,
@@ -1967,14 +1967,14 @@ func handleStaffSkillsSync(e *core.RequestEvent, scheduler *Scheduler) error {
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Missing required year parameter. Use ?year=YYYY",
 		})
 	}
 
 	year, err := strconv.Atoi(yearParam)
 	if err != nil || year < 2017 || year > 2050 {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Invalid year parameter. Must be between 2017 and 2050.",
 		})
 	}
@@ -1986,7 +1986,7 @@ func handleStaffSkillsSync(e *core.RequestEvent, scheduler *Scheduler) error {
 	// Get the service and set options
 	service, ok := orchestrator.GetService(syncType).(*StaffSkillsSync)
 	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]interface{}{
+		return e.JSON(http.StatusInternalServerError, map[string]any{
 			"error": "Staff skills sync service not found",
 		})
 	}
@@ -2016,7 +2016,7 @@ func handleStaffSkillsSync(e *core.RequestEvent, scheduler *Scheduler) error {
 		}
 	}()
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Staff skills extraction started",
 		"status":   "started",
 		"syncType": syncType,
@@ -2033,7 +2033,7 @@ func handleFinancialAidApplicationsSync(e *core.RequestEvent, scheduler *Schedul
 
 	// Check if already running
 	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]interface{}{
+		return e.JSON(http.StatusConflict, map[string]any{
 			"error":    "Financial aid applications sync already in progress",
 			"status":   "running",
 			"syncType": syncType,
@@ -2043,14 +2043,14 @@ func handleFinancialAidApplicationsSync(e *core.RequestEvent, scheduler *Schedul
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Missing required year parameter. Use ?year=YYYY",
 		})
 	}
 
 	year, err := strconv.Atoi(yearParam)
 	if err != nil || year < 2017 || year > 2050 {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Invalid year parameter. Must be between 2017 and 2050.",
 		})
 	}
@@ -2062,7 +2062,7 @@ func handleFinancialAidApplicationsSync(e *core.RequestEvent, scheduler *Schedul
 	// Get the service and set options
 	service, ok := orchestrator.GetService(syncType).(*FinancialAidApplicationsSync)
 	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]interface{}{
+		return e.JSON(http.StatusInternalServerError, map[string]any{
 			"error": "Financial aid applications sync service not found",
 		})
 	}
@@ -2091,7 +2091,7 @@ func handleFinancialAidApplicationsSync(e *core.RequestEvent, scheduler *Schedul
 		}
 	}()
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Financial aid applications extraction started",
 		"status":   "started",
 		"syncType": syncType,
@@ -2108,7 +2108,7 @@ func handleHouseholdDemographicsSync(e *core.RequestEvent, scheduler *Scheduler)
 
 	// Check if already running
 	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]interface{}{
+		return e.JSON(http.StatusConflict, map[string]any{
 			"error":    "Household demographics computation already in progress",
 			"status":   "running",
 			"syncType": syncType,
@@ -2118,14 +2118,14 @@ func handleHouseholdDemographicsSync(e *core.RequestEvent, scheduler *Scheduler)
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Missing required year parameter. Use ?year=YYYY",
 		})
 	}
 
 	year, err := strconv.Atoi(yearParam)
 	if err != nil || year < 2017 || year > 2050 {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Invalid year parameter. Must be between 2017 and 2050.",
 		})
 	}
@@ -2137,7 +2137,7 @@ func handleHouseholdDemographicsSync(e *core.RequestEvent, scheduler *Scheduler)
 	// Get the service and set options
 	service, ok := orchestrator.GetService(syncType).(*HouseholdDemographicsSync)
 	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]interface{}{
+		return e.JSON(http.StatusInternalServerError, map[string]any{
 			"error": "Household demographics sync service not found",
 		})
 	}
@@ -2167,7 +2167,7 @@ func handleHouseholdDemographicsSync(e *core.RequestEvent, scheduler *Scheduler)
 		}
 	}()
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Household demographics computation started",
 		"status":   "started",
 		"syncType": syncType,
@@ -2214,7 +2214,7 @@ func handleGetPhases(e *core.RequestEvent) error {
 		})
 	}
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"phases": result,
 	})
 }
@@ -2228,14 +2228,14 @@ func handleRunPhase(e *core.RequestEvent, scheduler *Scheduler) error {
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Missing required year parameter. Use ?year=YYYY",
 		})
 	}
 
 	year, err := strconv.Atoi(yearParam)
 	if err != nil || year < 2017 || year > 2050 {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Invalid year parameter. Must be between 2017 and 2050.",
 		})
 	}
@@ -2243,7 +2243,7 @@ func handleRunPhase(e *core.RequestEvent, scheduler *Scheduler) error {
 	// Parse required phase parameter
 	phaseParam := e.Request.URL.Query().Get("phase")
 	if phaseParam == "" {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Missing required phase parameter. Use ?phase=<source|expensive|transform|process|export>",
 		})
 	}
@@ -2258,7 +2258,7 @@ func handleRunPhase(e *core.RequestEvent, scheduler *Scheduler) error {
 		}
 	}
 	if !validPhase {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error":        "Invalid phase parameter",
 			"valid_phases": []string{"source", "expensive", "transform", "process", "export"},
 		})
@@ -2267,7 +2267,7 @@ func handleRunPhase(e *core.RequestEvent, scheduler *Scheduler) error {
 	// Get jobs for this phase
 	jobs := GetJobsForPhase(phase)
 	if len(jobs) == 0 {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "No jobs found for phase: " + string(phase),
 		})
 	}
@@ -2289,14 +2289,14 @@ func handleRunPhase(e *core.RequestEvent, scheduler *Scheduler) error {
 		// Queue the phase sync instead of returning conflict (pass debug flag)
 		qs, err := orchestrator.EnqueuePhaseSync(year, phase, debug, requestedBy)
 		if err != nil {
-			return e.JSON(http.StatusConflict, map[string]interface{}{
+			return e.JSON(http.StatusConflict, map[string]any{
 				"error": err.Error(),
 			})
 		}
 
 		// Successfully queued - return 202 Accepted
 		position := orchestrator.GetQueuePositionByID(qs.ID)
-		response := map[string]interface{}{
+		response := map[string]any{
 			"status":   "queued",
 			"queue_id": qs.ID,
 			"position": position,
@@ -2376,7 +2376,7 @@ func handleRunPhase(e *core.RequestEvent, scheduler *Scheduler) error {
 		processQueuedSyncs(orchestrator)
 	}()
 
-	response := map[string]interface{}{
+	response := map[string]any{
 		"message": "Phase sync started",
 		"status":  "started",
 		"phase":   string(phase),
@@ -2395,7 +2395,7 @@ func handleCamperDietarySync(e *core.RequestEvent, scheduler *Scheduler) error {
 
 	// Check if already running
 	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]interface{}{
+		return e.JSON(http.StatusConflict, map[string]any{
 			"error":    "Camper dietary sync already in progress",
 			"status":   "running",
 			"syncType": syncType,
@@ -2405,14 +2405,14 @@ func handleCamperDietarySync(e *core.RequestEvent, scheduler *Scheduler) error {
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Missing required year parameter. Use ?year=YYYY",
 		})
 	}
 
 	year, err := strconv.Atoi(yearParam)
 	if err != nil || year < 2017 || year > 2050 {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Invalid year parameter. Must be between 2017 and 2050.",
 		})
 	}
@@ -2420,7 +2420,7 @@ func handleCamperDietarySync(e *core.RequestEvent, scheduler *Scheduler) error {
 	// Get the service and set options
 	service, ok := orchestrator.GetService(syncType).(*CamperDietarySync)
 	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]interface{}{
+		return e.JSON(http.StatusInternalServerError, map[string]any{
 			"error": "Camper dietary sync service not found",
 		})
 	}
@@ -2446,7 +2446,7 @@ func handleCamperDietarySync(e *core.RequestEvent, scheduler *Scheduler) error {
 		}
 	}()
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Camper dietary extraction started",
 		"status":   "started",
 		"syncType": syncType,
@@ -2462,7 +2462,7 @@ func handleCamperTransportationSync(e *core.RequestEvent, scheduler *Scheduler) 
 
 	// Check if already running
 	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]interface{}{
+		return e.JSON(http.StatusConflict, map[string]any{
 			"error":    "Camper transportation sync already in progress",
 			"status":   "running",
 			"syncType": syncType,
@@ -2472,14 +2472,14 @@ func handleCamperTransportationSync(e *core.RequestEvent, scheduler *Scheduler) 
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Missing required year parameter. Use ?year=YYYY",
 		})
 	}
 
 	year, err := strconv.Atoi(yearParam)
 	if err != nil || year < 2017 || year > 2050 {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Invalid year parameter. Must be between 2017 and 2050.",
 		})
 	}
@@ -2487,7 +2487,7 @@ func handleCamperTransportationSync(e *core.RequestEvent, scheduler *Scheduler) 
 	// Get the service and set options
 	service, ok := orchestrator.GetService(syncType).(*CamperTransportationSync)
 	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]interface{}{
+		return e.JSON(http.StatusInternalServerError, map[string]any{
 			"error": "Camper transportation sync service not found",
 		})
 	}
@@ -2513,7 +2513,7 @@ func handleCamperTransportationSync(e *core.RequestEvent, scheduler *Scheduler) 
 		}
 	}()
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Camper transportation extraction started",
 		"status":   "started",
 		"syncType": syncType,
@@ -2529,7 +2529,7 @@ func handleQuestRegistrationsSync(e *core.RequestEvent, scheduler *Scheduler) er
 
 	// Check if already running
 	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]interface{}{
+		return e.JSON(http.StatusConflict, map[string]any{
 			"error":    "Quest registrations sync already in progress",
 			"status":   "running",
 			"syncType": syncType,
@@ -2539,14 +2539,14 @@ func handleQuestRegistrationsSync(e *core.RequestEvent, scheduler *Scheduler) er
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Missing required year parameter. Use ?year=YYYY",
 		})
 	}
 
 	year, err := strconv.Atoi(yearParam)
 	if err != nil || year < 2017 || year > 2050 {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Invalid year parameter. Must be between 2017 and 2050.",
 		})
 	}
@@ -2554,7 +2554,7 @@ func handleQuestRegistrationsSync(e *core.RequestEvent, scheduler *Scheduler) er
 	// Get the service and set options
 	service, ok := orchestrator.GetService(syncType).(*QuestRegistrationsSync)
 	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]interface{}{
+		return e.JSON(http.StatusInternalServerError, map[string]any{
 			"error": "Quest registrations sync service not found",
 		})
 	}
@@ -2580,7 +2580,7 @@ func handleQuestRegistrationsSync(e *core.RequestEvent, scheduler *Scheduler) er
 		}
 	}()
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Quest registrations extraction started",
 		"status":   "started",
 		"syncType": syncType,
@@ -2596,7 +2596,7 @@ func handleStaffApplicationsSync(e *core.RequestEvent, scheduler *Scheduler) err
 
 	// Check if already running
 	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]interface{}{
+		return e.JSON(http.StatusConflict, map[string]any{
 			"error":    "Staff applications sync already in progress",
 			"status":   "running",
 			"syncType": syncType,
@@ -2606,14 +2606,14 @@ func handleStaffApplicationsSync(e *core.RequestEvent, scheduler *Scheduler) err
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Missing required year parameter. Use ?year=YYYY",
 		})
 	}
 
 	year, err := strconv.Atoi(yearParam)
 	if err != nil || year < 2017 || year > 2050 {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Invalid year parameter. Must be between 2017 and 2050.",
 		})
 	}
@@ -2621,7 +2621,7 @@ func handleStaffApplicationsSync(e *core.RequestEvent, scheduler *Scheduler) err
 	// Get the service and set options
 	service, ok := orchestrator.GetService(syncType).(*StaffApplicationsSync)
 	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]interface{}{
+		return e.JSON(http.StatusInternalServerError, map[string]any{
 			"error": "Staff applications sync service not found",
 		})
 	}
@@ -2647,7 +2647,7 @@ func handleStaffApplicationsSync(e *core.RequestEvent, scheduler *Scheduler) err
 		}
 	}()
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Staff applications extraction started",
 		"status":   "started",
 		"syncType": syncType,
@@ -2663,7 +2663,7 @@ func handleStaffVehicleInfoSync(e *core.RequestEvent, scheduler *Scheduler) erro
 
 	// Check if already running
 	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]interface{}{
+		return e.JSON(http.StatusConflict, map[string]any{
 			"error":    "Staff vehicle info sync already in progress",
 			"status":   "running",
 			"syncType": syncType,
@@ -2673,14 +2673,14 @@ func handleStaffVehicleInfoSync(e *core.RequestEvent, scheduler *Scheduler) erro
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Missing required year parameter. Use ?year=YYYY",
 		})
 	}
 
 	year, err := strconv.Atoi(yearParam)
 	if err != nil || year < 2017 || year > 2050 {
-		return e.JSON(http.StatusBadRequest, map[string]interface{}{
+		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "Invalid year parameter. Must be between 2017 and 2050.",
 		})
 	}
@@ -2688,7 +2688,7 @@ func handleStaffVehicleInfoSync(e *core.RequestEvent, scheduler *Scheduler) erro
 	// Get the service and set options
 	service, ok := orchestrator.GetService(syncType).(*StaffVehicleInfoSync)
 	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]interface{}{
+		return e.JSON(http.StatusInternalServerError, map[string]any{
 			"error": "Staff vehicle info sync service not found",
 		})
 	}
@@ -2714,7 +2714,7 @@ func handleStaffVehicleInfoSync(e *core.RequestEvent, scheduler *Scheduler) erro
 		}
 	}()
 
-	return e.JSON(http.StatusOK, map[string]interface{}{
+	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Staff vehicle info extraction started",
 		"status":   "started",
 		"syncType": syncType,

--- a/pocketbase/sync/attendees.go
+++ b/pocketbase/sync/attendees.go
@@ -161,7 +161,7 @@ func (s *AttendeesSync) loadSessionIDs() error {
 
 // processAttendee processes a single attendee using pre-loaded existing attendees
 func (s *AttendeesSync) processAttendee(
-	attendeeData map[string]interface{},
+	attendeeData map[string]any,
 	existingAttendees map[string]*core.Record,
 ) error {
 	// Extract person ID
@@ -172,7 +172,7 @@ func (s *AttendeesSync) processAttendee(
 	personCMID := int(personID)
 
 	// Get session enrollments
-	sessionStatuses, ok := attendeeData["SessionProgramStatus"].([]interface{})
+	sessionStatuses, ok := attendeeData["SessionProgramStatus"].([]any)
 	if !ok || len(sessionStatuses) == 0 {
 		// No enrollments for this person
 		s.DebugLog("Skipping attendee: no session enrollments", "person_cm_id", personCMID)
@@ -182,7 +182,7 @@ func (s *AttendeesSync) processAttendee(
 
 	// Process each enrollment
 	for _, enrollmentData := range sessionStatuses {
-		enrollment, ok := enrollmentData.(map[string]interface{})
+		enrollment, ok := enrollmentData.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -199,7 +199,7 @@ func (s *AttendeesSync) processAttendee(
 // processEnrollment processes a single enrollment using pre-loaded existing attendees
 func (s *AttendeesSync) processEnrollment(
 	personCMID int,
-	enrollment map[string]interface{},
+	enrollment map[string]any,
 	existingAttendees map[string]*core.Record,
 ) error {
 	// Extract session ID
@@ -269,7 +269,7 @@ func (s *AttendeesSync) processEnrollment(
 	// Note: CampMinder attendee ID exists in enrollment["ID"] but we don't need it in PocketBase
 
 	// Prepare record data
-	recordData := map[string]interface{}{
+	recordData := map[string]any{
 		"person_id":        personCMID,
 		"status":           status,
 		"status_id":        statusID,
@@ -312,7 +312,7 @@ func (s *AttendeesSync) processEnrollment(
 // logStatusChange creates a record in attendee_status_history when a status transition is detected.
 // This is a non-critical operation - errors are logged but do not fail the sync.
 func (s *AttendeesSync) logStatusChange(
-	personCMID, sessionCMID int, oldStatus, newStatus string, recordData map[string]interface{},
+	personCMID, sessionCMID int, oldStatus, newStatus string, recordData map[string]any,
 ) error {
 	collection, err := s.App.FindCollectionByNameOrId("attendee_status_history")
 	if err != nil {

--- a/pocketbase/sync/attendees_status_history_test.go
+++ b/pocketbase/sync/attendees_status_history_test.go
@@ -215,13 +215,13 @@ func TestAttendeesSync_EffectiveDateExtraction(t *testing.T) {
 	// We test the pattern, not the full method (which needs PocketBase app).
 	tests := []struct {
 		name           string
-		enrollment     map[string]interface{}
+		enrollment     map[string]any
 		wantEffective  string
 		wantLastUpdate string
 	}{
 		{
 			name: "enrolled record has EffectiveDate = registration date",
-			enrollment: map[string]interface{}{
+			enrollment: map[string]any{
 				"PostDate":       "2024-11-18T00:00:00Z",
 				"EffectiveDate":  "2024-11-18T00:00:00Z",
 				"LastUpdatedUTC": "2024-11-18T12:30:00Z",
@@ -232,7 +232,7 @@ func TestAttendeesSync_EffectiveDateExtraction(t *testing.T) {
 		},
 		{
 			name: "cancelled record: EffectiveDate = original reg, PostDate = cancel date",
-			enrollment: map[string]interface{}{
+			enrollment: map[string]any{
 				"PostDate":       "2025-07-06T00:00:00Z",
 				"EffectiveDate":  "2024-11-18T00:00:00Z",
 				"LastUpdatedUTC": "2025-07-06T09:15:00Z",
@@ -243,7 +243,7 @@ func TestAttendeesSync_EffectiveDateExtraction(t *testing.T) {
 		},
 		{
 			name: "missing EffectiveDate results in empty string",
-			enrollment: map[string]interface{}{
+			enrollment: map[string]any{
 				"PostDate":       "2024-11-18T00:00:00Z",
 				"LastUpdatedUTC": "2024-11-18T12:30:00Z",
 				"StatusID":       float64(2),
@@ -253,7 +253,7 @@ func TestAttendeesSync_EffectiveDateExtraction(t *testing.T) {
 		},
 		{
 			name: "missing LastUpdatedUTC results in empty string",
-			enrollment: map[string]interface{}{
+			enrollment: map[string]any{
 				"PostDate":      "2024-11-18T00:00:00Z",
 				"EffectiveDate": "2024-11-18T00:00:00Z",
 				"StatusID":      float64(2),
@@ -284,7 +284,7 @@ func TestAttendeesSync_EffectiveDateExtraction(t *testing.T) {
 			}
 
 			// Verify that the recordData map would include these fields
-			recordData := map[string]interface{}{
+			recordData := map[string]any{
 				"effective_date":   effectiveDate,
 				"last_updated_utc": lastUpdatedUTC,
 			}
@@ -303,7 +303,7 @@ func TestAttendeesSync_EffectiveDateExtraction(t *testing.T) {
 // TestAttendeesSync_RecordDataContainsEffectiveDate verifies the full recordData map
 // built in processEnrollment would contain effective_date and last_updated_utc fields.
 func TestAttendeesSync_RecordDataContainsEffectiveDate(t *testing.T) {
-	enrollment := map[string]interface{}{
+	enrollment := map[string]any{
 		"SessionID":      float64(1001),
 		"StatusID":       float64(32), // cancelled
 		"PostDate":       "2025-07-06T00:00:00Z",
@@ -325,7 +325,7 @@ func TestAttendeesSync_RecordDataContainsEffectiveDate(t *testing.T) {
 		lastUpdatedUTC = ParseDate(lu)
 	}
 
-	recordData := map[string]interface{}{
+	recordData := map[string]any{
 		"enrollment_date":  enrollmentDate,
 		"effective_date":   effectiveDate,
 		"last_updated_utc": lastUpdatedUTC,

--- a/pocketbase/sync/base_sync.go
+++ b/pocketbase/sync/base_sync.go
@@ -125,13 +125,13 @@ func (b *BaseSyncService) ClearProcessedKeys() {
 }
 
 // TrackProcessedKey adds a composite key to the processed keys map
-func (b *BaseSyncService) TrackProcessedKey(id interface{}, year int) {
+func (b *BaseSyncService) TrackProcessedKey(id any, year int) {
 	compKey := CompositeKey(id, year)
 	b.ProcessedKeys[compKey] = true
 }
 
 // IsKeyProcessed checks if a key has already been processed in the current sync run
-func (b *BaseSyncService) IsKeyProcessed(id interface{}, year int) bool {
+func (b *BaseSyncService) IsKeyProcessed(id any, year int) bool {
 	compKey := CompositeKey(id, year)
 	return b.ProcessedKeys[compKey]
 }
@@ -223,7 +223,7 @@ func (b *BaseSyncService) DeleteOrphans(
 // Returns composite keys of records that exist in preloaded but weren't processed.
 // This is a pure function suitable for unit testing.
 // The preloaded map values can be any type (typically *core.Record or string PB IDs).
-func (b *BaseSyncService) FindOrphansFromPreloaded(preloaded map[interface{}]any) []string {
+func (b *BaseSyncService) FindOrphansFromPreloaded(preloaded map[any]any) []string {
 	if !b.SyncSuccessful {
 		return []string{}
 	}
@@ -247,7 +247,7 @@ func (b *BaseSyncService) FindOrphansFromPreloaded(preloaded map[interface{}]any
 //   - preloadedRecords: Map from PreloadRecords (composite key -> *core.Record)
 //   - entityName: Human-readable name for logging
 func (b *BaseSyncService) DeleteOrphansFromPreloaded(
-	preloadedRecords map[interface{}]*core.Record,
+	preloadedRecords map[any]*core.Record,
 	entityName string,
 ) error {
 	if !b.SyncSuccessful {
@@ -344,9 +344,9 @@ func (b *BaseSyncService) PaginateRecords(
 func (b *BaseSyncService) PreloadRecords(
 	collection string,
 	filter string,
-	keyExtractor func(*core.Record) (interface{}, bool),
-) (map[interface{}]*core.Record, error) {
-	existingRecords := make(map[interface{}]*core.Record)
+	keyExtractor func(*core.Record) (any, bool),
+) (map[any]*core.Record, error) {
+	existingRecords := make(map[any]*core.Record)
 
 	allRecords, err := b.App.FindRecordsByFilter(collection, filter, "", 0, 0)
 	if err != nil {
@@ -389,9 +389,9 @@ func (b *BaseSyncService) PreloadRecords(
 func (b *BaseSyncService) PreloadRecordsGlobal(
 	collection string,
 	filter string,
-	keyExtractor func(*core.Record) (interface{}, bool),
-) (map[interface{}]*core.Record, error) {
-	existingRecords := make(map[interface{}]*core.Record)
+	keyExtractor func(*core.Record) (any, bool),
+) (map[any]*core.Record, error) {
+	existingRecords := make(map[any]*core.Record)
 
 	allRecords, err := b.App.FindRecordsByFilter(collection, filter, "", 0, 0)
 	if err != nil {
@@ -414,9 +414,9 @@ func (b *BaseSyncService) PreloadRecordsGlobal(
 // ProcessSimpleRecord handles standard create/update logic for a single record
 func (b *BaseSyncService) ProcessSimpleRecord(
 	collection string,
-	key interface{},
-	recordData map[string]interface{},
-	existingRecords map[interface{}]*core.Record,
+	key any,
+	recordData map[string]any,
+	existingRecords map[any]*core.Record,
 	compareFields []string, // Optional: specific fields to check for updates
 ) error {
 	// Extract year from recordData - required for year isolation
@@ -443,7 +443,7 @@ func (b *BaseSyncService) ProcessSimpleRecord(
 		// Check if update is needed
 		needsUpdate := false
 		var triggeringField string
-		var existingVal, newVal interface{}
+		var existingVal, newVal any
 
 		if len(compareFields) > 0 {
 			// Only compare specified fields
@@ -525,9 +525,9 @@ func (b *BaseSyncService) ProcessSimpleRecord(
 // Unlike ProcessSimpleRecord, this does NOT require 'year' in recordData.
 func (b *BaseSyncService) ProcessSimpleRecordGlobal(
 	collection string,
-	key interface{},
-	recordData map[string]interface{},
-	existingRecords map[interface{}]*core.Record,
+	key any,
+	recordData map[string]any,
+	existingRecords map[any]*core.Record,
 	compareFields []string, // Optional: specific fields to check for updates
 ) error {
 	// Use key directly - no year component for global entities
@@ -639,7 +639,7 @@ func (b *BaseSyncService) PreloadCompositeRecords(
 func (b *BaseSyncService) ProcessCompositeRecord(
 	collection string,
 	compositeKey string,
-	recordData map[string]interface{},
+	recordData map[string]any,
 	existingRecords map[string]*core.Record,
 	skipFields []string, // Fields to skip during comparison (like "year" for idempotency)
 ) error {
@@ -809,7 +809,7 @@ func compareRecordNeedsUpdate(existing *core.Record, newData map[string]any, com
 
 // CompositeKey creates a year-scoped key for record lookups
 // This ensures year isolation by making the year part of the record's identity
-func CompositeKey(id interface{}, year int) string {
+func CompositeKey(id any, year int) string {
 	return fmt.Sprintf("%v|%d", id, year)
 }
 
@@ -841,7 +841,7 @@ func (b *BaseSyncService) ForceWALCheckpoint() error {
 // FieldEquals compares two field values for equality, handling type conversions and special cases
 //
 //nolint:gocyclo // complex type comparison logic requires many branches
-func (b *BaseSyncService) FieldEquals(existingValue, newValue interface{}) bool {
+func (b *BaseSyncService) FieldEquals(existingValue, newValue any) bool {
 	// Handle nil vs empty string equivalence
 	if (existingValue == nil && newValue == "") || (existingValue == "" && newValue == nil) {
 		return true
@@ -939,7 +939,7 @@ func (b *BaseSyncService) FieldEquals(existingValue, newValue interface{}) bool 
 
 	// If both look like JSON, compare them semantically
 	if existingIsJSON && newIsJSON {
-		var existingJSON, newJSON interface{}
+		var existingJSON, newJSON any
 		if err := json.Unmarshal([]byte(existingStr), &existingJSON); err == nil {
 			if err := json.Unmarshal([]byte(newStr), &newJSON); err == nil {
 				// Both parsed successfully, compare the parsed values
@@ -1135,7 +1135,7 @@ func normalizeToStringSlice(value any) []string {
 	}
 
 	// []interface{} (common from JSON unmarshaling)
-	if ifaceSlice, ok := value.([]interface{}); ok {
+	if ifaceSlice, ok := value.([]any); ok {
 		result := make([]string, 0, len(ifaceSlice))
 		for _, v := range ifaceSlice {
 			if s, ok := v.(string); ok {
@@ -1296,7 +1296,7 @@ func (b *BaseSyncService) BuildRecordCMIDMappings(
 }
 
 // PopulateRelations populates multiple relation fields in recordData
-func (b *BaseSyncService) PopulateRelations(recordData map[string]interface{}, relations []RelationConfig) error {
+func (b *BaseSyncService) PopulateRelations(recordData map[string]any, relations []RelationConfig) error {
 	for _, rel := range relations {
 		pbID, found := b.LookupRelation(rel.Collection, rel.CMID, rel.FieldName)
 		if !found {
@@ -1420,7 +1420,7 @@ func (b *BaseSyncService) ClearFieldDiffStats() {
 }
 
 // formatFieldValue formats a field value for logging, truncating long values
-func formatFieldValue(v interface{}) string {
+func formatFieldValue(v any) string {
 	if v == nil {
 		return "<nil>"
 	}

--- a/pocketbase/sync/base_sync_test.go
+++ b/pocketbase/sync/base_sync_test.go
@@ -127,7 +127,7 @@ func TestBaseSyncService_FindOrphansFromPreloaded(t *testing.T) {
 			}
 
 			// Build preloaded map with string keys (simulating composite keys)
-			preloaded := make(map[interface{}]any)
+			preloaded := make(map[any]any)
 			for _, key := range tt.preloadedKeys {
 				preloaded[key] = "pb-id-" + key // PB record ID (or *core.Record in real usage)
 			}

--- a/pocketbase/sync/base_sync_utils_test.go
+++ b/pocketbase/sync/base_sync_utils_test.go
@@ -9,7 +9,7 @@ import (
 func TestCompositeKey(t *testing.T) {
 	tests := []struct {
 		name     string
-		id       interface{}
+		id       any
 		year     int
 		expected string
 	}{
@@ -38,8 +38,8 @@ func TestFieldEquals(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		existing interface{}
-		newVal   interface{}
+		existing any
+		newVal   any
 		expected bool
 	}{
 		// Nil and empty equivalence
@@ -86,7 +86,7 @@ func TestFieldEquals(t *testing.T) {
 		{"different JSON arrays", `[1,2,3]`, `[1,2,4]`, false},
 
 		// Direct comparison
-		{"same interface values", interface{}(42), interface{}(42), true},
+		{"same interface values", any(42), any(42), true},
 	}
 
 	for _, tt := range tests {
@@ -186,8 +186,8 @@ func TestByteSliceHandling(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		existing interface{}
-		newVal   interface{}
+		existing any
+		newVal   any
 		expected bool
 	}{
 		{
@@ -225,9 +225,9 @@ func TestNormalizeToStringSlice(t *testing.T) {
 		{"nil input", nil, nil},
 		{"empty []string", []string{}, []string{}},
 		{"[]string with values", []string{"a", "b", "c"}, []string{"a", "b", "c"}},
-		{"empty []interface{}", []interface{}{}, []string{}},
-		{"[]interface{} with strings", []interface{}{"x", "y", "z"}, []string{"x", "y", "z"}},
-		{"[]interface{} with non-strings", []interface{}{"a", 123}, nil},
+		{"empty []interface{}", []any{}, []string{}},
+		{"[]interface{} with strings", []any{"x", "y", "z"}, []string{"x", "y", "z"}},
+		{"[]interface{} with non-strings", []any{"a", 123}, nil},
 		{"[]any with strings", []any{"p", "q"}, []string{"p", "q"}},
 		{"[]any with mixed types", []any{"a", true}, nil},
 		// Single string is intentionally converted to []string{str} because
@@ -268,8 +268,8 @@ func TestFieldEqualsSliceComparison(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		existing interface{}
-		newVal   interface{}
+		existing any
+		newVal   any
 		expected bool
 	}{
 		// Same type comparisons
@@ -278,17 +278,17 @@ func TestFieldEqualsSliceComparison(t *testing.T) {
 		{"different length []string", []string{"a", "b"}, []string{"a", "b", "c"}, false},
 
 		// Cross-type comparisons (PocketBase returns []interface{}, we set []string)
-		{"[]interface{} vs []string same", []interface{}{"id1", "id2"}, []string{"id1", "id2"}, true},
-		{"[]string vs []interface{} same", []string{"id1", "id2"}, []interface{}{"id1", "id2"}, true},
-		{"[]interface{} vs []string different", []interface{}{"id1", "id2"}, []string{"id1", "id3"}, false},
+		{"[]interface{} vs []string same", []any{"id1", "id2"}, []string{"id1", "id2"}, true},
+		{"[]string vs []interface{} same", []string{"id1", "id2"}, []any{"id1", "id2"}, true},
+		{"[]interface{} vs []string different", []any{"id1", "id2"}, []string{"id1", "id3"}, false},
 
 		// Order-independent comparison (sorted before compare)
 		{"same values different order", []string{"c", "a", "b"}, []string{"a", "b", "c"}, true},
-		{"[]interface{} vs []string different order", []interface{}{"z", "x", "y"}, []string{"x", "y", "z"}, true},
+		{"[]interface{} vs []string different order", []any{"z", "x", "y"}, []string{"x", "y", "z"}, true},
 
 		// Empty slices
 		{"both empty []string", []string{}, []string{}, true},
-		{"empty []interface{} vs empty []string", []interface{}{}, []string{}, true},
+		{"empty []interface{} vs empty []string", []any{}, []string{}, true},
 	}
 
 	for _, tt := range tests {

--- a/pocketbase/sync/bunk_assignments.go
+++ b/pocketbase/sync/bunk_assignments.go
@@ -172,7 +172,7 @@ func (s *BunkAssignmentsSync) Sync(ctx context.Context) error {
 			bunkPlanID := int(bunkPlanIDFloat)
 
 			// Get the assignments array from this result
-			assignmentsArray, ok := result["Assignments"].([]interface{})
+			assignmentsArray, ok := result["Assignments"].([]any)
 			if !ok {
 				slog.Warn("No Assignments array in result")
 				continue
@@ -187,7 +187,7 @@ func (s *BunkAssignmentsSync) Sync(ctx context.Context) error {
 
 			// Process each assignment in the array
 			for _, assignment := range assignmentsArray {
-				assignmentData, ok := assignment.(map[string]interface{})
+				assignmentData, ok := assignment.(map[string]any)
 				if !ok {
 					slog.Warn("Invalid assignment data type")
 					continue
@@ -409,7 +409,7 @@ func (s *BunkAssignmentsSync) findMatchingSession(personSessions, bunkPlanSessio
 
 // processAssignment processes a single bunk assignment using pre-loaded existing assignments
 func (s *BunkAssignmentsSync) processAssignment(
-	assignmentData map[string]interface{},
+	assignmentData map[string]any,
 	existingAssignments map[string]*core.Record,
 ) error {
 	// Extract required fields
@@ -476,7 +476,7 @@ func (s *BunkAssignmentsSync) processAssignment(
 	key := fmt.Sprintf("%d:%d:%d", personCMID, sessionCMID, year)
 
 	// Prepare record data with CM ID and is_deleted
-	recordData := map[string]interface{}{
+	recordData := map[string]any{
 		"year":       year,
 		"cm_id":      assignmentCMID, // The assignment's own CampMinder ID
 		"is_deleted": isDeleted,

--- a/pocketbase/sync/bunk_assignments_test.go
+++ b/pocketbase/sync/bunk_assignments_test.go
@@ -11,13 +11,13 @@ func TestBunkAssignmentsSync_processAssignment_ExtractsIsDeleted(t *testing.T) {
 
 	tests := []struct {
 		name             string
-		assignmentData   map[string]interface{}
+		assignmentData   map[string]any
 		wantIsDeleted    bool
 		wantInRecordData bool
 	}{
 		{
 			name: "assignment with is_deleted false (active)",
-			assignmentData: map[string]interface{}{
+			assignmentData: map[string]any{
 				"ID":         float64(1000),
 				"PersonID":   float64(123),
 				"SessionID":  float64(1),
@@ -30,7 +30,7 @@ func TestBunkAssignmentsSync_processAssignment_ExtractsIsDeleted(t *testing.T) {
 		},
 		{
 			name: "assignment with is_deleted true (deleted)",
-			assignmentData: map[string]interface{}{
+			assignmentData: map[string]any{
 				"ID":         float64(1001),
 				"PersonID":   float64(124),
 				"SessionID":  float64(1),
@@ -43,7 +43,7 @@ func TestBunkAssignmentsSync_processAssignment_ExtractsIsDeleted(t *testing.T) {
 		},
 		{
 			name: "assignment without is_deleted field defaults to false",
-			assignmentData: map[string]interface{}{
+			assignmentData: map[string]any{
 				"ID":         float64(1002),
 				"PersonID":   float64(125),
 				"SessionID":  float64(1),
@@ -76,7 +76,7 @@ func TestBunkAssignmentsSync_processAssignment_ExtractsIsDeleted(t *testing.T) {
 				return
 			}
 			assignmentCMID := int(idFloat)
-			recordData := map[string]interface{}{
+			recordData := map[string]any{
 				"year":       2025,
 				"cm_id":      assignmentCMID,
 				"is_deleted": isDeleted,
@@ -98,7 +98,7 @@ func TestBunkAssignmentsSync_IsDeletedFieldTypes(t *testing.T) {
 	// Test handling of different IsDeleted field types from API
 	tests := []struct {
 		name      string
-		apiValue  interface{}
+		apiValue  any
 		wantValue bool
 		wantOk    bool
 	}{

--- a/pocketbase/sync/bunk_plans.go
+++ b/pocketbase/sync/bunk_plans.go
@@ -264,10 +264,10 @@ func (s *BunkPlansSync) syncBunkPlans(ctx context.Context) error {
 }
 
 // processBunkPlan processes a single bunk plan record and returns the number of assignments created
-func (s *BunkPlansSync) processBunkPlan(planData map[string]interface{}) (int, error) {
+func (s *BunkPlansSync) processBunkPlan(planData map[string]any) (int, error) {
 	planID, _ := planData["ID"].(float64)
-	bunkIDs, _ := planData["BunkIDs"].([]interface{})
-	sessionIDs, _ := planData["SessionIDs"].([]interface{})
+	bunkIDs, _ := planData["BunkIDs"].([]any)
+	sessionIDs, _ := planData["SessionIDs"].([]any)
 
 	// Extract name and code fields
 	name, _ := planData["Name"].(string)
@@ -399,7 +399,7 @@ func (s *BunkPlansSync) createBunkPlan(planID, bunkCMID, sessionCMID int, name, 
 	s.TrackProcessedCompositeKey(key, year)
 
 	// Prepare data for the record
-	recordData := map[string]interface{}{
+	recordData := map[string]any{
 		"year":      year,
 		"cm_id":     planID, // The plan's own CampMinder ID
 		"name":      name,

--- a/pocketbase/sync/bunk_plans_test.go
+++ b/pocketbase/sync/bunk_plans_test.go
@@ -10,13 +10,13 @@ func TestBunkPlansSync_createBunkPlan_WithIsActive(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		planData     map[string]interface{}
-		wantIsActive interface{}
+		planData     map[string]any
+		wantIsActive any
 		wantInData   bool
 	}{
 		{
 			name: "plan with is_active true",
-			planData: map[string]interface{}{
+			planData: map[string]any{
 				"ID":       float64(1),
 				"Name":     "Test Plan",
 				"Code":     "TP1",
@@ -27,7 +27,7 @@ func TestBunkPlansSync_createBunkPlan_WithIsActive(t *testing.T) {
 		},
 		{
 			name: "plan with is_active false",
-			planData: map[string]interface{}{
+			planData: map[string]any{
 				"ID":       float64(2),
 				"Name":     "Inactive Plan",
 				"Code":     "IP1",
@@ -38,7 +38,7 @@ func TestBunkPlansSync_createBunkPlan_WithIsActive(t *testing.T) {
 		},
 		{
 			name: "plan without is_active field defaults to true",
-			planData: map[string]interface{}{
+			planData: map[string]any{
 				"ID":   float64(3),
 				"Name": "Default Plan",
 				"Code": "DP1",
@@ -68,7 +68,7 @@ func TestBunkPlansSync_createBunkPlan_WithIsActive(t *testing.T) {
 				t.Fatal("missing ID in test data")
 				return
 			}
-			recordData := map[string]interface{}{
+			recordData := map[string]any{
 				"year":      2025,
 				"cm_id":     int(idFloat),
 				"name":      tt.planData["Name"],
@@ -94,30 +94,30 @@ func TestBunkPlansSync_processBunkPlan_ExtractsIsActive(t *testing.T) {
 
 	testCases := []struct {
 		name         string
-		planData     map[string]interface{}
+		planData     map[string]any
 		expectActive bool
 	}{
 		{
 			name: "active plan",
-			planData: map[string]interface{}{
+			planData: map[string]any{
 				"ID":         float64(100),
 				"Name":       "Active Plan",
 				"Code":       "AP",
 				"IsActive":   true,
-				"BunkIDs":    []interface{}{float64(1)},
-				"SessionIDs": []interface{}{float64(1)},
+				"BunkIDs":    []any{float64(1)},
+				"SessionIDs": []any{float64(1)},
 			},
 			expectActive: true,
 		},
 		{
 			name: "inactive plan",
-			planData: map[string]interface{}{
+			planData: map[string]any{
 				"ID":         float64(101),
 				"Name":       "Inactive Plan",
 				"Code":       "IP",
 				"IsActive":   false,
-				"BunkIDs":    []interface{}{float64(1)},
-				"SessionIDs": []interface{}{float64(1)},
+				"BunkIDs":    []any{float64(1)},
+				"SessionIDs": []any{float64(1)},
 			},
 			expectActive: false,
 		},

--- a/pocketbase/sync/bunks.go
+++ b/pocketbase/sync/bunks.go
@@ -35,7 +35,7 @@ func (s *BunksSync) Sync(ctx context.Context) error {
 	filter := fmt.Sprintf("year = %d", year)
 
 	// Pre-load existing records for this year
-	existingRecords, err := s.PreloadRecords("bunks", filter, func(record *core.Record) (interface{}, bool) {
+	existingRecords, err := s.PreloadRecords("bunks", filter, func(record *core.Record) (any, bool) {
 		if cmID, ok := record.Get("cm_id").(float64); ok {
 			return int(cmID), true
 		}
@@ -143,8 +143,8 @@ func (s *BunksSync) Sync(ctx context.Context) error {
 }
 
 // transformBunkToPB transforms CampMinder bunk data to PocketBase format
-func (s *BunksSync) transformBunkToPB(cmBunk map[string]interface{}) (map[string]interface{}, error) {
-	pbData := make(map[string]interface{})
+func (s *BunksSync) transformBunkToPB(cmBunk map[string]any) (map[string]any, error) {
+	pbData := make(map[string]any)
 
 	// Extract base fields
 	if id, ok := cmBunk["ID"].(float64); ok {

--- a/pocketbase/sync/bunks_test.go
+++ b/pocketbase/sync/bunks_test.go
@@ -10,7 +10,7 @@ func TestBunksSync_transformBunkToPB_WithNewFields(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		input         map[string]interface{}
+		input         map[string]any
 		wantCMID      int
 		wantName      string
 		wantGender    string
@@ -21,7 +21,7 @@ func TestBunksSync_transformBunkToPB_WithNewFields(t *testing.T) {
 	}{
 		{
 			name: "bunk with all new fields",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"ID":        float64(123),
 				"Name":      "B-1",
 				"IsActive":  true,
@@ -38,7 +38,7 @@ func TestBunksSync_transformBunkToPB_WithNewFields(t *testing.T) {
 		},
 		{
 			name: "bunk with is_active false",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"ID":        float64(124),
 				"Name":      "G-2",
 				"IsActive":  false,
@@ -55,7 +55,7 @@ func TestBunksSync_transformBunkToPB_WithNewFields(t *testing.T) {
 		},
 		{
 			name: "AG bunk with new fields",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"ID":        float64(125),
 				"Name":      "AG-8",
 				"IsActive":  true,
@@ -72,7 +72,7 @@ func TestBunksSync_transformBunkToPB_WithNewFields(t *testing.T) {
 		},
 		{
 			name: "bunk with missing optional fields defaults properly",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"ID":   float64(126),
 				"Name": "B-3",
 				// IsActive, SortOrder, AreaID omitted
@@ -87,7 +87,7 @@ func TestBunksSync_transformBunkToPB_WithNewFields(t *testing.T) {
 		},
 		{
 			name: "bunk with zero values",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"ID":        float64(127),
 				"Name":      "G-4",
 				"IsActive":  false,

--- a/pocketbase/sync/camper_history.go
+++ b/pocketbase/sync/camper_history.go
@@ -289,7 +289,7 @@ func (c *CamperHistorySync) Sync(ctx context.Context) error {
 		}
 
 		// Build record data map for upsert comparison
-		recordData := map[string]interface{}{
+		recordData := map[string]any{
 			"person_id":           attendee.personCMID,
 			"session_cm_id":       attendee.sessionCMID,
 			"year":                year,
@@ -1120,7 +1120,7 @@ func (c *CamperHistorySync) preloadExistingRecords(year int) (map[string]*core.R
 // Uses compareFields (inclusion list): only the listed fields are checked for changes.
 // Delegates to the shared compareRecordNeedsUpdate in base_sync.go.
 func (c *CamperHistorySync) recordNeedsUpdate(
-	existing *core.Record, newData map[string]interface{}, compareFields []string,
+	existing *core.Record, newData map[string]any, compareFields []string,
 ) bool {
 	return compareRecordNeedsUpdate(existing, newData, compareFields)
 }

--- a/pocketbase/sync/camper_history_test.go
+++ b/pocketbase/sync/camper_history_test.go
@@ -2432,7 +2432,7 @@ func TestCamperHistoryRecordNeedsUpdateUsesCompareFields(t *testing.T) {
 		existing.Set("bunk_cm_id", 200)
 		existing.Set("synagogue", testSynagogue)
 
-		newData := map[string]interface{}{
+		newData := map[string]any{
 			"session_name":        "Session 1",
 			"first_name":          testFirstName,
 			"last_name":           "Garcia",
@@ -2487,7 +2487,7 @@ func TestCamperHistoryRecordNeedsUpdateUsesCompareFields(t *testing.T) {
 		existing.Set("bunk_cm_id", 200)
 		existing.Set("synagogue", testSynagogue)
 
-		newData := map[string]interface{}{
+		newData := map[string]any{
 			"session_name":        "Session 1",
 			"first_name":          testFirstName,
 			"last_name":           "Garcia",

--- a/pocketbase/sync/collect_traces_test.go
+++ b/pocketbase/sync/collect_traces_test.go
@@ -122,7 +122,7 @@ func TestCollectTraces_JSONSerialization(t *testing.T) {
 			t.Fatalf("failed to marshal request: %v", err)
 		}
 
-		var decoded map[string]interface{}
+		var decoded map[string]any
 		if err := json.Unmarshal(data, &decoded); err != nil {
 			t.Fatalf("failed to unmarshal: %v", err)
 		}
@@ -150,7 +150,7 @@ func TestCollectTraces_JSONSerialization(t *testing.T) {
 			t.Fatalf("failed to marshal request: %v", err)
 		}
 
-		var decoded map[string]interface{}
+		var decoded map[string]any
 		if err := json.Unmarshal(data, &decoded); err != nil {
 			t.Fatalf("failed to unmarshal: %v", err)
 		}
@@ -179,7 +179,7 @@ func TestCollectTraces_EndToEndFalseViaCallAPIProcessor(t *testing.T) {
 	var fieldPresent bool
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var body map[string]interface{}
+		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Errorf("failed to decode request body: %v", err)
 			w.WriteHeader(500)

--- a/pocketbase/sync/custom_field_definitions.go
+++ b/pocketbase/sync/custom_field_definitions.go
@@ -36,7 +36,7 @@ func (s *CustomFieldDefinitionsSync) Name() string {
 func (s *CustomFieldDefinitionsSync) Sync(ctx context.Context) error {
 	// Pre-load all existing records (no year filter - definitions are global)
 	// Use PreloadRecordsGlobal since this table has no year field
-	existingRecords, err := s.PreloadRecordsGlobal("custom_field_defs", "", func(record *core.Record) (interface{}, bool) {
+	existingRecords, err := s.PreloadRecordsGlobal("custom_field_defs", "", func(record *core.Record) (any, bool) {
 		if cmID, ok := record.Get("cm_id").(float64); ok && cmID > 0 {
 			return int(cmID), true
 		}
@@ -153,9 +153,9 @@ func (s *CustomFieldDefinitionsSync) Sync(ctx context.Context) error {
 // transformCustomFieldDefinitionToPB transforms CampMinder custom field definition data to PocketBase format
 // Note: CampMinder /persons/custom-fields endpoint uses camelCase field names
 func (s *CustomFieldDefinitionsSync) transformCustomFieldDefinitionToPB(
-	data map[string]interface{},
-) (map[string]interface{}, error) {
-	pbData := make(map[string]interface{})
+	data map[string]any,
+) (map[string]any, error) {
+	pbData := make(map[string]any)
 
 	// Extract ID (required) - API uses "id" (camelCase)
 	idFloat, ok := data["id"].(float64)

--- a/pocketbase/sync/custom_field_definitions_test.go
+++ b/pocketbase/sync/custom_field_definitions_test.go
@@ -22,7 +22,7 @@ func TestTransformCustomFieldDefinitionToPB(t *testing.T) {
 	s := &CustomFieldDefinitionsSync{}
 
 	// Mock CampMinder API response (camelCase field names)
-	data := map[string]interface{}{
+	data := map[string]any{
 		"id":         float64(12345),
 		"name":       "Dietary Restrictions",
 		"dataType":   "String",
@@ -106,7 +106,7 @@ func TestTransformCustomFieldDefinitionHandlesMissingFields(t *testing.T) {
 	s := &CustomFieldDefinitionsSync{}
 
 	// Minimal data with only required fields (camelCase)
-	data := map[string]interface{}{
+	data := map[string]any{
 		"id":   float64(12345),
 		"name": "Test Field",
 	}
@@ -157,7 +157,7 @@ func TestTransformCustomFieldDefinitionRequiredIDError(t *testing.T) {
 	s := &CustomFieldDefinitionsSync{}
 
 	// Missing ID field
-	data := map[string]interface{}{
+	data := map[string]any{
 		"name": "Test Field",
 	}
 
@@ -172,7 +172,7 @@ func TestTransformCustomFieldDefinitionRequiredNameError(t *testing.T) {
 	s := &CustomFieldDefinitionsSync{}
 
 	// Missing Name field
-	data := map[string]interface{}{
+	data := map[string]any{
 		"id": float64(12345),
 	}
 
@@ -187,7 +187,7 @@ func TestTransformCustomFieldDefinitionZeroIDError(t *testing.T) {
 	s := &CustomFieldDefinitionsSync{}
 
 	// ID=0 (invalid)
-	data := map[string]interface{}{
+	data := map[string]any{
 		"id":   float64(0),
 		"name": "Test Field",
 	}
@@ -203,7 +203,7 @@ func TestTransformCustomFieldDefinitionEmptyNameError(t *testing.T) {
 	s := &CustomFieldDefinitionsSync{}
 
 	// Empty Name
-	data := map[string]interface{}{
+	data := map[string]any{
 		"id":   float64(12345),
 		"name": "",
 	}
@@ -221,7 +221,7 @@ func TestTransformCustomFieldDefinitionValidDataTypes(t *testing.T) {
 	validDataTypes := []string{"None", "String", "Integer", "Decimal", "Date", "Time", "DateTime", "Boolean"}
 
 	for _, dt := range validDataTypes {
-		data := map[string]interface{}{
+		data := map[string]any{
 			"id":       float64(12345),
 			"name":     "Test Field",
 			"dataType": dt,
@@ -251,7 +251,7 @@ func TestTransformCustomFieldDefinitionValidPartitions(t *testing.T) {
 	validPartitions := []string{"None", "Family", "Alumnus", "Staff", "Camper", "Parent", "Adult"}
 
 	for _, p := range validPartitions {
-		data := map[string]interface{}{
+		data := map[string]any{
 			"id":        float64(12345),
 			"name":      "Test Field",
 			"partition": p,
@@ -281,7 +281,7 @@ func TestTransformCustomFieldDefinitionMultiValuePartition(t *testing.T) {
 	s := &CustomFieldDefinitionsSync{}
 
 	// Test multi-value partition (as returned by CampMinder API)
-	data := map[string]interface{}{
+	data := map[string]any{
 		"id":        float64(12345),
 		"name":      "Multi-Partition Field",
 		"partition": "Camper, Adult",
@@ -304,7 +304,7 @@ func TestTransformCustomFieldDefinitionTripleValuePartition(t *testing.T) {
 	s := &CustomFieldDefinitionsSync{}
 
 	// Test three-value partition
-	data := map[string]interface{}{
+	data := map[string]any{
 		"id":        float64(12345),
 		"name":      "Triple-Partition Field",
 		"partition": "Staff, Camper, Parent",

--- a/pocketbase/sync/delta_sync_test.go
+++ b/pocketbase/sync/delta_sync_test.go
@@ -10,7 +10,7 @@ func TestTransformPersonCustomFieldValue_CapturesLastUpdated(t *testing.T) {
 	s := &PersonCustomFieldValuesSync{}
 
 	// Mock CampMinder API response with lastUpdated
-	data := map[string]interface{}{
+	data := map[string]any{
 		"id":          float64(100),
 		"value":       "Vegetarian",
 		"lastUpdated": "2025-01-15T10:30:00Z",
@@ -32,7 +32,7 @@ func TestTransformPersonCustomFieldValue_MissingLastUpdated(t *testing.T) {
 	s := &PersonCustomFieldValuesSync{}
 
 	// Mock CampMinder API response WITHOUT lastUpdated
-	data := map[string]interface{}{
+	data := map[string]any{
 		"id":    float64(100),
 		"value": "Vegetarian",
 		// lastUpdated is missing
@@ -52,7 +52,7 @@ func TestTransformPersonCustomFieldValue_MissingLastUpdated(t *testing.T) {
 func TestTransformPersonCustomFieldValue_EmptyLastUpdated(t *testing.T) {
 	s := &PersonCustomFieldValuesSync{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"id":          float64(100),
 		"value":       "Vegetarian",
 		"lastUpdated": "",
@@ -71,7 +71,7 @@ func TestTransformPersonCustomFieldValue_EmptyLastUpdated(t *testing.T) {
 func TestTransformHouseholdCustomFieldValue_CapturesLastUpdated(t *testing.T) {
 	s := &HouseholdCustomFieldValuesSync{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"id":          float64(200),
 		"value":       "Has dietary restrictions",
 		"lastUpdated": "2025-01-20T14:45:00Z",
@@ -92,7 +92,7 @@ func TestTransformHouseholdCustomFieldValue_CapturesLastUpdated(t *testing.T) {
 func TestTransformHouseholdCustomFieldValue_MissingLastUpdated(t *testing.T) {
 	s := &HouseholdCustomFieldValuesSync{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"id":    float64(200),
 		"value": "Has dietary restrictions",
 		// lastUpdated is missing

--- a/pocketbase/sync/divisions.go
+++ b/pocketbase/sync/divisions.go
@@ -35,7 +35,7 @@ func (s *DivisionsSync) Name() string {
 func (s *DivisionsSync) Sync(ctx context.Context) error {
 	// Pre-load all existing records (no year filter - divisions are global)
 	// Use cm_id as the key since divisions have CampMinder IDs
-	existingRecords, err := s.PreloadRecordsGlobal("divisions", "", func(record *core.Record) (interface{}, bool) {
+	existingRecords, err := s.PreloadRecordsGlobal("divisions", "", func(record *core.Record) (any, bool) {
 		if cmID, ok := record.Get("cm_id").(float64); ok && cmID > 0 {
 			return int(cmID), true
 		}
@@ -209,8 +209,8 @@ func (s *DivisionsSync) resolveParentDivisionRelations(parentDivisionIDs map[int
 }
 
 // transformDivisionToPB transforms CampMinder division data to PocketBase format
-func (s *DivisionsSync) transformDivisionToPB(data map[string]interface{}) (map[string]interface{}, error) {
-	pbData := make(map[string]interface{})
+func (s *DivisionsSync) transformDivisionToPB(data map[string]any) (map[string]any, error) {
+	pbData := make(map[string]any)
 
 	// Extract ID (required)
 	idFloat, ok := data["ID"].(float64)

--- a/pocketbase/sync/divisions_test.go
+++ b/pocketbase/sync/divisions_test.go
@@ -20,7 +20,7 @@ func TestTransformDivisionToPB(t *testing.T) {
 	s := &DivisionsSync{}
 
 	// Mock CampMinder API response based on divisions endpoint schema
-	divisionData := map[string]interface{}{
+	divisionData := map[string]any{
 		"ID":                           float64(12345),
 		"Name":                         "Boys 3rd-4th Grade",
 		"Description":                  "Division for boys in 3rd-4th grade",
@@ -83,7 +83,7 @@ func TestTransformDivisionToPB_MinimalData(t *testing.T) {
 	s := &DivisionsSync{}
 
 	// Minimal data with only required fields
-	divisionData := map[string]interface{}{
+	divisionData := map[string]any{
 		"ID":   float64(12345),
 		"Name": "Test Division",
 	}
@@ -111,7 +111,7 @@ func TestTransformDivisionToPB_MinimalData(t *testing.T) {
 func TestTransformDivisionToPB_MissingID(t *testing.T) {
 	s := &DivisionsSync{}
 
-	divisionData := map[string]interface{}{
+	divisionData := map[string]any{
 		"Name": "Test Division",
 	}
 
@@ -125,7 +125,7 @@ func TestTransformDivisionToPB_MissingID(t *testing.T) {
 func TestTransformDivisionToPB_MissingName(t *testing.T) {
 	s := &DivisionsSync{}
 
-	divisionData := map[string]interface{}{
+	divisionData := map[string]any{
 		"ID": float64(12345),
 	}
 
@@ -139,7 +139,7 @@ func TestTransformDivisionToPB_MissingName(t *testing.T) {
 func TestTransformDivisionToPB_ZeroID(t *testing.T) {
 	s := &DivisionsSync{}
 
-	divisionData := map[string]interface{}{
+	divisionData := map[string]any{
 		"ID":   float64(0),
 		"Name": "Test Division",
 	}
@@ -154,7 +154,7 @@ func TestTransformDivisionToPB_ZeroID(t *testing.T) {
 func TestTransformDivisionToPB_EmptyName(t *testing.T) {
 	s := &DivisionsSync{}
 
-	divisionData := map[string]interface{}{
+	divisionData := map[string]any{
 		"ID":   float64(12345),
 		"Name": "",
 	}

--- a/pocketbase/sync/financial_aid_applications.go
+++ b/pocketbase/sync/financial_aid_applications.go
@@ -866,8 +866,8 @@ func (s *FinancialAidApplicationsSync) upsertApplications(
 }
 
 // recordToMap converts a PocketBase record to a map for comparison
-func (s *FinancialAidApplicationsSync) recordToMap(record *core.Record) map[string]interface{} {
-	return map[string]interface{}{
+func (s *FinancialAidApplicationsSync) recordToMap(record *core.Record) map[string]any {
+	return map[string]any{
 		// Core identifiers
 		"person":    record.GetString("person"),
 		"household": record.GetString("household"),
@@ -1024,8 +1024,8 @@ func (s *FinancialAidApplicationsSync) forceWALCheckpoint() error {
 }
 
 // toRecordData converts faApplicationData to a map for database operations
-func (app *faApplicationData) toRecordData(year int) map[string]interface{} {
-	return map[string]interface{}{
+func (app *faApplicationData) toRecordData(year int) map[string]any {
+	return map[string]any{
 		// Core identifiers
 		"person":    app.personPBID,
 		"household": app.householdPBID,
@@ -1129,7 +1129,7 @@ func (app *faApplicationData) toRecordData(year int) map[string]interface{} {
 }
 
 // fieldEquals compares two field values for equality, handling type conversions
-func (s *FinancialAidApplicationsSync) fieldEquals(existing, newVal interface{}) bool {
+func (s *FinancialAidApplicationsSync) fieldEquals(existing, newVal any) bool {
 	// Handle nil vs empty string
 	if (existing == nil && newVal == "") || (existing == "" && newVal == nil) {
 		return true
@@ -1175,7 +1175,7 @@ func (s *FinancialAidApplicationsSync) fieldEquals(existing, newVal interface{})
 
 // recordNeedsUpdate checks if any field differs between existing record and new data
 func (s *FinancialAidApplicationsSync) recordNeedsUpdate(
-	existing map[string]interface{}, newData map[string]interface{}, skipFields map[string]bool,
+	existing map[string]any, newData map[string]any, skipFields map[string]bool,
 ) bool {
 	for field, newValue := range newData {
 		if skipFields != nil && skipFields[field] {

--- a/pocketbase/sync/financial_aid_applications_test.go
+++ b/pocketbase/sync/financial_aid_applications_test.go
@@ -835,8 +835,8 @@ func TestFAFieldEquals(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		existing interface{}
-		newVal   interface{}
+		existing any
+		newVal   any
 		expected bool
 	}{
 		// nil vs empty string equivalence
@@ -889,21 +889,21 @@ func TestFARecordNeedsUpdate(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		existing   map[string]interface{}
-		newData    map[string]interface{}
+		existing   map[string]any
+		newData    map[string]any
 		skipFields map[string]bool
 		expected   bool
 	}{
 		{
 			name: "no changes - should not need update",
-			existing: map[string]interface{}{
+			existing: map[string]any{
 				"contact_first_name": "John",
 				"contact_email":      "john@example.com",
 				"total_gross_income": float64(100000),
 				"interest_expressed": true,
 				"year":               float64(2025),
 			},
-			newData: map[string]interface{}{
+			newData: map[string]any{
 				"contact_first_name": "John",
 				"contact_email":      "john@example.com",
 				"total_gross_income": float64(100000),
@@ -915,11 +915,11 @@ func TestFARecordNeedsUpdate(t *testing.T) {
 		},
 		{
 			name: "string field changed - should need update",
-			existing: map[string]interface{}{
+			existing: map[string]any{
 				"contact_first_name": "John",
 				"contact_email":      "john@example.com",
 			},
-			newData: map[string]interface{}{
+			newData: map[string]any{
 				"contact_first_name": "John",
 				"contact_email":      "john.new@example.com",
 			},
@@ -928,10 +928,10 @@ func TestFARecordNeedsUpdate(t *testing.T) {
 		},
 		{
 			name: "number field changed - should need update",
-			existing: map[string]interface{}{
+			existing: map[string]any{
 				"total_gross_income": float64(100000),
 			},
-			newData: map[string]interface{}{
+			newData: map[string]any{
 				"total_gross_income": float64(120000),
 			},
 			skipFields: nil,
@@ -939,10 +939,10 @@ func TestFARecordNeedsUpdate(t *testing.T) {
 		},
 		{
 			name: "bool field changed - should need update",
-			existing: map[string]interface{}{
+			existing: map[string]any{
 				"interest_expressed": false,
 			},
-			newData: map[string]interface{}{
+			newData: map[string]any{
 				"interest_expressed": true,
 			},
 			skipFields: nil,
@@ -950,11 +950,11 @@ func TestFARecordNeedsUpdate(t *testing.T) {
 		},
 		{
 			name: "only skipped field changed - should not need update",
-			existing: map[string]interface{}{
+			existing: map[string]any{
 				"contact_first_name": "John",
 				"year":               float64(2024),
 			},
-			newData: map[string]interface{}{
+			newData: map[string]any{
 				"contact_first_name": "John",
 				"year":               2025,
 			},
@@ -963,10 +963,10 @@ func TestFARecordNeedsUpdate(t *testing.T) {
 		},
 		{
 			name: "nil vs empty string - should not need update",
-			existing: map[string]interface{}{
+			existing: map[string]any{
 				"contact_first_name": nil,
 			},
-			newData: map[string]interface{}{
+			newData: map[string]any{
 				"contact_first_name": "",
 			},
 			skipFields: nil,
@@ -974,10 +974,10 @@ func TestFARecordNeedsUpdate(t *testing.T) {
 		},
 		{
 			name: "float64 vs int same value - should not need update",
-			existing: map[string]interface{}{
+			existing: map[string]any{
 				"num_children": float64(3),
 			},
-			newData: map[string]interface{}{
+			newData: map[string]any{
 				"num_children": 3,
 			},
 			skipFields: nil,
@@ -1014,7 +1014,7 @@ func TestFAApplicationToRecordData(t *testing.T) {
 	// Verify key fields are present and correct
 	tests := []struct {
 		field    string
-		expected interface{}
+		expected any
 	}{
 		{"person", "person123"},
 		{"household", "household456"},
@@ -1049,12 +1049,12 @@ func TestFAUpsertIdempotencyBehavior(t *testing.T) {
 	s := &FinancialAidApplicationsSync{}
 
 	// Scenario 1: Record data matches existing - should skip
-	existingData := map[string]interface{}{
+	existingData := map[string]any{
 		"contact_first_name": "John",
 		"contact_email":      "john@example.com",
 		"total_gross_income": float64(100000),
 	}
-	newDataSame := map[string]interface{}{
+	newDataSame := map[string]any{
 		"contact_first_name": "John",
 		"contact_email":      "john@example.com",
 		"total_gross_income": float64(100000),
@@ -1065,7 +1065,7 @@ func TestFAUpsertIdempotencyBehavior(t *testing.T) {
 	}
 
 	// Scenario 2: Record data differs - should update
-	newDataDifferent := map[string]interface{}{
+	newDataDifferent := map[string]any{
 		"contact_first_name": "John",
 		"contact_email":      "john.updated@example.com", // Changed
 		"total_gross_income": float64(100000),

--- a/pocketbase/sync/financial_lookups.go
+++ b/pocketbase/sync/financial_lookups.go
@@ -64,7 +64,7 @@ func (s *FinancialLookupsSync) syncFinancialCategories(ctx context.Context) erro
 	slog.Info("Syncing financial categories")
 
 	// Pre-load existing records (global - no year filter)
-	preloadFn := func(record *core.Record) (interface{}, bool) {
+	preloadFn := func(record *core.Record) (any, bool) {
 		if cmID, ok := record.Get("cm_id").(float64); ok && cmID > 0 {
 			return int(cmID), true
 		}
@@ -145,7 +145,7 @@ func (s *FinancialLookupsSync) syncPaymentMethods(ctx context.Context) error {
 	slog.Info("Syncing payment methods")
 
 	// Pre-load existing records (global - no year filter)
-	existingRecords, err := s.PreloadRecordsGlobal("payment_methods", "", func(record *core.Record) (interface{}, bool) {
+	existingRecords, err := s.PreloadRecordsGlobal("payment_methods", "", func(record *core.Record) (any, bool) {
 		if cmID, ok := record.Get("cm_id").(float64); ok && cmID > 0 {
 			return int(cmID), true
 		}
@@ -219,9 +219,9 @@ func (s *FinancialLookupsSync) syncPaymentMethods(ctx context.Context) error {
 // Transform functions
 
 func (s *FinancialLookupsSync) transformFinancialCategoryToPB(
-	data map[string]interface{},
-) (map[string]interface{}, error) {
-	pbData := make(map[string]interface{})
+	data map[string]any,
+) (map[string]any, error) {
+	pbData := make(map[string]any)
 
 	// id (required) - API uses lowercase field names
 	idFloat, ok := data["id"].(float64)
@@ -247,8 +247,8 @@ func (s *FinancialLookupsSync) transformFinancialCategoryToPB(
 	return pbData, nil
 }
 
-func (s *FinancialLookupsSync) transformPaymentMethodToPB(data map[string]interface{}) (map[string]interface{}, error) {
-	pbData := make(map[string]interface{})
+func (s *FinancialLookupsSync) transformPaymentMethodToPB(data map[string]any) (map[string]any, error) {
+	pbData := make(map[string]any)
 
 	// id (required) - API uses lowercase field names
 	idFloat, ok := data["id"].(float64)

--- a/pocketbase/sync/financial_lookups_test.go
+++ b/pocketbase/sync/financial_lookups_test.go
@@ -23,7 +23,7 @@ func TestTransformFinancialCategoryToPB(t *testing.T) {
 	s := &FinancialLookupsSync{}
 
 	// Mock CampMinder API response (lowercase field names per OpenAPI spec)
-	categoryData := map[string]interface{}{
+	categoryData := map[string]any{
 		"id":         float64(22650),
 		"name":       "Fees - Summer Camp",
 		"isArchived": false,
@@ -49,7 +49,7 @@ func TestTransformFinancialCategoryToPB(t *testing.T) {
 func TestTransformFinancialCategoryToPB_Archived(t *testing.T) {
 	s := &FinancialLookupsSync{}
 
-	categoryData := map[string]interface{}{
+	categoryData := map[string]any{
 		"id":         float64(100),
 		"name":       "Archived Category",
 		"isArchived": true,
@@ -69,7 +69,7 @@ func TestTransformFinancialCategoryToPB_NullName(t *testing.T) {
 	s := &FinancialLookupsSync{}
 
 	// API allows nullable name
-	categoryData := map[string]interface{}{
+	categoryData := map[string]any{
 		"id":         float64(100),
 		"name":       nil,
 		"isArchived": false,
@@ -90,7 +90,7 @@ func TestTransformFinancialCategoryToPB_MissingName(t *testing.T) {
 	s := &FinancialLookupsSync{}
 
 	// No name key at all
-	categoryData := map[string]interface{}{
+	categoryData := map[string]any{
 		"id":         float64(100),
 		"isArchived": false,
 	}
@@ -109,7 +109,7 @@ func TestTransformFinancialCategoryToPB_MissingName(t *testing.T) {
 func TestTransformFinancialCategoryToPB_MissingID(t *testing.T) {
 	s := &FinancialLookupsSync{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"name":       "Test Category",
 		"isArchived": false,
 	}
@@ -123,7 +123,7 @@ func TestTransformFinancialCategoryToPB_MissingID(t *testing.T) {
 func TestTransformFinancialCategoryToPB_ZeroID(t *testing.T) {
 	s := &FinancialLookupsSync{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"id":         float64(0),
 		"name":       "Test Category",
 		"isArchived": false,
@@ -143,7 +143,7 @@ func TestTransformPaymentMethodToPB(t *testing.T) {
 	s := &FinancialLookupsSync{}
 
 	// Mock CampMinder API response (lowercase field names per OpenAPI spec)
-	methodData := map[string]interface{}{
+	methodData := map[string]any{
 		"id":   float64(1),
 		"name": "Credit Card",
 	}
@@ -171,7 +171,7 @@ func TestTransformPaymentMethodToPB_NullName(t *testing.T) {
 	s := &FinancialLookupsSync{}
 
 	// API allows nullable name
-	methodData := map[string]interface{}{
+	methodData := map[string]any{
 		"id":   float64(1),
 		"name": nil,
 	}
@@ -191,7 +191,7 @@ func TestTransformPaymentMethodToPB_MissingName(t *testing.T) {
 	s := &FinancialLookupsSync{}
 
 	// No name key at all
-	methodData := map[string]interface{}{
+	methodData := map[string]any{
 		"id": float64(1),
 	}
 
@@ -209,7 +209,7 @@ func TestTransformPaymentMethodToPB_MissingName(t *testing.T) {
 func TestTransformPaymentMethodToPB_MissingID(t *testing.T) {
 	s := &FinancialLookupsSync{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"name": "Credit Card",
 	}
 
@@ -222,7 +222,7 @@ func TestTransformPaymentMethodToPB_MissingID(t *testing.T) {
 func TestTransformPaymentMethodToPB_ZeroID(t *testing.T) {
 	s := &FinancialLookupsSync{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"id":   float64(0),
 		"name": "Credit Card",
 	}

--- a/pocketbase/sync/financial_transactions.go
+++ b/pocketbase/sync/financial_transactions.go
@@ -60,7 +60,7 @@ func (s *FinancialTransactionsSync) SyncForYear(ctx context.Context, year int) e
 	// Pre-load existing records for this year
 	// Key by cm_id + amount since CampMinder returns original+reversal with same transactionId
 	filter := fmt.Sprintf("year = %d", year)
-	preloadFn := func(record *core.Record) (interface{}, bool) {
+	preloadFn := func(record *core.Record) (any, bool) {
 		cmID, ok1 := record.Get("cm_id").(float64)
 		amount, ok2 := record.Get("amount").(float64)
 		if ok1 && cmID > 0 && ok2 {
@@ -279,11 +279,11 @@ func (s *FinancialTransactionsSync) buildLookupMaps(year int) (TransactionLookup
 
 // transformTransactionToPB transforms CampMinder API data to PocketBase format
 func (s *FinancialTransactionsSync) transformTransactionToPB(
-	data map[string]interface{},
+	data map[string]any,
 	year int,
 	maps TransactionLookupMaps,
-) (map[string]interface{}, error) {
-	pbData := make(map[string]interface{})
+) (map[string]any, error) {
+	pbData := make(map[string]any)
 
 	// transactionId (required)
 	txnID, ok := data["transactionId"].(float64)
@@ -335,7 +335,7 @@ func (s *FinancialTransactionsSync) transformTransactionToPB(
 }
 
 // getStringOrEmpty safely extracts a string from the data map
-func getStringOrEmpty(data map[string]interface{}, key string) string {
+func getStringOrEmpty(data map[string]any, key string) string {
 	if val, ok := data[key]; ok {
 		if str, ok := val.(string); ok {
 			return strings.TrimSpace(str)
@@ -347,7 +347,7 @@ func getStringOrEmpty(data map[string]interface{}, key string) string {
 // setRelation maps a CampMinder ID field to a PocketBase relation.
 // It extracts the float64 ID from data[srcKey], looks it up in lookupMap,
 // and sets pbData[dstKey] if found.
-func setRelation(pbData, data map[string]interface{}, srcKey, dstKey string, lookupMap map[int]string) {
+func setRelation(pbData, data map[string]any, srcKey, dstKey string, lookupMap map[int]string) {
 	if id, ok := data[srcKey].(float64); ok && id > 0 {
 		if pbID, found := lookupMap[int(id)]; found {
 			pbData[dstKey] = pbID
@@ -356,14 +356,14 @@ func setRelation(pbData, data map[string]interface{}, srcKey, dstKey string, loo
 }
 
 // setIntFromFloat extracts a float64 from data and sets it as int in pbData.
-func setIntFromFloat(pbData, data map[string]interface{}, srcKey, dstKey string) {
+func setIntFromFloat(pbData, data map[string]any, srcKey, dstKey string) {
 	if val, ok := data[srcKey].(float64); ok {
 		pbData[dstKey] = int(val)
 	}
 }
 
 // setFloatFromFloat extracts a float64 from data and sets it in pbData.
-func setFloatFromFloat(pbData, data map[string]interface{}, srcKey, dstKey string) {
+func setFloatFromFloat(pbData, data map[string]any, srcKey, dstKey string) {
 	if val, ok := data[srcKey].(float64); ok {
 		pbData[dstKey] = val
 	}
@@ -379,10 +379,10 @@ func (s *FinancialTransactionsSync) transactionKey(cmID int, amount float64) str
 // deduplicateTransactions removes exact duplicate transactions from CampMinder
 // This handles a CampMinder bug where some $0 transactions are returned twice
 func (s *FinancialTransactionsSync) deduplicateTransactions(
-	transactions []map[string]interface{},
-) []map[string]interface{} {
+	transactions []map[string]any,
+) []map[string]any {
 	seen := make(map[string]bool)
-	result := make([]map[string]interface{}, 0, len(transactions))
+	result := make([]map[string]any, 0, len(transactions))
 	duplicates := 0
 
 	for _, txn := range transactions {

--- a/pocketbase/sync/financial_transactions_test.go
+++ b/pocketbase/sync/financial_transactions_test.go
@@ -34,7 +34,7 @@ func TestTransformTransactionToPB(t *testing.T) {
 	}
 
 	// Mock CampMinder API response (lowercase field names per OpenAPI spec)
-	transactionData := map[string]interface{}{
+	transactionData := map[string]any{
 		"transactionId":          float64(57783711),
 		"transactionNumber":      float64(12345),
 		"season":                 float64(2025),
@@ -112,7 +112,7 @@ func TestTransformTransactionToPB(t *testing.T) {
 }
 
 // Test helper functions for field verification
-func verifyIntField(t *testing.T, data map[string]interface{}, field string, want int) {
+func verifyIntField(t *testing.T, data map[string]any, field string, want int) {
 	t.Helper()
 	got, ok := data[field].(int)
 	if !ok {
@@ -124,7 +124,7 @@ func verifyIntField(t *testing.T, data map[string]interface{}, field string, wan
 	}
 }
 
-func verifyFloatField(t *testing.T, data map[string]interface{}, field string, want float64) {
+func verifyFloatField(t *testing.T, data map[string]any, field string, want float64) {
 	t.Helper()
 	got, ok := data[field].(float64)
 	if !ok {
@@ -136,7 +136,7 @@ func verifyFloatField(t *testing.T, data map[string]interface{}, field string, w
 	}
 }
 
-func verifyStringField(t *testing.T, data map[string]interface{}, field, want string) {
+func verifyStringField(t *testing.T, data map[string]any, field, want string) {
 	t.Helper()
 	got, ok := data[field].(string)
 	if !ok {
@@ -148,7 +148,7 @@ func verifyStringField(t *testing.T, data map[string]interface{}, field, want st
 	}
 }
 
-func verifyBoolField(t *testing.T, data map[string]interface{}, field string, want bool) {
+func verifyBoolField(t *testing.T, data map[string]any, field string, want bool) {
 	t.Helper()
 	got, ok := data[field].(bool)
 	if !ok {
@@ -160,14 +160,14 @@ func verifyBoolField(t *testing.T, data map[string]interface{}, field string, wa
 	}
 }
 
-func verifyFieldSet(t *testing.T, data map[string]interface{}, field string) {
+func verifyFieldSet(t *testing.T, data map[string]any, field string) {
 	t.Helper()
 	if data[field] == nil || data[field] == "" {
 		t.Errorf("%s should be set", field)
 	}
 }
 
-func verifyFieldEmpty(t *testing.T, data map[string]interface{}, field string) {
+func verifyFieldEmpty(t *testing.T, data map[string]any, field string) {
 	t.Helper()
 	if data[field] != nil && data[field] != "" {
 		t.Errorf("%s should be nil/empty, got %v", field, data[field])
@@ -178,7 +178,7 @@ func TestTransformTransactionToPB_Reversed(t *testing.T) {
 	s := &FinancialTransactionsSync{}
 	lookupMaps := TransactionLookupMaps{}
 
-	transactionData := map[string]interface{}{
+	transactionData := map[string]any{
 		"transactionId":       float64(12345),
 		"season":              float64(2025),
 		"isReversed":          true,
@@ -204,7 +204,7 @@ func TestTransformTransactionToPB_MissingTransactionID(t *testing.T) {
 	s := &FinancialTransactionsSync{}
 	lookupMaps := TransactionLookupMaps{}
 
-	transactionData := map[string]interface{}{
+	transactionData := map[string]any{
 		"season":              float64(2025),
 		"financialCategoryId": float64(100),
 		"amount":              float64(50.0),
@@ -220,7 +220,7 @@ func TestTransformTransactionToPB_ZeroTransactionID(t *testing.T) {
 	s := &FinancialTransactionsSync{}
 	lookupMaps := TransactionLookupMaps{}
 
-	transactionData := map[string]interface{}{
+	transactionData := map[string]any{
 		"transactionId":       float64(0),
 		"season":              float64(2025),
 		"financialCategoryId": float64(100),
@@ -238,7 +238,7 @@ func TestTransformTransactionToPB_NullOptionalFields(t *testing.T) {
 	lookupMaps := TransactionLookupMaps{}
 
 	// Transaction with all optional relation fields as nil
-	transactionData := map[string]interface{}{
+	transactionData := map[string]any{
 		"transactionId":          float64(12345),
 		"season":                 float64(2025),
 		"postDate":               "2025-11-11T00:00:00Z",
@@ -292,7 +292,7 @@ func TestTransformTransactionToPB_UnknownRelations(t *testing.T) {
 	// Empty lookup maps - relations won't be resolvable
 	lookupMaps := TransactionLookupMaps{}
 
-	transactionData := map[string]interface{}{
+	transactionData := map[string]any{
 		"transactionId":       float64(12345),
 		"season":              float64(2025),
 		"financialCategoryId": float64(999), // Not in lookup map
@@ -327,7 +327,7 @@ func TestTransformTransactionToPB_NegativeAmount(t *testing.T) {
 	lookupMaps := TransactionLookupMaps{}
 
 	// Refund/credit with negative amount
-	transactionData := map[string]interface{}{
+	transactionData := map[string]any{
 		"transactionId":       float64(12345),
 		"season":              float64(2025),
 		"financialCategoryId": float64(100),

--- a/pocketbase/sync/google_sheets.go
+++ b/pocketbase/sync/google_sheets.go
@@ -29,7 +29,7 @@ type TabPropertyUpdate struct {
 
 // SheetsWriter interface for writing to Google Sheets (enables mocking)
 type SheetsWriter interface {
-	WriteToSheet(ctx context.Context, spreadsheetID, sheetTab string, data [][]interface{}) error
+	WriteToSheet(ctx context.Context, spreadsheetID, sheetTab string, data [][]any) error
 	ClearSheet(ctx context.Context, spreadsheetID, sheetTab string) error
 	EnsureSheet(ctx context.Context, spreadsheetID, sheetTab string) error
 	SetTabColor(ctx context.Context, spreadsheetID, sheetTab string, color TabColor) error
@@ -55,7 +55,7 @@ func NewRealSheetsWriter(service *sheets.Service) *RealSheetsWriter {
 
 // WriteToSheet writes data to a specific sheet tab
 func (w *RealSheetsWriter) WriteToSheet(
-	ctx context.Context, spreadsheetID, sheetTab string, data [][]interface{},
+	ctx context.Context, spreadsheetID, sheetTab string, data [][]any,
 ) error {
 	valueRange := &sheets.ValueRange{
 		Values: data,
@@ -341,7 +341,7 @@ type PersonInfo struct {
 }
 
 // safeString safely converts an interface{} to string
-func safeString(v interface{}) string {
+func safeString(v any) string {
 	if v == nil {
 		return ""
 	}

--- a/pocketbase/sync/google_sheets_test.go
+++ b/pocketbase/sync/google_sheets_test.go
@@ -8,7 +8,7 @@ import (
 
 // MockSheetsWriter implements SheetsWriter interface for testing
 type MockSheetsWriter struct {
-	WrittenData   map[string][][]interface{} // sheetName -> rows
+	WrittenData   map[string][][]any // sheetName -> rows
 	ClearedTabs   []string
 	EnsuredTabs   []string            // Tracks tabs that were ensured to exist
 	ExistingTabs  map[string]bool     // Simulates which tabs already exist
@@ -35,7 +35,7 @@ type MockSheetsWriter struct {
 
 func NewMockSheetsWriter() *MockSheetsWriter {
 	return &MockSheetsWriter{
-		WrittenData:     make(map[string][][]interface{}),
+		WrittenData:     make(map[string][][]any),
 		ClearedTabs:     []string{},
 		EnsuredTabs:     []string{},
 		ExistingTabs:    make(map[string]bool),
@@ -47,7 +47,7 @@ func NewMockSheetsWriter() *MockSheetsWriter {
 	}
 }
 
-func (m *MockSheetsWriter) WriteToSheet(_ context.Context, _, sheetTab string, data [][]interface{}) error {
+func (m *MockSheetsWriter) WriteToSheet(_ context.Context, _, sheetTab string, data [][]any) error {
 	if m.WriteError != nil {
 		return m.WriteError
 	}

--- a/pocketbase/sync/household_custom_field_values.go
+++ b/pocketbase/sync/household_custom_field_values.go
@@ -278,7 +278,7 @@ func (s *HouseholdCustomFieldValuesSync) syncHouseholdCustomFieldValues(
 		}
 
 		// Fetch page of custom field values with rate limiting and retry
-		var values []map[string]interface{}
+		var values []map[string]any
 		var hasMore bool
 
 		err := s.rateLimiter.ExecuteWithRetry(ctx, func() error {
@@ -432,12 +432,12 @@ func (s *HouseholdCustomFieldValuesSync) deleteOrphans(year int) error {
 // transformHouseholdCustomFieldValueToPB transforms CampMinder custom field value data to PocketBase format
 // Schema: household, field_definition, value, year, last_updated (optional)
 func (s *HouseholdCustomFieldValuesSync) transformHouseholdCustomFieldValueToPB(
-	data map[string]interface{},
+	data map[string]any,
 	householdPBId string,
 	fieldDefPBId string,
 	year int,
-) map[string]interface{} {
-	pbData := make(map[string]interface{})
+) map[string]any {
+	pbData := make(map[string]any)
 
 	// Set relations
 	pbData["household"] = householdPBId

--- a/pocketbase/sync/household_custom_field_values_test.go
+++ b/pocketbase/sync/household_custom_field_values_test.go
@@ -25,7 +25,7 @@ func TestTransformHouseholdCustomFieldValueToPB(t *testing.T) {
 	s := &HouseholdCustomFieldValuesSync{}
 
 	// Mock CampMinder API response for a custom field value
-	data := map[string]interface{}{
+	data := map[string]any{
 		"id":    float64(100), // Custom field definition ID (used by caller to resolve PB ID)
 		"value": "Premium",
 	}
@@ -70,7 +70,7 @@ func TestTransformHouseholdCustomFieldValueToPB(t *testing.T) {
 func TestTransformHouseholdCustomFieldValueEmptyValue(t *testing.T) {
 	s := &HouseholdCustomFieldValuesSync{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"id":    float64(100),
 		"value": "",
 	}
@@ -86,7 +86,7 @@ func TestTransformHouseholdCustomFieldValueEmptyValue(t *testing.T) {
 func TestTransformHouseholdCustomFieldValueNilValue(t *testing.T) {
 	s := &HouseholdCustomFieldValuesSync{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"id": float64(100),
 		// Value is missing/nil
 	}

--- a/pocketbase/sync/households.go
+++ b/pocketbase/sync/households.go
@@ -63,7 +63,7 @@ func (s *HouseholdsSync) Sync(ctx context.Context) error {
 	filter := fmt.Sprintf("year = %d", year)
 
 	// Pre-load existing records for this year
-	existingRecords, err := s.PreloadRecords("households", filter, func(record *core.Record) (interface{}, bool) {
+	existingRecords, err := s.PreloadRecords("households", filter, func(record *core.Record) (any, bool) {
 		if cmID, ok := record.Get("cm_id").(float64); ok {
 			return int(cmID), true
 		}
@@ -97,7 +97,7 @@ func (s *HouseholdsSync) Sync(ctx context.Context) error {
 	slog.Info("Found unique persons from attendees for household extraction", "count", len(personIDs), "year", year)
 
 	// Track unique households across all batches
-	allHouseholds := make(map[int]map[string]interface{})
+	allHouseholds := make(map[int]map[string]any)
 
 	// Process persons in batches to extract households
 	batchSize := 500
@@ -198,12 +198,12 @@ func (s *HouseholdsSync) Sync(ctx context.Context) error {
 }
 
 // extractUniqueHouseholds extracts unique households from persons data
-func (s *HouseholdsSync) extractUniqueHouseholds(personsData []map[string]interface{}) []map[string]interface{} {
-	householdMap := make(map[int]map[string]interface{})
+func (s *HouseholdsSync) extractUniqueHouseholds(personsData []map[string]any) []map[string]any {
+	householdMap := make(map[int]map[string]any)
 
 	for _, person := range personsData {
 		// Get Households object from person
-		householdsObj, ok := person["Households"].(map[string]interface{})
+		householdsObj, ok := person["Households"].(map[string]any)
 		if !ok {
 			continue
 		}
@@ -211,7 +211,7 @@ func (s *HouseholdsSync) extractUniqueHouseholds(personsData []map[string]interf
 		// Extract households from all three possible locations
 		householdTypes := []string{"PrincipalHousehold", "PrimaryChildhoodHousehold", "AlternateChildhoodHousehold"}
 		for _, hType := range householdTypes {
-			if household, ok := householdsObj[hType].(map[string]interface{}); ok {
+			if household, ok := householdsObj[hType].(map[string]any); ok {
 				if id, idOK := household["ID"].(float64); idOK && id > 0 {
 					// Store household, deduplicating by ID
 					householdMap[int(id)] = household
@@ -221,7 +221,7 @@ func (s *HouseholdsSync) extractUniqueHouseholds(personsData []map[string]interf
 	}
 
 	// Convert map to slice
-	result := make([]map[string]interface{}, 0, len(householdMap))
+	result := make([]map[string]any, 0, len(householdMap))
 	for _, household := range householdMap {
 		result = append(result, household)
 	}
@@ -231,10 +231,10 @@ func (s *HouseholdsSync) extractUniqueHouseholds(personsData []map[string]interf
 
 // transformHouseholdToPB transforms CampMinder household data to PocketBase format
 func (s *HouseholdsSync) transformHouseholdToPB(
-	data map[string]interface{},
+	data map[string]any,
 	year int,
-) (map[string]interface{}, error) {
-	pbData := make(map[string]interface{})
+) (map[string]any, error) {
+	pbData := make(map[string]any)
 
 	// Extract ID (required)
 	idFloat, ok := data["ID"].(float64)
@@ -283,7 +283,7 @@ func (s *HouseholdsSync) transformHouseholdToPB(
 	pbData["billing_postal_code"] = ""
 	pbData["billing_country"] = ""
 
-	if billing, ok := data["BillingAddress"].(map[string]interface{}); ok {
+	if billing, ok := data["BillingAddress"].(map[string]any); ok {
 		hasAddressData := false
 
 		if addr1 := s.getString(billing, "Address1", ""); addr1 != "" {
@@ -340,7 +340,7 @@ func (s *HouseholdsSync) transformHouseholdToPB(
 }
 
 // getString extracts a string value from a map with a default fallback
-func (s *HouseholdsSync) getString(data map[string]interface{}, key, defaultValue string) string {
+func (s *HouseholdsSync) getString(data map[string]any, key, defaultValue string) string {
 	if val, ok := data[key].(string); ok {
 		return val
 	}

--- a/pocketbase/sync/households_test.go
+++ b/pocketbase/sync/households_test.go
@@ -20,7 +20,7 @@ func TestTransformHouseholdToPB(t *testing.T) {
 	s := &HouseholdsSync{}
 
 	// Mock CampMinder API response (based on HouseholdDetails schema in persons.yaml)
-	householdData := map[string]interface{}{
+	householdData := map[string]any{
 		"ID":                    float64(123456),
 		"ClientID":              float64(754),
 		"Greeting":              "Hunter and Ashley",
@@ -29,7 +29,7 @@ func TestTransformHouseholdToPB(t *testing.T) {
 		"BillingMailingTitle":   "Mr. and Mrs Hunter Doe",
 		"HouseholdPhone":        "212-523-5555",
 		"LastUpdatedUTC":        "2025-01-15T10:30:00.000Z",
-		"BillingAddress": map[string]interface{}{
+		"BillingAddress": map[string]any{
 			"Address1":      "123 Main St",
 			"Address2":      "Apt 4B",
 			"City":          "Boulder",
@@ -89,7 +89,7 @@ func TestTransformHouseholdHandlesMissingFields(t *testing.T) {
 	s := &HouseholdsSync{}
 
 	// Minimal data with only required fields
-	householdData := map[string]interface{}{
+	householdData := map[string]any{
 		"ID": float64(123456),
 	}
 
@@ -125,7 +125,7 @@ func TestTransformHouseholdRequiredIDError(t *testing.T) {
 	s := &HouseholdsSync{}
 
 	// Missing ID field
-	householdData := map[string]interface{}{
+	householdData := map[string]any{
 		"Greeting": "Hunter and Ashley",
 	}
 
@@ -140,7 +140,7 @@ func TestTransformHouseholdZeroIDError(t *testing.T) {
 	s := &HouseholdsSync{}
 
 	// ID=0 (invalid)
-	householdData := map[string]interface{}{
+	householdData := map[string]any{
 		"ID": float64(0),
 	}
 
@@ -155,15 +155,15 @@ func TestExtractHouseholdsFromPersons(t *testing.T) {
 	s := &HouseholdsSync{}
 
 	// Mock persons data with households
-	personsData := []map[string]interface{}{
+	personsData := []map[string]any{
 		{
 			"ID": float64(1001),
-			"Households": map[string]interface{}{
-				"PrincipalHousehold": map[string]interface{}{
+			"Households": map[string]any{
+				"PrincipalHousehold": map[string]any{
 					"ID":       float64(100),
 					"Greeting": "The Johnson Family",
 				},
-				"PrimaryChildhoodHousehold": map[string]interface{}{
+				"PrimaryChildhoodHousehold": map[string]any{
 					"ID":       float64(100), // Same as principal
 					"Greeting": "The Johnson Family",
 				},
@@ -171,8 +171,8 @@ func TestExtractHouseholdsFromPersons(t *testing.T) {
 		},
 		{
 			"ID": float64(1002),
-			"Households": map[string]interface{}{
-				"PrincipalHousehold": map[string]interface{}{
+			"Households": map[string]any{
+				"PrincipalHousehold": map[string]any{
 					"ID":       float64(200),
 					"Greeting": "The Garcia Family",
 				},
@@ -180,8 +180,8 @@ func TestExtractHouseholdsFromPersons(t *testing.T) {
 		},
 		{
 			"ID": float64(1003),
-			"Households": map[string]interface{}{
-				"PrincipalHousehold": map[string]interface{}{
+			"Households": map[string]any{
+				"PrincipalHousehold": map[string]any{
 					"ID":       float64(100), // Duplicate - same as person 1001
 					"Greeting": "The Johnson Family",
 				},
@@ -219,9 +219,9 @@ func TestExtractHouseholdsFromPersons(t *testing.T) {
 func TestTransformHouseholdToPB_BillingAddressFields(t *testing.T) {
 	s := &HouseholdsSync{}
 
-	householdData := map[string]interface{}{
+	householdData := map[string]any{
 		"ID": float64(123456),
-		"BillingAddress": map[string]interface{}{
+		"BillingAddress": map[string]any{
 			"Address1":      "123 Main St",
 			"Address2":      "Apt 4B",
 			"City":          "Boulder",
@@ -263,9 +263,9 @@ func TestTransformHouseholdToPB_BillingAddressFields(t *testing.T) {
 func TestTransformHouseholdToPB_BillingAddressFields_StateFieldFallback(t *testing.T) {
 	s := &HouseholdsSync{}
 
-	householdData := map[string]interface{}{
+	householdData := map[string]any{
 		"ID": float64(123456),
-		"BillingAddress": map[string]interface{}{
+		"BillingAddress": map[string]any{
 			"Address1":   "456 Oak St",
 			"City":       "Austin",
 			"State":      "TX", // Using State instead of StateProvince
@@ -290,9 +290,9 @@ func TestTransformHouseholdToPB_BillingAddressFields_StateFieldFallback(t *testi
 func TestTransformHouseholdToPB_BillingAddressFields_ZipFieldFallback(t *testing.T) {
 	s := &HouseholdsSync{}
 
-	householdData := map[string]interface{}{
+	householdData := map[string]any{
 		"ID": float64(123456),
-		"BillingAddress": map[string]interface{}{
+		"BillingAddress": map[string]any{
 			"Address1": "789 Pine Ave",
 			"City":     "Seattle",
 			"State":    "WA",
@@ -317,7 +317,7 @@ func TestTransformHouseholdToPB_BillingAddressFields_ZipFieldFallback(t *testing
 func TestTransformHouseholdToPB_BillingAddressFields_MissingAddress(t *testing.T) {
 	s := &HouseholdsSync{}
 
-	householdData := map[string]interface{}{
+	householdData := map[string]any{
 		"ID": float64(123456),
 		// No BillingAddress
 	}
@@ -345,9 +345,9 @@ func TestTransformHouseholdToPB_BillingAddressFields_MissingAddress(t *testing.T
 func TestTransformHouseholdToPB_BillingAddressFields_CountryDefault(t *testing.T) {
 	s := &HouseholdsSync{}
 
-	householdData := map[string]interface{}{
+	householdData := map[string]any{
 		"ID": float64(123456),
-		"BillingAddress": map[string]interface{}{
+		"BillingAddress": map[string]any{
 			"Address1": "123 Main St",
 			"City":     "Chicago",
 			"State":    "IL",

--- a/pocketbase/sync/multi_workbook_export.go
+++ b/pocketbase/sync/multi_workbook_export.go
@@ -374,7 +374,7 @@ func (m *MultiWorkbookExport) SyncForYears(
 }
 
 // queryCollection queries records from a PocketBase collection.
-func (m *MultiWorkbookExport) queryCollection(collection, filter string, limit int) ([]map[string]interface{}, error) {
+func (m *MultiWorkbookExport) queryCollection(collection, filter string, limit int) ([]map[string]any, error) {
 	records, err := m.App.FindRecordsByFilter(
 		collection,
 		filter,
@@ -387,9 +387,9 @@ func (m *MultiWorkbookExport) queryCollection(collection, filter string, limit i
 	}
 
 	// Convert to map format for generic processing
-	result := make([]map[string]interface{}, len(records))
+	result := make([]map[string]any, len(records))
 	for i, r := range records {
-		data := make(map[string]interface{})
+		data := make(map[string]any)
 		data["id"] = r.Id
 		for _, field := range r.Collection().Fields {
 			data[field.GetName()] = r.Get(field.GetName())

--- a/pocketbase/sync/multi_workbook_export_test.go
+++ b/pocketbase/sync/multi_workbook_export_test.go
@@ -286,7 +286,7 @@ func TestMultiWorkbookExport_GlobalsToGlobalsWorkbook(t *testing.T) {
 	}
 
 	// Write to a global sheet
-	data := [][]interface{}{{"Header1", "Header2"}, {"Value1", "Value2"}}
+	data := [][]any{{"Header1", "Header2"}, {"Value1", "Value2"}}
 	err = mockWriter.WriteToSheet(ctx, globalsID, "Tag Definitions", data)
 	if err != nil {
 		t.Fatalf("WriteToSheet() error = %v", err)
@@ -318,7 +318,7 @@ func TestMultiWorkbookExport_YearDataToYearWorkbook(t *testing.T) {
 	}
 
 	// Write to a year sheet (with readable name, no year prefix)
-	data := [][]interface{}{{"ID", "Name"}, {1, "Test Camper"}}
+	data := [][]any{{"ID", "Name"}, {1, "Test Camper"}}
 	err = mockWriter.WriteToSheet(ctx, yearID, "Attendees", data)
 	if err != nil {
 		t.Fatalf("WriteToSheet() error = %v", err)

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -205,15 +205,15 @@ type Status struct {
 
 // QueuedSync represents a sync request waiting in the queue
 type QueuedSync struct {
-	ID                  string                 `json:"id"`
-	Year                int                    `json:"year"`
-	Type                string                 `json:"type"`    // "unified", "phase", "individual"
-	Service             string                 `json:"service"` // unified: "all"; phase: phase name; individual: job name
-	IncludeCustomValues bool                   `json:"include_custom_values"`
-	Debug               bool                   `json:"debug"`
-	Options             map[string]interface{} `json:"options,omitempty"`
-	QueuedAt            time.Time              `json:"queued_at"`
-	RequestedBy         string                 `json:"requested_by"`
+	ID                  string         `json:"id"`
+	Year                int            `json:"year"`
+	Type                string         `json:"type"`    // "unified", "phase", "individual"
+	Service             string         `json:"service"` // unified: "all"; phase: phase name; individual: job name
+	IncludeCustomValues bool           `json:"include_custom_values"`
+	Debug               bool           `json:"debug"`
+	Options             map[string]any `json:"options,omitempty"`
+	QueuedAt            time.Time      `json:"queued_at"`
+	RequestedBy         string         `json:"requested_by"`
 }
 
 // MaxQueueSize is the maximum number of syncs that can be queued (0 = unlimited)
@@ -1503,7 +1503,7 @@ func (o *Orchestrator) EnqueuePhaseSync(year int, phase Phase, debug bool, reque
 // EnqueueIndividualSync adds an individual job sync request to the queue.
 // If a sync with the same year+job is already queued, returns the existing item.
 func (o *Orchestrator) EnqueueIndividualSync(
-	year int, jobID string, options map[string]interface{}, debug bool, requestedBy string,
+	year int, jobID string, options map[string]any, debug bool, requestedBy string,
 ) (*QueuedSync, error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()

--- a/pocketbase/sync/person_custom_field_values.go
+++ b/pocketbase/sync/person_custom_field_values.go
@@ -278,7 +278,7 @@ func (s *PersonCustomFieldValuesSync) syncPersonCustomFieldValues(
 		}
 
 		// Fetch page of custom field values with rate limiting and retry
-		var values []map[string]interface{}
+		var values []map[string]any
 		var hasMore bool
 
 		err := s.rateLimiter.ExecuteWithRetry(ctx, func() error {
@@ -435,12 +435,12 @@ func (s *PersonCustomFieldValuesSync) deleteOrphans(year int) error {
 // transformPersonCustomFieldValueToPB transforms CampMinder custom field value data to PocketBase format
 // Schema: person, field_definition, value, year, last_updated (optional)
 func (s *PersonCustomFieldValuesSync) transformPersonCustomFieldValueToPB(
-	data map[string]interface{},
+	data map[string]any,
 	personPBId string,
 	fieldDefPBId string,
 	year int,
-) map[string]interface{} {
-	pbData := make(map[string]interface{})
+) map[string]any {
+	pbData := make(map[string]any)
 
 	// Set relations
 	pbData["person"] = personPBId

--- a/pocketbase/sync/person_custom_field_values_test.go
+++ b/pocketbase/sync/person_custom_field_values_test.go
@@ -25,7 +25,7 @@ func TestTransformPersonCustomFieldValueToPB(t *testing.T) {
 	s := &PersonCustomFieldValuesSync{}
 
 	// Mock CampMinder API response for a custom field value
-	data := map[string]interface{}{
+	data := map[string]any{
 		"id":    float64(100), // Custom field definition ID (used by caller to resolve PB ID)
 		"value": "Vegetarian",
 	}
@@ -71,7 +71,7 @@ func TestTransformPersonCustomFieldValueEmptyValue(t *testing.T) {
 	s := &PersonCustomFieldValuesSync{}
 
 	// Empty value is valid (field might be cleared)
-	data := map[string]interface{}{
+	data := map[string]any{
 		"id":    float64(100),
 		"value": "",
 	}
@@ -88,7 +88,7 @@ func TestTransformPersonCustomFieldValueNilValue(t *testing.T) {
 	s := &PersonCustomFieldValuesSync{}
 
 	// Nil value (field has no value set)
-	data := map[string]interface{}{
+	data := map[string]any{
 		"id": float64(100),
 		// Value is missing/nil
 	}

--- a/pocketbase/sync/person_tag_definitions.go
+++ b/pocketbase/sync/person_tag_definitions.go
@@ -36,7 +36,7 @@ func (s *PersonTagDefinitionsSync) Sync(ctx context.Context) error {
 	// Pre-load all existing records (no year filter - definitions are global)
 	// Note: TagDef uses Name as identifier (no CM ID), so we key by name
 	// Use PreloadRecordsGlobal since this table has no year field
-	existingRecords, err := s.PreloadRecordsGlobal("person_tag_defs", "", func(record *core.Record) (interface{}, bool) {
+	existingRecords, err := s.PreloadRecordsGlobal("person_tag_defs", "", func(record *core.Record) (any, bool) {
 		if name, ok := record.Get("name").(string); ok && name != "" {
 			return name, true
 		}
@@ -134,9 +134,9 @@ func (s *PersonTagDefinitionsSync) Sync(ctx context.Context) error {
 
 // transformPersonTagDefinitionToPB transforms CampMinder tag definition data to PocketBase format
 func (s *PersonTagDefinitionsSync) transformPersonTagDefinitionToPB(
-	data map[string]interface{},
-) (map[string]interface{}, error) {
-	pbData := make(map[string]interface{})
+	data map[string]any,
+) (map[string]any, error) {
+	pbData := make(map[string]any)
 
 	// Extract name (required - this is the identifier)
 	name, ok := data["Name"].(string)

--- a/pocketbase/sync/person_tag_definitions_test.go
+++ b/pocketbase/sync/person_tag_definitions_test.go
@@ -21,7 +21,7 @@ func TestTransformPersonTagDefinitionToPB(t *testing.T) {
 
 	// Mock CampMinder API response (based on TagDef schema in persons.yaml)
 	// Note: TagDef does NOT have an ID field - Name is the identifier
-	tagData := map[string]interface{}{
+	tagData := map[string]any{
 		"Name":           "Alumni",
 		"IsSeasonal":     true,
 		"IsHidden":       false,
@@ -57,7 +57,7 @@ func TestTransformPersonTagDefinitionHandlesMissingFields(t *testing.T) {
 	s := &PersonTagDefinitionsSync{}
 
 	// Minimal data with only required fields
-	tagData := map[string]interface{}{
+	tagData := map[string]any{
 		"Name": "Volunteer",
 	}
 
@@ -85,7 +85,7 @@ func TestTransformPersonTagDefinitionRequiredNameError(t *testing.T) {
 	s := &PersonTagDefinitionsSync{}
 
 	// Missing Name field
-	tagData := map[string]interface{}{
+	tagData := map[string]any{
 		"IsSeasonal": true,
 	}
 
@@ -100,7 +100,7 @@ func TestTransformPersonTagDefinitionEmptyNameError(t *testing.T) {
 	s := &PersonTagDefinitionsSync{}
 
 	// Empty Name field
-	tagData := map[string]interface{}{
+	tagData := map[string]any{
 		"Name": "",
 	}
 

--- a/pocketbase/sync/persons.go
+++ b/pocketbase/sync/persons.go
@@ -414,7 +414,7 @@ func (s *PersonsSync) logSyncResults(householdStats Stats) {
 
 // processPerson processes a single person using pre-loaded existing persons
 func (s *PersonsSync) processPerson(
-	personData map[string]interface{},
+	personData map[string]any,
 	isCamper bool,
 	existingPersons map[int]*core.Record,
 	tagDefsByName map[string]string,
@@ -533,12 +533,12 @@ func (s *PersonsSync) processPerson(
 //
 //nolint:gocyclo // data transform function with many field mappings
 func (s *PersonsSync) transformPersonToPB(
-	cmPerson map[string]interface{},
+	cmPerson map[string]any,
 	year int,
 	isCamper bool,
-) (map[string]interface{}, error) {
+) (map[string]any, error) {
 	// Skip if no CamperDetails (means they're not a camper)
-	camperDetails, ok := cmPerson["CamperDetails"].(map[string]interface{})
+	camperDetails, ok := cmPerson["CamperDetails"].(map[string]any)
 	if !ok || camperDetails == nil {
 		name := s.getPersonName(cmPerson)
 		slog.Debug("Skipping person - no CamperDetails (not a camper)",
@@ -549,7 +549,7 @@ func (s *PersonsSync) transformPersonToPB(
 		return nil, nil
 	}
 
-	pbData := make(map[string]interface{})
+	pbData := make(map[string]any)
 
 	// Extract base fields
 	if id, ok := cmPerson["ID"].(float64); ok {
@@ -557,7 +557,7 @@ func (s *PersonsSync) transformPersonToPB(
 	}
 
 	// Name fields - fix ALL CAPS names from CampMinder while preserving mixed-case
-	if nameData, ok := cmPerson["Name"].(map[string]interface{}); ok {
+	if nameData, ok := cmPerson["Name"].(map[string]any); ok {
 		firstName := s.getString(nameData, "First", fmt.Sprintf("MISSING_FIRST_%.0f", cmPerson["ID"]))
 		lastName := s.getString(nameData, "Last", fmt.Sprintf("MISSING_LAST_%.0f", cmPerson["ID"]))
 
@@ -652,10 +652,10 @@ func (s *PersonsSync) transformPersonToPB(
 	// phone_numbers and email_addresses JSON fields removed (unused in application)
 	pbData["primary_email"] = ""
 	pbData["secondary_email"] = ""
-	if contactDetails, ok := cmPerson["ContactDetails"].(map[string]interface{}); ok {
+	if contactDetails, ok := cmPerson["ContactDetails"].(map[string]any); ok {
 		if emails := contactDetails["Emails"]; emails != nil {
 			// Extract primary and secondary emails to discrete fields
-			if emailList, ok := emails.([]interface{}); ok && len(emailList) > 0 {
+			if emailList, ok := emails.([]any); ok && len(emailList) > 0 {
 				primaryEmail, secondaryEmail := s.extractPrimarySecondaryEmails(emailList)
 				pbData["primary_email"] = primaryEmail
 				pbData["secondary_email"] = secondaryEmail
@@ -669,10 +669,10 @@ func (s *PersonsSync) transformPersonToPB(
 	// address JSON field removed - only discrete fields are populated
 	pbData["address_city"] = ""
 	pbData["address_state"] = ""
-	if households, ok := cmPerson["Households"].(map[string]interface{}); ok {
+	if households, ok := cmPerson["Households"].(map[string]any); ok {
 		// Extract address from primary childhood household
-		if primary, ok := households["PrimaryChildhoodHousehold"].(map[string]interface{}); ok {
-			if billing, ok := primary["BillingAddress"].(map[string]interface{}); ok {
+		if primary, ok := households["PrimaryChildhoodHousehold"].(map[string]any); ok {
+			if billing, ok := primary["BillingAddress"].(map[string]any); ok {
 				// Extract discrete address fields for querying
 				if city := s.getString(billing, "City", ""); city != "" {
 					pbData["address_city"] = city
@@ -691,9 +691,9 @@ func (s *PersonsSync) transformPersonToPB(
 	}
 
 	// Extract household ID from FamilyPersons (legacy field, kept for backward compatibility)
-	if familyPersons, ok := cmPerson["FamilyPersons"].([]interface{}); ok {
+	if familyPersons, ok := cmPerson["FamilyPersons"].([]any); ok {
 		for _, fp := range familyPersons {
-			if fpMap, ok := fp.(map[string]interface{}); ok {
+			if fpMap, ok := fp.(map[string]any); ok {
 				if familyID, ok := fpMap["FamilyID"].(float64); ok && familyID > 0 {
 					pbData["household_id"] = int(familyID)
 					break
@@ -704,10 +704,10 @@ func (s *PersonsSync) transformPersonToPB(
 
 	// Extract parent/guardian names from Relatives array
 	// Used for name resolution when bunk requests reference parents' last names
-	if relatives, ok := cmPerson["Relatives"].([]interface{}); ok {
-		parents := make([]map[string]interface{}, 0)
+	if relatives, ok := cmPerson["Relatives"].([]any); ok {
+		parents := make([]map[string]any, 0)
 		for _, rel := range relatives {
-			relMap, ok := rel.(map[string]interface{})
+			relMap, ok := rel.(map[string]any)
 			if !ok {
 				continue
 			}
@@ -717,10 +717,10 @@ func (s *PersonsSync) transformPersonToPB(
 				continue
 			}
 
-			parentData := make(map[string]interface{})
+			parentData := make(map[string]any)
 
 			// Extract name
-			if nameData, ok := relMap["Name"].(map[string]interface{}); ok {
+			if nameData, ok := relMap["Name"].(map[string]any); ok {
 				firstName := s.getString(nameData, "First", "")
 				lastName := s.getString(nameData, "Last", "")
 				if firstName != "" || lastName != "" {
@@ -764,8 +764,8 @@ func (s *PersonsSync) transformPersonToPB(
 
 // Helper methods
 
-func (s *PersonsSync) getPersonName(person map[string]interface{}) string {
-	if nameData, ok := person["Name"].(map[string]interface{}); ok {
+func (s *PersonsSync) getPersonName(person map[string]any) string {
+	if nameData, ok := person["Name"].(map[string]any); ok {
 		first := s.getString(nameData, "First", "")
 		last := s.getString(nameData, "Last", "")
 		return fmt.Sprintf("%s %s", first, last)
@@ -773,21 +773,21 @@ func (s *PersonsSync) getPersonName(person map[string]interface{}) string {
 	return "Unknown"
 }
 
-func (s *PersonsSync) getString(data map[string]interface{}, key, defaultValue string) string {
+func (s *PersonsSync) getString(data map[string]any, key, defaultValue string) string {
 	if val, ok := data[key].(string); ok {
 		return val
 	}
 	return defaultValue
 }
 
-func (s *PersonsSync) getInt(data map[string]interface{}, key string, defaultValue int) int {
+func (s *PersonsSync) getInt(data map[string]any, key string, defaultValue int) int {
 	if val, ok := data[key].(float64); ok {
 		return int(val)
 	}
 	return defaultValue
 }
 
-func (s *PersonsSync) getFloat(data map[string]interface{}, key string, defaultValue float64) float64 {
+func (s *PersonsSync) getFloat(data map[string]any, key string, defaultValue float64) float64 {
 	if val, ok := data[key].(float64); ok {
 		return val
 	}
@@ -833,7 +833,7 @@ func (s *PersonsSync) fixAllCapsName(name string) string {
 // extractPrimarySecondaryEmails extracts primary and secondary emails from CampMinder emails array.
 // Primary email is the one with IsLogin: true, or the first entry if none have IsLogin.
 // Secondary email is the first email that isn't the primary, if one exists.
-func (s *PersonsSync) extractPrimarySecondaryEmails(emailList []interface{}) (primary, secondary string) {
+func (s *PersonsSync) extractPrimarySecondaryEmails(emailList []any) (primary, secondary string) {
 	if len(emailList) == 0 {
 		return "", ""
 	}
@@ -843,7 +843,7 @@ func (s *PersonsSync) extractPrimarySecondaryEmails(emailList []interface{}) (pr
 	var otherEmails []string
 
 	for _, email := range emailList {
-		emailMap, ok := email.(map[string]interface{})
+		emailMap, ok := email.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -951,12 +951,12 @@ func (s *PersonsSync) updateAttendeeRelations(year int) error {
 }
 
 // extractUniqueHouseholds extracts unique households from persons data (combined sync)
-func (s *PersonsSync) extractUniqueHouseholds(personsData []map[string]interface{}) []map[string]interface{} {
-	householdMap := make(map[int]map[string]interface{})
+func (s *PersonsSync) extractUniqueHouseholds(personsData []map[string]any) []map[string]any {
+	householdMap := make(map[int]map[string]any)
 
 	for _, person := range personsData {
 		// Get Households object from person
-		householdsObj, ok := person["Households"].(map[string]interface{})
+		householdsObj, ok := person["Households"].(map[string]any)
 		if !ok {
 			continue
 		}
@@ -964,7 +964,7 @@ func (s *PersonsSync) extractUniqueHouseholds(personsData []map[string]interface
 		// Extract households from all three possible locations
 		householdTypes := []string{"PrincipalHousehold", "PrimaryChildhoodHousehold", "AlternateChildhoodHousehold"}
 		for _, hType := range householdTypes {
-			if household, ok := householdsObj[hType].(map[string]interface{}); ok {
+			if household, ok := householdsObj[hType].(map[string]any); ok {
 				if id, idOK := household["ID"].(float64); idOK && id > 0 {
 					// Store household, deduplicating by ID
 					householdMap[int(id)] = household
@@ -974,7 +974,7 @@ func (s *PersonsSync) extractUniqueHouseholds(personsData []map[string]interface
 	}
 
 	// Convert map to slice
-	result := make([]map[string]interface{}, 0, len(householdMap))
+	result := make([]map[string]any, 0, len(householdMap))
 	for _, household := range householdMap {
 		result = append(result, household)
 	}
@@ -984,27 +984,27 @@ func (s *PersonsSync) extractUniqueHouseholds(personsData []map[string]interface
 
 // extractHouseholdIDsFromPerson extracts the CampMinder IDs for all three household types
 // Returns a struct with the IDs (0 if not present)
-func (s *PersonsSync) extractHouseholdIDsFromPerson(personData map[string]interface{}) personHouseholdIDs {
+func (s *PersonsSync) extractHouseholdIDsFromPerson(personData map[string]any) personHouseholdIDs {
 	result := personHouseholdIDs{}
 
-	householdsObj, ok := personData["Households"].(map[string]interface{})
+	householdsObj, ok := personData["Households"].(map[string]any)
 	if !ok {
 		return result
 	}
 
-	if principal, ok := householdsObj["PrincipalHousehold"].(map[string]interface{}); ok {
+	if principal, ok := householdsObj["PrincipalHousehold"].(map[string]any); ok {
 		if id, ok := principal["ID"].(float64); ok && id > 0 {
 			result.PrincipalID = int(id)
 		}
 	}
 
-	if primary, ok := householdsObj["PrimaryChildhoodHousehold"].(map[string]interface{}); ok {
+	if primary, ok := householdsObj["PrimaryChildhoodHousehold"].(map[string]any); ok {
 		if id, ok := primary["ID"].(float64); ok && id > 0 {
 			result.PrimaryChildhoodID = int(id)
 		}
 	}
 
-	if alternate, ok := householdsObj["AlternateChildhoodHousehold"].(map[string]interface{}); ok {
+	if alternate, ok := householdsObj["AlternateChildhoodHousehold"].(map[string]any); ok {
 		if id, ok := alternate["ID"].(float64); ok && id > 0 {
 			result.AlternateChildhoodID = int(id)
 		}
@@ -1047,7 +1047,7 @@ func (s *PersonsSync) extractTagIDsWithYearFilter(
 		return nil
 	}
 
-	tagsArray, ok := tagsRaw.([]interface{})
+	tagsArray, ok := tagsRaw.([]any)
 	if !ok {
 		return nil
 	}
@@ -1060,7 +1060,7 @@ func (s *PersonsSync) extractTagIDsWithYearFilter(
 	seen := make(map[string]bool)
 	var tagIDs []string
 	for _, tagRaw := range tagsArray {
-		if tag, ok := tagRaw.(map[string]interface{}); ok {
+		if tag, ok := tagRaw.(map[string]any); ok {
 			name, nameOK := tag["Name"].(string)
 			if !nameOK || name == "" {
 				continue
@@ -1094,7 +1094,7 @@ func (s *PersonsSync) extractTagIDs(personData map[string]any, tagDefsByName map
 		return nil
 	}
 
-	tagsArray, ok := tagsRaw.([]interface{})
+	tagsArray, ok := tagsRaw.([]any)
 	if !ok {
 		return nil
 	}
@@ -1107,7 +1107,7 @@ func (s *PersonsSync) extractTagIDs(personData map[string]any, tagDefsByName map
 	seen := make(map[string]bool)
 	var tagIDs []string
 	for _, tagRaw := range tagsArray {
-		if tag, ok := tagRaw.(map[string]interface{}); ok {
+		if tag, ok := tagRaw.(map[string]any); ok {
 			if name, ok := tag["Name"].(string); ok && name != "" {
 				if tagID, exists := tagDefsByName[name]; exists {
 					if !seen[tagID] {
@@ -1123,8 +1123,8 @@ func (s *PersonsSync) extractTagIDs(personData map[string]any, tagDefsByName map
 }
 
 // transformHouseholdToPB transforms CampMinder household data to PocketBase format (combined sync)
-func (s *PersonsSync) transformHouseholdToPB(data map[string]interface{}, year int) (map[string]interface{}, error) {
-	pbData := make(map[string]interface{})
+func (s *PersonsSync) transformHouseholdToPB(data map[string]any, year int) (map[string]any, error) {
+	pbData := make(map[string]any)
 
 	// Extract ID (required)
 	idFloat, ok := data["ID"].(float64)
@@ -1173,7 +1173,7 @@ func (s *PersonsSync) transformHouseholdToPB(data map[string]interface{}, year i
 	pbData["billing_postal_code"] = ""
 	pbData["billing_country"] = ""
 
-	if billing, ok := data["BillingAddress"].(map[string]interface{}); ok {
+	if billing, ok := data["BillingAddress"].(map[string]any); ok {
 		hasAddressData := false
 
 		if addr1 := s.getString(billing, "Address1", ""); addr1 != "" {
@@ -1415,7 +1415,7 @@ func (s *PersonsSync) getPersonIDsFromStaff() ([]int, error) {
 	slog.Debug("Fetching staff person IDs from CampMinder")
 
 	pageSize := 500
-	var allStaffRecords []map[string]interface{}
+	var allStaffRecords []map[string]any
 
 	// Fetch staff across all statuses (active, resigned, dismissed, cancelled)
 	for _, status := range allStaffStatuses {
@@ -1443,7 +1443,7 @@ func (s *PersonsSync) getPersonIDsFromStaff() ([]int, error) {
 
 // extractPersonIDsFromStaffRecords extracts unique person IDs from staff API records
 // Handles deduplication and skips invalid/missing person IDs
-func (s *PersonsSync) extractPersonIDsFromStaffRecords(staffRecords []map[string]interface{}) []int {
+func (s *PersonsSync) extractPersonIDsFromStaffRecords(staffRecords []map[string]any) []int {
 	if len(staffRecords) == 0 {
 		return []int{}
 	}

--- a/pocketbase/sync/persons_test.go
+++ b/pocketbase/sync/persons_test.go
@@ -26,17 +26,17 @@ func TestTransformPersonToPB_CamperDetailsExpanded(t *testing.T) {
 
 	// Mock CampMinder API response with full CamperDetails
 	// Note: We don't set Age to avoid needing a Client for age calculation
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID":          float64(12345),
 		"DateOfBirth": "2010-03-15",
 		"GenderID":    float64(0), // Female
 		// No "Age" field - triggers default age behavior without needing client
-		"Name": map[string]interface{}{
+		"Name": map[string]any{
 			"First":     testFirstName,
 			"Last":      "Johnson",
 			"Preferred": "Emmy",
 		},
-		"CamperDetails": map[string]interface{}{
+		"CamperDetails": map[string]any{
 			"PartitionID":      float64(2),   // Grade grouping
 			"DivisionID":       float64(5),   // Division assignment
 			"LeadDate":         "2020-01-15", // Lead/inquiry date
@@ -49,8 +49,8 @@ func TestTransformPersonToPB_CamperDetailsExpanded(t *testing.T) {
 			"YearsAtCamp":      float64(3),
 			"LastYearAttended": float64(2024),
 		},
-		"FamilyPersons": []interface{}{
-			map[string]interface{}{
+		"FamilyPersons": []any{
+			map[string]any{
 				"FamilyID": float64(99999),
 			},
 		},
@@ -97,16 +97,16 @@ func TestTransformPersonToPB_MissingCamperDetailsFields(t *testing.T) {
 
 	// Minimal CamperDetails without optional fields
 	// Note: We don't set Age to avoid needing a Client for age calculation
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID":          float64(12345),
 		"DateOfBirth": "2010-03-15",
 		"GenderID":    float64(1), // Male
 		// No "Age" field - triggers default age behavior without needing client
-		"Name": map[string]interface{}{
+		"Name": map[string]any{
 			"First": "Liam",
 			"Last":  "Garcia",
 		},
-		"CamperDetails": map[string]interface{}{
+		"CamperDetails": map[string]any{
 			"CampGradeID": float64(6),
 		},
 	}
@@ -140,21 +140,21 @@ func TestExtractHouseholdsFromPersonData(t *testing.T) {
 	}
 
 	// Mock person data with households
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID": float64(12345),
-		"Households": map[string]interface{}{
-			"PrincipalHousehold": map[string]interface{}{
+		"Households": map[string]any{
+			"PrincipalHousehold": map[string]any{
 				"ID":       float64(100),
 				"Greeting": "The Johnson Family",
 			},
-			"PrimaryChildhoodHousehold": map[string]interface{}{
+			"PrimaryChildhoodHousehold": map[string]any{
 				"ID":       float64(100), // Same household
 				"Greeting": "The Johnson Family",
 			},
 		},
 	}
 
-	households := s.extractUniqueHouseholds([]map[string]interface{}{personData})
+	households := s.extractUniqueHouseholds([]map[string]any{personData})
 
 	if len(households) != 1 {
 		t.Errorf("expected 1 unique household, got %d", len(households))
@@ -173,11 +173,11 @@ func TestExtractHouseholdsFromPersonData_NoHouseholds(t *testing.T) {
 	}
 
 	// Person without Households
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID": float64(12345),
 	}
 
-	households := s.extractUniqueHouseholds([]map[string]interface{}{personData})
+	households := s.extractUniqueHouseholds([]map[string]any{personData})
 
 	if len(households) != 0 {
 		t.Errorf("expected 0 households for person without Households, got %d", len(households))
@@ -190,7 +190,7 @@ func TestPersonsSync_TransformHouseholdToPB(t *testing.T) {
 		missingDataStats: make(map[string]int),
 	}
 
-	householdData := map[string]interface{}{
+	householdData := map[string]any{
 		"ID":                    float64(123456),
 		"Greeting":              "Hunter and Ashley",
 		"MailingTitle":          "Mr. and Mrs Hunter Doe",
@@ -198,7 +198,7 @@ func TestPersonsSync_TransformHouseholdToPB(t *testing.T) {
 		"BillingMailingTitle":   "Mr. and Mrs Hunter Doe",
 		"HouseholdPhone":        "212-523-5555",
 		"LastUpdatedUTC":        "2025-01-15T10:30:00.000Z",
-		"BillingAddress": map[string]interface{}{
+		"BillingAddress": map[string]any{
 			"Address1": "123 Main St",
 			"City":     "Boulder",
 		},
@@ -268,18 +268,18 @@ func TestPersonsCompareFields(t *testing.T) {
 func TestExtractHouseholdIDsFromPerson(t *testing.T) {
 	s := &PersonsSync{}
 
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID": float64(12345),
-		"Households": map[string]interface{}{
-			"PrincipalHousehold": map[string]interface{}{
+		"Households": map[string]any{
+			"PrincipalHousehold": map[string]any{
 				"ID":       float64(100),
 				"Greeting": "The Smiths",
 			},
-			"PrimaryChildhoodHousehold": map[string]interface{}{
+			"PrimaryChildhoodHousehold": map[string]any{
 				"ID":       float64(200),
 				"Greeting": "Primary Home",
 			},
-			"AlternateChildhoodHousehold": map[string]interface{}{
+			"AlternateChildhoodHousehold": map[string]any{
 				"ID":       float64(300),
 				"Greeting": "Alternate Home",
 			},
@@ -304,10 +304,10 @@ func TestExtractHouseholdIDsFromPerson_Partial(t *testing.T) {
 	s := &PersonsSync{}
 
 	// Child with only primary childhood household
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID": float64(12345),
-		"Households": map[string]interface{}{
-			"PrimaryChildhoodHousehold": map[string]interface{}{
+		"Households": map[string]any{
+			"PrimaryChildhoodHousehold": map[string]any{
 				"ID":       float64(200),
 				"Greeting": "Primary Home",
 			},
@@ -494,14 +494,14 @@ func TestExtractTagIDs(t *testing.T) {
 		"Sibling":    "rec_sibling_003",
 	}
 
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID": float64(12345),
-		"Tags": []interface{}{
-			map[string]interface{}{
+		"Tags": []any{
+			map[string]any{
 				"Name":           "Alumni",
 				"LastUpdatedUTC": "2025-01-15T10:30:00.000Z",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Name":           "Leadership",
 				"LastUpdatedUTC": "2025-01-16T11:00:00.000Z",
 			},
@@ -542,7 +542,7 @@ func TestExtractTagIDs_NoTags(t *testing.T) {
 		"Alumni": testAlumniTagID,
 	}
 
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID": float64(12345),
 	}
 
@@ -561,9 +561,9 @@ func TestExtractTagIDs_EmptyTags(t *testing.T) {
 		"Alumni": testAlumniTagID,
 	}
 
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID":   float64(12345),
-		"Tags": []interface{}{},
+		"Tags": []any{},
 	}
 
 	tagIDs := s.extractTagIDs(personData, tagDefsByName)
@@ -581,7 +581,7 @@ func TestExtractTagIDs_NilTags(t *testing.T) {
 		"Alumni": testAlumniTagID,
 	}
 
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID":   float64(12345),
 		"Tags": nil,
 	}
@@ -601,13 +601,13 @@ func TestExtractTagIDs_UnknownTag(t *testing.T) {
 		"Alumni": testAlumniTagID,
 	}
 
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID": float64(12345),
-		"Tags": []interface{}{
-			map[string]interface{}{
+		"Tags": []any{
+			map[string]any{
 				"Name": "UnknownTag", // Not in tag definitions
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Name": "Alumni", // In tag definitions
 			},
 		},
@@ -632,13 +632,13 @@ func TestExtractTagIDs_EmptyTagName(t *testing.T) {
 		"Alumni": testAlumniTagID,
 	}
 
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID": float64(12345),
-		"Tags": []interface{}{
-			map[string]interface{}{
+		"Tags": []any{
+			map[string]any{
 				"Name": "", // Empty name
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Name": "Alumni",
 			},
 		},
@@ -663,7 +663,7 @@ func TestExtractTagIDs_EmptyTagName(t *testing.T) {
 func TestExtractPersonIDsFromStaffRecords(t *testing.T) {
 	s := &PersonsSync{}
 
-	staffRecords := []map[string]interface{}{
+	staffRecords := []map[string]any{
 		{"PersonID": float64(1001), "StatusID": float64(1), "Position1ID": float64(10)},
 		{"PersonID": float64(1002), "StatusID": float64(1), "Position1ID": float64(20)},
 		{"PersonID": float64(1003), "StatusID": float64(2), "Position1ID": float64(30)},
@@ -693,7 +693,7 @@ func TestExtractPersonIDsFromStaffRecords(t *testing.T) {
 func TestExtractPersonIDsFromStaffRecords_SkipsInvalidIDs(t *testing.T) {
 	s := &PersonsSync{}
 
-	staffRecords := []map[string]interface{}{
+	staffRecords := []map[string]any{
 		{"PersonID": float64(1001), "StatusID": float64(1)},
 		{"PersonID": float64(0), "StatusID": float64(1)},     // Invalid: zero ID
 		{"PersonID": float64(-5), "StatusID": float64(1)},    // Invalid: negative ID
@@ -728,7 +728,7 @@ func TestExtractPersonIDsFromStaffRecords_EmptyInput(t *testing.T) {
 		t.Errorf("expected 0 person IDs for nil input, got %d", len(personIDs))
 	}
 
-	personIDs = s.extractPersonIDsFromStaffRecords([]map[string]interface{}{})
+	personIDs = s.extractPersonIDsFromStaffRecords([]map[string]any{})
 	if len(personIDs) != 0 {
 		t.Errorf("expected 0 person IDs for empty input, got %d", len(personIDs))
 	}
@@ -739,7 +739,7 @@ func TestExtractPersonIDsFromStaffRecords_Deduplicates(t *testing.T) {
 	s := &PersonsSync{}
 
 	// Staff member appears in multiple records (e.g., different status pages)
-	staffRecords := []map[string]interface{}{
+	staffRecords := []map[string]any{
 		{"PersonID": float64(1001), "StatusID": float64(1)},
 		{"PersonID": float64(1001), "StatusID": float64(2)}, // Duplicate
 		{"PersonID": float64(1002), "StatusID": float64(1)},
@@ -922,13 +922,13 @@ func TestExtractTagIDs_FiltersFutureTags(t *testing.T) {
 		"Leadership":              "rec_leadership_002",
 	}
 
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID": float64(12345),
-		"Tags": []interface{}{
-			map[string]interface{}{"Name": "Alumni"},
-			map[string]interface{}{"Name": "2025 Registration"},
-			map[string]interface{}{"Name": "2026 Early Registration"}, // Should be filtered
-			map[string]interface{}{"Name": "Leadership"},
+		"Tags": []any{
+			map[string]any{"Name": "Alumni"},
+			map[string]any{"Name": "2025 Registration"},
+			map[string]any{"Name": "2026 Early Registration"}, // Should be filtered
+			map[string]any{"Name": "Leadership"},
 		},
 	}
 
@@ -974,15 +974,15 @@ func TestTransformPersonToPB_CMLeadDateExtracted(t *testing.T) {
 		missingDataStats: make(map[string]int),
 	}
 
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID":          float64(12345),
 		"DateOfBirth": "2010-03-15",
 		"GenderID":    float64(0),
-		"Name": map[string]interface{}{
+		"Name": map[string]any{
 			"First": testFirstName,
 			"Last":  "Johnson",
 		},
-		"CamperDetails": map[string]interface{}{
+		"CamperDetails": map[string]any{
 			"YearsAtCamp":      float64(5),
 			"LastYearAttended": float64(2024),
 			"LeadDate":         "2019-02-15",
@@ -1020,15 +1020,15 @@ func TestTransformPersonToPB_CMLeadDateMissing(t *testing.T) {
 		missingDataStats: make(map[string]int),
 	}
 
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID":          float64(12345),
 		"DateOfBirth": "2010-03-15",
 		"GenderID":    float64(1),
-		"Name": map[string]interface{}{
+		"Name": map[string]any{
 			"First": "Liam",
 			"Last":  "Garcia",
 		},
-		"CamperDetails": map[string]interface{}{
+		"CamperDetails": map[string]any{
 			"CampGradeID": float64(6), // Only grade, no cm_lead_date
 		},
 	}
@@ -1074,10 +1074,10 @@ func TestUpdatePersonHouseholdRelations_UsesHouseholdID(t *testing.T) {
 	s := &PersonsSync{}
 
 	// Person with only FamilyPersons household_id, no Households object
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID": float64(12345),
-		"FamilyPersons": []interface{}{
-			map[string]interface{}{
+		"FamilyPersons": []any{
+			map[string]any{
 				"FamilyID": float64(99999), // This becomes household_id
 			},
 		},
@@ -1107,15 +1107,15 @@ func TestTransformPersonToPB_IsCamperFlag(t *testing.T) {
 		missingDataStats: make(map[string]int),
 	}
 
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID":          float64(12345),
 		"DateOfBirth": "2010-03-15",
 		"GenderID":    float64(0),
-		"Name": map[string]interface{}{
+		"Name": map[string]any{
 			"First": testFirstName,
 			"Last":  "Johnson",
 		},
-		"CamperDetails": map[string]interface{}{
+		"CamperDetails": map[string]any{
 			"CampGradeID": float64(8),
 		},
 	}
@@ -1194,21 +1194,21 @@ func TestExtractAddressCity(t *testing.T) {
 		missingDataStats: make(map[string]int),
 	}
 
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID":          float64(12345),
 		"DateOfBirth": "2010-03-15",
 		"GenderID":    float64(0),
-		"Name": map[string]interface{}{
+		"Name": map[string]any{
 			"First": testFirstName,
 			"Last":  "Johnson",
 		},
-		"CamperDetails": map[string]interface{}{
+		"CamperDetails": map[string]any{
 			"CampGradeID": float64(8),
 		},
-		"Households": map[string]interface{}{
-			"PrimaryChildhoodHousehold": map[string]interface{}{
+		"Households": map[string]any{
+			"PrimaryChildhoodHousehold": map[string]any{
 				"ID": float64(100),
-				"BillingAddress": map[string]interface{}{
+				"BillingAddress": map[string]any{
 					"Street1":       "123 Main St",
 					"City":          "San Francisco",
 					"StateProvince": "CA",
@@ -1242,21 +1242,21 @@ func TestExtractAddressCity_StateField(t *testing.T) {
 		missingDataStats: make(map[string]int),
 	}
 
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID":          float64(12345),
 		"DateOfBirth": "2010-03-15",
 		"GenderID":    float64(0),
-		"Name": map[string]interface{}{
+		"Name": map[string]any{
 			"First": testFirstName,
 			"Last":  "Johnson",
 		},
-		"CamperDetails": map[string]interface{}{
+		"CamperDetails": map[string]any{
 			"CampGradeID": float64(8),
 		},
-		"Households": map[string]interface{}{
-			"PrimaryChildhoodHousehold": map[string]interface{}{
+		"Households": map[string]any{
+			"PrimaryChildhoodHousehold": map[string]any{
 				"ID": float64(100),
-				"BillingAddress": map[string]interface{}{
+				"BillingAddress": map[string]any{
 					"City":  "Oakland",
 					"State": "California",
 				},
@@ -1288,15 +1288,15 @@ func TestExtractAddressCity_NoHouseholds(t *testing.T) {
 		missingDataStats: make(map[string]int),
 	}
 
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID":          float64(12345),
 		"DateOfBirth": "2010-03-15",
 		"GenderID":    float64(0),
-		"Name": map[string]interface{}{
+		"Name": map[string]any{
 			"First": testFirstName,
 			"Last":  "Johnson",
 		},
-		"CamperDetails": map[string]interface{}{
+		"CamperDetails": map[string]any{
 			"CampGradeID": float64(8),
 		},
 		// No Households object
@@ -1330,24 +1330,24 @@ func TestExtractPrimaryEmail(t *testing.T) {
 		missingDataStats: make(map[string]int),
 	}
 
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID":          float64(12345),
 		"DateOfBirth": "2010-03-15",
 		"GenderID":    float64(0),
-		"Name": map[string]interface{}{
+		"Name": map[string]any{
 			"First": testFirstName,
 			"Last":  "Johnson",
 		},
-		"CamperDetails": map[string]interface{}{
+		"CamperDetails": map[string]any{
 			"CampGradeID": float64(8),
 		},
-		"ContactDetails": map[string]interface{}{
-			"Emails": []interface{}{
-				map[string]interface{}{
+		"ContactDetails": map[string]any{
+			"Emails": []any{
+				map[string]any{
 					"Address": "secondary@example.com",
 					"IsLogin": false,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"Address": "primary@example.com",
 					"IsLogin": true,
 				},
@@ -1379,23 +1379,23 @@ func TestExtractPrimaryEmail_FirstEntryFallback(t *testing.T) {
 		missingDataStats: make(map[string]int),
 	}
 
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID":          float64(12345),
 		"DateOfBirth": "2010-03-15",
 		"GenderID":    float64(0),
-		"Name": map[string]interface{}{
+		"Name": map[string]any{
 			"First": testFirstName,
 			"Last":  "Johnson",
 		},
-		"CamperDetails": map[string]interface{}{
+		"CamperDetails": map[string]any{
 			"CampGradeID": float64(8),
 		},
-		"ContactDetails": map[string]interface{}{
-			"Emails": []interface{}{
-				map[string]interface{}{
+		"ContactDetails": map[string]any{
+			"Emails": []any{
+				map[string]any{
 					"Address": "first@example.com",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"Address": "second@example.com",
 				},
 			},
@@ -1426,20 +1426,20 @@ func TestExtractPrimaryEmail_SingleEmail(t *testing.T) {
 		missingDataStats: make(map[string]int),
 	}
 
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID":          float64(12345),
 		"DateOfBirth": "2010-03-15",
 		"GenderID":    float64(0),
-		"Name": map[string]interface{}{
+		"Name": map[string]any{
 			"First": testFirstName,
 			"Last":  "Johnson",
 		},
-		"CamperDetails": map[string]interface{}{
+		"CamperDetails": map[string]any{
 			"CampGradeID": float64(8),
 		},
-		"ContactDetails": map[string]interface{}{
-			"Emails": []interface{}{
-				map[string]interface{}{
+		"ContactDetails": map[string]any{
+			"Emails": []any{
+				map[string]any{
 					"Address": "only@example.com",
 				},
 			},
@@ -1470,15 +1470,15 @@ func TestExtractPrimaryEmail_NoEmails(t *testing.T) {
 		missingDataStats: make(map[string]int),
 	}
 
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID":          float64(12345),
 		"DateOfBirth": "2010-03-15",
 		"GenderID":    float64(0),
-		"Name": map[string]interface{}{
+		"Name": map[string]any{
 			"First": testFirstName,
 			"Last":  "Johnson",
 		},
-		"CamperDetails": map[string]interface{}{
+		"CamperDetails": map[string]any{
 			"CampGradeID": float64(8),
 		},
 		// No ContactDetails
@@ -1512,20 +1512,20 @@ func TestPhoneNumbersRemoved(t *testing.T) {
 		missingDataStats: make(map[string]int),
 	}
 
-	personData := map[string]interface{}{
+	personData := map[string]any{
 		"ID":          float64(12345),
 		"DateOfBirth": "2010-03-15",
 		"GenderID":    float64(0),
-		"Name": map[string]interface{}{
+		"Name": map[string]any{
 			"First": testFirstName,
 			"Last":  "Johnson",
 		},
-		"CamperDetails": map[string]interface{}{
+		"CamperDetails": map[string]any{
 			"CampGradeID": float64(8),
 		},
-		"ContactDetails": map[string]interface{}{
-			"PhoneNumbers": []interface{}{
-				map[string]interface{}{
+		"ContactDetails": map[string]any{
+			"PhoneNumbers": []any{
+				map[string]any{
 					"Number": "555-123-4567",
 					"Type":   "Mobile",
 				},

--- a/pocketbase/sync/process_requests_test.go
+++ b/pocketbase/sync/process_requests_test.go
@@ -62,7 +62,7 @@ func TestCallAPIProcessor(t *testing.T) {
 				}
 
 				// Verify request body has expected fields
-				var reqBody map[string]interface{}
+				var reqBody map[string]any
 				if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
 					t.Errorf("failed to decode request body: %v", err)
 				}
@@ -103,7 +103,7 @@ func TestCallAPIProcessor(t *testing.T) {
 // TestCallAPIProcessor_ForceField verifies the force field is serialized in the request body
 func TestCallAPIProcessor_ForceField(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var reqBody map[string]interface{}
+		var reqBody map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
 			t.Fatalf("failed to decode request body: %v", err)
 		}
@@ -140,7 +140,7 @@ func TestCallAPIProcessor_ForceField(t *testing.T) {
 // TestCallAPIProcessor_CollectTracesField verifies collect_traces is serialized in the request body
 func TestCallAPIProcessor_CollectTracesField(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var reqBody map[string]interface{}
+		var reqBody map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
 			t.Fatalf("failed to decode request body: %v", err)
 		}

--- a/pocketbase/sync/rate_limit_integration_test.go
+++ b/pocketbase/sync/rate_limit_integration_test.go
@@ -221,12 +221,12 @@ type MockCustomFieldFetcher struct {
 	callCount    int
 	failUntil    int    // Return 429 until this many calls
 	errorMessage string // Error message to return on failure
-	values       []map[string]interface{}
+	values       []map[string]any
 }
 
 func (m *MockCustomFieldFetcher) GetPersonCustomFieldValuesPage(
 	_, _, _ int,
-) (results []map[string]interface{}, hasMore bool, err error) {
+) (results []map[string]any, hasMore bool, err error) {
 	m.callCount++
 	if m.callCount <= m.failUntil {
 		if m.errorMessage != "" {
@@ -252,13 +252,13 @@ func TestSyncWithRateLimiter_Integration(t *testing.T) {
 
 	mock := &MockCustomFieldFetcher{
 		failUntil: 2, // Fail first 2 calls with 429
-		values: []map[string]interface{}{
+		values: []map[string]any{
 			{"id": float64(100), "value": "test-value"},
 		},
 	}
 
 	// Simulate the wrapped API call pattern we'll implement
-	var result []map[string]interface{}
+	var result []map[string]any
 	var hasMore bool
 
 	err := rl.ExecuteWithRetry(ctx, func() error {
@@ -300,7 +300,7 @@ func TestSyncWithRateLimiter_PersistentFailure(t *testing.T) {
 		failUntil: 100, // Always fail
 	}
 
-	var result []map[string]interface{}
+	var result []map[string]any
 	var hasMore bool
 
 	err := rl.ExecuteWithRetry(ctx, func() error {
@@ -344,12 +344,12 @@ type MockHouseholdCustomFieldFetcher struct {
 	callCount    int
 	failUntil    int
 	errorMessage string
-	values       []map[string]interface{}
+	values       []map[string]any
 }
 
 func (m *MockHouseholdCustomFieldFetcher) GetHouseholdCustomFieldValuesPage(
 	_, _, _ int,
-) (results []map[string]interface{}, hasMore bool, err error) {
+) (results []map[string]any, hasMore bool, err error) {
 	m.callCount++
 	if m.callCount <= m.failUntil {
 		if m.errorMessage != "" {
@@ -374,12 +374,12 @@ func TestHouseholdSyncWithRateLimiter_Integration(t *testing.T) {
 
 	mock := &MockHouseholdCustomFieldFetcher{
 		failUntil: 2,
-		values: []map[string]interface{}{
+		values: []map[string]any{
 			{"id": float64(200), "value": "household-value"},
 		},
 	}
 
-	var result []map[string]interface{}
+	var result []map[string]any
 	var hasMore bool
 
 	err := rl.ExecuteWithRetry(ctx, func() error {

--- a/pocketbase/sync/rate_limited_sheets_writer.go
+++ b/pocketbase/sync/rate_limited_sheets_writer.go
@@ -68,7 +68,7 @@ func NewRateLimitedSheetsWriter(inner SheetsWriter, config *SheetsRateLimitConfi
 
 // WriteToSheet delegates to inner writer with rate limiting and 429 retry.
 func (w *RateLimitedSheetsWriter) WriteToSheet(
-	ctx context.Context, spreadsheetID, sheetTab string, data [][]interface{},
+	ctx context.Context, spreadsheetID, sheetTab string, data [][]any,
 ) error {
 	return w.executeWithRetry(ctx, "WriteToSheet", []*rate.Limiter{w.writeLimiter}, func() error {
 		return w.inner.WriteToSheet(ctx, spreadsheetID, sheetTab, data)

--- a/pocketbase/sync/rate_limited_sheets_writer_test.go
+++ b/pocketbase/sync/rate_limited_sheets_writer_test.go
@@ -50,7 +50,7 @@ func newTrackingMock() *trackingMock {
 	}
 }
 
-func (t *trackingMock) WriteToSheet(ctx context.Context, spreadsheetID, sheetTab string, data [][]interface{}) error {
+func (t *trackingMock) WriteToSheet(ctx context.Context, spreadsheetID, sheetTab string, data [][]any) error {
 	t.writeCalls.Add(1)
 	if t.writeErrFn != nil {
 		if err := t.writeErrFn(); err != nil {
@@ -155,7 +155,7 @@ func TestRateLimitedWriter_DelegatesAllMethods(t *testing.T) {
 	ctx := context.Background()
 
 	// WriteToSheet
-	data := [][]interface{}{{"a", "b"}}
+	data := [][]any{{"a", "b"}}
 	if err := writer.WriteToSheet(ctx, "s1", "tab", data); err != nil {
 		t.Fatalf("WriteToSheet: %v", err)
 	}
@@ -229,7 +229,7 @@ func TestRateLimitedWriter_RetriesWriteOn429(t *testing.T) {
 	mock.writeErrFn = failNTimes(2) // fail twice then succeed
 	writer := NewRateLimitedSheetsWriter(mock, testConfig())
 
-	err := writer.WriteToSheet(context.Background(), "s1", "tab", [][]interface{}{{"x"}})
+	err := writer.WriteToSheet(context.Background(), "s1", "tab", [][]any{{"x"}})
 	if err != nil {
 		t.Fatalf("WriteToSheet should succeed after retries, got: %v", err)
 	}
@@ -308,7 +308,7 @@ func TestRateLimitedWriter_GivesUpAfterMaxRetries(t *testing.T) {
 	mock.writeErrFn = failNTimes(10)
 	writer := NewRateLimitedSheetsWriter(mock, testConfig())
 
-	err := writer.WriteToSheet(context.Background(), "s1", "tab", [][]interface{}{{"x"}})
+	err := writer.WriteToSheet(context.Background(), "s1", "tab", [][]any{{"x"}})
 	if err == nil {
 		t.Fatal("WriteToSheet should return error after max retries")
 		return
@@ -336,7 +336,7 @@ func TestRateLimitedWriter_DoesNotRetryNon429Errors(t *testing.T) {
 	mock.writeErrFn = func() error { return permErr }
 	writer := NewRateLimitedSheetsWriter(mock, testConfig())
 
-	err := writer.WriteToSheet(context.Background(), "s1", "tab", [][]interface{}{{"x"}})
+	err := writer.WriteToSheet(context.Background(), "s1", "tab", [][]any{{"x"}})
 	if err == nil {
 		t.Fatal("WriteToSheet should return non-429 error immediately")
 		return
@@ -358,7 +358,7 @@ func TestRateLimitedWriter_DoesNotRetryGoogleAPINon429(t *testing.T) {
 	}
 	writer := NewRateLimitedSheetsWriter(mock, testConfig())
 
-	err := writer.WriteToSheet(context.Background(), "s1", "tab", [][]interface{}{{"x"}})
+	err := writer.WriteToSheet(context.Background(), "s1", "tab", [][]any{{"x"}})
 	if err == nil {
 		t.Fatal("WriteToSheet should return 403 error immediately")
 		return
@@ -388,7 +388,7 @@ func TestRateLimitedWriter_RespectsContextCancellation(t *testing.T) {
 		cancel()
 	}()
 
-	err := writer.WriteToSheet(ctx, "s1", "tab", [][]interface{}{{"x"}})
+	err := writer.WriteToSheet(ctx, "s1", "tab", [][]any{{"x"}})
 	if err == nil {
 		t.Fatal("WriteToSheet should return error when context is canceled")
 		return
@@ -494,7 +494,7 @@ func TestRateLimitedWriter_Retries429WrappedInFmtErrorf(t *testing.T) {
 	}
 	writer := NewRateLimitedSheetsWriter(mock, testConfig())
 
-	err := writer.WriteToSheet(context.Background(), "s1", "tab", [][]interface{}{{"x"}})
+	err := writer.WriteToSheet(context.Background(), "s1", "tab", [][]any{{"x"}})
 	if err != nil {
 		t.Fatalf("WriteToSheet should succeed after retrying wrapped 429, got: %v", err)
 	}

--- a/pocketbase/sync/session_groups.go
+++ b/pocketbase/sync/session_groups.go
@@ -36,7 +36,7 @@ func (s *SessionGroupsSync) Sync(ctx context.Context) error {
 	filter := fmt.Sprintf("year = %d", year)
 
 	// Pre-load existing records for this year
-	existingRecords, err := s.PreloadRecords("session_groups", filter, func(record *core.Record) (interface{}, bool) {
+	existingRecords, err := s.PreloadRecords("session_groups", filter, func(record *core.Record) (any, bool) {
 		if cmID, ok := record.Get("cm_id").(float64); ok {
 			return int(cmID), true
 		}
@@ -136,10 +136,10 @@ func (s *SessionGroupsSync) Sync(ctx context.Context) error {
 
 // transformSessionGroupToPB transforms CampMinder session group data to PocketBase format
 func (s *SessionGroupsSync) transformSessionGroupToPB(
-	data map[string]interface{},
+	data map[string]any,
 	year int,
-) (map[string]interface{}, error) {
-	pbData := make(map[string]interface{})
+) (map[string]any, error) {
+	pbData := make(map[string]any)
 
 	// Extract group ID (required)
 	groupIDFloat, ok := data["ID"].(float64)

--- a/pocketbase/sync/session_groups_test.go
+++ b/pocketbase/sync/session_groups_test.go
@@ -20,7 +20,7 @@ func TestTransformSessionGroupToPB(t *testing.T) {
 	s := &SessionGroupsSync{}
 
 	// Mock CampMinder API response
-	groupData := map[string]interface{}{
+	groupData := map[string]any{
 		"ID":          float64(100),
 		"Name":        "Main Sessions",
 		"Description": "Standard summer camp sessions",
@@ -61,7 +61,7 @@ func TestTransformSessionGroupHandlesMissingFields(t *testing.T) {
 	s := &SessionGroupsSync{}
 
 	// Minimal data with only required fields
-	groupData := map[string]interface{}{
+	groupData := map[string]any{
 		"ID":   float64(100),
 		"Name": "Main Sessions",
 	}
@@ -95,7 +95,7 @@ func TestTransformSessionGroupRequiredIDError(t *testing.T) {
 	s := &SessionGroupsSync{}
 
 	// Missing ID field
-	groupData := map[string]interface{}{
+	groupData := map[string]any{
 		"Name": "Main Sessions",
 	}
 

--- a/pocketbase/sync/sessions.go
+++ b/pocketbase/sync/sessions.go
@@ -65,7 +65,7 @@ func (s *SessionsSync) Sync(ctx context.Context) error {
 	filter := fmt.Sprintf("year = %d", year)
 
 	// Pre-load existing records for this year
-	existingRecords, err := s.PreloadRecords("camp_sessions", filter, func(record *core.Record) (interface{}, bool) {
+	existingRecords, err := s.PreloadRecords("camp_sessions", filter, func(record *core.Record) (any, bool) {
 		if cmID, ok := record.Get("cm_id").(float64); ok {
 			return int(cmID), true
 		}
@@ -77,7 +77,7 @@ func (s *SessionsSync) Sync(ctx context.Context) error {
 
 	// Pre-load session_groups to resolve group_id -> PocketBase record ID
 	s.groupIDMap = make(map[int]string)
-	groupRecords, err := s.PreloadRecords("session_groups", filter, func(record *core.Record) (interface{}, bool) {
+	groupRecords, err := s.PreloadRecords("session_groups", filter, func(record *core.Record) (any, bool) {
 		if cmID, ok := record.Get("cm_id").(float64); ok {
 			// Store the PocketBase ID for this group's CampMinder ID
 			s.groupIDMap[int(cmID)] = record.Id
@@ -299,12 +299,12 @@ func (s *SessionsSync) Sync(ctx context.Context) error {
 // overrideParents for the parent_id (for embedded sessions from date overlap detection).
 // AG sessions still use mainSessions for parent lookup (exact date matching).
 func (s *SessionsSync) transformSessionToPBWithParent(
-	data map[string]interface{},
+	data map[string]any,
 	mainSessions map[string]int,
 	overrideTypes map[int]string,
 	overrideParents map[int]int,
-) (map[string]interface{}, error) {
-	pbData := make(map[string]interface{})
+) (map[string]any, error) {
+	pbData := make(map[string]any)
 
 	// Extract session ID
 	sessionIDFloat, ok := data["ID"].(float64)
@@ -412,7 +412,7 @@ type sessionOverlapInfo struct {
 // 2. If durations are equal, alphabetically first name wins
 // 3. All others become "embedded" with parent_id set to the primary's cm_id
 func (s *SessionsSync) reclassifyOverlappingSessions(
-	sessions []map[string]interface{},
+	sessions []map[string]any,
 	initialTypes map[int]string,
 ) (correctedTypes map[int]string, parentIDs map[int]int) {
 	// Initialize output maps with input values

--- a/pocketbase/sync/sessions_test.go
+++ b/pocketbase/sync/sessions_test.go
@@ -29,7 +29,7 @@ func TestTransformSessionExtractsAllFields(t *testing.T) {
 
 	// Mock CampMinder API response with all fields
 	// Note: CampMinder API has typo "IsForChilden" (missing 'r')
-	sessionData := map[string]interface{}{
+	sessionData := map[string]any{
 		"ID":            float64(12345),
 		"Name":          testSessionName,
 		"StartDate":     "2025-06-15T00:00:00Z",
@@ -114,7 +114,7 @@ func TestTransformSessionHandlesMissingFields(t *testing.T) {
 	s := &SessionsSync{}
 
 	// Minimal session data with only required fields
-	sessionData := map[string]interface{}{
+	sessionData := map[string]any{
 		"ID":       float64(12345),
 		"Name":     testSessionName,
 		"SeasonID": float64(2025),
@@ -162,7 +162,7 @@ func TestTransformSessionHandlesNullFields(t *testing.T) {
 	s := &SessionsSync{}
 
 	// Session data with explicit nil values (as might come from JSON null)
-	sessionData := map[string]interface{}{
+	sessionData := map[string]any{
 		"ID":            float64(12345),
 		"Name":          testSessionName,
 		"StartDate":     "2025-06-15T00:00:00Z",
@@ -208,7 +208,7 @@ func TestReclassifyOverlappingSessions_SharedStartDate(t *testing.T) {
 
 	// Session 2 (June 15 - July 13) and Taste of Camp 2 (June 15 - June 20)
 	// Both share start date June 15, Session 2 is longer
-	sessions := []map[string]interface{}{
+	sessions := []map[string]any{
 		{
 			"ID":        float64(1001),
 			"Name":      "Session 2",
@@ -259,7 +259,7 @@ func TestReclassifyOverlappingSessions_SharedEndDate(t *testing.T) {
 
 	// Session 3 (July 14 - Aug 10) and Session 3a (Aug 1 - Aug 10)
 	// Both share end date Aug 10, Session 3 is longer
-	sessions := []map[string]interface{}{
+	sessions := []map[string]any{
 		{
 			"ID":        float64(2001),
 			"Name":      "Session 3",
@@ -303,7 +303,7 @@ func TestReclassifyOverlappingSessions_AGSessionsExempt(t *testing.T) {
 	s := &SessionsSync{}
 
 	// AG session with same dates as main session
-	sessions := []map[string]interface{}{
+	sessions := []map[string]any{
 		{
 			"ID":        float64(3001),
 			"Name":      "Session 2",
@@ -348,7 +348,7 @@ func TestReclassifyOverlappingSessions_EqualDurationAlphabetical(t *testing.T) {
 	s := &SessionsSync{}
 
 	// "Session A" and "Session B" with identical dates
-	sessions := []map[string]interface{}{
+	sessions := []map[string]any{
 		{
 			"ID":        float64(4002),
 			"Name":      "Session B",
@@ -392,7 +392,7 @@ func TestReclassifyOverlappingSessions_MultipleOverlaps(t *testing.T) {
 	s := &SessionsSync{}
 
 	// Session 2, ToC2, and Session 2b all share June 15 start
-	sessions := []map[string]interface{}{
+	sessions := []map[string]any{
 		{
 			"ID":        float64(5001),
 			"Name":      "Session 2",
@@ -450,7 +450,7 @@ func TestReclassifyOverlappingSessions_MultipleOverlaps(t *testing.T) {
 func TestReclassifyOverlappingSessions_NoOverlap(t *testing.T) {
 	s := &SessionsSync{}
 
-	sessions := []map[string]interface{}{
+	sessions := []map[string]any{
 		{
 			"ID":        float64(6001),
 			"Name":      "Session 2",
@@ -492,7 +492,7 @@ func TestReclassifyOverlappingSessions_NonMainUnchanged(t *testing.T) {
 	s := &SessionsSync{}
 
 	// Family camp with same dates as a main session
-	sessions := []map[string]interface{}{
+	sessions := []map[string]any{
 		{
 			"ID":        float64(7001),
 			"Name":      "Session 2",
@@ -535,7 +535,7 @@ func TestReclassifyOverlappingSessions_NonMainUnchanged(t *testing.T) {
 func TestReclassifyOverlappingSessions_MissingDates(t *testing.T) {
 	s := &SessionsSync{}
 
-	sessions := []map[string]interface{}{
+	sessions := []map[string]any{
 		{
 			"ID":        float64(8001),
 			"Name":      "Session 2",

--- a/pocketbase/sync/staff.go
+++ b/pocketbase/sync/staff.go
@@ -67,7 +67,7 @@ func (s *StaffSync) syncStaff(ctx context.Context) error {
 	filter := fmt.Sprintf("year = %d", year)
 
 	// Pre-load existing records for this year using person relation field as key
-	existingRecords, err := s.PreloadRecords("staff", filter, func(record *core.Record) (interface{}, bool) {
+	existingRecords, err := s.PreloadRecords("staff", filter, func(record *core.Record) (any, bool) {
 		if personRel := record.GetString("person"); personRel != "" {
 			return personRel, true // Use PocketBase person record ID as key
 		}
@@ -254,11 +254,11 @@ func (s *StaffSync) buildPersonMap(year int) map[int]string {
 }
 
 func (s *StaffSync) transformStaffToPB(
-	data map[string]interface{},
+	data map[string]any,
 	year int,
 	orgCategoryMap, positionMap, divisionMap, bunkMap, personMap map[int]string,
-) (map[string]interface{}, error) {
-	pbData := make(map[string]interface{})
+) (map[string]any, error) {
+	pbData := make(map[string]any)
 
 	// PersonID from CampMinder (required for resolving person relation)
 	personIDFloat, ok := data["PersonID"].(float64)
@@ -316,7 +316,7 @@ func (s *StaffSync) transformStaffToPB(
 }
 
 // setStatusFields extracts StatusID and StatusName from data.
-func (s *StaffSync) setStatusFields(pbData, data map[string]interface{}) {
+func (s *StaffSync) setStatusFields(pbData, data map[string]any) {
 	if statusID, ok := data["StatusID"].(float64); ok {
 		pbData["status_id"] = int(statusID)
 	}
@@ -327,7 +327,7 @@ func (s *StaffSync) setStatusFields(pbData, data map[string]interface{}) {
 
 // setStaffRelation maps a CampMinder ID field to a PocketBase relation.
 func (s *StaffSync) setStaffRelation(
-	pbData, data map[string]interface{},
+	pbData, data map[string]any,
 	srcKey, dstKey string,
 	lookupMap map[int]string,
 ) {
@@ -340,16 +340,16 @@ func (s *StaffSync) setStaffRelation(
 
 // setBunkAssignments extracts bunk assignments array and maps to PB IDs.
 func (s *StaffSync) setBunkAssignments(
-	pbData, data map[string]interface{},
+	pbData, data map[string]any,
 	bunkMap map[int]string,
 ) {
-	bunkAssignments, ok := data["BunkAssignments"].([]interface{})
+	bunkAssignments, ok := data["BunkAssignments"].([]any)
 	if !ok || len(bunkAssignments) == 0 {
 		return
 	}
 	var bunkIDs []string
 	for _, ba := range bunkAssignments {
-		if baMap, ok := ba.(map[string]interface{}); ok {
+		if baMap, ok := ba.(map[string]any); ok {
 			if bunkID, ok := baMap["ID"].(float64); ok && bunkID > 0 {
 				if pbID, found := bunkMap[int(bunkID)]; found {
 					bunkIDs = append(bunkIDs, pbID)
@@ -363,21 +363,21 @@ func (s *StaffSync) setBunkAssignments(
 }
 
 // setDateField extracts a date string and parses it.
-func (s *StaffSync) setDateField(pbData, data map[string]interface{}, srcKey, dstKey string) {
+func (s *StaffSync) setDateField(pbData, data map[string]any, srcKey, dstKey string) {
 	if dateStr, ok := data[srcKey].(string); ok && dateStr != "" {
 		pbData[dstKey] = ParseDate(dateStr)
 	}
 }
 
 // setStaffIntField extracts a float64 and sets as int.
-func (s *StaffSync) setStaffIntField(pbData, data map[string]interface{}, srcKey, dstKey string) {
+func (s *StaffSync) setStaffIntField(pbData, data map[string]any, srcKey, dstKey string) {
 	if val, ok := data[srcKey].(float64); ok {
 		pbData[dstKey] = int(val)
 	}
 }
 
 // setStaffFloatField extracts and sets a float64.
-func (s *StaffSync) setStaffFloatField(pbData, data map[string]interface{}, srcKey, dstKey string) {
+func (s *StaffSync) setStaffFloatField(pbData, data map[string]any, srcKey, dstKey string) {
 	if val, ok := data[srcKey].(float64); ok {
 		pbData[dstKey] = val
 	}

--- a/pocketbase/sync/staff_lookups.go
+++ b/pocketbase/sync/staff_lookups.go
@@ -71,7 +71,7 @@ func (s *StaffLookupsSync) syncProgramAreas(ctx context.Context) error {
 	slog.Info("Syncing staff program areas")
 
 	// Pre-load existing records (global - no year filter)
-	preloadFn := func(record *core.Record) (interface{}, bool) {
+	preloadFn := func(record *core.Record) (any, bool) {
 		if cmID, ok := record.Get("cm_id").(float64); ok && cmID > 0 {
 			return int(cmID), true
 		}
@@ -152,7 +152,7 @@ func (s *StaffLookupsSync) syncOrgCategories(ctx context.Context) error {
 	slog.Info("Syncing staff org categories")
 
 	// Pre-load existing records (global - no year filter)
-	preloadFn := func(record *core.Record) (interface{}, bool) {
+	preloadFn := func(record *core.Record) (any, bool) {
 		if cmID, ok := record.Get("cm_id").(float64); ok && cmID > 0 {
 			return int(cmID), true
 		}
@@ -231,7 +231,7 @@ func (s *StaffLookupsSync) syncPositions(ctx context.Context) error {
 	slog.Info("Syncing staff positions")
 
 	// Pre-load existing records (global - no year filter)
-	existingRecords, err := s.PreloadRecordsGlobal("staff_positions", "", func(record *core.Record) (interface{}, bool) {
+	existingRecords, err := s.PreloadRecordsGlobal("staff_positions", "", func(record *core.Record) (any, bool) {
 		if cmID, ok := record.Get("cm_id").(float64); ok && cmID > 0 {
 			return int(cmID), true
 		}
@@ -317,8 +317,8 @@ func (s *StaffLookupsSync) syncPositions(ctx context.Context) error {
 
 // Transform functions
 
-func (s *StaffLookupsSync) transformProgramAreaToPB(data map[string]interface{}) (map[string]interface{}, error) {
-	pbData := make(map[string]interface{})
+func (s *StaffLookupsSync) transformProgramAreaToPB(data map[string]any) (map[string]any, error) {
+	pbData := make(map[string]any)
 
 	// ID (required)
 	idFloat, ok := data["ID"].(float64)
@@ -337,8 +337,8 @@ func (s *StaffLookupsSync) transformProgramAreaToPB(data map[string]interface{})
 	return pbData, nil
 }
 
-func (s *StaffLookupsSync) transformOrgCategoryToPB(data map[string]interface{}) (map[string]interface{}, error) {
-	pbData := make(map[string]interface{})
+func (s *StaffLookupsSync) transformOrgCategoryToPB(data map[string]any) (map[string]any, error) {
+	pbData := make(map[string]any)
 
 	// ID (required)
 	idFloat, ok := data["ID"].(float64)
@@ -358,10 +358,10 @@ func (s *StaffLookupsSync) transformOrgCategoryToPB(data map[string]interface{})
 }
 
 func (s *StaffLookupsSync) transformPositionToPB(
-	data map[string]interface{},
+	data map[string]any,
 	programAreaMap map[int]string,
-) (map[string]interface{}, error) {
-	pbData := make(map[string]interface{})
+) (map[string]any, error) {
+	pbData := make(map[string]any)
 
 	// ID (required)
 	idFloat, ok := data["ID"].(float64)

--- a/pocketbase/sync/staff_lookups_test.go
+++ b/pocketbase/sync/staff_lookups_test.go
@@ -23,7 +23,7 @@ func TestTransformProgramAreaToPB(t *testing.T) {
 	s := &StaffLookupsSync{}
 
 	// Mock CampMinder API response
-	programAreaData := map[string]interface{}{
+	programAreaData := map[string]any{
 		"ID":   float64(100),
 		"Name": "Aquatics",
 	}
@@ -50,7 +50,7 @@ func TestTransformProgramAreaToPB(t *testing.T) {
 func TestTransformProgramAreaToPB_MissingID(t *testing.T) {
 	s := &StaffLookupsSync{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"Name": "Aquatics",
 	}
 
@@ -63,7 +63,7 @@ func TestTransformProgramAreaToPB_MissingID(t *testing.T) {
 func TestTransformProgramAreaToPB_ZeroID(t *testing.T) {
 	s := &StaffLookupsSync{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"ID":   float64(0),
 		"Name": "Aquatics",
 	}
@@ -77,7 +77,7 @@ func TestTransformProgramAreaToPB_ZeroID(t *testing.T) {
 func TestTransformProgramAreaToPB_MissingName(t *testing.T) {
 	s := &StaffLookupsSync{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"ID": float64(100),
 	}
 
@@ -90,7 +90,7 @@ func TestTransformProgramAreaToPB_MissingName(t *testing.T) {
 func TestTransformProgramAreaToPB_EmptyName(t *testing.T) {
 	s := &StaffLookupsSync{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"ID":   float64(100),
 		"Name": "",
 	}
@@ -109,7 +109,7 @@ func TestTransformOrgCategoryToPB(t *testing.T) {
 	s := &StaffLookupsSync{}
 
 	// Mock CampMinder API response
-	orgCategoryData := map[string]interface{}{
+	orgCategoryData := map[string]any{
 		"ID":   float64(200),
 		"Name": "Leadership",
 	}
@@ -136,7 +136,7 @@ func TestTransformOrgCategoryToPB(t *testing.T) {
 func TestTransformOrgCategoryToPB_MissingID(t *testing.T) {
 	s := &StaffLookupsSync{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"Name": "Leadership",
 	}
 
@@ -149,7 +149,7 @@ func TestTransformOrgCategoryToPB_MissingID(t *testing.T) {
 func TestTransformOrgCategoryToPB_ZeroID(t *testing.T) {
 	s := &StaffLookupsSync{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"ID":   float64(0),
 		"Name": "Leadership",
 	}
@@ -163,7 +163,7 @@ func TestTransformOrgCategoryToPB_ZeroID(t *testing.T) {
 func TestTransformOrgCategoryToPB_MissingName(t *testing.T) {
 	s := &StaffLookupsSync{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"ID": float64(200),
 	}
 
@@ -176,7 +176,7 @@ func TestTransformOrgCategoryToPB_MissingName(t *testing.T) {
 func TestTransformOrgCategoryToPB_EmptyName(t *testing.T) {
 	s := &StaffLookupsSync{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"ID":   float64(200),
 		"Name": "",
 	}
@@ -200,7 +200,7 @@ func TestTransformPositionToPB(t *testing.T) {
 	}
 
 	// Mock CampMinder API response
-	positionData := map[string]interface{}{
+	positionData := map[string]any{
 		"ID":            float64(300),
 		"Name":          "Lifeguard",
 		"ProgramAreaID": float64(100),
@@ -229,7 +229,7 @@ func TestTransformPositionToPB_NoProgramArea(t *testing.T) {
 	programAreaMap := map[int]string{}
 
 	// Position without program area
-	positionData := map[string]interface{}{
+	positionData := map[string]any{
 		"ID":   float64(300),
 		"Name": "Lifeguard",
 	}
@@ -262,7 +262,7 @@ func TestTransformPositionToPB_UnknownProgramArea(t *testing.T) {
 	}
 
 	// Position references a program area not in the map
-	positionData := map[string]interface{}{
+	positionData := map[string]any{
 		"ID":            float64(300),
 		"Name":          "Lifeguard",
 		"ProgramAreaID": float64(999), // Not in map
@@ -287,7 +287,7 @@ func TestTransformPositionToPB_MissingID(t *testing.T) {
 
 	programAreaMap := map[int]string{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"Name": "Lifeguard",
 	}
 
@@ -302,7 +302,7 @@ func TestTransformPositionToPB_ZeroID(t *testing.T) {
 
 	programAreaMap := map[int]string{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"ID":   float64(0),
 		"Name": "Lifeguard",
 	}
@@ -318,7 +318,7 @@ func TestTransformPositionToPB_MissingName(t *testing.T) {
 
 	programAreaMap := map[int]string{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"ID": float64(300),
 	}
 
@@ -333,7 +333,7 @@ func TestTransformPositionToPB_EmptyName(t *testing.T) {
 
 	programAreaMap := map[int]string{}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"ID":   float64(300),
 		"Name": "",
 	}

--- a/pocketbase/sync/staff_skills.go
+++ b/pocketbase/sync/staff_skills.go
@@ -212,7 +212,7 @@ func (s *StaffSkillsSync) Sync(ctx context.Context) error {
 		demo := demographics[sv.personCMID]
 
 		// Build record data
-		recordData := map[string]interface{}{
+		recordData := map[string]any{
 			"person_id":       sv.personCMID,
 			"skill_cm_id":     sv.skillCMID,
 			"skill_name":      sv.skillName,
@@ -352,7 +352,7 @@ func (s *StaffSkillsSync) containsStaffPartitionFromRaw(rawValue any) bool {
 	}
 
 	// Handle as []interface{} (JSON array from record.Get())
-	if arr, ok := rawValue.([]interface{}); ok {
+	if arr, ok := rawValue.([]any); ok {
 		for _, v := range arr {
 			if str, ok := v.(string); ok && str == partitionStaff {
 				return true
@@ -633,7 +633,7 @@ func (s *StaffSkillsSync) preloadExistingRecords(year int) (map[string]*core.Rec
 // Uses compareFields (inclusion list): only the listed fields are checked for changes.
 // Delegates to the shared compareRecordNeedsUpdate in base_sync.go.
 func (s *StaffSkillsSync) recordNeedsUpdate(
-	existing *core.Record, newData map[string]interface{}, compareFields []string,
+	existing *core.Record, newData map[string]any, compareFields []string,
 ) bool {
 	return compareRecordNeedsUpdate(existing, newData, compareFields)
 }

--- a/pocketbase/sync/staff_skills_test.go
+++ b/pocketbase/sync/staff_skills_test.go
@@ -234,28 +234,28 @@ func TestIsStaffPartition(t *testing.T) {
 func TestContainsStaffPartitionWithJSONArray(t *testing.T) {
 	tests := []struct {
 		name        string
-		rawValue    interface{}
+		rawValue    any
 		wantIsStaff bool
 	}{
 		// JSON array with Staff
 		{
 			name:        "JSON array with Staff only",
-			rawValue:    []interface{}{"Staff"},
+			rawValue:    []any{"Staff"},
 			wantIsStaff: true,
 		},
 		{
 			name:        "JSON array with Staff and others",
-			rawValue:    []interface{}{"Camper", "Staff", "Alumnus"},
+			rawValue:    []any{"Camper", "Staff", "Alumnus"},
 			wantIsStaff: true,
 		},
 		{
 			name:        "JSON array without Staff",
-			rawValue:    []interface{}{"Camper", "Parent"},
+			rawValue:    []any{"Camper", "Parent"},
 			wantIsStaff: false,
 		},
 		{
 			name:        "empty JSON array",
-			rawValue:    []interface{}{},
+			rawValue:    []any{},
 			wantIsStaff: false,
 		},
 		// String array variant
@@ -290,13 +290,13 @@ func TestContainsStaffPartitionWithJSONArray(t *testing.T) {
 
 // containsStaffPartitionFromRaw handles both JSON array (from Get) and string (from GetString)
 // This is what the fix should implement in staff_skills.go
-func containsStaffPartitionFromRaw(rawValue interface{}) bool {
+func containsStaffPartitionFromRaw(rawValue any) bool {
 	if rawValue == nil {
 		return false
 	}
 
 	// Handle as []interface{} (JSON array from record.Get())
-	if arr, ok := rawValue.([]interface{}); ok {
+	if arr, ok := rawValue.([]any); ok {
 		for _, v := range arr {
 			if str, ok := v.(string); ok && str == partitionStaff {
 				return true
@@ -863,7 +863,7 @@ func TestStaffSkillsRecordNeedsUpdateUsesCompareFields(t *testing.T) {
 		existing.Set("last_name", testLastName)
 		existing.Set("person", "pb_abc123")
 
-		newData := map[string]interface{}{
+		newData := map[string]any{
 			"skill_name":      "Archery",
 			"is_intermediate": true,
 			"is_experienced":  false,
@@ -892,7 +892,7 @@ func TestStaffSkillsRecordNeedsUpdateUsesCompareFields(t *testing.T) {
 		existing.Set("last_name", testLastName)
 		existing.Set("person", "pb_abc123")
 
-		newData := map[string]interface{}{
+		newData := map[string]any{
 			"skill_name":      "Archery",
 			"is_intermediate": true,
 			"is_experienced":  true,

--- a/pocketbase/sync/staff_test.go
+++ b/pocketbase/sync/staff_test.go
@@ -55,7 +55,7 @@ func TestTransformStaffToPB_PersonID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Build test data
-			data := map[string]interface{}{
+			data := map[string]any{
 				"PersonID": tt.personID,
 			}
 
@@ -92,8 +92,8 @@ func TestTransformStaffToPB_PersonID(t *testing.T) {
 
 // testTransformStaffPersonID simulates the person_id extraction logic from transformStaffToPB.
 // After the fix, both person_id (CM ID) and person (PB relation) should be set.
-func testTransformStaffPersonID(data map[string]interface{}, personMap map[int]string) (map[string]interface{}, error) {
-	pbData := make(map[string]interface{})
+func testTransformStaffPersonID(data map[string]any, personMap map[int]string) (map[string]any, error) {
+	pbData := make(map[string]any)
 
 	// PersonID from CampMinder (required for resolving person relation)
 	personIDFloat, ok := data["PersonID"].(float64)
@@ -165,8 +165,8 @@ func TestSetStatusFields_AllStatuses(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pbData := make(map[string]interface{})
-			data := map[string]interface{}{
+			pbData := make(map[string]any)
+			data := map[string]any{
 				"StatusID":   tt.statusID,
 				"StatusName": tt.statusName,
 			}
@@ -307,7 +307,7 @@ func TestPreserveBunkDataDeletesFields(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pbData := map[string]interface{}{
+			pbData := map[string]any{
 				"status_id":  tt.statusID,
 				"bunks":      []string{"new_bunk_1"},
 				"bunk_staff": true,
@@ -341,27 +341,27 @@ func TestPreserveBunkDataDeletesFields(t *testing.T) {
 func TestTransformStaffToPB_MissingPersonID(t *testing.T) {
 	tests := []struct {
 		name    string
-		data    map[string]interface{}
+		data    map[string]any
 		wantErr bool
 	}{
 		{
 			name:    "missing PersonID",
-			data:    map[string]interface{}{},
+			data:    map[string]any{},
 			wantErr: true,
 		},
 		{
 			name:    "zero PersonID",
-			data:    map[string]interface{}{"PersonID": float64(0)},
+			data:    map[string]any{"PersonID": float64(0)},
 			wantErr: true,
 		},
 		{
 			name:    "wrong type PersonID",
-			data:    map[string]interface{}{"PersonID": "12345"},
+			data:    map[string]any{"PersonID": "12345"},
 			wantErr: true,
 		},
 		{
 			name:    "valid PersonID",
-			data:    map[string]interface{}{"PersonID": float64(12345)},
+			data:    map[string]any{"PersonID": float64(12345)},
 			wantErr: false,
 		},
 	}

--- a/pocketbase/sync/table_exporter.go
+++ b/pocketbase/sync/table_exporter.go
@@ -160,7 +160,7 @@ func (r *FieldResolver) SetCMIDIndexedLookup(collection string, data map[int]str
 
 // ResolveWriteInOverride resolves write-in override fields
 // Returns write_in value if non-empty, otherwise standard field value
-func (r *FieldResolver) ResolveWriteInOverride(record map[string]interface{}, col *ColumnConfig) string {
+func (r *FieldResolver) ResolveWriteInOverride(record map[string]any, col *ColumnConfig) string {
 	// Check write-in field first
 	writeIn := safeString(record[col.WriteInField])
 	if writeIn != "" {
@@ -213,7 +213,7 @@ func (r *FieldResolver) LookupByCMID(collection string, cmID int) string {
 }
 
 // ResolveValue transforms a raw value based on column configuration
-func (r *FieldResolver) ResolveValue(value interface{}, col *ColumnConfig) interface{} {
+func (r *FieldResolver) ResolveValue(value any, col *ColumnConfig) any {
 	if value == nil {
 		return ""
 	}
@@ -326,7 +326,7 @@ func (r *FieldResolver) ResolveValue(value interface{}, col *ColumnConfig) inter
 }
 
 // resolveMultiRelation handles multi-select relation fields
-func (r *FieldResolver) resolveMultiRelation(value interface{}, col *ColumnConfig) string {
+func (r *FieldResolver) resolveMultiRelation(value any, col *ColumnConfig) string {
 	// Handle nil
 	if value == nil {
 		return ""
@@ -335,7 +335,7 @@ func (r *FieldResolver) resolveMultiRelation(value interface{}, col *ColumnConfi
 	// Convert to slice of IDs
 	var ids []string
 	switch v := value.(type) {
-	case []interface{}:
+	case []any:
 		for _, item := range v {
 			if s := safeString(item); s != "" {
 				ids = append(ids, s)
@@ -366,14 +366,14 @@ func (r *FieldResolver) resolveMultiRelation(value interface{}, col *ColumnConfi
 }
 
 // resolveMultiSelect handles multi-select fields (non-relation) by joining values
-func (r *FieldResolver) resolveMultiSelect(value interface{}) string {
+func (r *FieldResolver) resolveMultiSelect(value any) string {
 	if value == nil {
 		return ""
 	}
 
 	var values []string
 	switch v := value.(type) {
-	case []interface{}:
+	case []any:
 		for _, item := range v {
 			if s := safeString(item); s != "" {
 				values = append(values, s)
@@ -396,15 +396,15 @@ func (r *FieldResolver) resolveMultiSelect(value interface{}) string {
 // BuildDataMatrix converts records to a 2D array for Google Sheets
 // First row contains headers, subsequent rows contain data
 func BuildDataMatrix(
-	records []map[string]interface{},
+	records []map[string]any,
 	columns []ColumnConfig,
 	resolver *FieldResolver,
-) [][]interface{} {
+) [][]any {
 	// Preallocate: 1 header row + data rows
-	data := make([][]interface{}, 0, 1+len(records))
+	data := make([][]any, 0, 1+len(records))
 
 	// Build header row (use index to avoid copying 136-byte struct)
-	headers := make([]interface{}, len(columns))
+	headers := make([]any, len(columns))
 	for i := range columns {
 		headers[i] = columns[i].Header
 	}
@@ -412,7 +412,7 @@ func BuildDataMatrix(
 
 	// Build data rows (use index to avoid copying 136-byte struct)
 	for _, record := range records {
-		row := make([]interface{}, len(columns))
+		row := make([]any, len(columns))
 		for i := range columns {
 			col := &columns[i]
 			// WriteInOverride needs access to full record
@@ -448,7 +448,7 @@ func NewTableExporter(writer SheetsWriter, resolver *FieldResolver, spreadsheetI
 }
 
 // Export exports records to a Google Sheet tab
-func (e *TableExporter) Export(ctx context.Context, config *ExportConfig, records []map[string]interface{}) error {
+func (e *TableExporter) Export(ctx context.Context, config *ExportConfig, records []map[string]any) error {
 	// Get the resolved sheet name
 	sheetName := config.GetResolvedSheetName(e.year)
 

--- a/pocketbase/sync/table_exporter_test.go
+++ b/pocketbase/sync/table_exporter_test.go
@@ -186,7 +186,7 @@ func TestFieldResolver_ResolveMultiRelation(t *testing.T) {
 	}
 
 	// Input is array of PB IDs
-	ids := []interface{}{"tag_1", "tag_3"}
+	ids := []any{"tag_1", "tag_3"}
 	got := resolver.ResolveValue(ids, &col)
 
 	// Should be comma-separated names
@@ -214,7 +214,7 @@ func TestFieldResolver_ResolveMultiRelation_Empty(t *testing.T) {
 	}
 
 	// Empty array
-	got := resolver.ResolveValue([]interface{}{}, &col)
+	got := resolver.ResolveValue([]any{}, &col)
 	if got != "" {
 		t.Errorf("ResolveValue([]) = %q, want empty", got)
 	}
@@ -258,7 +258,7 @@ func TestBuildDataMatrix_Headers(t *testing.T) {
 	}
 
 	resolver := NewFieldResolver()
-	data := BuildDataMatrix([]map[string]interface{}{}, columns, resolver)
+	data := BuildDataMatrix([]map[string]any{}, columns, resolver)
 
 	// Should have header row
 	if len(data) != 1 {
@@ -288,7 +288,7 @@ func TestBuildDataMatrix_DataRows(t *testing.T) {
 		{Field: "grade", Header: "Grade", Type: FieldTypeNumber},
 	}
 
-	records := []map[string]interface{}{
+	records := []map[string]any{
 		{"first_name": "Emma", "grade": float64(5)},
 		{"first_name": "Liam", "grade": float64(6)},
 	}
@@ -385,7 +385,7 @@ func TestTableExporter_ExportCallsEnsureSheet(t *testing.T) {
 		},
 	}
 
-	records := []map[string]interface{}{
+	records := []map[string]any{
 		{"name": "Test Record"},
 	}
 
@@ -528,7 +528,7 @@ func TestFieldResolver_ResolveWriteInOverride(t *testing.T) {
 	}
 
 	// Test 1: Both fields empty - should return empty
-	record := map[string]interface{}{
+	record := map[string]any{
 		"gender_identity_name":     "",
 		"gender_identity_write_in": "",
 	}
@@ -538,7 +538,7 @@ func TestFieldResolver_ResolveWriteInOverride(t *testing.T) {
 	}
 
 	// Test 2: Standard field set, write-in empty - should return standard
-	record = map[string]interface{}{
+	record = map[string]any{
 		"gender_identity_name":     "Non-binary",
 		"gender_identity_write_in": "",
 	}
@@ -548,7 +548,7 @@ func TestFieldResolver_ResolveWriteInOverride(t *testing.T) {
 	}
 
 	// Test 3: Both set - write-in should take precedence
-	record = map[string]interface{}{
+	record = map[string]any{
 		"gender_identity_name":     "Other",
 		"gender_identity_write_in": "Genderqueer",
 	}
@@ -558,7 +558,7 @@ func TestFieldResolver_ResolveWriteInOverride(t *testing.T) {
 	}
 
 	// Test 4: Write-in set, standard empty - should return write-in
-	record = map[string]interface{}{
+	record = map[string]any{
 		"gender_identity_name":     "",
 		"gender_identity_write_in": "Custom Identity",
 	}
@@ -759,7 +759,7 @@ func TestBuildDataMatrix_WriteInOverride(t *testing.T) {
 	}
 
 	// Record with write-in value (should override)
-	records := []map[string]interface{}{
+	records := []map[string]any{
 		{"gender_identity_name": "Other", "gender_identity_write_in": "Genderqueer"},
 		{"gender_identity_name": "Non-binary", "gender_identity_write_in": ""},
 		{"gender_identity_name": "", "gender_identity_write_in": ""},

--- a/pocketbase/sync/workbook_manager.go
+++ b/pocketbase/sync/workbook_manager.go
@@ -413,7 +413,7 @@ func (m *WorkbookManager) UpdateMasterIndex(ctx context.Context) error {
 
 // BuildIndexSheetData builds the data matrix for the master index sheet.
 // Rows are sorted: globals first, then years in descending order.
-func BuildIndexSheetData(workbooks []WorkbookRecord) [][]interface{} {
+func BuildIndexSheetData(workbooks []WorkbookRecord) [][]any {
 	// Sort workbooks: globals first, then years descending
 	sorted := make([]WorkbookRecord, len(workbooks))
 	copy(sorted, workbooks)
@@ -430,13 +430,13 @@ func BuildIndexSheetData(workbooks []WorkbookRecord) [][]interface{} {
 	})
 
 	// Preallocate data with header row + one row per workbook
-	data := make([][]interface{}, 0, 1+len(sorted))
-	data = append(data, []interface{}{"Year", "Workbook", "Link", "Last Sync", "Tabs", "Records", "Status"})
+	data := make([][]any, 0, 1+len(sorted))
+	data = append(data, []any{"Year", "Workbook", "Link", "Last Sync", "Tabs", "Records", "Status"})
 
 	// Add data rows
 	for i := range sorted {
 		wb := &sorted[i]
-		var yearDisplay interface{}
+		var yearDisplay any
 		if wb.WorkbookType == workbookTypeGlobals {
 			yearDisplay = "Globals"
 		} else {
@@ -452,7 +452,7 @@ func BuildIndexSheetData(workbooks []WorkbookRecord) [][]interface{} {
 		// Create hyperlink formula for the link column
 		link := fmt.Sprintf(`=HYPERLINK(%q,"Open")`, wb.URL)
 
-		data = append(data, []interface{}{
+		data = append(data, []any{
 			yearDisplay,
 			wb.Title,
 			link,
@@ -467,7 +467,7 @@ func BuildIndexSheetData(workbooks []WorkbookRecord) [][]interface{} {
 }
 
 // safeInt safely converts an interface{} to int
-func safeInt(v interface{}) int {
+func safeInt(v any) int {
 	if v == nil {
 		return 0
 	}


### PR DESCRIPTION
## Summary

Mechanical codemod replacing 744 occurrences of `interface{}` with `any` across 61 Go files in `pocketbase/`.

- 603 are `map[string]interface{}` (§2c row #6)
- 141 are bare `interface{}` (§2c row #7)

`any` has been the canonical alias since Go 1.18; toolchain is on 1.26. Pure stylistic — AST-equivalent.

## Reproduction

```
cd pocketbase && gofmt -r 'interface{} -> any' -w .
```

## Notes

- 22 residual `interface{}` mentions remain in code comments and test-case description strings; left intact since they reference the historical type name in prose, where mechanical rewriting would muddy intent.
- Closes §2c rows #6 and #7 in `docs/reference/modernization-backlog.md`. Backlog status update will land as a follow-up commit on `feature/go-modernization` (alongside other doc-only updates) once this merges.

## Test plan

- [x] `cd pocketbase && go build ./...` clean
- [x] `cd pocketbase && go test ./...` — 2166 passed in 9 packages
- [x] `lefthook run pre-push` green (ruff, mypy, type-check, go-build, pb-js-lint, shellcheck)
- [ ] CI green