### PR TITLE
fix(api): unify material-parent definition across solver, validator, satisfaction (#1670)

### DIFF
--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field
 
 from bunking.logging_config import get_logger
 from bunking.models import Bunk, BunkAssignment, BunkRequest, Person, Session
+from bunking.satisfaction.bucket import MaterialReqRow, compute_material_request_ids
 from bunking.satisfaction.predicate import is_request_satisfied
 from bunking.solver.constants import (
     DEFAULT_BUNK_CAPACITY,
@@ -634,6 +635,26 @@ class BunkingValidator:
             except TypeError, ValueError:
                 return False
 
+        # #1664/#1671: contextual material-parent set. A form age_preference is
+        # material only as a sole form request — suppressed when its requester
+        # also has a resolved-and-possible form bunk_with/not_bunk_with. Computed
+        # once from the full request list with the impossibility report the
+        # validator already receives, mirroring the solver's single source of truth.
+        material_grouping: dict[int, list[MaterialReqRow]] = defaultdict(list)
+        for r in requests:
+            try:
+                material_grouping[int(r.requester_person_cm_id)].append(
+                    MaterialReqRow(
+                        id=r.id or "",
+                        source_field=r.source_field,
+                        request_type=r.request_type,
+                        status=r.status,
+                    )
+                )
+            except TypeError, ValueError:
+                pass  # non-numeric requester_person_cm_id — skipped, matching rest of validator
+        material_request_ids = compute_material_request_ids(material_grouping, impossible_request_ids or set())
+
         # Process each request
         for request in requests:
             requester_id = request.requester_person_cm_id
@@ -674,7 +695,13 @@ class BunkingValidator:
                     )
 
                 is_best_effort = raw_source_field == SourceField.SOCIALIZE_WITH
-                if raw_source_field == SourceField.BUNK_REQUEST_FORM:
+                # #1664/#1671: a form age-pref suppressed from material_request_ids
+                # is not a material request — drop it from material/alerting (it
+                # becomes an immaterial, uncounted row like socialize_with).
+                is_material = (
+                    raw_source_field == SourceField.BUNK_REQUEST_FORM and (request.id or "") in material_request_ids
+                )
+                if is_material:
                     material_parent_by_person[requester_id].append(request)
                     alerting_requests_by_person[requester_id].append(request)
                 elif is_best_effort:
@@ -691,7 +718,7 @@ class BunkingValidator:
                 # Check if this valid request is satisfied (#1170 — canonical predicate via _is_satisfied adapter).
                 if _is_satisfied(request):
                     satisfied_requests_by_person[requester_id].append(request)
-                    if raw_source_field == SourceField.BUNK_REQUEST_FORM:
+                    if is_material:
                         satisfied_material_parent_by_person[requester_id].append(request)
                         satisfied_alerting_by_person[requester_id].append(request)
                     elif is_best_effort:

--- a/bunking/satisfaction/aggregate.py
+++ b/bunking/satisfaction/aggregate.py
@@ -31,7 +31,13 @@ from bunking.satisfaction.api_shape import (
     SatisfactionFlags,
     SatisfactionResponse,
 )
-from bunking.satisfaction.bucket import COUNTED_BUCKETS, RequestBucket, classify_request
+from bunking.satisfaction.bucket import (
+    COUNTED_BUCKETS,
+    MaterialReqRow,
+    RequestBucket,
+    classify_request,
+    compute_material_request_ids,
+)
 from bunking.satisfaction.predicate import evaluate_request
 
 logger = get_logger(__name__)
@@ -119,6 +125,24 @@ def camper_satisfaction(
         CamperSatisfaction with per_request statuses, counted_totals,
         immaterial visible-uncounted bucket, and derived flags.
     """
+    # #1664/#1672: a form age_preference is material only as a sole form request.
+    # Suppress it (count as immaterial) when a coexisting resolved form
+    # bunk_with/not_bunk_with exists. This path has no impossibility data and is
+    # frontend-polled, so we pass an empty impossible set (option (b)): suppression
+    # fires on any resolved coexisting real form request. A coexisting *impossible*
+    # form request would over-suppress vs the solver/validator — an accepted,
+    # documented divergence for this hot read path. Per-request statuses are untouched.
+    material_rows = [
+        MaterialReqRow(
+            id=str(req.get("id", "")),
+            source_field=_coerce_str(req.get("source_field")),
+            request_type=_coerce_str(req.get("request_type")),
+            status="resolved",
+        )
+        for req in person_requests
+    ]
+    material_ids = compute_material_request_ids({person_cm_id: material_rows}, set())
+
     per_request: list[PerRequestStatus] = []
     counted: dict[RequestBucket, list[bool]] = {b: [] for b in COUNTED_BUCKETS}
     immaterial: list[bool] = []
@@ -137,10 +161,12 @@ def camper_satisfaction(
                 req.get("id"),
             )
             satisfied = False
-        per_request.append(
-            PerRequestStatus(request_id=str(req.get("id", "")), bucket=bucket, satisfied=satisfied, detail=detail)
-        )
-        if bucket in COUNTED_BUCKETS:
+        req_id = str(req.get("id", ""))
+        per_request.append(PerRequestStatus(request_id=req_id, bucket=bucket, satisfied=satisfied, detail=detail))
+        if bucket == RequestBucket.MATERIAL_PARENT and req_id not in material_ids:
+            # #1664: suppressed coexisting form age-pref — visible per-request, uncounted.
+            immaterial.append(satisfied)
+        elif bucket in COUNTED_BUCKETS:
             counted[bucket].append(satisfied)
         else:
             immaterial.append(satisfied)

--- a/bunking/satisfaction/bucket.py
+++ b/bunking/satisfaction/bucket.py
@@ -13,7 +13,8 @@ imports keep working, delegating all classification to the registry.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, NamedTuple, Protocol
 
 from bunking.logging_config import get_logger
 from bunking.satisfaction.request_registry import (
@@ -27,8 +28,39 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+
+class MaterialReqLike(Protocol):
+    """Minimal structural shape compute_material_request_ids reads from a request.
+
+    DirectBunkRequest (solver) and BunkRequest (validator) satisfy this
+    directly; dict-row callers (the satisfaction aggregator) wrap rows in
+    MaterialReqRow. Members are read-only properties so NamedTuple adapters and
+    plain-attribute models both match.
+    """
+
+    @property
+    def id(self) -> str: ...
+    @property
+    def source_field(self) -> str | None: ...
+    @property
+    def request_type(self) -> str: ...
+    @property
+    def status(self) -> str: ...
+
+
+class MaterialReqRow(NamedTuple):
+    """MaterialReqLike adapter for dict-based callers (e.g. the aggregator)."""
+
+    id: str
+    source_field: str | None
+    request_type: str
+    status: str
+
+
 __all__ = [
     "COUNTED_BUCKETS",
+    "MaterialReqLike",
+    "MaterialReqRow",
     "RequestBucket",
     "classify_request",
     "compute_material_request_ids",
@@ -46,7 +78,7 @@ def classify_request(source_field: str) -> RequestBucket:
     return report_group_for(source_field)
 
 
-def is_material_parent_request(request: DirectBunkRequest) -> bool:
+def is_material_parent_request(request: MaterialReqLike) -> bool:
     """True iff the request's source_field classifies as MATERIAL_PARENT.
 
     Defensive: missing or unknown source_field returns False with a debug log.
@@ -69,7 +101,7 @@ def is_material_parent_request(request: DirectBunkRequest) -> bool:
 
 
 def compute_material_request_ids(
-    requests_by_person: dict[int, list[DirectBunkRequest]],
+    requests_by_person: Mapping[int, Sequence[MaterialReqLike]],
     impossible_request_ids: set[str],
 ) -> set[str]:
     """Material-parent request IDs, with the #1664 age-preference suppression.

--- a/tests/unit/bunking/satisfaction/test_aggregate.py
+++ b/tests/unit/bunking/satisfaction/test_aggregate.py
@@ -354,6 +354,56 @@ def test_camper_satisfaction_threads_detail_for_unsatisfied_not_bunk_with() -> N
     assert result.per_request[0].detail == "Same bunk (conflict!)"
 
 
+class TestMaterialParentSuppression1672:
+    def test_coexisting_form_age_pref_suppressed_from_material(self) -> None:
+        """#1672/#1664: a form age_preference is material only as a sole form
+        request. With a coexisting form bunk_with it drops from the MATERIAL_PARENT
+        totals (counted as immaterial), and no longer masks the unsatisfied bunk_with.
+        Per-request statuses are untouched."""
+        bunk_with = _req("r1", "bunk_with", 1, 2, "bunk_request_form")
+        age_pref = _req(
+            "ap",
+            "age_preference",
+            1,
+            None,
+            "bunk_request_form",
+            requester_grade=5,
+            age_preference_target="older",
+        )
+        result = camper_satisfaction(
+            person_cm_id=1,
+            person_requests=[bunk_with, age_pref],
+            person_to_bunk={1: 100, 2: 101},  # bunk_with UNsatisfied
+            bunkmate_grades={1: [8]},  # older bunkmate -> age_pref satisfiable
+        )
+        mp = result.counted_totals[RequestBucket.MATERIAL_PARENT]
+        assert mp.total == 1  # age-pref suppressed (was 2)
+        assert mp.satisfied == 0  # only the unsatisfied bunk_with counts
+        # The unsatisfied sole material request now correctly trips the flag.
+        assert result.flags.parent_min_one_violation
+        # Per-request statuses untouched — both rows still reported.
+        assert len(result.per_request) == 2
+
+    def test_sole_form_age_pref_stays_material(self) -> None:
+        """A form age_preference with no coexisting real form request stays material."""
+        age_pref = _req(
+            "ap",
+            "age_preference",
+            1,
+            None,
+            "bunk_request_form",
+            requester_grade=5,
+            age_preference_target="older",
+        )
+        result = camper_satisfaction(
+            person_cm_id=1,
+            person_requests=[age_pref],
+            person_to_bunk={1: 100},
+            bunkmate_grades={1: [8]},
+        )
+        assert result.counted_totals[RequestBucket.MATERIAL_PARENT].total == 1
+
+
 def test_camper_satisfaction_malformed_request_has_none_detail() -> None:
     """Malformed rows logged as warning + treated as unsatisfied keep detail=None."""
     bad_age = {

--- a/tests/unit/bunking/satisfaction/test_bucket.py
+++ b/tests/unit/bunking/satisfaction/test_bucket.py
@@ -225,3 +225,19 @@ class TestComputeMaterialRequestIds:
             2: [_req("c", "age_preference", "bunk_request_form", requester=2, requested=None)],
         }
         assert compute_material_request_ids(reqs, set()) == {"b", "c"}
+
+    def test_accepts_non_directbunkrequest_rows_via_protocol(self) -> None:
+        """#1670: the single source of truth must accept any MaterialReqLike row,
+        not just DirectBunkRequest, so validator + aggregator can call it."""
+        from bunking.satisfaction.bucket import MaterialReqRow
+
+        reqs = {
+            1: [
+                MaterialReqRow(
+                    id="a", source_field="bunk_request_form", request_type="age_preference", status="resolved"
+                ),
+                MaterialReqRow(id="b", source_field="bunk_request_form", request_type="bunk_with", status="resolved"),
+            ]
+        }
+        # Same #1664 suppression as DirectBunkRequest input: the age-pref is dropped.
+        assert compute_material_request_ids(reqs, set()) == {"b"}

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -572,6 +572,50 @@ class TestBunkingValidator:
         adjacency_issues = [i for i in result.issues if i.type == "grade_adjacency_warning"]
         assert len(adjacency_issues) == 0
 
+    def test_coexisting_form_age_pref_not_counted_as_material(
+        self, validator, basic_session, basic_bunks, basic_persons
+    ):
+        """#1671/#1664: a form age_preference coexisting with a form bunk_with is
+        suppressed from material_parent, so it neither inflates the count nor masks
+        an unsatisfied bunk_with."""
+        assignments = [
+            MockBunkAssignment(person_cm_id="10001", bunk_cm_id="20001"),
+            MockBunkAssignment(person_cm_id="10002", bunk_cm_id="20002"),  # bunk_with UNsatisfied
+            MockBunkAssignment(person_cm_id="10003", bunk_cm_id="20002"),
+        ]
+        requests = [
+            MockBunkRequest(
+                id="r1",
+                requester_person_cm_id="10001",
+                requested_person_cm_id="10002",
+                request_type="bunk_with",
+                status="resolved",
+                source_field=SourceField.BUNK_REQUEST_FORM,
+                source="family",
+            ),
+            MockBunkRequest(
+                id="ap1",
+                requester_person_cm_id="10001",
+                requested_person_cm_id=None,
+                request_type="age_preference",
+                status="resolved",
+                source_field=SourceField.BUNK_REQUEST_FORM,
+                source="family",
+                age_preference_target="older",
+            ),
+        ]
+        result = validator.validate_bunking(
+            session=basic_session,
+            bunks=basic_bunks,
+            assignments=assignments,
+            persons=basic_persons,
+            requests=requests,
+        )
+        # Only the bunk_with is material; the coexisting age-pref is suppressed.
+        assert result.statistics.material_parent_requests == 1
+        # The sole material request (bunk_with) is unsatisfied -> NOT masked.
+        assert result.statistics.satisfied_material_parent_requests == 0
+
 
 class TestLevelProgressionValidation:
     """Tests for level progression validation."""


### PR DESCRIPTION
Unifies the "material parent" definition (#1664/#1668) across all three consumers via the single source of truth `compute_material_request_ids`. After #1668 fixed materiality solver-side, the post-check validator and `/api/satisfaction` aggregator still counted a coexisting form `age_preference` as material — diverging from the solver and masking campers who missed their only `bunk_with` but landed in their preferred age band.

- **#1670** — widen `compute_material_request_ids` to a read-only `MaterialReqLike` protocol (+ `MaterialReqRow` adapter). Covariant `Mapping[int, Sequence[...]]` signature means the solver's existing call sites are untouched.
- **#1671** — post-check validator suppresses coexisting form age-prefs, full precision (uses the real `impossible_request_ids` it already receives).
- **#1672** — `/api/satisfaction` aggregator applies the same suppression with an empty impossible set (documented option-(b) approximation; the path is frontend-polled and has no impossibility determination). Per-request statuses untouched.

TDD: red phase confirmed for each (ImportError → `2 == 1` count assertions). Full mockable suite green (5257 passed), mypy + ruff clean.

Closes #1670, #1671, #1672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected request satisfaction calculation to properly handle material parent requests.
  * Fixed request validation when multiple form types coexist in a single request set.
  * Enhanced accuracy of request counting for edge cases involving mixed request types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1678?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->