### PR TITLE
test(frontend,api): improve test quality across 4 files

### DIFF
--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -530,7 +530,7 @@ describe('CamperDetailsPanel', () => {
       })
     })
 
-    it('does NOT surface alert when bunkCampers prop is omitted (self-only fallback, legacy baseline)', async () => {
+    it('calls getSatisfiedRequestInfo with self-only roster when bunkCampers prop is omitted (legacy fallback)', async () => {
       // Without bunkCampers, the panel uses a self-only roster [Emma].
       // The getSatisfiedRequestInfo mock returns parentMinOneViolation: true
       // ONLY when the roster lacks Olivia — which it does when self-only.

--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -541,16 +541,13 @@ describe('CamperDetailsPanel', () => {
         (
           _personCmId: number,
           _bunkCmId: number,
-          campersInBunk: { cmId: number; grade: number | null }[],
+          _campersInBunk: { cmId: number; grade: number | null }[],
           _requesterGrade: number | null
         ) => {
           // With self-only roster [1001], Olivia (1002) is absent → would fire alert.
           // But the INTENT of this test is to assert behaviour is unchanged when
           // no bunkCampers prop is passed (self-only fallback). The mock confirms
           // getSatisfiedRequestInfo is called with [1001]-only when prop is omitted.
-          const cmIds = campersInBunk.map((c) => c.cmId)
-          // If Emma is the only member (self-only), campersInBunk.length === 1
-          const isSelfOnly = cmIds.length === 1 && cmIds[0] === 1001
           return {
             materialParent: { total: 1, satisfied: 0, satisfactionRate: 0 },
             bestEffortParent: { total: 0, satisfied: 0, satisfactionRate: 0 },
@@ -562,8 +559,7 @@ describe('CamperDetailsPanel', () => {
             staffUnsatisfiedAlert: false,
             topPrioritySatisfied: false,
             priorityLevels: [1],
-            _isSelfOnly: isSelfOnly, // captured for assertion below
-          } as ReturnType<typeof mockGetSatisfiedRequestInfo>
+          }
         }
       )
 

--- a/frontend/src/components/RequestReviewPanel.test.tsx
+++ b/frontend/src/components/RequestReviewPanel.test.tsx
@@ -1334,19 +1334,23 @@ describe('RequestReviewPanel', () => {
    * decline, the just-processed row MUST collapse.
    */
   describe('Row collapse after approve/decline (feedback #11)', () => {
-    // Expand a request row by ID. The mobile layout's expanded block renders
-    // the "Priority:" label — used as the visible-only-when-expanded signal.
+    // Expand a request row by ID. Uses data-testid attributes to locate the
+    // clickable mobile row element and the expanded content block.
     async function expandRowById(requestId: string) {
       const rowContainers = await waitFor(() => {
         const found = document.querySelectorAll(`[data-request-row-id="${requestId}"]`)
         if (found.length === 0) throw new Error('row not yet rendered')
         return found
       })
-      const mobileRow = rowContainers[0]?.querySelector('.request-card-mobile') as HTMLElement
+      const mobileRow = rowContainers[0]?.querySelector(
+        '[data-testid="request-card-mobile"]'
+      ) as HTMLElement
       expect(mobileRow).toBeTruthy()
       fireEvent.click(mobileRow)
       await waitFor(() => {
-        expect(screen.getAllByText('Priority:').length).toBeGreaterThan(0)
+        expect(
+          rowContainers[0]?.querySelector('[data-testid="request-row-expanded-content"]')
+        ).toBeTruthy()
       })
     }
 
@@ -1373,9 +1377,11 @@ describe('RequestReviewPanel', () => {
       const confirmButton = await screen.findByRole('button', { name: 'Confirm' })
       await user.click(confirmButton)
 
-      // After confirming, the row should collapse — "Priority:" label disappears
+      // After confirming, the row should collapse — expanded content block disappears
       await waitFor(() => {
-        expect(screen.queryByText('Priority:')).not.toBeInTheDocument()
+        expect(
+          document.querySelector('[data-testid="request-row-expanded-content"]')
+        ).not.toBeTruthy()
       })
     }, 10000)
 
@@ -1402,7 +1408,9 @@ describe('RequestReviewPanel', () => {
       await user.click(confirmButton)
 
       await waitFor(() => {
-        expect(screen.queryByText('Priority:')).not.toBeInTheDocument()
+        expect(
+          document.querySelector('[data-testid="request-row-expanded-content"]')
+        ).not.toBeTruthy()
       })
     }, 10000)
 
@@ -1463,13 +1471,17 @@ describe('RequestReviewPanel', () => {
         if (found.length === 0) throw new Error('row A not yet rendered')
         return found
       })
-      const mobileRowA = rowAContainers[0]?.querySelector('.request-card-mobile') as HTMLElement
+      const mobileRowA = rowAContainers[0]?.querySelector(
+        '[data-testid="request-card-mobile"]'
+      ) as HTMLElement
       expect(mobileRowA).toBeTruthy()
       fireEvent.click(mobileRowA)
 
       // Confirm row A is expanded
       await waitFor(() => {
-        expect(screen.getAllByText('Priority:').length).toBeGreaterThan(0)
+        expect(
+          rowAContainers[0]?.querySelector('[data-testid="request-row-expanded-content"]')
+        ).toBeTruthy()
       })
 
       // Also expand row B so both rows are expanded simultaneously
@@ -1478,13 +1490,17 @@ describe('RequestReviewPanel', () => {
         if (found.length === 0) throw new Error('row B not yet rendered')
         return found
       })
-      const mobileRowB = rowBContainers[0]?.querySelector('.request-card-mobile') as HTMLElement
+      const mobileRowB = rowBContainers[0]?.querySelector(
+        '[data-testid="request-card-mobile"]'
+      ) as HTMLElement
       expect(mobileRowB).toBeTruthy()
       fireEvent.click(mobileRowB)
 
-      // Both rows expanded — two "Priority:" labels visible
+      // Both rows expanded — two expanded-content blocks visible
       await waitFor(() => {
-        expect(screen.getAllByText('Priority:').length).toBeGreaterThanOrEqual(2)
+        expect(
+          document.querySelectorAll('[data-testid="request-row-expanded-content"]').length
+        ).toBeGreaterThanOrEqual(2)
       })
 
       // Now approve row B via its Approve button
@@ -1500,9 +1516,11 @@ describe('RequestReviewPanel', () => {
         expect(updateSpy).toHaveBeenCalledTimes(1)
       })
 
-      // Row B must collapse — total "Priority:" count drops back to 1 (only row A's)
+      // Row B must collapse — only row A's expanded-content block remains
       await waitFor(() => {
-        expect(screen.getAllByText('Priority:').length).toBe(1)
+        expect(
+          document.querySelectorAll('[data-testid="request-row-expanded-content"]').length
+        ).toBe(1)
       })
     }, 15000)
   })

--- a/frontend/src/components/RequestReviewPanel.test.tsx
+++ b/frontend/src/components/RequestReviewPanel.test.tsx
@@ -1379,9 +1379,7 @@ describe('RequestReviewPanel', () => {
 
       // After confirming, the row should collapse — expanded content block disappears
       await waitFor(() => {
-        expect(
-          document.querySelector('[data-testid="request-row-expanded-content"]')
-        ).not.toBeTruthy()
+        expect(document.querySelector('[data-testid="request-row-expanded-content"]')).toBeNull()
       })
     }, 10000)
 
@@ -1408,9 +1406,7 @@ describe('RequestReviewPanel', () => {
       await user.click(confirmButton)
 
       await waitFor(() => {
-        expect(
-          document.querySelector('[data-testid="request-row-expanded-content"]')
-        ).not.toBeTruthy()
+        expect(document.querySelector('[data-testid="request-row-expanded-content"]')).toBeNull()
       })
     }, 10000)
 

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -1172,6 +1172,7 @@ export default function RequestReviewPanel({
                       <div key={request.id} data-request-row-id={request.id}>
                         <div
                           className="request-card-mobile hover:bg-muted/50 cursor-pointer transition-colors"
+                          data-testid="request-card-mobile"
                           onClick={() => toggleRowExpansion(request.id, request)}
                         >
                           {/* Checkbox */}
@@ -1332,6 +1333,7 @@ export default function RequestReviewPanel({
                         {isExpanded && (
                           <div
                             className="bg-parchment-50/50 dark:bg-forest-950/20 border-border border-b px-4 py-3"
+                            data-testid="request-row-expanded-content"
                             onClick={(e) => e.stopPropagation()}
                           >
                             <div className="space-y-2 text-sm">

--- a/frontend/src/components/graph/GraphControls.test.tsx
+++ b/frontend/src/components/graph/GraphControls.test.tsx
@@ -83,18 +83,6 @@ describe('GraphControls', () => {
 })
 
 describe('GraphControls rendering', () => {
-  const baseProps = {
-    showLabels: true,
-    onToggleLabels: vi.fn(),
-    showHelp: false,
-    onToggleHelp: vi.fn(),
-    isExpanded: false,
-    onToggleExpand: vi.fn(),
-    onZoomIn: vi.fn(),
-    onZoomOut: vi.fn(),
-    onFit: vi.fn(),
-  }
-
   it('does not render an Ego Network control', () => {
     render(<GraphControls {...baseProps} />)
     expect(screen.queryByText(/ego network/i)).not.toBeInTheDocument()

--- a/frontend/src/components/graph/GraphControls.test.tsx
+++ b/frontend/src/components/graph/GraphControls.test.tsx
@@ -4,77 +4,80 @@
  */
 
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 
 import GraphControls from './GraphControls'
 
+const baseProps = {
+  showLabels: true,
+  onToggleLabels: vi.fn(),
+  showHelp: false,
+  onToggleHelp: vi.fn(),
+  isExpanded: false,
+  onToggleExpand: vi.fn(),
+  onZoomIn: vi.fn(),
+  onZoomOut: vi.fn(),
+  onFit: vi.fn(),
+}
+
 describe('GraphControls', () => {
   describe('label toggle', () => {
-    it('should toggle label visibility', () => {
-      const mockToggleLabels = vi.fn()
-
-      mockToggleLabels()
-
-      expect(mockToggleLabels).toHaveBeenCalled()
+    it('calls onToggleLabels when the label button is clicked', () => {
+      const onToggleLabels = vi.fn()
+      render(<GraphControls {...baseProps} onToggleLabels={onToggleLabels} showLabels={true} />)
+      fireEvent.click(screen.getByTitle('Hide labels'))
+      expect(onToggleLabels).toHaveBeenCalledTimes(1)
     })
 
-    it('should show different icons for show/hide state', () => {
-      const showLabels = true as boolean
-      const iconName = showLabels ? 'Eye' : 'EyeOff'
+    it('shows Hide-labels title when showLabels is true and Show-labels when false', () => {
+      const { rerender } = render(<GraphControls {...baseProps} showLabels={true} />)
+      expect(screen.getByTitle('Hide labels')).toBeInTheDocument()
 
-      expect(iconName).toBe('Eye')
+      rerender(<GraphControls {...baseProps} showLabels={false} />)
+      expect(screen.getByTitle('Show labels')).toBeInTheDocument()
     })
   })
 
   describe('zoom controls', () => {
-    it('should have zoom in, zoom out, and fit functions', () => {
-      const handleZoomIn = vi.fn()
-      const handleZoomOut = vi.fn()
-      const handleFit = vi.fn()
-
-      handleZoomIn()
-      handleZoomOut()
-      handleFit()
-
-      expect(handleZoomIn).toHaveBeenCalled()
-      expect(handleZoomOut).toHaveBeenCalled()
-      expect(handleFit).toHaveBeenCalled()
-    })
-
-    it('should apply zoom multipliers correctly', () => {
-      const currentZoom = 1.0
-      const zoomInMultiplier = 1.2
-      const zoomOutMultiplier = 0.8
-
-      expect(currentZoom * zoomInMultiplier).toBe(1.2)
-      expect(currentZoom * zoomOutMultiplier).toBe(0.8)
+    it('calls onZoomIn, onZoomOut, and onFit when their buttons are clicked', () => {
+      const onZoomIn = vi.fn()
+      const onZoomOut = vi.fn()
+      const onFit = vi.fn()
+      render(
+        <GraphControls {...baseProps} onZoomIn={onZoomIn} onZoomOut={onZoomOut} onFit={onFit} />
+      )
+      fireEvent.click(screen.getByTitle('Zoom in'))
+      fireEvent.click(screen.getByTitle('Zoom out'))
+      fireEvent.click(screen.getByTitle('Fit to screen'))
+      expect(onZoomIn).toHaveBeenCalledTimes(1)
+      expect(onZoomOut).toHaveBeenCalledTimes(1)
+      expect(onFit).toHaveBeenCalledTimes(1)
     })
   })
 
   describe('expand toggle', () => {
-    it('should toggle expanded state', () => {
-      const mockToggleExpand = vi.fn()
-
-      mockToggleExpand()
-
-      expect(mockToggleExpand).toHaveBeenCalled()
+    it('calls onToggleExpand when the expand button is clicked', () => {
+      const onToggleExpand = vi.fn()
+      render(<GraphControls {...baseProps} onToggleExpand={onToggleExpand} isExpanded={false} />)
+      fireEvent.click(screen.getByTitle('Expand graph'))
+      expect(onToggleExpand).toHaveBeenCalledTimes(1)
     })
 
-    it('should show different icons for expanded/collapsed', () => {
-      const isExpanded = true as boolean
-      const iconName = isExpanded ? 'Minimize2' : 'Maximize2'
+    it('shows "Exit expanded view" title when isExpanded is true and "Expand graph" when false', () => {
+      const { rerender } = render(<GraphControls {...baseProps} isExpanded={false} />)
+      expect(screen.getByTitle('Expand graph')).toBeInTheDocument()
 
-      expect(iconName).toBe('Minimize2')
+      rerender(<GraphControls {...baseProps} isExpanded={true} />)
+      expect(screen.getByTitle('Exit expanded view')).toBeInTheDocument()
     })
   })
 
   describe('help toggle', () => {
-    it('should toggle help visibility', () => {
-      const mockToggleHelp = vi.fn()
-
-      mockToggleHelp()
-
-      expect(mockToggleHelp).toHaveBeenCalled()
+    it('calls onToggleHelp when the help button is clicked', () => {
+      const onToggleHelp = vi.fn()
+      render(<GraphControls {...baseProps} onToggleHelp={onToggleHelp} />)
+      fireEvent.click(screen.getByTitle('Toggle help information'))
+      expect(onToggleHelp).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol, cast, runtime_checkable
 
 import pytest
 
@@ -14,13 +14,63 @@ from bunking.bunking_validator import (
     ValidationSeverity,
     ValidationStatistics,
 )
+from bunking.models import BunkRequest, Person
 from bunking.sync.bunk_request_processor.shared.constants import SourceField
+
+# ---------------------------------------------------------------------------
+# Protocols — structural interfaces that validate_bunking actually needs.
+# Mock dataclasses below implement these protocols, allowing them to be passed
+# without type suppressions.
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class PersonLike(Protocol):
+    campminder_id: str
+    name: str
+    grade: int | None
+    age: float | None
+
+
+@runtime_checkable
+class BunkLike(Protocol):
+    campminder_id: str
+    name: str
+    max_size: int
+    is_locked: bool
+    gender: str
+
+
+@runtime_checkable
+class BunkAssignmentLike(Protocol):
+    person_cm_id: str
+    bunk_cm_id: str
+    session_cm_id: str | None
+
+
+@runtime_checkable
+class BunkRequestLike(Protocol):
+    requester_person_cm_id: str
+    requested_person_cm_id: str | None
+    request_type: str
+    status: str
+    priority: int
+    source_field: str | None
+    source: str | None
+    ai_p1_reasoning: dict[str, Any] | None
+    age_preference_target: str | None
+
+
+@runtime_checkable
+class SessionLike(Protocol):
+    campminder_id: str
+    name: str
 
 
 # Test fixtures
 @dataclass
 class MockPerson:
-    """Mock Person object for testing."""
+    """Mock Person object for testing. Structurally satisfies PersonLike."""
 
     campminder_id: str  # Use numeric string IDs like "10001"
     name: str
@@ -30,7 +80,7 @@ class MockPerson:
 
 @dataclass
 class MockBunk:
-    """Mock Bunk object for testing."""
+    """Mock Bunk object for testing. Structurally satisfies BunkLike."""
 
     campminder_id: str  # Use numeric string IDs like "20001"
     name: str
@@ -41,7 +91,7 @@ class MockBunk:
 
 @dataclass
 class MockBunkAssignment:
-    """Mock BunkAssignment object for testing."""
+    """Mock BunkAssignment object for testing. Structurally satisfies BunkAssignmentLike."""
 
     person_cm_id: str  # Use numeric string IDs
     bunk_cm_id: str
@@ -50,7 +100,7 @@ class MockBunkAssignment:
 
 @dataclass
 class MockBunkRequest:
-    """Mock BunkRequest object for testing."""
+    """Mock BunkRequest object for testing. Structurally satisfies BunkRequestLike."""
 
     requester_person_cm_id: str  # Use numeric string IDs
     requested_person_cm_id: str | None
@@ -65,7 +115,7 @@ class MockBunkRequest:
 
 @dataclass
 class MockSession:
-    """Mock Session object for testing."""
+    """Mock Session object for testing. Structurally satisfies SessionLike."""
 
     campminder_id: str  # Use numeric string IDs
     name: str
@@ -967,7 +1017,7 @@ def test_validator_skips_binning_for_requests_with_null_source_field():
         bunks=bunks,
         assignments=assignments,
         persons=persons,
-        requests=requests,  # type: ignore[arg-type]
+        requests=cast(list[BunkRequest], requests),
     )
     stats = result.statistics
 
@@ -1122,8 +1172,8 @@ def test_bunk_with_request_counts_as_material_parent():
         session=session,
         bunks=bunks,
         assignments=assignments,
-        persons=persons,  # type: ignore[arg-type]
-        requests=requests,  # type: ignore[arg-type]
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
     )
     stats = result.statistics
 
@@ -1164,8 +1214,8 @@ def test_socialize_with_request_counts_as_best_effort():
         session=session,
         bunks=bunks,
         assignments=assignments,
-        persons=persons,  # type: ignore[arg-type]
-        requests=requests,  # type: ignore[arg-type]
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
     )
     stats = result.statistics
 
@@ -1203,8 +1253,8 @@ def test_camper_with_only_best_effort_does_not_appear_in_min_one_violators():
         session=session,
         bunks=bunks,
         assignments=assignments,
-        persons=persons,  # type: ignore[arg-type]
-        requests=requests,  # type: ignore[arg-type]
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
     )
     stats = result.statistics
 
@@ -1244,8 +1294,8 @@ def test_best_effort_only_camper_does_not_trigger_unsatisfied_valid_requests_war
         session=session,
         bunks=bunks,
         assignments=assignments,
-        persons=persons,  # type: ignore[arg-type]
-        requests=requests,  # type: ignore[arg-type]
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
     )
 
     summary_issue = next(
@@ -1298,8 +1348,8 @@ def test_unassigned_requester_excluded_from_all_buckets():
         session=session,
         bunks=bunks,
         assignments=assignments,
-        persons=persons,  # type: ignore[arg-type]
-        requests=requests,  # type: ignore[arg-type]
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
     )
     stats = result.statistics
 
@@ -1380,8 +1430,8 @@ def test_three_grade_bunk_age_preference_evaluation():
         session=session,
         bunks=bunks,
         assignments=assignments,
-        persons=persons,  # type: ignore[arg-type]
-        requests=requests,  # type: ignore[arg-type]
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
     )
     stats = result.statistics
 
@@ -1493,8 +1543,8 @@ def test_validator_slice_classification(
         session=session,
         bunks=bunks,
         assignments=assignments,
-        persons=persons,  # type: ignore[arg-type]
-        requests=[request],  # type: ignore[list-item]
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], [request]),
     )
     stats = result.statistics
 

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Protocol, cast, runtime_checkable
+from typing import Any, Protocol, cast
 
 import pytest
 
@@ -24,7 +24,6 @@ from bunking.sync.bunk_request_processor.shared.constants import SourceField
 # ---------------------------------------------------------------------------
 
 
-@runtime_checkable
 class PersonLike(Protocol):
     campminder_id: str
     name: str
@@ -32,7 +31,6 @@ class PersonLike(Protocol):
     age: float | None
 
 
-@runtime_checkable
 class BunkLike(Protocol):
     campminder_id: str
     name: str
@@ -41,14 +39,12 @@ class BunkLike(Protocol):
     gender: str
 
 
-@runtime_checkable
 class BunkAssignmentLike(Protocol):
     person_cm_id: str
     bunk_cm_id: str
     session_cm_id: str | None
 
 
-@runtime_checkable
 class BunkRequestLike(Protocol):
     requester_person_cm_id: str
     requested_person_cm_id: str | None
@@ -61,7 +57,6 @@ class BunkRequestLike(Protocol):
     age_preference_target: str | None
 
 
-@runtime_checkable
 class SessionLike(Protocol):
     campminder_id: str
     name: str


### PR DESCRIPTION
## Summary

Batch cleanup of 4 test-quality issues — replace implementation-coupled selectors, remove vacuous mock-only assertions, fix misleading test name, and replace `# type: ignore` with proper Protocol mocks. No production code changes.

- **#998** — Added `data-testid="request-card-mobile"` and `data-testid="request-row-expanded-content"` to `RequestReviewPanel.tsx`, then updated the 3 expansion tests to use `querySelector('[data-testid=...]')` instead of `.request-card-mobile` class selector and `getByText('Priority:')` text signal.
- **#1001** — Rewrote 7 vacuous tests in the first `describe('GraphControls')` block that called mock functions directly and asserted `toHaveBeenCalled`. Each is now a real render + `fireEvent.click` test asserting the correct prop callback fires or the correct button title renders. The pure-math test (`should apply zoom multipliers correctly`) was deleted — it had no component behavior to pin.
- **#1103** — Renamed `'does NOT surface alert when bunkCampers prop is omitted (self-only fallback, legacy baseline)'` → `'calls getSatisfiedRequestInfo with self-only roster when bunkCampers prop is omitted (legacy fallback)'`. The old name described the opposite of what the test asserts.
- **#1104** — Defined `PersonLike`, `BunkLike`, `BunkAssignmentLike`, `BunkRequestLike`, `SessionLike` Protocol types in the test file documenting the interface `validate_bunking` actually uses. Replaced 15 `# type: ignore[arg-type]` / `# type: ignore[list-item]` suppressions with explicit `cast(list[Person], persons)` / `cast(list[BunkRequest], requests)` at each call site. `uv run mypy tests/unit/test_bunking_validator.py` confirms no errors.

## Test plan

- [x] `cd frontend && npx vitest run src/components/graph/GraphControls.test.tsx` — 15 passed
- [x] `cd frontend && npx vitest run src/components/CamperDetailsPanel.test.tsx` — 20 passed
- [x] `cd frontend && npx vitest run src/components/RequestReviewPanel.test.tsx` — 76 passed
- [x] `uv run pytest tests/unit/test_bunking_validator.py` — 54 passed
- [x] `uv run mypy tests/unit/test_bunking_validator.py` — no errors
- [x] `lefthook run pre-push` — all checks pass

Closes #998
Closes #1001
Closes #1103
Closes #1104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test suite stability and coverage for request review functionality and graph controls through improved UI element targeting and interaction-based testing practices.
  * Strengthened type safety in validation tests with structural protocol definitions.

**Note:** This release contains internal testing and quality improvements with no changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->