### PR TITLE
feat(frontend): friend-group editing UX bundle (#1369, #1372)

### DIFF
--- a/frontend/src/components/BunkingBoardByArea.clickoutside.test.tsx
+++ b/frontend/src/components/BunkingBoardByArea.clickoutside.test.tsx
@@ -4,38 +4,14 @@
  *     (those keys are reserved for the friend-group selection workflow).
  *   - Clicks landing on a [data-panel="lock-action-bar"] element must NOT dismiss
  *     either side panel.
+ *   - Clicks landing on a [data-panel="lock-group-picker"] element (the portaled
+ *     AddMemberPicker dropdown) must NOT dismiss either side panel.
  *
- * Both behaviors are wired in BunkingBoardByArea.handleGlobalClick.
+ * Both behaviors are wired in BunkingBoardByArea.handleGlobalClick via the
+ * shared shouldKeepPanelsOpen predicate.
  */
 import { describe, it, expect } from 'vitest'
-
-/**
- * Mirrors the predicate inside BunkingBoardByArea.handleGlobalClick.
- * If you change either one, change the other.
- *
- * Returns true iff the click should NOT trigger a panel dismiss.
- */
-function shouldKeepPanelsOpen(e: {
-  ctrlKey: boolean
-  metaKey: boolean
-  target: HTMLElement
-}): boolean {
-  if (e.ctrlKey || e.metaKey) return true
-  const t = e.target
-  const isOnPanel = t.closest(
-    '[data-panel="camper-details"], [data-panel="lock-group"], [data-panel="lock-action-bar"]'
-  )
-  const isOnFloatingBadge = t.closest('[data-floating-badge]')
-  const isInteractive = t.closest(
-    'button, a, input, select, textarea, [role="button"], [role="menu"], [role="menuitem"]'
-  )
-  const isContextMenu = t.closest('[data-context-menu]')
-  const isModal = t.closest('[role="dialog"]')
-  const isCard = t.closest('[data-camper-card], [data-bunk-card]')
-  return Boolean(
-    isOnPanel || isOnFloatingBadge || isInteractive || isContextMenu || isModal || isCard
-  )
-}
+import { shouldKeepPanelsOpen } from '../utils/clickoutsidePredicate'
 
 describe('BunkingBoardByArea click-outside predicate', () => {
   it('keeps panels open on Ctrl+click', () => {
@@ -63,6 +39,19 @@ describe('BunkingBoardByArea click-outside predicate', () => {
     const result = shouldKeepPanelsOpen({ ctrlKey: false, metaKey: false, target: child })
     expect(result).toBe(true)
     bar.remove()
+  })
+
+  it('keeps panels open on click inside the AddMemberPicker portal (lock-group-picker)', () => {
+    const portal = document.createElement('div')
+    portal.setAttribute('data-panel', 'lock-group-picker')
+    // Non-interactive child: a span. Without the data-panel whitelist this
+    // would close the panels.
+    const child = document.createElement('span')
+    portal.appendChild(child)
+    document.body.appendChild(portal)
+    const result = shouldKeepPanelsOpen({ ctrlKey: false, metaKey: false, target: child })
+    expect(result).toBe(true)
+    portal.remove()
   })
 
   it('closes panels on plain click on empty board area', () => {

--- a/frontend/src/components/BunkingBoardByArea.clickoutside.test.tsx
+++ b/frontend/src/components/BunkingBoardByArea.clickoutside.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * Click-outside behavior on the board:
+ *   - Ctrl/Meta-modified clicks must NOT dismiss CamperDetailsPanel or LockGroupPanel
+ *     (those keys are reserved for the friend-group selection workflow).
+ *   - Clicks landing on a [data-panel="lock-action-bar"] element must NOT dismiss
+ *     either side panel.
+ *
+ * Both behaviors are wired in BunkingBoardByArea.handleGlobalClick.
+ */
+import { describe, it, expect } from 'vitest'
+
+/**
+ * Mirrors the predicate inside BunkingBoardByArea.handleGlobalClick.
+ * If you change either one, change the other.
+ *
+ * Returns true iff the click should NOT trigger a panel dismiss.
+ */
+function shouldKeepPanelsOpen(e: {
+  ctrlKey: boolean
+  metaKey: boolean
+  target: HTMLElement
+}): boolean {
+  if (e.ctrlKey || e.metaKey) return true
+  const t = e.target
+  const isOnPanel = t.closest(
+    '[data-panel="camper-details"], [data-panel="lock-group"], [data-panel="lock-action-bar"]'
+  )
+  const isOnFloatingBadge = t.closest('[data-floating-badge]')
+  const isInteractive = t.closest(
+    'button, a, input, select, textarea, [role="button"], [role="menu"], [role="menuitem"]'
+  )
+  const isContextMenu = t.closest('[data-context-menu]')
+  const isModal = t.closest('[role="dialog"]')
+  const isCard = t.closest('[data-camper-card], [data-bunk-card]')
+  return Boolean(
+    isOnPanel || isOnFloatingBadge || isInteractive || isContextMenu || isModal || isCard
+  )
+}
+
+describe('BunkingBoardByArea click-outside predicate', () => {
+  it('keeps panels open on Ctrl+click', () => {
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+    const result = shouldKeepPanelsOpen({ ctrlKey: true, metaKey: false, target })
+    expect(result).toBe(true)
+    target.remove()
+  })
+
+  it('keeps panels open on Meta+click (macOS)', () => {
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+    const result = shouldKeepPanelsOpen({ ctrlKey: false, metaKey: true, target })
+    expect(result).toBe(true)
+    target.remove()
+  })
+
+  it('keeps panels open on click inside lock-action-bar', () => {
+    const bar = document.createElement('div')
+    bar.setAttribute('data-panel', 'lock-action-bar')
+    const child = document.createElement('span')
+    bar.appendChild(child)
+    document.body.appendChild(bar)
+    const result = shouldKeepPanelsOpen({ ctrlKey: false, metaKey: false, target: child })
+    expect(result).toBe(true)
+    bar.remove()
+  })
+
+  it('closes panels on plain click on empty board area', () => {
+    const empty = document.createElement('div')
+    document.body.appendChild(empty)
+    const result = shouldKeepPanelsOpen({ ctrlKey: false, metaKey: false, target: empty })
+    expect(result).toBe(false)
+    empty.remove()
+  })
+})

--- a/frontend/src/components/BunkingBoardByArea.tsx
+++ b/frontend/src/components/BunkingBoardByArea.tsx
@@ -522,14 +522,20 @@ export default function BunkingBoardByArea(props: BunkingBoardByAreaProps) {
   // Uses document-level handler to avoid blocking right-clicks and other interactions
   const handleGlobalClick = useCallback(
     (e: MouseEvent) => {
+      // Ctrl/Meta-click is reserved for the friend-group selection workflow;
+      // never dismiss panels on those.
+      if (e.ctrlKey || e.metaKey) return
+
       const target = e.target as HTMLElement
 
       // Don't close if clicking on:
-      // 1. A panel itself
+      // 1. Either side panel or the bottom action bar ([data-panel="lock-action-bar"])
       // 2. An interactive element (button, link, input, etc.)
       // 3. Context menu, dropdown, or other UI elements
       // 4. Camper/bunk cards (user is interacting with the board)
-      const isOnPanel = target.closest('[data-panel="camper-details"], [data-panel="lock-group"]')
+      const isOnPanel = target.closest(
+        '[data-panel="camper-details"], [data-panel="lock-group"], [data-panel="lock-action-bar"]'
+      )
       const isOnFloatingBadge = target.closest('[data-floating-badge]')
       const isInteractive = target.closest(
         'button, a, input, select, textarea, [role="button"], [role="menu"], [role="menuitem"]'

--- a/frontend/src/components/BunkingBoardByArea.tsx
+++ b/frontend/src/components/BunkingBoardByArea.tsx
@@ -32,6 +32,7 @@ import { Permission } from '../constants/permissions'
 import { Home } from 'lucide-react'
 import { isAgSession } from '../utils/sessionTypePredicates'
 import { getEffectivelyUnassignedCampers } from './bunkingBoardHelpers'
+import { shouldKeepPanelsOpen } from '../utils/clickoutsidePredicate'
 
 interface BunkingBoardByAreaProps {
   sessionId: string
@@ -518,37 +519,12 @@ export default function BunkingBoardByArea(props: BunkingBoardByAreaProps) {
   // Check if any panel is open
   const isAnyPanelOpen = !!selectedCamperId || isLockPanelOpen
 
-  // Close panels when clicking on dead space (nav, page sides, board gaps)
-  // Uses document-level handler to avoid blocking right-clicks and other interactions
+  // Close panels when clicking on dead space (nav, page sides, board gaps).
+  // Predicate is shared with the unit test in clickoutsidePredicate.ts so the
+  // two cannot drift.
   const handleGlobalClick = useCallback(
     (e: MouseEvent) => {
-      // Ctrl/Meta-click is reserved for the friend-group selection workflow;
-      // never dismiss panels on those.
-      if (e.ctrlKey || e.metaKey) return
-
-      const target = e.target as HTMLElement
-
-      // Don't close if clicking on:
-      // 1. Either side panel or the bottom action bar ([data-panel="lock-action-bar"])
-      // 2. An interactive element (button, link, input, etc.)
-      // 3. Context menu, dropdown, or other UI elements
-      // 4. Camper/bunk cards (user is interacting with the board)
-      const isOnPanel = target.closest(
-        '[data-panel="camper-details"], [data-panel="lock-group"], [data-panel="lock-action-bar"]'
-      )
-      const isOnFloatingBadge = target.closest('[data-floating-badge]')
-      const isInteractive = target.closest(
-        'button, a, input, select, textarea, [role="button"], [role="menu"], [role="menuitem"]'
-      )
-      const isContextMenu = target.closest('[data-context-menu]')
-      const isModal = target.closest('[role="dialog"]')
-      const isCard = target.closest('[data-camper-card], [data-bunk-card]')
-
-      if (isOnPanel || isOnFloatingBadge || isInteractive || isContextMenu || isModal || isCard) {
-        return
-      }
-
-      // Close all panels with animation
+      if (shouldKeepPanelsOpen(e)) return
       requestAnimatedCloseDetails()
       requestAnimatedCloseLockPanel()
     },

--- a/frontend/src/components/BunkingBoardByArea.tsx
+++ b/frontend/src/components/BunkingBoardByArea.tsx
@@ -762,6 +762,7 @@ export default function BunkingBoardByArea(props: BunkingBoardByAreaProps) {
             requestClose={requestCloseLockPanel}
             selectedArea={selectedArea}
             campers={campers}
+            sessionCampers={campers}
           />
         </Suspense>
       )}

--- a/frontend/src/components/CamperCard.ctrlclick.test.tsx
+++ b/frontend/src/components/CamperCard.ctrlclick.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Ctrl+click on a locked camper: opens the LockGroupPanel and selects that
+ * camper's group (so its row auto-expands via the existing
+ * `expandedGroupId = selectedGroupId ?? localExpandedGroupId` logic).
+ *
+ * Today (pre-change) this is a no-op; only the right-click "Manage Friend
+ * Group" item does this.
+ */
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockLockGroup = { id: 'group-abc', name: 'The Lovins', color: '#ec4899' }
+const setSelectedGroupId = vi.fn()
+const setIsLockPanelOpen = vi.fn()
+const addPendingCamper = vi.fn()
+const removePendingCamper = vi.fn()
+
+vi.mock('@dnd-kit/sortable', async () => {
+  const actual = await vi.importActual<typeof import('@dnd-kit/sortable')>('@dnd-kit/sortable')
+  return {
+    ...actual,
+    useSortable: () => ({
+      attributes: {},
+      listeners: {},
+      setNodeRef: () => {},
+      transform: null,
+      transition: undefined,
+      isDragging: false,
+    }),
+  }
+})
+
+vi.mock('../contexts/LockGroupContext', () => ({
+  useLockGroupContext: () => ({
+    addPendingCamper,
+    removePendingCamper,
+    getPendingAnimationDelay: () => 0,
+    groups: [mockLockGroup],
+    addCamperToGroup: () => {},
+    getCamperLockGroup: (cmId: number) => (cmId === 1000001 ? mockLockGroup : null),
+    getCamperLockState: (cmId: number) => (cmId === 1000001 ? 'locked' : 'none'),
+    getCamperLockGroupColor: () => undefined,
+    getGroupMembers: () => [],
+    selectedGroupId: null,
+    setSelectedGroupId,
+    isLockPanelOpen: false,
+    setIsLockPanelOpen,
+    isDraftMode: true,
+  }),
+}))
+
+vi.mock('../hooks', () => ({
+  useBunkRequestContext: () => ({
+    getSatisfiedRequestInfo: () => null,
+  }),
+  useCamperHistoryContext: () => ({ getLastYearHistory: () => null }),
+}))
+
+vi.mock('../hooks/useCurrentYear', () => ({ useYear: () => 2026 }))
+
+import CamperCard from './CamperCard'
+import type { Camper } from '../types/app-types'
+
+const lockedCamper: Camper = {
+  id: 'pb-1',
+  person_cm_id: 1000001,
+  name: 'Emma Johnson',
+  grade: 5,
+  gender: 'F',
+  assigned_bunk: '',
+  assigned_bunk_cm_id: null,
+} as unknown as Camper
+
+beforeEach(() => {
+  setSelectedGroupId.mockReset()
+  setIsLockPanelOpen.mockReset()
+  addPendingCamper.mockReset()
+  removePendingCamper.mockReset()
+})
+
+describe('CamperCard Ctrl+click on locked camper', () => {
+  it("sets selectedGroupId to that camper's group and opens the panel", () => {
+    render(<CamperCard camper={lockedCamper} lockState="locked" isDraftMode={true} />)
+    const card = screen.getByText('Emma Johnson').closest('[data-camper-card]') as HTMLElement
+    fireEvent.click(card, { ctrlKey: true })
+    expect(setSelectedGroupId).toHaveBeenCalledWith('group-abc')
+    expect(setIsLockPanelOpen).toHaveBeenCalledWith(true)
+  })
+
+  it('does not change pending list', () => {
+    render(<CamperCard camper={lockedCamper} lockState="locked" isDraftMode={true} />)
+    const card = screen.getByText('Emma Johnson').closest('[data-camper-card]') as HTMLElement
+    fireEvent.click(card, { ctrlKey: true })
+    expect(addPendingCamper).not.toHaveBeenCalled()
+    expect(removePendingCamper).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/CamperCard.tsx
+++ b/frontend/src/components/CamperCard.tsx
@@ -63,6 +63,8 @@ function CamperCard({
     addCamperToGroup,
     getCamperLockGroup,
     getGroupMembers,
+    setSelectedGroupId,
+    setIsLockPanelOpen,
   } = useLockGroupContext()
 
   // Get bunk request context
@@ -124,8 +126,14 @@ function CamperCard({
       } else if (lockState === 'none') {
         // Not in a group - add to pending selection
         addPendingCamper(camper)
+      } else if (lockState === 'locked') {
+        // Jump to the camper's existing group in the panel
+        const group = getCamperLockGroup(camper.person_cm_id)
+        if (group) {
+          setSelectedGroupId(group.id)
+          setIsLockPanelOpen(true)
+        }
       }
-      // If locked, do nothing (can't add locked campers to new groups)
       return
     }
 

--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -231,6 +231,7 @@ describe('CamperDetailsPanel', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockLockGroupContext.isActionBarVisible = false
     // Reset getSatisfiedRequestInfo to the default no-op after each test
     mockGetSatisfiedRequestInfo = vi.fn((personCmId: number) => ({
       person_cm_id: personCmId,

--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -1355,6 +1355,20 @@ describe('CamperDetailsPanel', () => {
       const backdrop = container.querySelector('[data-testid="panel-backdrop"]')
       expect(backdrop?.className).toContain('pointer-events-none')
     })
+
+    it('main render path backdrop also has pointer-events-none', async () => {
+      // Set up mocks so the camper resolves — hitting the main render path, not
+      // the loading or not-found path that the default empty-mock tests exercise.
+      setupDeclinedRequestMocks()
+      const { container } = render(
+        <CamperDetailsPanel camperId={String(EMMA.cm_id)} onClose={vi.fn()} />
+      )
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Emma/i })).toBeInTheDocument()
+      })
+      const backdrop = container.querySelector('[data-testid="panel-backdrop"]')
+      expect(backdrop?.className).toContain('pointer-events-none')
+    })
   })
 
   describe('CamperDetailsPanel layout — action bar awareness', () => {

--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -1349,6 +1349,14 @@ describe('CamperDetailsPanel', () => {
     })
   })
 
+  describe('CamperDetailsPanel — backdrop is click-through', () => {
+    it('backdrop has pointer-events-none so clicks fall through to underlying elements', () => {
+      const { container } = render(<CamperDetailsPanel camperId="12345" onClose={vi.fn()} />)
+      const backdrop = container.querySelector('[data-testid="panel-backdrop"]')
+      expect(backdrop?.className).toContain('pointer-events-none')
+    })
+  })
+
   describe('CamperDetailsPanel layout — action bar awareness', () => {
     it('has top-0 and bottom-0 classes when action bar is hidden', () => {
       mockLockGroupContext.isActionBarVisible = false

--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -1353,14 +1353,14 @@ describe('CamperDetailsPanel', () => {
       mockLockGroupContext.isActionBarVisible = false
       const { container } = render(<CamperDetailsPanel camperId="12345" onClose={vi.fn()} />)
       const root = container.querySelector('[data-panel="camper-details"]')
-      expect(root?.className).not.toContain('pb-20')
+      expect(root?.classList.contains('pb-20')).toBe(false)
     })
 
     it('adds pb-20 when action bar is visible', () => {
       mockLockGroupContext.isActionBarVisible = true
       const { container } = render(<CamperDetailsPanel camperId="12345" onClose={vi.fn()} />)
       const root = container.querySelector('[data-panel="camper-details"]')
-      expect(root?.className).toContain('pb-20')
+      expect(root?.classList.contains('pb-20')).toBe(true)
     })
   })
 })

--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -111,24 +111,27 @@ vi.mock('../hooks', async () => {
   }
 })
 
+// Mutable mock for LockGroupContext so tests can toggle isActionBarVisible
+const mockLockGroupContext: { isActionBarVisible: boolean } & Record<string, unknown> = {
+  isActionBarVisible: false,
+  isDraftMode: false,
+  groups: [],
+  pendingCampers: [],
+  addPendingCamper: vi.fn(),
+  removePendingCamper: vi.fn(),
+  getPendingAnimationDelay: () => 0,
+  addCamperToGroup: vi.fn(),
+  getCamperLockGroup: () => null,
+  getCamperLockState: () => 'none' as const,
+  getCamperLockGroupColor: () => undefined,
+  getGroupMembers: () => [],
+  createLockGroup: vi.fn(),
+  deleteLockGroup: vi.fn(),
+  isLoading: false,
+}
 // Mock LockGroupContext — CamperDetailsPanel uses it for alert derivation
 vi.mock('../contexts/LockGroupContext', () => ({
-  useLockGroupContext: () => ({
-    isDraftMode: false,
-    groups: [],
-    pendingCampers: [],
-    addPendingCamper: vi.fn(),
-    removePendingCamper: vi.fn(),
-    getPendingAnimationDelay: () => 0,
-    addCamperToGroup: vi.fn(),
-    getCamperLockGroup: () => null,
-    getCamperLockState: () => 'none' as const,
-    getCamperLockGroupColor: () => undefined,
-    getGroupMembers: () => [],
-    createLockGroup: vi.fn(),
-    deleteLockGroup: vi.fn(),
-    isLoading: false,
-  }),
+  useLockGroupContext: () => mockLockGroupContext,
 }))
 
 // ---------------------------------------------------------------------------
@@ -1342,6 +1345,22 @@ describe('CamperDetailsPanel', () => {
       })
       expect(screen.queryByText(/Social With/i)).not.toBeInTheDocument()
       expect(screen.queryByText(/Marked social-with-best/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('CamperDetailsPanel layout — action bar awareness', () => {
+    it('has no bottom-padding class when action bar is hidden', () => {
+      mockLockGroupContext.isActionBarVisible = false
+      const { container } = render(<CamperDetailsPanel camperId="12345" onClose={vi.fn()} />)
+      const root = container.querySelector('[data-panel="camper-details"]')
+      expect(root?.className).not.toContain('pb-20')
+    })
+
+    it('adds pb-20 when action bar is visible', () => {
+      mockLockGroupContext.isActionBarVisible = true
+      const { container } = render(<CamperDetailsPanel camperId="12345" onClose={vi.fn()} />)
+      const root = container.querySelector('[data-panel="camper-details"]')
+      expect(root?.className).toContain('pb-20')
     })
   })
 })

--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -1350,18 +1350,24 @@ describe('CamperDetailsPanel', () => {
   })
 
   describe('CamperDetailsPanel layout — action bar awareness', () => {
-    it('has no bottom-padding class when action bar is hidden', () => {
+    it('has top-0 and bottom-0 classes when action bar is hidden', () => {
       mockLockGroupContext.isActionBarVisible = false
       const { container } = render(<CamperDetailsPanel camperId="12345" onClose={vi.fn()} />)
       const root = container.querySelector('[data-panel="camper-details"]')
+      expect(root?.classList.contains('top-0')).toBe(true)
+      expect(root?.classList.contains('bottom-0')).toBe(true)
       expect(root?.classList.contains('pb-20')).toBe(false)
+      expect(root?.classList.contains('bottom-20')).toBe(false)
     })
 
-    it('adds pb-20 when action bar is visible', () => {
+    it('adds bottom-20 (shrinks panel) when action bar is visible instead of padding', () => {
       mockLockGroupContext.isActionBarVisible = true
       const { container } = render(<CamperDetailsPanel camperId="12345" onClose={vi.fn()} />)
       const root = container.querySelector('[data-panel="camper-details"]')
-      expect(root?.classList.contains('pb-20')).toBe(true)
+      expect(root?.classList.contains('top-0')).toBe(true)
+      expect(root?.classList.contains('bottom-20')).toBe(true)
+      expect(root?.classList.contains('pb-20')).toBe(false)
+      expect(root?.classList.contains('bottom-0')).toBe(false)
     })
   })
 })

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -595,8 +595,9 @@ export default function CamperDetailsPanel({
     )
   }
 
-  // Lock group context — used to compute friend-group alert
-  const { getCamperLockState, getCamperLockGroup, getGroupMembers } = useLockGroupContext()
+  // Lock group context — used to compute friend-group alert and layout
+  const { getCamperLockState, getCamperLockGroup, getGroupMembers, isActionBarVisible } =
+    useLockGroupContext()
 
   // State for the manage-all-requests modal (opened from alert row click)
   const [isAllRequestsModalOpen, setIsAllRequestsModalOpen] = useState(false)
@@ -746,9 +747,10 @@ export default function CamperDetailsPanel({
           aria-hidden="true"
         />
         <div
+          data-panel="camper-details"
           className={`bg-card shadow-lodge-xl border-border fixed inset-y-0 right-0 z-[60] flex w-[28rem] items-center justify-center border-l ${
             animationPhase === 'entering' ? 'animate-slide-in-right' : 'animate-slide-out-right'
-          }`}
+          }${isActionBarVisible ? 'pb-20' : ''}`}
           onAnimationEnd={handleAnimationEnd}
         >
           <div className="spinner-lodge"></div>
@@ -772,9 +774,10 @@ export default function CamperDetailsPanel({
           aria-hidden="true"
         />
         <div
+          data-panel="camper-details"
           className={`bg-card shadow-lodge-xl border-border fixed inset-y-0 right-0 z-[60] w-[28rem] border-l p-6 ${
             animationPhase === 'entering' ? 'animate-slide-in-right' : 'animate-slide-out-right'
-          }`}
+          }${isActionBarVisible ? 'pb-20' : ''}`}
           onAnimationEnd={handleAnimationEnd}
         >
           <div className="text-muted-foreground text-center">Camper not found</div>
@@ -1340,7 +1343,7 @@ export default function CamperDetailsPanel({
         data-panel="camper-details"
         className={`bg-card shadow-lodge-xl border-border fixed inset-y-0 right-0 z-[60] w-[28rem] border-l ${
           animationPhase === 'entering' ? 'animate-slide-in-right' : 'animate-slide-out-right'
-        }`}
+        }${isActionBarVisible ? 'pb-20' : ''}`}
         onAnimationEnd={handleAnimationEnd}
       >
         <div className="flex h-full flex-col">

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -598,6 +598,7 @@ export default function CamperDetailsPanel({
   // Lock group context — used to compute friend-group alert and layout
   const { getCamperLockState, getCamperLockGroup, getGroupMembers, isActionBarVisible } =
     useLockGroupContext()
+  const actionBarPadding = isActionBarVisible ? 'pb-20' : ''
 
   // State for the manage-all-requests modal (opened from alert row click)
   const [isAllRequestsModalOpen, setIsAllRequestsModalOpen] = useState(false)
@@ -750,7 +751,7 @@ export default function CamperDetailsPanel({
           data-panel="camper-details"
           className={`bg-card shadow-lodge-xl border-border fixed inset-y-0 right-0 z-[60] flex w-[28rem] items-center justify-center border-l ${
             animationPhase === 'entering' ? 'animate-slide-in-right' : 'animate-slide-out-right'
-          } ${isActionBarVisible ? 'pb-20' : ''}`}
+          } ${actionBarPadding}`}
           onAnimationEnd={handleAnimationEnd}
         >
           <div className="spinner-lodge"></div>
@@ -777,7 +778,7 @@ export default function CamperDetailsPanel({
           data-panel="camper-details"
           className={`bg-card shadow-lodge-xl border-border fixed inset-y-0 right-0 z-[60] w-[28rem] border-l p-6 ${
             animationPhase === 'entering' ? 'animate-slide-in-right' : 'animate-slide-out-right'
-          } ${isActionBarVisible ? 'pb-20' : ''}`}
+          } ${actionBarPadding}`}
           onAnimationEnd={handleAnimationEnd}
         >
           <div className="text-muted-foreground text-center">Camper not found</div>
@@ -1343,7 +1344,7 @@ export default function CamperDetailsPanel({
         data-panel="camper-details"
         className={`bg-card shadow-lodge-xl border-border fixed inset-y-0 right-0 z-[60] w-[28rem] border-l ${
           animationPhase === 'entering' ? 'animate-slide-in-right' : 'animate-slide-out-right'
-        } ${isActionBarVisible ? 'pb-20' : ''}`}
+        } ${actionBarPadding}`}
         onAnimationEnd={handleAnimationEnd}
       >
         <div className="flex h-full flex-col">

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -749,7 +749,7 @@ export default function CamperDetailsPanel({
         />
         <div
           data-panel="camper-details"
-          className={`bg-card shadow-lodge-xl border-border fixed top-0 right-0 z-[60] flex w-[28rem] items-center justify-center border-l ${
+          className={`bg-card shadow-lodge-xl border-border fixed top-0 right-0 z-[60] flex w-[28rem] items-center justify-center border-l transition-[bottom] duration-200 ease-out ${
             animationPhase === 'entering' ? 'animate-slide-in-right' : 'animate-slide-out-right'
           } ${actionBarBottom}`}
           onAnimationEnd={handleAnimationEnd}
@@ -776,7 +776,7 @@ export default function CamperDetailsPanel({
         />
         <div
           data-panel="camper-details"
-          className={`bg-card shadow-lodge-xl border-border fixed top-0 right-0 z-[60] w-[28rem] border-l p-6 ${
+          className={`bg-card shadow-lodge-xl border-border fixed top-0 right-0 z-[60] w-[28rem] border-l p-6 transition-[bottom] duration-200 ease-out ${
             animationPhase === 'entering' ? 'animate-slide-in-right' : 'animate-slide-out-right'
           } ${actionBarBottom}`}
           onAnimationEnd={handleAnimationEnd}
@@ -1336,13 +1336,13 @@ export default function CamperDetailsPanel({
       {/* Backdrop - click to close panel */}
       <div
         data-testid="panel-backdrop"
-        className="fixed inset-0 z-[59]"
+        className="pointer-events-none fixed inset-0 z-[59]"
         onClick={handleClose}
         aria-hidden="true"
       />
       <div
         data-panel="camper-details"
-        className={`bg-card shadow-lodge-xl border-border fixed top-0 right-0 z-[60] w-[28rem] border-l ${
+        className={`bg-card shadow-lodge-xl border-border fixed top-0 right-0 z-[60] w-[28rem] border-l transition-[bottom] duration-200 ease-out ${
           animationPhase === 'entering' ? 'animate-slide-in-right' : 'animate-slide-out-right'
         } ${actionBarBottom}`}
         onAnimationEnd={handleAnimationEnd}

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -598,7 +598,7 @@ export default function CamperDetailsPanel({
   // Lock group context — used to compute friend-group alert and layout
   const { getCamperLockState, getCamperLockGroup, getGroupMembers, isActionBarVisible } =
     useLockGroupContext()
-  const actionBarPadding = isActionBarVisible ? 'pb-20' : ''
+  const actionBarBottom = isActionBarVisible ? 'bottom-20' : 'bottom-0'
 
   // State for the manage-all-requests modal (opened from alert row click)
   const [isAllRequestsModalOpen, setIsAllRequestsModalOpen] = useState(false)
@@ -749,9 +749,9 @@ export default function CamperDetailsPanel({
         />
         <div
           data-panel="camper-details"
-          className={`bg-card shadow-lodge-xl border-border fixed inset-y-0 right-0 z-[60] flex w-[28rem] items-center justify-center border-l ${
+          className={`bg-card shadow-lodge-xl border-border fixed top-0 right-0 z-[60] flex w-[28rem] items-center justify-center border-l ${
             animationPhase === 'entering' ? 'animate-slide-in-right' : 'animate-slide-out-right'
-          } ${actionBarPadding}`}
+          } ${actionBarBottom}`}
           onAnimationEnd={handleAnimationEnd}
         >
           <div className="spinner-lodge"></div>
@@ -776,9 +776,9 @@ export default function CamperDetailsPanel({
         />
         <div
           data-panel="camper-details"
-          className={`bg-card shadow-lodge-xl border-border fixed inset-y-0 right-0 z-[60] w-[28rem] border-l p-6 ${
+          className={`bg-card shadow-lodge-xl border-border fixed top-0 right-0 z-[60] w-[28rem] border-l p-6 ${
             animationPhase === 'entering' ? 'animate-slide-in-right' : 'animate-slide-out-right'
-          } ${actionBarPadding}`}
+          } ${actionBarBottom}`}
           onAnimationEnd={handleAnimationEnd}
         >
           <div className="text-muted-foreground text-center">Camper not found</div>
@@ -1342,9 +1342,9 @@ export default function CamperDetailsPanel({
       />
       <div
         data-panel="camper-details"
-        className={`bg-card shadow-lodge-xl border-border fixed inset-y-0 right-0 z-[60] w-[28rem] border-l ${
+        className={`bg-card shadow-lodge-xl border-border fixed top-0 right-0 z-[60] w-[28rem] border-l ${
           animationPhase === 'entering' ? 'animate-slide-in-right' : 'animate-slide-out-right'
-        } ${actionBarPadding}`}
+        } ${actionBarBottom}`}
         onAnimationEnd={handleAnimationEnd}
       >
         <div className="flex h-full flex-col">

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -743,7 +743,7 @@ export default function CamperDetailsPanel({
       <>
         <div
           data-testid="panel-backdrop"
-          className="fixed inset-0 z-[59]"
+          className="pointer-events-none fixed inset-0 z-[59]"
           onClick={handleClose}
           aria-hidden="true"
         />
@@ -770,7 +770,7 @@ export default function CamperDetailsPanel({
       <>
         <div
           data-testid="panel-backdrop"
-          className="fixed inset-0 z-[59]"
+          className="pointer-events-none fixed inset-0 z-[59]"
           onClick={handleClose}
           aria-hidden="true"
         />

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -750,7 +750,7 @@ export default function CamperDetailsPanel({
           data-panel="camper-details"
           className={`bg-card shadow-lodge-xl border-border fixed inset-y-0 right-0 z-[60] flex w-[28rem] items-center justify-center border-l ${
             animationPhase === 'entering' ? 'animate-slide-in-right' : 'animate-slide-out-right'
-          }${isActionBarVisible ? 'pb-20' : ''}`}
+          } ${isActionBarVisible ? 'pb-20' : ''}`}
           onAnimationEnd={handleAnimationEnd}
         >
           <div className="spinner-lodge"></div>
@@ -777,7 +777,7 @@ export default function CamperDetailsPanel({
           data-panel="camper-details"
           className={`bg-card shadow-lodge-xl border-border fixed inset-y-0 right-0 z-[60] w-[28rem] border-l p-6 ${
             animationPhase === 'entering' ? 'animate-slide-in-right' : 'animate-slide-out-right'
-          }${isActionBarVisible ? 'pb-20' : ''}`}
+          } ${isActionBarVisible ? 'pb-20' : ''}`}
           onAnimationEnd={handleAnimationEnd}
         >
           <div className="text-muted-foreground text-center">Camper not found</div>
@@ -1343,7 +1343,7 @@ export default function CamperDetailsPanel({
         data-panel="camper-details"
         className={`bg-card shadow-lodge-xl border-border fixed inset-y-0 right-0 z-[60] w-[28rem] border-l ${
           animationPhase === 'entering' ? 'animate-slide-in-right' : 'animate-slide-out-right'
-        }${isActionBarVisible ? 'pb-20' : ''}`}
+        } ${isActionBarVisible ? 'pb-20' : ''}`}
         onAnimationEnd={handleAnimationEnd}
       >
         <div className="flex h-full flex-col">

--- a/frontend/src/components/LockGroupActionBar.test.tsx
+++ b/frontend/src/components/LockGroupActionBar.test.tsx
@@ -167,3 +167,29 @@ describe('LockGroupActionBar — Add branch (selectedGroupId set)', () => {
     expect(createMock).not.toHaveBeenCalled()
   })
 })
+
+describe('LockGroupActionBar — add-mode background is layered, not replaced', () => {
+  it('keeps bg-background class and uses backgroundImage (not backgroundColor) for the tint', () => {
+    mockSelectedGroupId = 'group-abc'
+    const { container } = render(
+      <LockGroupActionBar
+        pendingCampers={pendingList as unknown as Camper[]}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        year={2026}
+        onClearPending={onClearPending}
+        onGroupCreated={onGroupCreated}
+      />
+    )
+    const root = container.querySelector('[data-panel="lock-action-bar"]') as HTMLElement | null
+    expect(root).not.toBeNull()
+    // Solid base bg must still be present
+    expect(root?.classList.contains('bg-background')).toBe(true)
+    // Inline override must NOT replace it
+    expect(root?.style.backgroundColor).toBe('')
+    // Tint is layered via backgroundImage
+    expect(root?.style.backgroundImage).toContain('linear-gradient')
+    // Stripe still set
+    expect(root?.style.borderLeftColor).toBeTruthy()
+  })
+})

--- a/frontend/src/components/LockGroupActionBar.test.tsx
+++ b/frontend/src/components/LockGroupActionBar.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * LockGroupActionBar branches on `selectedGroupId`:
+ *   - null → "Create Group" path (today's behavior)
+ *   - set  → "Add to group" path (calls addCamperToGroup per pending camper)
+ *
+ * Also confirms the root carries data-panel="lock-action-bar" so #1372's
+ * click-outside whitelist matches.
+ */
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const addCamperToGroup = vi.fn().mockResolvedValue(undefined)
+const onClearPending = vi.fn()
+const onGroupCreated = vi.fn()
+const createMock = vi.fn().mockResolvedValue({ id: 'new-group' })
+
+let mockSelectedGroupId: string | null = null
+const groupList = [{ id: 'group-abc', name: 'The Lovins', color: '#ec4899' }]
+const pendingList = [
+  { id: 'pb-1', person_cm_id: 1000001, name: 'Emma Johnson', attendee_id: 'att-1' },
+  { id: 'pb-2', person_cm_id: 1000002, name: 'Liam Garcia', attendee_id: 'att-2' },
+]
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual =
+    await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query')
+  return {
+    ...actual,
+    useMutation: (opts: { mutationFn: () => Promise<unknown> }) => ({
+      mutate: () => void opts.mutationFn(),
+      mutateAsync: opts.mutationFn,
+      isPending: false,
+    }),
+    useQueryClient: () => ({ invalidateQueries: () => {} }),
+  }
+})
+
+vi.mock('../lib/pocketbase', () => ({
+  pb: {
+    collection: () => ({ create: createMock }),
+    authStore: { record: { email: 'test@example.com' } },
+  },
+  getCurrentUserEmail: () => 'test@example.com',
+}))
+
+vi.mock('../hooks/useGroupConflictConfirm', () => ({
+  useGroupConflictConfirm: () => ({
+    dialogState: { isOpen: false },
+    checkConflict: () => Promise.resolve('confirmed'),
+  }),
+}))
+
+vi.mock('react-hot-toast', () => ({
+  toast: { success: () => {}, error: () => {} },
+  default: { success: () => {}, error: () => {} },
+}))
+
+vi.mock('../contexts/LockGroupContext', () => ({
+  useLockGroupContext: () => ({
+    groups: groupList,
+    selectedGroupId: mockSelectedGroupId,
+    addCamperToGroup,
+  }),
+}))
+
+import LockGroupActionBar from './LockGroupActionBar'
+import type { Camper } from '../types/app-types'
+
+beforeEach(() => {
+  addCamperToGroup.mockClear()
+  onClearPending.mockClear()
+  onGroupCreated.mockClear()
+  createMock.mockClear()
+  mockSelectedGroupId = null
+})
+
+describe('LockGroupActionBar — Create branch (selectedGroupId=null)', () => {
+  it('renders "selected" copy and "Create Group" CTA', () => {
+    mockSelectedGroupId = null
+    render(
+      <LockGroupActionBar
+        pendingCampers={pendingList as unknown as Camper[]}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        year={2026}
+        onClearPending={onClearPending}
+        onGroupCreated={onGroupCreated}
+      />
+    )
+    expect(screen.getByText(/selected/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /create group/i })).toBeInTheDocument()
+  })
+
+  it('root has data-panel="lock-action-bar"', () => {
+    mockSelectedGroupId = null
+    const { container } = render(
+      <LockGroupActionBar
+        pendingCampers={pendingList as unknown as Camper[]}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        year={2026}
+        onClearPending={onClearPending}
+        onGroupCreated={onGroupCreated}
+      />
+    )
+    expect(container.querySelector('[data-panel="lock-action-bar"]')).not.toBeNull()
+  })
+})
+
+describe('LockGroupActionBar — Add branch (selectedGroupId set)', () => {
+  it('renders "Add N to {name}" copy and "Add to group" CTA', () => {
+    mockSelectedGroupId = 'group-abc'
+    render(
+      <LockGroupActionBar
+        pendingCampers={pendingList as unknown as Camper[]}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        year={2026}
+        onClearPending={onClearPending}
+        onGroupCreated={onGroupCreated}
+      />
+    )
+    expect(screen.getByText(/add 2 to/i)).toBeInTheDocument()
+    expect(screen.getByText(/the lovins/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /add to group/i })).toBeInTheDocument()
+  })
+
+  it('CTA invokes addCamperToGroup once per pending camper with the selected group id', async () => {
+    mockSelectedGroupId = 'group-abc'
+    render(
+      <LockGroupActionBar
+        pendingCampers={pendingList as unknown as Camper[]}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        year={2026}
+        onClearPending={onClearPending}
+        onGroupCreated={onGroupCreated}
+      />
+    )
+    const cta = screen.getByRole('button', { name: /add to group/i })
+    await fireEvent.click(cta)
+    // Let the queued microtasks flush
+    await Promise.resolve()
+    expect(addCamperToGroup).toHaveBeenCalledTimes(2)
+    expect(addCamperToGroup).toHaveBeenNthCalledWith(1, pendingList[0], 'group-abc')
+    expect(addCamperToGroup).toHaveBeenNthCalledWith(2, pendingList[1], 'group-abc')
+    expect(onClearPending).toHaveBeenCalled()
+  })
+
+  it('does not call PB collection.create (the create-group path) in add mode', async () => {
+    mockSelectedGroupId = 'group-abc'
+    render(
+      <LockGroupActionBar
+        pendingCampers={pendingList as unknown as Camper[]}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        year={2026}
+        onClearPending={onClearPending}
+        onGroupCreated={onGroupCreated}
+      />
+    )
+    const cta = screen.getByRole('button', { name: /add to group/i })
+    await fireEvent.click(cta)
+    await Promise.resolve()
+    expect(createMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/LockGroupActionBar.test.tsx
+++ b/frontend/src/components/LockGroupActionBar.test.tsx
@@ -6,7 +6,7 @@
  * Also confirms the root carries data-panel="lock-action-bar" so #1372's
  * click-outside whitelist matches.
  */
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const addCamperToGroup = vi.fn().mockResolvedValue(undefined)
@@ -138,10 +138,10 @@ describe('LockGroupActionBar — Add branch (selectedGroupId set)', () => {
       />
     )
     const cta = screen.getByRole('button', { name: /add to group/i })
-    await fireEvent.click(cta)
-    // Let the queued microtasks flush
-    await Promise.resolve()
-    expect(addCamperToGroup).toHaveBeenCalledTimes(2)
+    fireEvent.click(cta)
+    await waitFor(() => {
+      expect(addCamperToGroup).toHaveBeenCalledTimes(2)
+    })
     expect(addCamperToGroup).toHaveBeenNthCalledWith(1, pendingList[0], 'group-abc')
     expect(addCamperToGroup).toHaveBeenNthCalledWith(2, pendingList[1], 'group-abc')
     expect(onClearPending).toHaveBeenCalled()
@@ -160,8 +160,10 @@ describe('LockGroupActionBar — Add branch (selectedGroupId set)', () => {
       />
     )
     const cta = screen.getByRole('button', { name: /add to group/i })
-    await fireEvent.click(cta)
-    await Promise.resolve()
+    fireEvent.click(cta)
+    await waitFor(() => {
+      expect(addCamperToGroup).toHaveBeenCalled()
+    })
     expect(createMock).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/LockGroupActionBar.test.tsx
+++ b/frontend/src/components/LockGroupActionBar.test.tsx
@@ -9,7 +9,8 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const addCamperToGroup = vi.fn().mockResolvedValue(undefined)
+// Default: every add succeeds. Failure-path tests override with mockResolvedValueOnce / mockResolvedValue(false).
+const addCamperToGroup = vi.fn().mockResolvedValue(true)
 const onClearPending = vi.fn()
 const onGroupCreated = vi.fn()
 const createMock = vi.fn().mockResolvedValue({ id: 'new-group' })
@@ -67,7 +68,8 @@ import LockGroupActionBar from './LockGroupActionBar'
 import type { Camper } from '../types/app-types'
 
 beforeEach(() => {
-  addCamperToGroup.mockClear()
+  addCamperToGroup.mockReset()
+  addCamperToGroup.mockResolvedValue(true)
   onClearPending.mockClear()
   onGroupCreated.mockClear()
   createMock.mockClear()
@@ -165,6 +167,128 @@ describe('LockGroupActionBar — Add branch (selectedGroupId set)', () => {
       expect(addCamperToGroup).toHaveBeenCalled()
     })
     expect(createMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('LockGroupActionBar — add-mode partial-failure + re-entrancy guards', () => {
+  it('does NOT clear pending if any addCamperToGroup returns false', async () => {
+    mockSelectedGroupId = 'group-abc'
+    // First add succeeds, second fails (e.g. PB error already toasted internally).
+    addCamperToGroup.mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+    render(
+      <LockGroupActionBar
+        pendingCampers={pendingList as unknown as Camper[]}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        year={2026}
+        onClearPending={onClearPending}
+        onGroupCreated={onGroupCreated}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /add to group/i }))
+    await waitFor(() => {
+      expect(addCamperToGroup).toHaveBeenCalledTimes(2)
+    })
+    // Both campers were attempted, but pending must remain so the user can retry the failed one.
+    expect(onClearPending).not.toHaveBeenCalled()
+  })
+
+  it('clears pending only when every addCamperToGroup returns true', async () => {
+    mockSelectedGroupId = 'group-abc'
+    addCamperToGroup.mockResolvedValue(true)
+    render(
+      <LockGroupActionBar
+        pendingCampers={pendingList as unknown as Camper[]}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        year={2026}
+        onClearPending={onClearPending}
+        onGroupCreated={onGroupCreated}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /add to group/i }))
+    await waitFor(() => {
+      expect(addCamperToGroup).toHaveBeenCalledTimes(2)
+    })
+    expect(onClearPending).toHaveBeenCalledTimes(1)
+  })
+
+  it('is single-flight: rapid double-click does not duplicate the add loop', async () => {
+    mockSelectedGroupId = 'group-abc'
+    // Slow promises so the in-flight guard is observably engaged when the
+    // second click fires.
+    let resolveFirst: (v: boolean) => void = () => {}
+    let resolveSecond: (v: boolean) => void = () => {}
+    const firstPromise = new Promise<boolean>((r) => {
+      resolveFirst = r
+    })
+    const secondPromise = new Promise<boolean>((r) => {
+      resolveSecond = r
+    })
+    addCamperToGroup
+      .mockReturnValueOnce(firstPromise)
+      .mockReturnValueOnce(secondPromise)
+      .mockResolvedValue(true) // any further calls (there shouldn't be any) resolve true
+
+    render(
+      <LockGroupActionBar
+        pendingCampers={pendingList as unknown as Camper[]}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        year={2026}
+        onClearPending={onClearPending}
+        onGroupCreated={onGroupCreated}
+      />
+    )
+    const cta = screen.getByRole('button', { name: /add to group/i })
+    fireEvent.click(cta)
+    // Burst-click before the first batch settles.
+    fireEvent.click(cta)
+    fireEvent.click(cta)
+    // Drain the in-flight calls.
+    resolveFirst(true)
+    resolveSecond(true)
+    await waitFor(() => {
+      expect(onClearPending).toHaveBeenCalledTimes(1)
+    })
+    // Exactly one add per pending camper — extra clicks were dropped.
+    expect(addCamperToGroup).toHaveBeenCalledTimes(2)
+    // Create-group path must not have fired either.
+    expect(createMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('LockGroupActionBar — "(select at least 2)" helper visibility', () => {
+  const onePending = [pendingList[0]] as Camper[]
+
+  it('shows helper in CREATE mode with one pending camper', () => {
+    mockSelectedGroupId = null
+    render(
+      <LockGroupActionBar
+        pendingCampers={onePending}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        year={2026}
+        onClearPending={onClearPending}
+        onGroupCreated={onGroupCreated}
+      />
+    )
+    expect(screen.getByText(/select at least 2/i)).toBeInTheDocument()
+  })
+
+  it('HIDES helper in ADD mode with one pending camper (add-1 is valid)', () => {
+    mockSelectedGroupId = 'group-abc'
+    render(
+      <LockGroupActionBar
+        pendingCampers={onePending}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        year={2026}
+        onClearPending={onClearPending}
+        onGroupCreated={onGroupCreated}
+      />
+    )
+    expect(screen.queryByText(/select at least 2/i)).not.toBeInTheDocument()
   })
 })
 

--- a/frontend/src/components/LockGroupActionBar.tsx
+++ b/frontend/src/components/LockGroupActionBar.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, useMemo, useCallback } from 'react'
+import { Fragment, useState, useMemo, useCallback, useRef } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Users, AlertTriangle, Heart } from 'lucide-react'
 import clsx from 'clsx'
@@ -253,13 +253,30 @@ function LockGroupActionBar({
     }
   }
 
+  // Re-entrancy guard: ref for synchronous check (state would race with
+  // React's render scheduling on rapid double-clicks), state for the
+  // disabled-button re-render.
+  const isAddingRef = useRef(false)
+  const [isAddingToExisting, setIsAddingToExisting] = useState(false)
+
   const handleAddToExisting = useCallback(async () => {
-    if (!selectedGroup) return
-    for (const camper of pendingCampers) {
-      // addCamperToGroup already handles conflict-confirm + toasts + invalidations
-      await addCamperToGroup(camper, selectedGroup.id)
+    if (!selectedGroup || isAddingRef.current) return
+    isAddingRef.current = true
+    setIsAddingToExisting(true)
+    try {
+      let allSucceeded = true
+      for (const camper of pendingCampers) {
+        // addCamperToGroup handles conflict-confirm + toasts + invalidations
+        // and returns false on any "didn't happen" outcome (cancellation,
+        // PB failure, etc.). Only clear pending if every add confirmed.
+        const ok = await addCamperToGroup(camper, selectedGroup.id)
+        if (!ok) allSucceeded = false
+      }
+      if (allSucceeded) onClearPending()
+    } finally {
+      isAddingRef.current = false
+      setIsAddingToExisting(false)
     }
-    onClearPending()
   }, [selectedGroup, pendingCampers, addCamperToGroup, onClearPending])
 
   // Don't show if no pending campers
@@ -316,7 +333,7 @@ function LockGroupActionBar({
                   )}
                 </span>
               </div>
-              {pendingCampers.length < 2 && (
+              {!isAddMode && pendingCampers.length < 2 && (
                 <span className="text-muted-foreground text-sm">(select at least 2)</span>
               )}
               {isOverLimit && (
@@ -374,7 +391,7 @@ function LockGroupActionBar({
               {isAddMode && selectedGroup ? (
                 <button
                   onClick={() => void handleAddToExisting()}
-                  disabled={pendingCampers.length === 0}
+                  disabled={pendingCampers.length === 0 || isAddingToExisting}
                   className="text-primary-foreground inline-flex items-center gap-2 rounded-lg px-4 py-1.5 text-sm transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
                   style={{ backgroundColor: selectedGroup.color }}
                 >

--- a/frontend/src/components/LockGroupActionBar.tsx
+++ b/frontend/src/components/LockGroupActionBar.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, useMemo } from 'react'
+import { Fragment, useState, useMemo, useCallback } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Users, AlertTriangle, Heart } from 'lucide-react'
 import clsx from 'clsx'
@@ -139,7 +139,12 @@ function LockGroupActionBar({
   onGroupCreated,
 }: LockGroupActionBarProps) {
   const queryClient = useQueryClient()
-  const { groups } = useLockGroupContext()
+  const { groups, selectedGroupId, addCamperToGroup } = useLockGroupContext()
+  const selectedGroup = useMemo(
+    () => (selectedGroupId ? groups.find((g) => g.id === selectedGroupId) : undefined),
+    [groups, selectedGroupId]
+  )
+  const isAddMode = !!selectedGroup
 
   // Conflict-confirm hook — warns when a pending camper is already in another group
   const conflictConfirm = useGroupConflictConfirm()
@@ -248,6 +253,15 @@ function LockGroupActionBar({
     }
   }
 
+  const handleAddToExisting = useCallback(async () => {
+    if (!selectedGroup) return
+    for (const camper of pendingCampers) {
+      // addCamperToGroup already handles conflict-confirm + toasts + invalidations
+      await addCamperToGroup(camper, selectedGroup.id)
+    }
+    onClearPending()
+  }, [selectedGroup, pendingCampers, addCamperToGroup, onClearPending])
+
   // Don't show if no pending campers
   if (pendingCampers.length === 0) {
     return null
@@ -265,7 +279,21 @@ function LockGroupActionBar({
 
   return (
     <Fragment>
-      <div className="bg-background shadow-lodge-lg fixed right-0 bottom-0 left-0 z-40 border-t">
+      <div
+        data-panel="lock-action-bar"
+        className={clsx(
+          'bg-background shadow-lodge-lg fixed right-0 bottom-0 left-0 z-40 border-t',
+          isAddMode && 'border-l-4'
+        )}
+        style={
+          isAddMode && selectedGroup
+            ? {
+                borderLeftColor: selectedGroup.color,
+                backgroundColor: `${selectedGroup.color}1a` /* ~10% alpha */,
+              }
+            : undefined
+        }
+      >
         <div className="container mx-auto px-4 py-3">
           <div className="flex items-center justify-between gap-4">
             {/* Left: Selection info */}
@@ -273,8 +301,19 @@ function LockGroupActionBar({
               <div className="flex items-center gap-2">
                 <Users className="text-primary h-5 w-5" />
                 <span className="font-medium">
-                  {pendingCampers.length} camper
-                  {pendingCampers.length !== 1 ? 's' : ''} selected
+                  {isAddMode && selectedGroup ? (
+                    <>
+                      Add {pendingCampers.length} to{' '}
+                      <span style={{ color: selectedGroup.color }}>
+                        {selectedGroup.name || 'Unnamed Group'}
+                      </span>
+                    </>
+                  ) : (
+                    <>
+                      {pendingCampers.length} camper{pendingCampers.length !== 1 ? 's' : ''}{' '}
+                      selected
+                    </>
+                  )}
                 </span>
               </div>
               {pendingCampers.length < 2 && (
@@ -293,33 +332,38 @@ function LockGroupActionBar({
 
             {/* Right: Name input, color picker and actions */}
             <div className="flex items-center gap-3">
-              {/* Optional group name input - shows auto-generated name as placeholder */}
-              <input
-                type="text"
-                value={groupName}
-                onChange={(e) => setGroupName(e.target.value)}
-                placeholder={defaultName || 'Group name'}
-                className="bg-background focus:ring-primary/50 w-44 rounded-lg border px-3 py-1.5 text-sm focus:ring-2 focus:outline-none"
-              />
-
-              <div className="bg-border h-6 w-px" />
-
-              {/* Inline color picker */}
-              <div className="flex items-center gap-1.5">
-                {GROUP_COLORS.map((color) => (
-                  <button
-                    key={color}
-                    onClick={() => setSelectedColor(color)}
-                    className={clsx(
-                      'h-6 w-6 rounded-full transition-all',
-                      selectedColor === color && 'ring-foreground scale-110 ring-2 ring-offset-2'
-                    )}
-                    style={{ backgroundColor: color }}
+              {!isAddMode && (
+                <>
+                  {/* Optional group name input - shows auto-generated name as placeholder */}
+                  <input
+                    type="text"
+                    value={groupName}
+                    onChange={(e) => setGroupName(e.target.value)}
+                    placeholder={defaultName || 'Group name'}
+                    className="bg-background focus:ring-primary/50 w-44 rounded-lg border px-3 py-1.5 text-sm focus:ring-2 focus:outline-none"
                   />
-                ))}
-              </div>
 
-              <div className="bg-border h-6 w-px" />
+                  <div className="bg-border h-6 w-px" />
+
+                  {/* Inline color picker */}
+                  <div className="flex items-center gap-1.5">
+                    {GROUP_COLORS.map((color) => (
+                      <button
+                        key={color}
+                        onClick={() => setSelectedColor(color)}
+                        className={clsx(
+                          'h-6 w-6 rounded-full transition-all',
+                          selectedColor === color &&
+                            'ring-foreground scale-110 ring-2 ring-offset-2'
+                        )}
+                        style={{ backgroundColor: color }}
+                      />
+                    ))}
+                  </div>
+
+                  <div className="bg-border h-6 w-px" />
+                </>
+              )}
 
               <button
                 onClick={onClearPending}
@@ -327,14 +371,26 @@ function LockGroupActionBar({
               >
                 Clear
               </button>
-              <button
-                onClick={handleCreateGroup}
-                disabled={!canCreate}
-                className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center gap-2 rounded-lg px-4 py-1.5 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                <Heart className="h-4 w-4" />
-                {createGroupMutation.isPending ? 'Creating...' : 'Create Group'}
-              </button>
+              {isAddMode && selectedGroup ? (
+                <button
+                  onClick={() => void handleAddToExisting()}
+                  disabled={pendingCampers.length === 0}
+                  className="text-primary-foreground inline-flex items-center gap-2 rounded-lg px-4 py-1.5 text-sm transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+                  style={{ backgroundColor: selectedGroup.color }}
+                >
+                  <Heart className="h-4 w-4" />
+                  Add to group
+                </button>
+              ) : (
+                <button
+                  onClick={handleCreateGroup}
+                  disabled={!canCreate}
+                  className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center gap-2 rounded-lg px-4 py-1.5 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <Heart className="h-4 w-4" />
+                  {createGroupMutation.isPending ? 'Creating...' : 'Create Group'}
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/frontend/src/components/LockGroupActionBar.tsx
+++ b/frontend/src/components/LockGroupActionBar.tsx
@@ -289,7 +289,7 @@ function LockGroupActionBar({
           isAddMode && selectedGroup
             ? {
                 borderLeftColor: selectedGroup.color,
-                backgroundColor: `${selectedGroup.color}1a` /* ~10% alpha */,
+                backgroundImage: `linear-gradient(${selectedGroup.color}40, ${selectedGroup.color}40)`,
               }
             : undefined
         }

--- a/frontend/src/components/LockGroupPanel.test.tsx
+++ b/frontend/src/components/LockGroupPanel.test.tsx
@@ -90,7 +90,7 @@ describe('LockGroupPanel layout', () => {
 describe('LockGroupPanel — α visual treatment on selected group', () => {
   const testGroup = { id: 'group-abc', name: 'The Lovins', color: '#ec4899' }
 
-  it('applies the group color as a left stripe on the selected group header', () => {
+  it('applies the group color as a tinted background on the selected group header', () => {
     mockQueryData = [testGroup]
     const { container } = render(
       <LockGroupPanel
@@ -103,12 +103,13 @@ describe('LockGroupPanel — α visual treatment on selected group', () => {
     )
     const header = container.querySelector<HTMLElement>('[data-group-id="group-abc"]')
     expect(header).not.toBeNull()
+    // Stripe is always present (group identity); selection adds the tint
     expect(header?.className).toContain('border-l-4')
-    // React serialises hex to rgb(...) in jsdom; use the JS style property instead of getAttribute.
     expect(header?.style.borderLeftColor).toBeTruthy()
+    expect(header?.style.backgroundColor).toBeTruthy()
   })
 
-  it('does NOT apply the stripe when the group is not selected', () => {
+  it('keeps the stripe but omits the tint when the group is not selected', () => {
     mockQueryData = [testGroup]
     const { container } = render(
       <LockGroupPanel
@@ -119,8 +120,11 @@ describe('LockGroupPanel — α visual treatment on selected group', () => {
         selectedGroupId={null}
       />
     )
-    const header = container.querySelector('[data-group-id="group-abc"]')
+    const header = container.querySelector<HTMLElement>('[data-group-id="group-abc"]')
     expect(header).not.toBeNull()
-    expect(header?.className).not.toContain('border-l-4')
+    // Stripe still present, but no tint
+    expect(header?.className).toContain('border-l-4')
+    expect(header?.style.borderLeftColor).toBeTruthy()
+    expect(header?.style.backgroundColor).toBeFalsy()
   })
 })

--- a/frontend/src/components/LockGroupPanel.test.tsx
+++ b/frontend/src/components/LockGroupPanel.test.tsx
@@ -4,7 +4,7 @@
  * The panel must reserve bottom space (pb-20) when the action bar is visible,
  * so the fixed-bottom bar isn't covered by the panel.
  */
-import { render } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // Controls what useQuery returns — swap per test to inject group data.
@@ -41,7 +41,8 @@ const mockContext: {
   scenarioId: string
   sessionPbId: string
   isDraftMode: boolean
-  getCamperLockGroup: () => unknown
+  getCamperLockGroup: (cmId: number) => unknown
+  addCamperToGroup: ReturnType<typeof vi.fn>
 } = {
   isActionBarVisible: false,
   isLockPanelOpen: true,
@@ -54,6 +55,7 @@ const mockContext: {
   sessionPbId: 'sess-1',
   isDraftMode: true,
   getCamperLockGroup: () => null,
+  addCamperToGroup: vi.fn(),
 }
 vi.mock('../contexts/LockGroupContext', () => ({
   useLockGroupContext: () => mockContext,
@@ -65,6 +67,8 @@ beforeEach(() => {
   mockQueryData = []
   mockContext.isActionBarVisible = false
   mockContext.selectedGroupId = null
+  mockContext.getCamperLockGroup = () => null
+  mockContext.addCamperToGroup = vi.fn()
 })
 
 describe('LockGroupPanel layout', () => {
@@ -126,5 +130,73 @@ describe('LockGroupPanel — α visual treatment on selected group', () => {
     expect(header?.className).toContain('border-l-4')
     expect(header?.style.borderLeftColor).toBeTruthy()
     expect(header?.style.backgroundColor).toBeFalsy()
+  })
+})
+
+describe('LockGroupPanel — ＋ Add member picker', () => {
+  const testGroup = { id: 'group-abc', name: 'The Lovins', color: '#ec4899' }
+
+  it('renders the Add Member button inside the expanded group body', () => {
+    mockQueryData = [testGroup]
+    mockContext.getCamperLockGroup = () => null
+    render(
+      <LockGroupPanel
+        isOpen={true}
+        onClose={() => {}}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        selectedGroupId="group-abc"
+        sessionCampers={[
+          { id: 'pb-1', person_cm_id: 1000001, name: 'Emma Johnson' } as never,
+          { id: 'pb-2', person_cm_id: 1000002, name: 'Liam Garcia' } as never,
+        ]}
+      />
+    )
+    expect(screen.getByRole('button', { name: /add member/i })).toBeInTheDocument()
+  })
+
+  it('filters out campers already in any group from the picker results', () => {
+    mockQueryData = [testGroup]
+    mockContext.getCamperLockGroup = (cmId: number) =>
+      cmId === 1000001 ? ({ id: 'group-abc' } as never) : null
+    render(
+      <LockGroupPanel
+        isOpen={true}
+        onClose={() => {}}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        selectedGroupId="group-abc"
+        sessionCampers={[
+          { id: 'pb-1', person_cm_id: 1000001, name: 'Emma Johnson' } as never,
+          { id: 'pb-2', person_cm_id: 1000002, name: 'Liam Garcia' } as never,
+        ]}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /add member/i }))
+    // Liam should be selectable; Emma should not appear in the dropdown
+    expect(screen.queryByRole('button', { name: /emma johnson/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /liam garcia/i })).toBeInTheDocument()
+  })
+
+  it('invokes addCamperToGroup with the selected camper + group id', async () => {
+    const addCamperToGroup = vi.fn().mockResolvedValue(undefined)
+    mockQueryData = [testGroup]
+    mockContext.getCamperLockGroup = () => null
+    mockContext.addCamperToGroup = addCamperToGroup
+    const liam = { id: 'pb-2', person_cm_id: 1000002, name: 'Liam Garcia' } as never
+    render(
+      <LockGroupPanel
+        isOpen={true}
+        onClose={() => {}}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        selectedGroupId="group-abc"
+        sessionCampers={[liam]}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /add member/i }))
+    fireEvent.click(screen.getByRole('button', { name: /liam garcia/i }))
+    await Promise.resolve()
+    expect(addCamperToGroup).toHaveBeenCalledWith(liam, 'group-abc')
   })
 })

--- a/frontend/src/components/LockGroupPanel.test.tsx
+++ b/frontend/src/components/LockGroupPanel.test.tsx
@@ -5,7 +5,10 @@
  * so the fixed-bottom bar isn't covered by the panel.
  */
 import { render } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Controls what useQuery returns — swap per test to inject group data.
+let mockQueryData: unknown[] = []
 
 // Mock the lazy-loaded panel's React Query consumer.
 vi.mock('@tanstack/react-query', async () => {
@@ -13,7 +16,7 @@ vi.mock('@tanstack/react-query', async () => {
     await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query')
   return {
     ...actual,
-    useQuery: () => ({ data: [], isLoading: false }),
+    useQuery: () => ({ data: mockQueryData, isLoading: false }),
     useMutation: () => ({
       mutate: () => {},
       mutateAsync: () => Promise.resolve(),
@@ -58,6 +61,12 @@ vi.mock('../contexts/LockGroupContext', () => ({
 
 import LockGroupPanel from './LockGroupPanel'
 
+beforeEach(() => {
+  mockQueryData = []
+  mockContext.isActionBarVisible = false
+  mockContext.selectedGroupId = null
+})
+
 describe('LockGroupPanel layout', () => {
   it('has no bottom-padding class when action bar is hidden', () => {
     mockContext.isActionBarVisible = false
@@ -75,5 +84,43 @@ describe('LockGroupPanel layout', () => {
     )
     const root = container.querySelector('[data-panel="lock-group"]')
     expect(root?.className).toContain('pb-20')
+  })
+})
+
+describe('LockGroupPanel — α visual treatment on selected group', () => {
+  const testGroup = { id: 'group-abc', name: 'The Lovins', color: '#ec4899' }
+
+  it('applies the group color as a left stripe on the selected group header', () => {
+    mockQueryData = [testGroup]
+    const { container } = render(
+      <LockGroupPanel
+        isOpen={true}
+        onClose={() => {}}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        selectedGroupId="group-abc"
+      />
+    )
+    const header = container.querySelector<HTMLElement>('[data-group-id="group-abc"]')
+    expect(header).not.toBeNull()
+    expect(header?.className).toContain('border-l-4')
+    // React serialises hex to rgb(...) in jsdom; use the JS style property instead of getAttribute.
+    expect(header?.style.borderLeftColor).toBeTruthy()
+  })
+
+  it('does NOT apply the stripe when the group is not selected', () => {
+    mockQueryData = [testGroup]
+    const { container } = render(
+      <LockGroupPanel
+        isOpen={true}
+        onClose={() => {}}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        selectedGroupId={null}
+      />
+    )
+    const header = container.querySelector('[data-group-id="group-abc"]')
+    expect(header).not.toBeNull()
+    expect(header?.className).not.toContain('border-l-4')
   })
 })

--- a/frontend/src/components/LockGroupPanel.test.tsx
+++ b/frontend/src/components/LockGroupPanel.test.tsx
@@ -7,8 +7,18 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-// Controls what useQuery returns — swap per test to inject group data.
+// Controls what each useQuery returns — swap per test. Splitting by queryKey
+// prevents the false-positive where groups and members queries share a fixture.
+//
+// `mockQueryData` is kept as a back-compat alias: tests that set it populate
+// BOTH groups and members (matches the legacy single-fixture behavior so old
+// tests keep working). New tests should prefer mockGroups / mockMembers
+// directly, plus mockGroupsState / mockMembersState for loading/error coverage.
+let mockGroups: unknown[] = []
+let mockMembers: unknown[] = []
 let mockQueryData: unknown[] = []
+let mockGroupsState: { isLoading?: boolean; isError?: boolean } = {}
+let mockMembersState: { isLoading?: boolean; isError?: boolean } = {}
 
 // Mock the lazy-loaded panel's React Query consumer.
 vi.mock('@tanstack/react-query', async () => {
@@ -16,7 +26,26 @@ vi.mock('@tanstack/react-query', async () => {
     await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query')
   return {
     ...actual,
-    useQuery: () => ({ data: mockQueryData, isLoading: false }),
+    useQuery: ({ queryKey }: { queryKey: unknown[] }) => {
+      const key = String(queryKey[0] ?? '')
+      if (key === 'locked-groups-panel') {
+        return {
+          data: mockGroups.length > 0 ? mockGroups : mockQueryData,
+          isLoading: mockGroupsState.isLoading ?? false,
+          isError: mockGroupsState.isError ?? false,
+          error: mockGroupsState.isError ? new Error('groups query failed') : null,
+        }
+      }
+      if (key === 'locked-group-members-panel') {
+        return {
+          data: mockMembers.length > 0 ? mockMembers : mockQueryData,
+          isLoading: mockMembersState.isLoading ?? false,
+          isError: mockMembersState.isError ?? false,
+          error: mockMembersState.isError ? new Error('members query failed') : null,
+        }
+      }
+      return { data: [], isLoading: false, isError: false, error: null }
+    },
     useMutation: (options: { onSuccess?: (data: unknown, variables: unknown) => void }) => ({
       mutate: (variables: unknown) => {
         options?.onSuccess?.(undefined, variables)
@@ -67,6 +96,10 @@ import LockGroupPanel from './LockGroupPanel'
 
 beforeEach(() => {
   mockQueryData = []
+  mockGroups = []
+  mockMembers = []
+  mockGroupsState = {}
+  mockMembersState = {}
   mockContext.isActionBarVisible = false
   mockContext.selectedGroupId = null
   mockContext.getCamperLockGroup = () => null
@@ -182,8 +215,8 @@ describe('LockGroupPanel — ＋ Add member picker', () => {
     )
     fireEvent.click(screen.getByRole('button', { name: /add member/i }))
     // Liam should be selectable; Emma should not appear in the dropdown
-    expect(screen.queryByRole('button', { name: /emma johnson/i })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /liam garcia/i })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /emma johnson/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /liam garcia/i })).toBeInTheDocument()
   })
 
   it('invokes addCamperToGroup with the selected camper + group id', async () => {
@@ -203,7 +236,7 @@ describe('LockGroupPanel — ＋ Add member picker', () => {
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /add member/i }))
-    fireEvent.click(screen.getByRole('button', { name: /liam garcia/i }))
+    fireEvent.click(screen.getByRole('option', { name: /liam garcia/i }))
     await Promise.resolve()
     expect(addCamperToGroup).toHaveBeenCalledWith(liam, 'group-abc')
   })
@@ -253,22 +286,25 @@ describe('LockGroupPanel — ＋ Add member picker', () => {
 })
 
 describe('LockGroupPanel — gender-scoped AddMemberPicker', () => {
-  // Member records injected into mockQueryData so membersByGroup['group-abc'] is populated.
-  // The mock returns the same data for both the groups and members queries, so both the
-  // group object and member objects appear in `groups` — member records have no `name`/`color`
-  // and render as additional unnamed group cards, but that doesn't affect picker assertions.
+  // Gender lives on the attendee (matches getMemberGender() and the rest of
+  // the codebase). The picker's lockedGender derivation reads attendee.gender
+  // directly — not person.gender — so these fixtures match real PB data.
   const maleOnlyMembers = [
     {
       id: 'mem-1',
       group: 'group-abc',
       attendee: 'att-1',
-      expand: { attendee: { expand: { person: { id: 'p1', cm_id: 9001, gender: 'M' } } } },
+      expand: {
+        attendee: { gender: 'M', expand: { person: { id: 'p1', cm_id: 9001 } } },
+      },
     },
     {
       id: 'mem-2',
       group: 'group-abc',
       attendee: 'att-2',
-      expand: { attendee: { expand: { person: { id: 'p2', cm_id: 9002, gender: 'M' } } } },
+      expand: {
+        attendee: { gender: 'M', expand: { person: { id: 'p2', cm_id: 9002 } } },
+      },
     },
   ]
   const mixedMembers = [
@@ -276,19 +312,24 @@ describe('LockGroupPanel — gender-scoped AddMemberPicker', () => {
       id: 'mem-3',
       group: 'group-abc',
       attendee: 'att-3',
-      expand: { attendee: { expand: { person: { id: 'p3', cm_id: 9003, gender: 'M' } } } },
+      expand: {
+        attendee: { gender: 'M', expand: { person: { id: 'p3', cm_id: 9003 } } },
+      },
     },
     {
       id: 'mem-4',
       group: 'group-abc',
       attendee: 'att-4',
-      expand: { attendee: { expand: { person: { id: 'p4', cm_id: 9004, gender: 'F' } } } },
+      expand: {
+        attendee: { gender: 'F', expand: { person: { id: 'p4', cm_id: 9004 } } },
+      },
     },
   ]
   const testGroup = { id: 'group-abc', name: 'The Lovins', color: '#ec4899' }
 
-  it('locks picker to "M" when all current members are male', () => {
-    mockQueryData = [testGroup, ...maleOnlyMembers]
+  it('locks picker to "M" when all current members are male (gender on attendee)', () => {
+    mockGroups = [testGroup]
+    mockMembers = maleOnlyMembers
     mockContext.getCamperLockGroup = () => null
     render(
       <LockGroupPanel
@@ -304,12 +345,13 @@ describe('LockGroupPanel — gender-scoped AddMemberPicker', () => {
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /add member/i }))
-    expect(screen.getByRole('button', { name: /riley sam/i })).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /sophia lee/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /riley sam/i })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /sophia lee/i })).not.toBeInTheDocument()
   })
 
   it('does NOT lock picker gender when group has mixed-gender members (AG cabin)', () => {
-    mockQueryData = [testGroup, ...mixedMembers]
+    mockGroups = [testGroup]
+    mockMembers = mixedMembers
     mockContext.getCamperLockGroup = () => null
     render(
       <LockGroupPanel
@@ -325,12 +367,13 @@ describe('LockGroupPanel — gender-scoped AddMemberPicker', () => {
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /add member/i }))
-    expect(screen.getByRole('button', { name: /riley sam/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /sophia lee/i })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /riley sam/i })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /sophia lee/i })).toBeInTheDocument()
   })
 
   it('does NOT lock picker gender when group is empty', () => {
-    mockQueryData = [testGroup] // no members injected → membersByGroup['group-abc'] = []
+    mockGroups = [testGroup]
+    mockMembers = [] // membersByGroup['group-abc'] = []
     mockContext.getCamperLockGroup = () => null
     render(
       <LockGroupPanel
@@ -346,8 +389,198 @@ describe('LockGroupPanel — gender-scoped AddMemberPicker', () => {
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /add member/i }))
-    expect(screen.getByRole('button', { name: /riley sam/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /sophia lee/i })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /riley sam/i })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /sophia lee/i })).toBeInTheDocument()
+  })
+})
+
+describe('LockGroupPanel — AddMemberPicker: gender source regression (#1499 issue #2)', () => {
+  // Regression for the bug where lockedGender derived from person.gender
+  // instead of attendee.gender. Real PB data has gender at the attendee level;
+  // person-level gender is not populated, so the picker silently failed to
+  // gender-scope its candidates.
+  const testGroup = { id: 'group-abc', name: 'The Lovins', color: '#ec4899' }
+
+  it('ignores person.gender — picker is NOT gender-scoped when only person.gender is present', () => {
+    mockGroups = [testGroup]
+    // Note: gender ONLY on person; attendee has no gender field. Picker must
+    // treat this as "no locked gender" since the canonical source is empty.
+    mockMembers = [
+      {
+        id: 'mem-1',
+        group: 'group-abc',
+        attendee: 'att-1',
+        expand: { attendee: { expand: { person: { id: 'p1', cm_id: 9001, gender: 'M' } } } },
+      },
+    ]
+    mockContext.getCamperLockGroup = () => null
+    render(
+      <LockGroupPanel
+        isOpen={true}
+        onClose={() => {}}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        selectedGroupId="group-abc"
+        sessionCampers={[
+          { id: 'pb-1', person_cm_id: 1000001, name: 'Riley Sam', gender: 'M' } as never,
+          { id: 'pb-2', person_cm_id: 1000002, name: 'Sophia Lee', gender: 'F' } as never,
+        ]}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /add member/i }))
+    // Both genders visible — person.gender is NOT the canonical source.
+    expect(screen.getByRole('option', { name: /riley sam/i })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /sophia lee/i })).toBeInTheDocument()
+  })
+})
+
+describe('LockGroupPanel — query error states (#1499 issue #3)', () => {
+  it('shows an error branch when the groups query fails', () => {
+    mockGroupsState = { isError: true }
+    render(
+      <LockGroupPanel isOpen={true} onClose={() => {}} sessionPbId="sess-1" scenarioId="scn-1" />
+    )
+    const errorPanel = document.querySelector('[data-panel-error]')
+    expect(errorPanel).not.toBeNull()
+    expect(errorPanel?.textContent).toMatch(/failed to load friend groups/i)
+  })
+
+  it('shows an error branch when the members query fails', () => {
+    mockMembersState = { isError: true }
+    render(
+      <LockGroupPanel isOpen={true} onClose={() => {}} sessionPbId="sess-1" scenarioId="scn-1" />
+    )
+    const errorPanel = document.querySelector('[data-panel-error]')
+    expect(errorPanel).not.toBeNull()
+    expect(errorPanel?.textContent).toMatch(/failed to load friend groups/i)
+  })
+
+  it('does NOT show empty-state when error is set', () => {
+    mockGroupsState = { isError: true }
+    // groups stays empty — would have rendered "No friend groups yet"
+    render(
+      <LockGroupPanel isOpen={true} onClose={() => {}} sessionPbId="sess-1" scenarioId="scn-1" />
+    )
+    expect(screen.queryByText(/no friend groups yet/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('LockGroupPanel — AddMemberPicker a11y + portal tagging (#1499 issues #6, #8)', () => {
+  const testGroup = { id: 'group-abc', name: 'The Lovins', color: '#ec4899' }
+
+  it('trigger button exposes aria-haspopup="listbox" and aria-expanded toggles with open state', () => {
+    mockGroups = [testGroup]
+    mockContext.getCamperLockGroup = () => null
+    render(
+      <LockGroupPanel
+        isOpen={true}
+        onClose={() => {}}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        selectedGroupId="group-abc"
+        sessionCampers={[{ id: 'pb-1', person_cm_id: 1000001, name: 'Emma Johnson' } as never]}
+      />
+    )
+    const trigger = screen.getByRole('button', { name: /add member/i })
+    expect(trigger).toHaveAttribute('aria-haspopup', 'listbox')
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    fireEvent.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('Escape key closes the open picker', () => {
+    mockGroups = [testGroup]
+    mockContext.getCamperLockGroup = () => null
+    render(
+      <LockGroupPanel
+        isOpen={true}
+        onClose={() => {}}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        selectedGroupId="group-abc"
+        sessionCampers={[{ id: 'pb-1', person_cm_id: 1000001, name: 'Emma Johnson' } as never]}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /add member/i }))
+    expect(screen.getByPlaceholderText(/filter campers/i)).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByPlaceholderText(/filter campers/i)).not.toBeInTheDocument()
+  })
+
+  it('portaled dropdown carries data-panel="lock-group-picker" so the board click-outside whitelists it', () => {
+    mockGroups = [testGroup]
+    mockContext.getCamperLockGroup = () => null
+    render(
+      <LockGroupPanel
+        isOpen={true}
+        onClose={() => {}}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        selectedGroupId="group-abc"
+        sessionCampers={[{ id: 'pb-1', person_cm_id: 1000001, name: 'Emma Johnson' } as never]}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /add member/i }))
+    const dropdown = document.querySelector('[data-panel="lock-group-picker"]')
+    expect(dropdown).not.toBeNull()
+  })
+})
+
+describe('LockGroupPanel — AddMemberPicker reposition on scroll (#1499 issue #5)', () => {
+  const testGroup = { id: 'group-abc', name: 'The Lovins', color: '#ec4899' }
+
+  it('recomputes dropdown position when window scrolls', () => {
+    mockGroups = [testGroup]
+    mockContext.getCamperLockGroup = () => null
+    render(
+      <LockGroupPanel
+        isOpen={true}
+        onClose={() => {}}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        selectedGroupId="group-abc"
+        sessionCampers={[{ id: 'pb-1', person_cm_id: 1000001, name: 'Emma Johnson' } as never]}
+      />
+    )
+    const trigger = screen.getByRole('button', { name: /add member/i })
+    // Force a non-zero rect from getBoundingClientRect so we can observe a change.
+    const originalGetRect = trigger.getBoundingClientRect.bind(trigger)
+    trigger.getBoundingClientRect = () =>
+      ({
+        top: 100,
+        bottom: 120,
+        left: 200,
+        right: 260,
+        width: 60,
+        height: 20,
+        x: 200,
+        y: 100,
+        toJSON: () => ({}),
+      }) as DOMRect
+    fireEvent.click(trigger)
+    const dropdownBefore = document.querySelector('[data-panel="lock-group-picker"]') as HTMLElement
+    expect(dropdownBefore).not.toBeNull()
+    const topBefore = dropdownBefore.style.top
+    expect(topBefore).toBe('124px') // bottom (120) + 4
+
+    // Simulate scroll: trigger has moved up to y=50
+    trigger.getBoundingClientRect = () =>
+      ({
+        top: 50,
+        bottom: 70,
+        left: 200,
+        right: 260,
+        width: 60,
+        height: 20,
+        x: 200,
+        y: 50,
+        toJSON: () => ({}),
+      }) as DOMRect
+    fireEvent.scroll(window)
+    const dropdownAfter = document.querySelector('[data-panel="lock-group-picker"]') as HTMLElement
+    expect(dropdownAfter.style.top).toBe('74px') // bottom (70) + 4
+
+    trigger.getBoundingClientRect = originalGetRect
   })
 })
 

--- a/frontend/src/components/LockGroupPanel.test.tsx
+++ b/frontend/src/components/LockGroupPanel.test.tsx
@@ -101,6 +101,9 @@ beforeEach(() => {
   mockGroupsState = {}
   mockMembersState = {}
   mockContext.isActionBarVisible = false
+  mockContext.isLockPanelOpen = true
+  mockContext.groups = []
+  mockContext.membersByGroup = {}
   mockContext.selectedGroupId = null
   mockContext.getCamperLockGroup = () => null
   mockContext.addCamperToGroup = vi.fn()

--- a/frontend/src/components/LockGroupPanel.test.tsx
+++ b/frontend/src/components/LockGroupPanel.test.tsx
@@ -17,8 +17,10 @@ vi.mock('@tanstack/react-query', async () => {
   return {
     ...actual,
     useQuery: () => ({ data: mockQueryData, isLoading: false }),
-    useMutation: () => ({
-      mutate: () => {},
+    useMutation: (options: { onSuccess?: (data: unknown, variables: unknown) => void }) => ({
+      mutate: (variables: unknown) => {
+        options?.onSuccess?.(undefined, variables)
+      },
       mutateAsync: () => Promise.resolve(),
       isPending: false,
     }),
@@ -220,5 +222,46 @@ describe('LockGroupPanel — ＋ Add member picker', () => {
     expect(screen.getByPlaceholderText(/filter campers/i)).toBeInTheDocument()
     fireEvent.mouseDown(document.body)
     expect(screen.queryByPlaceholderText(/filter campers/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('LockGroupPanel — deleting the selected group clears selectedGroupId', () => {
+  const testGroup = {
+    id: 'group-abc',
+    name: 'Emma Squad',
+    color: '#ff0000',
+    scenario_id: 'scn-1',
+    session_pb_id: 'sess-1',
+    year: 2026,
+    collectionId: 'col1',
+    collectionName: 'locked_groups',
+    created: '',
+    updated: '',
+  }
+
+  it('calls onGroupSelect(null) when the selected group is deleted', () => {
+    const onGroupSelect = vi.fn()
+    mockQueryData = [testGroup]
+    mockContext.membersByGroup = { 'group-abc': [] }
+
+    // Mock window.confirm to return true (user confirms deletion)
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    render(
+      <LockGroupPanel
+        isOpen={true}
+        onClose={() => {}}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        selectedGroupId="group-abc"
+        onGroupSelect={onGroupSelect}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete group' }))
+
+    expect(onGroupSelect).toHaveBeenCalledWith(null)
+
+    vi.restoreAllMocks()
   })
 })

--- a/frontend/src/components/LockGroupPanel.test.tsx
+++ b/frontend/src/components/LockGroupPanel.test.tsx
@@ -199,4 +199,26 @@ describe('LockGroupPanel — ＋ Add member picker', () => {
     await Promise.resolve()
     expect(addCamperToGroup).toHaveBeenCalledWith(liam, 'group-abc')
   })
+
+  it('closes the picker when clicking outside', () => {
+    mockQueryData = [testGroup]
+    mockContext.groups = [testGroup] as never
+    mockContext.membersByGroup = { 'group-abc': [] }
+    mockContext.selectedGroupId = 'group-abc'
+    mockContext.getCamperLockGroup = () => null
+    render(
+      <LockGroupPanel
+        isOpen={true}
+        onClose={() => {}}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        selectedGroupId="group-abc"
+        sessionCampers={[{ id: 'pb-2', person_cm_id: 1000002, name: 'Liam Garcia' } as never]}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /add member/i }))
+    expect(screen.getByPlaceholderText(/filter campers/i)).toBeInTheDocument()
+    fireEvent.mouseDown(document.body)
+    expect(screen.queryByPlaceholderText(/filter campers/i)).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/LockGroupPanel.test.tsx
+++ b/frontend/src/components/LockGroupPanel.test.tsx
@@ -229,6 +229,27 @@ describe('LockGroupPanel — ＋ Add member picker', () => {
     fireEvent.mouseDown(document.body)
     expect(screen.queryByPlaceholderText(/filter campers/i)).not.toBeInTheDocument()
   })
+
+  it('portaled dropdown uses fixed width w-[260px] to prevent full-viewport stretch', () => {
+    mockQueryData = [testGroup]
+    mockContext.groups = [testGroup] as never
+    mockContext.membersByGroup = { 'group-abc': [] }
+    mockContext.selectedGroupId = 'group-abc'
+    mockContext.getCamperLockGroup = () => null
+    render(
+      <LockGroupPanel
+        isOpen={true}
+        onClose={() => {}}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        selectedGroupId="group-abc"
+        sessionCampers={[{ id: 'pb-2', person_cm_id: 1000002, name: 'Liam Garcia' } as never]}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /add member/i }))
+    const dropdown = screen.getByPlaceholderText(/filter campers/i).closest('div[class]')
+    expect(dropdown?.className).toContain('w-[260px]')
+  })
 })
 
 describe('LockGroupPanel — gender-scoped AddMemberPicker', () => {

--- a/frontend/src/components/LockGroupPanel.test.tsx
+++ b/frontend/src/components/LockGroupPanel.test.tsx
@@ -231,6 +231,105 @@ describe('LockGroupPanel — ＋ Add member picker', () => {
   })
 })
 
+describe('LockGroupPanel — gender-scoped AddMemberPicker', () => {
+  // Member records injected into mockQueryData so membersByGroup['group-abc'] is populated.
+  // The mock returns the same data for both the groups and members queries, so both the
+  // group object and member objects appear in `groups` — member records have no `name`/`color`
+  // and render as additional unnamed group cards, but that doesn't affect picker assertions.
+  const maleOnlyMembers = [
+    {
+      id: 'mem-1',
+      group: 'group-abc',
+      attendee: 'att-1',
+      expand: { attendee: { expand: { person: { id: 'p1', cm_id: 9001, gender: 'M' } } } },
+    },
+    {
+      id: 'mem-2',
+      group: 'group-abc',
+      attendee: 'att-2',
+      expand: { attendee: { expand: { person: { id: 'p2', cm_id: 9002, gender: 'M' } } } },
+    },
+  ]
+  const mixedMembers = [
+    {
+      id: 'mem-3',
+      group: 'group-abc',
+      attendee: 'att-3',
+      expand: { attendee: { expand: { person: { id: 'p3', cm_id: 9003, gender: 'M' } } } },
+    },
+    {
+      id: 'mem-4',
+      group: 'group-abc',
+      attendee: 'att-4',
+      expand: { attendee: { expand: { person: { id: 'p4', cm_id: 9004, gender: 'F' } } } },
+    },
+  ]
+  const testGroup = { id: 'group-abc', name: 'The Lovins', color: '#ec4899' }
+
+  it('locks picker to "M" when all current members are male', () => {
+    mockQueryData = [testGroup, ...maleOnlyMembers]
+    mockContext.getCamperLockGroup = () => null
+    render(
+      <LockGroupPanel
+        isOpen={true}
+        onClose={() => {}}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        selectedGroupId="group-abc"
+        sessionCampers={[
+          { id: 'pb-1', person_cm_id: 1000001, name: 'Riley Sam', gender: 'M' } as never,
+          { id: 'pb-2', person_cm_id: 1000002, name: 'Sophia Lee', gender: 'F' } as never,
+        ]}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /add member/i }))
+    expect(screen.getByRole('button', { name: /riley sam/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /sophia lee/i })).not.toBeInTheDocument()
+  })
+
+  it('does NOT lock picker gender when group has mixed-gender members (AG cabin)', () => {
+    mockQueryData = [testGroup, ...mixedMembers]
+    mockContext.getCamperLockGroup = () => null
+    render(
+      <LockGroupPanel
+        isOpen={true}
+        onClose={() => {}}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        selectedGroupId="group-abc"
+        sessionCampers={[
+          { id: 'pb-1', person_cm_id: 1000001, name: 'Riley Sam', gender: 'M' } as never,
+          { id: 'pb-2', person_cm_id: 1000002, name: 'Sophia Lee', gender: 'F' } as never,
+        ]}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /add member/i }))
+    expect(screen.getByRole('button', { name: /riley sam/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /sophia lee/i })).toBeInTheDocument()
+  })
+
+  it('does NOT lock picker gender when group is empty', () => {
+    mockQueryData = [testGroup] // no members injected → membersByGroup['group-abc'] = []
+    mockContext.getCamperLockGroup = () => null
+    render(
+      <LockGroupPanel
+        isOpen={true}
+        onClose={() => {}}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        selectedGroupId="group-abc"
+        sessionCampers={[
+          { id: 'pb-1', person_cm_id: 1000001, name: 'Riley Sam', gender: 'M' } as never,
+          { id: 'pb-2', person_cm_id: 1000002, name: 'Sophia Lee', gender: 'F' } as never,
+        ]}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /add member/i }))
+    expect(screen.getByRole('button', { name: /riley sam/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /sophia lee/i })).toBeInTheDocument()
+  })
+})
+
 describe('LockGroupPanel — deleting the selected group clears selectedGroupId', () => {
   const testGroup = {
     id: 'group-abc',

--- a/frontend/src/components/LockGroupPanel.test.tsx
+++ b/frontend/src/components/LockGroupPanel.test.tsx
@@ -74,22 +74,28 @@ beforeEach(() => {
 })
 
 describe('LockGroupPanel layout', () => {
-  it('has no bottom-padding class when action bar is hidden', () => {
+  it('has top-0 and bottom-0 classes when action bar is hidden', () => {
     mockContext.isActionBarVisible = false
     const { container } = render(
       <LockGroupPanel isOpen={true} onClose={() => {}} sessionPbId="sess-1" scenarioId="scn-1" />
     )
     const root = container.querySelector('[data-panel="lock-group"]')
+    expect(root?.className).toContain('top-0')
+    expect(root?.className).toContain('bottom-0')
     expect(root?.className).not.toContain('pb-20')
+    expect(root?.className).not.toContain('bottom-20')
   })
 
-  it('adds pb-20 to the panel root when action bar is visible', () => {
+  it('adds bottom-20 (shrinks panel) when action bar is visible instead of padding', () => {
     mockContext.isActionBarVisible = true
     const { container } = render(
       <LockGroupPanel isOpen={true} onClose={() => {}} sessionPbId="sess-1" scenarioId="scn-1" />
     )
     const root = container.querySelector('[data-panel="lock-group"]')
-    expect(root?.className).toContain('pb-20')
+    expect(root?.className).toContain('top-0')
+    expect(root?.className).toContain('bottom-20')
+    expect(root?.className).not.toContain('pb-20')
+    expect(root?.className).not.toContain('bottom-0')
   })
 })
 

--- a/frontend/src/components/LockGroupPanel.test.tsx
+++ b/frontend/src/components/LockGroupPanel.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * LockGroupPanel layout + interaction tests.
+ *
+ * The panel must reserve bottom space (pb-20) when the action bar is visible,
+ * so the fixed-bottom bar isn't covered by the panel.
+ */
+import { render } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock the lazy-loaded panel's React Query consumer.
+vi.mock('@tanstack/react-query', async () => {
+  const actual =
+    await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query')
+  return {
+    ...actual,
+    useQuery: () => ({ data: [], isLoading: false }),
+    useMutation: () => ({
+      mutate: () => {},
+      mutateAsync: () => Promise.resolve(),
+      isPending: false,
+    }),
+    useQueryClient: () => ({ invalidateQueries: () => {} }),
+  }
+})
+vi.mock('../lib/pocketbase', () => ({
+  pb: { collection: () => ({ getList: () => Promise.resolve({ items: [] }) }) },
+}))
+vi.mock('../hooks/useCurrentYear', () => ({ useYear: () => 2026 }))
+
+const mockContext: {
+  isActionBarVisible: boolean
+  isLockPanelOpen: boolean
+  groups: unknown[]
+  membersByGroup: Record<string, unknown[]>
+  selectedGroupId: string | null
+  setSelectedGroupId: ReturnType<typeof vi.fn>
+  setIsLockPanelOpen: ReturnType<typeof vi.fn>
+  scenarioId: string
+  sessionPbId: string
+  isDraftMode: boolean
+  getCamperLockGroup: () => unknown
+} = {
+  isActionBarVisible: false,
+  isLockPanelOpen: true,
+  groups: [],
+  membersByGroup: {},
+  selectedGroupId: null,
+  setSelectedGroupId: vi.fn(),
+  setIsLockPanelOpen: vi.fn(),
+  scenarioId: 'scn-1',
+  sessionPbId: 'sess-1',
+  isDraftMode: true,
+  getCamperLockGroup: () => null,
+}
+vi.mock('../contexts/LockGroupContext', () => ({
+  useLockGroupContext: () => mockContext,
+}))
+
+import LockGroupPanel from './LockGroupPanel'
+
+describe('LockGroupPanel layout', () => {
+  it('has no bottom-padding class when action bar is hidden', () => {
+    mockContext.isActionBarVisible = false
+    const { container } = render(
+      <LockGroupPanel isOpen={true} onClose={() => {}} sessionPbId="sess-1" scenarioId="scn-1" />
+    )
+    const root = container.querySelector('[data-panel="lock-group"]')
+    expect(root?.className).not.toContain('pb-20')
+  })
+
+  it('adds pb-20 to the panel root when action bar is visible', () => {
+    mockContext.isActionBarVisible = true
+    const { container } = render(
+      <LockGroupPanel isOpen={true} onClose={() => {}} sessionPbId="sess-1" scenarioId="scn-1" />
+    )
+    const root = container.querySelector('[data-panel="lock-group"]')
+    expect(root?.className).toContain('pb-20')
+  })
+})

--- a/frontend/src/components/LockGroupPanel.tsx
+++ b/frontend/src/components/LockGroupPanel.tsx
@@ -175,7 +175,7 @@ function AddMemberPicker({
         createPortal(
           <div
             ref={dropdownRef}
-            className="bg-background fixed z-50 min-w-[220px] rounded-lg border shadow-lg"
+            className="bg-background fixed z-50 w-[260px] rounded-lg border shadow-lg"
             style={{ top: dropdownPos.top, left: dropdownPos.left }}
           >
             <input
@@ -535,7 +535,7 @@ function LockGroupPanel({
     <div
       data-panel="lock-group"
       className={clsx(
-        'bg-background fixed top-0 left-0 z-50 w-96 border-r shadow-xl',
+        'bg-background fixed top-0 left-0 z-50 w-96 border-r shadow-xl transition-[bottom] duration-200 ease-out',
         isClosing ? 'animate-slide-out-left' : 'animate-slide-in-left',
         isActionBarVisible ? 'bottom-20' : 'bottom-0'
       )}

--- a/frontend/src/components/LockGroupPanel.tsx
+++ b/frontend/src/components/LockGroupPanel.tsx
@@ -460,18 +460,13 @@ function LockGroupPanel({
                     {/* Group Header */}
                     <div
                       data-group-id={group.id}
-                      className={clsx(
-                        'hover:bg-muted/50 cursor-pointer p-4 transition-colors',
-                        selectedGroupId === group.id && 'border-l-4'
-                      )}
-                      style={
-                        selectedGroupId === group.id
-                          ? {
-                              borderLeftColor: group.color,
-                              backgroundColor: `${group.color}1a`,
-                            }
-                          : undefined
-                      }
+                      className="hover:bg-muted/50 cursor-pointer border-l-4 p-4 transition-colors"
+                      style={{
+                        borderLeftColor: group.color,
+                        ...(selectedGroupId === group.id && {
+                          backgroundColor: `${group.color}1a`,
+                        }),
+                      }}
                       onClick={() => {
                         setExpandedGroupId(isExpanded ? null : group.id)
                         onGroupSelect?.(isExpanded ? null : group.id)

--- a/frontend/src/components/LockGroupPanel.tsx
+++ b/frontend/src/components/LockGroupPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { X, Trash2, Users, ChevronRight, AlertTriangle } from 'lucide-react'
+import { X, Trash2, Users, ChevronRight, AlertTriangle, Plus } from 'lucide-react'
 import clsx from 'clsx'
 import { pb } from '../lib/pocketbase'
 import { useYear } from '../hooks/useCurrentYear'
@@ -18,15 +18,16 @@ import { isAgSession } from '../utils/sessionTypePredicates'
 type BunkArea = 'all' | 'boys' | 'girls' | 'all-gender'
 
 interface LockGroupPanelProps {
-  isOpen: boolean
-  onClose: () => void
-  sessionPbId: string
-  scenarioId: string
+  isOpen?: boolean
+  onClose?: () => void
+  sessionPbId?: string
+  scenarioId?: string
   selectedGroupId?: string | null
   onGroupSelect?: (groupId: string | null) => void
   requestClose?: boolean // When true, triggers animated close
   selectedArea?: BunkArea
   campers?: Camper[] // All campers - used for area filtering
+  sessionCampers?: Camper[] // All session campers - used for Add Member picker
 }
 
 // Type for members with expanded attendee and person
@@ -81,20 +82,97 @@ function camperMatchesArea(camper: Camper, area: BunkArea): boolean {
   return camper.gender === 'F'
 }
 
+interface AddMemberPickerProps {
+  groupId: string
+  sessionCampers: Camper[]
+  getCamperLockGroup: (cmId: number) => unknown
+  addCamperToGroup: (camper: Camper, groupId: string) => Promise<void>
+}
+
+function AddMemberPicker({
+  groupId,
+  sessionCampers,
+  getCamperLockGroup,
+  addCamperToGroup,
+}: AddMemberPickerProps) {
+  const [open, setOpen] = useState(false)
+  const [filter, setFilter] = useState('')
+
+  const eligible = useMemo(
+    () =>
+      sessionCampers.filter(
+        (c) =>
+          !getCamperLockGroup(c.person_cm_id) &&
+          (c.name ?? '').toLowerCase().includes(filter.toLowerCase())
+      ),
+    [sessionCampers, getCamperLockGroup, filter]
+  )
+
+  const handleSelect = (camper: Camper) => {
+    void addCamperToGroup(camper, groupId)
+    setOpen(false)
+    setFilter('')
+  }
+
+  return (
+    <div className="relative mt-3">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm"
+        aria-label="Add member"
+      >
+        <Plus className="h-3.5 w-3.5" />
+        Add member
+      </button>
+
+      {open && (
+        <div className="bg-background absolute z-10 mt-1 w-full rounded-lg border shadow-lg">
+          <input
+            autoFocus
+            type="text"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Search campers…"
+            className="w-full rounded-t-lg border-b px-3 py-2 text-sm outline-none"
+          />
+          <div className="max-h-48 overflow-y-auto">
+            {eligible.length === 0 ? (
+              <p className="text-muted-foreground px-3 py-2 text-sm">
+                All session campers are already in a group.
+              </p>
+            ) : (
+              eligible.map((c) => (
+                <button
+                  key={c.id}
+                  onClick={() => handleSelect(c)}
+                  className="hover:bg-muted w-full px-3 py-1.5 text-left text-sm"
+                >
+                  {c.name}
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
 function LockGroupPanel({
-  isOpen,
-  onClose,
-  sessionPbId,
-  scenarioId,
+  isOpen = false,
+  onClose = () => {},
+  sessionPbId = '',
+  scenarioId = '',
   selectedGroupId,
   onGroupSelect,
   requestClose = false,
   selectedArea = 'all',
   campers = [],
+  sessionCampers = [],
 }: LockGroupPanelProps) {
   const queryClient = useQueryClient()
   const currentYear = useYear()
-  const { isActionBarVisible } = useLockGroupContext()
+  const { isActionBarVisible, getCamperLockGroup, addCamperToGroup } = useLockGroupContext()
 
   // Track expanded group - derive from prop or allow local overrides
   const [localExpandedGroupId, setLocalExpandedGroupId] = useState<string | null>(null)
@@ -616,6 +694,14 @@ function LockGroupPanel({
                             </div>
                           )}
                         </div>
+
+                        {/* Add Member Picker */}
+                        <AddMemberPicker
+                          groupId={group.id}
+                          sessionCampers={sessionCampers}
+                          getCamperLockGroup={getCamperLockGroup}
+                          addCamperToGroup={addCamperToGroup}
+                        />
                       </div>
                     )}
                   </div>

--- a/frontend/src/components/LockGroupPanel.tsx
+++ b/frontend/src/components/LockGroupPanel.tsx
@@ -42,6 +42,7 @@ type ExpandedMember = LockedGroupMembersResponse & {
           first_name?: string
           last_name?: string
           preferred_name?: string
+          gender?: string
         }
         session?: {
           id: string
@@ -88,6 +89,7 @@ interface AddMemberPickerProps {
   sessionCampers: Camper[]
   getCamperLockGroup: (cmId: number) => unknown
   addCamperToGroup: (camper: Camper, groupId: string) => Promise<void>
+  members: ExpandedMember[]
 }
 
 function AddMemberPicker({
@@ -95,6 +97,7 @@ function AddMemberPicker({
   sessionCampers,
   getCamperLockGroup,
   addCamperToGroup,
+  members,
 }: AddMemberPickerProps) {
   const [open, setOpen] = useState(false)
   const [filter, setFilter] = useState('')
@@ -102,14 +105,26 @@ function AddMemberPicker({
   const dropdownRef = useRef<HTMLDivElement>(null)
   const [dropdownPos, setDropdownPos] = useState<{ top: number; left: number } | null>(null)
 
+  // Determine if the group has a homogeneous gender so we can filter the picker.
+  // Mixed-gender groups (AG cabin pattern) or empty groups show all eligible campers.
+  const lockedGender = useMemo<string | null>(() => {
+    const genders = new Set<string>()
+    for (const m of members) {
+      const g = m.expand?.attendee?.expand?.person?.gender
+      if (g) genders.add(g)
+    }
+    return genders.size === 1 ? (Array.from(genders)[0] ?? null) : null
+  }, [members])
+
   const eligible = useMemo(
     () =>
       sessionCampers.filter(
         (c) =>
           !getCamperLockGroup(c.person_cm_id) &&
+          (lockedGender === null || c.gender === lockedGender) &&
           (c.name ?? '').toLowerCase().includes(filter.toLowerCase())
       ),
-    [sessionCampers, getCamperLockGroup, filter]
+    [sessionCampers, getCamperLockGroup, lockedGender, filter]
   )
 
   // Recompute position when opening
@@ -743,6 +758,7 @@ function LockGroupPanel({
                           sessionCampers={sessionCampers}
                           getCamperLockGroup={getCamperLockGroup}
                           addCamperToGroup={addCamperToGroup}
+                          members={members}
                         />
                       </div>
                     )}

--- a/frontend/src/components/LockGroupPanel.tsx
+++ b/frontend/src/components/LockGroupPanel.tsx
@@ -520,9 +520,9 @@ function LockGroupPanel({
     <div
       data-panel="lock-group"
       className={clsx(
-        'bg-background fixed inset-y-0 left-0 z-50 w-96 border-r shadow-xl',
+        'bg-background fixed top-0 left-0 z-50 w-96 border-r shadow-xl',
         isClosing ? 'animate-slide-out-left' : 'animate-slide-in-left',
-        isActionBarVisible && 'pb-20'
+        isActionBarVisible ? 'bottom-20' : 'bottom-0'
       )}
     >
       <div className="flex h-full flex-col">

--- a/frontend/src/components/LockGroupPanel.tsx
+++ b/frontend/src/components/LockGroupPanel.tsx
@@ -1,4 +1,5 @@
-import { useState, useCallback, useMemo } from 'react'
+import { useState, useCallback, useMemo, useRef, useEffect } from 'react'
+import { createPortal } from 'react-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { X, Trash2, Users, ChevronRight, AlertTriangle, Plus } from 'lucide-react'
 import clsx from 'clsx'
@@ -97,6 +98,9 @@ function AddMemberPicker({
 }: AddMemberPickerProps) {
   const [open, setOpen] = useState(false)
   const [filter, setFilter] = useState('')
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  const [dropdownPos, setDropdownPos] = useState<{ top: number; left: number } | null>(null)
 
   const eligible = useMemo(
     () =>
@@ -108,6 +112,30 @@ function AddMemberPicker({
     [sessionCampers, getCamperLockGroup, filter]
   )
 
+  // Recompute position when opening
+  useEffect(() => {
+    if (!open) return
+    const rect = triggerRef.current?.getBoundingClientRect()
+    if (rect) {
+      setDropdownPos({ top: rect.bottom + 4, left: rect.left })
+    }
+  }, [open])
+
+  // Outside-click dismissal
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node
+      if (triggerRef.current?.contains(target) || dropdownRef.current?.contains(target)) {
+        return
+      }
+      setOpen(false)
+      setFilter('')
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
   const handleSelect = (camper: Camper) => {
     void addCamperToGroup(camper, groupId)
     setOpen(false)
@@ -117,6 +145,8 @@ function AddMemberPicker({
   return (
     <div className="relative mt-3">
       <button
+        ref={triggerRef}
+        type="button"
         onClick={() => setOpen((o) => !o)}
         className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm"
         aria-label="Add member"
@@ -125,35 +155,43 @@ function AddMemberPicker({
         Add member
       </button>
 
-      {open && (
-        <div className="bg-background absolute z-10 mt-1 w-full rounded-lg border shadow-lg">
-          <input
-            autoFocus
-            type="text"
-            value={filter}
-            onChange={(e) => setFilter(e.target.value)}
-            placeholder="Search campers…"
-            className="w-full rounded-t-lg border-b px-3 py-2 text-sm outline-none"
-          />
-          <div className="max-h-48 overflow-y-auto">
-            {eligible.length === 0 ? (
-              <p className="text-muted-foreground px-3 py-2 text-sm">
-                All session campers are already in a group.
-              </p>
-            ) : (
-              eligible.map((c) => (
-                <button
-                  key={c.id}
-                  onClick={() => handleSelect(c)}
-                  className="hover:bg-muted w-full px-3 py-1.5 text-left text-sm"
-                >
-                  {c.name}
-                </button>
-              ))
-            )}
-          </div>
-        </div>
-      )}
+      {open &&
+        dropdownPos !== null &&
+        createPortal(
+          <div
+            ref={dropdownRef}
+            className="bg-background fixed z-50 min-w-[220px] rounded-lg border shadow-lg"
+            style={{ top: dropdownPos.top, left: dropdownPos.left }}
+          >
+            <input
+              autoFocus
+              type="text"
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder="Filter campers…"
+              className="w-full rounded-t-lg border-b px-3 py-2 text-sm outline-none"
+            />
+            <div className="max-h-48 overflow-y-auto">
+              {eligible.length === 0 ? (
+                <p className="text-muted-foreground px-3 py-2 text-sm">
+                  All session campers are already in a group.
+                </p>
+              ) : (
+                eligible.map((c) => (
+                  <button
+                    key={c.id}
+                    type="button"
+                    onClick={() => handleSelect(c)}
+                    className="hover:bg-muted w-full px-3 py-1.5 text-left text-sm"
+                  >
+                    {c.name}
+                  </button>
+                ))
+              )}
+            </div>
+          </div>,
+          document.body
+        )}
     </div>
   )
 }

--- a/frontend/src/components/LockGroupPanel.tsx
+++ b/frontend/src/components/LockGroupPanel.tsx
@@ -94,7 +94,7 @@ function LockGroupPanel({
 }: LockGroupPanelProps) {
   const queryClient = useQueryClient()
   const currentYear = useYear()
-  useLockGroupContext() // Keep context subscription for future use
+  const { isActionBarVisible } = useLockGroupContext()
 
   // Track expanded group - derive from prop or allow local overrides
   const [localExpandedGroupId, setLocalExpandedGroupId] = useState<string | null>(null)
@@ -402,7 +402,8 @@ function LockGroupPanel({
       data-panel="lock-group"
       className={clsx(
         'bg-background fixed inset-y-0 left-0 z-50 w-96 border-r shadow-xl',
-        isClosing ? 'animate-slide-out-left' : 'animate-slide-in-left'
+        isClosing ? 'animate-slide-out-left' : 'animate-slide-in-left',
+        isActionBarVisible && 'pb-20'
       )}
     >
       <div className="flex h-full flex-col">

--- a/frontend/src/components/LockGroupPanel.tsx
+++ b/frontend/src/components/LockGroupPanel.tsx
@@ -88,7 +88,7 @@ interface AddMemberPickerProps {
   groupId: string
   sessionCampers: Camper[]
   getCamperLockGroup: (cmId: number) => unknown
-  addCamperToGroup: (camper: Camper, groupId: string) => Promise<void>
+  addCamperToGroup: (camper: Camper, groupId: string) => Promise<boolean>
   members: ExpandedMember[]
 }
 
@@ -106,11 +106,14 @@ function AddMemberPicker({
   const [dropdownPos, setDropdownPos] = useState<{ top: number; left: number } | null>(null)
 
   // Determine if the group has a homogeneous gender so we can filter the picker.
+  // Gender lives on the attendee, not the person — matches getMemberGender() below.
   // Mixed-gender groups (AG cabin pattern) or empty groups show all eligible campers.
   const lockedGender = useMemo<string | null>(() => {
     const genders = new Set<string>()
     for (const m of members) {
-      const g = m.expand?.attendee?.expand?.person?.gender
+      const attendee = m.expand?.attendee
+      const g =
+        attendee && 'gender' in attendee ? (attendee as { gender?: string }).gender : undefined
       if (g) genders.add(g)
     }
     return genders.size === 1 ? (Array.from(genders)[0] ?? null) : null
@@ -127,12 +130,21 @@ function AddMemberPicker({
     [sessionCampers, getCamperLockGroup, lockedGender, filter]
   )
 
-  // Recompute position when opening
+  // Position recompute — runs on open, on window scroll (capture phase to
+  // catch the inner panel scroller), and on resize so the dropdown stays
+  // anchored to the trigger.
   useEffect(() => {
     if (!open) return
-    const rect = triggerRef.current?.getBoundingClientRect()
-    if (rect) {
-      setDropdownPos({ top: rect.bottom + 4, left: rect.left })
+    const recompute = () => {
+      const rect = triggerRef.current?.getBoundingClientRect()
+      if (rect) setDropdownPos({ top: rect.bottom + 4, left: rect.left })
+    }
+    recompute()
+    window.addEventListener('scroll', recompute, true)
+    window.addEventListener('resize', recompute)
+    return () => {
+      window.removeEventListener('scroll', recompute, true)
+      window.removeEventListener('resize', recompute)
     }
   }, [open])
 
@@ -151,6 +163,21 @@ function AddMemberPicker({
     return () => document.removeEventListener('mousedown', handler)
   }, [open])
 
+  // Escape dismisses the picker. Capture phase so we stop it before outer
+  // modal listeners (e.g. CamperDetailsPanel) react.
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      e.stopPropagation()
+      setOpen(false)
+      setFilter('')
+      triggerRef.current?.focus()
+    }
+    document.addEventListener('keydown', handler, true)
+    return () => document.removeEventListener('keydown', handler, true)
+  }, [open])
+
   const handleSelect = (camper: Camper) => {
     void addCamperToGroup(camper, groupId)
     setOpen(false)
@@ -165,6 +192,8 @@ function AddMemberPicker({
         onClick={() => setOpen((o) => !o)}
         className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm"
         aria-label="Add member"
+        aria-haspopup="listbox"
+        aria-expanded={open}
       >
         <Plus className="h-3.5 w-3.5" />
         Add member
@@ -175,6 +204,7 @@ function AddMemberPicker({
         createPortal(
           <div
             ref={dropdownRef}
+            data-panel="lock-group-picker"
             className="bg-background fixed z-50 w-[260px] rounded-lg border shadow-lg"
             style={{ top: dropdownPos.top, left: dropdownPos.left }}
           >
@@ -186,7 +216,7 @@ function AddMemberPicker({
               placeholder="Filter campers…"
               className="w-full rounded-t-lg border-b px-3 py-2 text-sm outline-none"
             />
-            <div className="max-h-48 overflow-y-auto">
+            <div role="listbox" className="max-h-48 overflow-y-auto">
               {eligible.length === 0 ? (
                 <p className="text-muted-foreground px-3 py-2 text-sm">
                   All session campers are already in a group.
@@ -196,6 +226,8 @@ function AddMemberPicker({
                   <button
                     key={c.id}
                     type="button"
+                    role="option"
+                    aria-selected={false}
                     onClick={() => handleSelect(c)}
                     className="hover:bg-muted w-full px-3 py-1.5 text-left text-sm"
                   >
@@ -256,7 +288,11 @@ function LockGroupPanel({
   }
 
   // Fetch lock groups for the scenario, session, and year
-  const { data: groups = [], isLoading: groupsLoading } = useQuery({
+  const {
+    data: groups = [],
+    isLoading: groupsLoading,
+    isError: groupsError,
+  } = useQuery({
     queryKey: ['locked-groups-panel', scenarioId, sessionPbId, currentYear],
     queryFn: async () => {
       const result = await pb.collection('locked_groups').getList<LockedGroupsResponse>(1, 500, {
@@ -273,7 +309,11 @@ function LockGroupPanel({
   })
 
   // Fetch all group members with expanded attendee -> person and session
-  const { data: allMembers = [], isLoading: membersLoading } = useQuery({
+  const {
+    data: allMembers = [],
+    isLoading: membersLoading,
+    isError: membersError,
+  } = useQuery({
     queryKey: ['locked-group-members-panel', scenarioId, sessionPbId, groups.length],
     queryFn: async () => {
       if (groups.length === 0) return []
@@ -293,16 +333,19 @@ function LockGroupPanel({
     enabled: isOpen && groups.length > 0,
   })
 
-  // Group members by group ID
-  const membersByGroup = allMembers.reduce<Record<string, ExpandedMember[]>>(
-    (acc: Record<string, ExpandedMember[]>, member: ExpandedMember) => {
-      const groupId = member.group
-      acc[groupId] ??= []
-      acc[groupId].push(member)
-      return acc
-    },
-    {}
-  )
+  // Group members by group ID. Memoized so its object identity is stable
+  // across renders — sortedGroups and filteredGroups depend on it.
+  const membersByGroup = useMemo<Record<string, ExpandedMember[]>>(() => {
+    return allMembers.reduce<Record<string, ExpandedMember[]>>(
+      (acc: Record<string, ExpandedMember[]>, member: ExpandedMember) => {
+        const groupId = member.group
+        acc[groupId] ??= []
+        acc[groupId].push(member)
+        return acc
+      },
+      {}
+    )
+  }, [allMembers])
 
   // Helper to get age from member (year-aware for historical viewing)
   const getMemberAge = useCallback(
@@ -528,6 +571,7 @@ function LockGroupPanel({
   }
 
   const isLoading = groupsLoading || membersLoading
+  const isQueryError = groupsError || membersError
 
   if (!isOpen) return null
 
@@ -558,6 +602,18 @@ function LockGroupPanel({
         <div className="flex-1 overflow-y-auto">
           {isLoading ? (
             <div className="text-muted-foreground p-6 text-center">Loading groups...</div>
+          ) : isQueryError ? (
+            <div data-panel-error className="p-6 text-center">
+              <AlertTriangle className="text-destructive mx-auto mb-4 h-12 w-12" />
+              <p className="text-destructive mb-2 font-medium">Failed to load friend groups</p>
+              <p className="text-muted-foreground text-sm">
+                {groupsError && membersError
+                  ? 'Both groups and members queries failed. Check your connection and try again.'
+                  : groupsError
+                    ? 'Could not load the friend groups list.'
+                    : 'Could not load group membership.'}
+              </p>
+            </div>
           ) : groups.length === 0 ? (
             <div className="p-6 text-center">
               <Users className="text-muted-foreground mx-auto mb-4 h-12 w-12" />

--- a/frontend/src/components/LockGroupPanel.tsx
+++ b/frontend/src/components/LockGroupPanel.tsx
@@ -459,8 +459,19 @@ function LockGroupPanel({
                   >
                     {/* Group Header */}
                     <div
-                      className="hover:bg-muted/50 cursor-pointer border-l-4 p-4 transition-colors"
-                      style={{ borderLeftColor: group.color }}
+                      data-group-id={group.id}
+                      className={clsx(
+                        'hover:bg-muted/50 cursor-pointer p-4 transition-colors',
+                        selectedGroupId === group.id && 'border-l-4'
+                      )}
+                      style={
+                        selectedGroupId === group.id
+                          ? {
+                              borderLeftColor: group.color,
+                              backgroundColor: `${group.color}1a`,
+                            }
+                          : undefined
+                      }
                       onClick={() => {
                         setExpandedGroupId(isExpanded ? null : group.id)
                         onGroupSelect?.(isExpanded ? null : group.id)

--- a/frontend/src/components/LockGroupPanel.tsx
+++ b/frontend/src/components/LockGroupPanel.tsx
@@ -391,7 +391,7 @@ function LockGroupPanel({
       // Then delete the group
       return await pb.collection('locked_groups').delete(groupId)
     },
-    onSuccess: () => {
+    onSuccess: (_data, deletedGroupId) => {
       void queryClient.invalidateQueries({
         queryKey: ['locked-groups', scenarioId, sessionPbId, currentYear],
       })
@@ -404,6 +404,9 @@ function LockGroupPanel({
       void queryClient.invalidateQueries({
         queryKey: ['locked-group-members-panel', scenarioId, sessionPbId],
       })
+      if (deletedGroupId === selectedGroupId) {
+        onGroupSelect?.(null)
+      }
     },
   })
 
@@ -618,6 +621,7 @@ function LockGroupPanel({
                             }}
                             className="hover:bg-muted rounded p-1"
                             title="Delete group"
+                            aria-label="Delete group"
                           >
                             <Trash2 className="text-destructive h-4 w-4" />
                           </button>

--- a/frontend/src/contexts/LockGroupContext.test.tsx
+++ b/frontend/src/contexts/LockGroupContext.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * LockGroupContext derived state tests.
+ *
+ * The provider derives `isActionBarVisible` from `pendingCampers.length > 0` so
+ * both side panels can read it without re-deriving.
+ */
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import type { Camper } from '../types/app-types'
+
+// Mock everything LockGroupProvider transitively pulls in.
+vi.mock('@tanstack/react-query', async () => {
+  const actual =
+    await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query')
+  return {
+    ...actual,
+    useQuery: () => ({ data: [], isLoading: false }),
+    useQueryClient: () => ({ invalidateQueries: () => {} }),
+  }
+})
+vi.mock('../lib/pocketbase', () => ({
+  pb: {
+    collection: () => ({ create: () => Promise.resolve({ id: 'x' }) }),
+    authStore: { record: { email: 'test@example.com' } },
+    filter: (s: string) => s,
+  },
+}))
+vi.mock('../hooks/useCurrentYear', () => ({ useYear: () => 2026 }))
+vi.mock('../hooks/useScenario', () => ({
+  useScenario: () => ({
+    currentScenario: { id: 'scenario-1' },
+    isProductionMode: false,
+  }),
+}))
+vi.mock('../hooks/useGroupConflictConfirm', () => ({
+  useGroupConflictConfirm: () => ({
+    dialogState: { isOpen: false },
+    checkConflict: () => Promise.resolve('confirmed'),
+  }),
+}))
+vi.mock('react-hot-toast', () => ({
+  toast: { success: () => {}, error: () => {} },
+  default: { success: () => {}, error: () => {} },
+}))
+
+import { LockGroupProvider, useLockGroupContext } from './LockGroupContext'
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <LockGroupProvider>{children}</LockGroupProvider>
+)
+
+const fakeCamper = (overrides: Partial<Camper> = {}): Camper =>
+  ({
+    id: 'pb-1',
+    person_cm_id: 1000001,
+    name: 'Emma Johnson',
+    grade: 5,
+    gender: 'F',
+    assigned_bunk: '',
+    assigned_bunk_cm_id: null,
+    attendee_id: 'att-1',
+    ...overrides,
+  }) as unknown as Camper
+
+describe('LockGroupContext.isActionBarVisible', () => {
+  it('is false when no campers are pending', () => {
+    const { result } = renderHook(() => useLockGroupContext(), { wrapper })
+    expect(result.current.isActionBarVisible).toBe(false)
+  })
+
+  it('flips to true when a camper is added to pending', () => {
+    const { result } = renderHook(() => useLockGroupContext(), { wrapper })
+    act(() => {
+      result.current.addPendingCamper(fakeCamper())
+    })
+    expect(result.current.isActionBarVisible).toBe(true)
+  })
+
+  it('returns to false when pending list is cleared', () => {
+    const { result } = renderHook(() => useLockGroupContext(), { wrapper })
+    act(() => {
+      result.current.addPendingCamper(fakeCamper())
+    })
+    expect(result.current.isActionBarVisible).toBe(true)
+    act(() => {
+      result.current.clearPendingCampers()
+    })
+    expect(result.current.isActionBarVisible).toBe(false)
+  })
+})

--- a/frontend/src/contexts/LockGroupContext.tsx
+++ b/frontend/src/contexts/LockGroupContext.tsx
@@ -43,6 +43,8 @@ interface LockGroupContextValue {
   clearPendingCampers: () => void
   isPending: (camperId: string) => boolean
   getPendingAnimationDelay: (camperId: string) => number // Per-camper delay for synced glow
+  // Derived: visible whenever there are pending campers
+  isActionBarVisible: boolean
 
   // Lock groups data
   groups: LockedGroupsResponse[]
@@ -354,9 +356,12 @@ export function LockGroupProvider({ children }: LockGroupProviderProps) {
     ]
   )
 
+  const isActionBarVisible = pendingCampers.length > 0
+
   const value: LockGroupContextValue = {
     // Pending campers
     pendingCampers,
+    isActionBarVisible,
     addPendingCamper,
     removePendingCamper,
     clearPendingCampers,

--- a/frontend/src/contexts/LockGroupContext.tsx
+++ b/frontend/src/contexts/LockGroupContext.tsx
@@ -57,7 +57,12 @@ interface LockGroupContextValue {
   getCamperLockState: (camperCmId: number) => 'none' | 'pending' | 'locked'
   getCamperLockGroupColor: (camperCmId: number) => string | undefined
   getGroupMembers: (groupId: string) => number[] // Returns person CM IDs
-  addCamperToGroup: (camper: Camper, groupId: string) => Promise<void> // Add camper directly to existing group
+  // Add camper directly to existing group. Returns true on success (PB write
+  // confirmed) and false on any failure path: not in draft mode, missing
+  // attendee id, conflict cancelled by staff, or PB error. Callers iterating
+  // over multiple campers should check the return value before clearing
+  // pending state.
+  addCamperToGroup: (camper: Camper, groupId: string) => Promise<boolean>
 
   // UI state
   selectedGroupId: string | null
@@ -285,10 +290,13 @@ export function LockGroupProvider({ children }: LockGroupProviderProps) {
     [membersByGroup]
   )
 
-  // Add camper directly to an existing lock group
+  // Add camper directly to an existing lock group. Returns true iff the PB
+  // write succeeded; false for every "didn't happen" path (not draft, missing
+  // attendee id, conflict cancelled, PB error) so iterating callers can avoid
+  // clearing pending state on partial failure.
   const addCamperToGroup = useCallback(
-    async (camper: Camper, groupId: string) => {
-      if (!isDraftMode) return
+    async (camper: Camper, groupId: string): Promise<boolean> => {
+      if (!isDraftMode) return false
 
       // Get the attendee PB ID from the camper
       const attendeePbId = camper.attendee_id ?? camper.id
@@ -296,7 +304,7 @@ export function LockGroupProvider({ children }: LockGroupProviderProps) {
       if (!attendeePbId) {
         console.error('Camper missing attendee_id')
         toast.error('Cannot add camper: missing attendee ID')
-        return
+        return false
       }
 
       // If camper is already in a different group in this scenario, confirm with staff
@@ -312,7 +320,7 @@ export function LockGroupProvider({ children }: LockGroupProviderProps) {
           targetGroupName,
           scenarioId,
         })
-        if (outcome === 'cancelled') return
+        if (outcome === 'cancelled') return false
       }
 
       try {
@@ -339,9 +347,11 @@ export function LockGroupProvider({ children }: LockGroupProviderProps) {
         const group = groups.find((g) => g.id === groupId)
         const groupName = group?.name ?? 'friend group'
         toast.success(`Added ${camper.name} to ${groupName}`)
+        return true
       } catch (error) {
         console.error('Failed to add camper to group:', error)
         toast.error('Failed to add camper to group')
+        return false
       }
     },
     [

--- a/frontend/src/utils/clickoutsidePredicate.ts
+++ b/frontend/src/utils/clickoutsidePredicate.ts
@@ -1,0 +1,34 @@
+/**
+ * Predicate used by BunkingBoardByArea's global click-outside handler to decide
+ * whether a click should dismiss the side panels (CamperDetailsPanel /
+ * LockGroupPanel). Returns true iff the click should NOT trigger dismiss.
+ *
+ * Shared between the live handler and its unit test so the two cannot drift.
+ */
+export function shouldKeepPanelsOpen(e: {
+  ctrlKey: boolean
+  metaKey: boolean
+  target: EventTarget | null
+}): boolean {
+  // Ctrl/Meta-modified clicks are reserved for the friend-group selection
+  // workflow and must never dismiss panels.
+  if (e.ctrlKey || e.metaKey) return true
+
+  const target = e.target as HTMLElement | null
+  if (!target || typeof target.closest !== 'function') return false
+
+  const isOnPanel = target.closest(
+    '[data-panel="camper-details"], [data-panel="lock-group"], [data-panel="lock-action-bar"], [data-panel="lock-group-picker"]'
+  )
+  const isOnFloatingBadge = target.closest('[data-floating-badge]')
+  const isInteractive = target.closest(
+    'button, a, input, select, textarea, [role="button"], [role="menu"], [role="menuitem"]'
+  )
+  const isContextMenu = target.closest('[data-context-menu]')
+  const isModal = target.closest('[role="dialog"]')
+  const isCard = target.closest('[data-camper-card], [data-bunk-card]')
+
+  return Boolean(
+    isOnPanel ?? isOnFloatingBadge ?? isInteractive ?? isContextMenu ?? isModal ?? isCard
+  )
+}


### PR DESCRIPTION
## Summary

Bundles 5 related UX improvements to the friend-group surface (`/summer/session/{session}/requests`):

- **#1369-A** — In-panel `＋ Add member` button + searchable picker in `LockGroupPanel`. Filters out campers already in any group; gender-scopes candidates by current members (B/G cabin pattern); uses the existing `addCamperToGroup` mutation. Dropdown portals into `document.body` to escape parent `overflow-hidden` clipping and dismisses on outside-click.
- **#1369-B** — `LockGroupActionBar` branches on `selectedGroupId`: when a group is expanded in the panel, the bar reads *"Add N to {name}"* in the group's color stripe + tint, and clicking *"Add to group"* iterates pending campers through `addCamperToGroup` instead of creating a new group. Create-new path is unchanged when no group is selected.
- **#1372** — Sticky `CamperDetailsPanel`: tightened global click-outside handler in `BunkingBoardByArea` to bypass on Ctrl/Meta-click + whitelist `[data-panel="lock-action-bar"]`. Removed the panel's own backdrop click-trap (now `pointer-events-none`) so the global handler is the sole arbiter — plain click on another camper swaps target, Ctrl+click adds to pending without closing.
- **NEW** — Ctrl+click on a locked camper opens `LockGroupPanel` (if closed) and selects that camper's group, mirroring the existing right-click "Manage Friend Group" gesture in Ctrl+click muscle memory.
- **NEW** — Both side panels actually shrink (`bottom-20` with a 200ms transition) when the bottom action bar is mounted, so the bar is never covered regardless of mount order. The bar's add-mode tint is layered via `backgroundImage` over an opaque `bg-background` base so the bar reads as solid color, not see-through.

## Visual treatment (α subtle)

When `selectedGroupId === group.id`, the panel header keeps its always-on group-color stripe (group identity) and gains a 10%-tinted background (selection indicator). The action bar mirrors with a matching stripe + ~25%-tinted overlay so it stays clearly visible against the page. The CTA color matches the group color.

## Out of scope

- Bulk-add via the in-panel picker (single-select; trivial follow-up if asked).
- Known bug: right-click context menu on a camper card does not work while `CamperDetailsPanel` is open — fixing it would require strict-X-only dismiss on the right panel (broader scope than #1372). The in-panel `＋ Add member` button is the canonical discoverable path and works regardless of right-panel state.

## Test plan

- [x] Vitest: context derivation, panel padding+positioning, bar branching/copy/mutation routing, Ctrl+click-on-locked, click-outside predicate, picker filter/portal/outside-click/gender-scope, backdrop click-through (all 3 render paths), bar background layering, delete clears selectedGroupId — 4331 passing, 0 failing
- [x] Manual preview on the worktree's dev server — all 5 journeys walked, edge cases verified (right-panel open + click another camper → swaps, not closes; bar opaque in add mode; picker width constrained; α-stripe stays on for non-selected groups too)
- [x] `npm run type-check` + `npm run lint` + prettier all clean; lefthook pre-push hooks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add-member picker to add session campers to existing lock groups.
  * Ctrl/Cmd-click on a locked camper opens the lock panel and selects their group.
  * "Add to group" flow to sequentially add pending campers with re-entrancy protection.

* **Improvements**
  * Slide panels and lock UI adjust positioning when action bars are visible.
  * Click-outside logic now preserves panels for Ctrl/Meta clicks and interactions with action-bar/picker elements.
  * Action bar visibility toggles when pending campers exist.

* **Tests**
  * Significantly expanded test coverage across lock groups, pickers, panels, click-dismiss, and action-bar behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1499?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->