### PR TITLE
refactor(pb): consolidate camper_transportation migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000043_camper_transportation.js
+++ b/pocketbase/pb_migrations/1500000043_camper_transportation.js
@@ -16,11 +16,11 @@ migrate((app) => {
   const collection = new Collection({
     type: "base",
     name: "camper_transportation",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: null,
-    updateRule: null,
-    deleteRule: null,
+    listRule: '@request.auth.is_admin = true',
+    viewRule: '@request.auth.is_admin = true',
+    createRule: '@request.auth.is_admin = true',
+    updateRule: '@request.auth.is_admin = true',
+    deleteRule: '@request.auth.is_admin = true',
     fields: [
       // === Core Identity ===
       {
@@ -29,7 +29,7 @@ migrate((app) => {
         required: true,
         presentable: false,
         collectionId: attendeesCol.id,
-        cascadeDelete: false,
+        cascadeDelete: true,
         minSelect: null,
         maxSelect: 1
       },

--- a/pocketbase/pb_migrations/1500000064_cascade_delete_sync_orphan_blockers.js
+++ b/pocketbase/pb_migrations/1500000064_cascade_delete_sync_orphan_blockers.js
@@ -14,7 +14,6 @@
  * per year). Cascade operates on PB IDs, not CampMinder IDs.
  *
  * Affected relations:
- * - camper_transportation.attendee -> attendees
  * - locked_group_members.attendee -> attendees
  * - staff_vehicle_info.staff -> staff
  *
@@ -28,25 +27,13 @@
  * baked into merged CREATE migration #017.
  * Note: camper_dietary.attendee trimmed — final cascadeDelete: true
  * baked into merged CREATE migration #044.
+ * Note: camper_transportation.attendee trimmed — final cascadeDelete: true
+ * baked into merged CREATE migration #043.
  */
 
 migrate((app) => {
   const attendeesCol = app.findCollectionByNameOrId("attendees")
   const staffCol = app.findCollectionByNameOrId("staff")
-
-  // 2. camper_transportation.attendee -> attendees
-  const camperTransport = app.findCollectionByNameOrId("camper_transportation")
-  camperTransport.fields.add(new Field({
-    type: "relation",
-    name: "attendee",
-    required: true,
-    presentable: false,
-    collectionId: attendeesCol.id,
-    cascadeDelete: true,
-    minSelect: null,
-    maxSelect: 1
-  }))
-  app.save(camperTransport)
 
   // 3. locked_group_members.attendee -> attendees
   const lockedGroupMembers = app.findCollectionByNameOrId("locked_group_members")
@@ -81,13 +68,6 @@ migrate((app) => {
   const staffCol = app.findCollectionByNameOrId("staff")
 
   // Revert all to cascadeDelete: false
-
-  const camperTransport = app.findCollectionByNameOrId("camper_transportation")
-  camperTransport.fields.add(new Field({
-    type: "relation", name: "attendee", required: true, presentable: false,
-    collectionId: attendeesCol.id, cascadeDelete: false, minSelect: null, maxSelect: 1
-  }))
-  app.save(camperTransport)
 
   const lockedGroupMembers = app.findCollectionByNameOrId("locked_group_members")
   lockedGroupMembers.fields.add(new Field({

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -10,6 +10,8 @@
  * merged CREATE migration #046.
  * Note: camper_dietary trimmed — final adminOnly rules baked into
  * merged CREATE migration #044.
+ * Note: camper_transportation trimmed — final adminOnly rules baked into
+ * merged CREATE migration #043.
  */
 
 migrate((app) => {
@@ -29,7 +31,7 @@ migrate((app) => {
   const tier2 = [
     "household_custom_values",
     "financial_transactions", "financial_categories",
-    "payment_methods", "camper_transportation",
+    "payment_methods",
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills", "staff_vehicle_info",
     "person_custom_values", "person_tag_defs", "custom_field_defs",
@@ -66,7 +68,7 @@ migrate((app) => {
   const all = [
     "household_custom_values",
     "financial_transactions", "financial_categories",
-    "payment_methods", "camper_transportation",
+    "payment_methods",
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills", "staff_vehicle_info",
     "person_custom_values", "person_tag_defs", "custom_field_defs",


### PR DESCRIPTION
## Summary
- Trim-only round. Folds two multi-table mutations into the `camper_transportation` base CREATE (`1500000043_camper_transportation.js`).
- Net delta: **0 files** in `pocketbase/pb_migrations/`
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match between proposed and current.
- Identical shape to PR #1305 (camper_dietary): same CREATE + #064 + #075 template.

Trimmed multi-table files:
- `1500000064_cascade_delete_sync_orphan_blockers.js` — `camper_transportation.attendee` block trimmed from `up()` and `down()`. Final `cascadeDelete: true` baked into `#043`'s initial fields array (upsert-preserving-position; field order unchanged). `#064` still applies cascade-delete to `locked_group_members`, `staff_vehicle_info`.
- `1500000075_rbac_tier2_rules.js` — `"camper_transportation"` removed from `tier2[]` (up) and `all[]` (down). Final adminOnly rules baked into `#043`'s initial CREATE config.

Final state of `camper_transportation`: 19 fields (`attendee` with `cascadeDelete=true`, `person_id`, `session_id`, `year`, `to_camp_method`, `from_camp_method`, `dropoff_name/phone/relationship`, `pickup_name/phone/relationship`, `alt_pickup_1/2_*`, `used_legacy_fields`, `created`, `updated`), 3 indexes, 5 adminOnly rules.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green
- [ ] After merge, prod boot's OnServe `migrate history-sync` hook is a no-op (no files deleted this round)

🤖 Generated with [Claude Code](https://claude.com/claude-code)