### PR TITLE
feat(solver): age_spread Phase 2 — hard 24mo cap with edge-bunk escape hatch

### DIFF
--- a/.pip-audit-ignore
+++ b/.pip-audit-ignore
@@ -6,3 +6,4 @@
 CVE-2026-4539  # pygments ReDoS in AdlLexer (archetype.py) — local-only, no upstream fix yet — added 2026-03-24, remove by 2026-04-24
 CVE-2026-3219  # pip handles concatenated tar/ZIP files as ZIP — install-time only, no fix released yet — added 2026-04-25, remove by 2026-05-25
 CVE-2026-6357  # pip self-update import-deferral race; fixed in pip 26.1, system pip not yet bumped — added 2026-05-05, remove by 2026-06-05
+PYSEC-2025-183  # pyjwt weak-key advisory, disputed by supplier (key length is the application's choice); no fix version published — added 2026-05-20, remove by 2026-06-20

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -16,7 +16,11 @@ from pydantic import BaseModel, Field
 from bunking.logging_config import get_logger
 from bunking.models import Bunk, BunkAssignment, BunkRequest, Person, Session
 from bunking.satisfaction.predicate import is_request_satisfied
-from bunking.solver.constants import DEFAULT_BUNK_CAPACITY, MAX_UNIQUE_GRADES_PER_BUNK
+from bunking.solver.constants import (
+    DEFAULT_BUNK_CAPACITY,
+    MAX_AGE_SPREAD_MONTHS,
+    MAX_UNIQUE_GRADES_PER_BUNK,
+)
 from bunking.solver.constraints.helpers import extract_bunk_level, get_level_order
 from bunking.sync.bunk_request_processor.core.models import source_from_field
 from bunking.sync.bunk_request_processor.shared.constants import (
@@ -247,7 +251,7 @@ class BunkingValidator:
         # fire on the same threshold the solver enforced (with staff overrides
         # permitted on the bunking board — flagged via grade_spread_warning).
         self.max_grade_spread = MAX_UNIQUE_GRADES_PER_BUNK
-        self.max_age_spread_months = 24  # Maximum age difference (2 years)
+        self.max_age_spread_months = MAX_AGE_SPREAD_MONTHS
 
     def validate_bunking(
         self,

--- a/bunking/config/loader.py
+++ b/bunking/config/loader.py
@@ -385,9 +385,9 @@ class ConfigLoader:
             # level_progression removed - uses no_regression_penalty via constraint module
             # must_satisfy_one removed in Stage 4 (#1379) - replaced by hard MP constraint
             # grade_spread removed in Phase 2 - replaced by hard MAX_UNIQUE_GRADES_PER_BUNK constant
+            # age_spread removed in Phase 2 - replaced by hard MAX_AGE_SPREAD_MONTHS constant
             "age_grade_flow": "constraint.age_grade_flow.weight",
             "grade_cohesion": "constraint.grade_cohesion.weight",
-            "age_spread": "constraint.age_spread.penalty",
         }
 
         key = weight_mappings.get(constraint_name, f"constraint.{constraint_name}.weight")

--- a/bunking/config/schema.py
+++ b/bunking/config/schema.py
@@ -18,16 +18,13 @@ from .types import ConfigKey, ConfigType
 CONFIG_SCHEMA: dict[str, ConfigKey] = {
     # =========================================================================
     # SPREAD VALIDATION
-    # Used by both solver constraints and request processor
     # =========================================================================
-    "spread.max_age_months": ConfigKey(
-        key="spread.max_age_months",
-        config_type=ConfigType.INT,
-        required=True,
-        description="Maximum age difference in months for bunk requests",
-        min_value=0,
-        max_value=60,
-    ),
+    # Phase 2 cleanup: spread.max_age_months was collapsed into
+    # bunking/solver/constants.py — MAX_AGE_SPREAD_MONTHS (=24). It was only
+    # consumed by the sync-time spread filter while a separate phantom
+    # constraint.age_spread.months (default=24) drove solver behavior.
+    # spread.max_grade was collapsed earlier into MAX_UNIQUE_GRADES_PER_BUNK
+    # (Grade Spread Phase 2).
     # =========================================================================
     # SOLVER CONSTRAINTS - Grade Ratio
     # =========================================================================
@@ -55,21 +52,11 @@ CONFIG_SCHEMA: dict[str, ConfigKey] = {
     # =========================================================================
     # SOLVER CONSTRAINTS - Age Spread
     # =========================================================================
-    "constraint.age_spread.penalty": ConfigKey(
-        key="constraint.age_spread.penalty",
-        config_type=ConfigType.INT,
-        required=True,
-        description="Penalty for age spread violations",
-        min_value=0,
-    ),
-    "constraint.age_spread.preferred_months": ConfigKey(
-        key="constraint.age_spread.preferred_months",
-        config_type=ConfigType.INT,
-        required=True,
-        description="Preferred age spread in months — cabins at or below this spread earn a bonus (0 = disabled)",
-        min_value=0,
-        max_value=60,
-    ),
+    # Phase 2 cleanup: constraint.age_spread.{penalty, preferred_months} were
+    # collapsed into bunking/solver/constants.py — MAX_AGE_SPREAD_MONTHS (hard
+    # cap, =24) and PREFERRED_AGE_SPREAD_MONTHS (soft target, =18). The soft
+    # penalty path is gone; the constant takes the hardcoded threshold.
+    # constraint.age_spread.preferred_bonus is KEPT as the lone tunable knob.
     "constraint.age_spread.preferred_bonus": ConfigKey(
         key="constraint.age_spread.preferred_bonus",
         config_type=ConfigType.INT,

--- a/bunking/solver/constants.py
+++ b/bunking/solver/constants.py
@@ -20,6 +20,17 @@ seeded), ``constraint.grade_spread.mode`` (seeded "soft" but production runs
 never fired in observed solver logs), and the validator's parallel hardcode
 into the single constant below. Solver is hard-only.
 
+Age spread (Phase 2): collapsed phantom ``constraint.age_spread.months`` (read
+with ``default=24``, never in CONFIG_SCHEMA), ``spread.max_age_months`` PB
+config row (was only consumed by the sync-time spread filter; silently
+disconnected from solver behavior), ``constraint.age_spread.penalty`` (soft
+violation path being deleted), ``constraint.age_spread.preferred_months``
+(seed=12, bumped to 18 here per staff intent), the validator's parallel
+hardcoded ``24``, and the orphan ``DEFAULT_AGE_SPREAD_MONTHS`` in
+``bunking/sync/.../core/constants.py`` into the two constants below. Solver
+is hard-only. ``constraint.age_spread.preferred_bonus`` is KEPT in the config
+as the lone tunable knob in this domain.
+
 If per-bunk variance is ever needed (e.g., a smaller specialty cabin), add a
 real ``max_size`` integer column on the ``bunks`` PocketBase collection with a
 sync path that populates it. That's a feature, not a refactor.
@@ -63,3 +74,25 @@ Reads:
 - ``bunking/sync/bunk_request_processor/orchestrator/orchestrator.py`` — sync-
   time spread filter on incoming bunk requests (was reading ``spread.max_grade``
   which is gone)."""
+
+MAX_AGE_SPREAD_MONTHS = 24
+"""Hard ceiling for age range (months) within a non-AG bunk. Solver never
+emits a bunk with ``max_age - min_age > MAX_AGE_SPREAD_MONTHS``. Staff can
+override on the bunking board — the board allows >24mo with a display warning
+(same asymmetry as ``MAX_BUNK_CAPACITY`` / ``MAX_UNIQUE_GRADES_PER_BUNK``).
+Reads:
+
+- ``bunking/solver/constraints/age_spread.py`` — hard CP-SAT constraint.
+- ``bunking/solver/feasibility.py:_explain_age_spread_infeasibility`` — when
+  the hard cap causes INFEASIBLE, surfaces a staff-actionable message.
+- ``bunking/bunking_validator.py`` — board-side warning when staff manual
+  overrides exceed the limit.
+- ``bunking/sync/bunk_request_processor/orchestrator/orchestrator.py`` — sync-
+  time spread filter on incoming bunk requests."""
+
+PREFERRED_AGE_SPREAD_MONTHS = 18
+"""Soft target: bunks with spread <= ``PREFERRED_AGE_SPREAD_MONTHS`` earn a
+tunable objective bonus (``constraint.age_spread.preferred_bonus``, kept as a
+runtime knob). Bumped from the prior seed of 12 per staff intent — tighter
+clusters that approximate single-grade cabins are the goal, but the prior
+12-month target was too aggressive in practice."""

--- a/bunking/solver/constants.py
+++ b/bunking/solver/constants.py
@@ -96,3 +96,10 @@ tunable objective bonus (``constraint.age_spread.preferred_bonus``, kept as a
 runtime knob). Bumped from the prior seed of 12 per staff intent — tighter
 clusters that approximate single-grade cabins are the goal, but the prior
 12-month target was too aggressive in practice."""
+
+EDGE_AGE_OVERFLOW_PENALTY = 15_000
+"""Penalty charged when an edge bunk (lowest or highest level for its gender/session)
+exceeds MAX_AGE_SPREAD_MONTHS. Not exposed as a config knob — fires only when a hard
+constraint (MSO, locked group) leaves no other option. Set above the typical soft-objective
+gains the solver would otherwise chase (bunk-with weights are in the hundreds to low
+thousands), so overflow never happens for non-structural reasons."""

--- a/bunking/solver/constants.py
+++ b/bunking/solver/constants.py
@@ -27,9 +27,13 @@ disconnected from solver behavior), ``constraint.age_spread.penalty`` (soft
 violation path being deleted), ``constraint.age_spread.preferred_months``
 (seed=12, bumped to 18 here per staff intent), the validator's parallel
 hardcoded ``24``, and the orphan ``DEFAULT_AGE_SPREAD_MONTHS`` in
-``bunking/sync/.../core/constants.py`` into the two constants below. Solver
-is hard-only. ``constraint.age_spread.preferred_bonus`` is KEPT in the config
-as the lone tunable knob in this domain.
+``bunking/sync/.../core/constants.py`` into the three constants below
+(``MAX_AGE_SPREAD_MONTHS``, ``PREFERRED_AGE_SPREAD_MONTHS``,
+``EDGE_AGE_OVERFLOW_PENALTY``). Middle bunks treat the cap as hard;
+edge bunks (lowest/highest level per gender+session) get a soft escape
+hatch via ``EDGE_AGE_OVERFLOW_PENALTY`` so a hard MSO chain into the top
+cabin remains feasible. ``constraint.age_spread.preferred_bonus`` is KEPT
+in the config as the lone tunable knob in this domain.
 
 If per-bunk variance is ever needed (e.g., a smaller specialty cabin), add a
 real ``max_size`` integer column on the ``bunks`` PocketBase collection with a
@@ -76,13 +80,17 @@ Reads:
   which is gone)."""
 
 MAX_AGE_SPREAD_MONTHS = 24
-"""Hard ceiling for age range (months) within a non-AG bunk. Solver never
-emits a bunk with ``max_age - min_age > MAX_AGE_SPREAD_MONTHS``. Staff can
+"""Ceiling for age range (months) within a non-AG bunk. Enforced as a hard
+CP-SAT constraint for middle bunks (the solver is INFEASIBLE if a middle bunk
+exceeds it); for edge bunks (lowest/highest level per gender+session) the
+solver may exceed it by paying ``EDGE_AGE_OVERFLOW_PENALTY`` — fires only
+when a hard constraint (MSO chain, locked group) forces it. Staff can
 override on the bunking board — the board allows >24mo with a display warning
 (same asymmetry as ``MAX_BUNK_CAPACITY`` / ``MAX_UNIQUE_GRADES_PER_BUNK``).
 Reads:
 
-- ``bunking/solver/constraints/age_spread.py`` — hard CP-SAT constraint.
+- ``bunking/solver/constraints/age_spread.py`` — hard CP-SAT constraint
+  (middle bunks) + soft edge escape hatch.
 - ``bunking/solver/feasibility.py:_explain_age_spread_infeasibility`` — when
   the hard cap causes INFEASIBLE, surfaces a staff-actionable message.
 - ``bunking/bunking_validator.py`` — board-side warning when staff manual

--- a/bunking/solver/constraints/age_spread.py
+++ b/bunking/solver/constraints/age_spread.py
@@ -17,12 +17,13 @@ from __future__ import annotations
 
 from bunking.logging_config import get_logger
 from bunking.solver.constants import (
+    EDGE_AGE_OVERFLOW_PENALTY,
     MAX_AGE_SPREAD_MONTHS,
     PREFERRED_AGE_SPREAD_MONTHS,
 )
 
 from .base import SolverContext
-from .helpers import get_eligible_campers_for_bunk, is_ag_session_bunk
+from .helpers import get_eligible_campers_for_bunk, is_ag_session_bunk, is_edge_bunk_for_grades
 
 logger = get_logger(__name__)
 
@@ -35,19 +36,23 @@ def _age_to_months(age: float) -> int:
 
 
 def add_age_spread_constraints(ctx: SolverContext) -> None:
-    """Add hard age spread constraint + soft preferred-bonus path per non-AG bunk.
+    """Add age spread constraints per non-AG bunk.
 
-    Two-tier age spread system:
-    - Hard ceiling: ``spread <= MAX_AGE_SPREAD_MONTHS`` per non-AG bunk. Solver
-      never emits a bunk that violates this; staff can override on the
-      bunking board (board flags >24mo with a warning via the validator).
-    - Preferred bonus (soft): when ``spread <= PREFERRED_AGE_SPREAD_MONTHS``,
-      an objective bonus is added — encouraging tighter age clusters that
-      approximate single-grade cabins. Disabled when the configured bonus
-      weight is 0.
-
-    Uses TRUE min/max aggregation to reduce constraint count from O(n²) to
-    O(bunks).
+    Three-tier system:
+    - **Middle bunks** (not lowest/highest for their gender+session): hard cap
+      ``spread <= MAX_AGE_SPREAD_MONTHS``. Solver is INFEASIBLE if two campers
+      >24mo apart are forced in — there are always adjacent bunks to absorb
+      outliers, so no structural exception is warranted.
+    - **Edge bunks** (lowest or highest level for gender+session, including the
+      only bunk in a session): soft escape hatch via a reified
+      ``edge_age_overflow_b{idx}`` BoolVar. The 24mo cap is enforced only when
+      the bool is False; when True, ``EDGE_AGE_OVERFLOW_PENALTY`` is charged.
+      Since MSO satisfaction is a hard constraint, the solver sets this True only
+      when structurally forced (e.g., a hard bunk-with chain into the top cabin) —
+      never as a casual optimization choice.
+    - **Preferred bonus** (soft): bunks with spread <= ``PREFERRED_AGE_SPREAD_MONTHS``
+      earn a configurable bonus, regardless of edge/middle status. Disabled when
+      the configured bonus weight is 0.
     """
     if ctx.is_constraint_disabled("age_spread"):
         logger.info("Age spread constraints DISABLED via debug settings")
@@ -57,13 +62,14 @@ def add_age_spread_constraints(ctx: SolverContext) -> None:
     preferred_active = preferred_age_spread_bonus > 0
 
     logger.debug(
-        f"Adding hard age spread constraints (max {MAX_AGE_SPREAD_MONTHS}mo,"
+        f"Adding age spread constraints (max {MAX_AGE_SPREAD_MONTHS}mo,"
         f" preferred {PREFERRED_AGE_SPREAD_MONTHS}mo, bonus {preferred_age_spread_bonus},"
         f" preferred_active={preferred_active})"
     )
 
     bonus_count = 0
     bunk_count = 0
+    edge_count = 0
 
     for bunk_idx, bunk in enumerate(ctx.bunks):
         if is_ag_session_bunk(bunk):
@@ -100,8 +106,19 @@ def add_age_spread_constraints(ctx: SolverContext) -> None:
         spread = ctx.model.NewIntVar(0, max_possible - min_possible, f"age_spread_b{bunk_idx}")
         ctx.model.Add(spread == max_age_in_bunk - min_age_in_bunk)
 
-        # HARD: solver may never emit spread > MAX_AGE_SPREAD_MONTHS
-        ctx.model.Add(spread <= MAX_AGE_SPREAD_MONTHS)
+        is_edge, _ = is_edge_bunk_for_grades(bunk, ctx.bunks)
+        if is_edge:
+            # Soft escape hatch: solver pays EDGE_AGE_OVERFLOW_PENALTY to exceed 24mo.
+            # Only fires when a hard constraint (MSO, locked group) forces it.
+            edge_overflow = ctx.model.NewBoolVar(f"edge_age_overflow_b{bunk_idx}")
+            ctx.model.Add(spread <= MAX_AGE_SPREAD_MONTHS).OnlyEnforceIf(edge_overflow.Not())
+            ctx.soft_constraint_violations[f"edge_age_overflow_b{bunk_idx}"] = (
+                edge_overflow,
+                EDGE_AGE_OVERFLOW_PENALTY,
+            )
+            edge_count += 1
+        else:
+            ctx.model.Add(spread <= MAX_AGE_SPREAD_MONTHS)
 
         if preferred_active:
             within_preferred = ctx.model.NewBoolVar(f"age_spread_preferred_b{bunk_idx}")
@@ -113,4 +130,7 @@ def add_age_spread_constraints(ctx: SolverContext) -> None:
             )
             bonus_count += 1
 
