### PR TITLE
docs(docs): close out Go modernization §2 + refresh stale §0

### DIFF
--- a/docs/reference/modernization-backlog.md
+++ b/docs/reference/modernization-backlog.md
@@ -6,28 +6,30 @@ Reference audit of modern language/tooling features available to Kindred but not
 
 **Execution model:** Work this backlog one layer at a time (one PR per language/concept) rather than a single mega-PR. Each section governs its own execution order; there is no global cross-section ordering — pick which language to work on based on real-world signals (active PRs, blast radius, idle slot).
 
-**Section format:** §2 (Go) was rewritten to a §a/§b/§c structure (concrete rewrites with two version columns, honest survey-status table, ranked execution order). §1 (Python), §3 (Frontend), and §4 (Infrastructure) are still in the older single-table format and will be migrated when each section is next picked up — see `modernization-prompts.md` Part A. **§4 is a hardening checklist, not a language-version audit; the §a/§b/§c structure does not apply.**
+**Section lifecycle:** Open language sections start in single-table audit format (§1 Python, §3 Frontend today). On first execution loop they're restructured to §a/§b/§c per `modernization-prompts.md` Part A (concrete rewrites + honest survey-status + ranked execution order). Once every row has shipped or deferred, the section collapses to a closeout summary capturing wins / deferrals / retired false positives / surveyed-clean (§2 Go today). §4 (Infrastructure) is a hardening checklist — different artifact, no lifecycle.
 
-**Companion docs:** Ship rows by following `modernization-prompts.md` (Part B for execution, Part A for re-running an audit). The prompt doc names the false-positive lesson explicitly — every grep hit must be inspected with surrounding context before it lands in §2a.
+**Companion docs:** Ship rows by following `modernization-prompts.md` (Part B for execution, Part A for re-running an audit). The prompt doc names the false-positive lesson explicitly — every grep hit must be inspected with surrounding context before it lands in §a. When the last open section migrates, the §a/§b/§c template moves out of this doc into `modernization-prompts.md` as an appendix.
 
 ---
 
-## 0. Fixed in the PR carrying this doc
+## 0. Cross-cutting fixes (originating PR #972 + follow-ups)
+
+Shipped in originating PR #972 (Apr 2026):
 
 - **`CLAUDE.md` language versions** — `Python 3.12+, Go 1.24+` → `Python 3.14+, Go 1.26+` (matches `.python-version` and `pocketbase/go.mod`)
 - **`README.md`** — rewritten to include Camp Analytics (metrics module), architecture diagram, Python 3.14 / Go 1.26 pins, production-deployment note about Traefik/CrowdSec fronting Caddy
