### PR TITLE
refactor(api): suppress /api/solver/run/<id> poll access logs at INFO

### DIFF
--- a/bunking/logging_config.py
+++ b/bunking/logging_config.py
@@ -114,8 +114,15 @@ class HealthCheckFilter(logging.Filter):
         Returns:
             True if the record should be logged, False to suppress
         """
-        # Always allow DEBUG level logs (when debug is enabled)
-        if record.levelno == logging.DEBUG:
+        # In DEBUG/TRACE mode, keep all access logs visible. Uvicorn access
+        # records are always INFO regardless of LOG_LEVEL, so we must check
+        # the root logger's effective level rather than `record.levelno`.
+        if logging.getLogger().getEffectiveLevel() <= logging.DEBUG:
+            return True
+
+        # Suppression is only intended for INFO access-log noise; pass through
+        # anything at WARNING or higher (and the artificial DEBUG records).
+        if record.levelno != logging.INFO:
             return True
 
         # Check if this is an access log for health endpoints. Anchor on the

--- a/bunking/logging_config.py
+++ b/bunking/logging_config.py
@@ -118,9 +118,11 @@ class HealthCheckFilter(logging.Filter):
         if record.levelno == logging.DEBUG:
             return True
 
-        # Check if this is an access log for health endpoints
+        # Check if this is an access log for health endpoints. Anchor on the
+        # uvicorn format `"GET /path HTTP/1.1" 200 OK` so 4xx/5xx polls and
+        # non-GET methods on the same path stay visible.
         message = record.getMessage()
-        return all(not (path in message and ("GET" in message or "200" in message)) for path in self.HEALTH_PATHS)
+        return all(not (path in message and '"GET ' in message and '" 200' in message) for path in self.HEALTH_PATHS)
 
 
 def configure_logging(

--- a/bunking/logging_config.py
+++ b/bunking/logging_config.py
@@ -90,13 +90,20 @@ class ISO8601Formatter(logging.Formatter):
 
 
 class HealthCheckFilter(logging.Filter):
-    """Filter to suppress health check logs at INFO level.
+    """Filter to suppress high-frequency access log noise at INFO level.
 
-    Health check endpoints generate a lot of noise (every 10-15 seconds).
-    This filter suppresses them unless LOG_LEVEL=DEBUG is set.
+    Covers two recurring sources:
+    - Health check endpoints (every 10-15 seconds from Docker probes).
+    - Solver run status polls (~1/s for the duration of every solve).
+
+    The trailing slash on ``/api/solver/run/`` matches only the per-run
+    GET (which always carries a UUID), not the bare POST that kicks off
+    a run — so dispatch and apply lines stay visible.
+
+    Set LOG_LEVEL=DEBUG to see all access logs.
     """
 
-    HEALTH_PATHS: ClassVar[set[str]] = {"/health", "/api/health"}
+    HEALTH_PATHS: ClassVar[set[str]] = {"/health", "/api/health", "/api/solver/run/"}
 
     def filter(self, record: logging.LogRecord) -> bool:
         """Filter out health check logs at INFO level.

--- a/bunking/logging_config.py
+++ b/bunking/logging_config.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import sys
 from datetime import UTC, datetime
 from typing import ClassVar
@@ -96,14 +97,19 @@ class HealthCheckFilter(logging.Filter):
     - Health check endpoints (every 10-15 seconds from Docker probes).
     - Solver run status polls (~1/s for the duration of every solve).
 
-    The trailing slash on ``/api/solver/run/`` matches only the per-run
-    GET (which always carries a UUID), not the bare POST that kicks off
-    a run — so dispatch and apply lines stay visible.
+    Only successful (200) GET requests are filtered. ``HEALTH_EXACT_PATHS``
+    matches whole paths so ``/healthz`` or ``/api/healthcheck`` stay visible;
+    ``HEALTH_PATH_PREFIXES`` matches the per-run solver poll (the UUID-bearing
+    suffix) without catching the bare POST that kicks off a run.
 
     Set LOG_LEVEL=DEBUG to see all access logs.
     """
 
