### PR TITLE
perf(ci): speculative CD build + per-image gates

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -56,13 +56,17 @@ jobs:
     name: Detect Changed Files
     runs-on: ubuntu-latest
     outputs:
-      api: ${{ steps.filter.outputs.api }}
-      docker: ${{ steps.filter.outputs.docker }}
       initial_commit: ${{ steps.get-base-sha.outputs.initial_commit }}
       short_sha: ${{ steps.short-sha.outputs.short_sha }}
-      # Single source of truth for "is a Docker build needed for this commit".
-      # Downstream jobs (build-and-scan, integration-test, promote) gate on this.
-      should_build: ${{ steps.should-build.outputs.should_build }}
+      # Per-image rebuild decisions — matrix entries read these to choose
+      # between full rebuild and a fast retag from :latest.
+      build_caddy: ${{ steps.decide-builds.outputs.build_caddy }}
+      build_pocketbase: ${{ steps.decide-builds.outputs.build_pocketbase }}
+      build_api: ${{ steps.decide-builds.outputs.build_api }}
+      build_init: ${{ steps.decide-builds.outputs.build_init }}
+      # Global gate — true if any image rebuild OR deployment-metadata changes
+      # warrant running the matrix + integration-test + promote pipeline at all.
+      should_build: ${{ steps.decide-builds.outputs.should_build }}
     steps:
     - name: Harden runner
       uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
@@ -127,18 +131,34 @@ jobs:
       with:
         base: ${{ steps.get-base-sha.outputs.base_sha }}
         filters: |
+          # Per-image triggers — used to decide whether each matrix runner
+          # does a full rebuild or just retags :latest -> :test-<sha>.
+          # Be conservative: anything COPY'd into the Dockerfile triggers a rebuild.
+          caddy:
+            - 'frontend/**'
+            - 'config/branding*.json'
+            - 'docker/Caddyfile'
+            - 'docker/Dockerfile.caddy'
+            - 'docker/healthcheck/**'
+          pocketbase:
+            - 'pocketbase/**'
+            - 'docker/Dockerfile.pocketbase'
+            - 'docker/healthcheck/**'
           api:
             - 'api/**'
             - 'bunking/**'
             - 'campminder/**'
-            - 'pocketbase/**'
-            - 'frontend/**'
-            - 'config/*.json'
+            - 'config/**'
             - 'pyproject.toml'
             - 'uv.lock'
-            - 'docker/**'
-          docker:
-            - 'docker/**'
+            - 'docker/Dockerfile.api'
+          init:
+            - 'pocketbase/**'
+            - 'docker/init-entrypoint.sh'
+            - 'docker/Dockerfile.init'
+          # Deployment-metadata changes — affect how images run together but not
+          # image content. Triggers integration-test + promote without rebuilds.
+          deployment:
             - 'docker-compose*.yml'
             - '.dockerignore'
 
@@ -166,28 +186,61 @@ jobs:
         echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
         echo "Staging tag will be: :test-$SHORT_SHA"
 
-    - name: Decide if Docker build is needed
-      id: should-build
-      # Run even if earlier steps failed so downstream jobs get a definitive
-      # signal. If filter outputs are empty (detect failed), force-build as
-      # a safety fallback.
+    - name: Decide per-image build vs retag
+      id: decide-builds
+      # Always-run + safety fallback: if per-image filter outputs are empty
+      # (detect failed), force all rebuilds. Otherwise compute per-image
+      # build flags from filter outputs + the "rebuild everything" triggers
+      # (initial commit, workflow_dispatch, schedule).
       if: always()
       env:
+        CHANGES_CADDY: ${{ steps.filter.outputs.caddy }}
+        CHANGES_POCKETBASE: ${{ steps.filter.outputs.pocketbase }}
         CHANGES_API: ${{ steps.filter.outputs.api }}
-        CHANGES_DOCKER: ${{ steps.filter.outputs.docker }}
+        CHANGES_INIT: ${{ steps.filter.outputs.init }}
+        CHANGES_DEPLOYMENT: ${{ steps.filter.outputs.deployment }}
         CHANGES_INITIAL: ${{ steps.get-base-sha.outputs.initial_commit }}
         EVENT_NAME: ${{ github.event_name }}
       run: |
