### PR TITLE
fix(sync): replace string error matching with sentinel errors + errors.Is

### DIFF
--- a/pocketbase/sync/orchestrator_test.go
+++ b/pocketbase/sync/orchestrator_test.go
@@ -1573,7 +1573,7 @@ func TestQueueConcurrentAccess(t *testing.T) {
 	go func() {
 		for i := range 50 {
 			_, err := o.EnqueueUnifiedSync(2020+i%10, "all", false, false, "writer")
-			if err != nil && !strings.Contains(err.Error(), "full") && !strings.Contains(err.Error(), "duplicate") {
+			if err != nil {
 				errChan <- err
 			}
 		}

--- a/pocketbase/sync/scheduler.go
+++ b/pocketbase/sync/scheduler.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -10,6 +11,9 @@ import (
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/robfig/cron/v3"
 )
+
+// ErrUnknownSyncType is returned by TriggerSync when the sync type is not recognised.
+var ErrUnknownSyncType = errors.New("unknown sync type")
 
 // LogRetentionDays is the number of days to keep solver_runs logs before auto-pruning
 // This is hardcoded as it's an infrastructure setting, not a business rule
@@ -246,7 +250,7 @@ func (s *Scheduler) TriggerSync(ctx context.Context, syncType string) error {
 	case "custom-values":
 		return s.orchestrator.RunCustomValuesSync(ctx)
 	default:
-		return fmt.Errorf("unknown sync type: %s", syncType)
+		return fmt.Errorf("unknown sync type %q: %w", syncType, ErrUnknownSyncType)
 	}
 }
 

--- a/pocketbase/sync/scheduler.go
+++ b/pocketbase/sync/scheduler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/robfig/cron/v3"
 )
 
-// ErrUnknownSyncType is returned by TriggerSync when the sync type is not recognised.
+// ErrUnknownSyncType is returned by TriggerSync when the sync type is not recognized.
 var ErrUnknownSyncType = errors.New("unknown sync type")
 
 // LogRetentionDays is the number of days to keep solver_runs logs before auto-pruning

--- a/pocketbase/sync/scheduler_test.go
+++ b/pocketbase/sync/scheduler_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -65,9 +66,8 @@ func TestSchedulerUnknownSyncType(t *testing.T) {
 		t.Error("expected error for unknown sync type")
 	}
 
-	expectedMsg := "unknown sync type: invalid-type"
-	if err.Error() != expectedMsg {
-		t.Errorf("expected error %q, got %q", expectedMsg, err.Error())
+	if !errors.Is(err, ErrUnknownSyncType) {
+		t.Errorf("expected ErrUnknownSyncType, got %v", err)
 	}
 }
 
@@ -100,8 +100,8 @@ func TestSchedulerTriggerSyncCustomValues(t *testing.T) {
 
 	// TriggerSync should handle custom-values type
 	err := s.TriggerSync(context.Background(), "custom-values")
-	// It should not return "unknown sync type" error
-	if err != nil && err.Error() == "unknown sync type: custom-values" {
+	// It should not return ErrUnknownSyncType
+	if err != nil && errors.Is(err, ErrUnknownSyncType) {
 		t.Error("TriggerSync should handle custom-values type")
 	}
 }

--- a/pocketbase/sync/workbook_manager_test.go
+++ b/pocketbase/sync/workbook_manager_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/pocketbase/pocketbase/tests"
@@ -477,7 +478,7 @@ func TestGetOrCreateGlobalsWorkbook_DriveSearchFails_ContinuesToCreate(t *testin
 	}
 
 	// Error should be from CreateSpreadsheet (no credentials), not from Drive search
-	if err != nil && err.Error() == context.DeadlineExceeded.Error() {
+	if errors.Is(err, context.DeadlineExceeded) {
 		t.Error("Drive search error should not propagate - should continue to create")
 	}
 }


### PR DESCRIPTION
## What

Replaces string-based error matching with Go sentinel errors and \`errors.Is\`.

### Changes

**\`sync/scheduler.go\`** — define sentinel and wrap at the return site:
\`\`\`go
var ErrUnknownSyncType = errors.New("unknown sync type")
// ...
return fmt.Errorf("unknown sync type %q: %w", syncType, ErrUnknownSyncType)
\`\`\`

**\`sync/scheduler_test.go\`** — use \`errors.Is\` instead of message string comparison:
\`\`\`go
// before
if err.Error() != "unknown sync type: invalid-type" { ... }
if err != nil && err.Error() == "unknown sync type: custom-values" { ... }

// after
if !errors.Is(err, ErrUnknownSyncType) { ... }
if err != nil && errors.Is(err, ErrUnknownSyncType) { ... }
\`\`\`

**\`sync/workbook_manager_test.go\`** — use stdlib sentinel directly:
\`\`\`go
// before
if err != nil && err.Error() == context.DeadlineExceeded.Error() { ... }

// after
if errors.Is(err, context.DeadlineExceeded) { ... }
\`\`\`

**\`sync/orchestrator_test.go\`** — remove dead string-filter branches:
\`EnqueueUnifiedSync\` returns the existing item (not an error) on duplicates and has no queue-full path, so \`strings.Contains(err.Error(), "full"/"duplicate")\` were dead branches.

## Why

\`errors.Is\` respects the full error chain; string matching breaks when errors are wrapped and is fragile to message wording changes. The scheduler sentinel gives callers a stable, wrapping-safe contract.

## Backlog

Closes modernization-backlog §2c row 13. The \`rate_limited_sheets_writer.go\` string fallback in \`is429Error\` was retired from this row — it is a defensive last resort after \`errors.As(*googleapi.Error)\` and removing it without knowing all wrapping paths in the Google client library is risky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced error-handling validation in sync orchestration to surface all enqueue errors.
  * Updated scheduler and workbook manager tests to use robust error-unwrapping assertions.

* **Chores**
  * Added explicit handling for unknown sync types and standardized related error reporting for clearer diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->