### PR TITLE
refactor(pb): consolidate locked_groups migrations (round 1, trim-only)

### DIFF
--- a/pocketbase/pb_migrations/1500000024_locked_groups.js
+++ b/pocketbase/pb_migrations/1500000024_locked_groups.js
@@ -11,6 +11,8 @@
  */
 
 migrate((app) => {
+  const bunkingManage = '@request.auth.is_admin = true || @request.auth.cached_permissions ~ "bunking.manage"'
+
   // Dynamic lookups - these collections were created in earlier migrations
   const scenariosCol = app.findCollectionByNameOrId("saved_scenarios")
   const sessionsCol = app.findCollectionByNameOrId("camp_sessions")
@@ -19,11 +21,11 @@ migrate((app) => {
     id: "col_locked_groups",
     type: "base",
     name: "locked_groups",
-    listRule: '@request.auth.id != ""',
-    viewRule: '@request.auth.id != ""',
-    createRule: '@request.auth.id != ""',
-    updateRule: '@request.auth.id != ""',
-    deleteRule: '@request.auth.id != ""',
+    listRule: bunkingManage,
+    viewRule: bunkingManage,
+    createRule: bunkingManage,
+    updateRule: bunkingManage,
+    deleteRule: bunkingManage,
     fields: [
       {
         type: "relation",

--- a/pocketbase/pb_migrations/1500000074_rbac_tier1_rules.js
+++ b/pocketbase/pb_migrations/1500000074_rbac_tier1_rules.js
@@ -52,8 +52,8 @@ migrate((app) => {
   }
 
   // Read+Write: bunking.manage (frontend writes directly)
-  // Note: "bunk_assignments_draft", "locked_group_members" trimmed — all 5 rules use bunkingManage, baked into merged CREATE.
-  const bunkingManageReadWrite = ["locked_groups", "saved_scenarios"]
+  // Note: "bunk_assignments_draft", "locked_group_members", "locked_groups" trimmed — all 5 rules use bunkingManage, baked into merged CREATE.
+  const bunkingManageReadWrite = ["saved_scenarios"]
   for (const name of bunkingManageReadWrite) {
     setRules(name, bunkingManage, bunkingManage, bunkingManage, bunkingManage, bunkingManage)
   }
@@ -80,7 +80,7 @@ migrate((app) => {
   }
 
   const collections = [
-    "locked_groups", "saved_scenarios"
+    "saved_scenarios"
   ]
   for (const name of collections) {
     revertRules(name)


### PR DESCRIPTION
## Summary
- Trim-only round: removes `"locked_groups"` from `#1500000074`'s `bunkingManageReadWrite` array (both up and down).
- Bakes the final-state `bunkingManage` rule into all 5 rules of base `#1500000024` (`'@request.auth.is_admin = true || @request.auth.cached_permissions ~ "bunking.manage"'`).
- Net delta: **0 files** in `pocketbase/pb_migrations/`. `#074` still retains `"saved_scenarios"` until that round runs.
- Verified empirically by `scripts/dev/verify-consolidation.sh`: schemas match between proposed (modified #024 + trimmed #074) and current (untrimmed chain).

Trimmed:
- `#1500000074 rbac_tier1_rules` — `bunkingManageReadWrite` now `["saved_scenarios"]`; revert-side `collections` array now `["saved_scenarios"]`. File remains.

Final state of `locked_groups`: 8 fields, 3 indexes, all 5 rules = `bunkingManage`.

## Test plan
- [x] Local schema-diff harness passes (`schemas match`)
- [ ] CI green
- [ ] After merge, prod boot's OnServe `migrate history-sync` hook is a no-op (no file deletions this round)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized access control configuration for management operations and resource collections.
  * Refined permission rules to improve authorization handling and ensure proper access enforcement across system functions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1358)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->