### PR TITLE
feat(solver): enforce MP > STAFF hierarchy and equalize notes multipliers

### DIFF
--- a/bunking/solver/objective_evaluator.py
+++ b/bunking/solver/objective_evaluator.py
@@ -164,20 +164,23 @@ class ObjectiveEvaluator:
             and int(r["requester_id"]) != int(r["requestee_id"])
         )
 
-        # Source field multipliers (same as solver)
+        # Source field multipliers (same as solver). Fallback defaults mirror
+        # the seed values in pocketbase/pb_migrations/1500000011_config.js.
+        # Production never trips these because the keys are required by
+        # CONFIG_SCHEMA, but keeping them in sync avoids B-class drift.
         source_multipliers = {
             SourceField.BUNK_REQUEST_FORM: self.config.get_float(
-                "objective.source_multipliers.share_bunk_with", default=1.5
+                "objective.source_multipliers.share_bunk_with", default=1.75
             ),
             SourceField.STAFF_NOT_BUNK_WITH: self.config.get_float(
                 "objective.source_multipliers.do_not_share_with", default=1.5
             ),
-            SourceField.BUNKING_NOTES: self.config.get_float("objective.source_multipliers.bunking_notes", default=1.2),
+            SourceField.BUNKING_NOTES: self.config.get_float("objective.source_multipliers.bunking_notes", default=1.0),
             SourceField.INTERNAL_NOTES: self.config.get_float(
                 "objective.source_multipliers.internal_notes", default=1.0
             ),
             SourceField.SOCIALIZE_WITH: self.config.get_float(
-                "objective.source_multipliers.socialize_preference", default=0.8
+                "objective.source_multipliers.socialize_preference", default=0.6
             ),
         }
 

--- a/bunking/solver/score_evaluator.py
+++ b/bunking/solver/score_evaluator.py
@@ -133,15 +133,18 @@ def evaluate_scenario_score(
         and int(r["requester_id"]) != int(r["requestee_id"])
     )
 
-    # Source field multipliers
+    # Source field multipliers. Fallback defaults mirror the seed values in
+    # pocketbase/pb_migrations/1500000011_config.js. Production never trips
+    # these because the keys are required by CONFIG_SCHEMA, but keeping them
+    # in sync avoids B-class evaluator/seed drift.
     source_multipliers = {
-        SourceField.BUNK_REQUEST_FORM: config.get_float("objective.source_multipliers.share_bunk_with", default=1.5),
+        SourceField.BUNK_REQUEST_FORM: config.get_float("objective.source_multipliers.share_bunk_with", default=1.75),
         SourceField.STAFF_NOT_BUNK_WITH: config.get_float(
             "objective.source_multipliers.do_not_share_with", default=1.5
         ),
-        SourceField.BUNKING_NOTES: config.get_float("objective.source_multipliers.bunking_notes", default=1.2),
+        SourceField.BUNKING_NOTES: config.get_float("objective.source_multipliers.bunking_notes", default=1.0),
         SourceField.INTERNAL_NOTES: config.get_float("objective.source_multipliers.internal_notes", default=1.0),
-        SourceField.SOCIALIZE_WITH: config.get_float("objective.source_multipliers.socialize_preference", default=0.8),
+        SourceField.SOCIALIZE_WITH: config.get_float("objective.source_multipliers.socialize_preference", default=0.6),
     }
 
     # Track request satisfaction per person

--- a/docs/reference/objective-sensitivity.md
+++ b/docs/reference/objective-sensitivity.md
@@ -1,6 +1,8 @@
 # Solver Objective Sensitivity Analysis
 
-> **Snapshot:** 2026-05-18, post-v5.5.0 / post-#1523 mutual-request boost.
+> **Snapshot:** 2026-05-18, post-request-multiplier batch 1 (`share_bunk_with`
+> raised 1.5→1.75 to enforce MP-above-STAFF hierarchy; `internal_notes` raised
+> 0.8→1.0 to tie with `bunking_notes`).
 > Source-of-truth for the tables is `scripts/analyze_objective_sensitivity.py` —
 > regenerate with `uv run python scripts/analyze_objective_sensitivity.py`.
 > Test suite at `tests/unit/scripts/test_analyze_objective_sensitivity.py`
@@ -59,10 +61,10 @@ the `mutual` flag — see `score_evaluator.py` and the regression test
 
 | Source | Bucket | Slot 0 (first) | Slot 1 (second) | Slot 2+ (third+) | Mutual boost applies? |
 |---|---|---|---|---|---|
-| `bunk_with` | MP | 600 (1200 mutual) | 300 (600 mutual) | 60 (120 mutual) | Yes (×2.0) |
+| `bunk_with` | MP | 700 (1400 mutual) | 350 (700 mutual) | 70 (140 mutual) | Yes (×2.0) |
 | `not_bunk_with` | STAFF | 600 | 300 | 60 | No |
 | `bunking_notes` | STAFF | 400 | 200 | 40 | No |
-| `internal_notes` | STAFF | 320 | 160 | 32 | No |
+| `internal_notes` | STAFF | 400 | 200 | 40 | No |
 | `socialize_with` | IMP | 240 | 120 | 24 | No |
 
 `age_preference` MP requests are **not in the objective at all** — they are
