### PR TITLE
feat(api): structured age_direction field replaces target_name overload (#1401)

### DIFF
--- a/bunking/sync/bunk_request_processor/integration/ai_schemas.py
+++ b/bunking/sync/bunk_request_processor/integration/ai_schemas.py
@@ -91,6 +91,11 @@ class AIBunkRequestItem(AIBaseRequestItem):
     historical_year: int | None = None
     """Year of historical bunking reference (e.g., 2024 for 'same bunk last year')."""
 
+    age_direction: Literal["older", "younger"] | None = None
+    """Direction for age_preference requests. None means undirected (staff must review).
+    Schema-level only — the provider enforces that drift (e.g. age_direction set on
+    non-age_preference, or target_name set on age_preference) is salvaged + logged."""
+
 
 class AIParseResponse(_ForbidExtraModel):
     """Response from parse-only AI request.

--- a/bunking/sync/bunk_request_processor/integration/openai_provider.py
+++ b/bunking/sync/bunk_request_processor/integration/openai_provider.py
@@ -138,7 +138,11 @@ class OpenAIProvider(AIProvider):
             if self.debug and isinstance(parsed_response, AIParseResponse):
                 target_names = [r.target_name for r in parsed_response.requests]
                 request_types = [r.request_type for r in parsed_response.requests]
-                logger.debug(f"[AI-PARSE] Output: targets={target_names} request_types={request_types}")
+                age_directions = [r.age_direction for r in parsed_response.requests]
+                logger.debug(
+                    f"[AI-PARSE] Output: targets={target_names} request_types={request_types} "
+                    f"age_directions={age_directions}"
+                )
                 if reasoning_summary:
                     logger.debug(f"[AI-PARSE] Reasoning: {reasoning_summary}")
 
@@ -428,16 +432,25 @@ class OpenAIProvider(AIProvider):
                 supersedes_reason=supersedes_reason,
             )
 
-            # Handle age preference
-            if request_type == RequestType.AGE_PREFERENCE and parsed_request.target_name:
-                age_pref_map = {
+            # Handle age preference via structured age_direction field (#1401).
+            if request_type == RequestType.AGE_PREFERENCE:
+                if ai_req.target_name:
+                    # Drift: AI emitted old-shape target_name on age_preference. Salvage as
+                    # undirected — never silently re-map back to AgePreference, that masks
+                    # the bug class age_direction was introduced to eliminate.
+                    logger.error(
+                        "AI drift: target_name=%r on age_preference request — clearing and "
+                        "treating as undirected. AI must use age_direction field instead.",
+                        ai_req.target_name,
+                    )
+                    parsed_request.target_name = None
+                direction_map = {
                     "older": AgePreference.OLDER,
                     "younger": AgePreference.YOUNGER,
                 }
-                parsed_request.age_preference = age_pref_map.get(
-                    parsed_request.target_name.lower()
-                )  # "unclear" maps to None for manual review
-                parsed_request.target_name = None
+                parsed_request.age_preference = (
+                    direction_map.get(ai_req.age_direction) if ai_req.age_direction else None
+                )
 
             v2_requests.append(parsed_request)
 

--- a/bunking/sync/bunk_request_processor/integration/openai_provider.py
+++ b/bunking/sync/bunk_request_processor/integration/openai_provider.py
@@ -437,20 +437,24 @@ class OpenAIProvider(AIProvider):
                 if ai_req.target_name:
                     # Drift: AI emitted old-shape target_name on age_preference. Salvage as
                     # undirected — never silently re-map back to AgePreference, that masks
-                    # the bug class age_direction was introduced to eliminate.
+                    # the bug class age_direction was introduced to eliminate. Don't log
+                    # the raw value (could be a camper name if the AI is confused).
                     logger.error(
-                        "AI drift: target_name=%r on age_preference request — clearing and "
-                        "treating as undirected. AI must use age_direction field instead.",
-                        ai_req.target_name,
+                        "AI drift: target_name set on age_preference request "
+                        "(has_age_direction=%s) — clearing both and treating as undirected. "
+                        "AI must use age_direction field instead.",
+                        ai_req.age_direction is not None,
                     )
                     parsed_request.target_name = None
-                direction_map = {
-                    "older": AgePreference.OLDER,
-                    "younger": AgePreference.YOUNGER,
-                }
-                parsed_request.age_preference = (
-                    direction_map.get(ai_req.age_direction) if ai_req.age_direction else None
-                )
+                    parsed_request.age_preference = None
+                else:
+                    direction_map = {
+                        "older": AgePreference.OLDER,
+                        "younger": AgePreference.YOUNGER,
+                    }
+                    parsed_request.age_preference = (
+                        direction_map.get(ai_req.age_direction) if ai_req.age_direction else None
+                    )
 
             v2_requests.append(parsed_request)
 

--- a/bunking/sync/bunk_request_processor/services/request_builder.py
+++ b/bunking/sync/bunk_request_processor/services/request_builder.py
@@ -247,9 +247,11 @@ class RequestBuilder:
         # No person ID cases
         if person_cm_id is None:
             if parsed_req.request_type == RequestType.AGE_PREFERENCE:
+                # Mirror disposition_rules._age_preference_rules — staff need
+                # `undirected_preference` reason to surface these for review (#1406).
                 if parsed_req.age_preference is not None:
                     return RequestStatus.RESOLVED, "directional_preference"
-                return RequestStatus.PENDING, ""
+                return RequestStatus.PENDING, "undirected_preference"
             return RequestStatus.PENDING, ""
 
         # Negative ID means unresolved name

--- a/config/prompts/parse_bunk_with.txt
+++ b/config/prompts/parse_bunk_with.txt
@@ -33,7 +33,9 @@ This field commonly contains:
    target_name = person's name
 
 3. "age_preference" - Preference for older/younger cabinmates (no specific person named)
-   target_name = "older", "younger", or "unclear"
+   Leave target_name null.
+   Set age_direction to "older" or "younger" for a clear direction.
+   Leave age_direction null if the preference is undirected (e.g. "age-appropriate cabin").
    Use when text says "prefers older kids" without naming anyone specific
 
 IMPORTANT: Parents often embed negative requests in this field. Extract BOTH positive and negative.
@@ -111,9 +113,13 @@ Example 5 - Twin context for a named separation:
 Input: "Would prefer to be separate from Ava if possible. Not because they aren't thick as thieves, but precisely b/c they are! As twins, they have to do everything together"
 Output: 1 not_bunk_with request for "Ava" (specific named individual). The twin commentary is rationale, in parse_notes.
 
-Example 6 - Age preference with name:
+Example 6 - Directional age preference:
 Input: "Better with younger kids who are a little gentler. Ethan is citizenship oriented"
-Output: 1 age_preference "younger" request (no person named, just preference)
+Output: 1 age_preference request with age_direction="younger" (target_name null; no person named, just preference)
+
+Example 7 - Undirected age preference:
+Input: "Age-wise, prefers an age-appropriate cabin — no strong preference"
+Output: 1 age_preference request with age_direction=null (target_name null) — undirected; staff will review.
 
 === TEMPORAL CONFLICTS (CRITICAL!) ===
 
@@ -148,7 +154,8 @@ IGNORE Family Camp content entirely:
 
 For each valid request, provide:
 - request_type: "bunk_with" | "not_bunk_with" | "age_preference"
-- target_name: Person's name or age value ("older", "younger", "unclear")
+- target_name: Person's name for bunk_with/not_bunk_with; null for age_preference requests.
+- age_direction: age_preference requests only — "older", "younger", or null (undirected).
 - confidence: 0.0-1.0 (use LOW confidence for uncertain extractions)
 - keywords_found: Priority words like "must", "important", "critical", "first choice"
 

--- a/config/prompts/parse_bunking_notes.txt
+++ b/config/prompts/parse_bunking_notes.txt
@@ -30,6 +30,9 @@ This field may contain ANY request type:
    Keywords: "not with", "separate from", "avoid", "neg request", "don't bunk with"
 
 3. "age_preference" - Age/grade recommendations
+   Leave target_name null.
+   Set age_direction to "older" or "younger" for a clear direction.
+   Leave age_direction null when the preference is undirected.
    Keywords: "bunk older", "same age/younger", "would do better with younger kids"
 
 === NARRATIVE EXTRACTION RULES ===
@@ -67,7 +70,7 @@ parse_notes as today.
 
 Example 1 - Age preference from old note:
 Input: "2019 - Bunk with younger kids (emotionally immature)"
-Output: 1 age_preference "younger", parse_notes: "Staff note from 2019 - emotional maturity concern"
+Output: 1 age_preference request with age_direction="younger", parse_notes: "Staff note from 2019 - emotional maturity concern"
 
 Example 2 - Negative with context:
 Input: "Neg request: Sofia Petrov. They are still friends. Maya has a harder time making new friends when with Sofia"
@@ -75,7 +78,7 @@ Output: 1 not_bunk_with "Sofia Petrov", parse_notes: "friendship dynamics - hard
 
 Example 3 - Staff recommendation for separation:
 Input: "Counselors recommend he NOT be bunked with Lucas Wright or Ben Goldstein and would greatly benefit from being bunked with a younger and different group"
-Output: 3 requests - 2 not_bunk_with (Lucas Wright, Ben Goldstein), 1 age_preference "younger"
+Output: 3 requests - 2 not_bunk_with (Lucas Wright, Ben Goldstein), 1 age_preference (age_direction="younger")
 
 Example 4 - Multi-year progression:
 Input: "'25 bunking - continue to bunk separately from Ava Collins. See '24 notes."
@@ -98,6 +101,10 @@ Output: 2 requests:
 Example 8 - Unit placement (not bunk request):
 Input: "Same unit as twin Lily Thompson if possible"
 Output: 0 requests (unit placement, not cabin assignment - note in parse_notes if helpful)
+
+Example 9 - Undirected age preference:
+Input: "Age-wise, no strong direction — just somewhere age-appropriate"
+Output: 1 age_preference request with age_direction=null — undirected; staff will review.
 
 === TEMPORAL CONFLICTS (CRITICAL!) ===
 
@@ -126,7 +133,8 @@ DO NOT extract:
 
 For each valid request, provide:
 - request_type: "bunk_with" | "not_bunk_with" | "age_preference"
-- target_name: Person's name or age value
+- target_name: Person's name for bunk_with/not_bunk_with; null for age_preference requests.
+- age_direction: age_preference requests only — "older", "younger", or null (undirected).
 - confidence: 0.0-1.0 (lower for old notes, inferred requests)
 - keywords_found: Priority words like "must", "recommend", "counselors noted"
 

--- a/config/prompts/parse_internal_notes.txt
+++ b/config/prompts/parse_internal_notes.txt
@@ -27,6 +27,9 @@ This field may contain:
    Keywords: "not with", "separate from", "away from"
 
 3. "age_preference" - Age/grade preference
+   Leave target_name null.
+   Set age_direction to "older" or "younger" for a clear direction.
+   Leave age_direction null when the preference is undirected.
    Keywords: "bunk older", "same age/younger", "bunk with 5th/6th"
 
 === PARENT-CONTEXT SURNAME EXTRACTION ===
@@ -48,15 +51,15 @@ parse_notes as today.
 
 Example 1 - Age shorthand:
 Input: "same age/younger"
-Output: 1 age_preference "younger"
+Output: 1 age_preference request with age_direction="younger"
 
 Example 2 - Simple age directive:
 Input: "Bunk older"
-Output: 1 age_preference "older"
+Output: 1 age_preference request with age_direction="older"
 
 Example 3 - Grade range:
 Input: "Bunk with 5th/6th"
-Output: 1 age_preference "younger" (relative to camper's grade context)
+Output: 1 age_preference request with age_direction="younger" (relative to camper's grade context)
 
 Example 4 - CO reference with friend:
 Input: "CO noted friends with Riley Brooks"
@@ -88,7 +91,11 @@ Output: 1 bunk_with "Noah Garcia", parse_notes: "prior bunkmate 2024"
 
 Example 11 - Multiple notes concatenated:
 Input: "Bunk older. CO noted friends with Emma."
-Output: 2 requests - age_preference "older", bunk_with "Emma"
+Output: 2 requests - age_preference (age_direction="older"), bunk_with "Emma"
+
+Example 12 - Undirected age preference:
+Input: "Age-wise, no direction noted"
+Output: 1 age_preference request with age_direction=null — undirected; staff review.
 
 === INVALID EXTRACTIONS ===
 
@@ -111,7 +118,8 @@ Staff shorthand can be ambiguous. Use confidence scoring:
 
 For each valid request, provide:
 - request_type: "bunk_with" | "not_bunk_with" | "age_preference"
-- target_name: Person's name or age value
+- target_name: Person's name for bunk_with/not_bunk_with; null for age_preference requests.
+- age_direction: age_preference requests only — "older", "younger", or null (undirected).
 - confidence: 0.0-1.0 (lower for abbreviated/unclear content)
 - keywords_found: Priority words like "must", "first choice"
 

--- a/config/prompts/parse_request.txt
+++ b/config/prompts/parse_request.txt
@@ -20,7 +20,9 @@ TASK: Extract structured bunk requests from this text.
    target_name = person's name
 
 3. "age_preference" - Preference for older/younger cabinmates (no specific person named)
-   target_name = "older", "younger", or "unclear"
+   Leave target_name null.
+   Set age_direction to "older" or "younger" for a clear direction.
+   Leave age_direction null if the preference is undirected (e.g. "age-appropriate cabin").
    Use this when text says "prefers older kids" or "wants younger bunkmates" without naming anyone
 
 === TEMPORAL CONFLICTS (CRITICAL!) ===
@@ -91,7 +93,8 @@ Examples:
 
 For each valid request, provide:
 - request_type: "bunk_with" | "not_bunk_with" | "age_preference"
-- target_name: Person's name or age value ("older", "younger", "unclear")
+- target_name: Person's name for bunk_with/not_bunk_with; null for age_preference requests.
+- age_direction: age_preference requests only — "older", "younger", or null (undirected).
 - confidence: 0.0-1.0 (use LOW confidence for uncertain extractions)
 - temporal_info: null OR {{date_mentioned, is_superseded, supersedes_reason}}
 - keywords_found: Priority words like "must", "important", "critical", "first choice"

--- a/tests/unit/sync/bunk_request_processor/integration/test_ai_schemas.py
+++ b/tests/unit/sync/bunk_request_processor/integration/test_ai_schemas.py
@@ -144,3 +144,38 @@ class TestExtraForbidOnAllAISchemas:
     def test_full_parse_response_rejects_unknown_field(self) -> None:
         with pytest.raises(ValidationError):
             AIFullParseResponse(**{"unknown_field": "x"})
+
+
+class TestAIBunkRequestItemAgeDirection:
+    """#1401: age_direction is a first-class structured field on AI bunk requests.
+
+    Direction was previously overloaded onto target_name (e.g. target_name="older").
+    A dedicated Literal-constrained field eliminates that overload. The schema does
+    NOT police cross-field semantics — provider enforcement handles drift salvage.
+    """
+
+    def test_age_direction_defaults_to_none(self) -> None:
+        item = AIBunkRequestItem(request_type="age_preference")
+        assert item.age_direction is None
+
+    def test_age_direction_accepts_older(self) -> None:
+        item = AIBunkRequestItem(request_type="age_preference", age_direction="older")
+        assert item.age_direction == "older"
+
+    def test_age_direction_accepts_younger(self) -> None:
+        item = AIBunkRequestItem(request_type="age_preference", age_direction="younger")
+        assert item.age_direction == "younger"
+
+    def test_age_direction_rejects_invalid_value(self) -> None:
+        with pytest.raises(ValidationError):
+            AIBunkRequestItem(request_type="age_preference", age_direction="middle")
+
+    def test_age_direction_accepted_on_bunk_with_but_meaningless(self) -> None:
+        """Schema allows age_direction on any request type; semantic enforcement is in provider."""
+        item = AIBunkRequestItem(
+            request_type="bunk_with",
+            target_name="Emma",
+            age_direction="older",
+        )
+        assert item.request_type == "bunk_with"
+        assert item.age_direction == "older"

--- a/tests/unit/sync/bunk_request_processor/integration/test_prompts_age_direction.py
+++ b/tests/unit/sync/bunk_request_processor/integration/test_prompts_age_direction.py
@@ -1,0 +1,59 @@
+"""#1401 regression guard: prompt files use the structured age_direction field.
+
+Each of the 4 prompts that can emit age_preference requests must:
+  (a) mention the `age_direction` field, AND
+  (b) NOT contain old-shape phrases (target_name = "older"/"younger"/"unclear" or
+      age_preference "older"/"younger") that would re-introduce the
+      target_name-overload bug class.
+
+`parse_not_bunk_with.txt` is excluded — it forbids age_preference output entirely.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+PROMPTS_DIR = REPO_ROOT / "config" / "prompts"
+
+AGE_PREF_PROMPTS = [
+    "parse_bunk_with.txt",
+    "parse_request.txt",
+    "parse_bunking_notes.txt",
+    "parse_internal_notes.txt",
+]
+
+OLD_SHAPE_PATTERNS = [
+    re.compile(r'target_name\s*=\s*"older"'),
+    re.compile(r'target_name\s*=\s*"younger"'),
+    re.compile(r'target_name\s*=\s*"unclear"'),
+    re.compile(r'age_preference\s+"older"'),
+    re.compile(r'age_preference\s+"younger"'),
+]
+
+
+@pytest.mark.parametrize("prompt_name", AGE_PREF_PROMPTS)
+def test_prompt_mentions_age_direction(prompt_name: str) -> None:
+    """Each age_preference-emitting prompt must instruct the AI on the age_direction field."""
+    path = PROMPTS_DIR / prompt_name
+    text = path.read_text()
+    assert "age_direction" in text, (
+        f"{prompt_name} must mention the age_direction field — otherwise the AI will "
+        f"fall back to overloading target_name with direction values."
+    )
+
+
+@pytest.mark.parametrize("prompt_name", AGE_PREF_PROMPTS)
+def test_prompt_does_not_contain_old_shape(prompt_name: str) -> None:
+    """No prompt may carry the legacy target_name='older'/'younger'/'unclear' overload."""
+    path = PROMPTS_DIR / prompt_name
+    text = path.read_text()
+    for pattern in OLD_SHAPE_PATTERNS:
+        match = pattern.search(text)
+        assert match is None, (
+            f"{prompt_name} contains deprecated old-shape phrase {match.group()!r} — "
+            f"this was the bug class age_direction was introduced to eliminate (#1401)."
+        )

--- a/tests/unit/sync/bunk_request_processor/integration/test_prompts_age_direction.py
+++ b/tests/unit/sync/bunk_request_processor/integration/test_prompts_age_direction.py
@@ -27,11 +27,11 @@ AGE_PREF_PROMPTS = [
 ]
 
 OLD_SHAPE_PATTERNS = [
-    re.compile(r'target_name\s*=\s*"older"'),
-    re.compile(r'target_name\s*=\s*"younger"'),
-    re.compile(r'target_name\s*=\s*"unclear"'),
-    re.compile(r'age_preference\s+"older"'),
-    re.compile(r'age_preference\s+"younger"'),
+    re.compile(r"target_name\s*[:=]?\s*['\"]older['\"]", re.IGNORECASE),
+    re.compile(r"target_name\s*[:=]?\s*['\"]younger['\"]", re.IGNORECASE),
+    re.compile(r"target_name\s*[:=]?\s*['\"]unclear['\"]", re.IGNORECASE),
+    re.compile(r"age_preference\s*[:=]?\s*['\"]older['\"]", re.IGNORECASE),
+    re.compile(r"age_preference\s*[:=]?\s*['\"]younger['\"]", re.IGNORECASE),
 ]
 
 

--- a/tests/unit/sync/bunk_request_processor/integration/test_sdk_ai_provider.py
+++ b/tests/unit/sync/bunk_request_processor/integration/test_sdk_ai_provider.py
@@ -894,3 +894,99 @@ class TestOpenAIProviderDisambiguateMetadata:
         assert meta.get("no_match") is True, "no_match must be written to metadata"
         assert meta.get("no_match_reason") == "No candidate shares name with target"
         assert meta.get("ranked_selections") is None
+
+
+class TestOpenAIProviderAgeDirectionConversion:
+    """#1401: provider reads ai_req.age_direction directly (no target_name overload).
+
+    Drift case — target_name set on an age_preference — is logged as ERROR and
+    salvaged as an undirected preference (age_preference=None, target_name=None),
+    NOT silently re-mapped back to AgePreference like the old age_pref_map block did.
+    """
+
+    @pytest.fixture
+    def context(self):
+        return AIRequestContext(
+            requester_name="Test User",
+            requester_cm_id=12345,
+            session_cm_id=1000002,
+            year=2025,
+            additional_context={
+                "parse_only": True,
+                "field_type": "share_bunk_with",
+                "csv_source_field": "share_bunk_with",
+            },
+        )
+
+    def _build_response(self, **kwargs):
+        return AIParseResponse(requests=[AIBunkRequestItem(request_type="age_preference", **kwargs)])
+
+    def test_direction_older_produces_age_preference_older(self, context):
+        from bunking.sync.bunk_request_processor.core.models import AgePreference
+        from bunking.sync.bunk_request_processor.integration.openai_provider import OpenAIProvider
+
+        with patch("openai.AsyncOpenAI"):
+            provider = OpenAIProvider(api_key="test-key", model="gpt-5-nano")
+
+        ai_response = self._build_response(age_direction="older")
+        result = provider._convert_parse_response(ai_response, "wants older cabinmates", context)
+
+        assert len(result.requests) == 1
+        parsed = result.requests[0]
+        assert parsed.request_type == RequestType.AGE_PREFERENCE
+        assert parsed.age_preference == AgePreference.OLDER
+        assert parsed.target_name is None
+
+    def test_direction_younger_produces_age_preference_younger(self, context):
+        from bunking.sync.bunk_request_processor.core.models import AgePreference
+        from bunking.sync.bunk_request_processor.integration.openai_provider import OpenAIProvider
+
+        with patch("openai.AsyncOpenAI"):
+            provider = OpenAIProvider(api_key="test-key", model="gpt-5-nano")
+
+        ai_response = self._build_response(age_direction="younger")
+        result = provider._convert_parse_response(ai_response, "wants younger cabinmates", context)
+
+        parsed = result.requests[0]
+        assert parsed.age_preference == AgePreference.YOUNGER
+        assert parsed.target_name is None
+
+    def test_direction_none_produces_age_preference_none(self, context):
+        """Undirected age preference — staff must review downstream via _age_preference_rules."""
+        from bunking.sync.bunk_request_processor.integration.openai_provider import OpenAIProvider
+
+        with patch("openai.AsyncOpenAI"):
+            provider = OpenAIProvider(api_key="test-key", model="gpt-5-nano")
+
+        ai_response = self._build_response(age_direction=None)
+        result = provider._convert_parse_response(ai_response, "wants age-appropriate cabin", context)
+
+        parsed = result.requests[0]
+        assert parsed.request_type == RequestType.AGE_PREFERENCE
+        assert parsed.age_preference is None
+        assert parsed.target_name is None
+
+    def test_drift_target_name_on_age_pref_logs_error_and_salvages(self, context, caplog):
+        """Old-shape drift: AI emits target_name="older" on age_preference.
+
+        Provider must log ERROR and salvage as undirected (NOT re-map back to AgePreference.OLDER
+        as the old age_pref_map block did). This is the regression-prevention guard.
+        """
+        import logging
+
+        from bunking.sync.bunk_request_processor.integration.openai_provider import OpenAIProvider
+
+        with patch("openai.AsyncOpenAI"):
+            provider = OpenAIProvider(api_key="test-key", model="gpt-5-nano")
+
+        ai_response = self._build_response(target_name="older", age_direction=None)
+
+        with caplog.at_level(logging.ERROR):
+            result = provider._convert_parse_response(ai_response, "older please", context)
+
+        parsed = result.requests[0]
+        assert parsed.age_preference is None, "drift target_name must NOT be silently re-mapped to AgePreference"
+        assert parsed.target_name is None, "drift target_name must be cleared during salvage"
+        assert any("age_direction" in r.message or "drift" in r.message.lower() for r in caplog.records), (
+            "drift must be logged at ERROR level"
+        )

--- a/tests/unit/sync/bunk_request_processor/integration/test_sdk_ai_provider.py
+++ b/tests/unit/sync/bunk_request_processor/integration/test_sdk_ai_provider.py
@@ -56,19 +56,6 @@ class TestAISchemas:
         )
         assert response.requests[0].request_type == "not_bunk_with"
 
