### PR TITLE
feat(ci): CD runs integration/sync contract tests vs booted stack (PR3) + gate hardening (#1620, #1621)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -668,6 +668,14 @@ jobs:
       with:
         persist-credentials: false
 
+    - name: Setup Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      with:
+        python-version-file: '.python-version'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
       with:
@@ -737,6 +745,22 @@ jobs:
         }
         test_endpoint "http://localhost:8080/health" "Health check" || exit 1
         test_endpoint "http://localhost:8080/api/config" "FastAPI config" || exit 1
+
+    - name: Run server contract tests against the stack
+      env:
+        SKIP_POCKETBASE_TESTS: "false"
+        # PB (:8090) and FastAPI (:8000) are internal-only; reach PocketBase through caddy
+        # (:8080), which proxies /api/collections/* to PB. Admin creds match .env.ci above.
+        POCKETBASE_URL: http://127.0.0.1:8080
+        POCKETBASE_ADMIN_EMAIL: ci@test.local
+        POCKETBASE_ADMIN_PASSWORD: ci-test-password
+      run: |
+        uv sync --frozen -q
+        # Data-tolerant integration/sync contract tests (component wiring + dry-run): they
+        # validate connectivity/instantiation against the booted stack and pass against an
+        # empty PB. Data-dependent suites (e2e CLI, the 27 requires_pb_db metrics tests,
+        # performance) need a seeded dataset CD lacks — tracked in #1623.
+        uv run pytest tests/integration/sync -v --tb=short -p no:cacheprovider
 
     - name: Verify non-root user and distroless containers
       run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -754,18 +754,20 @@ jobs:
         POCKETBASE_URL: http://127.0.0.1:8080
         POCKETBASE_ADMIN_EMAIL: ci@test.local
         POCKETBASE_ADMIN_PASSWORD: ci-test-password
+        # The orchestrator/full-pipeline smoke tests construct an AI provider; its init is a
+        # *presence* check on the key. CD's PB is empty ⇒ the dry-run has 0 requests ⇒ no real
+        # AI call is made, so a placeholder satisfies init without a secret or API spend
+        # (verified: both pass with a deliberately-invalid key against an empty PB). When
+        # #1623 seeds data the pipeline would actually call the provider — a real key (secret)
+        # is needed then.
+        AI_PROVIDER: openai
+        AI_API_KEY: ci-placeholder-not-called
       run: |
         uv sync --frozen -q
-        # Connectivity/wiring contract tests: validate PocketBase reachability (through caddy)
-        # + repository/cache instantiation against the booted stack; they pass against an
-        # empty PB. The Orchestrator + full-pipeline smoke tests are deselected — they
-        # construct an AI provider (needs AI_API_KEY) that CD does not configure. Those, plus
-        # the data-dependent suites (e2e CLI, the 27 requires_pb_db metrics tests,
-        # performance), are tracked in #1623.
-        uv run pytest tests/integration/sync \
-          --deselect "tests/integration/sync/test_bunk_processor_smoke.py::TestOrchestratorSmoke::test_orchestrator_initializes_with_data_context" \
-          --deselect "tests/integration/sync/test_bunk_processor_smoke.py::TestFullPipelineSmoke::test_full_pipeline_dry_run" \
-          -v --tb=short -p no:cacheprovider
+        # Connectivity/wiring contract tests against the booted stack; pass against an empty
+        # PB. Data-dependent suites (e2e CLI, the 27 requires_pb_db metrics tests, performance)
+        # need a seeded dataset CD lacks — tracked in #1623.
+        uv run pytest tests/integration/sync -v --tb=short -p no:cacheprovider
 
     - name: Verify non-root user and distroless containers
       run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -756,11 +756,16 @@ jobs:
         POCKETBASE_ADMIN_PASSWORD: ci-test-password
       run: |
         uv sync --frozen -q
