### PR TITLE
feat(api): reconcile unguaranteeable age-preference cohort on post-check (honored_in_plan)

### DIFF
--- a/api/routers/validation.py
+++ b/api/routers/validation.py
@@ -396,6 +396,7 @@ async def validate_bunking(
         # (V1 above + V2 here) is acceptable overhead for now; a longer-term
         # consolidation would route validation through the same V2 data path.
         impossible_request_ids: set[str] = set()
+        impossible_mp_cohort: list[dict[str, Any]] = []
         try:
             v2_attendees, v2_bunks, v2_requests, v2_assignments, v2_bunk_plans = await fetch_session_data_v2(
                 request.session_cm_id, ctx.year, pb, scenario=request.scenario
@@ -405,6 +406,7 @@ async def validate_bunking(
             )
             impossibility_report = validate_impossibility(solver_input, ConfigLoader.get_instance())
             impossible_request_ids = {item.request_id for item in impossibility_report.flat}
+            impossible_mp_cohort = impossibility_report.mp_campers_entirely_impossible
         except Exception as e:
             # Impossibility computation is metric-gating only — if it fails, log
             # and fall through with ungated metrics so the validator still returns
@@ -427,6 +429,7 @@ async def validate_bunking(
             attendees=attendees_for_validator,
             historical_bunking=historical_bunking or None,
             impossible_request_ids=impossible_request_ids or None,
+            impossible_mp_cohort=impossible_mp_cohort or None,
         )
 
         return validation_result.model_dump()

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -953,9 +953,19 @@ class BunkingValidator:
                 satisfied_mp_requesters.add(int(pid))
             except TypeError, ValueError:
                 continue
+        bunks_map = bunk_by_id or {}
         for entry in impossible_mp_cohort or []:
-            honored = entry.get("cm_id") in satisfied_mp_requesters
-            stats.mp_campers_entirely_impossible.append({**entry, "honored_in_plan": honored})
+            entry_cm_id = entry.get("cm_id")
+            honored = entry_cm_id in satisfied_mp_requesters
+            # When honored, name the cabin that met the preference. assignments_by_person
+            # is keyed by str person_cm_id; the cohort cm_id is an int — normalize.
+            # Mirrors the not-bunk-with violation detail's bunk_name so the post-check reads alike.
+            bunk_name: str | None = None
+            if honored:
+                honored_asgn = assignments_by_person.get(str(entry_cm_id))
+                honored_bunk = bunks_map.get(honored_asgn.bunk_cm_id) if honored_asgn else None
+                bunk_name = honored_bunk.name if honored_bunk else None
+            stats.mp_campers_entirely_impossible.append({**entry, "honored_in_plan": honored, "bunk_name": bunk_name})
 
         # Best-effort parent (socialize_with source_field) stats.
         stats.best_effort_parent_requests = sum(len(reqs) for reqs in best_effort_parent_by_person.values())

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -221,6 +221,15 @@ class ValidationStatistics(BaseModel):
     mp_campers_with_at_least_one_satisfied: int = 0
     mp_campers_with_all_satisfied: int = 0
 
+    # Entirely-impossible MP cohort (the families-to-contact list), reconciled
+    # against the final plan. Each entry mirrors impossibility_report's
+    # mp_campers_entirely_impossible {cm_id, name, grade, gender, session_cm_id,
+    # reason_codes} PLUS honored_in_plan: did the final assignment satisfy any of
+    # their (flagged) MP requests anyway? Empty unless impossible_mp_cohort is
+    # passed in. These campers are excluded from mp_campers_total (gated), so the
+    # post-check renders the full MP camper count as mp_campers_total + len(this list).
+    mp_campers_entirely_impossible: list[dict[str, Any]] = Field(default_factory=list)
+
     # Per-gender bunk capacity and assigned-camper counts.
     # Splits bunks and assignments by bunk.gender (F/M) so the post-check
     # modal and PDF can render capacity-vs-assigned per gender.
@@ -264,6 +273,7 @@ class BunkingValidator:
         attendees: list[Any] | None = None,
         historical_bunking: list[HistoricalBunkingRecord] | None = None,
         impossible_request_ids: set[str] | None = None,
+        impossible_mp_cohort: list[dict[str, Any]] | None = None,
     ) -> ValidationResult:
         """
         Perform comprehensive validation of bunking assignments.
@@ -324,6 +334,7 @@ class BunkingValidator:
             issues,
             bunk_by_id=bunk_by_id,
             impossible_request_ids=impossible_request_ids,
+            impossible_mp_cohort=impossible_mp_cohort,
         )
 
         # Validate age/grade spreads
@@ -451,6 +462,7 @@ class BunkingValidator:
         issues: list[ValidationIssue],
         bunk_by_id: dict[str, Bunk] | None = None,
         impossible_request_ids: set[str] | None = None,
+        impossible_mp_cohort: list[dict[str, Any]] | None = None,
     ) -> None:
         """Validate request satisfaction - tracking by source field.
 
@@ -923,6 +935,27 @@ class BunkingValidator:
             for pid, reqs in material_parent_by_person.items()
             if _gated(reqs) and len(_gated(satisfied_material_parent_by_person.get(pid, []))) == len(_gated(reqs))
         )
