### PR TITLE
feat(solver): Tier 2 plateau-diagnostic metrics (roadmap Phase 2)

### DIFF
--- a/bunking/solver/callbacks.py
+++ b/bunking/solver/callbacks.py
@@ -14,13 +14,14 @@ from .logging import ConstraintLogger
 
 logger = get_logger(__name__)
 
-# Safety cap on the best-bound trajectory length. The callback fires on
-# discrete bound *improvements* (realistically tens-to-low-hundreds over a
-# 600 s solve), but a pathological model could fire it far more often — cap
-# rather than let `solver_runs.stats` bloat. NOT a lossy throttle: points are
-# only dropped once the cap is hit, so the drift invariant (see the Tier 2
-# spec) holds for every point actually recorded.
-_MAX_BOUND_POINTS = 2000
+# Safety cap on trajectory length, shared by both capture surfaces
+# (objective and best-bound). The callbacks fire on discrete *improvements*
+# (realistically tens-to-low-hundreds over a 600 s solve), but a pathological
+# model could fire either one far more often — cap rather than let
+# `solver_runs.stats` bloat. NOT a lossy throttle: points are only dropped
+# once the cap is hit, so the drift invariant (see the Tier 2 spec) holds for
+# every point actually recorded.
+_MAX_TRAJECTORY_POINTS = 2000
 
 
 class SolverProgressCallback(cp_model.CpSolverSolutionCallback):  # type: ignore[misc]
@@ -39,6 +40,7 @@ class SolverProgressCallback(cp_model.CpSolverSolutionCallback):  # type: ignore
         self.solution_count = 0
         self.start_monotonic = start_monotonic
         self.objective_trajectory: list[dict[str, float]] = []
+        self.truncated = False
 
     def on_solution_callback(self) -> None:
         """Called when a new solution is found."""
@@ -46,7 +48,12 @@ class SolverProgressCallback(cp_model.CpSolverSolutionCallback):  # type: ignore
         elapsed = time.monotonic() - self.start_monotonic
         objective = self.ObjectiveValue()
         bound = self.BestObjectiveBound()
-        self.objective_trajectory.append({"t": elapsed, "objective": objective, "bound": bound})
+        # Cap the trajectory in lockstep with BestBoundCallback so neither
+        # surface can bloat `solver_runs.stats`. Logging below is unaffected.
+        if len(self.objective_trajectory) >= _MAX_TRAJECTORY_POINTS:
+            self.truncated = True
+        else:
+            self.objective_trajectory.append({"t": elapsed, "objective": objective, "bound": bound})
 
         message = f"Solution #{self.solution_count} found after {elapsed:.1f}s - Objective: {objective}"
         self.constraint_logger.log_progress(message)
@@ -73,7 +80,7 @@ class BestBoundCallback:
         self.truncated = False
 
     def __call__(self, bound: float) -> None:
-        if len(self.bound_trajectory) >= _MAX_BOUND_POINTS:
+        if len(self.bound_trajectory) >= _MAX_TRAJECTORY_POINTS:
             self.truncated = True
             return
         self.bound_trajectory.append({"t": time.monotonic() - self.start_monotonic, "bound": bound})

--- a/bunking/solver/callbacks.py
+++ b/bunking/solver/callbacks.py
@@ -4,7 +4,7 @@ Solver Callbacks - Progress monitoring for OR-Tools CP-SAT solver.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+import time
 
 from ortools.sat.python import cp_model
 
@@ -14,28 +14,66 @@ from .logging import ConstraintLogger
 
 logger = get_logger(__name__)
 
+# Safety cap on the best-bound trajectory length. The callback fires on
+# discrete bound *improvements* (realistically tens-to-low-hundreds over a
+# 600 s solve), but a pathological model could fire it far more often — cap
+# rather than let `solver_runs.stats` bloat. NOT a lossy throttle: points are
+# only dropped once the cap is hit, so the drift invariant (see the Tier 2
+# spec) holds for every point actually recorded.
+_MAX_BOUND_POINTS = 2000
+
 
 class SolverProgressCallback(cp_model.CpSolverSolutionCallback):  # type: ignore[misc]
-    """Callback to log solver progress in real-time."""
+    """Callback to log solver progress and record the objective trajectory.
 
-    def __init__(self, constraint_logger: ConstraintLogger, debug_mode: bool = False) -> None:
+    Records `(t, objective, bound)` for each improving solution. `t` is
+    seconds since `start_monotonic`, a shared origin passed by the caller so
+    this trajectory and `BestBoundCallback.bound_trajectory` are directly
+    comparable.
+    """
+
+    def __init__(self, constraint_logger: ConstraintLogger, start_monotonic: float, debug_mode: bool = False) -> None:
         cp_model.CpSolverSolutionCallback.__init__(self)
         self.constraint_logger = constraint_logger
         self.debug_mode = debug_mode
         self.solution_count = 0
-        self.start_time = datetime.now(tz=UTC)
+        self.start_monotonic = start_monotonic
+        self.objective_trajectory: list[dict[str, float]] = []
 
     def on_solution_callback(self) -> None:
         """Called when a new solution is found."""
         self.solution_count += 1
-        current_time = datetime.now(tz=UTC)
-        elapsed = (current_time - self.start_time).total_seconds()
+        elapsed = time.monotonic() - self.start_monotonic
+        objective = self.ObjectiveValue()
+        bound = self.BestObjectiveBound()
+        self.objective_trajectory.append({"t": elapsed, "objective": objective, "bound": bound})
 
-        message = f"Solution #{self.solution_count} found after {elapsed:.1f}s - Objective: {self.ObjectiveValue()}"
-
+        message = f"Solution #{self.solution_count} found after {elapsed:.1f}s - Objective: {objective}"
         self.constraint_logger.log_progress(message)
 
         # In debug mode, log more details
         if self.debug_mode and self.solution_count <= 5:
-            logger.debug(f"  Best bound: {self.BestObjectiveBound()}")
-            logger.debug(f"  Gap: {abs(self.ObjectiveValue() - self.BestObjectiveBound())}")
+            logger.debug(f"  Best bound: {bound}")
+            logger.debug(f"  Gap: {abs(objective - bound)}")
+
+
+class BestBoundCallback:
+    """Records the CP-SAT best-objective-bound trajectory.
+
+    Assigned to `solver.best_bound_callback`; CP-SAT invokes it as
+    `callback(bound)` on every bound improvement — independent of solution
+    discovery, so it keeps sampling through an objective plateau when the
+    solution callback goes quiet. Shares its monotonic clock origin with
+    `SolverProgressCallback`.
+    """
+
+    def __init__(self, start_monotonic: float) -> None:
+        self.start_monotonic = start_monotonic
+        self.bound_trajectory: list[dict[str, float]] = []
+        self.truncated = False
+
+    def __call__(self, bound: float) -> None:
+        if len(self.bound_trajectory) >= _MAX_BOUND_POINTS:
+            self.truncated = True
+            return
+        self.bound_trajectory.append({"t": time.monotonic() - self.start_monotonic, "bound": bound})

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -676,6 +676,7 @@ class DirectBunkingSolver:
             "objective_trajectory": [],
             "bound_trajectory": [],
             "bound_trajectory_truncated": False,
+            "objective_trajectory_truncated": False,
             "lp_root_gap": None,
             "presolve_compression_ratio": None,
             "presolve_booleans_pre": 0,
@@ -893,6 +894,7 @@ class DirectBunkingSolver:
             objective_trajectory=callback.objective_trajectory,
             bound_trajectory=bound_cb.bound_trajectory,
             bound_trajectory_truncated=bound_cb.truncated,
+            objective_trajectory_truncated=callback.truncated,
         )
         stats["request_validation"] = self.request_validation_summary
 

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -6,6 +6,7 @@ No transformation needed.
 from __future__ import annotations
 
 import os
+import time
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
@@ -726,8 +727,11 @@ class DirectBunkingSolver:
         solver.parameters.cp_model_presolve = True  # Enable preprocessing
         solver.parameters.search_branching = cp_model.FIXED_SEARCH  # Try different search strategies
 
-        # Add callback for progress tracking
-        callback = SolverProgressCallback(self.constraint_logger, self.debug_mode)
+        # Add callback for progress tracking. Both capture surfaces (this and
+        # BestBoundCallback, wired below) share one monotonic origin so their
+        # trajectories are directly comparable.
+        start_monotonic = time.monotonic()
+        callback = SolverProgressCallback(self.constraint_logger, start_monotonic, self.debug_mode)
 
         # Log solver start
         self.constraint_logger.log_progress(f"Starting solver with {time_limit_seconds}s time limit...")

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -25,7 +25,7 @@ from bunking.sync.bunk_request_processor.core.models import RequestType
 from bunking.sync.bunk_request_processor.shared.constants import SOURCE_FIELD_TO_CONFIG_KEY
 from campminder.client import get_current_season
 
-from .callbacks import SolverProgressCallback
+from .callbacks import BestBoundCallback, SolverProgressCallback
 from .constraints.age_grade_flow import add_age_grade_flow_objective
 from .constraints.age_spread import add_age_spread_constraints
 from .constraints.base import SolverContext
@@ -745,6 +745,14 @@ class DirectBunkingSolver:
         start_monotonic = time.monotonic()
         callback = SolverProgressCallback(self.constraint_logger, start_monotonic, self.debug_mode)
 
+        # Best-bound capture surface — fires on every bound improvement,
+        # independent of solutions, so it samples through the plateau when
+        # `callback` goes quiet. hasattr guard: a pre-9.15 ortools local env
+        # degrades to an empty bound_trajectory instead of crashing.
+        bound_cb = BestBoundCallback(start_monotonic)
+        if hasattr(solver, "best_bound_callback"):
+            solver.best_bound_callback = bound_cb
+
         # Log solver start
         self.constraint_logger.log_progress(f"Starting solver with {time_limit_seconds}s time limit...")
         logger.debug(
@@ -882,6 +890,9 @@ class DirectBunkingSolver:
             satisfied_count=sum(len(reqs) for reqs in satisfied_requests.values()),
             soft_constraint_violations=self.soft_constraint_violations,
             requests_by_person=self.input.requests_by_person,
+            objective_trajectory=callback.objective_trajectory,
+            bound_trajectory=bound_cb.bound_trajectory,
+            bound_trajectory_truncated=bound_cb.truncated,
         )
         stats["request_validation"] = self.request_validation_summary
 

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -670,6 +670,18 @@ class DirectBunkingSolver:
             "request_density_histogram_by_bucket": _build_request_density_histogram_by_bucket(
                 self.input.requests_by_person
             ),
