### PR TITLE
refactor(sync): delete dead _try_spelling_variations from fuzzy_match

### DIFF
--- a/bunking/sync/bunk_request_processor/resolution/strategies/fuzzy_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/fuzzy_match.py
@@ -16,7 +16,7 @@ from ...core.models import Person
 from ...data.repositories import AttendeeRepository, PersonRepository
 from ...shared import last_name_matches, parse_name
 from ...shared.name_utils import ParsedName
-from ...shared.nickname_groups import SPELLING_VARIATIONS, find_nickname_variations
+from ...shared.nickname_groups import find_nickname_variations
 from ..interfaces import ResolutionResult
 from .base_match_strategy import (
     _FIRST_NAME_CLOSE_SPELLING_THRESHOLD,
@@ -104,14 +104,7 @@ class FuzzyMatchStrategy(BaseMatchStrategy):
             if result.is_resolved or result.is_ambiguous:
                 return result
 
-            # 2. Try spelling variations
-            result = self._try_spelling_variations(
-                name_parts, requester_cm_id, session_cm_id, year, candidates, attendee_info
-            )
-            if result.is_resolved or result.is_ambiguous:
-                return result
-
-            # 2b. Try Jaro-Winkler first name similarity
+            # 2. Try Jaro-Winkler first name similarity
             result = self._try_jaro_winkler_first_name(
                 parsed, requester_cm_id, session_cm_id, year, candidates, attendee_info, all_persons
             )
@@ -185,59 +178,6 @@ class FuzzyMatchStrategy(BaseMatchStrategy):
                         method=self.name,
                         metadata={
                             "ambiguity_reason": "multiple_nickname_matches",
-                            "match_count": len(matches),
-                            "variant": variant,
-                        },
-                    )
-
-        return ResolutionResult(confidence=0.0, method=self.name)
-
-    def _try_spelling_variations(
-        self,
-        name_parts: list[str],
-        requester_cm_id: int,
-        session_cm_id: int | None,
-        year: int | None,
-        candidates: list[Person] | None = None,
-        attendee_info: dict[int, dict[str, Any]] | None = None,
-    ) -> ResolutionResult:
-        """Try common spelling variations."""
-        first_name = name_parts[0].lower()
-        last_name = name_parts[-1]
-
-        if first_name not in SPELLING_VARIATIONS:
-            return ResolutionResult(confidence=0.0, method=self.name)
-
-        for variant in SPELLING_VARIATIONS[first_name]:
-            if candidates:
-                matches = [
-                    c
-                    for c in candidates
-                    if c.first_name.title() == variant.title() and last_name_matches(last_name, c.last_name)
-                ]
-            else:
-                matches = self.person_repo.find_by_name(variant.title(), last_name.title(), year=year)
-
-            matches = self._filter_self_references(matches, requester_cm_id)
-
-            if matches:
-                if len(matches) == 1:
-                    confidence = self._calculate_confidence(
-                        matches[0], requester_cm_id, session_cm_id, year, attendee_info, is_spelling=True
-                    )
-                    return ResolutionResult(
-                        person=matches[0],
-                        confidence=confidence,
-                        method=self.name,
-                        metadata={"match_type": "spelling_variation", "variant": variant},
-                    )
-                else:
-                    return ResolutionResult(
-                        candidates=matches,
-                        confidence=0.5,
-                        method=self.name,
-                        metadata={
-                            "ambiguity_reason": "multiple_spelling_matches",
                             "match_count": len(matches),
                             "variant": variant,
                         },
@@ -324,10 +264,9 @@ class FuzzyMatchStrategy(BaseMatchStrategy):
             # the wrong person silently (see PR for cascade analysis).
             if is_single_name_search:
                 first_only = parsed.first
-                # Step 1: literal first_only + nickname variations. SPELLING_VARIATIONS
-                # is intentionally NOT consulted here — find_nickname_variations already
-                # merges its values in (see nickname_groups._add), so a separate pass
-                # would be a no-op after dedup.
+                # Step 1: literal first_only + nickname variations. find_nickname_variations
+                # already merges in SPELLING_VARIATIONS values (see nickname_groups._add),
+                # so a separate pass would be redundant.
                 search_terms: list[str] = [first_only, *find_nickname_variations(first_only)]
                 seen_cm_ids: set[int] = set()
                 merged: list[Person] = []


### PR DESCRIPTION
## Summary

- Delete the `_try_spelling_variations` method from `fuzzy_match.py` (~52 LOC)
- Delete its call site in `resolve_with_context`
- Drop the now-unused `SPELLING_VARIATIONS` import
- Refresh one stale comment that referenced the dead method

## Why this is safe

`_try_spelling_variations` ran only when `_try_nickname_variations` returned 0.0 confidence. `_try_nickname_variations` iterates `find_nickname_variations(first_name)`, which at `nickname_groups.py:209-210` already inlines every `SPELLING_VARIATIONS[name_lower]` value. By the time `_try_spelling_variations` would have run, it queried the exact same variants the prior pass already queried and got nothing for. Guaranteed empty.

Same proof structure as the PR #1482 removal in `_try_normalized_search` — that PR left all 4656 tests passing unchanged.

## Test coverage

`test_spelling_variation` at `tests/unit/sync/bunk_request_processor/resolution/strategies/test_fuzzy_match.py` resolves "Sara Johnson" to `Sarah Johnson` and asserts `metadata["match_type"] == "nickname"`. The test name refers to the spelling-variation input, but the behavior is already served by the nickname path. Test continues to pass.

## What stays alive

The `SPELLING_VARIATIONS` constant in `nickname_groups.py` is still used at `nickname_groups.py:209` inside `find_nickname_variations`. Not touched here.

## Test plan

- [x] `pytest tests/unit/sync/bunk_request_processor/resolution/strategies/test_fuzzy_match.py` — 38 pass
- [x] `pytest tests/unit/sync/bunk_request_processor/resolution/strategies/` — 137 pass
- [x] `pytest tests/unit/sync/bunk_request_processor/` — 1900 pass
- [x] `ruff format` + `ruff check` + `mypy` clean

Closes #1486

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Refactor**
* Streamlined the fuzzy name resolution matching process by removing spelling-variation matching from the workflow
* Reorganized the order of name-matching strategies to prioritize similarity-based comparison earlier in the resolution sequence
* Simplified the normalized-search fallback logic by removing redundant matching operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->