### PR TITLE
feat(frontend): make tour opt-in only, drop staleness PB config

### DIFF
--- a/frontend/src/hooks/useTour.test.tsx
+++ b/frontend/src/hooks/useTour.test.tsx
@@ -57,13 +57,12 @@ async function flushAndAdvance(ms: number) {
 
 describe('useTour', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     vi.useFakeTimers()
     vi.mocked(tourRegistry.getTourIdForRoute).mockReturnValue('debug')
     vi.mocked(tourRegistry.loadTourDefinition).mockResolvedValue(mockTourDefinition)
     vi.mocked(tourRegistry.loadLayerDefinition).mockResolvedValue(mockLayerDefinition)
     vi.mocked(tourStorage.getTourStorage).mockReturnValue({ layers: {} })
-    mockDrive.mockClear()
-    mockDestroy.mockClear()
   })
 
   afterEach(() => {

--- a/frontend/src/hooks/useTour.test.tsx
+++ b/frontend/src/hooks/useTour.test.tsx
@@ -5,18 +5,12 @@ import * as tourRegistry from '../tours/tourRegistry'
 import * as tourStorage from '../tours/tourStorage'
 import type { TourDefinition, LayerDefinition } from '../tours/types'
 
-// Mock the modules
 vi.mock('../tours/tourStorage')
 vi.mock('../tours/tourRegistry')
-vi.mock('./useSolverConfig', () => ({
-  useSolverConfigValue: vi.fn(() => 30),
-  useSolverConfig: vi.fn(() => ({ data: undefined })),
-}))
 vi.mock('react-router', () => ({
   useLocation: vi.fn(() => ({ pathname: '/summer/debug' })),
 }))
 
-// Mock driver.js - the driver function
 const mockDrive = vi.fn()
 const mockDestroy = vi.fn()
 const mockDriverInstance = {
@@ -49,17 +43,13 @@ const mockLayerDefinition: LayerDefinition = {
   ],
 }
 
-/** Flush microtasks (resolved promises) and advance fake timers */
 async function flushAndAdvance(ms: number) {
-  // Flush microtasks first (promise resolutions)
   await act(async () => {
     await Promise.resolve()
   })
-  // Advance fake timers
   await act(async () => {
     vi.advanceTimersByTime(ms)
   })
-  // Flush any remaining microtasks
   await act(async () => {
     await Promise.resolve()
   })
@@ -71,7 +61,7 @@ describe('useTour', () => {
     vi.mocked(tourRegistry.getTourIdForRoute).mockReturnValue('debug')
     vi.mocked(tourRegistry.loadTourDefinition).mockResolvedValue(mockTourDefinition)
     vi.mocked(tourRegistry.loadLayerDefinition).mockResolvedValue(mockLayerDefinition)
-    vi.mocked(tourStorage.getTourStorage).mockReturnValue({ completed: {}, layers: {} })
+    vi.mocked(tourStorage.getTourStorage).mockReturnValue({ layers: {} })
     mockDrive.mockClear()
     mockDestroy.mockClear()
   })
@@ -82,32 +72,34 @@ describe('useTour', () => {
 
   it('returns tourId when a tour exists for the current route', async () => {
     const { result } = renderHook(() => useTour())
-
     await flushAndAdvance(0)
-
     expect(result.current.tourId).toBe('debug')
   })
 
   it('returns null tourId when no tour exists for the route', async () => {
     vi.mocked(tourRegistry.getTourIdForRoute).mockReturnValue(null)
-
     const { result } = renderHook(() => useTour())
-
     await flushAndAdvance(0)
-
     expect(result.current.tourId).toBeNull()
   })
 
-  it('does not auto-start tour when tour has no layers', async () => {
-    renderHook(() => useTour())
+  it('never auto-starts the tour on mount, even with unseen layers', async () => {
+    const tourWithLayers: TourDefinition = {
+      ...mockTourDefinition,
+      id: 'retention-overview',
+      layers: ['metrics-header'],
+    }
+    vi.mocked(tourRegistry.getTourIdForRoute).mockReturnValue('retention-overview')
+    vi.mocked(tourRegistry.loadTourDefinition).mockResolvedValue(tourWithLayers)
+    vi.mocked(tourStorage.getTourStorage).mockReturnValue({ layers: {} })
 
-    await flushAndAdvance(1000)
+    renderHook(() => useTour())
+    await flushAndAdvance(5000)
 
     expect(mockDrive).not.toHaveBeenCalled()
   })
 
-  it('provides a replay function that starts the tour in manual mode', async () => {
-    // Mock querySelector so readiness check passes for the first step element
+  it('replay() starts the tour', async () => {
     const mockElement = document.createElement('div')
     const originalQuerySelector = document.querySelector.bind(document)
     vi.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
@@ -116,36 +108,25 @@ describe('useTour', () => {
     })
 
     const { result } = renderHook(() => useTour())
-
-    // Let the definition load
     await flushAndAdvance(1000)
-
-    // Tour should NOT have auto-started (no layers)
     expect(mockDrive).not.toHaveBeenCalled()
 
-    // Now replay
     act(() => {
       result.current.replay()
     })
-
     await flushAndAdvance(1000)
-
     expect(mockDrive).toHaveBeenCalled()
 
     vi.mocked(document.querySelector).mockRestore()
   })
 
   it('does not start tour when first step element is not in DOM', async () => {
-    // Since we're in a test env with no DOM, querySelector returns null
     const { result } = renderHook(() => useTour())
-
     await flushAndAdvance(1000)
 
-    // Trigger replay and wait for retry exhaustion
     act(() => {
       result.current.replay()
     })
-
     await flushAndAdvance(6000)
 
     expect(mockDrive).not.toHaveBeenCalled()
@@ -153,13 +134,11 @@ describe('useTour', () => {
 
   it('destroys driver instance when readiness timeout is exhausted', async () => {
     const { result } = renderHook(() => useTour())
-
     await flushAndAdvance(1000)
 
     act(() => {
       result.current.replay()
     })
-
     await flushAndAdvance(6000)
 
     expect(mockDestroy).toHaveBeenCalled()
@@ -167,80 +146,56 @@ describe('useTour', () => {
 
   it('cleans up driver instance on unmount', async () => {
     const { result, unmount } = renderHook(() => useTour())
-
     await flushAndAdvance(1000)
 
-    // Trigger replay so driver instance is created
     act(() => {
       result.current.replay()
     })
     await flushAndAdvance(1000)
 
     unmount()
-
     expect(mockDestroy).toHaveBeenCalled()
   })
 
-  describe('layer auto-play', () => {
-    it('auto-plays when tour has unseen layers', async () => {
-      const tourWithLayers: TourDefinition = {
-        ...mockTourDefinition,
-        id: 'retention-overview',
-        layers: ['metrics-header'],
-      }
-      vi.mocked(tourRegistry.getTourIdForRoute).mockReturnValue('retention-overview')
-      vi.mocked(tourRegistry.loadTourDefinition).mockResolvedValue(tourWithLayers)
-      // Storage has no layer records → unseen
-      vi.mocked(tourStorage.getTourStorage).mockReturnValue({ completed: {}, layers: {} })
-
-      // Mock querySelector to return a truthy element for readiness
-      const mockElement = document.createElement('div')
-      const originalQuerySelector = document.querySelector.bind(document)
-      vi.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
-        if (selector === '[data-tour="metrics-header"]') return mockElement
-        return originalQuerySelector(selector)
-      })
-
-      renderHook(() => useTour())
-
-      // Flush promises for loadTourDefinition + loadLayerDefinition chain + setLoadedPath re-render
-      await flushAndAdvance(0)
-      await flushAndAdvance(0)
-      await flushAndAdvance(0)
-
-      // Advance past readiness check timer (AUTO_START_DELAY = 300ms)
-      await flushAndAdvance(1000)
-
-      expect(mockDrive).toHaveBeenCalled()
-
-      vi.mocked(document.querySelector).mockRestore()
-    })
-
-    it('does not auto-play when all layers are seen', async () => {
-      const tourWithLayers: TourDefinition = {
-        ...mockTourDefinition,
-        id: 'retention-overview',
-        layers: ['metrics-header'],
-      }
-      vi.mocked(tourRegistry.getTourIdForRoute).mockReturnValue('retention-overview')
-      vi.mocked(tourRegistry.loadTourDefinition).mockResolvedValue(tourWithLayers)
-      // Storage has the layer record → seen
-      vi.mocked(tourStorage.getTourStorage).mockReturnValue({
-        completed: {},
-        layers: {
-          'metrics-header': {
-            layerId: 'metrics-header',
-            completedVersion: 1,
-            completedAt: '2026-01-01T00:00:00Z',
-          },
+  it('replay() with a seen layer at current version skips the layer', async () => {
+    const tourWithLayers: TourDefinition = {
+      ...mockTourDefinition,
+      id: 'retention-overview',
+      layers: ['metrics-header'],
+    }
+    vi.mocked(tourRegistry.getTourIdForRoute).mockReturnValue('retention-overview')
+    vi.mocked(tourRegistry.loadTourDefinition).mockResolvedValue(tourWithLayers)
+    vi.mocked(tourStorage.getTourStorage).mockReturnValue({
+      layers: {
+        'metrics-header': {
+          layerId: 'metrics-header',
+          completedVersion: 1,
+          completedAt: new Date().toISOString(),
         },
-      })
-
-      renderHook(() => useTour())
-
-      await flushAndAdvance(2000)
-
-      expect(mockDrive).not.toHaveBeenCalled()
+      },
     })
+
+    const mockElement = document.createElement('div')
+    const originalQuerySelector = document.querySelector.bind(document)
+    vi.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
+      if (selector === '[data-tour="debug-header"]') return mockElement
+      return originalQuerySelector(selector)
+    })
+
+    const { driver } = await import('driver.js')
+    const { result } = renderHook(() => useTour())
+    await flushAndAdvance(1000)
+
+    act(() => {
+      result.current.replay()
+    })
+    await flushAndAdvance(1000)
+
+    expect(driver).toHaveBeenCalled()
+    const lastCall = vi.mocked(driver).mock.calls.at(-1)?.[0]
+    expect(lastCall?.steps).toHaveLength(1)
+    expect(lastCall?.steps?.[0]?.element).toBe('[data-tour="debug-header"]')
+
+    vi.mocked(document.querySelector).mockRestore()
   })
 })

--- a/frontend/src/hooks/useTour.test.tsx
+++ b/frontend/src/hooks/useTour.test.tsx
@@ -198,4 +198,125 @@ describe('useTour', () => {
 
     vi.mocked(document.querySelector).mockRestore()
   })
+
+  it('replay() with a malformed completedAt treats the layer as stale and includes it', async () => {
+    const tourWithLayers: TourDefinition = {
+      ...mockTourDefinition,
+      id: 'retention-overview',
+      layers: ['metrics-header'],
+    }
+    vi.mocked(tourRegistry.getTourIdForRoute).mockReturnValue('retention-overview')
+    vi.mocked(tourRegistry.loadTourDefinition).mockResolvedValue(tourWithLayers)
+    vi.mocked(tourStorage.getTourStorage).mockReturnValue({
+      layers: {
+        'metrics-header': {
+          layerId: 'metrics-header',
+          completedVersion: 1,
+          completedAt: 'not-a-real-timestamp',
+        },
+      },
+    })
+
+    const headerEl = document.createElement('div')
+    const originalQuerySelector = document.querySelector.bind(document)
+    vi.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
+      if (selector === '[data-tour="metrics-header"]') return headerEl
+      return originalQuerySelector(selector)
+    })
+
+    const { driver } = await import('driver.js')
+    const { result } = renderHook(() => useTour())
+    await flushAndAdvance(1000)
+
+    act(() => {
+      result.current.replay()
+    })
+    await flushAndAdvance(1000)
+
+    expect(driver).toHaveBeenCalled()
+    const lastCall = vi.mocked(driver).mock.calls.at(-1)?.[0]
+    // Both layer step + page step should be present when completedAt is malformed
+    expect(lastCall?.steps).toHaveLength(2)
+
+    vi.mocked(document.querySelector).mockRestore()
+  })
+
+  it('rapid double-replay() does not fire drive() on the destroyed prior driver', async () => {
+    const headerEl = document.createElement('div')
+    const originalQuerySelector = document.querySelector.bind(document)
+    vi.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
+      if (selector === '[data-tour="debug-header"]') return headerEl
+      return originalQuerySelector(selector)
+    })
+
+    const { result } = renderHook(() => useTour())
+    await flushAndAdvance(1000)
+
+    // First replay queues a checkReady timer (AUTO_START_DELAY = 300ms)
+    act(() => {
+      result.current.replay()
+    })
+    // Second replay arrives before the first's checkReady fires
+    act(() => {
+      result.current.replay()
+    })
+    await flushAndAdvance(1000)
+
+    // Only the second driver should reach drive(); the first's queued timer must
+    // have been cleared, otherwise drive() fires twice on what's now a destroyed instance.
+    expect(mockDrive).toHaveBeenCalledTimes(1)
+
+    vi.mocked(document.querySelector).mockRestore()
+  })
+
+  it('clears cached tour definition synchronously when route changes', async () => {
+    const reactRouter = await import('react-router')
+    const useLocationSpy = vi.mocked(reactRouter.useLocation)
+
+    // Page A: debug — loads successfully
+    useLocationSpy.mockReturnValue({
+      pathname: '/summer/debug',
+      search: '',
+      hash: '',
+      state: null,
+      key: 'default',
+    })
+    vi.mocked(tourRegistry.getTourIdForRoute).mockReturnValue('debug')
+    vi.mocked(tourRegistry.loadTourDefinition).mockResolvedValue(mockTourDefinition)
+
+    const headerEl = document.createElement('div')
+    const originalQuerySelector = document.querySelector.bind(document)
+    vi.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
+      if (selector === '[data-tour="debug-header"]') return headerEl
+      return originalQuerySelector(selector)
+    })
+
+    const { result, rerender } = renderHook(() => useTour())
+    await flushAndAdvance(0)
+
+    // Pivot to Page B: retention — but make its tour-definition load HANG so the
+    // race window is wide open (definitionRef for A is still set at this point
+    // without the fix).
+    useLocationSpy.mockReturnValue({
+      pathname: '/analytics/retention',
+      search: '',
+      hash: '',
+      state: null,
+      key: 'pageB',
+    })
+    vi.mocked(tourRegistry.getTourIdForRoute).mockReturnValue('retention-overview')
+    vi.mocked(tourRegistry.loadTourDefinition).mockReturnValue(new Promise(() => {}))
+
+    rerender()
+    // Click replay before Page B's tour finishes loading.
+    act(() => {
+      result.current.replay()
+    })
+    await flushAndAdvance(1000)
+
+    // No tour should have started — definitionRef must have been cleared on route change.
+    expect(mockDrive).not.toHaveBeenCalled()
+
+    vi.mocked(document.querySelector).mockRestore()
+  })
 })

--- a/frontend/src/hooks/useTour.ts
+++ b/frontend/src/hooks/useTour.ts
@@ -13,7 +13,6 @@ import type {
   LayerDefinition,
   TourStorageData,
 } from '../tours/types'
-import { useSolverConfigValue } from './useSolverConfig'
 
 /** Delay before checking readiness (ms) */
 const AUTO_START_DELAY = 300
@@ -24,8 +23,8 @@ const MAX_READY_RETRIES = 25
 /** Interval between readiness checks (ms) */
 const READY_CHECK_INTERVAL = 200
 
-/** Default staleness threshold in days */
-const DEFAULT_STALE_DAYS = 30
+/** Days before a previously-seen shared layer replays on "Tour This Page" */
+const STALE_DAYS = 30
 
 interface LayerBoundary {
   layerId: LayerId
@@ -36,15 +35,10 @@ interface LayerBoundary {
 export function useTour() {
   const { pathname } = useLocation()
   const [tourId, setTourId] = useState<TourId | null>(null)
-  const [loadedPath, setLoadedPath] = useState<string | null>(null)
   const driverRef = useRef<Driver | null>(null)
   const definitionRef = useRef<TourDefinition | null>(null)
   const layerDefsRef = useRef<LayerDefinition[]>([])
   const pendingTimersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set())
-  const autoPlayFiredRef = useRef<string | null>(null)
-
-  const staleDays =
-    useSolverConfigValue<number>('tour.staleness_days', DEFAULT_STALE_DAYS) ?? DEFAULT_STALE_DAYS
 
   const scheduleTimeout = useCallback((fn: () => void, ms: number) => {
     const id = setTimeout(() => {
@@ -59,8 +53,6 @@ export function useTour() {
   useEffect(() => {
     const id = getTourIdForRoute(pathname)
     setTourId(id)
-    setLoadedPath(null)
-    autoPlayFiredRef.current = null
 
     if (!id) {
       definitionRef.current = null
@@ -78,9 +70,6 @@ export function useTour() {
         const layerDefs = await Promise.all(def.layers.map(loadLayerDefinition))
         if (cancelled) return
         layerDefsRef.current = layerDefs
-
-        // Signal that definitions are loaded so auto-play effect can fire
-        setLoadedPath(pathname)
       })
       .catch(() => {
         if (cancelled) return
@@ -93,93 +82,62 @@ export function useTour() {
     }
   }, [pathname])
 
-  const startTour = useCallback(
-    (mode: 'auto' | 'manual') => {
-      const def = definitionRef.current
-      if (!def) return
-
-      const storage = getTourStorage()
-      const { steps, layerBoundaries } = assembleSteps(
-        def,
-        layerDefsRef.current,
-        mode,
-        staleDays,
-        storage
-      )
-
-      if (steps.length === 0) return
-
-      // Clean up any existing driver
-      if (driverRef.current) {
-        driverRef.current.destroy()
-      }
-
-      let highestStepReached = -1
-
-      const d = driver({
-        showProgress: true,
-        showButtons: ['next', 'previous', 'close'],
-        popoverClass: 'kindred-tour',
-        steps,
-        onHighlightStarted: (_el, _step, opts) => {
-          const idx = opts.state.activeIndex
-          if (idx !== undefined && idx > highestStepReached) {
-            highestStepReached = idx
-          }
-        },
-        onDestroyed: () => {
-          const completedLayers = layerBoundaries
-            .filter((b) => highestStepReached >= b.endIndex)
-            .map((b) => ({ layerId: b.layerId, version: b.version }))
-          const completedTour =
-            mode === 'manual' && highestStepReached >= steps.length - 1
-              ? { tourId: def.id, version: def.version }
-              : undefined
-          if (completedLayers.length > 0 || completedTour) {
-            batchComplete(completedLayers, completedTour)
-          }
-        },
-      })
-
-      driverRef.current = d
-
-      // Readiness: check first step's element exists in DOM (computed once, polled)
-      const firstSelector = typeof steps[0]?.element === 'string' ? steps[0].element : null
-
-      let retries = 0
-      const checkReady = () => {
-        const ready = firstSelector ? document.querySelector(firstSelector) !== null : true
-        if (ready) {
-          d.drive()
-          return
-        }
-        if (retries >= MAX_READY_RETRIES) {
-          d.destroy()
-          driverRef.current = null
-          return
-        }
-        retries++
-        scheduleTimeout(checkReady, READY_CHECK_INTERVAL)
-      }
-
-      scheduleTimeout(checkReady, AUTO_START_DELAY)
-    },
-    [scheduleTimeout, staleDays]
-  )
-
-  // Auto-play unseen layers after definitions are loaded
-  useEffect(() => {
-    if (!loadedPath || !definitionRef.current || autoPlayFiredRef.current === loadedPath) return
-    if (definitionRef.current.layers.length === 0) return
-    if (layerDefsRef.current.length === 0) return
+  const startTour = useCallback(() => {
+    const def = definitionRef.current
+    if (!def) return
 
     const storage = getTourStorage()
-    const hasUnseenLayers = definitionRef.current.layers.some((id) => !storage.layers[id])
-    if (!hasUnseenLayers) return
+    const { steps, layerBoundaries } = assembleSteps(def, layerDefsRef.current, storage)
 
-    autoPlayFiredRef.current = loadedPath
-    startTour('auto')
-  }, [loadedPath, startTour])
+    if (steps.length === 0) return
+
+    if (driverRef.current) {
+      driverRef.current.destroy()
+    }
+
+    let highestStepReached = -1
+
+    const d = driver({
+      showProgress: true,
+      showButtons: ['next', 'previous', 'close'],
+      popoverClass: 'kindred-tour',
+      steps,
+      onHighlightStarted: (_el, _step, opts) => {
+        const idx = opts.state.activeIndex
+        if (idx !== undefined && idx > highestStepReached) {
+          highestStepReached = idx
+        }
+      },
+      onDestroyed: () => {
+        const completedLayers = layerBoundaries
+          .filter((b) => highestStepReached >= b.endIndex)
+          .map((b) => ({ layerId: b.layerId, version: b.version }))
+        batchComplete(completedLayers)
+      },
+    })
+
+    driverRef.current = d
+
+    const firstSelector = typeof steps[0]?.element === 'string' ? steps[0].element : null
+
+    let retries = 0
+    const checkReady = () => {
+      const ready = firstSelector ? document.querySelector(firstSelector) !== null : true
+      if (ready) {
+        d.drive()
+        return
+      }
+      if (retries >= MAX_READY_RETRIES) {
+        d.destroy()
+        driverRef.current = null
+        return
+      }
+      retries++
+      scheduleTimeout(checkReady, READY_CHECK_INTERVAL)
+    }
+
+    scheduleTimeout(checkReady, AUTO_START_DELAY)
+  }, [scheduleTimeout])
 
   // Cleanup on unmount
   useEffect(() => {
@@ -195,18 +153,12 @@ export function useTour() {
     }
   }, [])
 
-  const replay = useCallback(() => {
-    startTour('manual')
-  }, [startTour])
-
-  return { tourId, replay }
+  return { tourId, replay: startTour }
 }
 
 function assembleSteps(
   def: TourDefinition,
   layerDefs: LayerDefinition[],
-  mode: 'auto' | 'manual',
-  staleDays: number,
   storage: TourStorageData
 ): {
   steps: TourStep[]
@@ -218,11 +170,9 @@ function assembleSteps(
   for (const layerDef of layerDefs) {
     const record = storage.layers[layerDef.id]
     const include =
-      mode === 'auto'
-        ? !record
-        : !record ||
-          record.completedVersion < layerDef.version ||
-          (Date.now() - new Date(record.completedAt).getTime()) / 86_400_000 >= staleDays
+      !record ||
+      record.completedVersion < layerDef.version ||
+      (Date.now() - new Date(record.completedAt).getTime()) / 86_400_000 >= STALE_DAYS
 
     if (include) {
       steps.push(...layerDef.steps)
@@ -234,9 +184,7 @@ function assembleSteps(
     }
   }
 
-  if (mode === 'manual') {
-    steps.push(...def.steps)
-  }
+  steps.push(...def.steps)
 
   return { steps, layerBoundaries }
 }

--- a/frontend/src/hooks/useTour.ts
+++ b/frontend/src/hooks/useTour.ts
@@ -54,9 +54,12 @@ export function useTour() {
     const id = getTourIdForRoute(pathname)
     setTourId(id)
 
+    // Clear cached refs synchronously so a manual replay between routes
+    // cannot start the previous page's tour while the new load is in flight.
+    definitionRef.current = null
+    layerDefsRef.current = []
+
     if (!id) {
-      definitionRef.current = null
-      layerDefsRef.current = []
       return
     }
 
@@ -93,7 +96,15 @@ export function useTour() {
 
     if (driverRef.current) {
       driverRef.current.destroy()
+      driverRef.current = null
     }
+
+    // Clear any queued readiness timers from a prior replay so their stale
+    // closures cannot fire drive()/destroy() on a freshly created driver.
+    for (const id of pendingTimersRef.current) {
+      clearTimeout(id)
+    }
+    pendingTimersRef.current.clear()
 
     let highestStepReached = -1
 
@@ -169,10 +180,14 @@ function assembleSteps(
 
   for (const layerDef of layerDefs) {
     const record = storage.layers[layerDef.id]
-    const include =
-      !record ||
-      record.completedVersion < layerDef.version ||
-      (Date.now() - new Date(record.completedAt).getTime()) / 86_400_000 >= STALE_DAYS
+    let include = !record || record.completedVersion < layerDef.version
+    if (!include && record) {
+      const completedTime = new Date(record.completedAt).getTime()
+      // Treat malformed timestamps as stale so a corrupted record can't
+      // permanently suppress a layer (NaN >= STALE_DAYS would be false).
+      include =
+        Number.isNaN(completedTime) || (Date.now() - completedTime) / 86_400_000 >= STALE_DAYS
+    }
 
     if (include) {
       steps.push(...layerDef.steps)

--- a/frontend/src/tours/tourStorage.test.ts
+++ b/frontend/src/tours/tourStorage.test.ts
@@ -1,14 +1,5 @@
 import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from 'vitest'
-import {
-  getTourStorage,
-  markLayerCompleted,
-  batchComplete,
-  getLayerCompletion,
-  isLayerSeen,
-  isLayerStaleOrUnseen,
-  resetAllTours,
-  TOUR_STORAGE_KEY,
-} from './tourStorage'
+import { getTourStorage, batchComplete, resetAllTours, TOUR_STORAGE_KEY } from './tourStorage'
 
 // Use real localStorage for these tests (the global setup mocks it)
 const realLocalStorage = (() => {
@@ -42,7 +33,11 @@ describe('tourStorage', () => {
     localStorage.removeItem(TOUR_STORAGE_KEY)
   })
 
-  describe('backward compatibility', () => {
+  describe('getTourStorage', () => {
+    it('returns an empty layers map when storage is empty', () => {
+      expect(getTourStorage()).toEqual({ layers: {} })
+    })
+
     it('handles legacy storage shape that still has a completed field', () => {
       localStorage.setItem(
         TOUR_STORAGE_KEY,
@@ -71,67 +66,10 @@ describe('tourStorage', () => {
       const storage = getTourStorage()
       expect(storage.layers['metrics-header']).toBeDefined()
     })
-  })
 
-  describe('markLayerCompleted', () => {
-    it('persists layer completion with timestamp', () => {
-      markLayerCompleted('metrics-header', 1)
-      const record = getLayerCompletion('metrics-header')
-      expect(record).not.toBeNull()
-      expect(record!.layerId).toBe('metrics-header')
-      expect(record!.completedVersion).toBe(1)
-      expect(record!.completedAt).toBeTruthy()
-    })
-
-    it('updates version on re-completion', () => {
-      markLayerCompleted('metrics-header', 1)
-      markLayerCompleted('metrics-header', 2)
-      const record = getLayerCompletion('metrics-header')
-      expect(record!.completedVersion).toBe(2)
-    })
-  })
-
-  describe('getLayerCompletion', () => {
-    it('returns null for unseen layers', () => {
-      expect(getLayerCompletion('metrics-header')).toBeNull()
-    })
-  })
-
-  describe('isLayerSeen', () => {
-    it('returns false for unseen layers', () => {
-      expect(isLayerSeen('metrics-header')).toBe(false)
-    })
-
-    it('returns true for seen layers regardless of version', () => {
-      markLayerCompleted('metrics-header', 1)
-      expect(isLayerSeen('metrics-header')).toBe(true)
-    })
-  })
-
-  describe('isLayerStaleOrUnseen', () => {
-    it('returns true for unseen layers', () => {
-      expect(isLayerStaleOrUnseen('metrics-header', 1, 30)).toBe(true)
-    })
-
-    it('returns true when version is bumped', () => {
-      markLayerCompleted('metrics-header', 1)
-      expect(isLayerStaleOrUnseen('metrics-header', 2, 30)).toBe(true)
-    })
-
-    it('returns false for recently seen layers at current version', () => {
-      markLayerCompleted('metrics-header', 1)
-      expect(isLayerStaleOrUnseen('metrics-header', 1, 30)).toBe(false)
-    })
-
-    it('returns true for stale layers', () => {
-      const storage = getTourStorage()
-      storage.layers['metrics-header'] = {
-        layerId: 'metrics-header',
-        completedVersion: 1,
-        completedAt: new Date(Date.now() - 31 * 86_400_000).toISOString(),
-      }
-      localStorage.setItem(TOUR_STORAGE_KEY, JSON.stringify(storage))
-      expect(isLayerStaleOrUnseen('metrics-header', 1, 30)).toBe(true)
+    it('returns empty shape on malformed JSON', () => {
+      localStorage.setItem(TOUR_STORAGE_KEY, 'not-json')
+      expect(getTourStorage()).toEqual({ layers: {} })
     })
   })
 
@@ -151,14 +89,20 @@ describe('tourStorage', () => {
       const storage = getTourStorage()
       expect(storage.layers).toEqual({})
     })
+
+    it('overwrites existing layer records with newer versions', () => {
+      batchComplete([{ layerId: 'metrics-header', version: 1 }])
+      batchComplete([{ layerId: 'metrics-header', version: 2 }])
+      const storage = getTourStorage()
+      expect(storage.layers['metrics-header']?.completedVersion).toBe(2)
+    })
   })
 
   describe('resetAllTours', () => {
     it('clears layer storage', () => {
-      markLayerCompleted('metrics-header', 1)
+      batchComplete([{ layerId: 'metrics-header', version: 1 }])
       resetAllTours()
-      const storage = getTourStorage()
-      expect(storage.layers).toEqual({})
+      expect(getTourStorage().layers).toEqual({})
     })
   })
 })

--- a/frontend/src/tours/tourStorage.test.ts
+++ b/frontend/src/tours/tourStorage.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from 'vitest'
 import {
   getTourStorage,
-  markTourCompleted,
   markLayerCompleted,
   batchComplete,
   getLayerCompletion,
@@ -44,16 +43,33 @@ describe('tourStorage', () => {
   })
 
   describe('backward compatibility', () => {
-    it('handles old storage shape without layers field', () => {
+    it('handles legacy storage shape that still has a completed field', () => {
       localStorage.setItem(
         TOUR_STORAGE_KEY,
         JSON.stringify({
           completed: { debug: { tourId: 'debug', completedVersion: 1, completedAt: '2026-01-01' } },
+          layers: {},
         })
       )
       const storage = getTourStorage()
       expect(storage.layers).toEqual({})
-      expect(storage.completed.debug).toBeDefined()
+    })
+
+    it('handles storage that only has layers', () => {
+      localStorage.setItem(
+        TOUR_STORAGE_KEY,
+        JSON.stringify({
+          layers: {
+            'metrics-header': {
+              layerId: 'metrics-header',
+              completedVersion: 1,
+              completedAt: '2026-01-01',
+            },
+          },
+        })
+      )
+      const storage = getTourStorage()
+      expect(storage.layers['metrics-header']).toBeDefined()
     })
   })
 
@@ -120,35 +136,28 @@ describe('tourStorage', () => {
   })
 
   describe('batchComplete', () => {
-    it('writes layers and tour in a single localStorage write', () => {
-      batchComplete(
-        [
-          { layerId: 'metrics-header', version: 1 },
-          { layerId: 'registration-intro', version: 1 },
-        ],
-        { tourId: 'debug', version: 2 }
-      )
+    it('writes multiple layers in a single localStorage write', () => {
+      batchComplete([
+        { layerId: 'metrics-header', version: 1 },
+        { layerId: 'registration-intro', version: 1 },
+      ])
       const storage = getTourStorage()
       expect(storage.layers['metrics-header']?.completedVersion).toBe(1)
       expect(storage.layers['registration-intro']?.completedVersion).toBe(1)
-      expect(storage.completed.debug?.completedVersion).toBe(2)
     })
 
-    it('works with layers only (no tour)', () => {
-      batchComplete([{ layerId: 'metrics-header', version: 1 }])
+    it('is a no-op when given an empty array', () => {
+      batchComplete([])
       const storage = getTourStorage()
-      expect(storage.layers['metrics-header']).toBeDefined()
-      expect(Object.keys(storage.completed)).toHaveLength(0)
+      expect(storage.layers).toEqual({})
     })
   })
 
   describe('resetAllTours', () => {
-    it('clears both tours and layers', () => {
-      markTourCompleted('debug', 1)
+    it('clears layer storage', () => {
       markLayerCompleted('metrics-header', 1)
       resetAllTours()
       const storage = getTourStorage()
-      expect(storage.completed).toEqual({})
       expect(storage.layers).toEqual({})
     })
   })

--- a/frontend/src/tours/tourStorage.ts
+++ b/frontend/src/tours/tourStorage.ts
@@ -1,29 +1,16 @@
-import type { TourId, TourStorageData, LayerId } from './types'
+import type { LayerId, TourStorageData } from './types'
 
 export const TOUR_STORAGE_KEY = 'kindred_tours'
 
 export function getTourStorage(): TourStorageData {
   try {
     const raw = localStorage.getItem(TOUR_STORAGE_KEY)
-    if (!raw) return { completed: {}, layers: {} }
+    if (!raw) return { layers: {} }
     const parsed = JSON.parse(raw) as Partial<TourStorageData>
-    return {
-      completed: parsed.completed ?? {},
-      layers: parsed.layers ?? {},
-    }
+    return { layers: parsed.layers ?? {} }
   } catch {
-    return { completed: {}, layers: {} }
+    return { layers: {} }
   }
-}
-
-export function markTourCompleted(tourId: TourId, version: number): void {
-  const storage = getTourStorage()
-  storage.completed[tourId] = {
-    tourId,
-    completedVersion: version,
-    completedAt: new Date().toISOString(),
-  }
-  localStorage.setItem(TOUR_STORAGE_KEY, JSON.stringify(storage))
 }
 
 export function getLayerCompletion(layerId: LayerId) {
@@ -57,35 +44,14 @@ export function isLayerStaleOrUnseen(
   return daysSince >= staleDays
 }
 
-/** Single-write batch: mark layers and optionally a page tour as completed */
-export function batchComplete(
-  layers: Array<{ layerId: LayerId; version: number }>,
-  tour?: { tourId: TourId; version: number }
-): void {
+/** Single-write batch mark for layers. No-op when given an empty array. */
+export function batchComplete(layers: Array<{ layerId: LayerId; version: number }>): void {
+  if (layers.length === 0) return
   const storage = getTourStorage()
   const now = new Date().toISOString()
   for (const { layerId, version } of layers) {
     storage.layers[layerId] = { layerId, completedVersion: version, completedAt: now }
   }
-  if (tour) {
-    storage.completed[tour.tourId] = {
-      tourId: tour.tourId,
-      completedVersion: tour.version,
-      completedAt: now,
-    }
-  }
-  localStorage.setItem(TOUR_STORAGE_KEY, JSON.stringify(storage))
-}
-
-export function resetTour(tourId: TourId): void {
-  const storage = getTourStorage()
-  const completed: TourStorageData['completed'] = {}
-  for (const key of Object.keys(storage.completed) as TourId[]) {
-    if (key !== tourId && storage.completed[key]) {
-      completed[key] = storage.completed[key]
-    }
-  }
-  storage.completed = completed
   localStorage.setItem(TOUR_STORAGE_KEY, JSON.stringify(storage))
 }
 

--- a/frontend/src/tours/tourStorage.ts
+++ b/frontend/src/tours/tourStorage.ts
@@ -6,8 +6,11 @@ export function getTourStorage(): TourStorageData {
   try {
     const raw = localStorage.getItem(TOUR_STORAGE_KEY)
     if (!raw) return { layers: {} }
-    const parsed = JSON.parse(raw) as Partial<TourStorageData>
-    return { layers: parsed.layers ?? {} }
+    const parsed: unknown = JSON.parse(raw)
+    const layers =
+      parsed && typeof parsed === 'object' && 'layers' in parsed ? parsed.layers : undefined
+    const isPlainObject = typeof layers === 'object' && layers !== null && !Array.isArray(layers)
+    return { layers: isPlainObject ? layers : {} }
   } catch {
     return { layers: {} }
   }

--- a/frontend/src/tours/tourStorage.ts
+++ b/frontend/src/tours/tourStorage.ts
@@ -13,37 +13,6 @@ export function getTourStorage(): TourStorageData {
   }
 }
 
-export function getLayerCompletion(layerId: LayerId) {
-  const storage = getTourStorage()
-  return storage.layers[layerId] ?? null
-}
-
-export function markLayerCompleted(layerId: LayerId, version: number): void {
-  const storage = getTourStorage()
-  storage.layers[layerId] = {
-    layerId,
-    completedVersion: version,
-    completedAt: new Date().toISOString(),
-  }
-  localStorage.setItem(TOUR_STORAGE_KEY, JSON.stringify(storage))
-}
-
-export function isLayerSeen(layerId: LayerId): boolean {
-  return getLayerCompletion(layerId) !== null
-}
-
-export function isLayerStaleOrUnseen(
-  layerId: LayerId,
-  version: number,
-  staleDays: number
-): boolean {
-  const record = getLayerCompletion(layerId)
-  if (!record) return true
-  if (record.completedVersion < version) return true
-  const daysSince = (Date.now() - new Date(record.completedAt).getTime()) / 86_400_000
-  return daysSince >= staleDays
-}
-
 /** Single-write batch mark for layers. No-op when given an empty array. */
 export function batchComplete(layers: Array<{ layerId: LayerId; version: number }>): void {
   if (layers.length === 0) return
@@ -55,6 +24,7 @@ export function batchComplete(layers: Array<{ layerId: LayerId; version: number 
   localStorage.setItem(TOUR_STORAGE_KEY, JSON.stringify(storage))
 }
 
+/** Nuclear devtools escape hatch — clears all tour state from localStorage. */
 export function resetAllTours(): void {
   localStorage.removeItem(TOUR_STORAGE_KEY)
 }

--- a/frontend/src/tours/types.test.ts
+++ b/frontend/src/tours/types.test.ts
@@ -29,9 +29,8 @@ describe('tour types', () => {
     expect(record.completedAt).toBeTruthy()
   })
 
-  it('TourStorageData includes layers field', () => {
+  it('TourStorageData has only layers field', () => {
     const data: TourStorageData = {
-      completed: {},
       layers: {
         'metrics-header': {
           layerId: 'metrics-header',
@@ -41,6 +40,8 @@ describe('tour types', () => {
       },
     }
     expect(data.layers['metrics-header']).toBeDefined()
+    // @ts-expect-error - completed field has been removed
+    expect(data.completed).toBeUndefined()
   })
 
   it('TourDefinition includes layers array', () => {

--- a/frontend/src/tours/types.ts
+++ b/frontend/src/tours/types.ts
@@ -28,13 +28,6 @@ export interface LayerDefinition {
   steps: TourStep[]
 }
 
-/** Persisted record of a completed tour */
-export interface TourCompletionRecord {
-  tourId: TourId
-  completedVersion: number
-  completedAt: string
-}
-
 /** Persisted record of a completed layer with timestamp for staleness */
 export interface LayerCompletionRecord {
   layerId: LayerId
@@ -44,7 +37,6 @@ export interface LayerCompletionRecord {
 
 /** Shape of the localStorage data */
 export interface TourStorageData {
-  completed: Partial<Record<TourId, TourCompletionRecord>>
   layers: Partial<Record<LayerId, LayerCompletionRecord>>
 }
 

--- a/pocketbase/pb_migrations/1500000092_remove_tour_config.js
+++ b/pocketbase/pb_migrations/1500000092_remove_tour_config.js
@@ -2,24 +2,48 @@
 
 migrate(
   (app) => {
+    // 1. Drop the tour staleness config row. Wrap only the find in try/catch
+    //    so delete errors propagate (mirrors the down migration's pattern).
+    let config = null
     try {
-      const config = app.findFirstRecordByFilter(
+      config = app.findFirstRecordByFilter(
         "config",
         'category = "tour" && config_key = "staleness_days"'
       )
-      if (config) app.delete(config)
     } catch {
       // already absent
     }
+    if (config) app.delete(config)
 
+    // 2. Drop the ui-preferences section only if no other config rows still
+    //    reference it via metadata.section. Today nothing else does, but the
+    //    guard future-proofs against any sibling config landing here later.
+    let section = null
     try {
-      const section = app.findFirstRecordByFilter(
+      section = app.findFirstRecordByFilter(
         "config_sections",
         'section_key = "ui-preferences"'
       )
-      if (section) app.delete(section)
     } catch {
       // already absent
+    }
+    if (section) {
+      let sectionHasOtherRefs
+      try {
+        const remaining = app.findRecordsByFilter(
+          "config",
+          'metadata.section = "ui-preferences"',
+          "",
+          1,
+          0
+        )
+        sectionHasOtherRefs = remaining.length > 0
+      } catch {
+        // If the JSON-path filter is unsupported in some build, err on the
+        // side of preserving the section rather than silently deleting it.
+        sectionHasOtherRefs = true
+      }
+      if (!sectionHasOtherRefs) app.delete(section)
     }
   },
   (app) => {

--- a/pocketbase/pb_migrations/1500000092_remove_tour_config.js
+++ b/pocketbase/pb_migrations/1500000092_remove_tour_config.js
@@ -1,0 +1,85 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+migrate(
+  (app) => {
+    try {
+      const config = app.findFirstRecordByFilter(
+        "config",
+        'category = "tour" && config_key = "staleness_days"'
+      )
+      if (config) app.delete(config)
+    } catch {
+      // already absent
+    }
+
+    try {
+      const section = app.findFirstRecordByFilter(
+        "config_sections",
+        'section_key = "ui-preferences"'
+      )
+      if (section) app.delete(section)
+    } catch {
+      // already absent
+    }
+  },
+  (app) => {
+    const sectionsCollection = app.findCollectionByNameOrId("config_sections")
+
+    let existingSection
+    try {
+      existingSection = app.findFirstRecordByFilter(
+        "config_sections",
+        'section_key = "ui-preferences"'
+      )
+    } catch {
+      existingSection = null
+    }
+
+    if (!existingSection) {
+      const section = new Record(sectionsCollection)
+      section.set("section_key", "ui-preferences")
+      section.set("title", "User Interface")
+      section.set("description", "Tour and display preferences")
+      section.set("display_order", 50)
+      section.set("expanded_by_default", true)
+      app.save(section)
+    }
+
+    const configCollection = app.findCollectionByNameOrId("config")
+
+    let existingConfig
+    try {
+      existingConfig = app.findFirstRecordByFilter(
+        "config",
+        'category = "tour" && config_key = "staleness_days"'
+      )
+    } catch {
+      existingConfig = null
+    }
+
+    if (!existingConfig) {
+      const record = new Record(configCollection)
+      record.set("category", "tour")
+      record.set("subcategory", "")
+      record.set("config_key", "staleness_days")
+      record.set("value", 30)
+      record.set("description", "Days before shared tour intros replay on 'Tour This Page'")
+      record.set("metadata", {
+        friendly_name: "Tour Staleness Threshold",
+        tooltip:
+          "How many days before the shared analytics intro steps are re-shown when a user clicks 'Tour This Page'. Lower values refresh knowledge more often.",
+        data_type: "integer",
+        source: "default_config",
+        default_value: 30,
+        min_value: 7,
+        max_value: 365,
+        section: "ui-preferences",
+        display_order: 1,
+        component_type: "number",
+        component_config: { min: 7, max: 365, step: 1, suffix: " days" },
+        business_category: "general",
+      })
+      app.save(record)
+    }
+  }
+)


### PR DESCRIPTION
Closes #1308.

## Summary

The product tour no longer auto-fires on first visit. It now plays only when the user clicks **Tour This Page** in the help (?) menu. Layer dedupe across pages is preserved with a hardcoded 30-day staleness window — a user who toured Registration Overview won't re-see the shared Year-over-Year intro on Registration Geo.

## Changes

- Remove auto-play `useEffect`, `autoPlayFiredRef`, and `loadedPath` from `useTour`
- Hardcode `STALE_DAYS = 30`; drop `useSolverConfigValue('tour.staleness_days')`
- Drop `storage.completed` entirely (it was written, never read at runtime)
- Drop `markTourCompleted`, `resetTour`, and `TourCompletionRecord`
- Simplify `batchComplete` to a single-arg layers-only signature
- New migration `1500000092_remove_tour_config.js` drops the `tour.staleness_days` config row and the (now-empty) `ui-preferences` config section

Net: 7 files, +227 / -271.

## Test plan

- [ ] Open Registration Overview as a logged-in user — tour does NOT auto-fire
- [ ] Click `?` → **Tour This Page** — full tour plays (Year-over-Year intro + page steps)
- [ ] Click through to the end, then navigate to Registration Geo
- [ ] Click `?` → **Tour This Page** on Geo — Year-over-Year intro is SKIPPED, only the Geo-specific page steps play
- [ ] Wipe `localStorage.kindred_tours`, repeat on Geo — Year-over-Year intro shows again
- [ ] Open PB Admin → Config — no "Tour Staleness Threshold" / "User Interface" section remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replay always uses the latest tour definition, no longer auto-starts on route changes; tour-level completion removed in favor of per-layer tracking.
  * Tour staleness logic fixed to 30 days.

* **Tests**
  * Updated tests for replay timing, driver lifecycle, route-change behavior, layer skipping, and storage edge cases.

* **Chores**
  * Removed configurable staleness setting and simplified tour storage to persist only per-layer state.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1319)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->