### PR TITLE
feat(solver,frontend): surface bucket-aware outcome metrics in debug page

### DIFF
--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -1169,6 +1169,18 @@ class DirectBunkingSolver:
         # directly would overstate the number shown in the diagnostic.
         resolved_possible_count: dict[int, int] = {}
 
+        # Symmetric met/total counts for the symmetric outcome metrics added in
+        # PR1 of the solver-debug metric expansion. Hoisted ABOVE the loop's
+        # early-continues because the diagnostic skips campers with >=1
+        # satisfied request, and we need every camper in scope here. Uses the
+        # canonical `classify_request()` from `bunking.satisfaction.bucket`.
+        mp_requests_total = 0
+        mp_requests_satisfied = 0
+        mp_campers_total = 0
+        mp_campers_satisfied = 0
+        all_campers_total = 0
+        all_campers_satisfied = 0
+
         for person_cm_id, requests in self.input.requests_by_person.items():
             if person_cm_id not in person_to_bunk:
                 continue
@@ -1176,6 +1188,31 @@ class DirectBunkingSolver:
             resolved_requests = [r for r in requests if r.status == "resolved"]
             if not resolved_requests:
                 continue
+
+            # PR1 symmetric counts -- must happen before the early-continue
+            # below, which skips campers with >=1 satisfied request.
+            satisfied_ids_for_person: set[str] = set(all_satisfied.get(person_cm_id, []))
+
+            def _is_mp(r: DirectBunkRequest) -> bool:
+                """Canonical MP classification, defensive on unknown source_field."""
+                if not r.source_field:
+                    return False
+                try:
+                    return classify_request(r.source_field) == RequestBucket.MATERIAL_PARENT
+                except ValueError:
+                    return False
+
+            resolved_mp = [r for r in resolved_requests if _is_mp(r)]
+            mp_requests_total += len(resolved_mp)
+            satisfied_mp = [r for r in resolved_mp if r.id in satisfied_ids_for_person]
+            mp_requests_satisfied += len(satisfied_mp)
+            if resolved_mp:
+                mp_campers_total += 1
+                if satisfied_mp:
+                    mp_campers_satisfied += 1
+            all_campers_total += 1
+            if any(r.id in satisfied_ids_for_person for r in resolved_requests):
+                all_campers_satisfied += 1
 
             resolved_ids = {r.id for r in resolved_requests}
             if any(rid in resolved_ids for rid in all_satisfied.get(person_cm_id, [])):
@@ -1187,6 +1224,12 @@ class DirectBunkingSolver:
                 continue
 
             resolved_possible_count[person_cm_id] = len(resolved_possible)
+            # TODO(stage-4-retire): when the parent-paramount Stage 4 reweighting
+            # lands, retire `_is_material_parent()` (it's a legacy wrapper around
+            # the canonical `classify_request()` from bunking.satisfaction.bucket;
+            # PR1's new MP counts above already use the canonical helper) and
+            # also retire the Stage-4-era `staff_*` / `immaterial_*` metric
+            # mirrors that read from this same diagnostic.
             if any(_is_material_parent(r) for r in resolved_possible):
                 material_parent_unmet.append(person_cm_id)
             else:
@@ -1197,6 +1240,16 @@ class DirectBunkingSolver:
         self.request_validation_summary["unsatisfied_no_possible"] = len(no_possible)
         self.request_validation_summary["unsatisfied_material_parent_unmet"] = len(material_parent_unmet)
         self.request_validation_summary["unsatisfied_other_unmet"] = len(other_unmet)
+
+        # PR1 symmetric met/total counts -- mirror the bucket-aware unmet keys
+        # above with positive-side counts. Consumers (debug page) derive unmet
+        # = total - satisfied; we don't persist unmet redundantly.
+        self.request_validation_summary["mp_requests_total"] = mp_requests_total
+        self.request_validation_summary["mp_requests_satisfied"] = mp_requests_satisfied
+        self.request_validation_summary["mp_campers_total"] = mp_campers_total
+        self.request_validation_summary["mp_campers_satisfied"] = mp_campers_satisfied
+        self.request_validation_summary["all_campers_total"] = all_campers_total
+        self.request_validation_summary["all_campers_satisfied"] = all_campers_satisfied
 
         if no_possible:
             logger.info(

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -808,6 +808,13 @@ class DirectBunkingSolver:
             "single_bunk_session": True,
         }
 
+        # Populate `request_validation` so the debug page's bucket-aware
+        # outcome columns (mp_request_rate, all_camper_rate, ...) render for
+        # single-bunk sessions identically to multi-bunk. Mirrors the
+        # multi-bunk solve() path that attaches the summary post-solve.
+        self._check_must_satisfy_one_violations(assignments)
+        stats["request_validation"] = self.request_validation_summary
+
         return DirectSolverOutput(
             assignments=assignments,
             satisfied_requests=satisfied_requests,
@@ -1193,16 +1200,7 @@ class DirectBunkingSolver:
             # below, which skips campers with >=1 satisfied request.
             satisfied_ids_for_person: set[str] = set(all_satisfied.get(person_cm_id, []))
 
-            def _is_mp(r: DirectBunkRequest) -> bool:
-                """Canonical MP classification, defensive on unknown source_field."""
-                if not r.source_field:
-                    return False
-                try:
-                    return classify_request(r.source_field) == RequestBucket.MATERIAL_PARENT
-                except ValueError:
-                    return False
-
-            resolved_mp = [r for r in resolved_requests if _is_mp(r)]
+            resolved_mp = [r for r in resolved_requests if _is_material_parent(r)]
             mp_requests_total += len(resolved_mp)
             satisfied_mp = [r for r in resolved_mp if r.id in satisfied_ids_for_person]
             mp_requests_satisfied += len(satisfied_mp)
@@ -1225,11 +1223,10 @@ class DirectBunkingSolver:
 
             resolved_possible_count[person_cm_id] = len(resolved_possible)
             # TODO(stage-4-retire): when the parent-paramount Stage 4 reweighting
-            # lands, retire `_is_material_parent()` (it's a legacy wrapper around
-            # the canonical `classify_request()` from bunking.satisfaction.bucket;
-            # PR1's new MP counts above already use the canonical helper) and
-            # also retire the Stage-4-era `staff_*` / `immaterial_*` metric
-            # mirrors that read from this same diagnostic.
+            # lands, retire `_is_material_parent()` (a legacy wrapper around
+            # `classify_request()` from bunking.satisfaction.bucket) and the
+            # Stage-4-era `staff_*` / `immaterial_*` metric mirrors that read
+            # from this same diagnostic.
             if any(_is_material_parent(r) for r in resolved_possible):
                 material_parent_unmet.append(person_cm_id)
             else:

--- a/frontend/src/hooks/useSolverRuns.ts
+++ b/frontend/src/hooks/useSolverRuns.ts
@@ -24,6 +24,27 @@ export interface SolverRunStats {
   model_num_constraints?: number
   constraint_type_breakdown?: Record<string, number>
   objective_value?: number | null
+  total_requests?: number | null
+  total_persons?: number | null
+  total_bunks?: number | null
+  satisfied_request_count?: number | null
+  assignments_changed?: number | null
+  new_assignments?: number | null
+  request_validation?: {
+    total_requests?: number
+    possible_requests?: number
+    impossible_requests?: number
+    affected_campers?: number
+    unsatisfied_no_possible?: number
+    unsatisfied_material_parent_unmet?: number
+    unsatisfied_other_unmet?: number
+    mp_requests_total?: number
+    mp_requests_satisfied?: number
+    mp_campers_total?: number
+    mp_campers_satisfied?: number
+    all_campers_total?: number
+    all_campers_satisfied?: number
+  }
 }
 
 export interface SolverRunDetails {

--- a/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.test.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.test.tsx
@@ -89,3 +89,42 @@ describe('DrillDownDrawer', () => {
     expect(document.activeElement).not.toBe(closeBtn)
   })
 })
