### PR TITLE
docs(sync): annotate batch-size constraints

### DIFF
--- a/pocketbase/sync/camper_history.go
+++ b/pocketbase/sync/camper_history.go
@@ -10,7 +10,10 @@ import (
 	"github.com/pocketbase/pocketbase/core"
 )
 
-// personBatchSize is the number of persons to process per batch for lookups
+// personBatchSize is the number of persons per PocketBase filter-string batch.
+// Bounded by SQLite filter-string length (each cm_id concatenates into a
+// `field = X || ...` filter). Distinct from the 500-size CampMinder API batches
+// in households.go / persons.go.
 const personBatchSize = 100
 
 // serviceNameCamperHistory is the canonical name for this sync service

--- a/pocketbase/sync/households.go
+++ b/pocketbase/sync/households.go
@@ -100,7 +100,10 @@ func (s *HouseholdsSync) Sync(ctx context.Context) error {
 	// Track unique households across all batches
 	allHouseholds := make(map[int]map[string]any)
 
-	// Process persons in batches to extract households
+	// Process persons in batches to extract households.
+	// batchSize bounds CampMinder GetPersons API calls — CM enforces a request
+	// size limit, so keep at 500. Different from the smaller PocketBase filter
+	// batches used elsewhere in this package.
 	const batchSize = 500
 	processed := 0
 	for batch := range slices.Chunk(personIDs, batchSize) {

--- a/pocketbase/sync/persons.go
+++ b/pocketbase/sync/persons.go
@@ -280,6 +280,9 @@ func (s *PersonsSync) processPersonBatches(
 		personHouseholdMap:    make(map[int]personHouseholdIDs),
 	}
 
+	// batchSize bounds CampMinder GetPersons API calls — CM enforces a request
+	// size limit, so keep at 500. Different from the smaller PocketBase filter
+	// batches used elsewhere in this package.
 	const batchSize = 500
 	processed := 0
 	for batch := range slices.Chunk(personIDs, batchSize) {

--- a/pocketbase/sync/session_resolver.go
+++ b/pocketbase/sync/session_resolver.go
@@ -184,7 +184,11 @@ func (r *SessionResolver) GetHouseholdIDsForSession(session string, year int) ([
 
 	// Query persons to get their household IDs
 	householdIDSet := make(map[int]bool)
-	// Process in batches to avoid long queries
+	// Process in batches to avoid long queries.
+	// batchSize bounds PocketBase filter-string length — each ID concatenates
+	// into an `id = X || ...` filter, so keep small to avoid SQLite filter
+	// overflow. More conservative than the 100 used in staff_skills.go; reduce
+	// further if filter-overflow errors appear in logs.
 	const batchSize = 50
 	for batch := range slices.Chunk(personPBIDs, batchSize) {
 		// Build ID filter

--- a/pocketbase/sync/staff_skills.go
+++ b/pocketbase/sync/staff_skills.go
@@ -537,7 +537,10 @@ func (s *StaffSkillsSync) loadStaffDemographics(
 		ids = append(ids, cmID)
 	}
 
-	// Process in batches
+	// Process in batches.
+	// batchSize bounds PocketBase filter-string length — each ID concatenates
+	// into a `cm_id = X || ...` filter, so keep small to avoid SQLite filter
+	// overflow. Distinct from the larger CampMinder API batches (500).
 	const batchSize = 100
 	for batch := range slices.Chunk(ids, batchSize) {
 		select {


### PR DESCRIPTION
## Summary

Document why batch sizes differ across sync services without changing values.

- **500-size CampMinder API batches** (persons, households): bounded by CM's request-size limit
- **100/50-size PocketBase batches** (staff_skills, camper_history, session_resolver): bounded by SQLite filter-string length

Prevents future maintainers from accidentally conflating the two constraints.

## Verification

- gofmt: passed
- go build ./...: passed
- golangci-lint: no issues

Closes #1079

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>