### PR TITLE
fix(pb): add "cancelled" to solver_runs.status enum

### DIFF
--- a/pocketbase/pb_migrations/1500000093_solver_runs_add_cancelled_status.js
+++ b/pocketbase/pb_migrations/1500000093_solver_runs_add_cancelled_status.js
@@ -1,0 +1,23 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: Add "cancelled" to solver_runs.status select enum
+ *
+ * The sweep-cancel path (api/services/sweep_runner.py::_mark_remaining)
+ * writes status="cancelled" for orphan run rows when a sweep is aborted
+ * mid-loop. The frontend (SolverDebugPage) already treats "cancelled"
+ * as a terminal/settled status, but the PB select enum never included
+ * it — so the PATCH was rejected with validation_invalid_value and the
+ * rows stayed "pending" forever.
+ */
+
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("solver_runs")
+  const field = collection.fields.getByName("status")
+  field.values = ["pending", "running", "success", "failed", "error", "cancelled"]
+  app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("solver_runs")
+  const field = collection.fields.getByName("status")
+  field.values = ["pending", "running", "success", "failed", "error"]
+  app.save(collection)
+})


### PR DESCRIPTION
## Summary
- Adds `"cancelled"` to the `solver_runs.status` select enum so sweep-cancel orphans can be persisted instead of silently rejected.

## Root cause
`api/services/sweep_runner.py::_mark_remaining` writes `status="cancelled"` for the un-launched orphan rows when a sweep is aborted mid-loop. The PB schema (`1500000023_solver_runs.js:54`) only allowed `["pending", "running", "success", "failed", "error"]`, so the PATCH was rejected with `validation_invalid_value`. The in-memory `solver_runs` dict got the new value, but a server restart wiped it and the DB rows reverted to `"pending"` — visible as ghost children in the debug UI.

The frontend (`pages/summer/SolverDebugPage/index.tsx:83` and `:138`) already treats `"cancelled"` as a real terminal/settled status, so the migration is the only piece that was out of step.

## Why the existing test didn't catch it
`api/services/test_sweep_runner.py::test_marks_remaining_run_ids_cancelled_when_sweep_cancelled` passes `pb=None`, so the PB write branch is unreachable. Worth a follow-up to add a mock-pb test that asserts the PATCH payload — but that's a separate PR.

## Test plan
- [ ] Apply the migration locally (`./scripts/start_dev.sh` picks it up on boot).
- [ ] Kick off a debug sweep, cancel mid-flight, confirm orphan rows are PATCHed to `cancelled` (no `validation_invalid_value` warnings in the API log).
- [ ] Restart the stack and confirm those rows persist as `cancelled` (not `pending`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to cancel solver runs. Solver runs can now be marked with a cancelled status to indicate when they have been stopped.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1330)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->