### PR TITLE
fix(frontend): gate CSV pipeline indicator on actual upload context

### DIFF
--- a/frontend/src/components/BunkRequestsUpload.tsx
+++ b/frontend/src/components/BunkRequestsUpload.tsx
@@ -2,7 +2,7 @@ import { type ChangeEvent, useState, useRef } from 'react'
 import { Upload, Loader2, FileText, AlertCircle, CheckCircle } from 'lucide-react'
 import { useApiWithAuth } from '../hooks/useApiWithAuth'
 import { syncService, type UploadError } from '../services/sync'
-import { CSV_UPLOAD_STORAGE_KEY } from '../services/csvPipelineStatus'
+import { clearCsvUploadMarker, markCsvUploadStarted } from '../services/csvPipelineStatus'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import toast from 'react-hot-toast'
 import { useCurrentYear } from '../hooks/useCurrentYear'
@@ -26,7 +26,7 @@ export default function BunkRequestsUpload({ compact = false }: BunkRequestsUplo
       // Mark this browser session as having initiated a CSV upload so the
       // CsvPipelineIndicator can attribute the next bunk_requests sync to
       // the upload (rather than the nightly cron, which also runs that sync).
-      localStorage.setItem(CSV_UPLOAD_STORAGE_KEY, new Date().toISOString())
+      markCsvUploadStarted()
     },
     onSuccess: () => {
       toast.success(
@@ -45,7 +45,7 @@ export default function BunkRequestsUpload({ compact = false }: BunkRequestsUplo
     onError: (error: UploadError) => {
       // Upload failed before the sync could start — clear the marker so a
       // subsequent cron run isn't falsely attributed to this upload.
-      localStorage.removeItem(CSV_UPLOAD_STORAGE_KEY)
+      clearCsvUploadMarker()
       if (error.missing_columns) {
         toast.error(
           <div>

--- a/frontend/src/components/BunkRequestsUpload.tsx
+++ b/frontend/src/components/BunkRequestsUpload.tsx
@@ -2,6 +2,7 @@ import { type ChangeEvent, useState, useRef } from 'react'
 import { Upload, Loader2, FileText, AlertCircle, CheckCircle } from 'lucide-react'
 import { useApiWithAuth } from '../hooks/useApiWithAuth'
 import { syncService, type UploadError } from '../services/sync'
+import { CSV_UPLOAD_STORAGE_KEY } from '../services/csvPipelineStatus'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import toast from 'react-hot-toast'
 import { useCurrentYear } from '../hooks/useCurrentYear'
@@ -21,6 +22,12 @@ export default function BunkRequestsUpload({ compact = false }: BunkRequestsUplo
 
   const uploadMutation = useMutation({
     mutationFn: (file: File) => syncService.uploadBunkRequestsCSV(file, fetchWithAuth, currentYear),
+    onMutate: () => {
+      // Mark this browser session as having initiated a CSV upload so the
+      // CsvPipelineIndicator can attribute the next bunk_requests sync to
+      // the upload (rather than the nightly cron, which also runs that sync).
+      localStorage.setItem(CSV_UPLOAD_STORAGE_KEY, new Date().toISOString())
+    },
     onSuccess: () => {
       toast.success(
         "Importing CSV — this may take a few minutes. The icon next to the Upload Requests button will update when it's done.",
@@ -36,6 +43,9 @@ export default function BunkRequestsUpload({ compact = false }: BunkRequestsUplo
       void queryClient.invalidateQueries({ queryKey: queryKeys.csvPipelineStatus() })
     },
     onError: (error: UploadError) => {
+      // Upload failed before the sync could start — clear the marker so a
+      // subsequent cron run isn't falsely attributed to this upload.
+      localStorage.removeItem(CSV_UPLOAD_STORAGE_KEY)
       if (error.missing_columns) {
         toast.error(
           <div>

--- a/frontend/src/components/CsvPipelineIndicator.test.tsx
+++ b/frontend/src/components/CsvPipelineIndicator.test.tsx
@@ -71,13 +71,13 @@ describe('CsvPipelineIndicator', () => {
   it('renders importing label with spinner', () => {
     setData({ phase: 'importing', startedAt: new Date().toISOString() })
     render(<CsvPipelineIndicator />)
-    expect(screen.getByText(/Loading new or updated requests from CSV/i)).toBeInTheDocument()
+    expect(screen.getByText(/Importing CSV/i)).toBeInTheDocument()
   })
 
   it('renders matching label with spinner', () => {
     setData({ phase: 'matching', startedAt: new Date().toISOString() })
     render(<CsvPipelineIndicator />)
-    expect(screen.getByText(/Resolving camper names and calculating requests/i)).toBeInTheDocument()
+    expect(screen.getByText(/Matching CSV requests/i)).toBeInTheDocument()
   })
 
   it('renders done state with mapped counts', () => {

--- a/frontend/src/components/CsvPipelineIndicator.tsx
+++ b/frontend/src/components/CsvPipelineIndicator.tsx
@@ -56,24 +56,24 @@ export default function CsvPipelineIndicator() {
       <button
         type="button"
         onClick={() => setPopoverOpen((v) => !v)}
-        className="flex items-center gap-1.5 rounded px-2 py-1 text-sm hover:bg-gray-100"
+        className="flex items-center gap-1.5 rounded px-2 py-1 text-xs whitespace-nowrap hover:bg-gray-100"
         aria-label="CSV pipeline status"
       >
         {data.phase === 'importing' && (
           <>
-            <Loader2 className="h-4 w-4 animate-spin text-blue-600" aria-hidden="true" />
-            <span>Loading new or updated requests from CSV</span>
+            <Loader2 className="h-3 w-3 animate-spin text-blue-600" aria-hidden="true" />
+            <span>Importing CSV…</span>
           </>
         )}
         {data.phase === 'matching' && (
           <>
-            <Loader2 className="h-4 w-4 animate-spin text-blue-600" aria-hidden="true" />
-            <span>Resolving camper names and calculating requests</span>
+            <Loader2 className="h-3 w-3 animate-spin text-blue-600" aria-hidden="true" />
+            <span>Matching CSV requests…</span>
           </>
         )}
         {data.phase === 'done' && (
           <>
-            <CheckCircle className="h-4 w-4 text-green-600" aria-hidden="true" />
+            <CheckCircle className="h-3 w-3 text-green-600" aria-hidden="true" />
             <span>
               Done {formatTimestamp(data.finishedAt)}: {data.counts.total} new or updated requests,{' '}
               {data.counts.autoMatched} auto-matched
@@ -83,7 +83,7 @@ export default function CsvPipelineIndicator() {
         )}
         {data.phase === 'error' && (
           <>
-            <AlertCircle className="h-4 w-4 text-red-600" aria-hidden="true" />
+            <AlertCircle className="h-3 w-3 text-red-600" aria-hidden="true" />
             <span>Import failed. Click for details.</span>
           </>
         )}

--- a/frontend/src/hooks/useCsvPipelineStatus.test.tsx
+++ b/frontend/src/hooks/useCsvPipelineStatus.test.tsx
@@ -160,12 +160,45 @@ describe('useCsvPipelineStatus', () => {
   })
 
   it.each([
-    ['idle', false],
-    ['importing', 2000],
-    ['matching', 2000],
-    ['done', false],
-    ['error', false],
-  ] as const)('pollIntervalForPhase(%s) returns %s', (phase, expected) => {
+    ['idle (no marker)', 'idle', false],
+    ['importing', 'importing', 2000],
+    ['matching', 'matching', 2000],
+    ['done (marker irrelevant)', 'done', false],
+    ['error (marker irrelevant)', 'error', false],
+  ] as const)('pollIntervalForPhase(%s) returns %s', (_label, phase, expected) => {
     expect(pollIntervalForPhase(phase)).toBe(expected)
+  })
+
+  describe('pollIntervalForPhase with CSV upload marker', () => {
+    it('polls actively when phase is idle and a recent upload marker is present (sync not yet started)', () => {
+      localStorage.setItem(CSV_UPLOAD_STORAGE_KEY, new Date().toISOString())
+      expect(pollIntervalForPhase('idle')).toBe(2000)
+    })
+
+    it('continues polling between 5 and 10 minutes after upload (poll window matches proximity window)', () => {
+      // 7 min old marker — outside the old 5-min POST_UPLOAD_POLL_WINDOW_MS but
+      // inside the 10-min CSV_UPLOAD_PROXIMITY_MS. Polling should still be active
+      // so we don't miss a slow-starting backend sync that derivePhase would
+      // still attribute correctly.
+      const marker = new Date(Date.now() - 7 * 60_000).toISOString()
+      localStorage.setItem(CSV_UPLOAD_STORAGE_KEY, marker)
+      expect(pollIntervalForPhase('idle')).toBe(2000)
+    })
+
+    it('stops polling once the upload marker exceeds the proximity window', () => {
+      const marker = new Date(Date.now() - 11 * 60_000).toISOString()
+      localStorage.setItem(CSV_UPLOAD_STORAGE_KEY, marker)
+      expect(pollIntervalForPhase('idle')).toBe(false)
+    })
+
+    it('does not poll on done even with a recent marker (avoids wasted polling after success)', () => {
+      localStorage.setItem(CSV_UPLOAD_STORAGE_KEY, new Date().toISOString())
+      expect(pollIntervalForPhase('done')).toBe(false)
+    })
+
+    it('does not poll on error even with a recent marker', () => {
+      localStorage.setItem(CSV_UPLOAD_STORAGE_KEY, new Date().toISOString())
+      expect(pollIntervalForPhase('error')).toBe(false)
+    })
   })
 })

--- a/frontend/src/hooks/useCsvPipelineStatus.test.tsx
+++ b/frontend/src/hooks/useCsvPipelineStatus.test.tsx
@@ -3,6 +3,7 @@ import { renderHook, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 import { useCsvPipelineStatus, pollIntervalForPhase } from './useCsvPipelineStatus'
+import { CSV_UPLOAD_STORAGE_KEY } from '../services/csvPipelineStatus'
 
 vi.mock('./useApiWithAuth', () => ({
   useApiWithAuth: () => ({
@@ -22,6 +23,17 @@ function makeWrapper() {
 beforeEach(() => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(globalThis as any).__mockFetch = undefined
+  // The global setup file mocks localStorage with vi.fn() that returns undefined.
+  // Override with a functional in-memory store for this suite so the CSV upload
+  // marker round-trips correctly.
+  const store = new Map<string, string>()
+  vi.mocked(localStorage.getItem).mockImplementation((k: string) => store.get(k) ?? null)
+  vi.mocked(localStorage.setItem).mockImplementation((k: string, v: string) => {
+    store.set(k, v)
+  })
+  vi.mocked(localStorage.removeItem).mockImplementation((k: string) => {
+    store.delete(k)
+  })
 })
 
 describe('useCsvPipelineStatus', () => {
@@ -37,8 +49,9 @@ describe('useCsvPipelineStatus', () => {
     await waitFor(() => expect(result.current.data?.phase).toBe('idle'))
   })
 
-  it('returns importing phase when bunk_requests is running', async () => {
+  it('returns importing phase when bunk_requests is running and CSV upload context exists', async () => {
     const startedAt = new Date().toISOString()
+    localStorage.setItem(CSV_UPLOAD_STORAGE_KEY, startedAt)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(globalThis as any).__mockFetch = vi.fn(async (url: string) => {
       if (url.includes('sync/status')) {
@@ -55,10 +68,29 @@ describe('useCsvPipelineStatus', () => {
     await waitFor(() => expect(result.current.data?.phase).toBe('importing'))
   })
 
-  it('returns done phase with mapped counts when fresh debug row exists', async () => {
+  it('returns idle when bunk_requests is running but no CSV upload context (cron)', async () => {
+    const startedAt = new Date().toISOString()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(globalThis as any).__mockFetch = vi.fn(async (url: string) => {
+      if (url.includes('sync/status')) {
+        return {
+          ok: true,
+          json: async () => ({
+            bunk_requests: { type: 'bunk_requests', status: 'running', start_time: startedAt },
+          }),
+        } as Response
+      }
+      return { ok: true, json: async () => ({ items: [] }) } as Response
+    })
+    const { result } = renderHook(() => useCsvPipelineStatus(), { wrapper: makeWrapper() })
+    await waitFor(() => expect(result.current.data?.phase).toBe('idle'))
+  })
+
+  it('returns done phase with mapped counts when fresh debug row exists and CSV context present', async () => {
     const startedAt = new Date(Date.now() - 5 * 60_000).toISOString()
     const finishedAt = new Date(Date.now() - 3 * 60_000).toISOString()
     const debugCreated = new Date(Date.now() - 1 * 60_000).toISOString()
+    localStorage.setItem(CSV_UPLOAD_STORAGE_KEY, startedAt)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(globalThis as any).__mockFetch = vi.fn(async (url: string) => {
       if (url.includes('sync/status')) {
@@ -102,9 +134,10 @@ describe('useCsvPipelineStatus', () => {
     await waitFor(() => expect(result.current.isError).toBe(true))
   })
 
-  it('still derives phase from sync when debug fetch fails', async () => {
+  it('still derives phase from sync when debug fetch fails (with CSV context)', async () => {
     const startedAt = new Date(Date.now() - 5 * 60_000).toISOString()
     const finishedAt = new Date(Date.now() - 3 * 60_000).toISOString()
+    localStorage.setItem(CSV_UPLOAD_STORAGE_KEY, startedAt)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(globalThis as any).__mockFetch = vi.fn(async (url: string) => {
       if (url.includes('sync/status')) {

--- a/frontend/src/hooks/useCsvPipelineStatus.ts
+++ b/frontend/src/hooks/useCsvPipelineStatus.ts
@@ -2,21 +2,16 @@ import { useQuery } from '@tanstack/react-query'
 import { useApiWithAuth } from './useApiWithAuth'
 import {
   CSV_UPLOAD_PROXIMITY_MS,
-  CSV_UPLOAD_STORAGE_KEY,
   derivePhase,
   fetchLatestDebugRun,
   fetchSyncStatus,
+  readCsvUploadMarker,
   type PipelinePhase,
 } from '../services/csvPipelineStatus'
 import { queryKeys } from '../utils/queryKeys'
 
 const ACTIVE_POLL_MS = 2000
 const STALE_TIME_MS = 1500
-
-function readCsvUploadMarker(): string | null {
-  if (typeof localStorage === 'undefined') return null
-  return localStorage.getItem(CSV_UPLOAD_STORAGE_KEY)
-}
 
 // Marker is "recent" while it is still within the attribution proximity window.
 // Sharing the same constant as derivePhase prevents the poll window and the

--- a/frontend/src/hooks/useCsvPipelineStatus.ts
+++ b/frontend/src/hooks/useCsvPipelineStatus.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useApiWithAuth } from './useApiWithAuth'
 import {
+  CSV_UPLOAD_STORAGE_KEY,
   derivePhase,
   fetchLatestDebugRun,
   fetchSyncStatus,
@@ -11,8 +12,26 @@ import { queryKeys } from '../utils/queryKeys'
 const ACTIVE_POLL_MS = 2000
 const STALE_TIME_MS = 1500
 
+// Poll briefly after a CSV upload even if the derived phase is still 'idle'
+// (e.g. backend hasn't started the sync yet) so we don't miss the transition.
+const POST_UPLOAD_POLL_WINDOW_MS = 5 * 60_000
+
+function readCsvUploadMarker(): string | null {
+  if (typeof localStorage === 'undefined') return null
+  return localStorage.getItem(CSV_UPLOAD_STORAGE_KEY)
+}
+
+function uploadMarkerIsRecent(marker: string | null): boolean {
+  if (!marker) return false
+  const ts = new Date(marker).getTime()
+  if (Number.isNaN(ts)) return false
+  return Date.now() - ts < POST_UPLOAD_POLL_WINDOW_MS
+}
+
 export function pollIntervalForPhase(phase: PipelinePhase['phase'] | undefined): number | false {
-  return phase === 'importing' || phase === 'matching' ? ACTIVE_POLL_MS : false
+  if (phase === 'importing' || phase === 'matching') return ACTIVE_POLL_MS
+  if (uploadMarkerIsRecent(readCsvUploadMarker())) return ACTIVE_POLL_MS
+  return false
 }
 
 export function useCsvPipelineStatus() {
@@ -27,7 +46,7 @@ export function useCsvPipelineStatus() {
       ])
       if (syncResult.status === 'rejected') throw syncResult.reason
       const debug = debugResult.status === 'fulfilled' ? debugResult.value : null
-      return derivePhase(syncResult.value, debug)
+      return derivePhase(syncResult.value, debug, readCsvUploadMarker())
     },
     refetchInterval: (q) => pollIntervalForPhase(q.state.data?.phase),
     staleTime: STALE_TIME_MS,

--- a/frontend/src/hooks/useCsvPipelineStatus.ts
+++ b/frontend/src/hooks/useCsvPipelineStatus.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useApiWithAuth } from './useApiWithAuth'
 import {
+  CSV_UPLOAD_PROXIMITY_MS,
   CSV_UPLOAD_STORAGE_KEY,
   derivePhase,
   fetchLatestDebugRun,
@@ -12,25 +13,27 @@ import { queryKeys } from '../utils/queryKeys'
 const ACTIVE_POLL_MS = 2000
 const STALE_TIME_MS = 1500
 
-// Poll briefly after a CSV upload even if the derived phase is still 'idle'
-// (e.g. backend hasn't started the sync yet) so we don't miss the transition.
-const POST_UPLOAD_POLL_WINDOW_MS = 5 * 60_000
-
 function readCsvUploadMarker(): string | null {
   if (typeof localStorage === 'undefined') return null
   return localStorage.getItem(CSV_UPLOAD_STORAGE_KEY)
 }
 
+// Marker is "recent" while it is still within the attribution proximity window.
+// Sharing the same constant as derivePhase prevents the poll window and the
+// attribution window from drifting apart.
 function uploadMarkerIsRecent(marker: string | null): boolean {
   if (!marker) return false
   const ts = new Date(marker).getTime()
   if (Number.isNaN(ts)) return false
-  return Date.now() - ts < POST_UPLOAD_POLL_WINDOW_MS
+  return Date.now() - ts < CSV_UPLOAD_PROXIMITY_MS
 }
 
 export function pollIntervalForPhase(phase: PipelinePhase['phase'] | undefined): number | false {
   if (phase === 'importing' || phase === 'matching') return ACTIVE_POLL_MS
-  if (uploadMarkerIsRecent(readCsvUploadMarker())) return ACTIVE_POLL_MS
+  // Only poll on idle (waiting for the sync to start). Done/error are terminal —
+  // continued polling there would burn requests for no benefit and could
+  // re-attribute a later cron sync to a stale marker.
+  if (phase === 'idle' && uploadMarkerIsRecent(readCsvUploadMarker())) return ACTIVE_POLL_MS
   return false
 }
 

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -711,7 +711,7 @@ export const AppLayout = () => {
                   <div className="text-muted-foreground flex items-center gap-3 text-xs">
                     {syncStatus.bunk_assignments?.end_time && (
                       <span
-                        className="flex items-center gap-1.5"
+                        className="flex items-center gap-1.5 whitespace-nowrap"
                         title={buildSyncTooltip('bunk assignments', syncStatus.bunk_assignments)}
                       >
                         <Home className="h-3 w-3" />
@@ -723,7 +723,7 @@ export const AppLayout = () => {
                     )}
                     {syncStatus.bunk_requests?.end_time && (
                       <span
-                        className="flex items-center gap-1.5"
+                        className="flex items-center gap-1.5 whitespace-nowrap"
                         title={buildSyncTooltip('bunk requests', syncStatus.bunk_requests)}
                       >
                         <Clock className="h-3 w-3" />

--- a/frontend/src/services/csvPipelineStatus.test.ts
+++ b/frontend/src/services/csvPipelineStatus.test.ts
@@ -11,170 +11,265 @@ const ago = (mins: number) => new Date(Date.now() - mins * 60_000).toISOString()
 
 describe('derivePhase', () => {
   it('returns idle when nothing has ever run', () => {
-    expect(derivePhase(null, null)).toEqual({ phase: 'idle' })
+    expect(derivePhase(null, null, null)).toEqual({ phase: 'idle' })
   })
 
-  it('returns importing when bunk_requests sync is running', () => {
-    const sync: SyncJobStatus = { name: 'bunk_requests', status: 'running', startedAt: ago(1) }
-    expect(derivePhase(sync, null).phase).toBe('importing')
-  })
+  describe('CSV upload gating', () => {
+    it('returns idle for a running sync when no CSV upload context exists (nightly cron)', () => {
+      const sync: SyncJobStatus = { name: 'bunk_requests', status: 'running', startedAt: ago(1) }
+      expect(derivePhase(sync, null, null).phase).toBe('idle')
+    })
 
-  it('returns matching when sync completed but no debug row yet', () => {
-    const sync: SyncJobStatus = {
-      name: 'bunk_requests',
-      status: 'completed',
-      startedAt: ago(5),
-      finishedAt: ago(2),
-    }
-    expect(derivePhase(sync, null).phase).toBe('matching')
-  })
+    it('returns idle for a completed sync with no debug row when no CSV upload context (nightly cron)', () => {
+      const sync: SyncJobStatus = {
+        name: 'bunk_requests',
+        status: 'completed',
+        startedAt: ago(5),
+        finishedAt: ago(2),
+      }
+      expect(derivePhase(sync, null, null).phase).toBe('idle')
+    })
 
-  it('returns matching when debug row exists but is older than current sync', () => {
-    const sync: SyncJobStatus = {
-      name: 'bunk_requests',
-      status: 'completed',
-      startedAt: ago(5),
-      finishedAt: ago(2),
-    }
-    const stale: DebugPipelineRun = {
-      run_id: 'old',
-      created: ago(60),
-      status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
-    }
-    expect(derivePhase(sync, stale).phase).toBe('matching')
-  })
+    it('returns idle when CSV upload is too far from sync.startedAt (> 10 min apart)', () => {
+      const sync: SyncJobStatus = {
+        name: 'bunk_requests',
+        status: 'completed',
+        startedAt: ago(2),
+        finishedAt: ago(1),
+      }
+      const csvUploadStartedAt = ago(30) // upload was 28 min before sync started
+      expect(derivePhase(sync, null, csvUploadStartedAt).phase).toBe('idle')
+    })
 
-  it('returns done with counts when fresh debug row exists', () => {
-    const sync: SyncJobStatus = {
-      name: 'bunk_requests',
-      status: 'completed',
-      startedAt: ago(5),
-      finishedAt: ago(3),
-    }
-    const fresh: DebugPipelineRun = {
-      run_id: 'r1',
-      created: ago(1),
-      status_breakdown: { status_resolved: 20, status_pending: 6, status_declined: 2 },
-    }
-    const result = derivePhase(sync, fresh)
-    expect(result.phase).toBe('done')
-    expect(result).toMatchObject({
-      counts: { total: 28, autoMatched: 22, needReview: 6 },
-      runId: 'r1',
+    it('returns idle for a completed cron sync with a fresh debug row but no CSV upload context', () => {
+      // Cron also runs process_requests in IS_DOCKER, which writes a debug row.
+      // Without a CSV upload from this browser, the user shouldn't see "Done at 3am" notifications.
+      const sync: SyncJobStatus = {
+        name: 'bunk_requests',
+        status: 'completed',
+        startedAt: ago(5),
+        finishedAt: ago(3),
+      }
+      const fresh: DebugPipelineRun = {
+        run_id: 'r-cron',
+        created: ago(1),
+        status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
+      }
+      expect(derivePhase(sync, fresh, null).phase).toBe('idle')
+    })
+
+    it('returns idle for a failed sync with no CSV upload context (cron failure invisible to user)', () => {
+      const sync: SyncJobStatus = {
+        name: 'bunk_requests',
+        status: 'failed',
+        startedAt: ago(60),
+        finishedAt: ago(40),
+        error: 'context deadline exceeded',
+      }
+      expect(derivePhase(sync, null, null).phase).toBe('idle')
     })
   })
 
-  it('returns error on failed sync with no orphan grace recovery', () => {
-    const sync: SyncJobStatus = {
-      name: 'bunk_requests',
-      status: 'failed',
-      startedAt: ago(60),
-      finishedAt: ago(40),
-      error: 'context deadline exceeded',
-    }
-    expect(derivePhase(sync, null).phase).toBe('error')
+  describe('CSV upload flow phases', () => {
+    it('returns importing when sync is running and CSV upload context exists', () => {
+      const startedAt = ago(1)
+      const sync: SyncJobStatus = { name: 'bunk_requests', status: 'running', startedAt }
+      const csvUploadStartedAt = ago(2) // upload kicked off the sync 1 min before it started
+      expect(derivePhase(sync, null, csvUploadStartedAt).phase).toBe('importing')
+    })
+
+    it('returns matching when sync completed but no debug row yet, with CSV context', () => {
+      const sync: SyncJobStatus = {
+        name: 'bunk_requests',
+        status: 'completed',
+        startedAt: ago(5),
+        finishedAt: ago(2),
+      }
+      const csvUploadStartedAt = ago(6)
+      expect(derivePhase(sync, null, csvUploadStartedAt).phase).toBe('matching')
+    })
+
+    it('returns matching when debug row exists but is older than current sync, with CSV context', () => {
+      const sync: SyncJobStatus = {
+        name: 'bunk_requests',
+        status: 'completed',
+        startedAt: ago(5),
+        finishedAt: ago(2),
+      }
+      const stale: DebugPipelineRun = {
+        run_id: 'old',
+        created: ago(60),
+        status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
+      }
+      const csvUploadStartedAt = ago(6)
+      expect(derivePhase(sync, stale, csvUploadStartedAt).phase).toBe('matching')
+    })
+
+    it('returns done with counts when fresh debug row exists, with CSV context', () => {
+      const sync: SyncJobStatus = {
+        name: 'bunk_requests',
+        status: 'completed',
+        startedAt: ago(5),
+        finishedAt: ago(3),
+      }
+      const fresh: DebugPipelineRun = {
+        run_id: 'r1',
+        created: ago(1),
+        status_breakdown: { status_resolved: 20, status_pending: 6, status_declined: 2 },
+      }
+      const csvUploadStartedAt = ago(6)
+      const result = derivePhase(sync, fresh, csvUploadStartedAt)
+      expect(result.phase).toBe('done')
+      expect(result).toMatchObject({
+        counts: { total: 28, autoMatched: 22, needReview: 6 },
+        runId: 'r1',
+      })
+    })
+
+    it('returns error on failed sync when CSV context exists', () => {
+      const sync: SyncJobStatus = {
+        name: 'bunk_requests',
+        status: 'failed',
+        startedAt: ago(8),
+        finishedAt: ago(2),
+        error: 'context deadline exceeded',
+      }
+      const csvUploadStartedAt = ago(9)
+      expect(derivePhase(sync, null, csvUploadStartedAt).phase).toBe('error')
+    })
+
+    it('keeps error when debug row predates finishedAt (negative grace delta is rejected)', () => {
+      const sync: SyncJobStatus = {
+        name: 'bunk_requests',
+        status: 'failed',
+        startedAt: ago(60),
+        finishedAt: ago(40),
+        error: 'context deadline exceeded',
+      }
+      const stale: DebugPipelineRun = {
+        run_id: 'r-stale',
+        created: ago(50),
+        status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
+      }
+      const csvUploadStartedAt = ago(61)
+      expect(derivePhase(sync, stale, csvUploadStartedAt).phase).toBe('error')
+    })
+
+    it('keeps error when debug row is outside the 30-min grace window', () => {
+      const sync: SyncJobStatus = {
+        name: 'bunk_requests',
+        status: 'failed',
+        startedAt: ago(120),
+        finishedAt: ago(100),
+        error: 'context deadline exceeded',
+      }
+      const tooLate: DebugPipelineRun = {
+        run_id: 'r3',
+        created: ago(50),
+        status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
+      }
+      const csvUploadStartedAt = ago(121)
+      expect(derivePhase(sync, tooLate, csvUploadStartedAt).phase).toBe('error')
+    })
+
+    it('treats exactly 30-min delta as done (inclusive boundary)', () => {
+      const sync: SyncJobStatus = {
+        name: 'bunk_requests',
+        status: 'failed',
+        startedAt: ago(90),
+        finishedAt: ago(60),
+        error: 'context deadline exceeded',
+      }
+      const debug: DebugPipelineRun = {
+        run_id: 'r-boundary',
+        created: ago(30),
+        status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
+      }
+      const csvUploadStartedAt = ago(91)
+      expect(derivePhase(sync, debug, csvUploadStartedAt).phase).toBe('done')
+    })
+
+    it('treats just past 30-min delta as error (exclusive past boundary)', () => {
+      const sync: SyncJobStatus = {
+        name: 'bunk_requests',
+        status: 'failed',
+        startedAt: ago(90),
+        finishedAt: ago(60),
+        error: 'context deadline exceeded',
+      }
+      const debug: DebugPipelineRun = {
+        run_id: 'r-just-past',
+        created: new Date(Date.now() - 29.99 * 60_000).toISOString(),
+        status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
+      }
+      const csvUploadStartedAt = ago(91)
+      expect(derivePhase(sync, debug, csvUploadStartedAt).phase).toBe('error')
+    })
+
+    it('recovers as done when orphan python finishes within 30-min grace window', () => {
+      const sync: SyncJobStatus = {
+        name: 'bunk_requests',
+        status: 'failed',
+        startedAt: ago(60),
+        finishedAt: ago(40),
+        error: 'context deadline exceeded',
+      }
+      const orphan: DebugPipelineRun = {
+        run_id: 'r2',
+        created: ago(20),
+        status_breakdown: { status_resolved: 5, status_pending: 1, status_declined: 0 },
+      }
+      // Long-running uploads can outlast the upload marker — proximity is checked, but
+      // orphan grace recovery is itself evidence the upload's matching ran. Pass a
+      // CSV upload context near startedAt to satisfy gating.
+      const csvUploadStartedAt = ago(61)
+      expect(derivePhase(sync, orphan, csvUploadStartedAt).phase).toBe('done')
+    })
+
+    it('handles all-zeros (csv-history dedup re-upload) as done', () => {
+      const sync: SyncJobStatus = {
+        name: 'bunk_requests',
+        status: 'completed',
+        startedAt: ago(2),
+        finishedAt: ago(1),
+      }
+      const dedup: DebugPipelineRun = {
+        run_id: 'r4',
+        created: ago(0.5),
+        status_breakdown: { status_resolved: 0, status_pending: 0, status_declined: 0 },
+      }
+      const csvUploadStartedAt = ago(3)
+      const result = derivePhase(sync, dedup, csvUploadStartedAt)
+      expect(result.phase).toBe('done')
+      expect(result).toMatchObject({ counts: { total: 0, autoMatched: 0, needReview: 0 } })
+    })
   })
 
-  it('recovers as done when orphan python finishes within 30-min grace window', () => {
-    const sync: SyncJobStatus = {
-      name: 'bunk_requests',
-      status: 'failed',
-      startedAt: ago(60),
-      finishedAt: ago(40),
-      error: 'context deadline exceeded',
-    }
-    const orphan: DebugPipelineRun = {
-      run_id: 'r2',
-      created: ago(20),
-      status_breakdown: { status_resolved: 5, status_pending: 1, status_declined: 0 },
-    }
-    expect(derivePhase(sync, orphan).phase).toBe('done')
-  })
+  describe('stuck-matching safety net', () => {
+    it('transitions matching to error when sync finished long ago and no debug row arrived', () => {
+      // Sync finished 15 min ago with CSV context, but matching never wrote a debug row.
+      // Without this safety net, the indicator would spin forever.
+      const sync: SyncJobStatus = {
+        name: 'bunk_requests',
+        status: 'completed',
+        startedAt: ago(20),
+        finishedAt: ago(15),
+      }
+      const csvUploadStartedAt = ago(21)
+      const result = derivePhase(sync, null, csvUploadStartedAt)
+      expect(result.phase).toBe('error')
+    })
 
-  it('keeps error when debug row predates finishedAt (negative grace delta is rejected)', () => {
-    // Sync started 60 min ago, debug created at 50 min ago, sync finished 40 min ago.
-    // debugIsFresh is true (debug.created >= startedAt) but debug.created < finishedAt,
-    // so delta is negative — must NOT be treated as orphan recovery.
-    const sync: SyncJobStatus = {
-      name: 'bunk_requests',
-      status: 'failed',
-      startedAt: ago(60),
-      finishedAt: ago(40),
-      error: 'context deadline exceeded',
-    }
-    const stale: DebugPipelineRun = {
-      run_id: 'r-stale',
-      created: ago(50),
-      status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
-    }
-    expect(derivePhase(sync, stale).phase).toBe('error')
-  })
-
-  it('keeps error when debug row is outside the 30-min grace window', () => {
-    const sync: SyncJobStatus = {
-      name: 'bunk_requests',
-      status: 'failed',
-      startedAt: ago(120),
-      finishedAt: ago(100),
-      error: 'context deadline exceeded',
-    }
-    const tooLate: DebugPipelineRun = {
-      run_id: 'r3',
-      created: ago(50),
-      status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
-    }
-    expect(derivePhase(sync, tooLate).phase).toBe('error')
-  })
-
-  it('treats exactly 30-min delta as done (inclusive boundary)', () => {
-    // finishedAt 60 min ago, debug created 30 min ago → delta = 30 min
-    const sync: SyncJobStatus = {
-      name: 'bunk_requests',
-      status: 'failed',
-      startedAt: ago(90),
-      finishedAt: ago(60),
-      error: 'context deadline exceeded',
-    }
-    const debug: DebugPipelineRun = {
-      run_id: 'r-boundary',
-      created: ago(30),
-      status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
-    }
-    expect(derivePhase(sync, debug).phase).toBe('done')
-  })
-
-  it('treats just past 30-min delta as error (exclusive past boundary)', () => {
-    // finishedAt 60 min ago, debug created 29.99 min ago → delta = 30.01 min
-    const sync: SyncJobStatus = {
-      name: 'bunk_requests',
-      status: 'failed',
-      startedAt: ago(90),
-      finishedAt: ago(60),
-      error: 'context deadline exceeded',
-    }
-    const debug: DebugPipelineRun = {
-      run_id: 'r-just-past',
-      created: new Date(Date.now() - 29.99 * 60_000).toISOString(),
-      status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
-    }
-    expect(derivePhase(sync, debug).phase).toBe('error')
-  })
-
-  it('handles all-zeros (csv-history dedup re-upload) as done', () => {
-    const sync: SyncJobStatus = {
-      name: 'bunk_requests',
-      status: 'completed',
-      startedAt: ago(2),
-      finishedAt: ago(1),
-    }
-    const dedup: DebugPipelineRun = {
-      run_id: 'r4',
-      created: ago(0.5),
-      status_breakdown: { status_resolved: 0, status_pending: 0, status_declined: 0 },
-    }
-    const result = derivePhase(sync, dedup)
-    expect(result.phase).toBe('done')
-    expect(result).toMatchObject({ counts: { total: 0, autoMatched: 0, needReview: 0 } })
+    it('keeps matching when sync finished within MATCHING_MAX_AGE_MS', () => {
+      const sync: SyncJobStatus = {
+        name: 'bunk_requests',
+        status: 'completed',
+        startedAt: ago(5),
+        finishedAt: ago(2),
+      }
+      const csvUploadStartedAt = ago(6)
+      expect(derivePhase(sync, null, csvUploadStartedAt).phase).toBe('matching')
+    })
   })
 })
 

--- a/frontend/src/services/csvPipelineStatus.test.ts
+++ b/frontend/src/services/csvPipelineStatus.test.ts
@@ -41,6 +41,66 @@ describe('derivePhase', () => {
       expect(derivePhase(sync, null, csvUploadStartedAt).phase).toBe('idle')
     })
 
+    it('returns idle when sync started well BEFORE the upload (cron mid-flight, then user uploads)', () => {
+      // A cron sync started 8 minutes ago. User uploads 1 minute ago. With a
+      // symmetric Math.abs check, the cron's running state would be incorrectly
+      // attributed to the upload — exactly the bug in the inverted-time
+      // direction. Direction matters: only syncs at-or-after the upload count.
+      const sync: SyncJobStatus = {
+        name: 'bunk_requests',
+        status: 'running',
+        startedAt: ago(8),
+      }
+      const csvUploadStartedAt = ago(1)
+      expect(derivePhase(sync, null, csvUploadStartedAt).phase).toBe('idle')
+    })
+
+    it('returns idle when a cron sync completed shortly before the upload', () => {
+      // Cron at 02:00, user uploads at 02:05. The cron's `done` state must NOT
+      // be displayed as the user's upload result.
+      const sync: SyncJobStatus = {
+        name: 'bunk_requests',
+        status: 'completed',
+        startedAt: ago(8),
+        finishedAt: ago(6),
+      }
+      const fresh: DebugPipelineRun = {
+        run_id: 'r-cron-recent',
+        created: ago(5),
+        status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
+      }
+      const csvUploadStartedAt = ago(2)
+      expect(derivePhase(sync, fresh, csvUploadStartedAt).phase).toBe('idle')
+    })
+  })
+
+  describe('clock skew tolerance', () => {
+    it('attributes a sync that started slightly before the upload (small client/server clock skew)', () => {
+      // Client clock is ~30 seconds ahead of server. The upload marker says
+      // T+30s but the server-recorded sync.startedAt says T+0. Within bounded
+      // skew tolerance, attribute the sync.
+      const now = Date.now()
+      const sync: SyncJobStatus = {
+        name: 'bunk_requests',
+        status: 'running',
+        startedAt: new Date(now).toISOString(),
+      }
+      const csvUploadStartedAt = new Date(now + 30_000).toISOString()
+      expect(derivePhase(sync, null, csvUploadStartedAt).phase).toBe('importing')
+    })
+
+    it('rejects a sync that started well before the upload, beyond skew tolerance', () => {
+      // Sync started 5 min before the upload — beyond reasonable clock skew,
+      // indicating a pre-existing cron run rather than this user's upload.
+      const sync: SyncJobStatus = {
+        name: 'bunk_requests',
+        status: 'running',
+        startedAt: ago(7),
+      }
+      const csvUploadStartedAt = ago(2)
+      expect(derivePhase(sync, null, csvUploadStartedAt).phase).toBe('idle')
+    })
+
     it('returns idle for a completed cron sync with a fresh debug row but no CSV upload context', () => {
       // Cron also runs process_requests in IS_DOCKER, which writes a debug row.
       // Without a CSV upload from this browser, the user shouldn't see "Done at 3am" notifications.

--- a/frontend/src/services/csvPipelineStatus.ts
+++ b/frontend/src/services/csvPipelineStatus.ts
@@ -32,7 +32,13 @@ const GRACE_WINDOW_MS = 30 * 60_000
 
 // CSV upload marker must be within this window of the sync's startedAt for the
 // indicator to attribute the sync to a CSV upload (vs a nightly cron run).
-const CSV_UPLOAD_PROXIMITY_MS = 10 * 60_000
+export const CSV_UPLOAD_PROXIMITY_MS = 10 * 60_000
+
+// csvUploadStartedAt is a client-clock timestamp; sync.startedAt is a server-
+// clock timestamp. Tolerate small skew (typical NTP drift) when comparing them
+// while still rejecting pre-existing cron syncs that started well before the
+// upload.
+const CLOCK_SKEW_TOLERANCE_MS = 2 * 60_000
 
 // Safety net: if a sync completed but no debug pipeline row arrives within this
 // window, the matching step is presumed crashed/short-circuited rather than
@@ -46,7 +52,11 @@ function isSyncFromCsvUpload(syncStartedAt: string, csvUploadStartedAt: string |
   const csvAt = new Date(csvUploadStartedAt).getTime()
   const syncAt = new Date(syncStartedAt).getTime()
   if (Number.isNaN(csvAt) || Number.isNaN(syncAt)) return false
-  return Math.abs(syncAt - csvAt) <= CSV_UPLOAD_PROXIMITY_MS
+  // Sync must have started at or after the upload (allowing for bounded clock
+  // skew). A pre-existing cron sync that started >tolerance before the upload
+  // is rejected even if it falls within the proximity window.
+  const delta = syncAt - csvAt
+  return delta >= -CLOCK_SKEW_TOLERANCE_MS && delta <= CSV_UPLOAD_PROXIMITY_MS
 }
 
 export function derivePhase(

--- a/frontend/src/services/csvPipelineStatus.ts
+++ b/frontend/src/services/csvPipelineStatus.ts
@@ -30,11 +30,38 @@ export type PipelinePhase =
 
 const GRACE_WINDOW_MS = 30 * 60_000
 
+// CSV upload marker must be within this window of the sync's startedAt for the
+// indicator to attribute the sync to a CSV upload (vs a nightly cron run).
+const CSV_UPLOAD_PROXIMITY_MS = 10 * 60_000
+
+// Safety net: if a sync completed but no debug pipeline row arrives within this
+// window, the matching step is presumed crashed/short-circuited rather than
+// still running. Surface as error instead of spinning forever.
+const MATCHING_MAX_AGE_MS = 10 * 60_000
+
+export const CSV_UPLOAD_STORAGE_KEY = 'csvUploadStartedAt'
+
+function isSyncFromCsvUpload(syncStartedAt: string, csvUploadStartedAt: string | null): boolean {
+  if (!csvUploadStartedAt) return false
+  const csvAt = new Date(csvUploadStartedAt).getTime()
+  const syncAt = new Date(syncStartedAt).getTime()
+  if (Number.isNaN(csvAt) || Number.isNaN(syncAt)) return false
+  return Math.abs(syncAt - csvAt) <= CSV_UPLOAD_PROXIMITY_MS
+}
+
 export function derivePhase(
   sync: SyncJobStatus | null,
-  debug: DebugPipelineRun | null
+  debug: DebugPipelineRun | null,
+  csvUploadStartedAt: string | null
 ): PipelinePhase {
   if (!sync) return { phase: 'idle' }
+
+  // Gate every non-idle phase on evidence the sync was triggered by a CSV upload
+  // from this browser. Nightly cron also runs `bunk_requests`, but the indicator
+  // is a CSV-pipeline UI — surfacing cron progress/results here is wrong.
+  if (!isSyncFromCsvUpload(sync.startedAt, csvUploadStartedAt)) {
+    return { phase: 'idle' }
+  }
 
   const debugIsFresh =
     debug !== null && new Date(debug.created).getTime() >= new Date(sync.startedAt).getTime()
@@ -43,6 +70,21 @@ export function derivePhase(
 
   if (sync.status === 'completed') {
     if (debugIsFresh && debug) return doneFromDebug(debug)
+
+    // No debug row yet. If matching has been pending too long, the trace
+    // collector likely never wrote a row (empty traces, crash, or processor
+    // never ran). Fall through to error rather than spin forever.
+    const finishedMs = sync.finishedAt
+      ? new Date(sync.finishedAt).getTime()
+      : new Date(sync.startedAt).getTime()
+    if (Date.now() - finishedMs > MATCHING_MAX_AGE_MS) {
+      return {
+        phase: 'error',
+        finishedAt: sync.finishedAt ?? sync.startedAt,
+        message: 'Matching step did not complete — check server logs',
+      }
+    }
+
     return { phase: 'matching', startedAt: sync.startedAt }
   }
 

--- a/frontend/src/services/csvPipelineStatus.ts
+++ b/frontend/src/services/csvPipelineStatus.ts
@@ -47,6 +47,21 @@ const MATCHING_MAX_AGE_MS = 10 * 60_000
 
 export const CSV_UPLOAD_STORAGE_KEY = 'csvUploadStartedAt'
 
+export function markCsvUploadStarted(): void {
+  if (typeof localStorage === 'undefined') return
+  localStorage.setItem(CSV_UPLOAD_STORAGE_KEY, new Date().toISOString())
+}
+
+export function clearCsvUploadMarker(): void {
+  if (typeof localStorage === 'undefined') return
+  localStorage.removeItem(CSV_UPLOAD_STORAGE_KEY)
+}
+
+export function readCsvUploadMarker(): string | null {
+  if (typeof localStorage === 'undefined') return null
+  return localStorage.getItem(CSV_UPLOAD_STORAGE_KEY)
+}
+
 function isSyncFromCsvUpload(syncStartedAt: string, csvUploadStartedAt: string | null): boolean {
   if (!csvUploadStartedAt) return false
   const csvAt = new Date(csvUploadStartedAt).getTime()


### PR DESCRIPTION
## Summary

Closes #1085. The CSV pipeline indicator was stuck on **"Resolving camper names and calculating requests"** after every nightly `bunk_requests` cron run, with the long copy also pushing the "Assignments synced / Requests synced" badges onto two lines and rendering at the wrong font size.

### Root cause

`derivePhase()` treated any completed `bunk_requests` sync without a fresh `debug_pipeline_runs` row as "matching in progress." The nightly cron runs that sync on its own — no CSV import, no matching/processor step that writes a debug row — so the indicator polled forever for a row that never arrives. The same shape applied to imports where matching crashed or short-circuited (empty traces never get flushed).

### Fix

- **Gate every non-idle phase on a CSV upload context.** `BunkRequestsUpload` writes a localStorage marker (`csvUploadStartedAt`) in `onMutate` before the upload fetch starts, clears it on `onError`. The hook reads the marker and passes it to `derivePhase`, which only attributes a sync to a CSV upload when the marker is within 10 min of `sync.startedAt`. Cron `bunk_requests` runs are now invisible to the indicator.
- **Stuck-matching safety net.** If a CSV-upload-triggered sync finishes but no debug row arrives within 10 min, surface as `error` rather than spin indefinitely.
- **UI cleanup.** Indicator copy is now `text-xs` (was `text-sm`) to match the secondary nav row. Shorter strings ("Importing CSV…" / "Matching CSV requests…") stop squeezing the synced badges. The synced spans get `whitespace-nowrap` so they no longer break onto two lines.

### Test plan

- [x] Unit tests added for the new gating: cron returns idle for running/completed/failed, CSV-context flow returns importing → matching → done → error correctly, stuck-matching safety net transitions to error.
- [x] Hook tests cover: idle without context, importing with context, idle when context is missing on a running sync, done with fresh debug row + context.
- [x] Existing grace-window boundary tests retained (now passing CSV context).
- [x] Pre-push verification: `vitest` (3308 / 3308 passed), `eslint`, `tsc`, prettier — all green.
- [ ] Manual: upload a CSV in dev → indicator shows Importing → Matching → Done. Trigger a fake cron-shape sync (no localStorage marker) → indicator stays idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV uploads now display separate status from automatic background syncs

* **Bug Fixes**
  * Fixed status text from wrapping across multiple lines
  * Added timeout detection for stalled import operations to prevent indefinite loading

* **UI/Style**
  * Streamlined pipeline status display with more compact icons and clearer labels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->