### PR TITLE
fix(frontend): survive react-query 5.100.14 NoInfer change + drop patched CVE ignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -3,5 +3,4 @@
 #
 # Format: CVE-ID  # reason — added YYYY-MM-DD, remove by YYYY-MM-DD
 
-CVE-2026-33186  # grpc-go auth bypass in caddy binary — waiting on upstream caddy rebuild with grpc v1.79.3 — added 2026-03-19, remove by 2026-05-19
 CVE-2026-30836  # smallstep/certificates SCEP vuln in caddy binary — we don't use Caddy's ACME/PKI server — added 2026-04-06, remove by 2026-07-06

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,7 +21,7 @@
         "@popperjs/core": "^2.11.8",
         "@react-pdf/renderer": "^4.5.1",
         "@tailwindcss/vite": "^4.2.2",
-        "@tanstack/react-query": "^5.100.7",
+        "@tanstack/react-query": "^5.100.14",
         "@tanstack/react-virtual": "^3.13.22",
         "@types/leaflet": "^1.9.21",
         "@vitejs/plugin-react": "^6.0.2",
@@ -52,7 +52,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@hey-api/openapi-ts": "^0.97.1",
-        "@tanstack/react-query-devtools": "^5.100.7",
+        "@tanstack/react-query-devtools": "^5.100.14",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.2.0",
         "@testing-library/react": "^16.3.2",
@@ -2462,9 +2462,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.100.10",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.10.tgz",
-      "integrity": "sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w==",
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.14.tgz",
+      "integrity": "sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2472,9 +2472,9 @@
       }
     },
     "node_modules/@tanstack/query-devtools": {
-      "version": "5.100.10",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.100.10.tgz",
-      "integrity": "sha512-3DmJf25hDPus5IpVvp6ujXv6bKV2zPzI9vpbAmpJigsL/H6DPvPjmf7/Q9yVKEke//8fgeQ45abjgnLuyYxAiw==",
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.100.14.tgz",
+      "integrity": "sha512-g96SmSSQecYTYcyuAMRXr895GplJv01UGt7qttQWPOUyZ5EGz5tbRc589bMc2m5BsPFD6O0PCEAHdbDYNP6UBw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2483,12 +2483,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.100.10",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.10.tgz",
-      "integrity": "sha512-FLaZf2RCrA/Zgp4aiu5tG3TyasTRO7aZ99skxQpr3Hg/zXOhu6yq5FZCYQ/tRaJtM9ylnoK8tFK7PolXQadv6Q==",
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.14.tgz",
+      "integrity": "sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.100.10"
+        "@tanstack/query-core": "5.100.14"
       },
       "funding": {
         "type": "github",
@@ -2499,20 +2499,20 @@
       }
     },
     "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.100.10",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.100.10.tgz",
-      "integrity": "sha512-zes0+o9ef5rAZXJ9f/SeaLs2nufJaeVkZkl/Or9NGrWVF41kL9Od9ED9nCwtQlgiF2VGtrzhEw5AU/igAO+aAg==",
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.100.14.tgz",
+      "integrity": "sha512-JkP5VDgKOw3t/QSA1OABRHEqx8BuNs5MfvZRooNqdvN57SzTuGq3fKR1a2IH5rqa5HDLUm+FOXUEnB9ueHiLzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-devtools": "5.100.10"
+        "@tanstack/query-devtools": "5.100.14"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "@tanstack/react-query": "^5.100.10",
+        "@tanstack/react-query": "^5.100.14",
         "react": "^18 || ^19"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,7 @@
     "@popperjs/core": "^2.11.8",
     "@react-pdf/renderer": "^4.5.1",
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/react-query": "^5.100.7",
+    "@tanstack/react-query": "^5.100.14",
     "@tanstack/react-virtual": "^3.13.22",
     "@types/leaflet": "^1.9.21",
     "@vitejs/plugin-react": "^6.0.2",
@@ -76,7 +76,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@hey-api/openapi-ts": "^0.97.1",
-    "@tanstack/react-query-devtools": "^5.100.7",
+    "@tanstack/react-query-devtools": "^5.100.14",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.2.0",
     "@testing-library/react": "^16.3.2",