-    logger.debug(f"Age spread: hard cap applied across {bunk_count} bunks with {bonus_count} preferred-bonus entries")
+    logger.debug(
+        f"Age spread: hard cap across {bunk_count - edge_count} middle bunks,"
+        f" escape hatch across {edge_count} edge bunks, {bonus_count} preferred-bonus entries"
+    )

--- a/bunking/solver/constraints/age_spread.py
+++ b/bunking/solver/constraints/age_spread.py
@@ -1,14 +1,25 @@
 """
-Age Spread Constraints - Limit age range within bunks.
+Age Spread Constraints - Hard cap on age range within non-AG bunks.
 
-This is a soft constraint that penalizes bunks where the age spread
-(max age - min age in months) exceeds the configured limit.
-Uses TRUE min/max aggregation to reduce constraint count from O(n²) to O(bunks).
+Enforces ``max_age_months - min_age_months <= MAX_AGE_SPREAD_MONTHS`` per
+non-AG bunk. Bunks with spread within ``PREFERRED_AGE_SPREAD_MONTHS`` earn a
+configurable soft bonus (``constraint.age_spread.preferred_bonus``). Uses TRUE
+min/max aggregation to reduce constraint count from O(n²) to O(bunks).
+
+Phase 2 collapsed the prior soft penalty path (``excess_spread`` /
+``has_violation`` reified machinery) into the single hard constraint above —
+the soft path was being absorbed by ~6% of bunks in production, and the
+hard cap moves that infeasibility upstream where the feasibility-warning hook
+in ``bunking/solver/feasibility.py`` can surface a staff-actionable message.
 """
 
 from __future__ import annotations
 
 from bunking.logging_config import get_logger
+from bunking.solver.constants import (
+    MAX_AGE_SPREAD_MONTHS,
+    PREFERRED_AGE_SPREAD_MONTHS,
+)
 
 from .base import SolverContext
 from .helpers import get_eligible_campers_for_bunk, is_ag_session_bunk
@@ -24,134 +35,82 @@ def _age_to_months(age: float) -> int:
 
 
 def add_age_spread_constraints(ctx: SolverContext) -> None:
-    """Add aggregated soft constraints for age spread within bunks.
+    """Add hard age spread constraint + soft preferred-bonus path per non-AG bunk.
 
     Two-tier age spread system:
-    - Soft penalty (violation-based): when spread > max_age_spread_months, a violation flag is set
-      and penalised in the objective (preserves existing 24mo behaviour).
-    - Preferred threshold (soft-bonus): when spread <= preferred_age_spread_months, a bonus
-      flag is set and added to the objective, encouraging tighter age grouping.
-      Disabled when preferred_age_spread_months == 0 or == max_age_spread_months.
+    - Hard ceiling: ``spread <= MAX_AGE_SPREAD_MONTHS`` per non-AG bunk. Solver
+      never emits a bunk that violates this; staff can override on the
+      bunking board (board flags >24mo with a warning via the validator).
+    - Preferred bonus (soft): when ``spread <= PREFERRED_AGE_SPREAD_MONTHS``,
+      an objective bonus is added — encouraging tighter age clusters that
+      approximate single-grade cabins. Disabled when the configured bonus
+      weight is 0.
 
-    Uses TRUE min/max aggregation to reduce constraint count from O(n²) to O(bunks).
+    Uses TRUE min/max aggregation to reduce constraint count from O(n²) to
+    O(bunks).
     """
     if ctx.is_constraint_disabled("age_spread"):
         logger.info("Age spread constraints DISABLED via debug settings")
         return
 
-    max_age_spread_months = ctx.config.get_constraint("age_spread", "months", default=24)
-
-    # Get weight for age spread violations - high weight to prioritize
-    age_spread_weight = ctx.config.get_soft_constraint_weight("age_spread")
-
-    # New: preferred (soft-bonus) threshold
-    preferred_age_spread_months = ctx.config.get_constraint("age_spread", "preferred_months", default=0)
-    preferred_age_spread_bonus = ctx.config.get_constraint("age_spread", "preferred_bonus", default=0)
-
-    # Preferred threshold is only active when it is strictly less than the max limit
-    # and both values are non-zero.
-    preferred_active = (
-        preferred_age_spread_months > 0
-        and preferred_age_spread_months < max_age_spread_months
-        and preferred_age_spread_bonus > 0
-    )
+    preferred_age_spread_bonus = ctx.config.get_constraint("age_spread", "preferred_bonus")
+    preferred_active = preferred_age_spread_bonus > 0
 
     logger.debug(
-        f"Adding TRUE min/max age spread constraints (max {max_age_spread_months} months, weight {age_spread_weight},"
-        f" preferred {preferred_age_spread_months} months, bonus {preferred_age_spread_bonus},"
+        f"Adding hard age spread constraints (max {MAX_AGE_SPREAD_MONTHS}mo,"
+        f" preferred {PREFERRED_AGE_SPREAD_MONTHS}mo, bonus {preferred_age_spread_bonus},"
         f" preferred_active={preferred_active})"
     )
 
-    violation_count = 0
     bonus_count = 0
     bunk_count = 0
 
-    # For each bunk, track min and max age
     for bunk_idx, bunk in enumerate(ctx.bunks):
-        # Skip AG bunks - they have no constraints
         if is_ag_session_bunk(bunk):
             continue
 
-        # Get only eligible campers for this bunk
         eligible_campers = get_eligible_campers_for_bunk(ctx, bunk)
-
         if len(eligible_campers) < 2:
             continue
 
         bunk_count += 1
 
-        # Convert ages to months for all eligible campers
         age_months_data = []
         for person_idx, person in eligible_campers:
             if hasattr(person, "age"):
                 age_months = _age_to_months(person.age)
             else:
-                # Fallback: estimate based on grade
-                age_months = person.grade * 12 + 120  # Assume grade 1 = 10 years old
+                age_months = person.grade * 12 + 120
             age_months_data.append((person_idx, age_months))
 
-        # Find possible min/max age values
         all_ages = [age for _, age in age_months_data]
         min_possible = min(all_ages)
         max_possible = max(all_ages)
 
-        # Create variables for min and max age in this bunk
         min_age_in_bunk = ctx.model.NewIntVar(min_possible, max_possible, f"min_age_months_b{bunk_idx}")
         max_age_in_bunk = ctx.model.NewIntVar(min_possible, max_possible, f"max_age_months_b{bunk_idx}")
 
-        # For each eligible camper, update min/max when they're assigned
         for person_idx, age_months in age_months_data:
             is_in_bunk = ctx.assignments[(person_idx, bunk_idx)]
-
-            # When person is in bunk, their age constrains min/max
-            # min_age <= age_months when person is in bunk
             ctx.model.Add(min_age_in_bunk <= age_months).OnlyEnforceIf(is_in_bunk)
-
-            # max_age >= age_months when person is in bunk
             ctx.model.Add(max_age_in_bunk >= age_months).OnlyEnforceIf(is_in_bunk)
 
-        # Ensure min <= max always
         ctx.model.Add(min_age_in_bunk <= max_age_in_bunk)
 
-        # Calculate the spread
         spread = ctx.model.NewIntVar(0, max_possible - min_possible, f"age_spread_b{bunk_idx}")
         ctx.model.Add(spread == max_age_in_bunk - min_age_in_bunk)
 
-        # Create excess spread variable (how much over the limit)
-        excess_spread = ctx.model.NewIntVar(0, max_possible - min_possible, f"excess_age_spread_b{bunk_idx}")
+        # HARD: solver may never emit spread > MAX_AGE_SPREAD_MONTHS
+        ctx.model.Add(spread <= MAX_AGE_SPREAD_MONTHS)
 
-        # excess = max(0, spread - max_age_spread_months)
-        ctx.model.AddMaxEquality(excess_spread, [0, spread - max_age_spread_months])
-
-        # Create violation indicator (true when excess > 0)
-        has_violation = ctx.model.NewBoolVar(f"age_spread_violation_b{bunk_idx}")
-        ctx.model.Add(excess_spread > 0).OnlyEnforceIf(has_violation)
-        ctx.model.Add(excess_spread == 0).OnlyEnforceIf(has_violation.Not())
-
-        # Store violation with penalty
-        if age_spread_weight > 0:
-            ctx.soft_constraint_violations[f"age_spread_b{bunk_idx}"] = (has_violation, age_spread_weight)
-
-            violation_count += 1
-
-        # New: preferred bonus — cabins with spread <= preferred_age_spread_months earn a bonus
         if preferred_active:
-            # within_preferred = 1 when spread <= preferred_age_spread_months
             within_preferred = ctx.model.NewBoolVar(f"age_spread_preferred_b{bunk_idx}")
-
-            # spread <= preferred ↔ within_preferred == 1
-            # Using big-M style enforced constraints:
-            ctx.model.Add(spread <= preferred_age_spread_months).OnlyEnforceIf(within_preferred)
-            ctx.model.Add(spread > preferred_age_spread_months).OnlyEnforceIf(within_preferred.Not())
-
+            ctx.model.Add(spread <= PREFERRED_AGE_SPREAD_MONTHS).OnlyEnforceIf(within_preferred)
+            ctx.model.Add(spread > PREFERRED_AGE_SPREAD_MONTHS).OnlyEnforceIf(within_preferred.Not())
             ctx.soft_constraint_bonuses[f"age_spread_preferred_b{bunk_idx}"] = (
                 within_preferred,
                 preferred_age_spread_bonus,
             )
-
             bonus_count += 1
 
-    logger.debug(
-        f"Age spread: applied {violation_count} violation entries + {bonus_count} bonus entries"
-        f" across {bunk_count} bunks"
-    )
+    logger.debug(f"Age spread: hard cap applied across {bunk_count} bunks with {bonus_count} preferred-bonus entries")

--- a/bunking/solver/constraints/age_spread.py
+++ b/bunking/solver/constraints/age_spread.py
@@ -1,16 +1,22 @@
 """
