### PR TITLE
refactor(solver): align evaluator slot-index with solver (#1524)

### DIFF
--- a/bunking/solver/objective_evaluator.py
+++ b/bunking/solver/objective_evaluator.py
@@ -230,13 +230,15 @@ class ObjectiveEvaluator:
                 # Sort by is_first_requested DESC (same as solver)
                 person_requests.sort(key=lambda x: x[0].get("is_first_requested", False), reverse=True)
 
-            satisfied_count_for_person = 0
-
+            # #1524: use the outer enumerate's `i` so the slot index reflects
+            # full-list position (matching the solver's `weight * satisfied_var`
+            # accumulator). An unsatisfied first-pick still advances `i`, so a
+            # satisfied second-pick lands at SECOND_REQUEST_MULTIPLIER, not
+            # FIRST. Pre-fix this tracked a satisfied-only counter, overcounting
+            # by 2x relative to the solver's ObjectiveValue.
             for i, (request, is_satisfied) in enumerate(person_requests):
                 if not is_satisfied:
                     continue
-
-                satisfied_count_for_person += 1
 
                 # Base weight (same as solver)
                 base_weight = float(BASE_REQUEST_WEIGHT)
@@ -265,11 +267,10 @@ class ObjectiveEvaluator:
                     if req_id and tgt_id and frozenset({int(req_id), int(tgt_id)}) in mutual_bunk_with_pairs:
                         base_weight = base_weight * mutual_request_boost
 
-                # Apply diminishing returns based on satisfaction order (always-on)
-                order_idx = satisfied_count_for_person - 1
-                if order_idx == 0:
+                # Apply diminishing returns based on full-list position.
+                if i == 0:
                     weight = base_weight * FIRST_REQUEST_MULTIPLIER
-                elif order_idx == 1:
+                elif i == 1:
                     weight = base_weight * SECOND_REQUEST_MULTIPLIER
                 else:
                     weight = base_weight * THIRD_PLUS_REQUEST_MULTIPLIER

--- a/bunking/solver/score_evaluator.py
+++ b/bunking/solver/score_evaluator.py
@@ -133,8 +133,11 @@ def evaluate_scenario_score(
         and int(r["requester_id"]) != int(r["requestee_id"])
     )
 
-    # Track request satisfaction per person
-    person_satisfaction: dict[int, list[tuple[dict[str, Any], int]]] = defaultdict(list)
+    # Track request satisfaction per person. Holds (request, weighted_score, is_satisfied)
+    # for every request, not just satisfied ones — the diminishing-returns loop
+    # iterates the full list to advance `i` across unsatisfied slots (matching
+    # the solver's full-list ordering — see #1524).
+    person_satisfaction: dict[int, list[tuple[dict[str, Any], int, bool]]] = defaultdict(list)
 
     # Field-level stats
     field_stats: dict[str, dict[str, Any]] = defaultdict(lambda: {"total": 0, "satisfied": 0, "raw_score": 0})
@@ -198,14 +201,16 @@ def evaluate_scenario_score(
             )
             is_satisfied = False
 
+        # Compute the per-request weight only when satisfied — unsatisfied
+        # requests contribute 0 to request_score (the diminishing-returns loop
+        # `continue`s past them), and calling weight_for() on an unknown
+        # (source, type) combo would raise. The placeholder 0 keeps the
+        # full-list position so `i` matches the solver's ordering (#1524).
         if is_satisfied:
             satisfied_count += 1
             field_stats[primary_field]["satisfied"] += 1
 
-            # Calculate base weight
             base_weight: float = float(BASE_REQUEST_WEIGHT)
-
-            # Apply source field multiplier
             multiplier = max(weight_for(f, request_type, config) for f in source_fields) if source_fields else 1.0
             base_weight = base_weight * multiplier
 
@@ -216,9 +221,11 @@ def evaluate_scenario_score(
                     base_weight = base_weight * mutual_request_boost
 
             weighted_score = int(base_weight)
-
-            person_satisfaction[requester_id].append((request, weighted_score))
             field_stats[primary_field]["raw_score"] += weighted_score
+        else:
+            weighted_score = 0
+
+        person_satisfaction[requester_id].append((request, weighted_score, is_satisfied))
 
     # Apply diminishing returns and calculate final request score
     request_score = 0
@@ -227,7 +234,9 @@ def evaluate_scenario_score(
         if enable_first_boost:
             satisfactions.sort(key=lambda x: x[0].get("is_first_requested", False), reverse=True)
 
-        for i, (request, base_score) in enumerate(satisfactions):
+        for i, (request, base_score, is_satisfied) in enumerate(satisfactions):
+            if not is_satisfied:
+                continue
             if i == 0:
                 final_score = base_score * FIRST_REQUEST_MULTIPLIER
             elif i == 1:

--- a/tests/unit/bunking/solver/test_mutual_request_boost.py
+++ b/tests/unit/bunking/solver/test_mutual_request_boost.py
@@ -283,6 +283,46 @@ def test_evaluator_not_bunk_with_never_boosts(evaluator):
     assert score == 2 * expected_per_request
 
 
+def test_objective_evaluator_unsatisfied_first_pick_does_not_promote_second(evaluator):
+    """#1524: slot-index alignment with solver.
+
+    Camper A has two bunk_with requests, sorted by is_first_requested DESC:
+      - A→B (is_first_requested=True): B placed in a different bunk → unsatisfied
+      - A→C (no first-pick flag):       C placed in A's bunk     → satisfied
+
+    The solver iterates the full list (sorted by is_first_requested DESC) and
+    multiplies each request's weight by its satisfaction BoolVar. So A→B's
+    BoolVar=0 contributes nothing at i=0, but i still advances; A→C lands at
+    i=1 → SECOND_REQUEST_MULTIPLIER (5x).
+
+    Pre-fix, the evaluator tracks a satisfied-only counter
+    (satisfied_count_for_person), so A→C is treated as the *first satisfied*
+    request and gets FIRST_REQUEST_MULTIPLIER (10x). Net 2x overcounting
+    versus the actual solver objective.
+
+    Post-fix, the evaluator uses the outer enumerate's `i`, matching the
+    solver. A→C scores `BASE × SECOND` (200), not `BASE × FIRST` (400).
+    """
+    assignments = {1: 100, 2: 200, 3: 100}  # A in 100, B in 200 (unsat), C in 100 (sat)
+    requests = [
+        _dict_req(1, 2, is_first_requested=True),  # A→B first-pick, will be unsatisfied
+        _dict_req(1, 3),  # A→C second-pick, will be satisfied
+    ]
+    person_by_cm_id = {
+        1: {"campminder_person_id": 1},
+        2: {"campminder_person_id": 2},
+        3: {"campminder_person_id": 3},
+    }
+
+    score, _ = evaluator._calculate_request_satisfaction(assignments, requests, person_by_cm_id)
+
+    expected = int(BASE_REQUEST_WEIGHT * 1.0 * SECOND_REQUEST_MULTIPLIER)
+    assert score == expected, (
+        f"Expected {expected} (BASE × SECOND, matching solver), got {score} — "
+        "evaluator is treating satisfied second-pick as slot 0 instead of slot 1"
+    )
+
+
 def test_evaluator_mutual_boost_applies_to_every_slot(evaluator):
     """A has two requests: A→B (mutual with B→A) and A→C (one-way).
     Both satisfied. With enable_first_boost=true and is_first_requested=true
@@ -469,6 +509,47 @@ def test_mutual_boost_schema_floor_is_one():
     assert entry.min_value == 1.0, (
         f"mutual_request_boost min_value must be 1.0 (got {entry.min_value}) — "
         "anything lower inversely downweights mutual pairs"
+    )
+
+
+def test_score_evaluator_unsatisfied_first_pick_does_not_promote_second():
+    """#1524: slot-index alignment with solver.
+
+    Same setup as the objective_evaluator twin test: A→B (first-pick) is
+    unsatisfied (B in a different bunk); A→C (second-pick) is satisfied.
+    The solver scores A→C at SECOND_REQUEST_MULTIPLIER (5x); pre-fix
+    score_evaluator only appends satisfied requests to `person_satisfaction`,
+    so A→C lands at i=0 → FIRST_REQUEST_MULTIPLIER (10x). 2x overcount.
+
+    Post-fix, all requests are appended (with their is_satisfied flag), the
+    diminishing-returns loop skips unsatisfied via `continue` but preserves
+    `i`, and A→C lands at i=1 matching the solver.
+    """
+    requests = [
+        _se_req(1, 2),  # A→B first-pick (is_first_requested=True via _se_req default)
+        {  # A→C — explicitly NOT first-pick to force B ahead in sort
+            "id": "r1_3",
+            "requester_id": 1,
+            "requestee_id": 3,
+            "request_type": "bunk_with",
+            "is_first_requested": False,
+            "source_field": None,
+        },
+    ]
+    assignments = [
+        {"person_cm_id": 1, "bunk_cm_id": 100},  # A
+        {"person_cm_id": 2, "bunk_cm_id": 200},  # B in different bunk → A→B unsat
+        {"person_cm_id": 3, "bunk_cm_id": 100},  # C with A → A→C sat
+    ]
+    persons = [{"cm_id": 1, "grade": 5}, {"cm_id": 2, "grade": 5}, {"cm_id": 3, "grade": 5}]
+    bunks = [{"cm_id": 100, "max_size": 12}, {"cm_id": 200, "max_size": 12}]
+    result = _run_score_evaluator(_ScoreEvalConfig(), requests, assignments, persons, bunks)
+
+    expected = int(BASE_REQUEST_WEIGHT * 1.0 * SECOND_REQUEST_MULTIPLIER)
+    assert result.request_satisfaction_score == expected, (
+        f"Expected {expected} (BASE × SECOND, matching solver), got "
+        f"{result.request_satisfaction_score} — score_evaluator is treating "
+        "satisfied second-pick as slot 0 instead of slot 1"
     )
 
 


### PR DESCRIPTION
## Summary

The solver and the two evaluators (`objective_evaluator.py`, `score_evaluator.py`) disagreed on how to compute the diminishing-returns slot index when a person's first-priority request was unsatisfied:

- **Solver** iterates the full request list (sorted by `is_first_requested DESC`) and multiplies each weight by its satisfaction `BoolVar`. An unsatisfied request contributes 0 but still advances `i`, so a satisfied second-pick lands at `SECOND_REQUEST_MULTIPLIER (5x)`.
- **Both evaluators** tracked a satisfied-only counter, so the same second-pick was treated as slot 0 → `FIRST_REQUEST_MULTIPLIER (10x)`. Net 2x overcount vs. the solver's `ObjectiveValue()`.

Stream 4's mutual boost (#1382) multiplied through this, turning the gap into 4x on reciprocal pairs. Scenario comparisons in the UI quietly drifted on any camper whose first-pick couldn't be honored.

## Why solver-as-truth

Reversing the choice (solver follows evaluators) isn't feasible — gating slot index on a CP-SAT BoolVar at model-build time would require reified constraints, exploding the model size. So the evaluators change to mirror the solver, which is what the model actually optimizes.

## Changes

- **`bunking/solver/objective_evaluator.py`**: use the outer enumerate's `i` directly; drop the dead `satisfied_count_for_person` and `order_idx` intermediates.
- **`bunking/solver/score_evaluator.py`**: append every request to `person_satisfaction` with an `is_satisfied` flag (weighted_score=0 for unsatisfied), then `continue` past unsatisfied in the diminishing-returns loop. `weight_for()` stays gated on `is_satisfied` so unknown `(source, type)` combos still log+skip instead of raising (preserves `test_score_evaluator_unknown_type.py` behavior).
- **`bunking/solver/direct_solver.py`**: no change — already the reference.

## Test plan

- [x] New `test_objective_evaluator_unsatisfied_first_pick_does_not_promote_second` + `test_score_evaluator_unsatisfied_first_pick_does_not_promote_second` — both fail red phase with the exact 2x divergence (400 vs 200), pass after the edits.
- [x] Full `test_mutual_request_boost.py` suite stays green (25 tests, +2 new).
- [x] Caught and fixed one regression mid-implementation: `weight_for()` was initially moved outside the `is_satisfied` gate, which broke `test_score_evaluator_unknown_type.py`. Re-gated.
- [x] `pre-push-verification` passes — 4867 pytest unit tests pass.

Closes #1524

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request satisfaction scoring to correctly apply diminishing-return multipliers based on request position within each requester's list.
  * Improved score evaluation to properly account for all requests when calculating satisfaction metrics, ensuring accurate weighting.

* **Tests**
  * Added tests to verify correct alignment of satisfaction metrics across evaluators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->