### PR TITLE
refactor(api): adopt pb_error_to_http at remaining ClientResponseError callsites

### DIFF
--- a/api/routers/scenarios.py
+++ b/api/routers/scenarios.py
@@ -194,7 +194,7 @@ async def create_scenario(
         )
 
     except ClientResponseError as e:
-        logger.error(f"PocketBase error creating scenario: {e}")
+        logger.error(f"PocketBase error creating scenario: {e}", exc_info=True)
         raise pb_error_to_http(e)
     except Exception as e:
         logger.error(f"Error creating scenario: {e}", exc_info=True)
@@ -420,7 +420,7 @@ async def get_scenario(
     except ClientResponseError as e:
         raise pb_error_to_http(e)
     except Exception as e:
-        logger.error(f"Error getting scenario: {e}")
+        logger.error(f"Error getting scenario: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to get scenario")
 
 
@@ -626,10 +626,17 @@ async def update_scenario_assignment(
                 }
 
     except ClientResponseError as e:
-        logger.error(
-            f"PocketBase error in update_scenario_assignment: status={e.status}, body={getattr(e, 'data', None)}"
-        )
-        logger.error(f"Scenario ID: {scenario_id}, Update: {update}")
+        if 400 <= e.status < 500:
+            logger.warning(
+                f"PocketBase error in update_scenario_assignment: status={e.status}, body={getattr(e, 'data', None)}"
+            )
+            logger.warning(f"Scenario ID: {scenario_id}, Update: {update}")
+        else:
+            logger.error(
+                f"PocketBase error in update_scenario_assignment: status={e.status}, body={getattr(e, 'data', None)}",
+                exc_info=True,
+            )
+            logger.error(f"Scenario ID: {scenario_id}, Update: {update}")
         raise pb_error_to_http(e)
     except HTTPException:
         raise
@@ -699,7 +706,7 @@ async def solve_scenario(
     except ClientResponseError as e:
         raise pb_error_to_http(e)
     except Exception as e:
-        logger.error(f"Error starting solver for scenario: {e}")
+        logger.error(f"Error starting solver for scenario: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to start solver")
 
 
@@ -733,5 +740,5 @@ async def clear_scenario(
     except ClientResponseError as e:
         raise pb_error_to_http(e)
     except Exception as e:
-        logger.error(f"Error clearing scenario: {e}")
+        logger.error(f"Error clearing scenario: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to clear scenario")

--- a/api/routers/scenarios.py
+++ b/api/routers/scenarios.py
@@ -43,6 +43,7 @@ from ..constants.collections import (
 from ..dependencies import pb, solver_runs
 from ..services.session_context import build_session_context
 from ..services.solver_runner import run_solver_task_v2
+from ..utils.pb_error import pb_error_to_http
 from ..utils.session_metrics import get_person_from_expand, get_session_from_expand
 
 logger = get_logger(__name__)
@@ -194,7 +195,7 @@ async def create_scenario(
 
     except ClientResponseError as e:
         logger.error(f"PocketBase error creating scenario: {e}")
-        raise HTTPException(status_code=400, detail=str(e))
+        raise pb_error_to_http(e)
     except Exception as e:
         logger.error(f"Error creating scenario: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to create scenario: {e!s}")
@@ -417,9 +418,7 @@ async def get_scenario(
         return scenario_result
 
     except ClientResponseError as e:
-        if e.status == 404:
-            raise HTTPException(status_code=404, detail="Scenario not found")
-        raise HTTPException(status_code=400, detail=str(e))
+        raise pb_error_to_http(e)
     except Exception as e:
         logger.error(f"Error getting scenario: {e}")
         raise HTTPException(status_code=500, detail="Failed to get scenario")
@@ -459,9 +458,7 @@ async def update_scenario(
         )
 
     except ClientResponseError as e:
-        if e.status == 404:
-            raise HTTPException(status_code=404, detail="Scenario not found")
-        raise HTTPException(status_code=400, detail=str(e))
+        raise pb_error_to_http(e)
     except Exception as e:
         logger.error(f"Error updating scenario: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to update scenario: {e!s}")
@@ -490,9 +487,7 @@ async def delete_scenario(
         return {"message": f"Scenario '{getattr(scenario, 'name', scenario_id)}' deleted successfully"}
 
     except ClientResponseError as e:
-        if e.status == 404:
-            raise HTTPException(status_code=404, detail="Scenario not found")
-        raise HTTPException(status_code=400, detail=str(e))
+        raise pb_error_to_http(e)
     except Exception as e:
         logger.error(f"Error deleting scenario: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to delete scenario: {e!s}")
@@ -635,12 +630,7 @@ async def update_scenario_assignment(
             f"PocketBase error in update_scenario_assignment: status={e.status}, body={getattr(e, 'data', None)}"
         )
         logger.error(f"Scenario ID: {scenario_id}, Update: {update}")
-        if e.status == 404:
-            raise HTTPException(status_code=404, detail="Scenario not found")
-        error_detail = str(e)
-        if hasattr(e, "data") and e.data:
-            error_detail = f"PocketBase error: {e.data}"
-        raise HTTPException(status_code=400, detail=error_detail)
+        raise pb_error_to_http(e)
     except HTTPException:
         raise
     except Exception as e:
@@ -707,9 +697,7 @@ async def solve_scenario(
         return {"run_id": run_id, "status": "started", "message": "Solver run started for scenario"}
 
     except ClientResponseError as e:
-        if e.status == 404:
-            raise HTTPException(status_code=404, detail="Scenario not found")
-        raise HTTPException(status_code=400, detail=str(e))
+        raise pb_error_to_http(e)
     except Exception as e:
         logger.error(f"Error starting solver for scenario: {e}")
         raise HTTPException(status_code=500, detail="Failed to start solver")
@@ -743,9 +731,7 @@ async def clear_scenario(
         }
 
     except ClientResponseError as e:
-        if e.status == 404:
-            raise HTTPException(status_code=404, detail="Scenario not found")
-        raise HTTPException(status_code=400, detail=str(e))
+        raise pb_error_to_http(e)
     except Exception as e:
         logger.error(f"Error clearing scenario: {e}")
         raise HTTPException(status_code=500, detail="Failed to clear scenario")

--- a/api/routers/validation.py
+++ b/api/routers/validation.py
@@ -8,12 +8,11 @@ against constraints and rules.
 from __future__ import annotations
 
 import asyncio
-import os
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from pocketbase.client import ClientResponseError  # type: ignore[attr-defined]
 
 from bunking.auth_middleware import AuthUser
@@ -399,7 +398,4 @@ async def validate_bunking(
         raise pb_error_to_http(e)
     except Exception as e:
         logger.error(f"Error during bunking validation: {e}", exc_info=True)
-        if os.environ.get("ENV", "development") == "development":
-            raise HTTPException(status_code=500, detail=f"Validation error: {e!s}")
-        else:
-            raise HTTPException(status_code=500, detail="Failed to validate bunking")
+        raise

--- a/api/routers/validation.py
+++ b/api/routers/validation.py
@@ -43,6 +43,7 @@ from ..constants.filters import ACTIVE_ENROLLED_FILTER
 from ..dependencies import pb
 from ..schemas import ValidateBunkingRequest
 from ..services.session_context import build_session_context
+from ..utils.pb_error import pb_error_to_http
 from ..utils.session_metrics import get_person_from_expand, get_session_from_expand
 
 logger = get_logger(__name__)
@@ -395,9 +396,7 @@ async def validate_bunking(
         return validation_result.model_dump()
 
     except ClientResponseError as e:
-        if e.status == 404:
-            raise HTTPException(status_code=404, detail="Session not found")
-        raise HTTPException(status_code=400, detail=str(e))
+        raise pb_error_to_http(e)
     except Exception as e:
         logger.error(f"Error during bunking validation: {e}", exc_info=True)
         if os.environ.get("ENV", "development") == "development":

--- a/api/services/data_fetcher.py
+++ b/api/services/data_fetcher.py
@@ -12,9 +12,9 @@ import asyncio
 from collections import defaultdict
 from typing import Any
 
-from fastapi import HTTPException
 from pocketbase.client import ClientResponseError  # type: ignore[attr-defined]
 
+from api.utils.pb_error import pb_error_to_http
 from api.utils.session_metrics import get_person_from_expand, get_session_from_expand
 from bunking.direct_solver import (
     DirectBunk,
@@ -166,7 +166,7 @@ async def fetch_session_data_v2(
 
     except ClientResponseError as e:
         logger.error(f"Failed to fetch session data for CM ID {session_cm_id}: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to fetch session data: {e!s}")
+        raise pb_error_to_http(e)
 
 
 async def fetch_historical_bunking(

--- a/api/utils/pb_error.py
+++ b/api/utils/pb_error.py
@@ -16,8 +16,12 @@ schema details, internal IDs) must not be exposed to API consumers.
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import HTTPException
 from pocketbase.client import ClientResponseError  # type: ignore[attr-defined]
+
+logger = logging.getLogger(__name__)
 
 
 def pb_error_to_http(error: ClientResponseError) -> HTTPException:
@@ -44,5 +48,6 @@ def pb_error_to_http(error: ClientResponseError) -> HTTPException:
     # Any PocketBase 5xx → 502 Bad Gateway (upstream failure, not our fault)
     if status >= 500:
         return HTTPException(status_code=502, detail="Upstream service error")
-    # Fallback for unexpected statuses
+    # Fallback for unexpected statuses (e.g. 429 rate-limited, other non-standard codes)
+    logger.warning("pb_error_to_http: unexpected upstream status %d", status)
     return HTTPException(status_code=502, detail="Upstream service error")

--- a/tests/unit/api/routers/test_pb_error_to_http_adoption.py
+++ b/tests/unit/api/routers/test_pb_error_to_http_adoption.py
@@ -1,0 +1,546 @@
+"""#1137 — adopt pb_error_to_http at remaining ClientResponseError callsites.
+
+PR #1135 introduced pb_error_to_http() and applied it to pre_validate_solver.
+This module covers the remaining callsites that still used legacy patterns:
+
+  - api/routers/scenarios.py  (create_scenario, get_scenario, update_scenario,
+                                delete_scenario, update_scenario_assignment,
+                                solve_scenario, clear_scenario)
+  - api/routers/validation.py (validate_bunking)
+  - api/services/data_fetcher.py (fetch_session_data_v2)
+
+For each callsite the tests assert:
+  1. PB 404 → HTTP 404 (not 400 and not 500)
+  2. PB 500 → HTTP 502 (not 500)
+  3. No raw PocketBase body content leaks into the response detail.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+test_dir = Path(__file__).resolve().parent
+project_root = test_dir.parent.parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from bunking.auth_middleware import AuthUser, get_current_user
+from bunking.rbac.permissions import ALL_PERMISSIONS
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_admin_user() -> AuthUser:
+    user = AuthUser(
+        username="TestAdmin",
+        email="test@example.com",
+        display_name="Test Admin",
+        groups=["admin"],
+        is_admin=True,
+    )
+    user.permissions = set(ALL_PERMISSIONS)
+    return user
+
+
+def _make_pb_error(status: int = 404, data: Any = "sensitive PocketBase detail") -> Any:
+    from pocketbase.client import ClientResponseError  # type: ignore[attr-defined]
+
+    return ClientResponseError(url="http://pb/test", status=status, data={"message": data})
+
+
+def _make_app(router: Any) -> FastAPI:
+    """Minimal FastAPI app mirroring main.py global exception handler."""
+    from fastapi import Request
+
+    app = FastAPI()
+
+    @app.exception_handler(Exception)
+    async def _unhandled(request: Request, exc: Exception) -> JSONResponse:
+        return JSONResponse(status_code=500, content={"detail": "Internal server error"})
+
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = _mock_admin_user
+    return app
+
+
+# ---------------------------------------------------------------------------
+# scenarios.py — create_scenario  (POST /api/scenarios)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateScenarioPbError:
+    """create_scenario must map PB errors via pb_error_to_http, not flatten to 400/str(e)."""
+
+    @pytest.fixture
+    def client_404(self) -> Iterator[TestClient]:
+        from api.routers.scenarios import router
+
+        pb_error = _make_pb_error(status=404)
+        app = _make_app(router)
+        with (
+            patch("api.routers.scenarios.build_session_context", side_effect=pb_error),
+            patch("api.routers.scenarios.pb", MagicMock()),
+        ):
+            yield TestClient(app, raise_server_exceptions=False)
+
+    @pytest.fixture
+    def client_500(self) -> Iterator[TestClient]:
+        from api.routers.scenarios import router
+
+        pb_error = _make_pb_error(status=500)
+        app = _make_app(router)
+        with (
+            patch("api.routers.scenarios.build_session_context", side_effect=pb_error),
+            patch("api.routers.scenarios.pb", MagicMock()),
+        ):
+            yield TestClient(app, raise_server_exceptions=False)
+
+    def _payload(self) -> dict[str, Any]:
+        return {"name": "Test Scenario", "session_cm_id": 1001, "year": 2025}
+
+    def test_pb_404_returns_404(self, client_404: TestClient) -> None:
+        resp = client_404.post("/api/scenarios", json=self._payload())
+        assert resp.status_code == 404, f"Expected 404, got {resp.status_code}: {resp.json()}"
+
+    def test_pb_500_returns_502(self, client_500: TestClient) -> None:
+        resp = client_500.post("/api/scenarios", json=self._payload())
+        assert resp.status_code == 502, f"Expected 502, got {resp.status_code}: {resp.json()}"
+
+    def test_detail_does_not_leak_pb_body(self, client_404: TestClient) -> None:
+        resp = client_404.post("/api/scenarios", json=self._payload())
+        body = resp.json()
+        assert "sensitive" not in str(body).lower()
+        assert "PocketBase" not in str(body)
+
+
+# ---------------------------------------------------------------------------
+# scenarios.py — get_scenario  (GET /api/scenarios/{id})
+# ---------------------------------------------------------------------------
+
+
+class TestGetScenarioPbError:
+    """get_scenario must map PB errors via pb_error_to_http."""
+
+    @pytest.fixture
+    def client_404(self) -> Iterator[TestClient]:
+        from api.routers.scenarios import router
+
+        pb_error = _make_pb_error(status=404)
+        mock_pb = MagicMock()
+        mock_pb.collection.return_value.get_one.side_effect = pb_error
+        app = _make_app(router)
+        with patch("api.routers.scenarios.pb", mock_pb):
+            yield TestClient(app, raise_server_exceptions=False)
+
+    @pytest.fixture
+    def client_500(self) -> Iterator[TestClient]:
+        from api.routers.scenarios import router
+
+        pb_error = _make_pb_error(status=500)
+        mock_pb = MagicMock()
+        mock_pb.collection.return_value.get_one.side_effect = pb_error
+        app = _make_app(router)
+        with patch("api.routers.scenarios.pb", mock_pb):
+            yield TestClient(app, raise_server_exceptions=False)
+
+    def test_pb_404_returns_404(self, client_404: TestClient) -> None:
+        resp = client_404.get("/api/scenarios/nonexistent-id")
+        assert resp.status_code == 404, f"Expected 404, got {resp.status_code}: {resp.json()}"
+
+    def test_pb_500_returns_502(self, client_500: TestClient) -> None:
+        resp = client_500.get("/api/scenarios/any-id")
+        assert resp.status_code == 502, f"Expected 502, got {resp.status_code}: {resp.json()}"
+
+    def test_detail_does_not_leak_pb_body(self, client_404: TestClient) -> None:
+        resp = client_404.get("/api/scenarios/nonexistent-id")
+        body = resp.json()
+        assert "sensitive" not in str(body).lower()
+        assert "PocketBase" not in str(body)
+
+
+# ---------------------------------------------------------------------------
+# scenarios.py — update_scenario  (PUT /api/scenarios/{id})
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateScenarioPbError:
+    """update_scenario must map PB errors via pb_error_to_http."""
+
+    @pytest.fixture
+    def client_404(self) -> Iterator[TestClient]:
+        from api.routers.scenarios import router
+
+        pb_error = _make_pb_error(status=404)
+        mock_pb = MagicMock()
+        mock_pb.collection.return_value.update.side_effect = pb_error
+        app = _make_app(router)
+        with patch("api.routers.scenarios.pb", mock_pb):
+            yield TestClient(app, raise_server_exceptions=False)
+
+    @pytest.fixture
+    def client_500(self) -> Iterator[TestClient]:
+        from api.routers.scenarios import router
+
+        pb_error = _make_pb_error(status=500)
+        mock_pb = MagicMock()
+        mock_pb.collection.return_value.update.side_effect = pb_error
+        app = _make_app(router)
+        with patch("api.routers.scenarios.pb", mock_pb):
+            yield TestClient(app, raise_server_exceptions=False)
+
+    def test_pb_404_returns_404(self, client_404: TestClient) -> None:
+        resp = client_404.put("/api/scenarios/nonexistent-id", json={"name": "Updated"})
+        assert resp.status_code == 404, f"Expected 404, got {resp.status_code}: {resp.json()}"
+
+    def test_pb_500_returns_502(self, client_500: TestClient) -> None:
+        resp = client_500.put("/api/scenarios/any-id", json={"name": "Updated"})
+        assert resp.status_code == 502, f"Expected 502, got {resp.status_code}: {resp.json()}"
+
+    def test_detail_does_not_leak_pb_body(self, client_404: TestClient) -> None:
+        resp = client_404.put("/api/scenarios/nonexistent-id", json={"name": "Updated"})
+        body = resp.json()
+        assert "sensitive" not in str(body).lower()
+        assert "PocketBase" not in str(body)
+
+
+# ---------------------------------------------------------------------------
+# scenarios.py — delete_scenario  (DELETE /api/scenarios/{id})
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteScenarioPbError:
+    """delete_scenario must map PB errors via pb_error_to_http."""
+
+    @pytest.fixture
+    def client_404(self) -> Iterator[TestClient]:
+        from api.routers.scenarios import router
+
+        pb_error = _make_pb_error(status=404)
+        mock_pb = MagicMock()
+        mock_pb.collection.return_value.get_one.side_effect = pb_error
+        app = _make_app(router)
+        with patch("api.routers.scenarios.pb", mock_pb):
+            yield TestClient(app, raise_server_exceptions=False)
+
+    @pytest.fixture
+    def client_500(self) -> Iterator[TestClient]:
+        from api.routers.scenarios import router
+
+        pb_error = _make_pb_error(status=500)
+        mock_pb = MagicMock()
+        mock_pb.collection.return_value.get_one.side_effect = pb_error
+        app = _make_app(router)
+        with patch("api.routers.scenarios.pb", mock_pb):
+            yield TestClient(app, raise_server_exceptions=False)
+
+    def test_pb_404_returns_404(self, client_404: TestClient) -> None:
+        resp = client_404.delete("/api/scenarios/nonexistent-id")
+        assert resp.status_code == 404, f"Expected 404, got {resp.status_code}: {resp.json()}"
+
+    def test_pb_500_returns_502(self, client_500: TestClient) -> None:
+        resp = client_500.delete("/api/scenarios/any-id")
+        assert resp.status_code == 502, f"Expected 502, got {resp.status_code}: {resp.json()}"
+
+    def test_detail_does_not_leak_pb_body(self, client_404: TestClient) -> None:
+        resp = client_404.delete("/api/scenarios/nonexistent-id")
+        body = resp.json()
+        assert "sensitive" not in str(body).lower()
+        assert "PocketBase" not in str(body)
+
+
+# ---------------------------------------------------------------------------
+# scenarios.py — solve_scenario  (POST /api/scenarios/{id}/solve)
+# ---------------------------------------------------------------------------
+
+
+class TestSolveScenarioPbError:
+    """solve_scenario must map PB errors via pb_error_to_http."""
+
+    @pytest.fixture
+    def client_404(self) -> Iterator[TestClient]:
+        from api.routers.scenarios import router
+
+        pb_error = _make_pb_error(status=404)
+        mock_pb = MagicMock()
+        mock_pb.collection.return_value.get_one.side_effect = pb_error
+        app = _make_app(router)
+        with patch("api.routers.scenarios.pb", mock_pb):
+            yield TestClient(app, raise_server_exceptions=False)
+
+    @pytest.fixture
+    def client_500(self) -> Iterator[TestClient]:
+        from api.routers.scenarios import router
+
+        pb_error = _make_pb_error(status=500)
+        mock_pb = MagicMock()
+        mock_pb.collection.return_value.get_one.side_effect = pb_error
+        app = _make_app(router)
+        with patch("api.routers.scenarios.pb", mock_pb):
+            yield TestClient(app, raise_server_exceptions=False)
+
+    def test_pb_404_returns_404(self, client_404: TestClient) -> None:
+        resp = client_404.post("/api/scenarios/nonexistent-id/solve")
+        assert resp.status_code == 404, f"Expected 404, got {resp.status_code}: {resp.json()}"
+
+    def test_pb_500_returns_502(self, client_500: TestClient) -> None:
+        resp = client_500.post("/api/scenarios/any-id/solve")
+        assert resp.status_code == 502, f"Expected 502, got {resp.status_code}: {resp.json()}"
+
+    def test_detail_does_not_leak_pb_body(self, client_404: TestClient) -> None:
+        resp = client_404.post("/api/scenarios/nonexistent-id/solve")
+        body = resp.json()
+        assert "sensitive" not in str(body).lower()
+        assert "PocketBase" not in str(body)
+
+
+# ---------------------------------------------------------------------------
+# scenarios.py — clear_scenario  (POST /api/scenarios/{id}/clear)
+# ---------------------------------------------------------------------------
+
+
+class TestClearScenarioPbError:
+    """clear_scenario must map PB errors via pb_error_to_http."""
+
+    @pytest.fixture
+    def client_404(self) -> Iterator[TestClient]:
+        from api.routers.scenarios import router
+
+        pb_error = _make_pb_error(status=404)
+        mock_pb = MagicMock()
+        mock_pb.collection.return_value.get_one.side_effect = pb_error
+        app = _make_app(router)
+        with patch("api.routers.scenarios.pb", mock_pb):
+            yield TestClient(app, raise_server_exceptions=False)
+
+    @pytest.fixture
+    def client_500(self) -> Iterator[TestClient]:
+        from api.routers.scenarios import router
+
+        pb_error = _make_pb_error(status=500)
+        mock_pb = MagicMock()
+        mock_pb.collection.return_value.get_one.side_effect = pb_error
+        app = _make_app(router)
+        with patch("api.routers.scenarios.pb", mock_pb):
+            yield TestClient(app, raise_server_exceptions=False)
+
+    def test_pb_404_returns_404(self, client_404: TestClient) -> None:
+        resp = client_404.post("/api/scenarios/nonexistent-id/clear", json={"year": 2025})
+        assert resp.status_code == 404, f"Expected 404, got {resp.status_code}: {resp.json()}"
+
+    def test_pb_500_returns_502(self, client_500: TestClient) -> None:
+        resp = client_500.post("/api/scenarios/any-id/clear", json={"year": 2025})
+        assert resp.status_code == 502, f"Expected 502, got {resp.status_code}: {resp.json()}"
+
+    def test_detail_does_not_leak_pb_body(self, client_404: TestClient) -> None:
+        resp = client_404.post("/api/scenarios/nonexistent-id/clear", json={"year": 2025})
+        body = resp.json()
+        assert "sensitive" not in str(body).lower()
+        assert "PocketBase" not in str(body)
+
+
+# ---------------------------------------------------------------------------
+# scenarios.py — update_scenario_assignment  (PUT /api/scenarios/{id}/assignments)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateScenarioAssignmentPbError:
+    """update_scenario_assignment outer handler must map PB errors via pb_error_to_http."""
+
+    @pytest.fixture
+    def client_404(self) -> Iterator[TestClient]:
+        from api.routers.scenarios import router
+
+        pb_error = _make_pb_error(status=404)
+        app = _make_app(router)
+        with (
+            patch("api.routers.scenarios.build_session_context", side_effect=pb_error),
+            patch("api.routers.scenarios.pb", MagicMock()),
+        ):
+            yield TestClient(app, raise_server_exceptions=False)
+
+    @pytest.fixture
+    def client_500(self) -> Iterator[TestClient]:
+        from api.routers.scenarios import router
+
+        pb_error = _make_pb_error(status=500)
+        app = _make_app(router)
+        with (
+            patch("api.routers.scenarios.build_session_context", side_effect=pb_error),
+            patch("api.routers.scenarios.pb", MagicMock()),
+        ):
+            yield TestClient(app, raise_server_exceptions=False)
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "person_id": 1001,
+            "bunk_id": 2001,
+            "session_cm_id": 3001,
+            "year": 2025,
+        }
+
+    def test_pb_404_returns_404(self, client_404: TestClient) -> None:
+        resp = client_404.put("/api/scenarios/any-id/assignments", json=self._payload())
+        assert resp.status_code == 404, f"Expected 404, got {resp.status_code}: {resp.json()}"
+
+    def test_pb_500_returns_502(self, client_500: TestClient) -> None:
+        resp = client_500.put("/api/scenarios/any-id/assignments", json=self._payload())
+        assert resp.status_code == 502, f"Expected 502, got {resp.status_code}: {resp.json()}"
+
+    def test_detail_does_not_leak_pb_body(self, client_404: TestClient) -> None:
+        resp = client_404.put("/api/scenarios/any-id/assignments", json=self._payload())
+        body = resp.json()
+        assert "sensitive" not in str(body).lower()
+        assert "PocketBase" not in str(body)
+
+
+# ---------------------------------------------------------------------------
+# validation.py — validate_bunking  (POST /api/validate/bunking)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateBunkingPbError:
+    """validate_bunking must map PB errors via pb_error_to_http, not use str(e) detail."""
+
+    @pytest.fixture
+    def client_404(self) -> Iterator[TestClient]:
+        from api.routers.validation import router
+
+        pb_error = _make_pb_error(status=404)
+        app = _make_app(router)
+        with (
+            patch("api.routers.validation.build_session_context", side_effect=pb_error),
+            patch("api.routers.validation.pb", MagicMock()),
+        ):
+            yield TestClient(app, raise_server_exceptions=False)
+
+    @pytest.fixture
+    def client_500(self) -> Iterator[TestClient]:
+        from api.routers.validation import router
+
+        pb_error = _make_pb_error(status=500)
+        app = _make_app(router)
+        with (
+            patch("api.routers.validation.build_session_context", side_effect=pb_error),
+            patch("api.routers.validation.pb", MagicMock()),
+        ):
+            yield TestClient(app, raise_server_exceptions=False)
+
+    def _payload(self) -> dict[str, Any]:
+        return {"session_cm_id": 1001, "year": 2025}
+
+    def test_pb_404_returns_404(self, client_404: TestClient) -> None:
+        resp = client_404.post("/api/validate-bunking", json=self._payload())
+        assert resp.status_code == 404, f"Expected 404, got {resp.status_code}: {resp.json()}"
+
+    def test_pb_500_returns_502(self, client_500: TestClient) -> None:
+        resp = client_500.post("/api/validate-bunking", json=self._payload())
+        assert resp.status_code == 502, f"Expected 502, got {resp.status_code}: {resp.json()}"
+
+    def test_detail_does_not_leak_pb_body(self, client_404: TestClient) -> None:
+        resp = client_404.post("/api/validate-bunking", json=self._payload())
+        body = resp.json()
+        assert "sensitive" not in str(body).lower()
+        assert "PocketBase" not in str(body)
+
+
+# ---------------------------------------------------------------------------
+# data_fetcher.py — fetch_session_data_v2  (tested via solver endpoint)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchSessionDataV2PbError:
+    """fetch_session_data_v2 must map PB errors via pb_error_to_http.
+
+    We test via the solver endpoint (start_solver) which calls fetch_session_data_v2
+    indirectly through run_solver_task_v2. However, since run_solver_task_v2 runs
+    as a background task, we test fetch_session_data_v2 directly as a unit test.
+    """
+
+    def test_pb_404_raises_404_http_exception(self) -> None:
+        """When PB returns 404, fetch_session_data_v2 must raise HTTPException(404)."""
+        import asyncio
+
+        from api.services.data_fetcher import fetch_session_data_v2
+
+        pb_error = _make_pb_error(status=404)
+        mock_pb = MagicMock()
+        mock_pb.collection.return_value.get_full_list.side_effect = pb_error
+
+        # We need to mock build_session_context too since it's called first
+        mock_ctx = MagicMock()
+        mock_ctx.year = 2025
+        mock_ctx.session_relation_filter = "session = 'abc'"
+        mock_ctx.session_id_filter = "session_cm_id = 1001"
+
+        from fastapi import HTTPException
+
+        with (
+            patch("api.services.data_fetcher.build_session_context", return_value=mock_ctx),
+            patch("api.services.data_fetcher.pb", mock_pb),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(fetch_session_data_v2(session_cm_id=1001, year=2025))
+            assert exc_info.value.status_code == 404, f"Expected HTTPException(404), got {exc_info.value.status_code}"
+
+    def test_pb_500_raises_502_http_exception(self) -> None:
+        """When PB returns 500, fetch_session_data_v2 must raise HTTPException(502)."""
+        import asyncio
+
+        from api.services.data_fetcher import fetch_session_data_v2
+
+        pb_error = _make_pb_error(status=500)
+        mock_pb = MagicMock()
+        mock_pb.collection.return_value.get_full_list.side_effect = pb_error
+
+        mock_ctx = MagicMock()
+        mock_ctx.year = 2025
+        mock_ctx.session_relation_filter = "session = 'abc'"
+        mock_ctx.session_id_filter = "session_cm_id = 1001"
+
+        from fastapi import HTTPException
+
+        with (
+            patch("api.services.data_fetcher.build_session_context", return_value=mock_ctx),
+            patch("api.services.data_fetcher.pb", mock_pb),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(fetch_session_data_v2(session_cm_id=1001, year=2025))
+            assert exc_info.value.status_code == 502, f"Expected HTTPException(502), got {exc_info.value.status_code}"
+
+    def test_detail_does_not_leak_pb_body(self) -> None:
+        """HTTPException detail must not contain raw PB error body."""
+        import asyncio
+
+        from api.services.data_fetcher import fetch_session_data_v2
+
+        pb_error = _make_pb_error(status=404, data="sensitive PocketBase internal schema info")
+        mock_pb = MagicMock()
+        mock_pb.collection.return_value.get_full_list.side_effect = pb_error
+
+        mock_ctx = MagicMock()
+        mock_ctx.year = 2025
+        mock_ctx.session_relation_filter = "session = 'abc'"
+        mock_ctx.session_id_filter = "session_cm_id = 1001"
+
+        from fastapi import HTTPException
+
+        with (
+            patch("api.services.data_fetcher.build_session_context", return_value=mock_ctx),
+            patch("api.services.data_fetcher.pb", mock_pb),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(fetch_session_data_v2(session_cm_id=1001, year=2025))
+            detail = str(exc_info.value.detail)
+            assert "sensitive" not in detail.lower()
+            assert "PocketBase" not in detail
+            assert "schema" not in detail.lower()

--- a/tests/unit/api/test_pb_error_to_http.py
+++ b/tests/unit/api/test_pb_error_to_http.py
@@ -119,6 +119,20 @@ class TestPbErrorToHttp:
         assert "sensitive" not in str(exc.detail).lower()
         assert "PocketBase" not in str(exc.detail)
 
+    def test_unexpected_status_emits_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """pb_error_to_http emits a WARNING for unexpected upstream statuses (e.g. 429)."""
+        import logging
+
+        from api.utils.pb_error import pb_error_to_http
+
+        with caplog.at_level(logging.WARNING, logger="api.utils.pb_error"):
+            exc = pb_error_to_http(_make_client_response_error(429))
+
+        assert exc.status_code == 502
+        assert any("429" in record.message for record in caplog.records), (
+            f"Expected a warning mentioning '429' but got: {[r.message for r in caplog.records]}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Integration smoke: pre_validate_solver maps 404 → 404


### PR DESCRIPTION
## Summary

Adopts the `pb_error_to_http()` helper (introduced in PR #1135) at all remaining `ClientResponseError` callsites in the FastAPI backend. Previously these handlers either leaked raw PocketBase body content via `detail=str(e)` or used hand-rolled status mapping that missed 5xx → 502 translation.

## Callsites migrated

| File | Function | Old pattern |
|------|----------|-------------|
| `api/routers/scenarios.py` | `create_scenario` | `HTTPException(400, str(e))` — status ignored, detail leaks |
| `api/routers/scenarios.py` | `get_scenario` | Manual `if 404: ... else: HTTPException(400, str(e))` |
| `api/routers/scenarios.py` | `update_scenario` | Manual `if 404: ... else: HTTPException(400, str(e))` |
| `api/routers/scenarios.py` | `delete_scenario` | Manual `if 404: ... else: HTTPException(400, str(e))` |
| `api/routers/scenarios.py` | `update_scenario_assignment` | Manual `if 404: ... else: HTTPException(400, e.data)` — data leak |
| `api/routers/scenarios.py` | `solve_scenario` | Manual `if 404: ... else: HTTPException(400, str(e))` |
| `api/routers/scenarios.py` | `clear_scenario` | Manual `if 404: ... else: HTTPException(400, str(e))` |
| `api/routers/validation.py` | `validate_bunking` | Manual `if 404: ... else: HTTPException(400, str(e))` |
| `api/services/data_fetcher.py` | `fetch_session_data_v2` | `HTTPException(500, str(e))` — always 500, detail leaks |

## Intentionally unchanged (silent-fail patterns)

- `data_fetcher.py: fetch_historical_bunking` — returns `[]` on error (historical data is optional)
- `data_fetcher.py: fetch_lock_groups` — returns `{}` on error (lock groups are optional)
- `debug.py: get_pipeline_trace` — uses `getattr(e, "status", 0)` duck-typing, appropriate for its context

## Helper extension

No new status mappings added. The existing helper covers all cases seen here: 404→404, 400→400, 401/403→403, 5xx→502.

## Cleanup commits (review feedback)

- **`exc_info=True` on 4 missing sites**: `create_scenario`, `get_scenario`, `solve_scenario`, `clear_scenario` catch-all blocks now include tracebacks in server logs
- **Drop ENV-conditional 500 in `validation.py`**: Replaced `if ENV == development: raise HTTPException(500, str(e)) else: raise HTTPException(500, ...)` with bare `raise` — global handler produces safe generic response and logs full traceback; removed now-unused `os` import (ruff also dropped the unused `HTTPException` import)
- **Log-level tuning in `update_scenario_assignment`**: PB 4xx → `WARNING` (client-caused noise), PB 5xx/unknown → `ERROR + exc_info`
- **`pb_error_to_http` fallback warning**: Added `logger.warning("pb_error_to_http: unexpected upstream status %d", status)` before the 502 fallback so unexpected codes (e.g. 429 rate-limited) are visible in server logs; covered by new `caplog` test

## Test plan

27 new tests in `tests/unit/api/routers/test_pb_error_to_http_adoption.py`:
- PB 404 → HTTP 404 for each migrated callsite
- PB 500 → HTTP 502 for each migrated callsite
- Detail string does not contain raw PB body content for each callsite

1 new test in `tests/unit/api/test_pb_error_to_http.py`:
- `test_unexpected_status_emits_warning`: asserts `caplog` captures WARNING with the unexpected status code (e.g. 429)

All 3908 unit tests pass.

Closes #1137