### PR TITLE
fix(frontend): graph layout spacing + expand-ref rebuild race

### DIFF
--- a/bunking/graph/social_graph_builder.py
+++ b/bunking/graph/social_graph_builder.py
@@ -458,52 +458,14 @@ class SocialGraphBuilder:
         except Exception as e:
             logger.error(f"Error adding request edges: {e}")
 
-        # Add ONLY sibling edges between bunk members
-        sibling_count = 0
-        try:
-            # Get all persons who are bunk members
-            persons_data = {}
-            for person_cm_id in bunk_members:
-                try:
-                    _person_rec = self.pb.collection(PERSONS).get_first_list_item(f"cm_id = {person_cm_id}")
-                    person = cast_person(_person_rec)
-                    if person.get("household_id"):
-                        persons_data[person_cm_id] = person["household_id"]
-                except Exception:  # noqa: S110 — intentional silent handling
-                    pass
-
-            # Find siblings
-            family_groups = defaultdict(list)
-            for person_id, family_id in persons_data.items():
-                family_groups[family_id].append(person_id)
-
-            # Add sibling edges
-            for family_id, members in family_groups.items():
-                if len(members) > 1:
-                    # Add BIDIRECTIONAL edges between all siblings in the same bunk
-                    for i in range(len(members)):
-                        for j in range(i + 1, len(members)):
-                            # For sibling edges, we need to handle them differently
-                            # Check if request edges already exist and add sibling info
-                            for source, target in [(members[i], members[j]), (members[j], members[i])]:
-                                if bunk_graph.has_edge(source, target):
-                                    # Edge exists, add sibling as secondary type
-                                    edge_data = bunk_graph[source][target]
-                                    if "secondary_type" not in edge_data:
-                                        edge_data["secondary_type"] = "sibling"
-                                        edge_data["has_sibling"] = True
-                                        logger.info(f"Added sibling as secondary type: {source} -> {target}")
-                                else:
-                                    # No existing edge, create sibling edge
-                                    bunk_graph.add_edge(source, target, weight=1.5, edge_type="sibling")
-                                    sibling_count += 1
-
-                            logger.info(f"Added separate sibling edges: {members[i]} <-> {members[j]}")
-
-            logger.info(f"Added {sibling_count} sibling edges to bunk graph")
-
-        except Exception as e:
-            logger.error(f"Error adding sibling edges: {e}")
+        # Sibling edges are intentionally NOT added (#1675). Siblings are a
+        # deprecated graph concept — the session graph dropped them under #1094.
+        # On the bunk graph they rendered as a spurious extra line per sibling
+        # pair (and, after the #1640 multi change, a spurious bezier). The bunk
+        # graph is now request-only, matching the session graph. Node
+        # degree/centrality below is therefore request-only too, so a camper
+        # connected only by a sibling relationship reads as isolated — correct,
+        # since they have no bunk requests.
 
         # Calculate basic node metrics for the bunk graph
         for node in bunk_graph.nodes():

--- a/bunking/graph/social_graph_builder.py
+++ b/bunking/graph/social_graph_builder.py
@@ -163,7 +163,10 @@ class SocialGraphBuilder:
         session_cm_id: int,
         scenario_id: str | None = None,
     ) -> nx.DiGraph:
-        """Build a graph specifically for a single bunk with only request and sibling edges.
+        """Build a graph specifically for a single bunk with only request edges.
+
+        Sibling edges are intentionally not added (#1675); the bunk graph is
+        request-only, matching the session graph.
 
         Args:
             year: Camp year.
@@ -490,8 +493,7 @@ class SocialGraphBuilder:
             f"Bunk graph built with {bunk_graph.number_of_nodes()} nodes and {bunk_graph.number_of_edges()} edges"
         )
         logger.info(
-            f"Edge types: request={len([e for e in bunk_graph.edges(data=True) if e[2].get('edge_type') == 'request'])}, "
-            f"sibling={len([e for e in bunk_graph.edges(data=True) if e[2].get('edge_type') == 'sibling'])}"
+            f"Edge types: request={len([e for e in bunk_graph.edges(data=True) if e[2].get('edge_type') == 'request'])}"
         )
 
         # Populate satisfaction node attrs (parent_satisfaction_status,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,7 +29,6 @@
         "codemirror": "^6.0.2",
         "cytoscape": "^3.33.4",
         "cytoscape-bubblesets": "^4.0.0",
-        "cytoscape-cola": "^2.5.1",
         "cytoscape-fcose": "^2.2.0",
         "cytoscape-layers": "^3.1.0",
         "cytoscape-popper": "^4.0.1",
@@ -3844,18 +3843,6 @@
         "cytoscape-layers": "^3.0.0"
       }
     },
-    "node_modules/cytoscape-cola": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/cytoscape-cola/-/cytoscape-cola-2.5.1.tgz",
-      "integrity": "sha512-4/2S9bW1LvdsEPmxXN1OEAPFPbk7DvCx2c9d+TblkQAAvptGaSgtPWCByTEGgT8UxCxcVqes2aFPO5pzwo7R2w==",
-      "license": "MIT",
-      "dependencies": {
-        "webcola": "^3.4.0"
-      },
-      "peerDependencies": {
-        "cytoscape": "^3.2.0"
-      }
-    },
     "node_modules/cytoscape-fcose": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
@@ -3916,22 +3903,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-dispatch": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
-      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-drag": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.5.tgz",
-      "integrity": "sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-dispatch": "1",
-        "d3-selection": "1"
-      }
-    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
@@ -3986,12 +3957,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/d3-selection": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
-      "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
@@ -7510,39 +7475,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/webcola": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/webcola/-/webcola-3.4.0.tgz",
-      "integrity": "sha512-4BiLXjXw3SJHo3Xd+rF+7fyClT6n7I+AR6TkBqyQ4kTsePSAMDLRCXY1f3B/kXJeP9tYn4G1TblxTO+jAt0gaw==",
-      "license": "MIT",
-      "dependencies": {
-        "d3-dispatch": "^1.0.3",
-        "d3-drag": "^1.0.4",
-        "d3-shape": "^1.3.5",
-        "d3-timer": "^1.0.5"
-      }
-    },
-    "node_modules/webcola/node_modules/d3-path": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
-      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/webcola/node_modules/d3-shape": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-path": "1"
-      }
-    },
-    "node_modules/webcola/node_modules/d3-timer": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
-      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,6 @@
     "codemirror": "^6.0.2",
     "cytoscape": "^3.33.4",
     "cytoscape-bubblesets": "^4.0.0",
-    "cytoscape-cola": "^2.5.1",
     "cytoscape-fcose": "^2.2.0",
     "cytoscape-layers": "^3.1.0",
     "cytoscape-popper": "^4.0.1",

--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -4,8 +4,6 @@ import type { Core } from 'cytoscape'
 import cytoscape from 'cytoscape'
 // @ts-expect-error - No types available for cytoscape-fcose
 import fcose from 'cytoscape-fcose'
