### PR TITLE
fix(sync): multi-enrollment session blind spots across ExactMatchStrategy paths

### DIFF
--- a/bunking/sync/bunk_request_processor/data/repositories/attendee_repository.py
+++ b/bunking/sync/bunk_request_processor/data/repositories/attendee_repository.py
@@ -282,6 +282,74 @@ class AttendeeRepository:
             logger.exception("bulk_get_sessions_chunk failed for %d person IDs (year=%d)", len(person_cm_ids), year)
             return {}
 
+    def bulk_get_all_sessions_for_persons(self, person_cm_ids: list[int], year: int) -> dict[int, list[int]]:
+        """Get ALL bunking-relevant session enrollments per person.
+
+        Unlike `bulk_get_sessions_for_persons` (which collapses to one session
+        per person via status-priority tiebreak), returns the full list of
+        bunking enrollments. Used by name-resolution matchers that need
+        multi-enrollment awareness.
+
+        Chunks at _BULK_CHUNK_SIZE (100) to avoid PocketBase OR clause length limits.
+        Filters to VALID_BUNKING_SESSION_TYPES.
+        """
+        if not person_cm_ids:
+            return {}
+
+        sessions_dict: dict[int, list[int]] = {}
+        for i in range(0, len(person_cm_ids), self._BULK_CHUNK_SIZE):
+            chunk = person_cm_ids[i : i + self._BULK_CHUNK_SIZE]
+            chunk_result = self._bulk_get_all_sessions_chunk(chunk, year)
+            for cm_id, session_list in chunk_result.items():
+                sessions_dict.setdefault(cm_id, []).extend(session_list)
+
+        return sessions_dict
+
+    def _bulk_get_all_sessions_chunk(self, person_cm_ids: list[int], year: int) -> dict[int, list[int]]:
+        """Get all bunking sessions for a single chunk of person IDs.
+
+        Mirrors `_bulk_get_sessions_chunk` but appends instead of overwriting,
+        so multi-enrolled campers get every bunking session returned.
+        """
+        from .session_repository import VALID_BUNKING_SESSION_TYPES
+
+        try:
+            or_conditions = [f"person_id = {cm_id}" for cm_id in person_cm_ids]
+            or_clause = " || ".join(or_conditions)
+
+            items = self.pb.collection("attendees").get_full_list(
+                query_params={
+                    "filter": f"({or_clause}) && year = {year}",
+                    "expand": "session",
+                },
+            )
+
+            sessions_dict: dict[int, list[int]] = {}
+            for item in items:
+                person_cm_id = getattr(item, "person_id", None)
+                session_cm_id = self._get_session_cm_id(item)
+                if not person_cm_id or not session_cm_id:
+                    continue
+
+                session = get_session_from_expand(item)
+                session_type = getattr(session, "session_type", None) if session else None
+                if session_type not in VALID_BUNKING_SESSION_TYPES:
+                    continue
+
+                bucket = sessions_dict.setdefault(person_cm_id, [])
+                if session_cm_id not in bucket:
+                    bucket.append(session_cm_id)
+
+            return sessions_dict
+
+        except Exception:
+            logger.exception(
+                "bulk_get_all_sessions_chunk failed for %d person IDs (year=%d)",
+                len(person_cm_ids),
+                year,
+            )
+            return {}
+
     def bulk_get_enrollment_for_persons(self, person_cm_ids: list[int], year: int) -> dict[int, EnrollmentInfo]:
         """Get enrollment info including status_id for each person.
 

--- a/bunking/sync/bunk_request_processor/resolution/interfaces.py
+++ b/bunking/sync/bunk_request_processor/resolution/interfaces.py
@@ -6,9 +6,22 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any
 
 from ..core.models import Person
+
+
+class SessionMatch(Enum):
+    """Tri-state classification for target's session vs requester's session.
+
+    Values match the existing metadata["session_match"] strings so call sites
+    can stamp `match.value` directly into ResolutionResult metadata.
+    """
+
+    SAME = "exact"
+    DIFFERENT = "different"
+    UNKNOWN = "unknown"
 
 
 @dataclass

--- a/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
@@ -377,7 +377,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
                 confidence = 0.90  # Base for parent surname match
                 if session_cm_id and attendee_info:
                     person_sessions = attendee_info.get(matches[0].cm_id, {}).get("session_cm_ids")
-                    if self._classify_session(person_sessions, session_cm_id) is not SessionMatch.SAME:
+                    if self._classify_session(person_sessions, session_cm_id) is SessionMatch.DIFFERENT:
                         confidence = 0.80  # Lower for different session
 
                 return ResolutionResult(
@@ -417,7 +417,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
             confidence = 0.90  # Base for parent-surname match (lower than direct-match base 0.95)
             if year and session_cm_id:
                 sessions_map = self.attendee_repo.bulk_get_all_sessions_for_persons([matches[0].cm_id], year)
-                if self._classify_session(sessions_map.get(matches[0].cm_id), session_cm_id) is not SessionMatch.SAME:
+                if self._classify_session(sessions_map.get(matches[0].cm_id), session_cm_id) is SessionMatch.DIFFERENT:
                     confidence = 0.80  # Lower for different session
             return ResolutionResult(
                 person=matches[0],
@@ -477,7 +477,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
             confidence = 0.90  # Base for parent-surname match (lower than direct-match base 0.95)
             if year and session_cm_id:
                 sessions_map = self.attendee_repo.bulk_get_all_sessions_for_persons([matches[0].cm_id], year)
-                if self._classify_session(sessions_map.get(matches[0].cm_id), session_cm_id) is not SessionMatch.SAME:
+                if self._classify_session(sessions_map.get(matches[0].cm_id), session_cm_id) is SessionMatch.DIFFERENT:
                     confidence = 0.80  # Lower for different session
             return ResolutionResult(
                 person=matches[0],

--- a/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
@@ -101,32 +101,19 @@ class ExactMatchStrategy(BaseMatchStrategy):
                     session_cm_id = requester_info.get("session_cm_id")
 
                 if session_cm_id:
-                    match_session = attendee_info.get(matches[0].cm_id, {}).get("session_cm_id")
-                    if self._is_same_session_via_attendee_info(matches[0].cm_id, session_cm_id, attendee_info):
-                        return ResolutionResult(
-                            person=matches[0],
-                            confidence=0.95,
-                            method=self.name,
-                            metadata={"sub_method": "unique", "session_match": "exact"},
-                        )
-                    elif match_session is not None:
-                        # Target enrolled in a different bunking session
-                        return ResolutionResult(
-                            person=matches[0],
-                            confidence=0.85,  # Lower confidence for different session
-                            method=self.name,
-                            metadata={"sub_method": "unique", "session_match": "different"},
-                        )
-                    else:
-                        # No session data for target in enrolled-only map.
-                        # Could be cancelled, waitlisted, or not enrolled.
-                        # Disposition handled by ConflictDetector.
-                        return ResolutionResult(
-                            person=matches[0],
-                            confidence=0.90,
-                            method=self.name,
-                            metadata={"sub_method": "unique", "session_match": "unknown"},
-                        )
+                    person_sessions = attendee_info.get(matches[0].cm_id, {}).get("session_cm_ids")
+                    match = self._classify_session(person_sessions, session_cm_id)
+                    confidence_map = {
+                        SessionMatch.SAME: 0.95,
+                        SessionMatch.DIFFERENT: 0.85,
+                        SessionMatch.UNKNOWN: 0.90,
+                    }
+                    return ResolutionResult(
+                        person=matches[0],
+                        confidence=confidence_map[match],
+                        method=self.name,
+                        metadata={"sub_method": "unique", "session_match": match.value},
+                    )
                 else:
                     # No session context available
                     return ResolutionResult(

--- a/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
@@ -507,9 +507,14 @@ class ExactMatchStrategy(BaseMatchStrategy):
             return ResolutionResult(confidence=0.0, method=self.name)
 
         if len(matches) == 1:
+            confidence = 0.90  # Base for parent-surname match (lower than direct-match base 0.95)
+            if year and session_cm_id:
+                sessions_map = self.attendee_repo.bulk_get_all_sessions_for_persons([matches[0].cm_id], year)
+                if self._classify_session(sessions_map.get(matches[0].cm_id), session_cm_id) is not SessionMatch.SAME:
+                    confidence = 0.80  # Lower for different session
             return ResolutionResult(
                 person=matches[0],
-                confidence=0.90,
+                confidence=confidence,
                 method=self.name,
                 metadata={
                     "sub_method": "parent_surname",

--- a/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
@@ -9,7 +9,7 @@ from typing import Any
 from ...core.models import Person
 from ...data.repositories import AttendeeRepository, PersonRepository
 from ...shared import last_name_matches, parse_name
-from ..interfaces import ResolutionResult
+from ..interfaces import ResolutionResult, SessionMatch
 from .base_match_strategy import BaseMatchStrategy
 
 
@@ -212,6 +212,21 @@ class ExactMatchStrategy(BaseMatchStrategy):
         if match_sessions:
             return session_cm_id in match_sessions
         return info.get("session_cm_id") == session_cm_id
+
+    @staticmethod
+    def _classify_session(
+        person_sessions: list[int] | None,
+        requester_session: int,
+    ) -> SessionMatch:
+        """Classify target's session vs requester's, multi-enrollment aware.
+
+        Both data sources (attendee_info dict's session_cm_ids and the new
+        bulk_get_all_sessions_for_persons map) collapse to list[int] | None
+        at the call site.
+        """
+        if not person_sessions:
+            return SessionMatch.UNKNOWN
+        return SessionMatch.SAME if requester_session in person_sessions else SessionMatch.DIFFERENT
 
     def _disambiguate_with_session(
         self,

--- a/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
@@ -136,30 +136,14 @@ class ExactMatchStrategy(BaseMatchStrategy):
                         effective_session = db_requester_info["session_cm_id"]
 
                 if effective_session:
-                    sessions_map = self.attendee_repo.bulk_get_sessions_for_persons([matches[0].cm_id], year)
-                    match_session = sessions_map.get(matches[0].cm_id)
-
-                    if match_session == effective_session:
-                        return ResolutionResult(
-                            person=matches[0],
-                            confidence=0.95,
-                            method=self.name,
-                            metadata={"sub_method": "unique", "session_match": "exact"},
-                        )
-                    elif match_session is not None:
-                        return ResolutionResult(
-                            person=matches[0],
-                            confidence=0.85,
-                            method=self.name,
-                            metadata={"sub_method": "unique", "session_match": "different"},
-                        )
-                    else:
-                        return ResolutionResult(
-                            person=matches[0],
-                            confidence=0.90,
-                            method=self.name,
-                            metadata={"sub_method": "unique", "session_match": "unknown"},
-                        )
+                    sessions_map = self.attendee_repo.bulk_get_all_sessions_for_persons([matches[0].cm_id], year)
+                    match = self._classify_session(sessions_map.get(matches[0].cm_id), effective_session)
+                    return ResolutionResult(
+                        person=matches[0],
+                        confidence=_DIRECT_MATCH_CONFIDENCE[match],
+                        method=self.name,
+                        metadata={"sub_method": "unique", "session_match": match.value},
+                    )
                 else:
                     return ResolutionResult(
                         person=matches[0],

--- a/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
@@ -449,10 +449,8 @@ class ExactMatchStrategy(BaseMatchStrategy):
         if len(matches) == 1:
             confidence = 0.90  # Slightly lower than direct match (0.95)
             if year and session_cm_id:
-                sessions_map = self.attendee_repo.bulk_get_sessions_for_persons([matches[0].cm_id], year)
-                if sessions_map.get(matches[0].cm_id) == session_cm_id:
-                    confidence = 0.90
-                else:
+                sessions_map = self.attendee_repo.bulk_get_all_sessions_for_persons([matches[0].cm_id], year)
+                if self._classify_session(sessions_map.get(matches[0].cm_id), session_cm_id) is not SessionMatch.SAME:
                     confidence = 0.80  # Lower for different session
             return ResolutionResult(
                 person=matches[0],

--- a/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
@@ -12,6 +12,16 @@ from ...shared import last_name_matches, parse_name
 from ..interfaces import ResolutionResult, SessionMatch
 from .base_match_strategy import BaseMatchStrategy
 
+# Confidence values for Path C (direct-match unique branch), keyed by SessionMatch:
+# - SAME (target enrolled in requester's session)        -> 0.95 high-confidence match
+# - DIFFERENT (target in known other session)            -> 0.85 likely-correct but session mismatch
+# - UNKNOWN (no session data; cancelled/waitlisted/etc.) -> 0.90 — ConflictDetector handles downstream
+_DIRECT_MATCH_CONFIDENCE: dict[SessionMatch, float] = {
+    SessionMatch.SAME: 0.95,
+    SessionMatch.DIFFERENT: 0.85,
+    SessionMatch.UNKNOWN: 0.90,
+}
+
 
 class ExactMatchStrategy(BaseMatchStrategy):
     """Strategy for exact name matching.
