### PR TITLE
chore(docs): layer CLAUDE.md per surface + worktree guard + tier1 denies

### DIFF
--- a/.claude/hooks/worktree-guard.sh
+++ b/.claude/hooks/worktree-guard.sh
@@ -9,19 +9,25 @@
 
 set -u
 
-if ! command -v jq >/dev/null 2>&1; then
-  # No jq → can't parse; fail open so we don't break other tooling.
-  exit 0
+input=$(cat)
+
+if command -v jq >/dev/null 2>&1; then
+  command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null)
+else
+  # Fallback: scan the raw JSON payload. Less precise than parsing
+  # .tool_input.command — may catch the literal string in other fields — but
+  # preserves enforcement. Failing open would leave worktree creation
+  # unguarded on hosts without jq.
+  command=$input
 fi
 
-input=$(cat)
-command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
-
-# Match `git worktree add` with arbitrary whitespace.
+# Match `git ... worktree add`, allowing intervening flags like `-C <dir>` or
+# `--git-dir=…` that would otherwise bypass the guard. Shell separators
+# (`;`, `&`, `|`) bound the match so chained commands still trigger.
 # The wrapper script itself shells out to `git worktree add` internally, but
 # those subprocesses don't go through the Bash tool, so the hook only sees
 # Claude's direct invocations.
-if printf '%s' "$command" | grep -qE '(^|[^/[:alnum:]_-])git[[:space:]]+worktree[[:space:]]+add\b'; then
+if printf '%s' "$command" | grep -qE '\bgit\b[^|;&]*\bworktree[[:space:]]+add\b'; then
   cat >&2 <<'EOF'
 [worktree-guard] BLOCKED: direct `git worktree add` is not allowed in this project.
 

