### PR TITLE
feat(pb): consolidate-migrations skill bootstrap (verification harness + history-sync hook)

### DIFF
--- a/.claude/skills/campminder-sync/SKILL.md
+++ b/.claude/skills/campminder-sync/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: campminder-sync
+description: Use when modifying Go sync services, adding new CampMinder data tables, changing sync jobs, or debugging data integrity issues between CampMinder and PocketBase. Triggers on pocketbase/ Go sync code changes.
+---
+
+# CampMinder Sync Layer
+
+## The #1 Rule
+
+**ALL cross-table relationships use CampMinder IDs, NEVER PocketBase IDs.**
+
+PocketBase IDs are auto-generated and unstable across syncs. CampMinder IDs (`cm_id`, `person_id`, `session_id`, etc.) are the source of truth for all foreign key relationships. The only place PocketBase IDs appear in relation fields is after `PopulateRelations()` resolves CM IDs to PB IDs at write time.
+
+```go
+// CORRECT: Store the CampMinder ID, resolve PB ID only for the relation field
+recordData["person_id"] = personCMID  // CM ID stored as data
+relations := []RelationConfig{
+    {FieldName: "person", Collection: "persons", CMID: personCMID, Required: false},
+}
+s.PopulateRelations(recordData, relations)
+
+// WRONG: Never store or look up by PocketBase ID for cross-table references
+recordData["person_id"] = record.Id  // NO - this is a PB ID
+```
+
+See `reference/id-conventions.md` for the full ID convention guide.
+
+## Critical Gotchas
+
+Before writing any sync code, read `gotchas.md`. The most common failures:
+
+1. **Year contamination** -- CampMinder reuses session IDs across years. Every CampMinder data table MUST have a `year` field. Unique indexes MUST include year. Forgetting year isolation causes cross-year data pollution.
+
+2. **Sync order violations** -- Derived tables that run before their dependencies produce empty results. The orchestrator enforces order via `syncJobMeta` in `orchestrator.go`.
+
+3. **PocketBase filter syntax** -- ALWAYS use spaces around operators: `field = value`, never `field=value`. Missing spaces cause silent filter failures.
+
+4. **Missing orchestrator registration** -- Registering a service but forgetting to add it to `syncJobMeta` means the job never runs in unified syncs.
+
+5. **Spelling: "cancelled"** -- Use British spelling consistently. The `.golangci.yml` misspell linter is configured to accept `cancelled` as correct.
+
+## Sync Order (Dependency Chain)
+
+Jobs execute in phase order. Within each phase, jobs run sequentially in the order listed in `syncJobMeta`:
+
+| Phase | Jobs | Notes |
+|-------|------|-------|
+| **Source** | session_groups, sessions, attendees, persons, bunks, bunk_plans, bunk_assignments, staff, financial_transactions | CampMinder API calls |
+| **Expensive** | person_custom_values, household_custom_values | 1 API call per entity, run weekly/on-demand |
+| **Transform** | camper_history, family_camp_derived, staff_skills, financial_aid_applications, household_demographics, camper_dietary, camper_transportation, quest_registrations, staff_applications, staff_vehicle_info, normalize_geographic, enrollment_snapshots | PocketBase-to-PocketBase computation |
+| **Process** | bunk_requests, process_requests | CSV import + AI processing |
+| **Export** | multi_workbook_export | Google Sheets export |
+
+See `reference/sync-order.md` for why order matters and how to add new jobs.
+
+## Go Coding Patterns
+
+All sync services follow the same structural pattern. See `reference/go-patterns.md` for the complete guide including:
+
+- Service struct embedding `BaseSyncService`
+- Required interface methods: `Name()`, `Sync(ctx)`, `GetStats()`
+- Preloading existing records for idempotent upserts
+- Composite key construction for multi-field uniqueness
+- Orphan detection and deletion
+- WAL checkpoint after writes
+- Context cancellation checks in loops
+
+## Adding a New Sync Job
+
+Follow the complete checklist in `docs/architecture/sync-layer.md` under "Adding a New Sync Job". The checklist covers:
+
+1. Go sync service (`pocketbase/sync/{job_name}.go`)
+2. Orchestrator registration (`orchestrator.go` -- add to `syncJobMeta` AND `GetDefaultUnifiedSyncJobs`)
+3. API endpoint (`api.go`)
+4. PocketBase migration (if new table)
+5. Frontend type registration (`syncTypes.ts`, `useRunIndividualSync.ts`)
+6. Historical sync support (if year-specific)
+7. Google Sheets export mapping (`table_exporter.go`)
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `pocketbase/sync/orchestrator.go` | Sync sequencing, phases, job metadata |
+| `pocketbase/sync/base_sync.go` | Shared utilities: preload, process, orphan delete, field comparison |
+| `pocketbase/sync/api.go` | HTTP endpoints for triggering syncs |
+| `pocketbase/sync/scheduler.go` | Cron scheduling (hourly, daily, weekly) |
+| `pocketbase/campminder/client.go` | CampMinder API client, auth, token caching |
+| `pocketbase/logging/logger.go` | Structured logging setup |
+| `.golangci.yml` | Go linting rules (misspell, wrapcheck, etc.) |
+| `docs/architecture/sync-layer.md` | Full architecture documentation |

--- a/.claude/skills/campminder-sync/gotchas.md
+++ b/.claude/skills/campminder-sync/gotchas.md
@@ -1,0 +1,141 @@
+# CampMinder Sync Gotchas
+
+These are real failure modes encountered in production. Read before writing sync code.
+
+## 1. Year Contamination (Critical)
+
+**Problem:** CampMinder reuses session IDs, person IDs, and other identifiers across years. Without year isolation, syncing 2026 data overwrites 2025 records with the same CM IDs.
+
+**Rules:**
+- Every CampMinder data table MUST have a required `year` field
+- All unique indexes MUST include `year` (e.g., `person_id + year + session`)
+- `PreloadRecords()` automatically builds composite keys as `{cm_id}|{year}`
+- `ProcessSimpleRecord()` requires `year` in `recordData` -- it will error without it
+- `LookupRelation()` auto-adds year filtering for known year-scoped collections
+- `PaginateRecords()` auto-adds year filtering for known year-scoped collections
+
+**Year-scoped collections** (auto-filtered): `persons`, `camp_sessions`, `bunks`, `bunk_plans`, `bunk_assignments`, `attendees`
+
+**Global collections** (no year field): `session_groups`, `person_tag_definitions`, `custom_field_definitions` -- use `PreloadRecordsGlobal()` and `ProcessSimpleRecordGlobal()` for these.
+
+**How year flows:**
+```go
+year := s.Client.GetSeasonID()  // From CAMPMINDER_SEASON_ID env var
+recordData["year"] = year       // MUST be set on every record
+```
+
+## 2. Sync Order Violations
+
+**Problem:** Running a derived table before its source data syncs produces empty or stale results.
+
+**Key dependencies:**
+- `persons` depends on `attendees` (reads attendee person_ids to know which persons to fetch)
+- `bunk_plans` depends on `bunks` and `sessions` (validates bunk/session CM IDs)
+- `bunk_assignments` depends on `bunk_plans`, `bunks`, `sessions`, `persons`
+- `camper_history` depends on `attendees`, `persons`, `sessions`
+- `family_camp_derived` depends on `person_custom_values`, `household_custom_values`
+- All transform-phase jobs use existing custom values data (may be stale from last weekly sync)
+
+**Prevention:** New jobs must be added to `syncJobMeta` in `orchestrator.go` in the correct position. The phase determines execution order.
+
+## 3. PocketBase Filter Syntax
+
+**Problem:** PocketBase requires spaces around operators in filter expressions. `field=value` silently fails or returns unexpected results.
+
+```go
+// CORRECT
+filter := fmt.Sprintf("year = %d", year)
+filter := fmt.Sprintf("cm_id = %d && year = %d", cmID, year)
+
+// WRONG - will silently fail
+filter := fmt.Sprintf("year=%d", year)
+filter := fmt.Sprintf("cm_id=%d&&year=%d", cmID, year)
+```
+
+**Also note:** String values in filters must be single-quoted:
+```go
+filter := fmt.Sprintf("id = '%s'", pbID)       // Correct
+filter := fmt.Sprintf("status = '%s'", status)  // Correct
+```
+
+## 4. Family Camp Exclusion
+
+**Problem:** Family camp sessions have different structures than main summer camp sessions. Including them in the solver or general bunking logic causes incorrect results.
+
+**How it works:**
+- Sessions are classified by `session_type` field (main, family, adult, embedded, tli, training, other)
+- Classification is based on `session_group` CM IDs defined in `sessions.go` constants
+- The solver and bunking logic filter to `session_type = "main"` or specific types
+- `family_camp_derived` handles family camp data separately via its own transform sync
+
+## 5. Attendee Filtering for the Solver
+
+**Problem:** Not all attendees should be included in cabin assignment optimization.
+
+**The filter:** `is_active = 1 AND status_id = 2`
+- `status_id = 2` means "enrolled" (not waitlisted, cancelled, withdrawn, etc.)
+- `is_active = 1` filters out deactivated records
+- Status map in `attendees.go`: 1=none, 2=enrolled, 4=applied, 8=waitlisted, 16=left_early, 32=cancelled, 64=dismissed, 128=inquiry, 256=withdrawn, 512=incomplete
+
+## 6. Orphan Deletion Safety
+
+**Problem:** If a sync fails mid-way, orphan detection would incorrectly delete records that weren't fetched yet.
+
+**Safety mechanism:** `SyncSuccessful` flag. Orphan deletion only runs when `SyncSuccessful = true`. Set this flag only after the first successful data fetch:
+```go
+if page == 1 && len(results) > 0 {
+    s.SyncSuccessful = true
+}
+```
+
+## 7. Sequential Session Syncs
+
+**Problem:** Bunk request processing (CSV import + AI parsing) for sessions 1-4 runs sequentially with independent history tracking. Running them in parallel causes race conditions on the `csv_history/` files.
+
+**How it works:** The `process_requests` sync accepts a `session` parameter (0=all, 1-4=specific). When session=0, it processes each session sequentially.
+
+## 8. Token Caching
+
+**Problem:** CampMinder API authentication is rate-limited. Authenticating on every request wastes quota.
+
+**How it works:** JWT tokens are cached in `~/.campminder_token_cache.json` with expiry tracking. The `campminder.Client` handles this transparently. If you see auth errors in tests, the token cache file may be stale or the mock may not handle auth correctly.
+
+## 9. Missing Orchestrator Registration
+
+**Problem:** Creating a sync service file but forgetting to register it in all required places means the job silently never runs.
+
+**Complete registration checklist:**
+1. Add to `syncJobMeta` in `orchestrator.go` (controls execution order and phase)
+2. Add to `GetDefaultUnifiedSyncJobs()` (controls inclusion in unified syncs)
+3. Register with `RegisterService()` in `InitializeSyncServices()`
+4. Add to `handleSyncStatus()` known types in `api.go` (required for GUI status display)
+5. Add to `SyncJobToCollections` in `table_exporter.go` (required for export skip optimization)
+
+## 10. WAL Checkpoint After Writes
+
+**Problem:** SQLite WAL mode means writes aren't immediately visible to other connections. Downstream sync jobs may not see data written by upstream jobs.
+
+**Solution:** Call `s.ForceWALCheckpoint()` at the end of every sync that creates or updates records. The base implementation automatically skips the checkpoint if no writes occurred.
+
+## 11. "cancelled" Spelling
+
+**Problem:** The Go misspell linter defaults to US English ("canceled"). This project uses British spelling ("cancelled") consistently because PocketBase fields use it (`cancelled_count`).
+
+**Configuration:** `.golangci.yml` has `extra-words` that maps "cancelled" to "cancelled" (identity mapping to suppress the linter). When you need to use "cancelled" in Go code and the linter complains, add `//nolint:misspell` with a comment:
+```go
+32: "cancelled", //nolint:misspell // CampMinder status value
+```
+
+## 12. Composite Key Patterns
+
+**Problem:** Some tables have multi-field uniqueness (e.g., attendees are unique by person_id + session, not by a single CM ID). Using simple keys causes duplicate records.
+
+**Solution:** Use `PreloadCompositeRecords()` and `ProcessCompositeRecord()`:
+```go
+key := fmt.Sprintf("%d:%d", personCMID, sessionCMID)
+s.TrackProcessedCompositeKey(key, year)
+// ...
+s.ProcessCompositeRecord("attendees", key, recordData, existingRecords, []string{"year"})
+```
+
+The base utilities automatically append `|{year}` to composite keys for year isolation.

--- a/.claude/skills/campminder-sync/reference/go-patterns.md
+++ b/.claude/skills/campminder-sync/reference/go-patterns.md
@@ -1,0 +1,328 @@
+# Go Coding Patterns for Sync Services
+
+## Service Struct Template
+
+Every sync service follows the same structure:
+
+```go
+package sync
+
+import (
+    "context"
+    "fmt"
+    "log/slog"
+
+    "github.com/camp/kindred/pocketbase/campminder"
+    "github.com/pocketbase/pocketbase/core"
+)
+
+// WidgetsSync handles syncing widget records from CampMinder
+type WidgetsSync struct {
+    BaseSyncService
+    // Add service-specific caches here
+}
+
+// NewWidgetsSync creates a new widgets sync service
+func NewWidgetsSync(app core.App, client *campminder.Client) *WidgetsSync {
+    return &WidgetsSync{
+        BaseSyncService: NewBaseSyncService(app, client),
+    }
+}
+
+// Name returns the name of this sync service
+func (s *WidgetsSync) Name() string {
+    return "widgets"
+}
+
+// Sync performs the widgets synchronization
+func (s *WidgetsSync) Sync(ctx context.Context) error {
+    s.LogSyncStart("widgets")
+    s.Stats = Stats{}
+    s.SyncSuccessful = false
+    s.ClearProcessedKeys()
+
+    // 1. Pre-load existing records
+    year := s.Client.GetSeasonID()
+    filter := fmt.Sprintf("year = %d", year)
+    existingRecords, err := s.PreloadRecords("widgets", filter, func(record *core.Record) (interface{}, bool) {
+        if cmID, ok := record.Get("cm_id").(float64); ok {
+            return int(cmID), true
+        }
+        return nil, false
+    })
+    if err != nil {
+        return err
+    }
+
+    // 2. Fetch from CampMinder
+    widgets, err := s.Client.GetWidgets()
+    if err != nil {
+        return fmt.Errorf("fetching widgets: %w", err)
+    }
+
+    if len(widgets) > 0 {
+        s.SyncSuccessful = true
+    }
+
+    // 3. Process each record
+    for _, widgetData := range widgets {
+        select {
+        case <-ctx.Done():
+            return fmt.Errorf("widgets sync cancelled: %w", ctx.Err())
+        default:
+        }
+
+        if err := s.processWidget(widgetData, existingRecords); err != nil {
+            slog.Error("Error processing widget", "error", err)
+            s.Stats.Errors++
+        }
+    }
+
+    // 4. Delete orphans
+    // ... (see orphan detection section)
+
+    // 5. WAL checkpoint
+    if err := s.ForceWALCheckpoint(); err != nil {
+        slog.Warn("WAL checkpoint failed", "error", err)
+    }
+
+    s.LogSyncComplete("Widgets")
+    return nil
+}
+```
+
+## Transform Service Template (No CampMinder Client)
+
+Transform services compute derived data from existing PocketBase records. They do NOT embed `BaseSyncService` because they don't need a CampMinder client:
+
+```go
+type StaffSkillsSync struct {
+    App            core.App
+    Year           int
+    Stats          Stats
+    SyncSuccessful bool
+}
+
+func NewStaffSkillsSync(app core.App) *StaffSkillsSync {
+    return &StaffSkillsSync{App: app}
+}
+
+// SetYear implements YearSetter for receiving year from orchestrator
+func (s *StaffSkillsSync) SetYear(year int) {
+    s.Year = year
+}
+```
+
+Transform services implement `YearSetter` so the orchestrator can inject the correct year.
+
+## Record Processing with Simple Keys
+
+For tables where `cm_id` alone is the unique key:
+
+```go
+func (s *WidgetsSync) processWidget(data map[string]interface{}, existing map[interface{}]*core.Record) error {
+    cmID := int(data["ID"].(float64))
+    year := s.Client.GetSeasonID()
+
+    // Track as processed for orphan detection
+    s.TrackProcessedKey(cmID, year)
+
+    // Build record data
+    recordData := map[string]interface{}{
+        "cm_id": cmID,
+        "name":  data["Name"],
+        "year":  year,
+    }
+
+    // Resolve relations (CM ID -> PB ID)
+    relations := []RelationConfig{
+        {FieldName: "session", Collection: "camp_sessions", CMID: sessionCMID, Required: true},
+    }
+    if err := s.PopulateRelations(recordData, relations); err != nil {
+        return fmt.Errorf("populating relations: %w", err)
+    }
+
+    // Upsert (create or update)
+    return s.ProcessSimpleRecord("widgets", cmID, recordData, existing, nil)
+}
+```
+
+The last parameter of `ProcessSimpleRecord` is `compareFields` -- pass `nil` to compare all fields, or a slice of field names to compare only specific fields.
+
+## Record Processing with Composite Keys
+
+For tables where uniqueness requires multiple fields (e.g., attendees = person + session):
+
+```go
+key := fmt.Sprintf("%d:%d", personCMID, sessionCMID)
+s.TrackProcessedCompositeKey(key, year)
+
+// PreloadCompositeRecords returns map[string]*core.Record (string keys, not interface{})
+return s.ProcessCompositeRecord("attendees", key, recordData, existingRecords, []string{"year"})
+```
+
+The `skipFields` parameter (last arg) lists fields to exclude from change detection. `"year"` is commonly skipped because it's part of the key, not variable data.
+
+## Paginated Fetching from CampMinder
+
+For large datasets, use pagination:
+
+```go
+page := 1
+pageSize := LargePageSize  // 500
+
+for {
+    select {
+    case <-ctx.Done():
+        return fmt.Errorf("sync cancelled: %w", ctx.Err())
+    default:
+    }
+
+    items, hasMore, err := s.Client.GetItemsPage(page, pageSize)
+    if err != nil {
+        return fmt.Errorf("fetching page %d: %w", page, err)
+    }
+
+    if page == 1 && len(items) > 0 {
+        s.SyncSuccessful = true
+    }
+
+    for _, item := range items {
+        // process...
+    }
+
+    if !hasMore || len(items) == 0 {
+        break
+    }
+    page++
+}
+```
+
+**Page size constants:**
+- `SmallPageSize = 10` -- For endpoints with known limitations
+- `DefaultPageSize = 100` -- General purpose
+- `LargePageSize = 500` -- High-volume operations
+
+## Orphan Detection
+
+After processing all CampMinder records, delete PocketBase records that no longer exist in CampMinder:
+
+### Simple key orphan deletion (re-queries PocketBase):
+```go
+s.DeleteOrphans("widgets",
+    func(record *core.Record) (string, bool) {
+        cmID, _ := record.Get("cm_id").(float64)
+        yearVal, _ := record.Get("year").(float64)
+        if cmID > 0 {
+            return CompositeKey(int(cmID), int(yearVal)), true
+        }
+        return "", false
+    },
+    "widget",
+    filter,
+)
+```
+
+### Preloaded orphan deletion (~200x faster for large tables):
+```go
+s.DeleteOrphansFromPreloaded(existingRecords, "widget")
+```
+
+## Logging Patterns
+
+```go
+// Initialize once at app startup
+import "github.com/camp/kindred/pocketbase/logging"
+logging.Init("pocketbase")
+
+// Then use slog throughout
+slog.Info("Processing widget", "cm_id", cmID, "name", name)
+slog.Error("Failed to process", "error", err, "cm_id", cmID)
+slog.Warn("Skipping invalid record", "reason", "missing field")
+slog.Debug("Detailed info", "field", value)  // Only visible with LOG_LEVEL=DEBUG
+```
+
+Format: `2026-01-06T14:05:52Z [pocketbase] INFO message key=value...`
+
+Use structured key=value pairs, not formatted strings:
+```go
+// CORRECT
+slog.Info("Fetched records", "count", len(records), "year", year)
+
+// WRONG
+slog.Info(fmt.Sprintf("Fetched %d records for year %d", len(records), year))
+```
+
+## Testing Patterns
+
+Tests use table-driven style with the standard `testing` package:
+
+```go
+func TestWidgetsSync_Name(t *testing.T) {
+    s := &WidgetsSync{}
+    if got := s.Name(); got != "widgets" {
+        t.Errorf("Name() = %q, want %q", got, "widgets")
+    }
+}
+
+func TestWidgetsSync_Transform(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   map[string]interface{}
+        want    int
+        wantErr bool
+    }{
+        {
+            name:  "valid widget",
+            input: map[string]interface{}{"ID": float64(123), "Name": "Test"},
+            want:  123,
+        },
+        {
+            name:    "missing ID",
+            input:   map[string]interface{}{"Name": "Test"},
+            wantErr: true,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            // test logic...
+        })
+    }
+}
+```
+
+**Note:** CampMinder API responses use `float64` for all numbers (JSON unmarshaling). Always type-assert as `float64` first, then convert: `int(data["ID"].(float64))`.
+
+## Error Handling
+
+```go
+// Wrap errors with context using fmt.Errorf and %w
+if err != nil {
+    return fmt.Errorf("fetching widgets page %d: %w", page, err)
+}
+
+// Non-fatal errors: log and increment error counter
+if err := s.processWidget(data); err != nil {
+    slog.Error("Error processing widget", "error", err, "cm_id", cmID)
+    s.Stats.Errors++
+    // Continue processing other records
+}
+
+// wrapcheck linter exceptions in .golangci.yml:
+// - github.com/pocketbase/pocketbase/tools/router (terminal HTTP responses)
+// - github.com/camp/kindred/pocketbase/campminder (wrapped by callers)
+```
+
+## Linting Notes
+
+Key linter configurations from `.golangci.yml`:
+
+- **Line length**: 120 characters max (`lll`)
+- **Cyclomatic complexity**: 15 max (`gocyclo`), relaxed for sync/ package
+- **Duplication threshold**: 100 tokens (`dupl`), relaxed for sync/ package
+- **Error wrapping**: Required by `wrapcheck` (exceptions for PocketBase router and CampMinder client)
+- **Shadow detection**: Enabled via `govet.enable: shadow`
+- **Exhaustive switches**: Required by `exhaustive` linter
+- **Misspell**: US locale, with `cancelled` allowed as an exception
+- **Build tags**: `pocketbase` tag required

