### PR TITLE
refactor(solver): split must-satisfy-one post-solve diagnostic by request bucket

### DIFF
--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -19,6 +19,7 @@ from bunking.models_v2 import (
     DirectSolverInput,
     DirectSolverOutput,
 )
+from bunking.satisfaction.bucket import RequestBucket, classify_request
 from bunking.sync.bunk_request_processor.core.models import RequestType
 from bunking.sync.bunk_request_processor.shared.constants import SOURCE_FIELD_TO_CONFIG_KEY
 from campminder.client import get_current_season
@@ -44,6 +45,23 @@ from .logging import ConstraintLogger
 from .solution import analyze_solution, calculate_satisfied_requests
 
 logger = get_logger(__name__)
+
+
+def _is_material_parent(request: DirectBunkRequest) -> bool:
+    """True iff a request's source_field classifies as MATERIAL_PARENT.
+
+    Defensive: missing or unknown source_field returns False. Used by the
+    post-solve diagnostic to bucket unsatisfied campers — surfacing as a
+    diagnostic miscount is preferable to crashing the solver run on a
+    data-hygiene edge case.
+    """
+    sf = request.source_field
+    if not sf:
+        return False
+    try:
+        return classify_request(sf) == RequestBucket.MATERIAL_PARENT
+    except ValueError:
+        return False
 
 
 class DirectBunkingSolver:
@@ -931,31 +949,111 @@ class DirectBunkingSolver:
         else:
             logger.info("✓ No soft constraint violations")
 
-        # 4. Check must-satisfy-one violations
-        unsatisfied_campers = []
+        # 4. Check must-satisfy-one violations (split by population — see helper).
+        self._check_must_satisfy_one_violations(assignments)
+
+        logger.info("=== End Constraint Violation Check ===")
+
+    def _check_must_satisfy_one_violations(self, assignments: list[DirectBunkAssignment]) -> None:
+        """Post-solve diagnostic: split unsatisfied campers into actionable buckets.
+
+        Three populations were previously emitted under one ``must_satisfy_one``
+        warning, which conflated solver-actionable failures with parent-input
+        issues. This split surfaces:
+
+        - ``must_satisfy_one_no_possible`` (info): all the camper's requests
+          are structurally impossible (cross-session target, target absent
+          from solver, malformed). The soft constraint at
+          ``must_satisfy.py:91-94`` already skips these — they were never
+          solver-actionable. Severity downgraded to info; staff fixes the
+          parent's input data.
+        - ``must_satisfy_one_material_parent_unmet`` (warning): camper has
+          ≥1 possible MATERIAL_PARENT request (``bunk_with``) and the solver
+          satisfied none. Headline staff failure mode per the parent-paramount
+          design.
+        - ``must_satisfy_one_other_unmet`` (info): camper has only non-material
+          possible requests (STAFF or IMMATERIAL_PARENT) and the solver
+          satisfied none. Lower-priority signal.
+
+        Counts are also surfaced in ``request_validation_summary`` so the
+        structured solver-log JSON carries the breakdown.
+        """
+        person_to_bunk = {a.person_cm_id: a.bunk_cm_id for a in assignments}
         all_satisfied = calculate_satisfied_requests(
             assignments, self.input.requests_by_person, self.input.person_by_cm_id
         )
+
+        no_possible: list[int] = []
+        material_parent_unmet: list[int] = []
+        other_unmet: list[int] = []
+
         for person_cm_id, requests in self.input.requests_by_person.items():
             if person_cm_id not in person_to_bunk:
                 continue
+            if not requests:
+                continue
+            if len(all_satisfied.get(person_cm_id, [])) > 0:
+                continue
 
-            # Check if any request is satisfied
-            satisfied_count = len(all_satisfied.get(person_cm_id, []))
+            possible = self.possible_requests.get(person_cm_id, [])
+            if not possible:
+                no_possible.append(person_cm_id)
+                continue
 
-            if satisfied_count == 0 and len(requests) > 0:
-                unsatisfied_campers.append(person_cm_id)
+            if any(_is_material_parent(r) for r in possible):
+                material_parent_unmet.append(person_cm_id)
+            else:
+                other_unmet.append(person_cm_id)
 
-        if unsatisfied_campers:
-            logger.info(f"{len(unsatisfied_campers)} campers with NO satisfied requests:")
-            for person_cm_id in unsatisfied_campers[:10]:  # Show first 10
+        # Persist the breakdown alongside the existing pre-solve totals so the
+        # structured JSON solver log carries it without scraping violation names.
+        self.request_validation_summary["unsatisfied_no_possible"] = len(no_possible)
+        self.request_validation_summary["unsatisfied_material_parent_unmet"] = len(material_parent_unmet)
+        self.request_validation_summary["unsatisfied_other_unmet"] = len(other_unmet)
+
+        if no_possible:
+            logger.info(
+                f"{len(no_possible)} campers had only structurally-impossible requests "
+                f"(parent input issue: requestee in another session or absent from solver)"
+            )
+            for person_cm_id in no_possible[:10]:
                 person = self.input.person_by_cm_id[person_cm_id]
                 self.constraint_logger.log_violation(
-                    "must_satisfy_one",
-                    f"{person.name} (ID: {person_cm_id}) has no satisfied requests",
+                    "must_satisfy_one_no_possible",
+                    f"{person.name} (ID: {person_cm_id}): all requests impossible — fix parent input",
+                    severity="info",
+                )
+            if len(no_possible) > 10:
+                logger.info(f"... and {len(no_possible) - 10} more")
+
+        if material_parent_unmet:
+            logger.info(
+                f"{len(material_parent_unmet)} campers with possible MATERIAL_PARENT requests "
+                f"left unsatisfied by the solver"
+            )
+            for person_cm_id in material_parent_unmet[:10]:
+                person = self.input.person_by_cm_id[person_cm_id]
+                possible_count = len(self.possible_requests.get(person_cm_id, []))
+                self.constraint_logger.log_violation(
+                    "must_satisfy_one_material_parent_unmet",
+                    f"{person.name} (ID: {person_cm_id}): {possible_count} possible requests, none satisfied",
                     severity="warning",
                 )
