### PR TITLE
fix(deps): bump tailwindcss to 4.3.0 and apply new prettier sort order

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -44,7 +44,7 @@
         "react-leaflet": "^5.0.0",
         "react-router": "^7.13.1",
         "recharts": "^3.8.0",
-        "tailwindcss": "^4.1.11",
+        "tailwindcss": "^4.3.0",
         "tippy.js": "^6.3.7",
         "zod": "^4.4.1"
       },
@@ -1768,6 +1768,12 @@
         "tailwindcss": "4.2.4"
       }
     },
+    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
+      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
@@ -2009,6 +2015,12 @@
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/tailwindcss": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
+      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+      "license": "MIT"
     },
     "node_modules/@tanstack/query-core": {
       "version": "5.100.9",
@@ -6207,9 +6219,9 @@
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
-      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "license": "MIT"
     },
     "node_modules/tapable": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,7 +62,7 @@
     "react-leaflet": "^5.0.0",
     "react-router": "^7.13.1",
     "recharts": "^3.8.0",
-    "tailwindcss": "^4.1.11",
+    "tailwindcss": "^4.3.0",
     "tippy.js": "^6.3.7",
     "zod": "^4.4.1"
   },

--- a/frontend/src/components/admin/ConfigTab.tsx
+++ b/frontend/src/components/admin/ConfigTab.tsx
@@ -130,7 +130,7 @@ export function ConfigTab() {
     <div className="flex flex-col gap-4 lg:flex-row lg:gap-6">
       {/* Mobile Category Tabs */}
       <div className="lg:hidden">
-        <div className="scrollbar-none -mx-1 flex gap-2 overflow-x-auto px-1 pb-2">
+        <div className="-mx-1 flex scrollbar-none gap-2 overflow-x-auto px-1 pb-2">
           {CONFIG_CATEGORIES.map((category) => {
             const Icon = category.icon
             const isActive = activeCategory === category.id


### PR DESCRIPTION
## Summary
- Bumps `tailwindcss` from `^4.1.11` (resolved 4.2.4) to `^4.3.0` in `frontend/package.json` and regenerates the lockfile.
- Applies the one-line `prettier-plugin-tailwindcss` re-sort that 4.3.0 considers canonical on `ConfigTab.tsx`.

## Why
The Dependabot Lock File Fix-up workflow refreshes each Dependabot PR's `frontend/package-lock.json`, picking up tailwindcss 4.3.0 (latest within the caret). Because main was pinned to 4.2.4, every Dependabot PR's merge commit had its sort order flagged by `prettier --check`, blocking `Frontend Lint`.

Aligning main's constraint and lockfile with 4.3.0 makes the fixup a no-op for the tailwindcss entry, and the file is canonically formatted under 4.3.0.

## Test plan
- [x] `npx prettier --check "frontend/src/**/*.{ts,tsx,js,jsx,json,css}"` passes locally with tailwindcss 4.3.0 installed.
- [x] `npm run type-check` clean.
- [x] `npm run build` clean.
- [x] No file other than `ConfigTab.tsx` requires re-formatting under 4.3.0 (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Tailwind CSS dependency to the latest patch version (4.3.0).

* **Style**
  * Optimized mobile navigation styling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1288)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->