-        # Data-tolerant integration/sync contract tests (component wiring + dry-run): they
-        # validate connectivity/instantiation against the booted stack and pass against an
-        # empty PB. Data-dependent suites (e2e CLI, the 27 requires_pb_db metrics tests,
-        # performance) need a seeded dataset CD lacks — tracked in #1623.
-        uv run pytest tests/integration/sync -v --tb=short -p no:cacheprovider
+        # Connectivity/wiring contract tests: validate PocketBase reachability (through caddy)
+        # + repository/cache instantiation against the booted stack; they pass against an
+        # empty PB. The Orchestrator + full-pipeline smoke tests are deselected — they
+        # construct an AI provider (needs AI_API_KEY) that CD does not configure. Those, plus
+        # the data-dependent suites (e2e CLI, the 27 requires_pb_db metrics tests,
+        # performance), are tracked in #1623.
+        uv run pytest tests/integration/sync \
+          --deselect "tests/integration/sync/test_bunk_processor_smoke.py::TestOrchestratorSmoke::test_orchestrator_initializes_with_data_context" \
+          --deselect "tests/integration/sync/test_bunk_processor_smoke.py::TestFullPipelineSmoke::test_full_pipeline_dry_run" \
+          -v --tb=short -p no:cacheprovider
 
     - name: Verify non-root user and distroless containers
       run: |

--- a/tests/_env.py
+++ b/tests/_env.py
@@ -1,0 +1,16 @@
+"""Dependency-free env-truthiness helper (no pytest import — safe in early conftest import).
+
+``is_truthy_env(name)`` is the single way the suite reads boolean gate vars
+(``SKIP_POCKETBASE_TESTS``, ``SKIP_MOCKING``, ...). It accepts the common truthy spellings
+and trims/lowercases. ``default`` preserves each call site's unset semantics: gate vars that
+should *run* tests when unset use the ``"false"`` default; the sync smoke/CLI tests that
+should *skip* when unset pass ``default="true"``.
+"""
+
+import os
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def is_truthy_env(name: str, *, default: str = "false") -> bool:
+    return os.environ.get(name, default).strip().lower() in _TRUTHY

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,12 +10,13 @@ This conftest.py provides common fixtures for all test categories:
 Note: sys.path manipulation is handled here to ensure imports work correctly.
 """
 
-import os
 import sys
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
+
+from tests._env import is_truthy_env
 
 # Add project root to path to allow imports
 project_root = Path(__file__).parent.parent
@@ -82,7 +83,7 @@ def mock_all_external_services():
     services like PocketBase, unless explicitly disabled.
     """
     # Skip mocking for integration tests that explicitly need real connections
-    if os.environ.get("SKIP_MOCKING") == "true":
+    if is_truthy_env("SKIP_MOCKING"):
         yield {}
         return
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -5,18 +5,18 @@ These tests require all services running (PocketBase, solver service, frontend).
 Skip them when SKIP_POCKETBASE_TESTS is set.
 """
 
-import os
-
 import pytest
 
+from tests._env import is_truthy_env
+
 # Skip all e2e tests when SKIP_POCKETBASE_TESTS is set
-if os.environ.get("SKIP_POCKETBASE_TESTS") == "true":
+if is_truthy_env("SKIP_POCKETBASE_TESTS"):
     collect_ignore_glob = ["**/*.py"]
 
 
 def pytest_collection_modifyitems(config, items):
     """Skip e2e tests when SKIP_POCKETBASE_TESTS is set."""
-    if os.environ.get("SKIP_POCKETBASE_TESTS") == "true":
+    if is_truthy_env("SKIP_POCKETBASE_TESTS"):
         skip_pb = pytest.mark.skip(reason="SKIP_POCKETBASE_TESTS is set")
         for item in items:
             if "e2e" in str(item.fspath):

--- a/tests/e2e/sync/test_bunk_processor_cli.py
+++ b/tests/e2e/sync/test_bunk_processor_cli.py
@@ -9,11 +9,13 @@ from pathlib import Path
 
 import pytest
 
+from tests._env import is_truthy_env
+
 # Get project root relative to this test file
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 
 pytestmark = pytest.mark.skipif(
-    os.environ.get("SKIP_POCKETBASE_TESTS", "true").lower() == "true",
+    is_truthy_env("SKIP_POCKETBASE_TESTS", default="true"),
     reason="E2E tests require running services",
 )
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,18 +6,18 @@ Skip them when SKIP_POCKETBASE_TESTS is set. The solver/ integration tests are p
 Python (DirectSolverInput fixtures, no network) and always run.
 """
 
