### PR TITLE
fix(pb): loosen debug_pipeline_* RBAC from admin-only to bunking.manage

### DIFF
--- a/pocketbase/main_debug_pipeline_rbac_test.go
+++ b/pocketbase/main_debug_pipeline_rbac_test.go
@@ -49,11 +49,11 @@ func TestDebugPipelineRBACMigrationUsesBunkingManageRule(t *testing.T) {
 		t.Errorf("migration %s must call app.save() to persist rule changes", path)
 	}
 
-	if !strings.Contains(body, "migrate((app)") || strings.Count(body, "migrate((app)") < 1 {
+	if !strings.Contains(body, "migrate((app)") {
 		t.Errorf("migration %s must define an up function via migrate((app) => ...)", path)
 	}
 
-	if !strings.Contains(body, "}, (app)") && !strings.Contains(body, "}, (app) =>") {
+	if !strings.Contains(body, "}, (app)") {
 		t.Errorf("migration %s must define a down function", path)
 	}
 }

--- a/pocketbase/main_debug_pipeline_rbac_test.go
+++ b/pocketbase/main_debug_pipeline_rbac_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestDebugPipelineRBACMigrationUsesBunkingManageRule verifies that
+// migration 1500000098_debug_pipeline_rbac.js loosens the admin-only
+// listRule/viewRule on the three debug_pipeline_* collections to the
+// canonical bunkingManage rule (admin OR users with bunking.manage in
+// cached_permissions). This matches the upload endpoint's auth gate
+// (requirePermission("bunking.manage", ...) in sync/api.go) so that
+// non-admin staff who can upload CSVs can also read the resulting debug
+// pipeline status — fixing the cascading 403→phase=error toolbar banner
+// described in #1370.
+//
+// Test asserts on the migration FILE content rather than runtime behavior
+// because applying JS migrations from a Go test requires bootstrapping
+// jsvm with the migrations dir, which tests.NewTestApp() does not do.
+// pb-js-lint validates syntax; this test locks in the semantics.
+func TestDebugPipelineRBACMigrationUsesBunkingManageRule(t *testing.T) {
+	const path = "pb_migrations/1500000098_debug_pipeline_rbac.js"
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration %s: %v", path, err)
+	}
+	body := string(content)
+
+	const expectedRule = `'@request.auth.is_admin = true || @request.auth.cached_permissions ~ "bunking.manage"'`
+	if !strings.Contains(body, expectedRule) {
+		t.Errorf("migration %s must contain canonical bunkingManage rule string %s", path, expectedRule)
+	}
+
+	for _, col := range []string{"debug_pipeline_runs", "debug_pipeline_traces", "debug_pipeline_summary"} {
+		if !strings.Contains(body, `"`+col+`"`) {
+			t.Errorf("migration %s must reference collection %q", path, col)
+		}
+	}
+
+	for _, fn := range []string{"listRule", "viewRule"} {
+		if !strings.Contains(body, fn) {
+			t.Errorf("migration %s must set %s", path, fn)
+		}
+	}
+
+	if !strings.Contains(body, "app.save(") {
+		t.Errorf("migration %s must call app.save() to persist rule changes", path)
+	}
+
+	if !strings.Contains(body, "migrate((app)") || strings.Count(body, "migrate((app)") < 1 {
+		t.Errorf("migration %s must define an up function via migrate((app) => ...)", path)
+	}
+
+	if !strings.Contains(body, "}, (app)") && !strings.Contains(body, "}, (app) =>") {
+		t.Errorf("migration %s must define a down function", path)
+	}
+}

