### PR TITLE
refactor(pb): consolidate camper_dietary migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000044_camper_dietary.js
+++ b/pocketbase/pb_migrations/1500000044_camper_dietary.js
@@ -15,11 +15,11 @@ migrate((app) => {
   const collection = new Collection({
     type: "base",
     name: "camper_dietary",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: null,
-    updateRule: null,
-    deleteRule: null,
+    listRule: '@request.auth.is_admin = true',
+    viewRule: '@request.auth.is_admin = true',
+    createRule: '@request.auth.is_admin = true',
+    updateRule: '@request.auth.is_admin = true',
+    deleteRule: '@request.auth.is_admin = true',
     fields: [
       // === Core Identity ===
       {
@@ -28,7 +28,7 @@ migrate((app) => {
         required: true,
         presentable: false,
         collectionId: attendeesCol.id,
-        cascadeDelete: false,
+        cascadeDelete: true,
         minSelect: null,
         maxSelect: 1
       },

--- a/pocketbase/pb_migrations/1500000064_cascade_delete_sync_orphan_blockers.js
+++ b/pocketbase/pb_migrations/1500000064_cascade_delete_sync_orphan_blockers.js
@@ -14,7 +14,6 @@
  * per year). Cascade operates on PB IDs, not CampMinder IDs.
  *
  * Affected relations:
- * - camper_dietary.attendee -> attendees
  * - camper_transportation.attendee -> attendees
  * - locked_group_members.attendee -> attendees
  * - staff_vehicle_info.staff -> staff
@@ -27,25 +26,13 @@
  * baked into merged CREATE migration #046.
  * Note: bunk_plans.bunk + bunk_plans.session trimmed — final cascadeDelete: true
  * baked into merged CREATE migration #017.
+ * Note: camper_dietary.attendee trimmed — final cascadeDelete: true
+ * baked into merged CREATE migration #044.
  */
 
 migrate((app) => {
   const attendeesCol = app.findCollectionByNameOrId("attendees")
   const staffCol = app.findCollectionByNameOrId("staff")
-
-  // 1. camper_dietary.attendee -> attendees
-  const camperDietary = app.findCollectionByNameOrId("camper_dietary")
-  camperDietary.fields.add(new Field({
-    type: "relation",
-    name: "attendee",
-    required: true,
-    presentable: false,
-    collectionId: attendeesCol.id,
-    cascadeDelete: true,
-    minSelect: null,
-    maxSelect: 1
-  }))
-  app.save(camperDietary)
 
   // 2. camper_transportation.attendee -> attendees
   const camperTransport = app.findCollectionByNameOrId("camper_transportation")
@@ -94,13 +81,6 @@ migrate((app) => {
   const staffCol = app.findCollectionByNameOrId("staff")
 
   // Revert all to cascadeDelete: false
-
-  const camperDietary = app.findCollectionByNameOrId("camper_dietary")
-  camperDietary.fields.add(new Field({
-    type: "relation", name: "attendee", required: true, presentable: false,
-    collectionId: attendeesCol.id, cascadeDelete: false, minSelect: null, maxSelect: 1
-  }))
-  app.save(camperDietary)
 
   const camperTransport = app.findCollectionByNameOrId("camper_transportation")
   camperTransport.fields.add(new Field({

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -8,6 +8,8 @@
  *
  * Note: staff_applications trimmed — final adminOnly rules baked into
  * merged CREATE migration #046.
+ * Note: camper_dietary trimmed — final adminOnly rules baked into
+ * merged CREATE migration #044.
  */
 
 migrate((app) => {
@@ -27,7 +29,7 @@ migrate((app) => {
   const tier2 = [
     "household_custom_values",
     "financial_transactions", "financial_categories",
-    "payment_methods", "camper_dietary", "camper_transportation",
+    "payment_methods", "camper_transportation",
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills", "staff_vehicle_info",
     "person_custom_values", "person_tag_defs", "custom_field_defs",
@@ -64,7 +66,7 @@ migrate((app) => {
   const all = [
     "household_custom_values",
     "financial_transactions", "financial_categories",
-    "payment_methods", "camper_dietary", "camper_transportation",
+    "payment_methods", "camper_transportation",
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills", "staff_vehicle_info",
     "person_custom_values", "person_tag_defs", "custom_field_defs",


### PR DESCRIPTION
## Summary
- Trim-only round. Folds two multi-table mutations into the `camper_dietary` base CREATE (`1500000044_camper_dietary.js`).
- Net delta: **0 files** in `pocketbase/pb_migrations/`
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match between proposed and current.

Trimmed multi-table files:
- `1500000064_cascade_delete_sync_orphan_blockers.js` — `camper_dietary.attendee` block trimmed from `up()` and `down()`. Final `cascadeDelete: true` baked into `#044`'s initial fields array (upsert-preserving-position; field order unchanged). `#064` still applies cascade-delete to `camper_transportation`, `locked_group_members`, `staff_vehicle_info`.
- `1500000075_rbac_tier2_rules.js` — `"camper_dietary"` removed from `tier2[]` (up) and `all[]` (down). Final adminOnly rules baked into `#044`'s initial CREATE config.

Final state of `camper_dietary`: 10 fields (`attendee` with `cascadeDelete=true`, `person_id`, `year`, `has_dietary_needs`, `dietary_explanation`, `has_allergies`, `allergy_info`, `additional_medical`, `created`, `updated`), 4 indexes, 5 adminOnly rules (`list/view/create/update/delete = '@request.auth.is_admin = true'`).

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green
- [ ] After merge, prod boot's OnServe `migrate history-sync` hook is a no-op (no files deleted this round)

🤖 Generated with [Claude Code](https://claude.com/claude-code)