### PR TITLE
test(ci): widen CI to full pytest tests/ + pre-push test gate + drift guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,7 +434,7 @@ jobs:
     - name: Run Python unit tests (no external deps)
       env:
         SKIP_POCKETBASE_TESTS: true
-      run: uv run pytest tests/unit/ -v --tb=short --ignore=tests/unit/api/
+      run: uv run pytest tests/ -v --tb=short
 
   # Go tests (parallel)
   tests-go:

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -90,6 +90,17 @@ pre-push:
         - "pyproject.toml"
       run: uv run ruff check .
 
+    # Full mockable Python suite, parallelized (~37s on 12 cores via xdist
+    # worksteal). SKIP_POCKETBASE_TESTS gates the server/DB-dependent suites;
+    # runs in parallel with the checks below. CI runs the same suite serially
+    # (deterministic merge gate); pre-push optimizes for local speed.
+    pytest:
+      glob:
+        - "**/*.py"
+        - "pyproject.toml"
+        - "conftest.py"
+      run: SKIP_POCKETBASE_TESTS=true uv run pytest tests/ -n auto --dist worksteal -q -p no:cacheprovider
+
     mypy:
       glob:
         - "**/*.py"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ Hooks are managed by [lefthook](https://github.com/evilmartians/lefthook) via `.
 |-------|---------|-----------|-------|
 | **pre-commit** | Every commit | Formatters on staged files (prettier, ruff format, gofmt) | <1s |
 | **commit-msg** | Every commit | commitlint validation | Instant |
-| **pre-push** | Every push | Type checks (mypy, tsc), go build, fast linters (ruff, shellcheck, pb-js-lint) | ~15s |
+| **pre-push** | Every push | Type checks (mypy, tsc), go build, fast linters (ruff, shellcheck, pb-js-lint), full mockable pytest (`SKIP_POCKETBASE_TESTS=true`, xdist) | ~40s |
 | **post-merge** | After pull | Worktree cleanup notifications | ~5s |
 
 Escape hatches and manual runs: `docs/reference/git-workflow.md`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ dev = [
     "pip-audit>=2.7.0",
     # Code metrics
     "radon>=6.0.0",
+    "pytest-xdist>=3.8.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -12,6 +12,7 @@ Pytest for Python (`bunking/` + `api/`). See `frontend/CLAUDE.md` for Vitest. La
 |--------|--------------|
 | `ai_required` | Skipped in CI (needs live AI tokens). Run locally with `AI_API_KEY` set. |
 | `pocketbase_required` | Skipped in CI (needs running PocketBase). Run locally with `./scripts/start_dev.sh` up. |
+| `requires_pb_db` (`tests/markers.py`) | Skipped in CI and pre-push (`SKIP_POCKETBASE_TESTS=true`). Hits PocketBase's SQLite directly, so it needs a real `data.db`. Runs locally and in CD. |
 
 **CI passing does not mean these tests passed.** Verify locally before merging features that touch AI or DB paths.
 
@@ -39,7 +40,7 @@ uv run pytest tests/ -k "keyword"                   # by keyword
 SKIP_POCKETBASE_TESTS=true uv run pytest tests/     # explicit skip even locally
 ```
 
-Pre-push runs type checks and fast linters only (mypy, tsc, ruff, golangci-lint, shellcheck, pb-js-lint) — pytest and vitest are CI-only. Run them locally when you make test-affecting changes. Integration/e2e require a running dev server regardless of where they run.
+Pre-push runs type checks and fast linters (mypy, tsc, ruff, golangci-lint, shellcheck, pb-js-lint) **plus the full mockable Python suite** (`SKIP_POCKETBASE_TESTS=true uv run pytest tests/ -n auto`). Vitest is still CI-only. DB/server-coupled tests (`requires_pb_db`, integration/e2e) are skipped on both pre-push and CI — run them locally with a running dev server.
 
 ## Worktree gotcha
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,23 +1,24 @@
 """
 Integration test configuration.
 
-These tests require external services (PocketBase, solver service).
-Skip them when SKIP_POCKETBASE_TESTS is set.
+The sync/ integration tests require external services (PocketBase, solver service).
+Skip them when SKIP_POCKETBASE_TESTS is set. The solver/ integration tests are pure
+Python (DirectSolverInput fixtures, no network) and always run.
 """
 
 import os
 
 import pytest
 
-# Skip all integration tests when SKIP_POCKETBASE_TESTS is set
+# Skip only the server-dependent sync integration tests when the gate is set.
 if os.environ.get("SKIP_POCKETBASE_TESTS") == "true":
-    collect_ignore_glob = ["**/*.py"]
+    collect_ignore_glob = ["sync/**"]
 
 
 def pytest_collection_modifyitems(config, items):
-    """Skip integration tests when SKIP_POCKETBASE_TESTS is set."""
+    """Skip server-dependent sync integration tests when SKIP_POCKETBASE_TESTS is set."""
     if os.environ.get("SKIP_POCKETBASE_TESTS") == "true":
         skip_pb = pytest.mark.skip(reason="SKIP_POCKETBASE_TESTS is set")
         for item in items:
-            if "integration" in str(item.fspath):
+            if "integration/sync" in str(item.fspath):
                 item.add_marker(skip_pb)

--- a/tests/markers.py
+++ b/tests/markers.py
@@ -1,0 +1,17 @@
+"""Shared pytest markers for the test suite.
+
+``requires_pb_db`` gates tests that reach PocketBase's SQLite directly (via
+``api.services.metrics_sql_connection``) and therefore need a real database file
+(``PB_DATA_DIR`` / ``pocketbase/pb_data/data.db``). These are integration-shaped
+tests living in the unit tree; they run locally and in CD (where a DB exists) and
+are skipped under ``SKIP_POCKETBASE_TESTS`` (CI / pre-push, where there is no DB).
+"""
+
+import os
+
+import pytest
+
+requires_pb_db = pytest.mark.skipif(
+    os.environ.get("SKIP_POCKETBASE_TESTS") == "true",
+    reason="Hits PocketBase SQLite directly; needs a real DB (PB_DATA_DIR / pocketbase/pb_data/data.db).",
+)

--- a/tests/performance/conftest.py
+++ b/tests/performance/conftest.py
@@ -1,0 +1,12 @@
+"""
+Performance test configuration.
+
+These modules drive a running stack (localhost:8080) and match the *_test.py
+collection pattern. Skip them when SKIP_POCKETBASE_TESTS is set (CI / pre-push) so
+`pytest tests/` neither imports nor runs them; they run in CD against the booted stack.
+"""
+
+import os
+
+if os.environ.get("SKIP_POCKETBASE_TESTS") == "true":
+    collect_ignore_glob = ["**/*.py"]

--- a/tests/performance/conftest.py
+++ b/tests/performance/conftest.py
@@ -1,9 +1,10 @@
 """
 Performance test configuration.
 
-These modules drive a running stack (localhost:8080) and match the *_test.py
-collection pattern. Skip them when SKIP_POCKETBASE_TESTS is set (CI / pre-push) so
-`pytest tests/` neither imports nor runs them; they run in CD against the booted stack.
+These modules drive a running stack (localhost:8080); the *_test.py files among them
+match pytest's collection pattern. Skip them when SKIP_POCKETBASE_TESTS is set (CI /
+pre-push) so `pytest tests/` neither imports nor runs them; they run in CD against the
+booted stack.
 """
 
 import os

--- a/tests/test_metrics_retention.py
+++ b/tests/test_metrics_retention.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock
 import pytest
 from fastapi.testclient import TestClient
 
+from tests.markers import requires_pb_db
+
 # ============================================================================
 # Test fixtures
 # ============================================================================
@@ -40,6 +42,7 @@ def test_client():
 # ============================================================================
 
 
+@requires_pb_db
 class TestRetentionTrendsEnrollmentByYear:
     """Tests for the enrollment_by_year field in RetentionTrendsResponse."""
 
@@ -255,6 +258,7 @@ class TestEnrollmentByYearSchemas:
 # ============================================================================
 
 
+@requires_pb_db
 class TestRetentionTrendsEnrollmentIntegration:
     """Integration tests for enrollment_by_year calculation."""
 
@@ -337,6 +341,7 @@ class TestRetentionTrendsEnrollmentIntegration:
         assert len(enrollment_by_year) == 4, f"Expected 4 entries, got {len(enrollment_by_year)}"
 
 
+@requires_pb_db
 class TestEnrollmentByYearAllSessions:
     """Tests for enrollment_by_year when 'All Sessions' is selected (no session_cm_id filter).
 

--- a/tests/unit/api/test_geo_service.py
+++ b/tests/unit/api/test_geo_service.py
@@ -1274,16 +1274,21 @@ class TestPersonIdCache:
     @pytest.mark.asyncio
     async def test_cache_expires_after_ttl(self, service: GeoService, mock_pb: MagicMock) -> None:
         """Cache should expire after TTL seconds."""
-        from api.services.geo_service import _PERSON_ID_CACHE
+        import time
+
+        from api.services.geo_service import _PERSON_ID_CACHE, _PERSON_ID_CACHE_TTL_SECONDS
 
         attendees = [_make_attendee_record("p1")]
         mock_pb.collection.return_value.get_full_list.return_value = attendees
 
         await service._fetch_active_person_pb_ids(2025)
 
-        # Manually expire the cache by setting timestamp to 0
+        # Force expiry relative to the monotonic clock. The cache ages via
+        # time.monotonic() (arbitrary origin ~ boot), so an absolute 0.0 is not
+        # reliably "expired" on a freshly-booted CI runner where monotonic() < TTL.
+        stale = time.monotonic() - _PERSON_ID_CACHE_TTL_SECONDS - 1
         for key in _PERSON_ID_CACHE:
-            _PERSON_ID_CACHE[key] = (_PERSON_ID_CACHE[key][0], 0.0)
+            _PERSON_ID_CACHE[key] = (_PERSON_ID_CACHE[key][0], stale)
 
         await service._fetch_active_person_pb_ids(2025)
         assert mock_pb.collection.return_value.get_full_list.call_count == 2

--- a/tests/unit/api/test_metrics.py
+++ b/tests/unit/api/test_metrics.py
@@ -12,6 +12,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from api.main import create_app
+from tests.markers import requires_pb_db
 from tests.unit.api.conftest import create_mock_attendee, create_mock_person, create_mock_session
 
 # ============================================================================
@@ -991,6 +992,7 @@ class TestCamperHistorySessionTypesFiltering:
         assert len(unfiltered) == 14  # All records
 
 
+@requires_pb_db
 class TestMetricsAPIEndpoints:
     """Integration tests for metrics API endpoints."""
 
@@ -1270,6 +1272,7 @@ class TestStatusesParameter:
         """Create test client."""
         return TestClient(app)
 
+    @requires_pb_db
     def test_registration_accepts_statuses_parameter(self, client: TestClient, mock_pocketbase: Mock) -> None:
         """Test that registration endpoint accepts statuses parameter.
 
@@ -1322,6 +1325,7 @@ class TestComparisonEndpointSessionTypes:
         """Create test client."""
         return TestClient(app)
 
+    @requires_pb_db
     def test_comparison_accepts_session_types_parameter(self, client: TestClient, mock_pocketbase: Mock) -> None:
         """Test that comparison endpoint accepts session_types parameter.
 
@@ -1434,6 +1438,7 @@ class TestDynamicStatusFetching:
 
         assert len(filtered) == 3
 
+    @requires_pb_db
     def test_registration_endpoint_uses_all_requested_statuses(
         self, attendees_with_all_statuses: list[Mock], mock_pocketbase: Mock
     ) -> None:
@@ -1477,6 +1482,7 @@ class TestDynamicStatusFetching:
         assert 'status = "waitlisted"' in expected_filter
         assert "||" in expected_filter
 
+    @requires_pb_db
     def test_empty_statuses_defaults_to_enrolled(self, mock_pocketbase: Mock) -> None:
         """Test that empty/missing statuses parameter defaults to enrolled.
 
@@ -1498,6 +1504,7 @@ class TestDynamicStatusFetching:
             response = client.get("/api/metrics/registration?year=2026")
             assert response.status_code == 200
 
+    @requires_pb_db
     def test_single_non_enrolled_status_works(self, mock_pocketbase: Mock) -> None:
         """Test that querying a single non-enrolled status works.
 
@@ -2832,6 +2839,7 @@ class TestBatchFetchSummerEnrollmentHistory:
         assert prior_sessions_by_person[103] == []  # No prior year enrollment
 
 
+@requires_pb_db
 class TestRetentionEndpointWithSessionCmId:
     """Integration tests for retention endpoint with session_cm_id parameter."""
 

--- a/tests/unit/api/test_metrics_registration.py
+++ b/tests/unit/api/test_metrics_registration.py
@@ -16,6 +16,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from api.main import create_app
+from tests.markers import requires_pb_db
 from tests.unit.api.conftest import create_mock_attendee, create_mock_person, create_mock_session
 
 # ============================================================================
@@ -542,6 +543,7 @@ class TestFirstSummerYearBreakdown:
 # ============================================================================
 
 
+@requires_pb_db
 class TestRegistrationEndpointWithSessionFilter:
     """Integration tests for the /api/metrics/registration endpoint with session filter."""
 

--- a/tests/unit/api/test_retention_trends.py
+++ b/tests/unit/api/test_retention_trends.py
@@ -401,6 +401,9 @@ class TestRetentionTrendsEndpoint:
             # Will 500 or 200 depending on implementation status
             assert response.status_code != 404
 
+    # Intentionally NOT @requires_pb_db: the missing required param yields a 422
+    # in FastAPI validation before the handler builds a repository, so no DB is
+    # touched and this runs in CI. If current_year ever becomes optional, gate it.
     def test_endpoint_requires_current_year(self, client: TestClient) -> None:
         """The current_year parameter should be required."""
         with patch("api.routers.metrics.pb") as mock_pb:

--- a/tests/unit/api/test_retention_trends.py
+++ b/tests/unit/api/test_retention_trends.py
@@ -17,6 +17,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from api.main import create_app
+from tests.markers import requires_pb_db
 from tests.unit.api.conftest import create_mock_attendee, create_mock_person, create_mock_session
 
 # ============================================================================
@@ -383,6 +384,7 @@ class TestRetentionTrendsParameters:
 class TestRetentionTrendsEndpoint:
     """Integration tests for the /api/metrics/retention-trends endpoint."""
 
+    @requires_pb_db
     def test_endpoint_exists(self, client: TestClient) -> None:
         """The retention-trends endpoint should exist and accept GET requests."""
         with patch("api.routers.metrics.pb") as mock_pb:
@@ -412,6 +414,7 @@ class TestRetentionTrendsEndpoint:
             # or 404 if endpoint not yet implemented
             assert response.status_code in (404, 422)
 
+    @requires_pb_db
     def test_endpoint_accepts_optional_params(self, client: TestClient) -> None:
         """Optional parameters should be accepted."""
         with patch("api.routers.metrics.pb") as mock_pb:
@@ -433,6 +436,7 @@ class TestRetentionTrendsEndpoint:
             # 404 if endpoint not implemented, 200/500 otherwise
             assert response.status_code != 422
 
+    @requires_pb_db
     def test_response_structure(self, client: TestClient) -> None:
         """Response should have expected structure once implemented."""
         with patch("api.routers.metrics.pb") as mock_pb:

--- a/tests/unit/test_collection_coverage.py
+++ b/tests/unit/test_collection_coverage.py
@@ -1,0 +1,36 @@
+"""Guard against orphaned test files outside the configured testpath.
+
+CI runs ``pytest tests/`` and ``testpaths = ["tests"]``. Any committed
+``test_*.py`` / ``*_test.py`` outside ``tests/`` is invisible to every gate — the
+``api/services/`` colocated-orphan incident (2026-05) had 209 tests run by nothing.
+This test fails closed if such a file reappears.
+"""
+
+import fnmatch
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEST_GLOBS = ("test_*.py", "*_test.py")  # mirrors pyproject [tool.pytest] python_files
+
+
+def _tracked_test_files() -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files", "*.py"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [
+        line for line in out.stdout.splitlines() if any(fnmatch.fnmatch(Path(line).name, glob) for glob in TEST_GLOBS)
+    ]
+
+
+def test_no_test_files_outside_testpath() -> None:
+    """Every committed test file must live under tests/ (the configured testpath)."""
+    orphans = [f for f in _tracked_test_files() if not f.startswith("tests/")]
+    assert not orphans, (
+        "Test files found outside the configured testpath 'tests/'. CI runs "
+        "`pytest tests/`, so these would never run. Move them under tests/:\n" + "\n".join(orphans)
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -420,6 +420,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
@@ -690,6 +699,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "radon" },
     { name = "ruff" },
     { name = "types-psutil" },
@@ -740,6 +750,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "radon", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.15.10" },
     { name = "types-psutil", specifier = ">=7.2.2.20260408" },
@@ -1467,6 +1478,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

**PR2 of the test-gating redesign** — stacked on #1615 (base: `feature/test-gating-redesign`). This is the gate change.

Standardizes on `SKIP_POCKETBASE_TESTS` as the capability gate (no new marker for server tests) and widens CI from `pytest tests/unit/ --ignore=tests/unit/api/` (skipped ~1,540 mockable tests) to **`pytest tests/`**.

- **`tests/integration/conftest.py`** — env-skip now ignores `sync/**` only, so the 8 **serverless** `tests/integration/solver/` tests run in CI (were wrongly blanket-skipped).
- **`tests/performance/conftest.py`** (new) — gates `load_test.py`/`quick_load_test.py` (they match `*_test.py`).
- **`tests/markers.py`** (new) — `requires_pb_db` marker. **Surgically gates 27 DB-coupled metrics endpoint tests** (FastAPI `TestClient` paths that hit real PocketBase SQLite) across 4 files. Whole-class where the class is 100% DB-coupled; method-level in mixed classes — so the ~160 mockable tests in those files still run in CI. These pass locally/CD (DB present), skip under the gate.
- **`tests/unit/test_collection_coverage.py`** (new) — drift guard: fails if any committed `test_*.py`/`*_test.py` lands outside `tests/`.
- **CI** (`ci.yml`) → `SKIP_POCKETBASE_TESTS=true pytest tests/` (serial, deterministic gate).
- **pre-push** (`.lefthook.yml`) → full mockable suite via `pytest -n auto --dist worksteal` (~40s on 12 cores; `pytest-xdist` added as a dev dep).

## Why DB-coupled tests are gated, not run in CI
They need a real PB database (`PB_DATA_DIR`), which CI doesn't have — they're integration-shaped tests living in the unit tree. Same status as today (CI never ran them); CI now additionally gains ~1,540 genuinely-mockable tests. Running them automatically is PR3's job (CD, against the booted stack).

## Verification
`SKIP_POCKETBASE_TESTS=true pytest tests/` → **5184 passed, 41 skipped, 0 failed** (41 = 27 DB-coupled gated + 14 reachability skips). Verified parallel-safe under xdist. Pre-push green (~43s). ruff + mypy clean (704 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs the full Python test suite (broader coverage)
  * Pre-push runs pytest in parallel for faster feedback
  * Dev dependencies updated to support parallel test execution

* **Tests**
  * Added a marker to conditionally skip PocketBase-dependent tests
  * Performance tests and certain integration tests are opt-out when DB tests are skipped
  * Added a test enforcing test files reside under the configured test path

* **Documentation**
  * Updated pre-push hook and test guidance in docs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->