### PR TITLE
docs(scripts): grab-feedback creates issues oldest-first to align numbering

### DIFF
--- a/.claude/skills/grab-feedback/SKILL.md
+++ b/.claude/skills/grab-feedback/SKILL.md
@@ -24,10 +24,19 @@ gh repo view --json nameWithOwner --jq '.nameWithOwner'
 ## Step 1: Fetch open issues from feedback repo
 
 ```bash
-gh issue list --repo {owner}/{repo}-feedback --state open --limit 50 --json number,title,body,labels
+gh issue list --repo {owner}/{repo}-feedback --state open --limit 50 --json number,title,body,labels --jq 'sort_by(.number)'
 ```
 
 If none: report "No new feedback" and stop.
+
+> **Order matters — oldest first.** `gh issue list` returns newest-first by
+> default; the `sort_by(.number)` re-sorts the working set ascending (oldest
+> feedback issue first, since GitHub issue numbers are monotonic with creation
+> order). **Preserve this ascending order through every later step — classify,
+> present, and especially create.** Creating newest-first inverts the mapping
+> (e.g. feedback #45 → public #1608, feedback #46 → public #1607), which is
+> confusing to reconcile. Oldest-first keeps public numbers increasing in
+> lockstep with feedback numbers.
 
 ### Step 1a: Filter out already-mirrored issues
 
@@ -71,7 +80,7 @@ Convert `[Bug]`/`[Feature Request]` prefix to conventional commit style:
 
 ## Step 5: Present table for approval
 
-Show all issues before creating anything. Use the **Mode** column to call out which issues need placeholder treatment:
+Show all issues before creating anything, **listed oldest-first (ascending feedback #)** so the approval order matches the creation order. Use the **Mode** column to call out which issues need placeholder treatment:
 
 | # (feedback) | Mode | New Title | Labels | PII Concerns |
 |---|---|---|---|---|
@@ -83,6 +92,12 @@ Modes: `transfer` (clean anonymize + close original) or `placeholder` (PII-free 
 Do NOT create issues until the user confirms. For placeholder mode, also confirm the generic title doesn't itself leak context.
 
 ## Step 7: Create in target repo
+
+**Create in ascending feedback-number order (oldest first), one at a time.**
+Walk the approved working set from the lowest feedback `#N` to the highest so the
+resulting public issue numbers stay monotonic with the feedback numbers. Do not
+batch or parallelize creation — out-of-order creation re-inverts the mapping that
+Step 1's sort fixed.
 
 For each approved issue, create in the target repo with appropriate labels.
 


### PR DESCRIPTION
## Problem

`gh issue list` returns issues **newest-first** by default. The `grab-feedback` skill fetched feedback issues in that order and created them in the main repo in the same order — so the *oldest* feedback issue got the *highest* public number:

- feedback #45 → public #1608
- feedback #46 → public #1607

That inverted mapping is confusing to reconcile against the source feedback repo.

## Fix

Make the skill preserve **oldest-first** ordering end to end:

- **Step 1** — sort the fetched working set ascending by issue number (`--jq 'sort_by(.number)'`), with a callout explaining why order matters and the inverted-mapping failure it prevents.
- **Step 5** — present the approval table oldest-first so approval order matches creation order.
- **Step 7** — require ascending, one-at-a-time creation so public issue numbers increase in lockstep with feedback numbers.

Docs-only change to the skill definition; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feedback processing workflow documentation to clarify ordering requirements and guidance for maintaining ascending feedback order throughout workflow stages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->