### PR TITLE
refactor(pb): consolidate bunks migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000006_bunks.js
+++ b/pocketbase/pb_migrations/1500000006_bunks.js
@@ -15,9 +15,9 @@ migrate((app) => {
     name: "bunks",
     listRule: '@request.auth.id != ""',
     viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    createRule: '@request.auth.is_admin = true',
+    updateRule: '@request.auth.is_admin = true',
+    deleteRule: '@request.auth.is_admin = true',
     fields: [
       {
         type: "number",

--- a/pocketbase/pb_migrations/1500000074_rbac_tier1_rules.js
+++ b/pocketbase/pb_migrations/1500000074_rbac_tier1_rules.js
@@ -36,9 +36,9 @@ migrate((app) => {
   }
 
   // Read-only: bunking.view (bunking data written by sync/solver)
-  // Note: "bunk_assignments", "bunk_plans" trimmed — final-state rules baked into merged CREATE.
-  // (bunk_plans final-state rules from #077 simplification: list/view = authed, c/u/d = adminOnly.)
-  const bunkingViewReadOnly = ["bunks"]
+  // Note: "bunk_assignments", "bunk_plans", "bunks" trimmed — final-state rules baked into merged CREATE.
+  // (bunks final-state rules from #077 simplification: list/view = authed, c/u/d = adminOnly.)
+  const bunkingViewReadOnly = []
   for (const name of bunkingViewReadOnly) {
     setRules(name, bunkingView, bunkingView, adminOnly, adminOnly, adminOnly)
   }
@@ -80,7 +80,6 @@ migrate((app) => {
 
   const collections = [
     "divisions",
-    "bunks",
     "locked_groups", "saved_scenarios"
   ]
   for (const name of collections) {

--- a/pocketbase/pb_migrations/1500000077_rbac_simplify_rules.js
+++ b/pocketbase/pb_migrations/1500000077_rbac_simplify_rules.js
@@ -30,8 +30,8 @@ migrate((app) => {
   }
 
   // Previously bunking.view — now any authenticated user
-  // Note: "bunk_assignments", "bunk_plans" trimmed — final-state rules baked into merged CREATE.
-  const bunkingReadOnly = ["bunks"]
+  // Note: "bunk_assignments", "bunk_plans", "bunks" trimmed — final-state rules baked into merged CREATE.
+  const bunkingReadOnly = []
   for (const name of bunkingReadOnly) {
     setRules(name, authed, authed, adminOnly, adminOnly, adminOnly)
   }
@@ -63,7 +63,7 @@ migrate((app) => {
     setRules(name, anyRole, anyRole, adminOnly, adminOnly, adminOnly)
   }
 
-  const bunkingViewReadOnly = ["bunks"]
+  const bunkingViewReadOnly = []
   for (const name of bunkingViewReadOnly) {
     setRules(name, bunkingView, bunkingView, adminOnly, adminOnly, adminOnly)
   }


### PR DESCRIPTION
## Summary
- Trim-only round folding final-state RBAC rules into base `#1500000006_bunks.js`.
- Trimmed two multi-table RBAC migrations (`#1500000074_rbac_tier1_rules.js`, `#1500000077_rbac_simplify_rules.js`).
- Net delta: **0 files** (bunks was the sole remaining member of both `bunkingViewReadOnly[]` and `bunkingReadOnly[]`; arrays now empty in both files).
- Verified empirically by `scripts/dev/verify-consolidation.sh`: `schemas match` between proposed and current.

Trimmed:
- `1500000074_rbac_tier1_rules.js` — removed `"bunks"` from `bunkingViewReadOnly[]` (up) and rollback `collections[]` (down); comment updated.
- `1500000077_rbac_simplify_rules.js` — removed `"bunks"` from `bunkingReadOnly[]` (up) and rollback `bunkingViewReadOnly[]` (down); comment updated.

Folded into merged CREATE `#1500000006_bunks.js`:
- `createRule`/`updateRule`/`deleteRule`: `'@request.auth.id != ""'` → `'@request.auth.is_admin = true'` (final state after #074 + #077).
- `listRule`/`viewRule`: unchanged (`'@request.auth.id != ""'`).
- Fields and indexes unchanged.

Final state of `bunks`: 9 fields, 3 indexes, list/view = authed, c/u/d = adminOnly.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green
- [ ] After merge, prod boot's OnServe `migrate history-sync` hook is a no-op for this round (no files deleted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Restricted modifications to bunks, limiting create, update, and delete operations to administrators only.
  * Simplified and adjusted permission rules for authenticated users across related collections.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1336)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->