### PR TITLE
chore(ci): parallelize mypy with --num-workers 4 (~2.8x faster cold)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,12 @@ jobs:
       run: uv run ruff check .
 
     - name: Python type check (mypy)
-      run: uv run mypy . --explicit-package-bases
+      # --num-workers 4: parallel checking is ~2.8x faster on a cold cache (CI
+      # restores no .mypy_cache). 4 is the sweet spot for this import graph (beats
+      # 8/12 even on >4 cores) and maps to the 4-vCPU ubuntu-latest runner. Output
+      # is byte-identical to single-threaded. Pre-push stays single-threaded — a
+      # warm cache makes worker-spawn overhead a net loss there. See #1660.
+      run: uv run mypy . --explicit-package-bases --num-workers 4
 
     - name: Security audit (pip-audit)
       run: |


### PR DESCRIPTION
## Summary

CI's `Python type check (mypy)` step always runs **cold** — CI restores no `.mypy_cache` (only uv's package cache). Adding `--num-workers 4` parallelizes it for a ~2.8× speedup with byte-identical output.

Closes #1660.

## Benchmark (mypy 2.1.0, 721 source files, 12-core box)

| Config | Cold (CI) | Warm (pre-push) | Output |
|--------|-----------|-----------------|--------|
| baseline (single-threaded) | 16.70s | **0.40s** | clean |
| **`--num-workers 4`** | **6.02s** ⚡ | 0.50s | identical |
| `--num-workers 8` | 6.63s | 0.58s | identical |
| `--num-workers 12` | 7.21s | 0.76s | identical |
| `--native-parser` | 13.39s | 0.41s | identical |
| `--native-parser --num-workers 8` | 5.97s | 0.61s | identical |

All six configs produced byte-identical output (`Success: no issues found in 721 source files`). The repo is mypy-clean, so the gate is pass/fail and parallel determinism is a non-issue.

## Decisions (#1660 acceptance)

- **`--num-workers 4` → adopted in CI only.** 16.7s → 6.0s cold (2.8×). 4 is the sweet spot for this import graph — it beats 8 and 12 *even on 12 cores*, so parallelism is import-graph-limited, not core-limited, and 4 maps cleanly to the 4-vCPU `ubuntu-latest` runner.
- **Pre-push → unchanged (single-threaded).** A warm cache makes worker-spawn overhead a net loss (0.40s → 0.50s). No change to `.lefthook.yml`.
- **`--native-parser` → deferred.** ~0 marginal benefit once parallel is on (native+nw8 5.97s ≈ nw4 6.02s) and still experimental. Revisit if it graduates.
- **CD / release / pre-commit → no change** (none run mypy).

## Validation

- `--num-workers 4` cold run in the worktree: **7.2s**, `Success: no issues found in 721 source files`.
- The mypy step on *this PR's own CI run* is the real-world check of the speedup on an actual runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)