### PR TITLE
perf(scripts): scope pre-push verification to changed files + parallelize

### DIFF
--- a/.claude/skills/pre-push-verification/SKILL.md
+++ b/.claude/skills/pre-push-verification/SKILL.md
@@ -59,11 +59,20 @@ Python: `ruff format` must run before `ruff check`. Formatting changes can intro
 ### mypy uses `--explicit-package-bases`
 The lefthook pre-push hook runs `uv run mypy . --explicit-package-bases`. Always include that flag. Without it, mypy may fail to resolve cross-package imports.
 
-### Frontend lint uses `npm run lint`, not raw eslint
-The `package.json` script (`npm run lint`) includes the correct flags (`--ext ts,tsx --report-unused-disable-directives`). Do not call `npx eslint` directly with different flags.
+### Frontend lint runs on changed files only
+The script passes only `.ts`/`.tsx` files changed since `@{push}` (or merge-base on first push) to `npx eslint --report-unused-disable-directives`. This matches `npm run lint`'s ruleset but skips the directory walk. Prettier is similarly file-scoped (`.ts/.tsx/.js/.jsx/.css/.json`). If you need a full-repo lint, run `npm run lint` from `frontend/` directly.
 
 ### Frontend type-check checks TWO tsconfigs
-`npm run type-check` runs `tsc --noEmit && tsc --noEmit -p tsconfig.node.json`. Both must pass. If you only run one, you may miss errors in Vite config files.
+`npm run type-check` runs `tsc --noEmit && tsc --noEmit -p tsconfig.node.json`. Both must pass. If you only run one, you may miss errors in Vite config files. Type-check is NOT file-scoped — signature changes propagate, so it always runs over the whole project.
+
+### Frontend vitest runs only affected tests
+The script runs `npx vitest run --changed $BASE`, which uses vitest's dependency graph to skip test files whose source dependencies are unchanged. On small PRs this cuts a 4000+ test run to dozens. Use `--all` to bypass.
+
+### Frontend checks run in parallel
+prettier, eslint, tsc, and vitest run concurrently with per-tool output captured to a tempdir; results replay in stable order after all complete. Wall time ≈ slowest single check, not sum.
+
+### `BASE` defaults to `@{push}`
+The "what changed" reference for both file detection and `vitest --changed` is `git @{push}` (the upstream-tracked tip), so subsequent pushes on a PR only re-verify new unpushed commits. First push to a new branch falls back to `merge-base HEAD origin/main`. Outside any remote-tracking branch, falls back to `HEAD~1`.
 
 ### Python tests run only unit tests on push
 The pre-push hook runs `uv run pytest tests/unit/ -v --tb=short`, not the full test suite. Integration tests require a running server and are not part of pre-push.

--- a/.claude/skills/pre-push-verification/scripts/verify.sh
+++ b/.claude/skills/pre-push-verification/scripts/verify.sh
@@ -14,6 +14,14 @@
 
 set -euo pipefail
 
+# Associative arrays (declare -A) below require bash 4+. macOS ships 3.2 by
+# default — recommend `brew install bash` for contributors on that platform.
+if ((BASH_VERSINFO[0] < 4)); then
+    echo "Error: bash 4+ required (you have $BASH_VERSION)." >&2
+    echo "On macOS, install via Homebrew: brew install bash" >&2
+    exit 1
+fi
+
 # ── Find repo root ──────────────────────────────────────────────────────
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
@@ -212,7 +220,11 @@ if $HAS_FRONTEND; then
 
     declare -A PIDS=()
 
-    if [[ -n "$CHANGED_FRONTEND_PRETTIER" ]]; then
+    if [[ "$RUN_ALL" == true ]]; then
+        ( cd frontend && npx prettier --check 'src/**/*.{ts,tsx,js,jsx,css,json}' ) \
+            >"$LOGDIR/prettier.log" 2>&1 &
+        PIDS[prettier]=$!
+    elif [[ -n "$CHANGED_FRONTEND_PRETTIER" ]]; then
         # shellcheck disable=SC2086  # word-split is the intent: pass each path
         ( cd frontend && npx prettier --check $CHANGED_FRONTEND_PRETTIER ) \
             >"$LOGDIR/prettier.log" 2>&1 &
@@ -221,7 +233,10 @@ if $HAS_FRONTEND; then
         echo "  (no prettier-eligible frontend/src files changed — skipping prettier)"
     fi
 
