### PR TITLE
docs(config): document confidential + PKCE OIDC posture

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -90,6 +90,18 @@ OIDC_USER_URL=https://auth.provider.com/application/o/userinfo/
 OIDC_SCOPES=openid,profile,email
 ```
 
+**PKCE posture:** The OIDC client is registered as **confidential + PKCE**.
+PocketBase v0.23+ supports PKCE on OAuth2 providers via the `pkce: true` field on
+the provider config. This repo enables it in both client-registration paths:
+
+- `docker/init-entrypoint.sh` (production init container)
+- `scripts/setup/configure_pocketbase_oauth.py` (dev script run by `start_dev.sh`)
+
+The IDP (Pocket ID, Authentik, Auth0, etc.) must also enforce PKCE on the client.
+Confidential + PKCE is the recommended posture for server-side apps: the client
+secret is never exposed to the browser, and PKCE adds protection against
+authorization-code interception.
+
 ### Network & Proxy Configuration
 ```bash
 # Traefik configuration (production)


### PR DESCRIPTION
## Summary
- Documents the confidential + PKCE posture of the OIDC client in `docs/reference/configuration.md`.
- PKCE has actually been enabled in both client-registration paths (`docker/init-entrypoint.sh`, `scripts/setup/configure_pocketbase_oauth.py`) for some time — the configuration reference just didn't mention it.

## Why
Verified end-to-end in production after enforcing PKCE on the Pocket ID side: login still works, and the PocketBase admin UI confirms "Support PKCE" is checked on the OIDC provider. The posture is the recommended one for a server-side app — the client secret stays on the server, and PKCE protects against auth-code interception in the browser.

Closes #1101.

## Test plan
- [x] PKCE enforced on Pocket ID side, prod login still works
- [x] `dashboard.../_/#/collections?collection=users` settings shows "Support PKCE" checked
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)