### PR TITLE
refactor(pb): consolidate locked_group_members migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000025_locked_group_members.js
+++ b/pocketbase/pb_migrations/1500000025_locked_group_members.js
@@ -15,15 +15,17 @@ migrate((app) => {
   const lockedGroupsCol = app.findCollectionByNameOrId("locked_groups")
   const attendeesCol = app.findCollectionByNameOrId("attendees")
 
+  const bunkingManage = '@request.auth.is_admin = true || @request.auth.cached_permissions ~ "bunking.manage"'
+
   const collection = new Collection({
     id: "col_locked_members",
     type: "base",
     name: "locked_group_members",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: bunkingManage,
+    viewRule: bunkingManage,
+    createRule: bunkingManage,
+    updateRule: bunkingManage,
+    deleteRule: bunkingManage,
     fields: [
       {
         type: "relation",
@@ -41,7 +43,7 @@ migrate((app) => {
         required: true,
         presentable: true,
         collectionId: attendeesCol.id,
-        cascadeDelete: false,
+        cascadeDelete: true,
         minSelect: null,
         maxSelect: 1
       },

--- a/pocketbase/pb_migrations/1500000064_cascade_delete_sync_orphan_blockers.js
+++ b/pocketbase/pb_migrations/1500000064_cascade_delete_sync_orphan_blockers.js
@@ -14,7 +14,6 @@
  * per year). Cascade operates on PB IDs, not CampMinder IDs.
  *
  * Affected relations:
- * - locked_group_members.attendee -> attendees
  * - staff_vehicle_info.staff -> staff
  *
  * Note: original_bunk_requests.requester trimmed — final cascadeDelete: true
@@ -29,25 +28,12 @@
  * baked into merged CREATE migration #044.
  * Note: camper_transportation.attendee trimmed — final cascadeDelete: true
  * baked into merged CREATE migration #043.
+ * Note: locked_group_members.attendee trimmed — final cascadeDelete: true
+ * baked into merged CREATE migration #025.
  */
 
 migrate((app) => {
-  const attendeesCol = app.findCollectionByNameOrId("attendees")
   const staffCol = app.findCollectionByNameOrId("staff")
-
-  // 3. locked_group_members.attendee -> attendees
-  const lockedGroupMembers = app.findCollectionByNameOrId("locked_group_members")
-  lockedGroupMembers.fields.add(new Field({
-    type: "relation",
-    name: "attendee",
-    required: true,
-    presentable: true,
-    collectionId: attendeesCol.id,
-    cascadeDelete: true,
-    minSelect: null,
-    maxSelect: 1
-  }))
-  app.save(lockedGroupMembers)
 
   // 4. staff_vehicle_info.staff -> staff
   const staffVehicle = app.findCollectionByNameOrId("staff_vehicle_info")
@@ -64,17 +50,9 @@ migrate((app) => {
   app.save(staffVehicle)
 
 }, (app) => {
-  const attendeesCol = app.findCollectionByNameOrId("attendees")
   const staffCol = app.findCollectionByNameOrId("staff")
 
   // Revert all to cascadeDelete: false
-
-  const lockedGroupMembers = app.findCollectionByNameOrId("locked_group_members")
-  lockedGroupMembers.fields.add(new Field({
-    type: "relation", name: "attendee", required: true, presentable: true,
-    collectionId: attendeesCol.id, cascadeDelete: false, minSelect: null, maxSelect: 1
-  }))
-  app.save(lockedGroupMembers)
 
   const staffVehicle = app.findCollectionByNameOrId("staff_vehicle_info")
   staffVehicle.fields.add(new Field({

--- a/pocketbase/pb_migrations/1500000074_rbac_tier1_rules.js
+++ b/pocketbase/pb_migrations/1500000074_rbac_tier1_rules.js
@@ -49,8 +49,8 @@ migrate((app) => {
   }
 
   // Read+Write: bunking.manage (frontend writes directly)
-  // Note: "bunk_assignments_draft" trimmed — all 5 rules use bunkingManage, baked into merged CREATE.
-  const bunkingManageReadWrite = ["locked_groups", "locked_group_members", "saved_scenarios"]
+  // Note: "bunk_assignments_draft", "locked_group_members" trimmed — all 5 rules use bunkingManage, baked into merged CREATE.
+  const bunkingManageReadWrite = ["locked_groups", "saved_scenarios"]
   for (const name of bunkingManageReadWrite) {
     setRules(name, bunkingManage, bunkingManage, bunkingManage, bunkingManage, bunkingManage)
   }
@@ -79,7 +79,7 @@ migrate((app) => {
   const collections = [
     "camp_sessions", "divisions",
     "bunks",
-    "locked_groups", "locked_group_members", "saved_scenarios"
+    "locked_groups", "saved_scenarios"
   ]
   for (const name of collections) {
     revertRules(name)


### PR DESCRIPTION
## Summary
- Trim-only round on `locked_group_members`. Folds the table's mutations from two multi-table migrations into base #1500000025.
- Trimmed `#1500000064` (cascade-delete-sync-orphan-blockers) — removed `locked_group_members.attendee` block from up()/down(). Only `staff_vehicle_info` remains in #064; one more round deletes the file entirely.
- Trimmed `#1500000074` (rbac_tier1_rules) — removed `"locked_group_members"` from `bunkingManageReadWrite[]` (up) and rollback `collections[]` (down).
- Net delta: **0 files** (trim-only). Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match between proposed (modified) and current (origin/main).

Folded into merged CREATE #025:
- `attendee.cascadeDelete: false → true` (from #064)
- All 5 rules → `bunkingManage` (from #074). Original was `@request.auth.id != ""` for all 5.

Final state of `locked_group_members`: 3 fields (group, attendee, added_by), 3 indexes (unique on group+attendee, plus singles on each), all 5 rules = `@request.auth.is_admin = true || @request.auth.cached_permissions ~ "bunking.manage"`.

Same shape as `camper_dietary` (#1305) and `camper_transportation` (#1307) rounds — all three follow the "CREATE + #064 cascade + tier-X rbac" template.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green
- [ ] After merge, prod boot's OnServe `migrate history-sync` hook is a no-op (no files removed this round)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated access control rules to require elevated privileges for managing sensitive data collections
  * Enhanced data consistency and integrity by enabling cascade delete behavior for dependent records
  * Refined role-based access control tier 1 rules for improved permission management and access control consistency across restricted collections

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1313)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->