### PR TITLE
refactor(frontend): adopt React 19 <Context> provider shorthand

### DIFF
--- a/frontend/src/components/ScenarioManagementModal.test.tsx
+++ b/frontend/src/components/ScenarioManagementModal.test.tsx
@@ -66,7 +66,7 @@ function renderModal(ctx: ScenarioContextType) {
   })
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={qc}>
-      <ScenarioContext.Provider value={ctx}>{children}</ScenarioContext.Provider>
+      <ScenarioContext value={ctx}>{children}</ScenarioContext>
       <Toaster />
     </QueryClientProvider>
   )

--- a/frontend/src/components/admin/PopulateFromPreviousYear.test.tsx
+++ b/frontend/src/components/admin/PopulateFromPreviousYear.test.tsx
@@ -55,7 +55,7 @@ function createWrapper(year = 2026) {
 
   return ({ children }: { children: React.ReactNode }) => (
     <QueryClientProvider client={queryClient}>
-      <CurrentYearContext.Provider value={mockYearContext}>{children}</CurrentYearContext.Provider>
+      <CurrentYearContext value={mockYearContext}>{children}</CurrentYearContext>
     </QueryClientProvider>
   )
 }

--- a/frontend/src/components/admin/RegistrationDatesConfig.test.tsx
+++ b/frontend/src/components/admin/RegistrationDatesConfig.test.tsx
@@ -48,7 +48,7 @@ const createWrapper = (year = 2026) => {
 
   return ({ children }: { children: React.ReactNode }) => (
     <QueryClientProvider client={queryClient}>
-      <CurrentYearContext.Provider value={mockYearContext}>{children}</CurrentYearContext.Provider>
+      <CurrentYearContext value={mockYearContext}>{children}</CurrentYearContext>
     </QueryClientProvider>
   )
 }

--- a/frontend/src/components/metrics/MetricsTypeTabs.test.tsx
+++ b/frontend/src/components/metrics/MetricsTypeTabs.test.tsx
@@ -47,11 +47,11 @@ const renderWithRouter = (initialPath: string) => {
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={[initialPath]}>
-        <CurrentYearContext.Provider value={mockYearContext}>
+        <CurrentYearContext value={mockYearContext}>
           <MetricsSessionProvider>
             <MetricsTypeTabs />
           </MetricsSessionProvider>
-        </CurrentYearContext.Provider>
+        </CurrentYearContext>
       </MemoryRouter>
     </QueryClientProvider>
   )

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -231,7 +231,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     checkAuth,
   }
 
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+  return <AuthContext value={value}>{children}</AuthContext>
 }
 
 // eslint-disable-next-line react-refresh/only-export-components

--- a/frontend/src/contexts/CurrentYearContext.tsx
+++ b/frontend/src/contexts/CurrentYearContext.tsx
@@ -114,7 +114,7 @@ export function CurrentYearProvider({ children }: { children: ReactNode }) {
   )
 
   return (
-    <CurrentYearContext.Provider
+    <CurrentYearContext
       value={{
         currentYear,
         setCurrentYear,
@@ -124,6 +124,6 @@ export function CurrentYearProvider({ children }: { children: ReactNode }) {
       }}
     >
       {children}
-    </CurrentYearContext.Provider>
+    </CurrentYearContext>
   )
 }

--- a/frontend/src/contexts/LockGroupContext.tsx
+++ b/frontend/src/contexts/LockGroupContext.tsx
@@ -405,7 +405,7 @@ export function LockGroupProvider({ children }: LockGroupProviderProps) {
   }
 
   return (
-    <LockGroupContext.Provider value={value}>
+    <LockGroupContext value={value}>
       {children}
       <GroupConflictDialog
         isOpen={conflictConfirm.dialogState.isOpen}
@@ -415,7 +415,7 @@ export function LockGroupProvider({ children }: LockGroupProviderProps) {
         onConfirm={conflictConfirm.dialogState.onConfirm}
         onCancel={conflictConfirm.dialogState.onCancel}
       />
-    </LockGroupContext.Provider>
+    </LockGroupContext>
   )
 }
 

