### PR TITLE
ci(release): drop feat/fix/perf-only gate on auto-bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,17 +90,6 @@ jobs:
           exit 1
         fi
 
-        # Check for release-worthy commits (skip if only docs/test/refactor)
-        if [ -z "$INPUT_VERSION" ]; then
-          RANGE="${LAST_TAG:+$LAST_TAG..HEAD}"
-          RANGE="${RANGE:-HEAD}"
-          WORTHY=$(git log $RANGE --oneline | grep -cE '^[a-f0-9]+ (feat|fix|perf)(\(.+\))?(!)?:' || true)
-          if [ "$WORTHY" -eq 0 ]; then
-            echo "::error::No release-worthy commits (feat/fix/perf) since $LAST_TAG. Use version override to force."
-            exit 1
-          fi
-        fi
-
         echo "version=$VER" >> "$GITHUB_OUTPUT"
         echo "### Version: $VER" >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
## Summary
Removes the per-commit-type gate in the `Calculate version` step of `release.yml`. Auto-bump now proceeds whenever `git cliff --bumped-version` returns a version that isn't already tagged.

## Why
The current gate hard-fails with `No release-worthy commits (feat/fix/perf) since <last tag>` whenever the only commits since the last tag are `refactor`, `chore`, etc. Recent migration-consolidation work (`refactor(pb): consolidate ... migrations`) is exactly that case — legitimate, release-worthy work that the gate was incorrectly skipping. Today's release run (2026-05-11) failed for this reason.

## What protects against accidental releases
Two safety nets remain:
1. **`git cliff --bumped-version` returns empty** when there is nothing semver-worthy to bump → the workflow exits at `git-cliff could not determine version`.
2. **Tag-already-exists check** catches the case where git-cliff returns the current version (no semver-bumping commits) → exit at `Tag $VER already exists`.

A manual `version` input override is also still available for forced releases.

## Test plan
- [ ] YAML parses (`python3 -c 'import yaml; yaml.safe_load(open(...))'`) ✓ locally
- [ ] Run the Release workflow on auto-bump after merge to verify it now proceeds past `Calculate version` (post-merge follow-up — workflow_dispatch only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to allow releases without requiring commits of specific types, making the release process more flexible.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1290)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->