### PR TITLE
refactor(sync): rename metadata["match_type"] to metadata["sub_method"] in resolution strategies (closes #1479)

### DIFF
--- a/bunking/sync/bunk_request_processor/data/repositories/request_repository.py
+++ b/bunking/sync/bunk_request_processor/data/repositories/request_repository.py
@@ -310,7 +310,11 @@ class RequestRepository:
             cleaned = {
                 k: v
                 for k, v in request.metadata.items()
-                if k not in ("disposition_reason", "disposition_rule_id", "resolution_method", "match_type")
+                # disposition_reason and resolution_method are promoted to top-level columns above.
+                # match_type is intentionally stripped as defensive cleanup for legacy DB rows from
+                # pre-PR-D writes; new writes use sub_method which stays in metadata. Can be removed
+                # in a future PR once a re-sync confirms no legacy rows still have it.
+                if k not in ("disposition_reason", "resolution_method", "match_type")
             }
             data["metadata"] = json.dumps(cleaned)
 

--- a/bunking/sync/bunk_request_processor/data/repositories/request_repository.py
+++ b/bunking/sync/bunk_request_processor/data/repositories/request_repository.py
@@ -312,8 +312,10 @@ class RequestRepository:
                 for k, v in request.metadata.items()
                 # disposition_reason and resolution_method are promoted to top-level columns above.
                 # match_type is intentionally stripped as defensive cleanup for legacy DB rows from
-                # pre-PR-D writes; new writes use sub_method which stays in metadata. Can be removed
-                # in a future PR once a re-sync confirms no legacy rows still have it.
+                # pre-PR-D writes; can be removed in a future PR once a re-sync confirms no legacy
+                # rows still have it. sub_method is intentionally NOT stripped: it is a diagnostic
+                # field retained in metadata (unlike disposition_reason/resolution_method which are
+                # promoted to columns), so it must pass through.
                 if k not in ("disposition_reason", "resolution_method", "match_type")
             }
             data["metadata"] = json.dumps(cleaned)

--- a/bunking/sync/bunk_request_processor/resolution/resolution_pipeline.py
+++ b/bunking/sync/bunk_request_processor/resolution/resolution_pipeline.py
@@ -248,11 +248,10 @@ class ResolutionPipeline:
                     )
                     all_results.append((strategy.name, result))
 
-                    # Derive sub_method from strategy metadata. Strategies already record
-                    # match_type for resolved paths and ambiguity_reason for ambiguous paths;
-                    # an explicit sub_method (set by some paths) wins over both.
+                    # Derive sub_method from strategy metadata. Strategies set sub_method
+                    # for resolved paths and ambiguity_reason for ambiguous paths.
                     meta = result.metadata or {}
-                    sub_method = meta.get("sub_method") or meta.get("match_type") or meta.get("ambiguity_reason")
+                    sub_method = meta.get("sub_method") or meta.get("ambiguity_reason")
                     strategy_attempts.append(
                         {
                             "strategy": strategy.name,

--- a/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
@@ -112,7 +112,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
                             person=matches[0],
                             confidence=0.95,
                             method=self.name,
-                            metadata={"match_type": "unique", "session_match": "exact"},
+                            metadata={"sub_method": "unique", "session_match": "exact"},
                         )
                     elif match_session is not None:
                         # Target enrolled in a different bunking session
@@ -120,7 +120,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
                             person=matches[0],
                             confidence=0.85,  # Lower confidence for different session
                             method=self.name,
-                            metadata={"match_type": "unique", "session_match": "different"},
+                            metadata={"sub_method": "unique", "session_match": "different"},
                         )
                     else:
                         # No session data for target in enrolled-only map.
@@ -130,7 +130,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
                             person=matches[0],
                             confidence=0.90,
                             method=self.name,
-                            metadata={"match_type": "unique", "session_match": "unknown"},
+                            metadata={"sub_method": "unique", "session_match": "unknown"},
                         )
                 else:
                     # No session context available
@@ -138,7 +138,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
                         person=matches[0],
                         confidence=0.90,  # Lower confidence without session verification
                         method=self.name,
-                        metadata={"match_type": "unique", "no_session_info": True},
+                        metadata={"sub_method": "unique", "no_session_info": True},
                     )
             elif year:
                 # No attendee_info: DB fallback for session lookup
@@ -157,28 +157,28 @@ class ExactMatchStrategy(BaseMatchStrategy):
                             person=matches[0],
                             confidence=0.95,
                             method=self.name,
