### PR TITLE
docs(config): enable CodeRabbit auto-review for non-default base branches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -32,8 +32,12 @@ reviews:
       mode: "off"
 
   # We don't open drafts (see CLAUDE.md global-preferences). No need to auto-review them.
+  # Default behavior is to only auto-review PRs targeting the default branch — opt in to
+  # all base branches so stacked PRs (e.g. `feature/foo` → `feature/foo-parent`) get reviews.
   auto_review:
     drafts: false
+    base_branches:
+      - ".*"
 
   # Workflow surfacing — these earn their space on this repo.
   related_issues: true


### PR DESCRIPTION
## Summary
- CodeRabbit defaults to only auto-reviewing PRs targeting the repo's default branch.
- Stacked PRs (e.g. #1574 and #1575 targeting \`feature/modernization-py-audit-redo\`) were skipped with the "Auto reviews are disabled on base/target branches other than the default branch" status message.
- Set \`reviews.auto_review.base_branches: [".*"]\` so every PR target gets a review.

## Test plan
- [ ] Merge, then re-open or push to a stacked PR and confirm CodeRabbit triggers a review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Auto-review configuration now covers pull requests to all base branches, including stacked PR scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->