### PR TITLE
refactor(pb): consolidate person_tag_defs migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000001_person_tag_defs.js
+++ b/pocketbase/pb_migrations/1500000001_person_tag_defs.js
@@ -11,15 +11,17 @@
 const COLLECTION_ID_PERSON_TAG_DEFS = "col_person_tag_defs";
 
 migrate((app) => {
+  const adminOnly = '@request.auth.is_admin = true';
+
   const collection = new Collection({
     id: COLLECTION_ID_PERSON_TAG_DEFS,
     type: "base",
     name: "person_tag_defs",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: adminOnly,
+    viewRule: adminOnly,
+    createRule: adminOnly,
+    updateRule: adminOnly,
+    deleteRule: adminOnly,
     fields: [
       {
         type: "text",

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -36,6 +36,8 @@
  * merged CREATE migration #010.
  * Note: person_custom_values trimmed — final adminOnly rules baked into
  * merged CREATE migration #028.
+ * Note: person_tag_defs trimmed — final adminOnly rules baked into
+ * merged CREATE migration #001.
  */
 
 migrate((app) => {
@@ -55,7 +57,6 @@ migrate((app) => {
   const tier2 = [
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",
-    "person_tag_defs",
     "sheets_workbooks"
   ]
 
@@ -87,7 +88,6 @@ migrate((app) => {
   const all = [
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",
-    "person_tag_defs",
     "sheets_workbooks",
     "debug_parse_results", "solver_runs"
   ]


### PR DESCRIPTION
## Summary
- Trim-only round folding final adminOnly rules into base `#1500000001` (CREATE).
- Trimmed 1 multi-table file (`#1500000075 rbac_tier2_rules`): removed `person_tag_defs` from `tier2[]` (up) and `all[]` (down). `tier2` still has 6 entries; file remains.
- Baked rules into merged CREATE via extracted `adminOnly` constant (same pattern as prior rounds #1340, #1342, #1344–#1349).
- Net delta: **0 files** (rule edits only — no migrations deleted).
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match.

Final state: rules = `@request.auth.is_admin = true`; all fields/indexes unchanged.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced access control restrictions for administrative features, limiting certain operations to admin users only.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1350)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->