### PR TITLE
refactor(api): route age_preference through determine_disposition (closes #1411)

### DIFF
--- a/bunking/sync/bunk_request_processor/services/request_builder.py
+++ b/bunking/sync/bunk_request_processor/services/request_builder.py
@@ -237,25 +237,25 @@ class RequestBuilder:
         """Determine the status and disposition reason for a bunk request.
 
         Returns:
-            Tuple of (status, disposition_reason). Unresolved names return (PENDING, "").
+            Tuple of (status, disposition_reason). AGE_PREFERENCE routes through
+            disposition rules regardless of resolution — direction alone determines
+            status (#1406). Unresolved names (other request types) return (PENDING, "").
             Resolved matches go through disposition rules (business gates + quality).
         """
         from ..disposition.disposition_rules import determine_disposition
 
+        age_direction = parsed_req.age_preference.value if parsed_req.age_preference else None
+
+        # AGE_PREFERENCE is resolution-independent: disposition_rules._age_preference_rules
+        # routes by direction alone. Delegate to avoid duplicating the literals (#1411).
+        if parsed_req.request_type == RequestType.AGE_PREFERENCE:
+            disposition = determine_disposition(parsed_req.request_type, age_direction=age_direction)
+            return disposition.status, disposition.reason
+
         person_cm_id = resolution_info.get("person_cm_id")
 
-        # No person ID cases
-        if person_cm_id is None:
-            if parsed_req.request_type == RequestType.AGE_PREFERENCE:
-                # Mirror disposition_rules._age_preference_rules — staff need
-                # `undirected_preference` reason to surface these for review (#1406).
-                if parsed_req.age_preference is not None:
-                    return RequestStatus.RESOLVED, "directional_preference"
-                return RequestStatus.PENDING, "undirected_preference"
-            return RequestStatus.PENDING, ""
-
-        # Negative ID means unresolved name
-        if person_cm_id < 0:
+        # Unresolved: no person ID, or negative hash-based ID for an unmatched name.
+        if person_cm_id is None or person_cm_id < 0:
             return RequestStatus.PENDING, ""
 
         # Resolved match — apply disposition rules
@@ -271,7 +271,7 @@ class RequestBuilder:
             target_has_bunking_session=conflict_type != "target_not_enrolled",
             target_waitlisted=resolution_info.get("target_waitlisted", False),
             session_match=conflict_type not in ("session_mismatch", "cross_session_satisfied"),
-            age_direction=parsed_req.age_preference.value if parsed_req.age_preference else None,
+            age_direction=age_direction,
             auto_resolve_threshold=self.auto_resolve_threshold,
         )
 

--- a/tests/unit/sync/bunk_request_processor/orchestrator/test_age_preference_undirected.py
+++ b/tests/unit/sync/bunk_request_processor/orchestrator/test_age_preference_undirected.py
@@ -28,6 +28,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from bunking.sync.bunk_request_processor.core.models import (
+    AgePreference,
     ParsedRequest,
     RequestStatus,
     RequestType,
@@ -126,3 +127,59 @@ class TestUndirectedAgePreferenceE2E:
         )
         assert req.requested_name is None, "requested_name must be cleared for age_preference"
         assert req.requested_cm_id is None, "undirected age_preference has no target person"
+
+
+class TestDirectionalAgePreferenceE2E:
+    """e2e characterization: a *directional* age_preference (age_preference=OLDER/YOUNGER)
+    with no target person must resolve to (RESOLVED, "directional_preference").
+
+    Locks the directional half of `disposition_rules._age_preference_rules` so the
+    #1411 refactor (routing AGE_PREFERENCE through `determine_disposition` instead of
+    duplicating the literals in `RequestBuilder.determine_request_status`) cannot
+    silently change behavior.
+    """
+
+    @pytest.mark.asyncio
+    @patch("bunking.sync.bunk_request_processor.orchestrator.orchestrator.ProviderFactory")
+    @patch("bunking.sync.bunk_request_processor.orchestrator.orchestrator.SocialGraph")
+    async def test_directional_age_preference_resolves_with_directional_preference_reason(
+        self, mock_social_graph, mock_factory
+    ):
+        mock_factory.return_value.create_provider.return_value = Mock()
+        mock_social_graph_instance = Mock()
+        mock_social_graph_instance.initialize = AsyncMock()
+        mock_social_graph.return_value = mock_social_graph_instance
+
+        pb = _create_mock_pocketbase()
+        orchestrator = RequestOrchestrator(pb=pb, year=2025)
+
+        parsed_req = ParsedRequest(
+            raw_text="wants to bunk with older campers",
+            request_type=RequestType.AGE_PREFERENCE,
+            target_name=None,
+            age_preference=AgePreference.OLDER,
+            source_field="bunk_with",
+            confidence=0.85,
+            csv_position=1,
+            metadata={},
+        )
+
+        resolution_info = {
+            "requester_cm_id": 11111,
+            "requester_name": "Test Requester",
+            "session_cm_id": 1000002,
+            "person_cm_id": None,
+            "person_name": None,
+            "confidence": 0.0,
+            "resolution_method": "age_preference",
+        }
+
+        created_requests, _ = await orchestrator._create_bunk_requests([(parsed_req, resolution_info)])
+
+        assert len(created_requests) == 1, "expected one BunkRequest"
+        req = created_requests[0]
+        assert req.status == RequestStatus.RESOLVED, f"directional age_preference must RESOLVE, got {req.status}"
+        assert req.disposition_reason == "directional_preference", (
+            f"disposition_reason must be 'directional_preference', got {req.disposition_reason!r}"
+        )
+        assert req.requested_cm_id is None, "directional age_preference has no target person"

--- a/tests/unit/sync/bunk_request_processor/orchestrator/test_age_preference_undirected.py
+++ b/tests/unit/sync/bunk_request_processor/orchestrator/test_age_preference_undirected.py
@@ -182,4 +182,5 @@ class TestDirectionalAgePreferenceE2E:
         assert req.disposition_reason == "directional_preference", (
             f"disposition_reason must be 'directional_preference', got {req.disposition_reason!r}"
         )
+        assert req.requested_name is None, "requested_name must be cleared for age_preference"
         assert req.requested_cm_id is None, "directional age_preference has no target person"


### PR DESCRIPTION
## Summary
- Hoist `AGE_PREFERENCE` handling above the `person_cm_id` checks in `RequestBuilder.determine_request_status` and delegate to `determine_disposition` instead of duplicating the `directional_preference` / `undirected_preference` literals.
- Update the `determine_request_status` docstring — it no longer claims "unresolved names return (PENDING, '')" unconditionally, since AGE_PREFERENCE is now resolution-independent.
- Add a directional-case e2e characterization test in `test_age_preference_undirected.py` alongside the existing undirected one, so both branches of `disposition_rules._age_preference_rules` are locked from the request_builder side.

Behavior is unchanged: `determine_disposition` already routes `AGE_PREFERENCE` via `_age_preference_rules` at the top of its dispatch with no dependency on resolution state, so the only effect is collapsing the duplicate literals.

Closes #1411.

## Test plan
- [x] Pre-push verification (`bash .claude/skills/pre-push-verification/scripts/verify.sh`) — 4436 unit tests pass, mypy, ruff, type-check, eslint, go build/test, shellcheck all green
- [x] New directional e2e test passes against the refactored code
- [x] Existing undirected e2e test still passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Age-preference requests now resolve using only the specified age direction, without requiring identification of a specific target person, ensuring correct disposition and clearer resolution reasons.

* **Tests**
  * Added end-to-end test coverage verifying directional age-preference requests resolve with the expected status and disposition reason.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1412)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->