### PR TITLE
feat(frontend): split red 'entirely-impossible MP campers' chip out of pre-check (#1440)

### DIFF
--- a/frontend/src/pages/summer/SolverDebugPage/SweepPanel.test.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/SweepPanel.test.tsx
@@ -465,6 +465,135 @@ describe('SweepPanel — pre-check chip', () => {
   })
 })
 
+describe('SweepPanel — entirely-impossible MP campers chip (#1440)', () => {
+  it('renders a separate red chip when preCheckEntirelyImpossibleCount > 0', () => {
+    render(
+      <SweepPanel
+        sessions={fakeSessions}
+        scenarios={fakeScenarios}
+        onRunSweep={vi.fn()}
+        onCancelSweep={vi.fn()}
+        inFlightSweep={null}
+        preCheckImpossibilityCount={33}
+        preCheckEntirelyImpossibleCount={3}
+      />
+    )
+    // Both chips render — amber pre-check chip stays, red "entirely-impossible MP" chip joins it.
+    expect(screen.getByRole('button', { name: /pre-check.*33.*issue/i })).toBeInTheDocument()
+    const redChip = screen.getByRole('button', { name: /entirely-impossible MP/i })
+    expect(redChip).toBeInTheDocument()
+    expect(redChip).toHaveTextContent('3')
+  })
+
+  it('exposes the entirely-impossible camper count in the red chip accessible name', () => {
+    render(
+      <SweepPanel
+        sessions={fakeSessions}
+        scenarios={fakeScenarios}
+        onRunSweep={vi.fn()}
+        onCancelSweep={vi.fn()}
+        inFlightSweep={null}
+        preCheckImpossibilityCount={10}
+        preCheckEntirelyImpossibleCount={2}
+      />
+    )
+    // Screen-reader text must reflect the count, not a static "entirely-impossible MP".
+    expect(
+      screen.getByRole('button', { name: /2.*entirely-impossible MP.*camper/i })
+    ).toBeInTheDocument()
+  })
+
+  it('omits the red chip when preCheckEntirelyImpossibleCount is 0', () => {
+    render(
+      <SweepPanel
+        sessions={fakeSessions}
+        scenarios={fakeScenarios}
+        onRunSweep={vi.fn()}
+        onCancelSweep={vi.fn()}
+        inFlightSweep={null}
+        preCheckImpossibilityCount={5}
+        preCheckEntirelyImpossibleCount={0}
+      />
+    )
+    // Amber chip still here, no red chip when nobody is entirely impossible.
+    expect(screen.getByRole('button', { name: /pre-check/i })).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /entirely-impossible MP/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('omits the red chip when preCheckEntirelyImpossibleCount is not provided', () => {
+    render(
+      <SweepPanel
+        sessions={fakeSessions}
+        scenarios={fakeScenarios}
+        onRunSweep={vi.fn()}
+        onCancelSweep={vi.fn()}
+        inFlightSweep={null}
+        preCheckImpossibilityCount={5}
+      />
+    )
+    expect(
+      screen.queryByRole('button', { name: /entirely-impossible MP/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('clicking the red chip invokes onOpenPreCheck (same modal as amber)', async () => {
+    const onOpenPreCheck = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <SweepPanel
+        sessions={fakeSessions}
+        scenarios={fakeScenarios}
+        onRunSweep={vi.fn()}
+        onCancelSweep={vi.fn()}
+        inFlightSweep={null}
+        preCheckImpossibilityCount={10}
+        preCheckEntirelyImpossibleCount={4}
+        onOpenPreCheck={onOpenPreCheck}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /entirely-impossible MP/i }))
+    expect(onOpenPreCheck).toHaveBeenCalledTimes(1)
+  })
+
+  it('clicking the red chip does not toggle panel collapse', async () => {
+    const user = userEvent.setup()
+    render(
+      <SweepPanel
+        sessions={fakeSessions}
+        scenarios={fakeScenarios}
+        onRunSweep={vi.fn()}
+        onCancelSweep={vi.fn()}
+        inFlightSweep={null}
+        preCheckImpossibilityCount={10}
+        preCheckEntirelyImpossibleCount={2}
+        onOpenPreCheck={vi.fn()}
+      />
+    )
+    expect(screen.getByRole('button', { name: /run sweep/i })).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /entirely-impossible MP/i }))
+    // Panel still expanded.
+    expect(screen.getByRole('button', { name: /run sweep/i })).toBeInTheDocument()
+  })
+
+  it('does not render the red chip while pre-check is loading (no count yet)', () => {
+    render(
+      <SweepPanel
+        sessions={fakeSessions}
+        scenarios={fakeScenarios}
+        onRunSweep={vi.fn()}
+        onCancelSweep={vi.fn()}
+        inFlightSweep={null}
+        preCheckIsLoading
+      />
+    )
+    expect(
+      screen.queryByRole('button', { name: /entirely-impossible MP/i })
+    ).not.toBeInTheDocument()
+  })
+})
+
 describe('SweepPanel collapse (#mockup-parity)', () => {
   const STORAGE_KEY = 'solver-debug.sweep-panel-expanded'
 

--- a/frontend/src/pages/summer/SolverDebugPage/SweepPanel.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/SweepPanel.tsx
@@ -44,6 +44,7 @@ export interface SweepPanelProps {
   onCancelSweep: (sweepId: string) => void
   inFlightSweep: InFlightSweep | null
   preCheckImpossibilityCount?: number
+  preCheckEntirelyImpossibleCount?: number
   preCheckIsLoading?: boolean
   preCheckIsError?: boolean
   onOpenPreCheck?: () => void
@@ -68,6 +69,7 @@ export function SweepPanel({
   onCancelSweep,
   inFlightSweep,
   preCheckImpossibilityCount,
+  preCheckEntirelyImpossibleCount,
   preCheckIsLoading,
   preCheckIsError,
   onOpenPreCheck,
@@ -155,43 +157,60 @@ export function SweepPanel({
           <Zap className="h-4 w-4 text-amber-500" />
           Run benchmark sweep
         </h3>
-        {preCheckIsLoading && typeof preCheckImpossibilityCount !== 'number' ? (
-          <button
-            type="button"
-            disabled
-            className="rounded-full border border-gray-200 bg-gray-50 px-2.5 py-0.5 text-xs font-medium text-gray-500"
-          >
-            … Pre-check · checking
-          </button>
-        ) : preCheckIsError && typeof preCheckImpossibilityCount !== 'number' ? (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation()
-              onOpenPreCheck?.()
-            }}
-            className="rounded-full border border-red-300 bg-red-50 px-2.5 py-0.5 text-xs font-medium text-red-700 hover:bg-red-100"
-          >
-            ⚠ Pre-check · failed
-          </button>
-        ) : typeof preCheckImpossibilityCount === 'number' ? (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation()
-              onOpenPreCheck?.()
-            }}
-            className={
-              preCheckImpossibilityCount > 0
-                ? 'rounded-full border border-amber-400 bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-900 hover:bg-amber-200'
-                : 'rounded-full border border-green-300 bg-green-50 px-2.5 py-0.5 text-xs font-medium text-green-800 hover:bg-green-100'
-            }
-          >
-            {preCheckImpossibilityCount > 0
-              ? `⚠ Pre-check · ${preCheckImpossibilityCount} issues`
-              : '✓ Pre-check · no issues'}
-          </button>
-        ) : null}
+        <div className="flex items-center gap-2">
+          {preCheckIsLoading && typeof preCheckImpossibilityCount !== 'number' ? (
+            <button
+              type="button"
+              disabled
+              className="rounded-full border border-gray-200 bg-gray-50 px-2.5 py-0.5 text-xs font-medium text-gray-500"
+            >
+              … Pre-check · checking
+            </button>
+          ) : preCheckIsError && typeof preCheckImpossibilityCount !== 'number' ? (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                onOpenPreCheck?.()
+              }}
+              className="rounded-full border border-red-300 bg-red-50 px-2.5 py-0.5 text-xs font-medium text-red-700 hover:bg-red-100"
+            >
+              ⚠ Pre-check · failed
+            </button>
+          ) : typeof preCheckImpossibilityCount === 'number' ? (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                onOpenPreCheck?.()
+              }}
+              className={
+                preCheckImpossibilityCount > 0
+                  ? 'rounded-full border border-amber-400 bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-900 hover:bg-amber-200'
+                  : 'rounded-full border border-green-300 bg-green-50 px-2.5 py-0.5 text-xs font-medium text-green-800 hover:bg-green-100'
+              }
+            >
+              {preCheckImpossibilityCount > 0
+                ? `⚠ Pre-check · ${preCheckImpossibilityCount} issues`
+                : '✓ Pre-check · no issues'}
+            </button>
+          ) : null}
+          {typeof preCheckEntirelyImpossibleCount === 'number' &&
+          preCheckEntirelyImpossibleCount > 0 ? (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                onOpenPreCheck?.()
+              }}
+              className="rounded-full border border-red-400 bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-900 hover:bg-red-200"
+            >
+              {`🛑 ${preCheckEntirelyImpossibleCount} entirely-impossible MP ${
+                preCheckEntirelyImpossibleCount === 1 ? 'camper' : 'campers'
+              }`}
+            </button>
+          ) : null}
+        </div>
         <button
           type="button"
           onClick={() => setExpanded((e) => !e)}

