### PR TITLE
feat(solver): hard staff/manual not_bunk_with separation + parent-paramount carve-out (#1541)

### DIFF
--- a/bunking/solver/constraints/base.py
+++ b/bunking/solver/constraints/base.py
@@ -82,6 +82,18 @@ class SolverContext:
     # `localize_hard_mso_infeasibility` in feasibility.py.
     mp_skip_cms: set[int] = field(default_factory=set)
 
+    # Hard staff/manual not_bunk_with (#1541): records where the hard separation
+    # was relaxed to protect a parent-paramount must-satisfy-one. Each entry:
+    # {nbw_request_id, subject_cm, target_cm, protected_parent_request_id,
+    # protected_camper_cm}. Populated by add_staff_separation_constraints; surfaced
+    # post-solve into request_validation_summary["staff_nbw_yielded"].
+    staff_nbw_yields: list[dict[str, Any]] = field(default_factory=list)
+
+    # IIS-localization probe: hard-NBW (subject, target) pairs whose separation
+    # should be skipped to localize a staff-separation infeasibility. Empty in
+    # production runs. Analogue of mp_skip_cms.
+    staff_nbw_skip_pairs: set[tuple[int, int]] = field(default_factory=set)
+
     # Canonical per-request satisfaction vars for bunk_with / not_bunk_with
     # requests, keyed by request.id. Built + memoized by
     # get_or_create_request_sat_var (bunk_requests.py); shared so add_objective

--- a/bunking/solver/constraints/staff_separation.py
+++ b/bunking/solver/constraints/staff_separation.py
@@ -84,7 +84,7 @@ def add_staff_separation_constraints(ctx: SolverContext) -> None:
 
     enforced = 0
     yielded = 0
-    for _cm_id, requests in ctx.possible_requests.items():
+    for requests in ctx.possible_requests.values():
         for r in requests:
             if not _is_hard_mnt(r):
                 continue

--- a/bunking/solver/constraints/staff_separation.py
+++ b/bunking/solver/constraints/staff_separation.py
@@ -1,0 +1,112 @@
+"""Hard staff/manual "do-not-bunk-with" separation constraints (#1541).
+
+Enforces SolverRule.HARD_MNT: not_bunk_with requests from the staff_not_bunk_with
+form and the admin-UI manual channel become a HARD separation
+(bunk[requester] != bunk[target]), not a soft objective term. The single
+parent-paramount carve-out lives in _mso_protection_applies.
+
+No impossibility predicate: cabins are not grade-hard-locked, so separation is
+essentially always feasible (a camper can land in an adjacent-grade bunk,
+penalized but legal). Rare genuine hard-vs-hard conflicts surface as
+infeasibility for manual resolution (find_infeasibility_cause / Stream B #1638).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from bunking.logging_config import get_logger
+from bunking.satisfaction.request_registry import SolverRule, rule_for
+from bunking.sync.bunk_request_processor.core.models import RequestType
+
+from .base import SolverContext
+from .bunk_requests import get_or_create_request_sat_var
+
+if TYPE_CHECKING:
+    from bunking.models_v2 import DirectBunkRequest
+
+logger = get_logger(__name__)
+
+
+def _is_hard_mnt(request: DirectBunkRequest) -> bool:
+    """True iff the registry classifies this request's (source, type) as HARD_MNT."""
+    source_field = request.source_field
+    if not source_field:
+        return False
+    try:
+        return rule_for(source_field, request.request_type) == SolverRule.HARD_MNT
+    except ValueError:
+        # Off-axis (source, type) combo — pipeline-hygiene issue, not HARD_MNT.
+        logger.debug(
+            "staff_separation: off-axis (source=%r, type=%r) request %s — not HARD_MNT",
+            source_field,
+            request.request_type,
+            request.id,
+        )
+        return False
+
+
+def _possible_mp_count(ctx: SolverContext, cm_id: int) -> int:
+    """Number of possible Material-Parent requests for a camper."""
+    from bunking.satisfaction.bucket import is_material_parent_request  # noqa: PLC0415
+
+    return sum(1 for r in ctx.possible_requests.get(cm_id, []) if is_material_parent_request(r))
+
+
+def _mso_protection_applies(ctx: SolverContext, subject_cm: int, target_cm: int) -> dict[str, Any] | None:
+    """Yield record if separating the pair would starve a parent-paramount MSO.
+
+    Looks for a Material-Parent bunk_with between {subject, target} whose requester
+    has exactly one possible MP request (this one). Either direction qualifies.
+    Returns the yield detail (protected_*) for ctx.staff_nbw_yields, or None.
+    """
+    from bunking.satisfaction.bucket import is_material_parent_request  # noqa: PLC0415
+
+    pair = {subject_cm, target_cm}
+    for requester_cm in (subject_cm, target_cm):
+        for r in ctx.possible_requests.get(requester_cm, []):
+            if r.request_type != RequestType.BUNK_WITH.value:
+                continue
+            if not is_material_parent_request(r):
+                continue
+            if {r.requester_person_cm_id, r.requested_person_cm_id} != pair:
+                continue
+            if _possible_mp_count(ctx, requester_cm) == 1:
+                return {"protected_parent_request_id": r.id, "protected_camper_cm": requester_cm}
+    return None
+
+
+def add_staff_separation_constraints(ctx: SolverContext) -> None:
+    """Force separation for staff/manual not_bunk_with (HARD_MNT), with MSO carve-out."""
+    if ctx.is_constraint_disabled("staff_separation"):
+        logger.info("staff_separation constraints DISABLED via debug settings")
+        return
+
+    enforced = 0
+    yielded = 0
+    for _cm_id, requests in ctx.possible_requests.items():
+        for r in requests:
+            if not _is_hard_mnt(r):
+                continue
+            subject_cm = r.requester_person_cm_id
+            target_cm = r.requested_person_cm_id
+            if target_cm is None:
+                continue  # malformed — dropped pre-solve; defensive
+            if (subject_cm, target_cm) in ctx.staff_nbw_skip_pairs:
+                continue  # IIS-localization probe
+
+            protection = _mso_protection_applies(ctx, subject_cm, target_cm)
+            if protection is not None:
+                ctx.staff_nbw_yields.append(
+                    {"nbw_request_id": r.id, "subject_cm": subject_cm, "target_cm": target_cm, **protection}
+                )
+                yielded += 1
+                continue
+
+            sat_var = get_or_create_request_sat_var(ctx, r)
+            if sat_var is None:
+                continue  # target not in roster ⇒ trivially separated
+            ctx.model.Add(sat_var == 1)  # force separation
+            enforced += 1
+
+    logger.info(f"staff_separation: enforced={enforced}, yielded(parent-paramount)={yielded}")

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -1230,6 +1230,11 @@ class DirectBunkingSolver:
         self.request_validation_summary["mp_set_entirely_impossible_count"] = len(self.mp_set_entirely_impossible)
         self.request_validation_summary["mp_set_entirely_impossible_cm_ids"] = list(self.mp_set_entirely_impossible)
 
+        # Hard staff/manual not_bunk_with separations that yielded to a parent-paramount
+        # MSO (#1541) — populated at add_constraints time; surfaced for Stream B (#1638).
+        self.request_validation_summary["staff_nbw_yielded_count"] = len(self.staff_nbw_yields)
+        self.request_validation_summary["staff_nbw_yielded"] = list(self.staff_nbw_yields)
+
         # PR1 symmetric met/total counts -- mirror the bucket-aware unmet keys
         # above with positive-side counts. Consumers (debug page) derive unmet
         # = total - satisfied; we don't persist unmet redundantly.

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -43,6 +43,7 @@ from .constraints.grade_spread import add_grade_spread_constraints
 from .constraints.group_locks import add_group_lock_constraints
 from .constraints.level_progression import add_level_progression_constraints
 from .constraints.parent_paramount import add_must_satisfy_one_request_constraints
+from .constraints.staff_separation import add_staff_separation_constraints
 from .feasibility import RequestValidationSummary
 from .feasibility import check_feasibility as _check_feasibility
 from .feasibility import find_infeasibility_cause as _find_infeasibility_cause
@@ -169,6 +170,10 @@ class DirectBunkingSolver:
         # Track campers whose entire MP request set was impossible — populated by
         # parent_paramount's hard constraint pass; surfaced post-solve into stats.
         self.mp_set_entirely_impossible: list[int] = []
+        # Hard staff/manual not_bunk_with yields (#1541) — separations relaxed to
+        # protect a parent-paramount MSO. Populated by add_staff_separation_constraints;
+        # surfaced post-solve into request_validation_summary["staff_nbw_yielded"].
+        self.staff_nbw_yields: list[dict[str, Any]] = []
 
         # Canonical per-request satisfaction vars (bunk_with / not_bunk_with),
         # keyed by request.id. Populated by get_or_create_request_sat_var via
@@ -220,6 +225,7 @@ class DirectBunkingSolver:
             soft_constraint_violations=self.soft_constraint_violations,
             soft_constraint_bonuses=self.soft_constraint_bonuses,
             mp_set_entirely_impossible=self.mp_set_entirely_impossible,
+            staff_nbw_yields=self.staff_nbw_yields,
             mp_skip_cms=self.mp_skip_cms,
             request_satisfied_vars=self.request_satisfied_vars,
         )
