### PR TITLE
feat(graph): dashed one-way + thick solid mutual edges on bunk graph

### DIFF
--- a/frontend/src/components/BunkSocialGraphModal.test.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.test.tsx
@@ -12,7 +12,7 @@
  * The helper unit tests plus TypeScript checking provide sufficient coverage.
  */
 import { describe, expect, it } from 'vitest'
-import { getBunkType, extractSortKey } from './BunkSocialGraphModal'
+import { extractSortKey, getBunkType } from './BunkSocialGraphModal'
 
 // ─── Inline simulation of sessionBunks derivation ────────────────────────────
 // Mirrors the useMemo body in BunkSocialGraphModal so we can assert the

--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -72,6 +72,10 @@ interface GraphEdge {
   target: number
   weight: number
   edge_type: string
+  // The backend (build_bunk_graph) collapses reciprocal pairs into a single
+  // edge with this flag set, so the frontend never sees two mirror edges. The
+  // cytoscape stylesheet reads it to render the bold solid double-headed
+  // line for mutual requests (#1309).
   reciprocal: boolean
   confidence?: number
   priority?: number
@@ -321,7 +325,14 @@ export default function BunkSocialGraphModal({
         {
           selector: 'edge',
           style: {
-            width: 2, // Uniform width for all edges
+            // Default is a dashed one-way request arrow. The backend
+            // (build_bunk_graph) already collapses mutual pairs into a single
+            // edge tagged reciprocal — those pick up the bold solid
+            // double-headed style from the edge[?reciprocal] selector below.
+            // Mirrors the session-level treatment in
+            // graph/cytoscapeStyles.ts (#1309).
+            width: 2,
+            'line-style': 'dashed',
             'line-color': (ele: EdgeSingular) => {
               const edgeType = ele.data('edge_type')
               return EDGE_COLORS[edgeType] ?? '#95a5a6'
@@ -334,16 +345,6 @@ export default function BunkSocialGraphModal({
               const edgeType = ele.data('edge_type')
               return EDGE_COLORS[edgeType] ?? '#95a5a6'
             },
-            'source-arrow-shape': (ele: EdgeSingular) => {
-              // Show arrow at source for reciprocal requests
-              const edgeType = ele.data('edge_type')
-              const reciprocal = ele.data('reciprocal')
-              return edgeType === 'request' && reciprocal ? 'triangle' : 'none'
-            },
-            'source-arrow-color': (ele: EdgeSingular) => {
-              const edgeType = ele.data('edge_type')
-              return EDGE_COLORS[edgeType] ?? '#95a5a6'
-            },
             'line-opacity': (ele: EdgeSingular) => {
               const confidence = ele.data('confidence') ?? 0.5
               // Opacity based on confidence: 0.3 to 0.9
@@ -352,6 +353,19 @@ export default function BunkSocialGraphModal({
             'curve-style': 'straight',
             'control-point-step-size': 40,
             'overlay-padding': '3px',
+          },
+        },
+        {
+          selector: 'edge[?reciprocal]',
+          style: {
+            // Bold solid double-headed line for backend-collapsed mutual pairs.
+            width: 4,
+            'line-style': 'solid',
+            'source-arrow-shape': 'triangle',
+            'source-arrow-color': (ele: EdgeSingular) => {
+              const edgeType = ele.data('edge_type')
+              return EDGE_COLORS[edgeType] ?? '#95a5a6'
+            },
           },
         },
       ],
@@ -419,8 +433,9 @@ export default function BunkSocialGraphModal({
       })
     })
 
-    // Process request edges. The backend sends both directions of mutual
-    // requests; we keep both so reciprocal source-arrows render.
+    // Backend already collapses mutual same-type pairs into a single edge
+    // tagged reciprocal=true; the edge[?reciprocal] cytoscape selector picks
+    // those up for the bold solid double-headed render (#1309).
     let edgeIndex = 0
     graphData.edges.forEach((edge) => {
       elements.push({
@@ -786,18 +801,38 @@ export default function BunkSocialGraphModal({
                         </div>
                       </div>
 
-                      {/* Directionality */}
+                      {/* Directionality — line style matches the canvas:
+                          dashed for one-way, bold solid for mutual (#1309). */}
                       <div className="mb-2">
                         <div className="text-muted-foreground mb-1 text-[11px] font-medium">
                           Direction
                         </div>
                         <div className="space-y-0.5">
                           <div className="flex items-center gap-2">
-                            <span className="text-[10px]">→</span>
+                            <svg width="20" height="6" className="flex-shrink-0">
+                              <line
+                                x1="0"
+                                y1="3"
+                                x2="20"
+                                y2="3"
+                                stroke={EDGE_COLORS['request']}
+                                strokeWidth="2"
+                                strokeDasharray="4 2"
+                              />
+                            </svg>
                             <span>One-way</span>
                           </div>
                           <div className="flex items-center gap-2">
-                            <span className="text-[10px]">↔</span>
+                            <svg width="20" height="8" className="flex-shrink-0">
+                              <line
+                                x1="0"
+                                y1="4"
+                                x2="20"
+                                y2="4"
+                                stroke={EDGE_COLORS['request']}
+                                strokeWidth="3"
+                              />
+                            </svg>
                             <span>Mutual</span>
                           </div>
                         </div>


### PR DESCRIPTION
## Summary

- Mirrors the session-level request-edge styling on the bunk-level graph (`BunkSocialGraphModal`): one-way requests render as a dashed thin arrow, mutual pairs render as a thick solid double-headed line.
- New cytoscape `edge[?reciprocal]` selector picks up the mutual treatment; the bunk backend (`build_bunk_graph` in `bunking/graph/social_graph_builder.py`) already collapses reciprocal pairs into a single edge tagged `reciprocal: true`, so no frontend pair-collapse is needed.
- Legend gets matching dashed/solid SVG swatches so the cue on screen matches the canvas.

## Test plan

- [x] `npx vitest run frontend/src/components/BunkSocialGraphModal.test.tsx` — 27/27 pass (no new tests; visual style is declarative)
- [x] `npx vitest run` full suite — 3978/3978 pass
- [x] `tsc --noEmit && tsc --noEmit -p tsconfig.node.json` — clean
- [x] Local manual QA on a session/bunks page: mutual = thick solid double-headed, one-way = dashed single arrow

## Notes

#1317 (proposed extraction of a shared collapse helper) is moot — the bunk backend already does what the session backend leaves to the frontend, so there is no shared logic to extract. Will leave a comment there for the maintainer to decide whether to rescope or close.

Closes #1309