-                            metadata={"match_type": "unique", "session_match": "exact"},
+                            metadata={"sub_method": "unique", "session_match": "exact"},
                         )
                     elif match_session is not None:
                         return ResolutionResult(
                             person=matches[0],
                             confidence=0.85,
                             method=self.name,
-                            metadata={"match_type": "unique", "session_match": "different"},
+                            metadata={"sub_method": "unique", "session_match": "different"},
                         )
                     else:
                         return ResolutionResult(
                             person=matches[0],
                             confidence=0.90,
                             method=self.name,
-                            metadata={"match_type": "unique", "session_match": "unknown"},
+                            metadata={"sub_method": "unique", "session_match": "unknown"},
                         )
                 else:
                     return ResolutionResult(
                         person=matches[0],
                         confidence=0.90,
                         method=self.name,
-                        metadata={"match_type": "unique", "no_session_info": True},
+                        metadata={"sub_method": "unique", "no_session_info": True},
                     )
             else:
                 # No year context
@@ -186,7 +186,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
                     person=matches[0],
                     confidence=0.90,  # Lower confidence without year context
                     method=self.name,
-                    metadata={"match_type": "unique"},
+                    metadata={"sub_method": "unique"},
                 )
 
         # Multiple matches - try to disambiguate with session
@@ -243,7 +243,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
                     person=same_session_matches[0],
                     confidence=0.95,
                     method=self.name,
-                    metadata={"match_type": "unique_same_session", "session_match": "exact"},
+                    metadata={"sub_method": "unique_same_session", "session_match": "exact"},
                 )
             elif len(same_session_matches) > 1:
                 return ResolutionResult(
@@ -267,7 +267,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
                         metadata={
                             "impossible": True,
                             "impossible_reason": "target_in_different_session",
-                            "match_type": "exact_different_session",
+                            "sub_method": "exact_different_session",
                             "target_session": target_session,
                             "requester_session": session_cm_id,
                         },
@@ -308,7 +308,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
                     person=same_session_matches[0],
                     confidence=0.95,
                     method=self.name,
-                    metadata={"match_type": "unique_same_session", "session_match": "exact"},
+                    metadata={"sub_method": "unique_same_session", "session_match": "exact"},
                 )
             elif len(same_session_matches) > 1:
                 return ResolutionResult(
@@ -331,7 +331,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
                         metadata={
                             "impossible": True,
                             "impossible_reason": "target_in_different_session",
-                            "match_type": "exact_different_session",
+                            "sub_method": "exact_different_session",
                             "target_session": sessions_map.get(matches[0].cm_id),
                             "requester_session": session_cm_id,
                         },
@@ -398,7 +398,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
                     confidence=confidence,
                     method=self.name,
                     metadata={
-                        "match_type": "parent_surname",
+                        "sub_method": "parent_surname",
                         "parent_last_name": last_name,
                         "camper_last_name": matches[0].last_name,
                     },
@@ -411,7 +411,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
                 metadata={
                     "ambiguity_reason": "multiple_parent_surname_matches",
                     "match_count": len(matches),
-                    "match_type": "parent_surname",
+                    "sub_method": "parent_surname",
                 },
             )
 
@@ -439,7 +439,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
                 confidence=confidence,
                 method=self.name,
                 metadata={
-                    "match_type": "parent_surname",
+                    "sub_method": "parent_surname",
                     "parent_last_name": last_name,
                     "camper_last_name": matches[0].last_name,
                 },
@@ -452,7 +452,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
             metadata={
                 "ambiguity_reason": "multiple_parent_surname_matches",
                 "match_count": len(matches),
-                "match_type": "parent_surname",
+                "sub_method": "parent_surname",
             },
         )
 
@@ -494,7 +494,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
                 confidence=0.90,
                 method=self.name,
                 metadata={
-                    "match_type": "parent_surname",
+                    "sub_method": "parent_surname",
                     "parent_last_name": last_name,
                     "camper_last_name": matches[0].last_name,
                 },
@@ -507,6 +507,6 @@ class ExactMatchStrategy(BaseMatchStrategy):
             metadata={
                 "ambiguity_reason": "multiple_parent_surname_matches",
                 "match_count": len(matches),
-                "match_type": "parent_surname",
+                "sub_method": "parent_surname",
             },
         )

--- a/bunking/sync/bunk_request_processor/resolution/strategies/fuzzy_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/fuzzy_match.py
@@ -163,7 +163,7 @@ class FuzzyMatchStrategy(BaseMatchStrategy):
                         person=matches[0],
                         confidence=confidence,
                         method=self.name,
-                        metadata={"match_type": "nickname", "variant": variant},
+                        metadata={"sub_method": "nickname", "variant": variant},
                     )
                 else:
                     return ResolutionResult(
@@ -218,7 +218,6 @@ class FuzzyMatchStrategy(BaseMatchStrategy):
                     method=self.name,
                     metadata={
                         "ambiguity_reason": "first_name_only_distant_match",
-                        "match_type": base_match_type,
                         "sub_method": base_match_type,
                     },
                 )
