### PR TITLE
feat(sync): reconcile bunk_requests against attendee state

### DIFF
--- a/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
@@ -307,6 +307,9 @@ class RequestOrchestrator:
             "ai_high_confidence": 0,
             "ai_manual_review": 0,
             "phase1_failed": 0,
+            # Phase C target-decline sidecar (#1069)
+            "target_declined_count": 0,
+            "target_declined_errors": 0,
         }
         self._phase1_first_error: str | None = None
 
@@ -1680,15 +1683,22 @@ class RequestOrchestrator:
         # Phase C (#1069): sweep bunk_requests for stale rows where the
         # requestee is no longer attending or now in a different session,
         # and decline them in place. Sidecar: usually empty, never fails
-        # the pipeline.
-        try:
-            target_decline_stats = run_target_decline_phase(self.pb, self.year)
-            self._stats["target_declined_count"] = target_decline_stats.get("declined_count", 0)
-            self._stats["target_declined_errors"] = target_decline_stats.get("error_count", 0)
-        except Exception:
-            logger.exception("target_decline phase raised; continuing")
-            self._stats["target_declined_count"] = 0
-            self._stats["target_declined_errors"] = 1
+        # the pipeline. Skipped under dry_run since it issues real writes.
+        if dry_run:
+            logger.info("=== Skipping Phase C target-decline (dry_run=True) ===")
+        else:
+            try:
+                target_decline_stats = run_target_decline_phase(self.pb, self.year)
+                self._stats["target_declined_count"] = target_decline_stats.get("declined_count", 0)
+                self._stats["target_declined_errors"] = target_decline_stats.get("error_count", 0)
+            except Exception:
+                logger.exception("target_decline phase raised; continuing")
+                self._stats["target_declined_errors"] = 1
+            logger.info(
+                f"Phase C target-decline: "
+                f"declined={self._stats['target_declined_count']}, "
+                f"errors={self._stats['target_declined_errors']}"
+            )
 
         # Log cache statistics if monitor is available
         if self.cache_monitor:

--- a/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
@@ -76,6 +76,7 @@ from ..social.social_graph import SocialGraph
 from ..validation.request_type_validator import validate_request_type_for_field
 from ..validation.rules.self_reference import SelfReferenceRule
 from .reconciliation import log_obr_reconciliation
+from .target_decline import run_target_decline_phase
 
 logger = get_logger(__name__)
 
@@ -1675,6 +1676,19 @@ class RequestOrchestrator:
         # #943: emit a single top-level OBR -> BR reconciliation line so the
         # full pipeline math is verifiable from the log alone.
         log_obr_reconciliation(self._stats)
+
+        # Phase C (#1069): sweep bunk_requests for stale rows where the
+        # requestee is no longer attending or now in a different session,
+        # and decline them in place. Sidecar: usually empty, never fails
+        # the pipeline.
+        try:
+            target_decline_stats = run_target_decline_phase(self.pb, self.year)
+            self._stats["target_declined_count"] = target_decline_stats.get("declined_count", 0)
+            self._stats["target_declined_errors"] = target_decline_stats.get("error_count", 0)
+        except Exception:
+            logger.exception("target_decline phase raised; continuing")
+            self._stats["target_declined_count"] = 0
+            self._stats["target_declined_errors"] = 1
 
         # Log cache statistics if monitor is available
         if self.cache_monitor:

--- a/bunking/sync/bunk_request_processor/orchestrator/reconciliation.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/reconciliation.py
@@ -36,6 +36,9 @@ _RECONCILIATION_KEYS = (
     "status_resolved",
     "status_pending",
     "status_declined",
+    # Phase C target-decline sidecar (#1069)
+    "target_declined_count",
+    "target_declined_errors",
 )
 
 
@@ -72,6 +75,8 @@ def format_obr_reconciliation(stats: dict[str, Any]) -> str:
         f" ({s['status_resolved']} resolved"
         f" / {s['status_pending']} pending"
         f" / {s['status_declined']} declined)"
+        f" | Phase C: {s['target_declined_count']} target-declined"
+        f" ({s['target_declined_errors']} errors)"
     )
 
 

