### PR TITLE
fix(ci): unbreak CD heredoc — escape ${...} in comment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -480,7 +480,7 @@ jobs:
         CAMPMINDER_SEASON_ID=
         SUB_BUNKING=
         DOMAIN_NAME=
-        # Required by docker-compose.yml's caddy service (${ADMIN_ALLOWLIST:?...}).
+        # Required by docker-compose.yml's caddy service compose-fail-loud guard.
         # CI test stack runs in isolation; "0.0.0.0/0 ::/0" explicitly opts into open
         # so the gate isn't tested here (the gate is for prod, where the var is set
         # to home/VPN ranges).


### PR DESCRIPTION
## Summary

CD on main is currently failing because of a shell-expansion trap in the heredoc that builds `.env.ci`. Self-inflicted in #1139.

## Root cause

`.github/workflows/cd.yml` writes `.env.ci` via an **unquoted** heredoc (`<< EOF`, not `<< 'EOF'`) so `${GH_RUN_ID}` interpolates correctly into the `COMPOSE_PROJECT_NAME` line. A comment I added in #1139 contained the literal text `${ADMIN_ALLOWLIST:?...}` — bash interpolated that as a real parameter expansion with the `:?` fail-loud directive, which fired because `ADMIN_ALLOWLIST` isn't set in the GHA runner env.

Net effect: heredoc never wrote `.env.ci`, so `docker compose --env-file .env.ci ...` then tripped its own `${ADMIN_ALLOWLIST:?...}` guard inside `docker-compose.yml` and CD failed.

## Fix

One-line: rephrase the comment to drop `${...}` syntax. The heredoc must stay unquoted because `GH_RUN_ID` interpolation is needed.

## Test plan

- [ ] CI passes (commitlint, etc.)
- [ ] CD's "Create CI environment file" step succeeds
- [ ] CD's "Start test stack" step interpolates `ADMIN_ALLOWLIST` cleanly from `.env.ci`
- [ ] Image `sha-<this commit>` and `latest` tags push to ghcr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