@@ -318,7 +317,7 @@ class FuzzyMatchStrategy(BaseMatchStrategy):
                 person=matches[0],
                 confidence=confidence,
                 method=self.name,
-                metadata={"match_type": match_type, "sub_method": match_type},
+                metadata={"sub_method": match_type},
             )
         else:
             # Try session disambiguation
@@ -392,7 +391,7 @@ class FuzzyMatchStrategy(BaseMatchStrategy):
                 person=all_candidates[0],
                 confidence=confidence,
                 method=self.name,
-                metadata={"match_type": "first_name_only"},
+                metadata={"sub_method": "first_name_only"},
             )
 
         # Try session disambiguation
@@ -457,7 +456,7 @@ class FuzzyMatchStrategy(BaseMatchStrategy):
                 person=all_matches[0],
                 confidence=confidence,
                 method=self.name,
-                metadata={"match_type": "parent_surname", "inferred_surname": last_name},
+                metadata={"sub_method": "parent_surname", "inferred_surname": last_name},
             )
         else:
             return ResolutionResult(
@@ -527,7 +526,7 @@ class FuzzyMatchStrategy(BaseMatchStrategy):
                 person=same_session[0],
                 confidence=confidence,
                 method=self.name,
-                metadata={"match_type": "session_disambiguated"},
+                metadata={"sub_method": "session_disambiguated"},
             )
 
         return ResolutionResult(confidence=0.0, method=self.name)
@@ -587,7 +586,7 @@ class FuzzyMatchStrategy(BaseMatchStrategy):
                 person=matches[0],
                 confidence=confidence,
                 method=self.name,
-                metadata={"match_type": match_type},
+                metadata={"sub_method": match_type},
             )
 
         return ResolutionResult(
@@ -597,7 +596,7 @@ class FuzzyMatchStrategy(BaseMatchStrategy):
             metadata={
                 "ambiguity_reason": "multiple_jaro_winkler_matches",
                 "match_count": len(matches),
-                "match_type": match_type,
+                "sub_method": match_type,
             },
         )
 
@@ -682,7 +681,7 @@ class FuzzyMatchStrategy(BaseMatchStrategy):
                 confidence=0.70 + best_score,  # Base 0.70 + relationship boost
                 method=self.name,
                 metadata={
-                    "match_type": "relationship_disambiguated",
+                    "sub_method": "relationship_disambiguated",
                     "relationship_boost": best_score,
                     "relationship_info": relationship_info,
                 },

--- a/bunking/sync/bunk_request_processor/resolution/strategies/phonetic_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/phonetic_match.py
@@ -100,7 +100,7 @@ class PhoneticMatchStrategy(BaseMatchStrategy):
                 person=matches[0],
                 confidence=confidence,
                 method=self.name,
-                metadata={"match_type": "soundex", "algorithm": "soundex"},
+                metadata={"sub_method": "soundex", "algorithm": "soundex"},
             )
 
         # Multiple matches - try to disambiguate with session
@@ -108,7 +108,7 @@ class PhoneticMatchStrategy(BaseMatchStrategy):
             result = self._disambiguate_with_session(matches, requester_cm_id, session_cm_id, year, attendee_info)
             if result.is_resolved:
                 if result.metadata is not None:
-                    result.metadata["match_type"] = "soundex_with_session"
+                    result.metadata["sub_method"] = "soundex_with_session"
                     result.metadata["algorithm"] = "soundex"
                 return result
 
@@ -169,7 +169,7 @@ class PhoneticMatchStrategy(BaseMatchStrategy):
                 person=matches[0],
                 confidence=confidence,
                 method=self.name,
-                metadata={"match_type": "metaphone", "algorithm": "metaphone"},
+                metadata={"sub_method": "metaphone", "algorithm": "metaphone"},
             )
 
         # Multiple matches - try to disambiguate
@@ -177,7 +177,7 @@ class PhoneticMatchStrategy(BaseMatchStrategy):
             result = self._disambiguate_with_session(matches, requester_cm_id, session_cm_id, year, attendee_info)
             if result.is_resolved:
                 if result.metadata is not None:
-                    result.metadata["match_type"] = "metaphone_with_session"
+                    result.metadata["sub_method"] = "metaphone_with_session"
                     result.metadata["algorithm"] = "metaphone"
                 return result
 
@@ -251,7 +251,7 @@ class PhoneticMatchStrategy(BaseMatchStrategy):
                 person=matches[0],
                 confidence=confidence,
                 method=self.name,
-                metadata={"match_type": "nickname", "algorithm": "nickname"},
+                metadata={"sub_method": "nickname", "algorithm": "nickname"},
             )
 
         # Multiple matches - try to disambiguate with session