-    if [[ -n "$CHANGED_FRONTEND_ESLINT" ]]; then
+    if [[ "$RUN_ALL" == true ]]; then
+        ( cd frontend && npm run lint ) >"$LOGDIR/eslint.log" 2>&1 &
+        PIDS[eslint]=$!
+    elif [[ -n "$CHANGED_FRONTEND_ESLINT" ]]; then
         # shellcheck disable=SC2086
         ( cd frontend && npx eslint --report-unused-disable-directives $CHANGED_FRONTEND_ESLINT ) \
             >"$LOGDIR/eslint.log" 2>&1 &
@@ -233,7 +248,11 @@ if $HAS_FRONTEND; then
     ( cd frontend && npm run type-check ) >"$LOGDIR/tsc.log" 2>&1 &
     PIDS[tsc]=$!
 
-    ( cd frontend && npx vitest run --changed "$BASE" ) >"$LOGDIR/vitest.log" 2>&1 &
+    if [[ "$RUN_ALL" == true ]]; then
+        ( cd frontend && npx vitest run ) >"$LOGDIR/vitest.log" 2>&1 &
+    else
+        ( cd frontend && npx vitest run --changed "$BASE" ) >"$LOGDIR/vitest.log" 2>&1 &
+    fi
     PIDS[vitest]=$!
 
     for name in prettier eslint tsc vitest; do

--- a/.claude/skills/pre-push-verification/scripts/verify.sh
+++ b/.claude/skills/pre-push-verification/scripts/verify.sh
@@ -38,8 +38,13 @@ if [[ "${1:-}" == "--all" ]]; then
 fi
 
 # ── Detect changed files ───────────────────────────────────────────────
-# Compare against the merge-base with origin/main (or HEAD if no remote)
-if git rev-parse --verify origin/main &>/dev/null; then
+# Prefer @{push} — the upstream-tracked branch tip — so subsequent pushes
+# only verify *new* unpushed commits, not the whole PR diff. Falls back to
+# merge-base with origin/main for the first push (no upstream yet) or to
+# HEAD~1 outside any remote-tracking branch.
+if BASE=$(git rev-parse --verify --quiet '@{push}' 2>/dev/null); then
+    :  # @{push} found
+elif git rev-parse --verify origin/main &>/dev/null; then
     BASE=$(git merge-base HEAD origin/main 2>/dev/null || echo "HEAD~1")
 else
     BASE="HEAD~1"
