### PR TITLE
fix(frontend): align CSV pipeline indicator with actual status_breakdown shape

### DIFF
--- a/frontend/src/hooks/useCsvPipelineStatus.test.tsx
+++ b/frontend/src/hooks/useCsvPipelineStatus.test.tsx
@@ -113,7 +113,7 @@ describe('useCsvPipelineStatus', () => {
             {
               run_id: 'r-done',
               created: debugCreated,
-              status_breakdown: { status_resolved: 18, status_pending: 4, status_declined: 2 },
+              status_breakdown: { resolved: 18, pending: 4, declined: 2 },
             },
           ],
         }),

--- a/frontend/src/services/csvPipelineStatus.test.ts
+++ b/frontend/src/services/csvPipelineStatus.test.ts
@@ -67,7 +67,7 @@ describe('derivePhase', () => {
       const fresh: DebugPipelineRun = {
         run_id: 'r-cron-recent',
         created: ago(5),
-        status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
+        status_breakdown: { resolved: 1, pending: 0, declined: 0 },
       }
       const csvUploadStartedAt = ago(2)
       expect(derivePhase(sync, fresh, csvUploadStartedAt).phase).toBe('idle')
@@ -113,7 +113,7 @@ describe('derivePhase', () => {
       const fresh: DebugPipelineRun = {
         run_id: 'r-cron',
         created: ago(1),
-        status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
+        status_breakdown: { resolved: 1, pending: 0, declined: 0 },
       }
       expect(derivePhase(sync, fresh, null).phase).toBe('idle')
     })
@@ -159,7 +159,7 @@ describe('derivePhase', () => {
       const stale: DebugPipelineRun = {
         run_id: 'old',
         created: ago(60),
-        status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
+        status_breakdown: { resolved: 1, pending: 0, declined: 0 },
       }
       const csvUploadStartedAt = ago(6)
       expect(derivePhase(sync, stale, csvUploadStartedAt).phase).toBe('matching')
@@ -175,7 +175,7 @@ describe('derivePhase', () => {
       const fresh: DebugPipelineRun = {
         run_id: 'r1',
         created: ago(1),
-        status_breakdown: { status_resolved: 20, status_pending: 6, status_declined: 2 },
+        status_breakdown: { resolved: 20, pending: 6, declined: 2 },
       }
       const csvUploadStartedAt = ago(6)
       const result = derivePhase(sync, fresh, csvUploadStartedAt)
@@ -209,7 +209,7 @@ describe('derivePhase', () => {
       const stale: DebugPipelineRun = {
         run_id: 'r-stale',
         created: ago(50),
-        status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
+        status_breakdown: { resolved: 1, pending: 0, declined: 0 },
       }
       const csvUploadStartedAt = ago(61)
       expect(derivePhase(sync, stale, csvUploadStartedAt).phase).toBe('error')
@@ -226,7 +226,7 @@ describe('derivePhase', () => {
       const tooLate: DebugPipelineRun = {
         run_id: 'r3',
         created: ago(50),
-        status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
+        status_breakdown: { resolved: 1, pending: 0, declined: 0 },
       }
       const csvUploadStartedAt = ago(121)
       expect(derivePhase(sync, tooLate, csvUploadStartedAt).phase).toBe('error')
@@ -243,7 +243,7 @@ describe('derivePhase', () => {
       const debug: DebugPipelineRun = {
         run_id: 'r-boundary',
         created: ago(30),
-        status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
+        status_breakdown: { resolved: 1, pending: 0, declined: 0 },
       }
       const csvUploadStartedAt = ago(91)
       expect(derivePhase(sync, debug, csvUploadStartedAt).phase).toBe('done')
@@ -260,7 +260,7 @@ describe('derivePhase', () => {
       const debug: DebugPipelineRun = {
         run_id: 'r-just-past',
         created: new Date(Date.now() - 29.99 * 60_000).toISOString(),
-        status_breakdown: { status_resolved: 1, status_pending: 0, status_declined: 0 },
+        status_breakdown: { resolved: 1, pending: 0, declined: 0 },
       }
       const csvUploadStartedAt = ago(91)
       expect(derivePhase(sync, debug, csvUploadStartedAt).phase).toBe('error')
@@ -277,7 +277,7 @@ describe('derivePhase', () => {
       const orphan: DebugPipelineRun = {
         run_id: 'r2',
         created: ago(20),
-        status_breakdown: { status_resolved: 5, status_pending: 1, status_declined: 0 },
+        status_breakdown: { resolved: 5, pending: 1, declined: 0 },
       }
       // Long-running uploads can outlast the upload marker — proximity is checked, but
       // orphan grace recovery is itself evidence the upload's matching ran. Pass a
@@ -296,7 +296,7 @@ describe('derivePhase', () => {
       const dedup: DebugPipelineRun = {
         run_id: 'r4',
         created: ago(0.5),
-        status_breakdown: { status_resolved: 0, status_pending: 0, status_declined: 0 },
+        status_breakdown: { resolved: 0, pending: 0, declined: 0 },
       }
       const csvUploadStartedAt = ago(3)
       const result = derivePhase(sync, dedup, csvUploadStartedAt)
@@ -453,7 +453,7 @@ describe('fetchLatestDebugRun', () => {
             id: 'pb-id',
             run_id: 'run-abc',
             created: '2026-04-27T19:05:00Z',
-            status_breakdown: { status_resolved: 5, status_pending: 1, status_declined: 0 },
+            status_breakdown: { resolved: 5, pending: 1, declined: 0 },
             year: 2026,
             trace_count: 6,
           },
@@ -465,7 +465,7 @@ describe('fetchLatestDebugRun', () => {
     expect(res).toEqual({
       run_id: 'run-abc',
       created: '2026-04-27T19:05:00Z',
-      status_breakdown: { status_resolved: 5, status_pending: 1, status_declined: 0 },
+      status_breakdown: { resolved: 5, pending: 1, declined: 0 },
     })
   })
 
@@ -498,7 +498,7 @@ describe('fetchLatestDebugRun', () => {
     expect(await fetchLatestDebugRun(mock)).toBeNull()
   })
 
-  it('returns null when status_breakdown.status_resolved is non-numeric', async () => {
+  it('returns null when status_breakdown.resolved is non-numeric', async () => {
     const mock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -506,11 +506,62 @@ describe('fetchLatestDebugRun', () => {
           {
             run_id: 'run-bad-type',
             created: '2026-04-27T19:05:00Z',
-            status_breakdown: { status_resolved: 'five', status_pending: 0, status_declined: 0 },
+            status_breakdown: { resolved: 'five', pending: 0, declined: 0 },
           },
         ],
       }),
     } as Response)
     expect(await fetchLatestDebugRun(mock)).toBeNull()
+  })
+
+  // Regression: trace_collector.py writes status_breakdown with unprefixed keys
+  // (resolved/pending/declined/skipped/deduped). The frontend previously expected
+  // a status_-prefixed shape and rejected every real row, causing the indicator
+  // to surface "Matching step did not complete" 10 minutes after sync completion
+  // even though processing had succeeded.
+  it('parses the production status_breakdown shape (unprefixed keys from trace_collector.py)', async () => {
+    const mock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            id: 'pb-id',
+            run_id: 'run-prod',
+            created: '2026-04-27T19:05:00Z',
+            status_breakdown: { resolved: 200, pending: 12, declined: 8, skipped: 3, deduped: 1 },
+          },
+        ],
+        totalItems: 1,
+      }),
+    } as Response)
+    const res = await fetchLatestDebugRun(mock)
+    expect(res).not.toBeNull()
+    expect(res?.run_id).toBe('run-prod')
+    expect(res?.status_breakdown.resolved).toBe(200)
+    expect(res?.status_breakdown.pending).toBe(12)
+    expect(res?.status_breakdown.declined).toBe(8)
+  })
+})
+
+describe('derivePhase with production status_breakdown shape', () => {
+  it("returns 'done' when fresh debug row arrives with unprefixed keys (regression for #1043)", () => {
+    const sync: SyncJobStatus = {
+      name: 'bunk_requests',
+      status: 'completed',
+      startedAt: ago(5),
+      finishedAt: ago(3),
+    }
+    const fresh: DebugPipelineRun = {
+      run_id: 'r-prod',
+      created: ago(1),
+      status_breakdown: { resolved: 200, pending: 12, declined: 8 },
+    }
+    const csvUploadStartedAt = ago(6)
+    const result = derivePhase(sync, fresh, csvUploadStartedAt)
+    expect(result.phase).toBe('done')
+    expect(result).toMatchObject({
+      counts: { total: 220, autoMatched: 208, needReview: 12 },
+      runId: 'r-prod',
+    })
   })
 })

--- a/frontend/src/services/csvPipelineStatus.ts
+++ b/frontend/src/services/csvPipelineStatus.ts
@@ -9,10 +9,13 @@ export interface SyncJobStatus {
 export interface DebugPipelineRun {
   run_id: string
   created: string
+  // Shape matches what trace_collector._compute_status_breakdown writes
+  // (bunking/sync/bunk_request_processor/debug/trace_collector.py). The other
+  // frontend consumer (PipelineRunSelector) reads the same keys — keep aligned.
   status_breakdown: {
-    status_resolved: number
-    status_pending: number
-    status_declined: number
+    resolved: number
+    pending: number
+    declined: number
   }
 }
 
@@ -131,9 +134,9 @@ export function derivePhase(
 }
 
 function doneFromDebug(d: DebugPipelineRun): PipelinePhase {
-  const { status_resolved, status_pending, status_declined } = d.status_breakdown
-  const autoMatched = status_resolved + status_declined
-  const needReview = status_pending
+  const { resolved, pending, declined } = d.status_breakdown
+  const autoMatched = resolved + declined
+  const needReview = pending
   return {
     phase: 'done',
     runId: d.run_id,
@@ -193,7 +196,13 @@ type RawDebugListResponse = {
   items: Array<{
     run_id: string
     created: string
-    status_breakdown: { status_resolved: number; status_pending: number; status_declined: number }
+    // PB returns the JSON field as-is. trace_collector also writes skipped and
+    // deduped, but only resolved/pending/declined are consumed here.
+    status_breakdown?: {
+      resolved?: unknown
+      pending?: unknown
+      declined?: unknown
+    }
   }>
 }
 
@@ -209,17 +218,18 @@ export async function fetchLatestDebugRun(
   if (!first) return null
   // Guard against malformed rows (schema mismatch, partial write). Without
   // this, doneFromDebug would throw a TypeError when destructuring the counts.
+  const sb = first.status_breakdown
   if (
-    !first.status_breakdown ||
-    typeof first.status_breakdown.status_resolved !== 'number' ||
-    typeof first.status_breakdown.status_pending !== 'number' ||
-    typeof first.status_breakdown.status_declined !== 'number'
+    !sb ||
+    typeof sb.resolved !== 'number' ||
+    typeof sb.pending !== 'number' ||
+    typeof sb.declined !== 'number'
   ) {
     return null
   }
   return {
     run_id: first.run_id,
     created: first.created,
-    status_breakdown: first.status_breakdown,
+    status_breakdown: { resolved: sb.resolved, pending: sb.pending, declined: sb.declined },
   }
 }


### PR DESCRIPTION
## Summary

The CSV upload indicator surfaced **"Matching step did not complete — check server logs"** after every successful upload. The matching step was fine — the GUI was mis-reading the result.

## Root cause

`bunking/sync/bunk_request_processor/debug/trace_collector.py:325` writes:
```python
{"resolved": N, "pending": N, "declined": N, "skipped": N, "deduped": N}
```

`frontend/src/services/csvPipelineStatus.ts` was reading `status_breakdown.status_resolved` / `.status_pending` / `.status_declined`. The validation guard rejected every real production row → `fetchLatestDebugRun` returned `null` → `derivePhase` fell through to the 10-minute `MATCHING_MAX_AGE_MS` safety net and surfaced the error message even though the pipeline had succeeded and 200+ requests were created.

The other frontend consumer of the same field (`PipelineRunSelector`) reads the correct unprefixed keys; `csvPipelineStatus.ts` and its test fixtures were the outlier. The mock in the existing test happened to use the same wrong shape, so the tests passed against data the system never produces.

## Changes

- `csvPipelineStatus.ts` — `DebugPipelineRun` shape, `doneFromDebug` destructure, raw response type, and validation guard now read `resolved`/`pending`/`declined`. The fetch result extracts only the three consumed fields rather than passing the raw object through, so future schema additions (`skipped`/`deduped` already exist) don't trip the type.
- `csvPipelineStatus.test.ts` — adds a regression test that mocks the actual production shape and a `derivePhase` test that exercises the full path to `'done'` with unprefixed keys; renames every existing fixture to match production.
- `useCsvPipelineStatus.test.tsx` — fixture rename.

## Test plan

- [x] New tests fail before the fix is applied (verified mid-development)
- [x] `frontend/src/services/csvPipelineStatus.test.ts` — 38 tests pass
- [x] `frontend/src/hooks/useCsvPipelineStatus.test.tsx` — 16 tests pass
- [x] Full frontend suite — 3606/3606 pass
- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [ ] Verify in prod: next CSV upload → indicator transitions importing → matching → done with counts; the 10-min "Matching step did not complete" error should not fire on successful runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal data structures for CSV pipeline status tracking to improve consistency and maintainability.

* **Tests**
  * Enhanced test coverage for pipeline status validation and parsing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->