-            if len(unsatisfied_campers) > 10:
-                logger.info(f"... and {len(unsatisfied_campers) - 10} more")
+            if len(material_parent_unmet) > 10:
+                logger.info(f"... and {len(material_parent_unmet) - 10} more")
 
-        logger.info("=== End Constraint Violation Check ===")
+        if other_unmet:
+            logger.info(
+                f"{len(other_unmet)} campers with only non-material (staff/immaterial) possible requests "
+                f"left unsatisfied"
+            )
+            for person_cm_id in other_unmet[:10]:
+                person = self.input.person_by_cm_id[person_cm_id]
+                possible_count = len(self.possible_requests.get(person_cm_id, []))
+                self.constraint_logger.log_violation(
+                    "must_satisfy_one_other_unmet",
+                    f"{person.name} (ID: {person_cm_id}): {possible_count} possible requests, none satisfied",
+                    severity="info",
+                )
+            if len(other_unmet) > 10:
+                logger.info(f"... and {len(other_unmet) - 10} more")

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -53,7 +53,8 @@ def _is_material_parent(request: DirectBunkRequest) -> bool:
     Defensive: missing or unknown source_field returns False. Used by the
     post-solve diagnostic to bucket unsatisfied campers — surfacing as a
     diagnostic miscount is preferable to crashing the solver run on a
-    data-hygiene edge case.
+    data-hygiene edge case. Unknown values are logged so a new source_field
+    added to the schema before the bucket map is updated leaves a trace.
     """
     sf = request.source_field
     if not sf:
@@ -61,6 +62,11 @@ def _is_material_parent(request: DirectBunkRequest) -> bool:
     try:
         return classify_request(sf) == RequestBucket.MATERIAL_PARENT
     except ValueError:
+        logger.debug(
+            "_is_material_parent: unknown source_field %r on request %s — treating as non-material",
+            sf,
+            request.id,
+        )
         return False
 
 
@@ -994,6 +1000,11 @@ class DirectBunkingSolver:
         no_possible: list[int] = []
         material_parent_unmet: list[int] = []
         other_unmet: list[int] = []
+        # Per-camper resolved-possible count, used for the violation message text.
+        # The unfiltered self.possible_requests dict can include pending/declined
+        # entries (validation doesn't filter by status), so reading its length
+        # directly would overstate the number shown in the diagnostic.
+        resolved_possible_count: dict[int, int] = {}
 
         for person_cm_id, requests in self.input.requests_by_person.items():
             if person_cm_id not in person_to_bunk:
@@ -1012,6 +1023,7 @@ class DirectBunkingSolver:
                 no_possible.append(person_cm_id)
                 continue
 
+            resolved_possible_count[person_cm_id] = len(resolved_possible)
             if any(_is_material_parent(r) for r in resolved_possible):
                 material_parent_unmet.append(person_cm_id)
             else:
@@ -1045,7 +1057,7 @@ class DirectBunkingSolver:
             )
             for person_cm_id in material_parent_unmet[:10]:
                 person = self.input.person_by_cm_id[person_cm_id]
-                possible_count = len(self.possible_requests.get(person_cm_id, []))
+                possible_count = resolved_possible_count[person_cm_id]
                 self.constraint_logger.log_violation(
                     "must_satisfy_one_material_parent_unmet",
                     f"{person.name} (ID: {person_cm_id}): {possible_count} possible requests, none satisfied",
@@ -1061,7 +1073,7 @@ class DirectBunkingSolver:
             )
             for person_cm_id in other_unmet[:10]:
                 person = self.input.person_by_cm_id[person_cm_id]
-                possible_count = len(self.possible_requests.get(person_cm_id, []))
+                possible_count = resolved_possible_count[person_cm_id]
                 self.constraint_logger.log_violation(
                     "must_satisfy_one_other_unmet",
                     f"{person.name} (ID: {person_cm_id}): {possible_count} possible requests, none satisfied",

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -957,23 +957,31 @@ class DirectBunkingSolver:
     def _check_must_satisfy_one_violations(self, assignments: list[DirectBunkAssignment]) -> None:
         """Post-solve diagnostic: split unsatisfied campers into actionable buckets.
 
