### PR TITLE
refactor(pb): consolidate financial_aid_applications migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000036_financial_aid_applications.js
+++ b/pocketbase/pb_migrations/1500000036_financial_aid_applications.js
@@ -26,11 +26,11 @@ migrate((app) => {
     id: COLLECTION_ID_FA_APPLICATIONS,
     type: "base",
     name: "financial_aid_applications",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: "@request.auth.is_admin = true",
+    viewRule: "@request.auth.is_admin = true",
+    createRule: "@request.auth.is_admin = true",
+    updateRule: "@request.auth.is_admin = true",
+    deleteRule: "@request.auth.is_admin = true",
     fields: [
       // === Identity (4 fields) ===
       {
@@ -39,7 +39,7 @@ migrate((app) => {
         required: true,
         presentable: true,
         collectionId: personsCol.id,
-        cascadeDelete: false,
+        cascadeDelete: true,
         minSelect: null,
         maxSelect: 1
       },
@@ -391,7 +391,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 5000,
+        max: 10000,
         pattern: ""
       },
 

--- a/pocketbase/pb_migrations/1500000056_increase_field_limits.js
+++ b/pocketbase/pb_migrations/1500000056_increase_field_limits.js
@@ -3,19 +3,6 @@
 // Several fields had values exceeding the original max limits.
 
 migrate((app) => {
-  // financial_aid_applications.special_circumstances: 5000 -> 10000
-  const financialAid = app.findCollectionByNameOrId("financial_aid_applications")
-  financialAid.fields.add(new Field({
-    type: "text",
-    name: "special_circumstances",
-    required: false,
-    presentable: false,
-    min: 0,
-    max: 10000,
-    pattern: ""
-  }))
-  app.save(financialAid)
-
   // household_demographics.away_phone: 200 -> 400
   const householdDemo = app.findCollectionByNameOrId("household_demographics")
   householdDemo.fields.add(new Field({
@@ -81,18 +68,6 @@ migrate((app) => {
   app.save(staffApps)
 }, (app) => {
   // Restore original limits
-
-  const financialAid = app.findCollectionByNameOrId("financial_aid_applications")
-  financialAid.fields.add(new Field({
-    type: "text",
-    name: "special_circumstances",
-    required: false,
-    presentable: false,
-    min: 0,
-    max: 5000,
-    pattern: ""
-  }))
-  app.save(financialAid)
 
   const householdDemo = app.findCollectionByNameOrId("household_demographics")
   householdDemo.fields.add(new Field({

--- a/pocketbase/pb_migrations/1500000059_cascade_delete_derived_relations.js
+++ b/pocketbase/pb_migrations/1500000059_cascade_delete_derived_relations.js
@@ -19,7 +19,7 @@
 migrate((app) => {
   const householdsCol = app.findCollectionByNameOrId("households");
 
-  // 2. household_demographics.household
+  // 1. household_demographics.household
   const hhDemo = app.findCollectionByNameOrId("household_demographics");
   hhDemo.fields.add(new Field({
     type: "relation",
@@ -33,7 +33,7 @@ migrate((app) => {
   }));
   app.save(hhDemo);
 
-  // 3. family_camp_adults.household
+  // 2. family_camp_adults.household
   const fcAdults = app.findCollectionByNameOrId("family_camp_adults");
   fcAdults.fields.add(new Field({
     type: "relation",
@@ -47,7 +47,7 @@ migrate((app) => {
   }));
   app.save(fcAdults);
 
-  // 4. family_camp_registrations.household
+  // 3. family_camp_registrations.household
   const fcRegs = app.findCollectionByNameOrId("family_camp_registrations");
   fcRegs.fields.add(new Field({
     type: "relation",
@@ -61,7 +61,7 @@ migrate((app) => {
   }));
   app.save(fcRegs);
 
-  // 5. family_camp_medical.household
+  // 4. family_camp_medical.household
   const fcMed = app.findCollectionByNameOrId("family_camp_medical");
   fcMed.fields.add(new Field({
     type: "relation",

--- a/pocketbase/pb_migrations/1500000059_cascade_delete_derived_relations.js
+++ b/pocketbase/pb_migrations/1500000059_cascade_delete_derived_relations.js
@@ -10,7 +10,6 @@
  * If the source person/household is gone, derived data should cascade-delete.
  *
  * Affected relations:
- * - financial_aid_applications.person -> persons
  * - household_demographics.household -> households
  * - family_camp_adults.household -> households
  * - family_camp_registrations.household -> households
@@ -18,22 +17,7 @@
  */
 
 migrate((app) => {
-  const personsCol = app.findCollectionByNameOrId("persons");
   const householdsCol = app.findCollectionByNameOrId("households");
-
-  // 1. financial_aid_applications.person
-  const faApps = app.findCollectionByNameOrId("financial_aid_applications");
-  faApps.fields.add(new Field({
-    type: "relation",
-    name: "person",
-    required: true,
-    presentable: true,
-    collectionId: personsCol.id,
-    cascadeDelete: true,
-    minSelect: null,
-    maxSelect: 1
-  }));
-  app.save(faApps);
 
   // 2. household_demographics.household
   const hhDemo = app.findCollectionByNameOrId("household_demographics");
@@ -92,21 +76,7 @@ migrate((app) => {
   app.save(fcMed);
 
 }, (app) => {
-  const personsCol = app.findCollectionByNameOrId("persons");
   const householdsCol = app.findCollectionByNameOrId("households");
-
-  const faApps = app.findCollectionByNameOrId("financial_aid_applications");
-  faApps.fields.add(new Field({
-    type: "relation",
-    name: "person",
-    required: true,
-    presentable: true,
-    collectionId: personsCol.id,
-    cascadeDelete: false,
-    minSelect: null,
-    maxSelect: 1
-  }));
-  app.save(faApps);
 
   const hhDemo = app.findCollectionByNameOrId("household_demographics");
   hhDemo.fields.add(new Field({

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -23,7 +23,7 @@ migrate((app) => {
   // Tier 2: Admin-only (sensitive data not accessed by frontend)
   const tier2 = [
     "household_custom_values", "household_demographics",
-    "financial_transactions", "financial_categories", "financial_aid_applications",
+    "financial_transactions", "financial_categories",
     "payment_methods", "camper_dietary", "camper_transportation",
     "staff", "staff_applications", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills", "staff_vehicle_info",
@@ -60,7 +60,7 @@ migrate((app) => {
 
   const all = [
     "household_custom_values", "household_demographics",
-    "financial_transactions", "financial_categories", "financial_aid_applications",
+    "financial_transactions", "financial_categories",
     "payment_methods", "camper_dietary", "camper_transportation",
     "staff", "staff_applications", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills", "staff_vehicle_info",


### PR DESCRIPTION
## Summary
- **First trim-only consolidation round.** No single-table modify migrations exist for `financial_aid_applications` — all three post-CREATE mutations are multi-table files. Net delta: **0 files** (none deleted; three trimmed).
- Folded into base #1500000036 (CREATE): `person.cascadeDelete=true`, `special_circumstances.max=10000`, all five collection rules `@request.auth.is_admin = true`
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match between proposed (4-file edit) and origin/main

Trimmed (still active for other sharers):
- `1500000056_increase_field_limits.js` — removed the `financial_aid_applications.special_circumstances` block from up() and rollback. Still bumps fields on `household_demographics`, `quest_registrations`, `staff_applications`
- `1500000059_cascade_delete_derived_relations.js` — removed the `financial_aid_applications.person` block from up() and rollback, plus the now-unused `personsCol` lookup. Still applies cascade-delete to `household_demographics`, `family_camp_adults`, `family_camp_registrations`, `family_camp_medical`
- `1500000075_rbac_tier2_rules.js` — removed `"financial_aid_applications"` from the `tier2` array and the rollback `all` array. Still applies admin-only rules to ~24 other tier-2 tables

Final state of `financial_aid_applications`: 68 fields (unchanged set, three property edits), 6 indexes (unchanged), all five rules `@request.auth.is_admin = true`.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green
- [ ] After merge, prod boot's OnServe `migrate history-sync` hook is a no-op for this round (no deleted files), but the trim work advances #056 / #059 / #075 toward eventual deletion when the last sharing table consolidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adjusted character limit for the "special circumstances" field.

* **Bug Fixes**
  * Enabled cascading deletes for related household and registration records to reduce orphaned data.

* **Chores**
  * Updated administrative access rules for financial collections.
  * Adjusted field length limits for contact phone, preferred name, and several staff application fields.
  * Modified admin-locking behavior for certain financial collections.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1286)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->