--- a/pocketbase/pb_migrations/1500000098_debug_pipeline_rbac.js
+++ b/pocketbase/pb_migrations/1500000098_debug_pipeline_rbac.js
@@ -1,0 +1,39 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: loosen RBAC on debug_pipeline_* collections from admin-only
+ * to bunking.manage, matching the CSV upload endpoint's auth gate.
+ *
+ * Fixes #1370: non-admin staff with bunking.manage permission could upload
+ * CSVs (POST /api/custom/sync/bunk_requests_upload — gated by
+ * requirePermission("bunking.manage", ...) in sync/api.go) but then got
+ * 403 on the follow-up GET /api/collections/debug_pipeline_runs/records
+ * call from useCsvPipelineStatus. Promise.allSettled swallowed the 403 as
+ * null, derivePhase saw debug=null with sync.status=completed, and after
+ * the 10-minute MATCHING_MAX_AGE_MS timeout returned phase=error — which
+ * rendered as a red "Import failed" banner in the toolbar even though the
+ * upload had succeeded.
+ *
+ * Collections only store summary counts (resolved/pending/declined),
+ * run_id, status_breakdown — no per-camper data — safe to expose to users
+ * with bunking.manage.
+ */
+
+migrate((app) => {
+  const bunkingManage = '@request.auth.is_admin = true || @request.auth.cached_permissions ~ "bunking.manage"'
+
+  for (const name of ["debug_pipeline_runs", "debug_pipeline_traces", "debug_pipeline_summary"]) {
+    const col = app.findCollectionByNameOrId(name)
+    col.listRule = bunkingManage
+    col.viewRule = bunkingManage
+    app.save(col)
+  }
+}, (app) => {
+  const adminOnly = '@request.auth.is_admin = true'
+
+  for (const name of ["debug_pipeline_runs", "debug_pipeline_traces", "debug_pipeline_summary"]) {
+    const col = app.findCollectionByNameOrId(name)
+    col.listRule = adminOnly
+    col.viewRule = adminOnly
+    app.save(col)
+  }
+});


### PR DESCRIPTION
## Summary

- Closes #1370 — non-admin staff with `bunking.manage` permission saw a red "Import failed" toolbar banner after every CSV upload, even though the upload itself succeeded.
- Root cause: `debug_pipeline_runs.listRule` was `@request.auth.is_admin = true` while the upload endpoint is gated on the broader `bunking.manage` permission. Authorized non-admin uploaders got 403 on the follow-up status fetch, which cascaded into a phase=error banner via the 10-min `MATCHING_MAX_AGE_MS` timeout in `useCsvPipelineStatus.ts`.
- Migration loosens `listRule`/`viewRule` on `debug_pipeline_runs`, `debug_pipeline_traces`, `debug_pipeline_summary` to the canonical `bunkingManage` rule (`@request.auth.is_admin = true || @request.auth.cached_permissions ~ "bunking.manage"`).

## Why this is safe

The collections only store summary counts (resolved/pending/declined), `run_id`, `created`, and `status_breakdown` — no per-camper data. Read access matches the upload gate, which is the audience that already triggers writes via the CSV pipeline.

## Failure chain (for the record)

1. Upload succeeds (POST 200).
2. `onSuccess` invalidates `queryKeys.csvPipelineStatus()`.
3. `useCsvPipelineStatus` calls `Promise.allSettled([fetchSyncStatus, fetchLatestDebugRun])`.
4. `fetchLatestDebugRun` hits 403 → throws → `Promise.allSettled` resolves with `debug = null`.
5. After 10 min, `derivePhase` returns `{ phase: "error" }`.
6. `CsvPipelineIndicator` renders the red toolbar banner.

## Test plan

- [ ] Apply migration via `start_dev`, confirm `debug_pipeline_runs.listRule` updated in `_collections`.
- [ ] As a non-admin staff user with `bunking.manage` permission: upload a CSV → no error banner after success.
- [ ] As an admin: upload a CSV → no regression.
- [ ] As a user without `bunking.manage`: confirm 403 still returned (rule still excludes them).
- [ ] Reverse migration restores admin-only rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a validation test ensuring the debug pipeline RBAC migration enforces the expected bunking.manage authorization rule.

* **Chores**
  * Updated RBAC for debug pipeline collections (runs, traces, summary) to allow access for admins or callers with bunking.manage; rollback restores previous admin-only rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1387)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->