@@ -103,14 +113,9 @@ class ExactMatchStrategy(BaseMatchStrategy):
                 if session_cm_id:
                     person_sessions = attendee_info.get(matches[0].cm_id, {}).get("session_cm_ids")
                     match = self._classify_session(person_sessions, session_cm_id)
-                    confidence_map = {
-                        SessionMatch.SAME: 0.95,
-                        SessionMatch.DIFFERENT: 0.85,
-                        SessionMatch.UNKNOWN: 0.90,
-                    }
                     return ResolutionResult(
                         person=matches[0],
-                        confidence=confidence_map[match],
+                        confidence=_DIRECT_MATCH_CONFIDENCE[match],
                         method=self.name,
                         metadata={"sub_method": "unique", "session_match": match.value},
                     )

--- a/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
@@ -173,23 +173,6 @@ class ExactMatchStrategy(BaseMatchStrategy):
         )
 
     @staticmethod
-    def _is_same_session_via_attendee_info(
-        person_cm_id: int,
-        session_cm_id: int,
-        attendee_info: dict[int, dict[str, Any]],
-    ) -> bool:
-        """Check if a person is enrolled in the given session, using pre-loaded attendee_info.
-
-        Prefers session_cm_ids (multi-enrollment) when available, falls back to singular
-        session_cm_id for backward compatibility.
-        """
-        info = attendee_info.get(person_cm_id, {})
-        match_sessions = info.get("session_cm_ids", [])
-        if match_sessions:
-            return session_cm_id in match_sessions
-        return info.get("session_cm_id") == session_cm_id
-
-    @staticmethod
     def _classify_session(
         person_sessions: list[int] | None,
         requester_session: int,
@@ -393,7 +376,8 @@ class ExactMatchStrategy(BaseMatchStrategy):
             if len(matches) == 1:
                 confidence = 0.90  # Base for parent surname match
                 if session_cm_id and attendee_info:
-                    if not self._is_same_session_via_attendee_info(matches[0].cm_id, session_cm_id, attendee_info):
+                    person_sessions = attendee_info.get(matches[0].cm_id, {}).get("session_cm_ids")
+                    if self._classify_session(person_sessions, session_cm_id) is not SessionMatch.SAME:
                         confidence = 0.80  # Lower for different session
 
                 return ResolutionResult(

--- a/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
@@ -248,7 +248,10 @@ class ExactMatchStrategy(BaseMatchStrategy):
                 )
 
             same_session_matches = [
-                m for m in matches if self._is_same_session_via_attendee_info(m.cm_id, session_cm_id, attendee_info)
+                m
+                for m in matches
+                if self._classify_session(attendee_info.get(m.cm_id, {}).get("session_cm_ids"), session_cm_id)
+                is SessionMatch.SAME
             ]
 
             if len(same_session_matches) == 1:
@@ -272,7 +275,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
             else:
                 # No matches in same session - mark as IMPOSSIBLE
                 if len(matches) == 1:
-                    target_session = attendee_info.get(matches[0].cm_id, {}).get("session_cm_id")
+                    target_sessions = attendee_info.get(matches[0].cm_id, {}).get("session_cm_ids", [])
                     return ResolutionResult(
                         person=matches[0],
                         confidence=0.0,
@@ -281,7 +284,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
                             "impossible": True,
                             "impossible_reason": "target_in_different_session",
                             "sub_method": "exact_different_session",
-                            "target_session": target_session,
+                            "target_sessions": target_sessions,
                             "requester_session": session_cm_id,
                         },
                     )
