### PR TITLE
feat(sync,frontend): auto-unassign campers stranded by bunk-plan changes (#1416, #1417)

### DIFF
--- a/frontend/src/components/BunkingBoardByArea.tsx
+++ b/frontend/src/components/BunkingBoardByArea.tsx
@@ -31,7 +31,7 @@ import { usePermissions } from '../hooks/usePermissions'
 import { Permission } from '../constants/permissions'
 import { Home } from 'lucide-react'
 import { isAgSession } from '../utils/sessionTypePredicates'
-import { isCamperEffectivelyUnassigned } from './bunkingBoardHelpers'
+import { getEffectivelyUnassignedCampers } from './bunkingBoardHelpers'
 
 interface BunkingBoardByAreaProps {
   sessionId: string
@@ -217,8 +217,7 @@ export default function BunkingBoardByArea(props: BunkingBoardByAreaProps) {
   // Get unassigned campers
   // React Compiler will optimize this computation
   const getUnassignedCampers = () => {
-    const validBunkIds = new Set(bunks.map((b) => b.id))
-    const unassigned = campers.filter((c) => isCamperEffectivelyUnassigned(c, validBunkIds))
+    const unassigned = getEffectivelyUnassignedCampers(campers, bunks)
 
     // If showing all areas, return all unassigned campers
     if (selectedArea === 'all') {

--- a/frontend/src/components/BunkingBoardByArea.tsx
+++ b/frontend/src/components/BunkingBoardByArea.tsx
@@ -32,6 +32,17 @@ import { Permission } from '../constants/permissions'
 import { Home } from 'lucide-react'
 import { isAgSession } from '../utils/sessionTypePredicates'
 
+/**
+ * A camper is "effectively unassigned" if they have no bunk, OR their bunk is
+ * not among the session's displayed bunks. The second case is the stranded
+ * camper from a bunk-plan reorganization (#1416): the bunk record still exists
+ * but has no bunk_plan for this session, so it has no column on the board.
+ * Without this check such campers match no column and vanish entirely.
+ */
+export function isCamperEffectivelyUnassigned(camper: Camper, validBunkIds: Set<string>): boolean {
+  return !camper.assigned_bunk || !validBunkIds.has(camper.assigned_bunk)
+}
+
 interface BunkingBoardByAreaProps {
   sessionId: string
   sessionCmId: number
@@ -216,7 +227,8 @@ export default function BunkingBoardByArea(props: BunkingBoardByAreaProps) {
   // Get unassigned campers
   // React Compiler will optimize this computation
   const getUnassignedCampers = () => {
-    const unassigned = campers.filter((c) => !c.assigned_bunk)
+    const validBunkIds = new Set(bunks.map((b) => b.id))
+    const unassigned = campers.filter((c) => isCamperEffectivelyUnassigned(c, validBunkIds))
 
     // If showing all areas, return all unassigned campers
     if (selectedArea === 'all') {

--- a/frontend/src/components/BunkingBoardByArea.tsx
+++ b/frontend/src/components/BunkingBoardByArea.tsx
@@ -31,17 +31,7 @@ import { usePermissions } from '../hooks/usePermissions'
 import { Permission } from '../constants/permissions'
 import { Home } from 'lucide-react'
 import { isAgSession } from '../utils/sessionTypePredicates'
-
-/**
- * A camper is "effectively unassigned" if they have no bunk, OR their bunk is
- * not among the session's displayed bunks. The second case is the stranded
- * camper from a bunk-plan reorganization (#1416): the bunk record still exists
- * but has no bunk_plan for this session, so it has no column on the board.
- * Without this check such campers match no column and vanish entirely.
- */
-export function isCamperEffectivelyUnassigned(camper: Camper, validBunkIds: Set<string>): boolean {
-  return !camper.assigned_bunk || !validBunkIds.has(camper.assigned_bunk)
-}
+import { isCamperEffectivelyUnassigned } from './bunkingBoardHelpers'
 
 interface BunkingBoardByAreaProps {
   sessionId: string

--- a/frontend/src/components/BunkingBoardByArea.unassigned.test.tsx
+++ b/frontend/src/components/BunkingBoardByArea.unassigned.test.tsx
@@ -1,9 +1,14 @@
 import { describe, it, expect } from 'vitest'
-import { isCamperEffectivelyUnassigned } from './bunkingBoardHelpers'
-import type { Camper } from '../types/app-types'
+import {
+  getEffectivelyUnassignedCampers,
+  isCamperEffectivelyUnassigned,
+} from './bunkingBoardHelpers'
+import type { Bunk, Camper } from '../types/app-types'
 
 const camper = (overrides: Partial<Camper>): Camper =>
   ({ id: 'p1:s1', person_cm_id: 1, ...overrides }) as Camper
+
+const bunk = (id: string): Bunk => ({ id }) as Bunk
 
 describe('isCamperEffectivelyUnassigned', () => {
   const validBunkIds = new Set(['bunkA', 'bunkB'])
@@ -26,5 +31,34 @@ describe('isCamperEffectivelyUnassigned', () => {
     expect(isCamperEffectivelyUnassigned(camper({ assigned_bunk: 'bunkGONE' }), validBunkIds)).toBe(
       true
     )
+  })
+})
+
+describe('getEffectivelyUnassignedCampers', () => {
+  const bunks = [bunk('bunkA'), bunk('bunkB')]
+
+  it('returns campers with no bunk and campers stranded off-plan', () => {
+    const { assigned_bunk: _omit, ...noBunk } = camper({ assigned_bunk: 'bunkA' })
+    void _omit
+    const stranded = camper({ id: 'p2:s1', assigned_bunk: 'bunkGONE' })
+    const assigned = camper({ id: 'p3:s1', assigned_bunk: 'bunkB' })
+
+    const result = getEffectivelyUnassignedCampers([noBunk as Camper, stranded, assigned], bunks)
+
+    expect(result).toEqual([noBunk, stranded])
+  })
+
+  it('does not flag assigned campers while bunks are still loading (empty list)', () => {
+    // bunks and campers are fed by independent React Query hooks, so bunks can
+    // be [] while campers has resolved. Falling through to the stranded check
+    // with an empty bunk set would flag every assigned camper. Guard: an empty
+    // bunks list falls back to the plain "no bunk" check.
+    const assigned = camper({ assigned_bunk: 'bunkA' })
+    const { assigned_bunk: _omit, ...noBunk } = camper({ id: 'p2:s1', assigned_bunk: 'bunkA' })
+    void _omit
+
+    const result = getEffectivelyUnassignedCampers([assigned, noBunk as Camper], [])
+
+    expect(result).toEqual([noBunk])
   })
 })

--- a/frontend/src/components/BunkingBoardByArea.unassigned.test.tsx
+++ b/frontend/src/components/BunkingBoardByArea.unassigned.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { isCamperEffectivelyUnassigned } from './BunkingBoardByArea'
+import type { Camper } from '../types/app-types'
+
+const camper = (overrides: Partial<Camper>): Camper =>
+  ({ id: 'p1:s1', person_cm_id: 1, ...overrides }) as Camper
+
+describe('isCamperEffectivelyUnassigned', () => {
+  const validBunkIds = new Set(['bunkA', 'bunkB'])
+
+  it('treats a camper with no bunk as unassigned', () => {
+    // omit assigned_bunk entirely to avoid exactOptionalPropertyTypes constraint
+    const { assigned_bunk: _, ...rest } = camper({ assigned_bunk: 'bunkA' })
+    void _
+    expect(isCamperEffectivelyUnassigned(rest as Camper, validBunkIds)).toBe(true)
+  })
+
+  it('treats a camper assigned to a displayed bunk as assigned', () => {
+    expect(isCamperEffectivelyUnassigned(camper({ assigned_bunk: 'bunkA' }), validBunkIds)).toBe(
+      false
+    )
+  })
+
+  it('treats a camper assigned to a bunk NOT in the session plan as unassigned', () => {
+    // The stranded case: bunk record exists but has no bunk_plan for this session.
+    expect(isCamperEffectivelyUnassigned(camper({ assigned_bunk: 'bunkGONE' }), validBunkIds)).toBe(
+      true
+    )
+  })
+})

--- a/frontend/src/components/BunkingBoardByArea.unassigned.test.tsx
+++ b/frontend/src/components/BunkingBoardByArea.unassigned.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isCamperEffectivelyUnassigned } from './BunkingBoardByArea'
+import { isCamperEffectivelyUnassigned } from './bunkingBoardHelpers'
 import type { Camper } from '../types/app-types'
 
 const camper = (overrides: Partial<Camper>): Camper =>

--- a/frontend/src/components/bunkingBoardHelpers.ts
+++ b/frontend/src/components/bunkingBoardHelpers.ts
@@ -1,0 +1,16 @@
+import type { Camper } from '../types/app-types'
+
+/**
+ * A camper is "effectively unassigned" if they have no bunk, OR their bunk is
+ * not among the session's bunks. The second case is the stranded camper from a
+ * bunk-plan reorganization (#1416): the bunk record still exists but has no
+ * bunk_plan for this session, so it has no column on the board. Without this
+ * check such campers match no column and vanish entirely.
+ *
+ * `validBunkIds` is built from the session-scoped `bunks` prop — not the
+ * area-filtered subset — so a camper in a real bunk that simply belongs to
+ * another area is correctly left assigned.
+ */
+export function isCamperEffectivelyUnassigned(camper: Camper, validBunkIds: Set<string>): boolean {
+  return !camper.assigned_bunk || !validBunkIds.has(camper.assigned_bunk)
+}

--- a/frontend/src/components/bunkingBoardHelpers.ts
+++ b/frontend/src/components/bunkingBoardHelpers.ts
@@ -1,4 +1,4 @@
-import type { Camper } from '../types/app-types'
+import type { Bunk, Camper } from '../types/app-types'
 
 /**
  * A camper is "effectively unassigned" if they have no bunk, OR their bunk is
@@ -13,4 +13,22 @@ import type { Camper } from '../types/app-types'
  */
 export function isCamperEffectivelyUnassigned(camper: Camper, validBunkIds: Set<string>): boolean {
   return !camper.assigned_bunk || !validBunkIds.has(camper.assigned_bunk)
+}
+
+/**
+ * Returns the campers that are effectively unassigned for the session.
+ *
+ * `bunks` and `campers` are fed by independent React Query hooks, so `bunks`
+ * can still be `[]` while `campers` has already resolved. With an empty bunk
+ * set every `assigned_bunk` would miss `validBunkIds` and the board would flash
+ * every assigned camper into the Unassigned pool. While bunks are unloaded we
+ * fall back to the plain "no bunk" check; the stranded-camper detection kicks
+ * in only once the session's bunks are known.
+ */
+export function getEffectivelyUnassignedCampers(campers: Camper[], bunks: Bunk[]): Camper[] {
+  if (bunks.length === 0) {
+    return campers.filter((c) => !c.assigned_bunk)
+  }
+  const validBunkIds = new Set(bunks.map((b) => b.id))
+  return campers.filter((c) => isCamperEffectivelyUnassigned(c, validBunkIds))
 }

--- a/frontend/src/components/graph/cytoscapeStyles.orphan.test.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.orphan.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { createGraphElements } from './cytoscapeStyles'
+import type { GraphNodeData, GraphEdgeData, ShowEdgesSettings } from './cytoscapeStyles'
+
+describe('createGraphElements — stranded bunk labels', () => {
+  it('never labels a bunk parent node with a raw numeric id', () => {
+    // One camper grouped under bunk cm_id 12345, which is absent from bunksData
+    // (its bunk has no plan for this session — stranded assignment, #1417).
+    const nodes: GraphNodeData[] = [
+      {
+        id: 1,
+        name: 'Emma Johnson',
+        bunk_cm_id: 12345,
+      },
+    ]
+    const edges: GraphEdgeData[] = []
+    const showEdges: ShowEdgesSettings = { request: true }
+
+    const { parentNodes } = createGraphElements(nodes, edges, {}, showEdges)
+
+    const orphanParent = parentNodes.find((p) => p.data.bunk_cm_id === 12345)
+    expect(orphanParent).toBeDefined()
+    expect(orphanParent!.data.label).not.toMatch(/\d{4,}/) // no 4+ digit number
+    expect(orphanParent!.data.label).toBe('Removed cabin')
+  })
+})

--- a/frontend/src/components/graph/cytoscapeStyles.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.ts
@@ -391,7 +391,10 @@ export function createGraphElements(
   // even though it's not a layout constraint.
   const parentNodes: ParentNodeElement[] = Object.keys(bunkGroups).map((bunkIdStr) => {
     const bunkId = parseInt(bunkIdStr, 10)
-    const bunkName = bunksData?.[bunkId] ?? `Bunk ${bunkId}`
+    // Fallback when the bunk has no name in bunksData — i.e. it has no
+    // bunk_plan for this session (a stranded assignment, #1417). Never render
+    // the raw CampMinder cm_id.
+    const bunkName = bunksData?.[bunkId] ?? 'Removed cabin'
     return {
       data: {
         id: `bunk-${bunkId}`,

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -90,6 +90,7 @@ var syncJobMeta = []JobMeta{
 	{"staff_vehicle_info", PhaseTransform, "Extract staff vehicle info from custom values"},
 	{"normalize_geographic", PhaseTransform, "Normalize geographic data (cities, schools, congregations)"},
 	{"enrollment_snapshots", PhaseTransform, "Capture daily enrollment counts per session"},
+	{"orphan_reconciler", PhaseTransform, "Auto-unassign scenario drafts stranded by bunk-plan changes"},
 
 	// Process phase - CSV + AI
 	{"reconcile_request_lifecycle", PhaseProcess, "Mark moved-requester OBRs for reprocessing"},
@@ -448,12 +449,15 @@ func GetWeeklySyncJobs() []string {
 
 // GetRefreshBunkingJobs returns the services needed for a full bunking refresh.
 // Runs in order: bunks (fetch latest bunk list), bunk_plans (update plans),
-// then bunk_assignments (update assignments).
+// bunk_assignments (update assignments), then orphan_reconciler — the bunk_plans
+// rewrite is exactly what strands scenario drafts, so they must be swept in the
+// same run rather than left until the next daily sync.
 func GetRefreshBunkingJobs() []string {
 	return []string{
 		"bunks",
 		"bunk_plans",
 		"bunk_assignments",
+		"orphan_reconciler",
 	}
 }
 

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -168,7 +168,7 @@ func GetDefaultUnifiedSyncJobs(includeCustomValues bool) []string {
 		"financial_aid_applications", "household_demographics",
 		"camper_dietary", "camper_transportation", "quest_registrations",
 		"staff_applications", "staff_vehicle_info", "normalize_geographic",
-		"enrollment_snapshots")
+		"enrollment_snapshots", "orphan_reconciler")
 
 	return jobs
 }
@@ -744,6 +744,10 @@ func (o *Orchestrator) RunDailySync(ctx context.Context) error {
 		orderedJobs = append(orderedJobs, "multi_workbook_export")
 	}
 
+	// Orphan reconciliation runs last — after bunk_plans is final, it sweeps
+	// scenario drafts left stranded by bunk-plan reorganizations (#1416, #1417).
+	orderedJobs = append(orderedJobs, "orphan_reconciler")
+
 	// Set daily sync flag and queue
 	o.mu.Lock()
 	o.dailySyncRunning = true
@@ -1264,6 +1268,12 @@ func (o *Orchestrator) RunSyncWithOptions(ctx context.Context, opts Options) err
 		enrollmentSnapshotsSync.Year = opts.Year
 		o.RegisterService("enrollment_snapshots", enrollmentSnapshotsSync)
 
+		// Orphan reconciler: sweeps scenario drafts stranded by bunk-plan changes.
+		// Year-scoped so a historical sync reconciles the correct year's drafts.
+		orphanReconcilerSync := NewOrphanReconcilerSync(o.app)
+		orphanReconcilerSync.Year = opts.Year
+		o.RegisterService("orphan_reconciler", orphanReconcilerSync)
+
 		// Custom value services for historical sync support
 		// These use GetSeasonID() to determine the year, so they need year-specific client
 		personCustomValuesSync := NewPersonCustomFieldValuesSync(o.app, yearClient)
@@ -1738,6 +1748,7 @@ func (o *Orchestrator) InitializeSyncServices() error {
 	o.RegisterService("bunk_plans", NewBunkPlansSync(o.app, client))
 	o.RegisterService("bunk_assignments", NewBunkAssignmentsSync(o.app, client))
 	o.RegisterService("reconcile_request_lifecycle", NewReconcileLifecycleSync(o.app))
+	o.RegisterService("orphan_reconciler", NewOrphanReconcilerSync(o.app))
 	o.RegisterService("bunk_requests", NewBunkRequestsSync(o.app, client))
 	// Register the request processor (no CampMinder client needed)
 	processor := NewRequestProcessor(o.app)

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -685,17 +685,12 @@ func (o *Orchestrator) checkGlobalTablesEmpty() bool {
 	return len(records) == 0
 }
 
-// RunDailySync runs all base data syncs in the correct order
-func (o *Orchestrator) RunDailySync(ctx context.Context) error {
-	// Check if global tables are empty - if so, run weekly sync first
-	// This ensures fresh DB setups have required global definitions before daily sync
-	if o.checkGlobalTablesEmpty() {
-		slog.Info("Global tables empty - running weekly sync first")
-		if err := o.RunWeeklySync(ctx); err != nil {
-			slog.Error("Weekly sync failed, continuing with daily", "error", err)
-		}
-	}
-
+// getDailySyncJobs returns the ordered list of jobs the daily sync runs,
+// respecting inter-job dependencies. orphan_reconciler is always appended last:
+// it must run after bunk_plans is final so it can sweep scenario drafts left
+// stranded by bunk-plan reorganizations (#1416, #1417). Extracted from
+// RunDailySync so the ordering can be asserted in tests.
+func getDailySyncJobs() []string {
 	// Define sync order (respecting dependencies)
 	// Note: person_tag_defs, custom_field_defs, and divisions run in weekly sync
 	// since they're global definitions that rarely change
@@ -747,6 +742,22 @@ func (o *Orchestrator) RunDailySync(ctx context.Context) error {
 	// Orphan reconciliation runs last — after bunk_plans is final, it sweeps
 	// scenario drafts left stranded by bunk-plan reorganizations (#1416, #1417).
 	orderedJobs = append(orderedJobs, "orphan_reconciler")
+
+	return orderedJobs
+}
+
+// RunDailySync runs all base data syncs in the correct order
+func (o *Orchestrator) RunDailySync(ctx context.Context) error {
+	// Check if global tables are empty - if so, run weekly sync first
+	// This ensures fresh DB setups have required global definitions before daily sync
+	if o.checkGlobalTablesEmpty() {
+		slog.Info("Global tables empty - running weekly sync first")
+		if err := o.RunWeeklySync(ctx); err != nil {
+			slog.Error("Weekly sync failed, continuing with daily", "error", err)
+		}
+	}
+
+	orderedJobs := getDailySyncJobs()
 
 	// Set daily sync flag and queue
 	o.mu.Lock()

--- a/pocketbase/sync/orchestrator_test.go
+++ b/pocketbase/sync/orchestrator_test.go
@@ -777,6 +777,35 @@ func TestWeeklySyncIncludesDivisions(t *testing.T) {
 	}
 }
 
+// TestGetDailySyncJobsOrphanReconcilerOrdering asserts the daily sync runs
+// orphan_reconciler last and strictly after bunk_plans. The reconciler's gating
+// logic depends on bunk_plans being final before it sweeps stranded drafts, so
+// a regression that drops it or moves it earlier must fail this test.
+func TestGetDailySyncJobsOrphanReconcilerOrdering(t *testing.T) {
+	jobs := getDailySyncJobs()
+
+	pos := make(map[string]int, len(jobs))
+	for i, j := range jobs {
+		pos[j] = i
+	}
+
+	orphanPos, ok := pos["orphan_reconciler"]
+	if !ok {
+		t.Fatalf("orphan_reconciler missing from daily sync jobs: %v", jobs)
+	}
+	if orphanPos != len(jobs)-1 {
+		t.Errorf("orphan_reconciler must run last — got position %d of %d: %v", orphanPos, len(jobs), jobs)
+	}
+
+	bunkPlansPos, ok := pos["bunk_plans"]
+	if !ok {
+		t.Fatalf("bunk_plans missing from daily sync jobs: %v", jobs)
+	}
+	if orphanPos <= bunkPlansPos {
+		t.Errorf("orphan_reconciler (pos %d) must run after bunk_plans (pos %d)", orphanPos, bunkPlansPos)
+	}
+}
+
 // TestDailySyncExcludesDivisions verifies divisions is NOT in daily sync
 func TestDailySyncExcludesDivisions(t *testing.T) {
 	// Daily sync jobs that would be in orderedJobs (excluding divisions)

--- a/pocketbase/sync/orchestrator_test.go
+++ b/pocketbase/sync/orchestrator_test.go
@@ -1851,6 +1851,28 @@ func TestJobMeta_TransformPhaseJobs(t *testing.T) {
 	}
 }
 
+// TestJobMeta_IncludesOrphanReconciler asserts the orphan reconciler is
+// registered in syncJobMeta so the phase API (?phase=transform) and the sync
+// dashboard surface it like every other sync job. Its predecessor
+// reconcile_request_lifecycle is registered there; orphan_reconciler must be too.
+func TestJobMeta_IncludesOrphanReconciler(t *testing.T) {
+	if got := GetPhaseForJob("orphan_reconciler"); got != PhaseTransform {
+		t.Errorf("GetPhaseForJob(\"orphan_reconciler\") = %q, want %q", got, PhaseTransform)
+	}
+
+	jobs := GetJobsForPhase(PhaseTransform)
+	found := false
+	for _, j := range jobs {
+		if j == "orphan_reconciler" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("orphan_reconciler missing from GetJobsForPhase(PhaseTransform): %v", jobs)
+	}
+}
+
 // TestJobMeta_ProcessPhaseJobs tests that CSV/AI jobs are in process phase
 func TestJobMeta_ProcessPhaseJobs(t *testing.T) {
 	expectedProcessJobs := []string{

--- a/pocketbase/sync/orchestrator_test.go
+++ b/pocketbase/sync/orchestrator_test.go
@@ -2341,7 +2341,7 @@ func TestRunSyncWithOptionsPhaseOrdering(t *testing.T) {
 			"financial_aid_applications", "household_demographics",
 			"camper_dietary", "camper_transportation", "quest_registrations",
 			"staff_applications", "staff_vehicle_info", "normalize_geographic",
-			"enrollment_snapshots",
+			"enrollment_snapshots", "orphan_reconciler",
 		}
 
 		if len(jobs) != len(expectedOrder) {

--- a/pocketbase/sync/orphan_reconciler.go
+++ b/pocketbase/sync/orphan_reconciler.go
@@ -218,6 +218,7 @@ func reconcileOrphanedAssignments(app core.App, year int, stats *Stats) error {
 		"year", year,
 		"stranded_drafts", len(strandedDrafts),
 		"drafts_swept", stats.Updated,
+		"errors", stats.Errors,
 	)
 	return nil
 }

--- a/pocketbase/sync/orphan_reconciler.go
+++ b/pocketbase/sync/orphan_reconciler.go
@@ -1,0 +1,193 @@
+// Package sync provides synchronization services between CampMinder and PocketBase.
+package sync
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+const serviceNameOrphanReconciler = "orphan_reconciler"
+
+// orphanCandidate is the minimal projection of an assignment row needed for
+// stranded-detection — decoupled from *core.Record so the detection logic is
+// unit-testable without a database.
+type orphanCandidate struct {
+	RecordID  string
+	SessionID string
+	BunkID    string
+}
+
+// orphanPairKey builds the composite key used to test whether a (session, bunk)
+// pair has a surviving bunk_plan. Both args are PocketBase record IDs.
+func orphanPairKey(sessionID, bunkID string) string {
+	return sessionID + ":" + bunkID
+}
+
+// findStrandedAssignments returns the candidates whose (session, bunk) pair is
+// absent from validPairs — i.e. the bunk has no bunk_plan for that session.
+// Candidates with no bunk are skipped (already unassigned).
+func findStrandedAssignments(validPairs map[string]bool, candidates []orphanCandidate) []orphanCandidate {
+	stranded := []orphanCandidate{}
+	for _, c := range candidates {
+		if c.BunkID == "" {
+			continue
+		}
+		if !validPairs[orphanPairKey(c.SessionID, c.BunkID)] {
+			stranded = append(stranded, c)
+		}
+	}
+	return stranded
+}
+
+// OrphanReconcilerSync silently auto-unassigns scenario draft assignments whose
+// bunk no longer has a bunk_plan for their session — left stranded when staff
+// reorganize a session's bunk plan — and audits production for the same.
+// Runs as the final step of the sync orchestrator. PocketBase-only — no
+// CampMinder client.
+type OrphanReconcilerSync struct {
+	App   core.App
+	Year  int
+	Debug bool
+	Stats Stats
+}
+
+// NewOrphanReconcilerSync constructs the service.
+func NewOrphanReconcilerSync(app core.App) *OrphanReconcilerSync {
+	return &OrphanReconcilerSync{App: app}
+}
+
+// Name returns the orchestrator-facing service name.
+func (s *OrphanReconcilerSync) Name() string { return serviceNameOrphanReconciler }
+
+// GetStats returns the current stats snapshot.
+func (s *OrphanReconcilerSync) GetStats() Stats { return s.Stats }
+
+// SetDebug toggles verbose logging (orchestrator hook).
+func (s *OrphanReconcilerSync) SetDebug(debug bool) { s.Debug = debug }
+
+// SetYear sets the year for this run (orchestrator hook).
+func (s *OrphanReconcilerSync) SetYear(year int) { s.Year = year }
+
+// WasSuccessful indicates whether the last run encountered no errors.
+func (s *OrphanReconcilerSync) WasSuccessful() bool { return s.Stats.Errors == 0 }
+
+// Sync runs the reconciliation against the configured year. When Year is 0
+// (the daily-sync registration path), falls back to CAMPMINDER_SEASON_ID via
+// ParseSeasonYear, matching every other yearless service in this package.
+func (s *OrphanReconcilerSync) Sync(_ context.Context) error {
+	year := s.Year
+	if year == 0 {
+		var err error
+		year, err = ParseSeasonYear()
+		if err != nil {
+			s.Stats.Errors++
+			return fmt.Errorf("orphan_reconciler: year resolution failed: %w", err)
+		}
+	}
+	return reconcileOrphanedAssignments(s.App, year, &s.Stats)
+}
+
+// reconcileOrphanedAssignments is the integration logic:
+//  1. Build the valid (session, bunk) set from bunk_plans for the year.
+//  2. GATE: if there are zero bunk_plans for the year, the plan set is
+//     unreliable (bunk_plans sync failed or never ran) — skip entirely, since
+//     sweeping against an empty set would null every valid draft.
+//  3. Sweep bunk_assignments_draft: null bunk + bunk_plan on stranded rows so
+//     the camper falls back into the Unassigned pool.
+//  4. Audit bunk_assignments (production): count stranded rows, log — but do
+//     NOT delete. The bunk_assignments sync's own deleteOrphans() owns prod.
+func reconcileOrphanedAssignments(app core.App, year int, stats *Stats) error {
+	yearFilter := fmt.Sprintf("year = %d", year)
+
+	plans, err := app.FindRecordsByFilter("bunk_plans", yearFilter, "", 0, 0)
+	if err != nil {
+		stats.Errors++
+		return fmt.Errorf("orphan_reconciler: query bunk_plans: %w", err)
+	}
+	// GATE.
+	if len(plans) == 0 {
+		slog.Warn("orphan_reconciler: skipping — no bunk_plans for year (sync may have failed)", "year", year)
+		return nil
+	}
+	validPairs := make(map[string]bool, len(plans))
+	for _, p := range plans {
+		validPairs[orphanPairKey(p.GetString("session"), p.GetString("bunk"))] = true
+	}
+
+	// --- Draft sweep ---
+	drafts, err := app.FindRecordsByFilter(
+		"bunk_assignments_draft",
+		fmt.Sprintf("%s && bunk != ''", yearFilter),
+		"", 0, 0,
+	)
+	if err != nil {
+		stats.Errors++
+		return fmt.Errorf("orphan_reconciler: query bunk_assignments_draft: %w", err)
+	}
+	draftByID := make(map[string]*core.Record, len(drafts))
+	draftCandidates := make([]orphanCandidate, 0, len(drafts))
+	for _, d := range drafts {
+		draftByID[d.Id] = d
+		draftCandidates = append(draftCandidates, orphanCandidate{
+			RecordID:  d.Id,
+			SessionID: d.GetString("session"),
+			BunkID:    d.GetString("bunk"),
+		})
+	}
+	strandedDrafts := findStrandedAssignments(validPairs, draftCandidates)
+
+	writes := 0
+	for _, c := range strandedDrafts {
+		rec := draftByID[c.RecordID]
+		rec.Set("bunk", "")
+		rec.Set("bunk_plan", "")
+		if err := app.Save(rec); err != nil {
+			stats.Errors++
+			slog.Error("orphan_reconciler: save draft", "id", c.RecordID, "error", err)
+			continue
+		}
+		writes++
+		stats.Updated++
+	}
+
+	// --- Production audit (observe only — bunk_assignments sync owns prod deletion) ---
+	prod, err := app.FindRecordsByFilter(
+		"bunk_assignments",
+		fmt.Sprintf("%s && bunk != ''", yearFilter),
+		"", 0, 0,
+	)
+	if err != nil {
+		stats.Errors++
+		slog.Error("orphan_reconciler: query bunk_assignments", "error", err)
+	} else {
+		prodCandidates := make([]orphanCandidate, 0, len(prod))
+		for _, p := range prod {
+			prodCandidates = append(prodCandidates, orphanCandidate{
+				RecordID:  p.Id,
+				SessionID: p.GetString("session"),
+				BunkID:    p.GetString("bunk"),
+			})
+		}
+		if strandedProd := findStrandedAssignments(validPairs, prodCandidates); len(strandedProd) > 0 {
+			slog.Warn("orphan_reconciler: stranded production assignments detected (not deleted — bunk_assignments sync owns prod cleanup)",
+				"year", year, "count", len(strandedProd))
+		}
+	}
+
+	// WAL checkpoint after writes.
+	if writes > 0 {
+		if _, err := app.DB().NewQuery("PRAGMA wal_checkpoint(FULL)").Execute(); err != nil {
+			slog.Warn("orphan_reconciler: WAL checkpoint failed", "error", err)
+		}
+	}
+
+	slog.Info("orphan_reconciler complete",
+		"year", year,
+		"stranded_drafts", len(strandedDrafts),
+		"drafts_swept", stats.Updated,
+	)
+	return nil
+}

--- a/pocketbase/sync/orphan_reconciler.go
+++ b/pocketbase/sync/orphan_reconciler.go
@@ -11,6 +11,11 @@ import (
 
 const serviceNameOrphanReconciler = "orphan_reconciler"
 
+// msgStrandedProd is the Warn message for the observe-only production audit.
+// Hoisted to a const to keep the call site within the line-length limit.
+const msgStrandedProd = "orphan_reconciler: stranded production assignments detected — " +
+	"not deleted (bunk_assignments sync owns prod cleanup)"
+
 // orphanCandidate is the minimal projection of an assignment row needed for
 // stranded-detection — decoupled from *core.Record so the detection logic is
 // unit-testable without a database.
@@ -28,11 +33,20 @@ func orphanPairKey(sessionID, bunkID string) string {
 
 // findStrandedAssignments returns the candidates whose (session, bunk) pair is
 // absent from validPairs — i.e. the bunk has no bunk_plan for that session.
-// Candidates with no bunk are skipped (already unassigned).
-func findStrandedAssignments(validPairs map[string]bool, candidates []orphanCandidate) []orphanCandidate {
+// Candidates with no bunk are skipped (already unassigned). Candidates whose
+// session is absent from plannedSessions are also skipped: a session with zero
+// bunk_plans is unreliable (that session's plans may have failed to sync), so
+// sweeping its drafts would null every valid assignment for the session.
+func findStrandedAssignments(
+	validPairs, plannedSessions map[string]bool,
+	candidates []orphanCandidate,
+) []orphanCandidate {
 	stranded := []orphanCandidate{}
 	for _, c := range candidates {
 		if c.BunkID == "" {
+			continue
+		}
+		if !plannedSessions[c.SessionID] {
 			continue
 		}
 		if !validPairs[orphanPairKey(c.SessionID, c.BunkID)] {
@@ -91,14 +105,16 @@ func (s *OrphanReconcilerSync) Sync(_ context.Context) error {
 }
 
 // reconcileOrphanedAssignments is the integration logic:
-//  1. Build the valid (session, bunk) set from bunk_plans for the year.
+//  1. Build the valid (session, bunk) set, plus the set of sessions that have
+//     at least one bunk_plan, from bunk_plans for the year.
 //  2. GATE: if there are zero bunk_plans for the year, the plan set is
-//     unreliable (bunk_plans sync failed or never ran) — skip entirely, since
-//     sweeping against an empty set would null every valid draft.
+//     unreliable (bunk_plans sync failed or never ran) — skip entirely. The
+//     same guard applies per session: a session with zero bunk_plans is left
+//     untouched, so a partial sync can't sweep an entire session's drafts.
 //  3. Sweep bunk_assignments_draft: null bunk + bunk_plan on stranded rows so
 //     the camper falls back into the Unassigned pool.
-//  4. Audit bunk_assignments (production): count stranded rows, log — but do
-//     NOT delete. The bunk_assignments sync's own deleteOrphans() owns prod.
+//  4. Audit bunk_assignments (production): log stranded rows — but do NOT
+//     delete. The bunk_assignments sync's own deleteOrphans() owns prod.
 func reconcileOrphanedAssignments(app core.App, year int, stats *Stats) error {
 	yearFilter := fmt.Sprintf("year = %d", year)
 
@@ -113,8 +129,11 @@ func reconcileOrphanedAssignments(app core.App, year int, stats *Stats) error {
 		return nil
 	}
 	validPairs := make(map[string]bool, len(plans))
+	plannedSessions := make(map[string]bool)
 	for _, p := range plans {
-		validPairs[orphanPairKey(p.GetString("session"), p.GetString("bunk"))] = true
+		sessionID := p.GetString("session")
+		validPairs[orphanPairKey(sessionID, p.GetString("bunk"))] = true
+		plannedSessions[sessionID] = true
 	}
 
 	// --- Draft sweep ---
@@ -129,6 +148,11 @@ func reconcileOrphanedAssignments(app core.App, year int, stats *Stats) error {
 	}
 	draftByID := make(map[string]*core.Record, len(drafts))
 	draftCandidates := make([]orphanCandidate, 0, len(drafts))
+	// Validity is derived from the (session, bunk) pair, NOT the draft's own
+	// bunk_plan relation: that relation is non-authoritative and may dangle
+	// (point at a since-deleted plan) even when the bunk is still planned. A
+	// draft whose bunk is still planned is left untouched here, stale
+	// bunk_plan and all.
 	for _, d := range drafts {
 		draftByID[d.Id] = d
 		draftCandidates = append(draftCandidates, orphanCandidate{
@@ -137,16 +161,16 @@ func reconcileOrphanedAssignments(app core.App, year int, stats *Stats) error {
 			BunkID:    d.GetString("bunk"),
 		})
 	}
-	strandedDrafts := findStrandedAssignments(validPairs, draftCandidates)
+	strandedDrafts := findStrandedAssignments(validPairs, plannedSessions, draftCandidates)
 
 	writes := 0
 	for _, c := range strandedDrafts {
 		rec := draftByID[c.RecordID]
 		rec.Set("bunk", "")
 		rec.Set("bunk_plan", "")
-		if err := app.Save(rec); err != nil {
+		if saveErr := app.Save(rec); saveErr != nil {
 			stats.Errors++
-			slog.Error("orphan_reconciler: save draft", "id", c.RecordID, "error", err)
+			slog.Error("orphan_reconciler: save draft", "id", c.RecordID, "error", saveErr)
 			continue
 		}
 		writes++
@@ -160,6 +184,9 @@ func reconcileOrphanedAssignments(app core.App, year int, stats *Stats) error {
 		"", 0, 0,
 	)
 	if err != nil {
+		// Audit-only failure: the draft sweep above already succeeded, so we
+		// log + flag it (WasSuccessful() will report false) but do NOT return —
+		// a prod-query hiccup must not abort the run or roll back the sweep.
 		stats.Errors++
 		slog.Error("orphan_reconciler: query bunk_assignments", "error", err)
 	} else {
@@ -171,9 +198,12 @@ func reconcileOrphanedAssignments(app core.App, year int, stats *Stats) error {
 				BunkID:    p.GetString("bunk"),
 			})
 		}
-		if strandedProd := findStrandedAssignments(validPairs, prodCandidates); len(strandedProd) > 0 {
-			slog.Warn("orphan_reconciler: stranded production assignments detected (not deleted — bunk_assignments sync owns prod cleanup)",
-				"year", year, "count", len(strandedProd))
+		if strandedProd := findStrandedAssignments(validPairs, plannedSessions, prodCandidates); len(strandedProd) > 0 {
+			pairs := make([]string, len(strandedProd))
+			for i, c := range strandedProd {
+				pairs[i] = fmt.Sprintf("%s(session=%s,bunk=%s)", c.RecordID, c.SessionID, c.BunkID)
+			}
+			slog.Warn(msgStrandedProd, "year", year, "count", len(strandedProd), "records", pairs)
 		}
 	}
 

--- a/pocketbase/sync/orphan_reconciler_test.go
+++ b/pocketbase/sync/orphan_reconciler_test.go
@@ -332,3 +332,61 @@ func TestOrphanReconciler_Idempotent(t *testing.T) {
 		t.Errorf("not idempotent — second run changed state: bunk=%q", got.GetString("bunk"))
 	}
 }
+
+// TestOrphanReconciler_ProdQueryErrorIsCountedNotFatal verifies that a failure
+// querying production bunk_assignments is recorded in Stats.Errors — so
+// WasSuccessful() reports false — but does NOT abort the run: the draft sweep
+// that already succeeded must still stand.
+func TestOrphanReconciler_ProdQueryErrorIsCountedNotFatal(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupOrphanCollections(t, app)
+
+	// Drop bunk_assignments so the production-audit query fails. The draft
+	// sweep (bunk_assignments_draft) is unaffected.
+	prodCol, err := app.FindCollectionByNameOrId("bunk_assignments")
+	if err != nil {
+		t.Fatalf("find bunk_assignments: %v", err)
+	}
+	if err = app.Delete(prodCol); err != nil {
+		t.Fatalf("delete bunk_assignments: %v", err)
+	}
+
+	sess := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 100, "year": 2026})
+	keptBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 1, "name": "B-1", "year": 2026})
+	goneBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 2, "name": "G-5", "year": 2026})
+	person := saveRec(t, app, "persons", map[string]any{"cm_id": 9001})
+	// Only keptBunk has a plan for the session — the draft below is stranded.
+	saveRec(t, app, "bunk_plans", map[string]any{"bunk": keptBunk.Id, "session": sess.Id, "year": 2026})
+	scenario := saveRec(t, app, "saved_scenarios", map[string]any{"name": "April", "session": sess.Id, "year": 2026})
+	draft := saveRec(t, app, "bunk_assignments_draft", map[string]any{
+		"scenario": scenario.Id, "person": person.Id, "session": sess.Id,
+		"bunk": goneBunk.Id, "year": 2026,
+	})
+
+	svc := NewOrphanReconcilerSync(app)
+	svc.SetYear(2026)
+	if err = svc.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync must not return an error on a prod-query failure: %v", err)
+	}
+
+	// The draft sweep still ran despite the prod-query failure.
+	got, err := app.FindRecordById("bunk_assignments_draft", draft.Id)
+	if err != nil {
+		t.Fatalf("reload draft: %v", err)
+	}
+	if got.GetString("bunk") != "" {
+		t.Errorf("stranded draft bunk should be cleared, got %q", got.GetString("bunk"))
+	}
+
+	// ...but the prod-query failure is recorded and surfaced.
+	if svc.Stats.Errors == 0 {
+		t.Error("Stats.Errors should be > 0 after a production-query failure")
+	}
+	if svc.WasSuccessful() {
+		t.Error("WasSuccessful() should be false when Stats.Errors > 0")
+	}
+}

--- a/pocketbase/sync/orphan_reconciler_test.go
+++ b/pocketbase/sync/orphan_reconciler_test.go
@@ -1,0 +1,291 @@
+package sync
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+)
+
+func TestFindStrandedAssignments(t *testing.T) {
+	validPairs := map[string]bool{
+		orphanPairKey("sess1", "bunkA"): true,
+		orphanPairKey("sess1", "bunkB"): true,
+	}
+	candidates := []orphanCandidate{
+		{RecordID: "r1", SessionID: "sess1", BunkID: "bunkA"}, // valid
+		{RecordID: "r2", SessionID: "sess1", BunkID: "bunkZ"}, // stranded
+		{RecordID: "r3", SessionID: "sess1", BunkID: ""},      // no bunk - skipped
+		{RecordID: "r4", SessionID: "sess2", BunkID: "bunkA"}, // stranded (wrong session)
+	}
+
+	stranded := findStrandedAssignments(validPairs, candidates)
+
+	if len(stranded) != 2 {
+		t.Fatalf("want 2 stranded, got %d: %+v", len(stranded), stranded)
+	}
+	if stranded[0].RecordID != "r2" || stranded[1].RecordID != "r4" {
+		t.Errorf("want [r2 r4], got [%s %s]", stranded[0].RecordID, stranded[1].RecordID)
+	}
+}
+
+// setupOrphanCollections builds the minimal schema the reconciler touches.
+func setupOrphanCollections(t *testing.T, app core.App) {
+	t.Helper()
+
+	sessions := core.NewBaseCollection("camp_sessions")
+	sessions.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
+	sessions.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(sessions); err != nil {
+		t.Fatalf("create camp_sessions: %v", err)
+	}
+
+	bunks := core.NewBaseCollection("bunks")
+	bunks.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
+	bunks.Fields.Add(&core.TextField{Name: "name"})
+	bunks.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(bunks); err != nil {
+		t.Fatalf("create bunks: %v", err)
+	}
+
+	persons := core.NewBaseCollection("persons")
+	persons.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
+	if err := app.Save(persons); err != nil {
+		t.Fatalf("create persons: %v", err)
+	}
+
+	plans := core.NewBaseCollection("bunk_plans")
+	plans.Fields.Add(&core.RelationField{Name: "bunk", CollectionId: bunks.Id, MaxSelect: 1})
+	plans.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	plans.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(plans); err != nil {
+		t.Fatalf("create bunk_plans: %v", err)
+	}
+
+	scenarios := core.NewBaseCollection("saved_scenarios")
+	scenarios.Fields.Add(&core.TextField{Name: "name"})
+	scenarios.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	scenarios.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(scenarios); err != nil {
+		t.Fatalf("create saved_scenarios: %v", err)
+	}
+
+	drafts := core.NewBaseCollection("bunk_assignments_draft")
+	drafts.Fields.Add(&core.RelationField{Name: "scenario", CollectionId: scenarios.Id, MaxSelect: 1})
+	drafts.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})
+	drafts.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	drafts.Fields.Add(&core.RelationField{Name: "bunk", CollectionId: bunks.Id, MaxSelect: 1})
+	drafts.Fields.Add(&core.RelationField{Name: "bunk_plan", CollectionId: plans.Id, MaxSelect: 1})
+	drafts.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(drafts); err != nil {
+		t.Fatalf("create bunk_assignments_draft: %v", err)
+	}
+
+	prod := core.NewBaseCollection("bunk_assignments")
+	prod.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})
+	prod.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	prod.Fields.Add(&core.RelationField{Name: "bunk", CollectionId: bunks.Id, MaxSelect: 1})
+	prod.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(prod); err != nil {
+		t.Fatalf("create bunk_assignments: %v", err)
+	}
+}
+
+func saveRec(t *testing.T, app core.App, collection string, data map[string]any) *core.Record {
+	t.Helper()
+	col, err := app.FindCollectionByNameOrId(collection)
+	if err != nil {
+		t.Fatalf("find %s: %v", collection, err)
+	}
+	r := core.NewRecord(col)
+	for k, v := range data {
+		r.Set(k, v)
+	}
+	if err := app.Save(r); err != nil {
+		t.Fatalf("save %s: %v", collection, err)
+	}
+	return r
+}
+
+func TestOrphanReconciler_SweepsStrandedDraft(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupOrphanCollections(t, app)
+
+	sess := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 100, "year": 2026})
+	keptBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 1, "name": "B-1", "year": 2026})
+	goneBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 2, "name": "G-5", "year": 2026})
+	person := saveRec(t, app, "persons", map[string]any{"cm_id": 9001})
+	// Only keptBunk has a plan for the session.
+	keptPlan := saveRec(t, app, "bunk_plans", map[string]any{"bunk": keptBunk.Id, "session": sess.Id, "year": 2026})
+	scenario := saveRec(t, app, "saved_scenarios", map[string]any{"name": "April", "session": sess.Id, "year": 2026})
+	// Draft assigned to the now-planless bunk, with a (now stale) bunk_plan ref.
+	draft := saveRec(t, app, "bunk_assignments_draft", map[string]any{
+		"scenario": scenario.Id, "person": person.Id, "session": sess.Id,
+		"bunk": goneBunk.Id, "bunk_plan": keptPlan.Id, "year": 2026,
+	})
+
+	svc := NewOrphanReconcilerSync(app)
+	svc.SetYear(2026)
+	if err := svc.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	got, err := app.FindRecordById("bunk_assignments_draft", draft.Id)
+	if err != nil {
+		t.Fatalf("reload draft: %v", err)
+	}
+	if got.GetString("bunk") != "" {
+		t.Errorf("want bunk cleared, got %q", got.GetString("bunk"))
+	}
+	if got.GetString("bunk_plan") != "" {
+		t.Errorf("want bunk_plan cleared, got %q", got.GetString("bunk_plan"))
+	}
+}
+
+func TestOrphanReconciler_GateSkipsWhenNoBunkPlans(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupOrphanCollections(t, app)
+
+	sess := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 100, "year": 2026})
+	bunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 1, "name": "B-1", "year": 2026})
+	person := saveRec(t, app, "persons", map[string]any{"cm_id": 9001})
+	scenario := saveRec(t, app, "saved_scenarios", map[string]any{"name": "April", "session": sess.Id, "year": 2026})
+	// A draft exists, but NO bunk_plans rows at all for the year.
+	draft := saveRec(t, app, "bunk_assignments_draft", map[string]any{
+		"scenario": scenario.Id, "person": person.Id, "session": sess.Id,
+		"bunk": bunk.Id, "year": 2026,
+	})
+
+	svc := NewOrphanReconcilerSync(app)
+	svc.SetYear(2026)
+	if err := svc.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	// Gate must have skipped: the draft must be untouched.
+	got, err := app.FindRecordById("bunk_assignments_draft", draft.Id)
+	if err != nil {
+		t.Fatalf("reload draft: %v", err)
+	}
+	if got.GetString("bunk") != bunk.Id {
+		t.Errorf("gate failed — draft was swept despite zero bunk_plans (bunk=%q)", got.GetString("bunk"))
+	}
+}
+
+func TestOrphanReconciler_LeavesValidDraftUntouched(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupOrphanCollections(t, app)
+
+	sess := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 100, "year": 2026})
+	bunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 1, "name": "B-1", "year": 2026})
+	person := saveRec(t, app, "persons", map[string]any{"cm_id": 9001})
+	plan := saveRec(t, app, "bunk_plans", map[string]any{"bunk": bunk.Id, "session": sess.Id, "year": 2026})
+	scenario := saveRec(t, app, "saved_scenarios", map[string]any{"name": "April", "session": sess.Id, "year": 2026})
+	draft := saveRec(t, app, "bunk_assignments_draft", map[string]any{
+		"scenario": scenario.Id, "person": person.Id, "session": sess.Id,
+		"bunk": bunk.Id, "bunk_plan": plan.Id, "year": 2026,
+	})
+
+	svc := NewOrphanReconcilerSync(app)
+	svc.SetYear(2026)
+	if err := svc.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	got, err := app.FindRecordById("bunk_assignments_draft", draft.Id)
+	if err != nil {
+		t.Fatalf("reload draft: %v", err)
+	}
+	if got.GetString("bunk") != bunk.Id {
+		t.Errorf("valid draft was swept — bunk=%q", got.GetString("bunk"))
+	}
+	if got.GetString("bunk_plan") != plan.Id {
+		t.Errorf("valid draft's bunk_plan was modified — got %q", got.GetString("bunk_plan"))
+	}
+}
+
+func TestOrphanReconciler_ProdAuditDoesNotDelete(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupOrphanCollections(t, app)
+
+	sess := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 100, "year": 2026})
+	keptBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 1, "name": "B-1", "year": 2026})
+	goneBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 2, "name": "G-5", "year": 2026})
+	person := saveRec(t, app, "persons", map[string]any{"cm_id": 9001})
+	saveRec(t, app, "bunk_plans", map[string]any{"bunk": keptBunk.Id, "session": sess.Id, "year": 2026})
+	// A stranded PRODUCTION assignment.
+	prodRow := saveRec(t, app, "bunk_assignments", map[string]any{
+		"person": person.Id, "session": sess.Id, "bunk": goneBunk.Id, "year": 2026,
+	})
+
+	svc := NewOrphanReconcilerSync(app)
+	svc.SetYear(2026)
+	if err := svc.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	// Prod row must still exist and be untouched — reconciler only audits prod.
+	got, err := app.FindRecordById("bunk_assignments", prodRow.Id)
+	if err != nil {
+		t.Fatalf("prod row was deleted/altered by the reconciler: %v", err)
+	}
+	if got.GetString("bunk") != goneBunk.Id {
+		t.Errorf("prod row bunk was modified — got %q", got.GetString("bunk"))
+	}
+}
+
+func TestOrphanReconciler_Idempotent(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupOrphanCollections(t, app)
+
+	sess := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 100, "year": 2026})
+	keptBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 1, "name": "B-1", "year": 2026})
+	goneBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 2, "name": "G-5", "year": 2026})
+	person := saveRec(t, app, "persons", map[string]any{"cm_id": 9001})
+	saveRec(t, app, "bunk_plans", map[string]any{"bunk": keptBunk.Id, "session": sess.Id, "year": 2026})
+	scenario := saveRec(t, app, "saved_scenarios", map[string]any{"name": "April", "session": sess.Id, "year": 2026})
+	draft := saveRec(t, app, "bunk_assignments_draft", map[string]any{
+		"scenario": scenario.Id, "person": person.Id, "session": sess.Id,
+		"bunk": goneBunk.Id, "year": 2026,
+	})
+
+	svc := NewOrphanReconcilerSync(app)
+	svc.SetYear(2026)
+	if err := svc.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync run 1: %v", err)
+	}
+	svc2 := NewOrphanReconcilerSync(app)
+	svc2.SetYear(2026)
+	if err := svc2.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync run 2: %v", err)
+	}
+
+	got, err := app.FindRecordById("bunk_assignments_draft", draft.Id)
+	if err != nil {
+		t.Fatalf("reload draft: %v", err)
+	}
+	if got.GetString("bunk") != "" {
+		t.Errorf("not idempotent — second run changed state: bunk=%q", got.GetString("bunk"))
+	}
+}

