### PR TITLE
fix(frontend): surface parent bunk-request form in camper sidebar

### DIFF
--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -2,7 +2,8 @@
  * Tests for CamperDetailsPanel component.
  *
  * This component displays detailed camper information in a slide-in panel,
- * including bunking preferences, camp journey history, siblings, and raw CSV data.
+ * including bunking preferences, camp journey history, siblings, and the
+ * parent-sourced bunk request form text.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '../test/testUtils'
@@ -1047,6 +1048,120 @@ describe('CamperDetailsPanel', () => {
       await waitFor(() => {
         expect(screen.getByText('Bunk with')).toBeInTheDocument()
       })
+    })
+  })
+
+  describe('Bunk Request Form section (parent-sourced quick-ref)', () => {
+    /** Build a minimal original_bunk_requests record matching the hook's schema. */
+    function originalBunkRecord(content: string) {
+      return {
+        id: 'obr-1',
+        field: 'bunk_with' as const,
+        content,
+        requester: 'pb-emma',
+        year: 2025,
+        created: '2025-01-01T00:00:00Z',
+        updated: '2025-05-01T00:00:00Z',
+        collectionId: 'original_bunk_requests',
+        collectionName: 'original_bunk_requests',
+        expand: { requester: { first_name: 'Emma', last_name: 'Johnson' } },
+      }
+    }
+
+    /** Set up mocks for Emma with a populated parent bunk-request form input. */
+    function setupParentBunkRequestText(content: string) {
+      mockGetFullListPersons.mockResolvedValue([EMMA])
+      mockGetFullListAttendees.mockResolvedValue([EMMA_ATTENDEE])
+      mockGetFullListBunkAssignments.mockResolvedValue([])
+      mockGetFullListBunkRequests.mockResolvedValue([])
+      mockGetListPersons.mockResolvedValue({ items: [], totalItems: 0 })
+      mockGetListOriginalBunkRequests.mockResolvedValue({
+        items: [originalBunkRecord(content)],
+        totalItems: 1,
+      })
+    }
+
+    it('renders the "Bunk Request Form" section header when parent text exists', async () => {
+      setupParentBunkRequestText('Riley Sam, Olivia Chen')
+
+      render(<CamperDetailsPanel camperId="100" onClose={mockOnClose} embedded={true} />)
+
+      await waitFor(() => {
+        expect(screen.getByText(/Bunk Request Form/i)).toBeInTheDocument()
+      })
+    })
+
+    it('shows the parent text by default (default expanded for quick-ref)', async () => {
+      setupParentBunkRequestText('Riley Sam, Olivia Chen')
+
+      render(<CamperDetailsPanel camperId="100" onClose={mockOnClose} embedded={true} />)
+
+      await waitFor(() => {
+        expect(screen.getByText(/Bunk Request Form/i)).toBeInTheDocument()
+      })
+      // Parent text immediately visible without any click
+      expect(screen.getByText('Riley Sam, Olivia Chen')).toBeInTheDocument()
+    })
+
+    it('collapses the parent text when the section header is clicked', async () => {
+      setupParentBunkRequestText('Riley Sam, Olivia Chen')
+
+      render(<CamperDetailsPanel camperId="100" onClose={mockOnClose} embedded={true} />)
+
+      // Wait for the section to render with text visible
+      await waitFor(() => {
+        expect(screen.getByText('Riley Sam, Olivia Chen')).toBeInTheDocument()
+      })
+
+      // Click the header to collapse
+      const header = screen.getByRole('button', { name: /Bunk Request Form/i })
+      header.click()
+
+      await waitFor(() => {
+        expect(screen.queryByText('Riley Sam, Olivia Chen')).not.toBeInTheDocument()
+      })
+    })
+
+    it('does not render the section when there is no parent bunk-request text', async () => {
+      // No original_bunk_requests record at all
+      mockGetFullListPersons.mockResolvedValue([EMMA])
+      mockGetFullListAttendees.mockResolvedValue([EMMA_ATTENDEE])
+      mockGetFullListBunkAssignments.mockResolvedValue([])
+      mockGetFullListBunkRequests.mockResolvedValue([])
+      mockGetListPersons.mockResolvedValue({ items: [], totalItems: 0 })
+      mockGetListOriginalBunkRequests.mockResolvedValue({ items: [], totalItems: 0 })
+
+      render(<CamperDetailsPanel camperId="100" onClose={mockOnClose} embedded={true} />)
+
+      // Wait for camper to load (heading appears)
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Emma/i })).toBeInTheDocument()
+      })
+      expect(screen.queryByText(/Bunk Request Form/i)).not.toBeInTheDocument()
+    })
+
+    it('does not render the section when bunk_with record exists but content is empty', async () => {
+      setupParentBunkRequestText('')
+
+      render(<CamperDetailsPanel camperId="100" onClose={mockOnClose} embedded={true} />)
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Emma/i })).toBeInTheDocument()
+      })
+      expect(screen.queryByText(/Bunk Request Form/i)).not.toBeInTheDocument()
+    })
+
+    it('queries original_bunk_requests using the working requester.cm_id filter (not the broken person_id)', async () => {
+      setupParentBunkRequestText('Riley Sam, Olivia Chen')
+
+      render(<CamperDetailsPanel camperId="100" onClose={mockOnClose} embedded={true} />)
+
+      await waitFor(() => {
+        expect(mockGetListOriginalBunkRequests).toHaveBeenCalled()
+      })
+      const filter = String(mockGetListOriginalBunkRequests.mock.calls[0]?.[2]?.filter ?? '')
+      expect(filter).toContain('requester.cm_id = 100')
+      expect(filter).not.toContain('person_id =')
     })
   })
 })

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -1130,11 +1130,11 @@ export default function CamperDetailsPanel({
           </section>
         )}
 
