### PR TITLE
docs(frontend): document blank disposition_reason on manual decline

### DIFF
--- a/frontend/src/components/AllCamperRequestsModal.tsx
+++ b/frontend/src/components/AllCamperRequestsModal.tsx
@@ -366,6 +366,8 @@ export function AllCamperRequestsModal({
           anchorRect={confirmPopover.anchorRect}
           action={confirmPopover.action}
           onConfirm={() => {
+            // Manual decline writes `status: 'declined'` only — `disposition_reason`
+            // is intentionally left blank (see DECLINED_REASONS in dispositionColors.ts, #1368).
             updateRequestMutation.mutate({
               id: confirmPopover.requestId,
               updates:

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -611,6 +611,9 @@ export default function RequestReviewPanel({
       labelVerb: 'approval',
     })
 
+  // Manual decline writes `status: 'declined'` only — `disposition_reason` is
+  // intentionally left blank. See DECLINED_REASONS in dispositionColors.ts for
+  // the full rationale (#1368).
   const handleReject = (id: string) =>
     handleAction({
       id,
@@ -626,6 +629,8 @@ export default function RequestReviewPanel({
         .map((id) => requests.find((r: BunkRequestsResponse) => r.id === id))
         .filter((r): r is BunkRequestsResponse => Boolean(r))
         .map((r) => ({ id: r.id, status: r.status }))
+      // Bulk decline writes `status: 'declined'` only — `disposition_reason`
+      // is intentionally left blank (see DECLINED_REASONS in dispositionColors.ts, #1368).
       const updates: Partial<BunkRequestsResponse> =
         action === 'approve'
           ? { status: 'resolved' as BunkRequestsStatusOptions }

--- a/frontend/src/utils/dispositionColors.ts
+++ b/frontend/src/utils/dispositionColors.ts
@@ -32,6 +32,21 @@ export const PENDING_REASONS = new Set([
   'self_referential',
 ])
 
+/**
+ * Declined disposition reasons emitted by the pipeline rules engine
+ * (`bunking/sync/bunk_request_processor/disposition/disposition_rules.py`) or
+ * by Phase C target-decline (`orchestrator/target_decline.py`).
+ *
+ * Manual UI declines (RequestReviewPanel, AllCamperRequestsModal) intentionally
+ * write `status: 'declined'` with **no** `disposition_reason`. The pipeline has
+ * no opinion to record on a staff-initiated decline, and overloading the field
+ * with a `staff_manual`-style sentinel would either lose the prior pipeline
+ * reason (overwrite) or only partially populate (only-when-empty), neither of
+ * which yields an accurate "staff-touched" signal. If that signal is ever
+ * needed, add a dedicated `reviewed_by`/`reviewed_at` field instead. Empty
+ * `disposition_reason` on a declined row is the correct shape for manual UI
+ * declines (issue #1368, closed 2026-05-13).
+ */
 export const DECLINED_REASONS = new Set([
   'session_mismatch',
   'target_not_attending',


### PR DESCRIPTION
## Summary

Closes #1368 as not-a-bug. Investigation re-traced the root cause and concluded the 18 prod rows with `status='declined' AND disposition_reason=''` are correctly shaped manual-decline data, not a pipeline gap.

## Why the prior root cause was wrong

Triage doc originally pointed at `bunking/sync/collected_request.py:64-65` — but `CollectedRequest` is dead code (defined, never imported). Phase C also can't be the producer: `apply_target_decline` has written non-empty `disposition_reason` since #1206. Real producer is the frontend manual-decline mutations at `RequestReviewPanel.tsx:617`/`:635` and `AllCamperRequestsModal.tsx`, which intentionally send `{ status: 'declined' }` without a reason.

## Why a `staff_manual` sentinel is the wrong fix

Three shapes were considered:

- **Always overwrite** with `staff_manual` on UI mutation — loses prior pipeline signal (e.g., `needs_review` → `staff_manual`, can no longer answer "what % of AI-flagged rows did staff approve?")
- **Only-when-empty** — partial accuracy; "staff-touched filter" misses any UI decision on a row that already had a pipeline opinion
- **Dedicated `reviewed_by`/`reviewed_at` field** — YAGNI; no concrete consumer of "staff-touched" filter today

Conclusion: empty `disposition_reason` on a manually-declined row is the correct shape — the pipeline genuinely has no opinion to express. If a staff-touched filter is needed later, add a dedicated audit field instead of overloading the disposition vocabulary.

## Changes

- `frontend/src/utils/dispositionColors.ts` — JSDoc on `DECLINED_REASONS` documenting the invariant, with the full rationale
- `frontend/src/components/RequestReviewPanel.tsx` — short pointer comments at `handleReject` (single decline) and the bulk-decline path
- `frontend/src/components/AllCamperRequestsModal.tsx` — short pointer comment at the modal decline path

No behavior change. No data backfill.

## Test plan

- [x] Read the JSDoc — invariant + rationale clearly documented
- [x] Confirmed empty `disposition_reason` already renders correctly: `shouldShowReasonInStatus` returns `false` for empty reasons (`dispositionColors.ts:128`), so manually-declined rows show only the "Declined" chip with no orphan reason line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal documentation clarifying decline action behavior and status field handling in request management components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1389)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->