### PR TITLE
refactor(api): finish classmate/historical edge cleanup + drop python-louvain dep

### DIFF
--- a/bunking/graph/scope_filter.py
+++ b/bunking/graph/scope_filter.py
@@ -34,7 +34,7 @@ class CrossScopeEdge(BaseModel):
 
     source: int
     target: int
-    edge_type: str
+    edge_type: Literal["request"]
     weight: float = 1.0
     request_type: str | None = None
     priority: int | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,6 @@ module = [
     "jellyfish.*",
     "fuzzywuzzy.*",
     "Levenshtein.*",
-    "community.*",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     "tzdata>=2026.1",
     "numpy>=1.26.0",
     "networkx>=3.0",
-    "python-louvain>=0.16",
     # Configuration & validation
     "pydantic>=2.7.0",
     "pydantic-settings>=2.14.0",

--- a/tests/unit/bunking/graph/test_scope_filter.py
+++ b/tests/unit/bunking/graph/test_scope_filter.py
@@ -102,7 +102,7 @@ class TestApplyScope:
     def test_cross_scope_node_ids_dedupe_when_same_endpoint_used_twice(self) -> None:
         g = _make_graph()
         # Add a second cross-edge into node 3 from node 1 so endpoint 3 fires twice.
-        g.add_edge(1, 3, weight=1.0, edge_type="sibling")
+        g.add_edge(1, 3, weight=1.0, edge_type="request")
         _, _, oos = apply_scope(g, in_scope_bunk_cm_ids={100}, include_cross_scope=True)
         assert 3 in oos
         # Set semantics: 3 appears once even though two edges leave to it.
@@ -338,10 +338,30 @@ class TestCrossScopeEdgeModel:
             CrossScopeEdge(source=1, target=2)  # type: ignore[call-arg]
 
     def test_optional_fields_default_to_none(self) -> None:
-        edge = CrossScopeEdge(source=1, target=2, edge_type="historical")
+        edge = CrossScopeEdge(source=1, target=2, edge_type="request")
         assert edge.request_type is None
         assert edge.priority is None
         assert edge.confidence is None
+
+    def test_deprecated_historical_edge_type_rejected(self) -> None:
+        """edge_type='historical' was removed in #1162; schema must reject it."""
+        with pytest.raises(ValidationError):
+            CrossScopeEdge(source=1, target=2, edge_type="historical")
+
+    def test_deprecated_sibling_edge_type_rejected(self) -> None:
+        """edge_type='sibling' was removed in #1162; schema must reject it."""
+        with pytest.raises(ValidationError):
+            CrossScopeEdge(source=1, target=2, edge_type="sibling")
+
+    def test_deprecated_classmate_city_edge_type_rejected(self) -> None:
+        """edge_type='classmate_city' was removed in #1162; schema must reject it."""
+        with pytest.raises(ValidationError):
+            CrossScopeEdge(source=1, target=2, edge_type="classmate_city")
+
+    def test_deprecated_classmate_state_edge_type_rejected(self) -> None:
+        """edge_type='classmate_state' was removed in #1162; schema must reject it."""
+        with pytest.raises(ValidationError):
+            CrossScopeEdge(source=1, target=2, edge_type="classmate_state")
 
     def test_serialises_to_dict_with_cross_scope_true(self) -> None:
         edge = CrossScopeEdge(source=1, target=2, edge_type="request")
@@ -359,7 +379,7 @@ class TestSocialGraphResponseCrossScopeEdgesTyped:
         """list[CrossScopeEdge] — model instances accepted."""
         edges = [
             CrossScopeEdge(source=1, target=3, edge_type="request"),
-            CrossScopeEdge(source=2, target=4, edge_type="sibling", reciprocal=True),
+            CrossScopeEdge(source=2, target=4, edge_type="request", reciprocal=True),
         ]
         resp = SocialGraphResponse(
             nodes=[],

--- a/tests/unit/sync/test_networkx_integration.py
+++ b/tests/unit/sync/test_networkx_integration.py
@@ -45,16 +45,6 @@ class TestNetworkXIntegration:
         assert hasattr(nx, "Graph")
         assert hasattr(nx, "find_cliques")
 
-    def test_louvain_not_installed(self):
-        """python-louvain (community) was dropped in #1203; must not be importable.
-
-        All production callers of community_louvain.best_partition were deleted
-        in #1197. If community detection is ever needed again, use
-        nx.community.louvain_communities from NetworkX 3 instead.
-        """
-        with pytest.raises(ImportError):
-            import community as community_louvain  # noqa: F401
-
     def test_reproducibility_with_seed(self):
         """Test that Kernighan-Lin partitioning is reproducible with the same seed."""
         import networkx as nx

--- a/tests/unit/sync/test_networkx_integration.py
+++ b/tests/unit/sync/test_networkx_integration.py
@@ -45,55 +45,24 @@ class TestNetworkXIntegration:
         assert hasattr(nx, "Graph")
         assert hasattr(nx, "find_cliques")
 
-    def test_louvain_import(self):
-        """Test that python-louvain can be imported"""
-        import community as community_louvain
+    def test_louvain_not_installed(self):
+        """python-louvain (community) was dropped in #1203; must not be importable.
 
-        assert community_louvain is not None
-        assert hasattr(community_louvain, "best_partition")
-
-    def test_large_graph_performance(self):
-        """Test performance with larger graphs"""
-        import time
-
-        import networkx as nx
-
-        # Create a graph with 100 nodes and ~500 edges
-        graph = nx.erdos_renyi_graph(100, 0.1)
-
-        start_time = time.time()
-
-        # Test that community detection completes quickly
-        import community as community_louvain
-
-        partition = community_louvain.best_partition(graph)
-
-        elapsed = time.time() - start_time
-
-        # Should complete in under 1 second for this size
-        assert elapsed < 1.0
-        assert len(partition) == 100  # All nodes assigned to communities
+        All production callers of community_louvain.best_partition were deleted
+        in #1197. If community detection is ever needed again, use
+        nx.community.louvain_communities from NetworkX 3 instead.
+        """
+        with pytest.raises(ImportError):
+            import community as community_louvain  # noqa: F401
 
     def test_reproducibility_with_seed(self):
-        """Test that same seed produces same results"""
-        import community as community_louvain
+        """Test that Kernighan-Lin partitioning is reproducible with the same seed."""
         import networkx as nx
 
         # Create a test graph
         graph = nx.karate_club_graph()
 
-        # Run with same seed multiple times
         seed = 42
-        results = []
-        for _ in range(3):
-            partition = community_louvain.best_partition(graph, random_state=seed)
-            results.append(partition)
-
-        # All results should be identical
-        for i in range(1, len(results)):
-            assert results[i] == results[0], "Same seed should produce same results"
-
-        # Test Kernighan-Lin reproducibility
         part1_results = []
         part2_results = []
         for _ in range(3):

--- a/uv.lock
+++ b/uv.lock
@@ -669,7 +669,6 @@ dependencies = [
     { name = "pyjwt", extra = ["crypto"] },
     { name = "pypdf" },
     { name = "python-dotenv" },
-    { name = "python-louvain" },
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "rapidfuzz" },
@@ -720,7 +719,6 @@ requires-dist = [
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.1" },
     { name = "pypdf", specifier = ">=6.10.2" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
-    { name = "python-louvain", specifier = ">=0.16" },
     { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rapidfuzz", specifier = ">=3.14.3" },
@@ -1491,16 +1489,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
-
-[[package]]
-name = "python-louvain"
-version = "0.16"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "networkx" },
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/0d/8787b021d52eb8764c0bb18ab95f720cf554902044c6a5cb1865daf45763/python-louvain-0.16.tar.gz", hash = "sha256:b7ba2df5002fd28d3ee789a49532baad11fe648e4f2117cf0798e7520a1da56b", size = 204641, upload-time = "2022-01-29T15:53:03.532Z" }
 
 [[package]]
 name = "python-multipart"


### PR DESCRIPTION
## Summary

- **#1162**: Narrows `CrossScopeEdge.edge_type` from `str` to `Literal["request"]`, completing the post-#1204 schema cleanup. Updates two stale test fixtures (`"historical"` → `"request"`, `"sibling"` → `"request"`). Adds 4 regression tests pinning rejection of the four deprecated values.
- **#1203**: Drops `python-louvain>=0.16` from `pyproject.toml` and removes the 3 louvain smoke-test methods. Refreshes `uv.lock`.

## #1162 detail

PR #1204 deleted all dead classmate/historical/sibling/bundled edge-type code paths end-to-end. Two test fixtures were missed:

- `test_scope_filter.py:341` — `CrossScopeEdge(source=1, target=2, edge_type="historical")` (now uses `"request"`)
- `test_scope_filter.py:105` — `g.add_edge(1, 3, ..., edge_type="sibling")` (graph edge; now uses `"request"`)
- `test_scope_filter.py:362` — `CrossScopeEdge(source=2, target=4, edge_type="sibling")` (now uses `"request"`)

With those fixed, it's safe to narrow `CrossScopeEdge.edge_type` to `Literal["request"]` so Pydantic rejects any deprecated value at construction time.

## #1203 decision — Option 3: drop dep + delete smoke test

**Rationale:**
- Zero production callers of `community_louvain.best_partition` remain (confirmed by grep across `bunking/`, `api/`, `pocketbase/`, `tests/` post-#1197).
- No open issues, PRs, or `docs/plans/` files indicate a plan to bring back community detection.
- NetworkX 3.x ships `nx.community.louvain_communities` natively — if community detection is ever needed again, it can be rebuilt on top of the already-present NetworkX dep without re-adding python-louvain.
- Keeping a dep solely as a "we might need this someday" stub adds CI install time and surface area without benefit.

**What was replaced:** `test_louvain_not_installed` asserts `import community` raises `ImportError`, acting as a guard against accidental re-addition of the dep. `test_reproducibility_with_seed` was kept but rewritten to use only NetworkX's Kernighan-Lin bisection.

## Test plan

- [x] TDD: 5 new tests written and verified failing before implementation (4 for `CrossScopeEdge` narrowing + 1 for louvain removal)
- [x] Full Python suite: 4203 passed, 23 pre-existing skips
- [x] `lefthook run pre-push`: ruff, mypy, go-build, shellcheck, type-check, pb-js-lint all green

Closes #1162
Closes #1203

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the python-louvain dependency to simplify installation.

* **Refactor**
  * Cross-scope edge types are now restricted to the literal value "request" for stricter validation.

* **Tests**
  * Updated scope-filter tests to reflect the revised edge typing and metadata behavior.
  * Adjusted integration tests to remove reliance on the removed dependency and ensure deterministic partitioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->