### PR TITLE
refactor(frontend): copy-then-sort → Array.toSorted

### DIFF
--- a/docs/reference/modernization-backlog.md
+++ b/docs/reference/modernization-backlog.md
@@ -188,7 +188,7 @@ Survey scope: Go 1.18 through 1.26. Re-run Part A on a 1.27+ toolchain bump.
 | # | From (current idiom) | To (modern) | `from` since | `to` since | Impact | Where | Count |
 |---|---|---|---|---|---|---|---|
 | 1 | `tsconfig` `target`/`lib` = `ES2022` | `ES2024` (lib at minimum) | — | TS lib 5.4 / Node 21 rt | **prereq** (unblocks #2, #6) | `frontend/tsconfig.json` | 1 |
-| 2 | `[...arr].sort(cmp)` / `arr.slice().sort(cmp)` | `arr.toSorted(cmp)` | ES2015 | ES2023 | MEDIUM (cheapest mechanical) | ≈29 files (`utils/sessionUtils.ts` ×5, `utils/csvExportHelpers.ts`, `components/BunkCard.tsx`, `pages/.../StaffCabinAnalysisPage.tsx`, `utils/retentionTransforms.ts`, …) | ≈41 |
+| 2 | `[...arr].sort(cmp)` / `arr.slice().sort(cmp)` | `arr.toSorted(cmp)` | ES2015 | ES2023 | MEDIUM (cheapest mechanical) | 22 files / 30 true-win sites (`utils/sessionUtils.ts` ×5, `utils/csvExportHelpers.ts` ×2, `components/BunkCard.tsx` ×2, `pages/.../StaffCabinAnalysisPage.tsx` ×2, …). **Not** `retentionTransforms.ts` — that's a Set-spread (skipped, see Retired) | 52 raw → 30 wins (#1587) |
 | 3 | `arr[arr.length - 1]` | `arr.at(-1)` | ES5 | ES2022 (already in lib) | LOW–MED (readability) | 18 files (`hooks/useUndoStack.ts`, metrics chart utils, `components/BunkCard.tsx`, …) | 27 |
 | 4 | `<Context.Provider value=>` | `<Context value=>` | React <19 | React 19 | LOW–MED (cosmetic) | 9 files (`contexts/*`, `providers/BunkRequestProvider.tsx:126`, …) | 18 |
 | 5 | `catch (e) { throw new Error(msg) }` | `throw new Error(msg, { cause: e })` | ES2015 | ES2022 (already in lib) | **HIGH** (stack-trace fidelity) | catch-and-wrap subset of 93 `catch` blocks (`services/*`, hooks); only `useCamperMovement.ts` chains today | scope to catch-rethrow sites (NOT the 138 bare `throw`) |
@@ -224,6 +224,7 @@ Survey scope: Go 1.18 through 1.26. Re-run Part A on a 1.27+ toolchain bump.
 |---|---|---|
 | `[...].sort()` → `toSorted` | inflated count | `areas[area as BunkArea].sort(...)` (`BunkingBoardByArea.tsx:157`) is an **in-place** sort inside `forEach`; the `].sort(` matched an *index bracket*, not a spread. Converting changes behavior. **Lesson: confirm a `[...` or `.slice()` precedes `.sort(`.** |
 | `[...ids].sort().join(',')` | `utils/queryKeys.ts:384` | Inside a doc **comment**, not code. **Lesson: filter comment lines.** |
+| `[...set].sort()` / `[...map.entries()].sort()` → `toSorted` | 10 sites (`retentionTransforms.ts` ×2, `SessionBunkHeatmap.tsx` ×2, `useVelocityChartData.ts` ×2, `useStaffRetentionData.ts`, `PdfExport/familyRows.ts`, `PostValidationResultsModal.tsx`, `PdfExport/BunkPlanReport.tsx`) | When the spread *materializes* a `Set`/`Map`/iterator (which have no `.sort()`/`.toSorted()`), the spread is **load-bearing**, not a defensive copy of an array. `[...x].toSorted()` allocates a second throwaway array; `[...x].sort()` sorts the first in place. `toSorted` is only a win over a *named Array* (`[...arr].sort()` → `arr.toSorted()`). **Lesson (#1587): grep `[\.\.\.IDENT]` is not enough — confirm IDENT is an Array, not a Set/Map/iterator; also exclude array-literal-append spreads like `[...prev, n].sort()`.** |
 | `use()` "eliminates throw-on-missing-provider wrapper" | prior HIGH row | `use(Context)` doesn't auto-throw or remove the null-guard; it only allows conditional reads. **Lesson: verify the feature's real semantics, not its reputation.** |
 | inflated counts | "100+ useContext", "~1,800 as const", "240 type defs", "only 2 lazy" | actual 13 / 208 / ≈1,758 / ≈50-lazy. **Lesson: counts decay — re-grep every pass (carried from §1/§2).** |
 
@@ -231,10 +232,10 @@ Survey scope: Go 1.18 through 1.26. Re-run Part A on a 1.27+ toolchain bump.
 
 | # | Status | Row | Title |
 |---|---|---|---|
-| 1 | `next` | 3a#1 | `build(frontend): bump tsconfig target+lib to ES2024` (unblocks #3, #5) |
-| 2 | | 3a#3 | `refactor(frontend): arr[len-1] → arr.at(-1)` (27 sites, no prereq) |
-| 3 | | 3a#2 | `refactor(frontend): [...].sort() → toSorted` (≈41 sites; needs #1) |
-| 4 | | 3a#4 | `refactor(frontend): <Context.Provider> → <Context> shorthand` (18 sites) |
+| 1 | `✓ shipped #1585` | 3a#1 | `build(frontend): bump tsconfig target+lib to ES2024` (unblocks #3, #5) |
+| 2 | `✓ shipped #1586` | 3a#3 | `refactor(frontend): arr[len-1] → arr.at(-1)` (27 sites, no prereq) |
+| 3 | `PR open #1587` | 3a#2 | `refactor(frontend): [...].sort() → toSorted` (30 true-win sites / 22 files; Set/iterator spreads skipped — see Retired) |
+| 4 | `next` | 3a#4 | `refactor(frontend): <Context.Provider> → <Context> shorthand` (18 sites) |
 | 5 | | 3a#6 | `refactor(frontend): Object.groupBy for LockGroup membersByGroup` (2 sites; needs #1) |
 | 6 | | 3a#5 | `refactor(frontend): error cause chaining on catch-rethrow` (behavioral — TDD per Rule 3) |
 | 7 | | 3a#9 | `refactor(frontend): satisfies on config/route maps` (targeted) |

--- a/frontend/src/components/BunkCard.tsx
+++ b/frontend/src/components/BunkCard.tsx
@@ -170,7 +170,7 @@ function BunkCard({
   const calculateBunkStats = () => {
     // Quick path when dragging - just sort campers
     if (isDragging) {
-      const sorted = [...bunk.campers].sort((a, b) => a.age - b.age)
+      const sorted = bunk.campers.toSorted((a, b) => a.age - b.age)
       return {
         gradeDistribution: null,
         ageRange: null,
@@ -185,7 +185,7 @@ function BunkCard({
     const isOverCapacity = bunk.occupancy > defaultCapacity
 
     // Sort campers by age (youngest to oldest)
-    const sorted = [...bunk.campers].sort((a, b) => a.age - b.age)
+    const sorted = bunk.campers.toSorted((a, b) => a.age - b.age)
 
     // Calculate grade distribution
     const gradeCounts = new Map<number, number>()

--- a/frontend/src/components/CamperAlertSection.tsx
+++ b/frontend/src/components/CamperAlertSection.tsx
@@ -98,7 +98,7 @@ function rowColorClasses(severity: AlertSeverity): string {
 export function CamperAlertSection({ alerts, onRequestAlertClick }: CamperAlertSectionProps) {
   if (alerts.length === 0) return null
 
-  const sorted = [...alerts].sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity])
+  const sorted = alerts.toSorted((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity])
 
   return (
     <section aria-label="Alerts" className="space-y-1">

--- a/frontend/src/components/FloatingUnassignedBadge.tsx
+++ b/frontend/src/components/FloatingUnassignedBadge.tsx
@@ -39,7 +39,7 @@ export default function FloatingUnassignedBadge({
 
   // Sort campers by lastname (alpha), then firstname, then filter by search term
   const sortedCampers = useMemo(() => {
-    const sorted = [...campers].sort((a, b) => {
+    const sorted = campers.toSorted((a, b) => {
       const lastNameA = a.last_name ?? a.name.split(' ').pop() ?? ''
       const lastNameB = b.last_name ?? b.name.split(' ').pop() ?? ''
       const lastNameCompare = lastNameA.localeCompare(lastNameB)

--- a/frontend/src/components/LockGroupActionBar.tsx
+++ b/frontend/src/components/LockGroupActionBar.tsx
@@ -51,7 +51,7 @@ function generateDefaultGroupName(campers: Camper[]): string {
   if (lastNames.length === 1) return lastNames[0] ?? ''
 
   // Sort by length, take shortest two
-  const sorted = [...lastNames].sort((a, b) => a.length - b.length)
+  const sorted = lastNames.toSorted((a, b) => a.length - b.length)
   const shortest = sorted.slice(0, 2)
 
   // Sort alphabetically for consistent display

--- a/frontend/src/components/LockGroupPanel.tsx
+++ b/frontend/src/components/LockGroupPanel.tsx
@@ -371,7 +371,7 @@ function LockGroupPanel({
 
   // Sort groups by average age of members (ascending)
   const sortedGroups = useMemo(() => {
-    return [...groups].sort((a, b) => {
+    return groups.toSorted((a, b) => {
       const avgA = getGroupAverageAge(membersByGroup[a.id] ?? []) ?? Infinity
       const avgB = getGroupAverageAge(membersByGroup[b.id] ?? []) ?? Infinity
       return avgA - avgB

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -88,7 +88,7 @@ function parseSessionForSort(name: string): [number, string] {
  * Sort sessions chronologically: by start_date ASC, then by session number
  */
 function sortSessionsChronologically<T extends CampSessionsResponse>(sessions: T[]): T[] {
-  return [...sessions].sort((a, b) => {
+  return sessions.toSorted((a, b) => {
     // All sessions sorted chronologically: earliest first
     const dateCompare = new Date(a.start_date).getTime() - new Date(b.start_date).getTime()
     if (dateCompare !== 0) return dateCompare

--- a/frontend/src/components/UnassignedCampers.tsx
+++ b/frontend/src/components/UnassignedCampers.tsx
@@ -29,7 +29,7 @@ export default function UnassignedCampers({
 
   // Sort campers by age (youngest to oldest)
   const sortedCampers = useMemo(() => {
-    return [...campers].sort(
+    return campers.toSorted(
       (a, b) =>
         (getDisplayAgeForYear(a, viewingYear) ?? 0) - (getDisplayAgeForYear(b, viewingYear) ?? 0)
     )

--- a/frontend/src/components/admin/SheetsTab.tsx
+++ b/frontend/src/components/admin/SheetsTab.tsx
@@ -122,7 +122,7 @@ export function SheetsTab() {
   }
 
   // Combine all workbooks: globals first, then years descending
-  const sortedWorkbooks = [...(workbooks ?? [])].sort((a, b) => {
+  const sortedWorkbooks = (workbooks ?? []).toSorted((a, b) => {
     if (a.workbook_type === 'globals') return -1
     if (b.workbook_type === 'globals') return 1
     return b.year - a.year

--- a/frontend/src/components/bunkGraphStyles.ts
+++ b/frontend/src/components/bunkGraphStyles.ts
@@ -41,7 +41,7 @@ export function getNodeColor(degree: number): string {
 /** Map each grade present in a bunk to a color from the light/dark ramp.
  *  Younger grades get the lighter end of the scale. */
 export function getBunkGradeColors(grades: readonly number[]): Record<number, string> {
-  const sorted = [...grades].sort((a, b) => a - b)
+  const sorted = grades.toSorted((a, b) => a - b)
   const result: Record<number, string> = {}
   sorted.forEach((grade, index) => {
     if (index === 0) {

--- a/frontend/src/components/metrics/DemographicTable.tsx
+++ b/frontend/src/components/metrics/DemographicTable.tsx
@@ -44,7 +44,7 @@ export function DemographicTable({ title, data, onRowClick }: DemographicTablePr
     }
 
     // Apply sorting
-    result = [...result].sort((a, b) => {
+    result = result.toSorted((a, b) => {
       let comparison = 0
       switch (sortField) {
         case 'name':

--- a/frontend/src/components/metrics/geo/GeoComparisonDetailList.tsx
+++ b/frontend/src/components/metrics/geo/GeoComparisonDetailList.tsx
@@ -71,7 +71,7 @@ export function GeoComparisonDetailList({
   }
 
   // Sort by primary value descending
-  const sorted = [...merged].sort((a, b) => b.primaryValue - a.primaryValue)
+  const sorted = merged.toSorted((a, b) => b.primaryValue - a.primaryValue)
 
   return (
     <div className={`card-lodge overflow-hidden ${className}`}>

--- a/frontend/src/components/pipeline-debug/PipelineBatchList.tsx
+++ b/frontend/src/components/pipeline-debug/PipelineBatchList.tsx
@@ -138,7 +138,7 @@ export function PipelineBatchList({
 
     if (!sort) return filtered
     const { field, desc } = sort
-    return [...filtered].sort((a, b) => {
+    return filtered.toSorted((a, b) => {
       const cmp = compareValues(a[field], b[field])
       return desc ? -cmp : cmp
     })

--- a/frontend/src/hooks/useCamperEnrollment.ts
+++ b/frontend/src/hooks/useCamperEnrollment.ts
@@ -88,7 +88,7 @@ export function useCamperEnrollment(
       }
 
       // 3. Get primary attendee (prefer main session)
-      const sortedAttendees = [...attendees].sort((a, b) => {
+      const sortedAttendees = attendees.toSorted((a, b) => {
         const aType = (a.expand as { session?: { session_type?: string } }).session?.session_type
         const bType = (b.expand as { session?: { session_type?: string } }).session?.session_type
         return sortEnrolledFirst(a.status, aType, b.status, bType)

--- a/frontend/src/hooks/useParseAnalysis.ts
+++ b/frontend/src/hooks/useParseAnalysis.ts
@@ -157,7 +157,7 @@ export function useParseResultsBatch(originalRequestIds: string[]) {
   const { fetchWithAuth, isAuthenticated } = useApiWithAuth()
 
   // Create a stable key from sorted IDs to avoid unnecessary refetches
-  const idsKey = originalRequestIds.length > 0 ? originalRequestIds.slice().sort().join(',') : ''
+  const idsKey = originalRequestIds.length > 0 ? originalRequestIds.toSorted().join(',') : ''
 
   return useQuery({
     queryKey: ['parse-results-batch', idsKey],
@@ -175,7 +175,7 @@ export function useParseResultsBatchDual(originalRequestIds: string[]) {
   const { fetchWithAuth, isAuthenticated } = useApiWithAuth()
 
   // Create a stable key from sorted IDs to avoid unnecessary refetches
-  const idsKey = originalRequestIds.length > 0 ? originalRequestIds.slice().sort().join(',') : ''
+  const idsKey = originalRequestIds.length > 0 ? originalRequestIds.toSorted().join(',') : ''
 
   return useQuery({
     queryKey: ['parse-results-batch-dual', idsKey],

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -514,7 +514,7 @@ export default function ScenarioComparisonPage() {
     // Sort change lists alphabetically by camper name (last, then first) so both
     // sides of the comparison present a stable, scannable order.
     const sortByCamper = <T extends { camper: CamperAssignment }>(arr: T[]): T[] =>
-      arr.slice().sort((a, b) => compareCamperByName(a.camper, b.camper))
+      arr.toSorted((a, b) => compareCamperByName(a.camper, b.camper))
 
     return {
       moved: sortByCamper(moved),

--- a/frontend/src/pages/metrics/retention/StaffCabinAnalysisPage.tsx
+++ b/frontend/src/pages/metrics/retention/StaffCabinAnalysisPage.tsx
@@ -31,7 +31,7 @@ interface HoveredCell {
 }
 
 function sortRows(rows: StaffRetentionRow[], field: SortField, dir: SortDir): StaffRetentionRow[] {
-  return [...rows].sort((a, b) => {
+  return rows.toSorted((a, b) => {
     let cmp: number
     if (field === 'name') {
       cmp = a.name.localeCompare(b.name)
@@ -59,7 +59,7 @@ export default function StaffCabinAnalysisPage() {
   // Sort sessions chronologically
   const sessionDateLookup = useMemo(() => buildSessionDateLookup(campSessions), [campSessions])
   const sortedSessions = useMemo(
-    () => [...sessions].sort((a, b) => compareByDateThenName(a, b, sessionDateLookup)),
+    () => sessions.toSorted((a, b) => compareByDateThenName(a, b, sessionDateLookup)),
     [sessions, sessionDateLookup]
   )
 

--- a/frontend/src/utils/csvExportHelpers.ts
+++ b/frontend/src/utils/csvExportHelpers.ts
@@ -84,7 +84,7 @@ export function buildCamperRows(
     filtered = campers.filter((c) => c.gender === options.filterGender)
   }
 
-  const sorted = [...filtered].sort((a, b) =>
+  const sorted = filtered.toSorted((a, b) =>
     compareNames(a.first_name ?? '', a.last_name ?? '', b.first_name ?? '', b.last_name ?? '')
   )
 
@@ -126,7 +126,7 @@ export interface MovedEntry {
  * @returns     - Array of string[] where each inner array is one CSV data row
  */
 export function buildMovedRows(moves: MovedEntry[]): string[][] {
-  const sorted = [...moves].sort((a, b) =>
+  const sorted = moves.toSorted((a, b) =>
     compareNames(a.firstName, a.lastName, b.firstName, b.lastName)
   )
   return sorted.map((m) => [

--- a/frontend/src/utils/enrollmentFilter.ts
+++ b/frontend/src/utils/enrollmentFilter.ts
@@ -122,7 +122,7 @@ export function filterEnrollmentsByStatus<T>(
     return { enrolled: [], fallback: null }
   }
 
-  const sorted = [...items].sort(
+  const sorted = items.toSorted(
     (a, b) => getStatusPriority(getStatus(a)) - getStatusPriority(getStatus(b))
   )
 

--- a/frontend/src/utils/graphUtils.ts
+++ b/frontend/src/utils/graphUtils.ts
@@ -26,7 +26,7 @@ export function convexHull(
   }
 
   // Sort points by polar angle with respect to start
-  const sorted = points.slice().sort((a, b) => {
+  const sorted = points.toSorted((a, b) => {
     if (a === start) return -1
     if (b === start) return 1
 

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -262,7 +262,7 @@ export const queryKeys = {
     sessionCmId: number,
     year: number,
     personCmIds: number[]
-  ) => ['cohort-bunk-assignments', scenarioId, sessionCmId, year, [...personCmIds].sort()] as const,
+  ) => ['cohort-bunk-assignments', scenarioId, sessionCmId, year, personCmIds.toSorted()] as const,
 
   // Camper Request Summary (Tier 2 - user data, used in expanded row)
   camperRequestSummary: (requesterCmId: number, year: number) =>

--- a/frontend/src/utils/scenarioComparisonUtils.ts
+++ b/frontend/src/utils/scenarioComparisonUtils.ts
@@ -53,7 +53,7 @@ export function compareCamperByName(a: SortableCamper, b: SortableCamper): numbe
  * Returns a new array; does not mutate the input.
  */
 export function sortCampersByName<T extends SortableCamper>(campers: readonly T[]): T[] {
-  return campers.slice().sort(compareCamperByName)
+  return campers.toSorted(compareCamperByName)
 }
 
 /**

--- a/frontend/src/utils/sessionUtils.ts
+++ b/frontend/src/utils/sessionUtils.ts
@@ -102,7 +102,7 @@ export function parseSessionName(name: string): [number, string] {
 export function sortSessionsByDate<T extends { name: string; start_date: string }>(
   sessions: T[]
 ): T[] {
-  return [...sessions].sort((a, b) => {
+  return sessions.toSorted((a, b) => {
     // Primary: sort by start_date
     const dateCompare = a.start_date.localeCompare(b.start_date)
     if (dateCompare !== 0) return dateCompare
@@ -129,7 +129,7 @@ export function filterSelectableSessions<T extends { session_type?: string | nul
  * Works with API response types that have session_name field.
  */
 export function sortSessionDataByName<T extends { session_name: string }>(data: T[]): T[] {
-  return [...data].sort((a, b) => {
+  return data.toSorted((a, b) => {
     const [numA, suffixA] = parseSessionName(a.session_name)
     const [numB, suffixB] = parseSessionName(b.session_name)
     if (numA !== numB) return numA - numB
@@ -193,7 +193,7 @@ export function sortSessionDataByDate<T extends { session_name: string }>(
   data: T[],
   dateLookup: SessionDateLookup
 ): T[] {
-  return [...data].sort((a, b) => compareByDateThenName(a.session_name, b.session_name, dateLookup))
+  return data.toSorted((a, b) => compareByDateThenName(a.session_name, b.session_name, dateLookup))
 }
 
 /**
@@ -205,7 +205,7 @@ export function sortPriorSessionDataByDate<T extends { prior_session: string }>(
   data: T[],
   dateLookup: SessionDateLookup
 ): T[] {
-  return [...data].sort((a, b) =>
+  return data.toSorted((a, b) =>
     compareByDateThenName(a.prior_session, b.prior_session, dateLookup)
   )
 }
@@ -262,7 +262,7 @@ export function sortSessionDataByCampThenQuest<T extends { session_name: string 
   dateLookup: SessionDateLookup,
   typeLookup: SessionTypeLookup
 ): T[] {
-  return [...data].sort((a, b) =>
+  return data.toSorted((a, b) =>
     compareByDateCampThenQuest(a.session_name, b.session_name, dateLookup, typeLookup)
   )
 }


### PR DESCRIPTION
Backlog row **§3a#2** (`docs/reference/modernization-backlog.md` §3c row #3) — unblocked by the ES2024 `tsconfig` lib bump (#1585).

**What it does:** Replaces `[...arr].sort(cmp)` / `arr.slice().sort(cmp)` with `arr.toSorted(cmp)` across **22 files / 30 sites**. `toSorted` returns a new sorted array directly, dropping the visible defensive copy and stating non-mutating intent in one call.

**Why:** Readability + intent; removes a latent-bug class where deleting the `[...]` spread later would silently turn a copy-sort into an in-place mutation. Bonus: `readonly`-array sources (e.g. `grades: readonly number[]`) get cleaner — `toSorted` exists on `ReadonlyArray`, where `[...].sort()` was the workaround.

**Pure rewrite — result-equivalent.** Existing tests are the spec (Rule 3): `tsc --noEmit` clean, 4450 Vitest pass / 0 fail, `lefthook run pre-push` green.

**Codemod (scoped to true-win files only):**
```
perl -i -pe 's/\[\.\.\.([\w.]+)\]\.sort\(/${1}.toSorted(/g' <spread-files>
perl -i -pe 's/\.slice\(\)\.sort\(/.toSorted(/g'              <slice-files>
```
queryKeys.ts (real win, not the JSDoc comment) and SheetsTab.tsx (parenthesized `(workbooks ?? [])`) edited by hand.

**Skipped (Rule 1 — verified in context, not regex-matched):**
- **Set/Map/iterator spreads** (`[...set].sort()`, `[...map.entries()].sort()`) — 10 sites where the spread is load-bearing *materialization*, not a defensive copy; `[...x].toSorted()` would double-allocate a throwaway. (retentionTransforms, SessionBunkHeatmap, useVelocityChartData, useStaffRetentionData, familyRows, PostValidationResultsModal, BunkPlanReport)
- **queryKeys.ts** `[...ids].sort().join(',')` — the already-retired JSDoc-comment false positive.
- **`*.test.*`** files — per the Python `tests/**` exclusion precedent (#1575).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal array sorting implementation across 20+ components and utilities to use modern sorting methods.
  * Maintained all existing sort behaviors and ordering logic throughout the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->