### PR TITLE
feat(solver): mutual-request boost in objective (Stream 4, Phase 3)

### DIFF
--- a/api/routers/scenarios.py
+++ b/api/routers/scenarios.py
@@ -275,11 +275,16 @@ async def evaluate_score(
         session_filter = ctx.session_relation_filter
         session_id_filter = ctx.session_id_filter
 
-        # Fetch bunk requests for the session
+        # Fetch bunk requests for the session. status="resolved" mirrors
+        # data_fetcher.py:140 — the solver only ever scores resolved requests,
+        # so the evaluator (which claims to mirror the solver) must too.
+        # Without this filter, a pending B→A reciprocating a resolved A→B
+        # would phantom-detect mutual and inflate the evaluator score vs. the
+        # solver's objective (Stream 4 / #1382).
         requests_raw = await asyncio.to_thread(
             pb.collection(BUNK_REQUESTS).get_full_list,
             query_params={
-                "filter": f"({session_id_filter}) && year = {year}",
+                "filter": f'({session_id_filter}) && year = {year} && status = "resolved"',
             },
         )
 

--- a/bunking/config/schema.py
+++ b/bunking/config/schema.py
@@ -226,6 +226,22 @@ CONFIG_SCHEMA: dict[str, ConfigKey] = {
         max_value=1,
     ),
     # =========================================================================
+    # OBJECTIVE FUNCTION - Mutual-request boost (Stream 4 / #1382)
+    # =========================================================================
+    "objective.mutual_request_boost": ConfigKey(
+        key="objective.mutual_request_boost",
+        config_type=ConfigType.FLOAT,
+        required=True,
+        description=(
+            "Multiplier applied to bunk_with requests when both directions exist "
+            "(A→B AND B→A both filed as bunk_with). Always on; set to 1.0 to disable "
+            "the boost without removing the code path. Stacks multiplicatively with "
+            "source_multipliers and diminishing-returns weights."
+        ),
+        min_value=0.0,
+        max_value=10.0,
+    ),
+    # =========================================================================
     # SOLVER SETTINGS
     # =========================================================================
     "solver.auto_apply_enabled": ConfigKey(

--- a/bunking/config/schema.py
+++ b/bunking/config/schema.py
@@ -238,7 +238,10 @@ CONFIG_SCHEMA: dict[str, ConfigKey] = {
             "the boost without removing the code path. Stacks multiplicatively with "
             "source_multipliers and diminishing-returns weights."
         ),
-        min_value=0.0,
+        # Hard floor at 1.0 — values below 1.0 would inversely *downweight*
+        # reciprocated requests vs. one-way ones, the opposite of the
+        # feature's intent. Disable is "set to 1.0", not "set to 0.0".
+        min_value=1.0,
         max_value=10.0,
     ),
     # =========================================================================

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import os
 import time
 from collections import defaultdict
+from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING, Any
 
 from ortools.sat.python import cp_model
@@ -69,6 +70,36 @@ BASE_REQUEST_WEIGHT = 40  # matches old `priority * 10` for typical P4 first-pic
 FIRST_REQUEST_MULTIPLIER = 10  # slot-0 boost
 SECOND_REQUEST_MULTIPLIER = 5
 THIRD_PLUS_REQUEST_MULTIPLIER = 1
+
+
+def compute_mutual_bunk_with_pairs(
+    requests_by_person: Mapping[int, Iterable[DirectBunkRequest]],
+) -> set[frozenset[int]]:
+    """Stream 4 (#1382): collect unordered cm_id pairs where both directions
+    are filed as bunk_with — A→B AND B→A. Used by the objective to apply the
+    `objective.mutual_request_boost` multiplier to reciprocated requests.
+
+    Self-loops, null requestees, and non-bunk_with rows are skipped. Reciprocal
+    not_bunk_with is intentionally NOT mutual: a bunk_with↔not_bunk_with pair
+    is a conflict, not an agreement, and reciprocal not_bunk_with is symmetric
+    by intent (penalty already treats both directions equally).
+    """
+    bunk_with_edges: set[tuple[int, int]] = set()
+    for reqs in requests_by_person.values():
+        for r in reqs:
+            if r.request_type != RequestType.BUNK_WITH.value:
+                continue
+            if r.requested_person_cm_id is None:
+                continue
+            if r.requester_person_cm_id == r.requested_person_cm_id:
+                continue
+            bunk_with_edges.add((r.requester_person_cm_id, r.requested_person_cm_id))
+
+    mutual: set[frozenset[int]] = set()
+    for a, b in bunk_with_edges:
+        if (b, a) in bunk_with_edges:
+            mutual.add(frozenset({a, b}))
+    return mutual
 
 
 class DirectBunkingSolver:
@@ -513,6 +544,11 @@ class DirectBunkingSolver:
         # boost in the solver-debug UI.
         enable_first_boost = bool(self.config.get_int("objective.enable_first_boost", default=1))
 
+        # Stream 4 (#1382): boost reciprocated bunk_with pairs. Always on;
+        # set to 1.0 to disable in-place without removing the code path.
+        mutual_request_boost = self.config.get_float("objective.mutual_request_boost", default=2.0)
+        mutual_bunk_with_pairs = compute_mutual_bunk_with_pairs(self.input.requests_by_person)
+
         for person_cm_id, request_satisfactions in person_request_satisfaction.items():
             if not request_satisfactions:
                 continue
@@ -527,6 +563,14 @@ class DirectBunkingSolver:
                 # Apply source field multiplier based on CSV fields
                 source_multiplier = self._get_csv_field_multiplier(request)
                 base_weight = base_weight * source_multiplier
+
+                if (
+                    request.request_type == RequestType.BUNK_WITH.value
+                    and request.requested_person_cm_id is not None
+                    and frozenset({request.requester_person_cm_id, request.requested_person_cm_id})
+                    in mutual_bunk_with_pairs
+                ):
+                    base_weight = base_weight * mutual_request_boost
 
                 if i == 0:
                     weight = base_weight * FIRST_REQUEST_MULTIPLIER

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -72,6 +72,15 @@ SECOND_REQUEST_MULTIPLIER = 5
 THIRD_PLUS_REQUEST_MULTIPLIER = 1
 
 
+def find_mutual_pairs(directed_edges: Iterable[tuple[int, int]]) -> set[frozenset[int]]:
+    """Given directed (a, b) edges, return the set of unordered {a, b} pairs
+    where both (a, b) and (b, a) are present. Caller is responsible for
+    filtering edges to the relevant subset (request type, validity, etc.).
+    """
+    edges = set(directed_edges)
+    return {frozenset({a, b}) for a, b in edges if (b, a) in edges}
+
+
 def compute_mutual_bunk_with_pairs(
     requests_by_person: Mapping[int, Iterable[DirectBunkRequest]],
 ) -> set[frozenset[int]]:
@@ -84,22 +93,14 @@ def compute_mutual_bunk_with_pairs(
     is a conflict, not an agreement, and reciprocal not_bunk_with is symmetric
     by intent (penalty already treats both directions equally).
     """
-    bunk_with_edges: set[tuple[int, int]] = set()
-    for reqs in requests_by_person.values():
-        for r in reqs:
-            if r.request_type != RequestType.BUNK_WITH.value:
-                continue
-            if r.requested_person_cm_id is None:
-                continue
-            if r.requester_person_cm_id == r.requested_person_cm_id:
-                continue
-            bunk_with_edges.add((r.requester_person_cm_id, r.requested_person_cm_id))
-
-    mutual: set[frozenset[int]] = set()
-    for a, b in bunk_with_edges:
-        if (b, a) in bunk_with_edges:
-            mutual.add(frozenset({a, b}))
-    return mutual
+    return find_mutual_pairs(
+        (r.requester_person_cm_id, r.requested_person_cm_id)
+        for reqs in requests_by_person.values()
+        for r in reqs
+        if r.request_type == RequestType.BUNK_WITH.value
+        and r.requested_person_cm_id is not None
+        and r.requester_person_cm_id != r.requested_person_cm_id
+    )
 
 
 class DirectBunkingSolver:

--- a/bunking/solver/objective_evaluator.py
+++ b/bunking/solver/objective_evaluator.py
@@ -8,6 +8,7 @@ Components evaluated:
 1. Request satisfaction (bunk_with, not_bunk_with) with:
    - First-pick boost (is_first_requested → 10x slot-0 multiplier)
    - Source field multipliers
+   - Mutual-request boost for reciprocated bunk_with (Stream 4 / #1382)
    - Diminishing returns (always-on, module constants)
 2. Age/grade flow bonuses (target grade distribution)
 3. Grade spread penalties (soft constraint)
@@ -30,6 +31,7 @@ from bunking.solver.direct_solver import (
     FIRST_REQUEST_MULTIPLIER,
     SECOND_REQUEST_MULTIPLIER,
     THIRD_PLUS_REQUEST_MULTIPLIER,
+    find_mutual_pairs,
 )
 from bunking.solver.penalties import (
     grade_spread_penalty,
@@ -150,21 +152,17 @@ class ObjectiveEvaluator:
         mutual_request_boost = self.config.get_float("objective.mutual_request_boost", default=2.0)
 
         # Mirror solver's mutual-pair detection on the dict-shaped requests
-        # the evaluator consumes. Same rules as compute_mutual_bunk_with_pairs:
-        # skip non-bunk_with, self-loops, null requestees.
-        mutual_bunk_with_pairs: set[frozenset[int]] = set()
-        bunk_with_edges: set[tuple[int, int]] = set()
-        for r in requests:
-            if r.get("request_type") != RequestType.BUNK_WITH.value:
-                continue
-            req_id = r.get("requester_id")
-            tgt_id = r.get("requestee_id")
-            if not req_id or not tgt_id or int(req_id) == int(tgt_id):
-                continue
-            bunk_with_edges.add((int(req_id), int(tgt_id)))
-        for a, b in bunk_with_edges:
-            if (b, a) in bunk_with_edges:
-                mutual_bunk_with_pairs.add(frozenset({a, b}))
+        # the evaluator consumes. Shared with compute_mutual_bunk_with_pairs
+        # via find_mutual_pairs — feed bunk_with edges only, skip self-loops
+        # and null requestees.
+        mutual_bunk_with_pairs = find_mutual_pairs(
+            (int(r["requester_id"]), int(r["requestee_id"]))
+            for r in requests
+            if r.get("request_type") == RequestType.BUNK_WITH.value
+            and r.get("requester_id")
+            and r.get("requestee_id")
+            and int(r["requester_id"]) != int(r["requestee_id"])
+        )
 
         # Source field multipliers (same as solver)
         source_multipliers = {

--- a/bunking/solver/objective_evaluator.py
+++ b/bunking/solver/objective_evaluator.py
@@ -147,6 +147,24 @@ class ObjectiveEvaluator:
         """
         # Config values (same as solver)
         enable_first_boost = bool(self.config.get_int("objective.enable_first_boost", default=1))
+        mutual_request_boost = self.config.get_float("objective.mutual_request_boost", default=2.0)
+
+        # Mirror solver's mutual-pair detection on the dict-shaped requests
+        # the evaluator consumes. Same rules as compute_mutual_bunk_with_pairs:
+        # skip non-bunk_with, self-loops, null requestees.
+        mutual_bunk_with_pairs: set[frozenset[int]] = set()
+        bunk_with_edges: set[tuple[int, int]] = set()
+        for r in requests:
+            if r.get("request_type") != RequestType.BUNK_WITH.value:
+                continue
+            req_id = r.get("requester_id")
+            tgt_id = r.get("requestee_id")
+            if not req_id or not tgt_id or int(req_id) == int(tgt_id):
+                continue
+            bunk_with_edges.add((int(req_id), int(tgt_id)))
+        for a, b in bunk_with_edges:
+            if (b, a) in bunk_with_edges:
+                mutual_bunk_with_pairs.add(frozenset({a, b}))
 
         # Source field multipliers (same as solver)
         source_multipliers = {
@@ -246,6 +264,13 @@ class ObjectiveEvaluator:
                 else:
                     multiplier = 1.0
                 base_weight = base_weight * multiplier
+
+                # Stream 4 (#1382): mutual bunk_with boost (mirrors solver).
+                if request.get("request_type") == RequestType.BUNK_WITH.value:
+                    req_id = request.get("requester_id")
+                    tgt_id = request.get("requestee_id")
+                    if req_id and tgt_id and frozenset({int(req_id), int(tgt_id)}) in mutual_bunk_with_pairs:
+                        base_weight = base_weight * mutual_request_boost
 
                 # Apply diminishing returns based on satisfaction order (always-on)
                 order_idx = satisfied_count_for_person - 1

--- a/bunking/solver/score_evaluator.py
+++ b/bunking/solver/score_evaluator.py
@@ -8,8 +8,9 @@ The scoring logic mirrors the solver's objective function:
 1. Request satisfaction (bunk_with, not_bunk_with, age_preference)
 2. First-pick boost (is_first_requested → 10x slot-0 multiplier)
 3. Source field multipliers (keyed by canonical SourceField values)
-4. Diminishing returns for multiple satisfied requests per person
-5. Soft constraint penalties (grade spread, capacity violations, etc.)
+4. Mutual-request boost for reciprocated bunk_with (Stream 4 / #1382)
+5. Diminishing returns for multiple satisfied requests per person
+6. Soft constraint penalties (grade spread, capacity violations, etc.)
 """
 
 from __future__ import annotations
@@ -28,6 +29,7 @@ from bunking.solver.direct_solver import (
     FIRST_REQUEST_MULTIPLIER,
     SECOND_REQUEST_MULTIPLIER,
     THIRD_PLUS_REQUEST_MULTIPLIER,
+    find_mutual_pairs,
 )
 from bunking.solver.penalties import (
     grade_spread_penalty,
@@ -105,6 +107,18 @@ def evaluate_scenario_score(
 
     # Get config values
     enable_first_boost = bool(config.get_int("objective.enable_first_boost", default=1))
+    mutual_request_boost = config.get_float("objective.mutual_request_boost", default=2.0)
+
+    # Stream 4 (#1382): pairs where both directions filed bunk_with. Same
+    # detection as solver / objective_evaluator via the shared helper.
+    mutual_bunk_with_pairs = find_mutual_pairs(
+        (int(r["requester_id"]), int(r["requestee_id"]))
+        for r in requests
+        if r.get("request_type") == RequestType.BUNK_WITH.value
+        and r.get("requester_id")
+        and r.get("requestee_id")
+        and int(r["requester_id"]) != int(r["requestee_id"])
+    )
 
     # Source field multipliers
     source_multipliers = {
@@ -187,11 +201,19 @@ def evaluate_scenario_score(
             field_stats[primary_field]["satisfied"] += 1
 
             # Calculate base weight
-            base_weight = BASE_REQUEST_WEIGHT
+            base_weight: float = float(BASE_REQUEST_WEIGHT)
 
             # Apply source field multiplier
             multiplier = max(source_multipliers.get(f, 1.0) for f in source_fields) if source_fields else 1.0
-            weighted_score = int(base_weight * multiplier)
+            base_weight = base_weight * multiplier
+
+            # Stream 4 (#1382): mutual bunk_with boost (mirrors solver).
+            if request_type == RequestType.BUNK_WITH.value:
+                requestee_id = request.get("requestee_id")
+                if requestee_id and frozenset({requester_id, int(requestee_id)}) in mutual_bunk_with_pairs:
+                    base_weight = base_weight * mutual_request_boost
+
+            weighted_score = int(base_weight)
 
             person_satisfaction[requester_id].append((request, weighted_score))
             field_stats[primary_field]["raw_score"] += weighted_score

--- a/pocketbase/pb_migrations/1500000103_mutual_request_boost_config.js
+++ b/pocketbase/pb_migrations/1500000103_mutual_request_boost_config.js
@@ -1,0 +1,66 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+/**
+ * Seed objective.mutual_request_boost config row for Stream 4 (#1382).
+ *
+ * Adds a single objective-category config row controlling the multiplier
+ * applied to bunk_with requests where both directions exist (A→B AND B→A
+ * both filed as bunk_with). Always on; default 2.0; set to 1.0 to disable
+ * the boost in-place without touching code. Range [0.0, 10.0] matches the
+ * existing source_multipliers entries.
+ *
+ * Idempotent — re-running the migration is a no-op.
+ */
+migrate(
+  (app) => {
+    let existing
+    try {
+      existing = app.findFirstRecordByFilter(
+        "config",
+        `category = "objective" && config_key = "mutual_request_boost"`,
+      )
+    } catch {
+      existing = null
+    }
+    if (existing) return
+
+    const configCollection = app.findCollectionByNameOrId("config")
+    const record = new Record(configCollection)
+    record.set("category", "objective")
+    record.set("subcategory", "")
+    record.set("config_key", "mutual_request_boost")
+    record.set("value", 2.0)
+    record.set(
+      "description",
+      "Multiplier applied to bunk_with requests when both directions exist (A→B AND B→A both filed as bunk_with). Always on; set to 1.0 to disable the boost without removing the code path. Stacks multiplicatively with source_multipliers and diminishing-returns weights.",
+    )
+    record.set("metadata", {
+      data_type: "float",
+      source: "default_config",
+      default_value: 2.0,
+      min_value: 0.0,
+      max_value: 10.0,
+      friendly_name: "Mutual Request Boost",
+      tooltip:
+        "Extra weight when both families name each other as bunk-with picks. 2.0 doubles the request's objective score; 1.0 disables the boost.",
+      section: "request-weighting",
+      display_order: 2,
+      business_category: "solver",
+      component_type: "number",
+      component_config: {},
+    })
+    app.save(record)
+  },
+  (app) => {
+    let record
+    try {
+      record = app.findFirstRecordByFilter(
+        "config",
+        `category = "objective" && config_key = "mutual_request_boost"`,
+      )
+    } catch {
+      return
+    }
+    if (record) app.delete(record)
+  },
+)

--- a/pocketbase/pb_migrations/1500000103_mutual_request_boost_config.js
+++ b/pocketbase/pb_migrations/1500000103_mutual_request_boost_config.js
@@ -44,7 +44,10 @@ migrate(
       tooltip:
         "Extra weight when both families name each other as bunk-with picks. 2.0 doubles the request's objective score; 1.0 disables the boost.",
       section: "request-weighting",
-      display_order: 2,
+      // request-weighting already has display_order 1–4 from
+      // 1500000100_priority_deletion.js (enable_first_boost + first/second/
+      // third multipliers). Place mutual boost after those.
+      display_order: 5,
       business_category: "solver",
       component_type: "number",
       component_config: {},

--- a/pocketbase/pb_migrations/1500000103_mutual_request_boost_config.js
+++ b/pocketbase/pb_migrations/1500000103_mutual_request_boost_config.js
@@ -38,7 +38,10 @@ migrate(
       data_type: "float",
       source: "default_config",
       default_value: 2.0,
-      min_value: 0.0,
+      // Hard floor at 1.0 — anything lower would inversely downweight
+      // reciprocated requests vs. one-way ones (opposite of intent).
+      // Disable = "set to 1.0", not "set to 0.0". Matches schema.py.
+      min_value: 1.0,
       max_value: 10.0,
       friendly_name: "Mutual Request Boost",
       tooltip:

--- a/tests/unit/bunking/satisfaction/test_baseline_regression.py
+++ b/tests/unit/bunking/satisfaction/test_baseline_regression.py
@@ -58,6 +58,12 @@ class _MinimalConfig:
         "objective.first_request_multiplier": 10,
         "objective.second_request_multiplier": 5,
         "objective.third_plus_request_multiplier": 1,
+        # Pin Stream 4 mutual boost off — this baseline is a centralization-
+        # invariant snapshot, not a feature-shipping baseline. The synthetic
+        # fixture contains r6↔r7 (4↔5 bunk_with) which the default 2.0 boost
+        # would inflate. Feature integration coverage lives in
+        # tests/unit/bunking/solver/test_mutual_request_boost.py.
+        "objective.mutual_request_boost": 1.0,
         "objective.source_multipliers.share_bunk_with": 1.5,
         "objective.source_multipliers.do_not_share_with": 1.5,
         "objective.source_multipliers.bunking_notes": 1.2,

--- a/tests/unit/bunking/solver/test_mutual_request_boost.py
+++ b/tests/unit/bunking/solver/test_mutual_request_boost.py
@@ -1,0 +1,318 @@
+"""Tests for Stream 4 mutual-request boost (#1382).
+
+When both directions of a bunk_with request exist (A→B AND B→A both filed
+as bunk_with), the objective weight on each direction gets multiplied by
+`objective.mutual_request_boost` (default 2.0). The boost is always-on and
+applies to every mutual request (any slot in the diminishing-returns stack);
+set the config to 1.0 to disable in-place. Only `bunk_with` is eligible —
+reciprocal `not_bunk_with` is meaningless to boost.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections import defaultdict
+from typing import Any
+
+import pytest
+
+from bunking.models import RequestType
+from bunking.models_v2 import DirectBunkRequest
+from bunking.solver.direct_solver import (
+    BASE_REQUEST_WEIGHT,
+    FIRST_REQUEST_MULTIPLIER,
+    SECOND_REQUEST_MULTIPLIER,
+    compute_mutual_bunk_with_pairs,
+)
+from bunking.solver.objective_evaluator import ObjectiveEvaluator
+
+
+def _req(
+    rid: str,
+    requester: int,
+    requested: int | None,
+    request_type: RequestType,
+) -> DirectBunkRequest:
+    return DirectBunkRequest(
+        id=rid,
+        requester_person_cm_id=requester,
+        requested_person_cm_id=requested,
+        request_type=request_type.value,
+        session_cm_id=1000,
+        year=2025,
+        confidence_score=1.0,
+        status="resolved",
+    )
+
+
+def _group(reqs: list[DirectBunkRequest]) -> dict[int, list[DirectBunkRequest]]:
+    out: dict[int, list[DirectBunkRequest]] = defaultdict(list)
+    for r in reqs:
+        out[r.requester_person_cm_id].append(r)
+    return dict(out)
+
+
+# ---------------------------------------------------------------------------
+# compute_mutual_bunk_with_pairs — helper that detects reciprocal pairs.
+# ---------------------------------------------------------------------------
+
+
+def test_compute_mutual_pairs_detects_reciprocal_bunk_with():
+    """A→B and B→A both as bunk_with → returns {frozenset({A, B})}."""
+    pairs = compute_mutual_bunk_with_pairs(
+        _group(
+            [
+                _req("r1", 1, 2, RequestType.BUNK_WITH),
+                _req("r2", 2, 1, RequestType.BUNK_WITH),
+            ]
+        )
+    )
+    assert pairs == {frozenset({1, 2})}
+
+
+def test_compute_mutual_pairs_ignores_one_way():
+    """A→B exists but B→A does not → empty set."""
+    pairs = compute_mutual_bunk_with_pairs(_group([_req("r1", 1, 2, RequestType.BUNK_WITH)]))
+    assert pairs == set()
+
+
+def test_compute_mutual_pairs_ignores_not_bunk_with_reciprocals():
+    """Reciprocal not_bunk_with is meaningless to boost (symmetric by intent
+    and the solver penalty already treats both directions equally)."""
+    pairs = compute_mutual_bunk_with_pairs(
+        _group(
+            [
+                _req("r1", 1, 2, RequestType.NOT_BUNK_WITH),
+                _req("r2", 2, 1, RequestType.NOT_BUNK_WITH),
+            ]
+        )
+    )
+    assert pairs == set()
+
+
+def test_compute_mutual_pairs_does_not_pair_mixed_types():
+    """A→B bunk_with paired with B→A not_bunk_with is NOT mutual.
+
+    These two requests are in direct conflict, not in agreement; the boost
+    must not apply to either.
+    """
+    pairs = compute_mutual_bunk_with_pairs(
+        _group(
+            [
+                _req("r1", 1, 2, RequestType.BUNK_WITH),
+                _req("r2", 2, 1, RequestType.NOT_BUNK_WITH),
+            ]
+        )
+    )
+    assert pairs == set()
+
+
+def test_compute_mutual_pairs_handles_multiple_disjoint_pairs():
+    """Two independent reciprocal pairs (A↔B and C↔D) → both returned."""
+    pairs = compute_mutual_bunk_with_pairs(
+        _group(
+            [
+                _req("r1", 1, 2, RequestType.BUNK_WITH),
+                _req("r2", 2, 1, RequestType.BUNK_WITH),
+                _req("r3", 3, 4, RequestType.BUNK_WITH),
+                _req("r4", 4, 3, RequestType.BUNK_WITH),
+            ]
+        )
+    )
+    assert pairs == {frozenset({1, 2}), frozenset({3, 4})}
+
+
+def test_compute_mutual_pairs_handles_self_loop_defensively():
+    """A→A self-request: pathological data, must not crash and must not
+    register as mutual (a single self-edge does not satisfy reciprocity)."""
+    pairs = compute_mutual_bunk_with_pairs(_group([_req("r1", 1, 1, RequestType.BUNK_WITH)]))
+    assert pairs == set()
+
+
+def test_compute_mutual_pairs_ignores_requests_with_null_requestee():
+    """Malformed bunk_with with no target → skip; don't fault."""
+    pairs = compute_mutual_bunk_with_pairs(
+        _group(
+            [
+                _req("r1", 1, None, RequestType.BUNK_WITH),
+                _req("r2", 2, 1, RequestType.BUNK_WITH),
+            ]
+        )
+    )
+    assert pairs == set()
+
+
+# ---------------------------------------------------------------------------
+# ObjectiveEvaluator — post-solve scoring mirror of the solver's logic.
+# ---------------------------------------------------------------------------
+
+
+class _StubConfig:
+    """Pure-Python config stub for evaluator tests."""
+
+    def __init__(self, overrides: dict[str, Any] | None = None):
+        self._values: dict[str, Any] = {
+            "objective.enable_first_boost": 1,
+            "objective.mutual_request_boost": 2.0,
+            "objective.source_multipliers.share_bunk_with": 1.0,
+            "objective.source_multipliers.do_not_share_with": 1.0,
+            "objective.source_multipliers.bunking_notes": 1.0,
+            "objective.source_multipliers.internal_notes": 1.0,
+            "objective.source_multipliers.socialize_preference": 1.0,
+        }
+        if overrides:
+            self._values.update(overrides)
+
+    def get_int(self, key: str, default: int = 0) -> int:
+        v = self._values.get(key, default)
+        return int(v) if v is not None else default
+
+    def get_float(self, key: str, default: float = 0.0) -> float:
+        v = self._values.get(key, default)
+        return float(v) if v is not None else default
+
+    def get_str(self, key: str, default: str = "") -> str:
+        v = self._values.get(key, default)
+        return str(v) if v is not None else default
+
+    def get_bool(self, key: str, default: bool = False) -> bool:
+        v = self._values.get(key, default)
+        return bool(v) if v is not None else default
+
+    def get(self, key: str) -> Any:
+        return self._values.get(key)
+
+
+def _dict_req(
+    requester: int,
+    requestee: int,
+    request_type: str = "bunk_with",
+    is_first_requested: bool = False,
+) -> dict[str, Any]:
+    """Build the dict shape the evaluator consumes."""
+    return {
+        "id": f"r{requester}_{requestee}",
+        "requester_id": requester,
+        "requestee_id": requestee,
+        "request_type": request_type,
+        "is_first_requested": is_first_requested,
+        "source_field": None,
+        "csv_source_fields": None,
+    }
+
+
+@pytest.fixture
+def evaluator() -> ObjectiveEvaluator:
+    return ObjectiveEvaluator(config=_StubConfig())  # type: ignore[arg-type]
+
+
+def test_evaluator_mutual_bunk_with_doubles_weight(evaluator):
+    """A↔B reciprocal bunk_with, both satisfied (in the same bunk).
+    Each direction's weight = BASE × source(1.0) × mutual(2.0) × diminishing[0](FIRST=10).
+    """
+    assignments = {1: 100, 2: 100}  # both in bunk 100
+    requests = [_dict_req(1, 2), _dict_req(2, 1)]
+    person_by_cm_id = {1: {"campminder_person_id": 1}, 2: {"campminder_person_id": 2}}
+
+    score, _ = evaluator._calculate_request_satisfaction(assignments, requests, person_by_cm_id)
+
+    expected_per_request = int(BASE_REQUEST_WEIGHT * 1.0 * 2.0 * FIRST_REQUEST_MULTIPLIER)
+    assert score == 2 * expected_per_request
+
+
+def test_evaluator_one_way_bunk_with_no_boost(evaluator):
+    """A→B but no B→A. Both satisfied (B happens to be in A's bunk).
+    A's weight = BASE × source × 1.0 (no mutual) × FIRST.
+    B's request doesn't exist, so only A's weight counted.
+    """
+    assignments = {1: 100, 2: 100}
+    requests = [_dict_req(1, 2)]
+    person_by_cm_id = {1: {"campminder_person_id": 1}, 2: {"campminder_person_id": 2}}
+
+    score, _ = evaluator._calculate_request_satisfaction(assignments, requests, person_by_cm_id)
+
+    expected = int(BASE_REQUEST_WEIGHT * 1.0 * 1.0 * FIRST_REQUEST_MULTIPLIER)
+    assert score == expected
+
+
+def test_evaluator_not_bunk_with_never_boosts(evaluator):
+    """Reciprocal not_bunk_with does NOT get the boost (only bunk_with does).
+    Both satisfied (placed in different bunks).
+    """
+    assignments = {1: 100, 2: 200}  # different bunks
+    requests = [
+        _dict_req(1, 2, request_type="not_bunk_with"),
+        _dict_req(2, 1, request_type="not_bunk_with"),
+    ]
+    person_by_cm_id = {1: {"campminder_person_id": 1}, 2: {"campminder_person_id": 2}}
+
+    score, _ = evaluator._calculate_request_satisfaction(assignments, requests, person_by_cm_id)
+
+    expected_per_request = int(BASE_REQUEST_WEIGHT * 1.0 * 1.0 * FIRST_REQUEST_MULTIPLIER)
+    assert score == 2 * expected_per_request
+
+
+def test_evaluator_mutual_boost_applies_to_every_slot(evaluator):
+    """A has two requests: A→B (mutual with B→A) and A→C (one-way).
+    Both satisfied. With enable_first_boost=true and is_first_requested=true
+    on A→B, A→B lands in slot 0 (FIRST=10) and A→C in slot 1 (SECOND=5).
+
+    A→B: BASE × source × mutual(2.0) × FIRST(10) = mutual-boosted slot 0.
+    A→C: BASE × source × 1.0 (no mutual) × SECOND(5) = one-way slot 1.
+    B→A: BASE × source × mutual(2.0) × FIRST(10) (B's only request).
+    Total = (40 × 2 × 10) + (40 × 1 × 5) + (40 × 2 × 10) = 800 + 200 + 800 = 1800.
+    """
+    assignments = {1: 100, 2: 100, 3: 100}  # all in bunk 100
+    requests = [
+        _dict_req(1, 2, is_first_requested=True),  # A→B mutual, first-pick
+        _dict_req(1, 3),  # A→C one-way
+        _dict_req(2, 1, is_first_requested=True),  # B→A reciprocal, first-pick
+    ]
+    person_by_cm_id = {
+        1: {"campminder_person_id": 1},
+        2: {"campminder_person_id": 2},
+        3: {"campminder_person_id": 3},
+    }
+
+    score, _ = evaluator._calculate_request_satisfaction(assignments, requests, person_by_cm_id)
+
+    a_b = int(BASE_REQUEST_WEIGHT * 1.0 * 2.0 * FIRST_REQUEST_MULTIPLIER)
+    a_c = int(BASE_REQUEST_WEIGHT * 1.0 * 1.0 * SECOND_REQUEST_MULTIPLIER)
+    b_a = int(BASE_REQUEST_WEIGHT * 1.0 * 2.0 * FIRST_REQUEST_MULTIPLIER)
+    assert score == a_b + a_c + b_a
+
+
+def test_evaluator_disabled_boost_via_config_1():
+    """Setting objective.mutual_request_boost=1.0 disables the boost without
+    removing the code path. Mutual pair scores as if non-mutual."""
+    ev = ObjectiveEvaluator(
+        config=_StubConfig({"objective.mutual_request_boost": 1.0}),  # type: ignore[arg-type]
+    )
+    assignments = {1: 100, 2: 100}
+    requests = [_dict_req(1, 2), _dict_req(2, 1)]
+    person_by_cm_id = {1: {"campminder_person_id": 1}, 2: {"campminder_person_id": 2}}
+
+    score, _ = ev._calculate_request_satisfaction(assignments, requests, person_by_cm_id)
+    # No mutual boost — each direction is just BASE × source × FIRST.
+    expected_per_request = int(BASE_REQUEST_WEIGHT * 1.0 * 1.0 * FIRST_REQUEST_MULTIPLIER)
+    assert score == 2 * expected_per_request
+
+
+# ---------------------------------------------------------------------------
+# Solver source inspection — light guard that the new config key is consumed
+# in add_objective. Full integration coverage lives in test_score_evaluator.py
+# golden tests.
+# ---------------------------------------------------------------------------
+
+
+def test_add_objective_consumes_mutual_request_boost():
+    """add_objective() must read objective.mutual_request_boost from config
+    and reference the precomputed mutual-pair set. Source inspection only —
+    full integration tested in objective end-to-end fixtures."""
+    from bunking.solver import direct_solver
+
+    src = inspect.getsource(direct_solver.DirectBunkingSolver.add_objective)
+    assert "objective.mutual_request_boost" in src, "add_objective must read the mutual_request_boost config key"
+    assert "compute_mutual_bunk_with_pairs" in src or "mutual_bunk_with_pairs" in src, (
+        "add_objective must use the precomputed mutual pairs set"
+    )

--- a/tests/unit/bunking/solver/test_mutual_request_boost.py
+++ b/tests/unit/bunking/solver/test_mutual_request_boost.py
@@ -448,6 +448,19 @@ def test_score_evaluator_disabled_boost_via_config_1():
     assert result.request_satisfaction_score == 2 * expected_per_request
 
 
+def test_mutual_boost_schema_floor_is_one():
+    """Defense-in-depth: schema must not allow values below 1.0. A boost <1.0
+    would inversely downweight reciprocated requests vs. one-way ones — the
+    opposite of the feature's intent. 'Disable' is set-to-1.0, not 0.0."""
+    from bunking.config.schema import CONFIG_SCHEMA
+
+    entry = CONFIG_SCHEMA["objective.mutual_request_boost"]
+    assert entry.min_value == 1.0, (
+        f"mutual_request_boost min_value must be 1.0 (got {entry.min_value}) — "
+        "anything lower inversely downweights mutual pairs"
+    )
+
+
 def test_score_evaluator_not_bunk_with_never_boosts():
     """Reciprocal not_bunk_with must NOT be boosted (symmetric by intent)."""
     from bunking.solver.score_evaluator import evaluate_scenario_score

--- a/tests/unit/bunking/solver/test_mutual_request_boost.py
+++ b/tests/unit/bunking/solver/test_mutual_request_boost.py
@@ -23,6 +23,7 @@ from bunking.solver.direct_solver import (
     FIRST_REQUEST_MULTIPLIER,
     SECOND_REQUEST_MULTIPLIER,
     compute_mutual_bunk_with_pairs,
+    find_mutual_pairs,
 )
 from bunking.solver.objective_evaluator import ObjectiveEvaluator
 
@@ -53,7 +54,37 @@ def _group(reqs: list[DirectBunkRequest]) -> dict[int, list[DirectBunkRequest]]:
 
 
 # ---------------------------------------------------------------------------
-# compute_mutual_bunk_with_pairs — helper that detects reciprocal pairs.
+# find_mutual_pairs — shared helper. Takes pre-filtered directed edges, returns
+# the unordered pairs that appear in both directions. Both solver-side
+# (compute_mutual_bunk_with_pairs) and evaluator-side detection sit on top.
+# ---------------------------------------------------------------------------
+
+
+def test_find_mutual_pairs_detects_reciprocal_edges():
+    assert find_mutual_pairs([(1, 2), (2, 1)]) == {frozenset({1, 2})}
+
+
+def test_find_mutual_pairs_ignores_one_way_edges():
+    assert find_mutual_pairs([(1, 2), (3, 4)]) == set()
+
+
+def test_find_mutual_pairs_handles_multiple_disjoint_pairs():
+    edges = [(1, 2), (2, 1), (3, 4), (4, 3)]
+    assert find_mutual_pairs(edges) == {frozenset({1, 2}), frozenset({3, 4})}
+
+
+def test_find_mutual_pairs_empty_input():
+    assert find_mutual_pairs([]) == set()
+
+
+def test_find_mutual_pairs_dedupes_repeated_edges():
+    """Repeated directed edges collapse via set semantics; the result is the
+    same as if each direction appeared once."""
+    assert find_mutual_pairs([(1, 2), (1, 2), (2, 1), (2, 1)]) == {frozenset({1, 2})}
+
+
+# ---------------------------------------------------------------------------
+# compute_mutual_bunk_with_pairs — bunk_with-specific wrapper over find_mutual_pairs.
 # ---------------------------------------------------------------------------
 
 
@@ -316,3 +347,117 @@ def test_add_objective_consumes_mutual_request_boost():
     assert "compute_mutual_bunk_with_pairs" in src or "mutual_bunk_with_pairs" in src, (
         "add_objective must use the precomputed mutual pairs set"
     )
+
+
+# ---------------------------------------------------------------------------
+# score_evaluator.py — third evaluator path, must mirror the same boost as
+# the solver (else baseline-regression goldens silently drift on reciprocal
+# pairs). The boost is "always-on" so it has to land here too.
+# ---------------------------------------------------------------------------
+
+
+class _ScoreEvalConfig:
+    """Config stub for score_evaluator tests. Keeps source multipliers at 1.0
+    so the test math reduces to BASE × mutual × slot."""
+
+    def __init__(self, mutual_boost: float = 2.0):
+        self._values: dict[str, Any] = {
+            "objective.enable_first_boost": 1,
+            "objective.mutual_request_boost": mutual_boost,
+            "objective.source_multipliers.share_bunk_with": 1.0,
+            "objective.source_multipliers.do_not_share_with": 1.0,
+            "objective.source_multipliers.bunking_notes": 1.0,
+            "objective.source_multipliers.internal_notes": 1.0,
+            "objective.source_multipliers.socialize_preference": 1.0,
+            "constraint.grade_spread.max_spread": 99,
+            "constraint.grade_spread.penalty": 0,
+            "constraint.cabin_minimum_occupancy.penalty": 0,
+            "constraint.cabin_capacity.penalty": 0,
+            "constraint.cabin_capacity.standard": 12,
+        }
+
+    def get_int(self, key: str, default: int = 0) -> int:
+        v = self._values.get(key, default)
+        return int(v) if v is not None else default
+
+    def get_float(self, key: str, default: float = 0.0) -> float:
+        v = self._values.get(key, default)
+        return float(v) if v is not None else default
+
+    def get_str(self, key: str, default: str = "") -> str:
+        v = self._values.get(key, default)
+        return str(v) if v is not None else default
+
+    def get_bool(self, key: str, default: bool = False) -> bool:
+        v = self._values.get(key, default)
+        return bool(v) if v is not None else default
+
+
+def _se_req(requester: int, requestee: int, request_type: str = "bunk_with") -> dict[str, Any]:
+    return {
+        "id": f"r{requester}_{requestee}",
+        "requester_id": requester,
+        "requestee_id": requestee,
+        "request_type": request_type,
+        "is_first_requested": True,
+        "source_field": None,
+    }
+
+
+def test_score_evaluator_mutual_bunk_with_doubles_weight():
+    """score_evaluator must apply the mutual boost — without this the third
+    evaluator path silently undercounts mutual pairs vs. the solver and
+    objective_evaluator. Both A↔B in the same bunk; default boost 2.0."""
+    from bunking.solver.score_evaluator import evaluate_scenario_score
+
+    requests = [_se_req(1, 2), _se_req(2, 1)]
+    assignments = [{"person_cm_id": 1, "bunk_cm_id": 100}, {"person_cm_id": 2, "bunk_cm_id": 100}]
+    persons = [{"cm_id": 1, "grade": 5}, {"cm_id": 2, "grade": 5}]
+    bunks = [{"cm_id": 100, "max_size": 12}]
+    result = evaluate_scenario_score(requests, assignments, persons, bunks, config=_ScoreEvalConfig())
+
+    expected_per_request = int(BASE_REQUEST_WEIGHT * 1.0 * 2.0 * FIRST_REQUEST_MULTIPLIER)
+    assert result.request_satisfaction_score == 2 * expected_per_request
+
+
+def test_score_evaluator_one_way_bunk_with_no_boost():
+    """One-way request gets no boost — baseline slot-0 weight only."""
+    from bunking.solver.score_evaluator import evaluate_scenario_score
+
+    requests = [_se_req(1, 2)]
+    assignments = [{"person_cm_id": 1, "bunk_cm_id": 100}, {"person_cm_id": 2, "bunk_cm_id": 100}]
+    persons = [{"cm_id": 1, "grade": 5}, {"cm_id": 2, "grade": 5}]
+    bunks = [{"cm_id": 100, "max_size": 12}]
+    result = evaluate_scenario_score(requests, assignments, persons, bunks, config=_ScoreEvalConfig())
+
+    expected = int(BASE_REQUEST_WEIGHT * 1.0 * 1.0 * FIRST_REQUEST_MULTIPLIER)
+    assert result.request_satisfaction_score == expected
+
+
+def test_score_evaluator_disabled_boost_via_config_1():
+    """objective.mutual_request_boost=1.0 disables the boost in-place."""
+    from bunking.solver.score_evaluator import evaluate_scenario_score
+
+    requests = [_se_req(1, 2), _se_req(2, 1)]
+    assignments = [{"person_cm_id": 1, "bunk_cm_id": 100}, {"person_cm_id": 2, "bunk_cm_id": 100}]
+    persons = [{"cm_id": 1, "grade": 5}, {"cm_id": 2, "grade": 5}]
+    bunks = [{"cm_id": 100, "max_size": 12}]
+    result = evaluate_scenario_score(requests, assignments, persons, bunks, config=_ScoreEvalConfig(mutual_boost=1.0))
+
+    expected_per_request = int(BASE_REQUEST_WEIGHT * 1.0 * 1.0 * FIRST_REQUEST_MULTIPLIER)
+    assert result.request_satisfaction_score == 2 * expected_per_request
+
+
+def test_score_evaluator_not_bunk_with_never_boosts():
+    """Reciprocal not_bunk_with must NOT be boosted (symmetric by intent)."""
+    from bunking.solver.score_evaluator import evaluate_scenario_score
+
+    requests = [_se_req(1, 2, "not_bunk_with"), _se_req(2, 1, "not_bunk_with")]
+    # Place in different bunks so both not_bunk_with are satisfied.
+    assignments = [{"person_cm_id": 1, "bunk_cm_id": 100}, {"person_cm_id": 2, "bunk_cm_id": 200}]
+    persons = [{"cm_id": 1, "grade": 5}, {"cm_id": 2, "grade": 5}]
+    bunks = [{"cm_id": 100, "max_size": 12}, {"cm_id": 200, "max_size": 12}]
+    result = evaluate_scenario_score(requests, assignments, persons, bunks, config=_ScoreEvalConfig())
+
+    expected_per_request = int(BASE_REQUEST_WEIGHT * 1.0 * 1.0 * FIRST_REQUEST_MULTIPLIER)
+    assert result.request_satisfaction_score == 2 * expected_per_request

--- a/tests/unit/bunking/solver/test_mutual_request_boost.py
+++ b/tests/unit/bunking/solver/test_mutual_request_boost.py
@@ -404,17 +404,32 @@ def _se_req(requester: int, requestee: int, request_type: str = "bunk_with") -> 
     }
 
 
+def _run_score_evaluator(
+    stub: _ScoreEvalConfig,
+    requests: list[dict[str, Any]],
+    assignments: list[dict[str, Any]],
+    persons: list[dict[str, Any]],
+    bunks: list[dict[str, Any]],
+) -> Any:
+    """Install the stub via ConfigLoader.use so the centralized accessors in
+    score_evaluator._calculate_penalties (grade_spread_penalty, etc.) read
+    from it. Without this, CI without a seeded DB fails on missing keys."""
+    from bunking.config import ConfigLoader
+    from bunking.solver.score_evaluator import evaluate_scenario_score
+
+    with ConfigLoader.use(stub):  # type: ignore[arg-type]
+        return evaluate_scenario_score(requests, assignments, persons, bunks, config=stub)
+
+
 def test_score_evaluator_mutual_bunk_with_doubles_weight():
     """score_evaluator must apply the mutual boost — without this the third
     evaluator path silently undercounts mutual pairs vs. the solver and
     objective_evaluator. Both A↔B in the same bunk; default boost 2.0."""
-    from bunking.solver.score_evaluator import evaluate_scenario_score
-
     requests = [_se_req(1, 2), _se_req(2, 1)]
     assignments = [{"person_cm_id": 1, "bunk_cm_id": 100}, {"person_cm_id": 2, "bunk_cm_id": 100}]
     persons = [{"cm_id": 1, "grade": 5}, {"cm_id": 2, "grade": 5}]
     bunks = [{"cm_id": 100, "max_size": 12}]
-    result = evaluate_scenario_score(requests, assignments, persons, bunks, config=_ScoreEvalConfig())
+    result = _run_score_evaluator(_ScoreEvalConfig(), requests, assignments, persons, bunks)
 
     expected_per_request = int(BASE_REQUEST_WEIGHT * 1.0 * 2.0 * FIRST_REQUEST_MULTIPLIER)
     assert result.request_satisfaction_score == 2 * expected_per_request
@@ -422,13 +437,11 @@ def test_score_evaluator_mutual_bunk_with_doubles_weight():
 
 def test_score_evaluator_one_way_bunk_with_no_boost():
     """One-way request gets no boost — baseline slot-0 weight only."""
-    from bunking.solver.score_evaluator import evaluate_scenario_score
-
     requests = [_se_req(1, 2)]
     assignments = [{"person_cm_id": 1, "bunk_cm_id": 100}, {"person_cm_id": 2, "bunk_cm_id": 100}]
     persons = [{"cm_id": 1, "grade": 5}, {"cm_id": 2, "grade": 5}]
     bunks = [{"cm_id": 100, "max_size": 12}]
-    result = evaluate_scenario_score(requests, assignments, persons, bunks, config=_ScoreEvalConfig())
+    result = _run_score_evaluator(_ScoreEvalConfig(), requests, assignments, persons, bunks)
 
     expected = int(BASE_REQUEST_WEIGHT * 1.0 * 1.0 * FIRST_REQUEST_MULTIPLIER)
     assert result.request_satisfaction_score == expected
@@ -436,13 +449,11 @@ def test_score_evaluator_one_way_bunk_with_no_boost():
 
 def test_score_evaluator_disabled_boost_via_config_1():
     """objective.mutual_request_boost=1.0 disables the boost in-place."""
-    from bunking.solver.score_evaluator import evaluate_scenario_score
-
     requests = [_se_req(1, 2), _se_req(2, 1)]
     assignments = [{"person_cm_id": 1, "bunk_cm_id": 100}, {"person_cm_id": 2, "bunk_cm_id": 100}]
     persons = [{"cm_id": 1, "grade": 5}, {"cm_id": 2, "grade": 5}]
     bunks = [{"cm_id": 100, "max_size": 12}]
-    result = evaluate_scenario_score(requests, assignments, persons, bunks, config=_ScoreEvalConfig(mutual_boost=1.0))
+    result = _run_score_evaluator(_ScoreEvalConfig(mutual_boost=1.0), requests, assignments, persons, bunks)
 
     expected_per_request = int(BASE_REQUEST_WEIGHT * 1.0 * 1.0 * FIRST_REQUEST_MULTIPLIER)
     assert result.request_satisfaction_score == 2 * expected_per_request
@@ -463,14 +474,12 @@ def test_mutual_boost_schema_floor_is_one():
 
 def test_score_evaluator_not_bunk_with_never_boosts():
     """Reciprocal not_bunk_with must NOT be boosted (symmetric by intent)."""
-    from bunking.solver.score_evaluator import evaluate_scenario_score
-
     requests = [_se_req(1, 2, "not_bunk_with"), _se_req(2, 1, "not_bunk_with")]
     # Place in different bunks so both not_bunk_with are satisfied.
     assignments = [{"person_cm_id": 1, "bunk_cm_id": 100}, {"person_cm_id": 2, "bunk_cm_id": 200}]
     persons = [{"cm_id": 1, "grade": 5}, {"cm_id": 2, "grade": 5}]
     bunks = [{"cm_id": 100, "max_size": 12}, {"cm_id": 200, "max_size": 12}]
-    result = evaluate_scenario_score(requests, assignments, persons, bunks, config=_ScoreEvalConfig())
+    result = _run_score_evaluator(_ScoreEvalConfig(), requests, assignments, persons, bunks)
 
     expected_per_request = int(BASE_REQUEST_WEIGHT * 1.0 * 1.0 * FIRST_REQUEST_MULTIPLIER)
     assert result.request_satisfaction_score == 2 * expected_per_request


### PR DESCRIPTION
Closes #1382. Implements **Phase 3** of the solver roadmap (Stream 4 — mutual-request boost). This is the next-build item per [docs/reference/solver-roadmap.md](docs/reference/solver-roadmap.md) after Phase 2's plateau-diagnostic metrics shipped in #1436.

## Summary
- New config knob `objective.mutual_request_boost` (FLOAT, default **2.0**, range [0.0, 10.0]). Always-on; set to 1.0 to disable in-place without removing the code path.
- New `compute_mutual_bunk_with_pairs(requests_by_person) -> set[frozenset[int]]` helper in `direct_solver.py` precomputes reciprocal `bunk_with` pairs once per solve. O(R) build, O(1) per-request lookup.
- `add_objective()` multiplies the per-request weight by the boost when the (requester, requestee) pair is mutual. Stacks multiplicatively with source_multipliers and the first/second/third-plus diminishing-returns multipliers, so a mutual first-pick = `BASE × source × 2.0 × FIRST_MULT` = up to 20× base.
- `objective_evaluator._calculate_request_satisfaction` mirrors the solver's logic exactly so post-solve scores match the solver's `ObjectiveValue()`.
- `not_bunk_with` is intentionally NOT boosted — reciprocal `not_bunk_with` is symmetric by intent (penalty already treats both directions equally), and a `bunk_with` ↔ `not_bunk_with` pair is a conflict, not agreement.
- Seed migration `1500000103_mutual_request_boost_config.js` inserts the default row with admin-GUI metadata (auto-renders via `ConfigInputs.tsx` — no frontend code needed).

## Why a config knob (not a hardcoded constant)
This is the only divergence from the doc's default "HARDCODE anything without production tuning evidence" lean. The user explicitly chose the knob path to enable empirical tuning of the multiplier against Phase 2's bound-trajectory chart (#1436). The revisit trigger for promoting to a constant is captured in the local `docs/reference/solver-config-decisions.md`.

## Test plan
- [x] 13 new unit tests in `tests/unit/bunking/solver/test_mutual_request_boost.py` — detection helper edge cases (one-way, self-loop, null requestee, mixed-type, multiple disjoint pairs, not_bunk_with) + evaluator weight calculation for mutual/one-way/not_bunk_with + every-slot stacking + the disable-via-1.0 path
- [x] All 426 solver tests pass, full unit suite 4688 passed
- [x] mypy clean, ruff clean
- [ ] Tune in real-camp solve via Solver Debug UI — sweep 1.5/2.0/3.0, watch bound-trajectory chart for plateau-break behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reciprocated bunk-with requests receive a configurable boost in objective scoring (config key objective.mutual_request_boost, float, min=1.0, max=10.0, default=2.0), increasing their per-request weight in diminishing-returns scoring.
* **Bug Fixes**
  * Score evaluation now only considers resolved bunk requests to avoid unresolved requests affecting scores.
* **Tests**
  * Added extensive unit tests for mutual-request detection, boosted scoring, schema guardrail, and baseline stability.
* **Chores**
  * Added a migration to seed the new config value.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->