### PR TITLE
feat(scripts): grab-feedback skips already-mirrored feedback issues

### DIFF
--- a/.claude/skills/grab-feedback/SKILL.md
+++ b/.claude/skills/grab-feedback/SKILL.md
@@ -29,6 +29,22 @@ gh issue list --repo {owner}/{repo}-feedback --state open --limit 50 --json numb
 
 If none: report "No new feedback" and stop.
 
+### Step 1a: Filter out already-mirrored issues
+
+Open feedback issues may already have a public placeholder (placeholder-mode issues stay open by design). Skip any issue whose comments already contain a `Public placeholder created at` or `Transferred to` annotation — those are tracked, not new work.
+
+```bash
+for n in <numbers from step 1>; do
+  mirrored=$(gh issue view "$n" --repo {owner}/{repo}-feedback --json comments \
+    --jq '.comments[] | select(.body | test("Public placeholder created|Transferred to")) | .body' | head -1)
+  if [ -n "$mirrored" ]; then
+    echo "#$n already mirrored: $mirrored"
+  fi
+done
+```
+
+Drop mirrored issues from the working set before proceeding to Step 2. Mention them in the report so the user knows they were considered.
+
 ## Step 2: Classify each issue
 
 For each issue, decide which path it takes:


### PR DESCRIPTION
## Summary

Adds **Step 1a** to the `grab-feedback` skill: before classifying open feedback issues, drop any whose comments already contain a `Public placeholder created` or `Transferred to` annotation.

## Why

Placeholder-mode issues (added in #1315) stay open by design, so each `grab-feedback` run was re-surfacing them as new work. This filters them out of the working set while still mentioning them in the report so they're visibly accounted for.

## Notes

- Pure skill/workflow doc change — no code, schema, or runtime impact.
- Pre-push hooks green (markdownlint, shellcheck on the bash snippet, plus the standard suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feedback processing to prevent duplicate transfers of previously mirrored issues by filtering out already-transferred items before classification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->