### PR TITLE
feat(solver): surface entirely-impossible MP campers in pre-check + fix Acceptable denominator

### DIFF
--- a/api/routers/solver.py
+++ b/api/routers/solver.py
@@ -521,6 +521,7 @@ async def pre_validate_solver(
                 "affected_campers": report.affected_campers,
                 "by_reason": {code: [asdict(item) for item in items] for code, items in report.by_reason.items()},
                 "flat": [asdict(item) for item in report.flat],
+                "mp_campers_entirely_impossible": report.mp_campers_entirely_impossible,
             },
             "session_breakdown": session_breakdown,
             "related_sessions": ctx.related_session_ids,

--- a/bunking/solver/constraints/bunk_requests.py
+++ b/bunking/solver/constraints/bunk_requests.py
@@ -201,7 +201,12 @@ class TargetNotInSolverImpossibility(HardConstraintImpossibility):
     name = "target_not_in_solver"
 
     def check_request(self, req: DirectBunkRequest, ctx: ImpossibilityContext) -> ImpossibilityReason | None:
-        if req.request_type not in ("bunk_with", "not_bunk_with"):
+        # bunk_with only — a not_bunk_with whose target is absent from the
+        # roster is trivially satisfied (they can never share a bunk), not
+        # impossible. Mirrors the satisfaction logic in bunking/satisfaction/
+        # predicate.py and the bunk_with-only guard in the gender/grade_spread/
+        # session_boundary predicates.
+        if req.request_type != "bunk_with":
             return None
         if not req.requested_person_cm_id:
             return None  # malformed — MalformedRequestImpossibility owns this

--- a/bunking/solver/constraints/bunk_requests.py
+++ b/bunking/solver/constraints/bunk_requests.py
@@ -195,3 +195,26 @@ class MalformedRequestImpossibility(HardConstraintImpossibility):
 
 
 register(MalformedRequestImpossibility())
+
+
+class TargetNotInSolverImpossibility(HardConstraintImpossibility):
+    name = "target_not_in_solver"
+
+    def check_request(self, req: DirectBunkRequest, ctx: ImpossibilityContext) -> ImpossibilityReason | None:
+        if req.request_type not in ("bunk_with", "not_bunk_with"):
+            return None
+        if not req.requested_person_cm_id:
+            return None  # malformed — MalformedRequestImpossibility owns this
+        if req.requested_person_cm_id in ctx.roster_cm_ids:
+            return None
+        return ImpossibilityReason(
+            code="target_not_in_solver",
+            message=(
+                f"Requested camper (cm_id {req.requested_person_cm_id}) is not "
+                f"enrolled in this session's solver roster."
+            ),
+            detail={"requested_person_cm_id": req.requested_person_cm_id},
+        )
+
+
+register(TargetNotInSolverImpossibility())

--- a/bunking/solver/constraints/parent_paramount.py
+++ b/bunking/solver/constraints/parent_paramount.py
@@ -61,8 +61,9 @@ def add_must_satisfy_one_request_constraints(ctx: SolverContext) -> None:
     separation, or clean-bunk depending on request type).
 
     Campers with no MP requests at all are skipped silently. Campers whose
-    every MP request is impossible (excluded from possible_requests but
-    present in the input) are recorded in ctx.mp_set_entirely_impossible.
+    every MP request is impossible are already recorded in
+    ctx.mp_set_entirely_impossible by _validate_requests; parent_paramount
+    reads this list for logging but does not modify it.
     """
     logger.info("=== Parent Paramount (Hard MP Must-Satisfy-One) Constraints ===")
     if ctx.is_constraint_disabled("parent_paramount"):
@@ -134,13 +135,11 @@ def add_must_satisfy_one_request_constraints(ctx: SolverContext) -> None:
             constraints_added += 1
             continue
 
-        # No forcing vars — did this camper have any MP requests at all?
-        all_requests = ctx.input.requests_by_person.get(person_cm_id, [])
-        if any(is_material_parent_request(r) for r in all_requests):
-            # Had MP requests but all were either impossible or malformed
-            ctx.mp_set_entirely_impossible.append(person_cm_id)
-            logger.debug(f"Camper {person_cm_id}: all MP requests impossible — no hard constraint added")
-        # else: no MP requests at all — silently skip
+        # No forcing vars built. Entirely-impossible MP campers are already
+        # recorded in ctx.mp_set_entirely_impossible by _validate_requests
+        # (single source of truth: validate_impossibility) — nothing to derive
+        # here. Campers with no MP requests at all also land here harmlessly.
+        logger.debug(f"Camper {person_cm_id}: no forcing vars built — no hard constraint added")
 
     # Step 4: end-of-build logging
     if ctx.mp_set_entirely_impossible:

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -223,17 +223,12 @@ class DirectBunkingSolver:
     def _validate_requests(self) -> None:
         """Classify requests as possible or impossible via the shared module.
 
