### PR TITLE
chore(frontend): batch trivial deletions and sentinel cleanup

### DIFF
--- a/frontend/src/components/ScenarioManagementModal.test.tsx
+++ b/frontend/src/components/ScenarioManagementModal.test.tsx
@@ -3,8 +3,8 @@
  * staff testing (April 2026). See ScenarioContext.test.tsx for full context.
  *
  * The modal must keep rendering the scenario cards while a delete mutation
- * is pending — only the initial query-fetch state should swap the list for
- * a "Loading scenarios..." placeholder.
+ * is pending — only the initial query-fetch (isLoading) should swap the list
+ * for a "Loading scenarios..." placeholder, not isMutating.
  */
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
@@ -47,7 +47,6 @@ function makeContext(overrides: Partial<ScenarioContextType>): ScenarioContextTy
     currentScenario: null,
     isProductionMode: true,
     scenarios,
-    loading: false,
     isLoading: false,
     isMutating: false,
     error: null,
@@ -77,18 +76,17 @@ function renderModal(ctx: ScenarioContextType) {
 describe('ScenarioManagementModal loading state', () => {
   it('shows "Loading scenarios..." during initial query fetch', () => {
     // Matches what ScenarioContext produces when the query is first loading:
-    // loading=true AND isLoading=true (scenarios list not yet fetched).
-    renderModal(makeContext({ loading: true, isLoading: true, scenarios: [] }))
+    // isLoading=true and scenarios list not yet fetched.
+    renderModal(makeContext({ isLoading: true, scenarios: [] }))
     expect(screen.getByText('Loading scenarios...')).toBeInTheDocument()
   })
 
   it('keeps scenario cards visible while a delete mutation is pending', () => {
-    // Simulates real context state mid-delete: the combined loading flag
-    // is true (because isMutating is true), but the query has already
-    // resolved (isLoading=false). Prior to the fix, the modal consumed the
-    // combined `loading` and swapped the list for the placeholder — this
-    // test asserts the fix by requiring the cards to remain visible.
-    renderModal(makeContext({ loading: true, isLoading: false, isMutating: true }))
+    // Simulates real context state mid-delete: the query has already resolved
+    // (isLoading=false) but a mutation is pending (isMutating=true). The modal
+    // uses isLoading (not isMutating) to show the placeholder, so cards remain
+    // visible while the delete processes.
+    renderModal(makeContext({ isLoading: false, isMutating: true }))
 
     expect(screen.getByText('Dorm Cabin Plan A')).toBeInTheDocument()
     expect(screen.queryByText('Loading scenarios...')).not.toBeInTheDocument()

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -52,8 +52,10 @@ export default function SessionView() {
     scenarios,
     loadScenarios,
     selectScenario,
-    loading: scenarioLoading,
+    isLoading: scenarioIsLoading,
+    isMutating: scenarioIsMutating,
   } = useScenario()
+  const scenarioLoading = scenarioIsLoading || scenarioIsMutating
   const { setSessionPbId: setLockGroupSessionPbId } = useLockGroupContext()
   const { hasPermission } = usePermissions()
   const canManage = hasPermission(Permission.BUNKING_MANAGE)

--- a/frontend/src/contexts/ScenarioContext.tsx
+++ b/frontend/src/contexts/ScenarioContext.tsx
@@ -55,12 +55,6 @@ export const ScenarioProvider: FC<ScenarioProviderProps> = ({ children }) => {
     deleteScenarioMutation.isPending ||
     clearScenarioMutation.isPending
 
-  // Combined loading state (initial fetch OR mutation pending). Kept for
-  // backward compatibility with any consumer that just needs a unified
-  // "busy" signal. Consumers that drive empty-state/placeholder UI should
-  // read `isLoading` instead.
-  const loading = isLoading || isMutating
-
   // Load scenarios for a session
   const loadScenarios = useCallback(async (sessionId: number) => {
     setCurrentSessionId(sessionId)
@@ -238,7 +232,6 @@ export const ScenarioProvider: FC<ScenarioProviderProps> = ({ children }) => {
     currentScenario,
     isProductionMode,
     scenarios,
-    loading,
     isLoading,
     isMutating,
     error,

--- a/frontend/src/hooks/useScenario.ts
+++ b/frontend/src/hooks/useScenario.ts
@@ -21,10 +21,8 @@ export interface ScenarioContextType {
   // `isLoading` reflects the initial React Query fetch — use this for
   // empty/placeholder UI. `isMutating` reflects any in-flight mutation
   // (create/update/delete/clear) — don't use it to hide list content, since
-  // doing so causes the list to "vanish" mid-mutation. `loading` is the
-  // combined flag, retained for existing consumers that only care that
-  // *something* is happening.
-  loading: boolean
+  // doing so causes the list to "vanish" mid-mutation. Callers that need a
+  // combined busy signal can derive it locally: `isLoading || isMutating`.
   isLoading: boolean
   isMutating: boolean
   error: string | null

--- a/frontend/src/pages/ScenarioComparisonPage.test.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.test.tsx
@@ -6,6 +6,7 @@ import {
   CamperPill,
   ValidationScoreCard,
   getExportButtonLabel,
+  getExportButtonTitle,
   type ValidationResult,
   type ValidationStatistics,
 } from './ScenarioComparisonPage'
@@ -295,22 +296,24 @@ describe('ValidationScoreCard parent-paramount stats', () => {
   })
 })
 
-// ─── #1003: Export button label should reflect the active changeFilter ───────
+// ─── #1003: Export button label/title should reflect the active changeFilter ──
 
 describe('getExportButtonLabel', () => {
   it('returns "Export Moved" when changeFilter is "moved"', () => {
     expect(getExportButtonLabel('moved')).toBe('Export Moved')
   })
 
-  it('returns "Export All Changes" when changeFilter is "all"', () => {
-    expect(getExportButtonLabel('all')).toBe('Export All Changes')
+  it('returns "Export All" when changeFilter is "all"', () => {
+    expect(getExportButtonLabel('all')).toBe('Export All')
+  })
+})
+
+describe('getExportButtonTitle', () => {
+  it('returns moved tooltip when changeFilter is "moved"', () => {
+    expect(getExportButtonTitle('moved')).toBe('Export moved campers to CSV')
   })
 
-  it('returns "Export Newly Assigned" when changeFilter is "newly-assigned"', () => {
-    expect(getExportButtonLabel('newly-assigned')).toBe('Export Newly Assigned')
-  })
-
-  it('returns "Export Newly Unassigned" when changeFilter is "newly-unassigned"', () => {
-    expect(getExportButtonLabel('newly-unassigned')).toBe('Export Newly Unassigned')
+  it('returns all tooltip when changeFilter is "all"', () => {
+    expect(getExportButtonTitle('all')).toBe('Export all campers to CSV')
   })
 })

--- a/frontend/src/pages/ScenarioComparisonPage.test.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.test.tsx
@@ -5,6 +5,7 @@ import { afterEach } from 'vitest'
 import {
   CamperPill,
   ValidationScoreCard,
+  getExportButtonLabel,
   type ValidationResult,
   type ValidationStatistics,
 } from './ScenarioComparisonPage'
@@ -291,5 +292,25 @@ describe('ValidationScoreCard parent-paramount stats', () => {
     const beScope = within(beSection)
     expect(beScope.getByText('63%')).toBeInTheDocument()
     expect(beScope.getByText('(5/8)')).toBeInTheDocument()
+  })
+})
+
+// ─── #1003: Export button label should reflect the active changeFilter ───────
+
+describe('getExportButtonLabel', () => {
+  it('returns "Export Moved" when changeFilter is "moved"', () => {
+    expect(getExportButtonLabel('moved')).toBe('Export Moved')
+  })
+
+  it('returns "Export All Changes" when changeFilter is "all"', () => {
+    expect(getExportButtonLabel('all')).toBe('Export All Changes')
+  })
+
+  it('returns "Export Newly Assigned" when changeFilter is "newly-assigned"', () => {
+    expect(getExportButtonLabel('newly-assigned')).toBe('Export Newly Assigned')
+  })
+
+  it('returns "Export Newly Unassigned" when changeFilter is "newly-unassigned"', () => {
+    expect(getExportButtonLabel('newly-unassigned')).toBe('Export Newly Unassigned')
   })
 })

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -208,19 +208,18 @@ export interface ValidationResult {
 type ViewMode = 'split' | 'changes'
 type ChangeFilter = 'all' | 'moved' | 'newly-assigned' | 'newly-unassigned'
 
-/** Returns the export button label that matches the active change filter. */
+/** Returns the export button label that matches the active change filter.
+ *  Only 'moved' and 'all' are reachable — the button is not rendered for
+ *  'newly-assigned' or 'newly-unassigned'. */
 // eslint-disable-next-line react-refresh/only-export-components -- pure utility, exported for tests
-export function getExportButtonLabel(filter: ChangeFilter): string {
-  switch (filter) {
-    case 'moved':
-      return 'Export Moved'
-    case 'newly-assigned':
-      return 'Export Newly Assigned'
-    case 'newly-unassigned':
-      return 'Export Newly Unassigned'
-    default:
-      return 'Export All Changes'
-  }
+export function getExportButtonLabel(filter: 'moved' | 'all'): string {
+  return filter === 'moved' ? 'Export Moved' : 'Export All'
+}
+
+/** Returns the export button tooltip that matches the active change filter. */
+// eslint-disable-next-line react-refresh/only-export-components -- pure utility, exported for tests
+export function getExportButtonTitle(filter: 'moved' | 'all'): string {
+  return filter === 'moved' ? 'Export moved campers to CSV' : 'Export all campers to CSV'
 }
 
 function useGroupMap(
@@ -1009,10 +1008,10 @@ export default function ScenarioComparisonPage() {
                         )
                       }}
                       className="bg-muted/50 text-muted-foreground hover:bg-muted ml-auto flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-all"
-                      title="Export moved campers to CSV"
+                      title={getExportButtonTitle(changeFilter as 'moved' | 'all')}
                     >
                       <Download className="h-4 w-4" />
-                      <span>{getExportButtonLabel(changeFilter)}</span>
+                      <span>{getExportButtonLabel(changeFilter as 'moved' | 'all')}</span>
                     </button>
                   )}
               </div>

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -208,6 +208,21 @@ export interface ValidationResult {
 type ViewMode = 'split' | 'changes'
 type ChangeFilter = 'all' | 'moved' | 'newly-assigned' | 'newly-unassigned'
 
+/** Returns the export button label that matches the active change filter. */
+// eslint-disable-next-line react-refresh/only-export-components -- pure utility, exported for tests
+export function getExportButtonLabel(filter: ChangeFilter): string {
+  switch (filter) {
+    case 'moved':
+      return 'Export Moved'
+    case 'newly-assigned':
+      return 'Export Newly Assigned'
+    case 'newly-unassigned':
+      return 'Export Newly Unassigned'
+    default:
+      return 'Export All Changes'
+  }
+}
+
 function useGroupMap(
   scenarioId: string,
   sessionPbId: string,
@@ -997,7 +1012,7 @@ export default function ScenarioComparisonPage() {
                       title="Export moved campers to CSV"
                     >
                       <Download className="h-4 w-4" />
-                      <span>Export Moved</span>
+                      <span>{getExportButtonLabel(changeFilter)}</span>
                     </button>
                   )}
               </div>

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -208,9 +208,7 @@ export interface ValidationResult {
 type ViewMode = 'split' | 'changes'
 type ChangeFilter = 'all' | 'moved' | 'newly-assigned' | 'newly-unassigned'
 
-/** Returns the export button label that matches the active change filter.
- *  Only 'moved' and 'all' are reachable — the button is not rendered for
- *  'newly-assigned' or 'newly-unassigned'. */
+/** Returns the export button label that matches the active change filter. */
 // eslint-disable-next-line react-refresh/only-export-components -- pure utility, exported for tests
 export function getExportButtonLabel(filter: 'moved' | 'all'): string {
   return filter === 'moved' ? 'Export Moved' : 'Export All'


### PR DESCRIPTION
## Summary

Batch cleanup of 5 frontend issues. Three were already resolved on main before this PR landed; this PR implements the remaining two plus updates tests.

- **#981** — Remove unreachable legacy key branch in `GraphCacheService.getBunkGraph` — **already resolved on main** (year is now a required parameter, no else branch)
- **#1002** — Remove combined `loading` flag from `ScenarioContext`; migrate sole consumer (`SessionView`) to derive `isLoading || isMutating` locally
- **#1003** — Fix "Export Moved" button label when `changeFilter === 'all'` — extracts `getExportButtonLabel()` helper so the label reflects the active filter
- **#1004** — Extract shared `buildRequesteeUpdate` helper — **already resolved on main** (`computeTargetUpdate` in `requestEditableHelpers.ts` is used by both `AllCamperRequestsModal` and `RequestReviewPanel` via `RequestEditableHeader`)
- **#1011** — Replace empty-object sentinel in `useSyncStatusAPI` with `null` — **already resolved on main** (hook already returns `null` on 401, tests already verify this)

## Test plan

- [x] `cd frontend && npx vitest run` — 3562 tests, 0 failures
- [x] `cd frontend && npx tsc --noEmit` — no errors
- [x] `lefthook run pre-push` — all checks pass (ruff, shellcheck, pb-js-lint, go-build, mypy, tsc)

Closes #981
Closes #1002
Closes #1003
Closes #1004
Closes #1011