### PR TITLE
feat(frontend): show CSV upload time on requests sync label

### DIFF
--- a/frontend/src/hooks/useSyncStatusAPI.ts
+++ b/frontend/src/hooks/useSyncStatusAPI.ts
@@ -98,6 +98,12 @@ export interface SyncStatusResponse {
   _queue_length?: number
   // Current run progress (remaining jobs in active sequence)
   _current_run?: CurrentRunProgress
+  // Most recent bunk_requests CSV upload (filename + RFC3339 timestamp).
+  // Absent if no CSV has been uploaded for the current data dir.
+  _bunk_requests_upload?: {
+    filename: string
+    uploaded_at: string
+  }
 }
 
 // On 401 the hook returns null instead of a fake `{}` cast to SyncStatusResponse.

--- a/frontend/src/layouts/AppLayout.test.tsx
+++ b/frontend/src/layouts/AppLayout.test.tsx
@@ -274,6 +274,81 @@ describe('AppLayout sync-status labels', () => {
   })
 })
 
+describe('AppLayout requests upload label', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPerms = {
+      hasPermission: (p: string) => p === 'bunking.manage',
+      isAdmin: false,
+    }
+  })
+
+  // Use an upload time well in the past so the relative phrase is stable
+  // across test runs ("about 1 month ago" instead of e.g. "less than a minute ago").
+  const uploadedAt = '2026-04-04T14:13:00.000Z'
+  const syncIso = '2026-04-22T12:00:00.000Z'
+
+  function mockWithUpload(filename: string) {
+    syncStatusSpy.mockImplementation(() => ({
+      data: {
+        bunk_assignments: {
+          status: 'success',
+          end_time: syncIso,
+          start_time: syncIso,
+          summary: { created: 1, updated: 2, skipped: 0, errors: 0 },
+        },
+        bunk_requests: {
+          status: 'success',
+          end_time: syncIso,
+          start_time: syncIso,
+          summary: { created: 3, updated: 4, skipped: 1, errors: 0 },
+        },
+        _bunk_requests_upload: { filename, uploaded_at: uploadedAt },
+      } as SyncStatusResponse,
+    }))
+  }
+
+  it('uses upload time and absolute+relative wording when metadata is present', () => {
+    mockWithUpload('BunkRequests_2026-04-04.csv')
+    renderAppLayout()
+
+    const label = screen.getByText(/Requests uploaded/)
+    expect(label).toBeInTheDocument()
+    // Absolute date (date-fns "MMM d" — locale-independent month abbrev)
+    expect(label.textContent).toMatch(/Apr 4/)
+    // Relative phrase ("ago" suffix)
+    expect(label.textContent).toMatch(/ago/)
+    // Should NOT use the sync end_time wording when upload metadata exists
+    expect(screen.queryByText(/Requests synced/)).not.toBeInTheDocument()
+  })
+
+  it('exposes the original CSV filename via tooltip', () => {
+    mockWithUpload('BunkRequests_2026-04-04.csv')
+    renderAppLayout()
+    const label = screen.getByText(/Requests uploaded/)
+    const tooltipHost = label.closest('[title]') as HTMLElement | null
+    expect(tooltipHost).not.toBeNull()
+    const title = tooltipHost?.getAttribute('title') ?? ''
+    expect(title).toContain('BunkRequests_2026-04-04.csv')
+  })
+
+  it('falls back to "Requests synced" wording when upload metadata is missing', () => {
+    syncStatusSpy.mockImplementation(() => ({
+      data: {
+        bunk_requests: {
+          status: 'success',
+          end_time: syncIso,
+          start_time: syncIso,
+          summary: { created: 0, updated: 0, skipped: 0, errors: 0 },
+        },
+      } as SyncStatusResponse,
+    }))
+    renderAppLayout()
+    expect(screen.getByText(/Requests synced/)).toBeInTheDocument()
+    expect(screen.queryByText(/Requests uploaded/)).not.toBeInTheDocument()
+  })
+})
+
 // Regression boundary: sentinel shape returned on 401, not the full
 // pb.afterSend async-redirect race. See #1011 for the discriminated-union fix.
 describe('AppLayout fresh-login crash guard', () => {

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -31,7 +31,7 @@ import { useYear } from '../hooks/useCurrentYear'
 import { usePermissions } from '../hooks/usePermissions'
 import { Permission } from '../constants/permissions'
 import { useSyncStatusAPI } from '../hooks/useSyncStatusAPI'
-import { formatDistanceToNow } from 'date-fns'
+import { format, formatDistanceToNow } from 'date-fns'
 import { useProgram } from '../contexts/ProgramContext'
 import { getProgramFromPath, getProgramHomeUrl } from '../utils/programUrls'
 import { pb } from '../lib/pocketbase'
@@ -707,7 +707,9 @@ export const AppLayout = () => {
               </div>
               {activeProgram === 'summer' &&
                 syncStatus &&
-                (syncStatus.bunk_assignments?.end_time ?? syncStatus.bunk_requests?.end_time) && (
+                (syncStatus.bunk_assignments?.end_time ??
+                  syncStatus.bunk_requests?.end_time ??
+                  syncStatus._bunk_requests_upload?.uploaded_at) && (
                   <div className="text-muted-foreground flex items-center gap-3 text-xs">
                     {syncStatus.bunk_assignments?.end_time && (
                       <span
@@ -721,17 +723,39 @@ export const AppLayout = () => {
                         })}
                       </span>
                     )}
-                    {syncStatus.bunk_requests?.end_time && (
+                    {syncStatus._bunk_requests_upload?.uploaded_at ? (
                       <span
                         className="flex items-center gap-1.5 whitespace-nowrap"
-                        title={buildSyncTooltip('bunk requests', syncStatus.bunk_requests)}
+                        title={`${syncStatus._bunk_requests_upload.filename} • ${buildSyncTooltip(
+                          'bunk requests',
+                          syncStatus.bunk_requests ?? { status: 'idle' }
+                        )}`}
                       >
                         <Clock className="h-3 w-3" />
-                        Requests synced{' '}
-                        {formatDistanceToNow(new Date(syncStatus.bunk_requests.end_time), {
-                          addSuffix: true,
-                        })}
+                        Requests uploaded{' '}
+                        {format(
+                          new Date(syncStatus._bunk_requests_upload.uploaded_at),
+                          'MMM d, h:mm a'
+                        )}
+                        {' · '}
+                        {formatDistanceToNow(
+                          new Date(syncStatus._bunk_requests_upload.uploaded_at),
+                          { addSuffix: true }
+                        )}
                       </span>
+                    ) : (
+                      syncStatus.bunk_requests?.end_time && (
+                        <span
+                          className="flex items-center gap-1.5 whitespace-nowrap"
+                          title={buildSyncTooltip('bunk requests', syncStatus.bunk_requests)}
+                        >
+                          <Clock className="h-3 w-3" />
+                          Requests synced{' '}
+                          {formatDistanceToNow(new Date(syncStatus.bunk_requests.end_time), {
+                            addSuffix: true,
+                          })}
+                        </span>
+                      )
                     )}
                   </div>
                 )}

--- a/pocketbase/sync/api.go
+++ b/pocketbase/sync/api.go
@@ -940,6 +940,16 @@ func handleSyncStatus(e *core.RequestEvent, scheduler *Scheduler) error {
 	}
 	statuses["_configured_year"] = configuredYear
 
+	// Add bunk requests CSV upload metadata if a CSV has ever been uploaded.
+	// Read failures are logged but not surfaced — the absence of this field is
+	// indistinguishable from "no upload yet" on the frontend, which is the
+	// correct fallback either way.
+	if meta, err := readBunkRequestsUploadMetadata(scheduler.app.DataDir()); err != nil {
+		slog.Warn("Failed to read bunk_requests upload metadata", "error", err)
+	} else if meta != nil {
+		statuses["_bunk_requests_upload"] = meta
+	}
+
 	// Add queue info
 	queue := orchestrator.GetQueuedSyncs()
 	queueInfo := make([]map[string]any, len(queue))

--- a/pocketbase/sync/upload_metadata.go
+++ b/pocketbase/sync/upload_metadata.go
@@ -1,0 +1,37 @@
+package sync
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// BunkRequestsUploadMetadata is the subset of upload_metadata.json exposed to
+// the frontend. The on-disk file may contain additional fields (size,
+// header_count, year) that are intentionally ignored here.
+type BunkRequestsUploadMetadata struct {
+	Filename   string `json:"filename"`
+	UploadedAt string `json:"uploaded_at"`
+}
+
+// readBunkRequestsUploadMetadata reads bunk_requests/upload_metadata.json from
+// the given data dir. Returns (nil, nil) when the file is absent — the typical
+// state before the first CSV upload of a season.
+func readBunkRequestsUploadMetadata(dataDir string) (*BunkRequestsUploadMetadata, error) {
+	path := filepath.Join(dataDir, "bunk_requests", "upload_metadata.json")
+	data, err := os.ReadFile(path) //nolint:gosec // path is composed from controlled dataDir
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read upload metadata: %w", err)
+	}
+
+	var meta BunkRequestsUploadMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("parse upload metadata: %w", err)
+	}
+	return &meta, nil
+}

--- a/pocketbase/sync/upload_metadata_test.go
+++ b/pocketbase/sync/upload_metadata_test.go
@@ -1,0 +1,66 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadBunkRequestsUploadMetadata_Missing(t *testing.T) {
+	tmp := t.TempDir()
+	got, err := readBunkRequestsUploadMetadata(tmp)
+	if err != nil {
+		t.Fatalf("expected nil error on missing metadata, got %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil result on missing metadata, got %+v", got)
+	}
+}
+
+func TestReadBunkRequestsUploadMetadata_Valid(t *testing.T) {
+	tmp := t.TempDir()
+	csvDir := filepath.Join(tmp, "bunk_requests")
+	if err := os.MkdirAll(csvDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	contents := `{
+		"filename": "BunkRequests_2026-05-04.csv",
+		"uploaded_at": "2026-05-04T14:13:22Z",
+		"size": 12345,
+		"header_count": 42,
+		"year": 2026
+	}`
+	if err := os.WriteFile(filepath.Join(csvDir, "upload_metadata.json"), []byte(contents), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := readBunkRequestsUploadMetadata(tmp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if got.Filename != "BunkRequests_2026-05-04.csv" {
+		t.Errorf("filename = %q, want BunkRequests_2026-05-04.csv", got.Filename)
+	}
+	if got.UploadedAt != "2026-05-04T14:13:22Z" {
+		t.Errorf("uploaded_at = %q, want 2026-05-04T14:13:22Z", got.UploadedAt)
+	}
+}
+
+func TestReadBunkRequestsUploadMetadata_InvalidJSON(t *testing.T) {
+	tmp := t.TempDir()
+	csvDir := filepath.Join(tmp, "bunk_requests")
+	if err := os.MkdirAll(csvDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(csvDir, "upload_metadata.json"), []byte("not json"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if _, err := readBunkRequestsUploadMetadata(tmp); err == nil {
+		t.Fatal("expected parse error on invalid JSON, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the relative-only **"Requests synced 9 hours ago"** label in the top nav with the actual CSV upload time, formatted absolute + relative:

> Requests uploaded May 4, 2:13 PM · about 8 hours ago

The original CSV filename is exposed via tooltip.

## Why

Staff wanted the *upload* time, not the sync-job finish time. The backend already captures both `filename` and `uploaded_at` in `bunk_requests/upload_metadata.json` on every CSV upload — but it was never exposed to the frontend.

## Changes

- **Backend (Go):** new \`readBunkRequestsUploadMetadata()\` reads the existing metadata JSON; \`/api/custom/sync/status\` now includes \`_bunk_requests_upload?: { filename, uploaded_at }\` when a CSV has been uploaded.
- **Frontend:** \`AppLayout\` prefers the upload time when present (absolute + relative wording, filename in tooltip) and falls back to the existing \`bunk_requests.end_time\` "Requests synced X ago" wording when no CSV upload metadata exists.
- No schema changes. No new endpoints. No migration.

## Test plan

- [x] 3 Go unit tests for the metadata reader (missing file, valid JSON, invalid JSON)
- [x] 3 RTL tests for the AppLayout label (upload-driven wording, filename in tooltip, fallback to old wording)
- [x] Full pre-push verification: \`go build\` + \`go test -race\` (1997 tests), TypeScript \`tsc --noEmit\`, ESLint, Vitest (3604 tests), shellcheck — all green
- [ ] Manual smoke: upload a CSV in dev, confirm label changes from "synced X ago" to "uploaded \<date\> · X ago"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced sync status display to show when bunk requests were uploaded with formatted timestamps and relative time information.
  * Bunk request upload details including original filename are now visible in a tooltip, providing transparency into request submission history.

* **Tests**
  * Added comprehensive test coverage for upload status display and metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->