-Age Spread Constraints - Hard cap on age range within non-AG bunks.
+Age Spread Constraints - cap on age range within non-AG bunks.
 
 Enforces ``max_age_months - min_age_months <= MAX_AGE_SPREAD_MONTHS`` per
-non-AG bunk. Bunks with spread within ``PREFERRED_AGE_SPREAD_MONTHS`` earn a
-configurable soft bonus (``constraint.age_spread.preferred_bonus``). Uses TRUE
-min/max aggregation to reduce constraint count from O(n²) to O(bunks).
+non-AG bunk. Middle bunks treat this as a hard constraint; edge bunks (lowest
+or highest level for their gender+session) get a soft escape hatch with
+``EDGE_AGE_OVERFLOW_PENALTY`` so structurally forced overflow (e.g., hard
+MSO chains into the top cabin) is feasible. Bunks with spread within
+``PREFERRED_AGE_SPREAD_MONTHS`` earn a configurable soft bonus
+(``constraint.age_spread.preferred_bonus``). Uses TRUE min/max aggregation
+to reduce constraint count from O(n²) to O(bunks).
 
-Phase 2 collapsed the prior soft penalty path (``excess_spread`` /
-``has_violation`` reified machinery) into the single hard constraint above —
-the soft path was being absorbed by ~6% of bunks in production, and the
-hard cap moves that infeasibility upstream where the feasibility-warning hook
-in ``bunking/solver/feasibility.py`` can surface a staff-actionable message.
+Phase 2 collapsed the prior all-bunks soft penalty path (``excess_spread`` /
+``has_violation`` reified machinery, absorbed by ~6% of bunks in production)
+into the current hard-middle / soft-edge split — the validator
+(``bunking/bunking_validator.py``) still warns post-solve on any >24mo
+spread regardless of edge/middle, and the feasibility-warning hook in
+``bunking/solver/feasibility.py`` surfaces a staff-actionable message when
+a middle bunk forces infeasibility.
 """
 
 from __future__ import annotations

--- a/bunking/solver/constraints/age_spread.py
+++ b/bunking/solver/constraints/age_spread.py
@@ -127,9 +127,21 @@ def add_age_spread_constraints(ctx: SolverContext) -> None:
             ctx.model.Add(spread <= MAX_AGE_SPREAD_MONTHS)
 
         if preferred_active:
+            # Gate the bonus on (spread within preferred) AND (bunk is used). Without the
+            # bunk-used gate, empty bunks' unconstrained min/max IntVars let the solver pick
+            # spread = 0 and claim the bonus for free, skewing the objective.
+            is_tight = ctx.model.NewBoolVar(f"age_spread_tight_b{bunk_idx}")
+            ctx.model.Add(spread <= PREFERRED_AGE_SPREAD_MONTHS).OnlyEnforceIf(is_tight)
+            ctx.model.Add(spread > PREFERRED_AGE_SPREAD_MONTHS).OnlyEnforceIf(is_tight.Not())
+
+            bunk_used = ctx.model.NewBoolVar(f"age_spread_bunk_used_b{bunk_idx}")
+            bunk_assignments = [ctx.assignments[(p_idx, bunk_idx)] for p_idx, _ in age_months_data]
+            ctx.model.AddMaxEquality(bunk_used, bunk_assignments)
+
             within_preferred = ctx.model.NewBoolVar(f"age_spread_preferred_b{bunk_idx}")
-            ctx.model.Add(spread <= PREFERRED_AGE_SPREAD_MONTHS).OnlyEnforceIf(within_preferred)
-            ctx.model.Add(spread > PREFERRED_AGE_SPREAD_MONTHS).OnlyEnforceIf(within_preferred.Not())
+            ctx.model.AddImplication(within_preferred, is_tight)
+            ctx.model.AddImplication(within_preferred, bunk_used)
+            ctx.model.AddBoolOr([within_preferred, is_tight.Not(), bunk_used.Not()])
             ctx.soft_constraint_bonuses[f"age_spread_preferred_b{bunk_idx}"] = (
                 within_preferred,
                 preferred_age_spread_bonus,

--- a/bunking/solver/feasibility.py
+++ b/bunking/solver/feasibility.py
@@ -12,7 +12,8 @@ from typing import TYPE_CHECKING, Any, TypedDict
 from ortools.sat.python import cp_model
 
 from bunking.logging_config import get_logger
-from bunking.solver.constants import MAX_UNIQUE_GRADES_PER_BUNK
+from bunking.solver.constants import MAX_AGE_SPREAD_MONTHS, MAX_UNIQUE_GRADES_PER_BUNK
+from bunking.solver.constraints.age_spread import _age_to_months
 
 if TYPE_CHECKING:
     from bunking.config import ConfigLoader
@@ -291,6 +292,7 @@ def find_infeasibility_cause(
         "session_boundary",
         "parent_paramount",  # supersedes the former must_satisfy_one probe
         "grade_spread",
+        "age_spread",
         "gender",
         "level_progression",
         "group_locks",
@@ -343,11 +345,48 @@ def find_infeasibility_cause(
                 actionable = _explain_grade_spread_infeasibility(input_data)
                 if actionable is not None:
                     return actionable
+            elif constraint == "age_spread":
+                actionable = _explain_age_spread_infeasibility(input_data)
+                if actionable is not None:
+                    return actionable
             return f"The {constraint} constraint is causing infeasibility"
 
     # If still infeasible with each individual constraint disabled, try combinations
     logger.info("No single constraint removal fixed it. The issue may be a combination.")
     return "Infeasibility caused by multiple interacting constraints"
+
+
+def _explain_age_spread_infeasibility(input_data: DirectSolverInput) -> str | None:
+    """Return a staff-actionable diagnosis when a locked group exceeds ``MAX_AGE_SPREAD_MONTHS``.
+
+    The hard ``MAX_AGE_SPREAD_MONTHS`` ceiling makes one new infeasibility
+    class possible: a locked group whose members span more than that many
+    months in age cannot fit any non-AG bunk. Surface that with the offending
+    group + the next action (split on the bunking board, or accept the manual
+    override).
+
+    Returns ``None`` if no locked group exceeds the limit — the caller falls
+    back to the generic ``"The age_spread constraint is causing
+    infeasibility"`` message in that case.
+    """
+    person_by_cm = input_data.person_by_cm_id
+    for group_id, member_cms in input_data.group_locks.items():
+        ages_months = []
+        for cm in member_cms:
+            person = person_by_cm.get(cm)
+            if person is not None and hasattr(person, "age"):
+                ages_months.append(_age_to_months(person.age))
+        if len(ages_months) < 2:
+            continue
+        spread = max(ages_months) - min(ages_months)
+        if spread > MAX_AGE_SPREAD_MONTHS:
+            return (
+                f"Cannot solve within the {MAX_AGE_SPREAD_MONTHS}-month age "
+                f"spread limit: locked group {group_id!r} spans {spread} months "
+                f"— split the group on the bunking board or accept the manual "
+                f"override."
+            )
+    return None
 
 
 def _explain_grade_spread_infeasibility(input_data: DirectSolverInput) -> str | None:

--- a/bunking/solver/observability.py
+++ b/bunking/solver/observability.py
@@ -180,6 +180,7 @@ _SOFT_CONSTRAINT_PREFIXES: tuple[tuple[str, str], ...] = (
     ("grade_ratio_", "grade_ratio"),
     ("level_regression_", "level_regression"),
     ("age_spread_b", "age_spread"),
+    ("edge_age_overflow_b", "age_spread"),
 )
 
 

--- a/bunking/sync/bunk_request_processor/core/constants.py
+++ b/bunking/sync/bunk_request_processor/core/constants.py
@@ -37,7 +37,8 @@ PRIORITY_KEYWORDS: tuple[str, ...] = (
 
 # Age filtering constants
 MAX_AGE_DIFFERENCE_MONTHS = 36  # For pre-filtering candidates
-DEFAULT_AGE_SPREAD_MONTHS = 24  # For validation warnings
+# DEFAULT_AGE_SPREAD_MONTHS deleted in Age Spread Phase 2 — use
+# bunking.solver.constants.MAX_AGE_SPREAD_MONTHS (the single source of truth).
 
 # Confidence thresholds
 # These define base confidence values for match types and status thresholds.

--- a/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
+++ b/bunking/sync/bunk_request_processor/orchestrator/orchestrator.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from bunking.config.loader import ConfigLoader
 from bunking.logging_config import get_logger
-from bunking.solver.constants import MAX_UNIQUE_GRADES_PER_BUNK
+from bunking.solver.constants import MAX_AGE_SPREAD_MONTHS, MAX_UNIQUE_GRADES_PER_BUNK
 from pocketbase import PocketBase
 
 if TYPE_CHECKING:
@@ -724,18 +724,15 @@ class RequestOrchestrator:
             year=self.year,
         )
 
-        # Create spread filter from unified spread.* config
-        from bunking.config.loader import ConfigLoader
-
+        # Create spread filter from MAX_AGE_SPREAD_MONTHS / MAX_UNIQUE_GRADES_PER_BUNK constants
         from ..name_resolution.filters.spread_filter import SpreadFilter
 
-        config_loader = ConfigLoader()
         spread_enabled = self.ai_config.get("spread_validation", {}).get("enabled", True)
         spread_filter: SpreadFilter | None
         if spread_enabled:
             spread_filter = SpreadFilter(
                 grade_spread=MAX_UNIQUE_GRADES_PER_BUNK,
-                age_spread_months=config_loader.get_int("spread.max_age_months", default=24),
+                age_spread_months=MAX_AGE_SPREAD_MONTHS,
             )
         else:
             spread_filter = None

--- a/pocketbase/pb_migrations/1500000011_config.js
+++ b/pocketbase/pb_migrations/1500000011_config.js
@@ -178,9 +178,9 @@ migrate((app) => {
     // Constraint Settings - Age & Grade (unified spread limits)
     // spread.max_grade + constraint.grade_spread.{mode, penalty} removed in
     // Phase 2 cleanup (collapsed to MAX_UNIQUE_GRADES_PER_BUNK).
-    'spread.max_age_months': 'Max Age Difference (months)',
-    'constraint.age_spread.penalty': 'Age Spread Violation Penalty',
-    'constraint.age_spread.preferred_months': 'Preferred Age Spread (months)',
+    // spread.max_age_months + constraint.age_spread.{penalty, preferred_months}
+    // removed in Age Spread Phase 2 (collapsed to MAX_AGE_SPREAD_MONTHS and
+    // PREFERRED_AGE_SPREAD_MONTHS). Only the bonus knob remains.
     'constraint.age_spread.preferred_bonus': 'Preferred Age Spread Bonus',
     'constraint.grade_ratio.max_percentage': 'Max Single Grade Percentage',
     'constraint.grade_ratio.penalty': 'Grade Ratio Violation Penalty',
@@ -244,9 +244,9 @@ migrate((app) => {
     // Constraint Settings - Age & Grade (unified spread limits)
     // spread.max_grade + constraint.grade_spread.{mode, penalty} removed in
     // Phase 2 cleanup (collapsed to MAX_UNIQUE_GRADES_PER_BUNK).
-    'spread.max_age_months': 'Maximum age difference in months allowed in bunks and bunk requests',
-    'constraint.age_spread.penalty': 'Penalty weight for exceeding age spread limit',
-    'constraint.age_spread.preferred_months': 'Cabins at or below this spread earn a bonus (0 = disabled). Must be less than Max Age Difference.',
+    // spread.max_age_months + constraint.age_spread.{penalty, preferred_months}
+    // removed in Age Spread Phase 2 (collapsed to MAX_AGE_SPREAD_MONTHS and
+    // PREFERRED_AGE_SPREAD_MONTHS).
     'constraint.age_spread.preferred_bonus': 'Objective bonus for each cabin within the preferred age spread. Higher = solver tries harder to form tight age groups.',
     'constraint.grade_ratio.max_percentage': 'Maximum percentage of cabin that can be from a single grade',
     'constraint.grade_ratio.penalty': 'Penalty weight for exceeding grade ratio limit',
@@ -312,9 +312,8 @@ migrate((app) => {
     // Age & Grade (unified spread limits)
     // spread.max_grade + constraint.grade_spread.{mode, penalty} removed in
     // Phase 2 cleanup (collapsed to MAX_UNIQUE_GRADES_PER_BUNK).
-    'spread.max_age_months': 'age-grade',
-    'constraint.age_spread.penalty': 'age-grade',
-    'constraint.age_spread.preferred_months': 'age-grade',
+    // spread.max_age_months + constraint.age_spread.{penalty, preferred_months}
+    // removed in Age Spread Phase 2.
     'constraint.age_spread.preferred_bonus': 'age-grade',
     'constraint.grade_ratio.max_percentage': 'age-grade',
     'constraint.grade_ratio.penalty': 'age-grade',
@@ -587,10 +586,6 @@ migrate((app) => {
       component_type: "number",
       component_config: { min: 0, max: 10000, step: 100 }
     },
-    "constraint.age_spread.preferred_months": {
-      component_type: "number",
-      component_config: { min: 0, max: 60, step: 1, suffix: " months" }
-    },
     "constraint.age_spread.preferred_bonus": {
       component_type: "slider",
       component_config: { min: 0, max: 10000, step: 100, showValue: true }
@@ -692,25 +687,10 @@ migrate((app) => {
     // Unified spread limits (used by both solver and request processor).
     // spread.max_grade removed in Phase 2 cleanup (collapsed to
     // MAX_UNIQUE_GRADES_PER_BUNK constant in bunking/solver/constants.py).
-    "spread.max_age_months": {
-      value: 24,
-      description: "Maximum age difference in months allowed in bunks and bunk requests",
-      min: 12,
-      max: 48
-    },
-
-    "constraint.age_spread.penalty": {
-      value: 1500,
-      description: "Penalty for age spread violations",
-      min: 0,
-      max: 10000
-    },
-    "constraint.age_spread.preferred_months": {
-      value: 12,
-      description: "Preferred age spread in months — cabins at or below this spread earn a bonus (0 = disabled)",
-      min: 0,
-      max: 60
-    },
+    // spread.max_age_months + constraint.age_spread.{penalty, preferred_months}
+    // removed in Age Spread Phase 2 (collapsed to MAX_AGE_SPREAD_MONTHS and
+    // PREFERRED_AGE_SPREAD_MONTHS constants). Only the bonus weight remains
+    // tunable.
     "constraint.age_spread.preferred_bonus": {
       value: 500,
       description: "Bonus weight for cabins whose age spread is within the preferred threshold",

--- a/pocketbase/pb_migrations/1500000107_drop_age_spread_orphan_configs.js
+++ b/pocketbase/pb_migrations/1500000107_drop_age_spread_orphan_configs.js
@@ -1,0 +1,148 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: drop the three dead age_spread config rows.
+ *
+ * Phase 2 (Age Spread) collapsed:
+ *  - ``spread.max_age_months`` (sync-side filter; never reached the solver
+ *    because the solver read a phantom ``constraint.age_spread.months`` key
+ *    instead — see decisions doc)
+ *  - ``constraint.age_spread.penalty`` (only consumed by the soft path, which
+ *    is now deleted; in practice the soft path fired on ~6% of bunks and
+ *    became infeasibility once collapsed to hard)
+ *  - ``constraint.age_spread.preferred_months`` (paired with preferred_bonus
+ *    to give tight cabins an objective boost; the threshold is now the
+ *    hardcoded ``PREFERRED_AGE_SPREAD_MONTHS = 18`` constant, bumped from
+ *    the prior seed of 12 per staff intent)
+ *
+ * into ``MAX_AGE_SPREAD_MONTHS = 24`` and ``PREFERRED_AGE_SPREAD_MONTHS = 18``
+ * in ``bunking/solver/constants.py``.
+ * ``constraint.age_spread.preferred_bonus`` is KEPT as the lone runtime knob
+ * in this domain.
+ *
+ * Idempotent: re-running after rows are gone is a no-op.
+ *
+ * Down-migration restores the rows with the pre-cleanup seeded values so a
+ * rollback returns the config table to its prior state. Metadata fields
+ * mirror the seed migration's metadata-builder so the admin GUI re-recognizes
+ * the rows after rollback.
+ */
+// Build a filter that matches both NULL and "" subcategory for 2-part keys.
+const subcategoryFilter = (subcategory) =>
+  subcategory === null || subcategory === ""
+    ? "subcategory = null"
+    : `subcategory = "${subcategory}"`
+
+migrate(
+  (app) => {
+    const targets = [
+      { category: "spread", subcategory: null, config_key: "max_age_months" },
+      { category: "constraint", subcategory: "age_spread", config_key: "penalty" },
+      { category: "constraint", subcategory: "age_spread", config_key: "preferred_months" },
+    ]
+    for (const t of targets) {
+      let record
+      try {
+        record = app.findFirstRecordByFilter(
+          "config",
+          `category = "${t.category}" && ${subcategoryFilter(t.subcategory)} && config_key = "${t.config_key}"`,
+        )
+      } catch {
+        // already gone — ignore (findFirstRecordByFilter throws on no match)
+      }
+      // Delete runs OUTSIDE the catch so real delete errors (permissions, FK,
+      // runtime) surface instead of being silently swallowed.
+      if (record) app.delete(record)
+    }
+  },
+  (app) => {
+    // Down: re-create the three rows with original seeded values so rollback
+    // restores the pre-cleanup state.
+    const configCollection = app.findCollectionByNameOrId("config")
+    const seeds = [
+      {
+        category: "spread",
+        subcategory: null,
+        config_key: "max_age_months",
+        value: 24,
+        description: "Maximum age difference in months allowed in bunks and bunk requests",
+        metadata: {
+          data_type: "integer",
+          source: "default_config",
+          default_value: 24,
+          min_value: 12,
+          max_value: 48,
+          friendly_name: "Max Age Difference (months)",
+          tooltip: "Maximum age difference in months allowed in bunks and bunk requests",
+          section: "age-grade",
+          business_category: "solver",
+          component_type: "slider",
+          component_config: {},
+        },
+      },
+      {
+        category: "constraint",
+        subcategory: "age_spread",
+        config_key: "penalty",
+        value: 1500,
+        description: "Penalty for age spread violations",
+        metadata: {
+          data_type: "integer",
+          source: "default_config",
+          default_value: 1500,
+          min_value: 0,
+          max_value: 10000,
+          friendly_name: "Age Spread Violation Penalty",
+          tooltip: "Penalty weight for exceeding age spread limit",
+          section: "age-grade",
+          business_category: "solver",
+          component_type: "slider",
+          component_config: {},
+        },
+      },
+      {
+        category: "constraint",
+        subcategory: "age_spread",
+        config_key: "preferred_months",
+        value: 12,
+        description:
+          "Preferred age spread in months — cabins at or below this spread earn a bonus (0 = disabled)",
+        metadata: {
+          data_type: "integer",
+          source: "default_config",
+          default_value: 12,
+          min_value: 0,
+          max_value: 60,
+          friendly_name: "Preferred Age Spread (months)",
+          tooltip:
+            "Cabins at or below this spread earn a bonus (0 = disabled). Must be less than Max Age Difference.",
+          section: "age-grade",
+          business_category: "solver",
+          component_type: "number",
+          component_config: { min: 0, max: 60, step: 1, suffix: " months" },
+        },
+      },
+    ]
+
+    for (const seed of seeds) {
+      let existing
+      try {
+        existing = app.findFirstRecordByFilter(
+          "config",
+          `category = "${seed.category}" && ${subcategoryFilter(seed.subcategory)} && config_key = "${seed.config_key}"`,
+        )
+      } catch {
+        existing = null
+      }
+      if (existing) continue
+
+      const record = new Record(configCollection)
+      record.set("category", seed.category)
+      record.set("subcategory", seed.subcategory)
+      record.set("config_key", seed.config_key)
+      record.set("value", seed.value)
+      record.set("description", seed.description)
+      record.set("metadata", seed.metadata)
+      app.save(record)
+    }
+  },
+)

--- a/tests/config/test_loader.py
+++ b/tests/config/test_loader.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from bunking.config import ConfigLoader, MissingKeyError
+from bunking.config.errors import UnknownKeyError
 
 
 class TestGetSoftConstraintWeightNoDefault:
@@ -74,3 +75,31 @@ class TestLoaderFailsLoudOnMissingRequiredKey:
         assert validate_param.default is True, (
             f"validate_on_init default should be True, got {validate_param.default!r}"
         )
+
+
+class TestAgeSpreadRemovedFromWeightMappings:
+    """Age Spread Phase 2: age_spread is no longer routed through soft-weight mapping.
+
+    The hard MAX_AGE_SPREAD_MONTHS constant replaces constraint.age_spread.penalty.
+    Any residual ``get_soft_constraint_weight("age_spread")`` call should fall
+    through to the default key shape ``constraint.age_spread.weight``, which
+    isn't in CONFIG_SCHEMA → UnknownKeyError.
+    """
+
+    def test_get_soft_constraint_weight_age_spread_falls_through(self) -> None:
+        """Calling with 'age_spread' should resolve to constraint.age_spread.weight (not .penalty)."""
+        ConfigLoader.reset()
+        fake_collection = MagicMock()
+        fake_collection.get_first_list_item.side_effect = Exception("not found")
+        fake_pb = MagicMock()
+        fake_pb.collection.return_value = fake_collection
+
+        with patch("bunking.config.loader.PocketBase", return_value=fake_pb):
+            ConfigLoader.initialize(
+                pocketbase_url="http://127.0.0.1:19999",
+                validate_on_init=False,
+            )
+            loader = ConfigLoader.get_instance()
+            with pytest.raises(UnknownKeyError):
+                loader.get_soft_constraint_weight("age_spread")
+        ConfigLoader.reset()

--- a/tests/unit/bunking/solver/conftest.py
+++ b/tests/unit/bunking/solver/conftest.py
@@ -57,10 +57,6 @@ class MinimalConfigLoader:
             "constraint.cabin_capacity.penalty": 3000,
             "constraint.grade_ratio.max_percentage": 67,
             "constraint.grade_ratio.penalty": 1000,
-            "constraint.age_spread.max_months": 24,
-            "constraint.age_spread.months": 24,
-            "constraint.age_spread.penalty": 1500,
-            "constraint.age_spread.preferred_months": 0,
             "constraint.age_spread.preferred_bonus": 0,
             "constraint.must_satisfy_one.penalty": 100000,
             "constraint.age_grade_flow.weight": 10,
@@ -105,13 +101,17 @@ class MinimalConfigLoader:
         return self.get_int(key, default)
 
     def get_soft_constraint_weight(self, constraint_name: str) -> int:
-        """Get soft constraint weight value for the given constraint."""
+        """Get soft constraint weight value for the given constraint.
+
+        Mirrors ``ConfigLoader.get_soft_constraint_weight`` in production —
+        keep this dict in sync so test code can't silently pass on a key
+        that production now resolves to ``UnknownKeyError``.
+        """
         weight_mappings = {
-            "age_spread": "constraint.age_spread.penalty",
-            "grade_spread": "constraint.grade_spread.penalty",
+            # age_spread, grade_spread, must_satisfy_one removed in Phase 2 —
+            # see ``bunking/config/loader.py`` for the production mapping.
             "age_grade_flow": "constraint.age_grade_flow.weight",
             "grade_cohesion": "constraint.grade_cohesion.weight",
-            "must_satisfy_one": "constraint.must_satisfy_one.penalty",
         }
         key = weight_mappings.get(constraint_name, f"constraint.{constraint_name}.weight")
         return self.get_int(key)

--- a/tests/unit/bunking/solver/constraints/test_age_spread.py
+++ b/tests/unit/bunking/solver/constraints/test_age_spread.py
@@ -265,6 +265,50 @@ class TestPreferred18moBonus:
         # Only the tight cabin (8mo) earns the bonus; the loose one (20mo) does not.
         assert active_bonuses == 1, f"Expected exactly 1 bunk to earn preferred bonus, got {active_bonuses}"
 
+    def test_empty_bunk_does_not_claim_preferred_bonus(self):
+        """Unused bunks must not claim the preferred-age bonus.
+
+        Without a bunk-used gate, an empty bunk's ``min_age_in_bunk`` and
+        ``max_age_in_bunk`` IntVars are unconstrained (no camper triggers the
+        ``OnlyEnforceIf(is_in_bunk)`` bounds), so the solver picks
+        ``spread = 0 <= PREFERRED_AGE_SPREAD_MONTHS`` and the bonus fires for
+        free — skewing the objective.
+        """
+        bunk_a = create_bunk(cm_id=2001, name="B-1", gender="M", capacity=12)
+        bunk_b = create_bunk(cm_id=2002, name="B-2", gender="M", capacity=12)
+
+        campers = [
+            _person_with_age_months(1001, 144),
+            _person_with_age_months(1002, 150),
+        ]
+
+        ctx = build_solver_context(
+            persons=campers,
+            bunks=[bunk_a, bunk_b],
+            config_overrides={"constraint.age_spread.preferred_bonus": 500},
+        )
+
+        add_age_spread_constraints(ctx)
+        # Force all campers into B-2 (bunk_idx=1); B-1 (bunk_idx=0) stays empty.
+        ctx.model.Add(ctx.assignments[(0, 1)] == 1)
+        ctx.model.Add(ctx.assignments[(1, 1)] == 1)
+
+        # Maximize bonuses so the solver claims every bonus it can.
+        objective_terms = [weight * var for var, weight in ctx.soft_constraint_bonuses.values()]
+        if objective_terms:
+            ctx.model.Maximize(sum(objective_terms))
+
+        solver = cp_model.CpSolver()
+        status = solver.Solve(ctx.model)
+        assert is_optimal_or_feasible(status)
+
+        empty_var, _ = ctx.soft_constraint_bonuses["age_spread_preferred_b0"]
+        assert solver.Value(empty_var) == 0, (
+            "Empty bunk must not claim preferred-age bonus when no campers are assigned"
+        )
+        occupied_var, _ = ctx.soft_constraint_bonuses["age_spread_preferred_b1"]
+        assert solver.Value(occupied_var) == 1, "Occupied tight bunk should still claim the preferred-age bonus"
+
 
 class TestEdgeBunkCarveOut:
     """Edge bunks (lowest/highest level per gender+session) get a soft escape hatch

