### PR TITLE
chore(frontend,sync): batch trivial deletions and legacy cleanup

### DIFF
--- a/frontend/src/components/CsvPipelineIndicator.test.tsx
+++ b/frontend/src/components/CsvPipelineIndicator.test.tsx
@@ -192,7 +192,7 @@ describe('CsvPipelineIndicator', () => {
       counts: { total: 1, autoMatched: 1, needReview: 0 },
     })
     render(<CsvPipelineIndicator />)
-    expect(screen.getByText(/Done .*: 1 new or updated requests/)).toBeInTheDocument()
+    expect(screen.getByText(/Done .*: 1 new or updated request/)).toBeInTheDocument()
   })
 
   it('clicking × stores current runId in dismissed-key and hides indicator', () => {

--- a/frontend/src/components/CsvPipelineIndicator.tsx
+++ b/frontend/src/components/CsvPipelineIndicator.tsx
@@ -31,9 +31,11 @@ export default function CsvPipelineIndicator() {
   useEffect(() => {
     if (data?.phase === 'done' && data.runId !== lastSeenRef.current) {
       const review = data.counts.needReview
-      const reviewLabel = review > 0 ? `, ${review} need review` : ''
+      const reviewLabel = review > 0 ? `, ${review} need${review === 1 ? 's' : ''} review` : ''
+      const total = data.counts.total
+      const matched = data.counts.autoMatched
       toast.success(
-        `Import complete: ${data.counts.total} new or updated requests, ${data.counts.autoMatched} auto-matched${reviewLabel}.`,
+        `Import complete: ${total} new or updated ${total === 1 ? 'request' : 'requests'}, ${matched} auto-matched${reviewLabel}.`,
         { duration: 6000 }
       )
       lastSeenRef.current = data.runId
@@ -75,9 +77,12 @@ export default function CsvPipelineIndicator() {
           <>
             <CheckCircle className="h-3 w-3 text-green-600" aria-hidden="true" />
             <span>
-              Done {formatTimestamp(data.finishedAt)}: {data.counts.total} new or updated requests,{' '}
-              {data.counts.autoMatched} auto-matched
-              {data.counts.needReview > 0 ? `, ${data.counts.needReview} need review` : ''}
+              Done {formatTimestamp(data.finishedAt)}: {data.counts.total} new or updated{' '}
+              {data.counts.total === 1 ? 'request' : 'requests'}, {data.counts.autoMatched}{' '}
+              auto-matched
+              {data.counts.needReview > 0
+                ? `, ${data.counts.needReview} need${data.counts.needReview === 1 ? 's' : ''} review`
+                : ''}
             </span>
           </>
         )}
@@ -116,9 +121,17 @@ export default function CsvPipelineIndicator() {
             <div className="space-y-2 text-sm">
               <p className="font-medium">Import complete</p>
               <ul className="list-disc pl-5">
-                <li>{data.counts.total} new or updated requests</li>
+                <li>
+                  {data.counts.total} new or updated{' '}
+                  {data.counts.total === 1 ? 'request' : 'requests'}
+                </li>
                 <li>{data.counts.autoMatched} auto-matched</li>
-                {data.counts.needReview > 0 && <li>{data.counts.needReview} need review</li>}
+                {data.counts.needReview > 0 && (
+                  <li>
+                    {data.counts.needReview} {data.counts.needReview === 1 ? 'needs' : 'need'}{' '}
+                    review
+                  </li>
+                )}
               </ul>
               <p className="text-xs text-gray-600">{formatTimestamp(data.finishedAt)}</p>
             </div>

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -68,14 +68,7 @@ function makeResults(statsOverrides: Record<string, unknown> = {}) {
 
 describe('PostValidationResultsModal — best-effort line removed (Stage 3b.2)', () => {
   it('does not render the best-effort one-liner even when best_effort_parent_requests > 0', () => {
-    render(
-      <PostValidationResultsModal
-        isOpen={true}
-        onClose={() => {}}
-        results={makeResults()}
-        sessionId="1000001"
-      />
-    )
+    render(<PostValidationResultsModal isOpen={true} onClose={() => {}} results={makeResults()} />)
 
     expect(screen.queryByText(/best-effort preferences honored/i)).not.toBeInTheDocument()
   })
@@ -89,7 +82,6 @@ describe('PostValidationResultsModal — best-effort line removed (Stage 3b.2)',
           best_effort_parent_requests: 0,
           satisfied_best_effort_parent_requests: 0,
         })}
-        sessionId="1000001"
       />
     )
 
@@ -109,7 +101,6 @@ describe('PostValidationResultsModal — banner sub-text (Stage 3b.2)', () => {
           material_parent_request_satisfaction_rate: 0.6,
           campers_with_unsatisfied_material_parent_requests: 6,
         })}
-        sessionId="1000001"
       />
     )
     expect(screen.getByText(/6 kids missed a parent request/i)).toBeInTheDocument()
@@ -126,7 +117,6 @@ describe('PostValidationResultsModal — banner sub-text (Stage 3b.2)', () => {
           material_parent_request_satisfaction_rate: 0.9,
           campers_with_unsatisfied_material_parent_requests: 1,
         })}
-        sessionId="1000001"
       />
     )
     expect(screen.getByText(/1 kid missed a parent request/i)).toBeInTheDocument()
@@ -144,7 +134,6 @@ describe('PostValidationResultsModal — banner sub-text (Stage 3b.2)', () => {
           material_parent_request_satisfaction_rate: 1.0,
           campers_with_unsatisfied_material_parent_requests: 0,
         })}
-        sessionId="1000001"
       />
     )
     expect(screen.getByText(/all 12 parent requests fulfilled/i)).toBeInTheDocument()
