### PR TITLE
fix(pb): reciprocity hook updates all siblings + reads cache before cascade (#1445)

### DIFF
--- a/pocketbase/bunk_requests/hooks.go
+++ b/pocketbase/bunk_requests/hooks.go
@@ -111,6 +111,23 @@ func runRecompute(e *core.RecordEvent) {
 	requestee := r.GetInt("requestee_id")
 	requestType := r.GetString("request_type")
 
+	// Read and clear the pre-update cache BEFORE invoking RecomputePairReciprocity.
+	// RecomputePairReciprocity may save sibling rows (or even this same row again,
+	// when multiple source_field siblings share these pair coords). Those saves
+	// re-enter OnRecordUpdate → captureOldCoords, which would overwrite our
+	// cache entry with post-mutation coords and cause us to miss the old-pair
+	// recompute below.
+	var oldCoords pairCoords
+	hasOldCoords := false
+	if r.Id != "" {
+		if cached, ok := preUpdateCache.LoadAndDelete(r.Id); ok {
+			if old, ok := cached.(pairCoords); ok {
+				oldCoords = old
+				hasOldCoords = true
+			}
+		}
+	}
+
 	if err := RecomputePairReciprocity(e.App, year, sessionID, requester, requestee, requestType); err != nil {
 		slog.Error("RecomputePairReciprocity failed",
 			"requester", requester,
@@ -120,37 +137,29 @@ func runRecompute(e *core.RecordEvent) {
 		)
 	}
 
-	if r.Id == "" {
-		return
-	}
-	cached, ok := preUpdateCache.LoadAndDelete(r.Id)
-	if !ok {
-		return
-	}
-	old, ok := cached.(pairCoords)
-	if !ok {
+	if !hasOldCoords {
 		return
 	}
 
-	pairUnchanged := old.Requester == requester &&
-		old.Requestee == requestee &&
-		old.Year == year &&
-		old.SessionID == sessionID &&
-		old.RequestType == requestType
+	pairUnchanged := oldCoords.Requester == requester &&
+		oldCoords.Requestee == requestee &&
+		oldCoords.Year == year &&
+		oldCoords.SessionID == sessionID &&
+		oldCoords.RequestType == requestType
 	if pairUnchanged {
 		return
 	}
-	if old.Requester == 0 || old.Requestee == 0 {
+	if oldCoords.Requester == 0 || oldCoords.Requestee == 0 {
 		return
 	}
 
 	if err := RecomputePairReciprocity(
-		e.App, old.Year, old.SessionID, old.Requester, old.Requestee, old.RequestType,
+		e.App, oldCoords.Year, oldCoords.SessionID, oldCoords.Requester, oldCoords.Requestee, oldCoords.RequestType,
 	); err != nil {
 		slog.Error("RecomputePairReciprocity failed (old pair)",
-			"requester", old.Requester,
-			"requestee", old.Requestee,
-			"request_type", old.RequestType,
+			"requester", oldCoords.Requester,
+			"requestee", oldCoords.Requestee,
+			"request_type", oldCoords.RequestType,
 			"error", err,
 		)
 	}

--- a/pocketbase/bunk_requests/reciprocity.go
+++ b/pocketbase/bunk_requests/reciprocity.go
@@ -14,12 +14,20 @@ const (
 	statusResolved         = "resolved"
 )
 
-// RecomputePairReciprocity recomputes is_reciprocal on both rows of a
+// RecomputePairReciprocity recomputes is_reciprocal on every row of a
 // (personA, personB, request_type) pair in the same year + session.
 // Idempotent: writes only if the new value differs from the stored one.
 //
 // Reciprocity is meaningful only for bunk_with and not_bunk_with rows that
 // share year+session+request_type; the call is a no-op for any other shape.
+//
+// Production allows multiple rows per directed pair when they originate
+// from different source_field values (the unique index includes source_field).
+// Reciprocity is a pair-level property — all sibling rows in the same
+// direction share the same target is_reciprocal — so every sibling must
+// be updated, not just the lowest-id one. The previous single-row logic
+// silently left non-lowest-id siblings stale when their request_type was
+// flipped (#1445).
 func RecomputePairReciprocity(
 	app core.App,
 	year int,
@@ -35,40 +43,44 @@ func RecomputePairReciprocity(
 		return nil
 	}
 
-	rowAB, err := findRow(app, year, sessionID, personA, personB, requestType)
+	rowsAB, err := findRows(app, year, sessionID, personA, personB, requestType)
 	if err != nil {
 		return fmt.Errorf("find A→B: %w", err)
 	}
-	rowBA, err := findRow(app, year, sessionID, personB, personA, requestType)
+	rowsBA, err := findRows(app, year, sessionID, personB, personA, requestType)
 	if err != nil {
 		return fmt.Errorf("find B→A: %w", err)
 	}
 
-	aResolved := rowAB != nil && rowAB.GetString("status") == statusResolved
-	bResolved := rowBA != nil && rowBA.GetString("status") == statusResolved
+	aResolved := anyResolved(rowsAB)
+	bResolved := anyResolved(rowsBA)
 
 	// Reciprocity is a symmetric pair-level property: both rows are reciprocal
-	// iff both exist AND both are resolved. Matches the graph builder's
-	// has_forward && has_backward semantic at social_graph_builder.py:379.
+	// iff at least one row on each side exists AND at least one is resolved on
+	// each side. Matches the graph builder's has_forward && has_backward
+	// semantic at social_graph_builder.py:379.
 	pairReciprocal := aResolved && bResolved
 
-	if err := setIfChanged(app, rowAB, pairReciprocal); err != nil {
-		return fmt.Errorf("update A→B: %w", err)
+	for _, row := range rowsAB {
+		if err := setIfChanged(app, row, pairReciprocal); err != nil {
+			return fmt.Errorf("update A→B sibling %s: %w", row.Id, err)
+		}
 	}
-	if err := setIfChanged(app, rowBA, pairReciprocal); err != nil {
-		return fmt.Errorf("update B→A: %w", err)
+	for _, row := range rowsBA {
+		if err := setIfChanged(app, row, pairReciprocal); err != nil {
+			return fmt.Errorf("update B→A sibling %s: %w", row.Id, err)
+		}
 	}
 	return nil
 }
 
-// findRow returns the bunk_request matching the given coordinates, or nil if
-// no row exists. Production allows multiple rows per directed pair when
-// they originate from different source_field values (the unique index
-// includes source_field). When that happens this helper returns the
-// lowest-id row deterministically — sufficient for "is the other direction
-// resolved?" since all sibling rows in the same direction share the same
-// pair coordinates.
-func findRow(app core.App, year, sessionID, requester, requestee int, requestType string) (*core.Record, error) {
+// findRows returns every bunk_request matching the given coordinates, or
+// an empty slice if none exist. Production allows multiple rows per directed
+// pair when they originate from different source_field values; this helper
+// returns all of them so reciprocity updates can apply uniformly across
+// siblings (#1445 — a single-row helper silently left stale state on
+// non-lowest-id rows when request_type was flipped).
+func findRows(app core.App, year, sessionID, requester, requestee int, requestType string) ([]*core.Record, error) {
 	filter := "year = {:year} && session_id = {:sessionID} && " +
 		"requester_id = {:requester} && requestee_id = {:requestee} && " +
 		"request_type = {:requestType}"
@@ -76,7 +88,7 @@ func findRow(app core.App, year, sessionID, requester, requestee int, requestTyp
 		"bunk_requests",
 		filter,
 		"id",
-		1,
+		0, // 0 = unlimited
 		0,
 		map[string]any{
 			"year":        year,
@@ -89,10 +101,17 @@ func findRow(app core.App, year, sessionID, requester, requestee int, requestTyp
 	if err != nil {
 		return nil, fmt.Errorf("find bunk_requests: %w", err)
 	}
-	if len(records) == 0 {
-		return nil, nil
+	return records, nil
+}
+
+// anyResolved reports whether any row in the slice has status = "resolved".
+func anyResolved(rows []*core.Record) bool {
+	for _, r := range rows {
+		if r.GetString("status") == statusResolved {
+			return true
+		}
 	}
-	return records[0], nil
+	return false
 }
 
 // setIfChanged updates is_reciprocal only if the stored value differs from

--- a/pocketbase/bunk_requests/reciprocity_test.go
+++ b/pocketbase/bunk_requests/reciprocity_test.go
@@ -88,7 +88,10 @@ func makeRequest(t *testing.T, app core.App, requester, requestee int, rtype, st
 // makeRequestWithID is like makeRequest but lets the caller pin a specific
 // record ID — used by tests that exercise the lowest-id-wins behavior of
 // findRow when multiple siblings share pair coords.
-func makeRequestWithID(t *testing.T, app core.App, id string, requester, requestee int, rtype, status string) *core.Record {
+func makeRequestWithID(
+	t *testing.T, app core.App, id string,
+	requester, requestee int, rtype, status string,
+) *core.Record {
 	t.Helper()
 	col, err := app.FindCollectionByNameOrId("bunk_requests")
 	if err != nil {
@@ -323,7 +326,7 @@ func TestHook_RequestTypeFlipUpdatesAllSiblings(t *testing.T) {
 
 	gotSecond = mustFindRecord(t, app, sibSecond.Id)
 	if gotSecond.GetBool("is_reciprocal") {
-		t.Errorf("after flip: just-edited sibling (higher ID) expected is_reciprocal=false, got true (multi-sibling recompute miss — findRow only updates lowest-id row)")
+		t.Errorf("after flip: higher-ID sibling expected is_reciprocal=false, got true (multi-sibling recompute miss)")
 	}
 	gotFirst = mustFindRecord(t, app, sibFirst.Id)
 	if gotFirst.GetBool("is_reciprocal") {

--- a/pocketbase/bunk_requests/reciprocity_test.go
+++ b/pocketbase/bunk_requests/reciprocity_test.go
@@ -82,11 +82,22 @@ func setupBunkRequestsCollection(t *testing.T, app core.App) {
 // pair coords + status. Returns the saved record.
 func makeRequest(t *testing.T, app core.App, requester, requestee int, rtype, status string) *core.Record {
 	t.Helper()
+	return makeRequestWithID(t, app, "", requester, requestee, rtype, status)
+}
+
+// makeRequestWithID is like makeRequest but lets the caller pin a specific
+// record ID — used by tests that exercise the lowest-id-wins behavior of
+// findRow when multiple siblings share pair coords.
+func makeRequestWithID(t *testing.T, app core.App, id string, requester, requestee int, rtype, status string) *core.Record {
+	t.Helper()
 	col, err := app.FindCollectionByNameOrId("bunk_requests")
 	if err != nil {
 		t.Fatalf("makeRequest: find collection: %v", err)
 	}
 	r := core.NewRecord(col)
+	if id != "" {
+		r.Id = id
+	}
 	r.Set("requester_id", requester)
 	r.Set("requestee_id", requestee)
 	r.Set("request_type", rtype)
@@ -251,6 +262,120 @@ func TestHook_StatusFlipFlipsPartner(t *testing.T) {
 	gotAB := mustFindRecord(t, app, rowAB.Id)
 	if gotAB.GetBool("is_reciprocal") {
 		t.Errorf("after A→B flip to declined: A→B expected is_reciprocal=false, got true")
+	}
+}
+
+// #1445: Multi-sibling case — production allows multiple rows for the same
+// (requester, requestee, request_type, year, session) when source_field differs.
+// When flipping the request_type of a non-lowest-id sibling, the hook's
+// findRow returned only the lowest-id sibling and updated it (a no-op when
+// it was already correct), leaving the just-flipped row stale. Asserts that
+// EVERY sibling sharing the destination pair coords has is_reciprocal recomputed.
+func TestHook_RequestTypeFlipUpdatesAllSiblings(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	defer app.Cleanup()
+
+	setupBunkRequestsCollection(t, app)
+	registerHooksOnApp(app)
+
+	// Setup mirrors prod: Asher (100) has one not_bunk_with → Owen (200) sibling
+	// from the CM not_bunk_with field, AND one bunk_with → Owen sibling parsed
+	// from staff notes. Owen has bunk_with → Asher. Force deterministic IDs so
+	// sibFirst < sibSecond lexicographically — production triggers this when
+	// staff_notes parses arrive after the CM field row gets a lower auto-ID.
+	sibFirst := makeRequestWithID(t, app, "aaa01first00000", 100, 200, "not_bunk_with", "resolved")
+	sibSecond := makeRequestWithID(t, app, "zzz99second0000", 100, 200, "bunk_with", "resolved")
+	rowBA := makeRequest(t, app, 200, 100, "bunk_with", "resolved")
+
+	// Sanity: sibSecond (bunk_with) is reciprocal with rowBA.
+	gotSecond := mustFindRecord(t, app, sibSecond.Id)
+	if !gotSecond.GetBool("is_reciprocal") {
+		t.Fatalf("precondition: expected bunk_with sibling is_reciprocal=true")
+	}
+	gotBA := mustFindRecord(t, app, rowBA.Id)
+	if !gotBA.GetBool("is_reciprocal") {
+		t.Fatalf("precondition: expected B→A is_reciprocal=true")
+	}
+	gotFirst := mustFindRecord(t, app, sibFirst.Id)
+	if gotFirst.GetBool("is_reciprocal") {
+		t.Fatalf("precondition: expected not_bunk_with sibling is_reciprocal=false (no partner)")
+	}
+
+	// Refetch sibSecond fresh from DB to mirror the production update flow —
+	// the frontend always loads the latest state before patching, so its
+	// is_reciprocal reflects the cascade-updated DB value (true). The original
+	// test Go pointer still holds stale in-memory is_reciprocal=false from
+	// when makeRequest ran, and saving that would mask the production bug.
+	sibSecondFresh := mustFindRecord(t, app, sibSecond.Id)
+
+	// Flip the SECOND sibling (higher ID, currently bunk_with) to not_bunk_with.
+	// Now there are TWO not_bunk_with siblings from A→B; B has no not_bunk_with
+	// partner. Both must end up reciprocal=false. The lower-ID sibFirst was
+	// already false; the just-flipped sibSecond was true (from its bunk_with
+	// life) and must be cleared.
+	sibSecondFresh.Set("request_type", "not_bunk_with")
+	if err := app.Save(sibSecondFresh); err != nil {
+		t.Fatalf("save flipped sibSecond: %v", err)
+	}
+
+	gotSecond = mustFindRecord(t, app, sibSecond.Id)
+	if gotSecond.GetBool("is_reciprocal") {
+		t.Errorf("after flip: just-edited sibling (higher ID) expected is_reciprocal=false, got true (multi-sibling recompute miss — findRow only updates lowest-id row)")
+	}
+	gotFirst = mustFindRecord(t, app, sibFirst.Id)
+	if gotFirst.GetBool("is_reciprocal") {
+		t.Errorf("after flip: pre-existing not_bunk_with sibling (lower ID) expected is_reciprocal=false, got true")
+	}
+	gotBA = mustFindRecord(t, app, rowBA.Id)
+	if gotBA.GetBool("is_reciprocal") {
+		t.Errorf("after flip: B→A expected is_reciprocal=false (old bunk_with pair orphaned), got true")
+	}
+}
+
+// Diagnostic — #1445 reproduction: flipping request_type on a reciprocal pair
+// must clear is_reciprocal on BOTH the mutated row AND the orphaned partner.
+// Mirror of TestHook_StatusFlipFlipsPartner but flips request_type instead.
+func TestHook_RequestTypeFlipFlipsBoth(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	defer app.Cleanup()
+
+	setupBunkRequestsCollection(t, app)
+	registerHooksOnApp(app)
+
+	rowAB := makeRequest(t, app, 100, 200, "bunk_with", "resolved")
+	rowBA := makeRequest(t, app, 200, 100, "bunk_with", "resolved")
+
+	// Sanity check — initial pair both reciprocal.
+	gotBA := mustFindRecord(t, app, rowBA.Id)
+	if !gotBA.GetBool("is_reciprocal") {
+		t.Fatalf("precondition: expected B→A reciprocal=true")
+	}
+	gotAB := mustFindRecord(t, app, rowAB.Id)
+	if !gotAB.GetBool("is_reciprocal") {
+		t.Fatalf("precondition: expected A→B reciprocal=true")
+	}
+
+	// Flip A→B from bunk_with → not_bunk_with. The old pair (100,200,bunk_with)
+	// is now orphaned (only B→A has bunk_with). The new pair (100,200,not_bunk_with)
+	// has only A→B (B has no not_bunk_with). Both rows should end up reciprocal=false.
+	rowAB.Set("request_type", "not_bunk_with")
+	if err := app.Save(rowAB); err != nil {
+		t.Fatalf("save mutated AB: %v", err)
+	}
+
+	gotAB = mustFindRecord(t, app, rowAB.Id)
+	if gotAB.GetBool("is_reciprocal") {
+		t.Errorf("after A→B request_type flip: A→B expected is_reciprocal=false, got true (same-row recompute miss)")
+	}
+	gotBA = mustFindRecord(t, app, rowBA.Id)
+	if gotBA.GetBool("is_reciprocal") {
+		t.Errorf("after A→B request_type flip: B→A expected is_reciprocal=false, got true (old-pair recompute miss)")
 	}
 }
 


### PR DESCRIPTION
## Summary

Two coupled bugs in the `bunk_requests` reciprocity hook caused `is_reciprocal` to go stale after a `request_type` flip when multiple sibling rows shared the same pair coords. Production allows multiple rows per `(requester, requestee, request_type, year, session)` because `source_field` is part of the unique index — e.g. the parent's CM `not_bunk_with` field AND a `staff_notes` AI parse of the same intent each get their own row. When you flip the request_type on one of these siblings, the hook left the just-edited row's `is_reciprocal` stale.

## Root causes

1. **`findRow` returned only the lowest-id sibling.** `setIfChanged` then operated on the wrong row — typically a no-op when that sibling already had the correct value — leaving the just-edited (higher-id) sibling untouched.

2. **Self-cascade overwrote `preUpdateCache`.** When `setIfChanged` saved the just-edited row again to clear stale state, the inner `OnRecordUpdate` re-ran `captureOldCoords`, overwriting the outer save's cached old coords with post-mutation coords. The outer `LoadAndDelete` then saw `pairUnchanged=true` and skipped the old-pair recompute, leaving the orphaned partner stale.

The two bugs masked each other: the original code didn't trigger #2 because `findRow` returned the lowest-id row, which was usually a no-op. Once #1 is fixed, #2 surfaces — both must be addressed.

## Implementation

- `reciprocity.go`: `findRow` → `findRows` (returns all matches, no `perPage=1` limit). `RecomputePairReciprocity` iterates `setIfChanged` over every sibling on both directions. New `anyResolved` helper preserves the pair-level "any row on this side is resolved" semantic.
- `hooks.go`: `runRecompute` now reads + clears `preUpdateCache` **before** invoking `RecomputePairReciprocity`, so cascading inner saves can't overwrite captured coords.
- `reciprocity_test.go`: +2 new tests:
  - `TestHook_RequestTypeFlipFlipsBoth` — single-row request_type flip (was implicitly covered, now explicit)
  - `TestHook_RequestTypeFlipUpdatesAllSiblings` — multi-sibling regression (failed without fix). Uses pinned IDs to force lowest-id sibling to NOT be the just-edited one.
  - Plus a `makeRequestWithID` helper for tests that need deterministic ID ordering.

## Test plan

- [x] All 13 reciprocity tests pass (11 original + 2 new)
- [x] `go build ./...` clean
- [x] `go vet ./bunk_requests/` clean
- [x] `gofmt` clean
- [x] `golangci-lint` clean
- [x] Verified on live data: after rebuild + restart, idempotent re-save on a stale row correctly clears `is_reciprocal=0`

Closes #1445

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable reciprocity updates: recomputes reciprocity across all sibling requests and ensures partner rows are updated or cleared consistently.
  * Improved hook behavior to avoid unnecessary recomputes by reading/clearing cached prior-pair info before processing.

* **Tests**
  * Added regression tests covering request-type flips and multi-sibling reciprocity updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1452)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->