--- a/frontend/src/hooks/useSyncCompletionToasts.ts
+++ b/frontend/src/hooks/useSyncCompletionToasts.ts
@@ -66,7 +66,7 @@ type PreviousStatuses = Record<string, string>
  * Hook that monitors sync status polling and fires toasts when syncs complete.
  * Detects transitions from 'running' -> 'success' or 'running' -> 'failed'.
  */
-export function useSyncCompletionToasts() {
+export function useSyncCompletionToasts(): SyncStatusResponse | null | undefined {
   const { data: syncStatus } = useSyncStatusAPI()
   const previousStatuses = useRef<PreviousStatuses>({})
 

--- a/frontend/src/services/csvPipelineStatus.test.ts
+++ b/frontend/src/services/csvPipelineStatus.test.ts
@@ -233,16 +233,20 @@ describe('derivePhase', () => {
     })
 
     it('treats exactly 30-min delta as done (inclusive boundary)', () => {
+      // Anchor both timestamps to a single `now`: two separate ago() calls each
+      // read Date.now(), so the delta is 30min + sub-ms jitter and tips the
+      // inclusive boundary to 'error' on a slow runner (flaky in CI).
+      const now = Date.now()
       const sync: SyncJobStatus = {
         name: 'bunk_requests',
         status: 'failed',
         startedAt: ago(90),
-        finishedAt: ago(60),
+        finishedAt: new Date(now - 60 * 60_000).toISOString(),
         error: 'context deadline exceeded',
       }
       const debug: DebugPipelineRun = {
         run_id: 'r-boundary',
-        created: ago(30),
+        created: new Date(now - 30 * 60_000).toISOString(),
         status_breakdown: { resolved: 1, pending: 0, declined: 0 },
       }
       const csvUploadStartedAt = ago(91)


### PR DESCRIPTION
## Why

Every open dependabot PR was failing **CI → Frontend Lint** — including Python-only ones (#1645–#1649). Root cause was **not** the bumps themselves: each dependabot PR's lockfile-fixup regenerates `frontend/package-lock.json` and pulls **`@tanstack/react-query` 5.100.14** (newest in the `^5.100.7` range), while `main` stayed pinned at 5.100.10.

react-query 5.100.14 wraps `useQuery`'s `data` type in `NoInfer<T>`. The `useSyncCompletionToasts` hook returned that data with **no explicit return type**, leaking `NoInfer<SyncStatusResponse | null>` into `SyncTab`, where:

```ts
syncStatus[syncType.id as keyof typeof syncStatus]
```

then failed with **TS2536** (`keyof NoInfer<…>` not assignable to index `SyncStatusResponse`) at lines 108, 165, 780.

## Fix

- **Annotate the hook's return type** (`SyncStatusResponse | null | undefined`) so the `NoInfer` wrapper is normalized at the hook boundary. One line; the sibling code at `useSyncCompletionToasts.ts:80` already uses the equivalent `keyof SyncStatusResponse` pattern.
- **Bump `@tanstack/react-query` (+ devtools) to 5.100.14** so this PR's own CI exercises the fix at the breaking version, and `main` no longer breaks on the next lockfile refresh.

Verified locally: type-check fails (3× TS2536) at 5.100.14 without the fix, passes at both 5.100.10 and 5.100.14 with it. Once merged, the dependabot PRs go green on rebase.

## Also: drop a patched CVE ignore

`CVE-2026-33186` (grpc-go authorization bypass) was past its remove-by date (2026-05-19). Confirmed remediated: the `dhi.io/caddy:2` base image (rebuilt 2026-05-11) now ships `google.golang.org/grpc v1.81.1` (≥ the v1.79.3 fix), verified via `go version -m` on the embedded caddy binary. `CVE-2026-30836` stays (not due until 2026-07-06; it's a "we don't use Caddy's ACME/PKI server" justification anyway).

## Test plan
- [x] `npm run type-check` clean at react-query 5.100.10 and 5.100.14
- [x] Full pre-push suite green (eslint, prettier, tsc, vitest, mypy, pytest 5245 passed, go-build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed a temporary security-related ignore entry
  * Updated React Query dependencies to latest patch versions
  * Added an explicit return type annotation to a frontend hook signature
* **Tests**
  * Stabilized a time-sensitive test to reduce CI flakiness and prevent intermittent failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1658?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->