### PR TITLE
fix(frontend): tour readiness gate runs per-step, not only step 0 (#1323)

### DIFF
--- a/frontend/src/hooks/useTour.test.tsx
+++ b/frontend/src/hooks/useTour.test.tsx
@@ -13,9 +13,13 @@ vi.mock('react-router', () => ({
 
 const mockDrive = vi.fn()
 const mockDestroy = vi.fn()
+const mockMoveNext = vi.fn()
+const mockMovePrevious = vi.fn()
 const mockDriverInstance = {
   drive: mockDrive,
   destroy: mockDestroy,
+  moveNext: mockMoveNext,
+  movePrevious: mockMovePrevious,
   isActive: vi.fn(() => false),
 }
 
@@ -315,6 +319,65 @@ describe('useTour', () => {
 
     // No tour should have started — definitionRef must have been cleared on route change.
     expect(mockDrive).not.toHaveBeenCalled()
+
+    vi.mocked(document.querySelector).mockRestore()
+  })
+
+  it('replay() — Next click waits for target step selector before advancing', async () => {
+    const twoStepTour: TourDefinition = {
+      id: 'debug',
+      version: 1,
+      layers: [],
+      steps: [
+        {
+          element: '[data-tour="step-one"]',
+          popover: { title: 'One', description: 'First' },
+        },
+        {
+          element: '[data-tour="step-two"]',
+          popover: { title: 'Two', description: 'Second' },
+        },
+      ],
+    }
+    vi.mocked(tourRegistry.getTourIdForRoute).mockReturnValue('debug')
+    vi.mocked(tourRegistry.loadTourDefinition).mockResolvedValue(twoStepTour)
+    vi.mocked(tourStorage.getTourStorage).mockReturnValue({ layers: {} })
+
+    const stepOneEl = document.createElement('div')
+    let stepTwoExists = false
+    const originalQuerySelector = document.querySelector.bind(document)
+    vi.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
+      if (selector === '[data-tour="step-one"]') return stepOneEl
+      if (selector === '[data-tour="step-two"]') return stepTwoExists ? stepOneEl : null
+      return originalQuerySelector(selector)
+    })
+
+    const driverModule = await import('driver.js')
+    const { result } = renderHook(() => useTour())
+    await flushAndAdvance(1000)
+
+    act(() => {
+      result.current.replay()
+    })
+    await flushAndAdvance(1000)
+    expect(mockDrive).toHaveBeenCalled()
+
+    const lastCall = vi.mocked(driverModule.driver).mock.calls.at(-1)?.[0]
+    expect(lastCall?.onNextClick).toBeDefined()
+
+    act(() => {
+      lastCall!.onNextClick!(undefined, twoStepTour.steps[0] as never, {
+        config: lastCall!,
+        state: { activeIndex: 0 } as never,
+        driver: mockDriverInstance as never,
+      })
+    })
+    await flushAndAdvance(1000)
+    expect(mockMoveNext).not.toHaveBeenCalled()
+
+    stepTwoExists = true
+    await flushAndAdvance(1000)
+    expect(mockMoveNext).toHaveBeenCalledTimes(1)
 
     vi.mocked(document.querySelector).mockRestore()
   })

--- a/frontend/src/hooks/useTour.test.tsx
+++ b/frontend/src/hooks/useTour.test.tsx
@@ -417,4 +417,62 @@ describe('useTour', () => {
 
     vi.mocked(document.querySelector).mockRestore()
   })
+
+  it('replay() — Prev click waits for target step selector before going back', async () => {
+    const twoStepTour: TourDefinition = {
+      id: 'debug',
+      version: 1,
+      layers: [],
+      steps: [
+        {
+          element: '[data-tour="step-one"]',
+          popover: { title: 'One', description: 'First' },
+        },
+        {
+          element: '[data-tour="step-two"]',
+          popover: { title: 'Two', description: 'Second' },
+        },
+      ],
+    }
+    vi.mocked(tourRegistry.getTourIdForRoute).mockReturnValue('debug')
+    vi.mocked(tourRegistry.loadTourDefinition).mockResolvedValue(twoStepTour)
+    vi.mocked(tourStorage.getTourStorage).mockReturnValue({ layers: {} })
+
+    const stepTwoEl = document.createElement('div')
+    let stepOneExists = false
+    const originalQuerySelector = document.querySelector.bind(document)
+    vi.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
+      if (selector === '[data-tour="step-two"]') return stepTwoEl
+      if (selector === '[data-tour="step-one"]') return stepOneExists ? stepTwoEl : null
+      return originalQuerySelector(selector)
+    })
+
+    const driverModule = await import('driver.js')
+    const { result } = renderHook(() => useTour())
+    await flushAndAdvance(1000)
+
+    act(() => {
+      result.current.replay()
+    })
+    await flushAndAdvance(1000)
+
+    const lastCall = vi.mocked(driverModule.driver).mock.calls.at(-1)?.[0]
+    expect(lastCall?.onPrevClick).toBeDefined()
+
+    act(() => {
+      lastCall!.onPrevClick!(undefined, twoStepTour.steps[1] as never, {
+        config: lastCall!,
+        state: { activeIndex: 1 } as never,
+        driver: mockDriverInstance as never,
+      })
+    })
+    await flushAndAdvance(1000)
+    expect(mockMovePrevious).not.toHaveBeenCalled()
+
+    stepOneExists = true
+    await flushAndAdvance(1000)
+    expect(mockMovePrevious).toHaveBeenCalledTimes(1)
+
+    vi.mocked(document.querySelector).mockRestore()
+  })
 })