--- a/.claude/skills/campminder-sync/reference/id-conventions.md
+++ b/.claude/skills/campminder-sync/reference/id-conventions.md
@@ -1,0 +1,106 @@
+# CampMinder ID vs PocketBase ID Conventions
+
+## The Core Principle
+
+**CampMinder IDs are the identity layer. PocketBase IDs are implementation details.**
+
+Every record synced from CampMinder has two IDs:
+- **CampMinder ID (`cm_id` or `person_id`)**: Stable identifier from the source system. Used for all cross-table lookups and relationships.
+- **PocketBase ID (`id`)**: Auto-generated 15-character alphanumeric string. Changes if a record is deleted and re-created. Never used for cross-table references in data fields.
+
+## Field Naming Conventions
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `cm_id` | int | The CampMinder ID for this record's primary entity |
+| `person_id` | int | CampMinder person ID (on attendees, bunk_assignments, etc.) |
+| `person` | relation | PocketBase relation field pointing to persons table (resolved from CM ID) |
+| `session` | relation | PocketBase relation field pointing to camp_sessions table |
+| `bunk` | relation | PocketBase relation field pointing to bunks table |
+| `year` | int | Season/year identifier (from `CAMPMINDER_SEASON_ID`) |
+
+**Pattern:** Data fields store CM IDs (`person_id = 12345`). Relation fields store PB IDs (`person = "abc123def456789"`). The relation fields are populated by resolving CM IDs at write time.
+
+## How Relations Are Resolved
+
+The `PopulateRelations()` utility on `BaseSyncService` resolves CM IDs to PB IDs:
+
+```go
+// 1. Store the CM ID as data
+recordData["person_id"] = personCMID
+
+// 2. Define relations to resolve
+relations := []RelationConfig{
+    {FieldName: "session", Collection: "camp_sessions", CMID: sessionCMID, Required: true},
+    {FieldName: "person", Collection: "persons", CMID: personCMID, Required: false},
+}
+
+// 3. PopulateRelations looks up each CM ID in PocketBase and sets the PB ID
+if err := s.PopulateRelations(recordData, relations); err != nil {
+    return fmt.Errorf("populating relations: %w", err)
+}
+// After this, recordData["session"] = "pb_id_of_session"
+// and recordData["person"] = "pb_id_of_person" (if found)
+```
+
+### Required vs Optional Relations
+
+- `Required: true` -- If the CM ID can't be resolved to a PB ID, `PopulateRelations` returns an error. Use for mandatory foreign keys (e.g., every attendee must have a session).
+- `Required: false` -- If the CM ID can't be resolved, the field is silently skipped. Use for optional associations (e.g., a person record that hasn't been synced yet).
+
+## LookupRelation Internals
+
+`LookupRelation(collection, cmID, fieldName)` queries PocketBase:
+```go
+filter := fmt.Sprintf("cm_id = %d", cmID)
+// For year-scoped collections, automatically adds:
+// filter += fmt.Sprintf(" && year = %d", year)
+```
+
+This is why year isolation is critical -- without the year filter, `cm_id = 12345` might match records from multiple years.
+
+## Composite Keys
+
+Some tables have multi-field uniqueness. The composite key format is `{field1}:{field2}`:
+
+```go
+// Attendees: unique by person + session
+key := fmt.Sprintf("%d:%d", personCMID, sessionCMID)
+
+// Bunk assignments: unique by person + bunk + session
+key := fmt.Sprintf("%d:%d:%d", personCMID, bunkCMID, sessionCMID)
+```
+
+For year isolation, the base utilities automatically append `|{year}`:
+```go
+// Internal storage key: "12345:67890|2026"
+s.TrackProcessedCompositeKey(key, year)
+```
+
+## Reverse Lookups
+
+When you have a PB ID and need the CM ID (uncommon, but needed for building composite keys from existing records):
+
+```go
+cmID, found := s.LookupCMIDByPBID("persons", pbID)
+```
+
+For batch reverse lookups:
+```go
+mappings, err := s.BuildRecordCMIDMappings("attendees", filter, map[string]string{
+    "person":  "persons",
+    "session": "camp_sessions",
+})
+// mappings[recordPBID]["personCMID"] = 12345
+// mappings[recordPBID]["sessionCMID"] = 67890
+```
+
+## Common Mistakes
+
+| Mistake | What happens | Fix |
+|---------|-------------|-----|
+| Store PB ID in `person_id` field | Breaks after re-sync (PB IDs change) | Always store CM ID in data fields |
+| Use `person_id` as a PB relation | PocketBase errors (wrong ID format) | Use `person` (relation) for PB joins |
+| Skip `PopulateRelations` | Relation fields empty, PB joins fail | Always call for every relation field |
+| Forget year in `LookupRelation` | Returns wrong-year record | `LookupRelation` auto-adds year for known collections |
+| Hardcode PB IDs in tests | Tests break when PB regenerates IDs | Use CM IDs and resolve in test setup |

--- a/.claude/skills/campminder-sync/reference/sync-order.md
+++ b/.claude/skills/campminder-sync/reference/sync-order.md
@@ -1,0 +1,116 @@
+# Sync Order and Dependency Chain
+
+## Why Order Matters
+
+Sync jobs have data dependencies. A job that reads from a table populated by another job must run after that job. The orchestrator enforces this through **phases** and **job ordering within phases**.
+
+## Phase Execution Order
+
+Phases execute strictly in order: Source -> Expensive -> Transform -> Process -> Export.
+
+### Phase 1: Source (CampMinder API)
+
+These jobs fetch data directly from the CampMinder API and write to PocketBase tables.
+
+```
+session_groups  (no dependencies -- session group definitions)
+    |
+sessions        (reads session_groups for group_id -> PB ID mapping)
+    |
+attendees       (reads camp_sessions for session validation)
+    |
+persons         (reads attendees for person ID list -- only syncs persons who are attendees)
+    |
+bunks           (no strict dependency, but runs after persons by convention)
+    |
+bunk_plans      (reads bunks + camp_sessions for validation)
+    |
+bunk_assignments (reads bunk_plans + bunks + camp_sessions + persons for validation)
+    |
+staff           (no strict dependency on above, but runs late to minimize API calls)
+    |
+financial_transactions (independent, runs last in source phase)
+```
+
+**Key insight:** `persons` depends on `attendees` because it reads the attendees table to build the list of person IDs to fetch from CampMinder. This avoids fetching every person in the CampMinder system -- only those enrolled as attendees.
+
+### Phase 2: Expensive (Custom Values)
+
+These jobs make one API call per entity (person or household). They are expensive and rate-limited, so they only run weekly or on explicit request.
+
+```
+person_custom_values      (reads persons for person ID list)
+    |
+household_custom_values   (reads persons for household ID list)
+```
+
+**Sequential execution required:** These run sequentially (not parallel) to avoid CampMinder API rate limit errors from concurrent requests.
+
+### Phase 3: Transform (PocketBase -> PocketBase)
+
+These jobs read from tables populated by Source and Expensive phases, then write derived/aggregated data to new tables. No external API calls.
+
+```
+camper_history             (reads attendees + persons + camp_sessions)
+family_camp_derived        (reads person_custom_values + household_custom_values)
+staff_skills               (reads person_custom_values)
+financial_aid_applications (reads person_custom_values)
+household_demographics     (reads household_custom_values)
+camper_dietary             (reads person_custom_values)
+camper_transportation      (reads person_custom_values)
+quest_registrations        (reads person_custom_values)
+staff_applications         (reads person_custom_values)
+staff_vehicle_info         (reads person_custom_values)
+normalize_geographic       (reads persons -- normalizes city/state/school data)
+enrollment_snapshots       (reads attendees -- captures point-in-time enrollment counts)
+```
+
+**Important:** Transform jobs use *existing* custom values data during daily syncs. Custom values are only refreshed during weekly or on-demand syncs. This means transform results may be up to 7 days stale for custom-value-derived data.
+
+### Phase 4: Process (CSV + AI)
+
+```
+bunk_requests      (imports CSV files into original_bunk_requests)
+    |
+process_requests   (runs AI pipeline on original_bunk_requests -> bunk_requests)
+```
+
+### Phase 5: Export
+
+```
+multi_workbook_export  (reads all PocketBase tables -> Google Sheets)
+```
+
+## Adding a New Job to the Order
+
+1. **Determine the phase:** Does it call CampMinder API (Source/Expensive), compute from existing PB data (Transform), or process external input (Process)?
+
+2. **Map dependencies:** Which tables does it read from? It must come after the jobs that populate those tables.
+
+3. **Add to `syncJobMeta`** in `orchestrator.go`:
+   ```go
+   var syncJobMeta = []JobMeta{
+       // ... existing jobs ...
+       {"your_job", PhaseTransform, "Description of what it computes"},
+   }
+   ```
+
+4. **Add to `GetDefaultUnifiedSyncJobs()`** in the appropriate position within its phase group.
+
+5. **Register the service** in `InitializeSyncServices()`.
+
+## Sync Schedules
+
+| Schedule | What runs | When |
+|----------|-----------|------|
+| **Hourly** | bunk_assignments only | Every hour (`:00`) |
+| **Daily** | All Source + Transform + Process + Export | 3:00 AM |
+| **Weekly** | All Source + Expensive + Transform + Process + Export | Sunday 2:00 AM |
+
+## Historical Syncs
+
+Historical syncs re-run Source + Transform (optionally Expensive) for a past year. They use a year-override client that changes `GetSeasonID()` to return the historical year.
+
+- All year-scoped jobs are included by default
+- `currentYearOnly: true` in frontend `syncTypes.ts` excludes jobs from historical sync UI
+- The orchestrator creates fresh service instances with the year-override client during historical syncs