@@ -312,9 +315,13 @@ class ExactMatchStrategy(BaseMatchStrategy):
                 )
 
             match_cm_ids = [m.cm_id for m in matches]
-            sessions_map = self.attendee_repo.bulk_get_sessions_for_persons(match_cm_ids, year)
+            sessions_map = self.attendee_repo.bulk_get_all_sessions_for_persons(match_cm_ids, year)
 
-            same_session_matches = [m for m in matches if sessions_map.get(m.cm_id) == session_cm_id]
+            same_session_matches = [
+                m
+                for m in matches
+                if self._classify_session(sessions_map.get(m.cm_id), session_cm_id) is SessionMatch.SAME
+            ]
 
             if len(same_session_matches) == 1:
                 return ResolutionResult(
@@ -345,7 +352,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
                             "impossible": True,
                             "impossible_reason": "target_in_different_session",
                             "sub_method": "exact_different_session",
-                            "target_session": sessions_map.get(matches[0].cm_id),
+                            "target_sessions": sessions_map.get(matches[0].cm_id, []),
                             "requester_session": session_cm_id,
                         },
                     )

--- a/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
+++ b/bunking/sync/bunk_request_processor/resolution/strategies/exact_match.py
@@ -447,7 +447,7 @@ class ExactMatchStrategy(BaseMatchStrategy):
             return ResolutionResult(confidence=0.0, method=self.name)
 
         if len(matches) == 1:
-            confidence = 0.90  # Slightly lower than direct match (0.95)
+            confidence = 0.90  # Base for parent-surname match (lower than direct-match base 0.95)
             if year and session_cm_id:
                 sessions_map = self.attendee_repo.bulk_get_all_sessions_for_persons([matches[0].cm_id], year)
                 if self._classify_session(sessions_map.get(matches[0].cm_id), session_cm_id) is not SessionMatch.SAME:

--- a/tests/unit/sync/bunk_request_processor/data/test_attendee_repository.py
+++ b/tests/unit/sync/bunk_request_processor/data/test_attendee_repository.py
@@ -409,6 +409,54 @@ class TestAttendeeRepository:
         # Should request expand for session
         assert args["query_params"]["expand"] == "session"
 