-import os
-
 import pytest
 
+from tests._env import is_truthy_env
+
 # Skip only the server-dependent sync integration tests when the gate is set.
-if os.environ.get("SKIP_POCKETBASE_TESTS") == "true":
+if is_truthy_env("SKIP_POCKETBASE_TESTS"):
     collect_ignore_glob = ["sync/**"]
 
 
 def pytest_collection_modifyitems(config, items):
     """Skip server-dependent sync integration tests when SKIP_POCKETBASE_TESTS is set."""
-    if os.environ.get("SKIP_POCKETBASE_TESTS") == "true":
+    if is_truthy_env("SKIP_POCKETBASE_TESTS"):
         skip_pb = pytest.mark.skip(reason="SKIP_POCKETBASE_TESTS is set")
         for item in items:
             if "integration/sync" in str(item.fspath):

--- a/tests/integration/sync/test_bunk_processor_smoke.py
+++ b/tests/integration/sync/test_bunk_processor_smoke.py
@@ -6,13 +6,13 @@ without mocks, catching interface mismatches early.
 Requires: SKIP_POCKETBASE_TESTS=false or running PocketBase instance
 """
 
-import os
-
 import pytest
+
+from tests._env import is_truthy_env
 
 # Skip if PocketBase not available
 pytestmark = pytest.mark.skipif(
-    os.environ.get("SKIP_POCKETBASE_TESTS", "true").lower() == "true",
+    is_truthy_env("SKIP_POCKETBASE_TESTS", default="true"),
     reason="PocketBase integration tests skipped",
 )
 

--- a/tests/markers.py
+++ b/tests/markers.py
@@ -7,11 +7,11 @@ tests living in the unit tree; they run locally and in CD (where a DB exists) an
 are skipped under ``SKIP_POCKETBASE_TESTS`` (CI / pre-push, where there is no DB).
 """
 
-import os
-
 import pytest
 
+from tests._env import is_truthy_env
+
 requires_pb_db = pytest.mark.skipif(
-    os.environ.get("SKIP_POCKETBASE_TESTS") == "true",
+    is_truthy_env("SKIP_POCKETBASE_TESTS"),
     reason="Hits PocketBase SQLite directly; needs a real DB (PB_DATA_DIR / pocketbase/pb_data/data.db).",
 )

--- a/tests/performance/conftest.py
+++ b/tests/performance/conftest.py
@@ -9,5 +9,11 @@ booted stack.
 
 from tests._env import is_truthy_env
 
+# collect_ignore_glob prevents *import/collection* (not just runtime skip), which matters
+# here: this dir has NO pytest_collection_modifyitems backup, and load_test.py /
+# quick_load_test.py match python_files=*_test.py, so a bad glob would import them under
+# the gate. They live DIRECTLY in tests/performance/ (no subdir), and "**/*.py" only
+# matches files under a subdirectory (the "**/" requires a path separator) — so the
+# top-level "*.py" entry is required to actually gate them. (#1621)
 if is_truthy_env("SKIP_POCKETBASE_TESTS"):
-    collect_ignore_glob = ["**/*.py"]
+    collect_ignore_glob = ["*.py", "**/*.py"]