-    def test_parse_response_valid_age_preference(self):
-        """Valid age_preference request parses correctly."""
-        response = AIParseResponse(
-            requests=[
-                AIBunkRequestItem(
-                    request_type="age_preference",
-                    target_name="older",
-                    source_type="parent",
-                )
-            ]
-        )
-        assert response.requests[0].request_type == "age_preference"
-
     def test_parse_response_invalid_request_type_rejected(self):
         """Invalid request_type is rejected by Pydantic."""
         from pydantic import ValidationError
@@ -979,14 +966,42 @@ class TestOpenAIProviderAgeDirectionConversion:
         with patch("openai.AsyncOpenAI"):
             provider = OpenAIProvider(api_key="test-key", model="gpt-5-nano")
 
-        ai_response = self._build_response(target_name="older", age_direction=None)
+        # Use a value that resembles a camper name so we can verify it's NOT logged.
+        ai_response = self._build_response(target_name="Emma Garcia", age_direction=None)
 
         with caplog.at_level(logging.ERROR):
-            result = provider._convert_parse_response(ai_response, "older please", context)
+            result = provider._convert_parse_response(ai_response, "drift case", context)
 
         parsed = result.requests[0]
         assert parsed.age_preference is None, "drift target_name must NOT be silently re-mapped to AgePreference"
         assert parsed.target_name is None, "drift target_name must be cleared during salvage"
