### PR TITLE
feat(pb): bunk_request reciprocity hook + backfill (#1059)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,8 @@ pocketbase/pb_migrations/*_updated_users.js
 !pocketbase/rbac/
 !pocketbase/feedback/
 !pocketbase/config/
+!pocketbase/bunk_requests/
+!pocketbase/cmd/
 !pocketbase/README.md
 # JS tooling for migrations/hooks linting
 !pocketbase/package.json

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,6 +64,8 @@ linters:
       ignore-package-globs:
         # PocketBase router event methods (e.JSON, e.NoContent, etc.) are terminal HTTP responses
         - github.com/pocketbase/pocketbase/tools/router
+        # PocketBase hook chain propagation — e.Next() passes through the middleware chain, already has context
+        - github.com/pocketbase/pocketbase/tools/hook
         # CampMinder client errors are wrapped by callers (ExecuteWithRetry adds context)
         - github.com/camp/kindred/pocketbase/campminder
       ignore-sig-regexps:

--- a/pocketbase/bunk_requests/backfill.go
+++ b/pocketbase/bunk_requests/backfill.go
@@ -1,6 +1,7 @@
 package bunkrequests
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/pocketbase/pocketbase/core"
@@ -9,6 +10,10 @@ import (
 // BackfillAll iterates every distinct (year, session_id, request_type, A, B)
 // tuple in bunk_requests and calls RecomputePairReciprocity for each.
 // Idempotent — safe to re-run.
+//
+// Returns the total number of tuples processed. If any individual recompute
+// fails, the loop continues but BackfillAll returns a non-nil error so the
+// CLI exit status reflects the partial failure.
 func BackfillAll(app core.App) (int, error) {
 	type tuple struct {
 		Year        int    `db:"year"`
@@ -32,19 +37,24 @@ func BackfillAll(app core.App) (int, error) {
 		  AND requester_id != requestee_id
 	`).All(&tuples)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("query distinct pair tuples: %w", err)
 	}
 
+	var failed int
 	for _, t := range tuples {
 		if err := RecomputePairReciprocity(
 			app, t.Year, t.SessionID, t.PersonA, t.PersonB, t.RequestType,
 		); err != nil {
+			failed++
 			slog.Warn("pair recompute failed",
 				"year", t.Year, "session", t.SessionID,
 				"a", t.PersonA, "b", t.PersonB, "type", t.RequestType,
 				"error", err,
 			)
 		}
+	}
+	if failed > 0 {
+		return len(tuples), fmt.Errorf("backfill incomplete: %d of %d pair recomputes failed", failed, len(tuples))
 	}
 	return len(tuples), nil
 }

--- a/pocketbase/bunk_requests/backfill.go
+++ b/pocketbase/bunk_requests/backfill.go
@@ -1,0 +1,50 @@
+package bunkrequests
+
+import (
+	"log/slog"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// BackfillAll iterates every distinct (year, session_id, request_type, A, B)
+// tuple in bunk_requests and calls RecomputePairReciprocity for each.
+// Idempotent — safe to re-run.
+func BackfillAll(app core.App) (int, error) {
+	type tuple struct {
+		Year        int    `db:"year"`
+		SessionID   int    `db:"session_id"`
+		RequestType string `db:"request_type"`
+		PersonA     int    `db:"a"`
+		PersonB     int    `db:"b"`
+	}
+	var tuples []tuple
+	err := app.DB().NewQuery(`
+		SELECT DISTINCT
+			year,
+			session_id,
+			request_type,
+			MIN(requester_id, requestee_id) AS a,
+			MAX(requester_id, requestee_id) AS b
+		FROM bunk_requests
+		WHERE request_type IN ('bunk_with', 'not_bunk_with')
+		  AND requester_id > 0
+		  AND requestee_id > 0
+		  AND requester_id != requestee_id
+	`).All(&tuples)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, t := range tuples {
+		if err := RecomputePairReciprocity(
+			app, t.Year, t.SessionID, t.PersonA, t.PersonB, t.RequestType,
+		); err != nil {
+			slog.Warn("pair recompute failed",
+				"year", t.Year, "session", t.SessionID,
+				"a", t.PersonA, "b", t.PersonB, "type", t.RequestType,
+				"error", err,
+			)
+		}
+	}
+	return len(tuples), nil
+}

--- a/pocketbase/bunk_requests/hooks.go
+++ b/pocketbase/bunk_requests/hooks.go
@@ -1,12 +1,50 @@
 package bunkrequests
 
 import (
+	"log/slog"
+
 	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/core"
 )
 
 // RegisterHooks wires reciprocity-recompute hooks onto the bunk_requests
 // collection. Errors are logged via slog and never block the underlying write.
 func RegisterHooks(app *pocketbase.PocketBase) {
-	// TODO: wire up Create/Update/Delete success hooks in Task 4
-	_ = app
+	app.OnRecordAfterCreateSuccess("bunk_requests").BindFunc(func(e *core.RecordEvent) error {
+		runRecompute(e)
+		return e.Next()
+	})
+	app.OnRecordAfterUpdateSuccess("bunk_requests").BindFunc(func(e *core.RecordEvent) error {
+		runRecompute(e)
+		return e.Next()
+	})
+	app.OnRecordAfterDeleteSuccess("bunk_requests").BindFunc(func(e *core.RecordEvent) error {
+		runRecompute(e)
+		return e.Next()
+	})
+
+	slog.Info("bunk_requests reciprocity hooks registered")
+}
+
+// runRecompute extracts pair coords from the event record and invokes the
+// helper. Errors are logged but never propagated — best-effort correctness.
+func runRecompute(e *core.RecordEvent) {
+	r := e.Record
+	if r == nil {
+		return
+	}
+	year := r.GetInt("year")
+	sessionID := r.GetInt("session_id")
+	requester := r.GetInt("requester_id")
+	requestee := r.GetInt("requestee_id")
+	requestType := r.GetString("request_type")
+
+	if err := RecomputePairReciprocity(e.App, year, sessionID, requester, requestee, requestType); err != nil {
+		slog.Error("RecomputePairReciprocity failed",
+			"requester", requester,
+			"requestee", requestee,
+			"request_type", requestType,
+			"error", err,
+		)
+	}
 }

--- a/pocketbase/bunk_requests/hooks.go
+++ b/pocketbase/bunk_requests/hooks.go
@@ -1,0 +1,12 @@
+package bunkrequests
+
+import (
+	"github.com/pocketbase/pocketbase"
+)
+
+// RegisterHooks wires reciprocity-recompute hooks onto the bunk_requests
+// collection. Errors are logged via slog and never block the underlying write.
+func RegisterHooks(app *pocketbase.PocketBase) {
+	// TODO: wire up Create/Update/Delete success hooks in Task 4
+	_ = app
+}

--- a/pocketbase/bunk_requests/hooks.go
+++ b/pocketbase/bunk_requests/hooks.go
@@ -2,14 +2,37 @@ package bunkrequests
 
 import (
 	"log/slog"
+	"sync"
 
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/core"
 )
 
+// pairCoords identifies a (year, session, requester, requestee, type) tuple.
+type pairCoords struct {
+	Year        int
+	SessionID   int
+	Requester   int
+	Requestee   int
+	RequestType string
+}
+
+// preUpdateCache stashes the pre-mutation DB state of each row about to be
+// updated, keyed by record ID. The post-success handler reads it to detect
+// pair-coord changes that orphan the old partner's is_reciprocal.
+//
+// PocketBase's Record.Original() refreshes mid-save and is unreliable inside
+// AfterUpdateSuccess, so we capture coords ourselves before the mutation
+// lands and read them out after.
+var preUpdateCache sync.Map // map[string]pairCoords
+
 // RegisterHooks wires reciprocity-recompute hooks onto the bunk_requests
 // collection. Errors are logged via slog and never block the underlying write.
 func RegisterHooks(app *pocketbase.PocketBase) {
+	app.OnRecordUpdate("bunk_requests").BindFunc(func(e *core.RecordEvent) error {
+		captureOldCoords(e)
+		return e.Next()
+	})
 	app.OnRecordAfterCreateSuccess("bunk_requests").BindFunc(func(e *core.RecordEvent) error {
 		runRecompute(e)
 		return e.Next()
@@ -26,8 +49,34 @@ func RegisterHooks(app *pocketbase.PocketBase) {
 	slog.Info("bunk_requests reciprocity hooks registered")
 }
 
+// captureOldCoords reads the pre-mutation pair coords directly from the DB
+// (since the in-memory e.Record already holds the user's mutations) and
+// stashes them keyed by record ID. The corresponding AfterUpdateSuccess
+// reads and clears the entry.
+func captureOldCoords(e *core.RecordEvent) {
+	r := e.Record
+	if r == nil || r.Id == "" {
+		return
+	}
+	old, err := e.App.FindRecordById("bunk_requests", r.Id)
+	if err != nil || old == nil {
+		return
+	}
+	preUpdateCache.Store(r.Id, pairCoords{
+		Year:        old.GetInt("year"),
+		SessionID:   old.GetInt("session_id"),
+		Requester:   old.GetInt("requester_id"),
+		Requestee:   old.GetInt("requestee_id"),
+		RequestType: old.GetString("request_type"),
+	})
+}
+
 // runRecompute extracts pair coords from the event record and invokes the
 // helper. Errors are logged but never propagated — best-effort correctness.
+//
+// If a previous UpdateExecute captured pre-mutation coords for this record
+// and they differ from the current coords, the OLD pair is also recomputed
+// so the previous partner's is_reciprocal doesn't get orphaned.
 func runRecompute(e *core.RecordEvent) {
 	r := e.Record
 	if r == nil {
@@ -44,6 +93,41 @@ func runRecompute(e *core.RecordEvent) {
 			"requester", requester,
 			"requestee", requestee,
 			"request_type", requestType,
+			"error", err,
+		)
+	}
+
+	if r.Id == "" {
+		return
+	}
+	cached, ok := preUpdateCache.LoadAndDelete(r.Id)
+	if !ok {
+		return
+	}
+	old, ok := cached.(pairCoords)
+	if !ok {
+		return
+	}
+
+	pairUnchanged := old.Requester == requester &&
+		old.Requestee == requestee &&
+		old.Year == year &&
+		old.SessionID == sessionID &&
+		old.RequestType == requestType
+	if pairUnchanged {
+		return
+	}
+	if old.Requester == 0 || old.Requestee == 0 {
+		return
+	}
+
+	if err := RecomputePairReciprocity(
+		e.App, old.Year, old.SessionID, old.Requester, old.Requestee, old.RequestType,
+	); err != nil {
+		slog.Error("RecomputePairReciprocity failed (old pair)",
+			"requester", old.Requester,
+			"requestee", old.Requestee,
+			"request_type", old.RequestType,
 			"error", err,
 		)
 	}

--- a/pocketbase/bunk_requests/hooks.go
+++ b/pocketbase/bunk_requests/hooks.go
@@ -31,7 +31,13 @@ var preUpdateCache sync.Map // map[string]pairCoords
 func RegisterHooks(app *pocketbase.PocketBase) {
 	app.OnRecordUpdate("bunk_requests").BindFunc(func(e *core.RecordEvent) error {
 		captureOldCoords(e)
-		return e.Next()
+		err := e.Next()
+		if err != nil && e.Record != nil && e.Record.Id != "" {
+			// AfterUpdateSuccess won't fire, so cleanup the cache entry
+			// captureOldCoords just stored — otherwise it leaks.
+			preUpdateCache.Delete(e.Record.Id)
+		}
+		return err
 	})
 	app.OnRecordAfterCreateSuccess("bunk_requests").BindFunc(func(e *core.RecordEvent) error {
 		runRecompute(e)
@@ -59,7 +65,17 @@ func captureOldCoords(e *core.RecordEvent) {
 		return
 	}
 	old, err := e.App.FindRecordById("bunk_requests", r.Id)
-	if err != nil || old == nil {
+	if err != nil {
+		// Best-effort: a failed read here means the post-update recompute
+		// won't see the OLD pair coords, so an ID-mutating update could
+		// orphan a stale partner row. Log so drift is at least traceable.
+		slog.Warn("captureOldCoords: pre-update read failed",
+			"record_id", r.Id,
+			"error", err,
+		)
+		return
+	}
+	if old == nil {
 		return
 	}
 	preUpdateCache.Store(r.Id, pairCoords{

--- a/pocketbase/bunk_requests/reciprocity.go
+++ b/pocketbase/bunk_requests/reciprocity.go
@@ -62,7 +62,12 @@ func RecomputePairReciprocity(
 }
 
 // findRow returns the bunk_request matching the given coordinates, or nil if
-// no row exists. If multiple match (dedup miss), returns the first.
+// no row exists. Production allows multiple rows per directed pair when
+// they originate from different source_field values (the unique index
+// includes source_field). When that happens this helper returns the
+// lowest-id row deterministically — sufficient for "is the other direction
+// resolved?" since all sibling rows in the same direction share the same
+// pair coordinates.
 func findRow(app core.App, year, sessionID, requester, requestee int, requestType string) (*core.Record, error) {
 	filter := "year = {:year} && session_id = {:sessionID} && " +
 		"requester_id = {:requester} && requestee_id = {:requestee} && " +
@@ -70,7 +75,7 @@ func findRow(app core.App, year, sessionID, requester, requestee int, requestTyp
 	records, err := app.FindRecordsByFilter(
 		"bunk_requests",
 		filter,
-		"",
+		"id",
 		1,
 		0,
 		map[string]any{

--- a/pocketbase/bunk_requests/reciprocity.go
+++ b/pocketbase/bunk_requests/reciprocity.go
@@ -3,12 +3,23 @@
 package bunkrequests
 
 import (
+	"fmt"
+
 	"github.com/pocketbase/pocketbase/core"
+)
+
+const (
+	requestTypeBunkWith    = "bunk_with"
+	requestTypeNotBunkWith = "not_bunk_with"
+	statusResolved         = "resolved"
 )
 
 // RecomputePairReciprocity recomputes is_reciprocal on both rows of a
 // (personA, personB, request_type) pair in the same year + session.
 // Idempotent: writes only if the new value differs from the stored one.
+//
+// Reciprocity is meaningful only for bunk_with and not_bunk_with rows that
+// share year+session+request_type; the call is a no-op for any other shape.
 func RecomputePairReciprocity(
 	app core.App,
 	year int,
@@ -17,6 +28,72 @@ func RecomputePairReciprocity(
 	personB int,
 	requestType string,
 ) error {
-	// TODO: implement in Task 3
+	if requestType != requestTypeBunkWith && requestType != requestTypeNotBunkWith {
+		return nil
+	}
+	if personA == 0 || personB == 0 || personA == personB {
+		return nil
+	}
+
+	rowAB, err := findRow(app, year, sessionID, personA, personB, requestType)
+	if err != nil {
+		return fmt.Errorf("find A→B: %w", err)
+	}
+	rowBA, err := findRow(app, year, sessionID, personB, personA, requestType)
+	if err != nil {
+		return fmt.Errorf("find B→A: %w", err)
+	}
+
+	aResolved := rowAB != nil && rowAB.GetString("status") == statusResolved
+	bResolved := rowBA != nil && rowBA.GetString("status") == statusResolved
+
+	// A→B's flag depends on whether B→A is currently resolved, and vice versa.
+	if err := setIfChanged(app, rowAB, bResolved); err != nil {
+		return fmt.Errorf("update A→B: %w", err)
+	}
+	if err := setIfChanged(app, rowBA, aResolved); err != nil {
+		return fmt.Errorf("update B→A: %w", err)
+	}
 	return nil
+}
+
+// findRow returns the bunk_request matching the given coordinates, or nil if
+// no row exists. If multiple match (dedup miss), returns the first.
+func findRow(app core.App, year, sessionID, requester, requestee int, requestType string) (*core.Record, error) {
+	records, err := app.FindRecordsByFilter(
+		"bunk_requests",
+		"year = {:year} && session_id = {:sessionID} && requester_id = {:requester} && requestee_id = {:requestee} && request_type = {:requestType}",
+		"",
+		1,
+		0,
+		map[string]any{
+			"year":        year,
+			"sessionID":   sessionID,
+			"requester":   requester,
+			"requestee":   requestee,
+			"requestType": requestType,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(records) == 0 {
+		return nil, nil
+	}
+	return records[0], nil
+}
+
+// setIfChanged updates is_reciprocal only if the stored value differs from
+// the target. This is the recursion-termination guarantee — when our save
+// triggers OnRecordAfterUpdateSuccess, the re-entry recomputes the same
+// target value and finds it already stored, so no further save fires.
+func setIfChanged(app core.App, row *core.Record, target bool) error {
+	if row == nil {
+		return nil
+	}
+	if row.GetBool("is_reciprocal") == target {
+		return nil
+	}
+	row.Set("is_reciprocal", target)
+	return app.Save(row)
 }

--- a/pocketbase/bunk_requests/reciprocity.go
+++ b/pocketbase/bunk_requests/reciprocity.go
@@ -47,11 +47,15 @@ func RecomputePairReciprocity(
 	aResolved := rowAB != nil && rowAB.GetString("status") == statusResolved
 	bResolved := rowBA != nil && rowBA.GetString("status") == statusResolved
 
-	// A→B's flag depends on whether B→A is currently resolved, and vice versa.
-	if err := setIfChanged(app, rowAB, bResolved); err != nil {
+	// Reciprocity is a symmetric pair-level property: both rows are reciprocal
+	// iff both exist AND both are resolved. Matches the graph builder's
+	// has_forward && has_backward semantic at social_graph_builder.py:379.
+	pairReciprocal := aResolved && bResolved
+
+	if err := setIfChanged(app, rowAB, pairReciprocal); err != nil {
 		return fmt.Errorf("update A→B: %w", err)
 	}
-	if err := setIfChanged(app, rowBA, aResolved); err != nil {
+	if err := setIfChanged(app, rowBA, pairReciprocal); err != nil {
 		return fmt.Errorf("update B→A: %w", err)
 	}
 	return nil

--- a/pocketbase/bunk_requests/reciprocity.go
+++ b/pocketbase/bunk_requests/reciprocity.go
@@ -64,9 +64,12 @@ func RecomputePairReciprocity(
 // findRow returns the bunk_request matching the given coordinates, or nil if
 // no row exists. If multiple match (dedup miss), returns the first.
 func findRow(app core.App, year, sessionID, requester, requestee int, requestType string) (*core.Record, error) {
+	filter := "year = {:year} && session_id = {:sessionID} && " +
+		"requester_id = {:requester} && requestee_id = {:requestee} && " +
+		"request_type = {:requestType}"
 	records, err := app.FindRecordsByFilter(
 		"bunk_requests",
-		"year = {:year} && session_id = {:sessionID} && requester_id = {:requester} && requestee_id = {:requestee} && request_type = {:requestType}",
+		filter,
 		"",
 		1,
 		0,
@@ -79,7 +82,7 @@ func findRow(app core.App, year, sessionID, requester, requestee int, requestTyp
 		},
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("find bunk_requests: %w", err)
 	}
 	if len(records) == 0 {
 		return nil, nil
@@ -99,5 +102,8 @@ func setIfChanged(app core.App, row *core.Record, target bool) error {
 		return nil
 	}
 	row.Set("is_reciprocal", target)
-	return app.Save(row)
+	if err := app.Save(row); err != nil {
+		return fmt.Errorf("save is_reciprocal: %w", err)
+	}
+	return nil
 }

--- a/pocketbase/bunk_requests/reciprocity.go
+++ b/pocketbase/bunk_requests/reciprocity.go
@@ -1,0 +1,22 @@
+// Package bunkrequests provides reciprocity-correctness hooks for the
+// bunk_requests PocketBase collection.
+package bunkrequests
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// RecomputePairReciprocity recomputes is_reciprocal on both rows of a
+// (personA, personB, request_type) pair in the same year + session.
+// Idempotent: writes only if the new value differs from the stored one.
+func RecomputePairReciprocity(
+	app core.App,
+	year int,
+	sessionID int,
+	personA int,
+	personB int,
+	requestType string,
+) error {
+	// TODO: implement in Task 3
+	return nil
+}

--- a/pocketbase/bunk_requests/reciprocity_test.go
+++ b/pocketbase/bunk_requests/reciprocity_test.go
@@ -1,0 +1,96 @@
+package bunkrequests
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+)
+
+// setupBunkRequestsCollection creates a minimal bunk_requests collection in
+// the test app — only the fields the reciprocity hook reads/writes. The
+// production schema has many more fields but they're irrelevant here.
+func setupBunkRequestsCollection(t *testing.T, app core.App) {
+	t.Helper()
+	col := core.NewBaseCollection("bunk_requests")
+	col.Fields.Add(&core.NumberField{Name: "requester_id", Required: true})
+	col.Fields.Add(&core.NumberField{Name: "requestee_id"})
+	col.Fields.Add(&core.SelectField{
+		Name:      "request_type",
+		Required:  true,
+		Values:    []string{"bunk_with", "not_bunk_with", "age_preference"},
+		MaxSelect: 1,
+	})
+	col.Fields.Add(&core.SelectField{
+		Name:      "status",
+		Required:  true,
+		Values:    []string{"pending", "resolved", "declined"},
+		MaxSelect: 1,
+	})
+	col.Fields.Add(&core.NumberField{Name: "year", Required: true})
+	col.Fields.Add(&core.NumberField{Name: "session_id"})
+	col.Fields.Add(&core.BoolField{Name: "is_reciprocal"})
+	if err := app.Save(col); err != nil {
+		t.Fatalf("setupBunkRequestsCollection: save: %v", err)
+	}
+}
+
+// makeRequest creates and persists a bunk_request record with the given
+// pair coords + status. Returns the saved record.
+func makeRequest(t *testing.T, app core.App, requester, requestee int, rtype, status string) *core.Record {
+	t.Helper()
+	col, err := app.FindCollectionByNameOrId("bunk_requests")
+	if err != nil {
+		t.Fatalf("makeRequest: find collection: %v", err)
+	}
+	r := core.NewRecord(col)
+	r.Set("requester_id", requester)
+	r.Set("requestee_id", requestee)
+	r.Set("request_type", rtype)
+	r.Set("status", status)
+	r.Set("year", 2026)
+	r.Set("session_id", 1235404)
+	r.Set("is_reciprocal", false)
+	if err := app.Save(r); err != nil {
+		t.Fatalf("makeRequest: save: %v", err)
+	}
+	return r
+}
+
+// Test 1: Create resolved A→B and B→A, then call RecomputePairReciprocity
+// directly. Both rows should end up with is_reciprocal=true.
+func TestRecomputePairReciprocity_CreatesPair(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	defer app.Cleanup()
+
+	setupBunkRequestsCollection(t, app)
+
+	// Insert pair as raw rows (is_reciprocal=false initially).
+	rowAB := makeRequest(t, app, 100, 200, "bunk_with", "resolved")
+	rowBA := makeRequest(t, app, 200, 100, "bunk_with", "resolved")
+
+	// Call helper directly — it should fix both rows.
+	if err := RecomputePairReciprocity(app, 2026, 1235404, 100, 200, "bunk_with"); err != nil {
+		t.Fatalf("RecomputePairReciprocity: %v", err)
+	}
+
+	// Reload from DB.
+	gotAB, err := app.FindRecordById("bunk_requests", rowAB.Id)
+	if err != nil {
+		t.Fatalf("reload AB: %v", err)
+	}
+	gotBA, err := app.FindRecordById("bunk_requests", rowBA.Id)
+	if err != nil {
+		t.Fatalf("reload BA: %v", err)
+	}
+
+	if !gotAB.GetBool("is_reciprocal") {
+		t.Errorf("A→B: expected is_reciprocal=true, got false")
+	}
+	if !gotBA.GetBool("is_reciprocal") {
+		t.Errorf("B→A: expected is_reciprocal=true, got false")
+	}
+}

--- a/pocketbase/bunk_requests/reciprocity_test.go
+++ b/pocketbase/bunk_requests/reciprocity_test.go
@@ -185,3 +185,41 @@ func TestHook_DeletionFlipsPartner(t *testing.T) {
 		t.Errorf("after A→B delete: B→A expected is_reciprocal=false, got true (#1059 bug)")
 	}
 }
+
+// Test 4 — #1069 coverage: status flip resolved → declined on one row should
+// flip the partner's is_reciprocal to false (declined doesn't count as
+// reciprocal).
+func TestHook_StatusFlipFlipsPartner(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	defer app.Cleanup()
+
+	setupBunkRequestsCollection(t, app)
+	registerHooksOnApp(app)
+
+	rowAB := makeRequest(t, app, 100, 200, "bunk_with", "resolved")
+	rowBA := makeRequest(t, app, 200, 100, "bunk_with", "resolved")
+
+	// Sanity check.
+	gotBA, _ := app.FindRecordById("bunk_requests", rowBA.Id)
+	if !gotBA.GetBool("is_reciprocal") {
+		t.Fatalf("precondition: expected B→A reciprocal=true")
+	}
+
+	// Flip A→B to declined; hook fires on update.
+	rowAB.Set("status", "declined")
+	if err := app.Save(rowAB); err != nil {
+		t.Fatalf("save flipped AB: %v", err)
+	}
+
+	gotBA, _ = app.FindRecordById("bunk_requests", rowBA.Id)
+	if gotBA.GetBool("is_reciprocal") {
+		t.Errorf("after A→B flip to declined: B→A expected is_reciprocal=false, got true")
+	}
+	gotAB, _ := app.FindRecordById("bunk_requests", rowAB.Id)
+	if gotAB.GetBool("is_reciprocal") {
+		t.Errorf("after A→B flip to declined: A→B expected is_reciprocal=false, got true")
+	}
+}

--- a/pocketbase/bunk_requests/reciprocity_test.go
+++ b/pocketbase/bunk_requests/reciprocity_test.go
@@ -28,7 +28,7 @@ func setupBunkRequestsCollection(t *testing.T, app core.App) {
 		MaxSelect: 1,
 	})
 	col.Fields.Add(&core.NumberField{Name: "year", Required: true})
-	col.Fields.Add(&core.NumberField{Name: "session_id"})
+	col.Fields.Add(&core.NumberField{Name: "session_id", Required: true})
 	col.Fields.Add(&core.BoolField{Name: "is_reciprocal"})
 	if err := app.Save(col); err != nil {
 		t.Fatalf("setupBunkRequestsCollection: save: %v", err)
@@ -73,7 +73,8 @@ func TestRecomputePairReciprocity_CreatesPair(t *testing.T) {
 	rowBA := makeRequest(t, app, 200, 100, "bunk_with", "resolved")
 
 	// Call helper directly — it should fix both rows.
-	if err := RecomputePairReciprocity(app, 2026, 1235404, 100, 200, "bunk_with"); err != nil {
+	err = RecomputePairReciprocity(app, 2026, 1235404, 100, 200, "bunk_with")
+	if err != nil {
 		t.Fatalf("RecomputePairReciprocity: %v", err)
 	}
 
@@ -133,10 +134,14 @@ func TestHook_FiresOnCreate(t *testing.T) {
 	}
 }
 
-// registerHooksOnApp wires the same three success hooks RegisterHooks does,
-// but takes a core.App (which the *tests.TestApp implements). We can't pass
-// *tests.TestApp to RegisterHooks because it expects *pocketbase.PocketBase.
+// registerHooksOnApp wires the same hooks RegisterHooks does, but takes a
+// core.App (which the *tests.TestApp implements). We can't pass *tests.TestApp
+// to RegisterHooks because it expects *pocketbase.PocketBase.
 func registerHooksOnApp(app core.App) {
+	app.OnRecordUpdate("bunk_requests").BindFunc(func(e *core.RecordEvent) error {
+		captureOldCoords(e)
+		return e.Next()
+	})
 	app.OnRecordAfterCreateSuccess("bunk_requests").BindFunc(func(e *core.RecordEvent) error {
 		runRecompute(e)
 		return e.Next()
@@ -173,7 +178,8 @@ func TestHook_DeletionFlipsPartner(t *testing.T) {
 	}
 
 	// Delete A→B; hook should fire and recompute B→A.
-	if err := app.Delete(rowAB); err != nil {
+	err = app.Delete(rowAB)
+	if err != nil {
 		t.Fatalf("delete AB: %v", err)
 	}
 
@@ -379,5 +385,49 @@ func TestRecomputePairReciprocity_IdempotentOnAlreadyCorrect(t *testing.T) {
 	}
 	if !gotBA2.GetDateTime("updated").Time().Equal(baUpdated) {
 		t.Errorf("idempotent call wrote B→A unnecessarily; updated changed")
+	}
+}
+
+// Test 10 — ID mutation orphans the old partner.
+//
+// If the requester_id (or requestee_id) on an existing row is mutated, the
+// hook's post-update recompute targets only the NEW pair coords. The OLD
+// partner row, whose pair is now broken (its mate's coords no longer match),
+// is silently left with stale is_reciprocal=true. The fix is for runRecompute
+// to also recompute the OLD coords (from e.Record.Original()) when they differ
+// from the new coords.
+func TestHook_RequesterIDMutationRecomputesOldPair(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	defer app.Cleanup()
+
+	setupBunkRequestsCollection(t, app)
+	registerHooksOnApp(app)
+
+	// Precondition: pair (100, 200) both resolved → both reciprocal=true.
+	rowAB := makeRequest(t, app, 100, 200, "bunk_with", "resolved")
+	rowBA := makeRequest(t, app, 200, 100, "bunk_with", "resolved")
+	gotBA, _ := app.FindRecordById("bunk_requests", rowBA.Id)
+	if !gotBA.GetBool("is_reciprocal") {
+		t.Fatalf("precondition: B→A expected reciprocal=true, got false")
+	}
+
+	// Mutate A→B's requester_id from 100 → 300. The (100, 200) pair coords are
+	// now orphaned: B→A still points at requester 100, but no row at (100, 200)
+	// exists any more. B→A's is_reciprocal must flip to false.
+	rowAB.Set("requester_id", 300)
+	err = app.Save(rowAB)
+	if err != nil {
+		t.Fatalf("save mutated AB: %v", err)
+	}
+
+	gotBA, err = app.FindRecordById("bunk_requests", rowBA.Id)
+	if err != nil {
+		t.Fatalf("reload BA: %v", err)
+	}
+	if gotBA.GetBool("is_reciprocal") {
+		t.Errorf("after requester_id mutation: B→A expected is_reciprocal=false (old pair orphaned), got true")
 	}
 }

--- a/pocketbase/bunk_requests/reciprocity_test.go
+++ b/pocketbase/bunk_requests/reciprocity_test.go
@@ -1,11 +1,54 @@
 package bunkrequests
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/tests"
 )
+
+// countPreUpdateCache reports the number of entries currently held in the
+// package-private preUpdateCache. Used by tests that assert no cache leak
+// across hook invocations.
+func countPreUpdateCache() int {
+	n := 0
+	preUpdateCache.Range(func(_, _ any) bool {
+		n++
+		return true
+	})
+	return n
+}
+
+// drainPreUpdateCache empties preUpdateCache so cross-test pollution can't
+// affect leak assertions in this package's tests.
+func drainPreUpdateCache() {
+	preUpdateCache.Range(func(k, _ any) bool {
+		preUpdateCache.Delete(k)
+		return true
+	})
+}
+
+// mustFindRecord reloads a bunk_requests row by id and fails the test on
+// any read error — replaces the noisy `_` discard pattern.
+func mustFindRecord(t *testing.T, app core.App, id string) *core.Record {
+	t.Helper()
+	r, err := app.FindRecordById("bunk_requests", id)
+	if err != nil {
+		t.Fatalf("FindRecordById %q: %v", id, err)
+	}
+	return r
+}
+
+// mustFindCollection returns the bunk_requests collection or fails the test.
+func mustFindCollection(t *testing.T, app core.App) *core.Collection {
+	t.Helper()
+	col, err := app.FindCollectionByNameOrId("bunk_requests")
+	if err != nil {
+		t.Fatalf("FindCollectionByNameOrId: %v", err)
+	}
+	return col
+}
 
 // setupBunkRequestsCollection creates a minimal bunk_requests collection in
 // the test app — only the fields the reciprocity hook reads/writes. The
@@ -116,7 +159,7 @@ func TestHook_FiresOnCreate(t *testing.T) {
 
 	// At this point only A→B exists; the hook fired but B→A doesn't exist
 	// yet, so A→B's flag stays false.
-	gotAB, _ := app.FindRecordById("bunk_requests", rowAB.Id)
+	gotAB := mustFindRecord(t, app, rowAB.Id)
 	if gotAB.GetBool("is_reciprocal") {
 		t.Errorf("after lone A→B insert: expected is_reciprocal=false, got true")
 	}
@@ -124,8 +167,8 @@ func TestHook_FiresOnCreate(t *testing.T) {
 	// Now insert B→A. Hook fires, recompute finds both rows resolved → both flip.
 	rowBA := makeRequest(t, app, 200, 100, "bunk_with", "resolved")
 
-	gotAB, _ = app.FindRecordById("bunk_requests", rowAB.Id)
-	gotBA, _ := app.FindRecordById("bunk_requests", rowBA.Id)
+	gotAB = mustFindRecord(t, app, rowAB.Id)
+	gotBA := mustFindRecord(t, app, rowBA.Id)
 	if !gotAB.GetBool("is_reciprocal") {
 		t.Errorf("after pair complete: A→B expected is_reciprocal=true, got false")
 	}
@@ -140,7 +183,11 @@ func TestHook_FiresOnCreate(t *testing.T) {
 func registerHooksOnApp(app core.App) {
 	app.OnRecordUpdate("bunk_requests").BindFunc(func(e *core.RecordEvent) error {
 		captureOldCoords(e)
-		return e.Next()
+		err := e.Next()
+		if err != nil && e.Record != nil && e.Record.Id != "" {
+			preUpdateCache.Delete(e.Record.Id)
+		}
+		return err
 	})
 	app.OnRecordAfterCreateSuccess("bunk_requests").BindFunc(func(e *core.RecordEvent) error {
 		runRecompute(e)
@@ -172,21 +219,17 @@ func TestHook_DeletionFlipsPartner(t *testing.T) {
 	rowBA := makeRequest(t, app, 200, 100, "bunk_with", "resolved")
 
 	// Sanity: both reciprocal after pair complete.
-	gotBA, _ := app.FindRecordById("bunk_requests", rowBA.Id)
+	gotBA := mustFindRecord(t, app, rowBA.Id)
 	if !gotBA.GetBool("is_reciprocal") {
 		t.Fatalf("setup precondition: expected B→A reciprocal=true, got false")
 	}
 
 	// Delete A→B; hook should fire and recompute B→A.
-	err = app.Delete(rowAB)
-	if err != nil {
+	if err := app.Delete(rowAB); err != nil {
 		t.Fatalf("delete AB: %v", err)
 	}
 
-	gotBA, err = app.FindRecordById("bunk_requests", rowBA.Id)
-	if err != nil {
-		t.Fatalf("reload BA: %v", err)
-	}
+	gotBA = mustFindRecord(t, app, rowBA.Id)
 	if gotBA.GetBool("is_reciprocal") {
 		t.Errorf("after A→B delete: B→A expected is_reciprocal=false, got true (#1059 bug)")
 	}
@@ -209,7 +252,7 @@ func TestHook_StatusFlipFlipsPartner(t *testing.T) {
 	rowBA := makeRequest(t, app, 200, 100, "bunk_with", "resolved")
 
 	// Sanity check.
-	gotBA, _ := app.FindRecordById("bunk_requests", rowBA.Id)
+	gotBA := mustFindRecord(t, app, rowBA.Id)
 	if !gotBA.GetBool("is_reciprocal") {
 		t.Fatalf("precondition: expected B→A reciprocal=true")
 	}
@@ -220,11 +263,11 @@ func TestHook_StatusFlipFlipsPartner(t *testing.T) {
 		t.Fatalf("save flipped AB: %v", err)
 	}
 
-	gotBA, _ = app.FindRecordById("bunk_requests", rowBA.Id)
+	gotBA = mustFindRecord(t, app, rowBA.Id)
 	if gotBA.GetBool("is_reciprocal") {
 		t.Errorf("after A→B flip to declined: B→A expected is_reciprocal=false, got true")
 	}
-	gotAB, _ := app.FindRecordById("bunk_requests", rowAB.Id)
+	gotAB := mustFindRecord(t, app, rowAB.Id)
 	if gotAB.GetBool("is_reciprocal") {
 		t.Errorf("after A→B flip to declined: A→B expected is_reciprocal=false, got true")
 	}
@@ -241,7 +284,7 @@ func TestHook_CrossSessionNotReciprocal(t *testing.T) {
 	setupBunkRequestsCollection(t, app)
 	registerHooksOnApp(app)
 
-	col, _ := app.FindCollectionByNameOrId("bunk_requests")
+	col := mustFindCollection(t, app)
 	rowAB := core.NewRecord(col)
 	rowAB.Set("requester_id", 100)
 	rowAB.Set("requestee_id", 200)
@@ -266,8 +309,8 @@ func TestHook_CrossSessionNotReciprocal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	gotAB, _ := app.FindRecordById("bunk_requests", rowAB.Id)
-	gotBA, _ := app.FindRecordById("bunk_requests", rowBA.Id)
+	gotAB := mustFindRecord(t, app, rowAB.Id)
+	gotBA := mustFindRecord(t, app, rowBA.Id)
 	if gotAB.GetBool("is_reciprocal") || gotBA.GetBool("is_reciprocal") {
 		t.Errorf("cross-session: expected both reciprocal=false, got AB=%v BA=%v",
 			gotAB.GetBool("is_reciprocal"), gotBA.GetBool("is_reciprocal"))
@@ -288,8 +331,8 @@ func TestHook_CrossTypeNotReciprocal(t *testing.T) {
 	rowAB := makeRequest(t, app, 100, 200, "bunk_with", "resolved")
 	rowBA := makeRequest(t, app, 200, 100, "not_bunk_with", "resolved")
 
-	gotAB, _ := app.FindRecordById("bunk_requests", rowAB.Id)
-	gotBA, _ := app.FindRecordById("bunk_requests", rowBA.Id)
+	gotAB := mustFindRecord(t, app, rowAB.Id)
+	gotBA := mustFindRecord(t, app, rowBA.Id)
 	if gotAB.GetBool("is_reciprocal") || gotBA.GetBool("is_reciprocal") {
 		t.Errorf("cross-type: expected both reciprocal=false, got AB=%v BA=%v",
 			gotAB.GetBool("is_reciprocal"), gotBA.GetBool("is_reciprocal"))
@@ -307,7 +350,7 @@ func TestHook_AgePreferenceNoop(t *testing.T) {
 	setupBunkRequestsCollection(t, app)
 	registerHooksOnApp(app)
 
-	col, _ := app.FindCollectionByNameOrId("bunk_requests")
+	col := mustFindCollection(t, app)
 	r := core.NewRecord(col)
 	r.Set("requester_id", 100)
 	r.Set("requestee_id", 0) // age_preference has no requestee
@@ -320,7 +363,7 @@ func TestHook_AgePreferenceNoop(t *testing.T) {
 	if err := app.Save(r); err != nil {
 		t.Fatalf("age_preference save (with hook): %v", err)
 	}
-	got, _ := app.FindRecordById("bunk_requests", r.Id)
+	got := mustFindRecord(t, app, r.Id)
 	if got.GetBool("is_reciprocal") {
 		t.Errorf("age_preference: expected reciprocal=false, got true")
 	}
@@ -339,7 +382,7 @@ func TestHook_SelfReferentialNoop(t *testing.T) {
 
 	r := makeRequest(t, app, 100, 100, "bunk_with", "resolved") // requester == requestee
 
-	got, _ := app.FindRecordById("bunk_requests", r.Id)
+	got := mustFindRecord(t, app, r.Id)
 	if got.GetBool("is_reciprocal") {
 		t.Errorf("self-referential: expected reciprocal=false, got true")
 	}
@@ -361,8 +404,8 @@ func TestRecomputePairReciprocity_IdempotentOnAlreadyCorrect(t *testing.T) {
 	rowBA := makeRequest(t, app, 200, 100, "bunk_with", "resolved")
 
 	// Both should already be reciprocal=true after hooks fire from Save.
-	gotAB, _ := app.FindRecordById("bunk_requests", rowAB.Id)
-	gotBA, _ := app.FindRecordById("bunk_requests", rowBA.Id)
+	gotAB := mustFindRecord(t, app, rowAB.Id)
+	gotBA := mustFindRecord(t, app, rowBA.Id)
 	if !gotAB.GetBool("is_reciprocal") || !gotBA.GetBool("is_reciprocal") {
 		t.Fatalf("precondition: expected both reciprocal=true, got AB=%v BA=%v",
 			gotAB.GetBool("is_reciprocal"), gotBA.GetBool("is_reciprocal"))
@@ -376,8 +419,8 @@ func TestRecomputePairReciprocity_IdempotentOnAlreadyCorrect(t *testing.T) {
 		t.Fatalf("RecomputePairReciprocity: %v", err)
 	}
 
-	gotAB2, _ := app.FindRecordById("bunk_requests", rowAB.Id)
-	gotBA2, _ := app.FindRecordById("bunk_requests", rowBA.Id)
+	gotAB2 := mustFindRecord(t, app, rowAB.Id)
+	gotBA2 := mustFindRecord(t, app, rowBA.Id)
 
 	// updated timestamp should not have moved if no save happened.
 	if !gotAB2.GetDateTime("updated").Time().Equal(abUpdated) {
@@ -385,6 +428,43 @@ func TestRecomputePairReciprocity_IdempotentOnAlreadyCorrect(t *testing.T) {
 	}
 	if !gotBA2.GetDateTime("updated").Time().Equal(baUpdated) {
 		t.Errorf("idempotent call wrote B→A unnecessarily; updated changed")
+	}
+}
+
+// Test 11 — Failed update must not leak preUpdateCache entries.
+//
+// captureOldCoords stashes pre-mutation coords keyed by record ID before
+// e.Next() runs. If e.Next() returns an error, AfterUpdateSuccess never
+// fires and the LoadAndDelete inside runRecompute never clears the entry —
+// the package-global sync.Map leaks one entry per failed update.
+func TestHook_FailedUpdateDoesNotLeakCache(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	defer app.Cleanup()
+
+	setupBunkRequestsCollection(t, app)
+	registerHooksOnApp(app)
+
+	row := makeRequest(t, app, 100, 200, "bunk_with", "resolved")
+
+	// Bind a second OnRecordUpdate hook that returns an error so the chain's
+	// e.Next() inside captureOldCoords' wrapper sees a failure.
+	forceErr := errors.New("force update failure")
+	app.OnRecordUpdate("bunk_requests").BindFunc(func(e *core.RecordEvent) error {
+		return forceErr
+	})
+
+	drainPreUpdateCache()
+
+	row.Set("status", "declined")
+	if err := app.Save(row); !errors.Is(err, forceErr) {
+		t.Fatalf("expected forced update failure, got %v", err)
+	}
+
+	if got := countPreUpdateCache(); got != 0 {
+		t.Errorf("preUpdateCache leak: expected 0 entries after failed update, got %d", got)
 	}
 }
 
@@ -409,7 +489,7 @@ func TestHook_RequesterIDMutationRecomputesOldPair(t *testing.T) {
 	// Precondition: pair (100, 200) both resolved → both reciprocal=true.
 	rowAB := makeRequest(t, app, 100, 200, "bunk_with", "resolved")
 	rowBA := makeRequest(t, app, 200, 100, "bunk_with", "resolved")
-	gotBA, _ := app.FindRecordById("bunk_requests", rowBA.Id)
+	gotBA := mustFindRecord(t, app, rowBA.Id)
 	if !gotBA.GetBool("is_reciprocal") {
 		t.Fatalf("precondition: B→A expected reciprocal=true, got false")
 	}
@@ -418,15 +498,11 @@ func TestHook_RequesterIDMutationRecomputesOldPair(t *testing.T) {
 	// now orphaned: B→A still points at requester 100, but no row at (100, 200)
 	// exists any more. B→A's is_reciprocal must flip to false.
 	rowAB.Set("requester_id", 300)
-	err = app.Save(rowAB)
-	if err != nil {
+	if err := app.Save(rowAB); err != nil {
 		t.Fatalf("save mutated AB: %v", err)
 	}
 
-	gotBA, err = app.FindRecordById("bunk_requests", rowBA.Id)
-	if err != nil {
-		t.Fatalf("reload BA: %v", err)
-	}
+	gotBA = mustFindRecord(t, app, rowBA.Id)
 	if gotBA.GetBool("is_reciprocal") {
 		t.Errorf("after requester_id mutation: B→A expected is_reciprocal=false (old pair orphaned), got true")
 	}

--- a/pocketbase/bunk_requests/reciprocity_test.go
+++ b/pocketbase/bunk_requests/reciprocity_test.go
@@ -223,3 +223,99 @@ func TestHook_StatusFlipFlipsPartner(t *testing.T) {
 		t.Errorf("after A→B flip to declined: A→B expected is_reciprocal=false, got true")
 	}
 }
+
+// Test 5 — Cross-session: A→B in session 1, B→A in session 2 → neither reciprocal.
+func TestHook_CrossSessionNotReciprocal(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	defer app.Cleanup()
+
+	setupBunkRequestsCollection(t, app)
+	registerHooksOnApp(app)
+
+	col, _ := app.FindCollectionByNameOrId("bunk_requests")
+	rowAB := core.NewRecord(col)
+	rowAB.Set("requester_id", 100)
+	rowAB.Set("requestee_id", 200)
+	rowAB.Set("request_type", "bunk_with")
+	rowAB.Set("status", "resolved")
+	rowAB.Set("year", 2026)
+	rowAB.Set("session_id", 1235404)
+	rowAB.Set("is_reciprocal", false)
+	if err := app.Save(rowAB); err != nil {
+		t.Fatal(err)
+	}
+
+	rowBA := core.NewRecord(col)
+	rowBA.Set("requester_id", 200)
+	rowBA.Set("requestee_id", 100)
+	rowBA.Set("request_type", "bunk_with")
+	rowBA.Set("status", "resolved")
+	rowBA.Set("year", 2026)
+	rowBA.Set("session_id", 9999999) // DIFFERENT session
+	rowBA.Set("is_reciprocal", false)
+	if err := app.Save(rowBA); err != nil {
+		t.Fatal(err)
+	}
+
+	gotAB, _ := app.FindRecordById("bunk_requests", rowAB.Id)
+	gotBA, _ := app.FindRecordById("bunk_requests", rowBA.Id)
+	if gotAB.GetBool("is_reciprocal") || gotBA.GetBool("is_reciprocal") {
+		t.Errorf("cross-session: expected both reciprocal=false, got AB=%v BA=%v",
+			gotAB.GetBool("is_reciprocal"), gotBA.GetBool("is_reciprocal"))
+	}
+}
+
+// Test 6 — Cross-type: A→B bunk_with, B→A not_bunk_with → neither reciprocal.
+func TestHook_CrossTypeNotReciprocal(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	defer app.Cleanup()
+
+	setupBunkRequestsCollection(t, app)
+	registerHooksOnApp(app)
+
+	rowAB := makeRequest(t, app, 100, 200, "bunk_with", "resolved")
+	rowBA := makeRequest(t, app, 200, 100, "not_bunk_with", "resolved")
+
+	gotAB, _ := app.FindRecordById("bunk_requests", rowAB.Id)
+	gotBA, _ := app.FindRecordById("bunk_requests", rowBA.Id)
+	if gotAB.GetBool("is_reciprocal") || gotBA.GetBool("is_reciprocal") {
+		t.Errorf("cross-type: expected both reciprocal=false, got AB=%v BA=%v",
+			gotAB.GetBool("is_reciprocal"), gotBA.GetBool("is_reciprocal"))
+	}
+}
+
+// Test 7 — age_preference: hook is a no-op, no errors.
+func TestHook_AgePreferenceNoop(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	defer app.Cleanup()
+
+	setupBunkRequestsCollection(t, app)
+	registerHooksOnApp(app)
+
+	col, _ := app.FindCollectionByNameOrId("bunk_requests")
+	r := core.NewRecord(col)
+	r.Set("requester_id", 100)
+	r.Set("requestee_id", 0) // age_preference has no requestee
+	r.Set("request_type", "age_preference")
+	r.Set("status", "resolved")
+	r.Set("year", 2026)
+	r.Set("session_id", 1235404)
+	r.Set("is_reciprocal", false)
+
+	if err := app.Save(r); err != nil {
+		t.Fatalf("age_preference save (with hook): %v", err)
+	}
+	got, _ := app.FindRecordById("bunk_requests", r.Id)
+	if got.GetBool("is_reciprocal") {
+		t.Errorf("age_preference: expected reciprocal=false, got true")
+	}
+}

--- a/pocketbase/bunk_requests/reciprocity_test.go
+++ b/pocketbase/bunk_requests/reciprocity_test.go
@@ -150,3 +150,38 @@ func registerHooksOnApp(app core.App) {
 		return e.Next()
 	})
 }
+
+// Test 3 — #1059 direct reproduction: pair both reciprocal=true, delete one,
+// surviving partner's flag should flip to false.
+func TestHook_DeletionFlipsPartner(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	defer app.Cleanup()
+
+	setupBunkRequestsCollection(t, app)
+	registerHooksOnApp(app)
+
+	rowAB := makeRequest(t, app, 100, 200, "bunk_with", "resolved")
+	rowBA := makeRequest(t, app, 200, 100, "bunk_with", "resolved")
+
+	// Sanity: both reciprocal after pair complete.
+	gotBA, _ := app.FindRecordById("bunk_requests", rowBA.Id)
+	if !gotBA.GetBool("is_reciprocal") {
+		t.Fatalf("setup precondition: expected B→A reciprocal=true, got false")
+	}
+
+	// Delete A→B; hook should fire and recompute B→A.
+	if err := app.Delete(rowAB); err != nil {
+		t.Fatalf("delete AB: %v", err)
+	}
+
+	gotBA, err = app.FindRecordById("bunk_requests", rowBA.Id)
+	if err != nil {
+		t.Fatalf("reload BA: %v", err)
+	}
+	if gotBA.GetBool("is_reciprocal") {
+		t.Errorf("after A→B delete: B→A expected is_reciprocal=false, got true (#1059 bug)")
+	}
+}

--- a/pocketbase/bunk_requests/reciprocity_test.go
+++ b/pocketbase/bunk_requests/reciprocity_test.go
@@ -319,3 +319,65 @@ func TestHook_AgePreferenceNoop(t *testing.T) {
 		t.Errorf("age_preference: expected reciprocal=false, got true")
 	}
 }
+
+// Test 8 — Self-referential row: hook is a no-op, no errors.
+func TestHook_SelfReferentialNoop(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	defer app.Cleanup()
+
+	setupBunkRequestsCollection(t, app)
+	registerHooksOnApp(app)
+
+	r := makeRequest(t, app, 100, 100, "bunk_with", "resolved") // requester == requestee
+
+	got, _ := app.FindRecordById("bunk_requests", r.Id)
+	if got.GetBool("is_reciprocal") {
+		t.Errorf("self-referential: expected reciprocal=false, got true")
+	}
+}
+
+// Test 9 — Idempotency: invoking the helper directly on an already-correct
+// pair should produce zero saves and not error.
+func TestRecomputePairReciprocity_IdempotentOnAlreadyCorrect(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	defer app.Cleanup()
+
+	setupBunkRequestsCollection(t, app)
+	registerHooksOnApp(app)
+
+	rowAB := makeRequest(t, app, 100, 200, "bunk_with", "resolved")
+	rowBA := makeRequest(t, app, 200, 100, "bunk_with", "resolved")
+
+	// Both should already be reciprocal=true after hooks fire from Save.
+	gotAB, _ := app.FindRecordById("bunk_requests", rowAB.Id)
+	gotBA, _ := app.FindRecordById("bunk_requests", rowBA.Id)
+	if !gotAB.GetBool("is_reciprocal") || !gotBA.GetBool("is_reciprocal") {
+		t.Fatalf("precondition: expected both reciprocal=true, got AB=%v BA=%v",
+			gotAB.GetBool("is_reciprocal"), gotBA.GetBool("is_reciprocal"))
+	}
+
+	abUpdated := gotAB.GetDateTime("updated").Time()
+	baUpdated := gotBA.GetDateTime("updated").Time()
+
+	// Direct invocation on already-correct pair.
+	if err := RecomputePairReciprocity(app, 2026, 1235404, 100, 200, "bunk_with"); err != nil {
+		t.Fatalf("RecomputePairReciprocity: %v", err)
+	}
+
+	gotAB2, _ := app.FindRecordById("bunk_requests", rowAB.Id)
+	gotBA2, _ := app.FindRecordById("bunk_requests", rowBA.Id)
+
+	// updated timestamp should not have moved if no save happened.
+	if !gotAB2.GetDateTime("updated").Time().Equal(abUpdated) {
+		t.Errorf("idempotent call wrote A→B unnecessarily; updated changed")
+	}
+	if !gotBA2.GetDateTime("updated").Time().Equal(baUpdated) {
+		t.Errorf("idempotent call wrote B→A unnecessarily; updated changed")
+	}
+}

--- a/pocketbase/bunk_requests/reciprocity_test.go
+++ b/pocketbase/bunk_requests/reciprocity_test.go
@@ -94,3 +94,59 @@ func TestRecomputePairReciprocity_CreatesPair(t *testing.T) {
 		t.Errorf("B→A: expected is_reciprocal=true, got false")
 	}
 }
+
+// Test 2: With the hook registered, inserting B→A on top of an existing
+// resolved A→B should fire the hook and flip both rows' is_reciprocal=true.
+func TestHook_FiresOnCreate(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	defer app.Cleanup()
+
+	setupBunkRequestsCollection(t, app)
+
+	// NOTE: we can't pass *tests.TestApp to RegisterHooks (which expects
+	// *pocketbase.PocketBase). Use the lower-level event API directly,
+	// matching what RegisterHooks does.
+	registerHooksOnApp(app)
+
+	rowAB := makeRequest(t, app, 100, 200, "bunk_with", "resolved")
+
+	// At this point only A→B exists; the hook fired but B→A doesn't exist
+	// yet, so A→B's flag stays false.
+	gotAB, _ := app.FindRecordById("bunk_requests", rowAB.Id)
+	if gotAB.GetBool("is_reciprocal") {
+		t.Errorf("after lone A→B insert: expected is_reciprocal=false, got true")
+	}
+
+	// Now insert B→A. Hook fires, recompute finds both rows resolved → both flip.
+	rowBA := makeRequest(t, app, 200, 100, "bunk_with", "resolved")
+
+	gotAB, _ = app.FindRecordById("bunk_requests", rowAB.Id)
+	gotBA, _ := app.FindRecordById("bunk_requests", rowBA.Id)
+	if !gotAB.GetBool("is_reciprocal") {
+		t.Errorf("after pair complete: A→B expected is_reciprocal=true, got false")
+	}
+	if !gotBA.GetBool("is_reciprocal") {
+		t.Errorf("after pair complete: B→A expected is_reciprocal=true, got false")
+	}
+}
+
+// registerHooksOnApp wires the same three success hooks RegisterHooks does,
+// but takes a core.App (which the *tests.TestApp implements). We can't pass
+// *tests.TestApp to RegisterHooks because it expects *pocketbase.PocketBase.
+func registerHooksOnApp(app core.App) {
+	app.OnRecordAfterCreateSuccess("bunk_requests").BindFunc(func(e *core.RecordEvent) error {
+		runRecompute(e)
+		return e.Next()
+	})
+	app.OnRecordAfterUpdateSuccess("bunk_requests").BindFunc(func(e *core.RecordEvent) error {
+		runRecompute(e)
+		return e.Next()
+	})
+	app.OnRecordAfterDeleteSuccess("bunk_requests").BindFunc(func(e *core.RecordEvent) error {
+		runRecompute(e)
+		return e.Next()
+	})
+}

--- a/pocketbase/cmd/backfill_reciprocity/main.go
+++ b/pocketbase/cmd/backfill_reciprocity/main.go
@@ -11,9 +11,16 @@ import (
 	"github.com/pocketbase/pocketbase"
 
 	bunkrequests "github.com/camp/kindred/pocketbase/bunk_requests"
+	"github.com/camp/kindred/pocketbase/logging"
 )
 
 func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	logging.Init("backfill_reciprocity")
+
 	dbDir := flag.String("data", "pb_data", "PocketBase data directory")
 	flag.Parse()
 
@@ -22,14 +29,19 @@ func main() {
 	})
 	if err := app.Bootstrap(); err != nil {
 		slog.Error("bootstrap", "error", err)
-		os.Exit(1)
+		return 1
 	}
-	defer app.ResetBootstrapState()
+	defer func() {
+		if err := app.ResetBootstrapState(); err != nil {
+			slog.Warn("ResetBootstrapState", "error", err)
+		}
+	}()
 
 	count, err := bunkrequests.BackfillAll(app)
 	if err != nil {
-		slog.Error("backfill failed", "error", err)
-		os.Exit(1)
+		slog.Error("backfill failed", "error", err, "pairs_attempted", count)
+		return 1
 	}
 	slog.Info("backfill complete", "pairs_processed", count)
+	return 0
 }

--- a/pocketbase/cmd/backfill_reciprocity/main.go
+++ b/pocketbase/cmd/backfill_reciprocity/main.go
@@ -1,0 +1,35 @@
+// Command backfill_reciprocity walks all bunk_requests pairs and recomputes
+// is_reciprocal for each, fixing any historical drift introduced before the
+// reciprocity hook was deployed. Idempotent — safe to re-run.
+package main
+
+import (
+	"flag"
+	"log/slog"
+	"os"
+
+	"github.com/pocketbase/pocketbase"
+
+	bunkrequests "github.com/camp/kindred/pocketbase/bunk_requests"
+)
+
+func main() {
+	dbDir := flag.String("data", "pb_data", "PocketBase data directory")
+	flag.Parse()
+
+	app := pocketbase.NewWithConfig(pocketbase.Config{
+		DefaultDataDir: *dbDir,
+	})
+	if err := app.Bootstrap(); err != nil {
+		slog.Error("bootstrap", "error", err)
+		os.Exit(1)
+	}
+	defer app.ResetBootstrapState()
+
+	count, err := bunkrequests.BackfillAll(app)
+	if err != nil {
+		slog.Error("backfill failed", "error", err)
+		os.Exit(1)
+	}
+	slog.Info("backfill complete", "pairs_processed", count)
+}

--- a/pocketbase/cmd/backfill_reciprocity/main_test.go
+++ b/pocketbase/cmd/backfill_reciprocity/main_test.go
@@ -41,7 +41,10 @@ func TestBackfill_FixesStaleRow(t *testing.T) {
 
 	// Insert a row that's intentionally stale: is_reciprocal=true on a row
 	// whose partner does NOT exist. Mirrors the production bug pattern.
-	col, _ := app.FindCollectionByNameOrId("bunk_requests")
+	col, err := app.FindCollectionByNameOrId("bunk_requests")
+	if err != nil {
+		t.Fatalf("find collection: %v", err)
+	}
 	r := core.NewRecord(col)
 	r.Set("requester_id", 100)
 	r.Set("requestee_id", 200)
@@ -58,7 +61,10 @@ func TestBackfill_FixesStaleRow(t *testing.T) {
 		t.Fatalf("backfill: %v", err)
 	}
 
-	got, _ := app.FindRecordById("bunk_requests", r.Id)
+	got, err := app.FindRecordById("bunk_requests", r.Id)
+	if err != nil {
+		t.Fatalf("reload row: %v", err)
+	}
 	if got.GetBool("is_reciprocal") {
 		t.Errorf("backfill failed to fix stale row: still is_reciprocal=true")
 	}

--- a/pocketbase/cmd/backfill_reciprocity/main_test.go
+++ b/pocketbase/cmd/backfill_reciprocity/main_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+
+	bunkrequests "github.com/camp/kindred/pocketbase/bunk_requests"
+)
+
+func setupBunkRequestsCollection(t *testing.T, app core.App) {
+	t.Helper()
+	col := core.NewBaseCollection("bunk_requests")
+	col.Fields.Add(&core.NumberField{Name: "requester_id", Required: true})
+	col.Fields.Add(&core.NumberField{Name: "requestee_id"})
+	col.Fields.Add(&core.SelectField{
+		Name: "request_type", Required: true,
+		Values: []string{"bunk_with", "not_bunk_with", "age_preference"}, MaxSelect: 1,
+	})
+	col.Fields.Add(&core.SelectField{
+		Name: "status", Required: true,
+		Values: []string{"pending", "resolved", "declined"}, MaxSelect: 1,
+	})
+	col.Fields.Add(&core.NumberField{Name: "year", Required: true})
+	col.Fields.Add(&core.NumberField{Name: "session_id"})
+	col.Fields.Add(&core.BoolField{Name: "is_reciprocal"})
+	if err := app.Save(col); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+}
+
+func TestBackfill_FixesStaleRow(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+
+	setupBunkRequestsCollection(t, app)
+
+	// Insert a row that's intentionally stale: is_reciprocal=true on a row
+	// whose partner does NOT exist. Mirrors the production bug pattern.
+	col, _ := app.FindCollectionByNameOrId("bunk_requests")
+	r := core.NewRecord(col)
+	r.Set("requester_id", 100)
+	r.Set("requestee_id", 200)
+	r.Set("request_type", "bunk_with")
+	r.Set("status", "resolved")
+	r.Set("year", 2026)
+	r.Set("session_id", 1235404)
+	r.Set("is_reciprocal", true) // <-- STALE
+	if err := app.Save(r); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := bunkrequests.BackfillAll(app); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	got, _ := app.FindRecordById("bunk_requests", r.Id)
+	if got.GetBool("is_reciprocal") {
+		t.Errorf("backfill failed to fix stale row: still is_reciprocal=true")
+	}
+}

--- a/pocketbase/cmd/backfill_reciprocity/main_test.go
+++ b/pocketbase/cmd/backfill_reciprocity/main_test.go
@@ -53,11 +53,11 @@ func TestBackfill_FixesStaleRow(t *testing.T) {
 	r.Set("year", 2026)
 	r.Set("session_id", 1235404)
 	r.Set("is_reciprocal", true) // <-- STALE
-	if err := app.Save(r); err != nil {
+	if err = app.Save(r); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := bunkrequests.BackfillAll(app); err != nil {
+	if _, err = bunkrequests.BackfillAll(app); err != nil {
 		t.Fatalf("backfill: %v", err)
 	}
 

--- a/pocketbase/cmd/backfill_reciprocity/main_test.go
+++ b/pocketbase/cmd/backfill_reciprocity/main_test.go
@@ -23,7 +23,7 @@ func setupBunkRequestsCollection(t *testing.T, app core.App) {
 		Values: []string{"pending", "resolved", "declined"}, MaxSelect: 1,
 	})
 	col.Fields.Add(&core.NumberField{Name: "year", Required: true})
-	col.Fields.Add(&core.NumberField{Name: "session_id"})
+	col.Fields.Add(&core.NumberField{Name: "session_id", Required: true})
 	col.Fields.Add(&core.BoolField{Name: "is_reciprocal"})
 	if err := app.Save(col); err != nil {
 		t.Fatalf("setup: %v", err)

--- a/pocketbase/main.go
+++ b/pocketbase/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pocketbase/pocketbase/tools/hook"
 
 	// Import our packages
+	bunkrequests "github.com/camp/kindred/pocketbase/bunk_requests"
 	"github.com/camp/kindred/pocketbase/feedback"
 	"github.com/camp/kindred/pocketbase/logging"
 	"github.com/camp/kindred/pocketbase/rbac"
@@ -151,6 +152,10 @@ func main() {
 
 	// Register RBAC hooks for permission cache recomputation
 	rbac.RegisterHooks(app)
+
+	// Register bunk_requests reciprocity hook (keeps is_reciprocal accurate
+	// after any write — closes #1059, supports #1069 status flips).
+	bunkrequests.RegisterHooks(app)
 
 	// Start scheduler after the app is fully initialized
 	app.OnServe().BindFunc(func(e *core.ServeEvent) error {


### PR DESCRIPTION
## Summary
- New PocketBase Go hook (`pocketbase/bunk_requests/`) recomputes `is_reciprocal` on both rows of a pair after every Create/Update/Delete on `bunk_requests`. Idempotent compare-and-set guards re-entry.
- One-shot backfill cmd at `pocketbase/cmd/backfill_reciprocity/` to correct existing stale rows. Run once on deploy.
- Hook also covers the #1069 attendee-leaves scenario for free — when #1069's sync logic flips a row to declined, the hook picks it up and updates the partner.

## Closes
- #1059 — stale `is_reciprocal` flag on surviving bunk_request when partner row is removed

## Notes
- Reciprocity is computed symmetrically: both rows are reciprocal iff both exist AND both have `status = "resolved"`. This matches the existing graph builder semantic at `bunking/graph/social_graph_builder.py:379` (`has_forward && has_backward`). The design spec's per-call logic step 5 had asymmetric wording (target_AB = bResolved); the implementation uses the symmetric form to stay consistent with the graph builder, which the spec itself self-references as authoritative.

## Test plan
- [x] All 9 new Go tests pass (`go test ./pocketbase/bunk_requests/...`)
- [x] Backfill test passes (`go test ./pocketbase/cmd/backfill_reciprocity/`)
- [x] Full `go test ./...` passes — 2190 tests, no regressions
- [x] lefthook pre-push checks pass (ruff, mypy, tsc, go-build, pb-js-lint, shellcheck)
- [ ] Backfill cmd built and ready for one-shot deploy run

## Deploy step
After merging, run `./pocketbase/cmd/backfill_reciprocity --data <path-to-pb_data>` once against production. Idempotent — safe to re-run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic reciprocity tracking for bunk requests with hooks registered at app startup.
  * New idempotent backfill command to recompute reciprocity across existing data.

* **Bug Fixes**
  * Clears stale/orphaned reciprocity flags and continues processing when individual recomputations fail (partial failures logged).

* **Tests**
  * Added tests covering hooks, backfill, edge cases, and cache-leak prevention.

* **Chores**
  * Updated ignore rules and static analysis config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->