### PR TITLE
feat(graph): collapse reciprocal pairs, dashed singles, drop sibling type

### DIFF
--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -365,12 +365,17 @@ export default function BunkSocialGraphModal({
 
     cyRef.current = cy
 
-    // Convert graph data to Cytoscape format
+    // Convert graph data to Cytoscape format. Sibling edges no longer
+    // render here (see follow-up issue) — filter once and use the result
+    // for both the degree calculation and the edge rendering pass so the
+    // node status agrees with the visible graph.
+    const visibleGraphEdges = graphData.edges.filter((edge) => edge.type !== 'sibling')
+
     const elements: cytoscape.ElementDefinition[] = []
     const nodeDegrees: Record<string, number> = {}
 
     // Calculate node degrees first
-    graphData.edges.forEach((edge) => {
+    visibleGraphEdges.forEach((edge) => {
       const sourceId = `node-${edge.source}`
       const targetId = `node-${edge.target}`
       nodeDegrees[sourceId] = (nodeDegrees[sourceId] ?? 0) + 1
@@ -438,43 +443,10 @@ export default function BunkSocialGraphModal({
       })
     })
 
-    // Process request edges. Sibling edges are filtered out — the sibling
-    // edge type is being removed end-to-end (see follow-up issue).
-
+    // Process request edges. The backend sends both directions of mutual
+    // requests; we keep both so reciprocal source-arrows render.
     let edgeIndex = 0
-
-    // First pass: Build complete edge map and detect edge types per pair
-    const edgesByKey: Record<string, GraphEdge> = {}
-    const nodePairEdgeTypes: Record<string, Set<string>> = {}
-
-    // Build complete edge map first
-    graphData.edges.forEach((edge) => {
-      if (edge.type === 'sibling') return
-      const directionalKey = `${edge.source}-${edge.target}-${edge.type}`
-      edgesByKey[directionalKey] = edge
-
-      // Track edge types per node pair
-      const pairKey = [edge.source, edge.target].sort().join('-')
-      nodePairEdgeTypes[pairKey] ??= new Set()
-      nodePairEdgeTypes[pairKey].add(edge.type)
-    })
-
-    // Note: We don't need to detect reciprocals - the backend already provides this information
-
-    // Third pass: Process edges
-    graphData.edges.forEach((edge) => {
-      // Sibling edges removed — defensive filter in case the API still emits them.
-      if (edge.type === 'sibling') return
-
-      // Note: We're NOT skipping duplicate request edges anymore
-      // The backend sends both directions of mutual requests and we need both
-      // to show reciprocal arrows
-
-      // Check if this node pair has multiple edge types
-      const pairKey = [edge.source, edge.target].sort().join('-')
-      const edgeTypes = nodePairEdgeTypes[pairKey]
-      const hasMultipleTypes = edgeTypes ? edgeTypes.size > 1 : false
-
+    visibleGraphEdges.forEach((edge) => {
       elements.push({
         group: 'edges',
         data: {
@@ -482,10 +454,8 @@ export default function BunkSocialGraphModal({
           id: `edge-${edgeIndex++}`, // Override with string version
           source: `node-${edge.source}`, // Override with string version
           target: `node-${edge.target}`, // Override with string version
-          // Use bezier curves when there are multiple edge types between nodes
-          curveStyle: hasMultipleTypes ? 'bezier' : 'straight',
+          curveStyle: 'straight',
           type: edge.type, // Ensure type is explicitly set
-          // Don't override reciprocal - it's already in ...edge
         },
       })
     })

--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -97,7 +97,6 @@ const getNodeColor = (degree: number): string => {
 // Edge type colors (matching main graph)
 const EDGE_COLORS: Record<string, string> = {
   request: '#3498db', // Blue for all request edges
-  sibling: '#e74c3c', // Red for all sibling edges
 }
 
 export default function BunkSocialGraphModal({
@@ -328,11 +327,7 @@ export default function BunkSocialGraphModal({
               return EDGE_COLORS[type] ?? '#95a5a6'
             },
             'target-arrow-shape': (ele: EdgeSingular) => {
-              // Show arrows for request edges, none for sibling edges
               const type = ele.data('type')
-              // Sibling edges never have arrows (they're always bidirectional)
-              if (type === 'sibling') return 'none'
-              // Request edges have arrows
               return type === 'request' ? 'triangle' : 'none'
             },
             'target-arrow-color': (ele: EdgeSingular) => {
@@ -343,10 +338,6 @@ export default function BunkSocialGraphModal({
               // Show arrow at source for reciprocal requests
               const type = ele.data('type')
               const reciprocal = ele.data('reciprocal')
-
-              // Sibling edges never have arrows
-              if (type === 'sibling') return 'none'
-              // Request edges have source arrow only if reciprocal
               return type === 'request' && reciprocal ? 'triangle' : 'none'
             },
             'source-arrow-color': (ele: EdgeSingular) => {
@@ -447,10 +438,10 @@ export default function BunkSocialGraphModal({
       })
     })
 
-    // Process edges - backend sends separate edges for sibling and request relationships
+    // Process request edges. Sibling edges are filtered out — the sibling
+    // edge type is being removed end-to-end (see follow-up issue).
 
     let edgeIndex = 0
-    const processedSiblingPairs = new Set<string>()
 
     // First pass: Build complete edge map and detect edge types per pair
     const edgesByKey: Record<string, GraphEdge> = {}
@@ -458,6 +449,7 @@ export default function BunkSocialGraphModal({
 
     // Build complete edge map first
     graphData.edges.forEach((edge) => {
+      if (edge.type === 'sibling') return
       const directionalKey = `${edge.source}-${edge.target}-${edge.type}`
       edgesByKey[directionalKey] = edge
 
@@ -471,14 +463,8 @@ export default function BunkSocialGraphModal({
 
     // Third pass: Process edges
     graphData.edges.forEach((edge) => {
-      // Skip duplicate sibling edges (they're bidirectional)
-      if (edge.type === 'sibling') {
-        const siblingKey = [edge.source, edge.target].sort().join('-')
-        if (processedSiblingPairs.has(siblingKey)) {
-          return
-        }
-        processedSiblingPairs.add(siblingKey)
-      }
+      // Sibling edges removed — defensive filter in case the API still emits them.
+      if (edge.type === 'sibling') return
 
       // Note: We're NOT skipping duplicate request edges anymore
       // The backend sends both directions of mutual requests and we need both
@@ -881,10 +867,6 @@ export default function BunkSocialGraphModal({
                               />
                             </svg>
                             <span>Request</span>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <div className="h-0.5 w-6 bg-red-500"></div>
-                            <span>Siblings</span>
                           </div>
                         </div>
                       </div>

--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -349,9 +349,7 @@ export default function BunkSocialGraphModal({
               // Opacity based on confidence: 0.3 to 0.9
               return Math.max(0.3, Math.min(0.9, confidence))
             },
-            'curve-style': (ele: EdgeSingular) => {
-              return ele.data('curveStyle') ?? 'straight'
-            },
+            'curve-style': 'straight',
             'control-point-step-size': 40,
             'overlay-padding': '3px',
           },
@@ -450,12 +448,11 @@ export default function BunkSocialGraphModal({
       elements.push({
         group: 'edges',
         data: {
-          ...edge, // Spread first to include all edge properties (including reciprocal from backend)
-          id: `edge-${edgeIndex++}`, // Override with string version
-          source: `node-${edge.source}`, // Override with string version
-          target: `node-${edge.target}`, // Override with string version
-          curveStyle: 'straight',
-          type: edge.type, // Ensure type is explicitly set
+          ...edge,
+          id: `edge-${edgeIndex++}`,
+          source: `node-${edge.source}`,
+          target: `node-${edge.target}`,
+          type: edge.type,
         },
       })
     })

--- a/frontend/src/components/SocialNetworkGraph.test.ts
+++ b/frontend/src/components/SocialNetworkGraph.test.ts
@@ -61,10 +61,10 @@ describe('SocialNetworkGraph safety guards', () => {
 describe('SocialNetworkGraph header layout — slim single row', () => {
   const source = readFileSync(resolve(__dirname, './SocialNetworkGraph.tsx'), 'utf-8')
 
-  it('initialises showEdges with request and sibling both true (always-on)', () => {
-    // request and sibling must be present and default to true
+  it('initialises showEdges with request true (always-on)', () => {
+    // request must be present and default to true. Sibling has been removed.
     expect(source).toContain('request: true')
-    expect(source).toContain('sibling: true')
+    expect(source).not.toContain('sibling: true')
   })
 
   it('does NOT render <EdgeFilters> (edge filter section removed)', () => {

--- a/frontend/src/components/SocialNetworkGraph.tsx
+++ b/frontend/src/components/SocialNetworkGraph.tsx
@@ -50,10 +50,10 @@ interface SocialNetworkGraphProps {
 import type { LayoutWorkerOutput } from '../workers/layoutWorker'
 import { makeLayoutToken, isStaleLayoutMessage } from '../workers/layoutWorkerGuards'
 
-// Module-level constant: request + sibling edges are always-on (not user-toggleable).
+// Module-level constant: request edges are always-on (not user-toggleable).
 // Hoisted outside the component so the reference is stable across renders —
 // passing a fresh object literal in deps arrays causes infinite re-renders.
-const SHOW_EDGES = { request: true, sibling: true } as const
+const SHOW_EDGES = { request: true } as const
 
 export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphProps) {
   const containerRef = useRef<HTMLDivElement>(null)

--- a/frontend/src/components/graph/EdgeFilters.test.tsx
+++ b/frontend/src/components/graph/EdgeFilters.test.tsx
@@ -12,11 +12,12 @@ import { getEdgeLabel } from './constants'
 describe('getEdgeLabel utility', () => {
   it('maps known edge types to display labels', () => {
     expect(getEdgeLabel('request')).toBe('Requests')
-    expect(getEdgeLabel('sibling')).toBe('Siblings')
   })
 
   it('falls back to the raw type for unknown edge types', () => {
     expect(getEdgeLabel('unknown')).toBe('unknown')
     expect(getEdgeLabel('custom')).toBe('custom')
+    // Sibling is intentionally not labeled — the type is removed.
+    expect(getEdgeLabel('sibling')).toBe('sibling')
   })
 })

--- a/frontend/src/components/graph/GraphLegend.test.tsx
+++ b/frontend/src/components/graph/GraphLegend.test.tsx
@@ -8,48 +8,6 @@ import { render, screen } from '@testing-library/react'
 
 import GraphLegend from './GraphLegend'
 
-describe('GraphLegend constants', () => {
-  describe('edge type colors', () => {
-    it('should have predefined colors for each edge type', () => {
-      const EDGE_COLORS: Record<string, string> = {
-        request: '#3498db',
-        historical: '#95a5a6',
-        sibling: '#e74c3c',
-        school: '#2ecc71',
-        bundled: '#9b59b6',
-      }
-
-      expect(EDGE_COLORS['request']).toBe('#3498db')
-      expect(EDGE_COLORS['historical']).toBe('#95a5a6')
-      expect(EDGE_COLORS['sibling']).toBe('#e74c3c')
-      expect(EDGE_COLORS['school']).toBe('#2ecc71')
-    })
-  })
-
-  describe('grade colors', () => {
-    it('should have colors for grades 1-12', () => {
-      const GRADE_COLORS: Record<number, string> = {
-        1: '#e74c3c',
-        2: '#e67e22',
-        3: '#f39c12',
-        4: '#f1c40f',
-        5: '#2ecc71',
-        6: '#27ae60',
-        7: '#16a085',
-        8: '#3498db',
-        9: '#2980b9',
-        10: '#9b59b6',
-        11: '#8e44ad',
-        12: '#34495e',
-      }
-
-      expect(Object.keys(GRADE_COLORS)).toHaveLength(12)
-      expect(GRADE_COLORS[1]).toBe('#e74c3c')
-      expect(GRADE_COLORS[12]).toBe('#34495e')
-    })
-  })
-})
-
 describe('GraphLegend rendering', () => {
   it('renames the node status section to "Camper request status"', () => {
     render(<GraphLegend />)

--- a/frontend/src/components/graph/GraphLegend.test.tsx
+++ b/frontend/src/components/graph/GraphLegend.test.tsx
@@ -95,8 +95,14 @@ describe('GraphLegend rendering', () => {
     expect(screen.getByText("Don't Bunk With")).toBeInTheDocument()
   })
 
-  it('renders a "Sibling" edge entry', () => {
+  it('does NOT render a Sibling edge entry', () => {
     render(<GraphLegend />)
-    expect(screen.getByText('Sibling')).toBeInTheDocument()
+    expect(screen.queryByText('Sibling')).not.toBeInTheDocument()
+    expect(screen.queryByText('Siblings')).not.toBeInTheDocument()
+  })
+
+  it('renders a "Mutual request" indicator showing the new bold-solid style', () => {
+    render(<GraphLegend />)
+    expect(screen.getByText('Mutual request')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/graph/GraphLegend.tsx
+++ b/frontend/src/components/graph/GraphLegend.tsx
@@ -15,6 +15,22 @@ export interface GraphLegendProps {
   existingGrades?: Set<number>
 }
 
+function DashedLine({ color }: { color: string }) {
+  return (
+    <svg width="20" height="6" className="flex-shrink-0">
+      <line x1="0" y1="3" x2="20" y2="3" stroke={color} strokeWidth="2" strokeDasharray="4 2" />
+    </svg>
+  )
+}
+
+function SolidLine({ color }: { color: string }) {
+  return (
+    <svg width="20" height="8" className="flex-shrink-0">
+      <line x1="0" y1="4" x2="20" y2="4" stroke={color} strokeWidth="3" />
+    </svg>
+  )
+}
+
 export default function GraphLegend({
   edgeColors = EDGE_COLORS,
   gradeColors = GRADE_COLORS,
@@ -27,37 +43,15 @@ export default function GraphLegend({
         <div className="mb-1 font-medium">Edge Types</div>
         <div className="space-y-1">
           <div className="flex items-center gap-2">
-            <svg width="20" height="6" className="flex-shrink-0">
-              <line
-                x1="0"
-                y1="3"
-                x2="20"
-                y2="3"
-                stroke={edgeColors['request']}
-                strokeWidth="2"
-                strokeDasharray="4 2"
-              />
-            </svg>
+            <DashedLine color={edgeColors['request'] ?? '#000'} />
             <span>Bunk Request</span>
           </div>
           <div className="flex items-center gap-2">
-            <svg width="20" height="6" className="flex-shrink-0">
-              <line
-                x1="0"
-                y1="3"
-                x2="20"
-                y2="3"
-                stroke={edgeColors['not_bunk_with']}
-                strokeWidth="2"
-                strokeDasharray="4 2"
-              />
-            </svg>
+            <DashedLine color={edgeColors['not_bunk_with'] ?? '#000'} />
             <span>Don't Bunk With</span>
           </div>
           <div className="flex items-center gap-2">
-            <svg width="20" height="8" className="flex-shrink-0">
-              <line x1="0" y1="4" x2="20" y2="4" stroke={edgeColors['request']} strokeWidth="3" />
-            </svg>
+            <SolidLine color={edgeColors['request'] ?? '#000'} />
             <span>Mutual request</span>
           </div>
         </div>

--- a/frontend/src/components/graph/GraphLegend.tsx
+++ b/frontend/src/components/graph/GraphLegend.tsx
@@ -27,16 +27,38 @@ export default function GraphLegend({
         <div className="mb-1 font-medium">Edge Types</div>
         <div className="space-y-1">
           <div className="flex items-center gap-2">
-            <div className="h-0.5 w-4" style={{ backgroundColor: edgeColors['request'] }} />
+            <svg width="20" height="6" className="flex-shrink-0">
+              <line
+                x1="0"
+                y1="3"
+                x2="20"
+                y2="3"
+                stroke={edgeColors['request']}
+                strokeWidth="2"
+                strokeDasharray="4 2"
+              />
+            </svg>
             <span>Bunk Request</span>
           </div>
           <div className="flex items-center gap-2">
-            <div className="h-0.5 w-4" style={{ backgroundColor: edgeColors['not_bunk_with'] }} />
+            <svg width="20" height="6" className="flex-shrink-0">
+              <line
+                x1="0"
+                y1="3"
+                x2="20"
+                y2="3"
+                stroke={edgeColors['not_bunk_with']}
+                strokeWidth="2"
+                strokeDasharray="4 2"
+              />
+            </svg>
             <span>Don't Bunk With</span>
           </div>
           <div className="flex items-center gap-2">
-            <div className="h-0.5 w-4" style={{ backgroundColor: edgeColors['sibling'] }} />
-            <span>Sibling</span>
+            <svg width="20" height="8" className="flex-shrink-0">
+              <line x1="0" y1="4" x2="20" y2="4" stroke={edgeColors['request']} strokeWidth="3" />
+            </svg>
+            <span>Mutual request</span>
           </div>
         </div>
       </div>

--- a/frontend/src/components/graph/constants.ts
+++ b/frontend/src/components/graph/constants.ts
@@ -23,14 +23,10 @@ export const GRADE_COLORS: Record<number, string> = {
 //
 // `request` is the positive bunk-with edge (blue). `not_bunk_with` is the
 // negative request keyed off `request_type` since the API ships both as
-// type='request' (the negative edge differs only by request_type). Sibling
-// is intentionally green so it doesn't share a hue with the negative
-// request — when both render in the same graph they need to be visually
-// distinct at a glance.
+// type='request' (the negative edge differs only by request_type).
 export const EDGE_COLORS: Record<string, string> = {
   request: '#3498db',
   not_bunk_with: '#e74c3c',
-  sibling: '#2ecc71',
   bundled: '#9b59b6',
 }
 
@@ -50,7 +46,6 @@ export const STATUS_COLORS: Record<string, string> = {
 // Edge type display labels
 export const EDGE_LABELS: Record<string, string> = {
   request: 'Requests',
-  sibling: 'Siblings',
 }
 
 /**

--- a/frontend/src/components/graph/cytoscapeStyles.test.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.test.ts
@@ -426,17 +426,27 @@ describe('EDGE_COLORS constant', () => {
 })
 
 describe('edge curve rendering', () => {
-  it('renders single relationships as straight lines (not curved)', () => {
-    // A pair with only one edge between them gets a plain directional
-    // arrow — easier to read than a slight curve. Curving is reserved for
-    // pairs with 2+ relationships.
+  it('renders single relationships as straight dashed lines (regular weight, single arrow)', () => {
     const styles = getCytoscapeStyles({ showLabels: true })
     const edgeStyle = styles.find((s) => s.selector === 'edge')
     expect(edgeStyle).toBeDefined()
     const styleObj = edgeStyle?.style as unknown as Record<string, unknown>
     expect(styleObj['curve-style']).toBe('straight')
-    // No double-headed arrowing — each edge owns its own one-way arrow.
+    expect(styleObj['line-style']).toBe('dashed')
+    expect(styleObj['width']).toBe(2)
+    expect(styleObj['target-arrow-shape']).toBe('triangle')
+    // No source arrowhead at the base — that's reserved for is_reciprocal.
     expect(styleObj['source-arrow-shape']).toBeUndefined()
+  })
+
+  it('overrides edge[?is_reciprocal] to bold solid with a source arrow', () => {
+    const styles = getCytoscapeStyles({ showLabels: true })
+    const reciprocalStyle = styles.find((s) => s.selector === 'edge[?is_reciprocal]')
+    expect(reciprocalStyle).toBeDefined()
+    const styleObj = reciprocalStyle?.style as unknown as Record<string, unknown>
+    expect(styleObj['width']).toBe(4)
+    expect(styleObj['line-style']).toBe('solid')
+    expect(styleObj['source-arrow-shape']).toBe('triangle')
   })
 
   it('overrides curve-style to unbundled-bezier on edges flagged with multi', () => {
@@ -447,9 +457,22 @@ describe('edge curve rendering', () => {
     expect(styleObj['curve-style']).toBe('unbundled-bezier')
   })
 
-  it('does not register a legacy edge[?is_reciprocal] override (per-edge rendering, not per-pair)', () => {
+  it('source-arrow-color on edge[?is_reciprocal] resolves like the line color', () => {
+    // The reciprocal source arrow must match the line color (same
+    // resolveEdgeColor function), otherwise a recip not_bunk_with would
+    // render with a blue source arrow.
     const styles = getCytoscapeStyles({ showLabels: true })
-    expect(styles.find((s) => s.selector === 'edge[?is_reciprocal]')).toBeUndefined()
+    const reciprocalStyle = styles.find((s) => s.selector === 'edge[?is_reciprocal]')
+    expect(reciprocalStyle).toBeDefined()
+    const styleObj = reciprocalStyle?.style as unknown as Record<string, unknown>
+    const sourceColor = styleObj['source-arrow-color']
+    expect(typeof sourceColor).toBe('function')
+    const fakeEdge = {
+      data: (key: string) =>
+        key === 'edge_type' ? 'request' : key === 'request_type' ? 'not_bunk_with' : null,
+    }
+    const color = (sourceColor as (e: unknown) => string)(fakeEdge)
+    expect(color).toBe('#e74c3c')
   })
 
   it('colors not_bunk_with request edges using EDGE_COLORS["not_bunk_with"]', () => {

--- a/frontend/src/components/graph/cytoscapeStyles.test.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.test.ts
@@ -316,6 +316,27 @@ describe('createGraphElements', () => {
     expect(out[0]?.data.request_type).toBe('not_bunk_with')
   })
 
+  it('filters out sibling edges defensively even if the API still emits them', () => {
+    const edges: GraphEdgeData[] = [
+      { source: 1, target: 2, type: 'sibling', priority: 0, confidence: 1, reciprocal: false },
+      {
+        source: 1,
+        target: 2,
+        type: 'request',
+        priority: 1,
+        confidence: 0.9,
+        reciprocal: false,
+        request_type: 'bunk_with',
+      },
+    ]
+    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
+      request: true,
+      sibling: true,
+    })
+    expect(out).toHaveLength(1)
+    expect(out[0]?.data.edge_type).toBe('request')
+  })
+
   it('keeps a single one-way edge unflagged (is_reciprocal falsy, no multi)', () => {
     // Cytoscape's edge[?is_reciprocal] selector matches truthy values; either
     // false or undefined skips the bold-solid override. We forward the

--- a/frontend/src/components/graph/cytoscapeStyles.test.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.test.ts
@@ -440,10 +440,6 @@ describe('EDGE_COLORS constant', () => {
   it('uses red for not_bunk_with (negative) requests', () => {
     expect(EDGE_COLORS['not_bunk_with']).toBe('#e74c3c')
   })
-
-  it('uses green for sibling edges (was previously red)', () => {
-    expect(EDGE_COLORS['sibling']).toBe('#2ecc71')
-  })
 })
 
 describe('edge curve rendering', () => {

--- a/frontend/src/components/graph/cytoscapeStyles.test.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.test.ts
@@ -223,9 +223,39 @@ describe('createGraphElements', () => {
     expect(requestEdge.data.is_reciprocal).toBe(true)
   })
 
-  it('flags edges as multi when the unordered pair has 2+ relationships', () => {
+  it('flags multi only on mixed-type pairs (different request_types still counts)', () => {
+    // After the same-type-collapse change, two edges of the same request_type
+    // collapse to one is_reciprocal edge. Multi only fires when types differ.
     const edges: GraphEdgeData[] = [
-      // pair (1,2): one bunk_with each direction → 2 edges → multi
+      {
+        source: 1,
+        target: 2,
+        type: 'request',
+        priority: 1,
+        confidence: 0.9,
+        reciprocal: false,
+        request_type: 'bunk_with',
+      },
+      {
+        source: 2,
+        target: 1,
+        type: 'request',
+        priority: 1,
+        confidence: 0.9,
+        reciprocal: false,
+        request_type: 'not_bunk_with',
+      },
+    ]
+    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
+      request: true,
+      sibling: true,
+    })
+    expect(out).toHaveLength(2)
+    expect(out.every((e) => e.data.multi === true)).toBe(true)
+  })
+
+  it('collapses a same-type reciprocal bunk_with pair into one edge tagged is_reciprocal', () => {
+    const edges: GraphEdgeData[] = [
       {
         source: 1,
         target: 2,
@@ -244,31 +274,53 @@ describe('createGraphElements', () => {
         reciprocal: true,
         request_type: 'bunk_with',
       },
-      // pair (2,3): single sibling edge → 1 edge → not multi
-      { source: 2, target: 3, type: 'sibling', priority: 0, confidence: 1, reciprocal: false },
     ]
     const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
       request: true,
-      historical: true,
       sibling: true,
-      school: true,
     })
-    const between12 = out.filter(
-      (e) =>
-        (e.data.source === '1' && e.data.target === '2') ||
-        (e.data.source === '2' && e.data.target === '1')
-    )
-    expect(between12).toHaveLength(2)
-    expect(between12.every((e) => e.data.multi === true)).toBe(true)
-
-    const between23 = expectDefined(
-      out.find((e) => e.data.source === '2' && e.data.target === '3'),
-      '2-3 edge'
-    )
-    expect(between23.data.multi).toBeUndefined()
+    expect(out).toHaveLength(1)
+    const edge = expectDefined(out[0], 'collapsed edge')
+    expect(edge.data.is_reciprocal).toBe(true)
+    expect(edge.data.multi).toBeUndefined()
+    expect(edge.data.request_type).toBe('bunk_with')
   })
 
-  it('treats sibling+request between the same pair as multi (different types still counts)', () => {
+  it('collapses a same-type reciprocal not_bunk_with pair', () => {
+    const edges: GraphEdgeData[] = [
+      {
+        source: 1,
+        target: 2,
+        type: 'request',
+        priority: 1,
+        confidence: 0.9,
+        reciprocal: true,
+        request_type: 'not_bunk_with',
+      },
+      {
+        source: 2,
+        target: 1,
+        type: 'request',
+        priority: 1,
+        confidence: 0.9,
+        reciprocal: true,
+        request_type: 'not_bunk_with',
+      },
+    ]
+    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
+      request: true,
+      sibling: true,
+    })
+    expect(out).toHaveLength(1)
+    expect(out[0]?.data.is_reciprocal).toBe(true)
+    expect(out[0]?.data.request_type).toBe('not_bunk_with')
+  })
+
+  it('keeps a single one-way edge unflagged (is_reciprocal falsy, no multi)', () => {
+    // Cytoscape's edge[?is_reciprocal] selector matches truthy values; either
+    // false or undefined skips the bold-solid override. We forward the
+    // original edge.reciprocal value (false here) for any downstream
+    // consumer that read it before.
     const edges: GraphEdgeData[] = [
       {
         source: 1,
@@ -279,16 +331,14 @@ describe('createGraphElements', () => {
         reciprocal: false,
         request_type: 'bunk_with',
       },
-      { source: 1, target: 2, type: 'sibling', priority: 0, confidence: 1, reciprocal: false },
     ]
     const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
       request: true,
-      historical: true,
       sibling: true,
-      school: true,
     })
-    expect(out).toHaveLength(2)
-    expect(out.every((e) => e.data.multi === true)).toBe(true)
+    expect(out).toHaveLength(1)
+    expect(out[0]?.data.is_reciprocal).toBeFalsy()
+    expect(out[0]?.data.multi).toBeUndefined()
   })
 
   it('passes request_type from edge data to EdgeElement so styles can color negative requests differently', () => {

--- a/frontend/src/components/graph/cytoscapeStyles.test.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.test.ts
@@ -267,6 +267,39 @@ describe('createGraphElements', () => {
     expect(edge.data.request_type).toBe('bunk_with')
   })
 
+  it('does NOT collapse two same-direction duplicate edges (defensive against API bugs)', () => {
+    // Two A→B edges of the same kind aren't a mutual pair — only opposite
+    // directions count. Without this guard, backend duplicates would render
+    // as a phantom mutual relationship.
+    const edges: GraphEdgeData[] = [
+      {
+        source: 1,
+        target: 2,
+        type: 'request',
+        priority: 1,
+        confidence: 0.9,
+        reciprocal: false,
+        request_type: 'bunk_with',
+      },
+      {
+        source: 1,
+        target: 2,
+        type: 'request',
+        priority: 1,
+        confidence: 0.9,
+        reciprocal: false,
+        request_type: 'bunk_with',
+      },
+    ]
+    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
+      request: true,
+    })
+    expect(out).toHaveLength(2)
+    expect(out.every((e) => e.data.is_reciprocal !== true)).toBe(true)
+    // Both edges land in the multi branch since the bucket has 2 entries.
+    expect(out.every((e) => e.data.multi === true)).toBe(true)
+  })
+
   it('collapses a same-type reciprocal not_bunk_with pair', () => {
     const edges: GraphEdgeData[] = [
       {
@@ -336,7 +369,7 @@ describe('createGraphElements', () => {
       request: true,
     })
     expect(out).toHaveLength(1)
-    expect(out[0]?.data.is_reciprocal).toBeFalsy()
+    expect(out[0]?.data.is_reciprocal).toBe(false)
     expect(out[0]?.data.multi).toBeUndefined()
   })
 

--- a/frontend/src/components/graph/cytoscapeStyles.test.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.test.ts
@@ -101,6 +101,21 @@ describe('createGraphElements', () => {
     100: 'Cabin A',
   }
 
+  const reqEdge = (
+    source: number,
+    target: number,
+    request_type: 'bunk_with' | 'not_bunk_with',
+    reciprocal = false
+  ): GraphEdgeData => ({
+    source,
+    target,
+    type: 'request',
+    priority: 1,
+    confidence: 0.9,
+    reciprocal,
+    request_type,
+  })
+
   it('creates parent nodes for bunks', () => {
     const { parentNodes } = createGraphElements(mockNodes, mockEdges, mockBunksData, {
       request: true,
@@ -209,57 +224,18 @@ describe('createGraphElements', () => {
   it('flags multi only on mixed-type pairs (different request_types still counts)', () => {
     // After the same-type-collapse change, two edges of the same request_type
     // collapse to one is_reciprocal edge. Multi only fires when types differ.
-    const edges: GraphEdgeData[] = [
-      {
-        source: 1,
-        target: 2,
-        type: 'request',
-        priority: 1,
-        confidence: 0.9,
-        reciprocal: false,
-        request_type: 'bunk_with',
-      },
-      {
-        source: 2,
-        target: 1,
-        type: 'request',
-        priority: 1,
-        confidence: 0.9,
-        reciprocal: false,
-        request_type: 'not_bunk_with',
-      },
-    ]
-    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
-      request: true,
-    })
+    const edges: GraphEdgeData[] = [reqEdge(1, 2, 'bunk_with'), reqEdge(2, 1, 'not_bunk_with')]
+    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, { request: true })
     expect(out).toHaveLength(2)
     expect(out.every((e) => e.data.multi === true)).toBe(true)
   })
 
   it('collapses a same-type reciprocal bunk_with pair into one edge tagged is_reciprocal', () => {
     const edges: GraphEdgeData[] = [
-      {
-        source: 1,
-        target: 2,
-        type: 'request',
-        priority: 1,
-        confidence: 0.9,
-        reciprocal: true,
-        request_type: 'bunk_with',
-      },
-      {
-        source: 2,
-        target: 1,
-        type: 'request',
-        priority: 1,
-        confidence: 0.9,
-        reciprocal: true,
-        request_type: 'bunk_with',
-      },
+      reqEdge(1, 2, 'bunk_with', true),
+      reqEdge(2, 1, 'bunk_with', true),
     ]
-    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
-      request: true,
-    })
+    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, { request: true })
     expect(out).toHaveLength(1)
     const edge = expectDefined(out[0], 'collapsed edge')
     expect(edge.data.is_reciprocal).toBe(true)
@@ -271,29 +247,8 @@ describe('createGraphElements', () => {
     // Two A→B edges of the same kind aren't a mutual pair — only opposite
     // directions count. Without this guard, backend duplicates would render
     // as a phantom mutual relationship.
-    const edges: GraphEdgeData[] = [
-      {
-        source: 1,
-        target: 2,
-        type: 'request',
-        priority: 1,
-        confidence: 0.9,
-        reciprocal: false,
-        request_type: 'bunk_with',
-      },
-      {
-        source: 1,
-        target: 2,
-        type: 'request',
-        priority: 1,
-        confidence: 0.9,
-        reciprocal: false,
-        request_type: 'bunk_with',
-      },
-    ]
-    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
-      request: true,
-    })
+    const edges: GraphEdgeData[] = [reqEdge(1, 2, 'bunk_with'), reqEdge(1, 2, 'bunk_with')]
+    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, { request: true })
     expect(out).toHaveLength(2)
     expect(out.every((e) => e.data.is_reciprocal !== true)).toBe(true)
     // Both edges land in the multi branch since the bucket has 2 entries.
@@ -302,28 +257,10 @@ describe('createGraphElements', () => {
 
   it('collapses a same-type reciprocal not_bunk_with pair', () => {
     const edges: GraphEdgeData[] = [
-      {
-        source: 1,
-        target: 2,
-        type: 'request',
-        priority: 1,
-        confidence: 0.9,
-        reciprocal: true,
-        request_type: 'not_bunk_with',
-      },
-      {
-        source: 2,
-        target: 1,
-        type: 'request',
-        priority: 1,
-        confidence: 0.9,
-        reciprocal: true,
-        request_type: 'not_bunk_with',
-      },
+      reqEdge(1, 2, 'not_bunk_with', true),
+      reqEdge(2, 1, 'not_bunk_with', true),
     ]
-    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
-      request: true,
-    })
+    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, { request: true })
     expect(out).toHaveLength(1)
     expect(out[0]?.data.is_reciprocal).toBe(true)
     expect(out[0]?.data.request_type).toBe('not_bunk_with')
@@ -332,19 +269,9 @@ describe('createGraphElements', () => {
   it('filters out sibling edges defensively even if the API still emits them', () => {
     const edges: GraphEdgeData[] = [
       { source: 1, target: 2, type: 'sibling', priority: 0, confidence: 1, reciprocal: false },
-      {
-        source: 1,
-        target: 2,
-        type: 'request',
-        priority: 1,
-        confidence: 0.9,
-        reciprocal: false,
-        request_type: 'bunk_with',
-      },
+      reqEdge(1, 2, 'bunk_with'),
     ]
-    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
-      request: true,
-    })
+    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, { request: true })
     expect(out).toHaveLength(1)
     expect(out[0]?.data.edge_type).toBe('request')
   })
@@ -354,20 +281,8 @@ describe('createGraphElements', () => {
     // false or undefined skips the bold-solid override. We forward the
     // original edge.reciprocal value (false here) for any downstream
     // consumer that read it before.
-    const edges: GraphEdgeData[] = [
-      {
-        source: 1,
-        target: 2,
-        type: 'request',
-        priority: 1,
-        confidence: 0.9,
-        reciprocal: false,
-        request_type: 'bunk_with',
-      },
-    ]
-    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
-      request: true,
-    })
+    const edges: GraphEdgeData[] = [reqEdge(1, 2, 'bunk_with')]
+    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, { request: true })
     expect(out).toHaveLength(1)
     expect(out[0]?.data.is_reciprocal).toBe(false)
     expect(out[0]?.data.multi).toBeUndefined()
@@ -375,28 +290,10 @@ describe('createGraphElements', () => {
 
   it('passes request_type from edge data to EdgeElement so styles can color negative requests differently', () => {
     const edges: GraphEdgeData[] = [
-      {
-        source: 1,
-        target: 2,
-        type: 'request',
-        priority: 1,
-        confidence: 0.9,
-        reciprocal: false,
-        request_type: 'not_bunk_with',
-      },
-      {
-        source: 2,
-        target: 3,
-        type: 'request',
-        priority: 1,
-        confidence: 0.9,
-        reciprocal: true,
-        request_type: 'bunk_with',
-      },
+      reqEdge(1, 2, 'not_bunk_with'),
+      reqEdge(2, 3, 'bunk_with', true),
     ]
-    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
-      request: true,
-    })
+    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, { request: true })
     expect(out).toHaveLength(2)
     const negative = expectDefined(
       out.find((e) => e.data.source === '1' && e.data.target === '2'),

--- a/frontend/src/components/graph/cytoscapeStyles.test.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.test.ts
@@ -104,9 +104,6 @@ describe('createGraphElements', () => {
   it('creates parent nodes for bunks', () => {
     const { parentNodes } = createGraphElements(mockNodes, mockEdges, mockBunksData, {
       request: true,
-      historical: true,
-      sibling: true,
-      school: true,
     })
     const bunkParent = expectDefined(
       parentNodes.find((p) => p.data.id === 'bunk-100'),
@@ -136,7 +133,7 @@ describe('createGraphElements', () => {
       [camper(1, 100), camper(2, 101), camper(3, 102), camper(4, 103)],
       [],
       { 100: 'B-1', 101: 'B-2', 102: 'G-1', 103: 'G-2' },
-      { request: true, historical: true, sibling: true, school: true }
+      { request: true }
     )
     expect(parentNodes.every((p) => p.data.isBunkParent)).toBe(true)
     expect(parentNodes.every((p) => p.data.id.startsWith('bunk-'))).toBe(true)
@@ -145,9 +142,6 @@ describe('createGraphElements', () => {
   it('creates camper nodes with correct data', () => {
     const { nodes } = createGraphElements(mockNodes, mockEdges, mockBunksData, {
       request: true,
-      historical: true,
-      sibling: true,
-      school: true,
     })
     expect(nodes).toHaveLength(3)
 
@@ -163,9 +157,6 @@ describe('createGraphElements', () => {
   it('assigns parent to nodes with bunk_cm_id', () => {
     const { nodes } = createGraphElements(mockNodes, mockEdges, mockBunksData, {
       request: true,
-      historical: true,
-      sibling: true,
-      school: true,
     })
 
     const alice = expectDefined(
@@ -181,25 +172,20 @@ describe('createGraphElements', () => {
     expect(charlie.data.parent).toBeUndefined()
   })
 
-  it('filters edges based on showEdges settings', () => {
+  it('filters out request edges when showEdges.request is false', () => {
     const { edges } = createGraphElements(mockNodes, mockEdges, mockBunksData, {
-      request: true,
-      historical: false,
-      sibling: true,
-      school: true,
+      request: false,
     })
 
+    // The fixture has one 'request' edge (filtered out) and one 'historical'
+    // edge (passes through — type isn't in showEdges, so it isn't filtered).
     expect(edges).toHaveLength(1)
-    const edge = expectDefined(edges[0], 'first edge')
-    expect(edge.data.edge_type).toBe('request')
+    expect(edges[0]?.data.edge_type).toBe('historical')
   })
 
   it('includes all edges when all types are enabled', () => {
     const { edges } = createGraphElements(mockNodes, mockEdges, mockBunksData, {
       request: true,
-      historical: true,
-      sibling: true,
-      school: true,
     })
 
     expect(edges).toHaveLength(2)
@@ -208,9 +194,6 @@ describe('createGraphElements', () => {
   it('creates edges with correct data mapping', () => {
     const { edges } = createGraphElements(mockNodes, mockEdges, mockBunksData, {
       request: true,
-      historical: true,
-      sibling: true,
-      school: true,
     })
 
     const requestEdge = expectDefined(
@@ -248,7 +231,6 @@ describe('createGraphElements', () => {
     ]
     const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
       request: true,
-      sibling: true,
     })
     expect(out).toHaveLength(2)
     expect(out.every((e) => e.data.multi === true)).toBe(true)
@@ -277,7 +259,6 @@ describe('createGraphElements', () => {
     ]
     const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
       request: true,
-      sibling: true,
     })
     expect(out).toHaveLength(1)
     const edge = expectDefined(out[0], 'collapsed edge')
@@ -309,7 +290,6 @@ describe('createGraphElements', () => {
     ]
     const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
       request: true,
-      sibling: true,
     })
     expect(out).toHaveLength(1)
     expect(out[0]?.data.is_reciprocal).toBe(true)
@@ -331,7 +311,6 @@ describe('createGraphElements', () => {
     ]
     const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
       request: true,
-      sibling: true,
     })
     expect(out).toHaveLength(1)
     expect(out[0]?.data.edge_type).toBe('request')
@@ -355,7 +334,6 @@ describe('createGraphElements', () => {
     ]
     const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
       request: true,
-      sibling: true,
     })
     expect(out).toHaveLength(1)
     expect(out[0]?.data.is_reciprocal).toBeFalsy()
@@ -385,9 +363,6 @@ describe('createGraphElements', () => {
     ]
     const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, {
       request: true,
-      historical: true,
-      sibling: true,
-      school: true,
     })
     expect(out).toHaveLength(2)
     const negative = expectDefined(
@@ -419,9 +394,6 @@ describe('createGraphElements', () => {
     ]
     const { nodes } = createGraphElements(nodesWithSplits, [], mockBunksData, {
       request: true,
-      historical: true,
-      sibling: true,
-      school: true,
     })
     const alice = expectDefined(
       nodes.find((n) => n.data.id === '1'),

--- a/frontend/src/components/graph/cytoscapeStyles.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.ts
@@ -268,8 +268,8 @@ export interface EdgeElement {
     confidence: number
     is_reciprocal: boolean
     request_type?: string
-    /** True when this pair of campers has 2+ relationships (any combination
-     *  of bunk_with, not_bunk_with, sibling). Drives the curved-bezier style. */
+    /** True when a pair has two opposing-direction request edges of mixed
+     *  request_type (bunk_with vs not_bunk_with). Drives the curved bezier. */
     multi?: boolean
   }
 }
@@ -368,55 +368,44 @@ export function createGraphElements(
   const edges: EdgeElement[] = []
   let edgeIndex = 0
 
-  pairBuckets.forEach((bucket) => {
-    const [first, second] = bucket
-    // Only collapse when the two edges genuinely point opposite directions —
-    // guards against backend duplicates (e.g., two A→B edges) being misread
-    // as a mutual pair.
-    const isOppositeDirections =
-      bucket.length === 2 &&
-      first !== undefined &&
-      second !== undefined &&
-      first.source === second.target &&
-      first.target === second.source
+  const buildEdge = (
+    e: GraphEdgeData,
+    flags: { is_reciprocal: boolean; multi?: boolean }
+  ): EdgeElement => ({
+    data: {
+      id: `edge-${edgeIndex++}`,
+      source: e.source.toString(),
+      target: e.target.toString(),
+      edge_type: e.type,
+      priority: e.priority,
+      confidence: e.confidence,
+      is_reciprocal: flags.is_reciprocal,
+      ...(e.request_type ? { request_type: e.request_type } : {}),
+      ...(flags.multi ? { multi: true } : {}),
+    },
+  })
 
-    if (isOppositeDirections && sameKind(first, second)) {
-      // Same-type reciprocal pair — emit one edge with is_reciprocal: true.
-      // Source/target come from the first edge; arrowheads are symmetric in
-      // the stylesheet so the choice does not affect rendering.
-      const e = first
-      edges.push({
-        data: {
-          id: `edge-${edgeIndex++}`,
-          source: e.source.toString(),
-          target: e.target.toString(),
-          edge_type: e.type,
-          priority: e.priority,
-          confidence: e.confidence,
-          is_reciprocal: true,
-          ...(e.request_type ? { request_type: e.request_type } : {}),
-        },
-      })
-      return
+  pairBuckets.forEach((bucket) => {
+    if (bucket.length === 2) {
+      // Only collapse when the two edges genuinely point opposite directions —
+      // guards against backend duplicates (e.g., two A→B edges) being misread
+      // as a mutual pair.
+      const [first, second] = bucket as [GraphEdgeData, GraphEdgeData]
+      if (
+        first.source === second.target &&
+        first.target === second.source &&
+        sameKind(first, second)
+      ) {
+        edges.push(buildEdge(first, { is_reciprocal: true }))
+        return
+      }
     }
 
     // Otherwise, emit each edge separately. Pairs with 2+ edges get the
     // multi flag so the stylesheet curves them (true conflicts).
     const isMulti = bucket.length >= 2
     bucket.forEach((edge) => {
-      edges.push({
-        data: {
-          id: `edge-${edgeIndex++}`,
-          source: edge.source.toString(),
-          target: edge.target.toString(),
-          edge_type: edge.type,
-          priority: edge.priority,
-          confidence: edge.confidence,
-          is_reciprocal: edge.reciprocal,
-          ...(edge.request_type ? { request_type: edge.request_type } : {}),
-          ...(isMulti ? { multi: true } : {}),
-        },
-      })
+      edges.push(buildEdge(edge, { is_reciprocal: edge.reciprocal, multi: isMulti }))
     })
   })
 

--- a/frontend/src/components/graph/cytoscapeStyles.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.ts
@@ -369,11 +369,22 @@ export function createGraphElements(
   let edgeIndex = 0
 
   pairBuckets.forEach((bucket) => {
-    if (bucket.length === 2 && sameKind(bucket[0]!, bucket[1]!)) {
+    const [first, second] = bucket
+    // Only collapse when the two edges genuinely point opposite directions —
+    // guards against backend duplicates (e.g., two A→B edges) being misread
+    // as a mutual pair.
+    const isOppositeDirections =
+      bucket.length === 2 &&
+      first !== undefined &&
+      second !== undefined &&
+      first.source === second.target &&
+      first.target === second.source
+
+    if (isOppositeDirections && sameKind(first, second)) {
       // Same-type reciprocal pair — emit one edge with is_reciprocal: true.
       // Source/target come from the first edge; arrowheads are symmetric in
       // the stylesheet so the choice does not affect rendering.
-      const e = bucket[0]!
+      const e = first
       edges.push({
         data: {
           id: `edge-${edgeIndex++}`,

--- a/frontend/src/components/graph/cytoscapeStyles.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.ts
@@ -117,23 +117,39 @@ export function getCytoscapeStyles({ showLabels }: CytoscapeStyleOptions): Style
       style: {
         width: 2,
         'line-color': (ele: EdgeSingular) => resolveEdgeColor(ele),
+        'line-style': 'dashed',
         'target-arrow-shape': 'triangle',
         'target-arrow-color': (ele: EdgeSingular) => resolveEdgeColor(ele),
-        // Default: a single relationship between two campers renders as a
-        // plain straight directional arrow. Pairs with 2+ relationships
-        // (mutual same-type, asymmetric, or sibling+request combinations)
-        // pick up the `multi` data flag in createGraphElements and switch
-        // to unbundled-bezier below so each direction is its own curve.
+        // Default: a single one-way request renders as a dashed straight
+        // arrow. Same-type reciprocal pairs are collapsed upstream in
+        // createGraphElements and tagged is_reciprocal — they're picked up
+        // by the rule below for bold solid + source arrowhead. Mixed-type
+        // pairs (true conflict) keep multi:true and inherit dashed straight
+        // here, then get curved by the multi rule.
         'curve-style': 'straight',
         'overlay-padding': '2px',
       },
     },
     {
+      selector: 'edge[?is_reciprocal]',
+      style: {
+        // Bold solid double-headed line for collapsed mutual-request pairs.
+        // line-color and target-arrow-color inherit from the base 'edge'
+        // rule; source-arrow-color must mirror them so a recip not_bunk_with
+        // doesn't render with a blue source arrow.
+        width: 4,
+        'line-style': 'solid',
+        'source-arrow-shape': 'triangle',
+        'source-arrow-color': (ele: EdgeSingular) => resolveEdgeColor(ele),
+      },
+    },
+    {
       selector: 'edge[?multi]',
       style: {
-        // Splay each edge of a multi-relationship pair onto its own curve.
-        // Distance/weight are intentionally moderate so two curves don't
-        // overlap each other yet stay close enough to read as a related pair.
+        // Splay each edge of a true-conflict pair onto its own curve. Width
+        // and line-style inherit from the base rule (regular dashed) — these
+        // are still one-way requests, just visually separated so both
+        // colors read.
         'curve-style': 'unbundled-bezier',
         'control-point-distances': [40],
         'control-point-weights': [0.5],

--- a/frontend/src/components/graph/cytoscapeStyles.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.ts
@@ -35,7 +35,6 @@ export interface GraphEdgeData {
 /** Edge visibility settings */
 export interface ShowEdgesSettings {
   request: boolean
-  sibling: boolean
   [key: string]: boolean
 }
 

--- a/frontend/src/components/graph/cytoscapeStyles.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.ts
@@ -329,30 +329,66 @@ export function createGraphElements(
     return showEdges[edgeType] !== false
   })
 
-  // Count relationships per unordered pair so the renderer can curve only
-  // when there are 2+ edges between the same two campers (mutuals, mixed
-  // bunk_with/not_bunk_with, sibling-and-request combinations). Single-
-  // edge pairs stay straight, which the user finds easier to read.
-  const pairCounts = new Map<string, number>()
+  // Group edges by unordered pair so we can detect same-type reciprocal pairs
+  // (collapse to one bold double-headed line) vs mixed-type pairs (keep two
+  // curved edges as today).
   const pairKey = (a: number, b: number) => (a < b ? `${a}-${b}` : `${b}-${a}`)
+  const pairBuckets = new Map<string, GraphEdgeData[]>()
   visibleEdges.forEach((e) => {
     const k = pairKey(e.source, e.target)
-    pairCounts.set(k, (pairCounts.get(k) ?? 0) + 1)
+    const bucket = pairBuckets.get(k) ?? []
+    bucket.push(e)
+    pairBuckets.set(k, bucket)
   })
 
-  const edges: EdgeElement[] = visibleEdges.map((edge, index) => ({
-    data: {
-      id: `edge-${index}`,
-      source: edge.source.toString(),
-      target: edge.target.toString(),
-      edge_type: edge.type,
-      priority: edge.priority,
-      confidence: edge.confidence,
-      is_reciprocal: edge.reciprocal,
-      ...(edge.request_type ? { request_type: edge.request_type } : {}),
-      ...((pairCounts.get(pairKey(edge.source, edge.target)) ?? 0) >= 2 ? { multi: true } : {}),
-    },
-  }))
+  // Helper: are two edges the "same kind" — same edge_type and same
+  // request_type? Used to decide whether a 2-edge pair collapses or splays.
+  const sameKind = (a: GraphEdgeData, b: GraphEdgeData) =>
+    a.type === b.type && (a.request_type ?? null) === (b.request_type ?? null)
+
+  const edges: EdgeElement[] = []
+  let edgeIndex = 0
+
+  pairBuckets.forEach((bucket) => {
+    if (bucket.length === 2 && sameKind(bucket[0]!, bucket[1]!)) {
+      // Same-type reciprocal pair — emit one edge with is_reciprocal: true.
+      // Source/target come from the first edge; arrowheads are symmetric in
+      // the stylesheet so the choice does not affect rendering.
+      const e = bucket[0]!
+      edges.push({
+        data: {
+          id: `edge-${edgeIndex++}`,
+          source: e.source.toString(),
+          target: e.target.toString(),
+          edge_type: e.type,
+          priority: e.priority,
+          confidence: e.confidence,
+          is_reciprocal: true,
+          ...(e.request_type ? { request_type: e.request_type } : {}),
+        },
+      })
+      return
+    }
+
+    // Otherwise, emit each edge separately. Pairs with 2+ edges get the
+    // multi flag so the stylesheet curves them (true conflicts).
+    const isMulti = bucket.length >= 2
+    bucket.forEach((edge) => {
+      edges.push({
+        data: {
+          id: `edge-${edgeIndex++}`,
+          source: edge.source.toString(),
+          target: edge.target.toString(),
+          edge_type: edge.type,
+          priority: edge.priority,
+          confidence: edge.confidence,
+          is_reciprocal: edge.reciprocal,
+          ...(edge.request_type ? { request_type: edge.request_type } : {}),
+          ...(isMulti ? { multi: true } : {}),
+        },
+      })
+    })
+  })
 
   return { parentNodes, nodes, edges }
 }

--- a/frontend/src/components/graph/cytoscapeStyles.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.ts
@@ -339,8 +339,12 @@ export function createGraphElements(
     },
   }))
 
-  // Filter and create edges based on visibility settings
+  // Filter and create edges based on visibility settings.
+  // Sibling edges are stripped client-side as a defensive measure — the
+  // sibling edge type is being removed end-to-end (see follow-up issue);
+  // this filter unblocks the visual change while the API is updated.
   const visibleEdges = edgeData.filter((edge) => {
+    if (edge.type === 'sibling') return false
     const edgeType = edge.type as keyof ShowEdgesSettings
     return showEdges[edgeType] !== false
   })


### PR DESCRIPTION
## Summary

- Reciprocal same-type request pairs (mutual `bunk_with`, mutual `not_bunk_with`) collapse into one bold solid double-headed edge instead of two curves.
- One-way requests render as dashed regular-weight single arrows so the reciprocal-vs-one-way contrast is visible at any zoom and is color-blind safe.
- True conflicts (`bunk_with` ↔ `not_bunk_with`) keep the existing curved dual-edge.
- Sibling edge type removed from both `SocialNetworkGraph` (modular cytoscape) and `BunkSocialGraphModal`. No styling changes in the modal — only the edge type and its legend row come out.
- Backend removal of the sibling edge type is tracked as a separate issue (frontend filters defensively in the meantime).

Picked **Option D** (dashed singles + bold-solid reciprocals) after staff brainstorm. All four mocked options are preserved in the local spec for UAT pivot.

## Test plan

- [x] `npx vitest run` — 3321 passed
- [x] `npx tsc --noEmit` — clean
- [x] `lefthook run pre-push` — clean (ruff, mypy, tsc, eslint, prettier, go build, golangci-lint, shellcheck, pb-js-lint)
- [ ] Visual: mutual `bunk_with` pair renders as one bold double-headed solid blue line
- [ ] Visual: one-way request renders as dashed blue with one arrowhead
- [ ] Visual: `bunk_with` vs `not_bunk_with` between same pair still curves
- [ ] Visual: no sibling edges in either graph
- [ ] Visual: legend has three Edge Types rows (no Sibling)
- [ ] Color-blind mode: dashed-vs-solid signal still distinguishes recip from one-way

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed sibling relationship rendering from social network graph visualization, including edge display and legend entries.
  * Redesigned the relationship legend interface to use SVG line graphics instead of color swatches for improved visual distinction between relationship types.
  * Updated legend indicators to feature "Mutual request" as the primary complementary relationship type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->