--- a/tests/unit/bunking/solver/constraints/test_age_spread.py
+++ b/tests/unit/bunking/solver/constraints/test_age_spread.py
@@ -1,16 +1,15 @@
 """
 Unit tests for age spread constraints.
 
-Tests both the existing 24mo soft penalty constraint and the new 12mo preferred
-threshold bonus (soft incentive for tighter age grouping).
+Phase 2 shape (post soft→hard collapse):
+- Hard constraint: ``spread <= MAX_AGE_SPREAD_MONTHS`` per non-AG bunk. Solver
+  is INFEASIBLE if two campers >24mo apart are forced into the same bunk.
+- Preferred bonus (soft): bunks with spread <= ``PREFERRED_AGE_SPREAD_MONTHS``
+  earn ``constraint.age_spread.preferred_bonus`` in the objective. Disabled
+  when the configured bonus weight is 0.
 
-Architecture:
-- 24mo threshold: soft penalty when spread > max_age_spread_months (weight from
-  constraint.age_spread.penalty)
-- 12mo preferred threshold: soft bonus when spread <= preferred_age_spread_months
-  (weight from constraint.age_spread.preferred_bonus)
-
-Both are implemented as objective-function terms (no hard infeasibility).
+The pre-Phase-2 ``excess_spread`` / ``has_violation`` machinery is gone —
+``soft_constraint_violations`` no longer contains any ``age_spread_*`` keys.
 """
 
 from __future__ import annotations