-        Delegates to bunking.solver.impossibility.validate_impossibility,
-        which both this solver and api.routers.solver.pre_validate_solver
-        share. Populates self.possible_requests, self.impossible_requests,
-        and self.request_validation_summary from the structured report.
-
-        Fallback: any bunk_with/not_bunk_with request whose target is not
-        present in self.person_idx_map (i.e., the target person was not
-        supplied in the input at all) is classified as impossible under the
-        "target_not_in_solver" reason code. The shared predicates cannot
-        catch this case because they only see persons present in the input;
-        the solver-level person_idx_map is the authoritative membership set.
+        Delegates entirely to bunking.solver.impossibility.validate_impossibility,
+        which both this solver and api.routers.solver.pre_validate_solver share —
+        there is no longer any hand-rolled fallback, so the two paths cannot
+        drift. Populates self.possible_requests, self.impossible_requests,
+        self.mp_set_entirely_impossible, and self.request_validation_summary
+        from the structured report.
         """
         from bunking.solver.impossibility import validate_impossibility
 
@@ -253,24 +248,16 @@ class DirectBunkingSolver:
         self.impossibility_report = report
         impossible_request_ids: set[str] = {item.request_id for item in report.flat}
 
-        # Tally requests not caught by predicates but whose target is absent
-        # from person_idx_map — these must be classified impossible here.
-        target_not_in_solver_extra: set[str] = set()
-        for person_cm_id, requests in self.input.requests_by_person.items():
-            if person_cm_id not in self.person_idx_map:
-                continue
-            for request in requests:
-                if request.id in impossible_request_ids:
-                    continue
-                if request.request_type in (RequestType.BUNK_WITH.value, RequestType.NOT_BUNK_WITH.value):
-                    if request.requested_person_cm_id and request.requested_person_cm_id not in self.person_idx_map:
-                        target_not_in_solver_extra.add(request.id)
+        # Camper-level rollup of entirely-impossible MP sets — single source of
+        # truth (computed in validate_impossibility). parent_paramount reads this
+        # instead of re-deriving during constraint build.
+        self.mp_set_entirely_impossible.extend(entry["cm_id"] for entry in report.mp_campers_entirely_impossible)
 
         for person_cm_id, requests in self.input.requests_by_person.items():
             if person_cm_id not in self.person_idx_map:
                 continue
             for request in requests:
-                if request.id in impossible_request_ids or request.id in target_not_in_solver_extra:
+                if request.id in impossible_request_ids:
                     self.impossible_requests[person_cm_id].append(request)
                 else:
                     self.possible_requests[person_cm_id].append(request)
@@ -282,7 +269,6 @@ class DirectBunkingSolver:
         impossible_pairs: list[tuple[DirectBunkRequest, str]] = [
             (request_by_id[item.request_id], item.reason_code) for item in report.flat
         ]
-        impossible_pairs.extend((request_by_id[rid], "target_not_in_solver") for rid in target_not_in_solver_extra)
         # NB: impossible_by_reason (bucketed) drops requests with unknown source_field,
         # while total_impossible never does — the two are intentionally independent counts.
         impossible_by_reason = _build_impossible_by_reason_by_bucket(impossible_pairs)
@@ -292,26 +278,15 @@ class DirectBunkingSolver:
             for person_cm_id, reqs in self.input.requests_by_person.items()
             if person_cm_id in self.person_idx_map
         )
-        total_impossible = report.total_impossible + len(target_not_in_solver_extra)
-        # Build the union of cm_ids — a camper with one predicate-caught request
-        # AND one target-not-in-solver request must be counted ONCE.
-        flat_cmids: set[int] = {item.requester["cm_id"] for item in report.flat if item.requester.get("cm_id")}
-        extra_cmids: set[int] = {
-            request.requester_person_cm_id
-            for person_cm_id, requests in self.input.requests_by_person.items()
-            if person_cm_id in self.person_idx_map
-            for request in requests
-            if request.id in target_not_in_solver_extra
-        }
         self.request_validation_summary: dict[str, Any] = {
             "total_requests": total_requests,
-            "possible_requests": total_requests - total_impossible,
-            "impossible_requests": total_impossible,
+            "possible_requests": total_requests - report.total_impossible,
+            "impossible_requests": report.total_impossible,
             "impossible_by_reason": impossible_by_reason,
-            "affected_campers": len(flat_cmids | extra_cmids),
+            "affected_campers": report.affected_campers,
         }
 
-        if total_impossible > 0:
+        if report.total_impossible > 0:
             reason_summary = (
                 " ".join(
                     f"{bucket}.{reason}={count}"
@@ -323,7 +298,8 @@ class DirectBunkingSolver:
                 or "unclassified — impossible requests have missing/unknown source_field"
             )
             logger.warning(
-                f"Request validation: {total_impossible} of {total_requests} requests are infeasible ({reason_summary})"
+                f"Request validation: {report.total_impossible} of {total_requests} "
+                f"requests are infeasible ({reason_summary})"
             )
             logger.warning(f"Affected campers: {self.request_validation_summary['affected_campers']}")
 

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -1065,6 +1065,11 @@ class DirectBunkingSolver:
         all_campers_total = 0
         all_campers_satisfied = 0
 
+        # "Acceptable" (mp_camper_rate) denominator must exclude campers whose
+        # entire MP set is structurally impossible — they can never be satisfied,
+        # so counting them understates the solver-actionable rate.
+        impossible_request_ids: set[str] = {item.request_id for item in self.impossibility_report.flat}
+
         for person_cm_id, requests in self.input.requests_by_person.items():
             if person_cm_id not in person_to_bunk:
                 continue
@@ -1081,9 +1086,13 @@ class DirectBunkingSolver:
             mp_requests_total += len(resolved_mp)
             satisfied_mp = [r for r in resolved_mp if r.id in satisfied_ids_for_person]
             mp_requests_satisfied += len(satisfied_mp)
-            if resolved_mp:
+            # Camper-level "Acceptable" rate: denominator = campers with >=1
+            # POSSIBLE MP request; numerator gated to the same possible subset so
+            # mp_campers_satisfied is always <= mp_campers_total (no >100%).
+            resolved_possible_mp = [r for r in resolved_mp if r.id not in impossible_request_ids]
+            if resolved_possible_mp:
                 mp_campers_total += 1
-                if satisfied_mp:
+                if any(r.id in satisfied_ids_for_person for r in resolved_possible_mp):
                     mp_campers_satisfied += 1
             all_campers_total += 1
             if any(r.id in satisfied_ids_for_person for r in resolved_requests):
@@ -1113,8 +1122,9 @@ class DirectBunkingSolver:
         # Dashboard and alerting latch onto this key specifically.
         self.request_validation_summary["mp_constraint_bug_signal"] = len(material_parent_unmet)
         # Campers whose entire MP set was structurally impossible — the hard
-        # constraint was not added for them. Populated by parent_paramount
-        # during constraint build; surfaced here for dashboard visibility.
+        # constraint was not added for them. Populated by `_validate_requests`
+        # from the impossibility report (single source of truth); `parent_paramount`
+        # no longer re-derives it. Surfaced here for dashboard visibility.
         self.request_validation_summary["mp_set_entirely_impossible_count"] = len(self.mp_set_entirely_impossible)
         self.request_validation_summary["mp_set_entirely_impossible_cm_ids"] = list(self.mp_set_entirely_impossible)
 

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -249,8 +249,8 @@ class DirectBunkingSolver:
         impossible_request_ids: set[str] = {item.request_id for item in report.flat}
 
         # Camper-level rollup of entirely-impossible MP sets — single source of
-        # truth (computed in validate_impossibility). parent_paramount reads this
-        # instead of re-deriving during constraint build.
+        # truth (computed in validate_impossibility). parent_paramount no longer
+        # re-derives this during constraint build; it consumes this list directly.
         self.mp_set_entirely_impossible.extend(entry["cm_id"] for entry in report.mp_campers_entirely_impossible)
 
         for person_cm_id, requests in self.input.requests_by_person.items():

--- a/bunking/solver/impossibility.py
+++ b/bunking/solver/impossibility.py
@@ -198,7 +198,7 @@ def validate_impossibility(input_data: DirectSolverInput, config: ConfigLoader) 
     # constraint. Pure derived property of `flat` — single source of truth for
     # both parent_paramount and the pre-validate endpoint. Local import keeps
     # the satisfaction package off impossibility.py's import-time graph.
-    from bunking.satisfaction.bucket import is_material_parent_request  # noqa: PLC0415
+    from bunking.satisfaction.bucket import is_material_parent_request
 
     impossible_ids = {item.request_id for item in report.flat}
     reasons_by_request: dict[str, set[str]] = defaultdict(set)

--- a/bunking/solver/impossibility.py
+++ b/bunking/solver/impossibility.py
@@ -42,6 +42,10 @@ class ImpossibilityContext:
     person_by_cm_id: dict[int, DirectPerson]
     person_session: dict[int, int]
     bunks_by_session: dict[int, list[DirectBunk]]
+    # The solver roster: every person cm_id present in the input. Equals
+    # person_by_cm_id.keys(); kept as an explicit set so membership-test intent
+    # ("is this requestee in the solver?") reads clearly in predicates.
+    roster_cm_ids: frozenset[int]
 
 
 @dataclass
@@ -133,6 +137,7 @@ def _build_context(input_data: DirectSolverInput, config: ConfigLoader) -> Impos
         person_by_cm_id=person_by_cm_id,
         person_session=person_session,
         bunks_by_session=dict(bunks_by_session),
+        roster_cm_ids=frozenset(person_by_cm_id),
     )
 
 

--- a/bunking/solver/impossibility.py
+++ b/bunking/solver/impossibility.py
@@ -65,6 +65,10 @@ class ImpossibilityReport:
     affected_campers: int = 0
     by_reason: dict[str, list[ImpossibleItem]] = field(default_factory=dict)
     flat: list[ImpossibleItem] = field(default_factory=list)
+    # Camper-level rollup: roster campers whose ENTIRE Material-Parent request
+    # set is impossible. Each entry: {cm_id, name, grade, gender, reason_codes}.
+    # Derived from `flat` — see validate_impossibility.
+    mp_campers_entirely_impossible: list[dict[str, Any]] = field(default_factory=list)
 
 
 class HardConstraintImpossibility:
@@ -188,6 +192,35 @@ def validate_impossibility(input_data: DirectSolverInput, config: ConfigLoader) 
     # ONE impossible request, not N. Same for the affected-campers headline.
     report.total_impossible = len({item.request_id for item in report.flat})
     report.affected_campers = len({item.requester.get("cm_id") for item in report.flat if item.requester.get("cm_id")})
+
+    # Camper-level rollup: a roster camper whose ENTIRE Material-Parent request
+    # set is impossible gets zero parent requests honored under the hard MP
+    # constraint. Pure derived property of `flat` — single source of truth for
+    # both parent_paramount and the pre-validate endpoint. Local import keeps
+    # the satisfaction package off impossibility.py's import-time graph.
+    from bunking.satisfaction.bucket import is_material_parent_request  # noqa: PLC0415
+
+    impossible_ids = {item.request_id for item in report.flat}
+    reasons_by_request: dict[str, set[str]] = defaultdict(set)
+    for item in report.flat:
+        reasons_by_request[item.request_id].add(item.reason_code)
+
+    for cm_id, requests in input_data.requests_by_person.items():
+        person = ctx.person_by_cm_id.get(cm_id)
+        if person is None:
+            continue  # requester not in the roster — out of scope
+        mp_requests = [r for r in requests if is_material_parent_request(r)]
+        if not mp_requests:
+            continue
+        if not all(r.id in impossible_ids for r in mp_requests):
+            continue  # >=1 possible MP request — solver-actionable, not "entirely impossible"
+        reason_codes: set[str] = set()
+        for r in mp_requests:
+            reason_codes |= reasons_by_request.get(r.id, set())
+        entry = _camper_dict(person)
+        entry["reason_codes"] = sorted(reason_codes)
+        report.mp_campers_entirely_impossible.append(entry)
+
     return report
 
 

--- a/docs/reference/solver-roadmap.md
+++ b/docs/reference/solver-roadmap.md
@@ -712,10 +712,24 @@ check feasibility") as insurance against drift. ~0.1s per probe; only
 runs on the residual 5-10%. Effort: medium. Mitigated today by
 `test_registry.py`; consider only if drift becomes a real issue.
 
+**Stream 6g — entirely-impossible MP camper pre-check visibility (shipped).**
+Promoted `target_not_in_solver` from a hand-rolled `_validate_requests` fallback
+to a registered `TargetNotInSolverImpossibility` predicate (closing the
+pre-validate ↔ `_validate_requests` drift). Added a derived
+`ImpossibilityReport.mp_campers_entirely_impossible` field computed in
+`validate_impossibility` — single source of truth; `parent_paramount` and
+`_validate_requests` consume it instead of re-deriving. Surfaced in the
+`/solver/pre-validate` response and both impossibility modals as a camper-level
+"will get zero parent requests honored" section. Also fixed the `mp_camper_rate`
+("Acceptable") denominator to count only campers with ≥1 *possible* MP request,
+and fixed a latent bug where `feasibility.py` read `mp_set_entirely_impossible`
+before it was populated. Audit follow-up: #1426.
+
 ### GitHub issues
 
 Framework + initial predicates ship in #1391. Substreams 6a–6f to be
-filed as separate issues if/when prioritized.
+filed as separate issues if/when prioritized. Stream 6g shipped in a
+follow-up PR; audit follow-up tracked in #1426.
 
 ---
 
@@ -821,3 +835,7 @@ diffs are clearer.
   extended with staff-friendly prose vs admin-detail views. Substreams
   6a–6f (level_progression, group_locks, per-bunk grade range, cohort
   census, "open request" link, solver-probe fallback) deferred.
+- **2026-05-14** — Stream 6g shipped: `target_not_in_solver` promoted to a
+  registered predicate; `mp_campers_entirely_impossible` rollup added to
+  `ImpossibilityReport`; `mp_camper_rate` denominator corrected. Filed #1426 to
+  audit `direct_solver` for other hand-rolled impossibility logic.

--- a/frontend/src/components/PreValidationResultsModal.test.tsx
+++ b/frontend/src/components/PreValidationResultsModal.test.tsx
@@ -413,6 +413,46 @@ describe('PreValidationResultsModal — staff-only view', () => {
     expect(screen.getByText(/Riley Raines/)).toBeInTheDocument()
   })
 
+  it('renders friendly label + subtext for target_not_in_solver (requestee is null)', () => {
+    const results = {
+      ...baseResults,
+      impossibility_report: {
+        total_impossible: 1,
+        affected_campers: 1,
+        by_reason: {
+          target_not_in_solver: [
+            {
+              request_id: 'br_ghost',
+              reason_code: 'target_not_in_solver',
+              reason_message: 'requested camper not enrolled',
+              request_type: 'bunk_with',
+              requester: { name: 'Emma Johnson', cm_id: 30, grade: 5, gender: 'F' },
+              requestee: null,
+              detail: { requested_person_cm_id: 99999 },
+            },
+          ],
+        },
+        flat: [],
+      } as unknown as import('../services/solver').ImpossibilityReport,
+    }
+
+    render(
+      <PreValidationResultsModal
+        isOpen
+        onClose={() => {}}
+        results={results}
+        sessionLookup={noopSessionLookup}
+      />
+    )
+
+    // Section header uses the friendly label, never the raw snake_case code.
+    expect(screen.queryByText('target_not_in_solver')).not.toBeInTheDocument()
+    expect(screen.getByText(/friend not enrolled/i)).toBeInTheDocument()
+    // Subtext explains the situation even though requestee is null — staff get
+    // an actionable line instead of a bare requester name.
+    expect(screen.getByText(/isn['’]t enrolled in this session/i)).toBeInTheDocument()
+  })
+
   it('does not render cluster_grade_compatibility reason code (clusters removed)', () => {
     // clusters field is no longer part of ImpossibilityReport; this verifies
     // the modal renders cleanly with no cluster-related output

--- a/frontend/src/components/PreValidationResultsModal.test.tsx
+++ b/frontend/src/components/PreValidationResultsModal.test.tsx
@@ -466,3 +466,60 @@ describe('PreValidationResultsModal — staff-only view', () => {
     expect(friendlyLabels).toHaveLength(1)
   })
 })
+
+describe('PreValidationResultsModal — entirely-impossible MP campers', () => {
+  it('renders a camper-level section with action hints by reason code', () => {
+    const results = {
+      ...baseResults,
+      impossibility_report: {
+        total_impossible: 2,
+        affected_campers: 2,
+        by_reason: {},
+        flat: [],
+        mp_campers_entirely_impossible: [
+          {
+            cm_id: 1,
+            name: 'Emma Johnson',
+            grade: 5,
+            gender: 'F',
+            reason_codes: ['target_not_in_solver'],
+          },
+          {
+            cm_id: 2,
+            name: 'Liam Garcia',
+            grade: 6,
+            gender: 'M',
+            reason_codes: ['grade_compatibility'],
+          },
+        ],
+      } as unknown as import('../services/solver').ImpossibilityReport,
+    }
+
+    render(
+      <PreValidationResultsModal
+        isOpen
+        onClose={() => {}}
+        results={results}
+        sessionLookup={noopSessionLookup}
+      />
+    )
+
+    expect(screen.getByText(/zero parent requests honored/i)).toBeInTheDocument()
+    expect(screen.getByText(/Emma Johnson/)).toBeInTheDocument()
+    expect(screen.getByText(/confirm enrollment/i)).toBeInTheDocument()
+    expect(screen.getByText(/Liam Garcia/)).toBeInTheDocument()
+    expect(screen.getByText(/fix parent input/i)).toBeInTheDocument()
+  })
+
+  it('renders no camper-level section when the rollup is empty', () => {
+    render(
+      <PreValidationResultsModal
+        isOpen
+        onClose={() => {}}
+        results={baseResults}
+        sessionLookup={noopSessionLookup}
+      />
+    )
+    expect(screen.queryByText(/zero parent requests honored/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/PreValidationResultsModal.tsx
+++ b/frontend/src/components/PreValidationResultsModal.tsx
@@ -11,7 +11,11 @@ import {
   Sparkles,
 } from 'lucide-react'
 import { Modal } from './ui/Modal'
-import type { ImpossibilityReport, ImpossibilityReportItem } from '../services/solver'
+import type {
+  ImpossibilityReport,
+  ImpossibilityReportItem,
+  EntirelyImpossibleMpCamper,
+} from '../services/solver'
 
 interface CapacityBreakdownItem {
   campers: number
@@ -140,6 +144,41 @@ const FRIENDLY_REASON_LABELS: Record<string, string> = {
 
 function friendlyReasonLabel(code: string): string {
   return FRIENDLY_REASON_LABELS[code] || code
+}
+
+// Camper-level action hint: target_not_in_solver means the named friend isn't
+// enrolled (confirm enrollment); any other reason means the request itself is
+// the problem (fix parent input).
+function camperActionHints(reasonCodes: string[]): string {
+  const hints = new Set<string>()
+  for (const code of reasonCodes) {
+    hints.add(code === 'target_not_in_solver' ? 'confirm enrollment' : 'fix parent input')
+  }
+  return Array.from(hints).join(' / ')
+}
+
+function EntirelyImpossibleMpSection({ campers }: { campers: EntirelyImpossibleMpCamper[] }) {
+  if (campers.length === 0) return null
+  return (
+    <details open className="rounded-lg border border-red-200 bg-red-50 p-3">
+      <summary className="flex cursor-pointer list-none items-center justify-between font-semibold text-red-900 [&::-webkit-details-marker]:hidden">
+        <span>{campers.length} camper(s) will get zero parent requests honored</span>
+        <span className="rounded-full bg-red-400 px-2 py-0.5 text-xs font-bold text-white">
+          {campers.length}
+        </span>
+      </summary>
+      <div className="mt-2 space-y-2 border-t border-red-200 pt-2">
+        {campers.map((c) => (
+          <div key={c.cm_id} className="text-sm">
+            <div className="font-medium">
+              {c.name} ({c.gender}) · {ordinalGrade(c.grade)}
+            </div>
+            <div className="text-xs text-stone-600">{camperActionHints(c.reason_codes)}</div>
+          </div>
+        ))}
+      </div>
+    </details>
+  )
 }
 
 function ordinalGrade(grade: number): string {
@@ -493,6 +532,9 @@ export default function PreValidationResultsModal({
 
       {/* Impossibility Report — staff view */}
       <div className="space-y-3 px-5 py-4">
+        <EntirelyImpossibleMpSection
+          campers={impossibility_report.mp_campers_entirely_impossible ?? []}
+        />
         {impossibility_report.total_impossible === 0 ? (
           <div className="rounded-lg border border-green-200 bg-green-50 p-4 text-green-800">
             <CheckCircle2 className="mr-2 inline-block h-5 w-5" />

--- a/frontend/src/components/PreValidationResultsModal.tsx
+++ b/frontend/src/components/PreValidationResultsModal.tsx
@@ -140,6 +140,7 @@ const FRIENDLY_REASON_LABELS: Record<string, string> = {
   pair_no_shared_bunk: "Can't share a cabin",
   age_pref_no_eligible_grade: 'No matching age group available',
   malformed: 'Incomplete request',
+  target_not_in_solver: 'Friend not enrolled',
 }
 
 function friendlyReasonLabel(code: string): string {
@@ -269,6 +270,15 @@ function renderSubtext(
       return (
         <div className="text-xs text-stone-600">
           <strong>Incomplete request</strong> — form is missing who they want to bunk with
+        </div>
+      )
+
+    case 'target_not_in_solver':
+      // requestee is null here — the named friend isn't on the roster, so we
+      // have no person record to render. Give staff the actionable line.
+      return (
+        <div className="text-xs text-stone-600">
+          Requested friend isn&rsquo;t enrolled in this session
         </div>
       )
 

--- a/frontend/src/components/SolverDebugImpossibilityModal.test.tsx
+++ b/frontend/src/components/SolverDebugImpossibilityModal.test.tsx
@@ -124,8 +124,15 @@ describe('SolverDebugImpossibilityModal — entirely-impossible MP campers', () 
     )
 
     expect(screen.getByText(/entirely-impossible MP campers/i)).toBeInTheDocument()
+    // Copy reads "honored" — "honorable" is ungrammatical here.
+    expect(screen.getByText(/zero parent requests honored/i)).toBeInTheDocument()
+    expect(screen.queryByText(/honorable/i)).not.toBeInTheDocument()
     expect(screen.getByText(/Emma Johnson/)).toBeInTheDocument()
-    expect(screen.getByText('target_not_in_solver')).toBeInTheDocument()
+    const chip = screen.getByText('target_not_in_solver')
+    expect(chip).toBeInTheDocument()
+    // target_not_in_solver has an explicit (red-tier) chip style, not the
+    // neutral gray fallback.
+    expect(chip).toHaveStyle({ background: '#fee2e2' })
   })
 })
 

--- a/frontend/src/components/SolverDebugImpossibilityModal.test.tsx
+++ b/frontend/src/components/SolverDebugImpossibilityModal.test.tsx
@@ -95,6 +95,40 @@ describe('SolverDebugImpossibilityModal — sortable header a11y', () => {
   })
 })
 
+describe('SolverDebugImpossibilityModal — entirely-impossible MP campers', () => {
+  it('renders a compact camper-level block with reason chips', () => {
+    const report = {
+      total_impossible: 1,
+      affected_campers: 1,
+      by_reason: {},
+      flat: [],
+      mp_campers_entirely_impossible: [
+        {
+          cm_id: 1,
+          name: 'Emma Johnson',
+          grade: 5,
+          gender: 'F',
+          reason_codes: ['target_not_in_solver'],
+        },
+      ],
+    } as unknown as import('../services/solver').ImpossibilityReport
+
+    render(
+      <SolverDebugImpossibilityModal
+        isOpen
+        onClose={() => {}}
+        report={report}
+        sessionCmId={1000001}
+        year={2026}
+      />
+    )
+
+    expect(screen.getByText(/entirely-impossible MP campers/i)).toBeInTheDocument()
+    expect(screen.getByText(/Emma Johnson/)).toBeInTheDocument()
+    expect(screen.getByText('target_not_in_solver')).toBeInTheDocument()
+  })
+})
+
 // C2 — new desired behavior: Copy JSON button writes pretty-printed JSON to clipboard
 describe('SolverDebugImpossibilityModal — C2: Copy JSON button', () => {
   it('Copy JSON button writes JSON.stringify(report, null, 2) to clipboard', () => {

--- a/frontend/src/components/SolverDebugImpossibilityModal.tsx
+++ b/frontend/src/components/SolverDebugImpossibilityModal.tsx
@@ -8,6 +8,7 @@ const REASON_CHIP_STYLES: Record<string, { bg: string; text: string }> = {
   malformed: { bg: '#fef3c7', text: '#92400e' },
   cross_session: { bg: '#fee2e2', text: '#991b1b' },
   pair_no_shared_bunk: { bg: '#fee2e2', text: '#991b1b' },
+  target_not_in_solver: { bg: '#fee2e2', text: '#991b1b' },
 }
 
 function reasonChipStyle(code: string) {
@@ -157,7 +158,7 @@ export default function SolverDebugImpossibilityModal({
           report.mp_campers_entirely_impossible.length > 0 && (
             <div className="mb-4 rounded-md border border-red-300 bg-red-50 p-3">
               <div className="text-xs font-bold text-red-900">
-                {`${report.mp_campers_entirely_impossible.length} entirely-impossible MP campers — zero parent requests honorable`}
+                {`${report.mp_campers_entirely_impossible.length} entirely-impossible MP campers — zero parent requests honored`}
               </div>
               <div className="mt-2 space-y-1">
                 {report.mp_campers_entirely_impossible.map((c) => (

--- a/frontend/src/components/SolverDebugImpossibilityModal.tsx
+++ b/frontend/src/components/SolverDebugImpossibilityModal.tsx
@@ -153,6 +153,35 @@ export default function SolverDebugImpossibilityModal({
   return (
     <Modal isOpen={isOpen} onClose={onClose} header={headerContent} size="xl" scrollable noPadding>
       <div className="px-5 py-4 font-mono">
+        {report.mp_campers_entirely_impossible &&
+          report.mp_campers_entirely_impossible.length > 0 && (
+            <div className="mb-4 rounded-md border border-red-300 bg-red-50 p-3">
+              <div className="text-xs font-bold text-red-900">
+                {`${report.mp_campers_entirely_impossible.length} entirely-impossible MP campers — zero parent requests honorable`}
+              </div>
+              <div className="mt-2 space-y-1">
+                {report.mp_campers_entirely_impossible.map((c) => (
+                  <div key={c.cm_id} className="flex items-center gap-2 text-xs">
+                    <span className="text-stone-700">
+                      {c.name} ({c.cm_id}/g{c.grade}/{c.gender})
+                    </span>
+                    {c.reason_codes.map((code) => {
+                      const chip = reasonChipStyle(code)
+                      return (
+                        <span
+                          key={code}
+                          className="rounded-full px-2 py-0.5 text-[10px] font-semibold"
+                          style={{ background: chip.bg, color: chip.text }}
+                        >
+                          {code}
+                        </span>
+                      )
+                    })}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         {empty ? (
           <div className="rounded-md bg-green-50 p-3 text-xs text-green-800">
             // impossibility_report empty — no issues detected

--- a/frontend/src/services/solver.ts
+++ b/frontend/src/services/solver.ts
@@ -61,11 +61,20 @@ export interface ImpossibilityReportItem {
   detail: Record<string, unknown>
 }
 
+export interface EntirelyImpossibleMpCamper {
+  cm_id: number
+  name: string
+  grade: number
+  gender: string
+  reason_codes: string[]
+}
+
 export interface ImpossibilityReport {
   total_impossible: number
   affected_campers: number
   by_reason: Record<string, ImpossibilityReportItem[]>
   flat: ImpossibilityReportItem[]
+  mp_campers_entirely_impossible?: EntirelyImpossibleMpCamper[]
 }
 
 interface ValidationResult {

--- a/tests/unit/api/routers/test_pre_validate_endpoint.py
+++ b/tests/unit/api/routers/test_pre_validate_endpoint.py
@@ -50,6 +50,7 @@ class _FakeReport:
     by_reason: dict[str, object] = field(default_factory=dict)
     flat: list[object] = field(default_factory=list)
     clusters: list[object] = field(default_factory=list)
+    mp_campers_entirely_impossible: list[dict[str, object]] = field(default_factory=list)
 
 
 def _make_session_ctx(session_cm_id: int = 1000001, year: int = 2026) -> MagicMock:
@@ -240,3 +241,43 @@ def test_capacity_breakdown_uses_actual_bunk_capacities(client: TestClient) -> N
     assert breakdown["boys"]["beds"] == 18, breakdown
     assert breakdown["girls"]["beds"] == 14, breakdown
     assert breakdown["ag"]["beds"] == 6, breakdown
+
+
+def test_response_includes_mp_campers_entirely_impossible(client: TestClient) -> None:
+    """The /solver/pre-validate response surfaces the camper-level MP rollup."""
+    fake_report = _FakeReport(
+        total_impossible=1,
+        affected_campers=1,
+        mp_campers_entirely_impossible=[
+            {
+                "cm_id": 1,
+                "name": "Emma Johnson",
+                "grade": 5,
+                "gender": "F",
+                "reason_codes": ["target_not_in_solver"],
+            },
+        ],
+    )
+    with (
+        patch("api.routers.solver.pb", _mock_pb()),
+        patch("api.routers.solver.build_session_context", new_callable=AsyncMock) as mock_build_ctx,
+        patch("api.routers.solver.fetch_session_data_v2", new_callable=AsyncMock) as mock_fetch,
+        patch("api.routers.solver.prepare_direct_solver_input") as mock_prepare,
+        patch("api.routers.solver.validate_impossibility") as mock_validate,
+        patch("api.routers.solver.ConfigLoader") as mock_config,
+    ):
+        _apply_standard_mocks(mock_build_ctx, mock_fetch, mock_prepare, mock_validate, mock_config, report=fake_report)
+        resp = client.post("/api/solver/pre-validate", json=_PAYLOAD)
+
+    assert resp.status_code == 200, resp.text
+    ir = resp.json()["impossibility_report"]
+    assert "mp_campers_entirely_impossible" in ir
+    assert ir["mp_campers_entirely_impossible"] == [
+        {
+            "cm_id": 1,
+            "name": "Emma Johnson",
+            "grade": 5,
+            "gender": "F",
+            "reason_codes": ["target_not_in_solver"],
+        },
+    ]

--- a/tests/unit/bunking/solver/constraints/test_parent_paramount_hard_constraint.py
+++ b/tests/unit/bunking/solver/constraints/test_parent_paramount_hard_constraint.py
@@ -168,8 +168,9 @@ class TestParentParamountSkipsAllImpossibleMP:
         """Camper has MP requests in input.requests_by_person but NONE are in
         ctx.possible_requests (all classified impossible).
 