+    def test_bulk_get_all_sessions_for_persons(self, repository, mock_pb_client):
+        """Test getting ALL bunking sessions per person (multi-enrollment aware).
+
+        Unlike bulk_get_sessions_for_persons (which collapses to one session
+        per person), returns the full list of bunking enrollments.
+        """
+        mock_client, mock_attendees, _ = mock_pb_client
+
+        def make_attendee(person_id, session_cm_id, year, session_type="main", status_id=2):
+            mock = Mock()
+            mock.person_id = person_id
+            mock.year = year
+            mock.status_id = status_id
+            session_mock = Mock()
+            session_mock.cm_id = session_cm_id
+            session_mock.session_type = session_type
+            mock.expand = {"session": session_mock}
+            return mock
+
+        # Person 12345 enrolled in TWO bunking sessions; person 67890 in one
+        mock_attendees.get_full_list.return_value = [
+            make_attendee(12345, 1000001, 2025, session_type="main"),
+            make_attendee(12345, 1000002, 2025, session_type="main"),
+            make_attendee(67890, 1000003, 2025, session_type="main"),
+            # Non-bunking session — must be excluded
+            make_attendee(12345, 9000001, 2025, session_type="family_camp"),
+        ]
+
+        sessions = repository.bulk_get_all_sessions_for_persons([12345, 67890], 2025)
+
+        # Person 12345 has BOTH bunking enrollments returned (multi-enrollment)
+        assert sorted(sessions[12345]) == [1000001, 1000002]
+        # Family-camp session is NOT included
+        assert 9000001 not in sessions[12345]
+        # Person 67890 has one enrollment
+        assert sessions[67890] == [1000003]
+
+        # Verify query shape
+        args = mock_attendees.get_full_list.call_args[1]
+        assert "person_id = 12345" in args["query_params"]["filter"]
+        assert "person_id = 67890" in args["query_params"]["filter"]
+        assert "year = 2025" in args["query_params"]["filter"]
+        assert args["query_params"]["expand"] == "session"
+
+    def test_bulk_get_all_sessions_for_persons_empty_input(self, repository):
+        """Empty input returns empty dict without DB hit."""
+        assert repository.bulk_get_all_sessions_for_persons([], 2025) == {}
+
 
 class TestBulkGetSessionsFiltersBunkingSessions:
     """Tests that bulk_get_sessions_for_persons only returns bunking-relevant sessions.

--- a/tests/unit/sync/bunk_request_processor/data/test_attendee_repository.py
+++ b/tests/unit/sync/bunk_request_processor/data/test_attendee_repository.py
@@ -417,11 +417,10 @@ class TestAttendeeRepository:
         """
         mock_client, mock_attendees, _ = mock_pb_client
 
-        def make_attendee(person_id, session_cm_id, year, session_type="main", status_id=2):
+        def make_attendee(person_id, session_cm_id, year, session_type="main"):
             mock = Mock()
             mock.person_id = person_id
             mock.year = year
-            mock.status_id = status_id
             session_mock = Mock()
             session_mock.cm_id = session_cm_id
             session_mock.session_type = session_type
