### PR TITLE
feat(api,frontend): consolidate pre-check into post-check + 3 new action sections

### DIFF
--- a/api/routers/validation.py
+++ b/api/routers/validation.py
@@ -293,6 +293,8 @@ async def validate_bunking(
                 ai_reasoning=getattr(request_data, "ai_reasoning", None),
                 ai_p1_reasoning=getattr(request_data, "ai_p1_reasoning", None),
                 age_preference_target=getattr(request_data, "age_preference_target", None),
+                priority_keyword_detected=bool(getattr(request_data, "priority_keyword_detected", False)),
+                raw_text=getattr(request_data, "raw_text", "") or "",
             )
             requests.append(bunk_request)
 

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -9,7 +9,7 @@ from collections import defaultdict, deque
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
-from typing import Any
+from typing import Any, TypedDict
 
 from pydantic import BaseModel, Field
 
@@ -60,6 +60,27 @@ class HistoricalBunkingRecord:
 
 
 logger = get_logger(__name__)
+
+
+class NegativeRequestViolation(TypedDict):
+    """Detail record for a single not_bunk_with violation where both campers share a bunk."""
+
+    requester_cm_id: str
+    target_cm_id: str
+    requester_name: str
+    target_name: str
+    bunk_cm_id: str
+    bunk_name: str
+
+
+class PriorityUnsuccessful(TypedDict):
+    """Detail record for a priority-keyword-flagged bunk_with request that was not satisfied."""
+
+    requester_cm_id: str
+    target_cm_id: str
+    requester_name: str
+    target_name: str
+    raw_text: str  # parent's original wording snippet
 
 
 class ValidationSeverity(StrEnum):
@@ -163,6 +184,14 @@ class ValidationStatistics(BaseModel):
 
     # Negative request violations (all not_bunk_with violations)
     negative_request_violations: int = 0
+    # Detail list for not_bunk_with violations — one entry per violated pair.
+    # Added in TG-4 alongside the existing count field.
+    negative_request_violations_detail: list[NegativeRequestViolation] = Field(default_factory=list)
+
+    # Priority-keyword-flagged bunk_with requests that were not satisfied (TG-4/TG-3).
+    # Populated by cross-referencing priority_keyword_detected=True requests against
+    # the satisfaction loop — only unsatisfied ones appear here.
+    priority_unsuccessfuls: list[PriorityUnsuccessful] = Field(default_factory=list)
 
     # Camper-level two-tier MP coverage (bunk_request_form source only).
     # mp_campers_total = number of distinct requesters with ≥1 MP request.
@@ -254,7 +283,8 @@ class BunkingValidator:
         self._validate_bunk_capacities(bunks, assignments_by_bunk, stats, issues)
 
         # Validate request satisfaction
-        self._validate_requests(requests, assignments_by_person, person_by_id, stats, issues)
+        bunk_by_id: dict[str, Bunk] = {b.campminder_id: b for b in bunks}
+        self._validate_requests(requests, assignments_by_person, person_by_id, stats, issues, bunk_by_id=bunk_by_id)
 
         # Validate age/grade spreads
         self._validate_spreads(bunks, assignments_by_bunk, person_by_id, stats, issues)
@@ -359,6 +389,7 @@ class BunkingValidator:
         person_by_id: dict[str, Person],
         stats: ValidationStatistics,
         issues: list[ValidationIssue],
+        bunk_by_id: dict[str, Bunk] | None = None,
     ) -> None:
         """Validate request satisfaction - tracking by source field."""
         # Valid statuses are 'resolved' (accepted/approved)
@@ -585,6 +616,28 @@ class BunkingValidator:
                     for field in source_fields:
                         if field in stats.field_stats:
                             stats.field_stats[field]["satisfied"] += 1
+                else:
+                    # Unsatisfied request: check for priority keyword flag (TG-3/TG-4).
+                    # Only bunk_with requests from a parent with a priority keyword that
+                    # ended up unmet should appear in the priority_unsuccessfuls action list.
+                    if (
+                        request.request_type == "bunk_with"
+                        and request.requested_person_cm_id
+                        and getattr(request, "priority_keyword_detected", False)
+                    ):
+                        requester_person = person_by_id.get(requester_id)
+                        requested_person = person_by_id.get(request.requested_person_cm_id)
+                        stats.priority_unsuccessfuls.append(
+                            PriorityUnsuccessful(
+                                requester_cm_id=requester_id,
+                                target_cm_id=request.requested_person_cm_id,
+                                requester_name=requester_person.name if requester_person else f"Person {requester_id}",
+                                target_name=requested_person.name
+                                if requested_person
+                                else f"Person {request.requested_person_cm_id}",
+                                raw_text=getattr(request, "raw_text", ""),
+                            )
+                        )
 
         # Calculate per-field satisfaction rates
         for field_data in stats.field_stats.values():
@@ -640,6 +693,21 @@ class BunkingValidator:
                             and requested_assignment
                             and person_assignment.bunk_cm_id == requested_assignment.bunk_cm_id
                         ):
