### PR TITLE
fix(frontend): suppress stale reason on manually-declined request rows (#1447)

### DIFF
--- a/frontend/src/utils/dispositionColors.test.ts
+++ b/frontend/src/utils/dispositionColors.test.ts
@@ -226,6 +226,60 @@ describe('shouldShowReasonInStatus', () => {
     expect(shouldShowReasonInStatus('declined', undefined)).toBe(false)
   })
 
+  // Manual UI declines (RequestReviewPanel, AllCamperRequestsModal) write
+  // `status: 'declined'` and leave `disposition_reason` at its prior pipeline
+  // value (intentional per #1368 — empty would lose audit context). The
+  // BunkRequestRow surface should not advertise that stale reason alongside
+  // the new Declined chip — it produces a contradictory display ("Declined ·
+  // Matched"). The all-camper audit modal continues to render the full
+  // history via its own code path; this predicate is for the per-camper
+  // BunkRequestRow only.
+  describe('declined rows with stale resolved-family disposition_reason (#1447)', () => {
+    it('returns false for declined + auto_resolved (stale manual decline)', () => {
+      expect(shouldShowReasonInStatus('declined', 'auto_resolved')).toBe(false)
+    })
+
+    it('returns false for declined + exact_match (stale match reason)', () => {
+      expect(shouldShowReasonInStatus('declined', 'exact_match')).toBe(false)
+    })
+
+    it('returns false for declined + high_confidence_match (stale match reason)', () => {
+      expect(shouldShowReasonInStatus('declined', 'high_confidence_match')).toBe(false)
+    })
+
+    it('returns false for declined + reciprocal_match (stale match reason)', () => {
+      expect(shouldShowReasonInStatus('declined', 'reciprocal_match')).toBe(false)
+    })
+
+    it('returns false for declined + cross_session_satisfied (stale resolved reason)', () => {
+      expect(shouldShowReasonInStatus('declined', 'cross_session_satisfied')).toBe(false)
+    })
+
+    it('returns false for declined + needs_review (stale pending reason)', () => {
+      expect(shouldShowReasonInStatus('declined', 'needs_review')).toBe(false)
+    })
+
+    it('returns false for declined + unknown_reason (unclassified stale reason)', () => {
+      expect(shouldShowReasonInStatus('declined', 'unknown_reason')).toBe(false)
+    })
+
+    it('returns true for declined + session_mismatch (canonical declined reason)', () => {
+      expect(shouldShowReasonInStatus('declined', 'session_mismatch')).toBe(true)
+    })
+
+    it('returns true for declined + target_not_attending (canonical declined reason)', () => {
+      expect(shouldShowReasonInStatus('declined', 'target_not_attending')).toBe(true)
+    })
+
+    it('returns true for declined + target_not_enrolled (canonical declined reason)', () => {
+      expect(shouldShowReasonInStatus('declined', 'target_not_enrolled')).toBe(true)
+    })
+
+    it('returns true for declined + requester_not_attending (canonical declined reason)', () => {
+      expect(shouldShowReasonInStatus('declined', 'requester_not_attending')).toBe(true)
+    })
+  })
+
   it('returns true for pending rows with a triage reason', () => {
     expect(shouldShowReasonInStatus('pending', 'needs_review')).toBe(true)
     expect(shouldShowReasonInStatus('pending', 'target_waitlisted')).toBe(true)

--- a/frontend/src/utils/dispositionColors.ts
+++ b/frontend/src/utils/dispositionColors.ts
@@ -132,7 +132,13 @@ export const formatReason = formatDispositionReason
  * Whether the Status cell should render a reason line under the chip.
  *
  * - Resolved rows: never (chip alone; mutual-match badge lives elsewhere).
- * - Declined rows: whenever a reason is present.
+ * - Declined rows: only for canonical pipeline-declined reasons
+ *   (DECLINED_REASONS). Manual UI declines leave the prior pipeline reason in
+ *   place (intentional per #1368), so the field is often a stale resolved- or
+ *   pending-family value — rendering it alongside "Declined" produces a
+ *   contradictory display ("Declined · Matched"). Symmetric with the pending
+ *   branch below. The all-camper audit modal renders full history via its own
+ *   code path, unaffected by this predicate (issue #1447).
  * - Pending rows: only for triage reasons (needs_review, target_waitlisted,
  *   undirected_preference, self_referential). Other pending rows stay chip-only.
  */
@@ -143,7 +149,7 @@ export function shouldShowReasonInStatus(
   if (!reason) return false
   const normalized = status.toLowerCase()
   if (normalized === 'resolved') return false
-  if (normalized === 'declined') return true
+  if (normalized === 'declined') return DECLINED_REASONS.has(reason)
   if (normalized === 'pending') return PENDING_REASONS.has(reason)
   return false
 }


### PR DESCRIPTION
## Summary

Fixes the contradictory "Declined · Matched" display on the request review tab when staff manually declines a row the pipeline had previously auto-resolved.

**Root cause:** manual UI declines write \`status: 'declined'\` and intentionally leave \`disposition_reason\` at its prior pipeline value (per #1368 — empty would lose audit context). The request review rows render the reason via \`shouldShowReasonInStatus\`, which returned \`true\` for any non-empty reason on declined rows, so stale resolved-family reasons like \`auto_resolved\` (formatted as "Matched") leaked through alongside the new "Declined" chip.

**Fix:** tighten \`shouldShowReasonInStatus\` so the \`declined\` branch only returns \`true\` for canonical \`DECLINED_REASONS\` — symmetric with the existing \`pending\` branch that already gated on \`PENDING_REASONS\`. One-line predicate change in \`frontend/src/utils/dispositionColors.ts\`.

## Scope

- **Tightened:** \`RequestRowDesktop\` / \`RequestRowMobile\` (request review tab) — both already routed through the helper, so they automatically benefit.
- **Untouched:** \`AllCamperRequestsModal\` (full audit modal — line 66 uses its own raw \`disposition_reason ?\` check) and \`BunkRequestRow\` (camper detail panel — inline \`status !== 'resolved'\` check). These are audit-flavor surfaces where staff want to see the pipeline's last-known stamp regardless of subsequent status changes. Per user direction.

## Follow-up

Issue #1458 captures the broader "audit trail when staff overrides the pipeline" design (\`staff_touched\` boolean flag). Out of scope here; #1447 is purely the display-layer cleanup.

## Test plan

- [x] 11 new tests in \`dispositionColors.test.ts\` — 7 stale resolved-/pending-family reasons (must-be-false) + 4 canonical declined reasons (must-be-true)
- [x] Pre-existing \`shouldShowReasonInStatus\` tests still pass (assertions unchanged; only the predicate's branch policy tightened)
- [x] Full \`dispositionColors.test.ts\` suite green (65 tests)
- [x] BunkRequestRow + RequestRow tests green (no regressions)
- [x] TypeScript clean, ESLint clean, Prettier clean

Closes #1447

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced status display for declined items to show only canonical decline reasons, preventing display of stale or unrelated disposition reasons carried over from previous states.

## Tests
* Added comprehensive test coverage validating status behavior for declined items across different disposition reason scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1459)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->