### PR TITLE
fix(frontend): scope embedded sessions independently and preserve raw names

### DIFF
--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -604,19 +604,14 @@ export default function CamperDetailsPanel({
     return getSessionShortNameUtil(camper?.expand?.session ?? undefined)
   }
 
-  /** Get short display name for an enrollment's session. */
+  /** Short display name for an enrollment's session — same util as the header. */
   const getEnrollmentShortName = (enrollment: CurrentEnrollment): string => {
-    if (enrollment.sessionType === 'ag') return enrollment.sessionName
-    if (enrollment.sessionType === 'embedded') {
-      const match = enrollment.sessionName.match(/([23][ab])/i)
-      if (match) return `Session ${match[1]}`
-    }
-    if (enrollment.sessionType === 'main') {
-      const match = enrollment.sessionName.match(/(\d+)/)
-      if (match) return `Session ${match[1]}`
-    }
-    if (enrollment.sessionName.toLowerCase().includes('taste')) return 'Taste of Camp'
-    return enrollment.sessionName || 'Unknown'
+    return (
+      getSessionShortNameUtil({
+        session_type: enrollment.sessionType,
+        name: enrollment.sessionName,
+      }) ?? 'Unknown'
+    )
   }
 
   // Lock group context — used to compute friend-group alert

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -354,9 +354,16 @@ export default function SessionView() {
               <BunkRequestProvider sessionCmId={selectedSessionCmId}>
                 <RequestReviewPanel
                   sessionId={selectedSessionCmId}
+                  // Only AG children bundle into the parent's request review.
+                  // Embedded sub-sessions (Session 2a, Taste of Camp 2) are
+                  // independent — they share the parent's start or end date
+                  // (which is exactly why date-overlap classified them as
+                  // embedded), but they're shorter programs with their own
+                  // bunking, not full-duration sub-cabins. AG sessions ARE
+                  // full-duration sub-cabins of the parent and stay bundled.
                   relatedSessionIds={
                     selectedSession === session.cm_id.toString()
-                      ? [...subSessions.map((s) => s.cm_id), ...agSessions.map((s) => s.cm_id)]
+                      ? agSessions.map((s) => s.cm_id)
                       : []
                   }
                   year={currentYear}

--- a/frontend/src/hooks/session/useSessionData.ts
+++ b/frontend/src/hooks/session/useSessionData.ts
@@ -271,6 +271,10 @@ export function useBunkRequestsCount({
   agSessions,
 }: UseBunkRequestsCountOptions) {
   return useQuery({
+    // subSessions still listed in the cache key so the query refetches if the
+    // hierarchy changes, even though we no longer aggregate them into the
+    // count — keeps the badge in sync with `relatedSessionIds` on the Requests
+    // tab, which only bundles AG children of the parent.
     queryKey: queryKeys.bunkRequestsCount(
       selectedSession ?? '',
       currentYear,
@@ -299,23 +303,15 @@ export function useBunkRequestsCount({
         return getRequestsCount(parseInt(selectedSession, 10))
       }
 
-      // For main sessions, aggregate from main + sub + AG sessions
-      let totalCount = 0
+      // Main session: count = self + AG children only. Embedded sub-sessions
+      // (Session 2a, Taste of Camp 2) are independent — they have their own
+      // session view and their own count, so don't double-count them under
+      // the parent. Matches the `relatedSessionIds` scoping on the Requests
+      // tab.
+      let totalCount = await getRequestsCount(parseInt(selectedSession, 10))
 
-      // Main session
-      totalCount += await getRequestsCount(parseInt(selectedSession, 10))
-
-      // Sub-sessions
-      if (subSessions.length > 0) {
-        const subCountPromises = subSessions.map((s) => getRequestsCount(s.cm_id))
-        const subCounts = await Promise.all(subCountPromises)
-        totalCount += subCounts.reduce((a, b) => a + b, 0)
-      }
-
-      // AG sessions
       if (agSessions.length > 0) {
-        const agCountPromises = agSessions.map((s) => getRequestsCount(s.cm_id))
-        const agCounts = await Promise.all(agCountPromises)
+        const agCounts = await Promise.all(agSessions.map((s) => getRequestsCount(s.cm_id)))
         totalCount += agCounts.reduce((a, b) => a + b, 0)
       }
 

--- a/frontend/src/utils/sessionDisplay.test.ts
+++ b/frontend/src/utils/sessionDisplay.test.ts
@@ -357,7 +357,7 @@ describe('sessionDisplay utilities', () => {
       expect(getSessionShortName(null as any)).toBe(null)
     })
 
-    it('should handle quest sessions', () => {
+    it('should return raw name for quest sessions', () => {
       expect(getSessionShortName(s({ session_type: 'quest', name: 'Teen Adventure Quests' }))).toBe(
         'Teen Adventure Quests'
       )
@@ -367,56 +367,65 @@ describe('sessionDisplay utilities', () => {
       expect(getSessionShortName(s({ session_type: 'quest' }))).toBe('Quest')
     })
 
-    it('should handle AG sessions', () => {
+    it('should shorten AG session names', () => {
+      expect(
+        getSessionShortName(
+          s({ session_type: 'ag', name: 'All-Gender Cabin-Session 2 (7th & 8th grades)' })
+        )
+      ).toBe('AG 2 (7-8)')
+      expect(
+        getSessionShortName(
+          s({ session_type: 'ag', name: 'All-Gender Cabin-Session 4 (4th - 6th grades)' })
+        )
+      ).toBe('AG 4 (4-6)')
+    })
+
+    it('should shorten AG sessions without grade ranges', () => {
       expect(
         getSessionShortName(s({ session_type: 'ag', name: 'All-Gender Cabin-Session 2' }))
-      ).toBe('All-Gender Cabin-Session 2')
+      ).toBe('AG 2')
     })
 
     it('should fallback to "AG" for AG session without name', () => {
       expect(getSessionShortName(s({ session_type: 'ag' }))).toBe('AG')
     })
 
-    it('should extract embedded session pattern (Session 2a)', () => {
+    it('should return raw name for embedded sessions (Session 2a)', () => {
       expect(getSessionShortName(s({ session_type: 'embedded', name: 'Session 2a' }))).toBe(
         'Session 2a'
       )
     })
 
-    it('should extract embedded session pattern (Session 3b)', () => {
-      expect(getSessionShortName(s({ session_type: 'embedded', name: 'Session 3b' }))).toBe(
-        'Session 3b'
+    it('should return raw name for embedded Taste of Camp 2 (no suffix stripping)', () => {
+      expect(getSessionShortName(s({ session_type: 'embedded', name: 'Taste of Camp 2' }))).toBe(
+        'Taste of Camp 2'
       )
     })
 
-    it('should fallback to name for embedded session without pattern match', () => {
-      expect(getSessionShortName(s({ session_type: 'embedded', name: 'Special Session' }))).toBe(
-        'Special Session'
-      )
-    })
-
-    it('should extract main session number', () => {
+    it('should return raw name for main sessions', () => {
       expect(getSessionShortName(s({ session_type: 'main', name: 'Session 2' }))).toBe('Session 2')
     })
 
-    it('should extract main session number from full name', () => {
+    it('should return raw name for main Taste of Camp 1 (no suffix stripping)', () => {
+      expect(getSessionShortName(s({ session_type: 'main', name: 'Taste of Camp 1' }))).toBe(
+        'Taste of Camp 1'
+      )
+    })
+
+    it('should return raw name even when it contains digits and parens', () => {
+      // Real-world AG names are shortened, but other types keep their raw text.
       expect(
-        getSessionShortName(
-          s({
-            session_type: 'main',
-            name: 'Session 2 (Grades 4-6) June 1-14',
-          })
-        )
-      ).toBe('Session 2')
+        getSessionShortName(s({ session_type: 'main', name: 'Session 2 (Grades 4-6) June 1-14' }))
+      ).toBe('Session 2 (Grades 4-6) June 1-14')
     })
 
-    it('should handle "Taste of Camp" pattern regardless of session_type', () => {
-      expect(getSessionShortName(s({ name: 'Taste of Camp' }))).toBe('Taste of Camp')
-      expect(getSessionShortName(s({ name: 'Taste of Camp 2' }))).toBe('Taste of Camp')
-      expect(getSessionShortName(s({ name: 'TASTE of Camp' }))).toBe('Taste of Camp')
+    it('should preserve case for non-AG sessions', () => {
+      expect(getSessionShortName(s({ session_type: 'main', name: 'TASTE OF CAMP 2' }))).toBe(
+        'TASTE OF CAMP 2'
+      )
     })
 
-    it('should return name as-is for unknown session types', () => {
+    it('should return name as-is for family/other unknown session types', () => {
       expect(getSessionShortName(s({ session_type: 'family', name: 'Family Camp 1' }))).toBe(
         'Family Camp 1'
       )
@@ -428,16 +437,18 @@ describe('sessionDisplay utilities', () => {
       expect(getSessionShortName(s({ session_type: 'unknown' }))).toBe(null)
     })
 
-    it('should prioritize session_type over name pattern for quest', () => {
-      // Even if name contains "taste", quest type takes precedence
-      expect(
-        getSessionShortName(s({ session_type: 'quest', name: 'Quest: Taste Adventure' }))
-      ).toBe('Quest: Taste Adventure')
-    })
-
-    it('should handle case-insensitive taste pattern matching', () => {
-      expect(getSessionShortName(s({ name: 'TASTE OF CAMP' }))).toBe('Taste of Camp')
-      expect(getSessionShortName(s({ name: 'taste of camp 3' }))).toBe('Taste of Camp')
+    it('should not strip suffix for taste-named sessions of any type', () => {
+      // Regression: previously "Taste of Camp 2" was collapsed to "Taste of Camp"
+      // by a name-based check. Raw name is the desired behavior — the suffix
+      // is meaningful (1 vs 2 are different sessions).
+      expect(getSessionShortName(s({ name: 'Taste of Camp 1' }))).toBe('Taste of Camp 1')
+      expect(getSessionShortName(s({ name: 'Taste of Camp 2' }))).toBe('Taste of Camp 2')
+      expect(getSessionShortName(s({ session_type: 'main', name: 'Taste of Camp 1' }))).toBe(
+        'Taste of Camp 1'
+      )
+      expect(getSessionShortName(s({ session_type: 'embedded', name: 'Taste of Camp 2' }))).toBe(
+        'Taste of Camp 2'
+      )
     })
   })
 })

--- a/frontend/src/utils/sessionDisplay.ts
+++ b/frontend/src/utils/sessionDisplay.ts
@@ -2,30 +2,20 @@ import type { Session } from '../types/app-types'
 import type { SessionDateLookup } from './sessionUtils'
 
 /**
- * Get a canonical short display name for a session, handling all session types.
+ * Canonical short display name for a session — used by the camper page (full +
+ * pop-in modal headers), the journey timeline current row, and any other
+ * surface that needs a single source of truth for the chip-style label.
  *
- * Returns a concise session identifier suitable for UI display (e.g., in headers, quick stats).
- * Converges logic from CamperDetail.tsx and CamperDetailsPanel.tsx.
+ * Behavior:
+ *   - AG sessions are abbreviated via `shortenSessionName` because the raw AG
+ *     name ("All-Gender Cabin-Session 2 (7th & 8th grades)") is too long for a
+ *     header chip. Result is e.g. "AG 2 (7-8)".
+ *   - Every other session type returns its raw `name` unchanged. Real-world
+ *     names are already concise ("Session 2", "Session 2a", "Taste of Camp 2",
+ *     "Teen Adventure Quests"), and the trailing digit on Taste of Camp is
+ *     meaningful — Taste of Camp 1 and Taste of Camp 2 are different sessions.
  *
- * @param session The session object (with at least session_type and name fields)
- * @returns Short name (e.g., "Quest", "AG", "Session 2", "Session 2a", "Taste of Camp")
- *          or null if session is undefined/falsy
- *
- * @example
- *   getSessionShortName({ session_type: 'main', name: 'Session 2' })
- *   // → "Session 2"
- *
- *   getSessionShortName({ session_type: 'quest', name: 'Teen Adventure Quests' })
- *   // → "Teen Adventure Quests"
- *
- *   getSessionShortName({ session_type: 'ag', name: 'All-Gender Cabin-Session 2' })
- *   // → "All-Gender Cabin-Session 2"
- *
- *   getSessionShortName({ session_type: 'embedded', name: 'Session 2a' })
- *   // → "Session 2a"
- *
- *   getSessionShortName(undefined)
- *   // → null
+ * @returns Short name, or null if no session/name to display.
  */
 export function getSessionShortName(
   session:
@@ -37,28 +27,12 @@ export function getSessionShortName(
 ): string | null {
   if (!session) return null
 
-  // Quest sessions: return as-is (they don't follow "Session N" pattern)
+  if (session.session_type === 'ag') {
+    return session.name ? shortenSessionName(session.name) : 'AG'
+  }
+
   if (session.session_type === 'quest') return session.name ?? 'Quest'
 
-  // AG sessions: return name as-is (e.g., "All-Gender Cabin-Session 2")
-  if (session.session_type === 'ag') return session.name ?? 'AG'
-
-  // Embedded sessions: extract "Session 2a" pattern
-  if (session.session_type === 'embedded') {
-    const match = session.name?.match(/([23][ab])/i)
-    if (match) return `Session ${match[1]}`
-  }
-
-  // Main sessions: extract session number
-  if (session.session_type === 'main') {
-    const match = session.name?.match(/(\d+)/)
-    if (match) return `Session ${match[1]}`
-  }
-
-  // Taste of Camp pattern (name-based, not type-based)
-  if (session.name?.toLowerCase().includes('taste')) return 'Taste of Camp'
-
-  // Fallback: return name as-is, or null if no name
   return session.name ?? null
 }
 


### PR DESCRIPTION
## Summary

Two issues on the camper detail page when a camper is enrolled only in an embedded sub-session (e.g. Taste of Camp 2, which the date-overlap sync classifies as `embedded` with `parent_id` pointing at its main session because they share an end date).

### Bug 1 — display name dropped the suffix

`getSessionShortName` collapsed any session name containing "taste" to the bare `Taste of Camp`, dropping the meaningful `1`/`2` suffix. The same logic was duplicated inline in `CamperDetailsPanel.getEnrollmentShortName`. Meanwhile the journey-timeline sidebar used a third path (`getSessionDisplayNameFromString`) that already returned the raw name — so the same camper rendered as `Taste of Camp 2` in the sidebar and `Taste of Camp` in the header / pop-in / current-year row.

**Fix:** rewrote `getSessionShortName` as the single source of truth — AG names go through `shortenSessionName` (header chips can't fit `All-Gender Cabin-Session 2 (7th & 8th grades)`), every other type returns the raw name. Real-world session names are already concise. Removed the inline `getEnrollmentShortName` and pointed it at the shared util.

### Bug 2 — embedded children leaked into the parent's request review

When viewing the Requests tab on a parent main session, the panel queried `session_id IN [parent, ...embedded children, ...AG children]`. That bundled embedded sub-sessions' requests under the parent — so a Taste of Camp 2 request appeared on the Session 2 Requests tab even for campers not enrolled in Session 2 at all.

The Python backend (`session_repository.get_related_session_ids`) already treats embedded sessions as independent. The frontend was the outlier. Embedded sessions share the parent's start or end date by construction (that's why date-overlap classifies them as embedded), but they're shorter programs with their own bunking pipeline. Only AG sessions are full-duration sub-cabins of the parent and stay bundled.

**Fix:** updated the Requests tab `relatedSessionIds` and `useBunkRequestsCount` (the count badge that has to match) to bundle AG only. Embedded sub-sessions remain navigable via their own session view.

## Files

- `frontend/src/utils/sessionDisplay.ts` — `getSessionShortName` rewrite
- `frontend/src/utils/sessionDisplay.test.ts` — flipped 7 assertions to lock in raw-name behavior, added regression coverage for Taste of Camp 1/2
- `frontend/src/components/CamperDetailsPanel.tsx` — removed inline `getEnrollmentShortName`, routes through shared util
- `frontend/src/components/SessionView.tsx` — `relatedSessionIds` now AG-only
- `frontend/src/hooks/session/useSessionData.ts` — `useBunkRequestsCount` matches the new scoping

## Test plan

- [x] `npx vitest run` — 3671 passed
- [x] `npx tsc --noEmit` — no errors
- [x] `eslint` on changed files — 0 errors (pre-existing warnings in untouched lines)
- [x] `prettier --check` on changed files
- [ ] Visual: open camper detail for an embedded-only camper, confirm header / pop-in / journey current row all show full name (e.g. `Taste of Camp 2`)
- [ ] Visual: open Session 2 Requests tab, confirm only Session 2 + AG children's requests appear; embedded children's requests don't leak in
- [ ] Visual: count badge on the Requests tab matches the row count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Streamlined how session names display across the interface: AG sessions show shortened grade-style names; Quest sessions show raw names (with sensible fallbacks); other sessions preserve raw names.
  * Requests tab now limits related-session grouping to AG child sessions when viewing a parent session.
  * Bunk-request totals for a main session now aggregate only AG child-session counts.
* **Tests**
  * Updated tests to reflect new session-naming and fallback behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->