### PR TITLE
refactor(pb): consolidate custom_field_defs migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000002_custom_field_defs.js
+++ b/pocketbase/pb_migrations/1500000002_custom_field_defs.js
@@ -10,15 +10,17 @@
 const COLLECTION_ID_CUSTOM_FIELD_DEFS = "col_custom_field_defs";
 
 migrate((app) => {
+  const adminOnly = '@request.auth.is_admin = true';
+
   const collection = new Collection({
     id: COLLECTION_ID_CUSTOM_FIELD_DEFS,
     type: "base",
     name: "custom_field_defs",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: adminOnly,
+    viewRule: adminOnly,
+    createRule: adminOnly,
+    updateRule: adminOnly,
+    deleteRule: adminOnly,
     fields: [
       {
         type: "number",

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -24,6 +24,8 @@
  * merged CREATE migration #005.
  * Note: config_sections trimmed — final adminOnly rules baked into
  * merged CREATE migration #012.
+ * Note: custom_field_defs trimmed — final adminOnly rules baked into
+ * merged CREATE migration #002.
  */
 
 migrate((app) => {
@@ -46,7 +48,7 @@ migrate((app) => {
     "payment_methods",
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",
-    "person_custom_values", "person_tag_defs", "custom_field_defs",
+    "person_custom_values", "person_tag_defs",
     "sheets_workbooks"
   ]
 
@@ -81,7 +83,7 @@ migrate((app) => {
     "payment_methods",
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",
-    "person_custom_values", "person_tag_defs", "custom_field_defs",
+    "person_custom_values", "person_tag_defs",
     "sheets_workbooks",
     "debug_parse_results", "solver_runs"
   ]


### PR DESCRIPTION
## Summary
- Trim-only round folding final adminOnly rules into base `#1500000002` (CREATE).
- Trimmed 1 multi-table file (`#1500000075 rbac_tier2_rules`): removed `custom_field_defs` from `tier2[]` (up) and `all[]` (down). `tier2` still has 12 entries; file remains.
- Baked `listRule/viewRule/createRule/updateRule/deleteRule = '@request.auth.is_admin = true'` into merged CREATE via extracted `adminOnly` constant (same pattern as session_groups #1340 and config_sections #1342).
- Net delta: **0 files** (rule edits only — no migrations deleted).
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match between proposed (rules baked into CREATE) and current (rules applied via #075).

Final state of `custom_field_defs`:
- 9 fields: cm_id, name, data_type, partition, is_seasonal, is_array, is_active, created, updated
- 2 indexes: unique(cm_id); idx_custom_field_defs_partition
- Rules: all 5 = `@request.auth.is_admin = true`

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted access to custom field definitions to administrators only.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1344)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->