### PR TITLE
refactor(pb): consolidate household_custom_values migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000029_household_custom_values.js
+++ b/pocketbase/pb_migrations/1500000029_household_custom_values.js
@@ -13,6 +13,8 @@
 const COLLECTION_ID_HOUSEHOLD_CUSTOM_VALUES = "col_household_cf_vals";
 
 migrate((app) => {
+  const adminOnly = '@request.auth.is_admin = true';
+
   const householdsCol = app.findCollectionByNameOrId("households");
   const customFieldDefsCol = app.findCollectionByNameOrId("custom_field_defs");
 
@@ -20,11 +22,11 @@ migrate((app) => {
     id: COLLECTION_ID_HOUSEHOLD_CUSTOM_VALUES,
     type: "base",
     name: "household_custom_values",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: adminOnly,
+    viewRule: adminOnly,
+    createRule: adminOnly,
+    updateRule: adminOnly,
+    deleteRule: adminOnly,
     fields: [
       // Relation to households collection
       {

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -30,6 +30,8 @@
  * merged CREATE migration #009.
  * Note: financial_transactions trimmed — final adminOnly rules baked into
  * merged CREATE migration #031.
+ * Note: household_custom_values trimmed — final adminOnly rules baked into
+ * merged CREATE migration #029.
  */
 
 migrate((app) => {
@@ -47,7 +49,6 @@ migrate((app) => {
 
   // Tier 2: Admin-only (sensitive data not accessed by frontend)
   const tier2 = [
-    "household_custom_values",
     "payment_methods",
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",
@@ -81,7 +82,6 @@ migrate((app) => {
   }
 
   const all = [
-    "household_custom_values",
     "payment_methods",
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",


### PR DESCRIPTION
## Summary
- Trim-only round folding final adminOnly rules into base `#1500000029` (CREATE).
- Trimmed 1 multi-table file (`#1500000075 rbac_tier2_rules`): removed `household_custom_values` from `tier2[]` (up) and `all[]` (down). `tier2` still has 9 entries; file remains.
- Baked rules into merged CREATE via extracted `adminOnly` constant (same pattern as #1340, #1342, #1344, #1345, #1346).
- Net delta: **0 files** (rule edits only — no migrations deleted).
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match between proposed and current.

Final state: rules = `@request.auth.is_admin = true`; all fields/indexes/relations unchanged.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced access controls for household custom values data with admin-only restrictions.

* **Chores**
  * Improved permission rule management by consolidating access control definitions and removing redundant rule configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1347)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->