### PR TITLE
fix(scripts): repair verify-consolidation harness + skill rule updates

### DIFF
--- a/.claude/skills/consolidate-migrations/SKILL.md
+++ b/.claude/skills/consolidate-migrations/SKILL.md
@@ -124,6 +124,23 @@ unless the user overrides explicitly.
 Hold for user input. Don't auto-pick. If the user says "you choose,"
 suggest the highest re-tallied count from Step 2.
 
+## Step 4a: Create a worktree for this round
+
+Every consolidation round happens in a worktree, never the main repo folder.
+Even if the user invokes the skill from `~/kindred`, create a worktree.
+
+```bash
+WORKTREE_NAME="consolidate-${TABLE}-$(date +%Y%m%d)"
+"$MAIN_REPO/scripts/worktree/new.sh" "$WORKTREE_NAME"
+WORKTREE_DIR="$HOME/kindred-worktrees/$WORKTREE_NAME"
+```
+
+All filesystem writes from Step 7 onward target `$WORKTREE_DIR/...`, NEVER
+`$MAIN_REPO/...`. The tracking doc is the only artifact in `$MAIN_REPO`
+(gitignored, not branched).
+
+If a worktree with that name already exists, append `-$(date +%H%M)` and retry.
+
 ## Step 5: Walk the chosen table's migration chain
 
 For the chosen table T, enumerate every file that mutates T. For each,
@@ -165,16 +182,16 @@ SCRATCH=$(mktemp -d -t pb-consolidate-XXXX)
 trap 'rm -rf "$SCRATCH"' EXIT INT TERM
 
 mkdir -p "$SCRATCH/proposed"
