### PR TITLE
feat(frontend): TG-6 two-tier camper-level MP coverage + score card relabels

### DIFF
--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -164,6 +164,14 @@ class ValidationStatistics(BaseModel):
     # Negative request violations (all not_bunk_with violations)
     negative_request_violations: int = 0
 
+    # Camper-level two-tier MP coverage (bunk_request_form source only).
+    # mp_campers_total = number of distinct requesters with ≥1 MP request.
+    # mp_campers_with_at_least_one_satisfied = campers where ≥1 of their MP requests is satisfied.
+    # mp_campers_with_all_satisfied = campers where ALL of their MP requests are satisfied.
+    mp_campers_total: int = 0
+    mp_campers_with_at_least_one_satisfied: int = 0
+    mp_campers_with_all_satisfied: int = 0
+
 
 class ValidationResult(BaseModel):
     """Complete validation result with statistics and issues."""
@@ -686,6 +694,22 @@ class BunkingValidator:
             person = person_by_id.get(pid)
             unmet_persons.append({"cm_id": cm_id, "name": person.name if person else f"Person {pid}"})
         stats.unsatisfied_material_parent_persons = sorted(unmet_persons, key=lambda entry: entry["name"])
+
+        # Camper-level two-tier MP coverage.
+        # mp_campers_total = distinct requesters with ≥1 MP request.
+        # at_least_one = requester has ≥1 satisfied MP request.
+        # all_satisfied = requester has ≥1 MP request AND every MP request is satisfied.
+        stats.mp_campers_total = sum(1 for reqs in material_parent_by_person.values() if reqs)
+        stats.mp_campers_with_at_least_one_satisfied = sum(
+            1
+            for pid, reqs in material_parent_by_person.items()
+            if reqs and satisfied_material_parent_by_person.get(pid)
+        )
+        stats.mp_campers_with_all_satisfied = sum(
+            1
+            for pid, reqs in material_parent_by_person.items()
+            if reqs and len(satisfied_material_parent_by_person.get(pid, [])) == len(reqs)
+        )
 
         # Best-effort parent (socialize_with source_field) stats.
         stats.best_effort_parent_requests = sum(len(reqs) for reqs in best_effort_parent_by_person.values())

--- a/frontend/src/pages/ScenarioComparisonPage.test.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.test.tsx
@@ -33,6 +33,9 @@ function makeStats(overrides: Partial<ValidationStatistics> = {}): ValidationSta
     assigned_campers: 0,
     unassigned_campers: 0,
     isolation_risks: 0,
+    mp_campers_total: 0,
+    mp_campers_with_at_least_one_satisfied: 0,
+    mp_campers_with_all_satisfied: 0,
     ...overrides,
   }
 }
@@ -178,46 +181,29 @@ describe('explicit_csv_* fields are removed', () => {
   })
 })
 
