### PR TITLE
refactor(sync): kill dual resolve() / resolve_with_context() API (part of #1478)

### DIFF
--- a/bunking/sync/bunk_request_processor/resolution/interfaces.py
+++ b/bunking/sync/bunk_request_processor/resolution/interfaces.py
@@ -65,28 +65,6 @@ class ResolutionStrategy(ABC):
 
     @abstractmethod
     def resolve(
-        self, name: str, requester_cm_id: int, session_cm_id: int | None = None, year: int | None = None
-    ) -> ResolutionResult:
-        """Attempt to resolve a name to a Person.
-
-        Args:
-            name: The name to resolve
-            requester_cm_id: The person making the request
-            session_cm_id: Optional session context
-            year: Year context for the resolution
-
-        Returns:
-            ResolutionResult with the outcome
-        """
-        pass
-
-    @property
-    @abstractmethod
-    def name(self) -> str:
-        """Strategy name for logging and debugging"""
-        pass
-
-    def resolve_with_context(
         self,
         name: str,
         requester_cm_id: int,
@@ -96,22 +74,15 @@ class ResolutionStrategy(ABC):
         attendee_info: dict[int, dict[str, Any]] | None = None,
         all_persons: list[Person] | None = None,
     ) -> ResolutionResult:
-        """Resolve a name with pre-loaded context data.
+        """Resolve a name to a Person.
 
-        This is an optional method for batch optimization. If not implemented,
-        the pipeline will fall back to the regular resolve method.
-
-        Args:
-            name: Name to resolve
-            requester_cm_id: Person making the request
-            session_cm_id: Optional session context
-            year: Year context for resolution
-            candidates: Pre-loaded candidate persons for this name
-            attendee_info: Pre-loaded attendee info dict {cm_id: {'session_cm_id': ..., 'school': ..., etc.}}
-            all_persons: All persons in the system, for fallback phonetic matching
-
-        Returns:
-            ResolutionResult with the outcome
+        When candidates/attendee_info/all_persons are provided, uses pre-loaded data
+        for batch optimization. Otherwise falls back to database queries.
         """
-        # Default implementation falls back to regular resolve
-        return self.resolve(name, requester_cm_id, session_cm_id, year)
+        pass
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Strategy name for logging and debugging"""
+        pass

--- a/bunking/sync/bunk_request_processor/resolution/resolution_pipeline.py
+++ b/bunking/sync/bunk_request_processor/resolution/resolution_pipeline.py
@@ -59,72 +59,6 @@ class ResolutionPipeline:
         """
         self._person_sessions = person_sessions
 
-    def resolve(
-        self, name: str, requester_cm_id: int, session_cm_id: int | None = None, year: int | None = None
-    ) -> ResolutionResult:
-        """Attempt to resolve a name using configured strategies.
-
-        Args:
-            name: Name to resolve
-            requester_cm_id: Person making the request
-            session_cm_id: Optional session context override
-            year: Year context for resolution
-
-        Returns:
-            ResolutionResult with the best outcome
-        """
-        # Check cache first
-        if self.cache:
-            cached_result = self.cache.get_cached_resolution(name, requester_cm_id, session_cm_id or 0, year or 0)
-            if cached_result:
-                return cached_result
-
-        # Get session context if not provided
-        if session_cm_id is None and year:
-            attendee_info = self.attendee_repo.get_by_person_and_year(requester_cm_id, year)
-            if attendee_info:
-                session_cm_id = attendee_info["session_cm_id"]
-
-        # Try each strategy in order
-        best_result = ResolutionResult()
-
-        for strategy in self.strategies:
-            try:
-                result = strategy.resolve(
-                    name=name, requester_cm_id=requester_cm_id, session_cm_id=session_cm_id, year=year
-                )
-
-                # If we got a definitive match with high confidence, use it
-                if result.is_resolved and result.confidence >= max(0.8, self.minimum_confidence):
-                    best_result = result
-                    break
-
-                # Track best result so far
-                if result.confidence > best_result.confidence:
-                    best_result = result
-
-                # If we have an ambiguous result, keep it unless we find better
-                if result.is_ambiguous and not best_result.is_ambiguous:
-                    best_result = result
-
-            except Exception:  # noqa: S112 — intentional continue on error
-                # Log error but continue with other strategies
-                continue
-
-        # Apply minimum confidence threshold
-        if best_result.is_resolved and best_result.confidence < self.minimum_confidence:
-            # Convert to unresolved if below threshold
-            best_result.person = None
-            if best_result.metadata is None:
-                best_result.metadata = {}
-            best_result.metadata["below_threshold"] = True
-
-        # Cache the result
-        if self.cache and best_result.confidence > 0:
-            self.cache.cache_resolution(name, requester_cm_id, session_cm_id or 0, year or 0, best_result)
-
-        return best_result
-
     def _generate_cache_key(self, name: str, requester_cm_id: int, session_cm_id: int | None, year: int | None) -> str:
         """Generate a cache key for resolution results"""
         parts = [
@@ -304,24 +238,15 @@ class ResolutionPipeline:
 
             for strategy in self.strategies:
                 try:
-                    # Check if strategy supports batch context
-                    if hasattr(strategy, "resolve_with_context"):
-                        # Pass pre-loaded data to strategy
-                        # attendee_info format: {cm_id: {'session_cm_id': ..., 'school': ..., etc.}}
-                        result = strategy.resolve_with_context(
-                            name=name,
-                            requester_cm_id=requester_cm_id,
-                            session_cm_id=session_cm_id,
-                            year=year,
-                            candidates=candidates,
-                            attendee_info=attendee_info,
-                            all_persons=all_persons_for_phonetic,
-                        )
-                    else:
-                        # Fall back to regular resolve
-                        result = strategy.resolve(
-                            name=name, requester_cm_id=requester_cm_id, session_cm_id=session_cm_id, year=year
-                        )
+                    result = strategy.resolve(
+                        name=name,
+                        requester_cm_id=requester_cm_id,
+                        session_cm_id=session_cm_id,
+                        year=year,
+                        candidates=candidates,
+                        attendee_info=attendee_info,
+                        all_persons=all_persons_for_phonetic,
+                    )
 
                     # Log detailed result info
                     logger.debug(

--- a/bunking/sync/bunk_request_processor/resolution/resolution_pipeline.py
+++ b/bunking/sync/bunk_request_processor/resolution/resolution_pipeline.py
@@ -59,17 +59,6 @@ class ResolutionPipeline:
         """
         self._person_sessions = person_sessions
 
-    def _generate_cache_key(self, name: str, requester_cm_id: int, session_cm_id: int | None, year: int | None) -> str:
-        """Generate a cache key for resolution results"""
-        parts = [
-            "resolution",
-            name.lower().strip(),
-            str(requester_cm_id),
-            str(session_cm_id or "none"),
-            str(year or "none"),
-        ]
-        return ":".join(parts)
-
     def batch_resolve(self, requests: list[tuple[str, int, int | None, int | None]]) -> list[ResolutionResult]:
         """Batch resolve multiple names efficiently.
 

--- a/bunking/sync/bunk_request_processor/resolution/strategies/base_match_strategy.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/base_match_strategy.py
@@ -10,7 +10,6 @@ the bunk_with/not_bunk_with thresholds — it's not a tunable knob."""
 
 from __future__ import annotations
 
-from abc import abstractmethod
 from typing import Any
 
 import jellyfish
@@ -70,17 +69,6 @@ class BaseMatchStrategy(ResolutionStrategy):
         """Strategy name for logging"""
         return self._strategy_name
 
-    @abstractmethod
-    def resolve(
-        self,
-        name: str,
-        requester_cm_id: int,
-        session_cm_id: int | None = None,
-        year: int | None = None,
-    ) -> ResolutionResult:
-        """Attempt to resolve a name. Must be implemented by subclasses."""
-        pass
-
     def _filter_self_references(self, matches: list[Person], requester_cm_id: int) -> list[Person]:
         """Filter out the requester from the matches list.
 
@@ -92,48 +80,6 @@ class BaseMatchStrategy(ResolutionStrategy):
             Filtered list without the requester
         """
         return [m for m in matches if m.cm_id != requester_cm_id]
-
-    def _disambiguate_with_session_context(
-        self,
-        matches: list[Person],
-        requester_cm_id: int,
-        session_cm_id: int,
-        year: int,
-        attendee_info: dict[int, dict[str, Any]] | None,
-    ) -> ResolutionResult:
-        """Try to disambiguate using session information from pre-loaded data.
-
-        Args:
-            matches: List of candidate persons
-            requester_cm_id: The person making the request
-            session_cm_id: The session to match against
-            year: Year context
-            attendee_info: Pre-loaded attendee info {person_cm_id: {'session_cm_id': ...}}
-
-        Returns:
-            ResolutionResult - resolved if exactly one match in same session
-        """
-        if not attendee_info:
-            return ResolutionResult(confidence=0.0, method=self.name)
-
-        # Filter by same session using pre-loaded attendee info
-        same_session_matches = []
-        for m in matches:
-            person_info = attendee_info.get(m.cm_id)
-            if person_info and person_info.get("session_cm_id") == session_cm_id:
-                same_session_matches.append(m)
-
-        if len(same_session_matches) == 1:
-            # Get session_match confidence from config with fallback
-            confidence = self.config.get("session_match", DEFAULT_SESSION_MATCH)
-            return ResolutionResult(
-                person=same_session_matches[0],
-                confidence=confidence,
-                method=self.name,
-                metadata={"session_match": "exact"},
-            )
-
-        return ResolutionResult(confidence=0.0, method=self.name)
 
     def _calculate_base_confidence(self, match_type: str) -> float:
         """Calculate base confidence for a match type from config.

--- a/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
@@ -36,12 +36,6 @@ class ExactMatchStrategy(BaseMatchStrategy):
         self._strategy_name = "exact_match"
 
     def resolve(
-        self, name: str, requester_cm_id: int, session_cm_id: int | None = None, year: int | None = None
-    ) -> ResolutionResult:
-        """Exact name resolution (simple API without pre-loaded data)."""
-        return self.resolve_with_context(name, requester_cm_id, session_cm_id, year)
-
-    def resolve_with_context(
         self,
         name: str,
         requester_cm_id: int,

--- a/bunking/sync/bunk_request_processor/resolution/strategies/fuzzy_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/fuzzy_match.py
@@ -69,12 +69,6 @@ class FuzzyMatchStrategy(BaseMatchStrategy):
         self.relationship_analyzer = relationship_analyzer
 
     def resolve(
-        self, name: str, requester_cm_id: int, session_cm_id: int | None = None, year: int | None = None
-    ) -> ResolutionResult:
-        """Attempt fuzzy name resolution (simple API without pre-loaded data)."""
-        return self.resolve_with_context(name, requester_cm_id, session_cm_id, year)
-
-    def resolve_with_context(
         self,
         name: str,
         requester_cm_id: int,
@@ -199,7 +193,7 @@ class FuzzyMatchStrategy(BaseMatchStrategy):
         match_type = "normalized"
 
         # Detect single-name search via parse_name so the gate's notion of "single
-        # name" matches the upstream `parsed.is_complete` branch in resolve_with_context.
+        # name" matches the upstream `parsed.is_complete` branch in resolve().
         # Raw `name.strip().split()` would miss enumeration prefixes (e.g. "1. Jo"
         # splits to 2 tokens but parse_name strips the prefix to yield a first-only
         # result).

--- a/bunking/sync/bunk_request_processor/resolution/strategies/phonetic_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/phonetic_match.py
@@ -55,12 +55,6 @@ class PhoneticMatchStrategy(BaseMatchStrategy):
         super().__init__(person_repository, attendee_repository, config)
         self._strategy_name = "phonetic_match"
 
-    def resolve(
-        self, name: str, requester_cm_id: int, session_cm_id: int | None = None, year: int | None = None
-    ) -> ResolutionResult:
-        """Phonetic name resolution (simple API without pre-loaded data)."""
-        return self.resolve_with_context(name, requester_cm_id, session_cm_id, year)
-
     def _try_soundex_match(
         self,
         name_parts: list[str],
@@ -482,7 +476,7 @@ class PhoneticMatchStrategy(BaseMatchStrategy):
         penalty = float(self._get_confidence("not_enrolled_penalty", DEFAULT_NOT_ENROLLED_PENALTY))
         return base_confidence + penalty
 
-    def resolve_with_context(
+    def resolve(
         self,
         name: str,
         requester_cm_id: int,

--- a/bunking/sync/bunk_request_processor/resolution/strategies/school_disambiguation.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/school_disambiguation.py
@@ -31,12 +31,6 @@ class SchoolDisambiguationStrategy(ResolutionStrategy):
         """Strategy name for logging"""
         return "school_disambiguation"
 
-    def resolve(
-        self, name: str, requester_cm_id: int, session_cm_id: int | None = None, year: int | None = None
-    ) -> ResolutionResult:
-        """School-based disambiguation resolution (simple API without pre-loaded data)."""
-        return self.resolve_with_context(name, requester_cm_id, session_cm_id, year)
-
     # School name abbreviation mappings for normalization
     SCHOOL_ABBREVIATIONS: ClassVar[dict[str, str]] = {
         "middle school": "ms",
@@ -274,7 +268,7 @@ class SchoolDisambiguationStrategy(ResolutionStrategy):
 
         return ResolutionResult(confidence=0.0, method=self.name)
 
-    def resolve_with_context(
+    def resolve(
         self,
         name: str,
         requester_cm_id: int,
@@ -284,11 +278,7 @@ class SchoolDisambiguationStrategy(ResolutionStrategy):
         attendee_info: dict[int, dict[str, Any]] | None = None,
         all_persons: list[Person] | None = None,
     ) -> ResolutionResult:
-        """Resolve using pre-loaded candidates and attendee info (canonical body).
-
-        When candidates and all_persons are both None, falls back to a database
-        query — this is the path taken when called via the resolve() shim.
-        """
+        """Resolve using pre-loaded candidates and attendee info."""
         # Parse the name
         parsed = parse_name(name)
         if not parsed.is_complete:

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_base_match_strategy.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_base_match_strategy.py
@@ -29,7 +29,16 @@ def create_concrete_strategy(config=None):
     class ConcreteMatchStrategy(BaseMatchStrategy):
         """Concrete implementation for testing base class methods."""
 
-        def resolve(self, name, requester_cm_id, session_cm_id=None, year=None):
+        def resolve(
+            self,
+            name,
+            requester_cm_id,
+            session_cm_id=None,
+            year=None,
+            candidates=None,
+            attendee_info=None,
+            all_persons=None,
+        ):
             """Dummy resolve implementation - not used in base class tests."""
             return ResolutionResult(confidence=0.0, method=self.name)
 
@@ -90,101 +99,6 @@ class TestBaseMatchStrategyFilterSelfReferences:
         result = base_strategy._filter_self_references([], 12345)
 
         assert result == []
-
-
-class TestBaseMatchStrategyDisambiguateWithSessionContext:
-    """Test _disambiguate_with_session_context method"""
-
-    @pytest.fixture
-    def base_strategy(self):
-        """Create a BaseMatchStrategy with session_match confidence config"""
-        return create_concrete_strategy(config={"session_match": 0.85})
-
-    def test_resolves_single_match_in_same_session(self, base_strategy):
-        """Should resolve when exactly one candidate is in same session"""
-        matches = [
-            Person(cm_id=12345, first_name="John", last_name="Smith"),
-            Person(cm_id=67890, first_name="John", last_name="Smythe"),
-        ]
-        session_cm_id = 1000002
-        attendee_info = {
-            12345: {"session_cm_id": 1000002},  # Same session
-            67890: {"session_cm_id": 1000003},  # Different session
-        }
-
-        result = base_strategy._disambiguate_with_session_context(
-            matches=matches,
-            requester_cm_id=99999,
-            session_cm_id=session_cm_id,
-            year=2025,
-            attendee_info=attendee_info,
-        )
-
-        assert result.is_resolved
-        assert result.person.cm_id == 12345
-        assert result.confidence == 0.85  # From config
-        assert result.metadata.get("session_match") == "exact"
-
-    def test_returns_unresolved_when_multiple_in_same_session(self, base_strategy):
-        """Should return unresolved when multiple candidates in same session"""
-        matches = [
-            Person(cm_id=12345, first_name="John", last_name="Smith"),
-            Person(cm_id=67890, first_name="John", last_name="Smythe"),
-        ]
-        session_cm_id = 1000002
-        attendee_info = {
-            12345: {"session_cm_id": 1000002},  # Same session
-            67890: {"session_cm_id": 1000002},  # Also same session
-        }
-
-        result = base_strategy._disambiguate_with_session_context(
-            matches=matches,
-            requester_cm_id=99999,
-            session_cm_id=session_cm_id,
-            year=2025,
-            attendee_info=attendee_info,
-        )
-
-        assert not result.is_resolved
-        assert result.confidence == 0.0
-
-    def test_returns_unresolved_when_none_in_same_session(self, base_strategy):
-        """Should return unresolved when no candidates in same session"""
-        matches = [
-            Person(cm_id=12345, first_name="John", last_name="Smith"),
-            Person(cm_id=67890, first_name="John", last_name="Smythe"),
-        ]
-        session_cm_id = 1000002
-        attendee_info = {
-            12345: {"session_cm_id": 1000003},  # Different session
-            67890: {"session_cm_id": 1000004},  # Also different session
-        }
-
-        result = base_strategy._disambiguate_with_session_context(
-            matches=matches,
-            requester_cm_id=99999,
-            session_cm_id=session_cm_id,
-            year=2025,
-            attendee_info=attendee_info,
-        )
-
-        assert not result.is_resolved
-        assert result.confidence == 0.0
-
-    def test_handles_missing_attendee_info(self, base_strategy):
-        """Should handle None attendee_info gracefully"""
-        matches = [Person(cm_id=12345, first_name="John", last_name="Smith")]
-
-        result = base_strategy._disambiguate_with_session_context(
-            matches=matches,
-            requester_cm_id=99999,
-            session_cm_id=1000002,
-            year=2025,
-            attendee_info=None,
-        )
-
-        assert not result.is_resolved
-        assert result.confidence == 0.0
 
 
 class TestBaseMatchStrategyCalculateBaseConfidence:
@@ -409,36 +323,6 @@ class TestBaseMatchStrategyIntegration:
             attendee_info=attendee_info,
         )
         assert adjusted == pytest.approx(0.90)  # 0.85 + 0.05 boost
-
-    def test_filter_then_disambiguate_workflow(self, base_strategy):
-        """Test workflow: filter self, then disambiguate"""
-        requester_cm_id = 99999
-        session_cm_id = 1000002
-        matches = [
-            Person(cm_id=99999, first_name="Self", last_name="Requester"),
-            Person(cm_id=12345, first_name="John", last_name="Smith"),
-            Person(cm_id=67890, first_name="John", last_name="Smythe"),
-        ]
-        attendee_info = {
-            12345: {"session_cm_id": 1000002},  # Same session
-            67890: {"session_cm_id": 1000003},  # Different session
-        }
-
-        # Filter out self
-        filtered = base_strategy._filter_self_references(matches, requester_cm_id)
-        assert len(filtered) == 2
-
-        # Disambiguate by session
-        result = base_strategy._disambiguate_with_session_context(
-            matches=filtered,
-            requester_cm_id=requester_cm_id,
-            session_cm_id=session_cm_id,
-            year=2025,
-            attendee_info=attendee_info,
-        )
-
-        assert result.is_resolved
-        assert result.person.cm_id == 12345
 
 
 class TestIsExactOrCloseFirstName:

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
@@ -232,7 +232,7 @@ class TestExactMatchStrategy:
             },
         }
 
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             name="Erez Costello",
             requester_cm_id=1000001,
             session_cm_id=1000010,
@@ -344,7 +344,7 @@ class TestExactMatchParentSurname:
         assert result.person is None
 
     def test_parent_surname_with_context_method(self, strategy, mock_repositories):
-        """Test parent surname matching with resolve_with_context method"""
+        """Test parent surname matching with resolve method"""
         person_repo, _ = mock_repositories
 
         # Pre-loaded candidate with parent surname
@@ -358,7 +358,7 @@ class TestExactMatchParentSurname:
 
         person_repo.find_by_name.return_value = []
 
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             "Emma Smith", requester_cm_id=67890, session_cm_id=1000002, year=2025, candidates=[person], attendee_info={}
         )
 
@@ -386,38 +386,38 @@ class TestExactMatchPreferredName:
         person_repo.get_all_for_phonetic_matching.return_value = []
         return ExactMatchStrategy(person_repo, attendee_repo)
 
-    def test_resolve_with_context_matches_preferred_name(self, strategy):
+    def test_resolve_matches_preferred_name(self, strategy):
         """preferred_name should match when first_name doesn't."""
         candidates = [
             Person(cm_id=100, first_name="Nicholas", last_name="Garcia", preferred_name="Nick"),
         ]
-        result = strategy.resolve_with_context("Nick Garcia", requester_cm_id=999, candidates=candidates)
+        result = strategy.resolve("Nick Garcia", requester_cm_id=999, candidates=candidates)
         assert result.is_resolved
         assert result.person.cm_id == 100
 
-    def test_resolve_with_context_preferred_name_none_safe(self, strategy):
+    def test_resolve_preferred_name_none_safe(self, strategy):
         """Candidates with preferred_name=None should not crash."""
         candidates = [
             Person(cm_id=100, first_name="Nicholas", last_name="Garcia", preferred_name=None),
         ]
-        result = strategy.resolve_with_context("Nick Garcia", requester_cm_id=999, candidates=candidates)
+        result = strategy.resolve("Nick Garcia", requester_cm_id=999, candidates=candidates)
         assert not result.is_resolved  # "Nick" != "Nicholas", no preferred_name
 
-    def test_resolve_with_context_first_name_still_works(self, strategy):
+    def test_resolve_first_name_still_works(self, strategy):
         """Standard first_name matching still works alongside preferred_name."""
         candidates = [
             Person(cm_id=100, first_name="Nicholas", last_name="Garcia", preferred_name="Nick"),
         ]
-        result = strategy.resolve_with_context("Nicholas Garcia", requester_cm_id=999, candidates=candidates)
+        result = strategy.resolve("Nicholas Garcia", requester_cm_id=999, candidates=candidates)
         assert result.is_resolved
         assert result.person.cm_id == 100
 
-    def test_resolve_with_context_preferred_name_case_insensitive(self, strategy):
+    def test_resolve_preferred_name_case_insensitive(self, strategy):
         """preferred_name matching should be case-insensitive via title()."""
         candidates = [
             Person(cm_id=100, first_name="Elizabeth", last_name="Chen", preferred_name="liz"),
         ]
-        result = strategy.resolve_with_context("Liz Chen", requester_cm_id=999, candidates=candidates)
+        result = strategy.resolve("Liz Chen", requester_cm_id=999, candidates=candidates)
         assert result.is_resolved
         assert result.person.cm_id == 100
 
@@ -426,12 +426,12 @@ class TestExactMatchPreferredName:
         candidates = [
             Person(cm_id=100, first_name="Nicholas", last_name="Garcia", preferred_name=""),
         ]
-        result = strategy.resolve_with_context("Nick Garcia", requester_cm_id=999, candidates=candidates)
+        result = strategy.resolve("Nick Garcia", requester_cm_id=999, candidates=candidates)
         assert not result.is_resolved
 
 
 class TestResolveWithContextSessionHandling:
-    """Tests for resolve_with_context: unknown vs different session distinction."""
+    """Tests for resolve: unknown vs different session distinction."""
 
     @pytest.fixture
     def mock_repositories(self):
@@ -457,7 +457,7 @@ class TestResolveWithContextSessionHandling:
             # 1234568 NOT present — cancelled target absent from enrolled-only map
         }
 
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             name="Emma Johnson",
             requester_cm_id=1000001,
             session_cm_id=1000010,
