### PR TITLE
fix(solver): age-preference is material only as a sole request (#1664)

### DIFF
--- a/bunking/satisfaction/bucket.py
+++ b/bunking/satisfaction/bucket.py
@@ -50,7 +50,9 @@ def is_material_parent_request(request: DirectBunkRequest) -> bool:
     """True iff the request's source_field classifies as MATERIAL_PARENT.
 
     Defensive: missing or unknown source_field returns False with a debug log.
-    Used by the solver hard constraint and the post-solve diagnostic.
+    Called by ``compute_material_request_ids``; solver constraints and the
+    post-solve diagnostic read the resulting ``material_request_ids`` set rather
+    than calling this directly, so the #1664 age-preference suppression applies.
     """
     sf = request.source_field
     if not sf:

--- a/bunking/satisfaction/bucket.py
+++ b/bunking/satisfaction/bucket.py
@@ -27,7 +27,13 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-__all__ = ["COUNTED_BUCKETS", "RequestBucket", "classify_request", "is_material_parent_request"]
+__all__ = [
+    "COUNTED_BUCKETS",
+    "RequestBucket",
+    "classify_request",
+    "compute_material_request_ids",
+    "is_material_parent_request",
+]
 
 
 def classify_request(source_field: str) -> RequestBucket:
@@ -58,6 +64,56 @@ def is_material_parent_request(request: DirectBunkRequest) -> bool:
             getattr(request, "id", "<unknown>"),
         )
         return False
+
+
+def compute_material_request_ids(
+    requests_by_person: dict[int, list[DirectBunkRequest]],
+    impossible_request_ids: set[str],
+) -> set[str]:
+    """Material-parent request IDs, with the #1664 age-preference suppression.
+
+    A request is material when ``is_material_parent_request`` is True (source →
+    MATERIAL_PARENT bucket; only ``bunk_request_form`` qualifies — ``manual`` and
+    the note sources are STAFF, ``socialize_with`` is IMMATERIAL_PARENT). The ONE
+    exception (#1664): a ``bunk_request_form`` AGE_PREFERENCE is dropped when its
+    requester also has a resolved-and-possible ``bunk_request_form``
+    BUNK_WITH/NOT_BUNK_WITH. When the only real form request(s) are impossible or
+    unresolved, the age-preference reverts to material (the child's sole viable
+    parent ask).
+
+    The output is NOT filtered by status/possibility: ``r.id in result`` is
+    equivalent to ``is_material_parent_request(r)`` for every non-suppressed
+    request, so consumers (including the entirely-impossible-MP rollup, which
+    must see impossible material requests) behave identically. The
+    resolved-and-possible test is applied ONLY when deciding suppression.
+
+    ``impossible_request_ids`` is the request-id set from the shared
+    ImpossibilityReport — the same "possible" determination used everywhere.
+    """
+    from bunking.sync.bunk_request_processor.core.models import RequestType  # noqa: PLC0415
+    from bunking.sync.bunk_request_processor.shared.constants import SourceField  # noqa: PLC0415
+
+    real_types = (RequestType.BUNK_WITH.value, RequestType.NOT_BUNK_WITH.value)
+    material: set[str] = set()
+    for reqs in requests_by_person.values():
+        has_possible_real_form_request = any(
+            r.source_field == SourceField.BUNK_REQUEST_FORM
+            and r.request_type in real_types
+            and r.status == "resolved"
+            and r.id not in impossible_request_ids
+            for r in reqs
+        )
+        for r in reqs:
+            if not is_material_parent_request(r):
+                continue
+            if (
+                r.request_type == RequestType.AGE_PREFERENCE.value
+                and r.source_field == SourceField.BUNK_REQUEST_FORM
+                and has_possible_real_form_request
+            ):
+                continue  # #1664: immaterial when a real form request is satisfiable
+            material.add(r.id)
+    return material
 
 
 def is_counted_request(request: DirectBunkRequest) -> bool:

