### PR TITLE
refactor(sync): adopt testing/synctest for time-based sync tests

### DIFF
--- a/pocketbase/sync/orchestrator_test.go
+++ b/pocketbase/sync/orchestrator_test.go
@@ -682,13 +682,16 @@ func TestRunSingleSyncRespectsPreMarkedStatus(t *testing.T) {
 			t.Errorf("expected 1 call to Sync, got %d", mock.GetCallCount())
 		}
 
-		// The status should have been updated to success
+		// The status should have been moved to lastCompletedStatus on success
 		o.mu.RLock()
-		finalStatus := o.runningJobs["test"]
+		completedStatus := o.lastCompletedStatus["test"]
 		o.mu.RUnlock()
 
+		if completedStatus == nil {
+			t.Fatal("expected completed status, got nil")
+		}
 		// Start time should be preserved from pre-marked status
-		if finalStatus != nil && !finalStatus.StartTime.Equal(preMarkedStartTime) {
+		if !completedStatus.StartTime.Equal(preMarkedStartTime) {
 			t.Errorf("expected StartTime to be preserved from MarkSyncRunning, got different time")
 		}
 	})

--- a/pocketbase/sync/orchestrator_test.go
+++ b/pocketbase/sync/orchestrator_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -647,48 +648,50 @@ func TestMarkSyncRunningPreservesStatus(t *testing.T) {
 // TestRunSingleSyncRespectsPreMarkedStatus tests that RunSingleSync uses existing status
 // if MarkSyncRunning was called first
 func TestRunSingleSyncRespectsPreMarkedStatus(t *testing.T) {
-	o := NewOrchestrator(nil)
+	synctest.Test(t, func(t *testing.T) {
+		o := NewOrchestrator(nil)
 
-	// Register a fast mock service
-	mock := &MockService{name: "test_service", delay: 10 * time.Millisecond}
-	o.RegisterService("test", mock)
+		// Register a fast mock service
+		mock := &MockService{name: "test_service", delay: 10 * time.Millisecond}
+		o.RegisterService("test", mock)
 
-	// Pre-mark as running (simulating what API handler will do)
-	err := o.MarkSyncRunning("test")
-	if err != nil {
-		t.Fatalf("MarkSyncRunning failed: %v", err)
-	}
+		// Pre-mark as running (simulating what API handler will do)
+		err := o.MarkSyncRunning("test")
+		if err != nil {
+			t.Fatalf("MarkSyncRunning failed: %v", err)
+		}
 
-	// Get the start time from pre-marked status
-	o.mu.RLock()
-	preMarkedStatus := o.runningJobs["test"]
-	preMarkedStartTime := preMarkedStatus.StartTime
-	o.mu.RUnlock()
+		// Get the start time from pre-marked status
+		o.mu.RLock()
+		preMarkedStatus := o.runningJobs["test"]
+		preMarkedStartTime := preMarkedStatus.StartTime
+		o.mu.RUnlock()
 
-	// RunSingleSync should use the existing status, not create a new one
-	ctx := context.Background()
-	err = o.RunSingleSync(ctx, "test")
-	if err != nil {
-		t.Fatalf("RunSingleSync failed: %v", err)
-	}
+		// RunSingleSync should use the existing status, not create a new one
+		ctx := context.Background()
+		err = o.RunSingleSync(ctx, "test")
+		if err != nil {
+			t.Fatalf("RunSingleSync failed: %v", err)
+		}
 
-	// Wait for the sync goroutine to complete
-	time.Sleep(50 * time.Millisecond)
+		// Wait for the sync goroutine to complete (virtual time advances past the mock's 10ms delay).
+		time.Sleep(50 * time.Millisecond)
 
-	// Check that the service was actually called
-	if mock.GetCallCount() != 1 {
-		t.Errorf("expected 1 call to Sync, got %d", mock.GetCallCount())
-	}
+		// Check that the service was actually called
+		if mock.GetCallCount() != 1 {
+			t.Errorf("expected 1 call to Sync, got %d", mock.GetCallCount())
+		}
 
-	// The status should have been updated to success
-	o.mu.RLock()
-	finalStatus := o.runningJobs["test"]
-	o.mu.RUnlock()
+		// The status should have been updated to success
+		o.mu.RLock()
+		finalStatus := o.runningJobs["test"]
+		o.mu.RUnlock()
 
-	// Start time should be preserved from pre-marked status
-	if finalStatus != nil && !finalStatus.StartTime.Equal(preMarkedStartTime) {
-		t.Errorf("expected StartTime to be preserved from MarkSyncRunning, got different time")
-	}
+		// Start time should be preserved from pre-marked status
+		if finalStatus != nil && !finalStatus.StartTime.Equal(preMarkedStartTime) {
+			t.Errorf("expected StartTime to be preserved from MarkSyncRunning, got different time")
+		}
+	})
 }
 
 // TestHistoricalSyncIncludesCustomValueServices verifies custom value services are
@@ -945,156 +948,162 @@ func TestWeeklySyncJobsCount(t *testing.T) {
 // deadlines appropriately, fixing the "rate limiter wait: context deadline exceeded" issue.
 func TestRunSingleSyncContextDeadlineHandling(t *testing.T) {
 	t.Run("uses parent context when deadline is generous", func(t *testing.T) {
-		o := NewOrchestrator(nil)
+		synctest.Test(t, func(t *testing.T) {
+			o := NewOrchestrator(nil)
 
-		// Track what context the service receives
-		var receivedCtx context.Context
-		var ctxMu sync.Mutex
+			// Track what context the service receives
+			var receivedCtx context.Context
+			var ctxMu sync.Mutex
 
-		mock := &contextCaptureMockService{
-			MockService: &MockService{name: "test", delay: 50 * time.Millisecond},
-			onSync: func(ctx context.Context) {
-				ctxMu.Lock()
-				receivedCtx = ctx
-				ctxMu.Unlock()
-			},
-		}
-		o.RegisterService("test", mock)
-
-		// Create a parent context with 2-hour deadline (generous)
-		parentCtx, cancel := context.WithTimeout(context.Background(), 2*time.Hour)
-		defer cancel()
-
-		err := o.RunSingleSync(parentCtx, "test")
-		if err != nil {
-			t.Fatalf("RunSingleSync failed: %v", err)
-		}
-
-		// Wait for sync to complete
-		time.Sleep(100 * time.Millisecond)
-
-		ctxMu.Lock()
-		ctx := receivedCtx
-		ctxMu.Unlock()
-
-		if ctx == nil {
-			t.Fatal("service was never called with a context")
-			return
-		}
-
-		// When parent has generous deadline (>=30min), the sync context should
-		// have a deadline that's at least 30 minutes out (not just whatever is left
-		// on the parent context)
-		deadline, hasDeadline := ctx.Deadline()
-		if !hasDeadline {
-			t.Error("expected sync context to have a deadline")
-		} else {
-			timeUntilDeadline := time.Until(deadline)
-			// Should have at least 30 minutes remaining (allowing some margin for test execution)
-			if timeUntilDeadline < 29*time.Minute {
-				t.Errorf("sync context deadline too short: %v remaining", timeUntilDeadline)
+			mock := &contextCaptureMockService{
+				MockService: &MockService{name: "test", delay: 50 * time.Millisecond},
+				onSync: func(ctx context.Context) {
+					ctxMu.Lock()
+					receivedCtx = ctx
+					ctxMu.Unlock()
+				},
 			}
-		}
+			o.RegisterService("test", mock)
+
+			// Create a parent context with 2-hour deadline (generous)
+			parentCtx, cancel := context.WithTimeout(context.Background(), 2*time.Hour)
+			defer cancel()
+
+			err := o.RunSingleSync(parentCtx, "test")
+			if err != nil {
+				t.Fatalf("RunSingleSync failed: %v", err)
+			}
+
+			// Wait for the sync goroutine to complete (virtual time advances past the mock's 50ms delay).
+			time.Sleep(100 * time.Millisecond)
+
+			ctxMu.Lock()
+			ctx := receivedCtx
+			ctxMu.Unlock()
+
+			if ctx == nil {
+				t.Fatal("service was never called with a context")
+				return
+			}
+
+			// When parent has generous deadline (>=30min), the sync context should
+			// have a deadline that's at least 30 minutes out (not just whatever is left
+			// on the parent context)
+			deadline, hasDeadline := ctx.Deadline()
+			if !hasDeadline {
+				t.Error("expected sync context to have a deadline")
+			} else {
+				timeUntilDeadline := time.Until(deadline)
+				// Should have at least 30 minutes remaining (allowing some margin for test execution)
+				if timeUntilDeadline < 29*time.Minute {
+					t.Errorf("sync context deadline too short: %v remaining", timeUntilDeadline)
+				}
+			}
+		})
 	})
 
 	t.Run("extends short parent deadline", func(t *testing.T) {
-		o := NewOrchestrator(nil)
+		synctest.Test(t, func(t *testing.T) {
+			o := NewOrchestrator(nil)
 
-		var receivedCtx context.Context
-		var ctxMu sync.Mutex
+			var receivedCtx context.Context
+			var ctxMu sync.Mutex
 
-		mock := &contextCaptureMockService{
-			MockService: &MockService{name: "test", delay: 50 * time.Millisecond},
-			onSync: func(ctx context.Context) {
-				ctxMu.Lock()
-				receivedCtx = ctx
-				ctxMu.Unlock()
-			},
-		}
-		o.RegisterService("test", mock)
-
-		// Create a parent context with very short deadline (1 minute - too short for sync)
-		parentCtx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-		defer cancel()
-
-		err := o.RunSingleSync(parentCtx, "test")
-		if err != nil {
-			t.Fatalf("RunSingleSync failed: %v", err)
-		}
-
-		// Wait for sync to complete
-		time.Sleep(100 * time.Millisecond)
-
-		ctxMu.Lock()
-		ctx := receivedCtx
-		ctxMu.Unlock()
-
-		if ctx == nil {
-			t.Fatal("service was never called with a context")
-			return
-		}
-
-		// When parent has short deadline (<30min), the sync should create
-		// its own generous timeout
-		deadline, hasDeadline := ctx.Deadline()
-		if !hasDeadline {
-			t.Error("expected sync context to have a deadline")
-		} else {
-			timeUntilDeadline := time.Until(deadline)
-			// Should have at least 30 minutes (the default generous timeout)
-			if timeUntilDeadline < 29*time.Minute {
-				t.Errorf("sync context should extend short parent deadline: got %v remaining", timeUntilDeadline)
+			mock := &contextCaptureMockService{
+				MockService: &MockService{name: "test", delay: 50 * time.Millisecond},
+				onSync: func(ctx context.Context) {
+					ctxMu.Lock()
+					receivedCtx = ctx
+					ctxMu.Unlock()
+				},
 			}
-		}
+			o.RegisterService("test", mock)
+
+			// Create a parent context with very short deadline (1 minute - too short for sync)
+			parentCtx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			defer cancel()
+
+			err := o.RunSingleSync(parentCtx, "test")
+			if err != nil {
+				t.Fatalf("RunSingleSync failed: %v", err)
+			}
+
+			// Wait for the sync goroutine to complete (virtual time advances past the mock's 50ms delay).
+			time.Sleep(100 * time.Millisecond)
+
+			ctxMu.Lock()
+			ctx := receivedCtx
+			ctxMu.Unlock()
+
+			if ctx == nil {
+				t.Fatal("service was never called with a context")
+				return
+			}
+
+			// When parent has short deadline (<30min), the sync should create
+			// its own generous timeout
+			deadline, hasDeadline := ctx.Deadline()
+			if !hasDeadline {
+				t.Error("expected sync context to have a deadline")
+			} else {
+				timeUntilDeadline := time.Until(deadline)
+				// Should have at least 30 minutes (the default generous timeout)
+				if timeUntilDeadline < 29*time.Minute {
+					t.Errorf("sync context should extend short parent deadline: got %v remaining", timeUntilDeadline)
+				}
+			}
+		})
 	})
 
 	t.Run("creates deadline when parent has none", func(t *testing.T) {
-		o := NewOrchestrator(nil)
+		synctest.Test(t, func(t *testing.T) {
+			o := NewOrchestrator(nil)
 
-		var receivedCtx context.Context
-		var ctxMu sync.Mutex
+			var receivedCtx context.Context
+			var ctxMu sync.Mutex
 
-		mock := &contextCaptureMockService{
-			MockService: &MockService{name: "test", delay: 50 * time.Millisecond},
-			onSync: func(ctx context.Context) {
-				ctxMu.Lock()
-				receivedCtx = ctx
-				ctxMu.Unlock()
-			},
-		}
-		o.RegisterService("test", mock)
-
-		// Parent context with no deadline
-		parentCtx := context.Background()
-
-		err := o.RunSingleSync(parentCtx, "test")
-		if err != nil {
-			t.Fatalf("RunSingleSync failed: %v", err)
-		}
-
-		// Wait for sync to complete
-		time.Sleep(100 * time.Millisecond)
-
-		ctxMu.Lock()
-		ctx := receivedCtx
-		ctxMu.Unlock()
-
-		if ctx == nil {
-			t.Fatal("service was never called with a context")
-			return
-		}
-
-		// When parent has no deadline, sync should create a generous timeout
-		deadline, hasDeadline := ctx.Deadline()
-		if !hasDeadline {
-			t.Error("expected sync context to have a deadline even when parent doesn't")
-		} else {
-			timeUntilDeadline := time.Until(deadline)
-			// Should have at least 1 hour (the extended timeout for no-deadline parents)
-			if timeUntilDeadline < 59*time.Minute {
-				t.Errorf("sync context deadline too short for no-deadline parent: %v remaining", timeUntilDeadline)
+			mock := &contextCaptureMockService{
+				MockService: &MockService{name: "test", delay: 50 * time.Millisecond},
+				onSync: func(ctx context.Context) {
+					ctxMu.Lock()
+					receivedCtx = ctx
+					ctxMu.Unlock()
+				},
 			}
-		}
+			o.RegisterService("test", mock)
+
+			// Parent context with no deadline
+			parentCtx := context.Background()
+
+			err := o.RunSingleSync(parentCtx, "test")
+			if err != nil {
+				t.Fatalf("RunSingleSync failed: %v", err)
+			}
+
+			// Wait for the sync goroutine to complete (virtual time advances past the mock's 50ms delay).
+			time.Sleep(100 * time.Millisecond)
+
+			ctxMu.Lock()
+			ctx := receivedCtx
+			ctxMu.Unlock()
+
+			if ctx == nil {
+				t.Fatal("service was never called with a context")
+				return
+			}
+
+			// When parent has no deadline, sync should create a generous timeout
+			deadline, hasDeadline := ctx.Deadline()
+			if !hasDeadline {
+				t.Error("expected sync context to have a deadline even when parent doesn't")
+			} else {
+				timeUntilDeadline := time.Until(deadline)
+				// Should have at least 1 hour (the extended timeout for no-deadline parents)
+				if timeUntilDeadline < 59*time.Minute {
+					t.Errorf("sync context deadline too short for no-deadline parent: %v remaining", timeUntilDeadline)
+				}
+			}
+		})
 	})
 }
 
@@ -2881,47 +2890,50 @@ func TestGetCurrentRunProgress_PriorityOrder(t *testing.T) {
 }
 
 func TestFinalizeSyncStatusSuccess(t *testing.T) {
-	o := NewOrchestrator(nil)
-	mock := &MockService{name: "test", delay: 0}
-	o.RegisterService("test", mock)
+	synctest.Test(t, func(t *testing.T) {
+		o := NewOrchestrator(nil)
+		mock := &MockService{name: "test", delay: 0}
+		o.RegisterService("test", mock)
 
-	err := o.MarkSyncRunning("test")
-	if err != nil {
-		t.Fatalf("MarkSyncRunning failed: %v", err)
-	}
+		err := o.MarkSyncRunning("test")
+		if err != nil {
+			t.Fatalf("MarkSyncRunning failed: %v", err)
+		}
 
-	time.Sleep(1010 * time.Millisecond)
+		// Advance virtual time so EndTime - StartTime rounds to a non-zero Duration (int seconds).
+		time.Sleep(1010 * time.Millisecond)
 
-	stats := Stats{Created: 5, Updated: 3, Skipped: 2, Errors: 0}
-	o.FinalizeSyncStatus("test", stats, nil)
+		stats := Stats{Created: 5, Updated: 3, Skipped: 2, Errors: 0}
+		o.FinalizeSyncStatus("test", stats, nil)
 
-	o.mu.RLock()
-	_, stillRunning := o.runningJobs["test"]
-	completed := o.lastCompletedStatus["test"]
-	o.mu.RUnlock()
+		o.mu.RLock()
+		_, stillRunning := o.runningJobs["test"]
+		completed := o.lastCompletedStatus["test"]
+		o.mu.RUnlock()
 
-	if stillRunning {
-		t.Error("expected test to be removed from runningJobs")
-	}
-	if completed == nil {
-		t.Fatal("expected test to be in lastCompletedStatus")
-		return
-	}
-	if completed.Status != statusSuccess {
-		t.Errorf("expected status 'success', got %q", completed.Status)
-	}
-	if completed.EndTime == nil {
-		t.Error("expected EndTime to be set")
-	}
-	if completed.Summary.Created != 5 {
-		t.Errorf("expected Created=5, got %d", completed.Summary.Created)
-	}
-	if completed.Summary.Duration <= 0 {
-		t.Error("expected Duration > 0")
-	}
-	if completed.Error != "" {
-		t.Errorf("expected no error, got %q", completed.Error)
-	}
+		if stillRunning {
+			t.Error("expected test to be removed from runningJobs")
+		}
+		if completed == nil {
+			t.Fatal("expected test to be in lastCompletedStatus")
+			return
+		}
+		if completed.Status != statusSuccess {
+			t.Errorf("expected status 'success', got %q", completed.Status)
+		}
+		if completed.EndTime == nil {
+			t.Error("expected EndTime to be set")
+		}
+		if completed.Summary.Created != 5 {
+			t.Errorf("expected Created=5, got %d", completed.Summary.Created)
+		}
+		if completed.Summary.Duration <= 0 {
+			t.Error("expected Duration > 0")
+		}
+		if completed.Error != "" {
+			t.Errorf("expected no error, got %q", completed.Error)
+		}
+	})
 }
 
 func TestFinalizeSyncStatusError(t *testing.T) {
@@ -3104,51 +3116,55 @@ func TestRunSingleSyncAtomicStatusTransition(t *testing.T) {
 
 // TestRunTokenPopulated tests that RunSingleSync populates RunToken on the status
 func TestRunTokenPopulated(t *testing.T) {
-	o := NewOrchestrator(nil)
+	synctest.Test(t, func(t *testing.T) {
+		o := NewOrchestrator(nil)
 
-	mock := &MockService{name: "test_service", delay: 50 * time.Millisecond}
-	o.RegisterService("test", mock)
+		mock := &MockService{name: "test_service", delay: 50 * time.Millisecond}
+		o.RegisterService("test", mock)
 
-	ctx := context.Background()
-	err := o.RunSingleSync(ctx, "test")
-	if err != nil {
-		t.Fatalf("RunSingleSync failed: %v", err)
-	}
+		ctx := context.Background()
+		err := o.RunSingleSync(ctx, "test")
+		if err != nil {
+			t.Fatalf("RunSingleSync failed: %v", err)
+		}
 
-	// While running, status should have a non-empty RunToken
-	o.mu.RLock()
-	status := o.runningJobs["test"]
-	o.mu.RUnlock()
+		// While running, status should have a non-empty RunToken.
+		// The sync goroutine is durably blocked in MockService.Sync's time.After,
+		// so virtual time has not advanced and the running status is still present.
+		o.mu.RLock()
+		status := o.runningJobs["test"]
+		o.mu.RUnlock()
 
-	if status == nil {
-		t.Fatal("expected running status")
-		return
-	}
+		if status == nil {
+			t.Fatal("expected running status")
+			return
+		}
 
-	if status.RunToken == "" {
-		t.Error("expected RunToken to be populated, got empty string")
-	}
+		if status.RunToken == "" {
+			t.Error("expected RunToken to be populated, got empty string")
+		}
 
-	// Wait for completion
-	time.Sleep(100 * time.Millisecond)
+		// Wait for the sync goroutine to complete (virtual time advances past the mock's 50ms delay).
+		time.Sleep(100 * time.Millisecond)
 
-	// Completed status should also have the token
-	o.mu.RLock()
-	completed := o.lastCompletedStatus["test"]
-	o.mu.RUnlock()
+		// Completed status should also have the token
+		o.mu.RLock()
+		completed := o.lastCompletedStatus["test"]
+		o.mu.RUnlock()
 
-	if completed == nil {
-		t.Fatal("expected completed status")
-		return
-	}
+		if completed == nil {
+			t.Fatal("expected completed status")
+			return
+		}
 
-	if completed.RunToken == "" {
-		t.Error("expected completed status to preserve RunToken")
-	}
+		if completed.RunToken == "" {
+			t.Error("expected completed status to preserve RunToken")
+		}
 
-	if completed.RunToken != status.RunToken {
-		t.Errorf("RunToken mismatch: running=%q completed=%q", status.RunToken, completed.RunToken)
-	}
+		if completed.RunToken != status.RunToken {
+			t.Errorf("RunToken mismatch: running=%q completed=%q", status.RunToken, completed.RunToken)
+		}
+	})
 }
 
 // TestRunTokenPreservedByFinalizeSyncStatus tests that FinalizeSyncStatus preserves

--- a/pocketbase/sync/rate_limited_sheets_writer_test.go
+++ b/pocketbase/sync/rate_limited_sheets_writer_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"google.golang.org/api/googleapi"
@@ -374,30 +375,32 @@ func TestRateLimitedWriter_DoesNotRetryGoogleAPINon429(t *testing.T) {
 // =============================================================================
 
 func TestRateLimitedWriter_RespectsContextCancellation(t *testing.T) {
-	mock := newTrackingMock()
-	mock.writeErrFn = failNTimes(10) // always fail
-	cfg := testConfig()
-	cfg.InitialBackoff = 100 * time.Millisecond // slow enough that we can cancel
-	writer := NewRateLimitedSheetsWriter(mock, cfg)
+	synctest.Test(t, func(t *testing.T) {
+		mock := newTrackingMock()
+		mock.writeErrFn = failNTimes(10) // always fail
+		cfg := testConfig()
+		cfg.InitialBackoff = 100 * time.Millisecond // slow enough that we can cancel
+		writer := NewRateLimitedSheetsWriter(mock, cfg)
 
-	ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(context.Background())
 
-	// Cancel after a short delay
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		cancel()
-	}()
+		// Cancel after a short delay
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+		}()
 
-	err := writer.WriteToSheet(ctx, "s1", "tab", [][]any{{"x"}})
-	if err == nil {
-		t.Fatal("WriteToSheet should return error when context is canceled")
-		return
-	}
+		err := writer.WriteToSheet(ctx, "s1", "tab", [][]any{{"x"}})
+		if err == nil {
+			t.Fatal("WriteToSheet should return error when context is canceled")
+			return
+		}
 
-	// Should have been called fewer times than max retries because context was canceled
-	if mock.writeCalls.Load() >= 4 {
-		t.Errorf("WriteToSheet: inner called %d times, should be < 4 due to context cancellation", mock.writeCalls.Load())
-	}
+		// Should have been called fewer times than max retries because context was canceled
+		if mock.writeCalls.Load() >= 4 {
+			t.Errorf("WriteToSheet: inner called %d times, should be < 4 due to context cancellation", mock.writeCalls.Load())
+		}
+	})
 }
 
 // =============================================================================

--- a/pocketbase/sync/scheduler_test.go
+++ b/pocketbase/sync/scheduler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -127,77 +128,79 @@ func TestGetCustomValuesSyncJobs(t *testing.T) {
 // This is a regression test for the "rate limiter wait: context deadline exceeded" issue
 // that occurred when both custom values syncs ran concurrently, doubling API pressure.
 func TestCustomValuesSyncRunsSequentially(t *testing.T) {
-	s := NewScheduler(nil)
+	synctest.Test(t, func(t *testing.T) {
+		s := NewScheduler(nil)
 
-	// Create mock services that track execution timing
-	type execRecord struct {
-		start time.Time
-		end   time.Time
-	}
-	var mu sync.Mutex
-	execTimes := make(map[string]*execRecord)
-
-	// Create slow mock services (100ms each) to make timing measurable
-	for _, name := range []string{"person_custom_values", "household_custom_values"} {
-		jobName := name
-		mock := &MockService{
-			name:  jobName,
-			delay: 100 * time.Millisecond,
+		// Create mock services that track execution timing
+		type execRecord struct {
+			start time.Time
+			end   time.Time
 		}
-		// Wrap the mock to record timing
-		wrappedMock := &timingMockService{
-			MockService: mock,
-			onSync: func() {
-				mu.Lock()
-				execTimes[jobName] = &execRecord{start: time.Now()}
-				mu.Unlock()
-			},
-			afterSync: func() {
-				mu.Lock()
-				if rec := execTimes[jobName]; rec != nil {
-					rec.end = time.Now()
-				}
-				mu.Unlock()
-			},
+		var mu sync.Mutex
+		execTimes := make(map[string]*execRecord)
+
+		// Create slow mock services (100ms each) to make timing measurable
+		for _, name := range []string{"person_custom_values", "household_custom_values"} {
+			jobName := name
+			mock := &MockService{
+				name:  jobName,
+				delay: 100 * time.Millisecond,
+			}
+			// Wrap the mock to record timing
+			wrappedMock := &timingMockService{
+				MockService: mock,
+				onSync: func() {
+					mu.Lock()
+					execTimes[jobName] = &execRecord{start: time.Now()}
+					mu.Unlock()
+				},
+				afterSync: func() {
+					mu.Lock()
+					if rec := execTimes[jobName]; rec != nil {
+						rec.end = time.Now()
+					}
+					mu.Unlock()
+				},
+			}
+			s.orchestrator.RegisterService(name, wrappedMock)
 		}
-		s.orchestrator.RegisterService(name, wrappedMock)
-	}
 
-	// Run the custom values sync (this should run sequentially)
-	s.runCustomValuesSync()
+		// Run the custom values sync (this should run sequentially)
+		s.runCustomValuesSync()
 
-	// Allow time for all goroutines to complete (2 syncs x 100ms + margin)
-	time.Sleep(300 * time.Millisecond)
+		// Allow virtual time to advance past both 100ms mock delays plus margin.
+		time.Sleep(300 * time.Millisecond)
 
-	// Verify sequential execution: job 2 should start AFTER job 1 ends
-	mu.Lock()
-	personRec := execTimes["person_custom_values"]
-	householdRec := execTimes["household_custom_values"]
-	mu.Unlock()
+		// Verify sequential execution: job 2 should start AFTER job 1 ends
+		mu.Lock()
+		personRec := execTimes["person_custom_values"]
+		householdRec := execTimes["household_custom_values"]
+		mu.Unlock()
 
-	if personRec == nil || householdRec == nil {
-		t.Fatal("expected both services to have been executed")
-		return
-	}
+		if personRec == nil || householdRec == nil {
+			t.Fatal("expected both services to have been executed")
+			return
+		}
 
-	// Ensure end times were recorded (syncs completed)
-	if personRec.end.IsZero() || householdRec.end.IsZero() {
-		t.Fatal("expected both services to have completed (end times recorded)")
-		return
-	}
+		// Ensure end times were recorded (syncs completed)
+		if personRec.end.IsZero() || householdRec.end.IsZero() {
+			t.Fatal("expected both services to have completed (end times recorded)")
+			return
+		}
 
-	// Check that there's no overlap - one must complete before the other starts
-	// Either: person ends before household starts, OR household ends before person starts
-	personEndsFirst := personRec.end.Before(householdRec.start) || personRec.end.Equal(householdRec.start)
-	householdEndsFirst := householdRec.end.Before(personRec.start) || householdRec.end.Equal(personRec.start)
+		// Check that there's no overlap - one must complete before the other starts
+		// Either: person ends before household starts, OR household ends before person starts
+		personEndsFirst := personRec.end.Before(householdRec.start) || personRec.end.Equal(householdRec.start)
+		householdEndsFirst := householdRec.end.Before(personRec.start) || householdRec.end.Equal(personRec.start)
 
-	if !personEndsFirst && !householdEndsFirst {
-		t.Errorf("custom values syncs ran concurrently (overlapped):\n"+
-			"  person_custom_values:    start=%v, end=%v\n"+
-			"  household_custom_values: start=%v, end=%v",
-			personRec.start.Format(time.RFC3339Nano), personRec.end.Format(time.RFC3339Nano),
-			householdRec.start.Format(time.RFC3339Nano), householdRec.end.Format(time.RFC3339Nano))
-	}
+		if !personEndsFirst && !householdEndsFirst {
+			t.Errorf("custom values syncs ran concurrently (overlapped):\n"+
+				"  person_custom_values:    start=%v, end=%v\n"+
+				"  household_custom_values: start=%v, end=%v",
+				personRec.start.Format(time.RFC3339Nano), personRec.end.Format(time.RFC3339Nano),
+				householdRec.start.Format(time.RFC3339Nano), householdRec.end.Format(time.RFC3339Nano))
+		}
+	})
 }
 
 // TestGetRefreshBunkingJobs tests that refresh bunking returns the correct services in order
@@ -223,50 +226,52 @@ func TestGetRefreshBunkingJobs(t *testing.T) {
 // bunks, bunk_plans, bunk_assignments, and stranded_assignment_cleanup in
 // sequence (not just bunk_assignments)
 func TestRefreshBunkingRunsAllServices(t *testing.T) {
-	s := NewScheduler(nil)
+	synctest.Test(t, func(t *testing.T) {
+		s := NewScheduler(nil)
 
-	// Track which services were called and in what order
-	var mu sync.Mutex
-	var callOrder []string
+		// Track which services were called and in what order
+		var mu sync.Mutex
+		var callOrder []string
 
-	for _, name := range GetRefreshBunkingJobs() {
-		jobName := name
-		mock := &MockService{
-			name:  jobName,
-			delay: 10 * time.Millisecond,
+		for _, name := range GetRefreshBunkingJobs() {
+			jobName := name
+			mock := &MockService{
+				name:  jobName,
+				delay: 10 * time.Millisecond,
+			}
+			wrappedMock := &timingMockService{
+				MockService: mock,
+				onSync: func() {
+					mu.Lock()
+					callOrder = append(callOrder, jobName)
+					mu.Unlock()
+				},
+			}
+			s.orchestrator.RegisterService(name, wrappedMock)
 		}
-		wrappedMock := &timingMockService{
-			MockService: mock,
-			onSync: func() {
-				mu.Lock()
-				callOrder = append(callOrder, jobName)
-				mu.Unlock()
-			},
+
+		err := s.TriggerSync(context.Background(), "refresh-bunking")
+		if err != nil {
+			t.Fatalf("TriggerSync failed: %v", err)
 		}
-		s.orchestrator.RegisterService(name, wrappedMock)
-	}
 
-	err := s.TriggerSync(context.Background(), "refresh-bunking")
-	if err != nil {
-		t.Fatalf("TriggerSync failed: %v", err)
-	}
+		// Allow virtual time to advance past all 4 services × 10ms mock delays plus margin.
+		time.Sleep(200 * time.Millisecond)
 
-	// Allow time for all services to complete
-	time.Sleep(200 * time.Millisecond)
+		mu.Lock()
+		defer mu.Unlock()
 
-	mu.Lock()
-	defer mu.Unlock()
-
-	expected := []string{"bunks", "bunk_plans", "bunk_assignments", "stranded_assignment_cleanup"}
-	if len(callOrder) != len(expected) {
-		t.Fatalf("expected %d services called, got %d: %v", len(expected), len(callOrder), callOrder)
-	}
-
-	for i, name := range expected {
-		if callOrder[i] != name {
-			t.Errorf("expected service %d to be %q, got %q (order: %v)", i, name, callOrder[i], callOrder)
+		expected := []string{"bunks", "bunk_plans", "bunk_assignments", "stranded_assignment_cleanup"}
+		if len(callOrder) != len(expected) {
+			t.Fatalf("expected %d services called, got %d: %v", len(expected), len(callOrder), callOrder)
 		}
-	}
+
+		for i, name := range expected {
+			if callOrder[i] != name {
+				t.Errorf("expected service %d to be %q, got %q (order: %v)", i, name, callOrder[i], callOrder)
+			}
+		}
+	})
 }
 
 // TestRefreshBunkingRegistersRequiredServices verifies that TriggerSync for


### PR DESCRIPTION
## Summary

Modernization backlog §2c row #14 — wrap 7 sync-package tests in `synctest.Test` bubbles so the ~2.0s of wall-clock `time.Sleep` waits per `go test ./sync/...` run become virtual. Each converted test now reports `0.00s` wall time; `go test ./sync/... -race` end-to-end dropped from **~29s → ~20s** locally on the test machine.

The 1010ms sleep in `TestFinalizeSyncStatusSuccess` (asserting `Duration > 0` rounds correctly) is the worst single offender — that alone is half the savings.

## What changed

Converted callsites — wrapped each test body in `synctest.Test(t, func(t *testing.T) { ... })`. Kept existing `time.Sleep(N)` calls as-is (they're now virtual):

| Test | Sleep duration |
|---|---|
| `TestRunSingleSyncRespectsPreMarkedStatus` | 50ms |
| `TestRunSingleSyncContextDeadlineHandling` × 3 subtests | 100ms ea |
| `TestFinalizeSyncStatusSuccess` | 1010ms |
| `TestRunTokenPopulated` | 100ms |
| `TestCustomValuesSyncRunsSequentially` | 300ms |
| `TestRefreshBunkingRunsAllServices` | 200ms |
| `TestRateLimitedWriter_RespectsContextCancellation` | 50ms |

## Intentionally NOT converted

- **`TestFinalizeSyncStatusAtomicTransition` + `TestRunSingleSyncAtomicStatusTransition`** — busy-spin race-detection tests with `for { default: GetStatus() }` readers. `synctest.Wait()` only advances when every goroutine is *durably blocked*; busy-spinners never reach that state, so the bubble would deadlock. These tests explicitly verify real-concurrency invariants — leaving them on the real clock is correct.
- **`pocketbase/rbac/config_hooks_test.go`** — `notifyMetricsCacheInvalidation` spawns a goroutine doing real `httptest.NewServer` I/O. Real socket I/O is not durably blocking inside a bubble.
- **`MockService.Sync`'s `time.After(m.delay)` (line 27)** — fixture used by many tests. Works fine in either context; modifying it would force every consumer into a bubble.
- **`runSyncAndWait` deadline guards** (`TestRunSyncAndWaitMatchesToken`, `TestRunSyncAndWaitZeroDelayNoDeadlock`) — internal channel-polling logic is harder to bubble cleanly; risk-reward for converting these is meh.

## Lesson learned mid-conversion

First pass tried `synctest.Wait()` to replace `time.Sleep` for "wait for sync goroutine to complete." That panics: `Wait` returns when other goroutines are *durably blocked* (including blocked on `time.After`), not when they exit. After Wait returns, the spawned goroutine is still sleeping on its `time.After(m.delay)`; the test then exits the bubble and `synctest.Test` panics with `deadlock: main bubble goroutine has exited but blocked goroutines remain`. Switching back to `time.Sleep(N)` (now virtual) gives correct semantics — main becomes durably blocked, virtual time advances past the spawned goroutine's timer, goroutine completes and exits, main wakes up.

This is the right idiom whenever the spawned goroutine has internal time-based blocks. `synctest.Wait()` works for pure-compute goroutines (no internal `time.*` calls).

## Test plan

- [x] `go test -race -count=1 -timeout=60s ./sync/...` — passes (2038 tests)
- [x] `go vet ./sync/...` — clean
- [x] `golangci-lint run ./sync/...` — clean
- [x] `lefthook run pre-push` — all green
- [x] Confirmed each converted test reports `0.00s` wall time via `go test -v`
- [x] Confirmed virtual clock visible in test logs (timestamps start at `1999/12/31 16:00:00 UTC`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Switched several sync and scheduler tests to a virtual-time test harness, making timing deterministic and faster.
  * Wrapped context/deadline and token-related sync assertions in the harness to ensure consistent behavior across scenarios.
  * Converted cancellation and rate-limit tests to the same harness for more reliable, reproducible test outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->