### PR TITLE
fix(frontend): pin cytoscape-layers as explicit dep so prod build resolves

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "cytoscape-bubblesets": "^4.0.0",
         "cytoscape-cola": "^2.5.1",
         "cytoscape-fcose": "^2.2.0",
+        "cytoscape-layers": "^3.1.0",
         "cytoscape-popper": "^4.0.1",
         "cytoscape-svg": "^0.4.0",
         "date-fns": "^4.1.0",
@@ -3342,6 +3343,15 @@
       },
       "peerDependencies": {
         "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-layers": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-layers/-/cytoscape-layers-3.1.0.tgz",
+      "integrity": "sha512-HhldyRPURRn4axeDsCiKdKqiZN8bcoWjclLXl3kWekDd7Wy4QHo5cntm4W4kxL/R0u8AA9VAfmNB1P7nJ9scew==",
+      "license": "MIT",
+      "peerDependencies": {
+        "cytoscape": "^3.23.0"
       }
     },
     "node_modules/cytoscape-popper": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,6 +48,7 @@
     "cytoscape-bubblesets": "^4.0.0",
     "cytoscape-cola": "^2.5.1",
     "cytoscape-fcose": "^2.2.0",
+    "cytoscape-layers": "^3.1.0",
     "cytoscape-popper": "^4.0.1",
     "cytoscape-svg": "^0.4.0",
     "date-fns": "^4.1.0",


### PR DESCRIPTION
## Summary

- `start_dev` on main fails: Vite/Rolldown can't resolve `cytoscape-layers` import inside `cytoscape-bubblesets/build/index.js`
- Adds `cytoscape-layers@^3.1.0` to `frontend/package.json` as an explicit dependency
- One-line fix; no source changes

## Root cause

PR #1211 ran `npm install --legacy-peer-deps` to install `openapi-typescript@7` (which pins `typescript: ^5.x` while the project is on TS 6). The legacy-peer-deps run dropped `cytoscape-layers@3.1.0` from the lockfile — it was previously present as `cytoscape-bubblesets@4.1.0`'s peer dependency.

`cytoscape-bubblesets`'s build does `import { ... } from 'cytoscape-layers'` unconditionally, so the prod bundler aborts when the module is missing. Dev imports may have been masked by Vite's lazy resolution; the failure surfaces at the prod build step in `start_dev`.

We don't import `cytoscape-layers` directly anywhere in `src/` — pinning it as a regular dep just restores the transitive install that the lockfile lost.

## Follow-up (separate issue)

A larger fix for `openapi-typescript`'s TS 6 peer-dep mismatch is being tracked separately so we can drop `--legacy-peer-deps` from CI/codegen entirely.

## Test plan

- [x] `cd frontend && npm install` — adds 1 package, no audit issues
- [x] `cd frontend && npm run build` — builds clean
- [x] `cd frontend && npm run type-check` — passes
- [x] `cd frontend && npm run lint` — 0 errors (pre-existing warnings only)
- [ ] User verifies `./scripts/start_dev.sh` on main now boots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to enhance compatibility and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->