### PR TITLE
fix(docker): persist /app/logs to prevent solver-log data loss on restart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,20 +221,19 @@ Format: `2026-01-06T14:05:52Z [source] LEVEL message key=value...`
 5. **Family camps excluded** in syncs for performance
 6. **Config is database-driven** - PocketBase `config` table, not JSON files. AI settings via env vars (`AI_API_KEY`, `AI_MODEL`, `AI_PROVIDER`)
 7. **AI model** - GPT-5-nano via `AI_MODEL` env var ($0.05/$0.40 per M tokens, reasoning enabled)
-8. **CSV history tracking** - `csv_history/` tracks changes, 30-day auto-cleanup, saves 70-90% AI costs
-9. **Token caching** - CampMinder JWT cached in `~/.campminder_token_cache.json`
-10. **Year-aware syncs** - Uses `season_id` from config; ready for new year with config update
-11. **Sequential session syncs** - Sessions 1-4 run sequentially with independent history
-12. **WAL checkpoint** - Required after database modifications
-13. **PocketBase filter syntax** - ALWAYS spaces around operators (`field = value` not `field=value`)
-14. **IPv4 in production** - Caddy/Vite configs use `127.0.0.1`; scripts may use localhost
-15. **React auth guards** - Check `isLoading` from `useAuth()` before authenticated API calls
-16. **React Query keys** - Use centralized keys from `frontend/src/utils/queryKeys.ts`
-17. **Attendee filtering** - Solver uses `status_id = 2` for active enrolled attendees
-18. **Git hooks** - Run `./scripts/setup-git-hooks.sh` once to install lefthook; config in `.lefthook.yml`
-19. **Python line length** - 120 chars (configured in `ruff.toml`), enforced by ruff format
-20. **Frontend tests** - Vitest (not Jest); `npm run test` for watch mode, `npx vitest run` for one-shot
-21. **Spelling: "cancelled"** - PocketBase fields use British spelling (`cancelled_count`). Go linter allows it via `.golangci.yml` extra-words. Use `cancelled` consistently, not `canceled`
+8. **Token caching** - CampMinder JWT cached in `~/.campminder_token_cache.json`
+9. **Year-aware syncs** - Uses `season_id` from config; ready for new year with config update
+10. **Sequential session syncs** - Sessions 1-4 run sequentially with independent history
+11. **WAL checkpoint** - Required after database modifications
+12. **PocketBase filter syntax** - ALWAYS spaces around operators (`field = value` not `field=value`)
+13. **IPv4 in production** - Caddy/Vite configs use `127.0.0.1`; scripts may use localhost
+14. **React auth guards** - Check `isLoading` from `useAuth()` before authenticated API calls
+15. **React Query keys** - Use centralized keys from `frontend/src/utils/queryKeys.ts`
+16. **Attendee filtering** - Solver uses `status_id = 2` for active enrolled attendees
+17. **Git hooks** - Run `./scripts/setup-git-hooks.sh` once to install lefthook; config in `.lefthook.yml`
+18. **Python line length** - 120 chars (configured in `ruff.toml`), enforced by ruff format
+19. **Frontend tests** - Vitest (not Jest); `npm run test` for watch mode, `npx vitest run` for one-shot
+20. **Spelling: "cancelled"** - PocketBase fields use British spelling (`cancelled_count`). Go linter allows it via `.golangci.yml` extra-words. Use `cancelled` consistently, not `canceled`
 
 ## Session Types and Bunking Structure
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -6,9 +6,10 @@ services:
   init-permissions:
     image: busybox:latest
     container_name: kindred-init-permissions
-    command: ["sh", "-c", "chown -R 65532:65532 /pb_data"]
+    command: ["sh", "-c", "chown -R 65532:65532 /pb_data /api_logs"]
     volumes:
       - kindred-pb-data:/pb_data
+      - kindred-api-logs:/api_logs
     restart: "no"
     networks:
       - kindred-local
@@ -97,10 +98,10 @@ services:
         condition: service_completed_successfully
     volumes:
       - kindred-pb-data:/pb_data:ro
