### PR TITLE
test(solver): golden alignment test between solve-time sat vars and predicate

### DIFF
--- a/docs/reference/solver-roadmap.md
+++ b/docs/reference/solver-roadmap.md
@@ -36,11 +36,13 @@ only) once individual streams are picked up.
 | **Stream 2 Tier 2 — plateau-diagnostic metrics** | **unfiled — file first** | — | ⬜ **Phase 2 (next)** |
 | Stream 4 — mutual-request boost | #1382 | — | ⬜ Phase 3 |
 | Stream 3 — variable-count attack surface | #1381 | — | ⬜ Phase 4 (re-scope first) |
-| Golden sat-var ↔ predicate alignment test | #1398 | — | ⬜ do now (drift defense for #1427) |
+| Golden sat-var ↔ predicate alignment test | #1398 | #1434 | 🔵 in review (Option 2 — bunk_with/not_bunk_with only) |
 | Retire `solution.calculate_satisfied_requests` | #1397 | — | ⬜ pairs with #1398 |
 | Penalty-driven MP-coverage investigation | #1396 | — | ⬜ low urgency |
 | Audit `direct_solver` for hand-rolled impossibility logic | #1426 | — | ⬜ after #1429 merges |
 | Schematize `grade_spread.max_spread` | #1424 | — | ⬜ small cleanup, anytime |
+| Schematize/remove `negative_requests.hard_constraint_threshold` (dead `not_bunk_with` hard branch) | #1432 | — | ⬜ cleanup (sibling of #1424) |
+| age_preference `sat_var` built-but-discarded + non-MP age_preference unmodeled | #1433 | — | ⬜ cleanup; prereq for #1398 age_preference coverage |
 | Stream 6 substreams 6a–6f | unfiled | — | ⬜ incremental |
 
 All work-item PRs use `Closes #N` in the body so the issue auto-closes on merge.
@@ -935,3 +937,15 @@ Superseded by **"Status & phased sequencing"** near the top of this doc
   issue map) and retired the stale "Suggested order" table. Reconciled the
   Stream 2/3/4 "GitHub issue" lines with filed issue numbers. Flagged Tier 2
   as unfiled (orphaned when #1380 closed on Tier 1 alone).
+- **2026-05-14** — #1398 in review (PR #1434): golden sat-var ↔ predicate
+  alignment test. Scoped to Option 2 — asserts agreement for every entry in
+  `request_satisfied_vars` (the shared bidirectional `bunk_with`/`not_bunk_with`
+  sat var, i.e. the complete output of `get_or_create_request_sat_var` and the
+  surface #1427 changed). `age_preference` is out of scope: digging into #1398
+  found its solve-time `sat_var` is one-way encoded *and* discarded by its only
+  caller — no faithful var to align against. Two dead-code findings filed:
+  #1432 (`negative_requests.hard_constraint_threshold` unschematized + the
+  `not_bunk_with` hard branch unreachable since real priorities are 1–4) and
+  #1433 (age_preference `sat_var` built-but-discarded; non-MP age_preference
+  unmodeled by the solver — confirm intent). #1433 is the prerequisite for ever
+  extending #1398's alignment test to `age_preference`.

--- a/tests/integration/solver/conftest.py
+++ b/tests/integration/solver/conftest.py
@@ -5,7 +5,14 @@ tests/unit/solver/test_satvar_unification.py: a MagicMock ConfigLoader that
 forwards every typed getter to its `default=`, plus a _PenaltyStubLoader
 installed via ConfigLoader.use() so penalty helpers in penalties.py that call
 ConfigLoader.get_instance() directly work without a real PocketBase