--- a/frontend/src/contexts/MetricsSessionContext.test.tsx
+++ b/frontend/src/contexts/MetricsSessionContext.test.tsx
@@ -124,9 +124,9 @@ function createWrapper(initialPath: string = '/analytics/registration') {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={[initialPath]}>
-          <CurrentYearContext.Provider value={mockYearContext}>
+          <CurrentYearContext value={mockYearContext}>
             <MetricsSessionProvider>{children}</MetricsSessionProvider>
-          </CurrentYearContext.Provider>
+          </CurrentYearContext>
         </MemoryRouter>
       </QueryClientProvider>
     )
@@ -308,13 +308,13 @@ describe('MetricsSessionContext', () => {
       render(
         <QueryClientProvider client={queryClient}>
           <MemoryRouter initialEntries={['/analytics/registration?year=2025']}>
-            <CurrentYearContext.Provider value={mockYearContext}>
+            <CurrentYearContext value={mockYearContext}>
               <MetricsSessionProvider>
                 <TestSetter sessionCmId={1001} />
                 <YearParamViewer />
                 <UrlParamViewer />
               </MetricsSessionProvider>
-            </CurrentYearContext.Provider>
+            </CurrentYearContext>
           </MemoryRouter>
         </QueryClientProvider>
       )

--- a/frontend/src/contexts/MetricsSessionContext.tsx
+++ b/frontend/src/contexts/MetricsSessionContext.tsx
@@ -286,5 +286,5 @@ export function MetricsSessionProvider({ children }: { children: ReactNode }) {
     ]
   )
 
-  return <MetricsSessionContext.Provider value={value}>{children}</MetricsSessionContext.Provider>
+  return <MetricsSessionContext value={value}>{children}</MetricsSessionContext>
 }

--- a/frontend/src/contexts/ProgramContext.tsx
+++ b/frontend/src/contexts/ProgramContext.tsx
@@ -39,9 +39,7 @@ export function ProgramProvider({ children }: { children: ReactNode }) {
   }, [])
 
   return (
-    <ProgramContext.Provider value={{ currentProgram, setProgram, clearProgram }}>
-      {children}
-    </ProgramContext.Provider>
+    <ProgramContext value={{ currentProgram, setProgram, clearProgram }}>{children}</ProgramContext>
   )
 }
 

--- a/frontend/src/contexts/ScenarioContext.tsx
+++ b/frontend/src/contexts/ScenarioContext.tsx
@@ -243,5 +243,5 @@ export const ScenarioProvider: FC<ScenarioProviderProps> = ({ children }) => {
     clearScenario,
   }
 
-  return <ScenarioContext.Provider value={value}>{children}</ScenarioContext.Provider>
+  return <ScenarioContext value={value}>{children}</ScenarioContext>
 }

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -115,7 +115,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   }, [])
 
   return (
-    <ThemeContext.Provider
+    <ThemeContext
       value={{
         theme,
         resolvedTheme,
@@ -125,6 +125,6 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       }}
     >
       {children}
-    </ThemeContext.Provider>
+    </ThemeContext>
   )
 }

--- a/frontend/src/hooks/useRunSweep.test.tsx
+++ b/frontend/src/hooks/useRunSweep.test.tsx
@@ -17,9 +17,9 @@ const wrapper = ({ children }: { children: ReactNode }) => {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   const authCtx = createMockAuthContext({ user: createMockUser() })
   return (
-    <AuthContext.Provider value={authCtx}>
+    <AuthContext value={authCtx}>
       <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    </AuthContext.Provider>
+    </AuthContext>
   )
 }
 