-        assert any("age_direction" in r.message or "drift" in r.message.lower() for r in caplog.records), (
-            "drift must be logged at ERROR level"
+        assert any("drift" in r.message.lower() for r in caplog.records), "drift must be logged at ERROR level"
+        for record in caplog.records:
+            assert "Emma Garcia" not in record.getMessage(), (
+                "drift log must NOT include raw target_name value — could be PII (camper name)"
+            )
+
+    def test_drift_compound_target_name_and_age_direction_treats_as_undirected(self, context, caplog):
+        """Compound drift: AI emits BOTH target_name AND age_direction on age_preference.
+
+        Spec says drift → undirected. The log message claims that, so the code must too —
+        applying age_direction while clearing target_name would be a silent contradiction.
+        """
+        import logging
+
+        from bunking.sync.bunk_request_processor.integration.openai_provider import OpenAIProvider
+
+        with patch("openai.AsyncOpenAI"):
+            provider = OpenAIProvider(api_key="test-key", model="gpt-5-nano")
+
+        ai_response = self._build_response(target_name="older", age_direction="younger")
+
+        with caplog.at_level(logging.ERROR):
+            result = provider._convert_parse_response(ai_response, "compound drift", context)
+
+        parsed = result.requests[0]
+        assert parsed.age_preference is None, (
+            "compound drift must clear age_direction too — the log claims undirected, the code must match"
         )
+        assert parsed.target_name is None
+        assert any("drift" in r.message.lower() for r in caplog.records)

--- a/tests/unit/sync/bunk_request_processor/orchestrator/test_age_preference_undirected.py
+++ b/tests/unit/sync/bunk_request_processor/orchestrator/test_age_preference_undirected.py
@@ -1,35 +1,56 @@
-"""Regression guard: the unsafe prose-sniffing fallback that auto-classified
-undirected age_preference requests must not be reintroduced.
+"""Regression guard + e2e: undirected age_preference requests must PEND for
+staff review and never have direction inferred from free-text prose.
 
-The deleted ``RequestOrchestrator._map_age_preference_direction`` substring-
-matched the AI's free-text rationale (parse_notes + ai_reasoning) for direction
-keywords ("older", "younger", "above", "below", "grade up", etc.) and overrode
-``openai_provider``'s structured ``target_name`` -> ``AgePreference`` mapping.
-It over-fired on prose where the AI used direction words to *describe* the
-absence of a direction. Examples from production:
-
-- "No explicit direction (older vs younger)."          -> wrongly OLDER
-- "kids a year older or a year younger"                -> wrongly OLDER (if/elif bias)
-- "parent unsure; 'a year below' as one option"        -> wrongly YOUNGER
-
-Direction now comes solely from the structured AI signal in
-``openai_provider.py:432-440`` (``target_name.lower()`` ->
-``AgePreference.OLDER`` / ``AgePreference.YOUNGER`` / ``None``). When ``None``,
-``disposition_rules._age_preference_rules`` PENDs the request with reason
-``undirected_preference`` for staff review. This is the intended design; the
-fallback was a hack that bypassed it.
+History:
+- The deleted ``RequestOrchestrator._map_age_preference_direction`` substring-
+  matched the AI's free-text rationale (parse_notes + ai_reasoning) for
+  direction keywords ("older", "younger", "above", "below", "grade up", etc.)
+  and over-fired on prose where the AI used direction words to *describe* the
+  absence of a direction (e.g. "No explicit direction (older vs younger)").
+- PR #1402 deleted the fallback and left undirected parses as PENDING.
+- PR #1401 makes direction a structured field on the AI schema:
+  ``AIBunkRequestItem.age_direction: Literal["older","younger"]|None``.
+  ``openai_provider`` reads it directly into ``ParsedRequest.age_preference``;
+  the request_builder forwards that to ``determine_disposition`` which routes
+  ``age_direction=None`` to ``Disposition(PENDING, "undirected_preference")``
+  via ``disposition_rules._age_preference_rules``.
 
 If you find yourself wanting to infer direction from any free-text source after
-the AI parse, **stop** — the AI's structured target_name is the only trusted
-signal. If structured signal isn't enough, change the AI schema (see issue
-#1401) rather than re-introducing prose sniffing.
+the AI parse, **stop** — the AI's structured ``age_direction`` is the only
+trusted signal. If structured signal isn't enough, change the AI schema rather
+than re-introducing prose sniffing.
 """
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from bunking.sync.bunk_request_processor.core.models import (
+    ParsedRequest,
+    RequestStatus,
+    RequestType,
+)
 from bunking.sync.bunk_request_processor.orchestrator.orchestrator import (
     RequestOrchestrator,
 )
+
+
+def _create_mock_pocketbase():
+    pb = Mock()
+
+    def mock_collection(_name):
+        collection = Mock()
+        collection.get_full_list = Mock(return_value=[])
+        collection.get_list = Mock(return_value=Mock(items=[], total_items=0))
+        collection.create = Mock(return_value=Mock(id="test-id"))
+        collection.update = Mock()
+        collection.delete = Mock()
+        return collection
+
+    pb.collection = mock_collection
+    return pb
 
 
 class TestKeywordFallbackNotReintroduced:
@@ -39,9 +60,69 @@ class TestKeywordFallbackNotReintroduced:
         not from substring-matching the AI's free-text rationale."""
         assert not hasattr(RequestOrchestrator, "_map_age_preference_direction"), (
             "Do not reintroduce _map_age_preference_direction. Direction must "
-            "come from openai_provider's structured target_name -> "
-            "AgePreference mapping; undirected parses must stay None and route "
-            "to PENDING/undirected_preference via "
+            "come from openai_provider's structured age_direction field; "
+            "undirected parses must stay None and route to "
+            "PENDING/undirected_preference via "
             "disposition_rules._age_preference_rules. See PR #1402 for the "
             "bug class this guards against."
         )
+
+
+class TestUndirectedAgePreferenceE2E:
+    """e2e through orchestrator._create_bunk_requests for an undirected age_preference.
+
+    Closes #1406 — locks down that an undirected request (age_preference=None
+    after provider conversion) produces a saved BunkRequest with:
+      status == RequestStatus.PENDING
+      disposition_reason == "undirected_preference"
+      target_name is None
+      age_preference is None
+    """
+
+    @pytest.mark.asyncio
+    @patch("bunking.sync.bunk_request_processor.orchestrator.orchestrator.ProviderFactory")
+    @patch("bunking.sync.bunk_request_processor.orchestrator.orchestrator.SocialGraph")
+    async def test_undirected_age_preference_pends_with_correct_disposition_reason(
+        self, mock_social_graph, mock_factory
+    ):
+        mock_factory.return_value.create_provider.return_value = Mock()
+        mock_social_graph_instance = Mock()
+        mock_social_graph_instance.initialize = AsyncMock()
+        mock_social_graph.return_value = mock_social_graph_instance
+
+        pb = _create_mock_pocketbase()
+        orchestrator = RequestOrchestrator(pb=pb, year=2025)
+
+        parsed_req = ParsedRequest(
+            raw_text="Age-wise, no strong direction",
+            request_type=RequestType.AGE_PREFERENCE,
+            target_name=None,
+            age_preference=None,
+            source_field="bunk_with",
+            confidence=0.85,
+            csv_position=1,
+            metadata={},
+        )
+
+        resolution_info = {
+            "requester_cm_id": 11111,
+            "requester_name": "Test Requester",
+            "session_cm_id": 1000002,
+            "person_cm_id": None,
+            "person_name": None,
+            "confidence": 0.0,
+            "resolution_method": "age_preference",
+        }
+
+        created_requests, _ = await orchestrator._create_bunk_requests([(parsed_req, resolution_info)])
+
+        assert len(created_requests) == 1, "expected one BunkRequest"
+        req = created_requests[0]
+        assert req.status == RequestStatus.PENDING, (
+            f"undirected age_preference must PEND for staff review, got {req.status}"
+        )
+        assert req.disposition_reason == "undirected_preference", (
+            f"disposition_reason must be 'undirected_preference', got {req.disposition_reason!r}"
+        )
+        assert req.requested_name is None, "requested_name must be cleared for age_preference"
+        assert req.requested_cm_id is None, "undirected age_preference has no target person"

--- a/tests/unit/sync/bunk_request_processor/services/test_phase1_parse_service.py
+++ b/tests/unit/sync/bunk_request_processor/services/test_phase1_parse_service.py
@@ -468,3 +468,115 @@ class TestPhase1FailureTracking:
         service.reset_stats()
 
         assert service.get_stats()["first_failure_reason"] is None
+
+
+class TestAgeDirectionPhase1Conversion:
+    """#1401 regression guard at the Phase 1 conversion boundary.
+
+    Exercises OpenAIProvider._convert_parse_response with prose-realistic AI responses
+    to lock down the contract: AI's age_direction maps directly to ParsedRequest.age_preference,
+    target_name on age_preference is salvaged (not silently re-mapped), and undirected
+    requests pass through as age_preference=None for downstream PENDING handling.
+
+    Sibling of TestOpenAIProviderAgeDirectionConversion in test_sdk_ai_provider.py —
+    placed at this layer so accidental refactors that route around the provider's
+    handling still get caught.
+    """
+
+    def _convert_single(self, ai_response):
+        """Helper: run a single-request AIParseResponse through OpenAIProvider._convert_parse_response."""
+        from unittest.mock import patch
+
+        from bunking.sync.bunk_request_processor.integration.ai_service import (
+            AIRequestContext,
+        )
+        from bunking.sync.bunk_request_processor.integration.openai_provider import (
+            OpenAIProvider,
+        )
+
+        with patch("openai.AsyncOpenAI"):
+            provider = OpenAIProvider(api_key="test-key", model="gpt-5-nano")
+
+        context = AIRequestContext(
+            requester_name="Test User",
+            requester_cm_id=12345,
+            session_cm_id=1000002,
+            year=2025,
+            additional_context={
+                "parse_only": True,
+                "field_type": "share_bunk_with",
+                "csv_source_field": "share_bunk_with",
+            },
+        )
+        result = provider._convert_parse_response(ai_response, "input text", context)
+        assert len(result.requests) == 1, "helper assumes single-request response"
+        return result.requests[0]
+
+    def test_older_prose_maps_to_age_preference_older(self):
+        from bunking.sync.bunk_request_processor.core.models import AgePreference
+        from bunking.sync.bunk_request_processor.integration.ai_schemas import (
+            AIBunkRequestItem,
+            AIParseResponse,
+        )
+
+        ai_response = AIParseResponse(
+            requests=[AIBunkRequestItem(request_type="age_preference", age_direction="older")]
+        )
+        parsed = self._convert_single(ai_response)
+        assert parsed.request_type == RequestType.AGE_PREFERENCE
+        assert parsed.age_preference == AgePreference.OLDER
+        assert parsed.target_name is None
+
+    def test_younger_prose_maps_to_age_preference_younger(self):
+        from bunking.sync.bunk_request_processor.core.models import AgePreference
+        from bunking.sync.bunk_request_processor.integration.ai_schemas import (
+            AIBunkRequestItem,
+            AIParseResponse,
+        )
+
+        ai_response = AIParseResponse(
+            requests=[AIBunkRequestItem(request_type="age_preference", age_direction="younger")]
+        )
+        parsed = self._convert_single(ai_response)
+        assert parsed.request_type == RequestType.AGE_PREFERENCE
+        assert parsed.age_preference == AgePreference.YOUNGER
+        assert parsed.target_name is None
+
+    def test_undirected_prose_maps_to_age_preference_none(self):
+        from bunking.sync.bunk_request_processor.integration.ai_schemas import (
+            AIBunkRequestItem,
+            AIParseResponse,
+        )
+
+        ai_response = AIParseResponse(requests=[AIBunkRequestItem(request_type="age_preference", age_direction=None)])
+        parsed = self._convert_single(ai_response)
+        assert parsed.request_type == RequestType.AGE_PREFERENCE
+        assert parsed.age_preference is None
+        assert parsed.target_name is None
+
+    def test_drift_target_name_on_age_pref_does_not_silently_remap(self):
+        """Critical regression: AI emits old-shape target_name='older' on age_preference.
+
+        Must NOT be silently re-mapped to AgePreference.OLDER (the old age_pref_map
+        behavior). Salvaged as undirected so staff catch the AI drift downstream.
+        """
+        from bunking.sync.bunk_request_processor.integration.ai_schemas import (
+            AIBunkRequestItem,
+            AIParseResponse,
+        )
+
+        ai_response = AIParseResponse(
+            requests=[
+                AIBunkRequestItem(
+                    request_type="age_preference",
+                    target_name="older",
+                    age_direction=None,
+                )
+            ]
+        )
+        parsed = self._convert_single(ai_response)
+        assert parsed.age_preference is None, (
+            "drift target_name must not be re-mapped to AgePreference — this was the "
+            "bug class age_direction was introduced to eliminate"
+        )
+        assert parsed.target_name is None


### PR DESCRIPTION
## Summary

- Adds first-class `age_direction: Literal["older","younger"] | None` field to the AI bunk-request schema, replacing the prior overload of `target_name` with direction values
- Provider reads `age_direction` directly and logs/salvages drift (old-shape `target_name="older"` on age_preference is no longer silently re-mapped to `AgePreference.OLDER`)
- All 4 age_preference-emitting prompts (`parse_bunk_with`, `parse_request`, `parse_bunking_notes`, `parse_internal_notes`) rewritten to set `age_direction` + new undirected examples; static regression guard catches reverts
- Fixes #1406: undirected age_preference now reports `disposition_reason="undirected_preference"` (previously empty string, hiding requests from the staff-review queue)

## Closes
- #1401 (structured age_direction field)
- #1406 (orchestrator e2e fold-in)
- #1405 (obsoleted by structured field)

## Test Plan
- [x] `pytest tests/unit/sync/bunk_request_processor/` — 1847 passed
- [x] `pytest tests/unit/sync/` — 1972 passed
- [x] `pytest tests/unit/` — 4435 passed
- [x] `ruff check` / `ruff format --check` / `mypy` on touched files — clean
- [x] Schema rejects invalid `age_direction` values
- [x] Drift case (target_name set on age_preference) logged at ERROR and salvaged as undirected, never re-mapped
- [x] Prompt regression guard fails when old-shape phrase reintroduced (verified by temporary injection)
- [x] e2e orchestrator test confirms undirected → PENDING + `disposition_reason="undirected_preference"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced explicit age-direction field ("older"/"younger"/undirected) for age-preference requests and updated prompts to produce this shape.
  * Undirected age preferences now route to staff review with a clear disposition reason.

* **Bug Fixes**
  * Improved detection/logging of inconsistent AI outputs for age preferences; avoids silent remapping.

* **Tests**
  * Added regression and unit tests covering age-direction parsing, conversion, drift handling, and end-to-end undirected behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1410)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->