### PR TITLE
fix(solver): precheck flags self-conflicting bunk_with + not_bunk_with pairs (#1446)

### DIFF
--- a/bunking/solver/constraints/self_conflict.py
+++ b/bunking/solver/constraints/self_conflict.py
@@ -1,0 +1,71 @@
+"""Self-conflict impossibility: same requester has both bunk_with and not_bunk_with to same target."""
+
+from __future__ import annotations
+
+from bunking.models_v2 import DirectBunkRequest
+from bunking.solver.impossibility import (
+    HardConstraintImpossibility,
+    ImpossibilityContext,
+    ImpossibilityReason,
+    register,
+)
+
+_OPPOSITE: dict[str, str] = {
+    "bunk_with": "not_bunk_with",
+    "not_bunk_with": "bunk_with",
+}
+
+
+class SelfConflictImpossibility(HardConstraintImpossibility):
+    """Flag any bunk_with or not_bunk_with request whose requester also has the
+    opposite-polarity request toward the same target camper.
+
+    Both sides of the contradictory pair are caught independently as the
+    predicate iterates over each request in turn.
+    """
+
+    name: str = "self_conflict"
+
+    def check_request(self, req: DirectBunkRequest, ctx: ImpossibilityContext) -> ImpossibilityReason | None:
+        if req.request_type not in ("bunk_with", "not_bunk_with"):
+            return None
+        if not req.requested_person_cm_id:
+            return None  # malformed — MalformedRequestImpossibility owns this
+
+        target_cm_id = req.requested_person_cm_id
+        opposite_type = _OPPOSITE[req.request_type]
+
+        sibling_requests = ctx.input.requests_by_person.get(req.requester_person_cm_id, [])
+        for sibling in sibling_requests:
+            if sibling.id == req.id:
+                continue
+            if sibling.request_type != opposite_type:
+                continue
+            if sibling.requested_person_cm_id != target_cm_id:
+                continue
+            requester = ctx.person_by_cm_id.get(req.requester_person_cm_id)
+            target = ctx.person_by_cm_id.get(target_cm_id)
+            requester_name = (
+                f"{requester.first_name} {requester.last_name}".strip()
+                if requester
+                else str(req.requester_person_cm_id)
+            )
+            target_name = f"{target.first_name} {target.last_name}".strip() if target else str(target_cm_id)
+            return ImpossibilityReason(
+                code="self_conflict",
+                message=(
+                    f"{requester_name} has both a {req.request_type!r} and a "
+                    f"{opposite_type!r} request toward {target_name} — "
+                    f"these are contradictory and cannot both be satisfied."
+                ),
+                detail={
+                    "conflicting_request_id": sibling.id,
+                    "requested_person_cm_id": target_cm_id,
+                    "this_type": req.request_type,
+                    "conflicting_type": opposite_type,
+                },
+            )
+        return None
+
+
+register(SelfConflictImpossibility())

--- a/bunking/solver/impossibility.py
+++ b/bunking/solver/impossibility.py
@@ -239,6 +239,7 @@ for _module_name in (
     "bunk_requests",
     "gender",
     "grade_spread",
+    "self_conflict",
     "session_boundary",
 ):
     _importlib.import_module(f"bunking.solver.constraints.{_module_name}")

--- a/frontend/src/components/PreValidationResultsModal.test.tsx
+++ b/frontend/src/components/PreValidationResultsModal.test.tsx
@@ -453,6 +453,52 @@ describe('PreValidationResultsModal — staff-only view', () => {
     expect(screen.getByText(/isn['’]t enrolled in this session/i)).toBeInTheDocument()
   })
 
+  it('renders friendly label + subtext for self_conflict (#1446)', () => {
+    const results = {
+      ...baseResults,
+      impossibility_report: {
+        total_impossible: 2,
+        affected_campers: 1,
+        by_reason: {
+          self_conflict: [
+            {
+              request_id: 'r_bw',
+              reason_code: 'self_conflict',
+              reason_message:
+                "Emma Johnson has both a 'bunk_with' and a 'not_bunk_with' request toward Liam Garcia",
+              request_type: 'bunk_with',
+              requester: { cm_id: 1, name: 'Emma Johnson', grade: 6, gender: 'F' },
+              requestee: { cm_id: 2, name: 'Liam Garcia', grade: 6, gender: 'M' },
+              detail: {
+                conflicting_request_id: 'r_nbw',
+                requested_person_cm_id: 2,
+                this_type: 'bunk_with',
+                conflicting_type: 'not_bunk_with',
+              },
+            },
+          ],
+        },
+        flat: [],
+      } as unknown as import('../services/solver').ImpossibilityReport,
+    }
+
+    render(
+      <PreValidationResultsModal
+        isOpen
+        onClose={() => {}}
+        results={results}
+        sessionLookup={noopSessionLookup}
+      />
+    )
+
+    // Section header uses the friendly label, never the raw snake_case code.
+    expect(screen.queryByText('self_conflict')).not.toBeInTheDocument()
+    expect(screen.getByText(/contradicting requests/i)).toBeInTheDocument()
+    // Subtext explains the contradiction shape: "bunk with X — also marked don't bunk with"
+    expect(screen.getByText(/Liam Garcia/)).toBeInTheDocument()
+    expect(screen.getByText(/don't bunk with/i)).toBeInTheDocument()
+  })
+
   it('does not render cluster_grade_compatibility reason code (clusters removed)', () => {
     // clusters field is no longer part of ImpossibilityReport; this verifies
     // the modal renders cleanly with no cluster-related output

--- a/frontend/src/components/PreValidationResultsModal.tsx
+++ b/frontend/src/components/PreValidationResultsModal.tsx
@@ -141,6 +141,7 @@ const FRIENDLY_REASON_LABELS: Record<string, string> = {
   age_pref_no_eligible_grade: 'No matching age group available',
   malformed: 'Incomplete request',
   target_not_in_solver: 'Friend not enrolled',
+  self_conflict: 'Contradicting requests',
 }
 
 function friendlyReasonLabel(code: string): string {
@@ -281,6 +282,20 @@ function renderSubtext(
           Requested friend isn&rsquo;t enrolled in this session
         </div>
       )
+
+    case 'self_conflict': {
+      const conflictingType = item.detail?.['conflicting_type'] as string | undefined
+      const conflictingVerb = conflictingType ? requestVerb(conflictingType) : 'do the opposite'
+      return r ? (
+        <div className="text-xs text-stone-600">
+          {verb}{' '}
+          <strong>
+            {r.name} ({r.gender})
+          </strong>{' '}
+          · {ordinalGrade(r.grade)} — also marked <strong>{conflictingVerb}</strong>
+        </div>
+      ) : null
+    }
 
     default:
       return r ? (

--- a/scripts/worktree/new.sh
+++ b/scripts/worktree/new.sh
@@ -207,14 +207,26 @@ fi
 echo -e "${BLUE}Building PocketBase...${NC}"
 (cd pocketbase && go build -o pocketbase .)
 
-# Seed database from main
+# Seed database from main.
+#
+# Use sqlite3 .backup (online backup API), NOT cp. Plain cp of a live SQLite
+# file can capture an inconsistent snapshot when WAL pages are mid-flight,
+# producing a copy that opens fine but reports "database disk image is
+# malformed" the first time PB queries the affected page. The online backup
+# API holds a shared lock on the source while streaming pages, so it is safe
+# to run against a database another process is reading/writing.
 echo -e "${BLUE}Seeding database from main...${NC}"
 if [ -f "$MAIN_REPO/pocketbase/pb_data/data.db" ]; then
+    if ! command -v sqlite3 &> /dev/null; then
+        echo -e "${RED}Error: sqlite3 CLI not found — required for safe DB seeding${NC}"
+        exit 1
+    fi
     mkdir -p "$WORKTREE_DIR/pocketbase/pb_data"
-    cp "$MAIN_REPO/pocketbase/pb_data/data.db" "$WORKTREE_DIR/pocketbase/pb_data/"
-    # Copy WAL files if they exist (for consistency)
-    cp "$MAIN_REPO/pocketbase/pb_data/data.db-shm" "$WORKTREE_DIR/pocketbase/pb_data/" 2>/dev/null || true
-    cp "$MAIN_REPO/pocketbase/pb_data/data.db-wal" "$WORKTREE_DIR/pocketbase/pb_data/" 2>/dev/null || true
+    # Online backup is safe even if main's PB is running. Do NOT copy *-shm /
+    # *-wal — the destination .db produced by .backup is already self-consistent
+    # in rollback-journal mode and stale WAL files from main would override it.
+    sqlite3 "$MAIN_REPO/pocketbase/pb_data/data.db" \
+        ".backup '$WORKTREE_DIR/pocketbase/pb_data/data.db'"
     # Mark as initialized so start_dev.sh skips admin bootstrap (DB already has credentials)
     touch "$WORKTREE_DIR/pocketbase/pb_data/.initialized"
     echo -e "${GREEN}Database seeded from main${NC}"

--- a/tests/unit/api/routers/test_pre_validate_endpoint.py
+++ b/tests/unit/api/routers/test_pre_validate_endpoint.py
@@ -281,3 +281,52 @@ def test_response_includes_mp_campers_entirely_impossible(client: TestClient) ->
             "reason_codes": ["target_not_in_solver"],
         },
     ]
+
+
+def test_response_propagates_self_conflict_bucket(client: TestClient) -> None:
+    """A self_conflict bucket in the impossibility report is present in the response."""
+    from bunking.solver.impossibility import ImpossibleItem
+
+    self_conflict_item = ImpossibleItem(
+        request_id="r_bw",
+        reason_code="self_conflict",
+        reason_message="Emma Johnson has both a 'bunk_with' and a 'not_bunk_with' request toward Liam Garcia.",
+        request_type="bunk_with",
+        requester={"cm_id": 1, "name": "Emma Johnson", "grade": 6, "gender": "F"},
+        requestee={"cm_id": 2, "name": "Liam Garcia", "grade": 6, "gender": "M"},
+        detail={
+            "conflicting_request_id": "r_nbw",
+            "requested_person_cm_id": 2,
+            "this_type": "bunk_with",
+            "conflicting_type": "not_bunk_with",
+        },
+    )
+    fake_report = _FakeReport(
+        total_impossible=1,
+        affected_campers=1,
+        by_reason={"self_conflict": [self_conflict_item]},
+        flat=[self_conflict_item],
+    )
+
+    with (
+        patch("api.routers.solver.pb", _mock_pb()),
+        patch("api.routers.solver.build_session_context", new_callable=AsyncMock) as mock_build_ctx,
+        patch("api.routers.solver.fetch_session_data_v2", new_callable=AsyncMock) as mock_fetch,
+        patch("api.routers.solver.prepare_direct_solver_input") as mock_prepare,
+        patch("api.routers.solver.validate_impossibility") as mock_validate,
+        patch("api.routers.solver.ConfigLoader") as mock_config,
+    ):
+        _apply_standard_mocks(mock_build_ctx, mock_fetch, mock_prepare, mock_validate, mock_config, report=fake_report)
+        resp = client.post("/api/solver/pre-validate", json=_PAYLOAD)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    ir = body["impossibility_report"]
+    assert ir["total_impossible"] == 1
+    assert ir["affected_campers"] == 1
+    assert "self_conflict" in ir["by_reason"]
+    bucket = ir["by_reason"]["self_conflict"]
+    assert len(bucket) == 1
+    assert bucket[0]["reason_code"] == "self_conflict"
+    assert bucket[0]["request_id"] == "r_bw"
+    assert bucket[0]["detail"]["conflicting_request_id"] == "r_nbw"

--- a/tests/unit/solver/impossibility/test_registry.py
+++ b/tests/unit/solver/impossibility/test_registry.py
@@ -17,6 +17,7 @@ EXPECTED_HARD_PREDICATES = {
     "age_preference",
     "grade_compatibility",
     "target_not_in_solver",
+    "self_conflict",
 }
 
 

--- a/tests/unit/solver/impossibility/test_self_conflict.py
+++ b/tests/unit/solver/impossibility/test_self_conflict.py
@@ -1,0 +1,190 @@
+"""SelfConflictImpossibility: bunk_with + not_bunk_with to same target from same requester.
+
+Tests exercise the predicate in isolation (direct class instantiation) and
+through the full validate_impossibility() pipeline.
+"""
+
+from __future__ import annotations
+
+from bunking.solver.constraints.self_conflict import SelfConflictImpossibility
+from bunking.solver.impossibility import _build_context, validate_impossibility
+
+from .conftest import make_bunk, make_input, make_person, make_request
+
+PREDICATE = SelfConflictImpossibility()
+
+
+# ---------------------------------------------------------------------------
+# Predicate-level tests (check_request)
+# ---------------------------------------------------------------------------
+
+
+def test_bunk_with_only_is_not_self_conflicting(mock_config):
+    """A single bunk_with request with no counterpart is not a self-conflict."""
+    p1 = make_person(1, session=1000)
+    p2 = make_person(2, session=1000)
+    req_bw = make_request("r_bw", requester=1, requestee=2, request_type="bunk_with", session=1000)
+    input_data = make_input([p1, p2], [make_bunk(10, session=1000)], [req_bw])
+    ctx = _build_context(input_data, mock_config)
+
+    assert PREDICATE.check_request(req_bw, ctx) is None
+
+
+def test_not_bunk_with_only_is_not_self_conflicting(mock_config):
+    """A single not_bunk_with request with no counterpart is not a self-conflict."""
+    p1 = make_person(1, session=1000)
+    p2 = make_person(2, session=1000)
+    req_nbw = make_request("r_nbw", requester=1, requestee=2, request_type="not_bunk_with", session=1000)
+    input_data = make_input([p1, p2], [make_bunk(10, session=1000)], [req_nbw])
+    ctx = _build_context(input_data, mock_config)
+
+    assert PREDICATE.check_request(req_nbw, ctx) is None
+
+
+def test_bunk_with_with_counter_not_bunk_with_is_self_conflict(mock_config):
+    """Emma has bunk_with Liam AND not_bunk_with Liam — the bunk_with side is flagged."""
+    p_emma = make_person(1, session=1000)
+    p_liam = make_person(2, session=1000)
+    req_bw = make_request("r_bw", requester=1, requestee=2, request_type="bunk_with", session=1000)
+    req_nbw = make_request("r_nbw", requester=1, requestee=2, request_type="not_bunk_with", session=1000)
+    input_data = make_input([p_emma, p_liam], [make_bunk(10, session=1000)], [req_bw, req_nbw])
+    ctx = _build_context(input_data, mock_config)
+
+    reason = PREDICATE.check_request(req_bw, ctx)
+    assert reason is not None
+    assert reason.code == "self_conflict"
+    assert "not_bunk_with" in reason.message or "conflict" in reason.message.lower()
+    assert reason.detail["conflicting_request_id"] == "r_nbw"
+    assert reason.detail["requested_person_cm_id"] == 2
+
+
+def test_not_bunk_with_with_counter_bunk_with_is_self_conflict(mock_config):
+    """The not_bunk_with side of the same pair is also flagged independently."""
+    p_emma = make_person(1, session=1000)
+    p_liam = make_person(2, session=1000)
+    req_bw = make_request("r_bw", requester=1, requestee=2, request_type="bunk_with", session=1000)
+    req_nbw = make_request("r_nbw", requester=1, requestee=2, request_type="not_bunk_with", session=1000)
+    input_data = make_input([p_emma, p_liam], [make_bunk(10, session=1000)], [req_bw, req_nbw])
+    ctx = _build_context(input_data, mock_config)
+
+    reason = PREDICATE.check_request(req_nbw, ctx)
+    assert reason is not None
+    assert reason.code == "self_conflict"
+    assert reason.detail["conflicting_request_id"] == "r_bw"
+    assert reason.detail["requested_person_cm_id"] == 2
+
+
+def test_different_target_is_not_self_conflict(mock_config):
+    """bunk_with Olivia + not_bunk_with Liam — different targets, not a conflict."""
+    p_emma = make_person(1, session=1000)
+    p_liam = make_person(2, session=1000)
+    p_olivia = make_person(3, session=1000)
+    req_bw = make_request("r_bw", requester=1, requestee=3, request_type="bunk_with", session=1000)
+    req_nbw = make_request("r_nbw", requester=1, requestee=2, request_type="not_bunk_with", session=1000)
+    input_data = make_input(
+        [p_emma, p_liam, p_olivia],
+        [make_bunk(10, session=1000)],
+        [req_bw, req_nbw],
+    )
+    ctx = _build_context(input_data, mock_config)
+
+    assert PREDICATE.check_request(req_bw, ctx) is None
+    assert PREDICATE.check_request(req_nbw, ctx) is None
+
+
+def test_age_preference_request_is_ignored(mock_config):
+    """age_preference requests are not bunk_with/not_bunk_with — predicate ignores them."""
+    p1 = make_person(1, session=1000)
+    req_age = make_request(
+        "r_age",
+        requester=1,
+        requestee=None,
+        request_type="age_preference",
+        session=1000,
+        age_preference_target="older",
+    )
+    input_data = make_input([p1], [make_bunk(10, session=1000)], [req_age])
+    ctx = _build_context(input_data, mock_config)
+
+    assert PREDICATE.check_request(req_age, ctx) is None
+
+
+def test_self_conflict_has_no_check_pair_effect(mock_config):
+    """check_pair is not overridden — returns None (Layer 2 does not apply)."""
+    p_emma = make_person(1, session=1000)
+    p_liam = make_person(2, session=1000)
+    req_bw = make_request("r_bw", requester=1, requestee=2, request_type="bunk_with", session=1000)
+    req_nbw = make_request("r_nbw", requester=1, requestee=2, request_type="not_bunk_with", session=1000)
+    input_data = make_input([p_emma, p_liam], [make_bunk(10, session=1000)], [req_bw, req_nbw])
+    ctx = _build_context(input_data, mock_config)
+
+    assert PREDICATE.check_pair(req_bw, ctx) is None
+
+
+# ---------------------------------------------------------------------------
+# Pipeline-level tests (validate_impossibility)
+# ---------------------------------------------------------------------------
+
+
+def test_self_conflict_pair_appears_in_pipeline(mock_config):
+    """Both requests in the contradictory pair appear in the pipeline report."""
+    p_emma = make_person(1, session=1000)
+    p_liam = make_person(2, session=1000)
+    req_bw = make_request("r_bw", requester=1, requestee=2, request_type="bunk_with", session=1000)
+    req_nbw = make_request("r_nbw", requester=1, requestee=2, request_type="not_bunk_with", session=1000)
+    input_data = make_input([p_emma, p_liam], [make_bunk(10, session=1000)], [req_bw, req_nbw])
+
+    report = validate_impossibility(input_data, mock_config)
+
+    assert "self_conflict" in report.by_reason, f"Expected self_conflict bucket; got: {list(report.by_reason)}"
+    flagged_ids = {item.request_id for item in report.by_reason["self_conflict"]}
+    assert "r_bw" in flagged_ids, "bunk_with side not flagged"
+    assert "r_nbw" in flagged_ids, "not_bunk_with side not flagged"
+
+
+def test_self_conflict_total_impossible_counts_both_requests(mock_config):
+    """total_impossible = 2 when both sides of the contradiction are flagged."""
+    p_emma = make_person(1, session=1000)
+    p_liam = make_person(2, session=1000)
+    req_bw = make_request("r_bw", requester=1, requestee=2, request_type="bunk_with", session=1000)
+    req_nbw = make_request("r_nbw", requester=1, requestee=2, request_type="not_bunk_with", session=1000)
+    input_data = make_input([p_emma, p_liam], [make_bunk(10, session=1000)], [req_bw, req_nbw])
+
+    report = validate_impossibility(input_data, mock_config)
+
+    assert report.total_impossible == 2
+
+
+def test_self_conflict_affected_campers_is_one(mock_config):
+    """affected_campers = 1: Emma is the single requester, despite two flagged requests."""
+    p_emma = make_person(1, session=1000)
+    p_liam = make_person(2, session=1000)
+    req_bw = make_request("r_bw", requester=1, requestee=2, request_type="bunk_with", session=1000)
+    req_nbw = make_request("r_nbw", requester=1, requestee=2, request_type="not_bunk_with", session=1000)
+    input_data = make_input([p_emma, p_liam], [make_bunk(10, session=1000)], [req_bw, req_nbw])
+
+    report = validate_impossibility(input_data, mock_config)
+
+    assert report.affected_campers == 1
+
+
+def test_unrelated_request_not_caught_by_self_conflict(mock_config):
+    """Emma's bunk_with Olivia (no counterpart) is not flagged as self-conflict."""
+    p_emma = make_person(1, session=1000)
+    p_liam = make_person(2, session=1000)
+    p_olivia = make_person(3, session=1000)
+    req_bw_liam = make_request("r_bw_liam", requester=1, requestee=2, request_type="bunk_with", session=1000)
+    req_nbw_liam = make_request("r_nbw_liam", requester=1, requestee=2, request_type="not_bunk_with", session=1000)
+    req_bw_olivia = make_request("r_bw_olivia", requester=1, requestee=3, request_type="bunk_with", session=1000)
+    input_data = make_input(
+        [p_emma, p_liam, p_olivia],
+        [make_bunk(10, session=1000, gender="F")],
+        [req_bw_liam, req_nbw_liam, req_bw_olivia],
+    )
+
+    report = validate_impossibility(input_data, mock_config)
+
+    flagged_ids = {item.request_id for item in report.flat}
+    assert "r_bw_olivia" not in flagged_ids, "Clean request incorrectly flagged"
+    assert "r_bw_liam" in flagged_ids
+    assert "r_nbw_liam" in flagged_ids


### PR DESCRIPTION
## Summary

- Adds `SelfConflictImpossibility` (Layer 1 `check_request`) that detects when a single requester has both a `bunk_with` and a `not_bunk_with` request toward the same target camper. Both sides of the contradictory pair are caught independently and land in a new `self_conflict` bucket on `/solver/pre-validate`.
- Adds a friendly label ("Contradicting requests") and a per-row subtext (`bunk with X — also marked don't bunk with`) in `PreValidationResultsModal`, so staff don't see the raw `self_conflict` code.
- Auto-registers via the existing `importlib` block in `impossibility.py`; no router change.

## Bonus: safe worktree DB seed (folded in)

`scripts/worktree/new.sh` used plain `cp` to seed each new worktree's PocketBase database from main. With main's PB running, `cp` can capture an inconsistent snapshot mid-WAL-flight — the destination opens but reports `database disk image is malformed` on the first query against an affected page. Discovered when this PR's own worktree DB landed in that state. Switched to `sqlite3 .backup` (online backup API), which holds a shared lock and streams pages safely.

## Why this layer

Layer 1 (`check_request`, first-match-wins) is correct because:
- The predicate fires per-request on its own sibling list — no pair iteration needed.
- A request already caught as `malformed` or `target_not_in_solver` should not also be flagged as self-conflicting (noise). First-match-wins handles this naturally.
- The `not_bunk_with` side of the pair is caught on its own iteration turn.

Cross-session false-positives aren't possible: cross-session requests auto-decline before they reach the solver, so `requests_by_person` here is implicitly per-session.

## Test plan

- [x] 11 unit tests for the predicate in `tests/unit/solver/impossibility/test_self_conflict.py` (isolation + full pipeline)
- [x] Registry discipline test extended (`EXPECTED_HARD_PREDICATES` includes `self_conflict`)
- [x] Endpoint shape test in `test_pre_validate_endpoint.py` confirms the bucket survives serialization
- [x] Frontend test in `PreValidationResultsModal.test.tsx` confirms the friendly label + subtext render
- [x] Full impossibility suite green (64 tests including pre-existing)
- [x] mypy strict clean, ruff format + check clean
- [x] TypeScript clean, eslint (local v10) 0 errors
- [x] shellcheck clean on the worktree seed script

Closes #1446

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Detects contradictory self-conflicting bunk requests (same requester both "bunk with" and "not bunk with" the same camper) and surfaces clear, staff-friendly messages including involved campers and request references.
  * UI: adds a staff-friendly label and subtext for this impossibility in pre-validation modal.

* **Tests**
  * Adds unit and integration tests covering predicate behavior, pipeline reporting, API serialization, and modal rendering.

* **Chores**
  * Improved worktree DB seeding to use sqlite3 .backup for safer initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1454)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->