-        No hard constraint should be added; ctx.mp_set_entirely_impossible
-        should contain the camper's cm_id.
+        No hard constraint should be added. ctx.mp_set_entirely_impossible is
+        pre-populated by _validate_requests (single source of truth); parent_paramount
+        must NOT re-derive it — it just consumes the pre-populated list unchanged.
         """
         camper1 = create_person(cm_id=100, first_name="Ava", last_name="Martinez", gender="F", grade=5)
         camper2 = create_person(cm_id=200, first_name="Ethan", last_name="Brown", gender="F", grade=5)
@@ -188,6 +189,10 @@ class TestParentParamountSkipsAllImpossibleMP:
         ctx.possible_requests[100] = []
         ctx.impossible_requests[100] = [req]
 
+        # Simulate _validate_requests having already recorded camper 100 as
+        # entirely-impossible (Task 4 made _validate_requests the single source of truth).
+        ctx.mp_set_entirely_impossible.append(100)
+
         from bunking.solver.constraints.parent_paramount import add_must_satisfy_one_request_constraints
 
         add_must_satisfy_one_request_constraints(ctx)
@@ -201,7 +206,8 @@ class TestParentParamountSkipsAllImpossibleMP:
         assert is_optimal_or_feasible(status), "No hard constraint should be added when all MP requests are impossible"
 
         assert 100 in ctx.mp_set_entirely_impossible, (
-            "Camper whose entire MP set is impossible must be recorded in mp_set_entirely_impossible"
+            "Camper pre-seeded as entirely-impossible must still be in mp_set_entirely_impossible "
+            "(parent_paramount must not clear or modify the list)"
         )
 
 
@@ -292,3 +298,29 @@ class TestParentParamountPartialImpossible:
         assert 100 not in ctx.mp_set_entirely_impossible, (
             "Camper with at least one possible MP request must NOT appear in mp_set_entirely_impossible"
         )
+
+
+def test_parent_paramount_does_not_rederive_entirely_impossible_set():
+    """mp_set_entirely_impossible is pre-populated by _validate_requests now.
+    parent_paramount must NOT append to it again (which would double-count)."""
+    p1 = create_person(cm_id=1, first_name="Emma", last_name="Johnson", gender="F", grade=5)
+    p2 = create_person(cm_id=2, first_name="Liam", last_name="Garcia", gender="F", grade=5)
+    bunks = [create_bunk(cm_id=10, name="G-1", gender="F")]
+    # Camper 1 has one MP request; we simulate it being impossible by clearing
+    # possible_requests for camper 1 after construction.
+    mp_req = _mp_request("r1", requester_cm_id=1, requested_cm_id=2)
+    ctx = build_solver_context(persons=[p1, p2], bunks=bunks, requests=[mp_req])
+    ctx.possible_requests = {}  # camper 1's MP request is impossible
+
+    # Simulate _validate_requests having already recorded camper 1.
+    ctx.mp_set_entirely_impossible.append(1)
+
+    from bunking.solver.constraints.parent_paramount import add_must_satisfy_one_request_constraints
+
+    add_must_satisfy_one_request_constraints(ctx)
+
+    # parent_paramount must leave the pre-populated list untouched — exactly [1].
+    assert ctx.mp_set_entirely_impossible == [1], (
+        "parent_paramount must not re-append camper 1 — mp_set_entirely_impossible should remain [1], "
+        f"got {ctx.mp_set_entirely_impossible}"
+    )

--- a/tests/unit/solver/impossibility/test_convergence.py
+++ b/tests/unit/solver/impossibility/test_convergence.py
@@ -43,3 +43,29 @@ def test_validate_impossibility_matches_solver_classification(mock_config):
     assert "r2" in standalone_ids
     # r3 is feasible (consecutive grades)
     assert "r3" not in standalone_ids
+
+
+def test_target_not_in_solver_no_drift(mock_config):
+    """A bunk_with to a requestee absent from the roster must be classified
+    impossible identically by the standalone validator and the solver.
+
+    Before target_not_in_solver was a predicate this drifted: the solver's
+    hand-rolled fallback caught it but validate_impossibility (and therefore
+    the /solver/pre-validate endpoint) did not.
+    """
+    p1 = make_person(1, session=1000001, gender="F", grade=5)
+    bunks = [make_bunk(10, session=1000001, gender="F", capacity=12)]
+    # r_ghost targets cm_id 777, who is NOT in the persons list.
+    requests = [make_request("r_ghost", requester=1, requestee=777, session=1000001)]
+    input_data = make_input([p1], bunks, requests)
+
+    standalone_report = validate_impossibility(input_data, mock_config)
+    standalone_ids = {item.request_id for item in standalone_report.flat}
+
+    solver = DirectBunkingSolver(input_data, mock_config)
+    solver_ids: set[str] = set()
+    for reqs in solver.impossible_requests.values():
+        solver_ids.update(r.id for r in reqs)
+
+    assert "r_ghost" in standalone_ids, "validate_impossibility missed target_not_in_solver"
+    assert standalone_ids == solver_ids, f"Drift. Standalone: {standalone_ids}. Solver: {solver_ids}."

--- a/tests/unit/solver/impossibility/test_mp_campers_entirely_impossible.py
+++ b/tests/unit/solver/impossibility/test_mp_campers_entirely_impossible.py
@@ -1,0 +1,58 @@
+"""ImpossibilityReport.mp_campers_entirely_impossible — camper-level MP rollup."""
+
+from __future__ import annotations
+
+from bunking.solver.impossibility import validate_impossibility
+
+from .conftest import make_bunk, make_input, make_person, make_request
+
+
+def test_camper_with_all_mp_requests_impossible_is_listed(mock_config):
+    """A camper whose every MP request is impossible appears in the rollup,
+    with the distinct reason codes that hit their MP requests."""
+    p1 = make_person(1, session=1000001, gender="F", grade=5)
+    bunks = [make_bunk(10, session=1000001, gender="F", capacity=12)]
+    # Camper 1's only MP request (source_field=bunk_with -> MATERIAL_PARENT
+    # bucket) targets cm_id 777, absent from the roster -> target_not_in_solver.
+    requests = [make_request("r1", requester=1, requestee=777, session=1000001)]
+    input_data = make_input([p1], bunks, requests)
+
+    report = validate_impossibility(input_data, mock_config)
+
+    entries = report.mp_campers_entirely_impossible
+    assert len(entries) == 1
+    assert entries[0]["cm_id"] == 1
+    assert entries[0]["name"]  # non-empty display name
+    assert entries[0]["reason_codes"] == ["target_not_in_solver"]
+
+
+def test_camper_with_one_possible_mp_request_is_not_listed(mock_config):
+    """If at least one MP request is possible, the camper is solver-actionable
+    and must NOT appear in the rollup."""
+    p1 = make_person(1, session=1000001, gender="F", grade=5)
+    p2 = make_person(2, session=1000001, gender="F", grade=5)
+    bunks = [make_bunk(10, session=1000001, gender="F", capacity=12)]
+    requests = [
+        make_request("r_ok", requester=1, requestee=2, session=1000001),  # possible
+        make_request("r_bad", requester=1, requestee=777, session=1000001),  # impossible
+    ]
+    input_data = make_input([p1, p2], bunks, requests)
+
+    report = validate_impossibility(input_data, mock_config)
+
+    assert report.mp_campers_entirely_impossible == []
+
+
+def test_camper_with_no_mp_requests_is_not_listed(mock_config):
+    """A camper with no MP requests at all is not 'entirely impossible'."""
+    p1 = make_person(1, session=1000001, gender="F", grade=5)
+    bunks = [make_bunk(10, session=1000001, gender="F", capacity=12)]
+    # source_field="bunking_notes" -> STAFF bucket, NOT material-parent.
+    requests = [
+        make_request("r1", requester=1, requestee=777, source_field="bunking_notes", session=1000001),
+    ]
+    input_data = make_input([p1], bunks, requests)
+
+    report = validate_impossibility(input_data, mock_config)
+
+    assert report.mp_campers_entirely_impossible == []

--- a/tests/unit/solver/impossibility/test_registry.py
+++ b/tests/unit/solver/impossibility/test_registry.py
@@ -16,6 +16,7 @@ EXPECTED_HARD_PREDICATES = {
     "malformed",
     "age_preference",
     "grade_compatibility",
+    "target_not_in_solver",
 }
 
 

--- a/tests/unit/solver/impossibility/test_target_not_in_solver.py
+++ b/tests/unit/solver/impossibility/test_target_not_in_solver.py
@@ -1,0 +1,19 @@
+"""TargetNotInSolverImpossibility: bunk_with/not_bunk_with to a non-roster requestee."""
+
+from __future__ import annotations
+
+from bunking.solver.impossibility import _build_context
+
+from .conftest import make_bunk, make_input, make_person
+
+
+def test_build_context_populates_roster_cm_ids(mock_config):
+    """roster_cm_ids is the frozenset of every person cm_id in the input."""
+    p1 = make_person(1, session=100)
+    p2 = make_person(2, session=100)
+    input_data = make_input([p1, p2], [make_bunk(10, session=100)], [])
+
+    ctx = _build_context(input_data, mock_config)
+
+    assert ctx.roster_cm_ids == frozenset({1, 2})
+    assert isinstance(ctx.roster_cm_ids, frozenset)

--- a/tests/unit/solver/impossibility/test_target_not_in_solver.py
+++ b/tests/unit/solver/impossibility/test_target_not_in_solver.py
@@ -1,4 +1,4 @@
-"""TargetNotInSolverImpossibility: bunk_with/not_bunk_with to a non-roster requestee."""
+"""TargetNotInSolverImpossibility: bunk_with to a non-roster requestee."""
 
 from __future__ import annotations
 
@@ -36,15 +36,20 @@ def test_bunk_with_to_non_roster_target_is_impossible(mock_config):
     assert reason.detail["requested_person_cm_id"] == 999
 
 
-def test_not_bunk_with_to_non_roster_target_is_impossible(mock_config):
+def test_not_bunk_with_to_non_roster_target_is_not_impossible(mock_config):
+    """A not_bunk_with whose requestee is absent from the roster is trivially
+    satisfied — the two campers can never share a bunk — so this predicate must
+    NOT flag it. Mirrors the satisfaction logic in bunking/satisfaction/
+    predicate.py ("requestee unassigned — no conflict possible") and the
+    bunk_with-only guard in the gender/grade_spread/session_boundary predicates.
+    Only a bunk_with to a non-roster target is genuinely impossible.
+    """
     p1 = make_person(1, session=100)
     req = make_request("r1", requester=1, requestee=999, request_type="not_bunk_with", session=100)
     input_data = make_input([p1], [make_bunk(10, session=100)], [req])
     ctx = _build_context(input_data, mock_config)
 
-    reason = PREDICATE.check_request(req, ctx)
-    assert reason is not None
-    assert reason.code == "target_not_in_solver"
+    assert PREDICATE.check_request(req, ctx) is None
 
 
 def test_bunk_with_to_in_roster_target_is_not_impossible(mock_config):

--- a/tests/unit/solver/impossibility/test_target_not_in_solver.py
+++ b/tests/unit/solver/impossibility/test_target_not_in_solver.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from bunking.solver.constraints.bunk_requests import TargetNotInSolverImpossibility
 from bunking.solver.impossibility import _build_context
 
-from .conftest import make_bunk, make_input, make_person
+from .conftest import make_bunk, make_input, make_person, make_request
+
+PREDICATE = TargetNotInSolverImpossibility()
 
 
 def test_build_context_populates_roster_cm_ids(mock_config):
@@ -17,3 +20,64 @@ def test_build_context_populates_roster_cm_ids(mock_config):
 
     assert ctx.roster_cm_ids == frozenset({1, 2})
     assert isinstance(ctx.roster_cm_ids, frozenset)
+
+
+def test_bunk_with_to_non_roster_target_is_impossible(mock_config):
+    """bunk_with whose requestee is not in the input roster is impossible."""
+    p1 = make_person(1, session=100)
+    # Requestee cm_id 999 is NOT in the persons list -> not in the roster.
+    req = make_request("r1", requester=1, requestee=999, request_type="bunk_with", session=100)
+    input_data = make_input([p1], [make_bunk(10, session=100)], [req])
+    ctx = _build_context(input_data, mock_config)
+
+    reason = PREDICATE.check_request(req, ctx)
+    assert reason is not None
+    assert reason.code == "target_not_in_solver"
+    assert reason.detail["requested_person_cm_id"] == 999
+
+
+def test_not_bunk_with_to_non_roster_target_is_impossible(mock_config):
+    p1 = make_person(1, session=100)
+    req = make_request("r1", requester=1, requestee=999, request_type="not_bunk_with", session=100)
+    input_data = make_input([p1], [make_bunk(10, session=100)], [req])
+    ctx = _build_context(input_data, mock_config)
+
+    reason = PREDICATE.check_request(req, ctx)
+    assert reason is not None
+    assert reason.code == "target_not_in_solver"
+
+
+def test_bunk_with_to_in_roster_target_is_not_impossible(mock_config):
+    p1 = make_person(1, session=100)
+    p2 = make_person(2, session=100)
+    req = make_request("r1", requester=1, requestee=2, request_type="bunk_with", session=100)
+    input_data = make_input([p1, p2], [make_bunk(10, session=100)], [req])
+    ctx = _build_context(input_data, mock_config)
+
+    assert PREDICATE.check_request(req, ctx) is None
+
+
+def test_malformed_request_is_not_target_not_in_solver(mock_config):
+    """No requestee_id -> MalformedRequestImpossibility's concern, not this one."""
+    p1 = make_person(1, session=100)
+    req = make_request("r1", requester=1, requestee=None, request_type="bunk_with", session=100)
+    input_data = make_input([p1], [make_bunk(10, session=100)], [req])
+    ctx = _build_context(input_data, mock_config)
+
+    assert PREDICATE.check_request(req, ctx) is None
+
+
+def test_age_preference_request_is_ignored(mock_config):
+    p1 = make_person(1, session=100)
+    req = make_request(
+        "r1",
+        requester=1,
+        requestee=None,
+        request_type="age_preference",
+        age_preference_target="older",
+        session=100,
+    )
+    input_data = make_input([p1], [make_bunk(10, session=100)], [req])
+    ctx = _build_context(input_data, mock_config)
+
+    assert PREDICATE.check_request(req, ctx) is None

