### PR TITLE
fix(solver): input-property unsatisfied_no_possible + finish weight_for migration

### DIFF
--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -21,10 +21,10 @@ from bunking.models_v2 import (
     DirectSolverInput,
     DirectSolverOutput,
 )
+from bunking.satisfaction import weight_for
 from bunking.satisfaction.batch import satisfied_request_ids_by_person
 from bunking.satisfaction.bucket import RequestBucket, is_counted_request, is_material_parent_request
 from bunking.sync.bunk_request_processor.core.models import RequestType
-from bunking.sync.bunk_request_processor.shared.constants import SOURCE_FIELD_TO_CONFIG_KEY
 from campminder.client import get_current_season
 
 from .callbacks import BestBoundCallback, SolverProgressCallback
@@ -480,18 +480,26 @@ class DirectBunkingSolver:
         add_gender_constraints(self._build_solver_context())
 
     def _get_csv_field_multiplier(self, request: DirectBunkRequest) -> float:
-        """Get the appropriate multiplier based on source field.
+        """Objective multiplier for a request, routed through the canonical
+        `(source, type)` registry (PR #1552 completion).
 
-        Maps canonical SourceField values to config keys for lookup.
+        Matches `score_evaluator.py` / `objective_evaluator.py` byte-for-byte
+        on in-registry data and on missing config keys (per-key
+        `_WEIGHT_DEFAULTS` fallback). Off-axis combos and missing source
+        fields fall back to a neutral 1.0 with a warning — same pattern the
+        evaluators use.
         """
-        if hasattr(request, "source_field") and request.source_field:
-            config_key = SOURCE_FIELD_TO_CONFIG_KEY.get(request.source_field)
-            if config_key:
-                return self.config.get_float(f"objective.source_multipliers.{config_key}", default=1.0)
-            logger.warning(f"Unknown source_field value not in SOURCE_FIELD_TO_CONFIG_KEY: {request.source_field!r}")
-
-        # Default multiplier
-        return 1.0
+        source_field = getattr(request, "source_field", None)
+        if not source_field:
+            return 1.0
+        try:
+            return weight_for(source_field, request.request_type, self.config)
+        except ValueError:
+            logger.warning(
+                "off-axis (source, type) combo in request %s — using multiplier 1.0",
+                request.id,
+            )
+            return 1.0
 
     def add_objective(self) -> None:
         """Add objective function to maximize satisfied requests with diminishing returns."""
@@ -1095,7 +1103,15 @@ class DirectBunkingSolver:
             assignments, self.input.requests_by_person, self.input.person_by_cm_id
         )
 
-        no_possible: list[int] = []
+        # Input-property `no_possible`: placed campers in the canonical rollup
+        # (`ImpossibilityReport.campers_no_resolved_possible`). Decoupled from
+        # `all_satisfied` so the count is invariant across solve outcomes. The
+        # diagnostic-loop body below skips these campers when bucketing into
+        # material_parent_unmet / other_unmet to preserve mutual exclusivity.
+        no_possible_cm_ids: set[int] = {
+            int(entry["cm_id"]) for entry in self.impossibility_report.campers_no_resolved_possible
+        }
+        no_possible: list[int] = [cm_id for cm_id in no_possible_cm_ids if cm_id in person_to_bunk]
         material_parent_unmet: list[int] = []
         other_unmet: list[int] = []
         # Per-camper resolved-possible count, used for the violation message text.
@@ -1162,15 +1178,16 @@ class DirectBunkingSolver:
                 if any(r.id in satisfied_ids_for_person for r in resolved_possible):
                     all_campers_satisfied += 1
 
+            # Campers already accounted for as input-property `no_possible` are
+            # not eligible for the post-solve unmet buckets (mutual exclusivity).
+            if person_cm_id in no_possible_cm_ids:
+                continue
+
             resolved_ids = {r.id for r in resolved_requests}
             if any(rid in resolved_ids for rid in all_satisfied.get(person_cm_id, [])):
                 continue
 
             resolved_possible = [r for r in self.possible_requests.get(person_cm_id, []) if r.status == "resolved"]
-            if not resolved_possible:
-                no_possible.append(person_cm_id)
-                continue
-
             resolved_possible_count[person_cm_id] = len(resolved_possible)
             if any(is_material_parent_request(r) for r in resolved_possible):
                 material_parent_unmet.append(person_cm_id)

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -496,8 +496,10 @@ class DirectBunkingSolver:
             return weight_for(source_field, request.request_type, self.config)
         except ValueError:
             logger.warning(
-                "off-axis (source, type) combo in request %s — using multiplier 1.0",
+                "objective_multiplier_fallback request_id=%s source_field=%s request_type=%s multiplier=1.0 reason=off_axis_source_type",
                 request.id,
+                source_field,
+                request.request_type,
             )
             return 1.0
 

--- a/bunking/solver/impossibility.py
+++ b/bunking/solver/impossibility.py
@@ -103,7 +103,10 @@ def filter_immaterial_requests(report: ImpossibilityReport) -> ImpossibilityRepo
 
     ``by_bucket_count`` is already request-id-unique per bucket, so dropping the
     immaterial key is sufficient. ``mp_campers_entirely_impossible`` is left
-    untouched (MP-only by definition).
+    untouched (MP-only by definition). ``campers_no_resolved_possible`` is also
+    left untouched: it powers the solver-side ``unsatisfied_no_possible``
+    diagnostic and must stay an input-property invariant, independent of which
+    buckets the pre-check chooses to display.
     """
     immaterial_bucket = RequestBucket.IMMATERIAL_PARENT.value
 

--- a/bunking/solver/impossibility.py
+++ b/bunking/solver/impossibility.py
@@ -78,6 +78,12 @@ class ImpossibilityReport:
     # set is impossible. Each entry: {cm_id, name, grade, gender, session_cm_id,
     # reason_codes}. Derived from `flat` — see validate_impossibility / _camper_dict.
     mp_campers_entirely_impossible: list[dict[str, Any]] = field(default_factory=list)
+    # Camper-level rollup: roster campers with ≥1 resolved request whose ENTIRE
+    # resolved request set is impossible. Superset of mp_campers_entirely_impossible
+    # (covers STAFF and IMMATERIAL_PARENT buckets too). Powers the
+    # `unsatisfied_no_possible` diagnostic — input-property, invariant across
+    # solve outcomes.
+    campers_no_resolved_possible: list[dict[str, Any]] = field(default_factory=list)
     # request_id-unique counts per RequestBucket.value. bucket=None items are excluded.
     # Used by the admin modal's filter chips so they show counts without re-aggregating.
     by_bucket_count: dict[str, int] = field(default_factory=dict)
@@ -295,6 +301,25 @@ def validate_impossibility(input_data: DirectSolverInput, config: ConfigLoader) 
         entry = _camper_dict(person)
         entry["reason_codes"] = sorted(reason_codes)
         report.mp_campers_entirely_impossible.append(entry)
+
+    # Camper-level rollup: campers with ≥1 resolved request whose every resolved
+    # request is impossible. Scoped to resolved status (the diagnostic ignores
+    # pending/declined — solver scope only). Input-property by construction.
+    for cm_id, requests in input_data.requests_by_person.items():
+        person = ctx.person_by_cm_id.get(cm_id)
+        if person is None:
+            continue
+        resolved = [r for r in requests if r.status == "resolved"]
+        if not resolved:
+            continue
+        if not all(r.id in impossible_ids for r in resolved):
+            continue
+        reason_codes_all: set[str] = set()
+        for r in resolved:
+            reason_codes_all |= reasons_by_request.get(r.id, set())
+        entry = _camper_dict(person)
+        entry["reason_codes"] = sorted(reason_codes_all)
+        report.campers_no_resolved_possible.append(entry)
 
     return report
 

--- a/tests/unit/solver/impossibility/test_campers_no_resolved_possible.py
+++ b/tests/unit/solver/impossibility/test_campers_no_resolved_possible.py
@@ -1,0 +1,93 @@
+"""ImpossibilityReport.campers_no_resolved_possible — camper-level rollup of
+campers whose entire resolved request set is structurally impossible.
+
+Analogous to ``mp_campers_entirely_impossible`` but covers ALL resolved
+requests, not just MATERIAL_PARENT. Powers the
+``unsatisfied_no_possible`` diagnostic in
+``_check_must_satisfy_one_violations``, which must be invariant across
+solve outcomes — it counts an input-property fact (the camper has zero
+solver-actionable resolved requests), not a post-solve placement fact.
+"""
+
+from __future__ import annotations
+
+from bunking.solver.impossibility import validate_impossibility
+
+from .conftest import make_bunk, make_input, make_person, make_request
+
+
+def test_camper_with_all_resolved_requests_impossible_is_listed(mock_config):
+    """A camper whose every resolved request is impossible appears in the rollup,
+    regardless of the request bucket (MATERIAL_PARENT or STAFF)."""
+    p1 = make_person(1, session=1000001, gender="F", grade=5)
+    bunks = [make_bunk(10, session=1000001, gender="F", capacity=12)]
+    # STAFF-source request to an absent target -> impossible (target_not_in_solver).
+    requests = [
+        make_request("r1", requester=1, requestee=777, source_field="bunking_notes", session=1000001),
+    ]
+    input_data = make_input([p1], bunks, requests)
+
+    report = validate_impossibility(input_data, mock_config)
+
+    entries = report.campers_no_resolved_possible
+    assert len(entries) == 1
+    assert entries[0]["cm_id"] == 1
+    assert entries[0]["name"]  # non-empty display name
+
+
+def test_camper_with_at_least_one_possible_resolved_request_is_not_listed(mock_config):
+    """If any resolved request is possible, the camper is solver-actionable
+    and must NOT appear, even if other resolved requests are impossible."""
+    p1 = make_person(1, session=1000001, gender="F", grade=5)
+    p2 = make_person(2, session=1000001, gender="F", grade=5)
+    bunks = [make_bunk(10, session=1000001, gender="F", capacity=12)]
+    requests = [
+        make_request("r_ok", requester=1, requestee=2, session=1000001),  # possible
+        make_request("r_bad", requester=1, requestee=777, session=1000001),  # impossible
+    ]
+    input_data = make_input([p1, p2], bunks, requests)
+
+    report = validate_impossibility(input_data, mock_config)
+
+    assert report.campers_no_resolved_possible == []
+
+
+def test_camper_with_only_impossible_mp_requests_is_listed(mock_config):
+    """A camper with only MATERIAL_PARENT requests, all impossible, appears in
+    BOTH rollups — mp_campers_entirely_impossible (MP subset) AND
+    campers_no_resolved_possible (entire resolved set)."""
+    p1 = make_person(1, session=1000001, gender="F", grade=5)
+    bunks = [make_bunk(10, session=1000001, gender="F", capacity=12)]
+    requests = [make_request("r1", requester=1, requestee=777, session=1000001)]
+    input_data = make_input([p1], bunks, requests)
+
+    report = validate_impossibility(input_data, mock_config)
+
+    assert len(report.mp_campers_entirely_impossible) == 1
+    assert len(report.campers_no_resolved_possible) == 1
+    assert report.campers_no_resolved_possible[0]["cm_id"] == 1
+
+
+def test_camper_with_only_pending_requests_is_not_listed(mock_config):
+    """A camper whose only requests are pending/declined has no resolved set —
+    they are not 'no_possible'; the diagnostic ignores non-resolved requests."""
+    p1 = make_person(1, session=1000001, gender="F", grade=5)
+    bunks = [make_bunk(10, session=1000001, gender="F", capacity=12)]
+    pending_request = make_request("r1", requester=1, requestee=777, session=1000001)
+    pending_request.status = "pending"
+    input_data = make_input([p1], bunks, [pending_request])
+
+    report = validate_impossibility(input_data, mock_config)
+
+    assert report.campers_no_resolved_possible == []
+
+
+def test_camper_with_no_requests_is_not_listed(mock_config):
+    """A camper with no requests at all is not 'no_possible'."""
+    p1 = make_person(1, session=1000001, gender="F", grade=5)
+    bunks = [make_bunk(10, session=1000001, gender="F", capacity=12)]
+    input_data = make_input([p1], bunks, [])
+
+    report = validate_impossibility(input_data, mock_config)
+
+    assert report.campers_no_resolved_possible == []

--- a/tests/unit/solver/test_impossible_request_no_sat_var.py
+++ b/tests/unit/solver/test_impossible_request_no_sat_var.py
@@ -195,11 +195,14 @@ def test_impossible_request_does_not_consume_slot(mock_config: Any) -> None:
     assert pos_b_coeff is not None, "pos_b var must appear in the objective"
 
     # CP-SAT stores Maximize objectives as their negation internally; compare
-    # by magnitude. Source multiplier defaults to 1.0 under mock_config; mutual
-    # boost doesn't apply (no reciprocal direction filed). Slot-0 = base*FIRST,
-    # slot-1 = base*SECOND.
-    expected_slot0 = int(BASE_REQUEST_WEIGHT * 1.0 * FIRST_REQUEST_MULTIPLIER)
-    expected_slot1 = int(BASE_REQUEST_WEIGHT * 1.0 * SECOND_REQUEST_MULTIPLIER)
+    # by magnitude. Post-#1530 the solver routes the multiplier through the
+    # `(source, type)` registry — bunk_request_form × bunk_with → share_bunk_with
+    # weight_key with `_WEIGHT_DEFAULTS = 1.75` (mock_config has no row, so the
+    # registry default kicks in). Mutual boost doesn't apply (no reciprocal
+    # direction filed). Slot-0 = base*1.75*FIRST, slot-1 = base*1.75*SECOND.
+    source_multiplier = 1.75
+    expected_slot0 = int(BASE_REQUEST_WEIGHT * source_multiplier * FIRST_REQUEST_MULTIPLIER)
+    expected_slot1 = int(BASE_REQUEST_WEIGHT * source_multiplier * SECOND_REQUEST_MULTIPLIER)
     actual = sorted([abs(pos_a_coeff), abs(pos_b_coeff)])
     assert actual == sorted([expected_slot0, expected_slot1]), (
         f"possible requests should claim slots 0+1 (magnitudes {expected_slot0}, {expected_slot1}); "

--- a/tests/unit/solver/test_source_field_keys.py
+++ b/tests/unit/solver/test_source_field_keys.py
@@ -188,7 +188,6 @@ class TestDirectSolverCanonicalKeys:
             requester_person_cm_id=100,
             requested_person_cm_id=200,
             request_type="bunk_with",
-            priority=5,
             session_cm_id=1000,
             year=2025,
             source_field=SourceField.BUNK_REQUEST_FORM,
@@ -196,3 +195,69 @@ class TestDirectSolverCanonicalKeys:
 
         multiplier = solver._get_csv_field_multiplier(request)
         assert multiplier == 1.75
+
+    def test_multiplier_uses_registry_default_when_config_missing_key(self):
+        """#1530: when the config has no row for the key, fall back to the
+        canonical per-key default in `_WEIGHT_DEFAULTS` — same as the
+        evaluators via `weight_for` (PR #1552). The pre-fix generic
+        `default=1.0` diverged from the evaluators for socialize_preference
+        (registry default 0.6) and `do_not_share_with` (1.5)."""
+        from bunking.models_v2 import DirectBunkRequest
+        from bunking.solver.direct_solver import DirectBunkingSolver
+
+        # Config has NO entry for the multiplier — any get_float call returns the default.
+        config = MagicMock()
+        config.get_float.side_effect = lambda key, default=None: default if default is not None else 1.0
+        config.get_int.return_value = 0
+
+        solver = DirectBunkingSolver.__new__(DirectBunkingSolver)
+        solver.config = config
+
+        # socialize_preference source paired with age_preference type → registry
+        # row exists with weight_key=objective.source_multipliers.socialize_preference,
+        # which has _WEIGHT_DEFAULTS = 0.6.
+        request = DirectBunkRequest(
+            id="req-soc",
+            requester_person_cm_id=100,
+            requested_person_cm_id=None,
+            request_type="age_preference",
+            session_cm_id=1000,
+            year=2025,
+            source_field=SourceField.SOCIALIZE_WITH,
+            age_preference_target="younger",
+        )
+
+        multiplier = solver._get_csv_field_multiplier(request)
+        # Pre-fix: 1.0 (generic default). Post-fix: 0.6 (registry-aware default).
+        assert multiplier == 0.6
+
+    def test_multiplier_off_axis_combo_falls_back_to_neutral(self):
+        """An off-axis (source, type) combo not in the 14-row registry falls back
+        to a neutral 1.0 with a warning — matches the evaluators' handling
+        (`objective_evaluator.py` / `score_evaluator.py` wrap `weight_for` in a
+        try/except ValueError)."""
+        from bunking.models_v2 import DirectBunkRequest
+        from bunking.solver.direct_solver import DirectBunkingSolver
+
+        config = MagicMock()
+        config.get_float.return_value = 1.0
+        config.get_int.return_value = 0
+
+        solver = DirectBunkingSolver.__new__(DirectBunkingSolver)
+        solver.config = config
+
+        # bunk_request_form × age_preference is not a valid combo (registry row
+        # for age_preference uses socialize_with sources, not bunk_request_form).
+        request = DirectBunkRequest(
+            id="req-off",
+            requester_person_cm_id=100,
+            requested_person_cm_id=None,
+            request_type="age_preference",
+            session_cm_id=1000,
+            year=2025,
+            source_field=SourceField.BUNK_REQUEST_FORM,
+            age_preference_target="younger",
+        )
+
+        multiplier = solver._get_csv_field_multiplier(request)
+        assert multiplier == 1.0

--- a/tests/unit/solver/test_source_field_keys.py
+++ b/tests/unit/solver/test_source_field_keys.py
@@ -218,10 +218,10 @@ class TestDirectSolverCanonicalKeys:
         # which has _WEIGHT_DEFAULTS = 0.6.
         request = DirectBunkRequest(
             id="req-soc",
-            requester_person_cm_id=100,
+            requester_person_cm_id=1000001,
             requested_person_cm_id=None,
             request_type="age_preference",
-            session_cm_id=1000,
+            session_cm_id=1000001,
             year=2025,
             source_field=SourceField.SOCIALIZE_WITH,
             age_preference_target="younger",
@@ -231,33 +231,45 @@ class TestDirectSolverCanonicalKeys:
         # Pre-fix: 1.0 (generic default). Post-fix: 0.6 (registry-aware default).
         assert multiplier == 0.6
 
-    def test_multiplier_off_axis_combo_falls_back_to_neutral(self):
+    def test_multiplier_off_axis_combo_falls_back_to_neutral(self, caplog):
         """An off-axis (source, type) combo not in the 14-row registry falls back
         to a neutral 1.0 with a warning — matches the evaluators' handling
         (`objective_evaluator.py` / `score_evaluator.py` wrap `weight_for` in a
         try/except ValueError)."""
+        import logging
+
         from bunking.models_v2 import DirectBunkRequest
         from bunking.solver.direct_solver import DirectBunkingSolver
 
+        # Fail the test if the fallback path ever reads config — `weight_for`
+        # raises ValueError via classify() BEFORE touching config for off-axis
+        # combos, so a config.get_float call signals a regression to plain
+        # lookup.
         config = MagicMock()
-        config.get_float.return_value = 1.0
+        config.get_float.side_effect = AssertionError("off-axis fallback should not rely on config.get_float lookup")
         config.get_int.return_value = 0
 
         solver = DirectBunkingSolver.__new__(DirectBunkingSolver)
         solver.config = config
 
-        # bunk_request_form × age_preference is not a valid combo (registry row
-        # for age_preference uses socialize_with sources, not bunk_request_form).
+        # socialize_with × bunk_with is genuinely off-axis: SOCIALIZE_WITH only
+        # registers with age_preference, so classify() raises ValueError before
+        # weight_for ever reads config.
         request = DirectBunkRequest(
             id="req-off",
-            requester_person_cm_id=100,
-            requested_person_cm_id=None,
-            request_type="age_preference",
-            session_cm_id=1000,
+            requester_person_cm_id=1000001,
+            requested_person_cm_id=1000002,
+            request_type="bunk_with",
+            session_cm_id=1000001,
             year=2025,
-            source_field=SourceField.BUNK_REQUEST_FORM,
-            age_preference_target="younger",
+            source_field=SourceField.SOCIALIZE_WITH,
         )
 
-        multiplier = solver._get_csv_field_multiplier(request)
+        with caplog.at_level(logging.WARNING, logger="bunking.solver.direct_solver"):
+            multiplier = solver._get_csv_field_multiplier(request)
+
         assert multiplier == 1.0
+        assert any(
+            "objective_multiplier_fallback" in rec.getMessage() and "req-off" in rec.getMessage()
+            for rec in caplog.records
+        ), "expected warning emission on off-axis fallback"

--- a/tests/unit/solver/test_unsatisfied_no_possible_invariance.py
+++ b/tests/unit/solver/test_unsatisfied_no_possible_invariance.py
@@ -1,0 +1,145 @@
+"""Invariance of `unsatisfied_no_possible` across solve outcomes.
+
+Pre-fix bug (#1527): the diagnostic loop in
+`_check_must_satisfy_one_violations` gates the `no_possible` bucket on
+`all_satisfied` (post-solve), which means
+`is_request_satisfied` returning True for a structurally-impossible request
+(e.g. a cross-session `not_bunk_with` whose target lands in a different
+bunk, which the predicate treats as "no conflict possible") skips the
+camper out of `no_possible` via the `continue`. With more solve time more
+campers get a "satisfied" tag on some request and drop out — the metric
+drifts from solve-time variability despite naming itself as an
+input-property fact.
+
+The fix consults the canonical input-property rollup
+(`ImpossibilityReport.campers_no_resolved_possible`), intersected with
+placed campers — independent of post-solve satisfaction.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from bunking.models_v2 import DirectBunk, DirectBunkAssignment, DirectBunkRequest, DirectPerson, DirectSolverInput
+from bunking.solver.direct_solver import DirectBunkingSolver
+
+
+def _person(cm_id: int, session: int, gender: str = "F") -> DirectPerson:
+    return DirectPerson(
+        campminder_person_id=cm_id,
+        first_name=f"Camper{cm_id}",
+        last_name="Test",
+        grade=5,
+        birthdate="2015-01-01",
+        gender=gender,
+        session_cm_id=session,
+    )
+
+
+def _bunk(cm_id: int, session: int, gender: str = "F") -> DirectBunk:
+    return DirectBunk(
+        id=f"bunk-{cm_id}",
+        campminder_id=cm_id,
+        name=f"Bunk{cm_id}",
+        capacity=10,
+        gender=gender,
+        session_cm_id=session,
+    )
+
+
+def _req(
+    req_id: str,
+    requester: int,
+    requestee: int | None,
+    session: int,
+    request_type: str = "bunk_with",
+    source_field: str = "bunk_request_form",
+) -> DirectBunkRequest:
+    return DirectBunkRequest(
+        id=req_id,
+        requester_person_cm_id=requester,
+        requested_person_cm_id=requestee,
+        request_type=request_type,
+        source_field=source_field,
+        status="resolved",
+        session_cm_id=session,
+        year=2026,
+    )
+
+
+def _run(
+    persons: list[DirectPerson],
+    bunks: list[DirectBunk],
+    requests: list[DirectBunkRequest],
+    assignments: dict[int, tuple[int, int]],  # cm_id -> (bunk_cm_id, session_cm_id)
+) -> int:
+    """Run only the post-solve diagnostic and return unsatisfied_no_possible."""
+    input_data = DirectSolverInput(persons=persons, bunks=bunks, requests=requests)
+    solver = DirectBunkingSolver(input_data, config_service=MagicMock())
+    assignment_list = [
+        DirectBunkAssignment(person_cm_id=pid, bunk_cm_id=bid, session_cm_id=sid, year=2026)
+        for pid, (bid, sid) in assignments.items()
+    ]
+    solver._check_must_satisfy_one_violations(assignment_list)
+    return int(solver.request_validation_summary["unsatisfied_no_possible"])
+
+
+def test_post_solve_satisfaction_of_impossible_request_still_counts_no_possible() -> None:
+    """The classic drift case: a request flagged impossible (pair_no_shared_bunk
+    via cross-gender) that the post-solve predicate marks satisfied because
+    both campers happen to land in the same bunk.
+
+    Pre-fix the diagnostic's `all_satisfied` continue skips the camper since
+    one of their resolved requests is "satisfied" — the
+    `unsatisfied_no_possible` count drops despite the input-property fact
+    that the camper has zero solver-actionable resolved requests. Post-fix
+    the rollup-driven count is unaffected by post-solve placement."""
+    persons = [
+        _person(1, session=100, gender="F"),
+        _person(2, session=100, gender="M"),
+    ]
+    bunks = [
+        _bunk(2001, session=100, gender="F"),
+        _bunk(2002, session=100, gender="M"),
+    ]
+    # Cross-gender bunk_with → impossible (pair_no_shared_bunk).
+    requests = [_req("r1", requester=1, requestee=2, session=100, request_type="bunk_with")]
+
+    # Fixture places both in the same bunk — synthetic but legal for the
+    # diagnostic helper, which doesn't re-validate gender. is_request_satisfied
+    # returns True (same bunk), feeding the `all_satisfied` continue pre-fix.
+    assignments = {1: (2001, 100), 2: (2001, 100)}
+
+    count = _run(persons, bunks, requests, assignments)
+
+    # Pre-fix: 0 (gated out by the all_satisfied continue).
+    # Post-fix: 1 (input-property: camper 1 has no resolved possible requests).
+    assert count == 1
+
+
+def test_no_possible_invariant_across_satisfaction_outcomes() -> None:
+    """Two scenarios with the same input — same `unsatisfied_no_possible`
+    regardless of which post-solve placements happen to satisfy other requests.
+
+    Camper 1 has all impossible resolved requests (cross-session bunk_with).
+    Camper 3 is independent and has a possible request that varies in
+    satisfaction across the two scenarios. The metric should not move."""
+    persons = [_person(1, session=100), _person(2, session=200), _person(3, session=100), _person(4, session=100)]
+    bunks = [_bunk(2001, session=100), _bunk(2002, session=100), _bunk(2003, session=200)]
+    requests = [
+        # Camper 1: impossible cross-session bunk_with (target session 200).
+        _req("r_imp", requester=1, requestee=2, session=100, request_type="bunk_with"),
+        # Camper 3: possible bunk_with against camper 4 (same session).
+        _req("r_ok", requester=3, requestee=4, session=100, request_type="bunk_with"),
+    ]
+
+    # Scenario A: camper 3 and 4 in DIFFERENT bunks (r_ok unsatisfied).
+    a_count = _run(persons, bunks, requests, {1: (2001, 100), 2: (2003, 200), 3: (2001, 100), 4: (2002, 100)})
+
+    # Scenario B: camper 3 and 4 in SAME bunk (r_ok satisfied).
+    b_count = _run(persons, bunks, requests, {1: (2001, 100), 2: (2003, 200), 3: (2002, 100), 4: (2002, 100)})
+
+    # Both scenarios: camper 1 has no possible requests → metric == 1, invariant.
+    assert a_count == 1
+    assert b_count == 1
+    assert a_count == b_count


### PR DESCRIPTION
## Summary

Group 64 bundle: two scoped solver fixes.

### #1527 — `unsatisfied_no_possible` is now input-property

The metric was named to imply an input-property fact (campers whose entire resolved request set is structurally impossible) but drifted with solve time — the user observed 12 → 3 → 1 across 30s/60s/180s budgets on identical input.

**Root cause:** the diagnostic loop in `_check_must_satisfy_one_violations` gated `no_possible` on `all_satisfied` (post-solve via `is_request_satisfied`). When the canonical satisfaction predicate happened to mark an impossible request satisfied — `not_bunk_with` with unassigned target, cross-gender `bunk_with` synthetically placed in the same bunk, etc. — the camper got `continue`d out of the count.

**Fix:** add `campers_no_resolved_possible` rollup to `ImpossibilityReport`, populated in `validate_impossibility` alongside the existing `mp_campers_entirely_impossible`. The diagnostic now reads `no_possible = intersect(rollup, person_to_bunk)` — purely input-property, invariant across solve outcomes. The post-solve `material_parent_unmet` / `other_unmet` buckets skip campers already in `no_possible` for mutual exclusivity.

### #1530 — finish PR #1552's `weight_for` migration

PR #1552 (Phase 3 of the source/type co-evolution series tracked in `docs/architecture/request-classification.md`) routed `score_evaluator.py` + `objective_evaluator.py` source multipliers through `weight_for`, but `direct_solver._get_csv_field_multiplier` was left on the old `config.get_float(key, default=1.0)` pattern. The two surfaces diverged on missing config keys (only matters in tests/analysis paths that mock `ConfigLoader` without populating these rows): solver fell back to 1.0; evaluators fell back to per-key `_WEIGHT_DEFAULTS` (e.g. socialize_preference=0.6, share_bunk_with=1.75).

**Fix:** `_get_csv_field_multiplier` now delegates to `weight_for(source, type, config)` with the same off-axis ValueError → neutral 1.0 fallback pattern the evaluators use. The legacy `SOURCE_FIELD_TO_CONFIG_KEY` import is removed.

## Tests

- `tests/unit/solver/impossibility/test_campers_no_resolved_possible.py` (5 tests) — pin the new rollup against MP-only, STAFF-only, mixed, pending-only, and empty-request fixtures.
- `tests/unit/solver/test_unsatisfied_no_possible_invariance.py` (2 tests) — demonstrate the drift case (impossible request post-solve-marked-satisfied still counts) and assert invariance across two scenarios with the same input.
- `tests/unit/solver/test_source_field_keys.py` (+2 tests) — `_get_csv_field_multiplier` returns `_WEIGHT_DEFAULTS` value when config is missing the key; off-axis (source, type) falls back to neutral 1.0.
- `tests/unit/solver/test_impossible_request_no_sat_var.py` — updated expected magnitudes to reflect post-migration multiplier behavior (the test verifies slot-accounting, multiplier value was incidental scaffolding).

Full solver suite: 893 passed.

## Test plan

- [x] `uv run pytest tests/unit/solver/ tests/unit/bunking/` — all 893 pass
- [x] `uv run ruff format` + `uv run ruff check` — clean
- [x] `uv run mypy bunking/solver/direct_solver.py bunking/solver/impossibility.py` — clean

Closes #1527, #1530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate diagnostics for campers whose resolved requests have no possible assignments.
  * More robust request weighting with safe fallbacks and warnings for unexpected source/type combinations.

* **Tests**
  * Added comprehensive impossibility diagnostic tests covering pending requests and mixed request sets.
  * Expanded tests for request multiplier resolution, registry fallbacks, and invariance of no-possible diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->