### PR TITLE
refactor(frontend): satisfies on conforming object literals

### DIFF
--- a/frontend/src/components/CamperCard.tsx
+++ b/frontend/src/components/CamperCard.tsx
@@ -205,7 +205,7 @@ function CamperCard({
             ...(lockState === 'pending'
               ? { animationDelay: `${getPendingAnimationDelay(camper.id)}ms` }
               : {}),
-          } as CSSProperties
+          } satisfies CSSProperties
         }
         className={clsx(
           'relative overflow-hidden rounded-xl border-2 p-2.5 transition-all select-none',

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -567,7 +567,7 @@ export default function SessionList() {
           hasAgSessions: agSessions.length > 0,
           agSessionCount: agSessions.length,
           pendingReviewCount: pendingReviewRequests.totalItems,
-        } as SessionStatistics
+        } satisfies SessionStatistics
       },
       enabled: !!user && sessions.length > 0,
     })),

--- a/frontend/src/components/admin/SyncTab.tsx
+++ b/frontend/src/components/admin/SyncTab.tsx
@@ -166,7 +166,7 @@ export function SyncTab() {
     const status =
       statusValue && typeof statusValue === 'object' && 'status' in statusValue
         ? statusValue
-        : ({ status: 'idle' } as SyncStatus)
+        : ({ status: 'idle' } satisfies SyncStatus)
     const Icon = syncType.icon
     const isRunning = status.status === 'running'
     const isPending = status.status === 'pending'
@@ -781,7 +781,7 @@ export function SyncTab() {
               const status =
                 statusValue && typeof statusValue === 'object' && 'status' in statusValue
                   ? statusValue
-                  : ({ status: 'idle' } as SyncStatus)
+                  : ({ status: 'idle' } satisfies SyncStatus)
               const Icon = syncType.icon
               const isRunning = status.status === 'running'
               const isPending = status.status === 'pending'

--- a/frontend/src/hooks/useCamperEnrollment.ts
+++ b/frontend/src/hooks/useCamperEnrollment.ts
@@ -127,7 +127,7 @@ export function useCamperEnrollment(
         camper: {
           ...camper,
           birthdate: person.birthdate,
-        } as Camper & { birthdate?: string },
+        } satisfies Camper & { birthdate?: string },
         person,
       }
     },


### PR DESCRIPTION
Backlog row **§3a#9** (`docs/reference/modernization-backlog.md` §3c row #7).

**What it does:** Flips 5 `<literal> as T` casts to `<literal> satisfies T` where the literal fully conforms — `satisfies` validates conformance *without* widening, catching excess/missing/typo'd properties that `as` silently allows. Zero runtime change (both erase at compile).

| Site | Flip |
|---|---|
| `SessionList.tsx:570` | `} satisfies SessionStatistics` |
| `CamperCard.tsx:208` | `} satisfies CSSProperties` |
| `useCamperEnrollment.ts:130` | `} satisfies Camper & { birthdate?: string }` |
| `SyncTab.tsx` ×2 | `{ status: 'idle' } satisfies SyncStatus` |

**Method (Rule 3):** flipped each candidate, kept only the ones `tsc` accepts. The type-checker *is* the spec here.

**Deferred — two load-bearing casts → #1590:** `useSiblings.ts` `as SiblingWithEnrollment` and `camper/useCamperEnrollment.ts` `as Camper` could not flip — they mask real `exactOptionalPropertyTypes` mismatches (`number | undefined` vs `number`; possibly-`undefined` session + enum/predicate tangle). Left as `as`, tracked in #1590 (fix the type, then convert).

**NOT flipped (Rule 1 traps):**
- **Array/tuple literal casts** (`[lat,lng] as LatLng` ×6, `['gross','net','delta'] as VelocityViewMode[]`) — array literals widen to `number[]`/`string[]`, *not* assignable to a tuple/string-literal-union, so `satisfies` rejects them; the `as` does genuine narrowing.
- **Empty-seed casts** (`{} as Record<…>`, `[] as T[]`) — literal doesn't conform; `as` asserts a future-populated shape.
- **Index/element-access casts** (`x[0] as T`, `obj[k] as T`) — coercion, not literal conformance.

**Verified:** `tsc --noEmit` clean · 4450 Vitest pass / 0 fail · `lefthook run pre-push` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced TypeScript type checking across components for improved code reliability and type safety.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->