### PR TITLE
refactor(pb): consolidate financial_transactions migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000031_financial_transactions.js
+++ b/pocketbase/pb_migrations/1500000031_financial_transactions.js
@@ -15,6 +15,8 @@
 const COLLECTION_ID_FINANCIAL_TRANSACTIONS = "col_financial_transactions";
 
 migrate((app) => {
+  const adminOnly = '@request.auth.is_admin = true';
+
   // Lookup related collections for relations
   const financialCategoriesCol = app.findCollectionByNameOrId("financial_categories");
   const paymentMethodsCol = app.findCollectionByNameOrId("payment_methods");
@@ -28,11 +30,11 @@ migrate((app) => {
     id: COLLECTION_ID_FINANCIAL_TRANSACTIONS,
     type: "base",
     name: "financial_transactions",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: adminOnly,
+    viewRule: adminOnly,
+    createRule: adminOnly,
+    updateRule: adminOnly,
+    deleteRule: adminOnly,
     fields: [
       // Identity
       {

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -28,6 +28,8 @@
  * merged CREATE migration #002.
  * Note: financial_categories trimmed — final adminOnly rules baked into
  * merged CREATE migration #009.
+ * Note: financial_transactions trimmed — final adminOnly rules baked into
+ * merged CREATE migration #031.
  */
 
 migrate((app) => {
@@ -46,7 +48,6 @@ migrate((app) => {
   // Tier 2: Admin-only (sensitive data not accessed by frontend)
   const tier2 = [
     "household_custom_values",
-    "financial_transactions",
     "payment_methods",
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",
@@ -81,7 +82,6 @@ migrate((app) => {
 
   const all = [
     "household_custom_values",
-    "financial_transactions",
     "payment_methods",
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",


### PR DESCRIPTION
## Summary
- Trim-only round folding final adminOnly rules into base `#1500000031` (CREATE).
- Trimmed 1 multi-table file (`#1500000075 rbac_tier2_rules`): removed `financial_transactions` from `tier2[]` (up) and `all[]` (down). `tier2` still has 10 entries; file remains.
- Baked `listRule/viewRule/createRule/updateRule/deleteRule = '@request.auth.is_admin = true'` into merged CREATE via extracted `adminOnly` constant (same pattern as session_groups #1340, config_sections #1342, custom_field_defs #1344, financial_categories #1345).
- Net delta: **0 files** (rule edits only — no migrations deleted).
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match between proposed (rules baked into CREATE) and current (rules applied via #075).

Final state of `financial_transactions` (largest tier2 CREATE so far, but trim-only pattern still trivial):
- 26 fields including 7 relations (financial_category, payment_method, session, session_group, division, person, household)
- 7 indexes
- Rules: all 5 = `@request.auth.is_admin = true`

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated financial transactions permissions to restrict access to administrators only. Previously accessible to any authenticated user, these records are now admin-exclusive.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1346)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->