### PR TITLE
fix(api): invalidate scenario graph cache after every draft writer

### DIFF
--- a/api/routers/scenarios.py
+++ b/api/routers/scenarios.py
@@ -40,7 +40,7 @@ from ..constants.collections import (
     PERSONS,
     SAVED_SCENARIOS,
 )
-from ..dependencies import pb, solver_runs
+from ..dependencies import graph_cache, pb, solver_runs
 from ..services.session_context import build_session_context
 from ..services.solver_runner import run_solver_task_v2
 from ..utils.pb_error import pb_error_to_http
@@ -182,6 +182,12 @@ async def create_scenario(
                     }
 
                 await asyncio.to_thread(pb.collection(BUNK_ASSIGNMENTS_DRAFT).create, draft_data)
+
+        # Defensively invalidate the new scenario's cache slot. A brand-new
+        # scenario should not have any cached graph yet, but if its id reuses
+        # one that was deleted recently the slot could carry over — costing
+        # ~µs to drop, much cheaper than serving a stale graph.
+        graph_cache.invalidate_scenario(int(request.session_cm_id), int(ctx.year), scenario.id)
 
         return SavedScenario(
             id=scenario.id,
@@ -475,7 +481,14 @@ async def delete_scenario(
 ) -> dict[str, str]:
     """Delete a scenario and all its data."""
     try:
-        scenario = await asyncio.to_thread(pb.collection(SAVED_SCENARIOS).get_one, scenario_id)
+        # Expand session up front so we can grab session.cm_id for the
+        # post-delete cache invalidation without a second round-trip.
+        scenario = await asyncio.to_thread(pb.collection(SAVED_SCENARIOS).get_one, scenario_id, {"expand": "session"})
+        scenario_session = getattr(scenario, "session", None)
+        scenario_session_cm_id: int | None = None
+        if scenario_session is not None and hasattr(scenario_session, "cm_id"):
+            scenario_session_cm_id = int(getattr(scenario_session, "cm_id", 0)) or None
+        scenario_year = int(getattr(scenario, "year", 0)) or None
 
         # Delete all related draft assignments first
         draft_assignments = await asyncio.to_thread(
@@ -488,6 +501,11 @@ async def delete_scenario(
 
         # Delete the scenario
         await asyncio.to_thread(pb.collection(SAVED_SCENARIOS).delete, scenario_id)
+
+        # Drop the cache slot so the next request rebuilds (or short-circuits
+        # to "scenario not found" cleanly instead of serving a phantom graph).
+        if scenario_session_cm_id is not None and scenario_year is not None:
+            graph_cache.invalidate_scenario(scenario_session_cm_id, scenario_year, scenario_id)
 
         return {"message": f"Scenario '{getattr(scenario, 'name', scenario_id)}' deleted successfully"}
 
@@ -544,10 +562,18 @@ async def update_scenario_assignment(
             query_params={"filter": f'scenario = "{scenario_id}" && person = "{person_pb_id}" && year = {ctx.year}'},
         )
 
+        # Helper: drop the cache slot whenever this call mutates the draft.
+        # Single-record edits change bunk membership for one camper, which
+        # alters parent-compound grouping in the rendered graph; the cache
+        # must rebuild against current DB on the next request.
+        def _invalidate() -> None:
+            graph_cache.invalidate_scenario(int(session_cm_id), int(ctx.year), scenario_id)
+
         if update.bunk_id is None:
             # Remove assignment
             if existing:
                 await asyncio.to_thread(pb.collection(BUNK_ASSIGNMENTS_DRAFT).delete, existing[0].id)
+                _invalidate()
                 return {"message": "Assignment removed", "person_id": update.person_id, "changed": True}
             else:
                 return {"message": "No change needed", "person_id": update.person_id, "changed": False}
@@ -575,6 +601,7 @@ async def update_scenario_assignment(
                     update_assignment_data["assignment_locked"] = update.locked
 
                 await asyncio.to_thread(pb.collection(BUNK_ASSIGNMENTS_DRAFT).update, record_id, update_assignment_data)
+                _invalidate()
 
                 return {
                     "message": "Assignment updated successfully",
@@ -623,6 +650,7 @@ async def update_scenario_assignment(
                     )
                     logger.error(f"Assignment data was: {new_assignment}")
                     raise
+                _invalidate()
 
                 return {
                     "message": "Assignment created successfully",
@@ -742,8 +770,12 @@ async def clear_scenario(
 ) -> dict[str, str | int]:
     """Clear all assignments in a scenario."""
     try:
-        # Verify scenario exists (raises 404 if not found)
-        await asyncio.to_thread(pb.collection(SAVED_SCENARIOS).get_one, scenario_id)
+        # Expand session so we have cm_id for cache invalidation below.
+        scenario = await asyncio.to_thread(pb.collection(SAVED_SCENARIOS).get_one, scenario_id, {"expand": "session"})
+        scenario_session = getattr(scenario, "session", None)
+        scenario_session_cm_id: int | None = None
+        if scenario_session is not None and hasattr(scenario_session, "cm_id"):
+            scenario_session_cm_id = int(getattr(scenario_session, "cm_id", 0)) or None
 
         # Use year from request for scoping (required field now)
         filter_str = f'scenario = "{scenario_id}" && year = {request.year}'
@@ -756,6 +788,11 @@ async def clear_scenario(
         for assignment in assignments:
             await asyncio.to_thread(pb.collection(BUNK_ASSIGNMENTS_DRAFT).delete, assignment.id)
             deleted_count += 1
+
+        # Drop this scenario's cache slot so the next graph request rebuilds
+        # against the now-empty draft set.
+        if scenario_session_cm_id is not None:
+            graph_cache.invalidate_scenario(scenario_session_cm_id, int(request.year), scenario_id)
 
         return {
             "message": f"Cleared {deleted_count} assignments from scenario for year {request.year}",

--- a/api/routers/solver.py
+++ b/api/routers/solver.py
@@ -40,7 +40,7 @@ from ..constants.collections import (
     SOLVER_RUNS,
 )
 from ..constants.filters import ACTIVE_ENROLLED_FILTER
-from ..dependencies import pb, solver_runs
+from ..dependencies import graph_cache, pb, solver_runs
 from ..schemas import (
     ClearAssignmentsRequest,
     MultiSessionSolverRequest,
@@ -671,6 +671,17 @@ async def apply_solver_results(
 
     table_name = "bunk_assignments_draft" if scenario else "bunk_assignments"
     assignments_dict: dict[str, Any] = assignments if isinstance(assignments, dict) else {}
+
+    # Drop the matching graph cache slot so the next /social-graph request
+    # rebuilds from current DB. Without this the cached NetworkX graph carries
+    # the previous draft's bunk_cm_id node attrs for up to TTL (15 min) — the
+    # symptom is "everyone in a big lump" because bubble grouping no longer
+    # matches the active scenario's assignments.
+    if scenario:
+        graph_cache.invalidate_scenario(int(session_cm_id), run_year, scenario)
+    else:
+        graph_cache.invalidate_session(int(session_cm_id), run_year)
+
     return {"message": f"Applied {len(assignments_dict)} assignments to {table_name}"}
 
 
@@ -846,6 +857,15 @@ async def clear_session_assignments(
             breakdown.append(
                 {"session_cm_id": sid, "session_name": session_names.get(sid, f"Session {sid}"), "deleted_count": count}
             )
+
+        # Invalidate the graph cache for every related session — clearing
+        # assignments materially changes the social graph, so any cached
+        # rendering would be stale.
+        for sid in ctx.related_session_ids:
+            if request.scenario:
+                graph_cache.invalidate_scenario(int(sid), int(ctx.year), request.scenario)
+            else:
+                graph_cache.invalidate_session(int(sid), int(ctx.year))
 
         return {
             "message": f"Cleared {total_deleted} assignments across {len(ctx.related_session_ids)} related sessions",

--- a/bunking/graph/graph_cache_manager.py
+++ b/bunking/graph/graph_cache_manager.py
@@ -240,6 +240,59 @@ class GraphCacheManager:
 
             return len(keys_to_remove)
 
+    def invalidate_scenario(self, session_cm_id: int, year: int, scenario_id: str) -> int:
+        """Invalidate cached graphs for a single scenario+session+year.
+
+        Drops both the session graph and every bunk graph cached under the
+        scenario slot, leaving production cache (``slug == "prod"``) and other
+        scenarios for the same session+year untouched.
+
+        Slug comparison is exact (positional, not substring) so a scenario id
+        that is a prefix of another (``"abc"`` vs ``"abcd"``) cannot
+        false-match — same guarantee as ``invalidate_session``'s bunk match.
+
+        Returns:
+            Number of graphs invalidated
+        """
+        if not scenario_id:
+            return 0
+
+        slug = self._scenario_slug(scenario_id)
+        session_str = str(session_cm_id)
+        year_str = str(year)
+        session_key = f"session_{session_str}_{year_str}_{slug}"
+
+        with self._lock:
+            keys_to_remove: list[str] = []
+            for key in self._cache:
+                if key == session_key:
+                    keys_to_remove.append(key)
+                    continue
+                if key.startswith("bunk_"):
+                    # Slug is the trailing segment; PocketBase ids are
+                    # alphanumeric in production but the slug field is a
+                    # free-form string, so rejoin parts[4:] to compare
+                    # exactly even when it contains underscores.
+                    parts = key.split("_")
+                    if (
+                        len(parts) >= 5
+                        and parts[2] == session_str
+                        and parts[3] == year_str
+                        and "_".join(parts[4:]) == slug
+                    ):
+                        keys_to_remove.append(key)
+
+            for key in keys_to_remove:
+                self._evict(key)
+
+            if keys_to_remove:
+                logger.info(
+                    f"Invalidated {len(keys_to_remove)} graphs for scenario {scenario_id} "
+                    f"(session {session_cm_id}, year {year})"
+                )
+
+            return len(keys_to_remove)
+
     def invalidate_bunk(self, bunk_cm_id: int) -> int:
         """Invalidate all cached graphs for a bunk.
 

--- a/tests/unit/api/routers/test_draft_writes_invalidate_cache.py
+++ b/tests/unit/api/routers/test_draft_writes_invalidate_cache.py
@@ -1,0 +1,377 @@
+"""Cache invalidation contract for every ``bunk_assignments_draft`` writer.
+
+Each writer that mutates ``bunk_assignments_draft`` (or, for solver apply,
+``bunk_assignments`` in the production case) must invalidate the matching
+scenario-scoped graph cache slot immediately. Without this, the
+``GraphCacheManager`` serves a stale graph (TTL 15 min) keyed under
+``session_{session_cm_id}_{year}_{scenario_id}`` after a solver re-run and
+apply, so the social-graph view shows campers grouped by the previous
+draft state — exactly the "big lump" symptom reported on the May 7 scenario.
+
+Writers covered:
+  * POST   /api/solver/apply/{run_id}                 (scenario + prod)
+  * POST   /api/sessions/{cm_id}/clear-assignments    (scenario + prod)
+  * POST   /api/scenarios/{id}/clear
+  * DELETE /api/scenarios/{id}
+  * PUT    /api/scenarios/{id}/assignments
+  * POST   /api/scenarios                             (copy from prod / from another scenario)
+
+Each test patches ``graph_cache`` and verifies the appropriate invalidation
+method is called with the expected arguments. The full PocketBase write path
+is mocked at the boundary — these are unit-level contract tests.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+test_dir = Path(__file__).resolve().parent
+project_root = test_dir.parent.parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from bunking.auth_middleware import AuthUser, get_current_user
+from bunking.rbac.permissions import ALL_PERMISSIONS
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _admin() -> AuthUser:
+    user = AuthUser(
+        username="TestAdmin",
+        email="test@example.com",
+        display_name="Test Admin",
+        groups=["admin"],
+        is_admin=True,
+    )
+    user.permissions = set(ALL_PERMISSIONS)
+    return user
+
+
+def _build_session_context_stub(session_cm_id: int = 1235404, year: int = 2026) -> Any:
+    """Return a SessionContext-shaped stub with the fields apply paths read."""
+    ctx = MagicMock()
+    ctx.session_cm_id = session_cm_id
+    ctx.year = year
+    ctx.session_pb_id = "sess_pb"
+    ctx.session_relation_filter = f"session.cm_id = {session_cm_id}"
+    ctx.related_session_ids = [session_cm_id]
+    ctx.id_cache = MagicMock()
+    ctx.id_cache.get_person_pb_id = AsyncMock(return_value="person_pb")
+    ctx.id_cache.get_bunk_pb_id = AsyncMock(return_value="bunk_pb")
+    ctx.id_cache.get_session_pb_id = AsyncMock(return_value="sess_pb")
+    ctx.id_cache.get_bunk_plan_id = AsyncMock(return_value="bp_pb")
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# /api/solver/apply/{run_id}
+# ---------------------------------------------------------------------------
+
+
+class TestApplySolverResultsInvalidatesCache:
+    """The user-reported case: solver re-run + apply must drop the stale graph."""
+
+    def _run_apply(
+        self,
+        *,
+        scenario: str | None,
+        session_cm_id: int = 1235404,
+        year: int = 2026,
+    ) -> MagicMock:
+        from api.dependencies import solver_runs
+        from api.routers.solver import router
+
+        run_id = "run-test-1"
+        solver_runs.clear()
+        solver_runs[run_id] = {
+            "id": run_id,
+            "status": "completed",
+            "session_cm_id": session_cm_id,
+            "scenario": scenario,
+            "config": {"year": year},
+            "results": {"assignments": {}},  # empty — no upsert work, focus is the cache call
+        }
+
+        mock_cache = MagicMock()
+        mock_pb = MagicMock()
+
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_current_user] = _admin
+
+        ctx = _build_session_context_stub(session_cm_id, year)
+        with (
+            patch("api.routers.solver.pb", mock_pb),
+            patch("api.routers.solver.graph_cache", mock_cache),
+            patch("api.routers.solver.build_session_context", AsyncMock(return_value=ctx)),
+        ):
+            client = TestClient(app)
+            resp = client.post(f"/api/solver/apply/{run_id}")
+            assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+
+        solver_runs.clear()
+        return mock_cache
+
+    def test_scenario_apply_invalidates_scenario_slot(self) -> None:
+        """Apply with a scenario must invalidate that scenario's cache slot."""
+        cache = self._run_apply(scenario="scn_abc123")
+        cache.invalidate_scenario.assert_called_once_with(1235404, 2026, "scn_abc123")
+        # Don't broadly nuke the prod or session-wide cache in scenario mode.
+        cache.invalidate_session.assert_not_called()
+
+    def test_prod_apply_invalidates_session_slot(self) -> None:
+        """Apply without a scenario writes to bunk_assignments — invalidate the
+        session cache so the prod graph rebuilds from current DB."""
+        cache = self._run_apply(scenario=None)
+        cache.invalidate_session.assert_called_once_with(1235404, 2026)
+        cache.invalidate_scenario.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# /api/sessions/{cm_id}/clear-assignments
+# ---------------------------------------------------------------------------
+
+
+class TestClearSessionAssignmentsInvalidatesCache:
+    """Bulk-clearing draft (or prod) assignments must drop the matching cache."""
+
+    def _run(self, *, scenario: str | None) -> MagicMock:
+        from api.routers.solver import router
+
+        mock_cache = MagicMock()
+        mock_pb = MagicMock()
+        # No assignments to delete — focus is the cache call after the loop.
+        mock_pb.collection.return_value.get_full_list.return_value = []
+
+        ctx = _build_session_context_stub(1235404, 2026)
+
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_current_user] = _admin
+
+        with (
+            patch("api.routers.solver.pb", mock_pb),
+            patch("api.routers.solver.graph_cache", mock_cache),
+            patch("api.routers.solver.build_session_context", AsyncMock(return_value=ctx)),
+        ):
+            body: dict[str, Any] = {"year": 2026, "session_cm_id": 1235404}
+            if scenario is not None:
+                body["scenario"] = scenario
+            client = TestClient(app)
+            resp = client.post("/api/sessions/1235404/clear-assignments", json=body)
+            assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+
+        return mock_cache
+
+    def test_scenario_clear_invalidates_scenario_slot(self) -> None:
+        cache = self._run(scenario="scn_abc123")
+        cache.invalidate_scenario.assert_called_once_with(1235404, 2026, "scn_abc123")
+
+    def test_prod_clear_invalidates_session_slot(self) -> None:
+        cache = self._run(scenario=None)
+        cache.invalidate_session.assert_called_once_with(1235404, 2026)
+
+
+# ---------------------------------------------------------------------------
+# /api/scenarios/{id}/clear
+# ---------------------------------------------------------------------------
+
+
+class TestClearScenarioInvalidatesCache:
+    def test_clear_scenario_invalidates_scenario_slot(self) -> None:
+        from api.routers.scenarios import router
+
+        # The clear path expands `session` so it can read cm_id for invalidation.
+        camp_session = SimpleNamespace(id="sess_pb", cm_id=1235404)
+        scenario_pb_with_session = SimpleNamespace(id="scn_abc", name="May 7", session=camp_session)
+
+        mock_cache = MagicMock()
+        mock_pb = MagicMock()
+        # First .get_one returns the scenario record
+        mock_pb.collection.return_value.get_one.return_value = scenario_pb_with_session
+        # No drafts — empty list of records to delete
+        mock_pb.collection.return_value.get_full_list.return_value = []
+
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_current_user] = _admin
+
+        # ClearScenarioRequest expects {year, session_cm_id?}
+        body = {"year": 2026}
+        with (
+            patch("api.routers.scenarios.pb", mock_pb),
+            patch("api.routers.scenarios.graph_cache", mock_cache),
+        ):
+            client = TestClient(app)
+            resp = client.post("/api/scenarios/scn_abc/clear", json=body)
+            assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+
+        mock_cache.invalidate_scenario.assert_called_once_with(1235404, 2026, "scn_abc")
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/scenarios/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteScenarioInvalidatesCache:
+    def test_delete_scenario_invalidates_scenario_slot(self) -> None:
+        from api.routers.scenarios import router
+
+        camp_session = SimpleNamespace(id="sess_pb", cm_id=1235404, year=2026)
+        scenario_pb = SimpleNamespace(
+            id="scn_abc",
+            name="May 7",
+            session=camp_session,
+            year=2026,
+        )
+
+        mock_cache = MagicMock()
+        mock_pb = MagicMock()
+        mock_pb.collection.return_value.get_one.return_value = scenario_pb
+        mock_pb.collection.return_value.get_full_list.return_value = []
+
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_current_user] = _admin
+
+        with (
+            patch("api.routers.scenarios.pb", mock_pb),
+            patch("api.routers.scenarios.graph_cache", mock_cache),
+        ):
+            client = TestClient(app)
+            resp = client.delete("/api/scenarios/scn_abc")
+            assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+
+        mock_cache.invalidate_scenario.assert_called_once_with(1235404, 2026, "scn_abc")
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/scenarios/{id}/assignments
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateScenarioAssignmentInvalidatesCache:
+    def test_update_assignment_invalidates_scenario_slot(self) -> None:
+        from api.routers.scenarios import router
+
+        camp_session = SimpleNamespace(id="sess_pb", cm_id=1235404, year=2026)
+        scenario_pb = SimpleNamespace(
+            id="scn_abc",
+            name="May 7",
+            session=camp_session,
+            expand={"session": camp_session},
+        )
+        person_pb = SimpleNamespace(id="person_pb", cm_id=12345)
+        bunk_pb = SimpleNamespace(id="bunk_pb", cm_id=4276)
+        bunk_plan_pb = SimpleNamespace(id="bp_pb")
+
+        mock_cache = MagicMock()
+        mock_pb = MagicMock()
+
+        # PB calls in order: scenarios.get_one, persons.get_full_list,
+        # bunk_assignments_draft.get_full_list (existing check), bunks.get_full_list,
+        # bunk_plans.get_full_list, bunk_assignments_draft.create
+        # Use side-effect-driven mock to return different things per collection.
+        def collection_factory(name: str) -> MagicMock:
+            mock = MagicMock()
+            if name == "saved_scenarios":
+                mock.get_one.return_value = scenario_pb
+            elif name == "persons":
+                mock.get_full_list.return_value = [person_pb]
+            elif name == "bunks":
+                mock.get_full_list.return_value = [bunk_pb]
+            elif name == "bunk_plans":
+                mock.get_full_list.return_value = [bunk_plan_pb]
+            elif name == "bunk_assignments_draft":
+                mock.get_full_list.return_value = []  # no existing
+                mock.create.return_value = MagicMock()
+            return mock
+
+        mock_pb.collection.side_effect = collection_factory
+
+        ctx = _build_session_context_stub(1235404, 2026)
+
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_current_user] = _admin
+
+        body = {
+            "person_id": 12345,
+            "bunk_id": 4276,
+            "session_cm_id": 1235404,
+            "year": 2026,
+        }
+        with (
+            patch("api.routers.scenarios.pb", mock_pb),
+            patch("api.routers.scenarios.graph_cache", mock_cache),
+            patch("api.routers.scenarios.build_session_context", AsyncMock(return_value=ctx)),
+        ):
+            client = TestClient(app)
+            resp = client.put("/api/scenarios/scn_abc/assignments", json=body)
+            assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+
+        mock_cache.invalidate_scenario.assert_called_once_with(1235404, 2026, "scn_abc")
+
+
+# ---------------------------------------------------------------------------
+# POST /api/scenarios (copy path)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateScenarioInvalidatesCache:
+    """When a new scenario is created and seeded from prod or another scenario,
+    invalidate that new scenario's cache slot. This is defensive — a brand-new
+    scenario shouldn't have any cached graph yet, but invalidating costs ~µs
+    and prevents a poisoned slot if the slug is reused after an earlier delete."""
+
+    def test_create_scenario_with_copy_invalidates_new_slot(self) -> None:
+        from api.routers.scenarios import router
+
+        new_scenario_pb = SimpleNamespace(
+            id="scn_new",
+            name="May 8",
+            session_cm_id=1235404,
+            session="sess_pb",
+            year=2026,
+            description="",
+            created_by="system",
+            is_active=True,
+        )
+
+        mock_cache = MagicMock()
+        mock_pb = MagicMock()
+        mock_pb.collection.return_value.create.return_value = new_scenario_pb
+        mock_pb.collection.return_value.get_full_list.return_value = []  # no source assignments
+
+        ctx = _build_session_context_stub(1235404, 2026)
+
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_current_user] = _admin
+
+        body = {
+            "name": "May 8",
+            "session_cm_id": 1235404,
+            "year": 2026,
+            "should_copy_from_production": True,
+        }
+        with (
+            patch("api.routers.scenarios.pb", mock_pb),
+            patch("api.routers.scenarios.graph_cache", mock_cache),
+            patch("api.routers.scenarios.build_session_context", AsyncMock(return_value=ctx)),
+        ):
+            client = TestClient(app)
+            resp = client.post("/api/scenarios", json=body)
+            assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+
+        mock_cache.invalidate_scenario.assert_called_once_with(1235404, 2026, "scn_new")

--- a/tests/unit/sync/test_graph_cache_manager.py
+++ b/tests/unit/sync/test_graph_cache_manager.py
@@ -461,5 +461,146 @@ class TestGraphCacheManagerBunkScenario(unittest.TestCase):
         assert self.cache.get_bunk_graph(101, 12345, 2025, scenario_id=None) is not None
 
 
+class TestGraphCacheManagerInvalidateScenario(unittest.TestCase):
+    """Surgical scenario-scoped invalidation.
+
+    Issue: after a solver re-run + apply, ``bunk_assignments_draft`` rows for
+    that scenario change but the cached session/bunk graphs in the scenario
+    slot are served stale for up to TTL (15 min). ``invalidate_scenario``
+    drops *only* that scenario's session key plus all bunk keys for the same
+    session+year+scenario, leaving prod and other scenarios untouched.
+    """
+
+    def setUp(self):
+        self.cache = GraphCacheManager(ttl_seconds=60, max_cache_size=20)
+
+        self.prod_graph = nx.DiGraph()
+        self.prod_graph.add_nodes_from([1, 2, 3])
+
+        self.scenario_graph = nx.DiGraph()
+        self.scenario_graph.add_nodes_from([10, 11, 12])
+
+        self.bunk_graph_a = nx.DiGraph()
+        self.bunk_graph_a.add_nodes_from([10, 11])
+
+        self.bunk_graph_b = nx.DiGraph()
+        self.bunk_graph_b.add_nodes_from([12])
+
+    def test_invalidate_scenario_drops_session_key(self):
+        """The session graph cached under the scenario slot is removed."""
+        self.cache.cache_session_graph(12345, 2025, self.scenario_graph, scenario_id="scn_abc")
+        assert self.cache.get_session_graph(12345, 2025, scenario_id="scn_abc") is not None
+
+        count = self.cache.invalidate_scenario(12345, 2025, "scn_abc")
+
+        assert count == 1
+        assert self.cache.get_session_graph(12345, 2025, scenario_id="scn_abc") is None
+
+    def test_invalidate_scenario_drops_all_bunk_keys_for_scenario(self):
+        """All bunk graphs for the same scenario+session+year are removed."""
+        self.cache.cache_bunk_graph(101, 12345, 2025, self.bunk_graph_a, scenario_id="scn_abc")
+        self.cache.cache_bunk_graph(102, 12345, 2025, self.bunk_graph_b, scenario_id="scn_abc")
+
+        count = self.cache.invalidate_scenario(12345, 2025, "scn_abc")
+
+        assert count == 2
+        assert self.cache.get_bunk_graph(101, 12345, 2025, scenario_id="scn_abc") is None
+        assert self.cache.get_bunk_graph(102, 12345, 2025, scenario_id="scn_abc") is None
+
+    def test_invalidate_scenario_drops_session_and_bunks_together(self):
+        """One call drops both the session entry and every bunk entry for that scenario."""
+        self.cache.cache_session_graph(12345, 2025, self.scenario_graph, scenario_id="scn_abc")
+        self.cache.cache_bunk_graph(101, 12345, 2025, self.bunk_graph_a, scenario_id="scn_abc")
+        self.cache.cache_bunk_graph(102, 12345, 2025, self.bunk_graph_b, scenario_id="scn_abc")
+
+        count = self.cache.invalidate_scenario(12345, 2025, "scn_abc")
+
+        assert count == 3
+        assert self.cache.get_session_graph(12345, 2025, scenario_id="scn_abc") is None
+        assert self.cache.get_bunk_graph(101, 12345, 2025, scenario_id="scn_abc") is None
+        assert self.cache.get_bunk_graph(102, 12345, 2025, scenario_id="scn_abc") is None
+
+    def test_invalidate_scenario_preserves_prod_cache(self):
+        """Production cache for the same session+year is untouched."""
+        self.cache.cache_session_graph(12345, 2025, self.prod_graph)  # prod
+        self.cache.cache_bunk_graph(101, 12345, 2025, self.prod_graph)  # prod
+        self.cache.cache_session_graph(12345, 2025, self.scenario_graph, scenario_id="scn_abc")
+        self.cache.cache_bunk_graph(101, 12345, 2025, self.bunk_graph_a, scenario_id="scn_abc")
+
+        self.cache.invalidate_scenario(12345, 2025, "scn_abc")
+
+        # Prod still cached
+        assert self.cache.get_session_graph(12345, 2025) is not None
+        assert self.cache.get_bunk_graph(101, 12345, 2025) is not None
+        # Scenario gone
+        assert self.cache.get_session_graph(12345, 2025, scenario_id="scn_abc") is None
+        assert self.cache.get_bunk_graph(101, 12345, 2025, scenario_id="scn_abc") is None
+
+    def test_invalidate_scenario_preserves_other_scenarios(self):
+        """Other scenarios for the same session+year are untouched."""
+        self.cache.cache_session_graph(12345, 2025, self.scenario_graph, scenario_id="scn_abc")
+        self.cache.cache_bunk_graph(101, 12345, 2025, self.bunk_graph_a, scenario_id="scn_abc")
+        self.cache.cache_session_graph(12345, 2025, self.scenario_graph, scenario_id="scn_xyz")
+        self.cache.cache_bunk_graph(101, 12345, 2025, self.bunk_graph_b, scenario_id="scn_xyz")
+
+        self.cache.invalidate_scenario(12345, 2025, "scn_abc")
+
+        # Other scenario survives
+        assert self.cache.get_session_graph(12345, 2025, scenario_id="scn_xyz") is not None
+        assert self.cache.get_bunk_graph(101, 12345, 2025, scenario_id="scn_xyz") is not None
+        # Targeted scenario gone
+        assert self.cache.get_session_graph(12345, 2025, scenario_id="scn_abc") is None
+        assert self.cache.get_bunk_graph(101, 12345, 2025, scenario_id="scn_abc") is None
+
+    def test_invalidate_scenario_preserves_other_sessions(self):
+        """Same scenario id used in a different session is not invalidated.
+
+        This is a defensive guard — in practice each scenario binds to one
+        session — but the cache key parser must not false-match.
+        """
+        self.cache.cache_session_graph(11111, 2025, self.scenario_graph, scenario_id="scn_abc")
+        self.cache.cache_bunk_graph(101, 11111, 2025, self.bunk_graph_a, scenario_id="scn_abc")
+        self.cache.cache_session_graph(22222, 2025, self.scenario_graph, scenario_id="scn_abc")
+        self.cache.cache_bunk_graph(101, 22222, 2025, self.bunk_graph_b, scenario_id="scn_abc")
+
+        self.cache.invalidate_scenario(11111, 2025, "scn_abc")
+
+        assert self.cache.get_session_graph(11111, 2025, scenario_id="scn_abc") is None
+        assert self.cache.get_bunk_graph(101, 11111, 2025, scenario_id="scn_abc") is None
+        assert self.cache.get_session_graph(22222, 2025, scenario_id="scn_abc") is not None
+        assert self.cache.get_bunk_graph(101, 22222, 2025, scenario_id="scn_abc") is not None
+
+    def test_invalidate_scenario_preserves_other_years(self):
+        """Same scenario id reused across years is not cross-invalidated."""
+        self.cache.cache_session_graph(12345, 2025, self.scenario_graph, scenario_id="scn_abc")
+        self.cache.cache_session_graph(12345, 2026, self.scenario_graph, scenario_id="scn_abc")
+
+        self.cache.invalidate_scenario(12345, 2025, "scn_abc")
+
+        assert self.cache.get_session_graph(12345, 2025, scenario_id="scn_abc") is None
+        assert self.cache.get_session_graph(12345, 2026, scenario_id="scn_abc") is not None
+
+    def test_invalidate_scenario_no_match_returns_zero(self):
+        """Calling on an empty/unmatched scenario returns 0."""
+        self.cache.cache_session_graph(12345, 2025, self.prod_graph)  # prod only
+
+        count = self.cache.invalidate_scenario(12345, 2025, "scn_abc")
+
+        assert count == 0
+        assert self.cache.get_session_graph(12345, 2025) is not None  # prod intact
+
+    def test_invalidate_scenario_does_not_match_scenario_id_substring(self):
+        """A scenario id that's a prefix of another id must not over-match."""
+        # 'abc' and 'abcd' are distinct slugs in cache keys. Splitting on '_' and
+        # comparing the slug field exactly guards against a substring match.
+        self.cache.cache_session_graph(12345, 2025, self.scenario_graph, scenario_id="abc")
+        self.cache.cache_session_graph(12345, 2025, self.scenario_graph, scenario_id="abcd")
+
+        self.cache.invalidate_scenario(12345, 2025, "abc")
+
+        assert self.cache.get_session_graph(12345, 2025, scenario_id="abc") is None
+        assert self.cache.get_session_graph(12345, 2025, scenario_id="abcd") is not None
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

The social-graph cache (`GraphCacheManager`, TTL 15 min, keyed by
`session_{cm_id}_{year}_{scenario_id|"prod"}`) was only invalidated by
drag-drop. **Every other writer to `bunk_assignments_draft` was leaking
stale graphs** — solver apply, bulk clear, scenario create/clear/delete,
single-assignment edits.

The user-visible symptom: rerunning the solver on a scenario + apply
left the previous draft's `bunk_cm_id` node attrs cached for up to
15 min. The frontend's bubble grouping then mismatched the active
assignments and rendered campers as one big lump.

## Changes

### New cache helper

`GraphCacheManager.invalidate_scenario(session_cm_id, year, scenario_id)`
in `bunking/graph/graph_cache_manager.py`:

- Drops only the named scenario's session key + every bunk key for that
  scenario+session+year. Production cache and other scenarios untouched.
- Slug match is positional on `parts[4:]` rejoined, so scenario ids that
  contain underscores match exactly and prefix collisions (`abc` vs
  `abcd`) cannot false-match.

### Wired into every writer

| Endpoint | File | Behavior |
|---|---|---|
| `POST /api/solver/apply/{run_id}` | `api/routers/solver.py` | scenario → `invalidate_scenario`, prod → `invalidate_session` |
| `POST /api/sessions/{cm_id}/clear-assignments` | `api/routers/solver.py` | per related session, scenario- or prod-aware |
| `PUT /api/scenarios/{id}/assignments` | `api/routers/scenarios.py` | invalidates after each mutating branch (delete, update, create) |
| `POST /api/scenarios/{id}/clear` | `api/routers/scenarios.py` | reads `session.cm_id` via expand before invalidating |
| `DELETE /api/scenarios/{id}` | `api/routers/scenarios.py` | same — also collapsed two `get_one` calls into one with expand |
| `POST /api/scenarios` (copy path) | `api/routers/scenarios.py` | defensive — covers slug reuse after delete |

## Test plan

- [x] Unit tests for `invalidate_scenario` cover: session-only / bunk-only / both / preserves prod / preserves other scenarios / preserves other sessions / preserves other years / no-match returns 0 / prefix-collision guard (9 cases)
- [x] Per-endpoint contract tests assert the correct invalidation method runs with the right args (8 tests, scenario + prod variants where applicable)
- [x] `ruff format`, `ruff check`, `mypy` clean
- [x] `tests/unit/sync/test_graph_cache_manager.py` 28 passed; `tests/unit/api/routers/` 137 passed (no regressions)
- [ ] Smoke test in dev: rerun solver on a scenario, hit `/api/sessions/{cm_id}/social-graph?scenario_id=...` immediately, confirm new `bunk_cm_id` values present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data consistency by resolving cache coherency issues for scenario operations (creation, deletion, updates, and assignments)
  * Fixed stale cache problems when applying solver results and clearing session assignments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->