### PR TITLE
docs(scripts): consolidate-migrations auto-PRs and auto-runs scan-it

### DIFF
--- a/.claude/skills/consolidate-migrations/SKILL.md
+++ b/.claude/skills/consolidate-migrations/SKILL.md
@@ -298,7 +298,7 @@ Add cross-cutting findings if anything novel surfaced (e.g., a
 multi-table migration was trimmed and the remainder is queued for another
 table's future round).
 
-## Step 10: Print summary, hand back
+## Step 10: Print summary
 
 | Field | Value |
 |-------|-------|
@@ -307,15 +307,84 @@ table's future round).
 | Files absorbed | M (deleted) + K (trimmed multi-table) |
 | Net migration count delta | -M (no new files) |
 | Verification | ✅ schema match |
-| PR draft message | "refactor(pb): consolidate $TABLE migrations (round N, -M files)" |
+| PR title | "refactor(pb): consolidate $TABLE migrations (round N, -M files)" |
 
-Stop. Do NOT auto-commit, do NOT push, do NOT open a PR. The user reviews
-the working-tree changes manually and decides when/how to ship.
+Print the table, then proceed directly to Step 11 — do NOT stop and ask.
 
 After the PR merges to main and prod restarts, the OnServe hook in
 `pocketbase/main.go` automatically calls `migrate history-sync` on first
 boot, removing orphan `_migrations` rows for the absorbed files. Fresh
 deploys see this hook as a no-op.
+
+## Step 11: Auto-commit, push, open PR
+
+Stage the migration changes, commit with the standard consolidation
+message, push, and open a PR. All git operations run from `$WORKTREE_DIR`.
+
+```bash
+cd "$WORKTREE_DIR"
+git add pocketbase/pb_migrations/
+git commit -m "$(cat <<'EOF'
+refactor(pb): consolidate $TABLE migrations (round N, -M files)
+
+<one-paragraph summary of what was absorbed/trimmed and the verified
+final state — fields, indexes, rules. Mirrors the per-table tracking-doc
+entry but written for the squash-merge commit log.>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin "$(git branch --show-current)"
+```
+
+Then open the PR:
+
+```bash
+gh pr create --title "refactor(pb): consolidate $TABLE migrations (round N, -M files)" --body "$(cat <<'EOF'
+## Summary
+- Collapses M modify-migrations into base #BBB (CREATE)
+- <multi-table trim notes if any>
+- Net delta: **-M files** in `pocketbase/pb_migrations/`
+- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match between proposed (1 file) and current (M+1 files)
+
+Absorbed:
+- `<file1>` — <one-line summary>
+- `<file2>` — <one-line summary>
+- ...
+
+Final state of `$TABLE`: <field count>, <index count>, <rules summary>.
+
+## Test plan
+- [x] Local schema-diff harness passes (`schemas match`)
+- [ ] CI green
+- [ ] After merge, prod boot's OnServe `migrate history-sync` hook auto-cleans the orphan `_migrations` rows for the M absorbed files
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Capture the PR number from `gh pr create` output for Step 12.
+
+If pre-push hooks fail, fix the underlying issue and retry — never use
+`--no-verify`. If the commit hits a commitlint warning about footer
+spacing, that's non-blocking and the commit succeeds.
+
+## Step 12: Auto-invoke scan-it
+
+Immediately invoke the `scan-it` skill against the new PR:
+
+```
+Skill tool: scan-it <PR#>
+```
+
+scan-it runs the internal code-review chain (5 parallel reviewer agents
++ Haiku scoring) plus pulls CodeRabbit findings, dedupes, and presents a
+table. Hold for user input on which findings (if any) to action.
+
+If the user accepts the consolidation as-is (no fixes) or asks for "handle
+it", invoke `handle-it` to enable auto-merge, monitor CI, and clean up
+the worktree.
 
 ## Edge cases the skill must handle
 


### PR DESCRIPTION
## Summary
- `consolidate-migrations` skill used to stop after Step 10 ("Hand back") and require manual commit/push/PR/scan
- Now Step 10 is print-and-proceed; Steps 11 and 12 fold the rest of the round into the skill itself:
  - Step 11: stage, commit (with the standard consolidation message), push, open PR
  - Step 12: invoke `scan-it` skill on the new PR; user reviews the deduped findings table and decides
- handle-it picks up from there if the user greenlights the PR

This matches the workflow we just ran end-to-end on the geo_overrides round (PR #1263).

## Test plan
- [x] Pre-push hooks pass locally (ruff, mypy, type-check, pb-js-lint, etc.)
- [ ] CI green
- [ ] Next consolidation round (table TBD) follows the new flow without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Consolidation workflow is now fully automated—automatically creates commits, pushes branches, and opens pull requests without manual intervention.
  * Added automated scanning of newly created pull requests, with user control over which findings to address.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1264)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->