@@ -259,7 +259,7 @@ class PhoneticMatchStrategy(BaseMatchStrategy):
             result = self._disambiguate_with_session(matches, requester_cm_id, session_cm_id, year, attendee_info)
             if result.is_resolved:
                 if result.metadata is not None:
-                    result.metadata["match_type"] = "nickname_with_session"
+                    result.metadata["sub_method"] = "nickname_with_session"
                     result.metadata["algorithm"] = "nickname"
                 return result
 
@@ -342,7 +342,7 @@ class PhoneticMatchStrategy(BaseMatchStrategy):
                 confidence=confidence,
                 method=self.name,
                 metadata={
-                    "match_type": "parent_surname_phonetic",
+                    "sub_method": "parent_surname_phonetic",
                     "algorithm": "soundex+metaphone",
                     "search_surname": last_name,
                 },
@@ -353,7 +353,7 @@ class PhoneticMatchStrategy(BaseMatchStrategy):
             result = self._disambiguate_with_session(matches, requester_cm_id, session_cm_id, year, attendee_info)
             if result.is_resolved:
                 if result.metadata is not None:
-                    result.metadata["match_type"] = "parent_surname_phonetic"
+                    result.metadata["sub_method"] = "parent_surname_phonetic"
                     result.metadata["algorithm"] = "soundex+metaphone"
                 result.confidence = min(result.confidence - 0.05, 0.80)
                 return result

--- a/bunking/sync/bunk_request_processor/resolution/strategies/school_disambiguation.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/school_disambiguation.py
@@ -214,7 +214,7 @@ class SchoolDisambiguationStrategy(ResolutionStrategy):
                 confidence=confidence,
                 method=self.name,
                 metadata={
-                    "match_type": "same_school_same_grade",
+                    "sub_method": "same_school_same_grade",
                     "school": requester_school,
                     "grade": requester_grade,
                 },
@@ -233,7 +233,7 @@ class SchoolDisambiguationStrategy(ResolutionStrategy):
                 confidence=0.70,  # Lower confidence for adjacent grade
                 method=self.name,
                 metadata={
-                    "match_type": "same_school_close_grade",
+                    "sub_method": "same_school_close_grade",
                     "school": requester_school,
                     "grade_diff": abs(close_grade_candidates[0].grade - requester_grade),
                 },
@@ -260,7 +260,7 @@ class SchoolDisambiguationStrategy(ResolutionStrategy):
                     confidence=0.65,  # Lower confidence for grade proximity
                     method=self.name,
                     metadata={
-                        "match_type": "same_school_closest_grade",
+                        "sub_method": "same_school_closest_grade",
                         "school": requester_school,
                         "grade_diff": grade_diff,
                     },
@@ -299,7 +299,7 @@ class SchoolDisambiguationStrategy(ResolutionStrategy):
                     person=db_candidates[0],
                     confidence=0.90,
                     method=self.name,
-                    metadata={"match_type": "single_exact_match"},
+                    metadata={"sub_method": "single_exact_match"},
                 )
             # Continue with DB-loaded candidates as the pool
             school_pool = db_candidates
@@ -326,7 +326,7 @@ class SchoolDisambiguationStrategy(ResolutionStrategy):
                 person=matching_candidates[0],
                 confidence=0.90,  # High confidence for exact match
                 method=self.name,
-                metadata={"match_type": "single_exact_match"},
+                metadata={"sub_method": "single_exact_match"},
             )
 
         # Multiple candidates - try school disambiguation
@@ -403,7 +403,7 @@ class SchoolDisambiguationStrategy(ResolutionStrategy):
                 confidence=0.75,  # Good confidence for school match
                 method=self.name,
                 metadata={
-                    "match_type": "same_school",
+                    "sub_method": "same_school",
                     "match_count": len(same_school_candidates),
                     "school": requester_school,
                 },

--- a/tests/unit/sync/bunk_request_processor/data/test_request_repository.py
+++ b/tests/unit/sync/bunk_request_processor/data/test_request_repository.py
@@ -760,7 +760,6 @@ class TestMapToDbDispositionFields:
                 "resolution_method": "should_be_removed",
                 "match_type": "should_be_removed",
                 "disposition_reason": "should_be_removed",
-                "disposition_rule_id": 5,
                 "other_field": "keep_me",
             },
             resolution_method="fuzzy_match",
@@ -777,7 +776,6 @@ class TestMapToDbDispositionFields:
         assert "resolution_method" not in meta
         assert "match_type" not in meta
         assert "disposition_reason" not in meta
-        assert "disposition_rule_id" not in meta
         assert meta["other_field"] == "keep_me"
 
 

--- a/tests/unit/sync/bunk_request_processor/debug/test_full_pipeline_tracing.py
+++ b/tests/unit/sync/bunk_request_processor/debug/test_full_pipeline_tracing.py
@@ -228,7 +228,7 @@ class TestFullPipelineTracing:
             person=mock_person,
             confidence=0.85,
             method="fuzzy_match",
