### PR TITLE
refactor(frontend): delete dead topPriority/topPrioritySatisfied/priorityLevels

### DIFF
--- a/frontend/src/components/BunkCard.dnd.test.tsx
+++ b/frontend/src/components/BunkCard.dnd.test.tsx
@@ -52,8 +52,6 @@ vi.mock('../hooks', () => ({
       staff: { total: 0, satisfied: 0, satisfactionRate: 0 },
       parentMinOneViolation: false,
       staffUnsatisfiedAlert: false,
-      topPrioritySatisfied: false,
-      priorityLevels: [],
     }),
   }),
   useBunkRequestsFromContext: () => ({ data: {}, requestStatus: {} }),

--- a/frontend/src/components/CamperAlertSection.test.tsx
+++ b/frontend/src/components/CamperAlertSection.test.tsx
@@ -211,8 +211,6 @@ describe('CamperAlertSection', () => {
       staff: { total: 0, satisfied: 0, satisfactionRate: 0 },
       parentMinOneViolation: false,
       staffUnsatisfiedAlert: false,
-      topPrioritySatisfied: true,
-      priorityLevels: [],
     }
 
     it('produces no parent alert when only best-effort requests are unsatisfied', () => {
@@ -319,8 +317,6 @@ vi.mock('../hooks', async () => {
         staff: { total: 0, satisfied: 0, satisfactionRate: 0 },
         parentMinOneViolation: false,
         staffUnsatisfiedAlert: false,
-        topPrioritySatisfied: false,
-        priorityLevels: [] as number[],
       }),
       isLoading: false,
       error: null,
@@ -372,8 +368,6 @@ describe('CamperDetailsPanel — alert section integration', () => {
         staff: { total: 0, satisfied: 0, satisfactionRate: 0 },
         parentMinOneViolation: true,
         staffUnsatisfiedAlert: false,
-        topPrioritySatisfied: false,
-        priorityLevels: [] as number[],
       })
     )
     vi.spyOn(hooks, 'useBunkRequestContext').mockReturnValue({

--- a/frontend/src/components/CamperCard.prod.test.tsx
+++ b/frontend/src/components/CamperCard.prod.test.tsx
@@ -21,8 +21,6 @@ const emptySatisfiedInfo: SatisfiedRequestInfo = {
   staff: EMPTY_SLICE,
   parentMinOneViolation: false,
   staffUnsatisfiedAlert: false,
-  topPrioritySatisfied: false,
-  priorityLevels: [],
 }
 
 let mockSatisfiedInfo: SatisfiedRequestInfo = { ...emptySatisfiedInfo }

--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -85,8 +85,6 @@ let mockGetSatisfiedRequestInfo = vi.fn(
     staff: { total: 0, satisfied: 0, satisfactionRate: 0 },
     parentMinOneViolation: false,
     staffUnsatisfiedAlert: false,
-    topPrioritySatisfied: false,
-    priorityLevels: [] as number[],
   })
 )
 
@@ -237,8 +235,6 @@ describe('CamperDetailsPanel', () => {
         staff: { total: 0, satisfied: 0, satisfactionRate: 0 },
         parentMinOneViolation: false,
         staffUnsatisfiedAlert: false,
-        topPrioritySatisfied: false,
-        priorityLevels: [] as number[],
       })
     )
     // Default: empty responses for all collections
@@ -509,8 +505,6 @@ describe('CamperDetailsPanel', () => {
             staff: { total: 0, satisfied: 0, satisfactionRate: 0 },
             parentMinOneViolation: !oliviaPresent,
             staffUnsatisfiedAlert: false,
-            topPrioritySatisfied: oliviaPresent,
-            priorityLevels: [1],
           }
         }
       )
@@ -557,8 +551,6 @@ describe('CamperDetailsPanel', () => {
             // passed to the mock matches the fallback [Emma-only] path.
             parentMinOneViolation: true,
             staffUnsatisfiedAlert: false,
-            topPrioritySatisfied: false,
-            priorityLevels: [1],
           }
         }
       )

--- a/frontend/src/components/FloatingUnassignedBadge.prod.test.tsx
+++ b/frontend/src/components/FloatingUnassignedBadge.prod.test.tsx
@@ -48,8 +48,6 @@ vi.mock('../hooks', () => ({
       staff: { total: 0, satisfied: 0, satisfactionRate: 0 },
       parentMinOneViolation: false,
       staffUnsatisfiedAlert: false,
-      topPrioritySatisfied: false,
-      priorityLevels: [],
     }),
   }),
   useCamperHistoryContext: () => ({ getLastYearHistory: () => null }),

--- a/frontend/src/components/UnassignedCampers.test.tsx
+++ b/frontend/src/components/UnassignedCampers.test.tsx
@@ -49,8 +49,6 @@ vi.mock('../hooks', () => ({
       staff: { total: 0, satisfied: 0, satisfactionRate: 0 },
       parentMinOneViolation: false,
       staffUnsatisfiedAlert: false,
-      topPrioritySatisfied: false,
-      priorityLevels: [],
     }),
   }),
   useCamperHistoryContext: () => ({ getLastYearHistory: () => null }),