@@ -479,7 +479,7 @@ class TestResolveWithContextSessionHandling:
             1234567: {"session_cm_id": 1000010},  # same session
         }
 
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             name="Ivy Smith",
             requester_cm_id=1000001,
             session_cm_id=1000010,
@@ -499,7 +499,7 @@ class TestResolveWithContextSessionHandling:
             1234567: {"session_cm_id": 1000020},  # different session
         }
 
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             name="Ivy Smith",
             requester_cm_id=1000001,
             session_cm_id=1000010,
@@ -522,7 +522,7 @@ class TestResolveWithContextSessionHandling:
             11444631: {"session_cm_id": 1235405, "session_cm_ids": [1235405]},
         }
 
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             name="Emily Shapiro",
             requester_cm_id=1000001,
             session_cm_id=1235405,
@@ -547,7 +547,7 @@ class TestResolveWithContextSessionHandling:
             },
         }
 
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             name="Erez Costello",
             requester_cm_id=1000001,
             session_cm_id=1000010,
@@ -570,7 +570,7 @@ class TestResolveWithContextSessionHandling:
             },
         }
 
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             name="Erez Costello",
             requester_cm_id=1000001,
             session_cm_id=1000010,
@@ -586,7 +586,7 @@ class TestResolveWithContextSessionHandling:
         """No attendee_info provided → confidence 0.90 (existing behavior)."""
         target = Person(cm_id=1234567, first_name="Ivy", last_name="Smith")
 
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             name="Ivy Smith",
             requester_cm_id=1000001,
             session_cm_id=1000010,

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
@@ -343,7 +343,7 @@ class TestExactMatchParentSurname:
         assert not result.is_resolved
         assert result.person is None
 
