### PR TITLE
refactor(pb): consolidate sheets_workbooks migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000039_sheets_workbooks.js
+++ b/pocketbase/pb_migrations/1500000039_sheets_workbooks.js
@@ -11,15 +11,17 @@
 const COLLECTION_ID_SHEETS_WORKBOOKS = "col_sheets_workbooks";
 
 migrate((app) => {
+  const adminOnly = '@request.auth.is_admin = true';
+
   const collection = new Collection({
     id: COLLECTION_ID_SHEETS_WORKBOOKS,
     type: "base",
     name: "sheets_workbooks",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: adminOnly,
+    viewRule: adminOnly,
+    createRule: adminOnly,
+    updateRule: adminOnly,
+    deleteRule: adminOnly,
     fields: [
       // Google Sheets spreadsheet ID (from URL)
       {

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -38,6 +38,8 @@
  * merged CREATE migration #028.
  * Note: person_tag_defs trimmed — final adminOnly rules baked into
  * merged CREATE migration #001.
+ * Note: sheets_workbooks trimmed — final adminOnly rules baked into
+ * merged CREATE migration #039.
  */
 
 migrate((app) => {
@@ -56,8 +58,7 @@ migrate((app) => {
   // Tier 2: Admin-only (sensitive data not accessed by frontend)
   const tier2 = [
     "staff", "staff_org_categories", "staff_positions",
-    "staff_program_areas", "staff_skills",
-    "sheets_workbooks"
+    "staff_program_areas", "staff_skills"
   ]
 
   for (const name of tier2) {
@@ -88,7 +89,6 @@ migrate((app) => {
   const all = [
     "staff", "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",
-    "sheets_workbooks",
     "debug_parse_results", "solver_runs"
   ]
 


### PR DESCRIPTION
## Summary
- Trim-only round folding final adminOnly rules into base `#1500000039` (CREATE).
- Trimmed 1 multi-table file (`#1500000075 rbac_tier2_rules`): removed `sheets_workbooks` from `tier2[]` (up) and `all[]` (down). `tier2` now has 5 entries (all staff*); file remains.
- Baked rules into merged CREATE via extracted `adminOnly` constant (same pattern as prior rounds #1340, #1342, #1344–#1350).
- Net delta: **0 files** (rule edits only — no migrations deleted).
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match.

Final state: rules = `@request.auth.is_admin = true`; all fields/indexes unchanged.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted workbook collection access to administrators only through updated access control rules.
  * Refined role-based access control configuration for workbook management operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1351)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->