--- a/.claude/skills/consolidate-migrations/SKILL.md
+++ b/.claude/skills/consolidate-migrations/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: consolidate-migrations
+description: >
+  Collapse one PocketBase table's migration chain into a single merged
+  CREATE migration. Verifies via empirical 2-DB schema diff. PB v0.23's
+  built-in `migrate history-sync` (auto-invoked on every server boot via
+  the OnServe hook in pocketbase/main.go) self-heals prod's _migrations
+  table — no per-round helper migrations needed. Triggers:
+  "consolidate migrations", "merge migrations for <table>",
+  "consolidate-it", or any similar request to reduce pb_migrations/ noise
+  for one table.
+---
+
+# Consolidate Migrations — One Table At A Time
+
+Collapses every modify-migration touching one PocketBase table into the
+table's original CREATE migration. Empirically verified by spinning up two
+scratch DBs (proposed set + current set) and diffing their `_collections`
+schemas. Each round produces a net REDUCTION in `pb_migrations/` file
+count — no helper migration files added.
+
+## Convention
+
+The tracking doc lives in the project's **main repo**, never in worktrees.
+Always resolve the absolute path before reading or writing:
+
+```bash
+MAIN_REPO=$(dirname "$(git rev-parse --git-common-dir)")
+TRACKING_DOC="$MAIN_REPO/docs/plans/migration-consolidation.md"
+```
+
+`git rev-parse --git-common-dir` returns the canonical `.git` directory
+regardless of whether you're invoked from a worktree (where `.git` is a
+file pointing into the main repo) or the main repo itself. Use
+`$TRACKING_DOC` for **all** Read and Write calls — never a
+worktree-relative path. Worktree copies are stale snapshots; edits there
+are lost on cleanup.
+
+If `$TRACKING_DOC` doesn't exist, the bootstrap PR for this skill should
+have seeded it. Tell the user to run the seed step first; do NOT create
+it from scratch in this skill.
+
+Spec: `docs/superpowers/specs/2026-05-08-migration-consolidation-design.md`.
+
+## Prerequisites
+
+This skill assumes the bootstrap PR has shipped:
+- `scripts/dev/migration-schema-diff.sh` (TDD'd, on `main`)
+- `scripts/dev/verify-consolidation.sh` (orchestrator, on `main`)
+- `pocketbase/main.go` OnServe hook calling `migrate history-sync` (on `main`)
+- `docs/plans/migration-consolidation.md` (the tracking doc, gitignored)
+
+If any are missing, stop and tell the user.
+
+## Step 0: Compress prior-round detail blocks
+
+Before starting a new round, scan per-table sections in the tracking doc.
+For any "[x] DONE" round whose absorbed-file deletions are present in
+`origin/main` (verified via `git log origin/main -- pocketbase/pb_migrations/<filename>` returning a delete commit), compress that round's full
+detail block into a single line under the table's "Rounds (compressed
+history)" log:
+
+```markdown
+- YYYY-MM-DD — round N — absorbed M files (#X, #Y, ...) into base #BBB — verified ✅
+```
+
+Remove the verbose detail block. Detail is recoverable from the
+consolidation PR's git diff. Cross-cutting findings stay in their
+dedicated section regardless.
+
+## Step 1: Read tracking doc
+
+```bash
+cat "$TRACKING_DOC"
+```
+
+Note current backlog statuses, in-progress rounds, auto-gen disposition,
+and cross-cutting findings.
+
+## Step 2: List candidate tables
+
+```bash
+cd "$MAIN_REPO/pocketbase/pb_migrations"
+for f in *.js; do
+  matches=$(grep -oE 'findCollectionByNameOrId\("[^"]+"|new Collection\(\{[^}]*name: "[^"]+"' "$f" | grep -oE '"[a-z_]+"' | sort -u)
+  for tbl in $matches; do echo "$tbl|$f"; done
+done | awk -F'|' '{count[$1]++} END {for (t in count) if (count[t] > 1) print count[t], t}' | sort -rn | head -10
+```
+
+Cross-reference against the tracking doc's backlog. Filter out tables in
+`[x] DONE` status. The user picks one, or you suggest the highest-count
+candidate not yet started.
+
+**Important:** The raw count above includes migrations that merely
+*reference* the table via a relation field. Before locking in a candidate,
+re-tally by inspecting each file: count only files whose mutations
+actually target this table (`fields.add`, `fields.removeByName`,
+`<rule> =`, index changes, data backfills against this table).
+
+## Step 3: Surface auto-generated PB UI migrations
+
+```bash
+ls "$MAIN_REPO/pocketbase/pb_migrations" | awk -F_ '{print $1}' \
+  | awk 'length($1) >= 10 && $1+0 > 1700000000'
+```
+
+For any file printed, check the disposition table in the tracking doc.
+If absent, ask the user:
+- Fold into the merged CREATE (when this table is consolidated)?
+- Leave alone (treat as untouchable)?
+- Investigate later (re-surface next invocation)?
+
+Record the disposition in the tracking doc.
+
+**Default disposition for `*_updated_users.js`:** these files are gitignored
+by existing repo convention (per `.gitignore`). They're per-deployment
+local state from PB's admin UI, not migration code we own. The skill
+should NOT fold them into merged CREATEs and should NOT delete them.
+Each deployment maintains its own. Disposition defaults to "leave alone"
+unless the user overrides explicitly.
+
+## Step 4: User picks the table
+
+Hold for user input. Don't auto-pick. If the user says "you choose,"
+suggest the highest re-tallied count from Step 2.
+
+## Step 5: Walk the chosen table's migration chain
+
+For the chosen table T, enumerate every file that mutates T. For each,
+classify:
+
+| Mutation kind | Detection |
+|---------------|-----------|
+| Field add | `collection.fields.add(new Field(...))` after `findCollectionByNameOrId("T")` |
+| Field remove | `collection.fields.removeByName(...)` |
+| Field property edit | `field.values = ...`, `field.max = ...` etc. on a field of T |
+| Rule change | `collection.<list\|view\|create\|update\|delete>Rule = ...` |
+| Index change | `collection.indexes = [...]`, `addIndex`, `removeIndex` |
+| Data backfill | `app.db().newQuery("UPDATE T ...")` or `INSERT INTO T` |
+| Seed insert | `app.save(record)` against T (typically config-style tables) |
+
+Build an in-memory ordered mutation log. Note any files that touch
+*other* tables too — those are multi-table and will be **trimmed**, not
+deleted.
+
+## Step 6: Build the merged CREATE in memory
+
+Take the original CREATE file as base. Apply mutations in order. Collapse:
+- add field X + later drop X → no field
+- add field X + later change X.max → field with final max
+- add field X + later set X.required → field with final required
+- rule changes → final rule wins
+- index changes → final index set
+- backfills classified as **unreachable** on fresh DB → drop (with note)
+- backfills classified as **reachable** → flag for user confirmation
+- seed inserts (against config-style tables) → fold into merged CREATE's `up()`
+
+Preserve the original collection ID verbatim (e.g., `id: "col_bunk_requests"`).
+Subsequent migrations may reference it.
+
+## Step 7: Empirical schema-diff verification
+
+```bash
+SCRATCH=$(mktemp -d -t pb-consolidate-XXXX)
+trap 'rm -rf "$SCRATCH"' EXIT INT TERM
+
+mkdir -p "$SCRATCH/proposed"
+cp "$MAIN_REPO"/pocketbase/pb_migrations/*.js "$SCRATCH/proposed/"
+
+# 1) Replace base CREATE with the merged version
+# 2) Delete absorbed files from $SCRATCH/proposed/
+# 3) Trim multi-table files (write trimmed versions in-place)
+# (do these steps with Write/Edit tools using the in-memory mutation log)
+
+"$MAIN_REPO/scripts/dev/verify-consolidation.sh" \
+  "$SCRATCH/proposed" \
+  "$MAIN_REPO/pocketbase/pb_migrations"
+```
+
+Exit 0: proceed to Step 8. Exit 1: drift detected. Save the diff output
+to the tracking doc under that table's "Verification failed" section
+(timestamped), abort the round, exit non-zero. The user re-invokes after
+fixing the merged CREATE.
+
+**Override path:** if the user explicitly states "override verification:
+<reason>" in their next prompt, record the rationale in the per-table
+section and proceed despite the diff. Never silent-override.
+
+## Step 8: Write changes to the working tree
+
+Once verification passes, mirror the same operations to the real
+`pb_migrations/` dir (not the scratch dir):
+
+1. Replace the base CREATE migration with the merged version
+2. Delete fully-absorbed migration files (`rm` them — no helper migration
+   needed; the OnServe history-sync hook in `pocketbase/main.go` cleans
+   the orphan `_migrations` rows automatically on next prod boot)
+3. Trim multi-table migration files (write trimmed versions in-place)
+
+## Step 9: Update the tracking doc
+
+Append (or update) the per-table section:
+
+```markdown
+### <table> — [x] DONE <date>
+
+**Rounds (compressed history):**
+- <date> — round N — absorbed M files (#X, #Y, ...) into base #BBB — verified ✅
+```
+
+Add cross-cutting findings if anything novel surfaced (e.g., a
+multi-table migration was trimmed and the remainder is queued for another
+table's future round).
+
+## Step 10: Print summary, hand back
+
+| Field | Value |
+|-------|-------|
+| Table consolidated | T |
+| Round number | N |
+| Files absorbed | M (deleted) + K (trimmed multi-table) |
+| Net migration count delta | -M (no new files) |
+| Verification | ✅ schema match |
+| PR draft message | "refactor(pb): consolidate $TABLE migrations (round N, -M files)" |
+
+Stop. Do NOT auto-commit, do NOT push, do NOT open a PR. The user reviews
+the working-tree changes manually and decides when/how to ship.
+
+After the PR merges to main and prod restarts, the OnServe hook in
+`pocketbase/main.go` automatically calls `migrate history-sync` on first
+boot, removing orphan `_migrations` rows for the absorbed files. Fresh
+deploys see this hook as a no-op.
+
+## Edge cases the skill must handle
+
+See spec §"Edge cases" for full detail. Quick reference:
+
+1. **Multi-table migrations** — trim, don't delete; cross-cutting log entry.
+2. **Data backfills** — drop if unreachable on fresh DB; flag if reachable.
+3. **Built-in collections** (e.g., `_pb_users_auth_`) — merge target is the
+   first migration WE wrote that touches it; merged file uses
+   `findCollectionByNameOrId(...)` not `new Collection(...)`.
+4. **Auto-generated PB UI migrations** — surface for user disposition,
+   never auto-skip.
+5. **Verification failure** — abort with diff written to tracking doc;
+   override only with explicit user statement.
+6. **Hardcoded collection IDs** — preserve verbatim in merged CREATE.
+7. **Indexes** — only the final set in the merged CREATE.

--- a/.claude/skills/grab-feedback/SKILL.md
+++ b/.claude/skills/grab-feedback/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: grab-feedback
+description: >
+  Transfer open issues from a feedback repo to the main project repo, anonymizing
+  PII and converting to conventional commit format. Triggers: "grab feedback",
+  "check feedback", "pull feedback", or similar requests to transfer feedback issues.
+---
+
+# Grab Feedback — Feedback Issue Transfer
+
+Transfers open issues from a `-feedback` companion repo to the main project repo.
+
+## Convention
+
+- **Source repo**: `{owner}/{repo}-feedback` (companion feedback repo)
+- **Target repo**: `{owner}/{repo}` (current project repo)
+
+Detect automatically:
+```bash
+gh repo view --json nameWithOwner --jq '.nameWithOwner'
+# e.g., "adamflagg/kindred" → source is "adamflagg/kindred-feedback"
+```
+
+## Step 1: Fetch open issues from feedback repo
+
+```bash
+gh issue list --repo {owner}/{repo}-feedback --state open --limit 50 --json number,title,body,labels
+```
+
+If none: report "No new feedback" and stop.
+
+## Step 2: Anonymize each issue
+
+Strip the following from the body:
+- `**Reported by:**` line (name + email)
+- `**Environment:**` block (browser UA, viewport, app version)
+- Any organization/company-specific names — replace with `{org_name}` or similar placeholder
+- Any real person names — replace with fictional equivalents
+- Any real session IDs, school names, or other PII
+
+## Step 3: Rewrite title
+
+Convert `[Bug]`/`[Feature Request]` prefix to conventional commit style:
+- `[Bug] Something broke` → `bug(scope): something broke`
+- `[Feature Request] Add X` → `feat(scope): add X`
+
+## Step 4: Present table for approval
+
+Show all issues before creating anything:
+
+| # (feedback) | New Title | Labels | PII Concerns |
+|---|---|---|---|
+
+## Step 5: Wait for approval
+
+Do NOT create issues until the user confirms.
+
+## Step 6: Create in target repo
+
+For each approved issue, create in the target repo with appropriate labels and a `*Source: {repo}-feedback#{N}*` backlink in the body.
+
+## Step 7: Close originals
+
+Close each transferred issue in the feedback repo with a comment: `Transferred to {owner}/{repo}#{N}`

--- a/.claude/skills/pocketbase-migrations/SKILL.md
+++ b/.claude/skills/pocketbase-migrations/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: pocketbase-migrations
+description: Use when creating, modifying, or debugging PocketBase migrations (pb_migrations/*.js), adding/removing collection fields, or changing schema. Triggers on any schema change work.
+---
+
+# PocketBase Migration Skill (v0.23+)
+
+## Workflow
+
+1. **Check the latest migration number**: `ls pocketbase/pb_migrations/ | sort | tail -5` — new files use `1500000NNN_descriptive_name.js` with NNN incremented from the highest existing number.
+2. **Read reference files** below as needed for field syntax and patterns.
+3. **Pick a template** from `templates/` that matches your task. Compose from it — don't generate from scratch.
+4. **Write the migration** with both `up` and `down` functions.
+5. **Run the checklist** in `checklist.md` before committing.
+
+## Reference Files (read on demand)
+
+| File | When to read |
+|------|-------------|
+| `reference/field-types.md` | Need exact property names for a field type |
+| `reference/common-patterns.md` | Creating collections, adding fields, data migrations, rules, indexes |
+| `reference/anti-patterns.md` | Debugging a migration that silently fails or behaves wrong |
+| `checklist.md` | Before committing any migration |
+
+## GOTCHAS — Read These First
+
+These are real failures from this project. Every one caused bugs that were hard to diagnose.
+
+### 1. `options: {}` wrapper is SILENTLY IGNORED (v0.23+)
+The single most dangerous mistake. Properties inside `options: {}` are ignored without error. The field gets PocketBase defaults (e.g., 5000 char limit for text) even though your code looks correct.
+```javascript
+// WRONG — options wrapper silently ignored, field gets 5000 char default
+{ type: "text", name: "notes", options: { min: 0, max: 100000 } }
+
+// CORRECT — direct properties are applied
+{ type: "text", name: "notes", min: 0, max: 100000, pattern: "" }
+```
+
+### 2. `collection.fields.push()` does nothing
+PocketBase fields are not a plain array. You must use the `add()` method with `new Field()`.
+```javascript
+// WRONG — silently does nothing
+collection.fields.push({ type: "text", name: "foo", min: 0, max: 200 })
+
+// CORRECT
+collection.fields.add(new Field({ type: "text", name: "foo", min: 0, max: 200, pattern: "" }))
+```
+
+### 3. `for...of` on fields causes "object is not iterable"
+PocketBase field collections are not JS iterables. Use index-based loops.
+```javascript
+// WRONG — runtime error
+for (const field of collection.fields) { ... }
+
+// CORRECT
+for (let i = 0; i < collection.fields.length; i++) {
+  const field = collection.fields.getByIndex(i);
+}
+```
+
+### 4. `min: 0, max: 0` means different things for text vs number
+For **text** fields, `max: 0` means "unlimited". For **number** fields, `max: 0` means "maximum value of 0" — rejecting all positive numbers. Use `null` for unbounded number fields.
+```javascript
+// Text: max: 0 = unlimited (OK)
+{ type: "text", name: "notes", min: 0, max: 0, pattern: "" }
+
+// Number: max: 0 = BROKEN, rejects positive values
+{ type: "number", name: "count", min: 0, max: 0 }
+
+// Number: null = no limit (CORRECT)
+{ type: "number", name: "count", min: null, max: null }
+```
+
+### 5. `return app.save()` can cause issues
+Just call `app.save(collection)` without `return`.
+
+### 6. Never hardcode collection IDs
+Always use `app.findCollectionByNameOrId("name")`. Hardcoded IDs break on fresh databases.
+
+### 7. Every migration file starts with the types reference
+```javascript
+/// <reference path="../pb_data/types.d.ts" />
+```
+
+### 8. Always write a `down` function
+The second argument to `migrate()` is the reverse migration. For new collections, delete it. For added fields, remove them. For data migrations, reverse the transform.
+
+### 9. PocketBase filter syntax requires spaces around operators
+```javascript
+// WRONG
+col.listRule = '@request.auth.id!=""'
+
+// CORRECT
+col.listRule = '@request.auth.id != ""'
+```

--- a/.claude/skills/pocketbase-migrations/checklist.md
+++ b/.claude/skills/pocketbase-migrations/checklist.md
@@ -1,0 +1,35 @@
+# Migration Pre-Commit Checklist
+
+Run through this before committing any migration file.
+
+## Syntax
+
+- [ ] File starts with `/// <reference path="../pb_data/types.d.ts" />`
+- [ ] **No `options: {}` wrappers** anywhere in the file — all field properties are direct
+- [ ] All `fields.add()` calls use `new Field({...})`, not plain objects
+- [ ] No `fields.push()` — only `fields.add()`
+- [ ] No `for...of` on `collection.fields` — use index-based loops or `getByName()`
+- [ ] No `return app.save()` — just `app.save()`
+- [ ] PocketBase filter rules have spaces around operators (`field = value`, not `field=value`)
+
+## Field Properties
+
+- [ ] Text fields: `min`, `max`, `pattern` are direct properties (not in `options`)
+- [ ] Number fields: unbounded limits use `null`, not `0` (which means "max of zero")
+- [ ] Select fields: `values` and `maxSelect` are direct properties
+- [ ] Relation fields: `collectionId` looked up via `app.findCollectionByNameOrId()`, never hardcoded
+- [ ] JSON fields: `maxSize` is a direct property
+
+## Structure
+
+- [ ] File named `1500000NNN_descriptive_name.js` with NNN sequential from latest existing migration
+- [ ] Down migration (second argument to `migrate()`) reverses all changes
+- [ ] Each collection `app.save()`'d immediately after its changes (not batched across collections)
+- [ ] SQL queries use `.bind()` with named parameters (`{:param}`), never string interpolation
+
+## Verification
+
+- [ ] `cd pocketbase && go build .` passes
+- [ ] Fresh DB test: delete `pb_data/` and verify schema creates correctly from all migrations
+- [ ] If adding/removing a collection: check `scripts/setup/seed_from_prod.py` skip lists
+- [ ] If modifying an enum: verify the migration actually updates values (use `scripts/fix_request_type_enum.py` if needed)

--- a/.claude/skills/pocketbase-migrations/reference/anti-patterns.md
+++ b/.claude/skills/pocketbase-migrations/reference/anti-patterns.md
@@ -1,0 +1,283 @@
+# Anti-Patterns: WRONG vs CORRECT
+
+Real failures from this project. Each "WRONG" example either compiled fine and silently broke, or caused a confusing runtime error.
+
+---
+
+## 1. The `options: {}` Wrapper (Silent Data Truncation)
+
+**Severity: CRITICAL** — No error, no warning. Data silently truncated.
+
+```javascript
+// WRONG — options wrapper is IGNORED in v0.23+
+// Field gets DEFAULT 5000 char limit even though you specified 100000
+{
+  type: "text",
+  name: "value",
+  options: { min: null, max: 100000, pattern: "" }
+}
+
+// CORRECT — properties applied as expected
+{
+  type: "text",
+  name: "value",
+  min: 0,
+  max: 100000,
+  pattern: ""
+}
+```
+
+```javascript
+// WRONG — select values inside options, field gets empty enum
+{
+  type: "select",
+  name: "status",
+  options: { values: ["active", "inactive"], maxSelect: 1 }
+}
+
+// CORRECT
+{
+  type: "select",
+  name: "status",
+  values: ["active", "inactive"],
+  maxSelect: 1
+}
+```
+
+```javascript
+// WRONG — relation config inside options, relation breaks
+{
+  type: "relation",
+  name: "person",
+  options: { collectionId: personsCol.id, maxSelect: 1 }
+}
+
+// CORRECT
+{
+  type: "relation",
+  name: "person",
+  collectionId: personsCol.id,
+  cascadeDelete: false,
+  minSelect: null,
+  maxSelect: 1
+}
+```
+
+**Why it happens**: PocketBase pre-v0.23 used `options: {}`. Many AI models and documentation still show the old syntax. PocketBase v0.23+ silently ignores the `options` key.
+
+---
+
+## 2. `fields.push()` Instead of `fields.add(new Field(...))`
+
+**Severity: HIGH** — Field silently not added.
+
+```javascript
+// WRONG — push does nothing on PocketBase field collections
+collection.fields.push({
+  type: "text",
+  name: "description",
+  min: 0,
+  max: 50000,
+  pattern: ""
+});
+
+// CORRECT — use add() with new Field()
+collection.fields.add(new Field({
+  type: "text",
+  name: "description",
+  min: 0,
+  max: 50000,
+  pattern: ""
+}));
+```
+
+**Why it happens**: PocketBase fields look like an array but are a custom collection type.
+
+---
+
+## 3. `for...of` on Field Collections
+
+**Severity: HIGH** — Runtime error: "object is not iterable"
+
+```javascript
+// WRONG — fields is not a JS iterable
+for (const field of collection.fields) {
+  if (field.name === "target") { ... }
+}
+
+// CORRECT — index-based loop
+for (let i = 0; i < collection.fields.length; i++) {
+  const field = collection.fields.getByIndex(i);
+  if (field.name === "target") { ... }
+}
+
+// ALSO CORRECT — find by name directly
+const field = collection.fields.getByName("target");
+```
+
+---
+
+## 4. Number Field `max: 0` Means "Maximum of Zero"
+
+**Severity: MEDIUM** — All positive values rejected.
+
+```javascript
+// WRONG — rejects any value > 0
+{
+  type: "number",
+  name: "count",
+  min: 0,
+  max: 0,     // means "maximum value is 0"
+  onlyInt: true
+}
+
+// CORRECT — null means no upper bound
+{
+  type: "number",
+  name: "count",
+  min: null,
+  max: null,
+  onlyInt: true
+}
+
+// ALSO CORRECT — explicit bounded range
+{
+  type: "number",
+  name: "year",
+  min: 2010,
+  max: 2100,
+  onlyInt: true
+}
+```
+
+**Contrast with text**: For text fields, `max: 0` means "unlimited length" (safe). The inconsistency is the trap.
+
+---
+
+## 5. `return app.save()`
+
+**Severity: LOW** — May cause subtle issues with migration sequencing.
+
+```javascript
+// AVOID
+migrate((app) => {
+  const col = app.findCollectionByNameOrId("my_collection");
+  col.listRule = '@request.auth.id != ""';
+  return app.save(col);  // unnecessary return
+}, ...);
+
+// CORRECT
+migrate((app) => {
+  const col = app.findCollectionByNameOrId("my_collection");
+  col.listRule = '@request.auth.id != ""';
+  app.save(col);
+}, ...);
+```
+
+---
+
+## 6. Hardcoded Collection IDs
+
+**Severity: HIGH** — Works on your database, breaks on fresh DB or other environments.
+
+```javascript
+// WRONG — ID only exists in your specific database
+{
+  type: "relation",
+  name: "person",
+  collectionId: "abc123xyz",
+  maxSelect: 1
+}
+
+// CORRECT — dynamic lookup
+const personsCol = app.findCollectionByNameOrId("persons");
+// then in the field definition:
+{
+  type: "relation",
+  name: "person",
+  collectionId: personsCol.id,
+  maxSelect: 1
+}
+```
+
+---
+
+## 7. Missing Types Reference Comment
+
+**Severity: LOW** — Lose TypeScript intellisense in editors.
+
+```javascript
+// WRONG — missing reference
+migrate((app) => { ... });
+
+// CORRECT — first line of every migration file
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => { ... });
+```
+
+---
+
+## 8. Missing Down Migration
+
+**Severity: MEDIUM** — Cannot roll back if something goes wrong.
+
+```javascript
+// WRONG — no reverse migration
+migrate((app) => {
+  const col = app.findCollectionByNameOrId("persons");
+  col.fields.add(new Field({ type: "text", name: "nickname", min: 0, max: 100, pattern: "" }));
+  app.save(col);
+});
+
+// CORRECT — includes reverse
+migrate((app) => {
+  const col = app.findCollectionByNameOrId("persons");
+  col.fields.add(new Field({ type: "text", name: "nickname", min: 0, max: 100, pattern: "" }));
+  app.save(col);
+}, (app) => {
+  const col = app.findCollectionByNameOrId("persons");
+  col.fields.removeByName("nickname");
+  app.save(col);
+});
+```
+
+---
+
+## 9. Filter Syntax Without Spaces
+
+**Severity: MEDIUM** — PocketBase silently evaluates the rule incorrectly or rejects it.
+
+```javascript
+// WRONG
+col.listRule = '@request.auth.id!=""'
+
+// CORRECT
+col.listRule = '@request.auth.id != ""'
+```
+
+---
+
+## 10. Forgetting `app.save()` After Multiple Collection Changes
+
+**Severity: HIGH** — Changes to the first collection lost when you modify the second.
+
+```javascript
+// WRONG — first collection's changes may not persist
+const col1 = app.findCollectionByNameOrId("persons");
+col1.fields.add(new Field({ type: "text", name: "foo", min: 0, max: 100, pattern: "" }));
+
+const col2 = app.findCollectionByNameOrId("attendees");
+col2.fields.add(new Field({ type: "text", name: "bar", min: 0, max: 100, pattern: "" }));
+
+app.save(col1);  // Too late? Depends on PB internals.
+app.save(col2);
+
+// CORRECT — save each collection immediately after its changes
+const col1 = app.findCollectionByNameOrId("persons");
+col1.fields.add(new Field({ type: "text", name: "foo", min: 0, max: 100, pattern: "" }));
+app.save(col1);
+
+const col2 = app.findCollectionByNameOrId("attendees");
+col2.fields.add(new Field({ type: "text", name: "bar", min: 0, max: 100, pattern: "" }));
+app.save(col2);
+```

--- a/.claude/skills/pocketbase-migrations/reference/common-patterns.md
+++ b/.claude/skills/pocketbase-migrations/reference/common-patterns.md
@@ -1,0 +1,239 @@
+# Common Migration Patterns
+
+## Pattern 1: Create a New Collection
+
+```javascript
+/// <reference path="../pb_data/types.d.ts" />
+
+migrate((app) => {
+  // Dynamic lookups for relation targets
+  const personsCol = app.findCollectionByNameOrId("persons");
+
+  const collection = new Collection({
+    type: "base",
+    name: "my_collection",
+    listRule: '@request.auth.id != ""',
+    viewRule: '@request.auth.id != ""',
+    createRule: '@request.auth.id != ""',
+    updateRule: '@request.auth.id != ""',
+    deleteRule: '@request.auth.id != ""',
+    fields: [
+      // Fields go here — see field-types.md for each type
+    ],
+    indexes: [
+      "CREATE INDEX `idx_my_collection_year` ON `my_collection` (`year`)",
+      "CREATE UNIQUE INDEX `idx_my_collection_uniq` ON `my_collection` (`field_a`, `field_b`) WHERE `field_a` != ''"
+    ]
+  });
+
+  app.save(collection);
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("my_collection");
+  app.delete(collection);
+});
+```
+
+**Notes:**
+- Collection type is usually `"base"`. Auth collections use `"auth"`.
+- Rules: `null` = admin-only, `""` = public, `'@request.auth.id != ""'` = any authenticated user.
+- Indexes use backtick-quoted names and table/column identifiers.
+- Conditional unique indexes use `WHERE` clause.
+
+## Pattern 2: Add Fields to Existing Collection
+
+```javascript
+/// <reference path="../pb_data/types.d.ts" />
+
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("persons");
+
+  collection.fields.add(new Field({
+    type: "text",
+    name: "address_city",
+    required: false,
+    presentable: false,
+    min: 0,
+    max: 200,
+    pattern: ""
+  }));
+
+  collection.fields.add(new Field({
+    type: "email",
+    name: "primary_email",
+    required: false,
+    presentable: false,
+    exceptDomains: [],
+    onlyDomains: []
+  }));
+
+  app.save(collection);
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("persons");
+  collection.fields.removeByName("address_city");
+  collection.fields.removeByName("primary_email");
+  app.save(collection);
+});
+```
+
+**Notes:**
+- `fields.add()` with matching `name` on an existing field **updates** it (upsert behavior).
+- This is how you change field limits — add the same field with new properties.
+- Remove fields with `collection.fields.removeByName("field_name")`.
+- Call `app.save(collection)` once after all field changes to the same collection.
+
+## Pattern 3: Modify Field Limits
+
+Same as adding a field — `fields.add()` upserts by name. The down function restores original limits.
+
+```javascript
+/// <reference path="../pb_data/types.d.ts" />
+
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("camper_history");
+
+  // synagogue: 200 -> 400
+  collection.fields.add(new Field({
+    type: "text",
+    name: "synagogue",
+    required: false,
+    presentable: false,
+    min: 0,
+    max: 400,
+    pattern: ""
+  }));
+
+  app.save(collection);
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("camper_history");
+
+  // Restore: synagogue: 400 -> 200
+  collection.fields.add(new Field({
+    type: "text",
+    name: "synagogue",
+    required: false,
+    presentable: false,
+    min: 0,
+    max: 200,
+    pattern: ""
+  }));
+
+  app.save(collection);
+});
+```
+
+**Notes:**
+- You can update multiple fields across multiple collections in one migration.
+- Call `app.save()` after each collection's changes (not batched across collections).
+
+## Pattern 4: Raw SQL Data Migration
+
+For transforming existing data without schema changes.
+
+```javascript
+/// <reference path="../pb_data/types.d.ts" />
+
+migrate((app) => {
+  const mappings = {
+    "Old Value": "new_value",
+    "Another Old": "another_new",
+  };
+
+  for (const [oldVal, newVal] of Object.entries(mappings)) {
+    app.db()
+      .newQuery(
+        `UPDATE my_table SET my_field = {:new} WHERE my_field = {:old}`
+      )
+      .bind({ new: newVal, old: oldVal })
+      .execute();
+  }
+}, (app) => {
+  // Reverse the mapping
+  const mappings = {
+    "new_value": "Old Value",
+    "another_new": "Another Old",
+  };
+
+  for (const [oldVal, newVal] of Object.entries(mappings)) {
+    app.db()
+      .newQuery(
+        `UPDATE my_table SET my_field = {:new} WHERE my_field = {:old}`
+      )
+      .bind({ new: newVal, old: oldVal })
+      .execute();
+  }
+});
+```
+
+**Notes:**
+- Use parameterized queries with `.bind()` — never string interpolation.
+- `{:paramName}` is PocketBase's bind syntax (not `?` or `$1`).
+- `Object.entries()` iteration is fine for plain JS objects (unlike PocketBase field collections).
+- For JSON columns, use `REPLACE()` and `LIKE` for pattern matching.
+
+## Pattern 5: Modify Collection Rules (RBAC)
+
+```javascript
+/// <reference path="../pb_data/types.d.ts" />
+
+migrate((app) => {
+  const adminOnly = '@request.auth.is_admin = true';
+  const anyRole = '@request.auth.is_admin = true || @request.auth.cached_permissions ~ "bunking.view"';
+
+  const col = app.findCollectionByNameOrId("bunk_assignments");
+  col.listRule = anyRole;
+  col.viewRule = anyRole;
+  col.createRule = adminOnly;
+  col.updateRule = adminOnly;
+  col.deleteRule = adminOnly;
+  app.save(col);
+}, (app) => {
+  const authed = '@request.auth.id != ""';
+
+  const col = app.findCollectionByNameOrId("bunk_assignments");
+  col.listRule = authed;
+  col.viewRule = authed;
+  col.createRule = authed;
+  col.updateRule = authed;
+  col.deleteRule = authed;
+  app.save(col);
+});
+```
+
+**Notes:**
+- Rules are strings assigned directly to collection properties.
+- The `~` operator checks if a JSON array contains a value.
+- Spaces around operators are required (`=`, `!=`, `~`).
+- `null` rule = superadmin only. `""` = public access. String = evaluated per request.
+
+## Pattern 6: Add Indexes
+
+Indexes are part of the collection and set via the `indexes` array.
+
+```javascript
+/// <reference path="../pb_data/types.d.ts" />
+
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("my_collection");
+
+  // Append to existing indexes
+  collection.indexes.push(
+    "CREATE INDEX `idx_my_collection_year` ON `my_collection` (`year`)"
+  );
+
+  app.save(collection);
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("my_collection");
+
+  // Remove the index by filtering it out
+  collection.indexes = collection.indexes.filter(
+    idx => !idx.includes("idx_my_collection_year")
+  );
+
+  app.save(collection);
+});
+```
+
+**Index types:**
+- `CREATE INDEX` — standard index
+- `CREATE UNIQUE INDEX` — unique constraint
+- `CREATE INDEX ... WHERE condition` — partial/conditional index

--- a/.claude/skills/pocketbase-migrations/reference/field-types.md
+++ b/.claude/skills/pocketbase-migrations/reference/field-types.md
@@ -1,0 +1,163 @@
+# PocketBase v0.23+ Field Type Reference
+
+All properties are **direct** on the field object. Never wrap in `options: {}`.
+
+## Field Types
+
+### text
+```javascript
+{
+  type: "text",
+  name: "field_name",
+  required: false,
+  presentable: false,
+  min: 0,          // minimum length (0 = no minimum)
+  max: 200,        // maximum length (0 = unlimited)
+  pattern: ""      // regex pattern ("" = no pattern)
+}
+```
+
+### number
+```javascript
+{
+  type: "number",
+  name: "field_name",
+  required: false,
+  presentable: false,
+  min: null,       // minimum value (null = no limit) — NOT 0, which means "minimum of 0"
+  max: null,       // maximum value (null = no limit) — NOT 0, which means "maximum of 0"
+  onlyInt: false   // true = integers only
+}
+```
+**Gotcha**: `min: 0, max: 0` on a number field means "value must be exactly 0". Use `null` for unbounded.
+
+### select
+```javascript
+{
+  type: "select",
+  name: "field_name",
+  required: false,
+  presentable: false,
+  values: ["option_a", "option_b", "option_c"],
+  maxSelect: 1     // 1 = single select, >1 = multi-select
+}
+```
+
+### relation
+```javascript
+{
+  type: "relation",
+  name: "field_name",
+  required: false,
+  presentable: false,
+  collectionId: targetCol.id,  // use app.findCollectionByNameOrId("name").id
+  cascadeDelete: false,
+  minSelect: null,
+  maxSelect: 1     // 1 = single relation, null or >1 = multiple
+}
+```
+**Gotcha**: Always look up `collectionId` dynamically. Never hardcode.
+
+### bool
+```javascript
+{
+  type: "bool",
+  name: "field_name",
+  required: false,
+  presentable: false
+}
+```
+
+### json
+```javascript
+{
+  type: "json",
+  name: "field_name",
+  required: false,
+  presentable: false,
+  maxSize: 2000000  // in bytes (0 = use PocketBase default)
+}
+```
+
+### file
+```javascript
+{
+  type: "file",
+  name: "field_name",
+  required: false,
+  presentable: false,
+  maxSelect: 1,
+  maxSize: 5242880,    // 5MB in bytes
+  mimeTypes: [],       // empty = allow all
+  thumbs: []           // thumbnail sizes
+}
+```
+
+### date
+```javascript
+{
+  type: "date",
+  name: "field_name",
+  required: false,
+  presentable: false,
+  min: "",   // ISO date string or "" for no limit
+  max: ""    // ISO date string or "" for no limit
+}
+```
+
+### autodate
+```javascript
+{
+  type: "autodate",
+  name: "created",    // typically "created" or "updated"
+  required: false,
+  presentable: false,
+  onCreate: true,
+  onUpdate: false     // true for "updated" fields
+}
+```
+
+### email
+```javascript
+{
+  type: "email",
+  name: "field_name",
+  required: false,
+  presentable: false,
+  exceptDomains: [],   // blocked domains
+  onlyDomains: []      // allowed domains (empty = all)
+}
+```
+
+### url
+```javascript
+{
+  type: "url",
+  name: "field_name",
+  required: false,
+  presentable: false,
+  exceptDomains: [],
+  onlyDomains: []
+}
+```
+
+### editor
+```javascript
+{
+  type: "editor",
+  name: "field_name",
+  required: false,
+  presentable: false,
+  maxSize: 0,           // 0 = default
+  convertUrls: false
+}
+```
+
+## Common Property Notes
+
+| Property | Applies to | Notes |
+|----------|-----------|-------|
+| `required` | All types | Makes the field mandatory |
+| `presentable` | All types | Shows in relation picker UI |
+| `hidden` | All types | Hides from API responses (admin only) |
+| `system` | All types | Marks as system field (cannot be deleted by user) |

--- a/.claude/skills/pocketbase-migrations/templates/add-fields.js
+++ b/.claude/skills/pocketbase-migrations/templates/add-fields.js
@@ -1,0 +1,36 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: Add {{field_names}} to {{collection_name}}
+ *
+ * {{description}}
+ */
+
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("{{collection_name}}");
+
+  // Add new field (fields.add with matching name upserts existing fields)
+  collection.fields.add(new Field({
+    type: "text",
+    name: "{{field_name}}",
+    required: false,
+    presentable: false,
+    min: 0,
+    max: 200,
+    pattern: ""
+  }));
+
+  // To remove a field instead:
+  // collection.fields.removeByName("old_field");
+
+  app.save(collection);
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("{{collection_name}}");
+
+  // Reverse: remove added fields
+  collection.fields.removeByName("{{field_name}}");
+
+  // Reverse: restore removed fields
+  // collection.fields.add(new Field({ ... original definition ... }));
+
+  app.save(collection);
+});

