### PR TITLE
fix(scripts): pre-push-verify.sh handles deleted files

### DIFF
--- a/.claude/skills/pre-push-verification/scripts/verify.sh
+++ b/.claude/skills/pre-push-verification/scripts/verify.sh
@@ -45,10 +45,12 @@ else
     BASE="HEAD~1"
 fi
 
-CHANGED_FILES=$(git diff --name-only "$BASE" HEAD 2>/dev/null || true)
+# --diff-filter=ACMRT excludes Deletions (and Unmerged/X) so per-file loops
+# below don't try to head/grep paths that no longer exist on disk.
+CHANGED_FILES=$(git diff --diff-filter=ACMRT --name-only "$BASE" HEAD 2>/dev/null || true)
 # Also include staged but uncommitted changes and unstaged modifications
-CHANGED_FILES="$CHANGED_FILES"$'\n'$(git diff --name-only --cached 2>/dev/null || true)
-CHANGED_FILES="$CHANGED_FILES"$'\n'$(git diff --name-only 2>/dev/null || true)
+CHANGED_FILES="$CHANGED_FILES"$'\n'$(git diff --diff-filter=ACMRT --name-only --cached 2>/dev/null || true)
+CHANGED_FILES="$CHANGED_FILES"$'\n'$(git diff --diff-filter=ACMRT --name-only 2>/dev/null || true)
 # Deduplicate
 CHANGED_FILES=$(echo "$CHANGED_FILES" | sort -u | grep -v '^$' || true)
 

--- a/scripts/pre-push-verify.sh
+++ b/scripts/pre-push-verify.sh
@@ -45,10 +45,12 @@ else
     BASE="HEAD~1"
 fi
 
-CHANGED_FILES=$(git diff --name-only "$BASE" HEAD 2>/dev/null || true)
+# --diff-filter=ACMRT excludes Deletions (and Unmerged/X) so per-file loops
+# below don't try to head/grep paths that no longer exist on disk.
+CHANGED_FILES=$(git diff --diff-filter=ACMRT --name-only "$BASE" HEAD 2>/dev/null || true)
 # Also include staged but uncommitted changes and unstaged modifications
-CHANGED_FILES="$CHANGED_FILES"$'\n'$(git diff --name-only --cached 2>/dev/null || true)
-CHANGED_FILES="$CHANGED_FILES"$'\n'$(git diff --name-only 2>/dev/null || true)
+CHANGED_FILES="$CHANGED_FILES"$'\n'$(git diff --diff-filter=ACMRT --name-only --cached 2>/dev/null || true)
+CHANGED_FILES="$CHANGED_FILES"$'\n'$(git diff --diff-filter=ACMRT --name-only 2>/dev/null || true)
 # Deduplicate
 CHANGED_FILES=$(echo "$CHANGED_FILES" | sort -u | grep -v '^$' || true)
 


### PR DESCRIPTION
Closes #1258.

## Summary
- Both `scripts/pre-push-verify.sh` and `.claude/skills/pre-push-verification/scripts/verify.sh` built `CHANGED_FILES` from `git diff --name-only`, which includes deleted paths. The migration-header loop then ran `head -1 "$file"` on those paths, failed under `set -euo pipefail`, and produced a false `FAIL migration headers` (the `options:{}` check produced the same stderr noise but didn't false-fail).
- Adds `--diff-filter=ACMRT` to all three `git diff` invocations in each script — excludes Deletions/Unmerged/X at the source so every per-file loop downstream is safe.
- Minimal diff: 3 lines per script + a 2-line comment explaining the filter. No behavior change for non-deletion workflows.

## Test plan
- [x] Reproduced the bug against origin/main's script with a staged migration deletion — `FAIL migration headers` fires with `head: cannot open …` and `grep: … No such file or directory` noise.
- [x] Patched script on the same state — silent, no false FAIL, no stderr noise.
- [x] `shellcheck --severity=warning scripts/pre-push-verify.sh` — clean.
- [ ] CI green.

## Out of scope
- Long-term de-duplication of the two near-identical scripts into one source of truth (called out in the issue).
- Pre-existing `SC2221/SC2222` warnings in `verify.sh`'s case patterns (present on main).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved pre-push verification scripts to more accurately detect changed files by filtering out deletions and non-applicable file states.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1306)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->