@@ -161,7 +150,6 @@ describe('PostValidationResultsModal — banner sub-text (Stage 3b.2)', () => {
           material_parent_request_satisfaction_rate: 1.0,
           campers_with_unsatisfied_material_parent_requests: 0,
         })}
-        sessionId="1000001"
       />
     )
     expect(screen.getByText(/all 1 parent request fulfilled/i)).toBeInTheDocument()
@@ -182,7 +170,6 @@ describe('PostValidationResultsModal — banner sub-text (Stage 3b.2)', () => {
           satisfied_requests: 19,
           total_requests: 20,
         })}
-        sessionId="1000001"
       />
     )
     // Expect existing per-tier copy ("Bunking looks great" for Excellent tier)
@@ -208,7 +195,6 @@ describe('PostValidationResultsModal — donut ring rate (Stage 3b.2)', () => {
           satisfied_requests: 27,
           total_requests: 30,
         })}
-        sessionId="1000001"
       />
     )
 
@@ -232,7 +218,6 @@ describe('PostValidationResultsModal — donut ring rate (Stage 3b.2)', () => {
           satisfied_requests: 17,
           total_requests: 20,
         })}
-        sessionId="1000001"
       />
     )
 
@@ -253,7 +238,6 @@ describe('PostValidationResultsModal — donut ring rate (Stage 3b.2)', () => {
           satisfied_requests: 27,
           total_requests: 30,
         })}
-        sessionId="1000001"
       />
     )
 
@@ -278,7 +262,6 @@ describe('PostValidationResultsModal — parent stats tile (Stage 3b.2)', () => 
           satisfied_requests: 27,
           total_requests: 30,
         })}
-        sessionId="1000001"
       />
     )
 
@@ -299,7 +282,6 @@ describe('PostValidationResultsModal — parent stats tile (Stage 3b.2)', () => 
           material_parent_request_satisfaction_rate: 0.6,
           campers_with_unsatisfied_material_parent_requests: 6,
         })}
-        sessionId="1000001"
       />
     )
 
@@ -323,7 +305,6 @@ describe('PostValidationResultsModal — parent stats tile (Stage 3b.2)', () => 
           material_parent_request_satisfaction_rate: 0.9,
           campers_with_unsatisfied_material_parent_requests: 0,
         })}
-        sessionId="1000001"
       />
     )
 
@@ -348,7 +329,6 @@ describe('PostValidationResultsModal — parent stats tile (Stage 3b.2)', () => 
           satisfied_requests: 18,
           total_requests: 20,
         })}
-        sessionId="1000001"
       />
     )
 

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -59,7 +59,6 @@ interface PostValidationResultsModalProps {
   isOpen: boolean
   onClose: () => void
   results: ValidationResults
-  sessionId: string
   scenarioId?: string
 }
 