-    def test_parent_surname_with_context_method(self, strategy, mock_repositories):
+    def test_parent_surname_via_resolve(self, strategy, mock_repositories):
         """Test parent surname matching with resolve method"""
         person_repo, _ = mock_repositories
 
@@ -430,7 +430,7 @@ class TestExactMatchPreferredName:
         assert not result.is_resolved
 
 
-class TestResolveWithContextSessionHandling:
+class TestResolveSessionHandling:
     """Tests for resolve: unknown vs different session distinction."""
 
     @pytest.fixture

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_fuzzy_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_fuzzy_match.py
@@ -323,7 +323,7 @@ class TestFuzzyMatchParentSurname:
         assert result.person.cm_id == 12345
         assert result.metadata.get("match_type") == "parent_surname"
 
-    def test_parent_surname_with_context_method(self, strategy, mock_repositories):
+    def test_parent_surname_via_resolve(self, strategy, mock_repositories):
         """Test parent surname matching with resolve method"""
         person_repo, _ = mock_repositories
 

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_fuzzy_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_fuzzy_match.py
@@ -324,7 +324,7 @@ class TestFuzzyMatchParentSurname:
         assert result.metadata.get("match_type") == "parent_surname"
 
     def test_parent_surname_with_context_method(self, strategy, mock_repositories):