+- **`ruff.toml`** — `target-version = "py312"` → `"py314"` (intended to defer but landed in #972 itself)
 
-### Deferred to its own PR
+Shipped in follow-up PRs:
 
-**Bundle: "Tell our tools we're on Python 3.14"** — ship these three together as **the first follow-up PR**. All three address the same root cause (tools assuming an older Python and flagging valid 3.14 syntax as errors). Kept separate from the docs PR so it stays docs-only.
+- **`ortools` PyPI switch** — PR #1038 moved `pyproject.toml:37` from the GitHub-release URL pin back to `ortools>=9.15`. PyPI now publishes cp314 wheels for `9.15.6755` (macOS/Linux/Windows), so the pin is healthy. Re-survey on the next ortools major bump.
 
-1. **`ruff.toml:21`** — `target-version` is still `py312` despite `pyproject.toml` requiring `>=3.14`. Bumping to `py314` activates rules (UP037 quoted annotations, UP043 unnecessary `Generator[..., None, None]` defaults) that fire on ~30+ existing test files. Do bump + `ruff check --fix` in one commit.
-2. **Add `.coderabbit.yaml` with Python-version `path_instructions`** — CodeRabbit's LLM keeps flagging modern 3.14 syntax (PEP 758 `except A, B:` without parens, PEP 649 bare annotations, PEP 695 generic syntax, `dict[str, X]` generics, `typing.TypeIs`, `asyncio.TaskGroup`) as Python 2.x errors. The right fix is a `reviews.path_instructions` block scoped to `**/*.py` that names the codebase's Python floor and the specific PEPs not to flag (20k-char budget per entry; safer than burying the note in CLAUDE.md). Schema: `docs.coderabbit.ai/reference/configuration` → `reviews.path_instructions`.
-3. **Add `AGENTS.md` at repo root** — CodeRabbit auto-scans `**/AGENTS.md` via `knowledge_base.code_guidelines` (alongside `**/CLAUDE.md`, `.cursorrules`, `.windsurfrules`, etc.). AGENTS.md is the cross-agent convention — same Python-version note benefits Codex, Cursor, Copilot, and future agents. The repo currently has neither file. Companion to #2, not a replacement: `.coderabbit.yaml` is review-scoped and harder for the reviewer model to overlook; AGENTS.md is the durable cross-agent home for the same facts.
+### Still outstanding
 
-### Outstanding quick check
+**Bundle: "Tell our tools we're on Python 3.14"** — `ruff` is already bumped (above). The two remaining bundle items remain unshipped; both files are absent from the repo today (`ls .coderabbit.yaml AGENTS.md` → not found):
 
-- **`ortools` on PyPI** — `9.15.6755` is published with wheels for cp310–cp313 only. **No cp314 wheel yet.** The GitHub-release URL pin in `pyproject.toml:37` is correct; revisit monthly. Switch back to `ortools>=9.15` on PyPI once Google publishes cp314 wheels.
+1. **Add `.coderabbit.yaml` with Python-version `path_instructions`** — CodeRabbit's LLM keeps flagging modern 3.14 syntax (PEP 758 `except A, B:` without parens, PEP 649 bare annotations, PEP 695 generic syntax, `dict[str, X]` generics, `typing.TypeIs`, `asyncio.TaskGroup`) as Python 2.x errors. The right fix is a `reviews.path_instructions` block scoped to `**/*.py` that names the codebase's Python floor and the specific PEPs not to flag (20k-char budget per entry; safer than burying the note in CLAUDE.md). Schema: `docs.coderabbit.ai/reference/configuration` → `reviews.path_instructions`.
+2. **Add `AGENTS.md` at repo root** — CodeRabbit auto-scans `**/AGENTS.md` via `knowledge_base.code_guidelines` (alongside `**/CLAUDE.md`, `.cursorrules`, `.windsurfrules`, etc.). AGENTS.md is the cross-agent convention — same Python-version note benefits Codex, Cursor, Copilot, and future agents. Companion to #1, not a replacement: `.coderabbit.yaml` is review-scoped and harder for the reviewer model to overlook; AGENTS.md is the durable cross-agent home for the same facts.
 
 ---
 
@@ -63,7 +65,7 @@ Baseline is strong: Pydantic v2 everywhere, `datetime.UTC` adopted, modern gener
 
 ### Recommended Python PR order
 
-1. `chore(ci): ruff target-version py314` — already in this PR
+1. ~~`chore(ci): ruff target-version py314`~~ — ✓ shipped in originating PR #972
 2. `chore(py): drop redundant __future__ annotations import` — mechanical, repo-wide
 3. `refactor(api): adopt asyncio.TaskGroup in metrics services` — focused, ~35 callsites, behavioral improvement
 4. `refactor(api): use itertools.batched for chunking` — 11 callsites
@@ -71,88 +73,70 @@ Baseline is strong: Pydantic v2 everywhere, `datetime.UTC` adopted, modern gener
 
 ---
 
-## 2. Go (project is on 1.26)
+## 2. Go — closed at 1.26 (May 2026)
 
-**Toolchain:** `pocketbase/go.mod` declares `go 1.26.0`; locally installed `go1.26.0`. 1.26 is the current stable as of April 2026 — already on latest, no version bump pending.
+**Toolchain at closeout:** Go 1.26.3 (toolchain pin `go 1.26.0`).
+**Idiom level pre-audit:** pre-1.18 (`interface{}` everywhere, `sort.*`, no `slices`/`maps`/`cmp`).
+**Idiom level post-audit:** through 1.25 except deferred row below.
+**Next-audit floor:** features added in Go 1.27+. Don't re-survey 1.18–1.26 — outcomes captured below.
 
-**Idiom level:** the compiler is 1.26 but the codebase mixes idiom from pre-1.18 through ~1.21. Baseline is otherwise excellent: 784 `slog` uses, 395 `fmt.Errorf("%w", ...)` wrappings, no `ioutil`, `math/rand/v2` already adopted. The dominant gap is an `interface{}` → `any` codemod the codebase never got.
+### Shipped
 
-### How to read these tables
+10 PRs landed 14 distinct rewrites across the sync layer and supporting packages:
 
-The first table lists rewrites with both a **`from` works since** column (oldest Go that accepts the current idiom — usually `1.0`) and a **`to` available since** column (when the target idiom became available). The codebase's effective idiom level is roughly *the highest "from works since" we still depend on*, which is `1.0` everywhere — i.e. our code reads like Go 1.0–1.18 even though we build on 1.26.
-
-The second table is an honest accounting of where the original audit *stopped looking*, with survey results filled in.
-
-### 2a. Concrete rewrites (current targets)
-
-| From (current idiom) | To (modern equivalent) | `from` works since | `to` available since | Impact | Where | Count |
-|---|---|---|---|---|---|---|
-| `interface{}` | `any` | 1.0 | 1.18 | **HIGH** | `sync/api.go` (108), `sync/base_sync.go` (42), `sync/households.go` (35+), widespread | 744 |
-| `map[string]interface{}` | `map[string]any` | 1.0 | 1.18 | **HIGH** | same hotspots | 603 |
-| `fmt.Sprintf(...)` inside `slog.Info(...)` etc. | raw key/value attrs | n/a | 1.21 (`log/slog`) | **HIGH** | `campminder/client.go:1008`, `sync/financial_transactions.go:106`, `sync/orchestrator.go:784,844` | 4 |
-| `strings.Contains(err.Error(), "...")` | sentinel errors + `errors.Is` / `errors.As` | 1.0 | 1.13 | **HIGH** | `sync/rate_limited_sheets_writer.go` (Google 429), `scheduler_test.go`, `workbook_manager_test.go`, `orchestrator_test.go` | 4 |
-| `sort.Slice(s, less)` | `slices.SortFunc(s, cmp)` | 1.0 (`sort.Slice` since 1.8) | 1.21 | **MEDIUM** | `sync/normalize_geographic_test.go`, `sync/workbook_manager.go`, `sync/multi_workbook_ordering.go` (2×) | 3 |
-| `sort.Strings(s)` | `slices.Sort(s)` | 1.0 | 1.21 | **MEDIUM** | `rbac/hooks.go`, `sync/base_sync.go` (2×), `sync/multi_workbook_ordering.go` (2×), `sync/table_exporter.go` | 6 |
-| `for i := 0; i < len(s); i++` | `for i := range s` | 1.0 | 1.22 (loop-var semantics) | **MEDIUM** | `sync/households.go`, `staff_skills.go`, `session_resolver.go`, `sessions.go`, `camper_history.go`, `rate_limited_sheets_writer.go`, tests | 26 |
-| manual map-clear loop | `clear(m)` | 1.0 | 1.21 | **MEDIUM** | `sync/base_sync.go:122–125, 130–133` | 2 |
-| Mixed `log` + `log/slog` in one file | consolidate on `slog` | n/a | 1.21 (`log/slog`) | **LOW** | `campminder/client.go:11` | 1 file |
-| ~~`strings.Index(x, y) != -1`~~ | ~~`strings.Contains(x, y)`~~ | — | — | **FALSE POSITIVE** | ~~`sync/base_sync.go:1084`~~ | ~~1~~ |
-| `time.After` in retry loop | reuse `time.NewTimer` | 1.0 | 1.0 | **?** | `sync/rate_limited_sheets_writer.go:194` | 1 |
-
-**Notes on caveats:**
-- `for i := 0; i < len(s); i++` → `for i := range s` was syntactically valid before 1.22; the reason it's now *preferred* is that 1.22 made the loop variable per-iteration scoped, which makes `i`-capture in closures/goroutines safe.
-- Some of the 26 `for i := 0; …` callsites use `i += batchSize` — those still need the classic form (or migrate to `slices.Chunk`, see survey table below).
-- **`strings.Index` row was a false positive.** The original audit pattern-matched `Index(...) != -1` without inspecting the body. The single hit at `sync/base_sync.go:1084` uses `idx` as a *slice boundary* (`result[:idx] + result[endIdx:]`), not just as a presence check, so `strings.Contains` would discard the offset that the next 7 lines depend on. **Lesson: every audit row must be confirmed against the surrounding code before claiming it's a candidate, not just against the regex.**
-
-### 2b. Survey status of features ≥ 1.22
-
-The original audit was scoped to "features the existing code visibly avoids," so library-level wins from 1.22 onward were under-surveyed. Findings below were filled in via this PR's discovery pass.
-
-| Feature | Since | Survey status | Findings | Notes |
-|---|---|---|---|---|
-| `min` / `max` builtins | 1.21 | surveyed | ~10 manual `if a > b` ternaries (`sync/orchestrator.go:565`, `sync/rate_limited_sheets_writer.go:211`, `sync/sheets_scheduling.go:60,63`, `sync/persons.go:637, 1029`, `ratelimit/ratelimit.go:85`, `sync/feedback/handler.go:104`) + 1 `math.Min` (`ratelimit/ratelimit.go:78`) | Drops a few `math` imports if all converted. **MEDIUM**. |
-| `cmp.Or` (first non-zero) | 1.22 | surveyed | ~5 chained-nonzero patterns (`sync/normalize_geographic.go:487`, `sync/table_exporter.go:262, 358`, `sync/camper_transportation_test.go:296`, `sync/camper_history_test.go:1045`) | Readability only. **LOW–MEDIUM**. |
-| `math/rand/v2` | 1.22 | **already adopted** | `sync/orchestrator.go:9` already imports `math/rand/v2`; `sync/rate_limited_sheets_writer.go` correctly uses `crypto/rand` for jitter | No work — confirms 1.22 idiom is partially adopted. ✓ |
-| `slices.Concat` | 1.22 | **retired (false positive)** | 3 `append(x, y...)` callsites (`sync/multi_workbook_ordering.go:39`, `sync/persons.go:1429`, `campminder/client.go:1020`) — but 2 are loop accumulators where `slices.Concat` would lose `append`'s growth amortization, and the 3rd rewrite is no clearer than the original | See Retired subsection in §2c. |
-| `slices.Chunk` | 1.23 | surveyed | 6 manual `for i := 0; i < len(x); i += batchSize` chunkers (`sync/households.go:104`, `staff_skills.go:541`, `session_resolver.go:188`, `camper_history.go:1042`, `persons.go:283`, plus `camper_history_test.go:529`) | **MEDIUM** — strictly better than the for-range rewrite for these specific loops. Replaces the "still needs classic form for `i += batchSize`" caveat above. |
-| Range-over-func iterators (`for x := range fn`) | 1.23 | surveyed | No callback-iteration patterns (`func(...) bool` only appears as `sort.Slice` less-funcs, which are migrating to `slices.SortFunc` anyway) | No candidates. ✓ |
-| Generic type aliases (`type Set[T] = map[T]struct{}`) | 1.24 | surveyed | No generic functions in the codebase (`func Foo[T ...]` returned 0 hits) | N/A — no generics to alias. ✓ |
-| `os.Root` (rooted FS, anti-traversal) | 1.24 | surveyed | All `os.ReadFile`/`os.WriteFile` use trusted internal paths (`s.App.DataDir()`, env-driven config paths, all already nolint'd as G304). No untrusted-input file ops. | Not security-relevant here. **LOW** value. |
-| `testing/synctest` (virtualized time in tests) | 1.24 (experiment) / 1.25 (GA) | **ungated** | Real candidates: `sync/orchestrator_test.go` (~10 `time.Sleep`s, total real-time ~1.5s+), `sync/scheduler_test.go` (300ms+200ms sleeps), `sync/rate_limited_sheets_writer_test.go:387`, `rbac/config_hooks_test.go:74,84` | **MEDIUM**. 1.25 GA shipped, toolchain is 1.26 — no longer gated. Would speed up test suite and remove flake risk. |
-| `encoding/json/v2` | 1.25 | surveyed | `campminder/client.go` is the hot path (33 callsites); `sync/base_sync.go` (8), `sync/normalize_geographic_test.go` (10) | Opt-in; v2 is a real API change, not a drop-in. **DEFER until ecosystem signal** — i.e. until logging/observability libs in our dep graph (or other packages we marshal *to*/from) accept v2 marshalers, so we don't have to wrap every boundary. The Go-stdlib gate is no longer the blocker (1.25 has shipped). |
-| `context.WithoutCancel` / `context.AfterFunc` | 1.21 / 1.21 | surveyed | Only `WithCancel` in tests; no production patterns where a derived context needs to outlive its parent | No candidates. ✓ |
-
-### 2c. Execution order (easiest → hardest)
-
-Operational ranking driving the row-by-row PR loop in `modernization-prompts.md` Part B. **Pick rule: status `next` first, else lowest-numbered live row.** Bundle hints in the table are guidance for the brief, not a directive to skip — never re-rank based on a bundle hint.
-
-#### Retired
-
-| Item | Where | Reason |
+| PR | Rewrite | Scope |
 |---|---|---|
-| `strings.Index() != -1` → `strings.Contains(...)` | `sync/base_sync.go:1084` | **FALSE POSITIVE** — `idx` is used as a slice boundary (`result[:idx] + result[endIdx:]`), not just as a presence check; `strings.Contains` would discard the offset. See §2a annotation. *Lesson: always inspect surrounding code before adding to §2a.* |
-| `append(x, y...)` → `slices.Concat` | `sync/multi_workbook_ordering.go:39`, `sync/persons.go:1429`, `campminder/client.go:1020` | **FALSE POSITIVE** — 2 of 3 callsites are loop accumulators (`persons.go:1429` inside `for status { for page {…} }`; `client.go:1020` inside `for month := 1; month <= 12 {…}`) where `slices.Concat` would lose `append`'s growth-amortized capacity and allocate fresh on every iteration. The 3rd site (`multi_workbook_ordering.go:39`) is a single conditional concat where the rewrite is no clearer than the current 5 lines. *Lesson: filter `append(x, y...)` candidates for non-loop context — the spread-append regex matches accumulator anti-patterns where `slices.Concat` is actively wrong.* |
+| #1066 | `clear()` builtin + `sort.{Slice,Strings,Ints}` → `slices.{SortFunc,Sort}` (drops `"sort"` import) | `sync/`, `rbac/` |
+| #1070 | `min`/`max` builtins + `cmp.Or` | `sync/`, `ratelimit/` |
+| #1071 | `interface{}` → `any` (744 sites, single `gofmt -r` codemod) | repo-wide |
+| #1074 | `log/slog` consolidation (drops `log.Printf` alongside `slog`) | `campminder/` |
+| #1075 | manual chunkers → `slices.Chunk` (6 sites; deleted `splitIntoBatches` helper) | `sync/` |
+| #1076 | `for i := 0; …` → `for i := range s` (closure-capture safety) | `sync/`, `ratelimit/`, tests |
+| #1562 | `fmt.Sprintf` inside `slog.*` → structured key/value attrs | `sync/` |
+| #1564 | `time.After` → reused `time.NewTimer` in retry loop | `sync/rate_limited_sheets_writer.go` |
+| #1565 | `strings.Contains(err.Error(), ...)` → sentinel errors + `errors.Is`/`errors.As` | `sync/scheduler.go` + tests |
+| #1566 | `testing/synctest` for time-based tests | `sync/`, `rbac/` |
 
-#### Live (renumbered after retired and already-done/N/A items removed)
+### Deferred
 
-| Rank | Status | Item | Where | Count | Bundle |
-|---|---|---|---|---|---|
-| 1 | ✓ shipped #1066 | manual map-clear → `clear()` builtin | `sync/base_sync.go:121, 1416` | 2 | — |
-| 2 | ✓ shipped #1066 | `sort.Strings` → `slices.Sort` | `rbac/hooks.go`, `sync/base_sync.go` (2×), `camper_history_test.go`, `multi_workbook_ordering.go` (2×), `table_exporter.go` (2×) | 8 | bundled w/ #3; drift +`camper_history_test.go:546` (audit miss) |
-| 3 | ✓ shipped #1066 | `sort.Slice` → `slices.SortFunc` | `sync/normalize_geographic_test.go`, `base_sync.go:1402`, `workbook_manager.go` | 3 | bundled w/ #2 |
-| — | ✓ shipped #1066 | `sort.Ints` → `slices.Sort` (drift, audit miss) | `sync/family_camp_derived_test.go:163` | 1 | included in #2/#3 bundle to drop `"sort"` import package-wide |
-| 4 | ✓ shipped #1070 | `min` / `max` builtins | `sync/orchestrator.go:565`, `rate_limited_sheets_writer.go:211`, `persons.go:637`, `ratelimit/ratelimit.go:78` | 4 | bundled w/ #5; ~7 audit entries retired as false positives (early-return validators in `sheets_scheduling.go:60,63` & `persons.go:1029`, side-effecting if in `ratelimit.go:85`, error-size check in `feedback/handler.go:104`) |
-| 5 | ✓ shipped #1070 | `cmp.Or` (first non-zero) | `sync/table_exporter.go:262` | 1 | bundled w/ #4; ~4 audit entries retired as false positives (`normalize_geographic.go:487`, `table_exporter.go:358` — "if non-empty, do X" patterns rather than first-non-zero fallbacks) |
-| 6 | ✓ shipped #1071 | `map[string]interface{}` → `map[string]any` | hotspots | 603 | bundled w/ #7 as single `gofmt -r` codemod; surfaced pre-existing dead branch in `normalizeToStringSlice` (issue #1072) |
-| 7 | ✓ shipped #1071 | `interface{}` → `any` | `sync/api.go` (122), `base_sync.go` (29), `households.go`, widespread | 141 (744 incl. #6) | bundled w/ #6 |
-| 8 | ✓ shipped #1074 | log/slog consolidation | `campminder/client.go:11` (`log.Printf` alongside `slog`) | 1 file | scan-it surfaced pre-existing unbounded recursion in `authenticate()` 429 retry — filed as issue #1079; constant `maxRequestRetries` extracted in same PR |
-| 9 | ✓ shipped #1075 | manual chunkers → `slices.Chunk` | `sync/households.go:104`, `staff_skills.go:541`, `session_resolver.go:188`, `camper_history.go:1042`, `persons.go:283`, plus test | 6 | scan-it surfaced inconsistent batch sizes (50/100/500) across sync services as a pre-existing issue — filed as #1078; deleted bespoke `splitIntoBatches` helper + its test |
-| 10 | ✓ shipped #1076 | `for i := 0; …` → `for i := range s` | `sync/sessions.go` (n² sort outer), `rate_limited_sheets_writer.go` (retry), `ratelimit/ratelimit.go` (retry), `household_demographics_test.go` (byte-indexed string), `google/client_test.go` (substring search), tests | 22 | originally stacked on #1075; rebased onto main with `git rebase --onto` after #1075 squash-merged; `lll` lint required wrapping multi-attr slog calls (caught only on CI — `golangci-lint` not in `lefthook pre-push`) |
-| 11 | next | `fmt.Sprintf` inside `slog` | `campminder/client.go:1008`, `sync/financial_transactions.go:106`, `sync/orchestrator.go:784,844` | 4 | — |
-| 12 | | `time.After` in retry loop | `sync/rate_limited_sheets_writer.go:194` | 1 | — |
-| 13 | | string error matching → sentinels | `sync/rate_limited_sheets_writer.go` (Google 429), `scheduler_test.go`, `workbook_manager_test.go`, `orchestrator_test.go` | 4 | behavioral |
-| 14 | | `testing/synctest` for time-based tests | `orchestrator_test.go`, `scheduler_test.go`, `rate_limited_sheets_writer_test.go`, `rbac/config_hooks_test.go` | 10+ sleeps | 1.25 GA shipped, toolchain is 1.26 — no longer gated |
-| 15 | deferred | `encoding/json/v2` | `campminder/client.go` (33), `sync/base_sync.go` (8) | hot path | defer until ecosystem signal (deps accept v2 marshalers) |
+- **`encoding/json/v2`** — still `GOEXPERIMENT=jsonv2`-gated in Go 1.26.3; package doc explicitly says *"not subject to the Go 1 compatibility promise … Most users should use `encoding/json`."* Hot path is `pocketbase/campminder/client.go` (32 callsites today; ~71 total across 15 files). Re-evaluate when v2 lands as GA stdlib (likely Go 1.27 or 1.28), not on ecosystem-signal alone. The original doc claim that "1.25 has shipped" implying GA was wrong.
+
+### Retired as false positives (calibration for future audits)
+
+These survived the regex pass to the brief stage before being killed. Worth remembering because the same regexes will keep matching:
+
+| Pattern | Where | Why it failed |
+|---|---|---|
+| `strings.Index(x, y) != -1` → `strings.Contains` | `sync/base_sync.go:1084` | `idx` used as slice boundary (`result[:idx] + result[endIdx:]`); `Contains` discards the offset that the next 7 lines need. **Lesson: inspect surrounding lines, not just the predicate.** |
+| `append(x, y...)` → `slices.Concat` | `multi_workbook_ordering.go:39`, `persons.go:1429`, `campminder/client.go:1020` | 2 of 3 hits are loop accumulators where `slices.Concat` allocates fresh on every iteration, losing `append`'s amortized growth. The 3rd is no clearer rewritten. **Lesson: filter `append(x, y...)` candidates for non-loop context.** |
+
+In-bundle retired false positives (caught during execution, not surfaced as standalone retired rows): `min`/`max` candidates that were really early-return validators (`sheets_scheduling.go:60,63`, `persons.go:1029`), side-effecting `if` (`ratelimit.go:85`), error-size check (`feedback/handler.go:104`); `cmp.Or` candidates that were "if non-empty, do X" rather than first-non-zero fallbacks (`normalize_geographic.go:487`, `table_exporter.go:358`); `fmt.Sprintf` inside `slog` candidates that were literal `/12` denominators (`campminder/client.go:1116,1130`).
+
+### Surveyed clean (no candidates / not applicable)
+
+Grepped at audit time, yielded nothing worth shipping. Don't re-audit on a 1.27+ pass.
+
+- **`math/rand/v2`** — already adopted in `sync/orchestrator.go`; `crypto/rand` used correctly elsewhere for jitter.
+- **Range-over-func iterators (`for x := range fn`, 1.23)** — no callback-iteration patterns; `func(...) bool` only appeared as `sort.Slice` less-funcs (migrated in #1066).
+- **Generic type aliases (1.24)** — no generic functions in the codebase (`func Foo[T ...]` returned 0 hits).
+- **`os.Root` (1.24)** — all file ops use trusted internal paths (`s.App.DataDir()`, env-driven config); no untrusted-input candidates.
+- **`context.WithoutCancel` / `context.AfterFunc` (1.21)** — no production patterns where a derived context outlives its parent.
+
+### Drift / discoveries during execution (filed separately)
+
+Modernization PRs surfaced unrelated pre-existing issues. Tracked for completeness:
+
+- **#1072** — dead branch in `normalizeToStringSlice` (surfaced during #1071 `interface{}` codemod review)
+- **#1078** — inconsistent batch sizes (50/100/500) across sync services (surfaced during #1075 `slices.Chunk` work)
+- **#1079** — unbounded recursion in `campminder/client.go` `authenticate()` 429 retry (surfaced during #1074 slog consolidation; constant `maxRequestRetries` extracted in same PR)
+
+### Process lessons (carried into `modernization-prompts.md` Rules 1–3)
+
+- **Inspect surrounding code, not just the regex** — see retired rows above.
+- **`lll` lint required wrapping multi-attr slog calls** in #1076; caught only on CI because `golangci-lint` is not in `lefthook pre-push`. Worth re-checking whether to move it into pre-push.
+- **CodeRabbit flagged "bypasses logging contract" on #1562** — false positive; logging pkg installs default slog handler via `slog.SetDefault` and no `logging.Info` wrapper exists. Worth a `.coderabbit.yaml` `path_instructions` entry once that lands (see §0).
+
+Survey scope: Go 1.18 through 1.26. Re-run Part A on a 1.27+ toolchain bump.
 
 ---
 


### PR DESCRIPTION
## Summary

- **§2 (Go) closed at 1.26.** Past-tense closeout replaces the §a/§b/§c audit format now that everything but `encoding/json/v2` has shipped. Shipped table covers 10 PRs landing 14 rewrites (#1066–#1566), single deferred row keeps `encoding/json/v2` blocked on GA stdlib (still `GOEXPERIMENT=jsonv2`-gated in 1.26.3 — original "1.25 shipped" claim was wrong). Retired false positives kept as calibration data for future audits. Next-audit floor = Go 1.27+ so future re-runs skip 1.18–1.26.
- **§0 refreshed.** ortools cp314 wheels now exist on PyPI (resolved by #1038); ruff `target-version=py314` actually shipped in originating PR #972 (not deferred); `.coderabbit.yaml` + `AGENTS.md` still missing — kept as outstanding bundle.
- **Doc preamble.** Replaced static "§2 uses §a/§b/§c" note with a lifecycle description (open audit → §a/§b/§c → closeout). Flagged that the §a/§b/§c template moves to `modernization-prompts.md` once the last open section (Python or Frontend) migrates.

## Test plan

- [x] `docs/reference/modernization-backlog.md` renders cleanly on GitHub
- [x] All shipped-PR references resolvable (#972, #1038, #1066, #1070, #1071, #1074, #1075, #1076, #1562, #1564, #1565, #1566)
- [x] §2 line count dropped ~80 lines while preserving audit trail + false-positive lessons

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated modernization backlog execution model and section lifecycle workflows.
  * Refreshed Python and Go language modernization tracking and closure status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->