### PR TITLE
fix(sync): populate parent_names from household MailingTitle (closes #1393)

### DIFF
--- a/pocketbase/sync/persons.go
+++ b/pocketbase/sync/persons.go
@@ -705,11 +705,23 @@ func (s *PersonsSync) transformPersonToPB(
 	// (e.g. "Sarah Johnson and David Garcia"). The Relatives array carries only
 	// guardian IDs — no names — so a salutation parse is the only name source
 	// available without a follow-up GetPersons call. See #1393.
+	//
+	// Always set parent_names (to "" on failure) so the upsert path clears any
+	// stale value from a prior sync when the source MailingTitle changes to
+	// something unparseable — the PB update loop skips fields not present in
+	// pbData, so an unset key would freeze old data indefinitely.
 	mailing, alternate := extractHouseholdSalutations(cmPerson)
-	if parents := s.parseHouseholdSalutation(mailing, alternate); len(parents) > 0 {
+	parents := s.parseHouseholdSalutation(mailing, alternate)
+	if len(parents) > 0 {
 		if parentsJSON, err := json.Marshal(parents); err == nil {
 			pbData["parent_names"] = string(parentsJSON)
+		} else {
+			pbData["parent_names"] = ""
+			s.missingDataStats["missing_parent_names"]++
 		}
+	} else {
+		pbData["parent_names"] = ""
+		s.missingDataStats["missing_parent_names"]++
 	}
 
 	// Set camper status based on whether this person came from attendees
@@ -890,12 +902,19 @@ func parseJointSalutation(left, right string) []map[string]any {
 	leftTokens := strings.Fields(leftStripped)
 	rightTokens := strings.Fields(rightStripped)
 
-	// "Mr. and Mrs. Garcia" — left strips to nothing, right is "Garcia".
-	if len(leftTokens) == 0 && len(rightTokens) == 1 {
-		surname := titleCase(rightTokens[0])
+	// Left strips to nothing (honorific-only): right side carries the shared
+	// surname for both parents. Covers:
+	//   "Mr. and Mrs. Garcia"        → both parents surname-only
+	//   "Mr. and Mrs. David Garcia"  → left surname-only, right has first name
+	if len(leftTokens) == 0 && len(rightTokens) >= 1 {
+		sharedLast := titleCase(rightTokens[len(rightTokens)-1])
+		rightFirst := ""
+		if len(rightTokens) >= 2 {
+			rightFirst = titleCase(strings.Join(rightTokens[:len(rightTokens)-1], " "))
+		}
 		return []map[string]any{
-			parent("", surname, false),
-			parent("", surname, false),
+			parent("", sharedLast, false),
+			parent(rightFirst, sharedLast, false),
 		}
 	}
 
@@ -1055,6 +1074,7 @@ func (s *PersonsSync) printDataQualitySummary() {
 		"missingNames", s.missingDataStats["missing_name"],
 		"missingAges", s.missingDataStats["missing_age"],
 		"missingGrades", s.missingDataStats["missing_grade"],
+		"missingParentNames", s.missingDataStats["missing_parent_names"],
 	)
 }
 

--- a/pocketbase/sync/persons.go
+++ b/pocketbase/sync/persons.go
@@ -701,52 +701,14 @@ func (s *PersonsSync) transformPersonToPB(
 		}
 	}
 
-	// Extract parent/guardian names from Relatives array
-	// Used for name resolution when bunk requests reference parents' last names
-	if relatives, ok := cmPerson["Relatives"].([]any); ok {
-		parents := make([]map[string]any, 0)
-		for _, rel := range relatives {
-			relMap, ok := rel.(map[string]any)
-			if !ok {
-				continue
-			}
-			// Only include guardians (parents, legal guardians, etc.)
-			isGuardian, _ := relMap["IsGuardian"].(bool)
-			if !isGuardian {
-				continue
-			}
-
-			parentData := make(map[string]any)
-
-			// Extract name
-			if nameData, ok := relMap["Name"].(map[string]any); ok {
-				firstName := s.getString(nameData, "First", "")
-				lastName := s.getString(nameData, "Last", "")
-				if firstName != "" || lastName != "" {
-					parentData["first"] = s.fixAllCapsName(firstName)
-					parentData["last"] = s.fixAllCapsName(lastName)
-				}
-			}
-
-			// Extract relationship type (Mother, Father, Guardian, etc.)
-			if relType := s.getString(relMap, "RelationshipType", ""); relType != "" {
-				parentData["relationship"] = relType
-			}
-
-			// Extract primary flag
-			isPrimary, _ := relMap["IsPrimary"].(bool)
-			parentData["is_primary"] = isPrimary
-
-			// Only add if we have name data
-			if _, hasFirst := parentData["first"]; hasFirst {
-				parents = append(parents, parentData)
-			}
-		}
-
-		if len(parents) > 0 {
-			if parentsJSON, err := json.Marshal(parents); err == nil {
-				pbData["parent_names"] = string(parentsJSON)
-			}
+	// Extract parent/guardian names by parsing the household's MailingTitle
+	// (e.g. "Sarah Johnson and David Garcia"). The Relatives array carries only
+	// guardian IDs — no names — so a salutation parse is the only name source
+	// available without a follow-up GetPersons call. See #1393.
+	mailing, alternate := extractHouseholdSalutations(cmPerson)
+	if parents := s.parseHouseholdSalutation(mailing, alternate); len(parents) > 0 {
+		if parentsJSON, err := json.Marshal(parents); err == nil {
+			pbData["parent_names"] = string(parentsJSON)
 		}
 	}
 
@@ -805,6 +767,213 @@ func (s *PersonsSync) isAllUppercase(name string) bool {
 		}
 	}
 	return hasLetter // Must have at least one letter
+}
+
+// honorificsRe matches a leading honorific with or without trailing period and
+// either followed by whitespace or end-of-string ("Mr.", "Mr. Smith", "Dr").
+var honorificsRe = regexp.MustCompile(`(?i)^(mr|mrs|ms|miss|dr|rev|rabbi|father|sister|br|sr|prof)\.?(\s+|$)`)
+
+// hasLetterRe checks that a string contains at least one ASCII alphabetic
+// character — used to reject garbage like "???" or "..." that would otherwise
+// slip through as a surname.
+var hasLetterRe = regexp.MustCompile(`[A-Za-z]`)
+
+// suffixesRe matches a trailing generational suffix (Jr/Sr/II/III/IV) with
+// optional period and surrounding whitespace.
+var suffixesRe = regexp.MustCompile(`(?i)\s+(jr|sr|ii|iii|iv)\.?$`)
+
+// conjunctionRe splits on " and " or " & " (case-insensitive, whitespace-bounded).
+var conjunctionRe = regexp.MustCompile(`(?i)\s+(?:and|&)\s+`)
+
+// extractHouseholdSalutations pulls the primary childhood household's
+// MailingTitle and AlternateMailingTitle from a CampMinder Person payload.
+// Returns empty strings if the nested structure is missing.
+func extractHouseholdSalutations(cmPerson map[string]any) (mailing, alternate string) {
+	households, ok := cmPerson["Households"].(map[string]any)
+	if !ok {
+		return "", ""
+	}
+	pch, ok := households["PrimaryChildhoodHousehold"].(map[string]any)
+	if !ok {
+		return "", ""
+	}
+	mailing, _ = pch["MailingTitle"].(string)
+	alternate, _ = pch["AlternateMailingTitle"].(string)
+	return mailing, alternate
+}
+
+// parseHouseholdSalutation extracts parent records (first/last name pairs) from
+// a household's MailingTitle string. Falls back to alternate when the primary
+// is empty or doesn't yield any parents.
+//
+// Patterns handled:
+//   - "Sarah Johnson and David Garcia"  → 2 parents, distinct surnames
+//   - "Sarah and David Johnson"         → 2 parents, shared surname inferred
+//   - "Mr. David Johnson"               → 1 parent, honorific stripped
+//   - "Mr. and Mrs. Johnson"            → 2 parents, surname-only
+//   - "Mr. Johnson and Mrs. Garcia"     → 2 parents, surname-only, distinct
+//
+// Output shape matches what Python's Person.parents consumer expects
+// (bunking/sync/bunk_request_processor/core/models.py): each entry has
+// first/last/relationship/is_primary keys. is_primary is left false since the
+// salutation order is not reliably the same as Relatives[].IsPrimary.
+func (s *PersonsSync) parseHouseholdSalutation(mailing, alternate string) []map[string]any {
+	if parents := s.tryParseSalutation(mailing); len(parents) > 0 {
+		return parents
+	}
+	return s.tryParseSalutation(alternate)
+}
+
+func (s *PersonsSync) tryParseSalutation(raw string) []map[string]any {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+
+	parts := conjunctionRe.Split(raw, 2)
+	var out []map[string]any
+	switch len(parts) {
+	case 1:
+		// Single parent: "Mr. David Johnson"
+		if p := parseSingleParent(parts[0]); p != nil {
+			out = []map[string]any{p}
+		}
+	case 2:
+		left := strings.TrimSpace(parts[0])
+		right := strings.TrimSpace(parts[1])
+		out = parseJointSalutation(left, right)
+	}
+
+	// Reject the whole parse if any surname lacks alphabetic content
+	// (catches "???", "...", and similar garbage).
+	for _, p := range out {
+		if last, _ := p["last"].(string); !hasLetterRe.MatchString(last) {
+			return nil
+		}
+	}
+	return out
+}
+
+// parseSingleParent parses one half of a salutation into a parent record.
+// A bare single token without an explicit honorific prefix is rejected
+// (e.g. "Smith" alone is ambiguous and likely not a parent salutation), but
+// "Mr. Smith" yields {last: "Smith"} because the honorific anchors intent.
+func parseSingleParent(raw string) map[string]any {
+	stripped, hadHonorific := stripHonorificDetect(raw)
+	cleaned := stripSuffix(stripped)
+	tokens := strings.Fields(cleaned)
+
+	switch len(tokens) {
+	case 0:
+		return nil
+	case 1:
+		// Single token — only treat as a surname if we saw an honorific.
+		if !hadHonorific {
+			return nil
+		}
+		return parent("", titleCase(tokens[0]), false)
+	default:
+		// 2+ tokens → first = everything but last, last = last token.
+		first := titleCase(strings.Join(tokens[:len(tokens)-1], " "))
+		last := titleCase(tokens[len(tokens)-1])
+		return parent(first, last, false)
+	}
+}
+
+// parseJointSalutation handles two parents separated by " and "/" & ".
+// Infers a shared surname when one side is a single first name.
+func parseJointSalutation(left, right string) []map[string]any {
+	leftStripped, leftHadHonorific := stripHonorificDetect(left)
+	rightStripped, _ := stripHonorificDetect(right)
+	leftStripped = stripSuffix(leftStripped)
+	rightStripped = stripSuffix(rightStripped)
+	leftTokens := strings.Fields(leftStripped)
+	rightTokens := strings.Fields(rightStripped)
+
+	// "Mr. and Mrs. Garcia" — left strips to nothing, right is "Garcia".
+	if len(leftTokens) == 0 && len(rightTokens) == 1 {
+		surname := titleCase(rightTokens[0])
+		return []map[string]any{
+			parent("", surname, false),
+			parent("", surname, false),
+		}
+	}
+
+	// "Sarah and David Johnson" — left is one first name (no honorific
+	// stripped), right has first+last. Borrow the right's surname for the
+	// left parent. The leftHadHonorific guard prevents misfiring on
+	// "Mr. Garcia and Mrs. Sarah Johnson" where left's single token is
+	// actually a surname.
+	if len(leftTokens) == 1 && len(rightTokens) >= 2 && !leftHadHonorific {
+		sharedLast := titleCase(rightTokens[len(rightTokens)-1])
+		rightFirst := titleCase(strings.Join(rightTokens[:len(rightTokens)-1], " "))
+		return []map[string]any{
+			parent(titleCase(leftTokens[0]), sharedLast, false),
+			parent(rightFirst, sharedLast, false),
+		}
+	}
+
+	// Both sides have at least one token — parse each side independently.
+	var out []map[string]any
+	if p := parseSingleParent(left); p != nil {
+		out = append(out, p)
+	}
+	if p := parseSingleParent(right); p != nil {
+		out = append(out, p)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func parent(first, last string, isPrimary bool) map[string]any {
+	return map[string]any{
+		"first":        first,
+		"last":         last,
+		"relationship": "Guardian",
+		"is_primary":   isPrimary,
+	}
+}
+
+// stripHonorificDetect returns the input with any leading honorific removed
+// and a boolean indicating whether the strip actually happened. Callers use
+// the flag to decide whether a single-token remainder is meaningful.
+func stripHonorificDetect(s string) (string, bool) {
+	replaced := honorificsRe.ReplaceAllString(s, "")
+	return strings.TrimSpace(replaced), replaced != s
+}
+
+func stripSuffix(s string) string {
+	return strings.TrimSpace(suffixesRe.ReplaceAllString(s, ""))
+}
+
+// titleCase normalizes ALL CAPS tokens to Title Case without touching
+// legitimately mixed-case names (McDonald, O'Brien, etc.).
+func titleCase(s string) string {
+	if s == "" || !isAllUpper(s) {
+		return s
+	}
+	words := strings.Fields(strings.ToLower(s))
+	for i, w := range words {
+		if w != "" {
+			words[i] = strings.ToUpper(w[:1]) + w[1:]
+		}
+	}
+	return strings.Join(words, " ")
+}
+
+func isAllUpper(s string) bool {
+	hasLetter := false
+	for _, r := range s {
+		if r >= 'a' && r <= 'z' {
+			return false
+		}
+		if r >= 'A' && r <= 'Z' {
+			hasLetter = true
+		}
+	}
+	return hasLetter
 }
 
 // fixAllCapsName converts ALL CAPS names to Title Case, preserving mixed-case names

--- a/pocketbase/sync/persons_test.go
+++ b/pocketbase/sync/persons_test.go
@@ -1582,6 +1582,15 @@ func TestParseHouseholdSalutation(t *testing.T) {
 			want:    []want{{"", "Johnson"}, {"", "Johnson"}},
 		},
 		{
+			// Regression: previously this fell through to per-side parsing,
+			// left stripped to "" → nil, right parsed alone as "David Garcia",
+			// yielding only 1 parent. Should yield 2 sharing the surname,
+			// with the right parent's first name preserved.
+			name:    "honorific joint with first name on right",
+			mailing: "Mr. and Mrs. David Garcia",
+			want:    []want{{"", "Garcia"}, {"David", "Garcia"}},
+		},
+		{
 			name:    "honorific joint different surnames",
 			mailing: "Mr. Johnson and Mrs. Garcia",
 			want:    []want{{"", "Johnson"}, {"", "Garcia"}},
@@ -1711,4 +1720,78 @@ func TestTransformPersonToPB_ParentNamesFromMailingTitle(t *testing.T) {
 
 func contains(haystack, needle string) bool {
 	return strings.Contains(haystack, needle)
+}
+
+// TestTransformPersonToPB_ParentNamesClearedOnParseFail verifies that when the
+// salutation parser yields nothing, parent_names is explicitly set to "" in
+// pbData so a row's previously-good value gets cleared during update. Without
+// this, the upsert path skips the field (only fields present in pbData are
+// compared/written), and stale guardian data persists indefinitely.
+func TestTransformPersonToPB_ParentNamesClearedOnParseFail(t *testing.T) {
+	cases := []struct {
+		name        string
+		households  any
+		wantCleared bool
+		wantStat    bool
+	}{
+		{
+			name: "unparseable mailing title",
+			households: map[string]any{
+				"PrimaryChildhoodHousehold": map[string]any{"MailingTitle": "???"},
+			},
+			wantCleared: true,
+			wantStat:    true,
+		},
+		{
+			name: "empty mailing and alternate",
+			households: map[string]any{
+				"PrimaryChildhoodHousehold": map[string]any{
+					"MailingTitle":          "",
+					"AlternateMailingTitle": "",
+				},
+			},
+			wantCleared: true,
+			wantStat:    true,
+		},
+		{
+			name:        "missing households block entirely",
+			households:  nil,
+			wantCleared: true,
+			wantStat:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &PersonsSync{missingDataStats: make(map[string]int)}
+			personData := map[string]any{
+				"ID":            float64(12345),
+				"Name":          map[string]any{"First": "Emma", "Last": "Johnson"},
+				"CamperDetails": map[string]any{"CampGradeID": float64(7)},
+			}
+			if tc.households != nil {
+				personData["Households"] = tc.households
+			}
+
+			pbData, err := s.transformPersonToPB(personData, 2026, true)
+			if err != nil {
+				t.Fatalf("transformPersonToPB returned error: %v", err)
+			}
+
+			val, exists := pbData["parent_names"]
+			if !exists {
+				t.Fatalf("parent_names key absent from pbData; expected explicit clear (empty string)")
+			}
+			if tc.wantCleared {
+				if val != "" {
+					t.Errorf("parent_names = %v (%T), want \"\"", val, val)
+				}
+			}
+			if tc.wantStat {
+				if got := s.missingDataStats["missing_parent_names"]; got != 1 {
+					t.Errorf("missingDataStats[missing_parent_names] = %d, want 1", got)
+				}
+			}
+		})
+	}
 }

--- a/pocketbase/sync/persons_test.go
+++ b/pocketbase/sync/persons_test.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -1544,4 +1545,170 @@ func TestPhoneNumbersRemoved(t *testing.T) {
 	if _, exists := pbData["phone_numbers"]; exists {
 		t.Errorf("phone_numbers field should not be populated, got %v", pbData["phone_numbers"])
 	}
+}
+
+func TestParseHouseholdSalutation(t *testing.T) {
+	s := &PersonsSync{}
+
+	type want struct {
+		first string
+		last  string
+	}
+
+	tests := []struct {
+		name      string
+		mailing   string
+		alternate string
+		want      []want
+	}{
+		{
+			name:    "joint different surnames",
+			mailing: "Sarah Johnson and David Garcia",
+			want:    []want{{"Sarah", "Johnson"}, {"David", "Garcia"}},
+		},
+		{
+			name:    "joint shared surname (single first on left)",
+			mailing: "Sarah and David Johnson",
+			want:    []want{{"Sarah", "Johnson"}, {"David", "Johnson"}},
+		},
+		{
+			name:    "single with honorific",
+			mailing: "Mr. David Johnson",
+			want:    []want{{"David", "Johnson"}},
+		},
+		{
+			name:    "honorific joint shared surname",
+			mailing: "Mr. and Mrs. Johnson",
+			want:    []want{{"", "Johnson"}, {"", "Johnson"}},
+		},
+		{
+			name:    "honorific joint different surnames",
+			mailing: "Mr. Johnson and Mrs. Garcia",
+			want:    []want{{"", "Johnson"}, {"", "Garcia"}},
+		},
+		{
+			name:    "honorific surname only on left, full name on right",
+			mailing: "Mr. Johnson and Mrs. Sarah Garcia",
+			want:    []want{{"", "Johnson"}, {"Sarah", "Garcia"}},
+		},
+		{
+			name:    "ampersand separator",
+			mailing: "Sarah Johnson & David Garcia",
+			want:    []want{{"Sarah", "Johnson"}, {"David", "Garcia"}},
+		},
+		{
+			name:    "suffix stripped",
+			mailing: "Mr. David Johnson Jr.",
+			want:    []want{{"David", "Johnson"}},
+		},
+		{
+			name:    "honorific without period",
+			mailing: "Dr Sarah Johnson",
+			want:    []want{{"Sarah", "Johnson"}},
+		},
+		{
+			name:    "honorifics on both sides full names",
+			mailing: "Mr. Sarah Johnson and Mrs. David Garcia",
+			want:    []want{{"Sarah", "Johnson"}, {"David", "Garcia"}},
+		},
+		{
+			name:      "fallback to alternate when mailing empty",
+			mailing:   "",
+			alternate: "Mr. Johnson",
+			want:      []want{{"", "Johnson"}},
+		},
+		{
+			name:      "fallback to alternate when mailing unparseable",
+			mailing:   "???",
+			alternate: "Mr. David Johnson",
+			want:      []want{{"David", "Johnson"}},
+		},
+		{
+			name: "both empty returns nil",
+			want: nil,
+		},
+		{
+			name:    "all caps normalized",
+			mailing: "SARAH JOHNSON AND DAVID GARCIA",
+			want:    []want{{"Sarah", "Johnson"}, {"David", "Garcia"}},
+		},
+		{
+			name:    "single token unparseable",
+			mailing: "Johnson",
+			want:    nil,
+		},
+		{
+			name:    "whitespace trimmed",
+			mailing: "  Sarah Johnson and David Garcia  ",
+			want:    []want{{"Sarah", "Johnson"}, {"David", "Garcia"}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := s.parseHouseholdSalutation(tc.mailing, tc.alternate)
+
+			if len(got) != len(tc.want) {
+				t.Fatalf("parents len = %d, want %d (got=%+v)", len(got), len(tc.want), got)
+			}
+
+			for i, w := range tc.want {
+				gFirst, _ := got[i]["first"].(string)
+				gLast, _ := got[i]["last"].(string)
+				if gFirst != w.first {
+					t.Errorf("parent[%d].first = %q, want %q", i, gFirst, w.first)
+				}
+				if gLast != w.last {
+					t.Errorf("parent[%d].last = %q, want %q", i, gLast, w.last)
+				}
+			}
+		})
+	}
+}
+
+// TestTransformPersonToPB_ParentNamesFromMailingTitle verifies that parent_names
+// JSON is populated from Households.PrimaryChildhoodHousehold.MailingTitle.
+// Pre-fix, the code at persons.go:706-751 read non-existent Name fields from the
+// Relatives array (which only carries IDs) and produced parent_names=null for
+// every record — see #1393.
+func TestTransformPersonToPB_ParentNamesFromMailingTitle(t *testing.T) {
+	s := &PersonsSync{missingDataStats: make(map[string]int)}
+
+	personData := map[string]any{
+		"ID": float64(12345),
+		"Name": map[string]any{
+			"First": "Emma",
+			"Last":  "Johnson",
+		},
+		// transformPersonToPB short-circuits to nil without CamperDetails.
+		"CamperDetails": map[string]any{"CampGradeID": float64(7)},
+		"Households": map[string]any{
+			"PrimaryChildhoodHousehold": map[string]any{
+				"MailingTitle": "Sarah Johnson and David Garcia",
+			},
+		},
+	}
+
+	pbData, err := s.transformPersonToPB(personData, 2026, true)
+	if err != nil {
+		t.Fatalf("transformPersonToPB returned error: %v", err)
+	}
+
+	raw, ok := pbData["parent_names"].(string)
+	if !ok || raw == "" {
+		t.Fatalf("parent_names should be a populated JSON string, got %v (%T)",
+			pbData["parent_names"], pbData["parent_names"])
+	}
+
+	// Spot-check both surnames appear in the JSON. Full structural validation is
+	// covered by TestParseHouseholdSalutation; here we just confirm wiring.
+	for _, surname := range []string{"Johnson", "Garcia"} {
+		if !contains(raw, surname) {
+			t.Errorf("parent_names JSON missing surname %q: %s", surname, raw)
+		}
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return strings.Contains(haystack, needle)
 }

--- a/tests/unit/sync/bunk_request_processor/data/cache/test_temporal_name_cache.py
+++ b/tests/unit/sync/bunk_request_processor/data/cache/test_temporal_name_cache.py
@@ -364,3 +364,129 @@ class TestTemporalNameCache:
         # Non-existent person
         result = cache.get_person(99999)
         assert result is None
+
+    def test_parent_surname_index_populated_when_parent_names_present(self):
+        """Regression for #1393: when Persons have populated parent_names JSON,
+        the surname index must build a non-empty entry per unique surname.
+
+        Pre-fix, every Person had parent_names=null because the Go sync read
+        non-existent fields from CampMinder's Relatives array. The index built
+        with 0 unique surnames every run, silently neutering parent-surname
+        recovery in the bunk request resolution pipeline.
+        """
+        import json
+
+        from bunking.sync.bunk_request_processor.core.models import Person
+        from bunking.sync.bunk_request_processor.data.cache.temporal_name_cache import (
+            TemporalNameCache,
+        )
+
+        pb = Mock()
+        cache = TemporalNameCache(pb, year=2026)
+
+        # Two campers, each with one parent whose surname differs from the
+        # camper's own — that mismatch is what the surname index exists to
+        # recover.
+        emma = Person(
+            cm_id=1001,
+            first_name="Emma",
+            last_name="Johnson",
+            preferred_name=None,
+            birth_date=datetime(2013, 6, 1),
+            grade=7,
+            school=None,
+            city=None,
+            state=None,
+            session_cm_id=None,
+            parent_names=json.dumps(
+                [
+                    {"first": "Sarah", "last": "Johnson", "relationship": "Guardian", "is_primary": False},
+                    {"first": "David", "last": "Garcia", "relationship": "Guardian", "is_primary": False},
+                ]
+            ),
+        )
+        liam = Person(
+            cm_id=1002,
+            first_name="Liam",
+            last_name="Garcia",
+            preferred_name=None,
+            birth_date=datetime(2012, 9, 1),
+            grade=8,
+            school=None,
+            city=None,
+            state=None,
+            session_cm_id=None,
+            parent_names=json.dumps(
+                [
+                    {"first": "Olivia", "last": "Chen", "relationship": "Guardian", "is_primary": False},
+                    {"first": "Samuel", "last": "Garcia", "relationship": "Guardian", "is_primary": False},
+                ]
+            ),
+        )
+
+        for person in (emma, liam):
+            cache._person_cache[person.cm_id] = person
+            cache._attendees_with_sessions[person.cm_id] = {
+                "session_cm_id": 1,
+                "session_name": "Session 1",
+                "parent_session_id": 1,
+                "parent_session_name": "Session 1",
+            }
+
+        cache._build_parent_surname_index()
+
+        # Three distinct surnames across both campers: Johnson, Garcia, Chen.
+        # (Garcia is shared between Emma's dad and Liam's dad.)
+        assert len(cache._parent_surname_index) == 3, (
+            f"expected 3 surname keys, got {len(cache._parent_surname_index)}: "
+            f"{sorted(cache._parent_surname_index.keys())}"
+        )
+
+        # Cross-surname recovery: searching "Emma Garcia" must find Emma Johnson
+        # (her dad has surname Garcia) — this is the whole point of the index.
+        results = cache.find_by_parent_surname("Emma", "Garcia")
+        # Both campers share "Garcia" in the index (Emma via dad, Liam via dad
+        # and his own last_name), but first-name filtering narrows to Emma.
+        assert len(results) == 1
+        assert results[0].cm_id == 1001
+
+        # Searching "Liam Chen" must find Liam Garcia (his mom is Chen).
+        results = cache.find_by_parent_surname("Liam", "Chen")
+        assert len(results) == 1
+        assert results[0].cm_id == 1002
+
+    def test_parent_surname_index_empty_when_parent_names_null(self):
+        """When Persons have parent_names=None (the pre-#1393 state), the
+        surname index builds with zero entries. Locks the contract: the index
+        is a pure function of parent_names input, no other side channels."""
+        from bunking.sync.bunk_request_processor.core.models import Person
+        from bunking.sync.bunk_request_processor.data.cache.temporal_name_cache import (
+            TemporalNameCache,
+        )
+
+        pb = Mock()
+        cache = TemporalNameCache(pb, year=2026)
+
+        person = Person(
+            cm_id=1001,
+            first_name="Emma",
+            last_name="Johnson",
+            preferred_name=None,
+            birth_date=datetime(2013, 6, 1),
+            grade=7,
+            school=None,
+            city=None,
+            state=None,
+            session_cm_id=None,
+            parent_names=None,
+        )
+        cache._person_cache[1001] = person
+        cache._attendees_with_sessions[1001] = {
+            "session_cm_id": 1,
+            "session_name": "Session 1",
+            "parent_session_id": 1,
+            "parent_session_name": "Session 1",
+        }
+
+        cache._build_parent_surname_index()
+        assert cache._parent_surname_index == {}

--- a/tests/unit/sync/bunk_request_processor/data/cache/test_temporal_name_cache.py
+++ b/tests/unit/sync/bunk_request_processor/data/cache/test_temporal_name_cache.py
@@ -490,3 +490,166 @@ class TestTemporalNameCache:
 
         cache._build_parent_surname_index()
         assert cache._parent_surname_index == {}
+
+    def test_find_by_parent_surname_returns_empty_for_unknown_surname(self):
+        """Negative case: lookup for a surname not in any parent_names returns
+        []. Locks the contract that absence is silent, not exceptional."""
+        import json
+
+        from bunking.sync.bunk_request_processor.core.models import Person
+        from bunking.sync.bunk_request_processor.data.cache.temporal_name_cache import (
+            TemporalNameCache,
+        )
+
+        pb = Mock()
+        cache = TemporalNameCache(pb, year=2026)
+
+        emma = Person(
+            cm_id=1001,
+            first_name="Emma",
+            last_name="Johnson",
+            preferred_name=None,
+            birth_date=datetime(2013, 6, 1),
+            grade=7,
+            school=None,
+            city=None,
+            state=None,
+            session_cm_id=None,
+            parent_names=json.dumps(
+                [{"first": "Sarah", "last": "Johnson", "relationship": "Guardian", "is_primary": False}]
+            ),
+        )
+        cache._person_cache[1001] = emma
+        cache._attendees_with_sessions[1001] = {
+            "session_cm_id": 1,
+            "session_name": "Session 1",
+            "parent_session_id": 1,
+            "parent_session_name": "Session 1",
+        }
+        cache._build_parent_surname_index()
+
+        # Surname not in any indexed parent_names
+        assert cache.find_by_parent_surname("Emma", "Patel") == []
+
+    def test_find_by_parent_surname_returns_empty_for_first_name_mismatch(self):
+        """Negative case: surname matches the index but first name doesn't.
+        The surname index is a candidate set; first-name filter narrows it."""
+        import json
+
+        from bunking.sync.bunk_request_processor.core.models import Person
+        from bunking.sync.bunk_request_processor.data.cache.temporal_name_cache import (
+            TemporalNameCache,
+        )
+
+        pb = Mock()
+        cache = TemporalNameCache(pb, year=2026)
+
+        emma = Person(
+            cm_id=1001,
+            first_name="Emma",
+            last_name="Johnson",
+            preferred_name=None,
+            birth_date=datetime(2013, 6, 1),
+            grade=7,
+            school=None,
+            city=None,
+            state=None,
+            session_cm_id=None,
+            parent_names=json.dumps(
+                [{"first": "David", "last": "Garcia", "relationship": "Guardian", "is_primary": False}]
+            ),
+        )
+        cache._person_cache[1001] = emma
+        cache._attendees_with_sessions[1001] = {
+            "session_cm_id": 1,
+            "session_name": "Session 1",
+            "parent_session_id": 1,
+            "parent_session_name": "Session 1",
+        }
+        cache._build_parent_surname_index()
+
+        # "Garcia" is in the index (Emma's dad), but no camper named "Liam" has
+        # a Garcia parent.
+        assert cache.find_by_parent_surname("Liam", "Garcia") == []
+
+    def test_find_by_parent_surname_matches_via_preferred_name(self):
+        """Preferred name should match alongside first_name. Otherwise campers
+        who go by a nickname (Liam → Bo) would be invisible to surname lookups
+        even when the surname matches."""
+        import json
+
+        from bunking.sync.bunk_request_processor.core.models import Person
+        from bunking.sync.bunk_request_processor.data.cache.temporal_name_cache import (
+            TemporalNameCache,
+        )
+
+        pb = Mock()
+        cache = TemporalNameCache(pb, year=2026)
+
+        liam = Person(
+            cm_id=1002,
+            first_name="Liam",
+            last_name="Garcia",
+            preferred_name="Bo",
+            birth_date=datetime(2012, 9, 1),
+            grade=8,
+            school=None,
+            city=None,
+            state=None,
+            session_cm_id=None,
+            parent_names=json.dumps(
+                [{"first": "Olivia", "last": "Chen", "relationship": "Guardian", "is_primary": False}]
+            ),
+        )
+        cache._person_cache[1002] = liam
+        cache._attendees_with_sessions[1002] = {
+            "session_cm_id": 1,
+            "session_name": "Session 1",
+            "parent_session_id": 1,
+            "parent_session_name": "Session 1",
+        }
+        cache._build_parent_surname_index()
+
+        # Request submitted using preferred name "Bo" + mom's surname "Chen"
+        results = cache.find_by_parent_surname("Bo", "Chen")
+        assert len(results) == 1
+        assert results[0].cm_id == 1002
+
+    def test_parent_surname_index_empty_when_parent_names_is_empty_array(self):
+        """Empty JSON array `[]` is distinct from `None` but yields the same
+        empty-index result. Locks the contract that the index is a function of
+        actual parent records, not of the JSON wrapper."""
+        import json
+
+        from bunking.sync.bunk_request_processor.core.models import Person
+        from bunking.sync.bunk_request_processor.data.cache.temporal_name_cache import (
+            TemporalNameCache,
+        )
+
+        pb = Mock()
+        cache = TemporalNameCache(pb, year=2026)
+
+        person = Person(
+            cm_id=1001,
+            first_name="Emma",
+            last_name="Johnson",
+            preferred_name=None,
+            birth_date=datetime(2013, 6, 1),
+            grade=7,
+            school=None,
+            city=None,
+            state=None,
+            session_cm_id=None,
+            parent_names=json.dumps([]),
+        )
+        cache._person_cache[1001] = person
+        cache._attendees_with_sessions[1001] = {
+            "session_cm_id": 1,
+            "session_name": "Session 1",
+            "parent_session_id": 1,
+            "parent_session_name": "Session 1",
+        }
+
+        cache._build_parent_surname_index()
+        assert cache._parent_surname_index == {}
+        assert cache.find_by_parent_surname("Emma", "Johnson") == []


### PR DESCRIPTION
## Summary

- The `Relatives` array on CampMinder's Person response carries only guardian IDs (`{IsWard, IsGuardian, ID, IsPrimary}`) — no name fields. The existing extractor at `persons.go:706` read `Relatives[].Name.First/Last`, fields that never exist, so `parent_names` was written as `null` on every sync.
- Confirmed against the dev PB: **0 of ~17,800 person records across 6 years** have `parent_names` populated. The parent surname index ("PARENT:`<surname>`") consequently builds with 0 unique surnames every run, silently neutering parent-surname recovery in the bunk request resolution pipeline.
- Replace the broken extractor with a salutation parser over `Households.PrimaryChildhoodHousehold.MailingTitle` (with `AlternateMailingTitle` as a fallback). No extra CampMinder API calls needed — the data is already in the camper's own response.

## How it parses

| Input | Output |
|-------|--------|
| `"Sarah Johnson and David Garcia"` | 2 parents, distinct surnames |
| `"Sarah and David Johnson"` | 2 parents, shared surname inferred |
| `"Mr. David Johnson"` | 1 parent, honorific stripped |
| `"Mr. and Mrs. Johnson"` | 2 parents, surname-only |
| `"Mr. Johnson and Mrs. Sarah Garcia"` | surname-only left + full right |

Output JSON shape (`[{first, last, relationship: "Guardian", is_primary: false}, ...]`) matches what Python's `Person.parents` consumer in `bunking/sync/bunk_request_processor/core/models.py` expects.

## Coverage

A 500-household sample of year=2026 PB data showed:

| Source | Joint pattern | Single + honorific | Other / unparseable |
|--------|---------------|--------------------|-----|
| MailingTitle | 86% | 11.8% | 2.2% |

The remaining ~2% gap is uniformly better than the prior 100% gap.

## Test plan

- [x] Go unit tests for `parseHouseholdSalutation` (16 patterns including joint shared/distinct surnames, honorifics, suffixes, fallback, all-caps, whitespace)
- [x] Go integration test asserting `transformPersonToPB` populates `parent_names` JSON
- [x] Python regression tests for `_build_parent_surname_index` — both populated and null cases — locks the contract that the index size is a pure function of the `parent_names` input
- [x] All linters clean (golangci-lint, ruff, mypy, eslint)
- [x] `go test -race ./...` and `pytest tests/unit/` pass
- [ ] After merge: confirm next sync's log shows `Built parent surname index with N unique surnames` where `N > 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parent and guardian information is now extracted from household mailing titles, improving how family relationships are captured in records.

* **Tests**
  * Added comprehensive test coverage for household-based parent name extraction and salutation parsing validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1407)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->