### PR TITLE
refactor(solver): unify bunk-request sat vars + remove orphaned one-way helper

### DIFF
--- a/bunking/solver/constraints/__init__.py
+++ b/bunking/solver/constraints/__init__.py
@@ -7,7 +7,7 @@ Each module contains constraint logic that can be added to the CP-SAT model.
 from .age_grade_flow import add_age_grade_flow_objective
 from .age_preference import add_age_preference_satisfaction_vars
 from .base import ConstraintBuilder, ObjectiveBuilder, SolverContext
-from .bunk_requests import add_bunk_request_satisfaction_vars
+from .bunk_requests import get_or_create_request_sat_var
 from .cabin_capacity import add_cabin_capacity_constraints
 from .cabin_occupancy import (
     add_cabin_minimum_occupancy_constraints,
@@ -22,11 +22,11 @@ __all__ = [
     "SolverContext",
     "add_age_grade_flow_objective",
     "add_age_preference_satisfaction_vars",
-    "add_bunk_request_satisfaction_vars",
     "add_cabin_capacity_constraints",
     "add_cabin_minimum_occupancy_constraints",
     "add_cabin_minimum_occupancy_soft_penalty",
     "add_grade_adjacency_constraints",
     "add_grade_spread_constraints",
     "add_grade_spread_soft_constraint",
+    "get_or_create_request_sat_var",
 ]

--- a/bunking/solver/constraints/base.py
+++ b/bunking/solver/constraints/base.py
@@ -82,6 +82,13 @@ class SolverContext:
     # `localize_hard_mso_infeasibility` in feasibility.py.
     mp_skip_cms: set[int] = field(default_factory=set)
 
+    # Canonical per-request satisfaction vars for bunk_with / not_bunk_with
+    # requests, keyed by request.id. Built + memoized by
+    # get_or_create_request_sat_var (bunk_requests.py); shared so add_objective
+    # and parent_paramount reference one honest bidirectional var per request
+    # instead of two. Exposed post-solve as DirectBunkingSolver.request_satisfied_vars.
+    request_satisfied_vars: dict[str, cp_model.IntVar] = field(default_factory=dict)
+
     def is_constraint_disabled(self, constraint_name: str) -> bool:
         """Check if a constraint is disabled in debug mode."""
         return self.debug_constraints.get(constraint_name, False)

--- a/bunking/solver/constraints/bunk_requests.py
+++ b/bunking/solver/constraints/bunk_requests.py
@@ -1,13 +1,18 @@
 """
-Bunk Request Satisfaction Variables.
+Bunk request satisfaction variables.
 
-Creates satisfaction variables for bunk_with and not_bunk_with requests.
-These variables are used by must_satisfy.py to ensure at least one request
-is satisfied per camper.
+Single canonical builder for bunk_with / not_bunk_with satisfaction vars.
+Both the objective (direct_solver.add_objective) and the hard MP constraint
+(parent_paramount) call get_or_create_request_sat_var, sharing exactly one
+honest bidirectional sat var per request via the memoized
+`ctx.request_satisfied_vars` map.
 
-This module handles the MECHANICS of request satisfaction:
-- bunk_with: satisfied when both campers are in the same bunk
-- not_bunk_with: satisfied when campers are in different bunks
+A sat var is true iff the request's placement condition actually holds:
+- bunk_with:     requester and target are in the same bunk
+- not_bunk_with: requester and target are in different bunks
+
+This module also hosts MalformedRequestImpossibility, the registered
+impossibility predicate for malformed bunk requests.
 """
 
 from __future__ import annotations
@@ -27,146 +32,55 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-def add_bunk_request_satisfaction_vars(
+def get_or_create_request_sat_var(
     ctx: SolverContext,
-    requests_by_person: dict[int, list[DirectBunkRequest]],
-) -> dict[int, list[cp_model.IntVar]]:
-    """Create satisfaction variables for bunk_with/not_bunk_with requests.
-
-    This function creates boolean variables that track whether each request
-    is satisfied. The actual "at least one satisfied" constraint is added
-    by must_satisfy.py.
-
-    Args:
-        ctx: Solver context with model, assignments, and mappings
-        requests_by_person: Dict mapping person_cm_id to their filtered
-            bunk_with/not_bunk_with requests (already filtered for explicit sources)
-
-    Returns:
-        Dict mapping person_cm_id to list of satisfaction BoolVars
-    """
-    satisfaction_vars: dict[int, list[cp_model.IntVar]] = {}
-
-    for person_cm_id, requests in requests_by_person.items():
-        if person_cm_id not in ctx.person_idx_map:
-            continue
-
-        person_idx = ctx.person_idx_map[person_cm_id]
-        person_sat_vars: list[cp_model.IntVar] = []
-
-        for request in requests:
-            if request.request_type == RequestType.BUNK_WITH.value:
-                sat_var = _create_bunk_with_satisfaction_var(ctx, person_idx, request)
-                if sat_var is not None:
-                    person_sat_vars.append(sat_var)
-
-            elif request.request_type == RequestType.NOT_BUNK_WITH.value:
-                sat_var = _create_not_bunk_with_satisfaction_var(ctx, person_idx, request)
-                if sat_var is not None:
-                    person_sat_vars.append(sat_var)
-
-        if person_sat_vars:
-            satisfaction_vars[person_cm_id] = person_sat_vars
-
-    return satisfaction_vars
-
-
-def _create_bunk_with_satisfaction_var(
-    ctx: SolverContext,
-    requester_idx: int,
     request: DirectBunkRequest,
 ) -> cp_model.IntVar | None:
-    """Create satisfaction variable for a bunk_with request.
+    """Return the shared bidirectional satisfaction var for a bunk request.
 
-    A bunk_with request is satisfied if both the requester and requested
-    person are assigned to the same bunk.
+    Creates and memoizes the var on first call; later calls for the same
+    request.id return the identical var object. Both add_objective and
+    parent_paramount call this, so each request gets exactly one sat var.
 
-    Args:
-        ctx: Solver context
-        requester_idx: Index of the requesting person
-        request: The bunk_with request
+    Encoding (bidirectional, via ctx.person_bunk_assignment):
+        bunk_with:     sat_var == 1  <=>  requester bunk == target bunk
+        not_bunk_with: sat_var == 1  <=>  requester bunk != target bunk
 
-    Returns:
-        BoolVar that's true when request is satisfied, or None if request is invalid
+    Returns None for requests this builder cannot encode: an unsupported
+    request_type (only bunk_with / not_bunk_with), a missing target, or a
+    target/requester absent from person_idx_map.
     """
-    if not request.requested_person_cm_id:
+    existing = ctx.request_satisfied_vars.get(request.id)
+    if existing is not None:
+        return existing
+
+    if request.request_type not in (RequestType.BUNK_WITH.value, RequestType.NOT_BUNK_WITH.value):
+        # Silent: an unsupported type (e.g. age_preference) is expected control
+        # flow for callers, not a data-integrity smell — unlike the cases below.
         return None
 
-    if request.requested_person_cm_id not in ctx.person_idx_map:
-        logger.debug(f"bunk_with request {request.id}: requested person {request.requested_person_cm_id} not in solver")
+    target_cm_id = request.requested_person_cm_id
+    requester_cm_id = request.requester_person_cm_id
+    if target_cm_id is None or target_cm_id not in ctx.person_idx_map:
+        logger.debug(f"request {request.id}: target {target_cm_id} not in solver — no sat var")
+        return None
+    if requester_cm_id not in ctx.person_idx_map:
+        logger.debug(f"request {request.id}: requester {requester_cm_id} not in solver — no sat var")
         return None
 
-    requested_idx = ctx.person_idx_map[request.requested_person_cm_id]
+    requester_bunk = ctx.person_bunk_assignment[ctx.person_idx_map[requester_cm_id]]
+    target_bunk = ctx.person_bunk_assignment[ctx.person_idx_map[target_cm_id]]
 
-    # Create the satisfaction variable
-    sat_var = ctx.model.NewBoolVar(f"req_{request.id}_satisfied")
+    sat_var = ctx.model.NewBoolVar(f"req_satisfied_{request.id}")
 
-    # Request is satisfied if both are in the same bunk
-    # For each bunk, create a helper variable tracking if both are there
-    for bunk_idx in range(len(ctx.bunks)):
-        both_in_bunk = ctx.model.NewBoolVar(f"req_{request.id}_bunk_{bunk_idx}")
+    if request.request_type == RequestType.BUNK_WITH.value:
+        ctx.model.Add(requester_bunk == target_bunk).OnlyEnforceIf(sat_var)
+        ctx.model.Add(requester_bunk != target_bunk).OnlyEnforceIf(sat_var.Not())
+    else:  # NOT_BUNK_WITH
+        ctx.model.Add(requester_bunk != target_bunk).OnlyEnforceIf(sat_var)
+        ctx.model.Add(requester_bunk == target_bunk).OnlyEnforceIf(sat_var.Not())
 
-        # Both must be in this bunk
-        ctx.model.Add(
-            ctx.assignments[(requester_idx, bunk_idx)] + ctx.assignments[(requested_idx, bunk_idx)] == 2
-        ).OnlyEnforceIf(both_in_bunk)
-
-        # If both in bunk, request is satisfied
-        ctx.model.Add(sat_var == 1).OnlyEnforceIf(both_in_bunk)
-
-    return sat_var
-
-
-def _create_not_bunk_with_satisfaction_var(
-    ctx: SolverContext,
-    requester_idx: int,
-    request: DirectBunkRequest,
-) -> cp_model.IntVar | None:
-    """Create satisfaction variable for a not_bunk_with request.
-
-    A not_bunk_with request is satisfied if the requester and requested
-    person are assigned to different bunks.
-
-    Args:
-        ctx: Solver context
-        requester_idx: Index of the requesting person
-        request: The not_bunk_with request
-
-    Returns:
-        BoolVar that's true when request is satisfied, or None if request is invalid
-    """
-    if not request.requested_person_cm_id:
-        return None
-
-    if request.requested_person_cm_id not in ctx.person_idx_map:
-        logger.debug(
-            f"not_bunk_with request {request.id}: requested person {request.requested_person_cm_id} not in solver"
-        )
-        return None
-
-    requested_idx = ctx.person_idx_map[request.requested_person_cm_id]
-
-    # Create the satisfaction variable
-    sat_var = ctx.model.NewBoolVar(f"req_{request.id}_satisfied")
-
-    # Request is satisfied if NOT in same bunk
-    # We need to check they're in different bunks
-    different_bunks_vars = []
-
-    for bunk_idx in range(len(ctx.bunks)):
-        # Check if person is in this bunk but requested is not
-        person_in_bunk = ctx.assignments[(requester_idx, bunk_idx)]
-        requested_not_in_bunk = ctx.model.NewBoolVar(f"req_{request.id}_diff_bunk_{bunk_idx}")
-        ctx.model.Add(ctx.assignments[(requested_idx, bunk_idx)] == 0).OnlyEnforceIf(requested_not_in_bunk)
-
-        # If person in bunk and requested not, they're separated
-        separated = ctx.model.NewBoolVar(f"req_{request.id}_separated_{bunk_idx}")
-        ctx.model.AddBoolAnd([person_in_bunk, requested_not_in_bunk]).OnlyEnforceIf(separated)
-        different_bunks_vars.append(separated)
-
-    # If separated in any bunk assignment, request is satisfied
-    ctx.model.AddBoolOr(different_bunks_vars).OnlyEnforceIf(sat_var)
-
+    ctx.request_satisfied_vars[request.id] = sat_var
     return sat_var
 
 

--- a/bunking/solver/constraints/parent_paramount.py
+++ b/bunking/solver/constraints/parent_paramount.py
@@ -14,11 +14,10 @@ constraint.
 Mechanism:
   * For each MP-having camper, build (or borrow) one forcing indicator per MP
     request and add ``model.Add(sum(forcing_indicators) >= 1)``.
-  * For bunk_with / not_bunk_with requests we build a bidirectional
-    ``person_bunk_assignment``-based sat var per request (matches the encoding
-    add_objective uses at direct_solver.py:663-714). One BoolVar + two reified
-    linears per request — much smaller than the per-bunk indicator helpers
-    use under the hood.
+  * For bunk_with / not_bunk_with requests we borrow the shared sat var from
+    ``get_or_create_request_sat_var`` (bunk_requests.py) — one honest
+    bidirectional ``person_bunk_assignment``-based BoolVar per request,
+    memoized in ``ctx.request_satisfied_vars`` and shared with add_objective.
   * For age_preference requests we read the per-(request, bunk) forcing
     indicators returned by ``add_age_preference_satisfaction_vars`` (the
     helper's internal ``person_in_clean_bunk`` / ``person_in_bunk`` BoolVars).
@@ -39,6 +38,7 @@ from bunking.sync.bunk_request_processor.core.models import RequestType
 
 from .age_preference import add_age_preference_satisfaction_vars
 from .base import SolverContext
+from .bunk_requests import get_or_create_request_sat_var
 
 if TYPE_CHECKING:
     from ortools.sat.python import cp_model
@@ -120,7 +120,7 @@ def add_must_satisfy_one_request_constraints(ctx: SolverContext) -> None:
         forcing_vars: list[cp_model.IntVar] = []
 
         for r in mp_bunk_requests_by_person.get(person_cm_id, []):
-            sat_var = _build_bunk_request_forcing_var(ctx, r)
+            sat_var = get_or_create_request_sat_var(ctx, r)
             if sat_var is not None:
                 forcing_vars.append(sat_var)
 
@@ -155,55 +155,3 @@ def add_must_satisfy_one_request_constraints(ctx: SolverContext) -> None:
         f"all_mp_impossible={len(ctx.mp_set_entirely_impossible)}, "
         f"no_requests={len(campers_without_requests)}{skip_suffix}"
     )
-
-
-def _build_bunk_request_forcing_var(
-    ctx: SolverContext,
-    request: DirectBunkRequest,
-) -> cp_model.IntVar | None:
-    """Build a bidirectional sat var for a bunk_with / not_bunk_with request.
-
-    Uses ``ctx.person_bunk_assignment`` (the integer-bunk-index variables) so
-    the sat var is honestly tied to placement: ``sat_var = 1`` iff the
-    requested co-placement (or separation) actually holds.
-
-    Mirrors the encoding ``add_objective`` uses at direct_solver.py:663-714
-    but creates a separate BoolVar (unification with the objective's vars is
-    a follow-up — see PR body).
-
-    Returns None for malformed requests (e.g., target not in person_idx_map),
-    which shouldn't happen because ctx.possible_requests is the input.
-    """
-    requester_cm_id = request.requester_person_cm_id
-    target_cm_id = request.requested_person_cm_id
-
-    if target_cm_id is None or target_cm_id not in ctx.person_idx_map:
-        return None
-    if requester_cm_id not in ctx.person_idx_map:
-        return None
-
-    requester_idx = ctx.person_idx_map[requester_cm_id]
-    target_idx = ctx.person_idx_map[target_cm_id]
-
-    sat_var = ctx.model.NewBoolVar(f"parent_paramount_req_{request.id}_satisfied")
-
-    if request.request_type == RequestType.BUNK_WITH.value:
-        # sat_var == 1 ⇔ requester and target are in the same bunk
-        ctx.model.Add(
-            ctx.person_bunk_assignment[requester_idx] == ctx.person_bunk_assignment[target_idx]
-        ).OnlyEnforceIf(sat_var)
-        ctx.model.Add(
-            ctx.person_bunk_assignment[requester_idx] != ctx.person_bunk_assignment[target_idx]
-        ).OnlyEnforceIf(sat_var.Not())
-    elif request.request_type == RequestType.NOT_BUNK_WITH.value:
-        # sat_var == 1 ⇔ requester and target are in DIFFERENT bunks
-        ctx.model.Add(
-            ctx.person_bunk_assignment[requester_idx] != ctx.person_bunk_assignment[target_idx]
-        ).OnlyEnforceIf(sat_var)
-        ctx.model.Add(
-            ctx.person_bunk_assignment[requester_idx] == ctx.person_bunk_assignment[target_idx]
-        ).OnlyEnforceIf(sat_var.Not())
-    else:
-        return None  # Unsupported request type for this helper
-
-    return sat_var

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -28,6 +28,7 @@ from .callbacks import SolverProgressCallback
 from .constraints.age_grade_flow import add_age_grade_flow_objective
 from .constraints.age_spread import add_age_spread_constraints
 from .constraints.base import SolverContext
+from .constraints.bunk_requests import get_or_create_request_sat_var
 from .constraints.cabin_occupancy import (
     add_cabin_minimum_occupancy_constraints,
     add_cabin_minimum_occupancy_soft_penalty,
@@ -452,6 +453,10 @@ class DirectBunkingSolver:
         # First, create satisfaction variables for each request
         person_request_satisfaction = defaultdict(list)  # person_cm_id -> list of (request, satisfaction_var)
 
+        # SolverContext carries self.request_satisfied_vars by reference, so
+        # get_or_create_request_sat_var memo-shares with parent_paramount.
+        ctx = self._build_solver_context()
+
         for person_cm_id, requests in self.input.requests_by_person.items():
             if person_cm_id not in self.person_idx_map:
                 continue
@@ -464,30 +469,20 @@ class DirectBunkingSolver:
                     if request.requested_person_cm_id and request.requested_person_cm_id in self.person_idx_map:
                         target_idx = self.person_idx_map[request.requested_person_cm_id]
 
-                        # Create satisfaction variable for this request
-                        request_satisfied = self.model.NewBoolVar(f"req_satisfied_{request.id}")
-
-                        # OPTIMIZED: Request is satisfied if both are in same bunk
-                        # Direct comparison - O(1) instead of O(bunks)
-
                         # Check if they can possibly be in the same bunk (gender/session compatible)
                         valid_bunks = self._get_valid_bunks_for_pair(person_idx, target_idx)
 
                         if not valid_bunks:
-                            # No valid bunks for this pair - request cannot be satisfied
+                            # No valid bunks for this pair - request cannot be satisfied.
+                            # Pinned-impossible var stays objective-local (not in the shared map).
+                            request_satisfied = self.model.NewBoolVar(f"req_satisfied_{request.id}")
                             self.model.Add(request_satisfied == 0)
                         else:
-                            # Request is satisfied if their bunk assignments are equal
-                            # This is a single constraint instead of 20+ constraints!
-                            self.model.Add(
-                                self.person_bunk_assignment[person_idx] == self.person_bunk_assignment[target_idx]
-                            ).OnlyEnforceIf(request_satisfied)
+                            # Borrow the one canonical bidirectional sat var.
+                            request_satisfied = get_or_create_request_sat_var(ctx, request)
 
-                            self.model.Add(
-                                self.person_bunk_assignment[person_idx] != self.person_bunk_assignment[target_idx]
-                            ).OnlyEnforceIf(request_satisfied.Not())
-
-                        person_request_satisfaction[person_cm_id].append((request, request_satisfied))
+                        if request_satisfied is not None:
+                            person_request_satisfaction[person_cm_id].append((request, request_satisfied))
 
                 elif request.request_type == RequestType.NOT_BUNK_WITH.value:
                     # Negative request - want them apart
@@ -510,29 +505,20 @@ class DirectBunkingSolver:
                                 )
                         else:
                             # Soft constraint - create satisfaction variable
-                            request_satisfied = self.model.NewBoolVar(f"req_satisfied_{request.id}")
-
-                            # OPTIMIZED: Request is satisfied if they are NOT in same bunk
-                            # Direct comparison - O(1) instead of O(bunks)
-
                             # Check if they can possibly be in the same bunk
                             valid_bunks = self._get_valid_bunks_for_pair(person_idx, target_idx)
 
                             if not valid_bunks:
-                                # No valid bunks for this pair - they can't be together anyway
+                                # No valid bunks for this pair - they can't be together anyway.
+                                # Pinned-trivial var stays objective-local (not in the shared map).
+                                request_satisfied = self.model.NewBoolVar(f"req_satisfied_{request.id}")
                                 self.model.Add(request_satisfied == 1)
                             else:
-                                # Request is satisfied if their bunk assignments are NOT equal
-                                # This is a single constraint instead of 20+ constraints!
-                                self.model.Add(
-                                    self.person_bunk_assignment[person_idx] != self.person_bunk_assignment[target_idx]
-                                ).OnlyEnforceIf(request_satisfied)
+                                # Borrow the one canonical bidirectional sat var.
+                                request_satisfied = get_or_create_request_sat_var(ctx, request)
 
-                                self.model.Add(
-                                    self.person_bunk_assignment[person_idx] == self.person_bunk_assignment[target_idx]
-                                ).OnlyEnforceIf(request_satisfied.Not())
-
-                            person_request_satisfaction[person_cm_id].append((request, request_satisfied))
+                            if request_satisfied is not None:
+                                person_request_satisfaction[person_cm_id].append((request, request_satisfied))
 
                 # Note: age_preference requests are handled by must_satisfy_one constraint only
 
@@ -582,9 +568,6 @@ class DirectBunkingSolver:
 
         # NOTE: Age preference is now handled by constraints/age_preference.py
         # NOTE: Level progression is now handled by constraints/level_progression.py
-
-        # Build solver context for modular constraint calls
-        ctx = self._build_solver_context()
 
         # Add age/grade flow incentives
         add_age_grade_flow_objective(ctx, objective_terms)

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -124,6 +124,11 @@ class DirectBunkingSolver:
         # parent_paramount's hard constraint pass; surfaced post-solve into stats.
         self.mp_set_entirely_impossible: list[int] = []
 
+        # Canonical per-request satisfaction vars (bunk_with / not_bunk_with),
+        # keyed by request.id. Populated by get_or_create_request_sat_var via
+        # parent_paramount and add_objective; one shared var per request.
+        self.request_satisfied_vars: dict[str, cp_model.IntVar] = {}
+
         # Limit debug logging for pair reduction (only first 5 pairs)
         self._pair_reduction_logged = 0
 
@@ -170,6 +175,7 @@ class DirectBunkingSolver:
             soft_constraint_bonuses=self.soft_constraint_bonuses,
             mp_set_entirely_impossible=self.mp_set_entirely_impossible,
             mp_skip_cms=self.mp_skip_cms,
+            request_satisfied_vars=self.request_satisfied_vars,
         )
 
     def _get_valid_bunks_for_pair(self, person1_idx: int, person2_idx: int) -> list[int]:

--- a/docs/reference/solver-roadmap.md
+++ b/docs/reference/solver-roadmap.md
@@ -100,16 +100,20 @@ ctx.model.Add(sum(all_sat_vars) >= 1)                                # +1 plain 
 …and removing 164 BoolVars / 328 reified linears / 164 objective terms
 from S2.
 
-> **Reality (#1391):** the existing `all_sat_vars` produced by
-> `add_bunk_request_satisfaction_vars` use **one-way `OnlyEnforceIf`
-> implications** (`bunk_requests.py:75-117`). The solver can set
-> `sat_var = 1` freely without forcing actual co-placement. A hard
-> `sum(all_sat_vars) >= 1` over them would be vacuously satisfiable.
-> The pre-Stage-4 soft constraint summed over these falsifiable vars
-> and the objective rewarded them — meaning the 287,600 penalty was
-> almost certainly operationally inert (the 95.73% MP coverage came
-> from cluster constraints emergently placing friends, not the
-> penalty). See #1396 for the investigation issue.
+> **Reality (#1391):** the `all_sat_vars` produced by the pre-#1391
+> `add_bunk_request_satisfaction_vars` used **one-way `OnlyEnforceIf`
+> implications**. The solver could set `sat_var = 1` freely without
+> forcing actual co-placement. A hard `sum(all_sat_vars) >= 1` over them
+> would be vacuously satisfiable. The now-deleted soft `must_satisfy.py`
+> summed over these falsifiable vars — meaning the 287,600 penalty was
+> almost certainly operationally inert (the 95.73% MP coverage came from
+> cluster constraints emergently placing friends, not the penalty).
+> **Correction (#1395):** the objective itself was *never* falsifiable —
+> `add_objective` has always built its own bidirectional `req_satisfied_*`
+> vars and never consumed `add_bunk_request_satisfaction_vars`. That helper
+> was orphaned when #1391 deleted `must_satisfy.py` and is removed in #1395,
+> which unifies the objective's and parent_paramount's sat vars into one
+> shared `request_satisfied_vars` map. See #1396 for the investigation issue.
 >
 > **What shipped** in #1391: hard constraint uses a bidirectional
 > per-request sat var via `ctx.person_bunk_assignment` (matches the
@@ -175,7 +179,7 @@ extend `_pair_has_shared_bunk` rather than adding a new reason.
 ### Code refs (post-#1391)
 
 - `bunking/solver/constraints/parent_paramount.py` — hard MP constraint (renamed from `must_satisfy.py`)
-- `bunking/solver/constraints/bunk_requests.py:75-117` — one-way soft sat var encoding (see #1395)
+- `bunking/solver/constraints/bunk_requests.py` — `get_or_create_request_sat_var`, the canonical bidirectional sat-var builder (post-#1395; replaced the orphaned one-way `add_bunk_request_satisfaction_vars`)
 - `bunking/solver/direct_solver.py:643-714` — bidirectional objective-side sat var encoding (template for #1391's hard path)
 - `bunking/solver/direct_solver.py:355-438` — `_validate_requests`, impossibility classification
 - `bunking/solver/direct_solver.py:1215-` — `_check_must_satisfy_one_violations` (post-solve diagnostic, ERROR severity under hard MSO)
@@ -210,7 +214,7 @@ Tracking: #1379 (closed by #1391 on 2026-05-13).
 
 ### Follow-ups surfaced during #1391 implementation
 
-- **#1395** — `refactor(solver): make add_bunk_request_satisfaction_vars bidirectional + unify sat vars with objective`. Eliminates the "free money" objective reward (one-way soft sat vars are falsifiable) and the ~250 duplicate BoolVars between `add_objective` and `parent_paramount`.
+- **#1395** — `refactor(solver): unify bunk-request sat vars + remove the orphaned one-way helper`. Behaviour-neutral cleanup: deleted the orphaned one-way `add_bunk_request_satisfaction_vars` (dead since #1391 removed `must_satisfy.py`), added the canonical bidirectional `get_or_create_request_sat_var`, and unified `add_objective` + `parent_paramount` onto one shared `request_satisfied_vars` map (~250 fewer duplicate BoolVars on S2). The "free money" framing was stale — the objective was never falsifiable; see the Stream 1 "Reality (#1391)" correction above.
 - **#1396** — `investigation: was historical MP coverage actually penalty-driven?` Three counterfactual experiments to determine whether the 95.73% pre-Stage-4 MP rate came from the soft penalty or from cluster constraints emergently placing friends.
 - **#1397** — `refactor(solver): retire solution.calculate_satisfied_requests + audit calculate_field_level_stats`. Cleanup of `solution.py` to delegate to `bunking.satisfaction.predicate`.
 - **#1398** — `test(solver): golden alignment test between solve-time sat vars and post-solve predicate`. Deferred from #1391 Task 9 (no integration fixture infrastructure).
@@ -330,9 +334,9 @@ to eliminate junk) yields:
 | Source | Pre-presolve count | Code ref |
 |---|---|---|
 | `person_in_bunk[p, b]` — one per (person, bunk) | 193 × 17 = 3,281 | `direct_solver.py:_create_assignment_variables` |
-| `both_in_bunk[req, b]` — one per BUNK_WITH request per bunk | 311 × 17 = 5,287 | `constraints/bunk_requests.py:add_bunk_request_satisfaction_vars` |
+| ~~`both_in_bunk[req, b]` — one per BUNK_WITH request per bunk~~ | ~~311 × 17 = 5,287~~ | ~~`constraints/bunk_requests.py:add_bunk_request_satisfaction_vars`~~ — pre-#1391 only; the helper was orphaned when #1391 deleted `must_satisfy.py` and removed entirely in #1395. No `both_in_bunk` vars exist in the live model. |
 | `req_satisfied[r]` — one per request | 504 | `constraints/bunk_requests.py`, `age_preference.py` |
-| ~~`must_satisfy_violation[p]` — one per MP camper~~ | ~~164~~ | ~~`constraints/must_satisfy.py`~~ (removed in #1391, replaced by ~250 bidirectional `parent_paramount_req_*_satisfied` sat vars; see #1395 for unification) |
+| ~~`must_satisfy_violation[p]` — one per MP camper~~ | ~~164~~ | ~~`constraints/must_satisfy.py`~~ (removed in #1391; the ~250 bidirectional MP sat vars it was replaced by were unified with the objective's set into one shared `request_satisfied_vars` map in #1395) |
 | Constraint-internal indicators (grade_ratio, age_spread, level_progression, grade_adjacency) | ~500 | various |
 | **Total before presolve** | **~9,750** | |
 | **Post-presolve (reported)** | **5,561** | |
@@ -342,7 +346,7 @@ to eliminate junk) yields:
 | # | Lever | Estimated savings | Risk | Effort |
 |---|---|---|---|---|
 | 3a | **Sparse `person_in_bunk` — gender filter at model-build time** | −~1,640 BoolVars for S2 (50% of 3,281) | Low — `person_idx_map` already gender-aware upstream | Modest PR |
-| 3b | **Sparse `both_in_bunk` — eligibility intersect** (skip bunks where requester OR requestee is gender/grade-ineligible) | −~1,500–2,500 BoolVars | Low | Modest PR |
+| ~~3b~~ | ~~**Sparse `both_in_bunk` — eligibility intersect**~~ — **moot:** `both_in_bunk` was orphaned by #1391 and removed by #1395. The live sat-var encoding is `person_bunk_assignment`-based (one BoolVar per request, no per-bunk fan-out). | — | — | — |
 | 3c | **Hard MSO** (Stream 1) | −164 BoolVars | Already covered by Stream 1 | — |
 | 3d | **Pre-solve fixed-assignment pass** for 1-bunk-eligible campers (e.g., AG-only, grade-locked) | −17 BoolVars per such camper | Low | Small PR |
 | 3e | **Drop `req_satisfied` for already-impossible requests** | −~4 per session (small) | None | Tiny |
@@ -821,3 +825,12 @@ diffs are clearer.
   extended with staff-friendly prose vs admin-detail views. Substreams
   6a–6f (level_progression, group_locks, per-bunk grade range, cohort
   census, "open request" link, solver-probe fallback) deferred.
+- **2026-05-14** — #1395 shipped: bunk-request sat-var unification. Deleted
+  the orphaned one-way `add_bunk_request_satisfaction_vars` (dead since
+  #1391 removed `must_satisfy.py`), added the canonical bidirectional
+  `get_or_create_request_sat_var`, and unified `add_objective` +
+  `parent_paramount` onto one shared `request_satisfied_vars` map.
+  Behaviour-neutral (both prior encodings were already honest bidirectional
+  comparisons); the win is ~250 fewer duplicate BoolVars on S2. Corrected
+  the Stream 1 "Reality" note (the objective was never falsifiable) and the
+  Stream 3 table / lever 3b (`both_in_bunk` no longer exists in the live model).

--- a/tests/unit/bunking/solver/constraints/test_bunk_requests.py
+++ b/tests/unit/bunking/solver/constraints/test_bunk_requests.py
@@ -1,12 +1,10 @@
-"""
-Unit tests for bunk request satisfaction variables.
+"""Unit tests for the canonical bunk-request satisfaction var builder.
 
-Tests the mechanics of request satisfaction:
-- bunk_with: satisfied when both campers are in the same bunk
-- not_bunk_with: satisfied when campers are in different bunks
+get_or_create_request_sat_var must produce an HONEST bidirectional sat var:
+    sat_var == 1  <=>  the request's placement condition actually holds.
 
-Note: This tests the satisfaction variable creation, not the "must satisfy"
-constraint (which is in must_satisfy.py).
+The headline tests are the "true implies" honesty tests — they fail for any
+one-way (falsifiable) encoding and pass only for the bidirectional one.
 """
 
 from __future__ import annotations
@@ -14,355 +12,190 @@ from __future__ import annotations
 from ortools.sat.python import cp_model
 
 from bunking.models import RequestType
-from bunking.solver.constraints.bunk_requests import add_bunk_request_satisfaction_vars
+from bunking.solver.constraints.bunk_requests import get_or_create_request_sat_var
 
-from ..conftest import build_solver_context, create_bunk, create_person, create_request, is_optimal_or_feasible
+from ..conftest import build_solver_context, create_bunk, create_person, create_request
 
 
-class TestBunkWithSatisfaction:
-    """Test bunk_with request satisfaction."""
+class TestBunkWithHonesty:
+    """A bunk_with sat var must be true IFF the pair is actually co-placed."""
 
-    def test_bunk_with_satisfied_when_together(self):
-        """bunk_with request is satisfied when both campers in same bunk."""
-        # 2 campers who want to bunk together, 1 bunk
-        camper1 = create_person(cm_id=1001, first_name="Alice", last_name="Test", gender="F", grade=5)
-        camper2 = create_person(cm_id=1002, first_name="Bob", last_name="Test", gender="F", grade=5)
-        bunk = create_bunk(cm_id=2001, name="G-1", gender="F", capacity=12)
+    def test_sat_var_true_implies_coplacement(self):
+        """sat_var == 1 with the pair in different bunks must be INFEASIBLE.
 
+        This is the falsifiability guard: a one-way encoding lets the solver
+        claim sat_var == 1 for free without honest co-placement.
+        """
+        c1 = create_person(cm_id=1001, first_name="Emma", last_name="Johnson", gender="F", grade=5)
+        c2 = create_person(cm_id=1002, first_name="Liam", last_name="Garcia", gender="F", grade=5)
+        bunk1 = create_bunk(cm_id=2001, name="G-1", gender="F", capacity=12)
+        bunk2 = create_bunk(cm_id=2002, name="G-2", gender="F", capacity=12)
         request = create_request(
             request_id="req-1",
             requester_cm_id=1001,
             requested_cm_id=1002,
             request_type=RequestType.BUNK_WITH,
         )
+        ctx = build_solver_context(persons=[c1, c2], bunks=[bunk1, bunk2], requests=[request])
 
-        ctx = build_solver_context(
-            persons=[camper1, camper2],
-            bunks=[bunk],
-            requests=[request],
-        )
+        sat_var = get_or_create_request_sat_var(ctx, request)
+        assert sat_var is not None
 
-        # Create satisfaction variables
-        requests_by_person = {1001: [request]}
-        sat_vars = add_bunk_request_satisfaction_vars(ctx, requests_by_person)
+        ctx.model.Add(ctx.person_bunk_assignment[0] != ctx.person_bunk_assignment[1])
+        ctx.model.Add(sat_var == 1)
 
-        # Solve
         solver = cp_model.CpSolver()
         status = solver.Solve(ctx.model)
+        assert status == cp_model.INFEASIBLE, (
+            "sat_var == 1 while the pair is in different bunks must be "
+            "INFEASIBLE — a one-way encoding makes this falsely FEASIBLE"
+        )
 
-        assert is_optimal_or_feasible(status)
-
-        # Both should be in same bunk (only 1 bunk available)
-        bunk_idx = ctx.bunk_idx_map[2001]
-        assert solver.Value(ctx.assignments[(0, bunk_idx)]) == 1
-        assert solver.Value(ctx.assignments[(1, bunk_idx)]) == 1
-
-        # Satisfaction variable should be 1
-        assert 1001 in sat_vars
-        assert len(sat_vars[1001]) == 1
-        # Can verify the satisfaction var value if needed
-
-    def test_bunk_with_can_be_satisfied_across_bunks(self):
-        """Solver can choose to satisfy bunk_with by putting campers together."""
-        # 2 campers, 2 bunks - solver should put them in same bunk to satisfy
-        camper1 = create_person(cm_id=1001, first_name="Alice", last_name="Test", gender="F", grade=5)
-        camper2 = create_person(cm_id=1002, first_name="Beth", last_name="Test", gender="F", grade=5)
+    def test_sat_var_false_implies_separation(self):
+        """sat_var == 0 with the pair in the same bunk must be INFEASIBLE."""
+        c1 = create_person(cm_id=1001, first_name="Emma", last_name="Johnson", gender="F", grade=5)
+        c2 = create_person(cm_id=1002, first_name="Liam", last_name="Garcia", gender="F", grade=5)
         bunk1 = create_bunk(cm_id=2001, name="G-1", gender="F", capacity=12)
         bunk2 = create_bunk(cm_id=2002, name="G-2", gender="F", capacity=12)
-
         request = create_request(
             request_id="req-1",
             requester_cm_id=1001,
             requested_cm_id=1002,
             request_type=RequestType.BUNK_WITH,
         )
+        ctx = build_solver_context(persons=[c1, c2], bunks=[bunk1, bunk2], requests=[request])
 
-        ctx = build_solver_context(
-            persons=[camper1, camper2],
-            bunks=[bunk1, bunk2],
-            requests=[request],
-        )
+        sat_var = get_or_create_request_sat_var(ctx, request)
+        assert sat_var is not None
 
-        # Create satisfaction variables
-        requests_by_person = {1001: [request]}
-        sat_vars = add_bunk_request_satisfaction_vars(ctx, requests_by_person)
+        ctx.model.Add(ctx.person_bunk_assignment[0] == ctx.person_bunk_assignment[1])
+        ctx.model.Add(sat_var == 0)
 
-        # Add objective to maximize satisfaction
-        assert 1001 in sat_vars
-        ctx.model.Maximize(sum(sat_vars[1001]))
-
-        # Solve
         solver = cp_model.CpSolver()
         status = solver.Solve(ctx.model)
-
-        assert is_optimal_or_feasible(status)
-
-        # Both should be in same bunk
-        bunk1_idx = ctx.bunk_idx_map[2001]
-        bunk2_idx = ctx.bunk_idx_map[2002]
-
-        c1_in_b1 = solver.Value(ctx.assignments[(0, bunk1_idx)])
-        c1_in_b2 = solver.Value(ctx.assignments[(0, bunk2_idx)])
-        c2_in_b1 = solver.Value(ctx.assignments[(1, bunk1_idx)])
-        c2_in_b2 = solver.Value(ctx.assignments[(1, bunk2_idx)])
-
-        # Either both in bunk1 or both in bunk2
-        assert (c1_in_b1 == 1 and c2_in_b1 == 1) or (c1_in_b2 == 1 and c2_in_b2 == 1)
-
-    def test_bunk_with_invalid_when_requested_not_in_solver(self):
-        """bunk_with returns None if requested person not in solver context."""
-        camper1 = create_person(cm_id=1001, first_name="Alice", last_name="Test", gender="F", grade=5)
-        bunk = create_bunk(cm_id=2001, name="G-1", gender="F", capacity=12)
-
-        # Request for person not in context
-        request = create_request(
-            request_id="req-1",
-            requester_cm_id=1001,
-            requested_cm_id=9999,  # Not in context
-            request_type=RequestType.BUNK_WITH,
-        )
-
-        ctx = build_solver_context(
-            persons=[camper1],
-            bunks=[bunk],
-            requests=[request],
-        )
-
-        # Create satisfaction variables
-        requests_by_person = {1001: [request]}
-        sat_vars = add_bunk_request_satisfaction_vars(ctx, requests_by_person)
-
-        # Should have no satisfaction vars (invalid request)
-        assert 1001 not in sat_vars or len(sat_vars.get(1001, [])) == 0
+        assert status == cp_model.INFEASIBLE
 
 
-class TestNotBunkWithSatisfaction:
-    """Test not_bunk_with request satisfaction."""
+class TestNotBunkWithHonesty:
+    """A not_bunk_with sat var must be true IFF the pair is actually separated."""
 
-    def test_not_bunk_with_satisfied_when_separated(self):
-        """not_bunk_with request is satisfied when campers in different bunks."""
-        camper1 = create_person(cm_id=1001, first_name="Alice", last_name="Test", gender="F", grade=5)
-        camper2 = create_person(cm_id=1002, first_name="Beth", last_name="Test", gender="F", grade=5)
+    def test_sat_var_true_implies_separation(self):
+        """sat_var == 1 with the pair in the same bunk must be INFEASIBLE."""
+        c1 = create_person(cm_id=1001, first_name="Emma", last_name="Johnson", gender="F", grade=5)
+        c2 = create_person(cm_id=1002, first_name="Liam", last_name="Garcia", gender="F", grade=5)
         bunk1 = create_bunk(cm_id=2001, name="G-1", gender="F", capacity=12)
         bunk2 = create_bunk(cm_id=2002, name="G-2", gender="F", capacity=12)
-
         request = create_request(
             request_id="req-1",
             requester_cm_id=1001,
             requested_cm_id=1002,
             request_type=RequestType.NOT_BUNK_WITH,
         )
+        ctx = build_solver_context(persons=[c1, c2], bunks=[bunk1, bunk2], requests=[request])
 
-        ctx = build_solver_context(
-            persons=[camper1, camper2],
-            bunks=[bunk1, bunk2],
-            requests=[request],
-        )
+        sat_var = get_or_create_request_sat_var(ctx, request)
+        assert sat_var is not None
 
-        # Create satisfaction variables
-        requests_by_person = {1001: [request]}
-        sat_vars = add_bunk_request_satisfaction_vars(ctx, requests_by_person)
+        ctx.model.Add(ctx.person_bunk_assignment[0] == ctx.person_bunk_assignment[1])
+        ctx.model.Add(sat_var == 1)
 
-        # Add objective to maximize satisfaction
-        assert 1001 in sat_vars
-        ctx.model.Maximize(sum(sat_vars[1001]))
-
-        # Solve
         solver = cp_model.CpSolver()
         status = solver.Solve(ctx.model)
-
-        assert is_optimal_or_feasible(status)
-
-        # Should be in different bunks
-        bunk1_idx = ctx.bunk_idx_map[2001]
-
-        c1_in_b1 = solver.Value(ctx.assignments[(0, bunk1_idx)])
-        c2_in_b1 = solver.Value(ctx.assignments[(1, bunk1_idx)])
-
-        # They should NOT both be in the same bunk
-        assert not (c1_in_b1 == 1 and c2_in_b1 == 1)
-
-    def test_not_bunk_with_not_satisfied_when_forced_together(self):
-        """not_bunk_with request cannot be satisfied if only one bunk available."""
-        camper1 = create_person(cm_id=1001, first_name="Alice", last_name="Test", gender="F", grade=5)
-        camper2 = create_person(cm_id=1002, first_name="Beth", last_name="Test", gender="F", grade=5)
-        bunk = create_bunk(cm_id=2001, name="G-1", gender="F", capacity=12)
-
-        request = create_request(
-            request_id="req-1",
-            requester_cm_id=1001,
-            requested_cm_id=1002,
-            request_type=RequestType.NOT_BUNK_WITH,
+        assert status == cp_model.INFEASIBLE, (
+            "sat_var == 1 while the pair shares a bunk must be INFEASIBLE — "
+            "a one-way encoding makes this falsely FEASIBLE"
         )
 
-        ctx = build_solver_context(
-            persons=[camper1, camper2],
-            bunks=[bunk],  # Only one bunk - can't separate
-            requests=[request],
-        )
-
-        # Create satisfaction variables (returns empty since only 1 bunk)
-        requests_by_person = {1001: [request]}
-        add_bunk_request_satisfaction_vars(ctx, requests_by_person)
-
-        # Solve (still feasible, just request unsatisfied)
-        solver = cp_model.CpSolver()
-        status = solver.Solve(ctx.model)
-
-        assert is_optimal_or_feasible(status)
-
-        # Both forced into same bunk
-        bunk_idx = ctx.bunk_idx_map[2001]
-        assert solver.Value(ctx.assignments[(0, bunk_idx)]) == 1
-        assert solver.Value(ctx.assignments[(1, bunk_idx)]) == 1
-
-
-class TestMultipleRequests:
-    """Test multiple requests from same person."""
-
-    def test_multiple_bunk_with_requests(self):
-        """Multiple bunk_with requests can be tracked."""
-        camper1 = create_person(cm_id=1001, first_name="Alice", last_name="Test", gender="F", grade=5)
-        camper2 = create_person(cm_id=1002, first_name="Beth", last_name="Test", gender="F", grade=5)
-        camper3 = create_person(cm_id=1003, first_name="Carol", last_name="Test", gender="F", grade=5)
-        bunk = create_bunk(cm_id=2001, name="G-1", gender="F", capacity=12)
-
-        # Alice wants to bunk with both Beth and Carol
-        request1 = create_request(
-            request_id="req-1",
-            requester_cm_id=1001,
-            requested_cm_id=1002,
-            request_type=RequestType.BUNK_WITH,
-        )
-        request2 = create_request(
-            request_id="req-2",
-            requester_cm_id=1001,
-            requested_cm_id=1003,
-            request_type=RequestType.BUNK_WITH,
-        )
-
-        ctx = build_solver_context(
-            persons=[camper1, camper2, camper3],
-            bunks=[bunk],
-            requests=[request1, request2],
-        )
-
-        # Create satisfaction variables
-        requests_by_person = {1001: [request1, request2]}
-        sat_vars = add_bunk_request_satisfaction_vars(ctx, requests_by_person)
-
-        # Should have 2 satisfaction variables for camper 1001
-        assert 1001 in sat_vars
-        assert len(sat_vars[1001]) == 2
-
-    def test_mixed_request_types(self):
-        """Mix of bunk_with and not_bunk_with for same person."""
-        camper1 = create_person(cm_id=1001, first_name="Alice", last_name="Test", gender="F", grade=5)
-        camper2 = create_person(cm_id=1002, first_name="Beth", last_name="Test", gender="F", grade=5)
-        camper3 = create_person(cm_id=1003, first_name="Carol", last_name="Test", gender="F", grade=5)
+    def test_sat_var_false_implies_coplacement(self):
+        """sat_var == 0 with the pair in different bunks must be INFEASIBLE."""
+        c1 = create_person(cm_id=1001, first_name="Emma", last_name="Johnson", gender="F", grade=5)
+        c2 = create_person(cm_id=1002, first_name="Liam", last_name="Garcia", gender="F", grade=5)
         bunk1 = create_bunk(cm_id=2001, name="G-1", gender="F", capacity=12)
         bunk2 = create_bunk(cm_id=2002, name="G-2", gender="F", capacity=12)
+        request = create_request(
+            request_id="req-1",
+            requester_cm_id=1001,
+            requested_cm_id=1002,
+            request_type=RequestType.NOT_BUNK_WITH,
+        )
+        ctx = build_solver_context(persons=[c1, c2], bunks=[bunk1, bunk2], requests=[request])
 
-        # Alice wants to bunk with Beth, but NOT with Carol
-        request1 = create_request(
+        sat_var = get_or_create_request_sat_var(ctx, request)
+        assert sat_var is not None
+
+        ctx.model.Add(ctx.person_bunk_assignment[0] != ctx.person_bunk_assignment[1])
+        ctx.model.Add(sat_var == 0)
+
+        solver = cp_model.CpSolver()
+        status = solver.Solve(ctx.model)
+        assert status == cp_model.INFEASIBLE
+
+
+class TestMemoization:
+    """The same request must yield one var, shared across callers."""
+
+    def test_second_call_returns_same_var(self):
+        c1 = create_person(cm_id=1001, first_name="Emma", last_name="Johnson", gender="F", grade=5)
+        c2 = create_person(cm_id=1002, first_name="Liam", last_name="Garcia", gender="F", grade=5)
+        bunk = create_bunk(cm_id=2001, name="G-1", gender="F", capacity=12)
+        request = create_request(
             request_id="req-1",
             requester_cm_id=1001,
             requested_cm_id=1002,
             request_type=RequestType.BUNK_WITH,
         )
-        request2 = create_request(
-            request_id="req-2",
-            requester_cm_id=1001,
-            requested_cm_id=1003,
-            request_type=RequestType.NOT_BUNK_WITH,
-        )
+        ctx = build_solver_context(persons=[c1, c2], bunks=[bunk], requests=[request])
 
-        ctx = build_solver_context(
-            persons=[camper1, camper2, camper3],
-            bunks=[bunk1, bunk2],
-            requests=[request1, request2],
-        )
+        first = get_or_create_request_sat_var(ctx, request)
+        second = get_or_create_request_sat_var(ctx, request)
 
-        # Create satisfaction variables
-        requests_by_person = {1001: [request1, request2]}
-        sat_vars = add_bunk_request_satisfaction_vars(ctx, requests_by_person)
-
-        # Maximize all satisfaction
-        assert 1001 in sat_vars
-        ctx.model.Maximize(sum(sat_vars[1001]))
-
-        # Solve
-        solver = cp_model.CpSolver()
-        status = solver.Solve(ctx.model)
-
-        assert is_optimal_or_feasible(status)
-
-        # Verify: Alice and Beth together, Carol separate
-        bunk1_idx = ctx.bunk_idx_map[2001]
-
-        alice_idx = ctx.person_idx_map[1001]
-        beth_idx = ctx.person_idx_map[1002]
-        carol_idx = ctx.person_idx_map[1003]
-
-        alice_bunk = 1 if solver.Value(ctx.assignments[(alice_idx, bunk1_idx)]) else 2
-        beth_bunk = 1 if solver.Value(ctx.assignments[(beth_idx, bunk1_idx)]) else 2
-        carol_bunk = 1 if solver.Value(ctx.assignments[(carol_idx, bunk1_idx)]) else 2
-
-        # Alice and Beth should be together
-        assert alice_bunk == beth_bunk
-        # Carol should be separate from Alice
-        assert alice_bunk != carol_bunk
+        assert first is second
+        assert ctx.request_satisfied_vars["req-1"] is first
+        assert len(ctx.request_satisfied_vars) == 1
 
 
-class TestRequestEdgeCases:
-    """Test edge cases for request handling."""
+class TestReturnsNone:
+    """Requests this builder cannot encode return None and register nothing."""
 
-    def test_request_with_no_requested_person(self):
-        """Request with None requested_person_cm_id is skipped."""
-        camper = create_person(cm_id=1001, first_name="Alice", last_name="Test", gender="F", grade=5)
+    def test_missing_target(self):
+        c1 = create_person(cm_id=1001, first_name="Emma", last_name="Johnson", gender="F", grade=5)
         bunk = create_bunk(cm_id=2001, name="G-1", gender="F", capacity=12)
-
         request = create_request(
             request_id="req-1",
             requester_cm_id=1001,
-            requested_cm_id=None,  # No target
+            requested_cm_id=None,
             request_type=RequestType.BUNK_WITH,
         )
+        ctx = build_solver_context(persons=[c1], bunks=[bunk], requests=[request])
 
-        ctx = build_solver_context(
-            persons=[camper],
-            bunks=[bunk],
-            requests=[request],
-        )
+        assert get_or_create_request_sat_var(ctx, request) is None
+        assert ctx.request_satisfied_vars == {}
 
-        # Create satisfaction variables
-        requests_by_person = {1001: [request]}
-        sat_vars = add_bunk_request_satisfaction_vars(ctx, requests_by_person)
-
-        # Should have no satisfaction vars
-        assert 1001 not in sat_vars or len(sat_vars.get(1001, [])) == 0
-
-    def test_requester_not_in_solver(self):
-        """Request from person not in solver is skipped."""
-        camper = create_person(cm_id=1001, first_name="Alice", last_name="Test", gender="F", grade=5)
+    def test_target_not_in_solver(self):
+        c1 = create_person(cm_id=1001, first_name="Emma", last_name="Johnson", gender="F", grade=5)
         bunk = create_bunk(cm_id=2001, name="G-1", gender="F", capacity=12)
-
         request = create_request(
             request_id="req-1",
-            requester_cm_id=9999,  # Not in context
-            requested_cm_id=1001,
+            requester_cm_id=1001,
+            requested_cm_id=9999,
             request_type=RequestType.BUNK_WITH,
         )
+        ctx = build_solver_context(persons=[c1], bunks=[bunk], requests=[request])
 
-        ctx = build_solver_context(
-            persons=[camper],
-            bunks=[bunk],
-            requests=[request],
+        assert get_or_create_request_sat_var(ctx, request) is None
+        assert ctx.request_satisfied_vars == {}
+
+    def test_unsupported_request_type(self):
+        c1 = create_person(cm_id=1001, first_name="Emma", last_name="Johnson", gender="F", grade=5)
+        c2 = create_person(cm_id=1002, first_name="Liam", last_name="Garcia", gender="F", grade=5)
+        bunk = create_bunk(cm_id=2001, name="G-1", gender="F", capacity=12)
+        request = create_request(
+            request_id="req-1",
+            requester_cm_id=1001,
+            requested_cm_id=1002,
+            request_type=RequestType.AGE_PREFERENCE,
         )
+        ctx = build_solver_context(persons=[c1, c2], bunks=[bunk], requests=[request])
 
-        # Create satisfaction variables
-        requests_by_person = {9999: [request]}
-        sat_vars = add_bunk_request_satisfaction_vars(ctx, requests_by_person)
-
-        # Should have no satisfaction vars
-        assert 9999 not in sat_vars
+        assert get_or_create_request_sat_var(ctx, request) is None
+        assert ctx.request_satisfied_vars == {}

--- a/tests/unit/bunking/solver/constraints/test_parent_paramount_hard_constraint.py
+++ b/tests/unit/bunking/solver/constraints/test_parent_paramount_hard_constraint.py
@@ -292,3 +292,31 @@ class TestParentParamountPartialImpossible:
         assert 100 not in ctx.mp_set_entirely_impossible, (
             "Camper with at least one possible MP request must NOT appear in mp_set_entirely_impossible"
         )
+
+
+class TestParentParamountSharesSatVarMap:
+    def test_mp_bunk_requests_registered_in_shared_map(self):
+        """parent_paramount must register MP bunk-request sat vars in the
+        shared ctx.request_satisfied_vars map (so add_objective can reuse
+        them instead of building duplicates)."""
+        camper1 = create_person(cm_id=100, first_name="Emma", last_name="Johnson", gender="F", grade=5)
+        camper2 = create_person(cm_id=200, first_name="Liam", last_name="Garcia", gender="F", grade=5)
+        bunk1 = create_bunk(cm_id=2001, name="G-1", gender="F", capacity=12)
+        bunk2 = create_bunk(cm_id=2002, name="G-2", gender="F", capacity=12)
+
+        req = _mp_request("r1", requester_cm_id=100, requested_cm_id=200)
+
+        ctx = build_solver_context(
+            persons=[camper1, camper2],
+            bunks=[bunk1, bunk2],
+            requests=[req],
+        )
+
+        from bunking.solver.constraints.parent_paramount import add_must_satisfy_one_request_constraints
+
+        add_must_satisfy_one_request_constraints(ctx)
+
+        assert "r1" in ctx.request_satisfied_vars, (
+            "parent_paramount must build MP bunk-request sat vars through the "
+            "shared get_or_create_request_sat_var builder"
+        )

--- a/tests/unit/solver/test_satvar_unification.py
+++ b/tests/unit/solver/test_satvar_unification.py
@@ -1,0 +1,79 @@
+"""Full-solver tests for #1395 sat-var unification.
+
+Asserts that bunk_with / not_bunk_with satisfaction vars are built once and
+shared between parent_paramount (hard MP constraint) and add_objective via
+the canonical `solver.request_satisfied_vars` map.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from bunking.solver.direct_solver import DirectBunkingSolver
+from tests.unit.solver.impossibility.conftest import (
+    make_bunk,
+    make_input,
+    make_person,
+)
+
+
+@pytest.fixture
+def mock_config() -> Any:
+    """ConfigLoader mock that forwards every typed getter to its `default=`.
+
+    Mirrors the proven fixture in tests/integration/solver/
+    test_taste_of_camp_feasible.py so add_constraints() + add_objective()
+    run cleanly without a real ConfigLoader.
+    """
+    # Forward-declared here; consumed by the add_constraints()/add_objective()
+    # tests added in later tasks of this plan.
+    cfg = MagicMock()
+
+    def _get_constraint(constraint_type: str, param: str, default: Any = None) -> Any:
+        if constraint_type == "grade_spread" and param == "max_spread":
+            return 2
+        return default if default is not None else 0
+
+    def _get_int(key: str, default: Any = None) -> Any:
+        return default if default is not None else 0
+
+    def _get_float(key: str, default: Any = None) -> Any:
+        return default if default is not None else 0.0
+
+    def _get_str(key: str, default: Any = None) -> Any:
+        if "grade_spread.mode" in key:
+            return "hard"
+        return default if default is not None else ""
+
+    def _get_bool(key: str, default: Any = None) -> Any:
+        return default if default is not None else False
+
+    def _get_priority(priority_type: str, subtype: str = "default") -> int:
+        return 4
+
+    def _get_soft_constraint_weight(constraint_name: str) -> int:
+        return 0
+
+    cfg.get_constraint.side_effect = _get_constraint
+    cfg.get_int.side_effect = _get_int
+    cfg.get_float.side_effect = _get_float
+    cfg.get_str.side_effect = _get_str
+    cfg.get_bool.side_effect = _get_bool
+    cfg.get_priority.side_effect = _get_priority
+    cfg.get_soft_constraint_weight.side_effect = _get_soft_constraint_weight
+    return cfg
+
+
+def test_solver_exposes_shared_request_satisfied_vars_map() -> None:
+    """DirectBunkingSolver owns a request_satisfied_vars dict, threaded
+    by-reference into every SolverContext it builds."""
+    persons = [make_person(1, session=1000, gender="F"), make_person(2, session=1000, gender="F")]
+    bunks = [make_bunk(100, session=1000, gender="F")]
+    solver = DirectBunkingSolver(make_input(persons, bunks, []), config_service=MagicMock())
+
+    assert solver.request_satisfied_vars == {}
+    ctx = solver._build_solver_context()
+    assert ctx.request_satisfied_vars is solver.request_satisfied_vars

--- a/tests/unit/solver/test_satvar_unification.py
+++ b/tests/unit/solver/test_satvar_unification.py
@@ -7,29 +7,59 @@ the canonical `solver.request_satisfied_vars` map.
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Generator
+from typing import Any, ClassVar
 from unittest.mock import MagicMock
 
 import pytest
 
+from bunking.config import ConfigLoader
 from bunking.solver.direct_solver import DirectBunkingSolver
 from tests.unit.solver.impossibility.conftest import (
     make_bunk,
     make_input,
     make_person,
+    make_request,
 )
+
+# ---------------------------------------------------------------------------
+# Minimal stub loader for penalty accessors that call ConfigLoader.get_instance()
+# directly (e.g. penalties.py::min_occupancy_penalty).
+# ---------------------------------------------------------------------------
+
+
+class _PenaltyStubLoader:
+    """Provides only the keys that penalties.py / grade_spread.py read via
+    ConfigLoader.get_instance(), returning sensible zero/stub values."""
+
+    # Extend when penalty helpers start reading new key types (get_str/get_constraint)
+    # via ConfigLoader.get_instance().
+    _values: ClassVar[dict[str, int]] = {
+        "constraint.cabin_minimum_occupancy.penalty": 0,
+        "constraint.grade_spread.penalty": 0,
+    }
+
+    def get_int(self, key: str, default: int | None = None) -> int:
+        v = self._values.get(key)
+        return int(v) if v is not None else (default if default is not None else 0)
+
+    def get_float(self, key: str, default: float | None = None) -> float:
+        v = self._values.get(key)
+        return float(v) if v is not None else (default if default is not None else 0.0)
 
 
 @pytest.fixture
-def mock_config() -> Any:
+def mock_config() -> Generator[Any]:
     """ConfigLoader mock that forwards every typed getter to its `default=`.
+
+    Also installs a _PenaltyStubLoader via ConfigLoader.use() so that
+    penalty helpers (penalties.py) that call ConfigLoader.get_instance()
+    directly work without a real PocketBase connection.
 
     Mirrors the proven fixture in tests/integration/solver/
     test_taste_of_camp_feasible.py so add_constraints() + add_objective()
     run cleanly without a real ConfigLoader.
     """
-    # Forward-declared here; consumed by the add_constraints()/add_objective()
-    # tests added in later tasks of this plan.
     cfg = MagicMock()
 
     def _get_constraint(constraint_type: str, param: str, default: Any = None) -> Any:
@@ -64,7 +94,9 @@ def mock_config() -> Any:
     cfg.get_bool.side_effect = _get_bool
     cfg.get_priority.side_effect = _get_priority
     cfg.get_soft_constraint_weight.side_effect = _get_soft_constraint_weight
-    return cfg
+
+    with ConfigLoader.use(_PenaltyStubLoader()):  # type: ignore[arg-type]
+        yield cfg
 
 
 def test_solver_exposes_shared_request_satisfied_vars_map() -> None:
@@ -77,3 +109,46 @@ def test_solver_exposes_shared_request_satisfied_vars_map() -> None:
     assert solver.request_satisfied_vars == {}
     ctx = solver._build_solver_context()
     assert ctx.request_satisfied_vars is solver.request_satisfied_vars
+
+
+def test_objective_registers_bunk_request_in_shared_map(mock_config: Any) -> None:
+    """add_objective routes bunk requests through the shared sat-var map.
+
+    Uses a non-MP bunk_with request (source_field=bunking_notes -> STAFF
+    bucket) so parent_paramount skips it -- only add_objective can put it
+    in the map.
+    """
+    persons = [make_person(1, session=1000, gender="F"), make_person(2, session=1000, gender="F")]
+    bunks = [make_bunk(100, session=1000, gender="F"), make_bunk(200, session=1000, gender="F")]
+    req = make_request("nr1", requester=1, requestee=2, request_type="bunk_with", source_field="bunking_notes")
+    solver = DirectBunkingSolver(make_input(persons, bunks, [req]), config_service=mock_config)
+
+    solver.add_constraints()
+    solver.add_objective()
+
+    assert "nr1" in solver.request_satisfied_vars
+
+
+def test_mp_objective_request_has_single_sat_var(mock_config: Any) -> None:
+    """An MP bunk request that is also objective-relevant gets exactly ONE
+    sat var, shared between parent_paramount and add_objective.
+
+    Proves both halves of the shared-var property:
+    - parent_paramount builds the var during add_constraints() (in the map).
+    - add_objective reuses it rather than building a duplicate (proto count 1).
+    """
+    persons = [make_person(1, session=1000, gender="F"), make_person(2, session=1000, gender="F")]
+    bunks = [make_bunk(100, session=1000, gender="F"), make_bunk(200, session=1000, gender="F")]
+    req = make_request("mr1", requester=1, requestee=2, request_type="bunk_with", source_field="bunk_with")
+    solver = DirectBunkingSolver(make_input(persons, bunks, [req]), config_service=mock_config)
+
+    solver.add_constraints()
+    # parent_paramount must have built the MP bunk_with sat var already.
+    assert "mr1" in solver.request_satisfied_vars
+
+    solver.add_objective()
+
+    var_names = [v.name for v in solver.model.Proto().variables]
+    assert var_names.count("req_satisfied_mr1") == 1, (
+        "MP objective request must have one shared sat var, not a parent_paramount copy plus an add_objective copy"
+    )


### PR DESCRIPTION
## What

Behavior-neutral refactor (#1395). `add_objective` and `parent_paramount` each built their own bidirectional satisfaction variable per `bunk_with`/`not_bunk_with` request — duplicates. This unifies them onto one shared, memoized, honest bidirectional sat var via a single canonical builder, and deletes an orphaned dead one-way helper.

## Changes

- **`get_or_create_request_sat_var`** (`bunking/solver/constraints/bunk_requests.py`) — new canonical builder. Memoized in a shared `ctx.request_satisfied_vars` map (`dict[str, IntVar]` keyed by `request.id`), bidirectional encoding via `person_bunk_assignment`. Replaces the orphaned one-way `add_bunk_request_satisfaction_vars` + its two `_create_*` helpers (dead code since #1391 removed `must_satisfy.py`, their only caller).
- **`parent_paramount`** and **`add_objective`** both now borrow from the shared map — whichever runs first builds the var, the second reuses it. `parent_paramount._build_bunk_request_forcing_var` deleted; `add_objective`'s inline encoding replaced.
- **`SolverContext` / `DirectBunkingSolver`** carry `request_satisfied_vars`, threaded by-reference through `_build_solver_context`. Exposed as `solver.request_satisfied_vars` — new post-solve surface.
- **`docs/reference/solver-roadmap.md`** — corrected stale Stream 1 / Stream 3 notes obsoleted by this change, including the factually-wrong "the objective rewarded [the falsifiable vars]" claim. The objective was never falsifiable — it always built its own bidirectional vars; the falsifiable one-way vars were only ever consumed by the now-deleted `must_satisfy.py`.

## Before/after — session 1235404 (192 persons / 528 requests / 17 bunks)

| Metric | Before (`main`) | After | Delta |
|---|---|---|---|
| model variables | 5552 | 5215 | **-337** |
| model constraints | 12734 | 12060 | **-674** (all `linear`) |
| reified constraints | 10386 | 9712 | **-674** |
| bool_and / bool_or / lin_max | 648 / 672 / 16 | 648 / 672 / 16 | identical |
| 30s solve | FEASIBLE, bound 167508 | FEASIBLE, bound 167508 | identical bound |

-337 duplicate BoolVars and exactly -674 reified linear constraints (337 x 2 — each eliminated duplicate was 1 BoolVar + 2 bidirectional reified implications). Identical best-bound, identical non-reified constraint counts, and FEASIBLE on both confirm the refactor is behavior-neutral; the -0.36% objective delta at a 30s wall budget is ordinary CP-SAT nondeterminism on a (now smaller) model.

## Testing

- `test_bunk_requests.py` (rewritten) — honesty tests proving the builder is bidirectional (a one-way encoding would make `sat_var=1` falsely FEASIBLE), memoization, all None-return paths.
- `test_satvar_unification.py` (new) — full-`DirectBunkingSolver` tests proving cross-consumer sharing: `parent_paramount` builds the MP var, `add_objective` reuses it (exactly one proto var per request). Uses a small `_PenaltyStubLoader` fixture because `add_objective`'s penalty helpers read config via the `ConfigLoader` singleton, bypassing the injected mock.
- `test_parent_paramount_hard_constraint.py` — added a shared-map registration test.
- Full unit suite green (4521 passed); ruff + mypy clean.

## Related

#1398 (golden alignment test between solve-time sat vars and post-solve predicate) can now read from the canonical `solver.request_satisfied_vars` map. The honesty tests here are a partial down-payment on that drift defense.

Closes #1395

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated bunk request satisfaction variable handling into a single canonical builder, eliminating duplicate logic across constraint modules and improving consistency across the solver.
  * Solver now maintains and exposes a shared satisfaction variable map (`request_satisfied_vars`) as the single source of truth for request satisfaction status.

* **Documentation**
  * Updated solver roadmap with corrected satisfaction variable behavior, clarified constraint architecture, and current model structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1427)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->