### PR TITLE
fix(api): skip AG sessions without cm_id in get_related_session_ids

### DIFF
--- a/api/services/session_utils.py
+++ b/api/services/session_utils.py
@@ -75,6 +75,6 @@ async def get_related_session_ids(session_cm_id: int, year: int, pb_client: Pock
         logger.debug(f"Session {session_cm_id} ({session_name}) year {year} has related AG sessions: {related_ids}")
 
     except Exception as e:
-        logger.error(f"Error finding related sessions for {session_cm_id}: {e}")
+        logger.error(f"Error finding related sessions for {session_cm_id}: {e}", exc_info=True)
 
     return related_ids

--- a/api/services/session_utils.py
+++ b/api/services/session_utils.py
@@ -62,7 +62,15 @@ async def get_related_session_ids(session_cm_id: int, year: int, pb_client: Pock
             query_params={"filter": f'session_type = "ag" && parent_id = {session_cm_id} && year = {year}'},
         )
 
-        related_ids.extend(getattr(session, "cm_id", 0) for session in ag_sessions)
+        for session in ag_sessions:
+            cm_id = getattr(session, "cm_id", None)
+            if cm_id is None or cm_id <= 0:
+                logger.warning(
+                    f"AG session linked to parent {session_cm_id} year {year} is missing a valid cm_id "
+                    f"(got {cm_id!r}) — skipping to avoid emitting session_id=0 in downstream filters"
+                )
+                continue
+            related_ids.append(cm_id)
 
         logger.debug(f"Session {session_cm_id} ({session_name}) year {year} has related AG sessions: {related_ids}")
 

--- a/frontend/src/components/graph/GraphControls.test.tsx
+++ b/frontend/src/components/graph/GraphControls.test.tsx
@@ -5,6 +5,7 @@
 
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import GraphControls from './GraphControls'
 
@@ -119,7 +120,6 @@ describe('GraphControls rendering', () => {
     })
 
     it('opens a menu with "Fit to graph" and "Current view" on click', async () => {
-      const { default: userEvent } = await import('@testing-library/user-event')
       const user = userEvent.setup()
       render(<GraphControls {...baseProps} onDownload={vi.fn()} />)
       await user.click(screen.getByTitle(/download as png/i))
@@ -129,7 +129,6 @@ describe('GraphControls rendering', () => {
 
     it('invokes onDownload("fit") when "Fit to graph" is clicked', async () => {
       const onDownload = vi.fn()
-      const { default: userEvent } = await import('@testing-library/user-event')
       const user = userEvent.setup()
       render(<GraphControls {...baseProps} onDownload={onDownload} />)
       await user.click(screen.getByTitle(/download as png/i))
@@ -140,7 +139,6 @@ describe('GraphControls rendering', () => {
 
     it('invokes onDownload("viewport") when "Current view" is clicked', async () => {
       const onDownload = vi.fn()
-      const { default: userEvent } = await import('@testing-library/user-event')
       const user = userEvent.setup()
       render(<GraphControls {...baseProps} onDownload={onDownload} />)
       await user.click(screen.getByTitle(/download as png/i))
@@ -149,7 +147,6 @@ describe('GraphControls rendering', () => {
     })
 
     it('closes the menu after a selection', async () => {
-      const { default: userEvent } = await import('@testing-library/user-event')
       const user = userEvent.setup()
       render(<GraphControls {...baseProps} onDownload={vi.fn()} />)
       await user.click(screen.getByTitle(/download as png/i))
@@ -158,7 +155,6 @@ describe('GraphControls rendering', () => {
     })
 
     it('closes the menu when clicking outside', async () => {
-      const { default: userEvent } = await import('@testing-library/user-event')
       const user = userEvent.setup()
       render(
         <div>

--- a/tests/unit/api/services/test_session_utils.py
+++ b/tests/unit/api/services/test_session_utils.py
@@ -1,0 +1,191 @@
+"""
+Unit tests for session_utils.get_related_session_ids.
+
+Covers the bug where AG sessions missing cm_id would emit 0 into
+downstream filter strings (e.g. session_id = 0).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+
+class TestGetRelatedSessionIds:
+    """Tests for get_related_session_ids function."""
+
+    @pytest.fixture
+    def mock_pb_client(self):
+        """Create a mock PocketBase client."""
+        return Mock()
+
+    @pytest.fixture
+    def mock_main_session(self):
+        """A normal main session with a valid cm_id."""
+        session = Mock()
+        session.cm_id = 12345
+        session.name = "Session 2"
+        session.session_type = "main"
+        session.year = 2025
+        return session
+
+    @pytest.fixture
+    def mock_ag_session_with_cm_id(self):
+        """An AG session that has a valid cm_id."""
+        session = Mock()
+        session.cm_id = 67890
+        session.name = "Session 2 AG"
+        session.session_type = "ag"
+        session.parent_id = 12345
+        session.year = 2025
+        return session
+
+    @pytest.fixture
+    def mock_ag_session_missing_cm_id(self):
+        """
+        An AG session whose cm_id attribute is absent (data-hygiene gap).
+
+        Using spec=[] ensures getattr(session, 'cm_id', 0) returns the
+        fallback 0 — exactly the pre-fix behaviour we're guarding against.
+        """
+        session = Mock(spec=[])  # no attributes at all
+        return session
+
+    # ------------------------------------------------------------------
+    # RED: AG session without cm_id MUST NOT produce 0 in the result
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_ag_session_missing_cm_id_does_not_emit_zero(
+        self, mock_pb_client, mock_main_session, mock_ag_session_missing_cm_id
+    ):
+        """
+        Core bug regression: get_related_session_ids must not include 0
+        when an AG session record is missing the cm_id field.
+        """
+        from api.services.session_utils import get_related_session_ids
+
+        def mock_get_full_list(query_params=None):
+            filter_str = (query_params or {}).get("filter", "")
+            if f"cm_id = {mock_main_session.cm_id} && year = 2025" in filter_str:
+                return [mock_main_session]
+            if 'session_type = "ag"' in filter_str:
+                return [mock_ag_session_missing_cm_id]
+            return []
+
+        mock_collection = Mock()
+        mock_collection.get_full_list = mock_get_full_list
+        mock_pb_client.collection.return_value = mock_collection
+
+        with patch("api.services.session_utils.asyncio.to_thread", new=AsyncMock(side_effect=lambda f, **kw: f(**kw))):
+            result = await get_related_session_ids(12345, 2025, mock_pb_client)
+
+        assert 0 not in result, f"cm_id=0 must not appear in related_ids; got {result}"
+
+    @pytest.mark.asyncio
+    async def test_ag_session_missing_cm_id_emits_warning(
+        self, mock_pb_client, mock_main_session, mock_ag_session_missing_cm_id
+    ):
+        """
+        A logger.warning must fire when an AG session is missing cm_id
+        (data-quality alert per acceptance criteria).
+        """
+        from api.services.session_utils import get_related_session_ids
+
+        def mock_get_full_list(query_params=None):
+            filter_str = (query_params or {}).get("filter", "")
+            if f"cm_id = {mock_main_session.cm_id} && year = 2025" in filter_str:
+                return [mock_main_session]
+            if 'session_type = "ag"' in filter_str:
+                return [mock_ag_session_missing_cm_id]
+            return []
+
+        mock_collection = Mock()
+        mock_collection.get_full_list = mock_get_full_list
+        mock_pb_client.collection.return_value = mock_collection
+
+        with patch("api.services.session_utils.asyncio.to_thread", new=AsyncMock(side_effect=lambda f, **kw: f(**kw))):
+            with patch("api.services.session_utils.logger") as mock_logger:
+                await get_related_session_ids(12345, 2025, mock_pb_client)
+
+        assert mock_logger.warning.called, "logger.warning should fire for AG session with missing cm_id"
+
+    # ------------------------------------------------------------------
+    # GREEN baseline: normal AG session still appears in result
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_ag_session_with_valid_cm_id_is_included(
+        self, mock_pb_client, mock_main_session, mock_ag_session_with_cm_id
+    ):
+        """AG session with a valid positive cm_id is included in result."""
+        from api.services.session_utils import get_related_session_ids
+
+        def mock_get_full_list(query_params=None):
+            filter_str = (query_params or {}).get("filter", "")
+            if f"cm_id = {mock_main_session.cm_id} && year = 2025" in filter_str:
+                return [mock_main_session]
+            if 'session_type = "ag"' in filter_str:
+                return [mock_ag_session_with_cm_id]
+            return []
+
+        mock_collection = Mock()
+        mock_collection.get_full_list = mock_get_full_list
+        mock_pb_client.collection.return_value = mock_collection
+
+        with patch("api.services.session_utils.asyncio.to_thread", new=AsyncMock(side_effect=lambda f, **kw: f(**kw))):
+            result = await get_related_session_ids(12345, 2025, mock_pb_client)
+
+        assert 12345 in result
+        assert 67890 in result
+        assert 0 not in result
+
+    @pytest.mark.asyncio
+    async def test_no_ag_sessions_returns_only_main(self, mock_pb_client, mock_main_session):
+        """When there are no AG sessions, only the main session id is returned."""
+        from api.services.session_utils import get_related_session_ids
+
+        def mock_get_full_list(query_params=None):
+            filter_str = (query_params or {}).get("filter", "")
+            if f"cm_id = {mock_main_session.cm_id} && year = 2025" in filter_str:
+                return [mock_main_session]
+            return []
+
+        mock_collection = Mock()
+        mock_collection.get_full_list = mock_get_full_list
+        mock_pb_client.collection.return_value = mock_collection
+
+        with patch("api.services.session_utils.asyncio.to_thread", new=AsyncMock(side_effect=lambda f, **kw: f(**kw))):
+            result = await get_related_session_ids(12345, 2025, mock_pb_client)
+
+        assert result == [12345]
+
+    @pytest.mark.asyncio
+    async def test_mixed_ag_sessions_filters_missing_cm_id(
+        self, mock_pb_client, mock_main_session, mock_ag_session_with_cm_id, mock_ag_session_missing_cm_id
+    ):
+        """
+        When some AG sessions have cm_id and others don't, only valid ones
+        are included; 0 never appears.
+        """
+        from api.services.session_utils import get_related_session_ids
+
+        def mock_get_full_list(query_params=None):
+            filter_str = (query_params or {}).get("filter", "")
+            if f"cm_id = {mock_main_session.cm_id} && year = 2025" in filter_str:
+                return [mock_main_session]
+            if 'session_type = "ag"' in filter_str:
+                return [mock_ag_session_with_cm_id, mock_ag_session_missing_cm_id]
+            return []
+
+        mock_collection = Mock()
+        mock_collection.get_full_list = mock_get_full_list
+        mock_pb_client.collection.return_value = mock_collection
+
+        with patch("api.services.session_utils.asyncio.to_thread", new=AsyncMock(side_effect=lambda f, **kw: f(**kw))):
+            result = await get_related_session_ids(12345, 2025, mock_pb_client)
+
+        assert 12345 in result
+        assert 67890 in result
+        assert 0 not in result


### PR DESCRIPTION
## Summary

- `getattr(session, "cm_id", 0)` on line 65 of `api/services/session_utils.py` emitted `cm_id=0` when an AG session record was missing the field, injecting `session_id = 0` as an OR clause into downstream PocketBase filter strings
- Replaced with an explicit loop that skips AG sessions with `None` or `≤ 0` cm_id values and fires `logger.warning` for each gap (data-quality alert per acceptance criteria)
- Inheriting endpoints like `/api/satisfaction` are now protected

## Changes

- `api/services/session_utils.py` — fix the comprehension at line 65 (one-liner → guarded loop with warning)
- `tests/unit/api/services/test_session_utils.py` — 5 new unit tests (new file)

## Test plan

- [x] `test_ag_session_missing_cm_id_does_not_emit_zero` — RED before fix, GREEN after
- [x] `test_ag_session_missing_cm_id_emits_warning` — RED before fix, GREEN after
- [x] `test_mixed_ag_sessions_filters_missing_cm_id` — RED before fix, GREEN after
- [x] `test_ag_session_with_valid_cm_id_is_included` — GREEN throughout (no regression)
- [x] `test_no_ag_sessions_returns_only_main` — GREEN throughout (no regression)
- [x] Full `tests/unit/api/` suite: **1228 passed, 0 failed**

Closes #1163

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where invalid session identifiers could be incorrectly included in downstream processing, ensuring only valid sessions are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->