### PR TITLE
refactor(sync): drop RequestSource enum, replace with string literals (#1142 stage 5)

### DIFF
--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -18,7 +18,7 @@ from bunking.models import Bunk, BunkAssignment, BunkRequest, Person, Session
 from bunking.satisfaction.predicate import is_request_satisfied
 from bunking.solver.constants import DEFAULT_BUNK_CAPACITY
 from bunking.solver.constraints.helpers import extract_bunk_level, get_level_order
-from bunking.sync.bunk_request_processor.core.models import RequestSource, source_from_field
+from bunking.sync.bunk_request_processor.core.models import source_from_field
 from bunking.sync.bunk_request_processor.shared.constants import (
     SOURCE_FIELD_TO_CONFIG_KEY,
     SourceField,
@@ -136,7 +136,7 @@ class ValidationStatistics(BaseModel):
     satisfied_best_effort_parent_requests: int = 0
     best_effort_parent_request_satisfaction_rate: float = 0.0
 
-    # Staff-source request tracking, per RequestSource.STAFF. Source fields:
+    # Staff-source request tracking (source_from_field returns "staff"). Source fields:
     # SourceField.NOT_BUNK_WITH (stats key "do_not_share_with"), BUNKING_NOTES,
     # INTERNAL_NOTES. Tracked separately because they don't satisfy the
     # "every camper gets one parent request" rule that Stage 4 will enforce.
@@ -530,7 +530,7 @@ class BunkingValidator:
                 # Staff binning derived from source_field via source_from_field helper (#1142).
                 raw_source_field = getattr(request, "source_field", None)
                 try:
-                    is_staff = source_from_field(raw_source_field) == RequestSource.STAFF if raw_source_field else False
+                    is_staff = source_from_field(raw_source_field) == "staff" if raw_source_field else False
                 except ValueError:
                     is_staff = False
 

--- a/bunking/sync/bunk_request_processor/core/models.py
+++ b/bunking/sync/bunk_request_processor/core/models.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 
 from ..shared.constants import (
     ACTIVE_ENROLLMENT_STATUSES,
@@ -34,48 +34,28 @@ class SessionFamily(Enum):
     FAMILY = "family"
 
 
-class RequestSource(Enum):
-    """Sources of bunk requests - simplified to two categories.
-
-    Note: Values must match PocketBase schema (see migration 1754196925)
-
-    FAMILY: Parent/family-submitted fields
-      - share_bunk_with (bunk_with)
-      - ret_parent_socialize_with_best (socialize_with)
-
-    STAFF: Staff-written fields (staff validates family input)
-      - do_not_share_bunk_with (not_bunk_with)
-      - bunking_notes
-      - internal_notes
-      - manual (admin-UI / CreateRequestModal — admin entry is staff entry)
-    """
-
-    FAMILY = "family"
-    STAFF = "staff"
-
-
-_SOURCE_FIELD_MAP: dict[str, RequestSource] = {
-    SourceField.BUNK_WITH: RequestSource.FAMILY,
-    SourceField.SOCIALIZE_WITH: RequestSource.FAMILY,
-    SourceField.NOT_BUNK_WITH: RequestSource.STAFF,
-    SourceField.BUNKING_NOTES: RequestSource.STAFF,
-    SourceField.INTERNAL_NOTES: RequestSource.STAFF,
-    SourceField.MANUAL: RequestSource.STAFF,
+_SOURCE_FIELD_MAP: dict[str, Literal["family", "staff"]] = {
+    SourceField.BUNK_WITH: "family",
+    SourceField.SOCIALIZE_WITH: "family",
+    SourceField.NOT_BUNK_WITH: "staff",
+    SourceField.BUNKING_NOTES: "staff",
+    SourceField.INTERNAL_NOTES: "staff",
+    SourceField.MANUAL: "staff",
 }
 
 
-def source_from_field(source_field: str) -> RequestSource:
-    """Derive RequestSource from a source_field value.
+def source_from_field(source_field: str) -> Literal["family", "staff"]:
+    """Derive the source classification ("family" or "staff") from a source_field value.
 
-    This is the authoritative 6→2 mapping that makes RequestSource a
-    deterministic projection of source_field rather than an independent axis.
+    This is the authoritative 6→2 mapping. After #1142 stage 5, "family" / "staff"
+    are plain strings — the former RequestSource enum is gone.
 
     Args:
         source_field: One of the 6 canonical SourceField values.
 
     Returns:
-        RequestSource.FAMILY for parent-visible fields (bunk_with, socialize_with).
-        RequestSource.STAFF for staff-entered channels (not_bunk_with, bunking_notes,
+        "family" for parent-visible fields (bunk_with, socialize_with).
+        "staff" for staff-entered channels (not_bunk_with, bunking_notes,
         internal_notes, manual). 'manual' is the admin-UI input channel for
         CreateRequestModal — admin entry is staff entry by definition.
 

--- a/bunking/sync/bunk_request_processor/processing/deduplicator.py
+++ b/bunking/sync/bunk_request_processor/processing/deduplicator.py
@@ -39,7 +39,7 @@ def _resolve_source(req: BunkRequest) -> str:
     fallback in the codebase.
     """
     try:
-        return source_from_field(req.source_field).value
+        return source_from_field(req.source_field)
     except ValueError:
         logger.debug(
             "deduplicator: unknown source_field %r, defaulting to 'family'",

--- a/bunking/sync/bunk_request_processor/shared/constants.py
+++ b/bunking/sync/bunk_request_processor/shared/constants.py
@@ -70,7 +70,8 @@ class SourceField:
 
     Five values describe CSV/form input channels (parent or staff). MANUAL is the
     sixth canonical value: the admin-UI input channel for staff-created requests
-    via CreateRequestModal. All non-parent channels project to RequestSource.STAFF.
+    via CreateRequestModal. All non-parent channels project to "staff" via
+    source_from_field().
     """
 
     BUNK_WITH = "bunk_with"

--- a/tests/unit/sync/bunk_request_processor/core/test_models.py
+++ b/tests/unit/sync/bunk_request_processor/core/test_models.py
@@ -213,7 +213,6 @@ class TestParsedRequest:
         """Test creating a bunk_with parsed request"""
         from bunking.sync.bunk_request_processor.core.models import (
             ParsedRequest,
-            RequestSource,
             RequestType,
             source_from_field,
         )
@@ -233,7 +232,7 @@ class TestParsedRequest:
         assert request.request_type == RequestType.BUNK_WITH
         assert request.target_name == "Johnny Smith"
         assert request.age_preference is None
-        assert source_from_field(request.source_field) == RequestSource.FAMILY
+        assert source_from_field(request.source_field) == "family"
         assert request.csv_position == 0
 
     def test_parsed_request_age_preference(self):
@@ -394,35 +393,26 @@ class TestResolvedName:
 
 
 class TestSourceFromField:
-    """Pin the canonical source_field → RequestSource projection (6→2 after #1142)."""
+    """Pin the canonical source_field → "family"/"staff" projection (6→2 after #1142)."""
 
     def test_manual_returns_staff(self):
         """'manual' is the admin-UI input channel — admin entry is always staff entry."""
-        from bunking.sync.bunk_request_processor.core.models import (
-            RequestSource,
-            source_from_field,
-        )
+        from bunking.sync.bunk_request_processor.core.models import source_from_field
 
-        assert source_from_field("manual") == RequestSource.STAFF
+        assert source_from_field("manual") == "staff"
 
     def test_canonical_family_fields_return_family(self):
-        from bunking.sync.bunk_request_processor.core.models import (
-            RequestSource,
-            source_from_field,
-        )
+        from bunking.sync.bunk_request_processor.core.models import source_from_field
 
-        assert source_from_field("bunk_with") == RequestSource.FAMILY
-        assert source_from_field("socialize_with") == RequestSource.FAMILY
+        assert source_from_field("bunk_with") == "family"
+        assert source_from_field("socialize_with") == "family"
 
     def test_canonical_staff_fields_return_staff(self):
-        from bunking.sync.bunk_request_processor.core.models import (
-            RequestSource,
-            source_from_field,
-        )
+        from bunking.sync.bunk_request_processor.core.models import source_from_field
 
-        assert source_from_field("not_bunk_with") == RequestSource.STAFF
-        assert source_from_field("bunking_notes") == RequestSource.STAFF
-        assert source_from_field("internal_notes") == RequestSource.STAFF
+        assert source_from_field("not_bunk_with") == "staff"
+        assert source_from_field("bunking_notes") == "staff"
+        assert source_from_field("internal_notes") == "staff"
 
     def test_unknown_source_field_raises_value_error(self):
         """Unknown input must raise ValueError — `_resolve_source` and

--- a/tests/unit/sync/bunk_request_processor/core/test_source_field_map_ts_parity.py
+++ b/tests/unit/sync/bunk_request_processor/core/test_source_field_map_ts_parity.py
@@ -1,4 +1,4 @@
-"""Cross-language drift guard for the source_field → RequestSource mapping.
+"""Cross-language drift guard for the source_field → "family"/"staff" mapping.
 
 Issue #1217. The same 5→2 mapping lives in two places:
 
@@ -50,7 +50,7 @@ def test_python_and_ts_source_field_maps_agree() -> None:
     assert _TS_FILE.exists(), f"missing TS source: {_TS_FILE}"
     ts_map = _parse_ts_source_field_map(_TS_FILE.read_text())
 
-    python_map = {key: source.value for key, source in _SOURCE_FIELD_MAP.items()}
+    python_map = dict(_SOURCE_FIELD_MAP)
 
     assert ts_map == python_map, (
         "source_field map drift between Python and TypeScript.\n"

--- a/tests/unit/sync/bunk_request_processor/core/test_source_from_field.py
+++ b/tests/unit/sync/bunk_request_processor/core/test_source_from_field.py
@@ -1,39 +1,41 @@
-"""Tests for source_from_field helper — Stage 1 of issue #1142.
+"""Tests for the source_from_field helper.
 
-Pins the 6→2 deterministic mapping from source_field values to RequestSource.
-Every classification is locked here so any future drift is caught immediately.
+Pins the 6→2 deterministic mapping from source_field values to "family" / "staff"
+strings. This is the authoritative spec — every other consumer derives from this.
 """
+
+from __future__ import annotations
 
 import pytest
 
-from bunking.sync.bunk_request_processor.core.models import RequestSource, source_from_field
+from bunking.sync.bunk_request_processor.core.models import source_from_field
 from bunking.sync.bunk_request_processor.shared.constants import SourceField
 
 
 class TestSourceFromFieldMapping:
-    """Pin every source_field → RequestSource classification."""
+    """Pin every source_field → string classification."""
 
     @pytest.mark.parametrize(
         ("source_field_value", "expected_source"),
         [
-            (SourceField.BUNK_WITH, RequestSource.FAMILY),
-            (SourceField.SOCIALIZE_WITH, RequestSource.FAMILY),
-            (SourceField.NOT_BUNK_WITH, RequestSource.STAFF),
-            (SourceField.BUNKING_NOTES, RequestSource.STAFF),
-            (SourceField.INTERNAL_NOTES, RequestSource.STAFF),
-            (SourceField.MANUAL, RequestSource.STAFF),
+            (SourceField.BUNK_WITH, "family"),
+            (SourceField.SOCIALIZE_WITH, "family"),
+            (SourceField.NOT_BUNK_WITH, "staff"),
+            (SourceField.BUNKING_NOTES, "staff"),
+            (SourceField.INTERNAL_NOTES, "staff"),
+            (SourceField.MANUAL, "staff"),
         ],
         ids=[
-            "bunk_with→FAMILY",
-            "socialize_with→FAMILY",
-            "not_bunk_with→STAFF",
-            "bunking_notes→STAFF",
-            "internal_notes→STAFF",
-            "manual→STAFF",
+            "bunk_with→family",
+            "socialize_with→family",
+            "not_bunk_with→staff",
+            "bunking_notes→staff",
+            "internal_notes→staff",
+            "manual→staff",
         ],
     )
-    def test_source_from_field_classification(self, source_field_value: str, expected_source: RequestSource) -> None:
-        """source_from_field returns the correct RequestSource for each SourceField."""
+    def test_source_from_field_classification(self, source_field_value: str, expected_source: str) -> None:
+        """source_from_field returns the correct string for each SourceField."""
         assert source_from_field(source_field_value) == expected_source
 
     def test_source_from_field_unknown_raises(self) -> None:
@@ -46,19 +48,20 @@ class TestSourceFromFieldMapping:
         with pytest.raises(ValueError, match="unknown source_field"):
             source_from_field("")
 
-    def test_source_from_field_returns_enum_member(self) -> None:
-        """source_from_field always returns a RequestSource enum member."""
+    def test_source_from_field_returns_string(self) -> None:
+        """source_from_field always returns a plain string, not an enum."""
         result = source_from_field(SourceField.BUNK_WITH)
-        assert isinstance(result, RequestSource)
+        assert isinstance(result, str)
+        assert result in ("family", "staff")
 
     def test_bunk_with_and_socialize_with_are_both_family(self) -> None:
-        """The two parent-visible fields both map to FAMILY."""
-        assert source_from_field(SourceField.BUNK_WITH) == RequestSource.FAMILY
-        assert source_from_field(SourceField.SOCIALIZE_WITH) == RequestSource.FAMILY
+        """The two parent-visible fields both map to "family"."""
+        assert source_from_field(SourceField.BUNK_WITH) == "family"
+        assert source_from_field(SourceField.SOCIALIZE_WITH) == "family"
 
     def test_all_notes_fields_are_staff(self) -> None:
-        """All four staff-written channels map to STAFF."""
-        assert source_from_field(SourceField.NOT_BUNK_WITH) == RequestSource.STAFF
-        assert source_from_field(SourceField.BUNKING_NOTES) == RequestSource.STAFF
-        assert source_from_field(SourceField.INTERNAL_NOTES) == RequestSource.STAFF
-        assert source_from_field(SourceField.MANUAL) == RequestSource.STAFF
+        """All four staff-written channels map to "staff"."""
+        assert source_from_field(SourceField.NOT_BUNK_WITH) == "staff"
+        assert source_from_field(SourceField.BUNKING_NOTES) == "staff"
+        assert source_from_field(SourceField.INTERNAL_NOTES) == "staff"
+        assert source_from_field(SourceField.MANUAL) == "staff"

--- a/tests/unit/sync/bunk_request_processor/integration/test_sdk_ai_provider.py
+++ b/tests/unit/sync/bunk_request_processor/integration/test_sdk_ai_provider.py
@@ -11,7 +11,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from bunking.sync.bunk_request_processor.core.models import (
-    RequestSource,
     RequestType,
 )
 from bunking.sync.bunk_request_processor.integration.ai_schemas import (
@@ -735,14 +734,6 @@ class TestSDKProviderRequestTypeMapping:
 
         for ai_type, expected_enum in mapping.items():
             assert expected_enum.value == ai_type or expected_enum.name.lower() == ai_type.replace("_", "_")
-
-    def test_source_type_mapping(self):
-        """AI source_type strings map to RequestSource enum."""
-
-        # Verify the enum values match what AI can output
-        # Note: NOTES was removed - AI "notes" output now maps to STAFF
-        assert RequestSource.FAMILY.value in ["family", "FAMILY"]
-        assert RequestSource.STAFF.value in ["staff", "STAFF"]
 
 
 class TestAIDisambiguationRankedSchema:

--- a/tests/unit/sync/bunk_request_processor/processing/test_deduplicator.py
+++ b/tests/unit/sync/bunk_request_processor/processing/test_deduplicator.py
@@ -15,7 +15,6 @@ sys.path.insert(0, str(project_root))
 
 from bunking.sync.bunk_request_processor.core.models import (
     BunkRequest,
-    RequestSource,
     RequestStatus,
     RequestType,
     source_from_field,
@@ -509,7 +508,7 @@ class TestDeduplicator:
         # Should deduplicate - only ONE kept (source priority first, then max confidence)
         assert len(result.kept_requests) == 1
         # FAMILY source wins over STAFF (#1088 parent-paramount flip), keeps max confidence from both
-        assert source_from_field(result.kept_requests[0].source_field) == RequestSource.FAMILY
+        assert source_from_field(result.kept_requests[0].source_field) == "family"
         assert result.kept_requests[0].confidence_score == 0.95  # Max confidence from both
         assert result.kept_requests[0].metadata["origin"] == "form"
         assert result.statistics["duplicates_removed"] == 1
@@ -611,7 +610,7 @@ class TestSimplifiedSourcePriority:
 
         # Family wins even with staff having a different source_field (source > confidence)
         assert len(result.kept_requests) == 1
-        assert source_from_field(result.kept_requests[0].source_field) == RequestSource.FAMILY
+        assert source_from_field(result.kept_requests[0].source_field) == "family"
         assert result.kept_requests[0].source_field == "bunk_with"
         assert result.statistics["duplicates_removed"] == 1
 
@@ -683,15 +682,6 @@ class TestSimplifiedSourcePriority:
         assert SOURCE_FIELD_PRIORITY[SourceField.NOT_BUNK_WITH] > SOURCE_FIELD_PRIORITY[SourceField.BUNKING_NOTES]
         assert SOURCE_FIELD_PRIORITY[SourceField.BUNKING_NOTES] == SOURCE_FIELD_PRIORITY[SourceField.INTERNAL_NOTES]
         assert SOURCE_FIELD_PRIORITY[SourceField.BUNKING_NOTES] > SOURCE_FIELD_PRIORITY[SourceField.SOCIALIZE_WITH]
-
-    def test_notes_enum_removed(self):
-        """Test that RequestSource.NOTES no longer exists.
-
-        All staff-written fields (bunking_notes, internal_notes, do_not_share_with)
-        should use RequestSource.STAFF.
-        """
-        # NOTES should not be a valid enum value
-        assert not hasattr(RequestSource, "NOTES")
 
     def test_not_bunk_with_beats_socialize_with_in_dedup(self):
         """Stage 3 ordering: not_bunk_with (STAFF exclusion, rank 3) outranks
@@ -941,7 +931,7 @@ class TestAgePreferenceDeduplication:
 
         # bunking_notes (rank 2) outranks socialize_with (rank 1) under #1142 Stage 3
         kept = result.kept_requests[0]
-        assert source_from_field(kept.source_field) == RequestSource.STAFF
+        assert source_from_field(kept.source_field) == "staff"
         assert kept.source_field == SourceField.BUNKING_NOTES
 
         # Confidence is boosted to max from all sources via merge_metadata
@@ -1000,7 +990,7 @@ class TestAgePreferenceDeduplication:
         # Deduplicated — bunking_notes (rank 2) wins over socialize_with (rank 1) under #1142 Stage 3
         assert len(result.kept_requests) == 1
         kept = result.kept_requests[0]
-        assert source_from_field(kept.source_field) == RequestSource.STAFF
+        assert source_from_field(kept.source_field) == "staff"
         assert kept.source_field == SourceField.BUNKING_NOTES
         assert kept.metadata["age_preference"] == "older"
         # Confidence boosted to max from all sources via merge_metadata
@@ -1211,7 +1201,7 @@ class TestAgePreferenceDeduplication:
         )
         assert result.statistics["duplicates_removed"] == 1
         # bunking_notes (rank 2) wins over socialize_with (rank 1) under #1142 Stage 3
-        assert source_from_field(result.kept_requests[0].source_field) == RequestSource.STAFF
+        assert source_from_field(result.kept_requests[0].source_field) == "staff"
         assert result.kept_requests[0].source_field == SourceField.BUNKING_NOTES
 
 
@@ -1219,7 +1209,7 @@ class TestParentAgePreferenceDeduplication:
     """Test Stage 1 parent-paramount fix: bunk_with source wins parent-vs-parent age_pref dedupe.
 
     When a parent submits an age preference both via bunk_with prose AND the
-    socialize_with checkbox, both become RequestSource.FAMILY with the same dedupe key.
+    socialize_with checkbox, both become "family" with the same dedupe key.
     The old sort was (SOURCE_PRIORITY, confidence_score) — the socialize_with dropdown
     gets a deterministic confidence=1.0 which beat the AI-parsed bunk_with at 0.85-0.95,
     so the wrong request was kept as primary.
@@ -1537,7 +1527,7 @@ class TestFamilyParamountTiebreak:
         survivor = result.kept_requests[0]
 
         # FAMILY is primary — origin of intent is authoritative
-        assert source_from_field(survivor.source_field) == RequestSource.FAMILY, (
+        assert source_from_field(survivor.source_field) == "family", (
             f"Expected FAMILY to be primary (parent-paramount); got {source_from_field(survivor.source_field)}"
         )
         assert survivor.source_field == SourceField.BUNK_WITH, (
@@ -1546,10 +1536,10 @@ class TestFamilyParamountTiebreak:
 
         # Staff row is the dropped duplicate
         assert len(result.duplicate_groups) == 1
-        assert source_from_field(result.duplicate_groups[0].primary.source_field) == RequestSource.FAMILY
+        assert source_from_field(result.duplicate_groups[0].primary.source_field) == "family"
         dropped = result.duplicate_groups[0].duplicates
         assert len(dropped) == 1
-        assert source_from_field(dropped[0].source_field) == RequestSource.STAFF
+        assert source_from_field(dropped[0].source_field) == "staff"
 
         # _merge_metadata must have folded the staff row's metadata into the survivor
         assert survivor.metadata.get("is_merged_duplicate") is True
@@ -1615,7 +1605,7 @@ class TestFamilyParamountTiebreak:
         survivor = result.kept_requests[0]
 
         # FAMILY wins as primary — parent-paramount
-        assert source_from_field(survivor.source_field) == RequestSource.FAMILY, (
+        assert source_from_field(survivor.source_field) == "family", (
             f"Expected FAMILY to win age_preference tiebreak (parent-paramount); got {source_from_field(survivor.source_field)}"
         )
 
@@ -1623,7 +1613,7 @@ class TestFamilyParamountTiebreak:
         assert len(result.duplicate_groups) == 1
         dropped = result.duplicate_groups[0].duplicates
         assert len(dropped) == 1
-        assert source_from_field(dropped[0].source_field) == RequestSource.STAFF
+        assert source_from_field(dropped[0].source_field) == "staff"
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -103,7 +103,7 @@ class MockBunkRequest:
     status: str = "resolved"
     priority: int = 5
     source_field: str | None = None
-    source: str | None = None  # "family" or "staff" (RequestSource enum value)
+    source: str | None = None  # "family" or "staff" (legacy column, derived via source_from_field post-#1142)
     ai_p1_reasoning: dict[str, Any] | None = None
     age_preference_target: str | None = None
 
@@ -870,7 +870,7 @@ def test_validation_statistics_has_parent_staff_breakdown_fields():
     assert stats.campers_with_unsatisfied_staff_requests == 0
 
 
-# Helpers for RequestSource binning tests
+# Helpers for family/staff binning tests
 # Use numeric string IDs per existing fixture convention
 
 
@@ -899,7 +899,7 @@ def _mock_request(
     requester,
     target,
     source_field,
-    source,  # "family", "staff", or None — RequestSource enum value
+    source,  # "family", "staff", or None — legacy column, derived via source_from_field post-#1142
     request_type="bunk_with",
     status="resolved",
 ):
@@ -914,7 +914,7 @@ def _mock_request(
 
 
 def test_validator_bins_parent_requests_separately_from_staff():
-    """material_parent (bunk_with source_field) and staff (RequestSource.STAFF) requests are counted separately."""
+    """material_parent (bunk_with source_field) and staff ("staff" via source_from_field) requests are counted separately."""
     session = _mock_session(cm_id="10000001", name="Test Session")
     persons = [_mock_person("20001"), _mock_person("20002")]
     bunks = [_mock_bunk("30001")]
@@ -1030,9 +1030,10 @@ def test_validator_skips_binning_for_requests_with_null_source_field():
 
 
 def test_validator_source_field_drives_binning_regardless_of_source_enum():
-    """source_field (not source enum) determines material vs best-effort vs staff bin.
-    A request with source_field=bunk_with and a legacy source="notes" value (not in
-    RequestSource enum) still bins as material_parent because source_field is bunk_with."""
+    """source_field (not the legacy source string) determines material vs best-effort vs staff bin.
+    A request with source_field=bunk_with and a legacy source="notes" value (no longer
+    a recognized "family"/"staff" string post-#1142) still bins as material_parent
+    because source_field is bunk_with."""
     session = _mock_session()
     persons = [_mock_person("20001"), _mock_person("20002")]
     bunks = [_mock_bunk("30001")]


### PR DESCRIPTION
## Summary

Stage 5 (final) of #1142. Drops the `RequestSource` enum from `bunking/sync/bunk_request_processor/core/models.py`. `source_from_field()` now returns `Literal["family", "staff"]` — plain strings instead of enum members. Last cleanup stage of the source-field consolidation.

After this PR, `RequestSource` does not exist anywhere in the Python codebase. The frontend already used a local `type RequestSource = 'family' | 'staff'` Literal alias — symmetry with Python is now restored.

### What changes

- **`core/models.py`** — deleted the `RequestSource(Enum)` class. `_SOURCE_FIELD_MAP` retyped to `dict[str, Literal["family", "staff"]]`. `source_from_field()` retyped to return `Literal["family", "staff"]`.
- **`processing/deduplicator.py`** — `_resolve_source` no longer accesses `.value` on the helper return (the return is already a string).
- **`bunking_validator.py`** — dropped the `RequestSource` import; the lone callsite now compares `source_from_field(...) == "staff"` instead of `== RequestSource.STAFF`.
- **`shared/constants.py`** — updated `SourceField` docstring to refer to the string `"staff"` rather than the deleted enum.
- **Tests** — stripped `RequestSource` imports and comparisons from 5 test files. Deleted two dead tests that only existed to assert properties of the enum: `test_notes_enum_removed` (in `test_deduplicator.py`) and `test_source_type_mapping` (in `test_sdk_ai_provider.py`). Both were testing the absence/presence of enum members, which is now structurally enforced (no enum exists).
- **TS↔Python parity drift guard** — still passes; `_SOURCE_FIELD_MAP` values are now strings, so the parity test simplifies from `source.value` to `source`.

### Test plan
- [x] mypy clean (261 source files, 0 errors)
- [x] All 4228 Python unit tests pass (1987 in sync + validator subset)
- [x] All 3873 frontend tests pass (no frontend changes)
- [x] ruff format + check clean, prettier clean, eslint 0 errors, pb-js-lint clean, go build clean
- [x] TS↔Python parity drift guard still validates the 6→2 mapping

### Stage history

- Stage 1+2 (#1210) — `source_from_field()` helper + read-site migration
- Stage 3 (#1237) — collapsed two-axis dedup tiebreak to single `SOURCE_FIELD_PRIORITY`
- Stage 4 (#1240) — dropped the `bunk_requests.source` column + dataclass field
- Stage 5 (this PR) — dropped the enum entirely

Follow-up smells from #1142 (now spawned as separate tickets, out of scope here):

- #1245 — AGE_PREFERENCE placeholder rethink
- #1246 — `bunk_with` naming collision (RequestType vs SourceField)

Closes #1142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified request source categorization logic by transitioning from enumerated types to direct string classifications. Updated validation, deduplication processing, and request source tracking accordingly. All associated unit and integration tests have been updated to maintain consistent behavior across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->