-        """Test parent surname matching with resolve_with_context method"""
+        """Test parent surname matching with resolve method"""
         person_repo, _ = mock_repositories
 
         # Pre-loaded candidate with parent surname
@@ -338,7 +338,7 @@ class TestFuzzyMatchParentSurname:
 
         person_repo.find_by_name.return_value = []
 
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             "Emma Smith", requester_cm_id=67890, session_cm_id=1000002, year=2025, candidates=[person], attendee_info={}
         )
 
@@ -398,7 +398,7 @@ class TestFuzzyMatchJaroWinklerFirstName:
     def test_jaro_winkler_first_name_charlie_charlotte(self, strategy):
         """JW catches close first-name variants not in nickname dict."""
         candidates = [Person(cm_id=100, first_name="Charlotte", last_name="Garcia")]
-        result = strategy.resolve_with_context("Charlie Garcia", requester_cm_id=999, candidates=candidates)
+        result = strategy.resolve("Charlie Garcia", requester_cm_id=999, candidates=candidates)
         assert result.is_resolved
         assert result.person.cm_id == 100
         assert result.metadata.get("match_type") == "jaro_winkler_first_name"
@@ -406,27 +406,27 @@ class TestFuzzyMatchJaroWinklerFirstName:
     def test_jaro_winkler_first_name_zoey_zoe(self, strategy):
         """Zoey/Zoe should match via JW."""
         candidates = [Person(cm_id=100, first_name="Zoe", last_name="Chen")]
