### PR TITLE
feat(frontend): Group 67 — graph parity, first-pick badge, bunk swap

### DIFF
--- a/frontend/src/components/BunkCard.tsx
+++ b/frontend/src/components/BunkCard.tsx
@@ -22,7 +22,7 @@ interface BunkCardProps {
   onCamperLockToggle?: (camper: Camper) => void
   onCamperUnassign?: (camper: Camper) => void
   onShowSocialGraph?: () => void
-  onSwapClick?: () => void
+  onSwapClick?: (() => void) | undefined
   isDragging?: boolean
   isProductionMode?: boolean
   defaultCapacity?: number

--- a/frontend/src/components/BunkCard.tsx
+++ b/frontend/src/components/BunkCard.tsx
@@ -2,7 +2,7 @@ import { Fragment } from 'react'
 import { useDroppable } from '@dnd-kit/core'
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import clsx from 'clsx'
-import { Network, Download } from 'lucide-react'
+import { Network, Download, ArrowLeftRight } from 'lucide-react'
 import type { BunkWithCampers, Camper } from '../types/app-types'
 import CamperCard from './CamperCard'
 import { useBunkRequestsFromContext } from '../hooks'
@@ -22,6 +22,7 @@ interface BunkCardProps {
   onCamperLockToggle?: (camper: Camper) => void
   onCamperUnassign?: (camper: Camper) => void
   onShowSocialGraph?: () => void
+  onSwapClick?: () => void
   isDragging?: boolean
   isProductionMode?: boolean
   defaultCapacity?: number
@@ -83,6 +84,7 @@ function BunkCard({
   onCamperLockToggle,
   onCamperUnassign,
   onShowSocialGraph,
+  onSwapClick,
   isDragging = false,
   isProductionMode = false,
   defaultCapacity = 12,
@@ -403,6 +405,16 @@ function BunkCard({
               title="Export bunk to CSV"
             >
               <Download className="h-4 w-4" />
+            </button>
+          )}
+          {onSwapClick && (
+            <button
+              onClick={onSwapClick}
+              className="btn-ghost p-2"
+              title="Swap this bunk's roster with another bunk"
+              aria-label="Swap bunk"
+            >
+              <ArrowLeftRight className="h-4 w-4" />
             </button>
           )}
           {onShowSocialGraph && bunk.campers.length > 0 && (

--- a/frontend/src/components/BunkSocialGraphModal.test.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.test.tsx
@@ -12,12 +12,8 @@
  * The helper unit tests plus TypeScript checking provide sufficient coverage.
  */
 import { describe, expect, it } from 'vitest'
-import {
-  buildBunksFilter,
-  extractBunkCmIdsFromPlans,
-  extractSortKey,
-  getBunkType,
-} from './BunkSocialGraphModal'
+import { buildBunksFilter, extractBunkCmIdsFromPlans } from './BunkSocialGraphModal'
+import { extractSortKey, getBunkType } from '../utils/bunkNaming'
 
 // ─── Inline simulation of sessionBunks derivation ────────────────────────────
 // Mirrors the useMemo body in BunkSocialGraphModal so we can assert the
@@ -51,86 +47,9 @@ function deriveSessionBunks(allBunks: BunkStub[] | undefined, bunkCmId: number) 
     }))
 }
 
-// ─── getBunkType ──────────────────────────────────────────────────────────────
-
-describe('getBunkType', () => {
-  it('returns B for an empty string', () => {
-    expect(getBunkType('')).toBe('B')
-  })
-
-  it('classifies boy bunks', () => {
-    expect(getBunkType('B-1')).toBe('B')
-    expect(getBunkType('B-12')).toBe('B')
-  })
-
-  it('classifies girl bunks', () => {
-    expect(getBunkType('G-1')).toBe('G')
-    expect(getBunkType('G-7')).toBe('G')
-  })
-
-  it('classifies AG bunks by prefix', () => {
-    expect(getBunkType('AG-1')).toBe('AG')
-    expect(getBunkType('AG1')).toBe('AG')
-  })
-
-  it('falls back to B for unrecognised names', () => {
-    expect(getBunkType('Cabin-5')).toBe('B')
-  })
-
-  // #1164: classification was previously a substring match (`name.includes('AG')`),
-  // which mis-classified incidental occurrences. The match must be prefix-anchored
-  // and bounded — AG followed by end-of-string, whitespace, hyphen, or a digit.
-  describe('#1164 — AG match must be prefix-anchored, not substring', () => {
-    it.each([
-      ['AG', 'AG'],
-      ['AG-1', 'AG'],
-      ['AG1', 'AG'],
-      ['AG Alph', 'AG'],
-      ['AG-Alpha-1', 'AG'],
-    ])('classifies %s as AG', (name, expected) => {
-      expect(getBunkType(name)).toBe(expected)
-    })
-
-    it.each([
-      ['STAGE', 'B'], // Incidental "AG" mid-word
-      ['page', 'B'], // Incidental "ag" lowercased
-      ['BAG-1', 'B'], // "AG" inside a B-prefixed name
-      ['B-1AG', 'B'], // Trailing AG suffix on a B bunk (was previously mis-AG'd; #1164 inverts)
-      ['Stage-1', 'B'], // Mixed-case "ag" mid-word
-    ])('does NOT classify %s as AG (incidental match)', (name, expected) => {
-      expect(getBunkType(name)).toBe(expected)
-    })
-  })
-})
-
-// ─── extractSortKey ───────────────────────────────────────────────────────────
-
-describe('extractSortKey', () => {
-  it('places Alpha bunks at primary -2', () => {
-    expect(extractSortKey('Alpha').primary).toBe(-2)
-    expect(extractSortKey('B-Alph-1').primary).toBe(-2)
-  })
-
-  it('places Beta bunks at primary -1', () => {
-    expect(extractSortKey('Beta').primary).toBe(-1)
-    expect(extractSortKey('G-Bet-2').primary).toBe(-1)
-  })
-
-  it('extracts numeric sort key for numbered bunks', () => {
-    expect(extractSortKey('B-3').primary).toBe(3)
-    expect(extractSortKey('G-10').primary).toBe(10)
-  })
-
-  it('sorts lower numbers before higher numbers', () => {
-    const k1 = extractSortKey('B-1')
-    const k2 = extractSortKey('B-9')
-    expect(k1.primary).toBeLessThan(k2.primary)
-  })
-
-  it('falls back to primary 999 for unrecognised patterns', () => {
-    expect(extractSortKey('Unknown').primary).toBe(999)
-  })
-})
+// Unit tests for getBunkType / extractSortKey now live in
+// `frontend/src/utils/bunkNaming.test.ts`. They're imported here only so the
+// sessionBunks derivation tests below can exercise the same logic.
 
 // ─── extractBunkCmIdsFromPlans ───────────────────────────────────────────────
 // Regression guard for #1339: bunk_plans schema has no flat bunk_cm_id column;

--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -102,19 +102,9 @@ interface BunkGraphData {
   health_score: number
 }
 
-// Helpers hoisted to module scope: they reference no closure values and were
-// previously redeclared on every useMemo recompute. Exported for unit tests.
-// eslint-disable-next-line react-refresh/only-export-components
-export const isAGBunkName = (name: string): boolean => /^AG(?:$|[\s-]|\d)/.test(name)
-
-// eslint-disable-next-line react-refresh/only-export-components
-export const getBunkType = (name: string): 'G' | 'B' | 'AG' => {
-  if (!name) return 'B'
-  if (isAGBunkName(name)) return 'AG'
-  if (name.startsWith('G-')) return 'G'
-  if (name.startsWith('B-')) return 'B'
-  return 'B'
-}
+// Bunk-naming predicates live in `utils/bunkNaming` so utility modules
+// (e.g. bunkSwap) can import them without depending on this component.
+import { getBunkType, extractSortKey, isAGBunkName } from '../utils/bunkNaming'
 
 /**
  * Build a PocketBase filter for fetching bunks by cm_id within a specific year.
@@ -155,15 +145,6 @@ export const extractBunkCmIdsFromPlans = (
       .filter((id): id is number => typeof id === 'number')
   ),
 ]
-
-// eslint-disable-next-line react-refresh/only-export-components
-export const extractSortKey = (name: string): { primary: number; secondary: string } => {
-  if (name.includes('Alph')) return { primary: -2, secondary: name }
-  if (name.includes('Bet')) return { primary: -1, secondary: name }
-  const match = name.match(/[GB]-(\d+)/)
-  if (match?.[1]) return { primary: parseInt(match[1], 10), secondary: name }
-  return { primary: 999, secondary: name }
-}
 
 export default function BunkSocialGraphModal({
   bunkCmId,

--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, Activity } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import type { Core, NodeSingular, EdgeSingular } from 'cytoscape'
+import type { Core } from 'cytoscape'
 import cytoscape from 'cytoscape'
 // @ts-expect-error - No types available for cytoscape-fcose
 import fcose from 'cytoscape-fcose'
@@ -27,10 +27,10 @@ import { getSessionShorthand } from '../utils/sessionDisplay'
 import {
   BUNK_NODE_COLORS,
   FIRST_YEAR_RING_COLOR,
-  FIRST_YEAR_RING_WIDTH,
+  getBunkCytoscapeStyles,
   getBunkGradeColors,
-  getNodeColor,
 } from './bunkGraphStyles'
+import { EDGE_COLORS } from './graph/constants'
 import { socialGraphService } from '../services/socialGraph'
 import { graphCacheService } from '../services/GraphCacheService'
 import { useApiWithAuth } from '../hooks/useApiWithAuth'
@@ -79,6 +79,10 @@ interface GraphEdge {
   // line for mutual requests (#1309).
   reciprocal: boolean
   confidence?: number
+  // `not_bunk_with` requests ship from the API with edge_type='request' (same
+  // as positive bunk_with) and are distinguished only by request_type — the
+  // shared `resolveEdgeColor` helper consults this field to pick the red hue.
+  request_type?: string | null
 }
 
 interface BunkGraphMetrics {
@@ -96,11 +100,6 @@ interface BunkGraphData {
   edges: GraphEdge[]
   metrics: BunkGraphMetrics
   health_score: number
-}
-
-// Edge type colors (matching main graph)
-const EDGE_COLORS: Record<string, string> = {
-  request: '#3498db', // Blue for all request edges
 }
 
 // Helpers hoisted to module scope: they reference no closure values and were
@@ -310,95 +309,7 @@ export default function BunkSocialGraphModal({
 
     const cy = cytoscape({
       container: containerRef.current,
-      style: [
-        {
-          selector: 'node',
-          style: {
-            'background-color': (ele: NodeSingular) => {
-              // const nodeId = parseInt(ele.id().replace('node-', ''));
-              const degree = ele.degree(false)
-              return getNodeColor(degree)
-            },
-            width: 40, // Fixed circular nodes
-            height: 40,
-            label: 'data(label)',
-            'font-size': '14px',
-            'font-weight': 600,
-            'text-valign': 'bottom',
-            'text-margin-y': 8, // More spacing from node
-            'text-wrap': 'wrap',
-            'text-max-width': '120px',
-            color: 'data(gradeColor)', // Keep grade color for text
-            'text-outline-width': 2,
-            'text-outline-color': '#ffffff',
-            'overlay-padding': '6px',
-          },
-        },
-        {
-          selector: 'node.isolated',
-          style: {
-            // Isolated nodes don't need special border styling
-          },
-        },
-        {
-          selector: 'node.first-year',
-          style: {
-            // The amber ring is the entire first-year signal — making it
-            // thicker than the default node border keeps the marker centered
-            // by geometry (no SVG badge to drift at fractional zooms) while
-            // still clearly distinguishing first-year campers.
-            'border-width': FIRST_YEAR_RING_WIDTH,
-            'border-color': FIRST_YEAR_RING_COLOR,
-            'border-style': 'solid',
-          },
-        },
-        {
-          selector: 'edge',
-          style: {
-            // Default is a dashed one-way request arrow. The backend
-            // (build_bunk_graph) already collapses mutual pairs into a single
-            // edge tagged reciprocal — those pick up the bold solid
-            // double-headed style from the edge[?reciprocal] selector below.
-            // Mirrors the session-level treatment in
-            // graph/cytoscapeStyles.ts (#1309).
-            width: 2,
-            'line-style': 'dashed',
-            'line-color': (ele: EdgeSingular) => {
-              const edgeType = ele.data('edge_type')
-              return EDGE_COLORS[edgeType] ?? '#95a5a6'
-            },
-            'target-arrow-shape': (ele: EdgeSingular) => {
-              const edgeType = ele.data('edge_type')
-              return edgeType === 'request' ? 'triangle' : 'none'
-            },
-            'target-arrow-color': (ele: EdgeSingular) => {
-              const edgeType = ele.data('edge_type')
-              return EDGE_COLORS[edgeType] ?? '#95a5a6'
-            },
-            'line-opacity': (ele: EdgeSingular) => {
-              const confidence = ele.data('confidence') ?? 0.5
-              // Opacity based on confidence: 0.3 to 0.9
-              return Math.max(0.3, Math.min(0.9, confidence))
-            },
-            'curve-style': 'straight',
-            'control-point-step-size': 40,
-            'overlay-padding': '3px',
-          },
-        },
-        {
-          selector: 'edge[?reciprocal]',
-          style: {
-            // Bold solid double-headed line for backend-collapsed mutual pairs.
-            width: 4,
-            'line-style': 'solid',
-            'source-arrow-shape': 'triangle',
-            'source-arrow-color': (ele: EdgeSingular) => {
-              const edgeType = ele.data('edge_type')
-              return EDGE_COLORS[edgeType] ?? '#95a5a6'
-            },
-          },
-        },
-      ],
+      style: getBunkCytoscapeStyles(),
       // Don't set layout in initialization - we'll run it after adding elements
       // wheelSensitivity: 0.3, // Removed to avoid warning
       minZoom: 0.5,

--- a/frontend/src/components/BunkSwapModal.test.tsx
+++ b/frontend/src/components/BunkSwapModal.test.tsx
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import BunkSwapModal from './BunkSwapModal'
+import type { BunkWithCampers } from '../types/app-types'
+
+function makeBunk(overrides: Partial<BunkWithCampers>): BunkWithCampers {
+  return {
+    id: 'bunk-x',
+    cm_id: 1001,
+    name: 'G-9',
+    gender: 'F',
+    is_active: true,
+    sort_order: 0,
+    year: 2026,
+    created: '2026-01-01T00:00:00Z',
+    updated: '2026-01-01T00:00:00Z',
+    collectionId: 'bunks',
+    collectionName: 'bunks',
+    campers: [],
+    occupancy: 0,
+    utilization: 0,
+    ...overrides,
+  } as BunkWithCampers
+}
+
+const sourceG9 = makeBunk({ id: 'g9', name: 'G-9', gender: 'F' })
+const candidates: BunkWithCampers[] = [
+  makeBunk({ id: 'g3', name: 'G-3', gender: 'F', campers: Array(10).fill({}) as never }),
+  makeBunk({ id: 'g5', name: 'G-5', gender: 'F', campers: Array(11).fill({}) as never }),
+  makeBunk({ id: 'g10b', name: 'G-10b', gender: 'F', campers: Array(10).fill({}) as never }),
+  makeBunk({ id: 'b3', name: 'B-3', gender: 'M', campers: Array(10).fill({}) as never }),
+  makeBunk({ id: 'ag7', name: 'AG-7', gender: 'F', campers: Array(8).fill({}) as never }),
+  makeBunk({ id: 'removed', name: 'Removed cabin', gender: 'F', campers: [] }),
+]
+
+describe('BunkSwapModal', () => {
+  it('renders only same-gender, non-AG, non-removed candidates', () => {
+    render(
+      <BunkSwapModal
+        source={sourceG9}
+        allBunks={[sourceG9, ...candidates]}
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+      />
+    )
+
+    // Eligible — rendered as radio inputs labeled with bunk name
+    expect(screen.getByRole('radio', { name: /G-3/ })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /G-5/ })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /G-10b/ })).toBeInTheDocument()
+
+    // Filtered out
+    expect(screen.queryByRole('radio', { name: /B-3/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('radio', { name: /AG-7/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('radio', { name: /Removed cabin/ })).not.toBeInTheDocument()
+    // Source itself never appears as a target
+    expect(screen.queryByRole('radio', { name: /^G-9/ })).not.toBeInTheDocument()
+  })
+
+  it('renders each candidate with name + camper count', () => {
+    render(
+      <BunkSwapModal
+        source={sourceG9}
+        allBunks={[sourceG9, ...candidates]}
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+      />
+    )
+    expect(screen.getByRole('radio', { name: /G-3.*10 campers/ })).toBeInTheDocument()
+  })
+
+  it('Confirm button is disabled until a target is selected', () => {
+    render(
+      <BunkSwapModal
+        source={sourceG9}
+        allBunks={[sourceG9, ...candidates]}
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+      />
+    )
+    const confirm = screen.getByRole('button', { name: /confirm swap/i })
+    expect(confirm).toBeDisabled()
+  })
+
+  it('clicking a target enables Confirm and shows it as selected', () => {
+    render(
+      <BunkSwapModal
+        source={sourceG9}
+        allBunks={[sourceG9, ...candidates]}
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+      />
+    )
+    const targetRow = screen.getByRole('radio', { name: /G-10b/ })
+    fireEvent.click(targetRow)
+    expect(targetRow).toBeChecked()
+    expect(screen.getByRole('button', { name: /confirm swap/i })).not.toBeDisabled()
+  })
+
+  it('clicking Confirm fires onConfirm with the selected bunk', () => {
+    const onConfirm = vi.fn()
+    render(
+      <BunkSwapModal
+        source={sourceG9}
+        allBunks={[sourceG9, ...candidates]}
+        onCancel={vi.fn()}
+        onConfirm={onConfirm}
+      />
+    )
+    fireEvent.click(screen.getByRole('radio', { name: /G-10b/ }))
+    fireEvent.click(screen.getByRole('button', { name: /confirm swap/i }))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    expect(onConfirm).toHaveBeenCalledWith(expect.objectContaining({ id: 'g10b', name: 'G-10b' }))
+  })
+
+  it('clicking Cancel fires onCancel and does not fire onConfirm', () => {
+    const onCancel = vi.fn()
+    const onConfirm = vi.fn()
+    render(
+      <BunkSwapModal
+        source={sourceG9}
+        allBunks={[sourceG9, ...candidates]}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('shows the empty state when no eligible candidates remain', () => {
+    render(
+      <BunkSwapModal
+        source={sourceG9}
+        allBunks={[sourceG9]}
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/no eligible bunks in this session/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /confirm swap/i })).toBeDisabled()
+  })
+})

--- a/frontend/src/components/BunkSwapModal.tsx
+++ b/frontend/src/components/BunkSwapModal.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 import { X } from 'lucide-react'
 import type { BunkWithCampers } from '../types/app-types'
 import { isEligibleSwapTarget } from '../utils/bunkSwap'
-import { extractSortKey } from './BunkSocialGraphModal'
+import { extractSortKey } from '../utils/bunkNaming'
 
 interface BunkSwapModalProps {
   source: BunkWithCampers

--- a/frontend/src/components/BunkSwapModal.tsx
+++ b/frontend/src/components/BunkSwapModal.tsx
@@ -1,0 +1,111 @@
+import { useMemo, useState } from 'react'
+import { X } from 'lucide-react'
+import type { BunkWithCampers } from '../types/app-types'
+import { isEligibleSwapTarget } from '../utils/bunkSwap'
+import { extractSortKey } from './BunkSocialGraphModal'
+
+interface BunkSwapModalProps {
+  source: BunkWithCampers
+  allBunks: BunkWithCampers[]
+  onCancel: () => void
+  onConfirm: (target: BunkWithCampers) => void
+}
+
+export default function BunkSwapModal({
+  source,
+  allBunks,
+  onCancel,
+  onConfirm,
+}: BunkSwapModalProps) {
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+
+  // Filter to eligible candidates and sort the same way the bunks-view
+  // sidebar does (Alpha/Beta first, then numeric ascending).
+  const candidates = useMemo(() => {
+    return allBunks
+      .filter((b) => isEligibleSwapTarget(source, b))
+      .sort((a, b) => {
+        const aKey = extractSortKey(a.name)
+        const bKey = extractSortKey(b.name)
+        if (aKey.primary !== bKey.primary) return aKey.primary - bKey.primary
+        return aKey.secondary.localeCompare(bKey.secondary)
+      })
+  }, [source, allBunks])
+
+  const selected = candidates.find((b) => b.id === selectedId) ?? null
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="bunk-swap-title"
+      className="fixed inset-0 z-[70] flex items-center justify-center bg-black/40"
+      onClick={onCancel}
+    >
+      <div
+        className="bg-card border-border shadow-lodge-xl w-full max-w-md rounded-2xl border p-5"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-3 flex items-center justify-between">
+          <h2 id="bunk-swap-title" className="text-base font-semibold">
+            Swap {source.name} with…
+          </h2>
+          <button type="button" onClick={onCancel} className="btn-ghost p-1" aria-label="Close">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {candidates.length === 0 ? (
+          <p className="text-muted-foreground py-6 text-center text-sm">
+            No eligible bunks in this session
+          </p>
+        ) : (
+          <div role="radiogroup" className="space-y-1">
+            {candidates.map((b) => {
+              const isSelected = b.id === selectedId
+              return (
+                <label
+                  key={b.id}
+                  className={`flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2 transition-colors ${
+                    isSelected ? 'bg-primary/10' : 'hover:bg-muted/50'
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="bunk-swap-target"
+                    value={b.id}
+                    checked={isSelected}
+                    onChange={() => setSelectedId(b.id)}
+                    aria-label={`${b.name} (${b.campers.length} campers)`}
+                  />
+                  <span className="font-medium">{b.name}</span>
+                  <span className="text-muted-foreground text-sm">
+                    · {b.campers.length} campers
+                  </span>
+                </label>
+              )
+            })}
+          </div>
+        )}
+
+        <div className="mt-4 flex justify-between">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="border-border hover:bg-muted/50 rounded-lg border px-4 py-2 text-sm font-medium"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => selected && onConfirm(selected)}
+            disabled={!selected}
+            className="bg-primary text-primary-foreground shadow-lodge-sm rounded-lg px-4 py-2 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Confirm swap
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/BunkingBoardByArea.swap.test.tsx
+++ b/frontend/src/components/BunkingBoardByArea.swap.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Integration tests for the bunk-swap action (#1546).
+ *
+ * Asserts that BunkingBoardByArea:
+ *   1. Passes onSwapClick down to each BunkCard.
+ *   2. Opens BunkSwapModal with the source bunk when a card's Swap button
+ *      is clicked.
+ *   3. Calls onCamperMove once per camper in both rosters when the user
+ *      confirms a swap, then closes the modal.
+ *   4. Does not move any campers when the modal is dismissed via Cancel.
+ *
+ * BunkCard itself is stubbed so the test exercises the wiring layer
+ * without booting dnd-kit / lock contexts. BunkSwapModal renders for real.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+
+import type { BunkWithCampers, Camper, Bunk } from '../types/app-types'
+
+vi.mock('./FloatingUnassignedBadge', () => ({ default: () => null }))
+vi.mock('./CamperDetailsPanel', () => ({ default: () => null }))
+vi.mock('./BunkSocialGraphModal', () => ({
+  default: () => null,
+  // BunkSwapModal imports `extractSortKey` from BunkSocialGraphModal; the
+  // mock must export it so the modal can sort candidates.
+  extractSortKey: (name: string) => {
+    if (name.includes('Alph')) return { primary: -2, secondary: name }
+    if (name.includes('Bet')) return { primary: -1, secondary: name }
+    const match = name.match(/[GB]-(\d+)/)
+    if (match?.[1]) return { primary: parseInt(match[1], 10), secondary: name }
+    return { primary: 999, secondary: name }
+  },
+  // bunkSwap.ts also imports `getBunkType` from this module.
+  getBunkType: (name: string): 'G' | 'B' | 'AG' => {
+    if (!name) return 'B'
+    if (/^AG(?:$|[\s-]|\d)/.test(name)) return 'AG'
+    if (name.startsWith('G-')) return 'G'
+    if (name.startsWith('B-')) return 'B'
+    return 'B'
+  },
+}))
+vi.mock('./LockGroupActionBar', () => ({ default: () => null }))
+vi.mock('./LockGroupPanel', () => ({ default: () => null }))
+
+// Stub BunkCard to expose only what the swap-wiring test needs: the bunk
+// name and a Swap button that fires onSwapClick. Keeps the test free of
+// dnd-kit / lock / context dependencies BunkCard pulls in for real.
+vi.mock('./BunkCard', () => ({
+  default: ({ bunk, onSwapClick }: { bunk: BunkWithCampers; onSwapClick?: () => void }) => (
+    <div data-testid={`bunk-card-${bunk.id}`}>
+      <span>{bunk.name}</span>
+      {onSwapClick && (
+        <button onClick={onSwapClick} aria-label={`Swap bunk ${bunk.name}`}>
+          Swap
+        </button>
+      )}
+    </div>
+  ),
+}))
+
+vi.mock('../contexts/LockGroupContext', () => ({
+  useLockGroupContext: () => ({
+    pendingCampers: [],
+    clearPendingCampers: () => {},
+    addPendingCamper: () => {},
+    removePendingCamper: () => {},
+    getCamperLockState: () => 'none',
+    getCamperLockGroup: () => null,
+    getGroupMembers: () => [],
+    scenarioId: null,
+    sessionPbId: null,
+    isDraftMode: false,
+    isLockPanelOpen: false,
+    setIsLockPanelOpen: () => {},
+    selectedGroupId: null,
+    setSelectedGroupId: () => {},
+    groups: [],
+    membersByGroup: new Map(),
+  }),
+}))
+
+vi.mock('../hooks/useCurrentYear', () => ({ useYear: () => 2026 }))
+vi.mock('../hooks/usePermissions', () => ({
+  usePermissions: () => ({ hasPermission: () => true }),
+}))
+
+import BunkingBoardByArea from './BunkingBoardByArea'
+
+function makeBunk(overrides: Partial<Bunk> = {}): Bunk {
+  return {
+    id: 'bunk-1',
+    cm_id: 1001,
+    name: 'G-9',
+    gender: 'F',
+    is_active: true,
+    sort_order: 0,
+    year: 2026,
+    created: '2026-01-01T00:00:00Z',
+    updated: '2026-01-01T00:00:00Z',
+    collectionId: 'bunks',
+    collectionName: 'bunks',
+    ...overrides,
+  } as Bunk
+}
+
+function makeCamper(overrides: Partial<Camper> & { id: string }): Camper {
+  const personCmId = parseInt(overrides.id.replace(/\D/g, ''), 10) || 9999
+  return {
+    name: 'Test Camper',
+    age: 12,
+    grade: 7,
+    gender: 'F',
+    session_cm_id: 1000001,
+    person_cm_id: personCmId,
+    created: '2026-01-01T00:00:00Z',
+    updated: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+const bunkG9 = makeBunk({ id: 'g9', name: 'G-9', gender: 'F' })
+const bunkG10b = makeBunk({ id: 'g10b', name: 'G-10b', gender: 'F' })
+const bunks = [bunkG9, bunkG10b]
+const c1 = makeCamper({ id: 'c1', assigned_bunk: 'g9' })
+const c2 = makeCamper({ id: 'c2', assigned_bunk: 'g9' })
+const c3 = makeCamper({ id: 'c3', assigned_bunk: 'g10b' })
+const campers = [c1, c2, c3]
+
+describe('BunkingBoardByArea — bunk swap', () => {
+  const baseProps = {
+    sessionId: 's1',
+    sessionCmId: 1000001,
+    bunks,
+    campers,
+    selectedArea: 'all' as const,
+    onAreaChange: () => {},
+  }
+
+  it('opens the swap modal when a bunk Swap button is clicked', () => {
+    render(<BunkingBoardByArea {...baseProps} onCamperMove={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Swap bunk G-9' }))
+    expect(screen.getByText(/Swap G-9 with/i)).toBeInTheDocument()
+  })
+
+  it('calls onCamperMove for each camper in both bunks when Confirm is clicked', async () => {
+    const onCamperMove = vi.fn().mockResolvedValue(undefined)
+    render(<BunkingBoardByArea {...baseProps} onCamperMove={onCamperMove} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Swap bunk G-9' }))
+    fireEvent.click(screen.getByRole('radio', { name: /G-10b/ }))
+    fireEvent.click(screen.getByRole('button', { name: /confirm swap/i }))
+
+    await waitFor(() => {
+      expect(onCamperMove).toHaveBeenCalledWith('c1', 'g10b')
+    })
+    expect(onCamperMove).toHaveBeenCalledWith('c2', 'g10b')
+    expect(onCamperMove).toHaveBeenCalledWith('c3', 'g9')
+    expect(onCamperMove).toHaveBeenCalledTimes(3)
+  })
+
+  it('closes the modal after a successful swap', async () => {
+    const onCamperMove = vi.fn().mockResolvedValue(undefined)
+    render(<BunkingBoardByArea {...baseProps} onCamperMove={onCamperMove} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Swap bunk G-9' }))
+    fireEvent.click(screen.getByRole('radio', { name: /G-10b/ }))
+    fireEvent.click(screen.getByRole('button', { name: /confirm swap/i }))
+    await waitFor(() => {
+      expect(screen.queryByText(/Swap G-9 with/i)).not.toBeInTheDocument()
+    })
+  })
+
+  it('does not call onCamperMove when the modal is cancelled', () => {
+    const onCamperMove = vi.fn()
+    render(<BunkingBoardByArea {...baseProps} onCamperMove={onCamperMove} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Swap bunk G-9' }))
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onCamperMove).not.toHaveBeenCalled()
+    expect(screen.queryByText(/Swap G-9 with/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/BunkingBoardByArea.swap.test.tsx
+++ b/frontend/src/components/BunkingBoardByArea.swap.test.tsx
@@ -13,32 +13,18 @@
  * without booting dnd-kit / lock contexts. BunkSwapModal renders for real.
  */
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { toast } from 'react-hot-toast'
 
 import type { BunkWithCampers, Camper, Bunk } from '../types/app-types'
 
+const { mockHasPermission } = vi.hoisted(() => ({
+  mockHasPermission: vi.fn(() => true),
+}))
+
 vi.mock('./FloatingUnassignedBadge', () => ({ default: () => null }))
 vi.mock('./CamperDetailsPanel', () => ({ default: () => null }))
-vi.mock('./BunkSocialGraphModal', () => ({
-  default: () => null,
-  // BunkSwapModal imports `extractSortKey` from BunkSocialGraphModal; the
-  // mock must export it so the modal can sort candidates.
-  extractSortKey: (name: string) => {
-    if (name.includes('Alph')) return { primary: -2, secondary: name }
-    if (name.includes('Bet')) return { primary: -1, secondary: name }
-    const match = name.match(/[GB]-(\d+)/)
-    if (match?.[1]) return { primary: parseInt(match[1], 10), secondary: name }
-    return { primary: 999, secondary: name }
-  },
-  // bunkSwap.ts also imports `getBunkType` from this module.
-  getBunkType: (name: string): 'G' | 'B' | 'AG' => {
-    if (!name) return 'B'
-    if (/^AG(?:$|[\s-]|\d)/.test(name)) return 'AG'
-    if (name.startsWith('G-')) return 'G'
-    if (name.startsWith('B-')) return 'B'
-    return 'B'
-  },
-}))
+vi.mock('./BunkSocialGraphModal', () => ({ default: () => null }))
 vi.mock('./LockGroupActionBar', () => ({ default: () => null }))
 vi.mock('./LockGroupPanel', () => ({ default: () => null }))
 
@@ -81,7 +67,7 @@ vi.mock('../contexts/LockGroupContext', () => ({
 
 vi.mock('../hooks/useCurrentYear', () => ({ useYear: () => 2026 }))
 vi.mock('../hooks/usePermissions', () => ({
-  usePermissions: () => ({ hasPermission: () => true }),
+  usePermissions: () => ({ hasPermission: mockHasPermission }),
 }))
 
 import BunkingBoardByArea from './BunkingBoardByArea'
@@ -136,6 +122,11 @@ describe('BunkingBoardByArea — bunk swap', () => {
     onAreaChange: () => {},
   }
 
+  beforeEach(() => {
+    mockHasPermission.mockReturnValue(true)
+    vi.restoreAllMocks()
+  })
+
   it('opens the swap modal when a bunk Swap button is clicked', () => {
     render(<BunkingBoardByArea {...baseProps} onCamperMove={vi.fn()} />)
     fireEvent.click(screen.getByRole('button', { name: 'Swap bunk G-9' }))
@@ -175,5 +166,29 @@ describe('BunkingBoardByArea — bunk swap', () => {
     fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
     expect(onCamperMove).not.toHaveBeenCalled()
     expect(screen.queryByText(/Swap G-9 with/i)).not.toBeInTheDocument()
+  })
+
+  it('hides the Swap button on every bunk when isProductionMode is true', () => {
+    render(<BunkingBoardByArea {...baseProps} onCamperMove={vi.fn()} isProductionMode={true} />)
+    expect(screen.queryByRole('button', { name: /Swap bunk/ })).not.toBeInTheDocument()
+  })
+
+  it('hides the Swap button when the user lacks BUNKING_MANAGE permission', () => {
+    mockHasPermission.mockReturnValue(false)
+    render(<BunkingBoardByArea {...baseProps} onCamperMove={vi.fn()} />)
+    expect(screen.queryByRole('button', { name: /Swap bunk/ })).not.toBeInTheDocument()
+  })
+
+  it('shows an error toast when a camper move rejects during swap', async () => {
+    const toastErrorSpy = vi.spyOn(toast, 'error').mockReturnValue('mock-id')
+    const onCamperMove = vi.fn().mockRejectedValue(new Error('move failed'))
+    render(<BunkingBoardByArea {...baseProps} onCamperMove={onCamperMove} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Swap bunk G-9' }))
+    fireEvent.click(screen.getByRole('radio', { name: /G-10b/ }))
+    fireEvent.click(screen.getByRole('button', { name: /confirm swap/i }))
+
+    await waitFor(() => {
+      expect(toastErrorSpy).toHaveBeenCalled()
+    })
   })
 })

--- a/frontend/src/components/BunkingBoardByArea.tsx
+++ b/frontend/src/components/BunkingBoardByArea.tsx
@@ -597,7 +597,9 @@ export default function BunkingBoardByArea(props: BunkingBoardByAreaProps) {
                       })
                     })
                   }}
-                  onSwapClick={() => setSelectedBunkForSwap(bunk)}
+                  onSwapClick={
+                    canManage && !isProductionMode ? () => setSelectedBunkForSwap(bunk) : undefined
+                  }
                   isDragging={isDragging}
                   isProductionMode={isProductionMode}
                   defaultCapacity={defaultCapacity}
@@ -704,7 +706,7 @@ export default function BunkingBoardByArea(props: BunkingBoardByAreaProps) {
       )}
 
       {/* Bunk Swap Modal — same-gender picker + Confirm flow (#1546) */}
-      {selectedBunkForSwap && (
+      {selectedBunkForSwap && canManage && !isProductionMode && (
         <BunkSwapModal
           source={selectedBunkForSwap}
           allBunks={allBunksWithCampers}
@@ -714,9 +716,14 @@ export default function BunkingBoardByArea(props: BunkingBoardByAreaProps) {
             // Close immediately so the user sees the board update as the
             // per-camper moves stream in.
             setSelectedBunkForSwap(null)
-            await swapBunks(source, target, async (camperId, bunkId) => {
-              await onCamperMove(camperId, bunkId)
-            })
+            try {
+              await swapBunks(source, target, async (camperId, bunkId) => {
+                await onCamperMove(camperId, bunkId)
+              })
+            } catch (error) {
+              console.error('Bunk swap failed:', error)
+              toast.error('Bunk swap failed — some campers may not have moved')
+            }
           }}
         />
       )}

--- a/frontend/src/components/BunkingBoardByArea.tsx
+++ b/frontend/src/components/BunkingBoardByArea.tsx
@@ -13,8 +13,10 @@ import {
 import { toast } from 'react-hot-toast'
 import type { Bunk, Camper, BunkWithCampers, DragItem } from '../types/app-types'
 import BunkCard from './BunkCard'
+import BunkSwapModal from './BunkSwapModal'
 import FloatingUnassignedBadge from './FloatingUnassignedBadge'
 import CamperDetailsPanel from './CamperDetailsPanel'
+import { swapBunks } from '../utils/bunkSwap'
 
 // Lazy load heavy components - only loads when needed
 const BunkSocialGraphModal = lazy(() => import('./BunkSocialGraphModal'))
@@ -69,6 +71,7 @@ export default function BunkingBoardByArea(props: BunkingBoardByAreaProps) {
     cmId: number
     name: string
   } | null>(null)
+  const [selectedBunkForSwap, setSelectedBunkForSwap] = useState<BunkWithCampers | null>(null)
   const [isDragging, setIsDragging] = useState(false)
   const [isUnassignedExpanded, setIsUnassignedExpanded] = useState(false)
   const [draggedGroupMembers, setDraggedGroupMembers] = useState<Camper[]>([])
@@ -203,6 +206,15 @@ export default function BunkingBoardByArea(props: BunkingBoardByAreaProps) {
   }
 
   const bunksByArea = getBunksByArea()
+
+  // Flat list of every BunkWithCampers in the session, regardless of the
+  // active area filter. Powers the swap modal's candidate picker so staff
+  // can swap across area views.
+  const allBunksWithCampers: BunkWithCampers[] = [
+    ...bunksByArea.boys,
+    ...bunksByArea.girls,
+    ...bunksByArea['all-gender'],
+  ]
 
   // Get displayed bunks based on selected area
   // React Compiler will optimize this computation
@@ -585,6 +597,7 @@ export default function BunkingBoardByArea(props: BunkingBoardByAreaProps) {
                       })
                     })
                   }}
