### PR TITLE
feat(solver,frontend): solver debug PR2 — data fixes (drop request_data, session relation, split outcome group)

### DIFF
--- a/api/routers/solver.py
+++ b/api/routers/solver.py
@@ -249,10 +249,11 @@ async def post_run_sweep(
     # remount, and PB had no rows until completion).
     created_pb_ids: list[str] = []
     try:
+        session_relation_id = await resolve_session_relation(pb, session_cm_id, year)
         for run_id, budget in zip(run_ids, request.time_budgets, strict=True):
             pb_data: dict[str, Any] = {
                 "run_id": run_id,
-                "session": await resolve_session_relation(pb, session_cm_id, year),
+                "session": session_relation_id,
                 "session_id": session_cm_id,
                 "year": year,
                 "status": "pending",

--- a/api/routers/solver.py
+++ b/api/routers/solver.py
@@ -49,7 +49,7 @@ from ..schemas import (
 )
 from ..schemas.solver import SweepRequest, SweepResponse
 from ..services.session_context import build_session_context
-from ..services.solver_runner import run_solver_task_v2
+from ..services.solver_runner import resolve_session_relation, run_solver_task_v2
 from ..services.sweep_input_snapshot import snapshot_session_input
 from ..services.sweep_registry import sweep_registry
 from ..services.sweep_runner import run_sweep
@@ -252,7 +252,7 @@ async def post_run_sweep(
         for run_id, budget in zip(run_ids, request.time_budgets, strict=True):
             pb_data: dict[str, Any] = {
                 "run_id": run_id,
-                "session": str(session_cm_id),
+                "session": await resolve_session_relation(pb, session_cm_id, year),
                 "session_id": session_cm_id,
                 "year": year,
                 "status": "pending",

--- a/api/services/solver_runner.py
+++ b/api/services/solver_runner.py
@@ -67,6 +67,26 @@ async def _persist_run_record(
     return await asyncio.to_thread(task_pb.collection(SOLVER_RUNS).create, payload)
 
 
+async def resolve_session_relation(pb: PocketBase, session_cm_id: int, year: int) -> str | None:
+    """Look up the camp_sessions PB id for a (cm_id, year) pair.
+
+    Returns the PB record id if a matching row exists, else None.
+    A 404 means no match — non-fatal; callers store NULL relation and
+    the row still records via session_id numeric + details.source_label.
+    Non-404 errors propagate so writes don't silently drop real failures.
+    """
+    try:
+        rec = await asyncio.to_thread(
+            pb.collection("camp_sessions").get_first_list_item,
+            f"cm_id = {int(session_cm_id)} && year = {int(year)}",
+        )
+    except ClientResponseError as e:
+        if e.status == 404:
+            return None
+        raise
+    return str(rec.id)
+
+
 async def run_solver_task_v2(
     run_id: str,
     session_cm_id: int,
@@ -287,7 +307,7 @@ async def run_solver_task_v2(
         try:
             pb_data: dict[str, Any] = {
                 "run_id": run_id,
-                "session": str(session_cm_id),
+                "session": await resolve_session_relation(task_pb, session_cm_id, year),
                 "session_id": session_cm_id,
                 "year": year,
                 "status": "success",
@@ -324,7 +344,7 @@ async def run_solver_task_v2(
         try:
             failure_payload = {
                 "run_id": run_id,
-                "session": str(session_cm_id),
+                "session": await resolve_session_relation(task_pb, session_cm_id, year),
                 "session_id": session_cm_id,
                 "year": year,
                 "status": "failed",

--- a/api/services/solver_runner.py
+++ b/api/services/solver_runner.py
@@ -19,7 +19,7 @@ from bunking.direct_solver import DirectBunkingSolver
 from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
-from ..constants.collections import SOLVER_RUNS, SUPERUSERS
+from ..constants.collections import CAMP_SESSIONS, SOLVER_RUNS, SUPERUSERS
 from ..dependencies import pb_url, solver_runs
 from ..settings import get_settings
 from .data_fetcher import (
@@ -77,7 +77,7 @@ async def resolve_session_relation(pb: PocketBase, session_cm_id: int, year: int
     """
     try:
         rec = await asyncio.to_thread(
-            pb.collection("camp_sessions").get_first_list_item,
+            pb.collection(CAMP_SESSIONS).get_first_list_item,
             f"cm_id = {int(session_cm_id)} && year = {int(year)}",
         )
     except ClientResponseError as e:

--- a/api/services/solver_runner.py
+++ b/api/services/solver_runner.py
@@ -342,9 +342,13 @@ async def run_solver_task_v2(
         # sweep children group correctly with their successful siblings in
         # the impact-analysis UI rather than appearing as orphans.
         try:
+            try:
+                failure_session_relation = await resolve_session_relation(task_pb, session_cm_id, year)
+            except Exception:
+                failure_session_relation = None
             failure_payload = {
                 "run_id": run_id,
-                "session": await resolve_session_relation(task_pb, session_cm_id, year),
+                "session": failure_session_relation,
                 "session_id": session_cm_id,
                 "year": year,
                 "status": "failed",

--- a/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.test.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.test.tsx
@@ -91,20 +91,25 @@ describe('DrillDownDrawer', () => {
 })
 
 describe('Registry-driven group rendering (PR1)', () => {
-  it('renders Outcome group when run has request_validation data', () => {
+  it('renders Outcome (requests) and Outcome (campers) section headers when run has both', () => {
     const outcomeRun: SolverRun = {
-      ...run,
+      id: 'r1',
+      run_id: 'r1',
+      status: 'success',
+      created: '2026-05-12T12:00:00Z',
       stats: {
-        ...(run.stats ?? {}),
         request_validation: {
-          mp_requests_satisfied: 80,
-          mp_requests_total: 100,
+          mp_requests_satisfied: 40,
+          mp_requests_total: 50,
+          mp_campers_satisfied: 17,
+          mp_campers_total: 20,
         },
       },
+      details: {},
     }
     render(<DrillDownDrawer run={outcomeRun} onClose={vi.fn()} />)
-    expect(screen.getByText('Outcome')).toBeInTheDocument()
-    expect(screen.getByText('Optimized (MP req)')).toBeInTheDocument()
+    expect(screen.getByText(/Outcome \(requests\)/i)).toBeInTheDocument()
+    expect(screen.getByText(/Outcome \(campers\)/i)).toBeInTheDocument()
   })
 
   it('renders Solution strategy row when solution_info is set', () => {

--- a/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.test.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.test.tsx
@@ -108,8 +108,13 @@ describe('Registry-driven group rendering (PR1)', () => {
       details: {},
     }
     render(<DrillDownDrawer run={outcomeRun} onClose={vi.fn()} />)
-    expect(screen.getByText(/Outcome \(requests\)/i)).toBeInTheDocument()
-    expect(screen.getByText(/Outcome \(campers\)/i)).toBeInTheDocument()
+    const reqHeader = screen.getByText(/Outcome \(requests\)/i)
+    const camperHeader = screen.getByText(/Outcome \(campers\)/i)
+    expect(reqHeader).toBeInTheDocument()
+    expect(camperHeader).toBeInTheDocument()
+    expect(
+      reqHeader.compareDocumentPosition(camperHeader) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
   })
 
   it('renders Solution strategy row when solution_info is set', () => {

--- a/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.tsx
@@ -9,7 +9,8 @@ import { pickStat } from './pickStat'
 import type { SolverRun } from '../../../hooks/useSolverRuns'
 
 const GROUP_LABELS: Record<MetricGroup, string> = {
-  outcome: 'Outcome',
+  outcome_requests: 'Outcome (requests)',
+  outcome_campers: 'Outcome (campers)',
   size: 'Size',
   timing: 'Timing',
   quality: 'Quality',
@@ -20,7 +21,8 @@ const GROUP_LABELS: Record<MetricGroup, string> = {
 }
 
 const GROUP_ORDER: MetricGroup[] = [
-  'outcome',
+  'outcome_requests',
+  'outcome_campers',
   'size',
   'timing',
   'quality',

--- a/frontend/src/pages/summer/SolverDebugPage/PinnedComparisonPanel.test.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/PinnedComparisonPanel.test.tsx
@@ -122,6 +122,41 @@ describe('PinnedComparisonPanel', () => {
     expect(screen.getByText(/^Model$/i)).toBeInTheDocument()
   })
 
+  it('renders Outcome (requests) and Outcome (campers) section headers in that order', () => {
+    const aOut: SolverRun = {
+      ...a,
+      stats: {
+        ...a.stats,
+        request_validation: {
+          mp_requests_satisfied: 85,
+          mp_requests_total: 100,
+          mp_campers_satisfied: 18,
+          mp_campers_total: 20,
+        },
+      },
+    }
+    const bOut: SolverRun = {
+      ...b,
+      stats: {
+        ...b.stats,
+        request_validation: {
+          mp_requests_satisfied: 92,
+          mp_requests_total: 100,
+          mp_campers_satisfied: 19,
+          mp_campers_total: 20,
+        },
+      },
+    }
+    render(<PinnedComparisonPanel runA={aOut} runB={bOut} onClear={vi.fn()} />)
+    const reqHeader = screen.getByText(/Outcome \(requests\)/i)
+    const camperHeader = screen.getByText(/Outcome \(campers\)/i)
+    expect(reqHeader).toBeInTheDocument()
+    expect(camperHeader).toBeInTheDocument()
+    expect(
+      reqHeader.compareDocumentPosition(camperHeader) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
   it('renders constraint-type sub-rows indented under model constraints (#mockup-parity)', () => {
     const statsWithBreakdown = {
       walltime_seconds: 10,

--- a/frontend/src/pages/summer/SolverDebugPage/PinnedComparisonPanel.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/PinnedComparisonPanel.tsx
@@ -85,7 +85,8 @@ function effectiveInterpretation(
 }
 
 const GROUP_LABELS: Record<MetricGroup, string> = {
-  outcome: 'Outcome',
+  outcome_requests: 'Outcome (requests)',
+  outcome_campers: 'Outcome (campers)',
   size: 'Size',
   timing: 'Timing',
   quality: 'Quality',
@@ -96,11 +97,12 @@ const GROUP_LABELS: Record<MetricGroup, string> = {
 }
 
 const GROUP_ORDER: MetricGroup[] = [
-  'outcome',
-  'size',
-  'timing',
+  'outcome_requests',
+  'outcome_campers',
   'quality',
   'churn',
+  'timing',
+  'size',
   'search',
   'model',
 ]
@@ -114,7 +116,8 @@ export function PinnedComparisonPanel({ runA, runB, onClear }: Props) {
 
   // Group metrics by their `group` field, preserving COMPARABLE_METRICS order within each group
   const byGroup: Record<MetricGroup, string[]> = {
-    outcome: [],
+    outcome_requests: [],
+    outcome_campers: [],
     size: [],
     timing: [],
     quality: [],

--- a/frontend/src/pages/summer/SolverDebugPage/metricRegistry.test.ts
+++ b/frontend/src/pages/summer/SolverDebugPage/metricRegistry.test.ts
@@ -16,7 +16,8 @@ describe('METRIC_REGISTRY', () => {
         'search',
         'model',
         'context',
-        'outcome',
+        'outcome_requests',
+        'outcome_campers',
         'size',
         'churn',
       ]).toContain(m.group)
@@ -172,8 +173,38 @@ describe('HighlightRule discriminated union (PR1)', () => {
 })
 
 describe('MetricGroup type accepts outcome/size/churn', () => {
-  it('mp_request_rate is in outcome group', () => {
-    expect(getMetric('mp_request_rate').group).toBe('outcome')
+  it('mp_request_rate is in outcome_requests group', () => {
+    expect(getMetric('mp_request_rate').group).toBe('outcome_requests')
+  })
+
+  it('partitions outcome metrics by accounting unit', () => {
+    const expectedRequests = [
+      'mp_request_rate',
+      'all_request_rate',
+      'mp_requests_satisfied',
+      'mp_requests_total',
+      'satisfied_request_count',
+      'total_requests',
+      'impossible_requests',
+    ]
+    const expectedCampers = [
+      'mp_camper_rate',
+      'all_camper_rate',
+      'mp_campers_satisfied',
+      'mp_campers_total',
+      'all_campers_satisfied',
+      'all_campers_total',
+      'affected_campers',
+      'unsatisfied_no_possible',
+      'unsatisfied_material_parent_unmet',
+      'unsatisfied_other_unmet',
+    ]
+    for (const k of expectedRequests) {
+      expect(getMetric(k).group).toBe('outcome_requests')
+    }
+    for (const k of expectedCampers) {
+      expect(getMetric(k).group).toBe('outcome_campers')
+    }
   })
 
   it('total_persons is in size group', () => {

--- a/frontend/src/pages/summer/SolverDebugPage/metricRegistry.test.ts
+++ b/frontend/src/pages/summer/SolverDebugPage/metricRegistry.test.ts
@@ -172,7 +172,7 @@ describe('HighlightRule discriminated union (PR1)', () => {
   })
 })
 
-describe('MetricGroup type accepts outcome/size/churn', () => {
+describe('MetricGroup type accepts outcome_requests/outcome_campers/size/churn', () => {
   it('mp_request_rate is in outcome_requests group', () => {
     expect(getMetric('mp_request_rate').group).toBe('outcome_requests')
   })

--- a/frontend/src/pages/summer/SolverDebugPage/metricRegistry.ts
+++ b/frontend/src/pages/summer/SolverDebugPage/metricRegistry.ts
@@ -6,7 +6,8 @@ export type MetricGroup =
   | 'search'
   | 'model'
   | 'context'
-  | 'outcome'
+  | 'outcome_requests'
+  | 'outcome_campers'
   | 'size'
   | 'churn'
 
@@ -174,7 +175,7 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
       'Material-parent requests honored / MP requests total. 100% is the ideal outcome — every parent priority request satisfied.',
     interpretation: 'higher-better',
     format: 'percent',
-    group: 'outcome',
+    group: 'outcome_requests',
   },
   mp_camper_rate: {
     key: 'mp_camper_rate',
@@ -183,7 +184,7 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
       'Campers with ≥1 MP request satisfied / Campers with ≥1 MP request. 100% means every camper with a parent priority got at least one MP request honored.',
     interpretation: 'higher-better',
     format: 'percent',
-    group: 'outcome',
+    group: 'outcome_campers',
   },
   all_request_rate: {
     key: 'all_request_rate',
@@ -191,7 +192,7 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
     description: 'All requests honored / all requests total, across every source bucket.',
     interpretation: 'higher-better',
     format: 'percent',
-    group: 'outcome',
+    group: 'outcome_requests',
   },
   all_camper_rate: {
     key: 'all_camper_rate',
@@ -199,7 +200,7 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
     description: 'Campers with ≥1 any-source request satisfied / campers with ≥1 request.',
     interpretation: 'higher-better',
     format: 'percent',
-    group: 'outcome',
+    group: 'outcome_campers',
   },
   mp_requests_satisfied: {
     key: 'mp_requests_satisfied',
@@ -207,7 +208,7 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
     description: 'Number of material-parent requests the solver honored.',
     interpretation: 'higher-better',
     format: 'integer',
-    group: 'outcome',
+    group: 'outcome_requests',
     parent: 'mp_request_rate',
   },
   mp_requests_total: {
@@ -216,7 +217,7 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
     description: 'Total resolved material-parent requests in scope this run.',
     interpretation: 'context',
     format: 'integer',
-    group: 'outcome',
+    group: 'outcome_requests',
     parent: 'mp_request_rate',
   },
   mp_campers_satisfied: {
@@ -225,7 +226,7 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
     description: 'Campers with ≥1 material-parent request satisfied.',
     interpretation: 'higher-better',
     format: 'integer',
-    group: 'outcome',
+    group: 'outcome_campers',
     parent: 'mp_camper_rate',
   },
   mp_campers_total: {
@@ -234,7 +235,7 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
     description: 'Campers with ≥1 resolved material-parent request.',
     interpretation: 'context',
     format: 'integer',
-    group: 'outcome',
+    group: 'outcome_campers',
     parent: 'mp_camper_rate',
   },
   all_campers_satisfied: {
@@ -243,7 +244,7 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
     description: 'Campers with ≥1 request of any source satisfied.',
     interpretation: 'higher-better',
     format: 'integer',
-    group: 'outcome',
+    group: 'outcome_campers',
     parent: 'all_camper_rate',
   },
   all_campers_total: {
@@ -252,7 +253,7 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
     description: 'Campers with ≥1 resolved request of any source.',
     interpretation: 'context',
     format: 'integer',
-    group: 'outcome',
+    group: 'outcome_campers',
     parent: 'all_camper_rate',
   },
   satisfied_request_count: {
@@ -261,7 +262,7 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
     description: 'Total requests honored across all sources.',
     interpretation: 'higher-better',
     format: 'integer',
-    group: 'outcome',
+    group: 'outcome_requests',
     parent: 'all_request_rate',
   },
   total_requests: {
@@ -270,7 +271,7 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
     description: 'Total resolved requests in scope this run, across all sources.',
     interpretation: 'context',
     format: 'integer',
-    group: 'outcome',
+    group: 'outcome_requests',
     parent: 'all_request_rate',
   },
   impossible_requests: {
@@ -280,7 +281,7 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
       'Requests that can never be satisfied (cross-session, requestee absent, etc.). Floor on unsatisfiability.',
     interpretation: 'context',
     format: 'integer',
-    group: 'outcome',
+    group: 'outcome_requests',
   },
   affected_campers: {
     key: 'affected_campers',
@@ -288,7 +289,7 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
     description: 'Campers with ≥1 impossible request — blast radius of the impossibility floor.',
     interpretation: 'context',
     format: 'integer',
-    group: 'outcome',
+    group: 'outcome_campers',
     parent: 'impossible_requests',
   },
   unsatisfied_no_possible: {
@@ -298,7 +299,7 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
       'Campers with only impossible requests. Should equal affected_campers; divergence is a bug signal.',
     interpretation: 'context',
     format: 'integer',
-    group: 'outcome',
+    group: 'outcome_campers',
     parent: 'impossible_requests',
     highlight: { mode: 'diverges-from', from: 'affected_campers' },
   },
@@ -309,7 +310,7 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
       'Campers who got zero requests satisfied AND had ≥1 possible MP request. The worst-case parent-priority failures.',
     interpretation: 'lower-better',
     format: 'integer',
-    group: 'outcome',
+    group: 'outcome_campers',
   },
   unsatisfied_other_unmet: {
     key: 'unsatisfied_other_unmet',
@@ -318,7 +319,7 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
       'Campers who got zero requests satisfied AND had only non-MP possible requests (STAFF / IMMATERIAL_PARENT).',
     interpretation: 'lower-better',
     format: 'integer',
-    group: 'outcome',
+    group: 'outcome_campers',
   },
   total_persons: {
     key: 'total_persons',
@@ -383,7 +384,8 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
 /** Group metrics by their `group` field, preserving insertion order from METRIC_REGISTRY. */
 export const METRIC_REGISTRY_BY_GROUP: Record<MetricGroup, MetricMeta[]> = (() => {
   const groups: Record<MetricGroup, MetricMeta[]> = {
-    outcome: [],
+    outcome_requests: [],
+    outcome_campers: [],
     size: [],
     timing: [],
     quality: [],

--- a/frontend/src/pages/summer/SolverDebugPage/metricRegistry.ts
+++ b/frontend/src/pages/summer/SolverDebugPage/metricRegistry.ts
@@ -402,20 +402,21 @@ export const METRIC_REGISTRY_BY_GROUP: Record<MetricGroup, MetricMeta[]> = (() =
 
 /** Subset rendered in pin-to-compare delta panel (numeric, comparable). */
 export const COMPARABLE_METRICS: readonly string[] = [
-  // outcome (PR1)
+  // outcome — requests (PR1)
   'mp_request_rate',
-  'mp_camper_rate',
+  'all_request_rate',
   'mp_requests_satisfied',
   'mp_requests_total',
-  'mp_campers_satisfied',
-  'mp_campers_total',
-  'all_request_rate',
-  'all_camper_rate',
   'satisfied_request_count',
   'total_requests',
+  'impossible_requests',
+  // outcome — campers (PR1)
+  'mp_camper_rate',
+  'all_camper_rate',
+  'mp_campers_satisfied',
+  'mp_campers_total',
   'all_campers_satisfied',
   'all_campers_total',
-  'impossible_requests',
   'affected_campers',
   'unsatisfied_no_possible',
   'unsatisfied_material_parent_unmet',

--- a/frontend/src/types/pocketbase-types.ts
+++ b/frontend/src/types/pocketbase-types.ts
@@ -1172,6 +1172,7 @@ export const SolverRunsStatusOptions = {
   success: 'success',
   failed: 'failed',
   error: 'error',
+  cancelled: 'cancelled',
 } as const
 export type SolverRunsStatusOptions =
   (typeof SolverRunsStatusOptions)[keyof typeof SolverRunsStatusOptions]
@@ -1180,7 +1181,6 @@ export type SolverRunsRecord<
   Tdetails = unknown,
   Terror = unknown,
   Tlogs = unknown,
-  Trequest_data = unknown,
   Tresult = unknown,
   Tstats = unknown,
 > = {
@@ -1192,18 +1192,18 @@ export type SolverRunsRecord<
   id: string
   logs?: null | Tlogs
   progress?: number
-  request_data?: null | Trequest_data
   result?: null | Tresult
   run_id: string
   run_type?: string
   scenario?: RecordIdString
-  session: string
+  session?: RecordIdString
   session_id?: number
   started_at?: IsoDateString
   stats?: null | Tstats
   status?: SolverRunsStatusOptions
   triggered_by?: string
   updated: IsoAutoDateString
+  year: number
 }
 
 export const StaffStatusOptions = {
@@ -1514,13 +1514,10 @@ export type SolverRunsResponse<
   Tdetails = unknown,
   Terror = unknown,
   Tlogs = unknown,
-  Trequest_data = unknown,
   Tresult = unknown,
   Tstats = unknown,
   Texpand = unknown,
-> = Required<
-  SolverRunsRecord<Tassignment_counts, Tdetails, Terror, Tlogs, Trequest_data, Tresult, Tstats>
-> &
+> = Required<SolverRunsRecord<Tassignment_counts, Tdetails, Terror, Tlogs, Tresult, Tstats>> &
   BaseSystemFields<Texpand>
 export type StaffResponse<Texpand = unknown> = Required<StaffRecord> & BaseSystemFields<Texpand>
 export type StaffApplicationsResponse<Texpand = unknown> = Required<StaffApplicationsRecord> &

--- a/pocketbase/pb_migrations/1500000095_solver_runs_schema_cleanup.js
+++ b/pocketbase/pb_migrations/1500000095_solver_runs_schema_cleanup.js
@@ -1,0 +1,68 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: Drop `request_data`; promote `session` to a relation.
+ *
+ * PR2 of the 3-PR solver-debug-dashboard sequence (see PR1: #1343).
+ *
+ * (1) DROP `request_data` (JSON, added in 1500000023). No code path
+ *     writes to it; NULL on every row. Removing prevents future drift
+ *     between schema and writer.
+ *
+ * (2) DROP + RECREATE `session` as relation -> sessions. The old text
+ *     column held str(cm_id) for joinability via `session_id`. The new
+ *     relation enables `expand=session` for future debug surfaces.
+ *     PB v0.23 can't alter text -> relation in place; drop+add is the
+ *     working pattern.
+ *
+ *     NO BACKFILL of historical rows -- they get session = NULL.
+ *     Debug page reads `session_id` numeric + `details.source_label`,
+ *     neither of which depend on the relation. New writers (api/services/
+ *     solver_runner.py + api/routers/solver.py) resolve the relation
+ *     on every new run.
+ */
+
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("solver_runs")
+  const sessionsCol = app.findCollectionByNameOrId("camp_sessions")
+
+  // (1) Drop request_data
+  collection.fields.removeByName("request_data")
+
+  // (2) Drop + recreate session as relation
+  collection.fields.removeByName("session")
+  collection.fields.add(new Field({
+    type: "relation",
+    name: "session",
+    required: false,
+    presentable: false,
+    collectionId: sessionsCol.id,
+    cascadeDelete: false,
+    minSelect: null,
+    maxSelect: 1,
+  }))
+
+  app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("solver_runs")
+
+  // Down: restore session as required text + request_data as json
+  collection.fields.removeByName("session")
+  collection.fields.add(new Field({
+    type: "text",
+    name: "session",
+    required: true,
+    presentable: false,
+    min: null,
+    max: null,
+    pattern: "",
+  }))
+  collection.fields.add(new Field({
+    type: "json",
+    name: "request_data",
+    required: false,
+    presentable: false,
+    maxSize: 2000000,
+  }))
+
+  app.save(collection)
+})

--- a/tests/unit/api/services/test_solver_runner_session_relation.py
+++ b/tests/unit/api/services/test_solver_runner_session_relation.py
@@ -1,0 +1,56 @@
+"""Test resolve_session_relation: cm_id+year -> camp_sessions PB id or None."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from api.services.solver_runner import resolve_session_relation
+
+
+@pytest.mark.asyncio
+async def test_returns_pb_id_when_session_exists():
+    """Happy path: cm_id matches a camp_sessions row in the given year."""
+    pb = MagicMock()
+    fake_session = MagicMock()
+    fake_session.id = "sessions_pb_id_abc"
+    pb.collection.return_value.get_first_list_item = MagicMock(return_value=fake_session)
+
+    result = await resolve_session_relation(pb, session_cm_id=1235404, year=2026)
+
+    assert result == "sessions_pb_id_abc"
+    pb.collection.assert_called_with("camp_sessions")
+    pb.collection.return_value.get_first_list_item.assert_called_once()
+    filter_arg = pb.collection.return_value.get_first_list_item.call_args[0][0]
+    assert "cm_id = 1235404" in filter_arg
+    assert "year = 2026" in filter_arg
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_no_match():
+    """Orphan path: no camp_sessions row for that cm_id+year -> None, no raise."""
+    from pocketbase.errors import ClientResponseError
+
+    pb = MagicMock()
+    pb.collection.return_value.get_first_list_item = MagicMock(
+        side_effect=ClientResponseError(url="x", status=404, data={})
+    )
+
+    result = await resolve_session_relation(pb, session_cm_id=9999999, year=2026)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_propagates_non_404_errors():
+    """Transient errors (500/503/timeout) re-raise so callers know writes are at risk."""
+    from pocketbase.errors import ClientResponseError
+
+    pb = MagicMock()
+    pb.collection.return_value.get_first_list_item = MagicMock(
+        side_effect=ClientResponseError(url="x", status=503, data={})
+    )
+
+    with pytest.raises(ClientResponseError):
+        await resolve_session_relation(pb, session_cm_id=1235404, year=2026)

--- a/tests/unit/api/services/test_solver_runner_session_relation.py
+++ b/tests/unit/api/services/test_solver_runner_session_relation.py
@@ -17,13 +17,13 @@ async def test_returns_pb_id_when_session_exists():
     fake_session.id = "sessions_pb_id_abc"
     pb.collection.return_value.get_first_list_item = MagicMock(return_value=fake_session)
 
-    result = await resolve_session_relation(pb, session_cm_id=1235404, year=2026)
+    result = await resolve_session_relation(pb, session_cm_id=1000001, year=2026)
 
     assert result == "sessions_pb_id_abc"
     pb.collection.assert_called_with("camp_sessions")
     pb.collection.return_value.get_first_list_item.assert_called_once()
     filter_arg = pb.collection.return_value.get_first_list_item.call_args[0][0]
-    assert "cm_id = 1235404" in filter_arg
+    assert "cm_id = 1000001" in filter_arg
     assert "year = 2026" in filter_arg
 
 
@@ -37,7 +37,7 @@ async def test_returns_none_when_no_match():
         side_effect=ClientResponseError(url="x", status=404, data={})
     )
 
-    result = await resolve_session_relation(pb, session_cm_id=9999999, year=2026)
+    result = await resolve_session_relation(pb, session_cm_id=1000002, year=2026)
 
     assert result is None
 
@@ -53,4 +53,4 @@ async def test_propagates_non_404_errors():
     )
 
     with pytest.raises(ClientResponseError):
-        await resolve_session_relation(pb, session_cm_id=1235404, year=2026)
+        await resolve_session_relation(pb, session_cm_id=1000001, year=2026)

--- a/tests/unit/api/test_solver_runner_pb_save.py
+++ b/tests/unit/api/test_solver_runner_pb_save.py
@@ -119,7 +119,7 @@ class TestSolverRunnerPocketBaseSave:
 
     @pytest.mark.asyncio
     async def test_success_path_sends_session_field(self, mock_solver_input):
-        """Schema field is 'session' (text), not 'session_cm_id'."""
+        """Schema field is 'session' (relation to camp_sessions), not 'session_cm_id'."""
         patches, mock_runs = self._setup_mocks(mock_solver_input)
 
         with (
@@ -144,6 +144,10 @@ class TestSolverRunnerPocketBaseSave:
                 "get_settings": m8,
             }
             mock_pb = self._configure_mocks(mocks, mock_solver_input)
+            # Wire a known PB id so resolve_session_relation returns it
+            fake_session = MagicMock()
+            fake_session.id = "camp_sessions_pb_id_xyz"
+            mock_pb.collection.return_value.get_first_list_item.return_value = fake_session
             mock_runs["test_run"] = {"status": "pending"}
 
             await sr_module.run_solver_task_v2(
@@ -156,7 +160,8 @@ class TestSolverRunnerPocketBaseSave:
             pb_data = mock_pb.collection.return_value.create.call_args_list[0][0][0]
             assert "session" in pb_data
             assert "session_cm_id" not in pb_data
-            assert pb_data["session"] == "100"
+            # session is now a PB relation id resolved from camp_sessions
+            assert pb_data["session"] == "camp_sessions_pb_id_xyz"
 
     @pytest.mark.asyncio
     async def test_success_path_sends_status_success(self, mock_solver_input):
@@ -384,6 +389,10 @@ class TestSolverRunnerPocketBaseSave:
                 "get_settings": m8,
             }
             mock_pb = self._configure_mocks(mocks, mock_solver_input, solver_succeeds=False)
+            # Wire a known PB id so resolve_session_relation returns it
+            fake_session = MagicMock()
+            fake_session.id = "camp_sessions_pb_id_xyz"
+            mock_pb.collection.return_value.get_first_list_item.return_value = fake_session
             mock_runs["test_run"] = {"status": "pending"}
 
             await sr_module.run_solver_task_v2(
@@ -395,7 +404,8 @@ class TestSolverRunnerPocketBaseSave:
 
             pb_data = mock_pb.collection.return_value.create.call_args_list[0][0][0]
             assert pb_data["run_id"] == "test_run"
-            assert pb_data["session"] == "100"
+            # session is now a PB relation id resolved from camp_sessions
+            assert pb_data["session"] == "camp_sessions_pb_id_xyz"
             assert pb_data["session_id"] == 100
             assert pb_data["status"] == "failed"
             assert "session_cm_id" not in pb_data


### PR DESCRIPTION
## Summary

PR2 of the 3-PR solver-debug-dashboard sequence (PR1 = #1343).

- **Frontend** — Split `outcome` MetricGroup into `outcome_requests` and `outcome_campers` so PinnedComparisonPanel and DrillDownDrawer show request-unit and camper-unit metrics under separate, paired headers. Reader can now tell which unit each comparison row is scored in.
- **Schema** — Drop `solver_runs.request_data` (JSON column added in 1500000023 but never populated). Drop + recreate `solver_runs.session` as a relation to `camp_sessions` (was a text column holding `str(cm_id)`). No backfill of historical rows: existing rows get `session = NULL`. The debug page reads `session_id` numeric + `details.source_label`, neither of which depend on the relation.
- **API** — New `resolve_session_relation(pb, cm_id, year)` async helper looks up the camp_sessions PB id for each run; called from the three `solver_runs` write sites (sweep pre-create, success path, failure path).

PR3 (status badges: no-OPTIMAL warning, stalling, zero-conflicts) is independent and can ship in either order.

## Test plan

- [x] Vitest `metricRegistry.test.ts` — verifies every outcome metric maps to `outcome_requests` or `outcome_campers` per its accounting unit
- [x] Vitest `PinnedComparisonPanel.test.tsx` / `DrillDownDrawer.test.tsx` — verifies the two paired section headers render in requests→campers order
- [x] Pytest `test_solver_runner_session_relation.py` — happy path, 404 → None, non-404 re-raise
- [x] Local smoke — solver run produces a `solver_runs` row whose `session` is a real PB id pointing at the right camp_sessions row
- [x] `request_data` column is gone from `solver_runs` schema after migration
- [x] Full pre-push verification (ruff, mypy, pytest unit, go build, eslint, tsc, vitest 4031/4031, pb-js-lint, migration headers) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "cancelled" status option for solver runs.

* **Improvements**
  * Outcome metrics split into separate "requests" and "campers" sections for clearer debugging and comparisons.
  * Solver run records now store a resolved camp-session relation (instead of a raw numeric id); the session field is optional.

* **Chores**
  * Database migration applied to adopt the new session relation and remove legacy request_data (no historical backfill).

* **Tests**
  * Updated tests to reflect schema and grouping changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1363)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->