### PR TITLE
feat(frontend): persistent solver infeasibility / review surface (#1638)

### DIFF
--- a/api/routers/solver.py
+++ b/api/routers/solver.py
@@ -348,6 +348,12 @@ async def get_solver_run(
                 "status": getattr(pb_run, "status", "unknown"),
                 "results": json.loads(getattr(pb_run, "results", "{}")) if getattr(pb_run, "results", None) else None,
                 "error_message": getattr(pb_run, "error_message", None),
+                # Stream B diagnostics are in-memory only; the PB-fetch path never
+                # has them. Return the keys as None so the response shape matches
+                # the in-memory branch below (#1656).
+                "infeasibility_cause": None,
+                "localization": None,
+                "impossibility_report": None,
             }
         except Exception:
             raise HTTPException(status_code=404, detail="Solver run not found")

--- a/api/routers/solver.py
+++ b/api/routers/solver.py
@@ -358,6 +358,11 @@ async def get_solver_run(
         "status": run["status"],
         "results": run.get("results"),
         "error_message": run.get("error_message"),
+        # Stream B (#1638): structured infeasibility diagnostics (in-memory only;
+        # the PB-fetch fallback above returns these as absent → null client-side).
+        "infeasibility_cause": run.get("infeasibility_cause"),
+        "localization": run.get("localization"),
+        "impossibility_report": run.get("impossibility_report"),
     }
 
 

--- a/api/services/solver_runner.py
+++ b/api/services/solver_runner.py
@@ -8,6 +8,7 @@ Main + AG sessions are automatically fetched together via get_related_session_id
 import asyncio
 import json
 import traceback
+from dataclasses import asdict
 from datetime import UTC, datetime
 from typing import Any
 
@@ -16,7 +17,9 @@ from pocketbase.errors import ClientResponseError
 from bunking.config import ConfigLoader
 from bunking.direct_solver import DirectBunkingSolver
 from bunking.logging_config import get_logger
+from bunking.solver.diagnostics import resolve_localization
 from bunking.solver.feasibility import localize_hard_mso_infeasibility
+from bunking.solver.impossibility import filter_immaterial_requests
 from pocketbase import PocketBase
 
 from ..constants.collections import CAMP_SESSIONS, SOLVER_RUNS, SUPERUSERS
@@ -219,6 +222,16 @@ async def run_solver_task_v2(
         if result is None:
             # Try to identify the cause of infeasibility
             logger.warning("Solver failed - running infeasibility analysis...")
+
+            # Surface the already-computed impossibility report (#1638). The solver
+            # holds it; immaterial-filter it to match the pre-validate surface.
+            try:
+                solver_runs[run_id]["impossibility_report"] = asdict(
+                    filter_immaterial_requests(solver.impossibility_report)
+                )
+            except Exception as e:
+                logger.error(f"Failed to capture impossibility report: {e}", exc_info=True)
+
             try:
                 cause = await asyncio.to_thread(solver.find_infeasibility_cause, time_limit_seconds=10)
                 logger.error(f"Infeasibility analysis result: {cause}")
@@ -235,6 +248,8 @@ async def run_solver_task_v2(
                     )
                     logger.error(f"Hard-MSO IIS localization: {iis}")
                     solver_runs[run_id]["parent_paramount_iis"] = iis
+                    # Name-resolve for the frontend (#1638).
+                    solver_runs[run_id]["localization"] = resolve_localization(iis, solver_input.person_by_cm_id)
             except Exception as e:
                 logger.error(f"Failed to run infeasibility analysis: {e}", exc_info=True)
 

--- a/bunking/solver/diagnostics.py
+++ b/bunking/solver/diagnostics.py
@@ -1,0 +1,43 @@
+"""Diagnostics helpers for surfacing solver infeasibility to the frontend.
+
+Stream B (#1638): the localizer (`localize_hard_mso_infeasibility`) returns
+cm_ids only. The solver runner has `person_by_cm_id`; resolve names here so the
+API response is self-contained (mirrors how `impossibility_report` items already
+carry `requester.name`).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bunking.models_v2 import DirectPerson
+
+
+def resolve_localization(iis: dict[str, Any], person_by_cm_id: dict[int, DirectPerson]) -> dict[str, Any]:
+    """Transform a `localize_hard_mso_infeasibility` IIS dict into a name-resolved shape.
+
+    Prefers `minimal_correction_set`; falls back to `singleton_critical_cms`.
+    Unknown cm_ids degrade to using the id as the display name.
+    """
+    cm_ids = iis.get("minimal_correction_set") or iis.get("singleton_critical_cms") or []
+    campers: list[dict[str, Any]] = []
+    for cm in cm_ids:
+        person = person_by_cm_id.get(cm)
+        if person is not None:
+            campers.append(
+                {
+                    "cm_id": cm,
+                    "name": f"{person.first_name} {person.last_name}".strip(),
+                    "grade": person.grade,
+                    "gender": person.gender,
+                }
+            )
+        else:
+            campers.append({"cm_id": cm, "name": str(cm), "grade": None, "gender": None})
+    return {
+        "approach": iis.get("approach", ""),
+        "candidate_count": iis.get("candidate_count", 0),
+        "campers": campers,
+        "notes": iis.get("notes", ""),
+    }

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -474,7 +474,10 @@ export default function SessionView() {
       {diagnostics && (
         <SolverDiagnosticsModal
           isOpen={showDiagnostics}
-          onClose={() => setShowDiagnostics(false)}
+          onClose={() => {
+            setShowDiagnostics(false)
+            setDiagnostics(null)
+          }}
           diagnostics={diagnostics}
           sessionCmId={session.cm_id}
           year={currentYear}

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -476,7 +476,7 @@ export default function SessionView() {
           isOpen={showDiagnostics}
           onClose={() => setShowDiagnostics(false)}
           diagnostics={diagnostics}
-          sessionCmId={session?.cm_id ?? null}
+          sessionCmId={session.cm_id}
           year={currentYear}
         />
       )}

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -18,6 +18,9 @@ import {
   useBunkRequestsCount,
 } from '../hooks/session'
 import SolverProgressModal, { useSolverProgress } from './SolverProgressModal'
+import SolverDiagnosticsModal from './SolverDiagnosticsModal'
+import type { SolverDiagnostics } from '../services/solver'
+import { resolveYields, hasReviewableDiagnostics } from '../utils/solverDiagnostics'
 import { isValidTab, type ValidTab, sessionNameToUrl } from '../utils/sessionUtils'
 import BunkingBoardByArea from './BunkingBoardByArea'
 import RequestReviewPanel from './RequestReviewPanel'
@@ -88,6 +91,10 @@ export default function SessionView() {
   // `constraint.cabin_capacity.standard` from the config table.
   const defaultBunkCapacity = DEFAULT_BUNK_CAPACITY
 
+  // #1638 — diagnostics modal state
+  const [diagnostics, setDiagnostics] = useState<SolverDiagnostics | null>(null)
+  const [showDiagnostics, setShowDiagnostics] = useState(false)
+
   // Solver progress modal
   const solverProgress = useSolverProgress()
 
@@ -120,6 +127,31 @@ export default function SessionView() {
     respectLocks,
   })
 
+  // Data fetching hooks — campers must be available before handleRunSolver
+  // so camperNameById (which depends on campers) can be used in the callback.
+  const { data: bunks = [] } = useSessionBunks({
+    selectedSession,
+    sessionCmId: session?.cm_id,
+    agSessions,
+    currentYear,
+  })
+
+  const { data: campers = [] } = useSessionCampers({
+    selectedSession,
+    agSessions,
+    currentYear,
+    scenarioId: currentScenario?.id,
+  })
+
+  // #1638 — name map for resolving staff-NBW yield cm_ids to display names.
+  const camperNameById = useMemo(
+    () =>
+      new Map<number, string>(
+        campers.map((c) => [c.person_cm_id, `${c.first_name ?? ''} ${c.last_name ?? ''}`.trim()])
+      ),
+    [campers]
+  )
+
   // Wrapped handleRunSolver that coordinates with progress modal
   // respectLocks is already wired through useSolverOperations state, so
   // we accept (but don't use) it from the button to satisfy the type signature
@@ -141,13 +173,24 @@ export default function SessionView() {
           assignments_changed: result.stats?.assignments_changed,
           new_assignments: result.stats?.new_assignments,
           request_validation: result.stats?.request_validation,
+          // #1638 — resolve staff-separation yields to names for the advisory.
+          staff_separation_yields: resolveYields(
+            result.stats?.request_validation?.staff_nbw_yielded,
+            camperNameById
+          ),
         })
+      } else if (hasReviewableDiagnostics(result.diagnostics)) {
+        // #1638 — persistent review surface replaces the transient red box.
+        solverProgress.close()
+        setDiagnostics(result.diagnostics ?? null)
+        setShowDiagnostics(true)
       } else {
-        // Show error in modal
+        // Generic failure (no diagnostics, e.g. transport/PB error) — keep the
+        // existing inline error box.
         solverProgress.fail(result.errorMessage ?? 'Optimization failed')
       }
     },
-    [solverProgress, runSolverInternal, currentScenario?.name]
+    [solverProgress, runSolverInternal, currentScenario?.name, camperNameById]
   )
 
   // Reset selected area if All-Gender is selected but no longer available (render-time check)
@@ -168,21 +211,6 @@ export default function SessionView() {
       setLockGroupSessionPbId(session.id)
     }
   }, [session?.id, setLockGroupSessionPbId])
-
-  // Data fetching hooks (extracted from SessionView)
-  const { data: bunks = [] } = useSessionBunks({
-    selectedSession,
-    sessionCmId: session?.cm_id,
-    agSessions,
-    currentYear,
-  })
-
-  const { data: campers = [] } = useSessionCampers({
-    selectedSession,
-    agSessions,
-    currentYear,
-    scenarioId: currentScenario?.id,
-  })
 
   // #1310 — feed in-session campers into RequestReviewPanel as the seed for
   // its personMap. The panel only needs cm_id + first/last name + grade for
@@ -441,6 +469,17 @@ export default function SessionView() {
 
       {/* Solver Progress Modal */}
       <SolverProgressModal state={solverProgress.state} onClose={solverProgress.close} />
+
+      {/* #1638 — Solver Diagnostics Modal (infeasibility review) */}
+      {diagnostics && (
+        <SolverDiagnosticsModal
+          isOpen={showDiagnostics}
+          onClose={() => setShowDiagnostics(false)}
+          diagnostics={diagnostics}
+          sessionCmId={session?.cm_id ?? null}
+          year={currentYear}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/components/SolverDiagnosticsModal.test.tsx
+++ b/frontend/src/components/SolverDiagnosticsModal.test.tsx
@@ -1,7 +1,19 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
+import type { ReactNode } from 'react'
 import SolverDiagnosticsModal from './SolverDiagnosticsModal'
 import type { SolverDiagnostics } from '../services/solver'
+
+// Light stand-ins so selecting a camper doesn't pull in the real lazy panel /
+// BunkRequestProvider (which need a query client + network).
+vi.mock('../providers/BunkRequestProvider', () => ({
+  BunkRequestProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+vi.mock('./impossibility/LazyCamperDetailsPanel', () => ({
+  LazyCamperDetailsPanel: ({ camperId }: { camperId: string }) => (
+    <div data-testid="camper-details-panel">camper:{camperId}</div>
+  ),
+}))
 
 const diagnostics: SolverDiagnostics = {
   infeasibilityCause: 'The parent_paramount constraint is causing infeasibility',
@@ -62,6 +74,66 @@ describe('SolverDiagnosticsModal (#1638)', () => {
       />
     )
     expect(screen.queryByText(/Solver could not find/i)).toBeNull()
+  })
+
+  it('renders localized campers even when there is no infeasibility cause', () => {
+    // #1638 review fix: hasAny counts localization, so the campers must render
+    // independently of infeasibilityCause — otherwise the body is blank
+    // (localization present, but the "no detail" notice suppressed).
+    render(
+      <SolverDiagnosticsModal
+        isOpen
+        onClose={() => {}}
+        diagnostics={{
+          infeasibilityCause: null,
+          localization: diagnostics.localization,
+          impossibilityReport: null,
+        }}
+        sessionCmId={1000001}
+        year={2026}
+      />
+    )
+    expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
+    expect(screen.getByText('Liam Garcia')).toBeInTheDocument()
+    expect(screen.queryByText(/no diagnostic detail/i)).toBeNull()
+  })
+
+  it('clears the selected camper when closed (no stale details panel on reopen)', () => {
+    // #1638 review fix: selectedCamperId must reset when the modal closes, or
+    // reopening immediately pops the previously-selected camper's panel.
+    const { rerender } = render(
+      <SolverDiagnosticsModal
+        isOpen
+        onClose={() => {}}
+        diagnostics={diagnostics}
+        sessionCmId={1000001}
+        year={2026}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Open details for Emma Johnson/i }))
+    expect(screen.getByTestId('camper-details-panel')).toHaveTextContent('camper:1000001')
+
+    // Close...
+    rerender(
+      <SolverDiagnosticsModal
+        isOpen={false}
+        onClose={() => {}}
+        diagnostics={diagnostics}
+        sessionCmId={1000001}
+        year={2026}
+      />
+    )
+    // ...then reopen: the previously-selected camper must NOT auto-reopen.
+    rerender(
+      <SolverDiagnosticsModal
+        isOpen
+        onClose={() => {}}
+        diagnostics={diagnostics}
+        sessionCmId={1000001}
+        year={2026}
+      />
+    )
+    expect(screen.queryByTestId('camper-details-panel')).toBeNull()
   })
 
   it('handles empty diagnostics gracefully', () => {

--- a/frontend/src/components/SolverDiagnosticsModal.test.tsx
+++ b/frontend/src/components/SolverDiagnosticsModal.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import SolverDiagnosticsModal from './SolverDiagnosticsModal'
 import type { SolverDiagnostics } from '../services/solver'
 
@@ -75,5 +75,29 @@ describe('SolverDiagnosticsModal (#1638)', () => {
       />
     )
     expect(screen.getByText(/no diagnostic detail/i)).toBeInTheDocument()
+  })
+
+  it('does not auto-dismiss on a timer (persists until explicit close)', () => {
+    // Spec §6.6: the review surface must stay up for review — never close on a
+    // timeout the way the old transient red box did. Advancing timers must not
+    // close it or fire onClose.
+    vi.useFakeTimers()
+    try {
+      const onClose = vi.fn()
+      render(
+        <SolverDiagnosticsModal
+          isOpen
+          onClose={onClose}
+          diagnostics={diagnostics}
+          sessionCmId={1000001}
+          year={2026}
+        />
+      )
+      vi.advanceTimersByTime(60_000)
+      expect(onClose).not.toHaveBeenCalled()
+      expect(screen.getByText(/Solver could not find a solution/i)).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/frontend/src/components/SolverDiagnosticsModal.test.tsx
+++ b/frontend/src/components/SolverDiagnosticsModal.test.tsx
@@ -149,6 +149,21 @@ describe('SolverDiagnosticsModal (#1638)', () => {
     expect(screen.getByText(/no diagnostic detail/i)).toBeInTheDocument()
   })
 
+  it('empty-state hints that a page refresh may have cleared diagnostics', () => {
+    // #1656 — diagnostics live in the in-memory run dict only; a reload drops
+    // them. The empty state should tell the user that, not imply none existed.
+    render(
+      <SolverDiagnosticsModal
+        isOpen
+        onClose={() => {}}
+        diagnostics={{ infeasibilityCause: null, localization: null, impossibilityReport: null }}
+        sessionCmId={1000001}
+        year={2026}
+      />
+    )
+    expect(screen.getByText(/refresh|reload/i)).toBeInTheDocument()
+  })
+
   it('does not auto-dismiss on a timer (persists until explicit close)', () => {
     // Spec §6.6: the review surface must stay up for review — never close on a
     // timeout the way the old transient red box did. Advancing timers must not

--- a/frontend/src/components/SolverDiagnosticsModal.test.tsx
+++ b/frontend/src/components/SolverDiagnosticsModal.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import SolverDiagnosticsModal from './SolverDiagnosticsModal'
+import type { SolverDiagnostics } from '../services/solver'
+
+const diagnostics: SolverDiagnostics = {
+  infeasibilityCause: 'The parent_paramount constraint is causing infeasibility',
+  localization: {
+    approach: 'singleton',
+    candidate_count: 2,
+    campers: [
+      { cm_id: 1000001, name: 'Emma Johnson', grade: 5, gender: 'F' },
+      { cm_id: 1000002, name: 'Liam Garcia', grade: 6, gender: 'M' },
+    ],
+    notes: 'Each listed camper alone restores feasibility.',
+  },
+  impossibilityReport: {
+    total_impossible: 1,
+    affected_campers: 1,
+    by_reason: {},
+    flat: [
+      {
+        request_id: 'r1',
+        reason_code: 'cross_session',
+        reason_message: 'Cross-session request',
+        request_type: 'bunk_with',
+        requester: { cm_id: 1000003, name: 'Olivia Chen', grade: 4, gender: 'F' },
+        requestee: null,
+        detail: {},
+        bucket: 'material_parent',
+      },
+    ],
+  },
+}
+
+describe('SolverDiagnosticsModal (#1638)', () => {
+  it('renders the cause, localized campers, and the impossibility row', () => {
+    render(
+      <SolverDiagnosticsModal
+        isOpen
+        onClose={() => {}}
+        diagnostics={diagnostics}
+        sessionCmId={1000001}
+        year={2026}
+      />
+    )
+    expect(screen.getByText(/parent_paramount constraint/i)).toBeInTheDocument()
+    expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
+    expect(screen.getByText('Liam Garcia')).toBeInTheDocument()
+    expect(screen.getByText('Olivia Chen')).toBeInTheDocument()
+    expect(screen.getByText('cross_session')).toBeInTheDocument()
+  })
+
+  it('renders nothing when closed', () => {
+    render(
+      <SolverDiagnosticsModal
+        isOpen={false}
+        onClose={() => {}}
+        diagnostics={diagnostics}
+        sessionCmId={1000001}
+        year={2026}
+      />
+    )
+    expect(screen.queryByText(/Solver could not find/i)).toBeNull()
+  })
+
+  it('handles empty diagnostics gracefully', () => {
+    render(
+      <SolverDiagnosticsModal
+        isOpen
+        onClose={() => {}}
+        diagnostics={{ infeasibilityCause: null, localization: null, impossibilityReport: null }}
+        sessionCmId={1000001}
+        year={2026}
+      />
+    )
+    expect(screen.getByText(/no diagnostic detail/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/SolverDiagnosticsModal.tsx
+++ b/frontend/src/components/SolverDiagnosticsModal.tsx
@@ -63,7 +63,8 @@ export default function SolverDiagnosticsModal({
       <div className="space-y-5 px-5 py-4">
         {!hasAny && (
           <div className="rounded-md bg-stone-50 p-3 text-sm text-stone-600">
-            No diagnostic detail was captured for this run.
+            No diagnostic detail is available for this run — it may have been cleared by a page
+            refresh. Re-run the solver to regenerate it.
           </div>
         )}
 

--- a/frontend/src/components/SolverDiagnosticsModal.tsx
+++ b/frontend/src/components/SolverDiagnosticsModal.tsx
@@ -1,0 +1,196 @@
+import { Suspense, useState } from 'react'
+import { Modal } from './ui/Modal'
+import type { ImpossibilityReportItem, SolverDiagnostics } from '../services/solver'
+import { CamperNameButton } from './impossibility/CamperNameButton'
+import { LazyCamperDetailsPanel } from './impossibility/LazyCamperDetailsPanel'
+import { BunkRequestProvider } from '../providers/BunkRequestProvider'
+import { ErrorBoundary } from './ErrorBoundary'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  diagnostics: SolverDiagnostics
+  sessionCmId: number | null
+  year: number
+}
+
+function compactDetail(detail: Record<string, unknown> | null | undefined): string {
+  if (!detail) return ''
+  return Object.entries(detail)
+    .map(([k, v]) => `${k}=${String(v)}`)
+    .join(', ')
+}
+
+export default function SolverDiagnosticsModal({
+  isOpen,
+  onClose,
+  diagnostics,
+  sessionCmId,
+  year,
+}: Props) {
+  const [selectedCamperId, setSelectedCamperId] = useState<string | null>(null)
+  const { infeasibilityCause, localization, impossibilityReport } = diagnostics
+  const hasAny =
+    Boolean(infeasibilityCause) ||
+    (localization?.campers.length ?? 0) > 0 ||
+    (impossibilityReport?.flat.length ?? 0) > 0
+
+  const header = (
+    <div className="border-border/50 flex items-center justify-between border-b px-5 py-3">
+      <div>
+        <div className="text-foreground text-sm font-bold">Solver could not find a solution</div>
+        <div className="text-muted-foreground mt-0.5 text-xs">
+          session={sessionCmId ?? '—'} · year={year}
+        </div>
+      </div>
+    </div>
+  )
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      header={header}
+      size="2xl"
+      scrollable
+      ariaLabel="Solver infeasibility diagnostics"
+    >
+      <div className="space-y-5 px-5 py-4">
+        {!hasAny && (
+          <div className="rounded-md bg-stone-50 p-3 text-sm text-stone-600">
+            No diagnostic detail was captured for this run.
+          </div>
+        )}
+
+        {/* Why the solve failed */}
+        {infeasibilityCause && (
+          <section>
+            <h3 className="mb-1 text-sm font-bold text-red-800">Why the solve failed</h3>
+            <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+              {infeasibilityCause}
+            </p>
+            {localization && localization.campers.length > 0 && (
+              <div className="mt-2 rounded-md border border-red-200 bg-white p-3">
+                <p className="text-xs text-stone-600">{localization.notes}</p>
+                <ul className="mt-2 space-y-1">
+                  {localization.campers.map((c) => (
+                    <li key={c.cm_id} className="text-sm">
+                      <CamperNameButton
+                        cmId={c.cm_id}
+                        name={c.name}
+                        onSelect={setSelectedCamperId}
+                        disabled={sessionCmId === null}
+                      />{' '}
+                      <span className="text-stone-500">
+                        ({c.cm_id}
+                        {c.grade != null ? `/g${c.grade}` : ''}
+                        {c.gender ? `/${c.gender}` : ''})
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </section>
+        )}
+
+        {/* Requests that can never be satisfied */}
+        {impossibilityReport && impossibilityReport.flat.length > 0 && (
+          <section>
+            <h3 className="mb-1 text-sm font-bold text-stone-700">
+              Requests that can never be satisfied ({impossibilityReport.total_impossible})
+            </h3>
+            <table className="w-full border-collapse text-xs">
+              <thead className="bg-stone-100">
+                <tr>
+                  <th className="border-b border-stone-300 px-2 py-1 text-left font-semibold">
+                    Reason
+                  </th>
+                  <th className="border-b border-stone-300 px-2 py-1 text-left font-semibold">
+                    Camper A
+                  </th>
+                  <th className="border-b border-stone-300 px-2 py-1 text-left font-semibold">
+                    Camper B
+                  </th>
+                  <th className="border-b border-stone-300 px-2 py-1 text-left font-semibold">
+                    Type
+                  </th>
+                  <th className="border-b border-stone-300 px-2 py-1 text-left font-semibold">
+                    Detail
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {impossibilityReport.flat.map((item: ImpossibilityReportItem) => (
+                  <tr
+                    key={`${item.request_id}-${item.reason_code}`}
+                    className="border-b border-stone-200"
+                  >
+                    <td className="px-2 py-1">
+                      <span className="rounded-full bg-stone-100 px-2 py-0.5 text-[10px] font-semibold text-stone-700">
+                        {item.reason_code}
+                      </span>
+                    </td>
+                    <td className="px-2 py-1">
+                      <CamperNameButton
+                        cmId={item.requester.cm_id}
+                        name={item.requester.name}
+                        onSelect={setSelectedCamperId}
+                        disabled={sessionCmId === null}
+                      />
+                    </td>
+                    <td className="px-2 py-1">
+                      {item.requestee ? (
+                        <CamperNameButton
+                          cmId={item.requestee.cm_id}
+                          name={item.requestee.name}
+                          onSelect={setSelectedCamperId}
+                          disabled={sessionCmId === null}
+                        />
+                      ) : (
+                        '—'
+                      )}
+                    </td>
+                    <td className="px-2 py-1 text-stone-600">{item.request_type}</td>
+                    <td className="px-2 py-1 whitespace-nowrap text-stone-600">
+                      {compactDetail(item.detail)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </section>
+        )}
+      </div>
+
+      {selectedCamperId != null && sessionCmId != null && (
+        <BunkRequestProvider sessionCmId={sessionCmId}>
+          <ErrorBoundary
+            fallback={(error, reset) => (
+              <div className="fixed inset-y-0 right-0 z-50 m-4 max-w-md rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-800">
+                <p>Couldn&apos;t load camper details: {error.message}</p>
+                <button
+                  type="button"
+                  onClick={() => {
+                    reset()
+                    setSelectedCamperId(null)
+                  }}
+                  className="mt-2 rounded bg-red-600 px-3 py-1 text-white"
+                >
+                  Close
+                </button>
+              </div>
+            )}
+          >
+            <Suspense fallback={null}>
+              <LazyCamperDetailsPanel
+                camperId={selectedCamperId}
+                onClose={() => setSelectedCamperId(null)}
+              />
+            </Suspense>
+          </ErrorBoundary>
+        </BunkRequestProvider>
+      )}
+    </Modal>
+  )
+}

--- a/frontend/src/components/SolverDiagnosticsModal.tsx
+++ b/frontend/src/components/SolverDiagnosticsModal.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import { Modal } from './ui/Modal'
 import type { ImpossibilityReportItem, SolverDiagnostics } from '../services/solver'
 import { CamperNameButton } from './impossibility/CamperNameButton'
@@ -29,6 +29,11 @@ export default function SolverDiagnosticsModal({
   year,
 }: Props) {
   const [selectedCamperId, setSelectedCamperId] = useState<string | null>(null)
+  // Reset the drill-through selection when the modal closes, so reopening it
+  // doesn't immediately pop the previously-selected camper's details panel.
+  useEffect(() => {
+    if (!isOpen) setSelectedCamperId(null)
+  }, [isOpen])
   const { infeasibilityCause, localization, impossibilityReport } = diagnostics
   const hasAny =
     Boolean(infeasibilityCause) ||
@@ -63,12 +68,14 @@ export default function SolverDiagnosticsModal({
         )}
 
         {/* Why the solve failed */}
-        {infeasibilityCause && (
+        {(infeasibilityCause || (localization?.campers.length ?? 0) > 0) && (
           <section>
             <h3 className="mb-1 text-sm font-bold text-red-800">Why the solve failed</h3>
-            <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
-              {infeasibilityCause}
-            </p>
+            {infeasibilityCause && (
+              <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+                {infeasibilityCause}
+              </p>
+            )}
             {localization && localization.campers.length > 0 && (
               <div className="mt-2 rounded-md border border-red-200 bg-white p-3">
                 <p className="text-xs text-stone-600">{localization.notes}</p>

--- a/frontend/src/components/SolverProgressModal.test.tsx
+++ b/frontend/src/components/SolverProgressModal.test.tsx
@@ -51,3 +51,41 @@ describe('SolverProgressModal material-only count passthrough (Group 65 #1539)',
     expect(screen.getByText('42/50')).toBeInTheDocument()
   })
 })
+
+const completedWithYields: SolverProgressState = {
+  isOpen: true,
+  phase: 'completed',
+  elapsedSeconds: 60,
+  timeLimit: 60,
+  stats: {
+    satisfied_request_count: 200,
+    total_requests: 220,
+    duration_seconds: 60,
+    new_assignments: 100,
+    staff_separation_yields: [
+      {
+        subjectName: 'Emma Johnson',
+        targetName: 'Liam Garcia',
+        protectedCamperName: 'Liam Garcia',
+      },
+    ],
+  },
+}
+
+describe('SolverProgressModal staff-separation yields (#1638)', () => {
+  it('renders the yield advisory when yields are present', () => {
+    render(<SolverProgressModal state={completedWithYields} onClose={() => {}} />)
+    expect(screen.getByText(/staff separation/i)).toBeInTheDocument()
+    expect(screen.getByText(/Emma Johnson/)).toBeInTheDocument()
+    expect(screen.getByText(/Liam Garcia/)).toBeInTheDocument()
+  })
+
+  it('omits the advisory when there are no yields', () => {
+    const noYields: SolverProgressState = {
+      ...completedWithYields,
+      stats: { ...completedWithYields.stats, staff_separation_yields: [] },
+    }
+    render(<SolverProgressModal state={noYields} onClose={() => {}} />)
+    expect(screen.queryByText(/staff separation/i)).toBeNull()
+  })
+})

--- a/frontend/src/components/SolverProgressModal.tsx
+++ b/frontend/src/components/SolverProgressModal.tsx
@@ -33,6 +33,13 @@ export type SolverPhase =
   | 'failed'
   | 'applying'
 
+/** A staff-separation yield with names already resolved (by SessionView). */
+export interface ResolvedStaffSeparationYield {
+  subjectName: string
+  targetName: string
+  protectedCamperName: string
+}
+
 // Stats from solver results
 export interface SolverResultStats {
   satisfied_request_count?: number | undefined
@@ -48,6 +55,7 @@ export interface SolverResultStats {
         affected_campers: number
       }
     | undefined
+  staff_separation_yields?: ResolvedStaffSeparationYield[] | undefined
 }
 
 export interface SolverProgressState {
@@ -441,6 +449,29 @@ export default function SolverProgressModal({
                     <p className="mt-0.5 text-xs text-amber-600 dark:text-amber-400">
                       Open Pre-Check for the breakdown by reason
                     </p>
+                  </div>
+                </div>
+              )}
+
+              {/* #1638 — staff separations that had to yield to protect a parent-paramount request. */}
+              {stats.staff_separation_yields && stats.staff_separation_yields.length > 0 && (
+                <div className="rounded-xl bg-amber-50 p-3 ring-1 ring-amber-200 dark:bg-amber-950/30 dark:ring-amber-800">
+                  <div className="flex items-start gap-3">
+                    <AlertTriangle className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-600 dark:text-amber-400" />
+                    <div>
+                      <p className="text-sm font-medium text-amber-700 dark:text-amber-300">
+                        {stats.staff_separation_yields.length} staff separation
+                        {stats.staff_separation_yields.length === 1 ? '' : 's'} overridden
+                      </p>
+                      <ul className="mt-1 space-y-1 text-xs text-amber-600 dark:text-amber-400">
+                        {stats.staff_separation_yields.map((y, i) => (
+                          <li key={i}>
+                            {y.subjectName} ↔ {y.targetName} — placed together to protect{' '}
+                            {y.protectedCamperName}&apos;s only honorable parent request
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
                   </div>
                 </div>
               )}

--- a/frontend/src/hooks/session/useSolverOperations.test.ts
+++ b/frontend/src/hooks/session/useSolverOperations.test.ts
@@ -4,6 +4,11 @@
  */
 
 import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createElement, type ReactNode } from 'react'
+import { useSolverOperations } from './useSolverOperations'
+import { solverService } from '../../services/solver'
 
 // These tests verify the solver operation logic
 // The actual hook uses solverService which is mocked in tests
@@ -185,5 +190,50 @@ describe('solver result statistics', () => {
       validation?.impossible_requests && validation.impossible_requests > 0
 
     expect(hasImpossibleRequests).toBeFalsy()
+  })
+})
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return createElement(QueryClientProvider, { client: qc }, children)
+}
+
+describe('useSolverOperations diagnostics passthrough (#1638)', () => {
+  it('returns diagnostics on a failed run', async () => {
+    vi.spyOn(solverService, 'runSolver').mockResolvedValue({
+      id: 'run-1',
+      session: '1000001',
+      status: 'failed',
+      error_message: 'Solver failed to find a solution',
+      diagnostics: {
+        infeasibilityCause: 'The parent_paramount constraint is causing infeasibility',
+        localization: null,
+        impossibilityReport: null,
+      },
+      created: '',
+      updated: '',
+    } as never)
+
+    const { result } = renderHook(
+      () =>
+        useSolverOperations({
+          selectedSession: '1000001',
+          currentYear: 2026,
+          currentScenario: null,
+          scenarios: [],
+          autoApplyEnabled: false,
+          autoApplyTimeout: 0,
+          fetchWithAuth: vi.fn(),
+          respectLocks: true,
+        }),
+      { wrapper }
+    )
+
+    let outcome: Awaited<ReturnType<typeof result.current.handleRunSolver>> | undefined
+    await act(async () => {
+      outcome = await result.current.handleRunSolver(60)
+    })
+    expect(outcome?.success).toBe(false)
+    expect(outcome?.diagnostics?.infeasibilityCause).toContain('parent_paramount')
   })
 })

--- a/frontend/src/hooks/session/useSolverOperations.test.ts
+++ b/frontend/src/hooks/session/useSolverOperations.test.ts
@@ -236,4 +236,44 @@ describe('useSolverOperations diagnostics passthrough (#1638)', () => {
     expect(outcome?.success).toBe(false)
     expect(outcome?.diagnostics?.infeasibilityCause).toContain('parent_paramount')
   })
+
+  it('logs a console.warn breadcrumb on a failed run', async () => {
+    // #1656 — failed runs no longer throw (diagnostics ride the return value), so
+    // without an explicit log an infeasible solve produces zero console output.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(solverService, 'runSolver').mockResolvedValue({
+      id: 'run-1',
+      session: '1000001',
+      status: 'failed',
+      error_message: 'Solver failed to find a solution',
+      diagnostics: { infeasibilityCause: null, localization: null, impossibilityReport: null },
+      created: '',
+      updated: '',
+    } as never)
+
+    const { result } = renderHook(
+      () =>
+        useSolverOperations({
+          selectedSession: '1000001',
+          currentYear: 2026,
+          currentScenario: null,
+          scenarios: [],
+          autoApplyEnabled: false,
+          autoApplyTimeout: 0,
+          fetchWithAuth: vi.fn(),
+          respectLocks: true,
+        }),
+      { wrapper }
+    )
+
+    await act(async () => {
+      await result.current.handleRunSolver(60)
+    })
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Solver run did not complete:',
+      'failed',
+      'Solver failed to find a solution'
+    )
+    warnSpy.mockRestore()
+  })
 })

--- a/frontend/src/hooks/session/useSolverOperations.ts
+++ b/frontend/src/hooks/session/useSolverOperations.ts
@@ -200,6 +200,10 @@ export function useSolverOperations({
           return { success: true, stats: resultStats }
         } else {
           const errorMessage = solverRun.error_message ?? 'Optimization failed'
+          // #1656 — a failed run is returned (not thrown) now that diagnostics
+          // ride the result; log a breadcrumb so an infeasible solve still leaves
+          // a trace in the console for debugging.
+          console.warn('Solver run did not complete:', solverRun.status, errorMessage)
           return { success: false, errorMessage, diagnostics: solverRun.diagnostics }
         }
       } catch (error) {

--- a/frontend/src/hooks/session/useSolverOperations.ts
+++ b/frontend/src/hooks/session/useSolverOperations.ts
@@ -12,7 +12,7 @@
 import { useState, useCallback } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'react-hot-toast'
-import { solverService } from '../../services/solver'
+import { solverService, type SolverDiagnostics, type StaffNbwYieldRaw } from '../../services/solver'
 import { graphCacheService } from '../../services/GraphCacheService'
 import { queryKeys } from '../../utils/queryKeys'
 import { invalidateAssignmentDerivedQueries } from '../../utils/queryInvalidation'
@@ -33,6 +33,7 @@ export interface SolverStats {
   request_validation?: {
     impossible_requests: number
     affected_campers: number
+    staff_nbw_yielded?: StaffNbwYieldRaw[]
   }
 }
 
@@ -40,6 +41,7 @@ export interface SolverRunResult {
   id: string
   status: 'completed' | 'failed' | 'pending' | 'running'
   error_message?: string
+  diagnostics?: SolverDiagnostics
   results?: {
     stats?: SolverStats
   }
@@ -65,6 +67,7 @@ export interface SolverRunResultWithStats {
   success: boolean
   stats?: SolverStats | undefined
   errorMessage?: string | undefined
+  diagnostics?: SolverDiagnostics | undefined
 }
 
 export interface UseSolverOperationsReturn {
@@ -197,7 +200,7 @@ export function useSolverOperations({
           return { success: true, stats: resultStats }
         } else {
           const errorMessage = solverRun.error_message ?? 'Optimization failed'
-          return { success: false, errorMessage }
+          return { success: false, errorMessage, diagnostics: solverRun.diagnostics }
         }
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'Failed to run optimizer'

--- a/frontend/src/services/solver.test.ts
+++ b/frontend/src/services/solver.test.ts
@@ -140,7 +140,7 @@ describe('pollSolverStatus diagnostics (#1638)', () => {
     const fetchWithAuth = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => failedBody,
-    } as Response)
+    })
 
     const run = await solverService.pollSolverStatus('run-1', fetchWithAuth, 60)
 

--- a/frontend/src/services/solver.test.ts
+++ b/frontend/src/services/solver.test.ts
@@ -121,3 +121,33 @@ describe('solverService.pollSolverStatus', () => {
     expect(fetchWithAuth).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('pollSolverStatus diagnostics (#1638)', () => {
+  it('returns a failed run carrying structured diagnostics instead of throwing', async () => {
+    const failedBody = {
+      status: 'failed',
+      session_id: '1000001',
+      error_message: 'Solver failed to find a solution',
+      infeasibility_cause: 'The parent_paramount constraint is causing infeasibility',
+      localization: {
+        approach: 'singleton',
+        candidate_count: 2,
+        campers: [{ cm_id: 1000001, name: 'Emma Johnson', grade: 5, gender: 'F' }],
+        notes: 'x',
+      },
+      impossibility_report: { total_impossible: 0, affected_campers: 0, flat: [] },
+    }
+    const fetchWithAuth = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => failedBody,
+    } as Response)
+
+    const run = await solverService.pollSolverStatus('run-1', fetchWithAuth, 60)
+
+    expect(run.status).toBe('failed')
+    expect(run.error_message).toBe('Solver failed to find a solution')
+    expect(run.diagnostics?.infeasibilityCause).toContain('parent_paramount')
+    expect(run.diagnostics?.localization?.campers[0]?.name).toBe('Emma Johnson')
+    expect(run.diagnostics?.impossibilityReport?.total_impossible).toBe(0)
+  })
+})

--- a/frontend/src/services/solver.ts
+++ b/frontend/src/services/solver.ts
@@ -84,6 +84,38 @@ export interface ImpossibilityReport {
   by_bucket_count?: Record<string, number>
 }
 
+export interface SolverLocalizationCamper {
+  cm_id: number
+  name: string
+  grade: number | null
+  gender: string | null
+}
+
+export interface SolverLocalization {
+  approach: string
+  candidate_count: number
+  campers: SolverLocalizationCamper[]
+  notes: string
+}
+
+export interface SolverDiagnostics {
+  infeasibilityCause: string | null
+  localization: SolverLocalization | null
+  impossibilityReport: ImpossibilityReport | null
+}
+
+/** Raw staff-separation yield as it rides in stats.request_validation (Stream A, #1541). cm_ids only. */
+export interface StaffNbwYieldRaw {
+  nbw_request_id: string
+  subject_cm: number
+  target_cm: number
+  protected_parent_request_id: string
+  protected_camper_cm: number
+}
+
+/** A SolverRun plus the optional failure diagnostics (#1638). */
+export type SolverRunWithDiagnostics = SolverRun & { diagnostics?: SolverDiagnostics }
+
 interface ValidationResult {
   valid: boolean
   errors: string[]
@@ -267,7 +299,7 @@ export const solverService = {
     fetchWithAuth: (url: string, options?: RequestInit) => Promise<Response>,
     timeLimit: number = 60,
     respectLocks: boolean = true
-  ): Promise<SolverRun> {
+  ): Promise<SolverRunWithDiagnostics> {
     try {
       // Call solver API directly
       const response = await fetchWithAuth(`${SOLVER_API_URL}/solver/run`, {
@@ -308,7 +340,7 @@ export const solverService = {
     solverRunId: string,
     fetchWithAuth: (url: string, options?: RequestInit) => Promise<Response>,
     timeLimitSeconds = 60
-  ): Promise<SolverRun> {
+  ): Promise<SolverRunWithDiagnostics> {
     const effectiveLimit = Math.max(1, Math.floor(timeLimitSeconds))
     const maxAttempts = effectiveLimit + POLL_BUFFER_SECONDS
     for (let i = 0; i < maxAttempts; i++) {
@@ -339,8 +371,21 @@ export const solverService = {
 
       if (runStatus.status === 'failed') {
         const errorMsg = runStatus.error_message ?? 'Solver failed'
-        console.error('Solver failed with error:', errorMsg)
-        throw new Error(errorMsg)
+        // #1638: return the failed run carrying structured diagnostics instead of
+        // throwing — the caller (useSolverOperations) handles non-completed status.
+        return {
+          id: solverRunId,
+          session: runStatus.session_id ?? '',
+          status: 'failed',
+          error_message: errorMsg,
+          diagnostics: {
+            infeasibilityCause: runStatus.infeasibility_cause ?? null,
+            localization: runStatus.localization ?? null,
+            impossibilityReport: runStatus.impossibility_report ?? null,
+          },
+          created: runStatus.created_at ?? new Date().toISOString(),
+          updated: runStatus.updated_at ?? new Date().toISOString(),
+        }
       }
 
       // Wait 1 second before next poll

--- a/frontend/src/utils/solverDiagnostics.test.ts
+++ b/frontend/src/utils/solverDiagnostics.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { resolveYields, hasReviewableDiagnostics } from './solverDiagnostics'
+import type { SolverDiagnostics, StaffNbwYieldRaw } from '../services/solver'
+
+describe('SessionView diagnostics helpers (#1638)', () => {
+  it('resolveYields maps cm_ids to names, falling back to the id', () => {
+    const nameById = new Map<number, string>([
+      [1000001, 'Emma Johnson'],
+      [1000002, 'Liam Garcia'],
+    ])
+    const raw: StaffNbwYieldRaw[] = [
+      {
+        nbw_request_id: 'n1',
+        subject_cm: 1000001,
+        target_cm: 1000002,
+        protected_parent_request_id: 'p1',
+        protected_camper_cm: 1000002,
+      },
+      {
+        nbw_request_id: 'n2',
+        subject_cm: 1000001,
+        target_cm: 999999,
+        protected_parent_request_id: 'p2',
+        protected_camper_cm: 999999,
+      },
+    ]
+    expect(resolveYields(raw, nameById)).toEqual([
+      {
+        subjectName: 'Emma Johnson',
+        targetName: 'Liam Garcia',
+        protectedCamperName: 'Liam Garcia',
+      },
+      { subjectName: 'Emma Johnson', targetName: '999999', protectedCamperName: '999999' },
+    ])
+  })
+
+  it('hasReviewableDiagnostics is true when any field has content', () => {
+    const empty: SolverDiagnostics = {
+      infeasibilityCause: null,
+      localization: null,
+      impossibilityReport: null,
+    }
+    expect(hasReviewableDiagnostics(undefined)).toBe(false)
+    expect(hasReviewableDiagnostics(empty)).toBe(false)
+    expect(hasReviewableDiagnostics({ ...empty, infeasibilityCause: 'x' })).toBe(true)
+  })
+})

--- a/frontend/src/utils/solverDiagnostics.ts
+++ b/frontend/src/utils/solverDiagnostics.ts
@@ -1,0 +1,26 @@
+import type { SolverDiagnostics, StaffNbwYieldRaw } from '../services/solver'
+import type { ResolvedStaffSeparationYield } from '../components/SolverProgressModal'
+
+/** #1638 — resolve raw staff-NBW yields (cm_ids) to display names via the session roster. */
+export function resolveYields(
+  raw: StaffNbwYieldRaw[] | undefined,
+  nameById: Map<number, string>
+): ResolvedStaffSeparationYield[] {
+  if (!raw) return []
+  const nameOf = (cm: number) => nameById.get(cm) ?? String(cm)
+  return raw.map((y) => ({
+    subjectName: nameOf(y.subject_cm),
+    targetName: nameOf(y.target_cm),
+    protectedCamperName: nameOf(y.protected_camper_cm),
+  }))
+}
+
+/** #1638 — does this diagnostics payload have anything worth opening the modal for? */
+export function hasReviewableDiagnostics(d: SolverDiagnostics | undefined): boolean {
+  if (!d) return false
+  return (
+    Boolean(d.infeasibilityCause) ||
+    (d.localization?.campers.length ?? 0) > 0 ||
+    (d.impossibilityReport?.flat.length ?? 0) > 0
+  )
+}

--- a/tests/unit/api/routers/test_get_solver_run.py
+++ b/tests/unit/api/routers/test_get_solver_run.py
@@ -1,5 +1,6 @@
 """GET /solver/run/{id} surfaces Stream B diagnostics from the in-memory run dict (#1638)."""
 
+from typing import Any
 from unittest.mock import patch
 
 from fastapi import FastAPI
@@ -29,7 +30,7 @@ def _client() -> TestClient:
 
 def test_get_solver_run_includes_diagnostics_when_present() -> None:
     run_id = "run-x1"
-    run = {
+    run: dict[str, Any] = {
         "id": run_id,
         "status": "failed",
         "results": None,
@@ -54,7 +55,7 @@ def test_get_solver_run_includes_diagnostics_when_present() -> None:
 
 def test_get_solver_run_diagnostics_default_none() -> None:
     run_id = "run-x2"
-    run = {"id": run_id, "status": "completed", "results": {"stats": {}}, "error_message": None}
+    run: dict[str, Any] = {"id": run_id, "status": "completed", "results": {"stats": {}}, "error_message": None}
     with patch.dict("api.routers.solver.solver_runs", {run_id: run}, clear=False):
         resp = _client().get(f"/api/solver/run/{run_id}")
     body = resp.json()

--- a/tests/unit/api/routers/test_get_solver_run.py
+++ b/tests/unit/api/routers/test_get_solver_run.py
@@ -62,3 +62,28 @@ def test_get_solver_run_diagnostics_default_none() -> None:
     assert body["infeasibility_cause"] is None
     assert body["localization"] is None
     assert body["impossibility_report"] is None
+
+
+def test_get_solver_run_pb_fallback_includes_diagnostics_keys() -> None:
+    """The PocketBase-fetch fallback returns the same diagnostics keys (as None)
+    as the in-memory path, so the response shape is uniform across storage paths (#1656)."""
+    run_id = "run-pb-1"
+
+    class _PbRun:
+        id = run_id
+        status = "completed"
+        results = '{"stats": {}}'
+        error_message = None
+
+    # Empty solver_runs forces the run_id-not-found PocketBase fallback branch.
+    with (
+        patch.dict("api.routers.solver.solver_runs", {}, clear=True),
+        patch("api.routers.solver.pb") as mock_pb,
+    ):
+        mock_pb.collection.return_value.get_one.return_value = _PbRun()
+        resp = _client().get(f"/api/solver/run/{run_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["infeasibility_cause"] is None
+    assert body["localization"] is None
+    assert body["impossibility_report"] is None

--- a/tests/unit/api/routers/test_get_solver_run.py
+++ b/tests/unit/api/routers/test_get_solver_run.py
@@ -1,0 +1,63 @@
+"""GET /solver/run/{id} surfaces Stream B diagnostics from the in-memory run dict (#1638)."""
+
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from bunking.auth_middleware import AuthUser, get_current_user
+
+
+def _admin_user() -> AuthUser:
+    return AuthUser(
+        username="TestAdmin",
+        email="test@example.com",
+        display_name="Test Admin",
+        groups=["admin"],
+        is_admin=True,
+    )
+
+
+def _client() -> TestClient:
+    from api.routers import solver
+
+    app = FastAPI()
+    app.include_router(solver.router)
+    app.dependency_overrides[get_current_user] = _admin_user
+    return TestClient(app)
+
+
+def test_get_solver_run_includes_diagnostics_when_present() -> None:
+    run_id = "run-x1"
+    run = {
+        "id": run_id,
+        "status": "failed",
+        "results": None,
+        "error_message": "Solver failed to find a solution",
+        "infeasibility_cause": "The parent_paramount constraint is causing infeasibility",
+        "localization": {
+            "approach": "singleton",
+            "candidate_count": 2,
+            "campers": [{"cm_id": 1000001, "name": "Emma Johnson", "grade": 5, "gender": "F"}],
+            "notes": "x",
+        },
+        "impossibility_report": {"total_impossible": 0, "affected_campers": 0, "flat": []},
+    }
+    with patch.dict("api.routers.solver.solver_runs", {run_id: run}, clear=False):
+        resp = _client().get(f"/api/solver/run/{run_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["infeasibility_cause"] == run["infeasibility_cause"]
+    assert body["localization"]["campers"][0]["name"] == "Emma Johnson"
+    assert body["impossibility_report"]["total_impossible"] == 0
+
+
+def test_get_solver_run_diagnostics_default_none() -> None:
+    run_id = "run-x2"
+    run = {"id": run_id, "status": "completed", "results": {"stats": {}}, "error_message": None}
+    with patch.dict("api.routers.solver.solver_runs", {run_id: run}, clear=False):
+        resp = _client().get(f"/api/solver/run/{run_id}")
+    body = resp.json()
+    assert body["infeasibility_cause"] is None
+    assert body["localization"] is None
+    assert body["impossibility_report"] is None

--- a/tests/unit/api/test_solver_runner_diagnostics.py
+++ b/tests/unit/api/test_solver_runner_diagnostics.py
@@ -1,0 +1,55 @@
+"""run_solver_task_v2 surfaces diagnostics on the result-is-None failure path (#1638)."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import api.services.solver_runner as sr_module
+from bunking.solver.impossibility import ImpossibilityReport
+
+
+def test_failure_branch_stores_localization_and_impossibility_report() -> None:
+    run_id = "run-diag-1"
+    mock_runs = {run_id: {"id": run_id, "status": "pending", "config": {}}}
+
+    mock_solver = MagicMock()
+    mock_solver.solve.return_value = None  # force the result-is-None failure branch
+    mock_solver.find_infeasibility_cause.return_value = "The parent_paramount constraint is causing infeasibility"
+    mock_solver.impossibility_report = ImpossibilityReport()  # empty, real dataclass → asdict works
+
+    mock_solver_input = MagicMock()
+    mock_solver_input.persons = []
+    mock_solver_input.existing_assignments = []
+    mock_solver_input.lock_groups_data = {}
+    mock_solver_input.person_by_cm_id = {}
+
+    fake_iis = {
+        "approach": "singleton",
+        "candidate_count": 0,
+        "singleton_critical_cms": [],
+        "minimal_correction_set": [],
+        "notes": "n/a",
+    }
+
+    with (
+        patch.object(sr_module, "fetch_session_data_v2", new_callable=AsyncMock) as m_fetch,
+        patch.object(sr_module, "fetch_historical_bunking", new_callable=AsyncMock) as m_hist,
+        patch.object(sr_module, "prepare_direct_solver_input", return_value=mock_solver_input),
+        patch.object(sr_module, "ConfigLoader") as m_config,
+        patch.object(sr_module, "DirectBunkingSolver", return_value=mock_solver),
+        patch.object(sr_module, "PocketBase") as m_pb,
+        patch.object(sr_module, "get_settings"),
+        patch.object(sr_module, "localize_hard_mso_infeasibility", return_value=fake_iis),
+        patch.object(sr_module, "solver_runs", mock_runs),
+    ):
+        m_fetch.return_value = ([], [], [], [], [])
+        m_hist.return_value = []
+        m_config.get_instance.return_value = MagicMock()
+        m_pb.return_value.collection.return_value.auth_with_password.return_value = {}
+
+        asyncio.run(sr_module.run_solver_task_v2(run_id, 1000001, 2026, 5))
+
+    assert mock_runs[run_id]["status"] == "failed"
+    assert "parent_paramount" in mock_runs[run_id]["infeasibility_cause"]
+    assert mock_runs[run_id]["localization"]["campers"] == []
+    assert mock_runs[run_id]["impossibility_report"]["total_impossible"] == 0
+    assert "by_reason" in mock_runs[run_id]["impossibility_report"]

--- a/tests/unit/api/test_solver_runner_diagnostics.py
+++ b/tests/unit/api/test_solver_runner_diagnostics.py
@@ -1,6 +1,7 @@
 """run_solver_task_v2 surfaces diagnostics on the result-is-None failure path (#1638)."""
 
 import asyncio
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import api.services.solver_runner as sr_module
@@ -9,7 +10,7 @@ from bunking.solver.impossibility import ImpossibilityReport
 
 def test_failure_branch_stores_localization_and_impossibility_report() -> None:
     run_id = "run-diag-1"
-    mock_runs = {run_id: {"id": run_id, "status": "pending", "config": {}}}
+    mock_runs: dict[str, dict[str, Any]] = {run_id: {"id": run_id, "status": "pending", "config": {}}}
 
     mock_solver = MagicMock()
     mock_solver.solve.return_value = None  # force the result-is-None failure branch

--- a/tests/unit/solver/test_diagnostics.py
+++ b/tests/unit/solver/test_diagnostics.py
@@ -1,0 +1,61 @@
+"""Unit tests for solver diagnostics name-resolution (Stream B, #1638)."""
+
+from dataclasses import dataclass
+
+from bunking.solver.diagnostics import resolve_localization
+
+
+@dataclass
+class _FakePerson:
+    first_name: str
+    last_name: str
+    grade: int
+    gender: str
+
+
+def test_resolve_localization_uses_minimal_correction_set_with_names() -> None:
+    people = {
+        1000001: _FakePerson("Emma", "Johnson", 5, "F"),
+        1000002: _FakePerson("Liam", "Garcia", 6, "M"),
+    }
+    iis = {
+        "approach": "singleton",
+        "candidate_count": 2,
+        "singleton_critical_cms": [1000001],
+        "minimal_correction_set": [1000001, 1000002],
+        "notes": "Removing these restores feasibility.",
+    }
+    result = resolve_localization(iis, people)  # type: ignore[arg-type]
+    assert result["approach"] == "singleton"
+    assert result["candidate_count"] == 2
+    assert result["notes"] == "Removing these restores feasibility."
+    assert result["campers"] == [
+        {"cm_id": 1000001, "name": "Emma Johnson", "grade": 5, "gender": "F"},
+        {"cm_id": 1000002, "name": "Liam Garcia", "grade": 6, "gender": "M"},
+    ]
+
+
+def test_resolve_localization_falls_back_to_singleton_when_no_mcs() -> None:
+    people = {1000001: _FakePerson("Emma", "Johnson", 5, "F")}
+    iis = {
+        "approach": "singleton",
+        "candidate_count": 1,
+        "singleton_critical_cms": [1000001],
+        "minimal_correction_set": [],
+        "notes": "",
+    }
+    result = resolve_localization(iis, people)  # type: ignore[arg-type]
+    assert [c["cm_id"] for c in result["campers"]] == [1000001]
+
+
+def test_resolve_localization_unknown_cm_id_uses_id_as_name() -> None:
+    result = resolve_localization(
+        {"minimal_correction_set": [999], "approach": "x", "candidate_count": 1, "notes": ""},
+        {},
+    )
+    assert result["campers"] == [{"cm_id": 999, "name": "999", "grade": None, "gender": None}]
+
+
+def test_resolve_localization_empty_iis() -> None:
+    result = resolve_localization({}, {})
+    assert result == {"approach": "", "candidate_count": 0, "campers": [], "notes": ""}


### PR DESCRIPTION
Closes #1638 (Stream B of the staff-hard-NBW effort). Renders Stream A's (#1541) yield output but is independently valuable — the failure UX was poor for *all* infeasibility causes.

## Problem

On a failed solve, staff got a one-line generic string (`"Solver failed to find a solution"`) in a transient red box that vanished. The backend already computes *which constraint broke the solve* (`find_infeasibility_cause`), *which campers conflict* (the parent-paramount localizer), and holds the solver's `impossibility_report` — but discarded all of it before the browser.

## What this does

Plumbs the **already-computed** diagnostics through the run API (no re-analysis, no recompute) and renders three semantically distinct surfaces:

| Section | When | Where |
|---|---|---|
| 🔴 **Why the solve failed** — cause verdict + name-resolved offending campers | infeasible solve | new persistent `SolverDiagnosticsModal` |
| ⚪ **Requests that can never be satisfied** — full impossibility table | infeasible solve | same modal |
| 🟡 **Staff separations overridden** — e.g. "Emma Johnson ↔ Liam Garcia — placed together to protect Liam's only honorable parent request" | successful solve | inline advisory in the existing success modal |

The failure modal is **non-auto-dismissing** (stays until explicitly closed), replacing the transient red box. Generic failures with no diagnostics still fall back to the old inline error.

## Plumbing (backend)

- `bunking/solver/diagnostics.py` — `resolve_localization()` turns the localizer's cm_ids into name-resolved camper dicts (the localizer returns cm_ids only; the impossibility report already carries names).
- `solver_runner.py` — on the `result is None` branch, stores name-resolved `localization` + the immaterial-filtered `impossibility_report` into the in-memory run dict (the solver already holds the report).
- `GET /solver/run/{id}` — surfaces `infeasibility_cause`, `localization`, `impossibility_report`. **No PB migration** — in-memory only; the PB-fetch fallback returns them as null.
- `solver.ts::pollSolverStatus` — returns a failed run carrying `diagnostics` instead of throwing (its sole caller already handles non-completed status).

## Stream A relationship

The 🟡 yield advisory renders **defensively** — it reads `results.stats.request_validation.staff_nbw_yielded` and is omitted when absent, so it works today on `main` and "lights up" automatically once #1541 merges. No dependency on that branch.

## Deliberately out of scope

- No dedicated `/solver-results` route or durable PB persistence (diagnostics are run_id-keyed in-memory; a route is a small follow-up).
- Success-path impossibility stays counts-only (the existing "open Pre-Check" box); the full table appears on failure.
- No re-call of the pre-validate endpoint (diagnostics are plumbed, not recomputed).
- Post-check consolidation (it discards a full impossibility report too) — noted for a possible follow-up, not pulled in.

## Testing (TDD)

- Backend: `resolve_localization` (4), solver-runner failure-branch stores diagnostics (1), `GET /solver/run/{id}` surfaces them / defaults null (2).
- Frontend (Vitest): service captures diagnostics on failure; hook threads them; `SolverDiagnosticsModal` renders all sections + does-not-auto-dismiss; success-modal yield advisory renders/omits defensively; yield name resolution with cm_id fallback.
- Full local gate green: mypy (710 files), full mockable pytest (5293), ruff, tsc, eslint (0 errors), vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Solver run responses now include reviewable diagnostics (infeasibility cause, localization, impossibility report) for in-memory runs and return the same diagnostics keys (null when absent) from the fallback path.
  * New diagnostics modal showing why a solve failed, localized camper details, and a table of impossible requests.
  * Staff-separation yield warnings now show resolved names when present.
  * Utilities to resolve yields/localization for UI display.

* **Tests**
  * Expanded coverage for diagnostics generation, persistence, polling, and UI display across API and frontend.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->