### PR TITLE
refactor(pb): consolidate staff_org_categories migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000008_staff_org_categories.js
+++ b/pocketbase/pb_migrations/1500000008_staff_org_categories.js
@@ -11,15 +11,17 @@
 const COLLECTION_ID_STAFF_ORG_CATEGORIES = "col_staff_org_cats";
 
 migrate((app) => {
+  const adminOnly = '@request.auth.is_admin = true';
+
   const collection = new Collection({
     id: COLLECTION_ID_STAFF_ORG_CATEGORIES,
     type: "base",
     name: "staff_org_categories",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: adminOnly,
+    viewRule: adminOnly,
+    createRule: adminOnly,
+    updateRule: adminOnly,
+    deleteRule: adminOnly,
     fields: [
       {
         type: "number",

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -42,6 +42,8 @@
  * merged CREATE migration #039.
  * Note: staff trimmed — final adminOnly rules baked into
  * merged CREATE migration #030.
+ * Note: staff_org_categories trimmed — final adminOnly rules baked into
+ * merged CREATE migration #008.
  */
 
 migrate((app) => {
@@ -59,7 +61,7 @@ migrate((app) => {
 
   // Tier 2: Admin-only (sensitive data not accessed by frontend)
   const tier2 = [
-    "staff_org_categories", "staff_positions",
+    "staff_positions",
     "staff_program_areas", "staff_skills"
   ]
 
@@ -89,7 +91,7 @@ migrate((app) => {
   }
 
   const all = [
-    "staff_org_categories", "staff_positions",
+    "staff_positions",
     "staff_program_areas", "staff_skills",
     "debug_parse_results", "solver_runs"
   ]


### PR DESCRIPTION
## Summary
- Trim-only round folding final adminOnly rules into base `#1500000008` (CREATE).
- Trimmed 1 multi-table file (`#1500000075 rbac_tier2_rules`): removed `staff_org_categories` from `tier2[]` (up) and `all[]` (down). `tier2` now has 3 entries (staff_positions, staff_program_areas, staff_skills); file remains.
- Baked rules into merged CREATE via extracted `adminOnly` constant (same pattern as prior rounds #1340–#1352).
- Net delta: **0 files** (rule edits only — no migrations deleted).
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match.

Final state: rules = `@request.auth.is_admin = true`; all fields/indexes unchanged.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security by restricting all staff organization categories management operations (list, view, create, update, delete) exclusively to administrators, preventing unauthorized access and modifications.
  * Consolidated and aligned role-based access control configuration across database migrations to maintain consistency in permission enforcement throughout the system.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1353)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->