### PR TITLE
fix(api): gate post-check rate metrics on impossibility (#1520)

### DIFF
--- a/api/routers/validation.py
+++ b/api/routers/validation.py
@@ -17,6 +17,7 @@ from pocketbase.client import ClientResponseError  # type: ignore[attr-defined]
 
 from bunking.auth_middleware import AuthUser
 from bunking.bunking_validator import BunkingValidator, HistoricalBunkingRecord
+from bunking.config import ConfigLoader
 from bunking.logging_config import get_logger
 from bunking.models import (
     Bunk,
@@ -27,6 +28,7 @@ from bunking.models import (
 )
 from bunking.rbac.dependencies import require_permission
 from bunking.rbac.permissions import Permission
+from bunking.solver.impossibility import validate_impossibility
 
 from ..constants.collections import (
     ATTENDEES,
@@ -41,6 +43,7 @@ from ..constants.collections import (
 from ..constants.filters import ACTIVE_ENROLLED_FILTER
 from ..dependencies import pb
 from ..schemas import ValidateBunkingRequest
+from ..services.data_fetcher import fetch_session_data_v2, prepare_direct_solver_input
 from ..services.session_context import build_session_context
 from ..utils.pb_error import pb_error_to_http
 from ..utils.session_metrics import get_person_from_expand, get_session_from_expand
@@ -376,6 +379,29 @@ async def validate_bunking(
             logger.warning(f"Failed to fetch historical bunking data: {e}")
             # Continue without historical data - level regression won't be checked
 
+        # #1520: Compute the impossibility set so post-check rate metrics gate on
+        # solver-actionable requests, matching the solver-side gating shipped in
+        # PR #1463. Mirrors the path `api.routers.solver.pre_validate_solver` uses
+        # so both endpoints agree on what counts as impossible. The doubled fetch
+        # (V1 above + V2 here) is acceptable overhead for now; a longer-term
+        # consolidation would route validation through the same V2 data path.
+        impossible_request_ids: set[str] = set()
+        try:
+            v2_attendees, v2_bunks, v2_requests, v2_assignments, v2_bunk_plans = await fetch_session_data_v2(
+                request.session_cm_id, ctx.year, pb, scenario=request.scenario
+            )
+            solver_input = prepare_direct_solver_input(
+                v2_attendees, v2_bunks, v2_requests, v2_assignments, v2_bunk_plans
+            )
+            impossibility_report = validate_impossibility(solver_input, ConfigLoader.get_instance())
+            impossible_request_ids = {item.request_id for item in impossibility_report.flat}
+        except Exception as e:
+            # Impossibility computation is metric-gating only — if it fails, log
+            # and fall through with ungated metrics so the validator still returns
+            # a usable result. The legacy ungated behavior was the pre-#1520
+            # default; failing closed (raising) would regress a working endpoint.
+            logger.warning(f"Impossibility gating skipped for session {ctx.session_cm_id}: {e}")
+
         # Run validation
         validator = BunkingValidator()
 
@@ -390,6 +416,7 @@ async def validate_bunking(
             bunk_plans=bunk_plans_for_validator,
             attendees=attendees_for_validator,
             historical_bunking=historical_bunking or None,
+            impossible_request_ids=impossible_request_ids or None,
         )
 
         return validation_result.model_dump()

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -251,6 +251,7 @@ class BunkingValidator:
         bunk_plans: list[Any] | None = None,
         attendees: list[Any] | None = None,
         historical_bunking: list[HistoricalBunkingRecord] | None = None,
+        impossible_request_ids: set[str] | None = None,
     ) -> ValidationResult:
         """
         Perform comprehensive validation of bunking assignments.
@@ -303,7 +304,15 @@ class BunkingValidator:
 
         # Validate request satisfaction
         bunk_by_id: dict[str, Bunk] = {b.campminder_id: b for b in bunks}
-        self._validate_requests(requests, assignments_by_person, person_by_id, stats, issues, bunk_by_id=bunk_by_id)
+        self._validate_requests(
+            requests,
+            assignments_by_person,
+            person_by_id,
+            stats,
+            issues,
+            bunk_by_id=bunk_by_id,
+            impossible_request_ids=impossible_request_ids,
+        )
 
         # Validate age/grade spreads
         self._validate_spreads(bunks, assignments_by_bunk, person_by_id, stats, issues)
@@ -433,8 +442,24 @@ class BunkingValidator:
         stats: ValidationStatistics,
         issues: list[ValidationIssue],
         bunk_by_id: dict[str, Bunk] | None = None,
+        impossible_request_ids: set[str] | None = None,
     ) -> None:
-        """Validate request satisfaction - tracking by source field."""
+        """Validate request satisfaction - tracking by source field.
+
+        Aggregate rate metrics (``material_parent_*``, ``staff_*``, ``total_*``,
+        ``mp_campers_*``) gate on ``impossible_request_ids`` so the post-check
+        denominators match the solver-side ones produced by PR #1463
+        (``direct_solver._check_must_satisfy_one_violations``). Without that
+        gating, structurally-impossible requests (cross-gender pairs, oldest-grade
+        kid asking for "older", etc.) drag the validator's rates below the
+        solver's even though no feasible assignment can fix them.
+        See #1520.
+
+        Issue listings (``valid_request_unsatisfied`` warnings,
+        ``unsatisfied_material_parent_persons`` drill-down) intentionally stay
+        ungated — the staff modal still surfaces every unmet request so
+        per-camper detail remains visible.
+        """
         # Valid statuses are 'resolved' (accepted/approved)
         valid_statuses = {"resolved"}
 
@@ -785,10 +810,21 @@ class BunkingValidator:
         total_alerting_requests = sum(len(reqs) for reqs in alerting_requests_by_person.values())
         total_satisfied_alerting_requests = sum(len(reqs) for reqs in satisfied_alerting_by_person.values())
 
+        # #1520: gate aggregate counters on the impossibility set so the
+        # post-check denominators match solver-side (PR #1463). Empty/None set
+        # = legacy ungated behavior (preserved for callers that don't compute
+        # impossibility).
+        _impossible_ids: set[str] = impossible_request_ids or set()
+
+        def _gated(reqs: list[BunkRequest]) -> list[BunkRequest]:
+            if not _impossible_ids:
+                return reqs
+            return [r for r in reqs if getattr(r, "id", None) not in _impossible_ids]
+
         # Material parent (bunk_with source_field) stats.
-        stats.material_parent_requests = sum(len(reqs) for reqs in material_parent_by_person.values())
+        stats.material_parent_requests = sum(len(_gated(reqs)) for reqs in material_parent_by_person.values())
         stats.satisfied_material_parent_requests = sum(
-            len(reqs) for reqs in satisfied_material_parent_by_person.values()
+            len(_gated(reqs)) for reqs in satisfied_material_parent_by_person.values()
         )
         if stats.material_parent_requests > 0:
             stats.material_parent_request_satisfaction_rate = (
@@ -852,19 +888,21 @@ class BunkingValidator:
         stats.unsatisfied_material_parent_detail = unsatisfied_material_parent_detail
 
         # Camper-level two-tier MP coverage.
-        # mp_campers_total = distinct requesters with ≥1 MP request.
-        # at_least_one = requester has ≥1 satisfied MP request.
-        # all_satisfied = requester has ≥1 MP request AND every MP request is satisfied.
-        stats.mp_campers_total = sum(1 for reqs in material_parent_by_person.values() if reqs)
+        # mp_campers_total = distinct requesters with ≥1 *possible* MP request.
+        # at_least_one = requester has ≥1 satisfied (possible) MP request.
+        # all_satisfied = requester has ≥1 MP request AND every *possible* MP request is satisfied.
+        # #1520: counts gate on impossibility so a camper whose entire MP set is
+        # impossible drops out of the denominator (matches solver-side parity).
+        stats.mp_campers_total = sum(1 for reqs in material_parent_by_person.values() if _gated(reqs))
         stats.mp_campers_with_at_least_one_satisfied = sum(
             1
             for pid, reqs in material_parent_by_person.items()
-            if reqs and satisfied_material_parent_by_person.get(pid)
+            if _gated(reqs) and _gated(satisfied_material_parent_by_person.get(pid, []))
         )
         stats.mp_campers_with_all_satisfied = sum(
             1
             for pid, reqs in material_parent_by_person.items()
-            if reqs and len(satisfied_material_parent_by_person.get(pid, [])) == len(reqs)
+            if _gated(reqs) and len(_gated(satisfied_material_parent_by_person.get(pid, []))) == len(_gated(reqs))
         )
 
         # Best-effort parent (socialize_with source_field) stats.
@@ -877,8 +915,10 @@ class BunkingValidator:
                 stats.satisfied_best_effort_parent_requests / stats.best_effort_parent_requests
             )
 
-        stats.staff_requests = sum(len(reqs) for reqs in staff_requests_by_person.values())
-        stats.satisfied_staff_requests = sum(len(reqs) for reqs in satisfied_staff_by_person.values())
+        # #1520: staff requests gate on impossibility too, so `total_requests`
+        # (= MP + staff) stays internally consistent.
+        stats.staff_requests = sum(len(_gated(reqs)) for reqs in staff_requests_by_person.values())
+        stats.satisfied_staff_requests = sum(len(_gated(reqs)) for reqs in satisfied_staff_by_person.values())
         if stats.staff_requests > 0:
             stats.staff_request_satisfaction_rate = stats.satisfied_staff_requests / stats.staff_requests
 

--- a/docs/reference/solver-roadmap.md
+++ b/docs/reference/solver-roadmap.md
@@ -923,9 +923,33 @@ stay ungated by design. **V1/V2 consolidation deferred** — the narrow path
 restores parity now and the structural divergence remains as a future trigger
 when a non-cosmetic field-validator drift surfaces.
 
-Known overhead: the validation route now does a second V2 data fetch
-alongside the existing V1 fetches. Acceptable for correctness; a longer-term
-refactor would consolidate validation onto the V2 data path.
+**Known overhead introduced by #1520.** `api/routers/validation.py` now does
+a parallel V2 fetch (`fetch_session_data_v2`) alongside its existing V1
+fetches — same PB collections (attendees, bunks, requests, assignments,
+bunk_plans) pulled twice with different shapes. Roughly **5 extra PB
+`get_full_list` round-trips per `/api/validate-bunking` call**. On a typical
+S2-sized session that's on the order of 100–500ms additional latency,
+dominated by PB call latency, not by `validate_impossibility` itself (which
+runs predicates over an in-memory list and is sub-ms).
+
+Two optimization paths if the overhead bites:
+
+- **Short-term — frontend passes precomputed IDs.** The post-check modal
+  already has a `preCheckQuery` that fetches `/api/solver/pre-validate` and
+  caches the impossibility report. Threading `impossible_request_ids` through
+  `ValidateBunkingRequest` lets the route skip the recompute when the caller
+  provides them. Validator keeps the route-side compute as a fallback so
+  legacy/scripted callers stay correct. Small change, no V1/V2 reshape.
+- **Long-term — V1/V2 validation route consolidation.** Refactor
+  `validation.py` to fetch via `fetch_session_data_v2` exclusively; the
+  validator either stays V1 behind a V2→V1 adapter or migrates to V2 directly.
+  This is the parked V1/V2 consolidation work — the #1520 fix doesn't trigger
+  it (the narrow path restored parity), but if the validation route gains
+  another structurally similar concern it becomes the forcing function.
+
+Neither is filed today. The overhead hasn't been measured in production yet;
+file if SolverDebug page latency or staff-modal-perceived lag actually
+regresses.
 
 ---
 

--- a/docs/reference/solver-roadmap.md
+++ b/docs/reference/solver-roadmap.md
@@ -5,6 +5,12 @@ emerged from the May 2026 stuck-core investigation. Each stream gets a
 dedicated GitHub issue; specs and plans live in `docs/superpowers/` (local
 only) once individual streams are picked up.
 
+> **Updated 2026-05-18 (post-#1523, post-#1520).** Stream 4 (mutual-request
+> boost, Phase 3) shipped. The #1520 validator-side parity fix also shipped.
+> Only **Stream 3 (#1381 — Phase 4, variable-count attack surface)** remains
+> genuinely open as planned work; Stream 6 substreams 6a–6f stay incremental
+> and unfiled until a real need surfaces.
+
 > **Why this doc exists.** The May 12 investigation surfaced four
 > distinct improvements at once (camp-policy fix, observability gap,
 > variable-count attack surface, objective tuning). The investigation
@@ -36,8 +42,8 @@ only) once individual streams are picked up.
 | Stream 2 Tier 2 — plateau-diagnostic metrics | none (spec in-doc) | #1436 | ✅ shipped 2026-05-14 |
 | Golden sat-var ↔ predicate alignment test | #1398 | #1434 | ✅ shipped 2026-05-14 (Option 2 — bunk_with/not_bunk_with only) |
 | Retire `solution.calculate_satisfied_requests` | #1397 | #1438 | ✅ shipped 2026-05-15 |
-| **Stream 4 — mutual-request boost** | #1382 | — | ⬜ **Phase 3 — next build** |
-| Stream 3 — variable-count attack surface | #1381 | — | ⬜ Phase 4 (re-scope first) |
+| Stream 4 — mutual-request boost | #1382 | #1523 | ✅ shipped 2026-05-18 (Phase 3) |
+| Stream 3 — variable-count attack surface | #1381 | — | ⬜ **Phase 4 — next build (re-scope first)** |
 | Penalty-driven MP-coverage investigation | #1396 | — | ✅ closed not-planned 2026-05-17 (Phase-2 bound-trajectory chart shows the plateau directly; counterfactuals moot) |
 | Audit `direct_solver` for hand-rolled impossibility logic | #1426 | — | ✅ closed 2026-05-17 — audit deliverable at `docs/plans/audit-1426-impossibility.md` (local); no remaining hand-rolled logic to migrate |
 | Consolidate parallel solver models (`bunking/models.py` vs `bunking/models_v2.py`) | #1451 | — | ✅ closed not-planned 2026-05-17 — see "Parked — V1/V2 models consolidation" section below |
@@ -47,7 +53,7 @@ only) once individual streams are picked up.
 | Separate red "totally impossible MP campers" chip on Solver Debug pre-check button | #1440 | #1465 | ✅ shipped 2026-05-15 |
 | Make camper names click-through in impossibility modals + replace "fix parent input" copy | #1441 | #1464 | ✅ shipped 2026-05-16 |
 | Exclude impossible requests from `all_camper_rate` ("Optimized") + surface in post-check modal | #1442 | #1463, #1464 | ✅ shipped 2026-05-15 |
-| Validator-side parity (post-check denominator gating) | #1520 | — | ⬜ small — see "First drift instance observed" in V1/V2 Parked section |
+| Validator-side parity (post-check denominator gating) | #1520 | (this PR) | ✅ shipped 2026-05-18 — narrow tactical path; V1/V2 consolidation still deferred |
 | Retire dead `DirectSolverOutput.analysis` path | #1437 | #1453 | ✅ shipped 2026-05-15 |
 | Tighten `request_validation_summary` to a `RequestValidationSummary` TypedDict | #1386 | #1487 | ✅ shipped 2026-05-18 |
 | Remove unreachable per-bunk branch in `age_preference` sat-var builder | #1467 | — | ✅ shipped 2026-05-16 |
@@ -89,14 +95,15 @@ issue. (Tier 2 was orphaned when #1380 ("Tier 1 + Tier 2") closed on Tier 1
 alone; the remaining Tier 2/Tier 3 metrics stay tracked in the Stream 2
 tables and are picked up only when a specific question demands them.)
 
-**Phase 3 — Mutual-request boost (NEXT BUILD — Stream 4 / #1382).** Highest-
-leverage plateau intervention: reshapes the objective toward reciprocated
-pairs so that when Stage 4's hard constraint binds, it preferentially honors
-mutual requests. Well-scoped (~80–120 LOC). Phase 2's best-bound trajectory
-is now in place, so a Phase 3 sweep can be evaluated against a real
-"converging vs. stuck" signal rather than just final objective shuffle.
+**Phase 3 — Mutual-request boost (SHIPPED — Stream 4 / #1382, PR #1523, 2026-05-18).**
+Highest-leverage plateau intervention: reshapes the objective toward
+reciprocated pairs so that when Stage 4's hard constraint binds, it
+preferentially honors mutual requests. Well-scoped (~80–120 LOC). Phase 2's
+best-bound trajectory is in place, so the post-merge sweep can be evaluated
+against a real "converging vs. stuck" signal rather than just final objective
+shuffle.
 
-**Phase 4 — Compound & consolidate.** Stream 3 variable-count attack
+**Phase 4 — Compound & consolidate (NEXT BUILD).** Stream 3 variable-count attack
 (#1381), **re-scoped first**: #1391 + #1427 already removed `both_in_bunk`
 (the old lever 3b) and the duplicate MP sat vars, so the blast radius is far
 smaller than the original estimate — lever 3a (sparse `person_in_bunk`
@@ -607,7 +614,7 @@ Add `objective.mutual_request_boost = 2.0` to admin GUI. Defaults to
 
 ### GitHub issue
 
-#1382. This is Phase 3 — the next *build* after Tier 2 (Phase 2) lands.
+#1382. **Shipped** in PR #1523 (2026-05-18) as Phase 3.
 
 ---
 
@@ -900,9 +907,25 @@ Revisit when **any** of these become true:
 
 Until one of these triggers, the priority-deletion-style per-domain cleanup (Phase 1.5 via `solver-config-it`) handles V1-side fields as they're individually retired (priority already gone via #1455). The duplication shrinks on its own as each domain wraps.
 
-### First drift instance observed (2026-05-18)
+### First drift instance observed (2026-05-18) — RESOLVED narrow
 
-Post-#1442 (solver-side impossibility gating), the post-check modal shows ~92% (152/166) where the solver-side JSON shows ~97% (151/155) for the same solve. Root cause: `bunking/bunking_validator.py:789-795` (V1 path) computes `material_parent_requests` independently from raw resolved requests and never gates on the impossibility report. Filed as **#1520** (tactical validator-side gating, scope-matched to #1463) rather than a V1/V2 trigger; the drift instance is captured here so the reviewer picking up #1520 can decide whether to fold the validator gating into a larger V1/V2 consolidation pass or ship narrow.
+Post-#1442 (solver-side impossibility gating), the post-check modal showed
+~92% (152/166) where the solver-side JSON showed ~97% (151/155) for the same
+solve. Root cause: `bunking/bunking_validator.py:789-795` (V1 path) computed
+`material_parent_requests` independently from raw resolved requests and never
+gated on the impossibility report. Filed as **#1520** and shipped 2026-05-18
+on the **narrow tactical** path: validator gained an `impossible_request_ids`
+kwarg, `api/routers/validation.py` computes it via the same
+`fetch_session_data_v2` → `prepare_direct_solver_input` →
+`validate_impossibility` path `pre_validate_solver` uses, and threads IDs to
+the validator. Validator stays V1-pure; issue listings (per-camper warnings)
+stay ungated by design. **V1/V2 consolidation deferred** — the narrow path
+restores parity now and the structural divergence remains as a future trigger
+when a non-cosmetic field-validator drift surfaces.
+
+Known overhead: the validation route now does a second V2 data fetch
+alongside the existing V1 fetches. Acceptable for correctness; a longer-term
+refactor would consolidate validation onto the V2 data path.
 
 ---
 
@@ -1082,3 +1105,24 @@ Post-#1442 (solver-side impossibility gating), the post-check modal shows ~92% (
   instance — `bunking_validator.py` doesn't gate the post-check denominator
   on impossibility, producing 92% (validator) vs 97% (solver) on the same
   run. Logged in the V1/V2 Parked section as candidate trigger.
+- **2026-05-18** — **Stream 4 (#1382, mutual-request boost) shipped in
+  PR #1523** — Phase 3 complete. Boost detects reciprocated `bunk_with`
+  pairs and applies a configurable `objective.mutual_request_boost`
+  multiplier in `score_evaluator`; symmetric so model symmetry is
+  preserved. Phase 2's best-bound trajectory is the post-merge
+  measurement signal. **Phase 4 (Stream 3 / #1381, variable-count attack
+  surface, re-scope first)** is the next build — lever 3a (sparse
+  `person_in_bunk` gender filter) is the main remaining win since #1391
+  + #1427 already ate `both_in_bunk`.
+- **2026-05-18** — **#1520 (validator-side parity) shipped** on the
+  narrow tactical path. `bunking_validator.validate_bunking()` gained an
+  `impossible_request_ids: set[str] | None` kwarg; aggregate counters
+  (`material_parent_*`, `staff_*`, `total_*`, `mp_campers_*`) gate on it
+  so post-check denominators match the solver-side gating from #1463.
+  `api/routers/validation.py` computes the set via the same
+  `fetch_session_data_v2` → `prepare_direct_solver_input` →
+  `validate_impossibility` path `pre_validate_solver` uses. Issue
+  listings stay ungated by design — per-camper warnings still surface
+  every unmet request. The first-drift entry in the V1/V2 Parked
+  section is now resolved; V1/V2 consolidation remains deferred until
+  a non-cosmetic field-validator drift forces it.

--- a/docs/reference/solver-roadmap.md
+++ b/docs/reference/solver-roadmap.md
@@ -103,13 +103,20 @@ best-bound trajectory is in place, so the post-merge sweep can be evaluated
 against a real "converging vs. stuck" signal rather than just final objective
 shuffle.
 
-**Phase 4 — Compound & consolidate (NEXT BUILD).** Stream 3 variable-count attack
-(#1381), **re-scoped first**: #1391 + #1427 already removed `both_in_bunk`
-(the old lever 3b) and the duplicate MP sat vars, so the blast radius is far
-smaller than the original estimate — lever 3a (sparse `person_in_bunk`
-gender filter) is the main remaining win, and Phase 2's compression-ratio
-metric tells you exactly what is left to cut. Plus the Group 55 tail
-(#1396, #1397) and Stream 6 substreams (#1426 audit, then 6a–6f).
+**Phase 4 — Compound & consolidate (NEXT BUILD).** Stream 3 variable-count
+attack (#1381), **re-scoped 2026-05-18** (see Stream 3 section below). Three
+sub-phases:
+
+- **Phase A** — read the most recent S2 `presolve_compression_ratio` from
+  PB (~30 min, no code) to decide whether lever 3a is justified.
+- **Phase B** — ship lever 3e (drop `req_satisfied` for impossible requests).
+  Tiny, low-risk, useful regardless of Phase A outcome.
+- **Phase C** — *conditional on Phase A* — sparse `person_in_bunk` +
+  `person_bunk_assignment` refactor; 11 constraint modules to update.
+
+Original lever 3b is moot (eaten by #1395), 3c shipped via Stream 1, and 3d/3f
+deferred per the re-scope rationale table. Stream 6 substreams 6a–6f remain
+incremental and unfiled.
 
 **Parallel / immediate (not gated):** #1398 golden alignment test shipped in
 #1434 (2026-05-14); #1397 retire-`calculate_satisfied_requests` shipped in
@@ -421,10 +428,116 @@ prioritizes them.
 
 ## Stream 3 — Variable-Count Attack Surface
 
-**Status:** Newly proposed. Compound savings; biggest blast radius of
-the four streams.
+**Status:** Re-scoped 2026-05-18 after Phase 0 (Stream 1 hard MSO),
+Phase 1 (pre-check honesty), and the sat-var unification in #1427
+removed roughly half the model bulk. The original spec is preserved
+below with strikethrough; the live re-scope is in **"Re-scope
+(2026-05-18)"** before the legacy section.
 
-### Motivation
+### Re-scope (2026-05-18)
+
+#### What changed
+
+The 2026-05-15 verification sweep showed S2 model size collapsed from
+**11,657 → 5,215 variables (−55%)** and **23,644 → 12,060 constraints
+(−49%)** after #1427's sat-var unification. The roadmap's original
+"5,561 booleans post-presolve, 9,750 pre-presolve" baseline is stale,
+and several of the original levers were eaten in the process:
+
+- Lever 3b (`both_in_bunk`) — **moot**, removed in #1395 (orphaned by
+  #1391)
+- Lever 3c (hard MSO) — **shipped** as Stream 1 (#1391)
+- The ~250 duplicate MP sat vars from the original spec — **gone**
+  via #1427's `request_satisfied_vars` unification
+
+The original compound-impact framing (**5,561 → ~3,000, −46%**) was
+predicated on 3a + 3b + Stream 1 together. With 3b moot and Stream 1
+shipped, lever 3a is the **only remaining mechanical lever of size**,
+and even its real value depends on a number nobody has measured yet:
+the **current** pre-presolve count post-#1427. Phase 2's
+`presolve_compression_ratio` metric (#1436) was built to answer
+exactly this.
+
+#### Phased re-scope
+
+**Phase A — Measure before modeling (~30 min, no code change).** Read
+the most recent S2 `solver_runs.stats.presolve_compression_ratio`
+from PB. Three branches:
+
+- **Ratio ≥ 0.3** (presolve eliminates ≥30%): lever 3a is worth the
+  foundational-layer touch. Proceed to Phase C.
+- **Ratio 0.15–0.3**: judgment call — fewer BoolVars to save, but
+  also smaller cleanup. Defer pending a real performance complaint.
+- **Ratio < 0.15** (model already tight): Stream 3 collapses to Phase
+  B only, and the rest of #1381 closes as "no remaining attack
+  surface." File a closing comment with the ratio number.
+
+This is not a tracked sub-issue — it's a sub-30-min `gh pr view`
+moment whoever picks Stream 3 up does first.
+
+**Phase B — Lever 3e warmup (small PR, any time).** Drop
+`req_satisfied` BoolVars for requests already in
+`impossibility_report.flat` (the per-request set is now the canonical
+post-#1429 source of truth). Tiny — ~10 LOC plus a test, no risk,
+behaviour-neutral since impossible requests already don't contribute
+to the objective. Worth shipping whether or not we proceed to 3a; it
+also establishes a clean "missing key → 0" pattern that Phase C will
+need at scale.
+
+**Phase C — Lever 3a (sparse `person_in_bunk` + `person_bunk_assignment`),
+conditional on Phase A.** Refactor
+`direct_solver.py:_create_assignment_variables` to skip cross-gender
+and cross-session (person, bunk) pairs at model-build. **11 constraint
+modules** consume `ctx.assignments[(p, b)]` directly via tuple-key
+access and will all need either a `.get(...)` guard or a range-filter
+update to handle missing keys; the readers are:
+`age_grade_flow.py`, `age_preference.py`, `age_spread.py`,
+`cabin_capacity.py`, `cabin_occupancy.py`, `gender.py`,
+`grade_adjacency.py`, `grade_ratio.py`, `grade_spread.py`,
+`group_locks.py`, `level_progression.py`. Gender constraint becomes
+mostly a no-op (the forced-zero cases never get created); residual
+gender enforcement stays for unknown-gender persons. Estimated savings
+on S2: ~1,640 BoolVars cross-gender plus whatever cross-session pairs
+exist in multi-session mode (related sessions). Risk: foundational
+modeling layer; new test fixtures required for gender-mismatch paths
+because today's tests pass trivially against the dense-then-forced-zero
+encoding.
+
+#### Dropped from scope (with rationale)
+
+| # | Status | Rationale |
+|---|---|---|
+| 3b | **Closed** | `both_in_bunk` removed by #1395; no sparse-encoding lever exists on a structure that no longer exists. |
+| 3c | **Shipped** | Hard MSO landed in #1391 (Stream 1 / Phase 0). |
+| 3d | **Deferred** | Fixed-assignment pass for 1-bunk-eligible campers overlaps with Stream 6b (group_locks impossibility) and the per-session value is unclear without measurement. Reassess after Phase A if AG-only / grade-locked camper counts justify the orchestration work. |
+| 3f | **Deferred** | `grade_ratio` bool_and → `AddAllowedAssignments` is a risky modeling rewrite with no concrete evidence the chains are the bottleneck. The Phase 2 best-bound trajectory shows the plateau is **bound movement**, not branching cost, so the case for tighter LP relaxation here is weak. File a separate issue if a future plateau analysis points back at grade_ratio specifically. |
+
+#### Why not just close Stream 3?
+
+Phase 0 + Phase 1 + #1427 ate enough that the burden of proof has
+flipped: Stream 3 used to be "obvious win," now it's "show me the
+compression ratio first." That's a meaningful re-scope, not a
+cancellation — Phase A is cheap, Phase B is tiny and worth doing
+either way, and Phase C remains the largest single-PR opportunity if
+the metric supports it. Closing the issue without Phase A would mean
+shipping #1381 on stale numbers.
+
+#### GitHub issue
+
+#1381 stays open; this section IS the re-scope referenced in the
+status table. No sub-issues filed — Phases A/B/C are intentionally
+inline-only until Phase A's number forces a decision (per
+[memory: don't file speculative-refactor issues]).
+
+---
+
+### Original spec (preserved for historical context)
+
+> The text below is the pre-2026-05-18 version of Stream 3 and is
+> retained so the original sizing math, lever inventory, and risk
+> framing remain traceable. Everything live is in the re-scope above.
+
+#### Motivation (original)
 
 For S2 (193 persons × 17 bunks), the pre-presolve model would have
 ~9,750 boolean variables. CP-SAT presolve compresses to 5,561 (~43%
@@ -441,7 +554,7 @@ to eliminate junk) yields:
 - Tighter LP relaxation
 - Clearer model when debugging
 
-### Boolean variable bulk (estimated, S2)
+#### Boolean variable bulk (estimated, S2, ORIGINAL — pre-#1427)
 
 | Source | Pre-presolve count | Code ref |
 |---|---|---|
@@ -453,7 +566,7 @@ to eliminate junk) yields:
 | **Total before presolve** | **~9,750** | |
 | **Post-presolve (reported)** | **5,561** | |
 
-### Levers, ranked by leverage
+#### Levers, ranked by leverage (ORIGINAL)
 
 | # | Lever | Estimated savings | Risk | Effort |
 |---|---|---|---|---|
@@ -464,13 +577,16 @@ to eliminate junk) yields:
 | 3e | **Drop `req_satisfied` for already-impossible requests** | −~4 per session (small) | None | Tiny |
 | 3f | **Convert `grade_ratio` bool_and chains to `AddAllowedAssignments`** (CP-SAT table constraints are tighter than `bool_and`) | Possibly significant, hard to estimate without prototyping | Medium — modeling rewrite | Medium PR |
 
-### Compound impact
+#### Compound impact (ORIGINAL)
 
 Stages 3a + 3b + Stream 1 (hard MSO) together could reduce booleans
 from **5,561 → ~3,000** (−46%) on S2, with corresponding linear
 constraint reductions. S4 (303 persons × 26 bunks) compounds higher.
 
-### Why 3a is the single best lever
+> Re-scope note: with 3b moot and Stream 1 shipped, the compound case
+> reduces to lever 3a alone — see the re-scope above.
+
+#### Why 3a is the single best lever (ORIGINAL — still mostly true)
 
 Camp bunks are single-gender. Currently the model creates a BoolVar
 for "girl placed in boys' bunk" for every (F-person, M-bunk) pair —
@@ -479,17 +595,18 @@ presolve. Limiting `person_in_bunk` creation to (person, eligible_bunk)
 pairs at model-build time eliminates the largest single source of
 pre-presolve redundancy.
 
-### Code refs
+#### Code refs (ORIGINAL — `bunk_requests.py` ref stale)
 
 - `bunking/solver/direct_solver.py:_create_assignment_variables` —
   source of the 3,281 BoolVars
-- `bunking/solver/constraints/bunk_requests.py` — `both_in_bunk` /
-  `separated` loops
+- ~~`bunking/solver/constraints/bunk_requests.py` — `both_in_bunk` /
+  `separated` loops~~ — gone post-#1395; replaced by the canonical
+  `get_or_create_request_sat_var` builder
 - `bunking/solver/direct_solver.py:_validate_requests` (lines
   355-438) — impossibility classification already provides the
   filter list for 3e
 
-### Risks
+#### Risks (ORIGINAL — still applies to Phase C)
 
 1. Refactoring `_create_assignment_variables` touches the foundational
    modeling layer. Many downstream functions assume the `assignments`
@@ -500,20 +617,16 @@ pre-presolve redundancy.
    creates the BoolVar and the gender constraint forces it to 0 —
    the test passes trivially). Need new test fixtures.
 
-### Out of scope
+#### Out of scope (ORIGINAL — unchanged)
 
 - Custom CP-SAT search-strategy injection. Stays with default workers
   for now.
 - Wholesale switch from CP-SAT to LP-based solver. Out of scope
   permanently for this codebase.
 
-### GitHub issue
+#### GitHub issue
 
-#1381. **Re-scope before starting** — #1391 + #1427 already eliminated
-`both_in_bunk` (the old lever 3b) and the duplicate MP sat vars; lever 3a
-(sparse `person_in_bunk`) is the main remaining win. Gated on Phase 2's
-presolve-compression-ratio metric. See Phase 4 in "Status & phased
-sequencing" above.
+#1381. Re-scope is the section above this one.
 
 ---
 

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -108,6 +108,7 @@ class MockBunkRequest:
     age_preference_target: str | None = None
     priority_keyword_detected: bool = False  # TG-3: True when parent text had an explicit priority keyword
     raw_text: str = ""  # TG-3: parent's original wording snippet
+    id: str | None = None  # PB record id, used for impossibility gating (#1520)
 
 
 @dataclass
@@ -904,6 +905,7 @@ def _mock_request(
     source,  # "family", "staff", or None — legacy column, derived via source_from_field post-#1142
     request_type="bunk_with",
     status="resolved",
+    id=None,
 ):
     return MockBunkRequest(
         requester_person_cm_id=requester,
@@ -912,6 +914,7 @@ def _mock_request(
         status=status,
         source_field=source_field,
         source=source,
+        id=id,
     )
 
 
@@ -2600,3 +2603,180 @@ def test_capacity_by_gender_aggregates_bunks_and_assignments():
     assert cap["female"]["assigned"] == 3  # 3 F campers assigned
     assert cap["male"]["capacity"] == 1 * DEFAULT_BUNK_CAPACITY  # 1 M bunk
     assert cap["male"]["assigned"] == 3
+
+
+# ---------------------------------------------------------------------------
+# #1520 — validator-side impossibility gating
+#
+# Mirrors the solver-side gating in PR #1463 (direct_solver._check_must_satisfy_one_violations).
+# Without this, an impossible parent request (cross-gender pair, oldest-grade kid
+# asking for "older", etc.) drags the post-check denominator down even though the
+# solver had no chance. The reference Taste 1 solve showed 152/166 (validator,
+# ungated) vs 151/155 (solver, gated) — the 11-request denominator delta is the
+# impossibility cohort.
+# ---------------------------------------------------------------------------
+
+
+def test_validator_gates_material_parent_counts_on_impossibility():
+    """When impossible_request_ids is provided, MP counts exclude impossibles
+    from BOTH numerator and denominator."""
+    session = _mock_session(cm_id="10000001", name="ImpossibilityGatingFixture")
+    persons = [_mock_person(str(cm), grade=5) for cm in (20001, 20002, 20003, 20004)]
+    bunks = [_mock_bunk("30001"), _mock_bunk("30002")]
+    # 20001+20002 together in 30001; 20003+20004 together in 30002.
+    assignments = [
+        _mock_assignment("20001", "30001"),
+        _mock_assignment("20002", "30001"),
+        _mock_assignment("20003", "30002"),
+        _mock_assignment("20004", "30002"),
+    ]
+    # 4 MP requests with explicit ids:
+    #   r1: 20001→20002 satisfied
+    #   r2: 20003→20004 satisfied
+    #   r3: 20001→20003 unsatisfied
+    #   r4: 20001→9999  unsatisfied AND impossible (target not on roster)
+    requests = [
+        _mock_request("20001", "20002", SourceField.BUNK_REQUEST_FORM, "family", id="r1"),
+        _mock_request("20003", "20004", SourceField.BUNK_REQUEST_FORM, "family", id="r2"),
+        _mock_request("20001", "20003", SourceField.BUNK_REQUEST_FORM, "family", id="r3"),
+        _mock_request("20001", "9999", SourceField.BUNK_REQUEST_FORM, "family", id="r4"),
+    ]
+
+    # Baseline (no gating): 4 total, 2 satisfied, rate 50%.
+    ungated = BunkingValidator().validate_bunking(
+        session=cast(Any, session),
+        bunks=cast(list[Bunk], bunks),
+        assignments=cast(list[BunkAssignment], assignments),
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+    )
+    assert ungated.statistics.material_parent_requests == 4
+    assert ungated.statistics.satisfied_material_parent_requests == 2
+    assert ungated.statistics.material_parent_request_satisfaction_rate == 0.5
+
+    # Gated (r4 impossible): 3 total, 2 satisfied, rate 2/3.
+    gated = BunkingValidator().validate_bunking(
+        session=cast(Any, session),
+        bunks=cast(list[Bunk], bunks),
+        assignments=cast(list[BunkAssignment], assignments),
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+        impossible_request_ids={"r4"},
+    )
+    assert gated.statistics.material_parent_requests == 3
+    assert gated.statistics.satisfied_material_parent_requests == 2
+    assert gated.statistics.material_parent_request_satisfaction_rate == pytest.approx(2 / 3)
+
+
+def test_validator_gates_total_and_staff_requests_on_impossibility():
+    """`total_requests = MP + staff` — gating must apply to both buckets so
+    `request_satisfaction_rate` reflects only solvable requests."""
+    session = _mock_session(cm_id="10000001", name="TotalGatingFixture")
+    persons = [_mock_person(str(cm), grade=5) for cm in (20001, 20002, 20003)]
+    bunks = [_mock_bunk("30001"), _mock_bunk("30002")]
+    assignments = [
+        _mock_assignment("20001", "30001"),
+        _mock_assignment("20002", "30001"),
+        _mock_assignment("20003", "30002"),
+    ]
+    requests = [
+        # MP satisfied
+        _mock_request("20001", "20002", SourceField.BUNK_REQUEST_FORM, "family", id="mp1"),
+        # MP impossible (target absent)
+        _mock_request("20001", "9999", SourceField.BUNK_REQUEST_FORM, "family", id="mp2"),
+        # Staff satisfied (not_bunk_with, different bunks)
+        _mock_request(
+            "20001",
+            "20003",
+            SourceField.STAFF_NOT_BUNK_WITH,
+            "staff",
+            request_type="not_bunk_with",
+            id="st1",
+        ),
+        # Staff impossible (target absent)
+        _mock_request(
+            "20001",
+            "9998",
+            SourceField.STAFF_NOT_BUNK_WITH,
+            "staff",
+            request_type="not_bunk_with",
+            id="st2",
+        ),
+    ]
+
+    result = BunkingValidator().validate_bunking(
+        session=cast(Any, session),
+        bunks=cast(list[Bunk], bunks),
+        assignments=cast(list[BunkAssignment], assignments),
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+        impossible_request_ids={"mp2", "st2"},
+    )
+    # MP: 1 total / 1 satisfied. Staff: 1 total / 1 satisfied.
+    assert result.statistics.material_parent_requests == 1
+    assert result.statistics.satisfied_material_parent_requests == 1
+    assert result.statistics.staff_requests == 1
+    assert result.statistics.satisfied_staff_requests == 1
+    assert result.statistics.total_requests == 2  # was 4 ungated
+    assert result.statistics.satisfied_requests == 2  # was 2 ungated
+    assert result.statistics.request_satisfaction_rate == 1.0
+
+
+def test_validator_gates_mp_camper_counts_on_impossibility():
+    """A camper whose ONLY MP request is impossible drops out of
+    mp_campers_total — matching solver-side `mp_campers_total` semantics."""
+    session = _mock_session(cm_id="10000001", name="CamperGatingFixture")
+    persons = [_mock_person(str(cm), grade=5) for cm in (20001, 20002, 20003)]
+    bunks = [_mock_bunk("30001"), _mock_bunk("30002")]
+    assignments = [
+        _mock_assignment("20001", "30001"),
+        _mock_assignment("20002", "30001"),
+        _mock_assignment("20003", "30002"),
+    ]
+    requests = [
+        # 20001's MP request is satisfied → counts toward mp_campers_total + satisfied.
+        _mock_request("20001", "20002", SourceField.BUNK_REQUEST_FORM, "family", id="r1"),
+        # 20003's ONLY MP request is impossible → must NOT count.
+        _mock_request("20003", "9999", SourceField.BUNK_REQUEST_FORM, "family", id="r2"),
+    ]
+
+    result = BunkingValidator().validate_bunking(
+        session=cast(Any, session),
+        bunks=cast(list[Bunk], bunks),
+        assignments=cast(list[BunkAssignment], assignments),
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+        impossible_request_ids={"r2"},
+    )
+    # Only 20001 has a possible MP request.
+    assert result.statistics.mp_campers_total == 1
+    assert result.statistics.mp_campers_with_at_least_one_satisfied == 1
+    assert result.statistics.mp_campers_with_all_satisfied == 1
+
+
+def test_validator_no_gating_when_impossibility_set_is_none():
+    """Backward compat: omitting `impossible_request_ids` preserves legacy
+    (ungated) counts so existing callers and tests aren't affected."""
+    session = _mock_session(cm_id="10000001", name="DefaultBehaviorFixture")
+    persons = [_mock_person(str(cm), grade=5) for cm in (20001, 20002)]
+    bunks = [_mock_bunk("30001"), _mock_bunk("30002")]
+    assignments = [
+        _mock_assignment("20001", "30001"),
+        _mock_assignment("20002", "30002"),
+    ]
+    requests = [
+        # Unsatisfied MP request to an absent target — would be impossible at solver
+        # layer, but the validator (without gating) still counts it ungated.
+        _mock_request("20001", "9999", SourceField.BUNK_REQUEST_FORM, "family", id="r1"),
+    ]
+    result = BunkingValidator().validate_bunking(
+        session=cast(Any, session),
+        bunks=cast(list[Bunk], bunks),
+        assignments=cast(list[BunkAssignment], assignments),
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+    )
+    assert result.statistics.material_parent_requests == 1
+    assert result.statistics.satisfied_material_parent_requests == 0
+    assert result.statistics.material_parent_request_satisfaction_rate == 0.0
+    assert result.statistics.mp_campers_total == 1


### PR DESCRIPTION
## Summary

- Validator gains `impossible_request_ids` kwarg; aggregate counters (`material_parent_*`, `staff_*`, `total_*`, `mp_campers_*`) gate on it so post-check denominators match the solver-side gating from #1463. Issue listings stay ungated — per-camper warnings still surface every unmet request.
- `api/routers/validation.py` computes the impossibility set via the same `fetch_session_data_v2` → `prepare_direct_solver_input` → `validate_impossibility` path `pre_validate_solver` uses (option (b) from the issue). Falls back to ungated metrics if impossibility computation fails so a working endpoint never regresses.
- Roadmap: Stream 4 (#1382 / PR #1523) marked shipped; #1520 V1/V2 first-drift entry resolved on the narrow tactical path. V1/V2 consolidation still deferred.

## Test plan
- [x] 4 new TDD tests in `tests/unit/test_bunking_validator.py` covering MP gating, staff/total gating, camper-level gating, and backward-compat (no gating when arg omitted) — verified failing before implementation
- [x] Full validator test file (79 tests) passes
- [x] `tests/unit/api/routers/` (252 tests) passes — no router regressions
- [x] `ruff format` + `ruff check` clean on touched files
- [x] `mypy bunking/bunking_validator.py api/routers/validation.py` clean
- [ ] Manual sanity: post-check modal rate now matches solver-side JSON for the reference Taste 1 solve (will validate after CI passes + deploy)

Closes #1520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validator now excludes truly impossible requests from aggregate satisfaction metrics, coverage counts, and fulfillment rates while keeping per-item diagnostics unchanged.

* **Documentation**
  * Roadmap updated to reflect shipped validation parity work and solver progress; notes added on the gating approach and resolution.

* **Tests**
  * Added unit tests for impossible-request gating and updated test helpers to label requests for gating.

* **Chores**
  * Validation endpoint now attempts to fetch optional gating data and continues gracefully if it cannot.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->