### PR TITLE
refactor(frontend): replace nested ternaries with switch/lookup patterns (closes #955)

### DIFF
--- a/frontend/src/components/AllCampersView.tsx
+++ b/frontend/src/components/AllCampersView.tsx
@@ -41,6 +41,7 @@ import type { BunksResponse } from '../types/pocketbase-types'
 import { SUMMER_CAMP_TYPES } from '../utils/sessionTypePredicates'
 import { buildCsvContent, downloadCsv, todayIso } from '../utils/csvExport'
 import { buildCamperRows, CAMPER_CSV_HEADERS } from '../utils/csvExportHelpers'
+import { filterSexLabel, filterSexCsvSegment } from '../utils/filterSexFormat'
 
 // Helper function to properly case a name
 function properCase(str: string | undefined): string {
@@ -433,7 +434,7 @@ export default function AllCampersView() {
             <Listbox value={filterSex} onChange={(v) => setFilterSex(v)}>
               <div className="relative">
                 <ListboxButton className="listbox-button-compact">
-                  <span>{filterSex === 'all' ? 'All' : filterSex === 'M' ? 'Boys' : 'Girls'}</span>
+                  <span>{filterSexLabel(filterSex)}</span>
                   <ChevronDown className="text-muted-foreground h-4 w-4" />
                 </ListboxButton>
                 <ListboxOptions className="listbox-options w-auto min-w-[100px]">
@@ -533,7 +534,7 @@ export default function AllCampersView() {
                 onClick={() => {
                   const rows = buildCamperRows(filteredCampers as Camper[], allSessions)
                   const csv = buildCsvContent([...CAMPER_CSV_HEADERS], rows)
-                  const genderPart = filterSex === 'M' ? '-boys' : filterSex === 'F' ? '-girls' : ''
+                  const genderPart = filterSexCsvSegment(filterSex)
                   downloadCsv(csv, `all-campers${genderPart}-${todayIso()}.csv`)
                 }}
                 className="btn-ghost flex items-center gap-1.5 px-2 py-1.5 text-sm"

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -21,6 +21,7 @@ import {
   getGenderIdentityDisplay,
   getGenderCategory,
   getGenderBadgeClasses,
+  formatGenderShort,
 } from '../utils/genderUtils'
 import { formatGradeOrdinal } from '../utils/gradeUtils'
 import { formatAge } from '../utils/age'
@@ -1290,7 +1291,7 @@ export default function CamperDetailsPanel({
                 </button>
               </div>
               <div className="text-forest-100 mt-1 flex items-center gap-2 text-xs">
-                <span>{camper.gender === 'M' ? 'M' : camper.gender === 'F' ? 'F' : 'NB'}</span>
+                <span>{formatGenderShort(camper.gender)}</span>
                 <span>•</span>
                 <span>{camper.pronouns ?? 'No Preference'}</span>
                 <span>•</span>

--- a/frontend/src/components/CampersView.tsx
+++ b/frontend/src/components/CampersView.tsx
@@ -15,6 +15,7 @@ import { getDisplayAgeForYear } from '../utils/displayAge'
 import type { Camper, Bunk, Session } from '../types/app-types'
 import { buildCsvContent, downloadCsv, slugify, todayIso } from '../utils/csvExport'
 import { buildCamperRows, CAMPER_CSV_HEADERS } from '../utils/csvExportHelpers'
+import { filterSexLabel, filterSexCsvSegment } from '../utils/filterSexFormat'
 
 // Bunk area color based on bunk prefix with dark mode support
 function getBunkAreaColor(bunkName: string | undefined): string {
@@ -222,7 +223,7 @@ export default function CampersView({
             <Listbox value={filterSex} onChange={(v) => setFilterSex(v)}>
               <div className="relative">
                 <ListboxButton className="listbox-button-compact">
-                  <span>{filterSex === 'all' ? 'All' : filterSex === 'M' ? 'Boys' : 'Girls'}</span>
+                  <span>{filterSexLabel(filterSex)}</span>
                   <ChevronDown className="text-muted-foreground h-4 w-4" />
                 </ListboxButton>
                 <ListboxOptions className="listbox-options w-auto min-w-[100px]">
@@ -316,7 +317,7 @@ export default function CampersView({
                   const rows = buildCamperRows(filteredCampers, sessions)
                   const csv = buildCsvContent([...CAMPER_CSV_HEADERS], rows)
                   const sessionSlug = _session ? slugify(_session.name) : 'session'
-                  const genderPart = filterSex === 'M' ? '-boys' : filterSex === 'F' ? '-girls' : ''
+                  const genderPart = filterSexCsvSegment(filterSex)
                   let bunkPart = ''
                   if (filterBunk === 'unassigned') {
                     bunkPart = '-unassigned'

--- a/frontend/src/components/OptimizeBunksButton.tsx
+++ b/frontend/src/components/OptimizeBunksButton.tsx
@@ -86,6 +86,7 @@ const warmthStyles = {
     text: 'text-blue-600 dark:text-blue-400',
     bg: 'bg-blue-50 dark:bg-blue-950/30',
     iconBg: 'bg-blue-100 dark:bg-blue-900/50',
+    dot: 'bg-blue-500',
   },
   warm: {
     glow: 'shadow-[0_0_15px_rgba(34,197,94,0.3)]',
@@ -94,6 +95,7 @@ const warmthStyles = {
     text: 'text-green-600 dark:text-green-400',
     bg: 'bg-green-50 dark:bg-green-950/30',
     iconBg: 'bg-green-100 dark:bg-green-900/50',
+    dot: 'bg-green-500',
   },
   hot: {
     glow: 'shadow-[0_0_20px_rgba(251,146,60,0.4)]',
@@ -102,6 +104,7 @@ const warmthStyles = {
     text: 'text-orange-600 dark:text-orange-400',
     bg: 'bg-orange-50 dark:bg-orange-950/30',
     iconBg: 'bg-orange-100 dark:bg-orange-900/50',
+    dot: 'animate-pulse bg-orange-500',
   },
   blazing: {
     glow: 'shadow-[0_0_25px_rgba(239,68,68,0.5)]',
@@ -110,6 +113,7 @@ const warmthStyles = {
     text: 'text-red-600 dark:text-red-400',
     bg: 'bg-red-50 dark:bg-red-950/30',
     iconBg: 'bg-red-100 dark:bg-red-900/50',
+    dot: 'animate-pulse bg-red-500',
   },
 }
 
@@ -342,7 +346,7 @@ export default function OptimizeBunksButton({
                       {/* Selection indicator */}
                       {isSelected && (
                         <div
-                          className={`h-2 w-2 flex-shrink-0 rounded-full ${level.warmth === 'cool' ? 'bg-blue-500' : ''} ${level.warmth === 'warm' ? 'bg-green-500' : ''} ${level.warmth === 'hot' ? 'animate-pulse bg-orange-500' : ''} ${level.warmth === 'blazing' ? 'animate-pulse bg-red-500' : ''} `}
+                          className={`h-2 w-2 flex-shrink-0 rounded-full ${warmthStyles[level.warmth].dot}`}
                         />
                       )}
                     </button>

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -467,12 +467,12 @@ function IssueGroup({
   }
 
   const styles = getSeverityStyles()
-  const SEVERITY_ICONS = {
+  const severityIcons = {
     error: AlertTriangle,
     warning: AlertCircle,
     info: Activity,
   } as const
-  const Icon = SEVERITY_ICONS[severity as keyof typeof SEVERITY_ICONS] ?? Activity
+  const Icon = severityIcons[severity as keyof typeof severityIcons] ?? Activity
 
   return (
     <div className={`rounded-xl border ${styles.border} overflow-hidden`}>

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -467,8 +467,12 @@ function IssueGroup({
   }
 
   const styles = getSeverityStyles()
-  const Icon =
-    severity === 'error' ? AlertTriangle : severity === 'warning' ? AlertCircle : Activity
+  const SEVERITY_ICONS = {
+    error: AlertTriangle,
+    warning: AlertCircle,
+    info: Activity,
+  } as const
+  const Icon = SEVERITY_ICONS[severity as keyof typeof SEVERITY_ICONS] ?? Activity
 
   return (
     <div className={`rounded-xl border ${styles.border} overflow-hidden`}>

--- a/frontend/src/components/SessionStats.tsx
+++ b/frontend/src/components/SessionStats.tsx
@@ -2,6 +2,12 @@ import { Users, Home, TrendingUp, AlertCircle, UserCheck } from 'lucide-react'
 import { getGenderIdentityDisplay, getGenderCategory } from '../utils/genderUtils'
 import type { Bunk, Camper } from '../types/app-types'
 
+function utilizationColor(utilization: number): 'red' | 'yellow' | 'purple' {
+  if (utilization >= 90) return 'red'
+  if (utilization >= 70) return 'yellow'
+  return 'purple'
+}
+
 interface SessionStatsProps {
   bunks: Bunk[]
   campers: Camper[]
@@ -63,7 +69,7 @@ export default function SessionStats({ bunks, campers, defaultCapacity = 12 }: S
       value: `${utilization.toFixed(0)}%`,
       detail: `${assignedCampers.length}/${effectiveCapacity} beds`,
       icon: TrendingUp,
-      color: utilization >= 90 ? 'red' : utilization >= 70 ? 'yellow' : 'purple',
+      color: utilizationColor(utilization),
       progress: utilization,
     },
     {

--- a/frontend/src/components/SolverProgressModal.tsx
+++ b/frontend/src/components/SolverProgressModal.tsx
@@ -373,13 +373,16 @@ export default function SolverProgressModal({
                 {['loading', 'searching', 'optimizing', 'finalizing'].map((p, i) => {
                   const phases = ['loading', 'searching', 'optimizing', 'finalizing']
                   const currentIndex = phases.indexOf(phase)
-                  const isActive = i === currentIndex
-                  const isPast = i < currentIndex
+
+                  let dotClass: string
+                  if (i === currentIndex) dotClass = 'w-8 bg-amber-500'
+                  else if (i < currentIndex) dotClass = 'w-2 bg-green-500'
+                  else dotClass = 'w-2 bg-muted'
 
                   return (
                     <div
                       key={p}
-                      className={`h-2 rounded-full transition-all duration-300 ${isActive ? 'w-8 bg-amber-500' : 'w-2'} ${isPast ? 'bg-green-500' : ''} ${!isActive && !isPast ? 'bg-muted' : ''} `}
+                      className={`h-2 rounded-full transition-all duration-300 ${dotClass}`}
                     />
                   )
                 })}

--- a/frontend/src/components/camper/HeroHeader.tsx
+++ b/frontend/src/components/camper/HeroHeader.tsx
@@ -8,6 +8,7 @@ import { CampMinderIcon } from '../icons'
 import { StatusBadge } from '../StatusBadge'
 import { getAvatarColor, getInitial } from '../../utils/avatarUtils'
 import { formatAge } from '../../utils/age'
+import { formatGenderFull } from '../../utils/genderUtils'
 import { formatGradeOrdinal } from '../../utils/gradeUtils'
 import { getDisplayAgeForYear } from '../../utils/displayAge'
 import { sessionNameToUrl } from '../../utils/sessionUtils'
@@ -73,8 +74,8 @@ export function HeroHeader({
                 </p>
               )}
             <p className="text-forest-100 mt-2 text-base sm:text-lg">
-              {camper.gender === 'M' ? 'Male' : camper.gender === 'F' ? 'Female' : 'Non-Binary'} •{' '}
-              {pronouns} • {formatAge(getDisplayAgeForYear(camper, currentYear) ?? 0)} •{' '}
+              {formatGenderFull(camper.gender)} • {pronouns} •{' '}
+              {formatAge(getDisplayAgeForYear(camper, currentYear) ?? 0)} •{' '}
               {formatGradeOrdinal(camper.grade)} Grade
             </p>
           </div>

--- a/frontend/src/components/camper/IdentityPanel.tsx
+++ b/frontend/src/components/camper/IdentityPanel.tsx
@@ -18,6 +18,7 @@ import {
   Users,
 } from 'lucide-react'
 import { formatAge } from '../../utils/age'
+import { formatGenderFull } from '../../utils/genderUtils'
 import { formatGradeOrdinal } from '../../utils/gradeUtils'
 import { getDisplayAgeForYear } from '../../utils/displayAge'
 import { useYear } from '../../hooks/useCurrentYear'
@@ -122,9 +123,7 @@ export function IdentityPanel({
                 Sex / Gender Identity
               </div>
               <div className="text-sm">
-                <span className="font-medium">
-                  {camper.gender === 'M' ? 'Male' : camper.gender === 'F' ? 'Female' : 'Non-Binary'}
-                </span>
+                <span className="font-medium">{formatGenderFull(camper.gender)}</span>
                 {' • '}
                 <span className="text-muted-foreground">
                   {camper.gender_identity_write_in && camper.gender_identity_write_in.trim() !== ''

--- a/frontend/src/components/graph/constants.ts
+++ b/frontend/src/components/graph/constants.ts
@@ -62,3 +62,14 @@ export const ZOOM_SETTINGS = {
   min: 0.1,
   max: 10,
 } as const
+
+/**
+ * Density threshold for hiding labels at a given zoom level. Lower zoom →
+ * higher threshold (hide more aggressively); higher zoom → lower threshold
+ * (show more labels).
+ */
+export function labelDensityThreshold(zoom: number): number {
+  if (zoom < 0.5) return 0.8
+  if (zoom < 0.7) return 0.6
+  return 0.4
+}

--- a/frontend/src/components/graph/graphInteractions.ts
+++ b/frontend/src/components/graph/graphInteractions.ts
@@ -3,6 +3,7 @@
  * Extracted from SocialNetworkGraph.tsx
  */
 import type { Core, NodeSingular } from 'cytoscape'
+import { labelDensityThreshold } from './constants'
 
 /**
  * Adjust label positions to prevent overlap
@@ -156,7 +157,7 @@ export function setupZoomBasedLabels(cy: Core): void {
 
   cy.on('zoom', () => {
     const zoom = cy.zoom()
-    const threshold = zoom < 0.5 ? 0.8 : zoom < 0.7 ? 0.6 : 0.4
+    const threshold = labelDensityThreshold(zoom)
 
     cy.nodes()
       .filter((n) => !n.data('isBunkParent'))

--- a/frontend/src/components/graph/graphLayout.ts
+++ b/frontend/src/components/graph/graphLayout.ts
@@ -4,6 +4,7 @@
  */
 import type { Core, NodeSingular } from 'cytoscape'
 import type { LayoutWorkerInput } from '../../workers/layoutWorker'
+import { labelDensityThreshold } from './constants'
 import type { ParentNodeElement, CamperNodeElement, EdgeElement } from './cytoscapeStyles'
 
 export interface FcoseOptionsParams {
@@ -182,7 +183,7 @@ export function setupGraphEventHandlers(
   // Dynamic label visibility based on zoom (skip parent nodes - they have fixed labels)
   cy.on('zoom', () => {
     const zoom = cy.zoom()
-    const threshold = zoom < 0.5 ? 0.8 : zoom < 0.7 ? 0.6 : 0.4
+    const threshold = labelDensityThreshold(zoom)
 
     cy.nodes()
       .filter((n) => !n.data('isBunkParent'))

--- a/frontend/src/components/metrics/TrendLineChart.tsx
+++ b/frontend/src/components/metrics/TrendLineChart.tsx
@@ -18,6 +18,7 @@ import { useMemo } from 'react'
 import type { YearMetrics } from '../../types/metrics'
 import { ChartCard } from './ChartCard'
 import { getNiceTicks, calculateVerticalLayout } from './cssChartUtils'
+import { formatLabelListValue, formatLabelListPercent } from '../../utils/chartFormatters'
 
 const COLORS = {
   total: 'hsl(160, 100%, 35%)', // Primary green
@@ -185,9 +186,7 @@ export function TrendLineChart({
                 position="top"
                 className="text-xs"
                 fill="hsl(var(--muted-foreground))"
-                formatter={(value) =>
-                  typeof value === 'number' ? value.toLocaleString() : String(value ?? '')
-                }
+                formatter={formatLabelListValue}
               />
             </Line>
           )}
@@ -209,9 +208,7 @@ export function TrendLineChart({
                   position="top"
                   className="text-xs"
                   fill="hsl(var(--muted-foreground))"
-                  formatter={(value) =>
-                    typeof value === 'number' ? value.toLocaleString() : String(value ?? '')
-                  }
+                  formatter={formatLabelListValue}
                 />
               </Line>
               <Line
@@ -229,9 +226,7 @@ export function TrendLineChart({
                   position="bottom"
                   className="text-xs"
                   fill="hsl(var(--muted-foreground))"
-                  formatter={(value) =>
-                    typeof value === 'number' ? value.toLocaleString() : String(value ?? '')
-                  }
+                  formatter={formatLabelListValue}
                 />
               </Line>
             </>
@@ -254,9 +249,7 @@ export function TrendLineChart({
                   position="top"
                   className="text-xs"
                   fill="hsl(var(--muted-foreground))"
-                  formatter={(value) =>
-                    typeof value === 'number' ? value.toLocaleString() : String(value ?? '')
-                  }
+                  formatter={formatLabelListValue}
                 />
               </Line>
               <Line
@@ -274,9 +267,7 @@ export function TrendLineChart({
                   position="bottom"
                   className="text-xs"
                   fill="hsl(var(--muted-foreground))"
-                  formatter={(value) =>
-                    typeof value === 'number' ? value.toLocaleString() : String(value ?? '')
-                  }
+                  formatter={formatLabelListValue}
                 />
               </Line>
             </>
@@ -298,9 +289,7 @@ export function TrendLineChart({
                 position="top"
                 className="text-xs"
                 fill="hsl(var(--muted-foreground))"
-                formatter={(value) =>
-                  typeof value === 'number' ? `${value.toFixed(1)}%` : String(value ?? '')
-                }
+                formatter={formatLabelListPercent}
               />
             </Line>
           )}

--- a/frontend/src/components/pipeline-debug/PipelineBatchList.tsx
+++ b/frontend/src/components/pipeline-debug/PipelineBatchList.tsx
@@ -497,7 +497,8 @@ function compareValues(a: unknown, b: unknown): number {
   if (b == null) return -1
   if (typeof a === 'number' && typeof b === 'number') return a - b
   if (typeof a === 'boolean' && typeof b === 'boolean') {
-    return a === b ? 0 : a ? -1 : 1
+    if (a === b) return 0
+    return a ? -1 : 1
   }
   return String(a).localeCompare(String(b))
 }

--- a/frontend/src/components/pipeline-debug/panels/HistoricalDetail.tsx
+++ b/frontend/src/components/pipeline-debug/panels/HistoricalDetail.tsx
@@ -25,7 +25,10 @@ export function HistoricalDetail({
   isRunning,
 }: HistoricalDetailProps) {
   const status = data.ran ? 'ran' : 'skipped'
-  const statusLabel = !data.ran ? 'skipped' : data.boost_applied ? 'boosted' : 'no boost'
+  let statusLabel: string
+  if (!data.ran) statusLabel = 'skipped'
+  else if (data.boost_applied) statusLabel = 'boosted'
+  else statusLabel = 'no boost'
 
   return (
     <div className="space-y-5">

--- a/frontend/src/components/pipeline-debug/panels/Phase1Detail.tsx
+++ b/frontend/src/components/pipeline-debug/panels/Phase1Detail.tsx
@@ -21,14 +21,25 @@ interface Phase1DetailProps {
 }
 
 export function Phase1Detail({ data, onRerunPhase, onRunFromHere, isRunning }: Phase1DetailProps) {
-  const status = !data.ran ? 'not_run' : data.is_valid ? 'ran' : 'error'
+  let status: 'not_run' | 'ran' | 'error'
+  let statusLabel: string
+  if (!data.ran) {
+    status = 'not_run'
+    statusLabel = 'skipped'
+  } else if (data.is_valid) {
+    status = 'ran'
+    statusLabel = 'valid'
+  } else {
+    status = 'error'
+    statusLabel = 'invalid'
+  }
 
   return (
     <div className="space-y-5">
       <PhaseHeader
         phase="phase1"
         status={status}
-        statusLabel={!data.ran ? 'skipped' : data.is_valid ? 'valid' : 'invalid'}
+        statusLabel={statusLabel}
         metrics={
           data.ran ? (
             <>

--- a/frontend/src/components/pipeline-debug/panels/Phase3Detail.tsx
+++ b/frontend/src/components/pipeline-debug/panels/Phase3Detail.tsx
@@ -158,12 +158,25 @@ export function Phase3Detail({
   const ranCount = data.filter((i) => i.ran).length
   const resolvedCount = data.filter((i) => i.result === 'resolved').length
 
+  let phaseStatus: 'not_run' | 'skipped' | 'ran'
+  let phaseStatusLabel: string
+  if (data.length === 0) {
+    phaseStatus = 'not_run'
+    phaseStatusLabel = 'not run'
+  } else if (ranCount === 0) {
+    phaseStatus = 'skipped'
+    phaseStatusLabel = 'skipped'
+  } else {
+    phaseStatus = 'ran'
+    phaseStatusLabel = `${ranCount} ran`
+  }
+
   return (
     <div className="space-y-5">
       <PhaseHeader
         phase="phase3"
-        status={data.length === 0 ? 'not_run' : ranCount === 0 ? 'skipped' : 'ran'}
-        statusLabel={data.length === 0 ? 'not run' : ranCount === 0 ? 'skipped' : `${ranCount} ran`}
+        status={phaseStatus}
+        statusLabel={phaseStatusLabel}
         metrics={
           data.length > 0 && ranCount > 0 ? (
             <>

--- a/frontend/src/components/requestSort.ts
+++ b/frontend/src/components/requestSort.ts
@@ -52,7 +52,9 @@ export function sortRequests(
         if (aFirst !== bFirst) return aFirst < bFirst ? -1 : 1
         const aLast = (aP?.last_name ?? '').toLowerCase()
         const bLast = (bP?.last_name ?? '').toLowerCase()
-        return aLast < bLast ? -1 : aLast > bLast ? 1 : 0
+        if (aLast < bLast) return -1
+        if (aLast > bLast) return 1
+        return 0
       }
       if (aGrade === null) return 1 // a goes after b regardless of direction
       if (bGrade === null) return -1 // a goes before b regardless of direction

--- a/frontend/src/hooks/camper/useCamperHistory.ts
+++ b/frontend/src/hooks/camper/useCamperHistory.ts
@@ -43,7 +43,9 @@ function resolveCurrentYearCampers(
   camperFallback: Camper | null
 ): Camper[] {
   const display = toDisplayList(filterEnrollmentsByStatus(allAttendees, (c) => c.attendee_status))
-  return display.length > 0 ? display : camperFallback ? [camperFallback] : []
+  if (display.length > 0) return display
+  if (camperFallback) return [camperFallback]
+  return []
 }
 
 export interface UseCamperHistoryResult {

--- a/frontend/src/hooks/useLockGroupDragDrop.tsx
+++ b/frontend/src/hooks/useLockGroupDragDrop.tsx
@@ -108,8 +108,10 @@ export function useLockGroupDragDrop({
 
       // Move all group members
       const activeCamper = campers.find((c) => c.id === active.id)
-      const campersToMove =
-        draggedGroupMembers.length > 0 ? draggedGroupMembers : activeCamper ? [activeCamper] : []
+      let campersToMove: Camper[]
+      if (draggedGroupMembers.length > 0) campersToMove = draggedGroupMembers
+      else if (activeCamper) campersToMove = [activeCamper]
+      else campersToMove = []
 
       if (campersToMove.length > 1) {
         toast(`Moving ${campersToMove.length} locked campers together...`, {

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -1128,18 +1128,16 @@ function StatBlock({
   satisfied: number
   total: number
 }) {
+  let pctColorClass: string
+  if (pct >= 80) pctColorClass = 'text-forest-600'
+  else if (pct >= 60) pctColorClass = 'text-amber-600'
+  else pctColorClass = 'text-red-600'
+
   return (
     <div>
       <div className="text-muted-foreground text-xs tracking-wider uppercase">{label}</div>
       <div className="flex items-baseline gap-1">
-        <span
-          className={clsx(
-            'text-xl font-bold',
-            pct >= 80 ? 'text-forest-600' : pct >= 60 ? 'text-amber-600' : 'text-red-600'
-          )}
-        >
-          {pct}%
-        </span>
+        <span className={clsx('text-xl font-bold', pctColorClass)}>{pct}%</span>
         <span className="text-muted-foreground text-xs">
           ({satisfied}/{total})
         </span>

--- a/frontend/src/pages/metrics/trends/TrendsOverview.tsx
+++ b/frontend/src/pages/metrics/trends/TrendsOverview.tsx
@@ -25,6 +25,7 @@ import { CssVerticalGroupedBarChart } from '../../../components/metrics/CssVerti
 import { Loader2, AlertCircle } from 'lucide-react'
 import { aggregateCityEnrollmentByRegion, REGION_DISPLAY_NAMES } from '../../../utils/regionUtils'
 import { getYearColor, YEAR_PALETTE } from '../../../utils/yearColors'
+import { trendDirection } from '../../../utils/trendDirection'
 import type { YearEnrollment } from '../../../types/metrics'
 
 interface GroupedChartItem {
@@ -241,14 +242,14 @@ export default function TrendsOverview() {
           title="Total Change"
           value={totalChange > 0 ? `+${totalChange}` : totalChange.toString()}
           subtitle={`${percentChange}% over ${data.years.length} years`}
-          trend={totalChange > 0 ? 'up' : totalChange < 0 ? 'down' : 'neutral'}
+          trend={trendDirection(totalChange)}
           trendValue={`${percentChange}%`}
         />
         <MetricCard
           title="Avg. Annual Growth"
           value={Number(avgGrowth) > 0 ? `+${avgGrowth}` : avgGrowth}
           subtitle="Campers per year"
-          trend={Number(avgGrowth) > 0 ? 'up' : Number(avgGrowth) < 0 ? 'down' : 'neutral'}
+          trend={trendDirection(avgGrowth)}
         />
       </div>
 

--- a/frontend/src/utils/chartFormatters.test.ts
+++ b/frontend/src/utils/chartFormatters.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import {
+  formatLabelListValue,
+  formatLabelListPercent,
+  formatDateShort,
+  priorYearDailyDateLabel,
+} from './chartFormatters'
+
+describe('formatLabelListValue', () => {
+  it('formats numbers with locale separators', () => {
+    expect(formatLabelListValue(1234)).toBe('1,234')
+    expect(formatLabelListValue(0)).toBe('0')
+  })
+
+  it('coerces non-numbers to string', () => {
+    expect(formatLabelListValue('hello')).toBe('hello')
+    expect(formatLabelListValue(null)).toBe('')
+    expect(formatLabelListValue(undefined)).toBe('')
+  })
+})
+
+describe('formatLabelListPercent', () => {
+  it('formats numbers with one decimal and percent sign', () => {
+    expect(formatLabelListPercent(12.345)).toBe('12.3%')
+    expect(formatLabelListPercent(0)).toBe('0.0%')
+  })
+
+  it('coerces non-numbers to string', () => {
+    expect(formatLabelListPercent('foo')).toBe('foo')
+    expect(formatLabelListPercent(null)).toBe('')
+  })
+})
+
+describe('formatDateShort', () => {
+  it('formats YYYY-MM-DD as locale short', () => {
+    expect(formatDateShort('2026-01-06')).toMatch(/Jan 6/)
+  })
+})
+
+describe('priorYearDailyDateLabel', () => {
+  it('returns null when seasonStarts missing', () => {
+    expect(priorYearDailyDateLabel(undefined, 2025, 0)).toBeNull()
+    expect(priorYearDailyDateLabel({}, 2025, 0)).toBeNull()
+  })
+
+  it('offsets by day count', () => {
+    const result = priorYearDailyDateLabel({ 2025: '2025-06-15' }, 2025, 2)
+    expect(result).toMatch(/Jun 17/)
+  })
+})

--- a/frontend/src/utils/chartFormatters.test.ts
+++ b/frontend/src/utils/chartFormatters.test.ts
@@ -8,8 +8,8 @@ import {
 
 describe('formatLabelListValue', () => {
   it('formats numbers with locale separators', () => {
-    expect(formatLabelListValue(1234)).toBe('1,234')
-    expect(formatLabelListValue(0)).toBe('0')
+    expect(formatLabelListValue(1234)).toBe((1234).toLocaleString())
+    expect(formatLabelListValue(0)).toBe((0).toLocaleString())
   })
 
   it('coerces non-numbers to string', () => {

--- a/frontend/src/utils/chartFormatters.ts
+++ b/frontend/src/utils/chartFormatters.ts
@@ -15,6 +15,24 @@ export const GENDER_COLORS = {
   girls: 'hsl(340, 65%, 55%)',
 }
 
+/**
+ * Format a Recharts <LabelList> value as a localized integer.
+ * Recharts passes `value` as `unknown` (number | string | undefined depending on data shape).
+ */
+export function formatLabelListValue(value: unknown): string {
+  if (typeof value === 'number') return value.toLocaleString()
+  return String(value ?? '')
+}
+
+/**
+ * Format a Recharts <LabelList> value as a percentage with one decimal.
+ * Returns the raw stringified value when not numeric (matches prior fallback).
+ */
+export function formatLabelListPercent(value: unknown): string {
+  if (typeof value === 'number') return `${value.toFixed(1)}%`
+  return String(value ?? '')
+}
+
 /** Format a date string (YYYY-MM-DD) to short display like "Jan 6". */
 export function formatDateShort(dateStr: string): string {
   const d = new Date(dateStr + 'T00:00:00')

--- a/frontend/src/utils/filterSexFormat.test.ts
+++ b/frontend/src/utils/filterSexFormat.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { filterSexLabel, filterSexCsvSegment } from './filterSexFormat'
+
+describe('filterSexLabel', () => {
+  it('all → All', () => {
+    expect(filterSexLabel('all')).toBe('All')
+  })
+
+  it('M → Boys', () => {
+    expect(filterSexLabel('M')).toBe('Boys')
+  })
+
+  it('F → Girls', () => {
+    expect(filterSexLabel('F')).toBe('Girls')
+  })
+})
+
+describe('filterSexCsvSegment', () => {
+  it('M → -boys', () => {
+    expect(filterSexCsvSegment('M')).toBe('-boys')
+  })
+
+  it('F → -girls', () => {
+    expect(filterSexCsvSegment('F')).toBe('-girls')
+  })
+
+  it('all → empty string', () => {
+    expect(filterSexCsvSegment('all')).toBe('')
+  })
+})

--- a/frontend/src/utils/filterSexFormat.ts
+++ b/frontend/src/utils/filterSexFormat.ts
@@ -1,0 +1,21 @@
+export type FilterSex = 'all' | 'M' | 'F'
+
+const LABELS: Record<FilterSex, string> = {
+  all: 'All',
+  M: 'Boys',
+  F: 'Girls',
+}
+
+const CSV_SEGMENTS: Record<FilterSex, string> = {
+  all: '',
+  M: '-boys',
+  F: '-girls',
+}
+
+export function filterSexLabel(filterSex: FilterSex): string {
+  return LABELS[filterSex]
+}
+
+export function filterSexCsvSegment(filterSex: FilterSex): string {
+  return CSV_SEGMENTS[filterSex]
+}

--- a/frontend/src/utils/genderUtils.test.ts
+++ b/frontend/src/utils/genderUtils.test.ts
@@ -230,6 +230,12 @@ describe('formatGenderFull', () => {
     expect(formatGenderFull(null)).toBe('Non-Binary')
     expect(formatGenderFull('')).toBe('Non-Binary')
   })
+
+  it('ignores prototype keys (no inherited-property leakage)', () => {
+    expect(formatGenderFull('toString')).toBe('Non-Binary')
+    expect(formatGenderFull('hasOwnProperty')).toBe('Non-Binary')
+    expect(formatGenderFull('__proto__')).toBe('Non-Binary')
+  })
 })
 
 describe('formatGenderShort', () => {

--- a/frontend/src/utils/genderUtils.test.ts
+++ b/frontend/src/utils/genderUtils.test.ts
@@ -13,6 +13,8 @@ import {
   getPronounCategory,
   getPronounColorClasses,
   getPronounBadgeClasses,
+  formatGenderFull,
+  formatGenderShort,
 } from './genderUtils'
 import type { Camper } from '../types/app-types'
 import type { PersonsResponse } from '../types/pocketbase-types'
@@ -210,5 +212,38 @@ describe('getPronounBadgeClasses', () => {
     ],
   ])('returns correct badge classes for %s', (category, expected) => {
     expect(getPronounBadgeClasses(category as any)).toBe(expected)
+  })
+})
+
+describe('formatGenderFull', () => {
+  it('maps M to Male', () => {
+    expect(formatGenderFull('M')).toBe('Male')
+  })
+
+  it('maps F to Female', () => {
+    expect(formatGenderFull('F')).toBe('Female')
+  })
+
+  it('maps anything else to Non-Binary', () => {
+    expect(formatGenderFull('X')).toBe('Non-Binary')
+    expect(formatGenderFull(undefined)).toBe('Non-Binary')
+    expect(formatGenderFull(null)).toBe('Non-Binary')
+    expect(formatGenderFull('')).toBe('Non-Binary')
+  })
+})
+
+describe('formatGenderShort', () => {
+  it('maps M to M', () => {
+    expect(formatGenderShort('M')).toBe('M')
+  })
+
+  it('maps F to F', () => {
+    expect(formatGenderShort('F')).toBe('F')
+  })
+
+  it('maps anything else to NB', () => {
+    expect(formatGenderShort('X')).toBe('NB')
+    expect(formatGenderShort(undefined)).toBe('NB')
+    expect(formatGenderShort(null)).toBe('NB')
   })
 })

--- a/frontend/src/utils/genderUtils.ts
+++ b/frontend/src/utils/genderUtils.ts
@@ -9,6 +9,21 @@ export function normalizeGender(gender: string): 'M' | 'F' | 'NB' {
   return gender === 'M' || gender === 'F' || gender === 'NB' ? gender : 'NB'
 }
 
+const GENDER_FULL_LABELS: Record<string, string> = { M: 'Male', F: 'Female' }
+const GENDER_SHORT_LABELS: Record<string, string> = { M: 'M', F: 'F' }
+
+/** Map a sex code to a long display label, defaulting to 'Non-Binary'. */
+export function formatGenderFull(gender: string | null | undefined): string {
+  if (gender && GENDER_FULL_LABELS[gender]) return GENDER_FULL_LABELS[gender]
+  return 'Non-Binary'
+}
+
+/** Map a sex code to a short display label (M / F / NB). */
+export function formatGenderShort(gender: string | null | undefined): string {
+  if (gender && GENDER_SHORT_LABELS[gender]) return GENDER_SHORT_LABELS[gender]
+  return 'NB'
+}
+
 /**
  * Categorizes gender identity into one of three groups
  */

--- a/frontend/src/utils/genderUtils.ts
+++ b/frontend/src/utils/genderUtils.ts
@@ -9,19 +9,21 @@ export function normalizeGender(gender: string): 'M' | 'F' | 'NB' {
   return gender === 'M' || gender === 'F' || gender === 'NB' ? gender : 'NB'
 }
 
-const GENDER_FULL_LABELS: Record<string, string> = { M: 'Male', F: 'Female' }
-const GENDER_SHORT_LABELS: Record<string, string> = { M: 'M', F: 'F' }
+const GENDER_FULL_LABELS: Record<'M' | 'F' | 'NB', string> = {
+  M: 'Male',
+  F: 'Female',
+  NB: 'Non-Binary',
+}
+const GENDER_SHORT_LABELS: Record<'M' | 'F' | 'NB', string> = { M: 'M', F: 'F', NB: 'NB' }
 
 /** Map a sex code to a long display label, defaulting to 'Non-Binary'. */
 export function formatGenderFull(gender: string | null | undefined): string {
-  if (gender && GENDER_FULL_LABELS[gender]) return GENDER_FULL_LABELS[gender]
-  return 'Non-Binary'
+  return GENDER_FULL_LABELS[normalizeGender(gender ?? '')]
 }
 
 /** Map a sex code to a short display label (M / F / NB). */
 export function formatGenderShort(gender: string | null | undefined): string {
-  if (gender && GENDER_SHORT_LABELS[gender]) return GENDER_SHORT_LABELS[gender]
-  return 'NB'
+  return GENDER_SHORT_LABELS[normalizeGender(gender ?? '')]
 }
 
 /**

--- a/frontend/src/utils/trendDirection.test.ts
+++ b/frontend/src/utils/trendDirection.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { trendDirection } from './trendDirection'
+
+describe('trendDirection', () => {
+  it('positive → up', () => {
+    expect(trendDirection(1)).toBe('up')
+    expect(trendDirection(0.001)).toBe('up')
+    expect(trendDirection(1000)).toBe('up')
+  })
+
+  it('negative → down', () => {
+    expect(trendDirection(-1)).toBe('down')
+    expect(trendDirection(-0.001)).toBe('down')
+  })
+
+  it('zero → neutral', () => {
+    expect(trendDirection(0)).toBe('neutral')
+  })
+
+  it('coerces string-numerics', () => {
+    expect(trendDirection('5')).toBe('up')
+    expect(trendDirection('-2')).toBe('down')
+    expect(trendDirection('0')).toBe('neutral')
+  })
+})

--- a/frontend/src/utils/trendDirection.ts
+++ b/frontend/src/utils/trendDirection.ts
@@ -1,0 +1,8 @@
+export type TrendDirection = 'up' | 'down' | 'neutral'
+
+export function trendDirection(value: number | string): TrendDirection {
+  const n = Number(value)
+  if (n > 0) return 'up'
+  if (n < 0) return 'down'
+  return 'neutral'
+}


### PR DESCRIPTION
## Summary

- Eliminates the remaining 31 genuinely-nested ternary expressions across the frontend after the metrics-chart slice (PR #1216).
- Adds 4 small shared helpers (with tests) for patterns repeated across multiple files.
- Inline cleanups (if/else chains, lookup records) for per-file patterns.

Per the issue's acceptance criteria, single 2-branch ternaries — including independent ternaries that share a JSX template string — are explicitly out of scope. The 12 remaining grep matches all fall into that category.

## What changed

**New shared helpers** (with tests):
- `genderUtils.formatGenderFull` / `formatGenderShort` — collapse the M→Male / F→Female / else→Non-Binary mapping (3 callsites)
- `filterSexFormat.filterSexLabel` / `filterSexCsvSegment` — collapse the all/M/F filter chip + CSV-name mapping (4 callsites)
- `trendDirection` — collapse positive/negative/zero → up/down/neutral (2 callsites)
- `chartFormatters.formatLabelListValue` / `formatLabelListPercent` — Recharts `<LabelList>` formatters (6 callsites)
- `graph/constants.labelDensityThreshold` — shared zoom-based density threshold for `graphLayout` + `graphInteractions`

**Inline cleanups** (no shared helper):
- `ScenarioComparisonPage` pct color → if/else
- `SessionStats` utilization color → local helper
- Pipeline-debug `Phase1Detail` / `Phase3Detail` / `HistoricalDetail` status+label → if/else
- `PostValidationResultsModal` severity icon → lookup record
- `PipelineBatchList` boolean comparator → if/else
- `requestSort` name comparator → if/else
- `SolverProgressModal` phase indicator → if/else
- `OptimizeBunksButton` warmth dot → consume existing `warmthStyles` record
- `useLockGroupDragDrop` / `useCamperHistory` fallback chains → if/else

## Test plan

- [x] `npx vitest run` — 3871 tests passing (266 files)
- [x] `npm run type-check` — both tsconfigs clean
- [x] `npm run lint` — no new errors (warnings unchanged)
- [x] `npm run format:check` — clean
- [ ] Manual smoke: trends page, scenario comparison, camper detail, optimize button, pipeline debug panels

## Out of scope

The 12 remaining grep matches are independent single-branch ternaries sharing a JSX template-string line (e.g. `${a ? 'x' : 'y'} ${b ? 'z' : ''}`). Per the issue:

> For non-enum 2-branch conditionals, leave single ternaries alone — they're fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consistent gender/sex labels throughout the UI and in CSV export filenames
  * Improved chart label formatting and zoom-aware label visibility
  * Clearer visual indicators for selection, phase progress, and validation severity

* **Refactor**
  * Centralized formatting and direction helpers to simplify conditional logic

* **Tests**
  * New unit tests covering formatting, gender/sex utilities, and trend direction
<!-- end of auto-generated comment: release notes by coderabbit.ai -->