### PR TITLE
refactor(api): rename SocialGraphEdge.type and CrossScopeEdge.type to edge_type

### DIFF
--- a/api/routers/social_graph.py
+++ b/api/routers/social_graph.py
@@ -267,7 +267,7 @@ async def get_session_social_graph(
                         source=source,
                         target=target,
                         weight=data.get("weight", 1.0),
-                        type=edge_type,
+                        edge_type=edge_type,
                         reciprocal=graph.has_edge(target, source),
                         confidence=data.get("metadata", {}).get("request", {}).get("confidence"),
                         priority=data.get("metadata", {}).get("request", {}).get("priority"),
@@ -284,7 +284,7 @@ async def get_session_social_graph(
                         source=source,
                         target=target,
                         weight=data.get("weight", 1.0),
-                        type=edge_type,
+                        edge_type=edge_type,
                         reciprocal=graph.has_edge(target, source),
                         confidence=data.get("confidence"),
                         priority=data.get("priority"),
@@ -541,7 +541,7 @@ async def get_bunk_social_graph(
                         source=source,
                         target=target,
                         weight=data.get("weight", 1.0),
-                        type=primary_type,
+                        edge_type=primary_type,
                         reciprocal=is_reciprocal,
                         confidence=data.get("confidence") if is_request else None,
                         priority=data.get("priority") if is_request else None,
@@ -556,7 +556,7 @@ async def get_bunk_social_graph(
                             source=source,
                             target=target,
                             weight=1.0,
-                            type=secondary_type,
+                            edge_type=secondary_type,
                             reciprocal=is_reciprocal,
                             confidence=data.get("request_confidence"),
                             priority=data.get("request_priority"),
@@ -570,7 +570,7 @@ async def get_bunk_social_graph(
                         source=source,
                         target=target,
                         weight=data.get("weight", 1.0),
-                        type=edge_type,
+                        edge_type=edge_type,
                         reciprocal=is_reciprocal,
                         confidence=data.get("confidence"),
                         priority=data.get("priority"),
@@ -581,7 +581,7 @@ async def get_bunk_social_graph(
         # Log final edge counts
         edge_type_summary: dict[str, int] = {}
         for edge in edges:
-            edge_type_summary[edge.type] = edge_type_summary.get(edge.type, 0) + 1
+            edge_type_summary[edge.edge_type] = edge_type_summary.get(edge.edge_type, 0) + 1
         logger.info(f"Final edges being sent to frontend: {edge_type_summary}, total={len(edges)}")
 
         # Calculate bunk-specific metrics

--- a/api/schemas/social_graph.py
+++ b/api/schemas/social_graph.py
@@ -39,7 +39,7 @@ class SocialGraphEdge(BaseModel):
     source: int
     target: int
     weight: float
-    type: str  # 'request', 'historical', 'classmate_city', 'classmate_state'
+    edge_type: str  # 'request', 'historical', 'classmate_city', 'classmate_state'
     # Note: 'sibling' is intentionally excluded — sibling edges remain in the
     # in-memory graph for name-resolution (confidence boost) but are filtered
     # at the API response boundary before reaching the frontend.

--- a/bunking/graph/scope_filter.py
+++ b/bunking/graph/scope_filter.py
@@ -34,7 +34,7 @@ class CrossScopeEdge(BaseModel):
 
     source: int
     target: int
-    type: str
+    edge_type: str
     weight: float = 1.0
     request_type: str | None = None
     priority: int | None = None
@@ -137,7 +137,7 @@ def apply_scope(
                         source=source,
                         target=target,
                         weight=data.get("weight", 1.0),
-                        type=data.get("edge_type", "request"),
+                        edge_type=data.get("edge_type", "request"),
                         request_type=data.get("request_type"),
                         priority=data.get("priority"),
                         confidence=data.get("confidence"),

--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -323,26 +323,26 @@ export default function BunkSocialGraphModal({
           style: {
             width: 2, // Uniform width for all edges
             'line-color': (ele: EdgeSingular) => {
-              const type = ele.data('type')
-              return EDGE_COLORS[type] ?? '#95a5a6'
+              const edgeType = ele.data('edge_type')
+              return EDGE_COLORS[edgeType] ?? '#95a5a6'
             },
             'target-arrow-shape': (ele: EdgeSingular) => {
-              const type = ele.data('type')
-              return type === 'request' ? 'triangle' : 'none'
+              const edgeType = ele.data('edge_type')
+              return edgeType === 'request' ? 'triangle' : 'none'
             },
             'target-arrow-color': (ele: EdgeSingular) => {
-              const type = ele.data('type')
-              return EDGE_COLORS[type] ?? '#95a5a6'
+              const edgeType = ele.data('edge_type')
+              return EDGE_COLORS[edgeType] ?? '#95a5a6'
             },
             'source-arrow-shape': (ele: EdgeSingular) => {
               // Show arrow at source for reciprocal requests
-              const type = ele.data('type')
+              const edgeType = ele.data('edge_type')
               const reciprocal = ele.data('reciprocal')
-              return type === 'request' && reciprocal ? 'triangle' : 'none'
+              return edgeType === 'request' && reciprocal ? 'triangle' : 'none'
             },
             'source-arrow-color': (ele: EdgeSingular) => {
-              const type = ele.data('type')
-              return EDGE_COLORS[type] ?? '#95a5a6'
+              const edgeType = ele.data('edge_type')
+              return EDGE_COLORS[edgeType] ?? '#95a5a6'
             },
             'line-opacity': (ele: EdgeSingular) => {
               const confidence = ele.data('confidence') ?? 0.5

--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -71,7 +71,7 @@ interface GraphEdge {
   source: number
   target: number
   weight: number
-  type: string
+  edge_type: string
   reciprocal: boolean
   confidence?: number
   priority?: number
@@ -430,7 +430,7 @@ export default function BunkSocialGraphModal({
           id: `edge-${edgeIndex++}`,
           source: `node-${edge.source}`,
           target: `node-${edge.target}`,
-          type: edge.type,
+          edge_type: edge.edge_type,
         },
       })
     })

--- a/frontend/src/components/graph/cytoscapeStyles.test.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.test.ts
@@ -118,7 +118,7 @@ describe('createGraphElements', () => {
     {
       source: 1,
       target: 2,
-      type: 'request',
+      edge_type: 'request',
       priority: 1,
       confidence: 0.9,
       reciprocal: true,
@@ -126,7 +126,7 @@ describe('createGraphElements', () => {
     {
       source: 2,
       target: 3,
-      type: 'historical',
+      edge_type: 'historical',
       priority: 2,
       confidence: 0.7,
       reciprocal: false,
@@ -145,7 +145,7 @@ describe('createGraphElements', () => {
   ): GraphEdgeData => ({
     source,
     target,
-    type: 'request',
+    edge_type: 'request',
     priority: 1,
     confidence: 0.9,
     reciprocal,
@@ -327,13 +327,20 @@ describe('createGraphElements', () => {
 
   it('emits cross-scope edges + ghost nodes with cross_scope=true so the renderer can ghost them', () => {
     const inScope: GraphEdgeData[] = [
-      { source: 1, target: 2, type: 'request', priority: 1, confidence: 0.9, reciprocal: false },
+      {
+        source: 1,
+        target: 2,
+        edge_type: 'request',
+        priority: 1,
+        confidence: 0.9,
+        reciprocal: false,
+      },
     ]
     const cross = [
       {
         source: 1,
         target: 99,
-        type: 'request',
+        edge_type: 'request',
         weight: 1,
         request_type: null,
         priority: null,

--- a/frontend/src/components/graph/cytoscapeStyles.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.ts
@@ -25,11 +25,11 @@ export interface GraphNodeData {
 export interface GraphEdgeData {
   source: number
   target: number
-  type: string
+  edge_type: string
   priority: number
   confidence: number
   reciprocal: boolean
-  /** For type='request' edges: 'bunk_with' or 'not_bunk_with'. */
+  /** For edge_type='request' edges: 'bunk_with' or 'not_bunk_with'. */
   request_type?: string
 }
 
@@ -441,7 +441,7 @@ export function createGraphElements(
   // never appear in edgeData here — no client-side defensive filter needed.
   const visibleEdges = edgeData.filter((edge) => {
     // Unknown edge types default to visible; sibling is filtered server-side (#1094)
-    const setting = showEdges[edge.type as keyof ShowEdgesSettings]
+    const setting = showEdges[edge.edge_type as keyof ShowEdgesSettings]
     return setting !== false
   })
 
@@ -462,7 +462,7 @@ export function createGraphElements(
   // Works on both GraphEdgeData and CrossScopeEdgeData (the relevant fields
   // are identically named on both shapes).
   const sameKind = (a: GraphEdgeData | CrossScopeEdgeData, b: GraphEdgeData | CrossScopeEdgeData) =>
-    a.type === b.type && (a.request_type ?? null) === (b.request_type ?? null)
+    a.edge_type === b.edge_type && (a.request_type ?? null) === (b.request_type ?? null)
 
   const edges: EdgeElement[] = []
   let edgeIndex = 0
@@ -475,7 +475,7 @@ export function createGraphElements(
       id: `edge-${edgeIndex++}`,
       source: e.source.toString(),
       target: e.target.toString(),
-      edge_type: e.type,
+      edge_type: e.edge_type,
       priority: e.priority,
       confidence: e.confidence,
       is_reciprocal: flags.is_reciprocal,
@@ -497,7 +497,7 @@ export function createGraphElements(
       id: `cross-edge-${edgeIndex++}`,
       source: e.source.toString(),
       target: e.target.toString(),
-      edge_type: e.type,
+      edge_type: e.edge_type,
       ...(e.priority != null ? { priority: e.priority } : {}),
       ...(e.confidence != null ? { confidence: e.confidence } : {}),
       is_reciprocal: flags.is_reciprocal,

--- a/frontend/src/components/graph/cytoscapeStyles.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.ts
@@ -162,7 +162,7 @@ export function getCytoscapeStyles({ showLabels }: CytoscapeStyleOptions): Style
       },
     },
     {
-      selector: 'edge[type = "bundled"]',
+      selector: 'edge[edge_type = "bundled"]',
       style: {
         width: 3,
         'line-style': 'solid',

--- a/frontend/src/types/graph.ts
+++ b/frontend/src/types/graph.ts
@@ -31,14 +31,13 @@ export interface GraphEdge {
   /** Edge type. Valid values: 'request' | 'historical' | 'classmate_city' | 'classmate_state' | 'bundled'.
    *  'sibling' is intentionally excluded: sibling edges are filtered at the API
    *  response boundary (#1094) and will never appear in graph API responses. */
-  type: string
+  edge_type: string
   reciprocal: boolean
-  request_type?: string // 'bunk_with' | 'not_bunk_with' for type='request' edges
+  request_type?: string // 'bunk_with' | 'not_bunk_with' for edge_type='request' edges
   confidence?: number // AI confidence score for request edges
   priority?: number // Priority level for request edges
   metadata?: Record<string, unknown> // Additional edge metadata (e.g., location for classmate edges)
   // Legacy fields that may still be referenced
-  edge_type?: string
   is_reciprocal?: boolean
 }
 
@@ -56,7 +55,7 @@ export interface GraphMetrics {
 export interface CrossScopeEdge {
   source: number
   target: number
-  type: string
+  edge_type: string
   weight: number
   request_type: string | null
   priority: number | null

--- a/tests/unit/api/routers/test_sibling_edge_filter.py
+++ b/tests/unit/api/routers/test_sibling_edge_filter.py
@@ -355,7 +355,7 @@ class TestBunkGraphSiblingEdgeFilter:
         payload = response.json()
         edges = payload.get("edges", [])
 
-        sibling_edges = [e for e in edges if e.get("type") == "sibling"]
+        sibling_edges = [e for e in edges if e.get("edge_type") == "sibling"]
         assert sibling_edges == [], (
             f"Bunk graph response must not include sibling edges, but found {len(sibling_edges)}: {sibling_edges}"
         )
@@ -373,7 +373,7 @@ class TestBunkGraphSiblingEdgeFilter:
         payload = response.json()
         edges = payload.get("edges", [])
 
-        request_edges = [e for e in edges if e.get("type") == "request"]
+        request_edges = [e for e in edges if e.get("edge_type") == "request"]
         assert len(request_edges) >= 1, (
             "At least one request edge must remain in the bunk graph response — only sibling edges should be stripped"
         )
@@ -397,14 +397,14 @@ class TestBunkGraphSiblingEdgeFilter:
         payload = response.json()
         edges = payload.get("edges", [])
 
-        sibling_edges = [e for e in edges if e.get("type") == "sibling"]
+        sibling_edges = [e for e in edges if e.get("edge_type") == "sibling"]
         assert sibling_edges == [], (
             f"Secondary sibling edges must also be stripped from bunk graph response, "
             f"but found {len(sibling_edges)}: {sibling_edges}"
         )
 
         # The primary request edge should still be present
-        request_edges = [e for e in edges if e.get("type") == "request"]
+        request_edges = [e for e in edges if e.get("edge_type") == "request"]
         assert len(request_edges) >= 1, (
             "Primary request edge must survive even when secondary_type='sibling' is dropped"
         )
@@ -431,7 +431,7 @@ class TestSessionSocialGraphSiblingEdgeFilter:
         payload = response.json()
         edges = payload.get("edges", [])
 
-        sibling_edges = [e for e in edges if e.get("type") == "sibling"]
+        sibling_edges = [e for e in edges if e.get("edge_type") == "sibling"]
         assert sibling_edges == [], (
             f"Session social-graph response must not include sibling edges, "
             f"but found {len(sibling_edges)}: {sibling_edges}"
@@ -450,7 +450,7 @@ class TestSessionSocialGraphSiblingEdgeFilter:
         payload = response.json()
         edges = payload.get("edges", [])
 
-        request_edges = [e for e in edges if e.get("type") == "request"]
+        request_edges = [e for e in edges if e.get("edge_type") == "request"]
         assert len(request_edges) >= 1, (
             "At least one request edge must remain in the session graph response — "
             "only sibling edges should be stripped"

--- a/tests/unit/bunking/graph/test_scope_filter.py
+++ b/tests/unit/bunking/graph/test_scope_filter.py
@@ -294,11 +294,11 @@ class TestCrossScopeEdgeModel:
     """
 
     def test_minimal_construction(self) -> None:
-        """Required fields: source, target, type. Everything else has defaults."""
-        edge = CrossScopeEdge(source=1, target=2, type="request")
+        """Required fields: source, target, edge_type. Everything else has defaults."""
+        edge = CrossScopeEdge(source=1, target=2, edge_type="request")
         assert edge.source == 1
         assert edge.target == 2
-        assert edge.type == "request"
+        assert edge.edge_type == "request"
         assert edge.weight == 1.0
         assert edge.reciprocal is False
         assert edge.cross_scope is True
@@ -308,7 +308,7 @@ class TestCrossScopeEdgeModel:
         edge = CrossScopeEdge(
             source=10,
             target=20,
-            type="request",
+            edge_type="request",
             weight=2.5,
             request_type="bunk_with",
             priority=5,
@@ -323,28 +323,28 @@ class TestCrossScopeEdgeModel:
     def test_cross_scope_false_is_rejected(self) -> None:
         """Pydantic should reject cross_scope=False since the field is Literal[True]."""
         with pytest.raises(ValidationError):
-            CrossScopeEdge(source=1, target=2, type="request", cross_scope=False)
+            CrossScopeEdge(source=1, target=2, edge_type="request", cross_scope=False)
 
     def test_missing_source_raises(self) -> None:
         with pytest.raises(ValidationError):
-            CrossScopeEdge(target=2, type="request")  # type: ignore[call-arg]
+            CrossScopeEdge(target=2, edge_type="request")  # type: ignore[call-arg]
 
     def test_missing_target_raises(self) -> None:
         with pytest.raises(ValidationError):
-            CrossScopeEdge(source=1, type="request")  # type: ignore[call-arg]
+            CrossScopeEdge(source=1, edge_type="request")  # type: ignore[call-arg]
 
-    def test_missing_type_raises(self) -> None:
+    def test_missing_edge_type_raises(self) -> None:
         with pytest.raises(ValidationError):
             CrossScopeEdge(source=1, target=2)  # type: ignore[call-arg]
 
     def test_optional_fields_default_to_none(self) -> None:
-        edge = CrossScopeEdge(source=1, target=2, type="historical")
+        edge = CrossScopeEdge(source=1, target=2, edge_type="historical")
         assert edge.request_type is None
         assert edge.priority is None
         assert edge.confidence is None
 
     def test_serialises_to_dict_with_cross_scope_true(self) -> None:
-        edge = CrossScopeEdge(source=1, target=2, type="request")
+        edge = CrossScopeEdge(source=1, target=2, edge_type="request")
         d = edge.model_dump()
         assert d["cross_scope"] is True
         assert d["source"] == 1
@@ -358,8 +358,8 @@ class TestSocialGraphResponseCrossScopeEdgesTyped:
     def test_accepts_cross_scope_edge_instances(self) -> None:
         """list[CrossScopeEdge] — model instances accepted."""
         edges = [
-            CrossScopeEdge(source=1, target=3, type="request"),
-            CrossScopeEdge(source=2, target=4, type="sibling", reciprocal=True),
+            CrossScopeEdge(source=1, target=3, edge_type="request"),
+            CrossScopeEdge(source=2, target=4, edge_type="sibling", reciprocal=True),
         ]
         resp = SocialGraphResponse(
             nodes=[],
@@ -373,7 +373,7 @@ class TestSocialGraphResponseCrossScopeEdgesTyped:
 
     def test_accepts_raw_dicts_via_pydantic_coercion(self) -> None:
         """Pydantic v2 coerces compatible dicts into CrossScopeEdge instances."""
-        raw = [{"source": 1, "target": 3, "type": "request"}]
+        raw = [{"source": 1, "target": 3, "edge_type": "request"}]
         resp = SocialGraphResponse(
             nodes=[],
             edges=[],
@@ -385,7 +385,7 @@ class TestSocialGraphResponseCrossScopeEdgesTyped:
         assert resp.cross_scope_edges[0].cross_scope is True
 
     def test_rejects_dict_missing_required_fields(self) -> None:
-        """Dict without 'type' fails Pydantic validation for CrossScopeEdge."""
+        """Dict without 'edge_type' fails Pydantic validation for CrossScopeEdge."""
         with pytest.raises(ValidationError):
             SocialGraphResponse(
                 nodes=[],
@@ -424,7 +424,7 @@ class TestApplyScopeReturnsCrossScopeEdgeObjects:
         _, cross, _ = apply_scope(g, in_scope_bunk_cm_ids={100}, include_cross_scope=True)
         by_pair = {(e.source, e.target): e for e in cross}
         e12 = by_pair[(1, 2)]
-        assert e12.type == "request"
+        assert e12.edge_type == "request"
         assert e12.priority == 3
         assert e12.confidence == 0.8
         assert e12.request_type == "bunk_with"


### PR DESCRIPTION
## Summary

Closes #1157.

- Renames the Pydantic field `SocialGraphEdge.type` → `edge_type` and `CrossScopeEdge.type` → `edge_type`, eliminating shadowing of Python's builtin `type`
- Updates all 6 constructor call sites in `api/routers/social_graph.py` (both the session-graph and bunk-graph serializers) and the 1 field read at the edge-type summary log
- Updates `bunking/graph/scope_filter.py` — the `CrossScopeEdge` model and the `apply_scope` constructor keyword arg
- Updates frontend `GraphEdge.type` → `edge_type` (in `types/graph.ts`), removes now-redundant legacy `edge_type?` compat field, updates `CrossScopeEdge.type` → `edge_type`
- Updates `GraphEdgeData.type` → `edge_type` in `cytoscapeStyles.ts` and all 4 internal usages (`showEdges` lookup, `sameKind` comparator, `buildEdge`, `buildCrossEdge`)
- Updates local `GraphEdge` interface in `BunkSocialGraphModal.tsx` and the Cytoscape data population at line 433
- Updates all test fixtures across `test_scope_filter.py`, `test_sibling_edge_filter.py`, and `cytoscapeStyles.test.ts`

Wire format note: API responses now emit `edge_type` instead of `type` for edges. The Cytoscape data layer already used `edge_type` as the key passed to stylesheet functions — that layer is unchanged.

## Test plan

- [x] TDD: tests updated to `edge_type` first, verified failing, then implementation updated
- [x] `uv run ruff format .` — no changes
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run mypy bunking api` — success, 246 source files
- [x] `uv run pytest tests/unit/bunking/graph/test_scope_filter.py tests/unit/api/ -x` — 1283 passed
- [x] `cd frontend && npx tsc --noEmit` — no errors
- [x] `cd frontend && npx vitest run src/components/graph/` — 175 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized social-graph edge field name from `type` to `edge_type` across API responses and frontend graph visualization for consistency.
* **Tests**
  * Updated unit and style tests to reflect the renamed edge field so graph rendering and filtering behave consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->