### PR TITLE
refactor(solver): replace dict[str, Any] with RequestValidationSummary TypedDict

### DIFF
--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -42,6 +42,7 @@ from .constraints.grade_spread import add_grade_spread_constraints, add_grade_sp
 from .constraints.group_locks import add_group_lock_constraints
 from .constraints.level_progression import add_level_progression_constraints
 from .constraints.parent_paramount import add_must_satisfy_one_request_constraints
+from .feasibility import RequestValidationSummary
 from .feasibility import check_feasibility as _check_feasibility
 from .feasibility import find_infeasibility_cause as _find_infeasibility_cause
 from .logging import ConstraintLogger
@@ -297,7 +298,7 @@ class DirectBunkingSolver:
             for person_cm_id, reqs in self.input.requests_by_person.items()
             if person_cm_id in self.person_idx_map
         )
-        self.request_validation_summary: dict[str, Any] = {
+        self.request_validation_summary: RequestValidationSummary = {
             "total_requests": total_requests,
             "possible_requests": total_requests - report.total_impossible,
             "impossible_requests": report.total_impossible,

--- a/bunking/solver/feasibility.py
+++ b/bunking/solver/feasibility.py
@@ -7,7 +7,7 @@ Pre-solve checks to identify potential issues before running the solver.
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from ortools.sat.python import cp_model
 
@@ -22,6 +22,33 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+class _RequestValidationSummaryBase(TypedDict, total=True):
+    # Required keys set by _validate_requests before check_feasibility is called
+    total_requests: int
+    possible_requests: int
+    impossible_requests: int
+    impossible_by_reason: dict[str, dict[str, int]]
+    affected_campers: int
+
+
+class RequestValidationSummary(_RequestValidationSummaryBase, total=False):
+    # Optional keys written post-solve in direct_solver.py
+    unsatisfied_no_possible: int
+    unsatisfied_material_parent_unmet: int
+    unsatisfied_other_unmet: int
+    mp_constraint_bug_signal: int
+    mp_set_entirely_impossible_count: int
+    mp_set_entirely_impossible_cm_ids: list[int]
+    mp_requests_total: int
+    mp_requests_satisfied: int
+    mp_campers_total: int
+    mp_campers_satisfied: int
+    all_campers_total: int
+    all_campers_satisfied: int
+    all_requests_total: int
+    all_requests_satisfied: int
+
+
 def check_feasibility(
     bunks: list[DirectBunk],
     person_ids: list[int],
@@ -30,7 +57,7 @@ def check_feasibility(
     person_idx_map: dict[int, int],
     possible_requests: dict[int, list[DirectBunkRequest]],
     impossible_requests: dict[int, list[DirectBunkRequest]],
-    request_validation_summary: dict[str, Any],
+    request_validation_summary: RequestValidationSummary,
 ) -> None:
     """Perform pre-solve feasibility checks and log warnings.
 

--- a/tests/unit/solver/test_request_validation_mp_counts.py
+++ b/tests/unit/solver/test_request_validation_mp_counts.py
@@ -8,11 +8,11 @@ the 'all requests' and 'MP requests' scopes on top.
 
 from __future__ import annotations
 
-from typing import Any
 from unittest.mock import MagicMock
 
 from bunking.models_v2 import DirectBunk, DirectBunkAssignment, DirectBunkRequest, DirectPerson, DirectSolverInput
 from bunking.solver.direct_solver import DirectBunkingSolver
+from bunking.solver.feasibility import RequestValidationSummary
 
 # --- Test fixture builders -------------------------------------------------
 
@@ -69,7 +69,7 @@ def _run_post_solve_with_fixed_assignments(
     bunks: list[DirectBunk],
     requests: list[DirectBunkRequest],
     assignments: dict[int, int],
-) -> dict[str, Any]:
+) -> RequestValidationSummary:
     """Build a DirectBunkingSolver, install fixed assignments, invoke the
     post-solve diagnostic helper directly, and return its
     request_validation_summary.


### PR DESCRIPTION
Fixes #1386.

## Summary

- Introduces `RequestValidationSummary` (two-level TypedDict) in `feasibility.py` — required base keys set by `_validate_requests`, optional extension keys written post-solve in `direct_solver.py`
- Updates `check_feasibility` parameter type and `DirectBunkingSolver.request_validation_summary` attribute annotation
- Updates the test helper's return type in `test_request_validation_mp_counts.py`

The issue described a flat `dict[str, int]` TypedDict with 8 keys. The actual dict has grown to 19 keys (14 post-solve metrics added in #1385) and `impossible_by_reason` is `dict[str, dict[str, int]]` (bucket → reason → count), not `dict[str, int]`. The two-level TypedDict approach (`total=True` base + `total=False` extension) avoids false Pyright warnings on keys that are always present when `check_feasibility` is called.

## Test plan

- [ ] `uv run mypy bunking/solver/direct_solver.py bunking/solver/feasibility.py tests/unit/solver/test_request_validation_mp_counts.py` — clean
- [ ] `uv run pytest tests/unit/ -q` — 4661 passed, 14 skipped
- [ ] Pre-push verification — all checks passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure and type safety for request validation handling. No end-user functionality changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->