+
+describe('Registry-driven group rendering (PR1)', () => {
+  it('renders Outcome group when run has request_validation data', () => {
+    const outcomeRun: SolverRun = {
+      ...run,
+      stats: {
+        ...(run.stats ?? {}),
+        request_validation: {
+          mp_requests_satisfied: 80,
+          mp_requests_total: 100,
+        },
+      },
+    }
+    render(<DrillDownDrawer run={outcomeRun} onClose={vi.fn()} />)
+    expect(screen.getByText('Outcome')).toBeInTheDocument()
+    expect(screen.getByText('Optimized (MP req)')).toBeInTheDocument()
+  })
+
+  it('renders Solution strategy row when solution_info is set', () => {
+    const stallingRun: SolverRun = {
+      ...run,
+      stats: {
+        ...(run.stats ?? {}),
+        solution_info: 'rnd_var_lns (d=8.93e-01 s=1183 t=0.10 p=0.54 stall=30 h=stalling)',
+      },
+    }
+    render(<DrillDownDrawer run={stallingRun} onClose={vi.fn()} />)
+    expect(screen.getByText('Solution strategy')).toBeInTheDocument()
+    expect(screen.getByText(/rnd_var_lns/)).toBeInTheDocument()
+  })
+
+  it('does NOT render Solution strategy when solution_info is missing', () => {
+    const { solution_info: _omit, ...statsNoSolutionInfo } = run.stats ?? {}
+    void _omit
+    const noInfoRun: SolverRun = { ...run, stats: statsNoSolutionInfo }
+    render(<DrillDownDrawer run={noInfoRun} onClose={vi.fn()} />)
+    expect(screen.queryByText('Solution strategy')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.tsx
@@ -3,9 +3,31 @@ import { useEffect, useId, useRef } from 'react'
 
 import { REPO_URL } from '../../../constants/repo'
 
-import { formatMetric } from './metricRegistry'
+import { formatMetric, METRIC_REGISTRY_BY_GROUP, type MetricGroup } from './metricRegistry'
+import { pickStat } from './pickStat'
 
 import type { SolverRun } from '../../../hooks/useSolverRuns'
+
+const GROUP_LABELS: Record<MetricGroup, string> = {
+  outcome: 'Outcome',
+  size: 'Size',
+  timing: 'Timing',
+  quality: 'Quality',
+  churn: 'Churn',
+  search: 'Search',
+  model: 'Model',
+  context: 'Context',
+}
+
+const GROUP_ORDER: MetricGroup[] = [
+  'outcome',
+  'size',
+  'timing',
+  'quality',
+  'churn',
+  'search',
+  'model',
+]
 
 interface Props {
   run: SolverRun | null
@@ -98,46 +120,35 @@ export function DrillDownDrawer({ run, onClose }: Props) {
           </div>
 
           <div className="grid grid-cols-2 gap-4">
-            <StatCard
-              title="Timing"
-              rows={[
-                ['Wall time', formatMetric('walltime_seconds', s.walltime_seconds)],
-                ['User time', formatMetric('user_time_seconds', s.user_time_seconds)],
-                ['Det. work', formatMetric('deterministic_time', s.deterministic_time)],
-              ]}
-            />
-            <StatCard
-              title="Quality"
-              rows={[
-                [
-                  'Objective',
-                  s.objective_value !== undefined && s.objective_value !== null
-                    ? s.objective_value.toLocaleString()
-                    : '—',
-                ],
-                ['Best bound', formatMetric('best_objective_bound', s.best_objective_bound)],
-                ['Gap', formatMetric('optimality_gap', s.optimality_gap)],
-                ['∫gap', formatMetric('gap_integral', s.gap_integral)],
-              ]}
-            />
-            <StatCard
-              title="Search"
-              rows={[
-                ['Branches', formatMetric('num_branches', s.num_branches)],
-                ['Conflicts', formatMetric('num_conflicts', s.num_conflicts)],
-                ['Solutions found', formatMetric('num_solutions_found', s.num_solutions_found)],
-              ]}
-            />
-            <StatCard
-              title="Model"
-              rows={[
-                ['Variables', formatMetric('model_num_variables', s.model_num_variables)],
-                ['Constraints', formatMetric('model_num_constraints', s.model_num_constraints)],
-                ['Booleans', formatMetric('num_booleans', s.num_booleans)],
-                ['Integers', formatMetric('num_integer_variables', s.num_integer_variables)],
-              ]}
-            />
+            {GROUP_ORDER.map((group) => {
+              const metas = METRIC_REGISTRY_BY_GROUP[group]
+              if (metas.length === 0) return null
+              return (
+                <StatCard
+                  key={group}
+                  title={GROUP_LABELS[group]}
+                  rows={metas.map((meta) => [
+                    meta.label,
+                    formatMetric(meta.key, pickStat(s, meta.key)),
+                  ])}
+                />
+              )
+            })}
           </div>
+
+          {s.solution_info ? (
+            <div className="mt-4">
+              <div className="mb-2 text-xs tracking-wide text-gray-500 uppercase">
+                Solution strategy
+              </div>
+              <div
+                className="rounded bg-gray-50 px-3 py-2 font-mono text-xs text-gray-700"
+                title={s.solution_info}
+              >
+                {s.solution_info}
+              </div>
+            </div>
+          ) : null}
 
           {s.constraint_type_breakdown ? (
             <div>
@@ -151,17 +162,6 @@ export function DrillDownDrawer({ run, onClose }: Props) {
                   </span>
                 ))}
               </div>
-            </div>
-          ) : null}
-
-          {s.solution_info ? (
-            <div>
-              <div className="mb-2 text-xs tracking-wide text-gray-500 uppercase">
-                Solution info
-              </div>
-              <code className="block rounded bg-gray-50 px-3 py-2 text-xs text-gray-700">
-                {s.solution_info}
-              </code>
             </div>
           ) : null}
 

--- a/frontend/src/pages/summer/SolverDebugPage/PinnedComparisonPanel.test.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/PinnedComparisonPanel.test.tsx
@@ -1,10 +1,10 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { getMetric } from './metricRegistry'
 import { PinnedComparisonPanel } from './PinnedComparisonPanel'
 
-import type { SolverRun, SolverRunStats } from '../../../hooks/useSolverRuns'
+import type { SolverRun } from '../../../hooks/useSolverRuns'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const makeRun = (statsOverride: Record<string, any> = {}, id = 'a'): SolverRun => ({
@@ -12,7 +12,7 @@ const makeRun = (statsOverride: Record<string, any> = {}, id = 'a'): SolverRun =
   run_id: id,
   status: 'success',
   created: '2026-05-07T16:42:00Z',
-  stats: statsOverride as unknown as SolverRun['stats'] & SolverRunStats,
+  stats: statsOverride,
   details: { git_sha: id === 'a' ? '4a2b1f3' : '8c9d2e7', source_label: 'S2 · Production' },
 })
 
@@ -102,8 +102,8 @@ describe('PinnedComparisonPanel', () => {
     // runA has num_branches=8421, runB is missing it. Branches row should
     // appear; runB cell should show — ; delta cell should show — (not 0,
     // not NaN, not a bogus number).
-    const aWith: SolverRun = { ...a, stats: { walltime_seconds: 45.2, num_branches: 8421 } }
-    const bWithout: SolverRun = { ...b, stats: { walltime_seconds: 23.1 } }
+    const aWith = { ...a, stats: { walltime_seconds: 45.2, num_branches: 8421 } }
+    const bWithout = { ...b, stats: { walltime_seconds: 23.1 } }
     render(<PinnedComparisonPanel runA={aWith} runB={bWithout} onClear={vi.fn()} />)
     const branchesRow = screen.getByText('Branches').closest('tr')
     expect(branchesRow).not.toBeNull()
@@ -138,20 +138,24 @@ describe('PinnedComparisonPanel', () => {
     expect(linearCell.className).toContain('pl-10')
   })
 
-  it('highlights cleanup-signal rows with yellow background (#mockup-parity)', () => {
-    const statsWithBreakdown = {
+  it('highlights cleanup-signal rows with yellow background only when values differ (#mockup-parity)', () => {
+    const aStats = {
       walltime_seconds: 10,
       constraint_type_breakdown: { bool_or: 5, linear: 20, bool_and: 3, lin_max: 2 },
     }
-    const aFull = makeRun(statsWithBreakdown, 'a')
-    const bFull = makeRun(statsWithBreakdown, 'b')
+    const bStats = {
+      walltime_seconds: 8,
+      constraint_type_breakdown: { bool_or: 7, linear: 20, bool_and: 3, lin_max: 2 },
+    }
+    const aFull = makeRun(aStats, 'a')
+    const bFull = makeRun(bStats, 'b')
     render(<PinnedComparisonPanel runA={aFull} runB={bFull} onClear={vi.fn()} />)
-    // bool_or row should have yellow bg (highlight=true)
+    // bool_or row should have yellow bg (on-delta, values differ: 5 vs 7)
     const boolOrRow = screen.getByText(/bool_or constraints/i).closest('tr')!
     expect(boolOrRow.className).toContain('bg-yellow-50')
-    // lin_max row also highlighted
+    // lin_max values match (2 vs 2), so NOT highlighted
     const linMaxRow = screen.getByText(/lin_max constraints/i).closest('tr')!
-    expect(linMaxRow.className).toContain('bg-yellow-50')
+    expect(linMaxRow.className).not.toContain('bg-yellow-50')
     // linear row is NOT highlighted
     const linearRow = screen.getByText(/linear constraints/i).closest('tr')!
     expect(linearRow.className).not.toContain('bg-yellow-50')
@@ -190,5 +194,111 @@ describe('PinnedComparisonPanel', () => {
     expect(boolOrRow.textContent).toContain('5')
     expect(boolOrRow.textContent).toContain('3')
     expect(boolOrRow.textContent).toMatch(/-2\s*↓/)
+  })
+})
+
+describe('Conditional highlighting (PR1)', () => {
+  function makeRun(overrides: Partial<SolverRun> = {}): SolverRun {
+    const base: SolverRun = {
+      id: 'r1',
+      run_id: 'run_1',
+      status: 'success',
+      created: '2026-05-12T00:00:00Z',
+      details: {
+        git_sha: 'abc1234',
+        config_snapshot: { 'solver.time_limit.seconds': '60' },
+      },
+      stats: {
+        walltime_seconds: 60,
+        objective_value: 100000,
+        constraint_type_breakdown: { bool_or: 5 },
+        request_validation: {
+          impossible_requests: 4,
+          affected_campers: 4,
+          unsatisfied_no_possible: 4,
+        },
+      },
+    }
+    return { ...base, ...overrides }
+  }
+
+  it('highlights num_bool_or when pinned runs differ', () => {
+    const runA = makeRun({
+      stats: { constraint_type_breakdown: { bool_or: 5 } },
+    })
+    const runB = makeRun({
+      stats: { constraint_type_breakdown: { bool_or: 7 } },
+    })
+    const { container } = render(
+      <PinnedComparisonPanel runA={runA} runB={runB} onClear={() => {}} />
+    )
+    const row = within(container).getByText('bool_or constraints').closest('tr')
+    expect(row).toHaveClass('bg-yellow-50')
+  })
+
+  it('does NOT highlight num_bool_or when pinned runs match', () => {
+    const runA = makeRun({
+      stats: { constraint_type_breakdown: { bool_or: 5 } },
+    })
+    const runB = makeRun({
+      stats: { constraint_type_breakdown: { bool_or: 5 } },
+    })
+    const { container } = render(
+      <PinnedComparisonPanel runA={runA} runB={runB} onClear={() => {}} />
+    )
+    const row = within(container).getByText('bool_or constraints').closest('tr')
+    expect(row).not.toHaveClass('bg-yellow-50')
+  })
+
+  it('highlights unsatisfied_no_possible when it diverges from affected_campers', () => {
+    const runA = makeRun({
+      stats: {
+        request_validation: {
+          impossible_requests: 4,
+          affected_campers: 4,
+          unsatisfied_no_possible: 2,
+        },
+      },
+    })
+    const runB = makeRun()
+    const { container } = render(
+      <PinnedComparisonPanel runA={runA} runB={runB} onClear={() => {}} />
+    )
+    const row = within(container).getByText('No-possible').closest('tr')
+    expect(row).toHaveClass('bg-yellow-50')
+  })
+
+  it('shows objective_value as higher-better when config_snapshots match', () => {
+    const runA = makeRun({
+      stats: { objective_value: 100000 },
+      details: { config_snapshot: { 'solver.time_limit.seconds': '60' } },
+    })
+    const runB = makeRun({
+      stats: { objective_value: 120000 },
+      details: { config_snapshot: { 'solver.time_limit.seconds': '60' } },
+    })
+    const { container } = render(
+      <PinnedComparisonPanel runA={runA} runB={runB} onClear={() => {}} />
+    )
+    const row = within(container).getByText('Objective').closest('tr')
+    const deltaCell = row?.querySelector('td:last-child')
+    expect(deltaCell).toHaveClass('text-green-700')
+  })
+
+  it('shows objective_value as context (gray) when config_snapshots differ', () => {
+    const runA = makeRun({
+      stats: { objective_value: 100000 },
+      details: { config_snapshot: { 'soft.grade_spread.penalty': '3000' } },
+    })
+    const runB = makeRun({
+      stats: { objective_value: 120000 },
+      details: { config_snapshot: { 'soft.grade_spread.penalty': '5000' } },
+    })
+    const { container } = render(
+      <PinnedComparisonPanel runA={runA} runB={runB} onClear={() => {}} />
+    )
+    const row = within(container).getByText('Objective').closest('tr')
+    const deltaCell = row?.querySelector('td:last-child')
+    expect(deltaCell).toHaveClass('text-gray-500')
   })
 })

--- a/frontend/src/pages/summer/SolverDebugPage/PinnedComparisonPanel.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/PinnedComparisonPanel.tsx
@@ -7,8 +7,9 @@ import {
   type MetricGroup,
   type MetricInterpretation,
 } from './metricRegistry'
+import { pickStat } from './pickStat'
 
-import type { SolverRun, SolverRunStats } from '../../../hooks/useSolverRuns'
+import type { SolverRun } from '../../../hooks/useSolverRuns'
 
 interface Props {
   runA: SolverRun | null
@@ -45,44 +46,6 @@ function formatDelta(metricKey: string, delta: number | null): string {
   return `${sign}${delta.toLocaleString('en-US', { maximumFractionDigits: 0 })}${arrow}`
 }
 
-function pickMetric(stats: SolverRunStats | undefined, key: string): number | null | undefined {
-  if (!stats) return undefined
-
-  // Existing: constraint sub-types live under constraint_type_breakdown
-  if (key === 'num_bool_or') return stats.constraint_type_breakdown?.['bool_or'] ?? null
-  if (key === 'num_linear') return stats.constraint_type_breakdown?.['linear'] ?? null
-  if (key === 'num_bool_and') return stats.constraint_type_breakdown?.['bool_and'] ?? null
-  if (key === 'num_lin_max') return stats.constraint_type_breakdown?.['lin_max'] ?? null
-
-  // PR1: derived rates computed at render time, not stored
-  if (key === 'mp_request_rate') {
-    const sat = stats.request_validation?.mp_requests_satisfied
-    const tot = stats.request_validation?.mp_requests_total
-    return tot ? (sat ?? 0) / tot : null
-  }
-  if (key === 'mp_camper_rate') {
-    const sat = stats.request_validation?.mp_campers_satisfied
-    const tot = stats.request_validation?.mp_campers_total
-    return tot ? (sat ?? 0) / tot : null
-  }
-  if (key === 'all_request_rate') {
-    const sat = stats.satisfied_request_count
-    const tot = stats.total_requests
-    return tot ? (sat ?? 0) / tot : null
-  }
-  if (key === 'all_camper_rate') {
-    const sat = stats.request_validation?.all_campers_satisfied
-    const tot = stats.request_validation?.all_campers_total
-    return tot ? (sat ?? 0) / tot : null
-  }
-
-  // PR1: outcome keys nested under request_validation get flattened
-  const rv = stats.request_validation as Record<string, number | null | undefined> | undefined
-  if (rv && key in rv) return rv[key]
-
-  return (stats as unknown as Record<string, number | null | undefined>)[key]
-}
-
 function shouldHighlight(
   meta: ReturnType<typeof getMetric>,
   runA: SolverRun,
@@ -90,13 +53,13 @@ function shouldHighlight(
 ): boolean {
   if (!meta.highlight) return false
   if (meta.highlight.mode === 'on-delta') {
-    return pickMetric(runA.stats, meta.key) !== pickMetric(runB.stats, meta.key)
+    return pickStat(runA.stats, meta.key) !== pickStat(runB.stats, meta.key)
   }
   // diverges-from: remaining union branch
   const fromKey = meta.highlight.from
   return (
-    pickMetric(runA.stats, meta.key) !== pickMetric(runA.stats, fromKey) ||
-    pickMetric(runB.stats, meta.key) !== pickMetric(runB.stats, fromKey)
+    pickStat(runA.stats, meta.key) !== pickStat(runA.stats, fromKey) ||
+    pickStat(runB.stats, meta.key) !== pickStat(runB.stats, fromKey)
   )
 }
 
@@ -209,8 +172,8 @@ export function PinnedComparisonPanel({ runA, runB, onClear }: Props) {
                 </tr>
                 {keys.map((key) => {
                   const meta = getMetric(key)
-                  const va = pickMetric(runA.stats, key)
-                  const vb = pickMetric(runB.stats, key)
+                  const va = pickStat(runA.stats, key)
+                  const vb = pickStat(runB.stats, key)
                   const delta = va != null && vb != null ? vb - va : null
                   const isChild = meta.parent != null
                   const rowBg = shouldHighlight(meta, runA, runB) ? 'bg-yellow-50' : ''

--- a/frontend/src/pages/summer/SolverDebugPage/PinnedComparisonPanel.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/PinnedComparisonPanel.tsx
@@ -1,6 +1,12 @@
 import React from 'react'
 
-import { COMPARABLE_METRICS, formatMetric, getMetric, type MetricGroup } from './metricRegistry'
+import {
+  COMPARABLE_METRICS,
+  formatMetric,
+  getMetric,
+  type MetricGroup,
+  type MetricInterpretation,
+} from './metricRegistry'
 
 import type { SolverRun, SolverRunStats } from '../../../hooks/useSolverRuns'
 
@@ -10,14 +16,20 @@ interface Props {
   onClear: () => void
 }
 
-function deltaClass(metricKey: string, delta: number | null): string {
+function deltaClass(
+  metricKey: string,
+  delta: number | null,
+  runA: SolverRun,
+  runB: SolverRun
+): string {
   if (delta === null) return 'text-gray-400'
   const meta = getMetric(metricKey)
   if (delta === 0) return 'text-gray-500'
-  if (meta.interpretation === 'context') return 'text-gray-500 font-semibold'
+  const interpretation = effectiveInterpretation(meta, runA, runB)
+  if (interpretation === 'context') return 'text-gray-500 font-semibold'
   const better =
-    (meta.interpretation === 'lower-better' && delta < 0) ||
-    (meta.interpretation === 'higher-better' && delta > 0)
+    (interpretation === 'lower-better' && delta < 0) ||
+    (interpretation === 'higher-better' && delta > 0)
   return better ? 'text-green-700 font-semibold' : 'text-red-700 font-semibold'
 }
 
@@ -35,22 +47,100 @@ function formatDelta(metricKey: string, delta: number | null): string {
 
 function pickMetric(stats: SolverRunStats | undefined, key: string): number | null | undefined {
   if (!stats) return undefined
+
+  // Existing: constraint sub-types live under constraint_type_breakdown
   if (key === 'num_bool_or') return stats.constraint_type_breakdown?.['bool_or'] ?? null
   if (key === 'num_linear') return stats.constraint_type_breakdown?.['linear'] ?? null
   if (key === 'num_bool_and') return stats.constraint_type_breakdown?.['bool_and'] ?? null
   if (key === 'num_lin_max') return stats.constraint_type_breakdown?.['lin_max'] ?? null
+
+  // PR1: derived rates computed at render time, not stored
+  if (key === 'mp_request_rate') {
+    const sat = stats.request_validation?.mp_requests_satisfied
+    const tot = stats.request_validation?.mp_requests_total
+    return tot ? (sat ?? 0) / tot : null
+  }
+  if (key === 'mp_camper_rate') {
+    const sat = stats.request_validation?.mp_campers_satisfied
+    const tot = stats.request_validation?.mp_campers_total
+    return tot ? (sat ?? 0) / tot : null
+  }
+  if (key === 'all_request_rate') {
+    const sat = stats.satisfied_request_count
+    const tot = stats.total_requests
+    return tot ? (sat ?? 0) / tot : null
+  }
+  if (key === 'all_camper_rate') {
+    const sat = stats.request_validation?.all_campers_satisfied
+    const tot = stats.request_validation?.all_campers_total
+    return tot ? (sat ?? 0) / tot : null
+  }
+
+  // PR1: outcome keys nested under request_validation get flattened
+  const rv = stats.request_validation as Record<string, number | null | undefined> | undefined
+  if (rv && key in rv) return rv[key]
+
   return (stats as unknown as Record<string, number | null | undefined>)[key]
 }
 
+function shouldHighlight(
+  meta: ReturnType<typeof getMetric>,
+  runA: SolverRun,
+  runB: SolverRun
+): boolean {
+  if (!meta.highlight) return false
+  if (meta.highlight.mode === 'on-delta') {
+    return pickMetric(runA.stats, meta.key) !== pickMetric(runB.stats, meta.key)
+  }
+  // diverges-from: remaining union branch
+  const fromKey = meta.highlight.from
+  return (
+    pickMetric(runA.stats, meta.key) !== pickMetric(runA.stats, fromKey) ||
+    pickMetric(runB.stats, meta.key) !== pickMetric(runB.stats, fromKey)
+  )
+}
+
+function configSnapshotsMatch(runA: SolverRun, runB: SolverRun): boolean {
+  const a = runA.details?.config_snapshot
+  const b = runB.details?.config_snapshot
+  if (!a || !b) return false
+  const keysA = Object.keys(a)
+  const keysB = Object.keys(b)
+  if (keysA.length !== keysB.length) return false
+  return keysA.every((k) => a[k] === b[k])
+}
+
+function effectiveInterpretation(
+  meta: ReturnType<typeof getMetric>,
+  runA: SolverRun,
+  runB: SolverRun
+): MetricInterpretation {
+  if (meta.key === 'objective_value' && configSnapshotsMatch(runA, runB)) {
+    return 'higher-better'
+  }
+  return meta.interpretation
+}
+
 const GROUP_LABELS: Record<MetricGroup, string> = {
+  outcome: 'Outcome',
+  size: 'Size',
   timing: 'Timing',
   quality: 'Quality',
+  churn: 'Churn',
   search: 'Search',
   model: 'Model',
   context: 'Context',
 }
 
-const GROUP_ORDER: MetricGroup[] = ['timing', 'quality', 'search', 'model']
+const GROUP_ORDER: MetricGroup[] = [
+  'outcome',
+  'size',
+  'timing',
+  'quality',
+  'churn',
+  'search',
+  'model',
+]
 
 export function PinnedComparisonPanel({ runA, runB, onClear }: Props) {
   if (!runA || !runB) return null
@@ -61,8 +151,11 @@ export function PinnedComparisonPanel({ runA, runB, onClear }: Props) {
 
   // Group metrics by their `group` field, preserving COMPARABLE_METRICS order within each group
   const byGroup: Record<MetricGroup, string[]> = {
+    outcome: [],
+    size: [],
     timing: [],
     quality: [],
+    churn: [],
     search: [],
     model: [],
     context: [],
@@ -120,7 +213,7 @@ export function PinnedComparisonPanel({ runA, runB, onClear }: Props) {
                   const vb = pickMetric(runB.stats, key)
                   const delta = va != null && vb != null ? vb - va : null
                   const isChild = meta.parent != null
-                  const rowBg = meta.highlight ? 'bg-yellow-50' : ''
+                  const rowBg = shouldHighlight(meta, runA, runB) ? 'bg-yellow-50' : ''
                   return (
                     <tr key={key} className={`hover:bg-forest-50/30 ${rowBg}`}>
                       <td
@@ -135,7 +228,7 @@ export function PinnedComparisonPanel({ runA, runB, onClear }: Props) {
                       <td className="px-3 py-2 text-right text-gray-600">
                         {formatMetric(key, vb)}
                       </td>
-                      <td className={`px-5 py-2 text-right ${deltaClass(key, delta)}`}>
+                      <td className={`px-5 py-2 text-right ${deltaClass(key, delta, runA, runB)}`}>
                         {formatDelta(key, delta)}
                       </td>
                     </tr>

--- a/frontend/src/pages/summer/SolverDebugPage/SolverRunsTable.test.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/SolverRunsTable.test.tsx
@@ -255,7 +255,7 @@ describe('SolverRunsTable', () => {
     )
     // Budget cell should be exactly "—" (not "—s")
     expect(screen.queryByText(/^—s$/)).not.toBeInTheDocument()
-    expect(screen.getByText('—')).toBeInTheDocument()
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0)
   })
 })
 
@@ -316,6 +316,55 @@ describe('SolverRunsTable footer (#1254)', () => {
     expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument()
     // Legend still shown
     expect(screen.getByText(/Showing 0 of 5 runs/i)).toBeInTheDocument()
+  })
+})
+
+describe('MP rate cells (PR1)', () => {
+  it('renders Optimized cell with MP request rate', () => {
+    const run: SolverRun = {
+      id: 'r1',
+      run_id: 'run_1',
+      status: 'success',
+      created: '2026-05-12T00:00:00Z',
+      stats: {
+        request_validation: {
+          mp_requests_satisfied: 80,
+          mp_requests_total: 100,
+        },
+      },
+    } as SolverRun
+    render(
+      <SolverRunsTable
+        runs={[run]}
+        visibleColumns={['mp_request_rate']}
+        pinnedRunIds={[]}
+        onTogglePin={vi.fn()}
+        onRowClick={vi.fn()}
+      />
+    )
+    expect(screen.getByText('80.00%')).toBeInTheDocument()
+  })
+
+  it('renders em-dash for MP rate when total is 0', () => {
+    const run: SolverRun = {
+      id: 'r1',
+      run_id: 'run_1',
+      status: 'success',
+      created: '2026-05-12T00:00:00Z',
+      stats: {
+        request_validation: { mp_requests_satisfied: 0, mp_requests_total: 0 },
+      },
+    } as SolverRun
+    render(
+      <SolverRunsTable
+        runs={[run]}
+        visibleColumns={['mp_request_rate']}
+        pinnedRunIds={[]}
+        onTogglePin={vi.fn()}
+        onRowClick={vi.fn()}
+      />
+    )
+    expect(screen.getByText('—')).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/pages/summer/SolverDebugPage/SolverRunsTable.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/SolverRunsTable.tsx
@@ -4,6 +4,7 @@ import { Fragment } from 'react'
 import { REPO_URL } from '../../../constants/repo'
 
 import { formatMetric, getMetric } from './metricRegistry'
+import { pickStat } from './pickStat'
 
 import type { SolverRun } from '../../../hooks/useSolverRuns'
 
@@ -177,6 +178,118 @@ export function SolverRunsTable({
                 bool_or
               </th>
             )}
+            {showCol('mp_request_rate') && (
+              <th
+                className="px-3 py-2.5 text-right font-medium"
+                title={getMetric('mp_request_rate').description}
+              >
+                Optimized
+              </th>
+            )}
+            {showCol('mp_camper_rate') && (
+              <th
+                className="px-3 py-2.5 text-right font-medium"
+                title={getMetric('mp_camper_rate').description}
+              >
+                Acceptable
+              </th>
+            )}
+            {showCol('all_request_rate') && (
+              <th
+                className="px-3 py-2.5 text-right font-medium"
+                title={getMetric('all_request_rate').description}
+              >
+                Request rate
+              </th>
+            )}
+            {showCol('all_camper_rate') && (
+              <th
+                className="px-3 py-2.5 text-right font-medium"
+                title={getMetric('all_camper_rate').description}
+              >
+                Camper rate
+              </th>
+            )}
+            {showCol('satisfied_request_count') && (
+              <th
+                className="px-3 py-2.5 text-right font-medium"
+                title={getMetric('satisfied_request_count').description}
+              >
+                Req met
+              </th>
+            )}
+            {showCol('total_requests') && (
+              <th
+                className="px-3 py-2.5 text-right font-medium"
+                title={getMetric('total_requests').description}
+              >
+                Req total
+              </th>
+            )}
+            {showCol('impossible_requests') && (
+              <th
+                className="px-3 py-2.5 text-right font-medium"
+                title={getMetric('impossible_requests').description}
+              >
+                Impossible
+              </th>
+            )}
+            {showCol('affected_campers') && (
+              <th
+                className="px-3 py-2.5 text-right font-medium"
+                title={getMetric('affected_campers').description}
+              >
+                Affected
+              </th>
+            )}
+            {showCol('total_persons') && (
+              <th
+                className="px-3 py-2.5 text-right font-medium"
+                title={getMetric('total_persons').description}
+              >
+                Persons
+              </th>
+            )}
+            {showCol('total_bunks') && (
+              <th
+                className="px-3 py-2.5 text-right font-medium"
+                title={getMetric('total_bunks').description}
+              >
+                Bunks
+              </th>
+            )}
+            {showCol('num_workers') && (
+              <th
+                className="px-3 py-2.5 text-right font-medium"
+                title={getMetric('num_workers').description}
+              >
+                Workers
+              </th>
+            )}
+            {showCol('assignments_changed') && (
+              <th
+                className="px-3 py-2.5 text-right font-medium"
+                title={getMetric('assignments_changed').description}
+              >
+                Δ assignments
+              </th>
+            )}
+            {showCol('new_assignments') && (
+              <th
+                className="px-3 py-2.5 text-right font-medium"
+                title={getMetric('new_assignments').description}
+              >
+                New
+              </th>
+            )}
+            {showCol('objective_value') && (
+              <th
+                className="px-3 py-2.5 text-right font-medium"
+                title={getMetric('objective_value').description}
+              >
+                Objective
+              </th>
+            )}
             {showCol('sha') && <th className="px-3 py-2.5 text-left font-medium">SHA</th>}
             {showCol('sweep') && <th className="px-3 py-2.5 text-left font-medium">Sweep</th>}
           </tr>
@@ -314,6 +427,127 @@ export function SolverRunsTable({
                         'num_bool_or',
                         run.stats?.constraint_type_breakdown?.['bool_or'] ?? null
                       )}
+                    </td>
+                  )}
+                  {showCol('mp_request_rate') && (
+                    <td
+                      className="px-3 py-2 text-right"
+                      title={getMetric('mp_request_rate').description}
+                    >
+                      {formatMetric('mp_request_rate', pickStat(run.stats, 'mp_request_rate'))}
+                    </td>
+                  )}
+                  {showCol('mp_camper_rate') && (
+                    <td
+                      className="px-3 py-2 text-right"
+                      title={getMetric('mp_camper_rate').description}
+                    >
+                      {formatMetric('mp_camper_rate', pickStat(run.stats, 'mp_camper_rate'))}
+                    </td>
+                  )}
+                  {showCol('all_request_rate') && (
+                    <td
+                      className="px-3 py-2 text-right"
+                      title={getMetric('all_request_rate').description}
+                    >
+                      {formatMetric('all_request_rate', pickStat(run.stats, 'all_request_rate'))}
+                    </td>
+                  )}
+                  {showCol('all_camper_rate') && (
+                    <td
+                      className="px-3 py-2 text-right"
+                      title={getMetric('all_camper_rate').description}
+                    >
+                      {formatMetric('all_camper_rate', pickStat(run.stats, 'all_camper_rate'))}
+                    </td>
+                  )}
+                  {showCol('satisfied_request_count') && (
+                    <td
+                      className="px-3 py-2 text-right"
+                      title={getMetric('satisfied_request_count').description}
+                    >
+                      {formatMetric(
+                        'satisfied_request_count',
+                        pickStat(run.stats, 'satisfied_request_count')
+                      )}
+                    </td>
+                  )}
+                  {showCol('total_requests') && (
+                    <td
+                      className="px-3 py-2 text-right"
+                      title={getMetric('total_requests').description}
+                    >
+                      {formatMetric('total_requests', pickStat(run.stats, 'total_requests'))}
+                    </td>
+                  )}
+                  {showCol('impossible_requests') && (
+                    <td
+                      className="px-3 py-2 text-right"
+                      title={getMetric('impossible_requests').description}
+                    >
+                      {formatMetric(
+                        'impossible_requests',
+                        pickStat(run.stats, 'impossible_requests')
+                      )}
+                    </td>
+                  )}
+                  {showCol('affected_campers') && (
+                    <td
+                      className="px-3 py-2 text-right"
+                      title={getMetric('affected_campers').description}
+                    >
+                      {formatMetric('affected_campers', pickStat(run.stats, 'affected_campers'))}
+                    </td>
+                  )}
+                  {showCol('total_persons') && (
+                    <td
+                      className="px-3 py-2 text-right"
+                      title={getMetric('total_persons').description}
+                    >
+                      {formatMetric('total_persons', pickStat(run.stats, 'total_persons'))}
+                    </td>
+                  )}
+                  {showCol('total_bunks') && (
+                    <td
+                      className="px-3 py-2 text-right"
+                      title={getMetric('total_bunks').description}
+                    >
+                      {formatMetric('total_bunks', pickStat(run.stats, 'total_bunks'))}
+                    </td>
+                  )}
+                  {showCol('num_workers') && (
+                    <td
+                      className="px-3 py-2 text-right"
+                      title={getMetric('num_workers').description}
+                    >
+                      {formatMetric('num_workers', pickStat(run.stats, 'num_workers'))}
+                    </td>
+                  )}
+                  {showCol('assignments_changed') && (
+                    <td
+                      className="px-3 py-2 text-right"
+                      title={getMetric('assignments_changed').description}
+                    >
+                      {formatMetric(
+                        'assignments_changed',
+                        pickStat(run.stats, 'assignments_changed')
+                      )}
+                    </td>
+                  )}
+                  {showCol('new_assignments') && (
+                    <td
+                      className="px-3 py-2 text-right"
+                      title={getMetric('new_assignments').description}
+                    >
+                      {formatMetric('new_assignments', pickStat(run.stats, 'new_assignments'))}
+                    </td>
+                  )}
+                  {showCol('objective_value') && (
+                    <td
+                      className="px-3 py-2 text-right"
+                      title={getMetric('objective_value').description}
+                    >
+                      {formatMetric('objective_value', pickStat(run.stats, 'objective_value'))}
                     </td>
                   )}
                   {showCol('sha') && (

--- a/frontend/src/pages/summer/SolverDebugPage/metricRegistry.test.ts
+++ b/frontend/src/pages/summer/SolverDebugPage/metricRegistry.test.ts
@@ -10,13 +10,23 @@ describe('METRIC_REGISTRY', () => {
       expect(m.description).toBeTruthy()
       expect(['lower-better', 'higher-better', 'context']).toContain(m.interpretation)
       expect(['integer', 'decimal', 'percent', 'duration']).toContain(m.format)
-      expect(['timing', 'quality', 'search', 'model', 'context']).toContain(m.group)
+      expect([
+        'timing',
+        'quality',
+        'search',
+        'model',
+        'context',
+        'outcome',
+        'size',
+        'churn',
+      ]).toContain(m.group)
     })
   })
 
   it('keys are stable (snapshot test for accidental rename detection)', () => {
     expect(Object.keys(METRIC_REGISTRY).sort()).toEqual(
       [
+        // existing 17
         'walltime_seconds',
         'user_time_seconds',
         'deterministic_time',
@@ -34,6 +44,31 @@ describe('METRIC_REGISTRY', () => {
         'num_linear',
         'num_bool_and',
         'num_lin_max',
+        // new PR1 keys
+        'mp_request_rate',
+        'mp_camper_rate',
+        'all_request_rate',
+        'all_camper_rate',
+        'mp_requests_satisfied',
+        'mp_requests_total',
+        'mp_campers_satisfied',
+        'mp_campers_total',
+        'all_campers_satisfied',
+        'all_campers_total',
+        'satisfied_request_count',
+        'total_requests',
+        'impossible_requests',
+        'affected_campers',
+        'unsatisfied_no_possible',
+        'unsatisfied_material_parent_unmet',
+        'unsatisfied_other_unmet',
+        'total_persons',
+        'total_bunks',
+        'num_workers',
+        'time_budget_seconds',
+        'assignments_changed',
+        'new_assignments',
+        'objective_value',
       ].sort()
     )
   })
@@ -94,11 +129,11 @@ describe('constraint-type metrics (mockup parity)', () => {
 
     const lin_max = getMetric('num_lin_max')
     expect(lin_max.parent).toBe('model_num_constraints')
-    expect(lin_max.highlight).toBe(true)
+    expect(lin_max.highlight).toEqual({ mode: 'on-delta' })
 
     const bool_or = getMetric('num_bool_or')
     expect(bool_or.parent).toBe('model_num_constraints')
-    expect(bool_or.highlight).toBe(true)
+    expect(bool_or.highlight).toEqual({ mode: 'on-delta' })
   })
 
   it('COMPARABLE_METRICS surfaces all four constraint-type metrics', () => {
@@ -113,5 +148,39 @@ describe('constraint-type metrics (mockup parity)', () => {
     expect(COMPARABLE_METRICS).toContain('best_objective_bound')
     expect(COMPARABLE_METRICS).toContain('num_booleans')
     expect(COMPARABLE_METRICS).toContain('num_integer_variables')
+  })
+})
+
+describe('HighlightRule discriminated union (PR1)', () => {
+  it('num_bool_or has on-delta highlight after PR1 migration', () => {
+    const meta = getMetric('num_bool_or')
+    expect(meta.highlight).toEqual({ mode: 'on-delta' })
+  })
+
+  it('num_lin_max has on-delta highlight after PR1 migration', () => {
+    const meta = getMetric('num_lin_max')
+    expect(meta.highlight).toEqual({ mode: 'on-delta' })
+  })
+
+  it('unsatisfied_no_possible diverges from affected_campers', () => {
+    const meta = getMetric('unsatisfied_no_possible')
+    expect(meta.highlight).toEqual({
+      mode: 'diverges-from',
+      from: 'affected_campers',
+    })
+  })
+})
+
+describe('MetricGroup type accepts outcome/size/churn', () => {
+  it('mp_request_rate is in outcome group', () => {
+    expect(getMetric('mp_request_rate').group).toBe('outcome')
+  })
+
+  it('total_persons is in size group', () => {
+    expect(getMetric('total_persons').group).toBe('size')
+  })
+
+  it('assignments_changed is in churn group', () => {
+    expect(getMetric('assignments_changed').group).toBe('churn')
   })
 })

--- a/frontend/src/pages/summer/SolverDebugPage/metricRegistry.ts
+++ b/frontend/src/pages/summer/SolverDebugPage/metricRegistry.ts
@@ -380,6 +380,24 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
   },
 }
 
+/** Group metrics by their `group` field, preserving insertion order from METRIC_REGISTRY. */
+export const METRIC_REGISTRY_BY_GROUP: Record<MetricGroup, MetricMeta[]> = (() => {
+  const groups: Record<MetricGroup, MetricMeta[]> = {
+    outcome: [],
+    size: [],
+    timing: [],
+    quality: [],
+    churn: [],
+    search: [],
+    model: [],
+    context: [],
+  }
+  for (const meta of Object.values(METRIC_REGISTRY)) {
+    groups[meta.group].push(meta)
+  }
+  return groups
+})()
+
 /** Subset rendered in pin-to-compare delta panel (numeric, comparable). */
 export const COMPARABLE_METRICS: readonly string[] = [
   // outcome (PR1)

--- a/frontend/src/pages/summer/SolverDebugPage/metricRegistry.ts
+++ b/frontend/src/pages/summer/SolverDebugPage/metricRegistry.ts
@@ -1,6 +1,16 @@
 export type MetricInterpretation = 'lower-better' | 'higher-better' | 'context'
 export type MetricFormat = 'integer' | 'decimal' | 'percent' | 'duration'
-export type MetricGroup = 'timing' | 'quality' | 'search' | 'model' | 'context'
+export type MetricGroup =
+  | 'timing'
+  | 'quality'
+  | 'search'
+  | 'model'
+  | 'context'
+  | 'outcome'
+  | 'size'
+  | 'churn'
+
+export type HighlightRule = { mode: 'on-delta' } | { mode: 'diverges-from'; from: string }
 
 export interface MetricMeta {
   key: string
@@ -10,7 +20,7 @@ export interface MetricMeta {
   format: MetricFormat
   group: MetricGroup
   parent?: string // sub-rows render indented under this metric key
-  highlight?: boolean // yellow background — cleanup signal
+  highlight?: HighlightRule
 }
 
 export const METRIC_REGISTRY: Record<string, MetricMeta> = {
@@ -127,7 +137,7 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
     format: 'integer',
     group: 'model',
     parent: 'model_num_constraints',
-    highlight: true,
+    highlight: { mode: 'on-delta' },
   },
   num_linear: {
     key: 'num_linear',
@@ -155,21 +165,254 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
     format: 'integer',
     group: 'model',
     parent: 'model_num_constraints',
-    highlight: true,
+    highlight: { mode: 'on-delta' },
+  },
+  mp_request_rate: {
+    key: 'mp_request_rate',
+    label: 'Optimized (MP req)',
+    description:
+      'Material-parent requests honored / MP requests total. 100% is the ideal outcome — every parent priority request satisfied.',
+    interpretation: 'higher-better',
+    format: 'percent',
+    group: 'outcome',
+  },
+  mp_camper_rate: {
+    key: 'mp_camper_rate',
+    label: 'Acceptable (MP camper)',
+    description:
+      'Campers with ≥1 MP request satisfied / Campers with ≥1 MP request. 100% means every camper with a parent priority got at least one MP request honored.',
+    interpretation: 'higher-better',
+    format: 'percent',
+    group: 'outcome',
+  },
+  all_request_rate: {
+    key: 'all_request_rate',
+    label: 'Request rate',
+    description: 'All requests honored / all requests total, across every source bucket.',
+    interpretation: 'higher-better',
+    format: 'percent',
+    group: 'outcome',
+  },
+  all_camper_rate: {
+    key: 'all_camper_rate',
+    label: 'Camper rate',
+    description: 'Campers with ≥1 any-source request satisfied / campers with ≥1 request.',
+    interpretation: 'higher-better',
+    format: 'percent',
+    group: 'outcome',
+  },
+  mp_requests_satisfied: {
+    key: 'mp_requests_satisfied',
+    label: 'MP req met',
+    description: 'Number of material-parent requests the solver honored.',
+    interpretation: 'higher-better',
+    format: 'integer',
+    group: 'outcome',
+    parent: 'mp_request_rate',
+  },
+  mp_requests_total: {
+    key: 'mp_requests_total',
+    label: 'MP req total',
+    description: 'Total resolved material-parent requests in scope this run.',
+    interpretation: 'context',
+    format: 'integer',
+    group: 'outcome',
+    parent: 'mp_request_rate',
+  },
+  mp_campers_satisfied: {
+    key: 'mp_campers_satisfied',
+    label: 'MP campers met',
+    description: 'Campers with ≥1 material-parent request satisfied.',
+    interpretation: 'higher-better',
+    format: 'integer',
+    group: 'outcome',
+    parent: 'mp_camper_rate',
+  },
+  mp_campers_total: {
+    key: 'mp_campers_total',
+    label: 'MP campers total',
+    description: 'Campers with ≥1 resolved material-parent request.',
+    interpretation: 'context',
+    format: 'integer',
+    group: 'outcome',
+    parent: 'mp_camper_rate',
+  },
+  all_campers_satisfied: {
+    key: 'all_campers_satisfied',
+    label: 'Campers met',
+    description: 'Campers with ≥1 request of any source satisfied.',
+    interpretation: 'higher-better',
+    format: 'integer',
+    group: 'outcome',
+    parent: 'all_camper_rate',
+  },
+  all_campers_total: {
+    key: 'all_campers_total',
+    label: 'Campers total',
+    description: 'Campers with ≥1 resolved request of any source.',
+    interpretation: 'context',
+    format: 'integer',
+    group: 'outcome',
+    parent: 'all_camper_rate',
+  },
+  satisfied_request_count: {
+    key: 'satisfied_request_count',
+    label: 'Req met',
+    description: 'Total requests honored across all sources.',
+    interpretation: 'higher-better',
+    format: 'integer',
+    group: 'outcome',
+    parent: 'all_request_rate',
+  },
+  total_requests: {
+    key: 'total_requests',
+    label: 'Req total',
+    description: 'Total resolved requests in scope this run, across all sources.',
+    interpretation: 'context',
+    format: 'integer',
+    group: 'outcome',
+    parent: 'all_request_rate',
+  },
+  impossible_requests: {
+    key: 'impossible_requests',
+    label: 'Impossible',
+    description:
+      'Requests that can never be satisfied (cross-session, requestee absent, etc.). Floor on unsatisfiability.',
+    interpretation: 'context',
+    format: 'integer',
+    group: 'outcome',
+  },
+  affected_campers: {
+    key: 'affected_campers',
+    label: 'Affected campers',
+    description: 'Campers with ≥1 impossible request — blast radius of the impossibility floor.',
+    interpretation: 'context',
+    format: 'integer',
+    group: 'outcome',
+    parent: 'impossible_requests',
+  },
+  unsatisfied_no_possible: {
+    key: 'unsatisfied_no_possible',
+    label: 'No-possible',
+    description:
+      'Campers with only impossible requests. Should equal affected_campers; divergence is a bug signal.',
+    interpretation: 'context',
+    format: 'integer',
+    group: 'outcome',
+    parent: 'impossible_requests',
+    highlight: { mode: 'diverges-from', from: 'affected_campers' },
+  },
+  unsatisfied_material_parent_unmet: {
+    key: 'unsatisfied_material_parent_unmet',
+    label: 'Failed-all w/ MP-possible',
+    description:
+      'Campers who got zero requests satisfied AND had ≥1 possible MP request. The worst-case parent-priority failures.',
+    interpretation: 'lower-better',
+    format: 'integer',
+    group: 'outcome',
+  },
+  unsatisfied_other_unmet: {
+    key: 'unsatisfied_other_unmet',
+    label: 'Failed-all no MP',
+    description:
+      'Campers who got zero requests satisfied AND had only non-MP possible requests (STAFF / IMMATERIAL_PARENT).',
+    interpretation: 'lower-better',
+    format: 'integer',
+    group: 'outcome',
+  },
+  total_persons: {
+    key: 'total_persons',
+    label: 'Persons',
+    description: 'Campers in scope this run.',
+    interpretation: 'context',
+    format: 'integer',
+    group: 'size',
+  },
+  total_bunks: {
+    key: 'total_bunks',
+    label: 'Bunks',
+    description: 'Cabins in scope this run.',
+    interpretation: 'context',
+    format: 'integer',
+    group: 'size',
+  },
+  num_workers: {
+    key: 'num_workers',
+    label: 'Workers',
+    description: 'CP-SAT parallel worker count.',
+    interpretation: 'context',
+    format: 'integer',
+    group: 'size',
+  },
+  time_budget_seconds: {
+    key: 'time_budget_seconds',
+    label: 'Budget',
+    description: 'Time limit configured for this run.',
+    interpretation: 'context',
+    format: 'duration',
+    group: 'size',
+  },
+  assignments_changed: {
+    key: 'assignments_changed',
+    label: 'Assignments changed',
+    description:
+      'Number of campers placed differently than the prior draft. 0 means the solver returned the same answer.',
+    interpretation: 'context',
+    format: 'integer',
+    group: 'churn',
+  },
+  new_assignments: {
+    key: 'new_assignments',
+    label: 'New assignments',
+    description: 'Number of campers receiving a placement this run (existing or new).',
+    interpretation: 'context',
+    format: 'integer',
+    group: 'churn',
+  },
+  objective_value: {
+    key: 'objective_value',
+    label: 'Objective',
+    description:
+      'Raw weighted score from the solver. Higher = better, BUT only when constraint/objective weights match between compared runs. Different weights mechanically inflate or deflate this number — see config_snapshot.',
+    interpretation: 'context',
+    format: 'integer',
+    group: 'quality',
   },
 }
 
 /** Subset rendered in pin-to-compare delta panel (numeric, comparable). */
 export const COMPARABLE_METRICS: readonly string[] = [
+  // outcome (PR1)
+  'mp_request_rate',
+  'mp_camper_rate',
+  'mp_requests_satisfied',
+  'mp_requests_total',
+  'mp_campers_satisfied',
+  'mp_campers_total',
+  'all_request_rate',
+  'all_camper_rate',
+  'satisfied_request_count',
+  'total_requests',
+  'all_campers_satisfied',
+  'all_campers_total',
+  'impossible_requests',
+  'affected_campers',
+  'unsatisfied_no_possible',
+  'unsatisfied_material_parent_unmet',
+  'unsatisfied_other_unmet',
   // timing
   'walltime_seconds',
   'user_time_seconds',
   'deterministic_time',
   // quality
+  'objective_value',
   'optimality_gap',
   'gap_integral',
   'best_objective_bound',
   'num_solutions_found',
+  // churn (PR1)
+  'assignments_changed',
+  'new_assignments',
   // search
   'num_branches',
   'num_conflicts',
@@ -178,11 +421,16 @@ export const COMPARABLE_METRICS: readonly string[] = [
   'num_booleans',
   'num_integer_variables',
   'model_num_constraints',
-  // model > constraint sub-types (rendered indented under model_num_constraints)
+  // model > constraint sub-types
   'num_linear',
   'num_bool_and',
   'num_bool_or',
   'num_lin_max',
+  // size (PR1)
+  'total_persons',
+  'total_bunks',
+  'num_workers',
+  'time_budget_seconds',
 ] as const
 
 export function getMetric(key: string): MetricMeta {

--- a/frontend/src/pages/summer/SolverDebugPage/pickStat.ts
+++ b/frontend/src/pages/summer/SolverDebugPage/pickStat.ts
@@ -1,0 +1,35 @@
+import type { SolverRunStats } from '../../../hooks/useSolverRuns'
+
+export function pickStat(
+  stats: SolverRunStats | undefined,
+  key: string
+): number | null | undefined {
+  if (!stats) return undefined
+  if (key === 'mp_request_rate') {
+    const sat = stats.request_validation?.mp_requests_satisfied
+    const tot = stats.request_validation?.mp_requests_total
+    return tot ? (sat ?? 0) / tot : null
+  }
+  if (key === 'mp_camper_rate') {
+    const sat = stats.request_validation?.mp_campers_satisfied
+    const tot = stats.request_validation?.mp_campers_total
+    return tot ? (sat ?? 0) / tot : null
+  }
+  if (key === 'all_request_rate') {
+    const sat = stats.satisfied_request_count
+    const tot = stats.total_requests
+    return tot ? (sat ?? 0) / tot : null
+  }
+  if (key === 'all_camper_rate') {
+    const sat = stats.request_validation?.all_campers_satisfied
+    const tot = stats.request_validation?.all_campers_total
+    return tot ? (sat ?? 0) / tot : null
+  }
+  if (key === 'num_bool_or') return stats.constraint_type_breakdown?.['bool_or'] ?? null
+  if (key === 'num_linear') return stats.constraint_type_breakdown?.['linear'] ?? null
+  if (key === 'num_bool_and') return stats.constraint_type_breakdown?.['bool_and'] ?? null
+  if (key === 'num_lin_max') return stats.constraint_type_breakdown?.['lin_max'] ?? null
+  const rv = stats.request_validation as Record<string, number | null | undefined> | undefined
+  if (rv && key in rv) return rv[key]
+  return (stats as unknown as Record<string, number | null | undefined>)[key]
+}

--- a/frontend/src/pages/summer/SolverDebugPage/solverColumns.ts
+++ b/frontend/src/pages/summer/SolverDebugPage/solverColumns.ts
@@ -20,6 +20,24 @@ export const ALL_COLUMNS = [
   { key: 'num_booleans', label: 'Booleans', group: 'Model' },
   { key: 'num_integer_variables', label: 'Integers', group: 'Model' },
   { key: 'num_bool_or', label: 'bool_or', group: 'Model' },
+  // PR1: outcome group
+  { key: 'mp_request_rate', label: 'Optimized', group: 'Outcome' },
+  { key: 'mp_camper_rate', label: 'Acceptable', group: 'Outcome' },
+  { key: 'all_request_rate', label: 'Request rate', group: 'Outcome' },
+  { key: 'all_camper_rate', label: 'Camper rate', group: 'Outcome' },
+  { key: 'satisfied_request_count', label: 'Req met', group: 'Outcome' },
+  { key: 'total_requests', label: 'Req total', group: 'Outcome' },
+  { key: 'impossible_requests', label: 'Impossible', group: 'Outcome' },
+  { key: 'affected_campers', label: 'Affected', group: 'Outcome' },
+  // PR1: size group
+  { key: 'total_persons', label: 'Persons', group: 'Size' },
+  { key: 'total_bunks', label: 'Bunks', group: 'Size' },
+  { key: 'num_workers', label: 'Workers', group: 'Size' },
+  // PR1: churn group
+  { key: 'assignments_changed', label: 'Δ assignments', group: 'Churn' },
+  { key: 'new_assignments', label: 'New', group: 'Churn' },
+  // PR1: quality additions
+  { key: 'objective_value', label: 'Objective', group: 'Quality' },
 ] as const
 
 export const DEFAULT_VISIBLE_COLUMNS: string[] = [
@@ -28,6 +46,8 @@ export const DEFAULT_VISIBLE_COLUMNS: string[] = [
   'status',
   'sha',
   'sweep',
+  'mp_request_rate', // PR1: headline outcome
+  'mp_camper_rate', // PR1: headline outcome
   'walltime_seconds',
   'deterministic_time',
   'optimality_gap',

--- a/tests/unit/solver/test_direct_solver_stats.py
+++ b/tests/unit/solver/test_direct_solver_stats.py
@@ -546,6 +546,107 @@ class TestSingleBunkStatsKeyParity:
         assert result.stats.get("constraint_type_breakdown") == {}
 
 
+class TestSingleBunkRequestValidation:
+    """Single-bunk stats must include the `request_validation` payload that
+    the multi-bunk path attaches at the end of `solve()`. Without it, the
+    debug page's MP/all-camper outcome rate columns render blank for every
+    AG / single-bunk session — different rendering from multi-bunk runs
+    even when the underlying signal exists.
+    """
+
+    def _make_input(
+        self,
+        num_persons: int = 3,
+        capacity: int = 12,
+        requests: list[DirectBunkRequest] | None = None,
+    ) -> DirectSolverInput:
+        bunk = DirectBunk(
+            id="bunk-1",
+            campminder_id=9001,
+            name="AG-1",
+            capacity=capacity,
+            gender="Mixed",
+            session_cm_id=500,
+        )
+        persons = [
+            DirectPerson(
+                campminder_person_id=1000 + i,
+                first_name=f"Camper{i}",
+                last_name="Test",
+                grade=8,
+                birthdate="2014-01-01",
+                gender="M" if i % 2 == 0 else "F",
+                session_cm_id=500,
+            )
+            for i in range(num_persons)
+        ]
+        return DirectSolverInput(persons=persons, requests=requests or [], bunks=[bunk])
+
+    def test_single_bunk_stats_includes_request_validation_key(self) -> None:
+        """The `request_validation` key must be present on single-bunk stats.
+
+        Frontend `pickStat` reads `stats.request_validation?.mp_requests_total`
+        etc.; a missing key collapses every bucket-aware outcome column to `—`
+        for AG sessions.
+        """
+        solver = DirectBunkingSolver(input_data=self._make_input(3), config_service=MagicMock())
+        result = solver.solve(time_limit_seconds=10)
+        assert result is not None
+        assert "request_validation" in result.stats, (
+            "single-bunk stats missing 'request_validation' key — debug-page outcome columns will render blank"
+        )
+
+    def test_single_bunk_request_validation_has_bucket_aware_count_keys(self) -> None:
+        """All 6 bucket-aware count keys must be populated on the single-bunk path."""
+        solver = DirectBunkingSolver(input_data=self._make_input(3), config_service=MagicMock())
+        result = solver.solve(time_limit_seconds=10)
+        assert result is not None
+        rv = result.stats.get("request_validation")
+        assert isinstance(rv, dict), f"expected dict request_validation payload, got {type(rv)!r}"
+        for key in (
+            "mp_requests_total",
+            "mp_requests_satisfied",
+            "mp_campers_total",
+            "mp_campers_satisfied",
+            "all_campers_total",
+            "all_campers_satisfied",
+        ):
+            assert key in rv, f"single-bunk request_validation missing {key!r}"
+
+    def test_single_bunk_counts_satisfied_mp_request(self) -> None:
+        """In a single-bunk session every camper shares a bunk, so a `bunk_with`
+        request between two enrolled campers is satisfied. The MP/all-camper
+        counts must reflect this — not return zeros because the diagnostic loop
+        was never run.
+        """
+        requests = [
+            DirectBunkRequest(
+                id="r1",
+                requester_person_cm_id=1000,
+                requested_person_cm_id=1001,
+                request_type="bunk_with",
+                source_field="bunk_with",
+                status="resolved",
+                priority=4,
+                session_cm_id=500,
+                year=2026,
+            )
+        ]
+        solver = DirectBunkingSolver(
+            input_data=self._make_input(num_persons=2, requests=requests),
+            config_service=MagicMock(),
+        )
+        result = solver.solve(time_limit_seconds=10)
+        assert result is not None
+        rv = result.stats["request_validation"]
+        assert rv["mp_requests_total"] == 1
+        assert rv["mp_requests_satisfied"] == 1
+        assert rv["mp_campers_total"] == 1
+        assert rv["mp_campers_satisfied"] == 1
+        assert rv["all_campers_total"] == 1
+        assert rv["all_campers_satisfied"] == 1
+
+
 class TestSingleBunkSatisfiedRequestsCentralization:
     """Single-bunk path must use shared `calculate_satisfied_requests` so it:
 

--- a/tests/unit/solver/test_request_validation_mp_counts.py
+++ b/tests/unit/solver/test_request_validation_mp_counts.py
@@ -1,0 +1,211 @@
+"""TDD tests for new MP and all-camper counts in request_validation_summary.
+
+See docs/superpowers/specs/2026-05-11-solver-debug-metric-expansion-design.md
+for the scenarios this exercises. The post-solve diagnostic loop already
+buckets unsatisfied campers; this PR layers symmetric met/total counts for
+the 'all requests' and 'MP requests' scopes on top.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from bunking.models_v2 import DirectBunk, DirectBunkAssignment, DirectBunkRequest, DirectPerson, DirectSolverInput
+from bunking.solver.direct_solver import DirectBunkingSolver
+from bunking.sync.bunk_request_processor.core.models import RequestType
+
+
+# --- Test fixture builders -------------------------------------------------
+
+
+def _person(cm_id: int, session_cm_id: int = 500) -> DirectPerson:
+    return DirectPerson(
+        campminder_person_id=cm_id,
+        first_name=f"Camper{cm_id}",
+        last_name="Test",
+        grade=5,
+        birthdate="2015-01-01",
+        gender="F",
+        session_cm_id=session_cm_id,
+    )
+
+
+def _bunk(cm_id: int, capacity: int = 10, session_cm_id: int = 500) -> DirectBunk:
+    return DirectBunk(
+        id=f"bunk-{cm_id}",
+        campminder_id=cm_id,
+        name=f"Bunk{cm_id}",
+        capacity=capacity,
+        gender="F",
+        session_cm_id=session_cm_id,
+    )
+
+
+def _req(
+    req_id: str,
+    requester_id: int,
+    target_id: int,
+    source_field: str,
+    request_type: str = "bunk_with",
+    status: str = "resolved",
+    priority: int = 4,
+    session_cm_id: int = 500,
+    year: int = 2026,
+) -> DirectBunkRequest:
+    return DirectBunkRequest(
+        id=req_id,
+        requester_person_cm_id=requester_id,
+        requested_person_cm_id=target_id,
+        request_type=request_type,
+        source_field=source_field,
+        status=status,
+        priority=priority,
+        session_cm_id=session_cm_id,
+        year=year,
+    )
+
+
+def _run_post_solve_with_fixed_assignments(
+    persons: list[DirectPerson],
+    bunks: list[DirectBunk],
+    requests: list[DirectBunkRequest],
+    assignments: dict[int, int],
+) -> dict[str, Any]:
+    """Build a DirectBunkingSolver, install fixed assignments, invoke the
+    post-solve diagnostic helper directly, and return its
+    request_validation_summary.
+
+    We bypass the full CP-SAT solve because the counts only depend on
+    (requests, assignments) — not on the solver's search behavior. This
+    keeps the test fast and deterministic.
+
+    Internally `_check_must_satisfy_one_violations` builds person_to_bunk
+    and calls `calculate_satisfied_requests` itself, so we only need to
+    hand it the assignment list.
+    """
+    input_data = DirectSolverInput(persons=persons, bunks=bunks, requests=requests)
+    solver = DirectBunkingSolver(input_data, config_service=MagicMock())
+
+    # _validate_requests() is called in __init__ and populates possible_requests
+    # + request_validation_summary; the diagnostic reads possible_requests, and
+    # the new MP count keys get merged into the same summary dict.
+
+    assignment_list = [
+        DirectBunkAssignment(person_cm_id=pid, bunk_cm_id=bid, session_cm_id=500, year=2026)
+        for pid, bid in assignments.items()
+    ]
+    solver._check_must_satisfy_one_violations(assignment_list)
+    return solver.request_validation_summary
+
+
+# --- Scenarios ------------------------------------------------------------
+
+
+class TestMPAndAllCamperCounts:
+    """Symmetric met/total/unmet counts for all-request and MP-request scopes."""
+
+    def test_camper_with_mp_satisfied_and_mp_unsatisfied(self) -> None:
+        """Scenario 1: One camper with [MP-sat, MP-unsat].
+
+        mp_requests_total=2, mp_requests_satisfied=1,
+        mp_campers_total=1, mp_campers_satisfied=1 (>=1 MP satisfied),
+        all_campers_total=1, all_campers_satisfied=1.
+        """
+        persons = [_person(1), _person(2), _person(3)]
+        bunks = [_bunk(100), _bunk(200)]
+        requests = [
+            _req("r1", 1, 2, source_field="bunk_with"),  # MP, satisfied (B in same bunk)
+            _req("r2", 1, 3, source_field="bunk_with"),  # MP, unsatisfied (C in other bunk)
+        ]
+        assignments = {1: 100, 2: 100, 3: 200}
+
+        s = _run_post_solve_with_fixed_assignments(persons, bunks, requests, assignments)
+
+        assert s["mp_requests_total"] == 2
+        assert s["mp_requests_satisfied"] == 1
+        assert s["mp_campers_total"] == 1
+        assert s["mp_campers_satisfied"] == 1
+        assert s["all_campers_total"] == 1
+        assert s["all_campers_satisfied"] == 1
+
+    def test_camper_with_mp_unsatisfied_and_other_satisfied(self) -> None:
+        """Scenario 2: [MP-unsat, OTHER-sat] -- locks in inequality vs unmet bucket.
+
+        Existing `unsatisfied_material_parent_unmet` bucket SKIPS this camper
+        (they got >=1 of anything). But mp_campers_satisfied does NOT count
+        them -- they didn't get any MP satisfied. all_campers_satisfied
+        counts them.
+        """
+        persons = [_person(1), _person(2), _person(3)]
+        bunks = [_bunk(100), _bunk(200)]
+        requests = [
+            _req("r1", 1, 3, source_field="bunk_with"),  # MP, unsatisfied
+            _req("r2", 1, 2, source_field="bunking_notes"),  # STAFF, satisfied
+        ]
+        assignments = {1: 100, 2: 100, 3: 200}
+
+        s = _run_post_solve_with_fixed_assignments(persons, bunks, requests, assignments)
+
+        assert s["mp_requests_total"] == 1
+        assert s["mp_requests_satisfied"] == 0
+        assert s["mp_campers_total"] == 1
+        assert s["mp_campers_satisfied"] == 0  # MP not satisfied
+        assert s["all_campers_total"] == 1
+        assert s["all_campers_satisfied"] == 1  # OTHER was satisfied
+        # Existing bucket: camper NOT in unmet (got >=1 anything satisfied)
+        assert s["unsatisfied_material_parent_unmet"] == 0
+
+    def test_camper_with_all_unsatisfied(self) -> None:
+        """Scenario 3: [MP-unsat, OTHER-unsat] -- in unmet bucket and not satisfied counts."""
+        persons = [_person(1), _person(2), _person(3)]
+        bunks = [_bunk(100), _bunk(200)]
+        requests = [
+            _req("r1", 1, 3, source_field="bunk_with"),  # MP, unsatisfied
+            _req("r2", 1, 3, source_field="bunking_notes"),  # STAFF, unsatisfied
+        ]
+        assignments = {1: 100, 2: 100, 3: 200}
+
+        s = _run_post_solve_with_fixed_assignments(persons, bunks, requests, assignments)
+
+        assert s["mp_campers_total"] == 1
+        assert s["mp_campers_satisfied"] == 0
+        assert s["all_campers_total"] == 1
+        assert s["all_campers_satisfied"] == 0
+        # Existing bucket: camper IS in unmet (got 0 anything satisfied) AND
+        # had MP possible -> material_parent_unmet
+        assert s["unsatisfied_material_parent_unmet"] == 1
+
+    def test_camper_with_only_other_satisfied(self) -> None:
+        """Scenario 4: no MP requests, only OTHER-sat -- excluded from MP counts entirely."""
+        persons = [_person(1), _person(2)]
+        bunks = [_bunk(100)]
+        requests = [
+            _req("r1", 1, 2, source_field="bunking_notes"),  # STAFF, satisfied
+        ]
+        assignments = {1: 100, 2: 100}
+
+        s = _run_post_solve_with_fixed_assignments(persons, bunks, requests, assignments)
+
+        assert s["mp_requests_total"] == 0
+        assert s["mp_requests_satisfied"] == 0
+        assert s["mp_campers_total"] == 0  # No MP -> can't be in total
+        assert s["mp_campers_satisfied"] == 0
+        assert s["all_campers_total"] == 1
+        assert s["all_campers_satisfied"] == 1
+
+    def test_camper_with_no_resolved_requests(self) -> None:
+        """Scenario 5: no requests at all -- excluded from all totals."""
+        persons = [_person(1), _person(2)]
+        bunks = [_bunk(100)]
+        requests: list[DirectBunkRequest] = []
+        assignments = {1: 100, 2: 100}
+
+        s = _run_post_solve_with_fixed_assignments(persons, bunks, requests, assignments)
+
+        assert s["mp_requests_total"] == 0
+        assert s["mp_campers_total"] == 0
+        assert s["all_campers_total"] == 0
+        assert s["all_campers_satisfied"] == 0

--- a/tests/unit/solver/test_request_validation_mp_counts.py
+++ b/tests/unit/solver/test_request_validation_mp_counts.py
@@ -11,12 +11,8 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock
 
-import pytest
-
 from bunking.models_v2 import DirectBunk, DirectBunkAssignment, DirectBunkRequest, DirectPerson, DirectSolverInput
 from bunking.solver.direct_solver import DirectBunkingSolver
-from bunking.sync.bunk_request_processor.core.models import RequestType
-
 
 # --- Test fixture builders -------------------------------------------------
 


### PR DESCRIPTION
## Summary

Surfaces every solver-run metric the backend captures on the solver-debug page, replaces the `highlight: true` flag with conditional highlighting, and refactors `DrillDownDrawer` to iterate the metric registry instead of hardcoding StatCard blocks.

### Backend
- Adds 6 new keys to `request_validation_summary` in `direct_solver.py`'s post-solve diagnostic:
  - `mp_requests_total`, `mp_requests_satisfied`
  - `mp_campers_total`, `mp_campers_satisfied`
  - `all_campers_total`, `all_campers_satisfied`
- MP classification uses canonical `classify_request()` from `bunking.satisfaction.bucket` with a defensive ValueError guard mirroring `_is_material_parent()`.
- `TODO(stage-4-retire)` flags the legacy wrapper + Stage-4-era mirror keys for removal when parent-paramount reweighting lands.

### Frontend
- `metricRegistry.ts` gains 3 new groups (`outcome`, `size`, `churn`), a `HighlightRule` discriminated union (`on-delta` | `diverges-from`), and 24 new metric entries (rate gauges, MP/all-camper raw counts, impossibility-floor, size, churn, `objective_value`).
- `PinnedComparisonPanel`: conditional highlighting via `shouldHighlight(meta, runA, runB)`; `objective_value` shows as `higher-better` only when both runs share an identical `config_snapshot`, gray-context otherwise.
- `SolverRunsTable`: `mp_request_rate` (Optimized) and `mp_camper_rate` (Acceptable) join `DEFAULT_VISIBLE_COLUMNS`; 12 more toggleable columns added.
- `DrillDownDrawer`: refactored to iterate `METRIC_REGISTRY_BY_GROUP` — every registry entry renders automatically. Adds a "Solution strategy" row that surfaces `s.solution_info` when present.
- Shared `pickStat` util replaces three near-duplicate helpers across the page.

## Test plan

- [x] `uv run pytest tests/unit/solver/` — 141 passed (incl. 5 new MP-count scenarios)
- [x] `cd frontend && npx vitest run` — 4023 passed (incl. new B5/C3/D2 tests)
- [x] `cd frontend && npx tsc --noEmit` — clean
- [x] `lefthook run pre-push` — ruff, go-build, pb-js-lint, shellcheck, mypy (646 files), tsc all green
- [ ] Manual: re-run a debug sweep against session 1235404; confirm Optimized + Acceptable cells render in the runs table
- [ ] Manual: pin two sweep runs, confirm compare panel shows outcome group with rate gauges + MP raw counts as indented sub-rows
- [ ] Manual: pin two runs with mismatched config_snapshot; confirm `objective_value` Δ renders in gray (context), not green/red

Spec: docs/superpowers/specs/2026-05-11-solver-debug-metric-expansion-design.md (local-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added symmetric satisfaction metrics and persisted request/camper totals; new rate and count columns (rates, totals, persons/bunks, workers, assignment churn, objective) with two rate columns visible by default.
* **Bug Fixes**
  * Debug view now shows outcome columns for single-session runs consistent with multi-session runs.
* **UX / Metrics**
  * Reorganized metric groups and introduced structured highlight/delta rules for clearer comparisons.
* **Tests**
  * Added unit and UI tests covering metrics, table rendering, drill-down groups, and conditional highlighting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1343)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->