### PR TITLE
fix(frontend): Group 69 — scan-it spinoffs from PR #1554

### DIFF
--- a/frontend/src/components/BunkCard.tsx
+++ b/frontend/src/components/BunkCard.tsx
@@ -91,8 +91,6 @@ function BunkCard({
   activeDragCamper = null,
 }: BunkCardProps) {
   const viewingYear = useYear()
-  // Use bunk.capacity if set, otherwise fall back to config default
-  const effectiveCapacity = bunk.capacity ?? defaultCapacity
 
   // Check if this bunk is a valid drop target for the dragged camper
   const isValidDropTarget = (): boolean => {
@@ -159,7 +157,7 @@ function BunkCard({
   const { data: requestStatus = {} } = useBunkRequestsFromContext(camperPersonIds)
 
   const utilizationColor =
-    bunk.occupancy > effectiveCapacity
+    bunk.occupancy > defaultCapacity
       ? 'text-red-600 dark:text-red-400'
       : bunk.utilization >= 90
         ? 'text-orange-600 dark:text-orange-400'
@@ -184,7 +182,7 @@ function BunkCard({
       }
     }
     // Calculate over capacity inside useMemo
-    const isOverCapacity = bunk.occupancy > effectiveCapacity
+    const isOverCapacity = bunk.occupancy > defaultCapacity
 
     // Sort campers by age (youngest to oldest)
     const sorted = [...bunk.campers].sort((a, b) => a.age - b.age)
@@ -320,7 +318,7 @@ function BunkCard({
           <div className="flex flex-col gap-1">
             <div className="flex items-center gap-3 text-sm">
               <span className={clsx('font-medium', utilizationColor)}>
-                {bunk.occupancy}/{effectiveCapacity}
+                {bunk.occupancy}/{defaultCapacity}
               </span>
               {gradeDistribution && (
                 <div className="text-muted-foreground flex-1">
@@ -433,7 +431,7 @@ function BunkCard({
       <BunkUtilizationBar
         utilization={bunk.utilization}
         occupancy={bunk.occupancy}
-        capacity={effectiveCapacity}
+        capacity={defaultCapacity}
       />
 
       {/* Campers List */}
@@ -478,7 +476,7 @@ function BunkCard({
         ageGapWarning={ageGapWarning}
         gradeRatioWarning={gradeRatioWarning}
         tooManyGradesWarning={tooManyGradesWarning}
-        capacity={effectiveCapacity}
+        capacity={defaultCapacity}
         isLocked={false}
       />
     </div>

--- a/frontend/src/components/BunkingBoardByArea.tsx
+++ b/frontend/src/components/BunkingBoardByArea.tsx
@@ -138,7 +138,7 @@ export default function BunkingBoardByArea(props: BunkingBoardByAreaProps) {
         ...bunk,
         campers: assignedCampers,
         occupancy: assignedCampers.length,
-        utilization: (assignedCampers.length / (bunk.capacity ?? defaultCapacity)) * 100,
+        utilization: (assignedCampers.length / defaultCapacity) * 100,
       }
 
       // Categorize by bunk name prefix
@@ -435,19 +435,16 @@ export default function BunkingBoardByArea(props: BunkingBoardByAreaProps) {
           toast.error(`Target bunk has reached maximum capacity (${MAX_BUNK_CAPACITY} campers)`)
           return
         }
-      } else if (targetBunk && targetBunk.occupancy >= (targetBunk.capacity ?? defaultCapacity)) {
+      } else if (targetBunk && targetBunk.occupancy >= defaultCapacity) {
         // Still allow move but show warning
         const sourceCamper = campers.find((c) => c.id === camperId)
         if (sourceCamper?.assigned_bunk !== targetBunkId) {
-          toast(
-            `⚠️ Warning: Bunk will exceed standard capacity (${DEFAULT_BUNK_CAPACITY} campers)`,
-            {
-              style: {
-                background: '#FEF3C7',
-                color: '#92400E',
-              },
-            }
-          )
+          toast(`⚠️ Warning: Bunk will exceed standard capacity (${defaultCapacity} campers)`, {
+            style: {
+              background: '#FEF3C7',
+              color: '#92400E',
+            },
+          })
         }
       }
     }

--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -272,6 +272,35 @@ describe('CamperDetailsPanel', () => {
         expect(screen.getByText('Camper not found')).toBeInTheDocument()
       })
     })
+
+    it('surfaces loading state for the parent-input fetch (#1558)', async () => {
+      // Camper data resolves so the panel renders past its top-level spinner,
+      // but the original_bunk_requests fetch is left pending so the inline
+      // loading indicator in the parent-input block is visible.
+      setupDeclinedRequestMocks()
+      mockGetListOriginalBunkRequests.mockReturnValue(new Promise(() => {}))
+
+      render(<CamperDetailsPanel camperId="100" onClose={mockOnClose} />)
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Emma/i })).toBeInTheDocument()
+      })
+      expect(screen.getByTestId('original-bunk-data-loading')).toBeInTheDocument()
+      expect(screen.queryByTestId('original-bunk-data-error')).not.toBeInTheDocument()
+    })
+
+    it('surfaces error state when the parent-input fetch fails instead of silently hiding (#1558)', async () => {
+      setupDeclinedRequestMocks()
+      mockGetListOriginalBunkRequests.mockRejectedValue(new Error('network down'))
+
+      render(<CamperDetailsPanel camperId="100" onClose={mockOnClose} />)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('original-bunk-data-error')).toBeInTheDocument()
+      })
+      expect(screen.getByRole('alert')).toHaveTextContent(/couldn't load parent input/i)
+      expect(screen.queryByTestId('original-bunk-data-loading')).not.toBeInTheDocument()
+    })
   })
 
   describe('Panel Behavior', () => {

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -550,7 +550,11 @@ export default function CamperDetailsPanel({
   // Original parent-sourced bunk-request form text (CSV import, normalized
   // per-field). Re-uses the same hook the full-page camper detail does so the
   // sidebar reads the same source of truth via `requester.cm_id`.
-  const { originalBunkData } = useOriginalBunkData(camper?.person_cm_id, currentYear)
+  const {
+    originalBunkData,
+    isLoading: isLoadingOriginalBunkData,
+    error: errorOriginalBunkData,
+  } = useOriginalBunkData(camper?.person_cm_id, currentYear)
 
   // Trigger close - for embedded mode, call directly; for slide panel, start exit animation
   const handleClose = useCallback(() => {
@@ -1143,6 +1147,28 @@ export default function CamperDetailsPanel({
               </div>
             )}
           </section>
+        )}
+
+        {/* Parent-input loading / error status row — gates the three blocks
+            below so users can tell "still fetching" / "fetch failed" apart
+            from "no parent input on file" (which silently shows nothing). */}
+        {isLoadingOriginalBunkData && (
+          <div
+            data-testid="original-bunk-data-loading"
+            className="text-muted-foreground flex items-center gap-2 px-3 py-2 text-sm italic"
+          >
+            <div className="spinner-lodge h-4 w-4" />
+            <span>Loading parent input…</span>
+          </div>
+        )}
+        {errorOriginalBunkData && !isLoadingOriginalBunkData && (
+          <div
+            data-testid="original-bunk-data-error"
+            role="alert"
+            className="rounded-r-lg border-l-2 border-red-400 bg-red-50/60 px-3 py-2 text-sm text-red-900 dark:border-red-500/60 dark:bg-red-900/20 dark:text-red-200"
+          >
+            Couldn&apos;t load parent input. Try refreshing.
+          </div>
         )}
 
         {/* Bunk Request Form — parent-sourced form input, expanded by default (quick-ref).

--- a/frontend/src/components/SessionStats.tsx
+++ b/frontend/src/components/SessionStats.tsx
@@ -32,7 +32,7 @@ export default function SessionStats({ bunks, campers, defaultCapacity = 12 }: S
   const effectiveCapacity = bunks.reduce((sum, bunk) => {
     const assignedToBunk = campers.filter((c) => c.assigned_bunk === bunk.id).length
     // If bunk is overfull, use actual occupancy as capacity for that bunk
-    return sum + Math.max(bunk.capacity ?? defaultCapacity, assignedToBunk)
+    return sum + Math.max(defaultCapacity, assignedToBunk)
   }, 0)
 
   const utilization = effectiveCapacity > 0 ? (assignedCampers.length / effectiveCapacity) * 100 : 0

--- a/frontend/src/components/SessionStats.tsx
+++ b/frontend/src/components/SessionStats.tsx
@@ -28,10 +28,8 @@ export default function SessionStats({ bunks, campers, defaultCapacity = 12 }: S
     {} as Record<'boys' | 'girls' | 'other', number>
   )
 
-  // Calculate effective capacity accounting for overfull bunks
   const effectiveCapacity = bunks.reduce((sum, bunk) => {
     const assignedToBunk = campers.filter((c) => c.assigned_bunk === bunk.id).length
-    // If bunk is overfull, use actual occupancy as capacity for that bunk
     return sum + Math.max(defaultCapacity, assignedToBunk)
   }, 0)
 

--- a/frontend/src/components/graph/cytoscapeStyles.test.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.test.ts
@@ -441,6 +441,47 @@ describe('createGraphElements', () => {
     expect(ghostParent.data.cross_scope).toBe(true)
   })
 
+  it('cross-scope edges respect showEdges visibility (#1556 — parallel pass must apply the same filter as in-scope)', () => {
+    // Same-shape inputs as the cross-scope plumbing test above, but with
+    // showEdges['request'] = false. The bunk graph's legend toggle for the
+    // `request` edge type should hide cross-scope request edges too, not just
+    // in-scope ones.
+    const cross = [
+      {
+        source: 1,
+        target: 99,
+        edge_type: 'request' as const,
+        weight: 1,
+        request_type: null,
+        confidence: null,
+        reciprocal: false,
+        cross_scope: true as const,
+      },
+    ]
+    const ghostNodes: GraphNodeData[] = [
+      {
+        id: 99,
+        name: 'Riley Sam',
+        grade: 6,
+        centrality: 0,
+        clustering: 0,
+        satisfaction_status: 'no_requests',
+        bunk_cm_id: 999,
+        community: 0,
+        first_year: false,
+      },
+    ]
+    const { edges } = createGraphElements(
+      mockNodes,
+      [],
+      mockBunksData,
+      { request: false, historical: true, school: true, cross_scope: true },
+      cross,
+      ghostNodes
+    )
+    expect(edges).toHaveLength(0)
+  })
+
   it('passes request_type from edge data to EdgeElement so styles can color negative requests differently', () => {
     const edges: GraphEdgeData[] = [
       reqEdge(1, 2, 'not_bunk_with'),

--- a/frontend/src/components/graph/cytoscapeStyles.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.ts
@@ -527,7 +527,10 @@ export function createGraphElements(
   // disjoint from pairBuckets by construction (an edge can't be both in-scope
   // and cross-scope on the same pair), so we don't need to coordinate counts
   // between the two passes.
-  const crossEdges = crossScopeEdges ?? []
+  const crossEdges = (crossScopeEdges ?? []).filter((edge) => {
+    const setting = showEdges[edge.edge_type as keyof ShowEdgesSettings]
+    return setting !== false
+  })
   const crossPairBuckets = new Map<string, CrossScopeEdgeData[]>()
   crossEdges.forEach((e) => {
     const k = pairKey(e.source, e.target)

--- a/frontend/src/hooks/camper/useOriginalBunkData.test.ts
+++ b/frontend/src/hooks/camper/useOriginalBunkData.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for useOriginalBunkData hook (#1558).
+ *
+ * Guards the contract that the hook surfaces fetch failures as `error` rather
+ * than swallowing them and returning null (which is indistinguishable from
+ * "no parent input recorded").
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '../../test/testUtils'
+import { useOriginalBunkData } from './useOriginalBunkData'
+
+const mockGetList = vi.fn()
+vi.mock('../../lib/pocketbase', () => ({
+  pb: {
+    collection: vi.fn(() => ({
+      getList: mockGetList,
+    })),
+  },
+}))
+
+describe('useOriginalBunkData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('surfaces fetch failure as `error` instead of swallowing it as null data (#1558)', async () => {
+    mockGetList.mockRejectedValue(new Error('network down'))
+
+    const { result } = renderHook(() => useOriginalBunkData(1000001, 2026), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.error).toBeInstanceOf(Error)
+    })
+    expect(result.current.error?.message).toBe('network down')
+    expect(result.current.originalBunkData).toBeNull()
+  })
+
+  it('returns null data without error when there are no records', async () => {
+    mockGetList.mockResolvedValue({ items: [], totalItems: 0 })
+
+    const { result } = renderHook(() => useOriginalBunkData(1000001, 2026), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+    expect(result.current.error).toBeNull()
+    expect(result.current.originalBunkData).toBeNull()
+  })
+})

--- a/frontend/src/hooks/camper/useOriginalBunkData.ts
+++ b/frontend/src/hooks/camper/useOriginalBunkData.ts
@@ -37,75 +37,70 @@ export function useOriginalBunkData(
         throw new Error('No camper person ID')
       }
 
-      try {
-        // Filter by relation field and year
-        const filter = `requester.cm_id = ${personCmId} && year = ${currentYear}`
-        const records = await pb
-          .collection('original_bunk_requests')
-          .getList<OriginalBunkRequestsResponse<{ requester?: PersonsResponse }>>(1, 100, {
-            filter,
-            expand: 'requester',
-          })
+      // Filter by relation field and year
+      const filter = `requester.cm_id = ${personCmId} && year = ${currentYear}`
+      const records = await pb
+        .collection('original_bunk_requests')
+        .getList<OriginalBunkRequestsResponse<{ requester?: PersonsResponse }>>(1, 100, {
+          filter,
+          expand: 'requester',
+        })
 
-        if (records.items.length === 0) {
-          return null
-        }
-
-        // Transform normalized records into denormalized object
-        const result: OriginalBunkData = {
-          person_cm_id: personCmId,
-        }
-
-        for (const record of records.items) {
-          const fieldName = record.field
-          const content = record.content
-          const updated = record.updated
-          const processed = record.processed
-
-          switch (fieldName) {
-            case 'bunk_request_form':
-              result.share_bunk_with = content
-              if (updated) result.share_bunk_with_updated = updated
-              if (processed) result.share_bunk_with_processed = processed
-              break
-            case 'staff_not_bunk_with':
-              result.do_not_share_bunk_with = content
-              if (updated) result.do_not_share_bunk_with_updated = updated
-              if (processed) result.do_not_share_bunk_with_processed = processed
-              break
-            case 'bunking_notes':
-              result.bunking_notes_notes = content
-              if (updated) result.bunking_notes_notes_updated = updated
-              if (processed) result.bunking_notes_notes_processed = processed
-              break
-            case 'internal_notes':
-              result.internal_bunk_notes = content
-              if (updated) result.internal_bunk_notes_updated = updated
-              if (processed) result.internal_bunk_notes_processed = processed
-              break
-            case 'socialize_with':
-              result.ret_parent_socialize_with_best = content
-              if (updated) result.ret_parent_socialize_with_best_updated = updated
-              if (processed) result.ret_parent_socialize_with_best_processed = processed
-              break
-          }
-        }
-
-        // Get first/last name from expanded requester if available
-        const firstRecord = records.items[0]
-        const requester = firstRecord?.expand.requester
-        if (requester?.first_name) {
-          result.first_name = requester.first_name
-        }
-        if (requester?.last_name) {
-          result.last_name = requester.last_name
-        }
-
-        return result
-      } catch (err) {
-        console.error('Error fetching original bunk requests:', err)
+      if (records.items.length === 0) {
         return null
       }
+
+      // Transform normalized records into denormalized object
+      const result: OriginalBunkData = {
+        person_cm_id: personCmId,
+      }
+
+      for (const record of records.items) {
+        const fieldName = record.field
+        const content = record.content
+        const updated = record.updated
+        const processed = record.processed
+
+        switch (fieldName) {
+          case 'bunk_request_form':
+            result.share_bunk_with = content
+            if (updated) result.share_bunk_with_updated = updated
+            if (processed) result.share_bunk_with_processed = processed
+            break
+          case 'staff_not_bunk_with':
+            result.do_not_share_bunk_with = content
+            if (updated) result.do_not_share_bunk_with_updated = updated
+            if (processed) result.do_not_share_bunk_with_processed = processed
+            break
+          case 'bunking_notes':
+            result.bunking_notes_notes = content
+            if (updated) result.bunking_notes_notes_updated = updated
+            if (processed) result.bunking_notes_notes_processed = processed
+            break
+          case 'internal_notes':
+            result.internal_bunk_notes = content
+            if (updated) result.internal_bunk_notes_updated = updated
+            if (processed) result.internal_bunk_notes_processed = processed
+            break
+          case 'socialize_with':
+            result.ret_parent_socialize_with_best = content
+            if (updated) result.ret_parent_socialize_with_best_updated = updated
+            if (processed) result.ret_parent_socialize_with_best_processed = processed
+            break
+        }
+      }
+
+      // Get first/last name from expanded requester if available
+      const firstRecord = records.items[0]
+      const requester = firstRecord?.expand.requester
+      if (requester?.first_name) {
+        result.first_name = requester.first_name
+      }
+      if (requester?.last_name) {
+        result.last_name = requester.last_name
+      }
+
+      return result
     },
     enabled: !!personCmId,
   })

--- a/frontend/src/test/mockData.ts
+++ b/frontend/src/test/mockData.ts
@@ -44,7 +44,6 @@ export const mockBunk = (overrides?: Partial<Bunk>): Bunk => ({
   id: 'bunk1',
   cm_id: 201,
   name: 'Bunk 1',
-  capacity: 12,
   gender: '',
   area_id: 0,
   is_active: true,
@@ -197,7 +196,6 @@ export const mockBunks = [
     id: 'bunk3',
     cm_id: 203,
     name: 'Bunk 10',
-    capacity: 14,
   }),
 ]
 

--- a/frontend/src/types/app-types.ts
+++ b/frontend/src/types/app-types.ts
@@ -105,10 +105,14 @@ export interface Camper {
 export type Session = CampSessionsResponse
 
 /**
- * Bunk type — PocketBase BunksResponse plus computed capacity.
- * capacity is computed from bunk_plans count, not stored in PB.
+ * Bunk type — direct alias for PocketBase BunksResponse.
+ *
+ * Note: there is no per-bunk capacity stored anywhere. Capacity is treated as
+ * a uniform `DEFAULT_BUNK_CAPACITY` (see `utils/capacityConstants`) at every
+ * reader site. If per-bunk capacity is ever introduced, model it on the bunks
+ * collection rather than re-adding a phantom optional field here.
  */
-export type Bunk = BunksResponse & { capacity?: number }
+export type Bunk = BunksResponse
 
 export interface BunkRequest {
   id: string


### PR DESCRIPTION
## Summary

Three pre-existing frontend bugs surfaced during scan-it on PR #1554 (Group 67 bunk-swap PR). All scoped, all anchors re-verified against current `main`. Single bundle PR per [triage refresh #5t](https://github.com/adamflagg/kindred/blob/main/docs/reference/issue-triage.md).

- **#1556** — bunk graph cross-scope edges bypassed the `showEdges` visibility filter (in-scope edges respect it on `cytoscapeStyles.ts:437`, but the parallel cross-scope pass at `:530` skipped the gate). Cross-scope edges now run through the same predicate, so legend toggles work on cross-scope ghost edges too.
- **#1557** — phantom `Bunk.capacity` field cleanup. The `Bunk` type declared `capacity?: number` claiming it was "computed from bunk_plans count", but nothing in `frontend/src/{hooks,services,...}` ever populated it. Five readers (`BunkCard`, `SessionStats`, two in `BunkingBoardByArea`, plus the warning-toast site) used `bunk.capacity ?? defaultCapacity` defensively against a perpetually-undefined field. Dropped the intersection type, inlined `defaultCapacity` at every reader, and aligned the BunkingBoard toast string (was: hardcoded `DEFAULT_BUNK_CAPACITY` constant while the gate read the prop). Removed the matching `capacity` overrides from `mockBunk` test fixtures.
- **#1558** — `useOriginalBunkData` silently swallowed fetch failures via a `try/catch` inside the queryFn, returning `null` indistinguishable from "no records on file". Removed the swallow so React Query populates `error`. `CamperDetailsPanel` now destructures `isLoading`/`error` and renders a small loading indicator during fetch + an error fallback row on failure (instead of leaving the parent-input section blank with no signal).

## Test plan

- [x] `npm run type-check` clean
- [x] Frontend unit suite: 4443 pass (5 new — 1 cross-scope filter test, 2 hook tests for `useOriginalBunkData`, 2 panel tests for loading/error UI)
- [x] Lint clean (prettier, eslint)
- [ ] Visual verify #1556 — toggle `request` off in bunk graph legend; cross-scope edges of that type hide
- [ ] Visual verify #1558 — open camper details panel; observe loading indicator during fetch, see error fallback if fetch fails

Closes #1556, #1557, #1558.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added loading indicator and error alert when fetching original bunk (parent) input.

* **Bug Fixes**
  * Standardized bunk capacity/occupancy displays to use the site default capacity.
  * Improved drag-and-drop warnings: explicit toast when moving would exceed the standard capacity (with clearer styling).
  * Updated graph view to respect edge-type visibility for cross-scope request edges.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->