+            # Tier 2 observability (Stream 2, Phase 2) — single-bunk path has
+            # no CP-SAT solve, so trajectories are empty and derived scalars
+            # are None. Keys present so frontend rendering is uniform.
+            "objective_trajectory": [],
+            "bound_trajectory": [],
+            "bound_trajectory_truncated": False,
+            "lp_root_gap": None,
+            "presolve_compression_ratio": None,
+            "presolve_booleans_pre": 0,
+            "objective_plateau_time": None,
+            "bound_gain_after_plateau": None,
+            "time_to_first_solution": None,
             "single_bunk_session": True,
         }
 

--- a/bunking/solver/observability.py
+++ b/bunking/solver/observability.py
@@ -82,6 +82,77 @@ def _compute_optimality_gap(objective: float | None, best_bound: float | None) -
     return abs(objective - best_bound) / max(abs(objective), 1.0)
 
 
+def _count_presolve_compression(model_proto: Any, solver: Any) -> dict[str, Any]:
+    """Pre-presolve vs post-presolve boolean-variable counts.
+
+    Pre = model-proto variables whose domain is exactly ``[0, 1]`` (the
+    booleans the model was *built* with). Post = ``solver.NumBooleans()``
+    (booleans the SAT core actually works on, after presolve). ``ratio`` =
+    post / pre — lower means presolve eliminated more redundancy, which is
+    the Stream 3 (variable-count attack) target signal. ``ratio`` is
+    ``None`` when the model has no booleans (avoids div-by-zero).
+    """
+    booleans_pre = sum(1 for v in model_proto.variables if list(v.domain) == [0, 1])
+    booleans_post = solver.NumBooleans()
+    ratio = (booleans_post / booleans_pre) if booleans_pre > 0 else None
+    return {"presolve_compression_ratio": ratio, "presolve_booleans_pre": booleans_pre}
+
+
+def _lp_root_gap(bound_trajectory: list[dict[str, float]], objective: float | None) -> float | None:
+    """Relative gap between the root LP bound and the final objective.
+
+    The first ``best_bound_callback`` value (``bound_trajectory[0]``) is the
+    earliest proven bound — CP-SAT computes it after presolve + the root LP
+    relaxation, before B&B opens any nodes — so it is a good proxy for the
+    root LP bound. The gap against the final objective is the relaxation's
+    quality, independent of the time budget. ``None`` if the trajectory is
+    empty (no bound was ever reported).
+
+    The "first point ≈ root LP bound" approximation relies on a
+    callback-ordering assumption — that the caller wires ``BestBoundCallback``
+    before ``Solve()`` and it fires once at the root before branching — which
+    this function cannot itself verify; it is not a model-level guarantee.
+    """
+    if not bound_trajectory:
+        return None
+    return _compute_optimality_gap(objective, bound_trajectory[0]["bound"])
+
+
+def _derive_plateau_scalars(
+    objective_trajectory: list[dict[str, float]],
+    bound_trajectory: list[dict[str, float]],
+) -> dict[str, float | None]:
+    """Comparable scalars distilled from the raw trajectories.
+
+    - ``objective_plateau_time``: ``t`` of the last objective improvement.
+      Low vs. the time budget = the solver stopped finding better solutions
+      early.
+    - ``bound_gain_after_plateau``: absolute bound movement *after* the last
+      solution. ~0 = fully stuck; large = the solver kept working the bound
+      even though the objective was flat. Absolute value so it is correct
+      regardless of min/max objective sense (the bound is monotonic).
+    - ``time_to_first_solution``: ``t`` of the first solution. Long = the
+      model was hard to even make feasible.
+
+    All ``None`` when ``objective_trajectory`` is empty (INFEASIBLE / no
+    solution / single-bunk path).
+    """
+    if not objective_trajectory:
+        return {
+            "objective_plateau_time": None,
+            "bound_gain_after_plateau": None,
+            "time_to_first_solution": None,
+        }
+    first = objective_trajectory[0]
+    last = objective_trajectory[-1]
+    final_bound = bound_trajectory[-1]["bound"] if bound_trajectory else last["bound"]
+    return {
+        "objective_plateau_time": last["t"],
+        "bound_gain_after_plateau": abs(final_bound - last["bound"]),
+        "time_to_first_solution": first["t"],
+    }
+
+
 def _is_linear_constraint(c: Any) -> bool:
     """True if the constraint proto is a linear constraint.
 

--- a/bunking/solver/observability.py
+++ b/bunking/solver/observability.py
@@ -294,6 +294,9 @@ def _build_stats_dict(
     *,
     soft_constraint_violations: dict[str, Any] | None = None,
     requests_by_person: dict[int, list[DirectBunkRequest]] | None = None,
+    objective_trajectory: list[dict[str, float]] | None = None,
+    bound_trajectory: list[dict[str, float]] | None = None,
+    bound_trajectory_truncated: bool = False,
 ) -> dict[str, Any]:
     """Build the full stats dict captured per solver run.
 
