### PR TITLE
docs(docs): refresh triage — close Group 32 + drop #1156/#1164 (in flight)

### DIFF
--- a/docs/reference/issue-triage.md
+++ b/docs/reference/issue-triage.md
@@ -1,33 +1,83 @@
 # Issue Triage
 
 Open issues grouped by code area with dependencies and suggested attack order.
-Last updated: 2026-04-15 (3 open issues, 10 closed since last update).
+Last updated: 2026-05-06 (29 open issues, 7 closed since last update).
 
 ---
 
 ## Remaining Open Issues
 
-### Standalone Issues
+### Group 33 — Social graph cleanup
 
 | # | Title | Type | Priority | Status |
 |---|-------|------|----------|--------|
-| 933 | test(sync): `test_analyze_group_cohesion` segfaults under Python 3.14 (networkx C extension) | bug | Medium | Ready — quick fix: `skipif sys.version_info >= (3, 14)`; longer-term upstream fix |
+| 1156 | fix(api): _add_classmate_edges reads removed JSON 'address' field | bug | Medium | Ready — confirmed still in code (`social_graph_builder.py:785-786`) |
+| 1164 | fix(frontend): BunkSocialGraphModal getBunkType uses incidental substring match for AG bunks | tech-debt | Medium | Ready |
+| 1163 | fix(api): session_utils.get_related_session_ids may emit cm_id=0 for AG sessions missing cm_id | tech-debt | Medium | Ready |
+| 1162 | refactor(api): switch SocialGraphBuilder to nx.MultiGraph for per-source request edges | tech-debt | Low | Ready |
+| 1157 | refactor(api): rename SocialGraphEdge.type and CrossScopeEdge.type to edge_type | refactor | Low | Ready |
+
+### Group 34 — Satisfaction frontend consolidation
+
+| # | Title | Type | Priority | Status |
+|---|-------|------|----------|--------|
+| 1167 | frontend: simplify buildCamperSatisfactionFromRequests test helper in BunkingStatusPanel.test.tsx | chore | Low | Ready |
+| 1165 | frontend: eliminate dual /api/satisfaction fetch (CamperDetail useSatisfactionData + BunkRequestProvider) | refactor | Medium | Ready |
+| 1160 | refactor: extend PerRequestStatus with status+detail to delete requestSatisfaction.ts | tech-debt | Medium | Ready |
+
+### Group 35 — Bunk request lifecycle
+
+| # | Title | Type | Priority | Status |
+|---|-------|------|----------|--------|
+| 1059 | bug(api): stale is_reciprocal flag on surviving bunk_request when partner row is removed | bug | Medium | Ready |
+| 1069 | feat(sync): decline bunk_requests when requestee no longer attending or moves session | feat | Medium | Ready |
+| 1068 | investigate: resolved bunk_requests rows with invalid requested_person_cm_id | investigation | Medium | Ready |
+| 954 | Clarify: should declining a bunk request clear `request_locked`? | question | Low | Needs product decision |
+
+### Group 36 — Scenarios & friend groups
+
+| # | Title | Type | Priority | Status |
+|---|-------|------|----------|--------|
+| 1149 | refactor(api): scenarios.py except HTTPException guard inconsistency between list_scenarios and update_scenario_assignment | refactor | Low | Ready |
+| 1150 | refactor(api): drop fragile locals() check in scenarios.py update_scenario_assignment | refactor | Low | Ready |
+| 1047 | feat(pb): enforce one friend group per camper per scenario | feat | Medium | Ready |
+| 1046 | feat(frontend): scenario copy should include locked friend groups | feat | Medium | Ready |
+
+### Group 37 — Frontend small refactors
+
+| # | Title | Type | Priority | Status |
+|---|-------|------|----------|--------|
+| 1166 | frontend: converge two getSessionShortName variants (CamperDetailsPanel + CamperDetail) | refactor | Low | Ready |
+| 1045 | refactor(frontend): centralize session_type business logic | refactor | Low | Ready |
+| 1024 | frontend: audit modal z-index pattern when nested inside z-[60] CamperDetailsPanel | chore | Low | Ready |
+| 956 | refactor(frontend): revisit useRef-syncing pattern in ConfirmActionPopover | refactor | Low | Ready |
+| 955 | refactor(frontend): replace nested ternaries with switch/lookup patterns | refactor | Low | Ready |
+| 953 | Frontend: audit auth isLoading gating and bunk-requests query-key invalidation patterns | refactor | Low | Ready |
+
+### Group 38 — Infrastructure & ops
+
+| # | Title | Type | Priority | Status |
+|---|-------|------|----------|--------|
+| 1179 | Add --max-time to container HEALTHCHECK to bound stuck probes | infra | Medium | Ready — small, defensive |
+| 1178 | Add single-flight serialization to /api/solver/run | infra | Medium | Ready |
+| 1155 | infra: wire up OpenAPI → TypeScript codegen to eliminate hand-mirrored API types | infra | Medium | Larger; cross-cuts api+frontend |
+| 1142 | refactor(sync): collapse dedup-tiebreak axes — derive RequestSource from source_field | refactor | Low | Ready |
+| 1125 | test(frontend): consolidate lazy `userEvent` import pattern in GraphControls.test.tsx | tech-debt | Low | Ready |
+| 1012 | chore(frontend): consider dropping mobile/touch support to simplify UI codebase | chore | Low | Needs product decision |
 | 919 | chore: improve Python docstring coverage (~57% → 80%) | chore | Low | Background / incremental |