--- a/.claude/skills/pocketbase-migrations/templates/data-migration.js
+++ b/.claude/skills/pocketbase-migrations/templates/data-migration.js
@@ -1,0 +1,54 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: {{description}}
+ *
+ * Data-only migration — no schema changes.
+ * Transforms existing data using raw SQL.
+ */
+
+migrate((app) => {
+  // Simple update with bind parameters
+  app.db()
+    .newQuery(
+      `UPDATE {{table_name}} SET {{column}} = {:newVal} WHERE {{column}} = {:oldVal}`
+    )
+    .bind({ newVal: "new_value", oldVal: "old_value" })
+    .execute();
+
+  // Batch update with a mapping
+  // const mappings = {
+  //   "Old Value A": "new_a",
+  //   "Old Value B": "new_b",
+  // };
+  //
+  // for (const [oldVal, newVal] of Object.entries(mappings)) {
+  //   app.db()
+  //     .newQuery(
+  //       `UPDATE {{table_name}} SET {{column}} = {:new} WHERE {{column}} = {:old}`
+  //     )
+  //     .bind({ new: newVal, old: oldVal })
+  //     .execute();
+  // }
+
+  // JSON column update (replace within JSON string)
+  // app.db()
+  //   .newQuery(
+  //     `UPDATE {{table_name}}
+  //      SET json_col = REPLACE(json_col, {:oldQuoted}, {:newQuoted})
+  //      WHERE json_col LIKE {:pattern}`
+  //   )
+  //   .bind({
+  //     oldQuoted: '"old_value"',
+  //     newQuoted: '"new_value"',
+  //     pattern: "%old_value%",
+  //   })
+  //   .execute();
+}, (app) => {
+  // Reverse the data transform
+  app.db()
+    .newQuery(
+      `UPDATE {{table_name}} SET {{column}} = {:newVal} WHERE {{column}} = {:oldVal}`
+    )
+    .bind({ newVal: "old_value", oldVal: "new_value" })
+    .execute();
+});

--- a/.claude/skills/pocketbase-migrations/templates/modify-field-limits.js
+++ b/.claude/skills/pocketbase-migrations/templates/modify-field-limits.js
@@ -1,0 +1,40 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: Increase field limits for {{collection_name}}
+ *
+ * {{description}}
+ */
+
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("{{collection_name}}");
+
+  // fields.add() with an existing field name upserts — updates the field definition
+  // {{field_name}}: {{old_limit}} -> {{new_limit}}
+  collection.fields.add(new Field({
+    type: "text",
+    name: "{{field_name}}",
+    required: false,
+    presentable: false,
+    min: 0,
+    max: 10000,   // new limit
+    pattern: ""
+  }));
+
+  app.save(collection);
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("{{collection_name}}");
+
+  // Restore original limit
+  // {{field_name}}: {{new_limit}} -> {{old_limit}}
+  collection.fields.add(new Field({
+    type: "text",
+    name: "{{field_name}}",
+    required: false,
+    presentable: false,
+    min: 0,
+    max: 5000,    // original limit
+    pattern: ""
+  }));
+
+  app.save(collection);
+});

--- a/.claude/skills/pocketbase-migrations/templates/new-collection.js
+++ b/.claude/skills/pocketbase-migrations/templates/new-collection.js
@@ -1,0 +1,78 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: Create {{collection_name}} collection
+ *
+ * {{description}}
+ */
+
+migrate((app) => {
+  // Dynamic lookups for relation targets (if needed)
+  // const personsCol = app.findCollectionByNameOrId("persons");
+
+  const collection = new Collection({
+    type: "base",
+    name: "{{collection_name}}",
+    listRule: '@request.auth.id != ""',
+    viewRule: '@request.auth.id != ""',
+    createRule: '@request.auth.id != ""',
+    updateRule: '@request.auth.id != ""',
+    deleteRule: '@request.auth.id != ""',
+    fields: [
+      // --- Replace with actual fields ---
+      // Text field
+      {
+        type: "text",
+        name: "name",
+        required: true,
+        presentable: true,
+        min: 0,
+        max: 200,
+        pattern: ""
+      },
+      // Number field (use null for unbounded, not 0)
+      {
+        type: "number",
+        name: "year",
+        required: true,
+        presentable: false,
+        min: 2010,
+        max: 2100,
+        onlyInt: true
+      },
+      // Select field
+      {
+        type: "select",
+        name: "status",
+        required: true,
+        presentable: false,
+        values: ["active", "inactive"],
+        maxSelect: 1
+      },
+      // Auto timestamps
+      {
+        type: "autodate",
+        name: "created",
+        required: false,
+        presentable: false,
+        onCreate: true,
+        onUpdate: false
+      },
+      {
+        type: "autodate",
+        name: "updated",
+        required: false,
+        presentable: false,
+        onCreate: true,
+        onUpdate: true
+      }
+    ],
+    indexes: [
+      "CREATE INDEX `idx_{{collection_name}}_year` ON `{{collection_name}}` (`year`)"
+    ]
+  });
+
+  app.save(collection);
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("{{collection_name}}");
+  app.delete(collection);
+});