-// ─── Stage 3a parent-paramount: ValidationScoreCard — material + best-effort tiles ──
+// ─── Stage 3a parent-paramount: ValidationScoreCard — staff tile (TG-6 updated) ──
+// Note: Material Parent and Best-Effort Parent tiles were replaced in TG-6 with
+// camper-level two-tier MP coverage tiles. Staff tile relabeled to "Staff requests".
 
 describe('ValidationScoreCard parent-paramount stats', () => {
-  it('renders Material Parent tile from material_parent_request_satisfaction_rate', () => {
+  it('renders Staff requests stat (relabeled from "Staff Requests")', () => {
     const stats = makeStats({
-      // Stage 3a material-parent values (what the tile SHOULD read)
-      material_parent_requests: 10,
-      satisfied_material_parent_requests: 9,
-      material_parent_request_satisfaction_rate: 0.9,
-    })
-    render(<ValidationScoreCard label="Test" validation={makeValidation(stats)} side="left" />)
-    const parentLabel = screen.getByText(/^Material Parent$/i)
-    const parentSection = parentLabel.parentElement!
-    const parentScope = within(parentSection)
-    expect(parentScope.getByText('90%')).toBeInTheDocument()
-    expect(parentScope.getByText('(9/10)')).toBeInTheDocument()
-  })
-
-  it('renders Staff Requests stat as a sibling badge', () => {
-    const stats = makeStats({
-      material_parent_requests: 10,
-      satisfied_material_parent_requests: 10,
-      material_parent_request_satisfaction_rate: 1.0,
       staff_requests: 50,
       satisfied_staff_requests: 25,
       staff_request_satisfaction_rate: 0.5,
     })
     render(<ValidationScoreCard label="Test" validation={makeValidation(stats)} side="right" />)
-    const staffLabel = screen.getByText(/^Staff Requests$/i)
+    const staffLabel = screen.getByText(/^staff requests$/i)
     const staffSection = staffLabel.parentElement!
     const staffScope = within(staffSection)
     expect(staffScope.getByText('50%')).toBeInTheDocument()
     expect(staffScope.getByText('(25/50)')).toBeInTheDocument()
   })
 
-  it('does not render NaN% when rate fields are missing from a stale payload', () => {
-    // Stage 3a rate fields are typed as required `number`, but during rollout
+  it('does not render NaN% when rate/camper fields are missing from a stale payload', () => {
+    // TG-6 rate fields are typed as required `number`, but during rollout
     // (or with a stale cached scenario response) the runtime payload can
-    // still arrive without them. Math.round(undefined * 100) === NaN, which
-    // would render as "NaN%". Guard against that.
+    // still arrive without them. Guard against NaN rendering.
     const stats = makeStats({
       total_requests: 100,
       satisfied_requests: 50,
@@ -226,74 +212,144 @@ describe('ValidationScoreCard parent-paramount stats', () => {
     // a stale runtime payload, mirroring the real risk during rollout.
     delete stats.request_satisfaction_rate
     // @ts-expect-error — see above
-    delete stats.material_parent_request_satisfaction_rate
-    // @ts-expect-error — see above
     delete stats.staff_request_satisfaction_rate
     // @ts-expect-error — see above
-    delete stats.best_effort_parent_request_satisfaction_rate
+    delete stats.mp_campers_total
+    // @ts-expect-error — see above
+    delete stats.mp_campers_with_at_least_one_satisfied
+    // @ts-expect-error — see above
+    delete stats.mp_campers_with_all_satisfied
 
     const { container } = render(
       <ValidationScoreCard label="Test" validation={makeValidation(stats)} side="left" />
     )
     expect(container.textContent).not.toContain('NaN')
-    expect(screen.getAllByText('0%').length).toBeGreaterThanOrEqual(4)
+    // Score card shows at least 2 zero-percent tiles (at-least-one + all-requests)
+    expect(screen.getAllByText('0%').length).toBeGreaterThanOrEqual(2)
   })
 
-  it('renders four tiles: All Requests, Material Parent, Best-Effort Parent, Staff', () => {
+  it('renders camper-level coverage tiles and staff tile (not legacy combo tiles)', () => {
     const stats = makeStats({
-      material_parent_requests: 10,
-      satisfied_material_parent_requests: 9,
-      material_parent_request_satisfaction_rate: 0.9,
-      best_effort_parent_requests: 5,
-      satisfied_best_effort_parent_requests: 3,
-      best_effort_parent_request_satisfaction_rate: 0.6,
+      mp_campers_total: 10,
+      mp_campers_with_at_least_one_satisfied: 9,
+      mp_campers_with_all_satisfied: 6,
       staff_requests: 50,
       satisfied_staff_requests: 26,
       staff_request_satisfaction_rate: 0.52,
     })
     render(<ValidationScoreCard label="Test" validation={makeValidation(stats)} side="left" />)
-    expect(screen.getByText(/^All Requests$/i)).toBeInTheDocument()
-    expect(screen.getByText(/^Material Parent$/i)).toBeInTheDocument()
-    expect(screen.getByText(/^Best-Effort Parent$/i)).toBeInTheDocument()
-    expect(screen.getByText(/^Staff Requests$/i)).toBeInTheDocument()
+    expect(screen.getByText(/at least one request/i)).toBeInTheDocument()
+    expect(screen.getByText(/^all requests$/i)).toBeInTheDocument()
+    expect(screen.getByText(/^staff requests$/i)).toBeInTheDocument()
+    // Old tiles must not appear
+    expect(screen.queryByText(/^material parent$/i)).toBeNull()
+    expect(screen.queryByText(/^best-effort parent$/i)).toBeNull()
+  })
+})
+
+// ─── TG-6: two-tier camper-level MP coverage tiles ──────────────────────────
+
+describe('ValidationScoreCard TG-6: two-tier MP coverage + relabels', () => {
+  it('renders "At least one request" tile from mp_campers_with_at_least_one_satisfied / mp_campers_total', () => {
+    // 3 MP campers total, 2 have at least one satisfied → 67%
+    const stats = makeStats({
+      mp_campers_total: 3,
+      mp_campers_with_at_least_one_satisfied: 2,
+      mp_campers_with_all_satisfied: 1,
+    })
+    render(<ValidationScoreCard label="Test" validation={makeValidation(stats)} side="left" />)
+    expect(screen.getByText(/at least one request/i)).toBeInTheDocument()
+    expect(screen.getByText('67%')).toBeInTheDocument()
+    expect(screen.getByText(/2\s*\/\s*3 campers/)).toBeInTheDocument()
   })
 
-  it('All Requests tile counts material_parent + staff only (excludes best-effort)', () => {
-    // material: 10 total, 8 satisfied; staff: 20 total, 15 satisfied
-    // best-effort: 5 total, 4 satisfied — must NOT appear in "All" denominator
-    // expected All: (8+15)/(10+20) = 23/30 = 76%
+  it('renders "All requests" tile from mp_campers_with_all_satisfied / mp_campers_total', () => {
+    // 3 MP campers total, 1 has all satisfied → 33%
+    const stats = makeStats({
+      mp_campers_total: 3,
+      mp_campers_with_at_least_one_satisfied: 2,
+      mp_campers_with_all_satisfied: 1,
+    })
+    render(<ValidationScoreCard label="Test" validation={makeValidation(stats)} side="left" />)
+    expect(screen.getByText(/^all requests$/i)).toBeInTheDocument()
+    expect(screen.getByText('33%')).toBeInTheDocument()
+    expect(screen.getByText(/1\s*\/\s*3 campers/)).toBeInTheDocument()
+  })
+
+  it('shows 0% when mp_campers_total is 0 (no division by zero)', () => {
+    const stats = makeStats({
+      mp_campers_total: 0,
+      mp_campers_with_at_least_one_satisfied: 0,
+      mp_campers_with_all_satisfied: 0,
+    })
+    const { container } = render(
+      <ValidationScoreCard label="Test" validation={makeValidation(stats)} side="left" />
+    )
+    expect(container.textContent).not.toContain('NaN')
+  })
+
+  it('labels "Violations" tile as "Families to call"', () => {
+    const stats = makeStats({ negative_request_violations: 3 })
+    render(<ValidationScoreCard label="Test" validation={makeValidation(stats)} side="left" />)
+    expect(screen.getByText(/families to call/i)).toBeInTheDocument()
+    expect(screen.queryByText(/^violations$/i)).toBeNull()
+  })
+
+  it('labels isolation tile as "Isolated campers" (not "Isolation Risks")', () => {
+    const stats = makeStats({ isolation_risks: 2 })
+    render(<ValidationScoreCard label="Test" validation={makeValidation(stats)} side="left" />)
+    expect(screen.getByText(/isolated campers/i)).toBeInTheDocument()
+    expect(screen.queryByText(/^isolation risks$/i)).toBeNull()
+  })
+
+  it('labels staff tile as "Staff requests" (not "Staff Requests" with capital R)', () => {
+    const stats = makeStats({
+      staff_requests: 10,
+      satisfied_staff_requests: 8,
+      staff_request_satisfaction_rate: 0.8,
+    })
+    render(<ValidationScoreCard label="Test" validation={makeValidation(stats)} side="left" />)
+    // Case-insensitive: staff requests label present
+    expect(screen.getByText(/^staff requests$/i)).toBeInTheDocument()
+  })
+
+  it('does NOT render synthetic "All Requests" MP+staff combo tile', () => {
     const stats = makeStats({
       material_parent_requests: 10,
       satisfied_material_parent_requests: 8,
-      material_parent_request_satisfaction_rate: 0.8,
-      best_effort_parent_requests: 5,
-      satisfied_best_effort_parent_requests: 4,
-      best_effort_parent_request_satisfaction_rate: 0.8,
       staff_requests: 20,
       satisfied_staff_requests: 15,
-      staff_request_satisfaction_rate: 0.75,
+      mp_campers_total: 5,
+      mp_campers_with_at_least_one_satisfied: 4,
+      mp_campers_with_all_satisfied: 3,
     })
     render(<ValidationScoreCard label="Test" validation={makeValidation(stats)} side="left" />)
-    const allLabel = screen.getByText(/^All Requests$/i)
-    const allSection = allLabel.parentElement!
-    const allScope = within(allSection)
-    // 23/30 = 76.666...% → Math.round = 77%
-    expect(allScope.getByText('77%')).toBeInTheDocument()
-    expect(allScope.getByText('(23/30)')).toBeInTheDocument()
+    // The old synthetic "All Requests" tile showed a count like "(23/30)" — that combo should be gone.
+    // We verify the old combined total (10+20=30) does NOT appear as a denominator.
+    expect(screen.queryByText('(23/30)')).toBeNull()
   })
 
-  it('Best-Effort Parent tile reads best_effort_parent_request_satisfaction_rate', () => {
+  it('does NOT render "Material Parent" (request-level) tile', () => {
     const stats = makeStats({
-      best_effort_parent_requests: 8,
-      satisfied_best_effort_parent_requests: 5,
-      best_effort_parent_request_satisfaction_rate: 0.625,
+      material_parent_requests: 10,
+      satisfied_material_parent_requests: 9,
+      material_parent_request_satisfaction_rate: 0.9,
+      mp_campers_total: 5,
+      mp_campers_with_at_least_one_satisfied: 4,
+      mp_campers_with_all_satisfied: 3,
     })
     render(<ValidationScoreCard label="Test" validation={makeValidation(stats)} side="left" />)
-    const beLabel = screen.getByText(/^Best-Effort Parent$/i)
-    const beSection = beLabel.parentElement!
-    const beScope = within(beSection)
-    expect(beScope.getByText('63%')).toBeInTheDocument()
-    expect(beScope.getByText('(5/8)')).toBeInTheDocument()
+    expect(screen.queryByText(/^material parent$/i)).toBeNull()
+  })
+
+  it('does NOT render "Best-Effort Parent" muted tile', () => {
+    const stats = makeStats({
+      best_effort_parent_requests: 5,
+      satisfied_best_effort_parent_requests: 3,
+      best_effort_parent_request_satisfaction_rate: 0.6,
+    })
+    render(<ValidationScoreCard label="Test" validation={makeValidation(stats)} side="left" />)
+    expect(screen.queryByText(/^best-effort parent$/i)).toBeNull()
   })
 })
 

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -824,9 +824,9 @@ export default function ScenarioComparisonPage() {
                     <ListboxOption
                       value="production"
                       disabled={leftScenarioId === 'production'}
-                      className="listbox-option"
+                      className="listbox-option border-2 border-dashed border-amber-400 bg-amber-50/40 font-semibold dark:bg-amber-900/20"
                     >
-                      CampMinder (Production)
+                      ⬩ CampMinder (Production)
                     </ListboxOption>
                     {scenarios.length > 0 && (
                       <div className="text-muted-foreground border-border mt-1 border-t px-4 py-1.5 text-xs font-semibold tracking-wider uppercase">

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -181,12 +181,12 @@ export interface ValidationStatistics {
   total_requests: number
   satisfied_requests: number
   request_satisfaction_rate: number
-  // Stage 3a material (hard) parent requests — tiles read these.
+  // Stage 3a material (hard) parent requests — raw counts kept for drill-down.
   material_parent_requests: number
   satisfied_material_parent_requests: number
   material_parent_request_satisfaction_rate: number
   campers_with_unsatisfied_material_parent_requests: number
-  // Stage 3a best-effort (soft) parent requests — de-emphasized tile.
+  // Stage 3a best-effort (soft) parent requests — not shown on score card.
   best_effort_parent_requests: number
   satisfied_best_effort_parent_requests: number
   best_effort_parent_request_satisfaction_rate: number
@@ -199,6 +199,10 @@ export interface ValidationStatistics {
   assigned_campers: number
   unassigned_campers: number
   isolation_risks: number
+  // TG-6: camper-level two-tier MP coverage.
+  mp_campers_total: number
+  mp_campers_with_at_least_one_satisfied: number
+  mp_campers_with_all_satisfied: number
 }
 
 export interface ValidationResult {
@@ -766,8 +770,11 @@ export default function ScenarioComparisonPage() {
                     <ChevronDown className="text-muted-foreground h-5 w-5 flex-shrink-0" />
                   </ListboxButton>
                   <ListboxOptions className="listbox-options w-full">
-                    <ListboxOption value="production" className="listbox-option">
-                      CampMinder (Production)
+                    <ListboxOption
+                      value="production"
+                      className="listbox-option border-2 border-dashed border-amber-400 bg-amber-50/40 font-semibold dark:bg-amber-900/20"
+                    >
+                      ⬩ CampMinder (Production)
                     </ListboxOption>
                     {scenarios.length > 0 && (
                       <div className="text-muted-foreground border-border mt-1 border-t px-4 py-1.5 text-xs font-semibold tracking-wider uppercase">
@@ -870,6 +877,8 @@ export default function ScenarioComparisonPage() {
               rightValidation={rightValidation}
               leftScenarioName={leftScenarioName}
               rightScenarioName={rightScenarioName}
+              leftScenarioId={leftScenarioId}
+              rightScenarioId={rightScenarioId}
             />
 
             {/* Metrics Summary */}
@@ -1146,32 +1155,6 @@ function StatBlock({
   )
 }
 
-// De-emphasized variant for best-effort (soft) requests — smaller text,
-// neutral color so it doesn't compete with the material parent tile.
-function StatBlockMuted({
-  label,
-  pct,
-  satisfied,
-  total,
-}: {
-  label: string
-  pct: number
-  satisfied: number
-  total: number
-}) {
-  return (
-    <div className="opacity-70">
-      <div className="text-muted-foreground text-xs tracking-wider uppercase">{label}</div>
-      <div className="flex items-baseline gap-1">
-        <span className="text-muted-foreground text-base font-semibold">{pct}%</span>
-        <span className="text-muted-foreground text-xs">
-          ({satisfied}/{total})
-        </span>
-      </div>
-    </div>
-  )
-}
-
 // ValidationSection — QueryGuard boundary for validation score comparison.
 // Handles loading / error / empty / success states so that ValidationScoreCard
 // only needs to render the success case.
@@ -1183,6 +1166,8 @@ export interface ValidationSectionProps {
   rightValidation: ValidationResult | null | undefined
   leftScenarioName: string
   rightScenarioName: string
+  leftScenarioId?: string
+  rightScenarioId?: string
 }
 
 export function ValidationSection({
@@ -1192,6 +1177,8 @@ export function ValidationSection({
   rightValidation,
   leftScenarioName,
   rightScenarioName,
+  leftScenarioId,
+  rightScenarioId,
 }: ValidationSectionProps) {
   return (
     <QueryGuard
@@ -1212,12 +1199,18 @@ export function ValidationSection({
           </div>
           <div className="bg-muted/20 grid grid-cols-1 gap-4 p-4 md:grid-cols-2">
             {/* Left Scenario Score */}
-            <ValidationScoreCard label={leftScenarioName} validation={leftValidation} side="left" />
+            <ValidationScoreCard
+              label={leftScenarioName}
+              validation={leftValidation}
+              side="left"
+              isProduction={leftScenarioId === 'production'}
+            />
             {/* Right Scenario Score */}
             <ValidationScoreCard
               label={rightScenarioName}
               validation={rightValidation}
               side="right"
+              isProduction={rightScenarioId === 'production'}
             />
           </div>
         </div>
@@ -1231,9 +1224,16 @@ export interface ValidationScoreCardProps {
   label: string
   validation: ValidationResult | null | undefined
   side: 'left' | 'right'
+  /** When true, applies a dashed-amber border to signal this is the live CampMinder snapshot. */
+  isProduction?: boolean
 }
 
-export function ValidationScoreCard({ label, validation, side }: ValidationScoreCardProps) {
+export function ValidationScoreCard({
+  label,
+  validation,
+  side,
+  isProduction = false,
+}: ValidationScoreCardProps) {
   // Note: loading / error / empty states are handled by the parent ValidationSection
   // (QueryGuard boundary). This component only renders in the success path.
   // null/undefined validation means the individual side has no data yet — render
@@ -1249,49 +1249,85 @@ export function ValidationScoreCard({ label, validation, side }: ValidationScore
 
   const stats = validation.statistics
 
-  // "All Requests" = material parent + staff only; best-effort excluded.
-  const allTotal = (stats.material_parent_requests ?? 0) + (stats.staff_requests ?? 0)
-  const allSatisfied =
-    (stats.satisfied_material_parent_requests ?? 0) + (stats.satisfied_staff_requests ?? 0)
-  const allPct = allTotal > 0 ? Math.round((allSatisfied / allTotal) * 100) : 0
+  // Camper-level two-tier MP coverage (TG-6).
+  const mpTotal = stats.mp_campers_total ?? 0
+  const atLeastOnePct =
+    mpTotal > 0
+      ? Math.round(((stats.mp_campers_with_at_least_one_satisfied ?? 0) / mpTotal) * 100)
+      : 0
+  const allMpPct =
+    mpTotal > 0 ? Math.round(((stats.mp_campers_with_all_satisfied ?? 0) / mpTotal) * 100) : 0
 
-  const materialParentPct = Math.round((stats.material_parent_request_satisfaction_rate ?? 0) * 100)
-  const bestEffortPct = Math.round((stats.best_effort_parent_request_satisfaction_rate ?? 0) * 100)
   const staffPct = Math.round((stats.staff_request_satisfaction_rate ?? 0) * 100)
 
   return (
     <div
       className={clsx(
         'rounded-xl border-2 p-4',
-        side === 'left'
-          ? 'border-bark-200 bg-bark-50 dark:border-bark-700 dark:bg-bark-900/20'
-          : 'border-forest-200 bg-forest-50 dark:border-forest-700 dark:bg-forest-900/20'
+        isProduction
+          ? 'border-dashed border-amber-400 bg-amber-50/40 dark:bg-amber-900/20'
+          : side === 'left'
+            ? 'border-bark-200 bg-bark-50 dark:border-bark-700 dark:bg-bark-900/20'
+            : 'border-forest-200 bg-forest-50 dark:border-forest-700 dark:bg-forest-900/20'
       )}
     >
       <div className="mb-3 truncate text-sm font-semibold">{label}</div>
       <div className="grid grid-cols-2 gap-3 text-sm">
-        <StatBlock label="All Requests" pct={allPct} satisfied={allSatisfied} total={allTotal} />
+        {/* Two-tier camper-level MP coverage — hero tiles */}
+        <div>
+          <div className="text-muted-foreground text-xs tracking-wider uppercase">
+            At least one request
+          </div>
+          <div className="flex items-baseline gap-1">
+            <span
+              className={clsx(
+                'text-xl font-bold',
+                atLeastOnePct >= 80
+                  ? 'text-forest-600'
+                  : atLeastOnePct >= 60
+                    ? 'text-amber-600'
+                    : 'text-red-600'
+              )}
+            >
+              {atLeastOnePct}%
+            </span>
+            <span className="text-muted-foreground text-xs">
+              {stats.mp_campers_with_at_least_one_satisfied ?? 0} / {mpTotal} campers
+            </span>
+          </div>
+        </div>
+        <div>
+          <div className="text-muted-foreground text-xs tracking-wider uppercase">All requests</div>
+          <div className="flex items-baseline gap-1">
+            <span
+              className={clsx(
+                'text-xl font-bold',
+                allMpPct >= 80
+                  ? 'text-forest-600'
+                  : allMpPct >= 60
+                    ? 'text-amber-600'
+                    : 'text-red-600'
+              )}
+            >
+              {allMpPct}%
+            </span>
+            <span className="text-muted-foreground text-xs">
+              {stats.mp_campers_with_all_satisfied ?? 0} / {mpTotal} campers
+            </span>
+          </div>
+        </div>
+        {/* Staff requests */}
         <StatBlock
-          label="Material Parent"
-          pct={materialParentPct}
-          satisfied={stats.satisfied_material_parent_requests ?? 0}
-          total={stats.material_parent_requests ?? 0}
-        />
-        <StatBlock
-          label="Staff Requests"
+          label="Staff requests"
           pct={staffPct}
           satisfied={stats.satisfied_staff_requests}
           total={stats.staff_requests}
         />
-        <StatBlockMuted
-          label="Best-Effort Parent"
-          pct={bestEffortPct}
-          satisfied={stats.satisfied_best_effort_parent_requests ?? 0}
-          total={stats.best_effort_parent_requests ?? 0}
-        />
-        {/* Violations & Risks */}
+        {/* Families to call (negative request violations) */}
         <div>
-          <div className="text-muted-foreground text-xs tracking-wider uppercase">Violations</div>
+          <div className="text-muted-foreground text-xs tracking-wider uppercase">
+            Families to call
+          </div>
           <div
             className={clsx(
               'text-xl font-bold',
@@ -1301,9 +1337,10 @@ export function ValidationScoreCard({ label, validation, side }: ValidationScore
             {stats.negative_request_violations}
           </div>
         </div>
+        {/* Isolated campers */}
         <div>
           <div className="text-muted-foreground text-xs tracking-wider uppercase">
-            Isolation Risks
+            Isolated campers
           </div>
           <div
             className={clsx(

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -14,7 +14,7 @@ from bunking.bunking_validator import (
     ValidationSeverity,
     ValidationStatistics,
 )
-from bunking.models import BunkRequest, Person
+from bunking.models import Bunk, BunkAssignment, BunkRequest, Person
 from bunking.sync.bunk_request_processor.shared.constants import SourceField
 
 # ---------------------------------------------------------------------------
@@ -1993,3 +1993,128 @@ def test_validator_handles_non_numeric_bunkmate_grade():
         requests=cast(list[BunkRequest], requests),
     )
     assert result.statistics is not None
+
+
+# ─── TG-6: camper-level two-tier MP coverage ─────────────────────────────────
+
+
+def test_mp_camper_level_coverage_at_least_one_and_all() -> None:
+    """Camper-level two-tier MP coverage: at-least-one vs all satisfied.
+
+    3 campers (Emma Johnson, Liam Garcia, Olivia Chen), each with 2 MP requests.
+    - Emma Johnson (pid=1): 2/2 satisfied → counts in BOTH tiers
+    - Liam Garcia  (pid=4): 1/2 satisfied → counts in "at least one" only
+    - Olivia Chen  (pid=7): 0/2 satisfied → counts in NEITHER tier
+
+    Expected:
+        mp_campers_total                     = 3
+        mp_campers_with_at_least_one_satisfied = 2  (Emma + Liam)
+        mp_campers_with_all_satisfied          = 1  (Emma only)
+    """
+    session = _mock_session(cm_id="10000001", name="Test Session")
+
+    # Three campers + their request targets (targets just need to exist as persons
+    # so the validator can resolve them; their own assignments don't matter).
+    persons = [
+        MockPerson(campminder_id="1", name="Emma Johnson"),
+        MockPerson(campminder_id="2", name="Riley Sam"),
+        MockPerson(campminder_id="3", name="Samuel Johnson"),
+        MockPerson(campminder_id="4", name="Liam Garcia"),
+        MockPerson(campminder_id="5", name="Alex Kim"),
+        MockPerson(campminder_id="6", name="Jordan Lee"),
+        MockPerson(campminder_id="7", name="Olivia Chen"),
+        MockPerson(campminder_id="8", name="Casey Morgan"),
+        MockPerson(campminder_id="9", name="Taylor Reed"),
+    ]
+
+    # Two bunks: alpha holds Emma + her two targets, beta holds Liam + one target.
+    bunks = [
+        MockBunk(campminder_id="100", name="Alpha"),
+        MockBunk(campminder_id="200", name="Beta"),
+    ]
+
+    assignments = [
+        # Emma Johnson (pid=1): both targets in same bunk → 2/2 satisfied
+        MockBunkAssignment(person_cm_id="1", bunk_cm_id="100"),
+        MockBunkAssignment(person_cm_id="2", bunk_cm_id="100"),
+        MockBunkAssignment(person_cm_id="3", bunk_cm_id="100"),
+        # Liam Garcia (pid=4): only first target in same bunk → 1/2 satisfied
+        MockBunkAssignment(person_cm_id="4", bunk_cm_id="200"),
+        MockBunkAssignment(person_cm_id="5", bunk_cm_id="200"),
+        MockBunkAssignment(person_cm_id="6", bunk_cm_id="100"),  # different bunk → unsatisfied
+        # Olivia Chen (pid=7): neither target in same bunk → 0/2 satisfied
+        MockBunkAssignment(person_cm_id="7", bunk_cm_id="200"),
+        MockBunkAssignment(person_cm_id="8", bunk_cm_id="100"),  # different bunk
+        MockBunkAssignment(person_cm_id="9", bunk_cm_id="100"),  # different bunk
+    ]
+
+    requests = [
+        # Emma Johnson: req 1 → Riley Sam (satisfied — both in alpha)
+        MockBunkRequest(
+            requester_person_cm_id="1",
+            requested_person_cm_id="2",
+            request_type="bunk_with",
+            status="resolved",
+            source_field=SourceField.BUNK_REQUEST_FORM,
+            source="family",
+        ),
+        # Emma Johnson: req 2 → Samuel Johnson (satisfied — both in alpha)
+        MockBunkRequest(
+            requester_person_cm_id="1",
+            requested_person_cm_id="3",
+            request_type="bunk_with",
+            status="resolved",
+            source_field=SourceField.BUNK_REQUEST_FORM,
+            source="family",
+        ),
+        # Liam Garcia: req 1 → Alex Kim (satisfied — both in beta)
+        MockBunkRequest(
+            requester_person_cm_id="4",
+            requested_person_cm_id="5",
+            request_type="bunk_with",
+            status="resolved",
+            source_field=SourceField.BUNK_REQUEST_FORM,
+            source="family",
+        ),
+        # Liam Garcia: req 2 → Jordan Lee (unsatisfied — Jordan in alpha, Liam in beta)
+        MockBunkRequest(
+            requester_person_cm_id="4",
+            requested_person_cm_id="6",
+            request_type="bunk_with",
+            status="resolved",
+            source_field=SourceField.BUNK_REQUEST_FORM,
+            source="family",
+        ),
+        # Olivia Chen: req 1 → Casey Morgan (unsatisfied — Casey in alpha, Olivia in beta)
+        MockBunkRequest(
+            requester_person_cm_id="7",
+            requested_person_cm_id="8",
+            request_type="bunk_with",
+            status="resolved",
+            source_field=SourceField.BUNK_REQUEST_FORM,
+            source="family",
+        ),
+        # Olivia Chen: req 2 → Taylor Reed (unsatisfied — Taylor in alpha, Olivia in beta)
+        MockBunkRequest(
+            requester_person_cm_id="7",
+            requested_person_cm_id="9",
+            request_type="bunk_with",
+            status="resolved",
+            source_field=SourceField.BUNK_REQUEST_FORM,
+            source="family",
+        ),
+    ]
+
+    validator = BunkingValidator()
+    result = validator.validate_bunking(
+        session=session,
+        bunks=cast(list[Bunk], bunks),
+        assignments=cast(list[BunkAssignment], assignments),
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+    )
+    stats = result.statistics
+
+    assert stats.mp_campers_total == 3
+    assert stats.mp_campers_with_at_least_one_satisfied == 2  # Emma + Liam
+    assert stats.mp_campers_with_all_satisfied == 1  # Emma only

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -2002,9 +2002,9 @@ def test_mp_camper_level_coverage_at_least_one_and_all() -> None:
     """Camper-level two-tier MP coverage: at-least-one vs all satisfied.
 
     3 campers (Emma Johnson, Liam Garcia, Olivia Chen), each with 2 MP requests.
-    - Emma Johnson (pid=1): 2/2 satisfied → counts in BOTH tiers
-    - Liam Garcia  (pid=4): 1/2 satisfied → counts in "at least one" only
-    - Olivia Chen  (pid=7): 0/2 satisfied → counts in NEITHER tier
+    - Emma Johnson (pid=1000001): 2/2 satisfied → counts in BOTH tiers
+    - Liam Garcia  (pid=1000004): 1/2 satisfied → counts in "at least one" only
+    - Olivia Chen  (pid=1000007): 0/2 satisfied → counts in NEITHER tier
 
     Expected:
         mp_campers_total                     = 3
@@ -2016,15 +2016,15 @@ def test_mp_camper_level_coverage_at_least_one_and_all() -> None:
     # Three campers + their request targets (targets just need to exist as persons
     # so the validator can resolve them; their own assignments don't matter).
     persons = [
-        MockPerson(campminder_id="1", name="Emma Johnson"),
-        MockPerson(campminder_id="2", name="Riley Sam"),
-        MockPerson(campminder_id="3", name="Samuel Johnson"),
-        MockPerson(campminder_id="4", name="Liam Garcia"),
-        MockPerson(campminder_id="5", name="Alex Kim"),
-        MockPerson(campminder_id="6", name="Jordan Lee"),
-        MockPerson(campminder_id="7", name="Olivia Chen"),
-        MockPerson(campminder_id="8", name="Casey Morgan"),
-        MockPerson(campminder_id="9", name="Taylor Reed"),
+        MockPerson(campminder_id="1000001", name="Emma Johnson"),
+        MockPerson(campminder_id="1000002", name="Riley Sam"),
+        MockPerson(campminder_id="1000003", name="Samuel Johnson"),
+        MockPerson(campminder_id="1000004", name="Liam Garcia"),
+        MockPerson(campminder_id="1000005", name="Olivia Chen"),
+        MockPerson(campminder_id="1000006", name="Riley Sam"),
+        MockPerson(campminder_id="1000007", name="Olivia Chen"),
+        MockPerson(campminder_id="1000008", name="Samuel Johnson"),
+        MockPerson(campminder_id="1000009", name="Liam Garcia"),
     ]
 
     # Two bunks: alpha holds Emma + her two targets, beta holds Liam + one target.
@@ -2034,25 +2034,25 @@ def test_mp_camper_level_coverage_at_least_one_and_all() -> None:
     ]
 
     assignments = [
-        # Emma Johnson (pid=1): both targets in same bunk → 2/2 satisfied
-        MockBunkAssignment(person_cm_id="1", bunk_cm_id="100"),
-        MockBunkAssignment(person_cm_id="2", bunk_cm_id="100"),
-        MockBunkAssignment(person_cm_id="3", bunk_cm_id="100"),
-        # Liam Garcia (pid=4): only first target in same bunk → 1/2 satisfied
-        MockBunkAssignment(person_cm_id="4", bunk_cm_id="200"),
-        MockBunkAssignment(person_cm_id="5", bunk_cm_id="200"),
-        MockBunkAssignment(person_cm_id="6", bunk_cm_id="100"),  # different bunk → unsatisfied
-        # Olivia Chen (pid=7): neither target in same bunk → 0/2 satisfied
-        MockBunkAssignment(person_cm_id="7", bunk_cm_id="200"),
-        MockBunkAssignment(person_cm_id="8", bunk_cm_id="100"),  # different bunk
-        MockBunkAssignment(person_cm_id="9", bunk_cm_id="100"),  # different bunk
+        # Emma Johnson (pid=1000001): both targets in same bunk → 2/2 satisfied
+        MockBunkAssignment(person_cm_id="1000001", bunk_cm_id="100"),
+        MockBunkAssignment(person_cm_id="1000002", bunk_cm_id="100"),
+        MockBunkAssignment(person_cm_id="1000003", bunk_cm_id="100"),
+        # Liam Garcia (pid=1000004): only first target in same bunk → 1/2 satisfied
+        MockBunkAssignment(person_cm_id="1000004", bunk_cm_id="200"),
+        MockBunkAssignment(person_cm_id="1000005", bunk_cm_id="200"),
+        MockBunkAssignment(person_cm_id="1000006", bunk_cm_id="100"),  # different bunk → unsatisfied
+        # Olivia Chen (pid=1000007): neither target in same bunk → 0/2 satisfied
+        MockBunkAssignment(person_cm_id="1000007", bunk_cm_id="200"),
+        MockBunkAssignment(person_cm_id="1000008", bunk_cm_id="100"),  # different bunk
+        MockBunkAssignment(person_cm_id="1000009", bunk_cm_id="100"),  # different bunk
     ]
 
     requests = [
         # Emma Johnson: req 1 → Riley Sam (satisfied — both in alpha)
         MockBunkRequest(
-            requester_person_cm_id="1",
-            requested_person_cm_id="2",
+            requester_person_cm_id="1000001",
+            requested_person_cm_id="1000002",
             request_type="bunk_with",
             status="resolved",
             source_field=SourceField.BUNK_REQUEST_FORM,
@@ -2060,44 +2060,44 @@ def test_mp_camper_level_coverage_at_least_one_and_all() -> None:
         ),
         # Emma Johnson: req 2 → Samuel Johnson (satisfied — both in alpha)
         MockBunkRequest(
-            requester_person_cm_id="1",
-            requested_person_cm_id="3",
+            requester_person_cm_id="1000001",
+            requested_person_cm_id="1000003",
             request_type="bunk_with",
             status="resolved",
             source_field=SourceField.BUNK_REQUEST_FORM,
             source="family",
         ),
-        # Liam Garcia: req 1 → Alex Kim (satisfied — both in beta)
+        # Liam Garcia: req 1 → Olivia Chen (satisfied — both in beta)
         MockBunkRequest(
-            requester_person_cm_id="4",
-            requested_person_cm_id="5",
+            requester_person_cm_id="1000004",
+            requested_person_cm_id="1000005",
             request_type="bunk_with",
             status="resolved",
             source_field=SourceField.BUNK_REQUEST_FORM,
             source="family",
         ),
-        # Liam Garcia: req 2 → Jordan Lee (unsatisfied — Jordan in alpha, Liam in beta)
+        # Liam Garcia: req 2 → Riley Sam (unsatisfied — Riley in alpha, Liam in beta)
         MockBunkRequest(
-            requester_person_cm_id="4",
-            requested_person_cm_id="6",
+            requester_person_cm_id="1000004",
+            requested_person_cm_id="1000006",
             request_type="bunk_with",
             status="resolved",
             source_field=SourceField.BUNK_REQUEST_FORM,
             source="family",
         ),
-        # Olivia Chen: req 1 → Casey Morgan (unsatisfied — Casey in alpha, Olivia in beta)
+        # Olivia Chen: req 1 → Samuel Johnson (unsatisfied — Samuel in alpha, Olivia in beta)
         MockBunkRequest(
-            requester_person_cm_id="7",
-            requested_person_cm_id="8",
+            requester_person_cm_id="1000007",
+            requested_person_cm_id="1000008",
             request_type="bunk_with",
             status="resolved",
             source_field=SourceField.BUNK_REQUEST_FORM,
             source="family",
         ),
-        # Olivia Chen: req 2 → Taylor Reed (unsatisfied — Taylor in alpha, Olivia in beta)
+        # Olivia Chen: req 2 → Liam Garcia (unsatisfied — Liam in alpha, Olivia in beta)
         MockBunkRequest(
-            requester_person_cm_id="7",
-            requested_person_cm_id="9",
+            requester_person_cm_id="1000007",
+            requested_person_cm_id="1000009",
             request_type="bunk_with",
             status="resolved",
             source_field=SourceField.BUNK_REQUEST_FORM,


### PR DESCRIPTION
## Summary

- **Backend**: Adds three new fields to `ValidationStatistics` dataclass — `mp_campers_total`, `mp_campers_with_at_least_one_satisfied`, `mp_campers_with_all_satisfied` — and populates them in the material-parent satisfaction loop (camper-level, not request-level)
- **Frontend**: Replaces the old request-level tiles (synthetic "All Requests" MP+staff combo, "Material Parent", "Best-Effort Parent") with two-tier camper-level MP coverage tiles ("At least one request" / "All requests"). Relabels: Violations → Families to call, Isolation Risks → Isolated campers, Staff Requests → Staff requests.
- **Optional polish (landed)**: dashed-amber `border-dashed border-amber-400` on the CampMinder (Production) dropdown option and on the `ValidationScoreCard` wrapper when `isProduction` is true.

## Files changed

- `bunking/bunking_validator.py` — 3 new `ValidationStatistics` fields + camper-level population
- `tests/unit/test_bunking_validator.py` — new `test_mp_camper_level_coverage_at_least_one_and_all` (3-camper fixture: Emma 2/2, Liam 1/2, Olivia 0/2)
- `frontend/src/pages/ScenarioComparisonPage.tsx` — `ValidationStatistics` TS interface extended; `ValidationScoreCard` rewritten; `ValidationSection` gains optional `leftScenarioId`/`rightScenarioId` props; dashed-amber styling on dropdown + score card
- `frontend/src/pages/ScenarioComparisonPage.test.tsx` — legacy tile tests updated + 9 new TG-6 tests (two-tier coverage values, relabels, removed-tile absence guards)

## Test plan

- [x] `uv run pytest tests/unit/test_bunking_validator.py::test_mp_camper_level_coverage_at_least_one_and_all` — PASS
- [x] `npx vitest run src/pages/ScenarioComparisonPage.test.tsx` — 32 passed, 0 failed
- [x] Pre-push verification: all checks PASSED (ruff, mypy, pytest, prettier, eslint, tsc, vitest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added camper-level two-tier material-parent (MP) coverage metrics and updated validation score UI: "At least one request", "All requests", and a new "Staff requests" tile; removed legacy request-level MP tiles. Relabeled tiles: "Violations"→"Families to call", "Isolation Risks"→"Isolated campers".

* **Tests**
  * Added unit and UI tests validating camper-level MP coverage counts, new tile labels, correct percentages/denominators, and absence of legacy MP tiles.

* **Style**
  * Updated production option to a distinct dashed amber appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->