### PR TITLE
ci(security): replace trivy curl-pipe-sh with setup-trivy action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -618,12 +618,20 @@ jobs:
     # Consolidated: scans all 4 images in one step instead of 8 separate action invocations.
     # Generates SARIF reports (HIGH+CRITICAL) and blocks on CRITICAL vulnerabilities.
     # Trivy DB is downloaded once and reused across all scans.
+    # Replaces a previous `curl | sudo sh` against raw.githubusercontent.com so
+    # we can drop that endpoint from the harden-runner allowlist. setup-trivy
+    # checks out the install script from a pinned commit of aquasecurity/trivy
+    # rather than the floating `main` branch.
+    - name: Install Trivy
+      if: steps.check.outputs.build == 'true'
+      uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
+      with:
+        version: v0.69.3
+
     - name: Scan all images with Trivy
       id: trivy-scan
       if: steps.check.outputs.build == 'true'
       run: |
-        # Install Trivy CLI
-        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.69.3
         trivy version
 
         IMAGES=("kindred-caddy" "kindred-pocketbase" "kindred-api" "kindred-init")

--- a/docker/Dockerfile.caddy
+++ b/docker/Dockerfile.caddy
@@ -1,5 +1,6 @@
 # =============================================================================
 # Stage 1: Frontend build
+# (no-op touch to trigger CD build-test-push for PR #1359; revert before merge)
 # =============================================================================
 FROM node:22-slim AS frontend-builder
 

--- a/docker/Dockerfile.caddy
+++ b/docker/Dockerfile.caddy
@@ -1,6 +1,5 @@
 # =============================================================================
 # Stage 1: Frontend build
-# (no-op touch to trigger CD build-test-push for PR #1359; revert before merge)
 # =============================================================================
 FROM node:22-slim AS frontend-builder
 


### PR DESCRIPTION
## Summary

- Replaces `curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh` in `cd.yml` with `aquasecurity/setup-trivy@v0.2.6` (SHA-pinned to `3fb12ec1`).
- Drops `raw.githubusercontent.com` from the runtime egress footprint of the `build-test-push` job — shrinks the allowlist we will need when flipping harden-runner from `audit` to `block` mode.
- `setup-trivy` clones the install script from a commit-pinned ref of `aquasecurity/trivy` rather than the floating `main` branch, which is also a supply-chain improvement on its own.

## Why this matters

`raw.githubusercontent.com` is the trickiest endpoint to enforce because harden-runner can only filter by domain, not by repo. Allowlisting it would let any compromised workflow step pull arbitrary scripts from any public GitHub repo. Removing the only consumer of that endpoint means we can leave it out of the allowlist entirely in the follow-up enforce-mode PR.

## What still needs `*.githubusercontent.com` in the allowlist

| Endpoint | Used for | Notes |
|---|---|---|
| `pkg-containers.githubusercontent.com` | GHCR registry backing storage | Required for every `ghcr.io` push/pull |
| `release-assets.githubusercontent.com` | GitHub Release asset downloads (Trivy binary, harden-runner agent) | Required |
| `results-receiver.actions.githubusercontent.com` | Actions runtime telemetry | Required |
| ~~`raw.githubusercontent.com`~~ | ~~Trivy install script (curl-pipe-sh)~~ | **Removed by this PR** |

## Test plan

- [ ] CI Summary passes
- [ ] The new `Install Trivy` step succeeds on the first push that triggers `build-test-push` (paths-filter on Dockerfiles/source — may need a CD-relevant change to validate)
- [ ] The existing `Scan all images with Trivy` step still produces SARIF reports for all 4 images
- [ ] After merge, confirm `raw.githubusercontent.com` no longer appears in the harden-runner audit endpoints for the next CD run on `main`

## Follow-ups (not in this PR)

- After 1–2 weeks of audit data accumulates with `raw.githubusercontent.com` absent, flip `cd.yml` to `egress-policy: block` with the tightened allowlist.
- Flip `release.yml` separately after a couple more release runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Trivy installation in the CD workflow to use the official setup action (pinned version) for more reliable, consistent installs; security scanning and gating remain unchanged.
  * Added a temporary placeholder comment to trigger a CI build for a specific PR; intended to be reverted before merge.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1359)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->