--- a/tests/performance/conftest.py
+++ b/tests/performance/conftest.py
@@ -7,7 +7,7 @@ pre-push) so `pytest tests/` neither imports nor runs them; they run in CD again
 booted stack.
 """
 
-import os
+from tests._env import is_truthy_env
 
-if os.environ.get("SKIP_POCKETBASE_TESTS") == "true":
+if is_truthy_env("SKIP_POCKETBASE_TESTS"):
     collect_ignore_glob = ["**/*.py"]

--- a/tests/unit/test_env_helper.py
+++ b/tests/unit/test_env_helper.py
@@ -1,0 +1,40 @@
+"""Tests for the shared env-truthiness helper (#1620)."""
+
+import pytest
+
+from tests._env import is_truthy_env
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("true", True),
+        ("True", True),
+        ("TRUE", True),
+        (" true ", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        ("false", False),
+        ("False", False),
+        ("0", False),
+        ("no", False),
+        ("off", False),
+        ("", False),
+        ("anything", False),
+    ],
+)
+def test_is_truthy_env_values(monkeypatch, raw, expected):
+    monkeypatch.setenv("X_GATE", raw)
+    assert is_truthy_env("X_GATE") is expected
+
+
+def test_is_truthy_env_unset_default_false(monkeypatch):
+    monkeypatch.delenv("X_GATE", raising=False)
+    assert is_truthy_env("X_GATE") is False
+
+
+def test_is_truthy_env_unset_default_true(monkeypatch):
+    """Skip-when-unset sites (sync smoke/CLI) pass default='true'."""
+    monkeypatch.delenv("X_GATE", raising=False)
+    assert is_truthy_env("X_GATE", default="true") is True


### PR DESCRIPTION
Completes the test-gating redesign (PR1 #1615, PR2 #1617 merged). Three independent changes:

### PR3 — CD runs server tests against the booted stack
CD's `integration-test` job booted the full stack but ran **zero pytest** (curl health checks only). Adds Python/uv setup + a step running `pytest tests/integration/sync` (`SKIP_POCKETBASE_TESTS=false`) against the running stack, reaching PocketBase through caddy (`:8080` → `/api/collections/*` proxy; PB `:8090` / FastAPI `:8000` are internal-only). Admin creds match `.env.ci`.

**Scope = the data-tolerant contract subset.** Investigation found CD's PocketBase boots **empty** (`SKIP_CAMPMINDER=true`, fresh volume, no seed). The 6 integration/sync smoke tests assert component wiring + a dry-run pipeline — they pass against an empty-but-reachable PB (verified locally against a schema-only PocketBase: 6/6). Data-*dependent* suites — the e2e CLI (exits 1 on empty data), the 27 `requires_pb_db` metrics tests, and `tests/performance` — need a seeded dataset CD lacks, tracked in **#1623**.

### #1620 — single env-truthiness helper
Replaces two divergent conventions (`== "true"` default-run vs `.get(...,"true").lower()=="true"` default-skip) with one dependency-free `is_truthy_env(name, *, default=...)` in `tests/_env.py`, applied at all 9 gate sites across 7 files. Each site keeps its unset default (the 2 sync smoke/CLI sites pass `default="true"`). Closes #1620.

### #1621 — fix performance `collect_ignore_glob` gate gap
`tests/performance/{load_test,quick_load_test}.py` match `python_files=*_test.py` and live **directly** in `tests/performance/`, but `collect_ignore_glob=["**/*.py"]` only matches sub*directory* files — so under the gate they were still imported (proven by an import-time pandas warning), with no `modifyitems` backup. Added `"*.py"`. Verified: gate-ON collects 0 (no import), gate-OFF still collects them. integration (`sync/**`) and e2e (subdir-only test files) already gate correctly. Closes #1621.

## Verification
- Full gate-ON suite: **5247 passed, 41 skipped, 0 failed** (`SKIP_POCKETBASE_TESTS=true pytest tests/`).
- integration/sync smoke: **6/6 pass** gate-OFF against an empty/schema-only PocketBase.
- pre-push verification: all checks pass.
- **CD note:** the `integration-test` job is `should_build`-gated, so a cd.yml-only change may not trigger it on this PR — exercise it via a forced build (`workflow_dispatch` REBUILD_ALL) or the next image-touching merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CI now installs a Python runtime and runs a dedicated server contract integration step during integration testing.
  * Test suite standardizes environment-variable truthiness parsing across unit, integration, e2e and performance tests.
  * Added unit tests for the new environment-variable truthiness helper to ensure consistent skip/gate behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->