### PR TITLE
fix(frontend,scripts): sidebar audit fallout (#1339, #1341)

### DIFF
--- a/frontend/src/components/BunkSocialGraphModal.test.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.test.tsx
@@ -12,7 +12,7 @@
  * The helper unit tests plus TypeScript checking provide sufficient coverage.
  */
 import { describe, expect, it } from 'vitest'
-import { extractSortKey, getBunkType } from './BunkSocialGraphModal'
+import { extractBunkCmIdsFromPlans, extractSortKey, getBunkType } from './BunkSocialGraphModal'
 
 // ─── Inline simulation of sessionBunks derivation ────────────────────────────
 // Mirrors the useMemo body in BunkSocialGraphModal so we can assert the
@@ -124,6 +124,42 @@ describe('extractSortKey', () => {
 
   it('falls back to primary 999 for unrecognised patterns', () => {
     expect(extractSortKey('Unknown').primary).toBe(999)
+  })
+})
+
+// ─── extractBunkCmIdsFromPlans ───────────────────────────────────────────────
+// Regression guard for #1339: bunk_plans schema has no flat bunk_cm_id column;
+// the bunk's CM ID is at expand.bunk.cm_id. Previously an inline interface
+// claimed a flat field, returning [] for every real bunk_plans record and
+// silently hiding the bunk navigation arrows in the social graph modal.
+
+describe('extractBunkCmIdsFromPlans', () => {
+  it('reads cm_id from the expanded bunk relation', () => {
+    const bunkPlans = [{ expand: { bunk: { cm_id: 101 } } }, { expand: { bunk: { cm_id: 102 } } }]
+    expect(extractBunkCmIdsFromPlans(bunkPlans)).toEqual([101, 102])
+  })
+
+  it('deduplicates repeated cm_ids', () => {
+    const bunkPlans = [
+      { expand: { bunk: { cm_id: 101 } } },
+      { expand: { bunk: { cm_id: 101 } } },
+      { expand: { bunk: { cm_id: 102 } } },
+    ]
+    expect(extractBunkCmIdsFromPlans(bunkPlans).sort()).toEqual([101, 102])
+  })
+
+  it('skips records missing the expand entirely (e.g. no expand requested)', () => {
+    const bunkPlans = [{}, { expand: { bunk: { cm_id: 101 } } }]
+    expect(extractBunkCmIdsFromPlans(bunkPlans)).toEqual([101])
+  })
+
+  it('skips records where expand.bunk lacks cm_id', () => {
+    const bunkPlans = [{ expand: { bunk: {} } }, { expand: { bunk: { cm_id: 102 } } }]
+    expect(extractBunkCmIdsFromPlans(bunkPlans)).toEqual([102])
+  })
+
+  it('returns [] for an empty input', () => {
+    expect(extractBunkCmIdsFromPlans([])).toEqual([])
   })
 })
 

--- a/frontend/src/components/BunkSocialGraphModal.test.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.test.tsx
@@ -12,7 +12,12 @@
  * The helper unit tests plus TypeScript checking provide sufficient coverage.
  */
 import { describe, expect, it } from 'vitest'
-import { extractBunkCmIdsFromPlans, extractSortKey, getBunkType } from './BunkSocialGraphModal'
+import {
+  buildBunksFilter,
+  extractBunkCmIdsFromPlans,
+  extractSortKey,
+  getBunkType,
+} from './BunkSocialGraphModal'
 
 // ─── Inline simulation of sessionBunks derivation ────────────────────────────
 // Mirrors the useMemo body in BunkSocialGraphModal so we can assert the
@@ -160,6 +165,34 @@ describe('extractBunkCmIdsFromPlans', () => {
 
   it('returns [] for an empty input', () => {
     expect(extractBunkCmIdsFromPlans([])).toEqual([])
+  })
+})
+
+// ─── buildBunksFilter ────────────────────────────────────────────────────────
+// Regression guard for #1339 follow-up: the bunks table stores one row per
+// (cm_id, year). An unscoped `cm_id = X` filter returns N years of rows per
+// logical bunk, leaving allBunks/sessionBunks with adjacent duplicate-cm_id
+// entries. Navigation then silently no-ops when wrap lands on a same-cm_id-
+// different-year row (the "right arrow not rotating" symptom).
+
+describe('buildBunksFilter', () => {
+  it('always includes a year clause', () => {
+    const filter = buildBunksFilter([4267, 4268], 2026)
+    expect(filter).toContain('year = 2026')
+  })
+
+  it('joins cm_id clauses with disjunction inside a parenthesised group', () => {
+    const filter = buildBunksFilter([1, 2, 3], 2026)
+    expect(filter).toBe('(cm_id = 1 || cm_id = 2 || cm_id = 3) && year = 2026')
+  })
+
+  it('handles a single cm_id', () => {
+    const filter = buildBunksFilter([42], 2025)
+    expect(filter).toBe('(cm_id = 42) && year = 2025')
+  })
+
+  it('returns empty string for an empty cm_id list', () => {
+    expect(buildBunksFilter([], 2026)).toBe('')
   })
 })
 

--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -39,6 +39,7 @@ import CamperDetailsPanel from './CamperDetailsPanel'
 import { pb } from '../lib/pocketbase'
 import { queryKeys } from '../utils/queryKeys'
 import type { Bunk, Session } from '../types/app-types'
+import type { BunkPlansResponse, BunksResponse } from '../types/pocketbase-types'
 
 // Register extensions
 cytoscape.use(fcose)
@@ -117,6 +118,28 @@ export const getBunkType = (name: string): 'G' | 'B' | 'AG' => {
   return 'B'
 }
 
+/**
+ * Extract bunk cm_ids from a list of expanded bunk_plans records.
+ *
+ * `bunk_plans` schema (per `pocketbase/pb_migrations/1500000017_bunk_plans.js`)
+ * has no flat `bunk_cm_id` column — the bunk reference is the `bunk` relation
+ * field, and the bunk's CM ID is reached via `expand.bunk.cm_id` when the
+ * caller requests `expand: 'bunk'`. A previous inline interface assumed a
+ * flat `bunk_cm_id` field which doesn't exist; the resulting always-empty
+ * array silently hid prev/next navigation in the bunk social graph modal
+ * (#1339 audit).
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export const extractBunkCmIdsFromPlans = (
+  bunkPlans: Array<{ expand?: { bunk?: { cm_id?: number } } }>
+): number[] => [
+  ...new Set(
+    bunkPlans
+      .map((bp) => bp.expand?.bunk?.cm_id)
+      .filter((id): id is number => typeof id === 'number')
+  ),
+]
+
 // eslint-disable-next-line react-refresh/only-export-components
 export const extractSortKey = (name: string): { primary: number; secondary: string } => {
   if (name.includes('Alph')) return { primary: -2, secondary: name }
@@ -194,26 +217,16 @@ export default function BunkSocialGraphModal({
 
       // Get bunk plans for this session using relation expansion
       const filter = `session.cm_id = ${session.cm_id} && year = ${year}`
-      const bunkPlans = await pb.collection('bunk_plans').getFullList({
-        filter,
-        expand: 'bunk',
-      })
+      const bunkPlans = await pb
+        .collection('bunk_plans')
+        .getFullList<BunkPlansResponse<{ bunk: BunksResponse }>>({
+          filter,
+          expand: 'bunk',
+        })
 
       if (bunkPlans.length === 0) return []
 
-      // Get unique bunk CampMinder IDs
-      interface BunkPlanRecord {
-        bunk_cm_id?: number
-      }
-      const bunkCmIds = [
-        ...new Set(
-          bunkPlans
-            .map((bp) => (bp as BunkPlanRecord).bunk_cm_id)
-            .filter((id): id is number => id !== undefined)
-        ),
-      ]
-
-      // Batch fetch bunks
+      const bunkCmIds = extractBunkCmIdsFromPlans(bunkPlans)
       if (bunkCmIds.length === 0) return []
 
       const bunkFilter = bunkCmIds.map((id) => `cm_id = ${id}`).join(' || ')

--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -119,6 +119,24 @@ export const getBunkType = (name: string): 'G' | 'B' | 'AG' => {
 }
 
 /**
+ * Build a PocketBase filter for fetching bunks by cm_id within a specific year.
+ *
+ * The bunks table stores one row per (cm_id, year) for history retention.
+ * Omitting the year clause returns ~N years of duplicate rows per logical
+ * bunk, which seeds the navigation list with adjacent same-cm_id entries
+ * and silently no-ops next/prev (#1339 audit follow-up).
+ *
+ * Returns an empty string for an empty cm_id list — callers should short-
+ * circuit before invoking.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export const buildBunksFilter = (cmIds: number[], year: number): string => {
+  if (cmIds.length === 0) return ''
+  const clause = cmIds.map((id) => `cm_id = ${id}`).join(' || ')
+  return `(${clause}) && year = ${year}`
+}
+
+/**
  * Extract bunk cm_ids from a list of expanded bunk_plans records.
  *
  * `bunk_plans` schema (per `pocketbase/pb_migrations/1500000017_bunk_plans.js`)
@@ -229,7 +247,7 @@ export default function BunkSocialGraphModal({
       const bunkCmIds = extractBunkCmIdsFromPlans(bunkPlans)
       if (bunkCmIds.length === 0) return []
 
-      const bunkFilter = bunkCmIds.map((id) => `cm_id = ${id}`).join(' || ')
+      const bunkFilter = buildBunksFilter(bunkCmIds, year)
       const bunks = await pb.collection<Bunk>('bunks').getFullList({ filter: bunkFilter })
 
       // Sort bunks by name

--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -150,13 +150,21 @@ const LIAM = mockPerson({
   household_id: 0,
 })
 
-/** Emma's declined bunk-with request targeting Liam Garcia (different session) */
+/**
+ * Emma's resolved-with-decline-disposition bunk-with request targeting Liam
+ * Garcia (different session).
+ *
+ * Production query at CamperDetailsPanel.tsx:422 filters `status = "resolved"`
+ * — declined-disposition rows reach the panel by being `status='resolved'` with
+ * a `disposition_reason` set, not by `status='declined'`. Fixture matches the
+ * shape that can actually surface in prod (#1341).
+ */
 const DECLINED_REQUEST: Record<string, unknown> = {
   id: 'req-declined-1',
   requester_id: 100,
   requestee_id: 201,
   request_type: 'bunk_with',
-  status: 'declined',
+  status: 'resolved',
   priority: 1,
   requested_person_name: 'Liam Garcia',
   disposition_reason: 'session_mismatch',
@@ -1013,15 +1021,20 @@ describe('CamperDetailsPanel', () => {
       })
     })
 
