### PR TITLE
feat(metrics): teen programs (SCIT/TLI) cohort + pickers (PR A)

### DIFF
--- a/api/routers/metrics.py
+++ b/api/routers/metrics.py
@@ -591,17 +591,19 @@ async def get_forecast(
 @router.get("/registration/day1", response_model=Day1Response)
 async def get_day1(
     year: int = Query(description="Camp year", ge=2000, le=2100),
+    session_types: str | None = Query(None, description="Comma-separated session types to filter (e.g., 'main,quest')"),
     user: AuthUser = Depends(get_current_user),
 ) -> Day1Response:
     """Get Day 1 first-24h registration counts by tier."""
-    cache_params = {"year": year}
+    cache_params = {"year": year, "session_types": session_types}
     cached: Day1Response | None = metrics_cache.get("day1", **cache_params)
     if cached is not None:
         return cached
 
+    type_filter = session_types.split(",") if session_types else None
     repository = _create_repository()
     service = Day1Service(repository)
-    result = await service.get_day1(year)
+    result = await service.get_day1(year, session_types=type_filter)
 
     metrics_cache.set("day1", result, **cache_params)
     return result

--- a/api/schemas/day1.py
+++ b/api/schemas/day1.py
@@ -8,8 +8,8 @@ class Day1CategoryCounts(BaseModel):
 
 
 class Day1Category(BaseModel):
-    category: str = Field(description="'at_camp' or 'quest'")
-    label: str = Field(description="'At Camp' or 'Quest'")
+    category: str = Field(description="'at_camp', 'quest', or 'teen'")
+    label: str = Field(description="'At Camp', 'Quest', or 'Teens'")
     count: int = Field(description="Enrollments in the 24h window for this category")
 
 

--- a/api/services/cancellation_service.py
+++ b/api/services/cancellation_service.py
@@ -24,15 +24,16 @@ from api.schemas.metrics import (
 from api.services.breakdown_calculator import calculate_percentage, compute_registration_breakdown
 from api.services.extractors import extract_gender, extract_grade
 from api.utils.session_metrics import (
-    DEFAULT_SUMMER_SESSION_TYPES as SUMMER_SESSION_TYPES,
-)
-from api.utils.session_metrics import (
+    DEFAULT_SUMMER_SESSION_TYPES,
     build_ag_parent_map,
     get_session_from_expand,
     resolve_duration_sessions,
 )
 from api.utils.session_swap import detect_session_swaps
 from bunking.logging_config import get_logger
+
+# Back-compat alias as an explicit module export (shared default lives in session_metrics).
+SUMMER_SESSION_TYPES = DEFAULT_SUMMER_SESSION_TYPES
 
 if TYPE_CHECKING:
     from .metrics_repository import MetricsRepository

--- a/api/services/cancellation_service.py
+++ b/api/services/cancellation_service.py
@@ -25,6 +25,7 @@ from api.services.breakdown_calculator import calculate_percentage, compute_regi
 from api.services.extractors import extract_gender, extract_grade
 from api.utils.session_metrics import (
     DEFAULT_SUMMER_SESSION_TYPES,
+    SUMMER_TEEN_TYPES,
     build_ag_parent_map,
     get_session_from_expand,
     resolve_duration_sessions,
@@ -73,8 +74,15 @@ class CancellationService:
         Returns:
             CancellationMetricsResponse with summary counts and breakdowns.
         """
-        # Fetch ALL sessions for enrollment lookup (cross-type visibility)
+        # Fetch ALL summer sessions for display + cross-session enrollment lookup.
         all_sessions = await self.repository.fetch_sessions(year, list(SUMMER_SESSION_TYPES))
+
+        # Teen programs (SCIT/TLI) also count as "still attending camp": a camper
+        # who cancels one teen session but keeps another reads as has_other_sessions,
+        # not a true departure. Fold teen session ids into the enrollment lookup
+        # only -- the display scope below stays summer-only / the requested filter.
+        teen_sessions = await self.repository.fetch_sessions(year, list(SUMMER_TEEN_TYPES))
+        enrollment_session_ids = set(all_sessions.keys()) | set(teen_sessions.keys())
 
         # Fetch filtered sessions for display
         effective_types = session_types or list(SUMMER_SESSION_TYPES)
@@ -96,8 +104,9 @@ class CancellationService:
         enrolled_attendees = await self.repository.fetch_attendees(year, status_filter="enrolled")
 
         # Filter cancelled to selected sessions, enrolled to ALL session types
+        # (summer + teen) so cross-session retention spans teen programs too.
         cancelled_attendees = self._filter_to_sessions(cancelled_attendees, valid_session_ids)
-        enrolled_attendees = self._filter_to_sessions(enrolled_attendees, set(all_sessions.keys()))
+        enrolled_attendees = self._filter_to_sessions(enrolled_attendees, enrollment_session_ids)
 
         # Build enrolled person set
         enrolled_person_ids: set[int] = set()

--- a/api/services/cancellation_service.py
+++ b/api/services/cancellation_service.py
@@ -23,7 +23,14 @@ from api.schemas.metrics import (
 )
 from api.services.breakdown_calculator import calculate_percentage, compute_registration_breakdown
 from api.services.extractors import extract_gender, extract_grade
-from api.utils.session_metrics import build_ag_parent_map, get_session_from_expand, resolve_duration_sessions
+from api.utils.session_metrics import (
+    DEFAULT_SUMMER_SESSION_TYPES as SUMMER_SESSION_TYPES,
+)
+from api.utils.session_metrics import (
+    build_ag_parent_map,
+    get_session_from_expand,
+    resolve_duration_sessions,
+)
 from api.utils.session_swap import detect_session_swaps
 from bunking.logging_config import get_logger
 
@@ -31,9 +38,6 @@ if TYPE_CHECKING:
     from .metrics_repository import MetricsRepository
 
 logger = get_logger(__name__)
-
-# Summer session types to include in analysis
-SUMMER_SESSION_TYPES = ("main", "embedded", "ag", "quest")
 
 # Statuses that indicate cancellation
 CANCELLED_STATUSES = ["cancelled", "withdrawn", "dismissed"]

--- a/api/services/day1_service.py
+++ b/api/services/day1_service.py
@@ -17,7 +17,7 @@ from api.schemas.day1 import (
 from api.services.camp_calendar import REGISTRATION_TIERS, day1_window
 from api.services.metrics_repository import MetricsRepository
 from api.services.reconstruction import ENROLLMENT_STATUSES, parse_date_only
-from api.utils.session_metrics import get_session_from_expand
+from api.utils.session_metrics import filter_attendees_by_session, get_session_from_expand
 from bunking.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -30,12 +30,19 @@ class Day1Service:
     def __init__(self, repository: MetricsRepository) -> None:
         self.repository = repository
 
-    async def get_day1(self, year: int) -> Day1Response:
-        """Get Day 1 registration counts for current year + 2 prior years."""
+    async def get_day1(self, year: int, session_types: list[str] | None = None) -> Day1Response:
+        """Get Day 1 registration counts for current year + 2 prior years.
+
+        Args:
+            year: The camp year to compute counts for.
+            session_types: Optional list of session types to include
+                (e.g. ``["main", "quest"]``). ``None`` preserves existing
+                behaviour and counts all attendees regardless of session type.
+        """
         current, prior_1, prior_2 = await asyncio.gather(
-            self._count_year(year),
-            self._count_year(year - 1),
-            self._count_year(year - 2),
+            self._count_year(year, session_types),
+            self._count_year(year - 1, session_types),
+            self._count_year(year - 2, session_types),
         )
         prior_years = [
             Day1YearData(year=year - 1, tiers=prior_1),
@@ -43,7 +50,7 @@ class Day1Service:
         ]
         return Day1Response(year=year, tiers=current, prior_years=prior_years)
 
-    async def _count_year(self, year: int) -> list[Day1TierData]:
+    async def _count_year(self, year: int, session_types: list[str] | None = None) -> list[Day1TierData]:
         """Count Day 1 registrations for a single year.
 
         Single-pass: iterates attendees once, bucketing each into matching tier windows.
@@ -59,6 +66,10 @@ class Day1Service:
         session_type_map: dict[int, str] = {}
         for cm_id, session in sessions.items():
             session_type_map[cm_id] = session.session_type
+
+        # Apply session type filter when specified
+        if session_types is not None:
+            attendees = filter_attendees_by_session(attendees, session_types)
 
         # Pre-compute tier windows
         tier_windows: list[tuple[str, str, str, date, datetime, datetime]] = []

--- a/api/services/day1_service.py
+++ b/api/services/day1_service.py
@@ -17,13 +17,18 @@ from api.schemas.day1 import (
 from api.services.camp_calendar import REGISTRATION_TIERS, day1_window
 from api.services.metrics_repository import MetricsRepository
 from api.services.reconstruction import ENROLLMENT_STATUSES, parse_date_only
-from api.utils.session_metrics import filter_attendees_by_session, get_session_from_expand
+from api.utils.session_metrics import (
+    SUMMER_TEEN_TYPES,
+    filter_attendees_by_session,
+    get_session_from_expand,
+)
 from bunking.logging_config import get_logger
 
 logger = get_logger(__name__)
 
 AT_CAMP_TYPES = {"main", "embedded", "ag"}
 QUEST_TYPES = {"quest"}
+TEEN_TYPES = set(SUMMER_TEEN_TYPES)
 
 
 class Day1Service:
@@ -36,8 +41,9 @@ class Day1Service:
         Args:
             year: The camp year to compute counts for.
             session_types: Optional list of session types to include
-                (e.g. ``["main", "quest"]``). ``None`` preserves existing
-                behaviour and counts all attendees regardless of session type.
+                (e.g. ``["main", "quest"]``). ``None`` preserves the existing
+                summer behaviour (At Camp + Quest); teens (scit/tli) are counted
+                only when explicitly requested via ``session_types``.
         """
         current, prior_1, prior_2 = await asyncio.gather(
             self._count_year(year, session_types),
@@ -67,7 +73,10 @@ class Day1Service:
         for cm_id, session in sessions.items():
             session_type_map[cm_id] = session.session_type
 
-        # Apply session type filter when specified
+        # Apply session type filter when specified. Teens (scit/tli) are counted
+        # only when the caller passes an explicit filter; the param-less (None)
+        # path keeps the historical At Camp + Quest summer scope.
+        count_teens = session_types is not None
         if session_types is not None:
             attendees = filter_attendees_by_session(attendees, session_types)
 
@@ -84,8 +93,8 @@ class Day1Service:
         if not tier_windows:
             return []
 
-        # Per-tier counters: tier_key -> {at_camp, quest, approximate}
-        counts: dict[str, dict[str, int]] = {tw[0]: {"at_camp": 0, "quest": 0} for tw in tier_windows}
+        # Per-tier counters: tier_key -> {at_camp, quest, teen}
+        counts: dict[str, dict[str, int]] = {tw[0]: {"at_camp": 0, "quest": 0, "teen": 0} for tw in tier_windows}
         approximate_flags: dict[str, bool] = {tw[0]: False for tw in tier_windows}
 
         # Build tier date lookup for simple date comparison
@@ -117,16 +126,20 @@ class Day1Service:
                     counts[tier_key]["at_camp"] += 1
                 elif stype in QUEST_TYPES:
                     counts[tier_key]["quest"] += 1
+                elif count_teens and stype in TEEN_TYPES:
+                    counts[tier_key]["teen"] += 1
 
         # Build response
         tiers: list[Day1TierData] = []
         for tier_key, _date_key, tier_label, tier_date, window_start, window_end in tier_windows:
             at_camp_count = counts[tier_key]["at_camp"]
             quest_count = counts[tier_key]["quest"]
-            total = at_camp_count + quest_count
+            teen_count = counts[tier_key]["teen"]
+            total = at_camp_count + quest_count + teen_count
             categories = [
                 Day1Category(category="at_camp", label="At Camp", count=at_camp_count),
                 Day1Category(category="quest", label="Quest", count=quest_count),
+                Day1Category(category="teen", label="Teens", count=teen_count),
             ]
             tiers.append(
                 Day1TierData(

--- a/api/services/drilldown_service.py
+++ b/api/services/drilldown_service.py
@@ -13,7 +13,10 @@ from typing import TYPE_CHECKING, Any
 from api.schemas.metrics import DrilldownAttendee, DrilldownSession
 from api.services.cancellation_service import CANCELLED_STATUSES
 from api.services.extractors import filter_aged_out_attendees
-from api.services.waitlist_service import DECLINED_STATUSES, SUMMER_SESSION_TYPES
+from api.services.waitlist_service import DECLINED_STATUSES
+from api.utils.session_metrics import (
+    DEFAULT_SUMMER_SESSION_TYPES as SUMMER_SESSION_TYPES,
+)
 from api.utils.session_metrics import (
     compute_summer_metrics,
     filter_attendees_by_session,

--- a/api/services/waitlist_service.py
+++ b/api/services/waitlist_service.py
@@ -22,16 +22,20 @@ from api.schemas.metrics import (
 )
 from api.services.breakdown_calculator import calculate_percentage, compute_registration_breakdown
 from api.services.extractors import extract_gender, extract_grade
-from api.utils.session_metrics import build_ag_parent_map, get_session_from_expand, resolve_duration_sessions
+from api.utils.session_metrics import (
+    DEFAULT_SUMMER_SESSION_TYPES as SUMMER_SESSION_TYPES,
+)
+from api.utils.session_metrics import (
+    build_ag_parent_map,
+    get_session_from_expand,
+    resolve_duration_sessions,
+)
 from bunking.logging_config import get_logger
 
 if TYPE_CHECKING:
     from .metrics_repository import MetricsRepository
 
 logger = get_logger(__name__)
-
-# Summer session types to include in analysis
-SUMMER_SESSION_TYPES = ("main", "embedded", "ag", "quest")
 
 # Statuses that indicate a camper declined placement
 DECLINED_STATUSES = ["cancelled", "withdrawn", "dismissed"]

--- a/api/services/waitlist_service.py
+++ b/api/services/waitlist_service.py
@@ -23,14 +23,15 @@ from api.schemas.metrics import (
 from api.services.breakdown_calculator import calculate_percentage, compute_registration_breakdown
 from api.services.extractors import extract_gender, extract_grade
 from api.utils.session_metrics import (
-    DEFAULT_SUMMER_SESSION_TYPES as SUMMER_SESSION_TYPES,
-)
-from api.utils.session_metrics import (
+    DEFAULT_SUMMER_SESSION_TYPES,
     build_ag_parent_map,
     get_session_from_expand,
     resolve_duration_sessions,
 )
 from bunking.logging_config import get_logger
+
+# Back-compat alias as an explicit module export (shared default lives in session_metrics).
+SUMMER_SESSION_TYPES = DEFAULT_SUMMER_SESSION_TYPES
 
 if TYPE_CHECKING:
     from .metrics_repository import MetricsRepository

--- a/api/services/waitlist_service.py
+++ b/api/services/waitlist_service.py
@@ -24,6 +24,7 @@ from api.services.breakdown_calculator import calculate_percentage, compute_regi
 from api.services.extractors import extract_gender, extract_grade
 from api.utils.session_metrics import (
     DEFAULT_SUMMER_SESSION_TYPES,
+    SUMMER_TEEN_TYPES,
     build_ag_parent_map,
     get_session_from_expand,
     resolve_duration_sessions,
@@ -65,8 +66,15 @@ class WaitlistService:
         Returns:
             WaitlistMetricsResponse with summary counts and breakdowns.
         """
-        # Fetch ALL sessions for enrollment lookup (cross-type visibility)
+        # Fetch ALL summer sessions for display + cross-session enrollment lookup.
         all_sessions = await self.repository.fetch_sessions(year, list(SUMMER_SESSION_TYPES))
+
+        # Teen programs (SCIT/TLI) also count as "enrolled at camp": a waitlisted
+        # teen who is enrolled in another teen session reads as has_enrollment,
+        # not no_enrollment. Fold teen session ids into the enrollment lookup only
+        # -- the display scope below stays summer-only / the requested filter.
+        teen_sessions = await self.repository.fetch_sessions(year, list(SUMMER_TEEN_TYPES))
+        enrollment_session_ids = set(all_sessions.keys()) | set(teen_sessions.keys())
 
         # Fetch filtered sessions for waitlist display
         effective_types = session_types or list(SUMMER_SESSION_TYPES)
@@ -88,8 +96,9 @@ class WaitlistService:
         enrolled_attendees = await self.repository.fetch_attendees(year, status_filter="enrolled")
 
         # Filter waitlisted to selected session types, enrolled to ALL types
+        # (summer + teen) so cross-session enrollment spans teen programs too.
         waitlisted_attendees = self._filter_to_sessions(waitlisted_attendees, valid_session_ids)
-        enrolled_attendees = self._filter_to_sessions(enrolled_attendees, set(all_sessions.keys()))
+        enrolled_attendees = self._filter_to_sessions(enrolled_attendees, enrollment_session_ids)
 
         # Build mapping: person_id -> list of (session_cm_id, session_name) they're enrolled in
         enrolled_sessions_by_person: dict[int, list[tuple[int, str]]] = defaultdict(list)

--- a/api/utils/session_metrics.py
+++ b/api/utils/session_metrics.py
@@ -22,6 +22,11 @@ from typing import Any
 # - tli: Teen Leadership Initiative (different program)
 DISPLAY_SESSION_TYPES = ("main", "embedded", "ag", "quest")
 
+# Default cohort for endpoints that scope to summer when the client sends no
+# session_types (param-less / direct API calls). The UI always sends an explicit
+# set, so teens are reached via the picker, not this default.
+DEFAULT_SUMMER_SESSION_TYPES = ("main", "embedded", "ag", "quest")
+
 # Session types that have cabin/bunk assignments relevant to the heatmap.
 # Used for filtering _build_session_bunk_breakdown to prevent family camp,
 # quest, training, and TLI sessions from appearing in the bunk heatmap.

--- a/api/utils/session_metrics.py
+++ b/api/utils/session_metrics.py
@@ -64,6 +64,48 @@ SESSION_LENGTH_ORDER: dict[str, int] = {
 # - tli: Teen Leadership Initiative (different program)
 SUMMER_PROGRAM_SESSION_TYPES = ("main", "embedded", "ag", "quest")
 
+# Summer teen programs: SCIT (CIT+SIT) and TLI. NOT a default-included cohort —
+# surfaced only when explicitly selected, and always summer-window-gated to
+# exclude off-season noise (fall Family-Camp CIT, Aug->May Teen Interns, Feb L.A. Trip).
+SUMMER_TEEN_TYPES = ("scit", "tli")
+
+
+def get_summer_window(sessions: dict[int, Any]) -> tuple[str, str] | None:
+    """Return (earliest main start_date, latest main end_date) as YYYY-MM-DD, or None.
+
+    Defines the per-year "summer" span from the main camp sessions, used to gate
+    which scit/tli sessions count as summer teen programs.
+    """
+    starts: list[str] = []
+    ends: list[str] = []
+    for s in sessions.values():
+        if getattr(s, "session_type", None) != "main":
+            continue
+        start = getattr(s, "start_date", None)
+        end = getattr(s, "end_date", None)
+        if start and end:
+            starts.append(str(start)[:10])
+            ends.append(str(end)[:10])
+    if not starts or not ends:
+        return None
+    return (min(starts), max(ends))
+
+
+def is_summer_teen_session(session: Any, window: tuple[str, str] | None) -> bool:
+    """True iff session is a teen type (scit/tli) AND its dates overlap the summer window."""
+    if getattr(session, "session_type", None) not in SUMMER_TEEN_TYPES:
+        return False
+    if window is None:
+        return False
+    start = getattr(session, "start_date", None)
+    end = getattr(session, "end_date", None)
+    if not start or not end:
+        return False
+    win_start, win_end = window
+    s_start, s_end = str(start)[:10], str(end)[:10]
+    # Overlap: session starts on/before window end AND ends on/after window start.
+    return s_start <= win_end and s_end >= win_start
+
 
 def get_session_from_expand(record: Any) -> Any:
     """Extract session from a record's PocketBase expand dict.

--- a/api/utils/session_metrics.py
+++ b/api/utils/session_metrics.py
@@ -107,6 +107,30 @@ def is_summer_teen_session(session: Any, window: tuple[str, str] | None) -> bool
     return s_start <= win_end and s_end >= win_start
 
 
+def resolve_cohort_session_ids(sessions: dict[int, Any], requested_types: list[str] | None) -> set[int]:
+    """Resolve requested session types to valid session cm_ids for a year.
+
+    Non-teen types pass on type membership alone. Teen types (scit/tli) are
+    additionally summer-window-gated via is_summer_teen_session so off-season
+    rows (fall Family-Camp CIT, year-long Teen Interns, Feb L.A. Trip) are excluded.
+    requested_types=None means "all summer cohorts" (non-teen displayable + gated teens).
+    """
+    window = get_summer_window(sessions)
+    result: set[int] = set()
+    for cm_id, s in sessions.items():
+        stype = getattr(s, "session_type", None)
+        if requested_types is not None and stype not in requested_types:
+            continue
+        if stype in SUMMER_TEEN_TYPES:
+            if not is_summer_teen_session(s, window):
+                continue
+        elif requested_types is None and stype not in DISPLAY_SESSION_TYPES:
+            # "all summer" only spans displayable summer types + gated teens
+            continue
+        result.add(int(cm_id))
+    return result
+
+
 def get_session_from_expand(record: Any) -> Any:
     """Extract session from a record's PocketBase expand dict.
 

--- a/api/utils/session_metrics.py
+++ b/api/utils/session_metrics.py
@@ -18,7 +18,7 @@ from typing import Any
 #
 # Excludes:
 # - family: Family camp (adult-focused, separate program)
-# - training: Staff training sessions
+# - scit: SCIT teen program (different program)
 # - tli: Teen Leadership Initiative (different program)
 DISPLAY_SESSION_TYPES = ("main", "embedded", "ag", "quest")
 
@@ -29,7 +29,7 @@ DEFAULT_SUMMER_SESSION_TYPES = ("main", "embedded", "ag", "quest")
 
 # Session types that have cabin/bunk assignments relevant to the heatmap.
 # Used for filtering _build_session_bunk_breakdown to prevent family camp,
-# quest, training, and TLI sessions from appearing in the bunk heatmap.
+# quest, scit, and tli sessions from appearing in the bunk heatmap.
 #
 # Includes:
 # - main: Standard sessions (Session 1, 2, 3, 4) with B-*/G-* bunks
@@ -39,7 +39,7 @@ DEFAULT_SUMMER_SESSION_TYPES = ("main", "embedded", "ag", "quest")
 # Excludes:
 # - quest: Adventure program (no traditional cabin bunking)
 # - family: Family camp (adult-focused, same bunk names but separate program)
-# - training: Staff training sessions
+# - scit: SCIT teen program (different program)
 # - tli: Teen Leadership Initiative
 BUNK_SESSION_TYPES = ("main", "embedded", "ag")
 
@@ -65,7 +65,7 @@ SESSION_LENGTH_ORDER: dict[str, int] = {
 #
 # Excludes:
 # - family: Family camp (adult-focused)
-# - training: Staff training sessions
+# - scit: SCIT teen program (different program)
 # - tli: Teen Leadership Initiative (different program)
 SUMMER_PROGRAM_SESSION_TYPES = ("main", "embedded", "ag", "quest")
 

--- a/frontend/src/components/AllCampersView.test.tsx
+++ b/frontend/src/components/AllCampersView.test.tsx
@@ -1,0 +1,272 @@
+/**
+ * Component-level tests for AllCampersView teen-program support (Task 10).
+ *
+ * These exercise the composition the utils tests cannot: the wiring between
+ * the session/camper fetches, the window-gated dropdownSessions, the
+ * FILTER_TEENS scope, and the headline noun.
+ *
+ * Data is mocked at the hook/fetcher boundary so the component's real
+ * filtering + headline logic runs unmocked.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/react'
+import { createWrapper } from '../test/testUtils'
+import type { Camper } from '../types/app-types'
+import type { CampSessionsResponse } from '../types/pocketbase-types'
+
+// ── Mock data fixtures ──────────────────────────────────────────────────────
+// Sessions: a summer main, a quest, a summer-window teen (scit), and an
+// off-season teen (tli) that does NOT overlap the main-session window.
+const SESSIONS = {
+  main: {
+    id: 'pb-main',
+    cm_id: 1000001,
+    name: 'Session 2',
+    session_type: 'main',
+    start_date: '2025-06-01',
+    end_date: '2025-06-14',
+    year: 2025,
+    created: '',
+    updated: '',
+  },
+  quest: {
+    id: 'pb-quest',
+    cm_id: 1000002,
+    name: 'Quest: Pacific Crest',
+    session_type: 'quest',
+    start_date: '2025-07-01',
+    end_date: '2025-07-14',
+    year: 2025,
+    created: '',
+    updated: '',
+  },
+  scit: {
+    id: 'pb-scit',
+    cm_id: 1000003,
+    name: 'SCIT: Rising 12th',
+    session_type: 'scit',
+    start_date: '2025-06-01',
+    end_date: '2025-06-14',
+    year: 2025,
+    created: '',
+    updated: '',
+  },
+  // Off-season tli — fall dates, no overlap with the June main window.
+  offseasonTli: {
+    id: 'pb-tli-fall',
+    cm_id: 1000004,
+    name: 'TLI: Fall Interns',
+    session_type: 'tli',
+    start_date: '2025-09-01',
+    end_date: '2025-09-14',
+    year: 2025,
+    created: '',
+    updated: '',
+  },
+  // AG session — never appears standalone in the dropdown; grouped under its
+  // parent main (parent_id → main.cm_id) via getSessionRelationshipsForCamperView.
+  ag: {
+    id: 'pb-ag',
+    cm_id: 1000005,
+    name: 'All-Gender Session 2',
+    session_type: 'ag',
+    parent_id: 1000001,
+    start_date: '2025-06-01',
+    end_date: '2025-06-14',
+    year: 2025,
+    created: '',
+    updated: '',
+  },
+} as const
+
+function camper(overrides: { person_cm_id: number; session_cm_id: number; name: string }): Camper {
+  const [first, last] = overrides.name.split(' ')
+  return {
+    id: `${overrides.person_cm_id}:${overrides.session_cm_id}`,
+    name: overrides.name,
+    first_name: first ?? '',
+    last_name: last ?? '',
+    age: 16,
+    grade: 11,
+    gender: 'M',
+    person_cm_id: overrides.person_cm_id,
+    session_cm_id: overrides.session_cm_id,
+    created: '',
+    updated: '',
+  }
+}
+
+// Mocks are reconfigured per test via these module-level holders.
+let sessionsFixture: CampSessionsResponse[] = []
+let campersFixture: Camper[] = []
+
+vi.mock('../hooks/useCurrentYear', () => ({
+  useYear: () => 2025,
+}))
+
+vi.mock('../lib/pocketbase', () => ({
+  pb: {
+    collection: () => ({
+      getFullList: () => Promise.resolve(sessionsFixture),
+    }),
+  },
+}))
+
+vi.mock('../utils/pocketbaseDataFetchers', () => ({
+  // Non-empty so the all-campers query doesn't early-return [].
+  fetchAttendeesWithPersons: () => Promise.resolve([{ id: 'att-1' }]),
+  fetchAssignmentsWithBunks: () => Promise.resolve([]),
+  fetchBunksWithPlansForYear: () => Promise.resolve({ bunks: [], bunkPlans: [] }),
+}))
+
+vi.mock('../utils/transforms', () => ({
+  buildCampersFromData: () => campersFixture,
+  createLookupMaps: () => ({ assignments: new Map(), bunks: new Map() }),
+}))
+
+// Render eagerly so the virtual table list mounts; not strictly needed since we
+// assert on the header count/noun, but keeps the component path realistic.
+import AllCampersView from './AllCampersView'
+
+function setFixtures(sessions: CampSessionsResponse[], campers: Camper[]) {
+  sessionsFixture = sessions
+  campersFixture = campers
+}
+
+/** Open the scope Listbox (by its current label) and return its options popup. */
+function openScopePicker(label: RegExp): HTMLElement {
+  const button = screen.getByRole('button', { name: label })
+  fireEvent.click(button)
+  return screen.getByRole('listbox')
+}
+
+/**
+ * The results header renders "<count><noun>[ of <total>]". Assert the headline
+ * noun robustly via the count span's parent, ignoring the optional " of N".
+ */
+function expectHeadline(count: number, noun: string) {
+  // The big bold count span.
+  const countEl = screen.getByText(String(count), {
+    selector: 'span.font-display',
+  })
+  // Its sibling noun span starts with the noun text.
+  const nounSpan = countEl.nextElementSibling as HTMLElement | null
+  expect(nounSpan?.textContent ?? '').toMatch(new RegExp(`^${noun}\\b`))
+}
+
+beforeEach(() => {
+  sessionsFixture = []
+  campersFixture = []
+})
+
+describe('AllCampersView — teen program support', () => {
+  it('(a) FILTER_TEENS shows only the summer-teen campers, count + "teens" noun, off-season excluded', async () => {
+    setFixtures(
+      [
+        SESSIONS.main,
+        SESSIONS.quest,
+        SESSIONS.scit,
+        SESSIONS.offseasonTli,
+      ] as CampSessionsResponse[],
+      [
+        camper({ person_cm_id: 1, session_cm_id: SESSIONS.main.cm_id, name: 'Emma Johnson' }),
+        camper({ person_cm_id: 2, session_cm_id: SESSIONS.quest.cm_id, name: 'Liam Garcia' }),
+        // two summer scit teens → count 2 → plural "teens"
+        camper({ person_cm_id: 3, session_cm_id: SESSIONS.scit.cm_id, name: 'Olivia Chen' }),
+        camper({ person_cm_id: 5, session_cm_id: SESSIONS.scit.cm_id, name: 'Noah Brooks' }),
+        // off-season teen — must never appear in any count
+        camper({ person_cm_id: 4, session_cm_id: SESSIONS.offseasonTli.cm_id, name: 'Riley Sam' }),
+      ]
+    )
+
+    render(<AllCampersView />, { wrapper: createWrapper() })
+    await waitFor(() => expect(screen.queryByText('Loading campers...')).not.toBeInTheDocument())
+
+    // Select Teen Programs scope.
+    const popup = openScopePicker(/All Summer/i)
+    fireEvent.click(within(popup).getByRole('option', { name: /^Teen Programs$/ }))
+
+    // Two summer teens; off-season Riley Sam excluded → count 2, noun "teens".
+    await waitFor(() => expectHeadline(2, 'teens'))
+  })
+
+  it('(b) "All Summer" headline matches cohorts; off-season teen never inflates count', async () => {
+    setFixtures(
+      [
+        SESSIONS.main,
+        SESSIONS.quest,
+        SESSIONS.scit,
+        SESSIONS.offseasonTli,
+      ] as CampSessionsResponse[],
+      [
+        camper({ person_cm_id: 1, session_cm_id: SESSIONS.main.cm_id, name: 'Emma Johnson' }),
+        camper({ person_cm_id: 2, session_cm_id: SESSIONS.quest.cm_id, name: 'Liam Garcia' }),
+        camper({ person_cm_id: 3, session_cm_id: SESSIONS.scit.cm_id, name: 'Olivia Chen' }),
+        camper({ person_cm_id: 4, session_cm_id: SESSIONS.offseasonTli.cm_id, name: 'Riley Sam' }),
+      ]
+    )
+
+    render(<AllCampersView />, { wrapper: createWrapper() })
+    await waitFor(() => expect(screen.queryByText('Loading campers...')).not.toBeInTheDocument())
+
+    // Window-gated universe = main + quest + scit (NOT off-season tli) → 3 campers,
+    // three cohorts. Off-season Riley Sam is dropped from the count entirely.
+    await waitFor(() => expectHeadline(3, 'campers, questers, and teens'))
+  })
+
+  it('(b2) off-season teen does NOT add a teen noun when no summer teens exist', async () => {
+    setFixtures([SESSIONS.main, SESSIONS.quest, SESSIONS.offseasonTli] as CampSessionsResponse[], [
+      camper({ person_cm_id: 1, session_cm_id: SESSIONS.main.cm_id, name: 'Emma Johnson' }),
+      camper({ person_cm_id: 2, session_cm_id: SESSIONS.quest.cm_id, name: 'Liam Garcia' }),
+      camper({ person_cm_id: 4, session_cm_id: SESSIONS.offseasonTli.cm_id, name: 'Riley Sam' }),
+    ])
+
+    render(<AllCampersView />, { wrapper: createWrapper() })
+    await waitFor(() => expect(screen.queryByText('Loading campers...')).not.toBeInTheDocument())
+
+    // No summer teen → 2 campers, noun "campers and questers", NOT "...and teens".
+    await waitFor(() => expectHeadline(2, 'campers and questers'))
+    expect(screen.queryByText(/teens/)).not.toBeInTheDocument()
+  })
+
+  it('(c) teen-free fixture renders no Teens option and the old noun', async () => {
+    setFixtures([SESSIONS.main, SESSIONS.quest] as CampSessionsResponse[], [
+      camper({ person_cm_id: 1, session_cm_id: SESSIONS.main.cm_id, name: 'Emma Johnson' }),
+      camper({ person_cm_id: 2, session_cm_id: SESSIONS.quest.cm_id, name: 'Liam Garcia' }),
+    ])
+
+    render(<AllCampersView />, { wrapper: createWrapper() })
+    await waitFor(() => expect(screen.queryByText('Loading campers...')).not.toBeInTheDocument())
+
+    // Old noun: campers and questers (no teens).
+    await waitFor(() => expectHeadline(2, 'campers and questers'))
+
+    // No "Teen Programs" quick-pick option in the scope picker.
+    const popup = openScopePicker(/All Summer/i)
+    expect(within(popup).queryByRole('option', { name: /^Teen Programs$/ })).not.toBeInTheDocument()
+  })
+
+  it('(d) AG campers survive the window-gate scoping (not dropped by summerCampers)', async () => {
+    // AG sessions never appear standalone in dropdownSessions, but each main's
+    // relationship entry includes its AG children's PB ids — so an AG-only
+    // camper must still be counted. Guards against a refactor silently dropping
+    // AG campers via scopedSessionPbIds / summerCampers.
+    setFixtures([SESSIONS.main, SESSIONS.ag] as CampSessionsResponse[], [
+      camper({ person_cm_id: 1, session_cm_id: SESSIONS.main.cm_id, name: 'Emma Johnson' }),
+      // enrolled ONLY in the AG session
+      camper({ person_cm_id: 2, session_cm_id: SESSIONS.ag.cm_id, name: 'Liam Garcia' }),
+    ])
+
+    render(<AllCampersView />, { wrapper: createWrapper() })
+    await waitFor(() => expect(screen.queryByText('Loading campers...')).not.toBeInTheDocument())
+
+    // All Summer: both campers counted (AG camper not dropped). AG counts as
+    // at-camp for the noun → "campers".
+    await waitFor(() => expectHeadline(2, 'campers'))
+
+    // Selecting "At Camp" must still include both (AG grouped under its parent main).
+    const popup = openScopePicker(/All Summer/i)
+    fireEvent.click(within(popup).getByRole('option', { name: /^At Camp$/ }))
+    await waitFor(() => expectHeadline(2, 'campers'))
+  })
+})

--- a/frontend/src/components/AllCampersView.test.tsx
+++ b/frontend/src/components/AllCampersView.test.tsx
@@ -173,7 +173,7 @@ describe('AllCampersView — teen program support', () => {
         camper({ person_cm_id: 2, session_cm_id: SESSIONS.quest.cm_id, name: 'Liam Garcia' }),
         // two summer scit teens → count 2 → plural "teens"
         camper({ person_cm_id: 3, session_cm_id: SESSIONS.scit.cm_id, name: 'Olivia Chen' }),
-        camper({ person_cm_id: 5, session_cm_id: SESSIONS.scit.cm_id, name: 'Noah Brooks' }),
+        camper({ person_cm_id: 5, session_cm_id: SESSIONS.scit.cm_id, name: 'Samuel Johnson' }),
         // off-season teen — must never appear in any count
         camper({ person_cm_id: 4, session_cm_id: SESSIONS.offseasonTli.cm_id, name: 'Riley Sam' }),
       ]

--- a/frontend/src/components/AllCampersView.tsx
+++ b/frontend/src/components/AllCampersView.tsx
@@ -33,12 +33,17 @@ import {
   FILTER_ALL,
   FILTER_AT_CAMP,
   FILTER_QUESTS,
+  FILTER_TEENS,
 } from '../utils/allCampersUtils'
 import { mergeMultiSessionCampers } from '../utils/mergeMultiSessionCampers'
 import type { MergedCamper } from '../utils/mergeMultiSessionCampers'
 import type { Camper, Session } from '../types/app-types'
 import type { BunksResponse } from '../types/pocketbase-types'
-import { SUMMER_CAMP_TYPES } from '../utils/sessionTypePredicates'
+import {
+  SUMMER_CAMP_TYPES,
+  TEEN_PROGRAM_TYPES,
+  isTeenProgram,
+} from '../utils/sessionTypePredicates'
 import { buildCsvContent, downloadCsv, todayIso } from '../utils/csvExport'
 import { buildCamperRows, CAMPER_CSV_HEADERS } from '../utils/csvExportHelpers'
 import { filterSexLabel, filterSexCsvSegment } from '../utils/filterSexFormat'
@@ -139,11 +144,14 @@ export default function AllCampersView() {
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [])
 
-  // Fetch all valid sessions
+  // Fetch all valid sessions (summer camp types + teen programs for window-gated teen picker)
   const { data: allSessions = [] } = useQuery({
     queryKey: ['all-sessions', currentYear],
     queryFn: async () => {
-      const sessionTypeFilter = createInclusionFilter('session_type', [...SUMMER_CAMP_TYPES])
+      const sessionTypeFilter = createInclusionFilter('session_type', [
+        ...SUMMER_CAMP_TYPES,
+        ...TEEN_PROGRAM_TYPES,
+      ])
       const yearFilter = `year = ${currentYear}`
       const filter = formatFilter(`${sessionTypeFilter} && ${yearFilter}`)
 
@@ -154,11 +162,15 @@ export default function AllCampersView() {
     },
   })
 
-  // Fetch all campers
+  // Fetch all campers (summer camp types + teen programs; off-season teen
+  // sessions are filtered out downstream via the window-gated dropdownSessions)
   const { data: allCampers = [], isLoading } = useQuery({
     queryKey: ['all-campers', currentYear],
     queryFn: async () => {
-      const sessionTypeFilter = createInclusionFilter('session_type', [...SUMMER_CAMP_TYPES])
+      const sessionTypeFilter = createInclusionFilter('session_type', [
+        ...SUMMER_CAMP_TYPES,
+        ...TEEN_PROGRAM_TYPES,
+      ])
       const yearFilter = `year = ${currentYear}`
       const filter = formatFilter(`${sessionTypeFilter} && ${yearFilter}`)
 
@@ -203,12 +215,6 @@ export default function AllCampersView() {
     return filterSummerCampBunks(bunksData.bunks, bunksData.bunkPlans, allSessions)
   }, [bunksData, allSessions])
 
-  // Merge multi-session campers into single entries
-  const mergedCampers: MergedCamper[] = useMemo(
-    () => mergeMultiSessionCampers(allCampers, allSessions),
-    [allCampers, allSessions]
-  )
-
   const dropdownSessions = useMemo(() => getDropdownSessions(allSessions), [allSessions])
   const sessionRelationships = useMemo(
     () => getSessionRelationshipsForCamperView(allSessions),
@@ -218,6 +224,46 @@ export default function AllCampersView() {
   const { campSessions, questSessions } = useMemo(
     () => splitDropdownSessionsByType(dropdownSessions),
     [dropdownSessions]
+  )
+
+  const teenSessions = useMemo(() => dropdownSessions.filter(isTeenProgram), [dropdownSessions])
+
+  // PocketBase session IDs in scope: every window-gated dropdown session plus
+  // its relationship-grouped children (AG sessions under their parent main).
+  // Teen sessions are window-gated, so off-season teen sessions are excluded.
+  const scopedSessionPbIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const session of dropdownSessions) {
+      const related = sessionRelationships.get(session.id) ?? [session.id]
+      related.forEach((id) => ids.add(id))
+    }
+    return ids
+  }, [dropdownSessions, sessionRelationships])
+
+  // cm_id → PocketBase id lookup for resolving camper enrollments to sessions.
+  const sessionPbIdByCmId = useMemo(() => {
+    const map = new Map<number, string>()
+    for (const s of allSessions) map.set(s.cm_id, s.id)
+    return map
+  }, [allSessions])
+
+  // Drop per-attendee camper records tied to off-season (non-window-gated)
+  // sessions — e.g. year-round teen interns — before merge, so they never leak
+  // into counts. Raw campers are one-per-enrollment, so a main + off-season-teen
+  // person keeps the main record and drops the teen record.
+  const summerCampers = useMemo(
+    () =>
+      allCampers.filter((camper) => {
+        const pbId = sessionPbIdByCmId.get(camper.session_cm_id)
+        return pbId ? scopedSessionPbIds.has(pbId) : false
+      }),
+    [allCampers, scopedSessionPbIds, sessionPbIdByCmId]
+  )
+
+  // Merge multi-session campers into single entries
+  const mergedCampers: MergedCamper[] = useMemo(
+    () => mergeMultiSessionCampers(summerCampers, allSessions),
+    [summerCampers, allSessions]
   )
 
   const scopedSessions = useMemo(
@@ -241,18 +287,20 @@ export default function AllCampersView() {
       })
     }
 
+    // mergedCampers is already scoped to window-gated dropdown sessions
+    // (off-season teens dropped via summerCampers), so FILTER_ALL = show all.
     if (filterSession !== FILTER_ALL) {
       const relatedSessionIds = new Set<string>()
+      const addRelated = (session: Session) => {
+        const ids = sessionRelationships.get(session.id) ?? [session.id]
+        ids.forEach((id) => relatedSessionIds.add(id))
+      }
       if (filterSession === FILTER_AT_CAMP) {
-        for (const session of campSessions) {
-          const ids = sessionRelationships.get(session.id) ?? [session.id]
-          ids.forEach((id) => relatedSessionIds.add(id))
-        }
+        campSessions.forEach(addRelated)
       } else if (filterSession === FILTER_QUESTS) {
-        for (const session of questSessions) {
-          const ids = sessionRelationships.get(session.id) ?? [session.id]
-          ids.forEach((id) => relatedSessionIds.add(id))
-        }
+        questSessions.forEach(addRelated)
+      } else if (filterSession === FILTER_TEENS) {
+        teenSessions.forEach(addRelated)
       } else {
         const ids = sessionRelationships.get(filterSession) ?? [filterSession]
         ids.forEach((id) => relatedSessionIds.add(id))
@@ -295,6 +343,7 @@ export default function AllCampersView() {
     allSessions,
     campSessions,
     questSessions,
+    teenSessions,
   ])
 
   // Check if any filters are active
@@ -363,12 +412,14 @@ export default function AllCampersView() {
                         ? 'At Camp'
                         : filterSession === FILTER_QUESTS
                           ? 'Quests'
-                          : (() => {
-                              const session = dropdownSessions.find((s) => s.id === filterSession)
-                              return session
-                                ? getSessionDisplayName(session, allSessions)
-                                : 'Unknown Session'
-                            })()}
+                          : filterSession === FILTER_TEENS
+                            ? 'Teen Programs'
+                            : (() => {
+                                const session = dropdownSessions.find((s) => s.id === filterSession)
+                                return session
+                                  ? getSessionDisplayName(session, allSessions)
+                                  : 'Unknown Session'
+                              })()}
                   </span>
                   <ChevronDown className="text-muted-foreground h-4 w-4 flex-shrink-0" />
                 </ListboxButton>
@@ -380,6 +431,11 @@ export default function AllCampersView() {
                   <ListboxOption value={FILTER_AT_CAMP} className="listbox-option py-1.5">
                     At Camp
                   </ListboxOption>
+                  {teenSessions.length > 0 && (
+                    <ListboxOption value={FILTER_TEENS} className="listbox-option py-1.5">
+                      Teen Programs
+                    </ListboxOption>
+                  )}
                   <ListboxOption value={FILTER_QUESTS} className="listbox-option py-1.5">
                     Quests
                   </ListboxOption>
@@ -395,6 +451,28 @@ export default function AllCampersView() {
                         Camp Sessions
                       </div>
                       {campSessions.map((session) => (
+                        <ListboxOption
+                          key={session.id}
+                          value={session.id}
+                          className="listbox-option py-1.5"
+                        >
+                          {getSessionDisplayName(session, allSessions)}
+                        </ListboxOption>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Teen Programs */}
+                  {teenSessions.length > 0 && (
+                    <div role="group" aria-labelledby="campers-teen-programs-group-label">
+                      <div className="border-border my-1 border-t" />
+                      <div
+                        id="campers-teen-programs-group-label"
+                        className="text-muted-foreground px-3 py-1 text-[10px] font-semibold tracking-wider uppercase"
+                      >
+                        Teen Programs
+                      </div>
+                      {teenSessions.map((session) => (
                         <ListboxOption
                           key={session.id}
                           value={session.id}

--- a/frontend/src/components/metrics/MetricsSessionSelector.test.tsx
+++ b/frontend/src/components/metrics/MetricsSessionSelector.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * Tests for MetricsSessionSelector component
+ * Covers Teens quick-pick and Teen Programs section in session dropdown
+ */
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MetricsSessionSelector } from './MetricsSessionSelector'
+import type { MetricsSessionContextType } from '../../hooks/useMetricsSession'
+
+const mockSetViewMode = vi.fn()
+const mockSetSelectedSessionCmId = vi.fn()
+const mockSetSelectedDuration = vi.fn()
+const mockSetSelectedTeenType = vi.fn()
+
+const baseMockContext = {
+  selectedSessionCmId: null,
+  selectedSession: undefined,
+  selectedDuration: null,
+  isLoading: false,
+  viewMode: 'sessions' as const,
+  setViewMode: mockSetViewMode,
+  setSelectedSessionCmId: mockSetSelectedSessionCmId,
+  setSelectedDuration: mockSetSelectedDuration,
+  clearSession: vi.fn(),
+  activeSessionTypes: ['main', 'embedded'],
+  sessionTypesParam: 'main,embedded',
+  sessions: [],
+  campSessions: [
+    {
+      cm_id: 1001,
+      name: 'Session 1',
+      session_type: 'main' as const,
+      start_date: '2026-06-15',
+      end_date: '2026-06-29',
+    },
+  ],
+  questSessions: [],
+  teenSessions: [
+    {
+      cm_id: 2001,
+      name: 'SCIT 2026',
+      session_type: 'scit' as const,
+      start_date: '2026-08-01',
+      end_date: '2026-08-14',
+    },
+    {
+      cm_id: 2002,
+      name: 'TLI 2026',
+      session_type: 'tli' as const,
+      start_date: '2026-08-10',
+      end_date: '2026-08-24',
+    },
+  ],
+  hasScit: true,
+  hasTli: true,
+  selectedTeenType: null as 'scit' | 'tli' | null,
+  setSelectedTeenType: mockSetSelectedTeenType,
+  durationGroups: new Map(),
+  durationParam: undefined,
+  filterOptions: {} as MetricsSessionContextType['filterOptions'],
+  expandedRetention: false,
+  setExpandedRetention: vi.fn(),
+  compareYear: null,
+  setCompareYear: vi.fn(),
+  isComparing: false,
+} satisfies MetricsSessionContextType
+
+vi.mock('../../hooks/useMetricsSession', () => ({
+  useMetricsSession: vi.fn(),
+}))
+
+import { useMetricsSession } from '../../hooks/useMetricsSession'
+
+const mockUseMetricsSession = vi.mocked(useMetricsSession)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUseMetricsSession.mockReturnValue(baseMockContext)
+})
+
+describe('MetricsSessionSelector — teen features', () => {
+  describe('with hasScit:true, hasTli:true', () => {
+    it('shows a "Teens" option in the quick-pick area', async () => {
+      const user = userEvent.setup()
+      render(<MetricsSessionSelector />)
+
+      // Open the listbox
+      const button = screen.getByRole('button')
+      await user.click(button)
+
+      expect(screen.getByRole('option', { name: 'Teens' })).toBeInTheDocument()
+    })
+
+    it('shows a "Teen Programs" group label', async () => {
+      const user = userEvent.setup()
+      render(<MetricsSessionSelector />)
+
+      const button = screen.getByRole('button')
+      await user.click(button)
+
+      expect(screen.getByText('Teen Programs')).toBeInTheDocument()
+    })
+
+    it('renders SCIT and TLI options under Teen Programs', async () => {
+      const user = userEvent.setup()
+      render(<MetricsSessionSelector />)
+
+      const button = screen.getByRole('button')
+      await user.click(button)
+
+      expect(screen.getByRole('option', { name: 'SCIT' })).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'TLI' })).toBeInTheDocument()
+    })
+
+    it('clicking "SCIT" calls setSelectedTeenType("scit")', async () => {
+      const user = userEvent.setup()
+      render(<MetricsSessionSelector />)
+
+      const button = screen.getByRole('button')
+      await user.click(button)
+
+      await user.click(screen.getByRole('option', { name: 'SCIT' }))
+      expect(mockSetSelectedTeenType).toHaveBeenCalledWith('scit')
+    })
+
+    it('clicking "Teens" calls setViewMode("teens")', async () => {
+      const user = userEvent.setup()
+      render(<MetricsSessionSelector />)
+
+      const button = screen.getByRole('button')
+      await user.click(button)
+
+      await user.click(screen.getByRole('option', { name: 'Teens' }))
+      expect(mockSetViewMode).toHaveBeenCalledWith('teens')
+    })
+  })
+
+  describe('with hasScit:false, hasTli:false', () => {
+    beforeEach(() => {
+      mockUseMetricsSession.mockReturnValue({
+        ...baseMockContext,
+        hasScit: false,
+        hasTli: false,
+        teenSessions: [],
+      })
+    })
+
+    it('does NOT render the Teens quick-pick option', async () => {
+      const user = userEvent.setup()
+      render(<MetricsSessionSelector />)
+
+      const button = screen.getByRole('button')
+      await user.click(button)
+
+      expect(screen.queryByRole('option', { name: 'Teens' })).not.toBeInTheDocument()
+    })
+
+    it('does NOT render the Teen Programs group label', async () => {
+      const user = userEvent.setup()
+      render(<MetricsSessionSelector />)
+
+      const button = screen.getByRole('button')
+      await user.click(button)
+
+      expect(screen.queryByText('Teen Programs')).not.toBeInTheDocument()
+    })
+
+    it('does NOT render SCIT or TLI options', async () => {
+      const user = userEvent.setup()
+      render(<MetricsSessionSelector />)
+
+      const button = screen.getByRole('button')
+      await user.click(button)
+
+      expect(screen.queryByRole('option', { name: 'SCIT' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('option', { name: 'TLI' })).not.toBeInTheDocument()
+    })
+  })
+
+  describe('display label when teen type is selected', () => {
+    it('shows "SCIT" as display label when selectedTeenType is "scit"', () => {
+      mockUseMetricsSession.mockReturnValue({
+        ...baseMockContext,
+        selectedTeenType: 'scit',
+      })
+      render(<MetricsSessionSelector />)
+      expect(screen.getByRole('button')).toHaveTextContent('SCIT')
+    })
+
+    it('shows "TLI" as display label when selectedTeenType is "tli"', () => {
+      mockUseMetricsSession.mockReturnValue({
+        ...baseMockContext,
+        selectedTeenType: 'tli',
+      })
+      render(<MetricsSessionSelector />)
+      expect(screen.getByRole('button')).toHaveTextContent('TLI')
+    })
+
+    it('shows "Teens" as display label when viewMode is "teens" and no selectedTeenType', () => {
+      mockUseMetricsSession.mockReturnValue({
+        ...baseMockContext,
+        viewMode: 'teens' as const,
+        selectedTeenType: null,
+      })
+      render(<MetricsSessionSelector />)
+      expect(screen.getByRole('button')).toHaveTextContent('Teens')
+    })
+  })
+})

--- a/frontend/src/components/metrics/MetricsSessionSelector.tsx
+++ b/frontend/src/components/metrics/MetricsSessionSelector.tsx
@@ -5,10 +5,11 @@
  * across most metrics tabs (hidden on Bunk Analysis tab which uses unfiltered data).
  *
  * Dropdown structure:
- * - At Camp / Quests / All Summer (type groupings)
+ * - At Camp / Quests / Teens / All Summer (type groupings)
  * - By Duration section (1 Week, 2 Week, etc.)
  * - Camp Sessions section (individual camp sessions)
  * - Quests section (individual quest sessions)
+ * - Teen Programs section (individual SCIT / TLI sessions)
  */
 
 import { Listbox, ListboxButton, ListboxOptions, ListboxOption } from '@headlessui/react'

--- a/frontend/src/components/metrics/MetricsSessionSelector.tsx
+++ b/frontend/src/components/metrics/MetricsSessionSelector.tsx
@@ -19,7 +19,9 @@ import type { DurationCategory } from '../../utils/sessionUtils'
 const ALL_SESSIONS_VALUE = 'all-sessions'
 const ALL_QUESTS_VALUE = 'all-quests'
 const ALL_SUMMER_VALUE = 'all-summer'
+const ALL_TEENS_VALUE = 'all-teens'
 const DURATION_PREFIX = 'duration:'
+const TEEN_PREFIX = 'teen:'
 
 /** Display labels for duration categories */
 const DURATION_LABELS: Record<DurationCategory, string> = {
@@ -42,29 +44,43 @@ export function MetricsSessionSelector() {
     campSessions,
     questSessions,
     durationGroups,
+    hasScit,
+    hasTli,
+    selectedTeenType,
+    setSelectedTeenType,
   } = useMetricsSession()
 
   // Display name for current selection
   const displayName = selectedSession
     ? selectedSession.name
-    : selectedDuration
-      ? DURATION_LABELS[selectedDuration]
-      : viewMode === 'all'
-        ? 'All Summer'
-        : viewMode === 'quests'
-          ? 'Quests'
-          : 'At Camp'
+    : selectedTeenType
+      ? selectedTeenType === 'scit'
+        ? 'SCIT'
+        : 'TLI'
+      : selectedDuration
+        ? DURATION_LABELS[selectedDuration]
+        : viewMode === 'all'
+          ? 'All Summer'
+          : viewMode === 'quests'
+            ? 'Quests'
+            : viewMode === 'teens'
+              ? 'Teens'
+              : 'At Camp'
 
   // Determine current listbox value
   const currentValue = selectedSessionCmId
     ? selectedSessionCmId.toString()
-    : selectedDuration
-      ? `${DURATION_PREFIX}${selectedDuration}`
-      : viewMode === 'all'
-        ? ALL_SUMMER_VALUE
-        : viewMode === 'quests'
-          ? ALL_QUESTS_VALUE
-          : ALL_SESSIONS_VALUE
+    : selectedTeenType
+      ? `${TEEN_PREFIX}${selectedTeenType}`
+      : selectedDuration
+        ? `${DURATION_PREFIX}${selectedDuration}`
+        : viewMode === 'all'
+          ? ALL_SUMMER_VALUE
+          : viewMode === 'quests'
+            ? ALL_QUESTS_VALUE
+            : viewMode === 'teens'
+              ? ALL_TEENS_VALUE
+              : ALL_SESSIONS_VALUE
 
   const handleChange = (value: string) => {
     if (value === ALL_SESSIONS_VALUE) {
@@ -73,6 +89,10 @@ export function MetricsSessionSelector() {
       setViewMode('quests')
     } else if (value === ALL_SUMMER_VALUE) {
       setViewMode('all')
+    } else if (value === ALL_TEENS_VALUE) {
+      setViewMode('teens')
+    } else if (value.startsWith(TEEN_PREFIX)) {
+      setSelectedTeenType(value.slice(TEEN_PREFIX.length) as 'scit' | 'tli')
     } else if (value.startsWith(DURATION_PREFIX)) {
       setSelectedDuration(value.slice(DURATION_PREFIX.length) as DurationCategory)
     } else {
@@ -96,6 +116,11 @@ export function MetricsSessionSelector() {
             <ListboxOption value={ALL_SESSIONS_VALUE} className="listbox-option">
               At Camp
             </ListboxOption>
+            {(hasScit || hasTli) && (
+              <ListboxOption value={ALL_TEENS_VALUE} className="listbox-option">
+                Teens
+              </ListboxOption>
+            )}
             <ListboxOption value={ALL_QUESTS_VALUE} className="listbox-option">
               Quests
             </ListboxOption>
@@ -144,6 +169,29 @@ export function MetricsSessionSelector() {
                     {session.name}
                   </ListboxOption>
                 ))}
+              </div>
+            )}
+
+            {/* Teen Programs (SCIT / TLI) */}
+            {(hasScit || hasTli) && (
+              <div role="group" aria-labelledby="teen-programs-group-label">
+                <div className="border-border my-1 border-t" />
+                <div
+                  id="teen-programs-group-label"
+                  className="text-muted-foreground px-3 py-1 text-[10px] font-semibold tracking-wider uppercase"
+                >
+                  Teen Programs
+                </div>
+                {hasScit && (
+                  <ListboxOption value={`${TEEN_PREFIX}scit`} className="listbox-option">
+                    SCIT
+                  </ListboxOption>
+                )}
+                {hasTli && (
+                  <ListboxOption value={`${TEEN_PREFIX}tli`} className="listbox-option">
+                    TLI
+                  </ListboxOption>
+                )}
               </div>
             )}
 

--- a/frontend/src/contexts/MetricsSessionContext.test.tsx
+++ b/frontend/src/contexts/MetricsSessionContext.test.tsx
@@ -1,13 +1,16 @@
 /**
  * Tests for MetricsSessionContext - URL-based session state for metrics module
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, act } from '@testing-library/react'
-import { MemoryRouter, useSearchParams } from 'react-router'
+import { renderHook } from '@testing-library/react'
+import { MemoryRouter, Routes, Route, useSearchParams, useLocation } from 'react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
 import { MetricsSessionProvider } from './MetricsSessionContext'
 import { useMetricsSession } from '../hooks/useMetricsSession'
 import { CurrentYearContext, type CurrentYearContextType } from '../hooks/useCurrentYear'
+import type { MetricsSession } from '../hooks/useMetricsSessions'
 
 // Mock useMetricsSessions hook
 vi.mock('../hooks/useMetricsSessions', () => ({
@@ -607,3 +610,267 @@ describe('MetricsSessionContext "all" viewMode', () => {
     })
   })
 })
+
+// =============================================================================
+// Teen session derivation tests
+//
+// Uses a separate session fixture that includes end_date (required for duration
+// grouping) and teen sessions (scit, tli).
+// Wrapped in an outer describe so beforeEach only affects these blocks.
+// =============================================================================
+
+// Import the mocked hook so we can swap its return value per-describe.
+import { useMetricsSessions } from '../hooks/useMetricsSessions'
+
+const TEEN_TEST_SESSIONS: MetricsSession[] = [
+  {
+    cm_id: 1,
+    name: 'Session 1',
+    session_type: 'main',
+    start_date: '2025-06-15',
+    end_date: '2025-07-05',
+  },
+  {
+    cm_id: 2,
+    name: 'Session 4',
+    session_type: 'main',
+    start_date: '2025-07-20',
+    end_date: '2025-08-02',
+  },
+  {
+    cm_id: 3,
+    name: 'Quest',
+    session_type: 'quest',
+    start_date: '2025-06-22',
+    end_date: '2025-07-06',
+  },
+  {
+    cm_id: 4,
+    name: 'SCIT',
+    session_type: 'scit',
+    start_date: '2025-06-08',
+    end_date: '2025-07-04',
+  },
+  {
+    cm_id: 5,
+    name: 'TLI',
+    session_type: 'tli',
+    start_date: '2025-07-11',
+    end_date: '2025-08-03',
+  },
+]
+
+// URL probe — captures latest search string after each act()
+let lastSearch = ''
+function LocationProbe() {
+  const loc = useLocation()
+  lastSearch = loc.search
+  return null
+}
+
+// Wrapper that uses MemoryRouter (for URL control) + MetricsSessionProvider + probe
+function makeTeenWrapper(initialEntry = '/') {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const mockYearContext: CurrentYearContextType = {
+    currentYear: 2025,
+    setCurrentYear: vi.fn(),
+    availableYears: [2025, 2024],
+    isTransitioning: false,
+    isYearReady: true,
+  }
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={[initialEntry]}>
+          <Routes>
+            <Route
+              path="*"
+              element={
+                <CurrentYearContext value={mockYearContext}>
+                  <MetricsSessionProvider>
+                    {children}
+                    <LocationProbe />
+                  </MetricsSessionProvider>
+                </CurrentYearContext>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+  }
+}
+
+describe('MetricsSessionProvider — teen features', () => {
+  beforeEach(() => {
+    lastSearch = ''
+    vi.mocked(useMetricsSessions).mockReturnValue({
+      data: TEEN_TEST_SESSIONS,
+      isLoading: false,
+    } as ReturnType<typeof useMetricsSessions>)
+  })
+
+  describe('MetricsSessionProvider — teen session derivation', () => {
+    it('teenSessions contains only scit and tli (cm_ids 4, 5)', () => {
+      const { result } = renderHook(() => useMetricsSession(), { wrapper: makeTeenWrapper() })
+      const ids = result.current.teenSessions.map((s) => s.cm_id)
+      expect(ids).toContain(4)
+      expect(ids).toContain(5)
+      expect(ids).toHaveLength(2)
+    })
+
+    it('campSessions contains only main/embedded (cm_ids 1, 2) — NOT teens or quest', () => {
+      const { result } = renderHook(() => useMetricsSession(), { wrapper: makeTeenWrapper() })
+      const ids = result.current.campSessions.map((s) => s.cm_id)
+      expect(ids).toContain(1)
+      expect(ids).toContain(2)
+      expect(ids).not.toContain(3) // quest
+      expect(ids).not.toContain(4) // scit
+      expect(ids).not.toContain(5) // tli
+      expect(ids).toHaveLength(2)
+    })
+
+    it('questSessions contains only quest (cm_id 3)', () => {
+      const { result } = renderHook(() => useMetricsSession(), { wrapper: makeTeenWrapper() })
+      const ids = result.current.questSessions.map((s) => s.cm_id)
+      expect(ids).toEqual([3])
+    })
+
+    it('hasScit is true when scit session present', () => {
+      const { result } = renderHook(() => useMetricsSession(), { wrapper: makeTeenWrapper() })
+      expect(result.current.hasScit).toBe(true)
+    })
+
+    it('hasTli is true when tli session present', () => {
+      const { result } = renderHook(() => useMetricsSession(), { wrapper: makeTeenWrapper() })
+      expect(result.current.hasTli).toBe(true)
+    })
+  })
+
+  describe('MetricsSessionProvider — view mode + teen session types', () => {
+    it("setViewMode('teens') → sessionTypesParam === 'scit,tli'", () => {
+      const { result } = renderHook(() => useMetricsSession(), { wrapper: makeTeenWrapper() })
+      act(() => result.current.setViewMode('teens'))
+      expect(result.current.sessionTypesParam).toBe('scit,tli')
+    })
+
+    it("setViewMode('all') → sessionTypesParam contains scit and tli", () => {
+      const { result } = renderHook(() => useMetricsSession(), { wrapper: makeTeenWrapper() })
+      act(() => result.current.setViewMode('all'))
+      expect(result.current.sessionTypesParam).toContain('scit')
+      expect(result.current.sessionTypesParam).toContain('tli')
+    })
+
+    it("setViewMode('teens') writes view=teens to URL", () => {
+      const { result } = renderHook(() => useMetricsSession(), { wrapper: makeTeenWrapper() })
+      act(() => result.current.setViewMode('teens'))
+      expect(lastSearch).toContain('view=teens')
+    })
+  })
+
+  describe('MetricsSessionProvider — selectedTeenType', () => {
+    it('selectedTeenType is null initially', () => {
+      const { result } = renderHook(() => useMetricsSession(), { wrapper: makeTeenWrapper() })
+      expect(result.current.selectedTeenType).toBeNull()
+    })
+
+    it('derives selectedTeenType from ?teen=scit on reload (parse path)', () => {
+      const { result } = renderHook(() => useMetricsSession(), {
+        wrapper: makeTeenWrapper('/?teen=scit'),
+      })
+      expect(result.current.selectedTeenType).toBe('scit')
+    })
+
+    it("setSelectedTeenType('scit') → sessionTypesParam === 'scit'", () => {
+      const { result } = renderHook(() => useMetricsSession(), { wrapper: makeTeenWrapper() })
+      act(() => result.current.setSelectedTeenType('scit'))
+      expect(result.current.sessionTypesParam).toBe('scit')
+    })
+
+    it("setSelectedTeenType('tli') → sessionTypesParam === 'tli'", () => {
+      const { result } = renderHook(() => useMetricsSession(), { wrapper: makeTeenWrapper() })
+      act(() => result.current.setSelectedTeenType('tli'))
+      expect(result.current.sessionTypesParam).toBe('tli')
+    })
+
+    it('setSelectedTeenType writes teen param to URL', () => {
+      const { result } = renderHook(() => useMetricsSession(), { wrapper: makeTeenWrapper() })
+      act(() => result.current.setSelectedTeenType('scit'))
+      expect(lastSearch).toContain('teen=scit')
+    })
+
+    it('setSelectedTeenType(null) clears the teen param', () => {
+      const { result } = renderHook(() => useMetricsSession(), {
+        wrapper: makeTeenWrapper('/?teen=scit'),
+      })
+      act(() => result.current.setSelectedTeenType(null))
+      expect(lastSearch).not.toContain('teen=')
+    })
+  })
+
+  describe('MetricsSessionProvider — mutual exclusion with teen param', () => {
+    it('setViewMode clears teen param', () => {
+      const { result } = renderHook(() => useMetricsSession(), {
+        wrapper: makeTeenWrapper('/?teen=scit'),
+      })
+      act(() => result.current.setViewMode('sessions'))
+      expect(lastSearch).not.toContain('teen=')
+    })
+
+    it('setSelectedTeenType clears view param', () => {
+      const { result } = renderHook(() => useMetricsSession(), {
+        wrapper: makeTeenWrapper('/?view=teens'),
+      })
+      act(() => result.current.setSelectedTeenType('tli'))
+      expect(lastSearch).not.toContain('view=')
+    })
+
+    it('setSelectedTeenType clears session param', () => {
+      const { result } = renderHook(() => useMetricsSession(), {
+        wrapper: makeTeenWrapper('/?session=1'),
+      })
+      act(() => result.current.setSelectedTeenType('scit'))
+      expect(lastSearch).not.toContain('session=')
+    })
+
+    it('setSelectedTeenType clears duration param', () => {
+      const { result } = renderHook(() => useMetricsSession(), {
+        wrapper: makeTeenWrapper('/?duration=3-week'),
+      })
+      act(() => result.current.setSelectedTeenType('scit'))
+      expect(lastSearch).not.toContain('duration=')
+    })
+
+    it('setSelectedDuration clears teen param', () => {
+      const { result } = renderHook(() => useMetricsSession(), {
+        wrapper: makeTeenWrapper('/?teen=scit'),
+      })
+      act(() => result.current.setSelectedDuration('2-week'))
+      expect(lastSearch).not.toContain('teen=')
+    })
+
+    it('setSelectedSessionCmId clears teen param', () => {
+      const { result } = renderHook(() => useMetricsSession(), {
+        wrapper: makeTeenWrapper('/?teen=scit'),
+      })
+      act(() => result.current.setSelectedSessionCmId(1))
+      expect(lastSearch).not.toContain('teen=')
+    })
+  })
+
+  describe('MetricsSessionProvider — durationGroups includes teen sessions', () => {
+    it('durationGroups includes SCIT (cm_id 4) — 27 days → 4-week+', () => {
+      const { result } = renderHook(() => useMetricsSession(), { wrapper: makeTeenWrapper() })
+      const allGrouped = Array.from(result.current.durationGroups.values()).flat()
+      const ids = allGrouped.map((s) => s.cm_id)
+      expect(ids).toContain(4)
+    })
+
+    it('durationGroups includes TLI (cm_id 5) — 24 days → 4-week+', () => {
+      const { result } = renderHook(() => useMetricsSession(), { wrapper: makeTeenWrapper() })
+      const allGrouped = Array.from(result.current.durationGroups.values()).flat()
+      const ids = allGrouped.map((s) => s.cm_id)
+      expect(ids).toContain(5)
+    })
+  })
+}) // end describe('MetricsSessionProvider — teen features')

--- a/frontend/src/contexts/MetricsSessionContext.tsx
+++ b/frontend/src/contexts/MetricsSessionContext.tsx
@@ -5,8 +5,10 @@
  * (Registration, Retention, Trends). Session selection persists in URL
  * params (?session=<cm_id>) and survives tab navigation.
  *
- * View mode (?view=quests) switches between camp sessions and quest sessions.
- * Default (no view param) shows camp sessions only.
+ * View mode (?view=) selects a session-type grouping: 'quests' (quest
+ * sessions), 'teens' (SCIT/TLI), or 'all' (every summer type including teens).
+ * Default (no view param) shows camp sessions only. Individual teen sessions
+ * are selected via ?teen=<scit|tli>, never via ?session=<cm_id>.
  *
  * Duration filter (?duration=<category>) filters sessions by length category
  * (e.g., "1-week", "2-week"). Mutually exclusive with session selection --

--- a/frontend/src/contexts/MetricsSessionContext.tsx
+++ b/frontend/src/contexts/MetricsSessionContext.tsx
@@ -30,7 +30,9 @@ import {
   AT_CAMP_TYPES,
   QUEST_SESSION_TYPES,
   SUMMER_CAMP_TYPES,
+  TEEN_PROGRAM_TYPES,
   isQuestSession,
+  isMainOrEmbedded,
   type MetricsViewMode,
 } from '../utils/sessionTypePredicates'
 
@@ -38,6 +40,7 @@ const SESSION_PARAM = 'session'
 const VIEW_PARAM = 'view'
 const COMPARE_PARAM = 'compare'
 const DURATION_PARAM = 'duration'
+const TEEN_PARAM = 'teen'
 
 /**
  * Parse session param from URL
@@ -67,7 +70,18 @@ function parseDurationParam(param: string | null): DurationCategory | null {
 function parseViewParam(param: string | null): MetricsViewMode {
   if (param === 'quests') return 'quests'
   if (param === 'all') return 'all'
+  if (param === 'teens') return 'teens'
   return 'sessions'
+}
+
+/**
+ * Parse teen type param from URL
+ * Returns null for invalid/missing values
+ */
+function parseTeenTypeParam(param: string | null): 'scit' | 'tli' | null {
+  if (param === 'scit') return 'scit'
+  if (param === 'tli') return 'tli'
+  return null
 }
 
 export function MetricsSessionProvider({ children }: { children: ReactNode }) {
@@ -98,6 +112,11 @@ export function MetricsSessionProvider({ children }: { children: ReactNode }) {
     return parseSessionParam(searchParams.get(COMPARE_PARAM))
   }, [searchParams])
 
+  // Get selected teen type from URL param
+  const selectedTeenType = useMemo(() => {
+    return parseTeenTypeParam(searchParams.get(TEEN_PARAM))
+  }, [searchParams])
+
   const isComparing = compareYear !== null
 
   // Find the selected session object
@@ -108,30 +127,49 @@ export function MetricsSessionProvider({ children }: { children: ReactNode }) {
 
   // Derive active session types based on view mode and selection
   const activeSessionTypes = useMemo(() => {
+    // SUMMER_CAMP_TYPES excludes scit/tli, and the backend applies session_types
+    // AND session_cm_id conjunctively. Teen programs are intentionally selected
+    // via selectedTeenType (type-based), NEVER via setSelectedSessionCmId. If a
+    // future change makes individual teen sessions cm_id-selectable, this branch
+    // MUST include the teen types or it will silently zero out the selected
+    // session's own attendees (session_type ∈ SUMMER_CAMP_TYPES filters them all out).
     if (selectedSessionCmId !== null) return SUMMER_CAMP_TYPES
-    if (selectedDuration) return AT_CAMP_TYPES
-    if (viewMode === 'all') return SUMMER_CAMP_TYPES
+    if (selectedTeenType) return [selectedTeenType] as const
+    if (selectedDuration) return [...AT_CAMP_TYPES, ...TEEN_PROGRAM_TYPES] as const
+    if (viewMode === 'all') return [...SUMMER_CAMP_TYPES, ...TEEN_PROGRAM_TYPES] as const
+    if (viewMode === 'teens') return TEEN_PROGRAM_TYPES
     if (viewMode === 'quests') return QUEST_SESSION_TYPES
     return AT_CAMP_TYPES
-  }, [selectedSessionCmId, selectedDuration, viewMode])
+  }, [selectedSessionCmId, selectedTeenType, selectedDuration, viewMode])
 
   const sessionTypesParam = useMemo(() => {
     return activeSessionTypes.join(',')
   }, [activeSessionTypes])
 
-  // Split sessions into camp and quest groups
+  // Split sessions into camp (main/embedded only), quest, and teen groups
   const campSessions = useMemo(() => {
-    return sortSessionsByDate(sessions.filter((s) => !isQuestSession(s)))
+    return sortSessionsByDate(sessions.filter(isMainOrEmbedded))
   }, [sessions])
 
   const questSessions = useMemo(() => {
     return sortSessionsByDate(sessions.filter(isQuestSession))
   }, [sessions])
 
-  // Group camp sessions by duration for dropdown
+  const teenSessions = useMemo(() => {
+    return sortSessionsByDate(
+      sessions.filter((s) =>
+        TEEN_PROGRAM_TYPES.includes(s.session_type as (typeof TEEN_PROGRAM_TYPES)[number])
+      )
+    )
+  }, [sessions])
+
+  const hasScit = useMemo(() => teenSessions.some((s) => s.session_type === 'scit'), [teenSessions])
+  const hasTli = useMemo(() => teenSessions.some((s) => s.session_type === 'tli'), [teenSessions])
+
+  // Group camp + teen sessions by duration for dropdown
   const durationGroups = useMemo(() => {
-    return groupSessionsByDuration(campSessions)
-  }, [campSessions])
+    return groupSessionsByDuration([...campSessions, ...teenSessions])
+  }, [campSessions, teenSessions])
 
   // Duration param for API calls
   const durationParam = selectedDuration ?? undefined
@@ -147,7 +185,7 @@ export function MetricsSessionProvider({ children }: { children: ReactNode }) {
     [sessionTypesParam, selectedSessionCmId, durationParam]
   )
 
-  // Set duration filter (clears session and view params)
+  // Set duration filter (clears session, view, and teen params)
   const setSelectedDuration = useCallback(
     (duration: DurationCategory | null) => {
       setSearchParams(
@@ -155,6 +193,7 @@ export function MetricsSessionProvider({ children }: { children: ReactNode }) {
           const newParams = new URLSearchParams(prev)
           newParams.delete(SESSION_PARAM)
           newParams.delete(VIEW_PARAM)
+          newParams.delete(TEEN_PARAM)
           if (duration) {
             newParams.set(DURATION_PARAM, duration)
           } else {
@@ -168,13 +207,14 @@ export function MetricsSessionProvider({ children }: { children: ReactNode }) {
     [setSearchParams]
   )
 
-  // Update URL param when session changes (clears view and duration params)
+  // Update URL param when session changes (clears view, duration, and teen params)
   const setSelectedSessionCmId = useCallback(
     (cmId: number | null) => {
       setSearchParams(
         (prev) => {
           const newParams = new URLSearchParams(prev)
           newParams.delete(DURATION_PARAM)
+          newParams.delete(TEEN_PARAM)
           if (cmId === null) {
             newParams.delete(SESSION_PARAM)
           } else {
@@ -189,7 +229,7 @@ export function MetricsSessionProvider({ children }: { children: ReactNode }) {
     [setSearchParams]
   )
 
-  // Set view mode (clears session and duration params)
+  // Set view mode (clears session, duration, and teen params)
   const setViewMode = useCallback(
     (mode: MetricsViewMode) => {
       setSearchParams(
@@ -197,12 +237,37 @@ export function MetricsSessionProvider({ children }: { children: ReactNode }) {
           const newParams = new URLSearchParams(prev)
           newParams.delete(SESSION_PARAM)
           newParams.delete(DURATION_PARAM)
+          newParams.delete(TEEN_PARAM)
           if (mode === 'quests') {
             newParams.set(VIEW_PARAM, 'quests')
           } else if (mode === 'all') {
             newParams.set(VIEW_PARAM, 'all')
+          } else if (mode === 'teens') {
+            newParams.set(VIEW_PARAM, 'teens')
           } else {
             newParams.delete(VIEW_PARAM)
+          }
+          return newParams
+        },
+        { replace: true }
+      )
+    },
+    [setSearchParams]
+  )
+
+  // Set teen sub-type (clears session, view, and duration params)
+  const setSelectedTeenType = useCallback(
+    (t: 'scit' | 'tli' | null) => {
+      setSearchParams(
+        (prev) => {
+          const newParams = new URLSearchParams(prev)
+          newParams.delete(SESSION_PARAM)
+          newParams.delete(VIEW_PARAM)
+          newParams.delete(DURATION_PARAM)
+          if (t) {
+            newParams.set(TEEN_PARAM, t)
+          } else {
+            newParams.delete(TEEN_PARAM)
           }
           return newParams
         },
@@ -250,6 +315,11 @@ export function MetricsSessionProvider({ children }: { children: ReactNode }) {
       sessionTypesParam,
       campSessions,
       questSessions,
+      teenSessions,
+      hasScit,
+      hasTli,
+      selectedTeenType,
+      setSelectedTeenType,
       selectedDuration,
       setSelectedDuration,
       durationParam,
@@ -274,6 +344,11 @@ export function MetricsSessionProvider({ children }: { children: ReactNode }) {
       sessionTypesParam,
       campSessions,
       questSessions,
+      teenSessions,
+      hasScit,
+      hasTli,
+      selectedTeenType,
+      setSelectedTeenType,
       selectedDuration,
       setSelectedDuration,
       durationParam,

--- a/frontend/src/hooks/useDay1.test.ts
+++ b/frontend/src/hooks/useDay1.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests for useDay1 hook.
+ *
+ * Verifies the Day 1 hook forwards the session-type filter (emitted by the
+ * shared metrics session picker) to the backend, so Day 1 honors the picker
+ * like every other registration page.
+ *
+ * TDD: Tests written BEFORE implementation.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '../test/testUtils'
+import { useDay1 } from './useDay1'
+
+const mockFetchWithAuth = vi.fn()
+
+vi.mock('./useApiWithAuth', () => ({
+  useApiWithAuth: () => ({
+    fetchWithAuth: mockFetchWithAuth,
+    isAuthenticated: true,
+    isAuthLoading: false,
+  }),
+}))
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ isLoading: false }),
+}))
+
+describe('useDay1', () => {
+  beforeEach(() => {
+    mockFetchWithAuth.mockReset()
+    mockFetchWithAuth.mockResolvedValue({
+      ok: true,
+      json: async () => ({ year: 2026, tiers: [], prior_years: [] }),
+    })
+  })
+
+  it('requests only the year when no session types are passed', async () => {
+    renderHook(() => useDay1(2026), { wrapper: createWrapper() })
+
+    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalled())
+    const url = String(mockFetchWithAuth.mock.calls[0]?.[0])
+    expect(url).toContain('year=2026')
+    expect(url).not.toContain('session_types')
+  })
+
+  it('forwards session_types to the endpoint when provided', async () => {
+    renderHook(() => useDay1(2026, 'main,embedded,ag,quest,scit,tli'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalled())
+    const url = decodeURIComponent(String(mockFetchWithAuth.mock.calls[0]?.[0]))
+    expect(url).toContain('session_types=main,embedded,ag,quest,scit,tli')
+  })
+})

--- a/frontend/src/hooks/useDay1.ts
+++ b/frontend/src/hooks/useDay1.ts
@@ -4,14 +4,15 @@ import { useApiWithAuth } from './useApiWithAuth'
 import { queryKeys, syncDataOptions } from '../utils/queryKeys'
 import type { Day1Response } from '../types/day1'
 
-export function useDay1(year: number) {
+export function useDay1(year: number, sessionTypes?: string) {
   const { fetchWithAuth } = useApiWithAuth()
   const { isLoading } = useAuth()
 
   return useQuery<Day1Response>({
-    queryKey: queryKeys.day1(year),
+    queryKey: queryKeys.day1(year, sessionTypes),
     queryFn: async () => {
       const params = new URLSearchParams({ year: String(year) })
+      if (sessionTypes) params.set('session_types', sessionTypes)
       const response = await fetchWithAuth(`/api/metrics/registration/day1?${params}`)
       if (!response.ok) {
         const error = await response.json().catch(() => ({}))

--- a/frontend/src/hooks/useMetricsSession.ts
+++ b/frontend/src/hooks/useMetricsSession.ts
@@ -31,10 +31,20 @@ export interface MetricsSessionContextType {
   activeSessionTypes: readonly string[]
   /** Comma-joined activeSessionTypes for API calls */
   sessionTypesParam: string
-  /** Non-quest sessions, sorted by date */
+  /** Main/embedded sessions only, sorted by date */
   campSessions: MetricsSession[]
   /** Quest sessions only, sorted by date */
   questSessions: MetricsSession[]
+  /** scit/tli sessions for the year (window-gated upstream), sorted by date */
+  teenSessions: MetricsSession[]
+  /** Whether any summer SCIT sessions exist this year */
+  hasScit: boolean
+  /** Whether any summer TLI sessions exist this year */
+  hasTli: boolean
+  /** Currently selected teen sub-type (null = none) */
+  selectedTeenType: 'scit' | 'tli' | null
+  /** Select a teen sub-type (clears session/duration/view) */
+  setSelectedTeenType: (t: 'scit' | 'tli' | null) => void
   /** Currently selected duration category (null = no duration filter) */
   selectedDuration: DurationCategory | null
   /** Set the duration filter and clear session selection */
@@ -43,7 +53,7 @@ export interface MetricsSessionContextType {
   durationParam: string | undefined
   /** Pre-built filter options for metrics hooks (sessionTypes + sessionCmId/duration, mutually exclusive) */
   filterOptions: MetricsFilterOptions
-  /** Camp sessions grouped by duration, for the dropdown */
+  /** Camp + teen sessions grouped by duration, for the dropdown */
   durationGroups: Map<DurationCategory, MetricsSession[]>
   /** Whether expanded retention analysis is enabled (5 years instead of 3) */
   expandedRetention: boolean

--- a/frontend/src/hooks/useMetricsSessions.test.ts
+++ b/frontend/src/hooks/useMetricsSessions.test.ts
@@ -3,8 +3,41 @@
  *
  * TDD: These tests define the expected behavior before implementation.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '../test/testUtils'
 import type { MetricsSession } from './useMetricsSessions'
+
+const mockGetFullList = vi.fn()
+const mockCollection = vi.fn((_name: string) => ({ getFullList: mockGetFullList }))
+
+vi.mock('../lib/pocketbase', () => ({
+  pb: {
+    collection: (name: string) => mockCollection(name),
+  },
+}))
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: '1', email: 'test@example.com' },
+    isLoading: false,
+    isAuthenticated: true,
+    isBypassMode: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    error: null,
+    checkAuth: vi.fn(),
+    pb: {},
+  }),
+}))
+
+import { useMetricsSessions } from './useMetricsSessions'
+
+beforeEach(() => {
+  mockGetFullList.mockReset()
+  mockCollection.mockClear()
+  mockGetFullList.mockResolvedValue([])
+})
 
 describe('useMetricsSessions', () => {
   it('should export useMetricsSessions hook', async () => {
@@ -64,6 +97,67 @@ describe('useMetricsSessions', () => {
       expect(sorted[1]?.name).toBe('Session 3')
       expect(sorted[2]?.name).toBe('Session 4')
     })
+  })
+})
+
+describe('useMetricsSessions teen window-gate wiring', () => {
+  it('includes summer scit + tli, excludes off-season fall scit (filter string + window gate together)', async () => {
+    // Two main sessions anchor the summer window (~2025-06-15 → 2025-08-02).
+    // Summer scit and tli overlap that window; the fall scit does not.
+    mockGetFullList.mockResolvedValue([
+      {
+        cm_id: 1,
+        name: 'Session 1',
+        session_type: 'main',
+        start_date: '2025-06-15',
+        end_date: '2025-06-28',
+      },
+      {
+        cm_id: 2,
+        name: 'Session 4',
+        session_type: 'main',
+        start_date: '2025-07-20',
+        end_date: '2025-08-02',
+      },
+      {
+        cm_id: 3,
+        name: 'SCIT Summer',
+        session_type: 'scit',
+        start_date: '2025-06-08',
+        end_date: '2025-07-04',
+      },
+      {
+        cm_id: 4,
+        name: 'TLI Summer',
+        session_type: 'tli',
+        start_date: '2025-07-11',
+        end_date: '2025-08-03',
+      },
+      {
+        cm_id: 5,
+        name: 'SCIT Fall',
+        session_type: 'scit',
+        start_date: '2025-09-12',
+        end_date: '2025-09-15',
+      },
+    ])
+
+    const { result } = renderHook(() => useMetricsSessions(2025), { wrapper: createWrapper() })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    // The filter widened to fetch teens too.
+    expect(mockCollection).toHaveBeenCalledWith('camp_sessions')
+    const callArg = mockGetFullList.mock.calls[0]?.[0] as { filter?: string } | undefined
+    expect(callArg?.filter).toContain('session_type = "scit"')
+    expect(callArg?.filter).toContain('session_type = "tli"')
+
+    const cmIds = (result.current.data ?? []).map((s) => s.cm_id)
+    expect(cmIds).toContain(1) // main
+    expect(cmIds).toContain(2) // main
+    expect(cmIds).toContain(3) // summer scit overlaps window
+    expect(cmIds).toContain(4) // summer tli overlaps window
+    expect(cmIds).not.toContain(5) // fall scit is off-season → gated out
+    expect(result.current.data).toHaveLength(4)
   })
 })
 

--- a/frontend/src/hooks/useMetricsSessions.ts
+++ b/frontend/src/hooks/useMetricsSessions.ts
@@ -1,7 +1,9 @@
 /**
  * Hook to fetch sessions for the metrics session dropdown.
  *
- * Returns main and embedded sessions for a given year, sorted by start_date.
+ * Returns main, embedded, quest, scit, and tli sessions for a given year,
+ * sorted by start_date. Teen sessions (scit/tli) are window-gated so only
+ * those overlapping the summer main-session window reach the picker.
  */
 
 import { useQuery, keepPreviousData } from '@tanstack/react-query'
@@ -9,11 +11,16 @@ import { queryKeys, syncDataOptions } from '../utils/queryKeys'
 import { pb } from '../lib/pocketbase'
 import { sortSessionsByDate } from '../utils/sessionUtils'
 import { useAuth } from '../contexts/AuthContext'
+import {
+  getSummerWindow,
+  isSummerTeenSession,
+  TEEN_PROGRAM_TYPES,
+} from '../utils/sessionTypePredicates'
 
 export interface MetricsSession {
   cm_id: number
   name: string
-  session_type: 'main' | 'embedded' | 'quest'
+  session_type: 'main' | 'embedded' | 'quest' | 'scit' | 'tli'
   start_date: string
   end_date: string
 }
@@ -21,8 +28,10 @@ export interface MetricsSession {
 /**
  * Fetch sessions available for the metrics session dropdown.
  *
- * Returns main, embedded, and quest session types (not ag, family, etc.)
- * since those are the summer camp sessions for metrics analysis.
+ * Returns main, embedded, quest, scit, and tli session types (not ag, family,
+ * etc.) since those are the summer camp sessions for metrics analysis. Teen
+ * sessions (scit/tli) are window-gated against the summer main-session window
+ * so off-season teen programs never appear in the picker.
  */
 export function useMetricsSessions(year: number) {
   const { isLoading } = useAuth()
@@ -31,18 +40,27 @@ export function useMetricsSessions(year: number) {
     queryKey: queryKeys.metricsSessions(year),
     queryFn: async (): Promise<MetricsSession[]> => {
       const sessions = await pb.collection('camp_sessions').getFullList({
-        filter: `year = ${year} && (session_type = "main" || session_type = "embedded" || session_type = "quest")`,
+        filter: `year = ${year} && (session_type = "main" || session_type = "embedded" || session_type = "quest" || session_type = "scit" || session_type = "tli")`,
         sort: 'start_date',
       })
 
       const mapped = sessions.map((s) => ({
         cm_id: s.cm_id,
         name: s.name,
-        session_type: s.session_type as 'main' | 'embedded' | 'quest',
+        session_type: s.session_type as 'main' | 'embedded' | 'quest' | 'scit' | 'tli',
         start_date: s.start_date,
         end_date: s.end_date,
       }))
-      return sortSessionsByDate(mapped)
+
+      // Gate teen sessions to only those overlapping the summer main-session window.
+      // Non-teen sessions pass through unchanged.
+      const window = getSummerWindow(mapped)
+      const gated = mapped.filter(
+        (s) =>
+          !TEEN_PROGRAM_TYPES.includes(s.session_type as (typeof TEEN_PROGRAM_TYPES)[number]) ||
+          isSummerTeenSession(s, window)
+      )
+      return sortSessionsByDate(gated)
     },
     enabled: year > 0 && !isLoading,
     placeholderData: keepPreviousData,

--- a/frontend/src/pages/metrics/registration/Day1Page.test.tsx
+++ b/frontend/src/pages/metrics/registration/Day1Page.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Tests for Day1Page.
+ *
+ * Day 1 is a registration metrics page and must honor the shared session
+ * picker like its siblings: the picker's session_types flow into the Day 1
+ * query, and teen (SCIT/TLI) counts surface as their own breakdown.
+ *
+ * TDD: Tests written BEFORE implementation.
+ */
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import Day1Page from './Day1Page'
+import type { Day1Response } from '../../../types/day1'
+
+vi.mock('../../../hooks/useCurrentYear', () => ({
+  useCurrentYear: vi.fn(() => ({ currentYear: 2026 })),
+  CurrentYearContext: { Provider: ({ children }: { children: React.ReactNode }) => children },
+}))
+
+const mockUseMetricsSession = vi.fn()
+vi.mock('../../../hooks/useMetricsSession', () => ({
+  useMetricsSession: () => mockUseMetricsSession(),
+}))
+
+const mockUseDay1 = vi.fn()
+vi.mock('../../../hooks/useDay1', () => ({
+  useDay1: (...args: unknown[]) => mockUseDay1(...args),
+}))
+
+/** A past-dated priority tier so the hero card renders its breakdown (not "Upcoming"). */
+function makeData(teenCount: number): Day1Response {
+  return {
+    year: 2026,
+    tiers: [
+      {
+        tier: 'priority',
+        tier_label: 'Priority Registration',
+        date: '2025-11-12',
+        window_start: '2025-11-12T00:00:00-08:00',
+        window_end: '2025-11-13T00:00:00-08:00',
+        categories: [
+          { category: 'at_camp', label: 'At Camp', count: 10 },
+          { category: 'quest', label: 'Quest', count: 3 },
+          { category: 'teen', label: 'Teens', count: teenCount },
+        ],
+        total: { count: 13 + teenCount },
+        approximate: false,
+      },
+    ],
+    prior_years: [],
+  }
+}
+
+function setSession(sessionTypesParam: string) {
+  mockUseMetricsSession.mockReturnValue({
+    selectedSessionCmId: null,
+    selectedSession: undefined,
+    sessions: [],
+    isLoading: false,
+    viewMode: 'sessions',
+    activeSessionTypes: sessionTypesParam.split(','),
+    sessionTypesParam,
+    campSessions: [],
+    questSessions: [],
+  })
+}
+
+const renderPage = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Day1Page />
+    </QueryClientProvider>
+  )
+}
+
+describe('Day1Page', () => {
+  beforeEach(() => {
+    mockUseMetricsSession.mockReset()
+    mockUseDay1.mockReset()
+  })
+
+  it('forwards the picker session_types into the Day 1 query', () => {
+    setSession('main,embedded,ag,quest,scit,tli')
+    mockUseDay1.mockReturnValue({ data: makeData(4), isLoading: false, error: null })
+
+    renderPage()
+
+    expect(mockUseDay1).toHaveBeenCalledWith(2026, 'main,embedded,ag,quest,scit,tli')
+  })
+
+  it('renders a Teens breakdown when teen counts are present', () => {
+    setSession('main,embedded,ag,quest,scit,tli')
+    mockUseDay1.mockReturnValue({ data: makeData(4), isLoading: false, error: null })
+
+    renderPage()
+
+    expect(screen.getAllByText('Teens').length).toBeGreaterThan(0)
+    // Teen count surfaces in both the hero chip and the comparison-table row.
+    expect(screen.getAllByText('4').length).toBeGreaterThan(0)
+  })
+
+  it('omits the Teens breakdown when there are no teen counts', () => {
+    setSession('main,embedded,ag')
+    mockUseDay1.mockReturnValue({ data: makeData(0), isLoading: false, error: null })
+
+    renderPage()
+
+    expect(screen.queryByText('Teens')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/metrics/registration/Day1Page.tsx
+++ b/frontend/src/pages/metrics/registration/Day1Page.tsx
@@ -1,9 +1,14 @@
 /**
  * Day1Page - First-24-hour registration analysis per tier opening.
  *
+ * Honors the shared metrics session picker (like every other registration
+ * page): the picker's session_types flow into the Day 1 query, so "All Summer"
+ * includes teens and "Teens" scopes to SCIT/TLI.
+ *
  * Shows:
  * - Hero cards (one per tier: priority/early/open) with current year totals
- * - Comparison table with At Camp / Quest / Total rows across tiers and years
+ * - Comparison table with At Camp / Quest / Teens / Total rows across tiers and
+ *   years (the Teens row appears only when teen counts are present)
  * - Delta indicators vs prior year
  * - Approximate count indicators when data is reconstructed
  */
@@ -11,6 +16,7 @@
 import { useMemo } from 'react'
 import { useCurrentYear } from '../../../hooks/useCurrentYear'
 import { useDay1 } from '../../../hooks/useDay1'
+import { useMetricsSession } from '../../../hooks/useMetricsSession'
 import { MetricsQueryGuard } from '../../../components/metrics/MetricsQueryGuard'
 import type { Day1Response, Day1TierData, Day1YearData } from '../../../types/day1'
 
@@ -101,6 +107,7 @@ function HeroCard({ tier, priorYears }: HeroCardProps) {
   const upcoming = isFutureTier(tier)
   const atCamp = getCategoryCount(tier, 'at_camp')
   const quest = getCategoryCount(tier, 'quest')
+  const teen = getCategoryCount(tier, 'teen')
 
   // Find prior year data for delta
   const priorYear = priorYears.length > 0 ? priorYears[0] : undefined
@@ -158,6 +165,12 @@ function HeroCard({ tier, priorYears }: HeroCardProps) {
                 <span className="font-semibold">{fmtCount(quest)}</span>
               </div>
             )}
+            {teen !== null && teen > 0 && (
+              <div>
+                <span className={config.accent}>Teens</span>{' '}
+                <span className="font-semibold">{fmtCount(teen)}</span>
+              </div>
+            )}
           </div>
 
           {/* Delta vs prior year */}
@@ -184,19 +197,25 @@ const TIER_LABELS: Array<{ tier: string; label: string }> = [
   { tier: 'open', label: 'Open' },
 ]
 
-/** Row categories for the comparison table */
-const ROW_CATEGORIES = [
-  { key: 'at_camp', label: 'At Camp' },
-  { key: 'quest', label: 'Quest' },
-  { key: 'total', label: 'Total' },
-]
-
 interface ComparisonTableProps {
   data: Day1Response
   currentYear: number
 }
 
 function ComparisonTable({ data, currentYear }: ComparisonTableProps) {
+  // The Teens row only appears when any tier (current or prior year) has teen
+  // counts, so the default At Camp / Quest views stay uncluttered.
+  const rowCategories = useMemo(() => {
+    const allTiers: Day1TierData[] = [...data.tiers, ...data.prior_years.flatMap((py) => py.tiers)]
+    const hasTeens = allTiers.some((t) => (getCategoryCount(t, 'teen') ?? 0) > 0)
+    return [
+      { key: 'at_camp', label: 'At Camp' },
+      { key: 'quest', label: 'Quest' },
+      ...(hasTeens ? [{ key: 'teen', label: 'Teens' }] : []),
+      { key: 'total', label: 'Total' },
+    ]
+  }, [data])
+
   // Build ordered year list: current year first, then prior years
   const years = useMemo(() => {
     const result = [currentYear]
@@ -283,7 +302,7 @@ function ComparisonTable({ data, currentYear }: ComparisonTableProps) {
           </tr>
         </thead>
         <tbody>
-          {ROW_CATEGORIES.map((row) => (
+          {rowCategories.map((row) => (
             <tr
               key={row.key}
               className={
@@ -318,7 +337,8 @@ function ComparisonTable({ data, currentYear }: ComparisonTableProps) {
 
 export default function Day1Page() {
   const { currentYear } = useCurrentYear()
-  const { data, isLoading, error } = useDay1(currentYear)
+  const { sessionTypesParam } = useMetricsSession()
+  const { data, isLoading, error } = useDay1(currentYear, sessionTypesParam)
 
   return (
     <div className="space-y-6">

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -8879,6 +8879,12 @@ export type GetDay1ApiMetricsRegistrationDay1GetData = {
      * Camp year
      */
     year: number
+    /**
+     * Session Types
+     *
+     * Comma-separated session types to filter (e.g., 'main,quest')
+     */
+    session_types?: string | null
   }
   url: '/api/metrics/registration/day1'
 }

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -823,13 +823,13 @@ export type Day1Category = {
   /**
    * Category
    *
-   * 'at_camp' or 'quest'
+   * 'at_camp', 'quest', or 'teen'
    */
   category: string
   /**
    * Label
    *
-   * 'At Camp' or 'Quest'
+   * 'At Camp', 'Quest', or 'Teens'
    */
   label: string
   /**

--- a/frontend/src/types/day1.ts
+++ b/frontend/src/types/day1.ts
@@ -3,7 +3,7 @@ export interface Day1CategoryCounts {
 }
 
 export interface Day1Category {
-  category: 'at_camp' | 'quest'
+  category: 'at_camp' | 'quest' | 'teen'
   label: string
   count: number
 }

--- a/frontend/src/utils/__tests__/sessionTypePredicates.test.ts
+++ b/frontend/src/utils/__tests__/sessionTypePredicates.test.ts
@@ -29,6 +29,8 @@ import {
   QUEST_SESSION_TYPES,
   SESSION_TYPE_LITERALS,
   buildSummerSessionTypeFilter,
+  getSummerWindow,
+  isSummerTeenSession,
 } from '../sessionTypePredicates'
 import type { Session } from '../../types/app-types'
 
@@ -104,9 +106,10 @@ describe('typed set exports', () => {
     expect(SUMMER_CAMP_TYPES).not.toContain('teen')
   })
 
-  it('TEEN_PROGRAM_TYPES contains tli, teen', () => {
+  it('TEEN_PROGRAM_TYPES contains scit, tli (not teen/winter)', () => {
+    expect(TEEN_PROGRAM_TYPES).toContain('scit')
     expect(TEEN_PROGRAM_TYPES).toContain('tli')
-    expect(TEEN_PROGRAM_TYPES).toContain('teen')
+    expect(TEEN_PROGRAM_TYPES).not.toContain('teen')
     expect(TEEN_PROGRAM_TYPES).not.toContain('main')
     expect(TEEN_PROGRAM_TYPES).not.toContain('quest')
   })
@@ -250,12 +253,12 @@ describe('isSummerCampSession', () => {
 })
 
 // ============================================================================
-// isTeenProgram — tli | teen
+// isTeenProgram — scit | tli
 // ============================================================================
 
 describe('isTeenProgram', () => {
-  const trueFor: AllType[] = ['tli', 'teen']
-  const falseFor: AllType[] = ['main', 'embedded', 'ag', 'quest', 'family', 'scit']
+  const trueFor: AllType[] = ['scit', 'tli']
+  const falseFor: AllType[] = ['main', 'embedded', 'ag', 'quest', 'family', 'teen']
 
   trueFor.forEach((t) => {
     it(`returns true for "${t}"`, () => {
@@ -412,8 +415,9 @@ describe('isSummerCampSessionType (string predicate)', () => {
 })
 
 describe('isTeenProgramType (string predicate)', () => {
+  it('returns true for "scit"', () => expect(isTeenProgramType('scit')).toBe(true))
   it('returns true for "tli"', () => expect(isTeenProgramType('tli')).toBe(true))
-  it('returns true for "teen"', () => expect(isTeenProgramType('teen')).toBe(true))
+  it('returns false for "teen"', () => expect(isTeenProgramType('teen')).toBe(false))
   it('returns false for "main"', () => expect(isTeenProgramType('main')).toBe(false))
 })
 
@@ -434,7 +438,7 @@ describe('exhaustiveness: every known literal is covered by at least one predica
       isQuestSession(s) ||
       isTeenProgram(s) ||
       s.session_type === 'family' ||
-      s.session_type === 'scit' ||
+      s.session_type === 'teen' ||
       s.session_type === 'bmitzvah' ||
       s.session_type === 'adult' ||
       s.session_type === 'school' ||
@@ -448,5 +452,37 @@ describe('exhaustiveness: every known literal is covered by at least one predica
       .filter(([, covered]) => !covered)
       .map(([t]) => t)
     expect(uncovered).toEqual([])
+  })
+})
+
+// ============================================================================
+// Teen cohort — summer-window helpers (mirror api/utils/session_metrics.py)
+// ============================================================================
+
+describe('teen cohort', () => {
+  const sess = (session_type: string, start_date: string, end_date: string) =>
+    ({ session_type, start_date, end_date }) as never
+
+  it('TEEN_PROGRAM_TYPES is scit + tli (not teen/winter)', () => {
+    expect(TEEN_PROGRAM_TYPES).toEqual(['scit', 'tli'])
+  })
+
+  it('getSummerWindow spans main sessions', () => {
+    const window = getSummerWindow([
+      sess('main', '2025-06-15', '2025-07-05'),
+      sess('main', '2025-07-20', '2025-08-02'),
+      sess('quest', '2025-09-01', '2025-09-05'),
+    ])
+    expect(window).toEqual(['2025-06-15', '2025-08-02'])
+  })
+
+  it('isSummerTeenSession includes summer scit/tli, excludes off-season', () => {
+    const w: [string, string] = ['2025-06-15', '2025-08-02']
+    expect(isSummerTeenSession(sess('scit', '2025-06-08', '2025-07-04'), w)).toBe(true)
+    expect(isSummerTeenSession(sess('tli', '2025-07-11', '2025-08-03'), w)).toBe(true)
+    expect(isSummerTeenSession(sess('scit', '2025-09-12', '2025-09-15'), w)).toBe(false) // fall
+    expect(isSummerTeenSession(sess('tli', '2025-08-23', '2026-05-01'), w)).toBe(false) // interns
+    expect(isSummerTeenSession(sess('main', '2025-06-15', '2025-07-05'), w)).toBe(false)
+    expect(isSummerTeenSession(sess('scit', '2025-06-08', '2025-07-04'), null)).toBe(false)
   })
 })

--- a/frontend/src/utils/allCampersUtils.test.ts
+++ b/frontend/src/utils/allCampersUtils.test.ts
@@ -9,6 +9,7 @@ import {
   FILTER_ALL,
   FILTER_AT_CAMP,
   FILTER_QUESTS,
+  FILTER_TEENS,
   type SessionWithType,
 } from './allCampersUtils'
 import type { BunksResponse, BunkPlansResponse } from '../types/pocketbase-types'
@@ -468,19 +469,54 @@ describe('allCampersUtils', () => {
     })
   })
 
-  // ── #6: Teen-program exclusion ───────────────────────────────────────────
-  describe('getDropdownSessions — teen program exclusion (#6)', () => {
-    it('should EXCLUDE tli sessions from the picker', () => {
+  // ── #6: Teen-program inclusion (window-gated) ────────────────────────────
+  describe('getDropdownSessions — teen program inclusion (#6)', () => {
+    it('should INCLUDE summer-window-overlapping tli sessions in the picker', () => {
+      // Both sessions share the same default dates → tli overlaps the window
       const sessions = [
         createMockSession({ name: 'Session 2', session_type: 'main' }),
         createMockSession({ name: 'TLI: Rising 11th', session_type: 'tli' }),
+      ]
+      const result = getDropdownSessions(sessions)
+      expect(result).toHaveLength(2)
+      expect(result.map((s: Session) => s.name)).toContain('Session 2')
+      expect(result.map((s: Session) => s.name)).toContain('TLI: Rising 11th')
+    })
+
+    it('should INCLUDE summer-window-overlapping scit sessions in the picker', () => {
+      const sessions = [
+        createMockSession({ name: 'Session 3', session_type: 'main' }),
+        createMockSession({ name: 'SCIT: Rising 12th', session_type: 'scit' }),
+      ]
+      const result = getDropdownSessions(sessions)
+      expect(result).toHaveLength(2)
+      expect(result.map((s: Session) => s.name)).toContain('Session 3')
+      expect(result.map((s: Session) => s.name)).toContain('SCIT: Rising 12th')
+    })
+
+    it('should EXCLUDE off-season teen sessions (no window overlap)', () => {
+      // off-season tli has dates that don't overlap the main-session window
+      const sessions = [
+        createMockSession({
+          name: 'Session 2',
+          session_type: 'main',
+          start_date: '2025-06-01',
+          end_date: '2025-06-14',
+        }),
+        createMockSession({
+          name: 'TLI: Fall Program',
+          session_type: 'tli',
+          start_date: '2025-09-01',
+          end_date: '2025-09-14',
+        }),
       ]
       const result = getDropdownSessions(sessions)
       expect(result).toHaveLength(1)
       expect(result[0]?.name).toBe('Session 2')
     })
 
-    it('should EXCLUDE teen sessions from the picker', () => {
+    it('should EXCLUDE legacy "teen" session_type (not in TEEN_PROGRAM_TYPES)', () => {
+      // session_type 'teen' is not the same as 'scit' or 'tli'
       const sessions = [
         createMockSession({ name: 'Session 3', session_type: 'main' }),
         createMockSession({ name: 'SCIT: Rising 12th', session_type: 'teen' }),
@@ -490,19 +526,85 @@ describe('allCampersUtils', () => {
       expect(result[0]?.name).toBe('Session 3')
     })
 
-    it('should still include quest sessions after teen exclusion', () => {
+    it('should include quest sessions alongside summer teen sessions', () => {
       const sessions = [
         createMockSession({ name: 'Session 2', session_type: 'main' }),
         createMockSession({ name: 'Quest: Pacific Crest', session_type: 'quest' }),
         createMockSession({ name: 'TLI: Rising 11th', session_type: 'tli' }),
-        createMockSession({ name: 'SCIT: Rising 12th', session_type: 'teen' }),
+        createMockSession({ name: 'SCIT: Rising 12th', session_type: 'scit' }),
+        createMockSession({ name: 'Legacy Teen', session_type: 'teen' }),
       ]
       const result = getDropdownSessions(sessions)
-      expect(result).toHaveLength(2)
+      // main + quest + tli + scit (4); 'teen' type excluded
+      expect(result).toHaveLength(4)
       expect(result.map((s: Session) => s.name)).toContain('Session 2')
       expect(result.map((s: Session) => s.name)).toContain('Quest: Pacific Crest')
-      expect(result.map((s: Session) => s.name)).not.toContain('TLI: Rising 11th')
-      expect(result.map((s: Session) => s.name)).not.toContain('SCIT: Rising 12th')
+      expect(result.map((s: Session) => s.name)).toContain('TLI: Rising 11th')
+      expect(result.map((s: Session) => s.name)).toContain('SCIT: Rising 12th')
+      expect(result.map((s: Session) => s.name)).not.toContain('Legacy Teen')
+    })
+  })
+
+  // ── FILTER_TEENS constant ─────────────────────────────────────────────────
+  describe('FILTER_TEENS constant', () => {
+    it('equals the string "teens"', () => {
+      expect(FILTER_TEENS).toBe('teens')
+    })
+  })
+
+  // ── resolveScopedSessions with FILTER_TEENS ───────────────────────────────
+  describe('resolveScopedSessions — FILTER_TEENS', () => {
+    const mainSession = createMockSession({ name: 'Session 2', session_type: 'main', id: 'main-2' })
+    const questSession = createMockSession({
+      name: 'Quest: Pacific Crest',
+      session_type: 'quest',
+      id: 'quest-1',
+    })
+    const scitSession = createMockSession({
+      name: 'SCIT: Rising 12th',
+      session_type: 'scit',
+      id: 'scit-1',
+    })
+    const tliSession = createMockSession({
+      name: 'TLI: Rising 11th',
+      session_type: 'tli',
+      id: 'tli-1',
+    })
+    const allSessions = [mainSession, questSession, scitSession, tliSession]
+
+    it(`'${FILTER_TEENS}' returns only teen sessions`, () => {
+      const result = resolveScopedSessions(FILTER_TEENS, allSessions)
+      expect(result).toHaveLength(2)
+      expect(result.map((s) => s.id)).toContain('scit-1')
+      expect(result.map((s) => s.id)).toContain('tli-1')
+    })
+
+    it(`'${FILTER_TEENS}' returns empty array when no teen sessions present`, () => {
+      const result = resolveScopedSessions(FILTER_TEENS, [mainSession, questSession])
+      expect(result).toEqual([])
+    })
+  })
+
+  // ── getSessionRelationshipsForCamperView — teen sessions ──────────────────
+  describe('getSessionRelationshipsForCamperView — teen sessions', () => {
+    it('teen sessions map to themselves (independent self-entry)', () => {
+      const sessions: SessionWithType[] = [
+        createMockSession({ name: 'SCIT: Rising 12th', session_type: 'scit', id: 'scit-1' }),
+        createMockSession({ name: 'TLI: Rising 11th', session_type: 'tli', id: 'tli-1' }),
+      ]
+      const relationships = getSessionRelationshipsForCamperView(sessions)
+      expect(relationships.get('scit-1')).toEqual(['scit-1'])
+      expect(relationships.get('tli-1')).toEqual(['tli-1'])
+    })
+
+    it('teen sessions are independent of main sessions', () => {
+      const sessions: SessionWithType[] = [
+        createMockSession({ name: 'Session 2', session_type: 'main', id: 'main-2' }),
+        createMockSession({ name: 'SCIT: Rising 12th', session_type: 'scit', id: 'scit-1' }),
+      ]
+      const relationships = getSessionRelationshipsForCamperView(sessions)
+      expect(relationships.get('main-2')).toEqual(['main-2'])
+      expect(relationships.get('scit-1')).toEqual(['scit-1'])
     })
   })
 
@@ -683,6 +785,73 @@ describe('allCampersUtils', () => {
     it('embedded sessions count as at-camp for noun purposes', () => {
       const embeddedSessions = [createMockSession({ name: 'Session 2a', session_type: 'embedded' })]
       expect(getCampersHeadlineNoun(embeddedSessions, 2)).toBe('campers')
+    })
+  })
+
+  // ── getCampersHeadlineNoun — teens (#10) ──────────────────────────────────
+  describe('getCampersHeadlineNoun — teens (#10)', () => {
+    it('returns "teen"/"teens" when only teen sessions are selected', () => {
+      const teenSessions = [
+        createMockSession({ name: 'SCIT: Rising 12th', session_type: 'scit' }),
+        createMockSession({ name: 'TLI: Rising 11th', session_type: 'tli' }),
+      ]
+      expect(getCampersHeadlineNoun(teenSessions, 1)).toBe('teen')
+      expect(getCampersHeadlineNoun(teenSessions, 5)).toBe('teens')
+    })
+
+    it('returns "campers and teens" when at-camp + teen only', () => {
+      const sessions = [
+        createMockSession({ name: 'Session 2', session_type: 'main' }),
+        createMockSession({ name: 'SCIT: Rising 12th', session_type: 'scit' }),
+      ]
+      expect(getCampersHeadlineNoun(sessions, 1)).toBe('camper and teen')
+      expect(getCampersHeadlineNoun(sessions, 5)).toBe('campers and teens')
+    })
+
+    it('returns "questers and teens" when quest + teen only', () => {
+      const sessions = [
+        createMockSession({ name: 'Quest: Pacific Crest', session_type: 'quest' }),
+        createMockSession({ name: 'TLI: Rising 11th', session_type: 'tli' }),
+      ]
+      expect(getCampersHeadlineNoun(sessions, 5)).toBe('questers and teens')
+    })
+
+    it('returns "campers, questers, and teens" when all three cohorts present', () => {
+      const sessions = [
+        createMockSession({ name: 'Session 2', session_type: 'main' }),
+        createMockSession({ name: 'Quest: Pacific Crest', session_type: 'quest' }),
+        createMockSession({ name: 'SCIT: Rising 12th', session_type: 'scit' }),
+      ]
+      expect(getCampersHeadlineNoun(sessions, 5)).toBe('campers, questers, and teens')
+    })
+
+    it('singular "camper, quester, and teen" for count=1 all three cohorts', () => {
+      const sessions = [
+        createMockSession({ name: 'Session 2', session_type: 'main' }),
+        createMockSession({ name: 'Quest: Pacific Crest', session_type: 'quest' }),
+        createMockSession({ name: 'TLI: Rising 11th', session_type: 'tli' }),
+      ]
+      expect(getCampersHeadlineNoun(sessions, 1)).toBe('camper, quester, and teen')
+    })
+
+    it('no-teen fixtures remain unchanged (at-camp only)', () => {
+      const atCampSessions = [createMockSession({ name: 'Session 2', session_type: 'main' })]
+      expect(getCampersHeadlineNoun(atCampSessions, 5)).toBe('campers')
+    })
+
+    it('no-teen fixtures remain unchanged (quest only)', () => {
+      const questSessions = [
+        createMockSession({ name: 'Quest: Pacific Crest', session_type: 'quest' }),
+      ]
+      expect(getCampersHeadlineNoun(questSessions, 5)).toBe('questers')
+    })
+
+    it('no-teen fixtures remain unchanged (at-camp + quest)', () => {
+      const sessions = [
+        createMockSession({ name: 'Session 2', session_type: 'main' }),
+        createMockSession({ name: 'Quest: Pacific Crest', session_type: 'quest' }),
+      ]
+      expect(getCampersHeadlineNoun(sessions, 5)).toBe('campers and questers')
     })
   })
 })

--- a/frontend/src/utils/allCampersUtils.ts
+++ b/frontend/src/utils/allCampersUtils.ts
@@ -17,6 +17,9 @@ import {
   isMainSession,
   isEmbeddedSession,
   isAtCampSession,
+  isTeenProgram,
+  getSummerWindow,
+  isSummerTeenSession,
 } from './sessionTypePredicates'
 
 // Export type alias for sessions with type information
@@ -49,15 +52,14 @@ export function filterSummerCampBunks(
 /**
  * Get sessions for the dropdown in AllCampers view
  * - Includes: main, embedded, quest sessions
- * - Excludes: AG (grouped with parent), family, training, etc.
- * - Embedded and quest sessions are independent entries (not grouped with main)
+ * - Includes: scit/tli teen sessions that overlap the summer main-session window
+ * - Excludes: AG (grouped with parent), family, training, off-season teen sessions, etc.
+ * - Embedded, quest, and teen sessions are independent entries (not grouped with main)
  */
 export function getDropdownSessions(sessions: Session[]): Session[] {
-  // Filter to only dropdown-eligible session types
-  const filteredSessions = sessions.filter(isInDropdown)
-
-  // Sort using shared utility (date primary, then session number+suffix)
-  return sortSessionsByDate(filteredSessions)
+  const window = getSummerWindow(sessions)
+  const filtered = sessions.filter((s) => isInDropdown(s) || isSummerTeenSession(s, window))
+  return sortSessionsByDate(filtered)
 }
 
 /**
@@ -106,6 +108,9 @@ export function getSessionRelationshipsForCamperView(
     } else if (isQuestSession(session)) {
       // Quest sessions are independent - only include themselves
       relationships.set(session.id, [session.id])
+    } else if (isTeenProgram(session)) {
+      // Teen sessions are independent - only include themselves
+      relationships.set(session.id, [session.id])
     }
   })
 
@@ -121,13 +126,15 @@ export function getSessionRelationshipsForCamperView(
 //              included in the camper-filter even though AG never appears in
 //              dropdownSessions itself)
 // 'quests'   → quest only
+// 'teens'    → scit + tli (summer-window-gated teen programs only)
 //
 // resolveScopedSessions returns the dropdown-level scope list for the headline
 // noun. Camper-level filtering in AllCampersView walks sessionRelationships
-// for AT_CAMP / QUESTS so AG inclusion comes from a single source of truth.
+// for AT_CAMP / QUESTS / TEENS so AG inclusion comes from a single source of truth.
 export const FILTER_ALL = 'all'
 export const FILTER_AT_CAMP = 'at-camp'
 export const FILTER_QUESTS = 'quests'
+export const FILTER_TEENS = 'teens'
 
 /**
  * Split an already-filtered dropdown session list into camp sessions
@@ -163,6 +170,9 @@ export function resolveScopedSessions(filterValue: string, dropdownSessions: Ses
   if (filterValue === FILTER_QUESTS) {
     return dropdownSessions.filter(isQuestSession)
   }
+  if (filterValue === FILTER_TEENS) {
+    return dropdownSessions.filter(isTeenProgram)
+  }
   // Specific session ID
   const match = dropdownSessions.find((s) => s.id === filterValue)
   return match ? [match] : []
@@ -172,10 +182,12 @@ export function resolveScopedSessions(filterValue: string, dropdownSessions: Ses
  * Return the collective noun for the /campers page header based on which
  * session types are represented in `sessions`.
  *
- * Rules (spec #5):
+ * Rules (spec #5 + #10):
  *   - At-camp only (main / embedded / ag)  → "camper" / "campers"
  *   - Quest only                            → "quester" / "questers"
- *   - Mixed at-camp + quest                 → "camper and quester" / "campers and questers"
+ *   - Teen only (scit / tli)                → "teen" / "teens"
+ *   - Mixed two cohorts                     → Oxford "X and Y"
+ *   - All three cohorts                     → Oxford "campers, questers, and teens"
  *
  * `count` controls singular vs plural.
  * Only collective count nouns are affected; individual-referring copy
@@ -183,16 +195,14 @@ export function resolveScopedSessions(filterValue: string, dropdownSessions: Ses
  */
 export function getCampersHeadlineNoun(sessions: Session[], count: number): string {
   const plural = count !== 1
+  const parts: string[] = []
 
-  const hasAtCamp = sessions.some(isAtCampSession)
-  const hasQuest = sessions.some(isQuestSession)
+  if (sessions.some(isAtCampSession)) parts.push(plural ? 'campers' : 'camper')
+  if (sessions.some(isQuestSession)) parts.push(plural ? 'questers' : 'quester')
+  if (sessions.some(isTeenProgram)) parts.push(plural ? 'teens' : 'teen')
 
-  if (hasAtCamp && hasQuest) {
-    return plural ? 'campers and questers' : 'camper and quester'
-  }
-  if (hasQuest) {
-    return plural ? 'questers' : 'quester'
-  }
-  // Default: at-camp only (or empty list — fall back to "campers")
-  return plural ? 'campers' : 'camper'
+  if (parts.length === 0 || parts[0] === undefined) return plural ? 'campers' : 'camper'
+  if (parts.length === 1) return parts[0]
+  if (parts.length === 2) return `${parts[0]} and ${parts[1]}`
+  return `${parts[0]}, ${parts[1]}, and ${parts[2]}`
 }

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -315,7 +315,7 @@ export const queryKeys = {
   geoOverrideCoords: (year: number) => ['geo', 'override-coords', year] as const,
 
   // Day 1 Registration (Tier 1 - sync data, historical analysis)
-  day1: (year: number) => ['metrics', 'day1', year] as const,
+  day1: (year: number, sessionTypes?: string) => ['metrics', 'day1', year, sessionTypes] as const,
 
   // Velocity (Tier 1 - sync data, historical analysis)
   velocity: (

--- a/frontend/src/utils/sessionTypePredicates.ts
+++ b/frontend/src/utils/sessionTypePredicates.ts
@@ -33,10 +33,10 @@ export const SUMMER_CAMP_TYPES = ['main', 'embedded', 'ag', 'quest'] as const
 export const QUEST_SESSION_TYPES = ['quest'] as const
 
 /** Teen program session types */
-export const TEEN_PROGRAM_TYPES = ['tli', 'teen'] as const
+export const TEEN_PROGRAM_TYPES = ['scit', 'tli'] as const
 
-/** View mode for metrics: camp sessions, quest sessions, or all combined */
-export type MetricsViewMode = 'sessions' | 'quests' | 'all'
+/** View mode for metrics: camp sessions, quest sessions, all combined, or teens */
+export type MetricsViewMode = 'sessions' | 'quests' | 'all' | 'teens'
 
 /**
  * Every known session_type literal from the PocketBase CampSessionsSessionTypeOptions enum.
@@ -115,7 +115,7 @@ export function isSummerCampSession(session: SessionLike): boolean {
   return SUMMER_CAMP_TYPES.includes(session.session_type as (typeof SUMMER_CAMP_TYPES)[number])
 }
 
-/** True for teen programs: tli, teen */
+/** True for teen programs: scit, tli */
 export function isTeenProgram(session: SessionLike): boolean {
   return TEEN_PROGRAM_TYPES.includes(session.session_type as (typeof TEEN_PROGRAM_TYPES)[number])
 }
@@ -174,7 +174,7 @@ export function isSummerCampSessionType(sessionType: string | null | undefined):
   return SUMMER_CAMP_TYPES.includes(sessionType as (typeof SUMMER_CAMP_TYPES)[number])
 }
 
-/** True if the session_type string is a teen program (tli | teen) */
+/** True if the session_type string is a teen program (scit | tli) */
 export function isTeenProgramType(sessionType: string | null | undefined): boolean {
   return TEEN_PROGRAM_TYPES.includes(sessionType as (typeof TEEN_PROGRAM_TYPES)[number])
 }
@@ -192,6 +192,39 @@ export function isTeenProgramType(sessionType: string | null | undefined): boole
  */
 export function buildSummerSessionTypeFilter(): string {
   return SUMMER_CAMP_TYPES.map((t) => `session.session_type = "${t}"`).join(' || ')
+}
+
+// ============================================================================
+// Summer-teen window helpers (mirror api/utils/session_metrics.py)
+// ============================================================================
+
+/** Min main start / max main end (YYYY-MM-DD), or null. Mirrors get_summer_window(). */
+export function getSummerWindow(
+  sessions: Array<{ session_type?: string | null; start_date: string; end_date: string }>
+): [string, string] | null {
+  const starts: string[] = []
+  const ends: string[] = []
+  for (const s of sessions) {
+    if (s.session_type !== 'main') continue
+    if (s.start_date && s.end_date) {
+      starts.push(s.start_date.slice(0, 10))
+      ends.push(s.end_date.slice(0, 10))
+    }
+  }
+  if (!starts.length || !ends.length) return null
+  return [starts.reduce((a, b) => (a < b ? a : b)), ends.reduce((a, b) => (a > b ? a : b))]
+}
+
+/** True iff a scit/tli session overlaps the summer window. Mirrors is_summer_teen_session(). */
+export function isSummerTeenSession(
+  session: { session_type?: string | null; start_date?: string; end_date?: string },
+  window: [string, string] | null
+): boolean {
+  if (!TEEN_PROGRAM_TYPES.includes(session.session_type as (typeof TEEN_PROGRAM_TYPES)[number]))
+    return false
+  if (!window || !session.start_date || !session.end_date) return false
+  const [winStart, winEnd] = window
+  return session.start_date.slice(0, 10) <= winEnd && session.end_date.slice(0, 10) >= winStart
 }
 
 // ============================================================================

--- a/tests/unit/api/test_cancellation_service.py
+++ b/tests/unit/api/test_cancellation_service.py
@@ -481,3 +481,63 @@ class TestRegistrationMonthBreakdown:
         # Months must be chronologically ordered: Mar 2025 → Nov 2025 → Jan 2026
         months = [m.month for m in result.by_registration_month]
         assert months == ["Mar 2025", "Nov 2025", "Jan 2026"]
+
+
+class TestTeenCrossSessionEnrollment:
+    """A cancelled teen who is still enrolled in another teen session must count
+    as 'has other sessions', not a true departure. The cross-session enrollment
+    lookup has to span teen programs (SCIT/TLI), not just summer-camp types.
+    """
+
+    @pytest.mark.asyncio
+    async def test_teen_kept_in_other_teen_session_counts_as_has_other(
+        self, cancellation_service, mock_repository, sample_persons
+    ):
+        scit = create_mock_session(2001, "SCIT", 2026, "scit", "2026-06-15", "2026-07-05")
+        tli = create_mock_session(2002, "TLI", 2026, "tli", "2026-06-15", "2026-07-05")
+        summer_sessions = {
+            1001: create_mock_session(1001, "Session 1", 2026, "main", "2026-06-15", "2026-07-05"),
+        }
+        teen_sessions = {2001: scit, 2002: tli}
+
+        # Olivia (103) cancelled SCIT but is still enrolled in TLI.
+        cancelled = [
+            create_mock_attendee(
+                103,
+                session_cm_id=scit.cm_id,
+                session=scit,
+                status="cancelled",
+                effective_date="2026-01-10",
+            ),
+        ]
+        enrolled = [
+            create_mock_attendee(
+                103,
+                session_cm_id=tli.cm_id,
+                session=tli,
+                status="enrolled",
+                effective_date="2025-11-10",
+            ),
+        ]
+
+        def fetch_sessions_side_effect(year, session_types=None):
+            requested = set(session_types or [])
+            # Teen-only requests (the teen-enrollment lookup and the Teens filter)
+            # resolve to teen sessions; everything else is summer camp.
+            if requested and requested <= {"scit", "tli"}:
+                return teen_sessions
+            return summer_sessions
+
+        mock_repository.fetch_sessions = AsyncMock(side_effect=fetch_sessions_side_effect)
+        mock_repository.fetch_persons.return_value = sample_persons
+        mock_repository.fetch_attendees = AsyncMock(
+            side_effect=lambda year, status_filter=None: (
+                cancelled if status_filter == ["cancelled", "withdrawn", "dismissed"] else enrolled
+            )
+        )
+        mock_repository.fetch_status_history = AsyncMock(return_value=[])
+
+        result = await cancellation_service.calculate_cancellations(year=2026, session_types=["scit", "tli"])
+
+        assert result.has_other_sessions == 1
+        assert result.no_other_sessions == 0

--- a/tests/unit/api/test_day1_service.py
+++ b/tests/unit/api/test_day1_service.py
@@ -260,3 +260,38 @@ async def test_day1_session_types_quest_only():
     # Only the 1 quest attendee passes the filter
     assert priority_tier.total.count == 1
     assert priority_tier.total.count < 3  # fewer than unfiltered (None = 3)
+
+
+@pytest.mark.asyncio
+async def test_day1_session_types_scit_only_counts_teens():
+    """session_types=['scit'] counts the teen attendee in a dedicated 'teen' bucket.
+
+    Regression guard: previously scit/tli fell through both AT_CAMP_TYPES and
+    QUEST_TYPES, so any teen-only filter silently returned a total of 0.
+    """
+    repo = _make_repo_with_mixed_sessions()
+    service = Day1Service(repo)
+    result = await service.get_day1(2026, session_types=["scit"])
+
+    priority_tier = next(t for t in result.tiers if t.tier == "priority")
+    teen = next(c for c in priority_tier.categories if c.category == "teen")
+    assert teen.count == 1
+    assert priority_tier.total.count == 1
+
+
+@pytest.mark.asyncio
+async def test_day1_session_types_all_including_teens():
+    """A filter covering camp + quest + teen counts all three buckets."""
+    repo = _make_repo_with_mixed_sessions()
+    service = Day1Service(repo)
+    result = await service.get_day1(2026, session_types=["main", "embedded", "ag", "quest", "scit", "tli"])
+
+    priority_tier = next(t for t in result.tiers if t.tier == "priority")
+    at_camp = next(c for c in priority_tier.categories if c.category == "at_camp")
+    quest = next(c for c in priority_tier.categories if c.category == "quest")
+    teen = next(c for c in priority_tier.categories if c.category == "teen")
+    assert at_camp.count == 2
+    assert quest.count == 1
+    assert teen.count == 1
+    # 2 main + 1 quest + 1 scit
+    assert priority_tier.total.count == 4

--- a/tests/unit/api/test_day1_service.py
+++ b/tests/unit/api/test_day1_service.py
@@ -10,6 +10,7 @@ from api.services.day1_service import Day1Service
 def _make_attendee(
     *,
     session_cm_id: int,
+    session_type: str = "main",
     status_id: int = 2,
     effective_date: str,
     enrollment_date: str = "",
@@ -20,6 +21,7 @@ def _make_attendee(
     att.enrollment_date = enrollment_date
     session_mock = MagicMock()
     session_mock.cm_id = session_cm_id
+    session_mock.session_type = session_type
     att.expand = {"session": session_mock}
     return att
 
@@ -173,3 +175,88 @@ async def test_day1_ignores_enrollment_date():
     priority_tier = next(t for t in result.tiers if t.tier == "priority")
     # Only first attendee should count (effective_date matches)
     assert priority_tier.total.count == 1
+
+
+# ============================================================================
+# session_types filter tests
+# ============================================================================
+
+
+def _make_repo_with_mixed_sessions() -> AsyncMock:
+    """Repo with main, quest, and scit sessions all having attendees on 2025-11-12."""
+    repo = AsyncMock()
+    repo.fetch_registration_dates.return_value = {
+        "priority_reg_date": "2025-11-12",
+    }
+    repo.fetch_sessions.return_value = {
+        1001: _make_session(1001, "main"),
+        1002: _make_session(1002, "quest"),
+        1003: _make_session(1003, "scit"),
+    }
+    repo.fetch_attendees_with_dates.return_value = [
+        # 2 main attendees
+        _make_attendee(session_cm_id=1001, session_type="main", effective_date="2025-11-12"),
+        _make_attendee(session_cm_id=1001, session_type="main", effective_date="2025-11-12"),
+        # 1 quest attendee
+        _make_attendee(session_cm_id=1002, session_type="quest", effective_date="2025-11-12"),
+        # 1 scit (teen) attendee
+        _make_attendee(session_cm_id=1003, session_type="scit", effective_date="2025-11-12"),
+    ]
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_day1_session_types_none_returns_existing_behavior():
+    """session_types=None preserves existing behavior.
+
+    With session_types=None, the existing code processes all attendees but only
+    counts those in AT_CAMP_TYPES (main, embedded, ag) or QUEST_TYPES (quest).
+    The scit attendee is on the tier date but falls into neither bucket, so
+    None returns 3 (2 main + 1 quest), not 4.  This test documents and protects
+    that contract: adding session_types must not change the None path.
+    """
+    repo = _make_repo_with_mixed_sessions()
+    service = Day1Service(repo)
+    result = await service.get_day1(2026)
+
+    priority_tier = next(t for t in result.tiers if t.tier == "priority")
+    # 2 main (at_camp) + 1 quest; scit is not bucketed so not counted
+    assert priority_tier.total.count == 3
+
+
+@pytest.mark.asyncio
+async def test_day1_session_types_main_only():
+    """session_types=['main'] restricts to main-session attendees only."""
+    repo = _make_repo_with_mixed_sessions()
+    service = Day1Service(repo)
+    result = await service.get_day1(2026, session_types=["main"])
+
+    priority_tier = next(t for t in result.tiers if t.tier == "priority")
+    # Only the 2 main attendees pass the filter; quest + scit are excluded
+    assert priority_tier.total.count == 2
+    assert priority_tier.total.count < 3  # fewer than unfiltered
+
+
+@pytest.mark.asyncio
+async def test_day1_session_types_main_and_quest():
+    """session_types=['main', 'quest'] counts main and quest but excludes scit."""
+    repo = _make_repo_with_mixed_sessions()
+    service = Day1Service(repo)
+    result = await service.get_day1(2026, session_types=["main", "quest"])
+
+    priority_tier = next(t for t in result.tiers if t.tier == "priority")
+    # 2 main + 1 quest = 3; scit is excluded by the filter
+    assert priority_tier.total.count == 3
+
+
+@pytest.mark.asyncio
+async def test_day1_session_types_quest_only():
+    """session_types=['quest'] restricts to quest-session attendees only."""
+    repo = _make_repo_with_mixed_sessions()
+    service = Day1Service(repo)
+    result = await service.get_day1(2026, session_types=["quest"])
+
+    priority_tier = next(t for t in result.tiers if t.tier == "priority")
+    # Only the 1 quest attendee passes the filter
+    assert priority_tier.total.count == 1
+    assert priority_tier.total.count < 3  # fewer than unfiltered (None = 3)

--- a/tests/unit/api/test_session_metrics.py
+++ b/tests/unit/api/test_session_metrics.py
@@ -12,6 +12,7 @@ Tests for:
 These tests are written FIRST before implementation (TDD).
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock
 
 from tests.unit.api.conftest import create_mock_attendee, create_mock_session
@@ -958,3 +959,60 @@ class TestFilterAttendeesBySessionCmIds:
         )
         # Both should pass: 101 is in the set, 301 is an AG child
         assert len(result) == 2
+
+
+# ============================================================================
+# Summer Teen Cohort Tests (Task 1 — PR A)
+# ============================================================================
+
+
+def _sess(cm_id: int, stype: str, start: str | None, end: str | None) -> SimpleNamespace:
+    return SimpleNamespace(cm_id=cm_id, session_type=stype, start_date=start, end_date=end)
+
+
+def test_summer_teen_types_value() -> None:
+    from api.utils.session_metrics import SUMMER_TEEN_TYPES
+
+    assert "scit" in SUMMER_TEEN_TYPES
+    assert "tli" in SUMMER_TEEN_TYPES
+
+
+def test_get_summer_window_spans_main_sessions() -> None:
+    from api.utils.session_metrics import get_summer_window
+
+    sessions = {
+        1: _sess(1, "main", "2025-06-15 07:00:00.000Z", "2025-07-05 07:00:00.000Z"),
+        2: _sess(2, "main", "2025-07-20 07:00:00.000Z", "2025-08-02 07:00:00.000Z"),
+        3: _sess(3, "quest", "2025-09-01 07:00:00.000Z", "2025-09-05 07:00:00.000Z"),
+    }
+    assert get_summer_window(sessions) == ("2025-06-15", "2025-08-02")
+
+
+def test_get_summer_window_none_without_main() -> None:
+    from api.utils.session_metrics import get_summer_window
+
+    assert get_summer_window({1: _sess(1, "quest", "2025-06-15", "2025-06-20")}) is None
+
+
+def test_is_summer_teen_session_includes_summer_scit_tli() -> None:
+    from api.utils.session_metrics import is_summer_teen_session
+
+    window = ("2025-06-15", "2025-08-02")
+    assert is_summer_teen_session(_sess(1, "scit", "2025-06-08 07:00:00.000Z", "2025-07-04 07:00:00.000Z"), window)
+    assert is_summer_teen_session(_sess(2, "tli", "2025-07-11 07:00:00.000Z", "2025-08-03 07:00:00.000Z"), window)
+
+
+def test_is_summer_teen_session_excludes_offseason_noise() -> None:
+    from api.utils.session_metrics import is_summer_teen_session
+
+    window = ("2025-06-15", "2025-08-02")
+    assert not is_summer_teen_session(_sess(3, "scit", "2025-09-12 07:00:00.000Z", "2025-09-15 07:00:00.000Z"), window)
+    assert not is_summer_teen_session(_sess(4, "tli", "2025-08-23 07:00:00.000Z", "2026-05-01 07:00:00.000Z"), window)
+    assert not is_summer_teen_session(_sess(5, "tli", "2025-02-15 08:00:00.000Z", "2025-02-18 08:00:00.000Z"), window)
+
+
+def test_is_summer_teen_session_false_for_nonteen_or_no_window() -> None:
+    from api.utils.session_metrics import is_summer_teen_session
+
+    assert not is_summer_teen_session(_sess(6, "main", "2025-06-15", "2025-07-05"), ("2025-06-15", "2025-08-02"))
+    assert not is_summer_teen_session(_sess(7, "scit", "2025-06-15", "2025-07-05"), None)

--- a/tests/unit/api/test_session_metrics.py
+++ b/tests/unit/api/test_session_metrics.py
@@ -1016,3 +1016,48 @@ def test_is_summer_teen_session_false_for_nonteen_or_no_window() -> None:
 
     assert not is_summer_teen_session(_sess(6, "main", "2025-06-15", "2025-07-05"), ("2025-06-15", "2025-08-02"))
     assert not is_summer_teen_session(_sess(7, "scit", "2025-06-15", "2025-07-05"), None)
+
+
+# ============================================================================
+# resolve_cohort_session_ids() Tests (Task 2 — PR A)
+# ============================================================================
+
+
+def test_resolve_cohort_window_gates_teens():
+    from api.utils.session_metrics import resolve_cohort_session_ids
+
+    s = {
+        10: _sess(10, "main", "2025-06-15 07:00:00.000Z", "2025-07-05 07:00:00.000Z"),
+        16: _sess(16, "main", "2025-07-20 07:00:00.000Z", "2025-08-02 07:00:00.000Z"),
+        11: _sess(11, "quest", "2025-06-20 07:00:00.000Z", "2025-07-03 07:00:00.000Z"),
+        12: _sess(12, "scit", "2025-06-08 07:00:00.000Z", "2025-07-04 07:00:00.000Z"),
+        13: _sess(13, "tli", "2025-07-11 07:00:00.000Z", "2025-08-03 07:00:00.000Z"),
+        14: _sess(14, "scit", "2025-09-12 07:00:00.000Z", "2025-09-15 07:00:00.000Z"),  # fall noise
+        15: _sess(15, "tli", "2025-02-15 08:00:00.000Z", "2025-02-18 08:00:00.000Z"),  # Feb noise
+    }
+    assert resolve_cohort_session_ids(s, ["scit", "tli"]) == {12, 13}
+
+
+def test_resolve_cohort_nonteen_types_not_gated():
+    from api.utils.session_metrics import resolve_cohort_session_ids
+
+    s = {
+        10: _sess(10, "main", "2025-06-15 07:00:00.000Z", "2025-07-05 07:00:00.000Z"),
+        11: _sess(11, "quest", "2025-06-20 07:00:00.000Z", "2025-07-03 07:00:00.000Z"),
+        12: _sess(12, "scit", "2025-06-08 07:00:00.000Z", "2025-07-04 07:00:00.000Z"),
+    }
+    assert resolve_cohort_session_ids(s, ["main", "quest"]) == {10, 11}
+
+
+def test_resolve_cohort_none_returns_nonteen_plus_gated_teens():
+    from api.utils.session_metrics import resolve_cohort_session_ids
+
+    s = {
+        10: _sess(10, "main", "2025-06-15 07:00:00.000Z", "2025-07-05 07:00:00.000Z"),
+        16: _sess(16, "main", "2025-07-20 07:00:00.000Z", "2025-08-02 07:00:00.000Z"),
+        11: _sess(11, "quest", "2025-06-20 07:00:00.000Z", "2025-07-03 07:00:00.000Z"),
+        12: _sess(12, "scit", "2025-06-08 07:00:00.000Z", "2025-07-04 07:00:00.000Z"),
+        13: _sess(13, "tli", "2025-07-11 07:00:00.000Z", "2025-08-03 07:00:00.000Z"),
+        14: _sess(14, "scit", "2025-09-12 07:00:00.000Z", "2025-09-15 07:00:00.000Z"),  # fall noise
+    }
+    assert resolve_cohort_session_ids(s, None) == {10, 16, 11, 12, 13}

--- a/tests/unit/api/test_session_metrics.py
+++ b/tests/unit/api/test_session_metrics.py
@@ -1061,3 +1061,18 @@ def test_resolve_cohort_none_returns_nonteen_plus_gated_teens():
         14: _sess(14, "scit", "2025-09-12 07:00:00.000Z", "2025-09-15 07:00:00.000Z"),  # fall noise
     }
     assert resolve_cohort_session_ids(s, None) == {10, 16, 11, 12, 13}
+
+
+# ============================================================================
+# DEFAULT_SUMMER_SESSION_TYPES Shared Constant Tests (Task 4 — PR A)
+# ============================================================================
+
+
+def test_default_summer_types_shared_constant():
+    from api.services.cancellation_service import SUMMER_SESSION_TYPES as cancel_types
+    from api.services.waitlist_service import SUMMER_SESSION_TYPES as waitlist_types
+
+    assert cancel_types == ("main", "embedded", "ag", "quest")
+    assert cancel_types == waitlist_types
+    # Default deliberately excludes teens (teens are opt-in via the picker).
+    assert "scit" not in cancel_types and "tli" not in cancel_types

--- a/tests/unit/api/test_session_metrics.py
+++ b/tests/unit/api/test_session_metrics.py
@@ -1069,10 +1069,11 @@ def test_resolve_cohort_none_returns_nonteen_plus_gated_teens():
 
 
 def test_default_summer_types_shared_constant():
-    from api.services.cancellation_service import SUMMER_SESSION_TYPES as cancel_types
-    from api.services.waitlist_service import SUMMER_SESSION_TYPES as waitlist_types
+    from api.services.cancellation_service import SUMMER_SESSION_TYPES as CANCEL_TYPES
+    from api.services.waitlist_service import SUMMER_SESSION_TYPES as WAITLIST_TYPES
 
-    assert cancel_types == ("main", "embedded", "ag", "quest")
-    assert cancel_types == waitlist_types
+    assert CANCEL_TYPES == ("main", "embedded", "ag", "quest")
+    assert CANCEL_TYPES == WAITLIST_TYPES
     # Default deliberately excludes teens (teens are opt-in via the picker).
-    assert "scit" not in cancel_types and "tli" not in cancel_types
+    assert "scit" not in CANCEL_TYPES
+    assert "tli" not in CANCEL_TYPES

--- a/tests/unit/api/test_waitlist_service.py
+++ b/tests/unit/api/test_waitlist_service.py
@@ -209,6 +209,48 @@ class TestWaitlistedHasEnrollment:
         assert result.waitlisted_has_enrollment == 1
         assert result.total_waitlisted == 2
 
+    @pytest.mark.asyncio
+    async def test_teen_waitlisted_with_other_teen_enrollment(
+        self,
+        waitlist_service: WaitlistService,
+        mock_repository: Mock,
+        sample_persons: dict[int, Mock],
+    ) -> None:
+        """A teen waitlisted for one teen session but enrolled in another teen
+        session counts as has_enrollment -- the cross-session lookup must span
+        teen programs, not summer-camp types only.
+        """
+        scit = create_mock_session(2001, "SCIT", 2026, "scit")
+        tli = create_mock_session(2002, "TLI", 2026, "tli")
+        summer_sessions = {1001: create_mock_session(1001, "Session 1", 2026, "main")}
+        teen_sessions = {2001: scit, 2002: tli}
+
+        waitlisted_attendees = [
+            create_mock_attendee(103, session_cm_id=scit.cm_id, session=scit, status="waitlisted", status_id=8),
+        ]
+        enrolled_attendees = [
+            create_mock_attendee(103, session_cm_id=tli.cm_id, session=tli, status="enrolled", status_id=2),
+        ]
+
+        def fetch_sessions_side_effect(year, session_types=None):
+            requested = set(session_types or [])
+            if requested and requested <= {"scit", "tli"}:
+                return teen_sessions
+            return summer_sessions
+
+        mock_repository.fetch_sessions = AsyncMock(side_effect=fetch_sessions_side_effect)
+        mock_repository.fetch_attendees = AsyncMock(
+            side_effect=lambda year, status_filter=None: (
+                waitlisted_attendees if status_filter == "waitlisted" else enrolled_attendees
+            )
+        )
+        mock_repository.fetch_persons.return_value = sample_persons
+
+        result = await waitlist_service.calculate_waitlist(year=2026, session_types=["scit", "tli"])
+
+        assert result.waitlisted_no_enrollment == 0
+        assert result.waitlisted_has_enrollment == 1
+
 
 # ============================================================================
 # UC3: Previously Waitlisted, Accepted (Now Enrolled)


### PR DESCRIPTION
## Summary

**PR A of 3** for *Teen Programs in Metrics*. Makes teen programs — **SCIT** (Counselor+Specialist In-Training, `session_type=scit`) and **TLI** (`tli`) — a selectable cohort across the metrics module and the shared `/campers` picker, with off-season noise excluded by a per-year **summer-window gate**.

Built TDD, task-by-task, with per-task spec + code-quality review.

### What's in PR A
- **Cohort foundation** (`api/utils/session_metrics.py`): `SUMMER_TEEN_TYPES`, `get_summer_window`, `is_summer_teen_session`, and `resolve_cohort_session_ids` — a teen session counts only if its dates overlap that year's main-camp window, excluding fall "Family Camp CIT", the year-long "Teen Interns", and the Feb "L.A. Trip". Mirrored in TS (`sessionTypePredicates.ts`).
- **Fix:** `TEEN_PROGRAM_TYPES` corrected from `['tli','teen']` → **`['scit','tli']`** (`teen` is the winter retreat, not a summer program; `scit` was missing).
- **Pickers:** "Teens" quick-pick + "Teen Programs" section (merged **SCIT**/**TLI**) in both the metrics session selector and the `/campers` picker; `/campers` headline becomes "…campers, questers, **and teens**" (and collapses to whichever cohorts are actually present). `/campers` camper fetch + count are honestly scoped (off-season teens never inflate the count).
- **Day1** endpoint honors a new `session_types` filter (`None` = unchanged behavior).
- **Consolidation:** duplicate `SUMMER_SESSION_TYPES` in cancellation/waitlist collapsed to one shared `DEFAULT_SUMMER_SESSION_TYPES`.

Teen **counts** now flow to registration / trends / velocity / availability / cancellation / waitlist / geo / day1 via the picker-emitted `session_types`.

### Deliberately NOT in PR A (scope boundaries)
- **No retention changes** and **no `DISPLAY_SESSION_TYPES` change** — that constant doubles as retention's "returned" cohort, so it lands in **PR B** with the window-gate wiring, the aged-out/teen-pipeline checkbox semantics, and the `TestRetentionComparePoolFiltering` updates. (`retention_service.py` / `extractors.py` are untouched here.)
- Forecast + manage-config cost rows → **PR C**.
- Whether teens count toward computed "Summers at Camp" → tracked in #1599.

### Notes for review
- `resolve_cohort_session_ids` ships **unused in prod** in PR A by design — it's the foundation PR B wires into retention.
- The summer-window gate is **client-enforced** on PR-A metrics surfaces (the picker structurally can't emit teen types unless window-gated teen sessions exist; `/campers` enforces it independently). The server resolver becomes the authority in PR B.

## Test plan
- [x] Backend: `ruff`, `mypy`, `pytest` (cohort/window/resolver, Day1 param, consolidation) green
- [x] Frontend: `tsc`, `eslint`, `vitest` (4512) green — incl. picker tests, window-gate hook test, and `/campers` component tests (teen scope, off-season exclusion, AG-camper survival)
- [x] Bunk-retention surfaces unchanged (teens aren't bunked — verified live in CampMinder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Teen Programs (SCIT/TLI) are first-class in metrics and camper views: selectable, window-gated, and reported as a “Teens” category.
  * Day 1 registration reporting accepts optional session-type filters and includes a teen category in totals.
  * Metrics session selector and session picker add a “Teen Programs” mode and teen-type selection.

* **Tests**
  * Expanded test coverage across metrics, services, hooks, and UI for teen filtering and window-gating behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->