--- a/bunking/sync/bunk_request_processor/orchestrator/target_decline.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/target_decline.py
@@ -1,0 +1,197 @@
+"""Phase C: target-decline sidecar.
+
+After the OBR-driven pipeline completes, sweep `bunk_requests` for any
+non-declined rows whose `requestee_id` refers to a person who is no longer
+attending (status_id != 2) or now sits in a different session for the year,
+and decline them in place using the canonical disposition_reason vocabulary
+(`target_not_attending`, `session_mismatch`).
+
+This is the requestee-side complement to:
+  - the orphan purge in the Go bunk_requests CSV sync (deletes BRs/OBRs
+    when the requester is no longer enrolled)
+  - reconcile_request_lifecycle (marks OBRs unprocessed for moved
+    requesters so process_requests rebuilds them)
+
+Both halves running together close the gap where attendee state changes
+silently leave stale `resolved` rows in `bunk_requests` between CSV uploads.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from bunking.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class TargetDeclineAction:
+    """A single bunk_requests row to decline with a specific reason."""
+
+    bunk_request_id: str
+    reason: str  # "target_not_attending" or "session_mismatch"
+
+
+def compute_target_decline_actions(
+    bunk_requests: list[dict[str, Any]],
+    inactive_cm_ids: set[int],
+    active_session_by_cm_id: dict[int, int],
+) -> list[TargetDeclineAction]:
+    """Pure-function decision: which BRs need to be declined and why.
+
+    Args:
+        bunk_requests: rows with at least `id`, `requestee_id`, `session_id`,
+            `status` keys.
+        inactive_cm_ids: cm_ids of attendees whose status_id is not 2 in
+            this year.
+        active_session_by_cm_id: cm_id → current session_cm_id for attendees
+            with status_id == 2.
+
+    Returns:
+        One `TargetDeclineAction` per BR that should flip to declined.
+        Already-declined rows are skipped. Rows with no `requestee_id`
+        (placeholders, age preferences) are skipped. Inactive takes
+        precedence over session mismatch.
+    """
+    actions: list[TargetDeclineAction] = []
+    for br in bunk_requests:
+        if br.get("status") == "declined":
+            continue
+        requestee = br.get("requestee_id")
+        if not requestee:
+            continue
+        if requestee in inactive_cm_ids:
+            actions.append(TargetDeclineAction(bunk_request_id=br["id"], reason="target_not_attending"))
+            continue
+        if requestee in active_session_by_cm_id:
+            current = active_session_by_cm_id[requestee]
+            stored = br.get("session_id")
+            if stored != current:
+                actions.append(TargetDeclineAction(bunk_request_id=br["id"], reason="session_mismatch"))
+    return actions
+
+
+def run_target_decline_phase(pb_client: Any, year: int) -> dict[str, int]:
+    """End-to-end Phase C runner for use inside the orchestrator pipeline.
+
+    Fetches the year's attendees and bunk_requests, computes which BRs should
+    flip to declined, and applies the updates. Empty inputs ⇒ empty stats.
+
+    Errors are caught and logged; this phase MUST NOT fail the surrounding
+    pipeline (it's a sidecar that is usually empty).
+
+    Returns the same stats dict as `apply_target_decline`, plus an
+    `error_count` if the top-level fetch fails.
+    """
+    try:
+        attendees = pb_client.collection("attendees").get_full_list(
+            query_params={"filter": f"year = {year}", "expand": "session"},
+        )
+    except Exception as e:
+        logger.warning(f"target_decline: failed to fetch attendees: {e}")
+        return {"declined_count": 0, "error_count": 1}
+
+    inactive_cm_ids: set[int] = set()
+    active_session_by_cm_id: dict[int, int] = {}
+    for a in attendees:
+        person_id = getattr(a, "person_id", None)
+        status_id = getattr(a, "status_id", None)
+        if not person_id:
+            continue
+        if status_id == 2:
+            session_cm_id = _attendee_session_cm_id(a)
+            if session_cm_id:
+                active_session_by_cm_id[int(person_id)] = int(session_cm_id)
+        else:
+            inactive_cm_ids.add(int(person_id))
+
+    try:
+        brs = pb_client.collection("bunk_requests").get_full_list(
+            query_params={"filter": f"year = {year}"},
+        )
+    except Exception as e:
+        logger.warning(f"target_decline: failed to fetch bunk_requests: {e}")
+        return {"declined_count": 0, "error_count": 1}
+
+    br_dicts: list[dict[str, Any]] = [
+        {
+            "id": getattr(br, "id", None),
+            "requestee_id": getattr(br, "requestee_id", None),
+            "session_id": getattr(br, "session_id", None),
+            "status": getattr(br, "status", None),
+        }
+        for br in brs
+    ]
+
+    actions = compute_target_decline_actions(
+        bunk_requests=br_dicts,
+        inactive_cm_ids=inactive_cm_ids,
+        active_session_by_cm_id=active_session_by_cm_id,
+    )
+    if not actions:
+        logger.debug(f"target_decline: no actions for year={year}")
+        return {"declined_count": 0, "error_count": 0}
+
+    logger.info(
+        f"target_decline: declining {len(actions)} bunk_requests "
+        f"(year={year}, inactive_targets={len(inactive_cm_ids)}, "
+        f"moved_targets={len(active_session_by_cm_id)})"
+    )
+    return apply_target_decline(pb_client, actions)
+
+
+def _attendee_session_cm_id(attendee: Any) -> int | None:
+    """Read the session.cm_id from an attendee record returned by PocketBase.
+
+    Handles both expanded relations (`expand.session.cm_id`) and raw
+    `session_id` fallback. Returns None if neither is available.
+    """
+    expand = getattr(attendee, "expand", None)
+    if expand is not None:
+        session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+        if session is not None:
+            cm_id = getattr(session, "cm_id", None)
+            if cm_id:
+                return int(cm_id)
+    direct = getattr(attendee, "session_id", None)
+    if direct:
+        return int(direct)
+    return None
+
+
+def apply_target_decline(
+    pb_client: Any,
+    actions: list[TargetDeclineAction],
+) -> dict[str, int]:
+    """Apply each action by updating the corresponding bunk_requests row.
+
+    A failure on one row is logged but does not stop the others. Phase C is
+    a sidecar; it should never fail the surrounding pipeline.
+
+    Args:
+        pb_client: PocketBase client (or wrapper) with
+            `.collection("bunk_requests").update(id, data)` available.
+        actions: list returned by `compute_target_decline_actions`.
+
+    Returns:
+        Stats dict: {"declined_count": int, "error_count": int}
+    """
+    stats = {"declined_count": 0, "error_count": 0}
+    if not actions:
+        return stats
+
+    collection = pb_client.collection("bunk_requests")
+    for action in actions:
+        payload = {
+            "status": "declined",
+            "disposition_reason": action.reason,
+        }
+        try:
+            collection.update(action.bunk_request_id, payload)
+            stats["declined_count"] += 1
+        except Exception as e:
+            stats["error_count"] += 1
+            logger.warning(f"target_decline: failed to update {action.bunk_request_id} (reason={action.reason}): {e}")
+    return stats

--- a/bunking/sync/bunk_request_processor/orchestrator/target_decline.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/target_decline.py
@@ -2,9 +2,15 @@
 
 After the OBR-driven pipeline completes, sweep `bunk_requests` for any
 non-declined rows whose `requestee_id` refers to a person who is no longer
-attending (status_id != 2) or now sits in a different session for the year,
-and decline them in place using the canonical disposition_reason vocabulary
+actively enrolled in the BR's session for the year, and decline them in
+place using the canonical disposition_reason vocabulary
 (`target_not_attending`, `session_mismatch`).
+
+Active enrollment is keyed per-session: a person can be enrolled in
+multiple sessions in the same year, and a separate cancelled/withdrawn row
+on another session does not invalidate their active enrollments. Phase C
+treats only `status_id == 2` rows as authoritative for "where this person
+currently is".
 
 This is the requestee-side complement to:
   - the orphan purge in the Go bunk_requests CSV sync (deletes BRs/OBRs
@@ -36,24 +42,21 @@ class TargetDeclineAction:
 
 def compute_target_decline_actions(
     bunk_requests: list[dict[str, Any]],
-    inactive_cm_ids: set[int],
-    active_session_by_cm_id: dict[int, int],
+    active_sessions_by_cm_id: dict[int, set[int]],
 ) -> list[TargetDeclineAction]:
     """Pure-function decision: which BRs need to be declined and why.
 
     Args:
         bunk_requests: rows with at least `id`, `requestee_id`, `session_id`,
             `status` keys.
-        inactive_cm_ids: cm_ids of attendees whose status_id is not 2 in
-            this year.
-        active_session_by_cm_id: cm_id → current session_cm_id for attendees
-            with status_id == 2.
+        active_sessions_by_cm_id: cm_id → set of session_cm_ids the person is
+            actively enrolled in (status_id == 2). A person absent from this
+            map has no active enrollment and is treated as not attending.
 
     Returns:
         One `TargetDeclineAction` per BR that should flip to declined.
         Already-declined rows are skipped. Rows with no `requestee_id`
-        (placeholders, age preferences) are skipped. Inactive takes
-        precedence over session mismatch.
+        (placeholders, age preferences) are skipped.
     """
     actions: list[TargetDeclineAction] = []
     for br in bunk_requests:
@@ -62,14 +65,12 @@ def compute_target_decline_actions(
         requestee = br.get("requestee_id")
         if not requestee:
             continue
-        if requestee in inactive_cm_ids:
+        active_sessions = active_sessions_by_cm_id.get(requestee)
+        if not active_sessions:
             actions.append(TargetDeclineAction(bunk_request_id=br["id"], reason="target_not_attending"))
             continue
-        if requestee in active_session_by_cm_id:
-            current = active_session_by_cm_id[requestee]
-            stored = br.get("session_id")
-            if stored != current:
-                actions.append(TargetDeclineAction(bunk_request_id=br["id"], reason="session_mismatch"))
+        if br.get("session_id") not in active_sessions:
+            actions.append(TargetDeclineAction(bunk_request_id=br["id"], reason="session_mismatch"))
     return actions
 
 
@@ -93,19 +94,16 @@ def run_target_decline_phase(pb_client: Any, year: int) -> dict[str, int]:
         logger.warning(f"target_decline: failed to fetch attendees: {e}")
         return {"declined_count": 0, "error_count": 1}
 
-    inactive_cm_ids: set[int] = set()
-    active_session_by_cm_id: dict[int, int] = {}
+    active_sessions_by_cm_id: dict[int, set[int]] = {}
     for a in attendees:
         person_id = getattr(a, "person_id", None)
         status_id = getattr(a, "status_id", None)
-        if not person_id:
+        if not person_id or status_id != 2:
             continue
-        if status_id == 2:
-            session_cm_id = _attendee_session_cm_id(a)
-            if session_cm_id:
-                active_session_by_cm_id[int(person_id)] = int(session_cm_id)
-        else:
-            inactive_cm_ids.add(int(person_id))
+        session_cm_id = _attendee_session_cm_id(a)
+        if session_cm_id is None:
+            continue
+        active_sessions_by_cm_id.setdefault(int(person_id), set()).add(int(session_cm_id))
 
     try:
         brs = pb_client.collection("bunk_requests").get_full_list(
@@ -127,8 +125,7 @@ def run_target_decline_phase(pb_client: Any, year: int) -> dict[str, int]:
 
     actions = compute_target_decline_actions(
         bunk_requests=br_dicts,
-        inactive_cm_ids=inactive_cm_ids,
-        active_session_by_cm_id=active_session_by_cm_id,
+        active_sessions_by_cm_id=active_sessions_by_cm_id,
     )
     if not actions:
         logger.debug(f"target_decline: no actions for year={year}")
@@ -136,8 +133,7 @@ def run_target_decline_phase(pb_client: Any, year: int) -> dict[str, int]:
 
     logger.info(
         f"target_decline: declining {len(actions)} bunk_requests "
-        f"(year={year}, inactive_targets={len(inactive_cm_ids)}, "
-        f"moved_targets={len(active_session_by_cm_id)})"
+        f"(year={year}, active_targets={len(active_sessions_by_cm_id)})"
     )
     return apply_target_decline(pb_client, actions)
 
@@ -145,20 +141,21 @@ def run_target_decline_phase(pb_client: Any, year: int) -> dict[str, int]:
 def _attendee_session_cm_id(attendee: Any) -> int | None:
     """Read the session.cm_id from an attendee record returned by PocketBase.
 
-    Handles both expanded relations (`expand.session.cm_id`) and raw
-    `session_id` fallback. Returns None if neither is available.
+    Reads the expanded relation (`expand.session.cm_id`). Returns None if
+    expand isn't available or the session has no cm_id — Phase C silently
+    drops such rows rather than guessing, since attendees.session is a
+    PocketBase relation ID (string) and cannot be substituted for cm_id.
     """
     expand = getattr(attendee, "expand", None)
-    if expand is not None:
-        session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
-        if session is not None:
-            cm_id = getattr(session, "cm_id", None)
-            if cm_id:
-                return int(cm_id)
-    direct = getattr(attendee, "session_id", None)
-    if direct:
-        return int(direct)
-    return None
+    if expand is None:
+        return None
+    session = expand.get("session") if isinstance(expand, dict) else getattr(expand, "session", None)
+    if session is None:
+        return None
+    cm_id = getattr(session, "cm_id", None)
+    if cm_id is None:
+        return None
+    return int(cm_id)
 
 
 def apply_target_decline(

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -92,6 +92,7 @@ var syncJobMeta = []JobMeta{
 	{"enrollment_snapshots", PhaseTransform, "Capture daily enrollment counts per session"},
 
 	// Process phase - CSV + AI
+	{"reconcile_request_lifecycle", PhaseProcess, "Mark moved-requester OBRs for reprocessing"},
 	{"bunk_requests", PhaseProcess, "Import bunk request CSV"},
 	{"process_requests", PhaseProcess, "AI processing of bunk requests"},
 
@@ -725,7 +726,8 @@ func (o *Orchestrator) RunDailySync(ctx context.Context) error {
 		"staff_vehicle_info",
 		"normalize_geographic",
 		"enrollment_snapshots",
-		"bunk_requests", // CSV import, depends on persons
+		"reconcile_request_lifecycle", // Detect session moves; marks OBRs for reprocessing
+		"bunk_requests",               // CSV import, depends on persons
 	}
 
 	// Only include process_requests in production (Docker) mode
@@ -1116,7 +1118,7 @@ func (o *Orchestrator) RunSyncWithOptions(ctx context.Context, opts Options) err
 		// and there's no need to re-process them for historical years
 		// opts.Year > 0 means this is a historical sync with a specific year
 		if opts.Year == 0 {
-			servicesToRun = append(servicesToRun, "bunk_requests")
+			servicesToRun = append(servicesToRun, "reconcile_request_lifecycle", "bunk_requests")
 			// Only include process_requests in production (Docker) mode
 			// In development, skip AI processing to avoid unnecessary API costs
 			if os.Getenv("IS_DOCKER") == boolTrueStr {
@@ -1191,6 +1193,9 @@ func (o *Orchestrator) RunSyncWithOptions(ctx context.Context, opts Options) err
 		o.RegisterService("bunks", NewBunksSync(o.app, yearClient))
 		o.RegisterService("bunk_plans", NewBunkPlansSync(o.app, yearClient))
 		o.RegisterService("bunk_assignments", NewBunkAssignmentsSync(o.app, yearClient))
+		yearReconcileSync := NewReconcileLifecycleSync(o.app)
+		yearReconcileSync.Year = opts.Year
+		o.RegisterService("reconcile_request_lifecycle", yearReconcileSync)
 		o.RegisterService("bunk_requests", NewBunkRequestsSync(o.app, yearClient))
 		yearProcessor := NewRequestProcessor(o.app)
 		yearProcessor.CollectTraces = true // Always collect traces for scheduled/automated runs
@@ -1732,6 +1737,7 @@ func (o *Orchestrator) InitializeSyncServices() error {
 	o.RegisterService("bunks", NewBunksSync(o.app, client))
 	o.RegisterService("bunk_plans", NewBunkPlansSync(o.app, client))
 	o.RegisterService("bunk_assignments", NewBunkAssignmentsSync(o.app, client))
+	o.RegisterService("reconcile_request_lifecycle", NewReconcileLifecycleSync(o.app))
 	o.RegisterService("bunk_requests", NewBunkRequestsSync(o.app, client))
 	// Register the request processor (no CampMinder client needed)
 	processor := NewRequestProcessor(o.app)

--- a/pocketbase/sync/reconcile_request_lifecycle.go
+++ b/pocketbase/sync/reconcile_request_lifecycle.go
@@ -1,0 +1,235 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+const serviceNameReconcileLifecycle = "reconcile_request_lifecycle"
+
+// ReconcileLifecycleSync detects requesters whose current attendees.session
+// differs from the session_id stored on their bunk_requests rows, and marks
+// their original_bunk_requests as processed=” so process_requests rebuilds
+// them with the correct session.
+//
+// This complements the orphan-purge in bunk_requests sync (which handles
+// cancellations by deleting OBRs/BRs for requesters no longer enrolled) and
+// the Phase C target-decline sidecar in process_requests (which handles
+// requestee-side stale rows by direct UPDATE).
+type ReconcileLifecycleSync struct {
+	App   core.App
+	Year  int
+	Debug bool
+	Stats Stats
+}
+
+// NewReconcileLifecycleSync constructs the sync service.
+func NewReconcileLifecycleSync(app core.App) *ReconcileLifecycleSync {
+	return &ReconcileLifecycleSync{App: app}
+}
+
+// Name returns the orchestrator-facing service name.
+func (s *ReconcileLifecycleSync) Name() string {
+	return serviceNameReconcileLifecycle
+}
+
+// GetStats returns the current stats snapshot.
+func (s *ReconcileLifecycleSync) GetStats() Stats {
+	return s.Stats
+}
+
+// SetDebug toggles verbose logging (orchestrator hook).
+func (s *ReconcileLifecycleSync) SetDebug(debug bool) {
+	s.Debug = debug
+}
+
+// SetYear sets the year for this run (orchestrator hook).
+func (s *ReconcileLifecycleSync) SetYear(year int) {
+	s.Year = year
+}
+
+// WasSuccessful indicates whether the last run encountered no errors.
+func (s *ReconcileLifecycleSync) WasSuccessful() bool {
+	return s.Stats.Errors == 0
+}
+
+// Sync runs the reconciliation against the configured year.
+func (s *ReconcileLifecycleSync) Sync(_ context.Context) error {
+	if s.Year == 0 {
+		return fmt.Errorf("reconcile_request_lifecycle: Year not set")
+	}
+	if err := reconcileRequestLifecycle(s.App, s.Year); err != nil {
+		s.Stats.Errors++
+		return err
+	}
+	return nil
+}
+
+// findMovedRequesters returns the cm_ids of requesters with at least one
+// bunk_requests row whose session_id differs from the requester's current
+// attendees.session. Requesters absent from currentSessions (i.e. no longer
+// enrolled) are skipped — those are handled by the existing orphan purge in
+// bunk_requests sync, not here.
+func findMovedRequesters(currentSessions map[int]int, storedBRSessions map[int][]int) []int {
+	moved := []int{}
+	for cmID, currentSession := range currentSessions {
+		stored, ok := storedBRSessions[cmID]
+		if !ok || len(stored) == 0 {
+			continue
+		}
+		for _, s := range stored {
+			if s != currentSession {
+				moved = append(moved, cmID)
+				break
+			}
+		}
+	}
+	return moved
+}
+
+// reconcileRequestLifecycle is the integration logic. It:
+//  1. Loads currently-enrolled (status_id=2) attendees for the year and
+//     their session cm_ids.
+//  2. Loads bunk_requests for the year and groups session_ids by requester_id.
+//  3. Calls findMovedRequesters to compute the cm_ids needing rebuild.
+//  4. For each, marks all of their OBRs in the year as processed=”.
+func reconcileRequestLifecycle(app core.App, year int) error {
+	currentSessions, err := loadEnrolledRequesterSessions(app, year)
+	if err != nil {
+		return fmt.Errorf("loading enrolled sessions: %w", err)
+	}
+	storedSessions, err := loadStoredBRSessions(app, year)
+	if err != nil {
+		return fmt.Errorf("loading bunk_requests sessions: %w", err)
+	}
+
+	moved := findMovedRequesters(currentSessions, storedSessions)
+	if len(moved) == 0 {
+		slog.Debug("reconcile_request_lifecycle: no moved requesters", "year", year)
+		return nil
+	}
+
+	for _, cmID := range moved {
+		if err := markRequesterOBRsUnprocessed(app, cmID, year); err != nil {
+			slog.Error("reconcile_request_lifecycle: mark OBRs unprocessed",
+				"cm_id", cmID, "year", year, "error", err)
+		}
+	}
+
+	slog.Info("reconcile_request_lifecycle complete",
+		"year", year, "moved_requesters", len(moved))
+	return nil
+}
+
+// loadEnrolledRequesterSessions returns a map of person cm_id -> session cm_id
+// for attendees with status_id=2 in the given year.
+func loadEnrolledRequesterSessions(app core.App, year int) (map[int]int, error) {
+	attendees, err := app.FindRecordsByFilter(
+		"attendees",
+		fmt.Sprintf("year = %d && status_id = 2", year),
+		"", 0, 0,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query attendees: %w", err)
+	}
+	if errs := app.ExpandRecords(attendees, []string{"session"}, nil); len(errs) > 0 {
+		slog.Warn("reconcile_request_lifecycle: some session expansions failed",
+			"errors", errs)
+	}
+
+	out := make(map[int]int, len(attendees))
+	for _, a := range attendees {
+		personCMID, ok := a.Get("person_id").(float64)
+		if !ok {
+			continue
+		}
+		session := a.ExpandedOne("session")
+		if session == nil {
+			continue
+		}
+		sessionCMID, ok := session.Get("cm_id").(float64)
+		if !ok {
+			continue
+		}
+		out[int(personCMID)] = int(sessionCMID)
+	}
+	return out, nil
+}
+
+// loadStoredBRSessions returns a map of requester cm_id -> distinct
+// session_ids stored on their bunk_requests rows for the year.
+func loadStoredBRSessions(app core.App, year int) (map[int][]int, error) {
+	rows, err := app.FindRecordsByFilter(
+		"bunk_requests",
+		fmt.Sprintf("year = %d", year),
+		"", 0, 0,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query bunk_requests: %w", err)
+	}
+
+	seen := make(map[int]map[int]bool)
+	for _, r := range rows {
+		requesterID, ok := r.Get("requester_id").(float64)
+		if !ok {
+			continue
+		}
+		sessionID, ok := r.Get("session_id").(float64)
+		if !ok {
+			continue
+		}
+		key := int(requesterID)
+		if seen[key] == nil {
+			seen[key] = make(map[int]bool)
+		}
+		seen[key][int(sessionID)] = true
+	}
+
+	out := make(map[int][]int, len(seen))
+	for cmID, sessions := range seen {
+		list := make([]int, 0, len(sessions))
+		for s := range sessions {
+			list = append(list, s)
+		}
+		out[cmID] = list
+	}
+	return out, nil
+}
+
+// markRequesterOBRsUnprocessed flips the `processed` flag to ” on every OBR
+// for the given requester and year, so process_requests will re-evaluate
+// them against current attendees state.
+func markRequesterOBRsUnprocessed(app core.App, requesterCMID, year int) error {
+	persons, err := app.FindRecordsByFilter(
+		"persons",
+		fmt.Sprintf("cm_id = %d", requesterCMID),
+		"", 1, 0,
+	)
+	if err != nil {
+		return fmt.Errorf("find person %d: %w", requesterCMID, err)
+	}
+	if len(persons) == 0 {
+		return nil
+	}
+	personPBID := persons[0].Id
+
+	obrs, err := app.FindRecordsByFilter(
+		"original_bunk_requests",
+		fmt.Sprintf("requester = '%s' && year = %d", personPBID, year),
+		"", 0, 0,
+	)
+	if err != nil {
+		return fmt.Errorf("find OBRs for person %d: %w", requesterCMID, err)
+	}
+
+	for _, obr := range obrs {
+		obr.Set("processed", "")
+		if err := app.Save(obr); err != nil {
+			return fmt.Errorf("save OBR %s: %w", obr.Id, err)
+		}
+	}
+	return nil
+}

--- a/pocketbase/sync/reconcile_request_lifecycle.go
+++ b/pocketbase/sync/reconcile_request_lifecycle.go
@@ -56,12 +56,23 @@ func (s *ReconcileLifecycleSync) WasSuccessful() bool {
 	return s.Stats.Errors == 0
 }
 
-// Sync runs the reconciliation against the configured year.
+// Sync runs the reconciliation against the configured year. When Year is 0
+// (the daily-sync registration path in InitializeSyncServices), falls back
+// to CAMPMINDER_SEASON_ID via ParseSeasonYear, matching the convention used
+// by every other yearless service in this package.
 func (s *ReconcileLifecycleSync) Sync(_ context.Context) error {
-	if s.Year == 0 {
-		return fmt.Errorf("reconcile_request_lifecycle: Year not set")
+	year := s.Year
+	if year == 0 {
+		var err error
+		year, err = ParseSeasonYear()
+		if err != nil {
+			s.Stats.Errors++
+			return fmt.Errorf("reconcile_request_lifecycle: year resolution failed: %w", err)
+		}
 	}
-	if err := reconcileRequestLifecycle(s.App, s.Year); err != nil {
+	markErrors, err := reconcileRequestLifecycle(s.App, year)
+	s.Stats.Errors += markErrors
+	if err != nil {
 		s.Stats.Errors++
 		return err
 	}
@@ -96,32 +107,38 @@ func findMovedRequesters(currentSessions map[int]int, storedBRSessions map[int][
 //  2. Loads bunk_requests for the year and groups session_ids by requester_id.
 //  3. Calls findMovedRequesters to compute the cm_ids needing rebuild.
 //  4. For each, marks all of their OBRs in the year as processed=”.
-func reconcileRequestLifecycle(app core.App, year int) error {
+//
+// Returns (markErrors, err) where markErrors counts per-cm save failures
+// that did not fail the overall run (sidecar continues on partial failure
+// but surfaces the count to Stats so WasSuccessful() reflects reality).
+func reconcileRequestLifecycle(app core.App, year int) (int, error) {
 	currentSessions, err := loadEnrolledRequesterSessions(app, year)
 	if err != nil {
-		return fmt.Errorf("loading enrolled sessions: %w", err)
+		return 0, fmt.Errorf("loading enrolled sessions: %w", err)
 	}
 	storedSessions, err := loadStoredBRSessions(app, year)
 	if err != nil {
-		return fmt.Errorf("loading bunk_requests sessions: %w", err)
+		return 0, fmt.Errorf("loading bunk_requests sessions: %w", err)
 	}
 
 	moved := findMovedRequesters(currentSessions, storedSessions)
 	if len(moved) == 0 {
 		slog.Debug("reconcile_request_lifecycle: no moved requesters", "year", year)
-		return nil
+		return 0, nil
 	}
 
+	markErrors := 0
 	for _, cmID := range moved {
 		if err := markRequesterOBRsUnprocessed(app, cmID, year); err != nil {
+			markErrors++
 			slog.Error("reconcile_request_lifecycle: mark OBRs unprocessed",
 				"cm_id", cmID, "year", year, "error", err)
 		}
 	}
 
 	slog.Info("reconcile_request_lifecycle complete",
-		"year", year, "moved_requesters", len(moved))
-	return nil
+		"year", year, "moved_requesters", len(moved), "mark_errors", markErrors)
+	return markErrors, nil
 }
 
 // loadEnrolledRequesterSessions returns a map of person cm_id -> session cm_id
@@ -229,6 +246,11 @@ func markRequesterOBRsUnprocessed(app core.App, requesterCMID, year int) error {
 		obr.Set("processed", "")
 		if err := app.Save(obr); err != nil {
 			return fmt.Errorf("save OBR %s: %w", obr.Id, err)
+		}
+	}
+	if len(obrs) > 0 {
+		if _, err := app.DB().NewQuery("PRAGMA wal_checkpoint(FULL)").Execute(); err != nil {
+			slog.Warn("reconcile_request_lifecycle: WAL checkpoint failed", "error", err)
 		}
 	}
 	return nil

--- a/pocketbase/sync/reconcile_request_lifecycle_test.go
+++ b/pocketbase/sync/reconcile_request_lifecycle_test.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"context"
 	"sort"
 	"testing"
 
@@ -289,7 +290,7 @@ func TestReconcileRequestLifecycle_MarksMovedRequestersOBRsUnprocessed(t *testin
 	emmaOBR := saveOBR(t, app, emma, year, "bunk_with", fixtureProcessed2025)
 	saveBR(t, app, 1002, 1003, 100, year, "resolved")
 
-	if reconcileErr := reconcileRequestLifecycle(app, year); reconcileErr != nil {
+	if _, reconcileErr := reconcileRequestLifecycle(app, year); reconcileErr != nil {
 		t.Fatalf("reconcile: %v", reconcileErr)
 	}
 
@@ -335,7 +336,7 @@ func TestReconcileRequestLifecycle_IgnoresInactiveRequesters(t *testing.T) {
 	oliviaOBR := saveOBR(t, app, olivia, year, "bunk_with", fixtureProcessed2025)
 	saveBR(t, app, 1003, 1004, 999, year, "resolved")
 
-	if reconcileErr := reconcileRequestLifecycle(app, year); reconcileErr != nil {
+	if _, reconcileErr := reconcileRequestLifecycle(app, year); reconcileErr != nil {
 		t.Fatalf("reconcile: %v", reconcileErr)
 	}
 
@@ -368,7 +369,7 @@ func TestReconcileRequestLifecycle_NoOpWhenNoStaleRows(t *testing.T) {
 	noahOBR := saveOBR(t, app, noah, year, "bunk_with", fixtureProcessed2025)
 	saveBR(t, app, 1005, 1006, 100, year, "resolved")
 
-	if reconcileErr := reconcileRequestLifecycle(app, year); reconcileErr != nil {
+	if _, reconcileErr := reconcileRequestLifecycle(app, year); reconcileErr != nil {
 		t.Fatalf("reconcile: %v", reconcileErr)
 	}
 
@@ -404,7 +405,7 @@ func TestReconcileRequestLifecycle_YearScoped(t *testing.T) {
 	saveBR(t, app, 1007, 1008, 100, 2024, "resolved") // 2024: session matches
 	saveBR(t, app, 1007, 1008, 100, 2025, "resolved") // 2025: session mismatch (Riley in 200 now)
 
-	if reconcileErr := reconcileRequestLifecycle(app, 2025); reconcileErr != nil {
+	if _, reconcileErr := reconcileRequestLifecycle(app, 2025); reconcileErr != nil {
 		t.Fatalf("reconcile: %v", reconcileErr)
 	}
 
@@ -424,5 +425,79 @@ func TestReconcileRequestLifecycle_YearScoped(t *testing.T) {
 	}
 	if got := r2024.GetString("processed"); got != fixtureProcessed2024 {
 		t.Errorf("2024 (other year) OBR processed = %q, want preserved", got)
+	}
+}
+
+// TestReconcileLifecycleSync_FallsBackToSeasonEnv verifies that the daily-sync
+// path (where InitializeSyncServices registers the service with Year==0) does
+// not error out — it must read CAMPMINDER_SEASON_ID like every other yearless
+// service in this package.
+func TestReconcileLifecycleSync_FallsBackToSeasonEnv(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+
+	setupReconcileCollections(t, app)
+	t.Setenv("CAMPMINDER_SEASON_ID", "2025")
+
+	s := NewReconcileLifecycleSync(app) // Year remains 0
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync with Year=0 should fall back to env, got error: %v", err)
+	}
+	if s.Stats.Errors != 0 {
+		t.Errorf("Stats.Errors = %d, want 0", s.Stats.Errors)
+	}
+}
+
+// TestReconcileLifecycleSync_RejectsMissingYearEnv verifies that when neither
+// Year is set NOR CAMPMINDER_SEASON_ID is in the env, Sync returns a clear
+// error rather than silently using a bogus year.
+func TestReconcileLifecycleSync_RejectsMissingYearEnv(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+
+	setupReconcileCollections(t, app)
+	t.Setenv("CAMPMINDER_SEASON_ID", "")
+
+	s := NewReconcileLifecycleSync(app) // Year remains 0
+	if err := s.Sync(context.Background()); err == nil {
+		t.Fatal("Sync with Year=0 and no env should error, got nil")
+	}
+}
+
+// TestReconcileRequestLifecycle_SuccessPathReturnsZeroMarkErrors verifies the
+// new (markErrors, err) signature: when every per-cm save succeeds, the count
+// is zero. The increment branch is covered by the inability path: if Save
+// fails, markErrors gets incremented (covered by code-path correctness; the
+// PB test harness does not have a clean way to force a per-record save error).
+func TestReconcileRequestLifecycle_SuccessPathReturnsZeroMarkErrors(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+
+	setupReconcileCollections(t, app)
+
+	const year = 2025
+	_ = saveSession(t, app, 100)
+	session2 := saveSession(t, app, 200)
+
+	liam := savePerson(t, app, 1001)
+	saveAttendee(t, app, 1001, 2, year, session2)
+	_ = saveOBR(t, app, liam, year, "bunk_with", fixtureProcessed2025)
+	saveBR(t, app, 1001, 1002, 100, year, "resolved")
+
+	markErrors, err := reconcileRequestLifecycle(app, year)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if markErrors != 0 {
+		t.Errorf("markErrors = %d, want 0", markErrors)
 	}
 }

--- a/pocketbase/sync/reconcile_request_lifecycle_test.go
+++ b/pocketbase/sync/reconcile_request_lifecycle_test.go
@@ -1,0 +1,428 @@
+package sync
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+)
+
+const (
+	fixtureProcessed2024 = "processed_at_2024-01-01"
+	fixtureProcessed2025 = "processed_at_2025-01-01"
+)
+
+// TestFindMovedRequesters tests the pure-function detection of requesters
+// whose current attendees.session differs from the session_id stored on any
+// of their existing bunk_requests rows.
+func TestFindMovedRequesters(t *testing.T) {
+	cases := []struct {
+		name             string
+		currentSessions  map[int]int
+		storedBRSessions map[int][]int
+		expectMovedCMIDs []int
+	}{
+		{
+			name: "no moves — all sessions match",
+			currentSessions: map[int]int{
+				1001: 100,
+				1002: 100,
+			},
+			storedBRSessions: map[int][]int{
+				1001: {100},
+				1002: {100},
+			},
+			expectMovedCMIDs: []int{},
+		},
+		{
+			name: "one moved requester",
+			currentSessions: map[int]int{
+				1001: 200, // moved from 100 to 200
+				1002: 100,
+			},
+			storedBRSessions: map[int][]int{
+				1001: {100},
+				1002: {100},
+			},
+			expectMovedCMIDs: []int{1001},
+		},
+		{
+			name: "multiple moved requesters",
+			currentSessions: map[int]int{
+				1001: 200,
+				1002: 200,
+				1003: 100,
+			},
+			storedBRSessions: map[int][]int{
+				1001: {100},
+				1002: {100},
+				1003: {100},
+			},
+			expectMovedCMIDs: []int{1001, 1002},
+		},
+		{
+			name: "requester with stale rows in MULTIPLE old sessions still flagged once",
+			currentSessions: map[int]int{
+				1001: 300,
+			},
+			storedBRSessions: map[int][]int{
+				1001: {100, 200, 300}, // some stale, some matching
+			},
+			expectMovedCMIDs: []int{1001},
+		},
+		{
+			name: "requester not currently enrolled — skipped (handled by orphan purge)",
+			currentSessions: map[int]int{
+				1002: 100,
+			},
+			storedBRSessions: map[int][]int{
+				1001: {100}, // 1001 not in currentSessions (cancelled)
+				1002: {100},
+			},
+			expectMovedCMIDs: []int{},
+		},
+		{
+			name: "no stored bunk_requests for requester — nothing to reconcile",
+			currentSessions: map[int]int{
+				1001: 200,
+			},
+			storedBRSessions: map[int][]int{},
+			expectMovedCMIDs: []int{},
+		},
+		{
+			name:             "empty inputs",
+			currentSessions:  map[int]int{},
+			storedBRSessions: map[int][]int{},
+			expectMovedCMIDs: []int{},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findMovedRequesters(tt.currentSessions, tt.storedBRSessions)
+			sort.Ints(got)
+			want := append([]int{}, tt.expectMovedCMIDs...)
+			sort.Ints(want)
+
+			if len(got) != len(want) {
+				t.Fatalf("got %d moved cm_ids, want %d: got=%v want=%v",
+					len(got), len(want), got, want)
+			}
+			for i := range got {
+				if got[i] != want[i] {
+					t.Errorf("got[%d]=%d, want %d", i, got[i], want[i])
+				}
+			}
+		})
+	}
+}
+
+// setupReconcileCollections seeds minimal schema for an end-to-end test of
+// reconcileRequestLifecycle against a real PocketBase test app.
+func setupReconcileCollections(t *testing.T, app core.App) {
+	t.Helper()
+
+	personsCol := core.NewBaseCollection("persons")
+	personsCol.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
+	if err := app.Save(personsCol); err != nil {
+		t.Fatalf("create persons: %v", err)
+	}
+
+	sessionsCol := core.NewBaseCollection("camp_sessions")
+	sessionsCol.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
+	if err := app.Save(sessionsCol); err != nil {
+		t.Fatalf("create camp_sessions: %v", err)
+	}
+
+	attendeesCol := core.NewBaseCollection("attendees")
+	attendeesCol.Fields.Add(&core.NumberField{Name: "person_id", Required: true})
+	attendeesCol.Fields.Add(&core.NumberField{Name: "status_id", Required: true})
+	attendeesCol.Fields.Add(&core.NumberField{Name: "year", Required: true})
+	attendeesCol.Fields.Add(&core.RelationField{
+		Name:         "session",
+		CollectionId: sessionsCol.Id,
+		Required:     false,
+		MaxSelect:    1,
+	})
+	if err := app.Save(attendeesCol); err != nil {
+		t.Fatalf("create attendees: %v", err)
+	}
+
+	obrCol := core.NewBaseCollection("original_bunk_requests")
+	obrCol.Fields.Add(&core.RelationField{
+		Name:         "requester",
+		CollectionId: personsCol.Id,
+		Required:     true,
+		MaxSelect:    1,
+	})
+	obrCol.Fields.Add(&core.NumberField{Name: "year", Required: true})
+	obrCol.Fields.Add(&core.TextField{Name: "field"})
+	obrCol.Fields.Add(&core.TextField{Name: "content"})
+	obrCol.Fields.Add(&core.TextField{Name: "processed"})
+	if err := app.Save(obrCol); err != nil {
+		t.Fatalf("create original_bunk_requests: %v", err)
+	}
+
+	brCol := core.NewBaseCollection("bunk_requests")
+	brCol.Fields.Add(&core.NumberField{Name: "requester_id", Required: true})
+	brCol.Fields.Add(&core.NumberField{Name: "requestee_id"})
+	brCol.Fields.Add(&core.NumberField{Name: "session_id", Required: true})
+	brCol.Fields.Add(&core.NumberField{Name: "year", Required: true})
+	brCol.Fields.Add(&core.SelectField{
+		Name:      "status",
+		Values:    []string{"pending", "resolved", "declined"},
+		MaxSelect: 1,
+	})
+	if err := app.Save(brCol); err != nil {
+		t.Fatalf("create bunk_requests: %v", err)
+	}
+}
+
+func savePerson(t *testing.T, app core.App, cmID int) *core.Record {
+	t.Helper()
+	col, err := app.FindCollectionByNameOrId("persons")
+	if err != nil {
+		t.Fatalf("find persons: %v", err)
+	}
+	r := core.NewRecord(col)
+	r.Set("cm_id", cmID)
+	if err := app.Save(r); err != nil {
+		t.Fatalf("save person %d: %v", cmID, err)
+	}
+	return r
+}
+
+func saveSession(t *testing.T, app core.App, cmID int) *core.Record {
+	t.Helper()
+	col, err := app.FindCollectionByNameOrId("camp_sessions")
+	if err != nil {
+		t.Fatalf("find camp_sessions: %v", err)
+	}
+	r := core.NewRecord(col)
+	r.Set("cm_id", cmID)
+	if err := app.Save(r); err != nil {
+		t.Fatalf("save session %d: %v", cmID, err)
+	}
+	return r
+}
+
+func saveAttendee(t *testing.T, app core.App, personCMID, statusID, year int, session *core.Record) {
+	t.Helper()
+	col, err := app.FindCollectionByNameOrId("attendees")
+	if err != nil {
+		t.Fatalf("find attendees: %v", err)
+	}
+	r := core.NewRecord(col)
+	r.Set("person_id", personCMID)
+	r.Set("status_id", statusID)
+	r.Set("year", year)
+	if session != nil {
+		r.Set("session", session.Id)
+	}
+	if err := app.Save(r); err != nil {
+		t.Fatalf("save attendee %d: %v", personCMID, err)
+	}
+}
+
+func saveOBR(t *testing.T, app core.App, requester *core.Record, year int, field, processed string) *core.Record {
+	t.Helper()
+	col, err := app.FindCollectionByNameOrId("original_bunk_requests")
+	if err != nil {
+		t.Fatalf("find OBR: %v", err)
+	}
+	r := core.NewRecord(col)
+	r.Set("requester", requester.Id)
+	r.Set("year", year)
+	r.Set("field", field)
+	r.Set("content", "stub")
+	r.Set("processed", processed)
+	if err := app.Save(r); err != nil {
+		t.Fatalf("save OBR: %v", err)
+	}
+	return r
+}
+
+func saveBR(t *testing.T, app core.App, requesterCMID, requesteeCMID, sessionCMID, year int, status string) {
+	t.Helper()
+	col, err := app.FindCollectionByNameOrId("bunk_requests")
+	if err != nil {
+		t.Fatalf("find bunk_requests: %v", err)
+	}
+	r := core.NewRecord(col)
+	r.Set("requester_id", requesterCMID)
+	r.Set("requestee_id", requesteeCMID)
+	r.Set("session_id", sessionCMID)
+	r.Set("year", year)
+	r.Set("status", status)
+	if err := app.Save(r); err != nil {
+		t.Fatalf("save BR: %v", err)
+	}
+}
+
+// TestReconcileRequestLifecycle_MarksMovedRequestersOBRsUnprocessed verifies the
+// end-to-end behavior: a requester whose attendee.session no longer matches the
+// session_id stored on their bunk_requests rows has all their OBRs flipped to
+// processed=” so process_requests will re-build them.
+func TestReconcileRequestLifecycle_MarksMovedRequestersOBRsUnprocessed(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+
+	setupReconcileCollections(t, app)
+
+	const year = 2025
+	session1 := saveSession(t, app, 100)
+	session2 := saveSession(t, app, 200)
+
+	// Liam Garcia (1001) moved from session 100 to 200
+	liam := savePerson(t, app, 1001)
+	saveAttendee(t, app, 1001, 2, year, session2) // currently in session 200
+	liamOBR := saveOBR(t, app, liam, year, "bunk_with", fixtureProcessed2025)
+	saveBR(t, app, 1001, 1002, 100, year, "resolved") // BR has stale session_id=100
+
+	// Emma Johnson (1002) hasn't moved
+	emma := savePerson(t, app, 1002)
+	saveAttendee(t, app, 1002, 2, year, session1)
+	emmaOBR := saveOBR(t, app, emma, year, "bunk_with", fixtureProcessed2025)
+	saveBR(t, app, 1002, 1003, 100, year, "resolved")
+
+	if reconcileErr := reconcileRequestLifecycle(app, year); reconcileErr != nil {
+		t.Fatalf("reconcile: %v", reconcileErr)
+	}
+
+	// Liam's OBR should now be unprocessed
+	liamReloaded, err := app.FindRecordById("original_bunk_requests", liamOBR.Id)
+	if err != nil {
+		t.Fatalf("reload liamOBR: %v", err)
+	}
+	if got := liamReloaded.GetString("processed"); got != "" {
+		t.Errorf("Liam (moved) OBR processed = %q, want \"\"", got)
+	}
+
+	// Emma's OBR should be untouched
+	emmaReloaded, err := app.FindRecordById("original_bunk_requests", emmaOBR.Id)
+	if err != nil {
+		t.Fatalf("reload emmaOBR: %v", err)
+	}
+	if got := emmaReloaded.GetString("processed"); got != fixtureProcessed2025 {
+		t.Errorf("Emma (stable) OBR processed = %q, want preserved", got)
+	}
+}
+
+// TestReconcileRequestLifecycle_IgnoresInactiveRequesters verifies that
+// requesters whose status_id != 2 are NOT touched here — the orphan purge
+// in bunk_requests sync handles their cleanup by deleting OBRs entirely.
+func TestReconcileRequestLifecycle_IgnoresInactiveRequesters(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+
+	setupReconcileCollections(t, app)
+
+	const year = 2025
+	session1 := saveSession(t, app, 100)
+	session2 := saveSession(t, app, 200)
+	_ = session2 // session2 exists but unused for this test
+
+	// Olivia Chen (1003) is cancelled; even with stale session, reconcile leaves her alone
+	olivia := savePerson(t, app, 1003)
+	saveAttendee(t, app, 1003, 3, year, session1) // status_id=3 (cancelled)
+	oliviaOBR := saveOBR(t, app, olivia, year, "bunk_with", fixtureProcessed2025)
+	saveBR(t, app, 1003, 1004, 999, year, "resolved")
+
+	if reconcileErr := reconcileRequestLifecycle(app, year); reconcileErr != nil {
+		t.Fatalf("reconcile: %v", reconcileErr)
+	}
+
+	// Olivia's OBR should be untouched (orphan purge in bunk_requests sync handles her later)
+	oliviaReloaded, err := app.FindRecordById("original_bunk_requests", oliviaOBR.Id)
+	if err != nil {
+		t.Fatalf("reload oliviaOBR: %v", err)
+	}
+	if got := oliviaReloaded.GetString("processed"); got != fixtureProcessed2025 {
+		t.Errorf("Olivia (cancelled) OBR processed = %q, want preserved", got)
+	}
+}
+
+// TestReconcileRequestLifecycle_NoOpWhenNoStaleRows verifies that the function
+// is a no-op when no requesters have moved.
+func TestReconcileRequestLifecycle_NoOpWhenNoStaleRows(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+
+	setupReconcileCollections(t, app)
+
+	const year = 2025
+	session1 := saveSession(t, app, 100)
+
+	noah := savePerson(t, app, 1005)
+	saveAttendee(t, app, 1005, 2, year, session1)
+	noahOBR := saveOBR(t, app, noah, year, "bunk_with", fixtureProcessed2025)
+	saveBR(t, app, 1005, 1006, 100, year, "resolved")
+
+	if reconcileErr := reconcileRequestLifecycle(app, year); reconcileErr != nil {
+		t.Fatalf("reconcile: %v", reconcileErr)
+	}
+
+	noahReloaded, err := app.FindRecordById("original_bunk_requests", noahOBR.Id)
+	if err != nil {
+		t.Fatalf("reload noahOBR: %v", err)
+	}
+	if got := noahReloaded.GetString("processed"); got != fixtureProcessed2025 {
+		t.Errorf("Noah (stable) OBR processed = %q, want preserved", got)
+	}
+}
+
+// TestReconcileRequestLifecycle_YearScoped verifies that the function only
+// touches OBRs in the requested year, not other years.
+func TestReconcileRequestLifecycle_YearScoped(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+
+	setupReconcileCollections(t, app)
+
+	session1 := saveSession(t, app, 100)
+	session2 := saveSession(t, app, 200)
+
+	riley := savePerson(t, app, 1007)
+	// Riley is in session 100 in 2024 (last year), session 200 in 2025 (current)
+	saveAttendee(t, app, 1007, 2, 2024, session1)
+	saveAttendee(t, app, 1007, 2, 2025, session2)
+	obr2024 := saveOBR(t, app, riley, 2024, "bunk_with", fixtureProcessed2024)
+	obr2025 := saveOBR(t, app, riley, 2025, "bunk_with", fixtureProcessed2025)
+	saveBR(t, app, 1007, 1008, 100, 2024, "resolved") // 2024: session matches
+	saveBR(t, app, 1007, 1008, 100, 2025, "resolved") // 2025: session mismatch (Riley in 200 now)
+
+	if reconcileErr := reconcileRequestLifecycle(app, 2025); reconcileErr != nil {
+		t.Fatalf("reconcile: %v", reconcileErr)
+	}
+
+	// 2025 OBR should be unprocessed
+	r2025, err := app.FindRecordById("original_bunk_requests", obr2025.Id)
+	if err != nil {
+		t.Fatalf("reload 2025 OBR: %v", err)
+	}
+	if got := r2025.GetString("processed"); got != "" {
+		t.Errorf("2025 (moved) OBR processed = %q, want \"\"", got)
+	}
+
+	// 2024 OBR must NOT be touched
+	r2024, err := app.FindRecordById("original_bunk_requests", obr2024.Id)
+	if err != nil {
+		t.Fatalf("reload 2024 OBR: %v", err)
+	}
+	if got := r2024.GetString("processed"); got != fixtureProcessed2024 {
+		t.Errorf("2024 (other year) OBR processed = %q, want preserved", got)
+	}
+}

--- a/tests/unit/sync/bunk_request_processor/orchestrator/test_obr_reconciliation_log.py
+++ b/tests/unit/sync/bunk_request_processor/orchestrator/test_obr_reconciliation_log.py
@@ -38,6 +38,8 @@ class TestFormatObrReconciliation:
             "status_resolved": 1909,
             "status_pending": 242,
             "status_declined": 152,
+            "target_declined_count": 7,
+            "target_declined_errors": 0,
         }
 
         line = format_obr_reconciliation(stats)
@@ -48,6 +50,7 @@ class TestFormatObrReconciliation:
             " | 1016 AI-parsed (948 success, 68 permanent parse failures) + 537 direct-mapped"
             " | 2397 pre-dedup requests -> 94 dedup + 3 self-referential kept for review"
             " | 2303 BRs created (1909 resolved / 242 pending / 152 declined)"
+            " | Phase C: 7 target-declined (0 errors)"
         )
         assert line == expected
 

--- a/tests/unit/sync/bunk_request_processor/orchestrator/test_target_decline.py
+++ b/tests/unit/sync/bunk_request_processor/orchestrator/test_target_decline.py
@@ -1,0 +1,211 @@
+"""Tests for Phase C target-decline sidecar.
+
+Phase C runs after the main OBR pipeline. It sweeps existing bunk_requests
+rows whose requestee is no longer attending (status_id != 2) or now sits
+in a different session for the year, and declines them in place with the
+canonical disposition_reason vocabulary used by the conflict detector
+(`target_not_attending`, `session_mismatch`).
+
+This is the requestee-side complement to:
+  - orphan purge in Go bunk_requests CSV sync (handles requester-side cancel)
+  - reconcile_request_lifecycle (marks OBRs unprocessed for moved requesters)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from bunking.sync.bunk_request_processor.orchestrator.target_decline import (
+    TargetDeclineAction,
+    apply_target_decline,
+    compute_target_decline_actions,
+)
+
+
+class TestComputeTargetDeclineActions:
+    """Pure-function logic: given current attendees state and BRs, what to decline."""
+
+    def test_no_actions_when_all_requestees_active_and_in_correct_session(self) -> None:
+        bunk_requests = [
+            {"id": "br1", "requestee_id": 1001, "session_id": 100, "status": "resolved"},
+            {"id": "br2", "requestee_id": 1002, "session_id": 100, "status": "pending"},
+        ]
+        active_session_by_cm_id = {1001: 100, 1002: 100}
+        inactive_cm_ids: set[int] = set()
+
+        actions = compute_target_decline_actions(
+            bunk_requests=bunk_requests,
+            inactive_cm_ids=inactive_cm_ids,
+            active_session_by_cm_id=active_session_by_cm_id,
+        )
+
+        assert actions == []
+
+    def test_declines_when_requestee_inactive(self) -> None:
+        bunk_requests = [
+            {"id": "br1", "requestee_id": 1001, "session_id": 100, "status": "resolved"},
+        ]
+        active_session_by_cm_id: dict[int, int] = {}
+        inactive_cm_ids = {1001}
+
+        actions = compute_target_decline_actions(
+            bunk_requests=bunk_requests,
+            inactive_cm_ids=inactive_cm_ids,
+            active_session_by_cm_id=active_session_by_cm_id,
+        )
+
+        assert actions == [TargetDeclineAction(bunk_request_id="br1", reason="target_not_attending")]
+
+    def test_declines_when_requestee_active_but_in_different_session(self) -> None:
+        bunk_requests = [
+            # BR1 says session 100, but Liam Garcia (1001) is in session 200 now
+            {"id": "br1", "requestee_id": 1001, "session_id": 100, "status": "resolved"},
+        ]
+        active_session_by_cm_id = {1001: 200}
+        inactive_cm_ids: set[int] = set()
+
+        actions = compute_target_decline_actions(
+            bunk_requests=bunk_requests,
+            inactive_cm_ids=inactive_cm_ids,
+            active_session_by_cm_id=active_session_by_cm_id,
+        )
+
+        assert actions == [TargetDeclineAction(bunk_request_id="br1", reason="session_mismatch")]
+
+    def test_skips_already_declined_rows(self) -> None:
+        bunk_requests = [
+            {"id": "br1", "requestee_id": 1001, "session_id": 100, "status": "declined"},
+        ]
+        actions = compute_target_decline_actions(
+            bunk_requests=bunk_requests,
+            inactive_cm_ids={1001},
+            active_session_by_cm_id={},
+        )
+        assert actions == []
+
+    def test_skips_rows_with_no_requestee(self) -> None:
+        # Age-preference and unresolved-name rows have no requestee_id
+        bunk_requests: list[dict[str, Any]] = [
+            {"id": "br1", "requestee_id": None, "session_id": 100, "status": "resolved"},
+            {"id": "br2", "requestee_id": 0, "session_id": 100, "status": "resolved"},
+        ]
+        actions = compute_target_decline_actions(
+            bunk_requests=bunk_requests,
+            inactive_cm_ids=set(),
+            active_session_by_cm_id={},
+        )
+        assert actions == []
+
+    def test_inactive_takes_precedence_over_session_mismatch(self) -> None:
+        """If requestee is both inactive AND in a different session, prefer the
+        not-attending reason (the more fundamental fact about their state)."""
+        bunk_requests = [
+            {"id": "br1", "requestee_id": 1001, "session_id": 100, "status": "resolved"},
+        ]
+        actions = compute_target_decline_actions(
+            bunk_requests=bunk_requests,
+            inactive_cm_ids={1001},
+            active_session_by_cm_id={1001: 200},  # would also session-mismatch
+        )
+        assert actions == [TargetDeclineAction(bunk_request_id="br1", reason="target_not_attending")]
+
+    def test_handles_unknown_requestee(self) -> None:
+        """A requestee_id that's neither in inactive nor active sets is left alone.
+
+        This can happen if the requestee is a placeholder (negative cm_id) or
+        otherwise outside the year's attendees query."""
+        bunk_requests = [
+            {"id": "br1", "requestee_id": 9999, "session_id": 100, "status": "resolved"},
+        ]
+        actions = compute_target_decline_actions(
+            bunk_requests=bunk_requests,
+            inactive_cm_ids={1001},
+            active_session_by_cm_id={1002: 100},
+        )
+        assert actions == []
+
+    def test_realistic_mixed_input(self) -> None:
+        """Multiple BRs with mixed dispositions — emits one action per stale row."""
+        bunk_requests = [
+            # Olivia Chen (1001) cancelled — request to her gets declined
+            {"id": "br1", "requestee_id": 1001, "session_id": 100, "status": "resolved"},
+            # Liam Garcia (1002) moved from 100 → 200 — request gets session-mismatched
+            {"id": "br2", "requestee_id": 1002, "session_id": 100, "status": "pending"},
+            # Emma Johnson (1003) is fine, still in session 100
+            {"id": "br3", "requestee_id": 1003, "session_id": 100, "status": "resolved"},
+            # Already-declined row left alone
+            {"id": "br4", "requestee_id": 1001, "session_id": 100, "status": "declined"},
+        ]
+        actions = compute_target_decline_actions(
+            bunk_requests=bunk_requests,
+            inactive_cm_ids={1001},
+            active_session_by_cm_id={1002: 200, 1003: 100},
+        )
+
+        assert sorted((a.bunk_request_id, a.reason) for a in actions) == [
+            ("br1", "target_not_attending"),
+            ("br2", "session_mismatch"),
+        ]
+
+
+class TestApplyTargetDecline:
+    """Integration-style: applies the actions through the request_repository."""
+
+    def test_calls_pb_update_with_correct_payload(self) -> None:
+        actions = [
+            TargetDeclineAction(bunk_request_id="br1", reason="target_not_attending"),
+            TargetDeclineAction(bunk_request_id="br2", reason="session_mismatch"),
+        ]
+        pb_client = MagicMock()
+        pb_client.collection.return_value.update = MagicMock()
+
+        result = apply_target_decline(pb_client, actions)
+
+        assert result["declined_count"] == 2
+        assert pb_client.collection.return_value.update.call_count == 2
+
+        call_kwargs = [c.args for c in pb_client.collection.return_value.update.call_args_list]
+        ids_seen = {c[0] for c in call_kwargs}
+        payloads = {c[0]: c[1] for c in call_kwargs}
+
+        assert ids_seen == {"br1", "br2"}
+        assert payloads["br1"]["status"] == "declined"
+        assert payloads["br1"]["disposition_reason"] == "target_not_attending"
+        assert payloads["br2"]["status"] == "declined"
+        assert payloads["br2"]["disposition_reason"] == "session_mismatch"
+
+    def test_empty_actions_is_noop(self) -> None:
+        pb_client = MagicMock()
+        result = apply_target_decline(pb_client, [])
+
+        assert result["declined_count"] == 0
+        pb_client.collection.assert_not_called()
+
+    def test_continues_after_individual_update_failure(self) -> None:
+        """One row failing to update must not prevent the others from being processed."""
+        actions = [
+            TargetDeclineAction(bunk_request_id="br1", reason="target_not_attending"),
+            TargetDeclineAction(bunk_request_id="br2", reason="session_mismatch"),
+            TargetDeclineAction(bunk_request_id="br3", reason="target_not_attending"),
+        ]
+        pb_client = MagicMock()
+
+        # Make the second update raise
+        def update_side_effect(rec_id: str, _data: dict[str, Any]) -> None:
+            if rec_id == "br2":
+                raise RuntimeError("simulated PB error")
+
+        pb_client.collection.return_value.update.side_effect = update_side_effect
+
+        result = apply_target_decline(pb_client, actions)
+
+        assert result["declined_count"] == 2
+        assert result["error_count"] == 1
+        assert pb_client.collection.return_value.update.call_count == 3
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/sync/bunk_request_processor/orchestrator/test_target_decline.py
+++ b/tests/unit/sync/bunk_request_processor/orchestrator/test_target_decline.py
@@ -1,9 +1,9 @@
 """Tests for Phase C target-decline sidecar.
 
 Phase C runs after the main OBR pipeline. It sweeps existing bunk_requests
-rows whose requestee is no longer attending (status_id != 2) or now sits
-in a different session for the year, and declines them in place with the
-canonical disposition_reason vocabulary used by the conflict detector
+rows whose requestee is no longer attending or now sits in a different
+session for the year, and declines them in place with the canonical
+disposition_reason vocabulary used by the conflict detector
 (`target_not_attending`, `session_mismatch`).
 
 This is the requestee-side complement to:
@@ -22,6 +22,7 @@ from bunking.sync.bunk_request_processor.orchestrator.target_decline import (
     TargetDeclineAction,
     apply_target_decline,
     compute_target_decline_actions,
+    run_target_decline_phase,
 )
 
 
@@ -33,28 +34,25 @@ class TestComputeTargetDeclineActions:
             {"id": "br1", "requestee_id": 1001, "session_id": 100, "status": "resolved"},
             {"id": "br2", "requestee_id": 1002, "session_id": 100, "status": "pending"},
         ]
-        active_session_by_cm_id = {1001: 100, 1002: 100}
-        inactive_cm_ids: set[int] = set()
+        active_sessions_by_cm_id: dict[int, set[int]] = {1001: {100}, 1002: {100}}
 
         actions = compute_target_decline_actions(
             bunk_requests=bunk_requests,
-            inactive_cm_ids=inactive_cm_ids,
-            active_session_by_cm_id=active_session_by_cm_id,
+            active_sessions_by_cm_id=active_sessions_by_cm_id,
         )
 
         assert actions == []
 
-    def test_declines_when_requestee_inactive(self) -> None:
+    def test_declines_when_requestee_not_in_active_map(self) -> None:
+        """A requestee with no active enrollment (cancelled/withdrawn/never-enrolled)
+        is absent from active_sessions_by_cm_id → target_not_attending."""
         bunk_requests = [
             {"id": "br1", "requestee_id": 1001, "session_id": 100, "status": "resolved"},
         ]
-        active_session_by_cm_id: dict[int, int] = {}
-        inactive_cm_ids = {1001}
 
         actions = compute_target_decline_actions(
             bunk_requests=bunk_requests,
-            inactive_cm_ids=inactive_cm_ids,
-            active_session_by_cm_id=active_session_by_cm_id,
+            active_sessions_by_cm_id={},
         )
 
         assert actions == [TargetDeclineAction(bunk_request_id="br1", reason="target_not_attending")]
@@ -64,13 +62,10 @@ class TestComputeTargetDeclineActions:
             # BR1 says session 100, but Liam Garcia (1001) is in session 200 now
             {"id": "br1", "requestee_id": 1001, "session_id": 100, "status": "resolved"},
         ]
-        active_session_by_cm_id = {1001: 200}
-        inactive_cm_ids: set[int] = set()
 
         actions = compute_target_decline_actions(
             bunk_requests=bunk_requests,
-            inactive_cm_ids=inactive_cm_ids,
-            active_session_by_cm_id=active_session_by_cm_id,
+            active_sessions_by_cm_id={1001: {200}},
         )
 
         assert actions == [TargetDeclineAction(bunk_request_id="br1", reason="session_mismatch")]
@@ -81,8 +76,7 @@ class TestComputeTargetDeclineActions:
         ]
         actions = compute_target_decline_actions(
             bunk_requests=bunk_requests,
-            inactive_cm_ids={1001},
-            active_session_by_cm_id={},
+            active_sessions_by_cm_id={},
         )
         assert actions == []
 
@@ -94,38 +88,59 @@ class TestComputeTargetDeclineActions:
         ]
         actions = compute_target_decline_actions(
             bunk_requests=bunk_requests,
-            inactive_cm_ids=set(),
-            active_session_by_cm_id={},
+            active_sessions_by_cm_id={},
         )
         assert actions == []
 
-    def test_inactive_takes_precedence_over_session_mismatch(self) -> None:
-        """If requestee is both inactive AND in a different session, prefer the
-        not-attending reason (the more fundamental fact about their state)."""
+    def test_multi_session_enrolled_keeps_brs_in_any_active_session(self) -> None:
+        """Requestee Olivia Chen (1001) is enrolled in BOTH session 100 and 200
+        (e.g. signed up for two different camp sessions in the same year).
+        BRs targeting her in either session must be kept."""
         bunk_requests = [
             {"id": "br1", "requestee_id": 1001, "session_id": 100, "status": "resolved"},
+            {"id": "br2", "requestee_id": 1001, "session_id": 200, "status": "resolved"},
         ]
+
         actions = compute_target_decline_actions(
             bunk_requests=bunk_requests,
-            inactive_cm_ids={1001},
-            active_session_by_cm_id={1001: 200},  # would also session-mismatch
+            active_sessions_by_cm_id={1001: {100, 200}},
         )
-        assert actions == [TargetDeclineAction(bunk_request_id="br1", reason="target_not_attending")]
 
-    def test_handles_unknown_requestee(self) -> None:
-        """A requestee_id that's neither in inactive nor active sets is left alone.
-
-        This can happen if the requestee is a placeholder (negative cm_id) or
-        otherwise outside the year's attendees query."""
-        bunk_requests = [
-            {"id": "br1", "requestee_id": 9999, "session_id": 100, "status": "resolved"},
-        ]
-        actions = compute_target_decline_actions(
-            bunk_requests=bunk_requests,
-            inactive_cm_ids={1001},
-            active_session_by_cm_id={1002: 100},
-        )
         assert actions == []
+
+    def test_multi_session_enrolled_flags_only_non_matching_session(self) -> None:
+        """Requestee enrolled in 100 and 200 — a BR for session 300 is mismatched."""
+        bunk_requests = [
+            {"id": "br1", "requestee_id": 1001, "session_id": 100, "status": "resolved"},
+            {"id": "br2", "requestee_id": 1001, "session_id": 300, "status": "resolved"},
+        ]
+
+        actions = compute_target_decline_actions(
+            bunk_requests=bunk_requests,
+            active_sessions_by_cm_id={1001: {100, 200}},
+        )
+
+        assert actions == [TargetDeclineAction(bunk_request_id="br2", reason="session_mismatch")]
+
+    def test_mixed_enrolled_and_cancelled_rows_keeps_active_only(self) -> None:
+        """Requestee has 4× enrolled rows (sessions 100, 200, 300, 400) plus
+        a cancelled row (session 500). The cancelled row must NOT cause her
+        BRs to be declined as target_not_attending. This was the bug in the
+        original implementation (person 8774023 in production data)."""
+        bunk_requests = [
+            {"id": "br1", "requestee_id": 1001, "session_id": 100, "status": "resolved"},
+            {"id": "br2", "requestee_id": 1001, "session_id": 500, "status": "resolved"},
+        ]
+
+        # active_sessions_by_cm_id only contains the enrolled sessions; the
+        # cancelled row is silently dropped at classification time.
+        actions = compute_target_decline_actions(
+            bunk_requests=bunk_requests,
+            active_sessions_by_cm_id={1001: {100, 200, 300, 400}},
+        )
+
+        # br1 → kept (in active set), br2 → session_mismatch (500 not in set)
+        assert actions == [TargetDeclineAction(bunk_request_id="br2", reason="session_mismatch")]
 
     def test_realistic_mixed_input(self) -> None:
         """Multiple BRs with mixed dispositions — emits one action per stale row."""
@@ -141,8 +156,7 @@ class TestComputeTargetDeclineActions:
         ]
         actions = compute_target_decline_actions(
             bunk_requests=bunk_requests,
-            inactive_cm_ids={1001},
-            active_session_by_cm_id={1002: 200, 1003: 100},
+            active_sessions_by_cm_id={1002: {200}, 1003: {100}},
         )
 
         assert sorted((a.bunk_request_id, a.reason) for a in actions) == [
@@ -193,7 +207,6 @@ class TestApplyTargetDecline:
         ]
         pb_client = MagicMock()
 
