### PR TITLE
refactor(frontend): Object.groupBy for LockGroup membersByGroup

### DIFF
--- a/frontend/src/components/LockGroupPanel.tsx
+++ b/frontend/src/components/LockGroupPanel.tsx
@@ -335,17 +335,10 @@ function LockGroupPanel({
 
   // Group members by group ID. Memoized so its object identity is stable
   // across renders — sortedGroups and filteredGroups depend on it.
-  const membersByGroup = useMemo<Record<string, ExpandedMember[]>>(() => {
-    return allMembers.reduce<Record<string, ExpandedMember[]>>(
-      (acc: Record<string, ExpandedMember[]>, member: ExpandedMember) => {
-        const groupId = member.group
-        acc[groupId] ??= []
-        acc[groupId].push(member)
-        return acc
-      },
-      {}
-    )
-  }, [allMembers])
+  const membersByGroup = useMemo(
+    () => Object.groupBy(allMembers, (member) => member.group),
+    [allMembers]
+  )
 
   // Helper to get age from member (year-aware for historical viewing)
   const getMemberAge = useCallback(

--- a/frontend/src/components/LockGroupsHub.tsx
+++ b/frontend/src/components/LockGroupsHub.tsx
@@ -27,7 +27,7 @@ type BunkArea = 'all' | 'boys' | 'girls' | 'all-gender'
 
 interface LockGroupsHubProps {
   groups: LockedGroupsResponse[]
-  membersByGroup: Record<string, ExpandedMember[]>
+  membersByGroup: Partial<Record<string, ExpandedMember[]>>
   pendingCampers: Camper[]
   selectedArea: BunkArea
   campers: Camper[] // All campers - used for looking up gender/session data

--- a/frontend/src/contexts/LockGroupContext.tsx
+++ b/frontend/src/contexts/LockGroupContext.tsx
@@ -49,7 +49,7 @@ interface LockGroupContextValue {
   // Lock groups data
   groups: LockedGroupsResponse[]
   groupsLoading: boolean
-  membersByGroup: Record<string, ExpandedMember[]>
+  membersByGroup: Partial<Record<string, ExpandedMember[]>>
   membersLoading: boolean
 
   // Helper functions
@@ -161,17 +161,10 @@ export function LockGroupProvider({ children }: LockGroupProviderProps) {
   })
 
   // Group members by group ID (using relation field 'group')
-  const membersByGroup = useMemo(() => {
-    return allMembers.reduce<Record<string, ExpandedMember[]>>(
-      (acc: Record<string, ExpandedMember[]>, member: ExpandedMember) => {
-        const groupId = member.group
-        acc[groupId] ??= []
-        acc[groupId].push(member)
-        return acc
-      },
-      {}
-    )
-  }, [allMembers])
+  const membersByGroup = useMemo(
+    () => Object.groupBy(allMembers, (member) => member.group),
+    [allMembers]
+  )
 
   // Create a map of camper person_id (CM ID) to group for quick lookups
   const camperToGroup = useMemo(() => {


### PR DESCRIPTION
Backlog row **§3a#6** (`docs/reference/modernization-backlog.md` §3c row #5) — unblocked by the ES2024 `tsconfig` lib (#1585).

**What it does:** Replaces two byte-identical `allMembers.reduce<Record<…>>(…)` group-by blocks with `Object.groupBy(allMembers, (m) => m.group)` in `LockGroupContext` + `LockGroupPanel` (16 lines → 2). Runtime-equivalent grouping.

**The type change is a correctness win, not just churn:** `Object.groupBy` returns `Partial<Record<…>>`. The manual reduce only populated keys it encountered, so missing keys were *already* `undefined` at runtime — the declared total `Record` was a **type lie**. Flipped the three declared types (context value field, `LockGroupPanel` memo generic, `LockGroupsHub` prop) to `Partial<Record<…>>`. Every consumer already guards with `membersByGroup[id] ?? []`, so `tsc` passes with **zero consumer changes**.

**Scope note (Rule 1):** the only 2 genuine groupBy candidates — the other nearby `.reduce` calls are flat param-maps (`{g0:id,…}`) or sum accumulators. `BunkingBoardByArea`'s `membersByGroup` is a separate `Map`, untouched.

**Verified:** `tsc --noEmit` clean (confirms `Object.groupBy` typed + all consumers tolerate `Partial`) · 4450 Vitest pass / 0 fail · `lefthook run pre-push` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal member grouping logic and type definitions for better code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1589?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->