### PR TITLE
docs(docs): collapse §1 Python modernization section to closeout

### DIFF
--- a/docs/reference/modernization-backlog.md
+++ b/docs/reference/modernization-backlog.md
@@ -6,7 +6,7 @@ Reference audit of modern language/tooling features available to Kindred but not
 
 **Execution model:** Work this backlog one layer at a time (one PR per language/concept) rather than a single mega-PR. Each section governs its own execution order; there is no global cross-section ordering — pick which language to work on based on real-world signals (active PRs, blast radius, idle slot).
 
-**Section lifecycle:** Open language sections start in single-table audit format (§3 Frontend today). On first execution loop they're restructured to §a/§b/§c per `modernization-prompts.md` Part A (concrete rewrites + honest survey-status + ranked execution order) — see §1 Python for the in-progress §a/§b/§c shape. Once every row has shipped or deferred, the section collapses to a closeout summary capturing wins / deferrals / retired false positives / surveyed-clean (§2 Go today). §4 (Infrastructure) is a hardening checklist — different artifact, no lifecycle.
+**Section lifecycle:** Open language sections start in single-table audit format (§3 Frontend today). On first execution loop they're restructured to §a/§b/§c per `modernization-prompts.md` Part A (concrete rewrites + honest survey-status + ranked execution order); that in-progress shape is preserved in this doc's git history (see §1 Python before its closeout). Once every row has shipped, skipped, or deferred, the section collapses to a closeout summary capturing wins / deferrals / retired false positives / surveyed-clean (§1 Python and §2 Go today). §4 (Infrastructure) is a hardening checklist — different artifact, no lifecycle.
 
 **Companion docs:** Ship rows by following `modernization-prompts.md` (Part B for execution, Part A for re-running an audit). The prompt doc names the false-positive lesson explicitly — every grep hit must be inspected with surrounding context before it lands in §a. When the last open section migrates, the §a/§b/§c template moves out of this doc into `modernization-prompts.md` as an appendix.
 
@@ -34,69 +34,56 @@ All three items resolved:
 
 ---
 
-## 1. Python (project is on 3.14)
+## 1. Python — closed at 3.14 (May 2026)
 
-**Toolchain at audit (May 2026):** `requires-python = ">=3.14"`; `.python-version` = `3.14`; `uv run python` ships `3.14.2`. Latest stable upstream is 3.14 (3.15 not GA). `ruff.toml target-version = "py314"`.
-**Idiom level pre-audit:** mixed 3.10–3.12. 510 files carry redundant `from __future__ import annotations` (a no-op under PEP 649 in 3.14); 24 manual `range(0, len(x), n)` chunkers; 35 `asyncio.gather` sites; 1 explicit `T = TypeVar(...)` declaration.
-**Idiom level post-audit goal:** through 3.14 except deferred row below.
+**Toolchain at closeout:** Python 3.14.2 (`requires-python = ">=3.14"`, `.python-version` = `3.14`); `ruff.toml target-version = "py314"`. Latest stable upstream is 3.14 (3.15 not GA).
+**Idiom level pre-audit:** mixed 3.10–3.12 — 510 redundant `from __future__ import annotations`, 24 `range(0, len(x), n)` chunkers, 35 `asyncio.gather` sites, 1 explicit `T = TypeVar(...)`.
+**Idiom level post-audit:** through 3.14 except the deferred + skipped rows below.
 **Next-audit floor:** features added in Python 3.15+. Don't re-survey 3.10–3.14 — outcomes captured below.
 
-Baseline is strong: Pydantic v2 everywhere, `from datetime import UTC` adopted in 23 files (zero `timezone.utc` left), modern generics (`dict[str, X]`), `StrEnum` in 4 files, three functions already use PEP 695 scoped generics, f-strings clean, mypy `strict = true`, no `Union`/`Optional`/`Dict`/`List`/`Tuple` typing imports outside docstrings.
+Baseline was already strong at audit: Pydantic v2 everywhere, `from datetime import UTC` in 23 files (zero `timezone.utc` left), PEP 585 builtin generics (`dict[str, X]`) and PEP 604 `X | Y` unions throughout, `StrEnum` in 4 files, three functions already on PEP 695 scoped generics, f-strings clean, mypy `strict = true`, no `Union`/`Optional`/`Dict`/`List`/`Tuple` typing imports outside docstrings.
 
