### PR TITLE
fix(api): silence satisfaction warnings for unassigned campers

### DIFF
--- a/bunking/satisfaction/aggregate.py
+++ b/bunking/satisfaction/aggregate.py
@@ -270,6 +270,16 @@ def session_satisfaction(
     for a in assignments:
         person_data = get_person_from_expand(a)
         bunk_data = get_bunk_from_expand(a)
+        # Distinguish "intentionally unassigned" from "dangling FK". The
+        # orphan_reconciler clears `bunk` to '' on draft rows whose
+        # (session, bunk) pair drops out of bunk_plans so the camper falls
+        # back into the Unassigned pool — empty rel is the canonical signal
+        # for that, not corruption. A non-empty rel that fails to expand
+        # IS corruption and must still surface.
+        person_rel = getattr(a, "person", "") or ""
+        bunk_rel = getattr(a, "bunk", "") or ""
+        if not person_rel or not bunk_rel:
+            continue
         if person_data is None or bunk_data is None:
             logger.warning(
                 "skipping assignment with unresolved expand (person/bunk missing): assignment_id=%s",

--- a/tests/unit/bunking/satisfaction/test_session_satisfaction.py
+++ b/tests/unit/bunking/satisfaction/test_session_satisfaction.py
@@ -714,3 +714,76 @@ def test_assignment_with_dict_style_expand_is_processed() -> None:
     # Both assignments must surface; dict-style must NOT be silently dropped.
     assert 1 in resp.campers
     assert 2 in resp.campers
+
+
+def _unassigned_draft_row(person_cm_id: int) -> Any:
+    """Scenario draft row where orphan_reconciler cleared the bunk rel.
+
+    Mirrors the post-reconciliation state: person rel + expand intact,
+    bunk rel is empty string, no bunk in expand payload. This is the
+    canonical "camper sitting in the Unassigned pool" shape.
+    """
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        id=f"a{person_cm_id:014d}",
+        cm_id=person_cm_id * 1000,
+        person=f"p{person_cm_id:014d}",
+        bunk="",
+        session=f"s{1:014d}",
+        expand={"person": SimpleNamespace(id=f"p{person_cm_id:014d}", cm_id=person_cm_id)},
+    )
+
+
+def _dangling_bunk_assignment(person_cm_id: int, bunk_rel_id: str) -> Any:
+    """Assignment row whose bunk rel points at a record that no longer exists.
+
+    Mirrors a true data-corruption case: rel value is set but the expand
+    payload omits bunk because the referenced record is gone.
+    """
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        id=f"a{person_cm_id:014d}",
+        cm_id=person_cm_id * 1000,
+        person=f"p{person_cm_id:014d}",
+        bunk=bunk_rel_id,
+        session=f"s{1:014d}",
+        expand={"person": SimpleNamespace(id=f"p{person_cm_id:014d}", cm_id=person_cm_id)},
+    )
+
+
+class TestUnresolvedExpandWarningClassification:
+    """Distinguish intentional unassigned (silent) from dangling FK (WARN).
+
+    orphan_reconciler clears `bunk` to '' on draft rows whose (session, bunk)
+    pair drops out of bunk_plans — the camper falls back into the Unassigned
+    pool by design. Warning about those is log noise. A non-empty bunk rel
+    that fails to expand IS real corruption and must still surface.
+    """
+
+    def test_empty_bunk_rel_does_not_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        persons = [_person(1)]
+        assignments = [_unassigned_draft_row(person_cm_id=1)]
+        pb = _build_pb_mock(persons, [], [], draft_assignments=assignments)
+
+        valid_scenario = "scenarioabc1234"
+        with caplog.at_level("WARNING", logger="bunking.satisfaction.aggregate"):
+            session_satisfaction(session_cm_ids=[999], year=2026, scenario_id=valid_scenario, pb_client=pb)
+
+        unresolved = [r for r in caplog.records if "unresolved expand" in r.getMessage()]
+        assert unresolved == [], f"unexpected warnings: {[r.getMessage() for r in unresolved]}"
+
+    def test_dangling_bunk_rel_still_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        persons = [_person(1)]
+        assignments = [_dangling_bunk_assignment(person_cm_id=1, bunk_rel_id="b00000000000999")]
+        pb = _build_pb_mock(persons, [], [], draft_assignments=assignments)
+
+        valid_scenario = "scenarioabc1234"
+        with caplog.at_level("WARNING", logger="bunking.satisfaction.aggregate"):
+            session_satisfaction(session_cm_ids=[999], year=2026, scenario_id=valid_scenario, pb_client=pb)
+
+        unresolved = [r for r in caplog.records if "unresolved expand" in r.getMessage()]
+        assert len(unresolved) == 1, (
+            f"expected exactly 1 unresolved-expand warning, got: {[r.getMessage() for r in unresolved]}"
+        )


### PR DESCRIPTION
## Summary
- `bunking/satisfaction/aggregate.py` warned once per camper sitting in the Unassigned pool of a scenario, conflating intentional state with data corruption
- `orphan_reconciler` clears `bunk = ''` on draft rows whose (session, bunk) pair drops out of `bunk_plans` so the camper falls back into the Unassigned pool — that's by design, not an error
- Split the two cases: empty `person`/`bunk` rel → skip silently; non-empty rel that fails to expand → still WARN (real dangling FK)

## Test plan
- [x] New `TestUnresolvedExpandWarningClassification` test class covering both shapes
- [x] `test_empty_bunk_rel_does_not_warn` failed before the fix, passes after
- [x] `test_dangling_bunk_rel_still_warns` ensures the corruption case still surfaces
- [x] Pre-push verification clean (4591 passed, 14 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced detection and handling of unassigned or incomplete assignment data, processing such cases earlier in the assignment pipeline.

* **Tests**
  * Added test coverage for warning logs in scenarios involving unresolved assignment data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->