### PR TITLE
fix(pb): embed stable github.com/raw URL for feedback screenshots

### DIFF
--- a/pocketbase/feedback/github.go
+++ b/pocketbase/feedback/github.go
@@ -118,7 +118,15 @@ func (c *GitHubClient) CreateIssue(params *IssueParams) error {
 }
 
 // UploadScreenshot uploads an image to the repo's attachments/ directory.
-// Returns the raw download URL for embedding in the issue body.
+// Returns a stable URL for embedding in the issue body.
+//
+// For private repos, GitHub's contents API returns a download_url with an
+// ephemeral ?token= query that expires within ~30 min — embedding that URL
+// silently breaks every screenshot once the token dies. We instead derive a
+// stable URL from html_url: https://github.com/{owner}/{repo}/raw/{branch}/{path}.
+// When a logged-in collaborator's browser hits this URL, GitHub redirects to a
+// freshly-minted raw.githubusercontent.com URL bound to their session, so the
+// embedded image renders indefinitely.
 func (c *GitHubClient) UploadScreenshot(data []byte, filename, timestamp string) (string, error) {
 	// Sanitize timestamp for filename: replace colons
 	safeTimestamp := strings.ReplaceAll(timestamp, ":", "-")
@@ -147,14 +155,19 @@ func (c *GitHubClient) UploadScreenshot(data []byte, filename, timestamp string)
 
 	var result struct {
 		Content struct {
-			DownloadURL string `json:"download_url"`
+			HTMLURL string `json:"html_url"`
 		} `json:"content"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return "", fmt.Errorf("decoding response: %w", err)
 	}
 
-	return result.Content.DownloadURL, nil
+	if result.Content.HTMLURL == "" {
+		return "", fmt.Errorf("GitHub response missing html_url")
+	}
+
+	// html_url is .../blob/{branch}/{path}; raw form is .../raw/{branch}/{path}.
+	return strings.Replace(result.Content.HTMLURL, "/blob/", "/raw/", 1), nil
 }
 
 // categoryDisplayNames maps slug values to human-readable labels.

--- a/pocketbase/feedback/github_test.go
+++ b/pocketbase/feedback/github_test.go
@@ -2,6 +2,7 @@ package feedback
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -239,8 +240,18 @@ func TestUploadScreenshot(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		resp := `{"content": {"download_url": ` +
-			`"https://raw.githubusercontent.com/org/repo/main/attachments/test.png"}}`
+		// Real GitHub response for a PRIVATE repo: download_url carries an
+		// ephemeral ?token=... that expires in ~30 min. html_url is the
+		// stable blob URL — the code must derive the embeddable raw URL
+		// from html_url, never from download_url.
+		ephemeralDL := "https://raw.githubusercontent.com/org/feedback/main/" +
+			"attachments/2026-03-11T10-30-00Z-screenshot.png?token=EPHEMERAL_TOKEN_XYZ"
+		stableHTML := "https://github.com/org/feedback/blob/main/" +
+			"attachments/2026-03-11T10-30-00Z-screenshot.png"
+		resp := fmt.Sprintf(
+			`{"content": {"download_url": %q, "html_url": %q}}`,
+			ephemeralDL, stableHTML,
+		)
 		_, _ = w.Write([]byte(resp))
 	}))
 	defer server.Close()
@@ -255,8 +266,16 @@ func TestUploadScreenshot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UploadScreenshot() error = %v", err)
 	}
-	if url != "https://raw.githubusercontent.com/org/repo/main/attachments/test.png" {
-		t.Errorf("url = %q, want raw URL", url)
+
+	wantURL := "https://github.com/org/feedback/raw/main/attachments/2026-03-11T10-30-00Z-screenshot.png"
+	if url != wantURL {
+		t.Errorf("url = %q, want %q (stable github.com/raw URL, not ephemeral download_url)", url, wantURL)
+	}
+	if strings.Contains(url, "?token=") {
+		t.Errorf("url must not contain ephemeral ?token= query: %q", url)
+	}
+	if strings.Contains(url, "/blob/") {
+		t.Errorf("url must use /raw/ not /blob/: %q", url)
 	}
 }
 
@@ -282,7 +301,8 @@ func TestUploadScreenshotWithSanitizedFilename(t *testing.T) {
 		receivedPath = r.URL.Path
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		resp := `{"content": {"download_url": "https://example.com/test.png"}}`
+		resp := `{"content": {"html_url": "https://github.com/org/feedback/` +
+			`blob/main/attachments/2026-03-11T10-30-00Z-evil.png"}}`
 		_, _ = w.Write([]byte(resp))
 	}))
 	defer server.Close()


### PR DESCRIPTION
## Summary

- `pocketbase/feedback/github.go` `UploadScreenshot` was returning GitHub's contents-API `download_url`. For **private** repos that field is a temporarily-tokenized URL (`?token=...`) with a TTL of ~30 minutes.
- Once the token expired, every embedded screenshot in every feedback issue 404'd for every viewer.
- Bug masqueraded as "Mac clipboard paste doesn't work" because submissions filed early in a session had tokens that expired before review hours later → looked Mac-specific. Tests filed on Windows appeared to work because they were viewed within minutes of filing.

## Fix

Replace `download_url` with the stable form derived from `html_url`:
```
https://github.com/{owner}/{repo}/raw/{branch}/{path}
```
When a logged-in collaborator's browser hits this URL, GitHub 302-redirects to a freshly-minted `raw.githubusercontent.com/...?token=...` bound to their session, so embedded images render indefinitely for anyone with repo access.

Implementation: read `html_url` from the contents-API response, swap `/blob/` for `/raw/`. Drops the `download_url` field from the response struct entirely.

## Test plan

- [x] `TestUploadScreenshot` updated to assert returned URL is the stable form, contains no `?token=`, contains no `/blob/`
- [x] Mock GitHub response now includes both `download_url` (ephemeral) and `html_url` (stable) — proves the code ignores the ephemeral form
- [x] `go test ./feedback/...` passes (36/36)
- [x] `golangci-lint run ./feedback/...` clean
- [x] Pre-push verification full sweep passes
- [ ] Backfill: rewrite ephemeral URLs in 3 historical feedback issue bodies — one-shot script, runs after merge

Closes #1371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)