-// @ts-expect-error - No types available for cytoscape-cola
-import cola from 'cytoscape-cola'
 // Tooltips removed - will implement React-based solution
 import {
   Network,
@@ -27,7 +25,7 @@ import {
   BUNK_NODE_COLORS,
   CROSS_SCOPE_NODE_COLOR,
   FIRST_YEAR_RING_COLOR,
-  buildBunkColaLayoutOptions,
+  buildBunkFcoseLayoutOptions,
   buildBunkGraphElements,
   getBunkCytoscapeStyles,
   getBunkGradeColors,
@@ -45,7 +43,6 @@ import type { BunkPlansResponse, BunksResponse } from '../types/pocketbase-types
 
 // Register extensions
 cytoscape.use(fcose)
-cytoscape.use(cola)
 
 interface BunkSocialGraphModalProps {
   bunkCmId: number
@@ -336,19 +333,13 @@ export default function BunkSocialGraphModal({
 
     cy.add(elements)
 
-    // Run layout after adding elements.
-    // Use cola for better layout control. Explicit spacing so disconnected
-    // sub-clusters don't pack adjacently and look falsely linked (#1640). The
-    // bounding box is derived from the live container so cola spreads nodes to
-    // fill the canvas's wide aspect rather than leaving big left/right margins.
-    // Cast required: cytoscape's BaseLayoutOptions doesn't include cola's
-    // plugin-specific options (nodeSpacing, handleDisconnected, boundingBox).
-    const container = containerRef.current
+    // Run layout after adding elements. fcose spreads a single bunk into a
+    // cleaner 2D arrangement than cola (which tended to collapse sparse bunks
+    // toward a line); see buildBunkFcoseLayoutOptions for the rationale.
+    // Cast required: cytoscape's BaseLayoutOptions doesn't include fcose's
+    // plugin-specific options.
     const layout = cy.layout(
-      buildBunkColaLayoutOptions(
-        container.clientWidth,
-        container.clientHeight
-      ) as unknown as Parameters<(typeof cy)['layout']>[0]
+      buildBunkFcoseLayoutOptions() as unknown as Parameters<(typeof cy)['layout']>[0]
     )
 
     layoutRef.current = layout

--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -27,6 +27,7 @@ import {
   BUNK_NODE_COLORS,
   CROSS_SCOPE_NODE_COLOR,
   FIRST_YEAR_RING_COLOR,
+  buildBunkColaLayoutOptions,
   buildBunkGraphElements,
   getBunkCytoscapeStyles,
   getBunkGradeColors,
@@ -335,17 +336,20 @@ export default function BunkSocialGraphModal({
 
     cy.add(elements)
 
-    // Run layout after adding elements
+    // Run layout after adding elements.
     // Use cola for better layout control. Explicit spacing so disconnected
-    // sub-clusters don't pack adjacently and look falsely linked (#1640).
+    // sub-clusters don't pack adjacently and look falsely linked (#1640). The
+    // bounding box is derived from the live container so cola spreads nodes to
+    // fill the canvas's wide aspect rather than leaving big left/right margins.
     // Cast required: cytoscape's BaseLayoutOptions doesn't include cola's
-    // plugin-specific options (nodeSpacing, handleDisconnected).
-    const layout = cy.layout({
-      name: 'cola',
-      nodeSpacing: 30,
-      padding: 30,
-      handleDisconnected: true,
-    } as Parameters<(typeof cy)['layout']>[0])
+    // plugin-specific options (nodeSpacing, handleDisconnected, boundingBox).
+    const container = containerRef.current
+    const layout = cy.layout(
+      buildBunkColaLayoutOptions(
+        container.clientWidth,
+        container.clientHeight
+      ) as unknown as Parameters<(typeof cy)['layout']>[0]
+    )
 
     layoutRef.current = layout
     layout.on('layoutstop', () => {

--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -336,12 +336,21 @@ export default function BunkSocialGraphModal({
     cy.add(elements)
 
     // Run layout after adding elements
-    // Use cola for better layout control
+    // Use cola for better layout control. Explicit spacing so disconnected
+    // sub-clusters don't pack adjacently and look falsely linked (#1640).
+    // Cast required: cytoscape's BaseLayoutOptions doesn't include cola's
+    // plugin-specific options (nodeSpacing, handleDisconnected).
     const layout = cy.layout({
       name: 'cola',
-    })
+      nodeSpacing: 30,
+      padding: 30,
+      handleDisconnected: true,
+    } as Parameters<(typeof cy)['layout']>[0])
 
     layoutRef.current = layout
+    layout.on('layoutstop', () => {
+      cy.fit(undefined, 30)
+    })
     layout.run()
 
     // Add click handler for nodes

--- a/frontend/src/components/SocialNetworkGraph.test.ts
+++ b/frontend/src/components/SocialNetworkGraph.test.ts
@@ -56,6 +56,24 @@ describe('SocialNetworkGraph safety guards', () => {
     expect(source).not.toMatch(/['"]ego['"]/)
     expect(source).not.toMatch(/\bViewMode\b/)
   })
+
+  it('resets hasMountedExpandRef on graph rebuild to prevent expand/fit RAF race (#1663)', () => {
+    // When graphData changes, the init effect destroys the old Cytoscape instance
+    // and creates a new one. Without resetting hasMountedExpandRef.current, the
+    // isExpanded effect skips its first-run guard and the expand/fit RAF chain
+    // races the new instance's own worker layout+fit call.
+    // Verify the reset appears adjacent to the destroy/null sequence.
+    const destroyPos = source.indexOf('cyRef.current.destroy()')
+    const nullPos = source.indexOf('cyRef.current = null')
+    const resetPos = source.indexOf('hasMountedExpandRef.current = false')
+    expect(destroyPos).toBeGreaterThan(0)
+    expect(nullPos).toBeGreaterThan(destroyPos)
+    // The ref reset must appear after the destroy and within the same block
+    expect(resetPos).toBeGreaterThan(destroyPos)
+    // And before a new `const cy = cytoscape` call that creates the next instance
+    const createPos = source.indexOf('const cy = cytoscape(')
+    expect(resetPos).toBeLessThan(createPos)
+  })
 })
 
 describe('SocialNetworkGraph header layout — slim single row', () => {

--- a/frontend/src/components/SocialNetworkGraph.tsx
+++ b/frontend/src/components/SocialNetworkGraph.tsx
@@ -314,6 +314,9 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
       }
       cyRef.current.destroy()
       cyRef.current = null
+      // Re-arm the first-run guard so the expand/fit RAF chain doesn't race
+      // the new instance's worker layout+fit on the next rebuild.
+      hasMountedExpandRef.current = false
     }
 
     const cy = cytoscape({

--- a/frontend/src/components/bunkGraphStyles.test.ts
+++ b/frontend/src/components/bunkGraphStyles.test.ts
@@ -7,6 +7,7 @@
  */
 import { describe, expect, it } from 'vitest'
 import {
+  buildBunkColaLayoutOptions,
   buildBunkGraphElements,
   BUNK_NODE_COLORS,
   FIRST_YEAR_RING_COLOR,
@@ -100,6 +101,165 @@ describe('buildBunkGraphElements grade coloring', () => {
     const node = elements.find((e) => e.data?.id === 'node-101')
     expect(node?.data?.['gradeColor']).toBe(getBunkGradeColors([0])[0])
     expect(node?.data?.['gradeColor']).not.toBe('#666666')
+  })
+})
+
+describe('buildBunkGraphElements multi (mixed-type conflict pairs)', () => {
+  const nodes = [
+    { id: 1, name: 'Emma Johnson', grade: 4 },
+    { id: 2, name: 'Liam Garcia', grade: 4 },
+  ]
+
+  it('flags both edges of a mixed-type opposing pair so the stylesheet curves them', () => {
+    // Backend buckets by (pair, request_type), so an A→B bunk_with paired with
+    // B→A not_bunk_with ships as TWO directed edges. As straight edges they'd
+    // overlap on one line; multi splays them onto opposing beziers.
+    const elements = buildBunkGraphElements(
+      {
+        nodes,
+        edges: [
+          {
+            source: 1,
+            target: 2,
+            weight: 1,
+            edge_type: 'request',
+            reciprocal: false,
+            request_type: 'bunk_with',
+          },
+          {
+            source: 2,
+            target: 1,
+            weight: 1,
+            edge_type: 'request',
+            reciprocal: false,
+            request_type: 'not_bunk_with',
+          },
+        ],
+      },
+      false,
+      () => 0.5
+    )
+    const edges = elements.filter((e) => e.group === 'edges')
+    expect(edges).toHaveLength(2)
+    expect(edges.every((e) => e.data?.['multi'] === true)).toBe(true)
+  })
+
+  it('does not flag a single one-way edge as multi', () => {
+    const elements = buildBunkGraphElements(
+      {
+        nodes,
+        edges: [
+          {
+            source: 1,
+            target: 2,
+            weight: 1,
+            edge_type: 'request',
+            reciprocal: false,
+            request_type: 'bunk_with',
+          },
+        ],
+      },
+      false,
+      () => 0.5
+    )
+    const edge = elements.find((e) => e.group === 'edges')
+    expect(edge?.data?.['multi']).toBeUndefined()
+  })
+
+  it('does not flag a backend-collapsed reciprocal edge as multi', () => {
+    // Same-type mutual pairs are collapsed to one reciprocal edge upstream —
+    // that single edge must stay straight/solid, not curved.
+    const elements = buildBunkGraphElements(
+      {
+        nodes,
+        edges: [
+          {
+            source: 1,
+            target: 2,
+            weight: 1,
+            edge_type: 'request',
+            reciprocal: true,
+            request_type: 'bunk_with',
+          },
+        ],
+      },
+      false,
+      () => 0.5
+    )
+    const edge = elements.find((e) => e.group === 'edges')
+    expect(edge?.data?.['multi']).toBeUndefined()
+  })
+
+  it('flags mixed-type cross-scope pairs as multi too', () => {
+    const elements = buildBunkGraphElements(
+      {
+        nodes: [{ id: 1, name: 'Emma Johnson', grade: 4 }],
+        edges: [],
+        cross_scope_nodes: [{ id: 9, name: 'Olivia Chen', grade: 4, bunk_name: 'Cabin 3' }],
+        cross_scope_edges: [
+          {
+            source: 1,
+            target: 9,
+            weight: 1,
+            edge_type: 'request',
+            request_type: 'bunk_with',
+            confidence: 0.8,
+            reciprocal: false,
+            cross_scope: true,
+          },
+          {
+            source: 9,
+            target: 1,
+            weight: 1,
+            edge_type: 'request',
+            request_type: 'not_bunk_with',
+            confidence: 0.8,
+            reciprocal: false,
+            cross_scope: true,
+          },
+        ],
+      },
+      true,
+      () => 0.5
+    )
+    const crossEdges = elements.filter(
+      (e) => e.group === 'edges' && e.data?.['cross_scope'] === true
+    )
+    expect(crossEdges).toHaveLength(2)
+    expect(crossEdges.every((e) => e.data?.['multi'] === true)).toBe(true)
+  })
+})
+
+describe('getBunkCytoscapeStyles edge[?multi]', () => {
+  it('splays multi-flagged edges onto unbundled-bezier curves (parity with session graph)', () => {
+    const multiStyle = findEdgeStyle(getBunkCytoscapeStyles(), 'edge[?multi]')
+    expect(multiStyle).toBeDefined()
+    expect(multiStyle?.['curve-style']).toBe('unbundled-bezier')
+    expect(multiStyle?.['control-point-distances']).toEqual([40])
+    expect(multiStyle?.['control-point-weights']).toEqual([0.5])
+  })
+})
+
+describe('buildBunkColaLayoutOptions', () => {
+  it('derives a bounding box matching the container aspect so cola fills the canvas width', () => {
+    const opts = buildBunkColaLayoutOptions(1600, 900)
+    const bb = opts['boundingBox'] as { x1: number; y1: number; w: number; h: number }
+    expect(bb).toEqual({ x1: 0, y1: 0, w: 1600, h: 900 })
+    expect(bb.w / bb.h).toBeCloseTo(1600 / 900)
+  })
+
+  it('preserves the #1640 disconnected-cluster spacing options', () => {
+    const opts = buildBunkColaLayoutOptions(1600, 900)
+    expect(opts['name']).toBe('cola')
+    expect(opts['nodeSpacing']).toBe(30)
+    expect(opts['padding']).toBe(30)
+    expect(opts['handleDisconnected']).toBe(true)
+  })
+
+  it('omits the bounding box when the container has not been measured yet', () => {
+    // Guards against a zero-area box on the first paint before layout settles.
+    expect(buildBunkColaLayoutOptions(0, 0)['boundingBox']).toBeUndefined()
+    expect(buildBunkColaLayoutOptions(1200, 0)['boundingBox']).toBeUndefined()
   })
 })
 

--- a/frontend/src/components/bunkGraphStyles.test.ts
+++ b/frontend/src/components/bunkGraphStyles.test.ts
@@ -275,11 +275,23 @@ describe('getBunkCytoscapeStyles edge[?multi]', () => {
 })
 
 describe('buildBunkColaLayoutOptions', () => {
-  it('derives a bounding box matching the container aspect so cola fills the canvas width', () => {
+  it('widens the bounding box to a forced landscape aspect so cola packs components across the width', () => {
+    // Matching the container aspect (~1.78:1 here) left sparse graphs too tall —
+    // cola stacked small disconnected groups into a centered column (#1675
+    // visual review of G8A). The box is widened (height preserved) to a forced
+    // landscape aspect so component packing spreads horizontally.
     const opts = buildBunkColaLayoutOptions(1600, 900)
     const bb = opts['boundingBox'] as { x1: number; y1: number; w: number; h: number }
-    expect(bb).toEqual({ x1: 0, y1: 0, w: 1600, h: 900 })
-    expect(bb.w / bb.h).toBeCloseTo(1600 / 900)
+    expect(bb.h).toBe(900) // never shrink the available height
+    expect(bb.w).toBeGreaterThan(1600) // a too-square container gets widened
+    expect(bb.w / bb.h).toBeGreaterThanOrEqual(2.2 - 1e-9)
+  })
+
+  it('leaves an already-landscape container unchanged', () => {
+    // 2400x900 is 2.67:1, already wider than the target — no widening needed.
+    const opts = buildBunkColaLayoutOptions(2400, 900)
+    const bb = opts['boundingBox'] as { x1: number; y1: number; w: number; h: number }
+    expect(bb).toEqual({ x1: 0, y1: 0, w: 2400, h: 900 })
   })
 
   it('preserves the #1640 disconnected-cluster spacing options', () => {

--- a/frontend/src/components/bunkGraphStyles.test.ts
+++ b/frontend/src/components/bunkGraphStyles.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, expect, it } from 'vitest'
 import {
-  buildBunkColaLayoutOptions,
+  buildBunkFcoseLayoutOptions,
   buildBunkGraphElements,
   BUNK_NODE_COLORS,
   FIRST_YEAR_RING_COLOR,
@@ -274,38 +274,29 @@ describe('getBunkCytoscapeStyles edge[?multi]', () => {
   })
 })
 
-describe('buildBunkColaLayoutOptions', () => {
-  it('widens the bounding box to a forced landscape aspect so cola packs components across the width', () => {
-    // Matching the container aspect (~1.78:1 here) left sparse graphs too tall —
-    // cola stacked small disconnected groups into a centered column (#1675
-    // visual review of G8A). The box is widened (height preserved) to a forced
-    // landscape aspect so component packing spreads horizontally.
-    const opts = buildBunkColaLayoutOptions(1600, 900)
-    const bb = opts['boundingBox'] as { x1: number; y1: number; w: number; h: number }
-    expect(bb.h).toBe(900) // never shrink the available height
-    expect(bb.w).toBeGreaterThan(1600) // a too-square container gets widened
-    expect(bb.w / bb.h).toBeGreaterThanOrEqual(2.2 - 1e-9)
+describe('buildBunkFcoseLayoutOptions', () => {
+  it('lays out with fcose, animation off and self-fit off so the component frames once', () => {
+    // fcose spreads a single bunk into a cleaner 2D arrangement than cola (which
+    // tended to collapse sparse bunks toward a line). animate:false → the layout
+    // paints once, already settled (no settle animation). fit:false → cy.fit() in
+    // the modal's layoutstop is the sole framing authority.
+    const opts = buildBunkFcoseLayoutOptions()
+    expect(opts['name']).toBe('fcose')
+    expect(opts['animate']).toBe(false)
+    expect(opts['fit']).toBe(false)
   })
 
-  it('leaves an already-landscape container unchanged', () => {
-    // 2400x900 is 2.67:1, already wider than the target — no widening needed.
-    const opts = buildBunkColaLayoutOptions(2400, 900)
-    const bb = opts['boundingBox'] as { x1: number; y1: number; w: number; h: number }
-    expect(bb).toEqual({ x1: 0, y1: 0, w: 2400, h: 900 })
+  it('packs disconnected components so unrelated sub-clusters do not look linked (#1640)', () => {
+    // fcose's packComponents replaces cola's handleDisconnected/landscape-box
+    // approach to keeping disconnected campers visually separate.
+    expect(buildBunkFcoseLayoutOptions()['packComponents']).toBe(true)
   })
 
-  it('preserves the #1640 disconnected-cluster spacing options', () => {
-    const opts = buildBunkColaLayoutOptions(1600, 900)
-    expect(opts['name']).toBe('cola')
-    expect(opts['nodeSpacing']).toBe(30)
-    expect(opts['padding']).toBe(30)
-    expect(opts['handleDisconnected']).toBe(true)
-  })
-
-  it('omits the bounding box when the container has not been measured yet', () => {
-    // Guards against a zero-area box on the first paint before layout settles.
-    expect(buildBunkColaLayoutOptions(0, 0)['boundingBox']).toBeUndefined()
-    expect(buildBunkColaLayoutOptions(1200, 0)['boundingBox']).toBeUndefined()
+  it('defines positive node-separation, edge-length and repulsion knobs', () => {
+    const opts = buildBunkFcoseLayoutOptions()
+    expect(opts['nodeSeparation']).toBeGreaterThan(0)
+    expect(opts['idealEdgeLength']).toBeGreaterThan(0)
+    expect(opts['nodeRepulsion']).toBeGreaterThan(0)
   })
 })
 

--- a/frontend/src/components/bunkGraphStyles.test.ts
+++ b/frontend/src/components/bunkGraphStyles.test.ts
@@ -190,6 +190,40 @@ describe('buildBunkGraphElements multi (mixed-type conflict pairs)', () => {
     expect(edge?.data?.['multi']).toBeUndefined()
   })
 
+  it('does not flag a same-type pair as multi (curving is only for bunk_with vs not_bunk_with)', () => {
+    // multi must be type-aware: two edges between a pair only splay onto beziers
+    // when they're a genuine bunk_with-vs-not_bunk_with conflict. Two same-type
+    // edges (or a request edge sitting next to a non-request edge) must NOT
+    // curve — that's what produced the spurious bezier on sibling pairs.
+    const elements = buildBunkGraphElements(
+      {
+        nodes,
+        edges: [
+          {
+            source: 1,
+            target: 2,
+            weight: 1,
+            edge_type: 'request',
+            reciprocal: false,
+            request_type: 'bunk_with',
+          },
+          {
+            source: 2,
+            target: 1,
+            weight: 1,
+            edge_type: 'request',
+            reciprocal: false,
+            request_type: 'bunk_with',
+          },
+        ],
+      },
+      false,
+      () => 0.5
+    )
+    const edges = elements.filter((e) => e.group === 'edges')
+    expect(edges.every((e) => e.data?.['multi'] === undefined)).toBe(true)
+  })
+
   it('flags mixed-type cross-scope pairs as multi too', () => {
     const elements = buildBunkGraphElements(
       {

--- a/frontend/src/components/bunkGraphStyles.ts
+++ b/frontend/src/components/bunkGraphStyles.ts
@@ -45,6 +45,39 @@ export function getNodeColor(degree: number): string {
   return degree === 0 ? BUNK_NODE_COLORS.noConnections : BUNK_NODE_COLORS.hasConnections
 }
 
+/** Unordered pair key so A→B and B→A bucket together. Used to detect
+ *  mixed-type conflict pairs that must splay onto opposing beziers. */
+const pairKey = (a: number, b: number): string => (a < b ? `${a}-${b}` : `${b}-${a}`)
+
+/**
+ * Cola layout options for the per-bunk graph. The bounding box is derived from
+ * the live container dimensions so cola spreads nodes across the canvas's
+ * (wide) aspect instead of settling into a square that leaves big left/right
+ * margins after `cy.fit()`. nodeSpacing/padding/handleDisconnected preserve the
+ * #1640 disconnected-cluster separation.
+ *
+ * Returned as a plain object (not typed against cytoscape's LayoutOptions)
+ * because cola's plugin-specific keys aren't in BaseLayoutOptions — the caller
+ * casts at the `cy.layout()` boundary, matching the existing pattern.
+ */
+export function buildBunkColaLayoutOptions(
+  containerWidth: number,
+  containerHeight: number
+): Record<string, unknown> {
+  const options: Record<string, unknown> = {
+    name: 'cola',
+    nodeSpacing: 30,
+    padding: 30,
+    handleDisconnected: true,
+  }
+  // Only constrain to a bounding box once the container has real dimensions —
+  // a zero-area box on the first paint would collapse the layout.
+  if (containerWidth > 0 && containerHeight > 0) {
+    options['boundingBox'] = { x1: 0, y1: 0, w: containerWidth, h: containerHeight }
+  }
+  return options
+}
+
 /** Map each grade present in a bunk to a color from the light/dark ramp.
  *  Younger grades get the lighter end of the scale. */
 export function getBunkGradeColors(grades: readonly number[]): Record<number, string> {
@@ -181,8 +214,20 @@ export function buildBunkGraphElements(
 
   // Backend already collapses mutual same-type pairs into a single edge tagged
   // reciprocal=true; the edge[?reciprocal] selector renders those bold/solid.
+  // A pair that STILL has 2+ edges here is a mixed-type conflict (e.g. A→B
+  // bunk_with + B→A not_bunk_with — backend buckets by (pair, request_type) so
+  // those don't collapse). As straight edges they'd overlap on one line; we tag
+  // them `multi` so the edge[?multi] selector splays them onto opposing beziers.
+  // Mirrors the session graph's treatment in graph/cytoscapeStyles.ts.
+  const inScopePairCounts = new Map<string, number>()
+  data.edges.forEach((edge) => {
+    const k = pairKey(edge.source, edge.target)
+    inScopePairCounts.set(k, (inScopePairCounts.get(k) ?? 0) + 1)
+  })
+
   let edgeIndex = 0
   data.edges.forEach((edge) => {
+    const isMulti = (inScopePairCounts.get(pairKey(edge.source, edge.target)) ?? 0) >= 2
     elements.push({
       group: 'edges',
       data: {
@@ -191,6 +236,7 @@ export function buildBunkGraphElements(
         source: `node-${edge.source}`,
         target: `node-${edge.target}`,
         edge_type: edge.edge_type,
+        ...(isMulti ? { multi: true } : {}),
       },
     })
   })
@@ -223,7 +269,14 @@ export function buildBunkGraphElements(
       })
     })
 
+    const crossPairCounts = new Map<string, number>()
     data.cross_scope_edges.forEach((edge) => {
+      const k = pairKey(edge.source, edge.target)
+      crossPairCounts.set(k, (crossPairCounts.get(k) ?? 0) + 1)
+    })
+
+    data.cross_scope_edges.forEach((edge) => {
+      const isMulti = (crossPairCounts.get(pairKey(edge.source, edge.target)) ?? 0) >= 2
       elements.push({
         group: 'edges',
         data: {
@@ -235,6 +288,7 @@ export function buildBunkGraphElements(
           confidence: edge.confidence,
           reciprocal: edge.reciprocal,
           cross_scope: true,
+          ...(isMulti ? { multi: true } : {}),
         },
       })
     })
@@ -328,6 +382,20 @@ export function getBunkCytoscapeStyles(): StylesheetStyle[] {
         'line-style': 'solid',
         'source-arrow-shape': 'triangle',
         'source-arrow-color': (ele: EdgeSingular) => resolveEdgeColor(ele),
+      },
+    },
+    {
+      selector: 'edge[?multi]',
+      style: {
+        // Mixed-type conflict pairs (bunk_with one way, not_bunk_with the
+        // other) arrive as two opposing straight edges that would overlap on a
+        // single line — hiding one color. Splay each onto its own bezier so
+        // both the blue and the red read. Width/line-style inherit from the
+        // base rule (these are still one-way requests). Mirrors the session
+        // graph's edge[?multi] rule in graph/cytoscapeStyles.ts.
+        'curve-style': 'unbundled-bezier',
+        'control-point-distances': [40],
+        'control-point-weights': [0.5],
       },
     },
     // Cross-scope ghost rendering — mirrors the session-graph stylesheet in

--- a/frontend/src/components/bunkGraphStyles.ts
+++ b/frontend/src/components/bunkGraphStyles.ts
@@ -75,11 +75,22 @@ const conflictedPairs = (
 }
 
 /**
+ * Minimum width:height ratio for the cola bounding box. Matching the container
+ * aspect alone left sparse graphs (many small disconnected groups) too tall —
+ * cola's handleDisconnected packing stacked them into a centered column
+ * (#1675 visual review of G8A). Forcing a landscape box gives that packing
+ * horizontal room to spread. cy.fit() then scales the result to the container,
+ * so a wider-than-container box fills the width (with modest top/bottom margin)
+ * rather than leaving left/right gaps.
+ */
+const MIN_LAYOUT_ASPECT = 2.2
+
+/**
  * Cola layout options for the per-bunk graph. The bounding box is derived from
- * the live container dimensions so cola spreads nodes across the canvas's
- * (wide) aspect instead of settling into a square that leaves big left/right
- * margins after `cy.fit()`. nodeSpacing/padding/handleDisconnected preserve the
- * #1640 disconnected-cluster separation.
+ * the live container, then widened (height preserved) to at least
+ * {@link MIN_LAYOUT_ASPECT} so cola packs disconnected components across the
+ * width instead of stacking them. nodeSpacing/padding/handleDisconnected
+ * preserve the #1640 disconnected-cluster separation.
  *
  * Returned as a plain object (not typed against cytoscape's LayoutOptions)
  * because cola's plugin-specific keys aren't in BaseLayoutOptions — the caller
@@ -98,7 +109,10 @@ export function buildBunkColaLayoutOptions(
   // Only constrain to a bounding box once the container has real dimensions —
   // a zero-area box on the first paint would collapse the layout.
   if (containerWidth > 0 && containerHeight > 0) {
-    options['boundingBox'] = { x1: 0, y1: 0, w: containerWidth, h: containerHeight }
+    // Widen (never shrink the height) so the box is at least MIN_LAYOUT_ASPECT
+    // wide. An already-landscape container is left as-is.
+    const w = Math.max(containerWidth, containerHeight * MIN_LAYOUT_ASPECT)
+    options['boundingBox'] = { x1: 0, y1: 0, w, h: containerHeight }
   }
   return options
 }

--- a/frontend/src/components/bunkGraphStyles.ts
+++ b/frontend/src/components/bunkGraphStyles.ts
@@ -75,46 +75,38 @@ const conflictedPairs = (
 }
 
 /**
- * Minimum width:height ratio for the cola bounding box. Matching the container
- * aspect alone left sparse graphs (many small disconnected groups) too tall —
- * cola's handleDisconnected packing stacked them into a centered column
- * (#1675 visual review of G8A). Forcing a landscape box gives that packing
- * horizontal room to spread. cy.fit() then scales the result to the container,
- * so a wider-than-container box fills the width (with modest top/bottom margin)
- * rather than leaving left/right gaps.
- */
-const MIN_LAYOUT_ASPECT = 2.2
-
-/**
- * Cola layout options for the per-bunk graph. The bounding box is derived from
- * the live container, then widened (height preserved) to at least
- * {@link MIN_LAYOUT_ASPECT} so cola packs disconnected components across the
- * width instead of stacking them. nodeSpacing/padding/handleDisconnected
- * preserve the #1640 disconnected-cluster separation.
+ * fcose layout options for the per-bunk graph.
+ *
+ * fcose replaced cola here (#1675): cola tended to collapse sparse bunks toward
+ * a line, which made an A→C shortcut overlap the A→B→C chain and read as one
+ * tangled connection. fcose's spectral seeding spreads a single bunk into a
+ * cleaner 2D arrangement, so triples land as triangles rather than rows.
+ *
+ * - `animate: false` → the layout computes silently and paints once, settled
+ *   (cola's default settle animation is gone).
+ * - `fit: false` → the modal's `layoutstop` `cy.fit()` is the sole framing
+ *   authority.
+ * - `packComponents: true` → keeps disconnected sub-clusters visually separate
+ *   (replaces cola's `handleDisconnected` for the #1640 concern).
  *
  * Returned as a plain object (not typed against cytoscape's LayoutOptions)
- * because cola's plugin-specific keys aren't in BaseLayoutOptions — the caller
+ * because fcose's plugin-specific keys aren't in BaseLayoutOptions — the caller
  * casts at the `cy.layout()` boundary, matching the existing pattern.
  */
-export function buildBunkColaLayoutOptions(
-  containerWidth: number,
-  containerHeight: number
-): Record<string, unknown> {
-  const options: Record<string, unknown> = {
-    name: 'cola',
-    nodeSpacing: 30,
+export function buildBunkFcoseLayoutOptions(): Record<string, unknown> {
+  return {
+    name: 'fcose',
+    animate: false,
+    fit: false,
     padding: 30,
-    handleDisconnected: true,
+    quality: 'default',
+    randomize: true,
+    packComponents: true,
+    nodeSeparation: 75,
+    idealEdgeLength: 80,
+    nodeRepulsion: 4500,
+    numIter: 2500,
   }
-  // Only constrain to a bounding box once the container has real dimensions —
-  // a zero-area box on the first paint would collapse the layout.
-  if (containerWidth > 0 && containerHeight > 0) {
-    // Widen (never shrink the height) so the box is at least MIN_LAYOUT_ASPECT
-    // wide. An already-landscape container is left as-is.
-    const w = Math.max(containerWidth, containerHeight * MIN_LAYOUT_ASPECT)
-    options['boundingBox'] = { x1: 0, y1: 0, w, h: containerHeight }
-  }
-  return options
 }
 
 /** Map each grade present in a bunk to a color from the light/dark ramp.

--- a/frontend/src/components/bunkGraphStyles.ts
+++ b/frontend/src/components/bunkGraphStyles.ts
@@ -50,6 +50,31 @@ export function getNodeColor(degree: number): string {
 const pairKey = (a: number, b: number): string => (a < b ? `${a}-${b}` : `${b}-${a}`)
 
 /**
+ * Pair keys that carry a genuine bunk_with-vs-not_bunk_with conflict — the ONLY
+ * case that should splay onto opposing beziers. Type-aware on purpose: a pair
+ * with two same-type edges (or a request edge next to a non-request edge) is not
+ * a conflict and must stay straight. A count-based check curved sibling pairs by
+ * mistake.
+ */
+const conflictedPairs = (
+  edges: ReadonlyArray<{ source: number; target: number; request_type?: string | null }>
+): Set<string> => {
+  const typesByPair = new Map<string, Set<string>>()
+  edges.forEach((e) => {
+    if (!e.request_type) return
+    const k = pairKey(e.source, e.target)
+    const set = typesByPair.get(k) ?? new Set<string>()
+    set.add(e.request_type)
+    typesByPair.set(k, set)
+  })
+  const conflicted = new Set<string>()
+  typesByPair.forEach((types, k) => {
+    if (types.has('bunk_with') && types.has('not_bunk_with')) conflicted.add(k)
+  })
+  return conflicted
+}
+
+/**
  * Cola layout options for the per-bunk graph. The bounding box is derived from
  * the live container dimensions so cola spreads nodes across the canvas's
  * (wide) aspect instead of settling into a square that leaves big left/right
@@ -214,20 +239,17 @@ export function buildBunkGraphElements(
 
   // Backend already collapses mutual same-type pairs into a single edge tagged
   // reciprocal=true; the edge[?reciprocal] selector renders those bold/solid.
-  // A pair that STILL has 2+ edges here is a mixed-type conflict (e.g. A→B
-  // bunk_with + B→A not_bunk_with — backend buckets by (pair, request_type) so
-  // those don't collapse). As straight edges they'd overlap on one line; we tag
-  // them `multi` so the edge[?multi] selector splays them onto opposing beziers.
-  // Mirrors the session graph's treatment in graph/cytoscapeStyles.ts.
-  const inScopePairCounts = new Map<string, number>()
-  data.edges.forEach((edge) => {
-    const k = pairKey(edge.source, edge.target)
-    inScopePairCounts.set(k, (inScopePairCounts.get(k) ?? 0) + 1)
-  })
+  // A pair carrying BOTH a bunk_with and a not_bunk_with (e.g. A→B bunk_with +
+  // B→A not_bunk_with — backend buckets by (pair, request_type) so those don't
+  // collapse) is a true conflict: as straight edges they'd overlap on one line,
+  // so we tag them `multi` and the edge[?multi] selector splays them onto
+  // opposing beziers. Mirrors the session graph's treatment in
+  // graph/cytoscapeStyles.ts.
+  const inScopeConflicts = conflictedPairs(data.edges)
 
   let edgeIndex = 0
   data.edges.forEach((edge) => {
-    const isMulti = (inScopePairCounts.get(pairKey(edge.source, edge.target)) ?? 0) >= 2
+    const isMulti = inScopeConflicts.has(pairKey(edge.source, edge.target))
     elements.push({
       group: 'edges',
       data: {
@@ -269,14 +291,10 @@ export function buildBunkGraphElements(
       })
     })
 
-    const crossPairCounts = new Map<string, number>()
-    data.cross_scope_edges.forEach((edge) => {
-      const k = pairKey(edge.source, edge.target)
-      crossPairCounts.set(k, (crossPairCounts.get(k) ?? 0) + 1)
-    })
+    const crossConflicts = conflictedPairs(data.cross_scope_edges)
 
     data.cross_scope_edges.forEach((edge) => {
-      const isMulti = (crossPairCounts.get(pairKey(edge.source, edge.target)) ?? 0) >= 2
+      const isMulti = crossConflicts.has(pairKey(edge.source, edge.target))
       elements.push({
         group: 'edges',
         data: {

--- a/frontend/src/components/graph/cytoscapeStyles.test.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.test.ts
@@ -151,7 +151,10 @@ describe('createGraphElements', () => {
       target: 2,
       edge_type: 'request',
       confidence: 0.9,
-      reciprocal: true,
+      // One-way 1→2 with no 2→1 — so reciprocal MUST be false. The backend sets
+      // reciprocal = graph.has_edge(target, source), which can't be true without
+      // a reverse edge. (A genuine mutual pair is covered by the collapse test.)
+      reciprocal: false,
       weight: 1,
       metadata: {},
       cross_scope: false,
@@ -290,7 +293,8 @@ describe('createGraphElements', () => {
     expect(requestEdge.data.source).toBe('1')
     expect(requestEdge.data.target).toBe('2')
     expect(requestEdge.data.confidence).toBe(0.9)
-    expect(requestEdge.data.is_reciprocal).toBe(true)
+    // A lone one-way edge is not reciprocal.
+    expect(requestEdge.data.is_reciprocal).toBe(false)
   })
 
   it('flags multi only on mixed-type pairs (different request_types still counts)', () => {
@@ -300,6 +304,24 @@ describe('createGraphElements', () => {
     const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, { request: true })
     expect(out).toHaveLength(2)
     expect(out.every((e) => e.data.multi === true)).toBe(true)
+  })
+
+  it('renders a mixed-type conflict as one-way edges even when the backend marks them reciprocal', () => {
+    // The session backend sets reciprocal = graph.has_edge(target, source), which
+    // is TRUE for any pair with edges both ways — including a true conflict
+    // (A wants B, B refuses A). Those edges are one-directional and must NOT
+    // render as the bold solid double-headed reciprocal style. The splay branch
+    // forces is_reciprocal=false so they stay dashed single-arrow (just curved
+    // onto separate beziers). Fixtures use reciprocal=true to mirror the live
+    // backend — the prior test masked this by defaulting reciprocal=false.
+    const edges: GraphEdgeData[] = [
+      reqEdge(1, 2, 'bunk_with', true),
+      reqEdge(2, 1, 'not_bunk_with', true),
+    ]
+    const { edges: out } = createGraphElements(mockNodes, edges, mockBunksData, { request: true })
+    expect(out).toHaveLength(2)
+    expect(out.every((e) => e.data.multi === true)).toBe(true)
+    expect(out.every((e) => e.data.is_reciprocal === false)).toBe(true)
   })
 
   it('collapses a same-type reciprocal bunk_with pair into one edge tagged is_reciprocal', () => {

--- a/frontend/src/components/graph/cytoscapeStyles.ts
+++ b/frontend/src/components/graph/cytoscapeStyles.ts
@@ -517,9 +517,17 @@ export function createGraphElements(
 
     // Otherwise, emit each edge separately. Pairs with 2+ edges get the
     // multi flag so the stylesheet curves them (true conflicts).
+    //
+    // Every edge reaching this branch is one-directional by construction —
+    // same-type mutuals already collapsed above. So is_reciprocal MUST be
+    // false here, regardless of the backend's edge.reciprocal: that flag is
+    // graph.has_edge(target, source), which is type-blind and reads true for a
+    // mixed-type conflict (A wants B, B refuses A). Forwarding it would render
+    // each one-way conflict edge as a bold solid double-headed line instead of
+    // a dashed single-arrow one.
     const isMulti = bucket.length >= 2
     bucket.forEach((edge) => {
-      edges.push(buildEdge(edge, { is_reciprocal: edge.reciprocal ?? false, multi: isMulti }))
+      edges.push(buildEdge(edge, { is_reciprocal: false, multi: isMulti }))
     })
   })
 
@@ -551,9 +559,12 @@ export function createGraphElements(
         return
       }
     }
+    // is_reciprocal false for the same reason as the in-scope splay branch:
+    // these are one-way edges, and the backend's type-blind reciprocal flag
+    // must not promote a conflict pair to the double-headed reciprocal style.
     const isMulti = bucket.length >= 2
     bucket.forEach((edge) => {
-      edges.push(buildCrossEdge(edge, { is_reciprocal: edge.reciprocal ?? false, multi: isMulti }))
+      edges.push(buildCrossEdge(edge, { is_reciprocal: false, multi: isMulti }))
     })
   })
 

--- a/frontend/src/components/graph/graphLayout.ts
+++ b/frontend/src/components/graph/graphLayout.ts
@@ -29,8 +29,8 @@ export function getFcoseOptions(params: FcoseOptionsParams) {
     componentSpacing: 130,
   }
   const noCompound = {
-    nodeSeparation: 400,
-    componentSpacing: 400,
+    nodeSeparation: 180,
+    componentSpacing: 180,
   }
   const spacing = params.hasCompoundNodes ? compound : noCompound
 

--- a/tests/unit/bunking/graph/test_satisfaction_status.py
+++ b/tests/unit/bunking/graph/test_satisfaction_status.py
@@ -752,6 +752,128 @@ def test_build_bunk_graph_reciprocal_pair_both_campers_satisfied() -> None:
 
 
 # ---------------------------------------------------------------------------
+# #1675 follow-up: sibling edges are deprecated and must NOT appear on the bunk
+# graph. The session builder (optimized_graph_builder) never adds them; the
+# bunk builder used to add sibling edges and tag request edges with a secondary
+# "sibling" type, which the router serialized as a second edge per pair —
+# rendering a spurious extra line (and, after the #1640 multi change, a spurious
+# bezier) between siblings. build_bunk_graph must now be request-only.
+# ---------------------------------------------------------------------------
+
+
+def _make_sibling_person(cm_id: int, first_name: str, last_name: str, household_id: int) -> object:
+    """Person stub that shares a household_id so the (removed) sibling path would fire."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        cm_id=cm_id,
+        first_name=first_name,
+        last_name=last_name,
+        grade=7,
+        gender="M",
+        age=12,
+        family_id=None,
+        household_id=household_id,
+    )
+
+
+def test_build_bunk_graph_omits_sibling_edges() -> None:
+    """Two siblings in the same bunk with NO requests between them must yield
+    zero edges — no edge_type='sibling' is ever added."""
+    pb = MagicMock()
+    person_a_id, person_b_id = 3001, 3002
+    bunk_cm_id, session_cm_id, year = 888, 999, 2026
+    household = 4242
+
+    assign_a = _make_assignment_with_expand(person_a_id)
+    assign_b = _make_assignment_with_expand(person_b_id)
+    person_a = _make_sibling_person(person_a_id, "Mateo", "Garcia", household)
+    person_b = _make_sibling_person(person_b_id, "Liam", "Garcia", household)
+
+    def _collection_side_effect(name: str) -> MagicMock:
+        col = MagicMock()
+        if name == "bunk_assignments":
+            col.get_full_list.return_value = [assign_a, assign_b]
+        elif name == "bunk_requests":
+            col.get_full_list.return_value = []
+        elif name == "persons":
+
+            def _get_first(flt: str, *_a: object, **_kw: object) -> object:
+                if str(person_a_id) in flt:
+                    return person_a
+                if str(person_b_id) in flt:
+                    return person_b
+                raise RuntimeError(f"no person for filter {flt!r}")
+
+            col.get_first_list_item.side_effect = _get_first
+        else:
+            col.get_full_list.return_value = []
+            col.get_first_list_item.side_effect = RuntimeError("no record")
+        return col
+
+    pb.collection.side_effect = _collection_side_effect
+
+    builder = SocialGraphBuilder(pb=pb)
+    bunk_graph = builder.build_bunk_graph(year=year, bunk_cm_id=bunk_cm_id, session_cm_id=session_cm_id)
+
+    sibling_edges = [(u, v) for u, v, d in bunk_graph.edges(data=True) if d.get("edge_type") == "sibling"]
+    assert not sibling_edges, f"expected no sibling edges, got {sibling_edges}"
+    assert bunk_graph.number_of_edges() == 0, (
+        f"siblings with no requests must yield zero edges, got {bunk_graph.number_of_edges()}"
+    )
+
+
+def test_build_bunk_graph_sibling_request_carries_no_sibling_secondary() -> None:
+    """Two siblings WITH a reciprocal bunk_with request must produce exactly the
+    request edge — no secondary_type='sibling' that the router would serialize as
+    a second (spurious) edge between them."""
+    pb = MagicMock()
+    person_a_id, person_b_id = 3101, 3102
+    bunk_cm_id, session_cm_id, year = 889, 999, 2026
+    household = 5252
+
+    assign_a = _make_assignment_with_expand(person_a_id)
+    assign_b = _make_assignment_with_expand(person_b_id)
+    person_a = _make_sibling_person(person_a_id, "Mateo", "Garcia", household)
+    person_b = _make_sibling_person(person_b_id, "Liam", "Garcia", household)
+    request_ab = _make_request_record(person_a_id, person_b_id, source="family")
+    request_ba = _make_request_record(person_b_id, person_a_id, source="family")
+
+    def _collection_side_effect(name: str) -> MagicMock:
+        col = MagicMock()
+        if name == "bunk_assignments":
+            col.get_full_list.return_value = [assign_a, assign_b]
+        elif name == "bunk_requests":
+            col.get_full_list.return_value = [request_ab, request_ba]
+        elif name == "persons":
+
+            def _get_first(flt: str, *_a: object, **_kw: object) -> object:
+                if str(person_a_id) in flt:
+                    return person_a
+                if str(person_b_id) in flt:
+                    return person_b
+                raise RuntimeError(f"no person for filter {flt!r}")
+
+            col.get_first_list_item.side_effect = _get_first
+        else:
+            col.get_full_list.return_value = []
+            col.get_first_list_item.side_effect = RuntimeError("no record")
+        return col
+
+    pb.collection.side_effect = _collection_side_effect
+
+    builder = SocialGraphBuilder(pb=pb)
+    bunk_graph = builder.build_bunk_graph(year=year, bunk_cm_id=bunk_cm_id, session_cm_id=session_cm_id)
+
+    for u, v, d in bunk_graph.edges(data=True):
+        assert d.get("edge_type") != "sibling", f"sibling edge {u}->{v} must not exist"
+        assert d.get("secondary_type") != "sibling", (
+            f"edge {u}->{v} must not carry a sibling secondary_type (got {d.get('secondary_type')!r})"
+        )
+        assert not d.get("has_sibling"), f"edge {u}->{v} must not be flagged has_sibling"
+
+
+# ---------------------------------------------------------------------------
 # Audit 2026-04-29 finding: build_bunk_graph fetched all request types.
 # A not_bunk_with row between two campers placed in the same bunk produced an
 # edge that the satisfaction bucketer treated as "satisfied" (bunk == bunk),


### PR DESCRIPTION
## Summary

- **#1663** — Re-arm `hasMountedExpandRef` on Cytoscape instance rebuild so the expand/fit RAF chain doesn't race the new instance's worker `layout+fit` call when `graphData` changes.
- **#1640** — Pass explicit cola layout options (`nodeSpacing: 30`, `padding: 30`, `handleDisconnected: true`) + `cy.fit()` on `layoutstop` so disconnected bunk-graph sub-clusters don't pack adjacently and appear falsely linked.
- **#1633** — Reduce `noCompound` fcose spacing from 400 → 180 (`nodeSeparation` + `componentSpacing`) so disconnected components in the friends graph pack without overflowing the fixed-height canvas.

## What to eyeball

**#1633** (`/summer/session/<n>/friends`, camper-only graph with no bunk compound nodes): clusters should be spaced comfortably but not scatter into a very tall arrangement. 180 is a first-pass visual pick — adjust if still too spread or too cramped.

**#1640** (Bunk Social Graph modal → any bunk): unrelated disconnected campers should no longer appear packed directly adjacent to the connected cluster. The `cy.fit()` on layout completion ensures the full graph is visible after cola settles.

## Notes

- `componentSpacing` is **not** a cytoscape-cola option (v2.5.1) — only `nodeSpacing`, `padding`, and `handleDisconnected` are supported. The original issue description mentioned `componentSpacing: 80` but cola doesn't expose that knob; `handleDisconnected: true` (cola's built-in disconnected-component separation) covers that intent.
- Cola's plugin-specific options required a `as Parameters<...>[0]` cast since `BaseLayoutOptions` doesn't include them.

## Test plan

- [x] All existing graph tests pass (46 tests, 0 failures): `SocialNetworkGraph`, `BunkSocialGraphModal`, `BunkSocialGraphModal.crossScope`, `graphLayout`
- [x] New source-assertion test added for #1663: verifies `hasMountedExpandRef.current = false` appears in the destroy block before `const cy = cytoscape(`
- [x] prettier, eslint, tsc, vitest all green
- [ ] Visual spot-check: `/summer/session/<n>/friends` for #1633 spacing
- [ ] Visual spot-check: Bunk Social Graph modal for #1640 cluster separation

## Update — edge-rendering correctness + aspect-fill layout (follow-up commits)

**Aspect-fill pre-fit (bunk graph):** cola now gets a bounding box derived from the live container, so the layout spreads to fill the canvas width instead of settling into a square with big left/right margins.

**Edge-rendering correctness (`fix(graph)`)** — three fixes about how request edges render:

- **Session graph — conflict edges.** A true conflict (A requests *bunk with* B, B requests *not with* A — two one-way requests) rendered as two thick solid **double-headed** beziers, as if both were mutual. They now render **dashed, single-arrow, curved** (one blue, one red). Root cause: the backend's `reciprocal` flag is `graph.has_edge(target, source)` — type-blind, true for any pair with edges both ways.
- **Bunk graph — siblings.** Sibling edges no longer render at all (the session graph dropped them under #1094). Previously a request between siblings drew the request edge *plus* a stray dashed sibling line, and the new bezier logic curved both. `build_bunk_graph` is now request-only (node degree/centrality too).
- **Bunk graph — bezier only on real conflicts.** Beziers now appear only when a pair carries *both* a bunk_with and a not_bunk_with, never for any other 2-edge pairing.

### What to eyeball (new)
- [ ] **Session graph** — a conflict pair (one camper wants another, the other refuses): two **dashed one-way** curved arrows (blue + red), NOT thick double-headed.
- [ ] **Bunk graph** — two siblings with a mutual request: ONE thick double-headed curve (the request) and **no** separate dashed sibling line. Siblings with no requests between them: **no edge** at all.
- [ ] **Bunk graph** — pre-fit uses the full width, not a centered square.

### Known limitation (out of scope)
A single camper filing BOTH *bunk with* and *not with* toward the same target can't be drawn as two edges today: the graph model (`nx.DiGraph`) keeps one edge per direction, so one is dropped (last-wins). The "dual mutual bezier + one-way dotted bezier" case would require switching the builders to `MultiDiGraph`.

Closes #1633, #1640, #1663

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed skipped expand/fullscreen resize+fit when a graph is rebuilt.
  * One-way conflict edges now render correctly (not misclassified as reciprocal).

* **Improvements**
  * Switched to a new graph layout engine with tighter spacing for sparse graphs and better component packing.
  * Conflicting edges splay apart using improved edge styling for clearer visuals.
  * Graph sizing/fit behavior improved after layout.

* **Tests**
  * Added coverage for rebuild behavior, conflict styling, layout options, and sibling-edge omission.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
