### PR TITLE
feat(frontend): tooltip metric descriptions in solver compare panel

### DIFF
--- a/frontend/src/pages/summer/SolverDebugPage/PinnedComparisonPanel.test.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/PinnedComparisonPanel.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
+import { getMetric } from './metricRegistry'
 import { PinnedComparisonPanel } from './PinnedComparisonPanel'
 
 import type { SolverRun, SolverRunStats } from '../../../hooks/useSolverRuns'
@@ -154,6 +155,22 @@ describe('PinnedComparisonPanel', () => {
     // linear row is NOT highlighted
     const linearRow = screen.getByText(/linear constraints/i).closest('tr')!
     expect(linearRow.className).not.toContain('bg-yellow-50')
+  })
+
+  it('shows metric description on each row label as a title tooltip (mirrors historical-list headers)', () => {
+    render(<PinnedComparisonPanel runA={a} runB={b} onClear={vi.fn()} />)
+    // The metric label cell in column 1 of each row should carry a title
+    // attribute matching getMetric(key).description — same explanation as
+    // the historical SolverRunsTable column headers.
+    const wallCell = screen.getByText('Wall time').closest('td')!
+    expect(wallCell.getAttribute('title')).toBe(getMetric('walltime_seconds').description)
+    expect(wallCell.className).toContain('cursor-help')
+
+    const gapCell = screen.getByText('Gap').closest('td')!
+    expect(gapCell.getAttribute('title')).toBe(getMetric('optimality_gap').description)
+
+    const branchesCell = screen.getByText('Branches').closest('td')!
+    expect(branchesCell.getAttribute('title')).toBe(getMetric('num_branches').description)
   })
 
   it('renders constraint-type values from constraint_type_breakdown (#mockup-parity)', () => {

--- a/frontend/src/pages/summer/SolverDebugPage/PinnedComparisonPanel.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/PinnedComparisonPanel.tsx
@@ -123,7 +123,10 @@ export function PinnedComparisonPanel({ runA, runB, onClear }: Props) {
                   const rowBg = meta.highlight ? 'bg-yellow-50' : ''
                   return (
                     <tr key={key} className={`hover:bg-forest-50/30 ${rowBg}`}>
-                      <td className={`px-5 py-2 text-gray-700 ${isChild ? 'pl-10' : ''}`}>
+                      <td
+                        className={`px-5 py-2 text-gray-700 ${isChild ? 'pl-10' : ''} ${meta.description ? 'cursor-help' : ''}`}
+                        title={meta.description || undefined}
+                      >
                         {meta.label}
                       </td>
                       <td className="px-3 py-2 text-right text-gray-600">


### PR DESCRIPTION
## Summary
- Adds `title` tooltips to each metric row label in the pin-to-compare panel on the solver debug page
- Mirrors the existing pattern on the historical-list column headers (`SolverRunsTable.tsx:84-90`)
- Descriptions are sourced from the same `metricRegistry` — no new copy, just exposure
- Adds `cursor-help` so the affordance is discoverable

Before: hovering a row label like "Convergence (∫gap)" or "bool_or constraints" gave no hint of what it meant.
After: same explanation as the historical-list column headers — e.g. "Cumulative integral of the gap over time; lower = converged faster."

## Test plan
- [x] New vitest case asserts `title` matches `getMetric(key).description` for Wall time, Gap, Branches
- [x] Verified red phase (test failed before implementation)
- [x] All 13 PinnedComparisonPanel tests pass
- [x] Full pre-push verification clean (ruff, mypy, tsc, eslint, prettier, vitest 4007 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive tooltips to metric labels in the pinned comparison panel. When available, metrics now display their descriptions on hover with a visual help cursor indicator.

* **Tests**
  * Added test coverage for the tooltip feature, verifying that metric descriptions appear correctly as title attributes and that the appropriate visual styling is applied.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1333)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->