### PR TITLE
fix(scripts): lefthook install --force in new.sh to survive stale .old hook backups

### DIFF
--- a/scripts/worktree/new.sh
+++ b/scripts/worktree/new.sh
@@ -224,9 +224,13 @@ API_PORT=$FASTAPI_PORT
 WORKTREE_NAME=$FEATURE_NAME
 EOF
 
-# Install lefthook hooks in the worktree
+# Install lefthook hooks in the worktree.
+# --force overwrites stale .old backups: worktrees share the main repo's .git/hooks, and
+# lefthook backs up existing hooks to <hook>.old on install. A leftover .old from a prior
+# worktree makes the backup-rename fail ("can't rename pre-push to pre-push.old"), and with
+# set -e that aborts new.sh mid-setup (before deps/local-config/DB-seed). --force skips that.
 if command -v lefthook &> /dev/null; then
-    lefthook install --reset-hooks-path
+    lefthook install --reset-hooks-path --force
 else
     echo -e "${YELLOW}Warning: lefthook not installed — run 'go install github.com/evilmartians/lefthook/v2@latest'${NC}"
 fi


### PR DESCRIPTION
## Problem

`scripts/worktree/new.sh` aborts mid-setup when the main repo's `.git/hooks` has a stale `<hook>.old` backup. Worktrees share `.git/hooks`; `lefthook install` backs up a foreign (non-lefthook) hook to `<hook>.old`, and if a leftover `.old` exists, the rename fails:

```
sync hooks: ❌
  Error: could not replace the hook: can't rename pre-push to pre-push.old - file already exists
```

With `set -e`, the script exits there — **before** `uv sync`, local-config symlinks, PocketBase build, and the DB seed — leaving a worktree with no deps, no branding, and no `data.db`. Hit this twice during recent worktree creation.

## Fix

Add `--force` to the `lefthook install --reset-hooks-path` call. Per `lefthook install --help`, `--force` "overwrite .old files and proceed" — so a stale `.old` no longer blocks setup.

## Verification

With a foreign `pre-push` + a stale `pre-push.old` planted:
- `lefthook install --reset-hooks-path` → `can't rename pre-push to pre-push.old`, **exit 1** (the abort).
- `lefthook install --reset-hooks-path --force` → `File pre-push.old already exists, overwriting` → `sync hooks: ✔️`, **exit 0**.

`shellcheck --severity=warning scripts/worktree/new.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
* Improved reliability of the development environment setup process to prevent potential interruptions during initialization.

---

*Note: This update affects development workflows only and has no impact on end-user functionality.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1625?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->