### PR TITLE
fix(sync): bunk request resolution cascade (closes #1377)

### DIFF
--- a/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
@@ -1271,6 +1271,7 @@ class RequestOrchestrator:
                         intent_trace=Phase2IntentTrace(
                             target_name=rr.target_name or "",
                             all_candidates=candidates_trace,
+                            pipeline_strategies_tried=list(rr_meta.get("pipeline_strategies_tried", [])),
                             staff_filtered=rr.method == "staff_filtered",
                             hallucination_detected=bool(rr_meta.get("below_threshold")),
                             final_result=Phase2FinalResult(

--- a/bunking/sync/bunk_request_processor/resolution/resolution_pipeline.py
+++ b/bunking/sync/bunk_request_processor/resolution/resolution_pipeline.py
@@ -384,9 +384,11 @@ class ResolutionPipeline:
 
             # Attach the per-request attempt log to the winning result so downstream
             # trace recorders can surface it on debug_pipeline_traces.phase2_resolution.
+            # Copy the list so per-request mutations can't leak into a shared/cached
+            # ResolutionResult if a strategy ever returns one.
             if best_result.metadata is None:
                 best_result.metadata = {}
-            best_result.metadata["pipeline_strategies_tried"] = strategy_attempts
+            best_result.metadata["pipeline_strategies_tried"] = list(strategy_attempts)
 
             # Log final decision
             logger.debug(

--- a/bunking/sync/bunk_request_processor/resolution/resolution_pipeline.py
+++ b/bunking/sync/bunk_request_processor/resolution/resolution_pipeline.py
@@ -297,6 +297,10 @@ class ResolutionPipeline:
             # Try each strategy with the pre-loaded data
             best_result = ResolutionResult()
             all_results = []  # Track all strategy results for debugging
+            # Per-request strategy attempt log for debug trace observability.
+            # Each entry: strategy name, derived sub_method, confidence, candidate count,
+            # and resolved/ambiguous flags. Attached to best_result.metadata at end.
+            strategy_attempts: list[dict[str, Any]] = []
 
             for strategy in self.strategies:
                 try:
@@ -330,6 +334,24 @@ class ResolutionPipeline:
                     )
                     all_results.append((strategy.name, result))
 
+                    # Derive sub_method from strategy metadata. Strategies already record
+                    # match_type for resolved paths and ambiguity_reason for ambiguous paths;
+                    # an explicit sub_method (set by some paths) wins over both.
+                    meta = result.metadata or {}
+                    sub_method = meta.get("sub_method") or meta.get("match_type") or meta.get("ambiguity_reason")
+                    strategy_attempts.append(
+                        {
+                            "strategy": strategy.name,
+                            "sub_method": sub_method,
+                            "confidence": result.confidence,
+                            "candidate_count": (
+                                len(result.candidates) if result.candidates else (1 if result.person else 0)
+                            ),
+                            "resolved": result.is_resolved,
+                            "ambiguous": result.is_ambiguous,
+                        }
+                    )
+
                     # If we got a definitive match with high confidence, use it
                     if result.is_resolved and result.confidence >= max(0.8, self.minimum_confidence):
                         best_result = result
@@ -347,7 +369,24 @@ class ResolutionPipeline:
                 except Exception as e:
                     # Log error but continue with other strategies
                     logger.error(f"Error in {strategy.name} strategy: {e}")
+                    strategy_attempts.append(
+                        {
+                            "strategy": strategy.name,
+                            "sub_method": None,
+                            "confidence": 0.0,
+                            "candidate_count": 0,
+                            "resolved": False,
+                            "ambiguous": False,
+                            "error": str(e),
+                        }
+                    )
                     continue
+
+            # Attach the per-request attempt log to the winning result so downstream
+            # trace recorders can surface it on debug_pipeline_traces.phase2_resolution.
+            if best_result.metadata is None:
+                best_result.metadata = {}
+            best_result.metadata["pipeline_strategies_tried"] = strategy_attempts
 
             # Log final decision
             logger.debug(

--- a/bunking/sync/bunk_request_processor/resolution/strategies/fuzzy_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/fuzzy_match.py
@@ -277,21 +277,31 @@ class FuzzyMatchStrategy(BaseMatchStrategy):
         matches = self._filter_self_references(matches, requester_cm_id)
 
         if not matches:
-            # Try first name only with nickname variations
+            # Single-name fallback: merge matches across the ORIGINAL first name and
+            # nickname variants, deduped by cm_id. The original is tried first so a
+            # literal-name match isn't shadowed by a variant match (e.g., "Katherine"
+            # finding only Kate Chen because year-filtering narrowed the variant pool).
+            # Without the merge, year filtering plus first-match-wins could resolve
+            # the wrong person silently (see PR for cascade analysis).
             name_parts = name.strip().split()
             if len(name_parts) == 1:
                 first_only = name_parts[0]
-                variations = find_nickname_variations(first_only)
-                for variant in variations:
+                search_terms = [first_only, *find_nickname_variations(first_only)]
+                seen_cm_ids: set[int] = set()
+                merged: list[Person] = []
+                for variant in search_terms:
                     if candidates:
                         var_matches = [c for c in candidates if c.first_name.lower() == variant.lower()]
                     else:
                         var_matches = self.person_repo.find_by_first_name(variant, year=year)
                     var_matches = self._filter_self_references(var_matches, requester_cm_id)
-                    if var_matches:
-                        matches = var_matches
-                        match_type = "first_name_nickname"
-                        break
+                    for p in var_matches:
+                        if p.cm_id not in seen_cm_ids:
+                            seen_cm_ids.add(p.cm_id)
+                            merged.append(p)
+                if merged:
+                    matches = merged
+                    match_type = "first_name_merged"
 
         if not matches:
             return ResolutionResult(confidence=0.0, method=self.name)
@@ -304,18 +314,24 @@ class FuzzyMatchStrategy(BaseMatchStrategy):
                 person=matches[0],
                 confidence=confidence,
                 method=self.name,
-                metadata={"match_type": match_type},
+                metadata={"match_type": match_type, "sub_method": match_type},
             )
         else:
             # Try session disambiguation
             result = self._disambiguate_with_session(matches, requester_cm_id, session_cm_id, year, attendee_info)
             if result.is_resolved:
+                if result.metadata is None:
+                    result.metadata = {}
+                result.metadata["sub_method"] = match_type
                 return result
 
             # Try relationship disambiguation
             if self.relationship_analyzer and session_cm_id:
                 result = self._pick_best_by_relationships(matches, requester_cm_id, session_cm_id)
                 if result.is_resolved:
+                    if result.metadata is None:
+                        result.metadata = {}
+                    result.metadata["sub_method"] = match_type
                     return result
 
             return ResolutionResult(
@@ -325,6 +341,7 @@ class FuzzyMatchStrategy(BaseMatchStrategy):
                 metadata={
                     "ambiguity_reason": "multiple_normalized_matches",
                     "match_count": len(matches),
+                    "sub_method": match_type,
                 },
             )
 

--- a/bunking/sync/bunk_request_processor/shared/nickname_groups.py
+++ b/bunking/sync/bunk_request_processor/shared/nickname_groups.py
@@ -215,7 +215,7 @@ def find_nickname_variations(name: str, config_service: Any = None) -> list[str]
     # 4. Check nicknames library (broadest coverage, lowest priority)
     _add(_get_library_variations(name_lower))
 
-    return variations
+    return sorted(variations)
 
 
 def names_match_via_nicknames(name1: str, name2: str, config_service: Any = None) -> bool:

--- a/config/prompts/parse_bunk_with.txt
+++ b/config/prompts/parse_bunk_with.txt
@@ -49,6 +49,21 @@ The requester's last name is included in the requester info above.
   almost always means friends, not family.
 - Shared school, grade, or classroom alone does NOT indicate siblings.
 
+=== PARENT-CONTEXT SURNAME EXTRACTION ===
+
+When a target name is followed by parenthetical content that identifies the
+camper's parent or supplies the camper's surname, infer the surname and
+include it in target_name. Examples:
+
+- "Emma (whose mother is Jane Garcia)" → target_name = "Emma Garcia"
+- "Liam (Olivia Chen's son)" → target_name = "Liam Chen"
+- "Olivia (Patel)" → target_name = "Olivia Patel"
+
+Do NOT apply this rule when parentheses contain only a relationship word
+(Cousin), (twin), (stepbrother); a grade or age (5th grade), (age 12); or
+descriptive context (camp veteran), (new this year). Those still go to
+parse_notes as today. Example 2 below illustrates the negative case.
+
 === PRIORITY INDICATORS ===
 
 Parents may indicate priority. Capture in keywords_found:
@@ -70,11 +85,18 @@ Example 1c - Name with hyphen:
 Input: "Liam Patel"
 Output: 1 bunk_with request for "Liam Patel", parse_notes: "Direct bunk request"
 
-Example 2 - Multiple names with priority:
+Example 1d - Name with parent-context surname (positive surname extraction):
+Input: "Emma (whose mother is Jane Garcia)"
+Output: 1 bunk_with request with target_name "Emma Garcia" (surname inferred
+  from parent identification), parse_notes: "Direct bunk request; surname
+  inferred from parent context"
+
+Example 2 - Multiple names with priority (negative case for surname extraction):
 Input: "1. Sophia Martinez (Cousin). 2. Olivia Rose Thompson"
 Output: 2 bunk_with requests with target_name "Sophia Martinez" and "Olivia Rose Thompson"
   (NOT "1. Sophia Martinez" — strip the enumeration prefix), list_position 0 and 1,
-  "Cousin" in parse_notes for first.
+  "Cousin" in parse_notes for first. NOTE: (Cousin) is a relationship word,
+  not a surname or parent identifier, so target_name keeps its original form.
 
 Example 3 - Embedded negative:
 Input: "Wants to be with Mia. PLEASE DO NOT put with Jake - he bullied Lucas last year"

--- a/config/prompts/parse_bunking_notes.txt
+++ b/config/prompts/parse_bunking_notes.txt
@@ -48,6 +48,21 @@ This field may contain ANY request type:
 4. Counselor recommendations ARE requests
    - "Counselors recommend NOT bunking with Lucas" = not_bunk_with
 
+=== PARENT-CONTEXT SURNAME EXTRACTION ===
+
+When a target name is followed by parenthetical content that identifies the
+camper's parent or supplies the camper's surname, infer the surname and
+include it in target_name. Examples:
+
+- "Emma (whose mother is Jane Garcia)" → target_name = "Emma Garcia"
+- "Liam (Olivia Chen's son)" → target_name = "Liam Chen"
+- "Olivia (Patel)" → target_name = "Olivia Patel"
+
+Do NOT apply this rule when parentheses contain only a relationship word
+(Cousin), (twin), (stepbrother); a grade or age (5th grade), (age 12); or
+descriptive context (camp veteran), (new this year). Those still go to
+parse_notes as today.
+
 === FIELD-SPECIFIC PATTERNS ===
 
 Example 1 - Age preference from old note:

--- a/config/prompts/parse_internal_notes.txt
+++ b/config/prompts/parse_internal_notes.txt
@@ -29,6 +29,21 @@ This field may contain:
 3. "age_preference" - Age/grade preference
    Keywords: "bunk older", "same age/younger", "bunk with 5th/6th"
 
+=== PARENT-CONTEXT SURNAME EXTRACTION ===
+
+When a target name is followed by parenthetical content that identifies the
+camper's parent or supplies the camper's surname, infer the surname and
+include it in target_name. Examples:
+
+- "Emma (whose mother is Jane Garcia)" → target_name = "Emma Garcia"
+- "Liam (Olivia Chen's son)" → target_name = "Liam Chen"
+- "Olivia (Patel)" → target_name = "Olivia Patel"
+
+Do NOT apply this rule when parentheses contain only a relationship word
+(Cousin), (twin), (stepbrother); a grade or age (5th grade), (age 12); or
+descriptive context (camp veteran), (new this year). Those still go to
+parse_notes as today.
+
 === STAFF SHORTHAND PATTERNS ===
 
 Example 1 - Age shorthand:

--- a/tests/unit/sync/bunk_request_processor/debug/test_full_pipeline_tracing.py
+++ b/tests/unit/sync/bunk_request_processor/debug/test_full_pipeline_tracing.py
@@ -203,6 +203,88 @@ class TestFullPipelineTracing:
         mock_trace_collector.record_phase2.assert_called()
 
     @pytest.mark.asyncio
+    async def test_phase2_trace_records_pipeline_strategies_tried(self, mock_orchestrator, mock_trace_collector):
+        """record_phase2() should propagate the pipeline_strategies_tried breadcrumb list
+        from ResolutionResult.metadata onto the Phase2IntentTrace it builds."""
+        # Re-arm the phase2 service so the resolution result carries the
+        # batch_resolve-style pipeline_strategies_tried metadata that orchestrator
+        # should read into the trace.
+        from bunking.sync.bunk_request_processor.resolution.interfaces import ResolutionResult
+
+        mock_person = MagicMock()
+        mock_person.cm_id = 67890
+        mock_person.full_name = "Olivia Chen"
+        attempts = [
+            {
+                "strategy": "fuzzy_match",
+                "sub_method": "first_name_merged",
+                "confidence": 0.85,
+                "candidate_count": 1,
+                "resolved": True,
+                "ambiguous": False,
+            },
+        ]
+        resolution_result = ResolutionResult(
+            person=mock_person,
+            confidence=0.85,
+            method="fuzzy_match",
+            metadata={"pipeline_strategies_tried": attempts, "match_type": "first_name_merged"},
+        )
+
+        # Re-arm phase2_service / historical_verification_service to return the
+        # metadata-bearing result.
+        from bunking.sync.bunk_request_processor.core.models import (
+            ParsedRequest,
+            ParseRequest,
+            ParseResult,
+            RequestType,
+        )
+        from bunking.sync.bunk_request_processor.shared.constants import SourceField
+
+        parsed_req = ParsedRequest(
+            raw_text="Olivia Chen",
+            request_type=RequestType.BUNK_WITH,
+            target_name="Olivia Chen",
+            age_preference=None,
+            source_field=SourceField.BUNK_REQUEST_FORM,
+            confidence=0.95,
+            csv_position=1,
+            metadata={},
+        )
+        row_data = _make_raw_request()
+        parse_request = ParseRequest(
+            request_text="Olivia Chen",
+            field_name=SourceField.BUNK_REQUEST_FORM,
+            requester_cm_id=12345,
+            requester_name="Emma Johnson",
+            requester_grade="5",
+            session_cm_id=1000001,
+            session_name="Session 1",
+            year=2025,
+            row_data=row_data,
+        )
+        parse_result = ParseResult(
+            parsed_requests=[parsed_req],
+            is_valid=True,
+            parse_request=parse_request,
+        )
+        mock_orchestrator.phase1_service.batch_parse = AsyncMock(return_value=[parse_result])
+        mock_orchestrator.phase2_service.batch_resolve = AsyncMock(return_value=[(parse_result, [resolution_result])])
+        mock_orchestrator.historical_verification_service.verify = AsyncMock(
+            return_value=[(parse_result, [resolution_result])]
+        )
+
+        raw_requests = [_make_raw_request()]
+        await mock_orchestrator.process_requests(raw_requests=raw_requests, clear_existing=False)
+
+        mock_trace_collector.record_phase2.assert_called()
+        call_kwargs = mock_trace_collector.record_phase2.call_args.kwargs
+        intent_trace = call_kwargs["intent_trace"]
+        assert intent_trace.pipeline_strategies_tried == attempts, (
+            f"expected pipeline_strategies_tried={attempts!r}, got {intent_trace.pipeline_strategies_tried!r}"
+        )
+
+    @pytest.mark.asyncio
     async def test_historical_trace_called(self, mock_orchestrator, mock_trace_collector):
         """record_historical() should be called after historical verification."""
         raw_requests = [_make_raw_request()]

--- a/tests/unit/sync/bunk_request_processor/debug/test_pipeline_strategies_tried.py
+++ b/tests/unit/sync/bunk_request_processor/debug/test_pipeline_strategies_tried.py
@@ -1,0 +1,119 @@
+"""Component 4: batch_resolve populates pipeline_strategies_tried on the winning
+ResolutionResult's metadata, with sub_method derived from each strategy's
+existing match_type / ambiguity_reason metadata.
+
+Downstream debug_pipeline_traces.phase2_resolution[*].pipeline_strategies_tried
+(field already declared in trace_models.Phase2FinalResult) is populated from
+this metadata in the trace recorder (Task 6)."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from bunking.sync.bunk_request_processor.core.models import Person
+from bunking.sync.bunk_request_processor.resolution.resolution_pipeline import ResolutionPipeline
+from bunking.sync.bunk_request_processor.resolution.strategies.fuzzy_match import FuzzyMatchStrategy
+
+
+@pytest.fixture
+def fuzzy_only_pipeline():
+    """ResolutionPipeline with just FuzzyMatchStrategy and minimal mocked repos.
+
+    Pool setup mirrors the original cascade case: searching "Katherine" with no
+    full-name match → falls into _try_normalized_search → merge fallback returns
+    a single same-session Katherine after disambiguation.
+    """
+    person_repo = Mock()
+    attendee_repo = Mock()
+
+    person_repo.name_cache = None
+    person_repo.find_by_name.return_value = []
+    person_repo.find_by_normalized_name.return_value = []
+    person_repo.find_by_first_and_parent_surname.return_value = []
+    person_repo.find_by_cm_id.return_value = None
+    person_repo.get_all_for_phonetic_matching.return_value = []
+
+    same_session_katherine = Person(cm_id=100, first_name="Katherine", last_name="Smith")
+    other_katherine = Person(cm_id=101, first_name="Katherine", last_name="Other")
+    kate = Person(cm_id=200, first_name="Kate", last_name="Chen")
+
+    def first_name_search(name, year=None):
+        n = name.lower()
+        if n == "katherine":
+            return [same_session_katherine, other_katherine]
+        if n == "kate":
+            return [kate]
+        return []
+
+    person_repo.find_by_first_name.side_effect = first_name_search
+
+    attendee_repo.get_by_person_and_year.return_value = None
+    attendee_repo.bulk_get_sessions_for_persons.return_value = {
+        100: 1001,
+        101: 2001,
+        200: 3001,
+        999: 1001,
+    }
+
+    pipeline = ResolutionPipeline(person_repository=person_repo, attendee_repository=attendee_repo)
+    pipeline.add_strategy(FuzzyMatchStrategy(person_repo, attendee_repo))
+    return pipeline
+
+
+def test_batch_resolve_records_pipeline_strategies_tried(fuzzy_only_pipeline):
+    """After batch_resolve, the winning result's metadata['pipeline_strategies_tried']
+    is a non-empty list with strategy + sub_method + confidence + flags."""
+    results = fuzzy_only_pipeline.batch_resolve([("Katherine", 999, 1001, 2026)])
+    assert len(results) == 1
+    result = results[0]
+
+    assert result.metadata is not None
+    strategies = result.metadata.get("pipeline_strategies_tried")
+    assert strategies, f"expected non-empty pipeline_strategies_tried, got {strategies!r}"
+    assert isinstance(strategies, list)
+    assert len(strategies) >= 1
+
+    entry = strategies[0]
+    for key in ("strategy", "sub_method", "confidence", "candidate_count", "resolved", "ambiguous"):
+        assert key in entry, f"missing key {key!r} in strategy entry {entry!r}"
+
+
+def test_pipeline_strategies_tried_records_sub_method_from_match_type(fuzzy_only_pipeline):
+    """sub_method is derived from the strategy's existing match_type metadata."""
+    results = fuzzy_only_pipeline.batch_resolve([("Katherine", 999, 1001, 2026)])
+    result = results[0]
+
+    strategies = result.metadata.get("pipeline_strategies_tried", [])
+    # Fuzzy merge fallback sets match_type='first_name_merged' (Task 3) → also sets
+    # sub_method='first_name_merged' explicitly. Session-disambiguation single match
+    # sets match_type='session_disambiguated' → sub_method should reflect one of these.
+    fuzzy_entry = next((s for s in strategies if s["strategy"] == "fuzzy_match"), None)
+    assert fuzzy_entry is not None
+    assert fuzzy_entry["sub_method"] in {
+        "first_name_merged",
+        "session_disambiguated",
+    }, f"unexpected sub_method: {fuzzy_entry['sub_method']!r}"
+
+
+def test_winning_entry_in_strategies_tried_matches_final_result(fuzzy_only_pipeline):
+    """The resolved entry's strategy and confidence match the final result."""
+    results = fuzzy_only_pipeline.batch_resolve([("Katherine", 999, 1001, 2026)])
+    result = results[0]
+    assert result.is_resolved
+
+    strategies = result.metadata.get("pipeline_strategies_tried", [])
+    winning = next((s for s in strategies if s.get("resolved")), None)
+    assert winning is not None, f"no resolved entry found in {strategies!r}"
+    assert winning["strategy"] == result.method
+    assert winning["confidence"] == pytest.approx(result.confidence)
+
+
+def test_strategies_tried_records_unresolved_attempt_when_no_match(fuzzy_only_pipeline):
+    """Even when the strategy returns 0.0/no-match, the attempt is recorded."""
+    results = fuzzy_only_pipeline.batch_resolve([("Xqyzzyzzy", 999, 1001, 2026)])
+    result = results[0]
+    strategies = (result.metadata or {}).get("pipeline_strategies_tried")
+    assert strategies, "expected the no-match attempt to still appear in the list"
+    assert all(not s.get("resolved") for s in strategies)

--- a/tests/unit/sync/bunk_request_processor/debug/test_pipeline_strategies_tried.py
+++ b/tests/unit/sync/bunk_request_processor/debug/test_pipeline_strategies_tried.py
@@ -51,10 +51,10 @@ def fuzzy_only_pipeline():
 
     attendee_repo.get_by_person_and_year.return_value = None
     attendee_repo.bulk_get_sessions_for_persons.return_value = {
-        100: 1001,
-        101: 2001,
-        200: 3001,
-        999: 1001,
+        100: 1000001,
+        101: 1000002,
+        200: 1000003,
+        999: 1000001,
     }
 
     pipeline = ResolutionPipeline(person_repository=person_repo, attendee_repository=attendee_repo)
@@ -65,7 +65,7 @@ def fuzzy_only_pipeline():
 def test_batch_resolve_records_pipeline_strategies_tried(fuzzy_only_pipeline):
     """After batch_resolve, the winning result's metadata['pipeline_strategies_tried']
     is a non-empty list with strategy + sub_method + confidence + flags."""
-    results = fuzzy_only_pipeline.batch_resolve([("Katherine", 999, 1001, 2026)])
+    results = fuzzy_only_pipeline.batch_resolve([("Katherine", 999, 1000001, 2026)])
     assert len(results) == 1
     result = results[0]
 
@@ -82,7 +82,7 @@ def test_batch_resolve_records_pipeline_strategies_tried(fuzzy_only_pipeline):
 
 def test_pipeline_strategies_tried_records_sub_method_from_match_type(fuzzy_only_pipeline):
     """sub_method is derived from the strategy's existing match_type metadata."""
-    results = fuzzy_only_pipeline.batch_resolve([("Katherine", 999, 1001, 2026)])
+    results = fuzzy_only_pipeline.batch_resolve([("Katherine", 999, 1000001, 2026)])
     result = results[0]
 
     strategies = result.metadata.get("pipeline_strategies_tried", [])
@@ -99,7 +99,7 @@ def test_pipeline_strategies_tried_records_sub_method_from_match_type(fuzzy_only
 
 def test_winning_entry_in_strategies_tried_matches_final_result(fuzzy_only_pipeline):
     """The resolved entry's strategy and confidence match the final result."""
-    results = fuzzy_only_pipeline.batch_resolve([("Katherine", 999, 1001, 2026)])
+    results = fuzzy_only_pipeline.batch_resolve([("Katherine", 999, 1000001, 2026)])
     result = results[0]
     assert result.is_resolved
 
@@ -112,7 +112,7 @@ def test_winning_entry_in_strategies_tried_matches_final_result(fuzzy_only_pipel
 
 def test_strategies_tried_records_unresolved_attempt_when_no_match(fuzzy_only_pipeline):
     """Even when the strategy returns 0.0/no-match, the attempt is recorded."""
-    results = fuzzy_only_pipeline.batch_resolve([("Xqyzzyzzy", 999, 1001, 2026)])
+    results = fuzzy_only_pipeline.batch_resolve([("Xqyzzyzzy", 999, 1000001, 2026)])
     result = results[0]
     strategies = (result.metadata or {}).get("pipeline_strategies_tried")
     assert strategies, "expected the no-match attempt to still appear in the list"

--- a/tests/unit/sync/bunk_request_processor/prompts/test_parse_prompts_parent_surname.py
+++ b/tests/unit/sync/bunk_request_processor/prompts/test_parse_prompts_parent_surname.py
@@ -10,9 +10,7 @@ from __future__ import annotations
 from collections.abc import Generator
 
 import pytest
-
 from bunking.sync.bunk_request_processor.prompts.loader import clear_cache, load_prompt
-
 
 PROMPTS_WITH_PARENT_RULE = ["parse_bunk_with", "parse_bunking_notes", "parse_internal_notes"]
 

--- a/tests/unit/sync/bunk_request_processor/prompts/test_parse_prompts_parent_surname.py
+++ b/tests/unit/sync/bunk_request_processor/prompts/test_parse_prompts_parent_surname.py
@@ -1,0 +1,57 @@
+"""Static prompt-content guards for the PARENT-CONTEXT SURNAME EXTRACTION rule.
+
+These tests verify the prompt FILES contain the rule and required examples.
+AI behavior on real inputs is verified separately via production trace inspection
+post-merge — this guard catches accidental rule deletion or example drift.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+
+from bunking.sync.bunk_request_processor.prompts.loader import clear_cache, load_prompt
+
+
+PROMPTS_WITH_PARENT_RULE = ["parse_bunk_with", "parse_bunking_notes", "parse_internal_notes"]
+
+SECTION_HEADER = "PARENT-CONTEXT SURNAME EXTRACTION"
+POSITIVE_EXAMPLE_MOTHER = "whose mother is Jane Garcia"
+POSITIVE_EXAMPLE_POSSESSIVE = "Olivia Chen's son"
+POSITIVE_EXAMPLE_BARE = "Olivia (Patel)"
+NEGATIVE_EXAMPLE_RELATIONSHIP = "(Cousin)"
+
+
+@pytest.fixture(autouse=True)
+def _reset_prompt_cache() -> Generator[None]:
+    clear_cache()
+    yield
+    clear_cache()
+
+
+class TestParentSurnameRule:
+    @pytest.mark.parametrize("prompt_name", PROMPTS_WITH_PARENT_RULE)
+    def test_prompt_has_section_header(self, prompt_name: str) -> None:
+        text = load_prompt(prompt_name)
+        assert SECTION_HEADER in text, f"{prompt_name}.txt missing section header {SECTION_HEADER!r}"
+
+    @pytest.mark.parametrize("prompt_name", PROMPTS_WITH_PARENT_RULE)
+    def test_prompt_has_positive_mother_example(self, prompt_name: str) -> None:
+        text = load_prompt(prompt_name)
+        assert POSITIVE_EXAMPLE_MOTHER in text, f"{prompt_name}.txt missing 'whose mother is' positive example"
+
+    @pytest.mark.parametrize("prompt_name", PROMPTS_WITH_PARENT_RULE)
+    def test_prompt_has_positive_possessive_example(self, prompt_name: str) -> None:
+        text = load_prompt(prompt_name)
+        assert POSITIVE_EXAMPLE_POSSESSIVE in text, f"{prompt_name}.txt missing possessive 'X's son/daughter' example"
+
+    @pytest.mark.parametrize("prompt_name", PROMPTS_WITH_PARENT_RULE)
+    def test_prompt_has_positive_bare_surname_example(self, prompt_name: str) -> None:
+        text = load_prompt(prompt_name)
+        assert POSITIVE_EXAMPLE_BARE in text, f"{prompt_name}.txt missing bare-surname-in-parens example"
+
+    @pytest.mark.parametrize("prompt_name", PROMPTS_WITH_PARENT_RULE)
+    def test_prompt_has_negative_relationship_example(self, prompt_name: str) -> None:
+        text = load_prompt(prompt_name)
+        assert NEGATIVE_EXAMPLE_RELATIONSHIP in text, f"{prompt_name}.txt missing (Cousin) negative example"

--- a/tests/unit/sync/bunk_request_processor/prompts/test_parse_prompts_parent_surname.py
+++ b/tests/unit/sync/bunk_request_processor/prompts/test_parse_prompts_parent_surname.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from collections.abc import Generator
 
 import pytest
+
 from bunking.sync.bunk_request_processor.prompts.loader import clear_cache, load_prompt
 
 PROMPTS_WITH_PARENT_RULE = ["parse_bunk_with", "parse_bunking_notes", "parse_internal_notes"]

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_fuzzy_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_fuzzy_match.py
@@ -685,7 +685,7 @@ class TestNormalizedSearchMergeFallback:
         person_repo.find_by_first_name.side_effect = lambda name, year=None: (
             [requester, other] if name.lower() == "katherine" else []
         )
-        attendee_repo.bulk_get_sessions_for_persons.side_effect = lambda cm_ids, year: {cm_id: 1001 for cm_id in cm_ids}
+        attendee_repo.bulk_get_sessions_for_persons.side_effect = lambda cm_ids, year: dict.fromkeys(cm_ids, 1001)
         result = strategy.resolve("Katherine", requester_cm_id=999, session_cm_id=1001, year=2026)
         if result.is_resolved:
             assert result.person.cm_id != 999, "requester was not filtered from candidates"
@@ -695,7 +695,7 @@ class TestNormalizedSearchMergeFallback:
         person_repo, attendee_repo = mock_repositories
         kate = Person(cm_id=200, first_name="Kate", last_name="Chen")
         person_repo.find_by_first_name.side_effect = lambda name, year=None: [kate] if name.lower() == "kate" else []
-        attendee_repo.bulk_get_sessions_for_persons.side_effect = lambda cm_ids, year: {cm_id: 1001 for cm_id in cm_ids}
+        attendee_repo.bulk_get_sessions_for_persons.side_effect = lambda cm_ids, year: dict.fromkeys(cm_ids, 1001)
         result = strategy.resolve("Katherine", requester_cm_id=999, session_cm_id=1001, year=2026)
         assert result.is_resolved, "variants must still be tried when original returns empty"
         assert result.person.cm_id == 200
@@ -711,7 +711,7 @@ class TestNormalizedSearchMergeFallback:
         person_repo.find_by_first_name.side_effect = lambda name, year=None: (
             katherines if name.lower() == "katherine" else []
         )
-        attendee_repo.bulk_get_sessions_for_persons.side_effect = lambda cm_ids, year: {cm_id: 1001 for cm_id in cm_ids}
+        attendee_repo.bulk_get_sessions_for_persons.side_effect = lambda cm_ids, year: dict.fromkeys(cm_ids, 1001)
         result = strategy.resolve("Katherine", requester_cm_id=999, session_cm_id=1001, year=2026)
         assert not result.is_resolved
         assert len(result.candidates or []) == 2

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_fuzzy_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_fuzzy_match.py
@@ -600,5 +600,122 @@ class TestFuzzyMatchDefaultOverrideMechanism:
         assert result == pytest.approx(0.80)
 
 
+class TestNormalizedSearchMergeFallback:
+    """Component 2: _try_normalized_search single-name fallback merges matches
+    across the original first name and nickname variants instead of breaking on
+    the first matching variant.
+
+    Bug pattern: searching "Katherine" with no full-name candidates falls into
+    the variant loop. Original behavior: iterates `find_nickname_variations`
+    only (skipping the original) and breaks on the first variant with any
+    match. If year-filtering narrows that variant to one wrong-session person,
+    the resolver silently picks that wrong person.
+
+    Fix: merge matches across [original, *variants], dedup by cm_id, then let
+    `_disambiguate_with_session` pick the unique same-session candidate.
+    """
+
+    @pytest.fixture
+    def mock_repositories(self):
+        mock_person_repo = Mock()
+        mock_attendee_repo = Mock()
+        return mock_person_repo, mock_attendee_repo
+
+    @pytest.fixture
+    def strategy(self, mock_repositories):
+        person_repo, attendee_repo = mock_repositories
+        attendee_repo.get_by_person_and_year.return_value = None
+        attendee_repo.bulk_get_sessions_for_persons.return_value = {}
+        person_repo.find_by_normalized_name.return_value = []
+        person_repo.find_by_first_name.return_value = []
+        person_repo.find_by_name.return_value = []
+        return FuzzyMatchStrategy(person_repository=person_repo, attendee_repository=attendee_repo)
+
+    def test_merge_original_with_variants_session_disambiguates_winner(self, strategy, mock_repositories):
+        """Pool has 1 same-session Katherine, 8 other-session Katherines, 1 Kate (variant),
+        3 Kits (variant). Merge produces 13 candidates; session disambiguation picks the
+        unique same-session Katherine at session_match base (0.85)."""
+        person_repo, attendee_repo = mock_repositories
+        same_session_katherine = Person(cm_id=100, first_name="Katherine", last_name="Smith")
+        other_katherines = [Person(cm_id=100 + i, first_name="Katherine", last_name=f"Other{i}") for i in range(1, 9)]
+        kate = Person(cm_id=200, first_name="Kate", last_name="Chen")
+        kits = [Person(cm_id=300 + i, first_name="Kit", last_name=f"K{i}") for i in range(3)]
+
+        def first_name_search(name, year=None):
+            n = name.lower()
+            if n == "katherine":
+                return [same_session_katherine, *other_katherines]
+            if n == "kate":
+                return [kate]
+            if n == "kit":
+                return kits
+            return []
+
+        person_repo.find_by_first_name.side_effect = first_name_search
+
+        attendee_sessions = {100: 1001}
+        for k in other_katherines:
+            attendee_sessions[k.cm_id] = 2001
+        attendee_sessions[200] = 3001  # Kate — different session
+        for k in kits:
+            attendee_sessions[k.cm_id] = 2001
+        attendee_repo.bulk_get_sessions_for_persons.side_effect = lambda cm_ids, year: {
+            cm_id: attendee_sessions.get(cm_id) for cm_id in cm_ids
+        }
+
+        result = strategy.resolve("Katherine", requester_cm_id=999, session_cm_id=1001, year=2026)
+
+        assert result.is_resolved, (
+            f"expected resolved; got is_resolved={result.is_resolved}, candidates={len(result.candidates or [])}"
+        )
+        assert result.person.cm_id == 100, (
+            f"expected Katherine Smith (cm_id=100); got cm_id={result.person.cm_id} "
+            f"(name={result.person.first_name} {result.person.last_name})"
+        )
+        assert result.confidence == 0.85
+        assert result.metadata.get("sub_method") == "first_name_merged", (
+            f"expected sub_method='first_name_merged'; got {result.metadata.get('sub_method')!r}"
+        )
+
+    def test_merge_filters_self_reference(self, strategy, mock_repositories):
+        """The requester is filtered out of merged matches even if they share the searched name."""
+        person_repo, attendee_repo = mock_repositories
+        requester = Person(cm_id=999, first_name="Katherine", last_name="Requester")
+        other = Person(cm_id=100, first_name="Katherine", last_name="Smith")
+        person_repo.find_by_first_name.side_effect = lambda name, year=None: (
+            [requester, other] if name.lower() == "katherine" else []
+        )
+        attendee_repo.bulk_get_sessions_for_persons.side_effect = lambda cm_ids, year: {cm_id: 1001 for cm_id in cm_ids}
+        result = strategy.resolve("Katherine", requester_cm_id=999, session_cm_id=1001, year=2026)
+        if result.is_resolved:
+            assert result.person.cm_id != 999, "requester was not filtered from candidates"
+
+    def test_merge_falls_through_to_variants_when_original_empty(self, strategy, mock_repositories):
+        """When the original first name finds 0 matches, variants must still be tried."""
+        person_repo, attendee_repo = mock_repositories
+        kate = Person(cm_id=200, first_name="Kate", last_name="Chen")
+        person_repo.find_by_first_name.side_effect = lambda name, year=None: [kate] if name.lower() == "kate" else []
+        attendee_repo.bulk_get_sessions_for_persons.side_effect = lambda cm_ids, year: {cm_id: 1001 for cm_id in cm_ids}
+        result = strategy.resolve("Katherine", requester_cm_id=999, session_cm_id=1001, year=2026)
+        assert result.is_resolved, "variants must still be tried when original returns empty"
+        assert result.person.cm_id == 200
+
+    def test_merge_two_same_session_candidates_returns_ambiguous(self, strategy, mock_repositories):
+        """Two same-session Katherines: disambiguation can't pick a unique winner, returns
+        ambiguous at 0.5 for staff review. Documented behavior of _disambiguate_with_session."""
+        person_repo, attendee_repo = mock_repositories
+        katherines = [
+            Person(cm_id=100, first_name="Katherine", last_name="Smith"),
+            Person(cm_id=101, first_name="Katherine", last_name="Jones"),
+        ]
+        person_repo.find_by_first_name.side_effect = lambda name, year=None: (
+            katherines if name.lower() == "katherine" else []
+        )
+        attendee_repo.bulk_get_sessions_for_persons.side_effect = lambda cm_ids, year: {cm_id: 1001 for cm_id in cm_ids}
+        result = strategy.resolve("Katherine", requester_cm_id=999, session_cm_id=1001, year=2026)
+        assert not result.is_resolved
+        assert len(result.candidates or []) == 2
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_fuzzy_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_fuzzy_match.py
@@ -653,17 +653,17 @@ class TestNormalizedSearchMergeFallback:
 
         person_repo.find_by_first_name.side_effect = first_name_search
 
-        attendee_sessions = {100: 1001}
+        attendee_sessions = {100: 1000001}
         for k in other_katherines:
-            attendee_sessions[k.cm_id] = 2001
-        attendee_sessions[200] = 3001  # Kate — different session
+            attendee_sessions[k.cm_id] = 1000002
+        attendee_sessions[200] = 1000003  # Kate — different session
         for k in kits:
-            attendee_sessions[k.cm_id] = 2001
+            attendee_sessions[k.cm_id] = 1000002
         attendee_repo.bulk_get_sessions_for_persons.side_effect = lambda cm_ids, year: {
             cm_id: attendee_sessions.get(cm_id) for cm_id in cm_ids
         }
 
-        result = strategy.resolve("Katherine", requester_cm_id=999, session_cm_id=1001, year=2026)
+        result = strategy.resolve("Katherine", requester_cm_id=999, session_cm_id=1000001, year=2026)
 
         assert result.is_resolved, (
             f"expected resolved; got is_resolved={result.is_resolved}, candidates={len(result.candidates or [])}"
@@ -685,18 +685,23 @@ class TestNormalizedSearchMergeFallback:
         person_repo.find_by_first_name.side_effect = lambda name, year=None: (
             [requester, other] if name.lower() == "katherine" else []
         )
-        attendee_repo.bulk_get_sessions_for_persons.side_effect = lambda cm_ids, year: dict.fromkeys(cm_ids, 1001)
-        result = strategy.resolve("Katherine", requester_cm_id=999, session_cm_id=1001, year=2026)
-        if result.is_resolved:
-            assert result.person.cm_id != 999, "requester was not filtered from candidates"
+        attendee_repo.bulk_get_sessions_for_persons.side_effect = lambda cm_ids, year: dict.fromkeys(cm_ids, 1000001)
+        result = strategy.resolve("Katherine", requester_cm_id=999, session_cm_id=1000001, year=2026)
+        assert result.is_resolved, (
+            f"expected resolved match on non-requester Katherine; "
+            f"got is_resolved={result.is_resolved}, candidates={len(result.candidates or [])}"
+        )
+        assert result.person.cm_id == 100, (
+            f"requester (cm_id=999) was not filtered out; got cm_id={result.person.cm_id}"
+        )
 
     def test_merge_falls_through_to_variants_when_original_empty(self, strategy, mock_repositories):
         """When the original first name finds 0 matches, variants must still be tried."""
         person_repo, attendee_repo = mock_repositories
         kate = Person(cm_id=200, first_name="Kate", last_name="Chen")
         person_repo.find_by_first_name.side_effect = lambda name, year=None: [kate] if name.lower() == "kate" else []
-        attendee_repo.bulk_get_sessions_for_persons.side_effect = lambda cm_ids, year: dict.fromkeys(cm_ids, 1001)
-        result = strategy.resolve("Katherine", requester_cm_id=999, session_cm_id=1001, year=2026)
+        attendee_repo.bulk_get_sessions_for_persons.side_effect = lambda cm_ids, year: dict.fromkeys(cm_ids, 1000001)
+        result = strategy.resolve("Katherine", requester_cm_id=999, session_cm_id=1000001, year=2026)
         assert result.is_resolved, "variants must still be tried when original returns empty"
         assert result.person.cm_id == 200
 
@@ -711,8 +716,8 @@ class TestNormalizedSearchMergeFallback:
         person_repo.find_by_first_name.side_effect = lambda name, year=None: (
             katherines if name.lower() == "katherine" else []
         )
-        attendee_repo.bulk_get_sessions_for_persons.side_effect = lambda cm_ids, year: dict.fromkeys(cm_ids, 1001)
-        result = strategy.resolve("Katherine", requester_cm_id=999, session_cm_id=1001, year=2026)
+        attendee_repo.bulk_get_sessions_for_persons.side_effect = lambda cm_ids, year: dict.fromkeys(cm_ids, 1000001)
+        result = strategy.resolve("Katherine", requester_cm_id=999, session_cm_id=1000001, year=2026)
         assert not result.is_resolved
         assert len(result.candidates or []) == 2
 

--- a/tests/unit/sync/bunk_request_processor/shared/test_nickname_groups.py
+++ b/tests/unit/sync/bunk_request_processor/shared/test_nickname_groups.py
@@ -128,3 +128,30 @@ class TestExistingBehaviorPreserved:
         variations = find_nickname_variations("Mike")
         lower_vars = [v.lower() for v in variations]
         assert "mike" not in lower_vars
+
+
+class TestDeterminismAndOrdering:
+    """Variations must be deterministic and alphabetically sorted across calls.
+
+    Underlying nickname groups are set-derived; without explicit sorting, iteration
+    order varies across Python invocations. The fuzzy_match fallback iterates this
+    list and a non-deterministic order produces inconsistent resolutions.
+    """
+
+    def test_find_nickname_variations_is_deterministic(self):
+        results = [find_nickname_variations("Katherine") for _ in range(10)]
+        first = results[0]
+        for i, r in enumerate(results[1:], start=2):
+            assert r == first, f"call #{i} returned {r!r}, expected {first!r}"
+
+    def test_find_nickname_variations_is_sorted(self):
+        variations = find_nickname_variations("Katherine")
+        assert variations == sorted(variations), f"not sorted: {variations}"
+
+    def test_find_nickname_variations_is_sorted_josephine(self):
+        variations = find_nickname_variations("Josephine")
+        assert variations == sorted(variations), f"not sorted: {variations}"
+
+    def test_find_nickname_variations_returns_empty_for_unknown_name(self):
+        variations = find_nickname_variations("Xqyzzyzzy")
+        assert variations == []


### PR DESCRIPTION
## Summary

Fixes the six-stage cascade that misresolved parent-supplied bunk requests when the AI dropped parenthetical surname disambiguators and the Phase 2 fallback merged nickname variants but never the original first name.

Specifically — for an input like `"Emma (whose mother is Jane Garcia)"`, today's pipeline:

1. AI Phase 1 drops the parent-context paren → `target_name = "Emma"`
2. Resolution pipeline empties candidates for single-name input
3. `find_by_normalized_name("Emma")` returns 0 (requires exact full-name match)
4. Fallback loop iterates `find_nickname_variations` only — original "Emma" never tried
5. Variant ordering is non-deterministic; first variant with any match wins
6. Year-filter narrows the chosen variant to a single wrong-session person → 0.7 confidence → ConflictDetector auto-DECLINEs

Four components in one PR:

1. **Phase 1 prompts** — AI extracts surname from `"X (whose mother is Y Z)"`, `"X (Y's child)"`, `"X (LastName)"` patterns. Negative cases (relationship words, grade hints, descriptive parens) still go to `parse_notes`.
2. **Phase 2 merge fallback** — `_try_normalized_search` now prepends the original first name to variants and merges all matches before session disambiguation.
3. **Deterministic nickname ordering** — `find_nickname_variations` returns `sorted()`.
4. **Trace instrumentation** — `pipeline_strategies_tried` populated on `Phase2IntentTrace` with strategy name, derived `sub_method`, confidence, and resolved/ambiguous flags per attempt.

## Out-of-scope follow-ups (already filed)

- #1392 — Phase 3 dict/dataclass crash
- #1393 — parent surname index dead code
- #1394 — deferred asymmetric cross-form nickname confidence penalty

## Test plan

- [x] Unit tests pass — 4414 total, 0 failures (pre-push verification clean)
- [x] Resolution module regression — 138 tests pass
- [x] Prompt static content tests — 35 pass
- [x] Determinism tests — `find_nickname_variations` returns identical sorted list across 10 consecutive calls
- [x] Merge fallback tests — original cascade case (mock parameters mirroring the real one) now resolves to the correct same-session camper at 0.85 instead of the wrong cross-session pick at 0.7
- [x] Trace recorder test — `Phase2IntentTrace.pipeline_strategies_tried` populated end-to-end from `batch_resolve` metadata through orchestrator
- [ ] Spot-check a production CSV reprocess after merge — verify AI synthesizes surnames from parent-context parens and that previously-misresolved cases now hit the correct same-session camper
- [ ] Watch for any unexpected PENDING/DECLINED count shifts vs. baseline

## Notes on Task 4 scope reduction

The plan originally called for explicit `sub_method` strings on every return path across 4 strategy files (~50 sites). During implementation I realized strategies already record `match_type` (resolved) and `ambiguity_reason` (ambiguous) on their metadata, so `batch_resolve` can derive `sub_method` from those existing keys without per-strategy edits. The single derivation site in `resolution_pipeline.py` gives ~95% of the observability value with a fraction of the surface area; strategies stay untouched. Result is trivially extensible later if we want canonicalized sub_method strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompts now infer surnames from parent-context in parentheses to produce fuller target names.
  * Resolution traces and intent records now include per-request pipeline strategy attempt logs for richer debug info.

* **Bug Fixes**
  * Fuzzy matching merges original first-name and nickname-variant matches for single-word inputs.
  * Nickname variation lookups now return results in a stable, sorted order.

* **Tests**
  * Added tests covering parent-context surname extraction, pipeline strategy tracing, fuzzy-match merge behavior, and nickname ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1399)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->