### PR TITLE
refactor(pb): consolidate family_camp_medical migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000035_family_camp_derived_tables.js
+++ b/pocketbase/pb_migrations/1500000035_family_camp_derived_tables.js
@@ -298,11 +298,11 @@ migrate((app) => {
   const medicalCollection = new Collection({
     type: "base",
     name: "family_camp_medical",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: '@request.auth.is_admin = true',
+    viewRule: '@request.auth.is_admin = true',
+    createRule: '@request.auth.is_admin = true',
+    updateRule: '@request.auth.is_admin = true',
+    deleteRule: '@request.auth.is_admin = true',
     fields: [
       // Household relation
       {
@@ -311,7 +311,7 @@ migrate((app) => {
         required: true,
         presentable: false,
         collectionId: householdsCol.id,
-        cascadeDelete: false,
+        cascadeDelete: true,
         minSelect: null,
         maxSelect: 1
       },

--- a/pocketbase/pb_migrations/1500000059_cascade_delete_derived_relations.js
+++ b/pocketbase/pb_migrations/1500000059_cascade_delete_derived_relations.js
@@ -11,9 +11,10 @@
  *
  * Affected relations:
  * - family_camp_registrations.household -> households
- * - family_camp_medical.household -> households
  *
  * Note: family_camp_adults trimmed — final cascadeDelete=true baked into
+ * merged CREATE migration #035.
+ * Note: family_camp_medical trimmed — final cascadeDelete=true baked into
  * merged CREATE migration #035.
  */
 
@@ -34,20 +35,6 @@ migrate((app) => {
   }));
   app.save(fcRegs);
 
-  // 2. family_camp_medical.household
-  const fcMed = app.findCollectionByNameOrId("family_camp_medical");
-  fcMed.fields.add(new Field({
-    type: "relation",
-    name: "household",
-    required: true,
-    presentable: false,
-    collectionId: householdsCol.id,
-    cascadeDelete: true,
-    minSelect: null,
-    maxSelect: 1
-  }));
-  app.save(fcMed);
-
 }, (app) => {
   const householdsCol = app.findCollectionByNameOrId("households");
 
@@ -63,17 +50,4 @@ migrate((app) => {
     maxSelect: 1
   }));
   app.save(fcRegs);
-
-  const fcMed = app.findCollectionByNameOrId("family_camp_medical");
-  fcMed.fields.add(new Field({
-    type: "relation",
-    name: "household",
-    required: true,
-    presentable: false,
-    collectionId: householdsCol.id,
-    cascadeDelete: false,
-    minSelect: null,
-    maxSelect: 1
-  }));
-  app.save(fcMed);
 });

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -16,6 +16,8 @@
  * merged CREATE migration #047.
  * Note: family_camp_adults trimmed — final adminOnly rules baked into
  * merged CREATE migration #035.
+ * Note: family_camp_medical trimmed — final adminOnly rules baked into
+ * merged CREATE migration #035.
  */
 
 migrate((app) => {
@@ -39,7 +41,6 @@ migrate((app) => {
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",
     "person_custom_values", "person_tag_defs", "custom_field_defs",
-    "family_camp_medical",
     "family_camp_registrations", "session_groups",
     "config_sections", "sheets_workbooks"
   ]
@@ -76,7 +77,6 @@ migrate((app) => {
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",
     "person_custom_values", "person_tag_defs", "custom_field_defs",
-    "family_camp_medical",
     "family_camp_registrations", "session_groups",
     "config_sections", "sheets_workbooks",
     "debug_parse_results", "solver_runs"


### PR DESCRIPTION
## Summary
- Trim-only round following the family_camp_adults pattern (PR #1320).
- Removed `family_camp_medical` from two multi-table migrations and folded the resulting property edits into the table's section of multi-table base CREATE #035.
- Net delta: **0 files** in `pocketbase/pb_migrations/` (no deletions this round; the next sibling round on `family_camp_registrations` will retire #059 entirely).
- Verified empirically by `scripts/dev/verify-consolidation.sh`: `schemas match` between proposed (3 edited files) and current (3 unedited files).

### Trimmed
- `#1500000059_cascade_delete_derived_relations.js` — removed the `family_camp_medical.household` block from `up()` and matching block from `down()`. Folded `household.cascadeDelete: false → true` into #035. Remaining sharer of #059: `family_camp_registrations` (next round deletes #059 entirely).
- `#1500000075_rbac_tier2_rules.js` — removed `"family_camp_medical"` from `tier2[]` (up) and `all[]` (down). Folded list/view/c/u/d → `@request.auth.is_admin = true` into #035. Remaining tier2 tables: 16.

### Folded into #035 (family_camp_medical section only; adults and registrations sections byte-identical in the diff)
- `household.cascadeDelete: false → true`
- list/view/c/u/d rules: `@request.auth.id != ""` → `@request.auth.is_admin = true`

### Final state of family_camp_medical
- 10 fields (unchanged set, only `household.cascadeDelete` property edit)
- 1 unique index on `(household, year)`
- Rules: list/view/c/u/d = `@request.auth.is_admin = true`

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green
- [ ] After merge, prod boot's OnServe `migrate history-sync` hook is a no-op for this round (no files deleted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)