### PR TITLE
refactor(sync,frontend): rename orphan_reconciler → stranded_assignment_cleanup (#1518)

### DIFF
--- a/bunking/satisfaction/aggregate.py
+++ b/bunking/satisfaction/aggregate.py
@@ -271,7 +271,7 @@ def session_satisfaction(
         person_data = get_person_from_expand(a)
         bunk_data = get_bunk_from_expand(a)
         # Distinguish "intentionally unassigned" from "dangling FK". The
-        # orphan_reconciler clears `bunk` to '' on draft rows whose
+        # stranded_assignment_cleanup clears `bunk` to '' on draft rows whose
         # (session, bunk) pair drops out of bunk_plans so the camper falls
         # back into the Unassigned pool — empty rel is the canonical signal
         # for that, not corruption. A non-empty rel that fails to expand

--- a/frontend/src/components/admin/syncTypes.test.ts
+++ b/frontend/src/components/admin/syncTypes.test.ts
@@ -4,23 +4,23 @@ import { getSyncTypesByPhase, YEAR_SYNC_TYPES } from './syncTypes'
 describe('syncTypes', () => {
   const currentYear = 2026
 
-  it('includes orphan_reconciler in transform phase', () => {
+  it('includes stranded_assignment_cleanup in transform phase', () => {
     const transformJobs = getSyncTypesByPhase('transform', currentYear, currentYear)
     const ids = transformJobs.map((t) => t.id)
-    expect(ids).toContain('orphan_reconciler')
+    expect(ids).toContain('stranded_assignment_cleanup')
   })
 
-  it('orphan_reconciler is last in the transform phase group', () => {
+  it('stranded_assignment_cleanup is last in the transform phase group', () => {
     const transformJobs = getSyncTypesByPhase('transform', currentYear, currentYear)
     const ids = transformJobs.map((t) => t.id)
     const enrollmentIdx = ids.indexOf('enrollment_snapshots')
-    const orphanIdx = ids.indexOf('orphan_reconciler')
-    expect(orphanIdx).toBeGreaterThan(enrollmentIdx)
-    expect(orphanIdx).toBe(ids.length - 1)
+    const cleanupIdx = ids.indexOf('stranded_assignment_cleanup')
+    expect(cleanupIdx).toBeGreaterThan(enrollmentIdx)
+    expect(cleanupIdx).toBe(ids.length - 1)
   })
 
-  it('orphan_reconciler has a description clarifying PB-only', () => {
-    const entry = YEAR_SYNC_TYPES.find((t) => t.id === 'orphan_reconciler')
+  it('stranded_assignment_cleanup has a description clarifying PB-only', () => {
+    const entry = YEAR_SYNC_TYPES.find((t) => t.id === 'stranded_assignment_cleanup')
     expect(entry).toBeDefined()
     expect('description' in entry!).toBe(true)
     if ('description' in entry!) {
@@ -28,8 +28,8 @@ describe('syncTypes', () => {
     }
   })
 
-  it('orphan_reconciler is not currentYearOnly', () => {
-    const entry = YEAR_SYNC_TYPES.find((t) => t.id === 'orphan_reconciler')
+  it('stranded_assignment_cleanup is not currentYearOnly', () => {
+    const entry = YEAR_SYNC_TYPES.find((t) => t.id === 'stranded_assignment_cleanup')
     expect(entry).toBeDefined()
     expect('currentYearOnly' in entry!).toBe(false)
   })

--- a/frontend/src/components/admin/syncTypes.ts
+++ b/frontend/src/components/admin/syncTypes.ts
@@ -279,8 +279,8 @@ export const YEAR_SYNC_TYPES = [
     phase: 'transform' as SyncPhase,
   },
   {
-    id: 'orphan_reconciler',
-    name: 'Orphan Reconciler',
+    id: 'stranded_assignment_cleanup',
+    name: 'Stranded Assignment Cleanup',
     description: 'PB-only · no CampMinder fetch',
     icon: UserX,
     color: 'text-orange-500',

--- a/frontend/src/hooks/useRunIndividualSync.test.ts
+++ b/frontend/src/hooks/useRunIndividualSync.test.ts
@@ -2,16 +2,16 @@ import { describe, it, expect } from 'vitest'
 import { SYNC_TYPE_NAMES } from './useRunIndividualSync'
 
 describe('SYNC_TYPE_NAMES', () => {
-  it('includes orphan_reconciler', () => {
-    expect(SYNC_TYPE_NAMES['orphan_reconciler']).toBeDefined()
-    expect(SYNC_TYPE_NAMES['orphan_reconciler']).toBe('Orphan Reconciler')
+  it('includes stranded_assignment_cleanup', () => {
+    expect(SYNC_TYPE_NAMES['stranded_assignment_cleanup']).toBeDefined()
+    expect(SYNC_TYPE_NAMES['stranded_assignment_cleanup']).toBe('Stranded Assignment Cleanup')
   })
 
-  it('maps orphan_reconciler to kebab-case endpoint segment', () => {
+  it('maps stranded_assignment_cleanup to kebab-case endpoint segment', () => {
     // The hook calls /api/custom/sync/${id.replace(/_/g, '-')}
     // Verify the id string produces the correct endpoint.
-    const id = 'orphan_reconciler'
+    const id = 'stranded_assignment_cleanup'
     const endpoint = id.replace(/_/g, '-')
-    expect(endpoint).toBe('orphan-reconciler')
+    expect(endpoint).toBe('stranded-assignment-cleanup')
   })
 })

--- a/frontend/src/hooks/useRunIndividualSync.ts
+++ b/frontend/src/hooks/useRunIndividualSync.ts
@@ -37,7 +37,7 @@ export const SYNC_TYPE_NAMES: Record<string, string> = {
   staff_vehicle_info: 'Staff Vehicle Info', // Extracted from SVI- custom fields
   normalize_geographic: 'Normalize Geographic', // Normalizes geographic columns to standard format
   enrollment_snapshots: 'Enrollment Snapshots', // Captures daily enrollment counts per session
-  orphan_reconciler: 'Orphan Reconciler', // Auto-unassigns scenario-draft assignments stranded by bunk_plan changes
+  stranded_assignment_cleanup: 'Stranded Assignment Cleanup', // Auto-unassigns scenario-draft assignments stranded by bunk_plan changes
   bunk_requests: 'Intake Requests',
   process_requests: 'Process Requests',
   // On-demand syncs (not part of daily sync)

--- a/frontend/src/hooks/useSyncStatusAPI.ts
+++ b/frontend/src/hooks/useSyncStatusAPI.ts
@@ -42,7 +42,7 @@ export interface SyncStatus {
     skipped: number
     errors: number
     already_processed?: number // For process_requests: records already processed
-    prod_audit_warnings?: number // For orphan_reconciler: stranded prod assignments (observe-only)
+    prod_audit_warnings?: number // For stranded_assignment_cleanup: stranded prod assignments (observe-only)
     duration?: number
     sub_stats?: Record<string, SubStats> // For combined syncs (e.g., persons includes households)
   }
@@ -82,7 +82,7 @@ export interface SyncStatusResponse {
   staff_vehicle_info: SyncStatus
   normalize_geographic: SyncStatus
   enrollment_snapshots: SyncStatus
-  orphan_reconciler: SyncStatus
+  stranded_assignment_cleanup: SyncStatus
   // Export phase
   multi_workbook_export: SyncStatus
   // On-demand custom value syncs (expensive, 1 API call per entity)

--- a/pocketbase/sync/api.go
+++ b/pocketbase/sync/api.go
@@ -475,12 +475,12 @@ func InitializeSyncService(app *pocketbase.PocketBase, e *core.ServeEvent) error
 			return handleIndividualSync(e, scheduler, "enrollment_snapshots")
 		}))
 
-	// Orphan reconciler sync
+	// Stranded assignment cleanup sync
 	// Auto-unassigns scenario-draft campers stranded by bunk-plan changes.
 	// PocketBase-only — no CampMinder API call.
-	e.Router.POST("/api/custom/sync/orphan-reconciler",
+	e.Router.POST("/api/custom/sync/stranded-assignment-cleanup",
 		requirePermission("bunking.manage", func(e *core.RequestEvent) error {
-			return handleIndividualSync(e, scheduler, "orphan_reconciler")
+			return handleIndividualSync(e, scheduler, "stranded_assignment_cleanup")
 		}))
 
 	return nil
@@ -896,21 +896,21 @@ func handleSyncStatus(e *core.RequestEvent, scheduler *Scheduler) error {
 		"bunks",
 		"bunk_plans",
 		"bunk_assignments",
-		"staff",                      // Year-scoped staff records (depends on divisions, bunks, persons)
-		"camper_history",             // Computed camper denorm with retention metrics
-		"financial_transactions",     // Year-scoped financial data (depends on sessions, persons, households)
-		"family_camp_derived",        // Computed from person_custom_values, household_custom_values
-		"staff_skills",               // Derived: staff skills extraction
-		"financial_aid_applications", // Derived: FA applications computation
-		"household_demographics",     // Derived: household demographics computation
-		"camper_dietary",             // Derived: camper dietary extraction
-		"camper_transportation",      // Derived: camper transportation extraction
-		"quest_registrations",        // Derived: Quest program registration extraction
-		"staff_applications",         // Derived: staff applications extraction
-		"staff_vehicle_info",         // Derived: staff vehicle info extraction
-		"normalize_geographic",       // Derived: normalize state/country names
-		"enrollment_snapshots",       // Derived: daily enrollment snapshot capture
-		"orphan_reconciler",          // Derived: auto-unassign stranded scenario-draft assignments
+		"staff",                       // Year-scoped staff records (depends on divisions, bunks, persons)
+		"camper_history",              // Computed camper denorm with retention metrics
+		"financial_transactions",      // Year-scoped financial data (depends on sessions, persons, households)
+		"family_camp_derived",         // Computed from person_custom_values, household_custom_values
+		"staff_skills",                // Derived: staff skills extraction
+		"financial_aid_applications",  // Derived: FA applications computation
+		"household_demographics",      // Derived: household demographics computation
+		"camper_dietary",              // Derived: camper dietary extraction
+		"camper_transportation",       // Derived: camper transportation extraction
+		"quest_registrations",         // Derived: Quest program registration extraction
+		"staff_applications",          // Derived: staff applications extraction
+		"staff_vehicle_info",          // Derived: staff vehicle info extraction
+		"normalize_geographic",        // Derived: normalize state/country names
+		"enrollment_snapshots",        // Derived: daily enrollment snapshot capture
+		"stranded_assignment_cleanup", // Derived: auto-unassign stranded scenario-draft assignments
 		"bunk_requests",
 		"process_requests",
 		"multi_workbook_export",

--- a/pocketbase/sync/api_test.go
+++ b/pocketbase/sync/api_test.go
@@ -1782,19 +1782,19 @@ func TestRunPhaseYearMustPropagateToServices(t *testing.T) {
 	t.Log("YearSetter interface is implemented by year-aware services")
 }
 
-// TestSyncStatusListIncludesOrphanReconciler verifies orphan_reconciler is registered
-// in syncJobMeta with a phase. handleSyncStatus's hardcoded syncTypes slice is a local
-// var that can't be read from tests; the placement in the diff is the primary safeguard.
-// This test catches one related regression: forgetting to register the job in
+// TestSyncStatusListIncludesStrandedAssignmentCleanup verifies stranded_assignment_cleanup
+// is registered in syncJobMeta with a phase. handleSyncStatus's hardcoded syncTypes slice
+// is a local var that can't be read from tests; the placement in the diff is the primary
+// safeguard. This test catches one related regression: forgetting to register the job in
 // syncJobMeta before adding it to the status list or routes.
-func TestSyncStatusListIncludesOrphanReconciler(t *testing.T) {
+func TestSyncStatusListIncludesStrandedAssignmentCleanup(t *testing.T) {
 	// Required jobs that must be registered in syncJobMeta. handleSyncStatus's
 	// local syncTypes slice can't be inspected here; placement in the diff is
 	// the human-readable guard for that path.
 	requiredInStatusList := []string{
 		"normalize_geographic",
 		"enrollment_snapshots",
-		"orphan_reconciler", // must be present — card shows "idle" without it
+		"stranded_assignment_cleanup", // must be present — card shows "idle" without it
 	}
 
 	// Cross-check against syncJobMeta: every job in the required list must also be

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -90,7 +90,7 @@ var syncJobMeta = []JobMeta{
 	{"staff_vehicle_info", PhaseTransform, "Extract staff vehicle info from custom values"},
 	{"normalize_geographic", PhaseTransform, "Normalize geographic data (cities, schools, congregations)"},
 	{"enrollment_snapshots", PhaseTransform, "Capture daily enrollment counts per session"},
-	{"orphan_reconciler", PhaseTransform, "Auto-unassign scenario drafts stranded by bunk-plan changes"},
+	{"stranded_assignment_cleanup", PhaseTransform, "Auto-unassign scenario drafts stranded by bunk-plan changes"},
 
 	// Process phase - CSV + AI
 	{"reconcile_request_lifecycle", PhaseProcess, "Mark moved-requester OBRs for reprocessing"},
@@ -169,7 +169,7 @@ func GetDefaultUnifiedSyncJobs(includeCustomValues bool) []string {
 		"financial_aid_applications", "household_demographics",
 		"camper_dietary", "camper_transportation", "quest_registrations",
 		"staff_applications", "staff_vehicle_info", "normalize_geographic",
-		"enrollment_snapshots", "orphan_reconciler")
+		"enrollment_snapshots", "stranded_assignment_cleanup")
 
 	return jobs
 }
@@ -451,7 +451,7 @@ func GetWeeklySyncJobs() []string {
 
 // GetRefreshBunkingJobs returns the services needed for a full bunking refresh.
 // Runs in order: bunks (fetch latest bunk list), bunk_plans (update plans),
-// bunk_assignments (update assignments), then orphan_reconciler — the bunk_plans
+// bunk_assignments (update assignments), then stranded_assignment_cleanup — the bunk_plans
 // rewrite is exactly what strands scenario drafts, so they must be swept in the
 // same run rather than left until the next daily sync.
 func GetRefreshBunkingJobs() []string {
@@ -459,7 +459,7 @@ func GetRefreshBunkingJobs() []string {
 		"bunks",
 		"bunk_plans",
 		"bunk_assignments",
-		"orphan_reconciler",
+		"stranded_assignment_cleanup",
 	}
 }
 
@@ -694,7 +694,7 @@ func (o *Orchestrator) checkGlobalTablesEmpty() bool {
 }
 
 // getDailySyncJobs returns the ordered list of jobs the daily sync runs,
-// respecting inter-job dependencies. orphan_reconciler is always appended last:
+// respecting inter-job dependencies. stranded_assignment_cleanup is always appended last:
 // it must run after bunk_plans is final so it can sweep scenario drafts left
 // stranded by bunk-plan reorganizations (#1416, #1417). Extracted from
 // RunDailySync so the ordering can be asserted in tests.
@@ -747,9 +747,10 @@ func getDailySyncJobs() []string {
 		orderedJobs = append(orderedJobs, "multi_workbook_export")
 	}
 
-	// Orphan reconciliation runs last — after bunk_plans is final, it sweeps
-	// scenario drafts left stranded by bunk-plan reorganizations (#1416, #1417).
-	orderedJobs = append(orderedJobs, "orphan_reconciler")
+	// Stranded assignment cleanup runs last — after bunk_plans is final, it
+	// sweeps scenario drafts left stranded by bunk-plan reorganizations
+	// (#1416, #1417).
+	orderedJobs = append(orderedJobs, "stranded_assignment_cleanup")
 
 	return orderedJobs
 }
@@ -1287,11 +1288,11 @@ func (o *Orchestrator) RunSyncWithOptions(ctx context.Context, opts Options) err
 		enrollmentSnapshotsSync.Year = opts.Year
 		o.RegisterService("enrollment_snapshots", enrollmentSnapshotsSync)
 
-		// Orphan reconciler: sweeps scenario drafts stranded by bunk-plan changes.
+		// Stranded assignment cleanup: sweeps scenario drafts stranded by bunk-plan changes.
 		// Year-scoped so a historical sync reconciles the correct year's drafts.
-		orphanReconcilerSync := NewOrphanReconcilerSync(o.app)
-		orphanReconcilerSync.Year = opts.Year
-		o.RegisterService("orphan_reconciler", orphanReconcilerSync)
+		strandedAssignmentCleanupSync := NewStrandedAssignmentCleanupSync(o.app)
+		strandedAssignmentCleanupSync.Year = opts.Year
+		o.RegisterService("stranded_assignment_cleanup", strandedAssignmentCleanupSync)
 
 		// Custom value services for historical sync support
 		// These use GetSeasonID() to determine the year, so they need year-specific client
@@ -1767,7 +1768,7 @@ func (o *Orchestrator) InitializeSyncServices() error {
 	o.RegisterService("bunk_plans", NewBunkPlansSync(o.app, client))
 	o.RegisterService("bunk_assignments", NewBunkAssignmentsSync(o.app, client))
 	o.RegisterService("reconcile_request_lifecycle", NewReconcileLifecycleSync(o.app))
-	o.RegisterService("orphan_reconciler", NewOrphanReconcilerSync(o.app))
+	o.RegisterService("stranded_assignment_cleanup", NewStrandedAssignmentCleanupSync(o.app))
 	o.RegisterService("bunk_requests", NewBunkRequestsSync(o.app, client))
 	// Register the request processor (no CampMinder client needed)
 	processor := NewRequestProcessor(o.app)

--- a/pocketbase/sync/orchestrator_test.go
+++ b/pocketbase/sync/orchestrator_test.go
@@ -777,11 +777,12 @@ func TestWeeklySyncIncludesDivisions(t *testing.T) {
 	}
 }
 
-// TestGetDailySyncJobsOrphanReconcilerOrdering asserts the daily sync runs
-// orphan_reconciler last and strictly after bunk_plans. The reconciler's gating
-// logic depends on bunk_plans being final before it sweeps stranded drafts, so
-// a regression that drops it or moves it earlier must fail this test.
-func TestGetDailySyncJobsOrphanReconcilerOrdering(t *testing.T) {
+// TestGetDailySyncJobsStrandedAssignmentCleanupOrdering asserts the daily sync
+// runs stranded_assignment_cleanup last and strictly after bunk_plans. The
+// cleanup's gating logic depends on bunk_plans being final before it sweeps
+// stranded drafts, so a regression that drops it or moves it earlier must fail
+// this test.
+func TestGetDailySyncJobsStrandedAssignmentCleanupOrdering(t *testing.T) {
 	jobs := getDailySyncJobs()
 
 	pos := make(map[string]int, len(jobs))
@@ -789,20 +790,20 @@ func TestGetDailySyncJobsOrphanReconcilerOrdering(t *testing.T) {
 		pos[j] = i
 	}
 
-	orphanPos, ok := pos["orphan_reconciler"]
+	cleanupPos, ok := pos["stranded_assignment_cleanup"]
 	if !ok {
-		t.Fatalf("orphan_reconciler missing from daily sync jobs: %v", jobs)
+		t.Fatalf("stranded_assignment_cleanup missing from daily sync jobs: %v", jobs)
 	}
-	if orphanPos != len(jobs)-1 {
-		t.Errorf("orphan_reconciler must run last — got position %d of %d: %v", orphanPos, len(jobs), jobs)
+	if cleanupPos != len(jobs)-1 {
+		t.Errorf("stranded_assignment_cleanup must run last — got position %d of %d: %v", cleanupPos, len(jobs), jobs)
 	}
 
 	bunkPlansPos, ok := pos["bunk_plans"]
 	if !ok {
 		t.Fatalf("bunk_plans missing from daily sync jobs: %v", jobs)
 	}
-	if orphanPos <= bunkPlansPos {
-		t.Errorf("orphan_reconciler (pos %d) must run after bunk_plans (pos %d)", orphanPos, bunkPlansPos)
+	if cleanupPos <= bunkPlansPos {
+		t.Errorf("stranded_assignment_cleanup (pos %d) must run after bunk_plans (pos %d)", cleanupPos, bunkPlansPos)
 	}
 }
 
@@ -1851,25 +1852,26 @@ func TestJobMeta_TransformPhaseJobs(t *testing.T) {
 	}
 }
 
-// TestJobMeta_IncludesOrphanReconciler asserts the orphan reconciler is
+// TestJobMeta_IncludesStrandedAssignmentCleanup asserts the cleanup is
 // registered in syncJobMeta so the phase API (?phase=transform) and the sync
 // dashboard surface it like every other sync job. Its predecessor
-// reconcile_request_lifecycle is registered there; orphan_reconciler must be too.
-func TestJobMeta_IncludesOrphanReconciler(t *testing.T) {
-	if got := GetPhaseForJob("orphan_reconciler"); got != PhaseTransform {
-		t.Errorf("GetPhaseForJob(\"orphan_reconciler\") = %q, want %q", got, PhaseTransform)
+// reconcile_request_lifecycle is registered there; stranded_assignment_cleanup
+// must be too.
+func TestJobMeta_IncludesStrandedAssignmentCleanup(t *testing.T) {
+	if got := GetPhaseForJob("stranded_assignment_cleanup"); got != PhaseTransform {
+		t.Errorf("GetPhaseForJob(\"stranded_assignment_cleanup\") = %q, want %q", got, PhaseTransform)
 	}
 
 	jobs := GetJobsForPhase(PhaseTransform)
 	found := false
 	for _, j := range jobs {
-		if j == "orphan_reconciler" {
+		if j == "stranded_assignment_cleanup" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("orphan_reconciler missing from GetJobsForPhase(PhaseTransform): %v", jobs)
+		t.Errorf("stranded_assignment_cleanup missing from GetJobsForPhase(PhaseTransform): %v", jobs)
 	}
 }
 
@@ -2392,7 +2394,7 @@ func TestRunSyncWithOptionsPhaseOrdering(t *testing.T) {
 			"financial_aid_applications", "household_demographics",
 			"camper_dietary", "camper_transportation", "quest_registrations",
 			"staff_applications", "staff_vehicle_info", "normalize_geographic",
-			"enrollment_snapshots", "orphan_reconciler",
+			"enrollment_snapshots", "stranded_assignment_cleanup",
 		}
 
 		if len(jobs) != len(expectedOrder) {

--- a/pocketbase/sync/scheduler_test.go
+++ b/pocketbase/sync/scheduler_test.go
@@ -204,9 +204,10 @@ func TestCustomValuesSyncRunsSequentially(t *testing.T) {
 func TestGetRefreshBunkingJobs(t *testing.T) {
 	jobs := GetRefreshBunkingJobs()
 
-	// orphan_reconciler runs last: refresh-bunking rewrites bunk_plans, which is
-	// exactly what strands scenario drafts — they must be swept in the same run.
-	expected := []string{"bunks", "bunk_plans", "bunk_assignments", "orphan_reconciler"}
+	// stranded_assignment_cleanup runs last: refresh-bunking rewrites bunk_plans,
+	// which is exactly what strands scenario drafts — they must be swept in the
+	// same run.
+	expected := []string{"bunks", "bunk_plans", "bunk_assignments", "stranded_assignment_cleanup"}
 	if len(jobs) != len(expected) {
 		t.Fatalf("expected %d jobs, got %d: %v", len(expected), len(jobs), jobs)
 	}
@@ -219,8 +220,8 @@ func TestGetRefreshBunkingJobs(t *testing.T) {
 }
 
 // TestRefreshBunkingRunsAllServices verifies that refresh-bunking triggers
-// bunks, bunk_plans, bunk_assignments, and orphan_reconciler in sequence
-// (not just bunk_assignments)
+// bunks, bunk_plans, bunk_assignments, and stranded_assignment_cleanup in
+// sequence (not just bunk_assignments)
 func TestRefreshBunkingRunsAllServices(t *testing.T) {
 	s := NewScheduler(nil)
 
@@ -256,7 +257,7 @@ func TestRefreshBunkingRunsAllServices(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	expected := []string{"bunks", "bunk_plans", "bunk_assignments", "orphan_reconciler"}
+	expected := []string{"bunks", "bunk_plans", "bunk_assignments", "stranded_assignment_cleanup"}
 	if len(callOrder) != len(expected) {
 		t.Fatalf("expected %d services called, got %d: %v", len(expected), len(callOrder), callOrder)
 	}

--- a/pocketbase/sync/stranded_assignment_cleanup.go
+++ b/pocketbase/sync/stranded_assignment_cleanup.go
@@ -9,11 +9,11 @@ import (
 	"github.com/pocketbase/pocketbase/core"
 )
 
-const serviceNameOrphanReconciler = "orphan_reconciler"
+const serviceNameStrandedAssignmentCleanup = "stranded_assignment_cleanup"
 
 // msgStrandedProd is the Warn message for the observe-only production audit.
 // Hoisted to a const to keep the call site within the line-length limit.
-const msgStrandedProd = "orphan_reconciler: stranded production assignments detected — " +
+const msgStrandedProd = "stranded_assignment_cleanup: stranded production assignments detected — " +
 	"not deleted (bunk_assignments sync owns prod cleanup)"
 
 // orphanCandidate is the minimal projection of an assignment row needed for
@@ -56,49 +56,49 @@ func findStrandedAssignments(
 	return stranded
 }
 
-// OrphanReconcilerSync silently auto-unassigns scenario draft assignments whose
+// StrandedAssignmentCleanupSync silently auto-unassigns scenario draft assignments whose
 // bunk no longer has a bunk_plan for their session — left stranded when staff
 // reorganize a session's bunk plan — and audits production for the same.
 // Runs as the final step of the sync orchestrator. PocketBase-only — no
 // CampMinder client.
-type OrphanReconcilerSync struct {
+type StrandedAssignmentCleanupSync struct {
 	App   core.App
 	Year  int
 	Debug bool
 	Stats Stats
 }
 
-// NewOrphanReconcilerSync constructs the service.
-func NewOrphanReconcilerSync(app core.App) *OrphanReconcilerSync {
-	return &OrphanReconcilerSync{App: app}
+// NewStrandedAssignmentCleanupSync constructs the service.
+func NewStrandedAssignmentCleanupSync(app core.App) *StrandedAssignmentCleanupSync {
+	return &StrandedAssignmentCleanupSync{App: app}
 }
 
 // Name returns the orchestrator-facing service name.
-func (s *OrphanReconcilerSync) Name() string { return serviceNameOrphanReconciler }
+func (s *StrandedAssignmentCleanupSync) Name() string { return serviceNameStrandedAssignmentCleanup }
 
 // GetStats returns the current stats snapshot.
-func (s *OrphanReconcilerSync) GetStats() Stats { return s.Stats }
+func (s *StrandedAssignmentCleanupSync) GetStats() Stats { return s.Stats }
 
 // SetDebug toggles verbose logging (orchestrator hook).
-func (s *OrphanReconcilerSync) SetDebug(debug bool) { s.Debug = debug }
+func (s *StrandedAssignmentCleanupSync) SetDebug(debug bool) { s.Debug = debug }
 
 // SetYear sets the year for this run (orchestrator hook).
-func (s *OrphanReconcilerSync) SetYear(year int) { s.Year = year }
+func (s *StrandedAssignmentCleanupSync) SetYear(year int) { s.Year = year }
 
 // WasSuccessful indicates whether the last run encountered no errors.
-func (s *OrphanReconcilerSync) WasSuccessful() bool { return s.Stats.Errors == 0 }
+func (s *StrandedAssignmentCleanupSync) WasSuccessful() bool { return s.Stats.Errors == 0 }
 
 // Sync runs the reconciliation against the configured year. When Year is 0
 // (the daily-sync registration path), falls back to CAMPMINDER_SEASON_ID via
 // ParseSeasonYear, matching every other yearless service in this package.
-func (s *OrphanReconcilerSync) Sync(_ context.Context) error {
+func (s *StrandedAssignmentCleanupSync) Sync(_ context.Context) error {
 	year := s.Year
 	if year == 0 {
 		var err error
 		year, err = ParseSeasonYear()
 		if err != nil {
 			s.Stats.Errors++
-			return fmt.Errorf("orphan_reconciler: year resolution failed: %w", err)
+			return fmt.Errorf("stranded_assignment_cleanup: year resolution failed: %w", err)
 		}
 	}
 	return reconcileOrphanedAssignments(s.App, year, &s.Stats)
@@ -121,11 +121,11 @@ func reconcileOrphanedAssignments(app core.App, year int, stats *Stats) error {
 	plans, err := app.FindRecordsByFilter("bunk_plans", yearFilter, "", 0, 0)
 	if err != nil {
 		stats.Errors++
-		return fmt.Errorf("orphan_reconciler: query bunk_plans: %w", err)
+		return fmt.Errorf("stranded_assignment_cleanup: query bunk_plans: %w", err)
 	}
 	// GATE.
 	if len(plans) == 0 {
-		slog.Warn("orphan_reconciler: skipping — no bunk_plans for year (sync may have failed)", "year", year)
+		slog.Warn("stranded_assignment_cleanup: skipping — no bunk_plans for year (sync may have failed)", "year", year)
 		return nil
 	}
 	validPairs := make(map[string]bool, len(plans))
@@ -144,7 +144,7 @@ func reconcileOrphanedAssignments(app core.App, year int, stats *Stats) error {
 	)
 	if err != nil {
 		stats.Errors++
-		return fmt.Errorf("orphan_reconciler: query bunk_assignments_draft: %w", err)
+		return fmt.Errorf("stranded_assignment_cleanup: query bunk_assignments_draft: %w", err)
 	}
 	draftByID := make(map[string]*core.Record, len(drafts))
 	draftCandidates := make([]orphanCandidate, 0, len(drafts))
@@ -170,7 +170,7 @@ func reconcileOrphanedAssignments(app core.App, year int, stats *Stats) error {
 		rec.Set("bunk_plan", "")
 		if saveErr := app.Save(rec); saveErr != nil {
 			stats.Errors++
-			slog.Error("orphan_reconciler: save draft", "id", c.RecordID, "error", saveErr)
+			slog.Error("stranded_assignment_cleanup: save draft", "id", c.RecordID, "error", saveErr)
 			continue
 		}
 		writes++
@@ -188,7 +188,7 @@ func reconcileOrphanedAssignments(app core.App, year int, stats *Stats) error {
 		// log + flag it (WasSuccessful() will report false) but do NOT return —
 		// a prod-query hiccup must not abort the run or roll back the sweep.
 		stats.Errors++
-		slog.Error("orphan_reconciler: query bunk_assignments", "error", err)
+		slog.Error("stranded_assignment_cleanup: query bunk_assignments", "error", err)
 	} else {
 		prodCandidates := make([]orphanCandidate, 0, len(prod))
 		for _, p := range prod {
@@ -212,11 +212,11 @@ func reconcileOrphanedAssignments(app core.App, year int, stats *Stats) error {
 	// WAL checkpoint after writes.
 	if writes > 0 {
 		if _, err := app.DB().NewQuery("PRAGMA wal_checkpoint(FULL)").Execute(); err != nil {
-			slog.Warn("orphan_reconciler: WAL checkpoint failed", "error", err)
+			slog.Warn("stranded_assignment_cleanup: WAL checkpoint failed", "error", err)
 		}
 	}
 
-	slog.Info("orphan_reconciler complete",
+	slog.Info("stranded_assignment_cleanup complete",
 		"year", year,
 		"stranded_drafts", len(strandedDrafts),
 		"drafts_swept", stats.Updated,

--- a/pocketbase/sync/stranded_assignment_cleanup.go
+++ b/pocketbase/sync/stranded_assignment_cleanup.go
@@ -16,18 +16,18 @@ const serviceNameStrandedAssignmentCleanup = "stranded_assignment_cleanup"
 const msgStrandedProd = "stranded_assignment_cleanup: stranded production assignments detected — " +
 	"not deleted (bunk_assignments sync owns prod cleanup)"
 
-// orphanCandidate is the minimal projection of an assignment row needed for
+// strandedCandidate is the minimal projection of an assignment row needed for
 // stranded-detection — decoupled from *core.Record so the detection logic is
 // unit-testable without a database.
-type orphanCandidate struct {
+type strandedCandidate struct {
 	RecordID  string
 	SessionID string
 	BunkID    string
 }
 
-// orphanPairKey builds the composite key used to test whether a (session, bunk)
+// strandedPairKey builds the composite key used to test whether a (session, bunk)
 // pair has a surviving bunk_plan. Both args are PocketBase record IDs.
-func orphanPairKey(sessionID, bunkID string) string {
+func strandedPairKey(sessionID, bunkID string) string {
 	return sessionID + ":" + bunkID
 }
 
@@ -39,9 +39,9 @@ func orphanPairKey(sessionID, bunkID string) string {
 // sweeping its drafts would null every valid assignment for the session.
 func findStrandedAssignments(
 	validPairs, plannedSessions map[string]bool,
-	candidates []orphanCandidate,
-) []orphanCandidate {
-	stranded := []orphanCandidate{}
+	candidates []strandedCandidate,
+) []strandedCandidate {
+	stranded := []strandedCandidate{}
 	for _, c := range candidates {
 		if c.BunkID == "" {
 			continue
@@ -49,7 +49,7 @@ func findStrandedAssignments(
 		if !plannedSessions[c.SessionID] {
 			continue
 		}
-		if !validPairs[orphanPairKey(c.SessionID, c.BunkID)] {
+		if !validPairs[strandedPairKey(c.SessionID, c.BunkID)] {
 			stranded = append(stranded, c)
 		}
 	}
@@ -101,10 +101,10 @@ func (s *StrandedAssignmentCleanupSync) Sync(_ context.Context) error {
 			return fmt.Errorf("stranded_assignment_cleanup: year resolution failed: %w", err)
 		}
 	}
-	return reconcileOrphanedAssignments(s.App, year, &s.Stats)
+	return reconcileStrandedAssignments(s.App, year, &s.Stats)
 }
 
-// reconcileOrphanedAssignments is the integration logic:
+// reconcileStrandedAssignments is the integration logic:
 //  1. Build the valid (session, bunk) set, plus the set of sessions that have
 //     at least one bunk_plan, from bunk_plans for the year.
 //  2. GATE: if there are zero bunk_plans for the year, the plan set is
@@ -115,7 +115,7 @@ func (s *StrandedAssignmentCleanupSync) Sync(_ context.Context) error {
 //     the camper falls back into the Unassigned pool.
 //  4. Audit bunk_assignments (production): log stranded rows — but do NOT
 //     delete. The bunk_assignments sync's own deleteOrphans() owns prod.
-func reconcileOrphanedAssignments(app core.App, year int, stats *Stats) error {
+func reconcileStrandedAssignments(app core.App, year int, stats *Stats) error {
 	yearFilter := fmt.Sprintf("year = %d", year)
 
 	plans, err := app.FindRecordsByFilter("bunk_plans", yearFilter, "", 0, 0)
@@ -132,7 +132,7 @@ func reconcileOrphanedAssignments(app core.App, year int, stats *Stats) error {
 	plannedSessions := make(map[string]bool)
 	for _, p := range plans {
 		sessionID := p.GetString("session")
-		validPairs[orphanPairKey(sessionID, p.GetString("bunk"))] = true
+		validPairs[strandedPairKey(sessionID, p.GetString("bunk"))] = true
 		plannedSessions[sessionID] = true
 	}
 
@@ -147,7 +147,7 @@ func reconcileOrphanedAssignments(app core.App, year int, stats *Stats) error {
 		return fmt.Errorf("stranded_assignment_cleanup: query bunk_assignments_draft: %w", err)
 	}
 	draftByID := make(map[string]*core.Record, len(drafts))
-	draftCandidates := make([]orphanCandidate, 0, len(drafts))
+	draftCandidates := make([]strandedCandidate, 0, len(drafts))
 	// Validity is derived from the (session, bunk) pair, NOT the draft's own
 	// bunk_plan relation: that relation is non-authoritative and may dangle
 	// (point at a since-deleted plan) even when the bunk is still planned. A
@@ -155,7 +155,7 @@ func reconcileOrphanedAssignments(app core.App, year int, stats *Stats) error {
 	// bunk_plan and all.
 	for _, d := range drafts {
 		draftByID[d.Id] = d
-		draftCandidates = append(draftCandidates, orphanCandidate{
+		draftCandidates = append(draftCandidates, strandedCandidate{
 			RecordID:  d.Id,
 			SessionID: d.GetString("session"),
 			BunkID:    d.GetString("bunk"),
@@ -190,9 +190,9 @@ func reconcileOrphanedAssignments(app core.App, year int, stats *Stats) error {
 		stats.Errors++
 		slog.Error("stranded_assignment_cleanup: query bunk_assignments", "error", err)
 	} else {
-		prodCandidates := make([]orphanCandidate, 0, len(prod))
+		prodCandidates := make([]strandedCandidate, 0, len(prod))
 		for _, p := range prod {
-			prodCandidates = append(prodCandidates, orphanCandidate{
+			prodCandidates = append(prodCandidates, strandedCandidate{
 				RecordID:  p.Id,
 				SessionID: p.GetString("session"),
 				BunkID:    p.GetString("bunk"),

--- a/pocketbase/sync/stranded_assignment_cleanup_test.go
+++ b/pocketbase/sync/stranded_assignment_cleanup_test.go
@@ -10,12 +10,12 @@ import (
 
 func TestFindStrandedAssignments(t *testing.T) {
 	validPairs := map[string]bool{
-		orphanPairKey("sess1", "bunkA"): true,
-		orphanPairKey("sess1", "bunkB"): true,
+		strandedPairKey("sess1", "bunkA"): true,
+		strandedPairKey("sess1", "bunkB"): true,
 	}
 	// Only sess1 has bunk_plans; sess2 has none (its plans failed to sync).
 	plannedSessions := map[string]bool{"sess1": true}
-	candidates := []orphanCandidate{
+	candidates := []strandedCandidate{
 		{RecordID: "r1", SessionID: "sess1", BunkID: "bunkA"}, // valid pair - kept
 		{RecordID: "r2", SessionID: "sess1", BunkID: "bunkZ"}, // stranded - bunk not planned
 		{RecordID: "r3", SessionID: "sess1", BunkID: ""},      // no bunk - skipped
@@ -32,8 +32,8 @@ func TestFindStrandedAssignments(t *testing.T) {
 	}
 }
 
-// setupOrphanCollections builds the minimal schema the reconciler touches.
-func setupOrphanCollections(t *testing.T, app core.App) {
+// setupStrandedCollections builds the minimal schema the reconciler touches.
+func setupStrandedCollections(t *testing.T, app core.App) {
 	t.Helper()
 
 	sessions := core.NewBaseCollection("camp_sessions")
@@ -116,7 +116,7 @@ func TestStrandedAssignmentCleanup_SweepsStrandedDraft(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer app.Cleanup()
-	setupOrphanCollections(t, app)
+	setupStrandedCollections(t, app)
 
 	sess := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 100, "year": 2026})
 	keptBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 1, "name": "B-1", "year": 2026})
@@ -155,7 +155,7 @@ func TestStrandedAssignmentCleanup_GateSkipsWhenNoBunkPlans(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer app.Cleanup()
-	setupOrphanCollections(t, app)
+	setupStrandedCollections(t, app)
 
 	sess := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 100, "year": 2026})
 	bunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 1, "name": "B-1", "year": 2026})
@@ -189,7 +189,7 @@ func TestStrandedAssignmentCleanup_GateSkipsPerSession(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer app.Cleanup()
-	setupOrphanCollections(t, app)
+	setupStrandedCollections(t, app)
 
 	// Session A has a bunk_plan; session B has none (its plans failed to sync).
 	// The global gate passes because plans exist overall — only the per-session
@@ -230,7 +230,7 @@ func TestStrandedAssignmentCleanup_LeavesValidDraftUntouched(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer app.Cleanup()
-	setupOrphanCollections(t, app)
+	setupStrandedCollections(t, app)
 
 	sess := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 100, "year": 2026})
 	bunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 1, "name": "B-1", "year": 2026})
@@ -266,7 +266,7 @@ func TestStrandedAssignmentCleanup_ProdAuditDoesNotDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer app.Cleanup()
-	setupOrphanCollections(t, app)
+	setupStrandedCollections(t, app)
 
 	sess := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 100, "year": 2026})
 	keptBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 1, "name": "B-1", "year": 2026})
@@ -300,7 +300,7 @@ func TestStrandedAssignmentCleanup_Idempotent(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer app.Cleanup()
-	setupOrphanCollections(t, app)
+	setupStrandedCollections(t, app)
 
 	sess := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 100, "year": 2026})
 	keptBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 1, "name": "B-1", "year": 2026})
@@ -339,7 +339,7 @@ func TestStrandedAssignmentCleanup_ProdAuditWarnings(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer app.Cleanup()
-	setupOrphanCollections(t, app)
+	setupStrandedCollections(t, app)
 
 	sess := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 100, "year": 2026})
 	// otherBunk has a plan → session IS in plannedSessions
@@ -381,7 +381,7 @@ func TestStrandedAssignmentCleanup_ProdQueryErrorIsCountedNotFatal(t *testing.T)
 		t.Fatal(err)
 	}
 	defer app.Cleanup()
-	setupOrphanCollections(t, app)
+	setupStrandedCollections(t, app)
 
 	// Drop bunk_assignments so the production-audit query fails. The draft
 	// sweep (bunk_assignments_draft) is unaffected.

--- a/pocketbase/sync/stranded_assignment_cleanup_test.go
+++ b/pocketbase/sync/stranded_assignment_cleanup_test.go
@@ -110,7 +110,7 @@ func saveRec(t *testing.T, app core.App, collection string, data map[string]any)
 	return r
 }
 
-func TestOrphanReconciler_SweepsStrandedDraft(t *testing.T) {
+func TestStrandedAssignmentCleanup_SweepsStrandedDraft(t *testing.T) {
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -131,7 +131,7 @@ func TestOrphanReconciler_SweepsStrandedDraft(t *testing.T) {
 		"bunk": goneBunk.Id, "bunk_plan": keptPlan.Id, "year": 2026,
 	})
 
-	svc := NewOrphanReconcilerSync(app)
+	svc := NewStrandedAssignmentCleanupSync(app)
 	svc.SetYear(2026)
 	if err = svc.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
@@ -149,7 +149,7 @@ func TestOrphanReconciler_SweepsStrandedDraft(t *testing.T) {
 	}
 }
 
-func TestOrphanReconciler_GateSkipsWhenNoBunkPlans(t *testing.T) {
+func TestStrandedAssignmentCleanup_GateSkipsWhenNoBunkPlans(t *testing.T) {
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -167,7 +167,7 @@ func TestOrphanReconciler_GateSkipsWhenNoBunkPlans(t *testing.T) {
 		"bunk": bunk.Id, "year": 2026,
 	})
 
-	svc := NewOrphanReconcilerSync(app)
+	svc := NewStrandedAssignmentCleanupSync(app)
 	svc.SetYear(2026)
 	if err = svc.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
@@ -183,7 +183,7 @@ func TestOrphanReconciler_GateSkipsWhenNoBunkPlans(t *testing.T) {
 	}
 }
 
-func TestOrphanReconciler_GateSkipsPerSession(t *testing.T) {
+func TestStrandedAssignmentCleanup_GateSkipsPerSession(t *testing.T) {
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -208,7 +208,7 @@ func TestOrphanReconciler_GateSkipsPerSession(t *testing.T) {
 		"bunk": bunkB.Id, "year": 2026,
 	})
 
-	svc := NewOrphanReconcilerSync(app)
+	svc := NewStrandedAssignmentCleanupSync(app)
 	svc.SetYear(2026)
 	if err = svc.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
@@ -224,7 +224,7 @@ func TestOrphanReconciler_GateSkipsPerSession(t *testing.T) {
 	}
 }
 
-func TestOrphanReconciler_LeavesValidDraftUntouched(t *testing.T) {
+func TestStrandedAssignmentCleanup_LeavesValidDraftUntouched(t *testing.T) {
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -242,7 +242,7 @@ func TestOrphanReconciler_LeavesValidDraftUntouched(t *testing.T) {
 		"bunk": bunk.Id, "bunk_plan": plan.Id, "year": 2026,
 	})
 
-	svc := NewOrphanReconcilerSync(app)
+	svc := NewStrandedAssignmentCleanupSync(app)
 	svc.SetYear(2026)
 	if err = svc.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
@@ -260,7 +260,7 @@ func TestOrphanReconciler_LeavesValidDraftUntouched(t *testing.T) {
 	}
 }
 
-func TestOrphanReconciler_ProdAuditDoesNotDelete(t *testing.T) {
+func TestStrandedAssignmentCleanup_ProdAuditDoesNotDelete(t *testing.T) {
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -278,7 +278,7 @@ func TestOrphanReconciler_ProdAuditDoesNotDelete(t *testing.T) {
 		"person": person.Id, "session": sess.Id, "bunk": goneBunk.Id, "year": 2026,
 	})
 
-	svc := NewOrphanReconcilerSync(app)
+	svc := NewStrandedAssignmentCleanupSync(app)
 	svc.SetYear(2026)
 	if err = svc.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
@@ -294,7 +294,7 @@ func TestOrphanReconciler_ProdAuditDoesNotDelete(t *testing.T) {
 	}
 }
 
-func TestOrphanReconciler_Idempotent(t *testing.T) {
+func TestStrandedAssignmentCleanup_Idempotent(t *testing.T) {
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -313,12 +313,12 @@ func TestOrphanReconciler_Idempotent(t *testing.T) {
 		"bunk": goneBunk.Id, "year": 2026,
 	})
 
-	svc := NewOrphanReconcilerSync(app)
+	svc := NewStrandedAssignmentCleanupSync(app)
 	svc.SetYear(2026)
 	if err = svc.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync run 1: %v", err)
 	}
-	svc2 := NewOrphanReconcilerSync(app)
+	svc2 := NewStrandedAssignmentCleanupSync(app)
 	svc2.SetYear(2026)
 	if err = svc2.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync run 2: %v", err)
@@ -333,7 +333,7 @@ func TestOrphanReconciler_Idempotent(t *testing.T) {
 	}
 }
 
-func TestOrphanReconciler_ProdAuditWarnings(t *testing.T) {
+func TestStrandedAssignmentCleanup_ProdAuditWarnings(t *testing.T) {
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -352,7 +352,7 @@ func TestOrphanReconciler_ProdAuditWarnings(t *testing.T) {
 		"person": person.Id, "session": sess.Id, "bunk": strandedBunk.Id, "year": 2026,
 	})
 
-	svc := NewOrphanReconcilerSync(app)
+	svc := NewStrandedAssignmentCleanupSync(app)
 	svc.SetYear(2026)
 	if err = svc.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
@@ -371,11 +371,11 @@ func TestOrphanReconciler_ProdAuditWarnings(t *testing.T) {
 	}
 }
 
-// TestOrphanReconciler_ProdQueryErrorIsCountedNotFatal verifies that a failure
+// TestStrandedAssignmentCleanup_ProdQueryErrorIsCountedNotFatal verifies that a failure
 // querying production bunk_assignments is recorded in Stats.Errors — so
 // WasSuccessful() reports false — but does NOT abort the run: the draft sweep
 // that already succeeded must still stand.
-func TestOrphanReconciler_ProdQueryErrorIsCountedNotFatal(t *testing.T) {
+func TestStrandedAssignmentCleanup_ProdQueryErrorIsCountedNotFatal(t *testing.T) {
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -405,7 +405,7 @@ func TestOrphanReconciler_ProdQueryErrorIsCountedNotFatal(t *testing.T) {
 		"bunk": goneBunk.Id, "year": 2026,
 	})
 
-	svc := NewOrphanReconcilerSync(app)
+	svc := NewStrandedAssignmentCleanupSync(app)
 	svc.SetYear(2026)
 	if err = svc.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync must not return an error on a prod-query failure: %v", err)

--- a/tests/unit/bunking/satisfaction/test_session_satisfaction.py
+++ b/tests/unit/bunking/satisfaction/test_session_satisfaction.py
@@ -717,7 +717,7 @@ def test_assignment_with_dict_style_expand_is_processed() -> None:
 
 
 def _unassigned_draft_row(person_cm_id: int) -> Any:
-    """Scenario draft row where orphan_reconciler cleared the bunk rel.
+    """Scenario draft row where stranded_assignment_cleanup cleared the bunk rel.
 
     Mirrors the post-reconciliation state: person rel + expand intact,
     bunk rel is empty string, no bunk in expand payload. This is the
@@ -756,7 +756,7 @@ def _dangling_bunk_assignment(person_cm_id: int, bunk_rel_id: str) -> Any:
 class TestUnresolvedExpandWarningClassification:
     """Distinguish intentional unassigned (silent) from dangling FK (WARN).
 
-    orphan_reconciler clears `bunk` to '' on draft rows whose (session, bunk)
+    stranded_assignment_cleanup clears `bunk` to '' on draft rows whose (session, bunk)
     pair drops out of bunk_plans — the camper falls back into the Unassigned
     pool by design. Warning about those is log noise. A non-empty bunk rel
     that fails to expand IS real corruption and must still surface.


### PR DESCRIPTION
## Summary

Closes #1518.

Renames the misleading `orphan_reconciler` admin sync job to `stranded_assignment_cleanup` — the service has nothing to do with person-side orphans; it sweeps `scenarios_bunk_assignments` rows stranded when bunk_plan changes drop a (session, bunk) pair. The bad name caused real confusion during the #1375 walkthrough when reasoning about where to fold bidirectional Phase C logic.

## Changes

- **Go service** (`pocketbase/sync/stranded_assignment_cleanup.go`): file rename, struct → `StrandedAssignmentCleanupSync`, constructor → `NewStrandedAssignmentCleanupSync`, service-name const, registration string, log prefixes
- **Go orchestrator/api**: registration calls in `orchestrator.go` (5 sites), route `/api/custom/sync/stranded-assignment-cleanup` in `api.go`, daily/refresh-bunking job-order strings
- **Go tests**: renamed `TestOrphanReconciler_*` → `TestStrandedAssignmentCleanup_*`, updated order-assertion strings, `TestJobMeta_IncludesStrandedAssignmentCleanup`
- **Frontend**: `syncTypes` id/name → "Stranded Assignment Cleanup", `SYNC_TYPE_NAMES` map entry, `SyncStatusResponse` interface field
- **Python**: stale comment in `bunking/satisfaction/aggregate.py` + test_session_satisfaction.py docs

## Migration

No migration needed. Verified via grep:
- No `pb_migrations/*.js` references the literal string
- No `.json` / `.toml` / `.yaml` configs reference it
- Persisted `sync_runs` audit rows simply retain the old name for history; the service isn't user-facing config

## Test plan

- [x] `go test ./sync/` — 2038 passed
- [x] `vitest` on renamed test files — 6/6 passed
- [x] Full pre-push verification (prettier, eslint, tsc, vitest, ruff, mypy, go build, golangci-lint) — all green
- [ ] After merge: spot-check that the admin Sync tab card now reads "Stranded Assignment Cleanup" and the manual-run button hits `/api/custom/sync/stranded-assignment-cleanup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed the sync job from "Orphan Reconciler" to "Stranded Assignment Cleanup" across the system — UI labels, API endpoints, status reporting, logs/messages, and background sync ordering updated. Tests and documentation/comments adjusted to match the new name.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->