### PR TITLE
feat(frontend): replace priority "1" badge with an "important" emoji (#1641)

### DIFF
--- a/frontend/src/components/camper/FirstPickBadge.test.tsx
+++ b/frontend/src/components/camper/FirstPickBadge.test.tsx
@@ -9,10 +9,10 @@ describe('FirstPickBadge', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('renders a "1" badge with the First pick accessible label when true', () => {
+  it('renders an "important" emoji badge with the First pick accessible label when true', () => {
     render(<FirstPickBadge isFirstRequested={true} />)
     const badge = screen.getByLabelText('First pick')
     expect(badge).toBeInTheDocument()
-    expect(badge).toHaveTextContent('1')
+    expect(badge).toHaveTextContent('❗')
   })
 })

--- a/frontend/src/components/camper/FirstPickBadge.tsx
+++ b/frontend/src/components/camper/FirstPickBadge.tsx
@@ -5,12 +5,8 @@ interface FirstPickBadgeProps {
 export default function FirstPickBadge({ isFirstRequested }: FirstPickBadgeProps) {
   if (!isFirstRequested) return null
   return (
-    <span
-      className="rounded bg-green-100 px-1.5 text-[10px] leading-4 font-bold text-green-800 dark:bg-green-900/40 dark:text-green-300"
-      title="First pick"
-      aria-label="First pick"
-    >
-      1
+    <span className="text-xs leading-none" title="First pick" aria-label="First pick" role="img">
+      ❗
     </span>
   )
 }


### PR DESCRIPTION
## Summary

Replaces the first-pick "1" badge glyph with an "important" emoji (❗), per primary-staff feedback (kindred-feedback#54).

`FirstPickBadge` previously rendered a `1` inside a green pill. The colored emoji is self-contained, so the green pill background is dropped; the `title`/`aria-label="First pick"` and a new `role="img"` keep it accessible.

Surfaces (unchanged): `ParsedRequestsPanel`, `BunkingStatusPanel`, `CamperDetailsPanel` — all consume `FirstPickBadge`, so the swap propagates everywhere the priority indicator appears (`/summer/sessions`).

## Testing

TDD: flipped `FirstPickBadge.test.tsx` to assert `❗` (red), then updated the component (green). prettier / eslint / tsc / vitest all pass.

Closes #1641

🤖 Generated with [Claude Code](https://claude.com/claude-code)