### PR TITLE
refactor(pb): consolidate household_demographics migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000041_household_demographics.js
+++ b/pocketbase/pb_migrations/1500000041_household_demographics.js
@@ -21,17 +21,19 @@
  */
 
 migrate((app) => {
+  const adminOnly = '@request.auth.is_admin = true';
+
   // Get households collection for relation
   const householdsCol = app.findCollectionByNameOrId("households");
 
   const collection = new Collection({
     type: "base",
     name: "household_demographics",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: null,  // Sync only
-    updateRule: null,
-    deleteRule: null,
+    listRule: adminOnly,
+    viewRule: adminOnly,
+    createRule: adminOnly,
+    updateRule: adminOnly,
+    deleteRule: adminOnly,
     fields: [
       // === Core Identity ===
       {
@@ -40,7 +42,7 @@ migrate((app) => {
         required: true,
         presentable: false,
         collectionId: householdsCol.id,
-        cascadeDelete: false,
+        cascadeDelete: true,
         minSelect: null,
         maxSelect: 1
       },
@@ -214,7 +216,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 200,
+        max: 400,
         pattern: ""
       },
       {

--- a/pocketbase/pb_migrations/1500000056_increase_field_limits.js
+++ b/pocketbase/pb_migrations/1500000056_increase_field_limits.js
@@ -3,19 +3,6 @@
 // Several fields had values exceeding the original max limits.
 
 migrate((app) => {
-  // household_demographics.away_phone: 200 -> 400
-  const householdDemo = app.findCollectionByNameOrId("household_demographics")
-  householdDemo.fields.add(new Field({
-    type: "text",
-    name: "away_phone",
-    required: false,
-    presentable: false,
-    min: 0,
-    max: 400,
-    pattern: ""
-  }))
-  app.save(householdDemo)
-
   // quest_registrations.preferred_name: 100 -> 200
   const questReg = app.findCollectionByNameOrId("quest_registrations")
   questReg.fields.add(new Field({
@@ -68,18 +55,6 @@ migrate((app) => {
   app.save(staffApps)
 }, (app) => {
   // Restore original limits
-
-  const householdDemo = app.findCollectionByNameOrId("household_demographics")
-  householdDemo.fields.add(new Field({
-    type: "text",
-    name: "away_phone",
-    required: false,
-    presentable: false,
-    min: 0,
-    max: 200,
-    pattern: ""
-  }))
-  app.save(householdDemo)
 
   const questReg = app.findCollectionByNameOrId("quest_registrations")
   questReg.fields.add(new Field({

--- a/pocketbase/pb_migrations/1500000059_cascade_delete_derived_relations.js
+++ b/pocketbase/pb_migrations/1500000059_cascade_delete_derived_relations.js
@@ -10,7 +10,6 @@
  * If the source person/household is gone, derived data should cascade-delete.
  *
  * Affected relations:
- * - household_demographics.household -> households
  * - family_camp_adults.household -> households
  * - family_camp_registrations.household -> households
  * - family_camp_medical.household -> households
@@ -19,21 +18,7 @@
 migrate((app) => {
   const householdsCol = app.findCollectionByNameOrId("households");
 
-  // 1. household_demographics.household
-  const hhDemo = app.findCollectionByNameOrId("household_demographics");
-  hhDemo.fields.add(new Field({
-    type: "relation",
-    name: "household",
-    required: true,
-    presentable: false,
-    collectionId: householdsCol.id,
-    cascadeDelete: true,
-    minSelect: null,
-    maxSelect: 1
-  }));
-  app.save(hhDemo);
-
-  // 2. family_camp_adults.household
+  // 1. family_camp_adults.household
   const fcAdults = app.findCollectionByNameOrId("family_camp_adults");
   fcAdults.fields.add(new Field({
     type: "relation",
@@ -47,7 +32,7 @@ migrate((app) => {
   }));
   app.save(fcAdults);
 
-  // 3. family_camp_registrations.household
+  // 2. family_camp_registrations.household
   const fcRegs = app.findCollectionByNameOrId("family_camp_registrations");
   fcRegs.fields.add(new Field({
     type: "relation",
@@ -61,7 +46,7 @@ migrate((app) => {
   }));
   app.save(fcRegs);
 
-  // 4. family_camp_medical.household
+  // 3. family_camp_medical.household
   const fcMed = app.findCollectionByNameOrId("family_camp_medical");
   fcMed.fields.add(new Field({
     type: "relation",
@@ -77,19 +62,6 @@ migrate((app) => {
 
 }, (app) => {
   const householdsCol = app.findCollectionByNameOrId("households");
-
-  const hhDemo = app.findCollectionByNameOrId("household_demographics");
-  hhDemo.fields.add(new Field({
-    type: "relation",
-    name: "household",
-    required: true,
-    presentable: false,
-    collectionId: householdsCol.id,
-    cascadeDelete: false,
-    minSelect: null,
-    maxSelect: 1
-  }));
-  app.save(hhDemo);
 
   const fcAdults = app.findCollectionByNameOrId("family_camp_adults");
   fcAdults.fields.add(new Field({

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -22,7 +22,7 @@ migrate((app) => {
 
   // Tier 2: Admin-only (sensitive data not accessed by frontend)
   const tier2 = [
-    "household_custom_values", "household_demographics",
+    "household_custom_values",
     "financial_transactions", "financial_categories",
     "payment_methods", "camper_dietary", "camper_transportation",
     "staff", "staff_applications", "staff_org_categories", "staff_positions",
@@ -59,7 +59,7 @@ migrate((app) => {
   }
 
   const all = [
-    "household_custom_values", "household_demographics",
+    "household_custom_values",
     "financial_transactions", "financial_categories",
     "payment_methods", "camper_dietary", "camper_transportation",
     "staff", "staff_applications", "staff_org_categories", "staff_positions",


### PR DESCRIPTION
## Summary
- Trim-only round (same pattern as financial_aid_applications #1286). No single-table modify migration existed for `household_demographics`; all 3 mutations lived in multi-table files.
- Folded final state directly into #041's initial CREATE:
  - `household.cascadeDelete = true`
  - `away_phone.max = 400`
  - list/view/c/u/d rules = `@request.auth.is_admin = true`
- Trimmed 3 multi-table files (each still applies to remaining sharers).
- Net delta: **0 files** — value comes from advancing #056/#059/#075 toward eventual deletion as each sharer consolidates.
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match between proposed (1 file) and current (4 files).

Trimmed:
- `1500000056_increase_field_limits.js` — removed `household_demographics.away_phone` (200→400) bump block from up() and rollback. Still applies field-limit bumps to `quest_registrations`, `staff_applications`.
- `1500000059_cascade_delete_derived_relations.js` — removed `household_demographics.household` (cascadeDelete false→true) block from up() and rollback. Still applies cascade-delete to `family_camp_adults`, `family_camp_registrations`, `family_camp_medical`.
- `1500000075_rbac_tier2_rules.js` — removed `"household_demographics"` from `tier2` and rollback `all` arrays. Still applies admin-only rules to ~23 other tier-2 tables.

Final state of `household_demographics`: 26 fields (unchanged set, only property edits), 2 indexes (unchanged), rules admin-only.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green
- [ ] After merge, no `_migrations` rows change (trim-only — no file deletions this round)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated access control and permission rules for household data collections.
  * Modified cascade deletion behavior for relation fields to improve data integrity.
  * Increased phone number field character limit to 400 characters.
  * Updated role-based access control rules for system collections.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1295)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->