### PR TITLE
feat(data,frontend): add staff_touched flag to bunk_requests (#1458)

### DIFF
--- a/frontend/src/components/AllCamperRequestsModal.test.tsx
+++ b/frontend/src/components/AllCamperRequestsModal.test.tsx
@@ -313,7 +313,7 @@ describe('AllCamperRequestsModal inline actions', () => {
     expect(screen.getByText(/approve this request\?/i)).toBeTruthy()
   })
 
-  it('confirming Approve calls pb.update with status=resolved (no request_locked)', async () => {
+  it('confirming Approve calls pb.update with status=resolved + staff_touched=true', async () => {
     bunkRequestsFixture = [pendingBunkWith]
     personsFixture = [{ cm_id: 1000002, first_name: 'Liam', last_name: 'Garcia', year: 2026 }]
     renderModal()
@@ -322,11 +322,12 @@ describe('AllCamperRequestsModal inline actions', () => {
     await waitFor(() =>
       expect(updateMock).toHaveBeenCalledWith('req1', {
         status: 'resolved',
+        staff_touched: true,
       })
     )
   })
 
-  it('confirming Decline calls pb.update with status=declined (no request_locked)', async () => {
+  it('confirming Decline calls pb.update with status=declined + staff_touched=true', async () => {
     bunkRequestsFixture = [pendingBunkWith]
     personsFixture = [{ cm_id: 1000002, first_name: 'Liam', last_name: 'Garcia', year: 2026 }]
     renderModal()
@@ -335,6 +336,7 @@ describe('AllCamperRequestsModal inline actions', () => {
     await waitFor(() =>
       expect(updateMock).toHaveBeenCalledWith('req1', {
         status: 'declined',
+        staff_touched: true,
       })
     )
   })
@@ -611,5 +613,53 @@ describe('AllCamperRequestsModal — target picker', () => {
 
     // Must NOT find a CamperLink (no resolved target)
     expect(screen.queryByRole('link', { name: /Liam Garcia/i })).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// staff_touched badge (issue #1458)
+// ---------------------------------------------------------------------------
+describe('AllCamperRequestsModal — staff_touched badge', () => {
+  it('renders a "staff edited" badge on cards with staff_touched=true', async () => {
+    bunkRequestsFixture = [
+      {
+        id: 'r-touched',
+        request_type: 'bunk_with',
+        requestee_id: 1000002,
+        requested_person_name: 'Liam Garcia',
+        status: 'resolved',
+        confidence_score: 0.9,
+        source_field: 'bunk_with',
+        source_fragment: 'Liam Garcia',
+        parse_notes: 'n',
+        staff_touched: true,
+        year: 2026,
+      },
+    ]
+    personsFixture = [{ cm_id: 1000002, first_name: 'Liam', last_name: 'Garcia', year: 2026 }]
+    renderModal()
+    expect(await screen.findByText(/staff edited/i)).toBeInTheDocument()
+  })
+
+  it('does not render a "staff edited" badge when staff_touched is false/undefined', async () => {
+    bunkRequestsFixture = [
+      {
+        id: 'r-pristine',
+        request_type: 'bunk_with',
+        requestee_id: 1000002,
+        requested_person_name: 'Liam Garcia',
+        status: 'resolved',
+        confidence_score: 0.9,
+        source_field: 'bunk_with',
+        source_fragment: 'Liam Garcia',
+        parse_notes: 'n',
+        year: 2026,
+      },
+    ]
+    personsFixture = [{ cm_id: 1000002, first_name: 'Liam', last_name: 'Garcia', year: 2026 }]
+    renderModal()
+    // Wait for card to render
+    await screen.findByText('Liam Garcia')
+    expect(screen.queryByText(/staff edited/i)).toBeNull()
   })
 })

--- a/frontend/src/components/AllCamperRequestsModal.tsx
+++ b/frontend/src/components/AllCamperRequestsModal.tsx
@@ -165,10 +165,13 @@ export function AllCamperRequestsModal({
 
   const handleConfirmCancel = useCallback(() => setConfirmPopover(null), [setConfirmPopover])
 
+  // SINGLE CHOKEPOINT for all bunk_requests writes from this modal — including
+  // the ConfirmActionPopover approve/decline path, which calls
+  // updateRequestMutation.mutate() rather than pb.collection().update() directly.
+  // Any new GUI-originated update path in this component MUST go through this
+  // mutation so the staff_touched: true stamp is applied uniformly. Issue #1458.
   const updateRequestMutation = useMutation({
     mutationFn: async ({ id, updates }: { id: string; updates: Partial<BunkRequestsResponse> }) =>
-      // GUI-originated write → flip staff_touched true so the audit signal
-      // sticks for any subsequent reader. Issue #1458.
       pb.collection('bunk_requests').update(id, { ...updates, staff_touched: true }),
     onSuccess: () => {
       void queryClient.invalidateQueries({

--- a/frontend/src/components/AllCamperRequestsModal.tsx
+++ b/frontend/src/components/AllCamperRequestsModal.tsx
@@ -65,6 +65,14 @@ function RequestCard({
             {request.status}
             {request.disposition_reason ? ` · ${formatReason(request.disposition_reason)}` : ''}
           </span>
+          {request.staff_touched && (
+            <span
+              title="A staff user has manually edited this request — the source/notes shown reflect the pipeline's original parse, not the current state."
+              className="border-border bg-muted text-muted-foreground inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium"
+            >
+              Staff edited
+            </span>
+          )}
           {onAction && (
             <div className="flex items-center gap-1">
               <button
@@ -159,7 +167,9 @@ export function AllCamperRequestsModal({
 
   const updateRequestMutation = useMutation({
     mutationFn: async ({ id, updates }: { id: string; updates: Partial<BunkRequestsResponse> }) =>
-      pb.collection('bunk_requests').update(id, updates),
+      // GUI-originated write → flip staff_touched true so the audit signal
+      // sticks for any subsequent reader. Issue #1458.
+      pb.collection('bunk_requests').update(id, { ...updates, staff_touched: true }),
     onSuccess: () => {
       void queryClient.invalidateQueries({
         queryKey: queryKeys.camperRequestSummary(requesterCmId, year),

--- a/frontend/src/components/RequestReviewPanel.test.tsx
+++ b/frontend/src/components/RequestReviewPanel.test.tsx
@@ -1280,6 +1280,7 @@ describe('RequestReviewPanel', () => {
 
       expect(updateSpy).toHaveBeenCalledWith('req-approve-1', {
         status: 'resolved',
+        staff_touched: true,
       })
     }, 10000)
 
@@ -1311,6 +1312,7 @@ describe('RequestReviewPanel', () => {
 
       expect(updateSpy).toHaveBeenCalledWith('req-reject-1', {
         status: 'declined',
+        staff_touched: true,
       })
     }, 10000)
   })
@@ -1557,9 +1559,11 @@ describe('RequestReviewPanel', () => {
 
       await waitFor(
         () => {
-          // inverse mutation: PATCH back to pending
+          // inverse mutation: PATCH back to pending; undo is still a staff
+          // action so staff_touched stays true (one-way flag, idempotent re-set)
           expect(updateSpy).toHaveBeenCalledWith('req-undo-2', {
             status: 'pending',
+            staff_touched: true,
           })
         },
         { timeout: 3000 }
@@ -1922,6 +1926,7 @@ describe('RequestReviewPanel', () => {
       await waitFor(() => {
         expect(updateSpy).toHaveBeenCalledWith('req-undo-3', {
           status: 'declined',
+          staff_touched: true,
         })
       })
 

--- a/frontend/src/components/RequestReviewPanel.test.tsx
+++ b/frontend/src/components/RequestReviewPanel.test.tsx
@@ -1904,6 +1904,138 @@ describe('RequestReviewPanel', () => {
       expect(pendingPatches.length).toBeGreaterThanOrEqual(2)
     }, 30000)
 
+    /**
+     * Bulk-action A→A skip: when a staff user bulk-approves a selection that
+     * includes rows already in the target status (e.g. status='resolved'),
+     * those rows are no-ops and MUST NOT be PATCHed at all. Only rows that
+     * actually change state get the staff_touched stamp. This keeps the
+     * audit signal honest: bulk-approve on an already-resolved row is not
+     * a "staff edit," it's a non-event.
+     */
+    it('bulk approve skips rows already in target status (no PATCH, no staff_touched)', async () => {
+      window.localStorage.setItem(
+        'kindred-requests-filters-1001',
+        JSON.stringify({
+          filters: {
+            requestTypes: [],
+            statuses: ['pending', 'declined', 'resolved'],
+            searchQuery: '',
+          },
+          sort: { sortBy: 'requester', sortOrder: 'asc' },
+        })
+      )
+
+      const records: BunkRequestsResponse[] = [
+        {
+          id: 'bulk-aa-pending',
+          requester_id: 610,
+          requestee_id: 611,
+          session_id: 1001,
+          year: 2025,
+          status: 'pending',
+          request_type: 'bunk_with',
+          confidence_score: 0.8,
+        } as BunkRequestsResponse,
+        {
+          id: 'bulk-aa-already-resolved',
+          requester_id: 620,
+          requestee_id: 621,
+          session_id: 1001,
+          year: 2025,
+          status: 'resolved',
+          request_type: 'bunk_with',
+          confidence_score: 0.7,
+        } as BunkRequestsResponse,
+      ]
+
+      const { pb } = (await import('../lib/pocketbase')) as unknown as {
+        pb: { collection: ReturnType<typeof vi.fn> }
+      }
+
+      const updateCalls: Array<{ id: string; updates: Partial<BunkRequestsResponse> }> = []
+
+      pb.collection.mockImplementation((name: string) => {
+        if (name === 'bunk_requests') {
+          return {
+            getFullList: vi.fn(async () => records.map((r) => ({ ...r }))),
+            getList: vi.fn(async () => ({
+              items: records.map((r) => ({ ...r })),
+              totalItems: records.length,
+            })),
+            update: vi.fn(async (id: string, updates: Partial<BunkRequestsResponse>) => {
+              updateCalls.push({ id, updates: { ...updates } })
+              const rec = records.find((r) => r.id === id)
+              if (rec) Object.assign(rec, updates)
+              return { ...rec }
+            }),
+          }
+        }
+        return {
+          getFullList: vi.fn().mockResolvedValue([]),
+          getList: vi.fn().mockResolvedValue({ items: [], totalItems: 0 }),
+          update: vi.fn().mockResolvedValue({}),
+        }
+      })
+
+      render(<RequestReviewPanel sessionId={1001} year={2025} />)
+      const user = userEvent.setup()
+
+      // Wait for both rows to render
+      await waitFor(
+        () => {
+          expect(screen.getAllByRole('checkbox').length).toBeGreaterThanOrEqual(3) // select-all + 2 rows
+        },
+        { timeout: 3000 }
+      )
+
+      // Select both rows via row checkboxes (skip already-checked select-all).
+      const allCheckboxes = screen.getAllByRole('checkbox')
+      for (const cb of allCheckboxes) {
+        if ((cb as HTMLInputElement).checked) continue
+        fireEvent.click(cb)
+        const toolbar = screen.queryByRole('toolbar', { name: /bulk actions/i })
+        if (toolbar && within(toolbar).queryByText(/^2 selected$/)) break
+      }
+
+      // Bulk Approve button in the sticky toolbar.
+      const toolbar = await waitFor(
+        () => {
+          const t = screen.queryByRole('toolbar', { name: /bulk actions/i })
+          if (!t) throw new Error('no toolbar yet')
+          if (!within(t).queryByText(/^2 selected$/)) throw new Error('not 2 selected yet')
+          return t
+        },
+        { timeout: 3000 }
+      )
+      const approveBtn = within(toolbar).getByRole('button', { name: /approve/i })
+      await user.click(approveBtn)
+
+      // Confirm in the bulk dialog.
+      const dialog = await screen.findByRole('dialog')
+      const approveConfirm = within(dialog).getByRole('button', { name: 'Approve' })
+      await user.click(approveConfirm)
+
+      // Wait for the pending row's PATCH to land.
+      await waitFor(
+        () => {
+          expect(updateCalls.some((c) => c.id === 'bulk-aa-pending')).toBe(true)
+        },
+        { timeout: 5000 }
+      )
+
+      // Pending row → PATCHed with status=resolved AND staff_touched=true.
+      const pendingPatch = updateCalls.find((c) => c.id === 'bulk-aa-pending')
+      expect(pendingPatch).toBeDefined()
+      expect(pendingPatch!.updates).toMatchObject({
+        status: 'resolved',
+        staff_touched: true,
+      })
+
+      // Already-resolved row → MUST NOT be PATCHed (no-op skip).
+      const noopCalls = updateCalls.filter((c) => c.id === 'bulk-aa-already-resolved')
+      expect(noopCalls).toHaveLength(0)
+    }, 20000)
+
     it('clicking Undo after decline restores status to pending', async () => {
       const { updateSpy, findButtonByTitle, user } = await renderPanelWithRequest({
         id: 'req-undo-3',

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -530,7 +530,10 @@ export default function RequestReviewPanel({
 
   const updateRequestMutation = useMutation<BunkRequestsResponse, Error, UpdateRequestVars>({
     mutationFn: async ({ id, updates }: UpdateRequestVars) => {
-      return pb.collection('bunk_requests').update(id, updates)
+      // GUI-originated write → flip staff_touched true so the audit signal
+      // sticks for any subsequent reader. One-way flag, idempotent re-set.
+      // Issue #1458.
+      return pb.collection('bunk_requests').update(id, { ...updates, staff_touched: true })
     },
     onSuccess: (_data, variables) => {
       invalidateRequestQueries(queryClient)
@@ -551,7 +554,11 @@ export default function RequestReviewPanel({
       ids: string[]
       updates: Partial<BunkRequestsResponse>
     }) => {
-      return Promise.all(ids.map((id) => pb.collection('bunk_requests').update(id, updates)))
+      return Promise.all(
+        ids.map((id) =>
+          pb.collection('bunk_requests').update(id, { ...updates, staff_touched: true })
+        )
+      )
     },
     onSuccess: () => {
       invalidateRequestQueries(queryClient)
@@ -592,7 +599,9 @@ export default function RequestReviewPanel({
               id,
               label: `Reverted ${labelVerb} of ${requesterName}`,
               inverse: async () => {
-                await pb.collection('bunk_requests').update(id, { status: priorStatus })
+                await pb
+                  .collection('bunk_requests')
+                  .update(id, { status: priorStatus, staff_touched: true })
                 invalidateRequestQueries(queryClient)
               },
             })
@@ -646,7 +655,9 @@ export default function RequestReviewPanel({
               inverse: async () => {
                 await Promise.all(
                   priors.map((p) =>
-                    pb.collection('bunk_requests').update(p.id, { status: p.status })
+                    pb
+                      .collection('bunk_requests')
+                      .update(p.id, { status: p.status, staff_touched: true })
                   )
                 )
                 invalidateRequestQueries(queryClient)

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -554,10 +554,23 @@ export default function RequestReviewPanel({
       ids: string[]
       updates: Partial<BunkRequestsResponse>
     }) => {
+      // A→A skip: bulk actions select rows en masse, and the selection may
+      // include rows already in the target state (e.g. bulk-approve over a
+      // mix of pending and already-resolved). For those, the PATCH would be
+      // a no-op — skip entirely so staff_touched stays honest (audit signal
+      // = "a human actually changed this row," not "a human clicked while
+      // this row was in the selection"). Issue #1458.
+      const updateKeys = Object.keys(updates) as Array<keyof BunkRequestsResponse>
       return Promise.all(
-        ids.map((id) =>
-          pb.collection('bunk_requests').update(id, { ...updates, staff_touched: true })
-        )
+        ids
+          .filter((id) => {
+            const current = requests.find((r: BunkRequestsResponse) => r.id === id)
+            if (!current) return true // unknown row — let server decide
+            return updateKeys.some((k) => current[k] !== updates[k])
+          })
+          .map((id) =>
+            pb.collection('bunk_requests').update(id, { ...updates, staff_touched: true })
+          )
       )
     },
     onSuccess: () => {

--- a/frontend/src/types/pocketbase-types.ts
+++ b/frontend/src/types/pocketbase-types.ts
@@ -326,6 +326,7 @@ export type BunkRequestsRecord<
   source_field: string
   source_fields?: null | Tsource_fields
   source_fragment?: string
+  staff_touched?: boolean
   status: BunkRequestsStatusOptions
   updated: IsoAutoDateString
   was_dropped_for_spread?: boolean

--- a/pocketbase/pb_migrations/1500000102_bunk_requests_staff_touched.js
+++ b/pocketbase/pb_migrations/1500000102_bunk_requests_staff_touched.js
@@ -1,0 +1,29 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: Add staff_touched bool to bunk_requests
+ *
+ * One-way flag set by GUI-originated mutations to mark that a staff user
+ * has manually edited this row (target, type, status, age-pref, etc.).
+ * Pipeline / sync / AI-parse writes leave the field alone, so the default
+ * false persists for machine-authored rows. Survives subsequent overrides
+ * (re-setting is idempotent) so the audit signal isn't lost on multi-edit.
+ */
+
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("bunk_requests");
+
+  collection.fields.add(new Field({
+    type: "bool",
+    name: "staff_touched",
+    required: false,
+    presentable: false
+  }));
+
+  app.save(collection);
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("bunk_requests");
+
+  collection.fields.removeByName("staff_touched");
+
+  app.save(collection);
+});


### PR DESCRIPTION
## Summary
- One-way `staff_touched: bool` on `bunk_requests`, flipped true by any GUI-originated mutation (5 callsites in `RequestReviewPanel` + `AllCamperRequestsModal`); pipeline / sync / AI-parse paths don't reference the field, so default-false persists for machine-authored rows.
- "Staff edited" chip rendered in `AllCamperRequestsModal` next to the status badge when `staff_touched=true` — preserves the audit trail (modal continues to show the pipeline's original `disposition_reason` / `source_field` / `parse_notes`) while signalling the row has been overridden since.
- Flag is one-way / idempotent re-set so multi-edit doesn't lose the audit signal (rejected the `previous_disposition_reason` approach for exactly this reason during scoping).

Closes #1458.

## Test plan
- [x] PB migration `1500000102_bunk_requests_staff_touched.js` lints clean; up + down both reverse-applied
- [x] 4 existing strict-equality assertions in `RequestReviewPanel.test.tsx` + 2 in `AllCamperRequestsModal.test.tsx` updated to expect `staff_touched: true` — failed as RED before impl, pass after
- [x] 2 new tests in `AllCamperRequestsModal.test.tsx` for chip render / no-render based on flag value
- [x] Full frontend suite: 4272 / 4272 pass; tsc + eslint clean
- [ ] Verify post-merge: a staff-edited row shows the chip; a sync-created row does not
- [ ] Verify post-merge: re-running the sync pipeline over a staff-touched row preserves the flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Requests now show a "Staff edited" badge when staff have modified them, with a tooltip clarifying the UI source.
  * Approve/Decline/Undo actions now mark requests as staff-edited so changes are tracked consistently.
  * Bulk approve skips rows already in the target state and only marks actually-changed requests as staff-edited.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->