### PR TITLE
fix(frontend): batch four small bugs (Firefox download, status demote, stale resolution, missing provider)

### DIFF
--- a/frontend/src/components/RequestEditableHeader.test.tsx
+++ b/frontend/src/components/RequestEditableHeader.test.tsx
@@ -66,24 +66,30 @@ function renderHeader(
 }
 
 describe('computeTypeUpdate', () => {
-  it('switching to age_preference clears requestee_id', () => {
+  it('switching to age_preference clears requestee_id and resets resolution state', () => {
     expect(computeTypeUpdate('age_preference')).toEqual({
       request_type: 'age_preference',
       requestee_id: null,
+      status: 'pending',
+      confidence_score: 0,
     })
   })
 
-  it('switching to bunk_with clears age_preference_target', () => {
+  it('switching to bunk_with clears age_preference_target and resets resolution state', () => {
     expect(computeTypeUpdate('bunk_with')).toEqual({
       request_type: 'bunk_with',
       age_preference_target: '',
+      status: 'pending',
+      confidence_score: 0,
     })
   })
 
-  it('switching to not_bunk_with clears age_preference_target', () => {
+  it('switching to not_bunk_with clears age_preference_target and resets resolution state', () => {
     expect(computeTypeUpdate('not_bunk_with')).toEqual({
       request_type: 'not_bunk_with',
       age_preference_target: '',
+      status: 'pending',
+      confidence_score: 0,
     })
   })
 })
@@ -97,9 +103,11 @@ describe('computeTargetUpdate', () => {
     })
   })
 
-  it('clearing requestee_id (null) does not set status/confidence', () => {
+  it('clearing requestee_id (null) resets status to pending and confidence to 0 (#997)', () => {
     expect(computeTargetUpdate({ requestee_id: null })).toEqual({
       requestee_id: null,
+      status: 'pending',
+      confidence_score: 0,
     })
   })
 
@@ -148,6 +156,8 @@ describe('RequestEditableHeader rendering', () => {
     expect(onUpdate).toHaveBeenCalledWith({
       request_type: 'age_preference',
       requestee_id: null,
+      status: 'pending',
+      confidence_score: 0,
     })
   })
 

--- a/frontend/src/components/RequestReviewPanel.test.tsx
+++ b/frontend/src/components/RequestReviewPanel.test.tsx
@@ -921,7 +921,7 @@ describe('RequestReviewPanel', () => {
       // BUG FIX: requestee_id must be null, not 0, when changing to age_preference
       // Setting requestee_id = 0 causes a unique constraint violation (400 error)
       const updates: Partial<BunkRequestsResponse> = {
-        request_type: 'age_preference' as BunkRequestsResponse['request_type'],
+        request_type: 'age_preference',
       }
       const newType: string = 'age_preference'
       if (newType === 'age_preference') {
@@ -935,7 +935,7 @@ describe('RequestReviewPanel', () => {
 
     it('includes age_preference_target: "" when switching to bunk_with', () => {
       const updates: Partial<BunkRequestsResponse> = {
-        request_type: 'bunk_with' as BunkRequestsResponse['request_type'],
+        request_type: 'bunk_with',
       }
       const newType: string = 'bunk_with'
       if (newType === 'age_preference') {
@@ -1211,7 +1211,7 @@ describe('RequestReviewPanel', () => {
         // The bug: requestee_id = 0 caused unique constraint violation (400 error)
         // The fix: requestee_id = null clears the field properly
         const updates: Partial<BunkRequestsResponse> = {
-          request_type: 'age_preference' as BunkRequestsResponse['request_type'],
+          request_type: 'age_preference',
         }
 
         // CORRECT: use null
@@ -1711,9 +1711,9 @@ describe('RequestReviewPanel', () => {
       )
 
       // Click Reject → Confirm
-      const rejectButton = (await waitFor(() => screen.getAllByTitle('Reject')[0]!, {
+      const rejectButton = await waitFor(() => screen.getAllByTitle('Reject')[0]!, {
         timeout: 3000,
-      })) as HTMLElement
+      })
       fireEvent.click(rejectButton)
       const confirmButton = await screen.findByRole('button', { name: 'Confirm' })
       await user.click(confirmButton)
@@ -1851,10 +1851,10 @@ describe('RequestReviewPanel', () => {
       // Simpler: use toggleRequestSelection by clicking checkboxes one at
       // a time and waiting for selectedRequests.size to grow (proxied by
       // the sticky toolbar's "{N} selected" text).
-      const allCheckboxes = screen.getAllByRole('checkbox') as HTMLInputElement[]
+      const allCheckboxes = screen.getAllByRole('checkbox')
       // Click checkboxes until we reach 2 selected (skipping select-all toggles).
       for (const cb of allCheckboxes) {
-        if (cb.checked) continue
+        if ((cb as HTMLInputElement).checked) continue
         fireEvent.click(cb)
         const toolbar = screen.queryByRole('toolbar', { name: /bulk actions/i })
         if (toolbar && within(toolbar).queryByText(/^2 selected$/)) break
@@ -1961,5 +1961,54 @@ describe('RequestReviewPanel', () => {
         { timeout: 3000 }
       )
     }, 15000)
+  })
+
+  // #1092 — RequestReviewPanel in SessionView.tsx Requests tab must be wrapped in BunkRequestProvider
+  describe('BunkRequestProvider requirement in SessionView (#1092)', () => {
+    /**
+     * When a camper name is clicked in RequestReviewPanel (rendered from the Requests tab),
+     * it mounts CamperDetailsPanel which calls useBunkRequestContext() unconditionally.
+     * Without BunkRequestProvider above it in the tree, this throws:
+     *   "useBunkRequestContext must be used within BunkRequestProvider"
+     *
+     * Regression guard: verify that SessionView.tsx wraps the Requests-tab
+     * RequestReviewPanel in BunkRequestProvider — the same pattern used in
+     * the Bunks tab and Friends tab.
+     */
+    it('SessionView Requests tab wraps RequestReviewPanel in BunkRequestProvider', () => {
+      const sessionViewSource = readFileSync(resolve(__dirname, 'SessionView.tsx'), 'utf-8')
+
+      // Find the Requests tab Activity block and assert BunkRequestProvider wraps it.
+      // The Friends tab (correct) looks like:
+      //   <Activity mode={activeTab === 'friends' ? 'visible' : 'hidden'}>
+      //     <BunkRequestProvider sessionCmId={...}>
+      //       <FriendGroupsView .../>
+      //     </BunkRequestProvider>
+      //   </Activity>
+      //
+      // The Requests tab (broken) only has:
+      //   <Activity mode={activeTab === 'requests' ? 'visible' : 'hidden'}>
+      //     <RequestReviewPanel .../>
+      //   </Activity>
+      //
+      // We verify that within the requests-tab Activity, BunkRequestProvider appears
+      // before RequestReviewPanel (i.e., BunkRequestProvider wraps it).
+
+      // Extract the requests tab block: from "requests tab" comment to the closing </Activity>
+      const requestsTabMatch = sessionViewSource.match(
+        /Requests Tab[\s\S]*?<Activity mode=\{activeTab === 'requests'[\s\S]*?<\/Activity>/
+      )
+      expect(requestsTabMatch).not.toBeNull()
+
+      const requestsTabBlock = requestsTabMatch![0]
+
+      // BunkRequestProvider must appear in the requests tab block
+      expect(requestsTabBlock).toContain('BunkRequestProvider')
+
+      // BunkRequestProvider must appear BEFORE RequestReviewPanel (wraps it)
+      const providerPos = requestsTabBlock.indexOf('BunkRequestProvider')
+      const panelPos = requestsTabBlock.indexOf('RequestReviewPanel')
+      expect(providerPos).toBeLessThan(panelPos)
+    })
   })
 })

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -248,6 +248,8 @@ export default function SessionView() {
     return <div>Session not found</div>
   }
 
+  const selectedSessionCmId = parseInt(selectedSession ?? '', 10)
+
   return (
     <div>
       {/* Header */}
@@ -342,14 +344,14 @@ export default function SessionView() {
         {/* Requests Tab - only mounted for canManage users; non-manage users are redirected away */}
         {canManage && (
           <Activity mode={activeTab === 'requests' ? 'visible' : 'hidden'}>
-            {selectedSession && !isNaN(parseInt(selectedSession, 10)) ? (
+            {selectedSession && !isNaN(selectedSessionCmId) ? (
               // #1092 — BunkRequestProvider required: CamperDetailsPanel calls
               // useBunkRequestContext() unconditionally. Use selectedSession (not
               // session.cm_id) to match whichever sub-session is active, same as
               // the Friends tab pattern.
-              <BunkRequestProvider sessionCmId={parseInt(selectedSession, 10)}>
+              <BunkRequestProvider sessionCmId={selectedSessionCmId}>
                 <RequestReviewPanel
-                  sessionId={parseInt(selectedSession, 10)}
+                  sessionId={selectedSessionCmId}
                   relatedSessionIds={
                     selectedSession === session.cm_id.toString()
                       ? [...subSessions.map((s) => s.cm_id), ...agSessions.map((s) => s.cm_id)]
@@ -357,8 +359,7 @@ export default function SessionView() {
                   }
                   year={currentYear}
                   sessionName={
-                    allSessionsForLookup.find((s) => s.cm_id === parseInt(selectedSession, 10))
-                      ?.name
+                    allSessionsForLookup.find((s) => s.cm_id === selectedSessionCmId)?.name
                   }
                 />
               </BunkRequestProvider>
@@ -370,9 +371,9 @@ export default function SessionView() {
 
         {/* Friends Tab - preserves group selection state */}
         <Activity mode={activeTab === 'friends' ? 'visible' : 'hidden'}>
-          {selectedSession && !isNaN(parseInt(selectedSession, 10)) ? (
-            <BunkRequestProvider sessionCmId={parseInt(selectedSession, 10)}>
-              <FriendGroupsView sessionCmId={parseInt(selectedSession, 10)} />
+          {selectedSession && !isNaN(selectedSessionCmId) ? (
+            <BunkRequestProvider sessionCmId={selectedSessionCmId}>
+              <FriendGroupsView sessionCmId={selectedSessionCmId} />
             </BunkRequestProvider>
           ) : (
             <div className="text-muted-foreground text-center">Loading session data...</div>

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -343,18 +343,25 @@ export default function SessionView() {
         {canManage && (
           <Activity mode={activeTab === 'requests' ? 'visible' : 'hidden'}>
             {selectedSession && !isNaN(parseInt(selectedSession, 10)) ? (
-              <RequestReviewPanel
-                sessionId={parseInt(selectedSession, 10)}
-                relatedSessionIds={
-                  selectedSession === session.cm_id.toString()
-                    ? [...subSessions.map((s) => s.cm_id), ...agSessions.map((s) => s.cm_id)]
-                    : []
-                }
-                year={currentYear}
-                sessionName={
-                  allSessionsForLookup.find((s) => s.cm_id === parseInt(selectedSession, 10))?.name
-                }
-              />
+              // #1092 — BunkRequestProvider required: CamperDetailsPanel calls
+              // useBunkRequestContext() unconditionally. Use selectedSession (not
+              // session.cm_id) to match whichever sub-session is active, same as
+              // the Friends tab pattern.
+              <BunkRequestProvider sessionCmId={parseInt(selectedSession, 10)}>
+                <RequestReviewPanel
+                  sessionId={parseInt(selectedSession, 10)}
+                  relatedSessionIds={
+                    selectedSession === session.cm_id.toString()
+                      ? [...subSessions.map((s) => s.cm_id), ...agSessions.map((s) => s.cm_id)]
+                      : []
+                  }
+                  year={currentYear}
+                  sessionName={
+                    allSessionsForLookup.find((s) => s.cm_id === parseInt(selectedSession, 10))
+                      ?.name
+                  }
+                />
+              </BunkRequestProvider>
             ) : (
               <div className="text-muted-foreground text-center">Loading session data...</div>
             )}

--- a/frontend/src/components/metrics/DrillDownModal.test.tsx
+++ b/frontend/src/components/metrics/DrillDownModal.test.tsx
@@ -275,4 +275,45 @@ describe('DrillDownModal', () => {
       expect(screen.queryByText('DNR')).not.toBeInTheDocument()
     })
   })
+
+  // #996 — Firefox download: anchor must be appended to DOM before click()
+  describe('CSV download — Firefox DOM attachment (#996)', () => {
+    it('appends anchor to document.body before click when Download CSV is clicked', () => {
+      // Provide at least one attendee so the Download CSV button is not disabled
+      mockAttendees = [
+        {
+          person_id: 101,
+          first_name: 'Emma',
+          last_name: 'Johnson',
+          grade: 6,
+          gender: 'F',
+          session_name: 'Session 1',
+          session_cm_id: 1001,
+          status: 'enrolled',
+        } as DrilldownAttendee,
+      ]
+
+      vi.stubGlobal('URL', {
+        createObjectURL: vi.fn(() => 'blob:mock'),
+        revokeObjectURL: vi.fn(),
+      })
+      // Track <a> elements appended to document.body during the download click
+      const appendedAnchorCount = { value: 0 }
+      const originalAppendChild = document.body.appendChild.bind(document.body)
+      vi.spyOn(document.body, 'appendChild').mockImplementation((node) => {
+        if ((node as HTMLElement).tagName === 'A') {
+          appendedAnchorCount.value++
+        }
+        return originalAppendChild(node)
+      })
+
+      renderWithClient(<DrillDownModal {...defaultProps} />)
+
+      const downloadBtn = screen.getByRole('button', { name: /download csv/i })
+      expect(downloadBtn).not.toBeDisabled()
+      fireEvent.click(downloadBtn)
+
+      expect(appendedAnchorCount.value).toBeGreaterThan(0)
+    })
+  })
 })

--- a/frontend/src/components/metrics/DrillDownModal.test.tsx
+++ b/frontend/src/components/metrics/DrillDownModal.test.tsx
@@ -276,10 +276,12 @@ describe('DrillDownModal', () => {
     })
   })
 
-  // #996 — Firefox download: anchor must be appended to DOM before click()
-  describe('CSV download — Firefox DOM attachment (#996)', () => {
-    it('appends anchor to document.body before click when Download CSV is clicked', () => {
-      // Provide at least one attendee so the Download CSV button is not disabled
+  // #996 — Firefox download: DOM attachment is tested in csvExport.test.ts
+  // (downloadCsv unit tests cover the appendChild-before-click contract).
+  // Here we verify that clicking Download CSV calls through to the shared utility
+  // (i.e. the button is enabled and clickable when attendees are present).
+  describe('CSV download button', () => {
+    it('Download CSV button is enabled when attendees are present', () => {
       mockAttendees = [
         {
           person_id: 101,
@@ -293,27 +295,10 @@ describe('DrillDownModal', () => {
         } as DrilldownAttendee,
       ]
 
-      vi.stubGlobal('URL', {
-        createObjectURL: vi.fn(() => 'blob:mock'),
-        revokeObjectURL: vi.fn(),
-      })
-      // Track <a> elements appended to document.body during the download click
-      const appendedAnchorCount = { value: 0 }
-      const originalAppendChild = document.body.appendChild.bind(document.body)
-      vi.spyOn(document.body, 'appendChild').mockImplementation((node) => {
-        if ((node as HTMLElement).tagName === 'A') {
-          appendedAnchorCount.value++
-        }
-        return originalAppendChild(node)
-      })
-
       renderWithClient(<DrillDownModal {...defaultProps} />)
 
       const downloadBtn = screen.getByRole('button', { name: /download csv/i })
       expect(downloadBtn).not.toBeDisabled()
-      fireEvent.click(downloadBtn)
-
-      expect(appendedAnchorCount.value).toBeGreaterThan(0)
     })
   })
 })

--- a/frontend/src/components/metrics/DrillDownModal.tsx
+++ b/frontend/src/components/metrics/DrillDownModal.tsx
@@ -14,6 +14,7 @@ import { X, Download, Search, ArrowUpDown, Loader2 } from 'lucide-react'
 import { SortIcon } from './SortIcon'
 import { useDrilldownAttendees } from '../../hooks/useDrilldownAttendees'
 import { shortenSessionName } from '../../utils/sessionDisplay'
+import { buildCsvContent, downloadCsv as triggerCsvDownload } from '../../utils/csvExport'
 import type { DrilldownAttendee, DrilldownFilter } from '../../types/metrics'
 
 /** Get display session name: comma-joined if multi-session, fallback to single session_name. */
@@ -358,22 +359,10 @@ export function DrillDownModal({
               ]
     )
 
-    const csv = [headers, ...rows]
-      .map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(','))
-      .join('\n')
-
-    const blob = new Blob([csv], { type: 'text/csv' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `${filter?.label.replace(/\s+/g, '_')}_${new Date().toISOString().split('T')[0]}.csv`
-    a.style.display = 'none'
-    // Firefox requires the anchor to be attached to the DOM before click()
-    // triggers a file download. Chrome/Safari work without it, masking this bug.
-    document.body.appendChild(a)
-    a.click()
-    document.body.removeChild(a)
-    URL.revokeObjectURL(url)
+    const stringRows = rows.map((row) => row.map((cell) => String(cell)))
+    const csv = buildCsvContent(headers, stringRows)
+    const filename = `${filter?.label.replace(/\s+/g, '_')}_${new Date().toISOString().split('T')[0]}.csv`
+    triggerCsvDownload(csv, filename)
   }
 
   if (!filter) return null

--- a/frontend/src/components/metrics/DrillDownModal.tsx
+++ b/frontend/src/components/metrics/DrillDownModal.tsx
@@ -367,7 +367,12 @@ export function DrillDownModal({
     const a = document.createElement('a')
     a.href = url
     a.download = `${filter?.label.replace(/\s+/g, '_')}_${new Date().toISOString().split('T')[0]}.csv`
+    a.style.display = 'none'
+    // Firefox requires the anchor to be attached to the DOM before click()
+    // triggers a file download. Chrome/Safari work without it, masking this bug.
+    document.body.appendChild(a)
     a.click()
+    document.body.removeChild(a)
     URL.revokeObjectURL(url)
   }
 

--- a/frontend/src/components/requestEditableHelpers.test.ts
+++ b/frontend/src/components/requestEditableHelpers.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for requestEditableHelpers — TDD tests written before fixes.
+ */
+import { describe, it, expect } from 'vitest'
+import { computeTypeUpdate, computeTargetUpdate } from './requestEditableHelpers'
+
+// ---------------------------------------------------------------------------
+// computeTypeUpdate
+// ---------------------------------------------------------------------------
+describe('computeTypeUpdate', () => {
+  it('sets request_type to age_preference', () => {
+    const result = computeTypeUpdate('age_preference')
+    expect(result.request_type).toBe('age_preference')
+  })
+
+  it('clears requestee_id to null when switching to age_preference', () => {
+    const result = computeTypeUpdate('age_preference')
+    expect(result.requestee_id).toBeNull()
+  })
+
+  it('clears age_preference_target when switching to bunk_with', () => {
+    const result = computeTypeUpdate('bunk_with')
+    expect(result.age_preference_target).toBe('')
+  })
+
+  // #1028 — switching type must reset stale resolution state
+  it('resets status to pending when switching to age_preference (#1028)', () => {
+    const result = computeTypeUpdate('age_preference')
+    expect(result.status).toBe('pending')
+  })
+
+  it('resets confidence_score to 0 when switching to age_preference (#1028)', () => {
+    const result = computeTypeUpdate('age_preference')
+    expect(result.confidence_score).toBe(0)
+  })
+
+  it('resets status to pending when switching to bunk_with (#1028)', () => {
+    const result = computeTypeUpdate('bunk_with')
+    expect(result.status).toBe('pending')
+  })
+
+  it('resets confidence_score to 0 when switching to bunk_with (#1028)', () => {
+    const result = computeTypeUpdate('bunk_with')
+    expect(result.confidence_score).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeTargetUpdate
+// ---------------------------------------------------------------------------
+describe('computeTargetUpdate', () => {
+  it('sets requestee_id when provided', () => {
+    const result = computeTargetUpdate({ requestee_id: 42 })
+    expect(result.requestee_id).toBe(42)
+  })
+
+  it('sets status=resolved and confidence=1.0 when requestee_id > 0', () => {
+    const result = computeTargetUpdate({ requestee_id: 42 })
+    expect(result.status).toBe('resolved')
+    expect(result.confidence_score).toBe(1.0)
+  })
+
+  it('sets age_preference_target when provided', () => {
+    const result = computeTargetUpdate({ age_preference_target: 'older' })
+    expect(result.age_preference_target).toBe('older')
+  })
+
+  // #997 — clearing requestee_id must demote to pending
+  it('resets status to pending when requestee_id is cleared to null (#997)', () => {
+    const result = computeTargetUpdate({ requestee_id: null })
+    expect(result.status).toBe('pending')
+  })
+
+  it('resets confidence_score to 0 when requestee_id is cleared to null (#997)', () => {
+    const result = computeTargetUpdate({ requestee_id: null })
+    expect(result.confidence_score).toBe(0)
+  })
+
+  it('resets status to pending when requestee_id is cleared to 0 (#997)', () => {
+    const result = computeTargetUpdate({ requestee_id: 0 })
+    expect(result.status).toBe('pending')
+  })
+
+  it('resets confidence_score to 0 when requestee_id is cleared to 0 (#997)', () => {
+    const result = computeTargetUpdate({ requestee_id: 0 })
+    expect(result.confidence_score).toBe(0)
+  })
+})

--- a/frontend/src/components/requestEditableHelpers.ts
+++ b/frontend/src/components/requestEditableHelpers.ts
@@ -1,4 +1,4 @@
-import type { BunkRequestsResponse, BunkRequestsStatusOptions } from '../types/pocketbase-types'
+import type { BunkRequestsResponse } from '../types/pocketbase-types'
 
 export function computeTypeUpdate(
   newType: BunkRequestsResponse['request_type']
@@ -10,6 +10,10 @@ export function computeTypeUpdate(
   } else {
     updates.age_preference_target = ''
   }
+  // #1028 — switching type invalidates prior resolution; the resolved state is now
+  // stale because the target field has been cleared. Reset to pending so staff review.
+  updates.status = 'pending'
+  updates.confidence_score = 0
   return updates
 }
 
@@ -25,8 +29,12 @@ export function computeTargetUpdate(updates: {
     pbUpdates.age_preference_target = updates.age_preference_target
   }
   if (updates.requestee_id && updates.requestee_id > 0) {
-    pbUpdates.status = 'resolved' as BunkRequestsStatusOptions
+    pbUpdates.status = 'resolved'
     pbUpdates.confidence_score = 1.0
+  } else if (updates.requestee_id !== undefined && !updates.requestee_id) {
+    // #997 — clearing requestee_id (null or 0) must demote back to pending
+    pbUpdates.status = 'pending'
+    pbUpdates.confidence_score = 0
   }
   return pbUpdates
 }

--- a/frontend/src/utils/csvExport.test.ts
+++ b/frontend/src/utils/csvExport.test.ts
@@ -140,32 +140,33 @@ describe('downloadCsv', () => {
     })
   })
 
-  it('creates an anchor element and triggers click', () => {
-    const clickSpy = vi.fn()
+  /** Helper: returns a mock anchor + stubs body.appendChild/removeChild to accept it */
+  function makeMockAnchor(clickImpl?: () => void) {
     const mockAnchor = {
       href: '',
       download: '',
-      click: clickSpy,
+      style: { display: '' },
+      click: vi.fn(clickImpl),
     }
+    vi.spyOn(document.body, 'appendChild').mockReturnValue(mockAnchor as unknown as Node)
+    vi.spyOn(document.body, 'removeChild').mockReturnValue(mockAnchor as unknown as Node)
     vi.spyOn(document, 'createElement').mockReturnValueOnce(
       mockAnchor as unknown as HTMLAnchorElement
     )
+    return mockAnchor
+  }
+
+  it('creates an anchor element and triggers click', () => {
+    const mockAnchor = makeMockAnchor()
 
     downloadCsv('test content', 'test-file.csv')
 
-    expect(clickSpy).toHaveBeenCalledOnce()
+    expect(mockAnchor.click).toHaveBeenCalledOnce()
     expect(mockAnchor.download).toBe('test-file.csv')
   })
 
   it('revokes the object URL after triggering download', () => {
-    const mockAnchor = {
-      href: '',
-      download: '',
-      click: vi.fn(),
-    }
-    vi.spyOn(document, 'createElement').mockReturnValueOnce(
-      mockAnchor as unknown as HTMLAnchorElement
-    )
+    makeMockAnchor()
 
     downloadCsv('test content', 'test-file.csv')
 
@@ -174,13 +175,44 @@ describe('downloadCsv', () => {
 
   it('uses text/csv MIME type', () => {
     const blobSpy = vi.spyOn(globalThis, 'Blob')
-    const mockAnchor = { href: '', download: '', click: vi.fn() }
-    vi.spyOn(document, 'createElement').mockReturnValueOnce(
-      mockAnchor as unknown as HTMLAnchorElement
-    )
+    makeMockAnchor()
 
     downloadCsv('a,b', 'file.csv')
 
     expect(blobSpy).toHaveBeenCalledWith(['a,b'], { type: 'text/csv;charset=utf-8;' })
+  })
+
+  // #996 — Firefox requires anchor to be in the DOM before click()
+  it('appends anchor to document.body before click (Firefox compatibility)', () => {
+    const callOrder: string[] = []
+    const mockAnchor = {
+      href: '',
+      download: '',
+      style: { display: '' },
+      click: vi.fn(() => callOrder.push('click')),
+    }
+    const appendChildSpy = vi
+      .spyOn(document.body, 'appendChild')
+      .mockImplementation((node: Node) => {
+        callOrder.push('appendChild')
+        return node
+      })
+    const removeChildSpy = vi
+      .spyOn(document.body, 'removeChild')
+      .mockImplementation((node: Node) => {
+        callOrder.push('removeChild')
+        return node
+      })
+    vi.spyOn(document, 'createElement').mockReturnValueOnce(
+      mockAnchor as unknown as HTMLAnchorElement
+    )
+
+    downloadCsv('test', 'file.csv')
+
+    // appendChild must happen before click, removeChild after
+    expect(appendChildSpy).toHaveBeenCalledWith(mockAnchor)
+    expect(removeChildSpy).toHaveBeenCalledWith(mockAnchor)
+    expect(callOrder.indexOf('appendChild')).toBeLessThan(callOrder.indexOf('click'))
+    expect(callOrder.indexOf('click')).toBeLessThan(callOrder.indexOf('removeChild'))
   })
 })

--- a/frontend/src/utils/csvExport.ts
+++ b/frontend/src/utils/csvExport.ts
@@ -51,7 +51,12 @@ export function downloadCsv(csvContent: string, filename: string): void {
   const a = document.createElement('a')
   a.href = url
   a.download = filename
+  a.style.display = 'none'
+  // Firefox requires the anchor to be attached to the DOM before click()
+  // triggers a file download. Chrome/Safari work without it, masking this bug.
+  document.body.appendChild(a)
   a.click()
+  document.body.removeChild(a)
   URL.revokeObjectURL(url)
 }
 


### PR DESCRIPTION
## Summary

Batch fix of 4 small frontend bugs — Firefox download compatibility, status-demotion on cleared requestee, stale resolution state on request-type change, and missing provider wrapper in RequestReviewPanel.

- **#996** — `downloadCsv` in `csvExport.ts` and the inline download in `DrillDownModal.tsx` now append the anchor to `document.body` before `click()` and remove it after. Firefox requires DOM attachment to trigger a file download; Chrome/Safari work without it, masking the bug.
- **#997** — `computeTargetUpdate` in `requestEditableHelpers.ts` now resets `status→pending` / `confidence_score→0` when `requestee_id` is cleared (null or 0). Previously the request stayed resolved with no target.
- **#1028** — `computeTypeUpdate` now resets `status→pending` / `confidence_score→0` whenever the request type is changed. Switching type clears the target field, making any prior resolved state stale.
- **#1092** — The Requests tab in `SessionView.tsx` now wraps `<RequestReviewPanel>` in `<BunkRequestProvider>`. `CamperDetailsPanel` calls `useBunkRequestContext()` unconditionally; without a provider above it the sidebar crashed. Matches the pattern already used by the Bunks and Friends tabs.

Also fixes a pre-existing TypeScript error: `.checked` access on `HTMLElement` in the bulk-select loop of `RequestReviewPanel.test.tsx` (cast to `HTMLInputElement`).

## Test plan

- [ ] `cd frontend && npx vitest run src/utils/csvExport.test.ts src/components/metrics/DrillDownModal.test.tsx src/components/requestEditableHelpers.test.ts src/components/RequestReviewPanel.test.tsx` — all 132 tests pass
- [ ] `cd frontend && npx tsc --noEmit` — no errors
- [ ] `lefthook run pre-push` — all checks pass

Closes #996
Closes #997
Closes #1028
Closes #1092