### PR TITLE
refactor(sync): replace time.After with time.NewTimer in retry loop

### DIFF
--- a/pocketbase/sync/rate_limited_sheets_writer.go
+++ b/pocketbase/sync/rate_limited_sheets_writer.go
@@ -187,11 +187,13 @@ func (w *RateLimitedSheetsWriter) executeWithRetry(
 			sleepDuration = backoff + cryptoJitter(backoff, w.config.JitterFraction)
 		}
 
-		// Sleep with context awareness
+		// Sleep with context awareness; NewTimer avoids goroutine leak on cancellation.
+		timer := time.NewTimer(sleepDuration)
 		select {
 		case <-ctx.Done():
+			timer.Stop()
 			return fmt.Errorf("%s retry cancelled: %w", opName, ctx.Err())
-		case <-time.After(sleepDuration):
+		case <-timer.C:
 		}
 
 		// Wait on rate limiters again before retry


### PR DESCRIPTION
## What

Replaces `time.After(sleepDuration)` with `time.NewTimer` + `timer.Stop()` in `executeWithRetry` (`sync/rate_limited_sheets_writer.go`).

**Before:**
```go
select {
case <-ctx.Done():
    return fmt.Errorf("%s retry cancelled: %w", opName, ctx.Err())
case <-time.After(sleepDuration):
}
```

**After:**
```go
timer := time.NewTimer(sleepDuration)
select {
case <-ctx.Done():
    timer.Stop()
    return fmt.Errorf("%s retry cancelled: %w", opName, ctx.Err())
case <-timer.C:
}
```

## Why

`time.After` allocates a timer goroutine that is not garbage-collected until the duration fires. If the context is cancelled before the sleep completes, the goroutine leaks for the remaining backoff window. `time.NewTimer` + `Stop()` on the early-exit arm releases it immediately.

## Backlog

Closes modernization-backlog §2c row 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved resource cleanup when canceling retry operations to prevent unnecessary resource retention.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->