--- a/frontend/src/components/ValidateBunkingButton.tsx
+++ b/frontend/src/components/ValidateBunkingButton.tsx
@@ -97,7 +97,6 @@ export default function ValidateBunkingButton({
           isOpen={showResults}
           onClose={() => setShowResults(false)}
           results={validationResults}
-          sessionId={sessionCmId.toString()}
           {...(currentScenario?.id && { scenarioId: currentScenario.id })}
         />
       )}

--- a/frontend/src/components/graph/cytoscapeStyles.test.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.test.ts
@@ -31,12 +31,6 @@ describe('getCytoscapeStyles', () => {
     expect(edgeStyle).toBeDefined()
   })
 
-  it('includes faded class selector', () => {
-    const styles = getCytoscapeStyles({ showLabels: true })
-    const fadedStyle = styles.find((s) => s.selector === '.faded')
-    expect(fadedStyle).toBeDefined()
-  })
-
   it('includes bunk parent node selector', () => {
     const styles = getCytoscapeStyles({ showLabels: true })
     const parentStyle = styles.find((s) => s.selector === 'node[isBunkParent]')

--- a/frontend/src/components/graph/cytoscapeStyles.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.ts
@@ -169,13 +169,6 @@ export function getCytoscapeStyles({ showLabels }: CytoscapeStyleOptions): Style
       },
     },
     {
-      selector: '.faded',
-      style: {
-        opacity: 0.1,
-        events: 'no',
-      },
-    },
-    {
       selector: '.scope-hidden',
       style: {
         opacity: 0,

--- a/frontend/src/services/csvPipelineStatus.test.ts
+++ b/frontend/src/services/csvPipelineStatus.test.ts
@@ -481,4 +481,36 @@ describe('fetchLatestDebugRun', () => {
     const mock = vi.fn().mockResolvedValue({ ok: false, status: 500 } as Response)
     await expect(fetchLatestDebugRun(mock)).rejects.toThrow()
   })
+
+  it('returns null when status_breakdown is missing from the row', async () => {
+    const mock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            run_id: 'run-malformed',
+            created: '2026-04-27T19:05:00Z',
+            // status_breakdown intentionally absent (schema mismatch / partial write)
+          },
+        ],
+      }),
+    } as Response)
+    expect(await fetchLatestDebugRun(mock)).toBeNull()
+  })
+
+  it('returns null when status_breakdown.status_resolved is non-numeric', async () => {
+    const mock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            run_id: 'run-bad-type',
+            created: '2026-04-27T19:05:00Z',
+            status_breakdown: { status_resolved: 'five', status_pending: 0, status_declined: 0 },
+          },
+        ],
+      }),
+    } as Response)
+    expect(await fetchLatestDebugRun(mock)).toBeNull()
+  })
 })