@@ -30,24 +29,15 @@ from ..conftest import (
 )
 
 
-# Helper: create a person with a specific age in total months
-# DirectPerson.age is a @property computed from birthdate.
-# We compute a birthdate that produces exactly total_months of age as of "now".
 def _person_with_age_months(cm_id: int, total_months: int, gender: str = "M") -> DirectPerson:
-    """Create a test person whose age converts to exactly total_months.
-
-    Uses a birthdate exactly total_months before today so DirectPerson.age
-    returns the right CampMinder-format value.
-    """
+    """Create a test person whose age converts to exactly total_months."""
     today = datetime.now(tz=UTC)
-    # Subtract total_months from today to get the birthdate
     birth_year = today.year - (total_months // 12)
     birth_month = today.month - (total_months % 12)
     if birth_month <= 0:
         birth_month += 12
         birth_year -= 1
-    # Use same day-of-month as today so fractional months are 0
-    birth_day = min(today.day, 28)  # avoid month-end edge cases
+    birth_day = min(today.day, 28)
     birthdate = f"{birth_year:04d}-{birth_month:02d}-{birth_day:02d}"
 
     return create_person(
@@ -60,204 +50,160 @@ def _person_with_age_months(cm_id: int, total_months: int, gender: str = "M") ->
     )
 
 
-def _solve_with_age_spread(campers, bunks, config_overrides=None):
-    """Build context with age spread constraints and solve. Returns (status, ctx, solver)."""
-    ctx = build_solver_context(
-        persons=campers,
-        bunks=bunks,
-        config_overrides=config_overrides or {},
-    )
+class TestHard24moConstraint:
+    """The hard cap: solver is INFEASIBLE if forced over the 24mo threshold."""
 
-    add_age_spread_constraints(ctx)
-
-    # Build objective from soft violations (penalties) and bonuses
-    objective_terms = []
-
-    # Penalty terms (violations): minimise these → subtract from Maximize
-    for var, weight in ctx.soft_constraint_violations.values():
-        objective_terms.append(-weight * var)
-
-    # Bonus terms: the bonus for preferred threshold
-    for var, weight in ctx.soft_constraint_bonuses.values():
-        objective_terms.append(weight * var)
-
-    if objective_terms:
-        ctx.model.Maximize(sum(objective_terms))
-
-    solver = cp_model.CpSolver()
-    status = solver.Solve(ctx.model)
-    return status, ctx, solver
-
-
-class TestExisting24moHardPenalty:
-    """Ensure the existing 24mo soft-penalty behaviour is unchanged."""
-
-    def test_spread_within_24mo_has_no_violation(self):
-        """Campers within 24mo spread → no age_spread violation registered."""
-        # Spread = 22 months (within 24mo limit)
+    def test_spread_at_24mo_boundary_is_feasible(self):
+        """Spread of exactly 24mo is allowed (boundary inclusive)."""
         campers = [
             _person_with_age_months(1001, 144),  # 12y 0m
-            _person_with_age_months(1002, 154),  # 12y 10m
-            _person_with_age_months(1003, 166),  # 13y 10m = 144+22
+            _person_with_age_months(1002, 168),  # 14y 0m  → 24mo spread
         ]
         bunk = create_bunk(cm_id=2001, name="B-1", gender="M", capacity=12)
 
         ctx = build_solver_context(
             persons=campers,
             bunks=[bunk],
-            config_overrides={
-                "constraint.age_spread.months": 24,
-                "constraint.age_spread.penalty": 1500,
-            },
+            config_overrides={"constraint.age_spread.preferred_bonus": 500},
         )
 
         add_age_spread_constraints(ctx)
+        # Force both campers into the same bunk
+        ctx.model.Add(ctx.assignments[(0, 0)] == 1)
+        ctx.model.Add(ctx.assignments[(1, 0)] == 1)
 
         solver = cp_model.CpSolver()
         status = solver.Solve(ctx.model)
 
         assert is_optimal_or_feasible(status)
-        # When all are in the single bunk, violation should be False
-        for key, (var, _weight) in ctx.soft_constraint_violations.items():
-            if "age_spread" in key:
-                assert solver.Value(var) == 0, f"Expected no violation for {key}"
 
-    def test_spread_exceeding_24mo_has_violation(self):
-        """Campers with >24mo spread → violation flag set."""
-        # Spread = 28 months (exceeds 24mo limit)
+    def test_spread_over_24mo_with_forced_assignment_is_infeasible(self):
+        """Two campers 25mo apart cannot share a non-AG bunk."""
         campers = [
             _person_with_age_months(1001, 144),  # 12y 0m
-            _person_with_age_months(1002, 172),  # 14y 4m = 144+28
+            _person_with_age_months(1002, 169),  # 14y 1m  → 25mo spread
         ]
         bunk = create_bunk(cm_id=2001, name="B-1", gender="M", capacity=12)
 
         ctx = build_solver_context(
             persons=campers,
             bunks=[bunk],
-            config_overrides={
-                "constraint.age_spread.months": 24,
-                "constraint.age_spread.penalty": 1500,
-            },
+            config_overrides={"constraint.age_spread.preferred_bonus": 500},
         )
 
         add_age_spread_constraints(ctx)
+        ctx.model.Add(ctx.assignments[(0, 0)] == 1)
+        ctx.model.Add(ctx.assignments[(1, 0)] == 1)
 
         solver = cp_model.CpSolver()
         status = solver.Solve(ctx.model)
 
-        assert is_optimal_or_feasible(status)
-        # When both are in the single bunk, violation should be True
-        violations = {k: v for k, v in ctx.soft_constraint_violations.items() if "age_spread" in k}
-        assert len(violations) >= 1, "Expected at least one age_spread violation entry"
-        for key, (var, weight) in violations.items():
-            assert solver.Value(var) == 1, f"Expected violation for {key} (28mo spread > 24mo max)"
-            assert weight == 1500
+        assert status == cp_model.INFEASIBLE
 
-    def test_penalty_weight_configurable(self):
-        """Penalty weight is read from config and stored correctly."""
+    def test_no_age_spread_entries_in_soft_violations(self):
+        """The soft penalty path is deleted — no `age_spread_*` violation keys."""
         campers = [
             _person_with_age_months(1001, 144),
-            _person_with_age_months(1002, 172),  # 28mo spread
+            _person_with_age_months(1002, 156),  # 12mo spread (well within)
         ]
         bunk = create_bunk(cm_id=2001, name="B-1", gender="M", capacity=12)
 
         ctx = build_solver_context(
             persons=campers,
             bunks=[bunk],
-            config_overrides={
-                "constraint.age_spread.months": 24,
-                "constraint.age_spread.penalty": 9999,
-            },
+            config_overrides={"constraint.age_spread.preferred_bonus": 500},
         )
 
         add_age_spread_constraints(ctx)
 
-        violations = {k: v for k, v in ctx.soft_constraint_violations.items() if "age_spread" in k}
-        assert len(violations) >= 1
-        for _var, weight in violations.values():
-            assert weight == 9999
+        age_spread_violation_keys = [k for k in ctx.soft_constraint_violations if "age_spread" in k]
+        assert age_spread_violation_keys == []
 
-
-class TestNew12moPreferredThreshold:
-    """Tests for the new 12mo preferred-spread bonus."""
-
-    def test_tight_cabin_earns_bonus_when_spread_within_12mo(self):
-        """A cabin with ≤12mo spread should get a preferred-threshold bonus."""
-        # Spread = 10 months (within 12mo preferred)
+    def test_skips_ag_bunks(self):
+        """AG bunks are exempt from the hard cap (existing behavior)."""
         campers = [
-            _person_with_age_months(1001, 144),  # 12y 0m
-            _person_with_age_months(1002, 150),  # 12y 6m
-            _person_with_age_months(1003, 154),  # 12y 10m = 144+10
+            _person_with_age_months(1001, 144),
+            _person_with_age_months(1002, 200),  # 56mo spread, would normally bind
+        ]
+        # AG bunks identified by name containing "AG"; gender-mixed is fine here.
+        bunk = create_bunk(cm_id=2001, name="AG-1", gender="M", capacity=12)
+
+        ctx = build_solver_context(
+            persons=campers,
+            bunks=[bunk],
+            config_overrides={"constraint.age_spread.preferred_bonus": 500},
+        )
+
+        add_age_spread_constraints(ctx)
+        ctx.model.Add(ctx.assignments[(0, 0)] == 1)
+        ctx.model.Add(ctx.assignments[(1, 0)] == 1)
+
+        solver = cp_model.CpSolver()
+        status = solver.Solve(ctx.model)
+
+        # AG bunk → no constraint → feasible
+        assert is_optimal_or_feasible(status)
+
+
+class TestPreferred18moBonus:
+    """The preferred-bonus path: bunks with spread <= 18mo earn the configured bonus."""
+
+    def test_tight_cabin_earns_bonus_when_spread_within_18mo(self):
+        """A cabin with <=18mo spread gets a preferred-bonus entry that resolves to 1."""
+        # Spread = 10mo (well within 18mo preferred)
+        campers = [
+            _person_with_age_months(1001, 144),
+            _person_with_age_months(1002, 150),
+            _person_with_age_months(1003, 154),
         ]
         bunk = create_bunk(cm_id=2001, name="B-1", gender="M", capacity=12)
 
         ctx = build_solver_context(
             persons=campers,
             bunks=[bunk],
-            config_overrides={
-                "constraint.age_spread.months": 24,
-                "constraint.age_spread.preferred_months": 12,
-                "constraint.age_spread.penalty": 1500,
-                "constraint.age_spread.preferred_bonus": 500,
-            },
+            config_overrides={"constraint.age_spread.preferred_bonus": 500},
         )
 
         add_age_spread_constraints(ctx)
 
         solver = cp_model.CpSolver()
         status = solver.Solve(ctx.model)
-
         assert is_optimal_or_feasible(status)
 
-        # Should have a bonus entry for the bunk
-        bonuses = ctx.soft_constraint_bonuses
-        assert len(bonuses) >= 1, "Expected at least one preferred-spread bonus entry"
-        bunk_bonuses = {k: v for k, v in bonuses.items() if "age_spread_preferred" in k}
-        assert len(bunk_bonuses) >= 1, f"Expected preferred_spread bonus, got bonuses: {list(bonuses.keys())}"
+        bunk_bonuses = {k: v for k, v in ctx.soft_constraint_bonuses.items() if "age_spread_preferred" in k}
+        assert len(bunk_bonuses) == 1
         for key, (var, weight) in bunk_bonuses.items():
-            assert solver.Value(var) == 1, f"Expected bonus active for {key} (10mo spread <= 12mo preferred)"
+            assert solver.Value(var) == 1, f"Expected bonus active for {key} (10mo <= 18mo)"
             assert weight == 500
 
-    def test_spread_between_12mo_and_24mo_earns_no_bonus(self):
-        """A cabin with 12mo < spread ≤ 24mo gets neither bonus nor violation."""
-        # Spread = 18 months (between preferred 12mo and max 24mo)
+    def test_spread_between_18mo_and_24mo_earns_no_bonus(self):
+        """A cabin with 18mo < spread <= 24mo: feasible (hard) but no bonus."""
         campers = [
-            _person_with_age_months(1001, 144),  # 12y 0m
-            _person_with_age_months(1002, 162),  # 13y 6m = 144+18
+            _person_with_age_months(1001, 144),
+            _person_with_age_months(1002, 164),  # 20mo spread → between 18 and 24
         ]
         bunk = create_bunk(cm_id=2001, name="B-1", gender="M", capacity=12)
 
         ctx = build_solver_context(
             persons=campers,
             bunks=[bunk],
-            config_overrides={
-                "constraint.age_spread.months": 24,
-                "constraint.age_spread.preferred_months": 12,
-                "constraint.age_spread.penalty": 1500,
-                "constraint.age_spread.preferred_bonus": 500,
-            },
+            config_overrides={"constraint.age_spread.preferred_bonus": 500},
         )
 
         add_age_spread_constraints(ctx)
+        ctx.model.Add(ctx.assignments[(0, 0)] == 1)
+        ctx.model.Add(ctx.assignments[(1, 0)] == 1)
 
         solver = cp_model.CpSolver()
         status = solver.Solve(ctx.model)
-
         assert is_optimal_or_feasible(status)
 
-        # No violation (spread ≤ 24mo)
-        for key, (var, _weight) in ctx.soft_constraint_violations.items():
-            if "age_spread" in key:
-                assert solver.Value(var) == 0, f"Expected no violation for {key} (18mo spread ≤ 24mo max)"
-
-        # No preferred bonus (spread > 12mo preferred)
-        bonuses = ctx.soft_constraint_bonuses
-        for key, (var, _weight) in bonuses.items():
+        for key, (var, _weight) in ctx.soft_constraint_bonuses.items():
             if "age_spread_preferred" in key:
-                assert solver.Value(var) == 0, f"Expected no bonus for {key} (18mo spread > 12mo preferred)"
+                assert solver.Value(var) == 0, f"Expected no bonus for {key} (20mo > 18mo)"
 
-    def test_preferred_threshold_disabled_when_zero(self):
-        """When preferred_months=0, no preferred bonus is added at all."""
+    def test_preferred_bonus_disabled_when_bonus_zero(self):
+        """When ``preferred_bonus=0``, no bonus entries are created."""
         campers = [
             _person_with_age_months(1001, 144),
             _person_with_age_months(1002, 150),
@@ -267,158 +213,50 @@ class TestNew12moPreferredThreshold:
         ctx = build_solver_context(
             persons=campers,
             bunks=[bunk],
-            config_overrides={
-                "constraint.age_spread.months": 24,
-                "constraint.age_spread.preferred_months": 0,  # disabled
-                "constraint.age_spread.penalty": 1500,
-                "constraint.age_spread.preferred_bonus": 500,
-            },
+            config_overrides={"constraint.age_spread.preferred_bonus": 0},
         )
 
         add_age_spread_constraints(ctx)
 
-        bonuses = ctx.soft_constraint_bonuses
-        preferred_bonuses = {k: v for k, v in bonuses.items() if "age_spread_preferred" in k}
-        assert len(preferred_bonuses) == 0, (
-            f"Expected no preferred bonuses when preferred_months=0, got: {list(preferred_bonuses.keys())}"
-        )
-
-    def test_preferred_threshold_disabled_when_equals_max(self):
-        """When preferred_months equals max months, no preferred bonus added (degenerate case)."""
-        campers = [
-            _person_with_age_months(1001, 144),
-            _person_with_age_months(1002, 150),
-        ]
-        bunk = create_bunk(cm_id=2001, name="B-1", gender="M", capacity=12)
-
-        ctx = build_solver_context(
-            persons=campers,
-            bunks=[bunk],
-            config_overrides={
-                "constraint.age_spread.months": 24,
-                "constraint.age_spread.preferred_months": 24,  # same as max → disabled
-                "constraint.age_spread.penalty": 1500,
-                "constraint.age_spread.preferred_bonus": 500,
-            },
-        )
-
-        add_age_spread_constraints(ctx)
-
-        bonuses = ctx.soft_constraint_bonuses
-        preferred_bonuses = {k: v for k, v in bonuses.items() if "age_spread_preferred" in k}
-        assert len(preferred_bonuses) == 0, (
-            f"Expected no preferred bonuses when preferred_months==max, got: {list(preferred_bonuses.keys())}"
-        )
-
-    def test_optimizer_prefers_tight_cabin_over_loose_one(self):
-        """Solver places similar-age campers together when both placements are valid.
-
-        Setup: 3 campers (10mo spread among them), 2 bunks each able to hold all 3.
-        Camper A: 144mo, Camper B: 150mo, Camper C: 154mo (spread=10mo if together).
-        With preferred bonus, solver should put all 3 in one bunk (tight spread) rather
-        than distributing them loosely.
-        """
-        # All in one bunk = 10mo spread → earns preferred bonus
-        # This is one valid solution; we just verify it's chosen over no-bonus alternatives.
-        campers = [
-            _person_with_age_months(1001, 144),  # 12y 0m
-            _person_with_age_months(1002, 150),  # 12y 6m
-            _person_with_age_months(1003, 154),  # 12y 10m
-        ]
-        bunk = create_bunk(cm_id=2001, name="B-1", gender="M", capacity=12)
-
-        ctx = build_solver_context(
-            persons=campers,
-            bunks=[bunk],
-            config_overrides={
-                "constraint.age_spread.months": 24,
-                "constraint.age_spread.preferred_months": 12,
-                "constraint.age_spread.penalty": 1500,
-                "constraint.age_spread.preferred_bonus": 500,
-            },
-        )
-
-        add_age_spread_constraints(ctx)
-
-        # Maximise bonuses, minimise penalties
-        objective_terms = []
-        for var, weight in ctx.soft_constraint_violations.values():
-            objective_terms.append(-weight * var)
-        for var, weight in ctx.soft_constraint_bonuses.values():
-            objective_terms.append(weight * var)
-
-        if objective_terms:
-            ctx.model.Maximize(sum(objective_terms))
-
-        solver = cp_model.CpSolver()
-        status = solver.Solve(ctx.model)
-
-        assert is_optimal_or_feasible(status)
-
-        # The preferred bonus should be active (all 3 in B-1 with 10mo spread)
-        bonuses = ctx.soft_constraint_bonuses
-        bunk_bonuses = {k: v for k, v in bonuses.items() if "age_spread_preferred" in k}
-        assert len(bunk_bonuses) >= 1
-        for key, (var, _weight) in bunk_bonuses.items():
-            assert solver.Value(var) == 1, f"Expected preferred bonus active for {key}"
+        preferred_bonuses = [k for k in ctx.soft_constraint_bonuses if "age_spread_preferred" in k]
+        assert preferred_bonuses == []
 
     def test_two_cabins_tighter_cabin_gets_bonus_wider_does_not(self):
-        """With two bunks of different age spreads, only the tight one earns the bonus.
-
-        Campers: 4 campers split across 2 bunks.
-        Bunk A: 2 campers, 8mo spread → earns bonus
-        Bunk B: 2 campers, 20mo spread → no bonus
-        """
-        # Force exactly 2 campers per bunk by setting per-bunk capacity to 2.
-        # Phase 2 cabin-capacity cleanup deleted the global cabin_capacity.*
-        # config keys, so per-bunk capacity is the only knob.
+        """With two bunks of different age spreads, only the tight one earns the bonus."""
         bunk_a = create_bunk(cm_id=2001, name="B-1", gender="M", capacity=2)
         bunk_b = create_bunk(cm_id=2002, name="B-2", gender="M", capacity=2)
 
         campers = [
             _person_with_age_months(1001, 144),  # 12y 0m → bunk A
-            _person_with_age_months(1002, 152),  # 12y 8m → bunk A (8mo spread)
+            _person_with_age_months(1002, 152),  # 12y 8m → bunk A  (8mo spread)
             _person_with_age_months(1003, 156),  # 13y 0m → bunk B
-            _person_with_age_months(1004, 176),  # 14y 8m → bunk B (20mo spread)
+            _person_with_age_months(1004, 176),  # 14y 8m → bunk B (20mo spread > 18mo preferred)
         ]
 
         ctx = build_solver_context(
             persons=campers,
             bunks=[bunk_a, bunk_b],
-            config_overrides={
-                "constraint.age_spread.months": 24,
-                "constraint.age_spread.preferred_months": 12,
-                "constraint.age_spread.penalty": 1500,
-                "constraint.age_spread.preferred_bonus": 500,
-            },
+            config_overrides={"constraint.age_spread.preferred_bonus": 500},
         )
 
         add_age_spread_constraints(ctx)
 
-        # Add capacity hard constraint so each bunk gets exactly 2 campers
         from bunking.solver.constraints.cabin_capacity import add_cabin_capacity_constraints
 
         add_cabin_capacity_constraints(ctx)
 
         # Maximise bonuses
-        objective_terms = []
-        for var, weight in ctx.soft_constraint_violations.values():
-            objective_terms.append(-weight * var)
-        for var, weight in ctx.soft_constraint_bonuses.values():
-            objective_terms.append(weight * var)
-
+        objective_terms = [weight * var for var, weight in ctx.soft_constraint_bonuses.values()]
         if objective_terms:
             ctx.model.Maximize(sum(objective_terms))
 
         solver = cp_model.CpSolver()
         status = solver.Solve(ctx.model)
-
         assert is_optimal_or_feasible(status)
 
-        bonuses = ctx.soft_constraint_bonuses
-        preferred_bonuses = {k: v for k, v in bonuses.items() if "age_spread_preferred" in k}
-        assert len(preferred_bonuses) >= 1, "Expected at least one preferred bonus entry"
+        preferred_bonuses = {k: v for k, v in ctx.soft_constraint_bonuses.items() if "age_spread_preferred" in k}
+        assert len(preferred_bonuses) == 2  # one per non-AG bunk
 
-        active_bonuses = sum(1 for _var, _w in preferred_bonuses.values() if solver.Value(_var) == 1)
-        # Exactly 1 of the 2 bunks should earn the preferred bonus
+        active_bonuses = sum(1 for var, _w in preferred_bonuses.values() if solver.Value(var) == 1)
+        # Only the tight cabin (8mo) earns the bonus; the loose one (20mo) does not.
         assert active_bonuses == 1, f"Expected exactly 1 bunk to earn preferred bonus, got {active_bonuses}"

--- a/tests/unit/bunking/solver/constraints/test_age_spread.py
+++ b/tests/unit/bunking/solver/constraints/test_age_spread.py
@@ -78,22 +78,26 @@ class TestHard24moConstraint:
         assert is_optimal_or_feasible(status)
 
     def test_spread_over_24mo_with_forced_assignment_is_infeasible(self):
-        """Two campers 25mo apart cannot share a non-AG bunk."""
+        """Two campers 25mo apart cannot share a non-edge (middle) bunk."""
         campers = [
             _person_with_age_months(1001, 144),  # 12y 0m
             _person_with_age_months(1002, 169),  # 14y 1m  → 25mo spread
         ]
-        bunk = create_bunk(cm_id=2001, name="B-1", gender="M", capacity=12)
+        # Three bunks so B-5 is the middle (non-edge) bunk — hard cap applies there.
+        bunk_low = create_bunk(cm_id=2001, name="B-3", gender="M", capacity=12)
+        bunk_mid = create_bunk(cm_id=2002, name="B-5", gender="M", capacity=12)
+        bunk_high = create_bunk(cm_id=2003, name="B-7", gender="M", capacity=12)
 
         ctx = build_solver_context(
             persons=campers,
-            bunks=[bunk],
+            bunks=[bunk_low, bunk_mid, bunk_high],
             config_overrides={"constraint.age_spread.preferred_bonus": 500},
         )
 
         add_age_spread_constraints(ctx)
-        ctx.model.Add(ctx.assignments[(0, 0)] == 1)
-        ctx.model.Add(ctx.assignments[(1, 0)] == 1)
+        # Force both campers into B-5 (bunk_idx=1 after sorting bunks by cm_id).
+        ctx.model.Add(ctx.assignments[(0, 1)] == 1)
+        ctx.model.Add(ctx.assignments[(1, 1)] == 1)
 
         solver = cp_model.CpSolver()
         status = solver.Solve(ctx.model)

--- a/tests/unit/bunking/solver/constraints/test_age_spread.py
+++ b/tests/unit/bunking/solver/constraints/test_age_spread.py
@@ -264,3 +264,124 @@ class TestPreferred18moBonus:
         active_bonuses = sum(1 for var, _w in preferred_bonuses.values() if solver.Value(var) == 1)
         # Only the tight cabin (8mo) earns the bonus; the loose one (20mo) does not.
         assert active_bonuses == 1, f"Expected exactly 1 bunk to earn preferred bonus, got {active_bonuses}"
+
+
+class TestEdgeBunkCarveOut:
+    """Edge bunks (lowest/highest level per gender+session) get a soft escape hatch
+    instead of the hard 24mo cap. Middle bunks are unchanged."""
+
+    def test_high_edge_bunk_overflow_is_feasible(self):
+        """A high-edge bunk can exceed 24mo when forced — escape hatch activates."""
+        campers = [
+            _person_with_age_months(1001, 144),  # 12y 0m
+            _person_with_age_months(1002, 169),  # 14y 1m  → 25mo spread
+        ]
+        bunk_low = create_bunk(cm_id=2001, name="B-3", gender="M", capacity=12)
+        bunk_mid = create_bunk(cm_id=2002, name="B-5", gender="M", capacity=12)
+        bunk_high = create_bunk(cm_id=2003, name="B-7", gender="M", capacity=12)
+
+        ctx = build_solver_context(
+            persons=campers,
+            bunks=[bunk_low, bunk_mid, bunk_high],
+            config_overrides={"constraint.age_spread.preferred_bonus": 500},
+        )
+
+        add_age_spread_constraints(ctx)
+        # Force both campers into B-7 (bunk_idx=2 after sorting by cm_id).
+        ctx.model.Add(ctx.assignments[(0, 2)] == 1)
+        ctx.model.Add(ctx.assignments[(1, 2)] == 1)
+
+        solver = cp_model.CpSolver()
+        status = solver.Solve(ctx.model)
+
+        assert is_optimal_or_feasible(status), "Edge bunk should allow >24mo overflow"
+        # The overflow bool must be True — it's the only way to be feasible here.
+        assert "edge_age_overflow_b2" in ctx.soft_constraint_violations
+        overflow_var, penalty = ctx.soft_constraint_violations["edge_age_overflow_b2"]
+        assert solver.Value(overflow_var) == 1, "Overflow bool should be True when forced"
+        assert penalty == 15_000
+
+    def test_middle_bunk_overflow_still_infeasible(self):
+        """Middle bunk retains the hard 24mo cap — no escape hatch."""
+        campers = [
+            _person_with_age_months(1001, 144),
+            _person_with_age_months(1002, 169),  # 25mo spread
+        ]
+        bunk_low = create_bunk(cm_id=2001, name="B-3", gender="M", capacity=12)
+        bunk_mid = create_bunk(cm_id=2002, name="B-5", gender="M", capacity=12)
+        bunk_high = create_bunk(cm_id=2003, name="B-7", gender="M", capacity=12)
+
+        ctx = build_solver_context(
+            persons=campers,
+            bunks=[bunk_low, bunk_mid, bunk_high],
+            config_overrides={"constraint.age_spread.preferred_bonus": 500},
+        )
+
+        add_age_spread_constraints(ctx)
+        # Force into B-5 (middle, bunk_idx=1).
+        ctx.model.Add(ctx.assignments[(0, 1)] == 1)
+        ctx.model.Add(ctx.assignments[(1, 1)] == 1)
+
+        solver = cp_model.CpSolver()
+        status = solver.Solve(ctx.model)
+
+        assert status == cp_model.INFEASIBLE, "Middle bunk must never allow >24mo spread"
+
+    def test_high_edge_bunk_no_overflow_when_within_cap(self):
+        """Edge bunk with ≤24mo spread keeps overflow bool False (no penalty paid)."""
+        campers = [
+            _person_with_age_months(1001, 144),
+            _person_with_age_months(1002, 164),  # 20mo spread — within cap
+        ]
+        bunk_low = create_bunk(cm_id=2001, name="B-3", gender="M", capacity=12)
+        bunk_mid = create_bunk(cm_id=2002, name="B-5", gender="M", capacity=12)
+        bunk_high = create_bunk(cm_id=2003, name="B-7", gender="M", capacity=12)
+
+        ctx = build_solver_context(
+            persons=campers,
+            bunks=[bunk_low, bunk_mid, bunk_high],
+            config_overrides={"constraint.age_spread.preferred_bonus": 500},
+        )
+
+        add_age_spread_constraints(ctx)
+        # Force into B-7 (highest, bunk_idx=2).
+        ctx.model.Add(ctx.assignments[(0, 2)] == 1)
+        ctx.model.Add(ctx.assignments[(1, 2)] == 1)
+        # Minimize violations so solver prefers overflow=False when spread is within cap.
+        # soft_constraint_violations values are (BoolVar, int) tuples.
+        violation_terms = [weight * var for var, weight in ctx.soft_constraint_violations.values()]
+        if violation_terms:
+            ctx.model.Minimize(sum(violation_terms))
+
+        solver = cp_model.CpSolver()
+        status = solver.Solve(ctx.model)
+
+        assert is_optimal_or_feasible(status)
+        assert "edge_age_overflow_b2" in ctx.soft_constraint_violations
+        overflow_var, _ = ctx.soft_constraint_violations["edge_age_overflow_b2"]
+        assert solver.Value(overflow_var) == 0, "Overflow bool must stay False when spread is within cap"
+
+    def test_only_bunk_for_session_is_edge(self):
+        """A session with a single bunk per gender is treated as edge — escape hatch applies."""
+        campers = [
+            _person_with_age_months(1001, 144),
+            _person_with_age_months(1002, 169),  # 25mo spread
+        ]
+        sole_bunk = create_bunk(cm_id=2001, name="B-5", gender="M", capacity=12)
+
+        ctx = build_solver_context(
+            persons=campers,
+            bunks=[sole_bunk],
+            config_overrides={"constraint.age_spread.preferred_bonus": 500},
+        )
+
+        add_age_spread_constraints(ctx)
+        # No need to force assignments — only one bunk exists.
+
+        solver = cp_model.CpSolver()
+        status = solver.Solve(ctx.model)
+
+        assert is_optimal_or_feasible(status), "Sole bunk is an edge bunk; >24mo should be allowed"
+        assert "edge_age_overflow_b0" in ctx.soft_constraint_violations
+        overflow_var, _ = ctx.soft_constraint_violations["edge_age_overflow_b0"]
+        assert solver.Value(overflow_var) == 1

--- a/tests/unit/bunking/solver/test_constants.py
+++ b/tests/unit/bunking/solver/test_constants.py
@@ -1,0 +1,24 @@
+"""Tests for solver-domain hardcoded constants in ``bunking.solver.constants``."""
+
+from __future__ import annotations
+
+
+def test_max_age_spread_months_is_24() -> None:
+    from bunking.solver.constants import MAX_AGE_SPREAD_MONTHS
+
+    assert MAX_AGE_SPREAD_MONTHS == 24
+
+
+def test_preferred_age_spread_months_is_18() -> None:
+    from bunking.solver.constants import PREFERRED_AGE_SPREAD_MONTHS
+
+    assert PREFERRED_AGE_SPREAD_MONTHS == 18
+
+
+def test_preferred_strictly_less_than_max() -> None:
+    from bunking.solver.constants import (
+        MAX_AGE_SPREAD_MONTHS,
+        PREFERRED_AGE_SPREAD_MONTHS,
+    )
+
+    assert 0 < PREFERRED_AGE_SPREAD_MONTHS < MAX_AGE_SPREAD_MONTHS

--- a/tests/unit/config/test_schema_orphan_keys.py
+++ b/tests/unit/config/test_schema_orphan_keys.py
@@ -54,3 +54,26 @@ def test_age_spread_deleted_keys_absent_from_schema():
 
 def test_age_spread_preferred_bonus_still_in_schema():
     assert "constraint.age_spread.preferred_bonus" in CONFIG_SCHEMA
+
+
+def test_age_spread_deleted_keys_absent_from_migration_metadata():
+    """Seed migration must not declare FRIENDLY_NAMES/TOOLTIPS/SECTION/configDef rows for the deleted keys.
+
+    Comment lines naming the keys are OK (they document the removal). Active
+    quoted dict-key declarations are not. The check below distinguishes by
+    looking for the JS-string form (``'key':`` or ``"key":``).
+    """
+    text = MAIN_MIGRATION.read_text()
+    for key in [
+        "spread.max_age_months",
+        "constraint.age_spread.penalty",
+        "constraint.age_spread.preferred_months",
+    ]:
+        assert f"'{key}':" not in text, f"single-quoted key {key!r} still in migration"
+        assert f'"{key}":' not in text, f"double-quoted key {key!r} still in migration"
+
+
+def test_age_spread_preferred_bonus_still_in_migration():
+    text = MAIN_MIGRATION.read_text()
+    assert "'constraint.age_spread.preferred_bonus':" in text
+    assert '"constraint.age_spread.preferred_bonus":' in text

--- a/tests/unit/config/test_schema_orphan_keys.py
+++ b/tests/unit/config/test_schema_orphan_keys.py
@@ -37,3 +37,20 @@ def test_enabled_orphan_labels_absent_from_migration_metadata():
         "constraint.grade_spread.enabled",
     ]:
         assert key not in text, f"orphan label {key} still in migration"
+
+
+# Age Spread Phase 2: 3 keys deleted, 1 kept.
+# - spread.max_age_months          → MAX_AGE_SPREAD_MONTHS constant
+# - constraint.age_spread.penalty  → deleted (soft path gone)
+# - constraint.age_spread.preferred_months → PREFERRED_AGE_SPREAD_MONTHS constant
+# - constraint.age_spread.preferred_bonus  → KEPT (lone tunable in domain)
+
+
+def test_age_spread_deleted_keys_absent_from_schema():
+    assert "spread.max_age_months" not in CONFIG_SCHEMA
+    assert "constraint.age_spread.penalty" not in CONFIG_SCHEMA
+    assert "constraint.age_spread.preferred_months" not in CONFIG_SCHEMA
+
+
+def test_age_spread_preferred_bonus_still_in_schema():
+    assert "constraint.age_spread.preferred_bonus" in CONFIG_SCHEMA

--- a/tests/unit/solver/test_age_spread_infeasibility_hook.py
+++ b/tests/unit/solver/test_age_spread_infeasibility_hook.py
@@ -1,0 +1,96 @@
+"""Feasibility-warning hook for the now-hard age_spread constraint.
+
+The hard ``MAX_AGE_SPREAD_MONTHS`` ceiling makes one new infeasibility class
+possible: a locked group whose members span >24 months in age cannot fit any
+non-AG bunk. The generic ``find_infeasibility_cause`` would print
+``"The age_spread constraint is causing infeasibility"`` — useful for the
+developer, useless for the staff member who needs to split the group or take a
+manual override on the bunking board.
+
+This hook pre-empts that generic message with the actionable group + age
+spread.
+"""
+
+from __future__ import annotations
+
+from bunking.models_v2 import DirectSolverInput
+
+from .impossibility.conftest import make_bunk, make_input, make_person
+
+
+def _input_with_lock_group(
+    *,
+    group_id: str,
+    member_birthdates: list[str],
+) -> DirectSolverInput:
+    """Build a minimal solver input with one named lock group."""
+    persons = [make_person(cm_id=100 + i, session=1000, birthdate=bd) for i, bd in enumerate(member_birthdates)]
+    bunks = [make_bunk(cm_id=10, session=1000)]
+    input_data = make_input(persons=persons, bunks=bunks, requests=[])
+    input_data.lock_groups_data = {group_id: [p.campminder_person_id for p in persons]}
+    return input_data
+
+
+def test_helper_returns_none_when_no_lock_groups() -> None:
+    """No locked groups → no actionable diagnosis (caller falls back to generic)."""
+    from bunking.solver.feasibility import _explain_age_spread_infeasibility
+
+    input_data = make_input(
+        persons=[make_person(cm_id=1, session=1000)],
+        bunks=[make_bunk(cm_id=10, session=1000)],
+        requests=[],
+    )
+
+    assert _explain_age_spread_infeasibility(input_data) is None
+
+
+def test_helper_returns_none_when_lock_group_within_limit() -> None:
+    """Locked group with members within 24mo of each other is fine."""
+    from bunking.solver.feasibility import _explain_age_spread_infeasibility
+
+    # 20mo spread (2014-01-01 vs 2015-09-01)
+    input_data = _input_with_lock_group(group_id="g1", member_birthdates=["2014-01-01", "2015-09-01"])
+
+    assert _explain_age_spread_infeasibility(input_data) is None
+
+
+def test_helper_flags_group_with_25mo_spread() -> None:
+    """Locked group spanning >24mo cannot fit any bunk under the hard cap."""
+    from bunking.solver.feasibility import _explain_age_spread_infeasibility
+
+    # 25mo spread (2014-01-01 vs 2016-02-01)
+    input_data = _input_with_lock_group(group_id="age-mismatch", member_birthdates=["2014-01-01", "2016-02-01"])
+
+    message = _explain_age_spread_infeasibility(input_data)
+    assert message is not None
+    assert "age-mismatch" in message
+    # Action must be named (split or override).
+    lower = message.lower()
+    assert "split" in lower or "override" in lower
+
+
+def test_helper_flags_large_group_with_three_year_spread() -> None:
+    """A 3-year spread (~36mo) inside a lock group is clearly too wide."""
+    from bunking.solver.feasibility import _explain_age_spread_infeasibility
+
+    input_data = _input_with_lock_group(
+        group_id="g42",
+        member_birthdates=["2013-06-15", "2014-06-15", "2016-06-15"],
+    )
+
+    message = _explain_age_spread_infeasibility(input_data)
+    assert message is not None
+    assert "g42" in message
+
+
+def test_message_names_the_age_limit_concretely() -> None:
+    """The actionable message must surface the 24mo limit so staff know what
+    threshold they need to fit under (or override)."""
+    from bunking.solver import feasibility as fmod
+
+    input_data = _input_with_lock_group(group_id="cabin-buddies", member_birthdates=["2014-01-01", "2016-06-01"])
+    message = fmod._explain_age_spread_infeasibility(input_data)
+    assert message is not None
+    assert "cabin-buddies" in message
+    assert "24" in message
+    assert "month" in message.lower()

--- a/tests/unit/solver/test_observability.py
+++ b/tests/unit/solver/test_observability.py
@@ -15,6 +15,7 @@ from bunking.models_v2 import DirectBunkRequest
 from bunking.solver.observability import (
     _build_impossible_by_reason_by_bucket,
     _build_request_density_histogram_by_bucket,
+    _classify_bucket,
     _count_presolve_compression,
     _derive_plateau_scalars,
     _lp_root_gap,
@@ -191,3 +192,24 @@ class TestDerivePlateauScalars:
         ]
         # final_bound falls back to last solution's bound (850) -> abs(850 - 850) = 0
         assert _derive_plateau_scalars(obj, [])["bound_gain_after_plateau"] == 0.0
+
+
+class TestClassifyBucket:
+    """Soft-constraint key → module bucket mapping (drives the dashboard rollup)."""
+
+    def test_grade_ratio_keys_bucket_into_grade_ratio(self) -> None:
+        assert _classify_bucket("grade_ratio_b0") == "grade_ratio"
+
+    def test_level_regression_keys_bucket_into_level_regression(self) -> None:
+        assert _classify_bucket("level_regression_p5") == "level_regression"
+
+    def test_age_spread_per_bunk_keys_bucket_into_age_spread(self) -> None:
+        assert _classify_bucket("age_spread_b3") == "age_spread"
+
+    def test_edge_age_overflow_keys_bucket_into_age_spread(self) -> None:
+        # Edge-bunk soft escape hatch (PR #1553) emits ``edge_age_overflow_b{idx}``;
+        # they belong in the age_spread bucket, not "other".
+        assert _classify_bucket("edge_age_overflow_b0") == "age_spread"
+
+    def test_unknown_prefix_falls_through_to_other(self) -> None:
+        assert _classify_bucket("some_brand_new_violation_b0") == "other"

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -147,8 +147,19 @@ class TestBunkingValidator:
         ]
 
     def test_validator_initialization(self, validator):
