### PR TITLE
docs(docs): mark §2c #8–10 as in flight (#1074, #1075, #1076)

### DIFF
--- a/docs/reference/modernization-backlog.md
+++ b/docs/reference/modernization-backlog.md
@@ -140,10 +140,10 @@ Operational ranking driving the row-by-row PR loop in `modernization-prompts.md`
 | 5 | ✓ shipped #1070 | `cmp.Or` (first non-zero) | `sync/table_exporter.go:262` | 1 | bundled w/ #4; ~4 audit entries retired as false positives (`normalize_geographic.go:487`, `table_exporter.go:358` — "if non-empty, do X" patterns rather than first-non-zero fallbacks) |
 | 6 | ✓ shipped #1071 | `map[string]interface{}` → `map[string]any` | hotspots | 603 | bundled w/ #7 as single `gofmt -r` codemod; surfaced pre-existing dead branch in `normalizeToStringSlice` (issue #1072) |
 | 7 | ✓ shipped #1071 | `interface{}` → `any` | `sync/api.go` (122), `base_sync.go` (29), `households.go`, widespread | 141 (744 incl. #6) | bundled w/ #6 |
-| 8 | next | log/slog consolidation | `campminder/client.go:11` (`log.Printf` alongside `slog`) | 1 file | — |
-| 9 | | manual chunkers → `slices.Chunk` | `sync/households.go:104`, `staff_skills.go:541`, `session_resolver.go:188`, `camper_history.go:1042`, `persons.go:283`, plus test | 6 | land before #10 |
-| 10 | | `for i := 0; …` → `for i := range s` | `sync/households.go`, `staff_skills.go`, `session_resolver.go`, `sessions.go`, `camper_history.go`, `rate_limited_sheets_writer.go`, tests | 26 (− #9 subset) | after #9 |
-| 11 | | `fmt.Sprintf` inside `slog` | `campminder/client.go:1008`, `sync/financial_transactions.go:106`, `sync/orchestrator.go:784,844` | 4 | — |
+| 8 | in flight #1074 | log/slog consolidation | `campminder/client.go:11` (`log.Printf` alongside `slog`) | 1 file | — |
+| 9 | in flight #1075 | manual chunkers → `slices.Chunk` | `sync/households.go:104`, `staff_skills.go:541`, `session_resolver.go:188`, `camper_history.go:1042`, `persons.go:283`, plus test | 6 | land before #10 |
+| 10 | in flight #1076 | `for i := 0; …` → `for i := range s` | `sync/sessions.go` (n² sort outer), `rate_limited_sheets_writer.go` (retry), `ratelimit/ratelimit.go` (retry), `household_demographics_test.go` (byte-indexed string), `google/client_test.go` (substring search), tests | 22 | stacked on #1075; not-obviously-safe sites documented in PR body |
+| 11 | next | `fmt.Sprintf` inside `slog` | `campminder/client.go:1008`, `sync/financial_transactions.go:106`, `sync/orchestrator.go:784,844` | 4 | — |
 | 12 | | `time.After` in retry loop | `sync/rate_limited_sheets_writer.go:194` | 1 | — |
 | 13 | | string error matching → sentinels | `sync/rate_limited_sheets_writer.go` (Google 429), `scheduler_test.go`, `workbook_manager_test.go`, `orchestrator_test.go` | 4 | behavioral |
 | 14 | | `testing/synctest` for time-based tests | `orchestrator_test.go`, `scheduler_test.go`, `rate_limited_sheets_writer_test.go`, `rbac/config_hooks_test.go` | 10+ sleeps | 1.25 GA shipped, toolchain is 1.26 — no longer gated |


### PR DESCRIPTION
## Summary

Update \`docs/reference/modernization-backlog.md\` §2c status column to reflect three in-flight Go modernization PRs and shift the \`next\` pointer to row #11.

| Row | Old status | New status |
|---|---|---|
| 8 | \`next\` | \`in flight #1074\` (log/slog consolidation) |
| 9 | (blank) | \`in flight #1075\` (manual chunkers → \`slices.Chunk\`) |
| 10 | (blank) | \`in flight #1076\` (\`for i := 0; …\` → \`for i := range\`) |
| 11 | (blank) | \`next\` (\`fmt.Sprintf\` inside \`slog\`) |

Also refines #10's "Where" column to reflect the actual converted sites after #9 absorbed the \`i += batchSize\` chunkers (count: 22, was 26).

Per \`modernization-prompts.md\` Part B step 6, statuses flip to \`✓ shipped #NNNN\` once each PR merges. Adding \`in flight\` upfront keeps the audit trail honest while the queue is in motion.

## Test plan
- [x] \`lefthook run pre-push\` — green
- [x] No real personal info in the diff (PII scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal modernization backlog with status changes for Go modernization initiatives, reflecting progress on consolidation and code rewrite efforts with refined scope and dependency tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->