### PR TITLE
chore(ci): disable CodeRabbit eslint tool

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -150,9 +150,14 @@ reviews:
 
   # All linters default to enabled. Mute the Python/JS ones we deliberately don't run
   # locally — they'd flag existing code against rules we don't enforce.
-  # Kept enabled (defaults): ruff, golangci-lint, eslint, shellcheck (mirror our pre-push hooks)
+  # Kept enabled (defaults): ruff, golangci-lint, shellcheck (mirror our pre-push hooks)
   # plus hadolint, actionlint, gitleaks, markdownlint, yamllint, semgrep, ast-grep — no local
   # equivalent, pure CR-side signal.
+  # eslint is disabled: CR runs it from the repo root, but the flat config + deps live in
+  # frontend/ (eslint.config.js). Flat config resolves from cwd, so a root-level run can't
+  # find it and CR just emits "ESLint skipped: no ESLint configuration detected in root
+  # package.json" on every PR. Already enforced by CI's Frontend Lint job (npm run lint in
+  # frontend/) + the pre-push hook — CR adds nothing here.
   tools:
     flake8:
       enabled: false
@@ -161,6 +166,8 @@ reviews:
     biome:
       enabled: false
     oxc:
+      enabled: false
+    eslint:
       enabled: false
 
 knowledge_base:


### PR DESCRIPTION
## Summary

CodeRabbit emits **"ESLint skipped: no ESLint configuration detected in root `package.json`"** on every PR. This disables CR's eslint tool, which can never work given the repo layout.

**Why CR skips it:** CR runs eslint from the repo **root**, but the flat config and deps live entirely in `frontend/` (`eslint.config.js`). ESLint flat config resolves from cwd, so a root-level run can't find it — the skip notice fires on every PR.

**Why it's safe to disable:** eslint is already gated by CI's **Frontend Lint** job (`npm run lint` in `frontend/`, `ci.yml`) and the pre-push hook. CR's root-level run adds zero signal — it only ever skips.

## Change

- `.coderabbit.yaml`: add `tools.eslint.enabled: false` (alongside the already-disabled flake8/pylint/biome/oxc) and update the comment to explain the root-vs-`frontend/` flat-config mismatch.

CR reads `.coderabbit.yaml` from the base branch, so this takes effect for PRs opened after it merges to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration to streamline linting enforcement and align with existing CI validation processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->