### PR TITLE
refactor(frontend): seal readonly leaks + exactOptional casts (Group 70: #1593, #1594, #1590)

### DIFF
--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -96,8 +96,8 @@ interface BunkGraphMetrics {
 interface BunkGraphData {
   bunk_cm_id: number
   bunk_name: string
-  nodes: GraphNode[]
-  edges: GraphEdge[]
+  readonly nodes: readonly GraphNode[]
+  readonly edges: readonly GraphEdge[]
   metrics: BunkGraphMetrics
   health_score: number
 }

--- a/frontend/src/components/SocialNetworkGraph.tsx
+++ b/frontend/src/components/SocialNetworkGraph.tsx
@@ -210,12 +210,12 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
     // node[?cross_scope] for nodes), and the ghost campers stay clickable
     // so users can open the detail panel for potential connections.
     const { parentNodes, nodes, edges } = createGraphElements(
-      graphData.nodes as Parameters<typeof createGraphElements>[0],
-      graphData.edges as Parameters<typeof createGraphElements>[1],
+      graphData.nodes,
+      graphData.edges,
       bunksData,
       SHOW_EDGES,
-      graphData.cross_scope_edges as Parameters<typeof createGraphElements>[4],
-      graphData.cross_scope_nodes as Parameters<typeof createGraphElements>[5]
+      graphData.cross_scope_edges,
+      graphData.cross_scope_nodes
     )
 
     // Single-shot batched add. The previous RAF-chunked staging approach added

--- a/frontend/src/components/graph/cytoscapeStyles.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.ts
@@ -347,12 +347,12 @@ export interface GraphElements {
  * combination still renders as a multi-curve.
  */
 export function createGraphElements(
-  nodeData: GraphNodeData[],
-  edgeData: GraphEdgeData[],
+  nodeData: readonly GraphNodeData[],
+  edgeData: readonly GraphEdgeData[],
   bunksData: Record<number, string> | null | undefined,
   showEdges: ShowEdgesSettings,
-  crossScopeEdges?: CrossScopeEdgeData[],
-  crossScopeNodes?: GraphNodeData[]
+  crossScopeEdges?: readonly CrossScopeEdgeData[],
+  crossScopeNodes?: readonly GraphNodeData[]
 ): GraphElements {
   // Group nodes by bunk. In-scope bunks always exist, even when a cross-scope
   // ghost camper happens to share a bunk_cm_id with an in-scope camper (rare

--- a/frontend/src/hooks/camper/types.ts
+++ b/frontend/src/hooks/camper/types.ts
@@ -2,7 +2,7 @@
  * Shared types for camper hooks
  */
 
-import type { PersonsResponse } from '../../types/pocketbase-types'
+import type { PersonsResponse, CampSessionsSessionTypeOptions } from '../../types/pocketbase-types'
 
 // Historical camp record
 export interface HistoricalRecord {
@@ -44,7 +44,7 @@ export interface SiblingWithEnrollment extends PersonsResponse {
     id: string
     cm_id: number
     name: string
-    session_type: string
+    session_type: CampSessionsSessionTypeOptions
     start_date?: string
     end_date?: string
   }

--- a/frontend/src/hooks/camper/useCamperEnrollment.ts
+++ b/frontend/src/hooks/camper/useCamperEnrollment.ts
@@ -135,7 +135,7 @@ export function useCamperEnrollment(
           grade: expandedPerson.grade,
           gender,
           session_cm_id: expandedSession?.cm_id ?? 0,
-          assigned_bunk_cm_id: assignedBunk?.cm_id,
+          ...(assignedBunk?.cm_id !== undefined && { assigned_bunk_cm_id: assignedBunk.cm_id }),
           assigned_bunk: assignedBunk?.id ?? '',
           person_cm_id: expandedPerson.cm_id,
           created: attendee.created || new Date().toISOString(),
@@ -153,10 +153,10 @@ export function useCamperEnrollment(
           gender_pronoun_write_in: expandedPerson.gender_pronoun_write_in,
           household_id: expandedPerson.household_id,
           expand: {
-            session: expandedSession,
-            assigned_bunk: assignedBunk,
+            session: expandedSession ?? null,
+            assigned_bunk: assignedBunk ?? null,
           },
-        } as Camper
+        } satisfies Camper
       })
 
       // Sort: enrolled first, then by session type priority

--- a/frontend/src/hooks/camper/useCamperEnrollment.ts
+++ b/frontend/src/hooks/camper/useCamperEnrollment.ts
@@ -161,8 +161,8 @@ export function useCamperEnrollment(
 
       // Sort: enrolled first, then by session type priority
       allCampers.sort((a, b) => {
-        const aType = (a.expand?.session as { session_type?: string } | undefined)?.session_type
-        const bType = (b.expand?.session as { session_type?: string } | undefined)?.session_type
+        const aType = (a.expand.session as { session_type?: string } | undefined)?.session_type
+        const bType = (b.expand.session as { session_type?: string } | undefined)?.session_type
         return sortEnrolledFirst(a.attendee_status, aType, b.attendee_status, bType)
       })
 

--- a/frontend/src/hooks/camper/useSiblings.ts
+++ b/frontend/src/hooks/camper/useSiblings.ts
@@ -109,19 +109,19 @@ export function useSiblings(
 
             return {
               ...siblingPerson,
-              session: session
-                ? {
-                    id: session.id,
-                    cm_id: session.cm_id,
-                    name: session.name,
-                    session_type: session.session_type,
-                    start_date: session.start_date,
-                    end_date: session.end_date,
-                  }
-                : undefined,
+              ...(session && {
+                session: {
+                  id: session.id,
+                  cm_id: session.cm_id,
+                  name: session.name,
+                  session_type: session.session_type,
+                  start_date: session.start_date,
+                  end_date: session.end_date,
+                },
+              }),
               bunkName,
               attendeeStatus: primaryAttendee.status,
-            } as SiblingWithEnrollment
+            } satisfies SiblingWithEnrollment
           } catch (err) {
             console.error(`Error checking enrollment for sibling ${siblingPerson.cm_id}:`, err)
             return null
@@ -129,8 +129,11 @@ export function useSiblings(
         })
       )
 
-      // Filter out nulls (siblings not enrolled)
-      return siblingsWithEnrollment.filter((s): s is SiblingWithEnrollment => s !== null)
+      // Filter out nulls (siblings not enrolled). TS infers the narrowing from
+      // `s !== null` (inferred type predicate), so no explicit annotation is
+      // needed — and the precise literal type is a subtype of
+      // SiblingWithEnrollment, which the hook's return boundary requires.
+      return siblingsWithEnrollment.filter((s) => s !== null)
     },
     enabled: !!(householdId && householdId > 0),
     staleTime: 0, // Always fetch fresh data

--- a/frontend/src/types/graph.ts
+++ b/frontend/src/types/graph.ts
@@ -59,7 +59,7 @@ export interface GraphMetrics {
 export interface CrossScopeEdge {
   readonly source: number
   readonly target: number
-  readonly edge_type: string
+  readonly edge_type: 'request'
   readonly weight: number
   readonly request_type: string | null
   readonly confidence: number | null


### PR DESCRIPTION
Closes #1593, closes #1594, closes #1590.

Group 70 — type-safety follow-ups deferred out of the §3 frontend-modernization PRs (#1585–#1592). Pure type-only hardening; no runtime behavior change. Each fix makes a type honest so a load-bearing cast can be deleted or flipped to `satisfies`.

## Changes
- **#1593** — widen `createGraphElements`'s four array params to `readonly` + narrow graph.ts `CrossScopeEdge.edge_type` to `'request'` (matches the generated type; the API only emits `'request'` cross-scope edges). All four `as Parameters<…>[N]` casts at `SocialNetworkGraph.tsx` are deleted.
- **#1594** — seal the local `BunkGraphData.nodes`/`.edges` `readonly`. The `as unknown as BunkGraphData` stays (the cached `GraphData` structurally diverges — `bunk_cm_id`/`bunk_name`/`metrics`/`health_score`), but downstream read-only protection is restored.
- **#1590** — make two literals honest under `exactOptionalPropertyTypes`:
  - `useCamperEnrollment`: flipping `as Camper` → `satisfies Camper` surfaced two masked violations — `assigned_bunk_cm_id` (`number | undefined` into optional `?: number`, now conditional-spread) and `expand.session`/`.assigned_bunk` (explicit `undefined` into `?: … | null`, now `?? null`). Also tightened a now-redundant `expand?.` optional chain.
  - `useSiblings`: `as SiblingWithEnrollment` → `satisfies`; conditional-spread the optional `session` key; typed `session_type` as the `CampSessionsSessionTypeOptions` enum; dropped the manual `s is SiblingWithEnrollment` predicate in favor of TS 6's inferred narrowing (the precise literal type is a subtype, satisfying the hook's return boundary).

## Test Plan
- [x] `npm run type-check` passes (both `tsconfig.json` + `tsconfig.node.json`) — each cast was verified load-bearing (removed → tsc fails) before its supporting type change.
- [x] `npm run lint` — 0 errors, no new warnings (the two introduced by the type-honesty change are fixed).
- [x] `npx vitest run` — 4450 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type safety by strengthening immutability constraints on data structures used for graph rendering and camper enrollment information.
  * Enhanced type accuracy for cross-scope edge data and session information to better align with backend contracts.
  * Simplified null-checking logic in enrollment and sibling data processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1597?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->