### PR TITLE
refactor(sync): collapse dedup tiebreak to source_field-ordered priority (#1142 stage 3)

### DIFF
--- a/bunking/sync/bunk_request_processor/core/constants.py
+++ b/bunking/sync/bunk_request_processor/core/constants.py
@@ -9,15 +9,6 @@ from __future__ import annotations
 # For DB-based session queries, use SessionRepository.get_valid_bunking_session_ids()
 VALID_SESSION_TYPES = {"main", "embedded", "ag"}
 
-# Source field (V2) to RequestSource mapping
-SOURCE_FIELD_TO_SOURCE = {
-    "bunk_with": "family",
-    "not_bunk_with": "family",
-    "socialize_with": "parent",
-    "internal_notes": "staff-notes",
-    "bunking_notes": "staff-notes",
-}
-
 # Priority keywords that indicate high importance
 # These should match the keywords in ai_config.json priority_overrides.keywords
 # plus common variations that parents use

--- a/bunking/sync/bunk_request_processor/processing/deduplicator.py
+++ b/bunking/sync/bunk_request_processor/processing/deduplicator.py
@@ -8,15 +8,20 @@ from __future__ import annotations
 import dataclasses
 from dataclasses import dataclass, field
 
-from ..core.models import BunkRequest, RequestSource, RequestStatus, RequestType, source_from_field
+from ..core.models import BunkRequest, RequestStatus, RequestType, source_from_field
 from ..data.repositories.request_repository import RequestRepository
 from ..shared.constants import SourceField
 
-# Source priority order (higher number = higher priority)
-# Used for deduplication tiebreaker only — FAMILY is authoritative (parent-paramount).
-SOURCE_PRIORITY = {
-    RequestSource.FAMILY: 2,  # Origin of intent — parent input is authoritative
-    RequestSource.STAFF: 1,  # Corroboration / observation — preserved as metadata
+# Source field priority for dedup tiebreak.
+# Materiality model: material parent intent > staff exclusion > staff
+# observation > immaterial parent input. Higher number = higher priority.
+# confidence_score breaks ties within rank.
+SOURCE_FIELD_PRIORITY = {
+    SourceField.BUNK_WITH: 4,  # material parent
+    SourceField.NOT_BUNK_WITH: 3,  # staff exclusion
+    SourceField.BUNKING_NOTES: 2,  # staff observation (tied with internal_notes)
+    SourceField.INTERNAL_NOTES: 2,  # staff observation (tied with bunking_notes)
+    SourceField.SOCIALIZE_WITH: 1,  # immaterial parent
 }
 
 
@@ -182,16 +187,13 @@ class Deduplicator:
                     # they are kept as distinct records for staff review.
                     continue
 
-                # Tiebreak order (descending): SOURCE_PRIORITY, then bunk_with-source
-                # preference (Stage 1 fix for parent age_pref dedupe), then confidence.
-                # SOURCE_PRIORITY dominates first, so the bunk_with bias only changes
-                # outcomes within same-source ties — most commonly parent-vs-parent
-                # age_pref (where bunk_with prose beats the socialize_with checkbox).
+                # Tiebreak: SOURCE_FIELD_PRIORITY (materiality rank), then confidence.
+                # bunk_with > not_bunk_with > bunking_notes/internal_notes (tied) >
+                # socialize_with. Within rank, higher confidence wins.
                 sorted_requests = sorted(
                     group_requests,
                     key=lambda r: (
-                        SOURCE_PRIORITY.get(r.source, 0),
-                        1 if r.source_field == SourceField.BUNK_WITH else 0,
+                        SOURCE_FIELD_PRIORITY.get(r.source_field, 0),
                         r.confidence_score,
                     ),
                     reverse=True,

--- a/tests/unit/sync/bunk_request_processor/processing/test_deduplicator.py
+++ b/tests/unit/sync/bunk_request_processor/processing/test_deduplicator.py
@@ -587,11 +587,13 @@ class TestSimplifiedSourcePriority:
         return Deduplicator()
 
     def test_family_over_staff_tiebreaker(self):
-        """Test that FAMILY source wins over STAFF in dedup tiebreaker (#1088 parent-paramount).
+        """Test that bunk_with (material parent, rank 4) outranks not_bunk_with
+        (staff exclusion, rank 3) in dedup tiebreak (#1142 materiality model).
 
-        When same (requester, requestee, type, session, year) comes from both
-        FAMILY and STAFF sources, FAMILY should win — origin of intent is authoritative.
-        Staff corroborates but does not supersede parent input.
+        When same (requester, requestee, type, session, year) appears in both
+        bunk_with and not_bunk_with source_fields, bunk_with wins — material
+        parent intent is the highest-rank source_field. Test name preserved
+        for CI stability; original rationale was FAMILY > STAFF (#1088).
         """
         family_request = BunkRequest(
             requester_cm_id=12345,
@@ -1550,12 +1552,13 @@ class TestFamilyParamountTiebreak:
         return Deduplicator()
 
     def test_family_beats_staff_bunk_with_tiebreak(self, deduplicator):
-        """When a FAMILY bunk_with and a STAFF bunking_notes share the same dedup key,
-        the FAMILY row must survive as primary.
+        """When a bunk_with row and a bunking_notes row share the same dedup key,
+        the bunk_with row must survive as primary (#1142 materiality model).
 
         Scenario: Emma Johnson's parent submits "bunk with Liam Garcia" via the family
-        form (source_field=bunk_with). Staff also notes it in bunking_notes.
-        The parent-sourced row must win — origin of intent is authoritative.
+        form (source_field=bunk_with, rank 4). Staff also notes it in bunking_notes
+        (rank 2). bunk_with outranks bunking_notes — material parent intent wins.
+        Test name preserved for CI stability; original rationale was FAMILY > STAFF.
         """
         family_request = BunkRequest(
             requester_cm_id=11111,
@@ -1628,12 +1631,14 @@ class TestFamilyParamountTiebreak:
         )
 
     def test_family_beats_staff_age_preference_tiebreak(self, deduplicator):
-        """When a FAMILY age_preference (AI-parsed from bunk_with prose) and a STAFF
-        age_preference (from bunking_notes) share the same dedup key, FAMILY wins.
+        """When an age_preference row from bunk_with and one from bunking_notes
+        share the same dedup key, the bunk_with row wins (#1142 materiality model).
 
         Scenario: Liam Garcia's parent writes "prefers younger bunk-mates" in the
-        bunk_with text field (AI-parsed to age_preference/FAMILY). Staff also notes
-        the same preference in bunking_notes (STAFF). The parent-sourced row must win.
+        bunk_with text field (AI-parsed to age_preference, rank 4). Staff also notes
+        the same preference in bunking_notes (rank 2). bunk_with outranks
+        bunking_notes — material parent intent wins. Test name preserved for CI
+        stability; original rationale was FAMILY > STAFF.
         """
         family_age_pref = BunkRequest(
             requester_cm_id=33333,

--- a/tests/unit/sync/bunk_request_processor/processing/test_deduplicator.py
+++ b/tests/unit/sync/bunk_request_processor/processing/test_deduplicator.py
@@ -679,21 +679,28 @@ class TestSimplifiedSourcePriority:
         assert result.kept_requests[0].confidence_score == 0.98
         assert result.statistics["duplicates_removed"] == 1
 
-    def test_source_priority_only_staff_and_family(self):
-        """Test that SOURCE_PRIORITY only contains STAFF and FAMILY, with FAMILY paramount.
+    def test_source_field_priority_structure(self):
+        """SOURCE_FIELD_PRIORITY contains all 5 source fields with materiality-based ordering.
 
-        NOTES category should not exist - bunking_notes and internal_notes
-        should map to STAFF source. FAMILY has higher priority than STAFF (#1088).
+        Locks the Stage 3 ordering: bunk_with (material parent) > not_bunk_with
+        (staff exclusion) > bunking_notes/internal_notes (staff observation, tied) >
+        socialize_with (immaterial parent). Confidence breaks ties within rank.
         """
-        from bunking.sync.bunk_request_processor.processing.deduplicator import SOURCE_PRIORITY
+        from bunking.sync.bunk_request_processor.processing.deduplicator import SOURCE_FIELD_PRIORITY
 
-        # Should only have two entries
-        assert len(SOURCE_PRIORITY) == 2
-        assert RequestSource.STAFF in SOURCE_PRIORITY
-        assert RequestSource.FAMILY in SOURCE_PRIORITY
+        # All 5 canonical source_field values must be present
+        assert len(SOURCE_FIELD_PRIORITY) == 5
+        assert SourceField.BUNK_WITH in SOURCE_FIELD_PRIORITY
+        assert SourceField.NOT_BUNK_WITH in SOURCE_FIELD_PRIORITY
+        assert SourceField.BUNKING_NOTES in SOURCE_FIELD_PRIORITY
+        assert SourceField.INTERNAL_NOTES in SOURCE_FIELD_PRIORITY
+        assert SourceField.SOCIALIZE_WITH in SOURCE_FIELD_PRIORITY
 
-        # FAMILY should have higher priority than STAFF (#1088 parent-paramount)
-        assert SOURCE_PRIORITY[RequestSource.FAMILY] > SOURCE_PRIORITY[RequestSource.STAFF]
+        # Materiality ordering
+        assert SOURCE_FIELD_PRIORITY[SourceField.BUNK_WITH] > SOURCE_FIELD_PRIORITY[SourceField.NOT_BUNK_WITH]
+        assert SOURCE_FIELD_PRIORITY[SourceField.NOT_BUNK_WITH] > SOURCE_FIELD_PRIORITY[SourceField.BUNKING_NOTES]
+        assert SOURCE_FIELD_PRIORITY[SourceField.BUNKING_NOTES] == SOURCE_FIELD_PRIORITY[SourceField.INTERNAL_NOTES]
+        assert SOURCE_FIELD_PRIORITY[SourceField.BUNKING_NOTES] > SOURCE_FIELD_PRIORITY[SourceField.SOCIALIZE_WITH]
 
     def test_notes_enum_removed(self):
         """Test that RequestSource.NOTES no longer exists.
@@ -703,6 +710,152 @@ class TestSimplifiedSourcePriority:
         """
         # NOTES should not be a valid enum value
         assert not hasattr(RequestSource, "NOTES")
+
+    def test_not_bunk_with_beats_socialize_with_in_dedup(self):
+        """Stage 3 ordering: not_bunk_with (STAFF exclusion, rank 3) outranks
+        socialize_with (FAMILY immaterial, rank 1) regardless of confidence.
+
+        Same dedup key (same requester/year/session, AGE_PREFERENCE).
+        Lower-confidence not_bunk_with row must win over higher-confidence
+        socialize_with row — proves rank dominates confidence.
+        """
+        not_bunk_with_req = BunkRequest(
+            requester_cm_id=44444,
+            requested_cm_id=None,
+            request_type=RequestType.AGE_PREFERENCE,
+            session_cm_id=1000002,
+            priority=4,
+            confidence_score=0.70,  # Lower confidence
+            source=RequestSource.STAFF,
+            source_field=SourceField.NOT_BUNK_WITH,
+            csv_position=0,
+            year=2025,
+            status=RequestStatus.RESOLVED,
+            is_placeholder=True,
+            metadata={"age_preference": "younger"},
+        )
+
+        socialize_with_req = BunkRequest(
+            requester_cm_id=44444,
+            requested_cm_id=None,
+            request_type=RequestType.AGE_PREFERENCE,
+            session_cm_id=1000002,
+            priority=1,
+            confidence_score=0.95,  # Higher confidence
+            source=RequestSource.FAMILY,
+            source_field=SourceField.SOCIALIZE_WITH,
+            csv_position=0,
+            year=2025,
+            status=RequestStatus.RESOLVED,
+            is_placeholder=True,
+            metadata={"age_preference": "younger"},
+        )
+
+        deduplicator = Deduplicator()
+        result = deduplicator.deduplicate_batch([socialize_with_req, not_bunk_with_req])
+
+        assert len(result.kept_requests) == 1
+        assert result.kept_requests[0].source_field == SourceField.NOT_BUNK_WITH, (
+            f"Expected not_bunk_with to win over socialize_with; got {result.kept_requests[0].source_field}"
+        )
+
+    def test_bunking_notes_beats_socialize_with_in_dedup(self):
+        """Stage 3 ordering: bunking_notes (STAFF observation, rank 2) outranks
+        socialize_with (FAMILY immaterial, rank 1) regardless of confidence.
+
+        Same dedup key (same requester/year/session, AGE_PREFERENCE).
+        Lower-confidence bunking_notes row must win over higher-confidence
+        socialize_with row.
+        """
+        bunking_notes_req = BunkRequest(
+            requester_cm_id=55555,
+            requested_cm_id=None,
+            request_type=RequestType.AGE_PREFERENCE,
+            session_cm_id=1000002,
+            priority=2,
+            confidence_score=0.70,  # Lower confidence
+            source=RequestSource.STAFF,
+            source_field=SourceField.BUNKING_NOTES,
+            csv_position=0,
+            year=2025,
+            status=RequestStatus.RESOLVED,
+            is_placeholder=True,
+            metadata={"age_preference": "older"},
+        )
+
+        socialize_with_req = BunkRequest(
+            requester_cm_id=55555,
+            requested_cm_id=None,
+            request_type=RequestType.AGE_PREFERENCE,
+            session_cm_id=1000002,
+            priority=1,
+            confidence_score=0.95,  # Higher confidence
+            source=RequestSource.FAMILY,
+            source_field=SourceField.SOCIALIZE_WITH,
+            csv_position=0,
+            year=2025,
+            status=RequestStatus.RESOLVED,
+            is_placeholder=True,
+            metadata={"age_preference": "older"},
+        )
+
+        deduplicator = Deduplicator()
+        result = deduplicator.deduplicate_batch([socialize_with_req, bunking_notes_req])
+
+        assert len(result.kept_requests) == 1
+        assert result.kept_requests[0].source_field == SourceField.BUNKING_NOTES, (
+            f"Expected bunking_notes to win over socialize_with; got {result.kept_requests[0].source_field}"
+        )
+
+    def test_bunking_notes_and_internal_notes_tied_confidence_breaks(self):
+        """Stage 3 ordering: bunking_notes and internal_notes share rank 2.
+        Confidence breaks the tie within rank.
+
+        Same dedup key (same requester/requestee/year/session, BUNK_WITH).
+        Higher-confidence internal_notes row wins because the rank tie defers
+        to the confidence_score secondary sort.
+        """
+        bunking_notes_req = BunkRequest(
+            requester_cm_id=66666,
+            requested_cm_id=77777,
+            request_type=RequestType.BUNK_WITH,
+            session_cm_id=1000002,
+            priority=2,
+            confidence_score=0.85,  # Lower confidence
+            source=RequestSource.STAFF,
+            source_field=SourceField.BUNKING_NOTES,
+            csv_position=0,
+            year=2025,
+            status=RequestStatus.RESOLVED,
+            is_placeholder=False,
+            metadata={"original_text": "wants to bunk with target"},
+        )
+
+        internal_notes_req = BunkRequest(
+            requester_cm_id=66666,
+            requested_cm_id=77777,
+            request_type=RequestType.BUNK_WITH,
+            session_cm_id=1000002,
+            priority=2,
+            confidence_score=0.95,  # Higher confidence
+            source=RequestSource.STAFF,
+            source_field=SourceField.INTERNAL_NOTES,
+            csv_position=0,
+            year=2025,
+            status=RequestStatus.RESOLVED,
+            is_placeholder=False,
+            metadata={"original_text": "internal: bunk with target"},
+        )
+
+        deduplicator = Deduplicator()
+        result = deduplicator.deduplicate_batch([bunking_notes_req, internal_notes_req])
+
+        assert len(result.kept_requests) == 1
+        survivor = result.kept_requests[0]
+        assert survivor.source_field == SourceField.INTERNAL_NOTES, (
+            f"Expected higher-confidence internal_notes to win on confidence tiebreak; got {survivor.source_field}"
+        )
+        assert survivor.confidence_score == 0.95
 
 
 class TestDatabaseDuplicateMerge:
@@ -765,8 +918,13 @@ class TestAgePreferenceDeduplication:
         """Test that age_preference from different sources ARE deduplicated.
 
         This is the bug fix test. Previously, age_preference requests from bunking_notes
-        and ret_parent_socialize_with_best had different dedup keys and both attempted
-        to save to the DB, violating the unique constraint.
+        and socialize_with had different dedup keys and both attempted to save to the
+        DB, violating the unique constraint.
+
+        Under #1142 Stage 3 materiality ordering: bunking_notes (rank 2, staff
+        observation) outranks socialize_with (rank 1, immaterial parent). The
+        bunking_notes row survives as primary; confidence is boosted to max via
+        merge_metadata.
         """
         # Age preference from bunking_notes (AI-parsed)
         ai_parsed = BunkRequest(
@@ -777,7 +935,7 @@ class TestAgePreferenceDeduplication:
             priority=1,
             confidence_score=0.85,
             source=RequestSource.STAFF,
-            source_field="bunking_notes",  # AI-parsed from staff notes
+            source_field=SourceField.BUNKING_NOTES,  # AI-parsed from staff notes
             csv_position=0,
             year=2025,
             status=RequestStatus.RESOLVED,
@@ -794,7 +952,7 @@ class TestAgePreferenceDeduplication:
             priority=1,
             confidence_score=1.0,  # Dropdown is 100% confidence
             source=RequestSource.FAMILY,
-            source_field="ret_parent_socialize_with_best",  # Dropdown field
+            source_field=SourceField.SOCIALIZE_WITH,  # Dropdown field (immaterial parent)
             csv_position=0,
             year=2025,
             status=RequestStatus.RESOLVED,
@@ -808,11 +966,12 @@ class TestAgePreferenceDeduplication:
         assert len(result.kept_requests) == 1
         assert result.statistics["duplicates_removed"] == 1
 
-        # FAMILY wins over STAFF (#1088 parent-paramount)
+        # bunking_notes (rank 2) outranks socialize_with (rank 1) under #1142 Stage 3
         kept = result.kept_requests[0]
-        assert kept.source == RequestSource.FAMILY
+        assert kept.source == RequestSource.STAFF
+        assert kept.source_field == SourceField.BUNKING_NOTES
 
-        # But confidence is boosted to max from all sources
+        # Confidence is boosted to max from all sources via merge_metadata
         assert kept.confidence_score == 1.0
 
         # Metadata should be merged
@@ -821,14 +980,17 @@ class TestAgePreferenceDeduplication:
     def test_age_preference_conflicting_values_highest_priority_wins(self, deduplicator):
         """Test that conflicting age preferences resolve to highest priority source.
 
-        Edge case: What if bunking_notes says "older" but dropdown says "younger"?
-        Higher priority source wins (FAMILY > STAFF, #1088 parent-paramount).
+        Edge case: bunking_notes says "older" and socialize_with says "younger".
+        Under #1142 Stage 3 materiality ordering, bunking_notes (rank 2, staff
+        observation) outranks socialize_with (rank 1, immaterial parent), so
+        the bunking_notes row's "older" value survives.
+
         Note: the conflict-target demotion path (_is_conflicting_age_preference_pair)
         only fires for BUNK_WITH vs SOCIALIZE_WITH source fields — this case uses
-        bunking_notes vs ret_parent_socialize_with_best, so it falls through to the
-        normal tiebreak and FAMILY wins as primary.
+        bunking_notes vs socialize_with, so it falls through to the normal tiebreak.
+        Confidence is still boosted to max via merge_metadata.
         """
-        # AI-parsed says "older" (STAFF source)
+        # AI-parsed says "older" (STAFF source, bunking_notes — rank 2)
         older_request = BunkRequest(
             requester_cm_id=12345,
             requested_cm_id=None,
@@ -837,7 +999,7 @@ class TestAgePreferenceDeduplication:
             priority=1,
             confidence_score=0.80,
             source=RequestSource.STAFF,
-            source_field="bunking_notes",
+            source_field=SourceField.BUNKING_NOTES,
             csv_position=0,
             year=2025,
             status=RequestStatus.RESOLVED,
@@ -845,16 +1007,16 @@ class TestAgePreferenceDeduplication:
             metadata={"age_preference": "older"},
         )
 
-        # Dropdown says "younger" (FAMILY source)
+        # Dropdown says "younger" (FAMILY source, socialize_with — rank 1)
         younger_request = BunkRequest(
             requester_cm_id=12345,
             requested_cm_id=None,
             request_type=RequestType.AGE_PREFERENCE,
             session_cm_id=1000002,
             priority=1,
-            confidence_score=1.0,  # Higher confidence
+            confidence_score=1.0,  # Higher confidence — but rank dominates
             source=RequestSource.FAMILY,
-            source_field="ret_parent_socialize_with_best",
+            source_field=SourceField.SOCIALIZE_WITH,
             csv_position=0,
             year=2025,
             status=RequestStatus.RESOLVED,
@@ -864,12 +1026,13 @@ class TestAgePreferenceDeduplication:
 
         result = deduplicator.deduplicate_batch([older_request, younger_request])
 
-        # Deduplicated - FAMILY wins (#1088 parent-paramount flip)
+        # Deduplicated — bunking_notes (rank 2) wins over socialize_with (rank 1) under #1142 Stage 3
         assert len(result.kept_requests) == 1
         kept = result.kept_requests[0]
-        assert kept.source == RequestSource.FAMILY
-        assert kept.metadata["age_preference"] == "younger"
-        # Confidence already highest on the family record
+        assert kept.source == RequestSource.STAFF
+        assert kept.source_field == SourceField.BUNKING_NOTES
+        assert kept.metadata["age_preference"] == "older"
+        # Confidence boosted to max from all sources via merge_metadata
         assert kept.confidence_score == 1.0
 
     def test_age_preference_same_source_same_field_deduplicated(self, deduplicator):
@@ -1040,8 +1203,10 @@ class TestAgePreferenceDeduplication:
 
         Even though is_placeholder=True, multiple AGE_PREFERENCE requests for the same
         requester/session/year from different sources should deduplicate to 1.
+
+        Under #1142 Stage 3, bunking_notes (rank 2) outranks socialize_with (rank 1).
         """
-        # AI-parsed from bunking_notes (STAFF source)
+        # AI-parsed from bunking_notes (STAFF source — rank 2)
         ai_parsed = BunkRequest(
             requester_cm_id=12345,
             requested_cm_id=None,
@@ -1050,7 +1215,7 @@ class TestAgePreferenceDeduplication:
             priority=1,
             confidence_score=0.85,
             source=RequestSource.STAFF,
-            source_field="bunking_notes",
+            source_field=SourceField.BUNKING_NOTES,
             csv_position=0,
             year=2025,
             status=RequestStatus.RESOLVED,
@@ -1058,7 +1223,7 @@ class TestAgePreferenceDeduplication:
             metadata={"age_preference": "older", "origin": "ai_parsed"},
         )
 
-        # Dropdown selection (FAMILY source)
+        # Dropdown selection (FAMILY source, socialize_with — rank 1)
         dropdown = BunkRequest(
             requester_cm_id=12345,
             requested_cm_id=None,
@@ -1067,7 +1232,7 @@ class TestAgePreferenceDeduplication:
             priority=1,
             confidence_score=1.0,
             source=RequestSource.FAMILY,
-            source_field="ret_parent_socialize_with_best",
+            source_field=SourceField.SOCIALIZE_WITH,
             csv_position=0,
             year=2025,
             status=RequestStatus.RESOLVED,
@@ -1083,8 +1248,9 @@ class TestAgePreferenceDeduplication:
             f"Possible bugs: double-add or no dedup across sources."
         )
         assert result.statistics["duplicates_removed"] == 1
-        # FAMILY wins over STAFF (#1088 parent-paramount)
-        assert result.kept_requests[0].source == RequestSource.FAMILY
+        # bunking_notes (rank 2) wins over socialize_with (rank 1) under #1142 Stage 3
+        assert result.kept_requests[0].source == RequestSource.STAFF
+        assert result.kept_requests[0].source_field == SourceField.BUNKING_NOTES
 
 
 class TestParentAgePreferenceDeduplication:
@@ -1181,16 +1347,22 @@ class TestParentAgePreferenceDeduplication:
             "Family source must win over staff socialize_with; SOURCE_PRIORITY (family > staff) dominates"
         )
 
-    def test_confidence_still_tiebreaks_when_both_non_bunk_with(self, deduplicator):
-        """When neither request is from bunk_with, confidence remains the final tiebreaker."""
+    def test_rank_dominates_confidence_when_both_non_bunk_with(self, deduplicator):
+        """Even when neither request is bunk_with, source_field rank dominates confidence.
+
+        Under #1142 Stage 3 materiality ordering, bunking_notes (rank 2) outranks
+        socialize_with (rank 1). The lower-confidence bunking_notes row wins —
+        confidence only breaks ties WITHIN the same rank (e.g., bunking_notes
+        vs internal_notes, both rank 2).
+        """
         high_conf = self._age_pref(SourceField.SOCIALIZE_WITH, confidence=1.0)
         low_conf = self._age_pref(SourceField.BUNKING_NOTES, confidence=0.75)
 
         result = deduplicator.deduplicate_batch([low_conf, high_conf])
 
         assert len(result.kept_requests) == 1
-        # Neither is bunk_with → confidence decides (1.0 beats 0.75)
-        assert result.kept_requests[0].source_field == SourceField.SOCIALIZE_WITH
+        # bunking_notes (rank 2) beats socialize_with (rank 1) regardless of confidence
+        assert result.kept_requests[0].source_field == SourceField.BUNKING_NOTES
 
 
 class TestConflictTargetDemotion:


### PR DESCRIPTION
## Summary

Stage 3 of issue #1142 — replace the two-axis dedup tiebreak in
`deduplicator.py` (`SOURCE_PRIORITY` dict + `bunk_with`-bias) with a single
`SOURCE_FIELD_PRIORITY` map keyed by `source_field`. Also delete the dead
`SOURCE_FIELD_TO_SOURCE` map in `core/constants.py`.

Ordering encodes the materiality model already implicit in the priority
calculator:

| Rank | source_field      | Category            |
|------|-------------------|---------------------|
| 4    | `bunk_with`       | material parent     |
| 3    | `not_bunk_with`   | staff exclusion     |
| 2    | `bunking_notes`   | staff observation   |
| 2    | `internal_notes`  | staff observation   |
| 1    | `socialize_with`  | immaterial parent   |

`confidence_score` breaks ties within rank.

## Behavior change

`socialize_with` (FAMILY immaterial) now loses tiebreak vs any staff field.
Aligns with the priority calculator's existing weights
(`parent_age_preference`=1 < `staff_notes`=2). Realistic occurrence rate
is low — `socialize_with` is primarily age preference, rare to dedupe-collide
with staff name fields.

## Tests

- 1 rewritten in place: `test_source_priority_only_staff_and_family` →
  `test_source_field_priority_structure` (locks new map shape)
- 3 new tests pinning the ordering:
  - `test_not_bunk_with_beats_socialize_with_in_dedup`
  - `test_bunking_notes_beats_socialize_with_in_dedup`
  - `test_bunking_notes_and_internal_notes_tied_confidence_breaks`
- 4 existing tests updated to reflect new policy:
  - `test_age_preference_from_different_sources_deduplicated`
  - `test_age_preference_conflicting_values_highest_priority_wins`
  - `test_age_preference_with_is_placeholder_true_deduplicates_across_sources`
  - `test_confidence_still_tiebreaks_when_both_non_bunk_with` →
    renamed `test_rank_dominates_confidence_when_both_non_bunk_with`

  Three of these were also using legacy CM raw field name
  `ret_parent_socialize_with_best` instead of canonical `SourceField.SOCIALIZE_WITH`
  — corrected to canonical values.
- 30 existing tests pass unchanged (all `bunk_with`-on-FAMILY-side cases still pass)
- 3 test docstrings updated to reflect materiality rationale

**Final test count: 38 passing in `test_deduplicator.py`; 1789 passing in
`tests/unit/sync/bunk_request_processor/`.**

## Out of scope

- Stage 4 — drop the `bunk_requests.source` schema column (separate PR)
- Stage 5 — sweep remaining `RequestSource` callsites at `validation.py:292`,
  `social_graph_builder.py:109/397/437` (separate PR)
- Priority calculator rule-key consolidation — `family_not_bunk_with` and
  `staff_not_bunk_with` are independent priority dimensions; not redundancy.

## Test plan

- [x] All 38 tests in `test_deduplicator.py` pass
- [x] Full `tests/unit/sync/bunk_request_processor/` suite passes (1789 passed)
- [x] `lefthook run pre-push` passes (ruff, mypy, golangci-lint, eslint, prettier, tsc, pb-js-lint, shellcheck, api-types-freshness, go-build)
- [ ] CI green
- [ ] Reviewer spot-check: `SOURCE_FIELD_PRIORITY` ordering matches the
      materiality model.

Refs #1142 (stage 3 of 5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the deduplication logic to use a materiality-based priority ranking system for identifying and processing duplicate requests. The system now prioritizes requests by source field type before using confidence scores as a tiebreaker, improving accuracy in duplicate detection and resolution.

* **Tests**
  * Updated test suite to validate the new deduplication ranking model and ensure proper handling of competing request records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->