+        Mirrors the solver's resolved-only scope (``data_fetcher.py:140``
+        filters bunk_requests to ``status="resolved"`` before they reach the
+        solver). Pending and declined requests are not the solver's concern,
+        so the diagnostic ignores them entirely. This also collapses the
+        cross-session "no possible" case in practice — those are auto-DECLINED
+        by the bunk_request_processor at sync time and never reach this loop
+        as resolved.
+
         Three populations were previously emitted under one ``must_satisfy_one``
         warning, which conflated solver-actionable failures with parent-input
         issues. This split surfaces:
 
-        - ``must_satisfy_one_no_possible`` (info): all the camper's requests
-          are structurally impossible (cross-session target, target absent
-          from solver, malformed). The soft constraint at
-          ``must_satisfy.py:91-94`` already skips these — they were never
-          solver-actionable. Severity downgraded to info; staff fixes the
-          parent's input data.
+        - ``must_satisfy_one_no_possible`` (info): the camper's resolved
+          requests are all structurally impossible from the solver's
+          perspective. With upstream resolution working correctly this
+          should be near-empty in production — non-empty values indicate a
+          data-hygiene regression where a request marked ``resolved`` is in
+          fact unsatisfiable.
         - ``must_satisfy_one_material_parent_unmet`` (warning): camper has
-          ≥1 possible MATERIAL_PARENT request (``bunk_with``) and the solver
-          satisfied none. Headline staff failure mode per the parent-paramount
-          design.
-        - ``must_satisfy_one_other_unmet`` (info): camper has only non-material
-          possible requests (STAFF or IMMATERIAL_PARENT) and the solver
-          satisfied none. Lower-priority signal.
+          ≥1 resolved possible MATERIAL_PARENT request (``bunk_with``) and
+          the solver satisfied none. Headline staff failure mode per the
+          parent-paramount design.
+        - ``must_satisfy_one_other_unmet`` (info): camper has only resolved
+          non-material possible requests (STAFF or IMMATERIAL_PARENT) and
+          the solver satisfied none. Lower-priority signal.
 
         Counts are also surfaced in ``request_validation_summary`` so the
         structured solver-log JSON carries the breakdown.
@@ -990,17 +998,21 @@ class DirectBunkingSolver:
         for person_cm_id, requests in self.input.requests_by_person.items():
             if person_cm_id not in person_to_bunk:
                 continue
-            if not requests:
-                continue
-            if len(all_satisfied.get(person_cm_id, [])) > 0:
+            # Restrict to resolved requests — pending/declined aren't part of the solver's scope.
+            resolved_requests = [r for r in requests if r.status == "resolved"]
+            if not resolved_requests:
                 continue
 
-            possible = self.possible_requests.get(person_cm_id, [])
-            if not possible:
+            resolved_ids = {r.id for r in resolved_requests}
+            if any(rid in resolved_ids for rid in all_satisfied.get(person_cm_id, [])):
+                continue
+
+            resolved_possible = [r for r in self.possible_requests.get(person_cm_id, []) if r.status == "resolved"]
+            if not resolved_possible:
                 no_possible.append(person_cm_id)
                 continue
 
-            if any(_is_material_parent(r) for r in possible):
+            if any(_is_material_parent(r) for r in resolved_possible):
                 material_parent_unmet.append(person_cm_id)
             else:
                 other_unmet.append(person_cm_id)