--- a/tests/unit/solver/test_request_validation_mp_counts.py
+++ b/tests/unit/solver/test_request_validation_mp_counts.py
@@ -205,3 +205,30 @@ class TestMPAndAllCamperCounts:
         assert s["mp_campers_total"] == 0
         assert s["all_campers_total"] == 0
         assert s["all_campers_satisfied"] == 0
+
+
+def test_entirely_impossible_mp_camper_excluded_from_mp_campers_total() -> None:
+    """mp_campers_total counts only campers with >=1 POSSIBLE MP request.
+
+    Camper 1's single MP request targets a non-roster cm_id (entirely
+    impossible). Camper 2 has a satisfiable MP request. With camper 1
+    correctly excluded, mp_campers_total == 1 and mp_campers_satisfied == 1
+    -> the 'Acceptable' rate is 100%, not 50%.
+    """
+    p1 = _person(1, session_cm_id=500)
+    p2 = _person(2, session_cm_id=500)
+    p3 = _person(3, session_cm_id=500)
+    bunks = [_bunk(10, capacity=10, session_cm_id=500)]
+    requests = [
+        # Camper 1: only MP request targets cm_id 999 (not in persons) -> impossible.
+        _req("r1", requester_id=1, target_id=999, source_field="bunk_with"),
+        # Camper 2: MP request to camper 3, satisfiable.
+        _req("r2", requester_id=2, target_id=3, source_field="bunk_with"),
+    ]
+    # Put everyone in the one bunk so r2 is satisfied.
+    assignments = {1: 10, 2: 10, 3: 10}
+
+    summary = _run_post_solve_with_fixed_assignments([p1, p2, p3], bunks, requests, assignments)
+
+    assert summary["mp_campers_total"] == 1
+    assert summary["mp_campers_satisfied"] == 1

