### PR TITLE
refactor(pb): consolidate debug_parse_results migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000027_debug_parse_results.js
+++ b/pocketbase/pb_migrations/1500000027_debug_parse_results.js
@@ -13,6 +13,9 @@
 const COLLECTION_ID_DEBUG_PARSE_RESULTS = "col_debug_parse_results";
 
 migrate((app) => {
+  // Tier 3 (FastAPI-only): deny all direct collection access; access only via admin endpoints.
+  const denyAll = '';
+
   // Dynamic lookups - these collections were created in earlier migrations
   const originalRequestsCol = app.findCollectionByNameOrId("original_bunk_requests");
   const sessionsCol = app.findCollectionByNameOrId("camp_sessions");
@@ -21,11 +24,11 @@ migrate((app) => {
     id: COLLECTION_ID_DEBUG_PARSE_RESULTS,
     type: "base",
     name: "debug_parse_results",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: denyAll,
+    viewRule: denyAll,
+    createRule: denyAll,
+    updateRule: denyAll,
+    deleteRule: denyAll,
     fields: [
       {
         type: "relation",

--- a/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
+++ b/pocketbase/pb_migrations/1500000075_rbac_tier2_rules.js
@@ -51,6 +51,8 @@
  * Note: staff_skills trimmed — final adminOnly rules baked into
  * merged CREATE migration #042. tier2[] is now empty; only tier3
  * (debug_parse_results, solver_runs) remains in this file.
+ * Note: debug_parse_results trimmed — final denyAll ('') rules baked into
+ * merged CREATE migration #027.
  */
 
 migrate((app) => {
@@ -74,7 +76,7 @@ migrate((app) => {
   }
 
   // Tier 3: Deny direct access (FastAPI-only via admin auth)
-  const tier3 = ["debug_parse_results", "solver_runs"]
+  const tier3 = ["solver_runs"]
 
   for (const name of tier3) {
     setRules(name, '', '', '', '', '')
@@ -95,7 +97,7 @@ migrate((app) => {
   }
 
   const all = [
-    "debug_parse_results", "solver_runs"
+    "solver_runs"
   ]
 
   for (const name of all) {


### PR DESCRIPTION
## Summary
**First tier3 trim.** After this PR, `#1500000075`'s `tier3[]` has only `["solver_runs"]`.

- Trim-only round folding final denyAll (`''`) rules into base `#1500000027` (CREATE).
- Trimmed 1 multi-table file (`#1500000075 rbac_tier2_rules`): removed `debug_parse_results` from `tier3[]` (up) and `all[]` (down).
- Baked rules into merged CREATE via extracted `denyAll = ''` constant (parallel to the `adminOnly` pattern used in the 13 prior tier2 rounds).
- Net delta: **0 files** (rule edits only — no migrations deleted).
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match.

### Different from tier2 rounds
Tier3 collections are deny-all (FastAPI-only access via admin endpoints), not adminOnly. They use `''` (empty string) for all 5 rules instead of `'@request.auth.is_admin = true'`. The harness confirms baking `''` at create-time produces an identical stored rule to `setRules(name, '', '', '', '', '')` post-create.

Final state of `debug_parse_results`:
- All fields and indexes unchanged
- Rules: all 5 = `''` (deny all)

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated access control rules for system collections to enforce stricter permissions on sensitive debug data and restrict unauthorized access.
  * Reorganized security policies to streamline permission management across services and strengthen system protection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1357)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->