### PR TITLE
build(scripts): bump lefthook to v2.x

### DIFF
--- a/scripts/setup-git-hooks.sh
+++ b/scripts/setup-git-hooks.sh
@@ -17,7 +17,7 @@ echo -e "${YELLOW}Setting up git hooks via lefthook...${NC}"
 if ! command -v lefthook &> /dev/null; then
     echo -e "${YELLOW}Installing lefthook...${NC}"
     if command -v go &> /dev/null; then
-        go install github.com/evilmartians/lefthook@latest
+        go install github.com/evilmartians/lefthook/v2@latest
     else
         echo -e "${RED}Error: Go is required to install lefthook${NC}"
         echo "Install Go first: https://go.dev/dl/"

--- a/scripts/worktree/new.sh
+++ b/scripts/worktree/new.sh
@@ -152,9 +152,9 @@ EOF
 
 # Install lefthook hooks in the worktree
 if command -v lefthook &> /dev/null; then
-    lefthook install
+    lefthook install --reset-hooks-path
 else
-    echo -e "${YELLOW}Warning: lefthook not installed — run 'go install github.com/evilmartians/lefthook@latest'${NC}"
+    echo -e "${YELLOW}Warning: lefthook not installed — run 'go install github.com/evilmartians/lefthook/v2@latest'${NC}"
 fi
 
 # Install dependencies (fast with caching)


### PR DESCRIPTION
## Summary

Upgrades lefthook from v1.13.6 → v2.1.6+ to pull in upstream fix [#1393](https://github.com/evilmartians/lefthook/pull/1393) (\"skip pty allocation when stdout is not a terminal\", April 2026), which resolves the \`/dev/pts/0: permission denied\` fast-fail seen when running \`git push\` from sandboxed bash environments.

## Changes

- \`scripts/setup-git-hooks.sh\`: install path \`lefthook@latest\` → \`lefthook/v2@latest\`. Without \`/v2\`, \`go install\` still pulls v1.13.6 (Sept 2025).
- \`scripts/worktree/new.sh\`: add \`--reset-hooks-path\` to \`lefthook install\`. Worktrees inherit \`core.hooksPath\` from the main repo, and v2 refuses to install on top of an existing setting without this flag. Also updates the user-facing install instruction to include \`/v2\`.

## Compatibility

- \`.lefthook.yml\` requires no changes — we don't use the \`skip_output\` or \`exclude\`-regex features that v2.0.0 removed.
- CI is unaffected — \`.github/workflows/\` invokes ruff/mypy/eslint/etc. directly, not via lefthook.
- One CLI-flag rename to be aware of for future ad-hoc invocations: \`lefthook run --files\` → \`--file\` (repeatable). Doesn't affect anything in-repo.

## Verified

- \`shellcheck\` on both scripts passes via \`lefthook run pre-push\` under v2.
- \`lefthook run pre-push\` no longer fast-fails on TTY access in this sandbox (pre-bump symptom).
- Other pre-push hook failures observed (\`api-types-freshness\`, \`pb-js-lint\`, \`type-check\`) are pre-existing worktree-state issues unrelated to the lefthook version.

## Upgrade note for existing setups

Re-run \`scripts/setup-git-hooks.sh\` after pulling to install the v2.x binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git hooks installation and configuration with improved setup methods for enhanced reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1298)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->