### PR TITLE
refactor(sync): replace fmt.Sprintf progress strings with structured slog attrs

### DIFF
--- a/pocketbase/sync/financial_transactions.go
+++ b/pocketbase/sync/financial_transactions.go
@@ -103,7 +103,7 @@ func (s *FinancialTransactionsSync) SyncForYear(ctx context.Context, year int) e
 
 		// Log progress every 2000 records
 		if i > 0 && i%2000 == 0 {
-			slog.Info("Processing transactions", "progress", fmt.Sprintf("%d/%d", i, totalTxns),
+			slog.Info("Processing transactions", "current", i, "total", totalTxns,
 				"created", s.Stats.Created, "updated", s.Stats.Updated, "skipped", s.Stats.Skipped)
 		}
 

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -805,7 +805,7 @@ func (o *Orchestrator) RunDailySync(ctx context.Context) error {
 			time.Sleep(o.jobSpacing)
 		}
 
-		slog.Info("Daily sync: Starting service", "service", jobName, "progress", fmt.Sprintf("%d/%d", i+1, len(orderedJobs)))
+		slog.Info("Daily sync: Starting service", "service", jobName, "current", i+1, "total", len(orderedJobs))
 
 		// Run sync and wait for completion
 		if err := o.runSyncAndWait(ctx, jobName); err != nil {
@@ -865,7 +865,7 @@ func (o *Orchestrator) RunWeeklySync(ctx context.Context) error {
 			time.Sleep(o.jobSpacing)
 		}
 
-		slog.Info("Weekly sync: Starting service", "service", jobName, "progress", fmt.Sprintf("%d/%d", i+1, len(weeklyJobs)))
+		slog.Info("Weekly sync: Starting service", "service", jobName, "current", i+1, "total", len(weeklyJobs))
 
 		// Run sync and wait for completion
 		if err := o.runSyncAndWait(ctx, jobName); err != nil {


### PR DESCRIPTION
## Summary

- Three `slog.Info` calls in the sync package built a `"progress"` attr via `fmt.Sprintf("%d/%d", current, total)`. Replace with raw `"current"` / `"total"` key-value attrs so log aggregators can index/filter on each independently and the per-call `fmt.Sprintf` allocation in the financial-transactions hot loop goes away.
- Modernization backlog §2c row #11.

## What changed

```diff
- slog.Info("Processing transactions", "progress", fmt.Sprintf("%d/%d", i, totalTxns), ...)
+ slog.Info("Processing transactions", "current", i, "total", totalTxns, ...)
```

Same shape at `sync/orchestrator.go:808` (Daily) and `:868` (Weekly).

## Out of scope (retired)

| Site | Why skipped |
|---|---|
| `campminder/client.go:1116,1130` (`"%d/12"`) | `/12` is a literal — `"month", month, "of", 12` is silly; `"month", month` loses the "of 12" framing. Domain string, not structured data. |
| `sync/orchestrator.go:1370` (`progress :=`) | Already pre-extracted to a local var consumed by two `slog.Info` calls. The variable IS the abstraction layer; rewriting splits one line into two-key pairs in both consumers. |

Net rewrite count: **3 callsites**, not the 4 the backlog listed (line numbers also drifted — see actual locations above).

## Verification

- `go build ./...` — clean
- `go test ./sync/...` — 2038 tests pass
- `lefthook run pre-push` — all stages green
- `golangci-lint run ./sync/...` — clean (lll/etc. confirmed; lines are 106 chars after rewrite, under 120 limit)

## TDD note

Treated as a **pure rewrite** (key rename + value type change, no behavioral contract). Rule 3's "log format change ⇒ failing test first" was infeasible:
- `RunDailySync` / `RunWeeklySync` have **no unit tests** (deep DB/API dependencies, would require dependency-injection refactor).
- The `financial_transactions.Sync` test exists but doesn't capture slog output.

Writing a slog-capture test that exercises these paths is a substantially bigger refactor than the rewrite itself. Existing build + sync tests are the spec.

## Test plan

- [ ] CI passes
- [ ] Manual: trigger a daily sync and confirm logs show `current=N total=M` instead of `progress="N/M"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal synchronization logging with structured fields for improved system observability and diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->