### PR TITLE
fix(deps): bump python-multipart to 0.0.27 for CVE-2026-42561

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     # Web framework
     "fastapi>=0.128.0",
     "uvicorn[standard]>=0.46.0",
-    "python-multipart>=0.0.26",
+    "python-multipart>=0.0.27",
     # Database
     "pocketbase>=0.15.0",
     # HTTP clients

--- a/uv.lock
+++ b/uv.lock
@@ -721,7 +721,7 @@ requires-dist = [
     { name = "pypdf", specifier = ">=6.10.2" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-louvain", specifier = ">=0.16" },
-    { name = "python-multipart", specifier = ">=0.0.26" },
+    { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rapidfuzz", specifier = ">=3.14.3" },
     { name = "requests", specifier = ">=2.33.1" },
@@ -1504,11 +1504,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/7c/0d/8787b021d52eb8764
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `python-multipart` 0.0.26 → 0.0.27 in `pyproject.toml` + `uv.lock`
- Resolves CVE-2026-42561 (DoS via unbounded multipart header parsing)
- Unblocks `pip-audit` step in Python Lint, currently failing on main and every open PR since 2026-05-06

## Why this couldn't wait for Dependabot
- 0.0.27 published 2026-04-27; weekly Dependabot run with 3-day cooldown should have grouped it next Monday
- GHSA published today; Dependabot security path hasn't propagated yet (`gh api dependabot/alerts` doesn't list it)
- Result: every PR's CI is red until this lands

## Risk
- 0.0.27 adds default limits on multipart header count + size (the CVE fix itself)
- We don't use `UploadFile` or `multipart` directly — it's a transitive FastAPI dep — so the new limits are defense-in-depth, no behavior change for our code
- Pure-Python universal wheel (`py3-none-any.whl`), `Requires-Python: >=3.10`

## Test plan
- [x] `uv run pip-audit` clean locally
- [x] Pre-push verification (ruff format/check, mypy, pytest unit suite — 4105 passed)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to ensure optimal stability and compatibility with the latest improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->