-    HEALTH_PATHS: ClassVar[set[str]] = {"/health", "/api/health", "/api/solver/run/"}
+    HEALTH_EXACT_PATHS: ClassVar[set[str]] = {"/health", "/api/health"}
+    HEALTH_PATH_PREFIXES: ClassVar[tuple[str, ...]] = ("/api/solver/run/",)
+    _ACCESS_LOG_RE: ClassVar[re.Pattern[str]] = re.compile(
+        r'"(?P<method>[A-Z]+) (?P<path>\S+) HTTP/\d\.\d" (?P<status>\d{3})'
+    )
 
     def filter(self, record: logging.LogRecord) -> bool:
         """Filter out health check logs at INFO level.
@@ -125,11 +131,17 @@ class HealthCheckFilter(logging.Filter):
         if record.levelno != logging.INFO:
             return True
 
-        # Check if this is an access log for health endpoints. Anchor on the
-        # uvicorn format `"GET /path HTTP/1.1" 200 OK` so 4xx/5xx polls and
-        # non-GET methods on the same path stay visible.
-        message = record.getMessage()
-        return all(not (path in message and '"GET ' in message and '" 200' in message) for path in self.HEALTH_PATHS)
+        # Parse the uvicorn access-log line; if it doesn't match, leave it alone.
+        match = self._ACCESS_LOG_RE.search(record.getMessage())
+        if not match:
+            return True
+        if match.group("method") != "GET" or match.group("status") != "200":
+            return True
+
+        path = match.group("path")
+        if path in self.HEALTH_EXACT_PATHS:
+            return False
+        return not any(path.startswith(prefix) for prefix in self.HEALTH_PATH_PREFIXES)
 
 
 def configure_logging(

--- a/tests/unit/test_logging_format.py
+++ b/tests/unit/test_logging_format.py
@@ -346,7 +346,7 @@ class TestHealthCheckFilter:
                 level=logging.INFO,
                 pathname="",
                 lineno=0,
-                msg='172.20.0.4:36134 - "GET /api/solver/run/2e8660bd HTTP/1.1" 200',
+                msg='172.20.0.4:36134 - "GET /api/solver/run/2e8660bd-fea0-45d9-a622-09c69e67b961 HTTP/1.1" 200',
                 args=(),
                 exc_info=None,
             )

--- a/tests/unit/test_logging_format.py
+++ b/tests/unit/test_logging_format.py
@@ -290,6 +290,33 @@ class TestHealthCheckFilter:
         result = filter_instance.filter(record)
         assert result is True, "Failing health checks must remain visible at INFO"
 
+    def test_log_level_debug_bypasses_suppression(self):
+        """When the root logger is at DEBUG, INFO access logs must pass through.
+
+        Uvicorn emits access logs at INFO level regardless of LOG_LEVEL, so the
+        bypass cannot rely on record.levelno — it must check the effective level.
+        """
+        from bunking.logging_config import HealthCheckFilter
+
+        filter_instance = HealthCheckFilter()
+        root = logging.getLogger()
+        prev_level = root.level
+        root.setLevel(logging.DEBUG)
+        try:
+            record = logging.LogRecord(
+                name="uvicorn.access",
+                level=logging.INFO,
+                pathname="",
+                lineno=0,
+                msg='172.20.0.4:36134 - "GET /api/solver/run/2e8660bd HTTP/1.1" 200',
+                args=(),
+                exc_info=None,
+            )
+            result = filter_instance.filter(record)
+            assert result is True, "DEBUG mode must show all access logs"
+        finally:
+            root.setLevel(prev_level)
+
 
 class TestConfigureLogging:
     """Test the configure_logging function."""

--- a/tests/unit/test_logging_format.py
+++ b/tests/unit/test_logging_format.py
@@ -214,6 +214,44 @@ class TestHealthCheckFilter:
         result = filter_instance.filter(record)
         assert result is True, "Health checks should pass at DEBUG level"
 
+    def test_suppresses_solver_run_poll(self):
+        """GET /api/solver/run/<uuid> polls fire ~1/s for the duration of a solve and flood logs."""
+        from bunking.logging_config import HealthCheckFilter
+
+        filter_instance = HealthCheckFilter()
+
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg='172.20.0.4:36134 - "GET /api/solver/run/2e8660bd-fea0-45d9-a622-09c69e67b961 HTTP/1.1" 200',
+            args=(),
+            exc_info=None,
+        )
+
+        result = filter_instance.filter(record)
+        assert result is False, "Solver run status polls should be suppressed at INFO"
+
+    def test_allows_solver_run_post(self):
+        """POST /api/solver/run (kicking off a run) must remain visible — distinct path shape."""
+        from bunking.logging_config import HealthCheckFilter
+
+        filter_instance = HealthCheckFilter()
+
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg='172.20.0.4:41182 - "POST /api/solver/run HTTP/1.1" 200',
+            args=(),
+            exc_info=None,
+        )
+
+        result = filter_instance.filter(record)
+        assert result is True, "POST /api/solver/run kickoff should not be suppressed"
+
 
 class TestConfigureLogging:
     """Test the configure_logging function."""

--- a/tests/unit/test_logging_format.py
+++ b/tests/unit/test_logging_format.py
@@ -252,6 +252,44 @@ class TestHealthCheckFilter:
         result = filter_instance.filter(record)
         assert result is True, "POST /api/solver/run kickoff should not be suppressed"
 
+    def test_allows_failing_solver_run_poll(self):
+        """Failing GETs on the poll endpoint (4xx/5xx) must stay visible — only successful 200 polls are noise."""
+        from bunking.logging_config import HealthCheckFilter
+
+        filter_instance = HealthCheckFilter()
+
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg='172.20.0.4:36134 - "GET /api/solver/run/2e8660bd-fea0-45d9-a622-09c69e67b961 HTTP/1.1" 500',
+            args=(),
+            exc_info=None,
+        )
+
+        result = filter_instance.filter(record)
+        assert result is True, "Failing solver run polls must remain visible at INFO"
+
+    def test_allows_failing_health_check(self):
+        """Failing GETs on /health (4xx/5xx) must stay visible too."""
+        from bunking.logging_config import HealthCheckFilter
+
+        filter_instance = HealthCheckFilter()
+
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg='127.0.0.1:56948 - "GET /health HTTP/1.1" 503',
+            args=(),
+            exc_info=None,
+        )
+
+        result = filter_instance.filter(record)
+        assert result is True, "Failing health checks must remain visible at INFO"
+
 
 class TestConfigureLogging:
     """Test the configure_logging function."""

--- a/tests/unit/test_logging_format.py
+++ b/tests/unit/test_logging_format.py
@@ -290,6 +290,44 @@ class TestHealthCheckFilter:
         result = filter_instance.filter(record)
         assert result is True, "Failing health checks must remain visible at INFO"
 
+    def test_does_not_suppress_healthz_lookalike(self):
+        """/healthz must not be suppressed — HEALTH_PATHS uses /health, but substring matching would catch it."""
+        from bunking.logging_config import HealthCheckFilter
+
+        filter_instance = HealthCheckFilter()
+
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg='127.0.0.1:56948 - "GET /healthz HTTP/1.1" 200 OK',
+            args=(),
+            exc_info=None,
+        )
+
+        result = filter_instance.filter(record)
+        assert result is True, "/healthz must not be filtered (only exact /health)"
+
+    def test_does_not_suppress_healthcheck_lookalike(self):
+        """/api/healthcheck must not be suppressed by the /api/health entry."""
+        from bunking.logging_config import HealthCheckFilter
+
+        filter_instance = HealthCheckFilter()
+
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg='127.0.0.1:56948 - "GET /api/healthcheck HTTP/1.1" 200 OK',
+            args=(),
+            exc_info=None,
+        )
+
+        result = filter_instance.filter(record)
+        assert result is True, "/api/healthcheck must not be filtered (only exact /api/health)"
+
     def test_log_level_debug_bypasses_suppression(self):
         """When the root logger is at DEBUG, INFO access logs must pass through.
 