-        assert validator.max_grade_spread == 2
-        assert validator.max_age_spread_months == 24
+        from bunking.solver.constants import MAX_AGE_SPREAD_MONTHS, MAX_UNIQUE_GRADES_PER_BUNK
+
+        assert validator.max_grade_spread == MAX_UNIQUE_GRADES_PER_BUNK
+        assert validator.max_age_spread_months == MAX_AGE_SPREAD_MONTHS
+
+    def test_validator_max_age_spread_is_imported_constant(self):
+        """Validator must reference MAX_AGE_SPREAD_MONTHS, not a literal 24."""
+        import inspect
+
+        from bunking.bunking_validator import BunkingValidator
+
+        src = inspect.getsource(BunkingValidator.__init__)
+        assert "MAX_AGE_SPREAD_MONTHS" in src, "validator should reference the constant by name"
 
     def test_validate_bunking_basic(self, validator, basic_session, basic_bunks, basic_persons):
         """Test basic validation with all campers assigned."""


### PR DESCRIPTION
## Summary

Collapses the prior soft `excess_spread` / `has_violation` penalty machinery into a single hard 24mo cap on age range per bunk, with a targeted soft escape hatch on **edge bunks** (lowest/highest level per gender+session) for structural cases where a hard MSO chain forces overflow.