+      # Solver run logs read back via /api/solver/logs/{session_id}; must persist across restarts.
+      - kindred-api-logs:/app/logs
     tmpfs:
       - /tmp:size=64m,uid=65532,gid=65532
-      - /app/logs:size=64m,uid=65532,gid=65532
-      - /app/csv_history:size=64m,uid=65532,gid=65532
     environment:
       - POCKETBASE_URL=http://pocketbase:8090
       - POCKETBASE_ADMIN_EMAIL=${POCKETBASE_ADMIN_EMAIL:-admin@test.local}
@@ -164,3 +165,4 @@ networks:
 
 volumes:
   kindred-pb-data:
+  kindred-api-logs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,10 +83,11 @@ services:
     volumes:
       - ${APPDATA_DIR}/kindred/pocketbase:/pb_data:ro
       - ${APPDATA_DIR}/kindred/config:/config:ro
+      # Solver run logs read back via /api/solver/logs/{session_id}; must persist across restarts.
+      # Host dir must be owned 65532:65532 (matches the api container's nonroot uid/gid).
+      - ${APPDATA_DIR}/kindred/api-logs:/app/logs
     tmpfs:
       - /tmp:size=64m,uid=65532,gid=65532
-      - /app/logs:size=64m,uid=65532,gid=65532
-      - /app/csv_history:size=64m,uid=65532,gid=65532
     environment:
       - POCKETBASE_URL=http://pocketbase:8090
       - POCKETBASE_ADMIN_EMAIL=${POCKETBASE_ADMIN_EMAIL}

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -20,7 +20,7 @@ FROM chainguard/wolfi-base:latest
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache python-3.14 libstdc++ curl \
-    && mkdir -p /app/logs /app/csv_history \
+    && mkdir -p /app/logs \
     && chown -R nonroot:nonroot /app
 
 WORKDIR /app


### PR DESCRIPTION
## Summary

The `kindred-api` container declared `/app/logs` and `/app/csv_history` as `tmpfs`, so every container recreate wiped persistent state. The bug surfaced as **solver-run JSON logs disappearing on restart** — `bunking/solver/logging.py:save_to_file()` writes per-run logs to `logs/solver/`, and `/api/solver/logs/{session_id}` reads them back.

While auditing, also confirmed `/app/csv_history` has been **dead code** since #577 (Mar 2026): the Python `CSVFieldHistoryTracker` was deleted, and uploaded CSV files are saved by the Go service into `pb_data/bunk_requests/` (already persistent via the existing pocketbase bind mount), not on the API container.

### Changes
- **`docker-compose.yml`**: replace `/app/logs` tmpfs with bind mount to `${APPDATA_DIR}/kindred/api-logs`. Drop `/app/csv_history` tmpfs.
- **`docker-compose.local.yml`**: replace `/app/logs` tmpfs with named volume `kindred-api-logs`; add it to `init-permissions` chown step. Drop `/app/csv_history` tmpfs.
- **`docker/Dockerfile.api`**: drop dead `csv_history` from the mkdir.
- **`CLAUDE.md`**: remove stale note 8 (`csv_history/` reference); renumber list.

### Deploy note
For prod, the host directory `${APPDATA_DIR}/kindred/api-logs` must exist and be owned `65532:65532` before `docker compose up -d`:
```sh
mkdir -p ${APPDATA_DIR}/kindred/api-logs && chown 65532:65532 ${APPDATA_DIR}/kindred/api-logs
```
The VPS deployment was already manually patched with this fix (separate session); this PR brings the upstream templates into alignment.

## Test plan
- [x] `docker compose -f docker-compose.yml config -q` — valid
- [x] `docker compose -f docker-compose.local.yml config -q` — valid
- [x] Pre-push hooks pass (ruff, mypy, go-build, eslint, tsc, shellcheck)
- [ ] After deploy: solver-run JSON logs survive `docker compose down && up -d`
- [ ] Verify `/api/solver/logs/{session_id}` returns historical runs after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * API and solver logs now persist across container restarts instead of being stored ephemerally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->