--- a/tests/unit/solver/test_validate_requests.py
+++ b/tests/unit/solver/test_validate_requests.py
@@ -575,3 +575,51 @@ class TestValidateRequestsReasonSummaryLog:
         infeasible_warnings = [r.message for r in caplog.records if "infeasible" in r.message]
         assert infeasible_warnings, "expected an infeasibility warning to be logged"
         assert "infeasible ()" not in infeasible_warnings[0]
+
+
+def test_target_not_in_solver_classified_impossible_after_delegation():
+    """_validate_requests still classifies a bunk_with to a non-roster target as
+    impossible — now via the predicate, not the deleted hand-rolled fallback."""
+    from unittest.mock import MagicMock
+
+    from bunking.solver.direct_solver import DirectBunkingSolver
+    from tests.unit.solver.impossibility.conftest import (
+        make_bunk,
+        make_input,
+        make_person,
+        make_request,
+    )
+
+    p1 = make_person(1, session=1000001, gender="F", grade=5)
+    bunks = [make_bunk(10, session=1000001, gender="F", capacity=12)]
+    requests = [make_request("r_ghost", requester=1, requestee=777, session=1000001)]
+    input_data = make_input([p1], bunks, requests)
+
+    solver = DirectBunkingSolver(input_data, MagicMock())
+
+    impossible_ids = {r.id for reqs in solver.impossible_requests.values() for r in reqs}
+    assert "r_ghost" in impossible_ids
+
+
+def test_mp_set_entirely_impossible_populated_at_init():
+    """The entirely-impossible MP camper rollup is populated during __init__
+    (from the report), before add_constraints runs."""
+    from unittest.mock import MagicMock
+
+    from bunking.solver.direct_solver import DirectBunkingSolver
+    from tests.unit.solver.impossibility.conftest import (
+        make_bunk,
+        make_input,
+        make_person,
+        make_request,
+    )
+
+    p1 = make_person(1, session=1000001, gender="F", grade=5)
+    bunks = [make_bunk(10, session=1000001, gender="F", capacity=12)]
+    # Camper 1's only MP request targets a non-roster cm_id -> entire MP set impossible.
+    requests = [make_request("r1", requester=1, requestee=777, session=1000001)]
+    input_data = make_input([p1], bunks, requests)
+
+    solver = DirectBunkingSolver(input_data, MagicMock())
+
+    assert solver.mp_set_entirely_impossible == [1]

