### PR TITLE
fix(sync): check session_cm_ids in parent-surname fast path (#1496)

### DIFF
--- a/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
@@ -389,8 +389,13 @@ class ExactMatchStrategy(BaseMatchStrategy):
             if len(matches) == 1:
                 confidence = 0.90  # Base for parent surname match
                 if session_cm_id and attendee_info:
-                    match_session = attendee_info.get(matches[0].cm_id, {}).get("session_cm_id")
-                    if match_session != session_cm_id:
+                    match_info = attendee_info.get(matches[0].cm_id, {})
+                    match_sessions = match_info.get("session_cm_ids", [])
+                    match_session = match_info.get("session_cm_id")
+                    in_same_session = (match_sessions and session_cm_id in match_sessions) or (
+                        match_session == session_cm_id
+                    )
+                    if not in_same_session:
                         confidence = 0.80  # Lower for different session
 
                 return ResolutionResult(

--- a/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
@@ -101,13 +101,8 @@ class ExactMatchStrategy(BaseMatchStrategy):
                     session_cm_id = requester_info.get("session_cm_id")
 
                 if session_cm_id:
-                    # Check match's session — use all sessions if available,
-                    # fall back to single session for backward compatibility
-                    match_info = attendee_info.get(matches[0].cm_id, {})
-                    match_sessions = match_info.get("session_cm_ids", [])
-                    match_session = match_info.get("session_cm_id")
-
-                    if (match_sessions and session_cm_id in match_sessions) or (match_session == session_cm_id):
+                    match_session = attendee_info.get(matches[0].cm_id, {}).get("session_cm_id")
+                    if self._is_same_session_via_attendee_info(matches[0].cm_id, session_cm_id, attendee_info):
                         return ResolutionResult(
                             person=matches[0],
                             confidence=0.95,
@@ -201,6 +196,23 @@ class ExactMatchStrategy(BaseMatchStrategy):
             metadata={"ambiguity_reason": "multiple_matches_no_year", "match_count": len(matches)},
         )
 
+    @staticmethod
+    def _is_same_session_via_attendee_info(
+        person_cm_id: int,
+        session_cm_id: int,
+        attendee_info: dict[int, dict[str, Any]],
+    ) -> bool:
+        """Check if a person is enrolled in the given session, using pre-loaded attendee_info.
+
+        Prefers session_cm_ids (multi-enrollment) when available, falls back to singular
+        session_cm_id for backward compatibility.
+        """
+        info = attendee_info.get(person_cm_id, {})
+        match_sessions = info.get("session_cm_ids", [])
+        if match_sessions:
+            return session_cm_id in match_sessions
+        return info.get("session_cm_id") == session_cm_id
+
     def _disambiguate_with_session(
         self,
         matches: list[Person],
@@ -228,15 +240,9 @@ class ExactMatchStrategy(BaseMatchStrategy):
                     metadata={"ambiguity_reason": "multiple_matches_no_session", "match_count": len(matches)},
                 )
 
-            # Filter by same session using pre-loaded data (check session_cm_ids first for multi-enrolled)
-            def _is_same_session(m: Person) -> bool:
-                info = attendee_info.get(m.cm_id, {})
-                match_sessions = info.get("session_cm_ids", [])
-                if match_sessions:
-                    return session_cm_id in match_sessions
-                return info.get("session_cm_id") == session_cm_id
-
-            same_session_matches = [m for m in matches if _is_same_session(m)]
+            same_session_matches = [
+                m for m in matches if self._is_same_session_via_attendee_info(m.cm_id, session_cm_id, attendee_info)
+            ]
 
             if len(same_session_matches) == 1:
                 return ResolutionResult(
@@ -389,13 +395,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
             if len(matches) == 1:
                 confidence = 0.90  # Base for parent surname match
                 if session_cm_id and attendee_info:
-                    match_info = attendee_info.get(matches[0].cm_id, {})
-                    match_sessions = match_info.get("session_cm_ids", [])
-                    match_session = match_info.get("session_cm_id")
-                    in_same_session = (match_sessions and session_cm_id in match_sessions) or (
-                        match_session == session_cm_id
-                    )
-                    if not in_same_session:
+                    if not self._is_same_session_via_attendee_info(matches[0].cm_id, session_cm_id, attendee_info):
                         confidence = 0.80  # Lower for different session
 
                 return ResolutionResult(

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
@@ -598,5 +598,92 @@ class TestResolveSessionHandling:
         assert result.confidence == 0.90
 
 
+class TestParentSurnameSessionCmIds:
+    """Tests that _try_parent_surname_match consults session_cm_ids, not just session_cm_id."""
+
+    @pytest.fixture
+    def strategy(self):
+        person_repo = Mock()
+        attendee_repo = Mock()
+        attendee_repo.get_by_person_and_year.return_value = None
+        attendee_repo.bulk_get_sessions_for_persons.return_value = {}
+        person_repo.name_cache = None
+        person_repo.find_by_name.return_value = []
+        person_repo.find_by_first_and_parent_surname.return_value = []
+        person_repo.get_all_for_phonetic_matching.return_value = []
+        return ExactMatchStrategy(person_repo, attendee_repo)
+
+    def test_parent_surname_fast_path_uses_session_cm_ids(self, strategy):
+        """parent-surname fast path must check session_cm_ids, not just session_cm_id.
+
+        Bug: when the matched person has session_cm_id pointing to a *different* session
+        but session_cm_ids includes the requester's session, the match should be
+        confidence=0.90 (same-session), NOT confidence=0.80 (different-session).
+        """
+        # Camper "Emma Garcia" whose parent surname is "Johnson"
+        camper = Person(
+            cm_id=2000001,
+            first_name="Emma",
+            last_name="Garcia",
+            parent_names=json.dumps([{"first": "Liam", "last": "Johnson", "relationship": "Father"}]),
+        )
+        # Requester is in session 1000010
+        # Camper's primary session_cm_id is 1000020, but session_cm_ids includes 1000010
+        attendee_info = {
+            1000001: {"session_cm_id": 1000010},
+            2000001: {
+                "session_cm_id": 1000020,  # primary session is different
+                "session_cm_ids": [1000020, 1000010],  # but multi-enrolled, includes requester's session
+            },
+        }
+
+        result = strategy.resolve(
+            name="Emma Johnson",
+            requester_cm_id=1000001,
+            session_cm_id=1000010,
+            year=2026,
+            candidates=[camper],
+            attendee_info=attendee_info,
+        )
+
+        assert result.is_resolved
+        assert result.person.cm_id == 2000001
+        # Multi-enrolled camper IS in the same session — should use base confidence (0.90),
+        # not the penalized different-session confidence (0.80)
+        assert result.confidence == 0.90, (
+            f"Expected 0.90 (same-session via session_cm_ids) but got {result.confidence}. "
+            "Bug: _try_parent_surname_match only checks session_cm_id (singular)."
+        )
+
+    def test_parent_surname_fast_path_still_penalises_truly_different_session(self, strategy):
+        """When session_cm_ids has no overlap with requester's session, confidence stays 0.80."""
+        camper = Person(
+            cm_id=2000001,
+            first_name="Olivia",
+            last_name="Chen",
+            parent_names=json.dumps([{"first": "Wei", "last": "Smith", "relationship": "Mother"}]),
+        )
+        attendee_info = {
+            1000001: {"session_cm_id": 1000010},
+            2000001: {
+                "session_cm_id": 1000020,
+                "session_cm_ids": [1000020, 1000030],  # neither is requester's 1000010
+            },
+        }
+
+        result = strategy.resolve(
+            name="Olivia Smith",
+            requester_cm_id=1000001,
+            session_cm_id=1000010,
+            year=2026,
+            candidates=[camper],
+            attendee_info=attendee_info,
+        )
+
+        assert result.is_resolved
+        assert result.person.cm_id == 2000001
+        assert result.confidence == 0.80  # correctly penalised
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Bug

`_try_parent_surname_match` (fast path in `exact_match.py`) checked only the singular `session_cm_id` field when scoring a matched person's session against the requester's session. The `session_cm_ids` list — which exists to support multi-enrolled attendees (e.g., a camper in both session 2 and session 3) — was ignored entirely.

Result: a multi-enrolled camper whose primary `session_cm_id` pointed to a different session got scored at confidence 0.80 (different-session penalty) even when the requester's session appeared in their `session_cm_ids` list.

## Fix

Copied the exact same guard pattern already used in the sibling method `_disambiguate_with_session` (lines 232–237):

```python
match_info = attendee_info.get(matches[0].cm_id, {})
match_sessions = match_info.get("session_cm_ids", [])
match_session = match_info.get("session_cm_id")
in_same_session = (match_sessions and session_cm_id in match_sessions) or (
    match_session == session_cm_id
)
if not in_same_session:
    confidence = 0.80  # Lower for different session
```

## Test plan

- `TestParentSurnameSessionCmIds::test_parent_surname_fast_path_uses_session_cm_ids` — new, was **FAILING** pre-fix (got 0.80, expected 0.90); passes post-fix
- `TestParentSurnameSessionCmIds::test_parent_surname_fast_path_still_penalises_truly_different_session` — new, confirms truly different sessions still get 0.80
- Full test suite: 4658 passed, 14 skipped, 0 failures

Closes #1496

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exact-match and parent-surname matching to correctly handle individuals enrolled in multiple sessions; confidence scores now reflect session overlap with the requester (reducing false positives when sessions differ).
* **Tests**
  * Added tests validating multi-session enrollment handling for parent-surname and exact-match resolution, covering both matching and non-overlapping session scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1500?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->