--- a/bunking/satisfaction/request_registry.py
+++ b/bunking/satisfaction/request_registry.py
@@ -17,8 +17,8 @@ import (raises if a source's rows disagree).
     (a strict source paired with a request_type it doesn't admit) is a
     pipeline-hygiene bug and we want it to fail loudly.
   * `rule == HARD_MNT` is a DECLARED placeholder for deferred staff-hardening
-    (#1543 / #1541); it is not enforced. `parent_paramount` still detects MP via
-    `is_material_parent_request` (report_group == MATERIAL_PARENT).
+    (#1543 / #1541); it is not enforced. `parent_paramount` detects MP via
+    the contextual material set (`compute_material_request_ids`).
 """
 
 from __future__ import annotations

--- a/bunking/solver/constraints/base.py
+++ b/bunking/solver/constraints/base.py
@@ -103,6 +103,13 @@ class SolverContext:
     # into request_validation_summary["parent_nbw_yielded"].
     parent_nbw_yields: list[dict[str, Any]] = field(default_factory=list)
 
+    # Material-parent request IDs after the #1664 age-preference suppression
+    # (compute_material_request_ids). Single source of truth for "is this
+    # request MSO-material in context" — read by parent_paramount, the
+    # impossibility rollup, the post-solve diagnostic, the staff-separation
+    # carve-out, and the IIS localizer instead of per-request is_material_parent_request.
+    material_request_ids: set[str] = field(default_factory=set)
+
     # Canonical per-request satisfaction vars for bunk_with / not_bunk_with
     # requests, keyed by request.id. Built + memoized by
     # get_or_create_request_sat_var (bunk_requests.py); shared so add_objective

--- a/bunking/solver/constraints/parent_paramount.py
+++ b/bunking/solver/constraints/parent_paramount.py
@@ -4,12 +4,12 @@ Parent Paramount Constraints — Hard must-satisfy-one for Material-Parent reque
 This module enforces that every camper with at least one possible Material-Parent
 (MP) request has at least one of those requests satisfied — as a HARD constraint.
 
-"Material-Parent" is determined by the request's source-field bucket (via
-``bunking.satisfaction.bucket.is_material_parent_request``), not the request
-type. A request of any type (bunk_with, not_bunk_with, age_preference) is MP
-iff its source_field classifies as MATERIAL_PARENT. Age preference requests
-that come from socialize-with sources are NOT MP and don't count toward this
-constraint.
+"Material-Parent" is determined by ``ctx.material_request_ids`` (pre-computed
+by ``bunking.satisfaction.bucket.compute_material_request_ids`` in
+``_validate_requests``), not per-request classification at build time.
+``material_request_ids`` applies the #1664 age-preference suppression: a form
+AGE_PREFERENCE is excluded from the material set when its requester already
+has a resolved-and-possible form BUNK_WITH/NOT_BUNK_WITH.
 
 Mechanism:
   * For each MP-having camper, build (or borrow) one forcing indicator per MP
@@ -33,7 +33,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from bunking.logging_config import get_logger
-from bunking.satisfaction.bucket import is_material_parent_request
 from bunking.sync.bunk_request_processor.core.models import RequestType
 
 from .age_preference import add_age_preference_satisfaction_vars
@@ -123,7 +122,7 @@ def add_must_satisfy_one_request_constraints(ctx: SolverContext) -> None:
             continue
 
         for r in possible_reqs:
-            if not is_material_parent_request(r):
+            if r.id not in ctx.material_request_ids:
                 continue
             if r.request_type in (RequestType.BUNK_WITH.value, RequestType.NOT_BUNK_WITH.value):
                 mp_bunk_requests_by_person.setdefault(cm_id, []).append(r)

--- a/bunking/solver/constraints/staff_separation.py
+++ b/bunking/solver/constraints/staff_separation.py
@@ -47,10 +47,8 @@ def _is_hard_mnt(request: DirectBunkRequest) -> bool:
 
 
 def _possible_mp_count(ctx: SolverContext, cm_id: int) -> int:
-    """Number of possible Material-Parent requests for a camper."""
-    from bunking.satisfaction.bucket import is_material_parent_request  # noqa: PLC0415
-
-    return sum(1 for r in ctx.possible_requests.get(cm_id, []) if is_material_parent_request(r))
+    """Number of possible Material-Parent requests for a camper (#1664-aware)."""
+    return sum(1 for r in ctx.possible_requests.get(cm_id, []) if r.id in ctx.material_request_ids)
 
 
 def _mso_protection_applies(ctx: SolverContext, subject_cm: int, target_cm: int) -> dict[str, Any] | None:
@@ -60,14 +58,12 @@ def _mso_protection_applies(ctx: SolverContext, subject_cm: int, target_cm: int)
     has exactly one possible MP request (this one). Either direction qualifies.
     Returns the yield detail (protected_*) for ctx.staff_nbw_yields, or None.
     """
-    from bunking.satisfaction.bucket import is_material_parent_request  # noqa: PLC0415
-
     pair = {subject_cm, target_cm}
     for requester_cm in (subject_cm, target_cm):
         for r in ctx.possible_requests.get(requester_cm, []):
             if r.request_type != RequestType.BUNK_WITH.value:
                 continue
-            if not is_material_parent_request(r):
+            if r.id not in ctx.material_request_ids:  # was: if not is_material_parent_request(r)
                 continue
             if {r.requester_person_cm_id, r.requested_person_cm_id} != pair:
                 continue

--- a/bunking/solver/constraints/staff_separation.py
+++ b/bunking/solver/constraints/staff_separation.py
@@ -63,7 +63,7 @@ def _mso_protection_applies(ctx: SolverContext, subject_cm: int, target_cm: int)
         for r in ctx.possible_requests.get(requester_cm, []):
             if r.request_type != RequestType.BUNK_WITH.value:
                 continue
-            if r.id not in ctx.material_request_ids:  # was: if not is_material_parent_request(r)
+            if r.id not in ctx.material_request_ids:
                 continue
             if {r.requester_person_cm_id, r.requested_person_cm_id} != pair:
                 continue

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -1190,9 +1190,7 @@ class DirectBunkingSolver:
             # below, which skips campers with >=1 satisfied request.
             satisfied_ids_for_person: set[str] = set(all_satisfied.get(person_cm_id, []))
 
-            resolved_mp = [
-                r for r in resolved_requests if r.id in self.material_request_ids
-            ]  # was: if is_material_parent_request(r)
+            resolved_mp = [r for r in resolved_requests if r.id in self.material_request_ids]
             resolved_possible_mp = [r for r in resolved_mp if r.id not in impossible_request_ids]
             resolved_possible = [r for r in resolved_requests if r.id not in impossible_request_ids]
 
@@ -1227,9 +1225,7 @@ class DirectBunkingSolver:
 
             resolved_possible = [r for r in self.possible_requests.get(person_cm_id, []) if r.status == "resolved"]
             resolved_possible_count[person_cm_id] = len(resolved_possible)
-            if any(
-                r.id in self.material_request_ids for r in resolved_possible
-            ):  # was: if any(is_material_parent_request(r) for r in resolved_possible)
+            if any(r.id in self.material_request_ids for r in resolved_possible):
                 material_parent_unmet.append(person_cm_id)
             else:
                 other_unmet.append(person_cm_id)

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -23,7 +23,7 @@ from bunking.models_v2 import (
 )
 from bunking.satisfaction import weight_for
 from bunking.satisfaction.batch import satisfied_request_ids_by_person
-from bunking.satisfaction.bucket import RequestBucket, is_counted_request, is_material_parent_request
+from bunking.satisfaction.bucket import RequestBucket, is_counted_request
 from bunking.sync.bunk_request_processor.core.models import RequestType
 from campminder.client import get_current_season
 
@@ -1190,7 +1190,9 @@ class DirectBunkingSolver:
             # below, which skips campers with >=1 satisfied request.
             satisfied_ids_for_person: set[str] = set(all_satisfied.get(person_cm_id, []))
 
-            resolved_mp = [r for r in resolved_requests if is_material_parent_request(r)]
+            resolved_mp = [
+                r for r in resolved_requests if r.id in self.material_request_ids
+            ]  # was: if is_material_parent_request(r)
             resolved_possible_mp = [r for r in resolved_mp if r.id not in impossible_request_ids]
             resolved_possible = [r for r in resolved_requests if r.id not in impossible_request_ids]
 
@@ -1225,7 +1227,9 @@ class DirectBunkingSolver:
 
             resolved_possible = [r for r in self.possible_requests.get(person_cm_id, []) if r.status == "resolved"]
             resolved_possible_count[person_cm_id] = len(resolved_possible)
-            if any(is_material_parent_request(r) for r in resolved_possible):
+            if any(
+                r.id in self.material_request_ids for r in resolved_possible
+            ):  # was: if any(is_material_parent_request(r) for r in resolved_possible)
                 material_parent_unmet.append(person_cm_id)
             else:
                 other_unmet.append(person_cm_id)

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -180,6 +180,10 @@ class DirectBunkingSolver:
         # request_validation_summary["parent_nbw_yielded"].
         self.parent_nbw_yields: list[dict[str, Any]] = []
 
+        # Material-parent request IDs after the #1664 age-preference suppression.
+        # Populated by _validate_requests via compute_material_request_ids.
+        self.material_request_ids: set[str] = set()
+
         # Canonical per-request satisfaction vars (bunk_with / not_bunk_with),
         # keyed by request.id. Populated by get_or_create_request_sat_var via
         # parent_paramount and add_objective; one shared var per request.
@@ -232,6 +236,7 @@ class DirectBunkingSolver:
             mp_set_entirely_impossible=self.mp_set_entirely_impossible,
             staff_nbw_yields=self.staff_nbw_yields,
             parent_nbw_yields=self.parent_nbw_yields,
+            material_request_ids=self.material_request_ids,
             mp_skip_cms=self.mp_skip_cms,
             request_satisfied_vars=self.request_satisfied_vars,
         )
@@ -316,6 +321,10 @@ class DirectBunkingSolver:
         )
         self.impossibility_report = report
         impossible_request_ids: set[str] = {item.request_id for item in report.flat}
+
+        from bunking.satisfaction.bucket import compute_material_request_ids  # noqa: PLC0415
+
+        self.material_request_ids = compute_material_request_ids(self.input.requests_by_person, impossible_request_ids)
 
         # Camper-level rollup of entirely-impossible MP sets — single source of
         # truth (computed in validate_impossibility). parent_paramount no longer

--- a/bunking/solver/feasibility.py
+++ b/bunking/solver/feasibility.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Any, TypedDict
 from ortools.sat.python import cp_model
 
 from bunking.logging_config import get_logger
-from bunking.satisfaction.bucket import is_material_parent_request
 from bunking.solver.constants import MAX_AGE_SPREAD_MONTHS, MAX_UNIQUE_GRADES_PER_BUNK
 from bunking.solver.constraints.age_spread import _age_to_months
 
@@ -517,7 +516,7 @@ def localize_hard_mso_infeasibility(
     candidate_cms = sorted(
         cm
         for cm, possible in probe.possible_requests.items()
-        if cm not in excluded and any(is_material_parent_request(r) for r in possible)
+        if cm not in excluded and any(r.id in probe.material_request_ids for r in possible)
     )
 
     logger.info(f"  Candidate MP-hard-constrained cms: {len(candidate_cms)}")

--- a/bunking/solver/impossibility.py
+++ b/bunking/solver/impossibility.py
@@ -25,7 +25,7 @@ from typing import Any, NamedTuple
 from bunking.config import ConfigLoader
 from bunking.logging_config import get_logger
 from bunking.models_v2 import DirectBunk, DirectBunkRequest, DirectPerson, DirectSolverInput
-from bunking.satisfaction.bucket import RequestBucket, classify_request, is_material_parent_request
+from bunking.satisfaction.bucket import RequestBucket, classify_request
 
 logger = get_logger(__name__)
 
@@ -177,7 +177,7 @@ def _record_item(
     requester = ctx.person_by_cm_id.get(req.requester_person_cm_id)
     requestee = ctx.person_by_cm_id.get(req.requested_person_cm_id) if req.requested_person_cm_id else None
 
-    # Bucket classification with safe fallback (mirrors is_material_parent_request precedent).
+    # Bucket classification with safe fallback (mirrors the precedent in classify_request callers).
     # An unknown source_field surfaces as bucket=None — the modal renders these in an
     # "Unbucketed" section so they're still visible but flagged as a data-hygiene gap.
     bucket: str | None = None
@@ -284,6 +284,11 @@ def validate_impossibility(input_data: DirectSolverInput, config: ConfigLoader) 
     # constraint. Pure derived property of `flat` — single source of truth for
     # both parent_paramount and the pre-validate endpoint.
     impossible_ids = {item.request_id for item in report.flat}
+
+    from bunking.satisfaction.bucket import compute_material_request_ids  # noqa: PLC0415
+
+    material_ids = compute_material_request_ids(input_data.requests_by_person, impossible_ids)
+
     reasons_by_request: dict[str, set[str]] = defaultdict(set)
     for item in report.flat:
         reasons_by_request[item.request_id].add(item.reason_code)
@@ -292,7 +297,7 @@ def validate_impossibility(input_data: DirectSolverInput, config: ConfigLoader) 
         person = ctx.person_by_cm_id.get(cm_id)
         if person is None:
             continue  # requester not in the roster — out of scope
-        mp_requests = [r for r in requests if is_material_parent_request(r)]
+        mp_requests = [r for r in requests if r.id in material_ids]
         if not mp_requests:
             continue
         if not all(r.id in impossible_ids for r in mp_requests):

--- a/tests/integration/solver/fixtures.py
+++ b/tests/integration/solver/fixtures.py
@@ -18,15 +18,57 @@ The two camper groups therefore land in different bunks in every feasible
 solution, which fixes the satisfied/unsatisfied outcome of every request the
 alignment test asserts on.
 
-``build_age_preference_alignment_fixture`` — age_preference coverage (#1433).
-Mixed-grade roster so age_preference requests have non-trivial outcomes.
-Determinism levers:
-  * 16 female campers split CLIQUE {cm_id 1 grade 5, 2..8 grade 6} and
-    OTHER {cm_id 9 grade 7, 10..16 grade 6}. MP bunk_with requests 2..8 -> 1
-    and 10..16 -> 9 force the two clusters into separate bunks. Grade gaps
-    of 1 satisfy GradeCompatibilityImpossibility (max_gap = max_spread - 1 = 1
-    under mock_config).
-  * Two bunks, capacity 8, MIN_BUNK_OCCUPANCY=8 -> exactly 8 per bunk.
+``build_age_preference_alignment_fixture`` — age_preference coverage (#1433),
+reshaped for the #1664 materiality rule.
+
+  #1664 — a ``bunk_request_form`` AGE_PREFERENCE is Material-Parent (gets an MSO
+  satvar via ``add_age_preference_satisfaction_vars`` → lands in
+  ``request_satisfied_vars``) ONLY IF its requester has no resolved-and-possible
+  ``bunk_request_form`` BUNK_WITH/NOT_BUNK_WITH. If the requester also carries a
+  satisfiable real form request, ``compute_material_request_ids`` suppresses the
+  age-pref (immaterial) and it gets NO satvar. So an age-pref camper that I want
+  to assert satisfaction on must NOT have a bunk_with of its OWN — otherwise it
+  is suppressed and never reaches the satvar map.
+
+  Why the old "unsatisfied material age-pref" case is GONE (not just relocated):
+  parent_paramount's hard must-satisfy-ONE forces at least one of a camper's MP
+  requests satisfied. A *material* age-pref, by #1664's own definition, is the
+  requester's ONLY material request (any satisfiable form bunk_with would have
+  suppressed it). So a material age-pref is its camper's sole MSO term and is
+  ALWAYS forced satisfied in any feasible solve — a deterministically-UNSATISFIED
+  material age-pref is structurally impossible under #1664. The previous fixture's
+  ``apref_realunsat`` relied on cm_10 ALSO carrying a satisfiable cohesion
+  bunk_with to absorb the MSO obligation, freeing the age-pref to go unsatisfied;
+  that exact shape is now what #1664 suppresses.
+
+  So the fixture's non-trivial coverage is preserved two ways:
+    1. A real, non-trivially-SATISFIED material age-pref on an age-pref-only
+       camper (cm_5), deterministically pinned to a bunk that lacks the bad grade
+       — exercises the satvar↔predicate alignment binding on a true satvar whose
+       outcome turns on bunk membership, not on the roster (the trivsat anchors
+       are satisfied regardless of placement).
+    2. The #1664 suppression itself: cm_13 carries BOTH a satisfiable cohesion
+       bunk_with AND a form age-pref; its age-pref is suppressed (NO satvar). The
+       tests assert that suppressed id is absent from request_satisfied_vars while
+       its bunk_with satvar is present — directly covering the rule this PR adds.
+
+Determinism levers (all hard constraints):
+  * 16 female campers, two bunks (capacity 8, MIN_BUNK_OCCUPANCY=8, 16 == 8*2
+    forces all-used) -> exactly 8 per bunk.
+  * MAX_UNIQUE_GRADES_PER_BUNK=2 caps each bunk at 2 distinct grades; max_gap=1
+    (max_spread-1 under mock_config) caps any bunk_with's grade gap at 1.
+  * Bunk A holds grades {5, 6}, Bunk B holds grades {6, 7}. The four grade-5
+    campers can only live with grade 6 (grade-5 + grade-7 = span 2, forbidden),
+    so they are grade-pinned to Bunk A; the four grade-7 campers are grade-pinned
+    to Bunk B. That fixes which bunk is "A" (the grade-5 bunk) vs "B".
+  * Pinning the age-pref-only SAT camper cm_5 (grade 6 fits BOTH bunks, so grade
+    alone won't pin it, and it has no bunk_with of its own to ride a cohesion
+    edge): a *grade-pinned puller* requests it. cm_2 (grade 5, pinned to A)
+    ``bunk_with`` -> cm_5 forces cm_5 into A. The puller owns the bunk_with (its
+    own age-pref, if any, would be the suppressed one — pullers have none), while
+    the pulled age-pref camper stays material under #1664.
+  * The suppression demonstrator cm_13 (grade 6) is pinned to B by its OWN
+    cohesion bunk_with -> cm_9 (grade 7, pinned to B).
 
 Avoids the mixed-grade case (has_older AND has_younger) — see
 AGE_PREF_EXPECTED_SATISFACTION's note on the solver/predicate semantic gap.
@@ -190,16 +232,56 @@ def build_alignment_fixture() -> DirectSolverInput:
     return make_input(persons, bunks, requests)
 
 
-# Mixed-grade roster for age_preference alignment. Grade gaps of 1 stay
-# within GradeCompatibilityImpossibility's max_gap=1 (max_spread=2 in mock_config).
-#   CLIQUE = {cm_id 1 grade 5, cm_ids 2..8 grade 6}
-#   OTHER  = {cm_id 9 grade 7, cm_ids 10..16 grade 6}
-AGE_CLIQUE_ANCHOR = 1  # grade 5
-AGE_CLIQUE_REQUESTERS = list(range(2, 9))  # 2..8, grade 6
-AGE_OTHER_ANCHOR = 9  # grade 7
-AGE_OTHER_REQUESTERS = list(range(10, 17))  # 10..16, grade 6
+# Roster for age_preference alignment, reshaped for #1664 (see module docstring).
+# Bunk A holds grades {5, 6}; Bunk B holds grades {6, 7}. Grade-5 campers are
+# grade-pinned to A and grade-7 campers to B (a {5,7} or {5,6,7} bunk exceeds
+# MAX_UNIQUE_GRADES_PER_BUNK=2 / max_gap=1). All bunk_with gaps are <= 1, so
+# none are dropped by GradeCompatibilityImpossibility.
+#
+#   Bunk A (grades {5,6}, 8 campers):
+#     cm_1  g5  age-pref "older"  (age-pref-only, MATERIAL — no bunk_with)
+#     cm_2  g5  puller: bunk_with -> cm_5 (pins cm_5 into A)
+#     cm_3  g5  filler: bunk_with -> cm_1
+#     cm_4  g5  filler: bunk_with -> cm_1
+#     cm_5  g6  age-pref "younger" (age-pref-only, MATERIAL — non-trivial SAT)
+#     cm_6  g6  filler: bunk_with -> cm_1
+#     cm_7  g6  filler: bunk_with -> cm_1
+#     cm_8  g6  filler: bunk_with -> cm_1
+#   Bunk B (grades {6,7}, 8 campers):
+#     cm_9  g7  age-pref "younger" (age-pref-only, MATERIAL — no bunk_with)
+#     cm_10 g7  filler: bunk_with -> cm_9
+#     cm_11 g7  filler: bunk_with -> cm_9
+#     cm_12 g7  filler: bunk_with -> cm_9
+#     cm_13 g6  bunk_with -> cm_9 (satisfiable) AND age-pref "younger"
+#               -> #1664 SUPPRESSES the age-pref (no satvar); bunk_with keeps one
+#     cm_14 g6  filler: bunk_with -> cm_9
+#     cm_15 g6  filler: bunk_with -> cm_9
+#     cm_16 g6  filler: bunk_with -> cm_9
+AGE_A_ANCHOR = 1  # grade 5, age-pref "older"
+AGE_A_G5_PULLER = 2  # grade 5, bunk_with -> cm_5
+AGE_A_G5_FILLERS = [3, 4]  # grade 5, bunk_with -> cm_1
+AGE_A_REALSAT = 5  # grade 6, age-pref "younger" (non-trivial SAT, pinned to A)
+AGE_A_G6_FILLERS = [6, 7, 8]  # grade 6, bunk_with -> cm_1
+AGE_B_ANCHOR = 9  # grade 7, age-pref "younger"
+AGE_B_G7_FILLERS = [10, 11, 12]  # grade 7, bunk_with -> cm_9
+AGE_B_SUPPRESSED = 13  # grade 6, bunk_with -> cm_9 + age-pref "younger" (suppressed)
+AGE_B_G6_FILLERS = [14, 15, 16]  # grade 6, bunk_with -> cm_9
 
 # Forced satisfaction outcomes for the age_preference alignment fixture.
+#
+# Materiality note (#1664): only age-pref-only campers (no bunk_with of their
+# own) keep an age_preference satvar. Each entry below is such a camper. The
+# fillers' bunk_with requests are MATERIAL too and DO get satvars — but they are
+# bunk_with, not age_preference, and the two age-pref tests only iterate this
+# map, so they are intentionally absent here.
+#
+# Why every entry is True (no unsatisfied case): parent_paramount's hard
+# must-satisfy-ONE forces a camper's sole material request satisfied, and a
+# material age-pref is — by #1664's own definition — its camper's only material
+# request. So a material age-pref is ALWAYS satisfied in a feasible solve; a
+# deterministically-unsatisfied material age-pref is structurally impossible
+# here. The lost "unsatisfied" coverage is replaced by AGE_PREF_SUPPRESSED_IDS
+# (the #1664 suppression assertion) below.
 #
 # Solver/predicate agreement note: the solver encoding treats "older" as
 # "no younger bunkmate" (and symmetric for "younger"). The post-solve predicate
@@ -210,28 +292,45 @@ AGE_OTHER_REQUESTERS = list(range(10, 17))  # 10..16, grade 6
 # the gap matters only if/when the age_preference sat_var becomes an objective
 # term and is documented in the PR description.
 AGE_PREF_EXPECTED_SATISFACTION: dict[str, bool] = {
-    # Trivially satisfied — no grade < 5 exists in roster.
+    # cm_1 (g5) "older": no grade < 5 exists anywhere -> trivially sat.
     "apref_trivsat_g5_older": True,
-    # Trivially satisfied — no grade > 7 exists in roster.
+    # cm_9 (g7) "younger": no grade > 7 exists anywhere -> trivially sat.
     "apref_trivsat_g7_younger": True,
-    # CLIQUE has no grade 7 -> bunk_is_clean -> sat.
+    # cm_5 (g6) "younger" pinned to Bunk A: Bunk A has no grade 7 (grade 7 lives
+    # only in Bunk B) -> no older bunkmate -> SAT. Non-trivial: the outcome turns
+    # on cm_5 being separated from the grade-7 campers (must-satisfy-one then
+    # binds the satvar to that clean placement), not on the roster as a whole.
     "apref_realsat_g6_younger": True,
-    # OTHER has grade 7 (cm_id 9) -> bunk dirty -> unsat.
-    "apref_realunsat_g6_younger": False,
 }
+
+# #1664 suppression: cm_13 carries BOTH a satisfiable cohesion bunk_with AND a
+# form age-pref. compute_material_request_ids drops the age-pref (immaterial), so
+# it never reaches add_age_preference_satisfaction_vars and gets NO satvar. The
+# tests assert this id is ABSENT from request_satisfied_vars while cm_13's
+# bunk_with (a real material request) IS present — the heart of this PR.
+AGE_PREF_SUPPRESSED_IDS: frozenset[str] = frozenset({"apref_suppressed_g6_younger"})
+
+# cm_13's coexisting (satisfiable, possible) bunk_with — present in the satvar
+# map even though its age-pref sibling is suppressed.
+AGE_PREF_SUPPRESSED_REQUESTER_BW_ID = "mp_b_filler_13"
 
 
 def build_age_preference_alignment_fixture() -> DirectSolverInput:
     """Build the age_preference satvar <-> predicate alignment scenario.
 
-    See module docstring for the determinism rationale and AGE_PREF_EXPECTED_
-    SATISFACTION for the deliberately-avoided mixed-grade case.
+    See module docstring for the determinism + #1664-materiality rationale and
+    AGE_PREF_EXPECTED_SATISFACTION for the deliberately-avoided mixed-grade case.
     """
     persons = [
-        make_person(AGE_CLIQUE_ANCHOR, session=SESSION, gender="F", grade=5),
-        *(make_person(cm_id, session=SESSION, gender="F", grade=6) for cm_id in AGE_CLIQUE_REQUESTERS),
-        make_person(AGE_OTHER_ANCHOR, session=SESSION, gender="F", grade=7),
-        *(make_person(cm_id, session=SESSION, gender="F", grade=6) for cm_id in AGE_OTHER_REQUESTERS),
+        make_person(AGE_A_ANCHOR, session=SESSION, gender="F", grade=5),
+        make_person(AGE_A_G5_PULLER, session=SESSION, gender="F", grade=5),
+        *(make_person(cm_id, session=SESSION, gender="F", grade=5) for cm_id in AGE_A_G5_FILLERS),
+        make_person(AGE_A_REALSAT, session=SESSION, gender="F", grade=6),
+        *(make_person(cm_id, session=SESSION, gender="F", grade=6) for cm_id in AGE_A_G6_FILLERS),
+        make_person(AGE_B_ANCHOR, session=SESSION, gender="F", grade=7),
+        *(make_person(cm_id, session=SESSION, gender="F", grade=7) for cm_id in AGE_B_G7_FILLERS),
+        make_person(AGE_B_SUPPRESSED, session=SESSION, gender="F", grade=6),
+        *(make_person(cm_id, session=SESSION, gender="F", grade=6) for cm_id in AGE_B_G6_FILLERS),
     ]
 
     bunks = [
@@ -241,68 +340,90 @@ def build_age_preference_alignment_fixture() -> DirectSolverInput:
 
     requests = []
 
-    # MP bunk_with cohesion: forces CLIQUE and OTHER into separate bunks.
-    for cm_id in AGE_CLIQUE_REQUESTERS:
-        requests.append(
-            make_request(
-                f"mp_clique_{cm_id}",
-                requester=cm_id,
-                requestee=AGE_CLIQUE_ANCHOR,
-                request_type="bunk_with",
-                source_field=MP_SOURCE,
-                session=SESSION,
-            )
+    # --- Bunk A cohesion (all MP bunk_with) ---
+    # Puller cm_2 (grade 5, grade-pinned to A) drags the SAT age-pref camper cm_5
+    # into A. cm_2 owns this bunk_with, so cm_5 has no request of its own and
+    # stays material under #1664.
+    requests.append(
+        make_request(
+            "mp_a_puller_5",
+            requester=AGE_A_G5_PULLER,
+            requestee=AGE_A_REALSAT,
+            request_type="bunk_with",
+            source_field=MP_SOURCE,
+            session=SESSION,
         )
-    for cm_id in AGE_OTHER_REQUESTERS:
+    )
+    # Grade-5 and grade-6 fillers ride cohesion edges to the grade-5 anchor cm_1.
+    for cm_id in AGE_A_G5_FILLERS + AGE_A_G6_FILLERS:
         requests.append(
             make_request(
-                f"mp_other_{cm_id}",
+                f"mp_a_filler_{cm_id}",
                 requester=cm_id,
-                requestee=AGE_OTHER_ANCHOR,
+                requestee=AGE_A_ANCHOR,
                 request_type="bunk_with",
                 source_field=MP_SOURCE,
                 session=SESSION,
             )
         )
 
-    # Age-preference assertion targets — all MP (source_field=MP_SOURCE) so
-    # they pass through add_age_preference_satisfaction_vars and land in
-    # request_satisfied_vars after the #1433 refactor.
+    # --- Bunk B cohesion (all MP bunk_with) ---
+    # Every grade-7 filler and grade-6 camper (incl. the suppression demonstrator
+    # cm_13) rides a cohesion edge to the grade-7 anchor cm_9. cm_13's bunk_with
+    # is what makes its sibling age-pref immaterial under #1664.
+    for cm_id in AGE_B_G7_FILLERS + [AGE_B_SUPPRESSED] + AGE_B_G6_FILLERS:
+        requests.append(
+            make_request(
+                f"mp_b_filler_{cm_id}",
+                requester=cm_id,
+                requestee=AGE_B_ANCHOR,
+                request_type="bunk_with",
+                source_field=MP_SOURCE,
+                session=SESSION,
+            )
+        )
+
+    # --- Age-preference targets ---
     requests += [
-        # cm_id 1 (grade 5) "older": no grade < 5 exists -> trivially sat.
+        # cm_1 (grade 5) "older", age-pref-only -> MATERIAL. No grade < 5 exists
+        # -> trivially sat.
         make_request(
             "apref_trivsat_g5_older",
-            requester=AGE_CLIQUE_ANCHOR,
+            requester=AGE_A_ANCHOR,
             requestee=None,
             request_type="age_preference",
             source_field=MP_SOURCE,
             age_preference_target="older",
             session=SESSION,
         ),
-        # cm_id 9 (grade 7) "younger": no grade > 7 exists -> trivially sat.
+        # cm_9 (grade 7) "younger", age-pref-only -> MATERIAL. No grade > 7 exists
+        # -> trivially sat.
         make_request(
             "apref_trivsat_g7_younger",
-            requester=AGE_OTHER_ANCHOR,
+            requester=AGE_B_ANCHOR,
             requestee=None,
             request_type="age_preference",
             source_field=MP_SOURCE,
             age_preference_target="younger",
             session=SESSION,
         ),
-        # cm_id 2 (grade 6) "younger" in CLIQUE: bad_grades={7}, CLIQUE has none -> sat.
+        # cm_5 (grade 6) "younger", age-pref-only -> MATERIAL. Pinned to Bunk A
+        # {5,6}: no grade 7 -> SAT (non-trivial).
         make_request(
             "apref_realsat_g6_younger",
-            requester=AGE_CLIQUE_REQUESTERS[0],
+            requester=AGE_A_REALSAT,
             requestee=None,
             request_type="age_preference",
             source_field=MP_SOURCE,
             age_preference_target="younger",
             session=SESSION,
         ),
-        # cm_id 10 (grade 6) "younger" in OTHER: bad_grades={7}, OTHER has cm_id 9 -> unsat.
+        # cm_13 (grade 6) "younger" — SUPPRESSED by #1664: cm_13 also has the
+        # satisfiable bunk_with mp_b_filler_13, so this age-pref is immaterial and
+        # gets NO satvar. Pinned (via that bunk_with) to Bunk B {6,7}.
         make_request(
-            "apref_realunsat_g6_younger",
-            requester=AGE_OTHER_REQUESTERS[0],
+            "apref_suppressed_g6_younger",
+            requester=AGE_B_SUPPRESSED,
             requestee=None,
             request_type="age_preference",
             source_field=MP_SOURCE,

--- a/tests/integration/solver/test_satvar_predicate_alignment.py
+++ b/tests/integration/solver/test_satvar_predicate_alignment.py
@@ -29,6 +29,8 @@ from bunking.satisfaction.predicate import is_request_satisfied
 from bunking.solver.direct_solver import DirectBunkingSolver
 from tests.integration.solver.fixtures import (
     AGE_PREF_EXPECTED_SATISFACTION,
+    AGE_PREF_SUPPRESSED_IDS,
+    AGE_PREF_SUPPRESSED_REQUESTER_BW_ID,
     BUILD_PATH_EXERCISERS,
     EXPECTED_SATISFACTION,
     build_age_preference_alignment_fixture,
@@ -177,11 +179,17 @@ def test_alignment_fixture_outcomes_are_deterministic(mock_config: Any) -> None:
 
 
 def test_age_preference_satvar_predicate_alignment(mock_config: Any) -> None:
-    """Every feasible MP age_preference sat var agrees with the predicate.
+    """Every MATERIAL MP age_preference sat var agrees with the predicate.
 
     #1433 — after the bidirectional refactor, age_preference sat vars are
     registered in ``DirectBunkingSolver.request_satisfied_vars`` and are
     bidirectionally bound to the post-solve satisfaction condition.
+
+    #1664 — a form age_preference is material (gets a sat var) ONLY when its
+    requester has no satisfiable form bunk_with/not_bunk_with. The fixture's
+    AGE_PREF_SUPPRESSED_IDS exercise that suppression: those age-prefs share a
+    requester with a satisfiable cohesion bunk_with and must NOT get a sat var,
+    while that requester's bunk_with still does.
     """
     solver, cp_solver = _build_and_solve(mock_config, build_age_preference_alignment_fixture)
     person_to_bunk = _person_to_bunk(solver, cp_solver)
@@ -189,12 +197,26 @@ def test_age_preference_satvar_predicate_alignment(mock_config: Any) -> None:
 
     sat_vars = solver.request_satisfied_vars
 
-    # Every expected age_preference request must have a sat var registered.
+    # Every expected (material) age_preference request must have a sat var.
     for req_id in AGE_PREF_EXPECTED_SATISFACTION:
         assert req_id in sat_vars, (
-            f"{req_id} (feasible MP age_preference) missing from request_satisfied_vars — "
+            f"{req_id} (material MP age_preference) missing from request_satisfied_vars — "
             f"the bidirectional refactor (#1433) is not wired into the shared map"
         )
+
+    # #1664 suppression: a form age_preference whose requester also has a
+    # satisfiable form bunk_with is immaterial and gets NO sat var, even though
+    # that requester's bunk_with does. This is the rule this PR adds.
+    for req_id in AGE_PREF_SUPPRESSED_IDS:
+        assert req_id not in sat_vars, (
+            f"{req_id} unexpectedly has a sat var — #1664 should suppress a form "
+            f"age_preference when its requester has a satisfiable form bunk_with"
+        )
+    assert AGE_PREF_SUPPRESSED_REQUESTER_BW_ID in sat_vars, (
+        f"{AGE_PREF_SUPPRESSED_REQUESTER_BW_ID} (the suppressed requester's own "
+        f"bunk_with) missing — suppression must drop only the age_preference, not "
+        f"the real form request it coexists with"
+    )
 
     requests_by_id = {r.id: r for r in solver.input.requests}
     grade_by_cm_id = {p.campminder_person_id: p.grade for p in solver.input.persons}
@@ -228,7 +250,13 @@ def test_age_preference_alignment_fixture_outcomes_are_deterministic(mock_config
     """The age_preference fixture's structurally-forced outcomes hold.
 
     Mirrors ``test_alignment_fixture_outcomes_are_deterministic`` but for the
-    age_preference fixture — anti-vacuity guard against fixture drift.
+    age_preference fixture — anti-drift guard.
+
+    Under #1664 every MATERIAL age-pref is satisfied (a material age-pref is its
+    camper's sole MP request, so must-satisfy-one forces it true), so the
+    non-trivial coverage is split: a real non-trivially-SATISFIED material
+    age-pref (apref_realsat_g6_younger, whose outcome turns on bunk membership)
+    plus the #1664 SUPPRESSION of a coexisting-bunk_with age-pref.
     """
     solver, cp_solver = _build_and_solve(mock_config, build_age_preference_alignment_fixture)
     sat_vars = solver.request_satisfied_vars
@@ -242,6 +270,15 @@ def test_age_preference_alignment_fixture_outcomes_are_deterministic(mock_config
             f"build_age_preference_alignment_fixture"
         )
 
-    # Both branches must be exercised.
+    # Suppressed (#1664) age-prefs must be absent; their requester's bunk_with present.
+    for req_id in AGE_PREF_SUPPRESSED_IDS:
+        assert req_id not in sat_vars, f"{req_id} should be suppressed by #1664 but appears in request_satisfied_vars"
+    assert AGE_PREF_SUPPRESSED_REQUESTER_BW_ID in sat_vars, (
+        f"{AGE_PREF_SUPPRESSED_REQUESTER_BW_ID} missing — suppression must keep the coexisting bunk_with"
+    )
+
+    # Anti-vacuity: at least one satisfied material age-pref AND at least one
+    # exercised #1664 suppression. (A deterministically-unsatisfied material
+    # age-pref is structurally impossible under #1664 — see fixtures.py.)
     assert any(AGE_PREF_EXPECTED_SATISFACTION.values()), "fixture has no satisfied case — vacuous"
-    assert not all(AGE_PREF_EXPECTED_SATISFACTION.values()), "fixture has no unsatisfied case — vacuous"
+    assert AGE_PREF_SUPPRESSED_IDS, "fixture exercises no #1664 suppression — vacuous"

--- a/tests/integration/solver/test_satvar_predicate_alignment.py
+++ b/tests/integration/solver/test_satvar_predicate_alignment.py
@@ -207,7 +207,12 @@ def test_age_preference_satvar_predicate_alignment(mock_config: Any) -> None:
     # #1664 suppression: a form age_preference whose requester also has a
     # satisfiable form bunk_with is immaterial and gets NO sat var, even though
     # that requester's bunk_with does. This is the rule this PR adds.
+    request_ids = {r.id for r in solver.input.requests}
     for req_id in AGE_PREF_SUPPRESSED_IDS:
+        assert req_id in request_ids, (
+            f"{req_id} missing from fixture requests — the suppression assertion "
+            f"would pass vacuously (fixture-ID drift)"
+        )
         assert req_id not in sat_vars, (
             f"{req_id} unexpectedly has a sat var — #1664 should suppress a form "
             f"age_preference when its requester has a satisfiable form bunk_with"
@@ -271,7 +276,12 @@ def test_age_preference_alignment_fixture_outcomes_are_deterministic(mock_config
         )
 
     # Suppressed (#1664) age-prefs must be absent; their requester's bunk_with present.
+    request_ids = {r.id for r in solver.input.requests}
     for req_id in AGE_PREF_SUPPRESSED_IDS:
+        assert req_id in request_ids, (
+            f"{req_id} missing from fixture requests — the suppression assertion "
+            f"would pass vacuously (fixture-ID drift)"
+        )
         assert req_id not in sat_vars, f"{req_id} should be suppressed by #1664 but appears in request_satisfied_vars"
     assert AGE_PREF_SUPPRESSED_REQUESTER_BW_ID in sat_vars, (
         f"{AGE_PREF_SUPPRESSED_REQUESTER_BW_ID} missing — suppression must keep the coexisting bunk_with"

--- a/tests/unit/bunking/satisfaction/test_bucket.py
+++ b/tests/unit/bunking/satisfaction/test_bucket.py
@@ -120,3 +120,108 @@ def test_classify_request_handles_renamed_source_fields() -> None:
 
     assert classify_request("bunk_request_form") == RequestBucket.MATERIAL_PARENT
     assert classify_request("staff_not_bunk_with") == RequestBucket.STAFF
+
+
+from bunking.models_v2 import DirectBunkRequest
+from bunking.satisfaction.bucket import compute_material_request_ids
+
+
+def _req(
+    rid: str,
+    rtype: str,
+    source: str,
+    *,
+    requester: int = 1,
+    requested: int | None = 2,
+    status: str = "resolved",
+) -> DirectBunkRequest:
+    return DirectBunkRequest(
+        id=rid,
+        requester_person_cm_id=requester,
+        requested_person_cm_id=requested,
+        request_type=rtype,
+        source_field=source,
+        session_cm_id=100,
+        year=2026,
+        status=status,
+    )
+
+
+class TestComputeMaterialRequestIds:
+    def test_form_age_pref_alone_is_material(self) -> None:
+        reqs = {1: [_req("a", "age_preference", "bunk_request_form", requested=None)]}
+        assert compute_material_request_ids(reqs, set()) == {"a"}
+
+    def test_form_age_pref_suppressed_by_possible_real_form_request(self) -> None:
+        reqs = {
+            1: [
+                _req("a", "age_preference", "bunk_request_form", requested=None),
+                _req("b", "bunk_with", "bunk_request_form"),
+            ]
+        }
+        assert compute_material_request_ids(reqs, set()) == {"b"}
+
+    def test_form_age_pref_revives_when_real_request_impossible(self) -> None:
+        reqs = {
+            1: [
+                _req("a", "age_preference", "bunk_request_form", requested=None),
+                _req("b", "bunk_with", "bunk_request_form"),
+            ]
+        }
+        # "b" is impossible but still a material-parent request → stays in the set.
+        # "a" revives because no possible real request exists to suppress it.
+        assert compute_material_request_ids(reqs, {"b"}) == {"a", "b"}
+
+    def test_not_bunk_with_also_suppresses(self) -> None:
+        reqs = {
+            1: [
+                _req("a", "age_preference", "bunk_request_form", requested=None),
+                _req("b", "not_bunk_with", "bunk_request_form"),
+            ]
+        }
+        assert compute_material_request_ids(reqs, set()) == {"b"}
+
+    def test_staff_request_does_not_suppress(self) -> None:
+        reqs = {
+            1: [
+                _req("a", "age_preference", "bunk_request_form", requested=None),
+                _req("b", "not_bunk_with", "bunking_notes"),
+            ]
+        }
+        assert compute_material_request_ids(reqs, set()) == {"a"}
+
+    def test_manual_request_does_not_suppress(self) -> None:
+        reqs = {
+            1: [
+                _req("a", "age_preference", "bunk_request_form", requested=None),
+                _req("b", "bunk_with", "manual"),
+            ]
+        }
+        # manual is STAFF bucket → not material-parent, so "b" is excluded.
+        # "a" stays material because manual never suppresses.
+        assert compute_material_request_ids(reqs, set()) == {"a"}
+
+    def test_socialize_with_age_pref_immaterial_regardless(self) -> None:
+        reqs = {1: [_req("a", "age_preference", "socialize_with", requested=None)]}
+        assert compute_material_request_ids(reqs, set()) == set()
+
+    def test_unresolved_real_request_does_not_suppress(self) -> None:
+        reqs = {
+            1: [
+                _req("a", "age_preference", "bunk_request_form", requested=None),
+                _req("b", "bunk_with", "bunk_request_form", status="pending"),
+            ]
+        }
+        # "b" is a material-parent request by source so it stays in the set.
+        # It does NOT suppress "a" because suppression requires resolved+possible.
+        assert compute_material_request_ids(reqs, set()) == {"a", "b"}
+
+    def test_per_requester_independent(self) -> None:
+        reqs = {
+            1: [
+                _req("a", "age_preference", "bunk_request_form", requester=1, requested=None),
+                _req("b", "bunk_with", "bunk_request_form", requester=1),
+            ],
+            2: [_req("c", "age_preference", "bunk_request_form", requester=2, requested=None)],
+        }
+        assert compute_material_request_ids(reqs, set()) == {"b", "c"}

--- a/tests/unit/bunking/solver/conftest.py
+++ b/tests/unit/bunking/solver/conftest.py
@@ -17,6 +17,7 @@ from bunking.models_v2 import (
     DirectPerson,
     DirectSolverInput,
 )
+from bunking.satisfaction.bucket import compute_material_request_ids
 from bunking.solver.constraints.base import SolverContext
 from bunking.solver.logging import ConstraintLogger
 
@@ -227,6 +228,11 @@ def build_solver_context(
     for req in requests:
         requests_by_person[req.requester_person_cm_id].append(req)
 
+    # Compute contextual material set (mirrors _validate_requests in the real solver).
+    # Tests that want to exercise suppression can override ctx.material_request_ids
+    # after calling build_solver_context.
+    material_ids = compute_material_request_ids(dict(requests_by_person), impossible_request_ids=set())
+
     # Create solver input
     solver_input = DirectSolverInput(
         persons=persons,
@@ -254,6 +260,7 @@ def build_solver_context(
         constraint_logger=ConstraintLogger(debug_mode=False),
         debug_constraints=debug_constraints or {},
         soft_constraint_violations={},
+        material_request_ids=material_ids,
     )
 
 

--- a/tests/unit/bunking/solver/constraints/test_parent_paramount_hard_constraint.py
+++ b/tests/unit/bunking/solver/constraints/test_parent_paramount_hard_constraint.py
@@ -350,3 +350,90 @@ class TestParentParamountSharesSatVarMap:
             "parent_paramount must build MP bunk-request sat vars through the "
             "shared get_or_create_request_sat_var builder"
         )
+
+
+def _mp_age_pref_request(
+    request_id: str,
+    requester_cm_id: int,
+    session_cm_id: int = 1000,
+    age_preference_target: str = "older",
+) -> DirectBunkRequest:
+    """Material-Parent age_preference request (source_field=bunk_request_form).
+
+    Used to simulate the #1664 suppression scenario: a form age_preference that
+    coexists with a form bunk_with and should be excluded from the MSO forcing set.
+    """
+    return DirectBunkRequest(
+        id=request_id,
+        requester_person_cm_id=requester_cm_id,
+        requested_person_cm_id=None,
+        request_type="age_preference",
+        session_cm_id=session_cm_id,
+        year=2025,
+        source_field="bunk_request_form",  # MATERIAL_PARENT bucket
+        confidence_score=1.0,
+        status="resolved",
+        age_preference_target=age_preference_target,
+    )
+
+
+class TestParentParamountAgePreferenceSuppression:
+    def test_suppressed_age_pref_does_not_escape_mso_forcing(self):
+        """#1664: when a form bunk_with and a form age_preference coexist,
+        the age_preference is dropped from ctx.material_request_ids.  The MSO
+        forcing set therefore contains ONLY the bunk_with sat var.
+
+        Setup: all campers are the same grade (5), so the "older" age_preference
+        is trivially satisfied (no younger peers → always-1 forcing indicator).
+        Under the OLD code (is_material_parent_request gate), the always-1
+        indicator would allow MSO to be satisfied even when the bunk_with is
+        violated → model FEASIBLE despite forcing the pair apart.
+        Under the NEW code (r.id in ctx.material_request_ids gate, with
+        material_request_ids containing ONLY the bunk_with), the age_pref is
+        skipped entirely → the only forcing var is the bunk_with sat var →
+        model INFEASIBLE when the pair is forced apart.
+
+        The test sets ctx.material_request_ids explicitly (only "r1"), mirroring
+        what compute_material_request_ids returns when a possible form bunk_with
+        exists alongside the form age_preference.
+        """
+        camper1 = create_person(cm_id=100, first_name="Emma", last_name="Johnson", gender="F", grade=5)
+        camper2 = create_person(cm_id=200, first_name="Liam", last_name="Garcia", gender="F", grade=5)
+        bunk1 = create_bunk(cm_id=2001, name="G-1", gender="F", capacity=12)
+        bunk2 = create_bunk(cm_id=2002, name="G-2", gender="F", capacity=12)
+
+        # r1: form bunk_with (material, kept in material_request_ids)
+        req_bw = _mp_request("r1", requester_cm_id=100, requested_cm_id=200)
+        # r2: form age_preference (suppressed by #1664 → NOT in material_request_ids)
+        req_ap = _mp_age_pref_request("r2", requester_cm_id=100, age_preference_target="older")
+
+        ctx = build_solver_context(
+            persons=[camper1, camper2],
+            bunks=[bunk1, bunk2],
+            requests=[req_bw, req_ap],
+        )
+
+        # Simulate #1664 suppression: only the bunk_with is material.
+        # (compute_material_request_ids suppresses the age_pref because a
+        # resolved, possible form bunk_with exists for the same requester.)
+        ctx.material_request_ids = {"r1"}
+
+        from bunking.solver.constraints.parent_paramount import add_must_satisfy_one_request_constraints
+
+        add_must_satisfy_one_request_constraints(ctx)
+
+        # Force the pair into DIFFERENT bunks — bunk_with is unsatisfied.
+        # Age_pref is trivially satisfied (all campers same grade → no younger
+        # peers → always-1 forcing indicator), so under OLD code this would
+        # allow MSO to be satisfied via the age_pref, keeping the model FEASIBLE.
+        # Under NEW code the age_pref is excluded, so the model must be INFEASIBLE.
+        _force_apart(ctx, 100, 200)
+
+        solver = cp_model.CpSolver()
+        status = solver.Solve(ctx.model)
+
+        assert is_infeasible(status), (
+            "With age_pref suppressed from material_request_ids, the MSO forcing set "
+            "contains only the bunk_with sat var. Forcing the pair apart must make the "
+            "model INFEASIBLE — the trivially-satisfied age_pref must NOT provide an escape hatch."
+        )

--- a/tests/unit/bunking/solver/constraints/test_staff_separation.py
+++ b/tests/unit/bunking/solver/constraints/test_staff_separation.py
@@ -197,3 +197,54 @@ def test_carveout_requires_material_parent_positive():
     _force_together(ctx, 100, 200)
     assert is_infeasible(cp_model.CpSolver().Solve(ctx.model))
     assert ctx.staff_nbw_yields == []
+
+
+def _age_pref(request_id: str, requester: int, source_field: str = "bunk_request_form") -> DirectBunkRequest:
+    """Create an age_preference request (no requestee)."""
+    return DirectBunkRequest(
+        id=request_id,
+        requester_person_cm_id=requester,
+        requested_person_cm_id=None,
+        request_type="age_preference",
+        session_cm_id=1000,
+        year=2025,
+        source_field=source_field,
+        confidence_score=1.0,
+        status="resolved",
+    )
+
+
+def test_carveout_fires_when_sole_real_mp_is_bunk_with_and_age_pref_suppressed():
+    """#1664: suppressed form age_preference does NOT inflate _possible_mp_count.
+
+    Liam (200) has:
+      - a bunk_request_form bunk_with toward Emma (100)  → material, mp_count = 1
+      - a bunk_request_form age_preference               → suppressed by #1664 (real form BW present)
+
+    After migration, _possible_mp_count(ctx, 200) == 1, so the MSO-protection
+    carve-out fires and the staff not_bunk_with yields.
+
+    Before migration (using is_material_parent_request directly), the age_pref
+    would also be counted → mp_count == 2 → no yield.
+    """
+    from bunking.solver.constraints.staff_separation import add_staff_separation_constraints
+
+    ctx = _two_girls_two_bunks(
+        [
+            _nbw("n1", 100, 200, "staff_not_bunk_with"),
+            _bunk_with("p1", 200, 100, "bunk_request_form"),
+            _age_pref("a1", 200),  # suppressed by #1664 → not in material_request_ids
+        ]
+    )
+    # Verify suppression: age_pref not in material set, bunk_with is.
+    assert "p1" in ctx.material_request_ids
+    assert "a1" not in ctx.material_request_ids
+
+    add_staff_separation_constraints(ctx)
+    _force_together(ctx, 100, 200)
+    assert is_optimal_or_feasible(cp_model.CpSolver().Solve(ctx.model))
+    assert len(ctx.staff_nbw_yields) == 1
+    y = ctx.staff_nbw_yields[0]
+    assert y["nbw_request_id"] == "n1"
+    assert y["protected_parent_request_id"] == "p1"
+    assert y["protected_camper_cm"] == 200

--- a/tests/unit/solver/impossibility/test_mp_campers_entirely_impossible.py
+++ b/tests/unit/solver/impossibility/test_mp_campers_entirely_impossible.py
@@ -67,3 +67,78 @@ def test_camper_with_no_mp_requests_is_not_listed(mock_config):
     report = validate_impossibility(input_data, mock_config)
 
     assert report.mp_campers_entirely_impossible == []
+
+
+def test_age_pref_suppressed_with_possible_bunk_with_not_entirely_impossible(mock_config):
+    """A camper with a suppressed age_preference + a POSSIBLE bunk_with is NOT
+    in mp_campers_entirely_impossible.
+
+    #1664 suppression: when a bunk_request_form age_preference is contextually
+    suppressed (requester also has a resolved-possible bunk_request_form bunk_with),
+    the rollup must use the contextual material set — not is_material_parent_request.
+
+    Both before and after migration the bunk_with is possible, so the all-impossible
+    check fails and the camper is correctly NOT listed. This locks the baseline.
+    """
+    p1 = make_person(1, session=1000001, gender="F", grade=5)
+    p2 = make_person(2, session=1000001, gender="F", grade=6)  # possible bunk_with target
+    bunks = [make_bunk(10, session=1000001, gender="F", capacity=12)]
+    requests = [
+        make_request("bw1", requester=1, requestee=2, session=1000001),  # possible bunk_with
+        make_request(
+            "ap1",
+            requester=1,
+            requestee=None,
+            request_type="age_preference",
+            source_field="bunk_request_form",
+            age_preference_target="older",
+            session=1000001,
+        ),
+    ]
+    input_data = make_input([p1, p2], bunks, requests)
+
+    report = validate_impossibility(input_data, mock_config)
+
+    # bw1 is possible → age_pref is suppressed → material set = {bw1}
+    # bw1 is possible → camper is NOT entirely impossible
+    assert report.mp_campers_entirely_impossible == []
+
+
+def test_age_pref_not_suppressed_when_bunk_with_impossible_camper_is_entirely_impossible(mock_config):
+    """A camper whose ONLY bunk_with is impossible and also has an impossible age_pref
+    IS in mp_campers_entirely_impossible.
+
+    When the bunk_with is impossible, the suppression gate does not fire → the
+    age_pref remains in the material set. Both requests are impossible → camper IS
+    entirely impossible.
+
+    Pre-migration: is_material_parent_request sees both as material (same result).
+    Post-migration: compute_material_request_ids sees no possible bunk_with →
+    suppression does not apply → both remain material → same result.
+
+    This test guards the invariant; it should pass both before and after migration.
+    """
+    # grade=6 at the top of a session that has only one girl → no older F peers → age_pref impossible
+    p1 = make_person(1, session=1000001, gender="F", grade=6)
+    bunks = [make_bunk(10, session=1000001, gender="F", capacity=12)]
+    requests = [
+        make_request("bw_imp", requester=1, requestee=777, session=1000001),  # impossible: target_not_in_solver
+        make_request(
+            "ap_imp",
+            requester=1,
+            requestee=None,
+            request_type="age_preference",
+            source_field="bunk_request_form",
+            age_preference_target="older",
+            session=1000001,
+        ),
+    ]
+    input_data = make_input([p1], bunks, requests)
+
+    report = validate_impossibility(input_data, mock_config)
+
+    # bw_imp impossible → suppression gate inactive → age_pref is material
+    # age_pref impossible (grade=6 → no older F) → both impossible → listed
+    entries = report.mp_campers_entirely_impossible
+    assert len(entries) == 1
+    assert entries[0]["cm_id"] == 1

--- a/tests/unit/solver/test_parent_nbw_yield_wiring.py
+++ b/tests/unit/solver/test_parent_nbw_yield_wiring.py
@@ -171,3 +171,67 @@ def test_no_yield_when_both_campers_have_sole_mp_nbw(mock_config):
     assert is_optimal_or_feasible(status)
     assert solver.parent_nbw_yields == []
     assert _bunk_idx(solver, cp, 100) != _bunk_idx(solver, cp, 200)  # both NBWs honored
+
+
+def test_form_age_pref_does_not_block_parent_nbw_yield(mock_config):
+    """#1664: a form age_preference coexisting with a form not_bunk_with is
+    suppressed from the material set, so it does NOT count as a second MP
+    request.  Camper A's sole real form request is not_bunk_with→B; their form
+    age_pref is suppressed (possible form not_bunk_with exists).  Camper B's
+    sole MP is bunk_with→A.  The both-sole opposing carve-out must fire: the
+    pair is co-placed and exactly one yield is recorded.
+    """
+    persons, bunks = _roster()
+    reqs = [
+        # A (100): sole real form request = not_bunk_with→B
+        make_request(
+            "n1", requester=100, requestee=200, request_type="not_bunk_with", source_field="bunk_request_form"
+        ),
+        # A (100): form age_preference — suppressed by #1664 (has a possible form NBW)
+        make_request(
+            "ap1",
+            requester=100,
+            requestee=None,
+            request_type="age_preference",
+            source_field="bunk_request_form",
+        ),
+        # B (200): sole MP = bunk_with→A
+        make_request("p1", requester=200, requestee=100, request_type="bunk_with", source_field="bunk_request_form"),
+    ]
+    solver = DirectBunkingSolver(make_input(persons, bunks, reqs), mock_config)
+    cp, status = _solve(solver)
+    assert is_optimal_or_feasible(status)
+    # Suppressed age_pref does NOT block the carve-out — exactly one yield recorded.
+    assert len(solver.parent_nbw_yields) == 1
+    y = solver.parent_nbw_yields[0]
+    assert y["nbw_request_id"] == "n1"
+    assert y["subject_cm"] == 100  # the yielding (NBW) camper
+    assert y["target_cm"] == 200
+    assert y["protected_parent_request_id"] == "p1"
+    assert y["protected_camper_cm"] == 200  # the bunk_with requester
+    # Pair is co-placed: positive wins.
+    assert _bunk_idx(solver, cp, 100) == _bunk_idx(solver, cp, 200)
+
+
+def test_second_material_request_still_blocks_yield(mock_config):
+    """#1664 does not suppress non-age-pref form requests.  When camper A has
+    a form not_bunk_with→B (their NBW) PLUS a second possible form bunk_with→C
+    (a real material request), A is NOT sole-MP — the carve-out must NOT fire
+    and no yield is recorded.
+    """
+    persons, bunks = _roster()
+    reqs = [
+        # A (100): NBW toward B
+        make_request(
+            "n1", requester=100, requestee=200, request_type="not_bunk_with", source_field="bunk_request_form"
+        ),
+        # A (100): second material form request (bunk_with→C = filler 1000)
+        make_request("p2", requester=100, requestee=1000, request_type="bunk_with", source_field="bunk_request_form"),
+        # B (200): sole MP = bunk_with→A
+        make_request("p1", requester=200, requestee=100, request_type="bunk_with", source_field="bunk_request_form"),
+    ]
+    solver = DirectBunkingSolver(make_input(persons, bunks, reqs), mock_config)
+    cp, status = _solve(solver)
+    assert is_optimal_or_feasible(status)
+    # A has two real MP requests (NBW + BW) → not sole → no carve-out, no yield.
+    assert solver.parent_nbw_yields == []

--- a/tests/unit/solver/test_validate_requests.py
+++ b/tests/unit/solver/test_validate_requests.py
@@ -624,3 +624,58 @@ def test_mp_set_entirely_impossible_populated_at_init():
     solver = DirectBunkingSolver(input_data, MagicMock())
 
     assert solver.mp_set_entirely_impossible == [1]
+
+
+class TestMaterialRequestIds:
+    """material_request_ids is computed in _validate_requests and exposed on the solver.
+
+    A resolved, possible bunk_request_form bunk_with is material.
+    A bunk_request_form age_preference is suppressed (#1664) when the same requester
+    also has a resolved-and-possible bunk_request_form bunk_with.
+    """
+
+    def test_bunk_with_is_in_material_request_ids(self, mock_config):
+        """A resolved bunk_with from bunk_request_form is material."""
+        solver = DirectBunkingSolver(
+            DirectSolverInput(
+                persons=[_make_person(1001, 1000001, gender="F"), _make_person(1002, 1000001, gender="F")],
+                requests=[
+                    _make_request(
+                        "bw1", 1001, 1002, 1000001, request_type="bunk_with", source_field="bunk_request_form"
+                    )
+                ],
+                bunks=[_make_bunk(2001, 1000001, gender="F")],
+            ),
+            ConfigLoader.get_instance(),
+        )
+
+        assert "bw1" in solver.material_request_ids
+
+    def test_age_pref_suppressed_when_bunk_with_is_possible(self, mock_config):
+        """A bunk_request_form age_preference is NOT in material_request_ids when the
+        requester also has a resolved, possible bunk_request_form bunk_with."""
+        solver = DirectBunkingSolver(
+            DirectSolverInput(
+                persons=[_make_person(1001, 1000001, gender="F"), _make_person(1002, 1000001, gender="F")],
+                requests=[
+                    _make_request(
+                        "bw1", 1001, 1002, 1000001, request_type="bunk_with", source_field="bunk_request_form"
+                    ),
+                    DirectBunkRequest(
+                        id="ap1",
+                        requester_person_cm_id=1001,
+                        request_type="age_preference",
+                        age_preference_target="older",
+                        session_cm_id=1000001,
+                        year=2026,
+                        status="resolved",
+                        source_field="bunk_request_form",
+                    ),
+                ],
+                bunks=[_make_bunk(2001, 1000001, gender="F")],
+            ),
+            ConfigLoader.get_instance(),
+        )
+
+        assert "bw1" in solver.material_request_ids
+        assert "ap1" not in solver.material_request_ids

--- a/tests/unit/solver/test_validate_requests.py
+++ b/tests/unit/solver/test_validate_requests.py
@@ -679,3 +679,54 @@ class TestMaterialRequestIds:
 
         assert "bw1" in solver.material_request_ids
         assert "ap1" not in solver.material_request_ids
+
+
+class TestMaterialRequestIdsConsistency:
+    """solver.material_request_ids must equal compute_material_request_ids applied
+    to the same input — single source of truth, no drift between solver and
+    validate_impossibility.
+
+    Guards the Task 4 migration: if validate_impossibility's MP rollup ever
+    diverges from the solver's material set, this test catches it.
+    """
+
+    def test_material_ids_equal_helper_output(self, mock_config):
+        """After _validate_requests, solver.material_request_ids == compute_material_request_ids.
+
+        Scenario: one bunk_request_form bunk_with (possible) + one bunk_request_form
+        age_preference (suppressed by #1664).  The helper and the solver must agree
+        on the final material set.
+        """
+        from bunking.satisfaction.bucket import compute_material_request_ids
+
+        solver = DirectBunkingSolver(
+            DirectSolverInput(
+                persons=[_make_person(1001, 1000001, gender="F"), _make_person(1002, 1000001, gender="F")],
+                requests=[
+                    _make_request(
+                        "bw_cons",
+                        1001,
+                        1002,
+                        1000001,
+                        request_type="bunk_with",
+                        source_field="bunk_request_form",
+                    ),
+                    DirectBunkRequest(
+                        id="ap_cons",
+                        requester_person_cm_id=1001,
+                        request_type="age_preference",
+                        age_preference_target="older",
+                        session_cm_id=1000001,
+                        year=2026,
+                        status="resolved",
+                        source_field="bunk_request_form",
+                    ),
+                ],
+                bunks=[_make_bunk(2001, 1000001, gender="F")],
+            ),
+            ConfigLoader.get_instance(),
+        )
+
+        impossible_ids = {item.request_id for item in solver.impossibility_report.flat}
+        expected = compute_material_request_ids(solver.input.requests_by_person, impossible_ids)
+        assert solver.material_request_ids == expected


### PR DESCRIPTION
## Problem

A `bunk_request_form` age-preference was treated as a **Material-Parent** request unconditionally, so it fed the parent-paramount must-satisfy-one (MSO) hard constraint even when the parent *also* named a real bunk request on the same form. The child became MSO-bound on a soft directional preference instead of (or alongside) their real request. Materiality was a pure per-request function (`is_material_parent_request` = source→bucket), blind to the requester's other requests.

Closes #1664 (feedback mirror kindred-feedback#55).

## Fix

A `bunk_request_form` `AGE_PREFERENCE` is material **only if** the requester has **no resolved-and-possible** `bunk_request_form` `bunk_with`/`not_bunk_with`. If a satisfiable real form request exists → the age-pref is immaterial; if the real request(s) are all impossible/unresolved → it reverts to material. Staff- and `manual`-sourced requests never suppress; `socialize_with` age-prefs were already immaterial and are untouched.

Implemented as one pure helper, `compute_material_request_ids(requests_by_person, impossible_request_ids)`, computed once in `_validate_requests` and stored on `SolverContext.material_request_ids`. The **six** solver sites that read `is_material_parent_request(r)` per-request now read membership in that single set:

- `add_must_satisfy_one_request_constraints` (hard MSO partition)
- `validate_impossibility` (entirely-impossible-MP rollup)
- `_check_must_satisfy_one_violations` (post-solve diagnostic, two sites)
- `_possible_mp_count` + `_mso_protection_applies` (staff-separation carve-out)
- `localize_hard_mso_infeasibility` (IIS localizer)

One source of truth ⇒ the hard constraint and the pre-check/diagnostic structurally cannot disagree on materiality. For every non-suppressed request `r.id in material_request_ids` is equivalent to `is_material_parent_request(r)`, so the migration is behavior-preserving apart from the intended age-pref drop.

## Interaction with the parent-NBW-yield carve-out (#1667)

This **closes a surfacing gap** in the recently-merged Stream C. A coexisting age-pref used to make a camper "not sole-MP", silently masking a parent-vs-parent `not_bunk_with`→`bunk_with` override so no yield was recorded. With the age-pref now suppressed, those both-sole contradictions surface on the advisory card as intended. Expect the parent-NBW-yield card to appear **more often** — this is the more-honest behavior and is intended. `_parent_nbw_yield_record` is untouched; it inherits corrected materiality through the constraint's partition step.

## Note on coverage

Under this rule a material age-pref is always a camper's *sole* MP request, so MSO forces it satisfied — there is no such thing as a *non-trivially-unsatisfied material* age-pref in a feasible solve. The satvar↔predicate alignment fixture was updated accordingly: a real satisfied material age-pref (age-pref-only camper) plus an explicit suppression case.

## Tests

TDD throughout: pure-helper unit suite (alone→material, suppressed by possible real, revives when real impossible, staff/manual don't suppress, etc.), a parent_paramount behavioral test, two #1667-interaction tests (yield fires when the age-pref is suppressed; control when a second real request exists), a `validate_impossibility`↔solver consistency test, a staff-separation carve-out test, and the updated satvar-alignment integration fixture. Full mockable suite green (5303 passed, DB-gated metrics tests skip as usual).

## No migration

Pure solve-time computation over existing requests — no schema change, no reprocess. Takes effect on the next solve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Age-preference form requests are suppressed when a coexisting satisfiable bunk request exists, improving material-parent classification, infeasibility/impossibility reporting, and staff-separation carve-out behavior.
* **Documentation**
  * Clarified how material-parent detection is determined in solver flows and diagnostics.
* **Tests**
  * Added extensive unit and integration tests to cover suppression behavior and ensure consistent material-parent handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1668?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->