### PR TITLE
docs(solver): objective sensitivity analysis + reproducible script

### DIFF
--- a/bunking/solver/score_evaluator.py
+++ b/bunking/solver/score_evaluator.py
@@ -4,13 +4,26 @@ This module provides functionality to evaluate the "solver score" for any
 given assignment state, allowing comparison of scenarios without running
 the full solver.
 
-The scoring logic mirrors the solver's objective function:
-1. Request satisfaction (bunk_with, not_bunk_with, age_preference)
+The scoring logic *approximately* mirrors the solver's objective function
+for diagnostic and scenario-comparison purposes. Components:
+
+1. Request satisfaction reward — `bunk_with`, `not_bunk_with`, and
+   `age_preference`. NOTE: `age_preference` is included here as a
+   diagnostic reward, but the live solver's CP-SAT objective
+   (`direct_solver.py:562-583`) does NOT include `age_preference` terms.
+   In the solver, MP `age_preference` is enforced as a HARD constraint via
+   `parent_paramount` (forcing indicators), and non-MP `age_preference`
+   has no solver representation at all. This evaluator's score therefore
+   over-counts relative to the solver's true objective when an assignment
+   satisfies `age_preference` requests; that is intentional for analysis.
 2. First-pick boost (is_first_requested → 10x slot-0 multiplier)
 3. Source field multipliers (keyed by canonical SourceField values)
 4. Mutual-request boost for reciprocated bunk_with (Stream 4 / #1382)
 5. Diminishing returns for multiple satisfied requests per person
 6. Soft constraint penalties (grade spread, capacity violations, etc.)
+
+See `docs/reference/objective-sensitivity.md` for the per-component
+magnitudes and the canonical solver-objective composition.
 """
 
 from __future__ import annotations

--- a/docs/reference/modernization-backlog.md
+++ b/docs/reference/modernization-backlog.md
@@ -49,6 +49,7 @@ Baseline is strong: Pydantic v2 everywhere, `datetime.UTC` adopted, modern gener
 | **LOW** | `@dataclass(slots=True, kw_only=True, frozen=True)` defaults | 41 `@dataclass` files | — | Mostly small DTOs, not hot paths. Apply opportunistically. |
 | **LOW** | `typing.TypeIs` (replaces `TypeGuard`) / `typing.ReadOnly` TypedDict fields | `geo_normalizer/normalizer.py:20` for ReadOnly; no `TypeGuard` in codebase | 1 | 3.13+. Low leverage here. |
 | **LOW** | `copy.replace()` | (unused; no `dataclasses.replace` callsites either) | 0 | 3.13+. No current use case. |
+| **LOW** | Enable ruff `PLC0415` (import-outside-toplevel) | repo-wide; surfaced by PR #1529 review (`test_analyze_objective_sensitivity.py` had `import pytest` inside a test body) | 1 known | Catches imports inside function bodies. Currently not in `ruff.toml`'s enabled rules. Likely a handful of pre-existing offenders to clean up before enabling. |
 
 ### Not applicable / already adopted
 

--- a/docs/reference/objective-sensitivity.md
+++ b/docs/reference/objective-sensitivity.md
@@ -1,0 +1,194 @@
+# Solver Objective Sensitivity Analysis
+
+> **Snapshot:** 2026-05-18, post-v5.5.0 / post-#1523 mutual-request boost.
+> Source-of-truth for the tables is `scripts/analyze_objective_sensitivity.py` —
+> regenerate with `uv run python scripts/analyze_objective_sensitivity.py`.
+> Test suite at `tests/unit/scripts/test_analyze_objective_sensitivity.py`
+> locks in every magnitude shown here.
+
+## What this doc is for
+
+Every solver tuning decision implicitly compares the **objective benefit** of
+honoring a request against the **penalty cost** of breaking a soft constraint.
+Until now those magnitudes lived in scattered places (`CONFIG_SCHEMA`, seed
+migrations, hardcoded constants in `direct_solver.py`) and the comparisons
+were done by gut. This doc compiles the magnitudes into one place and shows
+the arithmetic explicitly, so:
+
+- **Solver tuning decisions** (which penalty to bump, which knob to delete,
+  which threshold actually matters) have a concrete reference for ratio
+  analysis.
+- **`solver-config-it` cleanup decisions** (KEEP / HARDCODE / DELETE / FIX)
+  can be informed by "does this module actually contribute meaningful
+  objective magnitude relative to peers?"
+- **Residual-analysis** of unmet requests (the 21 S2 / 17 S4 partial tails)
+  has a single-paragraph arithmetic explanation instead of speculation.
+
+## When to consult this doc
+
+- Before proposing a new soft penalty / weight / source multiplier change.
+- Before filing a "the solver should honor this request" issue — confirm the
+  arithmetic actually supports the request winning against the local penalty.
+- When deciding whether to promote a soft constraint to hard (compare the
+  penalty magnitude against the dominant competing reward).
+- During `solver-config-it` rounds, as the second-pass criterion after code-usage check.
+
+## Per-request weights (current seed values)
+
+How a single satisfied request becomes an objective term. Formula (from
+`direct_solver.py:562-583`):
+
+```text
+weight = int(BASE_REQUEST_WEIGHT × source_multiplier × mutual_boost × slot_multiplier)
+       = int(40                  × source_multiplier × {2.0 or 1.0}  × {10, 5, 1})
+```
+
+`BASE_REQUEST_WEIGHT = 40` and `slot_multipliers = (10, 5, 1)` are hardcoded
+constants in `direct_solver.py:67-72` — they were config rows until migration
+`1500000100_priority_deletion.js` (PR #1455) deleted them. They can no longer
+be tuned without a code PR.
+
+Slot ordering: per-camper requests are sorted before the slot stack is
+applied. If `objective.enable_first_boost = 1` (seed: 1), each family's
+`is_first_requested=true` request lands at slot 0 first; everything else
+fills in order.
+
+The mutual boost applies **only** to `bunk_with`. Other source types ignore
+the `mutual` flag — see `score_evaluator.py` and the regression test
+`test_request_weight_mutual_boost_only_applies_to_bunk_with`.
+
+| Source | Bucket | Slot 0 (first) | Slot 1 (second) | Slot 2+ (third+) | Mutual boost applies? |
+|---|---|---|---|---|---|
+| `bunk_with` | MP | 600 (1200 mutual) | 300 (600 mutual) | 60 (120 mutual) | Yes (×2.0) |
+| `not_bunk_with` | STAFF | 600 | 300 | 60 | No |
+| `bunking_notes` | STAFF | 400 | 200 | 40 | No |
+| `internal_notes` | STAFF | 320 | 160 | 32 | No |
+| `socialize_with` | IMP | 240 | 120 | 24 | No |
+
+`age_preference` MP requests are **not in the objective at all** — they are
+enforced only by the parent_paramount hard constraint (`add_age_preference_*`
+forcing indicators). Non-MP `age_preference` has no solver representation.
+
+## Per-constraint penalty inventory
+
+Soft constraint magnitudes from `CONFIG_SCHEMA` defaults + seed migration
+`1500000011_config.js`. Each row is what gets added (or subtracted, for
+bonuses) to the objective when the constraint fires.
+
+| Module | Penalty / Bonus | Magnitude | Per-what | Trigger |
+|---|---|---|---|---|
+| `grade_ratio` | Penalty | 5000 | per grade × bunk | Single grade exceeds 67% of multi-grade bunk; edge bunks exempt |
+| `grade_spread_soft` | Penalty | 3000 | per excess unique grade × bunk | Unique-grade count above `max_spread` (2) |
+| `cabin_minimum_occupancy` | Penalty | 2000 | per spot × bunk | Used bunk below `PREFERRED_BUNK_OCCUPANCY` (10); capped at 2 spots / 4000 per bunk |
+| `age_spread` | Penalty | 1500 | per bunk | Age spread > 24 months |
+| `level_progression` | Penalty | 800 | per camper × eligible lower-level bunk | Returning camper placed in lower-level bunk than prior year |
+| `age_grade_flow` | Bonus (up to) | +300 | per camper × bunk | Continuous: `fit_score × weight`; camper's grade matches bunk's target grade |
+| `age_spread_preferred_bonus` | Bonus | +500 | per bunk | Age spread ≤ 12 months |
+
+Hard constraints (no penalty — solver cannot violate): `assignment`,
+`session_boundary`, `cabin_capacity` (12), `cabin_minimum_occupancy` floor
+(8), `gender`, `group_locks`, `grade_adjacency` (no-gap), `parent_paramount`,
+and `grade_spread` when `constraint.grade_spread.mode = "hard"` (seed mode is
+`"soft"`, so the soft path is the production reality).
+
+## Per-archetype totals + threshold ratios
+
+Five representative camper profiles. `Total earnable` is the sum of objective
+weight for every request in the archetype assuming all are satisfied.
+Threshold ratios are **`penalty / total`** — how many archetype-totals' worth
+of earnable would be needed to overcome a single instance of that penalty.
+
+| Archetype | Description | Total earnable | vs grade_ratio (5000) | vs grade_spread (3000) | vs level_progression (800) |
+|---|---|---|---|---|---|
+| **A. Loner mutual** | Singleton MP camper, 1 reciprocated bunk_with request. | 1200 | 4.17× | 2.50× | 0.67× |
+| **B. Loner one-way** | Singleton MP camper, 1 unreciprocated bunk_with request. | 600 | 8.33× | 5.00× | 1.33× |
+| **C. Cluster star** | Multi-MP camper, 3 reciprocated bunk_with requests forming a tight cluster. | 1920 | 2.60× | 1.56× | 0.42× |
+| **D. Mixed multi (THE RESIDUAL ARCHETYPE)** | Multi-MP camper, 1 reciprocated bunk_with at first-pick + 2 unreciprocated at slots 1-2. Matches the partial-tail pattern of the 21 S2 / 17 S4 unmet residuals. | 1560 | 3.21× | 1.92× | 0.51× |
+| **E. Popular target (own requests)** | A camper named by multiple other campers but with her own 2 unreciprocated MP requests elsewhere. Modeled here from her side; demand from other campers does not appear in her own objective contribution — see threshold analysis. | 900 | 5.56× | 3.33× | 0.89× |
+
+### Reading the ratios
+
+- **Ratio > 1**: penalty exceeds the archetype's entire earnable benefit. The
+  solver will NOT trigger this penalty for this archetype unless other
+  rewards compound to bridge the gap.
+- **Ratio < 1**: archetype's earnable exceeds the penalty cost. The solver
+  CAN absorb this penalty in exchange for satisfying the archetype.
+- **Ratio near 1**: marginal — the LP relaxation sees a near-tie and
+  shimmers between solutions; LNS strategies dominate the outcome.
+
+Three useful patterns visible in the table:
+
+1. **Loner one-way (B) is structurally hard to honor** — at 600 earnable,
+   it loses to grade_ratio by 8×. The solver only honors archetype B when
+   the placement is "free" (no soft constraint triggered). The mutual boost
+   (archetype A) cuts that ratio in half (4.17×) but doesn't break parity.
+2. **Cluster star (C) dominates level_progression** at 0.42× — a 3-MP all-
+   mutual camper's full benefit (1920) is more than 2× a single level
+   regression (800). The solver will accept the regression to keep the
+   cluster intact.
+3. **Mixed multi (D) — the residual archetype — has a "tail tax".** The
+   first-pick mutual is worth 1200 by itself (4.17× ratio vs grade_ratio,
+   same as archetype A — meaning the mutual alone is what gets honored).
+   The slots 1-2 add only 360 marginal earnable, vastly insufficient to
+   override any 5000 grade_ratio violation triggered by honoring them.
+   **This is the arithmetic explanation of the 21 S2 / 17 S4 residuals.**
+
+## Worked example: the 21 S2 partial-tail residuals
+
+Cross-reference data from solver run `qgc731ty5puoy3c` (S2, 180 s, current main):
+
+- **Soft constraints fired:** `grade_ratio=96`, `age_spread=16`, `level_regression=281`
+- **Total grade_ratio cost in the satisfied solution:** 96 × 5000 = **480,000**
+- **Total level_regression cost:** 281 × 800 = **224,800**
+- **Objective value:** 267,034 (this is rewards − penalties; gross rewards ≈ 1,000,000+)
+
+The solver is *paying* 480 K in grade_ratio penalties because the cluster
+rewards exceed them. So the 21 residuals are **not** "the solver refuses to
+break grade_ratio" — they are cases where honoring the slot-1/slot-2 tail
+would trigger an *additional* penalty whose 5000 cost exceeds the 60-300
+marginal benefit. The slot-0 first-pick (or mutual) already paid for the
+cluster's grade_ratio violation; adding the tail member doesn't earn enough
+to justify the next ratio break.
+
+Three illustrative cases from the residual analysis (camper IDs and bunk
+labels anonymized; the arithmetic is what matters, not who the campers are):
+
+| Requester (sat'd MPs) | Unmet target | Pattern |
+|---|---|---|
+| `1000001` (got 2/3, both mutual) | `1000002 → bunk X`, one-way, slot 1 | 2-grade gap + presumably ratio-locked target bunk; 300 marginal benefit vs 5000 ratio cost — solver correctly drops |
+| `1000003` (got 3/4) | `1000004 → bunk Y`, one-way, slot 2 | Adjacent grade, presumably full bunk; 60 marginal benefit — even cheaper to drop |
+| `1000005` (got 5/6, all mutual stacked) | `1000006 → bunk Z`, one-way, slot ? | Same-grade neighbor bunk — only triggers ratio if target's bunk would tip; 60-300 vs 5000 — drops |
+
+All 21 follow this shape. A "popular target boost" would shift archetype E's
+own benefit but not change the receiving side's arithmetic — see Phase 4
+brainstorming notes for why this lever was deprioritized.
+
+## Dead-config tracking
+
+This inventory pass surfaces config knobs whose magnitudes are vestigial or
+whose read sites are dead. Active tracking + per-domain resolutions live in
+`docs/reference/solver-config-decisions.md` (local-only, gitignored — the
+`solver-config-it` working artifact). Findings flagged during sensitivity
+analysis should be cross-checked against the cleanup doc's "Phantom keys" /
+"Cross-cutting findings" sections before being re-filed.
+
+## How to regenerate
+
+```bash
+uv run python scripts/analyze_objective_sensitivity.py > /tmp/tables.md
+```
+
+Then update the three table sections of this doc from `/tmp/tables.md`. The
+test suite at `tests/unit/scripts/test_analyze_objective_sensitivity.py`
+locks in every magnitude — if a config change ripples into changed weights,
+update `ObjectiveConfig` defaults in the script, update this doc's tables,
+update the test assertions, and ship all three together.
+
+## See also
+
+- `docs/reference/solver-roadmap.md` — the Phase 0-4 stream sequencing; Phase
+  3 changelog references this analysis for residual interpretation.
+- `docs/reference/solver-config-decisions.md` (local-only / gitignored) —
+  the per-domain cleanup tracker that this analysis feeds.
+- `bunking/solver/direct_solver.py:562-612` — objective assembly.
+- `bunking/satisfaction/bucket.py` — source_field → MP/IMP/STAFF mapping.

--- a/scripts/analyze_objective_sensitivity.py
+++ b/scripts/analyze_objective_sensitivity.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Objective-sensitivity analysis for the bunking solver.
+
+Computes per-request weights, per-constraint penalties, and per-archetype
+totals from the current seed-config values. Outputs markdown tables ready to
+drop into `docs/reference/objective-sensitivity.md`.
+
+Source values are snapshotted from migration `1500000011_config.js` and the
+`BASE_REQUEST_WEIGHT` / slot-multiplier constants hardcoded in
+`bunking/solver/direct_solver.py:67-72` (formerly config, deleted in
+migration `1500000100_priority_deletion.js`).
+
+Regenerate the doc tables:
+    uv run python scripts/analyze_objective_sensitivity.py
+
+If `BASE_REQUEST_WEIGHT`, slot multipliers, source multipliers, the mutual
+boost, or any seeded penalty changes, update `ObjectiveConfig` defaults below
+and re-run; the doc's tables and the test suite both lock in the current
+values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ObjectiveConfig:
+    base_request_weight: int = 40
+    slot_multipliers: tuple[int, ...] = (10, 5, 1)
+    source_multipliers: dict[str, float] = field(
+        default_factory=lambda: {
+            "bunk_with": 1.5,
+            "not_bunk_with": 1.5,
+            "bunking_notes": 1.0,
+            "internal_notes": 0.8,
+            "socialize_with": 0.6,
+        }
+    )
+    mutual_boost: float = 2.0
+    penalties: dict[str, int] = field(
+        default_factory=lambda: {
+            "grade_ratio": 5000,
+            "grade_spread_soft": 3000,
+            "cabin_minimum_occupancy": 2000,
+            "age_spread": 1500,
+            "level_progression": 800,
+            "age_grade_flow_max": 300,
+            "age_spread_preferred_bonus": 500,
+        }
+    )
+
+
+SOURCE_BUCKET: dict[str, str] = {
+    "bunk_with": "MP",
+    "not_bunk_with": "STAFF",
+    "bunking_notes": "STAFF",
+    "internal_notes": "STAFF",
+    "socialize_with": "IMP",
+}
+
+
+def request_weight(source: str, slot: int, mutual: bool, config: ObjectiveConfig) -> int:
+    """Return the objective coefficient for a single satisfied request.
+
+    Mirrors the arithmetic in `direct_solver.py:562-583`:
+        int(BASE_REQUEST_WEIGHT × source_multiplier × mutual_boost × slot_multiplier)
+
+    The mutual boost only applies to `bunk_with` (per `score_evaluator`); other
+    sources ignore the `mutual` flag.
+
+    Raises:
+        KeyError: if `source` is not in `config.source_multipliers`.
+        ValueError: if `slot` is negative — would otherwise silently wrap to
+            the tail of `slot_multipliers` via Python's negative indexing and
+            return a wrong coefficient.
+    """
+    if slot < 0:
+        raise ValueError(f"slot must be >= 0, got {slot}")
+    source_mult = config.source_multipliers[source]
+    slot_idx = min(slot, len(config.slot_multipliers) - 1)
+    slot_mult = config.slot_multipliers[slot_idx]
+    boost = config.mutual_boost if (mutual and source == "bunk_with") else 1.0
+    return int(config.base_request_weight * source_mult * boost * slot_mult)
+
+
+@dataclass(frozen=True)
+class RequestSpec:
+    source: str
+    slot: int
+    mutual: bool
+
+
+@dataclass(frozen=True)
+class Archetype:
+    name: str
+    description: str
+    requests: tuple[RequestSpec, ...]
+
+
+ARCHETYPES: dict[str, Archetype] = {
+    "A_loner_mutual": Archetype(
+        name="A. Loner mutual",
+        description="Singleton MP camper, 1 reciprocated bunk_with request.",
+        requests=(RequestSpec("bunk_with", 0, mutual=True),),
+    ),
+    "B_loner_oneway": Archetype(
+        name="B. Loner one-way",
+        description="Singleton MP camper, 1 unreciprocated bunk_with request.",
+        requests=(RequestSpec("bunk_with", 0, mutual=False),),
+    ),
+    "C_cluster_star": Archetype(
+        name="C. Cluster star",
+        description="Multi-MP camper, 3 reciprocated bunk_with requests forming a tight cluster.",
+        requests=(
+            RequestSpec("bunk_with", 0, mutual=True),
+            RequestSpec("bunk_with", 1, mutual=True),
+            RequestSpec("bunk_with", 2, mutual=True),
+        ),
+    ),
+    "D_mixed_multi": Archetype(
+        name="D. Mixed multi (THE RESIDUAL ARCHETYPE)",
+        description=(
+            "Multi-MP camper, 1 reciprocated bunk_with at first-pick + 2 unreciprocated "
+            "at slots 1-2. Matches the partial-tail pattern of the 21 S2 / 17 S4 unmet residuals."
+        ),
+        requests=(
+            RequestSpec("bunk_with", 0, mutual=True),
+            RequestSpec("bunk_with", 1, mutual=False),
+            RequestSpec("bunk_with", 2, mutual=False),
+        ),
+    ),
+    "E_popular_target_own": Archetype(
+        name="E. Popular target (own requests)",
+        description=(
+            "A camper named by multiple other campers but with her own 2 unreciprocated MP "
+            "requests elsewhere. Modeled here from her side; demand from other campers does "
+            "not appear in her own objective contribution — see threshold analysis."
+        ),
+        requests=(
+            RequestSpec("bunk_with", 0, mutual=False),
+            RequestSpec("bunk_with", 1, mutual=False),
+        ),
+    ),
+}
+
+
+def archetype_total_weight(arch: Archetype, config: ObjectiveConfig) -> int:
+    """Sum the objective coefficient of every request in the archetype, assuming all satisfied."""
+    return sum(request_weight(r.source, r.slot, r.mutual, config) for r in arch.requests)
+
+
+def threshold_ratio(arch: Archetype, penalty_module: str, config: ObjectiveConfig) -> float:
+    """Penalty magnitude divided by archetype total weight.
+
+    A ratio of 4.17 means the dominant penalty is 4.17× larger than the maximum
+    objective benefit the solver can earn by satisfying every request in the
+    archetype — so the solver will only honor those requests when the placement
+    is 'free' (does not trigger the penalty).
+    """
+    penalty = config.penalties[penalty_module]
+    total = archetype_total_weight(arch, config)
+    return penalty / total
+
+
+def render_request_weight_table(config: ObjectiveConfig) -> str:
+    """Markdown table: per-source weights at each slot, with/without mutual boost where applicable."""
+    rows: list[str] = [
+        "| Source | Bucket | Slot 0 (first) | Slot 1 (second) | Slot 2+ (third+) | Mutual boost applies? |",
+        "|---|---|---|---|---|---|",
+    ]
+    for source in ("bunk_with", "not_bunk_with", "bunking_notes", "internal_notes", "socialize_with"):
+        bucket = SOURCE_BUCKET[source]
+        mutual_applies = source == "bunk_with"
+        s0 = request_weight(source, 0, mutual=False, config=config)
+        s1 = request_weight(source, 1, mutual=False, config=config)
+        s2 = request_weight(source, 2, mutual=False, config=config)
+        if mutual_applies:
+            s0m = request_weight(source, 0, mutual=True, config=config)
+            s1m = request_weight(source, 1, mutual=True, config=config)
+            s2m = request_weight(source, 2, mutual=True, config=config)
+            s0_cell = f"{s0} ({s0m} mutual)"
+            s1_cell = f"{s1} ({s1m} mutual)"
+            s2_cell = f"{s2} ({s2m} mutual)"
+            applies = f"Yes (×{config.mutual_boost})"
+        else:
+            s0_cell, s1_cell, s2_cell = str(s0), str(s1), str(s2)
+            applies = "No"
+        rows.append(f"| `{source}` | {bucket} | {s0_cell} | {s1_cell} | {s2_cell} | {applies} |")
+    return "\n".join(rows)
+
+
+def render_penalty_table(config: ObjectiveConfig) -> str:
+    """Markdown table: per-constraint penalty magnitudes with per-what semantics."""
+    rows: list[str] = [
+        "| Module | Penalty / Bonus | Magnitude | Per-what | Trigger |",
+        "|---|---|---|---|---|",
+        f"| `grade_ratio` | Penalty | {config.penalties['grade_ratio']} | per grade × bunk | Single grade exceeds 67% of multi-grade bunk; edge bunks exempt |",
+        f"| `grade_spread_soft` | Penalty | {config.penalties['grade_spread_soft']} | per excess unique grade × bunk | Unique-grade count above `max_spread` (2) |",
+        f"| `cabin_minimum_occupancy` | Penalty | {config.penalties['cabin_minimum_occupancy']} | per spot × bunk | Used bunk below `PREFERRED_BUNK_OCCUPANCY` (10); capped at 2 spots / 4000 per bunk |",
+        f"| `age_spread` | Penalty | {config.penalties['age_spread']} | per bunk | Age spread > 24 months |",
+        f"| `level_progression` | Penalty | {config.penalties['level_progression']} | per camper × eligible lower-level bunk | Returning camper placed in lower-level bunk than prior year |",
+        f"| `age_grade_flow` | Bonus (up to) | +{config.penalties['age_grade_flow_max']} | per camper × bunk | Continuous: `fit_score × weight`; camper's grade matches bunk's target grade |",
+        f"| `age_spread_preferred_bonus` | Bonus | +{config.penalties['age_spread_preferred_bonus']} | per bunk | Age spread ≤ 12 months |",
+    ]
+    return "\n".join(rows)
+
+
+def render_archetype_table(config: ObjectiveConfig) -> str:
+    """Markdown table: per-archetype objective totals + threshold ratios vs dominant penalties."""
+    gr = config.penalties["grade_ratio"]
+    gs = config.penalties["grade_spread_soft"]
+    lp = config.penalties["level_progression"]
+    rows: list[str] = [
+        f"| Archetype | Description | Total earnable | vs grade_ratio ({gr}) | vs grade_spread ({gs}) | vs level_progression ({lp}) |",
+        "|---|---|---|---|---|---|",
+    ]
+    for arch in ARCHETYPES.values():
+        total = archetype_total_weight(arch, config)
+        ratio_gr = threshold_ratio(arch, "grade_ratio", config)
+        ratio_gs = threshold_ratio(arch, "grade_spread_soft", config)
+        ratio_lp = threshold_ratio(arch, "level_progression", config)
+        rows.append(
+            f"| **{arch.name}** | {arch.description} | {total} | {ratio_gr:.2f}× | {ratio_gs:.2f}× | {ratio_lp:.2f}× |"
+        )
+    return "\n".join(rows)
+
+
+def render_full_report(config: ObjectiveConfig) -> str:
+    """Concatenated markdown for all three tables, with section headers."""
+    return "\n\n".join(
+        [
+            "## Per-request weights (current seed values)",
+            render_request_weight_table(config),
+            "## Per-constraint penalty inventory",
+            render_penalty_table(config),
+            "## Per-archetype totals + threshold ratios",
+            render_archetype_table(config),
+        ]
+    )
+
+
+def main() -> None:
+    print(render_full_report(ObjectiveConfig()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/scripts/test_analyze_objective_sensitivity.py
+++ b/tests/unit/scripts/test_analyze_objective_sensitivity.py
@@ -1,0 +1,315 @@
+"""Tests for the objective-sensitivity analysis script.
+
+Locks in the arithmetic that drives the analysis. If `BASE_REQUEST_WEIGHT`,
+slot multipliers, source multipliers, the mutual boost, or any soft-constraint
+penalty changes, these tests fail and force a corresponding update to
+`docs/reference/objective-sensitivity.md`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parents[3] / "scripts" / "analyze_objective_sensitivity.py"
+
+spec = importlib.util.spec_from_file_location("analyze_objective_sensitivity", SCRIPT_PATH)
+assert spec is not None
+assert spec.loader is not None
+aos = importlib.util.module_from_spec(spec)
+sys.modules["analyze_objective_sensitivity"] = aos
+spec.loader.exec_module(aos)
+
+
+# ---------------------------------------------------------------------------
+# Per-request weight arithmetic
+# ---------------------------------------------------------------------------
+
+
+def test_request_weight_mp_bunk_with_mutual_first_pick() -> None:
+    """MP bunk_with at slot 0 with mutual boost: 40 × 1.5 × 2.0 × 10 = 1200."""
+    cfg = aos.ObjectiveConfig()
+    assert aos.request_weight("bunk_with", slot=0, mutual=True, config=cfg) == 1200
+
+
+def test_request_weight_mp_bunk_with_one_way_first_pick() -> None:
+    """MP bunk_with at slot 0, one-directional: 40 × 1.5 × 1.0 × 10 = 600."""
+    cfg = aos.ObjectiveConfig()
+    assert aos.request_weight("bunk_with", slot=0, mutual=False, config=cfg) == 600
+
+
+def test_request_weight_mp_bunk_with_one_way_second() -> None:
+    """MP bunk_with at slot 1, one-directional: 40 × 1.5 × 1.0 × 5 = 300."""
+    cfg = aos.ObjectiveConfig()
+    assert aos.request_weight("bunk_with", slot=1, mutual=False, config=cfg) == 300
+
+
+def test_request_weight_mp_bunk_with_one_way_third_plus() -> None:
+    """MP bunk_with at slot 2+, one-directional: 40 × 1.5 × 1.0 × 1 = 60."""
+    cfg = aos.ObjectiveConfig()
+    assert aos.request_weight("bunk_with", slot=2, mutual=False, config=cfg) == 60
+    # Slot 5 still caps at the third+ multiplier (1):
+    assert aos.request_weight("bunk_with", slot=5, mutual=False, config=cfg) == 60
+
+
+def test_request_weight_mp_bunk_with_mutual_second() -> None:
+    """MP bunk_with at slot 1 with mutual boost: 40 × 1.5 × 2.0 × 5 = 600."""
+    cfg = aos.ObjectiveConfig()
+    assert aos.request_weight("bunk_with", slot=1, mutual=True, config=cfg) == 600
+
+
+def test_request_weight_socialize_with_first_pick() -> None:
+    """IMP socialize_with at slot 0: 40 × 0.6 × 1.0 × 10 = 240."""
+    cfg = aos.ObjectiveConfig()
+    # socialize_with cannot be mutual-boosted (boost is bunk_with only)
+    assert aos.request_weight("socialize_with", slot=0, mutual=False, config=cfg) == 240
+
+
+def test_request_weight_mutual_boost_only_applies_to_bunk_with() -> None:
+    """mutual=True on socialize_with must NOT apply the boost — boost is bunk_with only."""
+    cfg = aos.ObjectiveConfig()
+    boosted = aos.request_weight("socialize_with", slot=0, mutual=True, config=cfg)
+    unboosted = aos.request_weight("socialize_with", slot=0, mutual=False, config=cfg)
+    assert boosted == unboosted == 240
+
+
+def test_request_weight_not_bunk_with_first_pick() -> None:
+    """STAFF not_bunk_with at slot 0: 40 × 1.5 × 1.0 × 10 = 600."""
+    cfg = aos.ObjectiveConfig()
+    assert aos.request_weight("not_bunk_with", slot=0, mutual=False, config=cfg) == 600
+
+
+def test_request_weight_internal_notes_first_pick() -> None:
+    """STAFF internal_notes at slot 0: 40 × 0.8 × 1.0 × 10 = 320."""
+    cfg = aos.ObjectiveConfig()
+    assert aos.request_weight("internal_notes", slot=0, mutual=False, config=cfg) == 320
+
+
+def test_request_weight_unknown_source_raises() -> None:
+    """Unknown source_field must raise — no silent fallback (matches bucket.classify_request)."""
+    cfg = aos.ObjectiveConfig()
+    with pytest.raises(KeyError):
+        aos.request_weight("bogus_source", slot=0, mutual=False, config=cfg)
+
+
+def test_request_weight_negative_slot_raises() -> None:
+    """Negative slot must raise — without the guard, slot=-2 silently returns slot_multipliers[-2]=5
+    (i.e. 300 instead of 60), and slot=-1 returns the last multiplier (1) only by coincidence of tuple length."""
+    cfg = aos.ObjectiveConfig()
+    with pytest.raises(ValueError, match="slot"):
+        aos.request_weight("bunk_with", slot=-1, mutual=False, config=cfg)
+    with pytest.raises(ValueError, match="slot"):
+        aos.request_weight("bunk_with", slot=-2, mutual=True, config=cfg)
+
+
+# ---------------------------------------------------------------------------
+# Penalty inventory
+# ---------------------------------------------------------------------------
+
+
+def test_penalty_grade_ratio() -> None:
+    """grade_ratio penalty: 5000 per violation per bunk (single-grade > 67%)."""
+    cfg = aos.ObjectiveConfig()
+    assert cfg.penalties["grade_ratio"] == 5000
+
+
+def test_penalty_grade_spread_soft() -> None:
+    """grade_spread soft penalty: 3000 per excess unique grade per bunk."""
+    cfg = aos.ObjectiveConfig()
+    assert cfg.penalties["grade_spread_soft"] == 3000
+
+
+def test_penalty_age_spread() -> None:
+    """age_spread violation penalty: 1500 per bunk (spread > 24mo)."""
+    cfg = aos.ObjectiveConfig()
+    assert cfg.penalties["age_spread"] == 1500
+
+
+def test_penalty_level_progression() -> None:
+    """level_progression: 800 per returning camper × lower-level-bunk pairing."""
+    cfg = aos.ObjectiveConfig()
+    assert cfg.penalties["level_progression"] == 800
+
+
+def test_penalty_cabin_minimum_occupancy() -> None:
+    """cabin_minimum_occupancy soft: 2000 per spot underfill (max 2 spots → 4000/bunk)."""
+    cfg = aos.ObjectiveConfig()
+    assert cfg.penalties["cabin_minimum_occupancy"] == 2000
+
+
+def test_bonus_age_grade_flow_max() -> None:
+    """age_grade_flow: up to +300 per camper × bunk bonus."""
+    cfg = aos.ObjectiveConfig()
+    assert cfg.penalties["age_grade_flow_max"] == 300
+
+
+def test_bonus_age_spread_preferred() -> None:
+    """age_spread preferred bonus: +500 per bunk (spread ≤ 12mo)."""
+    cfg = aos.ObjectiveConfig()
+    assert cfg.penalties["age_spread_preferred_bonus"] == 500
+
+
+# ---------------------------------------------------------------------------
+# Archetype totals
+# ---------------------------------------------------------------------------
+
+
+def test_archetype_a_loner_mutual_total() -> None:
+    """Archetype A: 1 MP bunk_with, mutual, slot 0 = 1200 earnable."""
+    cfg = aos.ObjectiveConfig()
+    arch = aos.ARCHETYPES["A_loner_mutual"]
+    assert aos.archetype_total_weight(arch, cfg) == 1200
+
+
+def test_archetype_b_loner_oneway_total() -> None:
+    """Archetype B: 1 MP bunk_with, one-way, slot 0 = 600 earnable."""
+    cfg = aos.ObjectiveConfig()
+    arch = aos.ARCHETYPES["B_loner_oneway"]
+    assert aos.archetype_total_weight(arch, cfg) == 600
+
+
+def test_archetype_c_cluster_star_all_mutual_total() -> None:
+    """Archetype C: 3 MP bunk_with all mutual, slots 0/1/2 = 1200+600+120 = 1920 earnable."""
+    cfg = aos.ObjectiveConfig()
+    arch = aos.ARCHETYPES["C_cluster_star"]
+    # slot 0 mutual: 40×1.5×2×10 = 1200
+    # slot 1 mutual: 40×1.5×2×5  = 600
+    # slot 2 mutual: 40×1.5×2×1  = 120
+    assert aos.archetype_total_weight(arch, cfg) == 1920
+
+
+def test_archetype_d_mixed_multi_total() -> None:
+    """Archetype D (residual): 3 MP, 1 mutual + 2 one-way = 1200+300+60 = 1560 earnable."""
+    cfg = aos.ObjectiveConfig()
+    arch = aos.ARCHETYPES["D_mixed_multi"]
+    # slot 0 mutual:  40×1.5×2×10 = 1200
+    # slot 1 one-way: 40×1.5×1×5  = 300
+    # slot 2 one-way: 40×1.5×1×1  = 60
+    assert aos.archetype_total_weight(arch, cfg) == 1560
+
+
+def test_archetype_e_popular_target_total_own() -> None:
+    """Archetype E: popular-target camper's own 2 MP one-way requests = 600+300 = 900 earnable from her side."""
+    cfg = aos.ObjectiveConfig()
+    arch = aos.ARCHETYPES["E_popular_target_own"]
+    assert aos.archetype_total_weight(arch, cfg) == 900
+
+
+# ---------------------------------------------------------------------------
+# Threshold analysis
+# ---------------------------------------------------------------------------
+
+
+def test_threshold_ratio_loner_oneway_vs_grade_ratio() -> None:
+    """Archetype B (600) vs grade_ratio (5000): 8.33× below — solver only honors if 'free'."""
+    cfg = aos.ObjectiveConfig()
+    arch = aos.ARCHETYPES["B_loner_oneway"]
+    ratio = aos.threshold_ratio(arch, "grade_ratio", cfg)
+    assert round(ratio, 2) == 8.33
+
+
+def test_threshold_ratio_loner_mutual_vs_grade_ratio() -> None:
+    """Archetype A (1200) vs grade_ratio (5000): 4.17× below."""
+    cfg = aos.ObjectiveConfig()
+    arch = aos.ARCHETYPES["A_loner_mutual"]
+    ratio = aos.threshold_ratio(arch, "grade_ratio", cfg)
+    assert round(ratio, 2) == 4.17
+
+
+def test_threshold_ratio_cluster_star_vs_grade_ratio() -> None:
+    """Archetype C (1920) vs grade_ratio (5000): 2.60× below — cluster placement can override a single ratio violation when stacked."""
+    cfg = aos.ObjectiveConfig()
+    arch = aos.ARCHETYPES["C_cluster_star"]
+    ratio = aos.threshold_ratio(arch, "grade_ratio", cfg)
+    assert round(ratio, 2) == 2.60
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering smoke test
+# ---------------------------------------------------------------------------
+
+
+def test_render_request_weight_table_smoke() -> None:
+    """The weight table renders with all expected rows and contains the canonical 1200 figure."""
+    cfg = aos.ObjectiveConfig()
+    md = aos.render_request_weight_table(cfg)
+    assert "bunk_with" in md
+    assert "1200" in md
+    assert "600" in md
+    assert "240" in md  # socialize_with
+
+
+def test_render_penalty_table_smoke() -> None:
+    """The penalty table renders with all module names and seed values."""
+    cfg = aos.ObjectiveConfig()
+    md = aos.render_penalty_table(cfg)
+    assert "grade_ratio" in md
+    assert "5000" in md
+    assert "level_progression" in md
+    assert "800" in md
+
+
+def test_render_archetype_table_smoke() -> None:
+    """The archetype table renders rows for A-E with correct totals."""
+    cfg = aos.ObjectiveConfig()
+    md = aos.render_archetype_table(cfg)
+    assert "A_loner_mutual" in md or "Loner mutual" in md
+    assert "1200" in md
+    assert "1920" in md  # cluster_star
+
+
+def test_render_archetype_table_header_uses_config() -> None:
+    """Header penalty values in the archetype table must come from config, not be hardcoded.
+
+    Regression for the CodeRabbit finding on PR #1529: if someone passes a non-default
+    config, the body rows compute ratios from `config.penalties[...]` but the header
+    should not say "(5000)" while the rows use a different penalty.
+    """
+    custom_cfg = aos.ObjectiveConfig(
+        penalties={
+            "grade_ratio": 7777,
+            "grade_spread_soft": 3333,
+            "cabin_minimum_occupancy": 2000,
+            "age_spread": 1500,
+            "level_progression": 999,
+            "age_grade_flow_max": 300,
+            "age_spread_preferred_bonus": 500,
+        }
+    )
+    md = aos.render_archetype_table(custom_cfg)
+    assert "7777" in md, "Header should reflect the custom grade_ratio penalty"
+    assert "3333" in md, "Header should reflect the custom grade_spread_soft penalty"
+    assert "999" in md, "Header should reflect the custom level_progression penalty"
+
+
+# ---------------------------------------------------------------------------
+# Linkage to solver constants — drift defense
+# ---------------------------------------------------------------------------
+
+
+def test_objective_config_defaults_match_solver_constants() -> None:
+    """`ObjectiveConfig` defaults must equal the hardcoded constants in
+    `bunking/solver/direct_solver.py`. If that file's constants change, this
+    test fails and forces a corresponding update to the script + doc + test suite.
+
+    Without this linkage, all 28 magnitude tests in this file could keep passing
+    while the analysis silently goes wrong (the script's `ObjectiveConfig` is a
+    parallel copy of the solver constants).
+    """
+    from bunking.solver.direct_solver import (
+        BASE_REQUEST_WEIGHT,
+        FIRST_REQUEST_MULTIPLIER,
+        SECOND_REQUEST_MULTIPLIER,
+        THIRD_PLUS_REQUEST_MULTIPLIER,
+    )
+
+    cfg = aos.ObjectiveConfig()
+    assert cfg.base_request_weight == BASE_REQUEST_WEIGHT
+    assert cfg.slot_multipliers == (
+        FIRST_REQUEST_MULTIPLIER,
+        SECOND_REQUEST_MULTIPLIER,
+        THIRD_PLUS_REQUEST_MULTIPLIER,
+    )


### PR DESCRIPTION
## Summary

Adds a new reference doc (`docs/reference/objective-sensitivity.md`) and a reproducible script (`scripts/analyze_objective_sensitivity.py`) that compile the solver's per-request weights and per-constraint penalty magnitudes into one place. Provides arithmetic explanations for solver behavior that was previously gut-checked.

Surfaced via residual analysis on the May 12 stuck-core investigation continuation — the 21 S2 / 17 S4 unmet MP requests turned out to be a clean arithmetic story once the magnitudes were tabulated.

## Why

Until now the solver's objective coefficients lived in scattered places (`CONFIG_SCHEMA`, seed migrations, hardcoded constants in `direct_solver.py:67-72`) and comparisons between request rewards and penalty costs were made by feel. This made tuning decisions ad-hoc and made the recent Phase 3 (#1523 mutual-request boost) result hard to interpret quantitatively.

Three concrete payoffs:

1. **Phase 4 brainstorming has a quantitative baseline.** The next stream's choice (sparse `person_in_bunk` vs. an objective-side lever vs. something else) can be ranked against actual magnitudes, not speculation.
2. **`solver-config-it` cleanup gains a second-pass criterion.** Beyond "does anything read this," now also "does this contribute meaningful objective magnitude vs. peers?"
3. **The 21 S2 / 17 S4 residuals have a definitive single-paragraph explanation.** Archetype D (1 mutual + 2 one-way) earns 1,200 from the mutual slot 0; the tail slots 1-2 add only 300+60 marginal. Any tail-honor that triggers a grade_ratio break loses by 5,000 vs 60-300. The solver drops them correctly.

## What's in the diff

- **`scripts/analyze_objective_sensitivity.py`** (~220 lines). Pure-function calculator: takes an `ObjectiveConfig` (default = current seed values), renders three markdown tables (per-request weights, per-constraint penalties, per-archetype totals + threshold ratios). Run with `uv run python scripts/analyze_objective_sensitivity.py`.
- **`tests/unit/scripts/test_analyze_objective_sensitivity.py`** (28 tests). Locks in every magnitude shown in the doc — if `BASE_REQUEST_WEIGHT`, slot multipliers, source multipliers, the mutual boost, or any seeded penalty changes, these tests fail and force a corresponding doc + script update.
- **`docs/reference/objective-sensitivity.md`** (~145 lines). Three tables + reading guide + worked example using real S2 sweep data + a cross-reference to `solver-config-decisions.md` for dead-config tracking (which catalogs three vestigial knobs that surfaced during the inventory but were already pre-tracked there with per-domain Phase 2 resolutions in flight).

## Findings worth flagging

- **`BASE_REQUEST_WEIGHT = 40` × slot multipliers (10/5/1)** makes a slot-0 mutual MP request worth 1,200 cost units. The roadmap's pre-Phase-3 arithmetic at line 528 ("`share_bunk_with × first_request_multiplier = 1.5 × 10 = 15`") is stale by 40× — PR #1455's migration `1500000100` hardcoded these constants after deleting the config rows. The roadmap's stuck-core investigation arithmetic predates this change.
- **Dead-config items surfaced during inventory were already cataloged** in `solver-config-decisions.md` (local-only) — `grade_cohesion.weight`, `level_progression.prefer_progression`, `grade_spread.max_spread`. Per-domain Phase 2 resolutions are already planned. No new findings to file; the reference doc now cross-references the cleanup doc instead of snapshotting these.

## Test plan

- [x] 28 unit tests pass (`uv run pytest tests/unit/scripts/test_analyze_objective_sensitivity.py`)
- [x] Tests written first; verified failing before script implementation (TDD red phase confirmed)
- [x] `ruff format` + `ruff check` clean on touched files
- [x] `mypy` clean on touched files
- [x] Script runs and produces expected markdown tables (`uv run python scripts/analyze_objective_sensitivity.py`)
- [x] Doc tables match script output byte-for-byte
- [ ] Manual sanity: visual review of the doc renders correctly in GitHub markdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a reference guide on solver objective-sensitivity: per-request weights, slot/source multipliers, soft/hard constraint magnitudes, archetype threshold ratios, worked examples, and regeneration instructions. Clarified scoring notes to explain diagnostic vs. solver-enforced preferences and added a modernization backlog note about a lint rule to address later.

* **New Features**
  * Added a reporting tool to compute and render objective-sensitivity tables and archetype totals.

* **Tests**
  * Added unit tests validating weight calculations, penalties/bonuses, archetype totals/ratios, and report rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1529?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->