--- a/tests/unit/solver/test_must_satisfy_diagnostic.py
+++ b/tests/unit/solver/test_must_satisfy_diagnostic.py
@@ -1,0 +1,346 @@
+"""Post-solve must-satisfy-one diagnostic split.
+
+Today the post-solve reporting loop in `_check_constraint_violations` step 4
+emits one `must_satisfy_one` warning category that conflates three populations:
+
+A) Camper had only impossible requests (parent input issue — requestee in
+   another session, or requestee not in the solver). The solver could never
+   satisfy these and the soft constraint at `must_satisfy.py:91-94` already
+   skips them entirely.
+B) Camper had ≥1 possible MATERIAL_PARENT request (bunk_with) that the solver
+   chose not to satisfy. This is the staff-headline failure mode.
+C) Camper had only non-MATERIAL_PARENT possible requests (STAFF /
+   IMMATERIAL_PARENT) and the solver satisfied none. Lower-priority signal
+   per the parent-paramount design.
+
+This split converts the diagnostic from "10 unsatisfied campers" (uninformative
+re. solver feasibility) into three actionable categories.
+
+The diagnostic only changes reporting — the soft constraint, hard constraints,
+and objective are unchanged.
+"""
+
+from __future__ import annotations
+
+from bunking.config import ConfigLoader
+from bunking.models_v2 import (
+    DirectBunk,
+    DirectBunkAssignment,
+    DirectBunkRequest,
+    DirectPerson,
+    DirectSolverInput,
+)
+from bunking.solver.direct_solver import DirectBunkingSolver
+
+_FICTIONAL_NAMES = [
+    ("Emma", "Johnson"),
+    ("Liam", "Garcia"),
+    ("Olivia", "Chen"),
+    ("Noah", "Williams"),
+    ("Ava", "Martinez"),
+    ("Ethan", "Brown"),
+    ("Sophia", "Davis"),
+    ("Mason", "Lopez"),
+]
+
+# New violation categories emitted by the split diagnostic.
+CAT_NO_POSSIBLE = "must_satisfy_one_no_possible"
+CAT_MATERIAL_PARENT_UNMET = "must_satisfy_one_material_parent_unmet"
+CAT_OTHER_UNMET = "must_satisfy_one_other_unmet"
+
+
+def _person(cm_id: int, session: int, *, gender: str = "F", grade: int = 6) -> DirectPerson:
+    first, last = _FICTIONAL_NAMES[cm_id % len(_FICTIONAL_NAMES)]
+    return DirectPerson(
+        campminder_person_id=cm_id,
+        first_name=first,
+        last_name=last,
+        grade=grade,
+        birthdate="2014-03-15",
+        gender=gender,
+        session_cm_id=session,
+    )
+
+
+def _bunk(cm_id: int, session: int, *, gender: str = "F") -> DirectBunk:
+    return DirectBunk(
+        id=f"bunk_{cm_id}",
+        campminder_id=cm_id,
+        name=f"B-{cm_id}",
+        capacity=12,
+        gender=gender,
+        session_cm_id=session,
+    )
+
+
+def _request(
+    req_id: str,
+    requester: int,
+    requested: int | None,
+    session: int,
+    *,
+    request_type: str = "bunk_with",
+    source_field: str = "bunk_with",
+) -> DirectBunkRequest:
+    return DirectBunkRequest(
+        id=req_id,
+        requester_person_cm_id=requester,
+        requested_person_cm_id=requested,
+        request_type=request_type,
+        session_cm_id=session,
+        year=2026,
+        status="resolved",
+        source_field=source_field,
+    )
+
+
+def _assignment(person_cm_id: int, bunk_cm_id: int, session: int) -> DirectBunkAssignment:
+    return DirectBunkAssignment(
+        person_cm_id=person_cm_id,
+        session_cm_id=session,
+        bunk_cm_id=bunk_cm_id,
+        year=2026,
+    )
+
+
+def _violation_details(solver: DirectBunkingSolver, category: str) -> list[str]:
+    """Extract the `details` strings logged under a given violation category."""
+    return [v["details"] for v in solver.constraint_logger.violations.get(category, [])]
+
+
+class TestMustSatisfyDiagnosticSplit:
+    """Splits the post-solve must-satisfy-one diagnostic into three categories.
+
+    Tests build a `DirectBunkingSolver` (which populates `possible_requests` /
+    `impossible_requests` via `_validate_requests`), then call the extracted
+    helper `_check_must_satisfy_one_violations(assignments)` and inspect
+    `constraint_logger.violations`.
+    """
+
+    def test_camper_with_only_impossible_requests_flagged_as_no_possible(self, mock_config):
+        """Type A: cross-session bunk_with → no possible request → 'no_possible' category, info severity."""
+        # Camper 1001 in session 100 wants to bunk with 1002 in session 200 → impossible.
+        input_data = DirectSolverInput(
+            persons=[_person(1001, 100), _person(1002, 200)],
+            requests=[_request("r1", 1001, 1002, 100)],
+            bunks=[_bunk(2001, 100), _bunk(2002, 200)],
+        )
+        solver = DirectBunkingSolver(input_data, ConfigLoader.get_instance())
+        # Pre-condition: validation flagged it impossible.
+        assert solver.possible_requests[1001] == []
+        assert len(solver.impossible_requests[1001]) == 1
+
+        # Place 1001 in some bunk (any solver outcome).
+        assignments = [_assignment(1001, 2001, 100), _assignment(1002, 2002, 200)]
+
+        solver._check_must_satisfy_one_violations(assignments)
+
+        no_possible = _violation_details(solver, CAT_NO_POSSIBLE)
+        assert len(no_possible) == 1
+        assert "1001" in no_possible[0]
+        # Severity should be `info` — the solver isn't at fault here.
+        sev = solver.constraint_logger.violations[CAT_NO_POSSIBLE][0]["severity"]
+        assert sev == "info"
+        # The other categories must NOT contain this camper.
+        assert _violation_details(solver, CAT_MATERIAL_PARENT_UNMET) == []
+        assert _violation_details(solver, CAT_OTHER_UNMET) == []
+
+    def test_unsatisfied_material_parent_request_flagged_as_material_parent_unmet(self, mock_config):
+        """Type B: possible material-parent request unsatisfied → 'material_parent_unmet', warning severity."""
+        # Both campers in session 100 — request is possible. After solve they're in different bunks.
+        input_data = DirectSolverInput(
+            persons=[_person(1001, 100), _person(1002, 100)],
+            requests=[_request("r1", 1001, 1002, 100, source_field="bunk_with")],
+            bunks=[_bunk(2001, 100), _bunk(2002, 100)],
+        )
+        solver = DirectBunkingSolver(input_data, ConfigLoader.get_instance())
+        assert len(solver.possible_requests[1001]) == 1
+        assert solver.impossible_requests[1001] == []
+
+        # Different bunks → bunk_with NOT satisfied.
+        assignments = [_assignment(1001, 2001, 100), _assignment(1002, 2002, 100)]
+
+        solver._check_must_satisfy_one_violations(assignments)
+
+        material = _violation_details(solver, CAT_MATERIAL_PARENT_UNMET)
+        assert len(material) == 1
+        assert "1001" in material[0]
+        sev = solver.constraint_logger.violations[CAT_MATERIAL_PARENT_UNMET][0]["severity"]
+        assert sev == "warning"
+        # Other categories empty.
+        assert _violation_details(solver, CAT_NO_POSSIBLE) == []
+        assert _violation_details(solver, CAT_OTHER_UNMET) == []
+
+    def test_unsatisfied_staff_only_request_flagged_as_other_unmet(self, mock_config):
+        """Type C: possible STAFF request unsatisfied, no MATERIAL_PARENT → 'other_unmet', info severity."""
+        # not_bunk_with from a bunking_notes/internal_notes/not_bunk_with source.
+        # The request is "satisfied" when targets are in DIFFERENT bunks; we put them in the SAME
+        # bunk so the request is unsatisfied.
+        input_data = DirectSolverInput(
+            persons=[_person(1001, 100), _person(1002, 100)],
+            requests=[
+                _request(
+                    "r1",
+                    1001,
+                    1002,
+                    100,
+                    request_type="not_bunk_with",
+                    source_field="not_bunk_with",
+                ),
+            ],
+            bunks=[_bunk(2001, 100)],
+        )
+        solver = DirectBunkingSolver(input_data, ConfigLoader.get_instance())
+        assert len(solver.possible_requests[1001]) == 1
+
+        # Both in the same bunk — not_bunk_with is violated.
+        assignments = [_assignment(1001, 2001, 100), _assignment(1002, 2001, 100)]
+
+        solver._check_must_satisfy_one_violations(assignments)
+
+        other = _violation_details(solver, CAT_OTHER_UNMET)
+        assert len(other) == 1
+        assert "1001" in other[0]
+        sev = solver.constraint_logger.violations[CAT_OTHER_UNMET][0]["severity"]
+        assert sev == "info"
+        assert _violation_details(solver, CAT_NO_POSSIBLE) == []
+        assert _violation_details(solver, CAT_MATERIAL_PARENT_UNMET) == []
+
+    def test_mixed_material_and_staff_unsatisfied_falls_in_material_category(self, mock_config):
+        """Mixed possible buckets: presence of any MATERIAL_PARENT routes to material_parent_unmet."""
+        # 1001 has TWO possible requests, neither satisfied:
+        #   - bunk_with 1002 (material, source_field='bunk_with')
+        #   - not_bunk_with 1003 (staff, source_field='not_bunk_with')
+        # Place 1001 separate from 1002 (bunk_with unmet) and same as 1003 (not_bunk_with unmet).
+        input_data = DirectSolverInput(
+            persons=[_person(1001, 100), _person(1002, 100), _person(1003, 100)],
+            requests=[
+                _request("r1", 1001, 1002, 100, source_field="bunk_with"),
+                _request(
+                    "r2",
+                    1001,
+                    1003,
+                    100,
+                    request_type="not_bunk_with",
+                    source_field="not_bunk_with",
+                ),
+            ],
+            bunks=[_bunk(2001, 100), _bunk(2002, 100)],
+        )
+        solver = DirectBunkingSolver(input_data, ConfigLoader.get_instance())
+        assert len(solver.possible_requests[1001]) == 2
+
+        # 1001 + 1003 in B-2001 (not_bunk_with violated), 1002 in B-2002 (bunk_with violated).
+        assignments = [
+            _assignment(1001, 2001, 100),
+            _assignment(1002, 2002, 100),
+            _assignment(1003, 2001, 100),
+        ]
+
+        solver._check_must_satisfy_one_violations(assignments)
+
+        # Material-parent presence wins — even though staff is also unmet, the camper appears
+        # ONCE in the material_parent_unmet category, NOT in other_unmet.
+        material = _violation_details(solver, CAT_MATERIAL_PARENT_UNMET)
+        assert len(material) == 1
+        assert "1001" in material[0]
+        assert _violation_details(solver, CAT_OTHER_UNMET) == []
+        assert _violation_details(solver, CAT_NO_POSSIBLE) == []
+
+    def test_camper_with_at_least_one_satisfied_request_not_flagged(self, mock_config):
+        """Camper with ≥1 satisfied request stays out of all three categories."""
+        # 1001 wants 1002 (satisfied — same bunk) AND 1003 (unsatisfied — different bunk).
+        input_data = DirectSolverInput(
+            persons=[_person(1001, 100), _person(1002, 100), _person(1003, 100)],
+            requests=[
+                _request("r1", 1001, 1002, 100, source_field="bunk_with"),
+                _request("r2", 1001, 1003, 100, source_field="bunk_with"),
+            ],
+            bunks=[_bunk(2001, 100), _bunk(2002, 100)],
+        )
+        solver = DirectBunkingSolver(input_data, ConfigLoader.get_instance())
+
+        # 1001 + 1002 in B-2001 (r1 satisfied), 1003 in B-2002 (r2 unsatisfied).
+        assignments = [
+            _assignment(1001, 2001, 100),
+            _assignment(1002, 2001, 100),
+            _assignment(1003, 2002, 100),
+        ]
+
+        solver._check_must_satisfy_one_violations(assignments)
+
+        assert _violation_details(solver, CAT_NO_POSSIBLE) == []
+        assert _violation_details(solver, CAT_MATERIAL_PARENT_UNMET) == []
+        assert _violation_details(solver, CAT_OTHER_UNMET) == []
+
+    def test_camper_with_no_requests_not_flagged(self, mock_config):
+        """A camper with no requests at all is not flagged in any category."""
+        input_data = DirectSolverInput(
+            persons=[_person(1001, 100)],
+            requests=[],
+            bunks=[_bunk(2001, 100)],
+        )
+        solver = DirectBunkingSolver(input_data, ConfigLoader.get_instance())
+        assignments = [_assignment(1001, 2001, 100)]
+
+        solver._check_must_satisfy_one_violations(assignments)
+
+        assert _violation_details(solver, CAT_NO_POSSIBLE) == []
+        assert _violation_details(solver, CAT_MATERIAL_PARENT_UNMET) == []
+        assert _violation_details(solver, CAT_OTHER_UNMET) == []
+
+    def test_request_validation_summary_carries_breakdown(self, mock_config):
+        """`request_validation_summary` exposes counts so the JSON log carries the breakdown.
+
+        The structured solver-log JSON snapshots `request_validation_summary`.
+        Adding the post-solve breakdown there makes the type-A vs type-B+C
+        split visible in logs without needing to scrape the violation-list
+        names.
+        """
+        # 1001 → type A (impossible), 1002 → type B (material unmet),
+        # 1003 → type C (staff unmet), 1004 → satisfied.
+        input_data = DirectSolverInput(
+            persons=[
+                _person(1001, 100),
+                _person(1002, 100),
+                _person(1003, 100),
+                _person(1004, 100),
+                _person(2001, 200),  # cross-session target for 1001
+                _person(1005, 100),  # target for 1002
+                _person(1006, 100),  # target for 1003
+                _person(1007, 100),  # target for 1004
+            ],
+            requests=[
+                _request("rA", 1001, 2001, 100, source_field="bunk_with"),  # type A
+                _request("rB", 1002, 1005, 100, source_field="bunk_with"),  # type B
+                _request(
+                    "rC",
+                    1003,
+                    1006,
+                    100,
+                    request_type="not_bunk_with",
+                    source_field="not_bunk_with",
+                ),  # type C
+                _request("rD", 1004, 1007, 100, source_field="bunk_with"),  # satisfied
+            ],
+            bunks=[_bunk(2001, 100), _bunk(2002, 100), _bunk(2010, 200)],
+        )
+        solver = DirectBunkingSolver(input_data, ConfigLoader.get_instance())
+
+        assignments = [
+            _assignment(1001, 2001, 100),
+            _assignment(1002, 2001, 100),  # 1005 elsewhere → unmet
+            _assignment(1005, 2002, 100),
+            _assignment(1003, 2001, 100),
+            _assignment(1006, 2001, 100),  # same bunk → not_bunk_with violated
+            _assignment(1004, 2002, 100),
+            _assignment(1007, 2002, 100),  # together → satisfied
+            _assignment(2001, 2010, 200),
+        ]
+
+        solver._check_must_satisfy_one_violations(assignments)
+
+        summary = solver.request_validation_summary
+        assert summary.get("unsatisfied_no_possible") == 1
+        assert summary.get("unsatisfied_material_parent_unmet") == 1
+        assert summary.get("unsatisfied_other_unmet") == 1