**Two-stage design**, decisions locked in `docs/reference/solver-config-decisions.md` § "Age Spread":

1. **Middle bunks** — hard cap `spread <= 24`. Solver is INFEASIBLE if two campers >24mo apart are forced in; there are always adjacent cabins to absorb outliers.
2. **Edge bunks** — reified `edge_age_overflow_b{idx}` BoolVar. The 24mo cap is enforced only when the bool is False; when True, `EDGE_AGE_OVERFLOW_PENALTY = 15_000` is charged via `soft_constraint_violations`. Since MSO satisfaction is a hard constraint, the solver sets this True only when structurally forced (e.g., a hard bunk-with chain into the top cabin) — never as a casual optimization choice.
3. **Preferred bonus** (unchanged) — bunks within 18mo earn `constraint.age_spread.preferred_bonus`, regardless of edge/middle status.

## Why the escape hatch

Initial Phase 2 (hard cap only) made S2 INFEASIBLE: a hard MSO pairing forces a younger camper into the highest boys cabin alongside the rest of the top-grade cohort, creating an unavoidable >24mo spread. There's no other cabin to route through — the top cabin has no "older" peer above it. The escape hatch lets the solver pay 15k to satisfy the MSO, and only fires at the genuine structural boundary.

Verified live against S2 (session 1235404): exactly one edge bunk (B-10) overflowed at 25mo; the other 3 edge bunks (B-3, G-3, G-10B) and all 8 middle bunks stayed at or under 24mo.