--- a/pocketbase/sync/orphan_reconciler_test.go
+++ b/pocketbase/sync/orphan_reconciler_test.go
@@ -13,20 +13,22 @@ func TestFindStrandedAssignments(t *testing.T) {
 		orphanPairKey("sess1", "bunkA"): true,
 		orphanPairKey("sess1", "bunkB"): true,
 	}
+	// Only sess1 has bunk_plans; sess2 has none (its plans failed to sync).
+	plannedSessions := map[string]bool{"sess1": true}
 	candidates := []orphanCandidate{
-		{RecordID: "r1", SessionID: "sess1", BunkID: "bunkA"}, // valid
-		{RecordID: "r2", SessionID: "sess1", BunkID: "bunkZ"}, // stranded
+		{RecordID: "r1", SessionID: "sess1", BunkID: "bunkA"}, // valid pair - kept
+		{RecordID: "r2", SessionID: "sess1", BunkID: "bunkZ"}, // stranded - bunk not planned
 		{RecordID: "r3", SessionID: "sess1", BunkID: ""},      // no bunk - skipped
-		{RecordID: "r4", SessionID: "sess2", BunkID: "bunkA"}, // stranded (wrong session)
+		{RecordID: "r4", SessionID: "sess2", BunkID: "bunkA"}, // session has zero plans - skipped
 	}
 