-connection. Lifted here so multiple integration tests can share it.
+connection.
+
+Lives in this conftest so future integration tests under
+tests/integration/solver/ can opt in; test_satvar_predicate_alignment.py is
+the current consumer. The sibling test_taste_of_camp_feasible.py keeps its own
+variant — it runs the full solve()+scoring path and injects the mock itself as
+the ConfigLoader singleton, which the shallow _PenaltyStubLoader here does not
+cover.
 """
 
 from __future__ import annotations

--- a/tests/integration/solver/conftest.py
+++ b/tests/integration/solver/conftest.py
@@ -1,0 +1,89 @@
+"""Shared fixtures for tests/integration/solver/.
+
+`mock_config` mirrors the proven fixture in
+tests/unit/solver/test_satvar_unification.py: a MagicMock ConfigLoader that
+forwards every typed getter to its `default=`, plus a _PenaltyStubLoader
+installed via ConfigLoader.use() so penalty helpers in penalties.py that call
+ConfigLoader.get_instance() directly work without a real PocketBase
+connection. Lifted here so multiple integration tests can share it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any, ClassVar
+from unittest.mock import MagicMock
+
+import pytest
+
+from bunking.config import ConfigLoader
+
+
+class _PenaltyStubLoader:
+    """Provides only the keys that penalties.py reads via
+    ConfigLoader.get_instance(), returning sensible zero/stub values."""
+
+    # Extend when penalty helpers start reading new key types via
+    # ConfigLoader.get_instance().
+    _values: ClassVar[dict[str, int]] = {
+        "constraint.cabin_minimum_occupancy.penalty": 0,
+        "constraint.grade_spread.penalty": 0,
+    }
+
+    def get_int(self, key: str, default: int | None = None) -> int:
+        v = self._values.get(key)
+        return int(v) if v is not None else (default if default is not None else 0)
+
+    def get_float(self, key: str, default: float | None = None) -> float:
+        v = self._values.get(key)
+        return float(v) if v is not None else (default if default is not None else 0.0)
+
+
+@pytest.fixture
+def mock_config() -> Generator[Any]:
+    """ConfigLoader mock that forwards every typed getter to its `default=`.
+
+    Also installs a _PenaltyStubLoader via ConfigLoader.use() so that penalty
+    helpers (penalties.py) that call ConfigLoader.get_instance() directly work
+    without a real ConfigLoader. With get_soft_constraint_weight pinned to 0,
+    soft penalties are inert and the solver only enforces hard constraints
+    (assignment, capacity, min-occupancy, grade_spread, grade_adjacency,
+    session_boundary, gender, parent_paramount).
+    """
+    cfg = MagicMock()
+
+    def _get_constraint(constraint_type: str, param: str, default: Any = None) -> Any:
+        if constraint_type == "grade_spread" and param == "max_spread":
+            return 2
+        return default if default is not None else 0
+
+    def _get_int(key: str, default: Any = None) -> Any:
+        return default if default is not None else 0
+
+    def _get_float(key: str, default: Any = None) -> Any:
+        return default if default is not None else 0.0
+
+    def _get_str(key: str, default: Any = None) -> Any:
+        if "grade_spread.mode" in key:
+            return "hard"
+        return default if default is not None else ""
+
+    def _get_bool(key: str, default: Any = None) -> Any:
+        return default if default is not None else False
+
+    def _get_priority(priority_type: str, subtype: str = "default") -> int:
+        return 4
+
+    def _get_soft_constraint_weight(constraint_name: str) -> int:
+        return 0
+
+    cfg.get_constraint.side_effect = _get_constraint
+    cfg.get_int.side_effect = _get_int
+    cfg.get_float.side_effect = _get_float
+    cfg.get_str.side_effect = _get_str
+    cfg.get_bool.side_effect = _get_bool
+    cfg.get_priority.side_effect = _get_priority
+    cfg.get_soft_constraint_weight.side_effect = _get_soft_constraint_weight
+
+    with ConfigLoader.use(_PenaltyStubLoader()):  # type: ignore[arg-type]
+        yield cfg