-        # Make the second update raise
         def update_side_effect(rec_id: str, _data: dict[str, Any]) -> None:
             if rec_id == "br2":
                 raise RuntimeError("simulated PB error")
@@ -205,6 +218,103 @@ class TestApplyTargetDecline:
         assert result["declined_count"] == 2
         assert result["error_count"] == 1
         assert pb_client.collection.return_value.update.call_count == 3
+
+
+def _make_attendee(person_id: int, status_id: int, session_cm_id: int) -> MagicMock:
+    """Build a MagicMock attendee record whose .expand.session.cm_id resolves."""
+    a = MagicMock()
+    a.person_id = person_id
+    a.status_id = status_id
+    session = MagicMock()
+    session.cm_id = session_cm_id
+    a.expand = {"session": session}
+    return a
+
+
+def _make_br(br_id: str, requestee_id: int | None, session_id: int, status: str = "resolved") -> MagicMock:
+    """Build a MagicMock bunk_requests record."""
+    br = MagicMock()
+    br.id = br_id
+    br.requestee_id = requestee_id
+    br.session_id = session_id
+    br.status = status
+    return br
+
+
+class TestRunTargetDeclinePhase:
+    """Integration: full classification + decision + application path.
+
+    This catches multi-attendee-per-person scenarios that the pure-function
+    tests don't reach (because they pre-construct the active_sessions map).
+    """
+
+    def test_multi_session_enrolled_person_with_one_cancelled_row_is_not_declined(self) -> None:
+        """Production scenario from person 8774023: 4× enrolled + 1× cancelled.
+        Phase C must NOT decline incoming BRs for them."""
+        attendees = [
+            _make_attendee(1001, status_id=2, session_cm_id=100),
+            _make_attendee(1001, status_id=2, session_cm_id=200),
+            _make_attendee(1001, status_id=2, session_cm_id=300),
+            _make_attendee(1001, status_id=2, session_cm_id=400),
+            _make_attendee(1001, status_id=32, session_cm_id=500),  # cancelled
+        ]
+        brs = [
+            _make_br("br1", requestee_id=1001, session_id=100),
+            _make_br("br2", requestee_id=1001, session_id=300),
+        ]
+
+        pb_client = MagicMock()
+        pb_client.collection.return_value.get_full_list.side_effect = [attendees, brs]
+
+        result = run_target_decline_phase(pb_client, year=2025)
+
+        assert result == {"declined_count": 0, "error_count": 0}
+        pb_client.collection.return_value.update.assert_not_called()
+
+    def test_session_mismatch_for_session_person_is_not_in(self) -> None:
+        """Person enrolled in {100, 200}; BR for session 300 → session_mismatch."""
+        attendees = [
+            _make_attendee(1001, status_id=2, session_cm_id=100),
+            _make_attendee(1001, status_id=2, session_cm_id=200),
+        ]
+        brs = [_make_br("br1", requestee_id=1001, session_id=300)]
+
+        pb_client = MagicMock()
+        pb_client.collection.return_value.get_full_list.side_effect = [attendees, brs]
+
+        result = run_target_decline_phase(pb_client, year=2025)
+
+        assert result == {"declined_count": 1, "error_count": 0}
+        pb_client.collection.return_value.update.assert_called_once_with(
+            "br1", {"status": "declined", "disposition_reason": "session_mismatch"}
+        )
+
+    def test_fully_cancelled_person_gets_target_not_attending(self) -> None:
+        """All status_id != 2 rows → person never enters active_sessions_by_cm_id."""
+        attendees = [
+            _make_attendee(1001, status_id=32, session_cm_id=100),  # cancelled
+            _make_attendee(1001, status_id=32, session_cm_id=200),  # cancelled
+        ]
+        brs = [_make_br("br1", requestee_id=1001, session_id=100)]
+
+        pb_client = MagicMock()
+        pb_client.collection.return_value.get_full_list.side_effect = [attendees, brs]
+
+        result = run_target_decline_phase(pb_client, year=2025)
+
+        assert result == {"declined_count": 1, "error_count": 0}
+        pb_client.collection.return_value.update.assert_called_once_with(
+            "br1", {"status": "declined", "disposition_reason": "target_not_attending"}
+        )
+
+    def test_attendees_fetch_failure_returns_error_without_writing(self) -> None:
+        pb_client = MagicMock()
+        pb_client.collection.return_value.get_full_list.side_effect = RuntimeError("PB down")
+
+        result = run_target_decline_phase(pb_client, year=2025)
+
+        assert result == {"declined_count": 0, "error_count": 1}
+        pb_client.collection.return_value.update.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1069.