-	stranded := findStrandedAssignments(validPairs, candidates)
+	stranded := findStrandedAssignments(validPairs, plannedSessions, candidates)
 
-	if len(stranded) != 2 {
-		t.Fatalf("want 2 stranded, got %d: %+v", len(stranded), stranded)
+	if len(stranded) != 1 {
+		t.Fatalf("want 1 stranded, got %d: %+v", len(stranded), stranded)
 	}
-	if stranded[0].RecordID != "r2" || stranded[1].RecordID != "r4" {
-		t.Errorf("want [r2 r4], got [%s %s]", stranded[0].RecordID, stranded[1].RecordID)
+	if stranded[0].RecordID != "r2" {
+		t.Errorf("want [r2], got [%s]", stranded[0].RecordID)
 	}
 }
 
@@ -131,7 +133,7 @@ func TestOrphanReconciler_SweepsStrandedDraft(t *testing.T) {
 
 	svc := NewOrphanReconcilerSync(app)
 	svc.SetYear(2026)
-	if err := svc.Sync(context.Background()); err != nil {
+	if err = svc.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
 
@@ -167,7 +169,7 @@ func TestOrphanReconciler_GateSkipsWhenNoBunkPlans(t *testing.T) {
 
 	svc := NewOrphanReconcilerSync(app)
 	svc.SetYear(2026)
-	if err := svc.Sync(context.Background()); err != nil {
+	if err = svc.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
 
@@ -178,6 +180,47 @@ func TestOrphanReconciler_GateSkipsWhenNoBunkPlans(t *testing.T) {
 	}
 	if got.GetString("bunk") != bunk.Id {
 		t.Errorf("gate failed — draft was swept despite zero bunk_plans (bunk=%q)", got.GetString("bunk"))
+	}
+}
+
+func TestOrphanReconciler_GateSkipsPerSession(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupOrphanCollections(t, app)
+
+	// Session A has a bunk_plan; session B has none (its plans failed to sync).
+	// The global gate passes because plans exist overall — only the per-session
+	// gate protects session B's drafts.
+	sessA := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 100, "year": 2026})
+	sessB := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 200, "year": 2026})
+	bunkA := saveRec(t, app, "bunks", map[string]any{"cm_id": 1, "name": "A-1", "year": 2026})
+	bunkB := saveRec(t, app, "bunks", map[string]any{"cm_id": 2, "name": "B-1", "year": 2026})
+	person := saveRec(t, app, "persons", map[string]any{"cm_id": 9001})
+	saveRec(t, app, "bunk_plans", map[string]any{"bunk": bunkA.Id, "session": sessA.Id, "year": 2026})
+	scenario := saveRec(t, app, "saved_scenarios", map[string]any{"name": "April", "session": sessB.Id, "year": 2026})
+	// A draft in session B, which has zero bunk_plans. It must NOT be swept —
+	// session B's empty plan set is unreliable, not authoritative.
+	draftB := saveRec(t, app, "bunk_assignments_draft", map[string]any{
+		"scenario": scenario.Id, "person": person.Id, "session": sessB.Id,
+		"bunk": bunkB.Id, "year": 2026,
+	})
+
+	svc := NewOrphanReconcilerSync(app)
+	svc.SetYear(2026)
+	if err = svc.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	got, err := app.FindRecordById("bunk_assignments_draft", draftB.Id)
+	if err != nil {
+		t.Fatalf("reload draft: %v", err)
+	}
+	if got.GetString("bunk") != bunkB.Id {
+		t.Errorf("per-session gate failed — session-B draft swept despite session B having zero bunk_plans (bunk=%q)",
+			got.GetString("bunk"))
 	}
 }
 