@@ -53,6 +58,19 @@ CHANGED_FILES="$CHANGED_FILES"$'\n'$(git diff --diff-filter=ACMRT --name-only --
 CHANGED_FILES="$CHANGED_FILES"$'\n'$(git diff --diff-filter=ACMRT --name-only 2>/dev/null || true)
 # Deduplicate
 CHANGED_FILES=$(echo "$CHANGED_FILES" | sort -u | grep -v '^$' || true)
+
+# Pre-extract frontend/src changed files (relative to frontend/) for the
+# per-check file filter. Two lists because prettier covers .css/.json too
+# but eslint is configured only for .ts/.tsx (--ext ts,tsx in package.json).
+# Empty list → that check is skipped (tsc + vitest still cover the area).
+CHANGED_FRONTEND_PRETTIER=$(echo "$CHANGED_FILES" \
+    | grep -E '^frontend/src/.*\.(ts|tsx|js|jsx|css|json)$' \
+    | sed 's|^frontend/||' \
+    | grep -v '^$' || true)
+CHANGED_FRONTEND_ESLINT=$(echo "$CHANGED_FILES" \
+    | grep -E '^frontend/src/.*\.(ts|tsx)$' \
+    | sed 's|^frontend/||' \
+    | grep -v '^$' || true)
 
 if [[ -z "$CHANGED_FILES" ]] && [[ "$RUN_ALL" == false ]]; then
     echo -e "${GREEN}No changed files detected. Nothing to verify.${NC}"
@@ -179,21 +197,57 @@ if $HAS_GO; then
     run_check "go test" bash -c "cd pocketbase && go test -race ./... -v"
 fi
 
-# ── Frontend checks ────────────────────────────────────────────────────
+# ── Frontend checks (parallel, file-scoped) ────────────────────────────
+# All four tools run concurrently; stdout+stderr captured per-tool and
+# replayed in stable order so output stays readable. prettier + eslint are
+# scoped to CHANGED_FRONTEND_REL (the files actually touched since BASE);
+# tsc keeps full-project scope (signature changes propagate); vitest uses
+# --changed BASE to run only test files whose dependency graph saw a
+# change. Mirrors the lefthook `pre-push` philosophy.
 if $HAS_FRONTEND; then
-    header "Frontend"
+    header "Frontend (parallel)"
 
-    # Format
-    run_check "prettier" bash -c "cd frontend && npx prettier --check 'src/**/*.{ts,tsx,js,jsx,json,css}'"
+    LOGDIR=$(mktemp -d)
+    trap 'rm -rf "$LOGDIR"' EXIT
 
-    # Lint
-    run_check "eslint" bash -c "cd frontend && npm run lint"
+    declare -A PIDS=()
 
-    # Type check (both tsconfigs)
-    run_check "tsc type-check" bash -c "cd frontend && npm run type-check"
+    if [[ -n "$CHANGED_FRONTEND_PRETTIER" ]]; then
+        # shellcheck disable=SC2086  # word-split is the intent: pass each path
+        ( cd frontend && npx prettier --check $CHANGED_FRONTEND_PRETTIER ) \
+            >"$LOGDIR/prettier.log" 2>&1 &
+        PIDS[prettier]=$!
+    else
+        echo "  (no prettier-eligible frontend/src files changed — skipping prettier)"
+    fi
 
-    # Tests
-    run_check "vitest" bash -c "cd frontend && npx vitest run"
+    if [[ -n "$CHANGED_FRONTEND_ESLINT" ]]; then
+        # shellcheck disable=SC2086
+        ( cd frontend && npx eslint --report-unused-disable-directives $CHANGED_FRONTEND_ESLINT ) \
+            >"$LOGDIR/eslint.log" 2>&1 &
+        PIDS[eslint]=$!
+    else
+        echo "  (no .ts/.tsx files changed — skipping eslint)"
+    fi
+
+    ( cd frontend && npm run type-check ) >"$LOGDIR/tsc.log" 2>&1 &
+    PIDS[tsc]=$!
+
+    ( cd frontend && npx vitest run --changed "$BASE" ) >"$LOGDIR/vitest.log" 2>&1 &
+    PIDS[vitest]=$!
+
+    for name in prettier eslint tsc vitest; do
+        pid="${PIDS[$name]:-}"
+        [[ -z "$pid" ]] && continue
+        if wait "$pid"; then
+            pass "$name"
+        else
+            fail "$name"
+            FAILURES+=("$name")
+            echo "── $name output ──"
+            cat "$LOGDIR/$name.log"
+        fi
+    done
 fi
 
 # ── Migration checks ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Pre-push `verify.sh` ran the full vitest suite (~4273 tests) and full-repo prettier/eslint on every invocation, taking ~150s on a 1-file frontend change.
- After this PR a 1-file frontend touch completes in **~28s (~5× wall-time cut)**; subsequent pushes on a PR drop further as `@{push}` narrows the diff.

## What changed
1. **vitest `--changed $BASE`** — uses vitest's dependency graph to skip unaffected test files. Smoke test: 4273 → 448 tests on a 1-file touch.
2. **prettier + eslint scoped to changed files** — `eslint` gets `.ts/.tsx` only (matches `--ext ts,tsx`); `prettier` gets `.ts/.tsx/.js/.jsx/.css/.json`. Empty list → skip (tsc + vitest still cover).
3. **`BASE = @{push}` with safe fallbacks** — subsequent pushes on a PR only re-verify *new* unpushed commits. First push falls back to `merge-base origin/main`; outside a remote-tracking branch, `HEAD~1`. Multi-commit unpushed sets are still fully covered.
4. **Frontend tier runs in parallel** — prettier, eslint, tsc, vitest concurrently; per-tool output captured and replayed in stable order. Wall time ≈ slowest check, not sum.

`SKILL.md` gotchas updated to document the new behavior (file-scoped lint, vitest --changed, parallel tier, BASE default).

## Test plan
- [x] Bash syntax check (`bash -n verify.sh`)
- [x] Shellcheck (no new warnings introduced)
- [x] Smoke test A — no-frontend change (.sh + .md only): ~1s, shell-only tier ✓
- [x] Smoke test B — 1-file frontend touch: ~28s vs previous ~150s ✓
- [x] Confirmed vitest `--changed` ran 448 tests instead of 4273 for that touch
- [ ] Real-world validation: run on a future PR with frontend changes and confirm the cut holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified pre-push verification behavior: lint/format run on changed frontend files, type-check runs project-wide (including node config), affected tests run only, and default/fallback base behavior explained.

* **Chores**
  * Checks now run concurrently with captured, replayed outputs for clearer results.
  * Improved changed-file detection and git ref fallback logic for more accurate verification scoping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1480?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->