### PR TITLE
fix(frontend): portal Modal to document.body and bump z-index

### DIFF
--- a/frontend/src/components/AllCamperRequestsModal.test.tsx
+++ b/frontend/src/components/AllCamperRequestsModal.test.tsx
@@ -272,11 +272,15 @@ describe('AllCamperRequestsModal framing (no read-only language)', () => {
       },
     ]
     personsFixture = [{ cm_id: 1000002, first_name: 'Liam', last_name: 'Garcia', year: 2026 }]
-    const { container } = renderModal()
+    renderModal()
     await screen.findByRole('button', { name: /^approve$/i })
-    expect(container.textContent?.toLowerCase()).not.toContain('read-only')
-    expect(container.textContent?.toLowerCase()).not.toContain('read only')
-    expect(container.textContent?.toLowerCase()).not.toContain('use the main table to take actions')
+    // Modal portals into document.body, so query the dialog itself rather than
+    // the test render container (which would make these negative assertions
+    // trivially pass).
+    const dialog = screen.getByRole('dialog')
+    expect(dialog.textContent?.toLowerCase()).not.toContain('read-only')
+    expect(dialog.textContent?.toLowerCase()).not.toContain('read only')
+    expect(dialog.textContent?.toLowerCase()).not.toContain('use the main table to take actions')
   })
 })
 

--- a/frontend/src/components/ui/Modal.test.tsx
+++ b/frontend/src/components/ui/Modal.test.tsx
@@ -324,6 +324,37 @@ describe('Modal', () => {
     })
   })
 
+  describe('portal rendering (z-index escape)', () => {
+    // Regression guard for #1024: the modal must render via createPortal so
+    // it escapes the stacking context of any z-[60] panel it may nest inside
+    // (e.g. CamperDetailsPanel). Without portaling, the modal's z-50 wrapper
+    // sits inside the panel's stacking context and can be visually layered
+    // below sibling overlays.
+    it('renders into document.body, not the local container', () => {
+      const { container } = render(
+        <Modal isOpen={true} onClose={() => {}}>
+          <p>Portal content</p>
+        </Modal>
+      )
+
+      // The render container should NOT contain the modal — it lives in body
+      expect(container.querySelector('[role="dialog"]')).toBeNull()
+      // But the modal IS in the document
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    it('uses z-[100] so it sits above z-[60] panels (e.g. CamperDetailsPanel)', () => {
+      render(
+        <Modal isOpen={true} onClose={() => {}}>
+          <p>Content</p>
+        </Modal>
+      )
+
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveClass('z-[100]')
+    })
+  })
+
   describe('scrollable option', () => {
     it('applies overflow-y-auto when scrollable is true', () => {
       render(

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,6 +1,7 @@
 import { X } from 'lucide-react'
 import { useEffect } from 'react'
 import type { ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 
 interface ModalProps {
   isOpen: boolean
@@ -89,9 +90,11 @@ export function Modal({
 
   const resolvedLabelledBy = ariaLabelledBy ?? (hasSimpleTitle ? 'modal-title' : undefined)
 
-  return (
+  // Portal to document.body so the modal escapes any parent stacking context
+  // (e.g. z-[60] CamperDetailsPanel). z-[100] keeps us above documented panels.
+  return createPortal(
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center"
+      className="fixed inset-0 z-[100] flex items-center justify-center"
       role="dialog"
       aria-modal="true"
       aria-labelledby={resolvedLabelledBy}
@@ -173,7 +176,8 @@ export function Modal({
         {/* Footer */}
         {footer && <div data-testid="modal-footer">{footer}</div>}
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }
 


### PR DESCRIPTION
## Summary

- Wrap shared `ui/Modal.tsx` in `createPortal(..., document.body)` so it escapes any parent stacking context (e.g. `z-[60]` `CamperDetailsPanel`, `RequestReviewPanel`)
- Bump wrapper z-index from `z-50` to `z-[100]` so it sits cleanly above documented panel layers
- Add regression tests asserting portal mount target and z-index class

## Why

The Modal previously rendered inline at `z-50`, so when nested inside `z-[60]` panels its stacking context sat *below* the panel. It worked visually thanks to `fixed` positioning, but was brittle — any sibling overlay inside the panel could layer above the modal. This affected `AllCamperRequestsModal` (CamperDetailsPanel) and `CreateRequestModal` / `MergeRequestsModal` / `SplitRequestModal` (RequestReviewPanel).

`createPortal` is already widely established in the codebase (9+ components), so this aligns the shared modal with the prevailing pattern.

## Test plan
- [x] `npx vitest run src/components/ui/Modal.test.tsx` — 30/30 pass (2 new regression tests)
- [x] `npx vitest run` — full suite 3661/3661 pass
- [x] `npx tsc --noEmit` — clean
- [x] eslint + prettier clean on changed files
- [ ] Manual: open camper details panel → open All Requests modal → confirm modal layers correctly above panel

Closes #1024

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed modal layering so dialogs reliably appear above other panels and are interactable.

* **Tests**
  * Expanded tests to confirm modals render in the correct place and maintain proper stacking order, and updated assertions to target the actual dialog content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->