-### §a — Concrete rewrites (current targets)
+### Shipped
 
-| Impact | From (current idiom) | To (modern equivalent) | `from` works since | `to` available since | Where | Count |
-|---|---|---|---|---|---|---|
-| **HIGH** | `from __future__ import annotations` | delete the import (PEP 649 in 3.14 makes deferred evaluation the default — note: PEP 649 ≠ PEP 563, see §c #3 verification note) **except** in files pairing `if TYPE_CHECKING:` imports with bare annotations, where the import is load-bearing | 3.7 | 3.14 (PEP 649) | repo-wide | ✓ shipped #1578: 467 deleted, 43 `TYPE_CHECKING` files kept (510 total) |
-| **HIGH** | `asyncio.gather(*tasks)` / `asyncio.gather(..., return_exceptions=True)` | `async with asyncio.TaskGroup() as tg: ... tg.create_task(...)` (aggregates failures via `ExceptionGroup` instead of dropping sibling tasks) | 3.4 | 3.11 (PEP 654 + asyncio.TaskGroup) | `api/services/{drilldown,forecast,geo,historical,registration,retention,session_availability,velocity,batch_processor,validation}.py`, `bunking/sync/.../{trace_collector,batch_processor}.py` | 35 across 11 files (1 of them uses `return_exceptions=True`) |
-| **MEDIUM** | `for i in range(0, len(x), n): chunk = x[i:i+n]` and the list-comprehension form `[x[i:i+n] for i in range(0, len(x), n)]` | `from itertools import batched; for chunk in batched(x, n)` (returns tuples — call `list()` if downstream mutates) | 3.0 | 3.12 (`itertools.batched`) | `api/routers/validation.py:198`, `api/services/{metrics_repository,metrics_sql_repository,data_fetcher}.py`, `bunking/satisfaction/aggregate.py:328`, `bunking/graph/optimized_graph_builder.py`, `bunking/sync/.../debug_parse_repository.py` (9), `.../attendee_repository.py` (3), `.../social_graph.py`, `.../ai_service.py`, `.../batch_processor.py:369` | 24 across 12 files |
-| **LOW** | `T = TypeVar("T")` + `def foo(x: T) -> T` | scoped generic `def foo[T](x: T) -> T:` (and drop the module-level `TypeVar`) | 3.5 (PEP 484) | 3.12 (PEP 695) | `bunking/sync/bunk_request_processor/services/phase3_disambiguation_service.py:6,20` | 1 declaration |
-| **LOW** | `dataclasses.replace(obj, field=value)` | `copy.replace(obj, field=value)` (generalizes — works for any class implementing `__replace__`) | 3.7 (`dataclasses`) | 3.13 (`copy.replace`) | `bunking/solver/impossibility.py:23`, `bunking/sync/.../phase1_parse_service.py:7`, `bunking/sync/.../deduplicator.py:193` | 3 |
-| **LOW** | Enable ruff `PLC0415` (`import-outside-toplevel`) — currently not in the enabled rules list | turn on the rule; clean offenders first | n/a | ruff 0.4+ | repo-wide; one known offender surfaced by PR #1529 review (`test_analyze_objective_sensitivity.py` had `import pytest` inside a test body) | 1 known + however many a fresh pass surfaces |
+5 PRs landed 5 distinct rewrites across the `api/` and `bunking/` layers:
 
-### §b — Survey status (features ≥ 3.11, plus 3.10 cleanups verified)
+| PR | Rewrite | Scope |
+|---|---|---|
+| #1574 | PEP 695 scoped generic `[T]` + drop the module-level `TypeVar` (3.12) | `phase3_disambiguation_service.py` |
+| #1575 | enable ruff `PLC0415` (`import-outside-toplevel`) + sweep 108 production import-hoists (+4 `# noqa` for genuine circular-import / test-monkeypatch cases); `tests/**` per-file-ignored | repo-wide |
+| #1578 | drop redundant `from __future__ import annotations` (PEP 649, 3.14) — 467 deleted, **43 `if TYPE_CHECKING:` files kept** (load-bearing under PEP 649, *not* PEP 563) | repo-wide |
+| #1579 | `dataclasses.replace` → `copy.replace` (3.13) — 3 callsites + spec-lock test | `bunking/` |
+| #1582 | `range(0, len(x), n)` chunkers → `itertools.batched` (3.12) — 23 sites / 10 files, all `strict=False`, tuple-vs-slice inspected per site (3 helpers widened `list`→`Sequence`, 2 list-comp forms kept via `[list(b) for b in batched(...)]`) | `api/`, `bunking/` |
 
-Each row records the actual search expression so the next audit can pick up where this one stopped looking.
+**Audit-count corrections found during execution** (counts decay — see Process lessons): `PLC0415` was 1,871 hits, not "1 known"; `__future__` redundancy was 467, not all 510; `itertools.batched` was 23 sites/10 files, not "24/12"; `asyncio.gather` was 35/13, not "35/11".
+
+### Deferred
+
+- **PEP 750 t-strings (3.14)** — `grep -rEn "f['\"](SELECT|INSERT|UPDATE|DELETE|CREATE TABLE|ALTER TABLE|DROP) " …` → 5 SQL f-strings in `scripts/setup/seed_from_prod.py` (3), `tests/test_seed_from_prod.py` (1), plus 2 multiline in `api/services/metrics_sql_repository.py`. None are user-input-driven (table/column identifiers only), and PocketBase/SQLite expose no t-string-aware API. Re-evaluate when a downstream library accepts `Template`.
+
+### Skipped
+
+- **`asyncio.gather` → `asyncio.TaskGroup` (3.11)** — 35 `gather` calls across **13 files** (the §a draft said "35 across 11"; it missed `comparison`/`day1`/`retention_trends` and listed `velocity_service`, which has none). **Skipped after in-context audit (Rule 1):** every site is a homogeneous `a, b = await gather(...)` positional-unpack fan-out with no local `try/except`. TaskGroup trades that one-liner for `create_task` + `.result()` boilerplate across ~34 sites to harden an error path that the global `@app.exception_handler(Exception)` (`api/main.py:103`) already collapses to the same generic 500 — `ExceptionGroup` ⊆ `Exception`, so client-facing behavior is unchanged. The only behavioral delta is direct-call tests asserting a concrete type (e.g. `test_session_availability.py:956` → `pytest.raises(RuntimeError)`) that would have to become `ExceptionGroup`. Net: readability regression across ~34 sites > marginal sibling-cancellation gain on a rarely-hit error path for read-only fan-outs. The `return_exceptions=True` site at `batch_processor.py` was excluded regardless (different pattern — it deliberately collects exceptions). Re-survey only if a heterogeneous / partial-success fan-out appears.
+
+### Surveyed clean / dismissed (no candidates) — search expressions retained
+
+Grepped at audit time; recorded so the next pass (3.15+) knows where this one stopped looking. Features found **already adopted** are folded into the baseline paragraph above (`datetime.UTC`, PEP 585/604, `StrEnum`, partial PEP 695).
 
 | Feature | Status | Evidence |
 |---|---|---|
-| PEP 604 `X \| Y` unions (3.10) | **already adopted** | `grep -rn 'from typing import.*\bUnion\b' --include='*.py' api bunking campminder scripts tests` → 0; `grep -rn '\bOptional\[' …` → 3 (all in docstrings of `tests/unit/sync/bunk_request_processor/social/test_ranked_candidate_passthrough.py`) |
-| PEP 585 builtin generics (`list[X]`, `dict[K,V]`) (3.9) | **already adopted** | `grep -rEn '\b(Dict\|List\|Tuple\|Set\|FrozenSet)\[' --include='*.py' …` → 10 hits, all inside docstring text |
-| `match` statement (PEP 634, 3.10) | **dismissed** | `grep -rEn '^\s*match [a-zA-Z_(]' --include='*.py' …` → 0 real `match X:` statements; the 16 hits were all `match = regex.match(...)` assignments. 18 `elif isinstance(...)` candidates exist but inspection in context shows all are 2-branch or mix value-based + type-based predicates — match doesn't improve them. See "Retired" below. |
-| `datetime.UTC` (3.11) | **already adopted** | `grep -rln 'from datetime import.*UTC\b' …` → 23 files; `grep -rn 'timezone\.utc' …` → 0 legacy holdouts |
-| `tomllib` (3.11) | **dismissed** | `grep -rn 'import tomli\|import toml\b\|from tomli\|from toml ' …` → 0; project doesn't parse TOML at runtime |
-| `typing.Self` (3.11) | **dismissed** | `grep -rln 'from typing import.*Self\b\|typing\.Self\b' …` → 0; `grep -rEn 'def [a-z_]+\(cls,?.*\) -> ["\047][A-Z]' …` → 0 awkward forward refs |
-| `ExceptionGroup` / `except*` (3.11) | **dismissed** | `grep -rn 'ExceptionGroup\|except\*' …` → 0; the one `return_exceptions=True` site at `batch_processor.py:348` is the TaskGroup migration target, not a separate ExceptionGroup row |
-| `StrEnum` / `IntEnum` (3.11) | **already adopted** | `grep -rn 'StrEnum\|IntEnum' --include='*.py' …` → 4 files (`api/constants/geo.py`, `bunking/satisfaction/request_registry.py`, `bunking/bunking_validator.py`) |
-| `typing.LiteralString` (3.11) | **dismissed** | `grep -rn 'LiteralString' …` → 0; no SQL-builder layer that would gate on it (raw SQL is in scripts/tests only) |
-| PEP 695 generic syntax (3.12) | **partially adopted** | `grep -rEn 'def [a-zA-Z_]+\[[A-Z]' …` → 3 functions (`api/services/breakdown_calculator.py:57,108`, `api/services/retention_service.py:412`); `grep -rn '= TypeVar(' …` → 1 holdout — see §a |
-| `@override` decorator (3.12) | **surveyed — not actionable** | `grep -rn '@override' …` → 0; `grep -rEn '^class [A-Z][a-zA-Z_]*\([A-Z]' …` → 289 inheritance lines (27 non-Pydantic/Enum/Protocol). Adding `@override` retroactively across the AIProvider hierarchy and ABCs is a discipline policy, not a row. Decide separately whether to add the ruff rule (`PLR6301`/`misc-no-explicit-override`) before opening PRs. |
-| `itertools.batched` (3.12) | **see §a** | `grep -rn 'itertools\.batched' …` → 0 already-adopted sites; 24 `range(0, len(...))` candidates verified |
-| PEP 695 `type` statement / `TypeAlias` (3.12) | **dismissed** | `grep -rn 'TypeAlias\b' …` → 0; `grep -rEn '^type [A-Z]' …` → 0; no aliases to migrate |
-| `from __future__ import annotations` redundancy (3.14, PEP 649) | **✓ shipped #1578** | `grep -rl 'from __future__ import annotations' …` → 510 files. **NOT a universal no-op:** 467 deleted; 43 files with `if TYPE_CHECKING:` + bare annotations kept the import (load-bearing under PEP 649 — see §c #3 + Process lessons). |
-| `typing.TypeIs` (3.13) | **dismissed** | `grep -rn 'TypeGuard' …` → 0 callers; nothing to migrate |
-| `typing.ReadOnly` TypedDict fields (3.13) | **surveyed — low value** | `grep -rln 'TypedDict' …` → 6 files; none are mutated cross-module in ways `ReadOnly` would catch. Re-survey if a TypedDict bug surfaces. |
-| `copy.replace()` (3.13) | **see §a** | 3 `dataclasses.replace` callsites verified |
-| PEP 696 TypeVar defaults (3.13) | **dismissed** | `grep -rn 'TypeVar.*default=' …` → 0; the single remaining TypeVar will get folded into PEP 695 anyway |
-| PEP 702 `@deprecated` (3.13) | **dismissed** | `grep -rn '@deprecated' …` → 0; no `DeprecationWarning` discipline in the codebase yet |
-| PEP 750 t-strings (3.14) | **deferred** | `grep -rEn "f['\"](SELECT\|INSERT\|UPDATE\|DELETE\|CREATE TABLE\|ALTER TABLE\|DROP) " …` → 5 SQL f-strings in `scripts/setup/seed_from_prod.py` (3), `tests/test_seed_from_prod.py` (1), plus 2 multiline in `api/services/metrics_sql_repository.py`. None are user-input-driven (table/column identifiers only), and PocketBase/SQLite have no t-string-aware API. Re-evaluate when a downstream library accepts `Template`. The prior audit's "no SQL/HTML template builders" claim was wrong — corrected here. |
-| `compression.zstd` (3.14) | **dismissed** | `grep -i 'zstd\|zstandard' pyproject.toml` → 0; no zstandard dep |
-| `@dataclass(slots=True, kw_only=True, frozen=True)` defaults | **surveyed — not a campaign** | `grep -rn '@dataclass' …` → 85 declarations across the codebase; only 1 currently sets `slots=True`. Hottest file `bunking/sync/.../core/models.py` has 9 dataclasses. Apply opportunistically when touching a file for another reason — not worth a sweep PR. |
-
-### §c — Ranked execution order
-
-**Status values:** blank (ready) · `next` (start here) · `PR open #N` (in flight, not yet merged) · `✓ shipped #N` (merged) · `skipped (reason)` · `deferred` · `gated (...)`. Per Part B step 6, statuses flip from `PR open` to `✓ shipped` after merge.
-
-| # | Row | Status | Score (s/m/t/r/p) | Notes |
-|---|---|---|---|---|
-| 1 | PEP 695 generic syntax on `phase3_disambiguation_service.py` | **✓ shipped #1574** | 1/1/1/1/1 = 5 | 1 file, drop `TypeVar` import + retype methods using `[T]`. Trivial; ships fast. |
-| 2 | Enable ruff `PLC0415` (`import-outside-toplevel`) + sweep production offenders | **✓ shipped #1575** | 3/2/1/3/1 = 10 | Audit-count correction: prior audit said "1 known offender"; real count was 1,871 (1,567 tests + 304 production). Path B chosen: per-file-ignore `tests/**` + `api/services/test_*.py`, then sweep 108 production hoists + 4 `# noqa: PLC0415` for genuine circular-import / test-monkeypatch cases. Original score of 5 was wrong; corrected to 10. |
-| 3 | `refactor(api): drop redundant __future__ annotations import` | **✓ shipped #1578** | 3/1/1/1/1 = 7 | Mechanical-but-verify sweep. Codemod: `sed -i '/^from __future__ import annotations$/d'` + `ruff check --fix --select I` + `ruff format`. **Audit-count correction:** prior premise said all 510 redundant; **only 467 are.** 43 files pair `if TYPE_CHECKING:` imports with **bare** annotations where the import is **load-bearing** under PEP 649 — accessing `__annotations__` (via `inspect.signature`, `unittest.mock` `spec=`, FastAPI introspection, dataclass field collection) evaluates the bare annotation → `NameError` on the `TYPE_CHECKING`-only name. PEP 563 kept those as strings; PEP 649 evaluates them. The full pytest suite caught it (4 files via `Mock(spec=)`); the 43 were restored. Verified: 4962 passed + `mypy --strict` clean. |
-| 4 | `refactor(api): copy.replace for dataclasses.replace` | **PR open #1579** | 1/1/1/1/1 = 5 | 3 callsites; mostly cosmetic. Could be bundled with #1 since both are 1-file touches — but they're in different files; keep separate per PR-sizing rules. |
-| 5 | `refactor(api): itertools.batched for chunking` | **PR open #1582** | 3/1/1/2/1 = 8 | Verified count: 23 converted across 10 files (not "24 across 12"); 1 deliberately skipped (`ai_service.py:151` reuses the running index `i` for `batch_indices`). All calls `strict=False` (preserves short-final-batch). Tuple-vs-slice: 18 iterate-only (direct), 3 attendee helpers widened `list[int]`→`Sequence[int]`, 2 list-comp forms keep `list[list[...]]` via `[list(b) for b in batched(...)]`. ruff `B911` requires explicit `strict=`. |
-| 6 | `refactor(api): adopt asyncio.TaskGroup for asyncio.gather` | | 3/3/2/3/1 = 12 | Behavioral contract change: callers will start seeing `ExceptionGroup` on partial failure instead of one of `gather`'s silently-dropped siblings. Audit each call's error-handling block before converting. Don't include the `return_exceptions=True` site at `batch_processor.py:348` — that one deliberately collects exceptions; the TaskGroup translation is a different pattern (catch the group and inspect `.exceptions`). |
-
-**Tie-breakers:** none of these rows unblock each other directly. #1–#4 can ship in any order; #5 before #6 (smaller blast radius first lets reviewer fatigue settle before the big behavioral one).
+| `match` statement (PEP 634, 3.10) | dismissed | `grep -rEn '^\s*match [a-zA-Z_(]' …` → 0 real `match X:`; the 16 hits were `match = regex.match(...)`. 18 `elif isinstance` candidates all 2-branch or mixed value/type predicates — see Retired |
+| `tomllib` (3.11) | dismissed | `grep -rn 'import tomli\|import toml\b\|from tomli\|from toml ' …` → 0; no runtime TOML parsing |
+| `typing.Self` (3.11) | dismissed | `grep -rln 'from typing import.*Self\b\|typing\.Self\b' …` → 0; `grep -rEn 'def [a-z_]+\(cls,?.*\) -> ["\047][A-Z]' …` → 0 awkward forward refs |
+| `ExceptionGroup` / `except*` (3.11) | dismissed | `grep -rn 'ExceptionGroup\|except\*' …` → 0 (the `return_exceptions=True` site was the TaskGroup target — now skipped) |
+| `typing.LiteralString` (3.11) | dismissed | `grep -rn 'LiteralString' …` → 0; no SQL-builder layer (raw SQL is in scripts/tests only) |
+| PEP 695 `type` statement / `TypeAlias` (3.12) | dismissed | `grep -rn 'TypeAlias\b' …` → 0; `grep -rEn '^type [A-Z]' …` → 0; no aliases to migrate |
+| `@override` decorator (3.12) | surveyed — not actionable | `grep -rn '@override' …` → 0; 289 inheritance lines (27 non-Pydantic/Enum/Protocol). A discipline policy + ruff-rule (`PLR6301`) decision, not a row |
+| `typing.TypeIs` (3.13) | dismissed | `grep -rn 'TypeGuard' …` → 0 callers; nothing to migrate |
+| `typing.ReadOnly` TypedDict fields (3.13) | surveyed — low value | `grep -rln 'TypedDict' …` → 6 files; none mutated cross-module in ways `ReadOnly` would catch. Re-survey if a TypedDict bug surfaces |
+| PEP 696 TypeVar defaults (3.13) | dismissed | `grep -rn 'TypeVar.*default=' …` → 0 |
+| PEP 702 `@deprecated` (3.13) | dismissed | `grep -rn '@deprecated' …` → 0; no `DeprecationWarning` discipline yet |
+| `compression.zstd` (3.14) | dismissed | `grep -i 'zstd\|zstandard' pyproject.toml` → 0; no zstandard dep |
+| `@dataclass(slots=True, kw_only=True, frozen=True)` | surveyed — not a campaign | `grep -rn '@dataclass' …` → 85 declarations, only 1 sets `slots=True` (hottest: `core/models.py`, 9 dataclasses). Apply opportunistically when touching a file, not a sweep |
 
 ### Retired as false positives (calibration for future audits)
 
@@ -107,7 +94,7 @@ These survived the regex pass in the previous (pre-§a/§b/§c) audit before bei
 | `match` statement replacing isinstance chains | "~15–20 hits across 4 files" | 18 `elif isinstance` hits exist but every one is either 2-branch (debug.py keywords/list-vs-str, campminder/client.py dict-vs-list, phase2 dict-vs-(int,str)) or mixes value comparison with type checks (metrics_repository.py: `elif status_filter == "enrolled"` between two `isinstance(…, list)` branches). The prompts doc's bar is ">2 branches"; none qualify. **Lesson: don't count `elif isinstance` lines — count distinct >2-branch type-only chains.** |
 | Residual `Optional[X]` → `X \| None` | "3 hits in test_ranked_candidate_passthrough.py:65,67" | All 3 hits sit inside a docstring describing a refactor (`Optional[Tuple[int, float, str]]` is plain text, not an annotation). **Lesson: filter grep hits for `--include='*.py'` AND verify they're not inside `"""..."""`. Or add `--exclude-dir` for docstring-heavy files.** |
 | `typing.ReadOnly` for `geo_normalizer/normalizer.py:20` | "1 hit" | The previous audit listed normalizer.py as a `ReadOnly` candidate; the actual line is an unrelated import. No TypedDict in the file would gain from `ReadOnly`. |
-| "no SQL/HTML template builders that would benefit from PEP 750" (Not-applicable list) | (claimed clean) | 5–7 SQL f-strings exist in `scripts/setup/seed_from_prod.py`, `tests/test_seed_from_prod.py`, `api/services/metrics_sql_repository.py`. Moved to §b as **deferred** — t-strings are real candidates, just not actionable without library support. **Lesson: "no candidates" claims need a search expression; the audit had none for PEP 750.** |
+| "no SQL/HTML template builders that would benefit from PEP 750" (Not-applicable list) | (claimed clean) | 5–7 SQL f-strings exist in `scripts/setup/seed_from_prod.py`, `tests/test_seed_from_prod.py`, `api/services/metrics_sql_repository.py`. Moved to the **Deferred** section above — t-strings are real candidates, just not actionable without library support. **Lesson: "no candidates" claims need a search expression; the audit had none for PEP 750.** |
 
 ### Process lessons (carried into `modernization-prompts.md` Rules 1–3)
 
@@ -116,6 +103,7 @@ These survived the regex pass in the previous (pre-§a/§b/§c) audit before bei
 - **`elif isinstance` ≠ `match` candidate.** Most chains in this codebase are 2-branch, mixed-predicate, or `else`-terminated dictionary parsers. The `match` statement doesn't help any of them. Don't count regex hits; count >2-branch type-only chains.
 - **Three functions already use PEP 695** scoped-generic syntax (`api/services/breakdown_calculator.py`, `api/services/retention_service.py`). The previous audit didn't notice. The remaining single `T = TypeVar` is the last holdout, not the lonely sentinel the prior audit framed it as.
 - **`from __future__ import annotations` is NOT redundant in `if TYPE_CHECKING:` files (PEP 649 ≠ PEP 563).** Dropping it broke 43 files (#1578). Mechanism: under PEP 563 (the future import) `__annotations__` holds *strings* and `TYPE_CHECKING`-only names are never evaluated; under PEP 649 (3.14 default) *accessing* `__annotations__` **evaluates** bare annotations → `NameError` on names that only exist under `if TYPE_CHECKING:`. The triggers are everywhere annotations get read at runtime: `inspect.signature`, `unittest.mock` `Mock(spec=X)`, FastAPI endpoint/dependency introspection, dataclass field collection, `typing.get_type_hints()`. **Lesson for the next sweep: before deleting the import, exclude every file containing `if TYPE_CHECKING:` (any alias form too). The test suite only catches the subset that a `Mock(spec=)`/`inspect` path happens to exercise — the rest are latent landmines, so scope by the guard, not by the test failures.**
+- **Reconcile §c against `gh pr list` on every pickup (Part B).** Stale/blank statuses spawned two duplicate PR pairs this round — #1579/#1581 (`copy.replace`) and #1580/#1582 (`itertools.batched`), same rows opened across sessions. The worse of each was closed; #1579 + #1582 shipped. Mark a row `PR open #N` the moment its PR opens; `gh pr list` is ground truth, the §c table is a lossy cache.
 
 Survey scope: features added in Python 3.10–3.14. Re-run Part A after toolchain bumps to 3.15+.
 


### PR DESCRIPTION
## What

Migrates **§1 Python** in `docs/reference/modernization-backlog.md` from the in-progress §a/§b/§c audit format to the Go-style (§2) **closeout summary**, now that every row is decided.

| Row | Outcome |
|-----|---------|
| #1 PEP 695 scoped generic | ✓ shipped #1574 |
| #2 ruff `PLC0415` | ✓ shipped #1575 |
| #3 drop `__future__` annotations | ✓ shipped #1578 |
| #4 `copy.replace` | ✓ shipped #1579 |
| #5 `itertools.batched` | ✓ shipped #1582 |
| #6 `asyncio.gather` → `TaskGroup` | **skipped** |

## Closeout structure (mirrors §2 Go)

- **Shipped** — the 5 PRs above + the audit-count corrections found during execution (counts decay).
- **Deferred** — PEP 750 t-strings (no t-string-aware library downstream yet).
- **Skipped** — `asyncio.TaskGroup`: the 35 `gather` sites across **13 files** are all homogeneous positional-unpack fan-outs with no local `try/except`. Converting trades a clean one-liner for `create_task`/`.result()` boilerplate to harden an error path the global `@app.exception_handler(Exception)` already collapses to the same 500 (`ExceptionGroup` ⊆ `Exception`). Net: readability regression across ~34 sites > marginal sibling-cancellation gain. Full rationale recorded in the section.
- **Surveyed clean / dismissed** — every search expression retained so the next (3.15+) pass knows where this one stopped looking.
- **Retired false positives** + **Process lessons** preserved verbatim, plus one new lesson: reconcile §c against `gh pr list` (stale statuses spawned the duplicate-PR pairs this round).

Docs-only. markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal modernization tracking documentation to reflect Python modernization progress through 2026 and added process improvements for status tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->