### PR TITLE
ci(security): add step-security/harden-runner in audit mode

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -60,6 +60,11 @@ jobs:
       docker: ${{ steps.filter.outputs.docker }}
       initial_commit: ${{ steps.get-base-sha.outputs.initial_commit }}
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+      with:
+        egress-policy: audit
+
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -143,6 +148,11 @@ jobs:
     permissions:
       checks: read
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+      with:
+        egress-policy: audit
+
     - name: Check CI and docs status for this commit
       env:
         GH_TOKEN: ${{ github.token }}
@@ -264,6 +274,11 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+      with:
+        egress-policy: audit
+
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -320,6 +335,11 @@ jobs:
       security-events: write
 
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+      with:
+        egress-policy: audit
+
     - name: Check if build needed
       id: check
       env:
@@ -721,6 +741,11 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+      with:
+        egress-policy: audit
+
     - name: Check build status
       env:
         BUILD_RESULT: ${{ needs.build-test-push.result }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,6 +25,11 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,6 +11,11 @@ jobs:
     if: github.triggering_actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v2
         id: metadata
       - if: steps.metadata.outputs.update-type != 'version-update:semver-major'

--- a/.github/workflows/dependabot-lockfile-fixup.yml
+++ b/.github/workflows/dependabot-lockfile-fixup.yml
@@ -23,6 +23,11 @@ jobs:
     if: github.actor == 'dependabot[bot]' || startsWith(github.head_ref, 'dependabot/')
     runs-on: ubuntu-latest
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - name: Checkout Dependabot branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+      with:
+        egress-policy: audit
+
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         fetch-depth: 0


### PR DESCRIPTION
## Summary

- Adds `step-security/harden-runner@v2.19.1` (SHA-pinned to `a5ad31d6`) in **audit-only** mode to 9 jobs across 5 workflows that handle secrets or push to `ghcr.io`.
- Defends against runtime egress from pinned-but-compromised transitive actions (glassworm / tj-actions-style supply chain attacks). All actions in the repo are already SHA-pinned; this adds runtime monitoring on top.
- No behavior change — `egress-policy: audit` only logs traffic; a follow-up PR will flip `cd.yml` + `release.yml` to `block` mode with explicit `allowed-endpoints` once the step-security dashboard has 1–2 weeks of baseline data.

### Workflows touched

| Workflow | Jobs | Why |
|---|---|---|
| `cd.yml` | 5 | Pushes Docker images to ghcr.io; holds `DHI_TOKEN`, `KINDRED_LOCAL_DEPLOY_KEY` |
| `release.yml` | 1 | Holds `RELEASE_TOKEN` (contents:write PAT); creates tags + GH releases |
| `claude.yml` | 1 | Holds `CLAUDE_CODE_OAUTH_TOKEN` (can edit PRs/issues) |
| `dependabot-lockfile-fixup.yml` | 1 | `contents: write` — pushes lockfile commits |
| `dependabot-auto-merge.yml` | 1 | `contents: write` + `pull-requests: write` — auto-merges |

Skipped: `ci.yml` (13 jobs, read-only, would be high-noise/low-value), `docs-check.yml`, `semantic-pr.yml`, `setup-labels.yml`.

## Test plan

- [ ] CI Summary passes
- [ ] The harden-runner step itself appears as a passing step in each affected workflow run
- [ ] After 1–2 weeks of merged-to-main traffic, check the step-security dashboard at https://app.stepsecurity.io for the baseline endpoint report
- [ ] Open follow-up PR to flip `cd.yml` + `release.yml` to `block` mode with allowlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows across continuous deployment, code validation, dependency management automation, and release processes with enhanced runner monitoring capabilities. Outbound network traffic is now subject to audit logging during all workflow executions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1318)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->