### PR TITLE
refactor(solver): remove unreachable per-bunk branch in age_preference sat-var builder

### DIFF
--- a/bunking/solver/constraints/age_preference.py
+++ b/bunking/solver/constraints/age_preference.py
@@ -59,8 +59,7 @@ def add_age_preference_satisfaction_vars(
 
     Returns:
         Dict mapping request.id to its per-(request, bunk) forcing indicators.
-        Each forcing indicator is a BoolVar (or an assignment IntVar in the
-        no-bad-grades-possible branch) that, when set to 1, forces the
+        Each forcing indicator is a BoolVar that, when set to 1, forces the
         requester into a clean bunk and thus satisfies the request. Consumed
         by parent_paramount's hard must-satisfy-one constraint via summation.
     """
@@ -159,12 +158,11 @@ def _create_age_preference_satisfaction_var(
     Returns:
         Tuple (sat_var, forcing_indicators):
         - sat_var: BoolVar true iff request is satisfied, or None if no valid check.
-        - forcing_indicators: per-(request, bunk) BoolVars (or assignment IntVars
-          in the no-bad-grades-possible branch) that, when forced to 1, force
-          the requester into a clean bunk. For the trivially-satisfied branch,
-          the list contains a single always-1 BoolVar. Used by parent_paramount's
-          hard MP constraint: summing these and constraining >= 1 forces real
-          satisfaction.
+        - forcing_indicators: per-(request, bunk) BoolVars that, when forced
+          to 1, force the requester into a clean bunk. For the trivially-
+          satisfied branch, the list contains a single always-1 BoolVar.
+          Used by parent_paramount's hard MP constraint: summing these and
+          constraining >= 1 forces real satisfaction.
     """
     # Get all grades present in the solver
     all_grades = set()
@@ -195,40 +193,33 @@ def _create_age_preference_satisfaction_var(
     # Create satisfaction variable
     sat_var = ctx.model.NewBoolVar(f"age_req_{request.id}_satisfied")
 
-    # For each bunk the person might be in, check if it contains bad grades
+    # For each bunk the person might be in, check if it contains bad grades.
+    # `bad_grade_present_vars` is always non-empty here: `_build_bunk_has_grade_vars`
+    # builds an entry for every (bunk_idx, grade) pair where grade is in the
+    # roster, and `bad_grades` is by construction a subset of those roster
+    # grades. The invariant is pinned by
+    # `tests/unit/solver/test_age_preference_satvar_invariant.py`.
     for bunk_idx in range(len(ctx.bunks)):
-        # Check: person in this bunk AND bunk has NO bad grades
         person_in_bunk = ctx.assignments[(person_idx, bunk_idx)]
+        bad_grade_present_vars = [bunk_has_grade[(bunk_idx, bad_grade)] for bad_grade in bad_grades]
 
-        # Collect "bunk has bad grade" variables for this bunk
-        bad_grade_present_vars = [
-            bunk_has_grade[(bunk_idx, bad_grade)] for bad_grade in bad_grades if (bunk_idx, bad_grade) in bunk_has_grade
-        ]
+        # bunk_is_clean ↔ NONE of the bad grades are present
+        bunk_is_clean = ctx.model.NewBoolVar(f"age_req_{request.id}_clean_bunk_{bunk_idx}")
+        ctx.model.AddBoolAnd([v.Not() for v in bad_grade_present_vars]).OnlyEnforceIf(bunk_is_clean)
+        # Converse for bidirectional alignment: if any bad grade is present,
+        # bunk is not clean. Without this, bunk_is_clean=0 is consistent
+        # with all bad_grade_present=0, which would let sat_var drift away
+        # from the post-solve predicate.
+        ctx.model.AddBoolOr(bad_grade_present_vars).OnlyEnforceIf(bunk_is_clean.Not())
 
-        if not bad_grade_present_vars:
-            # No bad grades possible in this bunk - satisfied if person is here.
-            # The assignment var IS the forcing indicator: setting it to 1
-            # forces the person into this bunk, which is trivially clean.
-            ctx.model.Add(sat_var == 1).OnlyEnforceIf(person_in_bunk)
-            forcing_indicators.append(person_in_bunk)
-        else:
-            # bunk_is_clean ↔ NONE of the bad grades are present
-            bunk_is_clean = ctx.model.NewBoolVar(f"age_req_{request.id}_clean_bunk_{bunk_idx}")
-            ctx.model.AddBoolAnd([v.Not() for v in bad_grade_present_vars]).OnlyEnforceIf(bunk_is_clean)
-            # Converse for bidirectional alignment: if any bad grade is present,
-            # bunk is not clean. Without this, bunk_is_clean=0 is consistent
-            # with all bad_grade_present=0, which would let sat_var drift away
-            # from the post-solve predicate.
-            ctx.model.AddBoolOr(bad_grade_present_vars).OnlyEnforceIf(bunk_is_clean.Not())
+        # person_in_clean_bunk ↔ person_in_bunk AND bunk_is_clean
+        person_in_clean_bunk = ctx.model.NewBoolVar(f"age_req_{request.id}_in_clean_{bunk_idx}")
+        ctx.model.AddBoolAnd([person_in_bunk, bunk_is_clean]).OnlyEnforceIf(person_in_clean_bunk)
+        # Converse: person_in_bunk AND bunk_is_clean ⇒ person_in_clean_bunk.
+        ctx.model.Add(person_in_clean_bunk == 1).OnlyEnforceIf([person_in_bunk, bunk_is_clean])
 
-            # person_in_clean_bunk ↔ person_in_bunk AND bunk_is_clean
-            person_in_clean_bunk = ctx.model.NewBoolVar(f"age_req_{request.id}_in_clean_{bunk_idx}")
-            ctx.model.AddBoolAnd([person_in_bunk, bunk_is_clean]).OnlyEnforceIf(person_in_clean_bunk)
-            # Converse: person_in_bunk AND bunk_is_clean ⇒ person_in_clean_bunk.
-            ctx.model.Add(person_in_clean_bunk == 1).OnlyEnforceIf([person_in_bunk, bunk_is_clean])
-
-            ctx.model.Add(sat_var == 1).OnlyEnforceIf(person_in_clean_bunk)
-            forcing_indicators.append(person_in_clean_bunk)
+        ctx.model.Add(sat_var == 1).OnlyEnforceIf(person_in_clean_bunk)
+        forcing_indicators.append(person_in_clean_bunk)
 
     # Bidirectional binding of sat_var to forcing_indicators. The forward
     # direction (forcing_indicator → sat_var=1) is already encoded per-bunk

--- a/bunking/solver/constraints/parent_paramount.py
+++ b/bunking/solver/constraints/parent_paramount.py
@@ -93,9 +93,9 @@ def add_must_satisfy_one_request_constraints(ctx: SolverContext) -> None:
     # Step 2: build bidirectional sat vars + forcing indicators for MP
     # age_preference requests via the helper. The helper registers each sat
     # var in ctx.request_satisfied_vars (shared with bunk_with / not_bunk_with)
-    # and returns per-request forcing indicators (person_in_clean_bunk BoolVars,
-    # or assignment vars in the no-bad-grades branch, or always-1 vars in the
-    # trivially-satisfied branch). We sum these directly in the hard constraint.
+    # and returns per-request forcing indicators (person_in_clean_bunk BoolVars
+    # per bunk, or a single always-1 BoolVar in the trivially-satisfied branch).
+    # We sum these directly in the hard constraint.
     age_forcing_indicators_by_req_id: dict[str, list[cp_model.IntVar]] = {}
     if mp_age_requests_by_person:
         age_forcing_indicators_by_req_id = add_age_preference_satisfaction_vars(ctx, mp_age_requests_by_person)

--- a/tests/unit/solver/test_age_preference_satvar_invariant.py
+++ b/tests/unit/solver/test_age_preference_satvar_invariant.py
@@ -1,0 +1,51 @@
+"""Pins the invariant that makes the per-bunk satvar loop branchless.
+
+`_create_age_preference_satisfaction_var` walks every bunk and builds the
+`bad_grade_present_vars` list via:
+
+    [bunk_has_grade[(bunk_idx, bad_grade)] for bad_grade in bad_grades]
+
+Without a guard, this list can only become empty if `bunk_has_grade` is
+sparse on `(bunk_idx, bad_grade)` keys. `_build_bunk_has_grade_vars`
+guarantees it is NOT sparse: it cross-products every bunk with every grade
+that appears in the roster, and `bad_grades` is by construction a subset
+of those roster grades. So the per-bunk loop never observes an empty list.
+
+If this test ever fails, `bunk_has_grade` has become sparse and any code
+that iterates `bad_grades` against it must guard against an empty result.
+At the time this test was added (issue #1467), the empty-list guard had
+already been deleted from `_create_age_preference_satisfaction_var` because
+this invariant was always true. Restore the guard and add coverage for
+the sparse case before merging the sparsifying change.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from bunking.solver.constraints.age_preference import _build_bunk_has_grade_vars
+from bunking.solver.direct_solver import DirectBunkingSolver
+from tests.unit.solver.impossibility.conftest import make_bunk, make_input, make_person
+
+
+def test_bunk_has_grade_is_dense_over_roster_grades_and_bunks() -> None:
+    persons = [
+        make_person(1, session=1000, gender="F", grade=4),
+        make_person(2, session=1000, gender="F", grade=5),
+        make_person(3, session=1000, gender="F", grade=6),
+        make_person(4, session=1000, gender="F", grade=6),  # duplicate grade
+        make_person(5, session=1000, gender="F", grade=7),
+    ]
+    bunks = [
+        make_bunk(100, session=1000, gender="F"),
+        make_bunk(200, session=1000, gender="F"),
+        make_bunk(300, session=1000, gender="F"),
+    ]
+    solver = DirectBunkingSolver(make_input(persons, bunks, []), config_service=MagicMock())
+    ctx = solver._build_solver_context()
+
+    bunk_has_grade = _build_bunk_has_grade_vars(ctx)
+
+    roster_grades = {p.grade for p in persons}
+    expected_keys = {(b_idx, g) for b_idx in range(len(bunks)) for g in roster_grades}
+    assert set(bunk_has_grade.keys()) == expected_keys


### PR DESCRIPTION
## Summary

- Closes #1467
- Delete the `if not bad_grade_present_vars:` branch in `_create_age_preference_satisfaction_var` (structurally unreachable) and the no-op `if (bunk_idx, bad_grade) in bunk_has_grade` filter; flatten the per-bunk loop to its one real path.
- Refresh docstrings in `age_preference.py` + `parent_paramount.py` that referenced "the no-bad-grades-possible branch."
- Add `tests/unit/solver/test_age_preference_satvar_invariant.py` — a tripwire that pins the density invariant `_build_bunk_has_grade_vars` provides (every roster grade × every bunk). Fails loudly if a future change makes the map sparse, prompting the dead branch to be reintroduced with real coverage.

## Why the branch is dead

Two facts:

1. `_build_bunk_has_grade_vars` cross-products every `bunk_idx` with every grade that appears in the roster.
2. `bad_grades` is built as `[g for g in all_grades if g <|> person_grade]` — so it's always a subset of those roster grades.

Therefore, once the outer `if not bad_grades:` early-return is past, the inner comprehension's filter is a no-op and `bad_grade_present_vars` is non-empty for every iteration.

## Test plan

- [x] New invariant unit test passes (`test_bunk_has_grade_is_dense_over_roster_grades_and_bunks`).
- [x] Existing predicate-alignment integration tests pass (`test_age_preference_satvar_predicate_alignment` + determinism sibling).
- [x] Full age_preference impossibility + post-solve predicate suites pass (36 tests in the focused run).
- [x] Pre-push verification clean (4592 pass, 14 skipped on unrelated infra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Improvements**
  * Enhanced age preference constraint handling to ensure cleaner and more reliable bunk assignments when age preferences are specified.

* **Tests**
  * Added new validation tests to verify the consistency of age preference constraints.

* **Documentation**
  * Updated internal documentation for age preference constraint logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->