@@ -431,7 +430,7 @@ class TestAttendeeRepository:
         # Person 12345 enrolled in TWO bunking sessions; person 67890 in one
         mock_attendees.get_full_list.return_value = [
             make_attendee(12345, 1000001, 2025, session_type="main"),
-            make_attendee(12345, 1000002, 2025, session_type="main"),
+            make_attendee(12345, 1000002, 2025, session_type="ag"),
             make_attendee(67890, 1000003, 2025, session_type="main"),
             # Non-bunking session — must be excluded
             make_attendee(12345, 9000001, 2025, session_type="family_camp"),
@@ -453,9 +452,11 @@ class TestAttendeeRepository:
         assert "year = 2025" in args["query_params"]["filter"]
         assert args["query_params"]["expand"] == "session"
 
-    def test_bulk_get_all_sessions_for_persons_empty_input(self, repository):
+    def test_bulk_get_all_sessions_for_persons_empty_input(self, repository, mock_pb_client):
         """Empty input returns empty dict without DB hit."""
+        _, mock_attendees, _ = mock_pb_client
         assert repository.bulk_get_all_sessions_for_persons([], 2025) == {}
+        mock_attendees.get_full_list.assert_not_called()
 
 
 class TestBulkGetSessionsFiltersBunkingSessions:

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
@@ -104,10 +104,10 @@ class TestExactMatchStrategy:
         person2 = Person(cm_id=67890, first_name="John", last_name="Smith")
         person_repo.find_by_name.return_value = [person1, person2]
 
-        # Mock session lookups
-        attendee_repo.bulk_get_sessions_for_persons.return_value = {
-            12345: 1000002,  # Session 1
-            67890: 1000003,  # Session 2
+        # Mock session lookups (new list-based bulk method: {cm_id: list[int]})
+        attendee_repo.bulk_get_all_sessions_for_persons.return_value = {
+            12345: [1000002],  # Session 1
+            67890: [1000003],  # Session 2
         }
 
         # Requester is in session 1
@@ -135,8 +135,8 @@ class TestExactMatchStrategy:
         person2 = Person(cm_id=67890, first_name="John", last_name="Smith")
         person_repo.find_by_name.return_value = [person1, person2]
 
-        # Both in same session
-        attendee_repo.bulk_get_sessions_for_persons.return_value = {12345: 1000002, 67890: 1000002}
+        # Both in same session (new list-based bulk method: {cm_id: list[int]})
+        attendee_repo.bulk_get_all_sessions_for_persons.return_value = {12345: [1000002], 67890: [1000002]}
 
         # Requester also in session
         attendee_repo.get_by_person_and_year.return_value = {
@@ -849,6 +849,93 @@ class TestParentSurnameSessionCmIds:
         assert result.is_resolved
         assert result.person.cm_id == 2000001
         assert result.confidence == 0.80  # correctly penalised
+
+
+class TestPathDDisambiguate:
+    """Tests for Path D: _disambiguate_with_session multi-enrollment fixes (#1501)."""
+
+    @pytest.fixture
+    def mock_repositories(self):
+        mock_person_repo = Mock()
+        mock_attendee_repo = Mock()
+        return mock_person_repo, mock_attendee_repo
+
+    @pytest.fixture
+    def strategy(self, mock_repositories):
+        person_repo, attendee_repo = mock_repositories
+        attendee_repo.get_by_person_and_year.return_value = None
+        attendee_repo.bulk_get_sessions_for_persons.return_value = {}
+        attendee_repo.bulk_get_all_sessions_for_persons.return_value = {}
+        person_repo.name_cache = None
+        person_repo.find_by_first_and_parent_surname.return_value = []
+        person_repo.get_all_for_phonetic_matching.return_value = []
+        return ExactMatchStrategy(person_repo, attendee_repo)
+
+    def test_path_d_disambiguate_db_multi_enrollment(self, strategy, mock_repositories):
+        """Path D (#1501): _disambiguate_with_session DB fallback uses bulk_get_all_sessions.
+
+        Two persons named "John Smith" both match. One is multi-enrolled in
+        [1000099, requester_session]. The DB fallback should select that match
+        as same-session via the new bulk method.
+        """
+        person_repo, attendee_repo = mock_repositories
+
+        person_a = Person(cm_id=11111, first_name="John", last_name="Smith")
+        person_b = Person(cm_id=22222, first_name="John", last_name="Smith")
+        person_repo.find_by_name.return_value = [person_a, person_b]
+
+        # Requester session lookup via DB
+        attendee_repo.get_by_person_and_year.return_value = {"session_cm_id": 1000002}
+
+        # NEW bulk method: person_a primary is 1000099 but secondary is 1000002 (multi-enrolled)
+        attendee_repo.bulk_get_all_sessions_for_persons.return_value = {
+            11111: [1000099, 1000002],  # Multi-enrolled, includes requester session
+            22222: [1000888],  # Different session only
+        }
+
+        result = strategy.resolve(
+            "John Smith",
+            requester_cm_id=67890,
+            session_cm_id=1000002,
+            year=2025,
+            attendee_info=None,  # Forces DB fallback
+        )
+
+        assert result.is_resolved
+        assert result.person.cm_id == 11111  # Multi-enrolled match selected
+        assert result.confidence == 0.95
+        assert result.metadata.get("session_match") == "exact"
+
+    def test_path_d_disambiguate_db_impossible_uses_target_sessions_list(self, strategy, mock_repositories):
+        """When _disambiguate_with_session DB fallback finds no same-session match for a
+        singleton input, IMPOSSIBLE metadata carries 'target_sessions' (list) not
+        'target_session' (int).
+
+        Note: _disambiguate_with_session is called directly with 1 match here because
+        resolve() routes single matches through a separate path.
+        """
+        _, attendee_repo = mock_repositories
+
+        person_a = Person(cm_id=11111, first_name="John", last_name="Smith")
+
+        attendee_repo.get_by_person_and_year.return_value = None  # session_cm_id provided directly
+        attendee_repo.bulk_get_all_sessions_for_persons.return_value = {11111: [1000099, 1000888]}
+
+        # Call _disambiguate_with_session directly with 1 match and no attendee_info
+        result = strategy._disambiguate_with_session(
+            matches=[person_a],
+            requester_cm_id=67890,
+            session_cm_id=1000002,
+            year=2025,
+            attendee_info=None,
+        )
+
+        # No same-session matches -> IMPOSSIBLE (singleton match branch)
+        assert result.metadata.get("impossible") is True
+        assert result.metadata.get("impossible_reason") == "target_in_different_session"
+        # NEW: list, not int
+        assert result.metadata.get("target_sessions") == [1000099, 1000888]
+        assert "target_session" not in result.metadata  # Old singular key removed
 
 
 class TestClassifySessionHelper:

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
@@ -412,6 +412,90 @@ class TestExactMatchParentSurname:
         assert result.confidence == 0.90
         attendee_repo.bulk_get_all_sessions_for_persons.assert_called_once_with([12345], 2025)
 
+    def test_path_b_via_db_multi_enrollment_same_session(self, strategy, mock_repositories):
+        """Path B (#1501): _try_parent_surname_match_via_db with multi-enrolled target.
+
+        Before fix: Path B accepts session_cm_id but never uses it, returns 0.90 always.
+        After fix: target in [X, requester_session] -> SAME -> 0.90 base preserved.
+        """
+        person_repo, attendee_repo = mock_repositories
+
+        person_repo.find_by_name.return_value = []  # No direct match
+        person_repo.name_cache = None  # Force Path B (via_db)
+
+        person = Person(
+            cm_id=12345,
+            first_name="Emma",
+            last_name="Johnson",
+            parent_names=json.dumps([{"first": "John", "last": "Smith", "relationship": "Father"}]),
+        )
+        person_repo.get_all_for_phonetic_matching.return_value = [person]
+
+        # Multi-enrollment: target in [1000099, requester_session]
+        attendee_repo.bulk_get_all_sessions_for_persons.return_value = {12345: [1000099, 1000002]}
+
+        result = strategy.resolve(
+            "Emma Smith",
+            requester_cm_id=67890,
+            session_cm_id=1000002,
+            year=2025,
+        )
+
+        assert result.is_resolved
+        assert result.confidence == 0.90  # SAME -> 0.90 base preserved
+        attendee_repo.bulk_get_all_sessions_for_persons.assert_called_once_with([12345], 2025)
+
+    def test_path_b_via_db_different_session_downgrades(self, strategy, mock_repositories):
+        """Path B (#1501): when target's sessions don't include requester's, confidence -> 0.80.
+
+        Before fix: returned 0.90 regardless. After: DIFFERENT -> 0.80.
+        """
+        person_repo, attendee_repo = mock_repositories
+
+        person_repo.find_by_name.return_value = []
+        person_repo.name_cache = None
+
+        person = Person(
+            cm_id=12345,
+            first_name="Emma",
+            last_name="Johnson",
+            parent_names=json.dumps([{"first": "John", "last": "Smith", "relationship": "Father"}]),
+        )
+        person_repo.get_all_for_phonetic_matching.return_value = [person]
+
+        attendee_repo.bulk_get_all_sessions_for_persons.return_value = {12345: [1000099, 1000888]}
+
+        result = strategy.resolve(
+            "Emma Smith",
+            requester_cm_id=67890,
+            session_cm_id=1000002,
+            year=2025,
+        )
+
+        assert result.is_resolved
+        assert result.confidence == 0.80  # DIFFERENT -> 0.80 (was 0.90 before fix)
+
+    def test_path_b_via_db_no_session_context_keeps_base(self, strategy, mock_repositories):
+        """Path B with no session_cm_id/year preserves base 0.90 (no downgrade)."""
+        person_repo, _ = mock_repositories
+
+        person_repo.find_by_name.return_value = []
+        person_repo.name_cache = None
+
+        person = Person(
+            cm_id=12345,
+            first_name="Emma",
+            last_name="Johnson",
+            parent_names=json.dumps([{"first": "John", "last": "Smith", "relationship": "Father"}]),
+        )
+        person_repo.get_all_for_phonetic_matching.return_value = [person]
+
+        # No session_cm_id passed
+        result = strategy.resolve("Emma Smith", requester_cm_id=67890, year=2025)
+
+        assert result.is_resolved
+        assert result.confidence == 0.90  # base preserved when no session context
+
 
 class TestExactMatchPreferredName:
     """Test preferred_name matching in ExactMatchStrategy."""

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
@@ -6,6 +6,7 @@ import json
 import sys
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -557,6 +558,96 @@ class TestExactMatchParentSurname:
 
         assert result.is_resolved
         assert result.confidence == 0.90  # base preserved when no session context
+
+    def test_parent_surname_candidates_unknown_session_keeps_base(self, strategy, mock_repositories):
+        """Parent-surname candidates branch: UNKNOWN session preserves 0.90 base.
+
+        attendee_info has no session_cm_ids entry for the target (cancelled, waitlisted,
+        or otherwise absent from enrolled-only map). Classifier returns UNKNOWN; downgrade
+        to 0.80 must only happen for DIFFERENT, not UNKNOWN.
+        """
+        person_repo, _ = mock_repositories
+
+        person = Person(
+            cm_id=12345,
+            first_name="Emma",
+            last_name="Johnson",
+            parent_names=json.dumps([{"first": "John", "last": "Smith", "relationship": "Father"}]),
+        )
+
+        # attendee_info present but target has no session data -> UNKNOWN
+        attendee_info: dict[int, dict[str, Any]] = {67890: {"session_cm_ids": [1000002]}}
+
+        result = strategy.resolve(
+            "Emma Smith",
+            requester_cm_id=67890,
+            session_cm_id=1000002,
+            year=2025,
+            candidates=[person],
+            attendee_info=attendee_info,
+        )
+
+        assert result.is_resolved
+        assert result.person.cm_id == 12345
+        assert result.confidence == 0.90  # UNKNOWN preserves base, only DIFFERENT downgrades to 0.80
+
+    def test_path_a_name_cache_unknown_session_keeps_base(self, strategy, mock_repositories):
+        """Path A (name_cache parent-surname): UNKNOWN session preserves 0.90 base."""
+        person_repo, attendee_repo = mock_repositories
+
+        person_repo.find_by_name.return_value = []
+
+        person = Person(
+            cm_id=12345,
+            first_name="Emma",
+            last_name="Johnson",
+            parent_names=json.dumps([{"first": "John", "last": "Smith", "relationship": "Father"}]),
+        )
+
+        mock_cache = Mock()
+        mock_cache.find_by_parent_surname.return_value = [person]
+        person_repo.name_cache = mock_cache
+
+        # Target absent from enrolled-only map -> UNKNOWN
+        attendee_repo.bulk_get_all_sessions_for_persons.return_value = {}
+
+        result = strategy.resolve(
+            "Emma Smith",
+            requester_cm_id=67890,
+            session_cm_id=1000002,
+            year=2025,
+        )
+
+        assert result.is_resolved
+        assert result.confidence == 0.90  # UNKNOWN preserves base
+
+    def test_path_b_via_db_unknown_session_keeps_base(self, strategy, mock_repositories):
+        """Path B (via_db parent-surname): UNKNOWN session preserves 0.90 base."""
+        person_repo, attendee_repo = mock_repositories
+
+        person_repo.find_by_name.return_value = []
+        person_repo.name_cache = None
+
+        person = Person(
+            cm_id=12345,
+            first_name="Emma",
+            last_name="Johnson",
+            parent_names=json.dumps([{"first": "John", "last": "Smith", "relationship": "Father"}]),
+        )
+        person_repo.get_all_for_phonetic_matching.return_value = [person]
+
+        # Target absent from enrolled-only map -> UNKNOWN
+        attendee_repo.bulk_get_all_sessions_for_persons.return_value = {}
+
+        result = strategy.resolve(
+            "Emma Smith",
+            requester_cm_id=67890,
+            session_cm_id=1000002,
+            year=2025,
+        )
+
+        assert result.is_resolved
+        assert result.confidence == 0.90  # UNKNOWN preserves base
 
 
 class TestExactMatchPreferredName:

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
@@ -218,6 +218,39 @@ class TestExactMatchStrategy:
         # Lower confidence without year context
         assert result.confidence == 0.90
 
+    def test_path_c_known_different_via_session_cm_ids_only(self, strategy, mock_repositories):
+        """Path C (#1501): direct-match unique-path elif must classify via session_cm_ids.
+
+        Before fix: target with session_cm_ids=[X,Y] (neither matches) and no singular
+        session_cm_id falls through to else branch -> 'unknown' 0.90.
+        After fix: classifier returns DIFFERENT -> 'different' 0.85.
+        """
+        person_repo, _ = mock_repositories
+
+        person = Person(cm_id=12345, first_name="John", last_name="Smith")
+        person_repo.find_by_name.return_value = [person]
+
+        attendee_info = {
+            # Target: only session_cm_ids populated (no singular key), neither matches requester
+            12345: {"session_cm_ids": [1000099, 1000888]},
+            # Requester has singular session
+            67890: {"session_cm_id": 1000002},
+        }
+
+        result = strategy.resolve(
+            "John Smith",
+            requester_cm_id=67890,
+            session_cm_id=1000002,
+            year=2025,
+            attendee_info=attendee_info,
+        )
+
+        assert result.is_resolved
+        assert result.person.cm_id == 12345
+        # DIFFERENT -> 0.85 (was 'unknown' 0.90 before fix)
+        assert result.confidence == 0.85
+        assert result.metadata.get("session_match") == "different"
+
     def test_multi_match_disambiguation_uses_session_cm_ids(self, strategy):
         """Multi-match disambiguation should check session_cm_ids, not just session_cm_id."""
         target_a = Person(cm_id=2000001, first_name="Erez", last_name="Costello")
@@ -608,7 +641,7 @@ class TestResolveSessionHandling:
         target = Person(cm_id=1234567, first_name="Ivy", last_name="Smith")
         attendee_info = {
             1000001: {"session_cm_id": 1000010},
-            1234567: {"session_cm_id": 1000010},  # same session
+            1234567: {"session_cm_id": 1000010, "session_cm_ids": [1000010]},  # same session
         }
 
         result = strategy.resolve(
@@ -628,7 +661,7 @@ class TestResolveSessionHandling:
         target = Person(cm_id=1234567, first_name="Ivy", last_name="Smith")
         attendee_info = {
             1000001: {"session_cm_id": 1000010},
-            1234567: {"session_cm_id": 1000020},  # different session
+            1234567: {"session_cm_id": 1000020, "session_cm_ids": [1000020]},  # different session
         }
 
         result = strategy.resolve(

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
@@ -369,6 +369,49 @@ class TestExactMatchParentSurname:
         assert result.person.cm_id == 12345
         assert result.metadata.get("sub_method") == "parent_surname"
 
+    def test_path_a_name_cache_multi_enrollment_same_session(self, strategy, mock_repositories):
+        """Path A (#1501): name_cache parent-surname match where target is multi-enrolled.
+
+        Target enrolled in [X, requester_session]. The OLD bulk_get_sessions_for_persons
+        returned only the primary (X), causing a same-session match to be downgraded to
+        0.80 'different'. Fix: bulk_get_all_sessions_for_persons returns both, classifier
+        sees requester_session in list -> SAME -> 0.90.
+        """
+        person_repo, attendee_repo = mock_repositories
+
+        # Direct match fails (different surname)
+        person_repo.find_by_name.return_value = []
+
+        # Person 12345 has parent surname "Smith", actual surname "Johnson"
+        person = Person(
+            cm_id=12345,
+            first_name="Emma",
+            last_name="Johnson",
+            parent_names=json.dumps([{"first": "John", "last": "Smith", "relationship": "Father"}]),
+        )
+
+        # name_cache available (so we hit Path A, not Path B)
+        mock_cache = Mock()
+        mock_cache.find_by_parent_surname.return_value = [person]
+        person_repo.name_cache = mock_cache
+
+        # NEW bulk method returns multi-enrollment: target in sessions [1000099, 1000002]
+        # where 1000002 is requester's session
+        attendee_repo.bulk_get_all_sessions_for_persons.return_value = {12345: [1000099, 1000002]}
+
+        result = strategy.resolve(
+            "Emma Smith",
+            requester_cm_id=67890,
+            session_cm_id=1000002,
+            year=2025,
+        )
+
+        assert result.is_resolved
+        assert result.person.cm_id == 12345
+        # SAME via session_cm_ids -> 0.90 (was 0.80 before the fix)
+        assert result.confidence == 0.90
+        attendee_repo.bulk_get_all_sessions_for_persons.assert_called_once_with([12345], 2025)
+
 
 class TestExactMatchPreferredName:
     """Test preferred_name matching in ExactMatchStrategy."""

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
@@ -176,8 +176,8 @@ class TestExactMatchStrategy:
         person = Person(cm_id=12345, first_name="John", last_name="Smith")
         person_repo.find_by_name.return_value = [person]
 
-        # Mock person is in the provided session
-        attendee_repo.bulk_get_sessions_for_persons.return_value = {12345: 1000002}
+        # Mock person is in the provided session (Path E uses bulk_get_all_sessions_for_persons)
+        attendee_repo.bulk_get_all_sessions_for_persons.return_value = {12345: [1000002]}
 
         # Test with explicit session
         result = strategy.resolve("John Smith", requester_cm_id=67890, session_cm_id=1000002, year=2025)
@@ -279,6 +279,35 @@ class TestExactMatchStrategy:
         assert result.confidence == 0.95
         assert result.person.cm_id == 2000001
         assert result.metadata.get("session_match") == "exact"
+
+    def test_path_e_resolve_elif_year_multi_enrollment_same_session(self, strategy, mock_repositories):
+        """Path E (#1501 scope expansion): resolve() elif-year DB fallback for single direct match.
+
+        Same bug shape as Path A: singular bulk_get_sessions_for_persons collapses
+        multi-enrolled target to one session, mis-classifies SAME-via-secondary as DIFFERENT.
+        Fix: use bulk_get_all_sessions_for_persons + _classify_session.
+        """
+        person_repo, attendee_repo = mock_repositories
+
+        person = Person(cm_id=12345, first_name="John", last_name="Smith")
+        person_repo.find_by_name.return_value = [person]
+
+        # Multi-enrollment: target in [1000099, 1000002], requester wants 1000002
+        attendee_repo.bulk_get_all_sessions_for_persons.return_value = {12345: [1000099, 1000002]}
+
+        # No attendee_info -> forces elif year branch (Path E)
+        result = strategy.resolve(
+            "John Smith",
+            requester_cm_id=67890,
+            session_cm_id=1000002,
+            year=2025,
+            attendee_info=None,
+        )
+
+        assert result.is_resolved
+        assert result.confidence == 0.95
+        assert result.metadata.get("session_match") == "exact"
+        attendee_repo.bulk_get_all_sessions_for_persons.assert_called_once_with([12345], 2025)
 
 
 class TestExactMatchParentSurname:

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
@@ -36,6 +36,7 @@ class TestExactMatchStrategy:
         # Mock attendee repo to return None by default (no session found)
         attendee_repo.get_by_person_and_year.return_value = None
         attendee_repo.bulk_get_sessions_for_persons.return_value = {}
+        attendee_repo.bulk_get_all_sessions_for_persons.return_value = {}
         # Mock parent surname search to return empty by default
         # Set name_cache to None so it falls through to DB method
         person_repo.name_cache = None
@@ -262,6 +263,7 @@ class TestExactMatchParentSurname:
         person_repo, attendee_repo = mock_repositories
         attendee_repo.get_by_person_and_year.return_value = None
         attendee_repo.bulk_get_sessions_for_persons.return_value = {}
+        attendee_repo.bulk_get_all_sessions_for_persons.return_value = {}
         # Default to empty - tests will override as needed
         person_repo.find_by_name.return_value = []
         # Set name_cache to None so it falls through to DB method
@@ -381,6 +383,7 @@ class TestExactMatchPreferredName:
         person_repo, attendee_repo = mock_repositories
         attendee_repo.get_by_person_and_year.return_value = None
         attendee_repo.bulk_get_sessions_for_persons.return_value = {}
+        attendee_repo.bulk_get_all_sessions_for_persons.return_value = {}
         person_repo.name_cache = None
         person_repo.find_by_first_and_parent_surname.return_value = []
         person_repo.get_all_for_phonetic_matching.return_value = []
@@ -439,6 +442,7 @@ class TestResolveSessionHandling:
         mock_attendee_repo = Mock()
         mock_attendee_repo.get_by_person_and_year.return_value = None
         mock_attendee_repo.bulk_get_sessions_for_persons.return_value = {}
+        mock_attendee_repo.bulk_get_all_sessions_for_persons.return_value = {}
         mock_person_repo.name_cache = None
         mock_person_repo.find_by_first_and_parent_surname.return_value = []
         mock_person_repo.get_all_for_phonetic_matching.return_value = []
@@ -607,6 +611,7 @@ class TestParentSurnameSessionCmIds:
         attendee_repo = Mock()
         attendee_repo.get_by_person_and_year.return_value = None
         attendee_repo.bulk_get_sessions_for_persons.return_value = {}
+        attendee_repo.bulk_get_all_sessions_for_persons.return_value = {}
         person_repo.name_cache = None
         person_repo.find_by_name.return_value = []
         person_repo.find_by_first_and_parent_surname.return_value = []
@@ -683,6 +688,40 @@ class TestParentSurnameSessionCmIds:
         assert result.is_resolved
         assert result.person.cm_id == 2000001
         assert result.confidence == 0.80  # correctly penalised
+
+
+class TestClassifySessionHelper:
+    """Test the static _classify_session helper that all 4 multi-enrollment-aware paths use."""
+
+    def test_returns_unknown_when_sessions_none(self):
+        from bunking.sync.bunk_request_processor.resolution.interfaces import SessionMatch
+
+        assert ExactMatchStrategy._classify_session(None, 1000001) is SessionMatch.UNKNOWN
+
+    def test_returns_unknown_when_sessions_empty(self):
+        from bunking.sync.bunk_request_processor.resolution.interfaces import SessionMatch
+
+        assert ExactMatchStrategy._classify_session([], 1000001) is SessionMatch.UNKNOWN
+
+    def test_returns_same_when_requester_session_in_list(self):
+        from bunking.sync.bunk_request_processor.resolution.interfaces import SessionMatch
+
+        assert ExactMatchStrategy._classify_session([1000001, 1000002], 1000001) is SessionMatch.SAME
+        # Multi-enrollment: requester session is second in list
+        assert ExactMatchStrategy._classify_session([1000002, 1000001], 1000001) is SessionMatch.SAME
+
+    def test_returns_different_when_requester_session_not_in_list(self):
+        from bunking.sync.bunk_request_processor.resolution.interfaces import SessionMatch
+
+        assert ExactMatchStrategy._classify_session([1000002, 1000003], 1000001) is SessionMatch.DIFFERENT
+
+    def test_enum_values_match_metadata_strings(self):
+        """SessionMatch.value must match the strings stamped into metadata['session_match']."""
+        from bunking.sync.bunk_request_processor.resolution.interfaces import SessionMatch
+
+        assert SessionMatch.SAME.value == "exact"
+        assert SessionMatch.DIFFERENT.value == "different"
+        assert SessionMatch.UNKNOWN.value == "unknown"
 
 
 if __name__ == "__main__":

--- a/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
+++ b/tests/unit/sync/bunk_request_processor/resolution/strategies/test_exact_match.py
@@ -16,6 +16,7 @@ project_root = test_dir.parent.parent.parent.parent.parent
 sys.path.insert(0, str(project_root))
 
 from bunking.sync.bunk_request_processor.core.models import Person
+from bunking.sync.bunk_request_processor.resolution.interfaces import SessionMatch
 from bunking.sync.bunk_request_processor.resolution.strategies.exact_match import ExactMatchStrategy
 
 
@@ -694,31 +695,21 @@ class TestClassifySessionHelper:
     """Test the static _classify_session helper that all 4 multi-enrollment-aware paths use."""
 
     def test_returns_unknown_when_sessions_none(self):
-        from bunking.sync.bunk_request_processor.resolution.interfaces import SessionMatch
-
         assert ExactMatchStrategy._classify_session(None, 1000001) is SessionMatch.UNKNOWN
 
     def test_returns_unknown_when_sessions_empty(self):
-        from bunking.sync.bunk_request_processor.resolution.interfaces import SessionMatch
-
         assert ExactMatchStrategy._classify_session([], 1000001) is SessionMatch.UNKNOWN
 
     def test_returns_same_when_requester_session_in_list(self):
-        from bunking.sync.bunk_request_processor.resolution.interfaces import SessionMatch
-
         assert ExactMatchStrategy._classify_session([1000001, 1000002], 1000001) is SessionMatch.SAME
         # Multi-enrollment: requester session is second in list
         assert ExactMatchStrategy._classify_session([1000002, 1000001], 1000001) is SessionMatch.SAME
 
     def test_returns_different_when_requester_session_not_in_list(self):
-        from bunking.sync.bunk_request_processor.resolution.interfaces import SessionMatch
-
         assert ExactMatchStrategy._classify_session([1000002, 1000003], 1000001) is SessionMatch.DIFFERENT
 
     def test_enum_values_match_metadata_strings(self):
         """SessionMatch.value must match the strings stamped into metadata['session_match']."""
-        from bunking.sync.bunk_request_processor.resolution.interfaces import SessionMatch
-
         assert SessionMatch.SAME.value == "exact"
         assert SessionMatch.DIFFERENT.value == "different"
         assert SessionMatch.UNKNOWN.value == "unknown"


### PR DESCRIPTION
## Summary

Closes #1501. Fixes five multi-enrollment session classification bugs in `ExactMatchStrategy`:

- **Path A** (`name_cache` parent-surname fast path) — multi-enrolled target now correctly classified as same-session via `session_cm_ids`, no longer downgraded to 0.80.
- **Path B** (`_try_parent_surname_match_via_db`) — previously-unused `session_cm_id` and `year` parameters now drive session-aware confidence (0.90 same / 0.80 different / 0.90 unknown).
- **Path C** (direct-match unique `elif`) — collapsed into a single classify-then-map via tri-state `SessionMatch` enum. Now structurally consistent with its sibling `if` arm.
- **Path D** (`_disambiguate_with_session` fast path + DB fallback) — multi-enrolled match selection via new `bulk_get_all_sessions_for_persons`. `target_session` (int) renamed to `target_sessions` (list) in IMPOSSIBLE metadata.
- **Path E** (`resolve` elif-year DB fallback for unique direct match) — caught during code review; same bug shape as Path A. Migrated symmetrically.

Plus three cleanups bundled: `SessionMatch(Enum)` in `resolution/interfaces.py`; new `_classify_session` static helper; `_is_same_session_via_attendee_info` deleted (all callers migrated); Path A self-reassign collapsed; module-level `_DIRECT_MATCH_CONFIDENCE` constant (shared between Paths C and E).

New repo API `AttendeeRepository.bulk_get_all_sessions_for_persons(cm_ids, year) -> dict[int, list[int]]` sits alongside the existing singular variant. The 13 other call sites of `bulk_get_sessions_for_persons` (`fuzzy_match`, `phonetic_match`, `school_disambiguation`, `conflict_detector`, etc.) share the same latent bug shape but are explicitly out of scope here.

## Test plan
- [x] `test_classify_session_helper` — 5 helper unit tests (None/empty/SAME/DIFFERENT/enum values)
- [x] `test_path_a_name_cache_multi_enrollment_same_session` — Path A fix
- [x] `test_path_b_via_db_multi_enrollment_same_session` + `_different_session_downgrades` + `_no_session_context_keeps_base` — Path B fix
- [x] `test_path_c_known_different_via_session_cm_ids_only` — Path C fix per issue acceptance
- [x] `test_path_d_disambiguate_db_multi_enrollment` + `test_path_d_disambiguate_db_impossible_uses_target_sessions_list` — Path D fix + target_sessions rename
- [x] `test_path_e_resolve_elif_year_multi_enrollment_same_session` — Path E fix
- [x] `test_bulk_get_all_sessions_for_persons` + `_empty_input` — new repo method
- [x] Full `tests/unit/sync/bunk_request_processor/` suite passes (1929+ tests)
- [x] mypy strict + ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-enrollment support: resolution now considers all sessions a person is enrolled in when matching.
  * Tri-state session classification added (exact / different / unknown) and surfaced in resolution metadata as session_match.
  * Metadata shape updated: disambiguation now emits target_sessions (list) where applicable.

* **Bug Fixes**
  * Better handling of multi-enrolled users and non-bunking session types to avoid incorrect matches.

* **Tests**
  * Added unit tests covering multi-enrollment behavior, classification helper, DB fallback paths, and metadata changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->