-cp "$MAIN_REPO"/pocketbase/pb_migrations/*.js "$SCRATCH/proposed/"
+cp "$WORKTREE_DIR"/pocketbase/pb_migrations/*.js "$SCRATCH/proposed/"
 
 # 1) Replace base CREATE with the merged version
 # 2) Delete absorbed files from $SCRATCH/proposed/
 # 3) Trim multi-table files (write trimmed versions in-place)
 # (do these steps with Write/Edit tools using the in-memory mutation log)
 
-"$MAIN_REPO/scripts/dev/verify-consolidation.sh" \
+"$WORKTREE_DIR/scripts/dev/verify-consolidation.sh" \
   "$SCRATCH/proposed" \
-  "$MAIN_REPO/pocketbase/pb_migrations"
+  "$WORKTREE_DIR/pocketbase/pb_migrations"
 ```
 
 Exit 0: proceed to Step 8. Exit 1: drift detected. Save the diff output
@@ -246,3 +263,38 @@ See spec §"Edge cases" for full detail. Quick reference:
    override only with explicit user statement.
 6. **Hardcoded collection IDs** — preserve verbatim in merged CREATE.
 7. **Indexes** — only the final set in the merged CREATE.
+8. **Merged CREATE comments** — the merged file reads like a fresh CREATE
+   migration. Do NOT include comments referencing absorbed/deleted file
+   numbers ("From #1500000092", "added in #095", consolidated-migrations
+   block headers, etc.). Those filenames vanish after the round ships and
+   the references rot. Keep functional comments only when they explain WHY
+   a non-obvious value was chosen ("max=200 because CampMinder caps name
+   at 200"). The commit message and tracking-doc per-round detail block
+   carry the historical context.
+9. **Collapse `app.save()` calls — only when truly redundant**
+
+   When the original CREATE used multiple `app.save()` calls, evaluate
+   whether the consolidated form still needs them. Three patterns to
+   recognize:
+
+   a. **Self-referencing relation (collapsible)** — original does
+      `app.save(collection)` then `collection.fields.add(new Field({...,
+      collectionId: SELF_ID}))` then `app.save(collection)`. With a
+      hardcoded collection-ID constant defined before the constructor,
+      the self-relation can move into the initial `fields:` array.
+      **Collapse to one save.**
+
+   b. **Seed-data inserts (NOT collapsible)** — original does
+      `app.save(collection)` then `new Record(collection)` followed by
+      `app.save(record)` for each seed row. The Record constructor needs
+      a saved collection (it copies the schema by reference). **Keep
+      multi-save.** Pattern is common for `config`, `roles`, and other
+      lookup-style tables.
+
+   c. **Cross-collection circular refs (NOT collapsible)** — rare; two
+      collections reference each other via relation fields and neither
+      can be created with both fields populated. Keep both saves; document
+      in the commit message.
+
+   The verification harness must still pass after any collapse — if a
+   collapse breaks the diff, restore the original multi-save structure.

--- a/scripts/dev/test-verify-consolidation.sh
+++ b/scripts/dev/test-verify-consolidation.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Test for verify-consolidation.sh
+# Verifies the documented exit contract:
+#   0 — proposed and current migration sets produce identical schemas
+#   1 — schemas differ
+#   2 — harness error (missing dir, smoke check failed, serve never came up, ...)
+#
+# Critically: exercises the END-TO-END harness against real migration sets,
+# not hand-crafted SQLite fixtures. The original v1 harness silently skipped
+# JS migrations and reported "schemas match" for empty schemas; this test
+# would have failed red on that bug (tests 2 and 3 specifically).
+
+set -euo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$HERE/../.." && pwd)
+VERIFY_SCRIPT="$HERE/verify-consolidation.sh"
+MIGRATIONS_DIR="$REPO_ROOT/pocketbase/pb_migrations"
+
+if [[ ! -x "$VERIFY_SCRIPT" ]]; then
+  echo "FAIL: $VERIFY_SCRIPT not executable or missing" >&2
+  exit 1
+fi
+
+if [[ ! -d "$MIGRATIONS_DIR" ]]; then
+  echo "FAIL: $MIGRATIONS_DIR not found (expected real migration set for E2E test)" >&2
+  exit 1
+fi
+
+SCRATCH=$(mktemp -d -t pb-verify-test-XXXX)
+trap 'rm -rf "$SCRATCH"' EXIT INT TERM
+
+echo "=== TEST 1: identical real migration sets should exit 0 ==="
+if "$VERIFY_SCRIPT" "$MIGRATIONS_DIR" "$MIGRATIONS_DIR" >/dev/null 2>"$SCRATCH/t1.err"; then
+  echo "PASS: identical real sets returned 0"
+else
+  rc=$?
+  echo "FAIL: identical real sets returned $rc; stderr:" >&2
+  cat "$SCRATCH/t1.err" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 2: drift in a real migration should exit 1 ==="
+mkdir -p "$SCRATCH/modified"
+cp "$MIGRATIONS_DIR"/*.js "$SCRATCH/modified/"
+# Produce reliable structural drift by omitting the LAST migration
+# (1500000102_drop_bunk_assignments_is_deleted.js). Without it, the proposed
+# DB retains the is_deleted field on bunk_assignments; the current DB drops it.
+# This avoids the fragile listRule approach where a later migration can
+# silently overwrite the mutation, causing a false "schemas match" result.
+LAST_MIGRATION="1500000102_drop_bunk_assignments_is_deleted.js"
+if [[ ! -f "$SCRATCH/modified/$LAST_MIGRATION" ]]; then
+  echo "FAIL: expected $LAST_MIGRATION in migration set (file renamed/removed?)" >&2
+  exit 1
+fi
+rm "$SCRATCH/modified/$LAST_MIGRATION"
+set +e
+"$VERIFY_SCRIPT" "$SCRATCH/modified" "$MIGRATIONS_DIR" >/dev/null 2>"$SCRATCH/t2.err"
+rc=$?
+set -e
+if [[ $rc -eq 1 ]]; then
+  echo "PASS: drift detected (exit 1)"
+else
+  echo "FAIL: drift expected exit 1, got $rc; stderr:" >&2
+  cat "$SCRATCH/t2.err" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 3: empty migrations dir should fail smoke check (exit 2) ==="
+mkdir -p "$SCRATCH/empty"
+set +e
+"$VERIFY_SCRIPT" "$SCRATCH/empty" "$MIGRATIONS_DIR" >/dev/null 2>"$SCRATCH/t3.err"
+rc=$?
+set -e
+if [[ $rc -eq 2 ]] && grep -q "smoke check failed" "$SCRATCH/t3.err"; then
+  echo "PASS: empty migrations dir → exit 2 with smoke check error"
+else
+  echo "FAIL: empty migrations dir expected exit 2 + 'smoke check failed' in stderr, got rc=$rc" >&2
+  echo "stderr:" >&2
+  cat "$SCRATCH/t3.err" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 4: nonexistent input dir should exit 2 (harness error) ==="
+set +e
+"$VERIFY_SCRIPT" "$SCRATCH/nonexistent" "$MIGRATIONS_DIR" >/dev/null 2>"$SCRATCH/t4.err"
+rc=$?
+set -e
+if [[ $rc -eq 2 ]]; then
+  echo "PASS: nonexistent input → exit 2"
+else
+  echo "FAIL: nonexistent input expected exit 2, got $rc" >&2
+  exit 1
+fi
+
+echo
+echo "All tests passed."

--- a/scripts/dev/test-verify-consolidation.sh
+++ b/scripts/dev/test-verify-consolidation.sh
@@ -43,20 +43,27 @@ fi
 echo
 echo "=== TEST 2: drift in a real migration should exit 1 ==="
 mkdir -p "$SCRATCH/modified"
-cp "$MIGRATIONS_DIR"/*.js "$SCRATCH/modified/"
+# Enumerate via nullglob so an empty $MIGRATIONS_DIR fails with a clear
+# "no .js files" message instead of `cp` exiting under set -e on an
+# unexpanded literal `*.js`.
+shopt -s nullglob
+migrations=("$MIGRATIONS_DIR"/*.js)
+shopt -u nullglob
+if [[ ${#migrations[@]} -eq 0 ]]; then
+  echo "FAIL: no .js files in $MIGRATIONS_DIR" >&2
+  exit 1
+fi
+cp "${migrations[@]}" "$SCRATCH/modified/"
 # Produce reliable structural drift by omitting the LAST migration
-# (lexicographically highest .js file). Picked dynamically so this test
-# survives consolidation rounds that absorb the previous tail file.
+# (lexicographically highest .js file). Bash globs sort alphabetically,
+# so the array's last element is the tail file. Picked dynamically so
+# this test survives consolidation rounds that absorb the previous tail.
 # Caveat: this assumes the tail migration produces some structural diff
 # when removed. If a future tail migration is purely a no-op-on-fresh-DB
 # (e.g. fully overwritten by a later mutation), this test could go green
 # spuriously — the harness's smoke check still guarantees something was
 # applied, but the drift signal would be weak.
-LAST_MIGRATION=$(find "$SCRATCH/modified" -maxdepth 1 -name '*.js' -printf '%f\n' | sort | tail -1)
-if [[ -z "$LAST_MIGRATION" ]]; then
-  echo "FAIL: no .js files in $SCRATCH/modified after copy from $MIGRATIONS_DIR" >&2
-  exit 1
-fi
+LAST_MIGRATION=$(basename "${migrations[-1]}")
 rm "$SCRATCH/modified/$LAST_MIGRATION"
 set +e
 "$VERIFY_SCRIPT" "$SCRATCH/modified" "$MIGRATIONS_DIR" >/dev/null 2>"$SCRATCH/t2.err"

--- a/scripts/dev/test-verify-consolidation.sh
+++ b/scripts/dev/test-verify-consolidation.sh
@@ -45,13 +45,16 @@ echo "=== TEST 2: drift in a real migration should exit 1 ==="
 mkdir -p "$SCRATCH/modified"
 cp "$MIGRATIONS_DIR"/*.js "$SCRATCH/modified/"
 # Produce reliable structural drift by omitting the LAST migration
-# (1500000102_drop_bunk_assignments_is_deleted.js). Without it, the proposed
-# DB retains the is_deleted field on bunk_assignments; the current DB drops it.
-# This avoids the fragile listRule approach where a later migration can
-# silently overwrite the mutation, causing a false "schemas match" result.
-LAST_MIGRATION="1500000102_drop_bunk_assignments_is_deleted.js"
-if [[ ! -f "$SCRATCH/modified/$LAST_MIGRATION" ]]; then
-  echo "FAIL: expected $LAST_MIGRATION in migration set (file renamed/removed?)" >&2
+# (lexicographically highest .js file). Picked dynamically so this test
+# survives consolidation rounds that absorb the previous tail file.
+# Caveat: this assumes the tail migration produces some structural diff
+# when removed. If a future tail migration is purely a no-op-on-fresh-DB
+# (e.g. fully overwritten by a later mutation), this test could go green
+# spuriously — the harness's smoke check still guarantees something was
+# applied, but the drift signal would be weak.
+LAST_MIGRATION=$(find "$SCRATCH/modified" -maxdepth 1 -name '*.js' -printf '%f\n' | sort | tail -1)
+if [[ -z "$LAST_MIGRATION" ]]; then
+  echo "FAIL: no .js files in $SCRATCH/modified after copy from $MIGRATIONS_DIR" >&2
   exit 1
 fi
 rm "$SCRATCH/modified/$LAST_MIGRATION"
@@ -100,8 +103,10 @@ echo
 echo "=== TEST 5: relative-path invocation should still work (regression for canonicalization fix) ==="
 # This catches the symlink-with-relative-path footgun. Before canonicalization,
 # the harness silently failed when called with relative paths from any cwd.
+set +e
 ( cd "$REPO_ROOT" && "$VERIFY_SCRIPT" pocketbase/pb_migrations pocketbase/pb_migrations >/dev/null 2>"$SCRATCH/t5.err" )
 rc=$?
+set -e
 if [[ $rc -eq 0 ]]; then
   echo "PASS: relative paths handled correctly"
 else

--- a/scripts/dev/test-verify-consolidation.sh
+++ b/scripts/dev/test-verify-consolidation.sh
@@ -97,4 +97,18 @@ else
 fi
 
 echo
+echo "=== TEST 5: relative-path invocation should still work (regression for canonicalization fix) ==="
+# This catches the symlink-with-relative-path footgun. Before canonicalization,
+# the harness silently failed when called with relative paths from any cwd.
+( cd "$REPO_ROOT" && "$VERIFY_SCRIPT" pocketbase/pb_migrations pocketbase/pb_migrations >/dev/null 2>"$SCRATCH/t5.err" )
+rc=$?
+if [[ $rc -eq 0 ]]; then
+  echo "PASS: relative paths handled correctly"
+else
+  echo "FAIL: relative-path invocation expected exit 0, got $rc; stderr:" >&2
+  cat "$SCRATCH/t5.err" >&2
+  exit 1
+fi
+
+echo
 echo "All tests passed."

--- a/scripts/dev/verify-consolidation.sh
+++ b/scripts/dev/verify-consolidation.sh
@@ -28,6 +28,16 @@ for d in "$PROPOSED_DIR" "$CURRENT_DIR"; do
   fi
 done
 
+# Canonicalize to absolute paths so the symlink in pb_apply() resolves
+# correctly regardless of whether the caller passed relative or absolute paths.
+PROPOSED_DIR=$(cd "$PROPOSED_DIR" && pwd)
+CURRENT_DIR=$(cd "$CURRENT_DIR" && pwd)
+
+# PB v0.37 ships 6 default collections (_authOrigins, _externalAuths, _mfas,
+# _otps, _superusers, users). Smoke check uses this as a lower bound — if a
+# future PB version ships more or fewer defaults, update this constant.
+PB_DEFAULT_COLLECTIONS=6
+
 if [[ ! -x "$DIFF_SCRIPT" ]]; then
   echo "error: $DIFF_SCRIPT missing or not executable" >&2
   exit 2
@@ -73,6 +83,8 @@ pb_apply() {
               --automigrate=true \
               > "$log" 2>&1 &
   local pid=$!
+  # Ensure backgrounded PB is cleaned up on every exit path from this function.
+  trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true' RETURN
 
   local ok=0
   for _ in $(seq 1 100); do
@@ -82,8 +94,8 @@ pb_apply() {
     sleep 0.1
   done
 
-  kill "$pid" 2>/dev/null
-  wait "$pid" 2>/dev/null
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
   rm -rf "$hooks_dir"
 
   if [[ "$ok" -ne 1 ]]; then
@@ -95,8 +107,8 @@ pb_apply() {
   local coll_count js_mig_count
   coll_count=$(sqlite3 "$db_dir/data.db" "SELECT COUNT(*) FROM _collections")
   js_mig_count=$(sqlite3 "$db_dir/data.db" "SELECT COUNT(*) FROM _migrations WHERE file LIKE '%.js'")
-  if [[ "$coll_count" -le 6 ]]; then
-    echo "error: smoke check failed — $coll_count collections in $db_dir (expected >6, only PB defaults applied)" >&2
+  if [[ "$coll_count" -le "$PB_DEFAULT_COLLECTIONS" ]]; then
+    echo "error: smoke check failed — $coll_count collections in $db_dir (expected >$PB_DEFAULT_COLLECTIONS, only PB defaults applied)" >&2
     exit 2
   fi
   if [[ "$js_mig_count" -lt 1 ]]; then

--- a/scripts/dev/verify-consolidation.sh
+++ b/scripts/dev/verify-consolidation.sh
@@ -38,6 +38,73 @@ fi
 SCRATCH=$(mktemp -d -t pb-verify-XXXX)
 trap 'rm -rf "$SCRATCH"' EXIT INT TERM
 
+# Apply all migrations in $mig_dir to a fresh DB at $db_dir via serve-and-kill.
+# Uses PB's real boot path (automigrate=true) which loads JS migrations through
+# the jsvm plugin — this is the only invocation path that actually runs them.
+# Plain `migrate up` silently skips JS migrations (PB v0.37 behavior, observed
+# 2026-05-08 during first consolidation round).
+#
+# IMPORTANT: jsvm.MustRegister() reads MigrationsDir before cobra parses CLI
+# flags (it runs at plugin registration time, not at serve time). Passing
+# --migrationsDir is therefore a no-op for jsvm — jsvm always falls back to
+# its default: filepath.Join(app.DataDir(), "../pb_migrations"). We exploit
+# this by symlinking $db_dir/../pb_migrations -> $mig_dir so the default
+# resolution lands on our scratch copy.
+#
+# Args: <db_dir> <migrations_dir> <log_path>
+# Exits the harness (exit 2) on serve-failure or empty-apply (smoke check).
+pb_apply() {
+  local db_dir="$1" mig_dir="$2" log="$3"
+  local hooks_dir
+  hooks_dir=$(mktemp -d -t pb-empty-hooks-XXXX)
+
+  # Symlink pb_migrations next to db_dir so jsvm's default path resolution
+  # finds $mig_dir when it computes filepath.Join(app.DataDir(), "../pb_migrations").
+  local parent_dir
+  parent_dir=$(dirname "$db_dir")
+  ln -sfn "$mig_dir" "$parent_dir/pb_migrations"
+
+  local port
+  port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+
+  "$SCRATCH/pocketbase" serve --http="127.0.0.1:$port" \
+              --dir "$db_dir" \
+              --hooksDir "$hooks_dir" \
+              --automigrate=true \
+              > "$log" 2>&1 &
+  local pid=$!
+
+  local ok=0
+  for _ in $(seq 1 100); do
+    if curl -sf "http://127.0.0.1:$port/api/health" >/dev/null 2>&1; then
+      ok=1; break
+    fi
+    sleep 0.1
+  done
+
+  kill "$pid" 2>/dev/null
+  wait "$pid" 2>/dev/null
+  rm -rf "$hooks_dir"
+
+  if [[ "$ok" -ne 1 ]]; then
+    echo "error: pocketbase serve never came up against $mig_dir; log:" >&2
+    cat "$log" >&2
+    exit 2
+  fi
+
+  local coll_count js_mig_count
+  coll_count=$(sqlite3 "$db_dir/data.db" "SELECT COUNT(*) FROM _collections")
+  js_mig_count=$(sqlite3 "$db_dir/data.db" "SELECT COUNT(*) FROM _migrations WHERE file LIKE '%.js'")
+  if [[ "$coll_count" -le 6 ]]; then
+    echo "error: smoke check failed — $coll_count collections in $db_dir (expected >6, only PB defaults applied)" >&2
+    exit 2
+  fi
+  if [[ "$js_mig_count" -lt 1 ]]; then
+    echo "error: smoke check failed — 0 .js entries in _migrations ($db_dir); jsvm migration loading broke" >&2
+    exit 2
+  fi
+}
+
 echo ">> building pocketbase binary..."
 ( cd "$REPO_ROOT/pocketbase" && go build -o "$SCRATCH/pocketbase" . ) > "$SCRATCH/build.log" 2>&1 \
   || { echo "pocketbase build failed; log:"; cat "$SCRATCH/build.log"; exit 2; }
@@ -45,16 +112,10 @@ echo ">> building pocketbase binary..."
 mkdir -p "$SCRATCH/db_a" "$SCRATCH/db_b"
 
 echo ">> applying PROPOSED migrations to DB-A..."
-"$SCRATCH/pocketbase" migrate up \
-    --dir "$SCRATCH/db_a" \
-    --migrationsDir "$PROPOSED_DIR" > "$SCRATCH/db_a.log" 2>&1 \
-  || { echo "DB-A migrate failed; log:"; cat "$SCRATCH/db_a.log"; exit 2; }
+pb_apply "$SCRATCH/db_a" "$PROPOSED_DIR" "$SCRATCH/db_a.log"
 
 echo ">> applying CURRENT migrations to DB-B..."
-"$SCRATCH/pocketbase" migrate up \
-    --dir "$SCRATCH/db_b" \
-    --migrationsDir "$CURRENT_DIR" > "$SCRATCH/db_b.log" 2>&1 \
-  || { echo "DB-B migrate failed; log:"; cat "$SCRATCH/db_b.log"; exit 2; }
+pb_apply "$SCRATCH/db_b" "$CURRENT_DIR" "$SCRATCH/db_b.log"
 
 echo ">> diffing schemas..."
 "$DIFF_SCRIPT" "$SCRATCH/db_a" "$SCRATCH/db_b"

--- a/scripts/dev/verify-consolidation.sh
+++ b/scripts/dev/verify-consolidation.sh
@@ -66,10 +66,15 @@ trap 'rm -rf "$SCRATCH"' EXIT INT TERM
 pb_apply() {
   local db_dir="$1" mig_dir="$2" log="$3"
   local hooks_dir
-  hooks_dir=$(mktemp -d -t pb-empty-hooks-XXXX)
+  # Place hooks_dir under $SCRATCH so the outer EXIT trap reclaims it on every
+  # exit path, including the `exit 2` harness-error branches below.
+  hooks_dir=$(mktemp -d "$SCRATCH/pb-empty-hooks-XXXX")
 
   # Symlink pb_migrations next to db_dir so jsvm's default path resolution
   # finds $mig_dir when it computes filepath.Join(app.DataDir(), "../pb_migrations").
+  # Caller is responsible for placing $db_dir under its own parent directory
+  # (not a shared $SCRATCH) so the symlink target doesn't collide between
+  # successive pb_apply() invocations.
   local parent_dir
   parent_dir=$(dirname "$db_dir")
   ln -sfn "$mig_dir" "$parent_dir/pb_migrations"
@@ -96,7 +101,6 @@ pb_apply() {
 
   kill "$pid" 2>/dev/null || true
   wait "$pid" 2>/dev/null || true
-  rm -rf "$hooks_dir"
 
   if [[ "$ok" -ne 1 ]]; then
     echo "error: pocketbase serve never came up against $mig_dir; log:" >&2
@@ -121,13 +125,19 @@ echo ">> building pocketbase binary..."
 ( cd "$REPO_ROOT/pocketbase" && go build -o "$SCRATCH/pocketbase" . ) > "$SCRATCH/build.log" 2>&1 \
   || { echo "pocketbase build failed; log:"; cat "$SCRATCH/build.log"; exit 2; }
 
-mkdir -p "$SCRATCH/db_a" "$SCRATCH/db_b"
+# Each DB lives under its own slot directory so pb_apply's symlink target
+# ($parent_dir/pb_migrations) is unique per call. Without this, both calls
+# would target $SCRATCH/pb_migrations and the second invocation would clobber
+# the first's symlink. Sequential execution masks the bug today, but the
+# isolation costs nothing and makes the harness robust to future parallelism
+# or PB internals changes.
+mkdir -p "$SCRATCH/slot_a/db_a" "$SCRATCH/slot_b/db_b"
 
 echo ">> applying PROPOSED migrations to DB-A..."
-pb_apply "$SCRATCH/db_a" "$PROPOSED_DIR" "$SCRATCH/db_a.log"
+pb_apply "$SCRATCH/slot_a/db_a" "$PROPOSED_DIR" "$SCRATCH/db_a.log"
 
 echo ">> applying CURRENT migrations to DB-B..."
-pb_apply "$SCRATCH/db_b" "$CURRENT_DIR" "$SCRATCH/db_b.log"
+pb_apply "$SCRATCH/slot_b/db_b" "$CURRENT_DIR" "$SCRATCH/db_b.log"
 
 echo ">> diffing schemas..."
-"$DIFF_SCRIPT" "$SCRATCH/db_a" "$SCRATCH/db_b"
+"$DIFF_SCRIPT" "$SCRATCH/slot_a/db_a" "$SCRATCH/slot_b/db_b"


### PR DESCRIPTION
## Summary

Three connected fixes that emerged from the rolled-back round-1 attempt at consolidating `bunk_requests` migrations on 2026-05-08:

- **`verify-consolidation.sh` was broken.** PB v0.37's CLI `migrate up` silently skips every `.js` migration in `--migrationsDir` (only built-in Go migrations register). Both scratch DBs in the harness ended up with the 6 PB-default collections, so every diff trivially matched `schemas match` regardless of what the merged CREATE contained. Fix: replace `migrate up` with a `pb_apply()` helper that does serve-and-kill (uses PB's real boot path via `automigrate=true`), plus a belt+suspenders smoke check (`_collections > 6` AND `_migrations` contains ≥1 `.js` filename).

- **No regression coverage for the harness.** The existing `test-migration-schema-diff.sh` only exercised the diff script with hand-crafted SQLite fixtures. New `test-verify-consolidation.sh` runs end-to-end against the real `pb_migrations/` tree. Tests 2 and 3 fail red on the unfixed harness — proving the test catches the bug class.

- **Three skill-quality rules baked into `SKILL.md`:** (1) new Step 4a creates a worktree for every round, (2) merged CREATE migrations contain no breadcrumb comments referencing absorbed file numbers, (3) `app.save()` collapse must distinguish three patterns (self-refs collapse, seed inserts and circular refs do not).

Two technical deviations from the original spec, both forced by PB internals (documented in commit messages):
- `--migrationsDir` flag is a no-op for `jsvm` (captured at plugin registration time, before cobra parses flags). Workaround: symlink the target migrations into the path jsvm's default resolution expects.
- Test 2's drift mutation pivoted from `listRule` rewrite (silently overwritten by a later migration) to omitting the last migration that drops a field — produces a deterministic structural diff.

## Test plan

- [ ] `bash scripts/dev/test-verify-consolidation.sh` — all 5 tests pass
- [ ] `bash scripts/dev/verify-consolidation.sh pocketbase/pb_migrations pocketbase/pb_migrations` — exits 0 with `schemas match`
- [ ] `bash scripts/dev/test-migration-schema-diff.sh` — still passes (no regression in the diff-script test)
- [ ] CI passes
- [ ] After merge: re-attempt round 1 (`bunk_requests`) in a follow-up session with the fixed harness and verify it produces a meaningful comparison this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive end-to-end verification suite that exercises consolidation scenarios and validates the verifier’s exit-code behavior and error messages.

* **Chores**
  * Hardened the consolidation verifier with absolute-path handling, improved application of migrations, stronger smoke checks, and more robust startup/error capture to better detect schema drift.

* **Documentation**
  * Expanded guidance on consolidation rounds, mandatory worktree usage, merged-file rules, and when saves may be collapsed versus preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->