### PR TITLE
feat(frontend): post-check modal — bundle 2 polish follow-ups

### DIFF
--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -1309,6 +1309,53 @@ describe('PostValidationResultsModal — bunk chip row expand on click (#1481)',
     await user.click(screen.getByText('Maple 1'))
     expect(screen.getByText('Bunk Maple 1 is over capacity')).toBeInTheDocument()
   })
+
+  it('resets expandedBunks when the modal closes, so reopening starts collapsed', async () => {
+    // Otherwise an expanded bunk stays expanded across close/reopen, leaking UI
+    // state between sessions the same way selectedCamperId did before its fix.
+    const user = userEvent.setup()
+    const issues = [
+      {
+        type: 'capacity_violation',
+        severity: 'error',
+        message: 'Bunk Pine 3 is over capacity (9/8)',
+        details: { bunk_name: 'Pine 3', assigned: 9, max_size: 8 },
+      },
+    ]
+    const { rerender } = render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{ statistics: makeStats(), issues, validated_at: '2025-06-01T12:00:00Z' }}
+      />
+    )
+    // Expand the bunk row.
+    await user.click(screen.getByText('Pine 3'))
+    // Verify it is expanded (detail text visible).
+    expect(screen.getByText(/9.*8|1 over/i)).toBeInTheDocument()
+
+    // Close the modal.
+    rerender(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={false}
+        onClose={() => {}}
+        results={{ statistics: makeStats(), issues, validated_at: '2025-06-01T12:00:00Z' }}
+      />
+    )
+
+    // Reopen — the detail panel should NOT come back with the stale expansion.
+    rerender(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{ statistics: makeStats(), issues, validated_at: '2025-06-01T12:00:00Z' }}
+      />
+    )
+    expect(screen.queryByText(/9.*8|1 over/i)).not.toBeInTheDocument()
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -1458,5 +1505,71 @@ describe('PostValidationResultsModal — sub-label breakdown (#1481)', () => {
     )
     // The old label "2 issues to review" should not appear
     expect(screen.queryByText(/2 issues? to review/i)).not.toBeInTheDocument()
+  })
+
+  it('uses singular "other issue" when otherCount === 1', () => {
+    // One non-bunk issue → should render "1 other issue", not "1 other issues"
+    const issues = [
+      {
+        type: 'unassigned_camper',
+        severity: 'error',
+        message: 'Liam Garcia is not assigned to any bunk',
+      },
+    ]
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{
+          statistics: makeStats({
+            request_satisfaction_rate: 0.5,
+            material_parent_requests: 0,
+            satisfied_material_parent_requests: 0,
+            material_parent_request_satisfaction_rate: 0,
+            campers_with_unsatisfied_material_parent_requests: 0,
+          }),
+          issues,
+          validated_at: '2025-06-01T12:00:00Z',
+        }}
+      />
+    )
+    expect(screen.getAllByText(/1 other issue(?!s)/i).length).toBeGreaterThanOrEqual(1)
+    expect(screen.queryByText(/1 other issues/i)).not.toBeInTheDocument()
+  })
+
+  it('uses plural "other issues" when otherCount > 1', () => {
+    // Two non-bunk issues → should render "2 other issues", not "2 other"
+    const issues = [
+      {
+        type: 'unassigned_camper',
+        severity: 'error',
+        message: 'Liam Garcia is not assigned to any bunk',
+      },
+      {
+        type: 'unassigned_camper',
+        severity: 'error',
+        message: 'Olivia Chen is not assigned to any bunk',
+      },
+    ]
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{
+          statistics: makeStats({
+            request_satisfaction_rate: 0.5,
+            material_parent_requests: 0,
+            satisfied_material_parent_requests: 0,
+            material_parent_request_satisfaction_rate: 0,
+            campers_with_unsatisfied_material_parent_requests: 0,
+          }),
+          issues,
+          validated_at: '2025-06-01T12:00:00Z',
+        }}
+      />
+    )
+    expect(screen.getAllByText(/2 other issues/i).length).toBeGreaterThanOrEqual(1)
   })
 })

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -1175,3 +1175,288 @@ describe('PostValidationResultsModal — Impossible by reason kicker', () => {
     ).toBeInTheDocument()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Issue #1481 Item 1 — Bunks needing attention: chip rows expand on click
+// ---------------------------------------------------------------------------
+
+describe('PostValidationResultsModal — bunk chip row expand on click (#1481)', () => {
+  const bunkIssues = [
+    {
+      type: 'capacity_violation',
+      severity: 'error',
+      message: 'Bunk Pine 3 is over capacity (9/8)',
+      details: { bunk_name: 'Pine 3', assigned: 9, max_size: 8 },
+    },
+    {
+      type: 'grade_ratio_warning',
+      severity: 'warning',
+      message: 'Bunk Pine 3 has 75.0% of campers from grade 5 (exceeds 67% limit)',
+      details: {
+        bunk_name: 'Pine 3',
+        grade: 5,
+        count: 6,
+        total: 8,
+        percentage: 75.0,
+        max_allowed: 67,
+        all_grades: { '5': 6, '4': 2 },
+      },
+    },
+  ]
+
+  it('default view shows chip labels, not numeric detail lines', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{
+          statistics: makeStats(),
+          issues: bunkIssues,
+          validated_at: '2025-06-01T12:00:00Z',
+        }}
+      />
+    )
+    // Chip labels visible
+    expect(screen.getByText(/capacity violation/i)).toBeInTheDocument()
+    // Detail line text NOT visible before click (the number "9 of 8" or "1 over")
+    expect(screen.queryByText(/9 of 8|1 over/i)).not.toBeInTheDocument()
+  })
+
+  it('clicking a bunk row expands to reveal numeric detail lines', async () => {
+    const user = userEvent.setup()
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{
+          statistics: makeStats(),
+          issues: bunkIssues,
+          validated_at: '2025-06-01T12:00:00Z',
+        }}
+      />
+    )
+    // Click the bunk row (by bunk name)
+    await user.click(screen.getByText('Pine 3'))
+    // Capacity detail line should now be visible with numbers
+    expect(screen.getByText(/9.*8|1 over/i)).toBeInTheDocument()
+  })
+
+  it('clicking the bunk row again collapses the detail', async () => {
+    const user = userEvent.setup()
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{
+          statistics: makeStats(),
+          issues: bunkIssues,
+          validated_at: '2025-06-01T12:00:00Z',
+        }}
+      />
+    )
+    await user.click(screen.getByText('Pine 3'))
+    // Expanded — detail visible
+    expect(screen.getByText(/9.*8|1 over/i)).toBeInTheDocument()
+    // Click again to collapse
+    await user.click(screen.getByText('Pine 3'))
+    expect(screen.queryByText(/9.*8|1 over/i)).not.toBeInTheDocument()
+  })
+
+  it('age_spread detail shows months and limit after expand', async () => {
+    const user = userEvent.setup()
+    const issues = [
+      {
+        type: 'age_spread_warning',
+        severity: 'warning',
+        message: 'Bunk Oak 2 has excessive age spread (26.0 months)',
+        details: { bunk_name: 'Oak 2', age_spread_months: 26, max_allowed: 24 },
+      },
+    ]
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{ statistics: makeStats(), issues, validated_at: '2025-06-01T12:00:00Z' }}
+      />
+    )
+    await user.click(screen.getByText('Oak 2'))
+    // Expect "26" and "24" and "months" in the rendered output
+    expect(screen.getByText(/26.*month|month.*26/i)).toBeInTheDocument()
+    expect(screen.getByText(/24/)).toBeInTheDocument()
+  })
+
+  it('falls back to raw message when details are absent', async () => {
+    const user = userEvent.setup()
+    const issues = [
+      {
+        type: 'capacity_violation',
+        severity: 'error',
+        message: 'Bunk Maple 1 is over capacity',
+      },
+    ]
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{ statistics: makeStats(), issues, validated_at: '2025-06-01T12:00:00Z' }}
+      />
+    )
+    await user.click(screen.getByText('Maple 1'))
+    expect(screen.getByText('Bunk Maple 1 is over capacity')).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue #1481 Item 2 — Sub-label section-aware breakdown
+// ---------------------------------------------------------------------------
+
+describe('PostValidationResultsModal — sub-label breakdown (#1481)', () => {
+  it('shows "no issues to review" when issues list is empty', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({
+          material_parent_requests: 0,
+          satisfied_material_parent_requests: 0,
+          material_parent_request_satisfaction_rate: 0,
+          campers_with_unsatisfied_material_parent_requests: 0,
+          request_satisfaction_rate: 0.5,
+        })}
+      />
+    )
+    // The "Needs Attention" tier is triggered by rate 0.5 — sub-label shows empty state
+    expect(screen.getByText(/no issues to review/i)).toBeInTheDocument()
+  })
+
+  it('shows section-aware breakdown with families, bunks, and other counts', () => {
+    // 1 family row (got_nothing camper), 1 bunk issue, 1 other issue
+    const impossibilityReport = makeImpossibilityReport({
+      mp_campers_entirely_impossible: [
+        {
+          cm_id: 1000001,
+          name: 'Emma Johnson',
+          grade: 5,
+          gender: 'F',
+          reason_codes: ['grade_compatibility'],
+        },
+      ],
+      by_reason: {},
+    })
+    const issues = [
+      {
+        type: 'age_spread_warning',
+        severity: 'warning',
+        message: 'Bunk Oak 2 has excessive age spread (26.0 months)',
+        details: { bunk_name: 'Oak 2', age_spread_months: 26, max_allowed: 24 },
+      },
+      {
+        type: 'unassigned_camper',
+        severity: 'error',
+        message: 'Liam Garcia is not assigned to any bunk',
+      },
+    ]
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{
+          statistics: makeStats({
+            request_satisfaction_rate: 0.5,
+            material_parent_requests: 0,
+            satisfied_material_parent_requests: 0,
+            material_parent_request_satisfaction_rate: 0,
+            campers_with_unsatisfied_material_parent_requests: 0,
+          }),
+          issues,
+          validated_at: '2025-06-01T12:00:00Z',
+        }}
+        impossibilityReport={impossibilityReport}
+      />
+    )
+    // Sub-label is in the header <p class="text-muted-foreground text-sm">
+    // It should contain sections for family/bunk separated by "·"
+    const sublabelMatches = screen.getAllByText(/famil.*bunk|bunk.*famil/i)
+    expect(sublabelMatches.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('omits zero-count sections from breakdown', () => {
+    // Only bunk issues — no family rows, no other issues
+    const issues = [
+      {
+        type: 'age_spread_warning',
+        severity: 'warning',
+        message: 'Bunk Oak 2 has excessive age spread (26.0 months)',
+        details: { bunk_name: 'Oak 2', age_spread_months: 26, max_allowed: 24 },
+      },
+    ]
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{
+          statistics: makeStats({
+            request_satisfaction_rate: 0.5,
+            material_parent_requests: 0,
+            satisfied_material_parent_requests: 0,
+            material_parent_request_satisfaction_rate: 0,
+            campers_with_unsatisfied_material_parent_requests: 0,
+          }),
+          issues,
+          validated_at: '2025-06-01T12:00:00Z',
+        }}
+      />
+    )
+    // "0 families" or "0 other" should NOT appear
+    expect(screen.queryByText(/0 famil/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/0 other/i)).not.toBeInTheDocument()
+    // "1 bunk" should appear somewhere in the document (the sub-label)
+    const bunkMatches = screen.getAllByText(/1 bunk/i)
+    expect(bunkMatches.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('does not show raw issues.length as the sub-label', () => {
+    const issues = [
+      {
+        type: 'capacity_violation',
+        severity: 'error',
+        message: 'Bunk Pine 3 is over capacity',
+        details: { bunk_name: 'Pine 3', assigned: 9, max_size: 8 },
+      },
+      {
+        type: 'age_spread_warning',
+        severity: 'warning',
+        message: 'Bunk Oak 2 has excessive age spread',
+        details: { bunk_name: 'Oak 2', age_spread_months: 26, max_allowed: 24 },
+      },
+    ]
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{
+          statistics: makeStats({
+            request_satisfaction_rate: 0.5,
+            material_parent_requests: 0,
+            satisfied_material_parent_requests: 0,
+            material_parent_request_satisfaction_rate: 0,
+            campers_with_unsatisfied_material_parent_requests: 0,
+          }),
+          issues,
+          validated_at: '2025-06-01T12:00:00Z',
+        }}
+      />
+    )
+    // The old label "2 issues to review" should not appear
+    expect(screen.queryByText(/2 issues? to review/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -1,10 +1,11 @@
-import { Suspense, useEffect, useMemo, useState } from 'react'
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
 import {
   BUNK_LEVEL_ISSUE_TYPES,
   SUPPRESSED_ISSUE_TYPES,
   extractBunkName,
   type PostCheckIssue,
 } from './issueClassifier'
+import { formatBunkIssueDetail } from '../utils/validationIssueFormatter'
 import {
   CheckCircle2,
   AlertTriangle,
@@ -552,6 +553,18 @@ export default function PostValidationResultsModal({
   const [showDetails, setShowDetails] = useState(false)
   const [showUnmetParents, setShowUnmetParents] = useState(false)
   const [selectedCamperId, setSelectedCamperId] = useState<string | null>(null)
+  const [expandedBunks, setExpandedBunks] = useState<Set<string>>(new Set())
+  const toggleBunkExpand = useCallback((bunkName: string) => {
+    setExpandedBunks((prev) => {
+      const next = new Set(prev)
+      if (next.has(bunkName)) {
+        next.delete(bunkName)
+      } else {
+        next.add(bunkName)
+      }
+      return next
+    })
+  }, [])
   useEffect(() => {
     if (!isOpen) setSelectedCamperId(null)
   }, [isOpen])
@@ -693,9 +706,18 @@ export default function PostValidationResultsModal({
         iconBg: 'bg-forest-500 text-white shadow-lg shadow-forest-500/30',
       }
     } else if (satisfactionRate >= 0.5) {
+      const parts: string[] = []
+      if (familyRows.length > 0)
+        parts.push(`${familyRows.length} ${familyRows.length === 1 ? 'family' : 'families'}`)
+      if (issuesByBunk.length > 0)
+        parts.push(`${issuesByBunk.length} ${issuesByBunk.length === 1 ? 'bunk' : 'bunks'}`)
+      const otherCount = groupedOtherIssues.reduce((sum, [, g]) => sum + g.issues.length, 0)
+      if (otherCount > 0) parts.push(`${otherCount} other`)
+      if (hasUnmetDrilldown && parts.length === 0) parts.push('unmet parent requests')
+      const sublabel = parts.length > 0 ? parts.join(' · ') : 'no issues to review'
       base = {
         label: 'Needs Attention',
-        sublabel: `${hasIssues ? issues.length : 0} issue${issues.length !== 1 ? 's' : ''} to review`,
+        sublabel,
         icon: AlertCircle,
         gradient: 'from-amber-500/15 to-amber-400/5',
         iconBg: 'bg-amber-500 text-white shadow-lg shadow-amber-500/30',
@@ -1023,25 +1045,49 @@ export default function PostValidationResultsModal({
               </span>
             </div>
             <ul className="mt-3 space-y-2 text-sm">
-              {issuesByBunk.map(([bunkName, bunkIssues]) => (
-                <li key={bunkName} className="rounded-lg bg-white px-3 py-2">
-                  <div className="font-medium text-stone-900">{bunkName}</div>
-                  <div className="mt-1 flex flex-wrap gap-1">
-                    {bunkIssues.map((iss, idx) => (
-                      <span
-                        key={idx}
-                        className={`rounded-full px-2 py-0.5 text-xs ${
-                          iss.type === 'capacity_violation'
-                            ? 'bg-red-200 text-red-900'
-                            : 'bg-amber-200 text-amber-900'
-                        }`}
-                      >
-                        {getIssueTypeLabel(iss.type)}
-                      </span>
-                    ))}
-                  </div>
-                </li>
-              ))}
+              {issuesByBunk.map(([bunkName, bunkIssues]) => {
+                const isExpanded = expandedBunks.has(bunkName)
+                return (
+                  <li key={bunkName} className="rounded-lg bg-white px-3 py-2">
+                    <button
+                      type="button"
+                      className="flex w-full items-center justify-between gap-2 text-left"
+                      onClick={() => toggleBunkExpand(bunkName)}
+                      aria-expanded={isExpanded}
+                    >
+                      <span className="font-medium text-stone-900">{bunkName}</span>
+                      {isExpanded ? (
+                        <ChevronUp className="h-3.5 w-3.5 shrink-0 text-stone-400" />
+                      ) : (
+                        <ChevronDown className="h-3.5 w-3.5 shrink-0 text-stone-400" />
+                      )}
+                    </button>
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {bunkIssues.map((iss, idx) => (
+                        <span
+                          key={idx}
+                          className={`rounded-full px-2 py-0.5 text-xs ${
+                            iss.type === 'capacity_violation'
+                              ? 'bg-red-200 text-red-900'
+                              : 'bg-amber-200 text-amber-900'
+                          }`}
+                        >
+                          {getIssueTypeLabel(iss.type)}
+                        </span>
+                      ))}
+                    </div>
+                    {isExpanded && (
+                      <ul className="mt-2 space-y-1 border-t border-stone-100 pt-2">
+                        {bunkIssues.map((iss, idx) => (
+                          <li key={idx} className="text-xs text-stone-600">
+                            {formatBunkIssueDetail(iss)}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </li>
+                )
+              })}
             </ul>
           </div>
         </div>

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -658,7 +658,6 @@ export default function PostValidationResultsModal({
     })
   }, [statistics, impossibilityReport])
 
-  const hasIssues = issues.length > 0
   const errorCount = issues.filter((i) => i.severity === 'error').length
   const warningCount = issues.filter((i) => i.severity === 'warning').length
   // KPI tile + section counts exclude suppressed types so the headline number

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -566,7 +566,10 @@ export default function PostValidationResultsModal({
     })
   }, [])
   useEffect(() => {
-    if (!isOpen) setSelectedCamperId(null)
+    if (!isOpen) {
+      setSelectedCamperId(null)
+      setExpandedBunks(new Set())
+    }
   }, [isOpen])
 
   // Need to compute these even when modal is closed since Modal might render conditionally
@@ -711,7 +714,7 @@ export default function PostValidationResultsModal({
       if (issuesByBunk.length > 0)
         parts.push(`${issuesByBunk.length} ${issuesByBunk.length === 1 ? 'bunk' : 'bunks'}`)
       const otherCount = groupedOtherIssues.reduce((sum, [, g]) => sum + g.issues.length, 0)
-      if (otherCount > 0) parts.push(`${otherCount} other`)
+      if (otherCount > 0) parts.push(`${otherCount} other issue${otherCount === 1 ? '' : 's'}`)
       if (hasUnmetDrilldown && parts.length === 0) parts.push('unmet parent requests')
       const sublabel = parts.length > 0 ? parts.join(' · ') : 'no issues to review'
       base = {

--- a/frontend/src/utils/validationIssueFormatter.test.ts
+++ b/frontend/src/utils/validationIssueFormatter.test.ts
@@ -1,0 +1,174 @@
+/**
+ * TDD tests for validationIssueFormatter — Issue #1481 Item 1
+ * RED PHASE: written before implementation.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { formatBunkIssueDetail } from './validationIssueFormatter'
+import type { PostCheckIssue } from '../components/issueClassifier'
+
+// Helper to build a minimal PostCheckIssue
+function issue(type: string, message: string, details?: Record<string, unknown>): PostCheckIssue {
+  return { type, severity: 'warning', message, details }
+}
+
+describe('formatBunkIssueDetail — capacity_violation', () => {
+  it('returns capacity detail with assigned and max', () => {
+    const result = formatBunkIssueDetail(
+      issue('capacity_violation', 'Bunk Pine 3 is over capacity (9/8)', {
+        bunk_name: 'Pine 3',
+        assigned: 9,
+        max_size: 8,
+      })
+    )
+    expect(result).toContain('9')
+    expect(result).toContain('8')
+    expect(result).toMatch(/over|capacity/i)
+  })
+
+  it('shows how many over capacity', () => {
+    const result = formatBunkIssueDetail(
+      issue('capacity_violation', 'Bunk Pine 3 is over capacity (9/8)', {
+        bunk_name: 'Pine 3',
+        assigned: 9,
+        max_size: 8,
+      })
+    )
+    // Should convey "1 over" or similar
+    expect(result).toMatch(/1\s*over|over.*1/i)
+  })
+})
+
+describe('formatBunkIssueDetail — age_spread_warning', () => {
+  it('returns age spread with months and limit', () => {
+    const result = formatBunkIssueDetail(
+      issue('age_spread_warning', 'Bunk Oak 2 has excessive age spread (26.0 months)', {
+        bunk_name: 'Oak 2',
+        age_spread_months: 26,
+        max_allowed: 24,
+      })
+    )
+    expect(result).toContain('26')
+    expect(result).toContain('24')
+    expect(result).toMatch(/month/i)
+  })
+})
+
+describe('formatBunkIssueDetail — grade_spread_warning', () => {
+  it('returns grade spread with unique grades count and limit', () => {
+    const result = formatBunkIssueDetail(
+      issue(
+        'grade_spread_warning',
+        'Bunk Maple 1 has too many different grades (3 grades, max allowed: 2)',
+        {
+          bunk_name: 'Maple 1',
+          unique_grades: 3,
+          grades: [4, 5, 6],
+          max_allowed: 2,
+        }
+      )
+    )
+    expect(result).toContain('3')
+    expect(result).toContain('2')
+    expect(result).toMatch(/grade/i)
+  })
+})
+
+describe('formatBunkIssueDetail — grade_ratio_warning', () => {
+  it('returns grade ratio with count and percentage', () => {
+    const result = formatBunkIssueDetail(
+      issue(
+        'grade_ratio_warning',
+        'Bunk Pine 3 has 75.0% of campers from grade 5 (exceeds 67% limit)',
+        {
+          bunk_name: 'Pine 3',
+          grade: 5,
+          count: 6,
+          total: 8,
+          percentage: 75.0,
+          max_allowed: 67,
+          all_grades: { '5': 6, '4': 2 },
+        }
+      )
+    )
+    expect(result).toContain('75')
+    expect(result).toContain('6')
+    expect(result).toContain('8')
+  })
+})
+
+describe('formatBunkIssueDetail — grade_adjacency_warning', () => {
+  it('returns missing grades info', () => {
+    const result = formatBunkIssueDetail(
+      issue(
+        'grade_adjacency_warning',
+        'Bunk Maple 1 has non-adjacent grades [4, 6] (missing grade 5)',
+        {
+          bunk_name: 'Maple 1',
+          grades_present: [4, 6],
+          missing_grades: [5],
+          gap: 1,
+        }
+      )
+    )
+    // Should reference the present grades [4, 6] and missing grade 5
+    expect(result).toMatch(/4.*6|6.*4/i)
+    expect(result).toContain('5')
+  })
+})
+
+describe('formatBunkIssueDetail — age_flow_inversion', () => {
+  it('returns avg age comparison between bunks', () => {
+    const result = formatBunkIssueDetail(
+      issue(
+        'age_flow_inversion',
+        'Riverside (avg age 12.5) has older campers than Hillcrest (avg age 11.2)',
+        {
+          bunk_name: 'Riverside',
+          lower_bunk: 'Riverside',
+          lower_avg_age: 12.5,
+          higher_bunk: 'Hillcrest',
+          higher_avg_age: 11.2,
+          gender: 'Boys',
+        }
+      )
+    )
+    expect(result).toMatch(/12\.5|12,5/i)
+    expect(result).toMatch(/11\.2|11,2/i)
+    expect(result).toContain('Hillcrest')
+  })
+})
+
+describe('formatBunkIssueDetail — isolation_risk', () => {
+  it('returns group size and isolated camper count', () => {
+    const result = formatBunkIssueDetail(
+      issue('isolation_risk', 'Pine 3 has 5 connected friends + 2 isolated camper(s)', {
+        bunk_name: 'Pine 3',
+        group_size: 5,
+        isolated_campers: [
+          { cm_id: 1, name: 'Emma Johnson' },
+          { cm_id: 2, name: 'Liam Garcia' },
+        ],
+      })
+    )
+    expect(result).toContain('5')
+    expect(result).toContain('2')
+    expect(result).toMatch(/isolat/i)
+  })
+})
+
+describe('formatBunkIssueDetail — fallback', () => {
+  it('returns issue.message when details is missing', () => {
+    const msg = 'Bunk Pine 3 has some unknown problem'
+    const result = formatBunkIssueDetail(issue('capacity_violation', msg))
+    expect(result).toBe(msg)
+  })
+
+  it('returns issue.message for unknown type with details', () => {
+    const msg = 'Unknown bunk issue occurred'
+    const result = formatBunkIssueDetail(
+      issue('unknown_type', msg, { bunk_name: 'Pine 3', some: 'data' })
+    )
+    expect(result).toBe(msg)
+  })
+})

--- a/frontend/src/utils/validationIssueFormatter.test.ts
+++ b/frontend/src/utils/validationIssueFormatter.test.ts
@@ -9,7 +9,9 @@ import type { PostCheckIssue } from '../components/issueClassifier'
 
 // Helper to build a minimal PostCheckIssue
 function issue(type: string, message: string, details?: Record<string, unknown>): PostCheckIssue {
-  return { type, severity: 'warning', message, details }
+  const base: PostCheckIssue = { type, severity: 'warning', message }
+  if (details !== undefined) base.details = details
+  return base
 }
 
 describe('formatBunkIssueDetail — capacity_violation', () => {

--- a/frontend/src/utils/validationIssueFormatter.ts
+++ b/frontend/src/utils/validationIssueFormatter.ts
@@ -1,0 +1,129 @@
+/**
+ * Per-type detail formatter for bunk-level ValidationIssues.
+ *
+ * Used by PostValidationResultsModal (expand-on-click rows) and will be
+ * reused by PDF export (BunkPlanReport) in a future PR.
+ *
+ * Each formatter receives the structured `details` dict emitted by
+ * bunking_validator.py and returns a short, human-readable string with
+ * the actual numeric context.
+ *
+ * Falls back to `issue.message` when `details` is absent or the type
+ * is not recognised.
+ */
+
+import type { PostCheckIssue } from '../components/issueClassifier'
+
+// ---------------------------------------------------------------------------
+// Per-type formatters
+// ---------------------------------------------------------------------------
+
+function formatCapacityViolation(details: Record<string, unknown>): string | null {
+  const assigned = details['assigned']
+  const maxSize = details['max_size']
+  if (typeof assigned !== 'number' || typeof maxSize !== 'number') return null
+  const over = assigned - maxSize
+  return `Capacity: ${assigned} of ${maxSize} campers (${over} over)`
+}
+
+function formatAgeSpreadWarning(details: Record<string, unknown>): string | null {
+  const spreadMonths = details['age_spread_months']
+  const maxAllowed = details['max_allowed']
+  if (typeof spreadMonths !== 'number' || typeof maxAllowed !== 'number') return null
+  const rounded = Math.round(spreadMonths)
+  return `Age spread: ${rounded} months range (limit ${maxAllowed})`
+}
+
+function formatGradeSpreadWarning(details: Record<string, unknown>): string | null {
+  const uniqueGrades = details['unique_grades']
+  const maxAllowed = details['max_allowed']
+  const grades = details['grades']
+  if (typeof uniqueGrades !== 'number' || typeof maxAllowed !== 'number') return null
+  const gradesStr = Array.isArray(grades) ? ` [${grades.join(', ')}]` : ''
+  return `${uniqueGrades} different grades${gradesStr} (limit ${maxAllowed})`
+}
+
+function formatGradeRatioWarning(details: Record<string, unknown>): string | null {
+  const grade = details['grade']
+  const count = details['count']
+  const total = details['total']
+  const percentage = details['percentage']
+  const maxAllowed = details['max_allowed']
+  if (
+    typeof grade !== 'number' ||
+    typeof count !== 'number' ||
+    typeof total !== 'number' ||
+    typeof percentage !== 'number'
+  )
+    return null
+  const pctStr = Math.round(percentage)
+  const limitStr = typeof maxAllowed === 'number' ? ` (limit ${maxAllowed}%)` : ''
+  return `Grade ratio: ${pctStr}% from grade ${grade} (${count} of ${total})${limitStr}`
+}
+
+function formatGradeAdjacencyWarning(details: Record<string, unknown>): string | null {
+  const gradesPresent = details['grades_present']
+  const missingGrades = details['missing_grades']
+  if (!Array.isArray(gradesPresent) || !Array.isArray(missingGrades)) return null
+  const missing = missingGrades.join(', ')
+  return `Grades [${gradesPresent.join(', ')}] (missing ${missing})`
+}
+
+function formatAgeFlowInversion(details: Record<string, unknown>): string | null {
+  const lowerBunk = details['lower_bunk']
+  const lowerAge = details['lower_avg_age']
+  const higherBunk = details['higher_bunk']
+  const higherAge = details['higher_avg_age']
+  if (
+    typeof lowerBunk !== 'string' ||
+    typeof lowerAge !== 'number' ||
+    typeof higherBunk !== 'string' ||
+    typeof higherAge !== 'number'
+  )
+    return null
+  return `${lowerBunk} avg age ${lowerAge} > ${higherBunk} avg age ${higherAge}`
+}
+
+function formatIsolationRisk(details: Record<string, unknown>): string | null {
+  const groupSize = details['group_size']
+  const isolatedCampers = details['isolated_campers']
+  if (typeof groupSize !== 'number' || !Array.isArray(isolatedCampers)) return null
+  const isolatedCount = isolatedCampers.length
+  return `${groupSize} connected friends + ${isolatedCount} isolated camper${isolatedCount === 1 ? '' : 's'}`
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch table
+// ---------------------------------------------------------------------------
+
+type Formatter = (details: Record<string, unknown>) => string | null
+
+const FORMATTERS: Record<string, Formatter> = {
+  capacity_violation: formatCapacityViolation,
+  age_spread_warning: formatAgeSpreadWarning,
+  grade_spread_warning: formatGradeSpreadWarning,
+  grade_ratio_warning: formatGradeRatioWarning,
+  grade_adjacency_warning: formatGradeAdjacencyWarning,
+  age_flow_inversion: formatAgeFlowInversion,
+  isolation_risk: formatIsolationRisk,
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a short human-readable detail string for a bunk-level validation
+ * issue, including the validator's actual numbers.
+ *
+ * Falls back to `issue.message` when `details` is absent, or the type has
+ * no registered formatter, or the formatter's required fields are missing.
+ */
+export function formatBunkIssueDetail(issue: PostCheckIssue): string {
+  const formatter = FORMATTERS[issue.type]
+  if (formatter && issue.details) {
+    const result = formatter(issue.details)
+    if (result !== null) return result
+  }
+  return issue.message
+}


### PR DESCRIPTION
Closes #1481

Wife-feedback follow-up to PR #1483 (post-check redesign). Two frontend-only polish items:

1. **Bunks needing attention chip rows now expand on click** — reveals one short line per issue with the validator's actual numbers (capacity counts, grade ratios, age spread months, etc.) for all 7 bunk-level types. Falls back to the raw \`issue.message\` when \`ValidationIssue.details\` is absent.
2. **Sub-label rewritten** — \`\${issues.length} issue to review\` was raw and double-counted; now a section-aware breakdown like \`3 families · 2 bunks · 1 other\` (zero-count sections omitted; empty state shows \`no issues to review\`).

Item 3 from the original bundle (capacity-by-gender summer-bunk scoping) was dropped after investigation confirmed it's GUI-unreachable.

## Test plan
- [ ] Chip-row default render unchanged
- [ ] Clicking a chip row expands; detail lines for each ValidationIssue type render with numbers
- [ ] Missing-details fallback renders raw message
- [ ] Sub-label breakdown reflects per-section counts; zero-count parts omitted
- [ ] Empty issues → "no issues to review"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bunk issue rows in validation results are now collapsible/expandable; expanded state resets when the modal closes.
  * Header sublabel now shows a granular breakdown by family, bunk, and other categories instead of a single total.

* **Tests**
  * Added comprehensive tests for the modal rendering, expand/collapse behavior, sublabel logic, and formatted issue detail outputs.

* **New**
  * Added human-readable formatting for various validation issue details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1517?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->