--- a/frontend/src/services/csvPipelineStatus.ts
+++ b/frontend/src/services/csvPipelineStatus.ts
@@ -1,4 +1,4 @@
-export type SyncJobStatus = {
+export interface SyncJobStatus {
   name: string
   status: 'running' | 'completed' | 'failed' | 'queued'
   startedAt: string
@@ -6,7 +6,7 @@ export type SyncJobStatus = {
   error?: string
 }
 
-export type DebugPipelineRun = {
+export interface DebugPipelineRun {
   run_id: string
   created: string
   status_breakdown: {
@@ -207,6 +207,16 @@ export async function fetchLatestDebugRun(
   const data = (await res.json()) as RawDebugListResponse
   const first = data.items[0]
   if (!first) return null
+  // Guard against malformed rows (schema mismatch, partial write). Without
+  // this, doneFromDebug would throw a TypeError when destructuring the counts.
+  if (
+    !first.status_breakdown ||
+    typeof first.status_breakdown.status_resolved !== 'number' ||
+    typeof first.status_breakdown.status_pending !== 'number' ||
+    typeof first.status_breakdown.status_declined !== 'number'
+  ) {
+    return null
+  }
   return {
     run_id: first.run_id,
     created: first.created,

--- a/frontend/src/utils/unitMapping.test.ts
+++ b/frontend/src/utils/unitMapping.test.ts
@@ -3,7 +3,7 @@
  * Maps bunk names (e.g. "B-1", "G-12", "Aleph") to unit names
  */
 import { describe, it, expect } from 'vitest'
-import { getUnitForBunk, getUnitSideForBunk, UNIT_COLORS } from './unitMapping'
+import { getUnitForBunk, getUnitSideForBunk } from './unitMapping'
 
 describe('getUnitForBunk', () => {
   describe('Nitzanim unit (Aleph, Bet)', () => {
@@ -203,29 +203,5 @@ describe('getUnitSideForBunk', () => {
     expect(getUnitSideForBunk('Unknown')).toBeNull()
     expect(getUnitSideForBunk('')).toBeNull()
     expect(getUnitSideForBunk('Bunk 12345')).toBeNull()
-  })
-})
-
-describe('UNIT_COLORS', () => {
-  it('has a color for every unit', () => {
-    const expectedUnits = [
-      'Nitzanim',
-      'Carmel',
-      'Galil',
-      'Eilat',
-      'Haifa',
-      'Chalutzim 1',
-      'Chalutzim 2',
-    ]
-    for (const unit of expectedUnits) {
-      expect(UNIT_COLORS[unit]).toBeDefined()
-      expect(typeof UNIT_COLORS[unit]).toBe('string')
-    }
-  })
-
-  it('colors are unique', () => {
-    const colors = Object.values(UNIT_COLORS)
-    const unique = new Set(colors)
-    expect(unique.size).toBe(colors.length)
   })
 })

--- a/frontend/src/utils/unitMapping.ts
+++ b/frontend/src/utils/unitMapping.ts
@@ -50,17 +50,6 @@ const BUNK_NUMBER_REGEX = /^(B|G|AG)-(\d+)[A-Za-z]?$/i
 /** Regex to extract prefix from prefixed Nitzanim names (B-Aleph, G-Bet) */
 const PREFIXED_NITZANIM_REGEX = /^(B|G)-(?:aleph|bet)$/i
 
-/** Muted colors for unit-level grouping (distinct from bunk bubble colors) */
-export const UNIT_COLORS: Record<string, string> = {
-  Nitzanim: '#7c8a5e',
-  Carmel: '#6b7b94',
-  Galil: '#8b7355',
-  Eilat: '#7a6b8a',
-  Haifa: '#5e8a7c',
-  'Chalutzim 1': '#8a6b6b',
-  'Chalutzim 2': '#6b7b6b',
-}
-
 /** All unit names in age order (youngest to oldest) */
 export const UNIT_NAMES = [
   'Nitzanim',

--- a/pocketbase/sync/base_sync.go
+++ b/pocketbase/sync/base_sync.go
@@ -1109,9 +1109,9 @@ func normalizeDateString(dateStr string) string {
 	return result
 }
 
-// normalizeToStringSlice converts various slice types to []string for comparison
-// Handles: []string, []any (== []interface{}) with string elements
-// Returns nil if the value is not a slice or cannot be converted
+// normalizeToStringSlice converts various types to []string for comparison
+// Handles: string, []string, []any (== []interface{}) with string elements
+// Returns nil if the value is not a string/slice or cannot be converted
 func normalizeToStringSlice(value any) []string {
 	if value == nil {
 		return nil

--- a/pocketbase/sync/base_sync.go
+++ b/pocketbase/sync/base_sync.go
@@ -1110,7 +1110,7 @@ func normalizeDateString(dateStr string) string {
 }
 
 // normalizeToStringSlice converts various slice types to []string for comparison
-// Handles: []string, []interface{} with string elements, []any with string elements
+// Handles: []string, []any (== []interface{}) with string elements
 // Returns nil if the value is not a slice or cannot be converted
 func normalizeToStringSlice(value any) []string {
 	if value == nil {
@@ -1132,27 +1132,14 @@ func normalizeToStringSlice(value any) []string {
 		return result
 	}
 
-	// []interface{} (common from JSON unmarshaling)
-	if ifaceSlice, ok := value.([]any); ok {
-		result := make([]string, 0, len(ifaceSlice))
-		for _, v := range ifaceSlice {
-			if s, ok := v.(string); ok {
-				result = append(result, s)
-			} else {
-				// Non-string element, can't normalize
-				return nil
-			}
-		}
-		return result
-	}
-
-	// []any (alias for []interface{})
+	// []any (== []interface{}) — common from JSON unmarshaling
 	if anySlice, ok := value.([]any); ok {
 		result := make([]string, 0, len(anySlice))
 		for _, v := range anySlice {
 			if s, ok := v.(string); ok {
 				result = append(result, s)
 			} else {
+				// Non-string element, can't normalize
 				return nil
 			}
 		}

--- a/pocketbase/sync/google_sheets.go
+++ b/pocketbase/sync/google_sheets.go
@@ -340,7 +340,7 @@ type PersonInfo struct {
 	Grade     int
 }
 
-// safeString safely converts an interface{} to string
+// safeString safely converts any to string
 func safeString(v any) string {
 	if v == nil {
 		return ""

--- a/pocketbase/sync/staff_skills.go
+++ b/pocketbase/sync/staff_skills.go
@@ -346,13 +346,13 @@ func (s *StaffSkillsSync) loadSkillDefinitions(_ context.Context) ([]skillDefini
 
 // containsStaffPartitionFromRaw checks if partition contains "Staff".
 // PocketBase stores select fields as JSON arrays, so record.Get() returns
-// []interface{} or []string, not a comma-separated string.
+// []any, not a comma-separated string.
 func (s *StaffSkillsSync) containsStaffPartitionFromRaw(rawValue any) bool {
 	if rawValue == nil {
 		return false
 	}
 
-	// Handle as []interface{} (JSON array from record.Get())
+	// Handle as []any (JSON array from record.Get())
 	if arr, ok := rawValue.([]any); ok {
 		for _, v := range arr {
 			if str, ok := v.(string); ok && str == partitionStaff {

--- a/pocketbase/sync/workbook_manager.go
+++ b/pocketbase/sync/workbook_manager.go
@@ -468,7 +468,7 @@ func BuildIndexSheetData(workbooks []WorkbookRecord) [][]any {
 	return data
 }
 
-// safeInt safely converts an interface{} to int
+// safeInt safely converts any to int
 func safeInt(v any) int {
 	if v == nil {
 		return 0


### PR DESCRIPTION
## Summary

Batch cleanup of 6 confirmed dead-code / unused-export removals and nit fixes across frontend and Go sync. Two issues deferred (see below).

- **#1000** — drop orphaned `.faded` Cytoscape style; class never applied after ego-network removal (PR #984)
- **#1005** — drop unused `UNIT_COLORS` export from `unitMapping.ts`; no consumers after graph visual pass (PR #990)
- **#1027** — `GraphMetrics.tsx` component was already deleted; `GraphMetrics` interface in `types/graph.ts` stays (part of `GraphData` API shape). Closing with comment instead of deleting.
- **#1072** — remove duplicate unreachable `[]any` branch in `normalizeToStringSlice`; update stale `interface{}` comments in `staff_skills.go`, `google_sheets.go`, `workbook_manager.go`
- **#1089** — three pre-existing CSV pipeline nits: `type→interface` for `SyncJobStatus`/`DebugPipelineRun`, defensive null-check on `status_breakdown` in `fetchLatestDebugRun`, fix singular/plural for request counts in `CsvPipelineIndicator`
- **#1116** — remove unused `sessionId` prop from `PostValidationResultsModal` and its pass-through in `ValidateBunkingButton`; remove from 14 render test call sites

## Deferred

- **#1086** — null `source_field` fallback removal requires a DB audit first (count rows with `source_field IS NULL` in `bunk_requests`). Dropping without knowing the count risks silently misclassifying any surviving legacy rows.
- **#1102** — dropping `'notes'` from the `bunk_requests.source` enum requires a PocketBase schema migration + frontend type/schema changes + data backfill. Not a one-liner.

## Test plan

- [x] `npx vitest run src/components/graph/cytoscapeStyles.test.ts` — 34 pass
- [x] `npx vitest run src/utils/unitMapping.test.ts` — 42 pass
- [x] `npx vitest run src/components/PostValidationResultsModal` — 21 pass
- [x] `npx vitest run src/services/csvPipelineStatus` — 34 pass
- [x] `cd pocketbase && go test ./sync/...` — 1994 pass
- [x] `lefthook run pre-push` — all checks pass (ruff, mypy, tsc, eslint, go-build, shellcheck)

Closes #1000
Closes #1005
Closes #1072
Closes #1089
Closes #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for parsing prefixed Nitzanim bunk names.

* **Bug Fixes**
  * Improved pluralization/formatting in completion and validation messages.
  * Validation hardened to avoid showing results from malformed pipeline data.
  * Removed previously applied visual fading for certain graph elements.
  * Modal header “(Draft)” indicator now reflects scenario presence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->