### PR TITLE
refactor(pb): consolidate financial_categories migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000009_financial_categories.js
+++ b/pocketbase/pb_migrations/1500000009_financial_categories.js
@@ -11,15 +11,17 @@
 const COLLECTION_ID_FINANCIAL_CATEGORIES = "col_financial_categories";
 
 migrate((app) => {
+  const adminOnly = '@request.auth.is_admin = true';
+
   const collection = new Collection({
     id: COLLECTION_ID_FINANCIAL_CATEGORIES,
     type: "base",
     name: "financial_categories",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: adminOnly,
+    viewRule: adminOnly,
+    createRule: adminOnly,
+    updateRule: adminOnly,
+    deleteRule: adminOnly,
     fields: [
       {
         type: "number",

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -26,6 +26,8 @@
  * merged CREATE migration #012.
  * Note: custom_field_defs trimmed — final adminOnly rules baked into
  * merged CREATE migration #002.
+ * Note: financial_categories trimmed — final adminOnly rules baked into
+ * merged CREATE migration #009.
  */
 
 migrate((app) => {
@@ -44,7 +46,7 @@ migrate((app) => {
   // Tier 2: Admin-only (sensitive data not accessed by frontend)
   const tier2 = [
     "household_custom_values",
-    "financial_transactions", "financial_categories",
+    "financial_transactions",
     "payment_methods",
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",
@@ -79,7 +81,7 @@ migrate((app) => {
 
   const all = [
     "household_custom_values",
-    "financial_transactions", "financial_categories",
+    "financial_transactions",
     "payment_methods",
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",


### PR DESCRIPTION
## Summary
- Trim-only round folding final adminOnly rules into base `#1500000009` (CREATE).
- Trimmed 1 multi-table file (`#1500000075 rbac_tier2_rules`): removed `financial_categories` from `tier2[]` (up) and `all[]` (down). `tier2` still has 11 entries; file remains.
- Baked `listRule/viewRule/createRule/updateRule/deleteRule = '@request.auth.is_admin = true'` into merged CREATE via extracted `adminOnly` constant (same pattern as session_groups #1340, config_sections #1342, custom_field_defs #1344).
- Net delta: **0 files** (rule edits only — no migrations deleted).
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match between proposed (rules baked into CREATE) and current (rules applied via #075).

Final state of `financial_categories`:
- 5 fields: cm_id, name, is_archived, created, updated
- 1 index: unique(cm_id)
- Rules: all 5 = `@request.auth.is_admin = true`

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Updated access control for financial categories to require admin privileges for all operations (list, view, create, update, delete).
* Updated access control for financial transactions to enforce admin-only privileges.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1345)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->