-        if [ -z "$CHANGES_API" ] && [ -z "$CHANGES_DOCKER" ]; then
-          echo "::warning::Change detection failed — building all images as safety fallback"
+        # Safety fallback: empty filter outputs mean detection failed.
+        DETECT_FAILED=false
+        if [ -z "$CHANGES_CADDY" ] && [ -z "$CHANGES_POCKETBASE" ] && \
+           [ -z "$CHANGES_API" ] && [ -z "$CHANGES_INIT" ]; then
+          echo "::warning::Per-image filter outputs empty — forcing all rebuilds as safety fallback"
+          DETECT_FAILED=true
+        fi
+
+        # "Rebuild everything" triggers: first commit, manual dispatch, weekly
+        # CVE scan, or detect-changes failure. These force build_X=true for every image.
+        REBUILD_ALL=false
+        if [ "$DETECT_FAILED" == "true" ] || [ "$CHANGES_INITIAL" == "true" ] || \
+           [ "$EVENT_NAME" == "workflow_dispatch" ] || [ "$EVENT_NAME" == "schedule" ]; then
+          REBUILD_ALL=true
+        fi
+
+        ANY_REBUILD=false
+        for IMG in caddy pocketbase api init; do
+          UPPER=$(echo "$IMG" | tr a-z A-Z)
+          VAR="CHANGES_${UPPER}"
+          if [ "$REBUILD_ALL" == "true" ] || [ "${!VAR}" == "true" ]; then
+            echo "build_${IMG}=true" >> $GITHUB_OUTPUT
+            ANY_REBUILD=true
+            echo "  ${IMG}: REBUILD"
+          else
+            echo "build_${IMG}=false" >> $GITHUB_OUTPUT
+            echo "  ${IMG}: retag from :latest"
+          fi
+        done
+
+        # should_build (global gate): run the matrix pipeline if any image needs
+        # a rebuild OR deployment metadata (compose/dockerignore) changed
+        # (we re-test the existing :latest images against the new compose).
+        if [ "$ANY_REBUILD" == "true" ] || [ "$CHANGES_DEPLOYMENT" == "true" ]; then
           echo "should_build=true" >> $GITHUB_OUTPUT
-        elif [ "$CHANGES_API" == "true" ] || [ "$CHANGES_DOCKER" == "true" ] || \
-             [ "$CHANGES_INITIAL" == "true" ] || \
-             [ "$EVENT_NAME" == "workflow_dispatch" ] || [ "$EVENT_NAME" == "schedule" ]; then
-          echo "should_build=true" >> $GITHUB_OUTPUT
+          echo "Matrix pipeline will run"
         else
           echo "should_build=false" >> $GITHUB_OUTPUT
-          echo "No relevant file changes — downstream jobs will skip"
+          echo "No relevant changes — entire matrix pipeline skips"
         fi
 
   # Verify CI passed before building/pushing images
@@ -406,30 +459,66 @@ jobs:
         include:
           - image: kindred-caddy
             dockerfile: docker/Dockerfile.caddy
+            should_build: ${{ needs.detect-changes.outputs.build_caddy }}
           - image: kindred-pocketbase
             dockerfile: docker/Dockerfile.pocketbase
+            should_build: ${{ needs.detect-changes.outputs.build_pocketbase }}
           - image: kindred-api
             dockerfile: docker/Dockerfile.api
+            should_build: ${{ needs.detect-changes.outputs.build_api }}
           - image: kindred-init
             dockerfile: docker/Dockerfile.init
+            should_build: ${{ needs.detect-changes.outputs.build_init }}
     steps:
     - name: Harden runner
       uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
       with:
         egress-policy: audit
 
+    # Always needed: GHCR login for both build-push and imagetools-create.
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    # === Fast path: source unchanged, retag :latest -> :test-<sha> ===
+    # Skips checkout, kindred-local clone, DHI login, buildx setup, full build.
+    # Errors loudly if :latest doesn't exist (e.g. brand-new image) — workflow_dispatch
+    # forces should_build=true via REBUILD_ALL, so this only hits when an existing
+    # image had its :latest deleted manually.
+    - name: Retag ${{ matrix.image }} from :latest
+      if: matrix.should_build == 'false'
+      env:
+        SHORT_SHA: ${{ needs.detect-changes.outputs.short_sha }}
+        IMAGE: ${{ matrix.image }}
+      run: |
+        STAGING_TAG="${REGISTRY}/${USERNAME}/${IMAGE}:test-${SHORT_SHA}"
+        LATEST_TAG="${REGISTRY}/${USERNAME}/${IMAGE}:latest"
+        echo "Source unchanged — retagging $LATEST_TAG -> $STAGING_TAG"
+        if ! docker buildx imagetools create -t "$STAGING_TAG" "$LATEST_TAG"; then
+          echo "::error::Retag failed. :latest may not exist for ${IMAGE}. Rerun with workflow_dispatch to force a full build."
+          exit 1
+        fi
+        echo "Retagged"
+
+    # === Slow path: source changed, full build ===
     - name: Checkout code
