### PR TITLE
refactor(pb): consolidate staff_positions migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000014_staff_positions.js
+++ b/pocketbase/pb_migrations/1500000014_staff_positions.js
@@ -10,17 +10,19 @@
 const COLLECTION_ID_STAFF_POSITIONS = "col_staff_positions";
 
 migrate((app) => {
+  const adminOnly = '@request.auth.is_admin = true';
+
   const programAreasCol = app.findCollectionByNameOrId("staff_program_areas");
 
   const collection = new Collection({
     id: COLLECTION_ID_STAFF_POSITIONS,
     type: "base",
     name: "staff_positions",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: adminOnly,
+    viewRule: adminOnly,
+    createRule: adminOnly,
+    updateRule: adminOnly,
+    deleteRule: adminOnly,
     fields: [
       {
         type: "number",

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -44,6 +44,8 @@
  * merged CREATE migration #030.
  * Note: staff_org_categories trimmed — final adminOnly rules baked into
  * merged CREATE migration #008.
+ * Note: staff_positions trimmed — final adminOnly rules baked into
+ * merged CREATE migration #014.
  */
 
 migrate((app) => {
@@ -61,7 +63,6 @@ migrate((app) => {
 
   // Tier 2: Admin-only (sensitive data not accessed by frontend)
   const tier2 = [
-    "staff_positions",
     "staff_program_areas", "staff_skills"
   ]
 
@@ -91,7 +92,6 @@ migrate((app) => {
   }
 
   const all = [
-    "staff_positions",
     "staff_program_areas", "staff_skills",
     "debug_parse_results", "solver_runs"
   ]


### PR DESCRIPTION
## Summary
- Trim-only round folding final adminOnly rules into base `#1500000014` (CREATE).
- Trimmed 1 multi-table file (`#1500000075 rbac_tier2_rules`): removed `staff_positions` from `tier2[]` (up) and `all[]` (down). `tier2` now has 2 entries (staff_program_areas, staff_skills); file remains.
- Baked rules into merged CREATE via extracted `adminOnly` constant (same pattern as prior rounds #1340–#1353).
- Net delta: **0 files** (rule edits only — no migrations deleted).
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match.

Final state: rules = `@request.auth.is_admin = true`; all fields/indexes unchanged.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated staff positions access controls to require administrator privileges, restricting management to authorized users only.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1354)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->