### PR TITLE
feat(frontend): multi-session cohort annotation + unmet parent drill-down (#1044, #1105)

### DIFF
--- a/api/utils/session_metrics.py
+++ b/api/utils/session_metrics.py
@@ -100,6 +100,24 @@ def get_person_from_expand(record: Any) -> Any:
     return getattr(expand, "person", None)
 
 
+def get_bunk_from_expand(record: Any) -> Any:
+    """Extract bunk from a record's PocketBase expand dict.
+
+    Symmetric to get_person_from_expand — handles both dict-style and
+    object-style expand attributes.
+
+    Args:
+        record: A PocketBase record with an expand attribute.
+
+    Returns:
+        The bunk object, or None if not found.
+    """
+    expand = getattr(record, "expand", {}) or {}
+    if isinstance(expand, dict):
+        return expand.get("bunk")
+    return getattr(expand, "bunk", None)
+
+
 def build_ag_parent_map(sessions: dict[int, Any]) -> dict[int, int]:
     """Build mapping from AG session cm_ids to their parent main session cm_ids.
 

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -15,13 +15,13 @@ from pydantic import BaseModel, Field
 
 from bunking.logging_config import get_logger
 from bunking.models import Bunk, BunkAssignment, BunkRequest, FriendGroup, Person, Session
+from bunking.satisfaction.predicate import is_request_satisfied
 from bunking.solver.constraints.helpers import extract_bunk_level, get_level_order
 from bunking.sync.bunk_request_processor.core.models import RequestSource
 from bunking.sync.bunk_request_processor.shared.constants import (
     SOURCE_FIELD_TO_CONFIG_KEY,
     SourceField,
 )
-from bunking.utils.age_preference import is_age_preference_satisfied
 
 # Canonical SourceField value → field_stats key used by the validator.
 # This is the single source of truth: adding a new SourceField means adding one
@@ -444,52 +444,63 @@ class BunkingValidator:
 
             return []
 
-        def is_request_satisfied(
-            request: BunkRequest,
-            person_assignment: BunkAssignment | None,
-            assignments_by_person: dict[str, BunkAssignment],
-        ) -> bool:
-            """Check if a request is satisfied."""
-            if not person_assignment:
-                return False
+        # Build the inputs the canonical predicate expects (#1170): person_to_bunk
+        # mapping (cm_id ints → bunk cm_id ints) and bunkmate_grades (cm_id →
+        # grades of OTHER campers in the same bunk). Built once per validation
+        # pass; reused for every request.
+        person_to_bunk_canon: dict[int, int] = {}
+        for cm_id_str, asgn in assignments_by_person.items():
+            try:
+                pid_int = int(cm_id_str)
+                bid_int = int(asgn.bunk_cm_id)
+            except TypeError, ValueError:
+                continue
+            if bid_int <= 0:
+                continue
+            person_to_bunk_canon[pid_int] = bid_int
 
-            if request.request_type == "bunk_with" and request.requested_person_cm_id:
-                requested_assignment = assignments_by_person.get(request.requested_person_cm_id)
-                return bool(requested_assignment and requested_assignment.bunk_cm_id == person_assignment.bunk_cm_id)
-            elif request.request_type == "not_bunk_with" and request.requested_person_cm_id:
-                requested_assignment = assignments_by_person.get(request.requested_person_cm_id)
-                return bool(not requested_assignment or requested_assignment.bunk_cm_id != person_assignment.bunk_cm_id)
-            elif request.request_type == "age_preference":
-                # Check if the bunk has older/younger bunkmates based on age_preference_target
-                age_pref_target = getattr(request, "age_preference_target", None)
-                if not age_pref_target:
+        bunkmate_grades_canon: dict[int, list[int]] = {}
+        for cm_id_str, asgn in assignments_by_person.items():
+            try:
+                pid_int = int(cm_id_str)
+            except TypeError, ValueError:
+                continue
+            grades: list[int] = []
+            for other in assignments_by_bunk.get(asgn.bunk_cm_id, []):
+                if other.person_cm_id == cm_id_str:
+                    continue
+                bunkmate = person_by_id.get(other.person_cm_id)
+                if bunkmate is None or bunkmate.grade is None:
+                    continue
+                grades.append(int(bunkmate.grade))
+            bunkmate_grades_canon[pid_int] = grades
+
+        def _is_satisfied(request: BunkRequest) -> bool:
+            """Adapter to bunking.satisfaction.predicate.is_request_satisfied.
+
+            Wraps ALL int() conversions and the canonical call in a single try/except
+            so any data-hygiene gap (non-numeric cm_id, non-numeric grade, unknown
+            request_type, out-of-range grade) returns False instead of crashing the
+            whole validation pass — matching the legacy local predicate's contract.
+            """
+            try:
+                requester_int = int(request.requester_person_cm_id)
+                if requester_int not in person_to_bunk_canon:
                     return False
-
-                # Get all bunkmates in the same bunk
-                bunk_assignments = assignments_by_bunk.get(person_assignment.bunk_cm_id, [])
-                if len(bunk_assignments) < 2:
-                    return False  # No bunkmates to compare
-
-                # Get the requester's grade
+                requester_grade: int | None = None
                 requester_person = person_by_id.get(request.requester_person_cm_id)
-                if not requester_person or requester_person.grade is None:
-                    return False
-
-                requester_grade = requester_person.grade
-
-                # Collect grades of all bunkmates (excluding the requester)
-                bunkmate_grades = []
-                for assignment in bunk_assignments:
-                    if assignment.person_cm_id != request.requester_person_cm_id:
-                        bunkmate = person_by_id.get(assignment.person_cm_id)
-                        if bunkmate and bunkmate.grade is not None:
-                            bunkmate_grades.append(bunkmate.grade)
-
-                # Use shared utility for consistent satisfaction logic
-                satisfied, _ = is_age_preference_satisfied(requester_grade, bunkmate_grades, age_pref_target)
-                return satisfied
-
-            return False
+                if requester_person is not None and requester_person.grade is not None:
+                    requester_grade = int(requester_person.grade)
+                row: dict[str, Any] = {
+                    "requester_id": requester_int,
+                    "requestee_id": int(request.requested_person_cm_id) if request.requested_person_cm_id else None,
+                    "request_type": request.request_type,
+                    "age_preference_target": getattr(request, "age_preference_target", None),
+                    "requester_grade": requester_grade,
+                }
+                return is_request_satisfied(row, person_to_bunk_canon, bunkmate_grades=bunkmate_grades_canon)
+            except TypeError, ValueError:
+                return False
 
         # Process each request
         for request in requests:
@@ -542,9 +553,8 @@ class BunkingValidator:
                     if field in stats.field_stats:
                         stats.field_stats[field]["total"] += 1
 
-                # Check if this valid request is satisfied
-                person_assignment = assignments_by_person.get(requester_id)
-                if is_request_satisfied(request, person_assignment, assignments_by_person):
+                # Check if this valid request is satisfied (#1170 — canonical predicate via _is_satisfied adapter).
+                if _is_satisfied(request):
                     satisfied_requests_by_person[requester_id].append(request)
                     if raw_source_field == SourceField.BUNK_WITH:
                         satisfied_material_parent_by_person[requester_id].append(request)
@@ -651,11 +661,18 @@ class BunkingValidator:
             for pid, reqs in material_parent_by_person.items()
             if reqs and not satisfied_material_parent_by_person.get(pid)
         )
-        stats.unsatisfied_material_parent_persons = [
-            {"cm_id": int(pid), "name": p.name if (p := person_by_id.get(pid)) else f"Person {pid}"}
-            for pid, reqs in material_parent_by_person.items()
-            if reqs and len(satisfied_material_parent_by_person.get(pid, [])) < len(reqs)
-        ]
+        # Match the canonical satisfaction policy from `bunking/satisfaction/aggregate.bucket_status`:
+        # the bucket is "unsatisfied" only when total > 0 AND zero satisfied. Partial satisfaction
+        # (≥1 of N) classifies as "satisfied" and must NOT appear here, otherwise the drill-down
+        # contradicts `campers_with_unsatisfied_material_parent_requests` above.
+        stats.unsatisfied_material_parent_persons = sorted(
+            (
+                {"cm_id": int(pid), "name": p.name if (p := person_by_id.get(pid)) else f"Person {pid}"}
+                for pid, reqs in material_parent_by_person.items()
+                if reqs and not satisfied_material_parent_by_person.get(pid)
+            ),
+            key=lambda entry: entry["name"],
+        )
 
         # Best-effort parent (socialize_with source_field) stats.
         stats.best_effort_parent_requests = sum(len(reqs) for reqs in best_effort_parent_by_person.values())

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -128,6 +128,9 @@ class ValidationStatistics(BaseModel):
     satisfied_material_parent_requests: int = 0
     material_parent_request_satisfaction_rate: float = 0.0
     campers_with_unsatisfied_material_parent_requests: int = 0
+    # Persons with ≥1 unmet material parent request — used by the Check Bunking
+    # modal drill-down (#1105). Each entry is {cm_id, name}.
+    unsatisfied_material_parent_persons: list[dict[str, Any]] = Field(default_factory=list)
 
     # Best-effort parent (socialize_with-source only) — emitted for modal display, drives no alarm.
     best_effort_parent_requests: int = 0
@@ -648,6 +651,11 @@ class BunkingValidator:
             for pid, reqs in material_parent_by_person.items()
             if reqs and not satisfied_material_parent_by_person.get(pid)
         )
+        stats.unsatisfied_material_parent_persons = [
+            {"cm_id": int(pid), "name": p.name if (p := person_by_id.get(pid)) else f"Person {pid}"}
+            for pid, reqs in material_parent_by_person.items()
+            if reqs and len(satisfied_material_parent_by_person.get(pid, [])) < len(reqs)
+        ]
 
         # Best-effort parent (socialize_with source_field) stats.
         stats.best_effort_parent_requests = sum(len(reqs) for reqs in best_effort_parent_by_person.values())

--- a/bunking/satisfaction/aggregate.py
+++ b/bunking/satisfaction/aggregate.py
@@ -23,6 +23,7 @@ from api.constants.collections import (
     BUNK_REQUESTS,
     PERSONS,
 )
+from api.utils.session_metrics import get_bunk_from_expand, get_person_from_expand
 from bunking.logging_config import get_logger
 from bunking.satisfaction.api_shape import (
     BucketCount,
@@ -237,9 +238,13 @@ def session_satisfaction(
     # Task 36: fetch assignments + requests in parallel — they are independent queries.
     # persons must come AFTER assignments because we scope it to person_to_bunk.keys().
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        # bunk_assignments has person/bunk as relation fields (PB record ids), not
+        # flat person_cm_id/bunk_cm_id attributes. expand=person,bunk populates the
+        # SDK's expand payload so cm_ids resolve via expand.person.cm_id /
+        # expand.bunk.cm_id — matches social_graph_builder.py's pattern.
         assignments_future = executor.submit(
             pb_client.collection(assignments_collection).get_full_list,
-            query_params={"filter": assignments_filter},
+            query_params={"filter": assignments_filter, "expand": "person,bunk"},
         )
         requests_future = executor.submit(
             pb_client.collection(BUNK_REQUESTS).get_full_list,
@@ -260,8 +265,36 @@ def session_satisfaction(
     person_to_bunk: dict[int, int] = {}
     bunk_to_persons: dict[int, list[int]] = defaultdict(list)
     for a in assignments:
-        pid = int(a.person_cm_id)
-        bid = int(a.bunk_cm_id)
+        person_data = get_person_from_expand(a)
+        bunk_data = get_bunk_from_expand(a)
+        if person_data is None or bunk_data is None:
+            logger.warning(
+                "skipping assignment with unresolved expand (person/bunk missing): assignment_id=%s",
+                getattr(a, "id", "<unknown>"),
+            )
+            continue
+        person_cm_id_val = getattr(person_data, "cm_id", None)
+        bunk_cm_id_val = getattr(bunk_data, "cm_id", None)
+        if person_cm_id_val is None or bunk_cm_id_val is None:
+            logger.warning(
+                "skipping assignment with missing cm_id on expanded relation: assignment_id=%s",
+                getattr(a, "id", "<unknown>"),
+            )
+            continue
+        try:
+            pid = int(person_cm_id_val)
+            bid = int(bunk_cm_id_val)
+        except TypeError, ValueError:
+            # Non-numeric cm_id — data hygiene gap (manual edit, partial sync,
+            # schema regression). Skip rather than 500 the whole aggregation.
+            logger.warning(
+                "skipping assignment with non-numeric cm_id on expanded relation: "
+                "assignment_id=%s person_cm_id=%r bunk_cm_id=%r",
+                getattr(a, "id", "<unknown>"),
+                person_cm_id_val,
+                bunk_cm_id_val,
+            )
+            continue
         if bid <= 0:
             logger.warning("skipping assignment with invalid bunk_cm_id=%d for person %d", bid, pid)
             continue

--- a/frontend/src/components/CamperCohortsSection.test.tsx
+++ b/frontend/src/components/CamperCohortsSection.test.tsx
@@ -405,7 +405,7 @@ describe('CamperCohortsSection multi-session annotation', () => {
     )
 
     await screen.findByText(/Also from Riverside Elementary/)
-    expect(screen.queryByText(/primary session/i)).not.toBeInTheDocument()
+    expect(screen.queryByText('Cohorts from this session only')).not.toBeInTheDocument()
   })
 
   it('shows primary-session annotation when hasMultipleEnrollments is true', async () => {
@@ -420,7 +420,7 @@ describe('CamperCohortsSection multi-session annotation', () => {
     )
 
     await screen.findByText(/Also from Riverside Elementary/)
-    expect(screen.getByText(/primary session/i)).toBeInTheDocument()
+    expect(screen.getByText('Cohorts from this session only')).toBeInTheDocument()
   })
 
   it('shows no annotation when hasMultipleEnrollments is omitted', async () => {
@@ -434,6 +434,6 @@ describe('CamperCohortsSection multi-session annotation', () => {
     )
 
     await screen.findByText(/Also from Riverside Elementary/)
-    expect(screen.queryByText(/primary session/i)).not.toBeInTheDocument()
+    expect(screen.queryByText('Cohorts from this session only')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/CamperCohortsSection.test.tsx
+++ b/frontend/src/components/CamperCohortsSection.test.tsx
@@ -379,3 +379,61 @@ describe('CamperCohortsSection', () => {
     })
   })
 })
+
+// ---------------------------------------------------------------------------
+// #1044: Multi-session camper annotation
+// ---------------------------------------------------------------------------
+describe('CamperCohortsSection multi-session annotation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCohortRequestRelations.mockReturnValue({ relations: new Map(), isLoading: false })
+    mockUseCamperCohorts.mockReturnValue({
+      cohorts: cohorts({ school: entry('Riverside Elementary', 3) }),
+      isLoading: false,
+    })
+  })
+
+  it('shows no annotation when hasMultipleEnrollments is false', async () => {
+    render(
+      <CamperCohortsSection
+        personCmId={1000001}
+        sessionCmId={201}
+        year={2025}
+        selfDisplayName="Emma"
+        hasMultipleEnrollments={false}
+      />
+    )
+
+    await screen.findByText(/Also from Riverside Elementary/)
+    expect(screen.queryByText(/primary session/i)).not.toBeInTheDocument()
+  })
+
+  it('shows primary-session annotation when hasMultipleEnrollments is true', async () => {
+    render(
+      <CamperCohortsSection
+        personCmId={1000001}
+        sessionCmId={201}
+        year={2025}
+        selfDisplayName="Emma"
+        hasMultipleEnrollments={true}
+      />
+    )
+
+    await screen.findByText(/Also from Riverside Elementary/)
+    expect(screen.getByText(/primary session/i)).toBeInTheDocument()
+  })
+
+  it('shows no annotation when hasMultipleEnrollments is omitted', async () => {
+    render(
+      <CamperCohortsSection
+        personCmId={1000001}
+        sessionCmId={201}
+        year={2025}
+        selfDisplayName="Emma"
+      />
+    )
+
+    await screen.findByText(/Also from Riverside Elementary/)
+    expect(screen.queryByText(/primary session/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/CamperCohortsSection.tsx
+++ b/frontend/src/components/CamperCohortsSection.tsx
@@ -23,6 +23,8 @@ interface CamperCohortsSectionProps {
   year: number
   /** Source camper's display name (preferred or first), used in modal copy. */
   selfDisplayName: string
+  /** When true, shows a "(primary session)" note — for campers enrolled in multiple sessions. */
+  hasMultipleEnrollments?: boolean
 }
 
 export function CamperCohortsSection({
@@ -30,6 +32,7 @@ export function CamperCohortsSection({
   sessionCmId,
   year,
   selfDisplayName,
+  hasMultipleEnrollments = false,
 }: CamperCohortsSectionProps) {
   const { cohorts, isLoading } = useCamperCohorts(personCmId, sessionCmId, year)
   const { relations } = useCohortRequestRelations(personCmId, sessionCmId, year)
@@ -81,6 +84,10 @@ export function CamperCohortsSection({
           )
         })}
       </div>
+
+      {hasMultipleEnrollments && (
+        <p className="text-muted-foreground/60 mt-0.5 px-1 text-xs">Primary session only</p>
+      )}
 
       {openKind && openEntry && (
         <CohortDrillDownModal

--- a/frontend/src/components/CamperCohortsSection.tsx
+++ b/frontend/src/components/CamperCohortsSection.tsx
@@ -86,7 +86,9 @@ export function CamperCohortsSection({
       </div>
 
       {hasMultipleEnrollments && (
-        <p className="text-muted-foreground/60 mt-0.5 px-1 text-xs">Primary session only</p>
+        <p className="text-muted-foreground/60 mt-0.5 px-1 text-xs">
+          Cohorts from this session only
+        </p>
       )}
 
       {openKind && openEntry && (

--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -872,6 +872,98 @@ describe('CamperDetailsPanel', () => {
       expect(screen.queryByText('P')).toBeNull()
     })
 
+    it('#1172: renders P badge from source_field=bunk_with when per_request is empty', async () => {
+      // Simulate /api/satisfaction unavailable: emptyCamperSatisfaction (per_request: []).
+      // Pre-#1158 the badge was driven by the row's own source_field — fall back to
+      // that path so a backend hiccup doesn't silently hide the P badge.
+      const bunkRequests: Record<string, unknown>[] = [
+        {
+          id: 'r3-fallback-p',
+          requester_id: 100,
+          requestee_id: 0,
+          request_type: 'age_preference',
+          source_field: 'bunk_with',
+          source: 'family',
+          age_preference_target: 'older',
+          status: 'resolved',
+          priority: 1,
+          year: 2025,
+          session_id: 3001,
+          is_reciprocal: false,
+          confidence_score: 0.9,
+          created: '2025-01-01T00:00:00Z',
+          updated: '2025-01-01T00:00:00Z',
+          collectionId: 'bunk_requests',
+          collectionName: 'bunk_requests',
+          metadata: {},
+        },
+      ]
+      setupR3Mocks(bunkRequests)
+      // Empty per_request — bucketByRequestId is empty → fallback path must fire.
+      mockGetSatisfiedRequestInfo = vi.fn((personCmId: number) => ({
+        person_cm_id: personCmId,
+        per_request: [] as PerRequestStatus[],
+        counted_totals: {
+          material_parent: { satisfied: 0, total: 0 },
+          staff: { satisfied: 0, total: 0 },
+        },
+        immaterial: { satisfied: 0, total: 0 },
+        flags: {
+          parent_min_one_violation: false,
+          staff_unsatisfied_alert: false,
+          has_any_counted_request: false,
+        },
+      }))
+
+      render(<CamperDetailsPanel camperId="100" onClose={vi.fn()} embedded={true} />)
+      expect(await screen.findByText('P')).toBeInTheDocument()
+      expect(screen.queryByText('S')).toBeNull()
+    })
+
+    it('#1172: renders S badge from source=staff when per_request is empty', async () => {
+      const bunkRequests: Record<string, unknown>[] = [
+        {
+          id: 'r3-fallback-s',
+          requester_id: 100,
+          requestee_id: 0,
+          request_type: 'age_preference',
+          source_field: 'bunking_notes',
+          source: 'staff',
+          age_preference_target: 'younger',
+          status: 'resolved',
+          priority: 1,
+          year: 2025,
+          session_id: 3001,
+          is_reciprocal: false,
+          confidence_score: 0.9,
+          created: '2025-01-01T00:00:00Z',
+          updated: '2025-01-01T00:00:00Z',
+          collectionId: 'bunk_requests',
+          collectionName: 'bunk_requests',
+          metadata: {},
+        },
+      ]
+      setupR3Mocks(bunkRequests)
+      mockGetSatisfiedRequestInfo = vi.fn((personCmId: number) => ({
+        person_cm_id: personCmId,
+        per_request: [] as PerRequestStatus[],
+        counted_totals: {
+          material_parent: { satisfied: 0, total: 0 },
+          staff: { satisfied: 0, total: 0 },
+        },
+        immaterial: { satisfied: 0, total: 0 },
+        flags: {
+          parent_min_one_violation: false,
+          staff_unsatisfied_alert: false,
+          has_any_counted_request: false,
+        },
+      }))
+
+      render(<CamperDetailsPanel camperId="100" onClose={vi.fn()} embedded={true} />)
+      expect(await screen.findByText('S')).toBeInTheDocument()
+      expect(screen.queryByText('P')).toBeNull()
+    })
+
     it('does NOT render any new "Parent request satisfaction:" summary line in the sidebar', async () => {
       // The sidebar conveys source-aware satisfaction via CamperAlertSection,
       // not a separate summary label. Spec §2.4 explicitly forbids adding one.

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -913,6 +913,7 @@ export default function CamperDetailsPanel({
             sessionCmId={camper.session_cm_id}
             year={currentYear}
             selfDisplayName={camper.preferred_name?.trim() || camper.first_name || 'this camper'}
+            hasMultipleEnrollments={currentEnrollments.length > 1}
           />
         )}
 

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -38,6 +38,7 @@ import { Collections } from '../types/pocketbase-types'
 import { toAppCamper } from '../utils/transforms'
 import { isConfirmedRequest } from '../utils/bunkRequest'
 import { partitionRequestsBySource } from '../utils/partitionRequestsBySource'
+import { resolveBadgeBucket } from '../utils/requestSatisfaction'
 import { useSatisfactionData } from '../hooks/camper/useSatisfactionData'
 import { computeRequestSatisfaction } from '../utils/requestSatisfaction'
 import type { SatisfactionMap } from '../hooks/camper/types'
@@ -969,6 +970,10 @@ export default function CamperDetailsPanel({
                   )}
                   {ageRows.map((req) => {
                     const satisfaction = satisfactionData[req.id]
+                    const { isMaterialAgePref, isStaffBadge } = resolveBadgeBucket(
+                      bucketByRequestId.get(req.id),
+                      req
+                    )
                     return (
                       <BunkRequestRow
                         key={req.id}
@@ -977,10 +982,8 @@ export default function CamperDetailsPanel({
                         satisfaction={satisfaction?.status ?? null}
                         satisfactionLoading={satisfactionLoading}
                         satisfactionDetail={satisfaction?.detail}
-                        isMaterialAgePreference={
-                          bucketByRequestId.get(req.id) === 'material_parent'
-                        }
-                        staffAgeBadge={bucketByRequestId.get(req.id) === 'staff'}
+                        isMaterialAgePreference={isMaterialAgePref}
+                        staffAgeBadge={isStaffBadge}
                       />
                     )
                   })}

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -338,3 +338,71 @@ describe('PostValidationResultsModal — parent stats tile (Stage 3b.2)', () => 
     expect(screen.getByText(/^requests met$/i)).toBeInTheDocument()
   })
 })
+
+// ---------------------------------------------------------------------------
+// #1105: Unmet parent requests drill-down section
+// ---------------------------------------------------------------------------
+import userEvent from '@testing-library/user-event'
+
+describe('PostValidationResultsModal — unmet parent requests drill-down (#1105)', () => {
+  it('shows no drill-down section when unsatisfied_material_parent_persons is absent', () => {
+    render(<PostValidationResultsModal isOpen={true} onClose={() => {}} results={makeResults()} />)
+
+    expect(screen.queryByText(/unmet parent requests/i)).not.toBeInTheDocument()
+  })
+
+  it('shows no drill-down section when unsatisfied_material_parent_persons is empty', () => {
+    render(
+      <PostValidationResultsModal
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({ unsatisfied_material_parent_persons: [] })}
+      />
+    )
+
+    expect(screen.queryByText(/unmet parent requests/i)).not.toBeInTheDocument()
+  })
+
+  it('shows collapsible drill-down section when unsatisfied persons present', () => {
+    render(
+      <PostValidationResultsModal
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({
+          unsatisfied_material_parent_persons: [
+            { cm_id: 1000001, name: 'Emma Johnson' },
+            { cm_id: 1000002, name: 'Liam Garcia' },
+          ],
+        })}
+      />
+    )
+
+    expect(screen.getByText(/unmet parent requests/i)).toBeInTheDocument()
+  })
+
+  it('shows camper names after expanding the drill-down section', async () => {
+    const user = userEvent.setup()
+    render(
+      <PostValidationResultsModal
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({
+          unsatisfied_material_parent_persons: [
+            { cm_id: 1000001, name: 'Emma Johnson' },
+            { cm_id: 1000002, name: 'Liam Garcia' },
+          ],
+        })}
+      />
+    )
+
+    // Names should not be visible before expanding
+    expect(screen.queryByText('Emma Johnson')).not.toBeInTheDocument()
+    expect(screen.queryByText('Liam Garcia')).not.toBeInTheDocument()
+
+    // Click to expand
+    await user.click(screen.getByText(/unmet parent requests/i))
+
+    expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
+    expect(screen.getByText('Liam Garcia')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -7,6 +7,7 @@
  */
 
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi } from 'vitest'
 
 import PostValidationResultsModal from './PostValidationResultsModal'
@@ -342,7 +343,6 @@ describe('PostValidationResultsModal — parent stats tile (Stage 3b.2)', () => 
 // ---------------------------------------------------------------------------
 // #1105: Unmet parent requests drill-down section
 // ---------------------------------------------------------------------------
-import userEvent from '@testing-library/user-event'
 
 describe('PostValidationResultsModal — unmet parent requests drill-down (#1105)', () => {
   it('shows no drill-down section when unsatisfied_material_parent_persons is absent', () => {
@@ -363,7 +363,7 @@ describe('PostValidationResultsModal — unmet parent requests drill-down (#1105
     expect(screen.queryByText(/unmet parent requests/i)).not.toBeInTheDocument()
   })
 
-  it('shows collapsible drill-down section when unsatisfied persons present', () => {
+  it('shows collapsible drill-down section with count when unsatisfied persons present', () => {
     render(
       <PostValidationResultsModal
         isOpen={true}
@@ -377,7 +377,8 @@ describe('PostValidationResultsModal — unmet parent requests drill-down (#1105
       />
     )
 
-    expect(screen.getByText(/unmet parent requests/i)).toBeInTheDocument()
+    // Pin both the literal label and the rendered count.
+    expect(screen.getByText('Unmet parent requests (2)')).toBeInTheDocument()
   })
 
   it('shows camper names after expanding the drill-down section', async () => {

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -36,6 +36,7 @@ interface ValidationStatistics {
   satisfied_material_parent_requests?: number
   material_parent_request_satisfaction_rate?: number
   campers_with_unsatisfied_material_parent_requests?: number
+  unsatisfied_material_parent_persons?: Array<{ cm_id: number; name: string }>
   best_effort_parent_requests?: number
   satisfied_best_effort_parent_requests?: number
   best_effort_parent_request_satisfaction_rate?: number
@@ -509,6 +510,7 @@ export default function PostValidationResultsModal({
   scenarioId,
 }: PostValidationResultsModalProps) {
   const [showDetails, setShowDetails] = useState(false)
+  const [showUnmetParents, setShowUnmetParents] = useState(false)
 
   // Need to compute these even when modal is closed since Modal might render conditionally
   const statistics = results.statistics
@@ -752,6 +754,36 @@ export default function PostValidationResultsModal({
           <p className="text-muted-foreground text-sm">
             No issues detected. All bunking assignments look great!
           </p>
+        </div>
+      )}
+
+      {/* Unmet parent requests drill-down (#1105) */}
+      {(statistics.unsatisfied_material_parent_persons?.length ?? 0) > 0 && (
+        <div className="border-border/50 border-t">
+          <button
+            onClick={() => setShowUnmetParents(!showUnmetParents)}
+            className="text-muted-foreground hover:text-foreground hover:bg-muted/30 flex w-full items-center justify-between px-5 py-3 text-sm transition-colors"
+          >
+            <span className="flex items-center gap-2">
+              <Users className="h-4 w-4" />
+              Unmet parent requests ({statistics.unsatisfied_material_parent_persons!.length})
+            </span>
+            {showUnmetParents ? (
+              <ChevronUp className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            )}
+          </button>
+
+          {showUnmetParents && (
+            <ul className="animate-fade-in space-y-1 px-5 pb-4">
+              {statistics.unsatisfied_material_parent_persons!.map((person) => (
+                <li key={person.cm_id} className="text-foreground text-sm">
+                  {person.name}
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
       )}
 

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -514,6 +514,7 @@ export default function PostValidationResultsModal({
 
   // Need to compute these even when modal is closed since Modal might render conditionally
   const statistics = results.statistics
+  const unmetParents = statistics.unsatisfied_material_parent_persons ?? []
   // Memoize issues to prevent dependency array changes on every render
   const issues = useMemo(() => results.issues, [results.issues])
   const parentTotal = statistics.material_parent_requests ?? 0
@@ -758,15 +759,16 @@ export default function PostValidationResultsModal({
       )}
 
       {/* Unmet parent requests drill-down (#1105) */}
-      {(statistics.unsatisfied_material_parent_persons?.length ?? 0) > 0 && (
+      {unmetParents.length > 0 && (
         <div className="border-border/50 border-t">
           <button
+            type="button"
             onClick={() => setShowUnmetParents(!showUnmetParents)}
             className="text-muted-foreground hover:text-foreground hover:bg-muted/30 flex w-full items-center justify-between px-5 py-3 text-sm transition-colors"
           >
             <span className="flex items-center gap-2">
               <Users className="h-4 w-4" />
-              Unmet parent requests ({statistics.unsatisfied_material_parent_persons!.length})
+              Unmet parent requests ({unmetParents.length})
             </span>
             {showUnmetParents ? (
               <ChevronUp className="h-4 w-4" />
@@ -776,8 +778,8 @@ export default function PostValidationResultsModal({
           </button>
 
           {showUnmetParents && (
-            <ul className="animate-fade-in space-y-1 px-5 pb-4">
-              {statistics.unsatisfied_material_parent_persons!.map((person) => (
+            <ul className="animate-fade-in max-h-48 space-y-1 overflow-y-auto px-5 pb-4">
+              {unmetParents.map((person) => (
                 <li key={person.cm_id} className="text-foreground text-sm">
                   {person.name}
                 </li>

--- a/frontend/src/components/camper/BunkingStatusPanel.test.tsx
+++ b/frontend/src/components/camper/BunkingStatusPanel.test.tsx
@@ -409,6 +409,151 @@ describe('BunkingStatusPanel — #1159 reads counted_totals from CamperSatisfact
   })
 })
 
+describe('BunkingStatusPanel — #1172 source_field/source fallback when /api/satisfaction unavailable', () => {
+  // PR #1158 made the badges depend on bucketByRequestId, sourced from
+  // /api/satisfaction. When that endpoint is down (#1171), the map is empty
+  // and badges silently disappear. Pre-1158 behavior was driven from each
+  // request's own source_field/source — local data, can't fail. The fallback
+  // restores that resilience: centralized path stays canonical when present;
+  // when bucket is undefined, fall back to the row's source_field/source.
+
+  it('renders P badge from source_field=bunk_with when per_request is empty', () => {
+    // Simulates /api/satisfaction returning emptyCamperSatisfaction (e.g. 500).
+    const ageReq = makeRequest({
+      id: 'no-bucket',
+      request_type: 'age_preference',
+      source_field: 'bunk_with',
+      source: 'family',
+      age_preference_target: 'older',
+    })
+    renderPanelWith({
+      allBunkRequests: [],
+      agePreferenceRequests: [ageReq],
+      satisfactionData: {},
+      camperSatisfaction: emptyCamperSatisfaction(12345),
+    })
+    expect(screen.getByText('P')).toBeInTheDocument()
+    expect(screen.queryByText('S')).toBeNull()
+  })
+
+  it('renders S badge from source=staff when per_request is empty', () => {
+    const ageReq = makeRequest({
+      id: 'no-bucket-staff',
+      request_type: 'age_preference',
+      source_field: 'bunking_notes',
+      source: 'staff',
+      age_preference_target: 'younger',
+    })
+    renderPanelWith({
+      allBunkRequests: [],
+      agePreferenceRequests: [ageReq],
+      satisfactionData: {},
+      camperSatisfaction: emptyCamperSatisfaction(12345),
+    })
+    expect(screen.getByText('S')).toBeInTheDocument()
+    expect(screen.queryByText('P')).toBeNull()
+  })
+
+  it('centralized bucket still wins when present (regression guard for #1159)', () => {
+    // When per_request entry exists, it must override the source_field fallback.
+    // This is the inverse of the fallback — pin that the bucket path remains
+    // canonical and source_field is read ONLY when the centralized map has no
+    // entry.
+    const ageReq = makeRequest({
+      id: 'present',
+      request_type: 'age_preference',
+      source_field: 'bunk_with', // would set P under fallback
+      source: 'family',
+      age_preference_target: 'older',
+    })
+    const camperSatisfaction: CamperSatisfaction = {
+      ...emptyCamperSatisfaction(12345),
+      per_request: [{ request_id: 'present', bucket: 'staff', satisfied: false }],
+    }
+    renderPanelWith({
+      allBunkRequests: [],
+      agePreferenceRequests: [ageReq],
+      satisfactionData: {},
+      camperSatisfaction,
+    })
+    // Bucket wins: S badge, not P.
+    expect(screen.getByText('S')).toBeInTheDocument()
+    expect(screen.queryByText('P')).toBeNull()
+  })
+
+  it('does NOT fabricate parent ratio when aggregator legitimately reports 0/0 parent + non-zero staff', () => {
+    // Aggregator is healthy: per_request has entries (staff classifications),
+    // counted_totals.staff > 0, counted_totals.material_parent = 0/0. A stale or
+    // local-only bunk_with row in the rendered list must NOT be re-bucketed by
+    // the fallback — that would silently contradict the canonical aggregator.
+    // Fallback fires only when the aggregator is genuinely empty/unavailable.
+    const ageStaff = makeRequest({
+      id: 'staff-1',
+      request_type: 'age_preference',
+      source_field: 'bunking_notes',
+      source: 'staff',
+      age_preference_target: 'younger',
+    })
+    const stalePartial = makeRequest({
+      id: 'stale-bunk_with',
+      request_type: 'bunk_with',
+      source_field: 'bunk_with',
+      source: 'family',
+      requestee_id: 99999,
+      requestedPersonName: 'Olivia Chen',
+    })
+    const camperSatisfaction: CamperSatisfaction = {
+      ...emptyCamperSatisfaction(12345),
+      // Aggregator says: 1 staff request, 0 parent. per_request has the staff entry,
+      // does NOT mention the stale parent row (data drift).
+      per_request: [{ request_id: 'staff-1', bucket: 'staff', satisfied: false }],
+      counted_totals: {
+        material_parent: { total: 0, satisfied: 0 },
+        staff: { total: 1, satisfied: 0 },
+      },
+    }
+    renderPanelWith({
+      allBunkRequests: [stalePartial],
+      agePreferenceRequests: [ageStaff],
+      satisfactionData: {},
+      camperSatisfaction,
+    })
+    // Aggregator's authoritative answer: NO parent satisfaction line.
+    expect(screen.queryByText(/Parent request satisfaction:/i)).toBeNull()
+    // Staff slice should still render (1 staff request).
+    expect(screen.getByText(/Staff request satisfaction:/i)).toBeInTheDocument()
+  })
+
+  it('derives parent ratio from local bunk_with rows when counted_totals is empty', () => {
+    // Two bunk_with parent rows, /api/satisfaction reports 0/0 (unavailable).
+    // Pre-1158 the slice ratio was driven from local rows; restore that as a
+    // fallback so a backend hiccup doesn't silently hide the 0/N display.
+    const allBunkRequests = [
+      makeRequest({
+        id: 'p1',
+        request_type: 'bunk_with',
+        source_field: 'bunk_with',
+        source: 'family',
+        requestedPersonName: 'Liam Garcia',
+      }),
+      makeRequest({
+        id: 'p2',
+        request_type: 'bunk_with',
+        source_field: 'bunk_with',
+        source: 'family',
+        requestedPersonName: 'Olivia Chen',
+      }),
+    ]
+    renderPanelWith({
+      allBunkRequests,
+      satisfactionData: { p1: { status: 'satisfied', detail: '' } },
+      camperSatisfaction: emptyCamperSatisfaction(12345),
+    })
+    // 1 satisfied (p1), 2 total → "1/2 met" must appear.
+    expect(screen.getByText('1/2 met')).toBeInTheDocument()
+  })
+})
+
 describe('BunkingStatusPanel — #1159 age-pref badges read per_request.bucket', () => {
   it('renders S badge when per_request bucket=staff even though source_field=bunk_with', () => {
     // Mismatched fixture: row's source_field says bunk_with (would set P badge

--- a/frontend/src/components/camper/BunkingStatusPanel.tsx
+++ b/frontend/src/components/camper/BunkingStatusPanel.tsx
@@ -7,6 +7,7 @@ import { Heart, Home, Clock, CheckCircle } from 'lucide-react'
 import { sessionNameToUrl } from '../../utils/sessionUtils'
 import { partitionRequestsBySource } from '../../utils/partitionRequestsBySource'
 import { isConfirmedRequest } from '../../utils/bunkRequest'
+import { resolveBadgeBucket } from '../../utils/requestSatisfaction'
 import { BunkRequestRow } from '../BunkRequestRow'
 import { ParentStaffDivider, AgePreferenceDivider } from './RequestSectionDividers'
 import type { Camper } from '../../types/app-types'
@@ -109,7 +110,7 @@ export function BunkingStatusPanel({
   // Slice totals come from the centralized aggregator (`/api/satisfaction`),
   // not from re-bucketing rows here. This is the single source of truth shared
   // with the bunking-board card and graph node states (#1159).
-  const materialParent = camperSatisfaction.counted_totals.material_parent
+  const centralizedMaterialParent = camperSatisfaction.counted_totals.material_parent
   const staff = camperSatisfaction.counted_totals.staff
 
   // Per-row bucket lookup so age-pref P/S badges read the centralized
@@ -123,6 +124,29 @@ export function BunkingStatusPanel({
       ),
     [camperSatisfaction]
   )
+
+  // #1172: when /api/satisfaction is fully unavailable, counted_totals is 0/0 AND
+  // per_request is empty AND staff total is 0 — that's the only signal that the
+  // aggregator has no answer for us. Fall back to deriving the parent slice from
+  // local bunk_with rows so a backend hiccup doesn't silently hide the 0/N ratio.
+  //
+  // Trigger MUST be tighter than just "material_parent.total === 0" — the
+  // aggregator legitimately reports 0/0 parent for staff-only campers, and we
+  // must not contradict it by re-bucketing local rows that the aggregator
+  // already classified differently (or filtered out).
+  const aggregatorEmpty =
+    camperSatisfaction.per_request.length === 0 &&
+    centralizedMaterialParent.total === 0 &&
+    staff.total === 0
+  const materialParent = useMemo(() => {
+    if (!aggregatorEmpty) return centralizedMaterialParent
+    const bunkWithRows = summaryRequests.filter((r) => r.source_field === 'bunk_with')
+    if (bunkWithRows.length === 0) return centralizedMaterialParent
+    const satisfied = bunkWithRows.filter(
+      (r) => satisfactionData[r.id]?.status === 'satisfied'
+    ).length
+    return { total: bunkWithRows.length, satisfied }
+  }, [aggregatorEmpty, centralizedMaterialParent, summaryRequests, satisfactionData])
 
   const showParent = materialParent.total > 0
   const showStaff = staff.total > 0
@@ -301,7 +325,10 @@ export function BunkingStatusPanel({
             )}
             {ageRows.map((req) => {
               const sat = satisfactionData[req.id]
-              const bucket = bucketByRequestId.get(req.id)
+              const { isMaterialAgePref, isStaffBadge } = resolveBadgeBucket(
+                bucketByRequestId.get(req.id),
+                req
+              )
               return (
                 <BunkRequestRow
                   key={req.id}
@@ -311,8 +338,8 @@ export function BunkingStatusPanel({
                   showSatisfaction={true}
                   satisfactionLoading={satisfactionLoading}
                   satisfactionDetail={sat?.detail}
-                  isMaterialAgePreference={bucket === 'material_parent'}
-                  staffAgeBadge={bucket === 'staff'}
+                  isMaterialAgePreference={isMaterialAgePref}
+                  staffAgeBadge={isStaffBadge}
                 />
               )
             })}

--- a/frontend/src/utils/requestSatisfaction.test.ts
+++ b/frontend/src/utils/requestSatisfaction.test.ts
@@ -8,8 +8,9 @@
  * orange-triangle alert.
  */
 import { describe, it, expect } from 'vitest'
-import { computeRequestSatisfaction } from './requestSatisfaction'
+import { computeRequestSatisfaction, resolveBadgeBucket } from './requestSatisfaction'
 import type { EnhancedBunkRequest } from '../hooks/camper/useAllBunkRequests'
+import type { RequestBucket } from '../types/satisfaction'
 
 // Minimal request fixture — only fields the utility reads
 function req(partial: Partial<EnhancedBunkRequest>): EnhancedBunkRequest {
@@ -211,5 +212,68 @@ describe('computeRequestSatisfaction — fallback', () => {
       requesterGrade: REQUESTER_GRADE,
     })
     expect(result.status).toBe('unknown')
+  })
+})
+
+describe('resolveBadgeBucket — #1172 centralized-bucket-with-source-field-fallback', () => {
+  // Pin contract: when the centralized aggregator (CamperSatisfaction.per_request)
+  // classifies the row, that wins. When it has no entry (aggregator unavailable
+  // or row not in the response), fall back to the row's own source_field/source —
+  // pre-#1158 behavior. Centralized 'immaterial_parent' yields no badge.
+
+  it('material_parent bucket → P badge regardless of source_field', () => {
+    const result = resolveBadgeBucket('material_parent', {
+      source_field: 'bunking_notes',
+      source: 'staff',
+    })
+    expect(result).toEqual({ isMaterialAgePref: true, isStaffBadge: false })
+  })
+
+  it('staff bucket → S badge regardless of source_field', () => {
+    const result = resolveBadgeBucket('staff', { source_field: 'bunk_with', source: 'family' })
+    expect(result).toEqual({ isMaterialAgePref: false, isStaffBadge: true })
+  })
+
+  it('immaterial_parent bucket → no badges', () => {
+    const result = resolveBadgeBucket('immaterial_parent', {
+      source_field: 'bunk_with',
+      source: 'staff',
+    })
+    expect(result).toEqual({ isMaterialAgePref: false, isStaffBadge: false })
+  })
+
+  it('undefined bucket + source_field=bunk_with → P badge (fallback)', () => {
+    const result = resolveBadgeBucket(undefined, { source_field: 'bunk_with', source: 'family' })
+    expect(result).toEqual({ isMaterialAgePref: true, isStaffBadge: false })
+  })
+
+  it('undefined bucket + source=staff → S badge (fallback)', () => {
+    const result = resolveBadgeBucket(undefined, { source_field: 'bunking_notes', source: 'staff' })
+    expect(result).toEqual({ isMaterialAgePref: false, isStaffBadge: true })
+  })
+
+  it('undefined bucket + neither → no badges', () => {
+    const result = resolveBadgeBucket(undefined, {
+      source_field: 'socialize_with',
+      source: 'family',
+    })
+    expect(result).toEqual({ isMaterialAgePref: false, isStaffBadge: false })
+  })
+
+  it('undefined bucket + missing source fields → no badges', () => {
+    const result = resolveBadgeBucket(undefined, {})
+    expect(result).toEqual({ isMaterialAgePref: false, isStaffBadge: false })
+  })
+
+  it('handles all RequestBucket values without throwing', () => {
+    const buckets: (RequestBucket | undefined)[] = [
+      'material_parent',
+      'immaterial_parent',
+      'staff',
+      undefined,
+    ]
+    for (const b of buckets) {
+      expect(() => resolveBadgeBucket(b, {})).not.toThrow()
+    }
   })
 })

--- a/frontend/src/utils/requestSatisfaction.ts
+++ b/frontend/src/utils/requestSatisfaction.ts
@@ -18,6 +18,7 @@ import { isAgePreferenceSatisfied } from './agePreferenceSatisfaction'
 import { formatGradeOrdinal } from './gradeUtils'
 import type { EnhancedBunkRequest } from '../hooks/camper/useAllBunkRequests'
 import type { SatisfactionResult } from '../hooks/camper/types'
+import type { RequestBucket } from '../types/satisfaction'
 
 export interface BunkmateInfo {
   cmId: number
@@ -104,4 +105,33 @@ export function computeRequestSatisfaction({
   }
 
   return { status: 'unknown' }
+}
+
+/**
+ * Resolve the P/S age-preference badge state for a request row (#1172).
+ *
+ * The centralized aggregator (`CamperSatisfaction.per_request[i].bucket`) is
+ * the source of truth when present — that's what #1158/#1159 consolidated.
+ * When the aggregator is unavailable (`/api/satisfaction` 500, empty response,
+ * loading state), bucket is `undefined` and the badge silently disappears
+ * unless we fall back to the row's own `source_field`/`source` — which is
+ * what drove the badge pre-#1158 and cannot fail.
+ *
+ * Centralized bucket wins; row-level fields are ONLY consulted when the
+ * centralized map has no entry for this row.
+ */
+export function resolveBadgeBucket(
+  bucket: RequestBucket | undefined,
+  req: { source_field?: string | null; source?: string | null }
+): { isMaterialAgePref: boolean; isStaffBadge: boolean } {
+  if (bucket === 'material_parent') return { isMaterialAgePref: true, isStaffBadge: false }
+  if (bucket === 'staff') return { isMaterialAgePref: false, isStaffBadge: true }
+  if (bucket === undefined) {
+    return {
+      isMaterialAgePref: req.source_field === 'bunk_with',
+      isStaffBadge: req.source === 'staff',
+    }
+  }
+  // bucket === 'immaterial_parent' → no badges (best-effort socialize_with).
+  return { isMaterialAgePref: false, isStaffBadge: false }
 }

--- a/tests/unit/api/test_session_metrics.py
+++ b/tests/unit/api/test_session_metrics.py
@@ -548,6 +548,47 @@ class TestGetSessionFromExpand:
         assert get_session_from_expand(record) is None
 
 
+class TestGetBunkFromExpand:
+    """Tests for get_bunk_from_expand() — symmetric helper to get_person_from_expand
+    so #1171's aggregate.py + social_graph_builder.py can resolve the bunk relation
+    consistently (handles both dict-style and object-style PB SDK expand payloads).
+    """
+
+    def test_extracts_bunk_from_dict_expand(self) -> None:
+        from api.utils.session_metrics import get_bunk_from_expand
+
+        bunk = Mock(cm_id=42)
+        record = Mock(expand={"bunk": bunk})
+        assert get_bunk_from_expand(record) is bunk
+
+    def test_extracts_bunk_from_object_expand(self) -> None:
+        from api.utils.session_metrics import get_bunk_from_expand
+
+        bunk = Mock(cm_id=42)
+        expand = Mock(bunk=bunk)
+        expand.__contains__ = Mock(side_effect=TypeError)
+        record = Mock(expand=expand)
+        assert get_bunk_from_expand(record) is bunk
+
+    def test_returns_none_for_empty_expand(self) -> None:
+        from api.utils.session_metrics import get_bunk_from_expand
+
+        record = Mock(expand={})
+        assert get_bunk_from_expand(record) is None
+
+    def test_returns_none_for_none_expand(self) -> None:
+        from api.utils.session_metrics import get_bunk_from_expand
+
+        record = Mock(expand=None)
+        assert get_bunk_from_expand(record) is None
+
+    def test_returns_none_for_missing_expand(self) -> None:
+        from api.utils.session_metrics import get_bunk_from_expand
+
+        record = Mock(spec=[])
+        assert get_bunk_from_expand(record) is None
+
+
 class TestBuildAgParentMap:
     """Tests for build_ag_parent_map() utility function."""
 

--- a/tests/unit/bunking/satisfaction/test_session_satisfaction.py
+++ b/tests/unit/bunking/satisfaction/test_session_satisfaction.py
@@ -25,10 +25,31 @@ def _person(cm_id: int, grade: int = 10, gender: str = "M") -> Any:
 
 
 def _assignment(person_cm_id: int, bunk_cm_id: int) -> Any:
-    a = MagicMock()
-    a.person_cm_id = person_cm_id
-    a.bunk_cm_id = bunk_cm_id
-    return a
+    """Build a bunk_assignments record shaped like the real PocketBase SDK returns.
+
+    person/bunk are relation fields (PB record ids); cm_ids resolve via the expand
+    payload (#1171). NEVER add flat person_cm_id/bunk_cm_id attributes — the real
+    schema doesn't have them and tests must mirror that.
+    """
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        id=f"a{person_cm_id:014d}",
+        cm_id=person_cm_id * 1000 + bunk_cm_id,
+        person=f"p{person_cm_id:014d}",
+        bunk=f"b{bunk_cm_id:014d}",
+        session=f"s{1:014d}",
+        expand={
+            "person": SimpleNamespace(
+                id=f"p{person_cm_id:014d}",
+                cm_id=person_cm_id,
+            ),
+            "bunk": SimpleNamespace(
+                id=f"b{bunk_cm_id:014d}",
+                cm_id=bunk_cm_id,
+            ),
+        },
+    )
 
 
 def _build_pb_mock(
@@ -460,8 +481,6 @@ def test_session_satisfaction_scopes_persons_fetch_to_assigned() -> None:
     persons in the year.  After Task 34 the filter must contain the specific
     cm_ids that appear in the assignment list, not a year-wide scan.
     """
-    from types import SimpleNamespace
-
     captured_filters: list[str] = []
 
     def make_collection(name: str) -> Any:
@@ -476,10 +495,7 @@ def test_session_satisfaction_scopes_persons_fetch_to_assigned() -> None:
 
             col.get_full_list.side_effect = capture
         elif name == BUNK_ASSIGNMENTS:
-            col.get_full_list.return_value = [
-                SimpleNamespace(person_cm_id=1, bunk_cm_id=10),
-                SimpleNamespace(person_cm_id=2, bunk_cm_id=10),
-            ]
+            col.get_full_list.return_value = [_assignment(1, 10), _assignment(2, 10)]
         elif name == BUNK_REQUESTS:
             col.get_full_list.return_value = []
         else:
@@ -512,8 +528,6 @@ def test_session_satisfaction_scopes_persons_fetch_to_assigned() -> None:
 
 def test_get_full_list_called_with_query_params_not_filter_kwarg() -> None:
     """All collection.get_full_list calls must use query_params={'filter': ...}."""
-    from types import SimpleNamespace
-
     seen_calls: list[tuple[str, dict[str, Any]]] = []
 
     def make_collection(name: str) -> Any:
@@ -522,7 +536,7 @@ def test_get_full_list_called_with_query_params_not_filter_kwarg() -> None:
         def capture(*_args: Any, **kwargs: Any) -> list[Any]:
             seen_calls.append((name, dict(kwargs)))
             if name == BUNK_ASSIGNMENTS:
-                return [SimpleNamespace(person_cm_id=1, bunk_cm_id=10)]
+                return [_assignment(1, 10)]
             return []
 
         col.get_full_list.side_effect = capture
@@ -581,3 +595,93 @@ def test_session_satisfaction_accepts_valid_scenario_id() -> None:
         scenario_id=valid,
         pb_client=pb,
     )
+
+
+# ---------------------------------------------------------------------------
+# #1171 — Real PocketBase Record shape regression
+#
+# bunk_assignments collection has `person` / `bunk` relation fields (returning
+# PB record ids) and `cm_id` for the assignment itself — but NO `person_cm_id`
+# / `bunk_cm_id` flat attributes. Reading those raises AttributeError on every
+# real Record. The _assignment helper above already mirrors the real shape
+# (relation strings + expand payload). These tests pin the contract.
+# ---------------------------------------------------------------------------
+
+
+def test_assignments_query_includes_expand_for_person_and_bunk() -> None:
+    """The assignments fetch must request `expand="person,bunk"` so the SDK populates
+    the relation payload. Without it, expand is empty and cm_ids cannot be resolved.
+    """
+    captured_kwargs: list[dict[str, Any]] = []
+
+    def make_collection(name: str) -> Any:
+        col = MagicMock()
+
+        def capture(*_args: Any, **kwargs: Any) -> list[Any]:
+            if name == BUNK_ASSIGNMENTS:
+                captured_kwargs.append(dict(kwargs))
+                return [_assignment(1, 100)]
+            if name == PERSONS:
+                return [_person(1, 10)]
+            return []
+
+        col.get_full_list.side_effect = capture
+        return col
+
+    pb = MagicMock()
+    pb.collection.side_effect = make_collection
+
+    session_satisfaction(session_cm_ids=[999], year=2026, scenario_id=None, pb_client=pb)
+
+    assert captured_kwargs, "BUNK_ASSIGNMENTS query was never issued"
+    qp = captured_kwargs[0].get("query_params") or {}
+    expand = qp.get("expand", "")
+    assert "person" in expand, f"expand missing 'person': {expand!r}"
+    assert "bunk" in expand, f"expand missing 'bunk': {expand!r}"
+
+
+def test_assignment_with_unresolved_expand_is_skipped() -> None:
+    """Defense: if the SDK returns an assignment without an expanded person/bunk
+    (stale data, missing relation), skip it with a log warning rather than 500.
+    """
+    from types import SimpleNamespace
+
+    persons = [_person(1, 10)]
+    # Valid: person 1 in bunk 10
+    good = _assignment(1, 10)
+    # Pathological: relation strings present but expand payload missing
+    bad = SimpleNamespace(id="abad", cm_id=42, person="p_orphan", bunk="b_orphan", session="s1", expand={})
+    pb = _build_pb_mock(persons, [good, bad], [])
+    resp = session_satisfaction([999], 2026, None, pb)
+
+    # Bad assignment is skipped silently; good one survives.
+    assert 1 in resp.campers
+
+
+def test_assignment_with_non_numeric_cm_id_is_skipped() -> None:
+    """CR1 — defense in depth: if the expanded person/bunk has a non-numeric cm_id
+    (data hygiene gap, manual edit, future schema regression), int() raises and would
+    abort the whole aggregation. Skip the row with a warning instead.
+    """
+    from types import SimpleNamespace
+
+    persons = [_person(1, 10), _person(2, 10)]
+    good = _assignment(1, 10)
+    # Pathological: cm_id is a non-numeric string. Real PB schema types it as number,
+    # but malformed data, partial-sync state, or schema migration gaps could surface
+    # this. The aggregator must not 500 the whole /api/satisfaction call on one bad row.
+    bad = SimpleNamespace(
+        id="abad",
+        cm_id=99,
+        person="p_bad",
+        bunk="b_bad",
+        session="s1",
+        expand={
+            "person": SimpleNamespace(id="p_bad", cm_id="not-a-number"),
+            "bunk": SimpleNamespace(id="b_bad", cm_id=20),
+        },
+    )
+    pb = _build_pb_mock(persons, [good, bad], [])
+    # Must not raise — bad row is skipped, good row is processed.
+    resp = session_satisfaction([999], 2026, None, pb)
+    assert 1 in resp.campers

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -1630,3 +1630,81 @@ def test_validator_warns_when_resolved_age_preference_has_null_source_field(
     assert any("source_field" in msg and "age_preference" in msg for msg in warning_messages), (
         f"Expected warning about null source_field on resolved age_preference; got: {warning_messages}"
     )
+
+
+# ---------------------------------------------------------------------------
+# #1105: unsatisfied_material_parent_persons drill-down list
+# ---------------------------------------------------------------------------
+
+
+def test_unsatisfied_material_parent_persons_empty_when_all_satisfied():
+    """When all material parent requests are satisfied, the drill-down list is empty."""
+    session = _mock_session()
+    persons = [_mock_person("20001"), _mock_person("20002")]
+    bunks = [_mock_bunk("30001")]
+    assignments = [_mock_assignment("20001", "30001"), _mock_assignment("20002", "30001")]
+    requests = [_mock_request("20001", "20002", SourceField.BUNK_WITH, "family")]
+
+    result = BunkingValidator().validate_bunking(
+        session=session,
+        bunks=bunks,
+        assignments=assignments,
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+    )
+
+    assert result.statistics.unsatisfied_material_parent_persons == []
+
+
+def test_unsatisfied_material_parent_persons_populated_when_request_unmet():
+    """When a material parent request is not satisfied, the person appears in the drill-down list."""
+    session = _mock_session()
+    persons = [_mock_person("20001"), _mock_person("20002"), _mock_person("20003")]
+    bunks = [_mock_bunk("30001"), _mock_bunk("30002")]
+    assignments = [
+        _mock_assignment("20001", "30001"),
+        _mock_assignment("20002", "30002"),  # NOT with 20001 — request unsatisfied
+        _mock_assignment("20003", "30001"),
+    ]
+    requests = [_mock_request("20001", "20002", SourceField.BUNK_WITH, "family")]
+
+    result = BunkingValidator().validate_bunking(
+        session=session,
+        bunks=bunks,
+        assignments=assignments,
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+    )
+
+    unmet = result.statistics.unsatisfied_material_parent_persons
+    assert len(unmet) == 1
+    assert unmet[0]["cm_id"] == 20001
+    assert unmet[0]["name"] == "Camper20001"
+
+
+def test_unsatisfied_material_parent_persons_includes_partial_satisfaction():
+    """Camper with 2 parent requests where only 1 is satisfied appears in the drill-down list."""
+    session = _mock_session()
+    persons = [_mock_person("20001"), _mock_person("20002"), _mock_person("20003")]
+    bunks = [_mock_bunk("30001"), _mock_bunk("30002")]
+    assignments = [
+        _mock_assignment("20001", "30001"),
+        _mock_assignment("20002", "30001"),  # satisfied: 20001 bunked with 20002
+        _mock_assignment("20003", "30002"),  # unsatisfied: 20001 NOT bunked with 20003
+    ]
+    requests = [
+        _mock_request("20001", "20002", SourceField.BUNK_WITH, "family"),  # satisfied
+        _mock_request("20001", "20003", SourceField.BUNK_WITH, "family"),  # unsatisfied
+    ]
+
+    result = BunkingValidator().validate_bunking(
+        session=session,
+        bunks=bunks,
+        assignments=assignments,
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+    )
+
+    unmet = result.statistics.unsatisfied_material_parent_persons
+    assert len(unmet) == 1, "Camper 20001 has 1 unmet parent request so must appear in the drill-down list"
+    assert unmet[0]["cm_id"] == 20001

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -1682,8 +1682,15 @@ def test_unsatisfied_material_parent_persons_populated_when_request_unmet():
     assert unmet[0]["name"] == "Camper20001"
 
 
-def test_unsatisfied_material_parent_persons_includes_partial_satisfaction():
-    """Camper with 2 parent requests where only 1 is satisfied appears in the drill-down list."""
+def test_unsatisfied_material_parent_persons_excludes_partial_satisfaction():
+    """Camper with 2 parent requests where ≥1 is satisfied is NOT in the drill-down list.
+
+    Per the canonical satisfaction policy in `bunking/satisfaction/aggregate.bucket_status`,
+    a bucket is "unsatisfied" only when total > 0 AND satisfied == 0. Partial satisfaction
+    (≥1 of N) classifies as "satisfied", so such campers must not appear in the unmet list
+    — otherwise the drill-down contradicts the modal header scalar
+    (`campers_with_unsatisfied_material_parent_requests`).
+    """
     session = _mock_session()
     persons = [_mock_person("20001"), _mock_person("20002"), _mock_person("20003")]
     bunks = [_mock_bunk("30001"), _mock_bunk("30002")]
@@ -1706,5 +1713,194 @@ def test_unsatisfied_material_parent_persons_includes_partial_satisfaction():
     )
 
     unmet = result.statistics.unsatisfied_material_parent_persons
-    assert len(unmet) == 1, "Camper 20001 has 1 unmet parent request so must appear in the drill-down list"
-    assert unmet[0]["cm_id"] == 20001
+    assert unmet == [], (
+        "Camper 20001 has 1 of 2 parent requests satisfied — per canonical policy this is "
+        "the 'satisfied' bucket, so they must NOT appear in the drill-down list."
+    )
+    # Sanity: scalar must agree.
+    assert result.statistics.campers_with_unsatisfied_material_parent_requests == 0
+
+
+def test_unsatisfied_material_parent_persons_sorted_alphabetically():
+    """Drill-down list is sorted alphabetically by name for deterministic UI rendering."""
+    session = _mock_session()
+    # Names chosen so insertion-order (request order) differs from alphabetical order.
+    persons = [
+        MockPerson(campminder_id="20001", name="Zoe Smith", grade=5),
+        MockPerson(campminder_id="20002", name="Anna Brown", grade=5),
+        MockPerson(campminder_id="20003", name="Mara Lee", grade=5),
+        _mock_person("20099"),
+    ]
+    bunks = [_mock_bunk("30001"), _mock_bunk("30002")]
+    # All requesters in their own bunk so no parent requests are satisfied.
+    assignments = [
+        _mock_assignment("20001", "30001"),
+        _mock_assignment("20002", "30001"),
+        _mock_assignment("20003", "30001"),
+        _mock_assignment("20099", "30002"),
+    ]
+    requests = [
+        _mock_request("20001", "20099", SourceField.BUNK_WITH, "family"),  # Zoe Smith
+        _mock_request("20002", "20099", SourceField.BUNK_WITH, "family"),  # Anna Brown
+        _mock_request("20003", "20099", SourceField.BUNK_WITH, "family"),  # Mara Lee
+    ]
+
+    result = BunkingValidator().validate_bunking(
+        session=session,
+        bunks=bunks,
+        assignments=assignments,
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+    )
+
+    unmet = result.statistics.unsatisfied_material_parent_persons
+    names = [entry["name"] for entry in unmet]
+    assert names == sorted(names), f"Expected alphabetical ordering, got: {names}"
+
+
+def test_unsatisfied_material_parent_persons_falls_back_when_person_missing():
+    """When a request's requester_id has no matching person row, fall back to 'Person {pid}'.
+
+    The requester (20999) IS assigned to a bunk so the request is processed, but is
+    absent from the persons list so `person_by_id.get(20999)` returns None and the
+    fallback name path executes.
+    """
+    session = _mock_session()
+    # 20999 is referenced as a requester but NOT in the persons list.
+    persons = [_mock_person("20002")]
+    bunks = [_mock_bunk("30001"), _mock_bunk("30002")]
+    assignments = [
+        _mock_assignment("20999", "30001"),  # requester assigned (so request is processed)
+        _mock_assignment("20002", "30002"),  # target in different bunk → unsatisfied
+    ]
+    requests = [_mock_request("20999", "20002", SourceField.BUNK_WITH, "family")]
+
+    result = BunkingValidator().validate_bunking(
+        session=session,
+        bunks=bunks,
+        assignments=assignments,
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+    )
+
+    unmet = result.statistics.unsatisfied_material_parent_persons
+    fallback_entries = [entry for entry in unmet if entry["name"] == "Person 20999"]
+    assert len(fallback_entries) == 1, f"Expected fallback entry for unknown person; got: {unmet}"
+    assert fallback_entries[0]["cm_id"] == 20999
+
+
+# ---------------------------------------------------------------------------
+# #1170 — Validator must consume bunking.satisfaction.predicate, not maintain a
+# local duplicate. The drift was surfaced when #1169 introduced
+# unsatisfied_material_parent_persons, whose initial classification contradicted
+# the canonical bucket_status policy because the validator's satisfaction logic
+# wasn't grounded in the canonical predicate.
+# ---------------------------------------------------------------------------
+
+
+def test_validator_imports_canonical_predicate_and_drops_local_duplicate():
+    """The validator module must import is_request_satisfied from
+    bunking.satisfaction.predicate and must NOT define its own local duplicate.
+    """
+    import inspect
+
+    import bunking.bunking_validator as v
+
+    src = inspect.getsource(v)
+    assert "from bunking.satisfaction.predicate import is_request_satisfied" in src, (
+        "validator must import is_request_satisfied from bunking.satisfaction.predicate"
+    )
+    # Local duplicate must be removed — single source of truth.
+    assert "def is_request_satisfied(" not in src, (
+        "validator still defines a local is_request_satisfied; drop it and use the canonical import"
+    )
+
+
+def test_validator_satisfied_counts_match_canonical_predicate_on_mixed_fixture():
+    """Behavioral pin: satisfied_material_parent_requests and satisfied counts
+    must match what bunking.satisfaction.predicate.is_request_satisfied would
+    compute for the same fixture. Guards against drift during the migration.
+
+    The validator bins by source_field, not source — so a fixture exercising the
+    binning + satisfaction split needs varied source_fields. This test sticks to
+    bunk_with parent requests because those drive the material_parent bucket
+    that #1170's drift surfaced.
+    """
+    session = _mock_session(cm_id="10000001", name="MixedFixture")
+    persons = [_mock_person(str(cm), grade=5) for cm in (20001, 20002, 20003, 20004)]
+    bunks = [_mock_bunk("30001"), _mock_bunk("30002")]
+    # 20001, 20002 in bunk 30001; 20003, 20004 in bunk 30002.
+    assignments = [
+        _mock_assignment("20001", "30001"),
+        _mock_assignment("20002", "30001"),
+        _mock_assignment("20003", "30002"),
+        _mock_assignment("20004", "30002"),
+    ]
+    requests = [
+        # satisfied bunk_with parent: 20001 → 20002 (same bunk)
+        _mock_request("20001", "20002", SourceField.BUNK_WITH, "family"),
+        # unsatisfied bunk_with parent: 20001 → 20003 (different bunks)
+        _mock_request("20001", "20003", SourceField.BUNK_WITH, "family"),
+        # unsatisfied bunk_with parent: 20003 → 20001 (different bunks)
+        _mock_request("20003", "20001", SourceField.BUNK_WITH, "family"),
+    ]
+
+    result = BunkingValidator().validate_bunking(
+        session=session,
+        bunks=bunks,
+        assignments=assignments,
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+    )
+    stats = result.statistics
+
+    # Material parent (bunk_with source_field): 3 total, 1 satisfied (20001→20002).
+    # The exact counts must hold across the predicate migration — they pin
+    # behavior that downstream metrics + UI depend on.
+    assert stats.material_parent_requests == 3
+    assert stats.satisfied_material_parent_requests == 1
+    # 20001 has ≥1 satisfied → bucket "satisfied" under canonical policy → NOT
+    # in unmet. 20003 has 0 satisfied → bucket "unsatisfied" → IS in unmet.
+    assert stats.campers_with_unsatisfied_material_parent_requests == 1
+    unmet_ids = {entry["cm_id"] for entry in stats.unsatisfied_material_parent_persons}
+    assert unmet_ids == {20003}
+
+
+def test_validator_is_satisfied_returns_false_on_non_numeric_grade():
+    """CR2 — defensive: the _is_satisfied adapter must absorb int() failures across
+    the FULL row construction (requested_person_cm_id, requester_grade), not just
+    the requester id. Currently a non-numeric grade would raise inside the adapter
+    and abort validation; legacy local predicate returned False on data-hygiene
+    gaps, and the adapter should mirror that.
+    """
+    session = _mock_session(cm_id="10000001", name="GradeHygieneFixture")
+    # Person with a non-numeric grade (corrupt CSV, schema migration gap, etc.).
+    # _mock_person normally takes int grade; cast to bypass the helper's typing.
+    bad_grade_person = MockPerson(campminder_id="20001", name="Camper20001", grade=cast(Any, "K"))
+    persons = [bad_grade_person, _mock_person("20002", grade=5)]
+    bunks = [_mock_bunk("30001"), _mock_bunk("30002")]
+    assignments = [
+        _mock_assignment("20001", "30001"),
+        _mock_assignment("20002", "30002"),
+    ]
+    # An age_preference request — needs requester_grade. Bad grade should NOT 500.
+    requests = [
+        _mock_request(
+            "20001",
+            "0",
+            SourceField.SOCIALIZE_WITH,
+            "family",
+            request_type="age_preference",
+        ),
+    ]
+
+    # Must not raise — adapter swallows ValueError, treats as unsatisfied.
+    result = BunkingValidator().validate_bunking(
+        session=session,
+        bunks=bunks,
+        assignments=assignments,
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+    )
+    # Validation completed without crashing — that's the contract.
+    assert result.statistics is not None


### PR DESCRIPTION
## Summary

- **#1044** — `CamperCohortsSection` now shows a "Primary session only" note below cohort rows when the camper is enrolled in multiple sessions. Wires `hasMultipleEnrollments={currentEnrollments.length > 1}` from `CamperDetailsPanel`.

- **#1105** — `PostValidationResultsModal` gains an "Unmet parent requests (N)" collapsible section. Backend emits a new `unsatisfied_material_parent_persons: [{cm_id, name}]` list (persons with ≥1 unmet material parent request). Expanding the section shows camper names so staff can immediately see who was missed without hunting through the roster.

## Files changed

| File | Change |
|---|---|
| `bunking/bunking_validator.py` | Add `unsatisfied_material_parent_persons` field to `ValidationStatistics`; populate from `material_parent_by_person` / `person_by_id` |
| `tests/unit/test_bunking_validator.py` | 3 new tests: empty when all satisfied, populated on unmet, includes partial-satisfaction case |
| `frontend/src/components/CamperCohortsSection.tsx` | Add `hasMultipleEnrollments?` prop; render "(Primary session only)" note |
| `frontend/src/components/CamperCohortsSection.test.tsx` | 3 new tests: annotation shown/hidden by prop |
| `frontend/src/components/CamperDetailsPanel.tsx` | Pass `hasMultipleEnrollments={currentEnrollments.length > 1}` |
| `frontend/src/components/PostValidationResultsModal.tsx` | Add `unsatisfied_material_parent_persons?` to interface; add collapsible drill-down section |
| `frontend/src/components/PostValidationResultsModal.render.test.tsx` | 4 new tests: section hidden when empty/absent, shown when populated, names visible after expand |

## Test plan

- [ ] Open a multi-session camper in `CamperDetailsPanel` → cohort rows show "Primary session only" note below
- [ ] Open a single-session camper → no note appears
- [ ] Run solver on a session with unmet parent requests → "Check Bunking" modal shows "Unmet parent requests (N)" section
- [ ] Expand the section → camper names listed
- [ ] Run solver where all parent requests are satisfied → section absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Unmet parent requests" drill-down in validation results to display campers whose parent requests were not satisfied.
  * Added multi-session indicator showing "Cohorts from this session only" when campers have multiple enrollments.
  * Enhanced badge logic for material age-preference and staff assignment indicators.

* **Bug Fixes**
  * Improved badge fallback rendering when backend satisfaction data is unavailable.
  * Enhanced resilience for missing or malformed assignment data.

* **Tests**
  * Expanded test coverage for badge rendering, fallback behavior, and multi-session workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->