--- a/tests/integration/solver/fixtures.py
+++ b/tests/integration/solver/fixtures.py
@@ -1,0 +1,182 @@
+"""Integration-test scenario builders for the solver.
+
+`build_alignment_fixture` returns a DirectSolverInput engineered so the solver
+has exactly one feasible partition (up to bunk relabelling) — every assertion
+target resolves to a known satisfied/unsatisfied value regardless of which
+optimal solution CP-SAT lands on.
+
+Determinism levers (all hard constraints):
+  * 16 grade-6 female campers, 2 female bunks, capacity 8 each.
+  * cabin min-occupancy (hardcoded MIN_BUNK_OCCUPANCY = 8) + force-all-used
+    (16 campers >= 8 * 2 bunks) => each used bunk holds exactly 8.
+  * Campers 2-8 each have one Material-Parent bunk_with -> camper 1, so
+    parent_paramount's hard must-satisfy-one binds them into camper 1's bunk.
+    {1..8} fills one bunk to capacity; {9..16} are forced into the other.
+
+The two camper groups therefore land in different bunks in every feasible
+solution, which fixes the satisfied/unsatisfied outcome of every request the
+alignment test asserts on.
+"""
+
+from __future__ import annotations
+
+from bunking.models_v2 import DirectSolverInput
+from tests.unit.solver.impossibility.conftest import (
+    make_bunk,
+    make_input,
+    make_person,
+    make_request,
+)
+
+SESSION = 1000001
+
+# Material-Parent source field (MATERIAL_PARENT bucket per bunking/satisfaction/
+# bucket.py); "bunking_notes" is an explicit-but-non-MP STAFF-bucket source.
+MP_SOURCE = "bunk_with"
+NON_MP_SOURCE = "bunking_notes"
+
+# Camper cm_ids 1..8 are the MP clique (forced together by parent_paramount);
+# 9..16 are forced into the other bunk.
+CLIQUE = list(range(1, 9))
+OTHER = list(range(9, 17))
+
+# Request ids the alignment test asserts on, with their structurally-forced
+# satisfaction outcome. The solver/predicate must agree with these values.
+EXPECTED_SATISFACTION: dict[str, bool] = {
+    # MP bunk_with: parent_paramount forces sat == 1, and co-placement holds.
+    "mp_2_1": True,
+    "mp_3_1": True,
+    "mp_4_1": True,
+    "mp_5_1": True,
+    "mp_6_1": True,
+    "mp_7_1": True,
+    "mp_8_1": True,
+    # Non-MP bunk_with, both ends in the OTHER bunk -> satisfied.
+    "sat_nonmp_bw": True,
+    # Non-MP bunk_with, one end in CLIQUE one in OTHER -> unsatisfied.
+    "unsat_nonmp_bw": False,
+    # Non-MP not_bunk_with, the two ends in different bunks -> satisfied.
+    "sat_nonmp_nbw": True,
+    # Non-MP not_bunk_with, both ends in CLIQUE (same bunk) -> unsatisfied.
+    "unsat_nonmp_nbw": False,
+}
+
+# Request ids that exercise the build/validation path but never get a shared
+# sat var (age_preference + impossible requests). The alignment test asserts
+# these are absent from request_satisfied_vars.
+BUILD_PATH_EXERCISERS: frozenset[str] = frozenset({"exer_age_pref", "exer_target_not_in_solver", "exer_malformed"})
+
+
+def build_alignment_fixture() -> DirectSolverInput:
+    """Build the satvar <-> predicate alignment scenario.
+
+    See module docstring for the determinism rationale.
+    """
+    persons = [make_person(cm_id, session=SESSION, gender="F", grade=6) for cm_id in CLIQUE + OTHER]
+
+    # capacity=8 + MIN_BUNK_OCCUPANCY=8 + 16 campers => exactly 8 per bunk.
+    bunks = [
+        make_bunk(2001, session=SESSION, gender="F", capacity=8),
+        make_bunk(2002, session=SESSION, gender="F", capacity=8),
+    ]
+
+    requests = []
+
+    # MP clique: campers 2..8 each request camper 1 (Material-Parent). Each is
+    # the camper's only MP request, so parent_paramount forces it satisfied.
+    for cm_id in CLIQUE[1:]:
+        requests.append(
+            make_request(
+                f"mp_{cm_id}_1",
+                requester=cm_id,
+                requestee=1,
+                request_type="bunk_with",
+                source_field=MP_SOURCE,
+                priority=4,
+                session=SESSION,
+            )
+        )
+
+    # Non-MP assertion targets — all between gender/grade-compatible pairs, so
+    # they get a shared bidirectional sat var via get_or_create_request_sat_var.
+    requests += [
+        # camper 9 -> camper 10, both forced into OTHER bunk -> satisfied.
+        make_request(
+            "sat_nonmp_bw",
+            requester=9,
+            requestee=10,
+            request_type="bunk_with",
+            source_field=NON_MP_SOURCE,
+            priority=3,
+            session=SESSION,
+        ),
+        # camper 1 (CLIQUE) -> camper 9 (OTHER) -> unsatisfied.
+        make_request(
+            "unsat_nonmp_bw",
+            requester=1,
+            requestee=9,
+            request_type="bunk_with",
+            source_field=NON_MP_SOURCE,
+            priority=3,
+            session=SESSION,
+        ),
+        # camper 1 (CLIQUE) -> camper 10 (OTHER), different bunks -> satisfied.
+        make_request(
+            "sat_nonmp_nbw",
+            requester=1,
+            requestee=10,
+            request_type="not_bunk_with",
+            source_field=NON_MP_SOURCE,
+            priority=3,
+            session=SESSION,
+        ),
+        # camper 1 -> camper 3, both in CLIQUE (same bunk) -> unsatisfied.
+        make_request(
+            "unsat_nonmp_nbw",
+            requester=1,
+            requestee=3,
+            request_type="not_bunk_with",
+            source_field=NON_MP_SOURCE,
+            priority=3,
+            session=SESSION,
+        ),
+    ]
+
+    # Build-path exercisers — never enter request_satisfied_vars. Kept non-MP
+    # so they don't perturb the deterministic partition.
+    requests += [
+        # age_preference: get_or_create_request_sat_var returns None for it.
+        # All campers are grade 6, so AgePreferenceImpossibility also flags it.
+        make_request(
+            "exer_age_pref",
+            requester=12,
+            requestee=None,
+            request_type="age_preference",
+            source_field=NON_MP_SOURCE,
+            age_preference_target="older",
+            priority=2,
+            session=SESSION,
+        ),
+        # target not in the solver roster -> TargetNotInSolverImpossibility.
+        make_request(
+            "exer_target_not_in_solver",
+            requester=13,
+            requestee=999999,
+            request_type="bunk_with",
+            source_field=NON_MP_SOURCE,
+            priority=2,
+            session=SESSION,
+        ),
+        # malformed bunk_with (no requestee) -> MalformedRequestImpossibility.
+        make_request(
+            "exer_malformed",
+            requester=14,
+            requestee=None,
+            request_type="bunk_with",
+            source_field=NON_MP_SOURCE,
+            priority=2,
+            session=SESSION,
+        ),
+    ]
+
+    return make_input(persons, bunks, requests)

