### PR TITLE
fix(api): map PocketBase ClientResponseError status codes to HTTP response

### DIFF
--- a/api/routers/solver.py
+++ b/api/routers/solver.py
@@ -24,8 +24,6 @@ from uuid import uuid4
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from pocketbase.client import ClientResponseError  # type: ignore[attr-defined]
 
-from ..utils.pb_error import pb_error_to_http
-
 from bunking.auth_middleware import AuthUser
 from bunking.config import ConfigLoader
 from bunking.logging_config import get_logger
@@ -51,6 +49,7 @@ from ..schemas import (
 )
 from ..services.session_context import build_session_context
 from ..services.solver_runner import run_solver_task_v2
+from ..utils.pb_error import pb_error_to_http
 from ..utils.session_metrics import get_session_from_expand
 
 logger = get_logger(__name__)

--- a/api/routers/solver.py
+++ b/api/routers/solver.py
@@ -24,6 +24,8 @@ from uuid import uuid4
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from pocketbase.client import ClientResponseError  # type: ignore[attr-defined]
 
+from ..utils.pb_error import pb_error_to_http
+
 from bunking.auth_middleware import AuthUser
 from bunking.config import ConfigLoader
 from bunking.logging_config import get_logger
@@ -448,7 +450,7 @@ async def pre_validate_solver(
         raise
     except ClientResponseError as e:
         logger.error(f"PocketBase API error in pre-validation: {e.status} - {e.data}", exc_info=True)
-        raise
+        raise pb_error_to_http(e)
     except Exception:
         logger.error("Pre-validation failed", exc_info=True)
         raise

--- a/api/utils/pb_error.py
+++ b/api/utils/pb_error.py
@@ -1,0 +1,48 @@
+"""Utility to map upstream PocketBase ClientResponseError to FastAPI HTTPException.
+
+When PocketBase returns a 4xx or 5xx, the API should propagate a meaningful
+status code rather than flattening everything to 500 via the global handler.
+
+Mapping rationale:
+- 404: record not found — pass through as 404
+- 400: bad request / validation error from PB — pass through as 400
+- 401/403: PocketBase auth/permission failure — map to 403 (client should not
+           retry with the same credentials; this is an authorization boundary)
+- 5xx: PocketBase itself is unhealthy — surface as 502 Bad Gateway (upstream error)
+
+Error detail is intentionally generic — PocketBase internal messages (field names,
+schema details, internal IDs) must not be exposed to API consumers.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException
+from pocketbase.client import ClientResponseError  # type: ignore[attr-defined]
+
+
+def pb_error_to_http(error: ClientResponseError) -> HTTPException:
+    """Convert a PocketBase ClientResponseError into a FastAPI HTTPException.
+
+    The returned exception carries a safe, generic detail string.
+    Call ``raise pb_error_to_http(e)`` instead of ``raise e`` in
+    ``except ClientResponseError`` handlers that proxy PocketBase calls.
+
+    Args:
+        error: The ClientResponseError raised by the pocketbase library.
+
+    Returns:
+        HTTPException with an appropriate status code and generic detail.
+    """
+    status = error.status
+
+    if status == 404:
+        return HTTPException(status_code=404, detail="Resource not found")
+    if status == 400:
+        return HTTPException(status_code=400, detail="Invalid request")
+    if status in (401, 403):
+        return HTTPException(status_code=403, detail="Forbidden")
+    # Any PocketBase 5xx → 502 Bad Gateway (upstream failure, not our fault)
+    if status >= 500:
+        return HTTPException(status_code=502, detail="Upstream service error")
+    # Fallback for unexpected statuses
+    return HTTPException(status_code=502, detail="Upstream service error")

--- a/tests/unit/api/routers/test_http_exception_500_str_e.py
+++ b/tests/unit/api/routers/test_http_exception_500_str_e.py
@@ -515,7 +515,13 @@ def _make_client_response_error(
 
 
 class TestPreValidateSolverClientResponseErrorNoLeak:
-    """pre_validate_solver ClientResponseError branch must not surface PocketBase details to client."""
+    """pre_validate_solver ClientResponseError branch must not surface PocketBase details to client.
+
+    After #1121, ClientResponseError.status is mapped to an appropriate HTTPException
+    rather than re-raised as-is (which would fall through to the global 500 handler).
+    The important invariant — no PocketBase-internal details in the response body —
+    is still enforced.
+    """
 
     @pytest.fixture
     def client(self) -> Generator[TestClient]:
@@ -532,17 +538,19 @@ class TestPreValidateSolverClientResponseErrorNoLeak:
         ):
             yield TestClient(app, raise_server_exceptions=False)
 
-    def test_status_is_500_not_pb_status(self, client: TestClient) -> None:
+    def test_status_is_mapped_not_500(self, client: TestClient) -> None:
+        # After #1121 a 404 from PocketBase maps to 404 at the API boundary.
         resp = client.post("/api/solver/pre-validate", json={"session_cm_id": 1001, "year": 2025})
-        assert resp.status_code == 500, f"Expected 500 from global handler, got {resp.status_code}"
+        assert resp.status_code == 404, (
+            f"Expected 404 when PocketBase returned 404 (status mapped via pb_error_to_http), got {resp.status_code}"
+        )
 
-    def test_detail_is_generic_not_pb_data(self, client: TestClient) -> None:
+    def test_detail_does_not_leak_pb_data(self, client: TestClient) -> None:
         resp = client.post("/api/solver/pre-validate", json={"session_cm_id": 1001, "year": 2025})
         body = resp.json()
-        assert body == INTERNAL_ERROR_BODY, f"ClientResponseError branch leaked PocketBase details. Got: {body!r}"
         detail = body.get("detail", "")
-        assert "PocketBase error" not in detail
-        assert "sensitive PocketBase" not in detail
+        assert "PocketBase error" not in detail, f"ClientResponseError leaked PocketBase label. Got: {body!r}"
+        assert "sensitive PocketBase" not in detail, f"Leaked sensitive data. Got: {body!r}"
 
     def test_logger_error_called_with_exc_info(self) -> None:
         from api.routers.solver import router

--- a/tests/unit/api/test_pb_error_to_http.py
+++ b/tests/unit/api/test_pb_error_to_http.py
@@ -1,0 +1,156 @@
+"""#1121 — pb_error_to_http maps upstream PocketBase ClientResponseError status codes.
+
+When PocketBase returns a 404 or 400, the API should propagate a matching
+HTTP status, not flatten everything to 500. The existing global exception
+handler was intentionally left catching ClientResponseError (see PR #1119),
+but the status-code mapping was out of scope then.
+
+This module tests:
+  1. The pb_error_to_http() helper itself (unit).
+  2. An integration smoke test verifying that pre_validate_solver returns 404
+     when PocketBase returns 404 on the session lookup.
+
+The current behaviour (before the fix) is 500 for all ClientResponseError
+statuses because the global handler catches the re-raised exception.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+test_dir = Path(__file__).resolve().parent
+project_root = test_dir.parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from bunking.auth_middleware import AuthUser, get_current_user
+from bunking.rbac.permissions import ALL_PERMISSIONS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_admin_user() -> AuthUser:
+    user = AuthUser(
+        username="TestAdmin",
+        email="test@example.com",
+        display_name="Test Admin",
+        groups=["admin"],
+        is_admin=True,
+    )
+    user.permissions = set(ALL_PERMISSIONS)
+    return user
+
+
+def _make_client_response_error(status: int = 404, data: Any = "not found") -> Any:
+    from pocketbase.client import ClientResponseError  # type: ignore[attr-defined]
+
+    return ClientResponseError(url="http://pb/test", status=status, data={"message": data})
+
+
+def _make_app_with_global_handler(router: Any) -> FastAPI:
+    """Create a minimal FastAPI app that mirrors main.py's global exception handler."""
+    from fastapi import Request
+
+    app = FastAPI()
+
+    @app.exception_handler(Exception)
+    async def _unhandled(request: Request, exc: Exception) -> JSONResponse:
+        return JSONResponse(status_code=500, content={"detail": "Internal server error"})
+
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = _mock_admin_user
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: pb_error_to_http() helper
+# ---------------------------------------------------------------------------
+
+
+class TestPbErrorToHttp:
+    """Unit tests for api.utils.pb_error.pb_error_to_http()."""
+
+    def _call(self, status: int) -> Any:
+        from api.utils.pb_error import pb_error_to_http
+
+        return pb_error_to_http(_make_client_response_error(status))
+
+    def test_404_maps_to_404(self) -> None:
+        exc = self._call(404)
+        assert exc.status_code == 404
+
+    def test_400_maps_to_400(self) -> None:
+        exc = self._call(400)
+        assert exc.status_code == 400
+
+    def test_401_maps_to_403(self) -> None:
+        # 401 from PocketBase → 403 (auth failure, caller shouldn't retry with same creds)
+        exc = self._call(401)
+        assert exc.status_code == 403
+
+    def test_403_maps_to_403(self) -> None:
+        exc = self._call(403)
+        assert exc.status_code == 403
+
+    def test_500_maps_to_502(self) -> None:
+        exc = self._call(500)
+        assert exc.status_code == 502
+
+    def test_503_maps_to_502(self) -> None:
+        exc = self._call(503)
+        assert exc.status_code == 502
+
+    def test_detail_does_not_leak_pb_internals(self) -> None:
+        from api.utils.pb_error import pb_error_to_http
+
+        err = _make_client_response_error(404, data="sensitive PocketBase info")
+        exc = pb_error_to_http(err)
+        # Detail must be a generic string, not the raw PocketBase error payload
+        assert "sensitive" not in str(exc.detail).lower()
+        assert "PocketBase" not in str(exc.detail)
+
+
+# ---------------------------------------------------------------------------
+# Integration smoke: pre_validate_solver maps 404 → 404
+# ---------------------------------------------------------------------------
+
+
+class TestPreValidateSolverMaps404:
+    """pre_validate_solver must return 404 when PocketBase returns 404 on session lookup."""
+
+    @pytest.fixture
+    def client(self) -> TestClient:
+        from api.routers.solver import router
+
+        pb_error = _make_client_response_error(status=404)
+        mock_pb = MagicMock()
+        app = _make_app_with_global_handler(router)
+
+        with (
+            patch("api.routers.solver.build_session_context", side_effect=pb_error),
+            patch("api.routers.solver.pb", mock_pb),
+        ):
+            yield TestClient(app, raise_server_exceptions=False)
+
+    def test_returns_404_not_500(self, client: TestClient) -> None:
+        resp = client.post("/api/solver/pre-validate", json={"session_cm_id": 1001, "year": 2025})
+        assert resp.status_code == 404, (
+            f"Expected 404 when PocketBase returned 404, got {resp.status_code}. "
+            "The ClientResponseError branch must map status codes via pb_error_to_http()."
+        )
+
+    def test_detail_is_safe(self, client: TestClient) -> None:
+        resp = client.post("/api/solver/pre-validate", json={"session_cm_id": 1001, "year": 2025})
+        body = resp.json()
+        assert "sensitive" not in str(body).lower()
+        assert "PocketBase" not in str(body)

--- a/tests/unit/api/test_pb_error_to_http.py
+++ b/tests/unit/api/test_pb_error_to_http.py
@@ -17,6 +17,7 @@ statuses because the global handler catches the re-raised exception.
 from __future__ import annotations
 
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -32,7 +33,6 @@ sys.path.insert(0, str(project_root))
 
 from bunking.auth_middleware import AuthUser, get_current_user
 from bunking.rbac.permissions import ALL_PERMISSIONS
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -129,7 +129,7 @@ class TestPreValidateSolverMaps404:
     """pre_validate_solver must return 404 when PocketBase returns 404 on session lookup."""
 
     @pytest.fixture
-    def client(self) -> TestClient:
+    def client(self) -> Iterator[TestClient]:
         from api.routers.solver import router
 
         pb_error = _make_client_response_error(status=404)


### PR DESCRIPTION
## Summary

When PocketBase returned a 404 or 400, the API surfaced a generic 500 via the global exception handler. A missing record should propagate as 404 at the API boundary, not "internal server error".

**Changes:**
- Add `api/utils/pb_error.py` with `pb_error_to_http()` helper:
  - `404` → `404 Not Found`
  - `400` → `400 Bad Request`
  - `401`/`403` → `403 Forbidden` (auth failure; client should not retry with same credentials)
  - `5xx` → `502 Bad Gateway` (upstream failure)
  - Detail strings are intentionally generic — no PocketBase internals leaked
- Apply to the `ClientResponseError` branch in `pre_validate_solver` (the exemplar route cited in the issue)
- The helper is importable for other routers to adopt incrementally

**Tests added/updated:**
- `tests/unit/api/test_pb_error_to_http.py`: unit tests for all status code mappings + detail-leak prevention; integration smoke test verifying `pre_validate_solver` returns 404 when PocketBase returns 404
- `tests/unit/api/routers/test_http_exception_500_str_e.py`: updated `TestPreValidateSolverClientResponseErrorNoLeak` to assert the new correct behaviour (404 mapped, not flattened to 500)

Closes #1121

## Test plan
- [ ] `uv run pytest tests/unit/api/test_pb_error_to_http.py tests/unit/api/routers/test_http_exception_500_str_e.py -v` — all tests pass
- [ ] CI passes