### PR TITLE
fix(frontend): correct misleading impossible-requests copy in solver progress modal

### DIFF
--- a/frontend/src/components/SolverProgressModal.test.tsx
+++ b/frontend/src/components/SolverProgressModal.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import SolverProgressModal, { type SolverProgressState } from './SolverProgressModal'
+
+const completedStateWithImpossibles: SolverProgressState = {
+  isOpen: true,
+  phase: 'completed',
+  elapsedSeconds: 60,
+  timeLimit: 60,
+  stats: {
+    satisfied_request_count: 261,
+    total_requests: 300,
+    duration_seconds: 60,
+    new_assignments: 151,
+    request_validation: {
+      impossible_requests: 18,
+      affected_campers: 17,
+    },
+  },
+}
+
+describe('SolverProgressModal validation warning', () => {
+  it('points users to Pre-Check for the breakdown instead of claiming campers are not enrolled', () => {
+    render(<SolverProgressModal state={completedStateWithImpossibles} onClose={() => {}} />)
+
+    expect(screen.getByText('18 requests skipped')).toBeInTheDocument()
+    expect(screen.getByText(/breakdown by reason/i)).toBeInTheDocument()
+    expect(screen.queryByText(/campers not enrolled/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/SolverProgressModal.tsx
+++ b/frontend/src/components/SolverProgressModal.tsx
@@ -439,7 +439,7 @@ export default function SolverProgressModal({
                       {stats.request_validation.impossible_requests} requests skipped
                     </p>
                     <p className="mt-0.5 text-xs text-amber-600 dark:text-amber-400">
-                      Campers not enrolled in this session
+                      Open Pre-Check for the breakdown by reason
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary

The post-solve progress modal's validation warning currently reads:

> **N requests skipped**
> Campers not enrolled in this session

The subtitle is wrong on two axes:

1. **Wrong unit** — the number is *requests*, not campers (matching the line above it).
2. **Wrong reason** — \`outcome_requests.impossible_requests\` is built from reason codes like \`grade_compatibility\`, \`pair_no_shared_bunk\`, and \`age_pref_no_eligible_grade\`. None of those are about enrollment. \"Not enrolled\" would only fit \`target_not_in_solver\` / \`cross_session\`, which are typically zero.

Replaced with a pointer to the Pre-Check modal, which already groups by reason using \`friendlyReasonLabel()\` from \`reasonHints.ts\`.

## Test plan

- [x] New vitest assertion in \`SolverProgressModal.test.tsx\` confirms the new copy renders and the old broken copy is gone
- [x] Pre-push verification: prettier / eslint / tsc / vitest all pass
- [ ] Manual: trigger a solve with impossible requests in dev and confirm the warning subtitle reads "Open Pre-Check for the breakdown by reason"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated validation warning message in the Solver Progress Modal to direct users to Pre-Check for detailed breakdown of skipped requests when impossible requests are encountered during completion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->