--- a/tests/integration/solver/test_satvar_predicate_alignment.py
+++ b/tests/integration/solver/test_satvar_predicate_alignment.py
@@ -1,0 +1,137 @@
+"""Golden alignment test: solve-time sat vars vs post-solve predicate.
+
+#1398 — drift defense between the solver's CP-SAT satisfaction encoding
+(``get_or_create_request_sat_var`` in
+``bunking/solver/constraints/bunk_requests.py``) and the post-solve oracle
+(``bunking.satisfaction.predicate.is_request_satisfied``).
+
+Scope (Option 2 — see #1398): asserts agreement for every entry in
+``DirectBunkingSolver.request_satisfied_vars`` — the shared bidirectional sat
+var built for ``bunk_with`` / ``not_bunk_with`` requests with in-roster
+targets. That map is the complete output of ``get_or_create_request_sat_var``
+and the exact surface PR #1427 changed.
+
+``age_preference`` is deliberately out of scope: it has no faithful
+satisfaction var to align against (its sat var is one-way encoded and
+discarded by its only caller — see #1433). The fixture still includes an
+``age_preference`` request plus impossible requests so the build/validation
+path is exercised, but they carry no shared sat var and so are not asserted.
+
+If ``test_satvar_predicate_alignment`` fails on real divergence (not a fixture
+bug), per the #1398 acceptance criteria file a follow-up to investigate which
+path — the encoding or the predicate — is wrong.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ortools.sat.python import cp_model
+
+from bunking.satisfaction.predicate import is_request_satisfied
+from bunking.solver.direct_solver import DirectBunkingSolver
+from tests.integration.solver.fixtures import (
+    BUILD_PATH_EXERCISERS,
+    EXPECTED_SATISFACTION,
+    build_alignment_fixture,
+)
+
+
+def _build_and_solve(mock_config: Any) -> tuple[DirectBunkingSolver, cp_model.CpSolver]:
+    """Build the alignment fixture, add constraints + objective, and solve.
+
+    Uses a test-local ``CpSolver`` with ``num_search_workers=1`` — the model is
+    tiny, and single-worker keeps the solve fast and reproducible. Mirrors the
+    build-and-inspect pattern established by
+    ``tests/unit/solver/test_satvar_unification.py``.
+    """
+    solver = DirectBunkingSolver(build_alignment_fixture(), config_service=mock_config)
+    solver.add_constraints()
+    solver.add_objective()
+
+    cp_solver = cp_model.CpSolver()
+    cp_solver.parameters.max_time_in_seconds = 10
+    cp_solver.parameters.num_search_workers = 1
+    status = cp_solver.Solve(solver.model)
+    assert status in (cp_model.OPTIMAL, cp_model.FEASIBLE), (
+        f"alignment fixture did not solve: status={cp_solver.StatusName(status)}"
+    )
+    return solver, cp_solver
+
+
+def _person_to_bunk(solver: DirectBunkingSolver, cp_solver: cp_model.CpSolver) -> dict[int, int]:
+    """Reconstruct the cm_id -> bunk_cm_id map the predicate consumes."""
+    person_to_bunk: dict[int, int] = {}
+    for person_idx, person_cm_id in enumerate(solver.person_ids):
+        for bunk_idx, bunk in enumerate(solver.bunks):
+            if cp_solver.Value(solver.assignments[(person_idx, bunk_idx)]) == 1:
+                person_to_bunk[person_cm_id] = bunk.campminder_id
+                break
+    return person_to_bunk
+
+
+def test_satvar_predicate_alignment(mock_config: Any) -> None:
+    """Every shared sat var agrees with ``is_request_satisfied`` post-solve."""
+    solver, cp_solver = _build_and_solve(mock_config)
+    person_to_bunk = _person_to_bunk(solver, cp_solver)
+
+    sat_vars = solver.request_satisfied_vars
+    assert sat_vars, "fixture produced no shared sat vars — nothing to align"
+
+    # age_preference / impossible requests must never get a shared sat var.
+    for req_id in BUILD_PATH_EXERCISERS:
+        assert req_id not in sat_vars, (
+            f"{req_id} unexpectedly has a shared sat var — get_or_create_request_sat_var "
+            f"should return None for age_preference / impossible requests"
+        )
+
+    requests_by_id = {r.id: r for r in solver.input.requests}
+    disagreements: list[str] = []
+    seen_true = seen_false = False
+
+    for req_id, sat_var in sat_vars.items():
+        request = requests_by_id[req_id]
+        solver_satisfied = bool(cp_solver.Value(sat_var))
+        # bunkmate_grades is unused: age_preference never reaches this map, and
+        # is_request_satisfied only requires it for age_preference requests.
+        predicate_satisfied = is_request_satisfied(
+            request.model_dump(),
+            person_to_bunk,
+            bunkmate_grades=None,
+        )
+        seen_true |= solver_satisfied
+        seen_false |= not solver_satisfied
+
+        if solver_satisfied != predicate_satisfied:
+            disagreements.append(
+                f"  {req_id} ({request.request_type}, "
+                f"{request.requester_person_cm_id}->{request.requested_person_cm_id}): "
+                f"solver sat_var={solver_satisfied}, is_request_satisfied={predicate_satisfied}"
+            )
+
+    assert not disagreements, "solve-time sat vars disagree with is_request_satisfied:\n" + "\n".join(disagreements)
+
+    # Anti-vacuous guards: the fixture must exercise BOTH predicate branches,
+    # else an all-satisfied (or all-unsatisfied) solve would pass trivially.
+    assert seen_true, "fixture exercised no satisfied request — alignment test is vacuous"
+    assert seen_false, "fixture exercised no unsatisfied request — alignment test is vacuous"
+
+
+def test_alignment_fixture_outcomes_are_deterministic(mock_config: Any) -> None:
+    """The fixture's structurally-forced outcomes hold.
+
+    Guards the fixture itself against silently drifting into a degenerate
+    scenario (e.g. all-satisfied) that would make the alignment assertion
+    vacuous. A failure here means the fixture needs re-checking — not that the
+    solver/predicate disagree.
+    """
+    solver, cp_solver = _build_and_solve(mock_config)
+    sat_vars = solver.request_satisfied_vars
+
+    for req_id, expected in EXPECTED_SATISFACTION.items():
+        assert req_id in sat_vars, f"{req_id} expected in request_satisfied_vars but absent"
+        actual = bool(cp_solver.Value(sat_vars[req_id]))
+        assert actual == expected, (
+            f"{req_id}: fixture expected sat_var={expected}, solver produced {actual} — "
+            f"the deterministic partition no longer holds, re-check build_alignment_fixture"
+        )

--- a/tests/integration/solver/test_satvar_predicate_alignment.py
+++ b/tests/integration/solver/test_satvar_predicate_alignment.py
@@ -60,13 +60,25 @@ def _build_and_solve(mock_config: Any) -> tuple[DirectBunkingSolver, cp_model.Cp
 
 
 def _person_to_bunk(solver: DirectBunkingSolver, cp_solver: cp_model.CpSolver) -> dict[int, int]:
-    """Reconstruct the cm_id -> bunk_cm_id map the predicate consumes."""
+    """Reconstruct the cm_id -> bunk_cm_id map the predicate consumes.
+
+    The hard assignment constraint (``sum(assignments) == 1`` per camper)
+    guarantees exactly one bunk per camper in any FEASIBLE/OPTIMAL solve. We
+    assert that cardinality explicitly so a fixture regression (e.g. the
+    assignment constraint disabled) fails loudly here rather than silently
+    masking an alignment failure.
+    """
     person_to_bunk: dict[int, int] = {}
     for person_idx, person_cm_id in enumerate(solver.person_ids):
-        for bunk_idx, bunk in enumerate(solver.bunks):
-            if cp_solver.Value(solver.assignments[(person_idx, bunk_idx)]) == 1:
-                person_to_bunk[person_cm_id] = bunk.campminder_id
-                break
+        assigned_bunks = [
+            bunk.campminder_id
+            for bunk_idx, bunk in enumerate(solver.bunks)
+            if cp_solver.Value(solver.assignments[(person_idx, bunk_idx)]) == 1
+        ]
+        assert len(assigned_bunks) == 1, (
+            f"expected exactly one assigned bunk for camper {person_cm_id}, got {assigned_bunks}"
+        )
+        person_to_bunk[person_cm_id] = assigned_bunks[0]
     return person_to_bunk
 
 
@@ -127,6 +139,17 @@ def test_alignment_fixture_outcomes_are_deterministic(mock_config: Any) -> None:
     """
     solver, cp_solver = _build_and_solve(mock_config)
     sat_vars = solver.request_satisfied_vars
