### PR TITLE
feat(docker): rewrite OAuth2 redirect to enable /_/* IP gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,21 @@ ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
 # Example: ALLOWED_ORIGINS_REGEX=https://app\.yourdomain\.com|https://admin\.yourdomain\.com
 ALLOWED_ORIGINS_REGEX=
 
+# REQUIRED. Space-separated CIDRs that may reach the PocketBase admin UI (/_/*).
+# Caddy fails to start if unset — no default — so a missing/malformed value can't
+# silently disable the gate. Use "0.0.0.0/0 ::/0" to explicitly opt into "open"
+# if that's actually intended.
+#
+# QUOTE THE VALUE: shell sources .env with `set -a`; an unquoted space breaks the
+# parse and the second CIDR is interpreted as a command (silent gate bypass).
+#
+# User OAuth login does NOT go through /_/ (Caddy rewrites the OAuth redirect
+# to /oauth2-complete.html), so gating this path only blocks admin UI access —
+# not regular user logins.
+#
+# Example: ADMIN_ALLOWLIST="10.0.0.0/8 192.168.0.0/16 2001:db8::/32"
+ADMIN_ALLOWLIST="0.0.0.0/0 ::/0"
+
 # Session Configuration
 # Generate a secure random string for SESSION_SECRET in production
 SESSION_SECRET=your-secure-session-secret-here

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -480,6 +480,11 @@ jobs:
         CAMPMINDER_SEASON_ID=
         SUB_BUNKING=
         DOMAIN_NAME=
+        # Required by docker-compose.yml's caddy service (${ADMIN_ALLOWLIST:?...}).
+        # CI test stack runs in isolation; "0.0.0.0/0 ::/0" explicitly opts into open
+        # so the gate isn't tested here (the gate is for prod, where the var is set
+        # to home/VPN ranges).
+        ADMIN_ALLOWLIST="0.0.0.0/0 ::/0"
         EOF
         # APPDATA_DIR needs shell expansion, add separately
         echo "APPDATA_DIR=${CI_DIR}" >> .env.ci

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,6 +132,8 @@ services:
       # its own CORS, so the app isn't broken — but the defense-in-depth Caddy
       # layer never fires. Set in .env (see .env.example).
       - ALLOWED_ORIGINS_REGEX=${ALLOWED_ORIGINS_REGEX:-}
+      # Required — Caddyfile fails to load if unset. See .env.example for details.
+      - ADMIN_ALLOWLIST=${ADMIN_ALLOWLIST:?ADMIN_ALLOWLIST is required (set in .env, see .env.example)}
     tmpfs:
       - /tmp:size=8m,uid=65532,gid=65532
       - /app/.config/caddy:size=8m,uid=65532,gid=65532

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -78,7 +78,7 @@
 	# PocketBase-specific patterns (explicit)
 	# These /api/* routes go to PocketBase (port 8090)
 	# Note: Must include both root paths and wildcards (e.g., /api/collections AND /api/collections/*)
-	@pocketbase path /api/collections /api/collections/* /api/files/* /api/realtime /api/custom/* /api/oauth2-redirect /api/settings /api/logs /api/logs/* /api/backups /api/backups/*
+	@pocketbase path /api/collections /api/collections/* /api/files/* /api/realtime /api/custom/* /api/settings /api/logs /api/logs/* /api/backups /api/backups/*
 
 	# PocketBase routes (database, auth, sync, file uploads)
 	handle @pocketbase {
@@ -87,8 +87,49 @@
 		}
 	}
 
-	# PocketBase admin UI
+	# OAuth2 redirect handler — separate from @pocketbase so we can rewrite
+	# the upstream's Location header. PocketBase issues a 307 to
+	# /_/#/auth/oauth2-redirect-{success,failure}, which would force /_/ to
+	# stay public. We rewrite to /oauth2-complete (kindred-served static page)
+	# so /_/ can be IP-gated below.
+	#
+	# The realtime @oauth2 message carrying {state, code} is sent server-side
+	# *before* PB issues the redirect (record_auth_with_oauth2_redirect.go),
+	# so the parent window receives the auth result regardless of where the
+	# popup follows the Location header.
+	handle /api/oauth2-redirect {
+		reverse_proxy {$POCKETBASE_HOST:pocketbase}:8090 {
+			header_up Host {host}
+			# Caddyfile gotcha: `redir /path 307` parses /path as a matcher
+			# (path-shortcut) and 307 as the redirect target. Use explicit
+			# header + respond to issue the rewrite unambiguously.
+			@oauth_success header Location *oauth2-redirect-success*
+			handle_response @oauth_success {
+				header Location "/oauth2-complete.html?status=success"
+				respond 307
+			}
+			@oauth_failure header Location *oauth2-redirect-failure*
+			handle_response @oauth_failure {
+				header Location "/oauth2-complete.html?status=failure"
+				respond 307
+			}
+		}
+	}
+
+	# PocketBase admin UI — IP-gated by ADMIN_ALLOWLIST (space-separated CIDRs).
+	# REQUIRED: must be set in .env. No default — Caddy fails to start if unset
+	# so a quoting mistake or missing var can't silently disable the gate. Use
+	# "0.0.0.0/0 ::/0" to explicitly opt into "open to all" if that's the intent.
+	# With OAuth's redirect rewritten above, gating /_/* does NOT break user login —
+	# the popup never lands at /_/ anymore; only superuser admin access does.
+	# Use client_ip (not remote_ip) so we match the real origin behind CF Tunnel
+	# / Traefik / any other trusted proxy. client_ip resolves via the
+	# trusted_proxies + client_ip_headers config in the global server block.
+	# (remote_ip would be the Docker bridge IP of whichever proxy handed off,
+	# which is the same for every real user — gate would fail open or closed.)
 	handle /_/* {
+		@admin_blocked not client_ip {$ADMIN_ALLOWLIST}
+		respond @admin_blocked 403
 		reverse_proxy {$POCKETBASE_HOST:pocketbase}:8090 {
 			header_up Host {host}
 		}

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -117,6 +117,14 @@ APPDATA_DIR=/path/to/appdata
 
 # IPv4 enforcement (critical!)
 # Always use 127.0.0.1, not localhost, for inter-service communication
+
+# PocketBase admin UI IP allowlist (Caddy /_/* gate)
+# Space-separated CIDRs. Default unset = open. Set to home/VPN ranges to
+# restrict admin UI access without affecting user OAuth login (Caddy rewrites
+# the OAuth completion redirect from /_/#/auth/oauth2-redirect-success to
+# the kindred-served /oauth2-complete.html, so /_/* is no longer in the user
+# login path).
+ADMIN_ALLOWLIST=10.0.0.0/8 192.168.0.0/16
 ```
 
 ### Logging & Monitoring

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -119,12 +119,18 @@ APPDATA_DIR=/path/to/appdata
 # Always use 127.0.0.1, not localhost, for inter-service communication
 
 # PocketBase admin UI IP allowlist (Caddy /_/* gate)
-# Space-separated CIDRs. Default unset = open. Set to home/VPN ranges to
-# restrict admin UI access without affecting user OAuth login (Caddy rewrites
-# the OAuth completion redirect from /_/#/auth/oauth2-redirect-success to
-# the kindred-served /oauth2-complete.html, so /_/* is no longer in the user
-# login path).
-ADMIN_ALLOWLIST=10.0.0.0/8 192.168.0.0/16
+# REQUIRED. Space-separated CIDRs. No default — Caddy fails closed (403) and
+# compose refuses to start if unset, so a missing/malformed value can't
+# silently disable the gate. Use "0.0.0.0/0 ::/0" to explicitly opt into
+# "open to all". Set to home/VPN ranges to restrict admin UI access without
+# affecting user OAuth login (Caddy rewrites the OAuth completion redirect
+# from /_/#/auth/oauth2-redirect-success to the kindred-served
+# /oauth2-complete.html, so /_/* is no longer in the user login path).
+#
+# QUOTE THE VALUE: shell sources .env with `set -a`; an unquoted space breaks
+# the parse and the second CIDR is interpreted as a command (silent gate
+# bypass). Always quote.
+ADMIN_ALLOWLIST="10.0.0.0/8 192.168.0.0/16"
 ```
 
 ### Logging & Monitoring

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -6,7 +6,7 @@
 	# PocketBase-specific patterns (explicit)
 	# These are the only /api/* routes that go to PocketBase
 	# Note: Must include both root paths and wildcards (e.g., /api/collections AND /api/collections/*)
-	@pocketbase path /api/collections /api/collections/* /api/files/* /api/realtime /api/custom/* /api/oauth2-redirect /api/settings /api/logs /api/logs/* /api/backups /api/backups/*
+	@pocketbase path /api/collections /api/collections/* /api/files/* /api/realtime /api/custom/* /api/settings /api/logs /api/logs/* /api/backups /api/backups/*
 
 	# PocketBase routes
 	handle @pocketbase {
@@ -15,8 +15,34 @@
 		}
 	}
 
-	# PocketBase admin UI
+	# OAuth2 redirect — rewrite PocketBase's redirect to the kindred-served
+	# completion page so /_/* can be gated. See docker/Caddyfile for the full
+	# explanation.
+	handle /api/oauth2-redirect {
+		reverse_proxy 127.0.0.1:{$POCKETBASE_PORT:8090} {
+			header_up Host {host}
+			# See docker/Caddyfile for why we use header+respond instead of redir.
+			@oauth_success header Location *oauth2-redirect-success*
+			handle_response @oauth_success {
+				header Location "/oauth2-complete.html?status=success"
+				respond 307
+			}
+			@oauth_failure header Location *oauth2-redirect-failure*
+			handle_response @oauth_failure {
+				header Location "/oauth2-complete.html?status=failure"
+				respond 307
+			}
+		}
+	}
+
+	# PocketBase admin UI — IP-gated by ADMIN_ALLOWLIST. Required in .env; no
+	# default (see docker/Caddyfile for why).
+	# client_ip falls back to remote_ip when trusted_proxies isn't configured,
+	# so this works in dev (direct connections) and stays consistent with
+	# docker/Caddyfile (where it matters because of CF Tunnel + Traefik).
 	handle /_/* {
+		@admin_blocked not client_ip {$ADMIN_ALLOWLIST}
+		respond @admin_blocked 403
 		reverse_proxy 127.0.0.1:{$POCKETBASE_PORT:8090} {
 			header_up Host {host}
 		}

--- a/frontend/public/oauth2-complete.html
+++ b/frontend/public/oauth2-complete.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex,nofollow" />
+  <title>Authentication complete</title>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; padding: 2rem; text-align: center; }
+    h1 { font-size: 1.25rem; margin-bottom: 0.5rem; }
+    p { color: #555; margin: 0; }
+    .err h1 { color: #b00; }
+  </style>
+</head>
+<body>
+  <main id="content">
+    <h1>Authentication complete.</h1>
+    <p>You can close this window and go back to the app.</p>
+  </main>
+  <script>
+    (function () {
+      var status = new URLSearchParams(window.location.search).get('status');
+      if (status === 'failure') {
+        var el = document.getElementById('content');
+        el.classList.add('err');
+        el.innerHTML = '<h1>Authentication failed.</h1><p>You can close this window and go back to the app to try again.</p>';
+      }
+      // Mirror PocketBase's admin-UI behavior: auto-close the popup. The realtime
+      // channel has already delivered the auth code to the parent window by this
+      // point, so closing here is purely a UX convenience. (The PocketBase JS SDK
+      // also calls s.close() on the popup from the parent window, so this is
+      // belt-and-suspenders — works even if the popup is opened standalone.)
+      window.close();
+    })();
+  </script>
+</body>
+</html>

--- a/scripts/start_dev.sh
+++ b/scripts/start_dev.sh
@@ -187,7 +187,7 @@ echo -e "${BLUE}Starting Caddy on port ${CADDY_PORT:-8080}...${NC}"
 # Set environment variables for Caddy
 # Use pb_public since it has both frontend build AND local assets
 export FRONTEND_BUILD_PATH="$PROJECT_ROOT/pocketbase/pb_public"
-export CADDY_PORT POCKETBASE_PORT FASTAPI_PORT
+export CADDY_PORT POCKETBASE_PORT FASTAPI_PORT ADMIN_ALLOWLIST
 cd "$PROJECT_ROOT/frontend"
 caddy run --config Caddyfile --adapter caddyfile &
 CADDY_PID=$!


### PR DESCRIPTION
## Summary
- Rewrite PocketBase's OAuth2 redirect at the Caddy edge so user login no longer touches `/_/`, then add an `ADMIN_ALLOWLIST` IP gate on `/_/*`.
- New static page `frontend/public/oauth2-complete.html` mirrors PocketBase's admin-UI completion page (shows "Authentication complete / failed", calls `window.close()`).

## Why
PocketBase's `/api/oauth2-redirect` handler issues a `307 Location: ../_/#/auth/oauth2-redirect-success` (`record_auth_with_oauth2_redirect.go:17-18`). The path is hardcoded — no env var, no config, no hook to override it. That forces `/_/*` to stay public, since gating it would break the user-facing OAuth login popup (it follows the redirect and loads the entire admin SPA bundle to render the success page).

The realtime `@oauth2` channel delivers `{state, code}` to the parent window *before* the redirect is issued (PB does this server-side), so closing the popup is purely UX. We can rewrite the redirect target to a kindred-served page without touching PB.

This PR does that rewrite at Caddy via `handle_response` on `/api/oauth2-redirect`. With user login off `/_/`, the admin UI can be gated to a CIDR allowlist, which closes #1100.

## Changes
- `docker/Caddyfile`, `frontend/Caddyfile`:
  - Pull `/api/oauth2-redirect` out of `@pocketbase` into its own `handle` with `handle_response` that rewrites success/failure `Location` headers to `/oauth2-complete.html?status=...`.
  - Gate `/_/*` behind `ADMIN_ALLOWLIST` (space-separated CIDRs). **No default** — Caddy fails closed (everyone gets 403) if the var is unset, so a quoting mistake or missing var can't silently disable the gate.
  - Use `client_ip` matcher (not `remote_ip`) so the gate works behind CF Tunnel + Traefik in production. `client_ip` resolves the real origin via the existing `trusted_proxies` + `client_ip_headers` config; falls back to `remote_ip` in dev where there's no proxy.
- `frontend/public/oauth2-complete.html`: ~30-line static page; reads `?status=`, shows the appropriate message, calls `window.close()`.
- `scripts/start_dev.sh` + `docker-compose.yml`: propagate `ADMIN_ALLOWLIST` to Caddy's process env in dev and to the caddy container in prod (compose uses `${VAR:?...}` so prod fails loud at compose-up if missing).
- `.env.example`: marks `ADMIN_ALLOWLIST` REQUIRED, documents the shell-quoting trap (`set -a` parses unquoted spaces wrong), shows a quoted example.

## Bug-finding journey (visible in commit history)
This started looking simple but hit three layered bugs that together would have shipped a security control that fails open silently. Documented in commits so the lessons stick:
1. **Caddyfile `redir` parsing** — `redir /path 307` parses `/path` as a path-shortcut matcher and `307` as the redirect target. The matcher never matches the actual request path, so the rewrite silently no-ops. Fixed by using explicit `header Location` + `respond 307`.
2. **Env propagation gap** — `start_dev.sh` only exported a hardcoded list of vars; `docker-compose.yml` only listed two for the caddy service. New env vars don't reach Caddy at all.
3. **`.env` shell-quoting** — values containing spaces (multi-CIDR allowlists) need quoting; without it, `set -a; source .env` leaves the var unset and may execute the trailing CIDR as a command.

Combined, these three meant `ADMIN_ALLOWLIST` never reached Caddy, the Caddyfile's `0.0.0.0/0 ::/0` default kept the gate open, and the PR appeared to "work" while gating nothing. Final design eliminates the silent-fail mode by removing the default.

## Test plan — verified end to end
Empirical tests on the worktree stack (laptop on LAN, server at `10.0.20.20`):
- [x] `caddy adapt` validates both Caddyfiles (stock + xcaddy)
- [x] `curl /api/oauth2-redirect?state=bogus&code=bogus` → `307 Location: /oauth2-complete.html?status=failure` (rewrite fires)
- [x] OIDC login from laptop completes; popup network panel shows `/api/oauth2-redirect` → `/oauth2-complete.html`, **never `/_/`**
- [x] With `ADMIN_ALLOWLIST="127.0.0.1/32 ::1/128"` (laptop excluded): `curl http://server:8140/_/` from laptop returns **403**, login still completes
- [x] With laptop's LAN added to allowlist: `/_/` admin UI loads from laptop
- [x] `respond 307` + `header Location` produces the expected redirect (verified via adapted JSON inspection)

## Stacked on
Branched off `feature/caddy-vps-hardening` (#995). That PR's `trusted_proxies` + `client_ip_headers` config is what makes `client_ip` resolve correctly. A related env-propagation fix for `ALLOWED_ORIGINS_REGEX` was pushed there directly (same class of bug, found while debugging this one).

Closes #1100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)