--- a/frontend/src/contexts/BunkRequestContext.ts
+++ b/frontend/src/contexts/BunkRequestContext.ts
@@ -26,8 +26,6 @@ export interface SatisfiedRequestInfo {
   staff: RequestSlice
   parentMinOneViolation: boolean
   staffUnsatisfiedAlert: boolean
-  topPrioritySatisfied: boolean
-  priorityLevels: number[]
 }
 
 interface BunkRequestContextValue {

--- a/frontend/src/utils/camperAlertUtils.test.ts
+++ b/frontend/src/utils/camperAlertUtils.test.ts
@@ -26,8 +26,6 @@ const BASE_INPUTS: CamperAlertInputs = {
     staff: EMPTY_SLICE,
     parentMinOneViolation: false,
     staffUnsatisfiedAlert: false,
-    topPrioritySatisfied: false,
-    priorityLevels: [],
   },
   lockState: 'none',
   lockGroupSize: 0,
@@ -116,8 +114,6 @@ describe('buildCamperAlerts — unsatisfied-parent-requests alert', () => {
         staff: { total: 0, satisfied: 0, satisfactionRate: 0 },
         parentMinOneViolation: false,
         staffUnsatisfiedAlert: false,
-        topPrioritySatisfied: false,
-        priorityLevels: [],
       },
     })
     expect(alerts.find((a) => a.id === 'unsatisfied-parent-requests')).toBeUndefined()

--- a/frontend/src/utils/computeSatisfiedRequestInfo.ts
+++ b/frontend/src/utils/computeSatisfiedRequestInfo.ts
@@ -35,16 +35,13 @@ const EMPTY_SLICE: RequestSlice = Object.freeze({
   satisfactionRate: 0,
 }) as RequestSlice
 
-// Frozen so the shared reference can't be mutated by any caller — the
-// `priorityLevels` array would otherwise alias across every empty return.
+// Frozen so the shared reference can't be mutated by any caller.
 export const EMPTY_SATISFIED_INFO: SatisfiedRequestInfo = Object.freeze({
   materialParent: EMPTY_SLICE,
   bestEffortParent: EMPTY_SLICE,
   staff: EMPTY_SLICE,
   parentMinOneViolation: false,
   staffUnsatisfiedAlert: false,
-  topPrioritySatisfied: false,
-  priorityLevels: Object.freeze([]) as readonly number[] as number[],
 }) as SatisfiedRequestInfo
 
 /**

--- a/frontend/src/utils/computeSlicesFromPredicate.ts
+++ b/frontend/src/utils/computeSlicesFromPredicate.ts
@@ -30,13 +30,11 @@ export function computeSlicesFromPredicate(
   let bestSat = 0
   let staffTotal = 0
   let staffSat = 0
-  const satisfiedRequests: BunkRequest[] = []
 
   for (const req of personRequests) {
     // §15.1 resolved-only boundary
     if (req.status !== 'resolved') continue
     const sat = isSatisfied(req)
-    if (sat) satisfiedRequests.push(req)
 
     if (req.source_field === 'bunk_with') {
       materialTotal++
@@ -61,23 +59,11 @@ export function computeSlicesFromPredicate(
     satisfactionRate: total === 0 ? 0 : satisfied / total,
   })
 
-  // NOTE: topPriority is computed from the UNFILTERED personRequests (any
-  // status), while satisfiedRequests holds only resolved+satisfied rows. This
-  // preserves Stage 3a's verbatim behavior — see #1090 for follow-up on whether
-  // this should be resolved-only.
-  const topPriority = personRequests.reduce((m, r) => Math.max(m, r.priority ?? 0), 0)
-  const topPrioritySatisfied = satisfiedRequests.some((r) => (r.priority ?? 0) === topPriority)
-  const priorityLevels = [...new Set(satisfiedRequests.map((r) => r.priority ?? 0))].sort(
-    (a, b) => b - a
-  )
-
   return {
     materialParent: slice(materialTotal, materialSat),
     bestEffortParent: slice(bestTotal, bestSat),
     staff: slice(staffTotal, staffSat),
     parentMinOneViolation: materialTotal >= 1 && materialSat === 0,
     staffUnsatisfiedAlert: staffTotal >= 1 && staffSat === 0,
-    topPrioritySatisfied,
-    priorityLevels,
   }
 }


### PR DESCRIPTION
## Summary

- `topPrioritySatisfied`, `priorityLevels`, and the local `topPriority` variable had **zero production `.tsx` consumers** — they existed only as boilerplate props in test fixtures (never read by any rendered component)
- Removed from: `SatisfiedRequestInfo` type, `computeSlicesFromPredicate` (computation + return), `EMPTY_SATISFIED_INFO` default object, and 7 test files that carried them as stubs
- The per-row `request.priority` field on individual `BunkRequest` rows is **unaffected** — only the aggregate derived values (`topPriority`/`topPrioritySatisfied`/`priorityLevels`) are deleted
- This sidesteps the (a)/(b) decision in #1090 entirely: rather than choosing between "resolved-only" vs "all-status" semantics for a value nothing reads, we just delete the buggy computation

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run` — 3603 passing, 0 failing (no regressions)
- [x] Pre-push verification — prettier, eslint, tsc, vitest all PASS

Closes #1090

🤖 Generated with [Claude Code](https://claude.com/claude-code)