--- a/frontend/src/pages/metrics/MetricsLayout.test.tsx
+++ b/frontend/src/pages/metrics/MetricsLayout.test.tsx
@@ -57,7 +57,7 @@ const renderWithRouter = (initialPath: string, childText = 'Child Content') => {
       { value: authCtx },
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={[initialPath]}>
-          <CurrentYearContext.Provider value={mockYearContext}>
+          <CurrentYearContext value={mockYearContext}>
             <Routes>
               <Route path="/analytics/*" element={<MetricsLayout />}>
                 <Route path="registration/*" element={<TestChild text={childText} />} />
@@ -67,7 +67,7 @@ const renderWithRouter = (initialPath: string, childText = 'Child Content') => {
                 <Route path="trends" element={<TestChild text="Trends" />} />
               </Route>
             </Routes>
-          </CurrentYearContext.Provider>
+          </CurrentYearContext>
         </MemoryRouter>
       </QueryClientProvider>
     )

--- a/frontend/src/pages/metrics/retention/BunkRetentionPage.test.tsx
+++ b/frontend/src/pages/metrics/retention/BunkRetentionPage.test.tsx
@@ -48,11 +48,11 @@ function renderPage() {
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={['/analytics/retention/bunks']}>
-        <CurrentYearContext.Provider value={mockYearContext}>
+        <CurrentYearContext value={mockYearContext}>
           <Routes>
             <Route path="/analytics/retention/bunks" element={<BunkRetentionPage />} />
           </Routes>
-        </CurrentYearContext.Provider>
+        </CurrentYearContext>
       </MemoryRouter>
     </QueryClientProvider>
   )

--- a/frontend/src/pages/metrics/retention/StaffCabinAnalysisPage.test.tsx
+++ b/frontend/src/pages/metrics/retention/StaffCabinAnalysisPage.test.tsx
@@ -47,11 +47,11 @@ function renderPage() {
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={['/analytics/retention/staff']}>
-        <CurrentYearContext.Provider value={mockYearContext}>
+        <CurrentYearContext value={mockYearContext}>
           <Routes>
             <Route path="/analytics/retention/staff" element={<StaffCabinAnalysisPage />} />
           </Routes>
-        </CurrentYearContext.Provider>
+        </CurrentYearContext>
       </MemoryRouter>
     </QueryClientProvider>
   )

--- a/frontend/src/providers/BunkRequestProvider.tsx
+++ b/frontend/src/providers/BunkRequestProvider.tsx
@@ -123,5 +123,5 @@ export function BunkRequestProvider({ sessionCmId, children }: BunkRequestProvid
     ]
   )
 
-  return <BunkRequestContext.Provider value={value}>{children}</BunkRequestContext.Provider>
+  return <BunkRequestContext value={value}>{children}</BunkRequestContext>
 }

--- a/frontend/src/providers/CamperHistoryProvider.tsx
+++ b/frontend/src/providers/CamperHistoryProvider.tsx
@@ -148,5 +148,5 @@ export function CamperHistoryProvider({
     error: error,
   }
 
-  return <CamperHistoryContext.Provider value={value}>{children}</CamperHistoryContext.Provider>
+  return <CamperHistoryContext value={value}>{children}</CamperHistoryContext>
 }


### PR DESCRIPTION
Backlog row **§3a#4** (`docs/reference/modernization-backlog.md` §3c row #4).

**What it does:** Renders context objects directly as their provider — `<ThemeContext value={v}>…</ThemeContext>` instead of `<ThemeContext.Provider value={v}>…</ThemeContext.Provider>`. **19 open + 19 close** tags across **18 files**.

**Eligibility (Rule 1):** all **9 distinct contexts** are React `createContext()` objects (cross-referenced), so every site is eligible for the React 19 shorthand. No third-party providers in the match set.

**Why:** React 19 idiom (the point of §3); `.Provider` is the legacy form React has signaled for deprecation. Pure rewrite — `value` prop unchanged, no behavioral change.

**Scope — includes test files:** unlike the toSorted row (tests excluded to dodge Set-spread traps), this conversion is zero-risk and mechanical, so the 9 `*.test.tsx` wrapper sites are converted too — a **complete** migration leaving no `.Provider` stragglers for the next audit.

**Codemod** (handles open + close; `\b` avoids `.ProviderFoo`):
```
perl -i -pe 's{<(/?)([A-Z][A-Za-z0-9_]*)\.Provider\b}{<$1$2}g' <files>
```

**Verified:** `tsc --noEmit` clean (React 19 + `@types/react` 19 accept `<Ctx>` as a provider — the real gate) · 4450 Vitest pass / 0 fail · `lefthook run pre-push` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal React context implementation patterns across multiple context providers and test files for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->