### PR TITLE
refactor(api): copy.replace for dataclasses.replace

### DIFF
--- a/bunking/solver/impossibility.py
+++ b/bunking/solver/impossibility.py
@@ -18,7 +18,8 @@ predicate.
 """
 
 from collections import defaultdict
-from dataclasses import dataclass, field, replace
+from copy import replace
+from dataclasses import dataclass, field
 from typing import Any, NamedTuple
 
 from bunking.config import ConfigLoader

--- a/bunking/sync/bunk_request_processor/processing/deduplicator.py
+++ b/bunking/sync/bunk_request_processor/processing/deduplicator.py
@@ -3,7 +3,7 @@
 Handles deduplication within batches and optionally checks against
 existing database records."""
 
-import dataclasses
+import copy
 from dataclasses import dataclass, field
 
 from bunking.logging_config import get_logger
@@ -188,7 +188,7 @@ class Deduplicator:
                 # staff review. Both rows survive — no merge.
                 if _is_conflicting_age_preference_pair(group_requests):
                     bunk_with_req, socialize_with_req = _split_age_pref_pair(group_requests)
-                    bunk_with_pending = dataclasses.replace(bunk_with_req, status=RequestStatus.PENDING)
+                    bunk_with_pending = copy.replace(bunk_with_req, status=RequestStatus.PENDING)
                     kept_requests.append(bunk_with_pending)
                     kept_requests.append(socialize_with_req)
                     # No entry in duplicate_groups: these are not merged duplicates,

--- a/bunking/sync/bunk_request_processor/services/phase1_parse_service.py
+++ b/bunking/sync/bunk_request_processor/services/phase1_parse_service.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from collections.abc import Callable
-from dataclasses import replace
+from copy import replace
 from typing import Any
 
 from bunking.logging_config import get_logger

--- a/tests/unit/sync/bunk_request_processor/services/test_phase1_parse_service.py
+++ b/tests/unit/sync/bunk_request_processor/services/test_phase1_parse_service.py
@@ -578,3 +578,46 @@ class TestAgeDirectionPhase1Conversion:
             "bug class age_direction was introduced to eliminate"
         )
         assert parsed.target_name is None
+
+
+class TestPhase1ParseServiceSanitization:
+    """Spec-lock for _sanitize_requests' field-replacement contract.
+
+    Locks the behavior of the `replace(req, request_text=...)` call so the
+    dataclasses.replace -> copy.replace modernization stays bit-equivalent:
+    a new ParseRequest is produced with only request_text swapped to the
+    sanitizer output; every other field is carried over unchanged.
+    """
+
+    def test_sanitize_replaces_only_request_text(self):
+        sanitizer = Mock()
+        sanitizer.process.return_value = Mock(
+            sanitized_text="cleaned text",
+            is_suspicious=False,
+        )
+        service = Phase1ParseService(
+            ai_service=Mock(),
+            context_builder=Mock(),
+            sanitizer=sanitizer,
+        )
+        req = _create_parse_request(request_text="raw text")
+
+        sanitized, metadata = service._sanitize_requests([req])
+
+        assert len(sanitized) == 1
+        result = sanitized[0]
+        # A new instance, not a mutated original
+        assert result is not req
+        # Only request_text is swapped, to the sanitizer's output
+        assert result.request_text == "cleaned text"
+        # Every other field is carried over unchanged
+        assert result.field_name == req.field_name
+        assert result.requester_name == req.requester_name
+        assert result.requester_cm_id == req.requester_cm_id
+        assert result.requester_grade == req.requester_grade
+        assert result.session_cm_id == req.session_cm_id
+        assert result.session_name == req.session_name
+        assert result.year == req.year
+        assert result.row_data == req.row_data
+        # Benign input records no security metadata
+        assert metadata == {}


### PR DESCRIPTION
## What

Modernization backlog **§1 Python row #4**. Swaps `dataclasses.replace(obj, **changes)` → `copy.replace(obj, **changes)` at the 3 callsites.

Since Python 3.13, `copy.replace()` dispatches to `obj.__replace__()`, which dataclasses implement automatically — so for dataclass instances the two are **bit-equivalent**, while adopting the generalized, type-agnostic spelling.

| File | Operand | Style |
|------|---------|-------|
| `bunking/solver/impossibility.py:120` | `ImpossibilityReport` | `from copy import replace` (bare call kept) |
| `bunking/sync/.../services/phase1_parse_service.py:244` | `ParseRequest` | `from copy import replace` (bare call kept) |
| `bunking/sync/.../processing/deduplicator.py:191` | `BunkRequest` | `import copy` + `copy.replace` — also drops now-unused `import dataclasses` |

## Why

`copy.replace` is the modern protocol-based spelling (works for any class implementing `__replace__`, not just dataclasses). In `deduplicator.py` it lets us delete a dead-weight `import dataclasses`.

## Testing (Rule 3 — pure rewrite)

Existing tests for `impossibility` + `deduplicator` are the spec (both green before/after). Added a spec-lock test for phase1 `_sanitize_requests` asserting the `replace` contract: new instance, only `request_text` swapped, all other fields preserved.

- `mypy --strict`: clean (the modern `copy.replace` symbol is recognized; editor Pyright stubs lag but are not the gate)
- 4879 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for request sanitization functionality to verify correct field replacement behavior and metadata handling.

* **Chores**
  * Updated internal module dependencies to improve code maintainability and consistency across the request processing pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->