--- a/tests/unit/solver/test_must_satisfy_diagnostic.py
+++ b/tests/unit/solver/test_must_satisfy_diagnostic.py
@@ -426,3 +426,86 @@ class TestMustSatisfyDiagnosticSplit:
         assert summary.get("unsatisfied_no_possible") == 1
         assert summary.get("unsatisfied_material_parent_unmet") == 1
         assert summary.get("unsatisfied_other_unmet") == 1
+
+    def test_violation_message_count_excludes_non_resolved_possibles(self, mock_config):
+        """The ``possible_count`` rendered in the violation message must reflect
+        resolved-only possibles, mirroring the diagnostic's resolved-only scope.
+
+        A camper with one resolved-unsatisfied bunk_with AND one pending-possible
+        bunk_with should be reported as having "1 possible requests" — not 2 —
+        because the diagnostic doesn't consider pending requests at all.
+        """
+        # 1001 has:
+        #   - resolved bunk_with → 1002 (unsatisfied: different bunks)
+        #   - pending bunk_with → 1003 (would be possible-but-pending)
+        # Both are structurally feasible (same session) so both land in
+        # possible_requests[1001]. Only the resolved one should drive the count
+        # shown in the violation message.
+        input_data = DirectSolverInput(
+            persons=[_person(1001, 100), _person(1002, 100), _person(1003, 100)],
+            requests=[
+                _request("r-resolved", 1001, 1002, 100, source_field="bunk_with", status="resolved"),
+                _request("r-pending", 1001, 1003, 100, source_field="bunk_with", status="pending"),
+            ],
+            bunks=[_bunk(2001, 100), _bunk(2002, 100)],
+        )
+        solver = DirectBunkingSolver(input_data, ConfigLoader.get_instance())
+        # Sanity: validation classified both as possible (no status filter at validate time).
+        assert len(solver.possible_requests[1001]) == 2
+
+        # Place 1001 alone in 2001, 1002 + 1003 elsewhere → resolved request unsatisfied.
+        assignments = [
+            _assignment(1001, 2001, 100),
+            _assignment(1002, 2002, 100),
+            _assignment(1003, 2002, 100),
+        ]
+
+        solver._check_must_satisfy_one_violations(assignments)
+
+        material = _violation_details(solver, CAT_MATERIAL_PARENT_UNMET)
+        assert len(material) == 1
+        # The message must show the resolved-only count of 1, not the unfiltered 2.
+        assert "1 possible requests" in material[0]
+        assert "2 possible requests" not in material[0]
+
+    def test_unknown_source_field_treated_as_non_material(self, mock_config):
+        """Unknown ``source_field`` values must not crash the diagnostic.
+
+        ``_is_material_parent`` defensively swallows ``ValueError`` from
+        ``classify_request`` — an unknown source_field should route the camper
+        to ``other_unmet`` rather than aborting the run. This guards against
+        silent regressions if a new source_field is added to the schema before
+        the bucket map is updated.
+        """
+        # 1001 has a single resolved bunk_with-ish request whose source_field is
+        # an entirely unknown string. The structural type (request_type) is still
+        # bunk_with so it lands in possible_requests; classification falls back.
+        input_data = DirectSolverInput(
+            persons=[_person(1001, 100), _person(1002, 100)],
+            requests=[
+                _request(
+                    "r1",
+                    1001,
+                    1002,
+                    100,
+                    request_type="bunk_with",
+                    source_field="some_future_unmapped_field",
+                ),
+            ],
+            bunks=[_bunk(2001, 100), _bunk(2002, 100)],
+        )
+        solver = DirectBunkingSolver(input_data, ConfigLoader.get_instance())
+        assert len(solver.possible_requests[1001]) == 1
+
+        # Different bunks → unsatisfied.
+        assignments = [_assignment(1001, 2001, 100), _assignment(1002, 2002, 100)]
+
+        solver._check_must_satisfy_one_violations(assignments)
+
+        # Unknown source_field → non-material → other_unmet (not material_parent_unmet).
+        assert _violation_details(solver, CAT_MATERIAL_PARENT_UNMET) == []
+        other = _violation_details(solver, CAT_OTHER_UNMET)
+        assert len(other) == 1
+        assert "1001" in other[0]
+        sev = solver.constraint_logger.violations[CAT_OTHER_UNMET][0]["severity"]
+        assert sev == "info"

