### PR TITLE
refactor(sync): manual chunkers → slices.Chunk

### DIFF
--- a/pocketbase/sync/camper_history.go
+++ b/pocketbase/sync/camper_history.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 
 	"github.com/pocketbase/pocketbase/core"
@@ -529,10 +530,7 @@ func (c *CamperHistorySync) loadPersonDemographics(
 ) (map[int]personDemographics, error) {
 	result := make(map[int]personDemographics)
 
-	// Split into batches
-	batches := c.splitIntoBatches(personCMIDs, personBatchSize)
-
-	for _, batch := range batches {
+	for batch := range slices.Chunk(personCMIDs, personBatchSize) {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -718,13 +716,11 @@ func (c *CamperHistorySync) loadHistoricalEnrollments(
 		result[cmID] = []historicalEnrollment{}
 	}
 
-	// Query historical attendees in batches
-	batches := c.splitIntoBatches(personCMIDs, personBatchSize)
-
 	// Cache session type lookups
 	sessionTypeCache := make(map[string]string)
 
-	for _, batch := range batches {
+	// Query historical attendees in batches
+	for batch := range slices.Chunk(personCMIDs, personBatchSize) {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -1035,19 +1031,6 @@ func (c *CamperHistorySync) isFamilySessionType(sessionType string) bool {
 // ============================================================================
 // Utility functions
 // ============================================================================
-
-// splitIntoBatches splits a slice into batches
-func (c *CamperHistorySync) splitIntoBatches(ids []int, batchSize int) [][]int {
-	var batches [][]int
-	for i := 0; i < len(ids); i += batchSize {
-		end := i + batchSize
-		if end > len(ids) {
-			end = len(ids)
-		}
-		batches = append(batches, ids[i:end])
-	}
-	return batches
-}
 
 // forceWALCheckpoint forces a SQLite WAL checkpoint
 func (c *CamperHistorySync) forceWALCheckpoint() error {

--- a/pocketbase/sync/camper_history_test.go
+++ b/pocketbase/sync/camper_history_test.go
@@ -324,43 +324,6 @@ func TestCamperHistoryStatusPriority(t *testing.T) {
 	}
 }
 
-// TestCamperHistoryBatchedPersonLookup tests that person lookups work in batches
-func TestCamperHistoryBatchedPersonLookup(t *testing.T) {
-	// Simulate a large number of person IDs that need batching
-	personIDs := make([]int, 1200) // More than typical batch size
-	for i := range personIDs {
-		personIDs[i] = 1000 + i
-	}
-
-	// Calculate expected batches
-	batchSize := 100
-	expectedBatches := (len(personIDs) + batchSize - 1) / batchSize
-
-	batches := splitIntoBatches(personIDs, batchSize)
-
-	if len(batches) != expectedBatches {
-		t.Errorf("expected %d batches, got %d", expectedBatches, len(batches))
-	}
-
-	// Verify all IDs are included
-	totalIDs := 0
-	for _, batch := range batches {
-		totalIDs += len(batch)
-	}
-	if totalIDs != len(personIDs) {
-		t.Errorf("expected %d total IDs across batches, got %d", len(personIDs), totalIDs)
-	}
-
-	// Verify last batch has correct size
-	lastBatchExpectedSize := len(personIDs) % batchSize
-	if lastBatchExpectedSize == 0 {
-		lastBatchExpectedSize = batchSize
-	}
-	if len(batches[len(batches)-1]) != lastBatchExpectedSize {
-		t.Errorf("last batch size = %d, want %d", len(batches[len(batches)-1]), lastBatchExpectedSize)
-	}
-}
-
 // ============================================================================
 // Test helper types and functions (these match the production implementation)
 // ============================================================================
@@ -521,19 +484,6 @@ func getBestStatus(statuses []string) string {
 	}
 	// Otherwise return first status
 	return statuses[0]
-}
-
-// splitIntoBatches splits a slice into batches of specified size
-func splitIntoBatches(ids []int, batchSize int) [][]int {
-	var batches [][]int
-	for i := 0; i < len(ids); i += batchSize {
-		end := i + batchSize
-		if end > len(ids) {
-			end = len(ids)
-		}
-		batches = append(batches, ids[i:end])
-	}
-	return batches
 }
 
 // joinSorted sorts strings and joins with ", "

--- a/pocketbase/sync/households.go
+++ b/pocketbase/sync/households.go
@@ -111,7 +111,11 @@ func (s *HouseholdsSync) Sync(ctx context.Context) error {
 		default:
 		}
 
-		slog.Debug("Fetching persons batch for household extraction", "start", processed+1, "end", processed+len(batch), "total", len(personIDs))
+		slog.Debug("Fetching persons batch for household extraction",
+			"start", processed+1,
+			"end", processed+len(batch),
+			"total", len(personIDs),
+		)
 
 		// Fetch persons for this batch (includes household data via includehouseholddetails=true)
 		persons, err := s.Client.GetPersons(batch)

--- a/pocketbase/sync/households.go
+++ b/pocketbase/sync/households.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 
 	"github.com/pocketbase/pocketbase/core"
 
@@ -100,8 +101,9 @@ func (s *HouseholdsSync) Sync(ctx context.Context) error {
 	allHouseholds := make(map[int]map[string]any)
 
 	// Process persons in batches to extract households
-	batchSize := 500
-	for i := 0; i < len(personIDs); i += batchSize {
+	const batchSize = 500
+	processed := 0
+	for batch := range slices.Chunk(personIDs, batchSize) {
 		// Check context cancellation
 		select {
 		case <-ctx.Done():
@@ -109,14 +111,7 @@ func (s *HouseholdsSync) Sync(ctx context.Context) error {
 		default:
 		}
 
-		// Get batch
-		end := i + batchSize
-		if end > len(personIDs) {
-			end = len(personIDs)
-		}
-		batch := personIDs[i:end]
-
-		slog.Debug("Fetching persons batch for household extraction", "start", i+1, "end", end, "total", len(personIDs))
+		slog.Debug("Fetching persons batch for household extraction", "start", processed+1, "end", processed+len(batch), "total", len(personIDs))
 
 		// Fetch persons for this batch (includes household data via includehouseholddetails=true)
 		persons, err := s.Client.GetPersons(batch)
@@ -125,7 +120,7 @@ func (s *HouseholdsSync) Sync(ctx context.Context) error {
 		}
 
 		// Mark sync as successful once we've successfully fetched data
-		if i == 0 && len(persons) > 0 {
+		if processed == 0 && len(persons) > 0 {
 			s.SyncSuccessful = true
 		}
 
@@ -136,6 +131,7 @@ func (s *HouseholdsSync) Sync(ctx context.Context) error {
 				allHouseholds[int(id)] = household
 			}
 		}
+		processed += len(batch)
 	}
 
 	slog.Info("Extracted unique households from persons", "count", len(allHouseholds))

--- a/pocketbase/sync/persons.go
+++ b/pocketbase/sync/persons.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode"
@@ -279,29 +280,28 @@ func (s *PersonsSync) processPersonBatches(
 		personHouseholdMap:    make(map[int]personHouseholdIDs),
 	}
 
-	batchSize := 500
-	for i := 0; i < len(personIDs); i += batchSize {
+	const batchSize = 500
+	processed := 0
+	for batch := range slices.Chunk(personIDs, batchSize) {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		default:
 		}
 
-		end := min(i+batchSize, len(personIDs))
-		batch := personIDs[i:end]
-
-		slog.Info("Processing persons batch", "start", i+1, "end", end, "total", len(personIDs))
+		slog.Info("Processing persons batch", "start", processed+1, "end", processed+len(batch), "total", len(personIDs))
 
 		persons, err := s.Client.GetPersons(batch)
 		if err != nil {
 			return nil, fmt.Errorf("fetching persons batch: %w", err)
 		}
 
-		if i == 0 && len(persons) > 0 {
+		if processed == 0 && len(persons) > 0 {
 			s.SyncSuccessful = true
 		}
 
 		s.processBatchPersons(persons, camperIDsSet, existingPersons, tagDefsByName, divisionsByID, year, result)
+		processed += len(batch)
 	}
 
 	slog.Info("Extracted unique households from persons", "count", len(result.extractedHouseholds))

--- a/pocketbase/sync/session_resolver.go
+++ b/pocketbase/sync/session_resolver.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"fmt"
 	"log/slog"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -184,14 +185,8 @@ func (r *SessionResolver) GetHouseholdIDsForSession(session string, year int) ([
 	// Query persons to get their household IDs
 	householdIDSet := make(map[int]bool)
 	// Process in batches to avoid long queries
-	batchSize := 50
-	for i := 0; i < len(personPBIDs); i += batchSize {
-		end := i + batchSize
-		if end > len(personPBIDs) {
-			end = len(personPBIDs)
-		}
-		batch := personPBIDs[i:end]
-
+	const batchSize = 50
+	for batch := range slices.Chunk(personPBIDs, batchSize) {
 		// Build ID filter
 		idConditions := make([]string, len(batch))
 		for j, id := range batch {

--- a/pocketbase/sync/staff_skills.go
+++ b/pocketbase/sync/staff_skills.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 
 	"github.com/pocketbase/pocketbase/core"
@@ -537,19 +538,13 @@ func (s *StaffSkillsSync) loadStaffDemographics(
 	}
 
 	// Process in batches
-	batchSize := 100
-	for i := 0; i < len(ids); i += batchSize {
+	const batchSize = 100
+	for batch := range slices.Chunk(ids, batchSize) {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		default:
 		}
-
-		end := i + batchSize
-		if end > len(ids) {
-			end = len(ids)
-		}
-		batch := ids[i:end]
 
 		// Build OR filter
 		conditions := make([]string, len(batch))


### PR DESCRIPTION
## Summary

Replace 6 manual `for i := 0; i < len(s); i += batchSize` chunker loops with `for batch := range slices.Chunk(s, batchSize)` (Go 1.23). Drops 4 lines of index/clamp boilerplate per callsite and deletes the bespoke `splitIntoBatches` helper (production copy + test copy).

**Backlog row:** §2c #9 — manual chunkers → \`slices.Chunk\`. See \`docs/reference/modernization-backlog.md\`.

### Sites converted
- \`sync/households.go\` — extract-households batch loop (size 500)
- \`sync/staff_skills.go\` — persons-by-cm_id query batches (size 100)
- \`sync/session_resolver.go\` — persons-by-id query batches (size 50)
- \`sync/persons.go\` — \`GetPersons\` batch loop (size 500)
- \`sync/camper_history.go\` — \`loadPersonDemographics\` + \`loadHistoricalEnrollments\` callers; \`splitIntoBatches\` helper deleted (-12 lines)
- \`sync/camper_history_test.go\` — helper copy and the helper-only test deleted (\`slices.Chunk\`'s behavior is stdlib-tested)

For loops that referenced \`i\` (first-batch detection in \`households.go\` / \`persons.go\`, slog \`start\`/\`end\` fields), a local \`processed\` counter is threaded through the loop instead.

### Why
- 4 lines of \`end := i+batchSize; if end > len { end = len }; batch := s[i:end]\` boilerplate gone per callsite
- \`splitIntoBatches\` allocated a \`[][]int\` of slice headers; \`slices.Chunk\` is zero-alloc beyond the iterator
- One less helper to maintain (production + test)
- Unblocks §2c #10 (\`for i := 0; …\` → \`for i := range\`) by removing the \`i += batchSize\` subset that the bare for-range can't cover

### Pre-merge verification
- \`lefthook run pre-push\`: ruff-check, shellcheck, pb-js-lint, go-build, mypy, type-check — all green
- \`go test ./sync/...\` — 1994 passed
- \`grep splitIntoBatches sync/\` — zero hits
- \`grep 'i += batchSize' sync/\` — zero hits

## Test plan
- [x] Pre-push hooks pass
- [x] \`go test ./sync/...\` passes (1994 tests)
- [x] No \`splitIntoBatches\` or \`i += batchSize\` stragglers

🤖 Generated with [Claude Code](https://claude.com/claude-code)