-        result = strategy.resolve_with_context("Zoey Chen", requester_cm_id=999, candidates=candidates)
+        result = strategy.resolve("Zoey Chen", requester_cm_id=999, candidates=candidates)
         assert result.is_resolved
         assert result.person.cm_id == 100
 
     def test_jaro_winkler_rejects_short_dissimilar(self, strategy):
         """Short dissimilar names should not match."""
         candidates = [Person(cm_id=100, first_name="May", last_name="Garcia")]
-        result = strategy.resolve_with_context("Max Garcia", requester_cm_id=999, candidates=candidates)
+        result = strategy.resolve("Max Garcia", requester_cm_id=999, candidates=candidates)
         assert not result.is_resolved
 
     def test_jaro_winkler_checks_preferred_name(self, strategy):
         """JW should also match against preferred_name."""
         candidates = [Person(cm_id=100, first_name="Charlotte", last_name="Garcia", preferred_name="Charli")]
-        result = strategy.resolve_with_context("Charlie Garcia", requester_cm_id=999, candidates=candidates)
+        result = strategy.resolve("Charlie Garcia", requester_cm_id=999, candidates=candidates)
         assert result.is_resolved
         assert result.person.cm_id == 100
 
     def test_jaro_winkler_requires_last_name_match(self, strategy):
         """JW first name match requires last name to also match."""
         candidates = [Person(cm_id=100, first_name="Charlotte", last_name="Johnson")]
-        result = strategy.resolve_with_context("Charlie Garcia", requester_cm_id=999, candidates=candidates)
+        result = strategy.resolve("Charlie Garcia", requester_cm_id=999, candidates=candidates)
         assert not result.is_resolved
 
     def test_jaro_winkler_multiple_matches_ambiguous(self, strategy):
@@ -435,7 +435,7 @@ class TestFuzzyMatchJaroWinklerFirstName:
             Person(cm_id=100, first_name="Charlotte", last_name="Garcia"),
             Person(cm_id=200, first_name="Charlene", last_name="Garcia"),
         ]
-        result = strategy.resolve_with_context("Charlie Garcia", requester_cm_id=999, candidates=candidates)
+        result = strategy.resolve("Charlie Garcia", requester_cm_id=999, candidates=candidates)
         assert result.is_ambiguous
         assert len(result.candidates) == 2
 
@@ -467,7 +467,7 @@ class TestJaroWinklerFullPoolFallback:
             Person(cm_id=1000099, first_name="Other", last_name="Person"),
         ]
 
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             name="Olivia Jonson",
             requester_cm_id=1000001,
             session_cm_id=1000010,
@@ -487,7 +487,7 @@ class TestJaroWinklerFullPoolFallback:
         target = Person(cm_id=1000002, first_name="Olivia", last_name="Completely-Different")
         all_persons = [target]
 
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             name="Olivia Jonson",
             requester_cm_id=1000001,
             session_cm_id=1000010,
@@ -505,7 +505,7 @@ class TestJaroWinklerFullPoolFallback:
         candidate = Person(cm_id=1000002, first_name="Olivia", last_name="Johnson")
         other_person = Person(cm_id=1000003, first_name="Olivia", last_name="Jonson-Match")
 
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             name="Olivia Johnson",  # exact match on candidate
             requester_cm_id=1000001,
             year=2026,
@@ -522,7 +522,7 @@ class TestJaroWinklerFullPoolFallback:
         """Empty candidates AND empty all_persons → unresolved, no crash."""
         strategy, _, _ = strategy_with_repos
 
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             name="Olivia Jonson",
             requester_cm_id=1000001,
             year=2026,
@@ -539,7 +539,7 @@ class TestJaroWinklerFullPoolFallback:
         self_person = Person(cm_id=1000001, first_name="Olivia", last_name="Johnson")
         all_persons = [self_person]
 
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             name="Olivia Jonson",
             requester_cm_id=1000001,
             year=2026,
@@ -593,7 +593,16 @@ class TestFuzzyMatchDefaultOverrideMechanism:
         )
 
         class ConcreteBase(BaseMatchStrategy):
-            def resolve(self, name, requester_cm_id, session_cm_id=None, year=None):
+            def resolve(
+                self,
+                name,
+                requester_cm_id,
+                session_cm_id=None,
+                year=None,
+                candidates=None,
+                attendee_info=None,
+                all_persons=None,
+            ):
                 return ResolutionResult(confidence=0.0, method=self.name)
 
         mock_person_repo = Mock()

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_phonetic_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_phonetic_match.py
@@ -454,7 +454,7 @@ class TestPhoneticMatchParentSurname:
         assert result.person.cm_id == 12345
         assert result.metadata.get("match_type") == "parent_surname_phonetic"
 
-    def test_parent_surname_phonetic_with_context(self, strategy, mock_repositories):
+    def test_parent_surname_phonetic_via_resolve(self, strategy, mock_repositories):
         """Test parent surname phonetic matching with resolve"""
         person_repo, _ = mock_repositories
 

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_phonetic_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_phonetic_match.py
@@ -455,7 +455,7 @@ class TestPhoneticMatchParentSurname:
         assert result.metadata.get("match_type") == "parent_surname_phonetic"
 
     def test_parent_surname_phonetic_with_context(self, strategy, mock_repositories):
-        """Test parent surname phonetic matching with resolve_with_context"""
+        """Test parent surname phonetic matching with resolve"""
         person_repo, _ = mock_repositories
 
         # Pre-loaded candidate with parent surname
@@ -467,7 +467,7 @@ class TestPhoneticMatchParentSurname:
             parent_names=json.dumps([{"first": "John", "last": "Smith", "relationship": "Father"}]),
         )
 
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             "Emma Smidt",  # Phonetically similar to Smith
             requester_cm_id=67890,
             session_cm_id=1000002,

--- a/tests/unit/sync/bunk_request_processor/resolution/test_resolution_pipeline.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/test_resolution_pipeline.py
@@ -27,7 +27,14 @@ class MockStrategy(ResolutionStrategy):
         self._result = result
 
     def resolve(
-        self, name: str, requester_cm_id: int, session_cm_id: int | None = None, year: int | None = None
+        self,
+        name: str,
+        requester_cm_id: int,
+        session_cm_id: int | None = None,
+        year: int | None = None,
+        candidates: list[Person] | None = None,
+        attendee_info: dict[int, dict[str, Any]] | None = None,
+        all_persons: list[Person] | None = None,
     ) -> ResolutionResult:
         return self._result
 
@@ -50,8 +57,11 @@ class TestResolutionPipeline:
     def pipeline(self, mock_repositories):
         """Create a ResolutionPipeline with mocked dependencies"""
         person_repo, attendee_repo = mock_repositories
-        # Mock attendee repo to return None by default (no session found)
-        attendee_repo.get_by_person_and_year.return_value = None
+        # Mock repos for batch_resolve path
+        person_repo.get_all_for_phonetic_matching.return_value = []
+        person_repo.find_by_name.return_value = []
+        person_repo.find_by_first_name.return_value = []
+        attendee_repo.bulk_get_sessions_for_persons.return_value = {}
         return ResolutionPipeline(person_repo, attendee_repo)
 
     def test_single_strategy_success(self, pipeline):