@@ -318,6 +321,9 @@ def _build_stats_dict(
     num_integers = response_proto.num_integers
     has_solution = int(status) in (cp_model.OPTIMAL, cp_model.FEASIBLE)
     num_solutions_found = (1 + len(response_proto.additional_solutions)) if has_solution else 0
+
+    objective_trajectory = objective_trajectory or []
+    bound_trajectory = bound_trajectory or []
 
     return {
         # Existing back-compat fields
@@ -358,4 +364,11 @@ def _build_stats_dict(
         "max_linear_coefficient": _max_linear_coefficient(model_proto),
         "soft_constraints_by_module": _count_soft_constraints_by_module(soft_constraint_violations or {}),
         "request_density_histogram_by_bucket": _build_request_density_histogram_by_bucket(requests_by_person or {}),
+        # Tier 2 observability (Stream 2, Phase 2 — plateau-diagnostic metrics)
+        "objective_trajectory": objective_trajectory,
+        "bound_trajectory": bound_trajectory,
+        "bound_trajectory_truncated": bound_trajectory_truncated,
+        "lp_root_gap": _lp_root_gap(bound_trajectory, objective),
+        **_count_presolve_compression(model_proto, solver),
+        **_derive_plateau_scalars(objective_trajectory, bound_trajectory),
     }

--- a/bunking/solver/observability.py
+++ b/bunking/solver/observability.py
@@ -297,6 +297,7 @@ def _build_stats_dict(
     objective_trajectory: list[dict[str, float]] | None = None,
     bound_trajectory: list[dict[str, float]] | None = None,
     bound_trajectory_truncated: bool = False,
+    objective_trajectory_truncated: bool = False,
 ) -> dict[str, Any]:
     """Build the full stats dict captured per solver run.
 
@@ -368,6 +369,7 @@ def _build_stats_dict(
         "objective_trajectory": objective_trajectory,
         "bound_trajectory": bound_trajectory,
         "bound_trajectory_truncated": bound_trajectory_truncated,
+        "objective_trajectory_truncated": objective_trajectory_truncated,
         "lp_root_gap": _lp_root_gap(bound_trajectory, objective),
         **_count_presolve_compression(model_proto, solver),
         **_derive_plateau_scalars(objective_trajectory, bound_trajectory),

--- a/docs/reference/solver-roadmap.md
+++ b/docs/reference/solver-roadmap.md
@@ -33,7 +33,7 @@ only) once individual streams are picked up.
 | Stream 6 — pre-check impossibility framework | (in #1379) | #1391 | ✅ shipped 2026-05-14 |
 | Sat-var unification | #1395 | #1427 | ✅ shipped 2026-05-14 |
 | Stream 6 substream — entirely-impossible MP campers in pre-check + "Acceptable" denominator fix | #1428 | #1429 | ✅ shipped 2026-05-14 |
-| **Stream 2 Tier 2 — plateau-diagnostic metrics** | none (spec in-doc) | — | 🔵 **Phase 2 — in progress** |
+| **Stream 2 Tier 2 — plateau-diagnostic metrics** | none (spec in-doc) | #1436 | 🔵 **Phase 2 — in review** |
 | Stream 4 — mutual-request boost | #1382 | — | ⬜ Phase 3 |
 | Stream 3 — variable-count attack surface | #1381 | — | ⬜ Phase 4 (re-scope first) |
 | Golden sat-var ↔ predicate alignment test | #1398 | — | ⬜ do now (drift defense for #1427) |
@@ -61,7 +61,7 @@ rollup as single source of truth, camper-level surfacing in the pre-validate
 modal, and the "Acceptable" metric denominator fixed to exclude
 structurally-impossible campers.
 
-**Phase 2 — Tier 2 metrics (IN PROGRESS).** Scoped to three
+**Phase 2 — Tier 2 metrics (IN REVIEW — PR #1436).** Scoped to three
 plateau-diagnostic metrics only: **best-bound trajectory, LP root gap,
 presolve compression ratio.** *Not* the full Tier 2 list — per-sub-solver
 wall time / symmetry flag / domain-size distribution defer until a specific
@@ -308,7 +308,7 @@ Tracking: #1379 (closed by #1391 on 2026-05-13).
 ## Stream 2 — Solver Debug Metrics Expansion (Tier 1 + Tier 2)
 
 **Status:** Tier 1 **shipped** — #1380 / PR #1385 (core metrics) and #1388 /
-PR #1425 (per-`RequestBucket` split). Tier 2 — **Phase 2, in progress** (see
+PR #1425 (per-`RequestBucket` split). Tier 2 — **Phase 2, in review (PR #1436)** (see
 "Status & phased sequencing" above). Scoped to three plateau-diagnostic
 metrics: best-bound trajectory, LP root gap, presolve compression ratio.
 Implemented **without a tracking issue** — Tier 2 was orphaned when #1380

--- a/docs/reference/solver-roadmap.md
+++ b/docs/reference/solver-roadmap.md
@@ -32,18 +32,20 @@ only) once individual streams are picked up.
 | Stream 5 — IIS infeasibility localization | (in #1379) | #1391 | ✅ shipped 2026-05-14 |
 | Stream 6 — pre-check impossibility framework | (in #1379) | #1391 | ✅ shipped 2026-05-14 |
 | Sat-var unification | #1395 | #1427 | ✅ shipped 2026-05-14 |
-| Stream 6 substream — entirely-impossible MP campers in pre-check + "Acceptable" denominator fix | #1428 | #1429 | 🔵 in review |
-| **Stream 2 Tier 2 — plateau-diagnostic metrics** | **unfiled — file first** | — | ⬜ **Phase 2 (next)** |
+| Stream 6 substream — entirely-impossible MP campers in pre-check + "Acceptable" denominator fix | #1428 | #1429 | ✅ shipped 2026-05-14 |
+| **Stream 2 Tier 2 — plateau-diagnostic metrics** | none (spec in-doc) | — | 🔵 **Phase 2 — in progress** |
 | Stream 4 — mutual-request boost | #1382 | — | ⬜ Phase 3 |
 | Stream 3 — variable-count attack surface | #1381 | — | ⬜ Phase 4 (re-scope first) |
 | Golden sat-var ↔ predicate alignment test | #1398 | — | ⬜ do now (drift defense for #1427) |
 | Retire `solution.calculate_satisfied_requests` | #1397 | — | ⬜ pairs with #1398 |
 | Penalty-driven MP-coverage investigation | #1396 | — | ⬜ low urgency |
-| Audit `direct_solver` for hand-rolled impossibility logic | #1426 | — | ⬜ after #1429 merges |
+| Audit `direct_solver` for hand-rolled impossibility logic | #1426 | — | ⬜ unblocked (#1429 merged) |
 | Schematize `grade_spread.max_spread` | #1424 | — | ⬜ small cleanup, anytime |
 | Stream 6 substreams 6a–6f | unfiled | — | ⬜ incremental |
 
-All work-item PRs use `Closes #N` in the body so the issue auto-closes on merge.
+Work-item PRs use `Closes #N` in the body so the issue auto-closes on merge,
+where a tracking issue exists. Phase 2 (Tier 2 metrics) is being implemented
+without an issue — its full spec lives in the Stream 2 section below.
 
 ### Phases
 
@@ -52,14 +54,14 @@ bucket split (#1385 / #1425), IIS localization & impossibility framework
 (#1391), sat-var unification (#1427). The S2 model is roughly half its
 pre-#1391 size; MP coverage is 100% of solver-actionable campers.
 
-**Phase 1 — Pre-check honesty (IN REVIEW — #1428 / PR #1429).**
+**Phase 1 — Pre-check honesty (DONE — #1428 / PR #1429, shipped 2026-05-14).**
 `target_not_in_solver` promoted to a registered predicate (closes the last
 pre-validate ↔ solver drift), `mp_campers_entirely_impossible` derived
 rollup as single source of truth, camper-level surfacing in the pre-validate
 modal, and the "Acceptable" metric denominator fixed to exclude
 structurally-impossible campers.
 
-**Phase 2 — Tier 2 metrics (NEXT — the unblock).** Scoped to three
+**Phase 2 — Tier 2 metrics (IN PROGRESS).** Scoped to three
 plateau-diagnostic metrics only: **best-bound trajectory, LP root gap,
 presolve compression ratio.** *Not* the full Tier 2 list — per-sub-solver
 wall time / symmetry flag / domain-size distribution defer until a specific
@@ -68,9 +70,12 @@ num_branches / num_conflicts turned out to be noise). Rationale: the
 remaining solver problem is the **plateau** — `objective_value` flattens by
 ~60 s and only the *bound* moves after; Tier 1 cannot distinguish
 "converging slowly" from "stuck", best-bound trajectory can. Phase 2
-hard-unblocks Phase 4 and makes Phase 3 measurable. **Needs an issue filed
-first** — Tier 2 was orphaned when #1380 ("Tier 1 + Tier 2") closed on
-Tier 1 alone.
+hard-unblocks Phase 4 and makes Phase 3 measurable. **No tracking issue** —
+the three-metric spec is fully captured in the Stream 2 section below, so
+the implementation PR carries it directly rather than re-deriving from a
+filed issue. (Tier 2 was orphaned when #1380 ("Tier 1 + Tier 2") closed on
+Tier 1 alone; the remaining Tier 2/Tier 3 metrics stay tracked in the
+Stream 2 tables and are picked up only when a specific question demands them.)
 
 **Phase 3 — Mutual-request boost (the build — Stream 4 / #1382).** Highest-
 leverage plateau intervention: reshapes the objective toward reciprocated
@@ -303,12 +308,14 @@ Tracking: #1379 (closed by #1391 on 2026-05-13).
 ## Stream 2 — Solver Debug Metrics Expansion (Tier 1 + Tier 2)
 
 **Status:** Tier 1 **shipped** — #1380 / PR #1385 (core metrics) and #1388 /
-PR #1425 (per-`RequestBucket` split). Tier 2 is **not yet filed** — it was
-orphaned when #1380 ("Tier 1 + Tier 2") closed on Tier 1 alone. Phase 2 (see
-"Status & phased sequencing" above) files a fresh Tier 2 issue scoped to the
-three plateau-diagnostic metrics: best-bound trajectory, LP root gap,
-presolve compression ratio. The rest of the Tier 2 / Tier 3 lists below
-defer until a specific question demands them.
+PR #1425 (per-`RequestBucket` split). Tier 2 — **Phase 2, in progress** (see
+"Status & phased sequencing" above). Scoped to three plateau-diagnostic
+metrics: best-bound trajectory, LP root gap, presolve compression ratio.
+Implemented **without a tracking issue** — Tier 2 was orphaned when #1380
+("Tier 1 + Tier 2") closed on Tier 1 alone, and the three-metric spec is
+fully captured here, so the PR carries it directly. The rest of the Tier 2
+table and the Tier 3 list below stay tracked here and defer until a specific
+question demands them.
 
 ### Motivation
 
@@ -386,8 +393,11 @@ variable-count savings are attributable.
 
 ### GitHub issue
 
-Tier 1: #1380 (closed by #1385) + #1388 (closed by #1425). Tier 2: unfiled —
-see Phase 2 in "Status & phased sequencing" above.
+Tier 1: #1380 (closed by #1385) + #1388 (closed by #1425). Tier 2: no tracking
+issue — implemented as Phase 2 directly from the spec above (see Phase 2 in
+"Status & phased sequencing"). The deferred Tier 2/Tier 3 metrics remain
+tracked in the tables above; file issues if/when a specific question
+prioritizes them.
 
 ---
 
@@ -935,3 +945,10 @@ Superseded by **"Status & phased sequencing"** near the top of this doc
   issue map) and retired the stale "Suggested order" table. Reconciled the
   Stream 2/3/4 "GitHub issue" lines with filed issue numbers. Flagged Tier 2
   as unfiled (orphaned when #1380 closed on Tier 1 alone).
+- **2026-05-14** — #1429 merged (closes #1428): Phase 1 (pre-check honesty)
+  complete — Stream 6g shipped, #1426 (`direct_solver` impossibility audit)
+  now unblocked. Phase 2 (Tier 2 plateau metrics) started **without a
+  tracking issue** — the three-metric spec (best-bound trajectory, LP root
+  gap, presolve compression ratio) is fully captured in the Stream 2 section,
+  so the PR carries it directly. The remaining Tier 2/Tier 3 metrics stay
+  tracked in the Stream 2 tables. Worktree: `tier2-plateau-metrics`.

--- a/frontend/src/hooks/useSolverRuns.ts
+++ b/frontend/src/hooks/useSolverRuns.ts
@@ -29,6 +29,16 @@ export interface SolverRunStats {
   max_linear_coefficient?: number
   soft_constraints_by_module?: Record<string, number>
   request_density_histogram_by_bucket?: Record<RequestBucket, Record<string, number>>
+  // Tier 2 observability (Stream 2, Phase 2 — plateau-diagnostic metrics)
+  objective_trajectory?: Array<{ t: number; objective: number; bound: number }>
+  bound_trajectory?: Array<{ t: number; bound: number }>
+  bound_trajectory_truncated?: boolean
+  lp_root_gap?: number | null
+  presolve_compression_ratio?: number | null
+  presolve_booleans_pre?: number
+  objective_plateau_time?: number | null
+  bound_gain_after_plateau?: number | null
+  time_to_first_solution?: number | null
   objective_value?: number | null
   total_requests?: number | null
   total_persons?: number | null

--- a/frontend/src/hooks/useSolverRuns.ts
+++ b/frontend/src/hooks/useSolverRuns.ts
@@ -33,6 +33,7 @@ export interface SolverRunStats {
   objective_trajectory?: Array<{ t: number; objective: number; bound: number }>
   bound_trajectory?: Array<{ t: number; bound: number }>
   bound_trajectory_truncated?: boolean
+  objective_trajectory_truncated?: boolean
   lp_root_gap?: number | null
   presolve_compression_ratio?: number | null
   presolve_booleans_pre?: number

--- a/frontend/src/pages/summer/SolverDebugPage/BoundTrajectoryChart.test.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/BoundTrajectoryChart.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { BoundTrajectoryChart } from './BoundTrajectoryChart'
+
+describe('BoundTrajectoryChart', () => {
+  it('renders an empty state when both trajectories are empty', () => {
+    render(<BoundTrajectoryChart objectiveTrajectory={[]} boundTrajectory={[]} />)
+    expect(screen.getByText(/no trajectory data/i)).toBeInTheDocument()
+  })
+
+  it('renders two polylines when both trajectories have points', () => {
+    const { container } = render(
+      <BoundTrajectoryChart
+        objectiveTrajectory={[
+          { t: 1, objective: 100, bound: 200 },
+          { t: 5, objective: 150, bound: 180 },
+        ]}
+        boundTrajectory={[
+          { t: 0.5, bound: 250 },
+          { t: 5, bound: 180 },
+        ]}
+      />
+    )
+    expect(container.querySelectorAll('polyline')).toHaveLength(2)
+  })
+
+  it('renders only the bound polyline when the objective trajectory is empty', () => {
+    const { container } = render(
+      <BoundTrajectoryChart
+        objectiveTrajectory={[]}
+        boundTrajectory={[
+          { t: 0.5, bound: 250 },
+          { t: 5, bound: 180 },
+        ]}
+      />
+    )
+    expect(container.querySelectorAll('polyline')).toHaveLength(1)
+  })
+
+  it('renders only the objective polyline when the bound trajectory is empty', () => {
+    const { container } = render(
+      <BoundTrajectoryChart
+        objectiveTrajectory={[
+          { t: 1, objective: 100, bound: 200 },
+          { t: 5, objective: 150, bound: 180 },
+        ]}
+        boundTrajectory={[]}
+      />
+    )
+    expect(container.querySelectorAll('polyline')).toHaveLength(1)
+  })
+})

--- a/frontend/src/pages/summer/SolverDebugPage/BoundTrajectoryChart.test.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/BoundTrajectoryChart.test.tsx
@@ -50,4 +50,23 @@ describe('BoundTrajectoryChart', () => {
     )
     expect(container.querySelectorAll('polyline')).toHaveLength(1)
   })
+
+  it('renders a visible marker for a single-point objective trajectory', () => {
+    // A 1-point polyline draws no segment; without a dot marker a solve that
+    // found exactly one solution would render a blank chart.
+    const { container } = render(
+      <BoundTrajectoryChart
+        objectiveTrajectory={[{ t: 3, objective: 100, bound: 200 }]}
+        boundTrajectory={[]}
+      />
+    )
+    expect(container.querySelectorAll('circle').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders a visible marker for a single-point bound trajectory', () => {
+    const { container } = render(
+      <BoundTrajectoryChart objectiveTrajectory={[]} boundTrajectory={[{ t: 3, bound: 200 }]} />
+    )
+    expect(container.querySelectorAll('circle').length).toBeGreaterThanOrEqual(1)
+  })
 })

--- a/frontend/src/pages/summer/SolverDebugPage/BoundTrajectoryChart.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/BoundTrajectoryChart.tsx
@@ -58,6 +58,14 @@ export function BoundTrajectoryChart({ objectiveTrajectory, boundTrajectory }: P
         {objPts.length > 0 ? (
           <polyline points={objLine} fill="none" stroke="#2563eb" strokeWidth={1.5} />
         ) : null}
+        {/* Dot markers per sample — a 1-point series has no polyline segment,
+            so without these a single-solution solve renders a blank chart. */}
+        {bndPts.map((p, i) => (
+          <circle key={`bnd-${i}-${p.t}`} cx={x(p.t)} cy={y(p.bound)} r={2} fill="#dc2626" />
+        ))}
+        {objPts.map((p, i) => (
+          <circle key={`obj-${i}-${p.t}`} cx={x(p.t)} cy={y(p.objective)} r={2} fill="#2563eb" />
+        ))}
       </svg>
       <div className="mt-1 flex gap-4 text-xs text-gray-500">
         <span>

--- a/frontend/src/pages/summer/SolverDebugPage/BoundTrajectoryChart.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/BoundTrajectoryChart.tsx
@@ -1,0 +1,81 @@
+import type { SolverRunStats } from '../../../hooks/useSolverRuns'
+
+interface Props {
+  objectiveTrajectory: NonNullable<SolverRunStats['objective_trajectory']>
+  boundTrajectory: NonNullable<SolverRunStats['bound_trajectory']>
+}
+
+const W = 560
+const H = 160
+const PAD = 8
+
+/**
+ * Hand-rolled SVG line chart for the Tier 2 best-bound trajectory. Two series
+ * — objective (blue) and best bound (red) — share one time axis. No charting
+ * dependency in the repo; this stays a small, dependency-free component.
+ */
+export function BoundTrajectoryChart({ objectiveTrajectory, boundTrajectory }: Props) {
+  const objPts = objectiveTrajectory
+  const bndPts = boundTrajectory
+
+  if (objPts.length === 0 && bndPts.length === 0) {
+    return (
+      <div className="text-sm text-gray-400">
+        No trajectory data — the solver returned no intermediate solutions.
+      </div>
+    )
+  }
+
+  const allT = [...objPts.map((p) => p.t), ...bndPts.map((p) => p.t)]
+  // Y-axis spans only the drawn series: objective_trajectory points also carry
+  // a `bound`, but the bound line is plotted from bound_trajectory — including
+  // objPts' bound here would inflate the axis when bound_trajectory is empty.
+  const allV = [...objPts.map((p) => p.objective), ...bndPts.map((p) => p.bound)]
+  const tMin = Math.min(...allT)
+  const tMax = Math.max(...allT)
+  const vMin = Math.min(...allV)
+  const vMax = Math.max(...allV)
+  const tSpan = tMax - tMin || 1
+  const vSpan = vMax - vMin || 1
+
+  const x = (t: number) => PAD + ((t - tMin) / tSpan) * (W - 2 * PAD)
+  const y = (v: number) => H - PAD - ((v - vMin) / vSpan) * (H - 2 * PAD)
+
+  const objLine = objPts.map((p) => `${x(p.t)},${y(p.objective)}`).join(' ')
+  const bndLine = bndPts.map((p) => `${x(p.t)},${y(p.bound)}`).join(' ')
+
+  return (
+    <div>
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        className="w-full rounded bg-gray-50"
+        role="img"
+        aria-label="Best-bound and objective trajectory over solve time"
+      >
+        {bndPts.length > 0 ? (
+          <polyline points={bndLine} fill="none" stroke="#dc2626" strokeWidth={1.5} />
+        ) : null}
+        {objPts.length > 0 ? (
+          <polyline points={objLine} fill="none" stroke="#2563eb" strokeWidth={1.5} />
+        ) : null}
+      </svg>
+      <div className="mt-1 flex gap-4 text-xs text-gray-500">
+        <span>
+          <span className="text-blue-600" aria-hidden="true">
+            ●
+          </span>{' '}
+          objective
+        </span>
+        <span>
+          <span className="text-red-600" aria-hidden="true">
+            ●
+          </span>{' '}
+          best bound
+        </span>
+        <span className="ml-auto">
+          {tMin.toFixed(1)}s – {tMax.toFixed(1)}s
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.test.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.test.tsx
@@ -250,6 +250,43 @@ describe('DrillDownDrawer', () => {
   })
 })
 
+describe('Tier 2 plateau-diagnostic metrics', () => {
+  it('renders the best-bound trajectory section when trajectory data is present', () => {
+    const trajectoryRun: SolverRun = {
+      ...run,
+      stats: {
+        status: 'FEASIBLE',
+        objective_trajectory: [
+          { t: 1, objective: 100, bound: 200 },
+          { t: 5, objective: 150, bound: 180 },
+        ],
+        bound_trajectory: [
+          { t: 0.5, bound: 250 },
+          { t: 5, bound: 180 },
+        ],
+      },
+    }
+    render(<DrillDownDrawer run={trajectoryRun} onClose={vi.fn()} />)
+    expect(screen.getByText(/best-bound trajectory/i)).toBeInTheDocument()
+    expect(
+      screen.getByRole('img', { name: /best-bound and objective trajectory/i })
+    ).toBeInTheDocument()
+  })
+
+  it('hides the best-bound trajectory section when no trajectory data is present', () => {
+    const noTrajectoryRun: SolverRun = {
+      ...run,
+      stats: {
+        status: 'FEASIBLE',
+        objective_trajectory: [],
+        bound_trajectory: [],
+      },
+    }
+    render(<DrillDownDrawer run={noTrajectoryRun} onClose={vi.fn()} />)
+    expect(screen.queryByText(/best-bound trajectory/i)).not.toBeInTheDocument()
+  })
+})
+
 describe('Registry-driven group rendering (PR1)', () => {
   it('renders Outcome (requests) and Outcome (campers) section headers when run has both', () => {
     const outcomeRun: SolverRun = {

--- a/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useId, useRef, useState } from 'react'
 import { REPO_URL } from '../../../constants/repo'
 import { copyText } from '../../../utils/copyText'
 
+import { BoundTrajectoryChart } from './BoundTrajectoryChart'
 import { buildRunSummary, hasNonEmptyBuckets } from './buildRunSummary'
 import { formatMetric, METRIC_REGISTRY_BY_GROUP, type MetricGroup } from './metricRegistry'
 import { pickStat } from './pickStat'
@@ -161,6 +162,19 @@ export function DrillDownDrawer({ run, onClose }: Props) {
               >
                 {s.solution_info}
               </div>
+            </div>
+          ) : null}
+
+          {s.objective_trajectory?.length || s.bound_trajectory?.length ? (
+            <div className="mt-4">
+              <div className="mb-2 text-xs tracking-wide text-gray-500 uppercase">
+                Best-bound trajectory
+                {s.bound_trajectory_truncated ? ' (truncated)' : ''}
+              </div>
+              <BoundTrajectoryChart
+                objectiveTrajectory={s.objective_trajectory ?? []}
+                boundTrajectory={s.bound_trajectory ?? []}
+              />
             </div>
           ) : null}
 

--- a/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/DrillDownDrawer.tsx
@@ -169,7 +169,9 @@ export function DrillDownDrawer({ run, onClose }: Props) {
             <div className="mt-4">
               <div className="mb-2 text-xs tracking-wide text-gray-500 uppercase">
                 Best-bound trajectory
-                {s.bound_trajectory_truncated ? ' (truncated)' : ''}
+                {s.bound_trajectory_truncated || s.objective_trajectory_truncated
+                  ? ' (truncated)'
+                  : ''}
               </div>
               <BoundTrajectoryChart
                 objectiveTrajectory={s.objective_trajectory ?? []}

--- a/frontend/src/pages/summer/SolverDebugPage/SolverRunsTable.test.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/SolverRunsTable.test.tsx
@@ -440,3 +440,105 @@ describe('SolverRunsTable in-flight chip (#1260)', () => {
     expect(screen.getByText('OPTIMAL')).toBeInTheDocument()
   })
 })
+
+describe('Tier 2 plateau columns (Stream 2, Phase 2)', () => {
+  const TIER2_COLUMNS = [
+    'lp_root_gap',
+    'bound_gain_after_plateau',
+    'objective_plateau_time',
+    'time_to_first_solution',
+    'presolve_compression_ratio',
+  ]
+
+  const tier2Run: SolverRun = {
+    ...r1,
+    stats: {
+      ...(r1.stats ?? {}),
+      lp_root_gap: 0.25,
+      bound_gain_after_plateau: 150,
+      objective_plateau_time: 12.3,
+      time_to_first_solution: 2.5,
+      presolve_compression_ratio: 0.6,
+    },
+  }
+
+  it('renders all five Tier 2 column headers when toggled on', () => {
+    render(
+      <SolverRunsTable
+        runs={[tier2Run]}
+        visibleColumns={[...DEFAULT_VISIBLE_COLUMNS, ...TIER2_COLUMNS]}
+        pinnedRunIds={[]}
+        onTogglePin={vi.fn()}
+        onRowClick={vi.fn()}
+      />
+    )
+    expect(screen.getByRole('columnheader', { name: /LP root gap/i })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /Bound gain/i })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /Plateau onset/i })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /Time to 1st/i })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /Presolve compression/i })).toBeInTheDocument()
+  })
+
+  it('renders Tier 2 metric values formatted per the registry', () => {
+    render(
+      <SolverRunsTable
+        runs={[tier2Run]}
+        visibleColumns={[...DEFAULT_VISIBLE_COLUMNS, ...TIER2_COLUMNS]}
+        pinnedRunIds={[]}
+        onTogglePin={vi.fn()}
+        onRowClick={vi.fn()}
+      />
+    )
+    expect(screen.getByText('25.00%')).toBeInTheDocument() // lp_root_gap (percent)
+    expect(screen.getByText('150')).toBeInTheDocument() // bound_gain_after_plateau (integer)
+    expect(screen.getByText('12.3s')).toBeInTheDocument() // objective_plateau_time (duration)
+    expect(screen.getByText('2.5s')).toBeInTheDocument() // time_to_first_solution (duration)
+    expect(screen.getByText('60.00%')).toBeInTheDocument() // presolve_compression_ratio (percent)
+  })
+
+  it('renders em-dash for a Tier 2 column when stats lack the key', () => {
+    render(
+      <SolverRunsTable
+        runs={[r1]}
+        visibleColumns={[...DEFAULT_VISIBLE_COLUMNS, 'lp_root_gap']}
+        pinnedRunIds={[]}
+        onTogglePin={vi.fn()}
+        onRowClick={vi.fn()}
+      />
+    )
+    const header = screen.getByRole('columnheader', { name: /LP root gap/i })
+    const colIndex = Array.from(header.parentElement!.children).indexOf(header)
+    const row = screen.getByText(/OPTIMAL/i).closest('tr')
+    expect(row!.children[colIndex]!.textContent).toBe('—')
+  })
+
+  it('keeps the SHA-divider colSpan aligned with the rendered column count', () => {
+    // Regression: the 5 keys were added to ALL_COLUMNS without <th>/<td> in the
+    // table, so colSpan (= 2 + visibleColumns.length) overshot the cells that
+    // actually rendered, skewing the divider row.
+    const newer: SolverRun = {
+      ...tier2Run,
+      id: 'newer',
+      created: '2026-05-08T11:00:00Z',
+      details: { ...(r1.details ?? {}), git_sha: 'aaaa111' },
+    }
+    const older: SolverRun = {
+      ...tier2Run,
+      id: 'older',
+      created: '2026-05-08T09:00:00Z',
+      details: { ...(r1.details ?? {}), git_sha: 'bbbb222' },
+    }
+    render(
+      <SolverRunsTable
+        runs={[newer, older]}
+        visibleColumns={[...DEFAULT_VISIBLE_COLUMNS, ...TIER2_COLUMNS]}
+        pinnedRunIds={[]}
+        onTogglePin={vi.fn()}
+        onRowClick={vi.fn()}
+      />
+    )
+    const headerCells = document.querySelectorAll('thead th')
+    const dividerCell = document.querySelector('[data-sha-divider] td')!
+    expect(Number(dividerCell.getAttribute('colspan'))).toBe(headerCells.length)
+  })
+})

--- a/frontend/src/pages/summer/SolverDebugPage/SolverRunsTable.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/SolverRunsTable.tsx
@@ -290,6 +290,47 @@ export function SolverRunsTable({
                 Objective
               </th>
             )}
+            {/* Tier 2 plateau metrics (Stream 2, Phase 2) */}
+            {showCol('lp_root_gap') && (
+              <th
+                className="px-3 py-2.5 text-right font-medium"
+                title={getMetric('lp_root_gap').description}
+              >
+                LP root gap
+              </th>
+            )}
+            {showCol('bound_gain_after_plateau') && (
+              <th
+                className="px-3 py-2.5 text-right font-medium"
+                title={getMetric('bound_gain_after_plateau').description}
+              >
+                Bound gain
+              </th>
+            )}
+            {showCol('objective_plateau_time') && (
+              <th
+                className="px-3 py-2.5 text-right font-medium"
+                title={getMetric('objective_plateau_time').description}
+              >
+                Plateau onset
+              </th>
+            )}
+            {showCol('time_to_first_solution') && (
+              <th
+                className="px-3 py-2.5 text-right font-medium"
+                title={getMetric('time_to_first_solution').description}
+              >
+                Time to 1st
+              </th>
+            )}
+            {showCol('presolve_compression_ratio') && (
+              <th
+                className="px-3 py-2.5 text-right font-medium"
+                title={getMetric('presolve_compression_ratio').description}
+              >
+                Presolve compression
+              </th>
+            )}
             {showCol('sha') && <th className="px-3 py-2.5 text-left font-medium">SHA</th>}
             {showCol('sweep') && <th className="px-3 py-2.5 text-left font-medium">Sweep</th>}
           </tr>
@@ -548,6 +589,59 @@ export function SolverRunsTable({
                       title={getMetric('objective_value').description}
                     >
                       {formatMetric('objective_value', pickStat(run.stats, 'objective_value'))}
+                    </td>
+                  )}
+                  {/* Tier 2 plateau metrics (Stream 2, Phase 2) */}
+                  {showCol('lp_root_gap') && (
+                    <td
+                      className="px-3 py-2 text-right"
+                      title={getMetric('lp_root_gap').description}
+                    >
+                      {formatMetric('lp_root_gap', pickStat(run.stats, 'lp_root_gap'))}
+                    </td>
+                  )}
+                  {showCol('bound_gain_after_plateau') && (
+                    <td
+                      className="px-3 py-2 text-right"
+                      title={getMetric('bound_gain_after_plateau').description}
+                    >
+                      {formatMetric(
+                        'bound_gain_after_plateau',
+                        pickStat(run.stats, 'bound_gain_after_plateau')
+                      )}
+                    </td>
+                  )}
+                  {showCol('objective_plateau_time') && (
+                    <td
+                      className="px-3 py-2 text-right"
+                      title={getMetric('objective_plateau_time').description}
+                    >
+                      {formatMetric(
+                        'objective_plateau_time',
+                        pickStat(run.stats, 'objective_plateau_time')
+                      )}
+                    </td>
+                  )}
+                  {showCol('time_to_first_solution') && (
+                    <td
+                      className="px-3 py-2 text-right"
+                      title={getMetric('time_to_first_solution').description}
+                    >
+                      {formatMetric(
+                        'time_to_first_solution',
+                        pickStat(run.stats, 'time_to_first_solution')
+                      )}
+                    </td>
+                  )}
+                  {showCol('presolve_compression_ratio') && (
+                    <td
+                      className="px-3 py-2 text-right"
+                      title={getMetric('presolve_compression_ratio').description}
+                    >
+                      {formatMetric(
+                        'presolve_compression_ratio',
+                        pickStat(run.stats, 'presolve_compression_ratio')
+                      )}
                     </td>
                   )}
                   {showCol('sha') && (

--- a/frontend/src/pages/summer/SolverDebugPage/metricRegistry.test.ts
+++ b/frontend/src/pages/summer/SolverDebugPage/metricRegistry.test.ts
@@ -73,6 +73,13 @@ describe('METRIC_REGISTRY', () => {
         'assignments_changed',
         'new_assignments',
         'objective_value',
+        // Tier 2 plateau metrics (Stream 2, Phase 2)
+        'lp_root_gap',
+        'presolve_compression_ratio',
+        'presolve_booleans_pre',
+        'objective_plateau_time',
+        'time_to_first_solution',
+        'bound_gain_after_plateau',
       ].sort()
     )
   })
@@ -216,5 +223,35 @@ describe('MetricGroup type accepts outcome_requests/outcome_campers/size/churn',
 
   it('assignments_changed is in churn group', () => {
     expect(getMetric('assignments_changed').group).toBe('churn')
+  })
+})
+
+describe('Tier 2 plateau metrics (Stream 2, Phase 2)', () => {
+  it('registers the six new scalars with valid groups', () => {
+    expect(getMetric('lp_root_gap').group).toBe('quality')
+    expect(getMetric('presolve_compression_ratio').group).toBe('model')
+    expect(getMetric('presolve_booleans_pre').group).toBe('model')
+    expect(getMetric('presolve_booleans_pre').parent).toBe('num_booleans')
+    expect(getMetric('objective_plateau_time').group).toBe('timing')
+    expect(getMetric('time_to_first_solution').group).toBe('timing')
+    expect(getMetric('bound_gain_after_plateau').group).toBe('quality')
+    // format / interpretation spot-checks — the fields most likely to be silently wrong
+    expect(getMetric('presolve_compression_ratio').format).toBe('percent')
+    expect(getMetric('presolve_compression_ratio').interpretation).toBe('lower-better')
+    expect(getMetric('lp_root_gap').format).toBe('percent')
+    expect(getMetric('objective_plateau_time').format).toBe('duration')
+  })
+
+  it('surfaces the comparable Tier 2 scalars in COMPARABLE_METRICS', () => {
+    for (const k of [
+      'lp_root_gap',
+      'presolve_compression_ratio',
+      'presolve_booleans_pre',
+      'objective_plateau_time',
+      'time_to_first_solution',
+      'bound_gain_after_plateau',
+    ]) {
+      expect(COMPARABLE_METRICS).toContain(k)
+    }
   })
 })

--- a/frontend/src/pages/summer/SolverDebugPage/metricRegistry.ts
+++ b/frontend/src/pages/summer/SolverDebugPage/metricRegistry.ts
@@ -400,6 +400,61 @@ export const METRIC_REGISTRY: Record<string, MetricMeta> = {
     format: 'integer',
     group: 'quality',
   },
+  // Tier 2 plateau metrics (Stream 2, Phase 2)
+  lp_root_gap: {
+    key: 'lp_root_gap',
+    label: 'LP root gap',
+    description:
+      'Relative gap between the root LP relaxation bound and the final objective. Relaxation quality, independent of the time budget — high = the LP is loose.',
+    interpretation: 'lower-better',
+    format: 'percent',
+    group: 'quality',
+  },
+  objective_plateau_time: {
+    key: 'objective_plateau_time',
+    label: 'Plateau onset',
+    description:
+      'Seconds elapsed at the last objective improvement. Low vs. the time budget = the solver stopped finding better solutions early (a plateau).',
+    interpretation: 'context',
+    format: 'duration',
+    group: 'timing',
+  },
+  time_to_first_solution: {
+    key: 'time_to_first_solution',
+    label: 'Time to 1st solution',
+    description:
+      'Seconds until the first feasible solution. Long = the model was hard to even make feasible.',
+    interpretation: 'lower-better',
+    format: 'duration',
+    group: 'timing',
+  },
+  bound_gain_after_plateau: {
+    key: 'bound_gain_after_plateau',
+    label: 'Bound gain post-plateau',
+    description:
+      'Absolute movement of the best bound after the last solution. ~0 = fully stuck; large = the solver kept tightening the bound while the objective was flat.',
+    interpretation: 'context',
+    format: 'integer',
+    group: 'quality',
+  },
+  presolve_compression_ratio: {
+    key: 'presolve_compression_ratio',
+    label: 'Presolve compression',
+    description:
+      'Post-presolve Booleans ÷ pre-presolve Booleans. Lower = presolve eliminated more redundant variables; a value near 1.0 means little compression occurred.',
+    interpretation: 'lower-better',
+    format: 'percent',
+    group: 'model',
+  },
+  presolve_booleans_pre: {
+    key: 'presolve_booleans_pre',
+    label: 'Booleans (pre-presolve)',
+    description: 'Boolean variables in the model as built, before CP-SAT presolve compressed it.',
+    interpretation: 'context',
+    format: 'integer',
+    group: 'model',
+    parent: 'num_booleans',
+  },
 }
 
 /** Group metrics by their `group` field, preserving insertion order from METRIC_REGISTRY. */
@@ -470,6 +525,13 @@ export const COMPARABLE_METRICS: readonly string[] = [
   'num_lin_max',
   'num_reified_linear',
   'max_linear_coefficient',
+  // Tier 2 plateau metrics (Stream 2, Phase 2)
+  'lp_root_gap',
+  'bound_gain_after_plateau',
+  'objective_plateau_time',
+  'time_to_first_solution',
+  'presolve_compression_ratio',
+  'presolve_booleans_pre',
   // size (PR1)
   'total_persons',
   'total_bunks',

--- a/frontend/src/pages/summer/SolverDebugPage/solverColumns.ts
+++ b/frontend/src/pages/summer/SolverDebugPage/solverColumns.ts
@@ -38,6 +38,14 @@ export const ALL_COLUMNS = [
   { key: 'new_assignments', label: 'New', group: 'Churn' },
   // PR1: quality additions
   { key: 'objective_value', label: 'Objective', group: 'Quality' },
+  // Tier 2 plateau metrics (Stream 2, Phase 2)
+  { key: 'lp_root_gap', label: 'LP root gap', group: 'Quality' },
+  { key: 'bound_gain_after_plateau', label: 'Bound gain', group: 'Quality' },
+  { key: 'objective_plateau_time', label: 'Plateau onset', group: 'Timing' },
+  { key: 'time_to_first_solution', label: 'Time to 1st', group: 'Timing' },
+  { key: 'presolve_compression_ratio', label: 'Presolve compression', group: 'Model' },
+  // presolve_booleans_pre is intentionally not a column — it renders as a drill-down
+  // sub-row under num_booleans (see its `parent` in metricRegistry.ts).
 ] as const
 
 export const DEFAULT_VISIBLE_COLUMNS: string[] = [

--- a/tests/integration/solver/test_trajectory_capture.py
+++ b/tests/integration/solver/test_trajectory_capture.py
@@ -175,8 +175,21 @@ def test_capture_surfaces_share_clock_and_bound() -> None:
     assert [p["t"] for p in obj_traj] == sorted(p["t"] for p in obj_traj)
     assert [p["t"] for p in bnd_traj] == sorted(p["t"] for p in bnd_traj)
 
-    # Drift invariant: each solution's bound == last bound-traj bound at-or-before its t
+    # Drift invariant: each solution's bound is consistent with the best-bound
+    # trajectory. Normally it equals the most-recent bound-traj entry at-or-
+    # before the solution's t. But when a bound improvement is coincident with
+    # this solution, BestBoundCallback may timestamp it microseconds *after*
+    # SolverProgressCallback (the two callbacks read time.monotonic()
+    # independently, and OR-Tools does not specify their relative firing order),
+    # so also accept a bound-traj entry within _EPS after the solution's t. A
+    # genuine drift bug — sign flip, clock-origin split, wrong value — still
+    # produces a bound that matches neither bracketing entry.
+    _EPS = 0.05
     for p in obj_traj:
-        prior = [e for e in bnd_traj if e["t"] <= p["t"]]  # O(n*m), fine for test-scale data
-        assert prior, f"no bound point at-or-before solution t={p['t']}"
-        assert prior[-1]["bound"] == p["bound"]
+        at_or_before = [e for e in bnd_traj if e["t"] <= p["t"]]  # O(n*m), fine for test-scale data
+        assert at_or_before, f"no bound point at-or-before solution t={p['t']}"
+        within_eps = [e for e in bnd_traj if e["t"] <= p["t"] + _EPS]
+        allowed = {at_or_before[-1]["bound"], within_eps[-1]["bound"]}
+        assert p["bound"] in allowed, (
+            f"solution bound {p['bound']} at t={p['t']} drifted from bound trajectory {allowed}"
+        )

--- a/tests/integration/solver/test_trajectory_capture.py
+++ b/tests/integration/solver/test_trajectory_capture.py
@@ -1,0 +1,136 @@
+"""Integration tests for Tier 2 trajectory capture (Stream 2, Phase 2).
+
+Implementation must conform to these tests, not the other way around.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+from unittest.mock import MagicMock
+
+import pytest
+
+from bunking.config import ConfigLoader
+from bunking.models_v2 import DirectBunk, DirectPerson, DirectSolverInput
+from bunking.solver.direct_solver import DirectBunkingSolver
+
+
+class _PenaltyStubLoader:
+    """Provides the keys that penalties.py reads via ConfigLoader.get_instance().
+
+    Mirrors the stub in tests/unit/solver/test_satvar_unification.py — the
+    pattern is established there and must stay in sync with it.
+    """
+
+    _values: ClassVar[dict[str, int]] = {
+        "constraint.cabin_minimum_occupancy.penalty": 0,
+        "constraint.grade_spread.penalty": 0,
+    }
+
+    def get_int(self, key: str, default: int | None = None) -> int:
+        v = self._values.get(key)
+        return int(v) if v is not None else (default if default is not None else 0)
+
+    def get_float(self, key: str, default: float | None = None) -> float:
+        v = self._values.get(key)
+        return float(v) if v is not None else (default if default is not None else 0.0)
+
+
+@pytest.fixture
+def mock_config() -> MagicMock:
+    """ConfigLoader mock returning typed defaults.
+
+    Returns the mock config object directly (no `yield`). The companion
+    `ConfigLoader.use(_PenaltyStubLoader())` context — needed so `penalties.py`
+    helpers that call `ConfigLoader.get_instance()` directly do not require a
+    real PocketBase — is installed inline in the test body, not in this
+    fixture. The side-effect stubs mirror the proven config mocks in
+    tests/integration/solver/test_taste_of_camp_feasible.py and
+    tests/unit/solver/test_satvar_unification.py.
+    """
+    cfg = MagicMock()
+
+    def _get_constraint(constraint_type: str, param: str, default: Any = None) -> Any:
+        if constraint_type == "grade_spread" and param == "max_spread":
+            return 2
+        return default if default is not None else 0
+
+    def _get_int(key: str, default: Any = None) -> Any:
+        return default if default is not None else 0
+
+    def _get_float(key: str, default: Any = None) -> Any:
+        return default if default is not None else 0.0
+
+    def _get_str(key: str, default: Any = None) -> Any:
+        if "grade_spread.mode" in key:
+            return "hard"
+        return default if default is not None else ""
+
+    def _get_bool(key: str, default: Any = None) -> Any:
+        return default if default is not None else False
+
+    def _get_priority(_priority_type: str, _subtype: str = "default") -> int:
+        return 4
+
+    def _get_soft_constraint_weight(_constraint_name: str) -> int:
+        return 0
+
+    cfg.get_constraint.side_effect = _get_constraint
+    cfg.get_int.side_effect = _get_int
+    cfg.get_float.side_effect = _get_float
+    cfg.get_str.side_effect = _get_str
+    cfg.get_bool.side_effect = _get_bool
+    cfg.get_priority.side_effect = _get_priority
+    cfg.get_soft_constraint_weight.side_effect = _get_soft_constraint_weight
+    return cfg
+
+
+def _two_bunk_input() -> DirectSolverInput:
+    """2 same-gender bunks, 10 same-session same-gender campers, no requests.
+
+    Trivially feasible: solver must place 10 campers across 2 bunks of
+    capacity 12 with only hard constraints active.  No requests means there
+    is exactly one solution family (any split satisfies all constraints), so
+    the solver finds the first solution quickly and `objective_trajectory`
+    will be non-empty.
+    """
+    bunks = [
+        DirectBunk(
+            id=f"bunk-{i}",
+            campminder_id=9000 + i,
+            name=f"Cabin-{i}",
+            capacity=12,
+            gender="M",
+            session_cm_id=1000001,
+        )
+        for i in range(2)
+    ]
+    persons = [
+        DirectPerson(
+            campminder_person_id=2000 + i,
+            first_name=f"Camper{i}",
+            last_name="Test",
+            grade=8,
+            birthdate="2014-01-01",
+            gender="M",
+            session_cm_id=1000001,
+        )
+        for i in range(10)
+    ]
+    return DirectSolverInput(persons=persons, requests=[], bunks=bunks)
+
+
+def test_multibunk_solve_populates_tier2_stats(mock_config: MagicMock) -> None:
+    with ConfigLoader.use(_PenaltyStubLoader()):  # type: ignore[arg-type]
+        solver = DirectBunkingSolver(input_data=_two_bunk_input(), config_service=mock_config)
+        result = solver.solve(time_limit_seconds=5)
+    assert result is not None
+    stats = result.stats
+    # The multi-bunk solve path wires both capture surfaces.
+    assert isinstance(stats["objective_trajectory"], list)
+    assert isinstance(stats["bound_trajectory"], list)
+    assert len(stats["objective_trajectory"]) >= 1, "a feasible solve yields >=1 solution callback"
+    assert stats["bound_trajectory_truncated"] is False
+    # presolve compression is computed from a real model
+    assert stats["presolve_booleans_pre"] > 0
+    assert isinstance(stats["presolve_compression_ratio"], float)

--- a/tests/integration/solver/test_trajectory_capture.py
+++ b/tests/integration/solver/test_trajectory_capture.py
@@ -5,14 +5,18 @@ Implementation must conform to these tests, not the other way around.
 
 from __future__ import annotations
 
+import time
 from typing import Any, ClassVar
 from unittest.mock import MagicMock
 
 import pytest
+from ortools.sat.python import cp_model
 
 from bunking.config import ConfigLoader
 from bunking.models_v2 import DirectBunk, DirectPerson, DirectSolverInput
+from bunking.solver.callbacks import BestBoundCallback, SolverProgressCallback
 from bunking.solver.direct_solver import DirectBunkingSolver
+from bunking.solver.logging import ConstraintLogger
 
 
 class _PenaltyStubLoader:
@@ -134,3 +138,45 @@ def test_multibunk_solve_populates_tier2_stats(mock_config: MagicMock) -> None:
     # presolve compression is computed from a real model
     assert stats["presolve_booleans_pre"] > 0
     assert isinstance(stats["presolve_compression_ratio"], float)
+
+
+def test_capture_surfaces_share_clock_and_bound() -> None:
+    """The two capture surfaces must not drift.
+
+    Both read the same CP-SAT best bound, and CP-SAT (single-worker) invokes
+    callbacks serially — so every objective-trajectory point's `bound` must
+    equal the most-recent bound-trajectory `bound` at-or-before its `t`. A
+    failure here means a clock-origin split, a sign flip, or one surface
+    recording the wrong value.
+    """
+    model = cp_model.CpModel()
+    n = 40
+    xs = [model.NewIntVar(0, 100, f"x{i}") for i in range(n)]
+    model.Add(sum(xs) <= 600)
+    model.Maximize(sum((i + 1) * xs[i] for i in range(n)))
+
+    solver = cp_model.CpSolver()
+    solver.parameters.num_search_workers = 1  # serialized callbacks, no race
+    solver.parameters.max_time_in_seconds = 3.0
+
+    start = time.monotonic()
+    sol_cb = SolverProgressCallback(MagicMock(spec=ConstraintLogger), start)
+    bound_cb = BestBoundCallback(start)
+    solver.best_bound_callback = bound_cb
+    solver.Solve(model, sol_cb)
+
+    obj_traj = sol_cb.objective_trajectory
+    bnd_traj = bound_cb.bound_trajectory
+
+    assert obj_traj, "expected >=1 solution callback"
+    assert bnd_traj, "expected >=1 best-bound callback"
+
+    # t monotonic non-decreasing within each surface
+    assert [p["t"] for p in obj_traj] == sorted(p["t"] for p in obj_traj)
+    assert [p["t"] for p in bnd_traj] == sorted(p["t"] for p in bnd_traj)
+
+    # Drift invariant: each solution's bound == last bound-traj bound at-or-before its t
+    for p in obj_traj:
+        prior = [e for e in bnd_traj if e["t"] <= p["t"]]  # O(n*m), fine for test-scale data
+        assert prior, f"no bound point at-or-before solution t={p['t']}"
+        assert prior[-1]["bound"] == p["bound"]

--- a/tests/unit/solver/test_callbacks.py
+++ b/tests/unit/solver/test_callbacks.py
@@ -1,0 +1,55 @@
+"""Unit tests for solver progress + best-bound capture surfaces.
+
+Implementation must conform to these tests, not the other way around.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+from ortools.sat.python import cp_model
+
+from bunking.solver.callbacks import _MAX_BOUND_POINTS, BestBoundCallback, SolverProgressCallback
+from bunking.solver.logging import ConstraintLogger
+
+
+class TestBestBoundCallback:
+    def test_records_points_with_t_and_bound(self) -> None:
+        cb = BestBoundCallback(time.monotonic())
+        cb(100.0)
+        cb(90.0)
+        assert len(cb.bound_trajectory) == 2
+        assert cb.bound_trajectory[0]["bound"] == 100.0
+        assert cb.bound_trajectory[1]["bound"] == 90.0
+        assert all(set(p) == {"t", "bound"} for p in cb.bound_trajectory)
+        assert all(p["t"] >= 0.0 for p in cb.bound_trajectory)
+        assert cb.truncated is False
+
+    def test_caps_at_max_points_and_sets_truncated(self) -> None:
+        cb = BestBoundCallback(time.monotonic())
+        for i in range(_MAX_BOUND_POINTS + 50):
+            cb(float(i))
+        assert len(cb.bound_trajectory) == _MAX_BOUND_POINTS
+        assert cb.truncated is True
+
+
+class TestSolverProgressCallbackTrajectory:
+    def test_records_objective_trajectory_during_solve(self) -> None:
+        model = cp_model.CpModel()
+        xs = [model.NewIntVar(0, 50, f"x{i}") for i in range(8)]
+        model.Add(sum(xs) <= 100)
+        model.Maximize(sum((i + 1) * xs[i] for i in range(8)))
+        solver = cp_model.CpSolver()
+        solver.parameters.num_search_workers = 1
+        solver.parameters.max_time_in_seconds = 0.5
+
+        cb = SolverProgressCallback(MagicMock(spec=ConstraintLogger), time.monotonic())
+        solver.Solve(model, cb)
+
+        assert len(cb.objective_trajectory) >= 1
+        for p in cb.objective_trajectory:
+            assert set(p) == {"t", "objective", "bound"}
+            assert p["t"] >= 0.0
+        ts = [p["t"] for p in cb.objective_trajectory]
+        assert ts == sorted(ts)

--- a/tests/unit/solver/test_callbacks.py
+++ b/tests/unit/solver/test_callbacks.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 
 from ortools.sat.python import cp_model
 
-from bunking.solver.callbacks import _MAX_BOUND_POINTS, BestBoundCallback, SolverProgressCallback
+from bunking.solver.callbacks import _MAX_TRAJECTORY_POINTS, BestBoundCallback, SolverProgressCallback
 from bunking.solver.logging import ConstraintLogger
 
 
@@ -28,9 +28,9 @@ class TestBestBoundCallback:
 
     def test_caps_at_max_points_and_sets_truncated(self) -> None:
         cb = BestBoundCallback(time.monotonic())
-        for i in range(_MAX_BOUND_POINTS + 50):
+        for i in range(_MAX_TRAJECTORY_POINTS + 50):
             cb(float(i))
-        assert len(cb.bound_trajectory) == _MAX_BOUND_POINTS
+        assert len(cb.bound_trajectory) == _MAX_TRAJECTORY_POINTS
         assert cb.truncated is True
 
 
@@ -53,3 +53,21 @@ class TestSolverProgressCallbackTrajectory:
             assert p["t"] >= 0.0
         ts = [p["t"] for p in cb.objective_trajectory]
         assert ts == sorted(ts)
+
+    def test_caps_objective_trajectory_and_sets_truncated(self) -> None:
+        """objective_trajectory is capped in lockstep with the bound surface."""
+
+        class _StubProgressCallback(SolverProgressCallback):
+            # on_solution_callback reads these off the CP-SAT base class; stub
+            # them so the cap can be exercised without a live 2000-solution solve.
+            def ObjectiveValue(self) -> float:  # noqa: N802 — matches OR-Tools API
+                return 1.0
+
+            def BestObjectiveBound(self) -> float:  # noqa: N802 — matches OR-Tools API
+                return 0.0
+
+        cb = _StubProgressCallback(MagicMock(spec=ConstraintLogger), time.monotonic())
+        for _ in range(_MAX_TRAJECTORY_POINTS + 50):
+            cb.on_solution_callback()
+        assert len(cb.objective_trajectory) == _MAX_TRAJECTORY_POINTS
+        assert cb.truncated is True

--- a/tests/unit/solver/test_direct_solver_stats.py
+++ b/tests/unit/solver/test_direct_solver_stats.py
@@ -488,6 +488,7 @@ _BUILD_STATS_DICT_KEYS = frozenset(
         "objective_trajectory",
         "bound_trajectory",
         "bound_trajectory_truncated",
+        "objective_trajectory_truncated",
         "lp_root_gap",
         "presolve_compression_ratio",
         "presolve_booleans_pre",
@@ -1363,11 +1364,13 @@ class TestTier2MetricsInStatsDict:
             objective_trajectory=obj_traj,
             bound_trajectory=bnd_traj,
             bound_trajectory_truncated=False,
+            objective_trajectory_truncated=True,
         )
 
         assert stats["objective_trajectory"] == obj_traj
         assert stats["bound_trajectory"] == bnd_traj
         assert stats["bound_trajectory_truncated"] is False
+        assert stats["objective_trajectory_truncated"] is True
         # _compute_optimality_gap(600, 1000) = |600-1000| / max(600,1) = 0.666...
         assert stats["lp_root_gap"] == abs(600.0 - 1000.0) / 600.0
         assert stats["presolve_compression_ratio"] == 2 / 3
@@ -1397,6 +1400,7 @@ class TestTier2MetricsInStatsDict:
         assert stats["objective_trajectory"] == []
         assert stats["bound_trajectory"] == []
         assert stats["bound_trajectory_truncated"] is False
+        assert stats["objective_trajectory_truncated"] is False
         assert stats["lp_root_gap"] is None
         assert stats["presolve_compression_ratio"] is None
         assert stats["presolve_booleans_pre"] == 0

--- a/tests/unit/solver/test_direct_solver_stats.py
+++ b/tests/unit/solver/test_direct_solver_stats.py
@@ -484,6 +484,16 @@ _BUILD_STATS_DICT_KEYS = frozenset(
         "max_linear_coefficient",
         "soft_constraints_by_module",
         "request_density_histogram_by_bucket",
+        # Tier 2 observability (Stream 2, Phase 2 — plateau-diagnostic metrics)
+        "objective_trajectory",
+        "bound_trajectory",
+        "bound_trajectory_truncated",
+        "lp_root_gap",
+        "presolve_compression_ratio",
+        "presolve_booleans_pre",
+        "objective_plateau_time",
+        "bound_gain_after_plateau",
+        "time_to_first_solution",
     }
 )
 
@@ -1296,3 +1306,100 @@ class TestTier1MetricsInStatsDict:
             "immaterial_parent": {},
             "staff": {},
         }
+
+
+class TestTier2MetricsInStatsDict:
+    """The 9 Tier 2 keys (Stream 2 Phase 2) must land in `solver_runs.stats`.
+
+    `_build_stats_dict` accepts `objective_trajectory`, `bound_trajectory`,
+    `bound_trajectory_truncated`; emits the trajectories raw plus `lp_root_gap`,
+    `presolve_compression_ratio`, `presolve_booleans_pre`, and the three
+    derived plateau scalars.
+    """
+
+    def _base_mock_solver(self) -> MagicMock:
+        solver = MagicMock()
+        solver.StatusName.return_value = "FEASIBLE"
+        solver.ObjectiveValue.return_value = 600.0
+        solver.WallTime.return_value = 60.0
+        solver.UserTime.return_value = 60.0
+        solver.BestObjectiveBound.return_value = 700.0
+        solver.NumBranches.return_value = 0
+        solver.NumConflicts.return_value = 0
+        solver.NumBooleans.return_value = 2
+        solver.ResponseProto.return_value = MagicMock(
+            gap_integral=None,
+            deterministic_time=0.0,
+            num_integers=0,
+            additional_solutions=[],
+            solution_info="",
+        )
+        return solver
+
+    def test_emits_tier2_keys_with_populated_trajectories(self) -> None:
+        from bunking.solver.observability import _build_stats_dict
+
+        model = cp_model.CpModel()
+        model.NewBoolVar("a")
+        model.NewBoolVar("b")
+        model.NewBoolVar("c")  # 3 pre-presolve booleans
+
+        obj_traj = [
+            {"t": 1.0, "objective": 500.0, "bound": 900.0},
+            {"t": 5.0, "objective": 600.0, "bound": 850.0},
+        ]
+        bnd_traj = [{"t": 0.5, "bound": 1000.0}, {"t": 60.0, "bound": 700.0}]
+
+        stats = _build_stats_dict(
+            solver=self._base_mock_solver(),
+            status=2,
+            model_proto=model.Proto(),
+            time_limit_seconds=600,
+            num_workers=8,
+            num_persons=2,
+            num_bunks=2,
+            num_requests=3,
+            satisfied_count=2,
+            objective_trajectory=obj_traj,
+            bound_trajectory=bnd_traj,
+            bound_trajectory_truncated=False,
+        )
+
+        assert stats["objective_trajectory"] == obj_traj
+        assert stats["bound_trajectory"] == bnd_traj
+        assert stats["bound_trajectory_truncated"] is False
+        # _compute_optimality_gap(600, 1000) = |600-1000| / max(600,1) = 0.666...
+        assert stats["lp_root_gap"] == abs(600.0 - 1000.0) / 600.0
+        assert stats["presolve_compression_ratio"] == 2 / 3
+        assert stats["presolve_booleans_pre"] == 3
+        assert stats["objective_plateau_time"] == 5.0
+        assert stats["bound_gain_after_plateau"] == 150.0  # abs(700 - 850)
+        assert stats["time_to_first_solution"] == 1.0
+
+    def test_emits_tier2_keys_with_empty_trajectories(self) -> None:
+        from bunking.solver.observability import _build_stats_dict
+
+        model = cp_model.CpModel()
+        model.NewIntVar(0, 10, "x")  # no booleans
+
+        stats = _build_stats_dict(
+            solver=self._base_mock_solver(),
+            status=2,
+            model_proto=model.Proto(),
+            time_limit_seconds=600,
+            num_workers=8,
+            num_persons=1,
+            num_bunks=1,
+            num_requests=1,
+            satisfied_count=1,
+        )
+
+        assert stats["objective_trajectory"] == []
+        assert stats["bound_trajectory"] == []
+        assert stats["bound_trajectory_truncated"] is False
+        assert stats["lp_root_gap"] is None
+        assert stats["presolve_compression_ratio"] is None
+        assert stats["presolve_booleans_pre"] == 0
+        assert stats["objective_plateau_time"] is None
+        assert stats["bound_gain_after_plateau"] is None
+        assert stats["time_to_first_solution"] is None

--- a/tests/unit/solver/test_observability.py
+++ b/tests/unit/solver/test_observability.py
@@ -6,13 +6,18 @@ Implementation must conform to these tests, not the other way around.
 from __future__ import annotations
 
 import logging
+from unittest.mock import MagicMock
 
 import pytest
+from ortools.sat.python import cp_model
 
 from bunking.models_v2 import DirectBunkRequest
 from bunking.solver.observability import (
     _build_impossible_by_reason_by_bucket,
     _build_request_density_histogram_by_bucket,
+    _count_presolve_compression,
+    _derive_plateau_scalars,
+    _lp_root_gap,
 )
 
 
@@ -116,3 +121,73 @@ class TestImpossibleByReasonByBucket:
             result = _build_impossible_by_reason_by_bucket([(_req("r1", 1001, "garbage_field"), "malformed")])
         assert result == {"material_parent": {}, "immaterial_parent": {}, "staff": {}}
         assert any("garbage_field" in r.message for r in caplog.records)
+
+
+class TestCountPresolveCompression:
+    def test_counts_booleans_pre_and_ratio(self) -> None:
+        model = cp_model.CpModel()
+        model.NewBoolVar("a")
+        model.NewBoolVar("b")
+        model.NewBoolVar("c")
+        model.NewIntVar(0, 10, "x")
+        solver = MagicMock()
+        solver.NumBooleans.return_value = 2
+        result = _count_presolve_compression(model.Proto(), solver)
+        assert result == {"presolve_compression_ratio": 2 / 3, "presolve_booleans_pre": 3}
+
+    def test_zero_pre_booleans_yields_none_ratio(self) -> None:
+        model = cp_model.CpModel()
+        model.NewIntVar(0, 10, "x")
+        solver = MagicMock()
+        solver.NumBooleans.return_value = 0
+        result = _count_presolve_compression(model.Proto(), solver)
+        assert result == {"presolve_compression_ratio": None, "presolve_booleans_pre": 0}
+
+
+class TestLpRootGap:
+    def test_uses_first_bound_point_vs_objective(self) -> None:
+        # _compute_optimality_gap(100, 120) = |100-120| / max(100,1) = 0.2
+        assert _lp_root_gap([{"t": 0.1, "bound": 120.0}, {"t": 5.0, "bound": 105.0}], 100.0) == 0.2
+
+    def test_empty_trajectory_returns_none(self) -> None:
+        assert _lp_root_gap([], 100.0) is None
+
+    def test_none_objective_returns_none(self) -> None:
+        assert _lp_root_gap([{"t": 0.0, "bound": 50.0}], None) is None
+
+
+class TestDerivePlateauScalars:
+    def test_normal_trajectories(self) -> None:
+        obj = [
+            {"t": 1.0, "objective": 500.0, "bound": 900.0},
+            {"t": 5.0, "objective": 600.0, "bound": 850.0},
+        ]
+        bnd = [{"t": 0.5, "bound": 1000.0}, {"t": 60.0, "bound": 700.0}]
+        assert _derive_plateau_scalars(obj, bnd) == {
+            "objective_plateau_time": 5.0,
+            "bound_gain_after_plateau": 150.0,  # abs(700 - 850)
+            "time_to_first_solution": 1.0,
+        }
+
+    def test_empty_objective_trajectory_all_none(self) -> None:
+        assert _derive_plateau_scalars([], []) == {
+            "objective_plateau_time": None,
+            "bound_gain_after_plateau": None,
+            "time_to_first_solution": None,
+        }
+
+    def test_single_solution_point(self) -> None:
+        obj = [{"t": 3.0, "objective": 500.0, "bound": 900.0}]
+        assert _derive_plateau_scalars(obj, []) == {
+            "objective_plateau_time": 3.0,
+            "bound_gain_after_plateau": 0.0,  # abs(900 - 900), bound_traj empty -> fallback
+            "time_to_first_solution": 3.0,
+        }
+
+    def test_bound_trajectory_empty_falls_back_to_solution_bound(self) -> None:
+        obj = [
+            {"t": 1.0, "objective": 500.0, "bound": 900.0},
+            {"t": 5.0, "objective": 600.0, "bound": 850.0},
+        ]
+        # final_bound falls back to last solution's bound (850) -> abs(850 - 850) = 0
+        assert _derive_plateau_scalars(obj, [])["bound_gain_after_plateau"] == 0.0


### PR DESCRIPTION
## Solver Tier 2 — Plateau-Diagnostic Metrics (roadmap Phase 2)

Adds three plateau-diagnostic metrics to `solver_runs.stats` and the Solver
Debug dashboard: **best-bound trajectory**, **LP root gap**, **presolve
compression ratio** — plus three derived comparable scalars
(`objective_plateau_time`, `bound_gain_after_plateau`,
`time_to_first_solution`).

### Why
Tier 1 metrics are counts and final scalars — they can't distinguish "the
solver is converging slowly" from "the solver hit a flat plateau". A
best-bound trajectory can. Phase 2 makes the plateau measurable, which
hard-unblocks Phase 4 and makes Phase 3 (mutual-request boost) comparable
run-to-run.

### How
Two CP-SAT capture surfaces share one monotonic clock origin:
- the existing `SolverProgressCallback` records `(t, objective, bound)` per improving solution;
- a new `BestBoundCallback` (`solver.best_bound_callback`, `hasattr`-guarded for pre-9.15 ortools) records `(t, bound)` per bound improvement — it keeps sampling through the plateau when the solution callback goes quiet.

`_build_stats_dict` derives the LP root gap, presolve compression ratio, and
the three plateau scalars post-solve. The frontend registers the 6 scalars in
the metric registry + columns and renders the raw trajectory as a hand-rolled
SVG chart (`BoundTrajectoryChart`) in the drill-down drawer.

### Notes
- **No tracking issue** — implemented as roadmap Phase 2 directly from the spec; Tier 2 was orphaned when #1380 closed on Tier 1 alone.
- **No PocketBase migration** — `solver_runs.stats` is already a JSON blob.
- An integration test asserts the two capture surfaces never drift (every solution's recorded bound equals the most-recent bound-trajectory value at-or-before its timestamp).

### Test plan
- [x] `uv run pytest tests/unit/solver/ tests/integration/solver/test_trajectory_capture.py` — pass
- [x] `uv run mypy bunking/solver/` — clean
- [x] `cd frontend && npx vitest run src/pages/summer/SolverDebugPage/` + `npx tsc --noEmit` — pass
- [x] pre-push verification — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debug UI: visual solver trajectory chart for objective and best-bound over time (includes single-point markers).
  * Backend: captures time-stamped objective and bound trajectories with truncation flags so debug pages render uniformly for all solve paths.
  * UI: added Tier‑2 plateau metric columns and drill‑down “Best‑bound trajectory” section with time-range legend.

* **Documentation**
  * Updated solver roadmap to reflect Phase 2 scope and status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1436)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->