### PR TITLE
build(docker): set GOTOOLCHAIN=auto in pocketbase go-builder

### DIFF
--- a/docker/Dockerfile.init
+++ b/docker/Dockerfile.init
@@ -3,6 +3,10 @@
 # =============================================================================
 FROM dhi.io/golang:1.26-dev AS go-builder
 
+# Allow Go to auto-download the toolchain pinned in go.mod when the base image
+# ships an older patch version (dhi.io golang tags lag upstream by a few patches).
+ENV GOTOOLCHAIN=auto
+
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
 WORKDIR /build

--- a/docker/Dockerfile.pocketbase
+++ b/docker/Dockerfile.pocketbase
@@ -3,6 +3,10 @@
 # =============================================================================
 FROM dhi.io/golang:1.26-dev AS go-builder
 
+# Allow Go to auto-download the toolchain pinned in go.mod when the base image
+# ships an older patch version (dhi.io golang tags lag upstream by a few patches).
+ENV GOTOOLCHAIN=auto
+
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
 WORKDIR /build


### PR DESCRIPTION
## Summary
- Fixes failing CD on `main` (`df13ef97`, `8d86fb59`) where `go mod download` aborted with `go: go.mod requires go >= 1.26.3 (running go 1.26.2; GOTOOLCHAIN=local)`.
- PR #1204 already bumped `pocketbase/go.mod` to `go 1.26.3` (transitive requirement from `pocketbase/pocketbase v0.37.4`), but `dhi.io/golang:1.26-dev` still ships Go 1.26.2 and defaults `GOTOOLCHAIN=local`, so Go refused to auto-download the newer toolchain.
- Setting `ENV GOTOOLCHAIN=auto` in the `go-builder` stage lets Go fetch `go1.26.3` transparently. Decouples our build from base-image patch lag.

## Test plan
- [x] Local: `docker buildx build -f docker/Dockerfile.pocketbase --target go-builder .` — passes (`go: downloading go1.26.3 (linux/amd64)` then build succeeds)
- [ ] CD green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Docker build process updated to automatically use the correct Go toolchain version for PocketBase, improving build reliability and compatibility across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->