@@ -475,6 +481,11 @@ class DirectBunkingSolver:
         # 10. Must satisfy one request constraints
         # Uses extracted constraint module - debug check is internal
         add_must_satisfy_one_request_constraints(self._build_solver_context())
+
+        # 10b. Hard staff/manual not_bunk_with separation (#1541), with the
+        # parent-paramount MSO carve-out. Runs after parent_paramount so the
+        # must-satisfy-one set is conceptually settled.
+        add_staff_separation_constraints(self._build_solver_context())
 
         # 11. Level progression constraints
         # Uses extracted constraint module - debug check is internal

--- a/bunking/solver/feasibility.py
+++ b/bunking/solver/feasibility.py
@@ -298,6 +298,7 @@ def find_infeasibility_cause(
     constraint_types = [
         "session_boundary",
         "parent_paramount",  # supersedes the former must_satisfy_one probe
+        "staff_separation",  # hard staff/manual not_bunk_with (#1541)
         "grade_spread",
         "age_spread",
         "gender",

--- a/bunking/solver/feasibility.py
+++ b/bunking/solver/feasibility.py
@@ -50,6 +50,11 @@ class RequestValidationSummary(_RequestValidationSummaryBase, total=False):
     all_campers_satisfied: int
     all_requests_total: int
     all_requests_satisfied: int
+    # Hard staff/manual not_bunk_with separations that yielded to a parent-paramount
+    # MSO (#1541). Each entry: {nbw_request_id, subject_cm, target_cm,
+    # protected_parent_request_id, protected_camper_cm}. Consumed by Stream B (#1638).
+    staff_nbw_yielded_count: int
+    staff_nbw_yielded: list[dict[str, Any]]
 
 
 def check_feasibility(

--- a/tests/unit/bunking/satisfaction/test_hard_mnt_contract.py
+++ b/tests/unit/bunking/satisfaction/test_hard_mnt_contract.py
@@ -1,0 +1,21 @@
+"""Guard: the (source, type) combos the hard staff-separation constraint relies on."""
+
+from bunking.satisfaction.request_registry import SolverRule, rule_for
+
+
+def test_staff_not_bunk_with_is_hard_mnt():
+    assert rule_for("staff_not_bunk_with", "not_bunk_with") == SolverRule.HARD_MNT
+
+
+def test_manual_not_bunk_with_is_hard_mnt():
+    assert rule_for("manual", "not_bunk_with") == SolverRule.HARD_MNT
+
+
+def test_parent_not_bunk_with_is_not_hard_mnt():
+    # bunk_request_form NBW is HARD_MSO (parent-paramount), NOT staff separation.
+    assert rule_for("bunk_request_form", "not_bunk_with") != SolverRule.HARD_MNT
+
+
+def test_notes_not_bunk_with_stays_soft():
+    assert rule_for("bunking_notes", "not_bunk_with") == SolverRule.SOFT
+    assert rule_for("internal_notes", "not_bunk_with") == SolverRule.SOFT

--- a/tests/unit/bunking/solver/constraints/test_staff_separation.py
+++ b/tests/unit/bunking/solver/constraints/test_staff_separation.py
@@ -1,0 +1,199 @@
+"""Hard staff/manual not_bunk_with separation (#1541)."""
+
+from ortools.sat.python import cp_model
+
+from bunking.models_v2 import DirectBunkRequest
+from bunking.solver.constraints.base import SolverContext
+from tests.unit.bunking.solver.conftest import (
+    build_solver_context,
+    create_bunk,
+    create_person,
+    is_infeasible,
+    is_optimal_or_feasible,
+)
+
+
+def _nbw(request_id: str, requester: int, requested: int | None, source_field: str) -> DirectBunkRequest:
+    return DirectBunkRequest(
+        id=request_id,
+        requester_person_cm_id=requester,
+        requested_person_cm_id=requested,
+        request_type="not_bunk_with",
+        session_cm_id=1000,
+        year=2025,
+        source_field=source_field,
+        confidence_score=1.0,
+        status="resolved",
+    )
+
+
+def _bunk_with(request_id: str, requester: int, requested: int, source_field: str) -> DirectBunkRequest:
+    return DirectBunkRequest(
+        id=request_id,
+        requester_person_cm_id=requester,
+        requested_person_cm_id=requested,
+        request_type="bunk_with",
+        session_cm_id=1000,
+        year=2025,
+        source_field=source_field,
+        confidence_score=1.0,
+        status="resolved",
+    )
+
+
+def _two_girls_two_bunks(requests: list[DirectBunkRequest], debug: dict[str, bool] | None = None) -> SolverContext:
+    return build_solver_context(
+        persons=[
+            create_person(cm_id=100, first_name="Emma", last_name="Johnson", gender="F", grade=5),
+            create_person(cm_id=200, first_name="Liam", last_name="Garcia", gender="F", grade=5),
+        ],
+        bunks=[
+            create_bunk(cm_id=2001, name="G-1", gender="F", capacity=12),
+            create_bunk(cm_id=2002, name="G-2", gender="F", capacity=12),
+        ],
+        requests=requests,
+        debug_constraints=debug,
+    )
+
+
+def _force_together(ctx: SolverContext, cm_a: int, cm_b: int, bunk_idx: int = 0) -> None:
+    a = ctx.person_idx_map[cm_a]
+    b = ctx.person_idx_map[cm_b]
+    ctx.model.Add(ctx.assignments[(a, bunk_idx)] == 1)
+    ctx.model.Add(ctx.assignments[(b, bunk_idx)] == 1)
+
+
+def test_staff_not_bunk_with_forces_separation():
+    from bunking.solver.constraints.staff_separation import add_staff_separation_constraints
+
+    ctx = _two_girls_two_bunks([_nbw("n1", 100, 200, "staff_not_bunk_with")])
+    add_staff_separation_constraints(ctx)
+    _force_together(ctx, 100, 200)
+    assert is_infeasible(cp_model.CpSolver().Solve(ctx.model))
+
+
+def test_manual_not_bunk_with_forces_separation():
+    from bunking.solver.constraints.staff_separation import add_staff_separation_constraints
+
+    ctx = _two_girls_two_bunks([_nbw("n1", 100, 200, "manual")])
+    add_staff_separation_constraints(ctx)
+    _force_together(ctx, 100, 200)
+    assert is_infeasible(cp_model.CpSolver().Solve(ctx.model))
+
+
+def test_parent_not_bunk_with_not_forced():
+    from bunking.solver.constraints.staff_separation import add_staff_separation_constraints
+
+    # bunk_request_form NBW is HARD_MSO, not HARD_MNT — staff_separation ignores it.
+    ctx = _two_girls_two_bunks([_nbw("n1", 100, 200, "bunk_request_form")])
+    add_staff_separation_constraints(ctx)
+    _force_together(ctx, 100, 200)
+    assert is_optimal_or_feasible(cp_model.CpSolver().Solve(ctx.model))
+
+
+def test_notes_not_bunk_with_not_forced():
+    from bunking.solver.constraints.staff_separation import add_staff_separation_constraints
+
+    ctx = _two_girls_two_bunks([_nbw("n1", 100, 200, "bunking_notes")])
+    add_staff_separation_constraints(ctx)
+    _force_together(ctx, 100, 200)
+    assert is_optimal_or_feasible(cp_model.CpSolver().Solve(ctx.model))
+
+
+def test_target_not_in_roster_no_constraint():
+    from bunking.solver.constraints.staff_separation import add_staff_separation_constraints
+
+    ctx = build_solver_context(
+        persons=[create_person(cm_id=100, first_name="Emma", last_name="Johnson", gender="F", grade=5)],
+        bunks=[
+            create_bunk(cm_id=2001, name="G-1", gender="F"),
+            create_bunk(cm_id=2002, name="G-2", gender="F"),
+        ],
+        requests=[_nbw("n1", 100, 999, "staff_not_bunk_with")],  # 999 not in roster
+    )
+    add_staff_separation_constraints(ctx)
+    assert is_optimal_or_feasible(cp_model.CpSolver().Solve(ctx.model))
+
+
+def test_disabled_via_debug():
+    from bunking.solver.constraints.staff_separation import add_staff_separation_constraints
+
+    ctx = _two_girls_two_bunks([_nbw("n1", 100, 200, "staff_not_bunk_with")], debug={"staff_separation": True})
+    add_staff_separation_constraints(ctx)
+    _force_together(ctx, 100, 200)
+    assert is_optimal_or_feasible(cp_model.CpSolver().Solve(ctx.model))
+
+
+def test_carveout_yields_when_positive_requester_has_one_mp():
+    from bunking.solver.constraints.staff_separation import add_staff_separation_constraints
+
+    # Liam (200) parents request only "bunk with Emma" → his SOLE MP request.
+    ctx = _two_girls_two_bunks(
+        [
+            _nbw("n1", 100, 200, "staff_not_bunk_with"),
+            _bunk_with("p1", 200, 100, "bunk_request_form"),
+        ]
+    )
+    add_staff_separation_constraints(ctx)
+    _force_together(ctx, 100, 200)  # carve-out → no hard separation → together is feasible
+    assert is_optimal_or_feasible(cp_model.CpSolver().Solve(ctx.model))
+    assert len(ctx.staff_nbw_yields) == 1
+    y = ctx.staff_nbw_yields[0]
+    assert y["nbw_request_id"] == "n1"
+    assert y["protected_parent_request_id"] == "p1"
+    assert y["protected_camper_cm"] == 200
+
+
+def test_carveout_holds_when_positive_requester_has_multiple_mp():
+    from bunking.solver.constraints.staff_separation import add_staff_separation_constraints
+
+    # Liam (200) has TWO MP requests → MSO met via Noah, so the staff NBW holds.
+    ctx = build_solver_context(
+        persons=[
+            create_person(cm_id=100, first_name="Emma", last_name="Johnson", gender="F", grade=5),
+            create_person(cm_id=200, first_name="Liam", last_name="Garcia", gender="F", grade=5),
+            create_person(cm_id=300, first_name="Noah", last_name="Chen", gender="F", grade=5),
+        ],
+        bunks=[create_bunk(cm_id=2001, name="G-1", gender="F"), create_bunk(cm_id=2002, name="G-2", gender="F")],
+        requests=[
+            _nbw("n1", 100, 200, "staff_not_bunk_with"),
+            _bunk_with("p1", 200, 100, "bunk_request_form"),
+            _bunk_with("p2", 200, 300, "bunk_request_form"),
+        ],
+    )
+    add_staff_separation_constraints(ctx)
+    _force_together(ctx, 100, 200)
+    assert is_infeasible(cp_model.CpSolver().Solve(ctx.model))
+    assert ctx.staff_nbw_yields == []
+
+
+def test_carveout_covers_both_directions():
+    from bunking.solver.constraints.staff_separation import add_staff_separation_constraints
+
+    # The NBW subject's own family wants the target — Emma (100) sole MP toward Liam.
+    ctx = _two_girls_two_bunks(
+        [
+            _nbw("n1", 100, 200, "staff_not_bunk_with"),
+            _bunk_with("p1", 100, 200, "bunk_request_form"),
+        ]
+    )
+    add_staff_separation_constraints(ctx)
+    _force_together(ctx, 100, 200)
+    assert is_optimal_or_feasible(cp_model.CpSolver().Solve(ctx.model))
+    assert ctx.staff_nbw_yields[0]["protected_camper_cm"] == 100
+
+
+def test_carveout_requires_material_parent_positive():
+    from bunking.solver.constraints.staff_separation import add_staff_separation_constraints
+
+    # A bunking_notes (STAFF, non-MP) bunk_with does NOT trigger the carve-out.
+    ctx = _two_girls_two_bunks(
+        [
+            _nbw("n1", 100, 200, "staff_not_bunk_with"),
+            _bunk_with("p1", 200, 100, "bunking_notes"),
+        ]
+    )
+    add_staff_separation_constraints(ctx)
+    _force_together(ctx, 100, 200)
+    assert is_infeasible(cp_model.CpSolver().Solve(ctx.model))
+    assert ctx.staff_nbw_yields == []

--- a/tests/unit/bunking/solver/constraints/test_staff_separation_context.py
+++ b/tests/unit/bunking/solver/constraints/test_staff_separation_context.py
@@ -1,0 +1,10 @@
+from tests.unit.bunking.solver.conftest import build_solver_context, create_bunk, create_person
+
+
+def test_context_has_empty_staff_nbw_fields_by_default():
+    ctx = build_solver_context(
+        persons=[create_person(cm_id=100, first_name="Emma", last_name="Johnson", gender="F", grade=5)],
+        bunks=[create_bunk(cm_id=2001, name="G-1", gender="F")],
+    )
+    assert ctx.staff_nbw_yields == []
+    assert ctx.staff_nbw_skip_pairs == set()

--- a/tests/unit/solver/test_staff_separation_wiring.py
+++ b/tests/unit/solver/test_staff_separation_wiring.py
@@ -1,0 +1,108 @@
+"""Full-solver wiring for hard staff separation (#1541).
+
+Constructs a real DirectBunkingSolver (mock ConfigLoader, no DB) and solves with
+cp_model to confirm the staff_separation module is invoked by add_constraints and
+behaves end-to-end. The fixture has 16 same-gender campers across 2 bunks: the
+hard minimum-occupancy floor (8/bunk) forces an 8/8 split, so separating one pair
+(or keeping it together) is genuinely feasible.
+"""
+
+from collections.abc import Generator
+from typing import Any, ClassVar
+from unittest.mock import MagicMock
+
+import pytest
+from ortools.sat.python import cp_model
+
+from bunking.config import ConfigLoader
+from bunking.models_v2 import DirectBunk, DirectPerson
+from bunking.solver.direct_solver import DirectBunkingSolver
+from tests.unit.bunking.solver.conftest import is_optimal_or_feasible
+from tests.unit.solver.impossibility.conftest import make_bunk, make_input, make_person, make_request
+
+
+class _PenaltyStubLoader:
+    _values: ClassVar[dict[str, int]] = {
+        "constraint.cabin_minimum_occupancy.penalty": 0,
+        "constraint.grade_spread.penalty": 0,
+    }
+
+    def get_int(self, key: str, default: int | None = None) -> int:
+        v = self._values.get(key)
+        return int(v) if v is not None else (default if default is not None else 0)
+
+    def get_float(self, key: str, default: float | None = None) -> float:
+        v = self._values.get(key)
+        return float(v) if v is not None else (default if default is not None else 0.0)
+
+
+@pytest.fixture
+def mock_config() -> Generator[Any]:
+    cfg = MagicMock()
+
+    def _get_constraint(constraint_type: str, param: str, default: Any = None) -> Any:
+        if constraint_type == "grade_spread" and param == "max_spread":
+            return 2
+        return default if default is not None else 0
+
+    cfg.get_constraint.side_effect = _get_constraint
+    cfg.get_int.side_effect = lambda key, default=None: default if default is not None else 0
+    cfg.get_float.side_effect = lambda key, default=None: default if default is not None else 0.0
+    cfg.get_str.side_effect = lambda key, default=None: "hard" if "grade_spread.mode" in key else (default or "")
+    cfg.get_bool.side_effect = lambda key, default=None: default if default is not None else False
+    cfg.get_soft_constraint_weight.side_effect = lambda name: 0
+
+    with ConfigLoader.use(_PenaltyStubLoader()):  # type: ignore[arg-type]
+        yield cfg
+
+
+def _roster() -> tuple[list[DirectPerson], list[DirectBunk]]:
+    # Emma=100, Liam=200, plus 14 filler girls → 16 campers, 2 F bunks (cap 12).
+    # min-occupancy 8/bunk forces an 8/8 split.
+    persons = [make_person(100, gender="F", grade=6), make_person(200, gender="F", grade=6)]
+    persons += [make_person(1000 + i, gender="F", grade=6) for i in range(14)]
+    bunks = [make_bunk(2001, gender="F"), make_bunk(2002, gender="F")]
+    return persons, bunks
+
+
+def _solve(solver: DirectBunkingSolver) -> tuple[cp_model.CpSolver, Any]:
+    solver.check_feasibility()
+    solver.add_constraints()
+    solver.add_objective()
+    cp = cp_model.CpSolver()
+    cp.parameters.max_time_in_seconds = 10
+    return cp, cp.Solve(solver.model)
+
+
+def _bunk_idx(solver: DirectBunkingSolver, cp: cp_model.CpSolver, cm_id: int) -> int:
+    return int(cp.Value(solver.person_bunk_assignment[solver.person_idx_map[cm_id]]))
+
+
+def test_solver_enforces_staff_nbw_separation(mock_config):
+    persons, bunks = _roster()
+    reqs = [
+        make_request(
+            "n1", requester=100, requestee=200, request_type="not_bunk_with", source_field="staff_not_bunk_with"
+        )
+    ]
+    solver = DirectBunkingSolver(make_input(persons, bunks, reqs), mock_config)
+    cp, status = _solve(solver)
+    assert is_optimal_or_feasible(status)
+    assert _bunk_idx(solver, cp, 100) != _bunk_idx(solver, cp, 200)
+    assert solver.staff_nbw_yields == []
+
+
+def test_solver_carveout_places_together_and_records_yield(mock_config):
+    persons, bunks = _roster()
+    reqs = [
+        make_request(
+            "n1", requester=100, requestee=200, request_type="not_bunk_with", source_field="staff_not_bunk_with"
+        ),
+        make_request("p1", requester=200, requestee=100, request_type="bunk_with", source_field="bunk_request_form"),
+    ]
+    solver = DirectBunkingSolver(make_input(persons, bunks, reqs), mock_config)
+    cp, status = _solve(solver)
+    assert is_optimal_or_feasible(status)
+    assert _bunk_idx(solver, cp, 100) == _bunk_idx(solver, cp, 200)  # parent paramount forces sole MP wish
+    assert len(solver.staff_nbw_yields) == 1
+    assert solver.staff_nbw_yields[0]["nbw_request_id"] == "n1"

--- a/tests/unit/solver/test_staff_separation_wiring.py
+++ b/tests/unit/solver/test_staff_separation_wiring.py
@@ -106,3 +106,19 @@ def test_solver_carveout_places_together_and_records_yield(mock_config):
     assert _bunk_idx(solver, cp, 100) == _bunk_idx(solver, cp, 200)  # parent paramount forces sole MP wish
     assert len(solver.staff_nbw_yields) == 1
     assert solver.staff_nbw_yields[0]["nbw_request_id"] == "n1"
+
+
+def test_yield_surfaced_in_request_validation_stats(mock_config):
+    persons, bunks = _roster()
+    reqs = [
+        make_request(
+            "n1", requester=100, requestee=200, request_type="not_bunk_with", source_field="staff_not_bunk_with"
+        ),
+        make_request("p1", requester=200, requestee=100, request_type="bunk_with", source_field="bunk_request_form"),
+    ]
+    solver = DirectBunkingSolver(make_input(persons, bunks, reqs), mock_config)
+    output = solver.solve(time_limit_seconds=10)
+    assert output is not None
+    rv = output.stats["request_validation"]
+    assert rv["staff_nbw_yielded_count"] == 1
+    assert rv["staff_nbw_yielded"][0]["nbw_request_id"] == "n1"

--- a/tests/unit/solver/test_staff_separation_wiring.py
+++ b/tests/unit/solver/test_staff_separation_wiring.py
@@ -122,3 +122,21 @@ def test_yield_surfaced_in_request_validation_stats(mock_config):
     rv = output.stats["request_validation"]
     assert rv["staff_nbw_yielded_count"] == 1
     assert rv["staff_nbw_yielded"][0]["nbw_request_id"] == "n1"
+
+
+def test_find_infeasibility_cause_isolates_staff_separation(mock_config):
+    from bunking.solver.feasibility import find_infeasibility_cause
+
+    # 8 girls fit one cabin (min-occupancy 8 is satisfied). A staff NBW between
+    # two of them then demands a separation with no second cabin → the staff
+    # constraint is the SOLE cause; disabling it restores feasibility.
+    persons = [make_person(100, gender="F", grade=6), make_person(200, gender="F", grade=6)]
+    persons += [make_person(1000 + i, gender="F", grade=6) for i in range(6)]
+    bunks = [make_bunk(2001, gender="F")]  # single cabin, capacity 12
+    reqs = [
+        make_request(
+            "n1", requester=100, requestee=200, request_type="not_bunk_with", source_field="staff_not_bunk_with"
+        )
+    ]
+    cause = find_infeasibility_cause(make_input(persons, bunks, reqs), mock_config, time_limit_seconds=5)
+    assert "staff_separation" in cause


### PR DESCRIPTION
Closes #1541 (Stream A). Supersedes #1543 (multiplier bump — a soft term can always be overridden; a supervisor "no-go" needs unconditional separation).

## What

Enforces the long-scaffolded `SolverRule.HARD_MNT` rule: `not_bunk_with` requests sourced from `staff_not_bunk_with` or admin-UI `manual` become a **hard** CP-SAT separation (`bunk[A] != bunk[B]`) instead of a soft objective term. Parent (`bunk_request_form`) and AI-notes sources are unchanged.

New module `bunking/solver/constraints/staff_separation.py` mirrors `parent_paramount.py`: it borrows the shared bidirectional sat var from `get_or_create_request_sat_var` and pins it to 1. The solver becomes the first real consumer of the registry's `rule_for(...)`.

## The one carve-out — parent-paramount (MSO) protection

A hard separation *yields* (pair placed together, recorded) only when honoring it would starve a parent-paramount must-satisfy-one — i.e. the conflicting Material-Parent `bunk_with` between the pair is the positive requester's **only** possible MP request. Checked both directions. This is the feasibility guardrail (same shape as MSO being dropped when a camper's sole parent wish is unsatisfiable), not a preference override.

| Conflicting parent `bunk_with` requester's possible MP requests | Result |
|---|---|
| exactly 1 (sole parent wish) | **Together** — NBW yields, surfaced for review |
| ≥ 2 (MSO satisfiable elsewhere) | **Apart** — hard NBW holds |

Yields surface in `request_validation_summary["staff_nbw_yielded"]` for the upcoming infeasibility/review page (#1638). `find_infeasibility_cause` gains a `staff_separation` probe so genuine hard-vs-hard conflicts name the constraint.

## Deliberately out of scope

- **No "can't physically separate" impossibility predicate** — cabins aren't grade-hard-locked, so separation is essentially always feasible (a camper can land in an adjacent-grade bunk, penalized but legal). If a placement is unacceptable, staff override (lock together) or decline the request.
- **Triangle / transitive carve-outs** → deferred to #1639.
- **Persistent infeasibility/review page** → #1638 (renders the yields + diagnostics surfaced here).

## Tests (TDD, written first)

- Registry contract guard (`rule_for == HARD_MNT` for both sources).
- Constraint-module: hard separation for staff + manual; parent/notes untouched; target-not-in-roster no-op; debug-disable; all four carve-out table rows + both-directions + MP-only gating.
- Full-solver wiring (real `DirectBunkingSolver`, 16-camper feasible fixture): separation enforced; carve-out places together + records the yield; yield surfaced in stats.
- `find_infeasibility_cause` isolates `staff_separation` as the sole cause.

Full mockable unit suite (5207) + solver/satisfaction regression green; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enforces hard staff/manual "not-bunk-with" separation constraints during assignment operations.
  * Added post-solve diagnostics reporting staff separation yields and counts when constraints are applied.

* **Improvements**
  * Staff separation constraints intelligently yield to parent-paramount requirements with detailed diagnostic tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1643?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->