### PR TITLE
feat(api): single-flight 409 on /solver/run for in-progress session

### DIFF
--- a/api/routers/scenarios.py
+++ b/api/routers/scenarios.py
@@ -690,12 +690,25 @@ async def solve_scenario(
         session_cm_id: int = getattr(scenario, "session_cm_id", 0)
         scenario_year: int = getattr(scenario, "year", 0)
 
+        # Single-flight guard: reject duplicate in-progress runs for the same session.
+        # Mirrors the guard in solver.py:run_solver — uses the unified "session_cm_id" key
+        # so that both the regular solver path and the scenario path see each other's runs.
+        for run in solver_runs.values():
+            if run.get("session_cm_id") == session_cm_id and run.get("status") in {"pending", "running"}:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "detail": f"Solver already running for session {session_cm_id}",
+                        "in_progress_run_id": run["id"],
+                    },
+                )
+
         run_id = str(uuid4())
         solver_runs[run_id] = {
             "id": run_id,
             "status": "pending",
             "scenario": scenario_id,
-            "session_id": session_cm_id,
+            "session_cm_id": session_cm_id,
             "year": scenario_year,
             "started_at": datetime.now(UTC),
         }

--- a/api/routers/solver.py
+++ b/api/routers/solver.py
@@ -69,6 +69,19 @@ async def run_solver(
     user: AuthUser = Depends(require_permission(Permission.BUNKING_MANAGE)),
 ) -> SolverResponse:
     """Run the bunking solver for a session."""
+    # Single-flight guard: reject duplicate in-progress runs for the same session.
+    # FastAPI serializes coroutines on the event loop and solver_runs is in-process,
+    # so no locking is needed beyond a plain dict scan.
+    for run in solver_runs.values():
+        if run.get("session_cm_id") == request.session_cm_id and run.get("status") in {"pending", "running"}:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "detail": f"Solver already running for session {request.session_cm_id}",
+                    "in_progress_run_id": run["id"],
+                },
+            )
+
     run_id = str(uuid4())
 
     # Get time limit from config if not specified in request