## Summary

Replaces the requestee-only fast-path approach with a coherent two-step design that complements the existing orphan purge in `bunk_requests` CSV sync.

## What main already does (don't reinvent)

The existing `bunk_requests` CSV intake's orphan purge already handles the **requester side** of cancellations on every daily run, even without a fresh CSV upload, as long as the on-disk CSV exists:

1. Attendees sync writes the new `status_id` first.
2. `bunk_requests` sync's `loadValidPersonIDs()` filters by `status='enrolled'` — cancelled person no longer in the valid set.
3. `processRow` skips their CSV row (`enrolled=false`), so `csvPersonIDs` doesn't include them.
4. `purgeOrphanedRequests` deletes their OBRs and `bunk_requests` where `requester_id = cmID`.

## What this PR adds

### 1. `reconcile_request_lifecycle` — new Go sync step between `attendees` and `bunk_requests`

Single responsibility: detect requesters whose current `attendees.session` for the year differs from the `session_id` stored on any of their `bunk_requests`, and mark their OBRs as `processed=''` so the existing pipeline rebuilds them.

Daily ordering becomes: `attendees → reconcile_request_lifecycle → bunk_requests → process_requests`. New step is a no-op on quiet days.

### 2. Phase C target-decline — final phase inside `process_requests` (Python)

