### PR TITLE
refactor(pb): consolidate session_groups migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000005_session_groups.js
+++ b/pocketbase/pb_migrations/1500000005_session_groups.js
@@ -8,16 +8,18 @@
 
 const COLLECTION_ID_SESSION_GROUPS = "col_session_groups";
 
+const adminOnly = '@request.auth.is_admin = true';
+
 migrate((app) => {
   const collection = new Collection({
     id: COLLECTION_ID_SESSION_GROUPS,
     type: "base",
     name: "session_groups",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: adminOnly,
+    viewRule: adminOnly,
+    createRule: adminOnly,
+    updateRule: adminOnly,
+    deleteRule: adminOnly,
     fields: [
       {
         type: "number",

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -20,6 +20,8 @@
  * merged CREATE migration #035.
  * Note: family_camp_registrations trimmed — final adminOnly rules baked into
  * merged CREATE migration #035.
+ * Note: session_groups trimmed — final adminOnly rules baked into
+ * merged CREATE migration #005.
  */
 
 migrate((app) => {
@@ -43,7 +45,6 @@ migrate((app) => {
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",
     "person_custom_values", "person_tag_defs", "custom_field_defs",
-    "session_groups",
     "config_sections", "sheets_workbooks"
   ]
 
@@ -79,7 +80,6 @@ migrate((app) => {
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",
     "person_custom_values", "person_tag_defs", "custom_field_defs",
-    "session_groups",
     "config_sections", "sheets_workbooks",
     "debug_parse_results", "solver_runs"
   ]


### PR DESCRIPTION
## Summary
- Trim-only round: removes `session_groups` from the multi-table RBAC tier2 rules migration (`#1500000075`) and bakes the final adminOnly rules into the merged CREATE migration (`#1500000005`)
- No fields, indexes, or properties change — `session_groups`' field set (`cm_id`, `name`, `description`, `is_active`, `sort_order`, `year`, `created`, `updated`), year column, and unique index are untouched
- Net delta: **0 files** in `pocketbase/pb_migrations/` (last sharer not yet removed; `tier2` array still has 13 other tables)
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match between proposed (this branch) and current (origin/main)

Trimmed:
- `#1500000075 rbac_tier2_rules` — removed `"session_groups"` from `tier2[]` (up) and `all[]` (down); header comment updated with trim note

Final state of `session_groups`: 8 fields, 2 indexes, all 5 rules = `@request.auth.is_admin = true`.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green
- [ ] After merge, prod boot's OnServe `migrate history-sync` hook is a no-op (no files deleted this round)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted access to session groups administration to administrator users exclusively. Consolidated permission configurations across database migrations to streamline administrative controls and enhance system security.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1340)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->