@@ -706,6 +719,20 @@ async def run_multi_session_solver(
                 session_groups[sex_eligible].append(session)
         else:
             session_groups["all"] = child_sessions
+
+        # Single-flight guard: check all child sessions before dispatching any run.
+        # Reject the entire request if any child session already has a pending/running solve.
+        for session in child_sessions:
+            candidate_cm_id = getattr(session, "cm_id", 0)
+            for run in solver_runs.values():
+                if run.get("session_cm_id") == candidate_cm_id and run.get("status") in {"pending", "running"}:
+                    raise HTTPException(
+                        status_code=409,
+                        detail={
+                            "detail": f"Solver already running for session {candidate_cm_id}",
+                            "in_progress_run_id": run["id"],
+                        },
+                    )
 
         run_ids: dict[str, list[dict[str, Any]]] = {}
         for sex_group, sessions in session_groups.items():

--- a/frontend/src/components/graph/GraphControls.test.tsx
+++ b/frontend/src/components/graph/GraphControls.test.tsx
@@ -5,6 +5,7 @@
 
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import GraphControls from './GraphControls'
 
@@ -119,7 +120,6 @@ describe('GraphControls rendering', () => {
     })
 
     it('opens a menu with "Fit to graph" and "Current view" on click', async () => {
-      const { default: userEvent } = await import('@testing-library/user-event')
       const user = userEvent.setup()
       render(<GraphControls {...baseProps} onDownload={vi.fn()} />)
       await user.click(screen.getByTitle(/download as png/i))
@@ -129,7 +129,6 @@ describe('GraphControls rendering', () => {
 
     it('invokes onDownload("fit") when "Fit to graph" is clicked', async () => {
       const onDownload = vi.fn()
-      const { default: userEvent } = await import('@testing-library/user-event')
       const user = userEvent.setup()
       render(<GraphControls {...baseProps} onDownload={onDownload} />)
       await user.click(screen.getByTitle(/download as png/i))
@@ -140,7 +139,6 @@ describe('GraphControls rendering', () => {
 
     it('invokes onDownload("viewport") when "Current view" is clicked', async () => {
       const onDownload = vi.fn()
-      const { default: userEvent } = await import('@testing-library/user-event')
       const user = userEvent.setup()
       render(<GraphControls {...baseProps} onDownload={onDownload} />)
       await user.click(screen.getByTitle(/download as png/i))
@@ -149,7 +147,6 @@ describe('GraphControls rendering', () => {
     })
 
     it('closes the menu after a selection', async () => {
-      const { default: userEvent } = await import('@testing-library/user-event')
       const user = userEvent.setup()
       render(<GraphControls {...baseProps} onDownload={vi.fn()} />)
       await user.click(screen.getByTitle(/download as png/i))
@@ -158,7 +155,6 @@ describe('GraphControls rendering', () => {
     })
 
     it('closes the menu when clicking outside', async () => {
-      const { default: userEvent } = await import('@testing-library/user-event')
       const user = userEvent.setup()
       render(
         <div>

--- a/tests/unit/api/routers/test_solver_singleflight.py
+++ b/tests/unit/api/routers/test_solver_singleflight.py
@@ -415,7 +415,7 @@ class TestScenarioSolverSingleFlight:
     # Test A: in-progress scenario run must block /api/solver/run
     # ------------------------------------------------------------------
 
-    def test_A_scenario_endpoint_writes_session_cm_id_key(self) -> None:
+    def test_a_scenario_endpoint_writes_session_cm_id_key(self) -> None:
         """POST /api/scenarios/{id}/solve must write "session_cm_id" (not "session_id") to solver_runs.
 
         Root cause of the guard gap: scenarios.py wrote solver_runs entries with
@@ -441,7 +441,7 @@ class TestScenarioSolverSingleFlight:
         )
         assert run_entry["session_cm_id"] == 5001  # matches mock_scenario.session_cm_id
 
-    def test_A_scenario_run_blocks_solver_run_for_same_session(self) -> None:
+    def test_a_scenario_run_blocks_solver_run_for_same_session(self) -> None:
         """POST /api/solver/run must return 409 when a scenario run is in-progress for the same session.
 
         Root cause: scenarios.py wrote solver_runs entries with key "session_id"
@@ -473,7 +473,7 @@ class TestScenarioSolverSingleFlight:
         assert detail["detail"] == "Solver already running for session 5001"
         assert detail["in_progress_run_id"] == scenario_run_id
 
-    def test_A_scenario_run_does_not_block_solver_run_for_different_session(self) -> None:
+    def test_a_scenario_run_does_not_block_solver_run_for_different_session(self) -> None:
         """POST /api/solver/run must succeed when the in-progress scenario run is for a different session."""
         scenario_run_id = "scenario-run-other-session"
         solver_runs_state: dict[str, Any] = {
@@ -499,7 +499,7 @@ class TestScenarioSolverSingleFlight:
     # Test B: scenario endpoint must block duplicate scenario runs
     # ------------------------------------------------------------------
 
-    def test_B_scenario_run_blocks_second_scenario_run_for_same_session(self) -> None:
+    def test_b_scenario_run_blocks_second_scenario_run_for_same_session(self) -> None:
         """POST /api/scenarios/{id}/solve must return 409 when a run is already in-progress for the same session.
 
         The scenario endpoint had no single-flight guard at all prior to the fix.
@@ -525,7 +525,7 @@ class TestScenarioSolverSingleFlight:
         assert detail["detail"] == "Solver already running for session 5001"
         assert detail["in_progress_run_id"] == existing_scenario_run_id
 
-    def test_B_scenario_run_allowed_when_no_in_progress_run_for_session(self) -> None:
+    def test_b_scenario_run_allowed_when_no_in_progress_run_for_session(self) -> None:
         """POST /api/scenarios/{id}/solve must succeed when no run is in-progress for the session."""
         solver_runs_state: dict[str, Any] = {}
 

--- a/tests/unit/api/routers/test_solver_singleflight.py
+++ b/tests/unit/api/routers/test_solver_singleflight.py
@@ -369,3 +369,169 @@ class TestRunMultiSessionSolverSingleFlight:
             )
 
         assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+
+
+# ---------------------------------------------------------------------------
+# Cross-path guard tests: scenario run vs. /api/solver/run
+# ---------------------------------------------------------------------------
+#
+# Bug: scenarios.py wrote the solver_runs entry with key "session_id" instead
+# of "session_cm_id".  The guard in solver.py reads "session_cm_id", so a
+# running scenario solve was invisible to it.
+#
+# Test A: In-progress scenario run must block /api/solver/run for same session.
+# Test B: In-progress scenario run must block a SECOND scenario run for same session.
+
+
+@contextmanager
+def _scenario_client(solver_runs_state: dict[str, Any]) -> Iterator[TestClient]:
+    """Return a TestClient for the scenarios router with patched solver_runs and pb."""
+    from api.routers.scenarios import router
+
+    mock_pb = MagicMock()
+    mock_scenario = MagicMock()
+    mock_scenario.session_cm_id = 5001
+    mock_scenario.year = 2026
+    mock_pb.collection.return_value.get_one.return_value = mock_scenario
+
+    app = _make_app(router)
+    with (
+        patch("api.routers.scenarios.solver_runs", solver_runs_state),
+        patch("api.routers.scenarios.pb", mock_pb),
+        patch("api.routers.scenarios.run_solver_task_v2"),
+    ):
+        yield TestClient(app, raise_server_exceptions=False)
+
+
+class TestScenarioSolverSingleFlight:
+    """Cross-path and scenario-vs-scenario single-flight guard tests.
+
+    These verify the two guard gaps identified post-PR #1189:
+    1. scenario run key "session_id" was invisible to /api/solver/run guard (uses "session_cm_id")
+    2. /api/scenarios/{id}/solve had no guard against duplicate scenario runs
+    """
+
+    # ------------------------------------------------------------------
+    # Test A: in-progress scenario run must block /api/solver/run
+    # ------------------------------------------------------------------
+
+    def test_A_scenario_endpoint_writes_session_cm_id_key(self) -> None:
+        """POST /api/scenarios/{id}/solve must write "session_cm_id" (not "session_id") to solver_runs.
+
+        Root cause of the guard gap: scenarios.py wrote solver_runs entries with
+        key "session_id" instead of "session_cm_id".  The guard in solver.py reads
+        "session_cm_id", so a running scenario solve was invisible to it.
+        This test verifies the write uses the correct unified key after the fix.
+        """
+        shared_solver_runs: dict[str, Any] = {}
+
+        with _scenario_client(shared_solver_runs) as client:
+            resp = client.post("/api/scenarios/test-scenario-uuid/solve")
+
+        assert resp.status_code == 200, f"Expected 200 on first call: {resp.status_code}: {resp.text}"
+        # After a successful solve kick-off, exactly one entry must be in solver_runs
+        assert len(shared_solver_runs) == 1, f"Expected 1 entry in solver_runs, got {len(shared_solver_runs)}"
+        run_entry = next(iter(shared_solver_runs.values()))
+        # The critical assertion: key must be "session_cm_id", not "session_id"
+        assert "session_cm_id" in run_entry, (
+            f"solver_runs entry must use key 'session_cm_id'. Got keys: {list(run_entry.keys())}"
+        )
+        assert "session_id" not in run_entry, (
+            f"solver_runs entry must NOT use the old 'session_id' key. Got keys: {list(run_entry.keys())}"
+        )
+        assert run_entry["session_cm_id"] == 5001  # matches mock_scenario.session_cm_id
+
+    def test_A_scenario_run_blocks_solver_run_for_same_session(self) -> None:
+        """POST /api/solver/run must return 409 when a scenario run is in-progress for the same session.
+
+        Root cause: scenarios.py wrote solver_runs entries with key "session_id"
+        (not "session_cm_id"), so the guard in solver.py could not see them.
+        After the fix, the key is "session_cm_id" and the guard fires correctly.
+        """
+        scenario_run_id = "scenario-run-in-progress"
+        # Scenario run stored with the correct "session_cm_id" key (after fix)
+        solver_runs_state: dict[str, Any] = {
+            scenario_run_id: {
+                "id": scenario_run_id,
+                "session_cm_id": 5001,
+                "status": "running",
+                "scenario": "some-scenario-uuid",
+            }
+        }
+
+        with _solver_client(solver_runs_state) as client:
+            resp = client.post(
+                "/api/solver/run",
+                json={"session_cm_id": 5001, "year": 2026},
+            )
+
+        assert resp.status_code == 409, (
+            f"Expected 409 — scenario run should block solver/run. Got {resp.status_code}: {resp.text}"
+        )
+        body = resp.json()
+        detail = body["detail"]
+        assert detail["detail"] == "Solver already running for session 5001"
+        assert detail["in_progress_run_id"] == scenario_run_id
+
+    def test_A_scenario_run_does_not_block_solver_run_for_different_session(self) -> None:
+        """POST /api/solver/run must succeed when the in-progress scenario run is for a different session."""
+        scenario_run_id = "scenario-run-other-session"
+        solver_runs_state: dict[str, Any] = {
+            scenario_run_id: {
+                "id": scenario_run_id,
+                "session_cm_id": 9999,  # different session
+                "status": "running",
+                "scenario": "some-scenario-uuid",
+            }
+        }
+
+        with _solver_client(solver_runs_state) as client:
+            resp = client.post(
+                "/api/solver/run",
+                json={"session_cm_id": 5001, "year": 2026},
+            )
+
+        assert resp.status_code == 200, (
+            f"Expected 200 — different session should not be blocked. Got {resp.status_code}: {resp.text}"
+        )
+
+    # ------------------------------------------------------------------
+    # Test B: scenario endpoint must block duplicate scenario runs
+    # ------------------------------------------------------------------
+
+    def test_B_scenario_run_blocks_second_scenario_run_for_same_session(self) -> None:
+        """POST /api/scenarios/{id}/solve must return 409 when a run is already in-progress for the same session.
+
+        The scenario endpoint had no single-flight guard at all prior to the fix.
+        """
+        existing_scenario_run_id = "existing-scenario-run"
+        solver_runs_state: dict[str, Any] = {
+            existing_scenario_run_id: {
+                "id": existing_scenario_run_id,
+                "session_cm_id": 5001,  # same session as mock_scenario.session_cm_id
+                "status": "running",
+                "scenario": "other-scenario-uuid",
+            }
+        }
+
+        with _scenario_client(solver_runs_state) as client:
+            resp = client.post("/api/scenarios/new-scenario-uuid/solve")
+
+        assert resp.status_code == 409, (
+            f"Expected 409 — scenario endpoint must guard against duplicate runs. Got {resp.status_code}: {resp.text}"
+        )
+        body = resp.json()
+        detail = body["detail"]
+        assert detail["detail"] == "Solver already running for session 5001"
+        assert detail["in_progress_run_id"] == existing_scenario_run_id
+
+    def test_B_scenario_run_allowed_when_no_in_progress_run_for_session(self) -> None:
+        """POST /api/scenarios/{id}/solve must succeed when no run is in-progress for the session."""
+        solver_runs_state: dict[str, Any] = {}
+
+        with _scenario_client(solver_runs_state) as client:
+            resp = client.post("/api/scenarios/new-scenario-uuid/solve")
+
+        assert resp.status_code == 200, (
+            f"Expected 200 — no existing run should allow the scenario solve. Got {resp.status_code}: {resp.text}"
+        )

--- a/tests/unit/api/routers/test_solver_singleflight.py
+++ b/tests/unit/api/routers/test_solver_singleflight.py
@@ -19,14 +19,12 @@ from contextlib import contextmanager
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-import pytest
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
 from bunking.auth_middleware import AuthUser, get_current_user
 from bunking.rbac.permissions import ALL_PERMISSIONS
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -45,10 +43,8 @@ def _mock_admin_user() -> AuthUser:
     return user
 
 
-def _make_app(router: Any, solver_runs_state: dict[str, Any]) -> FastAPI:
+def _make_app(router: Any) -> FastAPI:
     """Minimal FastAPI app with global exception handler and patched solver_runs."""
-    from api.routers import solver as solver_module
-
     app = FastAPI()
 
     @app.exception_handler(Exception)
@@ -65,7 +61,7 @@ def _solver_client(solver_runs_state: dict[str, Any]) -> Iterator[TestClient]:
     """Return a TestClient for the solver router with patched solver_runs."""
     from api.routers.solver import router
 
-    app = _make_app(router, solver_runs_state)
+    app = _make_app(router)
     with (
         patch("api.routers.solver.solver_runs", solver_runs_state),
         # Prevent real background tasks from executing

--- a/tests/unit/api/routers/test_solver_singleflight.py
+++ b/tests/unit/api/routers/test_solver_singleflight.py
@@ -1,0 +1,375 @@
+"""Single-flight serialization tests for /api/solver/run and /api/solver/run-multi-session.
+
+Guards against concurrent duplicate solves for the same session_cm_id.
+
+Decision from issue #1178:
+  - Reject a second run if any solver_runs[*]['status'] is 'pending' or 'running'
+    for the SAME session_cm_id.
+  - Return HTTP 409 with JSON body:
+      {"detail": "Solver already running for session X", "in_progress_run_id": "..."}
+  - A run for a DIFFERENT session must succeed (per-session lock, not global).
+  - Multi-session endpoint (/api/solver/run-multi-session) applies the same
+    per-session check for each child session it would dispatch.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from bunking.auth_middleware import AuthUser, get_current_user
+from bunking.rbac.permissions import ALL_PERMISSIONS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_admin_user() -> AuthUser:
+    user = AuthUser(
+        username="TestAdmin",
+        email="test@example.com",
+        display_name="Test Admin",
+        groups=["admin"],
+        is_admin=True,
+    )
+    user.permissions = set(ALL_PERMISSIONS)
+    return user
+
+
+def _make_app(router: Any, solver_runs_state: dict[str, Any]) -> FastAPI:
+    """Minimal FastAPI app with global exception handler and patched solver_runs."""
+    from api.routers import solver as solver_module
+
+    app = FastAPI()
+
+    @app.exception_handler(Exception)
+    async def _unhandled(request: Request, exc: Exception) -> JSONResponse:
+        return JSONResponse(status_code=500, content={"detail": "Internal server error"})
+
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = _mock_admin_user
+    return app
+
+
+@contextmanager
+def _solver_client(solver_runs_state: dict[str, Any]) -> Iterator[TestClient]:
+    """Return a TestClient for the solver router with patched solver_runs."""
+    from api.routers.solver import router
+
+    app = _make_app(router, solver_runs_state)
+    with (
+        patch("api.routers.solver.solver_runs", solver_runs_state),
+        # Prevent real background tasks from executing
+        patch("api.routers.solver.run_solver_task_v2"),
+        # Prevent ConfigLoader from touching disk/env
+        patch("api.routers.solver.ConfigLoader") as mock_cfg,
+    ):
+        mock_cfg.return_value.get_int.return_value = 60
+        yield TestClient(app, raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# /api/solver/run — single-flight guard
+# ---------------------------------------------------------------------------
+
+
+class TestRunSolverSingleFlight:
+    """POST /api/solver/run rejects duplicate in-progress runs for the same session."""
+
+    def test_409_when_pending_run_exists_for_same_session(self) -> None:
+        """Returns 409 when a 'pending' run already exists for the same session_cm_id."""
+        existing_run_id = "existing-run-abc"
+        solver_runs_state: dict[str, Any] = {
+            existing_run_id: {
+                "id": existing_run_id,
+                "session_cm_id": 1001,
+                "status": "pending",
+            }
+        }
+
+        with _solver_client(solver_runs_state) as client:
+            resp = client.post(
+                "/api/solver/run",
+                json={"session_cm_id": 1001, "year": 2026},
+            )
+
+        assert resp.status_code == 409, f"Expected 409, got {resp.status_code}: {resp.text}"
+        body = resp.json()
+        # HTTPException with a dict detail produces {"detail": {...}}
+        detail = body["detail"]
+        assert detail["detail"] == "Solver already running for session 1001"
+        assert detail["in_progress_run_id"] == existing_run_id
+
+    def test_409_when_running_run_exists_for_same_session(self) -> None:
+        """Returns 409 when a 'running' run already exists for the same session_cm_id."""
+        existing_run_id = "existing-run-xyz"
+        solver_runs_state: dict[str, Any] = {
+            existing_run_id: {
+                "id": existing_run_id,
+                "session_cm_id": 2002,
+                "status": "running",
+            }
+        }
+
+        with _solver_client(solver_runs_state) as client:
+            resp = client.post(
+                "/api/solver/run",
+                json={"session_cm_id": 2002, "year": 2026},
+            )
+
+        assert resp.status_code == 409, f"Expected 409, got {resp.status_code}: {resp.text}"
+        body = resp.json()
+        # HTTPException with a dict detail produces {"detail": {...}}
+        detail = body["detail"]
+        assert detail["detail"] == "Solver already running for session 2002"
+        assert detail["in_progress_run_id"] == existing_run_id
+
+    def test_200_when_completed_run_exists_for_same_session(self) -> None:
+        """Returns 200 (success) when only a 'completed' run exists for the same session_cm_id.
+
+        A completed run must NOT block new runs.
+        """
+        existing_run_id = "old-completed-run"
+        solver_runs_state: dict[str, Any] = {
+            existing_run_id: {
+                "id": existing_run_id,
+                "session_cm_id": 3003,
+                "status": "completed",
+            }
+        }
+
+        with _solver_client(solver_runs_state) as client:
+            resp = client.post(
+                "/api/solver/run",
+                json={"session_cm_id": 3003, "year": 2026},
+            )
+
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+
+    def test_200_when_failed_run_exists_for_same_session(self) -> None:
+        """Returns 200 (success) when only a 'failed' run exists for the same session_cm_id.
+
+        A failed run must NOT block new runs.
+        """
+        existing_run_id = "old-failed-run"
+        solver_runs_state: dict[str, Any] = {
+            existing_run_id: {
+                "id": existing_run_id,
+                "session_cm_id": 4004,
+                "status": "failed",
+            }
+        }
+
+        with _solver_client(solver_runs_state) as client:
+            resp = client.post(
+                "/api/solver/run",
+                json={"session_cm_id": 4004, "year": 2026},
+            )
+
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+
+    def test_200_when_running_run_exists_for_different_session(self) -> None:
+        """Returns 200 (success) when a running run exists for a DIFFERENT session_cm_id.
+
+        The lock is per-session, not global — concurrent solves for different
+        sessions are valid.
+        """
+        existing_run_id = "other-session-run"
+        solver_runs_state: dict[str, Any] = {
+            existing_run_id: {
+                "id": existing_run_id,
+                "session_cm_id": 9999,  # Different session
+                "status": "running",
+            }
+        }
+
+        with _solver_client(solver_runs_state) as client:
+            resp = client.post(
+                "/api/solver/run",
+                json={"session_cm_id": 5005, "year": 2026},  # Different session
+            )
+
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+
+    def test_200_when_no_existing_runs(self) -> None:
+        """Returns 200 (success) when no runs exist at all (empty solver_runs)."""
+        solver_runs_state: dict[str, Any] = {}
+
+        with _solver_client(solver_runs_state) as client:
+            resp = client.post(
+                "/api/solver/run",
+                json={"session_cm_id": 6006, "year": 2026},
+            )
+
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+
+    def test_409_response_shape(self) -> None:
+        """409 response body has exactly the fields: detail, in_progress_run_id."""
+        existing_run_id = "shape-check-run"
+        solver_runs_state: dict[str, Any] = {
+            existing_run_id: {
+                "id": existing_run_id,
+                "session_cm_id": 7007,
+                "status": "pending",
+            }
+        }
+
+        with _solver_client(solver_runs_state) as client:
+            resp = client.post(
+                "/api/solver/run",
+                json={"session_cm_id": 7007, "year": 2026},
+            )
+
+        assert resp.status_code == 409
+        body = resp.json()
+        # HTTPException with a dict detail produces {"detail": {...}}
+        assert "detail" in body
+        detail = body["detail"]
+        # Both required keys must be present in the inner detail object
+        assert "detail" in detail
+        assert "in_progress_run_id" in detail
+        assert detail["in_progress_run_id"] == existing_run_id
+
+
+# ---------------------------------------------------------------------------
+# /api/solver/run-multi-session — single-flight guard per child session
+# ---------------------------------------------------------------------------
+
+
+def _make_child_session(cm_id: int, name: str) -> MagicMock:
+    """Create a mock PocketBase child session record."""
+    session = MagicMock()
+    session.cm_id = cm_id
+    session.name = name
+    session.sex_eligible = "all"
+    return session
+
+
+@contextmanager
+def _multi_session_client(solver_runs_state: dict[str, Any], child_sessions: list[MagicMock]) -> Iterator[TestClient]:
+    """Return a TestClient for the solver router's multi-session endpoint."""
+    from api.routers.solver import router
+
+    mock_pb = MagicMock()
+    mock_pb.collection.return_value.get_full_list.return_value = child_sessions
+
+    app = FastAPI()
+
+    @app.exception_handler(Exception)
+    async def _unhandled(request: Request, exc: Exception) -> JSONResponse:
+        return JSONResponse(status_code=500, content={"detail": "Internal server error"})
+
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = _mock_admin_user
+
+    with (
+        patch("api.routers.solver.solver_runs", solver_runs_state),
+        patch("api.routers.solver.pb", mock_pb),
+        patch("api.routers.solver.run_solver_task_v2"),
+        patch("api.routers.solver.ConfigLoader") as mock_cfg,
+    ):
+        mock_cfg.return_value.get_int.return_value = 60
+        yield TestClient(app, raise_server_exceptions=False)
+
+
+class TestRunMultiSessionSolverSingleFlight:
+    """POST /api/solver/run-multi-session rejects child sessions with in-progress runs."""
+
+    def test_409_when_child_session_has_pending_run(self) -> None:
+        """Returns 409 when one of the child sessions already has a pending run."""
+        existing_run_id = "multi-pending-run"
+        solver_runs_state: dict[str, Any] = {
+            existing_run_id: {
+                "id": existing_run_id,
+                "session_cm_id": 101,
+                "status": "pending",
+            }
+        }
+        child_sessions = [_make_child_session(101, "Session A"), _make_child_session(102, "Session B")]
+
+        with _multi_session_client(solver_runs_state, child_sessions) as client:
+            resp = client.post(
+                "/api/solver/run-multi-session",
+                json={"parent_session_cm_id": 100, "year": 2026},
+            )
+
+        assert resp.status_code == 409, f"Expected 409, got {resp.status_code}: {resp.text}"
+        body = resp.json()
+        # HTTPException with a dict detail produces {"detail": {...}}
+        detail = body["detail"]
+        assert detail["detail"] == "Solver already running for session 101"
+        assert detail["in_progress_run_id"] == existing_run_id
+
+    def test_409_when_child_session_has_running_run(self) -> None:
+        """Returns 409 when one of the child sessions already has a running run."""
+        existing_run_id = "multi-running-run"
+        solver_runs_state: dict[str, Any] = {
+            existing_run_id: {
+                "id": existing_run_id,
+                "session_cm_id": 202,
+                "status": "running",
+            }
+        }
+        child_sessions = [_make_child_session(201, "Session X"), _make_child_session(202, "Session Y")]
+
+        with _multi_session_client(solver_runs_state, child_sessions) as client:
+            resp = client.post(
+                "/api/solver/run-multi-session",
+                json={"parent_session_cm_id": 200, "year": 2026},
+            )
+
+        assert resp.status_code == 409, f"Expected 409, got {resp.status_code}: {resp.text}"
+        body = resp.json()
+        # HTTPException with a dict detail produces {"detail": {...}}
+        detail = body["detail"]
+        assert detail["detail"] == "Solver already running for session 202"
+        assert detail["in_progress_run_id"] == existing_run_id
+
+    def test_200_when_only_completed_run_exists_for_child_session(self) -> None:
+        """Returns 200 when only a completed run exists for the child session."""
+        existing_run_id = "multi-completed-run"
+        solver_runs_state: dict[str, Any] = {
+            existing_run_id: {
+                "id": existing_run_id,
+                "session_cm_id": 301,
+                "status": "completed",
+            }
+        }
+        child_sessions = [_make_child_session(301, "Session Done")]
+
+        with _multi_session_client(solver_runs_state, child_sessions) as client:
+            resp = client.post(
+                "/api/solver/run-multi-session",
+                json={"parent_session_cm_id": 300, "year": 2026},
+            )
+
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+
+    def test_200_when_running_run_exists_for_unrelated_session(self) -> None:
+        """Returns 200 when a running run exists for an unrelated session (not a child)."""
+        existing_run_id = "unrelated-running-run"
+        solver_runs_state: dict[str, Any] = {
+            existing_run_id: {
+                "id": existing_run_id,
+                "session_cm_id": 9999,  # Not a child of parent 400
+                "status": "running",
+            }
+        }
+        child_sessions = [_make_child_session(401, "Child Session A"), _make_child_session(402, "Child Session B")]
+
+        with _multi_session_client(solver_runs_state, child_sessions) as client:
+            resp = client.post(
+                "/api/solver/run-multi-session",
+                json={"parent_session_cm_id": 400, "year": 2026},
+            )
+
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"


### PR DESCRIPTION
## Summary

- After PR #1176 moved solver execution to a worker thread, nothing prevented two concurrent `POST /api/solver/run` calls for the same session. Two concurrent solves split the 1.5 CPU container cap and risk the 1 GB memory cap.
- Adds a per-session single-flight guard to `POST /api/solver/run`: scans `solver_runs` for any entry with the same `session_cm_id` whose status is `pending` or `running`. If found, returns HTTP 409 with `{"detail": {"detail": "Solver already running for session X", "in_progress_run_id": "<uuid>"}}`.
- Applies the same check to `POST /api/solver/run-multi-session` (pre-checked across all child sessions before any are dispatched).
- Statuses `completed` and `failed` never block new runs. The lock is per-session — concurrent solves for different sessions continue to work.

## Implementation notes

No threading lock is needed: `solver_runs` is a module-level in-process dict and FastAPI serializes coroutines on the asyncio event loop, so the scan-and-dispatch is already atomic with respect to request handling (confirmed by the issue's "single-process" note from PR #1176).

## Test plan

- [x] 11 new unit tests in `tests/unit/api/routers/test_solver_singleflight.py`
  - `pending` → 409 (single-session endpoint)
  - `running` → 409 (single-session endpoint)
  - `completed` → 200 (must not block)
  - `failed` → 200 (must not block)
  - Different session running → 200 (per-session, not global)
  - Empty `solver_runs` → 200
  - Response shape validation (both `detail` and `in_progress_run_id` present)
  - Multi-session: child with `pending` → 409
  - Multi-session: child with `running` → 409
  - Multi-session: child with `completed` → 200
  - Multi-session: unrelated session running → 200
- [x] 37/37 existing solver-related tests still pass (no regressions)
- [x] Pre-push hooks pass (ruff, mypy, tsc, go-build, shellcheck, pb-js-lint)

Closes #1178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single-flight guard for solver runs: prevents starting duplicate concurrent runs for the same session; multi-session requests check each child session and return HTTP 409 with in-progress run details when blocked.
  * Scenario solves now honor the same per-session single-flight guard and use the unified session key for run tracking.

* **Tests**
  * Extensive tests added for single‑flight behavior, cross-path/regression coverage, and related interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->