+      if: matrix.should_build == 'true'
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         fetch-depth: 0
         persist-credentials: false
 
     - name: Clone private config for branding assets
+      if: matrix.should_build == 'true'
       uses: ./.github/actions/clone-kindred-local
       with:
         deploy-key: ${{ secrets.KINDRED_LOCAL_DEPLOY_KEY }}
 
     - name: Prepare local assets for Docker build
+      if: matrix.should_build == 'true'
       run: |
         mkdir -p local/assets
         if [ -f local/assets/camp-logo.png ]; then
@@ -438,14 +527,8 @@ jobs:
           echo "No local assets (kindred-local not available); using default branding"
         fi
 
-    - name: Log in to GitHub Container Registry
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Log in to Docker Hardened Images registry
+      if: matrix.should_build == 'true'
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
       with:
         registry: dhi.io
@@ -453,6 +536,7 @@ jobs:
         password: ${{ secrets.DHI_TOKEN }}
 
     - name: Get version and build date
+      if: matrix.should_build == 'true'
       id: version
       run: |
         VERSION=$(git describe --tags --always 2>/dev/null || echo "dev")
@@ -461,9 +545,11 @@ jobs:
         echo "build_date=$BUILD_DATE" >> $GITHUB_OUTPUT
 
     - name: Set up Docker Buildx
+      if: matrix.should_build == 'true'
       uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
     - name: Build and push ${{ matrix.image }} to staging tag