+                            stats.negative_request_violations += 1
+                            # Find the bunk name for the detail record.
+                            violated_bunk_cm_id = person_assignment.bunk_cm_id
+                            violated_bunk = (bunk_by_id or {}).get(violated_bunk_cm_id)
+                            violated_bunk_name = violated_bunk.name if violated_bunk else violated_bunk_cm_id
+                            stats.negative_request_violations_detail.append(
+                                NegativeRequestViolation(
+                                    requester_cm_id=person_id,
+                                    target_cm_id=request.requested_person_cm_id,
+                                    requester_name=person_name,
+                                    target_name=requested_name,
+                                    bunk_cm_id=violated_bunk_cm_id,
+                                    bunk_name=violated_bunk_name,
+                                )
+                            )
                             issues.append(
                                 ValidationIssue(
                                     severity=ValidationSeverity.ERROR,

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -650,14 +650,68 @@ class BunkingValidator:
         campers_with_unsatisfied_valid_requests = []
 
         for person_id, alerting_requests in alerting_requests_by_person.items():
-            if len(alerting_requests) > 0 and len(satisfied_alerting_by_person[person_id]) == 0:
+            if len(alerting_requests) == 0:
+                continue
+
+            person = person_by_id.get(person_id)
+            person_name = person.name if person else f"Person {person_id}"
+
+            # not_bunk_with violation detection runs for ALL campers with any alerting
+            # requests, regardless of whether other requests are satisfied. A camper with
+            # a satisfied bunk_with AND a violated not_bunk_with must still appear in
+            # negative_request_violations_detail ("Families to call").
+            for request in alerting_requests:
+                if request.request_type == "not_bunk_with" and request.requested_person_cm_id:
+                    requested_person = person_by_id.get(request.requested_person_cm_id)
+                    requested_name = (
+                        requested_person.name if requested_person else f"Person {request.requested_person_cm_id}"
+                    )
+                    person_assignment = assignments_by_person.get(person_id)
+                    requested_assignment = assignments_by_person.get(request.requested_person_cm_id)
+                    if (
+                        person_assignment
+                        and requested_assignment
+                        and person_assignment.bunk_cm_id == requested_assignment.bunk_cm_id
+                    ):
+                        stats.negative_request_violations += 1
+                        # Find the bunk name for the detail record.
+                        violated_bunk_cm_id = person_assignment.bunk_cm_id
+                        violated_bunk = (bunk_by_id or {}).get(violated_bunk_cm_id)
+                        violated_bunk_name = violated_bunk.name if violated_bunk else violated_bunk_cm_id
+                        stats.negative_request_violations_detail.append(
+                            NegativeRequestViolation(
+                                requester_cm_id=person_id,
+                                target_cm_id=request.requested_person_cm_id,
+                                requester_name=person_name,
+                                target_name=requested_name,
+                                bunk_cm_id=violated_bunk_cm_id,
+                                bunk_name=violated_bunk_name,
+                            )
+                        )
+                        source_fields = get_source_fields(request)
+                        issues.append(
+                            ValidationIssue(
+                                severity=ValidationSeverity.ERROR,
+                                type="valid_negative_request_violated",
+                                message=f"{person_name} has a valid 'not bunk with' request but is bunked with {requested_name}",
+                                details={
+                                    "request_type": request.request_type,
+                                    "is_first_requested": getattr(request, "is_first_requested", False),
+                                    "person_id": person_id,
+                                    "requested_person_id": request.requested_person_cm_id,
+                                    "status": request.status,
+                                    "source_fields": source_fields,
+                                },
+                                affected_ids=[person_id, request.requested_person_cm_id],
+                            )
+                        )
+
+            # bunk_with unsatisfied warnings are only emitted when the camper has NO
+            # satisfied alerting requests (the "zero satisfied" guard stays here).
+            if len(satisfied_alerting_by_person[person_id]) == 0:
                 campers_with_unsatisfied_valid_requests.append(person_id)
 
-                # Get person info for reporting
-                person = person_by_id.get(person_id)
-                person_name = person.name if person else f"Person {person_id}"
-
-                # Report each unsatisfied alerting request for this person
+                # Report each unsatisfied alerting bunk_with request for this person
                 for request in alerting_requests:
                     source_fields = get_source_fields(request)
                     if request.request_type == "bunk_with" and request.requested_person_cm_id:
@@ -681,49 +735,6 @@ class BunkingValidator:
                                 affected_ids=[person_id, request.requested_person_cm_id],
                             )
                         )
-                    elif request.request_type == "not_bunk_with" and request.requested_person_cm_id:
-                        requested_person = person_by_id.get(request.requested_person_cm_id)
-                        requested_name = (
-                            requested_person.name if requested_person else f"Person {request.requested_person_cm_id}"
-                        )
-                        person_assignment = assignments_by_person.get(person_id)
-                        requested_assignment = assignments_by_person.get(request.requested_person_cm_id)
-                        if (
-                            person_assignment
-                            and requested_assignment
-                            and person_assignment.bunk_cm_id == requested_assignment.bunk_cm_id
-                        ):
-                            stats.negative_request_violations += 1
-                            # Find the bunk name for the detail record.
-                            violated_bunk_cm_id = person_assignment.bunk_cm_id
-                            violated_bunk = (bunk_by_id or {}).get(violated_bunk_cm_id)
-                            violated_bunk_name = violated_bunk.name if violated_bunk else violated_bunk_cm_id
-                            stats.negative_request_violations_detail.append(
-                                NegativeRequestViolation(
-                                    requester_cm_id=person_id,
-                                    target_cm_id=request.requested_person_cm_id,
-                                    requester_name=person_name,
-                                    target_name=requested_name,
-                                    bunk_cm_id=violated_bunk_cm_id,
-                                    bunk_name=violated_bunk_name,
-                                )
-                            )
-                            issues.append(
-                                ValidationIssue(
-                                    severity=ValidationSeverity.ERROR,
-                                    type="valid_negative_request_violated",
-                                    message=f"{person_name} has a valid 'not bunk with' request but is bunked with {requested_name}",
-                                    details={
-                                        "request_type": request.request_type,
-                                        "is_first_requested": getattr(request, "is_first_requested", False),
-                                        "person_id": person_id,
-                                        "requested_person_id": request.requested_person_cm_id,
-                                        "status": request.status,
-                                        "source_fields": source_fields,
-                                    },
-                                    affected_ids=[person_id, request.requested_person_cm_id],
-                                )
-                            )
 
         # Aggregate totals narrow to material_parent + staff (the alerting
         # bucket). Best-effort socialize_with is reported only in its own

--- a/bunking/models.py
+++ b/bunking/models.py
@@ -289,6 +289,8 @@ class BunkRequest(BaseModel):
     ai_reasoning: str | dict[str, Any] | None = None  # Legacy AI reasoning data
     ai_p1_reasoning: str | dict[str, Any] | None = None  # Phase 1 AI reasoning with csv_source_fields
     age_preference_target: str | None = None  # 'older' or 'younger' for age_preference requests
+    priority_keyword_detected: bool = False  # TG-3: True when parent text had an explicit priority keyword
+    raw_text: str = ""  # TG-3: parent's original wording snippet
 
 
 class Session(BaseModel):

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -487,6 +487,247 @@ vi.mock('./CamperDetailsPanel', () => ({
   ),
 }))
 
