### PR TITLE
refactor(sync): adopt PEP 695 scoped generic in phase3 disambiguation

### DIFF
--- a/bunking/sync/bunk_request_processor/services/phase3_disambiguation_service.py
+++ b/bunking/sync/bunk_request_processor/services/phase3_disambiguation_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any
 
 from bunking.logging_config import get_logger
 
@@ -16,8 +16,6 @@ from .context_builder import ContextBuilder
 from .disambiguation_reranker import rerank_disambiguation_candidates
 
 logger = get_logger(__name__)
-
-T = TypeVar("T")
 
 
 class DisambiguationCase:
@@ -170,7 +168,7 @@ class Phase3DisambiguationService:
 
         return results
 
-    def _set_meta(self, case: DisambiguationCase, key: str, default: T) -> T:
+    def _set_meta[T](self, case: DisambiguationCase, key: str, default: T) -> T:
         """Return case.disambiguation_metadata[key], inserting *default* if absent."""
         value: T = case.disambiguation_metadata.setdefault(key, default)
         return value


### PR DESCRIPTION
## Summary

Closes §c row #1 of `docs/reference/modernization-backlog.md` §1 Python. Last module-level `TypeVar` declaration in the codebase converted to a scoped generic on its single consumer.

## Before / after

```diff
- from typing import Any, TypeVar
+ from typing import Any
...
- T = TypeVar("T")
- 
- 
  class DisambiguationCase:
...
-     def _set_meta(self, case: DisambiguationCase, key: str, default: T) -> T:
+     def _set_meta[T](self, case: DisambiguationCase, key: str, default: T) -> T:
          """Return case.disambiguation_metadata[key], inserting *default* if absent."""
          value: T = case.disambiguation_metadata.setdefault(key, default)
          return value
```

## Why

Three other functions in the repo already use PEP 695 scoped generics (`api/services/breakdown_calculator.py` x2, `api/services/retention_service.py` x1). This was the last `TypeVar("...")` declaration left — converting it brings idiom consistency. No runtime change; mypy treats both forms identically.

## Stacking

Base = `feature/modernization-py-audit-redo` (#1573). Merge #1573 first, then this rebases onto main cleanly.

## Test plan

- [x] Scoped pytest: `uv run pytest tests/unit/sync/bunk_request_processor/services/ -x` — 347 passed
- [x] Pre-push verification ran on push (no diagnostic errors on the rewritten function)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal type annotations and declarations with no changes to user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->