@@ -100,11 +102,11 @@ of earnable would be needed to overcome a single instance of that penalty.
 
 | Archetype | Description | Total earnable | vs grade_ratio (5000) | vs grade_spread (3000) | vs level_progression (800) |
 |---|---|---|---|---|---|
-| **A. Loner mutual** | Singleton MP camper, 1 reciprocated bunk_with request. | 1200 | 4.17× | 2.50× | 0.67× |
-| **B. Loner one-way** | Singleton MP camper, 1 unreciprocated bunk_with request. | 600 | 8.33× | 5.00× | 1.33× |
-| **C. Cluster star** | Multi-MP camper, 3 reciprocated bunk_with requests forming a tight cluster. | 1920 | 2.60× | 1.56× | 0.42× |
-| **D. Mixed multi (THE RESIDUAL ARCHETYPE)** | Multi-MP camper, 1 reciprocated bunk_with at first-pick + 2 unreciprocated at slots 1-2. Matches the partial-tail pattern of the 21 S2 / 17 S4 unmet residuals. | 1560 | 3.21× | 1.92× | 0.51× |
-| **E. Popular target (own requests)** | A camper named by multiple other campers but with her own 2 unreciprocated MP requests elsewhere. Modeled here from her side; demand from other campers does not appear in her own objective contribution — see threshold analysis. | 900 | 5.56× | 3.33× | 0.89× |
+| **A. Loner mutual** | Singleton MP camper, 1 reciprocated bunk_with request. | 1400 | 3.57× | 2.14× | 0.57× |
+| **B. Loner one-way** | Singleton MP camper, 1 unreciprocated bunk_with request. | 700 | 7.14× | 4.29× | 1.14× |
+| **C. Cluster star** | Multi-MP camper, 3 reciprocated bunk_with requests forming a tight cluster. | 2240 | 2.23× | 1.34× | 0.36× |
+| **D. Mixed multi (THE RESIDUAL ARCHETYPE)** | Multi-MP camper, 1 reciprocated bunk_with at first-pick + 2 unreciprocated at slots 1-2. Matches the partial-tail pattern of the 21 S2 / 17 S4 unmet residuals. | 1820 | 2.75× | 1.65× | 0.44× |
+| **E. Popular target (own requests)** | A camper named by multiple other campers but with her own 2 unreciprocated MP requests elsewhere. Modeled here from her side; demand from other campers does not appear in her own objective contribution — see threshold analysis. | 1050 | 4.76× | 2.86× | 0.76× |
 
 ### Reading the ratios
 
@@ -118,18 +120,19 @@ of earnable would be needed to overcome a single instance of that penalty.
 
 Three useful patterns visible in the table:
 
-1. **Loner one-way (B) is structurally hard to honor** — at 600 earnable,
-   it loses to grade_ratio by 8×. The solver only honors archetype B when
+1. **Loner one-way (B) is structurally hard to honor** — at 700 earnable,
+   it loses to grade_ratio by ~7×. The solver only honors archetype B when
    the placement is "free" (no soft constraint triggered). The mutual boost
-   (archetype A) cuts that ratio in half (4.17×) but doesn't break parity.
-2. **Cluster star (C) dominates level_progression** at 0.42× — a 3-MP all-
-   mutual camper's full benefit (1920) is more than 2× a single level
+   (archetype A) cuts that ratio roughly in half (3.57×) but doesn't break
+   parity.
+2. **Cluster star (C) dominates level_progression** at 0.36× — a 3-MP all-
+   mutual camper's full benefit (2240) is nearly 3× a single level
    regression (800). The solver will accept the regression to keep the
    cluster intact.
 3. **Mixed multi (D) — the residual archetype — has a "tail tax".** The