Two targeted UPDATEs against `bunk_requests`. Each is a no-op when nothing matches:

- Decline rows where `requestee_id` is no longer attending → `disposition_reason='target_not_attending'`
- Decline rows where `requestee_id` is in a different session → `disposition_reason='session_mismatch'`

Disposition reason vocabulary matches the existing conflict detector. Sidecar errors are logged but never fail the surrounding pipeline.

## Coverage matrix

| Scenario | Handled by |
|---|---|
| B cancels, requests **from** B (B as requester) | Existing orphan purge in `bunk_requests` sync |
| B cancels, requests **to** B (B as requestee) | Phase C — `target_not_attending` UPDATE |
| B moves session, requests **from** B | `reconcile_request_lifecycle` marks B's OBRs unprocessed → process_requests rebuilds → conflict detector emits `SESSION_MISMATCH → DECLINED` |
| B moves session, requests **to** B | Phase C — `session_mismatch` UPDATE |

## Test plan

- [x] `TestFindMovedRequesters` — 7 pure-function cases
- [x] `TestReconcileRequestLifecycle_MarksMovedRequestersOBRsUnprocessed` — moved requester's OBRs flipped, stable requesters untouched
- [x] `TestReconcileRequestLifecycle_IgnoresInactiveRequesters` — orphan purge handles cancellations, this step doesn't double-touch
- [x] `TestReconcileRequestLifecycle_NoOpWhenNoStaleRows` — no-op when steady-state
- [x] `TestReconcileRequestLifecycle_YearScoped` — only touches the current year
- [x] `TestComputeTargetDeclineActions` — 8 cases for action computation (inactive, session mismatch, precedence, edge cases)
- [x] `TestApplyTargetDecline` — 3 cases for PB application (success, empty, error resilience)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic cleanup of stale bunk requests: requests are now automatically declined when the requestee is no longer an active attendee or has moved to a different session.
  * Enhanced request lifecycle reconciliation to detect and handle requester session changes and mark requests for reprocessing when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->