-    it('renders the human-readable decline reason for a declined request in embedded mode', async () => {
+    it('does not render the disposition reason for a resolved-disposition row in embedded mode', async () => {
+      // BunkRequestRow.tsx skips disposition_reason rendering for status='resolved'
+      // rows on purpose ("the reason isn't user-meaningful here"). The
+      // production query at CamperDetailsPanel.tsx:422 only delivers
+      // status='resolved' rows, so the decline reason never surfaces in the
+      // sidebar. Asserting the absence pins that contract — a regression that
+      // re-introduced the line would change user-visible behavior.
       setupDeclinedRequestMocks()
 
       render(<CamperDetailsPanel camperId="100" onClose={mockOnClose} embedded={true} />)
 
-      // formatReason('session_mismatch') === 'Different sessions'
-      await waitFor(() => {
-        expect(screen.getByText(/·\s*Different sessions$/)).toBeInTheDocument()
-      })
+      // Wait for the row to render, then assert the disposition reason is absent.
+      await screen.findByText('Liam Garcia')
+      expect(screen.queryByText(/Different sessions/)).not.toBeInTheDocument()
     })
 
     it('does not show "Unknown" as the target name for a declined request in embedded mode', async () => {

--- a/frontend/src/utils/queryKeys.test.ts
+++ b/frontend/src/utils/queryKeys.test.ts
@@ -1,10 +1,11 @@
 /**
  * Contract tests for `queryKeys.ts` factories.
  *
- * - Pins the split between `originalBunkRequestsByPersonId` and
- *   `originalBunkRequestsByRequesterCmId` — two callers wrote to the same
- *   factory but produced different shapes from different filters, causing a
- *   cache collision. The factories MUST produce non-colliding keys.
+ * - Pins the `originalBunkRequestsByRequesterCmId` factory shape. A sibling
+ *   `originalBunkRequestsByPersonId` factory previously existed for a
+ *   `person_id =` filter that doesn't exist on `original_bunk_requests`; PR
+ *   #1338 removed the only caller and the audit (#1339) removed the dead
+ *   factory itself.
  * - Pins the `year` argument on `camperHistory` so filtering by year does
  *   not reuse a cache slot keyed only by personId.
  */
@@ -12,23 +13,8 @@
 import { describe, it, expect } from 'vitest'
 import { queryKeys } from './queryKeys'
 
-describe('queryKeys.originalBunkRequestsByPersonId vs originalBunkRequestsByRequesterCmId', () => {
-  it('produces distinct cache keys for the two callers', () => {
-    // Same numeric id, same year — different shapes (different filter columns)
-    // must not collide in the cache.
-    const personIdKey = queryKeys.originalBunkRequestsByPersonId(12345, 2025)
-    const cmIdKey = queryKeys.originalBunkRequestsByRequesterCmId(12345, 2025)
-    expect(personIdKey).not.toEqual(cmIdKey)
-  })
-
-  it('originalBunkRequestsByPersonId key includes a person-id discriminator', () => {
-    const key = queryKeys.originalBunkRequestsByPersonId(12345, 2025)
-    expect(key[0]).toBe('original-bunk-requests-by-person-id')
-    expect(key).toContain(12345)
-    expect(key).toContain(2025)
-  })
-
-  it('originalBunkRequestsByRequesterCmId key includes a requester-cm-id discriminator', () => {
+describe('queryKeys.originalBunkRequestsByRequesterCmId', () => {
+  it('key includes a requester-cm-id discriminator', () => {
     const key = queryKeys.originalBunkRequestsByRequesterCmId(12345, 2025)
     expect(key[0]).toBe('original-bunk-requests-by-requester-cm-id')
     expect(key).toContain(12345)
@@ -36,8 +22,8 @@ describe('queryKeys.originalBunkRequestsByPersonId vs originalBunkRequestsByRequ
   })
 
   it('handles undefined ids without colliding with the populated case', () => {
-    const populated = queryKeys.originalBunkRequestsByPersonId(12345, 2025)
-    const empty = queryKeys.originalBunkRequestsByPersonId(undefined, 2025)
+    const populated = queryKeys.originalBunkRequestsByRequesterCmId(12345, 2025)
+    const empty = queryKeys.originalBunkRequestsByRequesterCmId(undefined, 2025)
     expect(populated).not.toEqual(empty)
   })
 })

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -411,14 +411,6 @@ export const queryKeys = {
     ['person-for-siblings', camperId, year] as const,
   camperSiblingsPanel: (householdId: number | undefined, camperId: string, year: number) =>
     ['camper-siblings-panel', householdId, camperId, year] as const,
-  // Two callers query `original_bunk_requests` with different filter columns
-  // and shape the result differently — a single shared cache key would cause
-  // a collision. Split into two distinct factories.
-  //
-  // Filter: `person_id = {cmId}`. Returns first row as raw OriginalBunkData
-  // (used by CamperDetailsPanel). Caller must gate with `enabled: !!cmId`.
-  originalBunkRequestsByPersonId: (cmId: number | undefined, year: number) =>
-    ['original-bunk-requests-by-person-id', cmId, year] as const,
   // Filter: `requester.cm_id = {cmId}`. Returns denormalized
   // OriginalBunkData[] (used by useOriginalBunkData). Caller must gate
   // with `enabled: !!cmId`.

--- a/scripts/setup/seed_from_prod.py
+++ b/scripts/setup/seed_from_prod.py
@@ -38,6 +38,36 @@ def _get_data_tables(conn: sqlite3.Connection) -> set[str]:
     return tables
 
 
+def _get_columns(conn: sqlite3.Connection, table: str) -> list[str]:
+    """Return the column names for a table, in declaration order."""
+    return [row[1] for row in conn.execute(f"PRAGMA table_info([{table}])").fetchall()]
+
+
+def _detect_column_drift(dev_db: str, prod_db: str, common: list[str]) -> dict[str, dict[str, list[str]]]:
+    """Return per-table drift between dev and prod for the given shared tables.
+
+    Result shape: {table: {"dev_only": [...], "prod_only": [...]}}.
+    Empty for tables whose column sets match.
+    """
+    drift: dict[str, dict[str, list[str]]] = {}
+    dev_conn = sqlite3.connect(dev_db)
+    prod_conn = sqlite3.connect(prod_db)
+    try:
+        for table in common:
+            dev_cols = set(_get_columns(dev_conn, table))
+            prod_cols = set(_get_columns(prod_conn, table))
+            if dev_cols == prod_cols:
+                continue
+            drift[table] = {
+                "dev_only": sorted(dev_cols - prod_cols),
+                "prod_only": sorted(prod_cols - dev_cols),
+            }
+    finally:
+        dev_conn.close()
+        prod_conn.close()
+    return drift
+
+
 def _ensure_owned_by_current_user(db_path: str) -> None:
     """Chown the db (and -wal/-shm siblings) to the current user via sudo if needed.
 
@@ -136,17 +166,32 @@ def seed_from_prod(
     prod_only = sorted(prod_tables - dev_tables)
     dev_only = sorted(dev_tables - prod_tables)
 
-    if prod_only or dev_only:
+    # Detect column-level drift inside shared tables (e.g. a column dropped
+    # by a migration that landed in dev but not yet deployed to prod). The
+    # old bulk INSERT ... SELECT * would crash on the column-count mismatch
+    # and leave dev frozen at the last successful seed.
+    column_drift = _detect_column_drift(dev_db, prod_db, common)
+
+    if prod_only or dev_only or column_drift:
         if prod_only:
             print(f"WARNING: Skipping {len(prod_only)} tables in prod but not dev: {', '.join(prod_only)}")
         if dev_only:
             print(f"WARNING: Skipping {len(dev_only)} tables in dev but not prod: {', '.join(dev_only)}")
+        for table, cols in column_drift.items():
+            if cols["prod_only"]:
+                print(
+                    f"WARNING: column drift on {table} — prod has columns dev doesn't: {', '.join(cols['prod_only'])}"
+                )
+            if cols["dev_only"]:
+                print(f"WARNING: column drift on {table} — dev has columns prod doesn't: {', '.join(cols['dev_only'])}")
         if not allow_skip:
             print(
                 "\nERROR: schema drift detected between dev and prod. Dropping a "
-                "whole table's worth of rows silently is the failure mode #1338 "
-                "fixed at the query level; refusing to perpetuate it at the seed "
-                "level. Re-run with --allow-skip if the drift is intentional."
+                "whole table's (or column's) worth of rows silently is the failure "
+                "mode #1338 fixed at the query level; refusing to perpetuate it at "
+                "the seed level. Re-run with --allow-skip if the drift is "
+                "intentional (intersection columns will be copied; drifted columns "
+                "skipped)."
             )
             sys.exit(1)
 
@@ -166,6 +211,8 @@ def seed_from_prod(
             summary["skipped_prod_only"] = prod_only
         if dev_only:
             summary["skipped_dev_only"] = dev_only
+        if column_drift:
+            summary["column_drift"] = column_drift
 
         print("DRY RUN — no changes made")
         _print_summary(summary, dry_run=True)
@@ -182,10 +229,24 @@ def seed_from_prod(
         # ATTACH prod database
         cur.execute("ATTACH DATABASE ? AS prod", (prod_db,))
 
+        # Precompute the intersection column list per table — copying via an
+        # explicit list (instead of SELECT *) silently drops any drifted
+        # columns rather than crashing the whole INSERT on a count mismatch.
+        prod_conn_cols = sqlite3.connect(prod_db)
+        try:
+            shared_cols: dict[str, list[str]] = {}
+            for table in common:
+                dev_cols = set(_get_columns(conn, table))
+                prod_cols = set(_get_columns(prod_conn_cols, table))
+                shared_cols[table] = sorted(dev_cols & prod_cols)
+        finally:
+            prod_conn_cols.close()
+
         tables_copied = {}
         for table in common:
+            col_list = ", ".join(f"[{c}]" for c in shared_cols[table])
             cur.execute(f"DELETE FROM main.[{table}]")
-            cur.execute(f"INSERT INTO main.[{table}] SELECT * FROM prod.[{table}]")
+            cur.execute(f"INSERT INTO main.[{table}] ({col_list}) SELECT {col_list} FROM prod.[{table}]")
             count = cur.execute(f"SELECT COUNT(*) FROM main.[{table}]").fetchone()[0]
             tables_copied[table] = count
 
@@ -204,6 +265,8 @@ def seed_from_prod(
         summary["skipped_prod_only"] = prod_only
     if dev_only:
         summary["skipped_dev_only"] = dev_only
+    if column_drift:
+        summary["column_drift"] = column_drift
 
     _print_summary(summary)
     return summary

--- a/scripts/setup/seed_from_prod.py
+++ b/scripts/setup/seed_from_prod.py
@@ -91,6 +91,7 @@ def seed_from_prod(
     dev_db: str,
     prod_db: str,
     dry_run: bool = False,
+    allow_skip: bool = False,
 ) -> dict[str, object]:
     """Inject prod data into a clean dev database.
 
@@ -98,6 +99,11 @@ def seed_from_prod(
         dev_db: Path to the clean dev data.db (target).
         prod_db: Path to the prod data-prod.db (source).
         dry_run: If True, report what would change without modifying.
+        allow_skip: If True, fall back to warn-and-continue when prod has
+            tables dev doesn't (or vice versa). Default False fails fast —
+            dropping a whole table's worth of rows is the silent-empty
+            symptom that masked #1338, and a hard error makes the drift
+            visible (#1339 ask #2).
 
     Returns:
         Summary dict with table names and row counts.
@@ -130,10 +136,19 @@ def seed_from_prod(
     prod_only = sorted(prod_tables - dev_tables)
     dev_only = sorted(dev_tables - prod_tables)
 
-    if prod_only:
-        print(f"WARNING: Skipping {len(prod_only)} tables in prod but not dev: {', '.join(prod_only)}")
-    if dev_only:
-        print(f"WARNING: Skipping {len(dev_only)} tables in dev but not prod: {', '.join(dev_only)}")
+    if prod_only or dev_only:
+        if prod_only:
+            print(f"WARNING: Skipping {len(prod_only)} tables in prod but not dev: {', '.join(prod_only)}")
+        if dev_only:
+            print(f"WARNING: Skipping {len(dev_only)} tables in dev but not prod: {', '.join(dev_only)}")
+        if not allow_skip:
+            print(
+                "\nERROR: schema drift detected between dev and prod. Dropping a "
+                "whole table's worth of rows silently is the failure mode #1338 "
+                "fixed at the query level; refusing to perpetuate it at the seed "
+                "level. Re-run with --allow-skip if the drift is intentional."
+            )
+            sys.exit(1)
 
     summary: dict[str, object] = {}
 
@@ -241,6 +256,11 @@ def main() -> int:
         action="store_true",
         help="Report what would change without modifying",
     )
+    parser.add_argument(
+        "--allow-skip",
+        action="store_true",
+        help="Continue (with warning) when dev/prod schemas drift instead of failing",
+    )
     args = parser.parse_args()
 
     # Auto-detect project root
@@ -254,6 +274,7 @@ def main() -> int:
         dev_db=dev_db,
         prod_db=prod_db,
         dry_run=args.dry_run,
+        allow_skip=args.allow_skip,
     )
     return 0
 

--- a/tests/test_seed_from_prod.py
+++ b/tests/test_seed_from_prod.py
@@ -474,13 +474,17 @@ class TestDryRun:
 class TestSchemaMismatch:
     """Test handling when prod and dev have different sets of data tables."""
 
-    def test_extra_prod_table_skipped_with_warning(
+    def test_extra_prod_table_fails_by_default(
         self,
         tmp_path: Path,
         seed_module: types.ModuleType,
-        capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """Tables in prod but not dev should be skipped (logged as warning)."""
+        """Default (strict) behavior: prod-only data tables abort the seed.
+
+        Silently skipping a prod table drops a whole collection of rows from
+        the dev DB, which masks bugs like #1338 where a section silently
+        renders empty. Fail fast so the drift is visible (#1339 ask #2).
+        """
         dev_path = str(tmp_path / "data.db")
         prod_path = str(tmp_path / "data-prod.db")
         _create_dev_db(dev_path)
@@ -493,7 +497,29 @@ class TestSchemaMismatch:
         conn.commit()
         conn.close()
 
-        result = seed_module.seed_from_prod(dev_db=dev_path, prod_db=prod_path)
+        with pytest.raises(SystemExit):
+            seed_module.seed_from_prod(dev_db=dev_path, prod_db=prod_path)
+
+    def test_extra_prod_table_skipped_with_warning_when_allow_skip(
+        self,
+        tmp_path: Path,
+        seed_module: types.ModuleType,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """allow_skip=True restores the legacy warn-and-continue behavior."""
+        dev_path = str(tmp_path / "data.db")
+        prod_path = str(tmp_path / "data-prod.db")
+        _create_dev_db(dev_path)
+        _create_prod_db(prod_path)
+
+        # Add an extra table to prod that dev doesn't have
+        conn = sqlite3.connect(prod_path)
+        conn.execute("CREATE TABLE legacy_table (id TEXT PRIMARY KEY, data TEXT)")
+        conn.execute("INSERT INTO legacy_table VALUES ('l1', 'old data')")
+        conn.commit()
+        conn.close()
+
+        result = seed_module.seed_from_prod(dev_db=dev_path, prod_db=prod_path, allow_skip=True)
 
         # Should still succeed — other tables should be copied
         assert result["tables_copied"]["persons"] == 3
@@ -503,13 +529,16 @@ class TestSchemaMismatch:
         captured = capsys.readouterr()
         assert "legacy_table" in captured.out
 
-    def test_extra_dev_table_skipped(
+    def test_extra_dev_table_fails_by_default(
         self,
         tmp_path: Path,
         seed_module: types.ModuleType,
-        capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """Tables in dev but not prod should be skipped (left empty)."""
+        """Default (strict) behavior also fails on dev-only data tables.
+
+        A new collection added to dev that prod doesn't have yet leaves dev
+        out of parity. Same hard-error treatment as prod-only tables.
+        """
         dev_path = str(tmp_path / "data.db")
         prod_path = str(tmp_path / "data-prod.db")
         _create_dev_db(dev_path)
@@ -521,7 +550,28 @@ class TestSchemaMismatch:
         conn.commit()
         conn.close()
 
-        result = seed_module.seed_from_prod(dev_db=dev_path, prod_db=prod_path)
+        with pytest.raises(SystemExit):
+            seed_module.seed_from_prod(dev_db=dev_path, prod_db=prod_path)
+
+    def test_extra_dev_table_skipped_when_allow_skip(
+        self,
+        tmp_path: Path,
+        seed_module: types.ModuleType,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """allow_skip=True permits dev-only tables (left empty in dev)."""
+        dev_path = str(tmp_path / "data.db")
+        prod_path = str(tmp_path / "data-prod.db")
+        _create_dev_db(dev_path)
+        _create_prod_db(prod_path)
+
+        # Add an extra table to dev that prod doesn't have
+        conn = sqlite3.connect(dev_path)
+        conn.execute("CREATE TABLE new_feature (id TEXT PRIMARY KEY, data TEXT)")
+        conn.commit()
+        conn.close()
+
+        result = seed_module.seed_from_prod(dev_db=dev_path, prod_db=prod_path, allow_skip=True)
 
         # Should still succeed
         assert result["tables_copied"]["persons"] == 3
@@ -533,7 +583,7 @@ class TestSchemaMismatch:
     def test_matching_tables_still_copied_despite_mismatches(
         self, tmp_path: Path, seed_module: types.ModuleType
     ) -> None:
-        """Even with mismatched tables, the common tables should be copied."""
+        """With allow_skip=True, common tables copy even when extras exist on both sides."""
         dev_path = str(tmp_path / "data.db")
         prod_path = str(tmp_path / "data-prod.db")
         _create_dev_db(dev_path)
@@ -550,7 +600,7 @@ class TestSchemaMismatch:
         conn.commit()
         conn.close()
 
-        seed_module.seed_from_prod(dev_db=dev_path, prod_db=prod_path)
+        seed_module.seed_from_prod(dev_db=dev_path, prod_db=prod_path, allow_skip=True)
 
         # Common tables should still be copied
         conn = sqlite3.connect(dev_path)

--- a/tests/test_seed_from_prod.py
+++ b/tests/test_seed_from_prod.py
@@ -610,6 +610,124 @@ class TestSchemaMismatch:
 
 
 # ---------------------------------------------------------------------------
+# Tests: Column-level schema drift (within shared tables)
+# ---------------------------------------------------------------------------
+
+
+class TestColumnDrift:
+    """Schema drift inside a shared table — prod has a column dev doesn't (or vice versa).
+
+    This is the failure mode that caused #1339 in practice: PR #1384 dropped a
+    column from dev's schema, but prod hadn't been redeployed, so the column
+    survived in the prod DB copy. The old bulk `INSERT ... SELECT *` crashed
+    with a column-count mismatch; the rollback left dev's state frozen at
+    whatever the previous successful seed left, and the user couldn't tell
+    the seed had failed.
+    """
+
+    def _add_column_to_prod(self, prod_path: str, table: str, column: str) -> None:
+        conn = sqlite3.connect(prod_path)
+        conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} TEXT DEFAULT ''")
+        conn.commit()
+        conn.close()
+
+    def test_column_drift_fails_by_default(self, tmp_path: Path, seed_module: types.ModuleType) -> None:
+        """Default (strict) behavior: prod having an extra column on a shared table fails."""
+        dev_path = str(tmp_path / "data.db")
+        prod_path = str(tmp_path / "data-prod.db")
+        _create_dev_db(dev_path)
+        _create_prod_db(prod_path)
+
+        # Simulate post-#1384 state: prod still has a column dev's migrations dropped.
+        self._add_column_to_prod(prod_path, "persons", "legacy_field")
+
+        with pytest.raises(SystemExit):
+            seed_module.seed_from_prod(dev_db=dev_path, prod_db=prod_path)
+
+    def test_column_drift_error_message_names_table_and_column(
+        self,
+        tmp_path: Path,
+        seed_module: types.ModuleType,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """The strict failure message should name the drifted table and column."""
+        dev_path = str(tmp_path / "data.db")
+        prod_path = str(tmp_path / "data-prod.db")
+        _create_dev_db(dev_path)
+        _create_prod_db(prod_path)
+        self._add_column_to_prod(prod_path, "persons", "legacy_field")
+
+        with pytest.raises(SystemExit):
+            seed_module.seed_from_prod(dev_db=dev_path, prod_db=prod_path)
+
+        captured = capsys.readouterr()
+        assert "persons" in captured.out
+        assert "legacy_field" in captured.out
+
+    def test_column_drift_with_allow_skip_copies_intersection(
+        self, tmp_path: Path, seed_module: types.ModuleType
+    ) -> None:
+        """With allow_skip=True, the drifted column is dropped from the copy.
+
+        Intersection-copy means: ignore the column that exists only in prod
+        (or only in dev). The remaining shared columns are copied normally.
+        """
+        dev_path = str(tmp_path / "data.db")
+        prod_path = str(tmp_path / "data-prod.db")
+        _create_dev_db(dev_path)
+        _create_prod_db(prod_path)
+        self._add_column_to_prod(prod_path, "persons", "legacy_field")
+
+        result = seed_module.seed_from_prod(dev_db=dev_path, prod_db=prod_path, allow_skip=True)
+
+        # persons should still get its 3 prod rows
+        assert result["tables_copied"]["persons"] == 3
+
+        # The drifted column should be listed in the per-table drift summary
+        column_drift = result.get("column_drift", {})
+        assert "persons" in column_drift
+        assert "legacy_field" in column_drift["persons"]["prod_only"]
+
+    def test_column_drift_with_allow_skip_actually_copies_data(
+        self, tmp_path: Path, seed_module: types.ModuleType
+    ) -> None:
+        """Intersection-copy must produce dev rows with the shared-column data."""
+        dev_path = str(tmp_path / "data.db")
+        prod_path = str(tmp_path / "data-prod.db")
+        _create_dev_db(dev_path)
+        _create_prod_db(prod_path)
+        self._add_column_to_prod(prod_path, "persons", "legacy_field")
+
+        seed_module.seed_from_prod(dev_db=dev_path, prod_db=prod_path, allow_skip=True)
+
+        # Verify dev persons rows were actually copied with shared-column data
+        conn = sqlite3.connect(dev_path)
+        rows = conn.execute("SELECT cm_id, first_name FROM persons ORDER BY cm_id").fetchall()
+        conn.close()
+        assert rows == [("CM001", "Emma"), ("CM002", "Liam"), ("CM003", "Olivia")]
+
+    def test_column_drift_dev_only_column_also_handled(self, tmp_path: Path, seed_module: types.ModuleType) -> None:
+        """Symmetric case: dev has a column prod doesn't. Strict still fails; allow_skip copies intersection."""
+        dev_path = str(tmp_path / "data.db")
+        prod_path = str(tmp_path / "data-prod.db")
+        _create_dev_db(dev_path)
+        _create_prod_db(prod_path)
+
+        # Dev migrations added a new column prod hasn't deployed yet
+        conn = sqlite3.connect(dev_path)
+        conn.execute("ALTER TABLE persons ADD COLUMN new_field TEXT DEFAULT ''")
+        conn.commit()
+        conn.close()
+
+        with pytest.raises(SystemExit):
+            seed_module.seed_from_prod(dev_db=dev_path, prod_db=prod_path)
+
+        result = seed_module.seed_from_prod(dev_db=dev_path, prod_db=prod_path, allow_skip=True)
+        assert result["tables_copied"]["persons"] == 3
+        assert "new_field" in result["column_drift"]["persons"]["dev_only"]
+
+
+# ---------------------------------------------------------------------------
 # Tests: Missing file errors
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #1339, #1341.

## Audit scope

Followup to #1338, which fixed CamperDetailsPanel's "Raw CSV Data" section that
silently rendered empty due to an inline query filtering on a non-existent
`person_id` column. The audit walks the camper-detail / sidebar surfaces
looking for the same anti-pattern: inline `pb.collection().getList/getFullList`
queries whose section render guard is `{<query-result> && <section>}`, where
the query silently returning null makes the section invisible.

## Findings

| # | Finding | Severity |
|---|---------|----------|
| 1 | `BunkSocialGraphModal.tsx:211` reads `bp.bunk_cm_id` from `bunk_plans` records, but the schema has no such field — only a `bunk` relation. Prev/next navigation arrows never render. | Med (silent UI breakage) |
| 2 | `queryKeys.originalBunkRequestsByPersonId` is dead code after #1338. Stale comment still documents the broken filter. | Low (cleanup) |
| 3 | `CamperDetailsPanel.test.tsx` `DECLINED_REQUEST` fixture used `status='declined'`, but the production query at line 422 filters `status='resolved'` — test exercised a code path prod can never deliver. | Low (#1341) |
| 4 | `seed_from_prod.py` skipped schema-mismatched tables with only a WARNING. Dropping a whole table's worth of rows silently is the same failure mode #1338 fixed at the query level. | Med (#1339 ask #2) |

Other inline queries in the audited surfaces (CamperDetailsPanel, CamperDetail,
CamperTooltip, BunkSocialGraphModal) reference valid columns and use safe
`.length > 0 &&` render guards.

## Fixes

### 1. BunkSocialGraphModal silent breakage

Extract bunk-id extraction into a typed helper that reads from the expanded
relation. Add regression tests covering: typical extract, dedup, missing expand,
missing nested cm_id, empty input.

### 2. Dead queryKey cleanup

Remove `originalBunkRequestsByPersonId` factory + stale comment. Update contract
test to reflect single-factory state.

### 3. #1341 fixture fix

Change `DECLINED_REQUEST.status` to `'resolved'` (matches what the production
query at `CamperDetailsPanel.tsx:422` actually returns). Inverted the
"renders the human-readable decline reason" test to pin `BunkRequestRow.tsx`'s
"skip disposition reason for resolved rows" contract — a regression that
removed that guard would change user-visible sidebar behavior.

### 4. seed_from_prod.py hardening

Default behavior now fails fast (`sys.exit(1)`) when prod has tables dev
doesn't (or vice versa). `--allow-skip` CLI flag (or `allow_skip=True`
parameter) restores warn-and-continue behavior for intentional drift.

## Test plan

- [x] `npx vitest run` — 4080 tests pass (5 new for `extractBunkCmIdsFromPlans`)
- [x] `npx tsc --noEmit` — clean both tsconfigs
- [x] `uv run pytest tests/test_seed_from_prod.py` — 25 tests pass (2 new for default-strict behavior, 1 updated for `allow_skip` flag)
- [x] `uv run mypy . --explicit-package-bases` — no new errors
- [x] Pre-push verification script clean (eslint, prettier, tsc, vitest, ruff, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Align bunk-request disposition display with production behavior.

* **Improvements**
  * More reliable bunk social-graph filtering and CM ID handling for session data.

* **Refactoring**
  * Simplified query-key logic and removed an unused cache-key factory.

* **Tests**
  * Added bunk-plan extraction tests and tightened query-key contract tests.
  * Expanded seeding tests to cover strict vs. skip behavior and column-level schema drift.

* **Chores**
  * Seed tooling: added opt-in skip mode (CLI flag) and safer handling of table/column schema drift.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1400)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->