--- a/tests/unit/solver/test_validate_requests.py
+++ b/tests/unit/solver/test_validate_requests.py
@@ -223,7 +223,7 @@ class TestValidateRequestsCrossSession:
         target-not-in-solver request must be counted ONCE, not twice."""
         # Person 1001 has two impossible requests:
         #   r1: bunk_with cross-session 1002 → caught by predicate (report.flat)
-        #   r2: bunk_with 9999 (not in person_idx_map) → target_not_in_solver_extra
+        #   r2: bunk_with 9999 (not in person_idx_map) → target_not_in_solver predicate (report.flat)
         solver = DirectBunkingSolver(
             DirectSolverInput(
                 persons=[_make_person(1001, 1000001), _make_person(1002, 1000002)],


### PR DESCRIPTION
## What & why

Stage 4 (#1391) made must-satisfy-one a **hard** constraint. A cohort of campers have their *entire* Material-Parent (MP) request set structurally impossible (e.g. the requested camper isn't enrolled). That's pre-solve calculable, but it was invisible in the staff pre-check and it corrupted the "Acceptable" metric. This is the Stream 6 substream tracked in #1428.

## The four changes

1. **`target_not_in_solver` is now a registered predicate.** Promoted from a hand-rolled fallback in `DirectBunkingSolver._validate_requests` to a `TargetNotInSolverImpossibility` (`check_request`, Layer 1) predicate in `bunking/solver/constraints/bunk_requests.py`. `ImpossibilityContext` gains `roster_cm_ids`. `_validate_requests` now delegates **entirely** to `validate_impossibility` — the hand-rolled fallback is deleted, closing the pre-validate ↔ `_validate_requests` drift the endpoint docstring used to deny. Covered by the `test_registry.py` discipline check + a convergence drift test.

2. **`ImpossibilityReport.mp_campers_entirely_impossible`** — a derived rollup (`{cm_id, name, grade, gender, reason_codes}` per camper), computed in `validate_impossibility`. Single source of truth: `_validate_requests` populates `mp_set_entirely_impossible` from it at `__init__`, and `parent_paramount` stops re-deriving it.

3. **Surfaced in the API + both modals.** The `/solver/pre-validate` response carries `mp_campers_entirely_impossible`; `PreValidationResultsModal` (staff) and `SolverDebugImpossibilityModal` (debug) render a camper-level "will get zero parent requests honored" section with per-camper action hints (`target_not_in_solver` → "confirm enrollment"; else → "fix parent input").

4. **`mp_camper_rate` ("Acceptable") denominator fixed.** `mp_campers_total` now counts only campers with ≥1 *possible* MP request; the numerator is gated to the same subset (structurally ≤ the denominator — no >100%). `mp_set_entirely_impossible_count` stays a separate displayed chip.

## Notes for reviewers

- **Semantics shift:** `mp_set_entirely_impossible` changed from a *constraint-build artifact* (populated by `parent_paramount` during `add_constraints()`) to the *impossibility pre-check's predicate verdict* (populated by `_validate_requests` at `__init__`). Same set, earlier and authoritative.
- **Emergent fix:** moving population into `__init__` also fixes a latent bug — `feasibility.py`'s `localize_hard_mso_infeasibility` read `mp_set_entirely_impossible` *before* `add_constraints()` ran, so its `excluded` set was silently always empty. Follow-up: a dedicated regression test for that exclusion path isn't in this PR.
- **Rebase heads-up:** #1395 (sat-var unification) and #1388 (worktree `solver-tier1-bucket-split`) are both in flight and both touch `parent_paramount.py` / `direct_solver.py` in different regions — whoever merges later rebases.

## Testing

STRICT TDD throughout — failing tests written and verified red before each implementation. 353 solver/API unit tests + 20 frontend component tests pass; mypy / ruff / tsc clean; all pre-push checks green. No running server needed (unit-level).

Closes #1428
Related: #1426 (audit for other hand-rolled impossibility logic in `direct_solver`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API now returns a camper-level "entirely impossible" rollup; pre-validation modals show affected campers with actionable hints (e.g., "Friend not enrolled") and reason-code chips.

* **Bug Fixes**
  * MP satisfaction-rate calculation corrected to exclude campers whose MP requests are entirely impossible; validation summaries and warnings now use the unified rollup.

* **Documentation**
  * Solver roadmap updated to document the rollup and related correctness fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1429)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->