### PR TITLE
feat(frontend): bunk graph styling pass

### DIFF
--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -24,6 +24,13 @@ import {
 import clsx from 'clsx'
 import { formatGradeOrdinal } from '../utils/gradeUtils'
 import { getSessionShorthand } from '../utils/sessionDisplay'
+import {
+  BUNK_NODE_COLORS,
+  FIRST_YEAR_RING_COLOR,
+  FIRST_YEAR_RING_WIDTH,
+  getBunkGradeColors,
+  getNodeColor,
+} from './bunkGraphStyles'
 import { socialGraphService } from '../services/socialGraph'
 import { graphCacheService } from '../services/GraphCacheService'
 import { useApiWithAuth } from '../hooks/useApiWithAuth'
@@ -85,13 +92,6 @@ interface BunkGraphData {
   edges: GraphEdge[]
   metrics: BunkGraphMetrics
   health_score: number
-}
-
-// Node colors based on connection status
-const getNodeColor = (degree: number): string => {
-  if (degree === 0) return '#e74c3c' // Red - isolated
-  if (degree <= 2) return '#f39c12' // Yellow - weak connections
-  return '#2ecc71' // Green - well connected
 }
 
 // Edge type colors (matching main graph)
@@ -313,8 +313,12 @@ export default function BunkSocialGraphModal({
         {
           selector: 'node.first-year',
           style: {
-            'border-width': 3,
-            'border-color': '#9b59b6', // Purple border for first-year campers
+            // The amber ring is the entire first-year signal — making it
+            // thicker than the default node border keeps the marker centered
+            // by geometry (no SVG badge to drift at fractional zooms) while
+            // still clearly distinguishing first-year campers.
+            'border-width': FIRST_YEAR_RING_WIDTH,
+            'border-color': FIRST_YEAR_RING_COLOR,
             'border-style': 'solid',
           },
         },
@@ -380,33 +384,12 @@ export default function BunkSocialGraphModal({
       nodeDegrees[targetId] = (nodeDegrees[targetId] ?? 0) + 1
     })
 
-    // Calculate grade colors based on bunk structure (lower/upper grades)
-    // For camp bunks, typically lower grades are the younger campers
+    // Light → mid → dark grade ramp (younger to older). Logic lives in
+    // bunkGraphStyles so the mapping is unit-tested.
     const grades = [
       ...new Set(graphData.nodes.map((n) => n.grade).filter((g) => g !== null)),
     ] as number[]
-    grades.sort((a, b) => a - b)
-    const gradeColors: Record<number, string> = {}
-
-    if (grades.length > 0) {
-      // In camp bunks, lower number grades are younger (e.g., 3rd grade < 5th grade)
-      if (grades.length === 2) {
-        // 2-grade bunk: youngest = blue, oldest = red
-        const [grade0, grade1] = grades
-        if (grade0 !== undefined) gradeColors[grade0] = '#3498db' // Youngest - blue
-        if (grade1 !== undefined) gradeColors[grade1] = '#e74c3c' // Oldest - red
-      } else if (grades.length === 3) {
-        // 3-grade bunk: youngest = blue, middle = red, oldest = dark teal
-        const [grade0, grade1, grade2] = grades
-        if (grade0 !== undefined) gradeColors[grade0] = '#3498db' // Youngest - blue
-        if (grade1 !== undefined) gradeColors[grade1] = '#e74c3c' // Middle - red
-        if (grade2 !== undefined) gradeColors[grade2] = '#16a085' // Oldest - dark teal
-      } else {
-        // Single grade - just use blue
-        const grade0 = grades[0]
-        if (grade0 !== undefined) gradeColors[grade0] = '#3498db'
-      }
-    }
+    const gradeColors = getBunkGradeColors(grades)
 
     // Add nodes with vertical randomization
     graphData.nodes.forEach((node, index) => {
@@ -425,8 +408,11 @@ export default function BunkSocialGraphModal({
         data: {
           ...node,
           id: nodeId, // Override node.id with string version
-          // Display full name with grade and historical info
-          label: `${node.name} (${formatGradeOrdinal(node.grade)})${node.first_year ? ' ①' : ''}${
+          // Display full name with grade and historical info. The first-year
+          // marker is rendered as a centered badge inside the node (see the
+          // 'node.first-year' style) — appending "①" to the label was pushing
+          // longer names onto a third line.
+          label: `${node.name} (${formatGradeOrdinal(node.grade)})${
             node.last_year_bunk && node.last_year_session
               ? `\n${getSessionShorthand(node.last_year_session)}: ${node.last_year_bunk}`
               : ''
@@ -721,7 +707,7 @@ export default function BunkSocialGraphModal({
                     <div className="bg-forest-50/40 dark:bg-forest-950/30 rounded-xl p-3">
                       <div className="text-muted-foreground flex items-center gap-2 text-sm">
                         <AlertTriangle className="h-4 w-4" />
-                        Isolated
+                        No Connections
                       </div>
                       <div
                         className={clsx(
@@ -740,8 +726,11 @@ export default function BunkSocialGraphModal({
                   <div className="bg-parchment-50/50 dark:bg-forest-950/20 border-border relative rounded-xl border">
                     <div ref={containerRef} className="h-[50vh] w-full sm:h-[70vh]" />
 
-                    {/* Mobile Controls */}
-                    <div className="absolute top-2 right-2 flex flex-col gap-2 sm:hidden">
+                    {/* Zoom/fit controls — visible on every breakpoint so
+                        desktop users can fit and zoom without a wheel. The
+                        legend toggle stays mobile-only since the legend is
+                        always rendered on desktop. */}
+                    <div className="absolute top-2 right-2 flex flex-col gap-2">
                       <button
                         onClick={handleZoomIn}
                         className="bg-card/95 shadow-lodge-sm touch-manipulation rounded-xl p-2 backdrop-blur-sm"
@@ -765,7 +754,7 @@ export default function BunkSocialGraphModal({
                       </button>
                       <button
                         onClick={() => setShowLegend(!showLegend)}
-                        className="bg-card/95 shadow-lodge-sm touch-manipulation rounded-xl p-2 backdrop-blur-sm"
+                        className="bg-card/95 shadow-lodge-sm touch-manipulation rounded-xl p-2 backdrop-blur-sm sm:hidden"
                         title="Toggle legend"
                       >
                         <Info className="h-5 w-5" />
@@ -782,58 +771,25 @@ export default function BunkSocialGraphModal({
                     >
                       <div className="text-foreground mb-2 font-semibold">Graph Legend</div>
 
-                      {/* Node Status */}
+                      {/* Node Status — binary: any connection → green, none → red */}
                       <div className="mb-2">
                         <div className="text-muted-foreground mb-1 text-[11px] font-medium">
                           Connections
                         </div>
                         <div className="space-y-0.5">
                           <div className="flex items-center gap-2">
-                            <div className="h-3 w-3 rounded-full border border-gray-600 bg-red-500 dark:border-gray-400 dark:bg-red-600"></div>
-                            <span>Isolated (0)</span>
+                            <div
+                              className="h-3 w-3 rounded-full border border-gray-600 dark:border-gray-400"
+                              style={{ backgroundColor: BUNK_NODE_COLORS.noConnections }}
+                            ></div>
+                            <span>No connections</span>
                           </div>
                           <div className="flex items-center gap-2">
-                            <div className="h-3 w-3 rounded-full border border-gray-600 bg-yellow-500 dark:border-gray-400 dark:bg-yellow-600"></div>
-                            <span>Few (1-2)</span>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <div className="h-3 w-3 rounded-full border border-gray-600 bg-green-500 dark:border-gray-400 dark:bg-green-600"></div>
-                            <span>Good (3+)</span>
-                          </div>
-                        </div>
-                      </div>
-
-                      {/* Edge Types */}
-                      <div className="mb-2">
-                        <div className="text-muted-foreground mb-1 text-[11px] font-medium">
-                          Relationships
-                        </div>
-                        <div className="space-y-0.5">
-                          <div className="flex items-center gap-2">
-                            <svg width="24" height="10" className="flex-shrink-0">
-                              <defs>
-                                <marker
-                                  id="arrowhead"
-                                  markerWidth="10"
-                                  markerHeight="7"
-                                  refX="9"
-                                  refY="3.5"
-                                  orient="auto"
-                                >
-                                  <polygon points="0 0, 10 3.5, 0 7" fill="#3498db" />
-                                </marker>
-                              </defs>
-                              <line
-                                x1="0"
-                                y1="5"
-                                x2="20"
-                                y2="5"
-                                stroke="#3498db"
-                                strokeWidth="2"
-                                markerEnd="url(#arrowhead)"
-                              />
-                            </svg>
-                            <span>Request</span>
+                            <div
+                              className="h-3 w-3 rounded-full border border-gray-600 dark:border-gray-400"
+                              style={{ backgroundColor: BUNK_NODE_COLORS.hasConnections }}
+                            ></div>
+                            <span>Has connections</span>
                           </div>
                         </div>
                       </div>
@@ -876,67 +832,30 @@ export default function BunkSocialGraphModal({
 
                             if (uniqueGrades.length === 0) return null
 
-                            if (uniqueGrades.length === 1) {
-                              return (
-                                <div className="flex items-center gap-2">
-                                  <div className="h-3 w-3 rounded-full border-2 border-blue-500"></div>
-                                  <span>
-                                    {formatGradeOrdinal(uniqueGrades[0] ?? 0)} (
-                                    {gradeCounts[uniqueGrades[0] ?? 0] ?? 0})
-                                  </span>
-                                </div>
-                              )
-                            } else if (uniqueGrades.length === 2) {
-                              return (
-                                <>
-                                  <div className="flex items-center gap-2">
-                                    <div className="h-3 w-3 rounded-full border-2 border-blue-500"></div>
-                                    <span>
-                                      {formatGradeOrdinal(uniqueGrades[0] ?? 0)} (
-                                      {gradeCounts[uniqueGrades[0] ?? 0] ?? 0})
-                                    </span>
-                                  </div>
-                                  <div className="flex items-center gap-2">
-                                    <div className="h-3 w-3 rounded-full border-2 border-red-500"></div>
-                                    <span>
-                                      {formatGradeOrdinal(uniqueGrades[1] ?? 0)} (
-                                      {gradeCounts[uniqueGrades[1] ?? 0] ?? 0})
-                                    </span>
-                                  </div>
-                                </>
-                              )
-                            } else if (uniqueGrades.length === 3) {
-                              return (
-                                <>
-                                  <div className="flex items-center gap-2">
-                                    <div className="h-3 w-3 rounded-full border-2 border-blue-500"></div>
-                                    <span>
-                                      {formatGradeOrdinal(uniqueGrades[0] ?? 0)} (
-                                      {gradeCounts[uniqueGrades[0] ?? 0] ?? 0})
-                                    </span>
-                                  </div>
-                                  <div className="flex items-center gap-2">
-                                    <div className="h-3 w-3 rounded-full border-2 border-red-500"></div>
-                                    <span>
-                                      {formatGradeOrdinal(uniqueGrades[1] ?? 0)} (
-                                      {gradeCounts[uniqueGrades[1] ?? 0] ?? 0})
-                                    </span>
-                                  </div>
-                                  <div className="flex items-center gap-2">
-                                    <div className="h-3 w-3 rounded-full border-2 border-teal-600"></div>
-                                    <span>
-                                      {formatGradeOrdinal(uniqueGrades[2] ?? 0)} (
-                                      {gradeCounts[uniqueGrades[2] ?? 0] ?? 0})
-                                    </span>
-                                  </div>
-                                </>
-                              )
-                            }
+                            // Grade swatches reuse the same light/mid/dark
+                            // ramp the cytoscape nodes draw their text from,
+                            // so the legend matches the graph regardless of
+                            // how many grades the bunk happens to contain.
+                            const legendGradeColors = getBunkGradeColors(uniqueGrades)
+                            return uniqueGrades.map((grade) => (
+                              <div key={grade} className="flex items-center gap-2">
+                                <div
+                                  className="h-3 w-3 rounded-full"
+                                  style={{ backgroundColor: legendGradeColors[grade] }}
+                                ></div>
+                                <span>
+                                  {formatGradeOrdinal(grade)} ({gradeCounts[grade] ?? 0})
+                                </span>
+                              </div>
+                            ))
                           })()}
                           {graphData.nodes.some((n) => n.first_year) && (
                             <div className="flex items-center gap-2">
-                              <div className="h-3 w-3 rounded-full border-[3px] border-purple-500"></div>
-                              <span>First year ①</span>
+                              <div
+                                className="h-3 w-3 rounded-full border-[3px]"
+                                style={{ borderColor: FIRST_YEAR_RING_COLOR }}
+                              ></div>
+                              <span>First year</span>
                             </div>
                           )}
                         </div>

--- a/frontend/src/components/bunkGraphStyles.test.ts
+++ b/frontend/src/components/bunkGraphStyles.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for bunk graph style helpers.
+ *
+ * These helpers were extracted from BunkSocialGraphModal so their behavior
+ * (binary connection coloring, light/dark grade pairing, first-year badge)
+ * can be exercised without standing up cytoscape.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  BUNK_NODE_COLORS,
+  FIRST_YEAR_RING_COLOR,
+  FIRST_YEAR_RING_WIDTH,
+  getBunkGradeColors,
+  getNodeColor,
+} from './bunkGraphStyles'
+
+describe('getNodeColor', () => {
+  it('returns the no-connections red for an isolated node', () => {
+    expect(getNodeColor(0)).toBe(BUNK_NODE_COLORS.noConnections)
+  })
+
+  it('returns the connected green for any positive degree', () => {
+    expect(getNodeColor(1)).toBe(BUNK_NODE_COLORS.hasConnections)
+    expect(getNodeColor(2)).toBe(BUNK_NODE_COLORS.hasConnections)
+    expect(getNodeColor(7)).toBe(BUNK_NODE_COLORS.hasConnections)
+  })
+
+  it('uses only two colors — red and green, no yellow tier', () => {
+    const palette = new Set<string>()
+    for (let degree = 0; degree <= 10; degree++) {
+      palette.add(getNodeColor(degree))
+    }
+    expect(palette.size).toBe(2)
+    expect(palette.has(BUNK_NODE_COLORS.noConnections)).toBe(true)
+    expect(palette.has(BUNK_NODE_COLORS.hasConnections)).toBe(true)
+  })
+})
+
+describe('getBunkGradeColors', () => {
+  it('returns an empty mapping when no grades are present', () => {
+    expect(getBunkGradeColors([])).toEqual({})
+  })
+
+  it('uses the lighter end of the scale for a single grade', () => {
+    const colors = getBunkGradeColors([4])
+    expect(colors[4]).toBe(BUNK_NODE_COLORS.gradeLight)
+  })
+
+  it('maps youngest to light and oldest to dark for a 2-grade bunk', () => {
+    const colors = getBunkGradeColors([3, 5])
+    expect(colors[3]).toBe(BUNK_NODE_COLORS.gradeLight)
+    expect(colors[5]).toBe(BUNK_NODE_COLORS.gradeDark)
+  })
+
+  it('walks light → mid → dark for a 3-grade bunk', () => {
+    const colors = getBunkGradeColors([2, 3, 4])
+    expect(colors[2]).toBe(BUNK_NODE_COLORS.gradeLight)
+    expect(colors[3]).toBe(BUNK_NODE_COLORS.gradeMid)
+    expect(colors[4]).toBe(BUNK_NODE_COLORS.gradeDark)
+  })
+
+  it('does not use raw blue (#3498db) or raw red (#e74c3c) for grade hues', () => {
+    const colors = getBunkGradeColors([2, 3, 4])
+    const values = Object.values(colors)
+    expect(values).not.toContain('#3498db')
+    expect(values).not.toContain('#e74c3c')
+  })
+
+  it('sorts grades before assigning so input order does not matter', () => {
+    const ascending = getBunkGradeColors([3, 5])
+    const descending = getBunkGradeColors([5, 3])
+    expect(ascending).toEqual(descending)
+  })
+})
+
+describe('FIRST_YEAR_RING_COLOR', () => {
+  it('is not the legacy purple ring (#9b59b6)', () => {
+    expect(FIRST_YEAR_RING_COLOR.toLowerCase()).not.toBe('#9b59b6')
+  })
+
+  it('is a yellow/orange/amber hue (warm, high luminance)', () => {
+    // Loosely: warm hue means R component meaningfully above B component.
+    const hex = FIRST_YEAR_RING_COLOR.replace('#', '')
+    const r = parseInt(hex.slice(0, 2), 16)
+    const b = parseInt(hex.slice(4, 6), 16)
+    expect(r).toBeGreaterThan(b + 80)
+  })
+})
+
+describe('FIRST_YEAR_RING_WIDTH', () => {
+  it('is thicker than the default node border so the ring reads as a marker', () => {
+    expect(FIRST_YEAR_RING_WIDTH).toBeGreaterThanOrEqual(5)
+  })
+})

--- a/frontend/src/components/bunkGraphStyles.ts
+++ b/frontend/src/components/bunkGraphStyles.ts
@@ -1,0 +1,53 @@
+/**
+ * Bunk-graph styling helpers.
+ *
+ * Extracted from BunkSocialGraphModal so the connection-color, grade-color
+ * and first-year badge logic can be unit-tested without booting cytoscape.
+ */
+
+export const BUNK_NODE_COLORS = {
+  // Binary connection state — anything > 0 reads as "has connections".
+  noConnections: '#ef4444', // red-500
+  hasConnections: '#22c55e', // green-500
+  // Light → mid → dark grade ramp. Strong luminance contrast so younger vs
+  // older reads at a glance even on small screens; replaces the old blue/red
+  // pair which was hard to distinguish from the connection colors.
+  gradeLight: '#7dd3fc', // sky-300
+  gradeMid: '#6366f1', // indigo-500
+  gradeDark: '#312e81', // indigo-900
+} as const
+
+/** Outer ring drawn around first-year campers — must pop against every grade
+ *  fill above and against red/green node fills. Amber gives the strongest
+ *  contrast across the palette. */
+export const FIRST_YEAR_RING_COLOR = '#fbbf24' // amber-400
+
+/** Border thickness used for the first-year ring. The default border is 0;
+ *  bumping this to 6 makes the ring the entire "first-year" signal — no
+ *  inner badge needed, and Cytoscape keeps it perfectly centered at every
+ *  zoom level since the ring IS the geometry. */
+export const FIRST_YEAR_RING_WIDTH = 6
+
+/** Binary node coloring: red when isolated, green otherwise. The earlier
+ *  yellow "few connections" tier was dropped because it fought with the
+ *  amber first-year ring and added a third state without much signal. */
+export function getNodeColor(degree: number): string {
+  return degree === 0 ? BUNK_NODE_COLORS.noConnections : BUNK_NODE_COLORS.hasConnections
+}
+
+/** Map each grade present in a bunk to a color from the light/dark ramp.
+ *  Younger grades get the lighter end of the scale. */
+export function getBunkGradeColors(grades: readonly number[]): Record<number, string> {
+  const sorted = [...grades].sort((a, b) => a - b)
+  const result: Record<number, string> = {}
+  sorted.forEach((grade, index) => {
+    if (index === 0) {
+      result[grade] = BUNK_NODE_COLORS.gradeLight
+    } else if (index === sorted.length - 1) {
+      result[grade] = BUNK_NODE_COLORS.gradeDark
+    } else {
+      result[grade] = BUNK_NODE_COLORS.gradeMid
+    }
+  })
+  return result
+}


### PR DESCRIPTION
Stacked on top of #1093 — this is a follow-up styling pass on the bunk social-network modal.

## Summary
- **First-year marker:** thicker amber (`#fbbf24`) ring (`border-width: 6`) — drops the SVG "1" badge entirely. The ring IS the geometry, so cytoscape keeps it perfectly centered at every zoom level (the inner badge was drifting at fractional zooms).
- **Connection coloring:** binary red (no connections) / green (has any). The yellow "few connections" tier is gone.
- **Grade ramp:** light sky → indigo → deep indigo replaces blue/red for stronger lower-vs-upper-grade contrast.
- **Legend:** collapsed Connections to two entries, removed the now-redundant Relationships row (sibling already gone in #1093, only request edges remain), grade swatches now reuse the cytoscape ramp via `getBunkGradeColors`.
- **Top-right metric + legend label:** "Isolated" → "No Connections".
- **Zoom in / zoom out / fit-to-screen** controls now visible on every breakpoint (legend toggle stays mobile-only since desktop already shows the legend).

Helpers extracted to `bunkGraphStyles.ts` so binary coloring + the light/dark grade ramp are unit-tested without booting cytoscape.

> ⚠️ Base branch is `feature/graph-edge-style`, **not** `main`. Merge after #1093.

## Test plan
- [ ] Open a bunk's social network modal — first-year campers show a thick amber ring, no inner badge
- [ ] Confirm "1" no longer appears appended to the camper label
- [ ] Verify a bunk with 0 isolated campers reads "No Connections: 0" in green, isolated count > 0 reads in red
- [ ] Verify connections legend shows two entries (no/has) — no "Few" tier
- [ ] Verify grade swatches in legend match node text colors and use the new sky/indigo ramp (not blue/red)
- [ ] Verify zoom in / zoom out / fit-to-screen buttons show on desktop and work
- [ ] Verify a bunk with no first-year campers does not show the first-year row in the legend