+
+        # Reconcile the entirely-impossible MP cohort (the families-to-contact
+        # list) against the final plan. An age preference at the extreme grade
+        # (oldest "older" / youngest "younger") is flagged impossible — kept out
+        # of MSO so it never distorts cabin shape — yet the final assignment may
+        # satisfy it anyway when the camper lands in a single-grade cabin.
+        # honored_in_plan lets the post-check show "flagged but met anyway"
+        # instead of the contradiction. A camper is honored iff ANY of their MP
+        # requests is satisfied in the final plan (satisfied_material_parent_by_person
+        # is populated ungated above), so cross-gender / cross-session rows stay False.
+        # cohort cm_id is an int; satisfied_material_parent_by_person keys are the
+        # raw requester ids (str), so normalize to int before membership-testing.
+        satisfied_mp_requesters: set[int] = set()
+        for pid in satisfied_material_parent_by_person:
+            try:
+                satisfied_mp_requesters.add(int(pid))
+            except TypeError, ValueError:
+                continue
+        for entry in impossible_mp_cohort or []:
+            honored = entry.get("cm_id") in satisfied_mp_requesters
+            stats.mp_campers_entirely_impossible.append({**entry, "honored_in_plan": honored})
 
         # Best-effort parent (socialize_with source_field) stats.
         stats.best_effort_parent_requests = sum(len(reqs) for reqs in best_effort_parent_by_person.values())

--- a/frontend/src/components/PdfExport/familyRows.test.ts
+++ b/frontend/src/components/PdfExport/familyRows.test.ts
@@ -184,3 +184,66 @@ describe('buildFamilyRows — Group 65 #1540', () => {
     expect(rows[1]!.name).toBe('Has Grade')
   })
 })
+
+describe('buildFamilyRows — honored reconciliation', () => {
+  it('sources got_nothing from statistics cohort and marks honored sub-rows', () => {
+    const stats = _statistics({
+      mp_campers_entirely_impossible: [
+        {
+          cm_id: 21012687,
+          name: 'Nathan Vaisman',
+          grade: 10,
+          gender: 'M',
+          session_cm_id: 1235404,
+          reason_codes: ['age_pref_no_eligible_grade'],
+          honored_in_plan: true,
+        },
+      ],
+    })
+    // Pre-check report intentionally empty: statistics is authoritative.
+    const rows = buildFamilyRows(stats, _report())
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.cohort).toBe('got_nothing')
+    expect(rows[0]!.subRows[0]!.honoredInPlan).toBe(true)
+    expect(rows[0]!.subRows[0]!.detail).toBe('Flagged impossible · met by the final cabin anyway')
+  })
+
+  it('keeps the impossible detail when honored_in_plan is false', () => {
+    const stats = _statistics({
+      mp_campers_entirely_impossible: [
+        {
+          cm_id: 17411971,
+          name: 'Madelyn Kellner',
+          grade: 5,
+          gender: 'F',
+          session_cm_id: 1235404,
+          reason_codes: ['age_pref_no_eligible_grade'],
+          honored_in_plan: false,
+        },
+      ],
+    })
+    const rows = buildFamilyRows(stats, _report())
+    expect(rows[0]!.subRows[0]!.honoredInPlan).toBe(false)
+    expect(rows[0]!.subRows[0]!.detail).toContain('All requests impossible')
+  })
+
+  it('falls back to the pre-check report when statistics cohort is absent', () => {
+    const stats = _statistics() // no mp_campers_entirely_impossible
+    const report = _report({
+      mp_campers_entirely_impossible: [
+        {
+          cm_id: 19354792,
+          name: 'Asher King',
+          grade: 5,
+          gender: 'M',
+          session_cm_id: 1235404,
+          reason_codes: ['age_pref_no_eligible_grade'],
+        },
+      ],
+    })
+    const rows = buildFamilyRows(stats, report)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.name).toBe('Asher King')
+    expect(rows[0]!.subRows[0]!.honoredInPlan).toBeUndefined()
+  })
+})