@@ -65,7 +75,7 @@ class TestResolutionPipeline:
         pipeline.add_strategy(strategy)
 
         # Test resolution
-        final_result = pipeline.resolve("John Doe", requester_cm_id=67890, year=2025)
+        final_result = pipeline.batch_resolve([("John Doe", 67890, None, 2025)])[0]
 
         assert final_result.is_resolved
         assert final_result.person.cm_id == 12345
@@ -86,7 +96,7 @@ class TestResolutionPipeline:
         pipeline.add_strategy(MockStrategy("fuzzy", success_result))
 
         # Test resolution
-        final_result = pipeline.resolve("John Doe", requester_cm_id=67890, year=2025)
+        final_result = pipeline.batch_resolve([("John Doe", 67890, None, 2025)])[0]
 
         assert final_result.is_resolved
         assert final_result.person.cm_id == 12345
@@ -103,7 +113,7 @@ class TestResolutionPipeline:
         pipeline.add_strategy(MockStrategy("fuzzy", fail2))
 
         # Test resolution
-        final_result = pipeline.resolve("Unknown Person", requester_cm_id=67890, year=2025)
+        final_result = pipeline.batch_resolve([("Unknown Person", 67890, None, 2025)])[0]
 
         assert not final_result.is_resolved
         assert final_result.person is None
@@ -127,7 +137,7 @@ class TestResolutionPipeline:
         pipeline.add_strategy(MockStrategy("exact", ambiguous_result))
 
         # Test resolution
-        final_result = pipeline.resolve("John Smith", requester_cm_id=11111, year=2025)
+        final_result = pipeline.batch_resolve([("John Smith", 11111, None, 2025)])[0]
 
         assert not final_result.is_resolved
         assert final_result.is_ambiguous
@@ -144,7 +154,7 @@ class TestResolutionPipeline:
         pipeline.set_minimum_confidence(0.6)
 
         # Test resolution
-        final_result = pipeline.resolve("John Doe", requester_cm_id=67890, year=2025)
+        final_result = pipeline.batch_resolve([("John Doe", 67890, None, 2025)])[0]
 
         # Should not be considered resolved due to low confidence
         assert not final_result.is_resolved
@@ -164,7 +174,7 @@ class TestResolutionPipeline:
         mock_cache.get_cached_resolution.return_value = cached_result
 
         # Test resolution
-        final_result = pipeline.resolve("John Doe", requester_cm_id=67890, year=2025)
+        final_result = pipeline.batch_resolve([("John Doe", 67890, None, 2025)])[0]
 
         assert final_result.is_resolved
         assert final_result.person.cm_id == 12345
@@ -174,14 +184,12 @@ class TestResolutionPipeline:
         mock_cache.get_cached_resolution.assert_called_once()
 
     def test_session_context_passed_to_strategies(self, pipeline, mock_repositories):
-        """Test that session context is passed through to strategies"""
+        """Test that session context is derived from bulk_get_sessions_for_persons and passed to strategies"""
         _, attendee_repo = mock_repositories
 
