### PR TITLE
feat(frontend): post-check modal + PDF polish (8-section modal, MSP-focused PDF)

### DIFF
--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -833,8 +833,9 @@ class BunkingValidator:
                     continue
                 requester_asgn = assignments_by_person.get(pid)
                 target_asgn = assignments_by_person.get(req.requested_person_cm_id)
-                requester_bunk = bunk_by_id.get(requester_asgn.bunk_cm_id) if requester_asgn else None
-                target_bunk = bunk_by_id.get(target_asgn.bunk_cm_id) if target_asgn else None
+                bunks_map = bunk_by_id or {}
+                requester_bunk = bunks_map.get(requester_asgn.bunk_cm_id) if requester_asgn else None
+                target_bunk = bunks_map.get(target_asgn.bunk_cm_id) if target_asgn else None
                 unsatisfied_material_parent_detail.append(
                     {
                         "requester_cm_id": str(req.requester_person_cm_id),

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -827,10 +827,12 @@ class BunkingValidator:
             for req in reqs:
                 if not req.requested_person_cm_id:
                     continue
+                # Fall back to a Person {pid} label when person_by_id is incomplete
+                # (degraded-data scenarios e.g. partial sync). Mirrors the sibling
+                # `unsatisfied_material_parent_persons` block above so the modal's
+                # count stays accurate when one variant has data the other lacks.
                 requester = person_by_id.get(pid)
                 target = person_by_id.get(req.requested_person_cm_id)
-                if not requester or not target:
-                    continue
                 requester_asgn = assignments_by_person.get(pid)
                 target_asgn = assignments_by_person.get(req.requested_person_cm_id)
                 bunks_map = bunk_by_id or {}
@@ -839,9 +841,9 @@ class BunkingValidator:
                 unsatisfied_material_parent_detail.append(
                     {
                         "requester_cm_id": str(req.requester_person_cm_id),
-                        "requester_name": requester.name,
+                        "requester_name": requester.name if requester else f"Person {pid}",
                         "target_cm_id": str(req.requested_person_cm_id),
-                        "target_name": target.name,
+                        "target_name": (target.name if target else f"Person {req.requested_person_cm_id}"),
                         "requester_bunk_name": requester_bunk.name if requester_bunk else "unassigned",
                         "target_bunk_name": target_bunk.name if target_bunk else "unassigned",
                     }

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -1395,6 +1395,7 @@ class BunkingValidator:
                     higher_bunk: Bunk = higher["bunk"]
                     flow_violations.append(
                         {
+                            "bunk_name": lower_bunk.name,
                             "gender": "Boys" if gender == "M" else "Girls",
                             "lower_bunk": lower_bunk.name,
                             "lower_avg_age": round(lower_avg_age, 1),

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -151,6 +151,17 @@ class ValidationStatistics(BaseModel):
     # Persons with ≥1 unmet material parent request — used by the Check Bunking
     # modal drill-down (#1105). Each entry is {cm_id, name}.
     unsatisfied_material_parent_persons: list[dict[str, Any]] = Field(default_factory=list)
+    # One entry per unsatisfied MP request with requester_cm_id, requester_name,
+    # target_cm_id, target_name, requester_bunk_name, target_bunk_name.
+    # Powers the enriched 'Unmet parent requests' drill-down in the post-check modal.
+    unsatisfied_material_parent_detail: list[dict[str, str]] = Field(
+        default_factory=list,
+        description=(
+            "One entry per unsatisfied MP request with requester_cm_id, requester_name, "
+            "target_cm_id, target_name, requester_bunk_name, target_bunk_name. "
+            "Powers the enriched 'Unmet parent requests' drill-down in the post-check modal."
+        ),
+    )
 
     # Best-effort parent (socialize_with-source only) — emitted for modal display, drives no alarm.
     best_effort_parent_requests: int = 0
@@ -773,6 +784,37 @@ class BunkingValidator:
             person = person_by_id.get(pid)
             unmet_persons.append({"cm_id": cm_id, "name": person.name if person else f"Person {pid}"})
         stats.unsatisfied_material_parent_persons = sorted(unmet_persons, key=lambda entry: entry["name"])
+
+        # Per-request detail for unsatisfied MP requests — one entry per request (not per requester).
+        # Reuses material_parent_by_person, satisfied_material_parent_by_person, person_by_id,
+        # assignments_by_person, and bunk_by_id — no new lookups needed.
+        unsatisfied_material_parent_detail: list[dict[str, str]] = []
+        for pid, reqs in material_parent_by_person.items():
+            if not reqs or satisfied_material_parent_by_person.get(pid):
+                # Camper has ≥1 satisfied MP request → canonical "satisfied" bucket, skip all.
+                continue
+            for req in reqs:
+                if not req.requested_person_cm_id:
+                    continue
+                requester = person_by_id.get(pid)
+                target = person_by_id.get(req.requested_person_cm_id)
+                if not requester or not target:
+                    continue
+                requester_asgn = assignments_by_person.get(pid)
+                target_asgn = assignments_by_person.get(req.requested_person_cm_id)
+                requester_bunk = bunk_by_id.get(requester_asgn.bunk_cm_id) if requester_asgn else None
+                target_bunk = bunk_by_id.get(target_asgn.bunk_cm_id) if target_asgn else None
+                unsatisfied_material_parent_detail.append(
+                    {
+                        "requester_cm_id": str(req.requester_person_cm_id),
+                        "requester_name": requester.name,
+                        "target_cm_id": str(req.requested_person_cm_id),
+                        "target_name": target.name,
+                        "requester_bunk_name": requester_bunk.name if requester_bunk else "unassigned",
+                        "target_bunk_name": target_bunk.name if target_bunk else "unassigned",
+                    }
+                )
+        stats.unsatisfied_material_parent_detail = unsatisfied_material_parent_detail
 
         # Camper-level two-tier MP coverage.
         # mp_campers_total = distinct requesters with ≥1 MP request.

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -369,8 +369,9 @@ class BunkingValidator:
 
         # Per-gender capacity and assigned counts.
         # bunk.gender is "F" or "M"; unknown/other genders are skipped.
-        # Falls back to DEFAULT_BUNK_CAPACITY for real Bunk objects (no max_size column);
-        # MockBunk in tests supplies max_size directly so per-bunk variance is captured.
+        # Capacity is n_bunks × DEFAULT_BUNK_CAPACITY — the real Bunk model has no
+        # per-bunk size column (removed in Phase 2 cleanup), so this is headcount-based.
+        # If per-bunk variance is ever needed, add a max_size column and read it here.
         capacity_by_gender: dict[str, dict[str, int]] = {
             "female": {"capacity": 0, "assigned": 0},
             "male": {"capacity": 0, "assigned": 0},
@@ -379,7 +380,7 @@ class BunkingValidator:
             gender_key = "female" if bunk.gender == "F" else "male" if bunk.gender == "M" else None
             if gender_key is None:
                 continue
-            capacity_by_gender[gender_key]["capacity"] += getattr(bunk, "max_size", DEFAULT_BUNK_CAPACITY)
+            capacity_by_gender[gender_key]["capacity"] += DEFAULT_BUNK_CAPACITY
         for person in persons:
             if person.campminder_id not in assignments_by_person:
                 continue

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -379,8 +379,7 @@ class BunkingValidator:
             gender_key = "female" if bunk.gender == "F" else "male" if bunk.gender == "M" else None
             if gender_key is None:
                 continue
-            bunk_cap = getattr(bunk, "max_size", DEFAULT_BUNK_CAPACITY) or DEFAULT_BUNK_CAPACITY
-            capacity_by_gender[gender_key]["capacity"] += bunk_cap
+            capacity_by_gender[gender_key]["capacity"] += getattr(bunk, "max_size", DEFAULT_BUNK_CAPACITY)
         for person in persons:
             if person.campminder_id not in assignments_by_person:
                 continue

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -212,6 +212,14 @@ class ValidationStatistics(BaseModel):
     mp_campers_with_at_least_one_satisfied: int = 0
     mp_campers_with_all_satisfied: int = 0
 
+    # Per-gender bunk capacity and assigned-camper counts.
+    # Splits bunks and assignments by bunk.gender (F/M) so the post-check
+    # modal and PDF can render capacity-vs-assigned per gender.
+    capacity_by_gender: dict[str, dict[str, int]] = Field(
+        default_factory=lambda: {"female": {"capacity": 0, "assigned": 0}, "male": {"capacity": 0, "assigned": 0}},
+        description="Per-gender bunk capacity and assigned-camper counts. Keys: 'female', 'male'.",
+    )
+
 
 class ValidationResult(BaseModel):
     """Complete validation result with statistics and issues."""
@@ -358,6 +366,30 @@ class BunkingValidator:
         stats.used_capacity = stats.assigned_campers
         if stats.total_capacity > 0:
             stats.capacity_utilization_rate = stats.used_capacity / stats.total_capacity
+
+        # Per-gender capacity and assigned counts.
+        # bunk.gender is "F" or "M"; unknown/other genders are skipped.
+        # Falls back to DEFAULT_BUNK_CAPACITY for real Bunk objects (no max_size column);
+        # MockBunk in tests supplies max_size directly so per-bunk variance is captured.
+        capacity_by_gender: dict[str, dict[str, int]] = {
+            "female": {"capacity": 0, "assigned": 0},
+            "male": {"capacity": 0, "assigned": 0},
+        }
+        for bunk in bunks:
+            gender_key = "female" if bunk.gender == "F" else "male" if bunk.gender == "M" else None
+            if gender_key is None:
+                continue
+            bunk_cap = getattr(bunk, "max_size", DEFAULT_BUNK_CAPACITY) or DEFAULT_BUNK_CAPACITY
+            capacity_by_gender[gender_key]["capacity"] += bunk_cap
+        for person in persons:
+            if person.campminder_id not in assignments_by_person:
+                continue
+            person_gender = getattr(person, "gender", None)
+            gender_key = "female" if person_gender == "F" else "male" if person_gender == "M" else None
+            if gender_key is None:
+                continue
+            capacity_by_gender[gender_key]["assigned"] += 1
+        stats.capacity_by_gender = capacity_by_gender
 
         return ValidationResult(statistics=stats, issues=issues, session_id=session.campminder_id, scenario=scenario)
 

--- a/frontend/src/components/PdfExport/BunkPlanReport.test.tsx
+++ b/frontend/src/components/PdfExport/BunkPlanReport.test.tsx
@@ -247,3 +247,41 @@ describe('BunkPlanReport (PDF) — Families to contact page', () => {
     expect(text.indexOf('Riley Sam')).toBeLessThan(text.indexOf('Sophia Martinez'))
   }, 30000)
 })
+
+describe('BunkPlanReport (PDF) — Impossibility detail pages', () => {
+  it('renders full impossibility detail grouped by reason with friendly labels', async () => {
+    const items = [
+      { request_id: 'r1', reason_code: 'grade_compatibility', reason_message: 'wide', request_type: 'bunk_with', requester: { cm_id: 1, name: 'Emma Johnson', grade: 5, gender: 'F' }, requestee: { cm_id: 2, name: 'Liam Garcia', grade: 8, gender: 'M' }, detail: {}, bucket: null },
+      { request_id: 'r2', reason_code: 'grade_compatibility', reason_message: 'wide', request_type: 'bunk_with', requester: { cm_id: 3, name: 'Olivia Chen', grade: 4, gender: 'F' }, requestee: { cm_id: 4, name: 'Riley Sam', grade: 9, gender: 'F' }, detail: {}, bucket: null },
+    ]
+    const buf = await renderToBuffer(
+      <BunkPlanReport
+        sessionName="Session 3"
+        year={2026}
+        plannerName="Test Staff"
+        statistics={makeStats()}
+        impossibilityReport={{
+          by_reason: { grade_compatibility: items },
+          total_impossible: 2,
+          affected_campers: 4,
+          flat: items,
+          mp_campers_entirely_impossible: [],
+        } as any}
+      />
+    )
+    const parser = new PDFParse({ data: buf })
+    const result = await parser.getText()
+    await parser.destroy()
+    const text = result.text
+    const flat = stripSpaces(text)
+
+    expect(flat).toMatch(/IMPOSSIBILITYDETAIL/)
+    // Reason heading with count
+    expect(text).toMatch(/Grade range too wide \(2\)/)
+    // Each requester + requestee visible
+    expect(text).toMatch(/Emma Johnson/)
+    expect(text).toMatch(/Liam Garcia/)
+    expect(text).toMatch(/Olivia Chen/)
+    expect(text).toMatch(/Riley Sam/)
+  }, 30000)
+})

--- a/frontend/src/components/PdfExport/BunkPlanReport.test.tsx
+++ b/frontend/src/components/PdfExport/BunkPlanReport.test.tsx
@@ -163,3 +163,46 @@ describe('BunkPlanReport (PDF) — Cover/Summary page', () => {
     expect(buf.length).toBeGreaterThan(0)
   }, 30000)
 })
+
+describe('BunkPlanReport (PDF) — Families to contact page', () => {
+  it('renders Families to contact with all 3 cohorts in alphabetical order', async () => {
+    const buf = await renderToBuffer(
+      <BunkPlanReport
+        sessionName="Session 3"
+        year={2026}
+        plannerName="Test Staff"
+        statistics={makeStats({
+          negative_request_violations_detail: [
+            { requester_cm_id: '1', target_cm_id: '2', requester_name: 'Riley Sam', target_name: 'Samuel Johnson', bunk_cm_id: '10', bunk_name: 'Pine 3' },
+          ],
+          priority_unsuccessfuls: [
+            { requester_cm_id: '3', target_cm_id: '4', requester_name: 'Sophia Martinez', target_name: 'Mia Wilson', raw_text: 'top priority' },
+          ],
+        })}
+        impossibilityReport={{
+          by_reason: {},
+          total_impossible: 0,
+          affected_campers: 0,
+          flat: [],
+          mp_campers_entirely_impossible: [
+            { cm_id: 5, name: 'Emma Johnson', grade: 5, gender: 'F', reason_codes: ['grade_compatibility'] },
+          ],
+        } as any}
+      />
+    )
+    const parser = new PDFParse({ data: buf })
+    const result = await parser.getText()
+    await parser.destroy()
+    const text = result.text
+
+    // Section title visible (uppercase form likely "FAMILIES TO CONTACT" with letter-spacing)
+    expect(stripSpaces(text)).toMatch(/FAMILIESTOCONTACT/)
+    // All three campers visible
+    expect(text).toMatch(/Emma Johnson/)
+    expect(text).toMatch(/Riley Sam/)
+    expect(text).toMatch(/Sophia Martinez/)
+    // Alphabetical: Emma < Riley < Sophia
+    expect(text.indexOf('Emma Johnson')).toBeLessThan(text.indexOf('Riley Sam'))
+    expect(text.indexOf('Riley Sam')).toBeLessThan(text.indexOf('Sophia Martinez'))
+  }, 30000)
+})

--- a/frontend/src/components/PdfExport/BunkPlanReport.test.tsx
+++ b/frontend/src/components/PdfExport/BunkPlanReport.test.tsx
@@ -101,47 +101,52 @@ describe('BunkPlanReport (PDF)', () => {
     expect(flat).toMatch(/PRIORITYUNSUCCESSFULS/)
   }, 30000)
 
-describe('BunkPlanReport (PDF) — Cover/Summary page', () => {
-  it('renders MSP-focused KPIs + coverage table + impossibility summary + capacity by gender', async () => {
-    const buf = await renderToBuffer(
-      <BunkPlanReport
-        sessionName="Session 3"
-        year={2026}
-        plannerName="Test Staff"
-        statistics={makeStats({
-          total_campers: 130,
-          assigned_campers: 128,
-          material_parent_requests: 48,
-          satisfied_material_parent_requests: 42,
-          material_parent_request_satisfaction_rate: 0.875,
-          capacity_by_gender: { female: { capacity: 65, assigned: 62 }, male: { capacity: 85, assigned: 66 } },
-        })}
-        impossibilityReport={{
-          by_reason: { grade_compatibility: [{}, {}, {}, {}, {}, {}, {}] },
-          total_impossible: 7,
-          affected_campers: 5,
-          flat: [],
-          mp_campers_entirely_impossible: [],
-        } as any}
-      />
-    )
-    const parser = new PDFParse({ data: buf })
-    const result = await parser.getText()
-    await parser.destroy()
-    const flat = stripSpaces(result.text)
+  describe('BunkPlanReport (PDF) — Cover/Summary page', () => {
+    it('renders MSP-focused KPIs + coverage table + impossibility summary + capacity by gender', async () => {
+      const buf = await renderToBuffer(
+        <BunkPlanReport
+          sessionName="Session 3"
+          year={2026}
+          plannerName="Test Staff"
+          statistics={makeStats({
+            total_campers: 130,
+            assigned_campers: 128,
+            material_parent_requests: 48,
+            satisfied_material_parent_requests: 42,
+            material_parent_request_satisfaction_rate: 0.875,
+            capacity_by_gender: {
+              female: { capacity: 65, assigned: 62 },
+              male: { capacity: 85, assigned: 66 },
+            },
+          })}
+          impossibilityReport={
+            {
+              by_reason: { grade_compatibility: [{}, {}, {}, {}, {}, {}, {}] },
+              total_impossible: 7,
+              affected_campers: 5,
+              flat: [],
+              mp_campers_entirely_impossible: [],
+            } as any
+          }
+        />
+      )
+      const parser = new PDFParse({ data: buf })
+      const result = await parser.getText()
+      await parser.destroy()
+      const flat = stripSpaces(result.text)
 
-    // KPI section title (might be "EXECUTIVE SUMMARY" or "EXECUTIVESUMMARY" depending on letter-spacing strip)
-    expect(flat).toMatch(/EXECUTIVESUMMARY/)
-    // KPI values
-    expect(result.text).toMatch(/88\s*%|87\s*%/) // 0.875 → 88% rounded
-    // Section heads (stripped of whitespace + uppercased)
-    expect(flat).toMatch(/COVERAGE/i)
-    expect(flat).toMatch(/CAPACITYBYGENDER/)
-    expect(flat).toMatch(/IMPOSSIBLEBYREASON/)
-    // Friendly reason label (NOT uppercased — appears as regular cell text)
-    expect(result.text).toMatch(/Grade range too wide|grade_compatibility/i)
-  }, 30000)
-})
+      // KPI section title (might be "EXECUTIVE SUMMARY" or "EXECUTIVESUMMARY" depending on letter-spacing strip)
+      expect(flat).toMatch(/EXECUTIVESUMMARY/)
+      // KPI values
+      expect(result.text).toMatch(/88\s*%|87\s*%/) // 0.875 → 88% rounded
+      // Section heads (stripped of whitespace + uppercased)
+      expect(flat).toMatch(/COVERAGE/i)
+      expect(flat).toMatch(/CAPACITYBYGENDER/)
+      expect(flat).toMatch(/IMPOSSIBLEBYREASON/)
+      // Friendly reason label (NOT uppercased — appears as regular cell text)
+      expect(result.text).toMatch(/Grade range too wide|grade_compatibility/i)
+    }, 30000)
+  })
 
   it('handles empty action lists gracefully', async () => {
     const buf = await renderToBuffer(
@@ -173,16 +178,25 @@ describe('BunkPlanReport (PDF) — Bunks/Other/Unmet page', () => {
         plannerName="Test Staff"
         statistics={makeStats({
           unsatisfied_material_parent_detail: [
-            { requester_cm_id: '1', requester_name: 'Emma Johnson', target_cm_id: '2', target_name: 'Liam Garcia', requester_bunk_name: 'Pine 3', target_bunk_name: 'Oak 2' },
+            {
+              requester_cm_id: '1',
+              requester_name: 'Emma Johnson',
+              target_cm_id: '2',
+              target_name: 'Liam Garcia',
+              requester_bunk_name: 'Pine 3',
+              target_bunk_name: 'Oak 2',
+            },
           ],
         })}
-        impossibilityReport={{
-          by_reason: {},
-          total_impossible: 0,
-          affected_campers: 0,
-          flat: [],
-          mp_campers_entirely_impossible: [],
-        } as any}
+        impossibilityReport={
+          {
+            by_reason: {},
+            total_impossible: 0,
+            affected_campers: 0,
+            flat: [],
+            mp_campers_entirely_impossible: [],
+          } as any
+        }
         issues={[
           { type: 'capacity_violation', severity: 'error', message: 'Pine 3 over capacity' },
           { type: 'unassigned_campers', severity: 'error', message: '2 unassigned' },
@@ -214,21 +228,42 @@ describe('BunkPlanReport (PDF) — Families to contact page', () => {
         plannerName="Test Staff"
         statistics={makeStats({
           negative_request_violations_detail: [
-            { requester_cm_id: '1', target_cm_id: '2', requester_name: 'Riley Sam', target_name: 'Samuel Johnson', bunk_cm_id: '10', bunk_name: 'Pine 3' },
+            {
+              requester_cm_id: '1',
+              target_cm_id: '2',
+              requester_name: 'Riley Sam',
+              target_name: 'Samuel Johnson',
+              bunk_cm_id: '10',
+              bunk_name: 'Pine 3',
+            },
           ],
           priority_unsuccessfuls: [
-            { requester_cm_id: '3', target_cm_id: '4', requester_name: 'Sophia Martinez', target_name: 'Mia Wilson', raw_text: 'top priority' },
+            {
+              requester_cm_id: '3',
+              target_cm_id: '4',
+              requester_name: 'Sophia Martinez',
+              target_name: 'Mia Wilson',
+              raw_text: 'top priority',
+            },
           ],
         })}
-        impossibilityReport={{
-          by_reason: {},
-          total_impossible: 0,
-          affected_campers: 0,
-          flat: [],
-          mp_campers_entirely_impossible: [
-            { cm_id: 5, name: 'Emma Johnson', grade: 5, gender: 'F', reason_codes: ['grade_compatibility'] },
-          ],
-        } as any}
+        impossibilityReport={
+          {
+            by_reason: {},
+            total_impossible: 0,
+            affected_campers: 0,
+            flat: [],
+            mp_campers_entirely_impossible: [
+              {
+                cm_id: 5,
+                name: 'Emma Johnson',
+                grade: 5,
+                gender: 'F',
+                reason_codes: ['grade_compatibility'],
+              },
+            ],
+          } as any
+        }
       />
     )
     const parser = new PDFParse({ data: buf })
@@ -251,8 +286,26 @@ describe('BunkPlanReport (PDF) — Families to contact page', () => {
 describe('BunkPlanReport (PDF) — Impossibility detail pages', () => {
   it('renders full impossibility detail grouped by reason with friendly labels', async () => {
     const items = [
-      { request_id: 'r1', reason_code: 'grade_compatibility', reason_message: 'wide', request_type: 'bunk_with', requester: { cm_id: 1, name: 'Emma Johnson', grade: 5, gender: 'F' }, requestee: { cm_id: 2, name: 'Liam Garcia', grade: 8, gender: 'M' }, detail: {}, bucket: null },
-      { request_id: 'r2', reason_code: 'grade_compatibility', reason_message: 'wide', request_type: 'bunk_with', requester: { cm_id: 3, name: 'Olivia Chen', grade: 4, gender: 'F' }, requestee: { cm_id: 4, name: 'Riley Sam', grade: 9, gender: 'F' }, detail: {}, bucket: null },
+      {
+        request_id: 'r1',
+        reason_code: 'grade_compatibility',
+        reason_message: 'wide',
+        request_type: 'bunk_with',
+        requester: { cm_id: 1, name: 'Emma Johnson', grade: 5, gender: 'F' },
+        requestee: { cm_id: 2, name: 'Liam Garcia', grade: 8, gender: 'M' },
+        detail: {},
+        bucket: null,
+      },
+      {
+        request_id: 'r2',
+        reason_code: 'grade_compatibility',
+        reason_message: 'wide',
+        request_type: 'bunk_with',
+        requester: { cm_id: 3, name: 'Olivia Chen', grade: 4, gender: 'F' },
+        requestee: { cm_id: 4, name: 'Riley Sam', grade: 9, gender: 'F' },
+        detail: {},
+        bucket: null,
+      },
     ]
     const buf = await renderToBuffer(
       <BunkPlanReport
@@ -260,13 +313,15 @@ describe('BunkPlanReport (PDF) — Impossibility detail pages', () => {
         year={2026}
         plannerName="Test Staff"
         statistics={makeStats()}
-        impossibilityReport={{
-          by_reason: { grade_compatibility: items },
-          total_impossible: 2,
-          affected_campers: 4,
-          flat: items,
-          mp_campers_entirely_impossible: [],
-        } as any}
+        impossibilityReport={
+          {
+            by_reason: { grade_compatibility: items },
+            total_impossible: 2,
+            affected_campers: 4,
+            flat: items,
+            mp_campers_entirely_impossible: [],
+          } as any
+        }
       />
     )
     const parser = new PDFParse({ data: buf })

--- a/frontend/src/components/PdfExport/BunkPlanReport.test.tsx
+++ b/frontend/src/components/PdfExport/BunkPlanReport.test.tsx
@@ -214,6 +214,60 @@ describe('BunkPlanReport (PDF) — Bunks/Other/Unmet page', () => {
     expect(text).toMatch(/Emma Johnson/)
     expect(text).toMatch(/Liam Garcia/)
   }, 30000)
+
+  // #8 — Two requesters can share a name (Emma Johnson #1 and Emma Johnson #2
+  // at a 600-camper session). Sort by name alone leaves order non-deterministic;
+  // tiebreak on requester_cm_id (then target_cm_id) so the PDF is reproducible.
+  it('produces deterministic unmet order when requesters share a name (cm_id tiebreak)', async () => {
+    const buf = await renderToBuffer(
+      <BunkPlanReport
+        sessionName="Session 3"
+        year={2026}
+        plannerName="Test Staff"
+        statistics={makeStats({
+          unsatisfied_material_parent_detail: [
+            // Same requester_name; cm_id "1002" should sort AFTER "1001".
+            // Bunk names differ so we can read the order out of the PDF text.
+            {
+              requester_cm_id: '1002',
+              requester_name: 'Emma Johnson',
+              target_cm_id: '2002',
+              target_name: 'Liam Garcia',
+              requester_bunk_name: 'Pine 7',
+              target_bunk_name: 'Oak 2',
+            },
+            {
+              requester_cm_id: '1001',
+              requester_name: 'Emma Johnson',
+              target_cm_id: '2001',
+              target_name: 'Olivia Chen',
+              requester_bunk_name: 'Pine 3',
+              target_bunk_name: 'Oak 5',
+            },
+          ],
+        })}
+        impossibilityReport={
+          {
+            by_reason: {},
+            total_impossible: 0,
+            affected_campers: 0,
+            flat: [],
+            mp_campers_entirely_impossible: [],
+          } as any
+        }
+      />
+    )
+    const parser = new PDFParse({ data: buf })
+    const result = await parser.getText()
+    await parser.destroy()
+    const text = result.text
+
+    // Both rows render — and the cm_id="1001" row (Pine 3 / Olivia Chen) must
+    // come before the cm_id="1002" row (Pine 7 / Liam Garcia).
+    expect(text).toMatch(/Pine 3/)
+    expect(text).toMatch(/Pine 7/)
+    expect(text.indexOf('Pine 3')).toBeLessThan(text.indexOf('Pine 7'))
+  }, 30000)
 })
 
 describe('BunkPlanReport (PDF) — Families to contact page', () => {

--- a/frontend/src/components/PdfExport/BunkPlanReport.test.tsx
+++ b/frontend/src/components/PdfExport/BunkPlanReport.test.tsx
@@ -164,6 +164,47 @@ describe('BunkPlanReport (PDF) — Cover/Summary page', () => {
   }, 30000)
 })
 
+describe('BunkPlanReport (PDF) — Bunks/Other/Unmet page', () => {
+  it('renders Bunks needing attention, Other issues, and Unmet drill-down on one page', async () => {
+    const buf = await renderToBuffer(
+      <BunkPlanReport
+        sessionName="Session 3"
+        year={2026}
+        plannerName="Test Staff"
+        statistics={makeStats({
+          unsatisfied_material_parent_detail: [
+            { requester_cm_id: '1', requester_name: 'Emma Johnson', target_cm_id: '2', target_name: 'Liam Garcia', requester_bunk_name: 'Pine 3', target_bunk_name: 'Oak 2' },
+          ],
+        })}
+        impossibilityReport={{
+          by_reason: {},
+          total_impossible: 0,
+          affected_campers: 0,
+          flat: [],
+          mp_campers_entirely_impossible: [],
+        } as any}
+        issues={[
+          { type: 'capacity_violation', severity: 'error', message: 'Pine 3 over capacity' },
+          { type: 'unassigned_campers', severity: 'error', message: '2 unassigned' },
+        ]}
+      />
+    )
+    const parser = new PDFParse({ data: buf })
+    const result = await parser.getText()
+    await parser.destroy()
+    const text = result.text
+    const flat = stripSpaces(text)
+
+    expect(flat).toMatch(/BUNKSNEEDINGATTENTION/)
+    expect(text).toMatch(/Pine 3/)
+    expect(flat).toMatch(/OTHERISSUES/)
+    expect(text).toMatch(/unassigned/i)
+    expect(flat).toMatch(/UNMET/)
+    expect(text).toMatch(/Emma Johnson/)
+    expect(text).toMatch(/Liam Garcia/)
+  }, 30000)
+})
+
 describe('BunkPlanReport (PDF) — Families to contact page', () => {
   it('renders Families to contact with all 3 cohorts in alphabetical order', async () => {
     const buf = await renderToBuffer(

--- a/frontend/src/components/PdfExport/BunkPlanReport.test.tsx
+++ b/frontend/src/components/PdfExport/BunkPlanReport.test.tsx
@@ -96,9 +96,6 @@ describe('BunkPlanReport (PDF)', () => {
     const flat = stripSpaces(result.text)
 
     expect(flat).toMatch(/BUNKPLANREPORT/)
-    expect(flat).toMatch(/WHOGOTNOTHING/)
-    expect(flat).toMatch(/FAMILIESTOCALL/)
-    expect(flat).toMatch(/PRIORITYUNSUCCESSFULS/)
   }, 30000)
 
   describe('BunkPlanReport (PDF) — Cover/Summary page', () => {

--- a/frontend/src/components/PdfExport/BunkPlanReport.test.tsx
+++ b/frontend/src/components/PdfExport/BunkPlanReport.test.tsx
@@ -101,6 +101,48 @@ describe('BunkPlanReport (PDF)', () => {
     expect(flat).toMatch(/PRIORITYUNSUCCESSFULS/)
   }, 30000)
 
+describe('BunkPlanReport (PDF) — Cover/Summary page', () => {
+  it('renders MSP-focused KPIs + coverage table + impossibility summary + capacity by gender', async () => {
+    const buf = await renderToBuffer(
+      <BunkPlanReport
+        sessionName="Session 3"
+        year={2026}
+        plannerName="Test Staff"
+        statistics={makeStats({
+          total_campers: 130,
+          assigned_campers: 128,
+          material_parent_requests: 48,
+          satisfied_material_parent_requests: 42,
+          material_parent_request_satisfaction_rate: 0.875,
+          capacity_by_gender: { female: { capacity: 65, assigned: 62 }, male: { capacity: 85, assigned: 66 } },
+        })}
+        impossibilityReport={{
+          by_reason: { grade_compatibility: [{}, {}, {}, {}, {}, {}, {}] },
+          total_impossible: 7,
+          affected_campers: 5,
+          flat: [],
+          mp_campers_entirely_impossible: [],
+        } as any}
+      />
+    )
+    const parser = new PDFParse({ data: buf })
+    const result = await parser.getText()
+    await parser.destroy()
+    const flat = stripSpaces(result.text)
+
+    // KPI section title (might be "EXECUTIVE SUMMARY" or "EXECUTIVESUMMARY" depending on letter-spacing strip)
+    expect(flat).toMatch(/EXECUTIVESUMMARY/)
+    // KPI values
+    expect(result.text).toMatch(/88\s*%|87\s*%/) // 0.875 → 88% rounded
+    // Section heads (stripped of whitespace + uppercased)
+    expect(flat).toMatch(/COVERAGE/i)
+    expect(flat).toMatch(/CAPACITYBYGENDER/)
+    expect(flat).toMatch(/IMPOSSIBLEBYREASON/)
+    // Friendly reason label (NOT uppercased — appears as regular cell text)
+    expect(result.text).toMatch(/Grade range too wide|grade_compatibility/i)
+  }, 30000)
+})
+
   it('handles empty action lists gracefully', async () => {
     const buf = await renderToBuffer(
       <BunkPlanReport

--- a/frontend/src/components/PdfExport/BunkPlanReport.tsx
+++ b/frontend/src/components/PdfExport/BunkPlanReport.tsx
@@ -121,6 +121,8 @@ const styles = StyleSheet.create({
   },
   barFill: { height: 6, backgroundColor: GREEN, borderRadius: 2 },
   amberFill: { height: 6, backgroundColor: AMBER, borderRadius: 2 },
+  reasonGroup: { marginBottom: 10 },
+  reasonHead: { fontSize: 11, fontWeight: 700, color: STONE_950, marginBottom: 4 },
 })
 
 function pct(rate: number | undefined): string {
@@ -497,7 +499,58 @@ export function BunkPlanReport({
         )
       })()}
 
-      {/* ── Page 4 — Full unmet alphabetical list ── */}
+      {/* ── Pages 4–N — Full impossibility detail (one page, wraps) ── */}
+      {Object.keys(impossibilityReport.by_reason).length > 0 && (
+        <Page size="LETTER" style={styles.page} wrap>
+          <Text style={styles.sectionTitle}>Impossibility detail</Text>
+          {Object.entries(impossibilityReport.by_reason).map(([code, items]) => {
+            const list = items as Array<{
+              request_id: string
+              reason_code: string
+              reason_message: string
+              request_type: string
+              requester: { cm_id: number; name: string; grade: number; gender: string }
+              requestee: { cm_id: number; name: string; grade: number; gender: string } | null
+              detail: Record<string, unknown>
+              bucket: string | null
+            }>
+            return (
+              <View key={code} style={styles.reasonGroup} wrap>
+                <Text style={styles.reasonHead}>{friendlyReasonLabel(code)} ({list.length})</Text>
+                <View style={styles.tableHead}>
+                  <Text style={styles.cell}>Requester</Text>
+                  <Text style={styles.cell}>Target</Text>
+                  <Text style={styles.cell}>Source</Text>
+                </View>
+                {list.map((it, idx) => (
+                  <View key={`${code}-${idx}`} style={styles.tableRow} wrap={false}>
+                    <Text style={styles.cell}>
+                      {it.requester?.name
+                        ? `${it.requester.name} (${it.requester.grade}${it.requester.gender ? `, ${it.requester.gender}` : ''})`
+                        : '—'}
+                    </Text>
+                    <Text style={styles.cell}>
+                      {it.requestee?.name
+                        ? `${it.requestee.name} (${it.requestee.grade}${it.requestee.gender ? `, ${it.requestee.gender}` : ''})`
+                        : '—'}
+                    </Text>
+                    <Text style={styles.cell}>{it.request_type ?? '—'}</Text>
+                  </View>
+                ))}
+              </View>
+            )
+          })}
+          <Text
+            style={styles.footer}
+            render={({ pageNumber, totalPages }: { pageNumber: number; totalPages: number }) =>
+              `Page ${pageNumber} of ${totalPages}`
+            }
+            fixed
+          />
+        </Page>
+      )}
+
+      {/* ── Last page — Full unmet alphabetical list ── */}
       <Page size="LETTER" style={styles.page}>
         <Text style={styles.sectionTitle}>Unmet Parent Requests (full list)</Text>
         {unmetParents.length === 0 ? (

--- a/frontend/src/components/PdfExport/BunkPlanReport.tsx
+++ b/frontend/src/components/PdfExport/BunkPlanReport.tsx
@@ -294,7 +294,9 @@ export function BunkPlanReport({
         return (
           <Page size="LETTER" style={styles.page}>
             <Text style={styles.sectionTitle}>Families to contact ({familyRows.length})</Text>
-            <Text style={styles.subtitle}>Sorted alphabetically by camper first name. Each row needs a follow-up call.</Text>
+            <Text style={styles.subtitle}>
+              Sorted alphabetically by camper first name. Each row needs a follow-up call.
+            </Text>
             <View style={styles.tableHead}>
               <Text style={styles.cell}>Camper</Text>
               <Text style={styles.cell}>Cohort</Text>
@@ -516,7 +518,9 @@ export function BunkPlanReport({
             }>
             return (
               <View key={code} style={styles.reasonGroup} wrap>
-                <Text style={styles.reasonHead}>{friendlyReasonLabel(code)} ({list.length})</Text>
+                <Text style={styles.reasonHead}>
+                  {friendlyReasonLabel(code)} ({list.length})
+                </Text>
                 <View style={styles.tableHead}>
                   <Text style={styles.cell}>Requester</Text>
                   <Text style={styles.cell}>Target</Text>

--- a/frontend/src/components/PdfExport/BunkPlanReport.tsx
+++ b/frontend/src/components/PdfExport/BunkPlanReport.tsx
@@ -1,6 +1,7 @@
 import { Document, Page, Text, View, StyleSheet, Image } from '@react-pdf/renderer'
 import type { ImpossibilityReport, ValidationStatistics } from '../../services/solver'
 import { friendlyReasonLabel } from '../impossibility/reasonHints'
+import { buildFamilyRows, cohortLabel } from './familyRows'
 
 interface Props {
   sessionName: string
@@ -87,6 +88,7 @@ const styles = StyleSheet.create({
   },
   cell: { flex: 1, fontSize: 8 },
   cellWide: { flex: 2, fontSize: 8 },
+  subtitle: { fontSize: 8, color: STONE_600, marginBottom: 6 },
   emptyNote: { fontSize: 8, color: STONE_600, fontStyle: 'italic', marginTop: 4 },
   metaLine: { fontSize: 8, color: STONE_600, marginTop: 6 },
   footer: {
@@ -280,7 +282,38 @@ export function BunkPlanReport({
         />
       </Page>
 
-      {/* ── Page 2 — Action Lists ── */}
+      {/* ── Page 2 — Families to contact (consolidated) ── */}
+      {(() => {
+        const familyRows = buildFamilyRows(statistics, impossibilityReport)
+        if (familyRows.length === 0) return null
+        return (
+          <Page size="LETTER" style={styles.page}>
+            <Text style={styles.sectionTitle}>Families to contact ({familyRows.length})</Text>
+            <Text style={styles.subtitle}>Sorted alphabetically by camper first name. Each row needs a follow-up call.</Text>
+            <View style={styles.tableHead}>
+              <Text style={styles.cell}>Camper</Text>
+              <Text style={styles.cell}>Cohort</Text>
+              <Text style={[styles.cell, { flex: 2 }]}>Detail</Text>
+            </View>
+            {familyRows.map((r) => (
+              <View key={r.key} style={styles.tableRow} wrap={false}>
+                <Text style={styles.cell}>{r.name}</Text>
+                <Text style={styles.cell}>{cohortLabel(r.cohort)}</Text>
+                <Text style={[styles.cell, { flex: 2 }]}>{r.detail}</Text>
+              </View>
+            ))}
+            <Text
+              style={styles.footer}
+              render={({ pageNumber, totalPages }: { pageNumber: number; totalPages: number }) =>
+                `Page ${pageNumber} of ${totalPages}`
+              }
+              fixed
+            />
+          </Page>
+        )
+      })()}
+
+      {/* ── Page 3 — Action Lists (legacy) ── */}
       <Page size="LETTER" style={styles.page}>
         {/* Who Got Nothing */}
         <Text style={styles.sectionTitle}>Who Got Nothing</Text>

--- a/frontend/src/components/PdfExport/BunkPlanReport.tsx
+++ b/frontend/src/components/PdfExport/BunkPlanReport.tsx
@@ -2,7 +2,12 @@ import { Document, Page, Text, View, StyleSheet, Image } from '@react-pdf/render
 import type { ImpossibilityReport, ValidationStatistics } from '../../services/solver'
 import { friendlyReasonLabel } from '../impossibility/reasonHints'
 import { buildFamilyRows, cohortLabel } from './familyRows'
-import { BUNK_LEVEL_ISSUE_TYPES, SUPPRESSED_ISSUE_TYPES, extractBunkName } from '../issueClassifier'
+import {
+  BUNK_LEVEL_ISSUE_TYPES,
+  SUPPRESSED_ISSUE_TYPES,
+  extractBunkName,
+  type PostCheckIssue,
+} from '../issueClassifier'
 
 interface Props {
   sessionName: string
@@ -12,12 +17,7 @@ interface Props {
   impossibilityReport: ImpossibilityReport
   /** Optional branded logo — pass /local/assets/camp-logo.png from caller */
   logoUrl?: string
-  issues?: Array<{
-    type: string
-    severity: string
-    message: string
-    details?: Record<string, unknown>
-  }>
+  issues?: PostCheckIssue[]
 }
 
 // Theme: forest green, amber, cream (generic Tawonga-inspired palette)
@@ -357,8 +357,13 @@ export function BunkPlanReport({
         }
         const groupedOther = [...otherMap.entries()]
 
-        const sortedUnmet = [...unmetDetail].sort((a, b) =>
-          a.requester_name.localeCompare(b.requester_name)
+        // Tiebreak on requester_cm_id then target_cm_id so same-name requesters
+        // (Emma Johnson #1 vs Emma Johnson #2) render in deterministic order.
+        const sortedUnmet = [...unmetDetail].sort(
+          (a, b) =>
+            a.requester_name.localeCompare(b.requester_name) ||
+            a.requester_cm_id.localeCompare(b.requester_cm_id) ||
+            a.target_cm_id.localeCompare(b.target_cm_id)
         )
 
         return (

--- a/frontend/src/components/PdfExport/BunkPlanReport.tsx
+++ b/frontend/src/components/PdfExport/BunkPlanReport.tsx
@@ -1,5 +1,6 @@
 import { Document, Page, Text, View, StyleSheet, Image } from '@react-pdf/renderer'
 import type { ImpossibilityReport, ValidationStatistics } from '../../services/solver'
+import { friendlyReasonLabel } from '../impossibility/reasonHints'
 
 interface Props {
   sessionName: string
@@ -140,41 +141,11 @@ export function BunkPlanReport({
   const mpRate = statistics.material_parent_request_satisfaction_rate
   const mpTotal = statistics.material_parent_requests ?? 0
   const mpSatisfied = statistics.satisfied_material_parent_requests ?? 0
-  const overallRate = mpTotal > 0 ? mpRate : statistics.request_satisfaction_rate
-  const totalIssues =
-    (impossibilityReport.mp_campers_entirely_impossible?.length ?? 0) +
-    (statistics.negative_request_violations_detail?.length ?? 0) +
-    (statistics.priority_unsuccessfuls?.length ?? 0)
 
   // Unmet parent persons sorted alphabetically for page 3
   const unmetParents = [...(statistics.unsatisfied_material_parent_persons ?? [])].sort((a, b) =>
     a.name.localeCompare(b.name)
   )
-
-  // Coverage table rows
-  const coverageRows = [
-    {
-      label: 'All requests',
-      total: statistics.total_requests,
-      satisfied: statistics.satisfied_requests,
-      rate: statistics.request_satisfaction_rate,
-    },
-    {
-      label: 'Parent priority',
-      total: mpTotal,
-      satisfied: mpSatisfied,
-      rate: mpRate ?? 0,
-    },
-    ...Object.entries(statistics.field_stats)
-      .sort(([, a], [, b]) => b.total - a.total)
-      .slice(0, 4)
-      .map(([label, s]) => ({
-        label,
-        total: s.total,
-        satisfied: s.satisfied,
-        rate: s.satisfaction_rate,
-      })),
-  ]
 
   const generatedAt = new Date().toLocaleDateString('en-US', {
     year: 'numeric',
@@ -184,83 +155,116 @@ export function BunkPlanReport({
 
   return (
     <Document>
-      {/* ── Page 1 — Executive Summary ── */}
+      {/* ── Page 1 — Cover / Executive Summary (MSP-focused) ── */}
       <Page size="LETTER" style={styles.page}>
         {/* Brand header */}
         <View style={styles.brandHeader}>
           <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
             {logoUrl && <Image src={logoUrl} style={styles.logo} />}
             <View>
-              <Text style={styles.brandTitle}>Bunk Plan Report</Text>
+              <Text style={styles.brandTitle}>
+                Bunk Plan Report — {sessionName} · {year}
+              </Text>
               <Text style={styles.brandSubtitle}>
-                Generated {generatedAt} · Prepared by {plannerName}
+                Generated {generatedAt} by {plannerName}
               </Text>
             </View>
           </View>
-          <View style={styles.sessionBlock}>
-            <Text style={styles.sessionName}>{sessionName}</Text>
-            <Text style={styles.sessionYear}>{year}</Text>
-          </View>
         </View>
 
-        {/* KPI tiles */}
+        {/* KPI tiles — MSP-focused */}
         <Text style={styles.sectionTitle}>Executive Summary</Text>
         <View style={styles.kpiRow}>
           <View style={styles.kpi}>
-            <Text style={[styles.kpiValue, { color: coverageColor(overallRate ?? 0) }]}>
-              {pct(overallRate)}
+            <Text style={[styles.kpiValue, { color: coverageColor(mpRate ?? 0) }]}>
+              {pct(mpRate)}
             </Text>
-            <Text style={styles.kpiLabel}>Parent request{'\n'}satisfaction</Text>
+            <Text style={styles.kpiLabel}>MSP{'\n'}satisfaction</Text>
           </View>
           <View style={styles.kpi}>
-            <Text style={styles.kpiValue}>{statistics.assigned_campers}</Text>
+            <Text style={styles.kpiValue}>
+              {statistics.assigned_campers}/{statistics.total_campers}
+            </Text>
             <Text style={styles.kpiLabel}>Campers{'\n'}assigned</Text>
           </View>
           <View style={styles.kpi}>
             <Text style={styles.kpiValue}>
               {mpSatisfied}/{mpTotal || '—'}
             </Text>
-            <Text style={styles.kpiLabel}>Priority requests{'\n'}met</Text>
-          </View>
-          <View style={styles.kpi}>
-            <Text style={[styles.kpiValue, { color: totalIssues > 0 ? '#dc2626' : GREEN }]}>
-              {totalIssues}
-            </Text>
-            <Text style={styles.kpiLabel}>Action items{'\n'}flagged</Text>
+            <Text style={styles.kpiLabel}>MSP reqs{'\n'}met</Text>
           </View>
         </View>
 
-        {/* Coverage by category */}
-        <Text style={styles.sectionTitle}>Coverage by Category</Text>
+        {/* Coverage — MSP only */}
+        <Text style={styles.sectionTitle}>Coverage (MSP)</Text>
         <View style={styles.tableHead}>
           <Text style={{ flex: 2 }}>Category</Text>
-          <Text style={{ width: 40, textAlign: 'right' }}>Satisfied</Text>
-          <Text style={{ width: 30, textAlign: 'right' }}>Total</Text>
+          <Text style={{ width: 50, textAlign: 'right' }}>Satisfied</Text>
+          <Text style={{ width: 40, textAlign: 'right' }}>Total</Text>
           <Text style={{ width: 50, textAlign: 'right' }}>Rate</Text>
         </View>
-        {coverageRows.map((row, i) => (
-          <View
-            key={`cov-${i}`}
-            style={
-              i % 2 === 0 ? styles.coverageRow : { ...styles.coverageRow, backgroundColor: CREAM }
-            }
+        <View style={styles.coverageRow}>
+          <Text style={{ flex: 2, fontSize: 8 }}>Material satisfaction parent</Text>
+          <Text style={{ width: 50, textAlign: 'right', fontSize: 8 }}>{mpSatisfied}</Text>
+          <Text style={{ width: 40, textAlign: 'right', fontSize: 8 }}>{mpTotal}</Text>
+          <Text
+            style={{
+              width: 50,
+              textAlign: 'right',
+              fontSize: 8,
+              color: coverageColor(mpRate ?? 0),
+              fontWeight: 'bold',
+            }}
           >
-            <Text style={{ flex: 2, fontSize: 8 }}>{row.label}</Text>
-            <Text style={{ width: 40, textAlign: 'right', fontSize: 8 }}>{row.satisfied}</Text>
-            <Text style={{ width: 30, textAlign: 'right', fontSize: 8 }}>{row.total}</Text>
-            <Text
-              style={{
-                width: 50,
-                textAlign: 'right',
-                fontSize: 8,
-                color: coverageColor(row.rate),
-                fontWeight: 'bold',
-              }}
-            >
-              {pct(row.rate)}
-            </Text>
-          </View>
-        ))}
+            {pct(mpRate)}
+          </Text>
+        </View>
+
+        {/* Impossible by reason */}
+        <Text style={styles.sectionTitle}>Impossible by Reason</Text>
+        {Object.keys(impossibilityReport.by_reason ?? {}).length === 0 ? (
+          <Text style={styles.emptyNote}>No impossible requests.</Text>
+        ) : (
+          <>
+            <View style={styles.tableHead}>
+              <Text style={{ flex: 2 }}>Reason</Text>
+              <Text style={{ width: 50, textAlign: 'right' }}>Count</Text>
+            </View>
+            {Object.entries(impossibilityReport.by_reason ?? {}).map(([code, items], i) => (
+              <View
+                key={`reason-${code}`}
+                style={i % 2 === 0 ? styles.tableRow : styles.tableRowAlt}
+              >
+                <Text style={{ flex: 2, fontSize: 8 }}>{friendlyReasonLabel(code)}</Text>
+                <Text style={{ width: 50, textAlign: 'right', fontSize: 8 }}>
+                  {(items as unknown[]).length}
+                </Text>
+              </View>
+            ))}
+          </>
+        )}
+
+        {/* Capacity by gender */}
+        {statistics.capacity_by_gender && (
+          <>
+            <Text style={styles.sectionTitle}>Capacity by Gender</Text>
+            <View style={styles.tableHead}>
+              <Text style={{ flex: 2 }}>Gender</Text>
+              <Text style={{ width: 60, textAlign: 'right' }}>Assigned</Text>
+              <Text style={{ width: 60, textAlign: 'right' }}>Capacity</Text>
+            </View>
+            {Object.entries(statistics.capacity_by_gender).map(([gender, data], i) => (
+              <View
+                key={`cap-${gender}`}
+                style={i % 2 === 0 ? styles.tableRow : styles.tableRowAlt}
+              >
+                <Text style={{ flex: 2, fontSize: 8, textTransform: 'capitalize' }}>{gender}</Text>
+                <Text style={{ width: 60, textAlign: 'right', fontSize: 8 }}>{data.assigned}</Text>
+                <Text style={{ width: 60, textAlign: 'right', fontSize: 8 }}>{data.capacity}</Text>
+              </View>
+            ))}
+          </>
+        )}
 
         <Text style={styles.metaLine}>
           Bunks: {statistics.bunks_at_capacity} at capacity · {statistics.bunks_under_capacity}{' '}

--- a/frontend/src/components/PdfExport/BunkPlanReport.tsx
+++ b/frontend/src/components/PdfExport/BunkPlanReport.tsx
@@ -12,7 +12,12 @@ interface Props {
   impossibilityReport: ImpossibilityReport
   /** Optional branded logo — pass /local/assets/camp-logo.png from caller */
   logoUrl?: string
-  issues?: Array<{ type: string; severity: string; message: string }>
+  issues?: Array<{
+    type: string
+    severity: string
+    message: string
+    details?: Record<string, unknown>
+  }>
 }
 
 // Theme: forest green, amber, cream (generic Tawonga-inspired palette)
@@ -211,7 +216,7 @@ export function BunkPlanReport({
           <Text style={{ width: 50, textAlign: 'right' }}>Rate</Text>
         </View>
         <View style={styles.coverageRow}>
-          <Text style={{ flex: 2, fontSize: 8 }}>Material satisfaction parent</Text>
+          <Text style={{ flex: 2, fontSize: 8 }}>MP satisfaction</Text>
           <Text style={{ width: 50, textAlign: 'right', fontSize: 8 }}>{mpSatisfied}</Text>
           <Text style={{ width: 40, textAlign: 'right', fontSize: 8 }}>{mpTotal}</Text>
           <Text
@@ -320,91 +325,6 @@ export function BunkPlanReport({
         )
       })()}
 
-      {/* ── Page 3 — Action Lists (legacy) ── */}
-      <Page size="LETTER" style={styles.page}>
-        {/* Who Got Nothing */}
-        <Text style={styles.sectionTitle}>Who Got Nothing</Text>
-        {(impossibilityReport.mp_campers_entirely_impossible?.length ?? 0) === 0 ? (
-          <Text style={styles.emptyNote}>No campers with entirely impossible requests.</Text>
-        ) : (
-          <>
-            <View style={styles.tableHead}>
-              <Text style={styles.cellWide}>Camper</Text>
-              <Text style={styles.cell}>Gender</Text>
-              <Text style={styles.cell}>Grade</Text>
-              <Text style={styles.cellWide}>Reason codes</Text>
-            </View>
-            {(impossibilityReport.mp_campers_entirely_impossible ?? []).map((c, i) => (
-              <View
-                key={`imp-${c.cm_id}`}
-                style={i % 2 === 0 ? styles.tableRow : styles.tableRowAlt}
-              >
-                <Text style={styles.cellWide}>{c.name}</Text>
-                <Text style={styles.cell}>{c.gender}</Text>
-                <Text style={styles.cell}>{c.grade}</Text>
-                <Text style={styles.cellWide}>{(c.reason_codes ?? []).join(', ') || '—'}</Text>
-              </View>
-            ))}
-          </>
-        )}
-
-        {/* Families to Call */}
-        <Text style={styles.sectionTitle}>Families to Call</Text>
-        {(statistics.negative_request_violations_detail?.length ?? 0) === 0 ? (
-          <Text style={styles.emptyNote}>No not-bunk-with violations.</Text>
-        ) : (
-          <>
-            <View style={styles.tableHead}>
-              <Text style={styles.cellWide}>Requester</Text>
-              <Text style={styles.cellWide}>Placed with</Text>
-              <Text style={styles.cell}>Bunk</Text>
-            </View>
-            {(statistics.negative_request_violations_detail ?? []).map((v, i) => (
-              <View
-                key={`nbw-${v.requester_cm_id}-${v.target_cm_id}`}
-                style={i % 2 === 0 ? styles.tableRow : styles.tableRowAlt}
-              >
-                <Text style={styles.cellWide}>{v.requester_name}</Text>
-                <Text style={styles.cellWide}>{v.target_name}</Text>
-                <Text style={styles.cell}>{v.bunk_name}</Text>
-              </View>
-            ))}
-          </>
-        )}
-
-        {/* Priority Unsuccessfuls */}
-        <Text style={styles.sectionTitle}>Priority Unsuccessfuls</Text>
-        {(statistics.priority_unsuccessfuls?.length ?? 0) === 0 ? (
-          <Text style={styles.emptyNote}>No priority-keyword requests went unmet.</Text>
-        ) : (
-          <>
-            <View style={styles.tableHead}>
-              <Text style={styles.cellWide}>Requester</Text>
-              <Text style={styles.cellWide}>Requested</Text>
-              <Text style={styles.cellWide}>Original text</Text>
-            </View>
-            {(statistics.priority_unsuccessfuls ?? []).map((p, i) => (
-              <View
-                key={`pu-${p.requester_cm_id}-${p.target_cm_id}`}
-                style={i % 2 === 0 ? styles.tableRow : styles.tableRowAlt}
-              >
-                <Text style={styles.cellWide}>{p.requester_name}</Text>
-                <Text style={styles.cellWide}>{p.target_name}</Text>
-                <Text style={styles.cellWide}>{p.raw_text}</Text>
-              </View>
-            ))}
-          </>
-        )}
-
-        <Text
-          style={styles.footer}
-          render={({ pageNumber, totalPages }: { pageNumber: number; totalPages: number }) =>
-            `Page ${pageNumber} of ${totalPages} · Action Items`
-          }
-          fixed
-        />
-      </Page>
-
       {/* ── Page 3 — Bunks needing attention / Other issues / Unmet drill-down ── */}
       {(() => {
         const issuesList = issues ?? []
@@ -421,7 +341,7 @@ export function BunkPlanReport({
         // Group bunk-level issues by extracted bunk name
         const bunkMap = new Map<string, typeof bunkLevelIssues>()
         for (const issue of bunkLevelIssues) {
-          const bunk = extractBunkName(issue.message)
+          const bunk = extractBunkName(issue)
           const arr = bunkMap.get(bunk) ?? []
           arr.push(issue)
           bunkMap.set(bunk, arr)

--- a/frontend/src/components/PdfExport/BunkPlanReport.tsx
+++ b/frontend/src/components/PdfExport/BunkPlanReport.tsx
@@ -2,6 +2,7 @@ import { Document, Page, Text, View, StyleSheet, Image } from '@react-pdf/render
 import type { ImpossibilityReport, ValidationStatistics } from '../../services/solver'
 import { friendlyReasonLabel } from '../impossibility/reasonHints'
 import { buildFamilyRows, cohortLabel } from './familyRows'
+import { BUNK_LEVEL_ISSUE_TYPES, SUPPRESSED_ISSUE_TYPES, extractBunkName } from '../issueClassifier'
 
 interface Props {
   sessionName: string
@@ -11,6 +12,7 @@ interface Props {
   impossibilityReport: ImpossibilityReport
   /** Optional branded logo — pass /local/assets/camp-logo.png from caller */
   logoUrl?: string
+  issues?: Array<{ type: string; severity: string; message: string }>
 }
 
 // Theme: forest green, amber, cream (generic Tawonga-inspired palette)
@@ -139,6 +141,7 @@ export function BunkPlanReport({
   statistics,
   impossibilityReport,
   logoUrl,
+  issues,
 }: Props) {
   const mpRate = statistics.material_parent_request_satisfaction_rate
   const mpTotal = statistics.material_parent_requests ?? 0
@@ -398,7 +401,103 @@ export function BunkPlanReport({
         />
       </Page>
 
-      {/* ── Page 3 — Full unmet alphabetical list ── */}
+      {/* ── Page 3 — Bunks needing attention / Other issues / Unmet drill-down ── */}
+      {(() => {
+        const issuesList = issues ?? []
+        const bunkLevelIssues = issuesList.filter((i) => BUNK_LEVEL_ISSUE_TYPES.has(i.type))
+        const otherIssues = issuesList.filter(
+          (i) => !BUNK_LEVEL_ISSUE_TYPES.has(i.type) && !SUPPRESSED_ISSUE_TYPES.has(i.type)
+        )
+        const unmetDetail = statistics.unsatisfied_material_parent_detail ?? []
+
+        if (bunkLevelIssues.length === 0 && otherIssues.length === 0 && unmetDetail.length === 0) {
+          return null
+        }
+
+        // Group bunk-level issues by extracted bunk name
+        const bunkMap = new Map<string, typeof bunkLevelIssues>()
+        for (const issue of bunkLevelIssues) {
+          const bunk = extractBunkName(issue.message)
+          const arr = bunkMap.get(bunk) ?? []
+          arr.push(issue)
+          bunkMap.set(bunk, arr)
+        }
+        const issuesByBunk = [...bunkMap.entries()].sort(([a], [b]) => a.localeCompare(b))
+
+        // Group other issues by type
+        const otherMap = new Map<string, typeof otherIssues>()
+        for (const issue of otherIssues) {
+          const arr = otherMap.get(issue.type) ?? []
+          arr.push(issue)
+          otherMap.set(issue.type, arr)
+        }
+        const groupedOther = [...otherMap.entries()]
+
+        const sortedUnmet = [...unmetDetail].sort((a, b) =>
+          a.requester_name.localeCompare(b.requester_name)
+        )
+
+        return (
+          <Page size="LETTER" style={styles.page} wrap>
+            {issuesByBunk.length > 0 && (
+              <>
+                <Text style={styles.sectionTitle}>
+                  Bunks needing attention ({issuesByBunk.length})
+                </Text>
+                {issuesByBunk.map(([bunkName, items]) => (
+                  <View key={bunkName} style={styles.tableRow} wrap={false}>
+                    <Text style={[styles.cell, { fontWeight: 700 }]}>{bunkName}</Text>
+                    <Text style={[styles.cell, { flex: 3 }]}>
+                      {items.map((it) => it.type.replace(/_/g, ' ')).join(', ')}
+                    </Text>
+                  </View>
+                ))}
+              </>
+            )}
+
+            {groupedOther.length > 0 && (
+              <>
+                <Text style={styles.sectionTitle}>Other issues</Text>
+                {groupedOther.map(([type, items]) => (
+                  <View key={type} style={styles.tableRow} wrap={false}>
+                    <Text style={styles.cell}>{type.replace(/_/g, ' ')}</Text>
+                    <Text style={styles.cell}>{items.length}</Text>
+                  </View>
+                ))}
+              </>
+            )}
+
+            {sortedUnmet.length > 0 && (
+              <>
+                <Text style={styles.sectionTitle}>Unmet parent requests</Text>
+                {sortedUnmet.map((r) => (
+                  <View
+                    key={`${r.requester_cm_id}-${r.target_cm_id}`}
+                    style={styles.tableRow}
+                    wrap={false}
+                  >
+                    <Text style={styles.cell}>{r.requester_name}</Text>
+                    <Text style={styles.cell}>wanted {r.target_name}</Text>
+                    <Text style={styles.cell}>
+                      {r.requester_bunk_name} vs {r.target_bunk_name}
+                    </Text>
+                  </View>
+                ))}
+              </>
+            )}
+
+            <Text
+              style={styles.footer}
+              render={({ pageNumber, totalPages }: { pageNumber: number; totalPages: number }) =>
+                `Page ${pageNumber} of ${totalPages}`
+              }
+              fixed
+            />
+          </Page>
+        )
+      })()}
+
+      {/* ── Page 4 — Full unmet alphabetical list ── */}
       <Page size="LETTER" style={styles.page}>
         <Text style={styles.sectionTitle}>Unmet Parent Requests (full list)</Text>
         {unmetParents.length === 0 ? (

--- a/frontend/src/components/PdfExport/LazyPdfExportButton.test.tsx
+++ b/frontend/src/components/PdfExport/LazyPdfExportButton.test.tsx
@@ -13,8 +13,11 @@ vi.mock('react-hot-toast', () => ({
 
 // Default mock: returns a benign blob. Individual tests override per-call.
 const mockToBlob = vi.fn(async () => new Blob(['mock-pdf'], { type: 'application/pdf' }))
+// pdfMock captures the React element passed to pdf() so tests can inspect the
+// props BunkPlanReport received (without triggering an actual PDF render).
+const pdfMock = vi.fn((_element: unknown) => ({ toBlob: mockToBlob }))
 vi.mock('@react-pdf/renderer', () => ({
-  pdf: () => ({ toBlob: mockToBlob }),
+  pdf: (element: unknown) => pdfMock(element),
 }))
 vi.mock('./BunkPlanReport', () => ({ BunkPlanReport: () => null }))
 
@@ -56,12 +59,14 @@ describe('LazyPdfExportButton', () => {
     toastError.mockReset()
     mockToBlob.mockReset()
     mockToBlob.mockResolvedValue(new Blob(['mock-pdf'], { type: 'application/pdf' }))
+    pdfMock.mockClear()
     // vi.spyOn auto-restores via vi.restoreAllMocks in vitest's afterEach
     // (config: restoreMocks/clearMocks). Use spyOn rather than direct prototype
     // assignment so sibling tests don't inherit the stubs.
     vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock')
     vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
     vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+    vi.spyOn(window, 'setTimeout')
   })
 
   it('renders a single Export PDF button matching the green primary style', () => {
@@ -88,5 +93,66 @@ describe('LazyPdfExportButton', () => {
     expect(toastError.mock.calls[0]?.[0]).toMatch(/pdf/i)
     // Button returns to ready state (not stuck on "Preparing PDF…")
     expect(screen.getByRole('button', { name: /export pdf/i })).not.toBeDisabled()
+  })
+
+  // #2 — logoUrl must reach BunkPlanReport so the cover-page <Image src={logoUrl}>
+  // actually renders. Previously logoUrl was a typed slot on BunkPlanReport but
+  // had no caller path — every exported PDF shipped logo-less.
+  it('forwards logoUrl prop through to BunkPlanReport', async () => {
+    render(<LazyPdfExportButton {...baseProps} logoUrl="/local/assets/camp-logo.png" />)
+    fireEvent.click(screen.getByRole('button', { name: /export pdf/i }))
+
+    await waitFor(() => expect(pdfMock).toHaveBeenCalled())
+    // pdf() is called with a React element whose .props mirrors what was passed
+    // to <BunkPlanReport {...props} />.
+    const element = pdfMock.mock.calls[0]?.[0] as { props: { logoUrl?: string } }
+    expect(element.props.logoUrl).toBe('/local/assets/camp-logo.png')
+  })
+
+  // #3 — URL.revokeObjectURL called synchronously after a.click() can cancel
+  // the download in some browsers (Safari, older Firefox). Defer via setTimeout
+  // so the browser has a microtask to begin fetching the blob.
+  it('defers URL.revokeObjectURL via setTimeout (sync revoke can cancel blob download in some browsers)', async () => {
+    render(<LazyPdfExportButton {...baseProps} />)
+    fireEvent.click(screen.getByRole('button', { name: /export pdf/i }))
+
+    await waitFor(() => expect(URL.revokeObjectURL).toHaveBeenCalled())
+    // Assert revoke was scheduled via setTimeout(fn, ≥0), not invoked
+    // straight from finally.
+    expect(window.setTimeout).toHaveBeenCalled()
+    const setTimeoutCalls = (window.setTimeout as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls
+    const hasRevokeTimer = setTimeoutCalls.some(([fn]) => typeof fn === 'function')
+    expect(hasRevokeTimer).toBe(true)
+  })
+
+  // #5 — Filesystem-illegal characters in sessionName (/ \ : * ? " ' < > | etc.)
+  // can break downloads on some OS/browser combos and break the synthetic anchor's
+  // download attribute on Windows.
+  it('sanitizes filesystem-illegal characters out of the PDF filename', async () => {
+    const setDownload = vi.fn()
+    vi.spyOn(document, 'createElement').mockImplementation(((tag: string) => {
+      if (tag !== 'a') return document.createElementNS('http://www.w3.org/1999/xhtml', tag)
+      const a = {
+        href: '',
+        set download(v: string) {
+          setDownload(v)
+        },
+        click: vi.fn(),
+        parentNode: null,
+      } as unknown as HTMLAnchorElement
+      return a
+    }) as typeof document.createElement)
+
+    render(<LazyPdfExportButton {...baseProps} sessionName="Session 3 / Pine: *test* | quotes?" />)
+    fireEvent.click(screen.getByRole('button', { name: /export pdf/i }))
+
+    await waitFor(() => expect(setDownload).toHaveBeenCalled())
+    const filename = setDownload.mock.calls[0]?.[0] as string
+    // No slashes, colons, asterisks, pipes, or quotes
+    expect(filename).not.toMatch(/[/\\:*?"'<>|]/)
+    // Still contains a recognizable session token + year + extension
+    expect(filename).toMatch(/^bunk-plan-.*-2026\.pdf$/)
+    expect(filename.toLowerCase()).toContain('session')
   })
 })

--- a/frontend/src/components/PdfExport/LazyPdfExportButton.test.tsx
+++ b/frontend/src/components/PdfExport/LazyPdfExportButton.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { LazyPdfExportButton } from './LazyPdfExportButton'
+
+// Mock the lazy imports so the test doesn't pull in @react-pdf/renderer
+vi.mock('@react-pdf/renderer', () => ({
+  pdf: () => ({ toBlob: async () => new Blob(['mock-pdf'], { type: 'application/pdf' }) }),
+}))
+vi.mock('./BunkPlanReport', () => ({ BunkPlanReport: () => null }))
+
+describe('LazyPdfExportButton', () => {
+  const baseProps = {
+    sessionName: 'Session 3',
+    year: 2026,
+    plannerName: 'Test Staff',
+    statistics: { total_campers: 50 } as any,
+    impossibilityReport: { by_reason: {}, total_impossible: 0, affected_campers: 0 } as any,
+  }
+
+  it('renders a single Export PDF button matching the green primary style', () => {
+    render(<LazyPdfExportButton {...baseProps} />)
+    const btn = screen.getByRole('button', { name: /export pdf/i })
+    expect(btn.className).toContain('bg-emerald-700')
+  })
+
+  it('triggers a single click → blob download (no two-click arm pattern)', async () => {
+    const createObjectURL = vi.fn(() => 'blob:mock')
+    const revokeObjectURL = vi.fn()
+    Object.assign(URL, { createObjectURL, revokeObjectURL })
+    const clickSpy = vi.fn()
+    HTMLAnchorElement.prototype.click = clickSpy
+
+    render(<LazyPdfExportButton {...baseProps} />)
+    fireEvent.click(screen.getByRole('button', { name: /export pdf/i }))
+
+    await waitFor(() => expect(clickSpy).toHaveBeenCalled())
+    expect(createObjectURL).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/PdfExport/LazyPdfExportButton.test.tsx
+++ b/frontend/src/components/PdfExport/LazyPdfExportButton.test.tsx
@@ -1,21 +1,68 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { LazyPdfExportButton } from './LazyPdfExportButton'
+import type { ImpossibilityReport, ValidationStatistics } from '../../services/solver'
 
-// Mock the lazy imports so the test doesn't pull in @react-pdf/renderer
+// Mock react-hot-toast so we can assert error surfacing without
+// pulling in the full toaster runtime.
+const toastError = vi.fn()
+vi.mock('react-hot-toast', () => ({
+  default: { error: (msg: string) => toastError(msg) },
+  toast: { error: (msg: string) => toastError(msg) },
+}))
+
+// Default mock: returns a benign blob. Individual tests override per-call.
+const mockToBlob = vi.fn(async () => new Blob(['mock-pdf'], { type: 'application/pdf' }))
 vi.mock('@react-pdf/renderer', () => ({
-  pdf: () => ({ toBlob: async () => new Blob(['mock-pdf'], { type: 'application/pdf' }) }),
+  pdf: () => ({ toBlob: mockToBlob }),
 }))
 vi.mock('./BunkPlanReport', () => ({ BunkPlanReport: () => null }))
 
+const baseStats: ValidationStatistics = {
+  total_campers: 50,
+  assigned_campers: 48,
+  unassigned_campers: 2,
+  total_requests: 0,
+  satisfied_requests: 0,
+  request_satisfaction_rate: 0,
+  bunks_at_capacity: 0,
+  bunks_under_capacity: 0,
+  bunks_over_capacity: 0,
+  material_parent_requests: 0,
+  satisfied_material_parent_requests: 0,
+  material_parent_request_satisfaction_rate: 0,
+  campers_with_unsatisfied_material_parent_requests: 0,
+  best_effort_parent_requests: 0,
+  satisfied_best_effort_parent_requests: 0,
+  best_effort_parent_request_satisfaction_rate: 0,
+  field_stats: {},
+}
+const baseImpossibility: ImpossibilityReport = {
+  by_reason: {},
+  total_impossible: 0,
+  affected_campers: 0,
+  flat: [],
+}
+const baseProps = {
+  sessionName: 'Session 3',
+  year: 2026,
+  plannerName: 'Test Staff',
+  statistics: baseStats,
+  impossibilityReport: baseImpossibility,
+}
+
 describe('LazyPdfExportButton', () => {
-  const baseProps = {
-    sessionName: 'Session 3',
-    year: 2026,
-    plannerName: 'Test Staff',
-    statistics: { total_campers: 50 } as any,
-    impossibilityReport: { by_reason: {}, total_impossible: 0, affected_campers: 0 } as any,
-  }
+  beforeEach(() => {
+    toastError.mockReset()
+    mockToBlob.mockReset()
+    mockToBlob.mockResolvedValue(new Blob(['mock-pdf'], { type: 'application/pdf' }))
+    // vi.spyOn auto-restores via vi.restoreAllMocks in vitest's afterEach
+    // (config: restoreMocks/clearMocks). Use spyOn rather than direct prototype
+    // assignment so sibling tests don't inherit the stubs.
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock')
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+  })
 
   it('renders a single Export PDF button matching the green primary style', () => {
     render(<LazyPdfExportButton {...baseProps} />)
@@ -24,16 +71,22 @@ describe('LazyPdfExportButton', () => {
   })
 
   it('triggers a single click → blob download (no two-click arm pattern)', async () => {
-    const createObjectURL = vi.fn(() => 'blob:mock')
-    const revokeObjectURL = vi.fn()
-    Object.assign(URL, { createObjectURL, revokeObjectURL })
-    const clickSpy = vi.fn()
-    HTMLAnchorElement.prototype.click = clickSpy
+    render(<LazyPdfExportButton {...baseProps} />)
+    fireEvent.click(screen.getByRole('button', { name: /export pdf/i }))
+
+    await waitFor(() => expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled())
+    expect(URL.createObjectURL).toHaveBeenCalled()
+  })
+
+  it('surfaces a toast error and revokes any blob URL when PDF generation rejects', async () => {
+    mockToBlob.mockRejectedValueOnce(new Error('font load failed'))
 
     render(<LazyPdfExportButton {...baseProps} />)
     fireEvent.click(screen.getByRole('button', { name: /export pdf/i }))
 
-    await waitFor(() => expect(clickSpy).toHaveBeenCalled())
-    expect(createObjectURL).toHaveBeenCalled()
+    await waitFor(() => expect(toastError).toHaveBeenCalled())
+    expect(toastError.mock.calls[0]?.[0]).toMatch(/pdf/i)
+    // Button returns to ready state (not stuck on "Preparing PDF…")
+    expect(screen.getByRole('button', { name: /export pdf/i })).not.toBeDisabled()
   })
 })

--- a/frontend/src/components/PdfExport/LazyPdfExportButton.tsx
+++ b/frontend/src/components/PdfExport/LazyPdfExportButton.tsx
@@ -9,6 +9,7 @@
 import { useState } from 'react'
 import toast from 'react-hot-toast'
 import type { ImpossibilityReport, ValidationStatistics } from '../../services/solver'
+import type { PostCheckIssue } from '../issueClassifier'
 
 interface LazyPdfExportButtonProps {
   sessionName: string
@@ -16,12 +17,23 @@ interface LazyPdfExportButtonProps {
   plannerName: string
   statistics: ValidationStatistics
   impossibilityReport: ImpossibilityReport
-  issues?: Array<{
-    type: string
-    severity: string
-    message: string
-    details?: Record<string, unknown>
-  }>
+  issues?: PostCheckIssue[]
+  /** Optional branded logo URL (e.g. /local/assets/camp-logo.png) for the PDF cover. */
+  logoUrl?: string
+}
+
+// Lowercase, hyphenate whitespace, strip anything outside [a-z0-9-_] so the
+// resulting <a download="..."> attribute is safe on Windows/macOS/Linux and in
+// Safari/Chrome/Firefox. Falls back to "session" if the input is all-junk.
+function sanitizeForFilename(raw: string): string {
+  const cleaned = raw
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-_]/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+  return cleaned || 'session'
 }
 
 export function LazyPdfExportButton(props: LazyPdfExportButtonProps) {
@@ -37,7 +49,7 @@ export function LazyPdfExportButton(props: LazyPdfExportButtonProps) {
         import('@react-pdf/renderer'),
         import('./BunkPlanReport'),
       ])
-      const filename = `bunk-plan-${props.sessionName.replace(/\s+/g, '-').toLowerCase()}-${props.year}.pdf`
+      const filename = `bunk-plan-${sanitizeForFilename(props.sessionName)}-${props.year}.pdf`
       const blob = await pdf(<BunkPlanReport {...props} />).toBlob()
       url = URL.createObjectURL(blob)
       a = document.createElement('a')
@@ -50,7 +62,12 @@ export function LazyPdfExportButton(props: LazyPdfExportButtonProps) {
       toast.error('PDF export failed. Please try again.')
     } finally {
       if (a && a.parentNode) a.parentNode.removeChild(a)
-      if (url) URL.revokeObjectURL(url)
+      // Defer revoke so the browser has a tick to start fetching the blob.
+      // Safari and older Firefox can cancel the download otherwise.
+      if (url) {
+        const blobUrl = url
+        setTimeout(() => URL.revokeObjectURL(blobUrl), 0)
+      }
       setBusy(false)
     }
   }

--- a/frontend/src/components/PdfExport/LazyPdfExportButton.tsx
+++ b/frontend/src/components/PdfExport/LazyPdfExportButton.tsx
@@ -1,35 +1,13 @@
 /**
- * LazyPdfExportButton — defers loading @react-pdf/renderer (~1 MB) until
- * the user explicitly clicks "Export PDF". This keeps the renderer bundle
- * out of the main chunk entirely.
+ * LazyPdfExportButton — single-click download.
  *
- * Two-phase render:
- *  1. Initial: plain "Export PDF" button (zero PDF overhead).
- *  2. After click: React.lazy loads PDFDownloadLink + BunkPlanReport together,
- *     shown behind a Suspense fallback.
+ * Lazy-loads @react-pdf/renderer and BunkPlanReport on first click,
+ * generates the PDF as a Blob, and triggers a browser download via a
+ * synthetic <a> click. Browser settings (e.g. "always ask where to save")
+ * control whether the OS save-as dialog appears.
  */
-import { Suspense, lazy, useState } from 'react'
-import type { ComponentProps } from 'react'
+import { useState } from 'react'
 import type { ImpossibilityReport, ValidationStatistics } from '../../services/solver'
-
-// Lazy-loaded inner component — imports BOTH @react-pdf/renderer and BunkPlanReport
-// so neither ends up in the main bundle.
-const PdfDownloadLink = lazy(async () => {
-  const [{ PDFDownloadLink }, mod] = await Promise.all([
-    import('@react-pdf/renderer'),
-    import('./BunkPlanReport'),
-  ])
-  return {
-    default: ({
-      filename,
-      ...reportProps
-    }: ComponentProps<typeof mod.BunkPlanReport> & { filename: string }) => (
-      <PDFDownloadLink document={<mod.BunkPlanReport {...reportProps} />} fileName={filename}>
-        {({ loading }: { loading: boolean }) => (loading ? 'Preparing PDF…' : 'Download PDF')}
-      </PDFDownloadLink>
-    ),
-  }
-})
 
 interface LazyPdfExportButtonProps {
   sessionName: string
@@ -40,26 +18,39 @@ interface LazyPdfExportButtonProps {
 }
 
 export function LazyPdfExportButton(props: LazyPdfExportButtonProps) {
-  const [armed, setArmed] = useState(false)
+  const [busy, setBusy] = useState(false)
 
-  if (!armed) {
-    return (
-      <button
-        type="button"
-        onClick={() => setArmed(true)}
-        className="rounded bg-emerald-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-800"
-      >
-        Export PDF
-      </button>
-    )
+  async function handleClick() {
+    if (busy) return
+    setBusy(true)
+    try {
+      const [{ pdf }, { BunkPlanReport }] = await Promise.all([
+        import('@react-pdf/renderer'),
+        import('./BunkPlanReport'),
+      ])
+      const filename = `bunk-plan-${props.sessionName.replace(/\s+/g, '-').toLowerCase()}-${props.year}.pdf`
+      const blob = await pdf(<BunkPlanReport {...props} />).toBlob()
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = filename
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+    } finally {
+      setBusy(false)
+    }
   }
 
   return (
-    <Suspense fallback={<span className="text-sm text-stone-500">Loading PDF renderer…</span>}>
-      <PdfDownloadLink
-        {...props}
-        filename={`bunk-plan-${props.sessionName.replace(/\s+/g, '-').toLowerCase()}-${props.year}.pdf`}
-      />
-    </Suspense>
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={busy}
+      className="rounded bg-emerald-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-800 disabled:opacity-60"
+    >
+      {busy ? 'Preparing PDF…' : 'Export PDF'}
+    </button>
   )
 }

--- a/frontend/src/components/PdfExport/LazyPdfExportButton.tsx
+++ b/frontend/src/components/PdfExport/LazyPdfExportButton.tsx
@@ -15,6 +15,7 @@ interface LazyPdfExportButtonProps {
   plannerName: string
   statistics: ValidationStatistics
   impossibilityReport: ImpossibilityReport
+  issues?: Array<{ type: string; severity: string; message: string }>
 }
 
 export function LazyPdfExportButton(props: LazyPdfExportButtonProps) {

--- a/frontend/src/components/PdfExport/LazyPdfExportButton.tsx
+++ b/frontend/src/components/PdfExport/LazyPdfExportButton.tsx
@@ -7,6 +7,7 @@
  * control whether the OS save-as dialog appears.
  */
 import { useState } from 'react'
+import toast from 'react-hot-toast'
 import type { ImpossibilityReport, ValidationStatistics } from '../../services/solver'
 
 interface LazyPdfExportButtonProps {
@@ -15,7 +16,12 @@ interface LazyPdfExportButtonProps {
   plannerName: string
   statistics: ValidationStatistics
   impossibilityReport: ImpossibilityReport
-  issues?: Array<{ type: string; severity: string; message: string }>
+  issues?: Array<{
+    type: string
+    severity: string
+    message: string
+    details?: Record<string, unknown>
+  }>
 }
 
 export function LazyPdfExportButton(props: LazyPdfExportButtonProps) {
@@ -24,6 +30,8 @@ export function LazyPdfExportButton(props: LazyPdfExportButtonProps) {
   async function handleClick() {
     if (busy) return
     setBusy(true)
+    let url: string | null = null
+    let a: HTMLAnchorElement | null = null
     try {
       const [{ pdf }, { BunkPlanReport }] = await Promise.all([
         import('@react-pdf/renderer'),
@@ -31,15 +39,18 @@ export function LazyPdfExportButton(props: LazyPdfExportButtonProps) {
       ])
       const filename = `bunk-plan-${props.sessionName.replace(/\s+/g, '-').toLowerCase()}-${props.year}.pdf`
       const blob = await pdf(<BunkPlanReport {...props} />).toBlob()
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement('a')
+      url = URL.createObjectURL(blob)
+      a = document.createElement('a')
       a.href = url
       a.download = filename
       document.body.appendChild(a)
       a.click()
-      document.body.removeChild(a)
-      URL.revokeObjectURL(url)
+    } catch (err) {
+      console.error('PDF export failed', err)
+      toast.error('PDF export failed. Please try again.')
     } finally {
+      if (a && a.parentNode) a.parentNode.removeChild(a)
+      if (url) URL.revokeObjectURL(url)
       setBusy(false)
     }
   }

--- a/frontend/src/components/PdfExport/familyRows.ts
+++ b/frontend/src/components/PdfExport/familyRows.ts
@@ -14,7 +14,7 @@ export type FamilyRowData = {
 
 export function buildFamilyRows(
   statistics: ValidationStatistics,
-  impossibilityReport: ImpossibilityReport,
+  impossibilityReport: ImpossibilityReport
 ): FamilyRowData[] {
   const rows: FamilyRowData[] = []
 
@@ -56,4 +56,8 @@ export function buildFamilyRows(
 }
 
 export const cohortLabel = (c: FamilyCohort): string =>
-  c === 'got_nothing' ? 'Got nothing' : c === 'violated' ? 'Not-bunk-with violated' : 'Priority unmet'
+  c === 'got_nothing'
+    ? 'Got nothing'
+    : c === 'violated'
+      ? 'Not-bunk-with violated'
+      : 'Priority unmet'

--- a/frontend/src/components/PdfExport/familyRows.ts
+++ b/frontend/src/components/PdfExport/familyRows.ts
@@ -1,0 +1,59 @@
+import type { ValidationStatistics, ImpossibilityReport } from '../../services/solver'
+import { friendlyReasonLabel } from '../impossibility/reasonHints'
+
+export type FamilyCohort = 'got_nothing' | 'violated' | 'priority_unmet'
+export type FamilyRowData = {
+  key: string
+  name: string
+  cm_id: string
+  grade: number
+  gender: string
+  cohort: FamilyCohort
+  detail: string
+}
+
+export function buildFamilyRows(
+  statistics: ValidationStatistics,
+  impossibilityReport: ImpossibilityReport,
+): FamilyRowData[] {
+  const rows: FamilyRowData[] = []
+
+  for (const c of impossibilityReport.mp_campers_entirely_impossible ?? []) {
+    rows.push({
+      key: `gn-${c.cm_id}`,
+      name: c.name,
+      cm_id: String(c.cm_id),
+      grade: c.grade,
+      gender: c.gender,
+      cohort: 'got_nothing',
+      detail: `All requests impossible · ${c.reason_codes.map(friendlyReasonLabel).join(', ')}`,
+    })
+  }
+  for (const v of statistics.negative_request_violations_detail ?? []) {
+    rows.push({
+      key: `nv-${v.requester_cm_id}-${v.target_cm_id}-${v.bunk_cm_id}`,
+      name: v.requester_name,
+      cm_id: v.requester_cm_id,
+      grade: 0,
+      gender: '',
+      cohort: 'violated',
+      detail: `Placed with ${v.target_name} in ${v.bunk_name}`,
+    })
+  }
+  for (const p of statistics.priority_unsuccessfuls ?? []) {
+    rows.push({
+      key: `pu-${p.requester_cm_id}-${p.target_cm_id}`,
+      name: p.requester_name,
+      cm_id: p.requester_cm_id,
+      grade: 0,
+      gender: '',
+      cohort: 'priority_unmet',
+      detail: `Wanted ${p.target_name} · "${p.raw_text}"`,
+    })
+  }
+  rows.sort((a, b) => a.name.localeCompare(b.name) || a.grade - b.grade)
+  return rows
+}
+
+export const cohortLabel = (c: FamilyCohort): string =>
+  c === 'got_nothing' ? 'Got nothing' : c === 'violated' ? 'Not-bunk-with violated' : 'Priority unmet'

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -1088,3 +1088,38 @@ describe('PostValidationResultsModal — Capacity by gender section', () => {
     expect(screen.queryByText(/capacity by gender/i)).not.toBeInTheDocument()
   })
 })
+
+describe('PostValidationResultsModal — Bunks needing attention', () => {
+  it('groups bunk-level issues into one row per bunk with chips', () => {
+    const issues = [
+      { type: 'capacity_violation', severity: 'error', message: 'Pine 3 over capacity (9/8)' },
+      { type: 'grade_ratio_warning', severity: 'warning', message: 'Pine 3 has 75% one grade' },
+      { type: 'age_spread_warning', severity: 'warning', message: 'Oak 2 age gap 26 months' },
+    ]
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{ ...makeResults(), issues }}
+      />
+    )
+    expect(screen.getByText(/bunks needing attention/i)).toBeInTheDocument()
+    // Pine 3 appears in both the bunk row and the issues list — use getAllByText
+    expect(screen.getAllByText(/Pine 3/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/Oak 2/).length).toBeGreaterThan(0)
+  })
+
+  it('hides section when no bunk-level issues', () => {
+    const issues = [{ type: 'unassigned_campers', severity: 'error', message: '2 unassigned' }]
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{ ...makeResults(), issues }}
+      />
+    )
+    expect(screen.queryByText(/bunks needing attention/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -897,16 +897,41 @@ describe('PostValidationResultsModal — Families to contact', () => {
   it('combines impossibility, not-bunk-with violations, and priority unmet sorted by first name', () => {
     const impossibilityReport = makeImpossibilityReport({
       mp_campers_entirely_impossible: [
-        { cm_id: 1001, name: 'Olivia Chen', grade: 4, gender: 'F', reason_codes: ['pair_no_shared_bunk'] },
-        { cm_id: 1002, name: 'Emma Johnson', grade: 5, gender: 'F', reason_codes: ['grade_compatibility'] },
+        {
+          cm_id: 1001,
+          name: 'Olivia Chen',
+          grade: 4,
+          gender: 'F',
+          reason_codes: ['pair_no_shared_bunk'],
+        },
+        {
+          cm_id: 1002,
+          name: 'Emma Johnson',
+          grade: 5,
+          gender: 'F',
+          reason_codes: ['grade_compatibility'],
+        },
       ],
     })
     const stats = makeStats({
       negative_request_violations_detail: [
-        { requester_cm_id: '1003', target_cm_id: '1004', requester_name: 'Riley Sam', target_name: 'Samuel Johnson', bunk_cm_id: '2001', bunk_name: 'Pine 3' },
+        {
+          requester_cm_id: '1003',
+          target_cm_id: '1004',
+          requester_name: 'Riley Sam',
+          target_name: 'Samuel Johnson',
+          bunk_cm_id: '2001',
+          bunk_name: 'Pine 3',
+        },
       ],
       priority_unsuccessfuls: [
-        { requester_cm_id: '1005', target_cm_id: '1006', requester_name: 'Sophia Martinez', target_name: 'Mia Wilson', raw_text: 'top priority' },
+        {
+          requester_cm_id: '1005',
+          target_cm_id: '1006',
+          requester_name: 'Sophia Martinez',
+          target_name: 'Mia Wilson',
+          raw_text: 'top priority',
+        },
       ],
     })
     render(
@@ -965,7 +990,14 @@ describe('PostValidationResultsModal — Unmet drill-down enriched', () => {
         onClose={() => {}}
         results={makeResults({
           unsatisfied_material_parent_detail: [
-            { requester_cm_id: '1', requester_name: 'Emma Johnson', target_cm_id: '2', target_name: 'Liam Garcia', requester_bunk_name: 'Pine 3', target_bunk_name: 'Oak 2' },
+            {
+              requester_cm_id: '1',
+              requester_name: 'Emma Johnson',
+              target_cm_id: '2',
+              target_name: 'Liam Garcia',
+              requester_bunk_name: 'Pine 3',
+              target_bunk_name: 'Oak 2',
+            },
           ],
           // Keep the legacy persons array so the section still renders
           unsatisfied_material_parent_persons: [{ cm_id: 1, name: 'Emma Johnson' }],
@@ -1031,7 +1063,7 @@ describe('PostValidationResultsModal — Impossible by reason kicker', () => {
       />
     )
     expect(
-      screen.getByText(/see Pre-Check or export PDF for full per-camper detail/i),
+      screen.getByText(/see Pre-Check or export PDF for full per-camper detail/i)
     ).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -1055,3 +1055,36 @@ describe('PostValidationResultsModal — Details by request source order', () =>
     ])
   })
 })
+
+describe('PostValidationResultsModal — Capacity by gender section', () => {
+  it('renders female and male capacity bars from statistics.capacity_by_gender', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({
+          capacity_by_gender: {
+            female: { capacity: 65, assigned: 62 },
+            male: { capacity: 85, assigned: 66 },
+          },
+        })}
+      />
+    )
+    expect(screen.getByText(/capacity by gender/i)).toBeInTheDocument()
+    expect(screen.getByText(/62.*\/.*65/)).toBeInTheDocument()
+    expect(screen.getByText(/66.*\/.*85/)).toBeInTheDocument()
+  })
+
+  it('hides Capacity by gender when field is absent', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults()}
+      />
+    )
+    expect(screen.queryByText(/capacity by gender/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -980,3 +980,58 @@ describe('PostValidationResultsModal — Unmet drill-down enriched', () => {
     expect(screen.getByText(/Oak 2/)).toBeInTheDocument()
   })
 })
+
+describe('PostValidationResultsModal — KPI tiles use MSP signal', () => {
+  it('shows material parent satisfaction percentage when MP requests exist', () => {
+    const stats = makeStats({
+      material_parent_requests: 12,
+      satisfied_material_parent_requests: 10,
+      material_parent_request_satisfaction_rate: 0.83,
+      total_requests: 50,
+      satisfied_requests: 30,
+      request_satisfaction_rate: 0.6,
+    })
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults(stats)}
+      />
+    )
+    expect(screen.getByText(/83\s*%/)).toBeInTheDocument()
+  })
+})
+
+describe('PostValidationResultsModal — Impossible by reason kicker', () => {
+  it('renders the "see Pre-Check or export PDF" kicker', () => {
+    const impossibilityReport = makeImpossibilityReport({
+      by_reason: {
+        grade_compatibility: [
+          {
+            request_id: 'r1',
+            reason_code: 'grade_compatibility',
+            reason_message: 'wide',
+            request_type: 'bunk_with',
+            requester: { cm_id: 1, name: 'X', grade: 5, gender: 'F' },
+            requestee: null,
+            detail: {},
+            bucket: null,
+          },
+        ],
+      },
+    })
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults()}
+        impossibilityReport={impossibilityReport}
+      />
+    )
+    expect(
+      screen.getByText(/see Pre-Check or export PDF for full per-camper detail/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -1120,6 +1120,50 @@ describe('PostValidationResultsModal — Bunks needing attention', () => {
         results={{ ...makeResults(), issues }}
       />
     )
-    expect(screen.queryByText(/bunks needing attention/i)).not.toBeInTheDocument()
+    // The "Other issues" subtitle mentions "Bunks needing attention" — use a
+    // heading-role query to verify the Bunks section heading itself is absent.
+    expect(
+      screen.queryByRole('heading', { name: /bunks needing attention/i })
+    ).not.toBeInTheDocument()
+  })
+})
+
+describe('PostValidationResultsModal — Other issues residual', () => {
+  it('hides suppressed types and renders only residual camper-level types', () => {
+    const issues = [
+      { type: 'valid_negative_request_violated', severity: 'error', message: 'X separated' },
+      { type: 'unassigned_campers', severity: 'error', message: '2 unassigned' },
+      { type: 'no_requests', severity: 'warning', message: 'Liam got nothing' },
+      { type: 'level_regression', severity: 'warning', message: 'Samuel regressed' },
+      { type: 'valid_request_unsatisfied', severity: 'warning', message: 'Emma unmet' },
+    ]
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{ ...makeResults(), issues }}
+      />
+    )
+    expect(screen.getByText(/other issues/i)).toBeInTheDocument()
+    expect(screen.getByText(/unassigned campers/i)).toBeInTheDocument()
+    expect(screen.getByText(/level regression/i)).toBeInTheDocument()
+    // Suppressed types absent (their typeLabels via getIssueTypeLabel):
+    // valid_negative_request_violated → "Valid Negative Request Violated"
+    expect(screen.queryByText(/valid negative request violated/i)).not.toBeInTheDocument()
+    // no_requests → "No Requests"
+    expect(screen.queryByText(/^no requests$/i)).not.toBeInTheDocument()
+  })
+
+  it('hides Other issues entirely when no residual issues', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults()}
+      />
+    )
+    expect(screen.queryByText(/^other issues$/i)).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -493,168 +493,6 @@ vi.mock('./CamperDetailsPanel', () => ({
 }))
 
 // ---------------------------------------------------------------------------
-// Task 4.3 — "Campers who got nothing" section
-// ---------------------------------------------------------------------------
-
-describe('PostValidationResultsModal — Campers who got nothing section (TG-4.3)', () => {
-  it('renders named tiles for entirely-impossible MP campers', () => {
-    render(
-      <PostValidationResultsModal
-        sessionCmId={1000001}
-        isOpen={true}
-        onClose={() => {}}
-        results={makeResults()}
-        impossibilityReport={makeImpossibilityReport({
-          mp_campers_entirely_impossible: [
-            { cm_id: 1001, name: 'Emma Johnson', gender: 'Girls', grade: 7, reason_codes: [] },
-            { cm_id: 1002, name: 'Liam Garcia', gender: 'Boys', grade: 4, reason_codes: [] },
-          ],
-        })}
-      />
-    )
-    expect(screen.getByText('Campers who got nothing')).toBeInTheDocument()
-    expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
-    expect(screen.getByText('Liam Garcia')).toBeInTheDocument()
-  })
-
-  it('does not render "Campers who got nothing" when the list is empty', () => {
-    render(
-      <PostValidationResultsModal
-        sessionCmId={1000001}
-        isOpen={true}
-        onClose={() => {}}
-        results={makeResults()}
-        impossibilityReport={makeImpossibilityReport({ mp_campers_entirely_impossible: [] })}
-      />
-    )
-    expect(screen.queryByText('Campers who got nothing')).not.toBeInTheDocument()
-  })
-
-  it('does not render "Campers who got nothing" when impossibilityReport is absent', () => {
-    render(
-      <PostValidationResultsModal
-        sessionCmId={1000001}
-        isOpen={true}
-        onClose={() => {}}
-        results={makeResults()}
-      />
-    )
-    expect(screen.queryByText('Campers who got nothing')).not.toBeInTheDocument()
-  })
-})
-
-// ---------------------------------------------------------------------------
-// Task 4.4 — "Families to call" section
-// ---------------------------------------------------------------------------
-
-describe('PostValidationResultsModal — Families to call section (TG-4.4)', () => {
-  it('renders Families to call list with named rows for not_bunk_with violations', () => {
-    render(
-      <PostValidationResultsModal
-        sessionCmId={1000001}
-        isOpen={true}
-        onClose={() => {}}
-        results={makeResults({
-          negative_request_violations_detail: [
-            {
-              requester_cm_id: '1003',
-              target_cm_id: '1004',
-              requester_name: 'Riley Sam',
-              target_name: 'Samuel Johnson',
-              bunk_cm_id: '2003',
-              bunk_name: 'Pine 3',
-            },
-          ],
-        })}
-      />
-    )
-    expect(screen.getByText('Families to call')).toBeInTheDocument()
-    expect(screen.getByText('Riley Sam')).toBeInTheDocument()
-    expect(screen.getByText('Samuel Johnson')).toBeInTheDocument()
-    expect(screen.getByText('Pine 3')).toBeInTheDocument()
-  })
-
-  it('does not render "Families to call" when negative_request_violations_detail is absent', () => {
-    render(
-      <PostValidationResultsModal
-        sessionCmId={1000001}
-        isOpen={true}
-        onClose={() => {}}
-        results={makeResults()}
-      />
-    )
-    expect(screen.queryByText('Families to call')).not.toBeInTheDocument()
-  })
-
-  it('does not render "Families to call" when negative_request_violations_detail is empty', () => {
-    render(
-      <PostValidationResultsModal
-        sessionCmId={1000001}
-        isOpen={true}
-        onClose={() => {}}
-        results={makeResults({ negative_request_violations_detail: [] })}
-      />
-    )
-    expect(screen.queryByText('Families to call')).not.toBeInTheDocument()
-  })
-})
-
-// ---------------------------------------------------------------------------
-// Task 4.5 — "Priority unsuccessfuls" section
-// ---------------------------------------------------------------------------
-
-describe('PostValidationResultsModal — Priority unsuccessfuls section (TG-4.5)', () => {
-  it('renders Priority unsuccessfuls with parent wording snippets', () => {
-    render(
-      <PostValidationResultsModal
-        sessionCmId={1000001}
-        isOpen={true}
-        onClose={() => {}}
-        results={makeResults({
-          priority_unsuccessfuls: [
-            {
-              requester_cm_id: '1005',
-              target_cm_id: '1006',
-              requester_name: 'Sophia Martinez',
-              target_name: 'Mia Wilson',
-              raw_text: 'Mia is our top priority',
-            },
-          ],
-        })}
-      />
-    )
-    expect(screen.getByText('Priority unsuccessfuls')).toBeInTheDocument()
-    expect(screen.getByText('Sophia Martinez')).toBeInTheDocument()
-    expect(screen.getByText('Mia Wilson')).toBeInTheDocument()
-    expect(screen.getByText(/Mia is our top priority/)).toBeInTheDocument()
-  })
-
-  it('does not render "Priority unsuccessfuls" when the list is absent', () => {
-    render(
-      <PostValidationResultsModal
-        sessionCmId={1000001}
-        isOpen={true}
-        onClose={() => {}}
-        results={makeResults()}
-      />
-    )
-    expect(screen.queryByText('Priority unsuccessfuls')).not.toBeInTheDocument()
-  })
-
-  it('does not render "Priority unsuccessfuls" when the list is empty', () => {
-    render(
-      <PostValidationResultsModal
-        sessionCmId={1000001}
-        isOpen={true}
-        onClose={() => {}}
-        results={makeResults({ priority_unsuccessfuls: [] })}
-      />
-    )
-    expect(screen.queryByText('Priority unsuccessfuls')).not.toBeInTheDocument()
-  })
-})
-
-// ---------------------------------------------------------------------------
 // Task 4.6 — "Impossibility by reason" section
 // ---------------------------------------------------------------------------
 
@@ -769,70 +607,6 @@ describe('PostValidationResultsModal — impossibility section (#1442 part 2)', 
     expect(screen.queryByText(/impossible request/i)).not.toBeInTheDocument()
   })
 
-  it('renders camper count and total impossible request count as separate, independent texts', () => {
-    // The camper count is "entirely-impossible MP campers" (zero parent reqs
-    // honored), while total_impossible spans ALL impossible requests in the
-    // scenario (including partially-impossible kids not named here). Combining
-    // them into "X campers had Y impossible requests" implies the Y belong to
-    // the X, which is wrong. Render them as two distinct statements.
-    const report = makeReport(
-      [
-        { cm_id: 1, name: 'Emma Johnson', grade: 5, gender: 'F', reason_codes: ['cross_session'] },
-        { cm_id: 2, name: 'Liam Garcia', grade: 5, gender: 'M', reason_codes: ['malformed'] },
-        {
-          cm_id: 3,
-          name: 'Olivia Chen',
-          grade: 6,
-          gender: 'F',
-          reason_codes: ['grade_compatibility'],
-        },
-      ],
-      5
-    )
-    render(
-      <PostValidationResultsModal
-        sessionCmId={1000001}
-        isOpen={true}
-        onClose={() => {}}
-        results={makeResults()}
-        impossibilityReport={report}
-      />
-    )
-
-    // Primary line: how many campers got zero parent requests honored.
-    expect(
-      screen.getByText(/3 campers won['’]t get any parent request fulfilled/i)
-    ).toBeInTheDocument()
-    // Secondary line: scenario-wide impossible request count, labeled as a
-    // separate fact (not "they had Y").
-    expect(screen.getByText(/5 impossible requests total in this scenario/i)).toBeInTheDocument()
-    // Guard against the misleading combined phrasing.
-    expect(screen.queryByText(/3 campers had 5 impossible requests/i)).not.toBeInTheDocument()
-  })
-
-  it('uses singular grammar when only one camper and one impossible request', () => {
-    const report = makeReport(
-      [{ cm_id: 1, name: 'Emma Johnson', grade: 5, gender: 'F', reason_codes: ['malformed'] }],
-      1
-    )
-    render(
-      <PostValidationResultsModal
-        sessionCmId={1000001}
-        isOpen={true}
-        onClose={() => {}}
-        results={makeResults()}
-        impossibilityReport={report}
-      />
-    )
-
-    expect(
-      screen.getByText(/1 camper won['’]t get any parent request fulfilled/i)
-    ).toBeInTheDocument()
-    expect(screen.queryByText(/1 campers/i)).not.toBeInTheDocument()
-    expect(screen.getByText(/1 impossible request total in this scenario/i)).toBeInTheDocument()
-    expect(screen.queryByText(/1 impossible requests/i)).not.toBeInTheDocument()
-  })
-
   it('opens the panel when a camper name in the section is clicked', async () => {
     const report = makeReport([
       { cm_id: 42, name: 'Olivia Chen', grade: 6, gender: 'F', reason_codes: ['cross_session'] },
@@ -872,55 +646,6 @@ describe('PostValidationResultsModal — impossibility section (#1442 part 2)', 
     const provider = await screen.findByTestId('bunk-request-provider')
     expect(provider).toHaveAttribute('data-session-cm-id', '9876543')
     expect(provider).toContainElement(screen.getByTestId('camper-details-panel'))
-  })
-
-  it('renders the per-camper hint from REASON_HINTS', () => {
-    const report = makeReport([
-      {
-        cm_id: 7,
-        name: 'Samuel Johnson',
-        grade: 5,
-        gender: 'M',
-        reason_codes: ['cross_session'],
-      },
-    ])
-    render(
-      <PostValidationResultsModal
-        sessionCmId={1000001}
-        isOpen={true}
-        onClose={() => {}}
-        results={makeResults()}
-        impossibilityReport={report}
-      />
-    )
-    expect(
-      screen.getByText(/requested friend is in a different session — confirm intent/)
-    ).toBeInTheDocument()
-  })
-
-  // Scan-it row 1: post-check used to render snake_case reason codes
-  // directly; pre-check has always run them through FRIENDLY_REASON_LABELS.
-  it('renders reason chips with the friendly label, not the raw snake_case code', () => {
-    const report = makeReport([
-      {
-        cm_id: 8,
-        name: 'Liam Garcia',
-        grade: 4,
-        gender: 'M',
-        reason_codes: ['grade_compatibility'],
-      },
-    ])
-    render(
-      <PostValidationResultsModal
-        sessionCmId={1000001}
-        isOpen={true}
-        onClose={() => {}}
-        results={makeResults()}
-        impossibilityReport={report}
-      />
-    )
-    expect(screen.getByText('Grade range too wide')).toBeInTheDocument()
-    expect(screen.queryByText('grade_compatibility')).not.toBeInTheDocument()
   })
 
   it('shows a small "pre-check unavailable" notice when preCheckError is true and no report is in', () => {
@@ -1165,5 +890,68 @@ describe('PostValidationResultsModal — Other issues residual', () => {
       />
     )
     expect(screen.queryByText(/^other issues$/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('PostValidationResultsModal — Families to contact', () => {
+  it('combines impossibility, not-bunk-with violations, and priority unmet sorted by first name', () => {
+    const impossibilityReport = makeImpossibilityReport({
+      mp_campers_entirely_impossible: [
+        { cm_id: 1001, name: 'Olivia Chen', grade: 4, gender: 'F', reason_codes: ['pair_no_shared_bunk'] },
+        { cm_id: 1002, name: 'Emma Johnson', grade: 5, gender: 'F', reason_codes: ['grade_compatibility'] },
+      ],
+    })
+    const stats = makeStats({
+      negative_request_violations_detail: [
+        { requester_cm_id: '1003', target_cm_id: '1004', requester_name: 'Riley Sam', target_name: 'Samuel Johnson', bunk_cm_id: '2001', bunk_name: 'Pine 3' },
+      ],
+      priority_unsuccessfuls: [
+        { requester_cm_id: '1005', target_cm_id: '1006', requester_name: 'Sophia Martinez', target_name: 'Mia Wilson', raw_text: 'top priority' },
+      ],
+    })
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults(stats)}
+        impossibilityReport={impossibilityReport}
+      />
+    )
+    expect(screen.getByText(/families to contact/i)).toBeInTheDocument()
+    const rowOrder = screen.getAllByRole('listitem').map((el) => el.textContent ?? '')
+    const indexOf = (name: string) => rowOrder.findIndex((t) => t.includes(name))
+    expect(indexOf('Emma Johnson')).toBeLessThan(indexOf('Olivia Chen'))
+    expect(indexOf('Olivia Chen')).toBeLessThan(indexOf('Riley Sam'))
+    expect(indexOf('Riley Sam')).toBeLessThan(indexOf('Sophia Martinez'))
+    expect(screen.getAllByText(/got nothing/i).length).toBe(2)
+    expect(screen.getByText(/not-bunk-with violated/i)).toBeInTheDocument()
+    expect(screen.getByText(/priority unmet/i)).toBeInTheDocument()
+  })
+
+  it('hides section when all three sources are empty', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults()}
+      />
+    )
+    expect(screen.queryByText(/families to contact/i)).not.toBeInTheDocument()
+  })
+
+  it('removes the old "Campers who got nothing", "Families to call", and "Priority unsuccessfuls" sections', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults()}
+      />
+    )
+    expect(screen.queryByText(/campers who got nothing/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/families to call/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/priority unsuccessfuls/i)).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -1018,3 +1018,40 @@ describe('PostValidationResultsModal — PDF export button (TG-5)', () => {
     expect(screen.getByRole('button', { name: /Export PDF/i })).toBeInTheDocument()
   })
 })
+
+describe('PostValidationResultsModal — Details by request source order', () => {
+  it('renders source-field rows in fixed backend order, not by count', async () => {
+    const stats = makeStats({
+      field_stats: {
+        socialize_with: { total: 100, satisfied: 50, satisfaction_rate: 0.5 },
+        share_bunk_with: { total: 10, satisfied: 8, satisfaction_rate: 0.8 },
+        do_not_share_with: { total: 5, satisfied: 4, satisfaction_rate: 0.8 },
+        bunking_notes: { total: 20, satisfied: 15, satisfaction_rate: 0.75 },
+        internal_notes: { total: 15, satisfied: 10, satisfaction_rate: 0.67 },
+      },
+    })
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults(stats)}
+      />
+    )
+    // Expand the "Details by request source" collapsible
+    await userEvent.click(screen.getByText(/details by request source/i))
+
+    // Get the visible row labels in render order
+    const labels = screen.getAllByText(
+      /Bunk Request Form|Do NOT Share Bunk With|Bunking Notes|Internal Notes|Social With Checkbox/
+    )
+    const order = labels.map((el) => el.textContent)
+    expect(order).toEqual([
+      'Bunk Request Form',
+      'Do NOT Share Bunk With',
+      'Bunking Notes',
+      'Internal Notes',
+      'Social With Checkbox',
+    ])
+  })
+})

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -387,6 +387,30 @@ describe('PostValidationResultsModal — parent stats tile (Stage 3b.2)', () => 
 // #1105: Unmet parent requests drill-down section
 // ---------------------------------------------------------------------------
 
+describe('PostValidationResultsModal — KPI "issues" tile excludes suppressed types', () => {
+  it('counts only non-suppressed issues so the tile matches the sections below', () => {
+    // 2 visible + 3 suppressed = 5 raw; tile should show "2".
+    const issues = [
+      { type: 'capacity_violation', severity: 'error', message: 'Bunk Pine 1 is over capacity' },
+      { type: 'age_spread_warning', severity: 'warning', message: 'Bunk Oak 2 has excessive age' },
+      { type: 'valid_negative_request_violated', severity: 'warning', message: 'suppressed 1' },
+      { type: 'no_requests', severity: 'warning', message: 'suppressed 2' },
+      { type: 'campers_with_unsatisfied_valid_requests', severity: 'warning', message: 'sup 3' },
+    ]
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{ statistics: makeStats(), issues, validated_at: '2025-06-01T12:00:00Z' }}
+      />
+    )
+    const tileLabel = screen.getByText(/^issues$/i)
+    const tileValue = tileLabel.previousElementSibling
+    expect(tileValue?.textContent).toBe('2')
+  })
+})
+
 describe('PostValidationResultsModal — unmet parent requests drill-down (#1105)', () => {
   it('shows no drill-down section when unsatisfied_material_parent_persons is absent', () => {
     render(
@@ -816,10 +840,28 @@ describe('PostValidationResultsModal — Capacity by gender section', () => {
 
 describe('PostValidationResultsModal — Bunks needing attention', () => {
   it('groups bunk-level issues into one row per bunk with chips', () => {
+    // Real validator emits structured `details.bunk_name` for every
+    // bunk-level issue; the extractor reads that first and falls back to
+    // message parsing only when missing.
     const issues = [
-      { type: 'capacity_violation', severity: 'error', message: 'Pine 3 over capacity (9/8)' },
-      { type: 'grade_ratio_warning', severity: 'warning', message: 'Pine 3 has 75% one grade' },
-      { type: 'age_spread_warning', severity: 'warning', message: 'Oak 2 age gap 26 months' },
+      {
+        type: 'capacity_violation',
+        severity: 'error',
+        message: 'Bunk Pine 3 is over capacity (9/8)',
+        details: { bunk_name: 'Pine 3' },
+      },
+      {
+        type: 'grade_ratio_warning',
+        severity: 'warning',
+        message: 'Bunk Pine 3 has 75.0% of campers from grade 6 (exceeds 50% limit)',
+        details: { bunk_name: 'Pine 3' },
+      },
+      {
+        type: 'age_spread_warning',
+        severity: 'warning',
+        message: 'Bunk Oak 2 has excessive age spread (26.0 months)',
+        details: { bunk_name: 'Oak 2' },
+      },
     ]
     render(
       <PostValidationResultsModal
@@ -1010,6 +1052,32 @@ describe('PostValidationResultsModal — Unmet drill-down enriched', () => {
     expect(screen.getByText(/Liam Garcia/)).toBeInTheDocument()
     expect(screen.getByText(/Pine 3/)).toBeInTheDocument()
     expect(screen.getByText(/Oak 2/)).toBeInTheDocument()
+  })
+
+  it('renders drill-down when only unsatisfied_material_parent_detail is present (no legacy persons array)', async () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({
+          unsatisfied_material_parent_detail: [
+            {
+              requester_cm_id: '1',
+              requester_name: 'Emma Johnson',
+              target_cm_id: '2',
+              target_name: 'Liam Garcia',
+              requester_bunk_name: 'Pine 3',
+              target_bunk_name: 'Oak 2',
+            },
+          ],
+        })}
+      />
+    )
+    await userEvent.click(screen.getByText(/unmet parent requests/i))
+    expect(screen.getByText(/Emma Johnson/)).toBeInTheDocument()
+    expect(screen.getByText(/wanted/i)).toBeInTheDocument()
+    expect(screen.getByText(/Liam Garcia/)).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -955,3 +955,28 @@ describe('PostValidationResultsModal — Families to contact', () => {
     expect(screen.queryByText(/priority unsuccessfuls/i)).not.toBeInTheDocument()
   })
 })
+
+describe('PostValidationResultsModal — Unmet drill-down enriched', () => {
+  it('shows requester wanted target with bunk placements', async () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({
+          unsatisfied_material_parent_detail: [
+            { requester_cm_id: '1', requester_name: 'Emma Johnson', target_cm_id: '2', target_name: 'Liam Garcia', requester_bunk_name: 'Pine 3', target_bunk_name: 'Oak 2' },
+          ],
+          // Keep the legacy persons array so the section still renders
+          unsatisfied_material_parent_persons: [{ cm_id: 1, name: 'Emma Johnson' }],
+        })}
+      />
+    )
+    await userEvent.click(screen.getByText(/unmet parent requests/i))
+    expect(screen.getByText(/Emma Johnson/)).toBeInTheDocument()
+    expect(screen.getByText(/wanted/i)).toBeInTheDocument()
+    expect(screen.getByText(/Liam Garcia/)).toBeInTheDocument()
+    expect(screen.getByText(/Pine 3/)).toBeInTheDocument()
+    expect(screen.getByText(/Oak 2/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -454,7 +454,47 @@ describe('PostValidationResultsModal — unmet parent requests drill-down (#1105
     )
 
     // Pin both the literal label and the rendered count.
+    // Legacy persons-array path: count is unique-camper count, so label
+    // disambiguates from the request-count meaning used in the detail path.
+    expect(screen.getByText('Campers with unmet parent requests (2)')).toBeInTheDocument()
+  })
+
+  // #6 — Same badge label was being applied to two different denominators:
+  // request count (new detail path) and unique-requester count (legacy persons
+  // path). Disambiguate the label so the number matches the noun.
+  it('uses request-count label when detail array is present', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({
+          unsatisfied_material_parent_detail: [
+            {
+              requester_cm_id: '1',
+              requester_name: 'Emma Johnson',
+              target_cm_id: '2',
+              target_name: 'Liam Garcia',
+              requester_bunk_name: 'Pine 3',
+              target_bunk_name: 'Oak 2',
+            },
+            {
+              requester_cm_id: '1',
+              requester_name: 'Emma Johnson',
+              target_cm_id: '3',
+              target_name: 'Olivia Chen',
+              requester_bunk_name: 'Pine 3',
+              target_bunk_name: 'Oak 2',
+            },
+          ],
+        })}
+      />
+    )
+
+    // 2 requests across 1 camper — label reads as REQUESTS, count = 2.
     expect(screen.getByText('Unmet parent requests (2)')).toBeInTheDocument()
+    // The campers-with-requests label is NOT used when detail is present.
+    expect(screen.queryByText(/Campers with unmet parent requests/i)).not.toBeInTheDocument()
   })
 
   it('shows camper names after expanding the drill-down section', async () => {

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -1062,11 +1062,10 @@ export default function PostValidationResultsModal({
 
           {showDetails && (
             <div className="animate-fade-in space-y-2 px-5 pb-4">
-              {SOURCE_FIELD_ORDER
-                .filter((key) => key in statistics.field_stats)
-                .map((fieldName) => {
-                  const stats = statistics.field_stats[fieldName]
-                  return (
+              {SOURCE_FIELD_ORDER.map((fieldName) => {
+                const stats = statistics.field_stats[fieldName]
+                if (!stats) return null
+                return (
                   <div
                     key={fieldName}
                     className="bg-muted/40 flex items-center justify-between rounded-xl p-3"

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -989,6 +989,38 @@ export default function PostValidationResultsModal({
         </div>
       )}
 
+      {/* Capacity by gender */}
+      {statistics.capacity_by_gender && (
+        <div className="px-5 pt-3">
+          <div className="rounded-xl border border-stone-200 bg-stone-50 p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-sm font-semibold text-stone-900">Capacity by gender</h3>
+                <p className="mt-0.5 text-xs text-stone-500">Bunk fill compared to enrolled camper count</p>
+              </div>
+            </div>
+            <div className="mt-2">
+              {(['female', 'male'] as const).map((g) => {
+                const capByGender = statistics.capacity_by_gender
+                if (!capByGender) return null
+                const cap = capByGender[g]
+                const pct = cap.capacity > 0 ? Math.round((cap.assigned / cap.capacity) * 100) : 0
+                const barColor = cap.assigned > cap.capacity ? 'bg-red-500' : pct >= 90 ? 'bg-amber-500' : 'bg-emerald-500'
+                return (
+                  <div key={g} className="flex items-center gap-2 py-1.5">
+                    <span className="w-14 text-xs font-medium capitalize text-stone-700">{g}</span>
+                    <div className="h-2 flex-1 overflow-hidden rounded bg-stone-200">
+                      <div className={`h-full ${barColor}`} style={{ width: `${Math.min(pct, 100)}%` }} />
+                    </div>
+                    <span className="min-w-[80px] text-right text-xs text-stone-600">{cap.assigned} / {cap.capacity}</span>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Issues List (if any) */}
       {hasIssues && (
         <div className="max-h-64 space-y-2 overflow-y-auto px-5 py-4">

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -349,6 +349,16 @@ const GRADE_COLORS = [
   'bg-rose-400', // fifth+
 ]
 
+// Fixed display order for "Details by request source" collapsible.
+// Iteration order must be stable and independent of per-field totals.
+const SOURCE_FIELD_ORDER = [
+  'share_bunk_with',
+  'do_not_share_with',
+  'bunking_notes',
+  'internal_notes',
+  'socialize_with',
+] as const
+
 // Mini segmented grade bar component
 function GradeRatioBar({ ratio }: { ratio: NonNullable<ParsedIssue['gradeRatio']> }) {
   // Format grade as ordinal (5 -> 5th, 2 -> 2nd, etc.)
@@ -1052,9 +1062,11 @@ export default function PostValidationResultsModal({
 
           {showDetails && (
             <div className="animate-fade-in space-y-2 px-5 pb-4">
-              {Object.entries(statistics.field_stats)
-                .sort(([, a], [, b]) => b.total - a.total)
-                .map(([fieldName, stats]) => (
+              {SOURCE_FIELD_ORDER
+                .filter((key) => key in statistics.field_stats)
+                .map((fieldName) => {
+                  const stats = statistics.field_stats[fieldName]
+                  return (
                   <div
                     key={fieldName}
                     className="bg-muted/40 flex items-center justify-between rounded-xl p-3"
@@ -1079,7 +1091,8 @@ export default function PostValidationResultsModal({
                       {Math.round(stats.satisfaction_rate * 100)}%
                     </span>
                   </div>
-                ))}
+                  )
+                })}
 
               {/* Capacity info */}
               {statistics.bunks_over_capacity > 0 && (

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -17,7 +17,7 @@ import { Modal } from './ui/Modal'
 import { LazyPdfExportButton } from './PdfExport/LazyPdfExportButton'
 import { formatSourceField } from '../utils/formatSourceField'
 import { LazyCamperDetailsPanel } from './impossibility/LazyCamperDetailsPanel'
-import { friendlyReasonLabel, camperActionHints } from './impossibility/reasonHints'
+import { friendlyReasonLabel } from './impossibility/reasonHints'
 import { ErrorBoundary } from './ErrorBoundary'
 import type {
   ImpossibilityReport,
@@ -563,6 +563,16 @@ function IssueGroup({
   )
 }
 
+type FamilyRow = {
+  key: string
+  name: string
+  cm_id: string
+  grade: number
+  gender: string
+  cohort: 'got_nothing' | 'violated' | 'priority_unmet'
+  detail: React.ReactNode
+}
+
 export default function PostValidationResultsModal({
   isOpen,
   onClose,
@@ -585,7 +595,6 @@ export default function PostValidationResultsModal({
 
   const mpImpossible: EntirelyImpossibleMpCamper[] =
     impossibilityReport?.mp_campers_entirely_impossible ?? []
-  const totalImpossibleRequests = impossibilityReport?.total_impossible ?? 0
 
   // Need to compute these even when modal is closed since Modal might render conditionally
   const statistics = results.statistics
@@ -619,6 +628,66 @@ export default function PostValidationResultsModal({
     }
     return [...byType.entries()]
   }, [otherIssues])
+
+  // Unified "Families to contact" list — combines all three contact-action cohorts:
+  // got_nothing (entirely-impossible MP campers), violated (not-bunk-with violations),
+  // and priority_unmet (priority-flagged requests that didn't land). Sorted by first name.
+  const familyRows: FamilyRow[] = useMemo(() => {
+    const rows: FamilyRow[] = []
+
+    // Cohort A: got nothing (entirely-impossible MP campers)
+    for (const c of mpImpossible) {
+      rows.push({
+        key: `gn-${c.cm_id}`,
+        name: c.name,
+        cm_id: String(c.cm_id),
+        grade: c.grade,
+        gender: c.gender,
+        cohort: 'got_nothing',
+        detail: (
+          <span>
+            All requests impossible · {c.reason_codes.map(friendlyReasonLabel).join(', ')}
+          </span>
+        ),
+      })
+    }
+    // Cohort B: not-bunk-with violations (MSP + staff both kept)
+    for (const v of statistics.negative_request_violations_detail ?? []) {
+      rows.push({
+        key: `nv-${v.requester_cm_id}-${v.target_cm_id}-${v.bunk_cm_id}`,
+        name: v.requester_name,
+        cm_id: v.requester_cm_id,
+        grade: 0,
+        gender: '',
+        cohort: 'violated',
+        detail: (
+          <span>
+            Placed with {v.target_name} in{' '}
+            <span className="font-mono text-xs">{v.bunk_name}</span>
+          </span>
+        ),
+      })
+    }
+    // Cohort C: priority unmet
+    for (const p of statistics.priority_unsuccessfuls ?? []) {
+      rows.push({
+        key: `pu-${p.requester_cm_id}-${p.target_cm_id}`,
+        name: p.requester_name,
+        cm_id: p.requester_cm_id,
+        grade: 0,
+        gender: '',
+        cohort: 'priority_unmet',
+        detail: (
+          <span>
+            Wanted {p.target_name} ·{' '}
+            <em className="text-stone-500">&ldquo;{p.raw_text}&rdquo;</em>
+          </span>
+        ),
+      })
+    }
+    rows.sort((a, b) => a.name.localeCompare(b.name) || a.grade - b.grade)
+    return rows
+  }, [mpImpossible, statistics.negative_request_violations_detail, statistics.priority_unsuccessfuls])
 
   const hasIssues = issues.length > 0
   const errorCount = issues.filter((i) => i.severity === 'error').length
@@ -840,59 +909,63 @@ export default function PostValidationResultsModal({
         </div>
       </div>
 
-      {/* TG-4.3: "Campers who got nothing" — reformatted ImpossibilityCohortSection.
-          Preserves the existing text copy ("won't get any parent request fulfilled",
-          "impossible requests total") so pre-existing tests keep passing.
-          Named card approach per Option B visual language. */}
-      {mpImpossible.length > 0 && (
+      {/* TG-9: "Families to contact" — unified action list consolidating:
+          - Cohort A: entirely-impossible MP campers (got nothing)
+          - Cohort B: not-bunk-with violations (families to call)
+          - Cohort C: priority-flagged requests that didn't land
+          All rows sorted alphabetically by camper first name. */}
+      {familyRows.length > 0 && (
         <div className="px-5 pt-4">
           <div className="rounded-xl border border-red-200 bg-red-50/40 p-4">
             <div className="flex items-center justify-between">
               <div>
-                <h3 className="font-semibold text-red-800">Campers who got nothing</h3>
-                <p className="mt-0.5 text-xs text-red-700/80">
-                  {mpImpossible.length} camper{mpImpossible.length === 1 ? '' : 's'} won&rsquo;t get
-                  any parent request fulfilled
-                </p>
-                <p className="text-xs text-red-700/60">
-                  {totalImpossibleRequests} impossible request
-                  {totalImpossibleRequests === 1 ? '' : 's'} total in this scenario
+                <h3 className="text-sm font-semibold text-red-900">Families to contact</h3>
+                <p className="mt-0.5 text-xs text-red-800/80">
+                  {familyRows.length} follow-up call{familyRows.length === 1 ? '' : 's'} recommended
                 </p>
               </div>
-              <span className="rounded-full bg-red-200/80 px-2.5 py-1 text-xs font-medium text-red-800">
-                {mpImpossible.length}
+              <span className="rounded-full bg-red-200/80 px-2.5 py-1 text-xs font-medium text-red-900">
+                {familyRows.length}
               </span>
             </div>
-            <ul className="mt-3 grid grid-cols-1 gap-2 text-sm sm:grid-cols-2">
-              {mpImpossible.map((c) => (
-                <li
-                  key={c.cm_id}
-                  className="flex items-center justify-between rounded-lg bg-white px-3 py-2"
-                >
-                  <div className="flex-1">
+            <ul className="mt-3 divide-y divide-red-100 text-sm">
+              {familyRows.map((row) => (
+                <li key={row.key} className="flex items-center justify-between py-2 gap-2">
+                  <div className="min-w-0">
                     <button
                       type="button"
                       className="text-left font-medium text-stone-900 hover:text-red-700"
-                      onClick={() => setSelectedCamperId(String(c.cm_id))}
+                      onClick={() => setSelectedCamperId(row.cm_id)}
                     >
-                      {c.name}
+                      {row.name}
                     </button>
-                    {c.reason_codes.length > 0 && (
-                      <span className="ml-2 text-xs text-stone-500">
-                        {camperActionHints(c.reason_codes)}
+                    {row.grade > 0 && (
+                      <span className="text-stone-500 text-xs">
+                        {' '}
+                        · {row.grade}
+                        {['th', 'st', 'nd', 'rd'][((row.grade % 100) - 20) % 10] ||
+                          ['th', 'st', 'nd', 'rd'][row.grade % 100] ||
+                          'th'}{' '}
+                        · {row.gender}
                       </span>
                     )}
+                    <div className="text-xs text-stone-600">{row.detail}</div>
                   </div>
-                  <div className="flex flex-wrap justify-end gap-1">
-                    {c.reason_codes.map((code) => (
-                      <span
-                        key={code}
-                        className="rounded-full bg-amber-200 px-2 py-0.5 text-xs text-amber-900"
-                      >
-                        {friendlyReasonLabel(code)}
-                      </span>
-                    ))}
-                  </div>
+                  <span
+                    className={`flex-shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${
+                      row.cohort === 'got_nothing'
+                        ? 'bg-red-100 text-red-800'
+                        : row.cohort === 'violated'
+                          ? 'bg-amber-100 text-amber-800'
+                          : 'bg-pink-100 text-pink-800'
+                    }`}
+                  >
+                    {row.cohort === 'got_nothing'
+                      ? 'Got nothing'
+                      : row.cohort === 'violated'
+                        ? 'Not-bunk-with violated'
+                        : 'Priority unmet'}
+                  </span>
                 </li>
               ))}
             </ul>
@@ -923,107 +996,6 @@ export default function PostValidationResultsModal({
                 <li key={code} className="flex flex-col rounded-lg bg-white px-3 py-2 text-center">
                   <span className="text-foreground text-lg font-bold">{items.length}</span>
                   <span className="text-muted-foreground text-xs">{friendlyReasonLabel(code)}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      )}
-
-      {/* TG-4.4: "Families to call" — not_bunk_with violations detail list.
-          Shows requester/target pairs and the bunk where they both ended up. */}
-      {(statistics.negative_request_violations_detail ?? []).length > 0 && (
-        <div className="px-5 pt-3">
-          <div className="rounded-xl border border-amber-200 bg-amber-50/40 p-4">
-            <div className="flex items-center justify-between">
-              <div>
-                <h3 className="font-semibold text-amber-900">Families to call</h3>
-                <p className="text-xs text-amber-800/80">
-                  Material <em>do not bunk with</em> wasn&rsquo;t honored — heads-up calls
-                  recommended
-                </p>
-              </div>
-              <span className="rounded-full bg-amber-200/80 px-2.5 py-1 text-xs font-medium text-amber-900">
-                {(statistics.negative_request_violations_detail ?? []).length}
-              </span>
-            </div>
-            <ul className="mt-3 divide-y divide-amber-100 text-sm">
-              {(statistics.negative_request_violations_detail ?? []).map((v) => (
-                <li
-                  key={`${v.requester_cm_id}-${v.target_cm_id}-${v.bunk_cm_id}`}
-                  className="flex items-center justify-between py-2"
-                >
-                  <div>
-                    <button
-                      type="button"
-                      className="font-medium hover:text-amber-800"
-                      onClick={() => setSelectedCamperId(v.requester_cm_id)}
-                    >
-                      {v.requester_name}
-                    </button>
-                    <span> placed with </span>
-                    <button
-                      type="button"
-                      className="font-medium hover:text-amber-800"
-                      onClick={() => setSelectedCamperId(v.target_cm_id)}
-                    >
-                      {v.target_name}
-                    </button>
-                  </div>
-                  <span className="font-mono text-xs text-stone-500">{v.bunk_name}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      )}
-
-      {/* TG-4.5: "Priority unsuccessfuls" — priority-keyword-flagged requests that
-          didn't land. Uses priority_keyword_detected from TG-3 (PR #1474). */}
-      {(statistics.priority_unsuccessfuls ?? []).length > 0 && (
-        <div className="px-5 pt-3">
-          <div className="rounded-xl border border-stone-200 bg-stone-50 p-4">
-            <div className="flex items-center justify-between">
-              <div>
-                <h3 className="font-semibold text-stone-900">Priority unsuccessfuls</h3>
-                <p className="text-xs text-stone-600">
-                  Parents explicitly marked these as priority — request didn&rsquo;t land
-                </p>
-              </div>
-              <span className="rounded-full bg-stone-200 px-2.5 py-1 text-xs font-medium text-stone-700">
-                {(statistics.priority_unsuccessfuls ?? []).length}
-              </span>
-            </div>
-            <ul className="mt-3 divide-y divide-stone-200 text-sm">
-              {(statistics.priority_unsuccessfuls ?? []).map((p, idx) => (
-                <li
-                  key={`${p.requester_cm_id}-${p.target_cm_id}-${idx}`}
-                  className="flex items-center justify-between py-2"
-                >
-                  <div>
-                    <button
-                      type="button"
-                      className="font-medium hover:text-stone-700"
-                      onClick={() => setSelectedCamperId(p.requester_cm_id)}
-                    >
-                      {p.requester_name}
-                    </button>
-                    <span> wanted </span>
-                    <button
-                      type="button"
-                      className="font-medium hover:text-stone-700"
-                      onClick={() => setSelectedCamperId(p.target_cm_id)}
-                    >
-                      {p.target_name}
-                    </button>
-                    <span className="text-xs text-stone-500 italic">
-                      {' '}
-                      &middot; &ldquo;{p.raw_text}&rdquo;
-                    </span>
-                  </div>
-                  <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs text-red-700">
-                    unmet
-                  </span>
                 </li>
               ))}
             </ul>

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -987,9 +987,9 @@ export default function PostValidationResultsModal({
       {impossibilityReport && Object.keys(impossibilityReport.by_reason).length > 0 && (
         <div className="px-5 pt-3">
           <div className="rounded-xl border border-stone-200 bg-stone-50 p-4">
-            <h3 className="font-semibold text-stone-900">Impossible by reason</h3>
+            <h3 className="text-sm font-semibold text-stone-900">Impossible by reason</h3>
             <p className="mt-0.5 text-xs text-stone-500">
-              Why these requests can&rsquo;t be satisfied — from the latest pre-check
+              Summary only — see Pre-Check or export PDF for full per-camper detail
             </p>
             <ul className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3">
               {Object.entries(impossibilityReport.by_reason).map(([code, items]) => (

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -381,11 +381,11 @@ function GradeRatioBar({ ratio }: { ratio: NonNullable<ParsedIssue['gradeRatio']
         })}
       </div>
       {/* Grade labels with counts */}
-      <div className="flex flex-shrink-0 items-center gap-3">
+      <div className="flex shrink-0 items-center gap-3">
         {ratio.grades.map((g, i) => (
           <span key={g.grade} className="flex items-center gap-1 text-sm">
             <span
-              className={`h-2 w-2 flex-shrink-0 rounded-full ${GRADE_COLORS[Math.min(i, GRADE_COLORS.length - 1)]}`}
+              className={`h-2 w-2 shrink-0 rounded-full ${GRADE_COLORS[Math.min(i, GRADE_COLORS.length - 1)]}`}
             />
             <span
               className={`w-5 text-right font-semibold tabular-nums ${i === 0 ? 'text-foreground' : 'text-foreground/70'}`}
@@ -419,9 +419,7 @@ function IssueItem({ issue }: { issue: PostCheckIssue }) {
   if (parsed.gradeRatio) {
     return (
       <div className="flex items-center gap-3 px-3 py-2">
-        <span className="text-foreground w-12 flex-shrink-0 text-sm font-medium">
-          {parsed.primary}
-        </span>
+        <span className="text-foreground w-12 shrink-0 text-sm font-medium">{parsed.primary}</span>
         <GradeRatioBar ratio={parsed.gradeRatio} />
       </div>
     )
@@ -917,7 +915,7 @@ export default function PostValidationResultsModal({
                     <div className="text-xs text-stone-600">{row.detail}</div>
                   </div>
                   <span
-                    className={`flex-shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${
+                    className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${
                       row.cohort === 'got_nothing'
                         ? 'bg-red-100 text-red-800'
                         : row.cohort === 'violated'
@@ -981,10 +979,7 @@ export default function PostValidationResultsModal({
               </div>
             </div>
             <div className="mt-2">
-              {(['female', 'male'] as const).map((g) => {
-                const capByGender = statistics.capacity_by_gender
-                if (!capByGender) return null
-                const cap = capByGender[g]
+              {Object.entries(statistics.capacity_by_gender ?? {}).map(([g, cap]) => {
                 const pct = cap.capacity > 0 ? Math.round((cap.assigned / cap.capacity) * 100) : 0
                 const barColor =
                   cap.assigned > cap.capacity

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -21,11 +21,7 @@ import { LazyCamperDetailsPanel } from './impossibility/LazyCamperDetailsPanel'
 import { friendlyReasonLabel } from './impossibility/reasonHints'
 import { buildFamilyRows } from './PdfExport/familyRows'
 import { ErrorBoundary } from './ErrorBoundary'
-import type {
-  ImpossibilityReport,
-  EntirelyImpossibleMpCamper,
-  ValidationStatistics,
-} from '../services/solver'
+import type { ImpossibilityReport, ValidationStatistics } from '../services/solver'
 import { BunkRequestProvider } from '../providers/BunkRequestProvider'
 import { useAuth } from '../contexts/AuthContext'
 
@@ -278,9 +274,6 @@ export function getIssueTypeLabel(type: string): string {
   }
   return labels[type] ?? type.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase())
 }
-
-// Re-export for consumers that currently import from this module
-export { BUNK_LEVEL_ISSUE_TYPES, SUPPRESSED_ISSUE_TYPES, extractBunkName } from './issueClassifier'
 
 // Satisfaction ring component - the visual centerpiece
 function SatisfactionRing({ rate, size = 120 }: { rate: number; size?: number }) {
@@ -566,9 +559,6 @@ export default function PostValidationResultsModal({
     if (!isOpen) setSelectedCamperId(null)
   }, [isOpen])
 
-  const mpImpossible: EntirelyImpossibleMpCamper[] =
-    impossibilityReport?.mp_campers_entirely_impossible ?? []
-
   // Need to compute these even when modal is closed since Modal might render conditionally
   const statistics = results.statistics
   const unmetParents = statistics.unsatisfied_material_parent_persons ?? []
@@ -620,7 +610,7 @@ export default function PostValidationResultsModal({
       let detail: React.ReactNode
       if (r.cohort === 'got_nothing') {
         const c = (safeReport.mp_campers_entirely_impossible ?? []).find(
-          (x) => String(x.cm_id) === r.cm_id,
+          (x) => String(x.cm_id) === r.cm_id
         )
         detail = (
           <span>
@@ -629,24 +619,22 @@ export default function PostValidationResultsModal({
         )
       } else if (r.cohort === 'violated') {
         const v = (statistics.negative_request_violations_detail ?? []).find(
-          (x) => `nv-${x.requester_cm_id}-${x.target_cm_id}-${x.bunk_cm_id}` === r.key,
+          (x) => `nv-${x.requester_cm_id}-${x.target_cm_id}-${x.bunk_cm_id}` === r.key
         )
         detail = v ? (
           <span>
-            Placed with {v.target_name} in{' '}
-            <span className="font-mono text-xs">{v.bunk_name}</span>
+            Placed with {v.target_name} in <span className="font-mono text-xs">{v.bunk_name}</span>
           </span>
         ) : (
           <span>{r.detail}</span>
         )
       } else {
         const p = (statistics.priority_unsuccessfuls ?? []).find(
-          (x) => `pu-${x.requester_cm_id}-${x.target_cm_id}` === r.key,
+          (x) => `pu-${x.requester_cm_id}-${x.target_cm_id}` === r.key
         )
         detail = p ? (
           <span>
-            Wanted {p.target_name} ·{' '}
-            <em className="text-stone-500">&ldquo;{p.raw_text}&rdquo;</em>
+            Wanted {p.target_name} · <em className="text-stone-500">&ldquo;{p.raw_text}&rdquo;</em>
           </span>
         ) : (
           <span>{r.detail}</span>
@@ -654,7 +642,7 @@ export default function PostValidationResultsModal({
       }
       return { ...r, detail }
     })
-  }, [mpImpossible, statistics, impossibilityReport])
+  }, [statistics, impossibilityReport])
 
   const hasIssues = issues.length > 0
   const errorCount = issues.filter((i) => i.severity === 'error').length
@@ -898,7 +886,7 @@ export default function PostValidationResultsModal({
             </div>
             <ul className="mt-3 divide-y divide-red-100 text-sm">
               {familyRows.map((row) => (
-                <li key={row.key} className="flex items-center justify-between py-2 gap-2">
+                <li key={row.key} className="flex items-center justify-between gap-2 py-2">
                   <div className="min-w-0">
                     <button
                       type="button"
@@ -908,7 +896,7 @@ export default function PostValidationResultsModal({
                       {row.name}
                     </button>
                     {row.grade > 0 && (
-                      <span className="text-stone-500 text-xs">
+                      <span className="text-xs text-stone-500">
                         {' '}
                         · {row.grade}
                         {['th', 'st', 'nd', 'rd'][((row.grade % 100) - 20) % 10] ||
@@ -978,7 +966,9 @@ export default function PostValidationResultsModal({
             <div className="flex items-center justify-between">
               <div>
                 <h3 className="text-sm font-semibold text-stone-900">Capacity by gender</h3>
-                <p className="mt-0.5 text-xs text-stone-500">Bunk fill compared to enrolled camper count</p>
+                <p className="mt-0.5 text-xs text-stone-500">
+                  Bunk fill compared to enrolled camper count
+                </p>
               </div>
             </div>
             <div className="mt-2">
@@ -987,14 +977,24 @@ export default function PostValidationResultsModal({
                 if (!capByGender) return null
                 const cap = capByGender[g]
                 const pct = cap.capacity > 0 ? Math.round((cap.assigned / cap.capacity) * 100) : 0
-                const barColor = cap.assigned > cap.capacity ? 'bg-red-500' : pct >= 90 ? 'bg-amber-500' : 'bg-emerald-500'
+                const barColor =
+                  cap.assigned > cap.capacity
+                    ? 'bg-red-500'
+                    : pct >= 90
+                      ? 'bg-amber-500'
+                      : 'bg-emerald-500'
                 return (
                   <div key={g} className="flex items-center gap-2 py-1.5">
-                    <span className="w-14 text-xs font-medium capitalize text-stone-700">{g}</span>
+                    <span className="w-14 text-xs font-medium text-stone-700 capitalize">{g}</span>
                     <div className="h-2 flex-1 overflow-hidden rounded bg-stone-200">
-                      <div className={`h-full ${barColor}`} style={{ width: `${Math.min(pct, 100)}%` }} />
+                      <div
+                        className={`h-full ${barColor}`}
+                        style={{ width: `${Math.min(pct, 100)}%` }}
+                      />
                     </div>
-                    <span className="min-w-[80px] text-right text-xs text-stone-600">{cap.assigned} / {cap.capacity}</span>
+                    <span className="min-w-[80px] text-right text-xs text-stone-600">
+                      {cap.assigned} / {cap.capacity}
+                    </span>
                   </div>
                 )
               })}
@@ -1060,7 +1060,12 @@ export default function PostValidationResultsModal({
             </div>
             <div className="mt-3 space-y-2">
               {groupedOtherIssues.map(([type, group]) => (
-                <IssueGroup key={type} type={type} issues={group.issues} severity={group.severity} />
+                <IssueGroup
+                  key={type}
+                  type={type}
+                  issues={group.issues}
+                  severity={group.severity}
+                />
               ))}
             </div>
           </div>
@@ -1108,20 +1113,21 @@ export default function PostValidationResultsModal({
               {(() => {
                 const detail = statistics.unsatisfied_material_parent_detail ?? []
                 // When detail isn't available, fall back to plain names so older sessions still render.
-                const rows = detail.length > 0
-                  ? [...detail].sort((a, b) => a.requester_name.localeCompare(b.requester_name))
-                  : unmetParents.map((p) => ({
-                      requester_cm_id: String(p.cm_id),
-                      requester_name: p.name,
-                      target_cm_id: '',
-                      target_name: '',
-                      requester_bunk_name: '',
-                      target_bunk_name: '',
-                    }))
+                const rows =
+                  detail.length > 0
+                    ? [...detail].sort((a, b) => a.requester_name.localeCompare(b.requester_name))
+                    : unmetParents.map((p) => ({
+                        requester_cm_id: String(p.cm_id),
+                        requester_name: p.name,
+                        target_cm_id: '',
+                        target_name: '',
+                        requester_bunk_name: '',
+                        target_bunk_name: '',
+                      }))
                 return rows.map((r) => (
                   <li
                     key={`${r.requester_cm_id}-${r.target_cm_id}`}
-                    className="text-foreground text-sm py-1"
+                    className="text-foreground py-1 text-sm"
                   >
                     <span className="font-medium">{r.requester_name}</span>
                     {r.target_name && (
@@ -1131,7 +1137,11 @@ export default function PostValidationResultsModal({
                       </>
                     )}
                     {r.requester_bunk_name && r.target_bunk_name && (
-                      <span className="text-xs text-stone-500"> · <span className="font-mono">{r.requester_bunk_name}</span> vs <span className="font-mono">{r.target_bunk_name}</span></span>
+                      <span className="text-xs text-stone-500">
+                        {' '}
+                        · <span className="font-mono">{r.requester_bunk_name}</span> vs{' '}
+                        <span className="font-mono">{r.target_bunk_name}</span>
+                      </span>
                     )}
                   </li>
                 ))
@@ -1185,8 +1195,8 @@ export default function PostValidationResultsModal({
                       {Math.round(stats.satisfaction_rate * 100)}%
                     </span>
                   </div>
-                  )
-                })}
+                )
+              })}
 
               {/* Capacity info */}
               {statistics.bunks_over_capacity > 0 && (

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -1137,11 +1137,37 @@ export default function PostValidationResultsModal({
               id="unmet-parent-requests-list"
               className="animate-fade-in max-h-48 space-y-1 overflow-y-auto px-5 pb-4"
             >
-              {unmetParents.map((person) => (
-                <li key={person.cm_id} className="text-foreground text-sm">
-                  {person.name}
-                </li>
-              ))}
+              {(() => {
+                const detail = statistics.unsatisfied_material_parent_detail ?? []
+                // When detail isn't available, fall back to plain names so older sessions still render.
+                const rows = detail.length > 0
+                  ? [...detail].sort((a, b) => a.requester_name.localeCompare(b.requester_name))
+                  : unmetParents.map((p) => ({
+                      requester_cm_id: String(p.cm_id),
+                      requester_name: p.name,
+                      target_cm_id: '',
+                      target_name: '',
+                      requester_bunk_name: '',
+                      target_bunk_name: '',
+                    }))
+                return rows.map((r) => (
+                  <li
+                    key={`${r.requester_cm_id}-${r.target_cm_id}`}
+                    className="text-foreground text-sm py-1"
+                  >
+                    <span className="font-medium">{r.requester_name}</span>
+                    {r.target_name && (
+                      <>
+                        <span className="text-stone-500"> wanted </span>
+                        <span className="font-medium">{r.target_name}</span>
+                      </>
+                    )}
+                    {r.requester_bunk_name && r.target_bunk_name && (
+                      <span className="text-xs text-stone-500"> · <span className="font-mono">{r.requester_bunk_name}</span> vs <span className="font-mono">{r.target_bunk_name}</span></span>
+                    )}
+                  </li>
+                ))
+              })()}
             </ul>
           )}
         </div>

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -18,6 +18,7 @@ import { LazyPdfExportButton } from './PdfExport/LazyPdfExportButton'
 import { formatSourceField } from '../utils/formatSourceField'
 import { LazyCamperDetailsPanel } from './impossibility/LazyCamperDetailsPanel'
 import { friendlyReasonLabel } from './impossibility/reasonHints'
+import { buildFamilyRows } from './PdfExport/familyRows'
 import { ErrorBoundary } from './ErrorBoundary'
 import type {
   ImpossibilityReport,
@@ -632,62 +633,56 @@ export default function PostValidationResultsModal({
   // Unified "Families to contact" list — combines all three contact-action cohorts:
   // got_nothing (entirely-impossible MP campers), violated (not-bunk-with violations),
   // and priority_unmet (priority-flagged requests that didn't land). Sorted by first name.
+  // Sort/filter logic lives in PdfExport/familyRows.ts (shared with PDF export).
+  // Modal re-decorates string detail into JSX for richer inline formatting.
   const familyRows: FamilyRow[] = useMemo(() => {
-    const rows: FamilyRow[] = []
-
-    // Cohort A: got nothing (entirely-impossible MP campers)
-    for (const c of mpImpossible) {
-      rows.push({
-        key: `gn-${c.cm_id}`,
-        name: c.name,
-        cm_id: String(c.cm_id),
-        grade: c.grade,
-        gender: c.gender,
-        cohort: 'got_nothing',
-        detail: (
-          <span>
-            All requests impossible · {c.reason_codes.map(friendlyReasonLabel).join(', ')}
-          </span>
-        ),
-      })
+    const safeReport = impossibilityReport ?? {
+      mp_campers_entirely_impossible: [],
+      flat: [],
+      by_reason: {},
+      total_impossible: 0,
+      affected_campers: 0,
     }
-    // Cohort B: not-bunk-with violations (MSP + staff both kept)
-    for (const v of statistics.negative_request_violations_detail ?? []) {
-      rows.push({
-        key: `nv-${v.requester_cm_id}-${v.target_cm_id}-${v.bunk_cm_id}`,
-        name: v.requester_name,
-        cm_id: v.requester_cm_id,
-        grade: 0,
-        gender: '',
-        cohort: 'violated',
-        detail: (
+    const baseRows = buildFamilyRows(statistics, safeReport)
+    return baseRows.map((r) => {
+      let detail: React.ReactNode
+      if (r.cohort === 'got_nothing') {
+        const c = (safeReport.mp_campers_entirely_impossible ?? []).find(
+          (x) => String(x.cm_id) === r.cm_id,
+        )
+        detail = (
+          <span>
+            All requests impossible · {(c?.reason_codes ?? []).map(friendlyReasonLabel).join(', ')}
+          </span>
+        )
+      } else if (r.cohort === 'violated') {
+        const v = (statistics.negative_request_violations_detail ?? []).find(
+          (x) => `nv-${x.requester_cm_id}-${x.target_cm_id}-${x.bunk_cm_id}` === r.key,
+        )
+        detail = v ? (
           <span>
             Placed with {v.target_name} in{' '}
             <span className="font-mono text-xs">{v.bunk_name}</span>
           </span>
-        ),
-      })
-    }
-    // Cohort C: priority unmet
-    for (const p of statistics.priority_unsuccessfuls ?? []) {
-      rows.push({
-        key: `pu-${p.requester_cm_id}-${p.target_cm_id}`,
-        name: p.requester_name,
-        cm_id: p.requester_cm_id,
-        grade: 0,
-        gender: '',
-        cohort: 'priority_unmet',
-        detail: (
+        ) : (
+          <span>{r.detail}</span>
+        )
+      } else {
+        const p = (statistics.priority_unsuccessfuls ?? []).find(
+          (x) => `pu-${x.requester_cm_id}-${x.target_cm_id}` === r.key,
+        )
+        detail = p ? (
           <span>
             Wanted {p.target_name} ·{' '}
             <em className="text-stone-500">&ldquo;{p.raw_text}&rdquo;</em>
           </span>
-        ),
-      })
-    }
-    rows.sort((a, b) => a.name.localeCompare(b.name) || a.grade - b.grade)
-    return rows
-  }, [mpImpossible, statistics.negative_request_violations_detail, statistics.priority_unsuccessfuls])
+        ) : (
+          <span>{r.detail}</span>
+        )
+      }
+      return { ...r, detail }
+    })
+  }, [mpImpossible, statistics, impossibilityReport])
 
   const hasIssues = issues.length > 0
   const errorCount = issues.filter((i) => i.severity === 'error').length

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -294,6 +294,16 @@ export const BUNK_LEVEL_ISSUE_TYPES = new Set([
   'isolation_risk',
 ])
 
+// Issue types surfaced in dedicated sections (Families to contact, Unmet
+// drill-down). These are suppressed from the "Other issues" residual so they
+// don't double-render. Exported so Task 15 PDF code can reuse the same set.
+export const SUPPRESSED_ISSUE_TYPES = new Set([
+  'valid_negative_request_violated', // → Families to contact (Task 9)
+  'no_requests', // → Families to contact "Got nothing"
+  'valid_request_unsatisfied', // → Unmet parent drill-down (Task 10)
+  'campers_with_unsatisfied_valid_requests', // same
+])
+
 export function extractBunkName(issueMessage: string): string {
   const match = issueMessage.match(/^(\S+(?:\s+\S+)?)\s/)
   return match?.[1] ?? 'Unknown'
@@ -592,29 +602,23 @@ export default function PostValidationResultsModal({
   const PARENT_SATISFACTION_TARGET = 0.85
   const parentUnderTarget = parentTotal > 0 && satisfactionRate < PARENT_SATISFACTION_TARGET
 
-  // Group issues by type and severity
-  const groupedIssues = useMemo(() => {
+  // Residual issues: neither bunk-level nor suppressed (surfaced in dedicated sections).
+  const otherIssues = useMemo(
+    () =>
+      issues.filter(
+        (i) => !SUPPRESSED_ISSUE_TYPES.has(i.type) && !BUNK_LEVEL_ISSUE_TYPES.has(i.type)
+      ),
+    [issues]
+  )
+  const groupedOtherIssues = useMemo(() => {
     const byType = new Map<string, { issues: Issue[]; severity: string }>()
-
-    for (const issue of issues) {
+    for (const issue of otherIssues) {
       const existing = byType.get(issue.type)
-      if (existing) {
-        existing.issues.push(issue)
-      } else {
-        byType.set(issue.type, { issues: [issue], severity: issue.severity })
-      }
+      if (existing) existing.issues.push(issue)
+      else byType.set(issue.type, { issues: [issue], severity: issue.severity })
     }
-
-    // Sort by severity (errors first, then warnings, then info)
-    const severityOrder: Record<string, number> = {
-      error: 0,
-      warning: 1,
-      info: 2,
-    }
-    return [...byType.entries()].sort((a, b) => {
-      return (severityOrder[a[1].severity] ?? 3) - (severityOrder[b[1].severity] ?? 3)
-    })
-  }, [issues])
+    return [...byType.entries()]
+  }, [otherIssues])
 
   const hasIssues = issues.length > 0
   const errorCount = issues.filter((i) => i.severity === 'error').length
@@ -1099,17 +1103,32 @@ export default function PostValidationResultsModal({
         </div>
       )}
 
-      {/* Issues List (if any) */}
-      {hasIssues && (
-        <div className="max-h-64 space-y-2 overflow-y-auto px-5 py-4">
-          {groupedIssues.map(([type, { issues: typeIssues, severity }]) => (
-            <IssueGroup key={type} type={type} issues={typeIssues} severity={severity} />
-          ))}
+      {/* Other issues — residual types not covered by Families to contact or Bunks needing attention */}
+      {groupedOtherIssues.length > 0 && (
+        <div className="px-5 pt-3">
+          <div className="rounded-xl border border-stone-200 bg-stone-50 p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-sm font-semibold text-stone-900">Other issues</h3>
+                <p className="mt-0.5 text-xs text-stone-500">
+                  Items not covered by Families to contact or Bunks needing attention
+                </p>
+              </div>
+              <span className="rounded-full bg-stone-200 px-2.5 py-1 text-xs font-medium text-stone-700">
+                {groupedOtherIssues.reduce((sum, [, g]) => sum + g.issues.length, 0)}
+              </span>
+            </div>
+            <div className="mt-3 space-y-2">
+              {groupedOtherIssues.map(([type, group]) => (
+                <IssueGroup key={type} type={type} issues={group.issues} severity={group.severity} />
+              ))}
+            </div>
+          </div>
         </div>
       )}
 
       {/* Success state message */}
-      {!hasIssues && (
+      {issues.length === 0 && (
         <div className="px-5 py-6 text-center">
           <div className="bg-forest-500/10 mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-2xl">
             <Sparkles className="text-forest-500 h-6 w-6" />

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -1,5 +1,10 @@
 import { Suspense, useEffect, useMemo, useState } from 'react'
-import { BUNK_LEVEL_ISSUE_TYPES, SUPPRESSED_ISSUE_TYPES, extractBunkName } from './issueClassifier'
+import {
+  BUNK_LEVEL_ISSUE_TYPES,
+  SUPPRESSED_ISSUE_TYPES,
+  extractBunkName,
+  type PostCheckIssue,
+} from './issueClassifier'
 import {
   CheckCircle2,
   AlertTriangle,
@@ -24,17 +29,11 @@ import { ErrorBoundary } from './ErrorBoundary'
 import type { ImpossibilityReport, ValidationStatistics } from '../services/solver'
 import { BunkRequestProvider } from '../providers/BunkRequestProvider'
 import { useAuth } from '../contexts/AuthContext'
-
-interface Issue {
-  type: string
-  severity: string
-  message: string
-  details?: Record<string, unknown>
-}
+import { getLogoPath } from '../config/branding'
 
 interface ValidationResults {
   statistics: ValidationStatistics
-  issues: Issue[]
+  issues: PostCheckIssue[]
   validated_at: string
 }
 
@@ -89,7 +88,7 @@ interface ParsedIssue {
 }
 
 // eslint-disable-next-line react-refresh/only-export-components -- Utility function exported for testing
-export function parseIssueMessage(issue: Issue): ParsedIssue {
+export function parseIssueMessage(issue: PostCheckIssue): ParsedIssue {
   const msg = issue.message
 
   // Handle unsatisfied request messages
@@ -402,7 +401,7 @@ function GradeRatioBar({ ratio }: { ratio: NonNullable<ParsedIssue['gradeRatio']
 }
 
 // Single issue item with visual structure
-function IssueItem({ issue }: { issue: Issue }) {
+function IssueItem({ issue }: { issue: PostCheckIssue }) {
   const parsed = parseIssueMessage(issue)
 
   const getBadgeStyles = () => {
@@ -450,14 +449,14 @@ function IssueItem({ issue }: { issue: Issue }) {
   )
 }
 
-// Issue group component with expand/collapse
+// PostCheckIssue group component with expand/collapse
 function IssueGroup({
   type,
   issues,
   severity,
 }: {
   type: string
-  issues: Issue[]
+  issues: PostCheckIssue[]
   severity: string
 }) {
   const [isExpanded, setIsExpanded] = useState(issues.length <= 3)
@@ -587,7 +586,7 @@ export default function PostValidationResultsModal({
     [issues]
   )
   const groupedOtherIssues = useMemo(() => {
-    const byType = new Map<string, { issues: Issue[]; severity: string }>()
+    const byType = new Map<string, { issues: PostCheckIssue[]; severity: string }>()
     for (const issue of otherIssues) {
       const existing = byType.get(issue.type)
       if (existing) existing.issues.push(issue)
@@ -764,6 +763,7 @@ export default function PostValidationResultsModal({
             }
           }
           issues={results.issues}
+          {...(getLogoPath('large') ? { logoUrl: getLogoPath('large')! } : {})}
         />
       </div>
       <button
@@ -1105,8 +1105,11 @@ export default function PostValidationResultsModal({
           >
             <span className="flex items-center gap-2">
               <Users className="h-4 w-4" />
-              Unmet parent requests (
-              {unmetParentDetail.length > 0 ? unmetParentDetail.length : unmetParents.length})
+              {/* Detail path counts REQUESTS; legacy persons path counts unique
+                  CAMPERS — disambiguate the label so the noun matches the number. */}
+              {unmetParentDetail.length > 0
+                ? `Unmet parent requests (${unmetParentDetail.length})`
+                : `Campers with unmet parent requests (${unmetParents.length})`}
             </span>
             {showUnmetParents ? (
               <ChevronUp className="h-4 w-4" />

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -562,6 +562,10 @@ export default function PostValidationResultsModal({
   // Need to compute these even when modal is closed since Modal might render conditionally
   const statistics = results.statistics
   const unmetParents = statistics.unsatisfied_material_parent_persons ?? []
+  const unmetParentDetail = statistics.unsatisfied_material_parent_detail ?? []
+  // Either bucket (legacy persons array OR detail array) is enough to render
+  // the drill-down — backend may emit just one.
+  const hasUnmetDrilldown = unmetParents.length > 0 || unmetParentDetail.length > 0
   // Memoize issues to prevent dependency array changes on every render
   const issues = useMemo(() => results.issues, [results.issues])
   const parentTotal = statistics.material_parent_requests ?? 0
@@ -647,6 +651,9 @@ export default function PostValidationResultsModal({
   const hasIssues = issues.length > 0
   const errorCount = issues.filter((i) => i.severity === 'error').length
   const warningCount = issues.filter((i) => i.severity === 'warning').length
+  // KPI tile + section counts exclude suppressed types so the headline number
+  // matches the sum of what staff actually see below.
+  const visibleIssuesCount = issues.filter((i) => !SUPPRESSED_ISSUE_TYPES.has(i.type)).length
 
   // Bunk-level issues grouped by extracted bunk name (alphabetical).
   const bunkLevelIssues = useMemo(
@@ -656,7 +663,7 @@ export default function PostValidationResultsModal({
   const issuesByBunk = useMemo(() => {
     const map = new Map<string, typeof bunkLevelIssues>()
     for (const issue of bunkLevelIssues) {
-      const bunk = extractBunkName(issue.message)
+      const bunk = extractBunkName(issue)
       const arr = map.get(bunk) ?? []
       arr.push(issue)
       map.set(bunk, arr)
@@ -858,7 +865,9 @@ export default function PostValidationResultsModal({
               />
             </div>
             <div>
-              <p className="text-foreground text-lg leading-tight font-semibold">{issues.length}</p>
+              <p className="text-foreground text-lg leading-tight font-semibold">
+                {visibleIssuesCount}
+              </p>
               <p className="text-muted-foreground text-xs">issues</p>
             </div>
           </div>
@@ -1085,7 +1094,7 @@ export default function PostValidationResultsModal({
       )}
 
       {/* Unmet parent requests drill-down (#1105) */}
-      {unmetParents.length > 0 && (
+      {hasUnmetDrilldown && (
         <div className="border-border/50 border-t">
           <button
             type="button"
@@ -1096,7 +1105,8 @@ export default function PostValidationResultsModal({
           >
             <span className="flex items-center gap-2">
               <Users className="h-4 w-4" />
-              Unmet parent requests ({unmetParents.length})
+              Unmet parent requests (
+              {unmetParentDetail.length > 0 ? unmetParentDetail.length : unmetParents.length})
             </span>
             {showUnmetParents ? (
               <ChevronUp className="h-4 w-4" />

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -277,6 +277,28 @@ export function getIssueTypeLabel(type: string): string {
   return labels[type] ?? type.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase())
 }
 
+// Issue types that are bunk-scoped and should appear in the "Bunks needing
+// attention" section. Kept at module scope so Task 15 PDF code can import
+// them from this file without circular deps (or extract to a shared util then).
+// NOTE: extractBunkName parses the first 1-2 tokens of the validator message
+// string. This is fragile — if the validator changes its message format, this
+// breaks silently. The long-term fix is for the validator to emit a structured
+// `bunk_name` field in the issue payload.
+export const BUNK_LEVEL_ISSUE_TYPES = new Set([
+  'capacity_violation',
+  'age_spread_warning',
+  'grade_ratio_warning',
+  'grade_spread_warning',
+  'grade_adjacency_warning',
+  'age_flow_inversion',
+  'isolation_risk',
+])
+
+export function extractBunkName(issueMessage: string): string {
+  const match = issueMessage.match(/^(\S+(?:\s+\S+)?)\s/)
+  return match?.[1] ?? 'Unknown'
+}
+
 // Satisfaction ring component - the visual centerpiece
 function SatisfactionRing({ rate, size = 120 }: { rate: number; size?: number }) {
   const percentage = Math.round(rate * 100)
@@ -597,6 +619,22 @@ export default function PostValidationResultsModal({
   const hasIssues = issues.length > 0
   const errorCount = issues.filter((i) => i.severity === 'error').length
   const warningCount = issues.filter((i) => i.severity === 'warning').length
+
+  // Bunk-level issues grouped by extracted bunk name (alphabetical).
+  const bunkLevelIssues = useMemo(
+    () => issues.filter((i) => BUNK_LEVEL_ISSUE_TYPES.has(i.type)),
+    [issues]
+  )
+  const issuesByBunk = useMemo(() => {
+    const map = new Map<string, typeof bunkLevelIssues>()
+    for (const issue of bunkLevelIssues) {
+      const bunk = extractBunkName(issue.message)
+      const arr = map.get(bunk) ?? []
+      arr.push(issue)
+      map.set(bunk, arr)
+    }
+    return [...map.entries()].sort(([a], [b]) => a.localeCompare(b))
+  }, [bunkLevelIssues])
 
   const getOverallStatus = () => {
     let base: {
@@ -1017,6 +1055,46 @@ export default function PostValidationResultsModal({
                 )
               })}
             </div>
+          </div>
+        </div>
+      )}
+
+      {/* Bunks needing attention */}
+      {issuesByBunk.length > 0 && (
+        <div className="px-5 pt-3">
+          <div className="rounded-xl border border-orange-200 bg-orange-50/40 p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-sm font-semibold text-orange-900">Bunks needing attention</h3>
+                <p className="mt-0.5 text-xs text-orange-800/80">
+                  {issuesByBunk.length} bunk{issuesByBunk.length === 1 ? '' : 's'} have warnings
+                </p>
+              </div>
+              <span className="rounded-full bg-orange-200/80 px-2.5 py-1 text-xs font-medium text-orange-900">
+                {issuesByBunk.length}
+              </span>
+            </div>
+            <ul className="mt-3 space-y-2 text-sm">
+              {issuesByBunk.map(([bunkName, bunkIssues]) => (
+                <li key={bunkName} className="rounded-lg bg-white px-3 py-2">
+                  <div className="font-medium text-stone-900">{bunkName}</div>
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {bunkIssues.map((iss, idx) => (
+                      <span
+                        key={idx}
+                        className={`rounded-full px-2 py-0.5 text-xs ${
+                          iss.type === 'capacity_violation'
+                            ? 'bg-red-200 text-red-900'
+                            : 'bg-amber-200 text-amber-900'
+                        }`}
+                      >
+                        {getIssueTypeLabel(iss.type)}
+                      </span>
+                    ))}
+                  </div>
+                </li>
+              ))}
+            </ul>
           </div>
         </div>
       )}

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -1,4 +1,5 @@
 import { Suspense, useEffect, useMemo, useState } from 'react'
+import { BUNK_LEVEL_ISSUE_TYPES, SUPPRESSED_ISSUE_TYPES, extractBunkName } from './issueClassifier'
 import {
   CheckCircle2,
   AlertTriangle,
@@ -278,37 +279,8 @@ export function getIssueTypeLabel(type: string): string {
   return labels[type] ?? type.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase())
 }
 
-// Issue types that are bunk-scoped and should appear in the "Bunks needing
-// attention" section. Kept at module scope so Task 15 PDF code can import
-// them from this file without circular deps (or extract to a shared util then).
-// NOTE: extractBunkName parses the first 1-2 tokens of the validator message
-// string. This is fragile — if the validator changes its message format, this
-// breaks silently. The long-term fix is for the validator to emit a structured
-// `bunk_name` field in the issue payload.
-export const BUNK_LEVEL_ISSUE_TYPES = new Set([
-  'capacity_violation',
-  'age_spread_warning',
-  'grade_ratio_warning',
-  'grade_spread_warning',
-  'grade_adjacency_warning',
-  'age_flow_inversion',
-  'isolation_risk',
-])
-
-// Issue types surfaced in dedicated sections (Families to contact, Unmet
-// drill-down). These are suppressed from the "Other issues" residual so they
-// don't double-render. Exported so Task 15 PDF code can reuse the same set.
-export const SUPPRESSED_ISSUE_TYPES = new Set([
-  'valid_negative_request_violated', // → Families to contact (Task 9)
-  'no_requests', // → Families to contact "Got nothing"
-  'valid_request_unsatisfied', // → Unmet parent drill-down (Task 10)
-  'campers_with_unsatisfied_valid_requests', // same
-])
-
-export function extractBunkName(issueMessage: string): string {
-  const match = issueMessage.match(/^(\S+(?:\s+\S+)?)\s/)
-  return match?.[1] ?? 'Unknown'
-}
+// Re-export for consumers that currently import from this module
+export { BUNK_LEVEL_ISSUE_TYPES, SUPPRESSED_ISSUE_TYPES, extractBunkName } from './issueClassifier'
 
 // Satisfaction ring component - the visual centerpiece
 function SatisfactionRing({ rate, size = 120 }: { rate: number; size?: number }) {
@@ -796,6 +768,7 @@ export default function PostValidationResultsModal({
               mp_campers_entirely_impossible: [],
             }
           }
+          issues={results.issues}
         />
       </div>
       <button

--- a/frontend/src/components/issueClassifier.test.ts
+++ b/frontend/src/components/issueClassifier.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import { extractBunkName } from './issueClassifier'
+
+describe('extractBunkName', () => {
+  it('reads bunk_name from issue.details when present (preferred path)', () => {
+    expect(
+      extractBunkName({
+        type: 'capacity_violation',
+        message: 'Bunk Pine 3 is over capacity (11/10)',
+        details: { bunk_name: 'Pine 3' },
+      })
+    ).toBe('Pine 3')
+  })
+
+  it('falls back to message parsing when details.bunk_name is missing', () => {
+    expect(
+      extractBunkName({
+        type: 'capacity_violation',
+        message: 'Bunk Pine 3 is over capacity (11/10)',
+      })
+    ).toBe('Pine 3')
+  })
+
+  describe('message fallback covers all bunk-level issue formats', () => {
+    it('capacity_violation: "Bunk <name> is over capacity ..."', () => {
+      expect(extractBunkName({ type: 'x', message: 'Bunk Pine 3 is over capacity (11/10)' })).toBe(
+        'Pine 3'
+      )
+    })
+
+    it('grade_spread_warning: "Bunk <name> has too many ..."', () => {
+      expect(
+        extractBunkName({ type: 'x', message: 'Bunk Pine 3 has too many different grades (4...)' })
+      ).toBe('Pine 3')
+    })
+
+    it('age_spread_warning: "Bunk <name> has excessive age spread ..."', () => {
+      expect(
+        extractBunkName({
+          type: 'x',
+          message: 'Bunk Pine 3 has excessive age spread (24.0 months)',
+        })
+      ).toBe('Pine 3')
+    })
+
+    it('grade_ratio_warning: "Bunk <name> has X% ..."', () => {
+      expect(
+        extractBunkName({
+          type: 'x',
+          message: 'Bunk Pine 3 has 75.0% of campers from grade 6 (exceeds 50% limit)',
+        })
+      ).toBe('Pine 3')
+    })
+
+    it('grade_adjacency_warning: "Bunk <name> has non-adjacent ..."', () => {
+      expect(
+        extractBunkName({
+          type: 'x',
+          message: 'Bunk Pine 3 has non-adjacent grades [5, 7] (missing grade [6])',
+        })
+      ).toBe('Pine 3')
+    })
+
+    it('age_flow_inversion: "<name> (avg age N) has older campers ..."', () => {
+      expect(
+        extractBunkName({
+          type: 'x',
+          message: 'Pine 3 (avg age 12.1) has older campers than Pine 4 (avg age 11.2)',
+        })
+      ).toBe('Pine 3')
+    })
+
+    it('isolation_risk: "<name> has N connected friends ..."', () => {
+      expect(
+        extractBunkName({
+          type: 'x',
+          message: 'Pine 3 has 9 connected friends + 2 isolated camper(s): Emma, Liam',
+        })
+      ).toBe('Pine 3')
+    })
+
+    it('preserves multi-token bunk names', () => {
+      expect(
+        extractBunkName({ type: 'x', message: 'Bunk Long Cabin Name is over capacity (11/10)' })
+      ).toBe('Long Cabin Name')
+    })
+
+    it('distinguishes Pine 1 from Pine 2', () => {
+      const a = extractBunkName({ type: 'x', message: 'Bunk Pine 1 is over capacity (11/10)' })
+      const b = extractBunkName({ type: 'x', message: 'Bunk Pine 2 is over capacity (11/10)' })
+      expect(a).toBe('Pine 1')
+      expect(b).toBe('Pine 2')
+      expect(a).not.toBe(b)
+    })
+
+    it('returns "Unknown" when nothing matches', () => {
+      expect(extractBunkName({ type: 'x', message: 'totally unstructured noise' })).toBe('Unknown')
+    })
+  })
+})

--- a/frontend/src/components/issueClassifier.ts
+++ b/frontend/src/components/issueClassifier.ts
@@ -22,12 +22,33 @@ export const SUPPRESSED_ISSUE_TYPES = new Set([
   'campers_with_unsatisfied_valid_requests',
 ])
 
+interface IssueLike {
+  type: string
+  message: string
+  details?: Record<string, unknown>
+}
+
 /**
- * Best-effort bunk name extraction from validator-emitted message strings.
- * Validator messages start with "<BunkName> ..." today; if that ever changes,
- * the validator should emit a structured `bunk_name` field instead.
+ * Returns the bunk name associated with an issue.
+ *
+ * Prefers `issue.details.bunk_name` (emitted structurally by the validator
+ * for every bunk-level type). Falls back to format-specific regex parsing of
+ * `issue.message` for older payloads or unexpected shapes.
  */
-export function extractBunkName(issueMessage: string): string {
-  const match = issueMessage.match(/^(\S+(?:\s+\S+)?)\s/)
-  return match?.[1] ?? 'Unknown'
+export function extractBunkName(issue: IssueLike): string {
+  const structured = issue.details?.['bunk_name']
+  if (typeof structured === 'string' && structured.length > 0) return structured
+
+  // Fallback: parse the message. Each bunk-level message format has a known
+  // anchor — match the most specific patterns first.
+  const patterns: RegExp[] = [
+    /^Bunk\s+(.+?)\s+(?:is|has)\s/, // capacity_violation, grade_*, age_spread_warning
+    /^(.+?)\s+\(avg age\s/, // age_flow_inversion
+    /^(.+?)\s+has\s+\d+\s+connected\s/, // isolation_risk
+  ]
+  for (const pattern of patterns) {
+    const match = issue.message.match(pattern)
+    if (match?.[1]) return match[1]
+  }
+  return 'Unknown'
 }

--- a/frontend/src/components/issueClassifier.ts
+++ b/frontend/src/components/issueClassifier.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared classification for post-check Issue objects.
+ *
+ * Used by both PostValidationResultsModal (renders the in-app UI) and
+ * BunkPlanReport (PDF export). Keeping the sets/regex in one file
+ * avoids drift between the two surfaces.
+ */
+export const BUNK_LEVEL_ISSUE_TYPES = new Set([
+  'capacity_violation',
+  'age_spread_warning',
+  'grade_ratio_warning',
+  'grade_spread_warning',
+  'grade_adjacency_warning',
+  'age_flow_inversion',
+  'isolation_risk',
+])
+
+export const SUPPRESSED_ISSUE_TYPES = new Set([
+  'valid_negative_request_violated',
+  'no_requests',
+  'valid_request_unsatisfied',
+  'campers_with_unsatisfied_valid_requests',
+])
+
+/**
+ * Best-effort bunk name extraction from validator-emitted message strings.
+ * Validator messages start with "<BunkName> ..." today; if that ever changes,
+ * the validator should emit a structured `bunk_name` field instead.
+ */
+export function extractBunkName(issueMessage: string): string {
+  const match = issueMessage.match(/^(\S+(?:\s+\S+)?)\s/)
+  return match?.[1] ?? 'Unknown'
+}

--- a/frontend/src/components/issueClassifier.ts
+++ b/frontend/src/components/issueClassifier.ts
@@ -29,6 +29,18 @@ interface IssueLike {
 }
 
 /**
+ * Canonical post-check issue shape returned by the validator/API.
+ * Imported by PostValidationResultsModal, BunkPlanReport, and LazyPdfExportButton
+ * so a future field (e.g. `affected_ids`) only needs to land in one place.
+ */
+export interface PostCheckIssue {
+  type: string
+  severity: string
+  message: string
+  details?: Record<string, unknown>
+}
+
+/**
  * Returns the bunk name associated with an issue.
  *
  * Prefers `issue.details.bunk_name` (emitted structurally by the validator

--- a/frontend/src/services/solver.ts
+++ b/frontend/src/services/solver.ts
@@ -157,6 +157,20 @@ export interface ValidationStatistics {
   mp_campers_total?: number
   mp_campers_with_at_least_one_satisfied?: number
   mp_campers_with_all_satisfied?: number
+  /** TG-polish: one entry per unsatisfied MP request, with names + bunk placement. */
+  unsatisfied_material_parent_detail?: Array<{
+    requester_cm_id: string
+    requester_name: string
+    target_cm_id: string
+    target_name: string
+    requester_bunk_name: string
+    target_bunk_name: string
+  }>
+  /** TG-polish: per-gender bunk capacity + assigned counts. */
+  capacity_by_gender?: {
+    female: { capacity: number; assigned: number }
+    male: { capacity: number; assigned: number }
+  }
 }
 
 // Shared cache type for the pre-check query — written by PreValidateRequestsButton

--- a/tests/unit/api/test_geo_service.py
+++ b/tests/unit/api/test_geo_service.py
@@ -24,12 +24,15 @@ if TYPE_CHECKING:
     from api.services.geo_service import GeoService
 
 
-# Reset the module-level _PERSON_ID_CACHE before every test in this file so
-# cached results from one test don't bleed into another's call-count assertions.
+# Reset the module-level _PERSON_ID_CACHE before AND after every test in this
+# file so cached results don't bleed into another test's call-count assertions
+# (within file) or into other test files that share the same pytest process.
 @pytest.fixture(autouse=True)
-def _reset_geo_module_cache() -> None:
+def _reset_geo_module_cache() -> Generator[None]:
     from api.services.geo_service import clear_person_id_cache
 
+    clear_person_id_cache()
+    yield
     clear_person_id_cache()
 
 
@@ -1223,7 +1226,7 @@ class TestPersonIdCache:
     """Test TTL caching of active person IDs (module-level cache)."""
 
     @pytest.fixture(autouse=True)
-    def _clean_person_id_cache(self) -> Generator[None, None, None]:
+    def _clean_person_id_cache(self) -> Generator[None]:
         """Module-level cache leaks across test files; clear before and after each test."""
         from api.services.geo_service import clear_person_id_cache
 

--- a/tests/unit/api/test_geo_service.py
+++ b/tests/unit/api/test_geo_service.py
@@ -14,6 +14,7 @@ Tests verify:
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -1220,6 +1221,15 @@ class TestBatchResolveCoords:
 
 class TestPersonIdCache:
     """Test TTL caching of active person IDs (module-level cache)."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_person_id_cache(self) -> Generator[None, None, None]:
+        """Module-level cache leaks across test files; clear before and after each test."""
+        from api.services.geo_service import clear_person_id_cache
+
+        clear_person_id_cache()
+        yield
+        clear_person_id_cache()
 
     @pytest.fixture
     def mock_pb(self) -> MagicMock:

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -2449,3 +2449,48 @@ def test_priority_unsuccessfuls_empty_when_all_priority_requests_satisfied():
     )
 
     assert result.statistics.priority_unsuccessfuls == []
+
+
+def test_unsatisfied_material_parent_detail_populated_with_requester_target_and_bunks():
+    """Each unsatisfied MP request appears in detail list with requester+target names and bunk names."""
+    session = _mock_session(cm_id="10000001", name="DetailFixture")
+    persons = [
+        MockPerson(campminder_id="2001", name="Emma Johnson", grade=5),
+        MockPerson(campminder_id="2002", name="Liam Garcia", grade=5),
+    ]
+    bunks = [
+        MockBunk(campminder_id="3001", name="Pine 3", max_size=8),
+        MockBunk(campminder_id="3002", name="Oak 2", max_size=8),
+    ]
+    assignments = [
+        _mock_assignment("2001", "3001"),  # Emma in Pine 3
+        _mock_assignment("2002", "3002"),  # Liam in Oak 2
+    ]
+    requests = [
+        MockBunkRequest(
+            requester_person_cm_id="2001",
+            requested_person_cm_id="2002",
+            request_type="bunk_with",
+            status="resolved",
+            source_field=SourceField.BUNK_REQUEST_FORM,
+            source="family",
+        ),
+    ]
+
+    result = BunkingValidator().validate_bunking(
+        session=session,
+        bunks=cast(list[Bunk], bunks),
+        assignments=cast(list[BunkAssignment], assignments),
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+    )
+    detail = result.statistics.unsatisfied_material_parent_detail
+
+    assert len(detail) == 1
+    entry = detail[0]
+    assert entry["requester_cm_id"] == "2001"
+    assert entry["requester_name"] == "Emma Johnson"
+    assert entry["target_cm_id"] == "2002"
+    assert entry["target_name"] == "Liam Garcia"
+    assert entry["requester_bunk_name"] == "Pine 3"
+    assert entry["target_bunk_name"] == "Oak 2"

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -2498,6 +2498,70 @@ def test_unsatisfied_material_parent_detail_populated_with_requester_target_and_
     assert entry["target_bunk_name"] == "Oak 2"
 
 
+def test_unsatisfied_material_parent_detail_falls_back_when_person_missing():
+    """When requester or target is absent from `persons`, the detail row must still
+    appear with a `Person {pid}` fallback name — mirroring the sibling
+    `unsatisfied_material_parent_persons` block at validator L815-816.
+
+    Silently dropping the row (the old behavior) caused the modal's count to
+    under-report in any degraded-data scenario where a sync gap meant some person
+    rows weren't present locally.
+    """
+    session = _mock_session(cm_id="10000001", name="DetailFallback")
+    # Only the target (2002) is in the persons list; requester (2001) is missing.
+    persons = [MockPerson(campminder_id="2002", name="Liam Garcia", grade=5)]
+    bunks = [
+        MockBunk(campminder_id="3001", name="Pine 3", max_size=8),
+        MockBunk(campminder_id="3002", name="Oak 2", max_size=8),
+    ]
+    assignments = [
+        _mock_assignment("2001", "3001"),
+        _mock_assignment("2002", "3002"),
+    ]
+    requests = [
+        MockBunkRequest(
+            requester_person_cm_id="2001",
+            requested_person_cm_id="2002",
+            request_type="bunk_with",
+            status="resolved",
+            source_field=SourceField.BUNK_REQUEST_FORM,
+            source="family",
+        ),
+        # A second request where the TARGET is missing instead.
+        MockBunkRequest(
+            requester_person_cm_id="2002",
+            requested_person_cm_id="2003",
+            request_type="bunk_with",
+            status="resolved",
+            source_field=SourceField.BUNK_REQUEST_FORM,
+            source="family",
+        ),
+    ]
+    result = BunkingValidator().validate_bunking(
+        session=session,
+        bunks=cast(list[Bunk], bunks),
+        assignments=cast(list[BunkAssignment], assignments),
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+    )
+    detail = result.statistics.unsatisfied_material_parent_detail
+
+    by_requester = {entry["requester_cm_id"]: entry for entry in detail}
+
+    assert "2001" in by_requester, (
+        "Detail row dropped when requester was missing from persons — should use "
+        "Person {pid} fallback like the sibling persons block does."
+    )
+    assert by_requester["2001"]["requester_name"] == "Person 2001"
+    assert by_requester["2001"]["target_name"] == "Liam Garcia"
+
+    assert "2002" in by_requester, (
+        "Detail row dropped when target was missing from persons — should use Person {pid} fallback for target."
+    )
+    assert by_requester["2002"]["requester_name"] == "Liam Garcia"
+    assert by_requester["2002"]["target_name"] == "Person 2003"
+
+
 def test_capacity_by_gender_aggregates_bunks_and_assignments():
     """capacity_by_gender splits bunks/assignments by bunk.gender (F/M)."""
     session = _mock_session(cm_id="10000001", name="CapacityFixture")

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -2563,15 +2563,22 @@ def test_unsatisfied_material_parent_detail_falls_back_when_person_missing():
 
 
 def test_capacity_by_gender_aggregates_bunks_and_assignments():
-    """capacity_by_gender splits bunks/assignments by bunk.gender (F/M)."""
+    """capacity_by_gender splits bunks/assignments by bunk.gender (F/M).
+
+    Capacity is `n_bunks × DEFAULT_BUNK_CAPACITY` per gender — the real Bunk
+    model has no per-bunk size column (removed in Phase 2), so capacity is
+    headcount-based, not policy-driven.
+    """
+    from bunking.solver.constants import DEFAULT_BUNK_CAPACITY
+
     session = _mock_session(cm_id="10000001", name="CapacityFixture")
     persons = [
         MockPerson(campminder_id=f"2{i:03d}", name=f"P{i}", grade=5, gender=("F" if i < 3 else "M")) for i in range(6)
     ]
     bunks = [
-        MockBunk(campminder_id="3001", name="Female Pine 1", max_size=8, gender="F"),
-        MockBunk(campminder_id="3002", name="Female Pine 2", max_size=8, gender="F"),
-        MockBunk(campminder_id="3003", name="Male Oak 1", max_size=10, gender="M"),
+        MockBunk(campminder_id="3001", name="Female Pine 1", gender="F"),
+        MockBunk(campminder_id="3002", name="Female Pine 2", gender="F"),
+        MockBunk(campminder_id="3003", name="Male Oak 1", gender="M"),
     ]
     assignments = [
         _mock_assignment("2000", "3001"),
@@ -2589,7 +2596,7 @@ def test_capacity_by_gender_aggregates_bunks_and_assignments():
         requests=[],
     )
     cap = result.statistics.capacity_by_gender
-    assert cap["female"]["capacity"] == 16  # 2 F bunks × 8
+    assert cap["female"]["capacity"] == 2 * DEFAULT_BUNK_CAPACITY  # 2 F bunks
     assert cap["female"]["assigned"] == 3  # 3 F campers assigned
-    assert cap["male"]["capacity"] == 10  # 1 M bunk × 10
+    assert cap["male"]["capacity"] == 1 * DEFAULT_BUNK_CAPACITY  # 1 M bunk
     assert cap["male"]["assigned"] == 3

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -29,6 +29,7 @@ class PersonLike(Protocol):
     name: str
     grade: int | None
     age: float | None
+    gender: str | None
 
 
 class BunkLike(Protocol):
@@ -70,6 +71,7 @@ class MockPerson:
     name: str
     grade: int | None = None
     age: float | None = None
+    gender: str | None = None
 
 
 @dataclass
@@ -2494,3 +2496,36 @@ def test_unsatisfied_material_parent_detail_populated_with_requester_target_and_
     assert entry["target_name"] == "Liam Garcia"
     assert entry["requester_bunk_name"] == "Pine 3"
     assert entry["target_bunk_name"] == "Oak 2"
+
+
+def test_capacity_by_gender_aggregates_bunks_and_assignments():
+    """capacity_by_gender splits bunks/assignments by bunk.gender (F/M)."""
+    session = _mock_session(cm_id="10000001", name="CapacityFixture")
+    persons = [
+        MockPerson(campminder_id=f"2{i:03d}", name=f"P{i}", grade=5, gender=("F" if i < 3 else "M")) for i in range(6)
+    ]
+    bunks = [
+        MockBunk(campminder_id="3001", name="Female Pine 1", max_size=8, gender="F"),
+        MockBunk(campminder_id="3002", name="Female Pine 2", max_size=8, gender="F"),
+        MockBunk(campminder_id="3003", name="Male Oak 1", max_size=10, gender="M"),
+    ]
+    assignments = [
+        _mock_assignment("2000", "3001"),
+        _mock_assignment("2001", "3001"),
+        _mock_assignment("2002", "3002"),
+        _mock_assignment("2003", "3003"),
+        _mock_assignment("2004", "3003"),
+        _mock_assignment("2005", "3003"),
+    ]
+    result = BunkingValidator().validate_bunking(
+        session=session,
+        bunks=cast(list[Bunk], bunks),
+        assignments=cast(list[BunkAssignment], assignments),
+        persons=cast(list[Person], persons),
+        requests=[],
+    )
+    cap = result.statistics.capacity_by_gender
+    assert cap["female"]["capacity"] == 16  # 2 F bunks × 8
+    assert cap["female"]["assigned"] == 3  # 3 F campers assigned
+    assert cap["male"]["capacity"] == 10  # 1 M bunk × 10
+    assert cap["male"]["assigned"] == 3


### PR DESCRIPTION
## Summary
Polish round on PRs #1475 (post-check modal) + #1476 (PDF export). Reshapes the modal into 8 tight sections and expands the PDF into a comprehensive session report.

**Modal (Tasks 5-11):**
- New consolidated "Families to contact" section — merges the 3 legacy action sections (Got nothing / Families to call / Priority unsuccessfuls) into one alphabetical list with cohort pills
- New "Capacity by gender" section with female/male bars
- New "Bunks needing attention" section grouping bunk-level issues by extracted bunk name
- "Other issues" residual replaces the generic Issues List — suppressed types now surfaced in dedicated sections
- "Unmet parent requests" drill-down enriched: `Emma Johnson wanted Liam Garcia · Pine 3 vs Oak 2`
- "Details by request source" reordered to fixed backend order (no longer count-sorted)
- Impossibility kicker points users at Pre-Check / PDF for full per-camper detail
- Header styling normalized (`text-sm font-semibold` + themed colors)

**PDF (Tasks 12-16):**
- Single-click download (rewritten LazyPdfExportButton uses `pdf().toBlob()` + synthetic anchor)
- Page 1: MSP-focused Cover/Exec Summary (KPIs, coverage table, impossibility rollup, capacity by gender)
- Page 2: Families to contact (mirrors modal section)
- Page 3: Bunks needing attention + Other issues + Unmet drill-down (mirrors modal sections 5-7)
- Pages 4-N: Full impossibility detail grouped by reason

**Backend (Tasks 2-3):**
- `ValidationStatistics.unsatisfied_material_parent_detail` — powers enriched Unmet drill-down
- `ValidationStatistics.capacity_by_gender` — powers Capacity by gender section

**Shared code extracted:**
- `frontend/src/components/issueClassifier.ts` — `BUNK_LEVEL_ISSUE_TYPES`, `SUPPRESSED_ISSUE_TYPES`, `extractBunkName` used by both Modal and PDF
- `frontend/src/components/PdfExport/familyRows.ts` — shared cohort-merge logic for Families to contact

**Out of scope (deferred):**
- PDF per-bunk roster pages — needs raw bunks/persons/assignments/requests not currently on ValidationResults. Deferred to a follow-up PR per user decision.
- Bunks needing attention rich detail (chip+expand), "X issues to review" sub-label rephrase, Capacity by gender summer-session scoping — bundled into #1481 for separate PR.

**Test pollution fix:** Includes a one-line autouse fixture on `TestPersonIdCache` to clear the module-level `_PERSON_ID_CACHE` before/after each test. Pre-existing flake from PR #1462's geo-cache work; pytest's filesystem-dependent collection order surfaced it after a later PR shifted the order.

## Test plan
- [ ] Open post-check modal in dev — verify 8-section layout: KPI tiles → Families to contact → Impossible by reason → Capacity by gender → Bunks needing attention → Other issues → Unmet drill-down → Details by request source
- [ ] Confirm MSP-focused KPI tile shows MSP rate when MP requests exist
- [ ] Click "Export PDF" — verify single-click download (no two-click arm pattern)
- [ ] Open exported PDF — verify all sections render with the expected mock-up data
- [ ] Spot-check that suppressed issue types (`valid_negative_request_violated`, `no_requests`, `valid_request_unsatisfied`) appear in Families to contact / Unmet, NOT in Other issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single-click PDF export with safe filename, optional logo, executive summary, capacity-by-gender, and impossibility drill-downs.
  * Consolidated "Families to contact" card, "Bunks needing attention", and enriched unmet-parent rows showing requester/target names and bunk placements.
  * Conditional "Capacity by gender" and refined impossibility pagination/display.

* **Tests**
  * Expanded tests covering PDF pages/export, family rows ordering, validator statistics (capacity-by-gender, unsatisfied-parent details), and bunk-name parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->