--- a/tests/unit/solver/test_must_satisfy_diagnostic.py
+++ b/tests/unit/solver/test_must_satisfy_diagnostic.py
@@ -81,6 +81,7 @@ def _request(
     *,
     request_type: str = "bunk_with",
     source_field: str = "bunk_with",
+    status: str = "resolved",
 ) -> DirectBunkRequest:
     return DirectBunkRequest(
         id=req_id,
@@ -89,7 +90,7 @@ def _request(
         request_type=request_type,
         session_cm_id=session,
         year=2026,
-        status="resolved",
+        status=status,
         source_field=source_field,
     )
 
@@ -288,6 +289,87 @@ class TestMustSatisfyDiagnosticSplit:
         assert _violation_details(solver, CAT_NO_POSSIBLE) == []
         assert _violation_details(solver, CAT_MATERIAL_PARENT_UNMET) == []
         assert _violation_details(solver, CAT_OTHER_UNMET) == []
+
+    def test_pending_or_declined_requests_excluded_from_diagnostic(self, mock_config):
+        """Diagnostic mirrors the solver's resolved-only scope.
+
+        `data_fetcher.py:140` filters bunk_requests to ``status="resolved"`` before
+        the solver sees them — pending/declined never reach the constraint module
+        in production. The diagnostic should match: a camper whose only requests
+        are pending or declined must NOT show up in any of the three categories.
+        Otherwise we'd be flagging "no satisfied requests" against a request set
+        the solver was never asked to satisfy.
+
+        This also collapses the "type A: cross-session" case in practice — the
+        bunk_request_processor auto-DECLINES cross-session bunk_with at sync
+        time, so they'd be filtered out here regardless.
+        """
+        # 1001 has only pending requests. 1002 has only declined requests.
+        # Neither should appear in any diagnostic category.
+        input_data = DirectSolverInput(
+            persons=[_person(1001, 100), _person(1002, 100), _person(1003, 100)],
+            requests=[
+                _request("rA", 1001, 1003, 100, source_field="bunk_with", status="pending"),
+                _request("rB", 1002, 1003, 100, source_field="bunk_with", status="declined"),
+            ],
+            bunks=[_bunk(2001, 100), _bunk(2002, 100)],
+        )
+        solver = DirectBunkingSolver(input_data, ConfigLoader.get_instance())
+
+        # Place 1001/1002 separate from 1003 — would be unsatisfied if they counted.
+        assignments = [
+            _assignment(1001, 2001, 100),
+            _assignment(1002, 2001, 100),
+            _assignment(1003, 2002, 100),
+        ]
+
+        solver._check_must_satisfy_one_violations(assignments)
+
+        # Neither camper appears in any category — their requests aren't in solver scope.
+        assert _violation_details(solver, CAT_NO_POSSIBLE) == []
+        assert _violation_details(solver, CAT_MATERIAL_PARENT_UNMET) == []
+        assert _violation_details(solver, CAT_OTHER_UNMET) == []
+        # Summary counts reflect only resolved requests.
+        summary = solver.request_validation_summary
+        assert summary.get("unsatisfied_no_possible") == 0
+        assert summary.get("unsatisfied_material_parent_unmet") == 0
+        assert summary.get("unsatisfied_other_unmet") == 0
+
+    def test_only_resolved_request_counted_when_camper_has_mixed_statuses(self, mock_config):
+        """A camper with one resolved + one pending request is judged on the resolved one.
+
+        If the resolved request is satisfied, the camper passes — the pending
+        request neither helps nor hurts. If the resolved request is unsatisfied
+        and the camper has no other resolved possible, they're flagged on the
+        resolved one's bucket.
+        """
+        # 1001 has:
+        #   - resolved bunk_with → 1002 (unsatisfied, different bunks)
+        #   - pending bunk_with → 1003 (would-be-satisfied if counted, but pending so ignored)
+        input_data = DirectSolverInput(
+            persons=[_person(1001, 100), _person(1002, 100), _person(1003, 100)],
+            requests=[
+                _request("r-resolved", 1001, 1002, 100, source_field="bunk_with", status="resolved"),
+                _request("r-pending", 1001, 1003, 100, source_field="bunk_with", status="pending"),
+            ],
+            bunks=[_bunk(2001, 100), _bunk(2002, 100)],
+        )
+        solver = DirectBunkingSolver(input_data, ConfigLoader.get_instance())
+
+        # 1001 + 1003 in B-2001 (would satisfy the pending), 1002 in B-2002 (resolved unsatisfied).
+        assignments = [
+            _assignment(1001, 2001, 100),
+            _assignment(1003, 2001, 100),
+            _assignment(1002, 2002, 100),
+        ]
+
+        solver._check_must_satisfy_one_violations(assignments)
+
+        # Despite the pending request being "satisfied" by accident, the resolved one isn't —
+        # so the camper IS flagged.
+        material = _violation_details(solver, CAT_MATERIAL_PARENT_UNMET)
+        assert len(material) == 1
+        assert "1001" in material[0]
 
     def test_request_validation_summary_carries_breakdown(self, mock_config):
         """`request_validation_summary` exposes counts so the JSON log carries the breakdown.


### PR DESCRIPTION
## Summary

Splits the post-solve `must_satisfy_one` diagnostic at `direct_solver.py:935+` into three populations:

- **Type A** — `must_satisfy_one_no_possible` (info): all the camper's requests are structurally impossible (cross-session target, target absent, malformed). Soft constraint at `must_satisfy.py:91-94` already skips these — they were never solver-actionable. Staff fixes the parent's input.
- **Type B** — `must_satisfy_one_material_parent_unmet` (warning): camper has ≥1 possible MATERIAL_PARENT (`bunk_with`) request the solver didn't satisfy. Headline staff failure mode.
- **Type C** — `must_satisfy_one_other_unmet` (info): camper has only non-material (STAFF / IMMATERIAL_PARENT) possible requests, none satisfied. Lower-priority.

The split was needed because "10 unsatisfied campers per run" turned out to mix three different things: the soft penalty firing on solver-actionable cases, the dead-letter loop counting parent-input issues that the soft constraint already silently skips, and edge cases with no material-parent stake. With them mixed, the count couldn't inform any design decision.

Counts are surfaced into `request_validation_summary` so the structured solver-log JSON carries the breakdown without scraping violation-list strings.

## Why now

This is a small reporting-only PR ahead of the parent-paramount Stage 4 work (per `docs/plans/2026-04-28-parent-paramount-handoff.md` §6 + the Stage 4 sketch in the wife-feedback scoreboard). When Stage 4 narrows `must_satisfy_one` to MATERIAL_PARENT only, the diagnostic-side categorization will already match the new constraint shape, and the type-A/B/C breakdown over real solver runs will inform the hard-vs-soft design call.

**No solver behavior change.** Soft constraint, hard constraints, and the objective formulation are unchanged. Only the post-solve reporter and the structured-log summary change.

## Test plan

- [x] Unit tests for each population (type A, type B, type C, mixed-bucket-falls-in-material, satisfied-camper-not-flagged, no-requests-not-flagged, summary-carries-breakdown). 7 tests, all passing.
- [x] Pre-push verification (`bash .claude/skills/pre-push-verification/scripts/verify.sh`): ruff format, ruff check, mypy, 4217 unit tests pass.
- [ ] Manual: run the solver on a recent session and confirm the JSON solver-log contains the three new categories under `detailed_logs.violations` and the three new fields under `summary.request_validation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved post-solve diagnostics: unsatisfied "must-satisfy-one" requests are classified into three distinct categories (no possible options, parent-linked unmet, and other unmet), with separate severity levels, truncated per-person details, and per-category summary counters.

* **Tests**
  * Added comprehensive tests validating the three-way diagnostic split, severity assignments, exclusion of unresolved requests, rendered counts use resolved-only possibles, and summary-count accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->