### PR TITLE
docs(config): add .coderabbit.yaml + close out §0 AGENTS.md decision

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -54,7 +54,7 @@ reviews:
         - Built-in generics: `dict[str, X]`, `list[X]`, `tuple[X, ...]` (no `typing.Dict/List/Tuple`)
         - Union syntax: `X | None` (no `typing.Optional` / `typing.Union`)
         - `typing.TypeIs` (3.13+), `typing.ReadOnly` (3.13+), `typing.override` (3.12+)
-        - `asyncio.TaskGroup`, `asyncio.timeout`, `itertools.batched`, `copy.replace`, `tomllib`
+        - `asyncio.TaskGroup`, `asyncio.timeout`, `itertools.batched`, `copy.replace`
         Style preferences:
         - Prefer `asyncio.TaskGroup` over `asyncio.gather` for new concurrent code (aggregates exceptions via ExceptionGroup).
         - Prefer `itertools.batched(x, n)` over manual `range(0, len(x), n)` chunking.
@@ -72,6 +72,7 @@ reviews:
         - `slices.Chunk` for batching; `slices.SortFunc` / `slices.Sort`
         - `math/rand/v2` (already adopted); `crypto/rand` for jitter
         - `testing/synctest` for time-dependent tests
+        Logging contract: the `logging` package installs the default slog handler via `slog.SetDefault` at init — direct `slog.Info(...)` / `slog.Error(...)` / etc. calls are the correct pattern. There is no `logging.Info` wrapper. Do NOT flag direct `slog.*` calls as "bypasses logging contract" — that's a false positive.
         Do NOT suggest `encoding/json/v2` — still `GOEXPERIMENT=jsonv2`-gated as of Go 1.26.3 and not subject to the Go 1 compatibility promise. The codebase deliberately uses `encoding/json` until v2 is GA.
         Domain invariant: cross-table relationships use CampMinder IDs (`cm_id`, `person_id`), never PocketBase record IDs. All CampMinder-derived tables include a required `year` field; year filtering must use `CAMPMINDER_SEASON_ID` from env.
 
@@ -86,16 +87,22 @@ reviews:
 
     - path: "frontend/**/*.{ts,tsx}"
       instructions: |
