### PR TITLE
refactor(pb): consolidate staff migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000030_staff.js
+++ b/pocketbase/pb_migrations/1500000030_staff.js
@@ -14,6 +14,8 @@
 const COLLECTION_ID_STAFF = "col_staff";
 
 migrate((app) => {
+  const adminOnly = '@request.auth.is_admin = true';
+
   // Lookup related collections for relations
   const personsCol = app.findCollectionByNameOrId("persons");
   const positionsCol = app.findCollectionByNameOrId("staff_positions");
@@ -25,11 +27,11 @@ migrate((app) => {
     id: COLLECTION_ID_STAFF,
     type: "base",
     name: "staff",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: adminOnly,
+    viewRule: adminOnly,
+    createRule: adminOnly,
+    updateRule: adminOnly,
+    deleteRule: adminOnly,
     fields: [
       // Person relation
       {

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -40,6 +40,8 @@
  * merged CREATE migration #001.
  * Note: sheets_workbooks trimmed — final adminOnly rules baked into
  * merged CREATE migration #039.
+ * Note: staff trimmed — final adminOnly rules baked into
+ * merged CREATE migration #030.
  */
 
 migrate((app) => {
@@ -57,7 +59,7 @@ migrate((app) => {
 
   // Tier 2: Admin-only (sensitive data not accessed by frontend)
   const tier2 = [
-    "staff", "staff_org_categories", "staff_positions",
+    "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills"
   ]
 
@@ -87,7 +89,7 @@ migrate((app) => {
   }
 
   const all = [
-    "staff", "staff_org_categories", "staff_positions",
+    "staff_org_categories", "staff_positions",
     "staff_program_areas", "staff_skills",
     "debug_parse_results", "solver_runs"
   ]


### PR DESCRIPTION
## Summary
- Trim-only round folding final adminOnly rules into base `#1500000030` (CREATE).
- Trimmed 1 multi-table file (`#1500000075 rbac_tier2_rules`): removed `staff` from `tier2[]` (up) and `all[]` (down). `tier2` now has 4 entries (staff_org_categories, staff_positions, staff_program_areas, staff_skills); file remains.
- Baked rules into merged CREATE via extracted `adminOnly` constant (same pattern as prior rounds #1340–#1351).
- Net delta: **0 files** (rule edits only — no migrations deleted).
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match.

Final state: rules = `@request.auth.is_admin = true`; all fields, relations (persons, staff_positions, staff_org_categories, divisions, bunks), and indexes unchanged.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Staff collection access is now restricted to administrators only.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1352)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->