### PR TITLE
feat(frontend,sync): expose orphan_reconciler in admin Sync tab

### DIFF
--- a/frontend/src/components/admin/SyncTab.tsx
+++ b/frontend/src/components/admin/SyncTab.tsx
@@ -230,7 +230,7 @@ export function SyncTab() {
             <Icon className={`h-5 w-5 flex-shrink-0 ${syncType.color}`} />
             <div className="min-w-0">
               <div className="truncate text-sm font-semibold sm:text-base">{syncType.name}</div>
-              {'description' in syncType && syncType.description && (
+              {'description' in syncType && (
                 <div className="text-muted-foreground truncate text-xs">{syncType.description}</div>
               )}
             </div>

--- a/frontend/src/components/admin/SyncTab.tsx
+++ b/frontend/src/components/admin/SyncTab.tsx
@@ -228,7 +228,12 @@ export function SyncTab() {
         <div className="mb-3 flex items-center justify-between">
           <div className="flex min-w-0 items-center gap-2">
             <Icon className={`h-5 w-5 flex-shrink-0 ${syncType.color}`} />
-            <span className="truncate text-sm font-semibold sm:text-base">{syncType.name}</span>
+            <div className="min-w-0">
+              <div className="truncate text-sm font-semibold sm:text-base">{syncType.name}</div>
+              {'description' in syncType && syncType.description && (
+                <div className="text-muted-foreground truncate text-xs">{syncType.description}</div>
+              )}
+            </div>
           </div>
           <StatusIcon status={status.status} />
         </div>
@@ -259,6 +264,11 @@ export function SyncTab() {
                 {status.summary.errors > 0 && (
                   <span className="font-medium text-red-600 dark:text-red-400">
                     {status.summary.errors} err
+                  </span>
+                )}
+                {(status.summary.prod_audit_warnings ?? 0) > 0 && (
+                  <span className="font-medium text-amber-600 dark:text-amber-400">
+                    {status.summary.prod_audit_warnings} prod⚠
                   </span>
                 )}
               </div>

--- a/frontend/src/components/admin/syncTypes.test.ts
+++ b/frontend/src/components/admin/syncTypes.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { getSyncTypesByPhase, YEAR_SYNC_TYPES } from './syncTypes'
+
+describe('syncTypes', () => {
+  const currentYear = 2026
+
+  it('includes orphan_reconciler in transform phase', () => {
+    const transformJobs = getSyncTypesByPhase('transform', currentYear, currentYear)
+    const ids = transformJobs.map((t) => t.id)
+    expect(ids).toContain('orphan_reconciler')
+  })
+
+  it('orphan_reconciler is last in the transform phase group', () => {
+    const transformJobs = getSyncTypesByPhase('transform', currentYear, currentYear)
+    const ids = transformJobs.map((t) => t.id)
+    const enrollmentIdx = ids.indexOf('enrollment_snapshots')
+    const orphanIdx = ids.indexOf('orphan_reconciler')
+    expect(orphanIdx).toBeGreaterThan(enrollmentIdx)
+  })
+
+  it('orphan_reconciler has a description clarifying PB-only', () => {
+    const entry = YEAR_SYNC_TYPES.find((t) => t.id === 'orphan_reconciler')
+    expect(entry).toBeDefined()
+    expect('description' in entry!).toBe(true)
+    if ('description' in entry!) {
+      expect(entry.description).toMatch(/PB-only/i)
+    }
+  })
+
+  it('orphan_reconciler is not currentYearOnly', () => {
+    const entry = YEAR_SYNC_TYPES.find((t) => t.id === 'orphan_reconciler')
+    expect(entry).toBeDefined()
+    expect('currentYearOnly' in entry!).toBe(false)
+  })
+})

--- a/frontend/src/components/admin/syncTypes.test.ts
+++ b/frontend/src/components/admin/syncTypes.test.ts
@@ -16,6 +16,7 @@ describe('syncTypes', () => {
     const enrollmentIdx = ids.indexOf('enrollment_snapshots')
     const orphanIdx = ids.indexOf('orphan_reconciler')
     expect(orphanIdx).toBeGreaterThan(enrollmentIdx)
+    expect(orphanIdx).toBe(ids.length - 1)
   })
 
   it('orphan_reconciler has a description clarifying PB-only', () => {

--- a/frontend/src/components/admin/syncTypes.ts
+++ b/frontend/src/components/admin/syncTypes.ts
@@ -5,6 +5,7 @@ import {
   User,
   Layout,
   UserCheck,
+  UserX,
   FileText,
   Brain,
   Tag,
@@ -275,6 +276,14 @@ export const YEAR_SYNC_TYPES = [
     name: 'Enrollment Snapshots',
     icon: Camera,
     color: 'text-teal-500',
+    phase: 'transform' as SyncPhase,
+  },
+  {
+    id: 'orphan_reconciler',
+    name: 'Orphan Reconciler',
+    description: 'PB-only · no CampMinder fetch',
+    icon: UserX,
+    color: 'text-orange-500',
     phase: 'transform' as SyncPhase,
   },
   // Process phase - CSV + AI (current year only)

--- a/frontend/src/hooks/useRunIndividualSync.test.ts
+++ b/frontend/src/hooks/useRunIndividualSync.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { SYNC_TYPE_NAMES } from './useRunIndividualSync'
+
+describe('SYNC_TYPE_NAMES', () => {
+  it('includes orphan_reconciler', () => {
+    expect(SYNC_TYPE_NAMES['orphan_reconciler']).toBeDefined()
+    expect(SYNC_TYPE_NAMES['orphan_reconciler']).toBe('Orphan Reconciler')
+  })
+
+  it('maps orphan_reconciler to kebab-case endpoint segment', () => {
+    // The hook calls /api/custom/sync/${id.replace(/_/g, '-')}
+    // Verify the id string produces the correct endpoint.
+    const id = 'orphan_reconciler'
+    const endpoint = id.replace(/_/g, '-')
+    expect(endpoint).toBe('orphan-reconciler')
+  })
+})

--- a/frontend/src/hooks/useRunIndividualSync.ts
+++ b/frontend/src/hooks/useRunIndividualSync.ts
@@ -37,6 +37,7 @@ export const SYNC_TYPE_NAMES: Record<string, string> = {
   staff_vehicle_info: 'Staff Vehicle Info', // Extracted from SVI- custom fields
   normalize_geographic: 'Normalize Geographic', // Normalizes geographic columns to standard format
   enrollment_snapshots: 'Enrollment Snapshots', // Captures daily enrollment counts per session
+  orphan_reconciler: 'Orphan Reconciler', // Auto-unassigns scenario-draft assignments stranded by bunk_plan changes
   bunk_requests: 'Intake Requests',
   process_requests: 'Process Requests',
   // On-demand syncs (not part of daily sync)

--- a/frontend/src/hooks/useSyncStatusAPI.ts
+++ b/frontend/src/hooks/useSyncStatusAPI.ts
@@ -42,6 +42,7 @@ export interface SyncStatus {
     skipped: number
     errors: number
     already_processed?: number // For process_requests: records already processed
+    prod_audit_warnings?: number // For orphan_reconciler: stranded prod assignments (observe-only)
     duration?: number
     sub_stats?: Record<string, SubStats> // For combined syncs (e.g., persons includes households)
   }
@@ -81,6 +82,7 @@ export interface SyncStatusResponse {
   staff_vehicle_info: SyncStatus
   normalize_geographic: SyncStatus
   enrollment_snapshots: SyncStatus
+  orphan_reconciler: SyncStatus
   // Export phase
   multi_workbook_export: SyncStatus
   // On-demand custom value syncs (expensive, 1 API call per entity)

--- a/pocketbase/sync/api.go
+++ b/pocketbase/sync/api.go
@@ -475,6 +475,14 @@ func InitializeSyncService(app *pocketbase.PocketBase, e *core.ServeEvent) error
 			return handleIndividualSync(e, scheduler, "enrollment_snapshots")
 		}))
 
+	// Orphan reconciler sync
+	// Auto-unassigns scenario-draft campers stranded by bunk-plan changes.
+	// PocketBase-only — no CampMinder API call.
+	e.Router.POST("/api/custom/sync/orphan-reconciler",
+		requirePermission("bunking.manage", func(e *core.RequestEvent) error {
+			return handleIndividualSync(e, scheduler, "orphan_reconciler")
+		}))
+
 	return nil
 }
 
@@ -902,6 +910,7 @@ func handleSyncStatus(e *core.RequestEvent, scheduler *Scheduler) error {
 		"staff_vehicle_info",         // Derived: staff vehicle info extraction
 		"normalize_geographic",       // Derived: normalize state/country names
 		"enrollment_snapshots",       // Derived: daily enrollment snapshot capture
+		"orphan_reconciler",          // Derived: auto-unassign stranded scenario-draft assignments
 		"bunk_requests",
 		"process_requests",
 		"multi_workbook_export",

--- a/pocketbase/sync/api_test.go
+++ b/pocketbase/sync/api_test.go
@@ -1782,6 +1782,40 @@ func TestRunPhaseYearMustPropagateToServices(t *testing.T) {
 	t.Log("YearSetter interface is implemented by year-aware services")
 }
 
+// TestSyncStatusListIncludesOrphanReconciler verifies orphan_reconciler is registered
+// in syncJobMeta with a phase. handleSyncStatus's hardcoded syncTypes slice is a local
+// var that can't be read from tests; the placement in the diff is the primary safeguard.
+// This test catches one related regression: forgetting to register the job in
+// syncJobMeta before adding it to the status list or routes.
+func TestSyncStatusListIncludesOrphanReconciler(t *testing.T) {
+	// Required jobs that must be registered in syncJobMeta. handleSyncStatus's
+	// local syncTypes slice can't be inspected here; placement in the diff is
+	// the human-readable guard for that path.
+	requiredInStatusList := []string{
+		"normalize_geographic",
+		"enrollment_snapshots",
+		"orphan_reconciler", // must be present — card shows "idle" without it
+	}
+
+	// Cross-check against syncJobMeta: every job in the required list must also be
+	// registered with its expected phase so the two sources stay in sync.
+	for _, jobID := range requiredInStatusList {
+		phase := GetPhaseForJob(jobID)
+		if phase == "" {
+			t.Errorf("job %q not found in syncJobMeta — add it before adding to status list", jobID)
+		}
+	}
+
+	// Verify no duplicates in the required list.
+	seen := make(map[string]bool)
+	for _, id := range requiredInStatusList {
+		if seen[id] {
+			t.Errorf("duplicate in requiredInStatusList: %q", id)
+		}
+		seen[id] = true
+	}
+}
+
 // TestNormalizeSession verifies session "0" normalizes to DefaultSession ("all"),
 // matching the behavior of the other two endpoints that already handle this case.
 // Regression test for #806.

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -232,6 +232,8 @@ type Stats struct {
 	Expanded int `json:"expanded,omitempty"`
 	// AlreadyProcessed tracks records already processed (for process_requests)
 	AlreadyProcessed int `json:"already_processed,omitempty"`
+	// ProdAuditWarnings counts bunk_assignments rows found stranded but not cleared (observe-only).
+	ProdAuditWarnings int `json:"prod_audit_warnings,omitempty"`
 	// Duration in seconds
 	Duration int `json:"duration"`
 	// SubStats for combined syncs (e.g., persons includes households)

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -243,7 +243,7 @@ type Stats struct {
 // IsNoOp returns true if the sync made no changes to the database.
 // A sync is a no-op when Created, Updated, Deleted, and Errors are all zero.
 // Skipped records don't affect the data, so they're not considered changes.
-func (s Stats) IsNoOp() bool {
+func (s *Stats) IsNoOp() bool {
 	return s.Created == 0 && s.Updated == 0 && s.Deleted == 0 && s.Errors == 0
 }
 
@@ -649,6 +649,8 @@ func (o *Orchestrator) MarkSyncRunning(syncType string) error {
 // runningJobs to lastCompletedStatus. No-ops if syncType is not tracked.
 // Used by handlers that manage their own Service instances (e.g., process_requests)
 // rather than routing through RunSingleSync.
+//
+//nolint:gocritic // hugeParam: Stats grew past 80B with ProdAuditWarnings; signature refactor out of scope for #1439
 func (o *Orchestrator) FinalizeSyncStatus(syncType string, stats Stats, err error) {
 	endTime := time.Now()
 

--- a/pocketbase/sync/orphan_reconciler.go
+++ b/pocketbase/sync/orphan_reconciler.go
@@ -198,13 +198,14 @@ func reconcileOrphanedAssignments(app core.App, year int, stats *Stats) error {
 				BunkID:    p.GetString("bunk"),
 			})
 		}
-		if strandedProd := findStrandedAssignments(validPairs, plannedSessions, prodCandidates); len(strandedProd) > 0 {
+		strandedProd := findStrandedAssignments(validPairs, plannedSessions, prodCandidates)
+		stats.ProdAuditWarnings = len(strandedProd)
+		if len(strandedProd) > 0 {
 			pairs := make([]string, len(strandedProd))
 			for i, c := range strandedProd {
 				pairs[i] = fmt.Sprintf("%s(session=%s,bunk=%s)", c.RecordID, c.SessionID, c.BunkID)
 			}
 			slog.Warn(msgStrandedProd, "year", year, "count", len(strandedProd), "records", pairs)
-			stats.ProdAuditWarnings = len(strandedProd)
 		}
 	}
 

--- a/pocketbase/sync/orphan_reconciler.go
+++ b/pocketbase/sync/orphan_reconciler.go
@@ -204,6 +204,7 @@ func reconcileOrphanedAssignments(app core.App, year int, stats *Stats) error {
 				pairs[i] = fmt.Sprintf("%s(session=%s,bunk=%s)", c.RecordID, c.SessionID, c.BunkID)
 			}
 			slog.Warn(msgStrandedProd, "year", year, "count", len(strandedProd), "records", pairs)
+			stats.ProdAuditWarnings = len(strandedProd)
 		}
 	}
 

--- a/pocketbase/sync/orphan_reconciler_test.go
+++ b/pocketbase/sync/orphan_reconciler_test.go
@@ -333,6 +333,44 @@ func TestOrphanReconciler_Idempotent(t *testing.T) {
 	}
 }
 
+func TestOrphanReconciler_ProdAuditWarnings(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupOrphanCollections(t, app)
+
+	sess := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 100, "year": 2026})
+	// otherBunk has a plan → session IS in plannedSessions
+	otherBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 1, "name": "B-1", "year": 2026})
+	saveRec(t, app, "bunk_plans", map[string]any{"bunk": otherBunk.Id, "session": sess.Id, "year": 2026})
+	// strandedBunk has no plan for this session → prod assignment is stranded
+	strandedBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 2, "name": "G-5", "year": 2026})
+	person := saveRec(t, app, "persons", map[string]any{"cm_id": 9001})
+	saveRec(t, app, "bunk_assignments", map[string]any{
+		"person": person.Id, "session": sess.Id, "bunk": strandedBunk.Id, "year": 2026,
+	})
+
+	svc := NewOrphanReconcilerSync(app)
+	svc.SetYear(2026)
+	if err = svc.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	if svc.Stats.ProdAuditWarnings != 1 {
+		t.Errorf("want ProdAuditWarnings=1, got %d", svc.Stats.ProdAuditWarnings)
+	}
+	// Prod assignment must NOT be cleared (observe-only).
+	prods, err := app.FindRecordsByFilter("bunk_assignments", "year = 2026", "", 0, 0)
+	if err != nil || len(prods) != 1 {
+		t.Fatalf("prod assignment should still exist, got %d err=%v", len(prods), err)
+	}
+	if prods[0].GetString("bunk") != strandedBunk.Id {
+		t.Errorf("prod assignment bunk must not be cleared (observe-only)")
+	}
+}
+
 // TestOrphanReconciler_ProdQueryErrorIsCountedNotFatal verifies that a failure
 // querying production bunk_assignments is recorded in Stats.Errors — so
 // WasSuccessful() reports false — but does NOT abort the run: the draft sweep

--- a/pocketbase/sync/persons.go
+++ b/pocketbase/sync/persons.go
@@ -403,6 +403,8 @@ func (s *PersonsSync) updateRelationsAndCleanup(
 }
 
 // logSyncResults logs the final sync statistics.
+//
+//nolint:gocritic // hugeParam: Stats grew past 80B with ProdAuditWarnings; signature refactor out of scope for #1439
 func (s *PersonsSync) logSyncResults(householdStats Stats) {
 	slog.Info("Combined sync complete",
 		"persons_created", s.Stats.Created,


### PR DESCRIPTION
## Summary

Adds the missing GUI surface for the `orphan_reconciler` PhaseTransform job (introduced in #1431). The service already runs via daily sync, phase sync, and unified sync — this PR adds the individual HTTP route, the status-list registration, the frontend card, and a new prod-audit warning stat.

Closes #1439.

### Changes

- **Go**: New `ProdAuditWarnings` field on `Stats` surfaces stranded production assignments (observe-only — bunk_assignments owns prod cleanup).
- **Go**: New `POST /api/custom/sync/orphan-reconciler` route + `orphan_reconciler` entry in `handleSyncStatus()` (without the latter, the card would always show "idle").
- **Frontend**: New "Orphan Reconciler" card in the Transform phase, last after Enrollment Snapshots. Icon `UserX`, color `text-orange-500`, subtitle "PB-only · no CampMinder fetch".
- **Frontend**: `prod_audit_warnings` rendered as amber "N prod⚠" stat on the card when non-zero.
- **Lint**: `Stats.IsNoOp()` converted to pointer receiver (Stats crossed the 80B `hugeParam` threshold); two other call sites got scoped `//nolint:gocritic` deferrals.

### Architecture notes

- Individual Run button uses current configured year via `ParseSeasonYear()` — same behavior as peer transforms (`normalize_geographic`, `enrollment_snapshots`). Historical years are reached via Phase sync or full sync; both already include this job.
- The `description` field on sync type entries is new and currently only set on this card — TypeScript's `as const` inference makes it correctly optional in the union.

## Test Plan

- [x] Go tests pass (`go test ./sync/...` — 2038 pass; new `TestOrphanReconciler_ProdAuditWarnings` covers observe-only invariant)
- [x] Frontend tests pass (`npx vitest run` — 4159 pass; new `syncTypes.test.ts` + `useRunIndividualSync.test.ts`)
- [x] `tsc --noEmit` clean
- [x] `golangci-lint run ./sync/...` clean
- [x] `eslint` on modified files clean
- [ ] Visual: card appears last in Transform phase, subtitle reads "PB-only · no CampMinder fetch"
- [ ] Clicking Run triggers `/api/custom/sync/orphan-reconciler`, card transitions to running/success
- [ ] After a run that finds stranded prod assignments, amber "N prod⚠" stat appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Orphan Reconciler" sync type to identify and track production assignment discrepancies
  * UI sync controls allow running the Orphan Reconciler and show it in sync lists
  * Sync status cards now display production audit warnings as an amber "prod⚠" badge

* **Bug Fixes**
  * Sync status aggregation updated to include production audit warning counts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1456)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->