+                  onSwapClick={() => setSelectedBunkForSwap(bunk)}
                   isDragging={isDragging}
                   isProductionMode={isProductionMode}
                   defaultCapacity={defaultCapacity}
@@ -688,6 +701,24 @@ export default function BunkingBoardByArea(props: BunkingBoardByAreaProps) {
             onBunkChange={(cmId, name) => setSelectedBunkForGraph({ cmId, name })}
           />
         </Suspense>
+      )}
+
+      {/* Bunk Swap Modal — same-gender picker + Confirm flow (#1546) */}
+      {selectedBunkForSwap && (
+        <BunkSwapModal
+          source={selectedBunkForSwap}
+          allBunks={allBunksWithCampers}
+          onCancel={() => setSelectedBunkForSwap(null)}
+          onConfirm={async (target) => {
+            const source = selectedBunkForSwap
+            // Close immediately so the user sees the board update as the
+            // per-camper moves stream in.
+            setSelectedBunkForSwap(null)
+            await swapBunks(source, target, async (camperId, bunkId) => {
+              await onCamperMove(camperId, bunkId)
+            })
+          }}
+        />
       )}
 
       {/* Lock Group Action Bar - only shown in draft mode with pending selections (lazy loaded) */}

--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -1398,4 +1398,128 @@ describe('CamperDetailsPanel', () => {
       expect(root?.classList.contains('bottom-0')).toBe(false)
     })
   })
