### PR TITLE
fix(solver): count soft-constraint fires, not vars created (#1532)

### DIFF
--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -48,11 +48,11 @@ from .feasibility import check_feasibility as _check_feasibility
 from .feasibility import find_infeasibility_cause as _find_infeasibility_cause
 from .logging import ConstraintLogger
 from .observability import (
+    _bucket_soft_constraint_violations,
     _build_impossible_by_reason_by_bucket,
     _build_request_density_histogram_by_bucket,
     _build_stats_dict,
     _count_constraint_types,
-    _count_soft_constraints_by_module,
 )
 
 if TYPE_CHECKING:
@@ -663,6 +663,9 @@ class DirectBunkingSolver:
         # table renders every key from `_build_stats_dict`. Emit the full
         # key set with `None` for fields the simplified path can't populate
         # so column rendering is identical across session types.
+        single_bunk_fires, single_bunk_penalties = _bucket_soft_constraint_violations(
+            None, self.soft_constraint_violations
+        )
         stats: dict[str, Any] = {
             "status": "INFEASIBLE" if over_capacity else "OPTIMAL",
             # int() cast — same reason as _build_stats_dict above: cp_model
@@ -698,7 +701,8 @@ class DirectBunkingSolver:
             # and soft-by-module use the actual data we have.
             "num_reified_linear": 0,
             "max_linear_coefficient": 0,
-            "soft_constraints_by_module": _count_soft_constraints_by_module(self.soft_constraint_violations),
+            "soft_constraints_by_module": single_bunk_fires,
+            "soft_constraint_penalty_by_module": single_bunk_penalties,
             "request_density_histogram_by_bucket": _build_request_density_histogram_by_bucket(
                 self.input.requests_by_person
             ),
@@ -900,40 +904,21 @@ class DirectBunkingSolver:
         )
 
     def _log_objective_breakdown(self, solver: cp_model.CpSolver) -> None:
-        """Log breakdown of objective value by category.
-
-        Shows how much each soft constraint category contributed to the objective.
-        """
+        """Log breakdown of objective value by category."""
         logger.info("=== Post-Solve Objective Breakdown ===")
         logger.info(f"Total objective value: {solver.ObjectiveValue():.0f}")
 
-        # Group soft constraint violations by category
-        category_totals: dict[str, float] = defaultdict(float)
-        category_counts: dict[str, int] = defaultdict(int)
+        fires_by_module, penalty_by_module = _bucket_soft_constraint_violations(solver, self.soft_constraint_violations)
 
-        for name, (var, penalty) in self.soft_constraint_violations.items():
-            # Extract category from name (e.g., "grade_ratio_5_grade_7" -> "grade_ratio")
-            parts = name.split("_")
-            if len(parts) >= 2:
-                category = f"{parts[0]}_{parts[1]}"
-            else:
-                category = name
-
-            try:
-                value = solver.Value(var)
-                if value > 0:
-                    contribution = penalty * value if isinstance(value, int) else penalty
-                    category_totals[category] += contribution
-                    category_counts[category] += 1
-            except Exception:  # noqa: S110 — intentional silent handling
-                # Variable might not be in solution
-                pass
-
-        if category_totals:
+        firing_buckets = [
+            (label, penalty_by_module[label], fires_by_module[label])
+            for label in penalty_by_module
+            if fires_by_module[label] > 0
+        ]
+        if firing_buckets:
             logger.info("Soft constraint penalties by category:")
-            for category, total in sorted(category_totals.items(), key=lambda x: -x[1]):
-                count = category_counts[category]
-                logger.info(f"  {category}: {total:.0f} ({count} violations)")
+            for label, total, count in sorted(firing_buckets, key=lambda x: -x[1]):
+                logger.info(f"  {label}: {total} ({count} violations)")
         else:
             logger.info("No soft constraint penalties incurred")
 

--- a/bunking/solver/observability.py
+++ b/bunking/solver/observability.py
@@ -177,14 +177,13 @@ def _count_reified_linear_constraints(proto: Any) -> int:
 # modules should append a (prefix, module-label) pair here so they roll up
 # correctly. Keys whose prefix doesn't match any entry fall into "other".
 _SOFT_CONSTRAINT_PREFIXES: tuple[tuple[str, str], ...] = (
-    ("must_satisfy_", "must_satisfy"),
     ("grade_ratio_", "grade_ratio"),
     ("level_regression_", "level_regression"),
     ("age_spread_b", "age_spread"),
 )
 
 
-_MODULE_LABELS: tuple[str, ...] = ("must_satisfy", "grade_ratio", "level_regression", "age_spread", "other")
+_MODULE_LABELS: tuple[str, ...] = ("grade_ratio", "level_regression", "age_spread", "other")
 
 
 def _classify_bucket(name: str) -> str:

--- a/bunking/solver/observability.py
+++ b/bunking/solver/observability.py
@@ -184,22 +184,41 @@ _SOFT_CONSTRAINT_PREFIXES: tuple[tuple[str, str], ...] = (
 )
 
 
-def _count_soft_constraints_by_module(violations: dict[str, Any]) -> dict[str, int]:
-    """Group `soft_constraint_violations` keys by constraint module prefix.
+_MODULE_LABELS: tuple[str, ...] = ("must_satisfy", "grade_ratio", "level_regression", "age_spread", "other")
 
-    The dashboard uses this to show which constraint families dominate the
-    penalty surface — e.g. `grade_ratio=420` vs `must_satisfy=83` tells a
-    very different optimization story.
+
+def _classify_bucket(name: str) -> str:
+    for prefix, label in _SOFT_CONSTRAINT_PREFIXES:
+        if name.startswith(prefix):
+            return label
+    return "other"
+
+
+def _bucket_soft_constraint_violations(
+    solver: Any,
+    violations: dict[str, Any],
+) -> tuple[dict[str, int], dict[str, int]]:
+    """Bucket soft-constraint violation vars by module prefix.
+
+    Returns ``(fires_by_module, penalty_total_by_module)``. Both dicts are
+    keyed by ``_MODULE_LABELS`` and pre-seeded to 0 so missing-vs-zero is
+    unambiguous downstream. ``solver=None`` is the single-bunk path: the
+    CP-SAT model never runs, so both dicts come back all-zero.
+
+    Replaces the previous ``_count_soft_constraints_by_module`` (which
+    counted dict keys = vars created at model-build time, not fires
+    honored in the final solution; cf. #1532).
     """
-    result: dict[str, int] = {}
-    for key in violations:
-        bucket = "other"
-        for prefix, label in _SOFT_CONSTRAINT_PREFIXES:
-            if key.startswith(prefix):
-                bucket = label
-                break
-        result[bucket] = result.get(bucket, 0) + 1
-    return result
+    fires: dict[str, int] = dict.fromkeys(_MODULE_LABELS, 0)
+    penalty_totals: dict[str, int] = dict.fromkeys(_MODULE_LABELS, 0)
+    if solver is None or not violations:
+        return fires, penalty_totals
+    for name, (var, penalty) in violations.items():
+        bucket = _classify_bucket(name)
+        value = int(solver.Value(var))
+        fires[bucket] += value
+        penalty_totals[bucket] += penalty * value
+    return fires, penalty_totals
 
 
 def _max_linear_coefficient(proto: Any) -> int:
@@ -326,6 +345,8 @@ def _build_stats_dict(
     objective_trajectory = objective_trajectory or []
     bound_trajectory = bound_trajectory or []
 
+    fires_by_module, penalty_by_module = _bucket_soft_constraint_violations(solver, soft_constraint_violations or {})
+
     return {
         # Existing back-compat fields
         "status": solver.StatusName(status),
@@ -363,7 +384,8 @@ def _build_stats_dict(
         # Tier 1 observability (Stream 2, issue #1380)
         "num_reified_linear": _count_reified_linear_constraints(model_proto),
         "max_linear_coefficient": _max_linear_coefficient(model_proto),
-        "soft_constraints_by_module": _count_soft_constraints_by_module(soft_constraint_violations or {}),
+        "soft_constraints_by_module": fires_by_module,
+        "soft_constraint_penalty_by_module": penalty_by_module,
         "request_density_histogram_by_bucket": _build_request_density_histogram_by_bucket(requests_by_person or {}),
         # Tier 2 observability (Stream 2, Phase 2 — plateau-diagnostic metrics)
         "objective_trajectory": objective_trajectory,

--- a/tests/unit/solver/test_direct_solver_stats.py
+++ b/tests/unit/solver/test_direct_solver_stats.py
@@ -934,7 +934,6 @@ class TestBucketSoftConstraintViolations:
     `_MODULE_LABELS` keys so missing-vs-zero is unambiguous downstream.
 
     Violation-name prefixes (registered in `_SOFT_CONSTRAINT_PREFIXES`):
-    - `must_satisfy_<cm_id>`             (must_satisfy.py)
     - `grade_ratio_<bunk>_grade_<grade>` (grade_ratio.py)
     - `level_regression_<p>_<b>`         (level_progression.py)
     - `age_spread_b<bunk>`               (age_spread.py)
@@ -954,7 +953,7 @@ class TestBucketSoftConstraintViolations:
             _bucket_soft_constraint_violations,
         )
 
-        fires, penalties = _bucket_soft_constraint_violations(None, {"must_satisfy_1": (object(), 100)})
+        fires, penalties = _bucket_soft_constraint_violations(None, {"grade_ratio_0_grade_5": (object(), 100)})
         assert fires == dict.fromkeys(_MODULE_LABELS, 0)
         assert penalties == dict.fromkeys(_MODULE_LABELS, 0)
 
@@ -972,14 +971,11 @@ class TestBucketSoftConstraintViolations:
     def test_buckets_by_known_prefix_summing_fires_and_penalty(self) -> None:
         from bunking.solver.observability import _bucket_soft_constraint_violations
 
-        v_ms1, v_ms2 = self._make_var("ms1"), self._make_var("ms2")
         v_gr1, v_gr2 = self._make_var("gr1"), self._make_var("gr2")
         v_lr1 = self._make_var("lr1")
         v_as1 = self._make_var("as1")
 
         violations = {
-            "must_satisfy_1": (v_ms1, 1000),
-            "must_satisfy_2": (v_ms2, 1000),
             "grade_ratio_0_grade_5": (v_gr1, 50),
             "grade_ratio_1_grade_6": (v_gr2, 50),
             "level_regression_0_0": (v_lr1, 800),
@@ -987,8 +983,6 @@ class TestBucketSoftConstraintViolations:
         }
         solver = self._make_solver(
             {
-                v_ms1: 1,
-                v_ms2: 0,
                 v_gr1: 1,
                 v_gr2: 0,
                 v_lr1: 0,
@@ -998,14 +992,12 @@ class TestBucketSoftConstraintViolations:
 
         fires, penalties = _bucket_soft_constraint_violations(solver, violations)
         assert fires == {
-            "must_satisfy": 1,
             "grade_ratio": 1,
             "level_regression": 0,
             "age_spread": 1,
             "other": 0,
         }
         assert penalties == {
-            "must_satisfy": 1000,
             "grade_ratio": 50,
             "level_regression": 0,
             "age_spread": 200,
@@ -1016,18 +1008,18 @@ class TestBucketSoftConstraintViolations:
         from bunking.solver.observability import _bucket_soft_constraint_violations
 
         v_unknown = self._make_var("unknown")
-        v_ms = self._make_var("ms")
+        v_gr = self._make_var("gr")
         violations = {
             "some_future_constraint_42": (v_unknown, 17),
-            "must_satisfy_1": (v_ms, 1000),
+            "grade_ratio_0_grade_5": (v_gr, 50),
         }
-        solver = self._make_solver({v_unknown: 1, v_ms: 1})
+        solver = self._make_solver({v_unknown: 1, v_gr: 1})
 
         fires, penalties = _bucket_soft_constraint_violations(solver, violations)
         assert fires["other"] == 1
-        assert fires["must_satisfy"] == 1
+        assert fires["grade_ratio"] == 1
         assert penalties["other"] == 17
-        assert penalties["must_satisfy"] == 1000
+        assert penalties["grade_ratio"] == 50
 
 
 class TestBucketSoftConstraintViolationsCpSat:
@@ -1044,13 +1036,11 @@ class TestBucketSoftConstraintViolationsCpSat:
         v_lr_off = model.NewBoolVar("level_regression_0_1")
         v_gr_fire = model.NewBoolVar("grade_ratio_0_grade_5")
         v_as_off = model.NewBoolVar("age_spread_b0")
-        v_ms_fire = model.NewBoolVar("must_satisfy_1")
 
         model.Add(v_lr_fire == 1)
         model.Add(v_lr_off == 0)
         model.Add(v_gr_fire == 1)
         model.Add(v_as_off == 0)
-        model.Add(v_ms_fire == 1)
 
         solver = cp_model.CpSolver()
         status = solver.Solve(model)
@@ -1061,19 +1051,16 @@ class TestBucketSoftConstraintViolationsCpSat:
             "level_regression_0_1": (v_lr_off, 800),
             "grade_ratio_0_grade_5": (v_gr_fire, 50),
             "age_spread_b0": (v_as_off, 200),
-            "must_satisfy_1": (v_ms_fire, 1000),
         }
         fires, penalties = _bucket_soft_constraint_violations(solver, violations)
 
         assert fires == {
-            "must_satisfy": 1,
             "grade_ratio": 1,
             "level_regression": 1,
             "age_spread": 0,
             "other": 0,
         }
         assert penalties == {
-            "must_satisfy": 1000,
             "grade_ratio": 50,
             "level_regression": 800,
             "age_spread": 0,
@@ -1378,12 +1365,11 @@ class TestTier1MetricsInStatsDict:
         model.Add(50_000 * x <= 100).OnlyEnforceIf(a)  # reified + big-M
 
         solver = self._base_mock_solver()
-        v_ms1, v_ms2, v_gr1 = object(), object(), object()
-        solver.Value = lambda v, _m={v_ms1: 1, v_ms2: 1, v_gr1: 1}: _m[v]
+        v_gr1, v_gr2 = object(), object()
+        solver.Value = lambda v, _m={v_gr1: 1, v_gr2: 1}: _m[v]
         violations = {
-            "must_satisfy_1": (v_ms1, 1000),
-            "must_satisfy_2": (v_ms2, 1000),
             "grade_ratio_0_grade_5": (v_gr1, 50),
+            "grade_ratio_1_grade_6": (v_gr2, 50),
         }
         requests_by_person: dict[int, list[DirectBunkRequest]] = {
             1: [_make_req("r1", 1, "bunk_with")],
@@ -1406,15 +1392,13 @@ class TestTier1MetricsInStatsDict:
         assert stats["num_reified_linear"] == 1
         assert stats["max_linear_coefficient"] == 50_000
         assert stats["soft_constraints_by_module"] == {
-            "must_satisfy": 2,
-            "grade_ratio": 1,
+            "grade_ratio": 2,
             "level_regression": 0,
             "age_spread": 0,
             "other": 0,
         }
         assert stats["soft_constraint_penalty_by_module"] == {
-            "must_satisfy": 2000,
-            "grade_ratio": 50,
+            "grade_ratio": 100,
             "level_regression": 0,
             "age_spread": 0,
             "other": 0,

--- a/tests/unit/solver/test_direct_solver_stats.py
+++ b/tests/unit/solver/test_direct_solver_stats.py
@@ -483,6 +483,7 @@ _BUILD_STATS_DICT_KEYS = frozenset(
         "num_reified_linear",
         "max_linear_coefficient",
         "soft_constraints_by_module",
+        "soft_constraint_penalty_by_module",
         "request_density_histogram_by_bucket",
         # Tier 2 observability (Stream 2, Phase 2 — plateau-diagnostic metrics)
         "objective_trajectory",
@@ -925,55 +926,159 @@ class TestCountReifiedLinearConstraints:
         assert _count_reified_linear_constraints(model.Proto()) == 2
 
 
-class TestCountSoftConstraintsByModule:
-    """`soft_constraint_violations` keys carry module prefixes set by each
-    constraint helper. Roll them up into a per-module count so the dashboard
-    can show which constraint families produced the most penalty terms.
+class TestBucketSoftConstraintViolations:
+    """`_bucket_soft_constraint_violations` returns (fires_by_module, penalty_total_by_module).
 
-    Known prefixes (as of 2026-05):
+    Fires are summed `solver.Value(var)` per module prefix; penalty totals
+    are `penalty * value` per prefix. Both dicts are pre-seeded with all
+    `_MODULE_LABELS` keys so missing-vs-zero is unambiguous downstream.
+
+    Violation-name prefixes (registered in `_SOFT_CONSTRAINT_PREFIXES`):
     - `must_satisfy_<cm_id>`             (must_satisfy.py)
     - `grade_ratio_<bunk>_grade_<grade>` (grade_ratio.py)
     - `level_regression_<p>_<b>`         (level_progression.py)
     - `age_spread_b<bunk>`               (age_spread.py)
     """
 
-    def test_empty_dict_returns_empty(self) -> None:
-        from bunking.solver.observability import _count_soft_constraints_by_module
+    def _make_var(self, name: str) -> object:
+        return object()
 
-        assert _count_soft_constraints_by_module({}) == {}
+    def _make_solver(self, value_map: dict[object, int]) -> MagicMock:
+        solver = MagicMock()
+        solver.Value = lambda v: value_map[v]
+        return solver
 
-    def test_groups_keys_by_known_prefix(self) -> None:
-        from bunking.solver.observability import _count_soft_constraints_by_module
+    def test_solver_none_returns_zero_seeded_dicts(self) -> None:
+        from bunking.solver.observability import (
+            _MODULE_LABELS,
+            _bucket_soft_constraint_violations,
+        )
 
-        # Values don't matter — function only inspects keys
-        violations: dict[str, object] = {
-            "must_satisfy_12345": object(),
-            "must_satisfy_67890": object(),
-            "grade_ratio_0_grade_5": object(),
-            "grade_ratio_1_grade_6": object(),
-            "grade_ratio_2_grade_7": object(),
-            "level_regression_0_0": object(),
-            "age_spread_b0": object(),
-            "age_spread_b1": object(),
+        fires, penalties = _bucket_soft_constraint_violations(None, {"must_satisfy_1": (object(), 100)})
+        assert fires == dict.fromkeys(_MODULE_LABELS, 0)
+        assert penalties == dict.fromkeys(_MODULE_LABELS, 0)
+
+    def test_empty_violations_returns_zero_seeded_dicts(self) -> None:
+        from bunking.solver.observability import (
+            _MODULE_LABELS,
+            _bucket_soft_constraint_violations,
+        )
+
+        solver = self._make_solver({})
+        fires, penalties = _bucket_soft_constraint_violations(solver, {})
+        assert fires == dict.fromkeys(_MODULE_LABELS, 0)
+        assert penalties == dict.fromkeys(_MODULE_LABELS, 0)
+
+    def test_buckets_by_known_prefix_summing_fires_and_penalty(self) -> None:
+        from bunking.solver.observability import _bucket_soft_constraint_violations
+
+        v_ms1, v_ms2 = self._make_var("ms1"), self._make_var("ms2")
+        v_gr1, v_gr2 = self._make_var("gr1"), self._make_var("gr2")
+        v_lr1 = self._make_var("lr1")
+        v_as1 = self._make_var("as1")
+
+        violations = {
+            "must_satisfy_1": (v_ms1, 1000),
+            "must_satisfy_2": (v_ms2, 1000),
+            "grade_ratio_0_grade_5": (v_gr1, 50),
+            "grade_ratio_1_grade_6": (v_gr2, 50),
+            "level_regression_0_0": (v_lr1, 800),
+            "age_spread_b0": (v_as1, 200),
         }
-        result = _count_soft_constraints_by_module(violations)
-        assert result == {
-            "must_satisfy": 2,
-            "grade_ratio": 3,
-            "level_regression": 1,
-            "age_spread": 2,
+        solver = self._make_solver(
+            {
+                v_ms1: 1,
+                v_ms2: 0,
+                v_gr1: 1,
+                v_gr2: 0,
+                v_lr1: 0,
+                v_as1: 1,
+            }
+        )
+
+        fires, penalties = _bucket_soft_constraint_violations(solver, violations)
+        assert fires == {
+            "must_satisfy": 1,
+            "grade_ratio": 1,
+            "level_regression": 0,
+            "age_spread": 1,
+            "other": 0,
+        }
+        assert penalties == {
+            "must_satisfy": 1000,
+            "grade_ratio": 50,
+            "level_regression": 0,
+            "age_spread": 200,
+            "other": 0,
         }
 
     def test_unknown_prefix_lands_in_other(self) -> None:
-        from bunking.solver.observability import _count_soft_constraints_by_module
+        from bunking.solver.observability import _bucket_soft_constraint_violations
 
-        violations: dict[str, object] = {
-            "some_future_constraint_42": object(),
-            "must_satisfy_1": object(),
+        v_unknown = self._make_var("unknown")
+        v_ms = self._make_var("ms")
+        violations = {
+            "some_future_constraint_42": (v_unknown, 17),
+            "must_satisfy_1": (v_ms, 1000),
         }
-        result = _count_soft_constraints_by_module(violations)
-        assert result.get("must_satisfy") == 1
-        assert result.get("other") == 1
+        solver = self._make_solver({v_unknown: 1, v_ms: 1})
+
+        fires, penalties = _bucket_soft_constraint_violations(solver, violations)
+        assert fires["other"] == 1
+        assert fires["must_satisfy"] == 1
+        assert penalties["other"] == 17
+        assert penalties["must_satisfy"] == 1000
+
+
+class TestBucketSoftConstraintViolationsCpSat:
+    """End-to-end with a real CpSolver: forced BoolVars exercise the
+    `solver.Value()` path and catch BoolVar/IntVar type mismatches or
+    OR-Tools API drift that mocks can't see.
+    """
+
+    def test_real_solver_buckets_forced_fires_correctly(self) -> None:
+        from bunking.solver.observability import _bucket_soft_constraint_violations
+
+        model = cp_model.CpModel()
+        v_lr_fire = model.NewBoolVar("level_regression_0_0")
+        v_lr_off = model.NewBoolVar("level_regression_0_1")
+        v_gr_fire = model.NewBoolVar("grade_ratio_0_grade_5")
+        v_as_off = model.NewBoolVar("age_spread_b0")
+        v_ms_fire = model.NewBoolVar("must_satisfy_1")
+
+        model.Add(v_lr_fire == 1)
+        model.Add(v_lr_off == 0)
+        model.Add(v_gr_fire == 1)
+        model.Add(v_as_off == 0)
+        model.Add(v_ms_fire == 1)
+
+        solver = cp_model.CpSolver()
+        status = solver.Solve(model)
+        assert status in (cp_model.OPTIMAL, cp_model.FEASIBLE)
+
+        violations = {
+            "level_regression_0_0": (v_lr_fire, 800),
+            "level_regression_0_1": (v_lr_off, 800),
+            "grade_ratio_0_grade_5": (v_gr_fire, 50),
+            "age_spread_b0": (v_as_off, 200),
+            "must_satisfy_1": (v_ms_fire, 1000),
+        }
+        fires, penalties = _bucket_soft_constraint_violations(solver, violations)
+
+        assert fires == {
+            "must_satisfy": 1,
+            "grade_ratio": 1,
+            "level_regression": 1,
+            "age_spread": 0,
+            "other": 0,
+        }
+        assert penalties == {
+            "must_satisfy": 1000,
+            "grade_ratio": 50,
+            "level_regression": 800,
+            "age_spread": 0,
+            "other": 0,
+        }
 
 
 class TestMaxLinearCoefficient:
@@ -1273,10 +1378,12 @@ class TestTier1MetricsInStatsDict:
         model.Add(50_000 * x <= 100).OnlyEnforceIf(a)  # reified + big-M
 
         solver = self._base_mock_solver()
+        v_ms1, v_ms2, v_gr1 = object(), object(), object()
+        solver.Value = lambda v, _m={v_ms1: 1, v_ms2: 1, v_gr1: 1}: _m[v]
         violations = {
-            "must_satisfy_1": object(),
-            "must_satisfy_2": object(),
-            "grade_ratio_0_grade_5": object(),
+            "must_satisfy_1": (v_ms1, 1000),
+            "must_satisfy_2": (v_ms2, 1000),
+            "grade_ratio_0_grade_5": (v_gr1, 50),
         }
         requests_by_person: dict[int, list[DirectBunkRequest]] = {
             1: [_make_req("r1", 1, "bunk_with")],
@@ -1301,6 +1408,16 @@ class TestTier1MetricsInStatsDict:
         assert stats["soft_constraints_by_module"] == {
             "must_satisfy": 2,
             "grade_ratio": 1,
+            "level_regression": 0,
+            "age_spread": 0,
+            "other": 0,
+        }
+        assert stats["soft_constraint_penalty_by_module"] == {
+            "must_satisfy": 2000,
+            "grade_ratio": 50,
+            "level_regression": 0,
+            "age_spread": 0,
+            "other": 0,
         }
         assert stats["request_density_histogram_by_bucket"] == {
             "material_parent": {1: 1, 2: 1},

--- a/uv.lock
+++ b/uv.lock
@@ -566,11 +566,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Replace `_count_soft_constraints_by_module` (counted dict keys = vars created at model-build) with `_bucket_soft_constraint_violations` (sums `solver.Value(var)` = fires honored in final solution)
- Add new stats field `soft_constraint_penalty_by_module` (weighted penalty per bucket) alongside the now-fixed `soft_constraints_by_module` (fires per bucket)
- `_log_objective_breakdown` now consumes the same shared helper instead of duplicating bucketing logic

## Why
The pre-fix `level_regression: 281` on a recent S2 run was actually 0 fires — every var was created per `(returner × eligible-lower-bunk)` pair at model-build time, but only one is reachable per camper. Misled an "is the 800 penalty enough?" tuning discussion (it is). Same pattern affected `grade_ratio` and `age_spread`.

## Test plan
- [x] Unit tests for `_bucket_soft_constraint_violations` (solver=None / empty / mixed-fires / unknown-prefix → other)
- [x] CP-SAT integration test with real forced BoolVars
- [x] Existing `test_emits_new_tier1_keys` migrated to the new helper shape (`(var, penalty)` tuples + per-var value map on the mock solver)
- [x] All 304 solver unit tests still pass
- [x] Full pre-push verification (4757 pass / 14 skipped)

Closes #1532

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced soft-constraint observability: module-level breakdown of violation "fires" and penalty totals across categories (must-satisfy, grade-ratio, level-regression, age-spread, other).
  * Single-bunk stats now match bucketed analytics shape; reporting sorts buckets by descending penalty.

* **Tests**
  * Added and updated tests to validate per-module fires and penalty totals and ensure stats include the new soft_constraint_penalty_by_module metric.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1547?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->