--- a/frontend/src/components/PdfExport/familyRows.test.ts
+++ b/frontend/src/components/PdfExport/familyRows.test.ts
@@ -190,11 +190,11 @@ describe('buildFamilyRows — honored reconciliation', () => {
     const stats = _statistics({
       mp_campers_entirely_impossible: [
         {
-          cm_id: 21012687,
+          cm_id: 1000001,
           name: 'Samuel Johnson',
           grade: 10,
           gender: 'M',
-          session_cm_id: 1235404,
+          session_cm_id: 1000001,
           reason_codes: ['age_pref_no_eligible_grade'],
           honored_in_plan: true,
           bunk_name: 'Redwood 4',
@@ -214,11 +214,11 @@ describe('buildFamilyRows — honored reconciliation', () => {
     const stats = _statistics({
       mp_campers_entirely_impossible: [
         {
-          cm_id: 17411971,
+          cm_id: 1000002,
           name: 'Olivia Chen',
           grade: 5,
           gender: 'F',
-          session_cm_id: 1235404,
+          session_cm_id: 1000001,
           reason_codes: ['age_pref_no_eligible_grade'],
           honored_in_plan: false,
         },
@@ -234,11 +234,11 @@ describe('buildFamilyRows — honored reconciliation', () => {
     const report = _report({
       mp_campers_entirely_impossible: [
         {
-          cm_id: 19354792,
+          cm_id: 1000003,
           name: 'Liam Garcia',
           grade: 5,
           gender: 'M',
-          session_cm_id: 1235404,
+          session_cm_id: 1000001,
           reason_codes: ['age_pref_no_eligible_grade'],
         },
       ],
@@ -247,5 +247,25 @@ describe('buildFamilyRows — honored reconciliation', () => {
     expect(rows).toHaveLength(1)
     expect(rows[0]!.name).toBe('Liam Garcia')
     expect(rows[0]!.subRows[0]!.honoredInPlan).toBeUndefined()
+  })
+
+  it('treats an explicit empty stats cohort as authoritative (no fallback to pre-check)', () => {
+    // Post-check ran and found zero entirely-impossible campers; a stale
+    // pre-check report must NOT resurface got_nothing rows.
+    const stats = _statistics({ mp_campers_entirely_impossible: [] })
+    const report = _report({
+      mp_campers_entirely_impossible: [
+        {
+          cm_id: 1000001,
+          name: 'Emma Johnson',
+          grade: 5,
+          gender: 'F',
+          session_cm_id: 1000001,
+          reason_codes: ['age_pref_no_eligible_grade'],
+        },
+      ],
+    })
+    const rows = buildFamilyRows(stats, report)
+    expect(rows.filter((r) => r.cohort === 'got_nothing')).toHaveLength(0)
   })
 })

--- a/frontend/src/components/PdfExport/familyRows.test.ts
+++ b/frontend/src/components/PdfExport/familyRows.test.ts
@@ -191,12 +191,13 @@ describe('buildFamilyRows — honored reconciliation', () => {
       mp_campers_entirely_impossible: [
         {
           cm_id: 21012687,
-          name: 'Nathan Vaisman',
+          name: 'Samuel Johnson',
           grade: 10,
           gender: 'M',
           session_cm_id: 1235404,
           reason_codes: ['age_pref_no_eligible_grade'],
           honored_in_plan: true,
+          bunk_name: 'Redwood 4',
         },
       ],
     })
@@ -205,7 +206,8 @@ describe('buildFamilyRows — honored reconciliation', () => {
     expect(rows).toHaveLength(1)
     expect(rows[0]!.cohort).toBe('got_nothing')
     expect(rows[0]!.subRows[0]!.honoredInPlan).toBe(true)
-    expect(rows[0]!.subRows[0]!.detail).toBe('Flagged impossible · met by the final cabin anyway')
+    expect(rows[0]!.subRows[0]!.bunkName).toBe('Redwood 4')
+    expect(rows[0]!.subRows[0]!.detail).toBe('Met by same age cabin Redwood 4')
   })
 
   it('keeps the impossible detail when honored_in_plan is false', () => {
@@ -213,7 +215,7 @@ describe('buildFamilyRows — honored reconciliation', () => {
       mp_campers_entirely_impossible: [
         {
           cm_id: 17411971,
-          name: 'Madelyn Kellner',
+          name: 'Olivia Chen',
           grade: 5,
           gender: 'F',
           session_cm_id: 1235404,
@@ -233,7 +235,7 @@ describe('buildFamilyRows — honored reconciliation', () => {
       mp_campers_entirely_impossible: [
         {
           cm_id: 19354792,
-          name: 'Asher King',
+          name: 'Liam Garcia',
           grade: 5,
           gender: 'M',
           session_cm_id: 1235404,
@@ -243,7 +245,7 @@ describe('buildFamilyRows — honored reconciliation', () => {
     })
     const rows = buildFamilyRows(stats, report)
     expect(rows).toHaveLength(1)
-    expect(rows[0]!.name).toBe('Asher King')
+    expect(rows[0]!.name).toBe('Liam Garcia')
     expect(rows[0]!.subRows[0]!.honoredInPlan).toBeUndefined()
   })
 })

--- a/frontend/src/components/PdfExport/familyRows.ts
+++ b/frontend/src/components/PdfExport/familyRows.ts
@@ -50,10 +50,12 @@ export function buildFamilyRows(
   const raw: RawRow[] = []
 
   // Prefer the post-response cohort (carries honored_in_plan, reconciled against
-  // the final plan); fall back to the pre-check report for callers without it
-  // (e.g. PDF export from a pre-check, or post-check before this field shipped).
+  // the final plan); fall back to the pre-check report only when the field is
+  // absent entirely (e.g. PDF export from a pre-check, or post-check before this
+  // field shipped). An explicit empty array is authoritative — "zero impossible
+  // campers" — and must NOT resurface stale pre-check rows.
   const statsCohort = statistics.mp_campers_entirely_impossible
-  if (statsCohort && statsCohort.length > 0) {
+  if (statsCohort !== undefined) {
     for (const c of statsCohort) {
       raw.push({
         cm_id: String(c.cm_id),

--- a/frontend/src/components/PdfExport/familyRows.ts
+++ b/frontend/src/components/PdfExport/familyRows.ts
@@ -63,10 +63,11 @@ export function buildFamilyRows(
         cohort: 'got_nothing',
         session: String(c.session_cm_id),
         detail: c.honored_in_plan
-          ? 'Flagged impossible · met by the final cabin anyway'
+          ? `Met by same age cabin${c.bunk_name ? ` ${c.bunk_name}` : ''}`
           : `All requests impossible · ${c.reason_codes.map(friendlyReasonLabel).join(', ')}`,
         reasonCodes: c.reason_codes,
         honoredInPlan: c.honored_in_plan,
+        ...(c.bunk_name ? { bunkName: c.bunk_name } : {}),
       })
     }
   } else {

--- a/frontend/src/components/PdfExport/familyRows.ts
+++ b/frontend/src/components/PdfExport/familyRows.ts
@@ -13,6 +13,7 @@ export type FamilySubRow = {
   bunkName?: string
   rawText?: string
   reasonCodes?: string[]
+  honoredInPlan?: boolean
 }
 
 export type FamilyRowData = {
@@ -44,20 +45,43 @@ export function buildFamilyRows(
     bunkName?: string
     rawText?: string
     reasonCodes?: string[]
+    honoredInPlan?: boolean
   }
   const raw: RawRow[] = []
 
-  for (const c of impossibilityReport.mp_campers_entirely_impossible ?? []) {
-    raw.push({
-      cm_id: String(c.cm_id),
-      name: c.name,
-      grade: c.grade ?? 0,
-      gender: c.gender ?? '',
-      cohort: 'got_nothing',
-      session: String(c.session_cm_id), // normalize number → string
-      detail: `All requests impossible · ${c.reason_codes.map(friendlyReasonLabel).join(', ')}`,
-      reasonCodes: c.reason_codes,
-    })
+  // Prefer the post-response cohort (carries honored_in_plan, reconciled against
+  // the final plan); fall back to the pre-check report for callers without it
+  // (e.g. PDF export from a pre-check, or post-check before this field shipped).
+  const statsCohort = statistics.mp_campers_entirely_impossible
+  if (statsCohort && statsCohort.length > 0) {
+    for (const c of statsCohort) {
+      raw.push({
+        cm_id: String(c.cm_id),
+        name: c.name,
+        grade: c.grade ?? 0,
+        gender: c.gender ?? '',
+        cohort: 'got_nothing',
+        session: String(c.session_cm_id),
+        detail: c.honored_in_plan
+          ? 'Flagged impossible · met by the final cabin anyway'
+          : `All requests impossible · ${c.reason_codes.map(friendlyReasonLabel).join(', ')}`,
+        reasonCodes: c.reason_codes,
+        honoredInPlan: c.honored_in_plan,
+      })
+    }
+  } else {
+    for (const c of impossibilityReport.mp_campers_entirely_impossible ?? []) {
+      raw.push({
+        cm_id: String(c.cm_id),
+        name: c.name,
+        grade: c.grade ?? 0,
+        gender: c.gender ?? '',
+        cohort: 'got_nothing',
+        session: String(c.session_cm_id), // normalize number → string
+        detail: `All requests impossible · ${c.reason_codes.map(friendlyReasonLabel).join(', ')}`,
+        reasonCodes: c.reason_codes,
+      })
+    }
   }
   for (const v of statistics.negative_request_violations_detail ?? []) {
     raw.push({
@@ -97,6 +121,7 @@ export function buildFamilyRows(
       ...(r.bunkName !== undefined && { bunkName: r.bunkName }),
       ...(r.rawText !== undefined && { rawText: r.rawText }),
       ...(r.reasonCodes !== undefined && { reasonCodes: r.reasonCodes }),
+      ...(r.honoredInPlan !== undefined && { honoredInPlan: r.honoredInPlan }),
     }
     const existing = grouped.get(key)
     if (existing) {

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -1941,11 +1941,11 @@ describe('PostValidationResultsModal — honored subtext (Task 5)', () => {
         results={makeResults({
           mp_campers_entirely_impossible: [
             {
-              cm_id: 21012687,
+              cm_id: 1000001,
               name: 'Samuel Johnson',
               grade: 10,
               gender: 'M',
-              session_cm_id: 1235404,
+              session_cm_id: 1000001,
               reason_codes: ['age_pref_no_eligible_grade'],
               honored_in_plan: true,
               bunk_name: 'Redwood 4',

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -1928,10 +1928,10 @@ describe('PostValidationResultsModal — camper coverage tiles (#1631)', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Task 5 — honored-anyway subtext + reconciliation line
+// Task 5 — honored-anyway subtext
 // ---------------------------------------------------------------------------
 
-describe('PostValidationResultsModal — honored subtext and reconciliation line (Task 5)', () => {
+describe('PostValidationResultsModal — honored subtext (Task 5)', () => {
   it('renders "met by the final cabin anyway" subtext for honored camper instead of "All requests impossible"', () => {
     render(
       <PostValidationResultsModal
@@ -1942,64 +1942,20 @@ describe('PostValidationResultsModal — honored subtext and reconciliation line
           mp_campers_entirely_impossible: [
             {
               cm_id: 21012687,
-              name: 'Nathan Vaisman',
+              name: 'Samuel Johnson',
               grade: 10,
               gender: 'M',
               session_cm_id: 1235404,
               reason_codes: ['age_pref_no_eligible_grade'],
               honored_in_plan: true,
+              bunk_name: 'Redwood 4',
             },
           ],
         })}
       />
     )
-    expect(screen.getByText(/met by the final cabin anyway/i)).toBeInTheDocument()
+    expect(screen.getByText(/met by same age cabin/i)).toBeInTheDocument()
+    expect(screen.getByText('Redwood 4')).toBeInTheDocument()
     expect(screen.queryByText(/All requests impossible/i)).not.toBeInTheDocument()
-  })
-
-  it('renders coverage-reconciliation line showing guaranteeable + unguaranteeable = total', () => {
-    render(
-      <PostValidationResultsModal
-        sessionCmId={1000001}
-        isOpen={true}
-        onClose={() => {}}
-        results={makeResults({
-          mp_campers_total: 165,
-          mp_campers_entirely_impossible: [
-            {
-              cm_id: 1,
-              name: 'Emma Johnson',
-              grade: 5,
-              gender: 'F',
-              session_cm_id: 1000001,
-              reason_codes: ['age_pref_no_eligible_grade'],
-              honored_in_plan: false,
-            },
-            {
-              cm_id: 2,
-              name: 'Liam Garcia',
-              grade: 6,
-              gender: 'M',
-              session_cm_id: 1000001,
-              reason_codes: ['pair_no_shared_bunk'],
-              honored_in_plan: false,
-            },
-            {
-              cm_id: 3,
-              name: 'Olivia Chen',
-              grade: 7,
-              gender: 'F',
-              session_cm_id: 1000001,
-              reason_codes: ['grade_compatibility'],
-              honored_in_plan: true,
-            },
-          ],
-        })}
-      />
-    )
-    const recon = screen.getByTestId('coverage-reconciliation')
-    expect(recon).toHaveTextContent('165')
-    expect(recon).toHaveTextContent('3')
-    expect(recon).toHaveTextContent('168')
   })
 })

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -1926,3 +1926,80 @@ describe('PostValidationResultsModal — camper coverage tiles (#1631)', () => {
     expect(zeroDivZero.length).toBeGreaterThanOrEqual(2)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Task 5 — honored-anyway subtext + reconciliation line
+// ---------------------------------------------------------------------------
+
+describe('PostValidationResultsModal — honored subtext and reconciliation line (Task 5)', () => {
+  it('renders "met by the final cabin anyway" subtext for honored camper instead of "All requests impossible"', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({
+          mp_campers_entirely_impossible: [
+            {
+              cm_id: 21012687,
+              name: 'Nathan Vaisman',
+              grade: 10,
+              gender: 'M',
+              session_cm_id: 1235404,
+              reason_codes: ['age_pref_no_eligible_grade'],
+              honored_in_plan: true,
+            },
+          ],
+        })}
+      />
+    )
+    expect(screen.getByText(/met by the final cabin anyway/i)).toBeInTheDocument()
+    expect(screen.queryByText(/All requests impossible/i)).not.toBeInTheDocument()
+  })
+
+  it('renders coverage-reconciliation line showing guaranteeable + unguaranteeable = total', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({
+          mp_campers_total: 165,
+          mp_campers_entirely_impossible: [
+            {
+              cm_id: 1,
+              name: 'Emma Johnson',
+              grade: 5,
+              gender: 'F',
+              session_cm_id: 1000001,
+              reason_codes: ['age_pref_no_eligible_grade'],
+              honored_in_plan: false,
+            },
+            {
+              cm_id: 2,
+              name: 'Liam Garcia',
+              grade: 6,
+              gender: 'M',
+              session_cm_id: 1000001,
+              reason_codes: ['pair_no_shared_bunk'],
+              honored_in_plan: false,
+            },
+            {
+              cm_id: 3,
+              name: 'Olivia Chen',
+              grade: 7,
+              gender: 'F',
+              session_cm_id: 1000001,
+              reason_codes: ['grade_compatibility'],
+              honored_in_plan: true,
+            },
+          ],
+        })}
+      />
+    )
+    const recon = screen.getByTestId('coverage-reconciliation')
+    expect(recon).toHaveTextContent('165')
+    expect(recon).toHaveTextContent('3')
+    expect(recon).toHaveTextContent('168')
+  })
+})

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -671,6 +671,9 @@ export function PostCheckContents({
   )
   // Need to compute these even when modal is closed since Modal might render conditionally
   const statistics = results.statistics
+  const mpGuaranteeable = statistics.mp_campers_total ?? 0
+  const unguaranteeable = statistics.mp_campers_entirely_impossible?.length ?? 0
+  const mpWithRequests = mpGuaranteeable + unguaranteeable
   // Memoize issues to prevent dependency array changes on every render
   const issues = useMemo(() => results.issues, [results.issues])
   const parentTotal = statistics.material_parent_requests ?? 0
@@ -718,7 +721,9 @@ export function PostCheckContents({
       const decoratedSubRows = r.subRows.map((sub) => {
         let detail: React.ReactNode
         if (r.cohort === 'got_nothing') {
-          detail = (
+          detail = sub.honoredInPlan ? (
+            <span>Flagged impossible · met by the final cabin anyway</span>
+          ) : (
             <span>
               All requests impossible ·{' '}
               {(sub.reasonCodes ?? []).map(friendlyReasonLabel).join(', ')}
@@ -959,6 +964,16 @@ export function PostCheckContents({
               </div>
             </div>
           </div>
+
+          {unguaranteeable > 0 && (
+            <div
+              data-testid="coverage-reconciliation"
+              className="border-border/50 border-b px-5 pb-3 text-xs text-stone-600"
+            >
+              {mpGuaranteeable} guaranteeable · {unguaranteeable} can&rsquo;t be guaranteed ={' '}
+              {mpWithRequests} with parent requests
+            </div>
+          )}
 
           {/* TG-9: "Families to contact" — unified action list consolidating:
           - Cohort A: entirely-impossible MP campers (got nothing)

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -671,9 +671,6 @@ export function PostCheckContents({
   )
   // Need to compute these even when modal is closed since Modal might render conditionally
   const statistics = results.statistics
-  const mpGuaranteeable = statistics.mp_campers_total ?? 0
-  const unguaranteeable = statistics.mp_campers_entirely_impossible?.length ?? 0
-  const mpWithRequests = mpGuaranteeable + unguaranteeable
   // Memoize issues to prevent dependency array changes on every render
   const issues = useMemo(() => results.issues, [results.issues])
   const parentTotal = statistics.material_parent_requests ?? 0
@@ -722,7 +719,10 @@ export function PostCheckContents({
         let detail: React.ReactNode
         if (r.cohort === 'got_nothing') {
           detail = sub.honoredInPlan ? (
-            <span>Flagged impossible · met by the final cabin anyway</span>
+            <span>
+              Met by same age cabin{' '}
+              {sub.bunkName && <span className="font-mono text-xs">{sub.bunkName}</span>}
+            </span>
           ) : (
             <span>
               All requests impossible ·{' '}
@@ -964,16 +964,6 @@ export function PostCheckContents({
               </div>
             </div>
           </div>
-
-          {unguaranteeable > 0 && (
-            <div
-              data-testid="coverage-reconciliation"
-              className="border-border/50 border-b px-5 pb-3 text-xs text-stone-600"
-            >
-              {mpGuaranteeable} guaranteeable · {unguaranteeable} can&rsquo;t be guaranteed ={' '}
-              {mpWithRequests} with parent requests
-            </div>
-          )}
 
           {/* TG-9: "Families to contact" — unified action list consolidating:
           - Cohort A: entirely-impossible MP campers (got nothing)

--- a/frontend/src/services/solver.ts
+++ b/frontend/src/services/solver.ts
@@ -163,6 +163,16 @@ export interface ValidationStatistics {
   mp_campers_total?: number
   mp_campers_with_at_least_one_satisfied?: number
   mp_campers_with_all_satisfied?: number
+  /** Entirely-impossible MP cohort (families to contact), reconciled vs the final plan. */
+  mp_campers_entirely_impossible?: Array<{
+    cm_id: number
+    name: string
+    grade: number
+    gender: string
+    session_cm_id: number
+    reason_codes: string[]
+    honored_in_plan: boolean
+  }>
   /** TG-polish: one entry per unsatisfied MP request, with names + bunk placement. */
   unsatisfied_material_parent_detail?: Array<{
     requester_cm_id: string

--- a/frontend/src/services/solver.ts
+++ b/frontend/src/services/solver.ts
@@ -172,6 +172,8 @@ export interface ValidationStatistics {
     session_cm_id: number
     reason_codes: string[]
     honored_in_plan: boolean
+    /** Cabin that met the preference when honored_in_plan; null/absent otherwise. */
+    bunk_name?: string | null
   }>
   /** TG-polish: one entry per unsatisfied MP request, with names + bunk placement. */
   unsatisfied_material_parent_detail?: Array<{

--- a/tests/unit/solver/impossibility/test_age_preference_rollup.py
+++ b/tests/unit/solver/impossibility/test_age_preference_rollup.py
@@ -1,0 +1,37 @@
+"""Rollup-level guard: an oldest-grade 'older' MP-only camper is entirely impossible.
+
+This is the data that drives the post-check families-to-contact cohort and the
+mp_campers_total denominator gating. The per-request predicate is pinned in
+test_age_preference.py; this pins the camper-level rollup in
+validate_impossibility.mp_campers_entirely_impossible so a future change can't
+silently drop these campers out of the cohort (which would also pull them into
+the solver's must-satisfy-one constraint and distort cabin shape).
+"""
+
+from bunking.solver.impossibility import validate_impossibility
+
+from .conftest import make_bunk, make_input, make_person, make_request
+
+
+def test_oldest_grade_older_mp_camper_is_entirely_impossible(mock_config):
+    # Oldest grade-10 camper with a MATERIAL-parent 'older' age preference; one
+    # younger same-gender peer exists so the camper IS placeable, just not with
+    # an older peer. The rollup must still flag the camper (kept out of MSO).
+    oldest = make_person(1, session=100, gender="M", grade=10)
+    younger = make_person(2, session=100, gender="M", grade=9)
+    req = make_request(
+        "r1",
+        requester=1,
+        requestee=None,
+        request_type="age_preference",
+        age_preference_target="older",
+        session=100,
+        source_field="bunk_request_form",  # MATERIAL_PARENT
+    )
+    input_data = make_input([oldest, younger], [make_bunk(10, session=100, gender="M")], [req])
+
+    report = validate_impossibility(input_data, mock_config)
+
+    cohort = {c["cm_id"]: c for c in report.mp_campers_entirely_impossible}
+    assert 1 in cohort, "oldest-grade 'older' MP camper must be in the entirely-impossible rollup"
+    assert "age_pref_no_eligible_grade" in cohort[1]["reason_codes"]

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -2996,6 +2996,9 @@ def test_cohort_honored_in_plan_true_when_clean_cabin():
     assert out[0]["cm_id"] == 20001
     assert out[0]["honored_in_plan"] is True
     assert out[0]["reason_codes"] == ["age_pref_no_eligible_grade"]
+    # Honored campers carry the cabin that met the preference (like the
+    # not-bunk-with violation detail) so the post-check can name it.
+    assert out[0]["bunk_name"] == "Bunk-30001"
 
 
 def test_cohort_honored_in_plan_false_when_mixed_cabin():
@@ -3032,6 +3035,8 @@ def test_cohort_honored_in_plan_false_when_mixed_cabin():
     assert len(out) == 1
     assert out[0]["cm_id"] == 20001
     assert out[0]["honored_in_plan"] is False
+    # Not honored → no cabin to name.
+    assert out[0]["bunk_name"] is None
 
 
 def test_cohort_absent_leaves_field_empty():

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -2944,3 +2944,107 @@ def test_priority_unsuccessful_has_session_cm_id_and_requester_grade():
     assert row["session_cm_id"] == "10000098"
     assert "requester_grade" in row
     assert row["requester_grade"] == 7  # Olivia's grade
+
+
+def _age_pref_request(requester: str, target: str, id: str) -> MockBunkRequest:
+    """A MATERIAL-parent age_preference request (source_field=bunk_request_form)."""
+    return MockBunkRequest(
+        requester_person_cm_id=requester,
+        requested_person_cm_id=None,
+        request_type="age_preference",
+        source_field=SourceField.BUNK_REQUEST_FORM,
+        source="family",
+        age_preference_target=target,
+        id=id,
+    )
+
+
+def test_cohort_honored_in_plan_true_when_clean_cabin():
+    """An oldest-grade 'older' MP camper flagged impossible is honored_in_plan=True
+    when the final cabin has no younger grades (all same grade)."""
+    session = _mock_session(cm_id="10000001", name="HonoredFixture")
+    # Two grade-10 campers share one bunk -> no younger grade present -> 'older' satisfied.
+    persons = [
+        MockPerson(campminder_id="20001", name="Oldest", grade=10, gender="M"),
+        MockPerson(campminder_id="20002", name="Peer", grade=10, gender="M"),
+    ]
+    bunks = [_mock_bunk("30001")]
+    assignments = [_mock_assignment("20001", "30001"), _mock_assignment("20002", "30001")]
+    requests = [_age_pref_request("20001", "older", id="ap1")]
+    cohort = [
+        {
+            "cm_id": 20001,
+            "name": "Oldest",
+            "grade": 10,
+            "gender": "M",
+            "session_cm_id": 10000001,
+            "reason_codes": ["age_pref_no_eligible_grade"],
+        }
+    ]
+
+    result = BunkingValidator().validate_bunking(
+        session=cast(Any, session),
+        bunks=cast(list[Bunk], bunks),
+        assignments=cast(list[BunkAssignment], assignments),
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+        impossible_request_ids={"ap1"},
+        impossible_mp_cohort=cohort,
+    )
+    out = result.statistics.mp_campers_entirely_impossible
+    assert len(out) == 1
+    assert out[0]["cm_id"] == 20001
+    assert out[0]["honored_in_plan"] is True
+    assert out[0]["reason_codes"] == ["age_pref_no_eligible_grade"]
+
+
+def test_cohort_honored_in_plan_false_when_mixed_cabin():
+    """Same camper, but the cabin also has a grade-9 -> 'older' violated -> honored_in_plan=False."""
+    session = _mock_session(cm_id="10000001", name="NotHonoredFixture")
+    persons = [
+        MockPerson(campminder_id="20001", name="Oldest", grade=10, gender="M"),
+        MockPerson(campminder_id="20002", name="Younger", grade=9, gender="M"),
+    ]
+    bunks = [_mock_bunk("30001")]
+    assignments = [_mock_assignment("20001", "30001"), _mock_assignment("20002", "30001")]
+    requests = [_age_pref_request("20001", "older", id="ap1")]
+    cohort = [
+        {
+            "cm_id": 20001,
+            "name": "Oldest",
+            "grade": 10,
+            "gender": "M",
+            "session_cm_id": 10000001,
+            "reason_codes": ["age_pref_no_eligible_grade"],
+        }
+    ]
+
+    result = BunkingValidator().validate_bunking(
+        session=cast(Any, session),
+        bunks=cast(list[Bunk], bunks),
+        assignments=cast(list[BunkAssignment], assignments),
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+        impossible_request_ids={"ap1"},
+        impossible_mp_cohort=cohort,
+    )
+    out = result.statistics.mp_campers_entirely_impossible
+    assert len(out) == 1
+    assert out[0]["cm_id"] == 20001
+    assert out[0]["honored_in_plan"] is False
+
+
+def test_cohort_absent_leaves_field_empty():
+    """Omitting impossible_mp_cohort leaves mp_campers_entirely_impossible empty (legacy callers)."""
+    session = _mock_session(cm_id="10000001", name="NoCohortFixture")
+    persons = [_mock_person("20001", grade=5)]
+    bunks = [_mock_bunk("30001")]
+    assignments = [_mock_assignment("20001", "30001")]
+    result = BunkingValidator().validate_bunking(
+        session=cast(Any, session),
+        bunks=cast(list[Bunk], bunks),
+        assignments=cast(list[BunkAssignment], assignments),
+        persons=cast(list[Person], persons),
+        requests=[],
+    )
+    assert result.statistics.mp_campers_entirely_impossible == []


### PR DESCRIPTION
## Summary

The post-check "Families to contact" list flags campers whose entire Material-Parent (MP) request set is impossible. A common case: a camper at the **extreme grade of the session** (the oldest asking for "older", or the youngest asking for "younger") — there is no peer further in that direction, so it's flagged impossible, and we deliberately keep it **out** of the solver's must-satisfy-one constraint so it never distorts cabin shape.

But such a request *can* still be honored coincidentally when the camper lands in a single-grade cabin (an "older" preference just means "avoid younger"). Today that produces a contradiction: the camper shows up on the families-to-contact list **and** got their request — with no explanation.

This PR makes that one row honest. **No solver behavior changes** — the impossibility flag and MSO exclusion are untouched (a regression test pins that). It's reporting-only.

## What changed

**Backend**
- `bunking_validator.py`: new additive `ValidationStatistics.mp_campers_entirely_impossible` field; each cohort entry is reconciled against the final plan with a `honored_in_plan` flag (a camper is honored iff the final assignment satisfied any of their flagged MP requests anyway, so cross-gender/cross-session stay False). Honored entries also carry the `bunk_name` that met the preference — the same field the not-bunk-with violation detail already surfaces.
- `api/routers/validation.py`: `/validate-bunking` now returns that cohort (3-line passthrough), making the post modal self-sufficient instead of depending on a prior pre-check.
- New rollup regression test pinning that an oldest-grade "older" MP camper stays in the entirely-impossible cohort (so a future change can't pull it into MSO and distort the cabin).

**Frontend**
- `solver.ts`: typed the new `honored_in_plan` + `bunk_name` fields.
- `familyRows.ts`: `got_nothing` rows now source from the authoritative post-response (carrying `honored_in_plan` + `bunk_name`), falling back to the pre-check report for backward-compat.
- `PostValidationResultsModal.tsx`: honored campers get a distinct subtext — **"Met by same age cabin `<cabin>`"** (cabin rendered like the not-bunk-with note) instead of the contradictory "All requests impossible".

## Test plan

- [x] Validator: `honored_in_plan` True + `bunk_name` set (extreme-grade camper in a single-grade cabin) / False + `bunk_name` None (mixed cabin) / absent-cohort no-op — TDD, verified red first
- [x] Solver rollup guard: extreme-grade "older" MP camper stays in the entirely-impossible rollup
- [x] Frontend: `buildFamilyRows` sources from stats cohort + honored detail incl. cabin (3 tests); modal honored subtext names the cabin (1 test)
- [x] Full pre-push verification green: pytest unit (5187), frontend prettier/eslint/tsc/vitest, mypy / ruff all clean

## Notes

- **Stacked on #1637** (base branch `feature/postcheck-coverage-stats`). Rebase onto `main` + retarget once #1637 merges.
- Reporting-only: no change to the solver model, MSO, or the objective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validation now reports an “entirely impossible” MP camper cohort and whether each was honored in the final plan (including bunk name when applicable).

* **UI**
  * Family/report rows and PDF export show an “honored‑in‑plan” message (“Met by same age cabin …”) and carry honored status into sub-rows.
  * Post-validation modal renders honored-anyway messaging instead of “All requests impossible” when applicable.

* **Tests**
  * Added unit and frontend tests covering impossibility rollups and honored-in-plan display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->