### PR TITLE
refactor(solver): bidirectional age_preference sat var (#1433)

### DIFF
--- a/bunking/solver/constraints/age_preference.py
+++ b/bunking/solver/constraints/age_preference.py
@@ -34,42 +34,38 @@ logger = get_logger(__name__)
 def add_age_preference_satisfaction_vars(
     ctx: SolverContext,
     requests_by_person: dict[int, list[DirectBunkRequest]],
-    bunk_has_grade: dict[tuple[int, int], cp_model.IntVar] | None = None,
-) -> tuple[
-    dict[int, list[cp_model.IntVar]],
-    dict[tuple[int, int], cp_model.IntVar],
-    dict[str, list[cp_model.IntVar]],
-]:
-    """Create satisfaction variables for age_preference requests.
+) -> dict[str, list[cp_model.IntVar]]:
+    """Create bidirectional satisfaction variables for MP age_preference requests.
 
-    Uses efficient grade presence tracking:
-    1. Build shared bunk_has_grade[(bunk_idx, grade)] variables (if not provided)
-    2. For each request, check if bunk contains violating grades
-    3. Return satisfaction variables
+    Builds, for each feasible request, a sat_var bidirectionally bound to the
+    post-solve satisfaction condition ("requester's bunk contains no grades the
+    preference forbids") via the forcing_indicators returned to the caller.
+    Each sat_var is registered in ``ctx.request_satisfied_vars`` keyed by
+    request id — the same shared map ``get_or_create_request_sat_var`` uses for
+    bunk_with / not_bunk_with — so #1398's golden alignment test picks them up
+    automatically.
+
+    Only MP age_preference requests are modeled today; non-MP age_preference
+    requests have no solver representation. This is intentional — staff treat
+    non-MP age preferences as best-effort ("maybe you'll get it"), and the
+    planned material/immaterial/staff bucket weights (see
+    docs/reference/solver-config-decisions.md) will be the right home for any
+    future non-MP modeling.
 
     Args:
         ctx: Solver context with model, assignments, and mappings
-        requests_by_person: Dict mapping person_cm_id to their age_preference requests
-        bunk_has_grade: Optional pre-computed grade presence variables (for reuse)
+        requests_by_person: Dict mapping person_cm_id to their MP age_preference
+            requests (caller already filtered to MATERIAL_PARENT bucket)
 
     Returns:
-        Tuple of:
-        - Dict mapping person_cm_id to list of satisfaction BoolVars (objective-side,
-          one-way OnlyEnforceIf encoding — fine for soft maximization).
-        - The bunk_has_grade variables (for reuse by other constraints).
-        - Dict mapping request.id to its per-(request, bunk) forcing indicators.
-          Each forcing indicator is a BoolVar (or an assignment IntVar in the
-          no-bad-grades-possible branch) that, when set to 1, forces the
-          requester into a clean bunk and thus satisfies the request. Consumed
-          by parent_paramount's hard constraint via summation; one-way
-          OnlyEnforceIf anchoring is sufficient because the constraint forces
-          the indicator upward.
+        Dict mapping request.id to its per-(request, bunk) forcing indicators.
+        Each forcing indicator is a BoolVar (or an assignment IntVar in the
+        no-bad-grades-possible branch) that, when set to 1, forces the
+        requester into a clean bunk and thus satisfies the request. Consumed
+        by parent_paramount's hard must-satisfy-one constraint via summation.
     """
-    # Build or reuse shared grade presence variables
-    if bunk_has_grade is None:
-        bunk_has_grade = _build_bunk_has_grade_vars(ctx)
+    bunk_has_grade = _build_bunk_has_grade_vars(ctx)
 
-    satisfaction_vars: dict[int, list[cp_model.IntVar]] = {}
     forcing_indicators_by_req_id: dict[str, list[cp_model.IntVar]] = {}
 
     for person_cm_id, requests in requests_by_person.items():
@@ -79,8 +75,6 @@ def add_age_preference_satisfaction_vars(
         person_idx = ctx.person_idx_map[person_cm_id]
         person = ctx.person_by_cm_id[person_cm_id]
         person_grade = person.grade
-
-        person_sat_vars: list[cp_model.IntVar] = []
 
         for request in requests:
             if request.request_type != RequestType.AGE_PREFERENCE.value:
@@ -94,13 +88,10 @@ def add_age_preference_satisfaction_vars(
                 ctx, person_idx, person_grade, preference, request, bunk_has_grade
             )
             if sat_var is not None:
-                person_sat_vars.append(sat_var)
+                ctx.request_satisfied_vars[request.id] = sat_var
                 forcing_indicators_by_req_id[request.id] = forcing_indicators
 
-        if person_sat_vars:
-            satisfaction_vars[person_cm_id] = person_sat_vars
-
-    return satisfaction_vars, bunk_has_grade, forcing_indicators_by_req_id
+    return forcing_indicators_by_req_id
 
 
 def _build_bunk_has_grade_vars(ctx: SolverContext) -> dict[tuple[int, int], cp_model.IntVar]:
@@ -152,22 +143,28 @@ def _create_age_preference_satisfaction_var(
     request: DirectBunkRequest,
     bunk_has_grade: dict[tuple[int, int], cp_model.IntVar],
 ) -> tuple[cp_model.IntVar | None, list[cp_model.IntVar]]:
-    """Create satisfaction variable for a single age preference request.
+    """Create bidirectional satisfaction variable for a single age preference request.
 
     An age preference is satisfied when the camper's bunk does NOT contain
     any violating grades (younger for "older" pref, older for "younger" pref).
 
+    Both ``sat_var`` and its intermediate predicates (``bunk_is_clean``,
+    ``person_in_clean_bunk``) are bidirectionally bound to their definitions
+    so the post-solve predicate (``bunking.utils.age_preference.is_age_preference_satisfied``)
+    agrees with ``sat_var.value`` per the #1398 alignment test. (The predicate
+    is more permissive in the mixed-grade case has_older AND has_younger; the
+    integration fixture deliberately avoids that case — see
+    ``tests/integration/solver/fixtures.py``.)
+
     Returns:
         Tuple (sat_var, forcing_indicators):
-        - sat_var: BoolVar that's true when request is satisfied (objective-side,
-          one-way OnlyEnforceIf encoding), or None if no valid check.
+        - sat_var: BoolVar true iff request is satisfied, or None if no valid check.
         - forcing_indicators: per-(request, bunk) BoolVars (or assignment IntVars
           in the no-bad-grades-possible branch) that, when forced to 1, force
           the requester into a clean bunk. For the trivially-satisfied branch,
           the list contains a single always-1 BoolVar. Used by parent_paramount's
           hard MP constraint: summing these and constraining >= 1 forces real
-          satisfaction (one-way OnlyEnforceIf anchoring is sufficient when the
-          indicator is being forced upward).
+          satisfaction.
     """
     # Get all grades present in the solver
     all_grades = set()
@@ -215,21 +212,30 @@ def _create_age_preference_satisfaction_var(
             ctx.model.Add(sat_var == 1).OnlyEnforceIf(person_in_bunk)
             forcing_indicators.append(person_in_bunk)
         else:
-            # bunk_is_clean = NONE of the bad grades are present
+            # bunk_is_clean ↔ NONE of the bad grades are present
             bunk_is_clean = ctx.model.NewBoolVar(f"age_req_{request.id}_clean_bunk_{bunk_idx}")
-
-            # Clean means all bad_grade_present vars are 0
-            # Using AddBoolAnd with negated variables
             ctx.model.AddBoolAnd([v.Not() for v in bad_grade_present_vars]).OnlyEnforceIf(bunk_is_clean)
+            # Converse for bidirectional alignment: if any bad grade is present,
+            # bunk is not clean. Without this, bunk_is_clean=0 is consistent
+            # with all bad_grade_present=0, which would let sat_var drift away
+            # from the post-solve predicate.
+            ctx.model.AddBoolOr(bad_grade_present_vars).OnlyEnforceIf(bunk_is_clean.Not())
 
-            # If person in bunk AND bunk is clean, satisfied
+            # person_in_clean_bunk ↔ person_in_bunk AND bunk_is_clean
             person_in_clean_bunk = ctx.model.NewBoolVar(f"age_req_{request.id}_in_clean_{bunk_idx}")
             ctx.model.AddBoolAnd([person_in_bunk, bunk_is_clean]).OnlyEnforceIf(person_in_clean_bunk)
+            # Converse: person_in_bunk AND bunk_is_clean ⇒ person_in_clean_bunk.
+            ctx.model.Add(person_in_clean_bunk == 1).OnlyEnforceIf([person_in_bunk, bunk_is_clean])
+
             ctx.model.Add(sat_var == 1).OnlyEnforceIf(person_in_clean_bunk)
-            # Setting person_in_clean_bunk to 1 forces person_in_bunk = 1 and
-            # bunk_is_clean = 1 (which in turn forces all bad_grade_present = 0).
-            # That's real satisfaction.
             forcing_indicators.append(person_in_clean_bunk)
+
+    # Bidirectional binding of sat_var to forcing_indicators. The forward
+    # direction (forcing_indicator → sat_var=1) is already encoded per-bunk
+    # above. Here we add the reverse: sat_var=1 → at least one forcing
+    # indicator is 1. Without this, when all forcing_indicators=0 the solver
+    # is free to set sat_var=1 and disagree with the post-solve predicate.
+    ctx.model.AddBoolOr(forcing_indicators).OnlyEnforceIf(sat_var)
 
     return sat_var, forcing_indicators
 

--- a/bunking/solver/constraints/parent_paramount.py
+++ b/bunking/solver/constraints/parent_paramount.py
@@ -90,15 +90,15 @@ def add_must_satisfy_one_request_constraints(ctx: SolverContext) -> None:
             elif r.request_type == RequestType.AGE_PREFERENCE.value:
                 mp_age_requests_by_person.setdefault(cm_id, []).append(r)
 
-    # Step 2: build sat vars for MP age_preference requests via the helper.
-    # The third return value is a per-request list of forcing indicators
-    # (person_in_clean_bunk BoolVars, or assignment vars in the no-bad-grades
-    # branch, or always-1 vars in the trivially-satisfied branch). We sum
-    # these directly in the hard constraint — they're one-way OnlyEnforceIf-
-    # anchored to real placement, which is sufficient when forced upward.
+    # Step 2: build bidirectional sat vars + forcing indicators for MP
+    # age_preference requests via the helper. The helper registers each sat
+    # var in ctx.request_satisfied_vars (shared with bunk_with / not_bunk_with)
+    # and returns per-request forcing indicators (person_in_clean_bunk BoolVars,
+    # or assignment vars in the no-bad-grades branch, or always-1 vars in the
+    # trivially-satisfied branch). We sum these directly in the hard constraint.
     age_forcing_indicators_by_req_id: dict[str, list[cp_model.IntVar]] = {}
     if mp_age_requests_by_person:
-        _, _, age_forcing_indicators_by_req_id = add_age_preference_satisfaction_vars(ctx, mp_age_requests_by_person)
+        age_forcing_indicators_by_req_id = add_age_preference_satisfaction_vars(ctx, mp_age_requests_by_person)
 
     # Step 3: per-camper, build bunk-request forcing vars inline and combine
     # with age-preference forcing indicators. Add the hard constraint.

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -495,7 +495,14 @@ class DirectBunkingSolver:
                         if request_satisfied is not None:
                             person_request_satisfaction[person_cm_id].append((request, request_satisfied))
 
-                # Note: age_preference requests are handled by must_satisfy_one constraint only
+                # age_preference is intentionally absent from the objective:
+                # MP age_preference is enforced by parent_paramount's hard
+                # must-satisfy-one constraint (see constraints/age_preference.py).
+                # Non-MP age_preference has no solver representation — staff
+                # treat those as best-effort ("maybe you'll get it"), and the
+                # planned material/immaterial/staff bucket weights (see
+                # docs/reference/solver-config-decisions.md) will be the right
+                # home for any future non-MP modeling. #1433.
 
         # Apply diminishing returns to the satisfaction variables.
         # When `objective.enable_first_boost` is true, sort so that the

--- a/tests/integration/solver/fixtures.py
+++ b/tests/integration/solver/fixtures.py
@@ -1,10 +1,11 @@
 """Integration-test scenario builders for the solver.
 
-`build_alignment_fixture` returns a DirectSolverInput engineered so the solver
-has exactly one feasible partition (up to bunk relabelling) — every assertion
-target resolves to a known satisfied/unsatisfied value regardless of which
-optimal solution CP-SAT lands on.
+Two alignment fixtures live here, both engineered so the solver has exactly
+one feasible partition (up to bunk relabelling). Every assertion target
+resolves to a known satisfied/unsatisfied value regardless of which optimal
+solution CP-SAT lands on.
 
+``build_alignment_fixture`` — bunk_with / not_bunk_with coverage (#1398).
 Determinism levers (all hard constraints):
   * 16 grade-6 female campers, 2 female bunks, capacity 8 each.
   * cabin min-occupancy (hardcoded MIN_BUNK_OCCUPANCY = 8) + force-all-used
@@ -16,6 +17,19 @@ Determinism levers (all hard constraints):
 The two camper groups therefore land in different bunks in every feasible
 solution, which fixes the satisfied/unsatisfied outcome of every request the
 alignment test asserts on.
+
+``build_age_preference_alignment_fixture`` — age_preference coverage (#1433).
+Mixed-grade roster so age_preference requests have non-trivial outcomes.
+Determinism levers:
+  * 16 female campers split CLIQUE {cm_id 1 grade 5, 2..8 grade 6} and
+    OTHER {cm_id 9 grade 7, 10..16 grade 6}. MP bunk_with requests 2..8 -> 1
+    and 10..16 -> 9 force the two clusters into separate bunks. Grade gaps
+    of 1 satisfy GradeCompatibilityImpossibility (max_gap = max_spread - 1 = 1
+    under mock_config).
+  * Two bunks, capacity 8, MIN_BUNK_OCCUPANCY=8 -> exactly 8 per bunk.
+
+Avoids the mixed-grade case (has_older AND has_younger) — see
+AGE_PREF_EXPECTED_SATISFACTION's note on the solver/predicate semantic gap.
 """
 
 from __future__ import annotations
@@ -137,11 +151,15 @@ def build_alignment_fixture() -> DirectSolverInput:
         ),
     ]
 
-    # Build-path exercisers — never enter request_satisfied_vars. Kept non-MP
-    # so they don't perturb the deterministic partition.
+    # Build-path exercisers — impossible requests dropped by _validate_requests
+    # before sat-var creation, so they never enter request_satisfied_vars. Kept
+    # non-MP so they don't perturb the deterministic partition.
     requests += [
-        # age_preference: get_or_create_request_sat_var returns None for it.
-        # All campers are grade 6, so AgePreferenceImpossibility also flags it.
+        # age_preference: all campers are grade 6, so AgePreferenceImpossibility
+        # flags it and it's dropped before reaching the sat-var builder. Used to
+        # exercise the impossibility-drop path, NOT to assert age_preference has
+        # no sat var in general — feasible age_preference does, per #1433. See
+        # build_age_preference_alignment_fixture for the feasible-path tests.
         make_request(
             "exer_age_pref",
             requester=12,
@@ -167,6 +185,130 @@ def build_alignment_fixture() -> DirectSolverInput:
             requestee=None,
             request_type="bunk_with",
             source_field=NON_MP_SOURCE,
+            session=SESSION,
+        ),
+    ]
+
+    return make_input(persons, bunks, requests)
+
+
+# Mixed-grade roster for age_preference alignment. Grade gaps of 1 stay
+# within GradeCompatibilityImpossibility's max_gap=1 (max_spread=2 in mock_config).
+#   CLIQUE = {cm_id 1 grade 5, cm_ids 2..8 grade 6}
+#   OTHER  = {cm_id 9 grade 7, cm_ids 10..16 grade 6}
+AGE_CLIQUE_ANCHOR = 1  # grade 5
+AGE_CLIQUE_REQUESTERS = list(range(2, 9))  # 2..8, grade 6
+AGE_OTHER_ANCHOR = 9  # grade 7
+AGE_OTHER_REQUESTERS = list(range(10, 17))  # 10..16, grade 6
+
+# Forced satisfaction outcomes for the age_preference alignment fixture.
+#
+# Solver/predicate agreement note: the solver encoding treats "older" as
+# "no younger bunkmate" (and symmetric for "younger"). The post-solve predicate
+# is more permissive: "older" is also satisfied by has_older even if there are
+# younger bunkmates (see bunking/utils/age_preference.py is_age_preference_satisfied).
+# The two disagree in the mixed-grade case (has_older AND has_younger). This
+# fixture deliberately avoids that case so the alignment assertion holds today;
+# the gap matters only if/when the age_preference sat_var becomes an objective
+# term and is documented in the PR description.
+AGE_PREF_EXPECTED_SATISFACTION: dict[str, bool] = {
+    # Trivially satisfied — no grade < 5 exists in roster.
+    "apref_trivsat_g5_older": True,
+    # Trivially satisfied — no grade > 7 exists in roster.
+    "apref_trivsat_g7_younger": True,
+    # CLIQUE has no grade 7 -> bunk_is_clean -> sat.
+    "apref_realsat_g6_younger": True,
+    # OTHER has grade 7 (cm_id 9) -> bunk dirty -> unsat.
+    "apref_realunsat_g6_younger": False,
+}
+
+
+def build_age_preference_alignment_fixture() -> DirectSolverInput:
+    """Build the age_preference satvar <-> predicate alignment scenario.
+
+    See module docstring for the determinism rationale and AGE_PREF_EXPECTED_
+    SATISFACTION for the deliberately-avoided mixed-grade case.
+    """
+    persons = [
+        make_person(AGE_CLIQUE_ANCHOR, session=SESSION, gender="F", grade=5),
+        *(make_person(cm_id, session=SESSION, gender="F", grade=6) for cm_id in AGE_CLIQUE_REQUESTERS),
+        make_person(AGE_OTHER_ANCHOR, session=SESSION, gender="F", grade=7),
+        *(make_person(cm_id, session=SESSION, gender="F", grade=6) for cm_id in AGE_OTHER_REQUESTERS),
+    ]
+
+    bunks = [
+        make_bunk(2001, session=SESSION, gender="F", capacity=8),
+        make_bunk(2002, session=SESSION, gender="F", capacity=8),
+    ]
+
+    requests = []
+
+    # MP bunk_with cohesion: forces CLIQUE and OTHER into separate bunks.
+    for cm_id in AGE_CLIQUE_REQUESTERS:
+        requests.append(
+            make_request(
+                f"mp_clique_{cm_id}",
+                requester=cm_id,
+                requestee=AGE_CLIQUE_ANCHOR,
+                request_type="bunk_with",
+                source_field=MP_SOURCE,
+                session=SESSION,
+            )
+        )
+    for cm_id in AGE_OTHER_REQUESTERS:
+        requests.append(
+            make_request(
+                f"mp_other_{cm_id}",
+                requester=cm_id,
+                requestee=AGE_OTHER_ANCHOR,
+                request_type="bunk_with",
+                source_field=MP_SOURCE,
+                session=SESSION,
+            )
+        )
+
+    # Age-preference assertion targets — all MP (source_field=MP_SOURCE) so
+    # they pass through add_age_preference_satisfaction_vars and land in
+    # request_satisfied_vars after the #1433 refactor.
+    requests += [
+        # cm_id 1 (grade 5) "older": no grade < 5 exists -> trivially sat.
+        make_request(
+            "apref_trivsat_g5_older",
+            requester=AGE_CLIQUE_ANCHOR,
+            requestee=None,
+            request_type="age_preference",
+            source_field=MP_SOURCE,
+            age_preference_target="older",
+            session=SESSION,
+        ),
+        # cm_id 9 (grade 7) "younger": no grade > 7 exists -> trivially sat.
+        make_request(
+            "apref_trivsat_g7_younger",
+            requester=AGE_OTHER_ANCHOR,
+            requestee=None,
+            request_type="age_preference",
+            source_field=MP_SOURCE,
+            age_preference_target="younger",
+            session=SESSION,
+        ),
+        # cm_id 2 (grade 6) "younger" in CLIQUE: bad_grades={7}, CLIQUE has none -> sat.
+        make_request(
+            "apref_realsat_g6_younger",
+            requester=AGE_CLIQUE_REQUESTERS[0],
+            requestee=None,
+            request_type="age_preference",
+            source_field=MP_SOURCE,
+            age_preference_target="younger",
+            session=SESSION,
+        ),
+        # cm_id 10 (grade 6) "younger" in OTHER: bad_grades={7}, OTHER has cm_id 9 -> unsat.
+        make_request(
+            "apref_realunsat_g6_younger",
+            requester=AGE_OTHER_REQUESTERS[0],
+            requestee=None,
+            request_type="age_preference",
+            source_field=MP_SOURCE,
+            age_preference_target="younger",
             session=SESSION,
         ),
     ]

--- a/tests/integration/solver/test_satvar_predicate_alignment.py
+++ b/tests/integration/solver/test_satvar_predicate_alignment.py
@@ -1,25 +1,24 @@
 """Golden alignment test: solve-time sat vars vs post-solve predicate.
 
-#1398 — drift defense between the solver's CP-SAT satisfaction encoding
-(``get_or_create_request_sat_var`` in
-``bunking/solver/constraints/bunk_requests.py``) and the post-solve oracle
-(``bunking.satisfaction.predicate.is_request_satisfied``).
+#1398 — drift defense between the solver's CP-SAT satisfaction encoding and
+the post-solve oracle (``bunking.satisfaction.predicate.is_request_satisfied``).
 
-Scope (Option 2 — see #1398): asserts agreement for every entry in
-``DirectBunkingSolver.request_satisfied_vars`` — the shared bidirectional sat
-var built for ``bunk_with`` / ``not_bunk_with`` requests with in-roster
-targets. That map is the complete output of ``get_or_create_request_sat_var``
-and the exact surface PR #1427 changed.
+Scope:
+  * ``bunk_with`` / ``not_bunk_with`` — alignment for the shared bidirectional
+    sat var built by ``get_or_create_request_sat_var`` in
+    ``bunking/solver/constraints/bunk_requests.py``. See PR #1427.
+  * ``age_preference`` — alignment for the bidirectional sat var built by
+    ``_create_age_preference_satisfaction_var`` in
+    ``bunking/solver/constraints/age_preference.py``. See #1433.
 
-``age_preference`` is deliberately out of scope: it has no faithful
-satisfaction var to align against (its sat var is one-way encoded and
-discarded by its only caller — see #1433). The fixture still includes an
-``age_preference`` request plus impossible requests so the build/validation
-path is exercised, but they carry no shared sat var and so are not asserted.
+Impossible requests (dropped by ``_validate_requests`` before sat-var
+creation) carry no sat var and are not asserted; the fixture exercises the
+drop path with one ``age_preference`` and two malformed/missing-target
+``bunk_with`` requests.
 
-If ``test_satvar_predicate_alignment`` fails on real divergence (not a fixture
-bug), per the #1398 acceptance criteria file a follow-up to investigate which
-path — the encoding or the predicate — is wrong.
+If alignment fails on real divergence (not a fixture bug), per the #1398
+acceptance criteria file a follow-up to investigate which path — the encoding
+or the predicate — is wrong.
 """
 
 from __future__ import annotations
@@ -31,13 +30,18 @@ from ortools.sat.python import cp_model
 from bunking.satisfaction.predicate import is_request_satisfied
 from bunking.solver.direct_solver import DirectBunkingSolver
 from tests.integration.solver.fixtures import (
+    AGE_PREF_EXPECTED_SATISFACTION,
     BUILD_PATH_EXERCISERS,
     EXPECTED_SATISFACTION,
+    build_age_preference_alignment_fixture,
     build_alignment_fixture,
 )
 
 
-def _build_and_solve(mock_config: Any) -> tuple[DirectBunkingSolver, cp_model.CpSolver]:
+def _build_and_solve(
+    mock_config: Any,
+    fixture_builder: Any = build_alignment_fixture,
+) -> tuple[DirectBunkingSolver, cp_model.CpSolver]:
     """Build the alignment fixture, add constraints + objective, and solve.
 
     Uses a test-local ``CpSolver`` with ``num_search_workers=1`` — the model is
@@ -45,7 +49,7 @@ def _build_and_solve(mock_config: Any) -> tuple[DirectBunkingSolver, cp_model.Cp
     build-and-inspect pattern established by
     ``tests/unit/solver/test_satvar_unification.py``.
     """
-    solver = DirectBunkingSolver(build_alignment_fixture(), config_service=mock_config)
+    solver = DirectBunkingSolver(fixture_builder(), config_service=mock_config)
     solver.add_constraints()
     solver.add_objective()
 
@@ -57,6 +61,19 @@ def _build_and_solve(mock_config: Any) -> tuple[DirectBunkingSolver, cp_model.Cp
         f"alignment fixture did not solve: status={cp_solver.StatusName(status)}"
     )
     return solver, cp_solver
+
+
+def _bunkmate_grades(solver: DirectBunkingSolver, person_to_bunk: dict[int, int]) -> dict[int, list[int]]:
+    """Per-camper list of bunkmate grades, required by the age_preference predicate."""
+    bunk_to_persons: dict[int, list[int]] = {}
+    for cm_id, bunk_cm_id in person_to_bunk.items():
+        bunk_to_persons.setdefault(bunk_cm_id, []).append(cm_id)
+
+    grade_by_cm_id = {p.campminder_person_id: p.grade for p in solver.input.persons}
+    bunkmate_grades: dict[int, list[int]] = {}
+    for cm_id, bunk_cm_id in person_to_bunk.items():
+        bunkmate_grades[cm_id] = [grade_by_cm_id[other] for other in bunk_to_persons[bunk_cm_id] if other != cm_id]
+    return bunkmate_grades
 
 
 def _person_to_bunk(solver: DirectBunkingSolver, cp_solver: cp_model.CpSolver) -> dict[int, int]:
@@ -83,18 +100,19 @@ def _person_to_bunk(solver: DirectBunkingSolver, cp_solver: cp_model.CpSolver) -
 
 
 def test_satvar_predicate_alignment(mock_config: Any) -> None:
-    """Every shared sat var agrees with ``is_request_satisfied`` post-solve."""
+    """Every shared bunk_with/not_bunk_with sat var agrees with the predicate."""
     solver, cp_solver = _build_and_solve(mock_config)
     person_to_bunk = _person_to_bunk(solver, cp_solver)
 
     sat_vars = solver.request_satisfied_vars
     assert sat_vars, "fixture produced no shared sat vars — nothing to align"
 
-    # age_preference / impossible requests must never get a shared sat var.
+    # Impossible requests are dropped by _validate_requests before sat-var
+    # creation, so they must never appear in request_satisfied_vars.
     for req_id in BUILD_PATH_EXERCISERS:
         assert req_id not in sat_vars, (
-            f"{req_id} unexpectedly has a shared sat var — get_or_create_request_sat_var "
-            f"should return None for age_preference / impossible requests"
+            f"{req_id} unexpectedly has a shared sat var — _validate_requests should "
+            f"drop impossible requests before sat-var creation"
         )
 
     requests_by_id = {r.id: r for r in solver.input.requests}
@@ -104,8 +122,8 @@ def test_satvar_predicate_alignment(mock_config: Any) -> None:
     for req_id, sat_var in sat_vars.items():
         request = requests_by_id[req_id]
         solver_satisfied = bool(cp_solver.Value(sat_var))
-        # bunkmate_grades is unused: age_preference never reaches this map, and
-        # is_request_satisfied only requires it for age_preference requests.
+        # bunkmate_grades is unused: this fixture has no feasible age_preference
+        # requests, and is_request_satisfied only requires it for that type.
         predicate_satisfied = is_request_satisfied(
             request.model_dump(),
             person_to_bunk,
@@ -158,3 +176,74 @@ def test_alignment_fixture_outcomes_are_deterministic(mock_config: Any) -> None:
             f"{req_id}: fixture expected sat_var={expected}, solver produced {actual} — "
             f"the deterministic partition no longer holds, re-check build_alignment_fixture"
         )
+
+
+def test_age_preference_satvar_predicate_alignment(mock_config: Any) -> None:
+    """Every feasible MP age_preference sat var agrees with the predicate.
+
+    #1433 — after the bidirectional refactor, age_preference sat vars are
+    registered in ``DirectBunkingSolver.request_satisfied_vars`` and are
+    bidirectionally bound to the post-solve satisfaction condition.
+    """
+    solver, cp_solver = _build_and_solve(mock_config, build_age_preference_alignment_fixture)
+    person_to_bunk = _person_to_bunk(solver, cp_solver)
+    bunkmate_grades = _bunkmate_grades(solver, person_to_bunk)
+
+    sat_vars = solver.request_satisfied_vars
+
+    # Every expected age_preference request must have a sat var registered.
+    for req_id in AGE_PREF_EXPECTED_SATISFACTION:
+        assert req_id in sat_vars, (
+            f"{req_id} (feasible MP age_preference) missing from request_satisfied_vars — "
+            f"the bidirectional refactor (#1433) is not wired into the shared map"
+        )
+
+    requests_by_id = {r.id: r for r in solver.input.requests}
+    grade_by_cm_id = {p.campminder_person_id: p.grade for p in solver.input.persons}
+    disagreements: list[str] = []
+
+    for req_id in AGE_PREF_EXPECTED_SATISFACTION:
+        request = requests_by_id[req_id]
+        sat_var = sat_vars[req_id]
+        solver_satisfied = bool(cp_solver.Value(sat_var))
+        # is_request_satisfied reads requester_grade off the request dict (the
+        # production callers in score_evaluator / bunking_validator pad it on
+        # before calling). Mirror that here.
+        request_payload = request.model_dump()
+        request_payload["requester_grade"] = grade_by_cm_id[request.requester_person_cm_id]
+        predicate_satisfied = is_request_satisfied(
+            request_payload,
+            person_to_bunk,
+            bunkmate_grades=bunkmate_grades,
+        )
+        if solver_satisfied != predicate_satisfied:
+            disagreements.append(
+                f"  {req_id} (age_preference {request.age_preference_target}, "
+                f"requester={request.requester_person_cm_id}): "
+                f"solver sat_var={solver_satisfied}, is_request_satisfied={predicate_satisfied}"
+            )
+
+    assert not disagreements, "age_preference sat vars disagree with is_request_satisfied:\n" + "\n".join(disagreements)
+
+
+def test_age_preference_alignment_fixture_outcomes_are_deterministic(mock_config: Any) -> None:
+    """The age_preference fixture's structurally-forced outcomes hold.
+
+    Mirrors ``test_alignment_fixture_outcomes_are_deterministic`` but for the
+    age_preference fixture — anti-vacuity guard against fixture drift.
+    """
+    solver, cp_solver = _build_and_solve(mock_config, build_age_preference_alignment_fixture)
+    sat_vars = solver.request_satisfied_vars
+
+    for req_id, expected in AGE_PREF_EXPECTED_SATISFACTION.items():
+        assert req_id in sat_vars, f"{req_id} expected in request_satisfied_vars but absent"
+        actual = bool(cp_solver.Value(sat_vars[req_id]))
+        assert actual == expected, (
+            f"{req_id}: fixture expected sat_var={expected}, solver produced {actual} — "
+            f"the deterministic partition no longer holds, re-check "
+            f"build_age_preference_alignment_fixture"
+        )
+
+    # Both branches must be exercised.
+    assert any(AGE_PREF_EXPECTED_SATISFACTION.values()), "fixture has no satisfied case — vacuous"
+    assert not all(AGE_PREF_EXPECTED_SATISFACTION.values()), "fixture has no unsatisfied case — vacuous"


### PR DESCRIPTION
## Summary

- Closes #1433. Replaces the one-way `age_preference` sat_var (built then discarded at `parent_paramount.py:101`) with a faithful **bidirectional** encoding registered in `ctx.request_satisfied_vars`, extending #1398's golden alignment test to age_preference.
- Drops the dead 3-tuple return + unused `bunk_has_grade` reuse parameter from `add_age_preference_satisfaction_vars`.
- **Finding 2** (non-MP `age_preference` unmodeled) intentionally left as-is — documented at the `add_objective` skip site and on the helper. Aligns with staff stance ("eh, maybe you'll get it") and the planned `material/immaterial/staff` bucket weights in `solver-config-decisions.md`.

## Encoding

Three layers bidirectionally bound:

| Var | Forward (pre-existing) | Converse (added) |
|---|---|---|
| `bunk_is_clean` | `clean=1 → no bad_grade_present` | `clean=0 → some bad_grade_present=1` |
| `person_in_clean_bunk` | `picb=1 → person_in_bunk AND bunk_is_clean` | `person_in_bunk AND bunk_is_clean → picb=1` |
| `sat_var` | per-bunk: `forcing_indicator=1 → sat_var=1` | aggregate: `sat_var=1 → ∃ forcing_indicator=1` |

`forcing_indicators` (return value consumed by `parent_paramount`'s must-satisfy-one) is unchanged.

## Test coverage

New `build_age_preference_alignment_fixture` exercises the three encoding branches:
- **Trivially satisfied** — no bad grades exist in roster (grade-5 "older", grade-7 "younger")
- **Real satisfied** — bad grades exist elsewhere; requester's bunk lacks them (grade-6 "younger" in CLIQUE)
- **Real unsatisfied** — bad grades present in requester's bunk (grade-6 "younger" in OTHER)

The fixture **deliberately avoids** the mixed-grade case (`has_older AND has_younger`) where the solver encoding ("no younger" / "no older") and the post-solve predicate ("has older" OR "no younger") diverge. This gap is pre-existing and would only matter if `age_preference` becomes an objective term in future — not in scope here.

## Perf

Adds ~2 reified constraints per MP `age_preference` request (the converse `bunk_is_clean` + the aggregate `sat_var → ∃ indicator`) plus 1 per (request, bunk) for the bidirectional `person_in_clean_bunk`. For typical Kindred scale (50–200 MP age_preference requests) this is in the noise; CP-SAT presolve handles aggregate reifications cheaply.

## Test plan

- [x] New `test_age_preference_satvar_predicate_alignment` + `test_age_preference_alignment_fixture_outcomes_are_deterministic` pass
- [x] Existing `test_satvar_predicate_alignment` still passes (bunk_with / not_bunk_with unchanged)
- [x] Full `tests/unit/` + `tests/integration/solver/` green (4589 passed)
- [x] mypy strict, ruff, type-check all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined age preference constraint modeling with enhanced bidirectional binding for more consistent solver behavior.
  * Optimized parent constraint logic for clearer enforcement of critical requirements.
  * Clarified solver documentation regarding age preference handling.

* **Tests**
  * Expanded integration test coverage for age preference constraint validation and deterministic fixture outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1466?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->