### PR TITLE
refactor(pb): consolidate family_camp_adults migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000035_family_camp_derived_tables.js
+++ b/pocketbase/pb_migrations/1500000035_family_camp_derived_tables.js
@@ -21,11 +21,11 @@ migrate((app) => {
   const adultsCollection = new Collection({
     type: "base",
     name: "family_camp_adults",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: '@request.auth.is_admin = true',
+    viewRule: '@request.auth.is_admin = true',
+    createRule: '@request.auth.is_admin = true',
+    updateRule: '@request.auth.is_admin = true',
+    deleteRule: '@request.auth.is_admin = true',
     fields: [
       // Household relation
       {
@@ -34,7 +34,7 @@ migrate((app) => {
         required: true,
         presentable: false,
         collectionId: householdsCol.id,
-        cascadeDelete: false,
+        cascadeDelete: true,
         minSelect: null,
         maxSelect: 1
       },

--- a/pocketbase/pb_migrations/1500000059_cascade_delete_derived_relations.js
+++ b/pocketbase/pb_migrations/1500000059_cascade_delete_derived_relations.js
@@ -10,29 +10,17 @@
  * If the source person/household is gone, derived data should cascade-delete.
  *
  * Affected relations:
- * - family_camp_adults.household -> households
  * - family_camp_registrations.household -> households
  * - family_camp_medical.household -> households
+ *
+ * Note: family_camp_adults trimmed — final cascadeDelete=true baked into
+ * merged CREATE migration #035.
  */
 
 migrate((app) => {
   const householdsCol = app.findCollectionByNameOrId("households");
 
-  // 1. family_camp_adults.household
-  const fcAdults = app.findCollectionByNameOrId("family_camp_adults");
-  fcAdults.fields.add(new Field({
-    type: "relation",
-    name: "household",
-    required: true,
-    presentable: false,
-    collectionId: householdsCol.id,
-    cascadeDelete: true,
-    minSelect: null,
-    maxSelect: 1
-  }));
-  app.save(fcAdults);
-
-  // 2. family_camp_registrations.household
+  // 1. family_camp_registrations.household
   const fcRegs = app.findCollectionByNameOrId("family_camp_registrations");
   fcRegs.fields.add(new Field({
     type: "relation",
@@ -46,7 +34,7 @@ migrate((app) => {
   }));
   app.save(fcRegs);
 
-  // 3. family_camp_medical.household
+  // 2. family_camp_medical.household
   const fcMed = app.findCollectionByNameOrId("family_camp_medical");
   fcMed.fields.add(new Field({
     type: "relation",
@@ -62,19 +50,6 @@ migrate((app) => {
 
 }, (app) => {
   const householdsCol = app.findCollectionByNameOrId("households");
-
-  const fcAdults = app.findCollectionByNameOrId("family_camp_adults");
-  fcAdults.fields.add(new Field({
-    type: "relation",
-    name: "household",
-    required: true,
-    presentable: false,
-    collectionId: householdsCol.id,
-    cascadeDelete: false,
-    minSelect: null,
-    maxSelect: 1
-  }));
-  app.save(fcAdults);
 
   const fcRegs = app.findCollectionByNameOrId("family_camp_registrations");
   fcRegs.fields.add(new Field({

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -14,6 +14,8 @@
  * merged CREATE migration #043.
  * Note: staff_vehicle_info trimmed — final adminOnly rules baked into
  * merged CREATE migration #047.
+ * Note: family_camp_adults trimmed — final adminOnly rules baked into
+ * merged CREATE migration #035.
  */
 
 migrate((app) => {
@@ -37,7 +39,7 @@ migrate((app) => {
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",
     "person_custom_values", "person_tag_defs", "custom_field_defs",
-    "family_camp_adults", "family_camp_medical",
+    "family_camp_medical",
     "family_camp_registrations", "session_groups",
     "config_sections", "sheets_workbooks"
   ]
@@ -74,7 +76,7 @@ migrate((app) => {
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",
     "person_custom_values", "person_tag_defs", "custom_field_defs",
-    "family_camp_adults", "family_camp_medical",
+    "family_camp_medical",
     "family_camp_registrations", "session_groups",
     "config_sections", "sheets_workbooks",
     "debug_parse_results", "solver_runs"


### PR DESCRIPTION
## Summary
- Folds 2 modify-migrations touching `family_camp_adults` into its base CREATE in #1500000035 in-place
- Trims the family_camp_adults portions of 2 multi-table sharers (#1500000059, #1500000075)
- Net delta: **0 files** in `pocketbase/pb_migrations/` this round
- Path to deletion: after the two sibling rounds (`family_camp_medical`, `family_camp_registrations`), all 5 portions of #1500000059 will be trimmed and the file becomes deletable (-1 on the final sibling round)
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match between proposed (3 edited files) and current (3 originals)

Trimmed (multi-table, kept in place):
- `1500000059_cascade_delete_derived_relations.js` — removed family_camp_adults up()/down() blocks; remaining sharers: family_camp_medical, family_camp_registrations
- `1500000075_rbac_tier2_rules.js` — removed `"family_camp_adults"` from `tier2[]` (up) and `all[]` (down); 17 tier2 tables remain

Folded into #1500000035's family_camp_adults section (the other two collection definitions in #1500000035 — family_camp_medical, family_camp_registrations — are byte-identical):
- `household.cascadeDelete: false → true` (from #1500000059)
- list/view/create/update/delete rules → `'@request.auth.is_admin = true'` (from #1500000075)

Final state of `family_camp_adults`: 13 fields, 2 indexes, admin-only rules.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green
- [ ] After merge, prod boot's OnServe `migrate history-sync` hook is a no-op (no files deleted this round; only edits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted access to family camp data tables—certain operations now require administrator authentication.
  * Updated database cascade delete behavior to automatically remove related family camp records when associated household information is deleted, ensuring data consistency.
  * Refined role-based access control rules to enhance security and data governance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1320)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->