--- a/.claude/hooks/worktree-guard.sh
+++ b/.claude/hooks/worktree-guard.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash — blocks direct `git worktree add` calls.
+# Must use ./scripts/worktree/new.sh which handles port allocation,
+# branch naming, DB seeding, and config symlinks.
+#
+# Exit codes:
+#   0 = allow the tool call
+#   2 = block (Claude Code surfaces stderr as the denial reason)
+
+set -u
+
+if ! command -v jq >/dev/null 2>&1; then
+  # No jq → can't parse; fail open so we don't break other tooling.
+  exit 0
+fi
+
+input=$(cat)
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+
+# Match `git worktree add` with arbitrary whitespace.
+# The wrapper script itself shells out to `git worktree add` internally, but
+# those subprocesses don't go through the Bash tool, so the hook only sees
+# Claude's direct invocations.
+if printf '%s' "$command" | grep -qE '(^|[^/[:alnum:]_-])git[[:space:]]+worktree[[:space:]]+add\b'; then
+  cat >&2 <<'EOF'
+[worktree-guard] BLOCKED: direct `git worktree add` is not allowed in this project.
+
+Use: ./scripts/worktree/new.sh <feature-name>
+
+The script handles things bare `git worktree add` skips:
+  - Port allocation (Vite/FastAPI/Caddy/PocketBase offsets — parallel worktrees collide without it)
+  - Branch naming (feature/<name>)
+  - DB seed from main
+  - .env / local-config symlinks
+
+If the user explicitly asked for a non-standard worktree path, confirm that
+intent with them before bypassing — don't just retry.
+EOF
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "deny": [
+      "Read(pb_data/*.db)",
+      "Read(pb_data/*.db-*)",
+      "Read(pb_data/storage/**)",
+      "Read(pocketbase/pocketbase)",
+      "Read(local/assets/*.png)",
+      "Read(local/assets/*.jpg)",
+      "Read(local/assets/*.jpeg)",
+      "Read(local/assets/*.ico)",
+      "Edit(pb_data/**)",
+      "Write(pb_data/**)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/worktree-guard.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -211,6 +211,7 @@ tmp/
 !package.json
 !package-lock.json
 !.prettierrc.json
+# Claude Code project config — not sensitive; placed here to override `*.json`
 !.claude/settings.json
 !**/sample_*.csv
 !config/staff_list.example.json

--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ pocketbase/pb_migrations/*_updated_users.js
 !pocketbase/bunk_requests/
 !pocketbase/cmd/
 !pocketbase/README.md
+!pocketbase/CLAUDE.md
 # JS tooling for migrations/hooks linting
 !pocketbase/package.json
 !pocketbase/package-lock.json
@@ -172,6 +173,8 @@ coverage.xml
 .claude/*
 !.claude/skills/
 !.claude/skills/**
+!.claude/hooks/
+!.claude/hooks/**
 .superpowers
 docs/superpowers/
 
@@ -208,6 +211,7 @@ tmp/
 !package.json
 !package-lock.json
 !.prettierrc.json
+!.claude/settings.json
 !**/sample_*.csv
 !config/staff_list.example.json
 !config/sheets_export.example.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,58 +36,18 @@ OR-Tools Solver ─────────┘
 
 ## Codebase Map
 
-### Python Backend (`bunking/`)
-Core solver + data-processing package. `api/` is a thin HTTP layer over it.
+Subdir `CLAUDE.md` files load automatically when you edit files in that area — they contain conventions, gotchas, and commands specific to each surface. Root file (this one) covers cross-cutting rules; surface specifics live below.
 
-| Module/Package | Purpose |
-|----------------|---------|
-| `solver/` | OR-Tools CP-SAT solver (see below) |
-| `sync/bunk_request_processor/` | CSV → AI parse → name resolution → disposition pipeline |
-| `satisfaction/` | Single source of truth for "is request X satisfied?" — RequestBucket policy, per-request predicate, per-camper/session aggregation |
-| `metrics/` | Analytics aggregation |
-| `graph/` | Social graph construction + caching — `SocialGraphBuilder` is the public API |
-| `rbac/` | FastAPI permission dependencies (small; the Go side has its own `pocketbase/rbac/`) |
-| `geo_normalizer/` | City/state normalization against `uscities.csv` |
-| `config/` | `ConfigLoader` — reads the PocketBase `config` table |
-| `models_v2.py` | `DirectSolver*` dataclasses — the solver's I/O contract |
-| `bunking_validator.py` | Analyzes assignments and reports validation issues — consumed by `api/routers/validation.py` |
-| `auth_middleware.py` / `jwt_auth.py` | PocketBase JWT verification for FastAPI |
+| Surface | Where | Subdir context |
+|---------|-------|----------------|
+| Python core (sync pipeline, satisfaction policy, social graph, RBAC, geo, config) | `bunking/` | `bunking/CLAUDE.md` |
+| Solver (OR-Tools CP-SAT, constraints, feasibility) | `bunking/solver/` | `bunking/solver/CLAUDE.md` |
+| FastAPI HTTP layer | `api/` | `api/CLAUDE.md` |
+| PocketBase (Go, SQLite, CampMinder sync, migrations) | `pocketbase/` | `pocketbase/CLAUDE.md` |
+| React UI | `frontend/src/` | `frontend/CLAUDE.md` |
+| Tests (pytest + Vitest) | `tests/`, `frontend/src/**/*.test.ts` | `tests/CLAUDE.md` |
 
-### Solver (`bunking/solver/`)
-CP-SAT model built from composable **constraint builders**. Entry: `direct_solver.py`.
-- `constraints/` — one module per concern (gender, age_spread, grade_adjacency, bunk_requests, parent_paramount, group_locks, level_progression, …). Each follows the `ConstraintBuilder`/`ObjectiveBuilder` protocols in `constraints/base.py`.
-- `SolverContext` (`constraints/base.py`) — shared state threaded through builders.
-- `feasibility.py` / `impossibility.py` — diagnose infeasible models.
-- Organized by Tier / Stage / RequestBucket. Read before touching the solver: `docs/reference/solver-roadmap.md`, `docs/guides/solver-configuration.md`, `docs/api/solver-api.md`.
-
-### FastAPI (`api/`)
-Routers in `api/routers/` (solver, scenarios, social_graph, satisfaction, requests, metrics, validation, geo, debug, internal). Schemas in `api/schemas/`, helpers in `api/utils/`. Business logic lives in `bunking/`, not here.
-
-### PocketBase Go (`pocketbase/`)
-Entry: `main.go`. Packages: `sync/` + `campminder/`, `rbac/`, `feedback/`, `google/`, `bunk_requests/`, `ratelimit/`, `logging/`, `pb_hooks/` (JS hooks), `pb_migrations/` (schema source of truth).
-
-### Frontend (`frontend/src/`)
-
-| Directory | Purpose |
-|-----------|---------|
-| `components/` | Reusable React components |
-| `components/graph/` | Social network graph modules (styles, interactions, layout, UI) |
-| `pages/` | Route-level page components |
-| `hooks/` | Custom React hooks (data fetching, state) |
-| `services/` | API clients, business logic |
-| `types/` | TypeScript type definitions |
-| `lib/` | Third-party library integrations |
-| `contexts/` | React context providers |
-
-**Key Component Patterns:**
-- **Modular extraction**: Large components like `SocialNetworkGraph.tsx` are decomposed into utility modules
-- **Custom hooks**: Data fetching logic extracted to hooks (`useSocialGraphData`, `useBunkNames`, `useSessionHierarchy`)
-- **Barrel exports**: Component directories use `index.ts` for clean imports
-
-**Technologies**: React 19, TypeScript 5.8+, Vite, Tailwind CSS, React Query, @dnd-kit, Cytoscape.js
-
-### Tests (`tests/`)
-`tests/{unit,integration,e2e,performance}/`. Markers (`pyproject.toml`, strict mode — an unregistered marker is a failure): `ai_required` and `pocketbase_required` are **skipped in CI** (they need live AI tokens / a running PocketBase). Run them locally with a dev server up.
+Harness improvements roadmap: `docs/reference/claude-harness-improvements.md`.
 
 ## 📚 Full Documentation
 
@@ -160,11 +120,7 @@ Format: `type(scope): description` — Breaking changes: `feat(api)!: descriptio
 
 ## Logging Standards
 
-Format: `2026-01-06T14:05:52Z [source] LEVEL message key=value...`
-
-- Python: `from bunking.logging_config import configure_logging, get_logger`
-- Go: `import "github.com/camp/kindred/pocketbase/logging"` then `logging.Init("pocketbase")`
-- `LOG_LEVEL=INFO` (default) suppresses health checks; use `DEBUG` for verbose
+Format: `2026-01-06T14:05:52Z [source] LEVEL message key=value...`. `LOG_LEVEL=INFO` (default) suppresses health checks; `DEBUG` for verbose. Language-specific setup: `bunking/CLAUDE.md` (Python), `pocketbase/CLAUDE.md` (Go).
 
 ## Git Hooks (Lefthook)
 
@@ -183,22 +139,7 @@ Escape hatches and manual runs: `docs/reference/git-workflow.md`
 
 ## Error Handling Conventions
 
-**Frontend:**
-- **Page-level `<ErrorBoundary>`**: Every lazy-loaded route in `App.tsx` is wrapped with `<ErrorBoundary>` around `<Suspense>`. This isolates crashes to the affected page — nav and other routes remain functional. New routes MUST follow this pattern.
-- **`<QueryGuard>`** (`components/QueryGuard.tsx`): Render-prop component that handles loading/error/empty/success states for React Query data. Use it in new data-fetching pages to avoid hand-rolling the same if/isLoading/if/error pattern. Existing pages use inline patterns — don't refactor them unless already touching that code.
-- **All 4 states must be handled**: loading, error, empty, success. Never render a data-dependent component without checking the query state first.
-
-**Backend:**
-- **Global exception handler** in `api/main.py` catches unhandled exceptions and returns `{"detail": "Internal server error"}` (generic). Full error details are logged server-side with `exc_info=True`. Never use `raise HTTPException(status_code=500, detail=str(e))` — let the global handler catch it instead.
-
-## Tour & Hint Maintenance
-
-When modifying page layout, features, or `data-tour` attributes on a toured page, review and update the corresponding tour definition in `frontend/src/tours/definitions/`.
-Checklist:
-- [ ] data-tour attributes still reference correct elements
-- [ ] isReady() still checks the right element
-- [ ] Step/hint descriptions match current behavior
-- [ ] Bump `version` if steps changed (triggers re-play for returning users)
+Surface-specific — see `frontend/CLAUDE.md` (ErrorBoundary + QueryGuard patterns) and `api/CLAUDE.md` (global FastAPI exception handler).
 
 ---
 
@@ -216,22 +157,17 @@ Checklist:
 
 ## Development Notes
 
-### Invariants
-Internalize these — violating them produces incorrect code or data corruption.
+### Invariants (cross-cutting)
+Internalize these — violating them produces incorrect code or data corruption. Surface-specific invariants live in the corresponding subdir CLAUDE.md.
 
-1. **CampMinder IDs** — All cross-table relationships use CM IDs, never PocketBase IDs
+1. **CampMinder IDs** — all cross-table relationships use CM IDs, never PocketBase IDs
 2. **Sync order matters** — sessions → attendees → persons → bunks → plans → assignments → requests
-3. **Family-camp data syncs** alongside summer data — summer-camp views must filter `session_type` against `VALID_SUMMER_SESSION_TYPES` (frontend) / `valid_summer_session_types` equivalents to avoid leaking family-camp sessions, attendees, or bunks
+3. **Family-camp data syncs alongside summer data** — summer-camp views must filter `session_type` against `VALID_SUMMER_SESSION_TYPES` (frontend) / `valid_summer_session_types` equivalents
 4. **Config is database-driven** — PocketBase `config` table, not JSON files. AI settings via env vars (`AI_API_KEY`, `AI_MODEL`, `AI_PROVIDER`)
-5. **Year-aware syncs** — Uses `season_id` from config; ready for new year with config update
-6. **Sequential session syncs** — Sessions 1-4 run sequentially with independent history
-7. **WAL checkpoint** — Required after database modifications
-8. **PocketBase filter syntax** — ALWAYS spaces around operators (`field = value` not `field=value`)
-9. **React auth guards** — Check `isLoading` from `useAuth()` before authenticated API calls
-10. **React Query keys** — Use centralized keys from `frontend/src/utils/queryKeys.ts`
-11. **Attendee filtering** — Solver uses `status_id = 2` for active enrolled attendees
-12. **mypy strict mode** — `pyproject.toml` runs mypy with `strict = true`; all new Python must be fully type-annotated or pre-push fails
-13. **Spelling: "cancelled"** — PocketBase fields use British spelling (`cancelled_count`). Go linter allows it via `.golangci.yml` extra-words. Use `cancelled` consistently, not `canceled`
+5. **Year-aware syncs** — uses `season_id` from config; ready for new year with config update
+6. **Sequential session syncs** — sessions 1-4 run sequentially with independent history
+7. **WAL checkpoint required** after database modifications
+8. **Attendee filtering** — solver uses `status_id = 2` for active enrolled attendees
 
 ### Tooling Notes
 1. **Language Versions** — Python 3.14+, Go 1.26+, Node 22+, TypeScript 5.8+/ES2022
@@ -239,8 +175,6 @@ Internalize these — violating them produces incorrect code or data corruption.
 3. **AI model** — GPT-5-nano via `AI_MODEL` env var ($0.05/$0.40 per M tokens, reasoning enabled)
 4. **Token caching** — CampMinder JWT cached in `~/.campminder_token_cache.json`
 5. **IPv4 in production** — Caddy/Vite configs use `127.0.0.1`; scripts may use localhost
-6. **Python line length** — 120 chars (configured in `ruff.toml`), enforced by ruff format
-7. **Frontend tests** — Vitest (not Jest); `npm run test` for watch mode, `npx vitest run` for one-shot
 
 ---
 
@@ -252,11 +186,15 @@ Internalize these — violating them produces incorrect code or data corruption.
 
 **NEVER commit or push to `main`.** All changes go through a feature branch and PR. Main is protected; direct pushes fail anyway.
 
-**ALWAYS use a worktree for feature work.** Before starting ANY feature work:
+**ALWAYS create worktrees via `./scripts/worktree/new.sh` — never bare `git worktree add`, never `EnterWorktree`.** Before starting ANY feature work:
 ```bash
 ./scripts/worktree/new.sh <descriptive-feature-name>
 cd ../kindred-worktrees/<feature-name>
 ```
+
+The script does setup `git worktree add` skips: port allocation (Vite/FastAPI/Caddy/PocketBase offsets so parallel worktrees don't collide), branch naming (`feature/<name>`), DB seed from main, local-config symlinks. Bypassing it has caused parallel-agent port collisions on recent PRs.
+
+A `PreToolUse` hook (`.claude/hooks/worktree-guard.sh`) blocks direct `git worktree add` invocations. If it denies a call, that's working as intended — switch to `new.sh`.
 
 **When can I work in the main repo folder?** Only if BOTH conditions are met:
 

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -1,0 +1,42 @@
+# api/
+
+FastAPI HTTP layer over `bunking/`. Thin shell — routers parse input, call into `bunking/`, return shape.
+
+## Layout
+
+| Dir | Purpose |
+|-----|---------|
+| `routers/` | One file per logical area (solver, scenarios, social_graph, satisfaction, requests, metrics, validation, geo, debug, internal) |
+| `schemas/` | Pydantic request/response models |
+| `utils/` | Small router helpers |
+| `main.py` | App setup + global exception handler |
+
+## Business logic belongs in `bunking/`, not here
+
+Routers should be thin. If a router accumulates logic, extract to `bunking/` and have the router call back in. See `bunking/CLAUDE.md`.
+
+## Global exception handler
+
+`api/main.py` registers a handler that catches unhandled exceptions and returns:
+
+```json
+{"detail": "Internal server error"}
+```
+
+(generic message — never the actual error). Full traceback is logged server-side with `exc_info=True`.
+
+**Never use `raise HTTPException(status_code=500, detail=str(e))`** — that leaks internals to clients. Let the global handler catch it.
+
+## Routing
+
+Caddy uses an **inverse routing pattern**: specific PocketBase paths (`/api/collections/*`, `/api/files/*`, `/api/realtime`, `/api/custom/*`, `/api/oauth2-redirect`) go to PocketBase; everything else under `/api/*` goes to FastAPI. New FastAPI endpoints automatically work — no Caddy enumeration needed.
+
+Config: `docker/Caddyfile` (prod), `frontend/Caddyfile` (dev).
+
+## Auth
+
+`bunking/auth_middleware.py` + `bunking/jwt_auth.py` verify PocketBase JWTs. Frontend must use `fetchWithAuth` (not raw `fetch`) — the JWT lives in localStorage, not cookies. Protected endpoints must verify auth or they silently 401.
+
+## Conventions
+
+Same Python conventions as `bunking/` — Python 3.14+, mypy strict, line length 120, `bunking.logging_config` (tag this surface as `[api]`). Tests: `tests/integration/` for router tests, `tests/unit/` for schema tests.

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -35,7 +35,7 @@ Config: `docker/Caddyfile` (prod), `frontend/Caddyfile` (dev).
 
 ## Auth
 
-`bunking/auth_middleware.py` + `bunking/jwt_auth.py` verify PocketBase JWTs. Frontend must use `fetchWithAuth` (not raw `fetch`) — the JWT lives in localStorage, not cookies. Protected endpoints must verify auth or they silently 401.
+`bunking/auth_middleware.py` + `bunking/jwt_auth.py` verify PocketBase JWTs. Frontend must call protected endpoints through the `fetchWithAuth` wrapper returned by `useApiWithAuth()` (not raw `fetch`) — the JWT lives in localStorage, not cookies. Protected endpoints must verify auth or they silently 401.
 
 ## Conventions
 

--- a/bunking/CLAUDE.md
+++ b/bunking/CLAUDE.md
@@ -1,0 +1,55 @@
+# bunking/
+
+Core Python package: solver, data processing, satisfaction policy, social graphs, RBAC, geo, config. `api/` is a thin HTTP layer over this.
+
+## Modules
+
+| Module | Purpose |
+|--------|---------|
+| `solver/` | OR-Tools CP-SAT model — see `bunking/solver/CLAUDE.md` |
+| `sync/bunk_request_processor/` | CSV → AI parse → name resolution → disposition pipeline |
+| `satisfaction/` | Single source of truth for "is request X satisfied?" — RequestBucket policy, predicates, aggregation |
+| `metrics/` | Analytics aggregation |
+| `graph/` | Social graph construction + caching — `SocialGraphBuilder` is the public API |
+| `rbac/` | FastAPI permission dependencies (Go has its own `pocketbase/rbac/`) |
+| `geo_normalizer/` | City/state normalization against `uscities.csv` |
+| `config/` | `ConfigLoader` — reads the PocketBase `config` table |
+| `models_v2.py` | `DirectSolver*` dataclasses — solver I/O contract |
+| `bunking_validator.py` | Analyzes assignments; consumed by `api/routers/validation.py` |
+| `auth_middleware.py` / `jwt_auth.py` | PocketBase JWT verification for FastAPI |
+
+## Where business logic lives
+
+**Here, not in `api/`.** Routers should be thin: parse input, call into `bunking/`, return shape. Logic in a router is a smell — extract.
+
+## Python conventions
+
+- **Python 3.14+**, invoke via `uv run <cmd>`. Verify the interpreter with `uv run python` — NOT the system `python3` (often 3.12, which can misflag valid 3.14 syntax).
+- **mypy strict mode** — `pyproject.toml` runs mypy with `strict = true`. All new Python must be fully type-annotated; pre-push fails otherwise.
+- **Line length 120** — configured in `ruff.toml`, enforced by `ruff format`.
+
+## Logging
+
+```python
+from bunking.logging_config import configure_logging, get_logger
+logger = get_logger(__name__)
+```
+
+Format: `2026-01-06T14:05:52Z [bunking] LEVEL message key=value...`. `LOG_LEVEL=INFO` (default) suppresses noise; `DEBUG` for verbose.
+
+## Tests
+
+```bash
+uv run pytest tests/                                # all (CI markers respected)
+uv run pytest tests/path/test_file.py::test_name    # single
+uv run pytest tests/ -k "keyword"                   # by keyword
+```
+
+See `tests/CLAUDE.md` for marker semantics (some tests are skipped in CI).
+
+## Domain references
+
+- `docs/architecture/sync-layer.md` — read before touching sync jobs
+- `docs/architecture/bunk-request-pipeline.md` — CSV upload, AI parse, name resolution
+- `docs/architecture/metrics-module.md` — adding/modifying metrics
+- `docs/architecture/session-types.md` — sessions, bunking, AG logic

--- a/bunking/solver/CLAUDE.md
+++ b/bunking/solver/CLAUDE.md
@@ -1,0 +1,48 @@
+# bunking/solver/
+
+OR-Tools CP-SAT model built from composable constraint builders. Entry: `direct_solver.py` → `DirectBunkingSolver`.
+
+## Read first
+
+Before adding or modifying constraints:
+
+- `docs/reference/solver-roadmap.md` — Tier / Stage / RequestBucket organization, status, plan
+- `docs/guides/solver-configuration.md` — config keys, weights, thresholds
+- `docs/api/solver-api.md` — I/O contract via `models_v2.DirectSolver*` dataclasses
+
+## Architecture
+
+| File | Purpose |
+|------|---------|
+| `direct_solver.py` | `DirectBunkingSolver` — top-level orchestrator |
+| `constraints/base.py` | `ConstraintBuilder` / `ObjectiveBuilder` protocols + `SolverContext` |
+| `constraints/<concern>.py` | One module per concern (gender, age_spread, grade_adjacency, bunk_requests, parent_paramount, group_locks, level_progression, …) |
+| `feasibility.py`, `impossibility.py` | Diagnose infeasible models |
+
+## ConstraintBuilder pattern
+
+Each constraint module follows the `ConstraintBuilder` or `ObjectiveBuilder` protocol from `constraints/base.py`. `SolverContext` (defined there) threads shared state through builders — never reach around it.
+
+## RequestBucket / Tier organization
+
+Requests are organized by three axes:
+
+- **Tier** — priority class (Tier 1 parent-paramount, Tier 2 high-priority, Tier 3 preferences)
+- **Stage** — when in the solve cycle the constraint applies
+- **RequestBucket** — request-type grouping (see `bunking/satisfaction/`)
+
+**Satisfaction logic lives in `bunking/satisfaction/`, NOT in the constraint modules.** Constraints add CP-SAT variables; satisfaction reads them to score. Don't blur this boundary.
+
+## Soft constraints
+
+Soft violations and bonuses accumulate in `SolverContext.soft_constraint_violations` and `.soft_constraint_bonuses`. The objective sums these for the final score. `_log_objective_breakdown` in `direct_solver.py` shows how categories aggregate at solve time.
+
+## Infeasibility
+
+`find_infeasibility_cause()` and the `impossibility_report` field surface infeasibility analysis. `_validate_requests` runs early to drop physically impossible requests *before* solver setup — cheaper to filter than to solve and fail.
+
+## Don't conflate
+
+- **Satisfied ≠ possible.** A request can be possible (campers exist + eligible) but unsatisfied (solver didn't place them together). The metric distinction is enforced.
+- **Cross-session bunk requests auto-DECLINE.** They're physically impossible, not low-confidence. Don't raise thresholds to "fix" them.
+- **SAME_AGE preferences stay PENDING.** May be a dog-whistle for avoiding AG cabins — staff review required.

--- a/docs/reference/claude-harness-improvements.md
+++ b/docs/reference/claude-harness-improvements.md
@@ -47,7 +47,10 @@ Applied (Tier 1, binaries + DBs):
 "Read(pb_data/*.db-*)"
 "Read(pb_data/storage/**)"
 "Read(pocketbase/pocketbase)"
-"Read(local/assets/*.png|jpg|jpeg|ico)"
+"Read(local/assets/*.png)"
+"Read(local/assets/*.jpg)"
+"Read(local/assets/*.jpeg)"
+"Read(local/assets/*.ico)"
 "Edit(pb_data/**)"
 "Write(pb_data/**)"
 ```

--- a/docs/reference/claude-harness-improvements.md
+++ b/docs/reference/claude-harness-improvements.md
@@ -1,0 +1,190 @@
+# Claude Harness Improvements
+
+Tracking how the Claude Code setup for this repo measures against [the upstream guidance for large codebases](https://claude.com/blog/how-claude-code-works-in-large-codebases-best-practices-and-where-to-start). This is a living doc — re-audit roughly every 3–6 months, or after a major model release when behavior changes.
+
+The harness — CLAUDE.md layering, hooks, skills, plugins, MCP, LSP, subagents, permissions — often matters more than the model. Tuning it is the work.
+
+---
+
+## Status snapshot
+
+| # | Item | State |
+|---|------|-------|
+| 1 | Subdir CLAUDE.md layering | **Done** for `pocketbase/`, `bunking/`, `bunking/solver/`, `api/`, `frontend/`, `tests/`. Root file trimmed. |
+| 2 | `permissions.deny` rules | **Partial** — Tier 1 (binaries + DB files) applied. Tier 2 (noise reducers) pending. |
+| 3 | `.claudeignore` for lockfiles + reference dumps | Not started |
+| 4 | Stop hook (CLAUDE.md self-improvement) | Not started |
+| 5 | SessionStart hook (dynamic branch/PR/worktree context) | Not started |
+| 6 | Custom project subagents (`.claude/agents/`) | Not started |
+| 7 | Clean stale `/home/adam/bunking/` paths from allow lists | Not started |
+| 8 | Dedupe global vs project allow lists | Not started |
+| 9 | Plugin bundling | Deferred (solo dev) |
+| 10 | Cleanup `.claude/worktrees/agent-*` (EnterWorktree leftovers) | Not started |
+| 11 | Disable `rust-analyzer-lsp` plugin (no Rust in tree) | Not started |
+| 12 | Verify committed binaries (`pocketbase/pocketbase`, `pocketbase/diagnose_google`) | **Resolved** — `pocketbase/pocketbase` is the runtime (referenced by `start_dev.sh`, `new.sh`, Dockerfile.pocketbase); `diagnose_google` was an orphan OIDC-debug compile output, deleted. Both were gitignored, never tracked. |
+
+---
+
+## 1. Subdir CLAUDE.md — done, with maintenance notes
+
+Files load opportunistically: when Claude touches a file at path `P`, it walks up loading every `CLAUDE.md` along the way. Root + subdir stack — they don't replace.
+
+**Maintenance rule**: when adding to a subdir CLAUDE.md, *delete* the duplicate in root. Pre-push grep for the same phrase in both files is the cheap enforcement.
+
+**Anti-patterns**:
+- Putting tactical detail ("when you change X also update Y") — that's a code comment
+- Depth beyond top-level surface dirs (no `frontend/src/hooks/CLAUDE.md`)
+- Stuffing reusable expertise here that belongs in a skill
+
+---
+
+## 2. `permissions.deny` — Tier 1 applied, Tier 2 pending
+
+Applied (Tier 1, binaries + DBs):
+
+```json
+"Read(pb_data/*.db)"
+"Read(pb_data/*.db-*)"
+"Read(pb_data/storage/**)"
+"Read(pocketbase/pocketbase)"
+"Read(local/assets/*.png|jpg|jpeg|ico)"
+"Edit(pb_data/**)"
+"Write(pb_data/**)"
+```
+
+Still pending (Tier 2, noise reducers):
+
+```json
+"Read(frontend/node_modules/**)"
+"Read(frontend/dist/**)"
+"Read(pocketbase/pb_public/**)"
+"Read(**/__pycache__/**)"
+"Read(**/.pytest_cache/**)"
+"Read(**/.coverage)"
+```
+
+Reason for staging: Tier 1 prevents context destruction; Tier 2 only reduces grep noise. Worth doing but lower leverage.
+
+**Reminder**: deny does NOT block `Bash`. `sqlite3 pb_data/data.db ".schema"` still works (intentionally — preserves DB inspection workflow). If you want to fully restrict, tighten `Bash(cat:*)` and friends — but that has its own cost.
+
+---
+
+## 3. `.claudeignore`
+
+Complements `.gitignore` (which only affects git, not Claude) and `permissions.deny` (hard block). Use for files Claude could read but shouldn't surface in discovery (Grep, Glob).
+
+Candidates:
+- `uv.lock`, `frontend/package-lock.json`, `pocketbase/package-lock.json`, `pocketbase/go.sum` — lockfiles, occasionally useful, noisy in grep
+- `docs/api/response-examples.md` — large API output dump, useful when debugging contracts, noisy otherwise
+
+Not started.
+
+---
+
+## 4. Stop hook — CLAUDE.md self-improvement
+
+Idea from the upstream blog: at end of session, hook prompts Claude to reflect and propose CLAUDE.md updates while context is fresh. User reviews proposals next session.
+
+For kindred specifically, would help capture solver/sync/PB invariants that get learned in flight but lost. The auto-memory system catches some of this but is user-initiated.
+
+Not started. Implementation sketch:
+
+- `.claude/hooks/stop-claude-md-suggestions.sh` writes to `docs/plans/claude-md-suggestions.md` (gitignored)
+- Hook registered in `.claude/settings.json` under `Stop`
+
+---
+
+## 5. SessionStart hook — dynamic context
+
+On session start, inject current state:
+- `git worktree list` — which worktree am I in, which exist
+- `gh pr list --state open --limit 5` — what's in flight
+- `ls docs/plans/*.md` — what's drafted/being tracked
+- Last 3 commits — what just happened
+
+Currently a fresh session has to ask. The cost of a 5-line shell script is small; the gain on first-turn quality is real.
+
+Not started.
+
+---
+
+## 6. Custom project subagents
+
+`.claude/agents/` is empty. Today we lean on plugin-provided `Explore` and `general-purpose` — both generic, neither knows kindred.
+
+Candidates by leverage:
+
+| Name | Tools | Model | Job |
+|------|-------|-------|-----|
+| `solver-investigator` | read-only | sonnet | Knows `bunking/solver/` cold — constraints/, base.py protocols, SolverContext, satisfaction split. Maps the solver in one pass instead of grepping. |
+| `pb-migration-auditor` | read-only | haiku | Knows numbering rule, v0.23 syntax change, OnServe history-sync, the `_updated_users.js` outlier. Pre-PR sanity check. |
+| `kindred-frontend-pattern-checker` | read-only | sonnet | Verifies new components wrap with ErrorBoundary, use QueryGuard, use centralized queryKeys, use `fetchWithAuth` not raw `fetch`. |
+| `solver-config-walker` | read-only | sonnet | Agent form of the existing `solver-config-it` skill — walks CONFIG_SCHEMA, seed migration, GUI, code reads. |
+
+Win isn't "they can do something the main agent can't" — it's:
+- Pre-loaded with kindred lore (no need to repeat conventions)
+- Don't pollute main context
+- Can run in parallel
+
+Don't create these until a specific repeated pain calls for one. Premature subagents go stale.
+
+---
+
+## 7–8. Stale `/home/adam/bunking/` paths + duplicate allow rules
+
+Global `~/.claude/settings.json` has ~8 entries referencing `/home/adam/bunking/` (the pre-rename path). Project `~/kindred/.claude/settings.local.json` has ~4. They're dead rules — match nothing — but clutter the allow list and obscure what's actually needed.
+
+Some entries are hyper-specific (named test files from one investigation). Those should be replaced with broader globs (e.g. `Bash(uv run pytest:*)`).
+
+Also: the project settings.local.json (~31 KB) heavily duplicates global. Cleaner split:
+- **Global**: `gh api:*`, `git push:*`, `gh pr view:*`, common shell utilities
+- **Project**: `./scripts/worktree/*`, `./scripts/start_dev.sh`, `./scripts/vault*`, project-specific PB curl invocations
+
+Not started.
+
+---
+
+## 9. Plugin bundling — deferred
+
+Upstream guidance: bundle skills + hooks + MCP configs as a plugin so teammates get the full setup via one install. Low priority while solo. Revisit if onboarding anyone.
+
+---
+
+## 10. `.claude/worktrees/agent-*` cleanup
+
+Several leftovers from `EnterWorktree` calls in past sessions (the tool we now avoid in favor of `./scripts/worktree/new.sh`). Visible in `git worktree list` as nested entries under `~/kindred/.claude/worktrees/`.
+
+Audit + `git worktree remove` the stale ones. Not urgent — they don't break anything — but they pollute the worktree list.
+
+---
+
+## 11. `rust-analyzer-lsp` plugin
+
+Enabled in `~/.claude/settings.json` (`"rust-analyzer-lsp@claude-plugins-official": true`) but no Rust in the kindred tree. Disable to avoid spurious LSP probes.
+
+Verified working: `typescript-lsp`, `pyright-lsp`, `gopls-lsp` — binaries installed (`pyright@1.1.408`, `typescript-language-server@5.1.3`, `~/go/bin/gopls`), LSP tool returns symbols correctly.
+
+---
+
+## 12. Committed binaries — resolved
+
+Both were gitignored (`pocketbase/*` blanket rule) and never tracked.
+
+- `pocketbase/pocketbase` (~53 MB) — the actual compiled PocketBase server runtime. Built by `scripts/start_dev.sh`, `scripts/worktree/new.sh`, `docker/Dockerfile.pocketbase`. **Leave alone.** Still in `permissions.deny` to prevent accidental Read.
+- `pocketbase/diagnose_google` (~21 MB) — orphan OIDC-diagnostic compile output. Zero references in code, scripts, docs, or git history. **Deleted.**
+
+---
+
+## Re-audit triggers
+
+Don't let this go fully cold. Audit when:
+
+- **Major model release** — old workarounds may now constrain (a rule that forced single-file refactors blocks coordinated cross-file edits on a more capable model)
+- **New native feature** — retire hooks/skills the platform now does itself (the blog cites a Perforce `p4 edit` hook that became obsolete when native Perforce support landed)
+- **Every 3–6 months** — drift accumulates silently
+
+---
+
+## Reference
+
+Upstream guidance: <https://claude.com/blog/how-claude-code-works-in-large-codebases-best-practices-and-where-to-start>

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,74 @@
+# frontend/
+
+React + TypeScript + Vite. Dev server on `:3000` (HMR); prod served via Caddy at `:8080`. Tests: **Vitest, not Jest.**
+
+## Layout
+
+| Dir | Purpose |
+|-----|---------|
+| `src/components/` | Reusable React components |
+| `src/components/graph/` | Social network graph modules (styles, interactions, layout, UI) |
+| `src/pages/` | Route-level components |
+| `src/hooks/` | Custom React hooks (data fetching, state) |
+| `src/services/` | API clients, business logic |
+| `src/types/` | TypeScript type definitions |
+| `src/lib/` | Third-party integrations |
+| `src/contexts/` | React context providers |
+| `src/tours/definitions/` | Onboarding tour scripts |
+| `src/utils/queryKeys.ts` | Centralized React Query keys — use these, don't inline strings |
+
+## Component patterns
+
+- **Modular extraction** — large components (e.g. `SocialNetworkGraph.tsx`) decompose into utility modules
+- **Custom hooks** — data fetching extracted (`useSocialGraphData`, `useBunkNames`, `useSessionHierarchy`)
+- **Barrel exports** — directories use `index.ts` for clean imports
+
+## Error handling — non-negotiable
+
+- **Page-level `<ErrorBoundary>`** — every lazy-loaded route in `App.tsx` is wrapped with `<ErrorBoundary>` around `<Suspense>`. Isolates crashes to the affected page. New routes MUST follow this pattern.
+- **`<QueryGuard>`** (`components/QueryGuard.tsx`) — render-prop component for loading/error/empty/success states on React Query data. Use it in new data-fetching pages. Existing pages use inline patterns — don't refactor unless already touching them.
+- **All 4 states must be handled** — loading, error, empty, success. Never render a data-dependent component without checking query state first.
+
+## Auth — easy to get wrong
+
+- **`useAuth().isLoading` first.** Always check `isLoading` before making authenticated API calls.
+- **PB JWT lives in `localStorage`, not cookies.** Calling `fetch` with `credentials: 'include'` silently 401s on protected endpoints. Use `fetchWithAuth` from `services/` for protected FastAPI routes.
+- **Bypass-auth mode** grants admin via `usePermissions().isAdmin`, NOT `useAuth().user.is_admin`.
+
+## React Query keys
+
+Use the centralized keys from `src/utils/queryKeys.ts`. Inlining string keys causes cache collisions and silent bugs when invalidation misses the right query.
+
+## Tour maintenance
+
+When modifying page layout, features, or `data-tour` attributes on a toured page, review the corresponding tour in `src/tours/definitions/`:
+
+- [ ] `data-tour` attributes still reference correct elements
+- [ ] `isReady()` still checks the right element
+- [ ] Step/hint descriptions match current behavior
+- [ ] Bump `version` if steps changed (triggers re-play for returning users)
+
+## Build & test
+
+```bash
+cd frontend && npm run dev                            # dev server (HMR)
+cd frontend && npm run build                          # production bundle
+cd frontend && npm run lint
+cd frontend && npm run type-check
+cd frontend && npx vitest run                         # one-shot tests
+cd frontend && npx vitest run src/path/file.test.ts   # single test
+```
+
+Pre-push runs: prettier, eslint, tsc, vitest. Failing any blocks push.
+
+## Worktree-specific notes
+
+In a fresh worktree, hit the **Vite dev port** (e.g. `localhost:3010`), not the Caddy port — Caddy serves the stale built bundle from `pocketbase/pb_public/`.
+
+## Private config
+
+`frontend/vite.config.local.ts` is symlinked from `~/kindred-local/`. Don't commit it. The build falls back to defaults if missing.
+
+## Tech versions
+
+React 19, TypeScript 5.8+/ES2022, Vite, Tailwind CSS, @tanstack/react-query, @dnd-kit, Cytoscape.js. Node 22+.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -32,7 +32,7 @@ React + TypeScript + Vite. Dev server on `:3000` (HMR); prod served via Caddy at
 ## Auth — easy to get wrong
 
 - **`useAuth().isLoading` first.** Always check `isLoading` before making authenticated API calls.
-- **PB JWT lives in `localStorage`, not cookies.** Calling `fetch` with `credentials: 'include'` silently 401s on protected endpoints. Use `fetchWithAuth` from `services/` for protected FastAPI routes.
+- **PB JWT lives in `localStorage`, not cookies.** Calling `fetch` with `credentials: 'include'` silently 401s on protected endpoints. Obtain `fetchWithAuth` from the `useApiWithAuth()` hook (`hooks/useApiWithAuth.ts`) and pass it into service functions — services take it as a parameter, they don't export it.
 - **Bypass-auth mode** grants admin via `usePermissions().isAdmin`, NOT `useAuth().user.is_admin`.
 
 ## React Query keys
@@ -59,11 +59,11 @@ cd frontend && npx vitest run                         # one-shot tests
 cd frontend && npx vitest run src/path/file.test.ts   # single test
 ```
 
-Pre-push runs: prettier, eslint, tsc, vitest. Failing any blocks push.
+Pre-push runs `tsc --noEmit` for both `tsconfig.json` and `tsconfig.node.json`. Prettier runs at commit time; eslint and vitest run in CI only. Failing pre-push blocks push.
 
 ## Worktree-specific notes
 
-In a fresh worktree, hit the **Vite dev port** (e.g. `localhost:3010`), not the Caddy port — Caddy serves the stale built bundle from `pocketbase/pb_public/`.
+In a fresh worktree, hit the **Vite dev port printed by `new.sh`** (the port offset is hashed from the feature name — `localhost:3010`, `3080`, etc. depending on the worktree), not the Caddy port. Caddy serves the stale built bundle from `pocketbase/pb_public/`.
 
 ## Private config
 

--- a/pocketbase/CLAUDE.md
+++ b/pocketbase/CLAUDE.md
@@ -1,0 +1,101 @@
+# pocketbase/
+
+Go service: SQLite DB, auth, CampMinder sync. Entry: `main.go`. Module: `github.com/camp/kindred/pocketbase`.
+
+## Subpackages
+
+| Dir | Purpose |
+|-----|---------|
+| `sync/` + `campminder/` | CampMinder API → PocketBase sync jobs |
+| `rbac/` | Role / permission rules (distinct from FastAPI's `bunking/rbac/`) |
+| `bunk_requests/`, `feedback/`, `google/`, `ratelimit/`, `logging/` | Feature packages |
+| `pb_hooks/` | JS hooks executed by PocketBase v0.23 runtime |
+| `pb_migrations/` | Schema source of truth — JS migrations |
+
+## Migrations — read before writing any
+
+**MANDATORY:** `docs/reference/pocketbase-migrations.md`. PocketBase v0.23 changed field property syntax; using the old `options: {}` wrapper causes **silent data truncation**.
+
+### Numbering rule
+
+New migrations MUST use a number greater than the highest filename on `origin/main`:
+
+```bash
+HIGHEST=$(git ls-tree -r origin/main pocketbase/pb_migrations/ \
+  | awk '{print $4}' | grep -oE '15000[0-9]{5}' | sort -u | tail -1)
+NEXT=$((HIGHEST + 1))
+```
+
+Do not backfill gaps left by past consolidation runs — those numbers are "burned" to preserve a monotonically increasing record. Once merged to `main`, the file is frozen; if a competing PR landed and took your number, bump above the new HEAD.
+
+### History-sync (why consolidation is safe)
+
+`main.go` registers an `OnServe` hook that runs `migrate history-sync` on every server boot. It reconciles prod's `_migrations` table against the on-disk file list automatically — no per-round helper migrations needed when consolidating. Skill: `consolidate-migrations`.
+
+### `pb_users_auth_` table
+
+**Skip in consolidation rounds.** The gitignored `*_updated_users.js` outlier (e.g. `1769791931_updated_users.js`) makes clean consolidation impossible. Marked `[⏸]` in the tracking doc.
+
+## Filter syntax — spaces around operators
+
+PocketBase parses filters with strict whitespace requirements.
+
+```
+✓ field = value          ✗ field=value
+✓ field != ''            ✗ field!=''
+✓ created >= '2026-01-01'
+```
+
+No spaces → silently returns wrong results. Applies to Go `dao.FindRecordsByFilter`, JS hooks, and HTTP `filter=` params.
+
+## Spelling: "cancelled" (British)
+
+Fields use British spelling: `cancelled_count`, `cancelled_at`. Allowed via `extra-words` in `.golangci.yml`. Don't "fix" to `canceled` — it'll break PocketBase column references.
+
+## Year invariant
+
+All CampMinder data tables include a required `year` field. **Cross-table relationships use CampMinder IDs, never PocketBase IDs.** Unique indexes include `year` (e.g., `person_id, year, session`).
+
+Sync filters by `CAMPMINDER_SEASON_ID` from `.env`. Frontend year dropdown is display-only.
+
+## Build & test
+
+```bash
+cd pocketbase && go build ./...
+cd pocketbase && go test ./...
+cd pocketbase && go test ./sync/...     # one package
+```
+
+Pre-push runs: `go build`, `golangci-lint` (config: `.golangci.yml`), `pb-js-lint` (ESLint on `pb_hooks/`/`pb_migrations/` JS).
+
+**Fresh-worktree gotcha:** if `pb-js-lint` exits 2 with an ESLint config error, `pocketbase/node_modules` is empty. Fix: `cd pocketbase && npm install`.
+
+## Logging
+
+```go
+import "github.com/camp/kindred/pocketbase/logging"
+logging.Init("pocketbase")
+```
+
+Format: `2026-01-06T14:05:52Z [pocketbase] LEVEL message key=value...`. `LOG_LEVEL=INFO` (default) suppresses health-check noise; `DEBUG` for verbose.
+
+## Sync invariants
+
+1. **Sync order matters:** sessions → attendees → persons → bunks → plans → assignments → requests
+2. **Year-aware:** uses `season_id` from PocketBase `config` table
+3. **Sessions 1–4 run sequentially** with independent history
+4. **WAL checkpoint required** after database modifications
+5. **Family-camp data syncs alongside summer data** — summer-camp views must filter `session_type` against the configured valid-summer-session-types list
+
+See `docs/architecture/sync-layer.md` before adding or modifying sync jobs.
+
+## DB file access
+
+Don't `Read` `pb_data/data.db`, `*.db-wal`, or `*.db-shm` as files — they're binary and reading mid-write shows inconsistent state. To inspect:
+
+```bash
+sqlite3 pb_data/data.db ".schema collection_name"
+sqlite3 pb_data/data.db "SELECT count(*) FROM persons WHERE year = 2026"
+```
+
+For data CRUD, prefer the HTTP API (auth pattern in `CLAUDE.local.md`).

--- a/pocketbase/CLAUDE.md
+++ b/pocketbase/CLAUDE.md
@@ -82,7 +82,7 @@ Format: `2026-01-06T14:05:52Z [pocketbase] LEVEL message key=value...`. `LOG_LEV
 ## Sync invariants
 
 1. **Sync order matters:** sessions → attendees → persons → bunks → plans → assignments → requests
-2. **Year-aware:** uses `season_id` from PocketBase `config` table
+2. **Year-aware:** sync filters by `CAMPMINDER_SEASON_ID` env var (set in `.env`; see "Year invariant" above)
 3. **Sessions 1–4 run sequentially** with independent history
 4. **WAL checkpoint required** after database modifications
 5. **Family-camp data syncs alongside summer data** — summer-camp views must filter `session_type` against the configured valid-summer-session-types list

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,50 @@
+# tests/
+
+Pytest for Python (`bunking/` + `api/`). See `frontend/CLAUDE.md` for Vitest. Layout: `unit/`, `integration/`, `e2e/`, `performance/`.
+
+## Marker discipline — strict mode
+
+`pyproject.toml` runs pytest with strict marker mode. **An unregistered marker is a failure.** When adding a marker, register it in `pyproject.toml` first.
+
+### Skipped-in-CI markers
+
+| Marker | When it runs |
+|--------|--------------|
+| `ai_required` | Skipped in CI (needs live AI tokens). Run locally with `AI_API_KEY` set. |
+| `pocketbase_required` | Skipped in CI (needs running PocketBase). Run locally with `./scripts/start_dev.sh` up. |
+
+**CI passing does not mean these tests passed.** Verify locally before merging features that touch AI or DB paths.
+
+## Test data — fictional only
+
+NEVER use real camper/parent/staff/school names in tests, fixtures, comments, or assertions. Per `CLAUDE.md`:
+
+- **Campers**: Emma Johnson, Liam Garcia, Olivia Chen, Riley Sam, Samuel Johnson
+- **Schools**: Riverside Elementary, Oak Valley Middle, Hillcrest High
+- **Phone/email**: 555-0100, test@example.com
+- **IDs**: 1000001, 1000002 (generic, not real CampMinder IDs)
+
+If you find real names in existing tests, replace them in the same PR.
+
+## TDD discipline
+
+Write failing tests **first**, verify they fail (red phase), then implement. Tests and implementation can land in the same commit (squash merge), but the workflow must be tests-first. **Modifying tests to match implementation behavior is forbidden** — tests are the spec.
+
+## Run commands
+
+```bash
+uv run pytest tests/                                # all (CI markers respected)
+uv run pytest tests/path/test_file.py::test_name    # single test
+uv run pytest tests/ -k "keyword"                   # by keyword
+SKIP_POCKETBASE_TESTS=true uv run pytest tests/     # explicit skip even locally
+```
+
+Pre-push runs the full unit suite. Integration/e2e require a running dev server.
+
+## Worktree gotcha
+
+Worktrees don't have a running PocketBase by default. Integration tests that hit a live server (e.g. `test_metrics_retention.py`) will fail in a fresh worktree until `./scripts/start_dev.sh` is up. **Expected behavior, not a bug.** Don't "fix" by mocking the DB — see the no-mock-DB rule in your reviewer's feedback.
+
+## Coverage
+
+`.coverage` is a generated binary artifact — never `Read` it as a file. Use `uv run coverage report` instead.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -39,7 +39,7 @@ uv run pytest tests/ -k "keyword"                   # by keyword
 SKIP_POCKETBASE_TESTS=true uv run pytest tests/     # explicit skip even locally
 ```
 
-Pre-push runs the full unit suite. Integration/e2e require a running dev server.
+Pre-push runs type checks and fast linters only (mypy, tsc, ruff, golangci-lint, shellcheck, pb-js-lint) — pytest and vitest are CI-only. Run them locally when you make test-affecting changes. Integration/e2e require a running dev server regardless of where they run.
 
 ## Worktree gotcha
 


### PR DESCRIPTION
## Summary

Audit pass on the Claude Code harness against [upstream large-codebase guidance](https://claude.com/blog/how-claude-code-works-in-large-codebases-best-practices-and-where-to-start). Splits the monolithic root CLAUDE.md into per-surface subdir files that load opportunistically, hardens the worktree-creation rule with a deterministic hook, and adds the conservative slice of `permissions.deny` rules.

## Changes

**Subdir CLAUDE.md layering** — root trimmed 373 → 311 lines; surface specifics live where they're touched:

| File | Covers |
|---|---|
| `bunking/CLAUDE.md` | Modules, "business logic here not api", Python 3.14/uv/mypy strict/line length, logging, test commands |
| `bunking/solver/CLAUDE.md` | Read-first list, architecture, ConstraintBuilder, Tier/Stage/RequestBucket, satisfaction-vs-constraint boundary, don't-conflate gotchas |
| `api/CLAUDE.md` | Routers thin, global exception handler (no `HTTPException(500)`), inverse Caddy routing, auth |
| `frontend/CLAUDE.md` | ErrorBoundary + QueryGuard, `fetchWithAuth` vs raw fetch, centralized queryKeys, tour maintenance, Vitest |
| `tests/CLAUDE.md` | Strict marker mode, CI-skipped markers, fictional names, TDD discipline, worktree gotcha |
| `pocketbase/CLAUDE.md` | (Added earlier in branch) migrations, filter syntax, year invariant, history-sync, DB file guidance |

**Worktree guard hook** — `.claude/hooks/worktree-guard.sh` is a `PreToolUse` hook on `Bash` that blocks direct `git worktree add` invocations, forcing the use of `./scripts/worktree/new.sh` (which does port allocation, branch naming, and DB seeding). Wired via tracked `.claude/settings.json` with a relative path, so each worktree resolves its own copy.

**Tier 1 `permissions.deny`** in tracked `.claude/settings.json`:
- `Read(pb_data/*.db)`, `Read(pb_data/*.db-*)`, `Read(pb_data/storage/**)` — SQLite + WAL + uploaded files
- `Read(pocketbase/pocketbase)` — runtime binary
- `Read(local/assets/*.{png,jpg,jpeg,ico})` — branding image binaries
- `Edit(pb_data/**)`, `Write(pb_data/**)` — belt-and-suspenders against accidental DB writes

Bash is intentionally not restricted — `sqlite3 pb_data/data.db ".schema"` still works.

**Forward-looking doc** — `docs/reference/claude-harness-improvements.md`: 12-item status table for remaining harness work (Tier 2 denies, `.claudeignore`, stop/SessionStart hooks, custom subagents, allow-list cleanup, `rust-analyzer-lsp` disable, etc.) with re-audit triggers.

**`.gitignore`** — un-ignores `pocketbase/CLAUDE.md`, `.claude/hooks/**`, `.claude/settings.json` so the new tracked paths can be committed.

## Test plan

- [x] `shellcheck` on `worktree-guard.sh` passes
- [x] Hook test suite (6 cases: bare blocked, chained blocked, script allowed, list allowed, remove allowed, ls allowed) all pass
- [x] Pre-push verification script reports no Python/Go/TS areas to check (doc + config only)
- [x] Lefthook pre-push hooks pass
- [ ] Open a new worktree post-merge to confirm tracked `.claude/settings.json` is picked up and the hook fires across worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a pre-tool safety hook to block direct git worktree additions and enforce sanctioned worktree creation.
  * Updated ignore rules to expose CLAUDE settings and hooks for tooling.

* **Documentation**
  * Added and expanded CLAUDE.md guides across repo areas (root, api, bunking, frontend, pocketbase, tests) and a harness improvements page.

---
Note: No end-user visible runtime changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->