## Changes by area

**Solver:**
- `bunking/solver/constants.py` — add `MAX_AGE_SPREAD_MONTHS = 24`, `PREFERRED_AGE_SPREAD_MONTHS = 18`, `EDGE_AGE_OVERFLOW_PENALTY = 15_000`
- `bunking/solver/constraints/age_spread.py` — collapse soft path → hard middle / soft-edge split via `is_edge_bunk_for_grades`
- `bunking/solver/feasibility.py` — add `_explain_age_spread_infeasibility` hook for staff-actionable messages when a non-edge bunk forces infeasibility

**Config:**
- `bunking/config/loader.py` — drop `age_spread` from `weight_mappings`
- `bunking/config/schema.py` — drop 3 schema entries (`constraint.age_spread.{months,penalty,preferred_months}`)
- `pocketbase/pb_migrations/1500000011_config.js` — remove the 3 keys from `FRIENDLY_NAMES` / `TOOLTIPS` / `SECTION_MAPPING` / `configDefinitions` / `fullKeyMappings`
- `pocketbase/pb_migrations/1500000107_drop_age_spread_orphan_configs.js` — drop the orphan config rows

**Sync / Validator:**
- `bunking/bunking_validator.py` — import `MAX_AGE_SPREAD_MONTHS` (replaces parallel hardcode); still warns post-solve on any >24mo spread, including edge-bunk overflows
- `bunking/sync/bunk_request_processor/orchestrator/orchestrator.py` — import the constant; delete orphan `DEFAULT_AGE_SPREAD_MONTHS`

**Tests:**
- `tests/unit/bunking/solver/constraints/test_age_spread.py` — refactored `TestHard24moConstraint` (4 tests), added `TestPreferred18moBonus` (4 tests), added `TestEdgeBunkCarveOut` (4 tests)
- `tests/unit/solver/test_age_spread_infeasibility_hook.py` — 5 tests for the feasibility hook

## Test plan

- [x] `uv run pytest tests/` — 4931 passed, 23 skipped (PB-dependent), 0 failures
- [x] `uv run pytest tests/unit/bunking/solver/constraints/test_age_spread.py -v` — 12/12 pass
- [x] `uv run mypy bunking/solver/constraints/age_spread.py` — clean
- [x] Live parity check S2 (1235404): FEASIBLE obj=641,012; exactly one edge overflow on B-10 (top boys cabin); 0 middle-bunk overflows
- [x] Live parity check S4 (1235406): FEASIBLE obj=764,749 (+17k vs. baseline, normal variance)
- [ ] Manual: confirm `bunking_validator` board warning still fires for >24mo edge-bunk assignments

## Spec / plan

- Spec: `docs/superpowers/specs/2026-05-20-age-spread-edge-bunk-carveout-design.md` (local-only)
- Plan: `docs/superpowers/plans/2026-05-20-age-spread-edge-bunk-carveout.md` (local-only)
- Authoritative decisions: `docs/reference/solver-config-decisions.md` § "Age Spread"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced 24-month hard age-spread limit for middle bunks; edge bunks may overflow with a soft penalty
  * Added an 18-month preferred age-spread bonus; bonuses only apply to occupied bunks

* **Tests**
  * Expanded age-spread tests: hard-cap, preferred-bonus, edge-bunk carve-outs, infeasibility explanations, and empty-bunk behavior

* **Chores**
  * Consolidated age-spread settings into solver constants; removed redundant config keys and updated migrations and observability buckets

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->