### PR TITLE
ci(docs): use gitignore:true in markdownlint config

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -11,20 +11,15 @@
     "MD025": true,  // multiple top-level H1s in same doc
     "MD024": { "siblings_only": true } // duplicate headings — siblings only
   },
+  // Use .gitignore to automatically exclude gitignored paths (node_modules,
+  // .venv, dist, build, docs/plans, CLAUDE.local.md, docs/camp, etc.).
+  "gitignore": true,
   "globs": ["**/*.md"],
   "ignores": [
-    // Dependency directories
-    "**/node_modules/**",
-    "node_modules",
-    ".venv",
-    "dist",
-    "build",
-    // Local-only working artifacts (gitignored)
+    // docs/superpowers is in .gitignore but has a tracked file; keep explicit.
     "docs/superpowers",
-    "docs/plans",
-    // Local Claude skill files (not project docs)
-    ".claude",
-    // Private symlinked config (lives in kindred-local, not this repo)
-    "CLAUDE.local.md"
+    // .claude/skills/** is un-gitignored (tracked); keep explicit to avoid
+    // linting skill reference docs that aren't project documentation.
+    ".claude"
   ]
 }


### PR DESCRIPTION
Closes #1492

Replaces the hand-maintained ignores list in `.markdownlint-cli2.jsonc` with markdownlint-cli2's native `.gitignore` support. Verified `npx markdownlint-cli2 "**/*.md"` output is identical before and after the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Markdownlint configuration to enable gitignore-based filtering, allowing the linting tool to respect repository ignore patterns more effectively.
  * Adjusted documentation file ignore patterns to be more targeted and specific to particular paths, while removing previously hardcoded broader exclusions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1514?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->