### PR TITLE
fix(frontend): align field-source labels with validator emit

### DIFF
--- a/frontend/src/utils/formatSourceField.test.ts
+++ b/frontend/src/utils/formatSourceField.test.ts
@@ -2,17 +2,28 @@ import { describe, it, expect } from 'vitest'
 import { formatSourceField } from './formatSourceField'
 
 describe('formatSourceField', () => {
-  it.each([
-    ['bunk_with', 'Bunk Request Form'],
-    ['not_bunk_with', 'Do NOT Share Bunk With'],
-    ['bunking_notes', 'Bunking Notes'],
-    ['internal_notes', 'Internal Notes'],
-    ['socialize_with', 'Social With Checkbox'],
-  ])('formats %s as %s', (input, expected) => {
-    expect(formatSourceField(input)).toBe(expected)
+  describe('validator stats keys (bunking_validator.py output)', () => {
+    it.each([
+      ['share_bunk_with', 'Bunk Request Form'],
+      ['do_not_share_with', 'Do NOT Share Bunk With'],
+      ['bunking_notes', 'Bunking Notes'],
+      ['internal_notes', 'Internal Notes'],
+      ['socialize_with', 'Social With Checkbox'],
+    ])('maps %s -> %s', (input, expected) => {
+      expect(formatSourceField(input)).toBe(expected)
+    })
   })
 
-  it('passes through unknown values', () => {
+  describe('DB wire values (SourceField constants)', () => {
+    it.each([
+      ['bunk_with', 'Bunk Request Form'],
+      ['not_bunk_with', 'Do NOT Share Bunk With'],
+    ])('maps %s -> %s for backward compat', (input, expected) => {
+      expect(formatSourceField(input)).toBe(expected)
+    })
+  })
+
+  it('falls through to the raw key for unknown inputs', () => {
     expect(formatSourceField('unknown_field')).toBe('unknown_field')
   })
 })

--- a/frontend/src/utils/formatSourceField.ts
+++ b/frontend/src/utils/formatSourceField.ts
@@ -1,14 +1,21 @@
 /**
- * Human-readable display labels for source field V2 names.
+ * Human-readable display labels for source field names.
  *
  * This is the SINGLE source of truth for source field display labels.
- * V2 internal names (bunk_with, not_bunk_with, etc.) are the canonical
- * values stored in the database. This function converts them to
- * user-facing labels for display only.
+ * Handles both:
+ * - DB/SourceField wire values ("bunk_with", "not_bunk_with") — used by
+ *   PipelineBatchList and other views that read source_field from the DB.
+ * - Validator stats keys ("share_bunk_with", "do_not_share_with") — emitted
+ *   by bunking_validator.py and shown in the post-check modal.
  */
 const SOURCE_FIELD_LABELS: Record<string, string> = {
+  // Validator stats keys (bunking_validator.py _SOURCEFIELD_TO_STATS_KEY)
+  share_bunk_with: 'Bunk Request Form',
+  do_not_share_with: 'Do NOT Share Bunk With',
+  // DB wire values (SourceField constants — backward-compat for pipeline views)
   bunk_with: 'Bunk Request Form',
   not_bunk_with: 'Do NOT Share Bunk With',
+  // Shared keys (same in both contexts)
   bunking_notes: 'Bunking Notes',
   internal_notes: 'Internal Notes',
   socialize_with: 'Social With Checkbox',


### PR DESCRIPTION
## Summary

Post-check modal's \"Details by request source\" section was showing raw \`share_bunk_with\` / \`do_not_share_with\` because the frontend label map keyed on \`bunk_with\` / \`not_bunk_with\` (stale). Updated the map to match the backend emission.

The fix also preserves backward-compat: the label map now includes **both** the validator stats keys (`share_bunk_with` / `do_not_share_with`) and the DB wire values (`bunk_with` / `not_bunk_with`), so `PipelineBatchList` — which reads `source_field` directly from the DB — continues to display the correct human-readable labels without any component-level changes.

## Test plan

- [x] `formatSourceField.test.ts` covers all 5 validator stats keys + the 2 DB wire values + unknown-fallback (8 cases, all pass)
- [x] `PipelineBatchList.test.tsx` (44 tests) passes — confirmed no regression in pipeline debug view
- [ ] Visual check: open post-check modal in dev, expand \"Details by request source\", confirm \"Bunk Request Form\" + \"Do NOT Share Bunk With\" render as proper labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite organization for field mapping validation.

* **Refactor**
  * Improved internal field mapping configuration for expanded compatibility support.

---

*Note: This release contains primarily internal maintenance updates with no user-facing changes.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1472?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->