-   first-pick mutual is worth 1200 by itself (4.17× ratio vs grade_ratio,
+   first-pick mutual is worth 1400 by itself (3.57× ratio vs grade_ratio,
    same as archetype A — meaning the mutual alone is what gets honored).
-   The slots 1-2 add only 360 marginal earnable, vastly insufficient to
+   The slots 1-2 add only 420 marginal earnable, vastly insufficient to
    override any 5000 grade_ratio violation triggered by honoring them.
    **This is the arithmetic explanation of the 21 S2 / 17 S4 residuals.**
 
@@ -145,7 +148,7 @@ Cross-reference data from solver run `qgc731ty5puoy3c` (S2, 180 s, current main)
 The solver is *paying* 480 K in grade_ratio penalties because the cluster
 rewards exceed them. So the 21 residuals are **not** "the solver refuses to
 break grade_ratio" — they are cases where honoring the slot-1/slot-2 tail
-would trigger an *additional* penalty whose 5000 cost exceeds the 60-300
+would trigger an *additional* penalty whose 5000 cost exceeds the 70-350
 marginal benefit. The slot-0 first-pick (or mutual) already paid for the
 cluster's grade_ratio violation; adding the tail member doesn't earn enough
 to justify the next ratio break.
@@ -155,9 +158,9 @@ labels anonymized; the arithmetic is what matters, not who the campers are):
 
 | Requester (sat'd MPs) | Unmet target | Pattern |
 |---|---|---|
-| `1000001` (got 2/3, both mutual) | `1000002 → bunk X`, one-way, slot 1 | 2-grade gap + presumably ratio-locked target bunk; 300 marginal benefit vs 5000 ratio cost — solver correctly drops |
-| `1000003` (got 3/4) | `1000004 → bunk Y`, one-way, slot 2 | Adjacent grade, presumably full bunk; 60 marginal benefit — even cheaper to drop |
-| `1000005` (got 5/6, all mutual stacked) | `1000006 → bunk Z`, one-way, slot ? | Same-grade neighbor bunk — only triggers ratio if target's bunk would tip; 60-300 vs 5000 — drops |
+| `1000001` (got 2/3, both mutual) | `1000002 → bunk X`, one-way, slot 1 | 2-grade gap + presumably ratio-locked target bunk; 350 marginal benefit vs 5000 ratio cost — solver correctly drops |
+| `1000003` (got 3/4) | `1000004 → bunk Y`, one-way, slot 2 | Adjacent grade, presumably full bunk; 70 marginal benefit — even cheaper to drop |
+| `1000005` (got 5/6, all mutual stacked) | `1000006 → bunk Z`, one-way, slot ? | Same-grade neighbor bunk — only triggers ratio if target's bunk would tip; 70-350 vs 5000 — drops |
 
 All 21 follow this shape. A "popular target boost" would shift archetype E's
 own benefit but not change the receiving side's arithmetic — see Phase 4

--- a/pocketbase/pb_migrations/1500000011_config.js
+++ b/pocketbase/pb_migrations/1500000011_config.js
@@ -783,7 +783,7 @@ migrate((app) => {
 
     // Objective configurations
     "objective.source_multipliers.share_bunk_with": {
-      value: 1.5,
+      value: 1.75,
       description: "How much weight to give parent bunk requests",
       min: 0.5,
       max: 3
@@ -801,7 +801,7 @@ migrate((app) => {
       max: 3
     },
     "objective.source_multipliers.internal_notes": {
-      value: 0.8,
+      value: 1.0,
       description: "How much weight to give internal staff notes",
       min: 0.5,
       max: 3

--- a/pocketbase/pb_migrations/1500000104_update_request_multipliers.js
+++ b/pocketbase/pb_migrations/1500000104_update_request_multipliers.js
@@ -1,0 +1,75 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+/**
+ * Update objective.source_multipliers values to propagate the PR #1533
+ * behavioral change to existing deployments.
+ *
+ * Companion to the seed-value edits in 1500000011_config.js (frozen for prod
+ * — PocketBase never re-runs an applied migration filename). Without this
+ * follow-up, prod's config records keep the old values forever; only fresh
+ * installs / dev-DB resets would pick up the new seeds.
+ *
+ * Changes:
+ *   - objective.source_multipliers.share_bunk_with: 1.5 → 1.75
+ *     (enforces MP > STAFF hierarchy — one-way MP bunk_with 700 > STAFF
+ *      not_bunk_with 600 at slot 0)
+ *   - objective.source_multipliers.internal_notes: 0.8 → 1.0
+ *     (ties internal_notes with bunking_notes at 400 slot-0; staff said
+ *      notes should be equally weighted)
+ *
+ * Raw SQL is used because ``config.value`` is a JSON field — the JSVM
+ * Record getters (getFloat / get) deserialize via PocketBase's JSON codec,
+ * which complicates direct numeric equality. SQLite stores the JSON-encoded
+ * scalar as REAL when the value is a plain number, so a SQL UPDATE with a
+ * numeric WHERE clause compares cleanly.
+ *
+ * Idempotent: rows are updated only when the value still equals the old
+ * default. Manual operator overrides (any other value, including the new
+ * target after a prior run) are preserved.
+ */
+migrate(
+  (app) => {
+    const updates = [
+      { config_key: "share_bunk_with", oldValue: 1.5, newValue: 1.75 },
+      { config_key: "internal_notes", oldValue: 0.8, newValue: 1.0 },
+    ];
+
+    for (const u of updates) {
+      app
+        .db()
+        .newQuery(
+          `UPDATE config
+           SET value = {:newVal}
+           WHERE category = 'objective'
+             AND subcategory = 'source_multipliers'
+             AND config_key = {:key}
+             AND value = {:oldVal}`,
+        )
+        .bind({ newVal: u.newValue, oldVal: u.oldValue, key: u.config_key })
+        .execute();
+    }
+  },
+  (app) => {
+    // Reverse: roll values back, again only if the current value matches
+    // the post-PR target (skip manual overrides).
+    const updates = [
+      { config_key: "share_bunk_with", postValue: 1.75, preValue: 1.5 },
+      { config_key: "internal_notes", postValue: 1.0, preValue: 0.8 },
+    ];
+
+    for (const u of updates) {
+      app
+        .db()
+        .newQuery(
+          `UPDATE config
+           SET value = {:preVal}
+           WHERE category = 'objective'
+             AND subcategory = 'source_multipliers'
+             AND config_key = {:key}
+             AND value = {:postVal}`,
+        )
+        .bind({ preVal: u.preValue, postVal: u.postValue, key: u.config_key })
+        .execute();
+    }
+  },
+);

--- a/scripts/analyze_objective_sensitivity.py
+++ b/scripts/analyze_objective_sensitivity.py
@@ -30,10 +30,10 @@ class ObjectiveConfig:
     slot_multipliers: tuple[int, ...] = (10, 5, 1)
     source_multipliers: dict[str, float] = field(
         default_factory=lambda: {
-            "bunk_with": 1.5,
+            "bunk_with": 1.75,
             "not_bunk_with": 1.5,
             "bunking_notes": 1.0,
-            "internal_notes": 0.8,
+            "internal_notes": 1.0,
             "socialize_with": 0.6,
         }
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,10 +175,10 @@ TEST_CONFIG = {
     "constraint.grade_spread.mode": "soft",
     "constraint.grade_spread.penalty": 3000,
     # Objective function weights
-    "objective.source_multipliers.share_bunk_with": 1.5,
+    "objective.source_multipliers.share_bunk_with": 1.75,
     "objective.source_multipliers.do_not_share_with": 1.5,
     "objective.source_multipliers.bunking_notes": 1.0,
-    "objective.source_multipliers.internal_notes": 0.8,
+    "objective.source_multipliers.internal_notes": 1.0,
     "objective.source_multipliers.socialize_preference": 0.6,
     "objective.enable_diminishing_returns": 1,
     "objective.first_request_multiplier": 10,

--- a/tests/unit/scripts/test_analyze_objective_sensitivity.py
+++ b/tests/unit/scripts/test_analyze_objective_sensitivity.py
@@ -30,35 +30,44 @@ spec.loader.exec_module(aos)
 
 
 def test_request_weight_mp_bunk_with_mutual_first_pick() -> None:
-    """MP bunk_with at slot 0 with mutual boost: 40 × 1.5 × 2.0 × 10 = 1200."""
+    """MP bunk_with at slot 0 with mutual boost: 40 × 1.75 × 2.0 × 10 = 1400."""
     cfg = aos.ObjectiveConfig()
-    assert aos.request_weight("bunk_with", slot=0, mutual=True, config=cfg) == 1200
+    assert aos.request_weight("bunk_with", slot=0, mutual=True, config=cfg) == 1400
 
 
 def test_request_weight_mp_bunk_with_one_way_first_pick() -> None:
-    """MP bunk_with at slot 0, one-directional: 40 × 1.5 × 1.0 × 10 = 600."""
+    """MP bunk_with at slot 0, one-directional: 40 × 1.75 × 1.0 × 10 = 700.
+
+    Strictly above ``not_bunk_with`` at the same slot (600) — enforces the
+    MP-above-STAFF priority hierarchy. Prior parity at 600 (both at 1.5x)
+    violated the stated priority stack.
+    """
     cfg = aos.ObjectiveConfig()
-    assert aos.request_weight("bunk_with", slot=0, mutual=False, config=cfg) == 600
+    assert aos.request_weight("bunk_with", slot=0, mutual=False, config=cfg) == 700
+    # Strict hierarchy check: one-way MP bunk_with > STAFF not_bunk_with at same slot.
+    assert aos.request_weight("bunk_with", slot=0, mutual=False, config=cfg) > aos.request_weight(
+        "not_bunk_with", slot=0, mutual=False, config=cfg
+    )
 
 
 def test_request_weight_mp_bunk_with_one_way_second() -> None:
-    """MP bunk_with at slot 1, one-directional: 40 × 1.5 × 1.0 × 5 = 300."""
+    """MP bunk_with at slot 1, one-directional: 40 × 1.75 × 1.0 × 5 = 350."""
     cfg = aos.ObjectiveConfig()
-    assert aos.request_weight("bunk_with", slot=1, mutual=False, config=cfg) == 300
+    assert aos.request_weight("bunk_with", slot=1, mutual=False, config=cfg) == 350
 
 
 def test_request_weight_mp_bunk_with_one_way_third_plus() -> None:
-    """MP bunk_with at slot 2+, one-directional: 40 × 1.5 × 1.0 × 1 = 60."""
+    """MP bunk_with at slot 2+, one-directional: 40 × 1.75 × 1.0 × 1 = 70."""
     cfg = aos.ObjectiveConfig()
-    assert aos.request_weight("bunk_with", slot=2, mutual=False, config=cfg) == 60
+    assert aos.request_weight("bunk_with", slot=2, mutual=False, config=cfg) == 70
     # Slot 5 still caps at the third+ multiplier (1):
-    assert aos.request_weight("bunk_with", slot=5, mutual=False, config=cfg) == 60
+    assert aos.request_weight("bunk_with", slot=5, mutual=False, config=cfg) == 70
 
 
 def test_request_weight_mp_bunk_with_mutual_second() -> None:
-    """MP bunk_with at slot 1 with mutual boost: 40 × 1.5 × 2.0 × 5 = 600."""
+    """MP bunk_with at slot 1 with mutual boost: 40 × 1.75 × 2.0 × 5 = 700."""
     cfg = aos.ObjectiveConfig()
-    assert aos.request_weight("bunk_with", slot=1, mutual=True, config=cfg) == 600
+    assert aos.request_weight("bunk_with", slot=1, mutual=True, config=cfg) == 700
 
 
 def test_request_weight_socialize_with_first_pick() -> None:
@@ -83,9 +92,18 @@ def test_request_weight_not_bunk_with_first_pick() -> None:
 
 
 def test_request_weight_internal_notes_first_pick() -> None:
-    """STAFF internal_notes at slot 0: 40 × 0.8 × 1.0 × 10 = 320."""
+    """STAFF internal_notes at slot 0: 40 × 1.0 × 1.0 × 10 = 400.
+
+    Equalized with ``bunking_notes`` (both 1.0x → both 400) — staff notes are a
+    single bucket, not two tiers. Prior 0.8x produced 320 with no business
+    rationale for the split.
+    """
     cfg = aos.ObjectiveConfig()
-    assert aos.request_weight("internal_notes", slot=0, mutual=False, config=cfg) == 320
+    assert aos.request_weight("internal_notes", slot=0, mutual=False, config=cfg) == 400
+    # Equalization check: internal_notes and bunking_notes are tied.
+    assert aos.request_weight("internal_notes", slot=0, mutual=False, config=cfg) == aos.request_weight(
+        "bunking_notes", slot=0, mutual=False, config=cfg
+    )
 
 
 def test_request_weight_unknown_source_raises() -> None:
@@ -158,44 +176,44 @@ def test_bonus_age_spread_preferred() -> None:
 
 
 def test_archetype_a_loner_mutual_total() -> None:
-    """Archetype A: 1 MP bunk_with, mutual, slot 0 = 1200 earnable."""
+    """Archetype A: 1 MP bunk_with, mutual, slot 0 = 1400 earnable."""
     cfg = aos.ObjectiveConfig()
     arch = aos.ARCHETYPES["A_loner_mutual"]
-    assert aos.archetype_total_weight(arch, cfg) == 1200
+    assert aos.archetype_total_weight(arch, cfg) == 1400
 
 
 def test_archetype_b_loner_oneway_total() -> None:
-    """Archetype B: 1 MP bunk_with, one-way, slot 0 = 600 earnable."""
+    """Archetype B: 1 MP bunk_with, one-way, slot 0 = 700 earnable."""
     cfg = aos.ObjectiveConfig()
     arch = aos.ARCHETYPES["B_loner_oneway"]
-    assert aos.archetype_total_weight(arch, cfg) == 600
+    assert aos.archetype_total_weight(arch, cfg) == 700
 
 
 def test_archetype_c_cluster_star_all_mutual_total() -> None:
-    """Archetype C: 3 MP bunk_with all mutual, slots 0/1/2 = 1200+600+120 = 1920 earnable."""
+    """Archetype C: 3 MP bunk_with all mutual, slots 0/1/2 = 1400+700+140 = 2240 earnable."""
     cfg = aos.ObjectiveConfig()
     arch = aos.ARCHETYPES["C_cluster_star"]
-    # slot 0 mutual: 40×1.5×2×10 = 1200
-    # slot 1 mutual: 40×1.5×2×5  = 600
-    # slot 2 mutual: 40×1.5×2×1  = 120
-    assert aos.archetype_total_weight(arch, cfg) == 1920
+    # slot 0 mutual: 40×1.75×2×10 = 1400
+    # slot 1 mutual: 40×1.75×2×5  = 700
+    # slot 2 mutual: 40×1.75×2×1  = 140
+    assert aos.archetype_total_weight(arch, cfg) == 2240
 
 
 def test_archetype_d_mixed_multi_total() -> None:
-    """Archetype D (residual): 3 MP, 1 mutual + 2 one-way = 1200+300+60 = 1560 earnable."""
+    """Archetype D (residual): 3 MP, 1 mutual + 2 one-way = 1400+350+70 = 1820 earnable."""
     cfg = aos.ObjectiveConfig()
     arch = aos.ARCHETYPES["D_mixed_multi"]
-    # slot 0 mutual:  40×1.5×2×10 = 1200
-    # slot 1 one-way: 40×1.5×1×5  = 300
-    # slot 2 one-way: 40×1.5×1×1  = 60
-    assert aos.archetype_total_weight(arch, cfg) == 1560
+    # slot 0 mutual:  40×1.75×2×10 = 1400
+    # slot 1 one-way: 40×1.75×1×5  = 350
+    # slot 2 one-way: 40×1.75×1×1  = 70
+    assert aos.archetype_total_weight(arch, cfg) == 1820
 
 
 def test_archetype_e_popular_target_total_own() -> None:
-    """Archetype E: popular-target camper's own 2 MP one-way requests = 600+300 = 900 earnable from her side."""
+    """Archetype E: popular-target camper's own 2 MP one-way requests = 700+350 = 1050 earnable from her side."""
     cfg = aos.ObjectiveConfig()
     arch = aos.ARCHETYPES["E_popular_target_own"]
-    assert aos.archetype_total_weight(arch, cfg) == 900
+    assert aos.archetype_total_weight(arch, cfg) == 1050
 
 
 # ---------------------------------------------------------------------------
@@ -204,27 +222,27 @@ def test_archetype_e_popular_target_total_own() -> None:
 
 
 def test_threshold_ratio_loner_oneway_vs_grade_ratio() -> None:
-    """Archetype B (600) vs grade_ratio (5000): 8.33× below — solver only honors if 'free'."""
+    """Archetype B (700) vs grade_ratio (5000): 7.14× below — solver only honors if 'free'."""
     cfg = aos.ObjectiveConfig()
     arch = aos.ARCHETYPES["B_loner_oneway"]
     ratio = aos.threshold_ratio(arch, "grade_ratio", cfg)
-    assert round(ratio, 2) == 8.33
+    assert round(ratio, 2) == 7.14
 
 
 def test_threshold_ratio_loner_mutual_vs_grade_ratio() -> None:
-    """Archetype A (1200) vs grade_ratio (5000): 4.17× below."""
+    """Archetype A (1400) vs grade_ratio (5000): 3.57× below."""
     cfg = aos.ObjectiveConfig()
     arch = aos.ARCHETYPES["A_loner_mutual"]
     ratio = aos.threshold_ratio(arch, "grade_ratio", cfg)
-    assert round(ratio, 2) == 4.17
+    assert round(ratio, 2) == 3.57
 
 
 def test_threshold_ratio_cluster_star_vs_grade_ratio() -> None:
-    """Archetype C (1920) vs grade_ratio (5000): 2.60× below — cluster placement can override a single ratio violation when stacked."""
+    """Archetype C (2240) vs grade_ratio (5000): 2.23× below — cluster placement can override a single ratio violation when stacked."""
     cfg = aos.ObjectiveConfig()
     arch = aos.ARCHETYPES["C_cluster_star"]
     ratio = aos.threshold_ratio(arch, "grade_ratio", cfg)
-    assert round(ratio, 2) == 2.60
+    assert round(ratio, 2) == 2.23
 
 
 # ---------------------------------------------------------------------------
@@ -233,12 +251,12 @@ def test_threshold_ratio_cluster_star_vs_grade_ratio() -> None:
 
 
 def test_render_request_weight_table_smoke() -> None:
-    """The weight table renders with all expected rows and contains the canonical 1200 figure."""
+    """The weight table renders with all expected rows and contains canonical figures."""
     cfg = aos.ObjectiveConfig()
     md = aos.render_request_weight_table(cfg)
     assert "bunk_with" in md
-    assert "1200" in md
-    assert "600" in md
+    assert "1400" in md  # MP bunk_with slot 0 mutual
+    assert "700" in md  # MP bunk_with slot 0 one-way
     assert "240" in md  # socialize_with
 
 
@@ -257,8 +275,8 @@ def test_render_archetype_table_smoke() -> None:
     cfg = aos.ObjectiveConfig()
     md = aos.render_archetype_table(cfg)
     assert "A_loner_mutual" in md or "Loner mutual" in md
-    assert "1200" in md
-    assert "1920" in md  # cluster_star
+    assert "1400" in md  # A loner_mutual total
+    assert "2240" in md  # C cluster_star total
 
 
 def test_render_archetype_table_header_uses_config() -> None:

--- a/tests/unit/solver/test_score_evaluator.py
+++ b/tests/unit/solver/test_score_evaluator.py
@@ -101,11 +101,11 @@ class TestEvaluateScenarioScore:
         }.get(key, default)
 
         config.get_float.side_effect = lambda key, default=1.0: {
-            "objective.source_multipliers.share_bunk_with": 1.5,
+            "objective.source_multipliers.share_bunk_with": 1.75,
             "objective.source_multipliers.do_not_share_with": 1.5,
-            "objective.source_multipliers.bunking_notes": 1.2,
+            "objective.source_multipliers.bunking_notes": 1.0,
             "objective.source_multipliers.internal_notes": 1.0,
-            "objective.source_multipliers.socialize_preference": 0.8,
+            "objective.source_multipliers.socialize_preference": 0.6,
         }.get(key, default)
 
         return config
@@ -269,17 +269,17 @@ class TestEvaluateScenarioScore:
             config=mock_config,
         )
 
-        # Verify the first-pick gets slot-0 boost: score = 60 * 10 = 600
-        # (base_weight=40 * source_mult=1.5 * FIRST_REQUEST_MULTIPLIER=10)
-        assert first_pick.request_satisfaction_score == 600
+        # Verify the first-pick gets slot-0 boost: score = 70 * 10 = 700
+        # (base_weight=40 * source_mult=1.75 * FIRST_REQUEST_MULTIPLIER=10)
+        assert first_pick.request_satisfaction_score == 700
 
     def test_first_requested_flag_determines_slot_0(self, mock_config):
         """Two-request control: flipping is_first_requested between two
         requests with different source-mults must change the total score.
 
         Slot-0 (10x) goes to whichever request is flagged. With
-        BUNK_REQUEST_FORM(1.5) flagged first: 60*10 + 40*5 = 800.
-        With INTERNAL_NOTES(1.0) flagged first: 40*10 + 60*5 = 700.
+        BUNK_REQUEST_FORM(1.75) flagged first: 70*10 + 40*5 = 900.
+        With INTERNAL_NOTES(1.0) flagged first: 40*10 + 70*5 = 750.
         """
         from bunking.solver.score_evaluator import evaluate_scenario_score
 
@@ -323,8 +323,8 @@ class TestEvaluateScenarioScore:
             requests=internal_notes_first, assignments=assignments, persons=persons, bunks=bunks, config=mock_config
         )
 
-        assert a.request_satisfaction_score == 800
-        assert b.request_satisfaction_score == 700
+        assert a.request_satisfaction_score == 900
+        assert b.request_satisfaction_score == 750
         assert a.request_satisfaction_score > b.request_satisfaction_score
 
     def test_grade_spread_penalty(self, mock_config):

--- a/tests/unit/solver/test_source_field_keys.py
+++ b/tests/unit/solver/test_source_field_keys.py
@@ -67,16 +67,16 @@ class TestScoreEvaluatorCanonicalKeys:
             "constraint.cabin_capacity.standard": 12,
         }.get(key, default)
         config.get_float.side_effect = lambda key, default=1.0: {
-            "objective.source_multipliers.share_bunk_with": 1.5,
+            "objective.source_multipliers.share_bunk_with": 1.75,
             "objective.source_multipliers.do_not_share_with": 1.5,
-            "objective.source_multipliers.bunking_notes": 1.2,
+            "objective.source_multipliers.bunking_notes": 1.0,
             "objective.source_multipliers.internal_notes": 1.0,
-            "objective.source_multipliers.socialize_preference": 0.8,
+            "objective.source_multipliers.socialize_preference": 0.6,
         }.get(key, default)
         return config
 
     def test_source_multiplier_applied_with_canonical_source_field(self, mock_config):
-        """A request with canonical source_field="Share Bunk With" must get the 1.5x multiplier."""
+        """A request with canonical source_field="Share Bunk With" must get the 1.75x multiplier."""
         from bunking.solver.score_evaluator import evaluate_scenario_score
 
         share_result = evaluate_scenario_score(
@@ -100,10 +100,10 @@ class TestScoreEvaluatorCanonicalKeys:
             config=mock_config,
         )
 
-        # base_weight(40) * source_multiplier(1.5) = 60 (weighted_score)
-        # slot-0 → FIRST_REQUEST_MULTIPLIER(10): 60 * 10 = 600
+        # base_weight(40) * source_multiplier(1.75) = 70 (weighted_score)
+        # slot-0 → FIRST_REQUEST_MULTIPLIER(10): 70 * 10 = 700
         # Priority was deleted — base_weight replaces priority * 10.
-        assert share_result.request_satisfaction_score == 600
+        assert share_result.request_satisfaction_score == 700
 
     def test_field_scores_keyed_by_canonical_values(self, mock_config):
         """field_scores breakdown must use canonical SourceField values as keys."""
@@ -176,7 +176,7 @@ class TestDirectSolverCanonicalKeys:
 
         config = MagicMock()
         config.get_float.side_effect = lambda key, default=1.0: {
-            "objective.source_multipliers.share_bunk_with": 1.5,
+            "objective.source_multipliers.share_bunk_with": 1.75,
         }.get(key, default)
         config.get_int.return_value = 0
 
@@ -195,4 +195,4 @@ class TestDirectSolverCanonicalKeys:
         )
 
         multiplier = solver._get_csv_field_multiplier(request)
-        assert multiplier == 1.5
+        assert multiplier == 1.75

--- a/tests/unit/test_score_evaluator.py
+++ b/tests/unit/test_score_evaluator.py
@@ -239,11 +239,11 @@ class TestEvaluateScenarioScore:
 
         def get_float_side_effect(key, default=0.0):
             values = {
-                "objective.source_multipliers.share_bunk_with": 1.5,
+                "objective.source_multipliers.share_bunk_with": 1.75,
                 "objective.source_multipliers.do_not_share_with": 1.5,
-                "objective.source_multipliers.bunking_notes": 1.2,
+                "objective.source_multipliers.bunking_notes": 1.0,
                 "objective.source_multipliers.internal_notes": 1.0,
-                "objective.source_multipliers.socialize_preference": 0.8,
+                "objective.source_multipliers.socialize_preference": 0.6,
             }
             return values.get(key, default)
 
@@ -439,11 +439,11 @@ class TestEvaluateScenarioScore:
 
         # Two satisfied requests for person 1; different source_field multipliers
         # so the slot-0 vs slot-1 difference shows up in the score.
-        # bunk_with → 1.5x, internal_notes → 1.0x.
+        # bunk_with → 1.75x, internal_notes → 1.0x.
         # If first-pick flag works, the bunk_with request lands in slot-0:
-        #   slot-0: 40*1.5*10 = 600, slot-1: 40*1.0*5 = 200 → total 800.
+        #   slot-0: 40*1.75*10 = 700, slot-1: 40*1.0*5 = 200 → total 900.
         # If we flip the flag (internal_notes is first-pick instead):
-        #   slot-0: 40*1.0*10 = 400, slot-1: 40*1.5*5 = 300 → total 700.
+        #   slot-0: 40*1.0*10 = 400, slot-1: 40*1.75*5 = 350 → total 750.
         bunk_with_first = [
             {
                 "requester_id": 1,
@@ -468,8 +468,8 @@ class TestEvaluateScenarioScore:
         result_a = evaluate_scenario_score(bunk_with_first, assignments, persons, bunks, config=mock_config)
         result_b = evaluate_scenario_score(internal_notes_first, assignments, persons, bunks, config=mock_config)
 
-        assert result_a.request_satisfaction_score == 800
-        assert result_b.request_satisfaction_score == 700
+        assert result_a.request_satisfaction_score == 900
+        assert result_b.request_satisfaction_score == 750
         assert result_a.request_satisfaction_score > result_b.request_satisfaction_score
 
     def test_source_field_multiplier(self, mock_config):
@@ -479,7 +479,7 @@ class TestEvaluateScenarioScore:
                 "requester_id": 1,
                 "requestee_id": 2,
                 "request_type": "bunk_with",
-                "source_field": SourceField.BUNK_REQUEST_FORM,  # 1.5x multiplier (share_bunk_with)
+                "source_field": SourceField.BUNK_REQUEST_FORM,  # 1.75x multiplier (share_bunk_with)
             }
         ]
         socialize_request = [
@@ -487,7 +487,7 @@ class TestEvaluateScenarioScore:
                 "requester_id": 1,
                 "requestee_id": 2,
                 "request_type": "bunk_with",
-                "source_field": SourceField.SOCIALIZE_WITH,  # 0.8x multiplier (socialize_preference)
+                "source_field": SourceField.SOCIALIZE_WITH,  # 0.6x multiplier (socialize_preference)
             }
         ]
         assignments = [
@@ -503,7 +503,7 @@ class TestEvaluateScenarioScore:
         share_result = evaluate_scenario_score(share_bunk_request, assignments, persons, bunks, config=mock_config)
         socialize_result = evaluate_scenario_score(socialize_request, assignments, persons, bunks, config=mock_config)
 
-        # BUNK_WITH (1.5x) should score higher than SOCIALIZE_WITH (0.8x)
+        # BUNK_WITH (1.75x) should score higher than SOCIALIZE_WITH (0.6x)
         assert share_result.request_satisfaction_score > socialize_result.request_satisfaction_score
 
     def test_field_scores_breakdown(self, mock_config):


### PR DESCRIPTION
## Summary

Batch 1 of the business-rules-vs-magnitudes review (2026-05-18) — two tactical tuning deltas plus an adjacent B-class drift fix.

**Delta 3 — `share_bunk_with` 1.5 → 1.75.** MP one-way `bunk_with` is now strictly above staff `not_bunk_with` (700 vs 600 at slot 0; mutual 1400 vs 600). Prior parity (both 1.5x) violated the stated priority stack's "MP > STAFF" rule. Staff side held at 1.5 to preserve safety-separation weight.

**Delta 4 — `internal_notes` 0.8 → 1.0.** Both note sources tie at 400 (slot 0). Staff stated "notes should be tied"; raised the lower value rather than averaging down. No business rationale for the prior 80% split.

**Adjacent fix.** B-class evaluator/seed drift in `score_evaluator.py` and `objective_evaluator.py` — fallback defaults now mirror the new seed values (`share_bunk_with` 1.75, `bunking_notes` 1.0, `socialize_preference` 0.6). Production never trips these because `CONFIG_SCHEMA` requires the keys; the fix prevents code-reading confusion only.

## Behavioral impact

| Source | Old slot 0 | New slot 0 |
|---|---|---|
| `bunk_with` one-way | 600 | **700** |
| `bunk_with` mutual | 1200 | **1400** |
| `not_bunk_with` | 600 | 600 |
| `bunking_notes` | 400 | 400 |
| `internal_notes` | 320 | **400** |
| `socialize_with` | 240 | 240 |

Archetype residual analysis from `docs/reference/objective-sensitivity.md` is unchanged in shape — the multipliers raise totals but the dominant penalties (`grade_ratio=5000`, `grade_spread=3000`) still dwarf single-request earnable, so the 21 S2 / 17 S4 residual pattern continues for the same arithmetic reason.

## Files changed

- `pocketbase/pb_migrations/1500000011_config.js` — seed values (the behavioral change)
- `scripts/analyze_objective_sensitivity.py` — `ObjectiveConfig` defaults
- `bunking/solver/score_evaluator.py` + `bunking/solver/objective_evaluator.py` — fallback defaults
- `tests/conftest.py` — mock loader values
- `tests/unit/scripts/test_analyze_objective_sensitivity.py` — assertions for new arithmetic
- `tests/unit/solver/test_score_evaluator.py`, `tests/unit/test_score_evaluator.py`, `tests/unit/solver/test_source_field_keys.py` — mock dicts + magnitude assertions
- `docs/reference/objective-sensitivity.md` — regenerated tables + updated worked example

## Test plan

- [x] `uv run pytest tests/unit/scripts/test_analyze_objective_sensitivity.py` — all 31 sensitivity tests pass with new multipliers
- [x] `uv run pytest tests/unit/` — 4709 passed, 14 skipped (pre-existing skips), 0 failed
- [x] `uv run pytest tests/integration/` — 50 passed, 6 PocketBase-required skips
- [x] `uv run ruff format .` + `uv run ruff check .` — clean
- [x] `uv run mypy bunking/solver/score_evaluator.py bunking/solver/objective_evaluator.py scripts/analyze_objective_sensitivity.py` — no issues
- [ ] CI green
- [ ] CodeRabbit pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Recalibrated request-satisfaction weights: increased emphasis on shared bunking and adjusted weights for bunking notes and social preference handling.
* **Documentation**
  * Updated sensitivity analysis and reference tables to reflect the new weighting assumptions.
* **Tests**
  * Adjusted unit and integration tests to match recalibrated scoring and rendered reference outputs.
* **Chores**
  * Added migration to update persisted default weight values safely.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->