--- a/frontend/src/hooks/useTour.test.tsx
+++ b/frontend/src/hooks/useTour.test.tsx
@@ -475,4 +475,63 @@ describe('useTour', () => {
 
     vi.mocked(document.querySelector).mockRestore()
   })
+
+  it('replay() — pending Next-readiness wait is aborted on unmount', async () => {
+    const twoStepTour: TourDefinition = {
+      id: 'debug',
+      version: 1,
+      layers: [],
+      steps: [
+        {
+          element: '[data-tour="step-one"]',
+          popover: { title: 'One', description: 'First' },
+        },
+        {
+          element: '[data-tour="step-two"]',
+          popover: { title: 'Two', description: 'Second' },
+        },
+      ],
+    }
+    vi.mocked(tourRegistry.getTourIdForRoute).mockReturnValue('debug')
+    vi.mocked(tourRegistry.loadTourDefinition).mockResolvedValue(twoStepTour)
+    vi.mocked(tourStorage.getTourStorage).mockReturnValue({ layers: {} })
+
+    const stepOneEl = document.createElement('div')
+    let stepTwoExists = false
+    const originalQuerySelector = document.querySelector.bind(document)
+    vi.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
+      if (selector === '[data-tour="step-one"]') return stepOneEl
+      if (selector === '[data-tour="step-two"]') return stepTwoExists ? stepOneEl : null
+      return originalQuerySelector(selector)
+    })
+
+    const driverModule = await import('driver.js')
+    const { result, unmount } = renderHook(() => useTour())
+    await flushAndAdvance(1000)
+
+    act(() => {
+      result.current.replay()
+    })
+    await flushAndAdvance(1000)
+
+    const lastCall = vi.mocked(driverModule.driver).mock.calls.at(-1)?.[0]
+    act(() => {
+      lastCall!.onNextClick!(undefined, twoStepTour.steps[0] as never, {
+        config: lastCall!,
+        state: { activeIndex: 0 } as never,
+        driver: mockDriverInstance as never,
+      })
+    })
+
+    act(() => {
+      unmount()
+    })
+
+    stepTwoExists = true
+    await flushAndAdvance(5000)
+
+    expect(mockMoveNext).not.toHaveBeenCalled()
+
+    vi.mocked(document.querySelector).mockRestore()
+  })
 })

--- a/frontend/src/hooks/useTour.test.tsx
+++ b/frontend/src/hooks/useTour.test.tsx
@@ -381,4 +381,40 @@ describe('useTour', () => {
 
     vi.mocked(document.querySelector).mockRestore()
   })
+
+  it('replay() — Next click on the last step destroys the tour', async () => {
+    vi.mocked(tourRegistry.getTourIdForRoute).mockReturnValue('debug')
+    vi.mocked(tourRegistry.loadTourDefinition).mockResolvedValue(mockTourDefinition)
+    vi.mocked(tourStorage.getTourStorage).mockReturnValue({ layers: {} })
+
+    const el = document.createElement('div')
+    const originalQuerySelector = document.querySelector.bind(document)
+    vi.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
+      if (selector === '[data-tour="debug-header"]') return el
+      return originalQuerySelector(selector)
+    })
+
+    const driverModule = await import('driver.js')
+    const { result } = renderHook(() => useTour())
+    await flushAndAdvance(1000)
+
+    act(() => {
+      result.current.replay()
+    })
+    await flushAndAdvance(1000)
+
+    const lastCall = vi.mocked(driverModule.driver).mock.calls.at(-1)?.[0]
+    act(() => {
+      lastCall!.onNextClick!(undefined, mockTourDefinition.steps[0] as never, {
+        config: lastCall!,
+        state: { activeIndex: 0 } as never,
+        driver: mockDriverInstance as never,
+      })
+    })
+
+    expect(mockDestroy).toHaveBeenCalled()
+    expect(mockMoveNext).not.toHaveBeenCalled()
+
+    vi.mocked(document.querySelector).mockRestore()
+  })
 })

