### PR TITLE
refactor(api): stop emitting sibling edges in graph responses

### DIFF
--- a/api/routers/social_graph.py
+++ b/api/routers/social_graph.py
@@ -520,17 +520,6 @@ async def get_bunk_social_graph(
         # them for a 0.25 confidence boost), but must not reach the frontend.
         edges = []
 
-        # Debug: log edge counts by type
-        edge_type_counts = {"request": 0, "sibling": 0, "both": 0}
-        for source, target, data in bunk_graph.edges(data=True):
-            if data.get("secondary_type"):
-                edge_type_counts["both"] += 1
-            else:
-                edge_type_counts[data.get("edge_type", "unknown")] = (
-                    edge_type_counts.get(data.get("edge_type", "unknown"), 0) + 1
-                )
-        logger.info(f"Edge type counts in bunk graph: {edge_type_counts}")
-
         for source, target, data in bunk_graph.edges(data=True):
             # Use reciprocal flag from edge data (set during graph building)
             is_reciprocal = data.get("reciprocal", False)
@@ -542,6 +531,7 @@ async def get_bunk_social_graph(
             # Handle edges with both a primary type and a secondary_type.
             if data.get("secondary_type"):
                 primary_type = data.get("edge_type", "request")
+                is_request = primary_type == "request"
                 secondary_type = data.get("secondary_type")
 
                 # Add primary edge (always)
@@ -552,9 +542,9 @@ async def get_bunk_social_graph(
                         weight=data.get("weight", 1.0),
                         type=primary_type,
                         reciprocal=is_reciprocal,
-                        confidence=data.get("confidence") if primary_type == "request" else None,
-                        priority=data.get("priority") if primary_type == "request" else None,
-                        request_type=data.get("request_type") if primary_type == "request" else None,
+                        confidence=data.get("confidence") if is_request else None,
+                        priority=data.get("priority") if is_request else None,
+                        request_type=data.get("request_type") if is_request else None,
                     )
                 )
 

--- a/api/routers/social_graph.py
+++ b/api/routers/social_graph.py
@@ -249,6 +249,11 @@ async def get_session_social_graph(
             # Count edge types for metadata
             edge_type_counts[edge_type] = edge_type_counts.get(edge_type, 0) + 1
 
+            # Sibling edges stay in the in-memory graph (name-resolution pipeline
+            # uses them for a confidence boost), but must not reach the frontend.
+            if edge_type == "sibling":
+                continue
+
             # Filter by edge type if specified
             if allowed_edge_types and edge_type not in allowed_edge_types:
                 continue
@@ -518,9 +523,10 @@ async def get_bunk_social_graph(
                 )
             )
 
-        # Convert edges - handle edges that may have both request and sibling relationships
+        # Convert edges - handle edges that may have both request and sibling relationships.
+        # Sibling edges stay in the in-memory bunk_graph (name-resolution pipeline uses
+        # them for a 0.25 confidence boost), but must not reach the frontend.
         edges = []
-        processed_edges = set()  # Track processed edges to avoid duplication
 
         # Debug: log edge counts by type
         edge_type_counts = {"request": 0, "sibling": 0, "both": 0}
@@ -537,23 +543,16 @@ async def get_bunk_social_graph(
             # Use reciprocal flag from edge data (set during graph building)
             is_reciprocal = data.get("reciprocal", False)
 
-            # For sibling edges, only process once (they're always bidirectional)
+            # Sibling-only edges: skip entirely — they must not reach the frontend.
             if data.get("edge_type") == "sibling":
-                edge_key = tuple(sorted([source, target]))
-                if edge_key in processed_edges:
-                    continue
-                processed_edges.add(edge_key)
+                continue
 
-            # Handle edges with both sibling and request relationships
+            # Handle edges with both a primary type and a secondary_type.
             if data.get("secondary_type"):
-                # This edge has both types - create two separate edges for frontend
                 primary_type = data.get("edge_type", "request")
                 secondary_type = data.get("secondary_type")
-                logger.info(
-                    f"Processing edge with both types: {source}->{target}, primary={primary_type}, secondary={secondary_type}"
-                )
 
-                # Add primary edge
+                # Add primary edge (always)
                 edges.append(
                     SocialGraphEdge(
                         source=source,
@@ -567,23 +566,8 @@ async def get_bunk_social_graph(
                     )
                 )
 
-                # Add secondary edge (only if it's not a sibling that we already processed)
-                if secondary_type == "sibling":
-                    sec_edge_key = tuple(sorted([source, target]))
-                    if sec_edge_key not in processed_edges:
-                        processed_edges.add(sec_edge_key)
-                        edges.append(
-                            SocialGraphEdge(
-                                source=source,
-                                target=target,
-                                weight=1.5,
-                                type=secondary_type,
-                                reciprocal=True,  # Siblings are always reciprocal
-                                confidence=None,
-                                priority=None,
-                            )
-                        )
-                else:
+                # Secondary sibling edges are also filtered out at the response boundary.
+                if secondary_type != "sibling":
                     edges.append(
                         SocialGraphEdge(
                             source=source,
@@ -596,11 +580,8 @@ async def get_bunk_social_graph(
                         )
                     )
             else:
-                # Single type edge
+                # Single-type, non-sibling edge
                 edge_type = data.get("edge_type", "request")
-                # Siblings are always reciprocal, otherwise use the flag from edge data
-                if edge_type == "sibling":
-                    is_reciprocal = True
                 edges.append(
                     SocialGraphEdge(
                         source=source,

--- a/api/routers/social_graph.py
+++ b/api/routers/social_graph.py
@@ -491,15 +491,7 @@ async def get_bunk_social_graph(
                     first_year_campers.add(node_id)
                     logger.info(f"Person {node_id} ({name}) is a first-year camper (years_at_camp={years_at_camp})")
 
-                # Log grade info for debugging
-                if "mila" in name.lower() and "cowles" in name.lower():
-                    logger.info(
-                        f"MILA COWLES DEBUG - Person {node_id}: grade={grade}, years_at_camp={years_at_camp}, all fields: {vars(person)}"
-                    )
-                else:
-                    logger.debug(
-                        f"Bunk graph - Person {node_id} ({name}): grade={grade}, years_at_camp={years_at_camp}"
-                    )
+                logger.debug(f"Bunk graph - Person {node_id} ({name}): grade={grade}, years_at_camp={years_at_camp}")
             except Exception as e:
                 name = f"Person {node_id}"
                 grade = None

--- a/api/schemas/social_graph.py
+++ b/api/schemas/social_graph.py
@@ -36,7 +36,10 @@ class SocialGraphEdge(BaseModel):
     source: int
     target: int
     weight: float
-    type: str  # 'request', 'historical', 'sibling', 'classmate_city', 'classmate_state'
+    type: str  # 'request', 'historical', 'classmate_city', 'classmate_state'
+    # Note: 'sibling' is intentionally excluded — sibling edges remain in the
+    # in-memory graph for name-resolution (confidence boost) but are filtered
+    # at the API response boundary before reaching the frontend.
     reciprocal: bool = False
     confidence: float | None = None  # AI confidence score for request edges
     priority: int | None = None  # Priority level for request edges

--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -367,11 +367,9 @@ export default function BunkSocialGraphModal({
 
     cyRef.current = cy
 
-    // Convert graph data to Cytoscape format. Sibling edges no longer
-    // render here (see follow-up issue) — filter once and use the result
-    // for both the degree calculation and the edge rendering pass so the
-    // node status agrees with the visible graph.
-    const visibleGraphEdges = graphData.edges.filter((edge) => edge.type !== 'sibling')
+    // Convert graph data to Cytoscape format. Sibling edges are filtered at
+    // the API response boundary (#1094) and will never appear here.
+    const visibleGraphEdges = graphData.edges
 
     const elements: cytoscape.ElementDefinition[] = []
     const nodeDegrees: Record<string, number> = {}

--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -367,15 +367,13 @@ export default function BunkSocialGraphModal({
 
     cyRef.current = cy
 
-    // Convert graph data to Cytoscape format. Sibling edges are filtered at
-    // the API response boundary (#1094) and will never appear here.
-    const visibleGraphEdges = graphData.edges
-
+    // Build Cytoscape element definitions. Sibling edges are filtered at the
+    // API response boundary (#1094) and will never appear here.
     const elements: cytoscape.ElementDefinition[] = []
     const nodeDegrees: Record<string, number> = {}
 
     // Calculate node degrees first
-    visibleGraphEdges.forEach((edge) => {
+    graphData.edges.forEach((edge) => {
       const sourceId = `node-${edge.source}`
       const targetId = `node-${edge.target}`
       nodeDegrees[sourceId] = (nodeDegrees[sourceId] ?? 0) + 1
@@ -428,7 +426,7 @@ export default function BunkSocialGraphModal({
     // Process request edges. The backend sends both directions of mutual
     // requests; we keep both so reciprocal source-arrows render.
     let edgeIndex = 0
-    visibleGraphEdges.forEach((edge) => {
+    graphData.edges.forEach((edge) => {
       elements.push({
         group: 'edges',
         data: {

--- a/frontend/src/components/graph/EdgeFilters.test.tsx
+++ b/frontend/src/components/graph/EdgeFilters.test.tsx
@@ -17,7 +17,5 @@ describe('getEdgeLabel utility', () => {
   it('falls back to the raw type for unknown edge types', () => {
     expect(getEdgeLabel('unknown')).toBe('unknown')
     expect(getEdgeLabel('custom')).toBe('custom')
-    // Sibling is intentionally not labeled — the type is removed.
-    expect(getEdgeLabel('sibling')).toBe('sibling')
   })
 })

--- a/frontend/src/components/graph/cytoscapeStyles.test.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.test.ts
@@ -347,7 +347,6 @@ describe('createGraphElements', () => {
     const { edges } = createGraphElements(mockNodes, inScope, mockBunksData, {
       request: true,
       historical: true,
-      sibling: true,
       school: true,
       cross_scope: true,
     })
@@ -358,7 +357,7 @@ describe('createGraphElements', () => {
       mockNodes,
       inScope,
       mockBunksData,
-      { request: true, historical: true, sibling: true, school: true, cross_scope: true },
+      { request: true, historical: true, school: true, cross_scope: true },
       cross,
       ghostNodes
     )

--- a/frontend/src/components/graph/cytoscapeStyles.test.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.test.ts
@@ -302,11 +302,12 @@ describe('createGraphElements', () => {
     expect(out[0]?.data.request_type).toBe('not_bunk_with')
   })
 
-  it('filters out sibling edges defensively even if the API still emits them', () => {
-    const edges: GraphEdgeData[] = [
-      { source: 1, target: 2, type: 'sibling', priority: 0, confidence: 1, reciprocal: false },
-      reqEdge(1, 2, 'bunk_with'),
-    ]
+  it('sibling edges are not emitted by the API (#1094) and are not handled by createGraphElements', () => {
+    // Sibling edges are stripped at the API response boundary (#1094) —
+    // they never arrive in edgeData. The client-side defensive filter that
+    // used to exist here has been removed; this test documents the new contract:
+    // if only non-sibling edges are present, createGraphElements renders them.
+    const edges: GraphEdgeData[] = [reqEdge(1, 2, 'bunk_with')]
     const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, { request: true })
     expect(out).toHaveLength(1)
     expect(out[0]?.data.edge_type).toBe('request')

--- a/frontend/src/components/graph/cytoscapeStyles.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.ts
@@ -450,8 +450,9 @@ export function createGraphElements(
   // Sibling edges are filtered at the API response boundary (#1094) and will
   // never appear in edgeData here — no client-side defensive filter needed.
   const visibleEdges = edgeData.filter((edge) => {
-    const edgeType = edge.type as keyof ShowEdgesSettings
-    return showEdges[edgeType] !== false
+    // Unknown edge types default to visible; sibling is filtered server-side (#1094)
+    const setting = showEdges[edge.type as keyof ShowEdgesSettings]
+    return setting !== false
   })
 
   // Group edges by unordered pair so we can detect same-type reciprocal pairs

--- a/frontend/src/components/graph/cytoscapeStyles.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.ts
@@ -447,11 +447,9 @@ export function createGraphElements(
   }))
 
   // Filter and create edges based on visibility settings.
-  // Sibling edges are stripped client-side as a defensive measure — the
-  // sibling edge type is being removed end-to-end (see follow-up issue);
-  // this filter unblocks the visual change while the API is updated.
+  // Sibling edges are filtered at the API response boundary (#1094) and will
+  // never appear in edgeData here — no client-side defensive filter needed.
   const visibleEdges = edgeData.filter((edge) => {
-    if (edge.type === 'sibling') return false
     const edgeType = edge.type as keyof ShowEdgesSettings
     return showEdges[edgeType] !== false
   })

--- a/frontend/src/hooks/graph/useCytoscapeGraph.test.ts
+++ b/frontend/src/hooks/graph/useCytoscapeGraph.test.ts
@@ -45,7 +45,6 @@ describe('useCytoscapeGraph', () => {
         showLabels: true,
         showEdges: {
           request: true,
-          sibling: true,
         },
         showBubbles: false,
       }

--- a/frontend/src/hooks/graph/useCytoscapeGraph.ts
+++ b/frontend/src/hooks/graph/useCytoscapeGraph.ts
@@ -9,7 +9,6 @@ export interface GraphInitConfig {
   showLabels: boolean
   showEdges: {
     request: boolean
-    sibling: boolean
   }
   showBubbles: boolean
 }

--- a/frontend/src/types/graph.ts
+++ b/frontend/src/types/graph.ts
@@ -28,6 +28,9 @@ export interface GraphEdge {
   source: number
   target: number
   weight: number
+  /** Edge type. Valid values: 'request' | 'historical' | 'classmate_city' | 'classmate_state' | 'bundled'.
+   *  'sibling' is intentionally excluded: sibling edges are filtered at the API
+   *  response boundary (#1094) and will never appear in graph API responses. */
   type: string
   reciprocal: boolean
   request_type?: string // 'bunk_with' | 'not_bunk_with' for type='request' edges

--- a/tests/unit/api/routers/test_sibling_edge_filter.py
+++ b/tests/unit/api/routers/test_sibling_edge_filter.py
@@ -13,7 +13,7 @@ resolution pipeline. These tests only assert on the HTTP response payload.
 from __future__ import annotations
 
 import sys
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -208,7 +208,9 @@ PERSON_A = 101
 PERSON_B = 102
 
 
-def _make_pb_collection_mock(bunk_record: MagicMock, person_a: MagicMock, person_b: MagicMock):
+def _make_pb_collection_mock(
+    bunk_record: MagicMock, person_a: MagicMock, person_b: MagicMock
+) -> Callable[[str], MagicMock]:
     """Build a `pb.collection(name)` side_effect that dispatches by collection name."""
 
     def _pb_collection(name: str) -> MagicMock:

--- a/tests/unit/api/routers/test_sibling_edge_filter.py
+++ b/tests/unit/api/routers/test_sibling_edge_filter.py
@@ -208,21 +208,17 @@ PERSON_A = 101
 PERSON_B = 102
 
 
-@pytest.fixture
-def bunk_graph_client_with_siblings() -> Generator[TestClient]:
-    """TestClient where the mock bunk graph contains both request and sibling edges."""
-    fake_bunk = _make_bunk_record(BUNK_CM_ID)
-    person_a = _make_person_record(PERSON_A, "Emma", "Johnson")
-    person_b = _make_person_record(PERSON_B, "Liam", "Garcia")
+def _make_pb_collection_mock(bunk_record: MagicMock, person_a: MagicMock, person_b: MagicMock):
+    """Build a `pb.collection(name)` side_effect that dispatches by collection name."""
 
     def _pb_collection(name: str) -> MagicMock:
         col = MagicMock()
         if name == "bunks":
-            col.get_first_list_item.return_value = fake_bunk
+            col.get_first_list_item.return_value = bunk_record
         elif name == "persons":
 
             def _get_first(filter_str: str, **_kwargs: object) -> MagicMock:
-                return person_a if str(PERSON_A) in filter_str else person_b
+                return person_a if str(person_a.cm_id) in filter_str else person_b
 
             col.get_first_list_item.side_effect = _get_first
         else:
@@ -230,18 +226,15 @@ def bunk_graph_client_with_siblings() -> Generator[TestClient]:
             col.get_first_list_item.return_value = MagicMock()
         return col
 
-    mock_pb = MagicMock()
-    mock_pb.collection.side_effect = _pb_collection
+    return _pb_collection
 
-    fake_graph = _build_bunk_graph_with_sibling_and_request([PERSON_A, PERSON_B])
 
-    mock_builder = MagicMock()
-    mock_builder.build_bunk_graph.return_value = fake_graph
+def _make_bunk_test_client(mock_pb: MagicMock, mock_builder: MagicMock) -> Generator[TestClient]:
+    """Build a TestClient with social_graph router and standard bunk-graph mocks patched in."""
+    from api.routers.social_graph import router
 
     mock_cache = MagicMock()
     mock_cache.get_bunk_graph.return_value = None
-
-    from api.routers.social_graph import router
 
     app = FastAPI()
     app.include_router(router)
@@ -253,6 +246,22 @@ def bunk_graph_client_with_siblings() -> Generator[TestClient]:
         patch("api.routers.social_graph.OptimizedSocialGraphBuilder", return_value=mock_builder),
     ):
         yield TestClient(app)
+
+
+@pytest.fixture
+def bunk_graph_client_with_siblings() -> Generator[TestClient]:
+    """TestClient where the mock bunk graph contains both request and sibling edges."""
+    fake_bunk = _make_bunk_record(BUNK_CM_ID)
+    person_a = _make_person_record(PERSON_A, "Emma", "Johnson")
+    person_b = _make_person_record(PERSON_B, "Liam", "Garcia")
+
+    mock_pb = MagicMock()
+    mock_pb.collection.side_effect = _make_pb_collection_mock(fake_bunk, person_a, person_b)
+
+    mock_builder = MagicMock()
+    mock_builder.build_bunk_graph.return_value = _build_bunk_graph_with_sibling_and_request([PERSON_A, PERSON_B])
+
+    yield from _make_bunk_test_client(mock_pb, mock_builder)
 
 
 @pytest.fixture
@@ -262,44 +271,13 @@ def bunk_graph_client_with_secondary_sibling() -> Generator[TestClient]:
     person_a = _make_person_record(PERSON_A, "Olivia", "Chen")
     person_b = _make_person_record(PERSON_B, "Noah", "Williams")
 
-    def _pb_collection(name: str) -> MagicMock:
-        col = MagicMock()
-        if name == "bunks":
-            col.get_first_list_item.return_value = fake_bunk
-        elif name == "persons":
-
-            def _get_first(filter_str: str, **_kwargs: object) -> MagicMock:
-                return person_a if str(PERSON_A) in filter_str else person_b
-
-            col.get_first_list_item.side_effect = _get_first
-        else:
-            col.get_list.return_value = MagicMock(items=[])
-            col.get_first_list_item.return_value = MagicMock()
-        return col
-
     mock_pb = MagicMock()
-    mock_pb.collection.side_effect = _pb_collection
-
-    fake_graph = _build_bunk_graph_with_secondary_sibling([PERSON_A, PERSON_B])
+    mock_pb.collection.side_effect = _make_pb_collection_mock(fake_bunk, person_a, person_b)
 
     mock_builder = MagicMock()
-    mock_builder.build_bunk_graph.return_value = fake_graph
+    mock_builder.build_bunk_graph.return_value = _build_bunk_graph_with_secondary_sibling([PERSON_A, PERSON_B])
 
-    mock_cache = MagicMock()
-    mock_cache.get_bunk_graph.return_value = None
-
-    from api.routers.social_graph import router
-
-    app = FastAPI()
-    app.include_router(router)
-    app.dependency_overrides[get_current_user] = _mock_admin_user
-
-    with (
-        patch("api.routers.social_graph.pb", mock_pb),
-        patch("api.routers.social_graph.graph_cache", mock_cache),
-        patch("api.routers.social_graph.OptimizedSocialGraphBuilder", return_value=mock_builder),
-    ):
-        yield TestClient(app)
+    yield from _make_bunk_test_client(mock_pb, mock_builder)
 
 
 @pytest.fixture

--- a/tests/unit/api/routers/test_sibling_edge_filter.py
+++ b/tests/unit/api/routers/test_sibling_edge_filter.py
@@ -1,0 +1,477 @@
+"""#1094: sibling edges must be filtered from graph API responses.
+
+TDD tests — written first, verified failing before implementation.
+
+Scope:
+- /api/bunks/{id}/social-graph  → no sibling edges in response
+- /api/sessions/{id}/social-graph → no sibling edges in response
+
+Graph builders are NOT touched — sibling edges remain in-memory for the
+resolution pipeline. These tests only assert on the HTTP response payload.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import networkx as nx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+test_dir = Path(__file__).resolve().parent
+project_root = test_dir.parent.parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from bunking.auth_middleware import AuthUser, get_current_user
+
+
+def _mock_admin_user() -> AuthUser:
+    return AuthUser(
+        username="TestAdmin",
+        email="test@example.com",
+        display_name="Test Admin",
+        groups=["admin"],
+        is_admin=True,
+    )
+
+
+def _make_person_record(cm_id: int, first_name: str, last_name: str, grade: int = 7) -> MagicMock:
+    record = MagicMock()
+    record.cm_id = cm_id
+    record.first_name = first_name
+    record.last_name = last_name
+    record.grade = grade
+    record.years_at_camp = 2
+    return record
+
+
+def _make_bunk_record(bunk_cm_id: int, name: str = "Eagle Cabin") -> MagicMock:
+    record = MagicMock()
+    record.cm_id = bunk_cm_id
+    record.name = name
+    return record
+
+
+def _build_bunk_graph_with_sibling_and_request(person_ids: list[int]) -> nx.DiGraph:
+    """Graph that mirrors what the real builder produces for bunk members who are siblings.
+
+    The real social_graph_builder.py uses a single DiGraph, so when two nodes have
+    both a request edge AND a sibling relationship, the builder encodes both on one
+    edge via secondary_type.  This fixture uses the same approach:
+
+    - Edge A→B: edge_type='request', secondary_type=None  (pure request)
+    - Edge B→A: edge_type='sibling', secondary_type=None  (pure sibling — must be filtered)
+
+    This exercises the single-type sibling-skip branch in the bunk-graph serializer.
+    """
+    g = nx.DiGraph()
+    for pid in person_ids:
+        g.add_node(
+            pid,
+            centrality=0.5,
+            clustering=0.3,
+            community=0,
+            parent_satisfaction_status="satisfied",
+            staff_satisfaction_status="no_requests",
+            satisfaction_status="satisfied",
+            last_year_session=None,
+            last_year_bunk=None,
+        )
+
+    if len(person_ids) >= 2:
+        a, b = person_ids[0], person_ids[1]
+        # Forward bunk request edge — must survive the filter
+        g.add_edge(
+            a,
+            b,
+            edge_type="request",
+            weight=1.0,
+            reciprocal=False,
+            confidence=0.9,
+            priority=1,
+            request_type="bunk_with",
+            secondary_type=None,
+        )
+        # Reverse sibling edge — must be stripped at the response boundary.
+        # The builder adds sibling edges bidirectionally when no request exists in
+        # that direction; here we place it as B→A so it doesn't overwrite A→B.
+        g.add_edge(
+            b,
+            a,
+            edge_type="sibling",
+            weight=1.5,
+            reciprocal=True,
+            confidence=None,
+            priority=None,
+            request_type=None,
+            secondary_type=None,
+        )
+
+    return g
+
+
+def _build_bunk_graph_with_secondary_sibling(person_ids: list[int]) -> nx.DiGraph:
+    """Graph with an edge whose primary type is 'request' but secondary_type is 'sibling'.
+
+    The bunk-graph code path has a special branch for edges with secondary_type.
+    This tests that secondary sibling edges are also stripped.
+    """
+    g = nx.DiGraph()
+    for pid in person_ids:
+        g.add_node(
+            pid,
+            centrality=0.5,
+            clustering=0.3,
+            community=0,
+            parent_satisfaction_status="no_requests",
+            staff_satisfaction_status="no_requests",
+            satisfaction_status="no_requests",
+            last_year_session=None,
+            last_year_bunk=None,
+        )
+
+    if len(person_ids) >= 2:
+        a, b = person_ids[0], person_ids[1]
+        # Edge that carries BOTH request and sibling info — tests the secondary_type branch
+        g.add_edge(
+            a,
+            b,
+            edge_type="request",
+            weight=1.0,
+            reciprocal=False,
+            confidence=0.8,
+            priority=2,
+            request_type="bunk_with",
+            secondary_type="sibling",  # <- the secondary sibling that must be filtered
+        )
+
+    return g
+
+
+def _build_session_graph_with_sibling(person_ids: list[int]) -> nx.DiGraph:
+    """Minimal session-level graph with a sibling edge and a request edge."""
+    g = nx.DiGraph()
+    for pid in person_ids:
+        g.add_node(
+            pid,
+            centrality=0.5,
+            clustering=0.3,
+            community=0,
+            bunk_cm_id=9001,
+            satisfaction_status="satisfied",
+            parent_satisfaction_status="satisfied",
+            staff_satisfaction_status="no_requests",
+            name=f"Person {pid}",
+            grade=7,
+        )
+
+    if len(person_ids) >= 2:
+        a, b = person_ids[0], person_ids[1]
+        g.add_edge(
+            a,
+            b,
+            edge_type="request",
+            weight=1.0,
+            reciprocal=False,
+            confidence=0.85,
+            priority=1,
+            request_type="bunk_with",
+            metadata={},
+        )
+        g.add_edge(
+            b,
+            a,
+            edge_type="sibling",
+            weight=1.5,
+            reciprocal=True,
+            confidence=None,
+            priority=None,
+            request_type=None,
+            metadata={},
+        )
+
+    return g
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+BUNK_CM_ID = 9001
+SESSION_CM_ID = 5001
+YEAR = 2026
+PERSON_A = 101
+PERSON_B = 102
+
+
+@pytest.fixture
+def bunk_graph_client_with_siblings() -> Generator[TestClient]:
+    """TestClient where the mock bunk graph contains both request and sibling edges."""
+    fake_bunk = _make_bunk_record(BUNK_CM_ID)
+    person_a = _make_person_record(PERSON_A, "Emma", "Johnson")
+    person_b = _make_person_record(PERSON_B, "Liam", "Garcia")
+
+    def _pb_collection(name: str) -> MagicMock:
+        col = MagicMock()
+        if name == "bunks":
+            col.get_first_list_item.return_value = fake_bunk
+        elif name == "persons":
+
+            def _get_first(filter_str: str, **_kwargs: object) -> MagicMock:
+                return person_a if str(PERSON_A) in filter_str else person_b
+
+            col.get_first_list_item.side_effect = _get_first
+        else:
+            col.get_list.return_value = MagicMock(items=[])
+            col.get_first_list_item.return_value = MagicMock()
+        return col
+
+    mock_pb = MagicMock()
+    mock_pb.collection.side_effect = _pb_collection
+
+    fake_graph = _build_bunk_graph_with_sibling_and_request([PERSON_A, PERSON_B])
+
+    mock_builder = MagicMock()
+    mock_builder.build_bunk_graph.return_value = fake_graph
+
+    mock_cache = MagicMock()
+    mock_cache.get_bunk_graph.return_value = None
+
+    from api.routers.social_graph import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = _mock_admin_user
+
+    with (
+        patch("api.routers.social_graph.pb", mock_pb),
+        patch("api.routers.social_graph.graph_cache", mock_cache),
+        patch("api.routers.social_graph.OptimizedSocialGraphBuilder", return_value=mock_builder),
+    ):
+        yield TestClient(app)
+
+
+@pytest.fixture
+def bunk_graph_client_with_secondary_sibling() -> Generator[TestClient]:
+    """TestClient where the mock bunk graph has an edge with secondary_type='sibling'."""
+    fake_bunk = _make_bunk_record(BUNK_CM_ID)
+    person_a = _make_person_record(PERSON_A, "Olivia", "Chen")
+    person_b = _make_person_record(PERSON_B, "Noah", "Williams")
+
+    def _pb_collection(name: str) -> MagicMock:
+        col = MagicMock()
+        if name == "bunks":
+            col.get_first_list_item.return_value = fake_bunk
+        elif name == "persons":
+
+            def _get_first(filter_str: str, **_kwargs: object) -> MagicMock:
+                return person_a if str(PERSON_A) in filter_str else person_b
+
+            col.get_first_list_item.side_effect = _get_first
+        else:
+            col.get_list.return_value = MagicMock(items=[])
+            col.get_first_list_item.return_value = MagicMock()
+        return col
+
+    mock_pb = MagicMock()
+    mock_pb.collection.side_effect = _pb_collection
+
+    fake_graph = _build_bunk_graph_with_secondary_sibling([PERSON_A, PERSON_B])
+
+    mock_builder = MagicMock()
+    mock_builder.build_bunk_graph.return_value = fake_graph
+
+    mock_cache = MagicMock()
+    mock_cache.get_bunk_graph.return_value = None
+
+    from api.routers.social_graph import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = _mock_admin_user
+
+    with (
+        patch("api.routers.social_graph.pb", mock_pb),
+        patch("api.routers.social_graph.graph_cache", mock_cache),
+        patch("api.routers.social_graph.OptimizedSocialGraphBuilder", return_value=mock_builder),
+    ):
+        yield TestClient(app)
+
+
+@pytest.fixture
+def session_graph_client_with_siblings() -> Generator[TestClient]:
+    """TestClient where the mock session graph contains a sibling edge."""
+    person_a = _make_person_record(PERSON_A, "Samuel", "Johnson")
+    person_b = _make_person_record(PERSON_B, "Riley", "Sam")
+
+    def _pb_collection(name: str) -> MagicMock:
+        col = MagicMock()
+        if name == "bunk_requests":
+            result = MagicMock()
+            result.total_items = 1
+            col.get_list.return_value = result
+        elif name == "persons":
+
+            def _get_first(filter_str: str, **_kwargs: object) -> MagicMock:
+                return person_a if str(PERSON_A) in filter_str else person_b
+
+            col.get_first_list_item.side_effect = _get_first
+        else:
+            col.get_list.return_value = MagicMock(items=[], total_items=0)
+            col.get_first_list_item.return_value = MagicMock()
+        return col
+
+    mock_pb = MagicMock()
+    mock_pb.collection.side_effect = _pb_collection
+
+    fake_graph = _build_session_graph_with_sibling([PERSON_A, PERSON_B])
+
+    mock_builder = MagicMock()
+    mock_builder.build_social_network.return_value = fake_graph
+
+    mock_cache = MagicMock()
+    mock_cache.get_session_graph.return_value = None
+
+    from api.routers.social_graph import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = _mock_admin_user
+
+    with (
+        patch("api.routers.social_graph.pb", mock_pb),
+        patch("api.routers.social_graph.graph_cache", mock_cache),
+        patch("api.routers.social_graph.OptimizedSocialGraphBuilder", return_value=mock_builder),
+    ):
+        yield TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBunkGraphSiblingEdgeFilter:
+    """#1094: /api/bunks/{id}/social-graph must not emit sibling edges."""
+
+    def test_sibling_edges_absent_from_bunk_graph_response(self, bunk_graph_client_with_siblings: TestClient) -> None:
+        """Bunk graph response must contain zero edges with type='sibling'.
+
+        Even when the underlying NetworkX graph carries sibling edges
+        (required for name-resolution confidence boost), the serializer
+        must strip them before sending to the frontend.
+        """
+        response = bunk_graph_client_with_siblings.get(
+            f"/api/bunks/{BUNK_CM_ID}/social-graph",
+            params={"session_cm_id": SESSION_CM_ID, "year": YEAR},
+        )
+
+        assert response.status_code == 200, f"Unexpected status: {response.status_code}\n{response.text}"
+
+        payload = response.json()
+        edges = payload.get("edges", [])
+
+        sibling_edges = [e for e in edges if e.get("type") == "sibling"]
+        assert sibling_edges == [], (
+            f"Bunk graph response must not include sibling edges, but found {len(sibling_edges)}: {sibling_edges}"
+        )
+
+    def test_request_edges_still_present_in_bunk_graph_response(
+        self, bunk_graph_client_with_siblings: TestClient
+    ) -> None:
+        """Non-sibling edges (e.g. request) must still appear in the response."""
+        response = bunk_graph_client_with_siblings.get(
+            f"/api/bunks/{BUNK_CM_ID}/social-graph",
+            params={"session_cm_id": SESSION_CM_ID, "year": YEAR},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        edges = payload.get("edges", [])
+
+        request_edges = [e for e in edges if e.get("type") == "request"]
+        assert len(request_edges) >= 1, (
+            "At least one request edge must remain in the bunk graph response — only sibling edges should be stripped"
+        )
+
+    def test_secondary_sibling_edges_absent_from_bunk_graph_response(
+        self, bunk_graph_client_with_secondary_sibling: TestClient
+    ) -> None:
+        """Edges emitted with secondary_type='sibling' must also be filtered out.
+
+        The bunk-graph serializer has a special branch for edges that carry
+        both a primary type and a secondary_type. When secondary_type='sibling',
+        that secondary edge must not appear in the response.
+        """
+        response = bunk_graph_client_with_secondary_sibling.get(
+            f"/api/bunks/{BUNK_CM_ID}/social-graph",
+            params={"session_cm_id": SESSION_CM_ID, "year": YEAR},
+        )
+
+        assert response.status_code == 200, f"Unexpected status: {response.status_code}\n{response.text}"
+
+        payload = response.json()
+        edges = payload.get("edges", [])
+
+        sibling_edges = [e for e in edges if e.get("type") == "sibling"]
+        assert sibling_edges == [], (
+            f"Secondary sibling edges must also be stripped from bunk graph response, "
+            f"but found {len(sibling_edges)}: {sibling_edges}"
+        )
+
+        # The primary request edge should still be present
+        request_edges = [e for e in edges if e.get("type") == "request"]
+        assert len(request_edges) >= 1, (
+            "Primary request edge must survive even when secondary_type='sibling' is dropped"
+        )
+
+
+class TestSessionSocialGraphSiblingEdgeFilter:
+    """#1094: /api/sessions/{id}/social-graph must not emit sibling edges."""
+
+    def test_sibling_edges_absent_from_session_graph_response(
+        self, session_graph_client_with_siblings: TestClient
+    ) -> None:
+        """Session social graph response must contain zero edges with type='sibling'.
+
+        The session graph builder adds sibling edges to the in-memory graph for
+        name-resolution use. The serializer must strip them before the HTTP response.
+        """
+        response = session_graph_client_with_siblings.get(
+            f"/api/sessions/{SESSION_CM_ID}/social-graph",
+            params={"year": YEAR, "include_metrics": "false"},
+        )
+
+        assert response.status_code == 200, f"Unexpected status: {response.status_code}\n{response.text}"
+
+        payload = response.json()
+        edges = payload.get("edges", [])
+
+        sibling_edges = [e for e in edges if e.get("type") == "sibling"]
+        assert sibling_edges == [], (
+            f"Session social-graph response must not include sibling edges, "
+            f"but found {len(sibling_edges)}: {sibling_edges}"
+        )
+
+    def test_request_edges_still_present_in_session_graph_response(
+        self, session_graph_client_with_siblings: TestClient
+    ) -> None:
+        """Non-sibling edges must survive the filter in the session graph."""
+        response = session_graph_client_with_siblings.get(
+            f"/api/sessions/{SESSION_CM_ID}/social-graph",
+            params={"year": YEAR, "include_metrics": "false"},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        edges = payload.get("edges", [])
+
+        request_edges = [e for e in edges if e.get("type") == "request"]
+        assert len(request_edges) >= 1, (
+            "At least one request edge must remain in the session graph response — "
+            "only sibling edges should be stripped"
+        )


### PR DESCRIPTION
## Summary

Closes #1094

Filters sibling edges at the API response boundary for both graph endpoints. Graph builders, `_add_sibling_edges`, `_batch_find_sibling_edges`, and `RelationshipAnalyzer` are **untouched** — sibling edges remain in-memory for the name-resolution confidence boost (0.25 SIBLING_BOOST during fuzzy match).

**Changes:**
- `api/routers/social_graph.py`: skip `edge_type='sibling'` in the session graph serializer; skip `edge_type='sibling'` AND `secondary_type='sibling'` in the bunk graph serializer (both code paths covered)
- `api/schemas/social_graph.py`: remove `'sibling'` from `SocialGraphEdge.type` comment; add explanatory note
- `frontend/src/types/graph.ts`: document `'sibling'` as excluded from `GraphEdge.type`
- `frontend/src/components/graph/cytoscapeStyles.ts`: remove defensive client-side sibling filter added by PR #1093
- `frontend/src/components/BunkSocialGraphModal.tsx`: remove defensive client-side sibling filter
- `frontend/src/components/graph/cytoscapeStyles.test.ts`: update test to reflect new contract
- `tests/unit/api/routers/test_sibling_edge_filter.py`: 5 new TDD tests covering both endpoints and both sibling-type variants (pure sibling edge, secondary_type='sibling')

## Acceptance Criteria

- [x] No edge with `type: 'sibling'` (or `secondary_type: 'sibling'`) in any graph API response
- [x] Defensive client-side sibling filters removed from frontend
- [x] Resolution-pipeline tests pass unchanged (`test_relationship_analyzer.py` — 11 tests, all green)
- [x] Frontend `GraphEdgeData` comment updated — `'sibling'` documented as excluded
- [x] All checks green: ruff, mypy, eslint, tsc, pytest (114 unit tests), vitest (3603 tests)

## Test Plan

- [x] New tests written first (TDD), verified failing before implementation
- [x] `uv run pytest tests/unit/api/routers/test_sibling_edge_filter.py` — 5/5 pass
- [x] `uv run pytest tests/unit/api/routers/` — 103/103 pass
- [x] `uv run pytest tests/unit/sync/bunk_request_processor/` — unchanged (11/11 pass)
- [x] `cd frontend && npx vitest run` — 3603/3603 pass
- [x] Pre-push verification — ALL CHECKS PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)