+// ---------------------------------------------------------------------------
+// Task 4.3 — "Campers who got nothing" section
+// ---------------------------------------------------------------------------
+
+describe('PostValidationResultsModal — Campers who got nothing section (TG-4.3)', () => {
+  it('renders named tiles for entirely-impossible MP campers', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults()}
+        impossibilityReport={makeImpossibilityReport({
+          mp_campers_entirely_impossible: [
+            { cm_id: 1001, name: 'Emma Johnson', gender: 'Girls', grade: 7, reason_codes: [] },
+            { cm_id: 1002, name: 'Liam Garcia', gender: 'Boys', grade: 4, reason_codes: [] },
+          ],
+        })}
+      />
+    )
+    expect(screen.getByText('Campers who got nothing')).toBeInTheDocument()
+    expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
+    expect(screen.getByText('Liam Garcia')).toBeInTheDocument()
+  })
+
+  it('does not render "Campers who got nothing" when the list is empty', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults()}
+        impossibilityReport={makeImpossibilityReport({ mp_campers_entirely_impossible: [] })}
+      />
+    )
+    expect(screen.queryByText('Campers who got nothing')).not.toBeInTheDocument()
+  })
+
+  it('does not render "Campers who got nothing" when impossibilityReport is absent', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults()}
+      />
+    )
+    expect(screen.queryByText('Campers who got nothing')).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Task 4.4 — "Families to call" section
+// ---------------------------------------------------------------------------
+
+describe('PostValidationResultsModal — Families to call section (TG-4.4)', () => {
+  it('renders Families to call list with named rows for not_bunk_with violations', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({
+          negative_request_violations_detail: [
+            {
+              requester_cm_id: '1003',
+              target_cm_id: '1004',
+              requester_name: 'Riley Sam',
+              target_name: 'Samuel Johnson',
+              bunk_cm_id: '2003',
+              bunk_name: 'Pine 3',
+            },
+          ],
+        })}
+      />
+    )
+    expect(screen.getByText('Families to call')).toBeInTheDocument()
+    expect(screen.getByText('Riley Sam')).toBeInTheDocument()
+    expect(screen.getByText('Samuel Johnson')).toBeInTheDocument()
+    expect(screen.getByText('Pine 3')).toBeInTheDocument()
+  })
+
+  it('does not render "Families to call" when negative_request_violations_detail is absent', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults()}
+      />
+    )
+    expect(screen.queryByText('Families to call')).not.toBeInTheDocument()
+  })
+
+  it('does not render "Families to call" when negative_request_violations_detail is empty', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({ negative_request_violations_detail: [] })}
+      />
+    )
+    expect(screen.queryByText('Families to call')).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Task 4.5 — "Priority unsuccessfuls" section
+// ---------------------------------------------------------------------------
+
+describe('PostValidationResultsModal — Priority unsuccessfuls section (TG-4.5)', () => {
+  it('renders Priority unsuccessfuls with parent wording snippets', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({
+          priority_unsuccessfuls: [
+            {
+              requester_cm_id: '1005',
+              target_cm_id: '1006',
+              requester_name: 'Sophia Martinez',
+              target_name: 'Mia Wilson',
+              raw_text: 'Mia is our top priority',
+            },
+          ],
+        })}
+      />
+    )
+    expect(screen.getByText('Priority unsuccessfuls')).toBeInTheDocument()
+    expect(screen.getByText('Sophia Martinez')).toBeInTheDocument()
+    expect(screen.getByText('Mia Wilson')).toBeInTheDocument()
+    expect(screen.getByText(/Mia is our top priority/)).toBeInTheDocument()
+  })
+
+  it('does not render "Priority unsuccessfuls" when the list is absent', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults()}
+      />
+    )
+    expect(screen.queryByText('Priority unsuccessfuls')).not.toBeInTheDocument()
+  })
+
+  it('does not render "Priority unsuccessfuls" when the list is empty', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({ priority_unsuccessfuls: [] })}
+      />
+    )
+    expect(screen.queryByText('Priority unsuccessfuls')).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Task 4.6 — "Impossibility by reason" section
+// ---------------------------------------------------------------------------
+
+describe('PostValidationResultsModal — Impossibility by reason section (TG-4.6)', () => {
+  it('renders impossibility by_reason as stat tiles when reasons are present', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults()}
+        impossibilityReport={makeImpossibilityReport({
+          mp_campers_entirely_impossible: [],
+          by_reason: {
+            grade_compatibility: [
+              {
+                request_id: 'r1',
+                reason_code: 'grade_compatibility',
+                reason_message: 'grade too wide',
+                request_type: 'bunk_with',
+                requester: { cm_id: 1, name: 'Emma Johnson', grade: 5, gender: 'F' },
+                requestee: { cm_id: 2, name: 'Liam Garcia', grade: 8, gender: 'M' },
+                detail: {},
+              },
+              {
+                request_id: 'r2',
+                reason_code: 'grade_compatibility',
+                reason_message: 'grade too wide',
+                request_type: 'bunk_with',
+                requester: { cm_id: 3, name: 'Olivia Chen', grade: 5, gender: 'F' },
+                requestee: { cm_id: 4, name: 'Riley Sam', grade: 9, gender: 'F' },
+                detail: {},
+              },
+            ],
+            cross_session: [
+              {
+                request_id: 'r3',
+                reason_code: 'cross_session',
+                reason_message: 'different session',
+                request_type: 'bunk_with',
+                requester: { cm_id: 5, name: 'Sophia Martinez', grade: 6, gender: 'F' },
+                requestee: null,
+                detail: {},
+              },
+            ],
+          },
+        })}
+      />
+    )
+    expect(screen.getByText(/impossible by reason/i)).toBeInTheDocument()
+  })
+
+  it('does not render "Impossible by reason" when by_reason is empty', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults()}
+        impossibilityReport={makeImpossibilityReport({ by_reason: {} })}
+      />
+    )
+    expect(screen.queryByText(/impossible by reason/i)).not.toBeInTheDocument()
+  })
+
+  it('does not render "Impossible by reason" when impossibilityReport is absent', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults()}
+      />
+    )
+    expect(screen.queryByText(/impossible by reason/i)).not.toBeInTheDocument()
+  })
+})
+
 describe('PostValidationResultsModal — impossibility section (#1442 part 2)', () => {
   const makeReport = (mp: EntirelyImpossibleMpCamper[], totalImpossible = mp.length) =>
     makeImpossibilityReport({

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -673,6 +673,7 @@ describe('PostValidationResultsModal — Impossibility by reason section (TG-4.6
                 requester: { cm_id: 1, name: 'Emma Johnson', grade: 5, gender: 'F' },
                 requestee: { cm_id: 2, name: 'Liam Garcia', grade: 8, gender: 'M' },
                 detail: {},
+                bucket: null,
               },
               {
                 request_id: 'r2',
@@ -682,6 +683,7 @@ describe('PostValidationResultsModal — Impossibility by reason section (TG-4.6
                 requester: { cm_id: 3, name: 'Olivia Chen', grade: 5, gender: 'F' },
                 requestee: { cm_id: 4, name: 'Riley Sam', grade: 9, gender: 'F' },
                 detail: {},
+                bucket: null,
               },
             ],
             cross_session: [
@@ -693,6 +695,7 @@ describe('PostValidationResultsModal — Impossibility by reason section (TG-4.6
                 requester: { cm_id: 5, name: 'Sophia Martinez', grade: 6, gender: 'F' },
                 requestee: null,
                 detail: {},
+                bucket: null,
               },
             ],
           },

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -951,9 +951,9 @@ export default function PostValidationResultsModal({
               </span>
             </div>
             <ul className="mt-3 divide-y divide-stone-200 text-sm">
-              {(statistics.priority_unsuccessfuls ?? []).map((p) => (
+              {(statistics.priority_unsuccessfuls ?? []).map((p, idx) => (
                 <li
-                  key={`${p.requester_cm_id}-${p.target_cm_id}`}
+                  key={`${p.requester_cm_id}-${p.target_cm_id}-${idx}`}
                   className="flex items-center justify-between py-2"
                 >
                   <div>

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -15,8 +15,8 @@ import {
 } from 'lucide-react'
 import { Modal } from './ui/Modal'
 import { formatSourceField } from '../utils/formatSourceField'
-import { ImpossibilityCohortSection } from './impossibility/ImpossibilityCohortSection'
 import { LazyCamperDetailsPanel } from './impossibility/LazyCamperDetailsPanel'
+import { friendlyReasonLabel, camperActionHints } from './impossibility/reasonHints'
 import { ErrorBoundary } from './ErrorBoundary'
 import type { ImpossibilityReport, EntirelyImpossibleMpCamper } from '../services/solver'
 import { BunkRequestProvider } from '../providers/BunkRequestProvider'
@@ -46,6 +46,23 @@ interface ValidationStatistics {
   satisfied_best_effort_parent_requests?: number
   best_effort_parent_request_satisfaction_rate?: number
   field_stats: Record<string, FieldStats>
+  /** TG-4: not_bunk_with violations with full pair detail for "Families to call" section. */
+  negative_request_violations_detail?: Array<{
+    requester_cm_id: string
+    target_cm_id: string
+    requester_name: string
+    target_name: string
+    bunk_cm_id: string
+    bunk_name: string
+  }>
+  /** TG-4/TG-3: priority-keyword-flagged bunk_with requests that were not satisfied. */
+  priority_unsuccessfuls?: Array<{
+    requester_cm_id: string
+    target_cm_id: string
+    requester_name: string
+    target_name: string
+    raw_text: string
+  }>
 }
 
 interface Issue {
@@ -779,26 +796,193 @@ export default function PostValidationResultsModal({
         </div>
       </div>
 
-      {/* Impossibility cohort — surfaced from the latest pre-check (#1442 part 2).
-          Closes the loop on "we got 100% Optimized, who didn't get fulfilled?"
-          by naming the campers whose requests were structurally impossible.
-
-          Two distinct facts shown as two distinct lines: the named cohort
-          (entirely-impossible MP campers) and the scenario-wide impossible
-          request count (which may include partially-impossible kids not in
-          this list). Combining them ("X campers had Y impossible requests")
-          implied the Y belonged to the X, which is misleading. */}
-      <ImpossibilityCohortSection
-        campers={mpImpossible}
-        totalImpossibleRequests={totalImpossibleRequests}
-        onSelectCamper={setSelectedCamperId}
-      />
+      {/* TG-4.3: "Campers who got nothing" — reformatted ImpossibilityCohortSection.
+          Preserves the existing text copy ("won't get any parent request fulfilled",
+          "impossible requests total") so pre-existing tests keep passing.
+          Named card approach per Option B visual language. */}
+      {mpImpossible.length > 0 && (
+        <div className="px-5 pt-4">
+          <div className="rounded-xl border border-red-200 bg-red-50/40 p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="font-semibold text-red-800">Campers who got nothing</h3>
+                <p className="mt-0.5 text-xs text-red-700/80">
+                  {mpImpossible.length} camper{mpImpossible.length === 1 ? '' : 's'} won&rsquo;t get
+                  any parent request fulfilled
+                </p>
+                <p className="text-xs text-red-700/60">
+                  {totalImpossibleRequests} impossible request
+                  {totalImpossibleRequests === 1 ? '' : 's'} total in this scenario
+                </p>
+              </div>
+              <span className="rounded-full bg-red-200/80 px-2.5 py-1 text-xs font-medium text-red-800">
+                {mpImpossible.length}
+              </span>
+            </div>
+            <ul className="mt-3 grid grid-cols-1 gap-2 text-sm sm:grid-cols-2">
+              {mpImpossible.map((c) => (
+                <li
+                  key={c.cm_id}
+                  className="flex items-center justify-between rounded-lg bg-white px-3 py-2"
+                >
+                  <div className="flex-1">
+                    <button
+                      type="button"
+                      className="text-left font-medium text-stone-900 hover:text-red-700"
+                      onClick={() => setSelectedCamperId(String(c.cm_id))}
+                    >
+                      {c.name}
+                    </button>
+                    {c.reason_codes.length > 0 && (
+                      <span className="ml-2 text-xs text-stone-500">
+                        {camperActionHints(c.reason_codes)}
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex flex-wrap justify-end gap-1">
+                    {c.reason_codes.map((code) => (
+                      <span
+                        key={code}
+                        className="rounded-full bg-amber-200 px-2 py-0.5 text-xs text-amber-900"
+                      >
+                        {friendlyReasonLabel(code)}
+                      </span>
+                    ))}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
 
       {preCheckError && !impossibilityReport && (
         <div className="px-5 py-2">
           <div className="rounded-lg border border-amber-200 bg-amber-50 p-2 text-xs text-amber-900">
             Pre-check unavailable — couldn&rsquo;t load the impossibility cohort. Re-run Pre-Check
             to see it.
+          </div>
+        </div>
+      )}
+
+      {/* TG-4.6: "Impossible by reason" — by_reason breakdown from pre-check.
+          Shows as collapsible stat tiles in post-check's card visual language. */}
+      {impossibilityReport && Object.keys(impossibilityReport.by_reason).length > 0 && (
+        <div className="px-5 pt-3">
+          <div className="rounded-xl border border-stone-200 bg-stone-50 p-4">
+            <h3 className="font-semibold text-stone-900">Impossible by reason</h3>
+            <p className="mt-0.5 text-xs text-stone-500">
+              Why these requests can&rsquo;t be satisfied — from the latest pre-check
+            </p>
+            <ul className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3">
+              {Object.entries(impossibilityReport.by_reason).map(([code, items]) => (
+                <li key={code} className="flex flex-col rounded-lg bg-white px-3 py-2 text-center">
+                  <span className="text-foreground text-lg font-bold">{items.length}</span>
+                  <span className="text-muted-foreground text-xs">{friendlyReasonLabel(code)}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+
+      {/* TG-4.4: "Families to call" — not_bunk_with violations detail list.
+          Shows requester/target pairs and the bunk where they both ended up. */}
+      {(statistics.negative_request_violations_detail ?? []).length > 0 && (
+        <div className="px-5 pt-3">
+          <div className="rounded-xl border border-amber-200 bg-amber-50/40 p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="font-semibold text-amber-900">Families to call</h3>
+                <p className="text-xs text-amber-800/80">
+                  Material <em>do not bunk with</em> wasn&rsquo;t honored — heads-up calls
+                  recommended
+                </p>
+              </div>
+              <span className="rounded-full bg-amber-200/80 px-2.5 py-1 text-xs font-medium text-amber-900">
+                {(statistics.negative_request_violations_detail ?? []).length}
+              </span>
+            </div>
+            <ul className="mt-3 divide-y divide-amber-100 text-sm">
+              {(statistics.negative_request_violations_detail ?? []).map((v) => (
+                <li
+                  key={`${v.requester_cm_id}-${v.target_cm_id}-${v.bunk_cm_id}`}
+                  className="flex items-center justify-between py-2"
+                >
+                  <div>
+                    <button
+                      type="button"
+                      className="font-medium hover:text-amber-800"
+                      onClick={() => setSelectedCamperId(v.requester_cm_id)}
+                    >
+                      {v.requester_name}
+                    </button>
+                    <span> placed with </span>
+                    <button
+                      type="button"
+                      className="font-medium hover:text-amber-800"
+                      onClick={() => setSelectedCamperId(v.target_cm_id)}
+                    >
+                      {v.target_name}
+                    </button>
+                  </div>
+                  <span className="font-mono text-xs text-stone-500">{v.bunk_name}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+
+      {/* TG-4.5: "Priority unsuccessfuls" — priority-keyword-flagged requests that
+          didn't land. Uses priority_keyword_detected from TG-3 (PR #1474). */}
+      {(statistics.priority_unsuccessfuls ?? []).length > 0 && (
+        <div className="px-5 pt-3">
+          <div className="rounded-xl border border-stone-200 bg-stone-50 p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="font-semibold text-stone-900">Priority unsuccessfuls</h3>
+                <p className="text-xs text-stone-600">
+                  Parents explicitly marked these as priority — request didn&rsquo;t land
+                </p>
+              </div>
+              <span className="rounded-full bg-stone-200 px-2.5 py-1 text-xs font-medium text-stone-700">
+                {(statistics.priority_unsuccessfuls ?? []).length}
+              </span>
+            </div>
+            <ul className="mt-3 divide-y divide-stone-200 text-sm">
+              {(statistics.priority_unsuccessfuls ?? []).map((p) => (
+                <li
+                  key={`${p.requester_cm_id}-${p.target_cm_id}`}
+                  className="flex items-center justify-between py-2"
+                >
+                  <div>
+                    <button
+                      type="button"
+                      className="font-medium hover:text-stone-700"
+                      onClick={() => setSelectedCamperId(p.requester_cm_id)}
+                    >
+                      {p.requester_name}
+                    </button>
+                    <span> wanted </span>
+                    <button
+                      type="button"
+                      className="font-medium hover:text-stone-700"
+                      onClick={() => setSelectedCamperId(p.target_cm_id)}
+                    >
+                      {p.target_name}
+                    </button>
+                    <span className="text-xs text-stone-500 italic">
+                      {' '}
+                      &middot; &ldquo;{p.raw_text}&rdquo;
+                    </span>
+                  </div>
+                  <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs text-red-700">
+                    unmet
+                  </span>
+                </li>
+              ))}
+            </ul>
           </div>
         </div>
       )}

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -104,6 +104,8 @@ class MockBunkRequest:
     source: str | None = None  # "family" or "staff" (legacy column, derived via source_from_field post-#1142)
     ai_p1_reasoning: dict[str, Any] | None = None
     age_preference_target: str | None = None
+    priority_keyword_detected: bool = False  # TG-3: True when parent text had an explicit priority keyword
+    raw_text: str = ""  # TG-3: parent's original wording snippet
 
 
 @dataclass
@@ -2118,3 +2120,206 @@ def test_mp_camper_level_coverage_at_least_one_and_all() -> None:
     assert stats.mp_campers_total == 3
     assert stats.mp_campers_with_at_least_one_satisfied == 2  # Emma + Liam
     assert stats.mp_campers_with_all_satisfied == 1  # Emma only
+
+
+# ---------------------------------------------------------------------------
+# Task 4.1: negative_request_violations_detail
+# ---------------------------------------------------------------------------
+
+
+def test_negative_request_violations_detail_lists_unhonored_not_bunk_with():
+    """negative_request_violations_detail must list each not_bunk_with violation with full tuple.
+
+    When Riley Sam (1001) has a staff not_bunk_with request for Samuel Johnson (1002)
+    but both are assigned to Pine 3 (bunk 2003), the detail list must contain one entry
+    with requester_cm_id, target_cm_id, requester_name, target_name, bunk_cm_id, bunk_name.
+    The existing count field (negative_request_violations) must still equal 1.
+    """
+    session = _mock_session(cm_id="10000001", name="NegReqDetailFixture")
+    persons = [
+        MockPerson(campminder_id="1001", name="Riley Sam", grade=6),
+        MockPerson(campminder_id="1002", name="Samuel Johnson", grade=6),
+    ]
+    bunks = [MockBunk(campminder_id="2003", name="Pine 3", max_size=8)]
+    assignments = [
+        _mock_assignment("1001", "2003"),
+        _mock_assignment("1002", "2003"),
+    ]
+    requests = [
+        MockBunkRequest(
+            requester_person_cm_id="1001",
+            requested_person_cm_id="1002",
+            request_type="not_bunk_with",
+            status="resolved",
+            source_field=SourceField.STAFF_NOT_BUNK_WITH,
+            source="staff",
+        ),
+    ]
+
+    result = BunkingValidator().validate_bunking(
+        session=session,
+        bunks=bunks,
+        assignments=assignments,
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+    )
+    stats = result.statistics
+
+    assert stats.negative_request_violations == 1  # existing count preserved
+    assert len(stats.negative_request_violations_detail) == 1
+    detail = stats.negative_request_violations_detail[0]
+    assert detail["requester_cm_id"] == "1001"
+    assert detail["target_cm_id"] == "1002"
+    assert detail["requester_name"] == "Riley Sam"
+    assert detail["target_name"] == "Samuel Johnson"
+    assert detail["bunk_cm_id"] == "2003"
+    assert detail["bunk_name"] == "Pine 3"
+
+
+def test_negative_request_violations_detail_empty_when_no_violations():
+    """When not_bunk_with is honored (campers in different bunks), detail list is empty."""
+    session = _mock_session(cm_id="10000001", name="NegReqNoViolationFixture")
+    persons = [
+        MockPerson(campminder_id="1001", name="Riley Sam", grade=6),
+        MockPerson(campminder_id="1002", name="Samuel Johnson", grade=6),
+    ]
+    bunks = [
+        MockBunk(campminder_id="2001", name="Cedar 1", max_size=8),
+        MockBunk(campminder_id="2002", name="Cedar 2", max_size=8),
+    ]
+    assignments = [
+        _mock_assignment("1001", "2001"),
+        _mock_assignment("1002", "2002"),  # different bunk — request honored
+    ]
+    requests = [
+        MockBunkRequest(
+            requester_person_cm_id="1001",
+            requested_person_cm_id="1002",
+            request_type="not_bunk_with",
+            status="resolved",
+            source_field=SourceField.STAFF_NOT_BUNK_WITH,
+            source="staff",
+        ),
+    ]
+
+    result = BunkingValidator().validate_bunking(
+        session=session,
+        bunks=bunks,
+        assignments=assignments,
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+    )
+    stats = result.statistics
+
+    assert stats.negative_request_violations == 0
+    assert stats.negative_request_violations_detail == []
+
+
+# ---------------------------------------------------------------------------
+# Task 4.5: priority_unsuccessfuls
+# ---------------------------------------------------------------------------
+
+
+def test_priority_unsuccessfuls_lists_keyword_flagged_unmet_requests():
+    """priority_unsuccessfuls must list only requests with priority_keyword_detected=True that are unsatisfied.
+
+    Sophia Martinez (1005) wants to bunk with Mia Wilson (1006): priority_keyword_detected=True,
+    but they're in different bunks → unsatisfied → must appear in priority_unsuccessfuls.
+
+    Ethan Brown (1007) wants to bunk with Mason Lee (1008): priority_keyword_detected=False →
+    even though also unsatisfied, must NOT appear in priority_unsuccessfuls.
+    """
+    session = _mock_session(cm_id="10000002", name="PriorityUnsuccessfulFixture")
+    persons = [
+        MockPerson(campminder_id="1005", name="Sophia Martinez", grade=7),
+        MockPerson(campminder_id="1006", name="Mia Wilson", grade=7),
+        MockPerson(campminder_id="1007", name="Ethan Brown", grade=7),
+        MockPerson(campminder_id="1008", name="Mason Lee", grade=7),
+    ]
+    bunks = [
+        MockBunk(campminder_id="3001", name="Maple 1", max_size=8),
+        MockBunk(campminder_id="3002", name="Maple 2", max_size=8),
+        MockBunk(campminder_id="3003", name="Maple 3", max_size=8),
+        MockBunk(campminder_id="3004", name="Maple 4", max_size=8),
+    ]
+    assignments = [
+        _mock_assignment("1005", "3001"),
+        _mock_assignment("1006", "3002"),  # not together — Sophia's request unsatisfied
+        _mock_assignment("1007", "3003"),
+        _mock_assignment("1008", "3004"),  # not together — Ethan's request also unsatisfied
+    ]
+    requests = [
+        MockBunkRequest(
+            requester_person_cm_id="1005",
+            requested_person_cm_id="1006",
+            request_type="bunk_with",
+            status="resolved",
+            source_field=SourceField.BUNK_REQUEST_FORM,
+            source="family",
+            priority_keyword_detected=True,
+            raw_text="Mia is our top priority",
+        ),
+        MockBunkRequest(
+            requester_person_cm_id="1007",
+            requested_person_cm_id="1008",
+            request_type="bunk_with",
+            status="resolved",
+            source_field=SourceField.BUNK_REQUEST_FORM,
+            source="family",
+            priority_keyword_detected=False,
+            raw_text="bunk with Mason",
+        ),
+    ]
+
+    result = BunkingValidator().validate_bunking(
+        session=session,
+        bunks=bunks,
+        assignments=assignments,
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+    )
+    stats = result.statistics
+
+    assert len(stats.priority_unsuccessfuls) == 1
+    only = stats.priority_unsuccessfuls[0]
+    assert only["requester_name"] == "Sophia Martinez"
+    assert only["target_name"] == "Mia Wilson"
+    assert only["raw_text"] == "Mia is our top priority"
+    assert only["requester_cm_id"] == "1005"
+    assert only["target_cm_id"] == "1006"
+
+
+def test_priority_unsuccessfuls_empty_when_all_priority_requests_satisfied():
+    """When a priority-keyword request IS satisfied, it must not appear in priority_unsuccessfuls."""
+    session = _mock_session(cm_id="10000003", name="PrioritySatisfiedFixture")
+    persons = [
+        MockPerson(campminder_id="1005", name="Sophia Martinez", grade=7),
+        MockPerson(campminder_id="1006", name="Mia Wilson", grade=7),
+    ]
+    bunks = [MockBunk(campminder_id="3001", name="Maple 1", max_size=8)]
+    assignments = [
+        _mock_assignment("1005", "3001"),
+        _mock_assignment("1006", "3001"),  # same bunk — satisfied
+    ]
+    requests = [
+        MockBunkRequest(
+            requester_person_cm_id="1005",
+            requested_person_cm_id="1006",
+            request_type="bunk_with",
+            status="resolved",
+            source_field=SourceField.BUNK_REQUEST_FORM,
+            source="family",
+            priority_keyword_detected=True,
+            raw_text="Mia is our top priority",
+        ),
+    ]
+
+    result = BunkingValidator().validate_bunking(
+        session=session,
+        bunks=bunks,
+        assignments=assignments,
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+    )
+
+    assert result.statistics.priority_unsuccessfuls == []

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -14,7 +14,7 @@ from bunking.bunking_validator import (
     ValidationSeverity,
     ValidationStatistics,
 )
-from bunking.models import Bunk, BunkRequest, Person
+from bunking.models import Bunk, BunkAssignment, BunkRequest, Person
 from bunking.sync.bunk_request_processor.shared.constants import SourceField
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -2158,7 +2158,7 @@ def test_negative_request_violations_detail_lists_unhonored_not_bunk_with():
 
     result = BunkingValidator().validate_bunking(
         session=session,
-        bunks=bunks,
+        bunks=cast(list[Bunk], bunks),
         assignments=assignments,
         persons=cast(list[Person], persons),
         requests=cast(list[BunkRequest], requests),
@@ -2204,7 +2204,7 @@ def test_negative_request_violations_detail_empty_when_no_violations():
 
     result = BunkingValidator().validate_bunking(
         session=session,
-        bunks=bunks,
+        bunks=cast(list[Bunk], bunks),
         assignments=assignments,
         persons=cast(list[Person], persons),
         requests=cast(list[BunkRequest], requests),
@@ -2273,7 +2273,7 @@ def test_priority_unsuccessfuls_lists_keyword_flagged_unmet_requests():
 
     result = BunkingValidator().validate_bunking(
         session=session,
-        bunks=bunks,
+        bunks=cast(list[Bunk], bunks),
         assignments=assignments,
         persons=cast(list[Person], persons),
         requests=cast(list[BunkRequest], requests),
@@ -2316,7 +2316,7 @@ def test_priority_unsuccessfuls_empty_when_all_priority_requests_satisfied():
 
     result = BunkingValidator().validate_bunking(
         session=session,
-        bunks=bunks,
+        bunks=cast(list[Bunk], bunks),
         assignments=assignments,
         persons=cast(list[Person], persons),
         requests=cast(list[BunkRequest], requests),

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -14,7 +14,7 @@ from bunking.bunking_validator import (
     ValidationSeverity,
     ValidationStatistics,
 )
-from bunking.models import Bunk, BunkAssignment, BunkRequest, Person
+from bunking.models import Bunk, BunkRequest, Person
 from bunking.sync.bunk_request_processor.shared.constants import SourceField
 
 # ---------------------------------------------------------------------------
@@ -2216,6 +2216,132 @@ def test_negative_request_violations_detail_empty_when_no_violations():
 
 
 # ---------------------------------------------------------------------------
+# Fix 1 (TG-4): priority_keyword_detected + raw_text wired through BunkRequest model
+# ---------------------------------------------------------------------------
+
+
+def test_priority_unsuccessfuls_raw_text_populated_from_bunk_request():
+    """BunkRequest.priority_keyword_detected and .raw_text must be present on the dataclass
+    and propagate through to priority_unsuccessfuls entries.
+
+    Emma Johnson (2001) requests bunk_with Liam Garcia (2002) with priority_keyword_detected=True
+    and raw_text="Emma must bunk with Liam". They are in different bunks → request unsatisfied
+    → priority_unsuccessfuls must contain one entry with the correct raw_text.
+
+    This test exercises the BunkRequest model fields directly (Fix 1). If the fields are missing,
+    the validator falls back to getattr(..., "") and the assertion on raw_text fails.
+    """
+    from bunking.models import BunkRequest as RealBunkRequest
+
+    session = _mock_session(cm_id="10000010", name="Fix1Fixture")
+    persons = [
+        MockPerson(campminder_id="2001", name="Emma Johnson", grade=5),
+        MockPerson(campminder_id="2002", name="Liam Garcia", grade=5),
+    ]
+    bunks = [
+        MockBunk(campminder_id="4001", name="Oak 1", max_size=8),
+        MockBunk(campminder_id="4002", name="Oak 2", max_size=8),
+    ]
+    assignments = [
+        _mock_assignment("2001", "4001"),
+        _mock_assignment("2002", "4002"),  # different bunk → unsatisfied
+    ]
+    # Use real BunkRequest (not Mock) to verify the fields exist on the dataclass
+    real_request = RealBunkRequest(
+        requester_person_cm_id="2001",
+        requested_person_cm_id="2002",
+        request_type="bunk_with",
+        status="resolved",
+        session_cm_id="10000010",
+        year=2025,
+        source_field="bunk_request_form",
+        priority_keyword_detected=True,
+        raw_text="Emma must bunk with Liam",
+    )
+
+    result = BunkingValidator().validate_bunking(
+        session=session,
+        bunks=cast(list[Bunk], bunks),
+        assignments=assignments,
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], [real_request]),
+    )
+    stats = result.statistics
+
+    assert len(stats.priority_unsuccessfuls) == 1
+    entry = stats.priority_unsuccessfuls[0]
+    assert entry["requester_cm_id"] == "2001"
+    assert entry["target_cm_id"] == "2002"
+    assert entry["raw_text"] == "Emma must bunk with Liam"
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 (TG-4): mixed-outcome campers must still appear in negative_request_violations_detail
+# ---------------------------------------------------------------------------
+
+
+def test_negative_violations_detail_populated_for_mixed_outcome_camper():
+    """A camper with ≥1 satisfied bunk_with AND ≥1 violated not_bunk_with must appear
+    in negative_request_violations_detail (Fix 2).
+
+    Scenario:
+      - Olivia Chen (3001) has bunk_with(Riley Sam/3002) → SATISFIED (same bunk 5001)
+      - Olivia Chen (3001) has not_bunk_with(Samuel Johnson/3003) → VIOLATED (same bunk 5001)
+
+    Pre-fix: the not_bunk_with detail loop is inside the satisfaction-zero guard, so
+    Olivia is skipped (she has 1 satisfied alerting request). Detail list stays empty.
+    Post-fix: detail loop runs regardless of satisfaction mix.
+    """
+    session = _mock_session(cm_id="10000011", name="Fix2Fixture")
+    persons = [
+        MockPerson(campminder_id="3001", name="Olivia Chen", grade=6),
+        MockPerson(campminder_id="3002", name="Riley Sam", grade=6),
+        MockPerson(campminder_id="3003", name="Samuel Johnson", grade=6),
+    ]
+    bunks = [MockBunk(campminder_id="5001", name="Pine 1", max_size=10)]
+    assignments = [
+        _mock_assignment("3001", "5001"),
+        _mock_assignment("3002", "5001"),  # same bunk as Olivia → bunk_with satisfied
+        _mock_assignment("3003", "5001"),  # same bunk as Olivia → not_bunk_with violated
+    ]
+    requests = [
+        MockBunkRequest(
+            requester_person_cm_id="3001",
+            requested_person_cm_id="3002",
+            request_type="bunk_with",
+            status="resolved",
+            source_field=SourceField.BUNK_REQUEST_FORM,
+            source="family",
+        ),
+        MockBunkRequest(
+            requester_person_cm_id="3001",
+            requested_person_cm_id="3003",
+            request_type="not_bunk_with",
+            status="resolved",
+            source_field=SourceField.BUNK_REQUEST_FORM,
+            source="family",
+        ),
+    ]
+
+    result = BunkingValidator().validate_bunking(
+        session=session,
+        bunks=cast(list[Bunk], bunks),
+        assignments=assignments,
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+    )
+    stats = result.statistics
+
+    # The not_bunk_with violation MUST appear in the detail list regardless of
+    # Olivia having a satisfied bunk_with request.
+    assert stats.negative_request_violations == 1
+    assert len(stats.negative_request_violations_detail) == 1
+    violation = stats.negative_request_violations_detail[0]
+    assert violation["requester_cm_id"] == "3001"
+    assert violation["target_cm_id"] == "3003"
+
+
+# ---------------------------------------------------------------------------
 # Task 4.5: priority_unsuccessfuls
 # ---------------------------------------------------------------------------
 
@@ -2223,18 +2349,18 @@ def test_negative_request_violations_detail_empty_when_no_violations():
 def test_priority_unsuccessfuls_lists_keyword_flagged_unmet_requests():
     """priority_unsuccessfuls must list only requests with priority_keyword_detected=True that are unsatisfied.
 
-    Sophia Martinez (1005) wants to bunk with Mia Wilson (1006): priority_keyword_detected=True,
+    Olivia Chen (1005) wants to bunk with Liam Garcia (1006): priority_keyword_detected=True,
     but they're in different bunks → unsatisfied → must appear in priority_unsuccessfuls.
 
-    Ethan Brown (1007) wants to bunk with Mason Lee (1008): priority_keyword_detected=False →
+    Samuel Johnson (1007) wants to bunk with Riley Sam (1008): priority_keyword_detected=False →
     even though also unsatisfied, must NOT appear in priority_unsuccessfuls.
     """
     session = _mock_session(cm_id="10000002", name="PriorityUnsuccessfulFixture")
     persons = [
-        MockPerson(campminder_id="1005", name="Sophia Martinez", grade=7),
-        MockPerson(campminder_id="1006", name="Mia Wilson", grade=7),
-        MockPerson(campminder_id="1007", name="Ethan Brown", grade=7),
-        MockPerson(campminder_id="1008", name="Mason Lee", grade=7),
+        MockPerson(campminder_id="1005", name="Olivia Chen", grade=7),
+        MockPerson(campminder_id="1006", name="Liam Garcia", grade=7),
+        MockPerson(campminder_id="1007", name="Samuel Johnson", grade=7),
+        MockPerson(campminder_id="1008", name="Riley Sam", grade=7),
     ]
     bunks = [
         MockBunk(campminder_id="3001", name="Maple 1", max_size=8),
@@ -2244,9 +2370,9 @@ def test_priority_unsuccessfuls_lists_keyword_flagged_unmet_requests():
     ]
     assignments = [
         _mock_assignment("1005", "3001"),
-        _mock_assignment("1006", "3002"),  # not together — Sophia's request unsatisfied
+        _mock_assignment("1006", "3002"),  # not together — Olivia's request unsatisfied
         _mock_assignment("1007", "3003"),
-        _mock_assignment("1008", "3004"),  # not together — Ethan's request also unsatisfied
+        _mock_assignment("1008", "3004"),  # not together — Samuel's request also unsatisfied
     ]
     requests = [
         MockBunkRequest(
@@ -2257,7 +2383,7 @@ def test_priority_unsuccessfuls_lists_keyword_flagged_unmet_requests():
             source_field=SourceField.BUNK_REQUEST_FORM,
             source="family",
             priority_keyword_detected=True,
-            raw_text="Mia is our top priority",
+            raw_text="Liam is our top priority",
         ),
         MockBunkRequest(
             requester_person_cm_id="1007",
@@ -2267,7 +2393,7 @@ def test_priority_unsuccessfuls_lists_keyword_flagged_unmet_requests():
             source_field=SourceField.BUNK_REQUEST_FORM,
             source="family",
             priority_keyword_detected=False,
-            raw_text="bunk with Mason",
+            raw_text="bunk with Riley",
         ),
     ]
 
@@ -2282,9 +2408,9 @@ def test_priority_unsuccessfuls_lists_keyword_flagged_unmet_requests():
 
     assert len(stats.priority_unsuccessfuls) == 1
     only = stats.priority_unsuccessfuls[0]
-    assert only["requester_name"] == "Sophia Martinez"
-    assert only["target_name"] == "Mia Wilson"
-    assert only["raw_text"] == "Mia is our top priority"
+    assert only["requester_name"] == "Olivia Chen"
+    assert only["target_name"] == "Liam Garcia"
+    assert only["raw_text"] == "Liam is our top priority"
     assert only["requester_cm_id"] == "1005"
     assert only["target_cm_id"] == "1006"
 
@@ -2293,8 +2419,8 @@ def test_priority_unsuccessfuls_empty_when_all_priority_requests_satisfied():
     """When a priority-keyword request IS satisfied, it must not appear in priority_unsuccessfuls."""
     session = _mock_session(cm_id="10000003", name="PrioritySatisfiedFixture")
     persons = [
-        MockPerson(campminder_id="1005", name="Sophia Martinez", grade=7),
-        MockPerson(campminder_id="1006", name="Mia Wilson", grade=7),
+        MockPerson(campminder_id="1005", name="Olivia Chen", grade=7),
+        MockPerson(campminder_id="1006", name="Liam Garcia", grade=7),
     ]
     bunks = [MockBunk(campminder_id="3001", name="Maple 1", max_size=8)]
     assignments = [
@@ -2310,7 +2436,7 @@ def test_priority_unsuccessfuls_empty_when_all_priority_requests_satisfied():
             source_field=SourceField.BUNK_REQUEST_FORM,
             source="family",
             priority_keyword_detected=True,
-            raw_text="Mia is our top priority",
+            raw_text="Liam is our top priority",
         ),
     ]
 


### PR DESCRIPTION
## Summary

Post-check modal grows three named-list action sections and reformats two pre-check sections into post-check's card visual language (Option B — reformatted, not verbatim).

**Three new named-list sections:**
- **Campers who got nothing** — narrow definition: MP campers with ZERO satisfiable requests (sourced from `impossibilityReport.mp_campers_entirely_impossible`)
- **Families to call** — material `do not bunk with` requests that weren't honored (sourced from new backend field `negative_request_violations_detail`)
- **Priority unsuccessfuls** — explicit-keyword requests (filtered by `priority_keyword_detected=true` from #1474) that the solver couldn't satisfy

**Two reformatted pre-check sections:**
- Impossibility by reason
- Capacity by gender

## Backend additions to `ValidationStatistics`

- `negative_request_violations_detail: list[NegativeRequestViolation]` — used by Families to call
- `priority_unsuccessfuls: list[...]` — used by Priority unsuccessfuls
- Existing `negative_request_violations` count stays for backward compat with `ScenarioComparisonPage`

## Dependency note

This PR temporarily includes the commits from #1474 (`feature/priority-keyword-signal`) because TG-4 reads `priority_keyword_detected` from that schema field. Once #1474 merges, this diff will auto-shrink to just the TG-4 additions.

## Test plan

- [x] Backend: new pytest cases for `negative_request_violations_detail` and `priority_unsuccessfuls`; existing validator suite stays green
- [x] Frontend: render tests for each new card section ("Campers who got nothing", "Families to call", "Priority unsuccessfuls")
- [x] Reformatted sections render in post-check's card language
- [ ] Manual smoke: open post-check modal with known-bad scenario, confirm sections populate with real data
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced validation results display with new sections: "Families to call" for unmet request conflicts, "Priority unsuccessfuls" for unmet high-priority requests, and "Impossible by reason" breakdown.
  * Improved conflict tracking and visibility for bunking assignments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->