--- a/frontend/src/hooks/useTour.ts
+++ b/frontend/src/hooks/useTour.ts
@@ -161,22 +161,26 @@ export function useTour() {
           return
         }
         const nextSelector =
-          typeof steps[nextIdx]?.element === 'string' ? (steps[nextIdx].element as string) : null
-        waitForSelector(nextSelector, scheduleTimeout, abortController.signal).then((ready) => {
-          if (abortController.signal.aborted) return
-          if (ready) opts.driver.moveNext()
-        })
+          typeof steps[nextIdx]?.element === 'string' ? steps[nextIdx].element : null
+        void waitForSelector(nextSelector, scheduleTimeout, abortController.signal).then(
+          (ready) => {
+            if (abortController.signal.aborted) return
+            if (ready) opts.driver.moveNext()
+          }
+        )
       },
       onPrevClick: (_el, _step, opts) => {
         const currentIdx = opts.state.activeIndex ?? 0
         const prevIdx = currentIdx - 1
         if (prevIdx < 0) return
         const prevSelector =
-          typeof steps[prevIdx]?.element === 'string' ? (steps[prevIdx].element as string) : null
-        waitForSelector(prevSelector, scheduleTimeout, abortController.signal).then((ready) => {
-          if (abortController.signal.aborted) return
-          if (ready) opts.driver.movePrevious()
-        })
+          typeof steps[prevIdx]?.element === 'string' ? steps[prevIdx].element : null
+        void waitForSelector(prevSelector, scheduleTimeout, abortController.signal).then(
+          (ready) => {
+            if (abortController.signal.aborted) return
+            if (ready) opts.driver.movePrevious()
+          }
+        )
       },
       onDestroyed: () => {
         const completedLayers = layerBoundaries
@@ -191,7 +195,7 @@ export function useTour() {
     const firstSelector = typeof steps[0]?.element === 'string' ? steps[0].element : null
 
     scheduleTimeout(() => {
-      waitForSelector(firstSelector, scheduleTimeout, abortController.signal).then((ready) => {
+      void waitForSelector(firstSelector, scheduleTimeout, abortController.signal).then((ready) => {
         if (abortController.signal.aborted) return
         if (ready) {
           d.drive()

--- a/frontend/src/hooks/useTour.ts
+++ b/frontend/src/hooks/useTour.ts
@@ -32,6 +32,35 @@ interface LayerBoundary {
   endIndex: number
 }
 
+/** Poll for `selector` in the DOM. Resolves true when found, false on timeout or abort. */
+function waitForSelector(
+  selector: string | null,
+  schedule: (fn: () => void, ms: number) => void,
+  signal: AbortSignal
+): Promise<boolean> {
+  if (selector === null) return Promise.resolve(true)
+  return new Promise((resolve) => {
+    let retries = 0
+    const check = () => {
+      if (signal.aborted) {
+        resolve(false)
+        return
+      }
+      if (document.querySelector(selector) !== null) {
+        resolve(true)
+        return
+      }
+      if (retries >= MAX_READY_RETRIES) {
+        resolve(false)
+        return
+      }
+      retries++
+      schedule(check, READY_CHECK_INTERVAL)
+    }
+    schedule(check, 0)
+  })
+}
+
 export function useTour() {
   const { pathname } = useLocation()
   const [tourId, setTourId] = useState<TourId | null>(null)
@@ -39,6 +68,7 @@ export function useTour() {
   const definitionRef = useRef<TourDefinition | null>(null)
   const layerDefsRef = useRef<LayerDefinition[]>([])
   const pendingTimersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set())
+  const abortControllerRef = useRef<AbortController | null>(null)
 
   const scheduleTimeout = useCallback((fn: () => void, ms: number) => {
     const id = setTimeout(() => {
@@ -131,29 +161,28 @@ export function useTour() {
 
     const firstSelector = typeof steps[0]?.element === 'string' ? steps[0].element : null
 
-    let retries = 0
-    const checkReady = () => {
-      const ready = firstSelector ? document.querySelector(firstSelector) !== null : true
-      if (ready) {
-        d.drive()
-        return
-      }
-      if (retries >= MAX_READY_RETRIES) {
-        d.destroy()
-        driverRef.current = null
-        return
-      }
-      retries++
-      scheduleTimeout(checkReady, READY_CHECK_INTERVAL)
-    }
+    abortControllerRef.current?.abort()
+    const abortController = new AbortController()
+    abortControllerRef.current = abortController
 
-    scheduleTimeout(checkReady, AUTO_START_DELAY)
+    scheduleTimeout(() => {
+      waitForSelector(firstSelector, scheduleTimeout, abortController.signal).then((ready) => {
+        if (abortController.signal.aborted) return
+        if (ready) {
+          d.drive()
+        } else {
+          d.destroy()
+          driverRef.current = null
+        }
+      })
+    }, AUTO_START_DELAY)
   }, [scheduleTimeout])
 
   // Cleanup on unmount
   useEffect(() => {
     const timers = pendingTimersRef.current
     return () => {
+      abortControllerRef.current?.abort()
       if (driverRef.current) {
         driverRef.current.destroy()
       }

--- a/frontend/src/hooks/useTour.ts
+++ b/frontend/src/hooks/useTour.ts
@@ -138,6 +138,10 @@ export function useTour() {
 
     let highestStepReached = -1
 
+    abortControllerRef.current?.abort()
+    const abortController = new AbortController()
+    abortControllerRef.current = abortController
+
     const d = driver({
       showProgress: true,
       showButtons: ['next', 'previous', 'close'],
@@ -148,6 +152,20 @@ export function useTour() {
         if (idx !== undefined && idx > highestStepReached) {
           highestStepReached = idx
         }
+      },
+      onNextClick: (_el, _step, opts) => {
+        const currentIdx = opts.state.activeIndex ?? 0
+        const nextIdx = currentIdx + 1
+        if (nextIdx >= steps.length) {
+          opts.driver.destroy()
+          return
+        }
+        const nextSelector =
+          typeof steps[nextIdx]?.element === 'string' ? (steps[nextIdx].element as string) : null
+        waitForSelector(nextSelector, scheduleTimeout, abortController.signal).then((ready) => {
+          if (abortController.signal.aborted) return
+          if (ready) opts.driver.moveNext()
+        })
       },
       onDestroyed: () => {
         const completedLayers = layerBoundaries
@@ -160,10 +178,6 @@ export function useTour() {
     driverRef.current = d
 
     const firstSelector = typeof steps[0]?.element === 'string' ? steps[0].element : null
-
-    abortControllerRef.current?.abort()
-    const abortController = new AbortController()
-    abortControllerRef.current = abortController
 
     scheduleTimeout(() => {
       waitForSelector(firstSelector, scheduleTimeout, abortController.signal).then((ready) => {

--- a/frontend/src/hooks/useTour.ts
+++ b/frontend/src/hooks/useTour.ts
@@ -167,6 +167,17 @@ export function useTour() {
           if (ready) opts.driver.moveNext()
         })
       },
+      onPrevClick: (_el, _step, opts) => {
+        const currentIdx = opts.state.activeIndex ?? 0
+        const prevIdx = currentIdx - 1
+        if (prevIdx < 0) return
+        const prevSelector =
+          typeof steps[prevIdx]?.element === 'string' ? (steps[prevIdx].element as string) : null
+        waitForSelector(prevSelector, scheduleTimeout, abortController.signal).then((ready) => {
+          if (abortController.signal.aborted) return
+          if (ready) opts.driver.movePrevious()
+        })
+      },
       onDestroyed: () => {
         const completedLayers = layerBoundaries
           .filter((b) => highestStepReached >= b.endIndex)


### PR DESCRIPTION
## Summary
- Override driver.js's default Next/Prev with hooks that poll the target step's selector via \`waitForSelector\` before calling \`moveNext\`/\`movePrevious\`. Step 2/3 anchors now correctly resolve on pages where data fetches haven't finished mounting the anchors.
- Extract \`waitForSelector(selector, schedule, signal)\` from the inline polling loop so it backs both the initial drive-gate and the per-step hooks.
- Wire \`AbortController\` into the unmount cleanup so late-arriving selectors can't fire \`moveNext\` on a destroyed driver.
- Because overriding \`onNextClick\` suppresses driver.js's default "destroy on last-step Next", the hook handles last-step destroy explicitly.

Fixes #1323.

## Test plan
- [x] Existing useTour tests still pass (replay starts, initial gate exhausts → destroy, route-change clears refs, malformed timestamp, layer assembly).
- [x] New: Next click waits for target step selector before \`moveNext\`.
- [x] New: Last-step Next calls \`destroy\`, not \`moveNext\`.
- [x] New: Prev click waits for target step selector before \`movePrevious\`.
- [x] New: Unmount aborts pending readiness wait — late selector does NOT fire \`moveNext\`.
- [ ] Manual: load Registration Overview, click "Tour This Page" while data is still loading — layer steps run first, then step 2/3 anchors correctly to \`reg-overview-summary\` / \`reg-overview-demographics\` (no floating popover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tour now waits for target elements before moving between steps.
  * Final-step navigation closes the tour instead of attempting further advances.
  * Auto-start sequence now waits for the first step to appear and cancels the tour if not ready.
  * Cleanup on unmount aborts pending waits to prevent navigation after component teardown.

* **Tests**
  * Added end-to-end style tests covering replay navigation, next/previous behavior, and abort-on-unmount.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1329)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->