### PR TITLE
fix(graph): use Maximize icon for Fit-to-screen, not Maximize2

### DIFF
--- a/frontend/src/components/graph/GraphControls.test.tsx
+++ b/frontend/src/components/graph/GraphControls.test.tsx
@@ -172,4 +172,21 @@ describe('GraphControls rendering', () => {
       expect(screen.queryByRole('menuitem', { name: /fit to graph/i })).not.toBeInTheDocument()
     })
   })
+
+  describe('icon disambiguation (#1026)', () => {
+    it('"Fit to screen" and "Expand graph" buttons use visually distinct icons (different SVG paths)', () => {
+      render(<GraphControls {...baseProps} isExpanded={false} />)
+      const fitBtn = screen.getByTitle('Fit to screen')
+      const expandBtn = screen.getByTitle('Expand graph')
+
+      // Each button should contain exactly one SVG icon
+      const fitSvg = fitBtn.querySelector('svg')
+      const expandSvg = expandBtn.querySelector('svg')
+      expect(fitSvg).not.toBeNull()
+      expect(expandSvg).not.toBeNull()
+
+      // The two SVGs must not be identical — if they are, the icons are ambiguous
+      expect(fitSvg!.innerHTML).not.toBe(expandSvg!.innerHTML)
+    })
+  })
 })

--- a/frontend/src/components/graph/GraphControls.tsx
+++ b/frontend/src/components/graph/GraphControls.tsx
@@ -10,6 +10,7 @@ import {
   EyeOff,
   ZoomIn,
   ZoomOut,
+  Maximize,
   Maximize2,
   Minimize2,
   HelpCircle,
@@ -102,7 +103,7 @@ export default function GraphControls({
           className="hover:bg-muted border-border flex min-h-[44px] min-w-[44px] touch-manipulation items-center justify-center border-x p-2.5 transition-colors sm:p-2"
           title="Fit to screen"
         >
-          <Maximize2 className="h-5 w-5 sm:h-4 sm:w-4" />
+          <Maximize className="h-5 w-5 sm:h-4 sm:w-4" />
         </button>
         <button
           onClick={onZoomIn}


### PR DESCRIPTION
## Summary

Both "Fit to screen" (`cy.fit`) and "Expand graph" (full-screen toggle) used the `Maximize2` icon, making them visually identical when the graph is in its default collapsed state. Tooltips already disambiguated them in text, but the icon collision was unnecessarily confusing.

**Changes:**
- Change "Fit to screen" button icon from `Maximize2` to `Maximize` (the standard single-rectangle maximize icon)
- "Expand graph" retains `Maximize2` (diagonal double-arrow) / `Minimize2` pair since those better convey the two-state full-screen toggle

**Rationale:** `Maximize` reads as "fill the container" (frame-to-content); `Maximize2` reads as "push outward to full-screen" (content-to-viewport) — the distinction maps naturally to the two actions.

**Tests added** (`frontend/src/components/graph/GraphControls.test.tsx`):
- "Fit to screen" and "Expand graph" buttons render distinct SVG icons (icon disambiguation regression test)

Closes #1026

## Test plan
- [ ] `cd frontend && npx vitest run src/components/graph/GraphControls.test.tsx` — all tests pass
- [ ] CI passes