### PR TITLE
refactor(sync): drop stale Phase 3 known-issues + dead dict branch (closes #1392)

### DIFF
--- a/bunking/sync/bunk_request_processor/integration/batch_processor.py
+++ b/bunking/sync/bunk_request_processor/integration/batch_processor.py
@@ -419,10 +419,8 @@ class BatchProcessor:
             elif hasattr(item[0], "target_name"):
                 text_parts.append(item[0].target_name or "")
 
-            # Second element (context)
-            if isinstance(item[1], dict):
-                text_parts.append(json.dumps(item[1]))
-            elif hasattr(item[1], "requester_name"):
+            # Second element (AIRequestContext)
+            if hasattr(item[1], "requester_name"):
                 text_parts.append(item[1].requester_name)
 
             text = " ".join(text_parts)

--- a/docs/architecture/bunk-request-pipeline.md
+++ b/docs/architecture/bunk-request-pipeline.md
@@ -897,8 +897,6 @@ The Pipeline Debug page (`/summer/debug/pipeline`) provides:
 
 ### P0: Critical
 
-**Phase 3 dict/dataclass mismatch.** `BatchProcessor._process_batch_with_retry()` passes a dict to the disambiguation path where a dataclass with `.request_text` is expected. All Phase 3 AI disambiguation fails with `'dict' object has no attribute 'request_text'`. 14/14 cases crashed in v3.11. Phase 3 was working in v3.9 (March 25) — likely a regression from PR #786.
-
 **PB Go-side timeout shorter than API processing time.** The Go sync caller (`process_requests.go`) uses a 35-minute timeout. The v3.11 full-force run took ~2.3 hours. PocketBase logs `context deadline exceeded` and thinks the run failed, but the FastAPI API continues processing as an orphan and completes successfully. Data is written but the Go caller doesn't know.
 
 ### P1: High
@@ -908,8 +906,6 @@ The Pipeline Debug page (`/summer/debug/pipeline`) provides:
 **Confidence threshold `> 0.9` should be `>= 0.9`.** `confidence_scorer.py:198` uses strictly greater than. ExactMatchStrategy returns 0.90 for no-session-info and parent-surname matches. These get classified as "partial" (name_score=0.7) instead of "exact" (name_score=1.0), producing confidence 0.6975 instead of 0.9075. **39 exact matches stuck pending** in v3.11, plus 8 reciprocal-boosted at 0.7975 (still below 0.85 threshold).
 
 **PocketBase 400 on large IN clause.** Bulk person lookup with ~240 IDs exceeds PocketBase's URL/filter length limit. Need to chunk bulk lookups into smaller batches.
-
-**Parent surname index always empty.** `Built parent surname index with 0 unique surnames` logged in v3.11. The entire parent surname fallback resolution path in ExactMatchStrategy is dead code — `_try_parent_surname_match()` can never match anyone. Likely a cache initialization bug where parent data isn't loaded.
 
 **OBR processed flag doesn't distinguish success vs error.** When AI fails for an OBR (timeout, 500), the OBR is still marked `processed` with a timestamp — indistinguishable from a successful parse. On re-run without `force=true`, these are skipped as "already processed." PR #794 mitigates this by retrying transient failures (so fewer OBRs silently fail), but does not change the processed-flag logic. Need either: a separate `processed_error` state, or don't set `processed` timestamp when AI returns zero results due to transient failure.
 

--- a/tests/unit/sync/bunk_request_processor/integration/test_batch_processor.py
+++ b/tests/unit/sync/bunk_request_processor/integration/test_batch_processor.py
@@ -264,13 +264,14 @@ class TestEstimateTokens:
         assert tokens > 0
 
     def test_estimate_tokens_includes_context(self):
-        """Token estimation includes context dict."""
+        """Token estimation includes context's requester_name."""
         mock_provider = Mock()
         processor = BatchProcessor(ai_provider=mock_provider)
 
         request = Mock()
         request.request_text = "short"
-        context = {"key1": "value1", "key2": "value2"}
+        context = Mock(spec=["requester_name"])
+        context.requester_name = "Some Requester Name"
         item = (request, context)
 
         tokens = processor._estimate_tokens(item)


### PR DESCRIPTION
## Summary

Issue #1392 was filed today from the v3.11 snapshot in `docs/architecture/bunk-request-pipeline.md` but the bug it describes was already fixed two months ago:

| PR | Date | Fix |
|----|------|-----|
| **#803** | 2026-03-27 | Pass `AIRequestContext` objects directly to `disambiguate()` (no dict conversion); replace non-existent `context.request_text` with `parsed_request.target_name` |
| **#823** | ~6 weeks ago | Replace `parse_request(...)` with `disambiguate(parsed_request, context)` in the disambiguation branch |

Regression coverage already exists in `tests/unit/sync/bunk_request_processor/integration/test_batch_processor_disambiguate.py` — both `test_disambiguate_calls_disambiguate_not_parse_request` and `test_disambiguate_does_not_crash_on_real_context` pass against current code.

## Changes

- **Docs:** drop the P0 "Phase 3 dict/dataclass mismatch" entry from the v3.11 Known Issues snapshot so future triagers don't refile this.
- **Docs:** drop the P1 "Parent surname index always empty" entry — fixed today by PR #1407 (MailingTitle salutation parser).
- **Code:** remove the dead `isinstance(item[1], dict)` branch in `BatchProcessor._estimate_tokens`. It defended against the context-converted-to-dict bug that PR #803 fixed; type signatures now enforce `AIRequestContext` and the regression tests cover the boundary.

## Test plan

- [x] `tests/unit/sync/bunk_request_processor/integration/test_batch_processor_disambiguate.py` — 2 passed
- [x] `tests/unit/sync/bunk_request_processor/integration/test_batch_processor_resilience.py` — passed
- [x] `tests/unit/sync/bunk_request_processor/services/test_phase3_disambiguation_service.py` — passed (full 33-test Phase 3 suite)
- [x] `ruff format` + `ruff check` clean
- [x] `mypy` clean on changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token estimation so request context is only counted when a requester identity is present, yielding more accurate batch processing estimates.

* **Documentation**
  * Removed two known-issue entries from the request pipeline architecture doc to reflect updated state.

* **Tests**
  * Updated unit tests to reflect the new context-handling behavior in token estimation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1408)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->