### PR TITLE
fix(api): shim ListResult import for pocketbase SDK >=0.17.0

### DIFF
--- a/bunking/sync/bunk_request_processor/data/pocketbase_wrapper.py
+++ b/bunking/sync/bunk_request_processor/data/pocketbase_wrapper.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from pocketbase.models.utils.list_result import ListResult
+try:
+    from pocketbase.models.list_result import ListResult  # SDK >= 0.17.0
+except ImportError:
+    from pocketbase.models.utils.list_result import ListResult  # SDK < 0.17.0
 from pocketbase.services.record_service import RecordService
 
 # Import TRACE constant and ensure trace method is available


### PR DESCRIPTION
## Summary

Unblocks dependabot PR #1282 (`pocketbase` SDK >=0.15.0 → >=0.17.1).

The `vaphes/pocketbase` v0.17.0 release restructured to a src-layout and removed `pocketbase.models.utils/` — `list_result` moved one level up to `pocketbase.models.list_result`. Our wrapper imports the old path, so #1282's "Run Tests" fails with `ModuleNotFoundError: No module named 'pocketbase.models.utils'`, cascading into 8+ test modules.

A `try/except ImportError` shim works on both the currently-locked 0.15.0 and the upcoming 0.17.x — no version bump required here. Once this lands, `@dependabot recreate` on #1282 will produce a green PR.

## Verified

- ruff format / ruff check / mypy clean
- 4291 unit tests pass
- pb-js-lint and frontend type-check verified manually (lefthook hooks fast-fail on TTY access from sandbox; `--no-verify` authorized)

## Test plan

- [x] `uv run pytest tests/unit/` — 4291 passed
- [ ] CI green on this PR
- [ ] `@dependabot recreate` on #1282 → CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of query and filter operations with enhanced error handling and automatic fallback support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1296)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->