### PR TITLE
test(sync): Python↔TS source_field map drift guard (closes #1217)

### DIFF
--- a/tests/unit/sync/bunk_request_processor/core/test_source_field_map_ts_parity.py
+++ b/tests/unit/sync/bunk_request_processor/core/test_source_field_map_ts_parity.py
@@ -1,0 +1,72 @@
+"""Cross-language drift guard for the source_field → RequestSource mapping.
+
+Issue #1217. The same 5→2 mapping lives in two places:
+
+- Python: ``bunking/sync/bunk_request_processor/core/models.py`` — ``_SOURCE_FIELD_MAP``
+- TypeScript: ``frontend/src/utils/sourceFromField.ts`` — ``SOURCE_FIELD_MAP``
+
+If a sixth source_field is added on the Python side (or one is renamed), the TS
+helper will silently throw at runtime in the browser when that value reaches
+``safeSourceFromField``. This test parses the TS file and asserts both sides
+agree, so drift fails CI rather than the user.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from bunking.sync.bunk_request_processor.core.models import _SOURCE_FIELD_MAP
+
+# tests/unit/sync/bunk_request_processor/core/test_source_field_map_ts_parity.py → repo root
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_TS_FILE = _REPO_ROOT / "frontend" / "src" / "utils" / "sourceFromField.ts"
+
+# Matches the SOURCE_FIELD_MAP literal: ``key: 'value'`` or ``key: "value"``,
+# trailing comma optional.
+_TS_ENTRY_RE = re.compile(
+    r"^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*['\"]([a-zA-Z_]+)['\"]\s*,?\s*$",
+    re.MULTILINE,
+)
+
+
+def _parse_ts_source_field_map(ts_source: str) -> dict[str, str]:
+    """Extract the SOURCE_FIELD_MAP literal from sourceFromField.ts."""
+    match = re.search(
+        r"SOURCE_FIELD_MAP\s*:\s*Readonly<Record<[^>]+>>\s*=\s*\{([^}]*)\}",
+        ts_source,
+        re.DOTALL,
+    )
+    assert match, "SOURCE_FIELD_MAP literal not found in sourceFromField.ts"
+    return {m.group(1): m.group(2) for m in _TS_ENTRY_RE.finditer(match.group(1))}
+
+
+def test_python_and_ts_source_field_maps_agree() -> None:
+    """Python ``_SOURCE_FIELD_MAP`` and TS ``SOURCE_FIELD_MAP`` must match.
+
+    If this fails, update whichever side is out of date so they stay in sync.
+    """
+    assert _TS_FILE.exists(), f"missing TS source: {_TS_FILE}"
+    ts_map = _parse_ts_source_field_map(_TS_FILE.read_text())
+
+    python_map = {key: source.value for key, source in _SOURCE_FIELD_MAP.items()}
+
+    assert ts_map == python_map, (
+        "source_field map drift between Python and TypeScript.\n"
+        f"  Python ({len(python_map)} entries): {sorted(python_map.items())}\n"
+        f"  TypeScript ({len(ts_map)} entries): {sorted(ts_map.items())}\n"
+        "Update either bunking/sync/bunk_request_processor/core/models.py or "
+        "frontend/src/utils/sourceFromField.ts so both sides agree."
+    )
+
+
+def test_ts_parser_extracts_all_five_entries() -> None:
+    """Sanity check: parser finds exactly the 5 known SourceField entries."""
+    ts_map = _parse_ts_source_field_map(_TS_FILE.read_text())
+    assert set(ts_map.keys()) == {
+        "bunk_with",
+        "socialize_with",
+        "not_bunk_with",
+        "bunking_notes",
+        "internal_notes",
+    }

--- a/tests/unit/sync/bunk_request_processor/core/test_source_field_map_ts_parity.py
+++ b/tests/unit/sync/bunk_request_processor/core/test_source_field_map_ts_parity.py
@@ -23,9 +23,9 @@ _REPO_ROOT = Path(__file__).resolve().parents[5]
 _TS_FILE = _REPO_ROOT / "frontend" / "src" / "utils" / "sourceFromField.ts"
 
 # Matches the SOURCE_FIELD_MAP literal: ``key: 'value'`` or ``key: "value"``,
-# trailing comma optional.
+# trailing comma optional, optional ``// …`` end-of-line comment tolerated.
 _TS_ENTRY_RE = re.compile(
-    r"^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*['\"]([a-zA-Z_]+)['\"]\s*,?\s*$",
+    r"^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*['\"]([a-zA-Z_]+)['\"]\s*,?\s*(?://[^\n]*)?\s*$",
     re.MULTILINE,
 )
 
@@ -37,7 +37,8 @@ def _parse_ts_source_field_map(ts_source: str) -> dict[str, str]:
         ts_source,
         re.DOTALL,
     )
-    assert match, "SOURCE_FIELD_MAP literal not found in sourceFromField.ts"
+    if not match:
+        raise ValueError("SOURCE_FIELD_MAP literal not found in sourceFromField.ts")
     return {m.group(1): m.group(2) for m in _TS_ENTRY_RE.finditer(match.group(1))}
 
 
@@ -60,13 +61,7 @@ def test_python_and_ts_source_field_maps_agree() -> None:
     )
 
 
-def test_ts_parser_extracts_all_five_entries() -> None:
-    """Sanity check: parser finds exactly the 5 known SourceField entries."""
+def test_ts_parser_returns_non_empty_map() -> None:
+    """Sanity check: parser produced at least one entry (catches silent regex breakage)."""
     ts_map = _parse_ts_source_field_map(_TS_FILE.read_text())
-    assert set(ts_map.keys()) == {
-        "bunk_with",
-        "socialize_with",
-        "not_bunk_with",
-        "bunking_notes",
-        "internal_notes",
-    }
+    assert len(ts_map) > 0


### PR DESCRIPTION
## Summary

Adds a CI parity test that fails if the Python `_SOURCE_FIELD_MAP` in `bunking/sync/bunk_request_processor/core/models.py` ever drifts from the TypeScript `SOURCE_FIELD_MAP` in `frontend/src/utils/sourceFromField.ts`.

Today both sides agree (5 entries, identical 5→2 mapping). Without this guard, adding a sixth source_field to one side and forgetting the other silently throws at runtime in the browser. Now it fails CI instead.

## Approach

Per Option B in #1217: a Python pytest that imports `_SOURCE_FIELD_MAP` and parses the TS file with a regex (`SOURCE_FIELD_MAP\s*:\s*Readonly<...>\s*=\s*{...}` then `key: 'value'` entries inside). No build-time coupling, no shared JSON; just a single ~70-line test that catches the realistic failure mode.

## Test plan

- [x] `uv run pytest tests/unit/sync/bunk_request_processor/core/test_source_field_map_ts_parity.py` — 2/2 pass
- [x] Drift verified: temporarily flipped `socialize_with: 'family'` → `'staff'` in the TS file; test fails with a clear diff naming the divergent key
- [x] Full unit suite (`pre-push-verification`): 4210 passed, 14 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated tests to prevent drift between the Python and TypeScript mappings used by the app.
  * Includes a strict parity test that ensures the two mappings match exactly and a sanity test that verifies the TypeScript mapping is present and non-empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->