### PR TITLE
docs(solver): roadmap — Phase 3 measured impact + #1527 metric misnomer

### DIFF
--- a/docs/reference/solver-roadmap.md
+++ b/docs/reference/solver-roadmap.md
@@ -239,10 +239,13 @@ from S2.
 
 ### Safety gate
 
-`unsatisfied_no_possible` from `feasibility.py:196` counts campers whose
-ENTIRE MP set is structurally impossible. The gate is enforced upstream
-by `_validate_requests` in `direct_solver.py`, which classifies a
-request as impossible when any of the following holds:
+The authoritative input-property metric for "camper's entire MP set is
+structurally impossible" is `mp_set_entirely_impossible_count` (added
+in #1429). The legacy `unsatisfied_no_possible` field is a *post-solve
+outcome* that varies with budget — see **#1527** for the misnomer
+investigation and proposed rename/delete. The gate itself is enforced
+upstream by `_validate_requests` in `direct_solver.py`, which classifies
+a request as impossible when any of the following holds:
 
 - `target_not_in_solver` — requestee absent from `person_idx_map`
 - `cross_session` — `bunk_with` across sessions (boundary forbids)
@@ -1263,3 +1266,39 @@ regresses.
   every unmet request. The first-drift entry in the V1/V2 Parked
   section is now resolved; V1/V2 consolidation remains deferred until
   a non-cosmetic field-validator drift forces it.
+- **2026-05-18** — **Phase 3 measured impact (S4, session 1235406).**
+  Cross-SHA sweep: v5.5.0 prod (1×, no boost — SHA `ec49e204`) vs.
+  current main (5× boost). Both at 30/60/180 s budgets, 304 persons,
+  26 bunks, ~373 MP requests, 200/204 MP campers (4-camper enrollment
+  delta from PR #1515).
+
+  | Budget | v5.5.0 MP req rate | main 5× MP req rate | Δ | v5.5.0 gap | 5× gap |
+  |---|---|---|---|---|---|
+  | 30 s | 280/377 = 74.27% | 349/373 = 93.6% | **+19.3 pp** | 68.78% | 2.04% |
+  | 60 s | 325/377 = 86.21% | 356/373 = 95.4% | **+9.2 pp** | 14.71% | 1.40% |
+  | 180 s | 351/377 = 93.10% | 355/373 = 95.2% | +2.1 pp | 4.09% | 1.00% |
+
+  MP campers: **204/204 (100%) at every v5.5.0 budget** too — hard MSO
+  from #1391 was already saturated pre-boost on S4. The boost moves
+  *request-level* coverage, not camper-level.
+
+  **Headline:** boost is primarily a **convergence accelerator**, not a
+  ceiling-raiser. v5.5.0 reaches 93.10% MP at 180 s; current main 5×
+  reaches 93.6% at 30 s — Phase 3 compresses 180 s of v5.5.0 work into
+  30 s on the harder bed. Production-relevant budgets (30-60 s) see
+  the largest gains; long budgets converge to the same ceiling.
+
+  **Mechanism:** LP root gap collapsed **74.10% → 4.09%** at 30 s under
+  the boost-shaped objective. LP relaxation tightness explains most of
+  the speedup — solver enters its first solution near the basin.
+  `num_solutions_found = 1` across all 6 runs; boost doesn't help
+  the solver explore multiple incumbents (that's a Phase 4 lever).
+
+  Side-finding: `unsatisfied_no_possible` trajectory 12 → 3 → 1 across
+  budgets revealed the metric is a post-solve outcome, not an input
+  property — filed as #1527.
+
+  **Saturated-bed caveat:** S2 (session 1235404, 192×17) is at ceiling
+  for the boost (323/344 = 93.9% from 30 s budget onward at both 2× and
+  5×; residual 21 unmet are partial-tails of multi-MP campers, none
+  mutual). S4 is the right bed for any future coverage-moving lever.


### PR DESCRIPTION
## Summary

- Add S4 v5.5.0 → current main 5× cross-SHA sweep comparison to the Update log. Phase 3 (#1523 mutual-request boost) measured impact: **+19.3 pp** MP request rate at 30 s, **+9.2 pp** at 60 s, **+2.1 pp** at 180 s. Boost is a convergence accelerator (LP root gap collapses 74% → 4%), not a ceiling-raiser — long budgets converge to the same MP rate.
- Fix the Stream 1 safety-gate description: `unsatisfied_no_possible` is a post-solve outcome, not an input property. The authoritative input-property metric is `mp_set_entirely_impossible_count` (added in #1429). Cross-reference #1527 for the rename/delete decision.

## Context

Spawned from a manual cross-SHA sweep on session 1235406 today. v5.5.0 prod (SHA `ec49e204`, pre-#1523) was sampled at 30/60/180 s budgets and compared against current main at 5× boost. The S2 numbers (192×17) showed Phase 3 as a marginal +1.5 pp win; the S4 numbers (304×26) show Phase 3 as a massive production-time-budget win that S2's saturated bed obscured.

`unsatisfied_no_possible` was discovered to vary 12 → 3 → 1 across the same input at increasing budgets — a property an input-impossibility metric should not have. Root cause: the metric counts post-solve "campers who got zero satisfied requests AND have no possible requests left", not "campers whose entire MP set is structurally impossible". Filed as #1527.

## Test plan

- [x] Doc-only change; no code/test surface affected
- [x] Markdownlint pre-push passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated solver roadmap with clarified safety gate metrics and validation conditions
  * Added new "Phase 3 measured impact" section documenting performance analysis results
  * Included cross-version performance comparisons and solution behavior analysis across budget configurations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1528?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->