--- a/frontend/src/pages/summer/SolverDebugPage/index.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/index.tsx
@@ -273,6 +273,8 @@ export default function SolverDebugPage() {
         {...(typeof preCheckQuery.data?.impossibility_report.total_impossible === 'number'
           ? {
               preCheckImpossibilityCount: preCheckQuery.data.impossibility_report.total_impossible,
+              preCheckEntirelyImpossibleCount:
+                preCheckQuery.data.impossibility_report.mp_campers_entirely_impossible?.length ?? 0,
               onOpenPreCheck: () => setPreCheckModalOpen(true),
             }
           : {})}


### PR DESCRIPTION
## Summary

- Splits the Solver Debug `SweepPanel` pre-check chip into two: the existing amber count stays, and a new **red** chip joins it when `mp_campers_entirely_impossible.length > 0`.
- Both chips open the existing `SolverDebugImpossibilityModal` — no modal changes.
- Red chip copy mirrors the modal's section header (`"N entirely-impossible MP camper(s)"`) for consistency.
- Amber count is left untouched (raw `total_impossible`) per the issue's "start with whichever is cheaper" note — subtracting the entirely-impossible set from the amber count would require reason-row → camper-rollup translation.

Closes #1440.

## Test plan

- [x] `npx vitest run src/pages/summer/SolverDebugPage/SweepPanel.test.tsx` — 34 passing (7 new for the red chip: renders when count > 0, exposes accessible name with count, omits when count is 0/undefined, click invokes `onOpenPreCheck`, click does not toggle panel collapse, hidden during loading)
- [x] Full pre-push verify (eslint, tsc, vitest, prettier) — all green
- [ ] Visual sanity check on Solver Debug page in a session that has entirely-impossible MP campers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual status indicator in the solver debug panel displaying the count of entirely-impossible cases. When such cases are detected, the indicator appears with visual prominence and can be clicked to review detailed pre-check information without collapsing the panel.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->