+
+    # request_satisfied_vars must hold EXACTLY the expected request ids — no
+    # more, no less. Without the converse check, a future change that emits a
+    # shared sat var for an unexpected request id would slip past both this
+    # test and test_satvar_predicate_alignment (whose BUILD_PATH_EXERCISERS
+    # guard only names the three known exercisers).
+    assert set(sat_vars) == set(EXPECTED_SATISFACTION), (
+        "request_satisfied_vars key set drifted from EXPECTED_SATISFACTION:\n"
+        f"  unexpected: {sorted(set(sat_vars) - set(EXPECTED_SATISFACTION))}\n"
+        f"  missing:    {sorted(set(EXPECTED_SATISFACTION) - set(sat_vars))}"
+    )
 
     for req_id, expected in EXPECTED_SATISFACTION.items():
         assert req_id in sat_vars, f"{req_id} expected in request_satisfied_vars but absent"


### PR DESCRIPTION
## What

Adds the golden alignment test from #1398 — drift defense between the solver's CP-SAT satisfaction encoding (`get_or_create_request_sat_var`) and the post-solve oracle (`is_request_satisfied`).

For a fixed fixture session, the test asserts that every entry in `DirectBunkingSolver.request_satisfied_vars` agrees with `is_request_satisfied` evaluated against the resulting assignment.

