### PR TITLE
refactor(frontend): unify pinned-comparison delta logic

### DIFF
--- a/frontend/src/pages/summer/SolverDebugPage/PinnedComparisonPanel.test.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/PinnedComparisonPanel.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import * as comparisonModule from './buildComparisonSummary'
 import { getMetric } from './metricRegistry'
 import { PinnedComparisonPanel } from './PinnedComparisonPanel'
 
@@ -247,6 +248,18 @@ describe('PinnedComparisonPanel', () => {
 
     const branchesCell = screen.getByText('Branches').closest('td')!
     expect(branchesCell.getAttribute('title')).toBe(getMetric('num_branches').description)
+  })
+
+  it('table calls buildComparisonSummary for its row data (coupling test)', () => {
+    // Verifies structural coupling: the panel must call buildComparisonSummary
+    // to compute table row data, not its own parallel implementation.
+    // Spies on the named export; fails if the panel computes deltas independently.
+    const spy = vi.spyOn(comparisonModule, 'buildComparisonSummary')
+    render(<PinnedComparisonPanel runA={a} runB={b} onClear={vi.fn()} />)
+    // Panel must call buildComparisonSummary eagerly at render time for the table
+    // (the Copy JSON click handler also calls it, but that's a separate interaction).
+    expect(spy).toHaveBeenCalled()
+    spy.mockRestore()
   })
 
   it('renders constraint-type values from constraint_type_breakdown (#mockup-parity)', () => {

--- a/frontend/src/pages/summer/SolverDebugPage/PinnedComparisonPanel.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/PinnedComparisonPanel.tsx
@@ -3,14 +3,8 @@ import React, { useEffect, useRef, useState } from 'react'
 
 import { copyText } from '../../../utils/copyText'
 
-import { buildComparisonSummary } from './buildComparisonSummary'
-import {
-  COMPARABLE_METRICS,
-  formatMetric,
-  getMetric,
-  type MetricGroup,
-  type MetricInterpretation,
-} from './metricRegistry'
+import { buildComparisonSummary, type DeltaDirection } from './buildComparisonSummary'
+import { COMPARABLE_METRICS, formatMetric, getMetric, type MetricGroup } from './metricRegistry'
 import { pickStat } from './pickStat'
 
 import type { SolverRun } from '../../../hooks/useSolverRuns'
@@ -21,33 +15,12 @@ interface Props {
   onClear: () => void
 }
 
-function deltaClass(
-  metricKey: string,
-  delta: number | null,
-  runA: SolverRun,
-  runB: SolverRun
-): string {
-  if (delta === null) return 'text-gray-400'
-  const meta = getMetric(metricKey)
-  if (delta === 0) return 'text-gray-500'
-  const interpretation = effectiveInterpretation(meta, runA, runB)
-  if (interpretation === 'context') return 'text-gray-500 font-semibold'
-  const better =
-    (interpretation === 'lower-better' && delta < 0) ||
-    (interpretation === 'higher-better' && delta > 0)
-  return better ? 'text-green-700 font-semibold' : 'text-red-700 font-semibold'
-}
-
-function formatDelta(metricKey: string, delta: number | null): string {
-  if (delta === null) return '—'
-  const meta = getMetric(metricKey)
-  const sign = delta >= 0 ? '+' : ''
-  const arrow = delta > 0 ? ' ↑' : delta < 0 ? ' ↓' : ''
-  if (meta.format === 'percent') return `${sign}${(delta * 100).toFixed(2)}%${arrow}`
-  if (meta.format === 'duration') return `${sign}${delta.toFixed(1)}s${arrow}`
-  if (meta.format === 'decimal')
-    return `${sign}${delta.toLocaleString('en-US', { maximumFractionDigits: 2 })}${arrow}`
-  return `${sign}${delta.toLocaleString('en-US', { maximumFractionDigits: 0 })}${arrow}`
+const DIRECTION_CLASS: Record<DeltaDirection, string> = {
+  improved: 'text-green-700 font-semibold',
+  regressed: 'text-red-700 font-semibold',
+  context: 'text-gray-500 font-semibold',
+  unchanged: 'text-gray-500',
+  missing: 'text-gray-400',
 }
 
 function shouldHighlight(
@@ -65,27 +38,6 @@ function shouldHighlight(
     pickStat(runA.stats, meta.key) !== pickStat(runA.stats, fromKey) ||
     pickStat(runB.stats, meta.key) !== pickStat(runB.stats, fromKey)
   )
-}
-
-function configSnapshotsMatch(runA: SolverRun, runB: SolverRun): boolean {
-  const a = runA.details?.config_snapshot
-  const b = runB.details?.config_snapshot
-  if (!a || !b) return false
-  const keysA = Object.keys(a)
-  const keysB = Object.keys(b)
-  if (keysA.length !== keysB.length) return false
-  return keysA.every((k) => a[k] === b[k])
-}
-
-function effectiveInterpretation(
-  meta: ReturnType<typeof getMetric>,
-  runA: SolverRun,
-  runB: SolverRun
-): MetricInterpretation {
-  if (meta.key === 'objective_value' && configSnapshotsMatch(runA, runB)) {
-    return 'higher-better'
-  }
-  return meta.interpretation
 }
 
 const GROUP_LABELS: Record<MetricGroup, string> = {
@@ -117,6 +69,8 @@ export function PinnedComparisonPanel({ runA, runB, onClear }: Props) {
   const aCount = runA.details?.session_attendee_count
   const bCount = runB.details?.session_attendee_count
   const drift = aCount !== undefined && bCount !== undefined && aCount !== bCount
+
+  const summary = buildComparisonSummary(runA, runB)
 
   // Group metrics by their `group` field, preserving COMPARABLE_METRICS order within each group
   const byGroup: Record<MetricGroup, string[]> = {
@@ -188,11 +142,14 @@ export function PinnedComparisonPanel({ runA, runB, onClear }: Props) {
                 </tr>
                 {keys.map((key) => {
                   const meta = getMetric(key)
+                  const delta = summary.deltas[key]
                   const va = pickStat(runA.stats, key)
                   const vb = pickStat(runB.stats, key)
-                  const delta = va != null && vb != null ? vb - va : null
                   const isChild = meta.parent != null
                   const rowBg = shouldHighlight(meta, runA, runB) ? 'bg-yellow-50' : ''
+                  const directionClass = delta
+                    ? DIRECTION_CLASS[delta.direction]
+                    : DIRECTION_CLASS['missing']
                   return (
                     <tr key={key} className={`hover:bg-forest-50/30 ${rowBg}`}>
                       <td
@@ -207,8 +164,8 @@ export function PinnedComparisonPanel({ runA, runB, onClear }: Props) {
                       <td className="px-3 py-2 text-right text-gray-600">
                         {formatMetric(key, vb)}
                       </td>
-                      <td className={`px-5 py-2 text-right ${deltaClass(key, delta, runA, runB)}`}>
-                        {formatDelta(key, delta)}
+                      <td className={`px-5 py-2 text-right ${directionClass}`}>
+                        {delta?.delta_formatted ?? '—'}
                       </td>
                     </tr>
                   )


### PR DESCRIPTION
## Summary
- Consolidates `configSnapshotsMatch`, `effectiveInterpretation`, and delta value/direction computation between `PinnedComparisonPanel.tsx` and `buildComparisonSummary.ts`
- Table now renders directly from `buildComparisonSummary(runA, runB)` output via a `DIRECTION_CLASS` map on `DeltaDirection`
- Single source of truth for both JSON export and visible deltas — UI/JSON drift is now structurally prevented

Closes #1367

## Test plan
- [x] New test in `PinnedComparisonPanel.test.tsx` verifies panel calls `buildComparisonSummary` at render time (coupling test — was failing before refactor)
- [x] Existing `PinnedComparisonPanel.test.tsx` tests still pass (22 tests)
- [x] Existing `buildComparisonSummary.test.ts` tests still pass (9 tests)
- [x] Full SolverDebugPage test suite passes (189 tests)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean (0 errors in changed files)
- [x] `npx prettier --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for the comparison panel component behavior.

* **Refactor**
  * Updated the comparison panel component to use a centralized calculation method for delta values, improving code maintainability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->