### PR TITLE
feat(frontend): reveal precheck button in production mode (#1413)

### DIFF
--- a/frontend/src/components/session/SessionHeader.test.tsx
+++ b/frontend/src/components/session/SessionHeader.test.tsx
@@ -128,6 +128,60 @@ describe('SessionHeader scenario name truncation', () => {
 })
 
 // ---------------------------------------------------------------------------
+// DOM rendering tests — action button visibility by mode (#1413)
+// ---------------------------------------------------------------------------
+describe('SessionHeader action button visibility by mode', () => {
+  describe('when isProductionMode is true (viewing live CampMinder data)', () => {
+    it('renders the Pre-check button', () => {
+      renderSessionHeader({ isProductionMode: true, currentScenario: null })
+      expect(screen.getByRole('button', { name: /pre-check/i })).toBeInTheDocument()
+    })
+
+    it('renders the Validate Bunking (post-check) button', () => {
+      renderSessionHeader({ isProductionMode: true, currentScenario: null })
+      expect(screen.getByRole('button', { name: /validate bunking/i })).toBeInTheDocument()
+    })
+
+    it('does NOT render the Optimize Bunks (run-solver) button', () => {
+      renderSessionHeader({ isProductionMode: true, currentScenario: null })
+      expect(screen.queryByRole('button', { name: /optimize bunks/i })).not.toBeInTheDocument()
+    })
+
+    it('does NOT render the Clear assignments button', () => {
+      renderSessionHeader({ isProductionMode: true, currentScenario: null })
+      expect(screen.queryByRole('button', { name: /^clear$/i })).not.toBeInTheDocument()
+    })
+  })
+
+  describe('when isProductionMode is false (scenario/draft mode)', () => {
+    it('renders the Pre-check button', () => {
+      renderSessionHeader({ isProductionMode: false })
+      expect(screen.getByRole('button', { name: /pre-check/i })).toBeInTheDocument()
+    })
+
+    it('renders the Optimize Bunks button', () => {
+      renderSessionHeader({ isProductionMode: false })
+      expect(screen.getByRole('button', { name: /optimize bunks/i })).toBeInTheDocument()
+    })
+
+    it('renders the Clear button when a scenario is active', () => {
+      renderSessionHeader({
+        isProductionMode: false,
+        currentScenario: { id: 'sc1', name: 'Test Scenario' },
+      })
+      expect(screen.getByRole('button', { name: /^clear$/i })).toBeInTheDocument()
+    })
+  })
+
+  describe('when canManage is false', () => {
+    it('does NOT render the Pre-check button (regardless of mode)', () => {
+      renderSessionHeader({ canManage: false, isProductionMode: true, currentScenario: null })
+      expect(screen.queryByRole('button', { name: /pre-check/i })).not.toBeInTheDocument()
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Logic-only tests (no DOM) — existing coverage
 // ---------------------------------------------------------------------------
 
@@ -254,24 +308,6 @@ describe('SessionHeader', () => {
   })
 
   describe('conditional rendering', () => {
-    it('should show pre-validate button only in non-production mode', () => {
-      const isProductionMode = false as boolean
-      const session = { cm_id: 1001 } as { cm_id: number } | null
-
-      const shouldShowPreValidate = !isProductionMode && session !== null
-
-      expect(shouldShowPreValidate).toBe(true)
-    })
-
-    it('should hide pre-validate button in production mode', () => {
-      const isProductionMode = true as boolean
-      const session = { cm_id: 1001 } as { cm_id: number } | null
-
-      const shouldShowPreValidate = !isProductionMode && session !== null
-
-      expect(shouldShowPreValidate).toBe(false)
-    })
-
     it('should show clear button only when in scenario mode', () => {
       const isProductionMode = false as boolean
       const currentScenario = { id: 'scenario-1', name: 'Test Scenario' } as {

--- a/frontend/src/components/session/SessionHeader.tsx
+++ b/frontend/src/components/session/SessionHeader.tsx
@@ -190,7 +190,7 @@ export default function SessionHeader({
 
           {/* Right: Action buttons - ml-auto pushes to far right */}
           <div className="ml-auto flex items-center gap-2">
-            {canManage && !isProductionMode && (
+            {canManage && (
               <PreValidateRequestsButton
                 sessionCmId={session.cm_id}
                 year={currentYear}


### PR DESCRIPTION
## Summary
- Reveals the "Pre-check requests" button on the session bunks header when viewing live CampMinder data (production mode), so staff can sanity-check feasibility of the current registrar state without entering a draft scenario.
- Run-solver and clear-assignments remain hidden in production mode as before.
- Post-check (`Check Bunking`) already had no mode gate and is unchanged.

## Implementation
- Single-line change in `SessionHeader.tsx` — drop `!isProductionMode` from the precheck render gate.
- New DOM-render tests in `SessionHeader.test.tsx` verify the four buttons' visibility matrix across production and draft modes, plus the `canManage=false` case.
- Removed two tautological logic tests that re-derived the old conditional rather than asserting on rendered output.

Closes #1413

## Test plan
- [x] New unit tests pass: `npx vitest run src/components/session/SessionHeader.test.tsx`
- [x] Full SessionHeader suite green (34/34)
- [x] TypeScript clean
- [x] eslint + prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Pre-check action is now available in production mode for users with management permissions, enabling request validation regardless of environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1450)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->