### PR TITLE
build(pb): add go.work for multi-module gopls workspace

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,0 +1,6 @@
+go 1.26.3
+
+use (
+	./docker/healthcheck
+	./pocketbase
+)

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,1 @@
+cloud.google.com/go v0.112.2 h1:ZaGT6LiG7dBzi6zNOvVZwacaXlmf3lRqnC4DQzqyRQw=


### PR DESCRIPTION
## Summary
- Adds a `go.work` (+ `go.work.sum`) at the repo root listing the two existing Go modules: `pocketbase/` and `docker/healthcheck/`
- Silences gopls' "worktree not in Go workspace" warning (cosmetic but emitted by the LSP whenever the workspace folder contains >1 `go.mod` with no `go.work` to coordinate them)
- Enables cross-module navigation and `go build ./...` from the repo root

## Why
Kindred has two Go modules. Without `go.work`, gopls falls into ad-hoc workspace mode and emits warnings. Adding the file is the standard fix.

## CI safety
Both Dockerfiles (`docker/Dockerfile.pocketbase`, `docker/Dockerfile.caddy`) copy only a single module's directory into the build context:
- `COPY pocketbase/go.mod pocketbase/go.sum ./` + `COPY pocketbase/ ./`
- `COPY docker/healthcheck/ ./`

`go.work` is never inside the build context, so containers continue to build in module-only mode (unchanged behavior).

## Test plan
- [x] `go env GOWORK` returns the new file path
- [x] `(cd pocketbase && go build ./...)` succeeds
- [x] `(cd docker/healthcheck && go build ./...)` succeeds
- [x] `go build ./...` from repo root succeeds (new — previously only worked per-module)
- [x] `(cd pocketbase && go test -race ./...)` — 2235 tests pass
- [x] `go vet ./...` clean in both modules
- [ ] CI green (Docker builds, golangci-lint, all checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)