### PR TITLE
fix(frontend): scale solver poll budget to requested time_limit

### DIFF
--- a/frontend/src/services/solver.test.ts
+++ b/frontend/src/services/solver.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for solverService poll-budget behavior.
+ *
+ * Bug: pollSolverStatus had a hardcoded 60-attempt cap that fires at ~60s
+ * regardless of the requested solver time_limit, and runSolver did not
+ * thread the requested time_limit through to the poller. A user-selected
+ * 300s solve therefore always threw "Solver timeout - took longer than
+ * expected" even when the backend was still healthily working and
+ * ultimately succeeded.
+ *
+ * Fix: derive the poll budget from the requested time_limit so a 5m solve
+ * gets 5m + buffer of patience, and have runSolver pass timeLimit through.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { POLL_BUFFER_SECONDS, solverService } from './solver'
+
+const POLL_INTERVAL_MS = 1000
+const TEST_SESSION_ID = '1000001'
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(''),
+  } as Response
+}
+
+function pendingResponse() {
+  return jsonResponse({ status: 'pending' })
+}
+
+function completedResponse() {
+  return jsonResponse({
+    status: 'completed',
+    session_id: TEST_SESSION_ID,
+    started_at: '2026-05-06T21:07:12.000Z',
+    completed_at: '2026-05-06T21:12:12.000Z',
+    results: { stats: { status: 'FEASIBLE' } },
+  })
+}
+
+async function advancePolls(count: number) {
+  for (let i = 0; i < count; i++) {
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS)
+  }
+}
+
+describe('solverService.runSolver poll budget', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not give up at 60s when timeLimit is 300s and backend completes at ~200s', async () => {
+    let runIdReturned = false
+    let pollCount = 0
+
+    const fetchWithAuth = vi.fn(async (url: string) => {
+      // First call: POST /api/solver/run -> returns run_id
+      if (!runIdReturned) {
+        runIdReturned = true
+        return jsonResponse({ run_id: 'run-toc-1' })
+      }
+      // Subsequent calls: GET /api/solver/run/<id> -> pending until 200th poll
+      expect(url).toContain('/api/solver/run/run-toc-1')
+      pollCount += 1
+      if (pollCount < 200) return pendingResponse()
+      return completedResponse()
+    })
+
+    const promise = solverService.runSolver(TEST_SESSION_ID, 2026, null, fetchWithAuth, 300)
+    await advancePolls(205)
+    const result = await promise
+
+    expect(result.status).toBe('completed')
+    expect(pollCount).toBeGreaterThanOrEqual(200)
+  })
+
+  it('still throws when backend hangs longer than timeLimit + POLL_BUFFER_SECONDS', async () => {
+    let runIdReturned = false
+
+    const fetchWithAuth = vi.fn(async () => {
+      if (!runIdReturned) {
+        runIdReturned = true
+        return jsonResponse({ run_id: 'run-hang' })
+      }
+      return pendingResponse()
+    })
+
+    const timeLimit = 30
+    const promise = solverService.runSolver(TEST_SESSION_ID, 2026, null, fetchWithAuth, timeLimit)
+    // Attach the rejection assertion before advancing timers so we don't race
+    // the pre-emptive `.catch` suppressor against the assertion.
+    const rejection = expect(promise).rejects.toThrow(/timeout/i)
+
+    // Advance well past timeLimit + buffer to guarantee the throw fires.
+    await advancePolls(timeLimit + POLL_BUFFER_SECONDS + 10)
+
+    await rejection
+  })
+})
+
+describe('solverService.pollSolverStatus', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns immediately when first poll already shows completed', async () => {
+    const fetchWithAuth = vi.fn(async () => completedResponse())
+
+    const result = await solverService.pollSolverStatus('run-1', fetchWithAuth, 300)
+
+    expect(result.status).toBe('completed')
+    expect(fetchWithAuth).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/services/solver.ts
+++ b/frontend/src/services/solver.ts
@@ -75,6 +75,12 @@ const getSolverApiUrl = () => {
 
 const SOLVER_API_URL = getSolverApiUrl()
 
+// Solver runs up to its requested time_limit, then needs a tail to write
+// assignments to PocketBase before the run record flips to "completed".
+// Without this buffer, a solve that uses its full time_limit appears as a
+// frontend timeout even though the backend ultimately succeeds.
+export const POLL_BUFFER_SECONDS = 30
+
 export interface SolverRequest {
   session_id: string
   constraints: Constraint[]
@@ -126,7 +132,7 @@ export const solverService = {
       }
 
       // Poll for completion (solver runs async)
-      return await this.pollSolverStatus(result.run_id, fetchWithAuth)
+      return await this.pollSolverStatus(result.run_id, fetchWithAuth, timeLimit)
     } catch (error) {
       console.error('Solver error:', error)
       throw error
@@ -136,8 +142,10 @@ export const solverService = {
   async pollSolverStatus(
     solverRunId: string,
     fetchWithAuth: (url: string, options?: RequestInit) => Promise<Response>,
-    maxAttempts = 60
+    timeLimitSeconds = 60
   ): Promise<SolverRun> {
+    const effectiveLimit = Math.max(1, Math.floor(timeLimitSeconds))
+    const maxAttempts = effectiveLimit + POLL_BUFFER_SECONDS
     for (let i = 0; i < maxAttempts; i++) {
       // Poll the solver service API for status
       const response = await fetchWithAuth(`${SOLVER_API_URL}/solver/run/${solverRunId}`)


### PR DESCRIPTION
## Summary

- `pollSolverStatus` had a hardcoded 60-attempt cap (~60s) and `runSolver` did not thread the user-selected `time_limit` through to the poller, so any solve longer than ~60s always threw `Solver timeout - took longer than expected` in the UI — even though the backend was healthy and ultimately wrote a feasible solution to PocketBase.
- Most visible at the **5m** Optimize level on the larger sessions (Taste of Camp 1 in current data): backend ran the full 300s (returning `FEASIBLE` with the assignments saved), frontend gave up at 60s.
- Fix: derive `maxAttempts` from the requested `time_limit` plus a `POLL_BUFFER_SECONDS = 30` tail (covers the post-solve write-to-PocketBase phase). Clamp non-positive / non-integer time limits with `Math.max(1, Math.floor(...))`.

## Test plan

- [x] New `frontend/src/services/solver.test.ts` with three cases:
  - Polling continues past 60s when `timeLimit=300` and the backend completes at ~200s
  - `Solver timeout` still throws when the backend hangs longer than `timeLimit + POLL_BUFFER_SECONDS`
  - First-poll-completed short-circuits with no extra polls
- [x] `npx vitest run src/services/solver.test.ts` (3 pass)
- [x] `npx vitest run src/services/ src/hooks/session/useSolverOperations.test.ts` (79 pass, no regressions)
- [x] `npx tsc --noEmit` clean
- [x] `eslint` + `prettier` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed solver polling timeout behavior. The solver now respects configured time limits instead of using a hardcoded 60-second cap, allowing operations to complete within requested durations.

* **Tests**
  * Added comprehensive tests for solver polling, including timeout handling, completion detection, and poll budget validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->