### PR TITLE
build(docker): bound HEALTHCHECK probes with --max-time

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -47,6 +47,6 @@ ENV LOG_LEVEL=INFO
 ENV TZ=UTC
 
 HEALTHCHECK --interval=15s --timeout=10s --retries=5 --start-period=45s \
-    CMD curl -f http://127.0.0.1:8000/health || exit 1
+    CMD curl --connect-timeout 2 --max-time 5 -f http://127.0.0.1:8000/health || exit 1
 
 ENTRYPOINT ["/app/.venv/bin/python", "-m", "uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Adds defensive timeouts to the API container HEALTHCHECK probe.

**Problem:** If the `/health` endpoint hangs in a future regression, Docker's healthcheck 
could wait indefinitely for curl to timeout (or hang for the 10s HEALTHCHECK timeout). 
A slow health check can cause cascading failures in orchestrators.

**Solution:** Bound the curl probe with:
- `--connect-timeout 2` — fail fast if the connection can't establish
- `--max-time 5` — ensure the overall request completes within one timeout cycle

Both timeouts are well under the HEALTHCHECK `--timeout=10s`, leaving buffer for 
the container to respond and exit cleanly.

**Context:** Follow-up defensive hardening after PR #1176 (pre-push hook robustness).
No current symptom or bug — pure defense-in-depth.

Closes #1179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved API container health check response times and reliability by adding explicit timeout limits to health status monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->