-        # Mock getting session for requester
-        attendee_repo.get_by_person_and_year.return_value = {
-            "person_cm_id": 67890,
-            "session_cm_id": 1000002,
-            "year": 2025,
+        # Mock bulk session lookup to return session for requester
+        attendee_repo.bulk_get_sessions_for_persons.return_value = {
+            67890: 1000002,
         }
 
         # Create mock strategy that tracks calls
@@ -191,13 +199,16 @@ class TestResolutionPipeline:
 
         pipeline.add_strategy(mock_strategy)
 
-        # Test resolution
-        pipeline.resolve("John Doe", requester_cm_id=67890, year=2025)
+        # Test resolution (session_cm_id=None so pipeline derives it from pre-loaded data)
+        pipeline.batch_resolve([("John Doe", 67890, None, 2025)])
 
-        # Verify strategy was called with session context
-        mock_strategy.resolve.assert_called_once_with(
-            name="John Doe", requester_cm_id=67890, session_cm_id=1000002, year=2025
-        )
+        # Verify strategy was called once and received the derived session context
+        mock_strategy.resolve.assert_called_once()
+        call_kwargs = mock_strategy.resolve.call_args.kwargs
+        assert call_kwargs["name"] == "John Doe"
+        assert call_kwargs["requester_cm_id"] == 67890
+        assert call_kwargs["session_cm_id"] == 1000002
+        assert call_kwargs["year"] == 2025
 
     def test_strategy_ordering(self, pipeline):
         """Test that strategies are tried in order"""
@@ -225,7 +236,7 @@ class TestResolutionPipeline:
         pipeline.add_strategy(make_strategy("ai", False))  # Should not be called
 
         # Test resolution
-        result = pipeline.resolve("Test User", requester_cm_id=67890, year=2025)
+        result = pipeline.batch_resolve([("Test User", 67890, None, 2025)])[0]
 
         # Verify order and early termination
         assert call_order == ["exact", "fuzzy", "phonetic"]
@@ -285,11 +296,15 @@ class TestBatchResolveFirstNameInitialPattern:
             def name(self):
                 return "capturing"
 
-            def resolve(self, name, requester_cm_id, session_cm_id=None, year=None):
-                return ResolutionResult()
-
-            def resolve_with_context(  # type: ignore[override]
-                self, name, requester_cm_id, session_cm_id, year, candidates, attendee_info, all_persons=None
+            def resolve(
+                self,
+                name,
+                requester_cm_id,
+                session_cm_id=None,
+                year=None,
+                candidates=None,
+                attendee_info=None,
+                all_persons=None,
             ):
                 self.captured_candidates = candidates
                 # If we got exactly one candidate, return it as resolved
@@ -335,11 +350,15 @@ class TestBatchResolveFirstNameInitialPattern:
             def name(self):
                 return "capturing"
 
-            def resolve(self, name, requester_cm_id, session_cm_id=None, year=None):
-                return ResolutionResult()
-
-            def resolve_with_context(  # type: ignore[override]
-                self, name, requester_cm_id, session_cm_id, year, candidates, attendee_info, all_persons=None
+            def resolve(
+                self,
+                name,
+                requester_cm_id,
+                session_cm_id=None,
+                year=None,
+                candidates=None,
+                attendee_info=None,
+                all_persons=None,
             ):
                 self.captured_candidates = candidates
                 if candidates and len(candidates) > 1:
@@ -381,11 +400,15 @@ class TestBatchResolveFirstNameInitialPattern:
             def name(self):
                 return "capturing"
 
-            def resolve(self, name, requester_cm_id, session_cm_id=None, year=None):
-                return ResolutionResult()
-
-            def resolve_with_context(  # type: ignore[override]
-                self, name, requester_cm_id, session_cm_id, year, candidates, attendee_info, all_persons=None
+            def resolve(
+                self,
+                name,
+                requester_cm_id,
+                session_cm_id=None,
+                year=None,
+                candidates=None,
+                attendee_info=None,
+                all_persons=None,
             ):
                 self.captured_candidates = candidates
                 if candidates and len(candidates) == 1:
@@ -465,11 +488,15 @@ class TestBatchResolveAttendeeInfoFormat:
             def name(self):
                 return "capturing"
 
-            def resolve(self, name, requester_cm_id, session_cm_id=None, year=None):
-                return ResolutionResult()
-
-            def resolve_with_context(  # type: ignore[override]
-                self, name, requester_cm_id, session_cm_id, year, candidates, attendee_info, all_persons=None
+            def resolve(
+                self,
+                name,
+                requester_cm_id,
+                session_cm_id=None,
+                year=None,
+                candidates=None,
+                attendee_info=None,
+                all_persons=None,
             ):
                 self.captured_attendee_info = attendee_info
                 if candidates:
@@ -526,11 +553,15 @@ class TestBatchResolveAttendeeInfoFormat:
             def name(self):
                 return "capturing"
 
-            def resolve(self, name, requester_cm_id, session_cm_id=None, year=None):
-                return ResolutionResult()
-
-            def resolve_with_context(  # type: ignore[override]
-                self, name, requester_cm_id, session_cm_id, year, candidates, attendee_info, all_persons=None
+            def resolve(
+                self,
+                name,
+                requester_cm_id,
+                session_cm_id=None,
+                year=None,
+                candidates=None,
+                attendee_info=None,
+                all_persons=None,
             ):
                 self.captured_attendee_info = attendee_info
                 return ResolutionResult(
@@ -594,11 +625,15 @@ class TestBatchResolveAttendeeInfoFormat:
             def name(self):
                 return "session_disambiguator"
 
-            def resolve(self, name, requester_cm_id, session_cm_id=None, year=None):
-                return ResolutionResult()
-
-            def resolve_with_context(  # type: ignore[override]
-                self, name, requester_cm_id, session_cm_id, year, candidates, attendee_info, all_persons=None
+            def resolve(
+                self,
+                name,
+                requester_cm_id,
+                session_cm_id=None,
+                year=None,
+                candidates=None,
+                attendee_info=None,
+                all_persons=None,
             ):
                 if not candidates or len(candidates) <= 1:
                     return ResolutionResult(
@@ -695,11 +730,6 @@ class TestBatchResolvePreloadedPersonSessions:
                 return "capturing"
 
             def resolve(
-                self, name: str, requester_cm_id: int, session_cm_id: int | None = None, year: int | None = None
-            ) -> ResolutionResult:
-                return ResolutionResult()
-
-            def resolve_with_context(
                 self,
                 name: str,
                 requester_cm_id: int,
@@ -754,11 +784,6 @@ class TestBatchResolvePreloadedPersonSessions:
                 return "capturing"
 
             def resolve(
-                self, name: str, requester_cm_id: int, session_cm_id: int | None = None, year: int | None = None
-            ) -> ResolutionResult:
-                return ResolutionResult()
-
-            def resolve_with_context(
                 self,
                 name: str,
                 requester_cm_id: int,
@@ -805,11 +830,6 @@ class TestBatchResolvePreloadedPersonSessions:
                 return "capturing"
 
             def resolve(
-                self, name: str, requester_cm_id: int, session_cm_id: int | None = None, year: int | None = None
-            ) -> ResolutionResult:
-                return ResolutionResult()
-
-            def resolve_with_context(
                 self,
                 name: str,
                 requester_cm_id: int,
@@ -863,11 +883,6 @@ class TestBatchResolvePreloadedPersonSessions:
                 return "capturing"
 
             def resolve(
-                self, name: str, requester_cm_id: int, session_cm_id: int | None = None, year: int | None = None
-            ) -> ResolutionResult:
-                return ResolutionResult()
-
-            def resolve_with_context(
                 self,
                 name: str,
                 requester_cm_id: int,

--- a/tests/unit/sync/bunk_request_processor/resolution/test_single_name_batch_resolution.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/test_single_name_batch_resolution.py
@@ -29,7 +29,7 @@ from bunking.sync.bunk_request_processor.resolution.strategies.school_disambigua
 
 
 class TestSingleNameBatchResolution:
-    """Test that resolve_with_context falls back to resolve() when candidates is empty list."""
+    """Test that resolve falls back to resolve() when candidates is empty list."""
 
     @pytest.fixture
     def mock_repositories(self):
@@ -47,11 +47,11 @@ class TestSingleNameBatchResolution:
         return mock_person_repo, mock_attendee_repo
 
     def test_fuzzy_match_falls_back_with_empty_candidates(self, mock_repositories):
-        """FuzzyMatchStrategy.resolve_with_context should fall back to resolve()
+        """FuzzyMatchStrategy.resolve should fall back to resolve()
         when candidates is an empty list [], not just when None.
 
         This is the bug case: batch_resolve gives [] for single names,
-        but resolve_with_context checks `if candidates is None:` which is False for [].
+        but resolve checks `if candidates is None:` which is False for [].
         """
         person_repo, attendee_repo = mock_repositories
 
@@ -83,9 +83,9 @@ class TestSingleNameBatchResolution:
 
         strategy = FuzzyMatchStrategy(person_repo, attendee_repo)
 
-        # Call resolve_with_context with empty candidates list []
+        # Call resolve with empty candidates list []
         # This simulates what happens when batch_resolve() is called with single name "Mike"
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             name="Mike",  # Single name
             requester_cm_id=67890,
             session_cm_id=1000002,
@@ -97,12 +97,12 @@ class TestSingleNameBatchResolution:
         # Should fall back to resolve() and find Michael via nickname
         # BUG: Currently returns confidence 0.0 because it doesn't fall back
         assert result.is_resolved or result.is_ambiguous, (
-            "resolve_with_context should fall back to resolve() when candidates=[] "
+            "resolve should fall back to resolve() when candidates=[] "
             "and attempt to resolve via nickname/fuzzy matching"
         )
 
     def test_phonetic_match_falls_back_with_empty_candidates(self, mock_repositories):
-        """PhoneticMatchStrategy.resolve_with_context uses all_persons fallback
+        """PhoneticMatchStrategy.resolve uses all_persons fallback
         when candidates is an empty list [].
 
         Note: Implementation now uses all_persons parameter instead of calling resolve().
@@ -117,9 +117,9 @@ class TestSingleNameBatchResolution:
 
         strategy = PhoneticMatchStrategy(person_repo, attendee_repo)
 
-        # Call resolve_with_context with empty candidates list []
+        # Call resolve with empty candidates list []
         # Pass all_persons as the fallback pool (replaces resolve() fallback)
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             name="John Smyth",  # Phonetically similar to Smith
             requester_cm_id=67890,
             session_cm_id=1000002,
@@ -131,11 +131,11 @@ class TestSingleNameBatchResolution:
 
         # Should use all_persons fallback and find Smith via phonetic matching
         assert result.is_resolved or result.is_ambiguous, (
-            "resolve_with_context should use all_persons fallback when candidates=[] and attempt phonetic matching"
+            "resolve should use all_persons fallback when candidates=[] and attempt phonetic matching"
         )
 
     def test_school_disambiguation_falls_back_with_empty_candidates(self, mock_repositories):
-        """SchoolDisambiguationStrategy.resolve_with_context uses all_persons fallback
+        """SchoolDisambiguationStrategy.resolve uses all_persons fallback
         when candidates is an empty list [].
 
         Note: Implementation now uses all_persons parameter instead of calling resolve().
@@ -166,9 +166,9 @@ class TestSingleNameBatchResolution:
 
         strategy = SchoolDisambiguationStrategy(person_repo, attendee_repo)
 
-        # Call resolve_with_context with empty candidates list []
+        # Call resolve with empty candidates list []
         # Pass all_persons as the fallback pool (replaces resolve() fallback)
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             name="John Smith",
             requester_cm_id=11111,
             session_cm_id=1000002,
@@ -181,7 +181,7 @@ class TestSingleNameBatchResolution:
         # Should use all_persons fallback and try school disambiguation
         # Note: Resolution may find john1 (same school) or be ambiguous
         assert result.is_resolved or result.is_ambiguous, (
-            "resolve_with_context should use all_persons fallback when candidates=[] and attempt school disambiguation"
+            "resolve should use all_persons fallback when candidates=[] and attempt school disambiguation"
         )
 
 

--- a/tests/unit/sync/bunk_request_processor/test_school_disambiguation_city_state.py
+++ b/tests/unit/sync/bunk_request_processor/test_school_disambiguation_city_state.py
@@ -10,7 +10,7 @@ GAP being tested:
 
 Architecture context:
   - batch_resolve() pre-loads Person objects via find_by_name()
-  - These candidates are passed to strategies via resolve_with_context()
+  - These candidates are passed to strategies via resolve()
   - Person objects will have city/state when loaded from DB
   - City/state matching enables MORE local resolution, reducing AI calls
 
@@ -87,10 +87,10 @@ class TestSchoolDisambiguationWithLocation:
     share the same name but are in different locations.
     """
 
-    def test_resolve_with_context_uses_location_from_candidates(self):
+    def test_resolve_uses_location_from_candidates(self):
         """When candidates have city/state, use them for disambiguation.
 
-        This tests the resolve_with_context path which receives pre-loaded
+        This tests the resolve path which receives pre-loaded
         Person objects from batch_resolve(). The candidates should include
         city/state from the DB, enabling location-based filtering.
         """
@@ -134,8 +134,8 @@ class TestSchoolDisambiguationWithLocation:
 
         strategy = SchoolDisambiguationStrategy(person_repo, attendee_repo)
 
-        # Use resolve_with_context (the batch path) with pre-loaded candidates
-        result = strategy.resolve_with_context(
+        # Use resolve (the batch path) with pre-loaded candidates
+        result = strategy.resolve(
             name="Emma Wilson",
             requester_cm_id=100,
             session_cm_id=12345,
@@ -191,7 +191,7 @@ class TestSchoolDisambiguationWithLocation:
 
         strategy = SchoolDisambiguationStrategy(person_repo, attendee_repo)
 
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             name="Mike Johnson",
             requester_cm_id=100,
             session_cm_id=12345,
@@ -249,7 +249,7 @@ class TestSchoolDisambiguationWithLocation:
 
         strategy = SchoolDisambiguationStrategy(person_repo, attendee_repo)
 
-        result = strategy.resolve_with_context(
+        result = strategy.resolve(
             name="Emma Wilson",
             requester_cm_id=100,
             session_cm_id=12345,


### PR DESCRIPTION
## Summary

Final consolidation PR for Group 61. Eliminates the dual `resolve()` / `resolve_with_context()` API surface across resolution strategies. End state: ONE method per strategy, ONE abstract declaration, ONE pipeline entry point.

## Backstory (verified via git history)

The dual API was over-design from day one (initial commit). `pipeline.resolve()` had **ZERO production callers in any commit** — only test infrastructure used it. `pipeline.batch_resolve()` is the actual production path; it always called `resolve_with_context()` via a `hasattr` check, with a fallback to `resolve()` that never fired (all 4 subclasses implemented `resolve_with_context`).

PRs A/B1/B2/B3 collapsed each strategy's internal twin helpers but left the top-level dual API in place as a temporary measure (couldn't delete `strategy.resolve()` while `pipeline.resolve()` was still calling it for every strategy). This PR removes the whole vestigial API.

## What dies

- **`pipeline.resolve()` method (~65 LOC)** — never had a production caller
- **`batch_resolve()` hasattr branch + fallback (~15 LOC)** — folded into a single direct call
- **4 strategy `resolve()` shims** — the 1-line delegation methods added in PRs B1/B2/B3
- **`BaseMatchStrategy.resolve()` placeholder** — `pass`-only abstract override
- **`BaseMatchStrategy._disambiguate_with_session_context`** — dead since the PR-B series gave each strategy its own `_disambiguate_with_session`
- **Interface's `resolve_with_context()` default fallback** — never fired
- **Interface's old 4-arg abstract `resolve()`** — replaced

## What's renamed

`resolve_with_context()` → `resolve()` in all 4 strategies AND on the abstract interface. The new `resolve()` carries the full optional-pre-loaded signature: `(name, requester_cm_id, session_cm_id=None, year=None, candidates=None, attendee_info=None, all_persons=None)`.

Existing test calls `.resolve(name, cm_id, session, year)` keep working — same first 4 positional args.

## Test updates

- 5 strategy test files: mechanical `s/resolve_with_context/resolve/` (signature-compatible)
- `test_resolution_pipeline.py`: rewrote 8 `pipeline.resolve(...)` sites as `pipeline.batch_resolve([(...)])[0]`; deleted 10 obsolete mock-class shims; updated 6 mock `resolve()` signatures to match the new abstract
- `test_base_match_strategy.py`: deleted 5 tests of the now-deleted `_disambiguate_with_session_context` private method

## End state

- ONE `resolve()` per strategy with the full signature
- ONE `batch_resolve()` on the pipeline (production entry point)
- ONE abstract `resolve()` on the interface
- ONE clear contract: pass pre-loaded data for fast path, omit for DB fallback

The dual API is gone for good. Matches the architecture the codebase should have had from day one.

## LOC delta

14 files changed, +119 / -457 LOC (-338 net).

## Test plan

- [x] `pytest tests/.../resolution/` — passes (count drops by 5 because 5 tests of the deleted dead method were removed)
- [x] `pytest tests/unit/sync/bunk_request_processor/` — passes (likewise minus 5)
- [x] `ruff format` + `ruff check` + `mypy` clean (mypy validated on production + key test files)
- [x] Verified: 0 matches for `resolve_with_context` anywhere; pipeline.resolve no longer exists

## Context

Closes the architectural consolidation in Group 61 (Resolution strategy hygiene round). Sibling PRs that landed: #1488 (PR-A), #1491 (PR-B1), #1493 (PR-B2), #1494 (PR-B3). One more PR follows: PR-D (`match_type` → `sub_method` metadata rename, the original #1479 reframed).

Part of #1478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated name-resolution into a single, unified entrypoint and aligned all strategies to a batch-oriented resolution flow.
  * Replaced single-name orchestration with optimized batch processing that uses preloaded context for more consistent resolution behavior.
* **Tests**
  * Updated unit tests to exercise the new batch-based resolution calling convention.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1497?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->