### PR TITLE
fix(frontend): invalidate validator + requests-met on manual placement and disposition (#1607, #1608)

### DIFF
--- a/frontend/src/components/BunkingBoardByArea.swap.test.tsx
+++ b/frontend/src/components/BunkingBoardByArea.swap.test.tsx
@@ -9,6 +9,12 @@
  *      confirms a swap, then closes the modal.
  *   4. Does not move any campers when the modal is dismissed via Cancel.
  *
+ * Toast-aggregation tests (#1632):
+ *   5. A swap involving N+M campers shows exactly ONE success toast whose
+ *      message includes the total count — not one toast per camper.
+ *   6. A swap of a single camper (one-sided bunk empty) still produces
+ *      the expected single summary toast with count "1".
+ *
  * BunkCard itself is stubbed so the test exercises the wiring layer
  * without booting dnd-kit / lock contexts. BunkSwapModal renders for real.
  */
@@ -134,6 +140,7 @@ describe('BunkingBoardByArea — bunk swap', () => {
   })
 
   it('calls onCamperMove for each camper in both bunks when Confirm is clicked', async () => {
+    // Swap passes { silent: true } so the orchestrator can emit one count toast (#1632).
     const onCamperMove = vi.fn().mockResolvedValue(undefined)
     render(<BunkingBoardByArea {...baseProps} onCamperMove={onCamperMove} />)
     fireEvent.click(screen.getByRole('button', { name: 'Swap bunk G-9' }))
@@ -141,10 +148,10 @@ describe('BunkingBoardByArea — bunk swap', () => {
     fireEvent.click(screen.getByRole('button', { name: /confirm swap/i }))
 
     await waitFor(() => {
-      expect(onCamperMove).toHaveBeenCalledWith('c1', 'g10b')
+      expect(onCamperMove).toHaveBeenCalledWith('c1', 'g10b', { silent: true })
     })
-    expect(onCamperMove).toHaveBeenCalledWith('c2', 'g10b')
-    expect(onCamperMove).toHaveBeenCalledWith('c3', 'g9')
+    expect(onCamperMove).toHaveBeenCalledWith('c2', 'g10b', { silent: true })
+    expect(onCamperMove).toHaveBeenCalledWith('c3', 'g9', { silent: true })
     expect(onCamperMove).toHaveBeenCalledTimes(3)
   })
 
@@ -190,5 +197,55 @@ describe('BunkingBoardByArea — bunk swap', () => {
     await waitFor(() => {
       expect(toastErrorSpy).toHaveBeenCalled()
     })
+  })
+
+  // Toast-aggregation tests (#1632) — multi-camper swap must show ONE
+  // summary toast, not one-per-camper.
+  it('shows exactly one success toast with the total count when a swap moves multiple campers (#1632)', async () => {
+    // G-9 has c1 + c2 (2 campers), G-10b has c3 (1 camper) → 3 total moves
+    const toastSuccessSpy = vi.spyOn(toast, 'success').mockReturnValue('mock-id')
+    const onCamperMove = vi.fn().mockResolvedValue(undefined)
+    render(<BunkingBoardByArea {...baseProps} onCamperMove={onCamperMove} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Swap bunk G-9' }))
+    fireEvent.click(screen.getByRole('radio', { name: /G-10b/ }))
+    fireEvent.click(screen.getByRole('button', { name: /confirm swap/i }))
+
+    await waitFor(() => {
+      expect(onCamperMove).toHaveBeenCalledTimes(3)
+    })
+
+    // Must be exactly ONE toast call (not 3)
+    expect(toastSuccessSpy).toHaveBeenCalledTimes(1)
+    // The message must include the count
+    expect(toastSuccessSpy).toHaveBeenCalledWith(expect.stringMatching(/3/))
+  })
+
+  it('shows one toast for a single-camper swap (#1632)', async () => {
+    // G-10b has only c3 (1 camper), G-9 has c1 + c2. Test from G-10b side:
+    // Build scenario where only one side is populated to exercise count=1.
+    const bunkSolo = makeBunk({ id: 'solo', name: 'G-11', gender: 'F' })
+    const bunkEmpty = makeBunk({ id: 'empty', name: 'G-12', gender: 'F' })
+    const cSolo = makeCamper({ id: 'cSolo', assigned_bunk: 'solo' })
+    const singleProps = {
+      ...baseProps,
+      bunks: [bunkSolo, bunkEmpty],
+      campers: [cSolo],
+    }
+
+    const toastSuccessSpy = vi.spyOn(toast, 'success').mockReturnValue('mock-id')
+    const onCamperMove = vi.fn().mockResolvedValue(undefined)
+    render(<BunkingBoardByArea {...singleProps} onCamperMove={onCamperMove} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Swap bunk G-11' }))
+    fireEvent.click(screen.getByRole('radio', { name: /G-12/ }))
+    fireEvent.click(screen.getByRole('button', { name: /confirm swap/i }))
+
+    await waitFor(() => {
+      expect(onCamperMove).toHaveBeenCalledTimes(1)
+    })
+
+    expect(toastSuccessSpy).toHaveBeenCalledTimes(1)
+    expect(toastSuccessSpy).toHaveBeenCalledWith(expect.stringMatching(/1/))
   })
 })

--- a/frontend/src/components/BunkingBoardByArea.tsx
+++ b/frontend/src/components/BunkingBoardByArea.tsx
@@ -36,6 +36,15 @@ import { isAgSession } from '../utils/sessionTypePredicates'
 import { getEffectivelyUnassignedCampers } from './bunkingBoardHelpers'
 import { shouldKeepPanelsOpen } from '../utils/clickoutsidePredicate'
 
+/** Options forwarded to the individual moveCamper call. */
+interface CamperMoveOptions {
+  /**
+   * Suppress the per-move success toast. Pass true when the caller will emit
+   * its own summary toast for the whole batch (e.g. swap, lock-group move).
+   */
+  silent?: boolean
+}
+
 interface BunkingBoardByAreaProps {
   sessionId: string
   sessionCmId: number
@@ -43,7 +52,11 @@ interface BunkingBoardByAreaProps {
   campers: Camper[]
   selectedArea: 'all' | 'boys' | 'girls' | 'all-gender'
   onAreaChange: (area: 'all' | 'boys' | 'girls' | 'all-gender') => void
-  onCamperMove: (camperId: string, toBunkId: string | null) => Promise<void>
+  onCamperMove: (
+    camperId: string,
+    toBunkId: string | null,
+    options?: CamperMoveOptions
+  ) => Promise<void>
   onCamperLockToggle?: (camperId: string, locked: boolean, reason?: string) => Promise<void>
   isProductionMode?: boolean
   defaultCapacity?: number
@@ -470,12 +483,17 @@ export default function BunkingBoardByArea(props: BunkingBoardByAreaProps) {
       }
     }
 
+    const isMultiMove = campersToMove.length > 1
     try {
-      // Move all campers in the group
+      // For multi-camper moves (lock group), suppress per-move toasts (#1632)
+      // and emit a single count toast after the whole group resolves.
+      // Single-camper moves keep their normal individual toast.
       for (const camper of campersToMove) {
-        await onCamperMove(camper.id, targetBunkId)
+        await onCamperMove(camper.id, targetBunkId, isMultiMove ? { silent: true } : undefined)
       }
-      // Success toast moved to parent component after actual move completes
+      if (isMultiMove) {
+        toast.success(`${campersToMove.length} campers moved`)
+      }
     } catch (error) {
       toast.error('Failed to move camper(s)')
       console.error('Error moving camper(s):', error)
@@ -713,10 +731,15 @@ export default function BunkingBoardByArea(props: BunkingBoardByAreaProps) {
             // Close immediately so the user sees the board update as the
             // per-camper moves stream in.
             setSelectedBunkForSwap(null)
+            const totalCampers = source.campers.length + target.campers.length
             try {
+              // Suppress per-move toasts (#1632): the orchestrator emits one
+              // count toast below after the whole batch resolves.
               await swapBunks(source, target, async (camperId, bunkId) => {
-                await onCamperMove(camperId, bunkId)
+                await onCamperMove(camperId, bunkId, { silent: true })
               })
+              // One summary toast for the whole swap action.
+              toast.success(`${totalCampers} camper${totalCampers === 1 ? '' : 's'} moved`)
             } catch (error) {
               console.error('Bunk swap failed:', error)
               toast.error('Bunk swap failed — some campers may not have moved')

--- a/frontend/src/components/BunkingBoardByArea.tsx
+++ b/frontend/src/components/BunkingBoardByArea.tsx
@@ -28,6 +28,7 @@ const LockGroupsHub = lazy(() => import('./LockGroupsHub'))
 import { useLockGroupContext } from '../contexts/LockGroupContext'
 import { formatGradeOrdinal } from '../utils/gradeUtils'
 import { useYear } from '../hooks/useCurrentYear'
+import type { MoveCamperOptions } from '../hooks/session/useCamperMovement'
 import { DEFAULT_BUNK_CAPACITY, MAX_BUNK_CAPACITY } from '../utils/capacityConstants'
 import { usePermissions } from '../hooks/usePermissions'
 import { Permission } from '../constants/permissions'
@@ -35,15 +36,6 @@ import { Home } from 'lucide-react'
 import { isAgSession } from '../utils/sessionTypePredicates'
 import { getEffectivelyUnassignedCampers } from './bunkingBoardHelpers'
 import { shouldKeepPanelsOpen } from '../utils/clickoutsidePredicate'
-
-/** Options forwarded to the individual moveCamper call. */
-interface CamperMoveOptions {
-  /**
-   * Suppress the per-move success toast. Pass true when the caller will emit
-   * its own summary toast for the whole batch (e.g. swap, lock-group move).
-   */
-  silent?: boolean
-}
 
 interface BunkingBoardByAreaProps {
   sessionId: string
@@ -55,7 +47,7 @@ interface BunkingBoardByAreaProps {
   onCamperMove: (
     camperId: string,
     toBunkId: string | null,
-    options?: CamperMoveOptions
+    options?: MoveCamperOptions
   ) => Promise<void>
   onCamperLockToggle?: (camperId: string, locked: boolean, reason?: string) => Promise<void>
   isProductionMode?: boolean

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -1683,6 +1683,34 @@ describe('PostValidationResultsModal — violated sub-rows show distinct targets
 // Task: handleCamperClick — popout mode vs normal modal mode
 // ---------------------------------------------------------------------------
 
+describe('PostValidationResultsModal — background refresh indicator (#1635 scan #4)', () => {
+  it('shows a refreshing indicator while a background refetch is in flight', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults()}
+        isRefreshing={true}
+      />
+    )
+    expect(screen.getByTestId('postcheck-refreshing')).toBeInTheDocument()
+  })
+
+  it('does not show the refreshing indicator when not refetching', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults()}
+        isRefreshing={false}
+      />
+    )
+    expect(screen.queryByTestId('postcheck-refreshing')).not.toBeInTheDocument()
+  })
+})
+
 describe('PostValidationResultsModal — handleCamperClick behavior', () => {
   // Reset pathname after each test so subsequent describe blocks always start
   // in normal-modal (non-popout) mode.

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -20,6 +20,7 @@ import {
   Target,
   Activity,
   ExternalLink,
+  Loader2,
 } from 'lucide-react'
 import { useNavigate, useLocation } from 'react-router'
 import { sessionNameToUrl } from '../utils/sessionUtils'
@@ -78,6 +79,13 @@ interface PostValidationResultsModalProps {
    * Camp year for the PDF export filename and header.
    */
   year?: number | undefined
+  /**
+   * True while a background refetch of the post-check results is in flight
+   * (e.g. after a drag-drop or approve/decline invalidation while the modal is
+   * open). Surfaces a small "Updating…" indicator so the stale numbers on
+   * screen aren't mistaken for the refreshed result. #1607 / #1608.
+   */
+  isRefreshing?: boolean | undefined
 }
 
 /**
@@ -93,6 +101,8 @@ export interface PostCheckContentsProps {
   preCheckError?: boolean | undefined
   sessionName?: string | undefined
   year?: number | undefined
+  /** See PostValidationResultsModalProps.isRefreshing. */
+  isRefreshing?: boolean | undefined
   /**
    * When true, hides the "Close" button in the footer action area.
    * Used by the popout route where there's no modal to dismiss.
@@ -606,6 +616,7 @@ export function PostCheckContents({
   preCheckError = false,
   sessionName,
   year,
+  isRefreshing = false,
   hideCloseButton = false,
   onClose,
 }: PostCheckContentsProps) {
@@ -846,6 +857,15 @@ export function PostCheckContents({
               {status.sublabel}
               {scenarioId && <span className="ml-1 opacity-70">(Draft)</span>}
             </p>
+            {isRefreshing && (
+              <span
+                data-testid="postcheck-refreshing"
+                className="text-muted-foreground mt-0.5 inline-flex items-center gap-1 text-xs"
+              >
+                <Loader2 className="h-3 w-3 animate-spin" />
+                Updating…
+              </span>
+            )}
           </div>
           {!isPopoutRoute && (
             <button
@@ -1357,6 +1377,7 @@ export default function PostValidationResultsModal({
   preCheckError = false,
   sessionName,
   year,
+  isRefreshing = false,
 }: PostValidationResultsModalProps) {
   return (
     <Modal
@@ -1376,6 +1397,7 @@ export default function PostValidationResultsModal({
         preCheckError={preCheckError}
         sessionName={sessionName}
         year={year}
+        isRefreshing={isRefreshing}
         onClose={onClose}
       />
     </Modal>

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -340,8 +340,8 @@ export default function SessionView() {
                 campers={campers}
                 selectedArea={selectedBunkArea}
                 onAreaChange={setSelectedBunkArea}
-                onCamperMove={async (camperId, bunkId) => {
-                  await moveCamper(camperId, bunkId)
+                onCamperMove={async (camperId, bunkId, options) => {
+                  await moveCamper(camperId, bunkId, options)
                 }}
                 isProductionMode={isProductionMode}
                 defaultCapacity={defaultBunkCapacity}

--- a/frontend/src/components/ValidateBunkingButton.tsx
+++ b/frontend/src/components/ValidateBunkingButton.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { CheckCircle } from 'lucide-react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useScenario } from '../hooks/useScenario'
 import { useApiWithAuth } from '../hooks/useApiWithAuth'
 import { solverService, type PreCheckCacheValue } from '../services/solver'
@@ -52,10 +52,38 @@ export default function ValidateBunkingButton({
 }: ValidateBunkingButtonProps) {
   const { currentScenario } = useScenario()
   const { fetchWithAuth } = useApiWithAuth()
+  const queryClient = useQueryClient()
   const [isValidating, setIsValidating] = useState(false)
   const [showResults, setShowResults] = useState(false)
-  const [validationResults, setValidationResults] = useState<ValidationResults | null>(null)
   const [error, setError] = useState<string | null>(null)
+
+  const scenarioId = currentScenario?.id
+
+  // Post-check validation results — stored in the React Query cache so that
+  // mutations (drag-drop, approve/decline) can invalidate and trigger a
+  // refetch while the modal is open. #1607 / #1608.
+  //
+  // enabled: only fetch reactively (after invalidation) while the modal is
+  // visible; the initial data is seeded imperatively in handleValidate below
+  // via setQueryData so the modal opens immediately without a second round-trip.
+  const postCheckQuery = useQuery<ValidationResults>({
+    queryKey: queryKeys.postCheck(sessionCmId, scenarioId),
+    queryFn: () =>
+      solverService.validateBunking(
+        sessionCmId.toString(),
+        year,
+        scenarioId,
+        fetchWithAuth
+      ) as unknown as Promise<ValidationResults>,
+    enabled: showResults,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    retry: false,
+  })
+
+  // The validation results displayed in the modal: prefer live query data
+  // (which refreshes on invalidation), fall back to the last fetched value.
+  const validationResults = postCheckQuery.data ?? null
 
   // Pre-check report drives the "campers with impossible requests" section in
   // the post-check modal (#1442 part 2). Shared query key with the session-
@@ -81,10 +109,17 @@ export default function ValidateBunkingButton({
       const results = await solverService.validateBunking(
         sessionCmId.toString(),
         year,
-        currentScenario?.id,
+        scenarioId,
         fetchWithAuth
       )
-      setValidationResults(results as unknown as ValidationResults)
+      // Seed the React Query cache immediately so the modal shows data without
+      // waiting for a second fetch. Subsequent invalidations (drag-drop,
+      // approve/decline) will trigger a background refetch via the useQuery
+      // above while the modal stays open. #1607 / #1608.
+      queryClient.setQueryData<ValidationResults>(
+        queryKeys.postCheck(sessionCmId, scenarioId),
+        results as unknown as ValidationResults
+      )
       setShowResults(true)
     } catch (err) {
       console.error('Validation failed:', err)

--- a/frontend/src/components/ValidateBunkingButton.tsx
+++ b/frontend/src/components/ValidateBunkingButton.tsx
@@ -67,7 +67,7 @@ export default function ValidateBunkingButton({
   // visible; the initial data is seeded imperatively in handleValidate below
   // via setQueryData so the modal opens immediately without a second round-trip.
   const postCheckQuery = useQuery<ValidationResults>({
-    queryKey: queryKeys.postCheck(sessionCmId, scenarioId),
+    queryKey: queryKeys.postCheck(sessionCmId, year, scenarioId),
     queryFn: () =>
       solverService.validateBunking(
         sessionCmId.toString(),
@@ -117,7 +117,7 @@ export default function ValidateBunkingButton({
       // approve/decline) will trigger a background refetch via the useQuery
       // above while the modal stays open. #1607 / #1608.
       queryClient.setQueryData<ValidationResults>(
-        queryKeys.postCheck(sessionCmId, scenarioId),
+        queryKeys.postCheck(sessionCmId, year, scenarioId),
         results as unknown as ValidationResults
       )
       setShowResults(true)
@@ -158,6 +158,7 @@ export default function ValidateBunkingButton({
           preCheckError={preCheckQuery.isError}
           sessionName={sessionName}
           year={year}
+          isRefreshing={postCheckQuery.isFetching && !postCheckQuery.isLoading}
         />
       )}
     </>

--- a/frontend/src/hooks/session/__tests__/post-check-invalidation.test.ts
+++ b/frontend/src/hooks/session/__tests__/post-check-invalidation.test.ts
@@ -30,6 +30,7 @@ import { invalidateAssignmentDerivedQueries } from '../../../utils/queryInvalida
 
 const SESSION_CM_ID = 1001
 const SCENARIO_ID = 'scenario-abc'
+const YEAR = 2025
 
 /**
  * Build a QueryClient pre-seeded with postCheck cache entries so we can
@@ -44,7 +45,7 @@ function buildQcWithPostCheckCache() {
     defaultOptions: { queries: { retry: false, staleTime: 60_000 } },
   })
   // Production mode (no scenario)
-  qc.setQueryData(queryKeys.postCheck(SESSION_CM_ID, undefined), {
+  qc.setQueryData(queryKeys.postCheck(SESSION_CM_ID, YEAR, undefined), {
     statistics: {
       total_campers: 100,
       assigned_campers: 90,
@@ -56,7 +57,7 @@ function buildQcWithPostCheckCache() {
     validated_at: '2025-01-01T00:00:00Z',
   })
   // Scenario mode
-  qc.setQueryData(queryKeys.postCheck(SESSION_CM_ID, SCENARIO_ID), {
+  qc.setQueryData(queryKeys.postCheck(SESSION_CM_ID, YEAR, SCENARIO_ID), {
     statistics: {
       total_campers: 100,
       assigned_campers: 88,
@@ -73,18 +74,20 @@ function buildQcWithPostCheckCache() {
 function isPostCheckStale(
   qc: QueryClient,
   sessionCmId = SESSION_CM_ID,
+  year = YEAR,
   scenarioId: string | undefined = undefined
 ) {
-  const state = qc.getQueryState(queryKeys.postCheck(sessionCmId, scenarioId))
+  const state = qc.getQueryState(queryKeys.postCheck(sessionCmId, year, scenarioId))
   return state?.isInvalidated === true
 }
 
 function isPostCheckScenarioStale(
   qc: QueryClient,
   sessionCmId = SESSION_CM_ID,
+  year = YEAR,
   scenarioId: string = SCENARIO_ID
 ) {
-  const state = qc.getQueryState(queryKeys.postCheck(sessionCmId, scenarioId))
+  const state = qc.getQueryState(queryKeys.postCheck(sessionCmId, year, scenarioId))
   return state?.isInvalidated === true
 }
 
@@ -241,17 +244,17 @@ describe('postCheckPrefix — prefix invalidation covers both scenarios', () => 
   it('prefix-invalidating postCheckPrefix marks all postCheck entries stale', () => {
     void qc.invalidateQueries({ queryKey: queryKeys.postCheckPrefix() })
 
-    expect(isPostCheckStale(qc, SESSION_CM_ID, undefined)).toBe(true)
-    expect(isPostCheckScenarioStale(qc, SESSION_CM_ID, SCENARIO_ID)).toBe(true)
+    expect(isPostCheckStale(qc, SESSION_CM_ID, YEAR, undefined)).toBe(true)
+    expect(isPostCheckScenarioStale(qc, SESSION_CM_ID, YEAR, SCENARIO_ID)).toBe(true)
   })
 
   it('prefix invalidation is session-agnostic (catches a different session cm_id too)', () => {
     const OTHER_SESSION = 2002
-    qc.setQueryData(queryKeys.postCheck(OTHER_SESSION, undefined), { issues: [] })
+    qc.setQueryData(queryKeys.postCheck(OTHER_SESSION, YEAR, undefined), { issues: [] })
 
     void qc.invalidateQueries({ queryKey: queryKeys.postCheckPrefix() })
 
-    const otherState = qc.getQueryState(queryKeys.postCheck(OTHER_SESSION, undefined))
+    const otherState = qc.getQueryState(queryKeys.postCheck(OTHER_SESSION, YEAR, undefined))
     expect(otherState?.isInvalidated).toBe(true)
   })
 })

--- a/frontend/src/hooks/session/__tests__/post-check-invalidation.test.ts
+++ b/frontend/src/hooks/session/__tests__/post-check-invalidation.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Contract tests: post-check (validator report) cache invalidation after
+ * manual mutations.
+ *
+ * Bug: #1607 / #1608 — The "Check Bunking" validator report and the
+ * adjusted "requests met" count do not refresh after a staffer manually
+ * places/moves a camper (drag) or changes a request disposition
+ * (approve/decline). They only update after a full page refresh or after
+ * running the solver.
+ *
+ * Root cause: `postCheck` React Query entries have `staleTime: 5 min` and
+ * are never invalidated by the drag-drop (`useCamperMovement`) or
+ * disposition-change (`invalidateRequestQueries`) mutation paths — only the
+ * solver-apply path would invalidate them if it added the key (it currently
+ * does not).
+ *
+ * Fix: add `queryKeys.postCheckPrefix()` invalidation to:
+ *   - `invalidateAssignmentDerivedQueries` (covers drag-drop + solver apply/clear)
+ *   - `invalidateRequestQueries` (covers approve/decline/merge/split)
+ *
+ * This file is a sibling contract to alert-invalidation.test.ts and
+ * graph-invalidation.test.ts. Adding a new consumer of `postCheck` requires
+ * updating this file AND the production call-sites.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { QueryClient } from '@tanstack/react-query'
+import { invalidateRequestQueries, queryKeys } from '../../../utils/queryKeys'
+import { invalidateAssignmentDerivedQueries } from '../../../utils/queryInvalidation'
+
+const SESSION_CM_ID = 1001
+const SCENARIO_ID = 'scenario-abc'
+
+/**
+ * Build a QueryClient pre-seeded with postCheck cache entries so we can
+ * verify whether invalidation marks them stale.
+ *
+ * Two variants are seeded:
+ *  - production mode (no scenario)
+ *  - scenario mode
+ */
+function buildQcWithPostCheckCache() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 60_000 } },
+  })
+  // Production mode (no scenario)
+  qc.setQueryData(queryKeys.postCheck(SESSION_CM_ID, undefined), {
+    statistics: {
+      total_campers: 100,
+      assigned_campers: 90,
+      satisfied_requests: 45,
+      total_requests: 50,
+      request_satisfaction_rate: 0.9,
+    },
+    issues: [],
+    validated_at: '2025-01-01T00:00:00Z',
+  })
+  // Scenario mode
+  qc.setQueryData(queryKeys.postCheck(SESSION_CM_ID, SCENARIO_ID), {
+    statistics: {
+      total_campers: 100,
+      assigned_campers: 88,
+      satisfied_requests: 40,
+      total_requests: 50,
+      request_satisfaction_rate: 0.8,
+    },
+    issues: [],
+    validated_at: '2025-01-01T00:00:00Z',
+  })
+  return qc
+}
+
+function isPostCheckStale(
+  qc: QueryClient,
+  sessionCmId = SESSION_CM_ID,
+  scenarioId: string | undefined = undefined
+) {
+  const state = qc.getQueryState(queryKeys.postCheck(sessionCmId, scenarioId))
+  return state?.isInvalidated === true
+}
+
+function isPostCheckScenarioStale(
+  qc: QueryClient,
+  sessionCmId = SESSION_CM_ID,
+  scenarioId: string = SCENARIO_ID
+) {
+  const state = qc.getQueryState(queryKeys.postCheck(sessionCmId, scenarioId))
+  return state?.isInvalidated === true
+}
+
+// ---------------------------------------------------------------------------
+// Path 1: drag-drop (useCamperMovement.onSuccess) via invalidateAssignmentDerivedQueries
+// ---------------------------------------------------------------------------
+describe('useCamperMovement — onSuccess must invalidate postCheck via invalidateAssignmentDerivedQueries', () => {
+  let qc: QueryClient
+
+  beforeEach(() => {
+    qc = buildQcWithPostCheckCache()
+  })
+
+  it('marks postCheck (production) stale after a successful camper move', () => {
+    // Mirror the current onSuccess shape in useCamperMovement.ts.
+    // invalidateAssignmentDerivedQueries is called from both code paths (null
+    // and non-null response).
+    const onSuccess = (client: QueryClient, selectedSession: string) => {
+      void client.invalidateQueries({ queryKey: ['campers', selectedSession] })
+      void client.invalidateQueries({ queryKey: queryKeys.bunkRequestStatus() })
+      void client.invalidateQueries({ queryKey: queryKeys.allBunkRequestsPrefix() })
+      invalidateAssignmentDerivedQueries(client)
+    }
+
+    onSuccess(qc, String(SESSION_CM_ID))
+
+    expect(isPostCheckStale(qc)).toBe(true)
+  })
+
+  it('marks postCheck (scenario) stale after a successful camper move', () => {
+    const onSuccess = (client: QueryClient, selectedSession: string) => {
+      void client.invalidateQueries({ queryKey: ['campers', selectedSession] })
+      void client.invalidateQueries({ queryKey: queryKeys.bunkRequestStatus() })
+      void client.invalidateQueries({ queryKey: queryKeys.allBunkRequestsPrefix() })
+      invalidateAssignmentDerivedQueries(client)
+    }
+
+    onSuccess(qc, String(SESSION_CM_ID))
+
+    expect(isPostCheckScenarioStale(qc)).toBe(true)
+  })
+
+  it('marks postCheck stale even when the move response signals no change (null response path)', () => {
+    // useCamperMovement has two onSuccess code paths — null response (unassign)
+    // and non-null response (assign/move). Both must invalidate postCheck.
+    const onSuccessNull = (client: QueryClient, selectedSession: string) => {
+      void client.invalidateQueries({ queryKey: ['campers', selectedSession] })
+      void client.invalidateQueries({ queryKey: queryKeys.bunkRequestStatus() })
+      void client.invalidateQueries({ queryKey: queryKeys.allBunkRequestsPrefix() })
+      invalidateAssignmentDerivedQueries(client)
+    }
+
+    onSuccessNull(qc, String(SESSION_CM_ID))
+
+    expect(isPostCheckStale(qc)).toBe(true)
+    expect(isPostCheckScenarioStale(qc)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Path 2: solver apply (useSolverOperations) via invalidateAssignmentDerivedQueries
+// ---------------------------------------------------------------------------
+describe('useSolverOperations — apply path must invalidate postCheck via invalidateAssignmentDerivedQueries', () => {
+  let qc: QueryClient
+
+  beforeEach(() => {
+    qc = buildQcWithPostCheckCache()
+  })
+
+  it('marks postCheck stale after solver results are applied (auto-apply path)', async () => {
+    const applyResults = async (client: QueryClient, selectedSession: string) => {
+      await Promise.all([
+        client.invalidateQueries({ queryKey: ['campers', selectedSession] }),
+        client.invalidateQueries({ queryKey: ['bunks', selectedSession] }),
+        client.invalidateQueries({ queryKey: queryKeys.bunkRequestStatus() }),
+        client.invalidateQueries({ queryKey: ['all-sessions'] }),
+        client.invalidateQueries({ queryKey: queryKeys.allBunkRequestsPrefix() }),
+      ])
+      invalidateAssignmentDerivedQueries(client)
+    }
+
+    await applyResults(qc, String(SESSION_CM_ID))
+
+    expect(isPostCheckStale(qc)).toBe(true)
+    expect(isPostCheckScenarioStale(qc)).toBe(true)
+  })
+
+  it('marks postCheck stale after handleClearAssignments', async () => {
+    const clearAssignments = async (client: QueryClient, selectedSession: string) => {
+      await Promise.all([
+        client.invalidateQueries({ queryKey: ['campers', selectedSession] }),
+        client.invalidateQueries({ queryKey: ['bunks', selectedSession] }),
+      ])
+      invalidateAssignmentDerivedQueries(client)
+    }
+
+    await clearAssignments(qc, String(SESSION_CM_ID))
+
+    expect(isPostCheckStale(qc)).toBe(true)
+    expect(isPostCheckScenarioStale(qc)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Path 3: request disposition changes (RequestReviewPanel, AllCamperRequestsModal)
+//         via invalidateRequestQueries
+// ---------------------------------------------------------------------------
+describe('invalidateRequestQueries — must also invalidate postCheck', () => {
+  let qc: QueryClient
+
+  beforeEach(() => {
+    qc = buildQcWithPostCheckCache()
+  })
+
+  it('marks postCheck (production) stale after approve/decline', () => {
+    invalidateRequestQueries(qc)
+
+    expect(isPostCheckStale(qc)).toBe(true)
+  })
+
+  it('marks postCheck (scenario) stale after approve/decline', () => {
+    invalidateRequestQueries(qc)
+
+    expect(isPostCheckScenarioStale(qc)).toBe(true)
+  })
+
+  it('marks postCheck stale after bulk approve/decline', () => {
+    // bulkUpdateMutation also calls invalidateRequestQueries
+    invalidateRequestQueries(qc)
+
+    expect(isPostCheckStale(qc)).toBe(true)
+    expect(isPostCheckScenarioStale(qc)).toBe(true)
+  })
+
+  it('marks postCheck stale after merge/split request mutations', () => {
+    // MergeRequestsModal and SplitRequestModal also call invalidateRequestQueries
+    invalidateRequestQueries(qc)
+
+    expect(isPostCheckStale(qc)).toBe(true)
+    expect(isPostCheckScenarioStale(qc)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Regression: prefix match covers all session/scenario combinations
+// ---------------------------------------------------------------------------
+describe('postCheckPrefix — prefix invalidation covers both scenarios', () => {
+  let qc: QueryClient
+
+  beforeEach(() => {
+    qc = buildQcWithPostCheckCache()
+  })
+
+  it('prefix-invalidating postCheckPrefix marks all postCheck entries stale', () => {
+    void qc.invalidateQueries({ queryKey: queryKeys.postCheckPrefix() })
+
+    expect(isPostCheckStale(qc, SESSION_CM_ID, undefined)).toBe(true)
+    expect(isPostCheckScenarioStale(qc, SESSION_CM_ID, SCENARIO_ID)).toBe(true)
+  })
+
+  it('prefix invalidation is session-agnostic (catches a different session cm_id too)', () => {
+    const OTHER_SESSION = 2002
+    qc.setQueryData(queryKeys.postCheck(OTHER_SESSION, undefined), { issues: [] })
+
+    void qc.invalidateQueries({ queryKey: queryKeys.postCheckPrefix() })
+
+    const otherState = qc.getQueryState(queryKeys.postCheck(OTHER_SESSION, undefined))
+    expect(otherState?.isInvalidated).toBe(true)
+  })
+})

--- a/frontend/src/hooks/session/useCamperMovement.ts
+++ b/frontend/src/hooks/session/useCamperMovement.ts
@@ -75,9 +75,23 @@ export interface UseCamperMovementOptions {
   onPendingMoveCleared?: () => void
 }
 
+/** Options for a single camper move */
+export interface MoveCamperOptions {
+  /**
+   * When true, suppress the per-move success toast. Use this when the caller
+   * (e.g. swapBunks orchestrator) will emit its own summary toast after the
+   * whole batch resolves. Error toasts are always shown regardless.
+   */
+  silent?: boolean
+}
+
 export interface UseCamperMovementReturn {
   /** Move a camper to a bunk (or unassigned if bunkId is null) */
-  moveCamper: (camperId: string, bunkId: string | null) => Promise<void>
+  moveCamper: (
+    camperId: string,
+    bunkId: string | null,
+    options?: MoveCamperOptions
+  ) => Promise<void>
   /** Whether a move is in progress */
   isMoving: boolean
 }
@@ -282,7 +296,14 @@ export function useCamperMovement({
   const queryClient = useQueryClient()
 
   const mutation = useMutation({
-    mutationFn: async ({ camperId, bunkId }: { camperId: string; bunkId: string | null }) => {
+    mutationFn: async ({
+      camperId,
+      bunkId,
+    }: {
+      camperId: string
+      bunkId: string | null
+      silent?: boolean
+    }) => {
       // Resolve camper IDs
       const { personCmId, sessionCmId } = await resolveCamperIds(camperId)
 
@@ -337,7 +358,9 @@ export function useCamperMovement({
         selectedSession
       )
     },
-    onSuccess: (response) => {
+    onSuccess: (response, variables) => {
+      const { silent } = variables
+
       // Handle null response (e.g., production move to unassigned)
       if (!response) {
         void queryClient.invalidateQueries({
@@ -348,7 +371,9 @@ export function useCamperMovement({
         // Issue #1040 / #1041 — graph borders + satisfaction must refresh after move.
         invalidateAssignmentDerivedQueries(queryClient)
         onPendingMoveCleared?.()
-        toast.success('Camper moved successfully')
+        if (!silent) {
+          toast.success('Camper moved successfully')
+        }
         return
       }
 
@@ -369,8 +394,10 @@ export function useCamperMovement({
         graphCacheService.invalidate(sessionCmId)
       }
 
-      // Only show success message if something actually changed
-      if (wasChanged) {
+      // Only show success message if something actually changed and not silenced.
+      // Callers that orchestrate multi-camper batches (swap, lock-group move)
+      // pass silent:true and emit their own single count toast.
+      if (wasChanged && !silent) {
         toast.success('Camper moved successfully')
       }
     },
@@ -380,8 +407,16 @@ export function useCamperMovement({
     },
   })
 
-  const moveCamper = async (camperId: string, bunkId: string | null) => {
-    await mutation.mutateAsync({ camperId, bunkId })
+  const moveCamper = async (
+    camperId: string,
+    bunkId: string | null,
+    options?: MoveCamperOptions
+  ) => {
+    await mutation.mutateAsync({
+      camperId,
+      bunkId,
+      ...(options?.silent ? { silent: true } : {}),
+    })
   }
 
   return {

--- a/frontend/src/pages/PostCheckPopout/index.tsx
+++ b/frontend/src/pages/PostCheckPopout/index.tsx
@@ -152,7 +152,7 @@ function PostCheckPopoutContents({
   // Note: BunkingValidationResult in solver.ts is an older type definition —
   // the actual API response matches ValidationResults. Cast as ValidateBunkingButton does.
   const postCheckQuery = useQuery<ValidationResults>({
-    queryKey: queryKeys.postCheck(sessionCmId, scenarioId),
+    queryKey: queryKeys.postCheck(sessionCmId, year, scenarioId),
     queryFn: () =>
       solverService.validateBunking(
         String(sessionCmId),

--- a/frontend/src/utils/queryInvalidation.ts
+++ b/frontend/src/utils/queryInvalidation.ts
@@ -6,4 +6,7 @@ export function invalidateAssignmentDerivedQueries(qc: QueryClient): void {
   void qc.invalidateQueries({ queryKey: queryKeys.socialGraphPrefix() })
   void qc.invalidateQueries({ queryKey: queryKeys.bunkSocialGraphPrefix() })
   void qc.invalidateQueries({ queryKey: queryKeys.satisfactionPrefix() })
+  // #1607 / #1608 — post-check report must refresh after any assignment change
+  // (drag-drop, solver apply/clear). Prefix catches all sessions + scenarios.
+  void qc.invalidateQueries({ queryKey: queryKeys.postCheckPrefix() })
 }

--- a/frontend/src/utils/queryKeys.test.ts
+++ b/frontend/src/utils/queryKeys.test.ts
@@ -93,3 +93,30 @@ describe('queryKeys.allSessionsList', () => {
     expect(a).not.toEqual(b)
   })
 })
+
+describe('queryKeys.postCheck', () => {
+  // CampMinder reuses session ids across years (year-data-integrity invariant),
+  // so a key of [post-check, sessionCmId, scenarioId] collides across seasons
+  // and can serve stale prior-year validator data. Mirror the year-scoped
+  // satisfaction key: [post-check, sessionCmId, year, scenarioId].
+  it('includes year so a season switch does not reuse a prior-year cache slot', () => {
+    const a = queryKeys.postCheck(1001, 2025, undefined)
+    const b = queryKeys.postCheck(1001, 2026, undefined)
+    expect(a).not.toEqual(b)
+  })
+
+  it('pins the full key shape: [post-check, sessionCmId, year, scenarioId]', () => {
+    expect(queryKeys.postCheck(1001, 2025, 'scenario-abc')).toEqual([
+      'post-check',
+      1001,
+      2025,
+      'scenario-abc',
+    ])
+  })
+
+  it('postCheckPrefix is the head of the full key so prefix invalidation still matches', () => {
+    const prefix = queryKeys.postCheckPrefix()
+    const full = queryKeys.postCheck(1001, 2025, 'scenario-abc')
+    expect(full.slice(0, prefix.length)).toEqual([...prefix])
+  })
+})

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -446,10 +446,13 @@ export const queryKeys = {
   // Solver pre-validate (debug view) — see frontend/src/pages/summer/SolverDebugPage
   preCheck: (sessionCmId: number | null, year: number) => ['pre-check', sessionCmId, year] as const,
 
-  // Solver post-check validation (popout) — see frontend/src/pages/PostCheckPopout
-  postCheck: (sessionCmId: number | null, scenarioId: string | undefined) =>
-    ['post-check', sessionCmId, scenarioId] as const,
-  /** Root prefix for invalidating every post-check query at once (all sessions/scenarios). */
+  // Solver post-check validation (popout) — see frontend/src/pages/PostCheckPopout.
+  // Year-scoped (mirrors the satisfaction key): CampMinder reuses session ids
+  // across years, so the key must include year or a season switch reuses the
+  // same cache slot and serves stale prior-year validator data.
+  postCheck: (sessionCmId: number | null, year: number, scenarioId: string | undefined) =>
+    ['post-check', sessionCmId, year, scenarioId] as const,
+  /** Root prefix for invalidating every post-check query at once (all sessions/scenarios/years). */
   postCheckPrefix: () => ['post-check'] as const,
 
   // Saved scenarios list (year-scoped) — see frontend/src/hooks/useScenarioList.ts
@@ -462,8 +465,10 @@ export const queryKeys = {
  * mutation handler that changes a `bunk_requests` row.
  *
  * The full inventory of keys is pinned by
- * `frontend/src/hooks/session/__tests__/alert-invalidation.test.ts` —
- * adding a new key requires updating both this helper and that contract.
+ * `frontend/src/hooks/session/__tests__/alert-invalidation.test.ts`, except the
+ * post-check key (added in #1607/#1608) which is pinned by its sibling
+ * `post-check-invalidation.test.ts`. Adding a new key requires updating this
+ * helper and the matching contract test.
  *
  * Pass `includeSourceLinks: true` from merge/split handlers, which
  * additionally rewrite source linkages between rows.

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -449,6 +449,8 @@ export const queryKeys = {
   // Solver post-check validation (popout) — see frontend/src/pages/PostCheckPopout
   postCheck: (sessionCmId: number | null, scenarioId: string | undefined) =>
     ['post-check', sessionCmId, scenarioId] as const,
+  /** Root prefix for invalidating every post-check query at once (all sessions/scenarios). */
+  postCheckPrefix: () => ['post-check'] as const,
 
   // Saved scenarios list (year-scoped) — see frontend/src/hooks/useScenarioList.ts
   scenariosList: (year: number) => ['scenarios', 'list', year] as const,
@@ -487,6 +489,8 @@ export function invalidateRequestQueries(
   void queryClient.invalidateQueries({ queryKey: queryKeys.bunkSocialGraphPrefix() })
   // #1041 — satisfaction endpoint is authoritative; request mutations must refresh it.
   void queryClient.invalidateQueries({ queryKey: queryKeys.satisfactionPrefix() })
+  // #1607 / #1608 — post-check report must refresh after any request disposition change.
+  void queryClient.invalidateQueries({ queryKey: queryKeys.postCheckPrefix() })
   if (options.includeSourceLinks) {
     void queryClient.invalidateQueries({ queryKey: queryKeys.sourceLinksPrefix() })
     void queryClient.invalidateQueries({ queryKey: queryKeys.expandedSourceLinksPrefix() })


### PR DESCRIPTION
## Summary

- **Bug**: The "Check Bunking" validator report and the "requests met" count in the post-check modal did not refresh after a staffer dragged a camper to a new bunk or approved/declined a request. Only a full page reload or re-running the solver cleared stale data.
- **Root cause**: `postCheck` React Query entries (`['post-check', sessionCmId, scenarioId]`) were never invalidated by the manual-mutation paths — `invalidateAssignmentDerivedQueries` (drag-drop, solver apply/clear) and `invalidateRequestQueries` (approve/decline/merge/split) both skipped it.
- **Fix**: Three-part change:
  1. Added `queryKeys.postCheckPrefix()` factory — bare prefix catches all sessions/scenarios via React Query's default prefix matching
  2. Wired `postCheckPrefix()` into `invalidateAssignmentDerivedQueries` (covers drag-drop + solver apply/clear)
  3. Wired `postCheckPrefix()` into `invalidateRequestQueries` (covers approve/decline + bulk + merge/split)
  4. Converted `ValidateBunkingButton` from imperative-only to a hybrid: the button click seeds the `postCheck` cache via `setQueryData` (instant modal open, zero extra round-trip), and a reactive `useQuery` subscribes to that slot so subsequent invalidations trigger background refetches while the modal is open

**Part (b) — adjusted count cross-session scoping**: The `satisfaction` query key is `['satisfaction', sessionCmId, year, scenarioId]` — correctly scoped. `satisfactionPrefix()` invalidation is intentionally broad (refetches all open sessions) but causes no cross-session data bleed. No keying bug found; the part (b) observation is a performance note, not a correctness fix.

- **Bug (#1632)**: A cabin swap (swapBunks) or lock-group drag move fired one toast per camper, stacking a pile of toast cards.
- **Root cause**: `useCamperMovement`'s `onSuccess` always called `toast.success('Camper moved successfully')` regardless of whether the move was part of a multi-camper orchestrated batch.
- **Fix**: Added `silent?: boolean` option to `moveCamper` / `onCamperMove`. The swap orchestrator and lock-group handler pass `{ silent: true }` for each individual move and emit a single `"N campers moved"` summary toast after the whole batch resolves. Single-camper moves keep their normal individual toast.

## Test plan

- [x] New contract test file `frontend/src/hooks/session/__tests__/post-check-invalidation.test.ts` (11 tests) — RED before implementation, GREEN after
- [x] Existing session-hook contract tests: `alert-invalidation.test.ts`, `graph-invalidation.test.ts` — all pass (30 total)
- [x] New toast-aggregation tests in `BunkingBoardByArea.swap.test.tsx` (#1632): multi-camper swap → exactly 1 toast with count; single-camper swap → exactly 1 toast — RED before implementation, GREEN after
- [x] All swap/move related tests (65 total): 0 failures
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` — clean
- [x] `npx prettier --write` — clean

Closes #1607
Closes #1608
Closes #1632

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single summary notification for multi-camper moves and swaps (replaces multiple toasts)
  * Post-validation modal shows a small “Updating…” indicator when background refresh is in progress
  * Move actions now support a “silent” option to suppress per-camper toasts when batching

* **Bug Fixes**
  * Improved post-validation caching/refresh so validation results appear promptly when the modal opens

* **Tests**
  * Added coverage for post-check cache invalidation and notification behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->