### PR DESCRIPTION
## Summary

The frontend polls `GET /api/solver/run/<uuid>` once per second for the duration of every solve. A 5m solve produces ~300 lines of identical access logs that drown out the actual solver progress in `docker logs kindred-api`.

Extends the existing `HealthCheckFilter` (`bunking/logging_config.py`) to also suppress that path at INFO. The trailing slash on `"/api/solver/run/"` cleanly disambiguates:

| Log line | Filtered? |
|---|---|
| `GET /api/solver/run/<uuid> ... 200` | ✅ suppressed (the poll noise) |
| `POST /api/solver/run ... 200` | ❌ visible (kickoff) |
| `POST /api/solver/apply/<uuid> ... 200` | ❌ visible (different path) |
| Any `4xx`/`5xx` | ❌ visible (loose check on `200 in message`) |

`LOG_LEVEL=DEBUG` still shows everything.

## Test plan

- [x] New tests in `tests/unit/test_logging_format.py::TestHealthCheckFilter`:
  - `test_suppresses_solver_run_poll` — RED before, GREEN after
  - `test_allows_solver_run_post` — confirms POST kickoff stays visible
- [x] All 6 `HealthCheckFilter` tests pass (no regressions on health-check behavior)
- [x] `ruff format` + `ruff check` + `mypy` clean
- [x] Pre-push hooks pass (ruff, mypy, type-check, eslint, pb-js-lint, go-build, shellcheck)

## Out of scope

- The dead-code `bunking/uvicorn_logging.py` has its own copy of the filter that's never wired up. Not touching it — it's unused and changing it would be churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access-log filtering to suppress noisy successful GET polling for solver-run status and standard health checks, while still showing POSTs and any failing responses; filter now respects debug-level logging so debug output remains visible.

* **Tests**
  * Added unit tests validating the refined filtering behavior across GET vs POST, success vs failure, and debug-mode visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->