-            metadata={"pipeline_strategies_tried": attempts, "match_type": "first_name_merged"},
+            metadata={"pipeline_strategies_tried": attempts, "sub_method": "first_name_merged"},
         )
 
         # Re-arm phase2_service / historical_verification_service to return the

--- a/tests/unit/sync/bunk_request_processor/debug/test_pipeline_strategies_tried.py
+++ b/tests/unit/sync/bunk_request_processor/debug/test_pipeline_strategies_tried.py
@@ -1,6 +1,6 @@
 """Component 4: batch_resolve populates pipeline_strategies_tried on the winning
-ResolutionResult's metadata, with sub_method derived from each strategy's
-existing match_type / ambiguity_reason metadata.
+ResolutionResult's metadata, with sub_method taken from each strategy's
+sub_method / ambiguity_reason metadata.
 
 Downstream debug_pipeline_traces.phase2_resolution[*].pipeline_strategies_tried
 (field already declared in trace_models.Phase2FinalResult) is populated from
@@ -80,15 +80,14 @@ def test_batch_resolve_records_pipeline_strategies_tried(fuzzy_only_pipeline):
         assert key in entry, f"missing key {key!r} in strategy entry {entry!r}"
 
 
-def test_pipeline_strategies_tried_records_sub_method_from_match_type(fuzzy_only_pipeline):
-    """sub_method is derived from the strategy's existing match_type metadata."""
+def test_pipeline_strategies_tried_records_sub_method(fuzzy_only_pipeline):
+    """sub_method is taken directly from the strategy's sub_method metadata."""
     results = fuzzy_only_pipeline.batch_resolve([("Katherine", 999, 1000001, 2026)])
     result = results[0]
 
     strategies = result.metadata.get("pipeline_strategies_tried", [])
