### PR TITLE
refactor(solver): skip impossible requests in add_objective (#1381 Phase B)

### DIFF
--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -504,7 +504,17 @@ class DirectBunkingSolver:
         # get_or_create_request_sat_var memo-shares with parent_paramount.
         ctx = self._build_solver_context()
 
-        for person_cm_id, requests in self.input.requests_by_person.items():
+        # Stream 3 Phase B (#1381): iterate self.possible_requests instead of
+        # self.input.requests_by_person.items() so the objective builder never
+        # sees a request already in impossibility_report.flat. This drops the
+        # pinned-to-0 req_satisfied BoolVar (line ~525 below for the
+        # no-valid-bunks fallback) AND frees the diminishing-returns slot the
+        # impossible request would otherwise consume, letting a possible
+        # request claim a higher-weighted slot. _validate_requests initializes
+        # possible_requests for every person in requests_by_person but only
+        # populates entries for persons in person_idx_map, so the roster guard
+        # stays.
+        for person_cm_id, requests in self.possible_requests.items():
             if person_cm_id not in self.person_idx_map:
                 continue
 

--- a/tests/unit/solver/test_impossible_request_no_sat_var.py
+++ b/tests/unit/solver/test_impossible_request_no_sat_var.py
@@ -1,0 +1,144 @@
+"""Phase B (Stream 3 / #1381): impossible requests must not produce req_satisfied
+BoolVars in the model proto.
+
+Today the objective builder iterates ``self.input.requests_by_person`` and creates
+a pinned-to-0 ``req_satisfied_<id>`` BoolVar for every bunk_with request whose
+pair has no valid bunks (line 525 in ``add_objective``). For requests already
+classified impossible by ``validate_impossibility``, this is wasted model bulk
+AND consumes a diminishing-returns slot that should belong to a possible request.
+
+Switching the loop source to ``self.possible_requests`` (which already filters
+on ``{item.request_id for item in impossibility_report.flat}`` in
+``_validate_requests``) eliminates the pinned-to-0 var and frees the slot.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any, ClassVar
+from unittest.mock import MagicMock
+
+import pytest
+
+from bunking.config import ConfigLoader
+from bunking.solver.direct_solver import DirectBunkingSolver
+from tests.unit.solver.impossibility.conftest import (
+    make_bunk,
+    make_input,
+    make_person,
+    make_request,
+)
+
+
+class _PenaltyStubLoader:
+    """Mirrors the stub in test_satvar_unification.py — penalty accessors
+    that read via ``ConfigLoader.get_instance()`` need a real-ish object."""
+
+    _values: ClassVar[dict[str, int]] = {
+        "constraint.cabin_minimum_occupancy.penalty": 0,
+        "constraint.grade_spread.penalty": 0,
+    }
+
+    def get_int(self, key: str, default: int | None = None) -> int:
+        v = self._values.get(key)
+        return int(v) if v is not None else (default if default is not None else 0)
+
+    def get_float(self, key: str, default: float | None = None) -> float:
+        v = self._values.get(key)
+        return float(v) if v is not None else (default if default is not None else 0.0)
+
+
+@pytest.fixture
+def mock_config() -> Generator[Any]:
+    cfg = MagicMock()
+
+    def _get_constraint(constraint_type: str, param: str, default: Any = None) -> Any:
+        if constraint_type == "grade_spread" and param == "max_spread":
+            return 2
+        return default if default is not None else 0
+
+    def _get_int(key: str, default: Any = None) -> Any:
+        return default if default is not None else 0
+
+    def _get_float(key: str, default: Any = None) -> Any:
+        return default if default is not None else 0.0
+
+    def _get_str(key: str, default: Any = None) -> Any:
+        if "grade_spread.mode" in key:
+            return "hard"
+        return default if default is not None else ""
+
+    def _get_bool(key: str, default: Any = None) -> Any:
+        return default if default is not None else False
+
+    def _get_priority(priority_type: str, subtype: str = "default") -> int:
+        return 4
+
+    def _get_soft_constraint_weight(constraint_name: str) -> int:
+        return 0
+
+    cfg.get_constraint.side_effect = _get_constraint
+    cfg.get_int.side_effect = _get_int
+    cfg.get_float.side_effect = _get_float
+    cfg.get_str.side_effect = _get_str
+    cfg.get_bool.side_effect = _get_bool
+    cfg.get_priority.side_effect = _get_priority
+    cfg.get_soft_constraint_weight.side_effect = _get_soft_constraint_weight
+
+    with ConfigLoader.use(_PenaltyStubLoader()):  # type: ignore[arg-type]
+        yield cfg
+
+
+def test_cross_session_bunk_with_produces_no_sat_var(mock_config: Any) -> None:
+    """A bunk_with request across sessions is classified impossible by
+    ``SessionBoundaryImpossibility``. The objective builder must skip it
+    entirely — no ``req_satisfied_<id>`` BoolVar should appear in the model
+    proto."""
+    persons = [
+        make_person(1, session=1000, gender="F"),
+        make_person(2, session=2000, gender="F"),  # different session — pair_no_shared_bunk / cross_session
+    ]
+    bunks = [
+        make_bunk(100, session=1000, gender="F"),
+        make_bunk(200, session=2000, gender="F"),
+    ]
+    impossible_req = make_request(
+        "imp1",
+        requester=1,
+        requestee=2,
+        request_type="bunk_with",
+        source_field="bunk_request_form",
+        session=1000,
+    )
+    solver = DirectBunkingSolver(make_input(persons, bunks, [impossible_req]), config_service=mock_config)
+
+    solver.add_constraints()
+    solver.add_objective()
+
+    # The impossible request must appear in impossibility_report.flat — that's
+    # the precondition for Phase B to fire.
+    impossible_ids = {item.request_id for item in solver.impossibility_report.flat}
+    assert "imp1" in impossible_ids, (
+        "Test precondition: 'imp1' should be classified impossible by validate_impossibility"
+    )
+
+    var_names = [v.name for v in solver.model.Proto().variables]
+    assert "req_satisfied_imp1" not in var_names, (
+        f"Impossible request 'imp1' produced a req_satisfied BoolVar; saw {[n for n in var_names if 'imp1' in n]}"
+    )
+
+
+def test_possible_request_still_gets_sat_var(mock_config: Any) -> None:
+    """Regression guard: switching the loop source must not drop sat vars
+    for possible requests."""
+    persons = [make_person(1, session=1000, gender="F"), make_person(2, session=1000, gender="F")]
+    bunks = [make_bunk(100, session=1000, gender="F"), make_bunk(200, session=1000, gender="F")]
+    possible_req = make_request(
+        "pos1", requester=1, requestee=2, request_type="bunk_with", source_field="bunking_notes"
+    )
+    solver = DirectBunkingSolver(make_input(persons, bunks, [possible_req]), config_service=mock_config)
+
+    solver.add_constraints()
+    solver.add_objective()
+
+    assert "pos1" in solver.request_satisfied_vars, "Possible request must still register in the shared sat-var map"

--- a/tests/unit/solver/test_impossible_request_no_sat_var.py
+++ b/tests/unit/solver/test_impossible_request_no_sat_var.py
@@ -1,15 +1,17 @@
 """Phase B (Stream 3 / #1381): impossible requests must not produce req_satisfied
 BoolVars in the model proto.
 
-Today the objective builder iterates ``self.input.requests_by_person`` and creates
-a pinned-to-0 ``req_satisfied_<id>`` BoolVar for every bunk_with request whose
-pair has no valid bunks (line 525 in ``add_objective``). For requests already
-classified impossible by ``validate_impossibility``, this is wasted model bulk
-AND consumes a diminishing-returns slot that should belong to a possible request.
+Before this PR, the objective builder iterated ``self.input.requests_by_person``
+and created a pinned-to-0 ``req_satisfied_<id>`` BoolVar for every bunk_with
+request whose pair had no valid bunks (the no-valid-bunks fallback branch in
+``add_objective``). For requests already classified impossible by
+``validate_impossibility``, that was wasted model bulk AND consumed a
+diminishing-returns slot that should belong to a possible request.
 
-Switching the loop source to ``self.possible_requests`` (which already filters
-on ``{item.request_id for item in impossibility_report.flat}`` in
-``_validate_requests``) eliminates the pinned-to-0 var and frees the slot.
+Phase B switches the loop source to ``self.possible_requests`` (which
+``_validate_requests`` populates by filtering against
+``{item.request_id for item in impossibility_report.flat}``), eliminating the
+pinned-to-0 var and freeing the slot.
 """
 
 from __future__ import annotations
@@ -142,3 +144,64 @@ def test_possible_request_still_gets_sat_var(mock_config: Any) -> None:
     solver.add_objective()
 
     assert "pos1" in solver.request_satisfied_vars, "Possible request must still register in the shared sat-var map"
+
+
+def test_impossible_request_does_not_consume_slot(mock_config: Any) -> None:
+    """Slot-accounting guard: when a person has one impossible + two possible
+    bunk_with requests, the two possible requests must claim slots 0 and 1 of
+    the diminishing-returns stack (FIRST + SECOND multipliers), not slots 1
+    and 2 (SECOND + THIRD). Without Phase B, the impossible request consumed
+    slot 0 and the possible requests fell to slots 1 and 2.
+    """
+    from bunking.solver.direct_solver import (
+        BASE_REQUEST_WEIGHT,
+        FIRST_REQUEST_MULTIPLIER,
+        SECOND_REQUEST_MULTIPLIER,
+    )
+
+    persons = [
+        make_person(1, session=1000, gender="F"),
+        make_person(2, session=1000, gender="F"),
+        make_person(3, session=1000, gender="F"),
+        make_person(4, session=2000, gender="F"),  # different session for the impossible req
+    ]
+    bunks = [
+        make_bunk(100, session=1000, gender="F"),
+        make_bunk(200, session=1000, gender="F"),
+        make_bunk(300, session=2000, gender="F"),
+    ]
+    # Order matters: impossible request first ensures pre-fix would have given
+    # it slot 0 with the possible requests pushed down to slots 1 and 2.
+    requests = [
+        make_request("imp1", requester=1, requestee=4, request_type="bunk_with", session=1000),
+        make_request("pos_a", requester=1, requestee=2, request_type="bunk_with", session=1000),
+        make_request("pos_b", requester=1, requestee=3, request_type="bunk_with", session=1000),
+    ]
+    solver = DirectBunkingSolver(make_input(persons, bunks, requests), config_service=mock_config)
+
+    solver.add_constraints()
+    solver.add_objective()
+
+    impossible_ids = {item.request_id for item in solver.impossibility_report.flat}
+    assert "imp1" in impossible_ids, "precondition: imp1 must be classified impossible"
+
+    proto = solver.model.Proto()
+    name_to_index = {v.name: i for i, v in enumerate(proto.variables)}
+    coeff_by_var: dict[int, int] = dict(zip(proto.objective.vars, proto.objective.coeffs, strict=False))
+
+    pos_a_coeff = coeff_by_var.get(name_to_index["req_satisfied_pos_a"])
+    pos_b_coeff = coeff_by_var.get(name_to_index["req_satisfied_pos_b"])
+    assert pos_a_coeff is not None, "pos_a var must appear in the objective"
+    assert pos_b_coeff is not None, "pos_b var must appear in the objective"
+
+    # CP-SAT stores Maximize objectives as their negation internally; compare
+    # by magnitude. Source multiplier defaults to 1.0 under mock_config; mutual
+    # boost doesn't apply (no reciprocal direction filed). Slot-0 = base*FIRST,
+    # slot-1 = base*SECOND.
+    expected_slot0 = int(BASE_REQUEST_WEIGHT * 1.0 * FIRST_REQUEST_MULTIPLIER)
+    expected_slot1 = int(BASE_REQUEST_WEIGHT * 1.0 * SECOND_REQUEST_MULTIPLIER)
+    actual = sorted([abs(pos_a_coeff), abs(pos_b_coeff)])
+    assert actual == sorted([expected_slot0, expected_slot1]), (
+        f"possible requests should claim slots 0+1 (magnitudes {expected_slot0}, {expected_slot1}); "
+        f"got pos_a={pos_a_coeff}, pos_b={pos_b_coeff}"
+    )


### PR DESCRIPTION
## Summary

Stream 3 / #1381 Phase B. One-line sourcing change in `add_objective`:

```python
# before
for person_cm_id, requests in self.input.requests_by_person.items():

# after
for person_cm_id, requests in self.possible_requests.items():
```

`self.possible_requests` is already populated by `_validate_requests` using the canonical `{item.request_id for item in impossibility_report.flat}` gate (post-#1429). Impossible requests no longer reach the BoolVar-creation paths in `add_objective`.

## What this drops

- The pinned-to-0 `req_satisfied_<id>` BoolVar created at `direct_solver.py:525` for every impossible `bunk_with` request (no-valid-bunks fallback).
- The diminishing-returns **slot** that impossible request would have occupied — letting a possible request claim a higher-weighted slot (FIRST_REQUEST_MULTIPLIER vs SECOND_/THIRD_PLUS_).

Net effect is **monotonically positive**: impossible pinned-to-0 vars contributed 0 to the objective anyway; their removal lets possible vars get the boost they should have had.

## What stays

Runtime "no valid bunks" fallback branches (lines 522–526 for `bunk_with`, 545–549 for `not_bunk_with`) remain as defense-in-depth for any pair-impossibility cases that slip past the predicate registry. The roster guard `if person_cm_id not in self.person_idx_map: continue` stays too — `_validate_requests` initializes `possible_requests` for every person in `requests_by_person` but only populates entries for persons in `person_idx_map`.

## Context

Phase A (executed 2026-05-20) measured `presolve_compression_ratio = 0.938` on the most recent S2 runs — presolve eliminates only ~6% of booleans, so the foundational-layer Phase C refactor (sparse `person_in_bunk` across 11 constraint modules) was closed-as-moot. Phase B was the only Stream 3 work left worth shipping. See `docs/reference/solver-roadmap.md` Stream 3 re-scope.

## Test plan

- [x] Failing test added first (TDD red): `test_cross_session_bunk_with_produces_no_sat_var` asserts no `req_satisfied_imp1` var appears in the model proto after `add_objective` for a cross-session `bunk_with`.
- [x] Test now passes (TDD green).
- [x] Regression guard: `test_possible_request_still_gets_sat_var` confirms possible requests still register in `request_satisfied_vars`.
- [x] Full solver unit suite: 328 passed.
- [x] Solver integration tests: 8 passed.
- [x] Pre-push verification: 4855 tests passed across the suite.

Closes #1381 (with Phase A close-out + Phase C closed-as-moot recorded in the roadmap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Solver no longer creates satisfaction variables for structurally impossible requests, preventing them from consuming diminishing-returns slots and improving allocation for valid requests.
* **Tests**
  * Added unit tests verifying that impossible requests produce no satisfaction variable, possible requests still do, and impossible requests do not consume objective slots.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1555?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->