### PR TITLE
refactor(pb): consolidate quest_registrations migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000045_quest_registrations.js
+++ b/pocketbase/pb_migrations/1500000045_quest_registrations.js
@@ -14,14 +14,16 @@
 migrate((app) => {
   const attendeesCol = app.findCollectionByNameOrId("attendees");
 
+  const adminOnly = '@request.auth.is_admin = true';
+
   const collection = new Collection({
     type: "base",
     name: "quest_registrations",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: null,
-    updateRule: null,
-    deleteRule: null,
+    listRule: adminOnly,
+    viewRule: adminOnly,
+    createRule: adminOnly,
+    updateRule: adminOnly,
+    deleteRule: adminOnly,
     fields: [
       // === Core Identity ===
       {
@@ -30,7 +32,7 @@ migrate((app) => {
         required: true,
         presentable: false,
         collectionId: attendeesCol.id,
-        cascadeDelete: false,
+        cascadeDelete: true,
         minSelect: null,
         maxSelect: 1
       },
@@ -78,7 +80,7 @@ migrate((app) => {
         required: false,
         presentable: false,
         min: 0,
-        max: 100,
+        max: 200,
         pattern: ""
       },
 

--- a/pocketbase/pb_migrations/1500000056_increase_field_limits.js
+++ b/pocketbase/pb_migrations/1500000056_increase_field_limits.js
@@ -3,19 +3,6 @@
 // Several fields had values exceeding the original max limits.
 
 migrate((app) => {
-  // quest_registrations.preferred_name: 100 -> 200
-  const questReg = app.findCollectionByNameOrId("quest_registrations")
-  questReg.fields.add(new Field({
-    type: "text",
-    name: "preferred_name",
-    required: false,
-    presentable: false,
-    min: 0,
-    max: 200,
-    pattern: ""
-  }))
-  app.save(questReg)
-
   // staff_applications: 3 fields
   const staffApps = app.findCollectionByNameOrId("staff_applications")
 
@@ -55,18 +42,6 @@ migrate((app) => {
   app.save(staffApps)
 }, (app) => {
   // Restore original limits
-
-  const questReg = app.findCollectionByNameOrId("quest_registrations")
-  questReg.fields.add(new Field({
-    type: "text",
-    name: "preferred_name",
-    required: false,
-    presentable: false,
-    min: 0,
-    max: 100,
-    pattern: ""
-  }))
-  app.save(questReg)
 
   const staffApps = app.findCollectionByNameOrId("staff_applications")
   staffApps.fields.add(new Field({

--- a/pocketbase/pb_migrations/1500000064_cascade_delete_sync_orphan_blockers.js
+++ b/pocketbase/pb_migrations/1500000064_cascade_delete_sync_orphan_blockers.js
@@ -18,13 +18,14 @@
  * - bunk_plans.session -> camp_sessions
  * - camper_dietary.attendee -> attendees
  * - camper_transportation.attendee -> attendees
- * - quest_registrations.attendee -> attendees
  * - locked_group_members.attendee -> attendees
  * - staff_applications.staff -> staff
  * - staff_vehicle_info.staff -> staff
  *
  * Note: original_bunk_requests.requester trimmed — final cascadeDelete: true
  * baked into merged CREATE migration #020.
+ * Note: quest_registrations.attendee trimmed — final cascadeDelete: true
+ * baked into merged CREATE migration #045.
  */
 
 migrate((app) => {
@@ -86,21 +87,7 @@ migrate((app) => {
   }))
   app.save(camperTransport)
 
-  // 5. quest_registrations.attendee -> attendees
-  const questRegs = app.findCollectionByNameOrId("quest_registrations")
-  questRegs.fields.add(new Field({
-    type: "relation",
-    name: "attendee",
-    required: true,
-    presentable: false,
-    collectionId: attendeesCol.id,
-    cascadeDelete: true,
-    minSelect: null,
-    maxSelect: 1
-  }))
-  app.save(questRegs)
-
-  // 6. locked_group_members.attendee -> attendees
+  // 5. locked_group_members.attendee -> attendees
   const lockedGroupMembers = app.findCollectionByNameOrId("locked_group_members")
   lockedGroupMembers.fields.add(new Field({
     type: "relation",
@@ -114,7 +101,7 @@ migrate((app) => {
   }))
   app.save(lockedGroupMembers)
 
-  // 7. staff_applications.staff -> staff
+  // 6. staff_applications.staff -> staff
   const staffApps = app.findCollectionByNameOrId("staff_applications")
   staffApps.fields.add(new Field({
     type: "relation",
@@ -128,7 +115,7 @@ migrate((app) => {
   }))
   app.save(staffApps)
 
-  // 8. staff_vehicle_info.staff -> staff
+  // 7. staff_vehicle_info.staff -> staff
   const staffVehicle = app.findCollectionByNameOrId("staff_vehicle_info")
   staffVehicle.fields.add(new Field({
     type: "relation",
@@ -174,13 +161,6 @@ migrate((app) => {
     collectionId: attendeesCol.id, cascadeDelete: false, minSelect: null, maxSelect: 1
   }))
   app.save(camperTransport)
-
-  const questRegs = app.findCollectionByNameOrId("quest_registrations")
-  questRegs.fields.add(new Field({
-    type: "relation", name: "attendee", required: true, presentable: false,
-    collectionId: attendeesCol.id, cascadeDelete: false, minSelect: null, maxSelect: 1
-  }))
-  app.save(questRegs)
 
   const lockedGroupMembers = app.findCollectionByNameOrId("locked_group_members")
   lockedGroupMembers.fields.add(new Field({

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -29,7 +29,7 @@ migrate((app) => {
     "staff_program_areas", "staff_skills", "staff_vehicle_info",
     "person_custom_values", "person_tag_defs", "custom_field_defs",
     "family_camp_adults", "family_camp_medical",
-    "family_camp_registrations", "quest_registrations", "session_groups",
+    "family_camp_registrations", "session_groups",
     "config_sections", "sheets_workbooks"
   ]
 
@@ -66,7 +66,7 @@ migrate((app) => {
     "staff_program_areas", "staff_skills", "staff_vehicle_info",
     "person_custom_values", "person_tag_defs", "custom_field_defs",
     "family_camp_adults", "family_camp_medical",
-    "family_camp_registrations", "quest_registrations", "session_groups",
+    "family_camp_registrations", "session_groups",
     "config_sections", "sheets_workbooks",
     "debug_parse_results", "solver_runs"
   ]


### PR DESCRIPTION
## Summary
- Trim-only round across 3 multi-table migrations (#056, #064, #075). No files absorbed.
- All field-property and rule mutations folded directly into base CREATE #045 (`attendee.cascadeDelete=true`, `preferred_name.max=200`, all five rules = `@request.auth.is_admin = true`).
- Net delta: **0 files** in `pocketbase/pb_migrations/`. Value comes from advancing the three multi-table files toward eventual deletion.
- Verified empirically by `scripts/dev/verify-consolidation.sh`: `schemas match` between proposed (4 modified files) and current origin/main set.

Trimmed:
- `#056 increase_field_limits` — removed the `quest_registrations.preferred_name` 100→200 block from up() and rollback. File still bumps 3 fields on `staff_applications`.
- `#064 cascade_delete_sync_orphan_blockers` — removed the `quest_registrations.attendee` cascadeDelete=true block from up() and rollback; renumbered remaining inline comments. File still applies cascade-delete to 7 other tables.
- `#075 rbac_tier2_rules` — removed `"quest_registrations"` from the `tier2` array and the rollback `all` array. File still applies tier-2 RBAC to 22 other collections.

Final state of `quest_registrations`: 54 fields, 3 indexes (unique on `(person_id, year)`, index on `attendee`, index on `year`), rules = admin-only across the board.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green
- [ ] After merge, prod boot's OnServe `migrate history-sync` hook is a no-op for this round (no files deleted, only edits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Infrastructure & Stability**
  * Enhanced access control with stricter permissions for sensitive data.
  * Improved data integrity through cascading deletion safeguards for related records.
  * Increased field capacity limits to support larger text inputs.
  * Updated access tier rules for better system security and organization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1301)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->