### PR TITLE
docs(config): bundle CodeRabbit + AGENTS.md with ruff py314 bump

### DIFF
--- a/docs/reference/modernization-backlog.md
+++ b/docs/reference/modernization-backlog.md
@@ -19,7 +19,11 @@ Reference audit of modern language/tooling features available to Kindred but not
 
 ### Deferred to its own PR
 
-- **`ruff.toml:21`** — `target-version` is still `py312` despite `pyproject.toml` requiring `>=3.14`. Bumping to `py314` activates rules (UP037 quoted annotations, UP043 unnecessary `Generator[..., None, None]` defaults) that fire on ~30+ existing test files. This should be done as **the first follow-up PR** (bump + `ruff check --fix` in one commit). Kept separate so the docs PR stays docs-only.
+**Bundle: "Tell our tools we're on Python 3.14"** — ship these three together as **the first follow-up PR**. All three address the same root cause (tools assuming an older Python and flagging valid 3.14 syntax as errors). Kept separate from the docs PR so it stays docs-only.
+
+1. **`ruff.toml:21`** — `target-version` is still `py312` despite `pyproject.toml` requiring `>=3.14`. Bumping to `py314` activates rules (UP037 quoted annotations, UP043 unnecessary `Generator[..., None, None]` defaults) that fire on ~30+ existing test files. Do bump + `ruff check --fix` in one commit.
+2. **Add `.coderabbit.yaml` with Python-version `path_instructions`** — CodeRabbit's LLM keeps flagging modern 3.14 syntax (PEP 758 `except A, B:` without parens, PEP 649 bare annotations, PEP 695 generic syntax, `dict[str, X]` generics, `typing.TypeIs`, `asyncio.TaskGroup`) as Python 2.x errors. The right fix is a `reviews.path_instructions` block scoped to `**/*.py` that names the codebase's Python floor and the specific PEPs not to flag (20k-char budget per entry; safer than burying the note in CLAUDE.md). Schema: `docs.coderabbit.ai/reference/configuration` → `reviews.path_instructions`.
+3. **Add `AGENTS.md` at repo root** — CodeRabbit auto-scans `**/AGENTS.md` via `knowledge_base.code_guidelines` (alongside `**/CLAUDE.md`, `.cursorrules`, `.windsurfrules`, etc.). AGENTS.md is the cross-agent convention — same Python-version note benefits Codex, Cursor, Copilot, and future agents. The repo currently has neither file. Companion to #2, not a replacement: `.coderabbit.yaml` is review-scoped and harder for the reviewer model to overlook; AGENTS.md is the durable cross-agent home for the same facts.
 
 ### Outstanding quick check
 


### PR DESCRIPTION
## Summary
- Group three follow-ups into one PR in §0 of `modernization-backlog.md`: ruff `target-version` bump (already queued), new `.coderabbit.yaml` with Python-version `path_instructions`, and a new root `AGENTS.md`.
- Same root cause across all three: tools assume an older Python and flag valid 3.14 syntax (PEP 758 `except A, B:` without parens, PEP 649 bare annotations, PEP 695 generic syntax, etc.) as errors.
- Docs-only — no config files added in this PR; the bundle ships as the first follow-up.

## Why bundle
CodeRabbit auto-scans `**/AGENTS.md` and `**/CLAUDE.md` via `knowledge_base.code_guidelines`; `.coderabbit.yaml` `reviews.path_instructions` is the review-scoped equivalent. The ruff bump fixes ruff-derived findings CodeRabbit surfaces; #2 fixes CodeRabbit's own LLM commentary; #3 makes the same facts available to any future agent. Shipping together avoids three small PRs that each only fix one third of the noise.

## Test plan
- [ ] `docs/reference/modernization-backlog.md` §0 renders cleanly on GitHub
- [ ] Bundle is callable as a single follow-up PR brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the modernization backlog to track Python 3.14 support preparation. Includes documentation of planned updates for code analysis tooling and code review guidance to support Python 3.14 compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1526?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->