### PR TITLE
refactor(pb): consolidate camp_sessions migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000013_camp_sessions.js
+++ b/pocketbase/pb_migrations/1500000013_camp_sessions.js
@@ -18,9 +18,9 @@ migrate((app) => {
     name: "camp_sessions",
     listRule: '@request.auth.id != ""',
     viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    createRule: '@request.auth.is_admin = true',
+    updateRule: '@request.auth.is_admin = true',
+    deleteRule: '@request.auth.is_admin = true',
     fields: [
       {
         type: "number",

--- a/pocketbase/pb_migrations/1500000074_rbac_tier1_rules.js
+++ b/pocketbase/pb_migrations/1500000074_rbac_tier1_rules.js
@@ -25,10 +25,12 @@ migrate((app) => {
   }
 
   // Read-only: any role (shared reference data written by sync)
-  // Note: "persons", "attendees", "attendee_status_history", "config" trimmed —
-  // final-state rules baked into merged CREATE. (config-specific:
-  // list/view = authed; create/update = admin || registration.manage; delete = admin only.)
-  const anyRoleReadOnly = ["camp_sessions", "divisions"]
+  // Note: "persons", "attendees", "attendee_status_history", "config",
+  // "camp_sessions" trimmed — final-state rules baked into merged CREATE.
+  // (config-specific: list/view = authed; create/update = admin ||
+  // registration.manage; delete = admin only. camp_sessions final-state
+  // rules from #077 simplification: list/view = authed, c/u/d = adminOnly.)
+  const anyRoleReadOnly = ["divisions"]
   for (const name of anyRoleReadOnly) {
     setRules(name, anyRole, anyRole, adminOnly, adminOnly, adminOnly)
   }
@@ -77,7 +79,7 @@ migrate((app) => {
   }
 
   const collections = [
-    "camp_sessions", "divisions",
+    "divisions",
     "bunks",
     "locked_groups", "saved_scenarios"
   ]

--- a/pocketbase/pb_migrations/1500000077_rbac_simplify_rules.js
+++ b/pocketbase/pb_migrations/1500000077_rbac_simplify_rules.js
@@ -22,9 +22,9 @@ migrate((app) => {
   }
 
   // Previously anyRole (required at least one permission) — now any authenticated user
-  // Note: "persons", "attendees", "attendee_status_history", "config" trimmed —
-  // final-state rules baked into merged CREATE.
-  const openReadOnly = ["camp_sessions", "divisions"]
+  // Note: "persons", "attendees", "attendee_status_history", "config",
+  // "camp_sessions" trimmed — final-state rules baked into merged CREATE.
+  const openReadOnly = ["divisions"]
   for (const name of openReadOnly) {
     setRules(name, authed, authed, adminOnly, adminOnly, adminOnly)
   }
@@ -58,7 +58,7 @@ migrate((app) => {
     app.save(col)
   }
 
-  const anyRoleReadOnly = ["camp_sessions", "divisions"]
+  const anyRoleReadOnly = ["divisions"]
   for (const name of anyRoleReadOnly) {
     setRules(name, anyRole, anyRole, adminOnly, adminOnly, adminOnly)
   }


### PR DESCRIPTION
## Summary

Trim-only consolidation round on a table not in the original backlog. `camp_sessions` had three mutating files: `#1500000013` CREATE, `#1500000074` (tier1 RBAC rules), and `#1500000077` (simplify RBAC rules). Both rule files still serve other tables (divisions, bunks, locked_groups, saved_scenarios), so neither is deleted — both are trimmed.

- Net delta: **0 files** in `pocketbase/pb_migrations/`
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match between proposed (3 modified files) and current (3 unmodified files) DBs

## Changes

**Folded into merged CREATE `#1500000013_camp_sessions.js` (rule edits only):**
- `list/view`: `'@request.auth.id != ""'` (unchanged)
- `create/update/delete`: `'@request.auth.id != ""'` → `'@request.auth.is_admin = true'` (final state after the #074 + #077 simplification chain)

**Trimmed:**
- `#1500000074_rbac_tier1_rules.js` — removed `"camp_sessions"` from `anyRoleReadOnly[]` (up) and `collections[]` (down); header comment updated.
- `#1500000077_rbac_simplify_rules.js` — removed `"camp_sessions"` from `openReadOnly[]` (up) and `anyRoleReadOnly[]` (down); header comment updated.

**Final state of `camp_sessions`:** 20 fields (unchanged), 3 indexes (unchanged), rules baked as above.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green
- [ ] After merge, prod boot's OnServe `migrate history-sync` hook is a no-op (no file deletions this round)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Restricted camp sessions access to administrators only for create, update, and delete operations
  * Removed camp sessions from non-admin read-only access

* **Chores**
  * Updated system-wide access control rules to enforce stricter permission requirements

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1334)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->