### PR TITLE
refactor(pb): consolidate divisions migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000004_divisions.js
+++ b/pocketbase/pb_migrations/1500000004_divisions.js
@@ -17,9 +17,9 @@ migrate((app) => {
     name: "divisions",
     listRule: '@request.auth.id != ""',
     viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    createRule: '@request.auth.is_admin = true',
+    updateRule: '@request.auth.is_admin = true',
+    deleteRule: '@request.auth.is_admin = true',
     fields: [
       {
         type: "number",

--- a/pocketbase/pb_migrations/1500000074_rbac_tier1_rules.js
+++ b/pocketbase/pb_migrations/1500000074_rbac_tier1_rules.js
@@ -26,11 +26,12 @@ migrate((app) => {
 
   // Read-only: any role (shared reference data written by sync)
   // Note: "persons", "attendees", "attendee_status_history", "config",
-  // "camp_sessions" trimmed — final-state rules baked into merged CREATE.
-  // (config-specific: list/view = authed; create/update = admin ||
-  // registration.manage; delete = admin only. camp_sessions final-state
-  // rules from #077 simplification: list/view = authed, c/u/d = adminOnly.)
-  const anyRoleReadOnly = ["divisions"]
+  // "camp_sessions", "divisions" trimmed — final-state rules baked into
+  // merged CREATE. (config-specific: list/view = authed; create/update =
+  // admin || registration.manage; delete = admin only. camp_sessions and
+  // divisions final-state rules from #077 simplification:
+  // list/view = authed, c/u/d = adminOnly.)
+  const anyRoleReadOnly = []
   for (const name of anyRoleReadOnly) {
     setRules(name, anyRole, anyRole, adminOnly, adminOnly, adminOnly)
   }
@@ -79,7 +80,6 @@ migrate((app) => {
   }
 
   const collections = [
-    "divisions",
     "locked_groups", "saved_scenarios"
   ]
   for (const name of collections) {

--- a/pocketbase/pb_migrations/1500000077_rbac_simplify_rules.js
+++ b/pocketbase/pb_migrations/1500000077_rbac_simplify_rules.js
@@ -23,8 +23,8 @@ migrate((app) => {
 
   // Previously anyRole (required at least one permission) — now any authenticated user
   // Note: "persons", "attendees", "attendee_status_history", "config",
-  // "camp_sessions" trimmed — final-state rules baked into merged CREATE.
-  const openReadOnly = ["divisions"]
+  // "camp_sessions", "divisions" trimmed — final-state rules baked into merged CREATE.
+  const openReadOnly = []
   for (const name of openReadOnly) {
     setRules(name, authed, authed, adminOnly, adminOnly, adminOnly)
   }
@@ -58,7 +58,7 @@ migrate((app) => {
     app.save(col)
   }
 
-  const anyRoleReadOnly = ["divisions"]
+  const anyRoleReadOnly = []
   for (const name of anyRoleReadOnly) {
     setRules(name, anyRole, anyRole, adminOnly, adminOnly, adminOnly)
   }


### PR DESCRIPTION
## Summary
- Trim-only round: `divisions` was an active member of two multi-table RBAC migrations
- Folded final rules into base #1500000004 (`list/view = authed`, `c/u/d = adminOnly`)
- Trimmed `"divisions"` from #1500000074 `anyRoleReadOnly[]` and #1500000077 `openReadOnly[]` (both arrays now empty — divisions was the last sharer)
- Net delta: **0 files** (no deletions; absorbed-into-base + trimmed-in-place only)
- Two-save pattern in #004 preserved (`parent_division` self-relation per PB v0.23 constraints)
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match between proposed (3 modified files) and current (3 unmodified files)

Trimmed:
- `1500000074_rbac_tier1_rules.js` — `anyRoleReadOnly` array now `[]`; comment updated to record the divisions trim
- `1500000077_rbac_simplify_rules.js` — `openReadOnly` (up) and `anyRoleReadOnly` (down) both `[]`; comment updated

Final state of `divisions`: 12 fields, 1 unique index on `cm_id`, rules `list/view = authed`, `c/u/d = adminOnly`.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green
- [ ] After merge, prod boot's OnServe `migrate history-sync` hook is a no-op (no files deleted this round)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated access control rules restricting divisions creation, modification, and deletion to administrators only
  * Refined read-access permissions for divisions within the role-based access control system

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1337)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->