+
+  describe('first-pick indicator (#1544)', () => {
+    /** Reuse R3 person/attendee fixtures via local references. */
+    const EMMA = mockPerson({
+      id: 'pb-emma-fp',
+      cm_id: 100,
+      first_name: 'Emma',
+      last_name: 'Johnson',
+      grade: 6,
+      year: 2025,
+      household_id: 0,
+    })
+    const RILEY = mockPerson({
+      id: 'pb-riley-fp',
+      cm_id: 200,
+      first_name: 'Riley',
+      last_name: 'Sam',
+      grade: 6,
+      year: 2025,
+      household_id: 0,
+    })
+    const EMMA_ATTENDEE: Record<string, unknown> = {
+      id: 'att-emma-fp',
+      person: 'pb-emma-fp',
+      person_id: 100,
+      session: 'sess-fp',
+      status: 'enrolled',
+      status_id: 2,
+      year: 2025,
+      collectionId: 'attendees',
+      collectionName: 'attendees',
+      created: '2025-01-01T00:00:00Z',
+      updated: '2025-01-01T00:00:00Z',
+      expand: {
+        session: {
+          id: 'sess-fp',
+          cm_id: 3001,
+          name: 'Session FP',
+          session_type: 'main',
+        },
+      },
+    }
+
+    function setupFirstPickMocks(bunkRequests: Record<string, unknown>[]) {
+      mockGetFullListPersons.mockImplementation((opts: { filter?: string }) => {
+        const filter = opts.filter ?? ''
+        if (filter.includes('cm_id = 200')) return Promise.resolve([RILEY])
+        return Promise.resolve([EMMA])
+      })
+      mockGetFullListAttendees.mockResolvedValue([EMMA_ATTENDEE])
+      mockGetFullListBunkAssignments.mockResolvedValue([])
+      mockGetFullListBunkRequests.mockResolvedValue(bunkRequests)
+      mockGetListPersons.mockResolvedValue({ items: [], totalItems: 0 })
+      mockGetListOriginalBunkRequests.mockResolvedValue({ items: [], totalItems: 0 })
+    }
+
+    it('renders FirstPickBadge on parent rows with is_first_requested=true', async () => {
+      const bunkRequests: Record<string, unknown>[] = [
+        {
+          id: 'fp-first',
+          requester_id: 100,
+          requestee_id: 200,
+          request_type: 'bunk_with',
+          source_field: SourceField.BUNK_REQUEST_FORM,
+          source: 'family',
+          status: 'resolved',
+          requested_person_name: 'Riley Sam',
+          year: 2025,
+          session_id: 3001,
+          is_reciprocal: false,
+          confidence_score: 0.95,
+          is_first_requested: true,
+          created: '2025-01-01T00:00:00Z',
+          updated: '2025-01-01T00:00:00Z',
+          collectionId: 'bunk_requests',
+          collectionName: 'bunk_requests',
+          metadata: {},
+        },
+      ]
+      setupFirstPickMocks(bunkRequests)
+
+      render(<CamperDetailsPanel camperId="100" onClose={vi.fn()} embedded={true} />)
+
+      const badge = await screen.findByLabelText('First pick')
+      expect(badge).toBeInTheDocument()
+    })
+
+    it('does not render FirstPickBadge when no request is first-requested', async () => {
+      const bunkRequests: Record<string, unknown>[] = [
+        {
+          id: 'fp-none',
+          requester_id: 100,
+          requestee_id: 200,
+          request_type: 'bunk_with',
+          source_field: SourceField.BUNK_REQUEST_FORM,
+          source: 'family',
+          status: 'resolved',
+          requested_person_name: 'Riley Sam',
+          year: 2025,
+          session_id: 3001,
+          is_reciprocal: false,
+          confidence_score: 0.95,
+          is_first_requested: false,
+          created: '2025-01-01T00:00:00Z',
+          updated: '2025-01-01T00:00:00Z',
+          collectionId: 'bunk_requests',
+          collectionName: 'bunk_requests',
+          metadata: {},
+        },
+      ]
+      setupFirstPickMocks(bunkRequests)
+
+      const { container } = render(
+        <CamperDetailsPanel camperId="100" onClose={vi.fn()} embedded={true} />
+      )
+
+      // Wait for the request row to render (Riley appears as the target name).
+      await waitFor(() => {
+        expect(container.textContent).toContain('Riley')
+      })
+
+      expect(screen.queryByLabelText('First pick')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -15,6 +15,7 @@ import {
   MessageSquareQuote,
 } from 'lucide-react'
 import { ParentStaffDivider, AgePreferenceDivider } from './camper/RequestSectionDividers'
+import FirstPickBadge from './camper/FirstPickBadge'
 import { pb } from '../lib/pocketbase'
 import { StatusBadge } from './StatusBadge'
 import {
@@ -927,6 +928,9 @@ export default function CamperDetailsPanel({
                         showSatisfaction={isConfirmedRequest(req)}
                         satisfied={sat.satisfied}
                         detail={sat.detail}
+                        badge={
+                          <FirstPickBadge isFirstRequested={req.is_first_requested ?? false} />
+                        }
                       />
                     )
                   })}

--- a/frontend/src/components/bunkGraphStyles.test.ts
+++ b/frontend/src/components/bunkGraphStyles.test.ts
@@ -10,9 +10,23 @@ import {
   BUNK_NODE_COLORS,
   FIRST_YEAR_RING_COLOR,
   FIRST_YEAR_RING_WIDTH,
+  getBunkCytoscapeStyles,
   getBunkGradeColors,
   getNodeColor,
 } from './bunkGraphStyles'
+import { EDGE_COLORS } from './graph/constants'
+
+function fakeEle(data: Record<string, unknown>): { data: (key: string) => unknown } {
+  return { data: (key: string) => data[key] }
+}
+
+function findEdgeStyle(
+  styles: ReturnType<typeof getBunkCytoscapeStyles>,
+  selector: string
+): Record<string, unknown> | undefined {
+  const entry = styles.find((s) => s.selector === selector)
+  return entry?.style as Record<string, unknown> | undefined
+}
 
 describe('getNodeColor', () => {
   it('returns the no-connections red for an isolated node', () => {
@@ -90,5 +104,50 @@ describe('FIRST_YEAR_RING_COLOR', () => {
 describe('FIRST_YEAR_RING_WIDTH', () => {
   it('is thicker than the default node border so the ring reads as a marker', () => {
     expect(FIRST_YEAR_RING_WIDTH).toBeGreaterThanOrEqual(5)
+  })
+})
+
+describe('getBunkCytoscapeStyles', () => {
+  it('returns an array of style definitions including an edge selector', () => {
+    const styles = getBunkCytoscapeStyles()
+    expect(Array.isArray(styles)).toBe(true)
+    expect(styles.find((s) => s.selector === 'edge')).toBeDefined()
+  })
+
+  it('renders not_bunk_with edges with the red line-color (parity with session graph)', () => {
+    const edgeStyle = findEdgeStyle(getBunkCytoscapeStyles(), 'edge')
+    expect(edgeStyle).toBeDefined()
+    const lineColor = edgeStyle?.['line-color'] as (ele: ReturnType<typeof fakeEle>) => string
+    expect(typeof lineColor).toBe('function')
+    const ele = fakeEle({ edge_type: 'request', request_type: 'not_bunk_with' })
+    expect(lineColor(ele)).toBe(EDGE_COLORS['not_bunk_with'])
+  })
+
+  it('renders not_bunk_with edges with the red target-arrow-color (parity with session graph)', () => {
+    const edgeStyle = findEdgeStyle(getBunkCytoscapeStyles(), 'edge')
+    const arrowColor = edgeStyle?.['target-arrow-color'] as (
+      ele: ReturnType<typeof fakeEle>
+    ) => string
+    expect(typeof arrowColor).toBe('function')
+    const ele = fakeEle({ edge_type: 'request', request_type: 'not_bunk_with' })
+    expect(arrowColor(ele)).toBe(EDGE_COLORS['not_bunk_with'])
+  })
+
+  it('renders reciprocal not_bunk_with edges with the red source-arrow-color', () => {
+    const reciprocalStyle = findEdgeStyle(getBunkCytoscapeStyles(), 'edge[?reciprocal]')
+    expect(reciprocalStyle).toBeDefined()
+    const sourceArrowColor = reciprocalStyle?.['source-arrow-color'] as (
+      ele: ReturnType<typeof fakeEle>
+    ) => string
+    expect(typeof sourceArrowColor).toBe('function')
+    const ele = fakeEle({ edge_type: 'request', request_type: 'not_bunk_with' })
+    expect(sourceArrowColor(ele)).toBe(EDGE_COLORS['not_bunk_with'])
+  })
+
+  it('keeps bunk_with edges blue (line-color unchanged for positive requests)', () => {
+    const edgeStyle = findEdgeStyle(getBunkCytoscapeStyles(), 'edge')
+    const lineColor = edgeStyle?.['line-color'] as (ele: ReturnType<typeof fakeEle>) => string
+    const ele = fakeEle({ edge_type: 'request', request_type: 'bunk_with' })
+    expect(lineColor(ele)).toBe(EDGE_COLORS['request'])
   })
 })

--- a/frontend/src/components/bunkGraphStyles.ts
+++ b/frontend/src/components/bunkGraphStyles.ts
@@ -5,6 +5,9 @@
  * and first-year badge logic can be unit-tested without booting cytoscape.
  */
 
+import type { EdgeSingular, NodeSingular, StylesheetStyle } from 'cytoscape'
+import { resolveEdgeColor } from './graph/cytoscapeStyles'
+
 export const BUNK_NODE_COLORS = {
   // Binary connection state — anything > 0 reads as "has connections".
   noConnections: '#ef4444', // red-500
@@ -50,4 +53,94 @@ export function getBunkGradeColors(grades: readonly number[]): Record<number, st
     }
   })
   return result
+}
+
+/**
+ * Cytoscape stylesheet for the per-bunk graph (BunkSocialGraphModal).
+ *
+ * Edge color/arrow resolution routes through `resolveEdgeColor` from the
+ * shared graph module so `not_bunk_with` requests render red on the bunk
+ * graph the same way they do on the session graph. Previously a local
+ * single-entry `EDGE_COLORS` map keyed on `edge_type` alone collapsed both
+ * positive and negative requests to the same blue (#1545).
+ */
+export function getBunkCytoscapeStyles(): StylesheetStyle[] {
+  return [
+    {
+      selector: 'node',
+      style: {
+        'background-color': (ele: NodeSingular) => getNodeColor(ele.degree(false)),
+        width: 40,
+        height: 40,
+        label: 'data(label)',
+        'font-size': '14px',
+        'font-weight': 600,
+        'text-valign': 'bottom',
+        'text-margin-y': 8,
+        'text-wrap': 'wrap',
+        'text-max-width': '120px',
+        // gradeColor is set per-node in the element data builder so each
+        // camper's label picks up the light → dark ramp from getBunkGradeColors.
+        color: 'data(gradeColor)',
+        'text-outline-width': 2,
+        'text-outline-color': '#ffffff',
+        'overlay-padding': '6px',
+      },
+    },
+    {
+      selector: 'node.isolated',
+      style: {
+        // Isolated nodes don't need special border styling.
+      },
+    },
+    {
+      selector: 'node.first-year',
+      style: {
+        // The amber ring is the entire first-year signal — making it
+        // thicker than the default node border keeps the marker centered
+        // by geometry (no SVG badge to drift at fractional zooms).
+        'border-width': FIRST_YEAR_RING_WIDTH,
+        'border-color': FIRST_YEAR_RING_COLOR,
+        'border-style': 'solid',
+      },
+    },
+    {
+      selector: 'edge',
+      style: {
+        // Default is a dashed one-way request arrow. The backend
+        // (build_bunk_graph) already collapses mutual pairs into a single
+        // edge tagged reciprocal — those pick up the bold solid
+        // double-headed style from the edge[?reciprocal] selector below.
+        // Mirrors the session-level treatment in graph/cytoscapeStyles.ts.
+        width: 2,
+        'line-style': 'dashed',
+        'line-color': (ele: EdgeSingular) => resolveEdgeColor(ele),
+        'target-arrow-shape': (ele: EdgeSingular) => {
+          const edgeType = ele.data('edge_type')
+          return edgeType === 'request' ? 'triangle' : 'none'
+        },
+        'target-arrow-color': (ele: EdgeSingular) => resolveEdgeColor(ele),
+        'line-opacity': (ele: EdgeSingular) => {
+          const confidence = (ele.data('confidence') as number | undefined) ?? 0.5
+          return Math.max(0.3, Math.min(0.9, confidence))
+        },
+        'curve-style': 'straight',
+        'control-point-step-size': 40,
+        'overlay-padding': '3px',
+      },
+    },
+    {
+      selector: 'edge[?reciprocal]',
+      style: {
+        // Bold solid double-headed line for backend-collapsed mutual pairs.
+        // line-color and target-arrow-color inherit from the base 'edge'
+        // rule; source-arrow-color must mirror them so a recip not_bunk_with
+        // doesn't render with a blue source arrow.
+        width: 4,
+        'line-style': 'solid',
+        'source-arrow-shape': 'triangle',
+        'source-arrow-color': (ele: EdgeSingular) => resolveEdgeColor(ele),
+      },
+    },
+  ]
 }

--- a/frontend/src/components/camper/BunkingStatusPanel.test.tsx
+++ b/frontend/src/components/camper/BunkingStatusPanel.test.tsx
@@ -860,3 +860,47 @@ describe('BunkingStatusPanel — getRequestSatisfaction lookup', () => {
     expect(pill.parentElement).toHaveAttribute('title', 'No grade on file')
   })
 })
+
+describe('BunkingStatusPanel — first-pick indicator (#1544)', () => {
+  it('renders the FirstPickBadge on parent rows when is_first_requested=true', () => {
+    const requests: EnhancedBunkRequest[] = [
+      makeRequest({
+        id: 'first-pick',
+        status: 'resolved',
+        request_type: 'bunk_with',
+        source_field: SourceField.BUNK_REQUEST_FORM,
+        requestee_id: 67890,
+        requestedPersonName: 'Liam Garcia',
+        is_first_requested: true,
+      }),
+      makeRequest({
+        id: 'other',
+        status: 'resolved',
+        request_type: 'bunk_with',
+        source_field: SourceField.BUNK_REQUEST_FORM,
+        requestee_id: 67891,
+        requestedPersonName: 'Olivia Chen',
+        is_first_requested: false,
+      }),
+    ]
+    renderPanelWith({ allBunkRequests: requests, satisfactionData: {} })
+    const badges = screen.getAllByLabelText('First pick')
+    expect(badges).toHaveLength(1)
+  })
+
+  it('does not render the FirstPickBadge when no request is first-requested', () => {
+    const requests: EnhancedBunkRequest[] = [
+      makeRequest({
+        id: 'r1',
+        status: 'resolved',
+        request_type: 'bunk_with',
+        source_field: SourceField.BUNK_REQUEST_FORM,
+        requestee_id: 67890,
+        requestedPersonName: 'Liam Garcia',
+        is_first_requested: false,
+      }),
+    ]
+    renderPanelWith({ allBunkRequests: requests, satisfactionData: {} })
+    expect(screen.queryByLabelText('First pick')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/camper/BunkingStatusPanel.tsx
+++ b/frontend/src/components/camper/BunkingStatusPanel.tsx
@@ -9,6 +9,7 @@ import { partitionRequestsBySource } from '../../utils/partitionRequestsBySource
 import { isConfirmedRequest } from '../../utils/bunkRequest'
 import { resolveBadgeBucket } from '../../utils/satisfactionLookup'
 import { BunkRequestRow } from '../BunkRequestRow'
+import FirstPickBadge from './FirstPickBadge'
 import { ParentStaffDivider, AgePreferenceDivider } from './RequestSectionDividers'
 import type { Camper } from '../../types/app-types'
 import type { EnhancedBunkRequest } from '../../hooks/camper/useAllBunkRequests'
@@ -311,6 +312,7 @@ export function BunkingStatusPanel({
                   satisfied={sat.satisfied}
                   detail={sat.detail}
                   showSatisfaction={isConfirmedRequest(req)}
+                  badge={<FirstPickBadge isFirstRequested={req.is_first_requested ?? false} />}
                 />
               )
             })}

--- a/frontend/src/components/graph/cytoscapeStyles.test.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.test.ts
@@ -6,11 +6,39 @@ import type { NodeSingular } from 'cytoscape'
 import {
   getCytoscapeStyles,
   createGraphElements,
+  resolveEdgeColor,
   type GraphNodeData,
   type GraphEdgeData,
 } from './cytoscapeStyles'
 import { EDGE_COLORS, STATUS_COLORS } from './constants'
 import { expectDefined } from '../../test/testUtils'
+
+// Minimal stub matching cytoscape's `ele.data(key)` shape used by resolveEdgeColor.
+function fakeEle(data: Record<string, unknown>): { data: (key: string) => unknown } {
+  return { data: (key: string) => data[key] }
+}
+
+describe('resolveEdgeColor', () => {
+  it('returns the not_bunk_with red for request edges with request_type=not_bunk_with', () => {
+    const ele = fakeEle({ edge_type: 'request', request_type: 'not_bunk_with' })
+    expect(resolveEdgeColor(ele)).toBe(EDGE_COLORS['not_bunk_with'])
+  })
+
+  it('returns the request blue for request edges with request_type=bunk_with', () => {
+    const ele = fakeEle({ edge_type: 'request', request_type: 'bunk_with' })
+    expect(resolveEdgeColor(ele)).toBe(EDGE_COLORS['request'])
+  })
+
+  it('returns the request blue for request edges without a request_type', () => {
+    const ele = fakeEle({ edge_type: 'request' })
+    expect(resolveEdgeColor(ele)).toBe(EDGE_COLORS['request'])
+  })
+
+  it('falls back to neutral gray for unknown edge types', () => {
+    const ele = fakeEle({ edge_type: 'sibling' })
+    expect(resolveEdgeColor(ele)).toBe('#95a5a6')
+  })
+})
 
 describe('getCytoscapeStyles', () => {
   it('returns an array of style definitions', () => {

--- a/frontend/src/components/graph/cytoscapeStyles.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.ts
@@ -40,9 +40,10 @@ export interface CytoscapeStyleOptions {
  * Map a Cytoscape edge to its color. The negative bunk request
  * ('not_bunk_with') ships from the API with edge_type='request' — same as
  * the positive 'bunk_with' — so we have to consult request_type to pick
- * the right hue.
+ * the right hue. Shared with the bunk-level graph (BunkSocialGraphModal)
+ * so both surfaces stay in lockstep on negative-request coloring.
  */
-function resolveEdgeColor(ele: { data: (key: string) => unknown }): string {
+export function resolveEdgeColor(ele: { data: (key: string) => unknown }): string {
   const edgeType = ele.data('edge_type') as string
   if (edgeType === 'request') {
     const requestType = ele.data('request_type') as string | null | undefined

--- a/frontend/src/utils/bunkNaming.test.ts
+++ b/frontend/src/utils/bunkNaming.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for the shared bunk-naming helpers.
+ *
+ * These helpers were extracted from BunkSocialGraphModal so utility
+ * modules (`utils/bunkSwap`) and the swap modal could consume them
+ * without depending on a UI component.
+ */
+import { describe, expect, it } from 'vitest'
+import { extractSortKey, getBunkType, isAGBunkName } from './bunkNaming'
+
+describe('isAGBunkName', () => {
+  it.each([
+    ['AG', true],
+    ['AG-1', true],
+    ['AG1', true],
+    ['AG Alph', true],
+    ['BAG-1', false],
+    ['B-1AG', false],
+    ['Stage-1', false],
+    ['', false],
+  ])('isAGBunkName(%s) === %s', (name, expected) => {
+    expect(isAGBunkName(name)).toBe(expected)
+  })
+})
+
+describe('getBunkType', () => {
+  it('returns B for an empty string', () => {
+    expect(getBunkType('')).toBe('B')
+  })
+
+  it('classifies boy bunks', () => {
+    expect(getBunkType('B-1')).toBe('B')
+    expect(getBunkType('B-12')).toBe('B')
+  })
+
+  it('classifies girl bunks', () => {
+    expect(getBunkType('G-1')).toBe('G')
+    expect(getBunkType('G-7')).toBe('G')
+  })
+
+  it('classifies AG bunks by prefix', () => {
+    expect(getBunkType('AG-1')).toBe('AG')
+    expect(getBunkType('AG1')).toBe('AG')
+  })
+
+  it('falls back to B for unrecognised names', () => {
+    expect(getBunkType('Cabin-5')).toBe('B')
+  })
+
+  // #1164: classification was previously a substring match (`name.includes('AG')`),
+  // which mis-classified incidental occurrences. The match must be prefix-anchored.
+  it.each([
+    ['STAGE', 'B'],
+    ['page', 'B'],
+    ['BAG-1', 'B'],
+    ['B-1AG', 'B'],
+    ['Stage-1', 'B'],
+  ])('does NOT classify %s as AG (incidental match)', (name, expected) => {
+    expect(getBunkType(name)).toBe(expected)
+  })
+})
+
+describe('extractSortKey', () => {
+  it('places Alpha bunks at primary -2', () => {
+    expect(extractSortKey('Alpha').primary).toBe(-2)
+    expect(extractSortKey('B-Alph-1').primary).toBe(-2)
+  })
+
+  it('places Beta bunks at primary -1', () => {
+    expect(extractSortKey('Beta').primary).toBe(-1)
+    expect(extractSortKey('G-Bet-2').primary).toBe(-1)
+  })
+
+  it('extracts numeric sort key for numbered bunks', () => {
+    expect(extractSortKey('B-3').primary).toBe(3)
+    expect(extractSortKey('G-10').primary).toBe(10)
+  })
+
+  it('sorts lower numbers before higher numbers', () => {
+    const k1 = extractSortKey('B-1')
+    const k2 = extractSortKey('B-9')
+    expect(k1.primary).toBeLessThan(k2.primary)
+  })
+
+  it('falls back to primary 999 for unrecognised patterns', () => {
+    expect(extractSortKey('Unknown').primary).toBe(999)
+  })
+})

--- a/frontend/src/utils/bunkNaming.ts
+++ b/frontend/src/utils/bunkNaming.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared bunk-naming helpers.
+ *
+ * Pure string predicates and sort-key extractors that classify a bunk by
+ * name. Lived in BunkSocialGraphModal until the bunk-swap feature also
+ * needed them — the modal-internal exports inverted the normal direction
+ * (utils → component) and were marked `react-refresh/only-export-components`
+ * because they were ostensibly test-only. Hoisting them here removes that
+ * coupling so utility modules can depend on them cleanly.
+ */
+
+export const isAGBunkName = (name: string): boolean => /^AG(?:$|[\s-]|\d)/.test(name)
+
+export const getBunkType = (name: string): 'G' | 'B' | 'AG' => {
+  if (!name) return 'B'
+  if (isAGBunkName(name)) return 'AG'
+  if (name.startsWith('G-')) return 'G'
+  if (name.startsWith('B-')) return 'B'
+  return 'B'
+}
+
+export const extractSortKey = (name: string): { primary: number; secondary: string } => {
+  if (name.includes('Alph')) return { primary: -2, secondary: name }
+  if (name.includes('Bet')) return { primary: -1, secondary: name }
+  const match = name.match(/[GB]-(\d+)/)
+  if (match?.[1]) return { primary: parseInt(match[1], 10), secondary: name }
+  return { primary: 999, secondary: name }
+}

--- a/frontend/src/utils/bunkSwap.test.ts
+++ b/frontend/src/utils/bunkSwap.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest'
+import { isEligibleSwapTarget, swapBunks } from './bunkSwap'
+import type { BunkWithCampers } from '../types/app-types'
+
+function makeBunk(overrides: Partial<BunkWithCampers>): BunkWithCampers {
+  return {
+    id: 'bunk-1',
+    cm_id: 1001,
+    name: 'G-3',
+    gender: 'F',
+    is_active: true,
+    sort_order: 0,
+    year: 2026,
+    created: '2026-01-01T00:00:00Z',
+    updated: '2026-01-01T00:00:00Z',
+    collectionId: 'bunks',
+    collectionName: 'bunks',
+    campers: [],
+    occupancy: 0,
+    utilization: 0,
+    ...overrides,
+  } as BunkWithCampers
+}
+
+describe('isEligibleSwapTarget', () => {
+  it('returns false when candidate is the source bunk itself', () => {
+    const source = makeBunk({ id: 'bunk-a', gender: 'F' })
+    expect(isEligibleSwapTarget(source, source)).toBe(false)
+  })
+
+  it('returns false for the "Removed cabin" sentinel name', () => {
+    const source = makeBunk({ id: 'a', gender: 'F', name: 'G-3' })
+    const candidate = makeBunk({ id: 'b', gender: 'F', name: 'Removed cabin' })
+    expect(isEligibleSwapTarget(source, candidate)).toBe(false)
+  })
+
+  it('returns false when candidate is an AG bunk', () => {
+    const source = makeBunk({ id: 'a', gender: 'F', name: 'G-3' })
+    const ag = makeBunk({ id: 'b', gender: 'F', name: 'AG-8' })
+    expect(isEligibleSwapTarget(source, ag)).toBe(false)
+  })
+
+  it('returns false when source is an AG bunk', () => {
+    const source = makeBunk({ id: 'a', gender: 'F', name: 'AG-7' })
+    const candidate = makeBunk({ id: 'b', gender: 'F', name: 'G-9' })
+    expect(isEligibleSwapTarget(source, candidate)).toBe(false)
+  })
+
+  it('returns false when genders differ', () => {
+    const source = makeBunk({ id: 'a', gender: 'F', name: 'G-3' })
+    const candidate = makeBunk({ id: 'b', gender: 'M', name: 'B-3' })
+    expect(isEligibleSwapTarget(source, candidate)).toBe(false)
+  })
+
+  it('returns true for same-gender non-AG candidate with different id', () => {
+    const source = makeBunk({ id: 'a', gender: 'F', name: 'G-3' })
+    const candidate = makeBunk({ id: 'b', gender: 'F', name: 'G-10b' })
+    expect(isEligibleSwapTarget(source, candidate)).toBe(true)
+  })
+})
+
+describe('swapBunks', () => {
+  it('moves every camper in A into B and every camper in B into A', async () => {
+    const bunkA = makeBunk({
+      id: 'bunk-a',
+      campers: [
+        { id: 'c1', name: 'Emma Johnson' } as never,
+        { id: 'c2', name: 'Liam Garcia' } as never,
+      ],
+    })
+    const bunkB = makeBunk({
+      id: 'bunk-b',
+      campers: [{ id: 'c3', name: 'Olivia Chen' } as never],
+    })
+    const moveCamper = vi.fn().mockResolvedValue(undefined)
+
+    await swapBunks(bunkA, bunkB, moveCamper)
+
+    expect(moveCamper).toHaveBeenCalledWith('c1', 'bunk-b')
+    expect(moveCamper).toHaveBeenCalledWith('c2', 'bunk-b')
+    expect(moveCamper).toHaveBeenCalledWith('c3', 'bunk-a')
+    expect(moveCamper).toHaveBeenCalledTimes(3)
+  })
+
+  it('is a no-op when both bunks are empty', async () => {
+    const bunkA = makeBunk({ id: 'a', campers: [] })
+    const bunkB = makeBunk({ id: 'b', campers: [] })
+    const moveCamper = vi.fn().mockResolvedValue(undefined)
+
+    await swapBunks(bunkA, bunkB, moveCamper)
+
+    expect(moveCamper).not.toHaveBeenCalled()
+  })
+
+  it('handles one-sided empty (A populated, B empty)', async () => {
+    const bunkA = makeBunk({
+      id: 'a',
+      campers: [{ id: 'c1' } as never, { id: 'c2' } as never],
+    })
+    const bunkB = makeBunk({ id: 'b', campers: [] })
+    const moveCamper = vi.fn().mockResolvedValue(undefined)
+
+    await swapBunks(bunkA, bunkB, moveCamper)
+
+    expect(moveCamper).toHaveBeenCalledWith('c1', 'b')
+    expect(moveCamper).toHaveBeenCalledWith('c2', 'b')
+    expect(moveCamper).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects when any single moveCamper call rejects', async () => {
+    const bunkA = makeBunk({
+      id: 'a',
+      campers: [{ id: 'c1' } as never, { id: 'c2' } as never],
+    })
+    const bunkB = makeBunk({ id: 'b', campers: [{ id: 'c3' } as never] })
+    const moveCamper = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(undefined)
+
+    await expect(swapBunks(bunkA, bunkB, moveCamper)).rejects.toThrow('boom')
+  })
+})

--- a/frontend/src/utils/bunkSwap.ts
+++ b/frontend/src/utils/bunkSwap.ts
@@ -7,7 +7,7 @@
  * unit-testable without booting the query client.
  */
 import type { BunkWithCampers } from '../types/app-types'
-import { getBunkType } from '../components/BunkSocialGraphModal'
+import { getBunkType } from './bunkNaming'
 
 /**
  * True when `candidate` is a valid target to swap with `source`. Filters:
@@ -35,6 +35,14 @@ export function isEligibleSwapTarget(source: BunkWithCampers, candidate: BunkWit
  * Not atomic: a mid-loop failure leaves the bunks in a partial-swap state.
  * Acceptable for v1 — moveCamper already toasts per-call errors and staff
  * can re-swap to recover.
+ *
+ * Lock-group invariant: lock groups are guaranteed to live entirely within
+ * a single bunk (the solver and DnD path both enforce this). Swapping
+ * bunkA ↔ bunkB therefore relocates whole lock groups together — group
+ * members in bunkA all move to bunkB and vice versa — without any
+ * group-aware logic here. This relies on the upstream invariant; if a
+ * group ever ends up split across two unrelated bunks, that's a separate
+ * bug to fix at the source, not here.
  */
 export async function swapBunks(
   bunkA: BunkWithCampers,

--- a/frontend/src/utils/bunkSwap.ts
+++ b/frontend/src/utils/bunkSwap.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure helpers for the bunk-swap action (#1546).
+ *
+ * `isEligibleSwapTarget` gates which bunks can appear in the swap picker;
+ * `swapBunks` orchestrates the moves through an injected `moveCamper`
+ * callback so the React component layer stays thin and the logic is
+ * unit-testable without booting the query client.
+ */
+import type { BunkWithCampers } from '../types/app-types'
+import { getBunkType } from '../components/BunkSocialGraphModal'
+
+/**
+ * True when `candidate` is a valid target to swap with `source`. Filters:
+ *   - candidate is not the source itself,
+ *   - candidate is not the "Removed cabin" placeholder (a bunk dropped from
+ *     this session's plan but still referenced by stranded assignments),
+ *   - neither side is an AG bunk (AG sessions use sub-bunking),
+ *   - same gender on both sides (cross-gender swap is a hard block, not a
+ *     warning).
+ */
+export function isEligibleSwapTarget(source: BunkWithCampers, candidate: BunkWithCampers): boolean {
+  if (candidate.id === source.id) return false
+  if (candidate.name === 'Removed cabin') return false
+  if (getBunkType(source.name) === 'AG') return false
+  if (getBunkType(candidate.name) === 'AG') return false
+  return candidate.gender === source.gender
+}
+
+/**
+ * Swap the entire camper rosters between two bunks. Calls `moveCamper`
+ * once per camper in both bunks — N + M total moves for bunks with N and M
+ * occupants. Promises are awaited in parallel via Promise.all; rejection
+ * of any single move bubbles out as the rejection of swapBunks.
+ *
+ * Not atomic: a mid-loop failure leaves the bunks in a partial-swap state.
+ * Acceptable for v1 — moveCamper already toasts per-call errors and staff
+ * can re-swap to recover.
+ */
+export async function swapBunks(
+  bunkA: BunkWithCampers,
+  bunkB: BunkWithCampers,
+  moveCamper: (camperId: string, bunkId: string) => Promise<void>
+): Promise<void> {
+  const aToB = bunkA.campers.map((c) => moveCamper(c.id, bunkB.id))
+  const bToA = bunkB.campers.map((c) => moveCamper(c.id, bunkA.id))
+  await Promise.all([...aToB, ...bToA])
+}


### PR DESCRIPTION
## Summary

Wife-feedback batch 3 (kindred-feedback mirror #36 + #37 + #41) — three independent frontend touches on the bunks/camper surfaces.

- **#1545** — negative requests now render red on the bunk-level graph. Session graph already handled the API quirk where `not_bunk_with` edges ship with `edge_type='request'` (distinguished only by `request_type`); bunk-level graph collapsed both into blue. Fix exports `resolveEdgeColor` from `graph/cytoscapeStyles.ts` and routes the bunk graph through the same helper via a new pure `getBunkCytoscapeStyles()` extraction.
- **#1544** — first-pick badge (green "1" chip) now surfaces on the camper modal (`CamperDetailsPanel`) and the camper full-page view (`BunkingStatusPanel`). Backend already emits `is_first_requested` (priority-keyword pick OR positional-first parent request); the badge was previously wired only on the admin-only `ParsedRequestsPanel`.
- **#1546** — full bunk swap action. Per-bunk Swap icon on each `BunkCard` opens `BunkSwapModal` with same-gender candidates in the session; click target → highlight → Confirm dispatches the existing `moveCamper` mutation N+M times via a pure `swapBunks` orchestrator. Scenario routing inherited (scenario active → draft assignments; production mode → prod assignments, same as drag-and-drop).

## Test plan

- [x] Frontend unit + component tests pass (4432, +25 new across `bunkSwap`, `BunkSwapModal`, swap wiring, `getBunkCytoscapeStyles`, `resolveEdgeColor`, FirstPickBadge integration on both panels)
- [x] `npm run type-check` clean
- [x] Lint clean on all changed files (no new errors)
- [x] Visual verify #1545 (negative-request edge now red on bunk-level graph)
- [ ] Visual verify #1544 (first-pick badge on camper modal + full-page for a parent BUNK_WITH request with `is_first_requested=true`)
- [ ] Visual verify #1546 (Swap button on each bunk; picker filters to same-gender; Confirm swaps both rosters; Cancel/X/backdrop dismiss without moving anyone)

Closes #1545, #1544, #1546.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add "Swap bunk" UI and modal to reassign campers between same‑gender bunks.
  * First‑pick indicator badge shown on priority bunk requests.
  * Improved social‑graph styling and edge color rules to distinguish request types.

* **Refactor**
  * Extract shared bunk‑naming and graph‑style helpers for consistent behavior.

* **Tests**
  * New unit and integration tests covering swap flow, graph styles, naming helpers, and first‑pick badge.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1554?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->