### PR TITLE
refactor(frontend): seal readonly leaks in app-types consumers (#1596)

### DIFF
--- a/frontend/src/components/AllCampersView.tsx
+++ b/frontend/src/components/AllCampersView.tsx
@@ -532,7 +532,7 @@ export default function AllCampersView() {
             {filteredCampers.length > 0 && (
               <button
                 onClick={() => {
-                  const rows = buildCamperRows(filteredCampers as Camper[], allSessions)
+                  const rows = buildCamperRows(filteredCampers, allSessions)
                   const csv = buildCsvContent([...CAMPER_CSV_HEADERS], rows)
                   const genderPart = filterSexCsvSegment(filterSex)
                   downloadCsv(csv, `all-campers${genderPart}-${todayIso()}.csv`)

--- a/frontend/src/utils/mergeMultiSessionCampers.test.ts
+++ b/frontend/src/utils/mergeMultiSessionCampers.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for mergeMultiSessionCampers + the readonly contract on its output types.
+ *
+ * TDD (#1596): the `@ts-expect-error` assertions in "readonly contract" are the
+ * spec — they only type-check once `AdditionalSession`'s fields and
+ * `MergedCamper.additionalSessions` are `readonly`, matching the `readonly`
+ * `Camper` that `MergedCamper` extends. Verified via `tsc --noEmit`; before the
+ * change the directives are unused → TS2578.
+ */
+import { describe, it, expect } from 'vitest'
+import { mergeMultiSessionCampers } from './mergeMultiSessionCampers'
+import type { AdditionalSession, MergedCamper } from './mergeMultiSessionCampers'
+import type { Camper, Session } from '../types/app-types'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeCamper(overrides: Record<string, unknown> = {}): Camper {
+  return {
+    id: 'person-1:session-1',
+    name: 'Emma Johnson',
+    first_name: 'Emma',
+    last_name: 'Johnson',
+    age: 12.5,
+    grade: 7,
+    gender: 'F',
+    session_cm_id: 1000001,
+    person_cm_id: 2000001,
+    assigned_bunk: 'bunk-pb-id-1',
+    assigned_bunk_cm_id: 3000001,
+    created: '2025-01-01',
+    updated: '2025-01-01',
+    ...overrides,
+  } as unknown as Camper
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'session-pb-id-1',
+    cm_id: 1000001,
+    name: 'Session 1A',
+    session_type: 'main',
+    year: 2025,
+    start_date: '2025-06-01',
+    end_date: '2025-06-14',
+    parent_id: '',
+    ...overrides,
+  } as unknown as Session
+}
+
+// ---------------------------------------------------------------------------
+// Behavioral coverage
+// ---------------------------------------------------------------------------
+
+describe('mergeMultiSessionCampers', () => {
+  it('collapses two enrollments of one person into a single entry with additionalSessions', () => {
+    const campers = [
+      makeCamper({ id: 'p1:s1', session_cm_id: 1000001 }),
+      makeCamper({ id: 'p1:s2', session_cm_id: 1000002, assigned_bunk_cm_id: 3000002 }),
+    ]
+    const sessions = [
+      makeSession({ cm_id: 1000001, name: 'Session 1A', session_type: 'main' }),
+      makeSession({ cm_id: 1000002, name: 'Session 2A', session_type: 'embedded' }),
+    ]
+
+    const merged = mergeMultiSessionCampers(campers, sessions)
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0]?.additionalSessions).toHaveLength(1)
+    expect(merged[0]?.additionalSessions?.[0]?.session_cm_id).toBe(1000002)
+    expect(merged[0]?.additionalSessions?.[0]?.session_name).toBe('Session 2A')
+  })
+
+  it('leaves a single-session camper untouched (no additionalSessions)', () => {
+    const merged = mergeMultiSessionCampers([makeCamper()], [makeSession()])
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0]?.additionalSessions).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Readonly contract (#1596) — type-level spec, enforced by tsc --noEmit
+// ---------------------------------------------------------------------------
+
+describe('readonly contract', () => {
+  it('AdditionalSession fields are readonly', () => {
+    const addl: AdditionalSession = {
+      session_cm_id: 1000002,
+      session_name: 'Session 2A',
+    }
+
+    // @ts-expect-error - session_cm_id is readonly
+    addl.session_cm_id = 999
+    // @ts-expect-error - session_name is readonly
+    addl.session_name = 'mutated'
+    // @ts-expect-error - bunk_cm_id is readonly
+    addl.bunk_cm_id = 3000003
+
+    expect(addl.session_name).toBeDefined()
+  })
+
+  it('MergedCamper.additionalSessions is a readonly array', () => {
+    const merged: MergedCamper = {
+      ...makeCamper(),
+      additionalSessions: [{ session_cm_id: 1000002, session_name: 'Session 2A' }],
+    }
+
+    // @ts-expect-error - readonly array is not assignable to a mutable AdditionalSession[]
+    const mutable: AdditionalSession[] = merged.additionalSessions ?? []
+
+    expect(mutable).toHaveLength(1)
+  })
+})

--- a/frontend/src/utils/mergeMultiSessionCampers.ts
+++ b/frontend/src/utils/mergeMultiSessionCampers.ts
@@ -9,15 +9,15 @@
 import type { Camper, Session } from '../types/app-types'
 
 export interface AdditionalSession {
-  session_cm_id: number
-  session_name: string
-  bunk_cm_id?: number | undefined
-  bunk_name?: string | undefined
-  bunk_pb_id?: string | undefined
+  readonly session_cm_id: number
+  readonly session_name: string
+  readonly bunk_cm_id?: number | undefined
+  readonly bunk_name?: string | undefined
+  readonly bunk_pb_id?: string | undefined
 }
 
 export interface MergedCamper extends Camper {
-  additionalSessions?: AdditionalSession[] | undefined
+  readonly additionalSessions?: readonly AdditionalSession[] | undefined
 }
 
 /** Session type priority for picking the "primary" enrollment. */


### PR DESCRIPTION
Closes #1596.

Finishes the app-types `readonly` contract opened by #1595 — same latent readonly-leak class as the graph-type follow-ups #1593/#1594 (shipped in #1597). Two consumers were intentionally left out of #1595 to keep that a pure type-only change.

## Changes

1. **`AllCampersView.tsx`** — drop the now-redundant `as Camper[]` cast. #1595 widened `buildCamperRows` to accept `readonly Camper[]` (`csvExportHelpers.ts:73`), and `filteredCampers` is `MergedCamper[]` (`MergedCamper extends Camper`), so it's directly assignable. The standing cast only suppressed future compiler signal if the contract changed.

2. **`mergeMultiSessionCampers.ts`** — mark `AdditionalSession`'s fields and `MergedCamper.additionalSessions` `readonly`, matching the now-`readonly` `Camper` that `MergedCamper` extends. The builder constructs each `AdditionalSession` via `.map()` into fresh objects, so the element type going `readonly` is a clean change.

Pure type-only hardening — **no runtime behavior change**, no active mutation existed.

## Tests

Adds the first tests for `mergeMultiSessionCampers` (previously untested):
- **Behavioral coverage** — multi-enrollment merge produces one entry with `additionalSessions`; single-session camper untouched.
- **Readonly contract** — `@ts-expect-error` assertions enforced by `tsc --noEmit`. Verified red→green: before the change the directives are unused (TS2578); after, they type-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for multi-session camper merging functionality, including validation of camper data consolidation and immutability constraints.

* **Refactor**
  * Enhanced type safety in CSV export and camper data handling to prevent potential bugs and ensure data integrity during export operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->