### PR TITLE
refactor(frontend): adopt QueryGuard for ScenarioComparisonPage validation fetch

### DIFF
--- a/frontend/src/pages/ScenarioComparisonPage.test.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.test.tsx
@@ -410,3 +410,37 @@ describe('ValidationScoreCard — no longer shows Loading placeholder', () => {
     expect(screen.queryByText('Loading validation...')).toBeNull()
   })
 })
+
+// ─── Asymmetric data: left resolves, right is null ────────────────────────────
+
+describe('ValidationSection — asymmetric data (left valid, right null)', () => {
+  it('shows Validation Details heading and "Not available" placeholder for the right card', () => {
+    const stats = makeStats({
+      material_parent_requests: 5,
+      satisfied_material_parent_requests: 5,
+      material_parent_request_satisfaction_rate: 1.0,
+    })
+    const leftValidation = makeValidation(stats)
+
+    render(
+      <ValidationSection
+        isLoading={false}
+        error={null}
+        leftValidation={leftValidation}
+        rightValidation={null}
+        leftScenarioName="Left"
+        rightScenarioName="Right"
+      />
+    )
+
+    // Success branch must be entered (heading visible)
+    expect(screen.getByText('Validation Details')).toBeInTheDocument()
+
+    // Right card should show "Not available" placeholder, not "Loading validation..."
+    expect(screen.getByText('Not available')).toBeInTheDocument()
+    expect(screen.queryByText('Loading validation...')).toBeNull()
+
+    // Left scenario name should be visible
+    expect(screen.getByText('Left')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/ScenarioComparisonPage.test.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.test.tsx
@@ -5,6 +5,7 @@ import { afterEach } from 'vitest'
 import {
   CamperPill,
   ValidationScoreCard,
+  ValidationSection,
   getExportButtonLabel,
   getExportButtonTitle,
   type ValidationResult,
@@ -315,5 +316,97 @@ describe('getExportButtonTitle', () => {
 
   it('returns all tooltip when changeFilter is "all"', () => {
     expect(getExportButtonTitle('all')).toBe('Export all campers to CSV')
+  })
+})
+
+// ─── Issue #1083 + #1064: ValidationSection QueryGuard four-state coverage ───
+
+describe('ValidationSection — QueryGuard four states', () => {
+  const leftStats = makeStats({
+    material_parent_requests: 10,
+    satisfied_material_parent_requests: 8,
+    material_parent_request_satisfaction_rate: 0.8,
+  })
+  const leftValidation = makeValidation(leftStats)
+
+  it('loading state: renders loading spinner, not score cards', () => {
+    render(
+      <ValidationSection
+        isLoading={true}
+        error={null}
+        leftValidation={undefined}
+        rightValidation={undefined}
+        leftScenarioName="Before"
+        rightScenarioName="After"
+      />
+    )
+    // QueryGuard loading renders a spinner; score cards must not appear
+    expect(screen.queryByText('Loading validation...')).toBeNull()
+    expect(screen.queryByText('Validation Details')).toBeNull()
+    // Loading indicator must be present (spinner text or aria)
+    expect(document.querySelector('.animate-spin')).not.toBeNull()
+  })
+
+  it('error state: renders error message, not score cards', () => {
+    const error = new Error('Network error')
+    render(
+      <ValidationSection
+        isLoading={false}
+        error={error}
+        leftValidation={undefined}
+        rightValidation={undefined}
+        leftScenarioName="Before"
+        rightScenarioName="After"
+      />
+    )
+    expect(screen.queryByText('Loading validation...')).toBeNull()
+    expect(screen.queryByText('Validation Details')).toBeNull()
+    expect(screen.getByText(/Failed to load/i)).toBeInTheDocument()
+  })
+
+  it('empty state: renders empty message when both validations are null', () => {
+    render(
+      <ValidationSection
+        isLoading={false}
+        error={null}
+        leftValidation={null}
+        rightValidation={null}
+        leftScenarioName="Before"
+        rightScenarioName="After"
+      />
+    )
+    expect(screen.queryByText('Loading validation...')).toBeNull()
+    expect(screen.queryByText('Validation Details')).toBeNull()
+    expect(screen.getByText(/No validation data available/i)).toBeInTheDocument()
+  })
+
+  it('success state: renders Validation Details card with both score cards', () => {
+    render(
+      <ValidationSection
+        isLoading={false}
+        error={null}
+        leftValidation={leftValidation}
+        rightValidation={leftValidation}
+        leftScenarioName="Before"
+        rightScenarioName="After"
+      />
+    )
+    expect(screen.getByText('Validation Details')).toBeInTheDocument()
+    expect(screen.getByText('Before')).toBeInTheDocument()
+    expect(screen.getByText('After')).toBeInTheDocument()
+    // Score cards should show stat tiles, not "Loading validation..."
+    expect(screen.queryByText('Loading validation...')).toBeNull()
+  })
+})
+
+// ─── Issue #1064: ValidationScoreCard null guard removed ─────────────────────
+
+describe('ValidationScoreCard — no longer shows Loading placeholder', () => {
+  it('does not render "Loading validation..." text when validation is valid', () => {
+    const stats = makeStats({ material_parent_request_satisfaction_rate: 0.75 })
+    render(
+      <ValidationScoreCard label="Test Scenario" validation={makeValidation(stats)} side="left" />
+    )
+    expect(screen.queryByText('Loading validation...')).toBeNull()
   })
 })

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -1187,12 +1187,6 @@ export interface ValidationSectionProps {
   rightScenarioName: string
 }
 
-// Combined payload passed down once both queries have settled.
-interface ValidationPair {
-  left: ValidationResult | null | undefined
-  right: ValidationResult | null | undefined
-}
-
 export function ValidationSection({
   isLoading,
   error,
@@ -1201,20 +1195,15 @@ export function ValidationSection({
   leftScenarioName,
   rightScenarioName,
 }: ValidationSectionProps) {
-  const hasSomeData = leftValidation != null || rightValidation != null
-  const pair: ValidationPair | undefined = hasSomeData
-    ? { left: leftValidation, right: rightValidation }
-    : undefined
-
   return (
     <QueryGuard
       isLoading={isLoading}
       error={error}
-      data={pair}
+      data={leftValidation ?? rightValidation}
       label="validation"
       emptyMessage="No validation data available"
     >
-      {({ left, right }) => (
+      {() => (
         <div className="card-lodge mb-6 overflow-hidden">
           {/* Tinted header band — matches SolverProgressModal pattern */}
           <div className="border-border bg-forest-50 dark:bg-forest-900/20 flex items-center gap-2 border-b px-4 py-3">
@@ -1225,9 +1214,13 @@ export function ValidationSection({
           </div>
           <div className="bg-muted/20 grid grid-cols-1 gap-4 p-4 md:grid-cols-2">
             {/* Left Scenario Score */}
-            <ValidationScoreCard label={leftScenarioName} validation={left} side="left" />
+            <ValidationScoreCard label={leftScenarioName} validation={leftValidation} side="left" />
             {/* Right Scenario Score */}
-            <ValidationScoreCard label={rightScenarioName} validation={right} side="right" />
+            <ValidationScoreCard
+              label={rightScenarioName}
+              validation={rightValidation}
+              side="right"
+            />
           </div>
         </div>
       )}
@@ -1249,12 +1242,7 @@ export function ValidationScoreCard({ label, validation, side }: ValidationScore
   // a neutral placeholder within the already-visible success card.
   if (!validation) {
     return (
-      <div
-        className={clsx(
-          'rounded-xl border-2 border-dashed p-4',
-          side === 'left' ? 'border-muted' : 'border-muted'
-        )}
-      >
+      <div className="border-muted rounded-xl border-2 border-dashed p-4">
         <div className="text-muted-foreground mb-2 truncate text-sm font-medium">{label}</div>
         <div className="text-muted-foreground/60 text-sm">Not available</div>
       </div>

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -385,9 +385,9 @@ export default function ScenarioComparisonPage() {
     data: leftValidation,
     isLoading: isLeftValidationLoading,
     error: leftValidationError,
-  } = useQuery<ValidationResult | null>({
+  } = useQuery<ValidationResult>({
     queryKey: queryKeys.scenarioValidation(leftScenarioId, sessionCmId, currentYear),
-    queryFn: async (): Promise<ValidationResult | null> => {
+    queryFn: async (): Promise<ValidationResult> => {
       const scenarioId = leftScenarioId === 'production' ? undefined : leftScenarioId
       const result = await solverService.validateBunking(
         sessionCmId.toString(),
@@ -405,9 +405,9 @@ export default function ScenarioComparisonPage() {
     data: rightValidation,
     isLoading: isRightValidationLoading,
     error: rightValidationError,
-  } = useQuery<ValidationResult | null>({
+  } = useQuery<ValidationResult>({
     queryKey: queryKeys.scenarioValidation(rightScenarioId, sessionCmId, currentYear),
-    queryFn: async (): Promise<ValidationResult | null> => {
+    queryFn: async (): Promise<ValidationResult> => {
       const scenarioId = rightScenarioId === 'production' ? undefined : rightScenarioId
       const result = await solverService.validateBunking(
         sessionCmId.toString(),

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -51,6 +51,7 @@ import {
   type LockGroupSummary,
 } from '../utils/scenarioComparisonUtils'
 import { solverService } from '../services/solver'
+import { QueryGuard } from '../components/QueryGuard'
 import type { Session } from '../types/app-types'
 import { buildCsvContent, downloadCsv, slugify, todayIso } from '../utils/csvExport'
 import { buildMovedRows, MOVED_CSV_HEADERS } from '../utils/csvExportHelpers'
@@ -380,45 +381,48 @@ export default function ScenarioComparisonPage() {
   const isReady =
     Boolean(leftScenarioId) && Boolean(rightScenarioId) && leftScenarioId !== rightScenarioId
 
-  const { data: leftValidation } = useQuery<ValidationResult | null>({
-    queryKey: ['validation', leftScenarioId, sessionCmId, currentYear],
+  const {
+    data: leftValidation,
+    isLoading: isLeftValidationLoading,
+    error: leftValidationError,
+  } = useQuery<ValidationResult | null>({
+    queryKey: queryKeys.scenarioValidation(leftScenarioId, sessionCmId, currentYear),
     queryFn: async (): Promise<ValidationResult | null> => {
-      try {
-        const scenarioId = leftScenarioId === 'production' ? undefined : leftScenarioId
-        const result = await solverService.validateBunking(
-          sessionCmId.toString(),
-          currentYear,
-          scenarioId,
-          fetchWithAuth
-        )
-        return result as unknown as ValidationResult
-      } catch {
-        return null
-      }
+      const scenarioId = leftScenarioId === 'production' ? undefined : leftScenarioId
+      const result = await solverService.validateBunking(
+        sessionCmId.toString(),
+        currentYear,
+        scenarioId,
+        fetchWithAuth
+      )
+      return result as unknown as ValidationResult
     },
     ...userDataOptions,
     enabled: Boolean(user) && sessionCmId > 0 && isReady,
   })
 
-  const { data: rightValidation } = useQuery<ValidationResult | null>({
-    queryKey: ['validation', rightScenarioId, sessionCmId, currentYear],
+  const {
+    data: rightValidation,
+    isLoading: isRightValidationLoading,
+    error: rightValidationError,
+  } = useQuery<ValidationResult | null>({
+    queryKey: queryKeys.scenarioValidation(rightScenarioId, sessionCmId, currentYear),
     queryFn: async (): Promise<ValidationResult | null> => {
-      try {
-        const scenarioId = rightScenarioId === 'production' ? undefined : rightScenarioId
-        const result = await solverService.validateBunking(
-          sessionCmId.toString(),
-          currentYear,
-          scenarioId,
-          fetchWithAuth
-        )
-        return result as unknown as ValidationResult
-      } catch {
-        return null
-      }
+      const scenarioId = rightScenarioId === 'production' ? undefined : rightScenarioId
+      const result = await solverService.validateBunking(
+        sessionCmId.toString(),
+        currentYear,
+        scenarioId,
+        fetchWithAuth
+      )
+      return result as unknown as ValidationResult
     },
     ...userDataOptions,
     enabled: Boolean(user) && sessionCmId > 0 && isReady,
   })
+
+  const isValidationLoading = isLeftValidationLoading || isRightValidationLoading
+  const validationError = leftValidationError ?? rightValidationError ?? null
 
   // Type for expanded assignment
   interface ExpandedAssignment {
@@ -859,31 +863,14 @@ export default function ScenarioComparisonPage() {
         ) : (
           <>
             {/* Validation Score Comparison - Detailed breakdown */}
-            {(leftValidation ?? rightValidation) && (
-              <div className="card-lodge mb-6 overflow-hidden">
-                {/* Tinted header band — matches SolverProgressModal pattern */}
-                <div className="border-border bg-forest-50 dark:bg-forest-900/20 flex items-center gap-2 border-b px-4 py-3">
-                  <CheckCircle2 className="text-forest-600 dark:text-forest-400 h-5 w-5" />
-                  <h3 className="text-forest-900 dark:text-forest-100 font-semibold">
-                    Validation Details
-                  </h3>
-                </div>
-                <div className="bg-muted/20 grid grid-cols-1 gap-4 p-4 md:grid-cols-2">
-                  {/* Left Scenario Score */}
-                  <ValidationScoreCard
-                    label={leftScenarioName}
-                    validation={leftValidation}
-                    side="left"
-                  />
-                  {/* Right Scenario Score */}
-                  <ValidationScoreCard
-                    label={rightScenarioName}
-                    validation={rightValidation}
-                    side="right"
-                  />
-                </div>
-              </div>
-            )}
+            <ValidationSection
+              isLoading={isValidationLoading}
+              error={validationError}
+              leftValidation={leftValidation}
+              rightValidation={rightValidation}
+              leftScenarioName={leftScenarioName}
+              rightScenarioName={rightScenarioName}
+            />
 
             {/* Metrics Summary */}
             <div className="mb-6 grid grid-cols-2 gap-4 md:grid-cols-4">
@@ -1187,6 +1174,67 @@ function StatBlockMuted({
   )
 }
 
+// ValidationSection — QueryGuard boundary for validation score comparison.
+// Handles loading / error / empty / success states so that ValidationScoreCard
+// only needs to render the success case.
+
+export interface ValidationSectionProps {
+  isLoading: boolean
+  error: Error | null
+  leftValidation: ValidationResult | null | undefined
+  rightValidation: ValidationResult | null | undefined
+  leftScenarioName: string
+  rightScenarioName: string
+}
+
+// Combined payload passed down once both queries have settled.
+interface ValidationPair {
+  left: ValidationResult | null | undefined
+  right: ValidationResult | null | undefined
+}
+
+export function ValidationSection({
+  isLoading,
+  error,
+  leftValidation,
+  rightValidation,
+  leftScenarioName,
+  rightScenarioName,
+}: ValidationSectionProps) {
+  const hasSomeData = leftValidation != null || rightValidation != null
+  const pair: ValidationPair | undefined = hasSomeData
+    ? { left: leftValidation, right: rightValidation }
+    : undefined
+
+  return (
+    <QueryGuard
+      isLoading={isLoading}
+      error={error}
+      data={pair}
+      label="validation"
+      emptyMessage="No validation data available"
+    >
+      {({ left, right }) => (
+        <div className="card-lodge mb-6 overflow-hidden">
+          {/* Tinted header band — matches SolverProgressModal pattern */}
+          <div className="border-border bg-forest-50 dark:bg-forest-900/20 flex items-center gap-2 border-b px-4 py-3">
+            <CheckCircle2 className="text-forest-600 dark:text-forest-400 h-5 w-5" />
+            <h3 className="text-forest-900 dark:text-forest-100 font-semibold">
+              Validation Details
+            </h3>
+          </div>
+          <div className="bg-muted/20 grid grid-cols-1 gap-4 p-4 md:grid-cols-2">
+            {/* Left Scenario Score */}
+            <ValidationScoreCard label={leftScenarioName} validation={left} side="left" />
+            {/* Right Scenario Score */}
+            <ValidationScoreCard label={rightScenarioName} validation={right} side="right" />
+          </div>
+        </div>
+      )}
+    </QueryGuard>
+  )
+}
+
 // Validation Score Card Component - detailed validation stats
 export interface ValidationScoreCardProps {
   label: string
@@ -1195,6 +1243,10 @@ export interface ValidationScoreCardProps {
 }
 
 export function ValidationScoreCard({ label, validation, side }: ValidationScoreCardProps) {
+  // Note: loading / error / empty states are handled by the parent ValidationSection
+  // (QueryGuard boundary). This component only renders in the success path.
+  // null/undefined validation means the individual side has no data yet — render
+  // a neutral placeholder within the already-visible success card.
   if (!validation) {
     return (
       <div
@@ -1204,7 +1256,7 @@ export function ValidationScoreCard({ label, validation, side }: ValidationScore
         )}
       >
         <div className="text-muted-foreground mb-2 truncate text-sm font-medium">{label}</div>
-        <div className="text-muted-foreground/60 text-sm">Loading validation...</div>
+        <div className="text-muted-foreground/60 text-sm">Not available</div>
       </div>
     )
   }

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -58,6 +58,10 @@ export const queryKeys = {
   // Solver/movement status derived from bunk requests (no parameters — global flag).
   bunkRequestStatus: () => ['bunk-request-status'] as const,
 
+  // Scenario Validation (Tier 2 - user data, computed from solver)
+  scenarioValidation: (scenarioId: string, sessionCmId: number, year: number) =>
+    ['scenario-validation', scenarioId, sessionCmId, year] as const,
+
   // Locked Groups (Tier 2 - user data)
   lockedGroups: (scenarioId: string, sessionId: string, year: number) =>
     ['locked-groups', scenarioId, sessionId, year] as const,


### PR DESCRIPTION
## Summary

- **Block 1 (Issue #1083)**: Replaced the inline `{(leftValidation ?? rightValidation) && ...}` conditional with a new `<ValidationSection>` component. The outer guard was invisible during loading and silently absent on errors (queries swallowed errors via `catch → return null`). `ValidationSection` uses `<QueryGuard>` to properly surface all four states.
- **Block 2 (Issue #1064)**: `ValidationScoreCard` previously showed "Loading validation..." for every non-success state (loading, error, empty). The parent `ValidationSection` now owns the loading/error/empty states via `QueryGuard`; `ValidationScoreCard` only renders in the success path, with a minimal "Not available" placeholder when a single side has no data.

## UX deviations

- Error state: previously rendered nothing (errors were swallowed). Now renders an inline error card (`Failed to load validation data: ...`) via QueryGuard — consistent with all other QueryGuard usages in the codebase.
- Loading state: previously invisible. Now shows the QueryGuard spinner.
- Empty state (both sides `null`): previously invisible. Now shows "No validation data available".
- "Loading validation..." placeholder inside `ValidationScoreCard` replaced with "Not available" (only seen when one side resolves while the other is still pending within a success state).

## Changes

- `frontend/src/utils/queryKeys.ts`: Added `scenarioValidation` factory; the two inline `['validation', ...]` keys now use it.
- `frontend/src/pages/ScenarioComparisonPage.tsx`: Removed `try/catch` from validation `queryFn`s so errors propagate to React Query; exposed `isLoading`/`error` from both queries; added `ValidationSection` export; removed `if (!validation)` "Loading..." guard from `ValidationScoreCard`.

## Tests added

Four vitest cases in `ScenarioComparisonPage.test.tsx`:
- `ValidationSection` loading state: spinner present, score cards absent
- `ValidationSection` error state: error message present, score cards absent
- `ValidationSection` empty state: "No validation data available" shown
- `ValidationSection` success state: "Validation Details" card + both scenario names render
- Regression: `ValidationScoreCard` does not show "Loading validation..." text

Closes #1083
Closes #1064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed "Loading validation..." placeholder incorrectly appearing when validation data was available on the Scenario Comparison page.
  * Improved error handling and display for validation queries.

* **Tests**
  * Added test coverage for validation section component across loading, error, and success states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->