### PR TITLE
refactor(pb): consolidate payment_methods migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000010_payment_methods.js
+++ b/pocketbase/pb_migrations/1500000010_payment_methods.js
@@ -11,15 +11,17 @@
 const COLLECTION_ID_PAYMENT_METHODS = "col_payment_methods";
 
 migrate((app) => {
+  const adminOnly = '@request.auth.is_admin = true';
+
   const collection = new Collection({
     id: COLLECTION_ID_PAYMENT_METHODS,
     type: "base",
     name: "payment_methods",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: adminOnly,
+    viewRule: adminOnly,
+    createRule: adminOnly,
+    updateRule: adminOnly,
+    deleteRule: adminOnly,
     fields: [
       {
         type: "number",

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -32,6 +32,8 @@
  * merged CREATE migration #031.
  * Note: household_custom_values trimmed — final adminOnly rules baked into
  * merged CREATE migration #029.
+ * Note: payment_methods trimmed — final adminOnly rules baked into
+ * merged CREATE migration #010.
  */
 
 migrate((app) => {
@@ -49,7 +51,6 @@ migrate((app) => {
 
   // Tier 2: Admin-only (sensitive data not accessed by frontend)
   const tier2 = [
-    "payment_methods",
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",
     "person_custom_values", "person_tag_defs",
@@ -82,7 +83,6 @@ migrate((app) => {
   }
 
   const all = [
-    "payment_methods",
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",
     "person_custom_values", "person_tag_defs",


### PR DESCRIPTION
## Summary
- Trim-only round folding final adminOnly rules into base `#1500000010` (CREATE).
- Trimmed 1 multi-table file (`#1500000075 rbac_tier2_rules`): removed `payment_methods` from `tier2[]` (up) and `all[]` (down). `tier2` still has 8 entries; file remains.
- Baked rules into merged CREATE via extracted `adminOnly` constant (same pattern as #1340, #1342, #1344, #1345, #1346, #1347).
- Net delta: **0 files** (rule edits only — no migrations deleted).
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match between proposed and current.

Final state: rules = `@request.auth.is_admin = true`; all fields/indexes unchanged.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted payment methods access to administrators only, preventing non-admin users from viewing or modifying payment information.
  * Refined role-based access control rules to strengthen security governance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1348)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->