### PR TITLE
refactor(pb): consolidate original_bunk_requests migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000020_original_bunk_requests.js
+++ b/pocketbase/pb_migrations/1500000020_original_bunk_requests.js
@@ -12,6 +12,9 @@
 const COLLECTION_ID_ORIG_REQUESTS = "col_orig_requests";
 
 migrate((app) => {
+  const adminOnly = '@request.auth.is_admin = true'
+  const bunkingManage = '@request.auth.is_admin = true || @request.auth.cached_permissions ~ "bunking.manage"'
+
   // Dynamic lookups for relations
   const personsCol = app.findCollectionByNameOrId("persons")
 
@@ -19,11 +22,11 @@ migrate((app) => {
     id: COLLECTION_ID_ORIG_REQUESTS,
     name: "original_bunk_requests",
     type: "base",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: bunkingManage,
+    viewRule: bunkingManage,
+    createRule: adminOnly,
+    updateRule: adminOnly,
+    deleteRule: adminOnly,
     fields: [
       {
         type: "number",
@@ -40,7 +43,7 @@ migrate((app) => {
         required: true,
         presentable: false,
         collectionId: personsCol.id,
-        cascadeDelete: false,
+        cascadeDelete: true,
         minSelect: null,
         maxSelect: 1
       },

--- a/pocketbase/pb_migrations/1500000064_cascade_delete_sync_orphan_blockers.js
+++ b/pocketbase/pb_migrations/1500000064_cascade_delete_sync_orphan_blockers.js
@@ -22,7 +22,9 @@
  * - locked_group_members.attendee -> attendees
  * - staff_applications.staff -> staff
  * - staff_vehicle_info.staff -> staff
- * - original_bunk_requests.requester -> persons
+ *
+ * Note: original_bunk_requests.requester trimmed — final cascadeDelete: true
+ * baked into merged CREATE migration #020.
  */
 
 migrate((app) => {
@@ -30,7 +32,6 @@ migrate((app) => {
   const sessionsCol = app.findCollectionByNameOrId("camp_sessions")
   const attendeesCol = app.findCollectionByNameOrId("attendees")
   const staffCol = app.findCollectionByNameOrId("staff")
-  const personsCol = app.findCollectionByNameOrId("persons")
 
   // 1. bunk_plans.bunk -> bunks
   const bunkPlans = app.findCollectionByNameOrId("bunk_plans")
@@ -141,26 +142,11 @@ migrate((app) => {
   }))
   app.save(staffVehicle)
 
-  // 9. original_bunk_requests.requester -> persons
-  const origRequests = app.findCollectionByNameOrId("original_bunk_requests")
-  origRequests.fields.add(new Field({
-    type: "relation",
-    name: "requester",
-    required: true,
-    presentable: false,
-    collectionId: personsCol.id,
-    cascadeDelete: true,
-    minSelect: null,
-    maxSelect: 1
-  }))
-  app.save(origRequests)
-
 }, (app) => {
   const bunksCol = app.findCollectionByNameOrId("bunks")
   const sessionsCol = app.findCollectionByNameOrId("camp_sessions")
   const attendeesCol = app.findCollectionByNameOrId("attendees")
   const staffCol = app.findCollectionByNameOrId("staff")
-  const personsCol = app.findCollectionByNameOrId("persons")
 
   // Revert all to cascadeDelete: false
 
@@ -216,11 +202,4 @@ migrate((app) => {
     collectionId: staffCol.id, cascadeDelete: false, minSelect: null, maxSelect: 1
   }))
   app.save(staffVehicle)
-
-  const origRequests = app.findCollectionByNameOrId("original_bunk_requests")
-  origRequests.fields.add(new Field({
-    type: "relation", name: "requester", required: true, presentable: false,
-    collectionId: personsCol.id, cascadeDelete: false, minSelect: null, maxSelect: 1
-  }))
-  app.save(origRequests)
 })

--- a/pocketbase/pb_migrations/1500000074_rbac_tier1_rules.js
+++ b/pocketbase/pb_migrations/1500000074_rbac_tier1_rules.js
@@ -41,8 +41,8 @@ migrate((app) => {
   }
 
   // Read-only: bunking.manage (request source data written by sync)
-  // Note: "bunk_request_sources" trimmed — final-state rules baked into merged CREATE.
-  const bunkingManageReadOnly = ["original_bunk_requests"]
+  // Note: "bunk_request_sources", "original_bunk_requests" trimmed — final-state rules baked into merged CREATE.
+  const bunkingManageReadOnly = []
   for (const name of bunkingManageReadOnly) {
     setRules(name, bunkingManage, bunkingManage, adminOnly, adminOnly, adminOnly)
   }
@@ -78,7 +78,6 @@ migrate((app) => {
   const collections = [
     "camp_sessions", "divisions",
     "bunk_plans", "bunks",
-    "original_bunk_requests",
     "locked_groups", "locked_group_members", "saved_scenarios"
   ]
   for (const name of collections) {


### PR DESCRIPTION
## Summary
- Trim-only round for `original_bunk_requests` — folds final-state mutations into the merged CREATE at #1500000020 and trims `original_bunk_requests` from 2 multi-table modify files.
- Net delta: **0 files** in `pocketbase/pb_migrations/` (value is advancing the multi-table files toward eventual deletion as each sharer consolidates).
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match between proposed and current.

Trimmed multi-table files:
- `1500000064_cascade_delete_sync_orphan_blockers.js` — removed the `original_bunk_requests.requester` cascadeDelete update block (up + rollback) and the now-unused `personsCol` lookup. #064 still applies cascade-delete to 8 other tables.
- `1500000074_rbac_tier1_rules.js` — removed `"original_bunk_requests"` from `bunkingManageReadOnly` (now `[]`) and from rollback `collections`. #074 still applies RBAC rules to the remaining Tier-1 tables (post prior trims).

Final state of `original_bunk_requests`: 8 fields (`year`, `requester` with `cascadeDelete=true`, `field`, `content`, `content_hash`, `processed`, `created`, `updated`), 2 indexes (unique on `(year, field, requester)` + index on `requester`), rules = list/view = `bunking.manage`, create/update/delete = admin-only.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green
- [ ] After merge, prod boot's OnServe `migrate history-sync` hook runs as a no-op (no files deleted this round)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Database & Infrastructure**
  * Strengthened access control with admin-only restrictions and fine-grained permission-based authorization for request management.
  * Improved data integrity through cascading delete behavior, ensuring related records are automatically cleaned up when parent records are removed.
  * Updated role-based access control rules for enhanced security.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1299)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->