### PR TITLE
feat(frontend): teen camper detail + enriched journey

### DIFF
--- a/frontend/src/components/CamperDetail.test.tsx
+++ b/frontend/src/components/CamperDetail.test.tsx
@@ -7,6 +7,7 @@ import type { SatisfactionResponse } from '../types/satisfaction'
 
 let mockSessionYear = 2026
 let mockAttendeeYear = 2026
+let mockSessionType = 'main'
 
 // Mock the camper data hooks to return a minimal fixture.
 vi.mock('../hooks/camper', () => ({
@@ -20,7 +21,14 @@ vi.mock('../hooks/camper', () => ({
         year: mockAttendeeYear,
         first_name: 'Emma',
         last_name: 'Johnson',
-        expand: { session: { cm_id: 2, name: 'Session 2', year: mockSessionYear } },
+        expand: {
+          session: {
+            cm_id: 2,
+            name: 'Session 2',
+            year: mockSessionYear,
+            session_type: mockSessionType,
+          },
+        },
       },
     ],
     allAttendees: [],
@@ -151,6 +159,7 @@ beforeEach(() => {
   mockAuthValue = { user: null, isLoading: false }
   mockSessionYear = 2026
   mockAttendeeYear = 2026
+  mockSessionType = 'main'
   // Finding #19: tests below mutate `mockFetchWithAuth`; reset to default so
   // a later test doesn't inherit a prior suite's stub state.
   mockFetchWithAuth = _defaultMockFetchWithAuth
@@ -280,5 +289,29 @@ describe('CamperDetail satisfaction summary', () => {
     renderDetail()
     // "1/2 met" should appear once the provider resolves and BunkingStatusPanel renders
     expect(await screen.findByText(/1\/2 met/i)).toBeTruthy()
+  })
+})
+
+describe('CamperDetail teen programs', () => {
+  beforeEach(() => {
+    mockAuthValue = { user: { is_admin: true, cached_permissions: [] }, isLoading: false }
+  })
+
+  it('hides bunking panels and cohort context for a teen-program (scit) camper', async () => {
+    mockSessionType = 'scit'
+    renderDetail()
+    // Journey still renders (identity + journey + siblings are kept).
+    expect(await screen.findByText(/Camp Journey/i)).toBeTruthy()
+    // Bunking panels are gone for teens.
+    expect(screen.queryByText(/Parsed Bunk Requests/i)).toBeNull()
+    expect(screen.queryByText(/Raw Bunking Data/i)).toBeNull()
+    // cohortContext is suppressed → no cohort badges.
+    expect(screen.queryByTestId('cohort-badge-school')).toBeNull()
+  })
+
+  it('keeps bunking panels for a normal summer (main) camper', async () => {
+    mockSessionType = 'main'
+    renderDetail()
+    expect(await screen.findByText(/Parsed Bunk Requests/i)).toBeTruthy()
   })
 })

--- a/frontend/src/components/CamperDetail.tsx
+++ b/frontend/src/components/CamperDetail.tsx
@@ -14,6 +14,7 @@ import { usePermissions } from '../hooks/usePermissions'
 import { Permission } from '../constants/permissions'
 import { getLocationDisplay } from '../utils/addressUtils'
 import { getSessionShortName } from '../utils/sessionDisplay'
+import { isTeenProgram } from '../utils/sessionTypePredicates'
 import { BunkRequestContext } from '../contexts/BunkRequestContext'
 import { BunkRequestProvider } from '../providers/BunkRequestProvider'
 import type { PersonsResponse } from '../types/pocketbase-types'
@@ -100,6 +101,10 @@ function CamperDetailBody({
   const bunkRequestCtx = useContext(BunkRequestContext)!
   const camperSatisfaction = bunkRequestCtx.getSatisfiedRequestInfo(camper.person_cm_id)
 
+  // Teens aren't bunked and never enter request processing — hide bunk panels
+  // and cohort context for teen-program sessions (spec §6.6).
+  const isTeen = camper.expand?.session ? isTeenProgram(camper.expand.session) : false
+
   // Single source of truth for per-row satisfaction pills: read directly from
   // BunkRequestProvider's /api/satisfaction response. Replaces the previous
   // useSatisfactionData hook which independently fetched bunk_assignments.
@@ -168,6 +173,7 @@ function CamperDetailBody({
             defaultExpanded={true}
             cohortContext={
               camper.attendee_status === 'enrolled' &&
+              !isTeen &&
               camper.expand?.session?.year === currentYear &&
               camper.person_cm_id &&
               camper.session_cm_id > 0
@@ -182,8 +188,8 @@ function CamperDetailBody({
             }
           />
 
-          {/* Bunking panels - only shown for enrolled campers */}
-          {camper.attendee_status === 'enrolled' && (
+          {/* Bunking panels - only shown for enrolled, non-teen campers */}
+          {camper.attendee_status === 'enrolled' && !isTeen && (
             <>
               {/* Bunking Status */}
               <BunkingStatusPanel

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -53,6 +53,7 @@ import type { RequestBucket, SatisfactionEntry } from '../types/satisfaction'
 import type { EnhancedBunkRequest } from '../hooks/camper/useAllBunkRequests'
 import { useOriginalBunkData } from '../hooks/camper/useOriginalBunkData'
 import { fetchCamperJourney, fetchParentMainSessions } from '../hooks/camper/fetchCamperJourney'
+import { collapseAgEnrollments, buildAgParentPairs } from '../hooks/camper/agCollapse'
 import type { HistoricalRecord } from '../hooks/camper/types'
 import { useYear } from '../hooks/useCurrentYear'
 import { getDisplayAgeForYear } from '../utils/displayAge'
@@ -344,13 +345,8 @@ export default function CamperDetailsPanel({
 
       // AG is never shown as its own session — collapse Main+AG and relabel any
       // surviving AG enrollment to its parent main (spec §6.3).
-      const enrolledCmIds = new Set(enrollments.map((e) => e.sessionCmId))
-      const collapsed = enrollments.filter(
-        (e) => !(e.sessionType === 'ag' && enrolledCmIds.has(e.parentId))
-      )
-      const agPairs = collapsed
-        .filter((e) => e.sessionType === 'ag')
-        .map((e) => ({ year: currentYear, cmId: e.parentId }))
+      const collapsed = collapseAgEnrollments(enrollments)
+      const agPairs = buildAgParentPairs(collapsed, currentYear)
       const parentByKey = await fetchParentMainSessions(agPairs)
       const visibleEnrollments: CurrentEnrollment[] = collapsed.map((e) =>
         e.sessionType === 'ag'

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -30,7 +30,7 @@ import {
   getSessionDisplayNameFromString,
   getSessionShortName as getSessionShortNameUtil,
 } from '../utils/sessionDisplay'
-import { buildSummerSessionTypeFilter, isAtCampSession } from '../utils/sessionTypePredicates'
+import { buildSummerSessionTypeFilter } from '../utils/sessionTypePredicates'
 import type {
   PersonsResponse,
   AttendeesResponse,
@@ -52,6 +52,8 @@ import {
 import type { RequestBucket, SatisfactionEntry } from '../types/satisfaction'
 import type { EnhancedBunkRequest } from '../hooks/camper/useAllBunkRequests'
 import { useOriginalBunkData } from '../hooks/camper/useOriginalBunkData'
+import { fetchCamperJourney, fetchParentMainSessions } from '../hooks/camper/fetchCamperJourney'
+import type { HistoricalRecord } from '../hooks/camper/types'
 import { useYear } from '../hooks/useCurrentYear'
 import { getDisplayAgeForYear } from '../utils/displayAge'
 import { CampMinderIcon } from './icons'
@@ -96,22 +98,12 @@ interface ExpandedSession {
   id?: string
   cm_id?: number
   name?: string
-}
-
-interface ExpandedPerson {
-  cm_id?: number
-  grade?: number
+  parent_id?: number
 }
 
 interface ExpandedBunk {
   cm_id?: number
   name?: string
-}
-
-interface ExpandedAssignment {
-  session?: ExpandedSession
-  person?: ExpandedPerson
-  bunk?: ExpandedBunk
 }
 
 // Animation state machine - replaces isOpen/isClosing booleans
@@ -152,20 +144,12 @@ interface CamperDetailsPanelProps {
   getBunkForPerson?: (cmId: number) => number | null
 }
 
-// Interface for historical records
-interface HistoricalRecord {
-  year: number
-  sessionName: string
-  sessionType: string
-  bunkName: string
-  attendeeStatus?: string
-}
-
 // Interface for current-year enrollment (one per attendee record)
 interface CurrentEnrollment {
   sessionName: string
   sessionType: string
   sessionCmId: number
+  parentId: number
   bunkName: string | null
   attendeeStatus?: string
 }
@@ -336,6 +320,7 @@ export default function CamperDetailsPanel({
           sessionName: sess?.name ?? 'Unknown',
           sessionType: sess?.session_type ?? '',
           sessionCmId: sess?.cm_id ?? 0,
+          parentId: sess?.parent_id ?? 0,
           bunkName,
           attendeeStatus: att.status,
         })
@@ -357,7 +342,27 @@ export default function CamperDetailsPanel({
         primarySession as CampSessionsResponse | null
       )
 
-      return { camper, enrollments }
+      // AG is never shown as its own session — collapse Main+AG and relabel any
+      // surviving AG enrollment to its parent main (spec §6.3).
+      const enrolledCmIds = new Set(enrollments.map((e) => e.sessionCmId))
+      const collapsed = enrollments.filter(
+        (e) => !(e.sessionType === 'ag' && enrolledCmIds.has(e.parentId))
+      )
+      const agPairs = collapsed
+        .filter((e) => e.sessionType === 'ag')
+        .map((e) => ({ year: currentYear, cmId: e.parentId }))
+      const parentByKey = await fetchParentMainSessions(agPairs)
+      const visibleEnrollments: CurrentEnrollment[] = collapsed.map((e) =>
+        e.sessionType === 'ag'
+          ? {
+              ...e,
+              sessionName: parentByKey.get(`${currentYear}:${e.parentId}`)?.name ?? e.sessionName,
+              sessionType: 'main',
+            }
+          : e
+      )
+
+      return { camper, enrollments: visibleEnrollments }
     },
     retry: false,
   })
@@ -382,34 +387,10 @@ export default function CamperDetailsPanel({
     enabled: !!camperId,
   })
 
-  // Fetch historical bunking data
-  const { data: historicalData = [] } = useQuery({
+  // Fetch historical journey via the shared enrollment-sourced fetcher.
+  const { data: historicalData = [] } = useQuery<HistoricalRecord[]>({
     queryKey: queryKeys.camperHistory(camperId, currentYear),
-    queryFn: async () => {
-      const personCmId = parseInt(camperId)
-      const filter = `person.cm_id = ${personCmId} && year < ${currentYear}`
-      const assignments = await pb.collection('bunk_assignments').getFullList({
-        filter,
-        expand: 'person,session,bunk',
-        sort: '-year',
-      })
-
-      return assignments
-        .filter((record) => {
-          const expanded = record.expand as ExpandedAssignment | undefined
-          const session = expanded?.session
-          return session ? isAtCampSession(session) : false
-        })
-        .map((record) => {
-          const expanded = record.expand as ExpandedAssignment | undefined
-          return {
-            year: record.year,
-            sessionName: expanded?.session?.name ?? '',
-            sessionType: expanded?.session?.session_type ?? '',
-            bunkName: expanded?.bunk?.name ?? 'Unassigned',
-          }
-        })
-    },
+    queryFn: () => fetchCamperJourney(parseInt(camperId), currentYear),
     enabled: !!camper,
   })
 
@@ -1077,12 +1058,16 @@ export default function CamperDetailsPanel({
                       <span className="text-muted-foreground truncate text-xs">
                         {getSessionDisplayNameFromString(record.sessionName, record.sessionType)}
                       </span>
-                      <span className="text-muted-foreground text-xs">·</span>
-                      <span
-                        className={`truncate text-xs ${record.bunkName === 'Unassigned' ? 'text-amber-600 italic' : 'text-foreground'}`}
-                      >
-                        {record.bunkName}
-                      </span>
+                      {record.bunkName !== undefined && (
+                        <>
+                          <span className="text-muted-foreground text-xs">·</span>
+                          <span
+                            className={`truncate text-xs ${record.bunkName === 'Unassigned' ? 'text-amber-600 italic' : 'text-foreground'}`}
+                          >
+                            {record.bunkName}
+                          </span>
+                        </>
+                      )}
                     </div>
                   ))}
                 </div>

--- a/frontend/src/components/CamperTooltip.test.tsx
+++ b/frontend/src/components/CamperTooltip.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Tests for CamperTooltip — the hover mini-journey. Routes through the shared
+ * fetchCamperJourney so it shows real attended years incl. no-bunk (teen / gap)
+ * rows. TDD: written before implementation.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import CamperTooltip from './CamperTooltip'
+import type { Camper } from '../types/app-types'
+
+const mockFetchCamperJourney = vi.fn()
+vi.mock('../hooks/camper/fetchCamperJourney', () => ({
+  fetchCamperJourney: (...args: unknown[]) => mockFetchCamperJourney(...args),
+}))
+vi.mock('../lib/pocketbase', () => ({
+  pb: { collection: () => ({ getFullList: vi.fn().mockResolvedValue([]) }) },
+}))
+vi.mock('../hooks/useCurrentYear', () => ({ useYear: () => 2026 }))
+vi.mock('../contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: 'u1' } }) }))
+
+const camper = {
+  person_cm_id: 12887873,
+  name: 'Emma Johnson',
+  grade: 11,
+  gender: 'F',
+} as unknown as Camper
+
+function renderTooltip() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <CamperTooltip camper={camper} isVisible={true} position={{ x: 100, y: 100 }} />
+    </QueryClientProvider>
+  )
+}
+
+describe('CamperTooltip mini-journey', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('shows a no-bunk teen year and a bunked year, both routed through the fetcher', async () => {
+    mockFetchCamperJourney.mockResolvedValue([
+      { year: 2025, sessionName: 'Counselor In-Training', sessionType: 'scit' }, // no bunk
+      { year: 2023, sessionName: 'Session 3', sessionType: 'main', bunkName: 'G-8B' },
+    ])
+    renderTooltip()
+    expect(await screen.findByText(/2025:/)).toBeInTheDocument() // teen year now visible
+    expect(await screen.findByText(/2023:/)).toBeInTheDocument()
+    expect(screen.getByText(/G-8B/)).toBeInTheDocument()
+    expect(mockFetchCamperJourney).toHaveBeenCalledWith(12887873, 2026)
+  })
+})

--- a/frontend/src/components/CamperTooltip.tsx
+++ b/frontend/src/components/CamperTooltip.tsx
@@ -43,7 +43,7 @@ export default function CamperTooltip({ camper, isVisible, position }: CamperToo
 
   // Fetch the prior-year journey via the shared enrollment-sourced fetcher,
   // limited to the 3 most recent years for the compact tooltip. Routing through
-  // the fetcher surfaces real attended years (family/teen/2022 gap), not only
+  // the fetcher surfaces real attended years (teen/2022 gap), not only
   // bunked at-camp years.
   const { data: history = [] } = useQuery<HistoricalRecord[]>({
     queryKey: queryKeys.camperHistory(String(camper.person_cm_id), currentYear),

--- a/frontend/src/components/CamperTooltip.tsx
+++ b/frontend/src/components/CamperTooltip.tsx
@@ -7,7 +7,8 @@ import { useYear } from '../hooks/useCurrentYear'
 import { getSessionDisplayNameFromString } from '../utils/sessionDisplay'
 import { getDisplayAgeForYear } from '../utils/displayAge'
 import { formatGradeOrdinal } from '../utils/gradeUtils'
-import { isAtCampSession } from '../utils/sessionTypePredicates'
+import { fetchCamperJourney } from '../hooks/camper/fetchCamperJourney'
+import type { HistoricalRecord } from '../hooks/camper/types'
 import type { Camper } from '../types/app-types'
 import type { BunkRequestsResponse } from '../types/pocketbase-types'
 import { queryKeys } from '../utils/queryKeys'
@@ -16,15 +17,6 @@ interface CamperTooltipProps {
   camper: Camper
   isVisible: boolean
   position: { x: number; y: number }
-}
-
-interface CamperHistory {
-  year: number
-  sessionName: string
-  sessionType: string
-  bunkName: string
-  startDate: string
-  endDate: string
 }
 
 export default function CamperTooltip({ camper, isVisible, position }: CamperTooltipProps) {
@@ -49,61 +41,18 @@ export default function CamperTooltip({ camper, isVisible, position }: CamperToo
     enabled: !!user && isVisible && !!camper.person_cm_id,
   })
 
-  // Fetch camper history from bunk_assignments table
-  const { data: history = [] } = useQuery<CamperHistory[]>({
+  // Fetch the prior-year journey via the shared enrollment-sourced fetcher,
+  // limited to the 3 most recent years for the compact tooltip. Routing through
+  // the fetcher surfaces real attended years (family/teen/2022 gap), not only
+  // bunked at-camp years.
+  const { data: history = [] } = useQuery<HistoricalRecord[]>({
     queryKey: queryKeys.camperHistory(String(camper.person_cm_id), currentYear),
     queryFn: async () => {
       if (!camper.person_cm_id) return []
-
-      try {
-        // Parse ID to ensure it's a number
-        const personCmId = parseInt(camper.person_cm_id.toString(), 10)
-        if (isNaN(personCmId)) return []
-
-        // Fetch from bunk_assignments with expanded relations
-        const filter = `person.cm_id = ${personCmId} && year < ${currentYear}`
-        const assignments = await pb.collection('bunk_assignments').getFullList({
-          filter,
-          expand: 'person,session,bunk',
-          sort: '-year',
-        })
-
-        // Type for expanded assignment records
-        interface ExpandedAssignment {
-          session?: {
-            session_type?: string
-            name?: string
-            start_date?: string
-            end_date?: string
-          }
-          bunk?: { name?: string }
-        }
-
-        // Filter to only include at-camp session types (main, embedded, ag)
-        const allHistory = assignments
-          .filter((record) => {
-            const expanded = record.expand as ExpandedAssignment | undefined
-            const session = expanded?.session
-            return session ? isAtCampSession(session) : false
-          })
-          .map((record) => {
-            const expanded = record.expand as ExpandedAssignment | undefined
-            return {
-              year: record.year,
-              sessionName: expanded?.session?.name ?? '',
-              sessionType: expanded?.session?.session_type ?? '',
-              bunkName: expanded?.bunk?.name ?? 'Unassigned',
-              startDate: expanded?.session?.start_date ?? '',
-              endDate: expanded?.session?.end_date ?? '',
-            }
-          })
-
-        // Filter out unassigned bunks and limit to 3 most recent years
-        return allHistory.filter((record) => record.bunkName !== 'Unassigned').slice(0, 3)
-      } catch (error) {
-        console.error('Error fetching camper history:', error)
-        return []
-      }
+      const personCmId = parseInt(camper.person_cm_id.toString(), 10)
+      if (isNaN(personCmId)) return []
+      const journey = await fetchCamperJourney(personCmId, currentYear)
+      return journey.slice(0, 3)
     },
     enabled: !!user && isVisible && !!camper.person_cm_id,
     gcTime: 10 * 60 * 1000, // 10 minutes
@@ -170,8 +119,8 @@ export default function CamperTooltip({ camper, isVisible, position }: CamperToo
               <div key={`${record.year}-${record.sessionName}-${index}`} className="text-sm">
                 <span className="font-medium">{record.year}:</span>{' '}
                 <span className="text-muted-foreground">
-                  {getSessionDisplayNameFromString(record.sessionName, record.sessionType)} -{' '}
-                  {record.bunkName}
+                  {getSessionDisplayNameFromString(record.sessionName, record.sessionType)}
+                  {record.bunkName ? ` - ${record.bunkName}` : ''}
                 </span>
               </div>
             ))}

--- a/frontend/src/components/camper/CampJourneyTimeline.test.tsx
+++ b/frontend/src/components/camper/CampJourneyTimeline.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * Tests for CampJourneyTimeline display rules (spec §8).
+ * TDD: written before the bunk-segment guard.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CampJourneyTimeline } from './CampJourneyTimeline'
+import type { HistoricalRecord } from '../../hooks/camper/types'
+
+describe('CampJourneyTimeline display rules (spec §8)', () => {
+  it('hides the bunk segment for a no-bunk prior year but still lists the row', () => {
+    const history: HistoricalRecord[] = [
+      { year: 2023, sessionName: 'Session 3', sessionType: 'main', bunkName: 'G-8B' },
+      { year: 2022, sessionName: 'Session 4', sessionType: 'main' }, // no bunk
+    ]
+    render(<CampJourneyTimeline history={history} yearsAtCamp={3} currentYear={2026} />)
+    expect(screen.getByText('G-8B')).toBeInTheDocument()
+    expect(screen.getByText('2022')).toBeInTheDocument() // row still listed
+    expect(screen.queryByText('Unassigned')).toBeNull()
+    // The "·" bunk separator renders only for the labeled (G-8B) row — not the
+    // no-bunk row. (Old code rendered it for every enrolled row → length 2.)
+    expect(screen.queryAllByText('·')).toHaveLength(1)
+  })
+
+  it('still renders Unassigned for a current-year bunkable row not yet placed', () => {
+    const history: HistoricalRecord[] = [
+      { year: 2026, sessionName: 'Session Now', sessionType: 'main', bunkName: 'Unassigned' },
+    ]
+    render(<CampJourneyTimeline history={history} yearsAtCamp={1} currentYear={2026} />)
+    expect(screen.getByText('Unassigned')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/camper/CampJourneyTimeline.tsx
+++ b/frontend/src/components/camper/CampJourneyTimeline.tsx
@@ -89,8 +89,9 @@ export function CampJourneyTimeline({
                       </span>
                     )}
 
-                    {/* Only show bunk for enrolled records */}
-                    {!statusIndicator && (
+                    {/* Bunk — only for enrolled records that actually have a label.
+                        No-bunk prior years (teen / 2022 gap / family) show no segment. */}
+                    {!statusIndicator && record.bunkName !== undefined && (
                       <>
                         <span className="text-muted-foreground">·</span>
 

--- a/frontend/src/hooks/camper/agCollapse.test.ts
+++ b/frontend/src/hooks/camper/agCollapse.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for the pure AG collapse/relabel helpers.
+ * TDD: written before implementation.
+ */
+import { describe, it, expect } from 'vitest'
+import { collapseAgEnrollments, buildAgParentPairs } from './agCollapse'
+
+interface E {
+  sessionType: string
+  sessionCmId: number
+  parentId: number
+}
+const e = (sessionType: string, sessionCmId: number, parentId: number): E => ({
+  sessionType,
+  sessionCmId,
+  parentId,
+})
+
+describe('collapseAgEnrollments', () => {
+  it('drops an AG row when its parent main is also enrolled that year', () => {
+    const main = e('main', 100, 0)
+    const ag = e('ag', 101, 100)
+    expect(collapseAgEnrollments([main, ag])).toEqual([main])
+  })
+
+  it('keeps an AG row whose parent main is not enrolled', () => {
+    const ag = e('ag', 200, 199)
+    expect(collapseAgEnrollments([ag])).toEqual([ag])
+  })
+
+  it('keeps a parentless AG row (parentId 0) even when a cm_id-less session puts 0 in the set', () => {
+    // sessionCmId defaults to 0 for a session without a cm_id; without the
+    // parentId>0 guard, enrolledCmIds.has(0) would wrongly collapse the AG row.
+    const cmIdless = e('main', 0, 0)
+    const ag = e('ag', 300, 0)
+    expect(collapseAgEnrollments([cmIdless, ag])).toEqual([cmIdless, ag])
+  })
+
+  it('leaves non-AG rows untouched', () => {
+    const rows = [e('main', 1, 0), e('quest', 2, 0), e('embedded', 3, 0)]
+    expect(collapseAgEnrollments(rows)).toEqual(rows)
+  })
+})
+
+describe('buildAgParentPairs', () => {
+  it('builds (year, parentId) pairs for surviving AG rows with a real parent', () => {
+    const rows = [e('ag', 200, 199), e('main', 100, 0)]
+    expect(buildAgParentPairs(rows, 2026)).toEqual([{ year: 2026, cmId: 199 }])
+  })
+
+  it('skips AG rows with the 0 sentinel parentId (no bogus cm_id=0 lookup)', () => {
+    const rows = [e('ag', 300, 0)]
+    expect(buildAgParentPairs(rows, 2026)).toEqual([])
+  })
+})

--- a/frontend/src/hooks/camper/agCollapse.ts
+++ b/frontend/src/hooks/camper/agCollapse.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure AG collapse/relabel helpers for current-year enrollment lists.
+ *
+ * AG is a sub-track of a main session, never shown as its own attendance:
+ *  - collapseAgEnrollments drops an AG row when its parent main is also enrolled
+ *    that year (mirrors fetchCamperJourney's enrolledByYear collapse).
+ *  - buildAgParentPairs lists the (year, parent cm_id) lookups needed to relabel
+ *    surviving AG-only rows to their parent main.
+ *
+ * Both guard against the `parentId` sentinel: `parent_id` (and `sessionCmId`)
+ * default to 0 when absent, so a non-positive parentId never identifies a real
+ * parent. Those AG rows are kept as-is and never trigger a lookup. Without the
+ * guard a cm_id-less session (sessionCmId 0) would seed 0 into the enrolled set
+ * and silently collapse an unrelated parentless AG row.
+ */
+
+/** Minimal enrollment shape needed for AG collapse/relabel. */
+export interface AgCollapsibleEnrollment {
+  sessionType: string
+  sessionCmId: number
+  parentId: number
+}
+
+export function collapseAgEnrollments<T extends AgCollapsibleEnrollment>(enrollments: T[]): T[] {
+  const enrolledCmIds = new Set(enrollments.map((e) => e.sessionCmId))
+  return enrollments.filter(
+    (e) => !(e.sessionType === 'ag' && e.parentId > 0 && enrolledCmIds.has(e.parentId))
+  )
+}
+
+export function buildAgParentPairs<T extends AgCollapsibleEnrollment>(
+  enrollments: T[],
+  year: number
+): Array<{ year: number; cmId: number }> {
+  return enrollments
+    .filter((e) => e.sessionType === 'ag' && e.parentId > 0)
+    .map((e) => ({ year, cmId: e.parentId }))
+}

--- a/frontend/src/hooks/camper/fetchCamperJourney.test.ts
+++ b/frontend/src/hooks/camper/fetchCamperJourney.test.ts
@@ -79,7 +79,7 @@ describe('fetchCamperJourney', () => {
     expect(filter).toContain(`person_id = ${PERSON}`)
     expect(filter).toContain(`year < ${CURRENT_YEAR}`)
     expect(filter).toContain('status = "enrolled"')
-    expect(filter).toContain('session.session_type = "family"')
+    expect(filter).not.toContain('"family"') // family excluded — journey mirrors All Campers
     expect(filter).toContain('session.session_type = "scit"')
   })
 

--- a/frontend/src/hooks/camper/fetchCamperJourney.test.ts
+++ b/frontend/src/hooks/camper/fetchCamperJourney.test.ts
@@ -83,6 +83,20 @@ describe('fetchCamperJourney', () => {
     expect(filter).toContain('session.session_type = "scit"')
   })
 
+  it('restricts the bunk_assignments query to journey session types (no family-camp bunk leak)', async () => {
+    // A summer enrollment with no summer bunk + a lone family-camp bunk that year
+    // must NOT have the family bunk attached via the length===1 fallback. The
+    // query itself excludes non-journey (family) session types — mirrors the
+    // fb1a88d2 fix applied to current-year views in useCamperEnrollment.
+    mockAttendeesGetFullList.mockResolvedValue([attendee(2022, 100, 'main', 'Session 3')])
+    await fetchCamperJourney(PERSON, CURRENT_YEAR)
+    const filter = String(mockAssignmentsGetFullList.mock.calls[0]?.[0]?.filter ?? '')
+    expect(filter).toContain(`person.cm_id = ${PERSON}`)
+    expect(filter).toContain(`year < ${CURRENT_YEAR}`)
+    expect(filter).not.toContain('"family"')
+    expect(filter).toContain('session.session_type = "main"')
+  })
+
   it('labels a row via exact (year, session) assignment match', async () => {
     mockAttendeesGetFullList.mockResolvedValue([attendee(2023, 100, 'main', 'Session 3')])
     mockAssignmentsGetFullList.mockResolvedValue([assignment(2023, 100, 'G-8B')])

--- a/frontend/src/hooks/camper/fetchCamperJourney.test.ts
+++ b/frontend/src/hooks/camper/fetchCamperJourney.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for fetchCamperJourney — the shared prior-year journey source.
+ * TDD: written before implementation.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fetchCamperJourney } from './fetchCamperJourney'
+
+const mockAttendeesGetFullList = vi.fn()
+const mockAssignmentsGetFullList = vi.fn()
+const mockSessionsGetFullList = vi.fn()
+
+vi.mock('../../lib/pocketbase', () => ({
+  pb: {
+    collection: vi.fn((name: string) => {
+      if (name === 'attendees') return { getFullList: mockAttendeesGetFullList }
+      if (name === 'bunk_assignments') return { getFullList: mockAssignmentsGetFullList }
+      if (name === 'camp_sessions') return { getFullList: mockSessionsGetFullList }
+      throw new Error(`Unexpected collection: ${name}`)
+    }),
+  },
+}))
+
+const PERSON = 12887873
+const CURRENT_YEAR = 2026
+
+function attendee(
+  year: number,
+  sessionCmId: number,
+  sessionType: string,
+  name: string,
+  parentId?: number
+) {
+  return {
+    id: `att-${year}-${sessionCmId}`,
+    person_id: PERSON,
+    year,
+    status: 'enrolled',
+    expand: {
+      session: {
+        id: `sess-${sessionCmId}`,
+        cm_id: sessionCmId,
+        name,
+        session_type: sessionType,
+        ...(parentId !== undefined ? { parent_id: parentId } : {}),
+      },
+    },
+  }
+}
+
+function assignment(year: number, sessionCmId: number | null, bunkName: string) {
+  return {
+    id: `asn-${year}-${sessionCmId ?? 'x'}`,
+    year,
+    expand: {
+      ...(sessionCmId !== null ? { session: { cm_id: sessionCmId } } : {}),
+      bunk: { name: bunkName },
+    },
+  }
+}
+
+describe('fetchCamperJourney', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAttendeesGetFullList.mockResolvedValue([])
+    mockAssignmentsGetFullList.mockResolvedValue([])
+    mockSessionsGetFullList.mockResolvedValue([])
+  })
+
+  it('returns [] without querying when personCmId is falsy', async () => {
+    const out = await fetchCamperJourney(0, CURRENT_YEAR)
+    expect(out).toEqual([])
+    expect(mockAttendeesGetFullList).not.toHaveBeenCalled()
+  })
+
+  it('sources rows from attendees and queries by year < currentYear, enrolled, curated types', async () => {
+    mockAttendeesGetFullList.mockResolvedValue([attendee(2023, 100, 'main', 'Session 3')])
+    await fetchCamperJourney(PERSON, CURRENT_YEAR)
+    const filter = String(mockAttendeesGetFullList.mock.calls[0]?.[0]?.filter ?? '')
+    expect(filter).toContain(`person_id = ${PERSON}`)
+    expect(filter).toContain(`year < ${CURRENT_YEAR}`)
+    expect(filter).toContain('status = "enrolled"')
+    expect(filter).toContain('session.session_type = "family"')
+    expect(filter).toContain('session.session_type = "scit"')
+  })
+
+  it('labels a row via exact (year, session) assignment match', async () => {
+    mockAttendeesGetFullList.mockResolvedValue([attendee(2023, 100, 'main', 'Session 3')])
+    mockAssignmentsGetFullList.mockResolvedValue([assignment(2023, 100, 'G-8B')])
+    const out = await fetchCamperJourney(PERSON, CURRENT_YEAR)
+    expect(out[0]).toMatchObject({ year: 2023, sessionName: 'Session 3', bunkName: 'G-8B' })
+  })
+
+  it('relabels an AG-only year to its parent main via camp_sessions lookup, keeping the AG bunk', async () => {
+    // AG enrollment session cm_id 200 (parent main 199 NOT enrolled, so the AG row
+    // survives). The bunk is filed under the AG session itself (exact match → AG-4).
+    // The parent-main NAME comes from the camp_sessions lookup by (year, parent_id).
+    mockAttendeesGetFullList.mockResolvedValue([attendee(2021, 200, 'ag', 'Session B (AG)', 199)])
+    mockAssignmentsGetFullList.mockResolvedValue([assignment(2021, 200, 'AG-4')])
+    mockSessionsGetFullList.mockResolvedValue([
+      { year: 2021, cm_id: 199, name: 'Session B', session_type: 'main' },
+    ])
+    const out = await fetchCamperJourney(PERSON, CURRENT_YEAR)
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({
+      year: 2021,
+      sessionType: 'main',
+      sessionName: 'Session B',
+      bunkName: 'AG-4',
+    })
+    const lookupFilter = String(mockSessionsGetFullList.mock.calls[0]?.[0]?.filter ?? '')
+    expect(lookupFilter).toContain('cm_id = 199')
+    expect(lookupFilter).toContain('year = 2021')
+  })
+
+  it('collapses a same-year Main + AG enrollment into one Main row', async () => {
+    // AG (cm_id 101) is the child of the enrolled main (cm_id 100) → drop the AG
+    // row, show the single Main row (carrying the bunk if any; none here).
+    mockAttendeesGetFullList.mockResolvedValue([
+      attendee(2023, 100, 'main', 'Session 2'),
+      attendee(2023, 101, 'ag', 'Session 2 AG', 100),
+    ])
+    const out = await fetchCamperJourney(PERSON, CURRENT_YEAR)
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({ year: 2023, sessionType: 'main', sessionName: 'Session 2' })
+  })
+
+  it('leaves a row unlabeled when its year has >=2 assignments and none match the session', async () => {
+    mockAttendeesGetFullList.mockResolvedValue([attendee(2020, 300, 'embedded', 'Session X')])
+    mockAssignmentsGetFullList.mockResolvedValue([
+      assignment(2020, 301, 'Cabin 1'),
+      assignment(2020, 302, 'Cabin 2'),
+    ])
+    const out = await fetchCamperJourney(PERSON, CURRENT_YEAR)
+    expect(out[0]?.bunkName).toBeUndefined()
+  })
+
+  it('includes a no-assignment (e.g. 2022 gap / teen) year with no bunk label', async () => {
+    mockAttendeesGetFullList.mockResolvedValue([
+      attendee(2024, 400, 'scit', 'Counselor In-Training'),
+      attendee(2022, 100, 'main', 'Session 3'),
+    ])
+    // CM export gap: no 2022 rows; teens may be unbunked
+    mockAssignmentsGetFullList.mockResolvedValue([])
+    const out = await fetchCamperJourney(PERSON, CURRENT_YEAR)
+    expect(out.map((r) => r.year)).toEqual([2024, 2022]) // sorted -year
+    for (const r of out) expect(r.bunkName).toBeUndefined()
+  })
+
+  it('sorts output by year descending regardless of input order', async () => {
+    mockAttendeesGetFullList.mockResolvedValue([
+      attendee(2019, 1, 'main', 'a'),
+      attendee(2023, 2, 'main', 'b'),
+      attendee(2021, 3, 'main', 'c'),
+    ])
+    const out = await fetchCamperJourney(PERSON, CURRENT_YEAR)
+    expect(out.map((r) => r.year)).toEqual([2023, 2021, 2019])
+  })
+})

--- a/frontend/src/hooks/camper/fetchCamperJourney.ts
+++ b/frontend/src/hooks/camper/fetchCamperJourney.ts
@@ -72,14 +72,14 @@ export async function fetchCamperJourney(
   // stay distinct).
   const enrolledByYear = new Map<number, Set<number>>()
   for (const att of attendees) {
-    const cmId = att.expand?.session?.cm_id
+    const cmId = att.expand.session?.cm_id
     if (cmId === undefined) continue
     const set = enrolledByYear.get(att.year) ?? new Set<number>()
     set.add(cmId)
     enrolledByYear.set(att.year, set)
   }
   const deduped = attendees.filter((att) => {
-    const session = att.expand?.session
+    const session = att.expand.session
     if (session?.session_type !== 'ag') return true
     // AG row drops only when its parent main is also enrolled that year;
     // an unmatched parent_id (e.g. 0) is never present in enrolledByYear → kept.
@@ -94,7 +94,7 @@ export async function fetchCamperJourney(
       expand: 'session,bunk',
     })
 
-  const assignmentsByYear = new Map<number, BunkAssignmentsResponse<AssignmentExpand>[]>()
+  const assignmentsByYear = new Map<number, Array<BunkAssignmentsResponse<AssignmentExpand>>>()
   for (const a of assignments) {
     const list = assignmentsByYear.get(a.year) ?? []
     list.push(a)
@@ -105,23 +105,23 @@ export async function fetchCamperJourney(
   // parent main; AG names aren't derivable). One query, fires only when AG present.
   const agPairs: Array<{ year: number; cmId: number }> = []
   for (const att of deduped) {
-    const s = att.expand?.session
+    const s = att.expand.session
     if (s?.session_type === 'ag') agPairs.push({ year: att.year, cmId: s.parent_id })
   }
   const parentByKey = await fetchParentMainSessions(agPairs)
 
   const records = deduped.map((att): HistoricalRecord => {
-    const session = att.expand?.session
+    const session = att.expand.session
     const year = att.year
     const yearAssignments = assignmentsByYear.get(year) ?? []
 
     // Bunk-label join precedence (spec §7):
     // 1. exact (year, session) match
-    let match = yearAssignments.find((a) => a.expand?.session?.cm_id === session?.cm_id)
+    let match = yearAssignments.find((a) => a.expand.session?.cm_id === session?.cm_id)
     // 2. else year-fallback ONLY when the year has exactly one assignment
     if (!match && yearAssignments.length === 1) match = yearAssignments[0]
     // 3. else (>=2 assignments, no match, or zero) → no label
-    const bunkName = match?.expand?.bunk?.name
+    const bunkName = match?.expand.bunk?.name
 
     // AG is never shown as its own session (spec §3). For a surviving AG-only row,
     // relabel to its parent main: name from the camp_sessions lookup (AG names

--- a/frontend/src/hooks/camper/fetchCamperJourney.ts
+++ b/frontend/src/hooks/camper/fetchCamperJourney.ts
@@ -1,6 +1,6 @@
 /**
  * Shared prior-year journey source. Lists every prior year a camper was
- * ENROLLED (curated types: summer + teen + family), labeling each row with its
+ * ENROLLED (curated types: summer + teen, no family), labeling each row with its
  * bunk/day-group when an assignment exists. Sourcing from attendees (not
  * bunk_assignments) is what surfaces 2022 (a CampMinder export gap), teens, and
  * family camp uniformly.
@@ -87,10 +87,13 @@ export async function fetchCamperJourney(
   })
 
   // 2. Prior-year bunk assignments — used ONLY to label a row, never to gate it.
+  // Restricted to journey session types: without this, a lone family-camp bunk in
+  // a year could be attached to a summer row via the year-fallback below (the same
+  // leak fb1a88d2 closed for current-year views in useCamperEnrollment).
   const assignments = await pb
     .collection<BunkAssignmentsResponse<AssignmentExpand>>('bunk_assignments')
     .getFullList({
-      filter: `person.cm_id = ${personCmId} && year < ${currentYear}`,
+      filter: `person.cm_id = ${personCmId} && year < ${currentYear} && (${typeFilter})`,
       expand: 'session,bunk',
     })
 

--- a/frontend/src/hooks/camper/fetchCamperJourney.ts
+++ b/frontend/src/hooks/camper/fetchCamperJourney.ts
@@ -1,0 +1,147 @@
+/**
+ * Shared prior-year journey source. Lists every prior year a camper was
+ * ENROLLED (curated types: summer + teen + family), labeling each row with its
+ * bunk/day-group when an assignment exists. Sourcing from attendees (not
+ * bunk_assignments) is what surfaces 2022 (a CampMinder export gap), teens, and
+ * family camp uniformly.
+ *
+ * AG is never shown as its own session: a Main+AG same-year pair collapses to the
+ * Main row, and an AG-only year is relabeled to its parent main (name resolved via
+ * camp_sessions, since AG session names aren't reliably derivable).
+ */
+import { pb } from '../../lib/pocketbase'
+import { buildCamperJourneySessionTypeFilter } from '../../utils/sessionTypePredicates'
+import type {
+  AttendeesResponse,
+  BunkAssignmentsResponse,
+  BunksResponse,
+  CampSessionsResponse,
+} from '../../types/pocketbase-types'
+import type { HistoricalRecord } from './types'
+
+interface SessionExpand {
+  session?: CampSessionsResponse
+}
+interface AssignmentExpand {
+  session?: CampSessionsResponse
+  bunk?: BunksResponse
+}
+
+/**
+ * Fetch parent-main `camp_sessions` for a set of (year, cm_id) pairs, keyed
+ * `${year}:${cmId}`. Returns an empty map for no pairs (no query). Used to relabel
+ * AG rows to their parent main — AG session names aren't reliably derivable.
+ */
+export async function fetchParentMainSessions(
+  pairs: Array<{ year: number; cmId: number }>
+): Promise<Map<string, CampSessionsResponse>> {
+  const out = new Map<string, CampSessionsResponse>()
+  const unique = new Map<string, { year: number; cmId: number }>()
+  for (const p of pairs) unique.set(`${p.year}:${p.cmId}`, p)
+  if (unique.size === 0) return out
+  const orClause = [...unique.values()]
+    .map((p) => `(year = ${p.year} && cm_id = ${p.cmId})`)
+    .join(' || ')
+  const sessions = await pb
+    .collection<CampSessionsResponse>('camp_sessions')
+    .getFullList({ filter: orClause })
+  for (const s of sessions) out.set(`${s.year}:${s.cm_id}`, s)
+  return out
+}
+
+export async function fetchCamperJourney(
+  personCmId: number,
+  currentYear: number
+): Promise<HistoricalRecord[]> {
+  if (!personCmId || Number.isNaN(personCmId)) return []
+
+  const typeFilter = buildCamperJourneySessionTypeFilter()
+
+  // 1. Prior-year enrollments — the journey's source of truth.
+  const attendees = await pb.collection<AttendeesResponse<SessionExpand>>('attendees').getFullList({
+    filter: `person_id = ${personCmId} && year < ${currentYear} && status = "enrolled" && (${typeFilter})`,
+    expand: 'session',
+  })
+
+  if (attendees.length === 0) return []
+
+  // Collapse AG sub-tracks into their parent main: when both a main session and
+  // its AG child are enrolled the same year, AG isn't a separate attendance —
+  // show one Main row. AG enrolled without its parent main keeps its own row.
+  // This is the ONLY same-year row collapse (family/quest/teen alongside summer
+  // stay distinct).
+  const enrolledByYear = new Map<number, Set<number>>()
+  for (const att of attendees) {
+    const cmId = att.expand?.session?.cm_id
+    if (cmId === undefined) continue
+    const set = enrolledByYear.get(att.year) ?? new Set<number>()
+    set.add(cmId)
+    enrolledByYear.set(att.year, set)
+  }
+  const deduped = attendees.filter((att) => {
+    const session = att.expand?.session
+    if (session?.session_type !== 'ag') return true
+    // AG row drops only when its parent main is also enrolled that year;
+    // an unmatched parent_id (e.g. 0) is never present in enrolledByYear → kept.
+    return !enrolledByYear.get(att.year)?.has(session.parent_id)
+  })
+
+  // 2. Prior-year bunk assignments — used ONLY to label a row, never to gate it.
+  const assignments = await pb
+    .collection<BunkAssignmentsResponse<AssignmentExpand>>('bunk_assignments')
+    .getFullList({
+      filter: `person.cm_id = ${personCmId} && year < ${currentYear}`,
+      expand: 'session,bunk',
+    })
+
+  const assignmentsByYear = new Map<number, BunkAssignmentsResponse<AssignmentExpand>[]>()
+  for (const a of assignments) {
+    const list = assignmentsByYear.get(a.year) ?? []
+    list.push(a)
+    assignmentsByYear.set(a.year, list)
+  }
+
+  // Resolve parent-main sessions for any surviving AG rows (AG is relabeled to its
+  // parent main; AG names aren't derivable). One query, fires only when AG present.
+  const agPairs: Array<{ year: number; cmId: number }> = []
+  for (const att of deduped) {
+    const s = att.expand?.session
+    if (s?.session_type === 'ag') agPairs.push({ year: att.year, cmId: s.parent_id })
+  }
+  const parentByKey = await fetchParentMainSessions(agPairs)
+
+  const records = deduped.map((att): HistoricalRecord => {
+    const session = att.expand?.session
+    const year = att.year
+    const yearAssignments = assignmentsByYear.get(year) ?? []
+
+    // Bunk-label join precedence (spec §7):
+    // 1. exact (year, session) match
+    let match = yearAssignments.find((a) => a.expand?.session?.cm_id === session?.cm_id)
+    // 2. else year-fallback ONLY when the year has exactly one assignment
+    if (!match && yearAssignments.length === 1) match = yearAssignments[0]
+    // 3. else (>=2 assignments, no match, or zero) → no label
+    const bunkName = match?.expand?.bunk?.name
+
+    // AG is never shown as its own session (spec §3). For a surviving AG-only row,
+    // relabel to its parent main: name from the camp_sessions lookup (AG names
+    // aren't derivable from the AG session name), session_type forced to 'main'.
+    // The AG bunk above already comes from the exact (year, AG-session) match —
+    // in the data AG bunks are filed under the AG session itself.
+    const parent =
+      session?.session_type === 'ag' ? parentByKey.get(`${year}:${session.parent_id}`) : undefined
+    const displaySession = parent ?? session
+    const sessionType = session?.session_type === 'ag' ? 'main' : (session?.session_type ?? '')
+
+    return {
+      year,
+      sessionName: displaySession?.name ?? 'Unknown',
+      sessionType,
+      ...(bunkName !== undefined ? { bunkName } : {}),
+      ...(displaySession?.start_date !== undefined ? { startDate: displaySession.start_date } : {}),
+      ...(displaySession?.end_date !== undefined ? { endDate: displaySession.end_date } : {}),
+    }
+  })
+
+  return records.sort((a, b) => b.year - a.year)
+}

--- a/frontend/src/hooks/camper/index.ts
+++ b/frontend/src/hooks/camper/index.ts
@@ -9,6 +9,7 @@ export type { HistoricalRecord, OriginalBunkData, SiblingWithEnrollment } from '
 // Hooks
 export { useCamperEnrollment, type UseCamperEnrollmentResult } from './useCamperEnrollment'
 export { useCamperHistory, type UseCamperHistoryResult } from './useCamperHistory'
+export { fetchCamperJourney, fetchParentMainSessions } from './fetchCamperJourney'
 export { useSiblings, type UseSiblingsResult } from './useSiblings'
 export { useOriginalBunkData, type UseOriginalBunkDataResult } from './useOriginalBunkData'
 export {

--- a/frontend/src/hooks/camper/types.ts
+++ b/frontend/src/hooks/camper/types.ts
@@ -9,7 +9,8 @@ export interface HistoricalRecord {
   year: number
   sessionName: string
   sessionType: string
-  bunkName: string
+  /** Bunk/day-group name. Absent when the enrolled session had no bunk assignment. */
+  bunkName?: string
   startDate?: string
   endDate?: string
   /** Non-enrolled status (e.g. 'waitlisted', 'cancelled'). Absent for enrolled records. */

--- a/frontend/src/hooks/camper/useCamperEnrollment.test.tsx
+++ b/frontend/src/hooks/camper/useCamperEnrollment.test.tsx
@@ -327,4 +327,34 @@ describe('useCamperEnrollment', () => {
     expect(result.current.allAttendees).toHaveLength(1)
     expect(expectDefined(result.current.allAttendees[0]).assigned_bunk_cm_id).toBe(7000099)
   })
+
+  it('loads a teen-only (scit) attendee and queries attendees with teen types included', async () => {
+    mockAttendeesGetFullList.mockResolvedValue([
+      makeAttendee({
+        id: 'att_scit',
+        sessionPbId: 'sess_scit',
+        sessionCmId: 1407000,
+        sessionType: 'scit',
+      }),
+    ])
+    mockAssignmentsGetFullList.mockResolvedValue([]) // teens are never bunked
+
+    const { result } = renderHook(() => useCamperEnrollment(PERSON_CM_ID, YEAR), {
+      wrapper: createWrapper(),
+    })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.allAttendees).toHaveLength(1)
+    const teen = expectDefined(result.current.allAttendees[0], 'teen attendee')
+    expect(teen.session_cm_id).toBe(1407000)
+    expect(teen.assigned_bunk).toBe('')
+
+    // The attendee fetch must include teen types in its filter.
+    const attendeeFilter = String(mockAttendeesGetFullList.mock.calls[0]?.[0]?.filter ?? '')
+    expect(attendeeFilter).toContain('session.session_type = "scit"')
+    expect(attendeeFilter).toContain('session.session_type = "tli"')
+    // The assignment fetch stays summer-only (no teen types).
+    const assignmentFilter = String(mockAssignmentsGetFullList.mock.calls[0]?.[0]?.filter ?? '')
+    expect(assignmentFilter).not.toContain('"scit"')
+  })
 })

--- a/frontend/src/hooks/camper/useCamperEnrollment.ts
+++ b/frontend/src/hooks/camper/useCamperEnrollment.ts
@@ -7,6 +7,7 @@ import { useQuery } from '@tanstack/react-query'
 import { pb } from '../../lib/pocketbase'
 import {
   buildSummerSessionTypeFilter,
+  buildCamperDetailSessionTypeFilter,
   isSummerCampSessionType,
 } from '../../utils/sessionTypePredicates'
 import { queryKeys } from '../../utils/queryKeys'
@@ -54,10 +55,10 @@ export function useCamperEnrollment(
     queryFn: async () => {
       if (!personCmId) throw new Error('Invalid person ID')
 
-      // Query attendees with enrollment status check - source of truth for enrollment
-      // Filter to only valid summer session types (main, embedded, ag)
-      const sessionTypeFilter = buildSummerSessionTypeFilter()
-      const filter = `person_id = ${personCmId} && year = ${currentYear} && (${sessionTypeFilter})`
+      // Query attendees — source of truth for enrollment. Teen programs
+      // (scit/tli) are included so a teen-only camper's page loads.
+      const attendeeTypeFilter = buildCamperDetailSessionTypeFilter()
+      const filter = `person_id = ${personCmId} && year = ${currentYear} && (${attendeeTypeFilter})`
 
       const attendees = await pb.collection<AttendeesResponse>('attendees').getFullList({
         filter,
@@ -74,11 +75,12 @@ export function useCamperEnrollment(
         throw new Error(`Person with CampMinder ID ${personCmId} not found`)
       }
 
-      // Load this person's assignments for valid summer session types only.
-      // Restricting by session_type prevents family-camp bunks (which sync but
-      // are out-of-scope for the summer bunking views) from leaking onto a
+      // Load this person's assignments for valid *summer* session types only.
+      // Teens have no bunk; restricting to summer also prevents family-camp bunks
+      // (which sync but are out-of-scope for summer views) from leaking onto a
       // summer attendee row via the AG fallback below.
-      const assignmentFilter = `person.cm_id = ${personCmId} && year = ${currentYear} && (${sessionTypeFilter})`
+      const assignmentTypeFilter = buildSummerSessionTypeFilter()
+      const assignmentFilter = `person.cm_id = ${personCmId} && year = ${currentYear} && (${assignmentTypeFilter})`
       const personAssignments = await pb
         .collection<BunkAssignmentsResponse>('bunk_assignments')
         .getFullList({

--- a/frontend/src/hooks/camper/useCamperHistory.test.tsx
+++ b/frontend/src/hooks/camper/useCamperHistory.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Tests for useCamperHistory — merges live current-year records with the shared
+ * prior-year fetcher, applying AG collapse/relabel to the current year too.
+ * TDD: written before implementation.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper, expectDefined } from '../../test/testUtils'
+import { useCamperHistory } from './useCamperHistory'
+import type { Camper } from '../../types/app-types'
+
+const mockFetchCamperJourney = vi.fn()
+const mockFetchParentMainSessions = vi.fn()
+vi.mock('./fetchCamperJourney', () => ({
+  fetchCamperJourney: (...args: unknown[]) => mockFetchCamperJourney(...args),
+  fetchParentMainSessions: (...args: unknown[]) => mockFetchParentMainSessions(...args),
+}))
+
+const YEAR = 2026
+
+function currentCamper(opts: {
+  sessionCmId: number
+  sessionType: string
+  parentId?: number
+  bunkName?: string
+}): Camper {
+  return {
+    person_cm_id: 12887873,
+    attendee_status: 'enrolled',
+    session_cm_id: opts.sessionCmId,
+    expand: {
+      session: {
+        cm_id: opts.sessionCmId,
+        name: `Session ${opts.sessionCmId}`,
+        session_type: opts.sessionType,
+        start_date: '',
+        end_date: '',
+        ...(opts.parentId !== undefined ? { parent_id: opts.parentId } : {}),
+      },
+      assigned_bunk: opts.bunkName ? { name: opts.bunkName } : null,
+    },
+  } as unknown as Camper
+}
+
+describe('useCamperHistory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetchCamperJourney.mockResolvedValue([])
+    mockFetchParentMainSessions.mockResolvedValue(new Map())
+  })
+
+  it('merges current-year + prior fetcher rows and surfaces a 2022 gap year, sorted -year', async () => {
+    mockFetchCamperJourney.mockResolvedValue([
+      { year: 2023, sessionName: 'Session 3', sessionType: 'main', bunkName: 'G-8B' },
+      { year: 2022, sessionName: 'Session 3', sessionType: 'main' }, // CM gap: no bunk
+    ])
+    const camper = currentCamper({ sessionCmId: 500, sessionType: 'main', bunkName: 'Cabin 5' })
+    const { result } = renderHook(() => useCamperHistory(12887873, YEAR, camper, [camper]), {
+      wrapper: createWrapper(),
+    })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.camperHistory.map((r) => r.year)).toEqual([2026, 2023, 2022])
+    const r2022 = expectDefined(result.current.camperHistory.find((r) => r.year === 2022))
+    expect(r2022.bunkName).toBeUndefined()
+  })
+
+  it('does not stamp "Unassigned" on a current-year teen record', async () => {
+    const teen = currentCamper({ sessionCmId: 700, sessionType: 'scit' })
+    const { result } = renderHook(() => useCamperHistory(12887873, YEAR, teen, [teen]), {
+      wrapper: createWrapper(),
+    })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    const current = expectDefined(result.current.camperHistory.find((r) => r.year === YEAR))
+    expect(current.bunkName).toBeUndefined()
+  })
+
+  it('still stamps "Unassigned" on a current-year bunkable (main) record with no bunk', async () => {
+    const unplaced = currentCamper({ sessionCmId: 500, sessionType: 'main' })
+    const { result } = renderHook(() => useCamperHistory(12887873, YEAR, unplaced, [unplaced]), {
+      wrapper: createWrapper(),
+    })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    const current = expectDefined(result.current.camperHistory.find((r) => r.year === YEAR))
+    expect(current.bunkName).toBe('Unassigned')
+  })
+
+  it('collapses a current-year Main + AG enrollment into one Main row', async () => {
+    const main = currentCamper({ sessionCmId: 100, sessionType: 'main' })
+    const ag = currentCamper({ sessionCmId: 101, sessionType: 'ag', parentId: 100 })
+    const { result } = renderHook(() => useCamperHistory(12887873, YEAR, main, [main, ag]), {
+      wrapper: createWrapper(),
+    })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    const current = result.current.camperHistory.filter((r) => r.year === YEAR)
+    expect(current).toHaveLength(1)
+    expect(current[0]).toMatchObject({ sessionType: 'main', sessionName: 'Session 100' })
+  })
+
+  it('relabels a current-year AG-only camper to its parent main (never session_type ag)', async () => {
+    const ag = currentCamper({ sessionCmId: 200, sessionType: 'ag', parentId: 199 })
+    mockFetchParentMainSessions.mockResolvedValue(
+      new Map([
+        [
+          '2026:199',
+          {
+            cm_id: 199,
+            year: 2026,
+            name: 'Session B',
+            session_type: 'main',
+            start_date: '',
+            end_date: '',
+          },
+        ],
+      ])
+    )
+    const { result } = renderHook(() => useCamperHistory(12887873, YEAR, ag, [ag]), {
+      wrapper: createWrapper(),
+    })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    const current = expectDefined(result.current.camperHistory.find((r) => r.year === YEAR))
+    expect(current.sessionType).toBe('main')
+    expect(current.sessionName).toBe('Session B')
+    expect(mockFetchParentMainSessions).toHaveBeenCalledWith([{ year: 2026, cmId: 199 }])
+  })
+})

--- a/frontend/src/hooks/camper/useCamperHistory.ts
+++ b/frontend/src/hooks/camper/useCamperHistory.ts
@@ -44,7 +44,7 @@ function buildCurrentYearRecords(
   for (const c of campers) {
     const session = c.expand?.session
     if (!session) continue
-    const assignedBunk = c.expand?.assigned_bunk
+    const assignedBunk = c.expand.assigned_bunk
     const isEnrolled = c.attendee_status === 'enrolled'
     const isAg = session.session_type === 'ag'
     const parent = isAg ? parentByKey.get(`${currentYear}:${session.parent_id}`) : undefined

--- a/frontend/src/hooks/camper/useCamperHistory.ts
+++ b/frontend/src/hooks/camper/useCamperHistory.ts
@@ -4,35 +4,63 @@
  */
 
 import { useQuery } from '@tanstack/react-query'
-import { pb } from '../../lib/pocketbase'
-import { isSummerCampSessionType, isMainSession } from '../../utils/sessionTypePredicates'
+import { isAtCampSessionType } from '../../utils/sessionTypePredicates'
 import { filterEnrollmentsByStatus, toDisplayList } from '../../utils/enrollmentFilter'
+import { fetchCamperJourney, fetchParentMainSessions } from './fetchCamperJourney'
 import type { Camper } from '../../types/app-types'
-import type {
-  BunkAssignmentsResponse,
-  CampSessionsResponse,
-  BunksResponse,
-} from '../../types/pocketbase-types'
+import type { CampSessionsResponse } from '../../types/pocketbase-types'
 import type { HistoricalRecord } from './types'
 
-/** Build HistoricalRecord entries from current-year campers */
-function buildCurrentYearRecords(campers: Camper[], currentYear: number): HistoricalRecord[] {
+/**
+ * Drop a current-year AG camper when its parent main is also enrolled this year
+ * (AG is a sub-track, not a separate attendance → show one Main row). An AG
+ * camper without its parent main enrolled keeps its row (to be relabeled).
+ */
+function collapseAgIntoMain(campers: Camper[]): Camper[] {
+  const cmIds = new Set<number>()
+  for (const c of campers) {
+    const cm = c.expand?.session?.cm_id
+    if (cm !== undefined) cmIds.add(cm)
+  }
+  return campers.filter((c) => {
+    const s = c.expand?.session
+    if (s?.session_type !== 'ag') return true
+    return !cmIds.has(s.parent_id)
+  })
+}
+
+/**
+ * Build HistoricalRecord entries from current-year campers. AG is never shown as
+ * its own session — a surviving AG camper is relabeled to its parent main (name
+ * from `parentByKey`, type forced to 'main'). "Unassigned" appears only for a
+ * current-year *bunkable* (main/embedded/ag) session with no bunk yet.
+ */
+function buildCurrentYearRecords(
+  campers: Camper[],
+  currentYear: number,
+  parentByKey: Map<string, CampSessionsResponse>
+): HistoricalRecord[] {
   const records: HistoricalRecord[] = []
   for (const c of campers) {
-    if (c.expand?.session) {
-      const session = c.expand.session
-      const assignedBunk = c.expand.assigned_bunk
-      const isEnrolled = c.attendee_status === 'enrolled'
-      records.push({
-        year: currentYear,
-        sessionName: session.name || 'Unknown',
-        sessionType: session.session_type,
-        bunkName: assignedBunk?.name ?? 'Unassigned',
-        startDate: session.start_date,
-        endDate: session.end_date,
-        ...(isEnrolled ? {} : { attendeeStatus: c.attendee_status }),
-      })
-    }
+    const session = c.expand?.session
+    if (!session) continue
+    const assignedBunk = c.expand?.assigned_bunk
+    const isEnrolled = c.attendee_status === 'enrolled'
+    const isAg = session.session_type === 'ag'
+    const parent = isAg ? parentByKey.get(`${currentYear}:${session.parent_id}`) : undefined
+    const sessionName = parent?.name || session.name || 'Unknown'
+    const sessionType = isAg ? 'main' : session.session_type
+    const bunkName =
+      assignedBunk?.name ?? (isAtCampSessionType(sessionType) ? 'Unassigned' : undefined)
+    records.push({
+      year: currentYear,
+      sessionName,
+      sessionType,
+      ...(bunkName !== undefined ? { bunkName } : {}),
+      startDate: session.start_date,
+      endDate: session.end_date,
+      ...(isEnrolled ? {} : { attendeeStatus: c.attendee_status }),
+    })
   }
   return records
 }
@@ -75,69 +103,30 @@ export function useCamperHistory(
     ],
     queryFn: async () => {
       if (!personCmId) return []
-
       try {
         const allHistory: HistoricalRecord[] = []
-
-        // Add current year records from enrolled (or best fallback) attendees
-        const currentYearCampers = resolveCurrentYearCampers(allAttendees ?? [], camper)
-        allHistory.push(...buildCurrentYearRecords(currentYearCampers, currentYear))
-
-        // Fetch historical data from bunk_assignments for previous years
-        // Query by person.cm_id to get assignments across all year-specific person records
-        // (Person records are created per-year to preserve historical school info)
-        const historicalFilter = `person.cm_id = ${personCmId} && year < ${currentYear}`
-        const historicalAssignments = await pb
-          .collection('bunk_assignments')
-          .getFullList<
-            BunkAssignmentsResponse<{ session?: CampSessionsResponse; bunk?: BunksResponse }>
-          >({
-            filter: historicalFilter,
-            expand: 'session,bunk',
-            sort: '-year',
-            $autoCancel: false,
-          })
-
-        // Group by year and format
-        const yearMap = new Map<number, HistoricalRecord>()
-
-        for (const assignment of historicalAssignments) {
-          const session = assignment.expand.session
-          const bunk = assignment.expand.bunk
-
-          if (session && isSummerCampSessionType(session.session_type)) {
-            const year = assignment.year
-
-            // Format session name based on type
-            const sessionName = session.name
-
-            // If we haven't seen this year yet, or if this is a main session (preferred), add it
-            const existing = yearMap.get(year)
-            if (!existing || isMainSession(session)) {
-              yearMap.set(year, {
-                year,
-                sessionName,
-                sessionType: session.session_type,
-                bunkName: bunk?.name ?? 'Unassigned',
-                startDate: session.start_date,
-                endDate: session.end_date,
-              })
-            }
-          }
+        // Current year from live attendees, with AG collapse + relabel.
+        const currentCampers = collapseAgIntoMain(
+          resolveCurrentYearCampers(allAttendees ?? [], camper)
+        )
+        const agPairs: Array<{ year: number; cmId: number }> = []
+        for (const c of currentCampers) {
+          const s = c.expand?.session
+          if (s?.session_type === 'ag') agPairs.push({ year: currentYear, cmId: s.parent_id })
         }
-
-        // Add historical records to array
-        allHistory.push(...Array.from(yearMap.values()))
-
-        // Sort by year descending
+        const parentByKey = await fetchParentMainSessions(agPairs)
+        allHistory.push(...buildCurrentYearRecords(currentCampers, currentYear, parentByKey))
+        // Prior years from the shared enrollment-sourced fetcher.
+        allHistory.push(...(await fetchCamperJourney(personCmId, currentYear)))
+        // Sort by year descending.
         allHistory.sort((a, b) => b.year - a.year)
-
         return allHistory
       } catch (err) {
         console.error('Error fetching camp history:', err)
-        // If error, at least return current year data from enrolled campers
-        const fallbackCampers = resolveCurrentYearCampers(allAttendees ?? [], camper)
-        return buildCurrentYearRecords(fallbackCampers, currentYear)
+        const fallbackCampers = collapseAgIntoMain(
+          resolveCurrentYearCampers(allAttendees ?? [], camper)
+        )
+        return buildCurrentYearRecords(fallbackCampers, currentYear, new Map())
       }
     },
     enabled: !!personCmId && !!camper,

--- a/frontend/src/utils/__tests__/sessionTypePredicates.test.ts
+++ b/frontend/src/utils/__tests__/sessionTypePredicates.test.ts
@@ -492,16 +492,9 @@ describe('teen cohort', () => {
 })
 
 describe('camper journey/detail session-type sets', () => {
-  it('CAMPER_JOURNEY_TYPES is summer + teen + family', () => {
-    expect(CAMPER_JOURNEY_TYPES).toEqual([
-      'main',
-      'embedded',
-      'ag',
-      'quest',
-      'scit',
-      'tli',
-      'family',
-    ])
+  it('CAMPER_JOURNEY_TYPES is summer + teen, no family (mirrors All Campers / metrics)', () => {
+    expect(CAMPER_JOURNEY_TYPES).toEqual(['main', 'embedded', 'ag', 'quest', 'scit', 'tli'])
+    expect(CAMPER_JOURNEY_TYPES).not.toContain('family')
   })
 
   it('CAMPER_DETAIL_TYPES is summer + teen, no family', () => {
@@ -513,6 +506,7 @@ describe('camper journey/detail session-type sets', () => {
     const f = buildCamperJourneySessionTypeFilter()
     for (const t of CAMPER_JOURNEY_TYPES) expect(f).toContain(`session.session_type = "${t}"`)
     expect(f).toContain('||')
+    expect(f).not.toContain('"family"') // family is excluded from the journey
     expect(f.startsWith('(')).toBe(false) // caller wraps, matching buildSummerSessionTypeFilter
   })
 

--- a/frontend/src/utils/__tests__/sessionTypePredicates.test.ts
+++ b/frontend/src/utils/__tests__/sessionTypePredicates.test.ts
@@ -31,6 +31,10 @@ import {
   buildSummerSessionTypeFilter,
   getSummerWindow,
   isSummerTeenSession,
+  CAMPER_JOURNEY_TYPES,
+  CAMPER_DETAIL_TYPES,
+  buildCamperJourneySessionTypeFilter,
+  buildCamperDetailSessionTypeFilter,
 } from '../sessionTypePredicates'
 import type { Session } from '../../types/app-types'
 
@@ -484,5 +488,38 @@ describe('teen cohort', () => {
     expect(isSummerTeenSession(sess('tli', '2025-08-23', '2026-05-01'), w)).toBe(false) // interns
     expect(isSummerTeenSession(sess('main', '2025-06-15', '2025-07-05'), w)).toBe(false)
     expect(isSummerTeenSession(sess('scit', '2025-06-08', '2025-07-04'), null)).toBe(false)
+  })
+})
+
+describe('camper journey/detail session-type sets', () => {
+  it('CAMPER_JOURNEY_TYPES is summer + teen + family', () => {
+    expect(CAMPER_JOURNEY_TYPES).toEqual([
+      'main',
+      'embedded',
+      'ag',
+      'quest',
+      'scit',
+      'tli',
+      'family',
+    ])
+  })
+
+  it('CAMPER_DETAIL_TYPES is summer + teen, no family', () => {
+    expect(CAMPER_DETAIL_TYPES).toEqual(['main', 'embedded', 'ag', 'quest', 'scit', 'tli'])
+    expect(CAMPER_DETAIL_TYPES).not.toContain('family')
+  })
+
+  it('buildCamperJourneySessionTypeFilter ORs every journey type on session.session_type', () => {
+    const f = buildCamperJourneySessionTypeFilter()
+    for (const t of CAMPER_JOURNEY_TYPES) expect(f).toContain(`session.session_type = "${t}"`)
+    expect(f).toContain('||')
+    expect(f.startsWith('(')).toBe(false) // caller wraps, matching buildSummerSessionTypeFilter
+  })
+
+  it('buildCamperDetailSessionTypeFilter includes teens and excludes family', () => {
+    const f = buildCamperDetailSessionTypeFilter()
+    expect(f).toContain('session.session_type = "scit"')
+    expect(f).toContain('session.session_type = "tli"')
+    expect(f).not.toContain('"family"')
   })
 })

--- a/frontend/src/utils/sessionTypePredicates.ts
+++ b/frontend/src/utils/sessionTypePredicates.ts
@@ -35,6 +35,20 @@ export const QUEST_SESSION_TYPES = ['quest'] as const
 /** Teen program session types */
 export const TEEN_PROGRAM_TYPES = ['scit', 'tli'] as const
 
+/** Curated set shown in a camper's journey timeline: summer + teen + family. */
+export const CAMPER_JOURNEY_TYPES = [
+  'main',
+  'embedded',
+  'ag',
+  'quest',
+  'scit',
+  'tli',
+  'family',
+] as const
+
+/** Curated set driving a camper detail page's current-year fetch: summer + teen, no family. */
+export const CAMPER_DETAIL_TYPES = ['main', 'embedded', 'ag', 'quest', 'scit', 'tli'] as const
+
 /** View mode for metrics: camp sessions, quest sessions, all combined, or teens */
 export type MetricsViewMode = 'sessions' | 'quests' | 'all' | 'teens'
 
@@ -192,6 +206,22 @@ export function isTeenProgramType(sessionType: string | null | undefined): boole
  */
 export function buildSummerSessionTypeFilter(): string {
   return SUMMER_CAMP_TYPES.map((t) => `session.session_type = "${t}"`).join(' || ')
+}
+
+/**
+ * Build a PocketBase OR-clause restricting `session.session_type` to the camper
+ * journey set (summer + teen + family). Caller wraps the result in `(...)`.
+ */
+export function buildCamperJourneySessionTypeFilter(): string {
+  return CAMPER_JOURNEY_TYPES.map((t) => `session.session_type = "${t}"`).join(' || ')
+}
+
+/**
+ * Build a PocketBase OR-clause restricting `session.session_type` to the camper
+ * detail-page current-year set (summer + teen, no family). Caller wraps in `(...)`.
+ */
+export function buildCamperDetailSessionTypeFilter(): string {
+  return CAMPER_DETAIL_TYPES.map((t) => `session.session_type = "${t}"`).join(' || ')
 }
 
 // ============================================================================

--- a/frontend/src/utils/sessionTypePredicates.ts
+++ b/frontend/src/utils/sessionTypePredicates.ts
@@ -35,16 +35,12 @@ export const QUEST_SESSION_TYPES = ['quest'] as const
 /** Teen program session types */
 export const TEEN_PROGRAM_TYPES = ['scit', 'tli'] as const
 
-/** Curated set shown in a camper's journey timeline: summer + teen + family. */
-export const CAMPER_JOURNEY_TYPES = [
-  'main',
-  'embedded',
-  'ag',
-  'quest',
-  'scit',
-  'tli',
-  'family',
-] as const
+/**
+ * Curated set shown in a camper's journey timeline: summer + teen, no family —
+ * mirrors what's visible on the All Campers page and metrics. (Family camp made
+ * the journey noisy for multi-session staff kids; intentionally excluded.)
+ */
+export const CAMPER_JOURNEY_TYPES = ['main', 'embedded', 'ag', 'quest', 'scit', 'tli'] as const
 
 /** Curated set driving a camper detail page's current-year fetch: summer + teen, no family. */
 export const CAMPER_DETAIL_TYPES = ['main', 'embedded', 'ag', 'quest', 'scit', 'tli'] as const

--- a/frontend/src/utils/sessionTypePredicates.ts
+++ b/frontend/src/utils/sessionTypePredicates.ts
@@ -206,7 +206,7 @@ export function buildSummerSessionTypeFilter(): string {
 
 /**
  * Build a PocketBase OR-clause restricting `session.session_type` to the camper
- * journey set (summer + teen + family). Caller wraps the result in `(...)`.
+ * journey set (summer + teen, no family). Caller wraps the result in `(...)`.
  */
 export function buildCamperJourneySessionTypeFilter(): string {
   return CAMPER_JOURNEY_TYPES.map((t) => `session.session_type = "${t}"`).join(' || ')


### PR DESCRIPTION
## Summary

Makes teen-only campers' `/camper/:id` page load, and enriches the camp-journey timeline to show **every prior year a camper actually attended** within the same set shown on the All Campers page and metrics — summer (main/embedded/ag), quest, and teen programs (SCIT/TLI) — including years with no bunk assignment. **Family camp is excluded** (it made the journey noisy for multi-session staff kids).

The journey is now sourced from **enrollment**, not bunk assignments. A new shared `fetchCamperJourney(personCmId, currentYear)` queries `attendees` (enrolled, curated types) and left-joins `bunk_assignments` only to *label* a row. Three consumers (`useCamperHistory`, `CamperDetailsPanel`, `CamperTooltip`) call it so they can't drift.

## What changes
- **Teen pages load**: `useCamperEnrollment` widens its current-year attendee filter to include teen programs (`scit`/`tli`); the bunk-assignment sub-query stays summer-only (preserves the family-camp bunk-leak guard).
- **Enriched journey**: prior years come from enrollment, so years with a CampMinder export gap (no assignment rows), teen years, and no-bunk years all appear — within summer + teen (no family).
- **AG is never shown as its own session**: a same-year Main+AG enrollment collapses to one Main row; an AG-only year is relabeled to its parent Main (name resolved via a `camp_sessions` lookup by `(year, parent_id)`) while keeping the AG bunk. Applied to both prior-year and current-year rows.
- **Display rules**: a no-bunk row is listed with no bunk label; "Unassigned" survives only for a current-year *bunkable* (main/embedded/ag) session not yet placed.
- **Teen detail pages** hide the bunk panels (Bunking Status / Raw / Parsed) and cohort context — teens aren't bunked and don't enter request processing.

## ⚠️ Data dependency (prod follow-up, not this PR)
SCIT sessions must read `session_type='scit'` for teen pages to populate. The rename migration `1500000108_rename_training_to_scit.js` backfills `camp_sessions`/`camper_history` from `training` → `scit`. **However**, if that migration was recorded via the `OnServe` history-sync hook — which marks migrations applied to match the on-disk file list *without executing their UP* — the backfill may never have run, leaving the data on legacy `training` (which no current code matches). **Verify the live `camp_sessions.session_type`**; if it still reads `training`, run the backfill (or a sessions re-sync). This affects the teen metrics pickers too, not just this feature.

## Tests
TDD throughout. New/extended coverage for the fetcher (enrollment-sourced, curated filter excluding family, AG collapse + parent-Main relabel, bunk-label join precedence, no-bunk rows, sort), `useCamperHistory` (current+prior merge, gap-year surfacing, current-year AG handling), `useCamperEnrollment` (teen inclusion), the timeline + tooltip render guards, and `CamperDetail` teen-panel hiding. Full suite green (4540 tests), tsc/eslint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for teen program sessions (SCIT, TLI) with appropriate UI adjustments, hiding bunking panels and cohort badges for teen campers.
  * Improved camp journey history display with centralized data fetching.

* **Bug Fixes**
  * Bunk assignments now display only when applicable to a camper's session type.
  * Sub-track enrollments properly collapse and consolidate with parent main session data.

* **Tests**
  * Added comprehensive test coverage for teen programs, camp journey data fetching, and enrollment consolidation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->