### PR TITLE
fix(solver): exclude parent_nbw_yields from MP failure metrics / mp_constraint_bug_signal (#1669)

### DIFF
--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -1178,6 +1178,13 @@ class DirectBunkingSolver:
         # down and the metrics drift apart purely as bookkeeping artifacts.
         impossible_request_ids: set[str] = {item.request_id for item in self.impossibility_report.flat}
 
+        # #1669: parent_nbw_yields are intentionally co-placed (Stream C, #1667),
+        # so a yielded NBW must not read as an unmet material-parent request.
+        # Excluding them keeps mp_constraint_bug_signal a true "hard constraint
+        # failed to bind" alarm and stops mp_*_total inflation. Staff NBW yields
+        # classify as STAFF (never in material_request_ids), so no exclusion needed.
+        yielded_request_ids: set[str] = {y["nbw_request_id"] for y in self.parent_nbw_yields}
+
         for person_cm_id, requests in self.input.requests_by_person.items():
             if person_cm_id not in person_to_bunk:
                 continue
@@ -1190,7 +1197,9 @@ class DirectBunkingSolver:
             # below, which skips campers with >=1 satisfied request.
             satisfied_ids_for_person: set[str] = set(all_satisfied.get(person_cm_id, []))
 
-            resolved_mp = [r for r in resolved_requests if r.id in self.material_request_ids]
+            resolved_mp = [
+                r for r in resolved_requests if r.id in self.material_request_ids and r.id not in yielded_request_ids
+            ]
             resolved_possible_mp = [r for r in resolved_mp if r.id not in impossible_request_ids]
             resolved_possible = [r for r in resolved_requests if r.id not in impossible_request_ids]
 
@@ -1225,7 +1234,7 @@ class DirectBunkingSolver:
 
             resolved_possible = [r for r in self.possible_requests.get(person_cm_id, []) if r.status == "resolved"]
             resolved_possible_count[person_cm_id] = len(resolved_possible)
-            if any(r.id in self.material_request_ids for r in resolved_possible):
+            if any(r.id in self.material_request_ids and r.id not in yielded_request_ids for r in resolved_possible):
                 material_parent_unmet.append(person_cm_id)
             else:
                 other_unmet.append(person_cm_id)

--- a/tests/unit/solver/test_request_validation_mp_counts.py
+++ b/tests/unit/solver/test_request_validation_mp_counts.py
@@ -338,3 +338,62 @@ def test_not_bunk_with_unassigned_target_counts_as_satisfied() -> None:
     assert s["unsatisfied_no_possible"] == 0
     # not_bunk_with is non-material, so MP scopes are untouched.
     assert s["mp_campers_total"] == 0
+
+
+def test_parent_nbw_yield_excluded_from_mp_bug_signal() -> None:
+    """#1669: an intentionally-yielded parent NBW (Stream C carve-out, #1667)
+    must NOT count as an unmet material-parent request or trip
+    mp_constraint_bug_signal."""
+    persons = [_person(1), _person(2)]
+    bunks = [_bunk(100)]
+    # Camper 1's sole material request: form not_bunk_with -> camper 2.
+    requests = [_req("n1", 1, 2, source_field="bunk_request_form", request_type="not_bunk_with")]
+    # Place them TOGETHER so the NBW is UNsatisfied.
+    assignments = {1: 100, 2: 100}
+
+    input_data = DirectSolverInput(persons=persons, bunks=bunks, requests=requests)
+    solver = DirectBunkingSolver(input_data, config_service=MagicMock())
+    # Simulate Stream C having yielded n1 (the carve-out records it pre-solve).
+    solver.parent_nbw_yields = [
+        {
+            "nbw_request_id": "n1",
+            "subject_cm": 1,
+            "target_cm": 2,
+            "protected_parent_request_id": "pX",
+            "protected_camper_cm": 2,
+        }
+    ]
+    assignment_list = [
+        DirectBunkAssignment(person_cm_id=pid, bunk_cm_id=bid, session_cm_id=500, year=2026)
+        for pid, bid in assignments.items()
+    ]
+    solver._check_must_satisfy_one_violations(assignment_list)
+    s = solver.request_validation_summary
+
+    assert s["mp_constraint_bug_signal"] == 0
+    assert s["unsatisfied_material_parent_unmet"] == 0
+    assert s["mp_requests_total"] == 0  # the only MP request was a yield
+    assert s["mp_campers_total"] == 0
+
+
+def test_non_yielded_unmet_mp_still_signals() -> None:
+    """Guard against over-exclusion: a genuinely unmet material NBW (no yield
+    recorded) still increments mp_constraint_bug_signal."""
+    persons = [_person(1), _person(2)]
+    bunks = [_bunk(100)]
+    requests = [_req("n1", 1, 2, source_field="bunk_request_form", request_type="not_bunk_with")]
+    assignments = {1: 100, 2: 100}  # together -> NBW unsatisfied
+
+    input_data = DirectSolverInput(persons=persons, bunks=bunks, requests=requests)
+    solver = DirectBunkingSolver(input_data, config_service=MagicMock())
+    assert solver.parent_nbw_yields == []  # no yield recorded
+
+    assignment_list = [
+        DirectBunkAssignment(person_cm_id=pid, bunk_cm_id=bid, session_cm_id=500, year=2026)
+        for pid, bid in assignments.items()
+    ]
+    solver._check_must_satisfy_one_violations(assignment_list)
+    s = solver.request_validation_summary
+
+    assert s["mp_constraint_bug_signal"] == 1
+    assert s["mp_requests_total"] == 1


### PR DESCRIPTION
A parent `not_bunk_with` deliberately yielded by the Stream-C carve-out (#1667) was still counted as an unmet material-parent request in `_check_must_satisfy_one_violations`, inflating `mp_*_total` and raising `mp_constraint_bug_signal` — a false "hard constraint failed to bind" alarm on dashboards/alerting.

Excludes yielded request ids (`parent_nbw_yields`) from `resolved_mp` and the `material_parent_unmet` membership test. Staff NBW yields classify as STAFF (never in `material_request_ids`), so they need no exclusion. Families-to-call is unaffected — yielded separations still surface there via the validator as ordinary unmet requests.

Pre-existing on `main` from #1667; surfaced by CodeRabbit during the #1668 review. TDD: red phase confirmed (`1 == 0`), baseline non-yield test stays green, full solver suite 361 passed, mypy + ruff clean.

Closes #1669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed incorrect counting of unmet material-parent requests. The system now properly accounts for certain yield cases, preventing false reporting of unmet requests and maintaining accurate MP-related metrics.

* **Tests**
  * Added test coverage for material-parent request validation with yield cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->