### PR TITLE
feat(sync): extend explicit-priority keyword detector with OBR-validated terms

### DIFF
--- a/bunking/sync/bunk_request_processor/core/constants.py
+++ b/bunking/sync/bunk_request_processor/core/constants.py
@@ -29,7 +29,7 @@ PRIORITY_KEYWORDS: tuple[str, ...] = (
     "must be with",  # Config: must_be_with
     "#1",  # Config: hashtag_one
     # OBR-validated additions (corpus mining: docs/plans/obr-priority-mining.md)
-    "highest priority",  # "1) NADAV MUIR (highest priority) 2) Jack…"
+    "highest priority",  # "1) Olivia Chen (highest priority) 2) Liam Garcia…"
     "biggest request",  # "Her biggest request is to not be in the same bunk…"
     "only request",  # "our only request would be that she's with a few other kiddos…"
     "(priority)",  # "(priority)" inline after a name in ranked list

--- a/bunking/sync/bunk_request_processor/core/constants.py
+++ b/bunking/sync/bunk_request_processor/core/constants.py
@@ -12,7 +12,11 @@ VALID_SESSION_TYPES = {"main", "embedded", "ag"}
 # Priority keywords that indicate high importance
 # These should match the keywords in ai_config.json priority_overrides.keywords
 # plus common variations that parents use
-PRIORITY_KEYWORDS = [
+#
+# All entries are matched case-insensitively (lowercased before scan).
+# Exception: "IMPORTANT" (all-caps) is handled separately in _has_priority_keyword
+# as a case-sensitive guard — lowercase "important" is too common a word to trigger.
+PRIORITY_KEYWORDS: tuple[str, ...] = (
     # Original keywords
     "must have",
     "very important",
@@ -24,7 +28,12 @@ PRIORITY_KEYWORDS = [
     "most important",
     "must be with",  # Config: must_be_with
     "#1",  # Config: hashtag_one
-]
+    # OBR-validated additions (corpus mining: docs/plans/obr-priority-mining.md)
+    "highest priority",  # "1) NADAV MUIR (highest priority) 2) Jack…"
+    "biggest request",  # "Her biggest request is to not be in the same bunk…"
+    "only request",  # "our only request would be that she's with a few other kiddos…"
+    "(priority)",  # "(priority)" inline after a name in ranked list
+)
 
 # Age filtering constants
 MAX_AGE_DIFFERENCE_MONTHS = 36  # For pre-filtering candidates

--- a/bunking/sync/bunk_request_processor/processing/first_request_detector.py
+++ b/bunking/sync/bunk_request_processor/processing/first_request_detector.py
@@ -61,5 +61,11 @@ def is_first_requested(
 def _has_priority_keyword(text: str) -> bool:
     if not text:
         return False
+    # "IMPORTANT" is matched case-sensitively: the all-caps shout is a priority
+    # signal (7 occurrences in OBR corpus), but lowercase "important" is too
+    # common a word to be a reliable signal (e.g. "it is important to Eliana
+    # that she be able to be in a bunk with her cousin").
+    if "IMPORTANT" in text:
+        return True
     text_lower = text.lower()
     return any(keyword in text_lower for keyword in PRIORITY_KEYWORDS)

--- a/bunking/sync/bunk_request_processor/processing/first_request_detector.py
+++ b/bunking/sync/bunk_request_processor/processing/first_request_detector.py
@@ -11,6 +11,8 @@ they compete on bucket weight (Material/Immaterial/Staff), not on slot-0.
 
 from __future__ import annotations
 
+import re
+
 from ..core.constants import PRIORITY_KEYWORDS
 from ..core.models import ParsedRequest, RequestType
 from ..shared.constants import SourceField
@@ -65,7 +67,7 @@ def _has_priority_keyword(text: str) -> bool:
     # signal (7 occurrences in OBR corpus), but lowercase "important" is too
     # common a word to be a reliable signal (e.g. "it is important to Eliana
     # that she be able to be in a bunk with her cousin").
-    if "IMPORTANT" in text:
+    if re.search(r"\bIMPORTANT\b", text):
         return True
     text_lower = text.lower()
     return any(keyword in text_lower for keyword in PRIORITY_KEYWORDS)

--- a/tests/unit/sync/bunk_request_processor/processing/test_first_request_detector.py
+++ b/tests/unit/sync/bunk_request_processor/processing/test_first_request_detector.py
@@ -94,12 +94,98 @@ class TestKeywordPath:
             "most important",
             "must be with",
             "#1",
+            # OBR-validated additions
+            "highest priority",
+            "biggest request",
+            "only request",
+            "(priority)",
         ],
     )
     def test_all_priority_keywords_recognized(self, keyword: str) -> None:
         req = _family_bunk_with(raw_text=f"Emma Johnson {keyword}", csv_position=2)
         other = _family_bunk_with(raw_text="Liam Garcia", csv_position=1)
         assert is_first_requested(req, [req, other]) is True
+
+    def test_allcaps_important_triggers(self) -> None:
+        # IMPORTANT (all-caps) is a case-sensitive match: 7 occurrences in OBR corpus.
+        req = _family_bunk_with(raw_text="Olivia Chen IMPORTANT", csv_position=2)
+        other = _family_bunk_with(raw_text="Mia Garcia", csv_position=1)
+        assert is_first_requested(req, [req, other]) is True
+
+    def test_allcaps_important_inline_triggers(self) -> None:
+        # Mirrors real corpus pattern: "1) EMMA JOHNSON (highest priority) 2) Liam Garcia"
+        req = _family_bunk_with(raw_text="1) Ethan Smith IMPORTANT request 2) Mason Lee", csv_position=2)
+        other = _family_bunk_with(raw_text="Sophia Kim", csv_position=1)
+        assert is_first_requested(req, [req, other]) is True
+
+
+class TestNewKeywordsCaseInsensitive:
+    """OBR-added keywords are matched case-insensitively (lowercased before scan)."""
+
+    def test_highest_priority_uppercase(self) -> None:
+        req = _family_bunk_with(raw_text="Emma Johnson (HIGHEST PRIORITY)", csv_position=2)
+        other = _family_bunk_with(raw_text="Liam Garcia", csv_position=1)
+        assert is_first_requested(req, [req, other]) is True
+
+    def test_biggest_request_mixed_case(self) -> None:
+        req = _family_bunk_with(raw_text="Her Biggest Request is Olivia Chen", csv_position=2)
+        other = _family_bunk_with(raw_text="Riley Sam", csv_position=1)
+        assert is_first_requested(req, [req, other]) is True
+
+    def test_only_request_lowercase(self) -> None:
+        req = _family_bunk_with(raw_text="our only request is Mia Garcia", csv_position=2)
+        other = _family_bunk_with(raw_text="Emma Johnson", csv_position=1)
+        assert is_first_requested(req, [req, other]) is True
+
+    def test_priority_in_parens_inline(self) -> None:
+        # Mirrors corpus: "1. Emma Johnson (priority) 2. Liam Garcia"
+        req = _family_bunk_with(raw_text="1. Sophia Kim (priority) 2. Ethan Smith", csv_position=2)
+        other = _family_bunk_with(raw_text="Mason Lee", csv_position=1)
+        assert is_first_requested(req, [req, other]) is True
+
+
+class TestImportantCaseSensitivity:
+    """IMPORTANT is case-sensitive: only the ALL-CAPS spelling triggers.
+    Lowercase 'important' and mixed-case 'Important' must NOT trigger."""
+
+    def test_lowercase_important_does_not_trigger(self) -> None:
+        # "important" (lowercase) is a soft/common word — not a priority signal.
+        req = _family_bunk_with(raw_text="it is important to Eliana that she be with her cousin", csv_position=2)
+        other = _family_bunk_with(raw_text="Emma Johnson", csv_position=1)
+        # No keyword → falls through to csv_position logic; position=2 → False.
+        assert is_first_requested(req, [req, other]) is False
+
+    def test_mixed_case_important_does_not_trigger(self) -> None:
+        req = _family_bunk_with(raw_text="Liam Garcia Important", csv_position=2)
+        other = _family_bunk_with(raw_text="Olivia Chen", csv_position=1)
+        assert is_first_requested(req, [req, other]) is False
+
+    def test_titlecase_important_does_not_trigger(self) -> None:
+        req = _family_bunk_with(raw_text="Riley Sam - Important request", csv_position=2)
+        other = _family_bunk_with(raw_text="Mia Garcia", csv_position=1)
+        assert is_first_requested(req, [req, other]) is False
+
+
+class TestSoftMarkersExcluded:
+    """Soft markers ('if possible', 'ideally', 'would prefer', 'hoping') are
+    deliberately excluded — they signal flexibility, not urgency."""
+
+    @pytest.mark.parametrize(
+        "soft_phrase",
+        [
+            "if possible",
+            "ideally",
+            "would prefer",
+            "hoping",
+            "would love",
+            "would be great",
+        ],
+    )
+    def test_soft_marker_does_not_trigger(self, soft_phrase: str) -> None:
+        req = _family_bunk_with(raw_text=f"Emma Johnson {soft_phrase}", csv_position=2)
+        other = _family_bunk_with(raw_text="Liam Garcia", csv_position=1)
+        # Soft marker present but no hard keyword → csv_position=2 → False.
+        assert is_first_requested(req, [req, other]) is False
 
 
 class TestNonFamilyBunkWithReturnsFalse:

--- a/tests/unit/sync/bunk_request_processor/processing/test_first_request_detector.py
+++ b/tests/unit/sync/bunk_request_processor/processing/test_first_request_detector.py
@@ -109,13 +109,13 @@ class TestKeywordPath:
     def test_allcaps_important_triggers(self) -> None:
         # IMPORTANT (all-caps) is a case-sensitive match: 7 occurrences in OBR corpus.
         req = _family_bunk_with(raw_text="Olivia Chen IMPORTANT", csv_position=2)
-        other = _family_bunk_with(raw_text="Mia Garcia", csv_position=1)
+        other = _family_bunk_with(raw_text="Samuel Johnson", csv_position=1)
         assert is_first_requested(req, [req, other]) is True
 
     def test_allcaps_important_inline_triggers(self) -> None:
         # Mirrors real corpus pattern: "1) EMMA JOHNSON (highest priority) 2) Liam Garcia"
-        req = _family_bunk_with(raw_text="1) Ethan Smith IMPORTANT request 2) Mason Lee", csv_position=2)
-        other = _family_bunk_with(raw_text="Sophia Kim", csv_position=1)
+        req = _family_bunk_with(raw_text="1) Riley Sam IMPORTANT request 2) Liam Garcia", csv_position=2)
+        other = _family_bunk_with(raw_text="Olivia Chen", csv_position=1)
         assert is_first_requested(req, [req, other]) is True
 
 
@@ -133,14 +133,14 @@ class TestNewKeywordsCaseInsensitive:
         assert is_first_requested(req, [req, other]) is True
 
     def test_only_request_lowercase(self) -> None:
-        req = _family_bunk_with(raw_text="our only request is Mia Garcia", csv_position=2)
+        req = _family_bunk_with(raw_text="our only request is Olivia Chen", csv_position=2)
         other = _family_bunk_with(raw_text="Emma Johnson", csv_position=1)
         assert is_first_requested(req, [req, other]) is True
 
     def test_priority_in_parens_inline(self) -> None:
         # Mirrors corpus: "1. Emma Johnson (priority) 2. Liam Garcia"
-        req = _family_bunk_with(raw_text="1. Sophia Kim (priority) 2. Ethan Smith", csv_position=2)
-        other = _family_bunk_with(raw_text="Mason Lee", csv_position=1)
+        req = _family_bunk_with(raw_text="1. Riley Sam (priority) 2. Samuel Johnson", csv_position=2)
+        other = _family_bunk_with(raw_text="Liam Garcia", csv_position=1)
         assert is_first_requested(req, [req, other]) is True
 
 
@@ -162,7 +162,19 @@ class TestImportantCaseSensitivity:
 
     def test_titlecase_important_does_not_trigger(self) -> None:
         req = _family_bunk_with(raw_text="Riley Sam - Important request", csv_position=2)
-        other = _family_bunk_with(raw_text="Mia Garcia", csv_position=1)
+        other = _family_bunk_with(raw_text="Samuel Johnson", csv_position=1)
+        assert is_first_requested(req, [req, other]) is False
+
+    def test_unimportant_does_not_trigger(self) -> None:
+        # "UNIMPORTANT" contains "IMPORTANT" as substring — must NOT trigger.
+        req = _family_bunk_with(raw_text="Olivia Chen UNIMPORTANT stuff", csv_position=2)
+        other = _family_bunk_with(raw_text="Emma Johnson", csv_position=1)
+        assert is_first_requested(req, [req, other]) is False
+
+    def test_importantly_does_not_trigger(self) -> None:
+        # "IMPORTANTLY" contains "IMPORTANT" as substring — must NOT trigger.
+        req = _family_bunk_with(raw_text="IMPORTANTLY, Liam Garcia", csv_position=2)
+        other = _family_bunk_with(raw_text="Riley Sam", csv_position=1)
         assert is_first_requested(req, [req, other]) is False
 
 


### PR DESCRIPTION
## Summary

Extends \`PRIORITY_KEYWORDS\` with 4 lower-case phrases + a case-sensitive \`IMPORTANT\` guard, all validated against OBR corpus mining (full report: \`docs/plans/obr-priority-mining.md\`).

**New keywords added:**
- \`highest priority\` — e.g. "1) NADAV MUIR (highest priority) 2) Jack…"
- \`biggest request\` — e.g. "Her biggest request is to not be in the same bunk as her sister"
- \`only request\` — e.g. "our only request would be that she's with a few other kiddos…"
- \`(priority)\` — parenthetical inline after a name in a ranked list

**Case-sensitive guard:**
- \`IMPORTANT\` (all-caps only) — 7 occurrences in OBR corpus; lowercase "important" is too common a word to be a reliable signal and is explicitly NOT triggered

**Deliberately excluded** (soft markers — signal flexibility, not urgency):
- \`if possible\`, \`ideally\`, \`would prefer\`, \`hoping\`, \`would love\`, \`would be great\`

## Test plan

- [x] Parametric positive cases for each new phrase (added to existing \`test_all_priority_keywords_recognized\` parametrize list)
- [x] \`IMPORTANT\` (all-caps) triggers — 2 positive tests
- [x] \`TestNewKeywordsCaseInsensitive\` — confirms OBR phrases match regardless of case
- [x] \`TestImportantCaseSensitivity\` — lowercase \`important\`, mixed-case \`Important\`, title-case \`Important\` all return False
- [x] \`TestSoftMarkersExcluded\` — parametric: 6 soft markers all return False
- [x] All 25 pre-existing tests still green (44 total, 44 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded priority recognition to include additional phrases (e.g., "highest priority", "biggest request", "only request", "(priority)").
  * "IMPORTANT" in all caps is treated as an explicit priority marker; lowercase "important" is excluded.

* **Tests**
  * Added tests covering new keywords, case-sensitivity of "IMPORTANT", and ensuring soft markers (e.g., "if possible", "ideally") do not trigger priority selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1471?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->