-        {/* Bunk Request Form — parent-sourced form input, collapsed by default.
-            Quick-ref for the share_bunk_with field only; full 5-field CSV is
+        {/* Bunk Request Form — parent-sourced form input, expanded by default (quick-ref).
+            Shows the share_bunk_with field only; full 5-field CSV is
             available on the manage-requests modal, the requests row expansion,
             and the full-page bunk-csv view. */}
-        {originalBunkData?.share_bunk_with && (
+        {originalBunkData?.share_bunk_with?.trim() && (
           <section>
             <SectionHeader
               title="Bunk Request Form"

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -7,12 +7,12 @@ import {
   Heart,
   ChevronDown,
   ChevronRight,
-  FileText,
   MapPin,
   TreePine,
   Home,
   Users,
   ExternalLink,
+  MessageSquareQuote,
 } from 'lucide-react'
 import { ParentStaffDivider, AgePreferenceDivider } from './camper/RequestSectionDividers'
 import { pb } from '../lib/pocketbase'
@@ -51,6 +51,7 @@ import {
 } from '../utils/satisfactionLookup'
 import type { RequestBucket, SatisfactionEntry } from '../types/satisfaction'
 import type { EnhancedBunkRequest } from '../hooks/camper/useAllBunkRequests'
+import { useOriginalBunkData } from '../hooks/camper/useOriginalBunkData'
 import { useYear } from '../hooks/useCurrentYear'
 import { getDisplayAgeForYear } from '../utils/displayAge'
 import { CampMinderIcon } from './icons'
@@ -236,7 +237,7 @@ export default function CamperDetailsPanel({
     requests: true,
     history: true,
     siblings: true,
-    rawData: false,
+    bunkRequestForm: true,
   })
 
   const toggleSection = (section: keyof typeof expandedSections) => {
@@ -543,35 +544,10 @@ export default function CamperDetailsPanel({
     enabled: !!(person?.household_id && person.household_id > 0),
   })
 
-  // Fetch original CSV data
-  interface OriginalBunkData {
-    share_bunk_with?: string
-    share_bunk_with_updated?: string
-    do_not_share_bunk_with?: string
-    do_not_share_bunk_with_updated?: string
-    internal_bunk_notes?: string
-    internal_bunk_notes_updated?: string
-    bunking_notes_notes?: string
-    bunking_notes_notes_updated?: string
-    ret_parent_socialize_with_best?: string
-    ret_parent_socialize_with_best_updated?: string
-  }
-
-  const { data: originalBunkData } = useQuery({
-    queryKey: queryKeys.originalBunkRequestsByPersonId(camper?.person_cm_id, currentYear),
-    queryFn: async (): Promise<OriginalBunkData | null> => {
-      if (!camper?.person_cm_id) throw new Error('No camper person ID')
-      try {
-        const filter = `person_id = ${camper.person_cm_id} && year = ${currentYear}`
-        const records = await pb.collection('original_bunk_requests').getList(1, 1, { filter })
-        if (records.items.length === 0) return null
-        return records.items[0] as OriginalBunkData
-      } catch {
-        return null
-      }
-    },
-    enabled: !!camper?.person_cm_id,
-  })
+  // Original parent-sourced bunk-request form text (CSV import, normalized
+  // per-field). Re-uses the same hook the full-page camper detail does so the
+  // sidebar reads the same source of truth via `requester.cm_id`.
+  const { originalBunkData } = useOriginalBunkData(camper?.person_cm_id, currentYear)
 
   // Trigger close - for embedded mode, call directly; for slide panel, start exit animation
   const handleClose = useCallback(() => {
@@ -1154,60 +1130,24 @@ export default function CamperDetailsPanel({
           </section>
         )}
 
-        {/* Raw CSV Data - Collapsed by default */}
-        {originalBunkData && (
+        {/* Bunk Request Form — parent-sourced form input, collapsed by default.
+            Quick-ref for the share_bunk_with field only; full 5-field CSV is
+            available on the manage-requests modal, the requests row expansion,
+            and the full-page bunk-csv view. */}
+        {originalBunkData?.share_bunk_with && (
           <section>
             <SectionHeader
-              title="Raw CSV Data"
-              icon={FileText}
-              isExpanded={expandedSections.rawData}
-              onToggle={() => toggleSection('rawData')}
-              accentColor="stone"
+              title="Bunk Request Form"
+              icon={MessageSquareQuote}
+              isExpanded={expandedSections.bunkRequestForm}
+              onToggle={() => toggleSection('bunkRequestForm')}
+              accentColor="amber"
             />
-            {expandedSections.rawData && (
-              <div className="mt-2 space-y-2 text-xs">
-                {originalBunkData.share_bunk_with && (
-                  <div className="bg-muted/50 rounded-lg p-2">
-                    <span className="text-muted-foreground font-medium">Bunk Request Form:</span>
-                    <p className="text-foreground mt-1 whitespace-pre-wrap">
-                      {originalBunkData.share_bunk_with}
-                    </p>
-                  </div>
-                )}
-                {originalBunkData.do_not_share_bunk_with && (
-                  <div className="bg-muted/50 rounded-lg p-2">
-                    <span className="text-muted-foreground font-medium">
-                      Do NOT Share Bunk With:
-                    </span>
-                    <p className="text-foreground mt-1 whitespace-pre-wrap">
-                      {originalBunkData.do_not_share_bunk_with}
-                    </p>
-                  </div>
-                )}
-                {originalBunkData.internal_bunk_notes && (
-                  <div className="bg-muted/50 rounded-lg p-2">
-                    <span className="text-muted-foreground font-medium">Internal Notes:</span>
-                    <p className="text-foreground mt-1 whitespace-pre-wrap">
-                      {originalBunkData.internal_bunk_notes}
-                    </p>
-                  </div>
-                )}
-                {originalBunkData.bunking_notes_notes && (
-                  <div className="bg-muted/50 rounded-lg p-2">
-                    <span className="text-muted-foreground font-medium">Bunking Notes:</span>
-                    <p className="text-foreground mt-1 whitespace-pre-wrap">
-                      {originalBunkData.bunking_notes_notes}
-                    </p>
-                  </div>
-                )}
-                {originalBunkData.ret_parent_socialize_with_best && (
-                  <div className="bg-muted/50 rounded-lg p-2">
-                    <span className="text-muted-foreground font-medium">Social With Checkbox:</span>
-                    <p className="text-foreground mt-1 whitespace-pre-wrap">
-                      {originalBunkData.ret_parent_socialize_with_best}
-                    </p>
-                  </div>
-                )}
+            {expandedSections.bunkRequestForm && (
+              <div className="mt-2 pl-1">
+                <blockquote className="text-foreground rounded-r-lg border-l-2 border-amber-300 bg-amber-50/60 px-3 py-2 text-sm whitespace-pre-wrap italic dark:border-amber-500/60 dark:bg-amber-900/20">
+                  {originalBunkData.share_bunk_with}
+                </blockquote>
               </div>
             )}
           </section>


### PR DESCRIPTION
## Summary

- The sidebar's "Raw CSV Data" section was silently broken — its inline query filtered `original_bunk_requests` on a non-existent `person_id` column and cast the normalized record (which has `field`/`content` columns) as a flat object. `originalBunkData` was always null, so the section never rendered in prod despite living in the codebase.
- Replace the broken inline query with the existing `useOriginalBunkData` hook (single source of truth — same one the full-page camper detail uses, with the correct `requester.cm_id` filter and denormalization).
- Reduce the section to a focused **Bunk Request Form** quick-ref showing only the parent-sourced `share_bunk_with` text. The other four CSV fields stay available in the manage-requests modal, the requests row expansion, and the full-page bunk-csv view — the sidebar is now a true quick-glance surface.
- Visual: `MessageSquareQuote` icon, amber section accent, italic blockquote with a left amber bar to read as the parent's voice. Default expanded; whole section hidden when the parent submitted no `bunk_with` text.

## Test plan

- [x] New tests (TDD: written first, verified 4/6 failing before implementation):
  - section header renders when parent text exists
  - parent text visible by default (default-expanded quick-ref)
  - clicking header collapses
  - section absent when no `original_bunk_requests` record
  - section absent when `bunk_with` content is empty string
  - query uses `requester.cm_id` filter, not the broken `person_id`
- [x] Full `CamperDetailsPanel.test.tsx`: 29/29 pass
- [x] Full frontend test suite: 4013/4013 pass
- [x] `tsc --noEmit`, eslint, prettier all clean
- [ ] Manual verification in dev: open camper sidebar on a camper whose parent submitted bunk-request CSV text — confirm the new section renders with their words

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  - Added tests covering the Camper Details Panel Bunk Request Form behavior and collapse/expand interactions.

* **Bug Fixes**
  - Panel now shows parent-sourced Bunk Request Form text (not raw CSV) and defaults to the form view.
  - Bunk Request Form is collapsible with correct header rendering and updated iconography.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1338)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->