### PR TITLE
feat(frontend): surface camper-level parent-request coverage on bunking-validation popup (#1631)

### DIFF
--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -303,7 +303,13 @@ describe('PostValidationResultsModal — donut ring rate (Stage 3b.2)', () => {
 })
 
 describe('PostValidationResultsModal — parent stats tile (Stage 3b.2)', () => {
-  it('renders parent-only fraction in the second stats tile', () => {
+  // NOTE (#1631): The "parent requests met" and "bunks used" tiles have been
+  // removed from the quick-stats grid. These tests now verify the new
+  // camper-coverage tiles ("got ≥1 request" and "got all requests") that
+  // replaced them. The request-level fraction (18/30) is no longer displayed
+  // in the grid; the satisfaction ring still shows the parent satisfaction %.
+
+  it('does not render the request-level fraction in the stats grid (replaced by camper-coverage tiles)', () => {
     render(
       <PostValidationResultsModal
         sessionCmId={1000001}
@@ -317,63 +323,37 @@ describe('PostValidationResultsModal — parent stats tile (Stage 3b.2)', () => 
           request_satisfaction_rate: 0.9,
           satisfied_requests: 27,
           total_requests: 30,
+          mp_campers_total: 25,
+          mp_campers_with_at_least_one_satisfied: 20,
+          mp_campers_with_all_satisfied: 15,
         })}
       />
     )
 
-    expect(screen.getByText('18/30')).toBeInTheDocument()
-    expect(screen.getByText(/parent requests met/i)).toBeInTheDocument()
-    // Should NOT show the all-up "27/30" anywhere
-    expect(screen.queryByText('27/30')).not.toBeInTheDocument()
+    // "parent requests met" tile is gone
+    expect(screen.queryByText(/parent requests met/i)).not.toBeInTheDocument()
+    // The camper-coverage tiles render instead
+    expect(screen.getByText(/got ≥1 request/i)).toBeInTheDocument()
+    expect(screen.getByText(/got all requests/i)).toBeInTheDocument()
   })
 
-  it('uses amber styling on the parent tile when rate < 0.85', () => {
+  it('does not render the "bunks used" tile (removed in #1631)', () => {
     render(
       <PostValidationResultsModal
         sessionCmId={1000001}
         isOpen={true}
         onClose={() => {}}
         results={makeResults({
-          material_parent_requests: 30,
-          satisfied_material_parent_requests: 18,
-          material_parent_request_satisfaction_rate: 0.6,
-          campers_with_unsatisfied_material_parent_requests: 6,
+          bunks_at_capacity: 4,
+          bunks_under_capacity: 0,
+          bunks_over_capacity: 0,
         })}
       />
     )
-
-    // Find the parent tile by its caption, walk up to the tile container,
-    // and assert it has amber-toned classes.
-    const caption = screen.getByText(/parent requests met/i)
-    const tile = caption.closest('.flex.items-center')
-    expect(tile).not.toBeNull()
-    // Amber icon-background class should be present in the tile
-    expect(tile!.querySelector('.bg-amber-500\\/10')).not.toBeNull()
+    expect(screen.queryByText(/bunks used/i)).not.toBeInTheDocument()
   })
 
-  it('uses green styling on the parent tile when rate >= 0.85', () => {
-    render(
-      <PostValidationResultsModal
-        sessionCmId={1000001}
-        isOpen={true}
-        onClose={() => {}}
-        results={makeResults({
-          material_parent_requests: 20,
-          satisfied_material_parent_requests: 18,
-          material_parent_request_satisfaction_rate: 0.9,
-          campers_with_unsatisfied_material_parent_requests: 0,
-        })}
-      />
-    )
-
-    const caption = screen.getByText(/parent requests met/i)
-    const tile = caption.closest('.flex.items-center')
-    expect(tile).not.toBeNull()
-    expect(tile!.querySelector('.bg-forest-500\\/10')).not.toBeNull()
-    expect(tile!.querySelector('.bg-amber-500\\/10')).toBeNull()
-  })
-
-  it('falls back to all-up fraction when zero material parent requests', () => {
+  it('does not render the all-up "requests met" caption (removed in #1631)', () => {
     render(
       <PostValidationResultsModal
         sessionCmId={1000001}
@@ -391,10 +371,9 @@ describe('PostValidationResultsModal — parent stats tile (Stage 3b.2)', () => 
       />
     )
 
-    // No parent requests this session — show "18/20" with the original
-    // "requests met" caption (graceful degradation).
-    expect(screen.getByText('18/20')).toBeInTheDocument()
-    expect(screen.getByText(/^requests met$/i)).toBeInTheDocument()
+    // The old "requests met" fallback caption is gone; new tiles render instead
+    expect(screen.queryByText(/^requests met$/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/got ≥1 request/i)).toBeInTheDocument()
   })
 })
 
@@ -1775,5 +1754,147 @@ describe('PostValidationResultsModal — handleCamperClick behavior', () => {
     expect(openSpy).not.toHaveBeenCalled()
 
     openSpy.mockRestore()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #1631 — Camper-level coverage tiles
+// ---------------------------------------------------------------------------
+
+describe('PostValidationResultsModal — camper coverage tiles (#1631)', () => {
+  it('renders "got ≥1 request" tile with mp_campers_with_at_least_one_satisfied / mp_campers_total', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({
+          mp_campers_total: 40,
+          mp_campers_with_at_least_one_satisfied: 35,
+          mp_campers_with_all_satisfied: 28,
+        })}
+      />
+    )
+    // Label
+    expect(screen.getByText(/got ≥1 request/i)).toBeInTheDocument()
+    // Value fraction
+    expect(screen.getByText('35/40')).toBeInTheDocument()
+  })
+
+  it('renders "got all requests" tile with mp_campers_with_all_satisfied / mp_campers_total', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({
+          mp_campers_total: 40,
+          mp_campers_with_at_least_one_satisfied: 35,
+          mp_campers_with_all_satisfied: 28,
+        })}
+      />
+    )
+    // Label
+    expect(screen.getByText(/got all requests/i)).toBeInTheDocument()
+    // Value fraction
+    expect(screen.getByText('28/40')).toBeInTheDocument()
+  })
+
+  it('does NOT render the removed "parent requests met" tile', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({
+          material_parent_requests: 30,
+          satisfied_material_parent_requests: 18,
+          material_parent_request_satisfaction_rate: 0.6,
+          mp_campers_total: 40,
+          mp_campers_with_at_least_one_satisfied: 35,
+          mp_campers_with_all_satisfied: 28,
+        })}
+      />
+    )
+    expect(screen.queryByText(/parent requests met/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/^requests met$/i)).not.toBeInTheDocument()
+  })
+
+  it('does NOT render the removed "bunks used" tile', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({
+          bunks_at_capacity: 3,
+          bunks_under_capacity: 1,
+          bunks_over_capacity: 0,
+          mp_campers_total: 40,
+          mp_campers_with_at_least_one_satisfied: 35,
+          mp_campers_with_all_satisfied: 28,
+        })}
+      />
+    )
+    expect(screen.queryByText(/bunks used/i)).not.toBeInTheDocument()
+  })
+
+  it('tile row-major order: got≥1 · got-all (row 1), assigned · issues (row 2)', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({
+          mp_campers_total: 40,
+          mp_campers_with_at_least_one_satisfied: 35,
+          mp_campers_with_all_satisfied: 28,
+        })}
+      />
+    )
+    const allText = document.body.textContent ?? ''
+    const pos = (s: string) => allText.indexOf(s)
+
+    // Row 1: got≥1 before got-all
+    expect(pos('got ≥1 request')).toBeLessThan(pos('got all requests'))
+    // Row 1 before row 2
+    expect(pos('got ≥1 request')).toBeLessThan(pos('assigned'))
+    expect(pos('got all requests')).toBeLessThan(pos('assigned'))
+    // assigned before issues
+    expect(pos('assigned')).toBeLessThan(pos('issues'))
+  })
+
+  it('renders 0/0 without crashing when mp_campers_total is 0', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({
+          mp_campers_total: 0,
+          mp_campers_with_at_least_one_satisfied: 0,
+          mp_campers_with_all_satisfied: 0,
+        })}
+      />
+    )
+    // Both tiles should render 0/0 without crashing or showing NaN/%
+    const zeroDivZero = screen.getAllByText('0/0')
+    expect(zeroDivZero.length).toBeGreaterThanOrEqual(2)
+    expect(screen.queryByText(/NaN/)).not.toBeInTheDocument()
+  })
+
+  it('renders 0/0 when mp_campers fields are absent from statistics (backward compat)', () => {
+    // Old validator responses may not include these fields — must degrade gracefully.
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({})}
+      />
+    )
+    // Fields are undefined → treat as 0/0
+    const zeroDivZero = screen.getAllByText('0/0')
+    expect(zeroDivZero.length).toBeGreaterThanOrEqual(2)
   })
 })

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -13,8 +13,8 @@ import {
   ChevronDown,
   ChevronUp,
   Users,
-  Home,
-  Heart,
+  Check,
+  Star,
   Sparkles,
   TrendingUp,
   Target,
@@ -670,7 +670,6 @@ export function PostCheckContents({
       ? (statistics.material_parent_request_satisfaction_rate ?? 0)
       : statistics.request_satisfaction_rate
   const PARENT_SATISFACTION_TARGET = 0.85
-  const parentUnderTarget = parentTotal > 0 && satisfactionRate < PARENT_SATISFACTION_TARGET
 
   // Residual issues: neither bunk-level nor suppressed (surfaced in dedicated sections).
   const otherIssues = useMemo(
@@ -867,8 +866,37 @@ export function PostCheckContents({
             {/* Ring */}
             <SatisfactionRing rate={satisfactionRate} size={100} />
 
-            {/* Stats grid */}
+            {/* Stats grid — row 1: camper coverage; row 2: assigned + issues */}
             <div className="grid flex-1 grid-cols-2 gap-3">
+              {/* Tile 1: got ≥1 request */}
+              <div className="flex items-center gap-2">
+                <div className="bg-forest-500/10 flex h-8 w-8 items-center justify-center rounded-lg">
+                  <Check className="text-forest-600 h-4 w-4" />
+                </div>
+                <div>
+                  <p className="text-foreground text-lg leading-tight font-semibold">
+                    {statistics.mp_campers_with_at_least_one_satisfied ?? 0}/
+                    {statistics.mp_campers_total ?? 0}
+                  </p>
+                  <p className="text-muted-foreground text-xs">got ≥1 request</p>
+                </div>
+              </div>
+
+              {/* Tile 2: got all requests */}
+              <div className="flex items-center gap-2">
+                <div className="bg-forest-500/10 flex h-8 w-8 items-center justify-center rounded-lg">
+                  <Star className="text-forest-600 h-4 w-4" />
+                </div>
+                <div>
+                  <p className="text-foreground text-lg leading-tight font-semibold">
+                    {statistics.mp_campers_with_all_satisfied ?? 0}/
+                    {statistics.mp_campers_total ?? 0}
+                  </p>
+                  <p className="text-muted-foreground text-xs">got all requests</p>
+                </div>
+              </div>
+
+              {/* Tile 3: assigned */}
               <div className="flex items-center gap-2">
                 <div className="bg-forest-500/10 flex h-8 w-8 items-center justify-center rounded-lg">
                   <Users className="text-forest-600 h-4 w-4" />
@@ -881,42 +909,7 @@ export function PostCheckContents({
                 </div>
               </div>
 
-              <div className="flex items-center gap-2">
-                <div
-                  className={`flex h-8 w-8 items-center justify-center rounded-lg ${
-                    parentUnderTarget ? 'bg-amber-500/10' : 'bg-forest-500/10'
-                  }`}
-                >
-                  <Heart
-                    className={`h-4 w-4 ${parentUnderTarget ? 'text-amber-600' : 'text-forest-600'}`}
-                  />
-                </div>
-                <div>
-                  <p className="text-foreground text-lg leading-tight font-semibold">
-                    {parentTotal > 0
-                      ? `${statistics.satisfied_material_parent_requests ?? 0}/${parentTotal}`
-                      : `${statistics.satisfied_requests}/${statistics.total_requests}`}
-                  </p>
-                  <p className="text-muted-foreground text-xs">
-                    {parentTotal > 0 ? 'parent requests met' : 'requests met'}
-                  </p>
-                </div>
-              </div>
-
-              <div className="flex items-center gap-2">
-                <div className="bg-forest-500/10 flex h-8 w-8 items-center justify-center rounded-lg">
-                  <Home className="text-forest-600 h-4 w-4" />
-                </div>
-                <div>
-                  <p className="text-foreground text-lg leading-tight font-semibold">
-                    {statistics.bunks_at_capacity +
-                      statistics.bunks_under_capacity +
-                      statistics.bunks_over_capacity}
-                  </p>
-                  <p className="text-muted-foreground text-xs">bunks used</p>
-                </div>
-              </div>
-
+              {/* Tile 4: issues */}
               <div className="flex items-center gap-2">
                 <div
                   className={`flex h-8 w-8 items-center justify-center rounded-lg ${


### PR DESCRIPTION
## Summary

- Removes two tiles from the `PostValidationResultsModal` quick-stats 2×2 grid: **"parent requests met"** (request-level, redundant with the satisfaction ring) and **"bunks used"** (not actionable for staff)
- Adds two camper-level coverage tiles using stats already computed by the validator:
  - **"got ≥1 request"** — `mp_campers_with_at_least_one_satisfied / mp_campers_total`
  - **"got all requests"** — `mp_campers_with_all_satisfied / mp_campers_total`
- Final tile order (row-major): got ≥1 request · got all requests (row 1) / assigned · issues (row 2)

## Backend changes

None. All three `mp_campers_*` fields were already present on `ValidationStatistics` in `services/solver.ts` and already returned by the `/validate-bunking` endpoint. This is a pure display-layer change.

## Edge cases

- Division by zero when `mp_campers_total === 0` (no parent requests): guarded with `?? 0`, renders `0/0` without crash.
- Fields absent from old validator responses (backward compat): same `?? 0` guard degrades to `0/0`.

## Denominator note

Denominator is `mp_campers_total` (campers with ≥1 *possible* material-parent request — impossible-only campers excluded). The "include impossible in denominator (96/100)" idea is explicitly deferred out of scope per the design spec.

## Test plan

- [x] New `describe('PostValidationResultsModal — camper coverage tiles (#1631)')` with 7 tests: new tile values, removed tile absence, tile order, 0/0 edge case, backward compat — all verified red before implementation, green after
- [x] Updated existing "parent stats tile (Stage 3b.2)" tests to reflect new design (removed tiles replaced with assertions they no longer render)
- [x] Full render test suite: 64 tests green (up from 58)
- [x] `npx tsc --noEmit` — no errors
- [x] `npx eslint` — 0 errors, 10 pre-existing warnings (unchanged)
- [x] `npx prettier --write` — no changes needed

Closes #1631

🤖 Generated with [Claude Code](https://claude.com/claude-code)