-        React 19 + TypeScript 5.8 + ES2022 baseline. tsconfig already has bundler resolution, verbatimModuleSyntax, noImplicitOverride, erasableSyntaxOnly.
+        React 19 + TypeScript 6.0 + ES2022 baseline. tsconfig already has bundler resolution, verbatimModuleSyntax, noImplicitOverride, erasableSyntaxOnly. Lib target is ES2022 — do NOT suggest ES2023+ APIs (e.g. `Object.groupBy`, `Map.groupBy`, `Promise.withResolvers`) unless tsconfig `lib` is bumped first.
         Style preferences (don't insist, but prefer):
         - `Array.toSorted()` / `toReversed()` over `[...arr].sort()` / `.reverse()`
-        - `Object.groupBy()` over `reduce((acc, x) => ...)` groupBy patterns
         - `use()` hook over `useContext` for new contexts
         - `<Context>` shorthand over `<Context.Provider>`
         - Error cause chaining: `throw new Error(msg, { cause: err })`
         - `satisfies` for config / route / feature-map objects
         Critical auth invariant: protected FastAPI endpoints MUST be called via `fetchWithAuth` (NOT raw `fetch` with `credentials: 'include'`). The PocketBase JWT lives in `localStorage`, NOT cookies — raw fetch silently 401s. Mutation-mocked hook tests cannot catch this; service-level tests must assert the Authorization header.
         Routing pattern: Caddy routes specific PocketBase patterns to PocketBase; everything else under `/api/*` goes to FastAPI. New FastAPI endpoints automatically work — no Caddy enumeration needed.
+
+    - path: "api/**/*.py"
+      instructions: |
+        FastAPI HTTP layer — thin routers over `bunking/`. If a router accumulates logic, extract to `bunking/` and have the router call back in.
+        Global exception handler in `api/main.py` returns a generic `{"detail": "Internal server error"}` (never the actual error) and logs the traceback server-side with `exc_info=True`. Do NOT suggest `raise HTTPException(status_code=500, detail=str(e))` — that leaks internals; let the global handler catch it.
+        Auth: `bunking/auth_middleware.py` + `bunking/jwt_auth.py` verify PocketBase JWTs. Protected endpoints must verify auth or they silently 401 (the JWT lives in localStorage, not cookies — frontend must call them via `fetchWithAuth`, never raw `fetch` with `credentials: 'include'`).
+        Routers live in `api/routers/`, schemas in `api/schemas/`. Same Python 3.14 conventions as `bunking/` — tag the logger with `[api]`.
 
     - path: "bunking/**/*.py"
       instructions: |

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,129 @@
+# CodeRabbit configuration — schema: https://docs.coderabbit.ai/reference/configuration
+# Companion to the **/CLAUDE.md hierarchy already auto-scanned via
+# knowledge_base.code_guidelines. This file scopes review-time behavior;
+# CLAUDE.md captures durable repo conventions.
+
+language: en-US
+
+tone_instructions: |
+  Direct and terse. No emojis, no poems, no fortune. Point out real bugs; skip cosmetic nits.
+
+reviews:
+  profile: chill
+
+  # Noise reduction — recent walkthroughs were dense and buried the actionable lines.
+  collapse_walkthrough: true
+  high_level_summary: true
+  sequence_diagrams: false
+  poem: false
+  in_progress_fortune: false
+  changed_files_summary: true
+
+  # We don't open drafts (see CLAUDE.md global-preferences). No need to auto-review them.
+  auto_review:
+    drafts: false
+
+  # Workflow surfacing — these earn their space on this repo.
+  related_issues: true
+  assess_linked_issues: true
+  suggested_labels: false
+  suggested_reviewers: false
+
+  # Path-scoped review guidance. 20k char/entry limit.
+  path_instructions:
+    - path: "**/*.py"
+      instructions: |
+        Python 3.14+ codebase (see pyproject.toml `requires-python = ">=3.14"`).
+        Treat the following as valid syntax — do NOT flag as errors or "compatibility issues":
+        - PEP 758: `except A, B:` without parentheses
+        - PEP 649: bare runtime annotations (the codebase deliberately does NOT use `from __future__ import annotations`)
+        - PEP 695: generic type-parameter syntax — `def foo[T](x: T) -> T`, `class Box[T]:`, `type Alias[T] = list[T]`
+        - PEP 750: t-string literals
+        - Built-in generics: `dict[str, X]`, `list[X]`, `tuple[X, ...]` (no `typing.Dict/List/Tuple`)
+        - Union syntax: `X | None` (no `typing.Optional` / `typing.Union`)
+        - `typing.TypeIs` (3.13+), `typing.ReadOnly` (3.13+), `typing.override` (3.12+)
+        - `asyncio.TaskGroup`, `asyncio.timeout`, `itertools.batched`, `copy.replace`, `tomllib`
+        Style preferences:
+        - Prefer `asyncio.TaskGroup` over `asyncio.gather` for new concurrent code (aggregates exceptions via ExceptionGroup).
+        - Prefer `itertools.batched(x, n)` over manual `range(0, len(x), n)` chunking.
+        - Pydantic v2 throughout — do not suggest v1 patterns.
+        - Use `datetime.UTC`, not `datetime.timezone.utc`.
+
+    - path: "pocketbase/**/*.go"
+      instructions: |
+        Go 1.26+ codebase (pocketbase/go.mod declares `go 1.26.0`). Idiomatic baseline:
+        - `any` (not `interface{}`); `map[string]any` (not `map[string]interface{}`)
+        - `slices`, `maps`, `cmp` packages over legacy `sort.*`
+        - `min`/`max`/`clear` builtins; `cmp.Or` for first-non-zero
+        - `log/slog` with structured key/value attrs — do NOT suggest `fmt.Sprintf` inside `slog.*`
+        - `errors.Is` / `errors.As` with sentinel errors — never `strings.Contains(err.Error(), ...)`
+        - `slices.Chunk` for batching; `slices.SortFunc` / `slices.Sort`
+        - `math/rand/v2` (already adopted); `crypto/rand` for jitter
+        - `testing/synctest` for time-dependent tests
+        Do NOT suggest `encoding/json/v2` — still `GOEXPERIMENT=jsonv2`-gated as of Go 1.26.3 and not subject to the Go 1 compatibility promise. The codebase deliberately uses `encoding/json` until v2 is GA.
+        Domain invariant: cross-table relationships use CampMinder IDs (`cm_id`, `person_id`), never PocketBase record IDs. All CampMinder-derived tables include a required `year` field; year filtering must use `CAMPMINDER_SEASON_ID` from env.
+
+    - path: "pocketbase/pb_migrations/*.js"
+      instructions: |
+        PocketBase v0.23+ migration syntax. Specific gotchas:
+        - Field add() requires `new Field(...)` wrapper — bare object literal `add({...})` fails at server-boot apply time with "could not convert [object Object] to core.Field". Unit tests will NOT catch this.
+        - Do NOT use the old `options: {}` wrapper for field properties — v0.23 flattens them. Using the old wrapper causes silent data truncation.
+        - Filename numbering must exceed the highest filename on origin/main; never fill gaps left by consolidation runs (numbers are "burned" to preserve a monotonically increasing record).
+        - WAL checkpoint recommended after data-write migrations (`db.newQuery("PRAGMA wal_checkpoint(TRUNCATE)").execute()`).
+        Reference: docs/reference/pocketbase-migrations.md and the `pocketbase-migrations` skill's `templates/add-fields.js`.
+
+    - path: "frontend/**/*.{ts,tsx}"
+      instructions: |
+        React 19 + TypeScript 5.8 + ES2023 baseline. tsconfig already has bundler resolution, verbatimModuleSyntax, noImplicitOverride, erasableSyntaxOnly.
+        Style preferences (don't insist, but prefer):
+        - `Array.toSorted()` / `toReversed()` over `[...arr].sort()` / `.reverse()`
+        - `Object.groupBy()` over `reduce((acc, x) => ...)` groupBy patterns
+        - `use()` hook over `useContext` for new contexts
+        - `<Context>` shorthand over `<Context.Provider>`
+        - Error cause chaining: `throw new Error(msg, { cause: err })`
+        - `satisfies` for config / route / feature-map objects
+        Critical auth invariant: protected FastAPI endpoints MUST be called via `fetchWithAuth` (NOT raw `fetch` with `credentials: 'include'`). The PocketBase JWT lives in `localStorage`, NOT cookies — raw fetch silently 401s. Mutation-mocked hook tests cannot catch this; service-level tests must assert the Authorization header.
+        Routing pattern: Caddy routes specific PocketBase patterns to PocketBase; everything else under `/api/*` goes to FastAPI. New FastAPI endpoints automatically work — no Caddy enumeration needed.
+
+    - path: "bunking/solver/**/*.py"
+      instructions: |
+        OR-Tools CP-SAT solver. Constraint/objective changes need a unit test that exercises the constraint behavior, not just the solver's pass/fail. Soft-constraint penalties register through `weight_for(source_field, request_type)` — never collapse `(source_field, request_type)` keys that happen to share a numeric weight today; they're independent tunable dimensions.
+
+    - path: "tests/**/*.py"
+      instructions: |
+        Test data MUST use the fictional name set from CLAUDE.md: Emma Johnson, Liam Garcia, Olivia Chen, Riley Sam, Samuel Johnson, etc. Fictional schools: Riverside Elementary, Oak Valley Middle, Hillcrest High. Fictional session IDs: 1000001, 1000002.
+        Tests are the spec — do NOT suggest modifying tests to match implementation behavior. TDD is required for new behavioral code.
+        Integration tests that hit a running server (e.g. `test_metrics_retention.py`) will fail without one — that is expected, not a test bug.
+
+    - path: "**/*.md"
+      instructions: |
+        Documentation may use Unicode dashes (— –), arrow characters, and unnumbered headings. Do not suggest TOC additions for docs under 500 lines. Do not flag non-ASCII characters as problems.
+
+  # Drop generated / vendored / lockfile noise.
+  path_filters:
+    - "!frontend/dist/**"
+    - "!frontend/node_modules/**"
+    - "!pocketbase/pb_data/**"
+    - "!pocketbase/pb_public/**"
+    - "!**/*.lock"
+    - "!**/package-lock.json"
+    - "!**/go.sum"
+    - "!**/uv.lock"
+
+knowledge_base:
+  # Keep repo-specific learnings local — no cross-org pattern leakage.
+  learnings:
+    scope: local
+  # Already default, set explicit for clarity. Auto-scans **/CLAUDE.md and **/AGENTS.md.
+  code_guidelines:
+    enabled: true
+
+chat:
+  art: false
+
+# Code-generation features are off — we don't ask CR to write code in this repo.
+code_generation:
+  docstrings:
+    language: en-US
+
+early_access: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -19,6 +19,18 @@ reviews:
   in_progress_fortune: false
   changed_files_summary: true
 
+  # Pre-merge checks default to mode: warning when omitted. Turn them off explicitly —
+  # title/description quality and docstring coverage aren't gates we want CR enforcing.
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
+    title:
+      mode: "off"
+    description:
+      mode: "off"
+    issue_assessment:
+      mode: "off"
+
   # We don't open drafts (see CLAUDE.md global-preferences). No need to auto-review them.
   auto_review:
     drafts: false
@@ -51,7 +63,7 @@ reviews:
 
     - path: "pocketbase/**/*.go"
       instructions: |
-        Go 1.26+ codebase (pocketbase/go.mod declares `go 1.26.0`). Idiomatic baseline:
+        Go 1.26+ codebase (pocketbase/go.mod declares `go 1.26.3`). Idiomatic baseline:
         - `any` (not `interface{}`); `map[string]any` (not `map[string]interface{}`)
         - `slices`, `maps`, `cmp` packages over legacy `sort.*`
         - `min`/`max`/`clear` builtins; `cmp.Or` for first-non-zero
@@ -74,7 +86,7 @@ reviews:
 
     - path: "frontend/**/*.{ts,tsx}"
       instructions: |
-        React 19 + TypeScript 5.8 + ES2023 baseline. tsconfig already has bundler resolution, verbatimModuleSyntax, noImplicitOverride, erasableSyntaxOnly.
+        React 19 + TypeScript 5.8 + ES2022 baseline. tsconfig already has bundler resolution, verbatimModuleSyntax, noImplicitOverride, erasableSyntaxOnly.
         Style preferences (don't insist, but prefer):
         - `Array.toSorted()` / `toReversed()` over `[...arr].sort()` / `.reverse()`
         - `Object.groupBy()` over `reduce((acc, x) => ...)` groupBy patterns
@@ -85,6 +97,16 @@ reviews:
         Critical auth invariant: protected FastAPI endpoints MUST be called via `fetchWithAuth` (NOT raw `fetch` with `credentials: 'include'`). The PocketBase JWT lives in `localStorage`, NOT cookies — raw fetch silently 401s. Mutation-mocked hook tests cannot catch this; service-level tests must assert the Authorization header.
         Routing pattern: Caddy routes specific PocketBase patterns to PocketBase; everything else under `/api/*` goes to FastAPI. New FastAPI endpoints automatically work — no Caddy enumeration needed.
 
+    - path: "bunking/**/*.py"
+      instructions: |
+        Camp-data Python (sync pipeline, satisfaction policy, social graph, RBAC, geo, config).
+        Domain invariants — same as the Go sync path:
+        - Cross-table relationships use CampMinder IDs (`cm_id`, `person_id`), never PocketBase record IDs.
+        - All CampMinder-derived data carries a required `year` field; year filtering uses `CAMPMINDER_SEASON_ID` from env (frontend year dropdown is display-only).
+        - Sync order is fixed: sessions → attendees → persons → bunks → plans → assignments → requests. Don't suggest reordering.
+        - Active-attendee filter is `status_id = 2`.
+        - Family-camp data syncs alongside summer data — summer views filter `session_type` against `VALID_SUMMER_SESSION_TYPES`.
+
     - path: "bunking/solver/**/*.py"
       instructions: |
         OR-Tools CP-SAT solver. Constraint/objective changes need a unit test that exercises the constraint behavior, not just the solver's pass/fail. Soft-constraint penalties register through `weight_for(source_field, request_type)` — never collapse `(source_field, request_type)` keys that happen to share a numeric weight today; they're independent tunable dimensions.
@@ -94,6 +116,11 @@ reviews:
         Test data MUST use the fictional name set from CLAUDE.md: Emma Johnson, Liam Garcia, Olivia Chen, Riley Sam, Samuel Johnson, etc. Fictional schools: Riverside Elementary, Oak Valley Middle, Hillcrest High. Fictional session IDs: 1000001, 1000002.
         Tests are the spec — do NOT suggest modifying tests to match implementation behavior. TDD is required for new behavioral code.
         Integration tests that hit a running server (e.g. `test_metrics_retention.py`) will fail without one — that is expected, not a test bug.
+
+    - path: "frontend/src/**/*.test.{ts,tsx}"
+      instructions: |
+        Same fictional-name discipline as `tests/**/*.py`: Emma Johnson, Liam Garcia, Olivia Chen, Riley Sam, Samuel Johnson, etc. Fictional schools: Riverside Elementary, Oak Valley Middle, Hillcrest High. Fictional CampMinder IDs: 1000001, 1000002. Never propagate real names from production data into tests, fixtures, or snapshots.
+        Tests are the spec — do NOT suggest modifying tests to match implementation behavior. TDD is required for new behavioral code.
 
     - path: "**/*.md"
       instructions: |
@@ -109,6 +136,21 @@ reviews:
     - "!**/package-lock.json"
     - "!**/go.sum"
     - "!**/uv.lock"
+
+  # All linters default to enabled. Mute the Python/JS ones we deliberately don't run
+  # locally — they'd flag existing code against rules we don't enforce.
+  # Kept enabled (defaults): ruff, golangci-lint, eslint, shellcheck (mirror our pre-push hooks)
+  # plus hadolint, actionlint, gitleaks, markdownlint, yamllint, semgrep, ast-grep — no local
+  # equivalent, pure CR-side signal.
+  tools:
+    flake8:
+      enabled: false
+    pylint:
+      enabled: false
+    biome:
+      enabled: false
+    oxc:
+      enabled: false
 
 knowledge_base:
   # Keep repo-specific learnings local — no cross-org pattern leakage.

--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,15 @@ pocketbase/pb_migrations/*_updated_users.js
 !pocketbase/eslint.config.js
 
 # =============================================================================
+# Go workspace
+# =============================================================================
+# go.work is checked in (silences gopls multi-module LSP warning across
+# pocketbase/ and docker/healthcheck/). go.work.sum is a workspace-overlay
+# sum file regenerated on every workspace-aware `go` invocation — pure local
+# churn. Security-load-bearing sums live in pocketbase/go.sum.
+go.work.sum
+
+# =============================================================================
 # Database files
 # =============================================================================
 *.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ Internalize these — violating them produces incorrect code or data corruption.
 8. **Attendee filtering** — solver uses `status_id = 2` for active enrolled attendees
 
 #### Tooling Notes
-1. **Language Versions** — Python 3.14+, Go 1.26+, Node 22+, TypeScript 5.8+/ES2022
+1. **Language Versions** — Python 3.14+, Go 1.26+, Node 22+, TypeScript 6.0+/ES2022
 2. **Use uv** — `uv sync` to install, `uv run <cmd>` to execute
 3. **AI model** — GPT-5-nano via `AI_MODEL` env var ($0.05/$0.40 per M tokens, reasoning enabled)
 4. **Token caching** — CampMinder JWT cached in `~/.campminder_token_cache.json`

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ CampMinder API  ──►  Go Sync Services  ──┐
 
 ## Tech Stack
 
-- **Frontend**: React 19, TypeScript 5.8, Vite, Tailwind CSS, React Query, @dnd-kit, Cytoscape.js
+- **Frontend**: React 19, TypeScript 6.0, Vite, Tailwind CSS, React Query, @dnd-kit, Cytoscape.js
 - **Backend API**: Python 3.14+, FastAPI, Google OR-Tools, Pydantic v2
 - **Database & Auth**: PocketBase (Go 1.26+) on SQLite (WAL), OIDC auto-discovery for SSO
 - **Sync & Integrations**: Go services for CampMinder, Google Sheets/Drive, OpenAI (GPT-5-nano for bunk request parsing)

--- a/docs/reference/modernization-backlog.md
+++ b/docs/reference/modernization-backlog.md
@@ -24,12 +24,13 @@ Shipped in follow-up PRs:
 
 - **`ortools` PyPI switch** — PR #1038 moved `pyproject.toml:37` from the GitHub-release URL pin back to `ortools>=9.15`. PyPI now publishes cp314 wheels for `9.15.6755` (macOS/Linux/Windows), so the pin is healthy. Re-survey on the next ortools major bump.
 
-### Still outstanding
+### Bundle closeout — "Tell our tools we're on Python 3.14"
 
-**Bundle: "Tell our tools we're on Python 3.14"** — `ruff` is already bumped (above). The two remaining bundle items remain unshipped; both files are absent from the repo today (`ls .coderabbit.yaml AGENTS.md` → not found):
+All three items resolved:
 
-1. **Add `.coderabbit.yaml` with Python-version `path_instructions`** — CodeRabbit's LLM keeps flagging modern 3.14 syntax (PEP 758 `except A, B:` without parens, PEP 649 bare annotations, PEP 695 generic syntax, `dict[str, X]` generics, `typing.TypeIs`, `asyncio.TaskGroup`) as Python 2.x errors. The right fix is a `reviews.path_instructions` block scoped to `**/*.py` that names the codebase's Python floor and the specific PEPs not to flag (20k-char budget per entry; safer than burying the note in CLAUDE.md). Schema: `docs.coderabbit.ai/reference/configuration` → `reviews.path_instructions`.
-2. **Add `AGENTS.md` at repo root** — CodeRabbit auto-scans `**/AGENTS.md` via `knowledge_base.code_guidelines` (alongside `**/CLAUDE.md`, `.cursorrules`, `.windsurfrules`, etc.). AGENTS.md is the cross-agent convention — same Python-version note benefits Codex, Cursor, Copilot, and future agents. Companion to #1, not a replacement: `.coderabbit.yaml` is review-scoped and harder for the reviewer model to overlook; AGENTS.md is the durable cross-agent home for the same facts.
+1. **`ruff target-version = "py314"`** — ✓ shipped in originating PR #972.
+2. **`.coderabbit.yaml`** — ✓ shipped (this PR). Includes Python 3.14 `path_instructions` (PEP 758/649/695/750, `typing.TypeIs`, `asyncio.TaskGroup`) plus path-scoped guidance for Go 1.26 idioms, PocketBase v0.23 migration syntax, React 19 / TS 5.8 frontend conventions, OR-Tools solver invariants, fictional-test-data discipline, and Markdown noise filters. `learnings.scope: local` + `related_issues` / `assess_linked_issues` enabled; `pre_merge_checks`, `suggested_labels`, `poem`/`fortune` deliberately off.
+3. **`AGENTS.md`** — **decided not to add.** The only consumers of agent-instruction files in this repo are Claude Code and CodeRabbit. CodeRabbit already auto-scans `**/CLAUDE.md` via `knowledge_base.code_guidelines.filePatterns`, and the repo already has a 7-file CLAUDE.md hierarchy (root + `tests/`, `bunking/`, `bunking/solver/`, `frontend/`, `pocketbase/`, `api/`). AGENTS.md would duplicate those without serving a distinct audience. Revisit if Codex / Cursor / Jules adoption ever happens.
 
 ---
 

--- a/docs/reference/modernization-backlog.md
+++ b/docs/reference/modernization-backlog.md
@@ -29,7 +29,7 @@ Shipped in follow-up PRs:
 All three items resolved:
 
 1. **`ruff target-version = "py314"`** — ✓ shipped in originating PR #972.
-2. **`.coderabbit.yaml`** — ✓ shipped (this PR). Includes Python 3.14 `path_instructions` (PEP 758/649/695/750, `typing.TypeIs`, `asyncio.TaskGroup`) plus path-scoped guidance for Go 1.26 idioms, PocketBase v0.23 migration syntax, React 19 / TS 5.8 frontend conventions, OR-Tools solver invariants, fictional-test-data discipline, and Markdown noise filters. `learnings.scope: local` + `related_issues` / `assess_linked_issues` enabled; `pre_merge_checks`, `suggested_labels`, `poem`/`fortune` deliberately off.
+2. **`.coderabbit.yaml`** — ✓ shipped (this PR). Includes Python 3.14 `path_instructions` (PEP 758/649/695/750, `typing.TypeIs`, `asyncio.TaskGroup`) plus path-scoped guidance for Go 1.26 idioms (incl. the `slog.SetDefault` default-handler false-positive suppression), PocketBase v0.23 migration syntax, React 19 / TS 6.0 / ES2022 frontend conventions, the `api/` FastAPI surface, OR-Tools solver invariants, fictional-test-data discipline, and Markdown noise filters. `learnings.scope: local` + `related_issues` / `assess_linked_issues` enabled; `pre_merge_checks`, `suggested_labels`, `poem`/`fortune` deliberately off.
 3. **`AGENTS.md`** — **decided not to add.** The only consumers of agent-instruction files in this repo are Claude Code and CodeRabbit. CodeRabbit already auto-scans `**/CLAUDE.md` via `knowledge_base.code_guidelines.filePatterns`, and the repo already has a 7-file CLAUDE.md hierarchy (root + `tests/`, `bunking/`, `bunking/solver/`, `frontend/`, `pocketbase/`, `api/`). AGENTS.md would duplicate those without serving a distinct audience. Revisit if Codex / Cursor / Jules adoption ever happens.
 
 ---
@@ -135,7 +135,7 @@ Modernization PRs surfaced unrelated pre-existing issues. Tracked for completene
 
 - **Inspect surrounding code, not just the regex** — see retired rows above.
 - **`lll` lint required wrapping multi-attr slog calls** in #1076; caught only on CI because `golangci-lint` is not in `lefthook pre-push`. Worth re-checking whether to move it into pre-push.
-- **CodeRabbit flagged "bypasses logging contract" on #1562** — false positive; logging pkg installs default slog handler via `slog.SetDefault` and no `logging.Info` wrapper exists. Worth a `.coderabbit.yaml` `path_instructions` entry once that lands (see §0).
+- **CodeRabbit flagged "bypasses logging contract" on #1562** — false positive; logging pkg installs default slog handler via `slog.SetDefault` and no `logging.Info` wrapper exists. ✓ Addressed in §0 — `.coderabbit.yaml` `pocketbase/**/*.go` block documents the `slog.SetDefault` default-handler pattern explicitly.
 
 Survey scope: Go 1.18 through 1.26. Re-run Part A on a 1.27+ toolchain bump.
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -71,4 +71,4 @@ In a fresh worktree, hit the **Vite dev port printed by `new.sh`** (the port off
 
 ## Tech versions
 
-React 19, TypeScript 5.8+/ES2022, Vite, Tailwind CSS, @tanstack/react-query, @dnd-kit, Cytoscape.js. Node 22+.
+React 19, TypeScript 6.0+/ES2022, Vite, Tailwind CSS, @tanstack/react-query, @dnd-kit, Cytoscape.js. Node 22+.

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -27,7 +27,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
 
-    /* TypeScript 5.8.3 Enhanced Strictness */
+    /* TypeScript 6.0 Enhanced Strictness */
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "noPropertyAccessFromIndexSignature": true,

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,1 +1,0 @@
-cloud.google.com/go v0.112.2 h1:ZaGT6LiG7dBzi6zNOvVZwacaXlmf3lRqnC4DQzqyRQw=


### PR DESCRIPTION
## Summary

Resolves the §0 bundle in `docs/reference/modernization-backlog.md`:

1. **`.coderabbit.yaml`** — new file. Scopes review-time behavior per language/path while CLAUDE.md keeps the durable conventions. `knowledge_base.code_guidelines.enabled: true` ensures CR keeps auto-scanning the existing 7-file `**/CLAUDE.md` hierarchy.
2. **AGENTS.md** — **decided not to add.** The only consumers in this repo are Claude Code and CodeRabbit; CR already reads `**/CLAUDE.md`. Adding AGENTS.md would duplicate without serving a distinct audience. §0 records the decision so it doesn't keep surfacing in future audits.

## What's in `.coderabbit.yaml`

**Path-scoped review guidance** (the main payload, 20k char/entry):

| Path | Guidance |
|---|---|
| `**/*.py` | Python 3.14 baseline — PEP 758/649/695/750, `typing.TypeIs`, `asyncio.TaskGroup`, built-in generics, `X \| None` unions, `datetime.UTC`. Don't flag as syntax errors. |
| `pocketbase/**/*.go` | Go 1.26 baseline — `any` not `interface{}`, `slices`/`maps`/`cmp`, `min`/`max`/`clear`, structured `slog`, `errors.Is`/`As` with sentinels, `testing/synctest`. **Don't suggest `encoding/json/v2`** — still GOEXPERIMENT-gated. Domain invariants: CampMinder IDs across tables, `year` field required, `CAMPMINDER_SEASON_ID` env filter. |
| `pocketbase/pb_migrations/*.js` | PB v0.23 syntax — `new Field(...)` wrapper required; no `options: {}` wrapper; filename numbers must exceed `origin/main` HEAD; WAL checkpoint after data writes. |
| `frontend/**/*.{ts,tsx}` | React 19 + TS 5.8 + ES2023 — `toSorted`/`Object.groupBy`/`use()`/`<Context>`/error cause chaining/`satisfies`. **Critical auth invariant**: protected FastAPI endpoints MUST use `fetchWithAuth` (PB JWT in localStorage, not cookies). |
| `bunking/solver/**/*.py` | OR-Tools — `weight_for(source_field, request_type)` keys are independent tunable dimensions even when their numeric weights coincide today. |
| `tests/**/*.py` | Fictional names only (Emma Johnson, etc.). Tests are the spec; don't suggest modifying tests to match implementation. Integration tests fail without a running server — that's expected. |
| `**/*.md` | Tolerate Unicode dashes/arrows; no TOC suggestions under 500 lines. |

**Other settings:**
- `learnings.scope: local` — no cross-org pattern leakage
- `related_issues: true`, `assess_linked_issues: true` — workflow surfacing earns its space
- `pre_merge_checks`, `suggested_labels`, `auto_assign_reviewers` — explicitly off
- Noise reduction: `collapse_walkthrough`, `poem: false`, `in_progress_fortune: false`
- `path_filters` drop `dist/`, `pb_data/`, `*.lock`

## Test plan

- [x] YAML parses (`uv run python -c "import yaml; yaml.safe_load(open('.coderabbit.yaml'))"` → OK, 7 top-level keys)
- [x] `docs/reference/modernization-backlog.md` §0 reflects the three-item closeout
- [ ] CodeRabbit picks up the new config on this PR's own review (verify in walkthrough's "Configuration used" line — should switch from "Organization UI" to repo config)
- [ ] Future PRs touching Python 3.14 syntax / Go 1.26 idioms / PB migrations don't draw false-positive review nits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added repository-wide automation to standardize language/tone, review profile, summary behavior, path-scoped guidance, and local tooling preferences.
  * Updated ignore rules to exclude regenerated workspace checksum files and other generated/vendor artifacts.

* **Documentation**
  * Marked Python 3.14 modernization items resolved and documented related review notes.
  * Bumped frontend TypeScript version references and updated strictness guidance across docs and config.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->