### PR TITLE
refactor(data): remove request_locked field

### DIFF
--- a/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
@@ -2264,12 +2264,7 @@ class RequestOrchestrator:
             try:
                 # Check if this request should be merged with an existing DB record
                 if bunk_request.metadata.get("database_match_action") == "merge":
-                    if bunk_request.metadata.get("database_match_locked"):
-                        # Locked request - create new and flag for manual review
-                        saved = self._save_new_request_for_locked_merge(bunk_request)
-                    else:
-                        # Unlocked - perform auto-merge
-                        saved = self._merge_into_existing(bunk_request)
+                    saved = self._merge_into_existing(bunk_request)
                 else:
                     # No database match - create new request with source link
                     saved = self._save_new_request_with_source_link(bunk_request)
@@ -2380,24 +2375,6 @@ class RequestOrchestrator:
         )
 
         return True
-
-    def _save_new_request_for_locked_merge(self, request: BunkRequest) -> bool:
-        """Create a new request when merge target is locked.
-
-        Locked requests need manual review, so we create a separate record
-        and flag it for staff attention.
-
-        Args:
-            request: BunkRequest that would have merged with a locked record
-
-        Returns:
-            True if creation succeeded
-        """
-        # Flag for manual review
-        request.metadata["requires_manual_merge_review"] = True
-        request.metadata["locked_duplicate_id"] = request.metadata.get("database_duplicate_id")
-
-        return self._save_new_request_with_source_link(request)
 
     def _apply_validation_pipeline(
         self, requests: list[BunkRequest]

--- a/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
@@ -2249,8 +2249,7 @@ class RequestOrchestrator:
 
         Handles both new requests and cross-run merge scenarios:
         - New requests: Create record and primary source link
-        - Database match (unlocked): Merge into existing, add source link
-        - Database match (locked): Create new, flag for manual review
+        - Database match: Merge into existing, add source link
 
         Args:
             validated_requests: List of validated BunkRequest objects

--- a/bunking/sync/bunk_request_processor/processing/deduplicator.py
+++ b/bunking/sync/bunk_request_processor/processing/deduplicator.py
@@ -248,9 +248,6 @@ class Deduplicator:
                         request.metadata["database_duplicate_id"] = getattr(existing, "id", None)
                         # Set action for orchestrator - indicates this should be merged
                         request.metadata["database_match_action"] = "merge"
-                        # Include locked status for orchestrator decision
-                        # (locked requests need manual review, not auto-merge)
-                        request.metadata["database_match_locked"] = getattr(existing, "request_locked", False)
                         database_duplicates += 1
 
         # Compile statistics

--- a/bunking/sync/bunk_request_processor/processing/partial_invalidation.py
+++ b/bunking/sync/bunk_request_processor/processing/partial_invalidation.py
@@ -26,21 +26,19 @@ class InvalidationResult:
 
     deleted_requests: list[str] = field(default_factory=list)
     unlinked_requests: list[str] = field(default_factory=list)
-    flagged_for_review: list[str] = field(default_factory=list)
 
     @property
     def total_affected(self) -> int:
         """Total number of requests affected by this invalidation."""
-        return len(self.deleted_requests) + len(self.unlinked_requests) + len(self.flagged_for_review)
+        return len(self.deleted_requests) + len(self.unlinked_requests)
 
 
 class PartialInvalidationHandler:
     """Handles partial invalidation when source content changes.
 
     When an original_bunk_request's content_hash changes, we need to handle
-    all bunk_requests that were derived from it. The behavior depends on:
-    1. How many sources the request has (single vs multi-source)
-    2. Whether the request is locked (staff-validated)
+    all bunk_requests that were derived from it. Behavior depends on how
+    many sources the request has (single → delete; multi → unlink one source).
     """
 
     def __init__(
@@ -121,53 +119,22 @@ class PartialInvalidationHandler:
     ) -> None:
         """Handle a multi-source request when one source changes.
 
-        For multi-source requests:
-        - If locked: flag for manual review (don't auto-modify)
-        - If unlocked: remove the source link and update source_fields
+        Always unlinks the changed source from the merged request — the
+        request survives because it still has other contributing sources.
+        Per issue #1373 the former locked-flag-for-review branch was removed.
 
         Args:
             bunk_request_id: ID of the merged request
             original_request_id: ID of the changed source
             result: InvalidationResult to update
         """
-        # Get the request to check if it's locked
         request = self.request_repository.get_by_id(bunk_request_id)
 
         if request is None:
             logger.warning(f"Could not find request {bunk_request_id} for invalidation")
             return
 
-        if getattr(request, "request_locked", False):
-            # Locked request: flag for review instead of modifying
-            self._flag_locked_request(bunk_request_id, original_request_id, result)
-        else:
-            # Unlocked request: unlink the changed source
-            self._unlink_source(bunk_request_id, original_request_id, request, result)
-
-    def _flag_locked_request(
-        self,
-        bunk_request_id: str,
-        original_request_id: str,
-        result: InvalidationResult,
-    ) -> None:
-        """Flag a locked request for manual review.
-
-        Locked requests indicate staff validation, so we shouldn't
-        auto-modify them. Instead, flag for manual review.
-
-        Args:
-            bunk_request_id: ID of the locked request
-            original_request_id: ID of the changed source
-            result: InvalidationResult to update
-        """
-        self.request_repository.flag_for_review(
-            bunk_request_id,
-            reason="source_changed_while_locked",
-            changed_original_id=original_request_id,
-        )
-
-        result.flagged_for_review.append(bunk_request_id)
-        logger.info(f"Flagged locked request {bunk_request_id} for review due to source change")
+        self._unlink_source(bunk_request_id, original_request_id, request, result)
 
     def _unlink_source(
         self,

--- a/bunking/sync/bunk_request_processor/processing/partial_invalidation.py
+++ b/bunking/sync/bunk_request_processor/processing/partial_invalidation.py
@@ -2,8 +2,7 @@
 
 Handles the case when an original_bunk_request's content changes (hash differs):
 - For single-source requests: Delete the bunk_request entirely
-- For multi-source unlocked requests: Remove source link, update source_fields, keep request
-- For multi-source locked requests: Flag for manual review (don't auto-modify)
+- For multi-source requests: Remove source link, update source_fields, keep request
 """
 
 from __future__ import annotations

--- a/docs/reference/tables.md
+++ b/docs/reference/tables.md
@@ -466,7 +466,6 @@ Parsed and resolved bunk requests (output of Python processor).
 | `merged_into` | relation | Self-reference for merged requests |
 | `age_preference_target` | text | For age_preference type |
 | `is_active` | bool | Request is active |
-| `request_locked` | bool | Protected from sync overwrites |
 
 **Unique**: `(requester_id, requestee_id, request_type, year, session_id, source_field)`
 

--- a/frontend/src/components/AllCamperRequestsModal.test.tsx
+++ b/frontend/src/components/AllCamperRequestsModal.test.tsx
@@ -322,7 +322,7 @@ describe('AllCamperRequestsModal inline actions', () => {
     expect(screen.getByText(/approve this request\?/i)).toBeTruthy()
   })
 
-  it('confirming Approve calls pb.update with status=resolved and request_locked=true', async () => {
+  it('confirming Approve calls pb.update with status=resolved (no request_locked)', async () => {
     bunkRequestsFixture = [pendingBunkWith]
     personsFixture = [{ cm_id: 1000002, first_name: 'Liam', last_name: 'Garcia', year: 2026 }]
     renderModal()
@@ -331,12 +331,11 @@ describe('AllCamperRequestsModal inline actions', () => {
     await waitFor(() =>
       expect(updateMock).toHaveBeenCalledWith('req1', {
         status: 'resolved',
-        request_locked: true,
       })
     )
   })
 
-  it('confirming Decline calls pb.update with status=declined and request_locked=false', async () => {
+  it('confirming Decline calls pb.update with status=declined (no request_locked)', async () => {
     bunkRequestsFixture = [pendingBunkWith]
     personsFixture = [{ cm_id: 1000002, first_name: 'Liam', last_name: 'Garcia', year: 2026 }]
     renderModal()
@@ -345,7 +344,6 @@ describe('AllCamperRequestsModal inline actions', () => {
     await waitFor(() =>
       expect(updateMock).toHaveBeenCalledWith('req1', {
         status: 'declined',
-        request_locked: false,
       })
     )
   })

--- a/frontend/src/components/AllCamperRequestsModal.test.tsx
+++ b/frontend/src/components/AllCamperRequestsModal.test.tsx
@@ -468,7 +468,6 @@ describe('AllCamperRequestsModal — target picker', () => {
     priority: 1,
     confidence_score: 0.5,
     is_reciprocal: false,
-    request_locked: false,
     created: '2025-01-01',
     updated: '2025-01-01',
   }
@@ -532,11 +531,11 @@ describe('AllCamperRequestsModal — target picker', () => {
   })
 
   // ---------------------------------------------------------------------------
-  // Modal target/type pickers must mirror row-level behavior: visible for ANY
-  // status (resolved/declined/pending), disabled only by request_locked.
+  // Modal target/type pickers must mirror row-level behavior: visible and
+  // editable for ANY status (resolved/declined/pending).
   // ---------------------------------------------------------------------------
 
-  it('renders EditableRequestTarget (disabled) for a locked resolved request', async () => {
+  it('renders EditableRequestTarget (enabled) for a resolved request', async () => {
     const resolvedRequest = {
       id: 'req-resolved-1',
       request_type: 'bunk_with',
@@ -549,7 +548,6 @@ describe('AllCamperRequestsModal — target picker', () => {
       priority: 1,
       confidence_score: 1.0,
       is_reciprocal: false,
-      request_locked: true,
       created: '2025-01-01',
       updated: '2025-01-01',
     }
@@ -559,13 +557,12 @@ describe('AllCamperRequestsModal — target picker', () => {
 
     renderModal({ requesterCmId: 100, year: 2025 })
 
-    // Picker button shows the resolved name (no "(unresolved)" suffix) and is disabled.
     const pickerButton = await screen.findByRole('button', { name: /^Olivia Chen$/i })
     expect(pickerButton).toBeInTheDocument()
-    expect(pickerButton).toBeDisabled()
+    expect(pickerButton).not.toBeDisabled()
   })
 
-  it('renders EditableRequestTarget (enabled) for a declined unlocked request', async () => {
+  it('renders EditableRequestTarget (enabled) for a declined request', async () => {
     const declinedRequest = {
       id: 'req-declined-1',
       request_type: 'bunk_with',
@@ -578,7 +575,6 @@ describe('AllCamperRequestsModal — target picker', () => {
       priority: 1,
       confidence_score: 0.6,
       is_reciprocal: false,
-      request_locked: false,
       created: '2025-01-01',
       updated: '2025-01-01',
     }
@@ -606,7 +602,6 @@ describe('AllCamperRequestsModal — target picker', () => {
       priority: 1,
       confidence_score: 1.0,
       is_reciprocal: false,
-      request_locked: false,
       created: '2025-01-01',
       updated: '2025-01-01',
     }

--- a/frontend/src/components/AllCamperRequestsModal.tsx
+++ b/frontend/src/components/AllCamperRequestsModal.tsx
@@ -370,8 +370,8 @@ export function AllCamperRequestsModal({
               id: confirmPopover.requestId,
               updates:
                 confirmPopover.action === 'approve'
-                  ? { status: 'resolved', request_locked: true }
-                  : { status: 'declined', request_locked: false },
+                  ? { status: 'resolved' }
+                  : { status: 'declined' },
             })
           }}
           onCancel={handleConfirmCancel}

--- a/frontend/src/components/CreateRequestModal.tsx
+++ b/frontend/src/components/CreateRequestModal.tsx
@@ -74,7 +74,6 @@ export default function CreateRequestModal({ sessionId, year, onClose }: CreateR
         source_field: 'manual', // Required field - identifies this as a staff-created request
         original_text: `Manually created ${requestType} request`,
         parse_notes: notes || 'Created through admin interface',
-        request_locked: true, // Auto-lock manual requests
         is_active: true, // Manually created requests are active
       }
 

--- a/frontend/src/components/RequestEditableHeader.test.tsx
+++ b/frontend/src/components/RequestEditableHeader.test.tsx
@@ -16,7 +16,6 @@ const baseRequest: Partial<BunkRequestsResponse> = {
   session_id: 1000001,
   year: 2025,
   is_reciprocal: false,
-  request_locked: false,
   confidence_score: 0.5,
   priority: 1,
   created: '2025-01-01',
@@ -139,14 +138,6 @@ describe('RequestEditableHeader rendering', () => {
       }
     )
     expect(screen.getByRole('button', { name: /Prefers older/i })).toBeInTheDocument()
-  })
-
-  it('disables both pickers when request_locked is true', () => {
-    renderHeader({}, { request_locked: true })
-    const typeButton = screen.getByRole('button', { name: /^Bunk With$/i })
-    const targetButton = screen.getByRole('button', { name: /Olivia Chen/i })
-    expect(typeButton).toBeDisabled()
-    expect(targetButton).toBeDisabled()
   })
 
   it('emits onUpdate with computeTypeUpdate output when type changes', () => {

--- a/frontend/src/components/RequestEditableHeader.tsx
+++ b/frontend/src/components/RequestEditableHeader.tsx
@@ -25,7 +25,6 @@ export function RequestEditableHeader({
   onViewCamper,
   isCurrent,
 }: RequestEditableHeaderProps) {
-  const disabled = request.request_locked
   return (
     <div className="flex flex-wrap items-center gap-2 text-sm">
       <div onClick={(e) => e.stopPropagation()}>
@@ -34,7 +33,6 @@ export function RequestEditableHeader({
           onChange={(newType) =>
             onUpdate(computeTypeUpdate(newType as BunkRequestsResponse['request_type']))
           }
-          disabled={disabled}
         />
       </div>
       <span className="text-muted-foreground">→</span>
@@ -49,7 +47,6 @@ export function RequestEditableHeader({
           requestedPersonName={request.requested_person_name}
           personMap={personMap}
           sessionName={sessionName}
-          disabled={disabled}
           onChange={(updates) => onUpdate(computeTargetUpdate(updates))}
           onViewCamper={onViewCamper}
         />

--- a/frontend/src/components/RequestReviewPanel.test.tsx
+++ b/frontend/src/components/RequestReviewPanel.test.tsx
@@ -1249,7 +1249,7 @@ describe('RequestReviewPanel', () => {
    * asserting on a literal object shape.
    */
   describe('Approve / Reject mutation payloads (#918)', () => {
-    it('approve button fires update with status=resolved and request_locked=true', async () => {
+    it('approve button fires update with status=resolved (no request_locked)', async () => {
       const { updateSpy, findButtonByTitle, user } = await renderPanelWithRequest({
         id: 'req-approve-1',
         requester_id: 100,
@@ -1260,7 +1260,6 @@ describe('RequestReviewPanel', () => {
         request_type: 'bunk_with',
         confidence_score: 0.9,
         priority: 1,
-        request_locked: false,
       })
 
       // Wait for at least one row-level Approve button to appear
@@ -1282,11 +1281,10 @@ describe('RequestReviewPanel', () => {
 
       expect(updateSpy).toHaveBeenCalledWith('req-approve-1', {
         status: 'resolved',
-        request_locked: true,
       })
     }, 10000)
 
-    it('reject button fires update with status=declined and request_locked=false', async () => {
+    it('reject button fires update with status=declined (no request_locked)', async () => {
       const { updateSpy, findButtonByTitle, user } = await renderPanelWithRequest({
         id: 'req-reject-1',
         requester_id: 200,
@@ -1297,7 +1295,6 @@ describe('RequestReviewPanel', () => {
         request_type: 'bunk_with',
         confidence_score: 0.5,
         priority: 1,
-        request_locked: false,
       })
 
       const rejectButton = await findButtonByTitle('Reject')
@@ -1316,7 +1313,6 @@ describe('RequestReviewPanel', () => {
 
       expect(updateSpy).toHaveBeenCalledWith('req-reject-1', {
         status: 'declined',
-        request_locked: false,
       })
     }, 10000)
   })
@@ -1365,7 +1361,6 @@ describe('RequestReviewPanel', () => {
         request_type: 'bunk_with',
         confidence_score: 0.7,
         priority: 1,
-        request_locked: false,
       })
 
       await expandRowById('req-collapse-approve-1')
@@ -1394,7 +1389,6 @@ describe('RequestReviewPanel', () => {
         request_type: 'bunk_with',
         confidence_score: 0.4,
         priority: 1,
-        request_locked: false,
       })
 
       await expandRowById('req-collapse-decline-1')
@@ -1428,7 +1422,6 @@ describe('RequestReviewPanel', () => {
         request_type: 'bunk_with',
         confidence_score: 0.8,
         priority: 1,
-        request_locked: false,
       }
       const rowB: Partial<BunkRequestsResponse> = {
         id: 'req-unrelated-b',
@@ -1440,7 +1433,6 @@ describe('RequestReviewPanel', () => {
         request_type: 'bunk_with',
         confidence_score: 0.6,
         priority: 2,
-        request_locked: false,
       }
 
       pb.collection.mockImplementation((name: string) => {
@@ -1542,7 +1534,6 @@ describe('RequestReviewPanel', () => {
         request_type: 'bunk_with',
         confidence_score: 0.75,
         priority: 1,
-        request_locked: false,
       })
 
       updateSpy.mockResolvedValue({})
@@ -1576,7 +1567,6 @@ describe('RequestReviewPanel', () => {
           // inverse mutation: PATCH back to pending
           expect(updateSpy).toHaveBeenCalledWith('req-undo-2', {
             status: 'pending',
-            request_locked: false,
           })
         },
         { timeout: 3000 }
@@ -1608,7 +1598,6 @@ describe('RequestReviewPanel', () => {
         request_type: 'bunk_with',
         confidence_score: 0.85,
         priority: 1,
-        request_locked: false,
       })
 
       // Approve succeeds; first undo attempt fails; second attempt succeeds.
@@ -1688,7 +1677,6 @@ describe('RequestReviewPanel', () => {
         request_type: 'bunk_with',
         confidence_score: 0.9,
         priority: 1,
-        request_locked: false,
       } as BunkRequestsResponse
 
       const { pb } = (await import('../lib/pocketbase')) as unknown as {
@@ -1802,7 +1790,6 @@ describe('RequestReviewPanel', () => {
           request_type: 'bunk_with',
           confidence_score: 0.8,
           priority: 1,
-          request_locked: false,
         } as BunkRequestsResponse,
         {
           id: 'bulk-rec-2',
@@ -1814,7 +1801,6 @@ describe('RequestReviewPanel', () => {
           request_type: 'bunk_with',
           confidence_score: 0.7,
           priority: 1,
-          request_locked: false,
         } as BunkRequestsResponse,
       ]
 
@@ -1936,7 +1922,6 @@ describe('RequestReviewPanel', () => {
         request_type: 'not_bunk_with',
         confidence_score: 0.6,
         priority: 2,
-        request_locked: false,
       })
 
       updateSpy.mockResolvedValue({})
@@ -1949,7 +1934,6 @@ describe('RequestReviewPanel', () => {
       await waitFor(() => {
         expect(updateSpy).toHaveBeenCalledWith('req-undo-3', {
           status: 'declined',
-          request_locked: false,
         })
       })
 
@@ -1965,7 +1949,7 @@ describe('RequestReviewPanel', () => {
 
       await user.click(undoBtn)
 
-      // Inverse: restore to pending (prior state was pending, request_locked false)
+      // Inverse: restore to pending (prior state was pending)
       await waitFor(
         () => {
           const calls = updateSpy.mock.calls

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -14,7 +14,6 @@ import {
   ChevronUp,
   Search,
   AlertCircle,
-  Shield,
   Plus,
   GitMerge,
   Users,
@@ -580,7 +579,6 @@ export default function RequestReviewPanel({
       const req = requests.find((r: BunkRequestsResponse) => r.id === id)
       if (!req) return
       const priorStatus = req.status
-      const priorLocked = req.request_locked
 
       const requesterPerson = personMap.get(req.requester_id)
       const requesterName = requesterPerson
@@ -595,9 +593,7 @@ export default function RequestReviewPanel({
               id,
               label: `Reverted ${labelVerb} of ${requesterName}`,
               inverse: async () => {
-                await pb
-                  .collection('bunk_requests')
-                  .update(id, { status: priorStatus, request_locked: priorLocked })
+                await pb.collection('bunk_requests').update(id, { status: priorStatus })
                 invalidateRequestQueries(queryClient)
               },
             })
@@ -611,14 +607,14 @@ export default function RequestReviewPanel({
   const handleApprove = (id: string) =>
     handleAction({
       id,
-      updates: { status: 'resolved' as BunkRequestsStatusOptions, request_locked: true },
+      updates: { status: 'resolved' as BunkRequestsStatusOptions },
       labelVerb: 'approval',
     })
 
   const handleReject = (id: string) =>
     handleAction({
       id,
-      updates: { status: 'declined' as BunkRequestsStatusOptions, request_locked: false },
+      updates: { status: 'declined' as BunkRequestsStatusOptions },
       labelVerb: 'decline',
     })
 
@@ -629,11 +625,11 @@ export default function RequestReviewPanel({
       const priors = ids
         .map((id) => requests.find((r: BunkRequestsResponse) => r.id === id))
         .filter((r): r is BunkRequestsResponse => Boolean(r))
-        .map((r) => ({ id: r.id, status: r.status, request_locked: r.request_locked }))
+        .map((r) => ({ id: r.id, status: r.status }))
       const updates: Partial<BunkRequestsResponse> =
         action === 'approve'
-          ? { status: 'resolved' as BunkRequestsStatusOptions, request_locked: true }
-          : { status: 'declined' as BunkRequestsStatusOptions, request_locked: false }
+          ? { status: 'resolved' as BunkRequestsStatusOptions }
+          : { status: 'declined' as BunkRequestsStatusOptions }
       const labelVerb = action === 'approve' ? 'approval' : 'decline'
       bulkUpdateMutation.mutate(
         { ids, updates },
@@ -646,9 +642,7 @@ export default function RequestReviewPanel({
               inverse: async () => {
                 await Promise.all(
                   priors.map((p) =>
-                    pb
-                      .collection('bunk_requests')
-                      .update(p.id, { status: p.status, request_locked: p.request_locked })
+                    pb.collection('bunk_requests').update(p.id, { status: p.status })
                   )
                 )
                 invalidateRequestQueries(queryClient)
@@ -848,16 +842,6 @@ export default function RequestReviewPanel({
   const handleSelectCamperId = useCallback((cmId: string) => {
     setSelectedCamperId(cmId)
   }, [])
-
-  const handleUnlockRow = useCallback(
-    (id: string) => {
-      updateRequestMutation.mutate({
-        id,
-        updates: { request_locked: false },
-      })
-    },
-    [updateRequestMutation]
-  )
 
   const handlePriorityChangeRow = useCallback(
     (id: string, priority: number) => {
@@ -1191,7 +1175,6 @@ export default function RequestReviewPanel({
                           onToggleSelection={toggleRequestSelection}
                           onSelectCamper={handleSelectCamperId}
                           onValidatedUpdate={handleValidatedUpdate}
-                          onUnlock={handleUnlockRow}
                           onSplit={handleSplitRow}
                           onConfirmAction={openConfirmPopover}
                         />
@@ -1297,7 +1280,6 @@ export default function RequestReviewPanel({
                           onSelectCamper={handleSelectCamperId}
                           onValidatedUpdate={handleValidatedUpdate}
                           onPriorityChange={handlePriorityChangeRow}
-                          onUnlock={handleUnlockRow}
                           onSplit={handleSplitRow}
                           onConfirmAction={openConfirmPopover}
                         />
@@ -1469,16 +1451,6 @@ export default function RequestReviewPanel({
                                     Created: {new Date(request.created).toLocaleDateString()}
                                   </span>
                                 </div>
-
-                                {/* Protection status - show when applicable */}
-                                {request.request_locked && request.status === 'resolved' && (
-                                  <div className="flex items-center gap-4 text-xs">
-                                    <span className="text-primary flex items-center gap-1.5 font-medium">
-                                      <Shield className="h-3 w-3" />
-                                      Protected due to manual approval
-                                    </span>
-                                  </div>
-                                )}
                               </div>
                               <div className="max-w-xl">
                                 <CamperRequestSummary

--- a/frontend/src/components/RequestRowDesktop.tsx
+++ b/frontend/src/components/RequestRowDesktop.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback } from 'react'
 import clsx from 'clsx'
-import { CheckCircle, CheckCheck, XCircle, Shield, Scissors } from 'lucide-react'
+import { CheckCircle, CheckCheck, XCircle, Scissors } from 'lucide-react'
 import type { BunkRequestsResponse, PersonsResponse } from '../types/pocketbase-types'
 import EditableRequestType from './EditableRequestType'
 import EditableRequestTarget from './EditableRequestTarget'
@@ -29,7 +29,6 @@ export interface RequestRowDesktopProps {
   onSelectCamper: (cmId: string) => void
   onValidatedUpdate: (request: BunkRequestsResponse, updates: Partial<BunkRequestsResponse>) => void
   onPriorityChange: (id: string, priority: number) => void
-  onUnlock: (id: string) => void
   onSplit: (request: BunkRequestsResponse) => void
   onConfirmAction: (
     e: React.MouseEvent<HTMLButtonElement>,
@@ -96,7 +95,6 @@ function RequestRowDesktop({
   onSelectCamper,
   onValidatedUpdate,
   onPriorityChange,
-  onUnlock,
   onSplit,
   onConfirmAction,
 }: RequestRowDesktopProps) {
@@ -141,10 +139,6 @@ function RequestRowDesktop({
     },
     [onSelectCamper]
   )
-
-  const handleUnlock = useCallback(() => {
-    onUnlock(request.id)
-  }, [onUnlock, request.id])
 
   const handleSplit = useCallback(() => {
     onSplit(request)
@@ -203,7 +197,6 @@ function RequestRowDesktop({
           year={year}
           requesterCmId={request.requester_id}
           onChange={handleTargetChange}
-          disabled={request.request_locked}
           originalText={request.original_text}
           requestedPersonName={request.requested_person_name}
           parseNotes={request.parse_notes}
@@ -218,11 +211,7 @@ function RequestRowDesktop({
         )}
       </div>
       <div className="flex items-center px-4 py-3" onClick={(e) => e.stopPropagation()}>
-        <EditableRequestType
-          value={request.request_type}
-          onChange={handleTypeChange}
-          disabled={request.request_locked}
-        />
+        <EditableRequestType value={request.request_type} onChange={handleTypeChange} />
       </div>
       <div
         className="flex items-center justify-center px-4 py-3"
@@ -258,15 +247,6 @@ function RequestRowDesktop({
       </div>
       <div className="flex items-center justify-end px-4 py-3" onClick={(e) => e.stopPropagation()}>
         <div className="flex min-w-[100px] items-center justify-end gap-1">
-          {request.status === 'resolved' && request.request_locked && (
-            <button
-              onClick={handleUnlock}
-              className="hover:bg-primary/10 text-primary rounded-lg p-1.5 opacity-80 transition-colors hover:opacity-100"
-              title="Click to unprotect and allow editing"
-            >
-              <Shield className="h-4 w-4" />
-            </button>
-          )}
           {hasMultipleSources && (
             <button
               onClick={handleSplit}

--- a/frontend/src/components/RequestRowMobile.tsx
+++ b/frontend/src/components/RequestRowMobile.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback } from 'react'
 import clsx from 'clsx'
-import { CheckCircle, CheckCheck, XCircle, Shield, Scissors } from 'lucide-react'
+import { CheckCircle, CheckCheck, XCircle, Scissors } from 'lucide-react'
 import type { BunkRequestsResponse, PersonsResponse } from '../types/pocketbase-types'
 import EditableRequestType from './EditableRequestType'
 import EditableRequestTarget from './EditableRequestTarget'
@@ -27,7 +27,6 @@ export interface RequestRowMobileProps {
   onToggleSelection: (id: string) => void
   onSelectCamper: (cmId: string) => void
   onValidatedUpdate: (request: BunkRequestsResponse, updates: Partial<BunkRequestsResponse>) => void
-  onUnlock: (id: string) => void
   onSplit: (request: BunkRequestsResponse) => void
   onConfirmAction: (
     e: React.MouseEvent<HTMLButtonElement>,
@@ -93,7 +92,6 @@ function RequestRowMobile({
   onToggleSelection,
   onSelectCamper,
   onValidatedUpdate,
-  onUnlock,
   onSplit,
   onConfirmAction,
 }: RequestRowMobileProps) {
@@ -129,10 +127,6 @@ function RequestRowMobile({
     },
     [onSelectCamper]
   )
-
-  const handleUnlock = useCallback(() => {
-    onUnlock(request.id)
-  }, [onUnlock, request.id])
 
   const handleSplit = useCallback(() => {
     onSplit(request)
@@ -184,11 +178,7 @@ function RequestRowMobile({
           {request.is_reciprocal && <span className={MUTUAL_BADGE_CLASSES}>mutual</span>}
         </div>
         <div className="mt-0.5" onClick={(e) => e.stopPropagation()}>
-          <EditableRequestType
-            value={request.request_type}
-            onChange={handleTypeChange}
-            disabled={request.request_locked}
-          />
+          <EditableRequestType value={request.request_type} onChange={handleTypeChange} />
         </div>
       </div>
 
@@ -224,7 +214,6 @@ function RequestRowMobile({
           year={year}
           requesterCmId={request.requester_id}
           onChange={handleTargetChange}
-          disabled={request.request_locked}
           originalText={request.original_text}
           requestedPersonName={request.requested_person_name}
           parseNotes={request.parse_notes}
@@ -240,15 +229,6 @@ function RequestRowMobile({
       </div>
 
       <div className="card-actions" onClick={(e) => e.stopPropagation()}>
-        {request.status === 'resolved' && request.request_locked && (
-          <button
-            onClick={handleUnlock}
-            className="hover:bg-primary/10 text-primary touch-manipulation rounded-lg p-2 transition-colors"
-            title="Unprotect"
-          >
-            <Shield className="h-5 w-5" />
-          </button>
-        )}
         {hasMultipleSources && (
           <button
             onClick={handleSplit}

--- a/frontend/src/schemas/request.ts
+++ b/frontend/src/schemas/request.ts
@@ -40,7 +40,6 @@ export const BunkRequestsRecordSchema = z.object({
   original_text: z.string().optional(),
   parse_notes: z.string().optional(),
   priority: z.number().optional(),
-  request_locked: z.boolean().optional(),
   request_type: BunkRequestsRequestTypeSchema,
   requestee_id: z.number().optional(),
   requested_person_name: z.string().optional(),

--- a/frontend/src/types/app-types.ts
+++ b/frontend/src/types/app-types.ts
@@ -142,8 +142,6 @@ export interface BunkRequest {
   requires_manual_review?: boolean
   manual_review_reason?: string
   was_dropped_for_spread?: boolean
-  // Locking fields
-  request_locked?: boolean
   // Merge tracking — empty string or undefined means not merged; non-empty is the PB record ID it was merged into
   merged_into?: string
   created: string

--- a/frontend/src/types/pocketbase-types.ts
+++ b/frontend/src/types/pocketbase-types.ts
@@ -1671,8 +1671,7 @@ type ProcessCreateAndUpdateFields<T> = Omit<
     // Omit AutoDate fields
     [K in keyof T as Extract<T[K], IsoAutoDateString> extends never
       ? K
-      : never]: // Convert FileNameString to File
-    T[K] extends infer U
+      : never]: T[K] extends infer U // Convert FileNameString to File
       ? U extends FileNameString | FileNameString[]
         ? U extends any[]
           ? File[]

--- a/frontend/src/types/pocketbase-types.ts
+++ b/frontend/src/types/pocketbase-types.ts
@@ -312,7 +312,6 @@ export type BunkRequestsRecord<
   original_text?: string
   parse_notes?: string
   priority?: number
-  request_locked?: boolean
   request_type: BunkRequestsRequestTypeOptions
   requested_person_name?: string
   requestee_id?: number
@@ -1672,7 +1671,8 @@ type ProcessCreateAndUpdateFields<T> = Omit<
     // Omit AutoDate fields
     [K in keyof T as Extract<T[K], IsoAutoDateString> extends never
       ? K
-      : never]: T[K] extends infer U // Convert FileNameString to File
+      : never]: // Convert FileNameString to File
+    T[K] extends infer U
       ? U extends FileNameString | FileNameString[]
         ? U extends any[]
           ? File[]

--- a/pocketbase/pb_migrations/1500000097_drop_request_locked.js
+++ b/pocketbase/pb_migrations/1500000097_drop_request_locked.js
@@ -1,0 +1,32 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: Drop request_locked field from bunk_requests
+ *
+ * Per issue #1373, the lock provided no real protection beyond what the
+ * unique constraint and source_field distinction already give us, while
+ * creating UI traps when sync paths transitioned rows out of staff-blessed
+ * state without clearing the lock.
+ *
+ * Existing rows with request_locked=true (~35 in prod at migration time)
+ * lose the bit; staff edits and approvals continue to persist via status,
+ * disposition_reason, and requestee_id.
+ */
+migrate(
+  (app) => {
+    const collection = app.findCollectionByNameOrId("bunk_requests")
+    collection.fields.removeByName("request_locked")
+    app.save(collection)
+  },
+  (app) => {
+    const collection = app.findCollectionByNameOrId("bunk_requests")
+    collection.fields.add(
+      new Field({
+        name: "request_locked",
+        type: "bool",
+        required: false,
+        unique: false,
+      })
+    )
+    app.save(collection)
+  }
+)

--- a/tests/unit/sync/bunk_request_processor/data/test_request_repository.py
+++ b/tests/unit/sync/bunk_request_processor/data/test_request_repository.py
@@ -310,7 +310,7 @@ class TestRequestRepository:
         assert "match_type" not in deserialized
         assert len(deserialized["alternate_matches"]) == 2
 
-    def test_update_for_merge_does_not_touch_status_target_or_type(self, repository, mock_pb_client) -> None:
+    def test_update_for_merge_does_not_touch_status_target_or_type(self, repository, mock_pb_client):
         """update_for_merge writes only additive fields, never status/target/type.
 
         Regression lock for the invariant that request_locked was supposedly

--- a/tests/unit/sync/bunk_request_processor/data/test_request_repository.py
+++ b/tests/unit/sync/bunk_request_processor/data/test_request_repository.py
@@ -310,6 +310,37 @@ class TestRequestRepository:
         assert "match_type" not in deserialized
         assert len(deserialized["alternate_matches"]) == 2
 
+    def test_update_for_merge_does_not_touch_status_target_or_type(self, repository, mock_pb_client) -> None:
+        """update_for_merge writes only additive fields, never status/target/type.
+
+        Regression lock for the invariant that request_locked was supposedly
+        protecting — but which the merge path already enforces at a lower
+        level. Per issue #1373: with the lock gone, this guarantee is what
+        keeps staff approvals safe from sync overwrites.
+        """
+        _, mock_collection = mock_pb_client
+
+        repository.update_for_merge(
+            record_id="rec_123",
+            source_fields=["field_a", "field_b"],
+            confidence_score=0.95,
+            metadata={"merged": True},
+        )
+
+        mock_collection.update.assert_called_once()
+        call_args = mock_collection.update.call_args
+        record_id_arg = call_args[0][0]
+        payload = call_args[0][1]
+
+        assert record_id_arg == "rec_123"
+        # Only additive fields allowed
+        assert set(payload.keys()) == {"source_fields", "confidence_score", "metadata"}
+        # Never touched by merge
+        assert "status" not in payload
+        assert "requestee_id" not in payload
+        assert "request_type" not in payload
+        assert "disposition_reason" not in payload
+
 
 class TestClearAllForYear:
     """Test the clear_all_for_year functionality (test/reset mode).

--- a/tests/unit/sync/bunk_request_processor/orchestrator/test_orchestrator_merge.py
+++ b/tests/unit/sync/bunk_request_processor/orchestrator/test_orchestrator_merge.py
@@ -67,7 +67,6 @@ class TestOrchestratorMergeOnSave:
                 "has_database_duplicate": True,
                 "database_duplicate_id": "existing_pb_id_123",
                 "database_match_action": "merge",
-                "database_match_locked": False,
             },
         )
 
@@ -118,7 +117,6 @@ class TestOrchestratorMergeOnSave:
                 "has_database_duplicate": True,
                 "database_duplicate_id": "existing_pb_id_123",
                 "database_match_action": "merge",
-                "database_match_locked": False,
                 "original_request_id": "orig_req_456",  # The new source
             },
         )
@@ -167,7 +165,6 @@ class TestOrchestratorMergeOnSave:
                 "has_database_duplicate": True,
                 "database_duplicate_id": "existing_pb_id_123",
                 "database_match_action": "merge",
-                "database_match_locked": False,
             },
         )
 
@@ -276,53 +273,6 @@ class TestOrchestratorMergeOnSave:
             source_field="bunk_with",
         )
 
-    def test_locked_request_skips_auto_merge(self) -> None:
-        """Test that locked existing requests skip auto-merge.
-
-        When database_match_locked=True, we should NOT auto-merge.
-        Instead, create a new request and flag for manual review.
-        """
-        request = self._create_request(
-            source_field="bunking_notes",
-            metadata={
-                "has_database_duplicate": True,
-                "database_duplicate_id": "existing_locked_123",
-                "database_match_action": "merge",
-                "database_match_locked": True,  # Locked!
-                "original_request_id": "orig_req_456",
-            },
-        )
-
-        mock_request_repo = Mock()
-        mock_request_repo.create.return_value = True
-        mock_source_link_repo = Mock()
-
-        from bunking.sync.bunk_request_processor.orchestrator.orchestrator import (
-            RequestOrchestrator,
-        )
-
-        with patch.object(RequestOrchestrator, "__init__", lambda self: None):
-            orchestrator = RequestOrchestrator()
-            orchestrator.request_repository = mock_request_repo
-            orchestrator.source_link_repository = mock_source_link_repo
-            orchestrator._stats = {}
-
-            def set_id_on_create(req):
-                req.id = "new_pb_id_888"
-                return True
-
-            mock_request_repo.create.side_effect = set_id_on_create
-
-            saved = orchestrator._save_bunk_requests([request])
-
-        # Should create new, not merge (locked requests need manual review)
-        mock_request_repo.create.assert_called_once()
-        mock_request_repo.update_for_merge.assert_not_called()
-
-        # The saved request should be flagged for manual review
-        assert len(saved) == 1
-        assert saved[0].metadata.get("requires_manual_merge_review") is True
-
     def test_merge_preserves_higher_confidence(self) -> None:
         """Test that merge keeps the higher confidence score."""
         request = self._create_request(
@@ -332,7 +282,6 @@ class TestOrchestratorMergeOnSave:
                 "has_database_duplicate": True,
                 "database_duplicate_id": "existing_pb_id_123",
                 "database_match_action": "merge",
-                "database_match_locked": False,
             },
         )
 
@@ -374,7 +323,6 @@ class TestOrchestratorMergeOnSave:
                 "has_database_duplicate": True,
                 "database_duplicate_id": "existing_pb_id_123",
                 "database_match_action": "merge",
-                "database_match_locked": False,
             },
         )
 

--- a/tests/unit/sync/bunk_request_processor/processing/test_cross_run_deduplication.py
+++ b/tests/unit/sync/bunk_request_processor/processing/test_cross_run_deduplication.py
@@ -310,57 +310,5 @@ class TestCrossRunDeduplicationStatistics:
         assert result.statistics["database_duplicates"] == 1
 
 
-class TestLockedRequestHandling:
-    """Test handling of locked requests in cross-run deduplication.
-
-    Locked requests (request_locked=True) indicate staff has validated/edited
-    the request. These need special handling:
-    - If source changes, we shouldn't auto-delete the locked request
-    - Should flag for manual review instead
-    """
-
-    @pytest.fixture
-    def mock_request_repo(self):
-        """Create a mock request repository"""
-        return Mock()
-
-    @pytest.fixture
-    def deduplicator(self, mock_request_repo):
-        """Create a Deduplicator with mocked dependencies"""
-        return Deduplicator(mock_request_repo)
-
-    def test_database_match_includes_locked_status(self, deduplicator, mock_request_repo):
-        """Test that database match metadata includes locked status.
-
-        The orchestrator needs to know if the existing request is locked
-        to decide whether to merge or flag for review.
-        """
-        existing = Mock()
-        existing.id = "existing_locked"
-        existing.request_locked = True
-        mock_request_repo.find_existing.return_value = existing
-
-        new_request = BunkRequest(
-            requester_cm_id=12345,
-            requested_cm_id=67890,
-            request_type=RequestType.BUNK_WITH,
-            session_cm_id=1000002,
-            priority=3,
-            confidence_score=0.95,
-            source_field="bunking_notes",
-            csv_position=0,
-            year=2025,
-            status=RequestStatus.RESOLVED,
-            is_placeholder=False,
-            metadata={},
-        )
-
-        result = deduplicator.deduplicate_batch([new_request], check_database=True)
-
-        kept = result.kept_requests[0]
-        # Should include locked status for orchestrator decision
-        assert kept.metadata.get("database_match_locked") is True
-
-
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/sync/bunk_request_processor/processing/test_partial_invalidation.py
+++ b/tests/unit/sync/bunk_request_processor/processing/test_partial_invalidation.py
@@ -181,9 +181,8 @@ class TestPartialInvalidationMultiSource:
     def test_multi_source_unlinks_regardless_of_lock_state(self) -> None:
         """Multi-source rows unlink the changed source unconditionally.
 
-        TDD anchor for issue #1373: with request_locked removed, the lock
-        branch in _handle_multi_source goes away and unlink runs every time.
-        Today this fails because lock=True routes to flag_for_review.
+        Regression lock for issue #1373: the formerly-conditional lock branch
+        in _handle_multi_source is gone; unlink runs every time.
         """
         mock_request_repo = Mock()
         mock_source_link_repo = Mock()
@@ -194,10 +193,8 @@ class TestPartialInvalidationMultiSource:
         mock_source_link_repo.count_sources_for_request.return_value = 2
         mock_source_link_repo.get_source_field_for_link.return_value = "field_a"
 
-        # Locked row — currently routed to flag_for_review, post-refactor routes to unlink
         mock_request = Mock()
         mock_request.id = "br_456"
-        mock_request.request_locked = True
         mock_request.source_fields = ["field_a", "field_b"]
         mock_request_repo.get_by_id.return_value = mock_request
 

--- a/tests/unit/sync/bunk_request_processor/processing/test_partial_invalidation.py
+++ b/tests/unit/sync/bunk_request_processor/processing/test_partial_invalidation.py
@@ -227,6 +227,48 @@ class TestPartialInvalidationMultiSource:
         # Result should indicate flagged
         assert result.flagged_for_review == ["br_locked_789"]
 
+    def test_multi_source_unlinks_regardless_of_lock_state(self) -> None:
+        """Multi-source rows unlink the changed source unconditionally.
+
+        TDD anchor for issue #1373: with request_locked removed, the lock
+        branch in _handle_multi_source goes away and unlink runs every time.
+        Today this fails because lock=True routes to flag_for_review.
+        """
+        mock_request_repo = Mock()
+        mock_source_link_repo = Mock()
+
+        original_request_id = "orig_123"
+
+        mock_source_link_repo.get_requests_for_source.return_value = ["br_456"]
+        mock_source_link_repo.count_sources_for_request.return_value = 2
+        mock_source_link_repo.get_source_field_for_link.return_value = "field_a"
+
+        # Locked row — currently routed to flag_for_review, post-refactor routes to unlink
+        mock_request = Mock()
+        mock_request.id = "br_456"
+        mock_request.request_locked = True
+        mock_request.source_fields = ["field_a", "field_b"]
+        mock_request_repo.get_by_id.return_value = mock_request
+
+        from bunking.sync.bunk_request_processor.processing.partial_invalidation import (
+            PartialInvalidationHandler,
+        )
+
+        handler = PartialInvalidationHandler(
+            request_repository=mock_request_repo,
+            source_link_repository=mock_source_link_repo,
+        )
+
+        result = handler.handle_source_change(original_request_id)
+
+        # Unlink ran, flag_for_review did NOT
+        mock_source_link_repo.remove_source_link.assert_called_once_with(
+            bunk_request_id="br_456",
+            original_request_id=original_request_id,
+        )
+        mock_request_repo.flag_for_review.assert_not_called()
+        assert "br_456" in result.unlinked_requests
+
 
 class TestPartialInvalidationMultipleRequests:
     """Test partial invalidation when one source links to multiple requests."""

--- a/tests/unit/sync/bunk_request_processor/processing/test_partial_invalidation.py
+++ b/tests/unit/sync/bunk_request_processor/processing/test_partial_invalidation.py
@@ -34,7 +34,6 @@ class TestPartialInvalidationSingleSource:
         request_type: RequestType = RequestType.BUNK_WITH,
         source_field: str = "share_bunk_with",
         pb_id: str = "br_123",
-        request_locked: bool = False,
     ) -> BunkRequest:
         """Helper to create a BunkRequest for testing."""
         request = BunkRequest(
@@ -141,10 +140,8 @@ class TestPartialInvalidationMultiSource:
         # This request has MULTIPLE sources (merged request)
         mock_source_link_repo.count_sources_for_request.return_value = 3
 
-        # Mock the request to check if it's locked
         mock_request = Mock()
         mock_request.id = "br_merged_456"
-        mock_request.request_locked = False  # NOT locked
         mock_request.source_fields = ["share_bunk_with", "bunking_notes", "internal_notes"]
         mock_request_repo.get_by_id.return_value = mock_request
 
@@ -180,52 +177,6 @@ class TestPartialInvalidationMultiSource:
         # Result should indicate unlinking, not deletion
         assert result.deleted_requests == []
         assert "br_merged_456" in result.unlinked_requests
-
-    def test_multi_source_locked_flags_for_review(self) -> None:
-        """Test that locked multi-source requests are flagged for review.
-
-        Locked requests indicate staff validation. When a source changes,
-        we shouldn't auto-modify - instead, flag for manual review.
-        """
-        mock_request_repo = Mock()
-        mock_source_link_repo = Mock()
-
-        original_request_id = "orig_123"
-
-        mock_source_link_repo.get_requests_for_source.return_value = ["br_locked_789"]
-        mock_source_link_repo.count_sources_for_request.return_value = 2
-
-        # Mock a LOCKED request
-        mock_request = Mock()
-        mock_request.id = "br_locked_789"
-        mock_request.request_locked = True  # LOCKED
-        mock_request.metadata = {}
-        mock_request_repo.get_by_id.return_value = mock_request
-
-        from bunking.sync.bunk_request_processor.processing.partial_invalidation import (
-            PartialInvalidationHandler,
-        )
-
-        handler = PartialInvalidationHandler(
-            request_repository=mock_request_repo,
-            source_link_repository=mock_source_link_repo,
-        )
-
-        result = handler.handle_source_change(original_request_id)
-
-        # Should NOT delete or unlink
-        mock_request_repo.delete.assert_not_called()
-        mock_source_link_repo.remove_source_link.assert_not_called()
-
-        # Should flag for manual review
-        mock_request_repo.flag_for_review.assert_called_once_with(
-            "br_locked_789",
-            reason="source_changed_while_locked",
-            changed_original_id=original_request_id,
-        )
-
-        # Result should indicate flagged
-        assert result.flagged_for_review == ["br_locked_789"]
 
     def test_multi_source_unlinks_regardless_of_lock_state(self) -> None:
         """Multi-source rows unlink the changed source unconditionally.
@@ -302,7 +253,6 @@ class TestPartialInvalidationMultipleRequests:
             if request_id == "br_multi_2":
                 mock_req = Mock()
                 mock_req.id = request_id
-                mock_req.request_locked = False
                 mock_req.source_fields = ["field_a", "field_b"]
                 return mock_req
             return None
@@ -352,7 +302,6 @@ class TestPartialInvalidationStatistics:
         # Should have statistics attributes
         assert hasattr(result, "deleted_requests")
         assert hasattr(result, "unlinked_requests")
-        assert hasattr(result, "flagged_for_review")
         assert hasattr(result, "total_affected")
 
 


### PR DESCRIPTION
## Summary

Removes the `request_locked` field from `bunk_requests` — schema column, all backend reads, all frontend gates, mutations, badge, unlock handler, and obsolete tests.

Per issue #1373: the lock provided no real protection beyond what the unique constraint and `source_field` distinction already give us, while creating UI traps (e.g. the 113 rows healed by PR #1366 that became un-editable in prod because no sync path clears the lock).

## Behavior changes

- **Same-content CSV re-upload**: still merges cleanly via `update_for_merge`, which only touches additive fields (`source_fields`, `confidence_score`, `metadata`). No status/target overwrite — invariant locked in by new regression test `test_update_for_merge_does_not_touch_status_target_or_type`.
- **Multi-source one-source-change**: always unlinks the changed source (was conditional on lock). New TDD anchor `test_multi_source_unlinks_regardless_of_lock_state` asserts this.
- **Manual-created rows**: no longer auto-locked. Protection from sync now comes from the empty `source_field` (dedup key includes `source_field`, so sync rows can't collide).
- **Approve / decline**: mutation payloads carry only `status` (decline also continues to set `disposition_reason` where applicable).
- **UI**: target & type editors always enabled; locked badge gone; unlock handler gone.

## Test plan

- [x] Backend anchor test: `test_multi_source_unlinks_regardless_of_lock_state` (red → green)
- [x] Backend regression test: `test_update_for_merge_does_not_touch_status_target_or_type` (green, locks in invariant)
- [x] Frontend payload tests: approve/decline mutations carry no `request_locked` (red → green across `AllCamperRequestsModal.test.tsx` and `RequestReviewPanel.test.tsx`)
- [x] Full backend test suite: 1798 passed, 1 skipped
- [x] Full Go test suite: 2199 passed
- [x] Full frontend test suite: 4069 passed
- [x] lefthook pre-push green (ruff, mypy, tsc, go build, golangci-lint, eslint, prettier, pb-js-lint)
- [ ] Smoke (post-merge / pre-merge browser): create / approve / decline / bulk-approve via UI to confirm editors stay editable and no badges/buttons orphaned

## Rollback

Revert PR → migration `down()` re-adds the field as null on all rows. Functionally equivalent to "everywhere unlocked" since nothing reads it after revert. The ~35 rows that had `request_locked=true` pre-merge do NOT get the bit back on revert (acceptable per the linked analysis).

Closes #1373

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Removed Features**
  * Request locking mechanism removed; staff can no longer lock/unlock requests or see a protection indicator for resolved requests.

* **Changes**
  * Approve/decline actions now update only status.
  * Merge/dedup flows no longer treat locked rows differently.
  * Manually created requests are no longer auto-locked; new manual-review fields added.

* **Tests**
  * Updated/added tests to reflect removed locking behavior and new fields.

* **Chores**
  * Database migration to drop the obsolete lock field.



<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1384)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->