### PR TITLE
ci(tests): include .python-version in backend/python/migrations filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
             - 'go.mod'
             - 'go.sum'
             - '.golangci.yml'
+            - '.python-version'
           python:
             - 'api/**/*.py'
             - 'bunking/**/*.py'
@@ -125,6 +126,7 @@ jobs:
             - 'uv.lock'
             - 'tests/**'
             - 'conftest.py'
+            - '.python-version'
           go:
             - 'pocketbase/**/*.go'
             - 'go.mod'
@@ -134,6 +136,7 @@ jobs:
             - 'pocketbase/pb_migrations/**'
             - 'pocketbase/main.go'
             - 'scripts/ci/validate_migrations.py'
+            - '.python-version'
           frontend:
             - 'frontend/**'
             - 'package*.json'


### PR DESCRIPTION
## Summary
- Add `.python-version` to the `backend`, `python`, and `migrations` path filters in `detect-changes`.

## Why
`setup-python` reads `python-version-file: '.python-version'` in `python-lint`, `tests-python`, and `tests-migrations`. Without `.python-version` in any of those filters, a PR that only bumps the interpreter version would skip all three jobs — i.e. an untested interpreter bump lands on main.

CodeRabbit flagged this on #1292 for `backend` + `python`. The same root cause applies to `migrations` (since the migration smoke test also runs Python for `validate_migrations.py`), so this PR adds the line in all three places.

## Test plan
- [ ] CI Summary green
- [ ] If you later touch `.python-version`, `python-lint`, `tests-python`, and `tests-migrations` should all run (verifiable with a future probe PR if desired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline configuration to ensure automated tests trigger when Python version dependencies are updated, improving code quality checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1293)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->