### PR TITLE
refactor(pb): consolidate staff_skills migrations (round 1, trim-only) — final tier2

### DIFF
--- a/pocketbase/pb_migrations/1500000042_staff_skills.js
+++ b/pocketbase/pb_migrations/1500000042_staff_skills.js
@@ -23,17 +23,19 @@
 const COLLECTION_ID_STAFF_SKILLS = "col_staff_skills";
 
 migrate((app) => {
+  const adminOnly = '@request.auth.is_admin = true';
+
   const personsCol = app.findCollectionByNameOrId("persons");
 
   const collection = new Collection({
     id: COLLECTION_ID_STAFF_SKILLS,
     type: "base",
     name: "staff_skills",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: adminOnly,
+    viewRule: adminOnly,
+    createRule: adminOnly,
+    updateRule: adminOnly,
+    deleteRule: adminOnly,
     fields: [
       // Person identification (CampMinder ID for sync lookup)
       {

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -48,6 +48,9 @@
  * merged CREATE migration #014.
  * Note: staff_program_areas trimmed — final adminOnly rules baked into
  * merged CREATE migration #007.
+ * Note: staff_skills trimmed — final adminOnly rules baked into
+ * merged CREATE migration #042. tier2[] is now empty; only tier3
+ * (debug_parse_results, solver_runs) remains in this file.
  */
 
 migrate((app) => {
@@ -64,9 +67,7 @@ migrate((app) => {
   }
 
   // Tier 2: Admin-only (sensitive data not accessed by frontend)
-  const tier2 = [
-    "staff_skills"
-  ]
+  const tier2 = []
 
   for (const name of tier2) {
     setRules(name, adminOnly, adminOnly, adminOnly, adminOnly, adminOnly)
@@ -94,7 +95,6 @@ migrate((app) => {
   }
 
   const all = [
-    "staff_skills",
     "debug_parse_results", "solver_runs"
   ]
 


### PR DESCRIPTION
## Summary
**Final tier2 trim.** After this PR, `#1500000075`'s `tier2[]` is empty.

- Trim-only round folding final adminOnly rules into base `#1500000042` (CREATE).
- Trimmed 1 multi-table file (`#1500000075 rbac_tier2_rules`): removed `staff_skills` from `tier2[]` and `all[]`. `tier2[]` is now `[]`; `all[]` retains only tier3 entries (`debug_parse_results`, `solver_runs`).
- Baked rules into merged CREATE via extracted `adminOnly` constant (same pattern as the 12 prior tier2 rounds in this batch).
- Net delta: **0 files** (rule edits only — no migrations deleted).
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match.

Final state of `staff_skills`: rules = `@request.auth.is_admin = true`; all fields, relations (persons), and indexes unchanged.

The empty `tier2[]` block remains as dead code for now; `#1500000075` still applies rules to the two tier3 collections (`debug_parse_results`, `solver_runs`). When those are consolidated in future rounds, the file can be deleted entirely.

### tier2 batch complete (13 PRs)

This PR completes the tier2 consolidation batch: custom_field_defs, financial_categories, financial_transactions, household_custom_values, payment_methods, person_custom_values, person_tag_defs, sheets_workbooks, staff, staff_org_categories, staff_positions, staff_program_areas, staff_skills — all with `adminOnly` rules baked into their CREATE migrations.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted staff skills management operations to admin users only, enhancing application security and access control permissions. Access rules for viewing, creating, updating, and deleting staff-related information now require administrative privileges.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1356)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->