### PR TITLE
fix(solver): mutual-pair detection consults possible_requests (#1561)

### DIFF
--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -594,7 +594,10 @@ class DirectBunkingSolver:
         # Stream 4 (#1382): boost reciprocated bunk_with pairs. Always on;
         # set to 1.0 to disable in-place without removing the code path.
         mutual_request_boost = self.config.get_float("objective.mutual_request_boost", default=2.0)
-        mutual_bunk_with_pairs = compute_mutual_bunk_with_pairs(self.input.requests_by_person)
+        # #1561: feed possible_requests so an impossible reciprocal (e.g.
+        # self_conflict on B's side, malformed B→A) doesn't register (A, B)
+        # as mutual and falsely apply the 2x boost to A→B.
+        mutual_bunk_with_pairs = compute_mutual_bunk_with_pairs(self.possible_requests)
 
         for person_cm_id, request_satisfactions in person_request_satisfaction.items():
             if not request_satisfactions:

--- a/tests/unit/bunking/solver/test_mutual_request_boost.py
+++ b/tests/unit/bunking/solver/test_mutual_request_boost.py
@@ -349,6 +349,31 @@ def test_add_objective_consumes_mutual_request_boost():
     )
 
 
+def test_add_objective_filters_mutual_pairs_through_possible_requests():
+    """#1561: mutual-pair detection must read self.possible_requests, not the
+    unfiltered self.input.requests_by_person. Otherwise an asymmetric
+    impossibility (e.g. self_conflict on B's side, malformed B→A) would still
+    register (A, B) as mutual and apply the 2x boost to A→B even though B→A
+    can never be satisfied.
+
+    Symmetric impossibilities (cross_session, gender, grade_spread,
+    target_not_in_solver) zero out both directions so the bug doesn't
+    misfire there in practice, but the semantic intent of the Stream 4
+    boost is "both sides satisfiable" — the call site should reflect that.
+    """
+    from bunking.solver import direct_solver
+
+    src = inspect.getsource(direct_solver.DirectBunkingSolver.add_objective)
+    assert "compute_mutual_bunk_with_pairs(self.possible_requests)" in src, (
+        "add_objective must call compute_mutual_bunk_with_pairs with "
+        "self.possible_requests so impossible reciprocals don't count as mutual"
+    )
+    assert "compute_mutual_bunk_with_pairs(self.input.requests_by_person)" not in src, (
+        "add_objective still passes the unfiltered self.input.requests_by_person; "
+        "switch to self.possible_requests (see #1561)"
+    )
+
+
 # ---------------------------------------------------------------------------
 # score_evaluator.py — third evaluator path, must mirror the same boost as
 # the solver (else baseline-regression goldens silently drift on reciprocal


### PR DESCRIPTION
## Summary

- `add_objective` was computing `mutual_bunk_with_pairs` from the unfiltered `self.input.requests_by_person`. Switched to `self.possible_requests` so the mutual-pair set matches what the rest of the objective builder iterates (post-#1555).
- Without this, an asymmetric impossibility (`self_conflict` on B's side, malformed `B→A`) could falsely register `(A, B)` as mutual and inflate A→B's weight with the 2x `objective.mutual_request_boost`.

## Why this is a semantic fix, not a hot bug

The pair-property impossibility predicates (`cross_session`, `gender`, `grade_spread`, `target_not_in_solver`) are all symmetric — if B→A is impossible for any of these, A→B is also impossible, A→B never gets iterated in `person_request_satisfaction`, and the boost never applies. The bug only misfires on `self_conflict` / `malformed`, which require contradictory or broken input on one side. Still worth aligning the call site with the post-#1555 semantics.

## Test plan

- [x] New `test_add_objective_filters_mutual_pairs_through_possible_requests` (source-inspection style, matching the existing `test_add_objective_consumes_mutual_request_boost`) — added as failing first, passes after the one-line fix.
- [x] Full `test_mutual_request_boost.py` still green (24 tests).
- [x] `pre-push-verification` passes — 4866 pytest unit tests pass.

Closes #1561

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where invalid reciprocal requests were incorrectly boosted in the matching algorithm. The matching logic now properly filters out infeasible requests before calculating mutual request bonuses, improving matching accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->