--- a/.claude/skills/pre-push-verification/SKILL.md
+++ b/.claude/skills/pre-push-verification/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: pre-push-verification
+description: Use before committing, pushing, or claiming implementation is complete. Runs appropriate linters, type checkers, and tests based on which files changed. MUST be invoked before any success claims.
+---
+
+# Pre-Push Verification
+
+**TRIGGER**: Run this skill BEFORE any of these actions:
+- Claiming "done", "complete", "tests pass", or "implementation is finished"
+- Running `git commit` or `git push`
+- Telling the user that changes are ready for review
+
+**NEVER claim success without actually running the commands below and showing their output.**
+
+## Step 1: Detect What Changed
+
+Run the verification script to detect changed file types and execute all relevant checks:
+
+```bash
+bash /path/to/repo/.claude/skills/pre-push-verification/scripts/verify.sh
+```
+
+Or from the repo root:
+
+```bash
+bash .claude/skills/pre-push-verification/scripts/verify.sh
+```
+
+Use `--all` to run every check regardless of what changed:
+
+```bash
+bash .claude/skills/pre-push-verification/scripts/verify.sh --all
+```
+
+## Step 2: If the Script Fails
+
+The script exits non-zero on any failure. When it fails:
+
+1. **Read the output** -- it tells you exactly which check failed
+2. **Fix the issue** -- common fixes listed in the area-specific checklists below
+3. **Re-run the script** -- do not claim success until it passes clean
+
+## Step 3: Area-Specific Checklists
+
+The script handles detection automatically, but if you need to run checks manually or understand what each area requires, consult:
+
+| Changed files match | Checklist |
+|---|---|
+| `**/*.py`, `pyproject.toml`, `ruff.toml` | [Python checks](checklists/python.md) |
+| `pocketbase/**/*.go`, `.golangci.yml` | [Go checks](checklists/go.md) |
+| `frontend/**/*.{ts,tsx,js,jsx,css}` | [Frontend checks](checklists/frontend.md) |
+| `pocketbase/pb_migrations/*.js` | [Migration checks](checklists/migration.md) |
+
+## Gotchas -- Read These
+
+### Format BEFORE lint
+Python: `ruff format` must run before `ruff check`. Formatting changes can introduce or resolve lint errors. The script handles this order automatically.
+
+### mypy uses `--explicit-package-bases`
+The lefthook pre-push hook runs `uv run mypy . --explicit-package-bases`. Always include that flag. Without it, mypy may fail to resolve cross-package imports.
+
+### Frontend lint uses `npm run lint`, not raw eslint
+The `package.json` script (`npm run lint`) includes the correct flags (`--ext ts,tsx --report-unused-disable-directives`). Do not call `npx eslint` directly with different flags.
+
+### Frontend type-check checks TWO tsconfigs
+`npm run type-check` runs `tsc --noEmit && tsc --noEmit -p tsconfig.node.json`. Both must pass. If you only run one, you may miss errors in Vite config files.
+
+### Python tests run only unit tests on push
+The pre-push hook runs `uv run pytest tests/unit/ -v --tb=short`, not the full test suite. Integration tests require a running server and are not part of pre-push.
+
+### Go tests use `-race` flag
+The pre-push hook runs `go test -race ./... -v`. The race detector catches data races that normal tests miss. Do not skip it.
+
+### PocketBase JS files have their own eslint
+Migration and hook JS files are linted separately via `cd pocketbase && npm run lint` (which runs `eslint pb_migrations pb_hooks`). This is separate from the frontend eslint.
+
+### Shell scripts are checked by shellcheck
+Any `.sh` file changes trigger `shellcheck --severity=warning`. Fix warnings before pushing.
+
+### Do not trust "it compiled" as proof of correctness
+A successful `go build` or `tsc --noEmit` only proves type safety. You still need to run tests.
+
+### The pre-push hook runs checks in parallel
+Lefthook runs all pre-push checks simultaneously. A failure in one does not cancel others. The script mirrors this: it runs all relevant checks and reports all failures at the end, not just the first one.

--- a/.claude/skills/pre-push-verification/checklists/frontend.md
+++ b/.claude/skills/pre-push-verification/checklists/frontend.md
@@ -1,0 +1,71 @@
+# Frontend Verification Checklist
+
+All commands run from the `frontend/` directory.
+
+## 1. Format
+
+```bash
+cd frontend && npx prettier --write "src/**/*.{ts,tsx,js,jsx,json,css}"
+```
+
+Auto-fixes formatting. Run before linting.
+
+To check without writing (dry run):
+```bash
+cd frontend && npx prettier --check "src/**/*.{ts,tsx,js,jsx,json,css}"
+```
+
+## 2. Lint
+
+```bash
+cd frontend && npm run lint
+```
+
+This runs `eslint . --ext ts,tsx --report-unused-disable-directives`. Uses the flat config in `eslint.config.js`.
+
+Do NOT run `npx eslint` directly with different flags -- the `npm run lint` script has the correct configuration.
+
+Common lint issues:
+- **react-hooks/exhaustive-deps**: Missing dependencies in useEffect/useMemo/useCallback. Add them or justify with a comment.
+- **react-refresh/only-export-components**: Only export components from files that use HMR. Move non-component exports to separate files.
+- **@typescript-eslint/no-unused-vars**: Remove unused variables or prefix with underscore.
+
+## 3. Type Check
+
+```bash
+cd frontend && npm run type-check
+```
+
+This runs TWO commands: `tsc --noEmit && tsc --noEmit -p tsconfig.node.json`. Both must pass.
+
+- `tsconfig.json`: Covers `src/` (application code)
+- `tsconfig.node.json`: Covers Vite config, test config, and other Node-side files
+
+Common type failures:
+- **`noUncheckedIndexedAccess`**: Array/object index access returns `T | undefined`. Add a null check before using the value.
+- **`exactOptionalPropertyTypes`**: Cannot assign `undefined` to an optional property explicitly. Use `delete obj.prop` or omit the property entirely.
+- **`noPropertyAccessFromIndexSignature`**: Use bracket notation (`obj["key"]`) for index signature access, not dot notation.
+- **`verbatimModuleSyntax`**: Use `import type { X }` for type-only imports, not `import { X }`.
+
+## 4. Tests
+
+```bash
+cd frontend && npx vitest run
+```
+
+Runs all tests once (no watch mode). Uses `vitest` (not Jest).
+
+To run a specific test:
+```bash
+cd frontend && npx vitest run src/path/file.test.ts
+```
+
+## Common Gotchas
+
+- **Vitest, not Jest**: This project uses Vitest. Do not use Jest APIs (`jest.fn()`) -- use Vitest equivalents (`vi.fn()`).
+- **React 19**: The project uses React 19. Be aware of changes to `forwardRef` (no longer needed), `use()` hook, and other React 19 features.
+- **Tailwind CSS v4**: Uses `@tailwindcss/vite` plugin. Class names follow v4 conventions.
+- **Path aliases**: `@/*` maps to `src/*` (configured in `tsconfig.json`). Use `@/components/...` not relative paths from deep nesting.
+- **Query keys**: Use centralized keys from `src/utils/queryKeys.ts`. Do not hardcode query key strings.
+- **ErrorBoundary + Suspense**: Every lazy-loaded route must be wrapped in `<ErrorBoundary>` around `<Suspense>`. Check `App.tsx` when adding new routes.
+- **`npm run type-check` checks two configs**: If you only run `tsc --noEmit`, you miss errors in `tsconfig.node.json` files (Vite config, vitest config, etc.).

--- a/.claude/skills/pre-push-verification/checklists/go.md
+++ b/.claude/skills/pre-push-verification/checklists/go.md
@@ -1,0 +1,53 @@
+# Go Verification Checklist
+
+All commands run from the `pocketbase/` directory.
+
+## 1. Format
+
+```bash
+cd pocketbase && gofmt -w .
+```
+
+Auto-fixes formatting in place. Unlike Python, Go formatting is canonical and non-configurable.
+
+## 2. Build
+
+```bash
+cd pocketbase && go build .
+```
+
+Must pass before any other checks. If this fails, nothing else matters.
+
+Common build failures:
+- **Unused imports**: Remove them (Go treats these as errors, not warnings)
+- **Unused variables**: Remove or use them
+- **Missing dependencies**: Run `go mod tidy`
+
+## 3. Lint
+
+```bash
+cd pocketbase && golangci-lint run --config ../.golangci.yml
+```
+
+The config file is at the repo root (`.golangci.yml`), not in the pocketbase directory. The `--config` flag is required.
+
+Common lint issues:
+- **errcheck**: Unhandled error returns. Wrap with `if err != nil { ... }`
+- **govet**: Suspicious constructs (printf arg mismatches, struct tag issues)
+- **staticcheck**: Bug-prone patterns
+- **misspell**: Note that "cancelled" is allowed (British spelling, configured in `.golangci.yml` extra-words)
+
+## 4. Tests
+
+```bash
+cd pocketbase && go test -race ./... -v
+```
+
+The `-race` flag enables the race detector. This catches data races in concurrent code. Do not skip it.
+
+## Common Gotchas
+
+- **`go mod tidy`**: If you add or remove imports, run `go mod tidy` to update `go.mod` and `go.sum`. Failing to do so will break the build in CI.
+- **"cancelled" spelling**: The project uses British spelling consistently. The golangci-lint config allows it. Do not "fix" it to American spelling.
+- **CGO**: The build may require CGO for SQLite. If `go build` fails with CGO errors, ensure `gcc` is available.
+- **Migration JS files**: Go loads PocketBase migrations from `pb_migrations/*.js`. If you change migrations, `go build` verifies they parse correctly. See the [migration checklist](migration.md) for JS-specific checks.

--- a/.claude/skills/pre-push-verification/checklists/migration.md
+++ b/.claude/skills/pre-push-verification/checklists/migration.md
@@ -1,0 +1,100 @@
+# PocketBase Migration Verification Checklist
+
+Migrations live in `pocketbase/pb_migrations/*.js`.
+
+## 1. Header Check
+
+Every migration file MUST start with the type reference header:
+
+```javascript
+/// <reference path="../pb_data/types.d.ts" />
+```
+
+Without this, the IDE and linter cannot resolve PocketBase types.
+
+## 2. No `options: {}` Wrapper Anti-Pattern
+
+**CRITICAL**: PocketBase v0.23+ changed field property syntax. The old `options: {}` wrapper is SILENTLY IGNORED, causing fields to use default values (e.g., 5000 char max for text fields instead of your specified value).
+
+Search your migration for `options:` or `options :`. If found, it is almost certainly wrong.
+
+Correct pattern -- properties are DIRECT on the field object:
+```javascript
+// CORRECT
+{ type: "text", name: "value", min: 0, max: 100000, pattern: "" }
+
+// WRONG -- options wrapper is IGNORED, field gets 5000 char default
+{ type: "text", name: "value", options: { min: 0, max: 100000 } }
+```
+
+This applies to: text, number, select, relation, json, file, date, url, email, editor fields.
+
+## 3. Dynamic Collection Lookups
+
+Never hardcode collection IDs. Always use:
+```javascript
+const col = app.findCollectionByNameOrId("collection_name")
+// then use col.id for relation fields
+```
+
+Hardcoded IDs break on fresh databases where IDs differ.
+
+## 4. Field Addition Pattern
+
+Use `new Field()` constructor with `fields.add()`:
+```javascript
+collection.fields.add(new Field({
+  type: "text",
+  name: "description",
+  min: 0,
+  max: 50000,
+}));
+```
+
+Do NOT use `collection.fields.push({...})` -- plain objects are not recognized.
+
+## 5. Schema Iteration
+
+Use index-based `for` loops:
+```javascript
+for (let i = 0; i < collection.fields.length; i++) {
+  const field = collection.fields[i];
+}
+```
+
+Do NOT use `for...of` on fields -- causes "object is not iterable" error.
+
+## 6. Build Verification
+
+```bash
+cd pocketbase && go build .
+```
+
+Go loads and parses all migration JS files at build time. If a migration has syntax errors, the build fails.
+
+## 7. JS Lint
+
+```bash
+cd pocketbase && npm run lint
+```
+
+This runs `eslint pb_migrations pb_hooks` with the PocketBase-specific eslint config.
+
+## 8. Number Field Gotcha
+
+For number fields, `min: 0, max: 0` means "maximum value is 0" (rejects all positive numbers). Use `min: null, max: null` for no limits on number fields.
+
+For text fields, `max: 0` means "unlimited". The semantics differ by field type.
+
+## Full Checklist
+
+Before committing any migration:
+
+- [ ] File starts with `/// <reference path="../pb_data/types.d.ts" />`
+- [ ] No `options: {}` wrappers -- all field properties are direct
+- [ ] Collection lookups use `app.findCollectionByNameOrId()`, no hardcoded IDs
+- [ ] Field additions use `new Field()` constructor with `fields.add()`
+- [ ] Schema iteration uses index-based loops, not `for...of`
+- [ ] `cd pocketbase && go build .` passes
+- [ ] `cd pocketbase && npm run lint` passes
+- [ ] Number field min/max use `null` for no limit (not `0`)

--- a/.claude/skills/pre-push-verification/checklists/python.md
+++ b/.claude/skills/pre-push-verification/checklists/python.md
@@ -1,0 +1,61 @@
+# Python Verification Checklist
+
+All commands run from the repository root.
+
+## 1. Format (must run first)
+
+```bash
+uv run ruff format .
+```
+
+This auto-fixes formatting. Run it BEFORE linting because format changes can resolve or introduce lint issues.
+
+**Line length**: 120 chars (configured in `ruff.toml`).
+
+## 2. Lint
+
+```bash
+uv run ruff check --fix .
+```
+
+The `--fix` flag auto-fixes safe issues (unused imports, import sorting, etc.). Review the fixes before committing.
+
+If issues remain after `--fix`, they require manual intervention. Common unfixable issues:
+- `T201` (print statements) -- replace with logger calls using `from bunking.logging_config import get_logger`
+- `S101` (assert in production code) -- use proper error handling instead
+- `N802`/`N803` (naming) -- rename to snake_case
+- `DTZ005` (naive datetime) -- add timezone info
+
+## 3. Type Check
+
+```bash
+uv run mypy . --explicit-package-bases
+```
+
+**Critical flag**: `--explicit-package-bases` is required. Without it, mypy cannot resolve cross-package imports in this project's layout.
+
+Common mypy failures and fixes:
+- **Missing return type**: Add `-> None` or the appropriate type
+- **Incompatible types**: Check if you need `Optional[X]` instead of `X`
+- **Missing stubs**: Third-party packages without stubs are configured in `pyproject.toml` under `[[tool.mypy.overrides]]`. Add new packages there if needed.
+- **`Any` type leaking**: Strict mode disallows untyped defs. Add type annotations.
+
+## 4. Tests
+
+```bash
+uv run pytest tests/unit/ -v --tb=short
+```
+
+This runs only unit tests (matching the pre-push hook). Integration tests require a running PocketBase server and are not part of pre-push verification.
+
+To run a specific test:
+```bash
+uv run pytest tests/unit/path/test_file.py::test_name -v --tb=short
+```
+
+## Common Gotchas
+
+- **Import order matters**: `ruff check --fix` will auto-sort imports, but sometimes this breaks circular imports. If tests fail after auto-fix, check import changes.
+- **Per-file ignores**: Test files (`tests/**/*.py`) and scripts (`scripts/**/*.py`) have relaxed rules (see `ruff.toml` `[lint.per-file-ignores]`). Do not add production code under these paths to avoid weaker linting.
+- **mypy strict mode**: All of `disallow_untyped_defs`, `disallow_untyped_calls`, `disallow_incomplete_defs` are enabled. Test files have relaxed overrides, but production code must be fully typed.
+- **Python version**: mypy targets Python 3.14 (`python_version = "3.14"` in `pyproject.toml`). Do not use features removed in 3.14.