-
-### Blocked
-
-| # | Title | Blocked on |
-|---|-------|------------|
-| 697 | Switch pocketbase-typegen to upstream | External upstream merge of `--use-const` flag |
 
 ---
 
 ## Suggested Attack Order
 
-1. **#933** — Unblocks clean local pre-push runs; one-line `skipif` mitigation is low risk
-2. **#919** — Background docstring coverage, incremental
-3. **#697** — Blocked externally
+1. **Group 33 (#1156 first)** — confirmed bug with concrete fix path; the rest of the group is tech-debt and can ride along in same PR or follow-up.
+2. **Group 35 (#1059, #1069, #1068)** — bunk-request lifecycle correctness; #1059 is a bug, others are feat/investigation but cohesive.
+3. Remaining groups by priority/readiness.
 
 ## Completed Groups
 
-Historical completed groups (Groups 1–31) are reflected in closed GitHub issues and git history; see `git log docs/reference/issue-triage.md` for prior triage snapshots if needed.
+- **Group 32** — `/api/satisfaction` regression cluster (PR #1158/1169 fallout). Shipped via PR #1169 (commit c985edf8) and PR #1177 (commit 3e0eb524). All three issues closed: #1171 (aggregate.py 500), #1172 (P-badge / 0-of-N source_field fallback), #1170 (bunking_validator → satisfaction.predicate migration).
+
+Historical completed groups (Groups 1–31) are reflected in closed GitHub issues
+and git history; see `git log docs/reference/issue-triage.md` for prior triage
+snapshots if needed.

--- a/docs/reference/issue-triage.md
+++ b/docs/reference/issue-triage.md
@@ -1,18 +1,16 @@
 # Issue Triage
 
 Open issues grouped by code area with dependencies and suggested attack order.
-Last updated: 2026-05-06 (29 open issues, 7 closed since last update).
+Last updated: 2026-05-06 (27 open issues, 9 closed since last update).
 
 ---
 
 ## Remaining Open Issues
 
-### Group 33 — Social graph cleanup
+### Group 33 — Social graph cleanup (residual tech-debt)
 
 | # | Title | Type | Priority | Status |
 |---|-------|------|----------|--------|
-| 1156 | fix(api): _add_classmate_edges reads removed JSON 'address' field | bug | Medium | Ready — confirmed still in code (`social_graph_builder.py:785-786`) |
-| 1164 | fix(frontend): BunkSocialGraphModal getBunkType uses incidental substring match for AG bunks | tech-debt | Medium | Ready |
 | 1163 | fix(api): session_utils.get_related_session_ids may emit cm_id=0 for AG sessions missing cm_id | tech-debt | Medium | Ready |
 | 1162 | refactor(api): switch SocialGraphBuilder to nx.MultiGraph for per-source request edges | tech-debt | Low | Ready |
 | 1157 | refactor(api): rename SocialGraphEdge.type and CrossScopeEdge.type to edge_type | refactor | Low | Ready |
@@ -70,13 +68,14 @@ Last updated: 2026-05-06 (29 open issues, 7 closed since last update).
 
 ## Suggested Attack Order
 
-1. **Group 33 (#1156 first)** — confirmed bug with concrete fix path; the rest of the group is tech-debt and can ride along in same PR or follow-up.
-2. **Group 35 (#1059, #1069, #1068)** — bunk-request lifecycle correctness; #1059 is a bug, others are feat/investigation but cohesive.
+1. **Group 35 (#1059, #1069, #1068)** — bunk-request lifecycle correctness; #1059 is a bug, others are feat/investigation but cohesive. (#1059's surface area shrank since filing — only `BunkRequestRow.tsx:258` still trusts the stored `is_reciprocal` flag.)
+2. **Group 38 small wins (#1179, #1178)** — defensive infra, both small.
 3. Remaining groups by priority/readiness.
 
 ## Completed Groups
 
 - **Group 32** — `/api/satisfaction` regression cluster (PR #1158/1169 fallout). Shipped via PR #1169 (commit c985edf8) and PR #1177 (commit 3e0eb524). All three issues closed: #1171 (aggregate.py 500), #1172 (P-badge / 0-of-N source_field fallback), #1170 (bunking_validator → satisfaction.predicate migration).
+- **Group 33 confirmed bugs** — #1156 (_add_classmate_edges discrete address columns) and #1164 (anchored AG match) shipping in PR #1182. The remaining three issues in Group 33 are tech-debt/refactor only.
 
 Historical completed groups (Groups 1–31) are reflected in closed GitHub issues
 and git history; see `git log docs/reference/issue-triage.md` for prior triage


### PR DESCRIPTION
## Summary

- Triage doc claimed Group 32 (#1172, #1170) was Ready, but both fixes already shipped — closing the issues with citations and dropping Group 32 from triage.
- Drop #1156 and #1164 from Group 33 (their fixes are in flight in PR #1182). Group 33 narrows to tech-debt only.
- Net: 27 open issues remaining (down from 31). Suggested attack order: Group 35 (#1059) now next up.

## Why this is a docs-only PR

Both Group 32 fixes are already in `main`, regression-locked by tests:

- **#1172** — `resolveBadgeBucket` utility in `frontend/src/utils/requestSatisfaction.ts` plus the `aggregatorEmpty` parent-slice fallback in `frontend/src/components/camper/BunkingStatusPanel.tsx`. Shipped in PR #1169 (commit c985edf8), refined in PR #1177 (3e0eb524). Test coverage in `requestSatisfaction.test.ts` (`#1172 centralized-bucket-with-source-field-fallback` describe block) and `BunkingStatusPanel.test.tsx:412+` (including "does NOT fabricate parent ratio when aggregator legitimately reports 0/0" inverse case).
- **#1170** — `bunking/bunking_validator.py:18` imports from `bunking.satisfaction.predicate`; `_is_satisfied` adapter at lines 481-506 wraps the canonical predicate. Regression test at `tests/unit/test_bunking_validator.py:1814` asserts `"def is_request_satisfied(" not in src` to block reintroduction. 65/65 validator tests pass; 100/100 satisfaction tests pass.

The triage doc was last updated 2026-05-06, same day PR #1177 merged — the "Ready" status was true for a few hours and then went stale.

## Group 33 follow-up

PR #1182 ships the two confirmed bugs in Group 33 (#1156, #1164). This PR drops them from the active triage list ahead of merge. Group 33 narrows to tech-debt only (#1163, #1162, #1157).

## Process note

The `triage-it` staleness check confirmed presence of identifiers at cited line numbers, but didn't compare current code shape against the issue body's "broken" example. Future triage runs will diff current code against the issue's broken snippet and grep `git log --grep=<issue#>` plus pickaxe for referenced symbols before declaring an issue Ready.

## Test plan

- [x] `uv run pytest tests/unit/test_bunking_validator.py` — 65/65 pass
- [x] `uv run pytest tests/unit/bunking/satisfaction/` — 100/100 pass
- [x] `bash .claude/skills/pre-push-verification/scripts/verify.sh` — clean (docs-only)
- [x] Visual diff of triage doc — Group 32 removed, Group 33 narrowed to tech-debt, attack order renumbered, completed-groups list updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated issue triage snapshot to 2026-05-06.
  * Reorganized open issues into Groups 33–38 and removed prior standalone tables.
  * Added a “Remaining Open Issues” section with grouped issue rows and refreshed “Completed Groups” notes.
  * Revised suggested attack order to prioritize bunk-request lifecycle and infrastructure items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->