### PR TITLE
feat(frontend): parent-paramount Stage 3b.1 — visuals + bug fix

### DIFF
--- a/frontend/src/components/BunkRequestRow.test.tsx
+++ b/frontend/src/components/BunkRequestRow.test.tsx
@@ -33,55 +33,49 @@ function makePerson(overrides: Partial<PersonsResponse> = {}): PersonsResponse {
 }
 
 describe('BunkRequestRow', () => {
-  it('renders a resolved status with a green check icon', () => {
+  it('renders a green dot for bunk_with rows', () => {
     const { container } = render(
       <BunkRequestRow
-        request={makeRequest({ status: 'resolved', requestee_id: 200 })}
+        request={makeRequest({ request_type: 'bunk_with', requestee_id: 200 })}
         targetPerson={makePerson()}
       />
     )
-    // CheckCircle for resolved - forest-600
-    expect(container.querySelector('.text-forest-600')).toBeTruthy()
+    // Type-keyed dot — green for bunk_with regardless of status
+    expect(container.querySelector('.bg-green-500')).toBeTruthy()
   })
 
-  it('renders a pending status with an amber clock icon', () => {
+  it('renders a red dot for not_bunk_with rows', () => {
     const { container } = render(
       <BunkRequestRow
-        request={makeRequest({ status: 'pending', requested_person_name: 'Liam Garcia' })}
+        request={makeRequest({ request_type: 'not_bunk_with', requestee_id: 200 })}
+        targetPerson={makePerson()}
       />
     )
-    expect(container.querySelector('.text-amber-500')).toBeTruthy()
+    expect(container.querySelector('.bg-red-500')).toBeTruthy()
   })
 
-  it('renders a declined status with a bark X icon', () => {
-    const { container } = render(
-      <BunkRequestRow
-        request={makeRequest({ status: 'declined', requested_person_name: 'Noah Smith' })}
-      />
-    )
-    expect(container.querySelector('.text-bark-600')).toBeTruthy()
-  })
-
-  it('renders "Bunk with" label for bunk_with requests', () => {
+  it('renders "Bunk with" label in green for bunk_with requests', () => {
     render(
       <BunkRequestRow
         request={makeRequest({ request_type: 'bunk_with', requestee_id: 200 })}
         targetPerson={makePerson()}
       />
     )
-    expect(screen.getByText('Bunk with')).toBeInTheDocument()
+    const label = screen.getByText('Bunk with')
+    expect(label).toBeInTheDocument()
+    expect(label.className).toMatch(/text-green-700/)
   })
 
-  it('renders "Not bunk with" label in red for not_bunk_with requests', () => {
+  it('renders "Not with" label in red for not_bunk_with requests', () => {
     render(
       <BunkRequestRow
         request={makeRequest({ request_type: 'not_bunk_with', requestee_id: 200 })}
         targetPerson={makePerson()}
       />
     )
-    const label = screen.getByText('Not bunk with')
+    const label = screen.getByText('Not with')
     expect(label).toBeInTheDocument()
-    expect(label.className).toMatch(/text-red-600/)
+    expect(label.className).toMatch(/text-red-700/)
   })
 
   it('renders target name via CamperLink when requestee_id set and resolved', () => {
@@ -129,7 +123,7 @@ describe('BunkRequestRow', () => {
     expect(screen.queryByText('mutual')).not.toBeInTheDocument()
   })
 
-  it('renders satisfaction check when showSatisfaction and satisfied', () => {
+  it('renders "Met" pill when showSatisfaction and satisfied', () => {
     render(
       <BunkRequestRow
         request={makeRequest({ status: 'resolved', requestee_id: 200 })}
@@ -138,10 +132,10 @@ describe('BunkRequestRow', () => {
         satisfaction="satisfied"
       />
     )
-    expect(screen.getByText('✓')).toBeInTheDocument()
+    expect(screen.getByText('Met')).toBeInTheDocument()
   })
 
-  it('renders satisfaction X when showSatisfaction and not_satisfied', () => {
+  it('renders red "Unmet" pill when showSatisfaction and not_satisfied', () => {
     render(
       <BunkRequestRow
         request={makeRequest({ status: 'resolved', requestee_id: 200 })}
@@ -150,10 +144,13 @@ describe('BunkRequestRow', () => {
         satisfaction="not_satisfied"
       />
     )
-    expect(screen.getByText('✗')).toBeInTheDocument()
+    const pill = screen.getByText('Unmet')
+    expect(pill).toBeInTheDocument()
+    expect(pill.className).toMatch(/bg-red-100/)
+    expect(pill.className).toMatch(/text-red-700/)
   })
 
-  it('renders satisfaction ? when showSatisfaction and unknown', () => {
+  it('renders nothing on the right when showSatisfaction and unknown', () => {
     render(
       <BunkRequestRow
         request={makeRequest({ status: 'resolved', requestee_id: 200 })}
@@ -162,10 +159,11 @@ describe('BunkRequestRow', () => {
         satisfaction="unknown"
       />
     )
-    expect(screen.getByText('?')).toBeInTheDocument()
+    expect(screen.queryByText('Met')).not.toBeInTheDocument()
+    expect(screen.queryByText('Unmet')).not.toBeInTheDocument()
   })
 
-  it('does not render satisfaction icons when showSatisfaction is false', () => {
+  it('does not render Met/Unmet pill when showSatisfaction is false', () => {
     render(
       <BunkRequestRow
         request={makeRequest({ status: 'resolved', requestee_id: 200 })}
@@ -174,7 +172,8 @@ describe('BunkRequestRow', () => {
         satisfaction="satisfied"
       />
     )
-    expect(screen.queryByText('✓')).not.toBeInTheDocument()
+    expect(screen.queryByText('Met')).not.toBeInTheDocument()
+    expect(screen.queryByText('Unmet')).not.toBeInTheDocument()
   })
 
   it('renders "Prefers bunking with older campers" for age_preference request', () => {

--- a/frontend/src/components/BunkRequestRow.test.tsx
+++ b/frontend/src/components/BunkRequestRow.test.tsx
@@ -443,3 +443,56 @@ describe('BunkRequestRow', () => {
     })
   })
 })
+
+describe('BunkRequestRow — material age preference marker', () => {
+  function ageReq(overrides: Partial<BunkRequestsResponse> = {}): BunkRequestsResponse {
+    return makeRequest({
+      request_type: 'age_preference',
+      age_preference_target: 'older',
+      source_field: 'bunk_with',
+      source: 'family',
+      status: 'resolved',
+      ...overrides,
+    })
+  }
+
+  it('applies sparkle-material class when isMaterialAgePreference=true', () => {
+    const { container } = render(
+      <BunkRequestRow request={ageReq()} isMaterialAgePreference={true} />
+    )
+    const sparkle = container.querySelector('.sparkle-material')
+    expect(sparkle).not.toBeNull()
+  })
+
+  it('does NOT apply sparkle-material class when isMaterialAgePreference=false', () => {
+    const { container } = render(
+      <BunkRequestRow
+        request={ageReq({ source_field: 'socialize_with' })}
+        isMaterialAgePreference={false}
+      />
+    )
+    const sparkle = container.querySelector('.sparkle-material')
+    expect(sparkle).toBeNull()
+  })
+
+  it('renders P badge when isMaterialAgePreference=true', () => {
+    render(<BunkRequestRow request={ageReq()} isMaterialAgePreference={true} />)
+    expect(screen.getByText('P')).toBeInTheDocument()
+  })
+
+  it('renders S badge when staffAgeBadge=true', () => {
+    render(
+      <BunkRequestRow
+        request={ageReq({ source_field: 'bunking_notes', source: 'staff' })}
+        staffAgeBadge={true}
+      />
+    )
+    expect(screen.getByText('S')).toBeInTheDocument()
+  })
+
+  it('renders neither badge for plain best-effort age row', () => {
+    render(<BunkRequestRow request={ageReq({ source_field: 'socialize_with' })} />)
+    expect(screen.queryByText('P')).toBeNull()
+    expect(screen.queryByText('S')).toBeNull()
+  })
+})

--- a/frontend/src/components/BunkRequestRow.tsx
+++ b/frontend/src/components/BunkRequestRow.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { CheckCircle, XCircle, Clock, Sparkles } from 'lucide-react'
+import { Sparkles } from 'lucide-react'
 import clsx from 'clsx'
 import CamperLink from './CamperLink'
 import { formatReason, MUTUAL_BADGE_CLASSES } from '../utils/dispositionColors'
@@ -71,21 +71,23 @@ function ClickableRow({
   )
 }
 
-function statusIcon(status: string) {
-  if (status === 'resolved')
-    return <CheckCircle className="text-forest-600 dark:text-forest-400 h-4 w-4 flex-shrink-0" />
-  if (status === 'declined')
-    return <XCircle className="text-bark-600 dark:text-bark-400 h-4 w-4 flex-shrink-0" />
-  return <Clock className="h-4 w-4 flex-shrink-0 text-amber-500" />
+// Type-keyed dot: green for bunk_with (and age_preference fallback), red for
+// not_bunk_with. We only render resolved rows here, so there is no pending /
+// declined branching — the dot color reflects the request's intent.
+function typeDot(requestType: string) {
+  const isNotWith = requestType === 'not_bunk_with'
+  return (
+    <span
+      className={clsx(
+        'h-2 w-2 flex-shrink-0 rounded-full',
+        isNotWith ? 'bg-red-500' : 'bg-green-500'
+      )}
+      aria-hidden="true"
+    />
+  )
 }
 
-const SATISFACTION_ICONS = {
-  satisfied: <span className="sat-icon sat-icon-met">✓</span>,
-  not_satisfied: <span className="sat-icon sat-icon-unmet">✗</span>,
-  unknown: <span className="sat-icon sat-icon-unknown">?</span>,
-}
-
-function SatisfactionIcon({
+function MetPill({
   satisfaction,
   satisfactionLoading,
   satisfactionDetail,
@@ -94,15 +96,32 @@ function SatisfactionIcon({
   satisfactionLoading: boolean
   satisfactionDetail?: string | undefined
 }) {
-  return (
-    <span className="ml-auto" title={satisfactionDetail}>
-      {satisfactionLoading ? (
-        <span className="sat-spinner" />
-      ) : satisfaction ? (
-        (SATISFACTION_ICONS[satisfaction as keyof typeof SATISFACTION_ICONS] ?? null)
-      ) : null}
-    </span>
-  )
+  if (satisfactionLoading) {
+    return (
+      <span className="ml-auto" title={satisfactionDetail}>
+        <span className="border-muted-foreground/30 border-t-primary inline-block h-3 w-3 animate-spin rounded-full border" />
+      </span>
+    )
+  }
+  if (satisfaction === 'satisfied') {
+    return (
+      <span className="ml-auto" title={satisfactionDetail}>
+        <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
+          Met
+        </span>
+      </span>
+    )
+  }
+  if (satisfaction === 'not_satisfied') {
+    return (
+      <span className="ml-auto" title={satisfactionDetail}>
+        <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-900/30 dark:text-red-400">
+          Unmet
+        </span>
+      </span>
+    )
+  }
+  return null
 }
 
 /**
@@ -135,26 +154,32 @@ export function BunkRequestRow({
     const prefersOlder = request.age_preference_target === 'older'
     const ageChildren = (
       <>
-        <span className="inline-flex items-center gap-1">
+        {/* Wrap the SVG in a span so the animation has a reliable inline-flex
+            container — applying CSS animations directly to <svg> is fragile
+            across browsers and the `transform-origin` interacts oddly with
+            SVG default rendering boxes. The span owns the animation; the SVG
+            inherits the transform via the parent. */}
+        <span
+          className={clsx('inline-flex', isMaterialAgePreference && 'sparkle-material')}
+          aria-hidden="true"
+        >
           <Sparkles
             className={clsx(
               'h-3 w-3 flex-shrink-0',
-              isMaterialAgePreference
-                ? 'sparkle-material text-amber-600 dark:text-amber-400'
-                : 'text-amber-500'
+              isMaterialAgePreference ? 'text-amber-600 dark:text-amber-400' : 'text-amber-500'
             )}
           />
-          {isMaterialAgePreference && (
-            <span className="rounded bg-amber-100 px-1.5 text-[10px] leading-4 font-bold text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
-              P
-            </span>
-          )}
-          {staffAgeBadge && (
-            <span className="rounded bg-indigo-100 px-1.5 text-[10px] leading-4 font-bold text-indigo-800 dark:bg-indigo-900/40 dark:text-indigo-300">
-              S
-            </span>
-          )}
         </span>
+        {isMaterialAgePreference && (
+          <span className="rounded bg-amber-100 px-1.5 text-[10px] leading-4 font-bold text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
+            P
+          </span>
+        )}
+        {staffAgeBadge && (
+          <span className="rounded bg-indigo-100 px-1.5 text-[10px] leading-4 font-bold text-indigo-800 dark:bg-indigo-900/40 dark:text-indigo-300">
+            S
+          </span>
+        )}
         <span>
           Prefers bunking with{' '}
           <span className="text-foreground font-medium">{prefersOlder ? 'older' : 'younger'}</span>{' '}
@@ -162,7 +187,7 @@ export function BunkRequestRow({
         </span>
         {badge}
         {showSatisfaction && (
-          <SatisfactionIcon
+          <MetPill
             satisfaction={satisfaction}
             satisfactionLoading={satisfactionLoading}
             satisfactionDetail={satisfactionDetail}
@@ -171,13 +196,7 @@ export function BunkRequestRow({
       </>
     )
     return (
-      <ClickableRow
-        className={clsx(
-          rowClass,
-          'text-muted-foreground text-xs ring-1 ring-amber-300/60 dark:ring-amber-700/40'
-        )}
-        onSelect={onSelect}
-      >
+      <ClickableRow className={clsx(rowClass, 'text-muted-foreground')} onSelect={onSelect}>
         {ageChildren}
       </ClickableRow>
     )
@@ -200,18 +219,21 @@ export function BunkRequestRow({
 
   const children = (
     <>
-      {/* Status indicator */}
-      {statusIcon(request.status)}
+      {/* Type-keyed dot: green for bunk_with, red for not_with. */}
+      {typeDot(request.request_type)}
 
-      {/* Type label */}
+      {/* Type label — colored to match the dot. */}
       <span
-        className={clsx('text-muted-foreground', !isBunkWith && 'text-red-600 dark:text-red-400')}
+        className={clsx(
+          'font-medium',
+          isBunkWith ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400'
+        )}
       >
-        {isBunkWith ? 'Bunk with' : 'Not bunk with'}
+        {isBunkWith ? 'Bunk with' : 'Not with'}
       </span>
 
       {/* Arrow */}
-      <span className="text-muted-foreground">→</span>
+      <span className="text-muted-foreground/60">→</span>
 
       {/* Target - clickable when we have a real requestee match (resolved OR
           declined-but-matched, e.g. cross-session). Unresolved italic fallback
@@ -238,9 +260,9 @@ export function BunkRequestRow({
       {/* Optional badge slot (e.g. "Current request", "Pinned") */}
       {badge}
 
-      {/* Satisfaction - concise icon only */}
+      {/* "Met" pill on right when satisfied (nothing for unmet/unknown). */}
       {showSatisfaction && (
-        <SatisfactionIcon
+        <MetPill
           satisfaction={satisfaction}
           satisfactionLoading={satisfactionLoading}
           satisfactionDetail={satisfactionDetail}

--- a/frontend/src/components/BunkRequestRow.tsx
+++ b/frontend/src/components/BunkRequestRow.tsx
@@ -33,6 +33,10 @@ export interface BunkRequestRowProps {
    * camper-requests panel to inject the "Current request" chip.
    */
   badge?: ReactNode | undefined
+  /** When true: applies sparkle-material class to the Sparkles icon and renders an amber "P" badge. */
+  isMaterialAgePreference?: boolean
+  /** When true: renders an indigo "S" badge next to the Sparkles icon. */
+  staffAgeBadge?: boolean
 }
 
 function ClickableRow({
@@ -116,6 +120,8 @@ export function BunkRequestRow({
   satisfactionDetail,
   onSelect,
   badge,
+  isMaterialAgePreference = false,
+  staffAgeBadge = false,
 }: BunkRequestRowProps) {
   const rowClass = clsx(
     'flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm transition-colors',
@@ -129,7 +135,26 @@ export function BunkRequestRow({
     const prefersOlder = request.age_preference_target === 'older'
     const ageChildren = (
       <>
-        <Sparkles className="h-3 w-3 flex-shrink-0 text-amber-500" />
+        <span className="inline-flex items-center gap-1">
+          <Sparkles
+            className={clsx(
+              'h-3 w-3 flex-shrink-0',
+              isMaterialAgePreference
+                ? 'sparkle-material text-amber-600 dark:text-amber-400'
+                : 'text-amber-500'
+            )}
+          />
+          {isMaterialAgePreference && (
+            <span className="rounded bg-amber-100 px-1.5 text-[10px] leading-4 font-bold text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
+              P
+            </span>
+          )}
+          {staffAgeBadge && (
+            <span className="rounded bg-indigo-100 px-1.5 text-[10px] leading-4 font-bold text-indigo-800 dark:bg-indigo-900/40 dark:text-indigo-300">
+              S
+            </span>
+          )}
+        </span>
         <span>
           Prefers bunking with{' '}
           <span className="text-foreground font-medium">{prefersOlder ? 'older' : 'younger'}</span>{' '}

--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -709,11 +709,11 @@ describe('CamperDetailsPanel', () => {
         expect(container.textContent).toContain('Riley')
       })
 
-      // Find the Staff sub-divider: leaf element whose trimmed text === "Staff"
-      const dividerEl = Array.from(container.querySelectorAll('*')).find(
-        (el) => el.textContent?.trim() === 'Staff' && el.children.length === 0
-      )
+      // The combined Parent ↑ │ ⬇ Staff divider is the only element with the
+      // `font-mono` utility on its container <div>.
+      const dividerEl = container.querySelector('div.font-mono')
       expect(dividerEl).not.toBeNull()
+      expect(dividerEl?.textContent).toMatch(/Parent.*Staff/)
 
       const allElements = Array.from(container.querySelectorAll('*'))
       const dividerIdx = allElements.indexOf(dividerEl as Element)
@@ -769,11 +769,8 @@ describe('CamperDetailsPanel', () => {
         expect(container.textContent).toContain('Riley')
       })
 
-      // No leaf element with text strictly "Staff" (the divider label)
-      const staffDivider = Array.from(container.querySelectorAll('*')).find(
-        (el) => el.textContent?.trim() === 'Staff' && el.children.length === 0
-      )
-      expect(staffDivider).toBeFalsy()
+      // No combined Parent/Staff divider when only parent rows exist.
+      expect(container.querySelector('div.font-mono')).toBeNull()
     })
 
     it('renders P badge on bunk_with-derived age preference (family source)', async () => {

--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -859,8 +859,8 @@ describe('CamperDetailsPanel', () => {
       setupR3Mocks(bunkRequests)
 
       render(<CamperDetailsPanel camperId="100" onClose={vi.fn()} embedded={true} />)
-      // Wait briefly for any async-rendered content
-      await new Promise((r) => setTimeout(r, 50))
+      // Wait for the row to render before asserting the summary lines are absent.
+      await screen.findByText('Riley Sam')
       expect(screen.queryByText(/Parent request satisfaction:/i)).toBeNull()
       expect(screen.queryByText(/Staff request satisfaction:/i)).toBeNull()
     })

--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -587,6 +587,288 @@ describe('CamperDetailsPanel', () => {
     })
   })
 
+  // ---------------------------------------------------------------------------
+  // Stage 3b.1 — R3 row list: Parent rows → Staff sub-divider → Staff rows
+  // → age preference divider → age rows (with P/S badges).
+  // ---------------------------------------------------------------------------
+  describe('CamperDetailsPanel — Stage 3b.1 R3 row list in Bunking Preferences section', () => {
+    /** Person record for Emma Johnson (parent request source) */
+    const EMMA_R3 = mockPerson({
+      id: 'pb-emma-r3',
+      cm_id: 100,
+      first_name: 'Emma',
+      last_name: 'Johnson',
+      grade: 6,
+      year: 2025,
+      household_id: 0,
+    })
+
+    /** Person record for Riley Sam (target of the parent request) */
+    const RILEY_PERSON = mockPerson({
+      id: 'pb-riley-r3',
+      cm_id: 200,
+      first_name: 'Riley',
+      last_name: 'Sam',
+      grade: 6,
+      year: 2025,
+      household_id: 0,
+    })
+
+    /** Attendee record for Emma in session sess-r3 */
+    const EMMA_R3_ATTENDEE: Record<string, unknown> = {
+      id: 'att-emma-r3',
+      person: 'pb-emma-r3',
+      person_id: 100,
+      session: 'sess-r3',
+      status: 'enrolled',
+      status_id: 2,
+      year: 2025,
+      collectionId: 'attendees',
+      collectionName: 'attendees',
+      created: '2025-01-01T00:00:00Z',
+      updated: '2025-01-01T00:00:00Z',
+      expand: {
+        session: {
+          id: 'sess-r3',
+          cm_id: 3001,
+          name: 'Session R3',
+          session_type: 'main',
+        },
+      },
+    }
+
+    /**
+     * Set up mocks for a given set of bunk requests.
+     * Persons lookup resolves requestee_id=200 to Riley, otherwise returns Emma.
+     */
+    function setupR3Mocks(bunkRequests: Record<string, unknown>[]) {
+      mockGetFullListPersons.mockImplementation((opts: { filter?: string }) => {
+        const filter = opts.filter ?? ''
+        if (filter.includes('cm_id = 200')) return Promise.resolve([RILEY_PERSON])
+        return Promise.resolve([EMMA_R3])
+      })
+      mockGetFullListAttendees.mockResolvedValue([EMMA_R3_ATTENDEE])
+      mockGetFullListBunkAssignments.mockResolvedValue([])
+      mockGetFullListBunkRequests.mockResolvedValue(bunkRequests)
+      mockGetListPersons.mockResolvedValue({ items: [], totalItems: 0 })
+      mockGetListOriginalBunkRequests.mockResolvedValue({ items: [], totalItems: 0 })
+    }
+
+    it('renders Parent rows before Staff sub-divider before Staff rows', async () => {
+      // Two requests: one parent (bunk_with Emma→Riley), one staff (not_bunk_with)
+      const bunkRequests: Record<string, unknown>[] = [
+        {
+          id: 'r3-p1',
+          requester_id: 100,
+          requestee_id: 200,
+          request_type: 'bunk_with',
+          source_field: 'bunk_with',
+          source: 'family',
+          status: 'resolved',
+          priority: 1,
+          requested_person_name: 'Riley Sam',
+          year: 2025,
+          session_id: 3001,
+          is_reciprocal: false,
+          confidence_score: 0.95,
+          created: '2025-01-01T00:00:00Z',
+          updated: '2025-01-01T00:00:00Z',
+          collectionId: 'bunk_requests',
+          collectionName: 'bunk_requests',
+          metadata: {},
+        },
+        {
+          id: 'r3-s1',
+          requester_id: 100,
+          requestee_id: 0,
+          request_type: 'not_bunk_with',
+          source_field: 'not_bunk_with',
+          source: 'staff',
+          status: 'resolved',
+          priority: 1,
+          requested_person_name: 'Olivia Chen',
+          year: 2025,
+          session_id: 3001,
+          is_reciprocal: false,
+          confidence_score: 0.9,
+          created: '2025-01-01T00:00:00Z',
+          updated: '2025-01-01T00:00:00Z',
+          collectionId: 'bunk_requests',
+          collectionName: 'bunk_requests',
+          metadata: {},
+        },
+      ]
+      setupR3Mocks(bunkRequests)
+
+      const { container } = render(
+        <CamperDetailsPanel camperId="100" onClose={vi.fn()} embedded={true} />
+      )
+
+      // Wait for requests to load (Riley Sam appears as a target name)
+      await waitFor(() => {
+        expect(container.textContent).toContain('Riley')
+      })
+
+      // Find the Staff sub-divider: leaf element whose trimmed text === "Staff"
+      const dividerEl = Array.from(container.querySelectorAll('*')).find(
+        (el) => el.textContent?.trim() === 'Staff' && el.children.length === 0
+      )
+      expect(dividerEl).not.toBeNull()
+
+      const allElements = Array.from(container.querySelectorAll('*'))
+      const dividerIdx = allElements.indexOf(dividerEl as Element)
+
+      // Leaf element containing "Riley" but not "Olivia"
+      const rileyEl = Array.from(container.querySelectorAll('*')).find(
+        (el) => el.textContent?.includes('Riley') && !el.textContent?.includes('Olivia')
+      )
+      // Leaf element containing "Olivia" but not "Riley"
+      const oliviaEl = Array.from(container.querySelectorAll('*')).find(
+        (el) => el.textContent?.includes('Olivia') && !el.textContent?.includes('Riley')
+      )
+      const rileyIdx = allElements.indexOf(rileyEl as Element)
+      const oliviaIdx = allElements.indexOf(oliviaEl as Element)
+
+      expect(rileyIdx).toBeGreaterThan(-1)
+      expect(oliviaIdx).toBeGreaterThan(-1)
+      // Parent request (Riley) appears BEFORE the Staff divider
+      expect(rileyIdx).toBeLessThan(dividerIdx)
+      // Staff request (Olivia) appears AFTER the Staff divider
+      expect(dividerIdx).toBeLessThan(oliviaIdx)
+    })
+
+    it('omits Staff sub-divider when there are no staff rows', async () => {
+      const bunkRequests: Record<string, unknown>[] = [
+        {
+          id: 'r3-p1-only',
+          requester_id: 100,
+          requestee_id: 200,
+          request_type: 'bunk_with',
+          source_field: 'bunk_with',
+          source: 'family',
+          status: 'resolved',
+          priority: 1,
+          requested_person_name: 'Riley Sam',
+          year: 2025,
+          session_id: 3001,
+          is_reciprocal: false,
+          confidence_score: 0.95,
+          created: '2025-01-01T00:00:00Z',
+          updated: '2025-01-01T00:00:00Z',
+          collectionId: 'bunk_requests',
+          collectionName: 'bunk_requests',
+          metadata: {},
+        },
+      ]
+      setupR3Mocks(bunkRequests)
+
+      const { container } = render(
+        <CamperDetailsPanel camperId="100" onClose={vi.fn()} embedded={true} />
+      )
+      await waitFor(() => {
+        expect(container.textContent).toContain('Riley')
+      })
+
+      // No leaf element with text strictly "Staff" (the divider label)
+      const staffDivider = Array.from(container.querySelectorAll('*')).find(
+        (el) => el.textContent?.trim() === 'Staff' && el.children.length === 0
+      )
+      expect(staffDivider).toBeFalsy()
+    })
+
+    it('renders P badge on bunk_with-derived age preference (family source)', async () => {
+      const bunkRequests: Record<string, unknown>[] = [
+        {
+          id: 'r3-age-p',
+          requester_id: 100,
+          requestee_id: 0,
+          request_type: 'age_preference',
+          source_field: 'bunk_with',
+          source: 'family',
+          age_preference_target: 'older',
+          status: 'resolved',
+          priority: 1,
+          year: 2025,
+          session_id: 3001,
+          is_reciprocal: false,
+          confidence_score: 0.9,
+          created: '2025-01-01T00:00:00Z',
+          updated: '2025-01-01T00:00:00Z',
+          collectionId: 'bunk_requests',
+          collectionName: 'bunk_requests',
+          metadata: {},
+        },
+      ]
+      setupR3Mocks(bunkRequests)
+
+      render(<CamperDetailsPanel camperId="100" onClose={vi.fn()} embedded={true} />)
+      expect(await screen.findByText('P')).toBeInTheDocument()
+    })
+
+    it('renders S badge on staff-source age preference', async () => {
+      const bunkRequests: Record<string, unknown>[] = [
+        {
+          id: 'r3-age-s',
+          requester_id: 100,
+          requestee_id: 0,
+          request_type: 'age_preference',
+          source_field: 'bunking_notes',
+          source: 'staff',
+          age_preference_target: 'younger',
+          status: 'resolved',
+          priority: 1,
+          year: 2025,
+          session_id: 3001,
+          is_reciprocal: false,
+          confidence_score: 0.9,
+          created: '2025-01-01T00:00:00Z',
+          updated: '2025-01-01T00:00:00Z',
+          collectionId: 'bunk_requests',
+          collectionName: 'bunk_requests',
+          metadata: {},
+        },
+      ]
+      setupR3Mocks(bunkRequests)
+
+      render(<CamperDetailsPanel camperId="100" onClose={vi.fn()} embedded={true} />)
+      expect(await screen.findByText('S')).toBeInTheDocument()
+    })
+
+    it('does NOT render any new "Parent request satisfaction:" summary line in the sidebar', async () => {
+      // The sidebar conveys source-aware satisfaction via CamperAlertSection,
+      // not a separate summary label. Spec §2.4 explicitly forbids adding one.
+      const bunkRequests: Record<string, unknown>[] = [
+        {
+          id: 'r3-no-summary',
+          requester_id: 100,
+          requestee_id: 200,
+          request_type: 'bunk_with',
+          source_field: 'bunk_with',
+          source: 'family',
+          status: 'resolved',
+          priority: 1,
+          requested_person_name: 'Riley Sam',
+          year: 2025,
+          session_id: 3001,
+          is_reciprocal: false,
+          confidence_score: 0.95,
+          created: '2025-01-01T00:00:00Z',
+          updated: '2025-01-01T00:00:00Z',
+          collectionId: 'bunk_requests',
+          collectionName: 'bunk_requests',
+          metadata: {},
+        },
+      ]
+      setupR3Mocks(bunkRequests)
+
+      render(<CamperDetailsPanel camperId="100" onClose={vi.fn()} embedded={true} />)
+      // Wait briefly for any async-rendered content
+      await new Promise((r) => setTimeout(r, 50))
+      expect(screen.queryByText(/Parent request satisfaction:/i)).toBeNull()
+      expect(screen.queryByText(/Staff request satisfaction:/i)).toBeNull()
+    })
+  })
+
   describe('Bunk request display in embedded (sidebar) mode', () => {
     it('renders the target camper name (not "Unknown") for a declined request in embedded mode', async () => {
       setupDeclinedRequestMocks()

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -7,6 +7,7 @@ import {
   Heart,
   ChevronDown,
   ChevronRight,
+  ChevronUp,
   FileText,
   MapPin,
   TreePine,
@@ -928,14 +929,24 @@ export default function CamperDetailsPanel({
             {expandedSections.requests &&
               (parentRows.length > 0 || staffRows.length > 0 || ageRows.length > 0) && (
                 <div className="mt-2 space-y-1">
-                  {/* Reusable source sub-divider — matches Age preference divider style */}
+                  {/* Parent ↑ │ ⬇ Staff divider between the two peer groups, plus a
+                      quieter "Age preference" divider above the age tail section. */}
                   {(() => {
-                    const SubDivider = ({ label }: { label: string }) => (
-                      <div className="text-muted-foreground/60 my-3 flex items-center gap-3 font-mono text-[10.5px] tracking-[0.18em] uppercase">
+                    const ParentStaffDivider = () => (
+                      <div className="text-muted-foreground/70 my-3 flex items-center gap-2 font-mono text-[10.5px] tracking-[0.18em] uppercase">
                         <span className="border-border/60 flex-1 border-t" />
-                        <span>{label}</span>
+                        <span className="inline-flex items-center gap-1">
+                          Parent <ChevronUp className="h-3 w-3" aria-hidden="true" />
+                        </span>
+                        <span className="border-border/60 h-3 border-l" aria-hidden="true" />
+                        <span className="inline-flex items-center gap-1">
+                          <ChevronDown className="h-3 w-3" aria-hidden="true" /> Staff
+                        </span>
                         <span className="border-border/60 flex-1 border-t" />
                       </div>
+                    )
+                    const AgePreferenceDivider = () => (
+                      <div className="border-border/60 my-2 border-t" aria-hidden="true" />
                     )
                     return (
                       <>
@@ -954,7 +965,7 @@ export default function CamperDetailsPanel({
                           )
                         })}
 
-                        {staffRows.length > 0 && <SubDivider label="Staff" />}
+                        {parentRows.length > 0 && staffRows.length > 0 && <ParentStaffDivider />}
                         {staffRows.map((req) => {
                           const satisfaction = satisfactionData[req.id]
                           return (
@@ -970,7 +981,9 @@ export default function CamperDetailsPanel({
                           )
                         })}
 
-                        {ageRows.length > 0 && <SubDivider label="Age preference" />}
+                        {ageRows.length > 0 && (parentRows.length > 0 || staffRows.length > 0) && (
+                          <AgePreferenceDivider />
+                        )}
                         {ageRows.map((req) => {
                           const satisfaction = satisfactionData[req.id]
                           return (

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -36,6 +36,7 @@ import type {
 import { Collections } from '../types/pocketbase-types'
 import { toAppCamper } from '../utils/transforms'
 import { isConfirmedRequest } from '../utils/bunkRequest'
+import { partitionRequestsBySource } from '../utils/partitionRequestsBySource'
 import { useSatisfactionData } from '../hooks/camper/useSatisfactionData'
 import { computeRequestSatisfaction } from '../utils/requestSatisfaction'
 import type { SatisfactionMap } from '../hooks/camper/types'
@@ -579,9 +580,6 @@ export default function CamperDetailsPanel({
     return enrollment.sessionName || 'Unknown'
   }
 
-  // Get age preference request for socializes best with
-  const agePreferenceRequest = bunkRequests.find((r) => r.request_type === 'age_preference')
-
   // Lock group context — used to compute friend-group alert
   const { getCamperLockState, getCamperLockGroup, getGroupMembers } = useLockGroupContext()
 
@@ -612,11 +610,17 @@ export default function CamperDetailsPanel({
     bunkRequests.map(pbToEnhanced)
   )
 
-  // Derived request lists — declared here so renderContent() (defined below)
+  // Derived request partitions — declared here so renderContent() (defined below)
   // and the embedded early-return both see them. Previously these were declared
   // after the embedded-mode return, causing a TDZ ReferenceError in that path.
-  const nonAgeRequests = bunkRequests.filter((r) => r.request_type !== 'age_preference')
-  const hasOtherRequests = nonAgeRequests.length > 0
+  // Partition the PanelBunkRequest objects directly (they satisfy PartitionableRequest
+  // and are what BunkRequestRow expects). pbToEnhanced is only used for the
+  // satisfaction-computation hooks which accept EnhancedBunkRequest.
+  const {
+    parent: parentRows,
+    staff: staffRows,
+    age: ageRows,
+  } = useMemo(() => partitionRequestsBySource(bunkRequests), [bunkRequests])
 
   // ── Build alert catalog from the SAME source CamperCard uses ───────────────
   // Placed before early returns so useMemo is called unconditionally (Rules of Hooks).
@@ -669,9 +673,6 @@ export default function CamperDetailsPanel({
 
   const satisfactionData: SatisfactionMap = clientSatisfactionData ?? pbSatisfaction
   const satisfactionLoading: boolean = clientSatisfactionData ? false : pbLoading
-  const ageSatisfaction = agePreferenceRequest
-    ? satisfactionData[agePreferenceRequest.id]
-    : undefined
 
   // Prefer scenario-aware assignment from the parent (e.g. BunkingBoardByArea
   // passes the active scenario's bunk). Falls back to the live PB assignment
@@ -913,7 +914,7 @@ export default function CamperDetailsPanel({
           />
         )}
 
-        {/* Bunking Preferences - Compact view */}
+        {/* Bunking Preferences - Compact view (R3: Parent → Staff → Age partition) */}
         {bunkRequests.length > 0 && (
           <section>
             <SectionHeader
@@ -924,39 +925,74 @@ export default function CamperDetailsPanel({
               badge={bunkRequests.length}
               accentColor="forest"
             />
-            {expandedSections.requests && (
-              <div className="mt-2 space-y-1">
-                {nonAgeRequests.map((request) => {
-                  const satisfaction = satisfactionData[request.id]
-                  return (
-                    <BunkRequestRow
-                      key={request.id}
-                      request={request}
-                      targetPerson={request.targetPerson ?? null}
-                      showSatisfaction={isConfirmedRequest(request)}
-                      satisfaction={satisfaction?.status ?? null}
-                      satisfactionLoading={satisfactionLoading}
-                      satisfactionDetail={satisfaction?.detail}
-                    />
-                  )
-                })}
+            {expandedSections.requests &&
+              (parentRows.length > 0 || staffRows.length > 0 || ageRows.length > 0) && (
+                <div className="mt-2 space-y-1">
+                  {/* Reusable source sub-divider — matches Age preference divider style */}
+                  {(() => {
+                    const SubDivider = ({ label }: { label: string }) => (
+                      <div className="text-muted-foreground/60 my-3 flex items-center gap-3 font-mono text-[10.5px] tracking-[0.18em] uppercase">
+                        <span className="border-border/60 flex-1 border-t" />
+                        <span>{label}</span>
+                        <span className="border-border/60 flex-1 border-t" />
+                      </div>
+                    )
+                    return (
+                      <>
+                        {parentRows.map((req) => {
+                          const satisfaction = satisfactionData[req.id]
+                          return (
+                            <BunkRequestRow
+                              key={req.id}
+                              request={req}
+                              targetPerson={req.targetPerson ?? null}
+                              showSatisfaction={isConfirmedRequest(req)}
+                              satisfaction={satisfaction?.status ?? null}
+                              satisfactionLoading={satisfactionLoading}
+                              satisfactionDetail={satisfaction?.detail}
+                            />
+                          )
+                        })}
 
-                {/* Age preference - subtle at bottom with satisfaction */}
-                {agePreferenceRequest?.age_preference_target && (
-                  <div className={hasOtherRequests ? 'border-border/50 mt-3 border-t pt-2' : ''}>
-                    <BunkRequestRow
-                      request={agePreferenceRequest}
-                      // Pending (e.g. SAME_AGE staff-review) and declined age
-                      // preferences must not render a "fulfilled" indicator.
-                      showSatisfaction={agePreferenceRequest.status === 'resolved'}
-                      satisfaction={ageSatisfaction?.status ?? null}
-                      satisfactionLoading={satisfactionLoading}
-                      satisfactionDetail={ageSatisfaction?.detail}
-                    />
-                  </div>
-                )}
-              </div>
-            )}
+                        {staffRows.length > 0 && <SubDivider label="Staff" />}
+                        {staffRows.map((req) => {
+                          const satisfaction = satisfactionData[req.id]
+                          return (
+                            <BunkRequestRow
+                              key={req.id}
+                              request={req}
+                              targetPerson={req.targetPerson ?? null}
+                              showSatisfaction={isConfirmedRequest(req)}
+                              satisfaction={satisfaction?.status ?? null}
+                              satisfactionLoading={satisfactionLoading}
+                              satisfactionDetail={satisfaction?.detail}
+                            />
+                          )
+                        })}
+
+                        {ageRows.length > 0 && <SubDivider label="Age preference" />}
+                        {ageRows.map((req) => {
+                          const satisfaction = satisfactionData[req.id]
+                          return (
+                            <BunkRequestRow
+                              key={req.id}
+                              request={req}
+                              // Pending (e.g. SAME_AGE staff-review) and declined age
+                              // preferences must not render a "fulfilled" indicator.
+                              showSatisfaction={req.status === 'resolved'}
+                              satisfaction={satisfaction?.status ?? null}
+                              satisfactionLoading={satisfactionLoading}
+                              satisfactionDetail={satisfaction?.detail}
+                              isMaterialAgePreference={req.source_field === 'bunk_with'}
+                              staffAgeBadge={req.source === 'staff'}
+                            />
+                          )
+                        })}
+                      </>
+                    )
+                  })()}
+                </div>
+              )}
           </section>
         )}
 

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -7,7 +7,6 @@ import {
   Heart,
   ChevronDown,
   ChevronRight,
-  ChevronUp,
   FileText,
   MapPin,
   TreePine,
@@ -15,6 +14,7 @@ import {
   Users,
   ExternalLink,
 } from 'lucide-react'
+import { ParentStaffDivider, AgePreferenceDivider } from './camper/RequestSectionDividers'
 import { pb } from '../lib/pocketbase'
 import { StatusBadge } from './StatusBadge'
 import {
@@ -931,79 +931,55 @@ export default function CamperDetailsPanel({
                 <div className="mt-2 space-y-1">
                   {/* Parent ↑ │ ⬇ Staff divider between the two peer groups, plus a
                       quieter "Age preference" divider above the age tail section. */}
-                  {(() => {
-                    const ParentStaffDivider = () => (
-                      <div className="text-muted-foreground/70 my-3 flex items-center gap-2 font-mono text-[10.5px] tracking-[0.18em] uppercase">
-                        <span className="border-border/60 flex-1 border-t" />
-                        <span className="inline-flex items-center gap-1">
-                          Parent <ChevronUp className="h-3 w-3" aria-hidden="true" />
-                        </span>
-                        <span className="border-border/60 h-3 border-l" aria-hidden="true" />
-                        <span className="inline-flex items-center gap-1">
-                          <ChevronDown className="h-3 w-3" aria-hidden="true" /> Staff
-                        </span>
-                        <span className="border-border/60 flex-1 border-t" />
-                      </div>
-                    )
-                    const AgePreferenceDivider = () => (
-                      <div className="border-border/60 my-2 border-t" aria-hidden="true" />
-                    )
+                  {parentRows.map((req) => {
+                    const satisfaction = satisfactionData[req.id]
                     return (
-                      <>
-                        {parentRows.map((req) => {
-                          const satisfaction = satisfactionData[req.id]
-                          return (
-                            <BunkRequestRow
-                              key={req.id}
-                              request={req}
-                              targetPerson={req.targetPerson ?? null}
-                              showSatisfaction={isConfirmedRequest(req)}
-                              satisfaction={satisfaction?.status ?? null}
-                              satisfactionLoading={satisfactionLoading}
-                              satisfactionDetail={satisfaction?.detail}
-                            />
-                          )
-                        })}
-
-                        {parentRows.length > 0 && staffRows.length > 0 && <ParentStaffDivider />}
-                        {staffRows.map((req) => {
-                          const satisfaction = satisfactionData[req.id]
-                          return (
-                            <BunkRequestRow
-                              key={req.id}
-                              request={req}
-                              targetPerson={req.targetPerson ?? null}
-                              showSatisfaction={isConfirmedRequest(req)}
-                              satisfaction={satisfaction?.status ?? null}
-                              satisfactionLoading={satisfactionLoading}
-                              satisfactionDetail={satisfaction?.detail}
-                            />
-                          )
-                        })}
-
-                        {ageRows.length > 0 && (parentRows.length > 0 || staffRows.length > 0) && (
-                          <AgePreferenceDivider />
-                        )}
-                        {ageRows.map((req) => {
-                          const satisfaction = satisfactionData[req.id]
-                          return (
-                            <BunkRequestRow
-                              key={req.id}
-                              request={req}
-                              // Pending (e.g. SAME_AGE staff-review) and declined age
-                              // preferences must not render a "fulfilled" indicator.
-                              showSatisfaction={req.status === 'resolved'}
-                              satisfaction={satisfaction?.status ?? null}
-                              satisfactionLoading={satisfactionLoading}
-                              satisfactionDetail={satisfaction?.detail}
-                              isMaterialAgePreference={req.source_field === 'bunk_with'}
-                              staffAgeBadge={req.source === 'staff'}
-                            />
-                          )
-                        })}
-                      </>
+                      <BunkRequestRow
+                        key={req.id}
+                        request={req}
+                        targetPerson={req.targetPerson ?? null}
+                        showSatisfaction={isConfirmedRequest(req)}
+                        satisfaction={satisfaction?.status ?? null}
+                        satisfactionLoading={satisfactionLoading}
+                        satisfactionDetail={satisfaction?.detail}
+                      />
                     )
-                  })()}
+                  })}
+
+                  {parentRows.length > 0 && staffRows.length > 0 && <ParentStaffDivider />}
+                  {staffRows.map((req) => {
+                    const satisfaction = satisfactionData[req.id]
+                    return (
+                      <BunkRequestRow
+                        key={req.id}
+                        request={req}
+                        targetPerson={req.targetPerson ?? null}
+                        showSatisfaction={isConfirmedRequest(req)}
+                        satisfaction={satisfaction?.status ?? null}
+                        satisfactionLoading={satisfactionLoading}
+                        satisfactionDetail={satisfaction?.detail}
+                      />
+                    )
+                  })}
+
+                  {ageRows.length > 0 && (parentRows.length > 0 || staffRows.length > 0) && (
+                    <AgePreferenceDivider />
+                  )}
+                  {ageRows.map((req) => {
+                    const satisfaction = satisfactionData[req.id]
+                    return (
+                      <BunkRequestRow
+                        key={req.id}
+                        request={req}
+                        showSatisfaction={true}
+                        satisfaction={satisfaction?.status ?? null}
+                        satisfactionLoading={satisfactionLoading}
+                        satisfactionDetail={satisfaction?.detail}
+                        isMaterialAgePreference={req.source_field === 'bunk_with'}
+                        staffAgeBadge={req.source === 'staff'}
+                      />
+                    )
+                  })}
                 </div>
               )}
           </section>

--- a/frontend/src/components/CamperRequestSummary.test.tsx
+++ b/frontend/src/components/CamperRequestSummary.test.tsx
@@ -147,14 +147,14 @@ describe('CamperRequestSummary', () => {
     expect(inner.className).not.toMatch(/ring-primary\/40/)
   })
 
-  it('shows "Not bunk with" label in red for not_bunk_with requests', async () => {
+  it('shows "Not with" label in red for not_bunk_with requests', async () => {
     mockFetch()
     render(<CamperRequestSummary requesterCmId={100} year={2025} currentRequestId="req1" />)
     await waitFor(() => {
       expect(screen.getByText('Olivia Chen')).toBeInTheDocument()
     })
-    const notBunk = screen.getByText('Not bunk with')
-    expect(notBunk.className).toMatch(/text-red-600/)
+    const notBunk = screen.getByText('Not with')
+    expect(notBunk.className).toMatch(/text-red-700/)
   })
 
   it('shows a loading indicator while requests load', () => {

--- a/frontend/src/components/camper/BunkingStatusPanel.test.tsx
+++ b/frontend/src/components/camper/BunkingStatusPanel.test.tsx
@@ -64,20 +64,25 @@ function renderPanel(allBunkRequests: EnhancedBunkRequest[]) {
 
 interface RenderPanelOptions {
   allBunkRequests: EnhancedBunkRequest[]
+  agePreferenceRequests?: EnhancedBunkRequest[]
   satisfactionData: Record<
     string,
     { status: 'satisfied' | 'not_satisfied' | 'checking' | 'unknown'; detail?: string }
   >
 }
 
-function renderPanelWith({ allBunkRequests, satisfactionData }: RenderPanelOptions) {
+function renderPanelWith({
+  allBunkRequests,
+  agePreferenceRequests = [],
+  satisfactionData,
+}: RenderPanelOptions) {
   return render(
     <MemoryRouter>
       <BunkingStatusPanel
         camper={makeCamper()}
         sessionShortName="S1"
         allBunkRequests={allBunkRequests}
-        agePreferenceRequests={[]}
+        agePreferenceRequests={agePreferenceRequests}
         satisfactionData={satisfactionData}
         satisfactionLoading={false}
       />
@@ -238,5 +243,140 @@ describe('BunkingStatusPanel — Stage 3b.1 two-column summary line', () => {
     const { container } = renderPanelWith({ allBunkRequests, satisfactionData })
     const greenCheck = container.querySelector('.text-green-500, .text-green-400, .text-green-600')
     expect(greenCheck).not.toBeNull()
+  })
+})
+
+describe('BunkingStatusPanel — Stage 3b.1 R3 row list', () => {
+  it('renders Parent rows before Staff sub-divider before Staff rows', () => {
+    const allBunkRequests = [
+      makeRequest({
+        id: 'p1',
+        request_type: 'bunk_with',
+        source_field: 'bunk_with',
+        source: 'family',
+        ...({
+          targetPerson: { first_name: 'Emma', last_name: 'Johnson', cm_id: 100 },
+        } as unknown as Partial<EnhancedBunkRequest>),
+      }),
+      makeRequest({
+        id: 's1',
+        request_type: 'not_bunk_with',
+        source_field: 'not_bunk_with',
+        source: 'staff',
+        ...({
+          targetPerson: { first_name: 'Riley', last_name: 'Sam', cm_id: 200 },
+        } as unknown as Partial<EnhancedBunkRequest>),
+      }),
+    ]
+    const satisfactionData = {
+      p1: { status: 'satisfied' as const, detail: '' },
+      s1: { status: 'satisfied' as const, detail: '' },
+    }
+    const { container } = renderPanelWith({ allBunkRequests, satisfactionData })
+    const text = container.textContent ?? ''
+    const emmaIdx = text.indexOf('Emma')
+    const staffIdx = text.indexOf('Staff')
+    const rileyIdx = text.indexOf('Riley')
+    expect(emmaIdx).toBeGreaterThan(-1)
+    expect(staffIdx).toBeGreaterThan(emmaIdx)
+    expect(rileyIdx).toBeGreaterThan(staffIdx)
+  })
+
+  it('omits Staff sub-divider when no staff rows exist', () => {
+    const allBunkRequests = [
+      makeRequest({
+        id: 'p1',
+        request_type: 'bunk_with',
+        source_field: 'bunk_with',
+        source: 'family',
+        ...({
+          targetPerson: { first_name: 'Emma', last_name: 'Johnson', cm_id: 100 },
+        } as unknown as Partial<EnhancedBunkRequest>),
+      }),
+    ]
+    const satisfactionData = { p1: { status: 'satisfied' as const, detail: '' } }
+    const { container } = renderPanelWith({ allBunkRequests, satisfactionData })
+    // The bare word "Staff" should not appear as a divider label.
+    // Note: this is a heuristic — if the existing UI uses "Staff" in some other
+    // context (e.g. an alert label), the assertion may need refining. For now
+    // assert no divider element with the literal text "Staff" exists.
+    const dividers = Array.from(container.querySelectorAll('*')).filter(
+      (el) => el.textContent?.trim() === 'Staff'
+    )
+    expect(dividers.length).toBe(0)
+  })
+
+  it('sorts Parent rows alphabetically by requestee first_name', () => {
+    const allBunkRequests = [
+      makeRequest({
+        id: 'p-olivia',
+        request_type: 'bunk_with',
+        source_field: 'bunk_with',
+        source: 'family',
+        ...({
+          targetPerson: { first_name: 'Olivia', last_name: 'Chen', cm_id: 100 },
+        } as unknown as Partial<EnhancedBunkRequest>),
+      }),
+      makeRequest({
+        id: 'p-emma',
+        request_type: 'bunk_with',
+        source_field: 'bunk_with',
+        source: 'family',
+        ...({
+          targetPerson: { first_name: 'Emma', last_name: 'Johnson', cm_id: 101 },
+        } as unknown as Partial<EnhancedBunkRequest>),
+      }),
+      makeRequest({
+        id: 'p-liam',
+        request_type: 'bunk_with',
+        source_field: 'bunk_with',
+        source: 'family',
+        ...({
+          targetPerson: { first_name: 'Liam', last_name: 'Garcia', cm_id: 102 },
+        } as unknown as Partial<EnhancedBunkRequest>),
+      }),
+    ]
+    const satisfactionData = Object.fromEntries(
+      allBunkRequests.map((r) => [r.id, { status: 'satisfied' as const, detail: '' }])
+    )
+    const { container } = renderPanelWith({ allBunkRequests, satisfactionData })
+    const text = container.textContent ?? ''
+    expect(text.indexOf('Emma')).toBeLessThan(text.indexOf('Liam'))
+    expect(text.indexOf('Liam')).toBeLessThan(text.indexOf('Olivia'))
+  })
+
+  it('renders animated sparkle + P badge on material age preference', () => {
+    const ageReq = makeRequest({
+      id: 'a1',
+      request_type: 'age_preference',
+      source_field: 'bunk_with',
+      source: 'family',
+      age_preference_target: 'older',
+    })
+    const allBunkRequests = [ageReq]
+    const agePreferenceRequests = [ageReq]
+    const satisfactionData = { a1: { status: 'satisfied' as const, detail: '' } }
+    const { container } = renderPanelWith({
+      allBunkRequests,
+      agePreferenceRequests,
+      satisfactionData,
+    })
+    expect(container.querySelector('.sparkle-material')).not.toBeNull()
+    expect(screen.getByText('P')).toBeInTheDocument()
+  })
+
+  it('renders S badge on staff-source age preference', () => {
+    const ageReq = makeRequest({
+      id: 'a1',
+      request_type: 'age_preference',
+      source_field: 'bunking_notes',
+      source: 'staff',
+      age_preference_target: 'younger',
+    })
+    const allBunkRequests = [ageReq]
+    const agePreferenceRequests = [ageReq]
+    const satisfactionData = { a1: { status: 'satisfied' as const, detail: '' } }
+    renderPanelWith({ allBunkRequests, agePreferenceRequests, satisfactionData })
+    expect(screen.getByText('S')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/camper/BunkingStatusPanel.test.tsx
+++ b/frontend/src/components/camper/BunkingStatusPanel.test.tsx
@@ -276,15 +276,13 @@ describe('BunkingStatusPanel — Stage 3b.1 R3 row list', () => {
 
     // Assert using document-order positions of key elements.
     //
-    // The Staff sub-divider renders a <span> whose trimmed textContent is
-    // exactly "Staff" — no children (text-only span). The summary line
-    // "Staff request satisfaction:" contains "Staff" as a substring but does
-    // NOT trim to exactly "Staff", so this selector targets only the divider.
+    // The combined Parent ↑ │ ⬇ Staff divider is the only element on the
+    // panel with the `font-mono` utility on its container <div>. The summary
+    // and row text don't use font-mono.
     const allElements = Array.from(container.querySelectorAll('*'))
-    const dividerEl = allElements.find(
-      (el) => el.textContent?.trim() === 'Staff' && el.children.length === 0
-    )
+    const dividerEl = container.querySelector('div.font-mono')
     expect(dividerEl).not.toBeNull()
+    expect(dividerEl?.textContent).toMatch(/Parent.*Staff/)
     const dividerIdx = allElements.indexOf(dividerEl as Element)
 
     // Emma and Riley's names appear in a <Link> (rendered as <a>) or <span>
@@ -331,14 +329,10 @@ describe('BunkingStatusPanel — Stage 3b.1 R3 row list', () => {
     ]
     const satisfactionData = { p1: { status: 'satisfied' as const, detail: '' } }
     const { container } = renderPanelWith({ allBunkRequests, satisfactionData })
-    // The bare word "Staff" should not appear as a divider label.
-    // Note: this is a heuristic — if the existing UI uses "Staff" in some other
-    // context (e.g. an alert label), the assertion may need refining. For now
-    // assert no divider element with the literal text "Staff" exists.
-    const dividers = Array.from(container.querySelectorAll('*')).filter(
-      (el) => el.textContent?.trim() === 'Staff'
-    )
-    expect(dividers.length).toBe(0)
+    // The Parent ↑ │ ⬇ Staff divider only renders when both groups exist.
+    // With only parent rows present, the font-mono divider container should
+    // not be in the DOM.
+    expect(container.querySelector('div.font-mono')).toBeNull()
   })
 
   it('sorts Parent rows alphabetically by requestee first_name', () => {

--- a/frontend/src/components/camper/BunkingStatusPanel.test.tsx
+++ b/frontend/src/components/camper/BunkingStatusPanel.test.tsx
@@ -273,13 +273,48 @@ describe('BunkingStatusPanel — Stage 3b.1 R3 row list', () => {
       s1: { status: 'satisfied' as const, detail: '' },
     }
     const { container } = renderPanelWith({ allBunkRequests, satisfactionData })
-    const text = container.textContent ?? ''
-    const emmaIdx = text.indexOf('Emma')
-    const staffIdx = text.indexOf('Staff')
-    const rileyIdx = text.indexOf('Riley')
+
+    // Assert using document-order positions of key elements.
+    //
+    // The Staff sub-divider renders a <span> whose trimmed textContent is
+    // exactly "Staff" — no children (text-only span). The summary line
+    // "Staff request satisfaction:" contains "Staff" as a substring but does
+    // NOT trim to exactly "Staff", so this selector targets only the divider.
+    const allElements = Array.from(container.querySelectorAll('*'))
+    const dividerEl = allElements.find(
+      (el) => el.textContent?.trim() === 'Staff' && el.children.length === 0
+    )
+    expect(dividerEl).not.toBeNull()
+    const dividerIdx = allElements.indexOf(dividerEl as Element)
+
+    // Emma and Riley's names appear in a <Link> (rendered as <a>) or <span>
+    // with the full "First Last" string and possibly a nested SVG icon. We
+    // find the closest ancestor element that (a) contains the name, and (b)
+    // does NOT contain the other name, so we stay within the individual row.
+    const emmaEl = allElements.find(
+      (el) =>
+        el.textContent?.includes('Emma') &&
+        !el.textContent?.includes('Riley') &&
+        el.tagName !== 'BODY' &&
+        el.tagName !== 'HTML'
+    )
+    const rileyEl = allElements.find(
+      (el) =>
+        el.textContent?.includes('Riley') &&
+        !el.textContent?.includes('Emma') &&
+        el.tagName !== 'BODY' &&
+        el.tagName !== 'HTML'
+    )
+
+    expect(emmaEl).not.toBeNull()
+    expect(rileyEl).not.toBeNull()
+
+    const emmaIdx = allElements.indexOf(emmaEl as Element)
+    const rileyIdx = allElements.indexOf(rileyEl as Element)
+
     expect(emmaIdx).toBeGreaterThan(-1)
-    expect(staffIdx).toBeGreaterThan(emmaIdx)
-    expect(rileyIdx).toBeGreaterThan(staffIdx)
+    expect(emmaIdx).toBeLessThan(dividerIdx)
+    expect(dividerIdx).toBeLessThan(rileyIdx)
   })
 
   it('omits Staff sub-divider when no staff rows exist', () => {

--- a/frontend/src/components/camper/BunkingStatusPanel.test.tsx
+++ b/frontend/src/components/camper/BunkingStatusPanel.test.tsx
@@ -62,6 +62,29 @@ function renderPanel(allBunkRequests: EnhancedBunkRequest[]) {
   )
 }
 
+interface RenderPanelOptions {
+  allBunkRequests: EnhancedBunkRequest[]
+  satisfactionData: Record<
+    string,
+    { status: 'satisfied' | 'not_satisfied' | 'checking' | 'unknown'; detail?: string }
+  >
+}
+
+function renderPanelWith({ allBunkRequests, satisfactionData }: RenderPanelOptions) {
+  return render(
+    <MemoryRouter>
+      <BunkingStatusPanel
+        camper={makeCamper()}
+        sessionShortName="S1"
+        allBunkRequests={allBunkRequests}
+        agePreferenceRequests={[]}
+        satisfactionData={satisfactionData}
+        satisfactionLoading={false}
+      />
+    </MemoryRouter>
+  )
+}
+
 describe('BunkingStatusPanel — resolved-only request list', () => {
   it('does not render pending bunk_with rows in the per-camper request list', () => {
     const requests: EnhancedBunkRequest[] = [
@@ -128,5 +151,92 @@ describe('BunkingStatusPanel — resolved-only request list', () => {
     expect(screen.getByText(/no bunk requests on file/i)).toBeTruthy()
     expect(screen.queryByText('Olivia Chen')).toBeNull()
     expect(screen.queryByText('Riley Sam')).toBeNull()
+  })
+})
+
+describe('BunkingStatusPanel — Stage 3b.1 two-column summary line', () => {
+  it('renders two columns when both materialParent and staff have requests', () => {
+    const allBunkRequests = [
+      makeRequest({
+        id: 'p1',
+        request_type: 'bunk_with',
+        source_field: 'bunk_with',
+        source: 'family',
+      }),
+      makeRequest({
+        id: 's1',
+        request_type: 'not_bunk_with',
+        source_field: 'not_bunk_with',
+        source: 'staff',
+      }),
+    ]
+    const satisfactionData = {
+      p1: { status: 'satisfied' as const, detail: '' },
+      s1: { status: 'satisfied' as const, detail: '' },
+    }
+    renderPanelWith({ allBunkRequests, satisfactionData })
+    expect(screen.getByText(/Parent request satisfaction:/i)).toBeInTheDocument()
+    expect(screen.getByText(/Staff request satisfaction:/i)).toBeInTheDocument()
+  })
+
+  it('renders single Parent line when only parent material requests', () => {
+    const allBunkRequests = [
+      makeRequest({
+        id: 'p1',
+        request_type: 'bunk_with',
+        source_field: 'bunk_with',
+        source: 'family',
+      }),
+    ]
+    const satisfactionData = { p1: { status: 'satisfied' as const, detail: '' } }
+    renderPanelWith({ allBunkRequests, satisfactionData })
+    expect(screen.getByText(/Parent request satisfaction:/i)).toBeInTheDocument()
+    expect(screen.queryByText(/Staff request satisfaction:/i)).toBeNull()
+  })
+
+  it('renders single Staff line when only staff requests', () => {
+    const allBunkRequests = [
+      makeRequest({
+        id: 's1',
+        request_type: 'not_bunk_with',
+        source_field: 'not_bunk_with',
+        source: 'staff',
+      }),
+    ]
+    const satisfactionData = { s1: { status: 'satisfied' as const, detail: '' } }
+    renderPanelWith({ allBunkRequests, satisfactionData })
+    expect(screen.getByText(/Staff request satisfaction:/i)).toBeInTheDocument()
+    expect(screen.queryByText(/Parent request satisfaction:/i)).toBeNull()
+  })
+
+  it('hides summary entirely when only best-effort parent (no material, no staff)', () => {
+    const allBunkRequests = [
+      makeRequest({
+        id: 'b1',
+        request_type: 'age_preference',
+        source_field: 'socialize_with',
+        source: 'family',
+        age_preference_target: 'older',
+      }),
+    ]
+    const satisfactionData = { b1: { status: 'satisfied' as const, detail: '' } }
+    renderPanelWith({ allBunkRequests, satisfactionData })
+    expect(screen.queryByText(/Parent request satisfaction:/i)).toBeNull()
+    expect(screen.queryByText(/Staff request satisfaction:/i)).toBeNull()
+  })
+
+  it('shows green check when ratio is 1.0', () => {
+    const allBunkRequests = [
+      makeRequest({
+        id: 'p1',
+        request_type: 'bunk_with',
+        source_field: 'bunk_with',
+        source: 'family',
+      }),
+    ]
+    const satisfactionData = { p1: { status: 'satisfied' as const, detail: '' } }
+    const { container } = renderPanelWith({ allBunkRequests, satisfactionData })
+    const greenCheck = container.querySelector('.text-green-500, .text-green-400, .text-green-600')
+    expect(greenCheck).not.toBeNull()
   })
 })

--- a/frontend/src/components/camper/BunkingStatusPanel.test.tsx
+++ b/frontend/src/components/camper/BunkingStatusPanel.test.tsx
@@ -215,19 +215,55 @@ describe('BunkingStatusPanel — Stage 3b.1 two-column summary line', () => {
   })
 
   it('hides summary entirely when only best-effort parent (no material, no staff)', () => {
-    const allBunkRequests = [
-      makeRequest({
-        id: 'b1',
-        request_type: 'age_preference',
-        source_field: 'socialize_with',
-        source: 'family',
-        age_preference_target: 'older',
-      }),
-    ]
+    const bestEffortAgePref = makeRequest({
+      id: 'b1',
+      request_type: 'age_preference',
+      source_field: 'socialize_with',
+      source: 'family',
+      age_preference_target: 'older',
+    })
     const satisfactionData = { b1: { status: 'satisfied' as const, detail: '' } }
-    renderPanelWith({ allBunkRequests, satisfactionData })
+    renderPanelWith({
+      allBunkRequests: [bestEffortAgePref],
+      agePreferenceRequests: [bestEffortAgePref],
+      satisfactionData,
+    })
     expect(screen.queryByText(/Parent request satisfaction:/i)).toBeNull()
     expect(screen.queryByText(/Staff request satisfaction:/i)).toBeNull()
+  })
+
+  it('shows Parent line for material parent age preference (source_field=bunk_with)', () => {
+    const materialAgePref = makeRequest({
+      id: 'a1',
+      request_type: 'age_preference',
+      source_field: 'bunk_with',
+      source: 'family',
+      age_preference_target: 'older',
+    })
+    const satisfactionData = { a1: { status: 'satisfied' as const, detail: '' } }
+    renderPanelWith({
+      allBunkRequests: [materialAgePref],
+      agePreferenceRequests: [materialAgePref],
+      satisfactionData,
+    })
+    expect(screen.getByText(/Parent request satisfaction:/i)).toBeInTheDocument()
+  })
+
+  it('shows Staff line for staff age preference (source=staff)', () => {
+    const staffAgePref = makeRequest({
+      id: 'a2',
+      request_type: 'age_preference',
+      source_field: 'bunking_notes',
+      source: 'staff',
+      age_preference_target: 'younger',
+    })
+    const satisfactionData = { a2: { status: 'satisfied' as const, detail: '' } }
+    renderPanelWith({
+      allBunkRequests: [staffAgePref],
+      agePreferenceRequests: [staffAgePref],
+      satisfactionData,
+    })
+    expect(screen.getByText(/Staff request satisfaction:/i)).toBeInTheDocument()
   })
 
   it('shows green check when ratio is 1.0', () => {
@@ -240,8 +276,14 @@ describe('BunkingStatusPanel — Stage 3b.1 two-column summary line', () => {
       }),
     ]
     const satisfactionData = { p1: { status: 'satisfied' as const, detail: '' } }
-    const { container } = renderPanelWith({ allBunkRequests, satisfactionData })
-    const greenCheck = container.querySelector('.text-green-500, .text-green-400, .text-green-600')
+    renderPanelWith({ allBunkRequests, satisfactionData })
+    // Scope to the parent-summary block so unrelated green elements (e.g. the
+    // satisfied-row "Met" pill) can't false-pass the assertion.
+    const parentSummary = screen.getByText(/Parent request satisfaction:/i).closest('div')
+    expect(parentSummary).not.toBeNull()
+    const greenCheck = parentSummary?.querySelector(
+      '.text-green-500, .text-green-400, .text-green-600'
+    )
     expect(greenCheck).not.toBeNull()
   })
 })

--- a/frontend/src/components/camper/BunkingStatusPanel.tsx
+++ b/frontend/src/components/camper/BunkingStatusPanel.tsx
@@ -206,12 +206,30 @@ export function BunkingStatusPanel({
       </div>
 
       <div className="space-y-4 p-6">
-        {/* Bunk Requests - partitioned into parent / staff / age sections.
-            Rendered BEFORE the summary so that DOM text order matches the
-            visual grouping (parent rows → Staff sub-divider → staff rows →
-            age rows). The summary "Staff request satisfaction:" label would
-            otherwise appear before the row list in text() content, breaking
-            ordering assertions in tests. */}
+        {/* Request Satisfaction Summary — rendered above the row list, matching
+            the spec design. Summary appears first so staff can immediately see
+            overall satisfaction before scanning individual rows. */}
+        {showSummary && (
+          <div className="bg-muted/40 border-border rounded-lg border px-4 py-3">
+            {showParent && showStaff ? (
+              <div className="grid grid-cols-[1fr_1px_1fr] items-center">
+                <div className="px-4">
+                  <SliceLine label="Parent request satisfaction:" slice={slices.materialParent} />
+                </div>
+                <div className="bg-border self-stretch" />
+                <div className="px-4">
+                  <SliceLine label="Staff request satisfaction:" slice={slices.staff} />
+                </div>
+              </div>
+            ) : showParent ? (
+              <SliceLine label="Parent request satisfaction:" slice={slices.materialParent} />
+            ) : (
+              <SliceLine label="Staff request satisfaction:" slice={slices.staff} />
+            )}
+          </div>
+        )}
+
+        {/* Bunk Requests - partitioned into parent / staff / age sections. */}
         {parentRows.length > 0 || staffRows.length > 0 || ageRows.length > 0 ? (
           <div className="space-y-1">
             {parentRows.map((req) => {
@@ -273,30 +291,6 @@ export function BunkingStatusPanel({
         ) : (
           <div className="py-4 text-center">
             <p className="text-muted-foreground text-sm">No bunk requests on file</p>
-          </div>
-        )}
-
-        {/* Request Satisfaction Summary — rendered after the row list so that
-            DOM text order (rows first, summary below) aligns with the visual
-            scan order and avoids "Staff request satisfaction:" appearing before
-            the Staff sub-divider in text() content. */}
-        {showSummary && (
-          <div className="bg-muted/40 border-border mt-3 rounded-lg border px-4 py-3">
-            {showParent && showStaff ? (
-              <div className="grid grid-cols-[1fr_1px_1fr] items-center">
-                <div className="px-4">
-                  <SliceLine label="Parent request satisfaction:" slice={slices.materialParent} />
-                </div>
-                <div className="bg-border self-stretch" />
-                <div className="px-4">
-                  <SliceLine label="Staff request satisfaction:" slice={slices.staff} />
-                </div>
-              </div>
-            ) : showParent ? (
-              <SliceLine label="Parent request satisfaction:" slice={slices.materialParent} />
-            ) : (
-              <SliceLine label="Staff request satisfaction:" slice={slices.staff} />
-            )}
           </div>
         )}
       </div>

--- a/frontend/src/components/camper/BunkingStatusPanel.tsx
+++ b/frontend/src/components/camper/BunkingStatusPanel.tsx
@@ -3,7 +3,7 @@
  */
 import { useMemo } from 'react'
 import { Link } from 'react-router'
-import { Heart, Home, Clock, CheckCircle } from 'lucide-react'
+import { Heart, Home, Clock, CheckCircle, ChevronUp, ChevronDown } from 'lucide-react'
 import { sessionNameToUrl } from '../../utils/sessionUtils'
 import { deriveSlicesFromSatisfactionMap } from '../../utils/deriveSlicesFromSatisfactionMap'
 import { partitionRequestsBySource } from '../../utils/partitionRequestsBySource'
@@ -45,17 +45,29 @@ interface BunkingStatusPanelProps {
   satisfactionLoading: boolean
 }
 
-// Sub-divider between parent rows and staff rows (and before age rows).
-// Styled to match the existing age-preference divider style used elsewhere
-// in this panel family.
-function SubDivider({ label }: { label: string }) {
+// Single divider between parent and staff sections — labeled on both sides
+// with directional chevrons so staff can read which group is above and which
+// is below at a glance. Renders only when BOTH groups have rows.
+function ParentStaffDivider() {
   return (
-    <div className="text-muted-foreground/60 my-3 flex items-center gap-3 font-mono text-[10.5px] tracking-[0.18em] uppercase">
+    <div className="text-muted-foreground/70 my-3 flex items-center gap-2 font-mono text-[10.5px] tracking-[0.18em] uppercase">
       <span className="border-border/60 flex-1 border-t" />
-      <span>{label}</span>
+      <span className="inline-flex items-center gap-1">
+        Parent <ChevronUp className="h-3 w-3" aria-hidden="true" />
+      </span>
+      <span className="border-border/60 h-3 border-l" aria-hidden="true" />
+      <span className="inline-flex items-center gap-1">
+        <ChevronDown className="h-3 w-3" aria-hidden="true" /> Staff
+      </span>
       <span className="border-border/60 flex-1 border-t" />
     </div>
   )
+}
+
+// Subtle hairline above the age-preference tail section — no label, just a
+// quiet visual break so age rows don't bleed into the staff/parent rows above.
+function AgePreferenceDivider() {
+  return <div className="border-border/60 my-2 border-t" aria-hidden="true" />
 }
 
 export function BunkingStatusPanel({
@@ -99,7 +111,6 @@ export function BunkingStatusPanel({
       ...personRequests,
       ...(agePreferenceRequests ?? []).filter((r) => r.status === 'resolved'),
     ],
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [personRequests, agePreferenceRequests]
   )
 
@@ -210,7 +221,7 @@ export function BunkingStatusPanel({
             the spec design. Summary appears first so staff can immediately see
             overall satisfaction before scanning individual rows. */}
         {showSummary && (
-          <div className="bg-muted/40 border-border rounded-lg border px-4 py-3">
+          <div className="bg-muted/20 border-border rounded-lg border px-4 py-3">
             {showParent && showStaff ? (
               <div className="grid grid-cols-[1fr_1px_1fr] items-center">
                 <div className="px-4">
@@ -252,7 +263,7 @@ export function BunkingStatusPanel({
               )
             })}
 
-            {staffRows.length > 0 && <SubDivider label="Staff" />}
+            {parentRows.length > 0 && staffRows.length > 0 && <ParentStaffDivider />}
             {staffRows.map((req) => {
               const sat = satisfactionData[req.id]
               return (
@@ -270,7 +281,9 @@ export function BunkingStatusPanel({
               )
             })}
 
-            {ageRows.length > 0 && <SubDivider label="Age preference" />}
+            {ageRows.length > 0 && (parentRows.length > 0 || staffRows.length > 0) && (
+              <AgePreferenceDivider />
+            )}
             {ageRows.map((req) => {
               const sat = satisfactionData[req.id]
               return (

--- a/frontend/src/components/camper/BunkingStatusPanel.tsx
+++ b/frontend/src/components/camper/BunkingStatusPanel.tsx
@@ -3,16 +3,25 @@
  */
 import { useMemo } from 'react'
 import { Link } from 'react-router'
-import { Heart, Home, Clock, CheckCircle, ChevronUp, ChevronDown } from 'lucide-react'
+import { Heart, Home, Clock, CheckCircle } from 'lucide-react'
 import { sessionNameToUrl } from '../../utils/sessionUtils'
 import { deriveSlicesFromSatisfactionMap } from '../../utils/deriveSlicesFromSatisfactionMap'
 import { partitionRequestsBySource } from '../../utils/partitionRequestsBySource'
+import { isConfirmedRequest } from '../../utils/bunkRequest'
 import { BunkRequestRow } from '../BunkRequestRow'
+import { ParentStaffDivider, AgePreferenceDivider } from './RequestSectionDividers'
 import type { Camper } from '../../types/app-types'
 import type { EnhancedBunkRequest } from '../../hooks/camper/useAllBunkRequests'
 import type { SatisfactionMap } from '../../hooks/camper/types'
 import type { RequestSlice } from '../../contexts/BunkRequestContext'
 import type { BunkRequestsResponse, PersonsResponse } from '../../types/pocketbase-types'
+
+/** Augments a request with the resolved targetPerson used for sort + display.
+ *  EnhancedBunkRequest itself doesn't declare targetPerson — we attach it in
+ *  partitionInput below. */
+type WithTargetPerson<T> = T & {
+  targetPerson?: { first_name?: string; last_name?: string } | null
+}
 
 function ratioColor(slice: RequestSlice): string {
   if (slice.total === 0) return ''
@@ -45,31 +54,6 @@ interface BunkingStatusPanelProps {
   satisfactionLoading: boolean
 }
 
-// Single divider between parent and staff sections — labeled on both sides
-// with directional chevrons so staff can read which group is above and which
-// is below at a glance. Renders only when BOTH groups have rows.
-function ParentStaffDivider() {
-  return (
-    <div className="text-muted-foreground/70 my-3 flex items-center gap-2 font-mono text-[10.5px] tracking-[0.18em] uppercase">
-      <span className="border-border/60 flex-1 border-t" />
-      <span className="inline-flex items-center gap-1">
-        Parent <ChevronUp className="h-3 w-3" aria-hidden="true" />
-      </span>
-      <span className="border-border/60 h-3 border-l" aria-hidden="true" />
-      <span className="inline-flex items-center gap-1">
-        <ChevronDown className="h-3 w-3" aria-hidden="true" /> Staff
-      </span>
-      <span className="border-border/60 flex-1 border-t" />
-    </div>
-  )
-}
-
-// Subtle hairline above the age-preference tail section — no label, just a
-// quiet visual break so age rows don't bleed into the staff/parent rows above.
-function AgePreferenceDivider() {
-  return <div className="border-border/60 my-2 border-t" aria-hidden="true" />
-}
-
 export function BunkingStatusPanel({
   camper,
   enrolledCampers,
@@ -79,48 +63,51 @@ export function BunkingStatusPanel({
   satisfactionData,
   satisfactionLoading,
 }: BunkingStatusPanelProps) {
-  // The per-camper list must agree with the summary above —
-  // both filter to status === 'resolved' so pending and declined rows
-  // don't render here with status-colored dots.
-  const personRequests = allBunkRequests.filter(
-    (r) => r.status === 'resolved' && r.request_type !== 'age_preference'
+  // The per-camper list must agree with the summary above — both filter to
+  // status === 'resolved' so pending and declined rows don't render with
+  // status-colored dots. `personRequests` covers non-age_preference resolved
+  // rows; resolved age prefs flow in via `agePreferenceRequests` and are
+  // merged into `summaryRequests` for both the slice summary and the row list.
+  const personRequests = useMemo(
+    () =>
+      allBunkRequests.filter((r) => r.status === 'resolved' && r.request_type !== 'age_preference'),
+    [allBunkRequests]
+  )
+
+  const resolvedAgePrefs = useMemo(
+    () => (agePreferenceRequests ?? []).filter((r) => r.status === 'resolved'),
+    [agePreferenceRequests]
+  )
+
+  // Used for both the summary slices and the row partition so material parent
+  // age prefs (source_field='bunk_with') and staff age prefs (source='staff')
+  // contribute to "X/Y met" instead of only rendering as rows below.
+  const summaryRequests = useMemo(
+    () => [...personRequests, ...resolvedAgePrefs],
+    [personRequests, resolvedAgePrefs]
   )
 
   const slices = useMemo(
-    () => deriveSlicesFromSatisfactionMap(personRequests, satisfactionData),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [allBunkRequests, satisfactionData]
+    () => deriveSlicesFromSatisfactionMap(summaryRequests, satisfactionData),
+    [summaryRequests, satisfactionData]
   )
 
   const showParent = slices.materialParent.total > 0
   const showStaff = slices.staff.total > 0
   const showSummary = showParent || showStaff
 
-  // R3: Combine person + resolved age preference requests into one list,
-  // then partition into parent / staff / age buckets for ordered rendering.
-  //
-  // targetPerson enrichment strategy (Case b): EnhancedBunkRequest carries
+  // R3: targetPerson enrichment strategy (Case b): EnhancedBunkRequest carries
   // `requestedPersonName` (a pre-built "First Last" string) for production
   // data. The partition utility sorts by `targetPerson.{first_name,last_name}`.
   // We split the string here so the sort works; if the string is absent (rare
   // edge case) the row gets a no-op sort key of '' which is acceptable.
-  // In tests, `targetPerson` is supplied directly via the cast in makeRequest()
+  // In tests, `targetPerson` is supplied directly via the WithTargetPerson type
   // and takes precedence via the `?? parsedFallback` below.
-  const renderableRequests = useMemo(
-    () => [
-      ...personRequests,
-      ...(agePreferenceRequests ?? []).filter((r) => r.status === 'resolved'),
-    ],
-    [personRequests, agePreferenceRequests]
-  )
-
   const partitionInput = useMemo(
     () =>
-      renderableRequests.map((r) => {
-        // r may carry targetPerson directly (test injection or future enrichment)
-        const existing = (
-          r as unknown as { targetPerson?: { first_name?: string; last_name?: string } | null }
-        ).targetPerson
+      summaryRequests.map((r) => {
+        // r may carry targetPerson directly (test injection or future enrichment).
+        const existing = (r as WithTargetPerson<EnhancedBunkRequest>).targetPerson
         if (existing) return { ...r, targetPerson: existing }
         // Fall back: split requestedPersonName "First Last" into parts
         const name = r.requestedPersonName ?? ''
@@ -133,7 +120,7 @@ export function BunkingStatusPanel({
           : undefined
         return { ...r, targetPerson: parsedFallback }
       }),
-    [renderableRequests]
+    [summaryRequests]
   )
 
   const {
@@ -254,9 +241,7 @@ export function BunkingStatusPanel({
                   // we pass the targetPerson we already computed in partitionInput.
                   targetPerson={req.targetPerson as unknown as PersonsResponse | null}
                   satisfaction={sat?.status ?? null}
-                  showSatisfaction={
-                    req.status === 'resolved' && !!req.requestee_id && req.requestee_id > 0
-                  }
+                  showSatisfaction={isConfirmedRequest(req)}
                   satisfactionLoading={satisfactionLoading}
                   satisfactionDetail={sat?.detail}
                 />
@@ -272,9 +257,7 @@ export function BunkingStatusPanel({
                   request={req as unknown as BunkRequestsResponse}
                   targetPerson={req.targetPerson as unknown as PersonsResponse | null}
                   satisfaction={sat?.status ?? null}
-                  showSatisfaction={
-                    req.status === 'resolved' && !!req.requestee_id && req.requestee_id > 0
-                  }
+                  showSatisfaction={isConfirmedRequest(req)}
                   satisfactionLoading={satisfactionLoading}
                   satisfactionDetail={sat?.detail}
                 />

--- a/frontend/src/components/camper/BunkingStatusPanel.tsx
+++ b/frontend/src/components/camper/BunkingStatusPanel.tsx
@@ -3,15 +3,16 @@
  */
 import { useMemo } from 'react'
 import { Link } from 'react-router'
-import { Heart, Home, Clock, CheckCircle, Sparkles } from 'lucide-react'
-import CamperLink from '../CamperLink'
+import { Heart, Home, Clock, CheckCircle } from 'lucide-react'
 import { sessionNameToUrl } from '../../utils/sessionUtils'
-import { MUTUAL_BADGE_CLASSES } from '../../utils/dispositionColors'
 import { deriveSlicesFromSatisfactionMap } from '../../utils/deriveSlicesFromSatisfactionMap'
+import { partitionRequestsBySource } from '../../utils/partitionRequestsBySource'
+import { BunkRequestRow } from '../BunkRequestRow'
 import type { Camper } from '../../types/app-types'
 import type { EnhancedBunkRequest } from '../../hooks/camper/useAllBunkRequests'
 import type { SatisfactionMap } from '../../hooks/camper/types'
 import type { RequestSlice } from '../../contexts/BunkRequestContext'
+import type { BunkRequestsResponse, PersonsResponse } from '../../types/pocketbase-types'
 
 function ratioColor(slice: RequestSlice): string {
   if (slice.total === 0) return ''
@@ -44,6 +45,19 @@ interface BunkingStatusPanelProps {
   satisfactionLoading: boolean
 }
 
+// Sub-divider between parent rows and staff rows (and before age rows).
+// Styled to match the existing age-preference divider style used elsewhere
+// in this panel family.
+function SubDivider({ label }: { label: string }) {
+  return (
+    <div className="text-muted-foreground/60 my-3 flex items-center gap-3 font-mono text-[10.5px] tracking-[0.18em] uppercase">
+      <span className="border-border/60 flex-1 border-t" />
+      <span>{label}</span>
+      <span className="border-border/60 flex-1 border-t" />
+    </div>
+  )
+}
+
 export function BunkingStatusPanel({
   camper,
   enrolledCampers,
@@ -69,6 +83,53 @@ export function BunkingStatusPanel({
   const showParent = slices.materialParent.total > 0
   const showStaff = slices.staff.total > 0
   const showSummary = showParent || showStaff
+
+  // R3: Combine person + resolved age preference requests into one list,
+  // then partition into parent / staff / age buckets for ordered rendering.
+  //
+  // targetPerson enrichment strategy (Case b): EnhancedBunkRequest carries
+  // `requestedPersonName` (a pre-built "First Last" string) for production
+  // data. The partition utility sorts by `targetPerson.{first_name,last_name}`.
+  // We split the string here so the sort works; if the string is absent (rare
+  // edge case) the row gets a no-op sort key of '' which is acceptable.
+  // In tests, `targetPerson` is supplied directly via the cast in makeRequest()
+  // and takes precedence via the `?? parsedFallback` below.
+  const renderableRequests = useMemo(
+    () => [
+      ...personRequests,
+      ...(agePreferenceRequests ?? []).filter((r) => r.status === 'resolved'),
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [personRequests, agePreferenceRequests]
+  )
+
+  const partitionInput = useMemo(
+    () =>
+      renderableRequests.map((r) => {
+        // r may carry targetPerson directly (test injection or future enrichment)
+        const existing = (
+          r as unknown as { targetPerson?: { first_name?: string; last_name?: string } | null }
+        ).targetPerson
+        if (existing) return { ...r, targetPerson: existing }
+        // Fall back: split requestedPersonName "First Last" into parts
+        const name = r.requestedPersonName ?? ''
+        const spaceIdx = name.indexOf(' ')
+        const parsedFallback = name
+          ? {
+              first_name: spaceIdx >= 0 ? name.slice(0, spaceIdx) : name,
+              last_name: spaceIdx >= 0 ? name.slice(spaceIdx + 1) : '',
+            }
+          : undefined
+        return { ...r, targetPerson: parsedFallback }
+      }),
+    [renderableRequests]
+  )
+
+  const {
+    parent: parentRows,
+    staff: staffRows,
+    age: ageRows,
+  } = useMemo(() => partitionRequestsBySource(partitionInput), [partitionInput])
 
   return (
     <div className="bg-card border-border overflow-hidden rounded-2xl border shadow-sm">
@@ -145,7 +206,80 @@ export function BunkingStatusPanel({
       </div>
 
       <div className="space-y-4 p-6">
-        {/* Request Satisfaction Summary */}
+        {/* Bunk Requests - partitioned into parent / staff / age sections.
+            Rendered BEFORE the summary so that DOM text order matches the
+            visual grouping (parent rows → Staff sub-divider → staff rows →
+            age rows). The summary "Staff request satisfaction:" label would
+            otherwise appear before the row list in text() content, breaking
+            ordering assertions in tests. */}
+        {parentRows.length > 0 || staffRows.length > 0 || ageRows.length > 0 ? (
+          <div className="space-y-1">
+            {parentRows.map((req) => {
+              const sat = satisfactionData[req.id]
+              return (
+                <BunkRequestRow
+                  key={req.id}
+                  request={req as unknown as BunkRequestsResponse}
+                  // targetPerson drives displayName in BunkRequestRow. EnhancedBunkRequest
+                  // uses camelCase requestedPersonName (not the PB snake_case field), so
+                  // we pass the targetPerson we already computed in partitionInput.
+                  targetPerson={req.targetPerson as unknown as PersonsResponse | null}
+                  satisfaction={sat?.status ?? null}
+                  showSatisfaction={
+                    req.status === 'resolved' && !!req.requestee_id && req.requestee_id > 0
+                  }
+                  satisfactionLoading={satisfactionLoading}
+                  satisfactionDetail={sat?.detail}
+                />
+              )
+            })}
+
+            {staffRows.length > 0 && <SubDivider label="Staff" />}
+            {staffRows.map((req) => {
+              const sat = satisfactionData[req.id]
+              return (
+                <BunkRequestRow
+                  key={req.id}
+                  request={req as unknown as BunkRequestsResponse}
+                  targetPerson={req.targetPerson as unknown as PersonsResponse | null}
+                  satisfaction={sat?.status ?? null}
+                  showSatisfaction={
+                    req.status === 'resolved' && !!req.requestee_id && req.requestee_id > 0
+                  }
+                  satisfactionLoading={satisfactionLoading}
+                  satisfactionDetail={sat?.detail}
+                />
+              )
+            })}
+
+            {ageRows.length > 0 && <SubDivider label="Age preference" />}
+            {ageRows.map((req) => {
+              const sat = satisfactionData[req.id]
+              return (
+                <BunkRequestRow
+                  key={req.id}
+                  request={req as unknown as BunkRequestsResponse}
+                  targetPerson={req.targetPerson as unknown as PersonsResponse | null}
+                  satisfaction={sat?.status ?? null}
+                  showSatisfaction={true}
+                  satisfactionLoading={satisfactionLoading}
+                  satisfactionDetail={sat?.detail}
+                  isMaterialAgePreference={req.source_field === 'bunk_with'}
+                  staffAgeBadge={req.source === 'staff'}
+                />
+              )
+            })}
+          </div>
+        ) : (
+          <div className="py-4 text-center">
+            <p className="text-muted-foreground text-sm">No bunk requests on file</p>
+          </div>
+        )}
+
+        {/* Request Satisfaction Summary — rendered after the row list so that
+            DOM text order (rows first, summary below) aligns with the visual
+            scan order and avoids "Staff request satisfaction:" appearing before
+            the Staff sub-divider in text() content. */}
         {showSummary && (
           <div className="bg-muted/40 border-border mt-3 rounded-lg border px-4 py-3">
             {showParent && showStaff ? (
@@ -165,142 +299,7 @@ export function BunkingStatusPanel({
             )}
           </div>
         )}
-
-        {/* Bunk Requests - Compact list */}
-        {personRequests.length > 0 ? (
-          <div className="space-y-1.5">
-            {personRequests.map((request, idx) => {
-              const isBunkWith = request.request_type === 'bunk_with'
-              const isConfirmed =
-                request.status === 'resolved' && request.requestee_id && request.requestee_id > 0
-
-              // Determine display name
-              const displayName =
-                request.requestedPersonName ??
-                (request as unknown as { requested_person_name?: string }).requested_person_name ??
-                (request.requestee_id && request.requestee_id < 0
-                  ? `Person ${request.requestee_id}`
-                  : 'Unknown')
-
-              // Get satisfaction status
-              const satisfaction = satisfactionData[request.id]
-              const showSatisfaction =
-                request.status === 'resolved' && request.requestee_id && request.requestee_id > 0
-
-              return (
-                <div
-                  key={request.id || idx}
-                  className="hover:bg-muted/50 hover:border-border/50 flex items-center gap-2 rounded-lg border border-transparent px-3 py-2 text-sm transition-colors"
-                >
-                  {/* Status indicator */}
-                  <div
-                    className={`h-2 w-2 flex-shrink-0 rounded-full ${
-                      request.status === 'resolved'
-                        ? 'bg-green-500'
-                        : request.status === 'declined'
-                          ? 'bg-red-500'
-                          : 'bg-amber-500'
-                    }`}
-                  />
-
-                  {/* Request type */}
-                  <span
-                    className={`font-medium ${isBunkWith ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400'}`}
-                  >
-                    {isBunkWith ? 'Bunk with' : 'Not with'}
-                  </span>
-
-                  <span className="text-muted-foreground/60">→</span>
-
-                  {/* Target camper link */}
-                  <CamperLink
-                    personCmId={request.requestee_id}
-                    displayName={displayName}
-                    isConfirmed={!!isConfirmed}
-                  />
-
-                  {/* Mutual badge */}
-                  {request.is_reciprocal && <span className={MUTUAL_BADGE_CLASSES}>mutual</span>}
-
-                  {/* Satisfaction status */}
-                  {showSatisfaction && (
-                    <span className="ml-auto flex items-center">
-                      {satisfactionLoading ? (
-                        <span className="border-muted-foreground/30 border-t-primary inline-block h-3 w-3 animate-spin rounded-full border" />
-                      ) : satisfaction?.status === 'satisfied' ? (
-                        <span
-                          className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400"
-                          title={satisfaction.detail}
-                        >
-                          Met
-                        </span>
-                      ) : satisfaction?.status === 'not_satisfied' ? (
-                        <span
-                          className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-900/30 dark:text-red-400"
-                          title={satisfaction.detail}
-                        >
-                          Unmet
-                        </span>
-                      ) : null}
-                    </span>
-                  )}
-                </div>
-              )
-            })}
-          </div>
-        ) : (
-          <div className="py-4 text-center">
-            <p className="text-muted-foreground text-sm">No bunk requests on file</p>
-          </div>
-        )}
-
-        {/* Age Preference */}
-        {agePreferenceRequests.length > 0 && agePreferenceRequests[0]?.age_preference_target && (
-          <AgePreferenceNote
-            request={agePreferenceRequests[0]}
-            satisfaction={satisfactionData[agePreferenceRequests[0].id]}
-            satisfactionLoading={satisfactionLoading}
-          />
-        )}
       </div>
-    </div>
-  )
-}
-
-function AgePreferenceNote({
-  request,
-  satisfaction,
-  satisfactionLoading,
-}: {
-  request: EnhancedBunkRequest
-  satisfaction: { status: string; detail?: string } | undefined
-  satisfactionLoading: boolean
-}) {
-  const prefersOlder = request.age_preference_target === 'older'
-
-  return (
-    <div className="border-border flex items-center gap-2 border-t px-3 pt-3 text-sm">
-      <Sparkles className="h-4 w-4 flex-shrink-0 text-amber-500" />
-      <span className="text-muted-foreground">
-        Prefers bunking with{' '}
-        <span className="text-foreground font-medium">{prefersOlder ? 'older' : 'younger'}</span>{' '}
-        campers
-      </span>
-
-      {/* Satisfaction status */}
-      <span className="ml-auto" title={satisfaction?.detail}>
-        {satisfactionLoading ? (
-          <span className="border-muted-foreground/30 border-t-primary inline-block h-3 w-3 animate-spin rounded-full border" />
-        ) : satisfaction?.status === 'satisfied' ? (
-          <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
-            Met
-          </span>
-        ) : satisfaction?.status === 'not_satisfied' ? (
-          <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-900/30 dark:text-red-400">
-            Unmet
-          </span>
-        ) : null}
-      </span>
     </div>
   )
 }

--- a/frontend/src/components/camper/BunkingStatusPanel.tsx
+++ b/frontend/src/components/camper/BunkingStatusPanel.tsx
@@ -1,14 +1,38 @@
 /**
  * Panel showing bunking status, assignments, and request satisfaction
  */
+import { useMemo } from 'react'
 import { Link } from 'react-router'
 import { Heart, Home, Clock, CheckCircle, Sparkles } from 'lucide-react'
 import CamperLink from '../CamperLink'
 import { sessionNameToUrl } from '../../utils/sessionUtils'
 import { MUTUAL_BADGE_CLASSES } from '../../utils/dispositionColors'
+import { deriveSlicesFromSatisfactionMap } from '../../utils/deriveSlicesFromSatisfactionMap'
 import type { Camper } from '../../types/app-types'
 import type { EnhancedBunkRequest } from '../../hooks/camper/useAllBunkRequests'
 import type { SatisfactionMap } from '../../hooks/camper/types'
+import type { RequestSlice } from '../../contexts/BunkRequestContext'
+
+function ratioColor(slice: RequestSlice): string {
+  if (slice.total === 0) return ''
+  if (slice.satisfied === slice.total) return 'text-green-600 dark:text-green-400'
+  if (slice.satisfied === 0) return 'text-red-600 dark:text-red-400'
+  return 'text-amber-600 dark:text-amber-400'
+}
+
+function SliceLine({ label, slice }: { label: string; slice: RequestSlice }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-muted-foreground text-sm">{label}</span>
+      <span className={`text-sm font-semibold ${ratioColor(slice)}`}>
+        {slice.satisfied}/{slice.total} met
+      </span>
+      {slice.total > 0 && slice.satisfied === slice.total && (
+        <CheckCircle className="h-4 w-4 text-green-500 dark:text-green-400" aria-hidden="true" />
+      )}
+    </div>
+  )
+}
 
 interface BunkingStatusPanelProps {
   camper: Camper
@@ -29,28 +53,22 @@ export function BunkingStatusPanel({
   satisfactionData,
   satisfactionLoading,
 }: BunkingStatusPanelProps) {
-  // Calculate satisfaction summary. Use the affirmative resolved-only
-  // filter; an earlier `status !== 'pending'` form silently admitted
-  // declined rows.
-  const countableRequests = allBunkRequests.filter(
-    (r) =>
-      r.status === 'resolved' &&
-      (r.request_type === 'bunk_with' || r.request_type === 'not_bunk_with'
-        ? r.requestee_id && r.requestee_id > 0
-        : !!r.age_preference_target)
-  )
-  const totalCount = countableRequests.length
-  const satisfiedCount = countableRequests.filter(
-    (r) => satisfactionData[r.id]?.status === 'satisfied'
-  ).length
-  const hasSatisfactionData = !satisfactionLoading && Object.keys(satisfactionData).length > 0
-
-  // The per-camper list must agree with the "X/Y met" summary above —
+  // The per-camper list must agree with the summary above —
   // both filter to status === 'resolved' so pending and declined rows
   // don't render here with status-colored dots.
   const personRequests = allBunkRequests.filter(
     (r) => r.status === 'resolved' && r.request_type !== 'age_preference'
   )
+
+  const slices = useMemo(
+    () => deriveSlicesFromSatisfactionMap(personRequests, satisfactionData),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [allBunkRequests, satisfactionData]
+  )
+
+  const showParent = slices.materialParent.total > 0
+  const showStaff = slices.staff.total > 0
+  const showSummary = showParent || showStaff
 
   return (
     <div className="bg-card border-border overflow-hidden rounded-2xl border shadow-sm">
@@ -128,22 +146,22 @@ export function BunkingStatusPanel({
 
       <div className="space-y-4 p-6">
         {/* Request Satisfaction Summary */}
-        {totalCount > 0 && hasSatisfactionData && (
-          <div className="bg-muted/40 flex items-center gap-3 rounded-lg px-3 py-2 text-sm">
-            <span className="text-muted-foreground">Request satisfaction:</span>
-            <span
-              className={`font-semibold ${
-                satisfiedCount === totalCount
-                  ? 'text-green-600 dark:text-green-400'
-                  : satisfiedCount > 0
-                    ? 'text-amber-600 dark:text-amber-400'
-                    : 'text-red-600 dark:text-red-400'
-              }`}
-            >
-              {satisfiedCount}/{totalCount} met
-            </span>
-            {satisfiedCount === totalCount && totalCount > 0 && (
-              <CheckCircle className="h-4 w-4 text-green-500" />
+        {showSummary && (
+          <div className="bg-muted/40 border-border mt-3 rounded-lg border px-4 py-3">
+            {showParent && showStaff ? (
+              <div className="grid grid-cols-[1fr_1px_1fr] items-center">
+                <div className="px-4">
+                  <SliceLine label="Parent request satisfaction:" slice={slices.materialParent} />
+                </div>
+                <div className="bg-border self-stretch" />
+                <div className="px-4">
+                  <SliceLine label="Staff request satisfaction:" slice={slices.staff} />
+                </div>
+              </div>
+            ) : showParent ? (
+              <SliceLine label="Parent request satisfaction:" slice={slices.materialParent} />
+            ) : (
+              <SliceLine label="Staff request satisfaction:" slice={slices.staff} />
             )}
           </div>
         )}

--- a/frontend/src/components/camper/RequestSectionDividers.tsx
+++ b/frontend/src/components/camper/RequestSectionDividers.tsx
@@ -1,0 +1,31 @@
+/**
+ * Shared dividers used between parent / staff / age-preference row sections in
+ * BunkingStatusPanel and CamperDetailsPanel. Lives outside both panels so the
+ * two views stay visually identical without two copies of the JSX drifting.
+ */
+import { ChevronDown, ChevronUp } from 'lucide-react'
+
+// Single divider between parent and staff sections — labeled on both sides
+// with directional chevrons so staff can read which group is above and which
+// is below at a glance. Render only when BOTH groups have rows.
+export function ParentStaffDivider() {
+  return (
+    <div className="text-muted-foreground/70 my-3 flex items-center gap-2 font-mono text-[10.5px] tracking-[0.18em] uppercase">
+      <span className="border-border/60 flex-1 border-t" />
+      <span className="inline-flex items-center gap-1">
+        Parent <ChevronUp className="h-3 w-3" aria-hidden="true" />
+      </span>
+      <span className="border-border/60 h-3 border-l" aria-hidden="true" />
+      <span className="inline-flex items-center gap-1">
+        <ChevronDown className="h-3 w-3" aria-hidden="true" /> Staff
+      </span>
+      <span className="border-border/60 flex-1 border-t" />
+    </div>
+  )
+}
+
+// Subtle hairline above the age-preference tail section — no label, just a
+// quiet visual break so age rows don't bleed into the staff/parent rows above.
+export function AgePreferenceDivider() {
+  return <div className="border-border/60 my-2 border-t" aria-hidden="true" />
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -891,30 +891,6 @@
     }
   }
 
-  @keyframes sparkleAnim {
-    0%,
-    100% {
-      transform: scale(1) rotate(0deg);
-      opacity: 1;
-    }
-    50% {
-      transform: scale(1.18) rotate(8deg);
-      opacity: 0.85;
-    }
-  }
-
-  .sparkle-material {
-    animation: sparkleAnim 1.6s ease-in-out infinite;
-    display: inline-flex;
-    transform-origin: center center;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .sparkle-material {
-      animation: none;
-    }
-  }
-
   /* Synchronized pending lock group glow - all elements pulse together */
   .pending-lock-glow {
     animation: pulse-glow 2s ease-in-out infinite;
@@ -1373,4 +1349,29 @@
   stroke: hsl(var(--card));
   stroke-width: 3px;
   stroke-linejoin: round;
+}
+
+/* Material age preference sparkle animation. Kept outside @layer utilities so
+   the @keyframes rule isn't subject to Tailwind v4's layer tree-shaking. */
+@keyframes sparkleAnim {
+  0%,
+  100% {
+    transform: scale(1) rotate(0deg);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.18) rotate(8deg);
+    opacity: 0.85;
+  }
+}
+
+.sparkle-material {
+  animation: sparkleAnim 1.6s ease-in-out infinite;
+  transform-origin: center center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sparkle-material {
+    animation: none;
+  }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -891,6 +891,30 @@
     }
   }
 
+  @keyframes sparkleAnim {
+    0%,
+    100% {
+      transform: scale(1) rotate(0deg);
+      opacity: 1;
+    }
+    50% {
+      transform: scale(1.18) rotate(8deg);
+      opacity: 0.85;
+    }
+  }
+
+  .sparkle-material {
+    animation: sparkleAnim 1.6s ease-in-out infinite;
+    display: inline-flex;
+    transform-origin: center center;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .sparkle-material {
+      animation: none;
+    }
+  }
+
   /* Synchronized pending lock group glow - all elements pulse together */
   .pending-lock-glow {
     animation: pulse-glow 2s ease-in-out infinite;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1353,7 +1353,7 @@
 
 /* Material age preference sparkle animation. Kept outside @layer utilities so
    the @keyframes rule isn't subject to Tailwind v4's layer tree-shaking. */
-@keyframes sparkleAnim {
+@keyframes sparkle-anim {
   0%,
   100% {
     transform: scale(1) rotate(0deg);
@@ -1366,7 +1366,7 @@
 }
 
 .sparkle-material {
-  animation: sparkleAnim 1.6s ease-in-out infinite;
+  animation: sparkle-anim 1.6s ease-in-out infinite;
   transform-origin: center center;
 }
 

--- a/frontend/src/providers/BunkRequestProvider.tsx
+++ b/frontend/src/providers/BunkRequestProvider.tsx
@@ -117,13 +117,7 @@ export function BunkRequestProvider({ sessionCmId, children }: BunkRequestProvid
       }
     }
 
-    return computeSatisfiedRequestInfo(
-      personRequests,
-      personCmId,
-      personSet,
-      bunkmateGrades,
-      requesterGrade
-    )
+    return computeSatisfiedRequestInfo(personRequests, personSet, bunkmateGrades, requesterGrade)
   }
 
   const value = {

--- a/frontend/src/utils/computeSatisfiedRequestInfo.test.ts
+++ b/frontend/src/utils/computeSatisfiedRequestInfo.test.ts
@@ -161,3 +161,43 @@ describe('computeSatisfiedRequestInfo Shape A', () => {
     expect(result.staffUnsatisfiedAlert).toBe(true)
   })
 })
+
+describe('Stage 3b.1 bug fix — request_type=not_bunk_with with source_field=bunk_with', () => {
+  it('routes to materialParent, not staff (was buggy pre-3b.1)', () => {
+    const personRequests = [
+      {
+        id: 'bug-fix-case',
+        requester_id: 1000001,
+        requestee_id: 1000002,
+        request_type: 'not_bunk_with',
+        source_field: 'bunk_with',
+        source: 'family',
+        status: 'resolved',
+        priority: 1,
+      } as BunkRequest,
+    ]
+    const personSet = new Set<number>() // requestee NOT in bunk → not_bunk_with satisfied
+    const result = computeSatisfiedRequestInfo(personRequests, 1000001, personSet, [], null)
+    expect(result.materialParent).toEqual({ total: 1, satisfied: 1, satisfactionRate: 1 })
+    expect(result.staff.total).toBe(0)
+  })
+
+  it('parent bunk_with-derived not_bunk_with with target IN bunk → materialParent unsatisfied', () => {
+    const personRequests = [
+      {
+        id: 'unsatisfied-case',
+        requester_id: 1000001,
+        requestee_id: 1000002,
+        request_type: 'not_bunk_with',
+        source_field: 'bunk_with',
+        source: 'family',
+        status: 'resolved',
+        priority: 1,
+      } as BunkRequest,
+    ]
+    const personSet = new Set<number>([1000002]) // requestee IS in bunk → not_bunk_with violated
+    const result = computeSatisfiedRequestInfo(personRequests, 1000001, personSet, [], null)
+    expect(result.materialParent).toEqual({ total: 1, satisfied: 0, satisfactionRate: 0 })
+    expect(result.parentMinOneViolation).toBe(true)
+  })
+})

--- a/frontend/src/utils/computeSatisfiedRequestInfo.test.ts
+++ b/frontend/src/utils/computeSatisfiedRequestInfo.test.ts
@@ -24,7 +24,7 @@ describe('computeSatisfiedRequestInfo Shape A', () => {
   const personSet = new Set([1001, 1002])
 
   it('returns three slices and derived flags', () => {
-    const result = computeSatisfiedRequestInfo([baseReq({})], 1001, personSet, [], 6)
+    const result = computeSatisfiedRequestInfo([baseReq({})], personSet, [], 6)
     expect(result.materialParent.total).toBe(1)
     expect(result.materialParent.satisfied).toBe(1)
     expect(result.materialParent.satisfactionRate).toBe(1.0)
@@ -37,7 +37,6 @@ describe('computeSatisfiedRequestInfo Shape A', () => {
   it('source_field=bunk_with bins to materialParent', () => {
     const result = computeSatisfiedRequestInfo(
       [baseReq({ source_field: 'bunk_with' })],
-      1001,
       personSet,
       [],
       6
@@ -55,7 +54,6 @@ describe('computeSatisfiedRequestInfo Shape A', () => {
           age_preference_target: 'older',
         }),
       ],
-      1001,
       personSet,
       [7, 7],
       6
@@ -74,7 +72,6 @@ describe('computeSatisfiedRequestInfo Shape A', () => {
           request_type: 'not_bunk_with',
         }),
       ],
-      1001,
       new Set([1001]), // requestee NOT in same bunk → not_bunk_with satisfied
       [],
       6
@@ -85,7 +82,7 @@ describe('computeSatisfiedRequestInfo Shape A', () => {
 
   it('parentMinOneViolation true only when material parent unsatisfied', () => {
     const unsatBunkWith = baseReq({ source_field: 'bunk_with', requestee_id: 9999 })
-    const result = computeSatisfiedRequestInfo([unsatBunkWith], 1001, personSet, [], 6)
+    const result = computeSatisfiedRequestInfo([unsatBunkWith], personSet, [], 6)
     expect(result.materialParent.satisfied).toBe(0)
     expect(result.parentMinOneViolation).toBe(true)
   })
@@ -97,7 +94,7 @@ describe('computeSatisfiedRequestInfo Shape A', () => {
       age_preference_target: 'older',
       requestee_id: null,
     })
-    const result = computeSatisfiedRequestInfo([unsatSocialize], 1001, new Set([1001]), [], 6)
+    const result = computeSatisfiedRequestInfo([unsatSocialize], new Set([1001]), [], 6)
     expect(result.materialParent.total).toBe(0)
     expect(result.bestEffortParent.satisfied).toBe(0)
     expect(result.parentMinOneViolation).toBe(false)
@@ -129,7 +126,6 @@ describe('computeSatisfiedRequestInfo Shape A', () => {
     })
     const result = computeSatisfiedRequestInfo(
       [pendingMaterial, declinedBestEffort, pendingStaff],
-      1001,
       personSet,
       [],
       6
@@ -151,7 +147,6 @@ describe('computeSatisfiedRequestInfo Shape A', () => {
           requestee_id: 1002,
         }),
       ],
-      1001,
       personSet, // requestee IS in same bunk → not_bunk_with UNsatisfied
       [],
       6
@@ -177,7 +172,7 @@ describe('Stage 3b.1 bug fix — request_type=not_bunk_with with source_field=bu
       } as BunkRequest,
     ]
     const personSet = new Set<number>() // requestee NOT in bunk → not_bunk_with satisfied
-    const result = computeSatisfiedRequestInfo(personRequests, 1000001, personSet, [], null)
+    const result = computeSatisfiedRequestInfo(personRequests, personSet, [], null)
     expect(result.materialParent).toEqual({ total: 1, satisfied: 1, satisfactionRate: 1 })
     expect(result.staff.total).toBe(0)
   })
@@ -196,7 +191,7 @@ describe('Stage 3b.1 bug fix — request_type=not_bunk_with with source_field=bu
       } as BunkRequest,
     ]
     const personSet = new Set<number>([1000002]) // requestee IS in bunk → not_bunk_with violated
-    const result = computeSatisfiedRequestInfo(personRequests, 1000001, personSet, [], null)
+    const result = computeSatisfiedRequestInfo(personRequests, personSet, [], null)
     expect(result.materialParent).toEqual({ total: 1, satisfied: 0, satisfactionRate: 0 })
     expect(result.parentMinOneViolation).toBe(true)
   })

--- a/frontend/src/utils/computeSatisfiedRequestInfo.ts
+++ b/frontend/src/utils/computeSatisfiedRequestInfo.ts
@@ -51,13 +51,9 @@ export const EMPTY_SATISFIED_INFO: SatisfiedRequestInfo = Object.freeze({
  * Scenario-aware slice computation. Builds an in-memory satisfaction predicate
  * from the bunk roster (personSet) and bunkmate grades, then delegates to the
  * shared aggregator for source classification + slice math.
- *
- * Public signature preserved across the Stage 3b.1 refactor — existing
- * BunkRequestProvider callers work unchanged.
  */
 export function computeSatisfiedRequestInfo(
   personRequests: BunkRequest[],
-  personCmId: number,
   personSet: Set<number>,
   bunkmateGrades: number[],
   requesterGrade: number | null
@@ -77,7 +73,6 @@ export function computeSatisfiedRequestInfo(
     return false
   }
 
-  void personCmId // preserved param for caller compatibility, not used internally
   return computeSlicesFromPredicate(personRequests, isSatisfied)
 }
 

--- a/frontend/src/utils/computeSatisfiedRequestInfo.ts
+++ b/frontend/src/utils/computeSatisfiedRequestInfo.ts
@@ -12,6 +12,10 @@
  * Derived flags:
  *   - parentMinOneViolation: materialParent.total >= 1 && satisfied === 0
  *   - staffUnsatisfiedAlert: staff.total >= 1 && satisfied === 0
+ *
+ * Stage 3b.1 refactor: delegates all slice math + source classification to
+ * computeSlicesFromPredicate. Public signature preserved — existing callers
+ * work unchanged.
  */
 import type { BunkRequest } from '../types/app-types'
 import type {
@@ -19,6 +23,10 @@ import type {
   RequestSlice,
   SatisfiedRequestInfo,
 } from '../contexts/BunkRequestContext'
+import {
+  computeSlicesFromPredicate,
+  type SatisfactionPredicate,
+} from './computeSlicesFromPredicate'
 import { isAgePreferenceSatisfied } from './agePreferenceSatisfaction'
 
 const EMPTY_SLICE: RequestSlice = Object.freeze({
@@ -39,6 +47,14 @@ export const EMPTY_SATISFIED_INFO: SatisfiedRequestInfo = Object.freeze({
   priorityLevels: Object.freeze([]) as readonly number[] as number[],
 }) as SatisfiedRequestInfo
 
+/**
+ * Scenario-aware slice computation. Builds an in-memory satisfaction predicate
+ * from the bunk roster (personSet) and bunkmate grades, then delegates to the
+ * shared aggregator for source classification + slice math.
+ *
+ * Public signature preserved across the Stage 3b.1 refactor — existing
+ * BunkRequestProvider callers work unchanged.
+ */
 export function computeSatisfiedRequestInfo(
   personRequests: BunkRequest[],
   personCmId: number,
@@ -46,11 +62,7 @@ export function computeSatisfiedRequestInfo(
   bunkmateGrades: number[],
   requesterGrade: number | null
 ): SatisfiedRequestInfo {
-  if (personRequests.length === 0) {
-    return EMPTY_SATISFIED_INFO
-  }
-
-  const isSatisfied = (req: BunkRequest): boolean => {
+  const isSatisfied: SatisfactionPredicate = (req) => {
     if (req.request_type === 'bunk_with' && req.requestee_id) {
       return personSet.has(req.requestee_id)
     }
@@ -59,74 +71,14 @@ export function computeSatisfiedRequestInfo(
     }
     if (req.request_type === 'age_preference' && req.age_preference_target) {
       if (requesterGrade === null || bunkmateGrades.length === 0) return false
-      const preference = req.age_preference_target as 'older' | 'younger'
-      return isAgePreferenceSatisfied(requesterGrade, bunkmateGrades, preference).satisfied
+      const target = req.age_preference_target as 'older' | 'younger'
+      return isAgePreferenceSatisfied(requesterGrade, bunkmateGrades, target).satisfied
     }
     return false
   }
 
-  let materialTotal = 0
-  let materialSat = 0
-  let bestTotal = 0
-  let bestSat = 0
-  let staffTotal = 0
-  let staffSat = 0
-  const satisfiedRequests: BunkRequest[] = []
-
-  for (const req of personRequests) {
-    // Only resolved rows count toward satisfaction stats.
-    // Pending (e.g. SAME_AGE staff-review path) and declined must not leak
-    // into any of the three slices.
-    if (req.status !== 'resolved') continue
-    const sat = isSatisfied(req)
-    if (sat) satisfiedRequests.push(req)
-    // not_bunk_with is the staff classification by definition (see
-    // RequestSource enum). Match on request_type first so a FAMILY-source
-    // not_bunk_with still bins to staff instead of falling through.
-    if (req.request_type === 'not_bunk_with') {
-      staffTotal += 1
-      if (sat) staffSat += 1
-    } else if (req.source_field === 'bunk_with') {
-      materialTotal += 1
-      if (sat) materialSat += 1
-    } else if (req.source_field === 'socialize_with') {
-      bestTotal += 1
-      if (sat) bestSat += 1
-    } else if (req.source === 'staff') {
-      staffTotal += 1
-      if (sat) staffSat += 1
-    }
-  }
-
-  const slice = (total: number, satisfied: number): RequestSlice => ({
-    total,
-    satisfied,
-    satisfactionRate: total === 0 ? 0 : satisfied / total,
-  })
-
-  const sortedSatisfied = [...satisfiedRequests].sort(
-    (a, b) => (b.priority ?? 0) - (a.priority ?? 0)
-  )
-  const topPriority = personRequests.reduce((max, req) => Math.max(max, req.priority ?? 0), 0)
-  const topPrioritySatisfied = sortedSatisfied.some((req) => (req.priority ?? 0) === topPriority)
-  const priorityLevels = [...new Set(sortedSatisfied.map((r) => r.priority ?? 0))].sort(
-    (a, b) => b - a
-  )
-
-  // Surface personCmId so future tests can confirm wiring without breaking
-  // existing callers (param is otherwise unused — kept so the call shape mirrors
-  // the provider's getSatisfiedRequestInfo and so renaming/refactoring is local).
-  void personCmId
-
-  return {
-    materialParent: slice(materialTotal, materialSat),
-    bestEffortParent: slice(bestTotal, bestSat),
-    staff: slice(staffTotal, staffSat),
-    parentMinOneViolation: materialTotal >= 1 && materialSat === 0,
-    staffUnsatisfiedAlert: staffTotal >= 1 && staffSat === 0,
-    topPrioritySatisfied,
-    priorityLevels,
-  }
+  void personCmId // preserved param for caller compatibility, not used internally
+  return computeSlicesFromPredicate(personRequests, isSatisfied)
 }
 
 // Re-export BunkmateInfo for tests that import from this module so they don't

--- a/frontend/src/utils/computeSlicesFromPredicate.test.ts
+++ b/frontend/src/utils/computeSlicesFromPredicate.test.ts
@@ -1,0 +1,205 @@
+// frontend/src/utils/computeSlicesFromPredicate.test.ts
+import { describe, it, expect } from 'vitest'
+import { computeSlicesFromPredicate } from './computeSlicesFromPredicate'
+import type { BunkRequest } from '../types/app-types'
+
+function makeReq(overrides: Partial<BunkRequest> = {}): BunkRequest {
+  return {
+    id: 'r1',
+    requester_id: 1000001,
+    requestee_id: 1000002,
+    request_type: 'bunk_with',
+    source_field: 'bunk_with',
+    source: 'family',
+    status: 'resolved',
+    priority: 1,
+    year: 2026,
+    session_id: 9999,
+    ...overrides,
+  } as BunkRequest
+}
+
+describe('computeSlicesFromPredicate — source classification truth table', () => {
+  const allSatisfied = () => true
+
+  it('bunk_with × bunk_with × family → materialParent', () => {
+    const req = makeReq({
+      id: 'a',
+      request_type: 'bunk_with',
+      source_field: 'bunk_with',
+      source: 'family',
+    })
+    const slices = computeSlicesFromPredicate([req], allSatisfied)
+    expect(slices.materialParent).toEqual({ total: 1, satisfied: 1, satisfactionRate: 1 })
+    expect(slices.bestEffortParent.total).toBe(0)
+    expect(slices.staff.total).toBe(0)
+  })
+
+  it('bunk_with × bunking_notes × staff → staff', () => {
+    const req = makeReq({
+      request_type: 'bunk_with',
+      source_field: 'bunking_notes',
+      source: 'staff',
+    })
+    const slices = computeSlicesFromPredicate([req], allSatisfied)
+    expect(slices.staff).toEqual({ total: 1, satisfied: 1, satisfactionRate: 1 })
+    expect(slices.materialParent.total).toBe(0)
+  })
+
+  it('bunk_with × internal_notes × staff → staff', () => {
+    const req = makeReq({
+      request_type: 'bunk_with',
+      source_field: 'internal_notes',
+      source: 'staff',
+    })
+    const slices = computeSlicesFromPredicate([req], allSatisfied)
+    expect(slices.staff.total).toBe(1)
+  })
+
+  // BUG-FIX CASE — pre-fix this row landed in `staff` due to the
+  // `request_type === 'not_bunk_with'` short-circuit. Post-fix it's `materialParent`.
+  it('not_bunk_with × bunk_with × family → materialParent (Stage 3b.1 bug fix)', () => {
+    const req = makeReq({
+      request_type: 'not_bunk_with',
+      source_field: 'bunk_with',
+      source: 'family',
+    })
+    const slices = computeSlicesFromPredicate([req], allSatisfied)
+    expect(slices.materialParent).toEqual({ total: 1, satisfied: 1, satisfactionRate: 1 })
+    expect(slices.staff.total).toBe(0)
+  })
+
+  it('not_bunk_with × not_bunk_with × staff → staff', () => {
+    const req = makeReq({
+      request_type: 'not_bunk_with',
+      source_field: 'not_bunk_with',
+      source: 'staff',
+    })
+    const slices = computeSlicesFromPredicate([req], allSatisfied)
+    expect(slices.staff.total).toBe(1)
+  })
+
+  it('not_bunk_with × bunking_notes × staff → staff', () => {
+    const req = makeReq({
+      request_type: 'not_bunk_with',
+      source_field: 'bunking_notes',
+      source: 'staff',
+    })
+    const slices = computeSlicesFromPredicate([req], allSatisfied)
+    expect(slices.staff.total).toBe(1)
+  })
+
+  it('not_bunk_with × internal_notes × staff → staff', () => {
+    const req = makeReq({
+      request_type: 'not_bunk_with',
+      source_field: 'internal_notes',
+      source: 'staff',
+    })
+    const slices = computeSlicesFromPredicate([req], allSatisfied)
+    expect(slices.staff.total).toBe(1)
+  })
+
+  it('age_preference × bunk_with × family → materialParent', () => {
+    const req = makeReq({
+      request_type: 'age_preference',
+      source_field: 'bunk_with',
+      source: 'family',
+      age_preference_target: 'older',
+    })
+    const slices = computeSlicesFromPredicate([req], allSatisfied)
+    expect(slices.materialParent.total).toBe(1)
+  })
+
+  it('age_preference × socialize_with × family → bestEffortParent', () => {
+    const req = makeReq({
+      request_type: 'age_preference',
+      source_field: 'socialize_with',
+      source: 'family',
+      age_preference_target: 'younger',
+    })
+    const slices = computeSlicesFromPredicate([req], allSatisfied)
+    expect(slices.bestEffortParent.total).toBe(1)
+    expect(slices.materialParent.total).toBe(0)
+  })
+
+  it('age_preference × null × family → bestEffortParent (legacy fallback, #1086)', () => {
+    const req = makeReq({
+      request_type: 'age_preference',
+      source_field: null as any,
+      source: 'family',
+      age_preference_target: 'older',
+    })
+    const slices = computeSlicesFromPredicate([req], allSatisfied)
+    expect(slices.bestEffortParent.total).toBe(1)
+  })
+
+  it('age_preference × bunking_notes × staff → staff', () => {
+    const req = makeReq({
+      request_type: 'age_preference',
+      source_field: 'bunking_notes',
+      source: 'staff',
+      age_preference_target: 'older',
+    })
+    const slices = computeSlicesFromPredicate([req], allSatisfied)
+    expect(slices.staff.total).toBe(1)
+  })
+
+  it('age_preference × internal_notes × staff → staff', () => {
+    const req = makeReq({
+      request_type: 'age_preference',
+      source_field: 'internal_notes',
+      source: 'staff',
+      age_preference_target: 'younger',
+    })
+    const slices = computeSlicesFromPredicate([req], allSatisfied)
+    expect(slices.staff.total).toBe(1)
+  })
+})
+
+describe('computeSlicesFromPredicate — flag derivation', () => {
+  const noneSatisfied = () => false
+
+  it('parentMinOneViolation true when material total > 0 but none satisfied', () => {
+    const req = makeReq({ request_type: 'bunk_with', source_field: 'bunk_with', source: 'family' })
+    const slices = computeSlicesFromPredicate([req], noneSatisfied)
+    expect(slices.parentMinOneViolation).toBe(true)
+  })
+
+  it('parentMinOneViolation false when at least one material satisfied', () => {
+    const req = makeReq({ request_type: 'bunk_with', source_field: 'bunk_with', source: 'family' })
+    const slices = computeSlicesFromPredicate([req], () => true)
+    expect(slices.parentMinOneViolation).toBe(false)
+  })
+
+  it('parentMinOneViolation false when no material requests at all', () => {
+    const req = makeReq({
+      request_type: 'not_bunk_with',
+      source_field: 'not_bunk_with',
+      source: 'staff',
+    })
+    const slices = computeSlicesFromPredicate([req], noneSatisfied)
+    expect(slices.parentMinOneViolation).toBe(false)
+  })
+
+  it('staffUnsatisfiedAlert true when staff total > 0 but none satisfied', () => {
+    const req = makeReq({
+      request_type: 'not_bunk_with',
+      source_field: 'not_bunk_with',
+      source: 'staff',
+    })
+    const slices = computeSlicesFromPredicate([req], noneSatisfied)
+    expect(slices.staffUnsatisfiedAlert).toBe(true)
+  })
+
+  it('skips non-resolved requests entirely', () => {
+    const req = makeReq({
+      request_type: 'bunk_with',
+      source_field: 'bunk_with',
+      source: 'family',
+      status: 'pending',
+    })
+    const slices = computeSlicesFromPredicate([req], () => true)
+    expect(slices.materialParent.total).toBe(0)
+    expect(slices.staff.total).toBe(0)
+  })
+})

--- a/frontend/src/utils/computeSlicesFromPredicate.test.ts
+++ b/frontend/src/utils/computeSlicesFromPredicate.test.ts
@@ -124,7 +124,7 @@ describe('computeSlicesFromPredicate — source classification truth table', () 
   it('age_preference × null × family → bestEffortParent (legacy fallback, #1086)', () => {
     const req = makeReq({
       request_type: 'age_preference',
-      source_field: undefined,
+      source_field: null as any, // null as any: tsconfig has exactOptionalPropertyTypes; null models real DB null state
       source: 'family',
       age_preference_target: 'older',
     })

--- a/frontend/src/utils/computeSlicesFromPredicate.test.ts
+++ b/frontend/src/utils/computeSlicesFromPredicate.test.ts
@@ -153,6 +153,34 @@ describe('computeSlicesFromPredicate — source classification truth table', () 
     const slices = computeSlicesFromPredicate([req], allSatisfied)
     expect(slices.staff).toEqual({ total: 1, satisfied: 1, satisfactionRate: 1 })
   })
+
+  it('bunk_with × null × family (malformed legacy) → not binned', () => {
+    const req = makeReq({
+      request_type: 'bunk_with',
+      source_field: null as unknown as string,
+      source: 'family',
+    })
+    const slices = computeSlicesFromPredicate([req], allSatisfied)
+    expect(slices.materialParent.total).toBe(0)
+    expect(slices.bestEffortParent.total).toBe(0)
+    expect(slices.staff.total).toBe(0)
+  })
+
+  it('not_bunk_with × not_bunk_with × notes (legacy notes source) → not binned', () => {
+    // Upstream openai_provider maps 'notes' → STAFF before write, so this
+    // schema-allowed source value should never appear in production. Catch-all
+    // now requires source === 'staff'; legacy 'notes' rows are excluded
+    // rather than silently binned as staff.
+    const req = makeReq({
+      request_type: 'not_bunk_with',
+      source_field: 'bunking_notes',
+      source: 'notes',
+    })
+    const slices = computeSlicesFromPredicate([req], allSatisfied)
+    expect(slices.staff.total).toBe(0)
+    expect(slices.materialParent.total).toBe(0)
+    expect(slices.bestEffortParent.total).toBe(0)
+  })
 })
 
 describe('computeSlicesFromPredicate — flag derivation', () => {

--- a/frontend/src/utils/computeSlicesFromPredicate.test.ts
+++ b/frontend/src/utils/computeSlicesFromPredicate.test.ts
@@ -24,7 +24,6 @@ describe('computeSlicesFromPredicate — source classification truth table', () 
 
   it('bunk_with × bunk_with × family → materialParent', () => {
     const req = makeReq({
-      id: 'a',
       request_type: 'bunk_with',
       source_field: 'bunk_with',
       source: 'family',
@@ -53,7 +52,7 @@ describe('computeSlicesFromPredicate — source classification truth table', () 
       source: 'staff',
     })
     const slices = computeSlicesFromPredicate([req], allSatisfied)
-    expect(slices.staff.total).toBe(1)
+    expect(slices.staff).toEqual({ total: 1, satisfied: 1, satisfactionRate: 1 })
   })
 
   // BUG-FIX CASE — pre-fix this row landed in `staff` due to the
@@ -76,7 +75,7 @@ describe('computeSlicesFromPredicate — source classification truth table', () 
       source: 'staff',
     })
     const slices = computeSlicesFromPredicate([req], allSatisfied)
-    expect(slices.staff.total).toBe(1)
+    expect(slices.staff).toEqual({ total: 1, satisfied: 1, satisfactionRate: 1 })
   })
 
   it('not_bunk_with × bunking_notes × staff → staff', () => {
@@ -86,7 +85,7 @@ describe('computeSlicesFromPredicate — source classification truth table', () 
       source: 'staff',
     })
     const slices = computeSlicesFromPredicate([req], allSatisfied)
-    expect(slices.staff.total).toBe(1)
+    expect(slices.staff).toEqual({ total: 1, satisfied: 1, satisfactionRate: 1 })
   })
 
   it('not_bunk_with × internal_notes × staff → staff', () => {
@@ -96,7 +95,7 @@ describe('computeSlicesFromPredicate — source classification truth table', () 
       source: 'staff',
     })
     const slices = computeSlicesFromPredicate([req], allSatisfied)
-    expect(slices.staff.total).toBe(1)
+    expect(slices.staff).toEqual({ total: 1, satisfied: 1, satisfactionRate: 1 })
   })
 
   it('age_preference × bunk_with × family → materialParent', () => {
@@ -107,7 +106,7 @@ describe('computeSlicesFromPredicate — source classification truth table', () 
       age_preference_target: 'older',
     })
     const slices = computeSlicesFromPredicate([req], allSatisfied)
-    expect(slices.materialParent.total).toBe(1)
+    expect(slices.materialParent).toEqual({ total: 1, satisfied: 1, satisfactionRate: 1 })
   })
 
   it('age_preference × socialize_with × family → bestEffortParent', () => {
@@ -118,19 +117,19 @@ describe('computeSlicesFromPredicate — source classification truth table', () 
       age_preference_target: 'younger',
     })
     const slices = computeSlicesFromPredicate([req], allSatisfied)
-    expect(slices.bestEffortParent.total).toBe(1)
+    expect(slices.bestEffortParent).toEqual({ total: 1, satisfied: 1, satisfactionRate: 1 })
     expect(slices.materialParent.total).toBe(0)
   })
 
   it('age_preference × null × family → bestEffortParent (legacy fallback, #1086)', () => {
     const req = makeReq({
       request_type: 'age_preference',
-      source_field: null as any,
+      source_field: undefined,
       source: 'family',
       age_preference_target: 'older',
     })
     const slices = computeSlicesFromPredicate([req], allSatisfied)
-    expect(slices.bestEffortParent.total).toBe(1)
+    expect(slices.bestEffortParent).toEqual({ total: 1, satisfied: 1, satisfactionRate: 1 })
   })
 
   it('age_preference × bunking_notes × staff → staff', () => {
@@ -141,7 +140,7 @@ describe('computeSlicesFromPredicate — source classification truth table', () 
       age_preference_target: 'older',
     })
     const slices = computeSlicesFromPredicate([req], allSatisfied)
-    expect(slices.staff.total).toBe(1)
+    expect(slices.staff).toEqual({ total: 1, satisfied: 1, satisfactionRate: 1 })
   })
 
   it('age_preference × internal_notes × staff → staff', () => {
@@ -152,7 +151,7 @@ describe('computeSlicesFromPredicate — source classification truth table', () 
       age_preference_target: 'younger',
     })
     const slices = computeSlicesFromPredicate([req], allSatisfied)
-    expect(slices.staff.total).toBe(1)
+    expect(slices.staff).toEqual({ total: 1, satisfied: 1, satisfactionRate: 1 })
   })
 })
 
@@ -189,6 +188,16 @@ describe('computeSlicesFromPredicate — flag derivation', () => {
     })
     const slices = computeSlicesFromPredicate([req], noneSatisfied)
     expect(slices.staffUnsatisfiedAlert).toBe(true)
+  })
+
+  it('staffUnsatisfiedAlert false when at least one staff satisfied', () => {
+    const req = makeReq({
+      request_type: 'not_bunk_with',
+      source_field: 'not_bunk_with',
+      source: 'staff',
+    })
+    const slices = computeSlicesFromPredicate([req], () => true)
+    expect(slices.staffUnsatisfiedAlert).toBe(false)
   })
 
   it('skips non-resolved requests entirely', () => {

--- a/frontend/src/utils/computeSlicesFromPredicate.ts
+++ b/frontend/src/utils/computeSlicesFromPredicate.ts
@@ -49,10 +49,13 @@ export function computeSlicesFromPredicate(
       // Tracked for removal: #1086.
       bestTotal++
       if (sat) bestSat++
-    } else {
+    } else if (req.source === 'staff') {
       // socialize_with is handled in the branch above; this catches:
       // not_bunk_with / bunking_notes / internal_notes / any future staff
-      // source_field. Upstream invariant: req.source === 'staff'.
+      // source_field. The explicit `source === 'staff'` guard skips legacy
+      // or malformed rows (e.g. bunk_with × null × family, or the unreachable
+      // schema-allowed `source = 'notes'`) rather than silently binning them
+      // as staff.
       staffTotal++
       if (sat) staffSat++
     }

--- a/frontend/src/utils/computeSlicesFromPredicate.ts
+++ b/frontend/src/utils/computeSlicesFromPredicate.ts
@@ -1,0 +1,79 @@
+// frontend/src/utils/computeSlicesFromPredicate.ts
+import type { BunkRequest } from '../types/app-types'
+import type { SatisfiedRequestInfo, RequestSlice } from '../contexts/BunkRequestContext'
+
+export type SatisfactionPredicate = (req: BunkRequest) => boolean
+
+/**
+ * Source-of-truth slice aggregator.
+ *
+ * Iterates resolved requests once; classifies each by source_field per the
+ * Stage 3b.1 truth table; sums totals + satisfied per slice; derives the
+ * parent/staff alert flags. Both code paths (scenario-aware and prod-aligned)
+ * delegate here, so the source-classification rules live in exactly one place.
+ *
+ * The bug fixed in Stage 3b.1: the previous `computeSatisfiedRequestInfo`
+ * short-circuited on `request_type === 'not_bunk_with'` and routed those rows
+ * to `staff`, even when the row was a parent's bunk_with text that the AI had
+ * parsed into a not_bunk_with. This function uses source_field-first
+ * classification with `req.source === 'staff'` as the catch-all.
+ */
+export function computeSlicesFromPredicate(
+  personRequests: BunkRequest[],
+  isSatisfied: SatisfactionPredicate
+): SatisfiedRequestInfo {
+  let materialTotal = 0
+  let materialSat = 0
+  let bestTotal = 0
+  let bestSat = 0
+  let staffTotal = 0
+  let staffSat = 0
+  const satisfiedRequests: BunkRequest[] = []
+
+  for (const req of personRequests) {
+    // §15.1 resolved-only boundary
+    if (req.status !== 'resolved') continue
+    const sat = isSatisfied(req)
+    if (sat) satisfiedRequests.push(req)
+
+    if (req.source_field === 'bunk_with') {
+      materialTotal++
+      if (sat) materialSat++
+    } else if (req.source_field === 'socialize_with') {
+      bestTotal++
+      if (sat) bestSat++
+    } else if (!req.source_field && req.request_type === 'age_preference') {
+      // Legacy fallback (mirrors backend bunking_validator.py:514-516).
+      // Tracked for removal: #1086.
+      bestTotal++
+      if (sat) bestSat++
+    } else {
+      // Catch-all: not_bunk_with / bunking_notes / internal_notes / any
+      // future staff source_field. Upstream invariant: req.source === 'staff'.
+      staffTotal++
+      if (sat) staffSat++
+    }
+  }
+
+  const slice = (total: number, satisfied: number): RequestSlice => ({
+    total,
+    satisfied,
+    satisfactionRate: total === 0 ? 0 : satisfied / total,
+  })
+
+  const topPriority = personRequests.reduce((m, r) => Math.max(m, r.priority ?? 0), 0)
+  const topPrioritySatisfied = satisfiedRequests.some((r) => (r.priority ?? 0) === topPriority)
+  const priorityLevels = [...new Set(satisfiedRequests.map((r) => r.priority ?? 0))].sort(
+    (a, b) => b - a
+  )
+
+  return {
+    materialParent: slice(materialTotal, materialSat),
+    bestEffortParent: slice(bestTotal, bestSat),
+    staff: slice(staffTotal, staffSat),
+    parentMinOneViolation: materialTotal >= 1 && materialSat === 0,
+    staffUnsatisfiedAlert: staffTotal >= 1 && staffSat === 0,
+    topPrioritySatisfied,
+    priorityLevels,
+  }
+}

--- a/frontend/src/utils/computeSlicesFromPredicate.ts
+++ b/frontend/src/utils/computeSlicesFromPredicate.ts
@@ -16,7 +16,9 @@ export type SatisfactionPredicate = (req: BunkRequest) => boolean
  * short-circuited on `request_type === 'not_bunk_with'` and routed those rows
  * to `staff`, even when the row was a parent's bunk_with text that the AI had
  * parsed into a not_bunk_with. This function uses source_field-first
- * classification with `req.source === 'staff'` as the catch-all.
+ * classification; the `else` catch-all covers staff source fields
+ * (`not_bunk_with`, `bunking_notes`, `internal_notes`). By upstream invariant,
+ * all rows reaching the catch-all have `req.source === 'staff'`.
  */
 export function computeSlicesFromPredicate(
   personRequests: BunkRequest[],
@@ -48,8 +50,9 @@ export function computeSlicesFromPredicate(
       bestTotal++
       if (sat) bestSat++
     } else {
-      // Catch-all: not_bunk_with / bunking_notes / internal_notes / any
-      // future staff source_field. Upstream invariant: req.source === 'staff'.
+      // socialize_with is handled in the branch above; this catches:
+      // not_bunk_with / bunking_notes / internal_notes / any future staff
+      // source_field. Upstream invariant: req.source === 'staff'.
       staffTotal++
       if (sat) staffSat++
     }
@@ -61,6 +64,10 @@ export function computeSlicesFromPredicate(
     satisfactionRate: total === 0 ? 0 : satisfied / total,
   })
 
+  // NOTE: topPriority is computed from the UNFILTERED personRequests (any
+  // status), while satisfiedRequests holds only resolved+satisfied rows. This
+  // preserves Stage 3a's verbatim behavior — see #1090 for follow-up on whether
+  // this should be resolved-only.
   const topPriority = personRequests.reduce((m, r) => Math.max(m, r.priority ?? 0), 0)
   const topPrioritySatisfied = satisfiedRequests.some((r) => (r.priority ?? 0) === topPriority)
   const priorityLevels = [...new Set(satisfiedRequests.map((r) => r.priority ?? 0))].sort(

--- a/frontend/src/utils/deriveSlicesFromSatisfactionMap.test.ts
+++ b/frontend/src/utils/deriveSlicesFromSatisfactionMap.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import { deriveSlicesFromSatisfactionMap } from './deriveSlicesFromSatisfactionMap'
+import type { BunkRequest } from '../types/app-types'
+import type { SatisfactionMap } from '../hooks/camper/types'
+
+function makeReq(id: string, overrides: Partial<BunkRequest> = {}): BunkRequest {
+  return {
+    id,
+    requester_id: 1000001,
+    requestee_id: 1000002,
+    request_type: 'bunk_with',
+    source_field: 'bunk_with',
+    source: 'family',
+    status: 'resolved',
+    priority: 1,
+    ...overrides,
+  } as BunkRequest
+}
+
+describe('deriveSlicesFromSatisfactionMap', () => {
+  it('counts a row as satisfied when map entry is "satisfied"', () => {
+    const reqs = [makeReq('r1')]
+    const map: SatisfactionMap = { r1: { status: 'satisfied', detail: '' } }
+    const slices = deriveSlicesFromSatisfactionMap(reqs, map)
+    expect(slices.materialParent.satisfied).toBe(1)
+  })
+
+  it('does NOT count "not_satisfied"', () => {
+    const reqs = [makeReq('r1')]
+    const map: SatisfactionMap = { r1: { status: 'not_satisfied', detail: '' } }
+    const slices = deriveSlicesFromSatisfactionMap(reqs, map)
+    expect(slices.materialParent.total).toBe(1)
+    expect(slices.materialParent.satisfied).toBe(0)
+  })
+
+  it('does NOT count "unknown"', () => {
+    const reqs = [makeReq('r1')]
+    const map: SatisfactionMap = { r1: { status: 'unknown', detail: '' } }
+    const slices = deriveSlicesFromSatisfactionMap(reqs, map)
+    expect(slices.materialParent.satisfied).toBe(0)
+  })
+
+  it('does NOT count "checking"', () => {
+    const reqs = [makeReq('r1')]
+    const map: SatisfactionMap = { r1: { status: 'checking', detail: '' } }
+    const slices = deriveSlicesFromSatisfactionMap(reqs, map)
+    expect(slices.materialParent.satisfied).toBe(0)
+  })
+
+  it('does NOT count rows missing from the map (treats as unsatisfied)', () => {
+    const reqs = [makeReq('r1')]
+    const map: SatisfactionMap = {}
+    const slices = deriveSlicesFromSatisfactionMap(reqs, map)
+    expect(slices.materialParent.total).toBe(1)
+    expect(slices.materialParent.satisfied).toBe(0)
+  })
+
+  it('classifies multiple rows correctly across slices', () => {
+    const reqs = [
+      makeReq('r-mat', { source_field: 'bunk_with' }),
+      makeReq('r-best', {
+        request_type: 'age_preference',
+        source_field: 'socialize_with',
+        age_preference_target: 'older',
+      }),
+      makeReq('r-staff', {
+        request_type: 'not_bunk_with',
+        source_field: 'not_bunk_with',
+        source: 'staff',
+      }),
+    ]
+    const map: SatisfactionMap = {
+      'r-mat': { status: 'satisfied', detail: '' },
+      'r-best': { status: 'not_satisfied', detail: '' },
+      'r-staff': { status: 'satisfied', detail: '' },
+    }
+    const slices = deriveSlicesFromSatisfactionMap(reqs, map)
+    expect(slices.materialParent).toEqual({ total: 1, satisfied: 1, satisfactionRate: 1 })
+    expect(slices.bestEffortParent).toEqual({ total: 1, satisfied: 0, satisfactionRate: 0 })
+    expect(slices.staff).toEqual({ total: 1, satisfied: 1, satisfactionRate: 1 })
+  })
+})

--- a/frontend/src/utils/deriveSlicesFromSatisfactionMap.ts
+++ b/frontend/src/utils/deriveSlicesFromSatisfactionMap.ts
@@ -1,0 +1,23 @@
+// frontend/src/utils/deriveSlicesFromSatisfactionMap.ts
+import type { BunkRequest } from '../types/app-types'
+import type { SatisfiedRequestInfo } from '../contexts/BunkRequestContext'
+import type { SatisfactionMap } from '../hooks/camper/types'
+import { computeSlicesFromPredicate } from './computeSlicesFromPredicate'
+
+/**
+ * Prod-aligned slice computation. Builds the satisfaction predicate from a
+ * pre-computed SatisfactionMap (typically from useSatisfactionData) and
+ * delegates to the shared aggregator for source classification + slice math.
+ *
+ * Used by BunkingStatusPanel where the satisfaction state is sourced from
+ * persisted PocketBase assignments rather than the live in-memory scenario.
+ */
+export function deriveSlicesFromSatisfactionMap(
+  personRequests: BunkRequest[],
+  satisfactionMap: SatisfactionMap
+): SatisfiedRequestInfo {
+  return computeSlicesFromPredicate(
+    personRequests,
+    (req) => satisfactionMap[req.id]?.status === 'satisfied'
+  )
+}

--- a/frontend/src/utils/partitionRequestsBySource.test.ts
+++ b/frontend/src/utils/partitionRequestsBySource.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { partitionRequestsBySource } from './partitionRequestsBySource'
+import type { EnhancedBunkRequest } from '../hooks/camper/useAllBunkRequests'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function row(
+  overrides: Partial<EnhancedBunkRequest> & Record<string, any> = {}
+): EnhancedBunkRequest {
+  return {
+    id: 'r' + Math.random().toString(36).slice(2, 8),
+    requester_id: 1000001,
+    requestee_id: 1000002,
+    request_type: 'bunk_with',
+    source_field: 'bunk_with',
+    source: 'family',
+    status: 'resolved',
+    priority: 1,
+    targetPerson: { first_name: 'Aa', last_name: 'Aa' },
+    ...overrides,
+  } as unknown as EnhancedBunkRequest
+}
+
+describe('partitionRequestsBySource', () => {
+  it('routes bunk_with source_field to parent', () => {
+    const r = row({ source_field: 'bunk_with' })
+    const { parent, staff, age } = partitionRequestsBySource([r])
+    expect(parent).toEqual([r])
+    expect(staff).toEqual([])
+    expect(age).toEqual([])
+  })
+
+  it('routes socialize_with source_field to parent (best-effort still parent-rendered)', () => {
+    const r = row({ request_type: 'bunk_with', source_field: 'socialize_with' })
+    const { parent } = partitionRequestsBySource([r])
+    expect(parent).toEqual([r])
+  })
+
+  it('routes age_preference of any source_field to age', () => {
+    const a = row({
+      request_type: 'age_preference',
+      source_field: 'bunk_with',
+      age_preference_target: 'older',
+    })
+    const b = row({
+      request_type: 'age_preference',
+      source_field: 'socialize_with',
+      age_preference_target: 'younger',
+    })
+    const c = row({
+      request_type: 'age_preference',
+      source_field: 'bunking_notes',
+      source: 'staff',
+    })
+    const { parent, staff, age } = partitionRequestsBySource([a, b, c])
+    expect(parent).toEqual([])
+    expect(staff).toEqual([])
+    expect(age).toHaveLength(3)
+  })
+
+  it('routes not_bunk_with with source_field=bunk_with to parent (post-bug-fix)', () => {
+    const r = row({ request_type: 'not_bunk_with', source_field: 'bunk_with' })
+    const { parent, staff } = partitionRequestsBySource([r])
+    expect(parent).toEqual([r])
+    expect(staff).toEqual([])
+  })
+
+  it('routes not_bunk_with with staff source_field to staff', () => {
+    const r = row({ request_type: 'not_bunk_with', source_field: 'not_bunk_with', source: 'staff' })
+    const { parent, staff } = partitionRequestsBySource([r])
+    expect(parent).toEqual([])
+    expect(staff).toEqual([r])
+  })
+
+  it('routes bunk_with with bunking_notes source to staff', () => {
+    const r = row({ request_type: 'bunk_with', source_field: 'bunking_notes', source: 'staff' })
+    const { staff } = partitionRequestsBySource([r])
+    expect(staff).toEqual([r])
+  })
+
+  it('sorts parent rows by requestee first_name, tiebreak last_name', () => {
+    const a = row({ id: 'a', targetPerson: { first_name: 'Olivia', last_name: 'Chen' } })
+    const b = row({ id: 'b', targetPerson: { first_name: 'Emma', last_name: 'Johnson' } })
+    const c = row({ id: 'c', targetPerson: { first_name: 'Liam', last_name: 'Garcia' } })
+    const { parent } = partitionRequestsBySource([a, b, c])
+    expect(parent.map((r) => r.id)).toEqual(['b', 'c', 'a'])
+  })
+
+  it('tiebreaks identical first_name by last_name', () => {
+    const a = row({ id: 'a', targetPerson: { first_name: 'Riley', last_name: 'Torres' } })
+    const b = row({ id: 'b', targetPerson: { first_name: 'Riley', last_name: 'Sam' } })
+    const { parent } = partitionRequestsBySource([a, b])
+    expect(parent.map((r) => r.id)).toEqual(['b', 'a'])
+  })
+
+  it('handles missing targetPerson gracefully (sorts to top)', () => {
+    const a = row({ id: 'a', targetPerson: { first_name: 'Riley', last_name: 'Sam' } })
+    const b = row({ id: 'b', targetPerson: undefined })
+    const { parent } = partitionRequestsBySource([a, b])
+    expect(parent.map((r) => r.id)).toEqual(['b', 'a'])
+  })
+})

--- a/frontend/src/utils/partitionRequestsBySource.test.ts
+++ b/frontend/src/utils/partitionRequestsBySource.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest'
 import { partitionRequestsBySource } from './partitionRequestsBySource'
 import type { EnhancedBunkRequest } from '../hooks/camper/useAllBunkRequests'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function row(
   overrides: Partial<EnhancedBunkRequest> & Record<string, any> = {}
 ): EnhancedBunkRequest {

--- a/frontend/src/utils/partitionRequestsBySource.ts
+++ b/frontend/src/utils/partitionRequestsBySource.ts
@@ -1,0 +1,57 @@
+// Sort key: targetPerson.first_name then last_name.
+// Field origin documented in CamperDetailsPanel/BunkingStatusPanel consumer wiring.
+//
+// `targetPerson` is NOT a field on the canonical EnhancedBunkRequest — it is
+// added by CamperDetailsPanel as `PanelBunkRequest.targetPerson: PersonsResponse | null`.
+// This function accepts a generic constraint so callers may pass any request
+// type that carries targetPerson (or not), without requiring changes to the
+// EnhancedBunkRequest type itself.
+
+type SortableTarget = { first_name?: string; last_name?: string } | null | undefined
+
+export interface PartitionableRequest {
+  id: string
+  request_type: string
+  source_field?: string | null
+  source?: string
+  targetPerson?: SortableTarget
+}
+
+interface Partitioned<T extends PartitionableRequest> {
+  parent: T[]
+  staff: T[]
+  age: T[]
+}
+
+export function partitionRequestsBySource<T extends PartitionableRequest>(
+  requests: T[]
+): Partitioned<T> {
+  const parent: T[] = []
+  const staff: T[] = []
+  const age: T[] = []
+
+  for (const r of requests) {
+    if (r.request_type === 'age_preference') {
+      age.push(r)
+      continue
+    }
+    if (r.source_field === 'bunk_with' || r.source_field === 'socialize_with') {
+      parent.push(r)
+      continue
+    }
+    staff.push(r)
+  }
+
+  const byName = (a: T, b: T): number => {
+    const af = a.targetPerson?.first_name ?? ''
+    const bf = b.targetPerson?.first_name ?? ''
+    if (af !== bf) return af.localeCompare(bf)
+    const al = a.targetPerson?.last_name ?? ''
+    const bl = b.targetPerson?.last_name ?? ''
+    return al.localeCompare(bl)
+  }
+
+  parent.sort(byName)
+  staff.sort(byName)
+  return { parent, staff, age }
+}

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -1408,7 +1408,7 @@ def test_three_grade_bunk_age_preference_evaluation():
 
 
 @pytest.mark.parametrize(
-    "request_type, source_field, source, expected_slice",
+    ("request_type", "source_field", "source", "expected_slice"),
     [
         # row 1: bunk_with / bunk_with / family → materialParent
         ("bunk_with", SourceField.BUNK_WITH, "family", "material"),

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -1392,3 +1392,137 @@ def test_three_grade_bunk_age_preference_evaluation():
     # the slice-specific rate instead.
     assert stats.best_effort_parent_request_satisfaction_rate == 1.0
     assert stats.material_parent_requests == 0
+
+
+# ---------------------------------------------------------------------------
+# Stage 3b.1 §2.8 — Backend parity: slice classification truth table
+# ---------------------------------------------------------------------------
+# Each parametrize entry maps one row of the §2.8 truth table to the
+# validator slice counter that must increment. We test classification only —
+# satisfaction doesn't matter, so we don't bother building satisfying bunks.
+#
+# "material"     → stats.material_parent_requests   == 1
+# "best_effort"  → stats.best_effort_parent_requests == 1
+# "staff"        → stats.staff_requests              == 1
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "request_type, source_field, source, expected_slice",
+    [
+        # row 1: bunk_with / bunk_with / family → materialParent
+        ("bunk_with", SourceField.BUNK_WITH, "family", "material"),
+        # row 2: bunk_with / bunking_notes / staff → staff
+        ("bunk_with", SourceField.BUNKING_NOTES, "staff", "staff"),
+        # row 3: bunk_with / internal_notes / staff → staff
+        ("bunk_with", SourceField.INTERNAL_NOTES, "staff", "staff"),
+        # row 4: not_bunk_with / bunk_with / family → materialParent  (bug-fix parity)
+        ("not_bunk_with", SourceField.BUNK_WITH, "family", "material"),
+        # row 5: not_bunk_with / not_bunk_with / staff → staff
+        ("not_bunk_with", SourceField.NOT_BUNK_WITH, "staff", "staff"),
+        # row 6: not_bunk_with / bunking_notes / staff → staff
+        ("not_bunk_with", SourceField.BUNKING_NOTES, "staff", "staff"),
+        # row 7: not_bunk_with / internal_notes / staff → staff
+        ("not_bunk_with", SourceField.INTERNAL_NOTES, "staff", "staff"),
+        # row 8: age_preference / bunk_with / family → materialParent
+        ("age_preference", SourceField.BUNK_WITH, "family", "material"),
+        # row 9: age_preference / socialize_with / family → bestEffortParent
+        ("age_preference", SourceField.SOCIALIZE_WITH, "family", "best_effort"),
+        # row 10: age_preference / null / family → bestEffortParent  (legacy fallback #1086)
+        ("age_preference", None, "family", "best_effort"),
+        # row 11: age_preference / bunking_notes / staff → staff
+        ("age_preference", SourceField.BUNKING_NOTES, "staff", "staff"),
+        # row 12: age_preference / internal_notes / staff → staff
+        ("age_preference", SourceField.INTERNAL_NOTES, "staff", "staff"),
+    ],
+    ids=[
+        "bunk_with__bunk_with__family",
+        "bunk_with__bunking_notes__staff",
+        "bunk_with__internal_notes__staff",
+        "not_bunk_with__bunk_with__family",
+        "not_bunk_with__not_bunk_with__staff",
+        "not_bunk_with__bunking_notes__staff",
+        "not_bunk_with__internal_notes__staff",
+        "age_preference__bunk_with__family",
+        "age_preference__socialize_with__family",
+        "age_preference__null__family",
+        "age_preference__bunking_notes__staff",
+        "age_preference__internal_notes__staff",
+    ],
+)
+def test_validator_slice_classification(
+    request_type: str,
+    source_field: str | None,
+    source: str,
+    expected_slice: str,
+) -> None:
+    """Backend slice classification must match the frontend computeSlicesFromPredicate
+    truth table per Stage 3b.1 §2.8.
+
+    We test classification (which counter increments) not satisfaction. Both campers
+    are placed in the same bunk; not_bunk_with rows will therefore be unsatisfied, but
+    that doesn't affect which slice counter receives the request.
+    """
+    session = _mock_session(cm_id="10000099", name="Parity Test")
+    persons = [
+        MockPerson(campminder_id="9901", name="Emma Johnson", grade=5),
+        MockPerson(campminder_id="9902", name="Liam Garcia", grade=6),
+    ]
+    bunks = [_mock_bunk("8801")]
+    assignments = [
+        _mock_assignment("9901", "8801"),
+        _mock_assignment("9902", "8801"),
+    ]
+
+    # For age_preference rows the target is None (no concrete person); for all
+    # others it points to the second camper.
+    target = None if request_type == "age_preference" else "9902"
+
+    request = MockBunkRequest(
+        requester_person_cm_id="9901",
+        requested_person_cm_id=target,
+        request_type=request_type,
+        status="resolved",
+        source_field=source_field,
+        source=source,
+        age_preference_target="older" if request_type == "age_preference" else None,
+    )
+
+    validator = BunkingValidator()
+    result = validator.validate_bunking(
+        session=session,
+        bunks=bunks,
+        assignments=assignments,
+        persons=persons,  # type: ignore[arg-type]
+        requests=[request],  # type: ignore[arg-type]
+    )
+    stats = result.statistics
+
+    material = stats.material_parent_requests
+    best_effort = stats.best_effort_parent_requests
+    staff = stats.staff_requests
+
+    if expected_slice == "material":
+        assert material == 1, (
+            f"Expected material_parent_requests=1 for "
+            f"(request_type={request_type!r}, source_field={source_field!r}, source={source!r}); "
+            f"got material={material}, best_effort={best_effort}, staff={staff}"
+        )
+        assert best_effort == 0
+        assert staff == 0
+    elif expected_slice == "best_effort":
+        assert best_effort == 1, (
+            f"Expected best_effort_parent_requests=1 for "
+            f"(request_type={request_type!r}, source_field={source_field!r}, source={source!r}); "
+            f"got material={material}, best_effort={best_effort}, staff={staff}"
+        )
+        assert material == 0
+        assert staff == 0
+    elif expected_slice == "staff":
+        assert staff == 1, (
+            f"Expected staff_requests=1 for "
+            f"(request_type={request_type!r}, source_field={source_field!r}, source={source!r}); "
+            f"got material={material}, best_effort={best_effort}, staff={staff}"
+        )
+        assert material == 0
+        assert best_effort == 0

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -1494,7 +1494,7 @@ def test_validator_slice_classification(
         bunks=bunks,
         assignments=assignments,
         persons=persons,  # type: ignore[arg-type]
-        requests=[request],  # type: ignore[arg-type]
+        requests=[request],  # type: ignore[list-item]
     )
     stats = result.statistics
 


### PR DESCRIPTION
## Summary

Stage 3b.1 surfaces Stage 3a's three-slice taxonomy (`materialParent` / `bestEffortParent` / `staff`) in `BunkingStatusPanel` and `CamperDetailsPanel`, refactors slice math into a shared predicate-driven aggregator, and fixes a request-type-vs-source-field classification bug in `computeSatisfiedRequestInfo`.

**All rules from Stage 3a §15 still apply; new code paths introduced have been audited per §15.4.**

Spec: `docs/plans/2026-04-30-parent-paramount-stage3b1-design.md` (gitignored — local working document).

## What ships

- **Two-column summary line** in `BunkingStatusPanel` — "Parent request satisfaction: X/Y met" / "Staff request satisfaction: X/Y met" with collapse-to-single-line behavior. Hidden when only best-effort parent rows exist.
- **R3 row list** (Parent → optional Staff sub-divider → Staff → existing Age preference divider → age rows) in both `BunkingStatusPanel` and `CamperDetailsPanel`. Sort within sections by requestee first/last name.
- **Animated material age marker** — pulse-and-rotate sparkle + amber `P` badge on `source_field='bunk_with'` age preferences. Plain sparkle for best-effort. Plain sparkle + indigo `S` badge for staff-source age preferences. `prefers-reduced-motion: reduce` honored.
- **Bug fix** — `computeSatisfiedRequestInfo` no longer short-circuits on `request_type === 'not_bunk_with'`. A parent's bunk_with text producing a `not_bunk_with` request now correctly bins to `materialParent`.
- **Predicate-extraction architecture** — new `computeSlicesFromPredicate` shared aggregator; `computeSatisfiedRequestInfo` becomes a thin wrapper preserving its public signature; new `deriveSlicesFromSatisfactionMap` for the prod-aligned path used by `BunkingStatusPanel`.
- **Backend validator parity** verified — 12-case parametrize matches the §2.8 truth table; backend already correctly source_field-driven, no `bunking_validator.py` change needed.

## §15.4 reviewer checklist

- [x] No new PB fetches of `bunk_requests`; reuses existing audited queries
- [x] All new array filters use `r.status === 'resolved'` (loop top of `computeSlicesFromPredicate`)
- [x] Three new entries added to §15.3 boundary inventory: `computeSlicesFromPredicate.ts`, `deriveSlicesFromSatisfactionMap.ts`, `partitionRequestsBySource.ts`
- [x] No new mutation handlers introduced
- [x] No new `alert-invalidation.test.ts` assertions needed
- [x] Source-breakout layouts honor resolved-only via single-pass classification (one filter, one classification, no slice divergence possible)

## Baseline measurement

The bug fix changes slice classification for one specific row pattern: `request_type='not_bunk_with' AND source_field='bunk_with'` (parent bunk-with text that AI parsed into an exclusion). These rows previously routed to `staff` and now correctly route to `materialParent`.

Baseline to be confirmed against current data; affected rows are those matching that pattern. Material-parent counts for those campers go up by one; staff counts go down by one. No other slices are affected.

## Test surface

- **Frontend:** 3372 vitest tests pass (~50 new for Stage 3b.1: full source-classification truth table, predicate plumbing, partition + sort, summary line render rules, R3 row list ordering, material/staff age markers in both surfaces).
- **Backend:** 3781 pytest tests pass, including 12 new parametrized parity cases mirroring the §2.8 truth table.
- **Go:** 2167 tests pass.
- **TypeScript** clean. **mypy** clean. **Lefthook pre-push** green.

## Out of scope (tracked)

- AllCamperRequestsModal source-split (Group C) — Stage 3b.2
- ValidationResultsModal + PostValidationResultsModal source aggregates (Group B) — Stage 3b.2
- Legacy null-source_field age-pref fallback removal — #1086
- Dedup priority FAMILY > STAFF — #1088
- topPriority unfiltered-vs-resolved population mismatch (preserved 3a behavior) — #1090
- Solver weight classes by source — Stage 4 / scoreboard #18c

## Test plan

- [ ] CI passes
- [ ] Visual review in dev preview: open `/camper/<id>` for a camper with both parent and staff requests; confirm two-column summary + R3 row list (Parent rows → Staff sub-divider → Staff rows → Age preference divider → age rows)
- [ ] Visual review in dev preview: open camper sidebar from bunking board / graph; confirm R3 row list inside Bunking Preferences section; no new summary line in sidebar
- [ ] Visual review: find a camper with a parent bunk_with-derived age preference; confirm animated sparkle + amber `P` badge
- [ ] Visual review: find a camper with only best-effort parent rows; confirm summary line is hidden
- [ ] Optional: trigger reduced-motion in browser dev tools; confirm sparkle stops animating
- [ ] Confirm scoreboard #18b and #27 are unblocked by these per-camper visuals (Group A); Group B/C deferred to Stage 3b.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "P"/"S" age-preference badges, a sparkle animation for material age preferences (respects reduced-motion), new dividers between parent/staff/age sections, and improved satisfaction pill/spinner UI.

* **Bug Fixes**
  * Corrected request classification/routing between material-parent, best-effort parent, and staff; fixed satisfaction aggregation and per-row satisfaction rendering, ordering, and divider display.

* **Tests**
  * Added comprehensive tests for badges, partitioning, slice aggregation, ordering, validators, and satisfaction UI scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->