--- a/.claude/skills/pre-push-verification/scripts/verify.sh
+++ b/.claude/skills/pre-push-verification/scripts/verify.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# verify.sh — Detect changed files and run relevant pre-push checks.
+#
+# Usage:
+#   bash verify.sh          # Auto-detect changes, run relevant checks
+#   bash verify.sh --all    # Run all checks regardless of changes
+#
+# Exit codes:
+#   0 — All checks passed
+#   1 — One or more checks failed
+#
+# This script mirrors the lefthook pre-push configuration in .lefthook.yml.
+# It runs checks sequentially within each area but reports ALL failures.
+
+set -euo pipefail
+
+# ── Find repo root ──────────────────────────────────────────────────────
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# ── Color helpers ───────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; }
+skip() { echo -e "  ${YELLOW}SKIP${NC} $1"; }
+header() { echo -e "\n${BLUE}${BOLD}── $1 ──${NC}"; }
+
+# ── Parse args ──────────────────────────────────────────────────────────
+RUN_ALL=false
+if [[ "${1:-}" == "--all" ]]; then
+    RUN_ALL=true
+fi
+
+# ── Detect changed files ───────────────────────────────────────────────
+# Compare against the merge-base with origin/main (or HEAD if no remote)
+if git rev-parse --verify origin/main &>/dev/null; then
+    BASE=$(git merge-base HEAD origin/main 2>/dev/null || echo "HEAD~1")
+else
+    BASE="HEAD~1"
+fi
+
+CHANGED_FILES=$(git diff --name-only "$BASE" HEAD 2>/dev/null || true)
+# Also include staged but uncommitted changes and unstaged modifications
+CHANGED_FILES="$CHANGED_FILES"$'\n'$(git diff --name-only --cached 2>/dev/null || true)
+CHANGED_FILES="$CHANGED_FILES"$'\n'$(git diff --name-only 2>/dev/null || true)
+# Deduplicate
+CHANGED_FILES=$(echo "$CHANGED_FILES" | sort -u | grep -v '^$' || true)
+
+if [[ -z "$CHANGED_FILES" ]] && [[ "$RUN_ALL" == false ]]; then
+    echo -e "${GREEN}No changed files detected. Nothing to verify.${NC}"
+    echo "Use --all to run all checks regardless."
+    exit 0
+fi
+
+# ── Detect areas ────────────────────────────────────────────────────────
+HAS_PYTHON=false
+HAS_GO=false
+HAS_FRONTEND=false
+HAS_MIGRATIONS=false
+HAS_SHELL=false
+HAS_PB_JS=false
+
+if [[ "$RUN_ALL" == true ]]; then
+    HAS_PYTHON=true
+    HAS_GO=true
+    HAS_FRONTEND=true
+    HAS_MIGRATIONS=true
+    HAS_SHELL=true
+    HAS_PB_JS=true
+else
+    while IFS= read -r file; do
+        [[ -z "$file" ]] && continue
+        case "$file" in
+            *.py|pyproject.toml|ruff.toml)
+                HAS_PYTHON=true ;;
+            pocketbase/*.go|pocketbase/**/*.go|.golangci.yml|pocketbase/go.mod|pocketbase/go.sum)
+                HAS_GO=true ;;
+            frontend/src/*.ts|frontend/src/*.tsx|frontend/src/**/*.ts|frontend/src/**/*.tsx|frontend/src/**/*.css|frontend/eslint.config.js|frontend/tsconfig.json|frontend/tsconfig.node.json|frontend/vitest.config.ts)
+                HAS_FRONTEND=true ;;
+            pocketbase/pb_migrations/*.js)
+                HAS_MIGRATIONS=true
+                HAS_PB_JS=true ;;
+            pocketbase/pb_hooks/*.js)
+                HAS_PB_JS=true ;;
+            *.sh)
+                HAS_SHELL=true ;;
+        esac
+    done <<< "$CHANGED_FILES"
+
+    # Broader pattern matching for paths that don't match simple globs
+    if echo "$CHANGED_FILES" | grep -qE '\.py$|pyproject\.toml|ruff\.toml'; then
+        HAS_PYTHON=true
+    fi
+    if echo "$CHANGED_FILES" | grep -qE 'pocketbase/.*\.go$|\.golangci\.yml|pocketbase/go\.(mod|sum)'; then
+        HAS_GO=true
+    fi
+    if echo "$CHANGED_FILES" | grep -qE 'frontend/.*\.(ts|tsx|js|jsx|css)$|frontend/eslint\.config|frontend/tsconfig|frontend/vitest\.config'; then
+        HAS_FRONTEND=true
+    fi
+    if echo "$CHANGED_FILES" | grep -qE 'pocketbase/pb_migrations/.*\.js$'; then
+        HAS_MIGRATIONS=true
+        HAS_PB_JS=true
+    fi
+    if echo "$CHANGED_FILES" | grep -qE 'pocketbase/pb_hooks/.*\.js$'; then
+        HAS_PB_JS=true
+    fi
+    if echo "$CHANGED_FILES" | grep -qE '\.sh$'; then
+        HAS_SHELL=true
+    fi
+fi
+
+# ── Summary of what will run ───────────────────────────────────────────
+echo -e "${BOLD}Pre-push verification${NC}"
+echo -e "Mode: $( [[ "$RUN_ALL" == true ]] && echo '--all (everything)' || echo 'auto-detect' )"
+echo ""
+echo "Areas to check:"
+$HAS_PYTHON     && echo "  - Python (ruff format, ruff check, mypy, pytest)" || true
+$HAS_GO         && echo "  - Go (build, golangci-lint, tests)" || true
+$HAS_FRONTEND   && echo "  - Frontend (prettier, eslint, tsc, vitest)" || true
+$HAS_MIGRATIONS && echo "  - Migrations (header, options anti-pattern, build)" || true
+$HAS_PB_JS      && echo "  - PocketBase JS (eslint)" || true
+$HAS_SHELL      && echo "  - Shell (shellcheck)" || true
+echo ""
+
+# ── Track failures ─────────────────────────────────────────────────────
+FAILURES=()
+
+run_check() {
+    local name="$1"
+    shift
+    if "$@" 2>&1; then
+        pass "$name"
+    else
+        fail "$name"
+        FAILURES+=("$name")
+    fi
+}
+
+# ── Python checks ──────────────────────────────────────────────────────
+if $HAS_PYTHON; then
+    header "Python"
+
+    # Format first (modifies files)
+    run_check "ruff format" uv run ruff format .
+
+    # Lint (with auto-fix for safe issues)
+    run_check "ruff check" uv run ruff check --fix .
+
+    # Type check
+    run_check "mypy" uv run mypy . --explicit-package-bases
+
+    # Unit tests
+    run_check "pytest (unit)" uv run pytest tests/unit/ -v --tb=short
+fi
+
+# ── Go checks ──────────────────────────────────────────────────────────
+if $HAS_GO; then
+    header "Go"
+
+    # Build first
+    run_check "go build" bash -c "cd pocketbase && go build ."
+
+    # Lint
+    if command -v golangci-lint &>/dev/null; then
+        run_check "golangci-lint" bash -c "cd pocketbase && golangci-lint run --config ../.golangci.yml"
+    else
+        skip "golangci-lint (not installed)"
+    fi
+
+    # Tests
+    run_check "go test" bash -c "cd pocketbase && go test -race ./... -v"
+fi
+
+# ── Frontend checks ────────────────────────────────────────────────────
+if $HAS_FRONTEND; then
+    header "Frontend"
+
+    # Format
+    run_check "prettier" bash -c "cd frontend && npx prettier --check 'src/**/*.{ts,tsx,js,jsx,json,css}'"
+
+    # Lint
+    run_check "eslint" bash -c "cd frontend && npm run lint"
+
+    # Type check (both tsconfigs)
+    run_check "tsc type-check" bash -c "cd frontend && npm run type-check"
+
+    # Tests
+    run_check "vitest" bash -c "cd frontend && npx vitest run"
+fi
+
+# ── Migration checks ───────────────────────────────────────────────────
+if $HAS_MIGRATIONS; then
+    header "Migrations"
+
+    # Check for /// <reference path header
+    MIGRATION_HEADER_OK=true
+    while IFS= read -r file; do
+        [[ -z "$file" ]] && continue
+        [[ "$file" != pocketbase/pb_migrations/*.js ]] && continue
+        if ! head -1 "$file" | grep -q '/// <reference path='; then
+            echo "    Missing type reference header: $file"
+            MIGRATION_HEADER_OK=false
+        fi
+    done <<< "$CHANGED_FILES"
+    if $MIGRATION_HEADER_OK; then
+        pass "migration headers"
+    else
+        fail "migration headers"
+        FAILURES+=("migration headers")
+    fi
+
+    # Check for options: {} anti-pattern
+    OPTIONS_OK=true
+    while IFS= read -r file; do
+        [[ -z "$file" ]] && continue
+        [[ "$file" != pocketbase/pb_migrations/*.js ]] && continue
+        if grep -n 'options\s*:' "$file" | grep -v '//.*options' | grep -q .; then
+            echo "    Found 'options:' wrapper (v0.23+ anti-pattern): $file"
+            grep -n 'options\s*:' "$file" | grep -v '//.*options' | head -5 | while read -r line; do
+                echo "      $line"
+            done
+            OPTIONS_OK=false
+        fi
+    done <<< "$CHANGED_FILES"
+    if $OPTIONS_OK; then
+        pass "no options:{} anti-pattern"
+    else
+        fail "no options:{} anti-pattern"
+        FAILURES+=("options:{} anti-pattern found")
+    fi
+
+    # Go build covers migration parsing
+    if ! $HAS_GO; then
+        run_check "go build (migrations)" bash -c "cd pocketbase && go build ."
+    fi
+fi
+
+# ── PocketBase JS lint ─────────────────────────────────────────────────
+if $HAS_PB_JS; then
+    header "PocketBase JS"
+    run_check "pb-js-lint" bash -c "cd pocketbase && npm run lint"
+fi
+
+# ── Shell checks ───────────────────────────────────────────────────────
+if $HAS_SHELL; then
+    header "Shell"
+    if command -v shellcheck &>/dev/null; then
+        run_check "shellcheck" bash -c "find scripts/ docker/ frontend/ tests/shell/ -maxdepth 3 -name '*.sh' 2>/dev/null | xargs shellcheck --severity=warning"
+    else
+        skip "shellcheck (not installed)"
+    fi
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────
+echo ""
+echo -e "${BOLD}═══════════════════════════════════════${NC}"
+if [[ ${#FAILURES[@]} -eq 0 ]]; then
+    echo -e "${GREEN}${BOLD}ALL CHECKS PASSED${NC}"
+    echo -e "${BOLD}═══════════════════════════════════════${NC}"
+    exit 0
+else
+    echo -e "${RED}${BOLD}${#FAILURES[@]} CHECK(S) FAILED:${NC}"
+    for f in "${FAILURES[@]}"; do
+        echo -e "  ${RED}- $f${NC}"
+    done
+    echo -e "${BOLD}═══════════════════════════════════════${NC}"
+    exit 1
+fi

--- a/.claude/skills/solver-config-it/SKILL.md
+++ b/.claude/skills/solver-config-it/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: solver-config-it
+description: >
+  Resume the solver/admin config cleanup. Walk one constraint domain at a time
+  across all four surfaces (CONFIG_SCHEMA, seed migration, GUI, code reads),
+  propose KEEP/HARDCODE/DELETE/FIX decisions, hold for user gut-check before
+  any Phase 2 PR. Triggers: "solver config it", "config-it", "config decisions",
+  "next config domain", or similar requests to advance the cleanup.
+---
+
+# Solver Config It — Phase 1.5 Domain Walks
+
+Advances the multi-phase solver/admin config cleanup. The decisions doc is the source of truth across conversations; this skill is the repeatable workflow.
+
+## Convention
+
+The decisions doc lives in the project's **main repo**, never in worktrees. Always resolve the absolute path before reading or writing:
+
+```bash
+MAIN_REPO=$(dirname "$(git rev-parse --git-common-dir)")
+DECISIONS_DOC="$MAIN_REPO/docs/reference/solver-config-decisions.md"
+```
+
+`git rev-parse --git-common-dir` returns the canonical `.git` directory regardless of whether you're invoked from a worktree or the main repo. Use `$DECISIONS_DOC` for **all** Read and Write calls — never a worktree-relative path. Worktree copies, if any exist, are stale snapshots; edits there are lost on cleanup.
+
+Companion to `docs/reference/issue-triage.md` (resolved the same way). Both are reference-tier working docs that survive across conversations.
+
+If `$DECISIONS_DOC` doesn't exist, do NOT create it. Tell the user: this skill is for resuming an in-flight cleanup; the doc should already exist with prior context. Stop.
+
+## Step 1: Read state, top to bottom
+
+Read the entire `docs/reference/solver-config-decisions.md`. The "For fresh agents" header at the top has the orientation. Then read the spec/plan it points at:
+
+- Spec: `docs/superpowers/specs/2026-05-07-solver-config-cleanup-design.md`
+- Plan: `docs/superpowers/plans/2026-05-07-solver-config-cleanup.md`
+
+Note which domain checkboxes are `[ ]`, which are `✅`. Find any "Status: in progress" markers on individual domain sections.
+
+## Step 2: Pick the domain
+
+Backlog states:
+- `[ ]` — not yet walked.
+- `[⏳]` — surface walk done, decisions proposed, awaiting user green-light. Resume.
+- `[⏸]` — **TABLED.** Surface walk may be done, but user has explicitly deferred until upstream PRs ship or some other condition. **Skip.** Don't re-walk, don't re-prompt for green-light. The user picks the unblock moment, not you.
+- `[x]` / `✅` — decisions locked in (or PR shipped). Don't reopen.
+
+Default order:
+1. If user named a domain, use that — even if tabled. ("Take another look at Grade Ratio" is an explicit unblock.)
+2. Else if any domain is `[⏳]` (decisions proposed, no green-light), resume that one — re-state the proposed decisions and hold for the user.
+3. Else pick the first `[ ]` from the backlog, **skipping any `[⏸]` entries**. If you skipped tabled domains to reach the chosen one, mention this in your opening line so the user knows you saw them and respected the deferral.
+
+When the user tables a domain (e.g., "let's circle back after the other PRs ship"), update the doc:
+- Backlog line: change marker to `[⏸]`, append a brief "TABLED — revisit when [condition]" note explaining what unblocks it.
+- Domain section: change `**Status:**` to `⏸ **TABLED [date].** [reason]. Skip when picking the next domain.`
+- Preserve the surface walk and decision leans intact — the work isn't wrong, just deferred.
+
+## Step 3: Walk all four surfaces for the chosen domain
+
+For the chosen domain, lay out:
+
+1. **CONFIG_SCHEMA** entries in `bunking/config/schema.py` — keys, types, ranges, required flags.
+2. **Seed migration** entries — every key seeded in `pocketbase/pb_migrations/1500000011_config.js` (the main migration) plus any later fixup migrations that touch this domain. Capture seeded values, FRIENDLY_NAMES, TOOLTIPS, SECTION_MAPPING bucket.
+3. **GUI** — section header in `1500000012_config_sections.js`, which `/admin/config/*` page renders it, any frontend live reads via `useSolverConfigValue` or direct `pb.collection('config')` reads.
+4. **Code paths (Python)** — every `get_int`/`get_float`/`get_bool`/`get_str`/`get_constraint`/`get_soft_constraint_weight` consumer in `bunking/` and `api/`. Note `default=` kwarg drift, phantom keys not in schema, dead-row queries that look up nonexistent rows.
+
+Use the existing **Cabin Capacity** section in the decisions doc as the depth template — that's the canonical surface breakdown shape.
+
+## Step 4: Propose per-key decisions
+
+For every key in the domain, propose one of:
+
+- **KEEP** — stays in admin GUI as a tunable knob; user actually tunes it at runtime.
+- **HARDCODE** — move to a constants module; user can change via code PR.
+- **DELETE** — orphan; no consumer; remove from schema/seed/GUI entirely.
+- **FIX** — has a real bug (phantom key, wrong default, wrong query) that needs a code change before keep/hardcode/delete can apply.
+
+User strongly prefers HARDCODE over KEEP for anything they don't actually tune at runtime. Defer to the user when in doubt — they're the sole admin-config user and know which knobs they touch.
+
+If multiple keys interact (e.g., a `mode` flag that gates a code path consuming a `penalty` key), propose decisions as a coherent group, not key-by-key.
+
+## Step 5: Capture in the doc
+
+Update the domain's section in `docs/reference/solver-config-decisions.md`:
+
+- Surface breakdown (1 through 4).
+- Per-key decisions with rationale.
+- Required FIXes that must precede the keep/hardcode/delete actions.
+- Open questions for the user.
+- "Status: decisions proposed, awaiting user green-light before Phase 2 PR" until user approves.
+
+Also update the "Cross-cutting findings" section if the domain surfaced anything that applies to other domains (e.g., another phantom key, another dead-row query, another section-drift case).
+
+## Step 6: Hold for feedback
+
+The full surface walk lives in the doc. **Do not paste it into chat.** The user has the doc open if they want depth. Chat is for the gut-check: name the domain, frame the asks, surface what's surprising, list the open questions. Nothing more.
+
+Structure the chat presentation in this order:
+
+1. **Domain header** — one line: which domain you walked, where it lives in the doc (`### <Domain> in solver-config-decisions.md`). The user can't tell from your tool calls; they need to know which slice you analyzed.
+2. **One-sentence framing per key** — what each key actually controls in the system, in plain English. The user is the sole admin-config user but won't remember every knob's runtime role from a key name. One short clause is enough — "max % of cabin from one grade", "bonus weight for matching target grade per bunk", etc.
+3. **Tuning evidence summary** — one line per key on whether it's been touched (logs, git, GUI). "No tuning evidence" or "fired 3/6 May 2026 runs at seeded value" or "confirmed orphan, zero consumers". This is what drives HARDCODE vs KEEP.
+4. **In reality today** — 2-4 bullets translating each surface into staff-visible behavior at current values. Solver: what does the cost path actually push toward, and how does this domain's penalty/bonus weight stack against the others (must_satisfy_one=100k is the reference)? Validator/board: do `_validate_*` methods emit user-visible ValidationIssue WARNINGs, and does that path read these keys or run independently? Frontend: any live reads, or display-only? What's already dead — phantom-controlled bonus paths, stub functions, soft paths gated off by a flipped toggle? This is the lens that turns "is value X tuned?" into "would changing X be visible to anyone?", which is what makes HARDCODE-vs-KEEP an actionable call rather than a static-analysis exercise. Skip bullets that are obvious or shared with another domain you've already presented.
+5. **Surprises and gotchas** — anything that broke your assumptions or might break the user's. Phantom keys, parallel hardcodes, orphan-from-initial-commit findings, B-class drift surfaces, conceptually-different validator algorithms. Two to four bullets max.
+6. **Decision table** — keys × leaning decision × one-clause rationale. Mark leans clearly (HARDCODE *(open)*) when the call is genuinely the user's.
+
+   | Key | Lean | Rationale |
+   |---|---|---|
+
+7. **Open questions** — numbered, each with enough framing that the user can answer without re-reading anything. Two phrasings to avoid: "thoughts?" (too open) and "should I X or Y?" with no context (too closed). The right shape: "X is the seeded behavior; Y would require Z. Pattern-match says X, but you might want Y because [edge case]. Your call."
+
+Length budget: the whole presentation should fit on one screen. If you're past 40 lines, you're dumping the doc. Cut.
+
+**Do NOT start implementing the Phase 2 PR.** Wait for the user to:
+- Answer open questions.
+- Green-light the per-key decisions (or amend them).
+- Tell you to proceed with implementation.
+
+After green-light, mark the domain `✅` in the backlog with a brief note on what shipped, and stop. The user picks the next domain.
+
+## Hard rules
+
+- **One domain at a time.** Don't conflate. Don't propose Phase 2 PRs that span multiple domains unless the user explicitly asks.
+- **Don't run ahead.** No PR drafting before user green-light. No "while I'm at it" cleanups in adjacent domains.
+- **Don't propose Phase 3 (storage split) work.** Out of scope.
+- **Don't reopen Phase 1 (PRs #1212-#1215) decisions.** Those shipped; reference them, don't relitigate.
+- **Workstream 5 (manifest pattern) stays deferred** until after Phase 2 — sections will collapse during the hardcoding sweep.
+- **Workstream 6 (runtime metadata backfill)** is a small standalone PR available anytime; user has held it for now. Don't ship without explicit ask.

--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ pocketbase/pb_migrations/*_updated_users.js
 !pocketbase/go.mod
 !pocketbase/go.sum
 !pocketbase/main.go
+!pocketbase/main_*_test.go
 !pocketbase/sync/
 !pocketbase/logging/
 !pocketbase/campminder/

--- a/.gitignore
+++ b/.gitignore
@@ -169,7 +169,9 @@ coverage.xml
 *.pkl
 *.cache
 .playwright-mcp/
-.claude/
+.claude/*
+!.claude/skills/
+!.claude/skills/**
 .superpowers
 docs/superpowers/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,6 +258,20 @@ CampMinder reuses session IDs across years. Year field prevents data contaminati
 
 > **MANDATORY:** Read `docs/reference/pocketbase-migrations.md` before writing ANY migration. PocketBase v0.23+ changed field property syntax — using old `options: {}` wrapper pattern causes silent data truncation.
 
+## PocketBase Migration Numbering Rule
+
+New migrations MUST use a number greater than the highest filename in `pocketbase/pb_migrations/` on `origin/main`. Do not fill numbering gaps left by past consolidations.
+
+```bash
+HIGHEST=$(git ls-tree -r origin/main pocketbase/pb_migrations/ \
+  | awk '{print $4}' | grep -oE '15000[0-9]{5}' | sort -u | tail -1)
+NEXT=$((HIGHEST + 1))
+```
+
+Within an unmerged PR you may iterate, rename, or renumber your own new migrations freely — reset the dev DB to re-apply if you change a filename or content. Once merged to `main`, the file is frozen; if a competing PR landed on `main` first and took your number, bump above the new HEAD.
+
+History: gaps may exist from migration consolidation runs (skill: `consolidate-migrations`, gitignored tracking doc: `docs/plans/migration-consolidation.md`). Those numbers are NOT free for reuse — they're "burned" to preserve a monotonically increasing record. The OnServe history-sync hook in `pocketbase/main.go` keeps prod's `_migrations` table in sync with the on-disk file list automatically on every server boot.
+
 ## 🚨 CRITICAL: Worktree and Branch Rules
 
 **These rules are NON-NEGOTIABLE. Violating them can corrupt work from parallel agents.**

--- a/docs/reference/pocketbase-migrations.md
+++ b/docs/reference/pocketbase-migrations.md
@@ -183,3 +183,16 @@ Before committing any migration:
 **Enum update workaround**: If migration applies but enum values unchanged, use `scripts/fix_request_type_enum.py` to update schema JSON directly.
 
 **Schema iteration**: Use index-based `for` loops, NOT `for...of` (causes "object is not iterable").
+
+## Migration Consolidation
+
+When `pb_migrations/` accumulates many modify-migrations for the same table, run the `consolidate-migrations` skill (machine-local at `~/.claude/skills/consolidate-migrations/`) to fold them into the table's original CREATE migration. Each round is empirically verified by spinning up two scratch DBs (one with the proposed merged set, one with the current set) and diffing their `_collections` schemas — the merge is rejected if it would change the table's shape.
+
+Skill artifacts:
+- Tracking doc (gitignored): `docs/plans/migration-consolidation.md` — backlog, per-round history, multi-table cross-cutting findings
+- Verification harness: `scripts/dev/verify-consolidation.sh` (orchestrator), `scripts/dev/migration-schema-diff.sh` (canonical schema dump + diff)
+- Spec: `docs/superpowers/specs/2026-05-08-migration-consolidation-design.md`
+
+Cleanup mechanism: PB v0.23 has a built-in `migrate history-sync` subcommand (`RemoveMissingAppliedMigrations` in `core/migrations_runner.go`) that DELETEs every `_migrations` row whose file is no longer on disk. `pocketbase/main.go` registers an `OnServe` hook that calls this on every server boot, so prod's `_migrations` self-heals after each consolidation merge. Idempotent — no-op on clean DBs.
+
+Numbering: gaps may appear in `pb_migrations/` numbering after consolidation. Per CLAUDE.md "PocketBase Migration Numbering Rule", new migrations must use a number greater than the highest existing filename on `origin/main` — never fill consolidation gaps.

--- a/docs/reference/pocketbase-migrations.md
+++ b/docs/reference/pocketbase-migrations.md
@@ -186,7 +186,7 @@ Before committing any migration:
 
 ## Migration Consolidation
 
-When `pb_migrations/` accumulates many modify-migrations for the same table, run the `consolidate-migrations` skill (machine-local at `~/.claude/skills/consolidate-migrations/`) to fold them into the table's original CREATE migration. Each round is empirically verified by spinning up two scratch DBs (one with the proposed merged set, one with the current set) and diffing their `_collections` schemas — the merge is rejected if it would change the table's shape.
+When `pb_migrations/` accumulates many modify-migrations for the same table, run the `consolidate-migrations` skill (tracked in this repo at `.claude/skills/consolidate-migrations/`) to fold them into the table's original CREATE migration. Each round is empirically verified by spinning up two scratch DBs (one with the proposed merged set, one with the current set) and diffing their `_collections` schemas — the merge is rejected if it would change the table's shape.
 
 Skill artifacts:
 - Tracking doc (gitignored): `docs/plans/migration-consolidation.md` — backlog, per-round history, multi-table cross-cutting findings

--- a/pocketbase/main.go
+++ b/pocketbase/main.go
@@ -130,11 +130,9 @@ func main() {
 	// `migrate history-sync` (RemoveMissingAppliedMigrations) deletes rows
 	// for files no longer present. Idempotent — no-op on clean DBs. Used by
 	// the consolidate-migrations skill to self-heal prod's migration history
-	// after consolidation merges drop intermediate migration files. See
-	// docs/superpowers/specs/2026-05-08-migration-consolidation-design.md.
+	// after consolidation merges drop intermediate migration files.
 	app.OnServe().BindFunc(func(e *core.ServeEvent) error {
-		runner := core.NewMigrationsRunner(e.App, core.AppMigrations)
-		if err := runner.Run("history-sync"); err != nil {
+		if err := runHistorySync(e.App); err != nil {
 			slog.Warn("history-sync hook failed", "err", err)
 		}
 		return e.Next()
@@ -203,6 +201,26 @@ func main() {
 		slog.Error("Failed to start application", "error", err)
 		os.Exit(1)
 	}
+}
+
+// runHistorySync removes _migrations rows whose files no longer exist on disk
+// (registered in core.SystemMigrations or core.AppMigrations). Mirrors PB's
+// own BaseApp.RunAllMigrations list construction so we don't accidentally
+// delete rows for PB's built-in system migrations (e.g. 1640988000_init.go),
+// which would cause the next boot to re-apply them and fail with
+// "_params exec error: table _params already exists". After a successful
+// sync, flushes the WAL so the change persists across docker stop/start.
+func runHistorySync(app core.App) error {
+	list := core.MigrationsList{}
+	list.Copy(core.SystemMigrations)
+	list.Copy(core.AppMigrations)
+	if err := core.NewMigrationsRunner(app, list).Run("history-sync"); err != nil {
+		return fmt.Errorf("history-sync: %w", err)
+	}
+	if _, err := app.DB().NewQuery("PRAGMA wal_checkpoint(TRUNCATE)").Execute(); err != nil {
+		slog.Warn("history-sync WAL checkpoint failed", "err", err)
+	}
+	return nil
 }
 
 // the default pb_public dir location is relative to the executable

--- a/pocketbase/main.go
+++ b/pocketbase/main.go
@@ -218,7 +218,7 @@ func runHistorySync(app core.App) error {
 		return fmt.Errorf("history-sync: %w", err)
 	}
 	if _, err := app.DB().NewQuery("PRAGMA wal_checkpoint(TRUNCATE)").Execute(); err != nil {
-		slog.Warn("history-sync WAL checkpoint failed", "err", err)
+		return fmt.Errorf("history-sync WAL checkpoint failed: %w", err)
 	}
 	return nil
 }

--- a/pocketbase/main.go
+++ b/pocketbase/main.go
@@ -125,6 +125,21 @@ func main() {
 		Dir:          migrationsDir,
 	})
 
+	// History-sync hook: keep prod's _migrations table in sync with the
+	// on-disk migration file list on every server boot. PB's built-in
+	// `migrate history-sync` (RemoveMissingAppliedMigrations) deletes rows
+	// for files no longer present. Idempotent — no-op on clean DBs. Used by
+	// the consolidate-migrations skill to self-heal prod's migration history
+	// after consolidation merges drop intermediate migration files. See
+	// docs/superpowers/specs/2026-05-08-migration-consolidation-design.md.
+	app.OnServe().BindFunc(func(e *core.ServeEvent) error {
+		runner := core.NewMigrationsRunner(e.App, core.AppMigrations)
+		if err := runner.Run("history-sync"); err != nil {
+			slog.Warn("history-sync hook failed", "err", err)
+		}
+		return e.Next()
+	})
+
 	// Config initialization now handled by migrations
 
 	// ---------------------------------------------------------------

--- a/pocketbase/main_history_sync_test.go
+++ b/pocketbase/main_history_sync_test.go
@@ -3,32 +3,44 @@ package main
 import (
 	"testing"
 
-	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/tests"
 )
 
-// TestHistorySyncRemovesOrphanRows verifies that running migrate history-sync
-// (the operation invoked by the OnServe hook in main.go) removes _migrations
-// rows whose files are not present in the runner's migrations list.
+// TestHistorySyncRemovesOrphansButPreservesValidRows verifies that
+// runHistorySync removes _migrations rows whose files no longer exist on
+// disk while LEAVING rows for legitimate migrations alone — including
+// system migrations registered to core.SystemMigrations (e.g.
+// 1640988000_init.go), which are baked into the PocketBase binary and not
+// part of core.AppMigrations.
 //
-// This validates the API call that the OnServe hook uses. The hook itself is
-// pure plumbing that calls the same runner.Run("history-sync") at server boot.
-func TestHistorySyncRemovesOrphanRows(t *testing.T) {
+// Regression guard: an earlier version constructed the runner with only
+// core.AppMigrations, so RemoveMissingAppliedMigrations deleted every
+// _migrations row whose filename wasn't a JS migration — including PB's
+// own system migrations — causing subsequent boots to re-apply them and
+// fail with "_params exec error: table _params already exists".
+func TestHistorySyncRemovesOrphansButPreservesValidRows(t *testing.T) {
 	app, err := tests.NewTestApp()
 	if err != nil {
 		t.Fatalf("NewTestApp: %v", err)
 	}
 	defer app.Cleanup()
 
-	// Ensure the _migrations table exists. NewTestApp may have already created
-	// it via PB's internal init; CREATE TABLE IF NOT EXISTS is idempotent.
 	if _, err := app.DB().NewQuery(
 		"CREATE TABLE IF NOT EXISTS _migrations (file VARCHAR(255) PRIMARY KEY NOT NULL, applied INTEGER NOT NULL)",
 	).Execute(); err != nil {
 		t.Fatalf("ensure _migrations table: %v", err)
 	}
 
-	// Seed an orphan row for a file that doesn't exist in core.AppMigrations.
+	// Seed a system migration row. This filename is registered in
+	// core.SystemMigrations (PB internals) and MUST survive history-sync.
+	const systemFile = "1640988000_init.go"
+	if _, err := app.DB().NewQuery(
+		"INSERT OR REPLACE INTO _migrations (file, applied) VALUES ({:file}, 1)",
+	).Bind(map[string]any{"file": systemFile}).Execute(); err != nil {
+		t.Fatalf("seed system migration row: %v", err)
+	}
+
+	// Seed an orphan row that shouldn't exist in either migration list.
 	const orphanFile = "1500000999_test_orphan_should_be_removed.js"
 	if _, err := app.DB().NewQuery(
 		"INSERT OR REPLACE INTO _migrations (file, applied) VALUES ({:file}, 1)",
@@ -36,36 +48,46 @@ func TestHistorySyncRemovesOrphanRows(t *testing.T) {
 		t.Fatalf("seed orphan row: %v", err)
 	}
 
-	// Sanity: orphan present before sync.
-	var beforeCount int
+	if err := runHistorySync(app); err != nil {
+		t.Fatalf("runHistorySync: %v", err)
+	}
+
+	// Orphan row removed.
+	var orphanCount int
 	if err := app.DB().NewQuery(
 		"SELECT COUNT(*) FROM _migrations WHERE file = {:file}",
-	).Bind(map[string]any{"file": orphanFile}).Row(&beforeCount); err != nil {
-		t.Fatalf("count before: %v", err)
+	).Bind(map[string]any{"file": orphanFile}).Row(&orphanCount); err != nil {
+		t.Fatalf("count orphan after sync: %v", err)
 	}
-	if beforeCount != 1 {
-		t.Fatalf("expected orphan row present before sync, got count=%d", beforeCount)
-	}
-
-	// Run history-sync — the same call the OnServe hook makes.
-	runner := core.NewMigrationsRunner(app, core.AppMigrations)
-	if err := runner.Run("history-sync"); err != nil {
-		t.Fatalf("run history-sync: %v", err)
+	if orphanCount != 0 {
+		t.Fatalf("expected orphan row removed, got count=%d", orphanCount)
 	}
 
-	// Orphan should be gone.
-	var afterCount int
+	// System migration row preserved.
+	var systemCount int
 	if err := app.DB().NewQuery(
 		"SELECT COUNT(*) FROM _migrations WHERE file = {:file}",
-	).Bind(map[string]any{"file": orphanFile}).Row(&afterCount); err != nil {
-		t.Fatalf("count after: %v", err)
+	).Bind(map[string]any{"file": systemFile}).Row(&systemCount); err != nil {
+		t.Fatalf("count system migration after sync: %v", err)
 	}
-	if afterCount != 0 {
-		t.Fatalf("expected orphan row removed after sync, got count=%d", afterCount)
+	if systemCount != 1 {
+		t.Fatalf(
+			"expected system migration row %q preserved, got count=%d "+
+				"(deleted by history-sync — would break next boot)",
+			systemFile, systemCount,
+		)
 	}
 
-	// Idempotency: running again with no orphans is a no-op (no error).
-	if err := runner.Run("history-sync"); err != nil {
-		t.Fatalf("run history-sync second time: %v", err)
+	// Idempotency: a second invocation with a clean slate is a no-op.
+	if err := runHistorySync(app); err != nil {
+		t.Fatalf("runHistorySync second time: %v", err)
+	}
+	if err := app.DB().NewQuery(
+		"SELECT COUNT(*) FROM _migrations WHERE file = {:file}",
+	).Bind(map[string]any{"file": systemFile}).Row(&systemCount); err != nil {
+		t.Fatalf("count system migration after second sync: %v", err)
+	}
+	if systemCount != 1 {
+		t.Fatalf("expected system migration row preserved on second run, got count=%d", systemCount)
 	}
 }

--- a/pocketbase/main_history_sync_test.go
+++ b/pocketbase/main_history_sync_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+)
+
+// TestHistorySyncRemovesOrphanRows verifies that running migrate history-sync
+// (the operation invoked by the OnServe hook in main.go) removes _migrations
+// rows whose files are not present in the runner's migrations list.
+//
+// This validates the API call that the OnServe hook uses. The hook itself is
+// pure plumbing that calls the same runner.Run("history-sync") at server boot.
+func TestHistorySyncRemovesOrphanRows(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	defer app.Cleanup()
+
+	// Ensure the _migrations table exists. NewTestApp may have already created
+	// it via PB's internal init; CREATE TABLE IF NOT EXISTS is idempotent.
+	if _, err := app.DB().NewQuery(
+		"CREATE TABLE IF NOT EXISTS _migrations (file VARCHAR(255) PRIMARY KEY NOT NULL, applied INTEGER NOT NULL)",
+	).Execute(); err != nil {
+		t.Fatalf("ensure _migrations table: %v", err)
+	}
+
+	// Seed an orphan row for a file that doesn't exist in core.AppMigrations.
+	const orphanFile = "1500000999_test_orphan_should_be_removed.js"
+	if _, err := app.DB().NewQuery(
+		"INSERT OR REPLACE INTO _migrations (file, applied) VALUES ({:file}, 1)",
+	).Bind(map[string]any{"file": orphanFile}).Execute(); err != nil {
+		t.Fatalf("seed orphan row: %v", err)
+	}
+
+	// Sanity: orphan present before sync.
+	var beforeCount int
+	if err := app.DB().NewQuery(
+		"SELECT COUNT(*) FROM _migrations WHERE file = {:file}",
+	).Bind(map[string]any{"file": orphanFile}).Row(&beforeCount); err != nil {
+		t.Fatalf("count before: %v", err)
+	}
+	if beforeCount != 1 {
+		t.Fatalf("expected orphan row present before sync, got count=%d", beforeCount)
+	}
+
+	// Run history-sync — the same call the OnServe hook makes.
+	runner := core.NewMigrationsRunner(app, core.AppMigrations)
+	if err := runner.Run("history-sync"); err != nil {
+		t.Fatalf("run history-sync: %v", err)
+	}
+
+	// Orphan should be gone.
+	var afterCount int
+	if err := app.DB().NewQuery(
+		"SELECT COUNT(*) FROM _migrations WHERE file = {:file}",
+	).Bind(map[string]any{"file": orphanFile}).Row(&afterCount); err != nil {
+		t.Fatalf("count after: %v", err)
+	}
+	if afterCount != 0 {
+		t.Fatalf("expected orphan row removed after sync, got count=%d", afterCount)
+	}
+
+	// Idempotency: running again with no orphans is a no-op (no error).
+	if err := runner.Run("history-sync"); err != nil {
+		t.Fatalf("run history-sync second time: %v", err)
+	}
+}

--- a/scripts/dev/migration-schema-diff.sh
+++ b/scripts/dev/migration-schema-diff.sh
@@ -15,6 +15,21 @@ if [[ $# -ne 2 ]]; then
   exit 2
 fi
 
+# Normalize harness errors (missing tools, jq < 1.6, dump failures) to exit 2.
+for cmd in sqlite3 jq diff; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "error: required command not found: $cmd" >&2
+    exit 2
+  fi
+done
+
+# walk/1 was added in jq 1.6 (2019). Older jq either lacks it or silently
+# emits wrong output, so fail loudly with the documented harness exit code.
+if ! echo '{}' | jq -e 'walk(.)' >/dev/null 2>&1; then
+  echo "error: jq lacks walk/1 (need jq >= 1.6); found: $(jq --version 2>&1)" >&2
+  exit 2
+fi
+
 DB_A="$1/data.db"
 DB_B="$2/data.db"
 
@@ -51,7 +66,7 @@ ORDER BY id;
 
 DUMP_A=$(mktemp -t pb-dump-a-XXXX.json)
 DUMP_B=$(mktemp -t pb-dump-b-XXXX.json)
-trap 'rm -f "$DUMP_A" "$DUMP_B"' EXIT
+trap 'rm -f "$DUMP_A" "$DUMP_B"' EXIT INT TERM
 
 # Strip auto-generated secret fields (per-DB-random token signing keys
 # nested inside collection options like authToken.secret, fileToken.secret,
@@ -60,13 +75,28 @@ trap 'rm -f "$DUMP_A" "$DUMP_B"' EXIT
 # source between independently-applied scratch DBs.
 SCRUB_FILTER='walk(if type == "object" and has("secret") then .secret = "<scrubbed>" else . end)'
 
-sqlite3 "$DB_A" "$DUMP_SQL" | jq -S "$SCRUB_FILTER" > "$DUMP_A"
-sqlite3 "$DB_B" "$DUMP_SQL" | jq -S "$SCRUB_FILTER" > "$DUMP_B"
+# PIPESTATUS captures the per-stage exit code for each pipeline. Any non-zero
+# stage (sqlite3 dump failure, jq filter error) is a harness error → exit 2.
+dump() {
+  local label="$1" db="$2" out="$3"
+  sqlite3 "$db" "$DUMP_SQL" | jq -S "$SCRUB_FILTER" > "$out"
+  local pipe=("${PIPESTATUS[@]}")
+  if [[ "${pipe[0]}" -ne 0 || "${pipe[1]}" -ne 0 ]]; then
+    echo "error: failed to dump/normalize schema for $label (sqlite3=${pipe[0]} jq=${pipe[1]})" >&2
+    return 2
+  fi
+}
+dump A "$DB_A" "$DUMP_A" || exit 2
+dump B "$DB_B" "$DUMP_B" || exit 2
 
-if diff -u "$DUMP_A" "$DUMP_B"; then
-  echo "schemas match"
-  exit 0
-else
-  echo "schemas differ (above is unified diff: < a / > b)"
-  exit 1
-fi
+# diff exits 0 (match), 1 (differ), or >=2 (trouble — e.g. unreadable file).
+# Map only 0/1 to the documented contract; anything else → 2.
+set +e
+diff -u "$DUMP_A" "$DUMP_B"
+diff_rc=$?
+set -e
+case "$diff_rc" in
+  0) echo "schemas match"; exit 0 ;;
+  1) echo "schemas differ (above is unified diff: < a / > b)"; exit 1 ;;
+  *) echo "error: diff exited $diff_rc" >&2; exit 2 ;;
+esac

--- a/scripts/dev/migration-schema-diff.sh
+++ b/scripts/dev/migration-schema-diff.sh
@@ -53,8 +53,15 @@ DUMP_A=$(mktemp -t pb-dump-a-XXXX.json)
 DUMP_B=$(mktemp -t pb-dump-b-XXXX.json)
 trap 'rm -f "$DUMP_A" "$DUMP_B"' EXIT
 
-sqlite3 "$DB_A" "$DUMP_SQL" | jq -S . > "$DUMP_A"
-sqlite3 "$DB_B" "$DUMP_SQL" | jq -S . > "$DUMP_B"
+# Strip auto-generated secret fields (per-DB-random token signing keys
+# nested inside collection options like authToken.secret, fileToken.secret,
+# verificationToken.secret, etc.). Our migrations don't intentionally set
+# any field named "secret", so this is safe and eliminates a major drift
+# source between independently-applied scratch DBs.
+SCRUB_FILTER='walk(if type == "object" and has("secret") then .secret = "<scrubbed>" else . end)'
+
+sqlite3 "$DB_A" "$DUMP_SQL" | jq -S "$SCRUB_FILTER" > "$DUMP_A"
+sqlite3 "$DB_B" "$DUMP_SQL" | jq -S "$SCRUB_FILTER" > "$DUMP_B"
 
 if diff -u "$DUMP_A" "$DUMP_B"; then
   echo "schemas match"

--- a/scripts/dev/migration-schema-diff.sh
+++ b/scripts/dev/migration-schema-diff.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Diff PocketBase _collections schemas between two pb_data dirs.
+# Used by the consolidate-migrations skill (and verify-consolidation.sh) to
+# prove a merged migration set produces an identical schema to the current
+# set. Excludes `created` and `updated` timestamps which always differ
+# between independently-applied scratch DBs.
+#
+# Usage: migration-schema-diff.sh <pb_data_dir_a> <pb_data_dir_b>
+# Exits 0 if schemas match, 1 if they differ, 2 on harness error.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <pb_data_dir_a> <pb_data_dir_b>" >&2
+  exit 2
+fi
+
+DB_A="$1/data.db"
+DB_B="$2/data.db"
+
+for f in "$DB_A" "$DB_B"; do
+  if [[ ! -f "$f" ]]; then
+    echo "error: $f not found" >&2
+    exit 2
+  fi
+done
+
+# Canonical schema dump: order by id, exclude created/updated, JSON-normalize
+# the JSON columns so semantically-equal JSON formatted differently by SQLite
+# still compares equal after jq -S sorts keys. Note: SQLite treats "x" as an
+# identifier reference when it matches a column name; json_object labels must
+# use single quotes to be interpreted as string literals.
+DUMP_SQL="
+SELECT json_object(
+  'id', id,
+  'system', system,
+  'type', type,
+  'name', name,
+  'fields', json(fields),
+  'indexes', json(indexes),
+  'listRule', listRule,
+  'viewRule', viewRule,
+  'createRule', createRule,
+  'updateRule', updateRule,
+  'deleteRule', deleteRule,
+  'options', json(options)
+)
+FROM _collections
+ORDER BY id;
+"
+
+DUMP_A=$(mktemp -t pb-dump-a-XXXX.json)
+DUMP_B=$(mktemp -t pb-dump-b-XXXX.json)
+trap 'rm -f "$DUMP_A" "$DUMP_B"' EXIT
+
+sqlite3 "$DB_A" "$DUMP_SQL" | jq -S . > "$DUMP_A"
+sqlite3 "$DB_B" "$DUMP_SQL" | jq -S . > "$DUMP_B"
+
+if diff -u "$DUMP_A" "$DUMP_B"; then
+  echo "schemas match"
+  exit 0
+else
+  echo "schemas differ (above is unified diff: < a / > b)"
+  exit 1
+fi

--- a/scripts/dev/test-migration-schema-diff.sh
+++ b/scripts/dev/test-migration-schema-diff.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Test for migration-schema-diff.sh
+# Verifies: identical schemas → exit 0; differing schemas → exit 1;
+# created/updated drift does NOT cause a false positive.
+
+set -euo pipefail
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+DIFF_SCRIPT="$HERE/migration-schema-diff.sh"
+
+if [[ ! -x "$DIFF_SCRIPT" ]]; then
+  echo "FAIL: $DIFF_SCRIPT not executable or missing" >&2
+  exit 1
+fi
+
+SCRATCH=$(mktemp -d -t pb-diff-test-XXXX)
+trap 'rm -rf "$SCRATCH"' EXIT
+
+mkdir -p "$SCRATCH/db_a" "$SCRATCH/db_b"
+sqlite3 "$SCRATCH/db_a/data.db" <<'SQL'
+CREATE TABLE `_collections` (
+  `id` TEXT PRIMARY KEY,
+  `system` BOOLEAN,
+  `type` TEXT,
+  `name` TEXT UNIQUE,
+  `fields` JSON,
+  `indexes` JSON,
+  `listRule` TEXT,
+  `viewRule` TEXT,
+  `createRule` TEXT,
+  `updateRule` TEXT,
+  `deleteRule` TEXT,
+  `options` JSON,
+  `created` TEXT,
+  `updated` TEXT
+);
+INSERT INTO _collections (id, system, type, name, fields, indexes, listRule, viewRule, createRule, updateRule, deleteRule, options, created, updated)
+  VALUES ('r1', 0, 'base', 'foo', '[{"name":"x","type":"text"}]', '[]', '@request.auth.id != ""', NULL, NULL, NULL, NULL, '{}', '2026-01-01', '2026-01-01');
+SQL
+cp "$SCRATCH/db_a/data.db" "$SCRATCH/db_b/data.db"
+
+echo "=== TEST 1: identical DBs should exit 0 ==="
+if "$DIFF_SCRIPT" "$SCRATCH/db_a" "$SCRATCH/db_b"; then
+  echo "PASS: identical DBs returned 0"
+else
+  echo "FAIL: identical DBs returned non-zero"
+  exit 1
+fi
+
+echo
+echo "=== TEST 2: differing DBs should exit 1 ==="
+sqlite3 "$SCRATCH/db_b/data.db" "UPDATE _collections SET fields = '[{\"name\":\"x\",\"type\":\"number\"}]' WHERE name = 'foo';"
+if "$DIFF_SCRIPT" "$SCRATCH/db_a" "$SCRATCH/db_b"; then
+  echo "FAIL: differing DBs returned 0"
+  exit 1
+else
+  echo "PASS: differing DBs returned non-zero"
+fi
+
+echo
+echo "=== TEST 3: created/updated drift should NOT cause false positive ==="
+cp "$SCRATCH/db_a/data.db" "$SCRATCH/db_b/data.db"
+sqlite3 "$SCRATCH/db_b/data.db" "UPDATE _collections SET created = '2099-12-31', updated = '2099-12-31' WHERE name = 'foo';"
+if "$DIFF_SCRIPT" "$SCRATCH/db_a" "$SCRATCH/db_b"; then
+  echo "PASS: created/updated drift ignored"
+else
+  echo "FAIL: created/updated drift caused false positive"
+  exit 1
+fi
+
+echo
+echo "All tests passed."

--- a/scripts/dev/test-migration-schema-diff.sh
+++ b/scripts/dev/test-migration-schema-diff.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 # Test for migration-schema-diff.sh
-# Verifies: identical schemas → exit 0; differing schemas → exit 1;
-# created/updated drift does NOT cause a false positive.
+# Verifies the documented exit contract:
+#   0 — schemas match
+#   1 — schemas differ
+#   2 — harness error (missing tool, missing input, etc.)
+# Plus: created/updated/secret drift do NOT cause false positives.
 
 set -euo pipefail
 HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -13,7 +16,7 @@ if [[ ! -x "$DIFF_SCRIPT" ]]; then
 fi
 
 SCRATCH=$(mktemp -d -t pb-diff-test-XXXX)
-trap 'rm -rf "$SCRATCH"' EXIT
+trap 'rm -rf "$SCRATCH"' EXIT INT TERM
 
 mkdir -p "$SCRATCH/db_a" "$SCRATCH/db_b"
 sqlite3 "$SCRATCH/db_a/data.db" <<'SQL'
@@ -49,11 +52,15 @@ fi
 echo
 echo "=== TEST 2: differing DBs should exit 1 ==="
 sqlite3 "$SCRATCH/db_b/data.db" "UPDATE _collections SET fields = '[{\"name\":\"x\",\"type\":\"number\"}]' WHERE name = 'foo';"
-if "$DIFF_SCRIPT" "$SCRATCH/db_a" "$SCRATCH/db_b"; then
-  echo "FAIL: differing DBs returned 0"
-  exit 1
+set +e
+"$DIFF_SCRIPT" "$SCRATCH/db_a" "$SCRATCH/db_b" >/dev/null 2>&1
+rc=$?
+set -e
+if [[ $rc -eq 1 ]]; then
+  echo "PASS: differing DBs returned 1"
 else
-  echo "PASS: differing DBs returned non-zero"
+  echo "FAIL: differing DBs expected exit 1, got $rc"
+  exit 1
 fi
 
 echo
@@ -85,11 +92,50 @@ echo "=== TEST 5: real options drift (e.g. duration change) SHOULD cause failure
 cp "$SCRATCH/db_a/data.db" "$SCRATCH/db_b/data.db"
 sqlite3 "$SCRATCH/db_a/data.db" "UPDATE _collections SET options = '{\"authToken\":{\"duration\":86400,\"secret\":\"X\"}}' WHERE name = 'foo';"
 sqlite3 "$SCRATCH/db_b/data.db" "UPDATE _collections SET options = '{\"authToken\":{\"duration\":99999,\"secret\":\"X\"}}' WHERE name = 'foo';"
-if "$DIFF_SCRIPT" "$SCRATCH/db_a" "$SCRATCH/db_b"; then
-  echo "FAIL: real options drift NOT detected"
-  exit 1
+set +e
+"$DIFF_SCRIPT" "$SCRATCH/db_a" "$SCRATCH/db_b" >/dev/null 2>&1
+rc=$?
+set -e
+if [[ $rc -eq 1 ]]; then
+  echo "PASS: real options drift detected even with secret-stripping (exit 1)"
 else
-  echo "PASS: real options drift detected even with secret-stripping"
+  echo "FAIL: real options drift expected exit 1, got $rc"
+  exit 1
+fi
+
+echo
+echo "=== TEST 6: missing input file should exit 2 (harness error) ==="
+set +e
+"$DIFF_SCRIPT" "$SCRATCH/db_a" "$SCRATCH/nonexistent_dir" >/dev/null 2>&1
+rc=$?
+set -e
+if [[ $rc -eq 2 ]]; then
+  echo "PASS: missing input → exit 2"
+else
+  echo "FAIL: missing input expected exit 2, got $rc"
+  exit 1
+fi
+
+echo
+echo "=== TEST 7: missing required dep (sqlite3) should exit 2 (harness error) ==="
+# Sandbox PATH with bash + jq + diff but NOT sqlite3, then invoke the script.
+# This proves the upfront command -v checks normalize tool absence to rc=2
+# instead of leaking 127 from set -e or exit 1 from the caller's diff branch.
+SANDBOX_BIN=$(mktemp -d -t pb-diff-sandbox-XXXX)
+trap 'rm -rf "$SCRATCH" "$SANDBOX_BIN"' EXIT INT TERM
+for tool in bash jq diff mktemp rm cat env mkdir grep sed awk dirname basename type command; do
+  src="$(command -v "$tool" 2>/dev/null || true)"
+  [[ -n "$src" ]] && ln -sf "$src" "$SANDBOX_BIN/$tool"
+done
+set +e
+PATH="$SANDBOX_BIN" "$DIFF_SCRIPT" "$SCRATCH/db_a" "$SCRATCH/db_b" >/dev/null 2>&1
+rc=$?
+set -e
+if [[ $rc -eq 2 ]]; then
+  echo "PASS: missing sqlite3 → exit 2"
+else
+  echo "FAIL: missing sqlite3 expected exit 2, got $rc"
+  exit 1
 fi
 
 echo

--- a/scripts/dev/test-migration-schema-diff.sh
+++ b/scripts/dev/test-migration-schema-diff.sh
@@ -68,4 +68,29 @@ else
 fi
 
 echo
+echo "=== TEST 4: per-DB-random secrets in options.* should NOT cause false positive ==="
+# Reset to identical DBs, then drift only the auto-generated token secrets
+cp "$SCRATCH/db_a/data.db" "$SCRATCH/db_b/data.db"
+sqlite3 "$SCRATCH/db_a/data.db" "UPDATE _collections SET options = '{\"authToken\":{\"duration\":86400,\"secret\":\"AAAAAAAAAA\"},\"verificationToken\":{\"duration\":259200,\"secret\":\"BBBBBBBBBB\"}}' WHERE name = 'foo';"
+sqlite3 "$SCRATCH/db_b/data.db" "UPDATE _collections SET options = '{\"authToken\":{\"duration\":86400,\"secret\":\"ZZZZZZZZZZ\"},\"verificationToken\":{\"duration\":259200,\"secret\":\"YYYYYYYYYY\"}}' WHERE name = 'foo';"
+if "$DIFF_SCRIPT" "$SCRATCH/db_a" "$SCRATCH/db_b"; then
+  echo "PASS: per-DB-random secret drift ignored"
+else
+  echo "FAIL: per-DB-random secret drift caused false positive"
+  exit 1
+fi
+
+echo
+echo "=== TEST 5: real options drift (e.g. duration change) SHOULD cause failure ==="
+cp "$SCRATCH/db_a/data.db" "$SCRATCH/db_b/data.db"
+sqlite3 "$SCRATCH/db_a/data.db" "UPDATE _collections SET options = '{\"authToken\":{\"duration\":86400,\"secret\":\"X\"}}' WHERE name = 'foo';"
+sqlite3 "$SCRATCH/db_b/data.db" "UPDATE _collections SET options = '{\"authToken\":{\"duration\":99999,\"secret\":\"X\"}}' WHERE name = 'foo';"
+if "$DIFF_SCRIPT" "$SCRATCH/db_a" "$SCRATCH/db_b"; then
+  echo "FAIL: real options drift NOT detected"
+  exit 1
+else
+  echo "PASS: real options drift detected even with secret-stripping"
+fi
+
+echo
 echo "All tests passed."

--- a/scripts/dev/verify-consolidation.sh
+++ b/scripts/dev/verify-consolidation.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Verify a proposed PocketBase migration set produces the same schema as the
+# current set. Used by the consolidate-migrations skill before letting the
+# user commit a merged CREATE migration: spins up two scratch DBs (one with
+# the proposed migration directory, one with the current one), then calls
+# migration-schema-diff.sh on the resulting _collections schemas.
+#
+# Usage: verify-consolidation.sh <proposed_migrations_dir> <current_migrations_dir>
+# Exits 0 if schemas match, 1 if drift, 2 on harness error.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <proposed_migrations_dir> <current_migrations_dir>" >&2
+  exit 2
+fi
+
+PROPOSED_DIR="$1"
+CURRENT_DIR="$2"
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$HERE/../.." && pwd)
+DIFF_SCRIPT="$HERE/migration-schema-diff.sh"
+
+for d in "$PROPOSED_DIR" "$CURRENT_DIR"; do
+  if [[ ! -d "$d" ]]; then
+    echo "error: $d not a directory" >&2
+    exit 2
+  fi
+done
+
+if [[ ! -x "$DIFF_SCRIPT" ]]; then
+  echo "error: $DIFF_SCRIPT missing or not executable" >&2
+  exit 2
+fi
+
+# Build pocketbase binary once and reuse for both scratch DBs to avoid
+# paying go-build cost twice. Built in scratch dir so it's auto-cleaned.
+SCRATCH=$(mktemp -d -t pb-verify-XXXX)
+trap 'rm -rf "$SCRATCH"' EXIT INT TERM
+
+echo ">> building pocketbase binary..."
+( cd "$REPO_ROOT/pocketbase" && go build -o "$SCRATCH/pocketbase" . ) > "$SCRATCH/build.log" 2>&1 \
+  || { echo "pocketbase build failed; log:"; cat "$SCRATCH/build.log"; exit 2; }
+
+mkdir -p "$SCRATCH/db_a" "$SCRATCH/db_b"
+
+echo ">> applying PROPOSED migrations to DB-A..."
+"$SCRATCH/pocketbase" migrate up \
+    --dir "$SCRATCH/db_a" \
+    --migrationsDir "$PROPOSED_DIR" > "$SCRATCH/db_a.log" 2>&1 \
+  || { echo "DB-A migrate failed; log:"; cat "$SCRATCH/db_a.log"; exit 2; }
+
+echo ">> applying CURRENT migrations to DB-B..."
+"$SCRATCH/pocketbase" migrate up \
+    --dir "$SCRATCH/db_b" \
+    --migrationsDir "$CURRENT_DIR" > "$SCRATCH/db_b.log" 2>&1 \
+  || { echo "DB-B migrate failed; log:"; cat "$SCRATCH/db_b.log"; exit 2; }
+
+echo ">> diffing schemas..."
+"$DIFF_SCRIPT" "$SCRATCH/db_a" "$SCRATCH/db_b"


### PR DESCRIPTION
## Summary

Ships the foundation for the new `consolidate-migrations` skill (collapsing PocketBase table migration chains into one merged CREATE) AND brings kindred-specific skills into git tracking.

### Verification harness + history-sync hook
- `scripts/dev/migration-schema-diff.sh` + tests — TDD'd 2-DB `_collections` schema diff with secret-strip filter (excludes per-DB-random `authToken.secret`, `verificationToken.secret`, etc.) and `created`/`updated` timestamp drift exclusion
- `scripts/dev/verify-consolidation.sh` — orchestrator that builds DB-A (proposed migrations) and DB-B (current) and calls the diff harness
- `pocketbase/main.go` — single `OnServe` hook calling PB v0.23's built-in `migrate history-sync` on every server boot. Idempotent: no-op on clean DBs; self-healing on prod after consolidation merges drop intermediate migration files

### Skill tracking
- `.claude/skills/` exception added to `.gitignore` so kindred-specific Claude Code skills are now real shared artifacts (settings.json, agents/, plugins/ stay ignored)
- Skills now committed:
  - `consolidate-migrations` (new this PR)
  - `solver-config-it` (moved from `~/claude-dotfiles/skills/`; was kindred-specific but synced as if generic)
  - `campminder-sync`, `grab-feedback`, `pocketbase-migrations`, `pre-push-verification` (existed locally on dev machine but never tracked)

### Docs
- CLAUDE.md numbering rule — codifies "new migrations must use a number greater than the highest filename on `origin/main`; never fill consolidation gaps"
- `docs/reference/pocketbase-migrations.md` — cross-reference to the consolidation skill, harness, and hook

## Design pivot during implementation

Original spec proposed per-round helper JS migrations to `DELETE` orphan `_migrations` rows. During Task 1 research we found PB v0.23 already ships this functionality as `migrate history-sync` (in `core/migrations_runner.go`). Replaced helper migrations with a single `OnServe` hook that invokes `runner.Run("history-sync")` on boot — net result is **0 new files added per consolidation round**, same prod self-healing.

## Test plan

- [x] `scripts/dev/test-migration-schema-diff.sh` — 5 unit tests pass (identical → 0; field drift → 1; timestamp drift ignored; secret drift ignored; real options drift detected)
- [x] `scripts/dev/verify-consolidation.sh pocketbase/pb_migrations pocketbase/pb_migrations` → `schemas match`, exit 0 (identity check)
- [x] `go test -run TestHistorySyncRemovesOrphanRows` → PASS (orphan row removed, idempotent on second invocation)
- [x] End-to-end smoke test: scratch DB with injected orphan row → `pocketbase serve` boot → orphan removed by hook → confirmed `count = 0` after
- [x] `lefthook run pre-push` → all 7 checks pass (ruff-check, go-build, shellcheck, pb-js-lint, api-types-freshness, mypy, type-check)
- [x] gitignore exception verified: `.claude/settings.json` and `.claude/foo.txt` stay IGNORED; `.claude/skills/test.md` is NOT-IGNORED
- [ ] First real consolidation round (e.g., `bunk_requests`) — follow-up PR

## Post-merge cleanup (operator)

After this PR merges:
- Remove stale symlink: `rm ~/.claude/skills/solver-config-it`
- Delete from `~/claude-dotfiles/skills/solver-config-it/` and push to claude-dotfiles repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server now runs a history-sync on startup to remove orphan migration records while preserving valid entries.

* **Documentation**
  * Large PocketBase migrations reference: numbering/consolidation rules, templates, anti‑patterns, field-type & common-pattern guides, and multiple operational skill docs (consolidation, pre-push verification, CampMinder sync, feedback transfer, solver-config).

* **Tests**
  * Added regression test for history-sync and harnessed tests validating migration schema-diff behavior.

* **Chores**
  * New dev verification and migration diff/verify scripts; refined .gitignore handling for test files and local cache entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->