-    # Fuzzy merge fallback sets match_type='first_name_merged' (Task 3) → also sets
-    # sub_method='first_name_merged' explicitly. Session-disambiguation single match
-    # sets match_type='session_disambiguated' → sub_method should reflect one of these.
+    # Fuzzy merge fallback sets sub_method='first_name_merged'. Session-disambiguation
+    # single match sets sub_method='session_disambiguated'. Either is valid here.
     fuzzy_entry = next((s for s in strategies if s["strategy"] == "fuzzy_match"), None)
     assert fuzzy_entry is not None
     assert fuzzy_entry["sub_method"] in {

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
@@ -300,7 +300,7 @@ class TestExactMatchParentSurname:
         assert result.person.last_name == "Johnson"
         # Slightly lower confidence for parent surname match
         assert result.confidence <= 0.90
-        assert result.metadata.get("match_type") == "parent_surname"
+        assert result.metadata.get("sub_method") == "parent_surname"
 
     def test_parent_surname_match_lower_confidence_than_direct(self, strategy, mock_repositories):
         """Test that parent surname matches have lower confidence than direct matches"""
@@ -364,7 +364,7 @@ class TestExactMatchParentSurname:
 
         assert result.is_resolved
         assert result.person.cm_id == 12345
-        assert result.metadata.get("match_type") == "parent_surname"
+        assert result.metadata.get("sub_method") == "parent_surname"
 
 
 class TestExactMatchPreferredName:

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_fuzzy_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_fuzzy_match.py
@@ -67,7 +67,7 @@ class TestFuzzyMatchStrategy:
         assert result.person.cm_id == 12345
         assert result.confidence == pytest.approx(0.80)  # 0.85 base - 0.05 for no session info
         assert result.method == "fuzzy_match"
-        assert result.metadata["match_type"] == "nickname"
+        assert result.metadata["sub_method"] == "nickname"
 
     def test_spelling_variation(self, strategy, mock_repositories):
         """Test matching common spelling variations"""
@@ -88,7 +88,7 @@ class TestFuzzyMatchStrategy:
         assert result.is_resolved
         assert result.person.cm_id == 12345
         assert result.confidence == pytest.approx(0.80)  # 0.85 base - 0.05 for no session info
-        assert result.metadata["match_type"] == "nickname"  # Sara/Sarah is in nickname groups
+        assert result.metadata["sub_method"] == "nickname"  # Sara/Sarah is in nickname groups
 
     def test_single_name_fuzzy(self, strategy, mock_repositories):
         """Single-name nickname-table inference (Mike → Michael) goes PENDING via #1394 gate.
@@ -191,7 +191,7 @@ class TestFuzzyMatchStrategy:
         assert result.is_resolved
         assert result.person.cm_id == 12345
         assert result.confidence == 0.75  # Normalized match without session info
-        assert result.metadata["match_type"] == "preferred_name"
+        assert result.metadata["sub_method"] == "preferred_name"
 
     def test_case_and_punctuation_normalization(self, strategy, mock_repositories):
         """Test normalization of case and punctuation"""
@@ -293,7 +293,7 @@ class TestFuzzyMatchParentSurname:
         assert result.person.cm_id == 12345
         assert result.person.last_name == "Johnson"
         assert result.confidence <= 0.90  # Slightly lower for parent surname match
-        assert result.metadata.get("match_type") == "parent_surname"
+        assert result.metadata.get("sub_method") == "parent_surname"
 
     def test_fuzzy_match_parent_surname_with_nickname(self, strategy, mock_repositories):
         """Test matching nickname + parent surname.
@@ -321,7 +321,7 @@ class TestFuzzyMatchParentSurname:
 
         assert result.is_resolved
         assert result.person.cm_id == 12345
-        assert result.metadata.get("match_type") == "parent_surname"
+        assert result.metadata.get("sub_method") == "parent_surname"
 
     def test_parent_surname_via_resolve(self, strategy, mock_repositories):
         """Test parent surname matching with resolve method"""
@@ -344,7 +344,7 @@ class TestFuzzyMatchParentSurname:
 
         assert result.is_resolved
         assert result.person.cm_id == 12345
-        assert result.metadata.get("match_type") == "parent_surname"
+        assert result.metadata.get("sub_method") == "parent_surname"
 
     def test_parent_surname_lower_priority_than_direct(self, strategy, mock_repositories):
         """Test that direct matches are preferred over parent surname matches.
@@ -371,7 +371,7 @@ class TestFuzzyMatchParentSurname:
         # Should match Michael Smith via nickname, not fall through to parent surname
         assert result.is_resolved
         assert result.person.cm_id == 11111  # Direct match via nickname
-        assert result.metadata.get("match_type") == "nickname"
+        assert result.metadata.get("sub_method") == "nickname"
 
 
 class TestFuzzyMatchJaroWinklerFirstName:
@@ -401,7 +401,7 @@ class TestFuzzyMatchJaroWinklerFirstName:
         result = strategy.resolve("Charlie Garcia", requester_cm_id=999, candidates=candidates)
         assert result.is_resolved
         assert result.person.cm_id == 100
-        assert result.metadata.get("match_type") == "jaro_winkler_first_name"
+        assert result.metadata.get("sub_method") == "jaro_winkler_first_name"
 
     def test_jaro_winkler_first_name_zoey_zoe(self, strategy):
         """Zoey/Zoe should match via JW."""
@@ -478,7 +478,7 @@ class TestJaroWinklerFullPoolFallback:
 
         assert result.is_resolved
         assert result.person.cm_id == 1000002
-        assert result.metadata.get("match_type") == "jaro_winkler_full_pool"
+        assert result.metadata.get("sub_method") == "jaro_winkler_full_pool"
 
     def test_misspelled_last_name_below_threshold_does_not_resolve(self, strategy_with_repos):
         """Very different last name below JW 0.90 threshold does not match."""
@@ -516,7 +516,7 @@ class TestJaroWinklerFullPoolFallback:
         # Verify candidates are preferred — match should come from candidate pool
         if result.is_resolved:
             assert result.person.cm_id == candidate.cm_id
-            assert result.metadata.get("match_type") != "jaro_winkler_full_pool"
+            assert result.metadata.get("sub_method") != "jaro_winkler_full_pool"
 
     def test_both_empty_returns_unresolved(self, strategy_with_repos):
         """Empty candidates AND empty all_persons → unresolved, no crash."""

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_fuzzy_match_with_relationships.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_fuzzy_match_with_relationships.py
@@ -71,7 +71,7 @@ class TestFuzzyMatchWithRelationships:
         assert result.person.cm_id == 12345
         # Base nickname confidence (0.85) + sibling boost (0.25) = 1.1, capped at 0.95
         assert result.confidence == 0.95
-        assert result.metadata["match_type"] == "nickname"
+        assert result.metadata["sub_method"] == "nickname"
 
         # Verify relationship analyzer was called
         mock_relationship_analyzer.analyze_relationships.assert_called_once()

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_phonetic_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_phonetic_match.py
@@ -91,7 +91,7 @@ class TestPhoneticMatchStrategy:
         assert result.person.cm_id == 12345
         assert result.person.last_name == "Smythe"
         assert result.confidence == pytest.approx(0.65)  # Base 0.70 - 0.05 for no session
-        assert result.metadata["match_type"] == "soundex"
+        assert result.metadata["sub_method"] == "soundex"
         assert result.metadata["algorithm"] == "soundex"
 
     def test_multiple_soundex_matches(self, strategy, mock_repositories):
@@ -131,7 +131,7 @@ class TestPhoneticMatchStrategy:
         assert result.person.cm_id == 12345
         assert result.person.first_name == "Katherine"
         assert result.confidence == pytest.approx(0.60)  # Base 0.65 - 0.05 (no session info)
-        assert result.metadata["match_type"] == "metaphone"
+        assert result.metadata["sub_method"] == "metaphone"
         assert result.metadata["algorithm"] == "metaphone"
 
     def test_session_disambiguation(self, strategy, mock_repositories):
@@ -156,7 +156,7 @@ class TestPhoneticMatchStrategy:
         assert result.is_resolved
         assert result.person.cm_id == 12345
         assert result.confidence == 0.75
-        assert result.metadata["match_type"] == "soundex_with_session"
+        assert result.metadata["sub_method"] == "soundex_with_session"
         assert result.metadata["session_match"] == "exact"
 
     def test_confidence_boost_same_session(self, strategy, mock_repositories):
@@ -288,7 +288,7 @@ class TestPhoneticMatchNicknameIntegration:
         assert result.person.cm_id == 12345
         assert result.person.first_name == "Michael"
         assert (
-            "nickname" in result.metadata.get("match_type", "").lower()
+            "nickname" in result.metadata.get("sub_method", "").lower()
             or result.metadata.get("algorithm") == "nickname"
         )
 
@@ -427,7 +427,7 @@ class TestPhoneticMatchParentSurname:
         assert result.is_resolved
         assert result.person.cm_id == 12345
         assert result.person.last_name == "Johnson"
-        assert result.metadata.get("match_type") == "parent_surname_phonetic"
+        assert result.metadata.get("sub_method") == "parent_surname_phonetic"
 
     def test_phonetic_match_parent_surname_with_nickname(self, strategy, mock_repositories):
         """Test phonetic parent surname matching with nickname.
@@ -452,7 +452,7 @@ class TestPhoneticMatchParentSurname:
 
         assert result.is_resolved
         assert result.person.cm_id == 12345
-        assert result.metadata.get("match_type") == "parent_surname_phonetic"
+        assert result.metadata.get("sub_method") == "parent_surname_phonetic"
 
     def test_parent_surname_phonetic_via_resolve(self, strategy, mock_repositories):
         """Test parent surname phonetic matching with resolve"""
@@ -478,7 +478,7 @@ class TestPhoneticMatchParentSurname:
 
         assert result.is_resolved
         assert result.person.cm_id == 12345
-        assert result.metadata.get("match_type") == "parent_surname_phonetic"
+        assert result.metadata.get("sub_method") == "parent_surname_phonetic"
 
     def test_parent_surname_lower_confidence_than_direct(self, strategy, mock_repositories):
         """Test that parent surname phonetic matches have lower confidence"""

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_school_disambiguation.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_school_disambiguation.py
@@ -118,7 +118,7 @@ class TestSchoolDisambiguationStrategy:
         assert result.is_resolved
         assert result.person.cm_id == 12345
         assert result.confidence == 0.90
-        assert result.metadata["match_type"] == "single_exact_match"
+        assert result.metadata["sub_method"] == "single_exact_match"
 
     def test_same_school_disambiguation(self, strategy, mock_repositories):
         """Test successful disambiguation using same school"""
@@ -140,7 +140,7 @@ class TestSchoolDisambiguationStrategy:
         assert result.is_resolved
         assert result.person.cm_id == 12345
         assert result.confidence == 0.85
-        assert result.metadata["match_type"] == "same_school_same_grade"
+        assert result.metadata["sub_method"] == "same_school_same_grade"
 
     def test_multiple_same_school_ambiguous(self, strategy, mock_repositories):
         """Test when multiple candidates from same school with equidistant grades"""
@@ -188,7 +188,7 @@ class TestSchoolDisambiguationStrategy:
         assert result.is_resolved
         assert result.person.cm_id == 12345  # Grade 8, only one within 1 grade
         assert result.confidence == 0.70  # Actual value from implementation
-        assert result.metadata["match_type"] == "same_school_close_grade"
+        assert result.metadata["sub_method"] == "same_school_close_grade"
         assert result.metadata["grade_diff"] == 1
 
     def test_exact_grade_match(self, strategy, mock_repositories):
@@ -211,7 +211,7 @@ class TestSchoolDisambiguationStrategy:
         assert result.is_resolved
         assert result.person.cm_id == 67890  # Exact grade match
         assert result.confidence == 0.85
-        assert result.metadata["match_type"] == "same_school_same_grade"
+        assert result.metadata["sub_method"] == "same_school_same_grade"
 
     def test_no_requester_school(self, strategy, mock_repositories):
         """Test when requester has no school info"""

--- a/tests/unit/sync/bunk_request_processor/test_school_disambiguation_city_state.py
+++ b/tests/unit/sync/bunk_request_processor/test_school_disambiguation_city_state.py
@@ -263,7 +263,7 @@ class TestSchoolDisambiguationWithLocation:
         # The metadata should NOT indicate location matching was used
         if result.is_resolved:
             assert result.metadata is not None
-            assert "same_location" not in str(result.metadata.get("match_type", "")), (
+            assert "same_location" not in str(result.metadata.get("sub_method", "")), (
                 "Should not claim location match when requester has no location"
             )
 


### PR DESCRIPTION
## Summary

Final consolidation PR for Group 61 — closes the half-finished \`match_type\` → \`sub_method\` rename in resolution strategy metadata. Closes #1479 (reframed during planning; see below).

## Reframing of #1479

#1479 was filed as a persistence bug — "metadata.match_type from resolution strategies is never persisted to bunk_requests rows." Audit during Group 61 planning showed the real story:

- \`metadata["match_type"]\` was a **vestigial intermediate hint**, not a persisted record
- ONE reader in production: \`resolution_pipeline.py\` had a fallback chain \`meta.get("sub_method") or meta.get("match_type") or meta.get("ambiguity_reason")\` that translated to \`sub_method\`
- The translated \`sub_method\` IS persisted inside \`pipeline_strategies_tried[]\` (visible in the pipeline-debug UI)
- Some strategy sites redundantly set both \`match_type\` AND \`sub_method\` — evidence of a half-finished rename from a prior PR

This PR finishes the rename so strategies write \`sub_method\` directly, the pipeline reader drops the \`match_type\` fallback, and tests rename mechanically.

## What changed

### Production

- **4 strategy files (~42 sites):** \`metadata["match_type"] = X\` → \`metadata["sub_method"] = X\`. Sites that set both keys are deduped to just \`sub_method\`.
- **\`resolution_pipeline.py\`:** reader simplified to \`meta.get("sub_method") or meta.get("ambiguity_reason")\`. Comment updated.
- **\`request_repository.py\` (\`_map_to_db\` strip tuple):**
  - Removed \`disposition_rule_id\` — zero setters anywhere in the codebase per audit (truly dead)
  - Kept \`match_type\` in the tuple as defensive cleanup for legacy DB rows from pre-PR-D writes, with a comment marking it for removal after a re-sync confirms no legacy rows remain

### Tests (~25 asserts)

- 5 strategy test files: \`["match_type"]\` / \`.get("match_type")\` → \`["sub_method"]\` / \`.get("sub_method")\`
- \`test_school_disambiguation_city_state.py\`: 1 negative assertion key renamed
- \`test_full_pipeline_tracing.py\`: fixture key renamed
- \`test_pipeline_strategies_tried.py\`: test method name dropped \`_from_match_type\` suffix; docstring updated
- \`test_request_repository.py\`: removed \`disposition_rule_id\` fixture entry + assertion (no longer being stripped). The \`match_type\` strip-cleanup assertions stay — they test the legacy-row cleanup behavior.

## What stays the same

- Behavior: the persisted \`pipeline_strategies_tried[].sub_method\` is unchanged. Strategies set sub_method directly now instead of going through a translation; the persisted trace is byte-identical.
- \`_calculate_base_confidence(match_type: str)\` parameter name in \`base_match_strategy.py\` — this is a strategy-local concept (lookup key like \`"normalized_base"\`), not the metadata key. Unchanged.

## Group 61 closes here

| PR | Issue | LOC delta |
|---|---|---|
| #1488 | #1486 dead-code | -66 |
| #1491 | #1478a phonetic | -247 |
| #1493 | #1478b exact | -85 |
| #1494 | #1478c school | -126 |
| #1497 | #1478d dual-API kill | -338 |
| **this PR** | #1479 metadata rename | ~0 (rename) |

Total: ~-862 LOC of dead/duplicate API and key duplication removed.

## Test plan

- [x] \`pytest tests/.../resolution/\` — 154/154 pass (matches baseline)
- [x] \`pytest tests/unit/sync/bunk_request_processor/\` — 1895/1895 pass (1 pre-existing skip)
- [x] \`ruff format\` + \`ruff check\` + \`mypy\` clean
- [x] Verified: 0 \`match_type\` dict keys in strategies/pipeline; 0 \`disposition_rule_id\` references anywhere; legacy strip-cleanup test still passes

Closes #1479
Part of #1478

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized metadata naming: resolution strategies now emit a unified "sub_method" key for match subtypes.
* **Chore**
  * Adjusted legacy metadata cleanup to stop stripping disposition_rule_id while continuing other cleanup.
* **Tests**
  * Updated test expectations to reflect the new metadata shape ("sub_method") across resolution and tracing tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->