### PR TITLE
ci(tests): shard frontend tests across 2 matrix jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,12 +582,17 @@ jobs:
 
         echo "✅ Migration smoke test passed"
 
-  # Frontend tests (parallel)
+  # Frontend tests — sharded across 2 matrix jobs to cut wall-clock
+  # (vitest --shard splits files; matrix gives each shard its own runner)
   tests-frontend:
     name: Frontend Tests
     needs: detect-changes
     if: needs.detect-changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -605,9 +610,9 @@ jobs:
       working-directory: ./frontend
       run: npm ci
 
-    - name: Run frontend tests
+    - name: Run frontend tests (shard ${{ matrix.shard }}/2)
       working-directory: ./frontend
-      run: npm run test -- --run
+      run: npm run test -- --run --shard=${{ matrix.shard }}/2
 
   # Summary job - gate for PR merges
   summary:


### PR DESCRIPTION
## Summary
- Add a 2-shard matrix strategy to the `tests-frontend` job.
- Each shard runs `vitest --shard=<n>/2` on its own runner, in parallel.

## Why
After the test-job split (#1292), `tests-frontend` is the wall-clock bottleneck at ~193s (~173s of vitest + ~20s setup). Vitest already parallelizes within a runner across CPU cores, but a free GitHub runner caps at ~4 cores. Sharding gives each shard its own 4-core runner.

## Measured results

Pushed a probe commit on this branch to trigger the new matrix and measured against the baseline:

| Leg | Baseline (#25686271314) | This branch (probe run #25691183996) | Δ |
|---|---|---|---|
| Frontend Tests (1) | — | 102s | — |
| Frontend Tests (2) | — | 100s | — |
| **tests-frontend wall-clock** | **193s** | **102s** | **−91s (~47%)** |

Other legs unchanged. New wall-clock cap on a full-stack PR shifts from frontend (193s) to **tests-go (~120s)**.

## Config notes
- `fail-fast: false` so a failure in one shard still lets the other run, for full diagnostics.
- `needs.tests-frontend.result` in `CI Summary` aggregates the matrix automatically (success iff all shards pass), so no gate changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)