+      if: matrix.should_build == 'true'
       env:
         INPUT_NO_CACHE: ${{ github.event.inputs.no_cache }}
         BUILD_VERSION: ${{ steps.version.outputs.version }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -384,13 +384,17 @@ jobs:
   # integration tests pass.
   build-and-scan:
     name: Build & Scan (${{ matrix.image }})
-    needs: [detect-changes, verify-ci, smoke-test]
+    # SPECULATIVE: runs in parallel with verify-ci. CI on main almost always
+    # passes (PR CI gated the merge; squash-merge produces a tree-equal commit),
+    # so the EV strongly favors building now. The push gate (promote) still
+    # requires verify-ci, so a CI failure here just wastes runner-minutes on
+    # a build that won't ship.
+    needs: [detect-changes, smoke-test]
     if: |
       always() &&
       needs.detect-changes.outputs.should_build == 'true' &&
-      (needs.verify-ci.result == 'success' || needs.verify-ci.result == 'skipped') &&
       (needs.smoke-test.result == 'success' || needs.smoke-test.result == 'skipped') &&
-      !(needs.verify-ci.result == 'failure' || needs.smoke-test.result == 'failure')
+      !(needs.smoke-test.result == 'failure')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -667,10 +671,17 @@ jobs:
   # layers, just manifest copies). Skipped on PR validation and dry-run.
   promote:
     name: Promote staging tags
-    needs: [detect-changes, build-and-scan, integration-test]
+    # SAFETY GATE: build-and-scan now runs speculatively (no verify-ci dep),
+    # so promote MUST explicitly require verify-ci to succeed before shipping.
+    # The `|| skipped` is intentional and load-bearing — verify-ci is skipped
+    # on workflow_dispatch and schedule events, which are legitimate non-PR
+    # triggers where we trust the operator/scheduler. On `push` to main,
+    # verify-ci runs and must succeed.
+    needs: [detect-changes, verify-ci, build-and-scan, integration-test]
     if: |
       always() &&
       needs.detect-changes.outputs.should_build == 'true' &&
+      (needs.verify-ci.result == 'success' || needs.verify-ci.result == 'skipped') &&
       needs.build-and-scan.result == 'success' &&
       needs.integration-test.result == 'success' &&
       github.event_name != 'pull_request' &&

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -134,16 +134,21 @@ jobs:
           # Per-image triggers — used to decide whether each matrix runner
           # does a full rebuild or just retags :latest -> :test-<sha>.
           # Be conservative: anything COPY'd into the Dockerfile triggers a rebuild.
+          # .dockerignore controls what gets COPY'd into every image, so an
+          # edit (especially one that excludes a previously-included file) must
+          # trigger a rebuild for every image to catch the regression.
           caddy:
             - 'frontend/**'
             - 'config/branding*.json'
             - 'docker/Caddyfile'
             - 'docker/Dockerfile.caddy'
             - 'docker/healthcheck/**'
+            - '.dockerignore'
           pocketbase:
             - 'pocketbase/**'
             - 'docker/Dockerfile.pocketbase'
             - 'docker/healthcheck/**'
+            - '.dockerignore'
           api:
             - 'api/**'
             - 'bunking/**'
@@ -152,15 +157,16 @@ jobs:
             - 'pyproject.toml'
             - 'uv.lock'
             - 'docker/Dockerfile.api'
+            - '.dockerignore'
           init:
             - 'pocketbase/**'
             - 'docker/init-entrypoint.sh'
             - 'docker/Dockerfile.init'
+            - '.dockerignore'
           # Deployment-metadata changes — affect how images run together but not
           # image content. Triggers integration-test + promote without rebuilds.
           deployment:
             - 'docker-compose*.yml'
-            - '.dockerignore'
 
     - name: Compute short SHA for staging tag
       id: short-sha
@@ -485,6 +491,9 @@ jobs:
 
     # === Fast path: source unchanged, retag :latest -> :test-<sha> ===
     # Skips checkout, kindred-local clone, DHI login, buildx setup, full build.
+    # Assumes :latest is single-platform linux/amd64 (see build step --platform);
+    # imagetools create copies the manifest reference verbatim, so a multi-arch
+    # :latest would carry through unchanged.
     # Errors loudly if :latest doesn't exist (e.g. brand-new image) — workflow_dispatch
     # forces should_build=true via REBUILD_ALL, so this only hits when an existing
     # image had its :latest deleted manually.
@@ -592,12 +601,20 @@ jobs:
           .
         echo "Pushed $STAGING_TAG"
 
+    # Trivy gated on full-build path only. Retag path reuses an already-scanned
+    # :latest digest; the weekly cron-triggered REBUILD_ALL re-scans against the
+    # current CVE DB. Also: .trivyignore lives at the repo root, so without the
+    # checkout from the build path, --ignorefile would silently no-op and the
+    # currently-suppressed CRITICAL CVEs would block every retag run.
+    # SARIF upload step below auto-skips via `steps.trivy-scan.outcome != 'skipped'`.
     - name: Install Trivy
+      if: matrix.should_build == 'true'
       uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
       with:
         version: v0.69.3
 
     - name: Scan ${{ matrix.image }} with Trivy
+      if: matrix.should_build == 'true'
       id: trivy-scan
       env:
         SHORT_SHA: ${{ needs.detect-changes.outputs.short_sha }}
@@ -816,7 +833,10 @@ jobs:
   # Summary job
   summary:
     name: Build Summary
-    needs: [build-and-scan, integration-test, promote]
+    # verify-ci is in needs so a CI failure (which would skip promote via the
+    # gate above) surfaces here as a workflow failure instead of being masked
+    # by the promote=skipped branch below logging "passed".
+    needs: [verify-ci, build-and-scan, integration-test, promote]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -827,6 +847,7 @@ jobs:
 
     - name: Check build status
       env:
+        VERIFY_CI_RESULT: ${{ needs.verify-ci.result }}
         BUILD_RESULT: ${{ needs.build-and-scan.result }}
         TEST_RESULT: ${{ needs.integration-test.result }}
         PROMOTE_RESULT: ${{ needs.promote.result }}
@@ -834,8 +855,9 @@ jobs:
         DRY_RUN: ${{ github.event.inputs.dry_run }}
         GH_USERNAME: ${{ env.USERNAME }}
       run: |
-        # Treat skipped as OK (no-changes path, or PR/dry-run for promote)
-        for RES_NAME in BUILD_RESULT TEST_RESULT PROMOTE_RESULT; do
+        # Treat skipped as OK (no-changes path, PR/dry-run for promote, or
+        # workflow_dispatch/schedule for verify-ci).
+        for RES_NAME in VERIFY_CI_RESULT BUILD_RESULT TEST_RESULT PROMOTE_RESULT; do
           RES="${!RES_NAME}"
           if [ "$RES" != "success" ] && [ "$RES" != "skipped" ]; then
             echo "$RES_NAME failed: $RES"
@@ -849,9 +871,13 @@ jobs:
           echo "CD validation passed (PR mode - staging tags pushed, no promote)"
         elif [ "$DRY_RUN" == "true" ]; then
           echo "CD dry-run passed (staging tags pushed, no promote)"
-        else
+        elif [ "$PROMOTE_RESULT" == "success" ]; then
           echo "All CD checks passed; images promoted to :latest and :sha-NNN"
           for IMG in kindred-caddy kindred-pocketbase kindred-api kindred-init; do
             echo "  - ghcr.io/${GH_USERNAME}/${IMG}"
           done
+        else
+          # build/test succeeded but promote was skipped — most commonly because
+          # verify-ci failed (its gate on promote). Surface this clearly.
+          echo "Build + integration-test succeeded but promote was skipped (verify_ci=$VERIFY_CI_RESULT, promote=$PROMOTE_RESULT). Images NOT promoted to :latest."
         fi


### PR DESCRIPTION
## Summary

Third and final PR in the CD parallelization series (after #1502 + #1503).

**Two changes, one PR per your request:**

### 1. Speculative build (parallel with verify-ci)

Drop `verify-ci` from `build-and-scan.needs` so the matrix builds run in parallel with CI verification. Add `verify-ci` to `promote.needs` as the safety gate — a failing CI on main wastes speculative-build runner-minutes but cannot leak to `:latest`.

### 2. Per-image rebuild gates

Replace the binary `should_build` with per-image rebuild decisions. Each matrix runner now branches:

- **Source changed** → full build + push `:test-<sha>` (~80s)
- **Source unchanged** → `docker buildx imagetools create -t :test-<sha> :latest` (~1s in-registry retag)

The integration-test job is unaffected — it always pulls uniform `:test-<sha>` tags regardless of how they were produced.

New per-image path filters in `detect-changes`:

| Image | Triggers |
|---|---|
| `kindred-caddy` | `frontend/**`, `config/branding*.json`, `docker/Caddyfile`, `docker/Dockerfile.caddy`, `docker/healthcheck/**` |
| `kindred-pocketbase` | `pocketbase/**`, `docker/Dockerfile.pocketbase`, `docker/healthcheck/**` |
| `kindred-api` | `api/**`, `bunking/**`, `campminder/**`, `config/**`, `pyproject.toml`, `uv.lock`, `docker/Dockerfile.api` |
| `kindred-init` | `pocketbase/**`, `docker/init-entrypoint.sh`, `docker/Dockerfile.init` |

A separate `deployment` filter (`docker-compose*.yml`, `.dockerignore`) keeps the matrix pipeline running on compose-only changes so existing `:latest` images get re-tested against the new compose and pinned with a fresh `:sha-<NNN>`.

## Expected impact

| Scenario | Original CD | After PR 2 | After this PR |
|---|---|---|---|
| Frontend-only PR | ~8:30 | ~6:00 | **~2:30** |
| API-only PR | ~8:30 | ~6:00 | **~2:30** |
| Cross-cutting | ~8:30 | ~6:00 | **~3:30** |
| Docs/test-only | ~1:00 (skipped) | ~1:00 (skipped) | ~1:00 (skipped) |

Critical-path math for typical case (1 image rebuilds, 3 retag):

```
max(verify-ci=~120s, build=80s) + integration-test=70s + promote=25s + summary=10s
= 120s + 70s + 25s + 10s = 225s ≈ 3:45 wall-clock
```

With BuildKit cache warm (typical for single-file source changes), the build step is often closer to 30-50s, dropping wall-clock further into the 2:30 range.

## Safety design

- **Speculation** doesn't compromise correctness: `promote` requires `verify-ci.result == 'success' || == 'skipped'`. The `|| skipped` is intentional — verify-ci is skipped on `workflow_dispatch` and `schedule`, both legitimate non-PR triggers where the operator/scheduler is trusted.
- **Per-image retag failure** (e.g. `:latest` deleted manually): retag step errors loudly with a clear message. Rerun with `workflow_dispatch` to force `REBUILD_ALL=true`.
- **Initial commits** and `workflow_dispatch`/`schedule` force `REBUILD_ALL=true` so all images get fresh builds (avoids the chicken-and-egg of needing `:latest` to exist).

## Test plan

- [ ] CD-on-PR validation (this PR is `.github`-only, so all matrix entries should hit the retag path)
- [ ] Workflow_dispatch dry-run on this branch — confirms full-rebuild path still works end-to-end after speculation
- [ ] First post-merge run on main: timeline view shows `build-and-scan` starting at T+0 (parallel with verify-ci), not after
- [ ] Future single-image PR (frontend or API): timeline shows 1 build, 3 retags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved deployment pipeline to rebuild only affected images, reducing unnecessary work and speeding deployments.
  * Added safer gating so promotions only proceed when CI checks pass or are explicitly skipped.
  * Enabled speculative, faster test-paths that retag existing images instead of full rebuilds when appropriate.
  * Clarified CI summary reporting to surface failures and distinguish skipped promotions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->