## Scope (Option 2)

Covers the shared bidirectional sat var for `bunk_with` / `not_bunk_with` requests with in-roster targets — the **complete output** of `get_or_create_request_sat_var` and the exact surface PR #1427 changed.

`age_preference` is deliberately **out of scope**: it has no faithful satisfaction var to align against — its sat var is one-way encoded *and* discarded by its only caller (filed as #1433). The fixture still includes an `age_preference` request plus impossible requests so the build/validation path is exercised; they carry no shared sat var and so aren't asserted. A meaningful age_preference alignment test is a follow-up gated on #1433.

## Files

- `tests/integration/solver/fixtures.py` — `build_alignment_fixture()`: 16 grade-6 campers / 2 capacity-8 bunks. Hard constraints (capacity + min-occupancy=8 + `parent_paramount` MP clique) force a *single* feasible partition, so every assertion target has a structurally-determined outcome — no manually-verified "golden assignment" needed (alignment is solution-agnostic).
- `tests/integration/solver/conftest.py` — shared `mock_config` fixture (mirrors the proven fixture in `test_satvar_unification.py`).
- `tests/integration/solver/test_satvar_predicate_alignment.py` — the alignment test, a fixture-determinism guard, and anti-vacuous checks (both predicate branches must be exercised; build-path exercisers must be absent from the map).

## Verification

- Both tests pass; full unit suite green (4536 passed); ruff + mypy clean.
- **Drift-detection proven non-vacuous:** temporarily inverting the `bunk_with` encoding in `get_or_create_request_sat_var` made the test fail with a clean per-request disagreement report. Reverted.

## Related

- Closes #1398
- #1432, #1433 — dead-code findings surfaced while digging into #1398 (unschematized `negative_requests.hard_constraint_threshold` / dead `not_bunk_with` hard branch; age_preference `sat_var` built-but-discarded + non-MP age_preference unmodeled)
- #1397 pairs with this — once `solution.calculate_satisfied_requests` is retired, `is_request_satisfied` becomes the sole post-solve oracle this test guards
- Tracked in `docs/reference/solver-roadmap.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded solver roadmap Phase 2 with additional planned cleanups, investigations, and follow-ups
  * Added changelog entry documenting the alignment verification test and related discoveries

* **Tests**
  * Added integration test configuration and fixtures to build deterministic solver scenarios
  * Added integration tests verifying solver sat-variable ↔ predicate alignment and fixture determinism

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1434)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->