### PR TITLE
refactor(pb): consolidate bunk_plans migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000017_bunk_plans.js
+++ b/pocketbase/pb_migrations/1500000017_bunk_plans.js
@@ -16,15 +16,18 @@ migrate((app) => {
   const bunksCol = app.findCollectionByNameOrId("bunks")
   const sessionsCol = app.findCollectionByNameOrId("camp_sessions")
 
+  const adminOnly = '@request.auth.is_admin = true'
+  const authed = '@request.auth.id != ""'
+
   const collection = new Collection({
     id: COLLECTION_ID_BUNK_PLANS,
     name: "bunk_plans",
     type: "base",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: authed,
+    viewRule: authed,
+    createRule: adminOnly,
+    updateRule: adminOnly,
+    deleteRule: adminOnly,
     fields: [
       {
         name: "cm_id",
@@ -41,7 +44,7 @@ migrate((app) => {
         required: true,
         presentable: true,
         collectionId: bunksCol.id,
-        cascadeDelete: false,
+        cascadeDelete: true,
         minSelect: null,
         maxSelect: 1
       },
@@ -51,7 +54,7 @@ migrate((app) => {
         required: true,
         presentable: true,
         collectionId: sessionsCol.id,
-        cascadeDelete: false,
+        cascadeDelete: true,
         minSelect: null,
         maxSelect: 1
       },

--- a/pocketbase/pb_migrations/1500000064_cascade_delete_sync_orphan_blockers.js
+++ b/pocketbase/pb_migrations/1500000064_cascade_delete_sync_orphan_blockers.js
@@ -3,7 +3,7 @@
  * Migration: Enable cascadeDelete on remaining orphan-blocking relations
  *
  * Extends migration 1500000059 which fixed 5 derived-table relations.
- * This migration fixes the remaining 6 relations where child tables have
+ * This migration fixes the remaining 4 relations where child tables have
  * required references with cascadeDelete=false to parent tables that perform
  * orphan deletion during sync.
  *

--- a/pocketbase/pb_migrations/1500000064_cascade_delete_sync_orphan_blockers.js
+++ b/pocketbase/pb_migrations/1500000064_cascade_delete_sync_orphan_blockers.js
@@ -14,8 +14,6 @@
  * per year). Cascade operates on PB IDs, not CampMinder IDs.
  *
  * Affected relations:
- * - bunk_plans.bunk -> bunks
- * - bunk_plans.session -> camp_sessions
  * - camper_dietary.attendee -> attendees
  * - camper_transportation.attendee -> attendees
  * - locked_group_members.attendee -> attendees
@@ -27,40 +25,15 @@
  * baked into merged CREATE migration #045.
  * Note: staff_applications.staff trimmed — final cascadeDelete: true
  * baked into merged CREATE migration #046.
+ * Note: bunk_plans.bunk + bunk_plans.session trimmed — final cascadeDelete: true
+ * baked into merged CREATE migration #017.
  */
 
 migrate((app) => {
-  const bunksCol = app.findCollectionByNameOrId("bunks")
-  const sessionsCol = app.findCollectionByNameOrId("camp_sessions")
   const attendeesCol = app.findCollectionByNameOrId("attendees")
   const staffCol = app.findCollectionByNameOrId("staff")
 
-  // 1. bunk_plans.bunk -> bunks
-  const bunkPlans = app.findCollectionByNameOrId("bunk_plans")
-  bunkPlans.fields.add(new Field({
-    type: "relation",
-    name: "bunk",
-    required: true,
-    presentable: true,
-    collectionId: bunksCol.id,
-    cascadeDelete: true,
-    minSelect: null,
-    maxSelect: 1
-  }))
-  // 2. bunk_plans.session -> camp_sessions
-  bunkPlans.fields.add(new Field({
-    type: "relation",
-    name: "session",
-    required: true,
-    presentable: true,
-    collectionId: sessionsCol.id,
-    cascadeDelete: true,
-    minSelect: null,
-    maxSelect: 1
-  }))
-  app.save(bunkPlans)
-
-  // 3. camper_dietary.attendee -> attendees
+  // 1. camper_dietary.attendee -> attendees
   const camperDietary = app.findCollectionByNameOrId("camper_dietary")
   camperDietary.fields.add(new Field({
     type: "relation",
@@ -74,7 +47,7 @@ migrate((app) => {
   }))
   app.save(camperDietary)
 
-  // 4. camper_transportation.attendee -> attendees
+  // 2. camper_transportation.attendee -> attendees
   const camperTransport = app.findCollectionByNameOrId("camper_transportation")
   camperTransport.fields.add(new Field({
     type: "relation",
@@ -88,7 +61,7 @@ migrate((app) => {
   }))
   app.save(camperTransport)
 
-  // 5. locked_group_members.attendee -> attendees
+  // 3. locked_group_members.attendee -> attendees
   const lockedGroupMembers = app.findCollectionByNameOrId("locked_group_members")
   lockedGroupMembers.fields.add(new Field({
     type: "relation",
@@ -102,7 +75,7 @@ migrate((app) => {
   }))
   app.save(lockedGroupMembers)
 
-  // 6. staff_vehicle_info.staff -> staff
+  // 4. staff_vehicle_info.staff -> staff
   const staffVehicle = app.findCollectionByNameOrId("staff_vehicle_info")
   staffVehicle.fields.add(new Field({
     type: "relation",
@@ -117,23 +90,10 @@ migrate((app) => {
   app.save(staffVehicle)
 
 }, (app) => {
-  const bunksCol = app.findCollectionByNameOrId("bunks")
-  const sessionsCol = app.findCollectionByNameOrId("camp_sessions")
   const attendeesCol = app.findCollectionByNameOrId("attendees")
   const staffCol = app.findCollectionByNameOrId("staff")
 
   // Revert all to cascadeDelete: false
-
-  const bunkPlans = app.findCollectionByNameOrId("bunk_plans")
-  bunkPlans.fields.add(new Field({
-    type: "relation", name: "bunk", required: true, presentable: true,
-    collectionId: bunksCol.id, cascadeDelete: false, minSelect: null, maxSelect: 1
-  }))
-  bunkPlans.fields.add(new Field({
-    type: "relation", name: "session", required: true, presentable: true,
-    collectionId: sessionsCol.id, cascadeDelete: false, minSelect: null, maxSelect: 1
-  }))
-  app.save(bunkPlans)
 
   const camperDietary = app.findCollectionByNameOrId("camper_dietary")
   camperDietary.fields.add(new Field({

--- a/pocketbase/pb_migrations/1500000074_rbac_tier1_rules.js
+++ b/pocketbase/pb_migrations/1500000074_rbac_tier1_rules.js
@@ -34,8 +34,9 @@ migrate((app) => {
   }
 
   // Read-only: bunking.view (bunking data written by sync/solver)
-  // Note: "bunk_assignments" trimmed — final-state rules baked into merged CREATE.
-  const bunkingViewReadOnly = ["bunk_plans", "bunks"]
+  // Note: "bunk_assignments", "bunk_plans" trimmed — final-state rules baked into merged CREATE.
+  // (bunk_plans final-state rules from #077 simplification: list/view = authed, c/u/d = adminOnly.)
+  const bunkingViewReadOnly = ["bunks"]
   for (const name of bunkingViewReadOnly) {
     setRules(name, bunkingView, bunkingView, adminOnly, adminOnly, adminOnly)
   }
@@ -77,7 +78,7 @@ migrate((app) => {
 
   const collections = [
     "camp_sessions", "divisions",
-    "bunk_plans", "bunks",
+    "bunks",
     "locked_groups", "locked_group_members", "saved_scenarios"
   ]
   for (const name of collections) {

--- a/pocketbase/pb_migrations/1500000077_rbac_simplify_rules.js
+++ b/pocketbase/pb_migrations/1500000077_rbac_simplify_rules.js
@@ -30,8 +30,8 @@ migrate((app) => {
   }
 
   // Previously bunking.view — now any authenticated user
-  // Note: "bunk_assignments" trimmed — final-state rules baked into merged CREATE.
-  const bunkingReadOnly = ["bunk_plans", "bunks"]
+  // Note: "bunk_assignments", "bunk_plans" trimmed — final-state rules baked into merged CREATE.
+  const bunkingReadOnly = ["bunks"]
   for (const name of bunkingReadOnly) {
     setRules(name, authed, authed, adminOnly, adminOnly, adminOnly)
   }
@@ -63,7 +63,7 @@ migrate((app) => {
     setRules(name, anyRole, anyRole, adminOnly, adminOnly, adminOnly)
   }
 
-  const bunkingViewReadOnly = ["bunk_plans", "bunks"]
+  const bunkingViewReadOnly = ["bunks"]
   for (const name of bunkingViewReadOnly) {
     setRules(name, bunkingView, bunkingView, adminOnly, adminOnly, adminOnly)
   }


### PR DESCRIPTION
## Summary
- Trims 3 multi-table modify-migrations (#1500000064 cascade-delete, #1500000074 RBAC tier-1, #1500000077 RBAC simplification) by removing `bunk_plans` from each; folds the final-state effects directly into base CREATE #1500000017.
- Net delta: **0 files** in `pocketbase/pb_migrations/` (all three trimmed files still serve other tables).
- Verified empirically by `scripts/dev/verify-consolidation.sh` against `origin/main`: schemas match between proposed (64 files) and current (64 files).

Trimmed:
- `1500000064_cascade_delete_sync_orphan_blockers.js` — removed both `bunk_plans.bunk` and `bunk_plans.session` blocks from up() and rollback; dropped the `bunksCol`/`sessionsCol` lookups (only used for bunk_plans); renumbered remaining comments 3→1, 4→2, 5→3, 6→4. Still applies cascade-delete to 4 other tables.
- `1500000074_rbac_tier1_rules.js` — removed `"bunk_plans"` from `bunkingViewReadOnly` (array now `["bunks"]`) and from rollback `collections` array. Still applies tier-1 RBAC to `bunks` and 5 other collections.
- `1500000077_rbac_simplify_rules.js` — removed `"bunk_plans"` from `bunkingReadOnly` (up) and from `bunkingViewReadOnly` (rollback). Final-state rules baked into #017. Still simplifies rules for `bunks` and 2 other collections.

Folded into #017:
- `bunk.cascadeDelete: false → true` (from #064)
- `session.cascadeDelete: false → true` (from #064)
- Rules: c/u/d tightened from `@request.auth.id != ""` to `@request.auth.is_admin = true` (final state per #077, which superseded #074's transient bunkingView).

Final state of `bunk_plans`: 9 fields unchanged set; 3 indexes unchanged; list/view = `@request.auth.id != ""`, c/u/d = `@request.auth.is_admin = true`.

Notes:
- First three-multi-table-trim round (prior rounds touched 1–2 multi-table files). The transient #074 `bunkingView` state was correctly superseded by #077's `authed` state — only #077's outcome lands in the merged CREATE, matching the harness's "final-state wins" model.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data integrity by enabling cascade deletion so dependent records are removed when related items are deleted.

* **Chores**
  * Updated access control rules and permission checks, adjusting which collections are readable by authenticated users and refining role/permission scopes for collections such as camp_sessions, divisions, bunks, bunk_plans, locked_groups, locked_group_members, saved_scenarios, and user auth listings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1304)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->