### PR TITLE
refactor(pb): consolidate person_custom_values migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000028_person_custom_values.js
+++ b/pocketbase/pb_migrations/1500000028_person_custom_values.js
@@ -13,6 +13,8 @@
 const COLLECTION_ID_PERSON_CUSTOM_VALUES = "col_person_cf_vals";
 
 migrate((app) => {
+  const adminOnly = '@request.auth.is_admin = true';
+
   // Get collection IDs for relations
   const personsCol = app.findCollectionByNameOrId("persons");
   const customFieldDefsCol = app.findCollectionByNameOrId("custom_field_defs");
@@ -21,11 +23,11 @@ migrate((app) => {
     id: COLLECTION_ID_PERSON_CUSTOM_VALUES,
     type: "base",
     name: "person_custom_values",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: adminOnly,
+    viewRule: adminOnly,
+    createRule: adminOnly,
+    updateRule: adminOnly,
+    deleteRule: adminOnly,
     fields: [
       // Relation to persons collection
       {

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -34,6 +34,8 @@
  * merged CREATE migration #029.
  * Note: payment_methods trimmed — final adminOnly rules baked into
  * merged CREATE migration #010.
+ * Note: person_custom_values trimmed — final adminOnly rules baked into
+ * merged CREATE migration #028.
  */
 
 migrate((app) => {
@@ -53,7 +55,7 @@ migrate((app) => {
   const tier2 = [
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",
-    "person_custom_values", "person_tag_defs",
+    "person_tag_defs",
     "sheets_workbooks"
   ]
 
@@ -85,7 +87,7 @@ migrate((app) => {
   const all = [
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",
-    "person_custom_values", "person_tag_defs",
+    "person_tag_defs",
     "sheets_workbooks",
     "debug_parse_results", "solver_runs"
   ]


### PR DESCRIPTION
## Summary
- Trim-only round folding final adminOnly rules into base `#1500000028` (CREATE).
- Trimmed 1 multi-table file (`#1500000075 rbac_tier2_rules`): removed `person_custom_values` from `tier2[]` (up) and `all[]` (down). `tier2` still has 7 entries; file remains.
- Baked rules into merged CREATE via extracted `adminOnly` constant (same pattern as #1340, #1342, #1344–#1348).
- Net delta: **0 files** (rule edits only — no migrations deleted).
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match.

Final state: rules = `@request.auth.is_admin = true`; all fields/relations/indexes unchanged.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified database access control rules for data collections
  * Updated role-based access permissions configuration

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1349)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->