### PR TITLE
refactor(pb): extract wireHooks(core.App) for shared hook wiring

### DIFF
--- a/pocketbase/bunk_requests/hooks.go
+++ b/pocketbase/bunk_requests/hooks.go
@@ -29,6 +29,15 @@ var preUpdateCache sync.Map // map[string]pairCoords
 // RegisterHooks wires reciprocity-recompute hooks onto the bunk_requests
 // collection. Errors are logged via slog and never block the underlying write.
 func RegisterHooks(app *pocketbase.PocketBase) {
+	wireHooks(app)
+	slog.Info("bunk_requests reciprocity hooks registered")
+}
+
+// wireHooks attaches all 4 reciprocity BindFunc calls to any core.App
+// implementation. Extracted so that both RegisterHooks (production) and the
+// test suite (which uses *tests.TestApp, not *pocketbase.PocketBase) share a
+// single hook-binding implementation.
+func wireHooks(app core.App) {
 	app.OnRecordUpdate("bunk_requests").BindFunc(func(e *core.RecordEvent) error {
 		captureOldCoords(e)
 		err := e.Next()
@@ -51,8 +60,6 @@ func RegisterHooks(app *pocketbase.PocketBase) {
 		runRecompute(e)
 		return e.Next()
 	})
-
-	slog.Info("bunk_requests reciprocity hooks registered")
 }
 
 // captureOldCoords reads the pre-mutation pair coords directly from the DB

--- a/pocketbase/bunk_requests/reciprocity_test.go
+++ b/pocketbase/bunk_requests/reciprocity_test.go
@@ -181,26 +181,7 @@ func TestHook_FiresOnCreate(t *testing.T) {
 // core.App (which the *tests.TestApp implements). We can't pass *tests.TestApp
 // to RegisterHooks because it expects *pocketbase.PocketBase.
 func registerHooksOnApp(app core.App) {
-	app.OnRecordUpdate("bunk_requests").BindFunc(func(e *core.RecordEvent) error {
-		captureOldCoords(e)
-		err := e.Next()
-		if err != nil && e.Record != nil && e.Record.Id != "" {
-			preUpdateCache.Delete(e.Record.Id)
-		}
-		return err
-	})
-	app.OnRecordAfterCreateSuccess("bunk_requests").BindFunc(func(e *core.RecordEvent) error {
-		runRecompute(e)
-		return e.Next()
-	})
-	app.OnRecordAfterUpdateSuccess("bunk_requests").BindFunc(func(e *core.RecordEvent) error {
-		runRecompute(e)
-		return e.Next()
-	})
-	app.OnRecordAfterDeleteSuccess("bunk_requests").BindFunc(func(e *core.RecordEvent) error {
-		runRecompute(e)
-		return e.Next()
-	})
+	wireHooks(app)
 }
 
 // Test 3 — #1059 direct reproduction: pair both reciprocal=true, delete one,


### PR DESCRIPTION
## Summary

- Extracts `wireHooks(app core.App)` from `RegisterHooks` in `pocketbase/bunk_requests/hooks.go` as the single source of truth for all 4 `BindFunc` calls
- `RegisterHooks(*pocketbase.PocketBase)` now delegates to `wireHooks` then logs
- `registerHooksOnApp(core.App)` in the test file now delegates to `wireHooks` — the 22-line duplicate is gone
- `wireHooks` is package-private (lowercase); no new public surface

## Test plan

- [x] Baseline: all 11 tests in `pocketbase/bunk_requests/...` pass before refactor
- [x] Post-refactor: all 11 tests still pass
- [x] `go build ./...` clean
- [x] `golangci-lint run ./bunk_requests/...` — no issues

Closes #1185

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced internal hook registration system by consolidating code and reducing duplication between production and test environments, improving maintainability and consistency across request handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->