### PR TITLE
feat(solver): parent not_bunk_with yields to parent bunk_with (Stream C, #1638)

### DIFF
--- a/bunking/solver/constraints/base.py
+++ b/bunking/solver/constraints/base.py
@@ -94,6 +94,15 @@ class SolverContext:
     # production runs. Analogue of mp_skip_cms.
     staff_nbw_skip_pairs: set[tuple[int, int]] = field(default_factory=set)
 
+    # Parent-paramount carve-out (#1638 Stream C): records where a parent
+    # not_bunk_with that is the requester's SOLE Material-Parent request yielded
+    # to a conflicting sole-MP parent bunk_with (the "with" wins). Each entry has
+    # the same shape as staff_nbw_yields:
+    # {nbw_request_id, subject_cm, target_cm, protected_parent_request_id, protected_camper_cm}.
+    # Populated by add_must_satisfy_one_request_constraints; surfaced post-solve
+    # into request_validation_summary["parent_nbw_yielded"].
+    parent_nbw_yields: list[dict[str, Any]] = field(default_factory=list)
+
     # Canonical per-request satisfaction vars for bunk_with / not_bunk_with
     # requests, keyed by request.id. Built + memoized by
     # get_or_create_request_sat_var (bunk_requests.py); shared so add_objective

--- a/bunking/solver/constraints/parent_paramount.py
+++ b/bunking/solver/constraints/parent_paramount.py
@@ -30,7 +30,7 @@ Campers whose every MP request is impossible (filtered out of
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from bunking.logging_config import get_logger
 from bunking.satisfaction.bucket import is_material_parent_request
@@ -46,6 +46,46 @@ if TYPE_CHECKING:
     from bunking.models_v2 import DirectBunkRequest
 
 logger = get_logger(__name__)
+
+
+def _parent_nbw_yield_record(
+    person_cm_id: int,
+    mp_bunk_requests_by_person: dict[int, list[DirectBunkRequest]],
+    mp_age_requests_by_person: dict[int, list[DirectBunkRequest]],
+) -> dict[str, Any] | None:
+    """Yield record if this camper's SOLE Material-Parent request is a
+    not_bunk_with whose target's SOLE MP request is a bunk_with toward this pair.
+
+    In that both-sole, directly-opposing case the positive request wins: the
+    caller skips this camper's must-satisfy-one (dropping the NBW) so the
+    target's bunk_with MSO can co-place the pair. Returns the yield detail for
+    ctx.parent_nbw_yields (same shape as staff_nbw_yields), or None.
+    """
+    own = mp_bunk_requests_by_person.get(person_cm_id, [])
+    if len(own) != 1 or mp_age_requests_by_person.get(person_cm_id):
+        return None  # not a sole MP request
+    nbw = own[0]
+    if nbw.request_type != RequestType.NOT_BUNK_WITH.value:
+        return None
+    target_cm = nbw.requested_person_cm_id
+    if target_cm is None:
+        return None
+    pair = {person_cm_id, target_cm}
+    target_own = mp_bunk_requests_by_person.get(target_cm, [])
+    if len(target_own) != 1 or mp_age_requests_by_person.get(target_cm):
+        return None  # target's positive wish must also be sole-MP
+    bw = target_own[0]
+    if bw.request_type != RequestType.BUNK_WITH.value:
+        return None
+    if {bw.requester_person_cm_id, bw.requested_person_cm_id} != pair:
+        return None
+    return {
+        "nbw_request_id": nbw.id,
+        "subject_cm": person_cm_id,
+        "target_cm": target_cm,
+        "protected_parent_request_id": bw.id,
+        "protected_camper_cm": target_cm,
+    }
 
 
 def add_must_satisfy_one_request_constraints(ctx: SolverContext) -> None:
@@ -116,6 +156,14 @@ def add_must_satisfy_one_request_constraints(ctx: SolverContext) -> None:
         # minimal infeasible subset. The constraint is otherwise unchanged.
         if person_cm_id in ctx.mp_skip_cms:
             skipped_for_iis_probe += 1
+            continue
+
+        # Parent-paramount carve-out (#1638 Stream C): if this camper's sole MP
+        # wish is a not_bunk_with that directly opposes a sole-MP parent bunk_with,
+        # the positive wins — skip this camper's MSO (drop the NBW) and record it.
+        parent_yield = _parent_nbw_yield_record(person_cm_id, mp_bunk_requests_by_person, mp_age_requests_by_person)
+        if parent_yield is not None:
+            ctx.parent_nbw_yields.append(parent_yield)
             continue
 
         forcing_vars: list[cp_model.IntVar] = []

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -174,6 +174,11 @@ class DirectBunkingSolver:
         # protect a parent-paramount MSO. Populated by add_staff_separation_constraints;
         # surfaced post-solve into request_validation_summary["staff_nbw_yielded"].
         self.staff_nbw_yields: list[dict[str, Any]] = []
+        # Parent not_bunk_with yields (#1638 Stream C) — a sole-MP parent NBW
+        # relaxed because the opposing sole-MP parent bunk_with wins. Populated by
+        # add_must_satisfy_one_request_constraints; surfaced post-solve into
+        # request_validation_summary["parent_nbw_yielded"].
+        self.parent_nbw_yields: list[dict[str, Any]] = []
 
         # Canonical per-request satisfaction vars (bunk_with / not_bunk_with),
         # keyed by request.id. Populated by get_or_create_request_sat_var via
@@ -226,6 +231,7 @@ class DirectBunkingSolver:
             soft_constraint_bonuses=self.soft_constraint_bonuses,
             mp_set_entirely_impossible=self.mp_set_entirely_impossible,
             staff_nbw_yields=self.staff_nbw_yields,
+            parent_nbw_yields=self.parent_nbw_yields,
             mp_skip_cms=self.mp_skip_cms,
             request_satisfied_vars=self.request_satisfied_vars,
         )
@@ -1234,6 +1240,11 @@ class DirectBunkingSolver:
         # MSO (#1541) — populated at add_constraints time; surfaced for Stream B (#1638).
         self.request_validation_summary["staff_nbw_yielded_count"] = len(self.staff_nbw_yields)
         self.request_validation_summary["staff_nbw_yielded"] = list(self.staff_nbw_yields)
+
+        # Parent NBW yields (#1638 Stream C) — sole-MP parent separations that
+        # yielded to a sole-MP parent bunk_with. Populated at add_constraints time.
+        self.request_validation_summary["parent_nbw_yielded_count"] = len(self.parent_nbw_yields)
+        self.request_validation_summary["parent_nbw_yielded"] = list(self.parent_nbw_yields)
 
         # PR1 symmetric met/total counts -- mirror the bucket-aware unmet keys
         # above with positive-side counts. Consumers (debug page) derive unmet

--- a/bunking/solver/feasibility.py
+++ b/bunking/solver/feasibility.py
@@ -55,6 +55,11 @@ class RequestValidationSummary(_RequestValidationSummaryBase, total=False):
     # protected_parent_request_id, protected_camper_cm}. Consumed by Stream B (#1638).
     staff_nbw_yielded_count: int
     staff_nbw_yielded: list[dict[str, Any]]
+    # Parent not_bunk_with separations that yielded to a sole-MP parent bunk_with
+    # (#1638 Stream C). Same entry shape as staff_nbw_yielded. Consumed by the
+    # rose advisory card in the solver-success modal.
+    parent_nbw_yielded_count: int
+    parent_nbw_yielded: list[dict[str, Any]]
 
 
 def check_feasibility(

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -178,6 +178,11 @@ export default function SessionView() {
             result.stats?.request_validation?.staff_nbw_yielded,
             camperNameById
           ),
+          // #1638 Stream C — resolve parent-NBW yields to names for the rose advisory.
+          parent_separation_yields: resolveYields(
+            result.stats?.request_validation?.parent_nbw_yielded,
+            camperNameById
+          ),
         })
       } else if (hasReviewableDiagnostics(result.diagnostics)) {
         // #1638 — persistent review surface replaces the transient red box.

--- a/frontend/src/components/SolverProgressModal.test.tsx
+++ b/frontend/src/components/SolverProgressModal.test.tsx
@@ -100,11 +100,15 @@ const completedWithParentYields: SolverProgressState = {
     total_requests: 220,
     duration_seconds: 60,
     new_assignments: 100,
+    // protectedCamperName is deliberately distinct from targetName here so the
+    // test verifies the protected-camper slot is wired independently. (In real
+    // parent yields protected_camper_cm == target_cm, but the modal is purely
+    // presentational and must render whatever it's handed into the right slot.)
     parent_separation_yields: [
       {
         subjectName: 'Liam Garcia',
         targetName: 'Emma Johnson',
-        protectedCamperName: 'Emma Johnson',
+        protectedCamperName: 'Olivia Chen',
       },
     ],
   },
@@ -116,6 +120,9 @@ describe('SolverProgressModal parent-NBW override (#1638 Stream C)', () => {
     expect(screen.getByText(/parent .*do-not-bunk.* overridden/i)).toBeInTheDocument()
     expect(screen.getByText(/Liam Garcia/)).toBeInTheDocument()
     expect(screen.getByText(/Emma Johnson/)).toBeInTheDocument()
+    // The protected-camper name fills its own clause ("...to honor X's only
+    // parent request"), distinct from the target name above it.
+    expect(screen.getByText(/Olivia Chen.*only parent request/i)).toBeInTheDocument()
   })
 
   it('omits the parent-NBW card when there are no parent yields', () => {

--- a/frontend/src/components/SolverProgressModal.test.tsx
+++ b/frontend/src/components/SolverProgressModal.test.tsx
@@ -89,3 +89,41 @@ describe('SolverProgressModal staff-separation yields (#1638)', () => {
     expect(screen.queryByText(/staff separation/i)).toBeNull()
   })
 })
+
+const completedWithParentYields: SolverProgressState = {
+  isOpen: true,
+  phase: 'completed',
+  elapsedSeconds: 60,
+  timeLimit: 60,
+  stats: {
+    satisfied_request_count: 200,
+    total_requests: 220,
+    duration_seconds: 60,
+    new_assignments: 100,
+    parent_separation_yields: [
+      {
+        subjectName: 'Liam Garcia',
+        targetName: 'Emma Johnson',
+        protectedCamperName: 'Emma Johnson',
+      },
+    ],
+  },
+}
+
+describe('SolverProgressModal parent-NBW override (#1638 Stream C)', () => {
+  it('renders the parent-NBW override card when parent_separation_yields present', () => {
+    render(<SolverProgressModal state={completedWithParentYields} onClose={() => {}} />)
+    expect(screen.getByText(/parent .*do-not-bunk.* overridden/i)).toBeInTheDocument()
+    expect(screen.getByText(/Liam Garcia/)).toBeInTheDocument()
+    expect(screen.getByText(/Emma Johnson/)).toBeInTheDocument()
+  })
+
+  it('omits the parent-NBW card when there are no parent yields', () => {
+    const noYields: SolverProgressState = {
+      ...completedWithParentYields,
+      stats: { ...completedWithParentYields.stats, parent_separation_yields: [] },
+    }
+    render(<SolverProgressModal state={noYields} onClose={() => {}} />)
+    expect(screen.queryByText(/parent .*do-not-bunk.* overridden/i)).toBeNull()
+  })
+})

--- a/frontend/src/components/SolverProgressModal.tsx
+++ b/frontend/src/components/SolverProgressModal.tsx
@@ -18,6 +18,7 @@ import {
   Clock,
   Target,
   AlertTriangle,
+  ShieldAlert,
   X,
   Minimize2,
 } from 'lucide-react'
@@ -56,6 +57,7 @@ export interface SolverResultStats {
       }
     | undefined
   staff_separation_yields?: ResolvedStaffSeparationYield[] | undefined
+  parent_separation_yields?: ResolvedStaffSeparationYield[] | undefined
 }
 
 export interface SolverProgressState {
@@ -468,6 +470,30 @@ export default function SolverProgressModal({
                           <li key={i}>
                             {y.subjectName} ↔ {y.targetName} — placed together to protect{' '}
                             {y.protectedCamperName}&apos;s only honorable parent request
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* #1638 Stream C — parent "keep-apart" overridden by a parent "bunk-with". */}
+              {stats.parent_separation_yields && stats.parent_separation_yields.length > 0 && (
+                <div className="rounded-xl bg-rose-50 p-3 ring-1 ring-rose-200 dark:bg-rose-950/30 dark:ring-rose-800">
+                  <div className="flex items-start gap-3">
+                    <ShieldAlert className="mt-0.5 h-5 w-5 flex-shrink-0 text-rose-600 dark:text-rose-400" />
+                    <div>
+                      <p className="text-sm font-medium text-rose-700 dark:text-rose-300">
+                        {stats.parent_separation_yields.length} parent &ldquo;do-not-bunk&rdquo;
+                        {stats.parent_separation_yields.length === 1 ? '' : 's'} overridden
+                      </p>
+                      <ul className="mt-1 space-y-1 text-xs text-rose-600 dark:text-rose-400">
+                        {stats.parent_separation_yields.map((y, i) => (
+                          <li key={i}>
+                            {y.subjectName} ↔ {y.targetName} — placed together to honor{' '}
+                            {y.protectedCamperName}&apos;s only parent request; {y.subjectName}
+                            &apos;s parent asked to keep them apart
                           </li>
                         ))}
                       </ul>

--- a/frontend/src/hooks/session/useSolverOperations.ts
+++ b/frontend/src/hooks/session/useSolverOperations.ts
@@ -12,7 +12,12 @@
 import { useState, useCallback } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'react-hot-toast'
-import { solverService, type SolverDiagnostics, type StaffNbwYieldRaw } from '../../services/solver'
+import {
+  solverService,
+  type SolverDiagnostics,
+  type StaffNbwYieldRaw,
+  type ParentNbwYieldRaw,
+} from '../../services/solver'
 import { graphCacheService } from '../../services/GraphCacheService'
 import { queryKeys } from '../../utils/queryKeys'
 import { invalidateAssignmentDerivedQueries } from '../../utils/queryInvalidation'
@@ -34,6 +39,7 @@ export interface SolverStats {
     impossible_requests: number
     affected_campers: number
     staff_nbw_yielded?: StaffNbwYieldRaw[]
+    parent_nbw_yielded?: ParentNbwYieldRaw[]
   }
 }
 

--- a/frontend/src/services/solver.ts
+++ b/frontend/src/services/solver.ts
@@ -113,6 +113,9 @@ export interface StaffNbwYieldRaw {
   protected_camper_cm: number
 }
 
+/** Raw parent-NBW yield — identical shape to StaffNbwYieldRaw, distinct source (#1638 Stream C). */
+export type ParentNbwYieldRaw = StaffNbwYieldRaw
+
 /** A SolverRun plus the optional failure diagnostics (#1638). */
 export type SolverRunWithDiagnostics = SolverRun & { diagnostics?: SolverDiagnostics }
 

--- a/tests/unit/solver/test_parent_nbw_yield_wiring.py
+++ b/tests/unit/solver/test_parent_nbw_yield_wiring.py
@@ -1,0 +1,94 @@
+"""Full-solver wiring for the parent-paramount NBW carve-out (#1638 Stream C).
+
+Constructs a real DirectBunkingSolver (mock ConfigLoader, no DB) and solves with
+cp_model to confirm that when a parent-form ``not_bunk_with`` is a camper's SOLE
+Material-Parent request and directly opposes another camper's sole-MP parent
+``bunk_with``, the positive request wins: the pair is co-placed, the NBW yields,
+and the yield is recorded + surfaced. The fixture has 16 same-gender campers
+across 2 bunks: the hard minimum-occupancy floor (8/bunk) forces an 8/8 split,
+so co-placing one pair (or separating it) is genuinely feasible.
+"""
+
+from collections.abc import Generator
+from typing import Any, ClassVar
+from unittest.mock import MagicMock
+
+import pytest
+from ortools.sat.python import cp_model
+
+from bunking.config import ConfigLoader
+from bunking.models_v2 import DirectBunk, DirectPerson
+from bunking.solver.direct_solver import DirectBunkingSolver
+from tests.unit.bunking.solver.conftest import is_optimal_or_feasible
+from tests.unit.solver.impossibility.conftest import make_bunk, make_input, make_person, make_request
+
+
+class _PenaltyStubLoader:
+    _values: ClassVar[dict[str, int]] = {
+        "constraint.cabin_minimum_occupancy.penalty": 0,
+        "constraint.grade_spread.penalty": 0,
+    }
+
+    def get_int(self, key: str, default: int | None = None) -> int:
+        v = self._values.get(key)
+        return int(v) if v is not None else (default if default is not None else 0)
+
+    def get_float(self, key: str, default: float | None = None) -> float:
+        v = self._values.get(key)
+        return float(v) if v is not None else (default if default is not None else 0.0)
+
+
+@pytest.fixture
+def mock_config() -> Generator[Any]:
+    cfg = MagicMock()
+
+    def _get_constraint(constraint_type: str, param: str, default: Any = None) -> Any:
+        if constraint_type == "grade_spread" and param == "max_spread":
+            return 2
+        return default if default is not None else 0
+
+    cfg.get_constraint.side_effect = _get_constraint
+    cfg.get_int.side_effect = lambda key, default=None: default if default is not None else 0
+    cfg.get_float.side_effect = lambda key, default=None: default if default is not None else 0.0
+    cfg.get_str.side_effect = lambda key, default=None: "hard" if "grade_spread.mode" in key else (default or "")
+    cfg.get_bool.side_effect = lambda key, default=None: default if default is not None else False
+    cfg.get_soft_constraint_weight.side_effect = lambda name: 0
+
+    with ConfigLoader.use(_PenaltyStubLoader()):  # type: ignore[arg-type]
+        yield cfg
+
+
+def _roster() -> tuple[list[DirectPerson], list[DirectBunk]]:
+    # Emma=100, Liam=200, plus 14 filler girls → 16 campers, 2 F bunks (cap 12).
+    # min-occupancy 8/bunk forces an 8/8 split.
+    persons = [make_person(100, gender="F", grade=6), make_person(200, gender="F", grade=6)]
+    persons += [make_person(1000 + i, gender="F", grade=6) for i in range(14)]
+    bunks = [make_bunk(2001, gender="F"), make_bunk(2002, gender="F")]
+    return persons, bunks
+
+
+def _solve(solver: DirectBunkingSolver) -> tuple[cp_model.CpSolver, Any]:
+    solver.check_feasibility()
+    solver.add_constraints()
+    solver.add_objective()
+    cp = cp_model.CpSolver()
+    cp.parameters.max_time_in_seconds = 10
+    return cp, cp.Solve(solver.model)
+
+
+def _bunk_idx(solver: DirectBunkingSolver, cp: cp_model.CpSolver, cm_id: int) -> int:
+    return int(cp.Value(solver.person_bunk_assignment[solver.person_idx_map[cm_id]]))
+
+
+def test_clean_solve_exposes_empty_parent_nbw_yielded(mock_config):
+    persons, bunks = _roster()
+    reqs = [
+        make_request("p1", requester=100, requestee=200, request_type="bunk_with", source_field="bunk_request_form"),
+    ]
+    solver = DirectBunkingSolver(make_input(persons, bunks, reqs), mock_config)
+    output = solver.solve(time_limit_seconds=10)
+    assert output is not None
+    rv = output.stats["request_validation"]
+    assert rv["parent_nbw_yielded_count"] == 0
+    assert rv["parent_nbw_yielded"] == []
+    assert solver.parent_nbw_yields == []

--- a/tests/unit/solver/test_parent_nbw_yield_wiring.py
+++ b/tests/unit/solver/test_parent_nbw_yield_wiring.py
@@ -150,3 +150,24 @@ def test_no_yield_when_positive_camper_has_a_second_mp(mock_config):
     assert is_optimal_or_feasible(status)
     assert solver.parent_nbw_yields == []
     assert _bunk_idx(solver, cp, 100) != _bunk_idx(solver, cp, 200)  # NBW honored
+
+
+def test_no_yield_when_both_campers_have_sole_mp_nbw(mock_config):
+    # Mutual avoidance: Emma's parent NOT bunk_with Liam (Emma's only MP) AND
+    # Liam's parent NOT bunk_with Emma (Liam's only MP). Neither side's sole MP
+    # is a bunk_with, so the carve-out must NOT fire (it requires the target's
+    # sole MP to be a bunk_with). Both NBWs hold: no yield, pair kept apart.
+    persons, bunks = _roster()
+    reqs = [
+        make_request(
+            "n1", requester=100, requestee=200, request_type="not_bunk_with", source_field="bunk_request_form"
+        ),
+        make_request(
+            "n2", requester=200, requestee=100, request_type="not_bunk_with", source_field="bunk_request_form"
+        ),
+    ]
+    solver = DirectBunkingSolver(make_input(persons, bunks, reqs), mock_config)
+    cp, status = _solve(solver)
+    assert is_optimal_or_feasible(status)
+    assert solver.parent_nbw_yields == []
+    assert _bunk_idx(solver, cp, 100) != _bunk_idx(solver, cp, 200)  # both NBWs honored

--- a/tests/unit/solver/test_parent_nbw_yield_wiring.py
+++ b/tests/unit/solver/test_parent_nbw_yield_wiring.py
@@ -92,3 +92,61 @@ def test_clean_solve_exposes_empty_parent_nbw_yielded(mock_config):
     assert rv["parent_nbw_yielded_count"] == 0
     assert rv["parent_nbw_yielded"] == []
     assert solver.parent_nbw_yields == []
+
+
+def test_carveout_places_together_and_records_yield(mock_config):
+    # Emma's parent: bunk_with Liam (Emma's only MP). Liam's parent: NOT bunk_with
+    # Emma (Liam's only MP). Positive wins -> together, Liam's NBW recorded.
+    persons, bunks = _roster()
+    reqs = [
+        make_request("p1", requester=100, requestee=200, request_type="bunk_with", source_field="bunk_request_form"),
+        make_request(
+            "n1", requester=200, requestee=100, request_type="not_bunk_with", source_field="bunk_request_form"
+        ),
+    ]
+    solver = DirectBunkingSolver(make_input(persons, bunks, reqs), mock_config)
+    cp, status = _solve(solver)
+    assert is_optimal_or_feasible(status)
+    assert _bunk_idx(solver, cp, 100) == _bunk_idx(solver, cp, 200)  # together
+    assert len(solver.parent_nbw_yields) == 1
+    y = solver.parent_nbw_yields[0]
+    assert y["nbw_request_id"] == "n1"
+    assert y["subject_cm"] == 200  # the yielding (NBW) camper
+    assert y["target_cm"] == 100
+    assert y["protected_parent_request_id"] == "p1"
+    assert y["protected_camper_cm"] == 100  # the bunk_with requester
+
+
+def test_no_yield_when_nbw_camper_has_a_second_mp(mock_config):
+    # Liam has NBW Emma AND bunk_with a filler -> his MSO is satisfiable elsewhere,
+    # so the NBW is never the sole forcing var: no carve-out, no recorded yield.
+    persons, bunks = _roster()
+    reqs = [
+        make_request("p1", requester=100, requestee=200, request_type="bunk_with", source_field="bunk_request_form"),
+        make_request(
+            "n1", requester=200, requestee=100, request_type="not_bunk_with", source_field="bunk_request_form"
+        ),
+        make_request("p2", requester=200, requestee=1000, request_type="bunk_with", source_field="bunk_request_form"),
+    ]
+    solver = DirectBunkingSolver(make_input(persons, bunks, reqs), mock_config)
+    cp, status = _solve(solver)
+    assert is_optimal_or_feasible(status)
+    assert solver.parent_nbw_yields == []
+
+
+def test_no_yield_when_positive_camper_has_a_second_mp(mock_config):
+    # Emma has bunk_with Liam AND bunk_with a filler -> Emma's MSO is satisfiable
+    # without Liam, so Liam's sole-MP NBW holds: pair apart, no yield.
+    persons, bunks = _roster()
+    reqs = [
+        make_request("p1", requester=100, requestee=200, request_type="bunk_with", source_field="bunk_request_form"),
+        make_request("p2", requester=100, requestee=1000, request_type="bunk_with", source_field="bunk_request_form"),
+        make_request(
+            "n1", requester=200, requestee=100, request_type="not_bunk_with", source_field="bunk_request_form"
+        ),
+    ]
+    solver = DirectBunkingSolver(make_input(persons, bunks, reqs), mock_config)
+    cp, status = _solve(solver)
+    assert is_optimal_or_feasible(status)
+    assert solver.parent_nbw_yields == []
+    assert _bunk_idx(solver, cp, 100) != _bunk_idx(solver, cp, 200)  # NBW honored


### PR DESCRIPTION
## Summary

Stream C of the staff-hard-not-bunk-with family (Stream A #1643, Stream B #1656).

Today every parent-form request — `bunk_with`, `not_bunk_with`, `age` — is `HARD_MSO`: each camper's *sole* Material-Parent (MP) wish is guaranteed via `parent_paramount`'s must-satisfy-one. When two campers' sole MP wishes **directly contradict** — A's parent says "bunk A with B", B's parent says "do **not** bunk B with A" — the two MSOs are mutually exclusive and the solve dead-ends as **infeasible** with no auto-resolution.

This PR makes the **positive request win**: the `not_bunk_with` yields (the pair is co-placed), the yield is recorded, and it's surfaced for staff review — instead of dead-ending.

## The exact trigger (both-sole, directly opposing)

A parent `not_bunk_with` between {A, B} yields **only when both** hold:
1. the NBW is **A's only** possible MP request, **and**
2. B has a parent `bunk_with` toward A that is **B's only** possible MP request.

Any other shape is already feasible (the non-sole side degrades to soft naturally), so no yield fires. Mirrors the existing staff carve-out `staff_separation._mso_protection_applies`.

## Mechanism

Detect-and-relax inside `parent_paramount.add_must_satisfy_one_request_constraints`: a new `_parent_nbw_yield_record` helper identifies the loser; the caller **skips that camper's MSO** (dropping the NBW) so the winner's `bunk_with` MSO co-places the pair, and appends a record to a new `ctx.parent_nbw_yields`. The contradiction never enters the model, so the hard-MSO localizer no longer trips on it (it still fires for genuine infeasibilities — capacity, 3-way chains).

## Surfacing — distinct rose card, success only

`ctx.parent_nbw_yields` → name-resolved `parent_nbw_yielded` in the request-validation summary → a **distinct rose advisory card** (lucide `ShieldAlert`) in the solver-success modal, separate from the amber staff-yield card. A parent yield can only occur on a solve the yield itself made feasible, so there is **no failure-path rendering**.

**Safety note:** unlike the staff carve-out (staff < parent, cross-tier), this is *same-tier* — one parent's wish overrides another's, and a "do-not-bunk" can encode a real conflict. The higher-stakes rose card exists so staff reliably catch and can reverse a bad auto-pairing.

## Scope

- Direct pairwise contradictions only (no 3-way chains).
- Hardcoded behavior, no config toggle — consistent with how the staff carve-out shipped.

## Tests (TDD — written + verified failing first)

- **Solver** (`tests/unit/solver/test_parent_nbw_yield_wiring.py`): clean solve exposes empty yield list; both-sole opposing pair → co-placed + exactly one recorded yield; non-trigger when the NBW camper has a second MP; non-trigger when the positive camper has a second MP (separation honored).
- **Frontend** (`SolverProgressModal.test.tsx`): rose card renders when `parent_separation_yields` present; omitted when empty.
- No regression across `test_parent_paramount_diagnostic.py`, `test_hard_mso_localization.py`, `test_staff_separation_wiring.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Solver reports when a parent's "do not bunk" request is overridden by another parent's "bunk together" request; counts and detailed lists are surfaced in results.
  * Completion UI shows a warning card listing each parent separation that was overridden, with camper names and context.

* **Tests**
  * Added end-to-end tests covering parent do-not-bunk override scenarios and expected reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->