### PR TITLE
refactor(sync): consolidate campminder/client.go on slog

### DIFF
--- a/pocketbase/campminder/client.go
+++ b/pocketbase/campminder/client.go
@@ -207,7 +207,11 @@ func (c *Client) makeRequestWithURLRetry(method, fullURL string, retryCount int)
 	if resp.StatusCode == http.StatusTooManyRequests && retryCount < maxRequestRetries {
 		waitTime := c.parseRateLimitSeconds(string(body))
 		if waitTime > 0 {
-			slog.Warn("CampMinder rate limited", "wait_seconds", waitTime, "retry", retryCount+1, "max_retries", maxRequestRetries)
+			slog.Warn("CampMinder rate limited",
+				"wait_seconds", waitTime,
+				"retry", retryCount+1,
+				"max_retries", maxRequestRetries,
+			)
 			time.Sleep(time.Duration(waitTime) * time.Second)
 			// Retry the request
 			return c.makeRequestWithURLRetry(method, fullURL, retryCount+1)

--- a/pocketbase/campminder/client.go
+++ b/pocketbase/campminder/client.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -97,7 +96,7 @@ func (c *Client) authenticate() error {
 		if resp.StatusCode == http.StatusTooManyRequests {
 			waitTime := c.parseRateLimitSeconds(string(body))
 			if waitTime > 0 {
-				log.Printf("CampMinder: Rate limited during auth. Waiting %d seconds...", waitTime)
+				slog.Warn("CampMinder rate limited during auth", "wait_seconds", waitTime)
 				time.Sleep(time.Duration(waitTime) * time.Second)
 				// Retry authentication
 				return c.authenticate()
@@ -204,7 +203,7 @@ func (c *Client) makeRequestWithURLRetry(method, fullURL string, retryCount int)
 	if resp.StatusCode == http.StatusTooManyRequests && retryCount < 10 {
 		waitTime := c.parseRateLimitSeconds(string(body))
 		if waitTime > 0 {
-			log.Printf("CampMinder: Rate limited. Waiting %d seconds before retry %d/10...", waitTime, retryCount+1)
+			slog.Warn("CampMinder rate limited", "wait_seconds", waitTime, "retry", retryCount+1, "max_retries", 10)
 			time.Sleep(time.Duration(waitTime) * time.Second)
 			// Retry the request
 			return c.makeRequestWithURLRetry(method, fullURL, retryCount+1)

--- a/pocketbase/campminder/client.go
+++ b/pocketbase/campminder/client.go
@@ -19,6 +19,10 @@ import (
 
 const (
 	baseURL = "https://api.campminder.com"
+
+	// maxRequestRetries caps retries on HTTP 429 responses for non-auth requests.
+	// Auth retries are currently uncapped — see issue #1079.
+	maxRequestRetries = 10
 )
 
 // Client wraps CampMinder API interactions
@@ -200,10 +204,10 @@ func (c *Client) makeRequestWithURLRetry(method, fullURL string, retryCount int)
 	}
 
 	// Handle rate limiting
-	if resp.StatusCode == http.StatusTooManyRequests && retryCount < 10 {
+	if resp.StatusCode == http.StatusTooManyRequests && retryCount < maxRequestRetries {
 		waitTime := c.parseRateLimitSeconds(string(body))
 		if waitTime > 0 {
-			slog.Warn("CampMinder rate limited", "wait_seconds", waitTime, "retry", retryCount+1, "max_retries", 10)
+			slog.Warn("CampMinder rate limited", "wait_seconds", waitTime, "retry", retryCount+1, "max_retries", maxRequestRetries)
 			time.Sleep(time.Duration(waitTime) * time.Second)
 			// Retry the request
 			return c.makeRequestWithURLRetry(method, fullURL, retryCount+1)


### PR DESCRIPTION
## Summary

Drops the `"log"` import from `pocketbase/campminder/client.go` and converts the two remaining `log.Printf` rate-limit messages to `slog.Warn` with structured attributes. The rest of the file (and the 784 `slog` uses repo-wide) is already on `log/slog`.

**Backlog row:** §2c #8 — log/slog consolidation. See `docs/reference/modernization-backlog.md`.

### What it does
- Remove `"log"` import (line 11)
- `log.Printf("CampMinder: Rate limited during auth. Waiting %d seconds...", waitTime)` → `slog.Warn("CampMinder rate limited during auth", "wait_seconds", waitTime)`
- `log.Printf("CampMinder: Rate limited. Waiting %d seconds before retry %d/10...", waitTime, retryCount+1)` → `slog.Warn("CampMinder rate limited", "wait_seconds", waitTime, "retry", retryCount+1, "max_retries", 10)`

### Why
- Single logging library per file — consistency with the rest of the codebase
- Rate-limit waits are an operationally relevant degraded condition; `Warn` (not `Debug`) is the right level
- Structured attrs (`wait_seconds`, `retry`) make these events queryable instead of regex-on-message
- Crosses off these two callsites for §2c #11 (`fmt.Sprintf` inside slog) preemptively

### Verification
Pure-rewrite per Part B Rule 3 — no failing test required; existing tests + `lefthook run pre-push` lock the contract. No tests reference these log strings.

## Test plan
- [x] `lefthook run pre-push` (ruff-check, shellcheck, pb-js-lint, go-build, mypy, type-check) — green
- [x] `go test ./campminder/...` — 22 passed
- [x] `grep '\<log\.' campminder/client.go` returns zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved rate-limit logging infrastructure with structured format for enhanced monitoring and diagnostics capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->