### PR TITLE
refactor(pb): consolidate staff_program_areas migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000007_staff_program_areas.js
+++ b/pocketbase/pb_migrations/1500000007_staff_program_areas.js
@@ -10,15 +10,17 @@
 const COLLECTION_ID_STAFF_PROGRAM_AREAS = "col_staff_prog_areas";
 
 migrate((app) => {
+  const adminOnly = '@request.auth.is_admin = true';
+
   const collection = new Collection({
     id: COLLECTION_ID_STAFF_PROGRAM_AREAS,
     type: "base",
     name: "staff_program_areas",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: adminOnly,
+    viewRule: adminOnly,
+    createRule: adminOnly,
+    updateRule: adminOnly,
+    deleteRule: adminOnly,
     fields: [
       {
         type: "number",

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -46,6 +46,8 @@
  * merged CREATE migration #008.
  * Note: staff_positions trimmed — final adminOnly rules baked into
  * merged CREATE migration #014.
+ * Note: staff_program_areas trimmed — final adminOnly rules baked into
+ * merged CREATE migration #007.
  */
 
 migrate((app) => {
@@ -63,7 +65,7 @@ migrate((app) => {
 
   // Tier 2: Admin-only (sensitive data not accessed by frontend)
   const tier2 = [
-    "staff_program_areas", "staff_skills"
+    "staff_skills"
   ]
 
   for (const name of tier2) {
@@ -92,7 +94,7 @@ migrate((app) => {
   }
 
   const all = [
-    "staff_program_areas", "staff_skills",
+    "staff_skills",
     "debug_parse_results", "solver_runs"
   ]
 


### PR DESCRIPTION
## Summary
- Trim-only round folding final adminOnly rules into base `#1500000007` (CREATE).
- Trimmed 1 multi-table file (`#1500000075 rbac_tier2_rules`): removed `staff_program_areas` from `tier2[]` (up) and `all[]` (down). `tier2` now has 1 entry (staff_skills); file remains.
- Baked rules into merged CREATE via extracted `adminOnly` constant (same pattern as prior rounds #1340–#1354).
- Net delta: **0 files** (rule edits only — no migrations deleted).
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match.

Final state: rules = `@request.auth.is_admin = true`; all fields/indexes unchanged.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated access controls for staff program areas to restrict functionality to admin users only. Previously, any authenticated user could access this feature.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1355)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->