@@ -201,7 +244,7 @@ func TestOrphanReconciler_LeavesValidDraftUntouched(t *testing.T) {
 
 	svc := NewOrphanReconcilerSync(app)
 	svc.SetYear(2026)
-	if err := svc.Sync(context.Background()); err != nil {
+	if err = svc.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
 
@@ -237,7 +280,7 @@ func TestOrphanReconciler_ProdAuditDoesNotDelete(t *testing.T) {
 
 	svc := NewOrphanReconcilerSync(app)
 	svc.SetYear(2026)
-	if err := svc.Sync(context.Background()); err != nil {
+	if err = svc.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
 
@@ -272,12 +315,12 @@ func TestOrphanReconciler_Idempotent(t *testing.T) {
 
 	svc := NewOrphanReconcilerSync(app)
 	svc.SetYear(2026)
-	if err := svc.Sync(context.Background()); err != nil {
+	if err = svc.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync run 1: %v", err)
 	}
 	svc2 := NewOrphanReconcilerSync(app)
 	svc2.SetYear(2026)
-	if err := svc2.Sync(context.Background()); err != nil {
+	if err = svc2.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync run 2: %v", err)
 	}
 

--- a/pocketbase/sync/scheduler_test.go
+++ b/pocketbase/sync/scheduler_test.go
@@ -204,9 +204,11 @@ func TestCustomValuesSyncRunsSequentially(t *testing.T) {
 func TestGetRefreshBunkingJobs(t *testing.T) {
 	jobs := GetRefreshBunkingJobs()
 
-	expected := []string{"bunks", "bunk_plans", "bunk_assignments"}
+	// orphan_reconciler runs last: refresh-bunking rewrites bunk_plans, which is
+	// exactly what strands scenario drafts — they must be swept in the same run.
+	expected := []string{"bunks", "bunk_plans", "bunk_assignments", "orphan_reconciler"}
 	if len(jobs) != len(expected) {
-		t.Fatalf("expected %d jobs, got %d", len(expected), len(jobs))
+		t.Fatalf("expected %d jobs, got %d: %v", len(expected), len(jobs), jobs)
 	}
 
 	for i, job := range expected {
@@ -216,9 +218,10 @@ func TestGetRefreshBunkingJobs(t *testing.T) {
 	}
 }
 
-// TestRefreshBunkingRunsAllThreeServices verifies that refresh-bunking triggers
-// bunks, bunk_plans, and bunk_assignments in sequence (not just bunk_assignments)
-func TestRefreshBunkingRunsAllThreeServices(t *testing.T) {
+// TestRefreshBunkingRunsAllServices verifies that refresh-bunking triggers
+// bunks, bunk_plans, bunk_assignments, and orphan_reconciler in sequence
+// (not just bunk_assignments)
+func TestRefreshBunkingRunsAllServices(t *testing.T) {
 	s := NewScheduler(nil)
 
 	// Track which services were called and in what order
@@ -253,7 +256,7 @@ func TestRefreshBunkingRunsAllThreeServices(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	expected := []string{"bunks", "bunk_plans", "bunk_assignments"}
+	expected := []string{"bunks", "bunk_plans", "bunk_assignments", "orphan_reconciler"}
 	if len(callOrder) != len(expected) {
 		t.Fatalf("expected %d services called, got %d: %v", len(expected), len(callOrder), callOrder)
 	}
@@ -266,7 +269,7 @@ func TestRefreshBunkingRunsAllThreeServices(t *testing.T) {
 }
 
 // TestRefreshBunkingRegistersRequiredServices verifies that TriggerSync for
-// refresh-bunking registers mock services for all three bunking sync jobs
+// refresh-bunking requires every bunking sync job to be registered
 func TestRefreshBunkingRegistersRequiredServices(t *testing.T) {
 	s := NewScheduler(nil)
 


### PR DESCRIPTION
## Summary

When staff reorganize a session's bunk plan, scenario draft campers can be left assigned to a bunk that no longer has a `bunk_plan` for that session — the camper then vanishes from the bunks board and shows up as a raw 5-digit CampMinder id in the social graph.

- **`orphan_reconciler`** — a new post-sync Go service that detects stranded draft assignments (`(session, bunk)` pairs with no `bunk_plan`) and silently nulls their `bunk`/`bunk_plan` so the camper falls back into the Unassigned pool. Gated on `bunk_plans` being present for the year (won't sweep against an empty plan set); audits production `bunk_assignments` observe-only (logs, never deletes — the existing `bunk_assignments` sync owns prod cleanup). Wired into the daily sync, the unified `?service=all` sync, and the year-scoped historical sync path.
- **Board** — a camper whose bunk has no plan for the session now falls into the Unassigned panel instead of vanishing entirely.
- **Graph** — a stranded bunk renders as "Removed cabin" instead of a raw 5-digit CampMinder id.

Handled silently — no toast or badge; affected campers simply reappear in the Unassigned pool.

Closes #1416
Closes #1417

## Test Plan

- [x] `go build .` + `go vet ./...` clean
- [x] `go test ./sync/` — full sync suite passes (2032 tests), including 5 new `orphan_reconciler` integration tests (sweep, zero-plans gate, valid-draft-untouched, prod-audit-observe-only, idempotency) + the pure detection-helper unit test
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — board + graph suites pass (181 tests), including new unit tests for `isCamperEffectivelyUnassigned` and the graph fallback label
- [ ] Post-merge: confirm a sync run reconciles the already-stranded `Taste of Camp 1` scenario drafts in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic reconciliation that clears orphaned draft bunk assignments after bunk-plan reorganizations.
  * Improved detection of campers effectively unassigned (including “stranded” cases) with a fallback to avoid board flicker while plans load.

* **Bug Fixes**
  * Graph/diagram parent labels for removed bunks now display "Removed cabin" instead of raw IDs.
  * Draft assignments referencing nonexistent bunks are swept to prevent stranded drafts.

* **Tests**
  * Added tests for orphan reconciliation, stranded-assignment detection, orphan labeling, and unassigned-camper logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1431)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->