### PR TITLE
feat(solver,frontend): Tier 1 observability metrics (#1380)

### DIFF
--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -110,6 +110,85 @@ def _compute_optimality_gap(objective: float | None, best_bound: float | None) -
     return abs(objective - best_bound) / max(abs(objective), 1.0)
 
 
+def _is_linear_constraint(c: Any) -> bool:
+    """True if the constraint proto is a linear constraint.
+
+    Uses the ``has_linear()`` accessor exposed by ortools' wrapped protobuf,
+    matching the pattern used by :func:`_count_constraint_types`.
+    """
+    checker = getattr(c, "has_linear", None)
+    return bool(callable(checker) and checker())
+
+
+def _count_reified_linear_constraints(proto: Any) -> int:
+    """Count linear constraints with non-empty enforcement_literal.
+
+    Stage 4 of Stream 1 (hard MSO) cuts ~164 reified-linear constraints from
+    the S2 model. Without this metric in `solver_runs.stats` the
+    simplification wins are invisible on the dashboard.
+    """
+    return sum(1 for c in proto.constraints if _is_linear_constraint(c) and len(c.enforcement_literal) > 0)
+
+
+# Soft-constraint key prefixes set by each constraint helper. New constraint
+# modules should append a (prefix, module-label) pair here so they roll up
+# correctly. Keys whose prefix doesn't match any entry fall into "other".
+_SOFT_CONSTRAINT_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("must_satisfy_", "must_satisfy"),
+    ("grade_ratio_", "grade_ratio"),
+    ("level_regression_", "level_regression"),
+    ("age_spread_b", "age_spread"),
+)
+
+
+def _count_soft_constraints_by_module(violations: dict[str, Any]) -> dict[str, int]:
+    """Group `soft_constraint_violations` keys by constraint module prefix.
+
+    The dashboard uses this to show which constraint families dominate the
+    penalty surface — e.g. `grade_ratio=420` vs `must_satisfy=83` tells a
+    very different optimization story.
+    """
+    result: dict[str, int] = {}
+    for key in violations:
+        bucket = "other"
+        for prefix, label in _SOFT_CONSTRAINT_PREFIXES:
+            if key.startswith(prefix):
+                bucket = label
+                break
+        result[bucket] = result.get(bucket, 0) + 1
+    return result
+
+
+def _max_linear_coefficient(proto: Any) -> int:
+    """Max absolute linear coefficient across all linear constraints (plain
+    and reified). Values >100K signal big-M modeling; weak LP relaxation."""
+    max_coef = 0
+    for c in proto.constraints:
+        if _is_linear_constraint(c):
+            for coef in c.linear.coeffs:
+                abs_coef = abs(coef)
+                if abs_coef > max_coef:
+                    max_coef = abs_coef
+    return max_coef
+
+
+def _build_request_density_histogram(
+    requests_by_person: dict[int, list[Any]],
+) -> dict[int, int]:
+    """Histogram of (request_count -> camper_count).
+
+    Excludes campers with zero requests — they're the silent majority and
+    aren't useful signal. The interesting tail is single-request campers
+    (the stuck-core cohort from the S2 sweep)."""
+    result: dict[int, int] = {}
+    for reqs in requests_by_person.values():
+        count = len(reqs)
+        if count == 0:
+            continue
+        result[count] = result.get(count, 0) + 1
+    return result
+
+
 def _build_stats_dict(
     solver: Any,
     status: Any,  # `cp_model.CpSolverStatus` enum at runtime; cast to int for JSON
@@ -120,6 +199,9 @@ def _build_stats_dict(
     num_bunks: int,
     num_requests: int,
     satisfied_count: int,
+    *,
+    soft_constraint_violations: dict[str, Any] | None = None,
+    requests_by_person: dict[int, list[Any]] | None = None,
 ) -> dict[str, Any]:
     """Build the full stats dict captured per solver run.
 
@@ -179,6 +261,11 @@ def _build_stats_dict(
         "model_num_variables": len(model_proto.variables),
         "model_num_constraints": len(model_proto.constraints),
         "constraint_type_breakdown": _count_constraint_types(model_proto),
+        # Tier 1 observability (Stream 2, issue #1380)
+        "num_reified_linear": _count_reified_linear_constraints(model_proto),
+        "max_linear_coefficient": _max_linear_coefficient(model_proto),
+        "soft_constraints_by_module": _count_soft_constraints_by_module(soft_constraint_violations or {}),
+        "request_density_histogram": _build_request_density_histogram(requests_by_person or {}),
     }
 
 
@@ -365,6 +452,11 @@ class DirectBunkingSolver:
         total_requests = 0
         impossible_count = 0
         affected_campers = set()
+        impossible_by_reason = {
+            "target_not_in_solver": 0,
+            "cross_session": 0,
+            "malformed": 0,
+        }
 
         for person_cm_id, requests in self.input.requests_by_person.items():
             if person_cm_id not in self.person_idx_map:
@@ -383,6 +475,7 @@ class DirectBunkingSolver:
                             # Requested person not in solver at all
                             self.impossible_requests[person_cm_id].append(request)
                             impossible_count += 1
+                            impossible_by_reason["target_not_in_solver"] += 1
                             affected_campers.add(person_cm_id)
                         elif (
                             request.request_type == RequestType.BUNK_WITH.value
@@ -394,6 +487,7 @@ class DirectBunkingSolver:
                             # (not_bunk_with across sessions is trivially satisfied.)
                             self.impossible_requests[person_cm_id].append(request)
                             impossible_count += 1
+                            impossible_by_reason["cross_session"] += 1
                             affected_campers.add(person_cm_id)
                         else:
                             self.possible_requests[person_cm_id].append(request)
@@ -401,6 +495,7 @@ class DirectBunkingSolver:
                         # No requested person specified - treat as impossible
                         self.impossible_requests[person_cm_id].append(request)
                         impossible_count += 1
+                        impossible_by_reason["malformed"] += 1
                 else:
                     # Other request types (age_preference, etc.) are always possible
                     self.possible_requests[person_cm_id].append(request)
@@ -430,11 +525,12 @@ class DirectBunkingSolver:
                         )
 
         # Store summary for later use
-        self.request_validation_summary = {
+        self.request_validation_summary: dict[str, Any] = {
             "total_requests": total_requests,
             "possible_requests": total_requests - impossible_count,
             "impossible_requests": impossible_count,
             "affected_campers": len(affected_campers),
+            "impossible_by_reason": impossible_by_reason,
         }
 
     def check_feasibility(self) -> None:
@@ -805,6 +901,13 @@ class DirectBunkingSolver:
             "model_num_variables": None,
             "model_num_constraints": None,
             "constraint_type_breakdown": {},
+            # Tier 1 observability (Stream 2, issue #1380) — single-bunk
+            # path has no CP-SAT model, so reified/big-M are 0. Histogram
+            # and soft-by-module use the actual data we have.
+            "num_reified_linear": 0,
+            "max_linear_coefficient": 0,
+            "soft_constraints_by_module": _count_soft_constraints_by_module(self.soft_constraint_violations),
+            "request_density_histogram": _build_request_density_histogram(self.input.requests_by_person),
             "single_bunk_session": True,
         }
 
@@ -1000,6 +1103,8 @@ class DirectBunkingSolver:
             num_bunks=len(self.bunks),
             num_requests=len(self.input.requests),
             satisfied_count=sum(len(reqs) for reqs in satisfied_requests.values()),
+            soft_constraint_violations=self.soft_constraint_violations,
+            requests_by_person=self.input.requests_by_person,
         )
         stats["request_validation"] = self.request_validation_summary
 

--- a/bunking/solver/feasibility.py
+++ b/bunking/solver/feasibility.py
@@ -29,7 +29,7 @@ def check_feasibility(
     person_idx_map: dict[int, int],
     possible_requests: dict[int, list[DirectBunkRequest]],
     impossible_requests: dict[int, list[DirectBunkRequest]],
-    request_validation_summary: dict[str, int],
+    request_validation_summary: dict[str, Any],
 ) -> None:
     """Perform pre-solve feasibility checks and log warnings.
 

--- a/frontend/src/hooks/useSolverRuns.ts
+++ b/frontend/src/hooks/useSolverRuns.ts
@@ -23,6 +23,11 @@ export interface SolverRunStats {
   model_num_variables?: number
   model_num_constraints?: number
   constraint_type_breakdown?: Record<string, number>
+  // Tier 1 observability (Stream 2, issue #1380)
+  num_reified_linear?: number
+  max_linear_coefficient?: number
+  soft_constraints_by_module?: Record<string, number>
+  request_density_histogram?: Record<string, number>
   objective_value?: number | null
   total_requests?: number | null
   total_persons?: number | null
@@ -44,6 +49,8 @@ export interface SolverRunStats {
     mp_campers_satisfied?: number
     all_campers_total?: number
     all_campers_satisfied?: number
+    // Tier 1 observability (Stream 2, issue #1380)
+    impossible_by_reason?: Record<string, number>
   }
 }
 

--- a/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.test.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.test.tsx
@@ -74,7 +74,7 @@ describe('DrillDownDrawer', () => {
 
     it('renders soft constraints by module as chips', () => {
       render(<DrillDownDrawer run={tier1Run} onClose={vi.fn()} />)
-      expect(screen.getByText(/Soft constraints by module/i)).toBeInTheDocument()
+      expect(screen.getByText(/Soft constraint terms by module/i)).toBeInTheDocument()
       expect(screen.getByText(/must_satisfy: 83/)).toBeInTheDocument()
       expect(screen.getByText(/grade_ratio: 420/)).toBeInTheDocument()
       expect(screen.getByText(/age_spread: 17/)).toBeInTheDocument()
@@ -113,7 +113,7 @@ describe('DrillDownDrawer', () => {
         },
       }
       render(<DrillDownDrawer run={emptyRun} onClose={vi.fn()} />)
-      expect(screen.queryByText(/Soft constraints by module/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Soft constraint terms by module/i)).not.toBeInTheDocument()
       expect(screen.queryByText(/Request density/i)).not.toBeInTheDocument()
       // 0/0/0 breakdown is still meaningful when validation ran — hide only
       // when all three reasons are zero.

--- a/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.test.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.test.tsx
@@ -53,6 +53,74 @@ describe('DrillDownDrawer', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
+  describe('Tier 1 observability metrics (issue #1380)', () => {
+    const tier1Run: SolverRun = {
+      ...run,
+      stats: {
+        ...run.stats,
+        num_reified_linear: 164,
+        max_linear_coefficient: 250_000,
+        soft_constraints_by_module: { must_satisfy: 83, grade_ratio: 420, age_spread: 17 },
+        request_density_histogram: { 1: 142, 2: 38, 3: 12, 5: 1 },
+        request_validation: {
+          total_requests: 240,
+          possible_requests: 236,
+          impossible_requests: 4,
+          affected_campers: 3,
+          impossible_by_reason: { target_not_in_solver: 2, cross_session: 1, malformed: 1 },
+        },
+      },
+    }
+
+    it('renders soft constraints by module as chips', () => {
+      render(<DrillDownDrawer run={tier1Run} onClose={vi.fn()} />)
+      expect(screen.getByText(/Soft constraints by module/i)).toBeInTheDocument()
+      expect(screen.getByText(/must_satisfy: 83/)).toBeInTheDocument()
+      expect(screen.getByText(/grade_ratio: 420/)).toBeInTheDocument()
+      expect(screen.getByText(/age_spread: 17/)).toBeInTheDocument()
+    })
+
+    it('renders request density histogram', () => {
+      render(<DrillDownDrawer run={tier1Run} onClose={vi.fn()} />)
+      expect(screen.getByText(/Request density/i)).toBeInTheDocument()
+      // Chip format: "{count}× requests: {camper_count}"
+      expect(screen.getByText(/1× requests: 142/)).toBeInTheDocument()
+      expect(screen.getByText(/5× requests: 1/)).toBeInTheDocument()
+    })
+
+    it('renders impossible request breakdown by reason', () => {
+      render(<DrillDownDrawer run={tier1Run} onClose={vi.fn()} />)
+      expect(screen.getByText(/Impossible requests by reason/i)).toBeInTheDocument()
+      expect(screen.getByText(/target_not_in_solver: 2/)).toBeInTheDocument()
+      expect(screen.getByText(/cross_session: 1/)).toBeInTheDocument()
+      expect(screen.getByText(/malformed: 1/)).toBeInTheDocument()
+    })
+
+    it('hides empty dict-shaped sections', () => {
+      const emptyRun: SolverRun = {
+        ...run,
+        stats: {
+          ...run.stats,
+          soft_constraints_by_module: {},
+          request_density_histogram: {},
+          request_validation: {
+            total_requests: 0,
+            possible_requests: 0,
+            impossible_requests: 0,
+            affected_campers: 0,
+            impossible_by_reason: { target_not_in_solver: 0, cross_session: 0, malformed: 0 },
+          },
+        },
+      }
+      render(<DrillDownDrawer run={emptyRun} onClose={vi.fn()} />)
+      expect(screen.queryByText(/Soft constraints by module/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Request density/i)).not.toBeInTheDocument()
+      // 0/0/0 breakdown is still meaningful when validation ran — hide only
+      // when all three reasons are zero.
+      expect(screen.queryByText(/Impossible requests by reason/i)).not.toBeInTheDocument()
+    })
+  })
+
   it('exposes drawer as an aria dialog labeled by its heading', () => {
     render(<DrillDownDrawer run={run} onClose={vi.fn()} />)
     const dialog = screen.getByRole('dialog')

--- a/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.tsx
@@ -176,6 +176,56 @@ export function DrillDownDrawer({ run, onClose }: Props) {
             </div>
           ) : null}
 
+          {s.soft_constraints_by_module && Object.keys(s.soft_constraints_by_module).length > 0 ? (
+            <div>
+              <div className="mb-2 text-xs tracking-wide text-gray-500 uppercase">
+                Soft constraints by module
+              </div>
+              <div className="flex flex-wrap gap-2 text-sm">
+                {Object.entries(s.soft_constraints_by_module).map(([mod, count]) => (
+                  <span key={mod} className="rounded bg-amber-50 px-3 py-1 text-amber-900">
+                    {mod}: {count.toLocaleString()}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {s.request_density_histogram && Object.keys(s.request_density_histogram).length > 0 ? (
+            <div>
+              <div className="mb-2 text-xs tracking-wide text-gray-500 uppercase">
+                Request density (campers grouped by request count)
+              </div>
+              <div className="flex flex-wrap gap-2 text-sm">
+                {Object.entries(s.request_density_histogram)
+                  .sort(([a], [b]) => Number(a) - Number(b))
+                  .map(([count, campers]) => (
+                    <span key={count} className="rounded bg-emerald-50 px-3 py-1 text-emerald-900">
+                      {count}× requests: {campers.toLocaleString()}
+                    </span>
+                  ))}
+              </div>
+            </div>
+          ) : null}
+
+          {s.request_validation?.impossible_by_reason &&
+          Object.values(s.request_validation.impossible_by_reason).some((n) => n > 0) ? (
+            <div>
+              <div className="mb-2 text-xs tracking-wide text-gray-500 uppercase">
+                Impossible requests by reason
+              </div>
+              <div className="flex flex-wrap gap-2 text-sm">
+                {Object.entries(s.request_validation.impossible_by_reason).map(
+                  ([reason, count]) => (
+                    <span key={reason} className="rounded bg-red-50 px-3 py-1 text-red-900">
+                      {reason}: {count.toLocaleString()}
+                    </span>
+                  )
+                )}
+              </div>
+            </div>
+          ) : null}
+
           {d.config_snapshot ? (
             <details className="rounded-lg bg-gray-50">
               <summary className="cursor-pointer px-4 py-3 text-xs font-medium tracking-wide text-gray-500 uppercase">

--- a/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.tsx
@@ -179,7 +179,7 @@ export function DrillDownDrawer({ run, onClose }: Props) {
           {s.soft_constraints_by_module && Object.keys(s.soft_constraints_by_module).length > 0 ? (
             <div>
               <div className="mb-2 text-xs tracking-wide text-gray-500 uppercase">
-                Soft constraints by module
+                Soft constraint terms by module
               </div>
               <div className="flex flex-wrap gap-2 text-sm">
                 {Object.entries(s.soft_constraints_by_module).map(([mod, count]) => (

--- a/frontend/src/pages/summer/SolverDebugPage/buildRunSummary.test.ts
+++ b/frontend/src/pages/summer/SolverDebugPage/buildRunSummary.test.ts
@@ -137,6 +137,59 @@ describe('buildRunSummary', () => {
     ])
   })
 
+  describe('Tier 1 observability dict fields (issue #1380)', () => {
+    const withTier1: SolverRun = {
+      ...fullRun,
+      stats: {
+        ...fullRun.stats,
+        soft_constraints_by_module: { must_satisfy: 167, grade_ratio: 96 },
+        request_density_histogram: { '1': 38, '2': 58 },
+        request_validation: {
+          ...(fullRun.stats?.request_validation ?? {}),
+          impossible_by_reason: { target_not_in_solver: 2, cross_session: 1, malformed: 0 },
+        },
+      },
+    }
+
+    it('includes soft_constraints_by_module when non-empty', () => {
+      const out = buildRunSummary(withTier1)
+      expect(out.soft_constraints_by_module).toEqual({ must_satisfy: 167, grade_ratio: 96 })
+    })
+
+    it('includes request_density_histogram when non-empty', () => {
+      const out = buildRunSummary(withTier1)
+      expect(out.request_density_histogram).toEqual({ '1': 38, '2': 58 })
+    })
+
+    it('includes impossible_request_breakdown when any reason > 0', () => {
+      const out = buildRunSummary(withTier1)
+      expect(out.impossible_request_breakdown).toEqual({
+        target_not_in_solver: 2,
+        cross_session: 1,
+        malformed: 0,
+      })
+    })
+
+    it('omits dict fields when empty or all zero', () => {
+      const empty: SolverRun = {
+        ...fullRun,
+        stats: {
+          ...fullRun.stats,
+          soft_constraints_by_module: {},
+          request_density_histogram: {},
+          request_validation: {
+            ...(fullRun.stats?.request_validation ?? {}),
+            impossible_by_reason: { target_not_in_solver: 0, cross_session: 0, malformed: 0 },
+          },
+        },
+      }
+      const out = buildRunSummary(empty)
+      expect(out.soft_constraints_by_module).toBeUndefined()
+      expect(out.request_density_histogram).toBeUndefined()
+      expect(out.impossible_request_breakdown).toBeUndefined()
+    })
+  })
+
   it('includes solution_strategy when solution_info is set, omits otherwise', () => {
     const out = buildRunSummary(fullRun)
     expect(out.solution_strategy).toBe(

--- a/frontend/src/pages/summer/SolverDebugPage/buildRunSummary.ts
+++ b/frontend/src/pages/summer/SolverDebugPage/buildRunSummary.ts
@@ -37,6 +37,9 @@ export interface RunSummary {
   model?: Record<string, string | number>
   solution_strategy?: string
   constraint_type_breakdown?: Record<string, number>
+  soft_constraints_by_module?: Record<string, number>
+  request_density_histogram?: Record<string, number>
+  impossible_request_breakdown?: Record<string, number>
   config_snapshot?: Record<string, string>
 }
 
@@ -83,6 +86,19 @@ export function buildRunSummary(run: SolverRun): RunSummary {
   if (stats.solution_info) summary.solution_strategy = stats.solution_info
   if (stats.constraint_type_breakdown) {
     summary.constraint_type_breakdown = stats.constraint_type_breakdown
+  }
+  if (
+    stats.soft_constraints_by_module &&
+    Object.keys(stats.soft_constraints_by_module).length > 0
+  ) {
+    summary.soft_constraints_by_module = stats.soft_constraints_by_module
+  }
+  if (stats.request_density_histogram && Object.keys(stats.request_density_histogram).length > 0) {
+    summary.request_density_histogram = stats.request_density_histogram
+  }
+  const breakdown = stats.request_validation?.impossible_by_reason
+  if (breakdown && Object.values(breakdown).some((n) => n > 0)) {
+    summary.impossible_request_breakdown = breakdown
   }
   if (details.config_snapshot) summary.config_snapshot = details.config_snapshot
 

--- a/frontend/src/pages/summer/SolverDebugPage/metricRegistry.test.ts
+++ b/frontend/src/pages/summer/SolverDebugPage/metricRegistry.test.ts
@@ -45,6 +45,9 @@ describe('METRIC_REGISTRY', () => {
         'num_linear',
         'num_bool_and',
         'num_lin_max',
+        // Tier 1 observability (Stream 2, issue #1380)
+        'num_reified_linear',
+        'max_linear_coefficient',
         // new PR1 keys
         'mp_request_rate',
         'mp_camper_rate',

--- a/frontend/src/pages/summer/SolverDebugPage/metricRegistry.ts
+++ b/frontend/src/pages/summer/SolverDebugPage/metricRegistry.ts
@@ -168,6 +168,27 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
     parent: 'model_num_constraints',
     highlight: { mode: 'on-delta' },
   },
+  num_reified_linear: {
+    key: 'num_reified_linear',
+    label: 'reified linear',
+    description:
+      'Linear constraints with an enforcement literal (indicator-style). Direct measure of model complexity — fewer = simpler relaxation.',
+    interpretation: 'lower-better',
+    format: 'integer',
+    group: 'model',
+    parent: 'num_linear',
+    highlight: { mode: 'on-delta' },
+  },
+  max_linear_coefficient: {
+    key: 'max_linear_coefficient',
+    label: 'max linear coef',
+    description:
+      'Largest absolute coefficient across all linear constraints. Values >100K signal big-M modeling and weak LP relaxation.',
+    interpretation: 'lower-better',
+    format: 'integer',
+    group: 'model',
+    highlight: { mode: 'on-delta' },
+  },
   mp_request_rate: {
     key: 'mp_request_rate',
     label: 'Optimized (MP req)',
@@ -447,6 +468,8 @@ export const COMPARABLE_METRICS: readonly string[] = [
   'num_bool_and',
   'num_bool_or',
   'num_lin_max',
+  'num_reified_linear',
+  'max_linear_coefficient',
   // size (PR1)
   'total_persons',
   'total_bunks',

--- a/tests/unit/solver/test_direct_solver_stats.py
+++ b/tests/unit/solver/test_direct_solver_stats.py
@@ -467,6 +467,11 @@ _BUILD_STATS_DICT_KEYS = frozenset(
         "model_num_variables",
         "model_num_constraints",
         "constraint_type_breakdown",
+        # Tier 1 observability (Stream 2, issue #1380)
+        "num_reified_linear",
+        "max_linear_coefficient",
+        "soft_constraints_by_module",
+        "request_density_histogram",
     }
 )
 
@@ -784,3 +789,466 @@ class TestUnknownConstraintBucket:
         assert result.get("bool_and") == 1
         assert result.get("unknown") == 1
         assert sum(result.values()) == 2
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Tier 1 observability metrics (Stream 2 of solver roadmap, issue #1380)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCountReifiedLinearConstraints:
+    """Reified linear = linear constraint with non-empty enforcement_literal.
+
+    Stage 4 of Stream 1 (hard MSO) cuts ~164 reified-linear constraints. We
+    need this metric in `solver_runs.stats` so the simplification PR is
+    visible on the dashboard.
+    """
+
+    def test_empty_model_returns_zero(self) -> None:
+        from bunking.solver.direct_solver import _count_reified_linear_constraints
+
+        model = cp_model.CpModel()
+        assert _count_reified_linear_constraints(model.Proto()) == 0
+
+    def test_plain_linear_not_counted(self) -> None:
+        from bunking.solver.direct_solver import _count_reified_linear_constraints
+
+        model = cp_model.CpModel()
+        x = model.NewIntVar(0, 10, "x")
+        model.Add(x >= 5)  # plain linear, no enforcement_literal
+        assert _count_reified_linear_constraints(model.Proto()) == 0
+
+    def test_counts_reified_linear_constraints(self) -> None:
+        from bunking.solver.direct_solver import _count_reified_linear_constraints
+
+        model = cp_model.CpModel()
+        x = model.NewIntVar(0, 10, "x")
+        a = model.NewBoolVar("a")
+        b = model.NewBoolVar("b")
+        # Two reified linear: x>=5 only when a; x<=3 only when b
+        model.Add(x >= 5).OnlyEnforceIf(a)
+        model.Add(x <= 3).OnlyEnforceIf(b)
+        # One plain linear (no enforcement) — must NOT be counted
+        model.Add(x != 7)
+        # One bool_and — must NOT be counted (different constraint type)
+        model.AddBoolAnd([a, b])
+        assert _count_reified_linear_constraints(model.Proto()) == 2
+
+
+class TestCountSoftConstraintsByModule:
+    """`soft_constraint_violations` keys carry module prefixes set by each
+    constraint helper. Roll them up into a per-module count so the dashboard
+    can show which constraint families produced the most penalty terms.
+
+    Known prefixes (as of 2026-05):
+    - `must_satisfy_<cm_id>`             (must_satisfy.py)
+    - `grade_ratio_<bunk>_grade_<grade>` (grade_ratio.py)
+    - `level_regression_<p>_<b>`         (level_progression.py)
+    - `age_spread_b<bunk>`               (age_spread.py)
+    """
+
+    def test_empty_dict_returns_empty(self) -> None:
+        from bunking.solver.direct_solver import _count_soft_constraints_by_module
+
+        assert _count_soft_constraints_by_module({}) == {}
+
+    def test_groups_keys_by_known_prefix(self) -> None:
+        from bunking.solver.direct_solver import _count_soft_constraints_by_module
+
+        # Values don't matter — function only inspects keys
+        violations: dict[str, object] = {
+            "must_satisfy_12345": object(),
+            "must_satisfy_67890": object(),
+            "grade_ratio_0_grade_5": object(),
+            "grade_ratio_1_grade_6": object(),
+            "grade_ratio_2_grade_7": object(),
+            "level_regression_0_0": object(),
+            "age_spread_b0": object(),
+            "age_spread_b1": object(),
+        }
+        result = _count_soft_constraints_by_module(violations)
+        assert result == {
+            "must_satisfy": 2,
+            "grade_ratio": 3,
+            "level_regression": 1,
+            "age_spread": 2,
+        }
+
+    def test_unknown_prefix_lands_in_other(self) -> None:
+        from bunking.solver.direct_solver import _count_soft_constraints_by_module
+
+        violations: dict[str, object] = {
+            "some_future_constraint_42": object(),
+            "must_satisfy_1": object(),
+        }
+        result = _count_soft_constraints_by_module(violations)
+        assert result.get("must_satisfy") == 1
+        assert result.get("other") == 1
+
+
+class TestMaxLinearCoefficient:
+    """Max absolute linear coefficient surfaces big-M modeling. Values >100K
+    are a signal that the model has weak indicator-style constraints that
+    LP relaxation can't tighten."""
+
+    def test_empty_model_returns_zero(self) -> None:
+        from bunking.solver.direct_solver import _max_linear_coefficient
+
+        model = cp_model.CpModel()
+        assert _max_linear_coefficient(model.Proto()) == 0
+
+    def test_finds_max_across_linear_constraints(self) -> None:
+        from bunking.solver.direct_solver import _max_linear_coefficient
+
+        model = cp_model.CpModel()
+        x = model.NewIntVar(0, 1000, "x")
+        y = model.NewIntVar(0, 1000, "y")
+        model.Add(2 * x + 1000 * y <= 50_000)
+        model.Add(3 * x + 7 * y >= 10)
+        # Largest abs coefficient is 1000 (the 50_000 is the bound, not a coeff)
+        assert _max_linear_coefficient(model.Proto()) == 1000
+
+    def test_negative_coefficient_uses_absolute_value(self) -> None:
+        from bunking.solver.direct_solver import _max_linear_coefficient
+
+        model = cp_model.CpModel()
+        x = model.NewIntVar(0, 100, "x")
+        y = model.NewIntVar(0, 100, "y")
+        model.Add(-50_000 * x + 3 * y <= 0)
+        assert _max_linear_coefficient(model.Proto()) == 50_000
+
+    def test_includes_reified_linear_constraints(self) -> None:
+        from bunking.solver.direct_solver import _max_linear_coefficient
+
+        model = cp_model.CpModel()
+        x = model.NewIntVar(0, 100, "x")
+        a = model.NewBoolVar("a")
+        model.Add(250_000 * x <= 0).OnlyEnforceIf(a)
+        assert _max_linear_coefficient(model.Proto()) == 250_000
+
+    def test_ignores_non_linear_constraint_types(self) -> None:
+        from bunking.solver.direct_solver import _max_linear_coefficient
+
+        model = cp_model.CpModel()
+        a = model.NewBoolVar("a")
+        b = model.NewBoolVar("b")
+        model.AddBoolAnd([a, b])  # No coefficients to look at
+        model.AddBoolOr([a, b])
+        assert _max_linear_coefficient(model.Proto()) == 0
+
+
+class TestRequestDensityHistogram:
+    """Per-camper request count histogram. Maps (request_count -> camper_count)
+    so the dashboard can show whether the stuck-core is dominated by
+    single-request kids (the typical S2 finding)."""
+
+    def test_empty_dict_returns_empty(self) -> None:
+        from bunking.solver.direct_solver import _build_request_density_histogram
+
+        assert _build_request_density_histogram({}) == {}
+
+    def test_groups_campers_by_request_count(self) -> None:
+        from bunking.solver.direct_solver import _build_request_density_histogram
+
+        # 1 camper with 3 requests, 2 with 1, 1 with 5
+        requests_by_person: dict[int, list[object]] = {
+            1001: [object(), object(), object()],
+            1002: [object()],
+            1003: [object()],
+            1004: [object(), object(), object(), object(), object()],
+        }
+        result = _build_request_density_histogram(requests_by_person)
+        assert result == {3: 1, 1: 2, 5: 1}
+
+    def test_skips_zero_request_campers(self) -> None:
+        from bunking.solver.direct_solver import _build_request_density_histogram
+
+        requests_by_person: dict[int, list[object]] = {
+            1001: [object()],
+            1002: [],  # zero-request campers excluded
+        }
+        result = _build_request_density_histogram(requests_by_person)
+        assert result == {1: 1}
+
+
+class TestImpossibleRequestBreakdownByReason:
+    """`_validate_requests` already classifies impossible requests into three
+    cases internally (target_not_in_solver / cross_session / malformed). The
+    summary previously exposed only the total — now it must expose per-reason
+    counts so the dashboard can show *why* requests are impossible.
+    """
+
+    def _make_input(
+        self,
+        persons: list[DirectPerson],
+        requests: list[DirectBunkRequest],
+        bunks: list[DirectBunk] | None = None,
+    ) -> DirectSolverInput:
+        if bunks is None:
+            bunks = [
+                DirectBunk(
+                    id="bunk-1",
+                    campminder_id=9001,
+                    name="A",
+                    capacity=10,
+                    gender="Mixed",
+                    session_cm_id=500,
+                ),
+                DirectBunk(
+                    id="bunk-2",
+                    campminder_id=9002,
+                    name="B",
+                    capacity=10,
+                    gender="Mixed",
+                    session_cm_id=501,
+                ),
+            ]
+        return DirectSolverInput(persons=persons, requests=requests, bunks=bunks)
+
+    def test_summary_includes_breakdown_dict(self) -> None:
+        persons = [
+            DirectPerson(
+                campminder_person_id=1,
+                first_name="A",
+                last_name="X",
+                grade=8,
+                birthdate="2014-01-01",
+                gender="M",
+                session_cm_id=500,
+            ),
+        ]
+        input_data = self._make_input(persons, requests=[])
+        solver = DirectBunkingSolver(input_data=input_data, config_service=MagicMock())
+        # _validate_requests has been called in __init__
+        breakdown = solver.request_validation_summary.get("impossible_by_reason")
+        assert isinstance(breakdown, dict)
+        assert breakdown == {
+            "target_not_in_solver": 0,
+            "cross_session": 0,
+            "malformed": 0,
+        }
+
+    def test_target_not_in_solver_counted(self) -> None:
+        persons = [
+            DirectPerson(
+                campminder_person_id=1,
+                first_name="A",
+                last_name="X",
+                grade=8,
+                birthdate="2014-01-01",
+                gender="M",
+                session_cm_id=500,
+            ),
+        ]
+        # Request targets person 9999 who does not exist in input.persons
+        request = DirectBunkRequest(
+            id="req-1",
+            requester_person_cm_id=1,
+            requested_person_cm_id=9999,
+            request_type="bunk_with",
+            session_cm_id=500,
+            year=2026,
+        )
+        input_data = self._make_input(persons, requests=[request])
+        solver = DirectBunkingSolver(input_data=input_data, config_service=MagicMock())
+        breakdown = solver.request_validation_summary["impossible_by_reason"]
+        assert breakdown["target_not_in_solver"] == 1
+        assert breakdown["cross_session"] == 0
+        assert breakdown["malformed"] == 0
+
+    def test_cross_session_counted(self) -> None:
+        persons = [
+            DirectPerson(
+                campminder_person_id=1,
+                first_name="A",
+                last_name="X",
+                grade=8,
+                birthdate="2014-01-01",
+                gender="M",
+                session_cm_id=500,
+            ),
+            DirectPerson(
+                campminder_person_id=2,
+                first_name="B",
+                last_name="Y",
+                grade=8,
+                birthdate="2014-01-01",
+                gender="M",
+                session_cm_id=501,  # different session
+            ),
+        ]
+        request = DirectBunkRequest(
+            id="req-1",
+            requester_person_cm_id=1,
+            requested_person_cm_id=2,
+            request_type="bunk_with",
+            session_cm_id=500,
+            year=2026,
+        )
+        input_data = self._make_input(persons, requests=[request])
+        solver = DirectBunkingSolver(input_data=input_data, config_service=MagicMock())
+        breakdown = solver.request_validation_summary["impossible_by_reason"]
+        assert breakdown["cross_session"] == 1
+        assert breakdown["target_not_in_solver"] == 0
+        assert breakdown["malformed"] == 0
+
+    def test_malformed_counted(self) -> None:
+        persons = [
+            DirectPerson(
+                campminder_person_id=1,
+                first_name="A",
+                last_name="X",
+                grade=8,
+                birthdate="2014-01-01",
+                gender="M",
+                session_cm_id=500,
+            ),
+        ]
+        # bunk_with with empty requested_person_cm_id → malformed
+        request = DirectBunkRequest(
+            id="req-1",
+            requester_person_cm_id=1,
+            requested_person_cm_id=None,
+            request_type="bunk_with",
+            session_cm_id=500,
+            year=2026,
+        )
+        input_data = self._make_input(persons, requests=[request])
+        solver = DirectBunkingSolver(input_data=input_data, config_service=MagicMock())
+        breakdown = solver.request_validation_summary["impossible_by_reason"]
+        assert breakdown["malformed"] == 1
+        assert breakdown["target_not_in_solver"] == 0
+        assert breakdown["cross_session"] == 0
+
+    def test_breakdown_sum_equals_total_impossible(self) -> None:
+        persons = [
+            DirectPerson(
+                campminder_person_id=1,
+                first_name="A",
+                last_name="X",
+                grade=8,
+                birthdate="2014-01-01",
+                gender="M",
+                session_cm_id=500,
+            ),
+            DirectPerson(
+                campminder_person_id=2,
+                first_name="B",
+                last_name="Y",
+                grade=8,
+                birthdate="2014-01-01",
+                gender="M",
+                session_cm_id=501,
+            ),
+        ]
+        requests = [
+            # target_not_in_solver
+            DirectBunkRequest(
+                id="r1",
+                requester_person_cm_id=1,
+                requested_person_cm_id=9999,
+                request_type="bunk_with",
+                session_cm_id=500,
+                year=2026,
+            ),
+            # cross_session
+            DirectBunkRequest(
+                id="r2",
+                requester_person_cm_id=1,
+                requested_person_cm_id=2,
+                request_type="bunk_with",
+                session_cm_id=500,
+                year=2026,
+            ),
+            # malformed
+            DirectBunkRequest(
+                id="r3",
+                requester_person_cm_id=1,
+                requested_person_cm_id=None,
+                request_type="bunk_with",
+                session_cm_id=500,
+                year=2026,
+            ),
+        ]
+        input_data = self._make_input(persons, requests=requests)
+        solver = DirectBunkingSolver(input_data=input_data, config_service=MagicMock())
+        summary = solver.request_validation_summary
+        breakdown = summary["impossible_by_reason"]
+        assert sum(breakdown.values()) == summary["impossible_requests"]
+        assert summary["impossible_requests"] == 3
+
+
+class TestTier1MetricsInStatsDict:
+    """The 5 new Tier 1 metrics (Stream 2) must land in `solver_runs.stats`.
+
+    `_build_stats_dict` now accepts:
+    - `soft_constraint_violations`: dict — to compute soft_by_module
+    - `requests_by_person`: dict — to compute request density histogram
+    - `request_validation_summary`: dict — pass-through with impossible_by_reason
+
+    And emits:
+    - `num_reified_linear`: int
+    - `max_linear_coefficient`: int
+    - `soft_constraints_by_module`: dict[str, int]
+    - `request_density_histogram`: dict[int, int]
+    - request_validation.impossible_by_reason: dict[str, int]  (via existing field)
+    """
+
+    def _base_mock_solver(self) -> MagicMock:
+        solver = MagicMock()
+        solver.StatusName.return_value = "OPTIMAL"
+        solver.ObjectiveValue.return_value = 1.0
+        solver.WallTime.return_value = 0.1
+        solver.UserTime.return_value = 0.1
+        solver.BestObjectiveBound.return_value = 1.0
+        solver.NumBranches.return_value = 0
+        solver.NumConflicts.return_value = 0
+        solver.NumBooleans.return_value = 0
+        solver.ResponseProto.return_value = MagicMock(
+            gap_integral=None,
+            deterministic_time=0.0,
+            num_integers=0,
+            additional_solutions=[],
+            solution_info="",
+        )
+        return solver
+
+    def test_emits_new_tier1_keys(self) -> None:
+        from bunking.solver.direct_solver import _build_stats_dict
+
+        model = cp_model.CpModel()
+        x = model.NewIntVar(0, 10, "x")
+        a = model.NewBoolVar("a")
+        model.Add(50_000 * x <= 100).OnlyEnforceIf(a)  # reified + big-M
+
+        solver = self._base_mock_solver()
+        violations = {
+            "must_satisfy_1": object(),
+            "must_satisfy_2": object(),
+            "grade_ratio_0_grade_5": object(),
+        }
+        requests_by_person: dict[int, list[object]] = {
+            1: [object()],
+            2: [object(), object()],
+        }
+        stats = _build_stats_dict(
+            solver=solver,
+            status=4,  # OPTIMAL int — keep test stable across versions
+            model_proto=model.Proto(),
+            time_limit_seconds=60,
+            num_workers=8,
+            num_persons=2,
+            num_bunks=1,
+            num_requests=3,
+            satisfied_count=0,
+            soft_constraint_violations=violations,
+            requests_by_person=requests_by_person,
+        )
+
+        assert stats["num_reified_linear"] == 1
+        assert stats["max_linear_coefficient"] == 50_000
+        assert stats["soft_constraints_by_module"] == {
+            "must_satisfy": 2,
+            "grade_ratio": 1,
+        }
+        assert stats["request_density_histogram"] == {1: 1, 2: 1}


### PR DESCRIPTION
## Summary

Stream 2 of the [Solver Optimization Roadmap Q2 2026](https://github.com/adamflagg/kindred/blob/main/docs/reference/solver-roadmap.md#stream-2--solver-debug-metrics-expansion-tier-1--tier-2). Closes #1380 (Tier 1 only; Tier 2 deferred to a follow-up).

Adds 5 read-only metrics to `solver_runs.stats` so the SolverDebug dashboard can show **why** the solver behaved a given way, not just that it did. Scaffolds Stream 1's reified-linear simplification wins and the stuck-core cohort analysis.

### Backend (`bunking/solver/direct_solver.py`)

| Metric | Source | Why |
|---|---|---|
| `num_reified_linear` | scan `model.Proto().constraints` for linear + non-empty `enforcement_literal` | Direct measure of model complexity; Stage 4 cuts ~164 |
| `max_linear_coefficient` | scan model proto linear coeffs (abs) | Values >100K signal big-M modeling; weak LP relaxation |
| `soft_constraints_by_module` | group `ctx.soft_constraint_violations` keys by prefix | 4 modules: `must_satisfy`, `grade_ratio`, `level_regression`, `age_spread` |
| `request_density_histogram` | precompute from `requests_by_person` | Single-request kids are the stuck-core; visualize the distribution |
| `request_validation.impossible_by_reason` | extend `_validate_requests` reason tracking | Split single "impossible" count into `target_not_in_solver` / `cross_session` / `malformed` |

### Frontend (`SolverDebugPage/DrillDownDrawer.tsx`)

Renders all four dict-shaped fields as colored chip rows (mirrors the existing `constraint_type_breakdown` pattern). Sections hide when empty.

### Out of scope

Tier 2 (best-bound trajectory callback, LP root gap, per-sub-solver wall time, presolve compression ratio, symmetry flag) deferred — those need callback-time capture and response-proto digging, separate from this read-only scaffold.

## Test plan

- [x] Backend: 52 unit tests pass (`uv run pytest tests/unit/solver/test_direct_solver_stats.py`) — 20 new tests for the 5 metrics, all existing tests still green
- [x] Frontend: 4074 tests pass (`npx vitest run`) — 4 new tests in `DrillDownDrawer.test.tsx` for chip rendering + empty-section hiding
- [x] mypy clean, ruff clean, eslint clean, prettier clean
- [ ] Spot-check on dev SolverDebug page that drill-down drawer renders the new sections from a real solve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended solver observability with tier‑1 metrics: reified linear counts, max linear coefficient, soft‑constraint counts by module, and request‑density histogram
  * Request validation now records impossibility breakdowns by reason and surfaces them in run stats

* **UI**
  * Debug drawer and run summary expose soft‑constraint, request‑density, and impossible‑reason sections only when data present
  * New metrics added to metric registry and comparison panel

* **Tests**
  * Added unit/integration tests covering the new observability metrics and impossibility breakdowns

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1385)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->