### PR TITLE
ci(security): flip cd.yml + release.yml harden-runner to egress-policy block

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -71,7 +71,39 @@ jobs:
     - name: Harden runner
       uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
       with:
-        egress-policy: audit
+        egress-policy: block
+        allowed-endpoints: >
+          *.githubapp.com:443
+          9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
+          agent.api.stepsecurity.io:443
+          api.github.com:443
+          apk.cgr.dev:443
+          auth.docker.io:443
+          check.trivy.dev:443
+          customer-transient-data-277233109775.s3.us-west-2.amazonaws.com:443
+          d-gj2h7tnxlh.execute-api.us-west-2.amazonaws.com:443
+          deb.debian.org:443
+          dhi.io:443
+          files.pythonhosted.org:443
+          get.trivy.dev:443
+          ghcr.io:443
+          github.com:22
+          github.com:443
+          mirror.gcr.io:443
+          pkg-containers.githubusercontent.com:443
+          prod.app-api.stepsecurity.io:443
+          production.cloudflare.docker.com:443
+          production.cloudfront.docker.com:443
+          productionresultssa*.blob.core.windows.net:443
+          proxy.golang.org:443
+          pypi.org:443
+          raw.githubusercontent.com:443
+          registry-1.docker.io:443
+          registry.npmjs.org:443
+          release-assets.githubusercontent.com:443
+          releases.astral.sh:443
+          results-receiver.actions.githubusercontent.com:443
+          storage.googleapis.com:443
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -263,7 +295,39 @@ jobs:
     - name: Harden runner
       uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
       with:
-        egress-policy: audit
+        egress-policy: block
+        allowed-endpoints: >
+          *.githubapp.com:443
+          9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
+          agent.api.stepsecurity.io:443
+          api.github.com:443
+          apk.cgr.dev:443
+          auth.docker.io:443
+          check.trivy.dev:443
+          customer-transient-data-277233109775.s3.us-west-2.amazonaws.com:443
+          d-gj2h7tnxlh.execute-api.us-west-2.amazonaws.com:443
+          deb.debian.org:443
+          dhi.io:443
+          files.pythonhosted.org:443
+          get.trivy.dev:443
+          ghcr.io:443
+          github.com:22
+          github.com:443
+          mirror.gcr.io:443
+          pkg-containers.githubusercontent.com:443
+          prod.app-api.stepsecurity.io:443
+          production.cloudflare.docker.com:443
+          production.cloudfront.docker.com:443
+          productionresultssa*.blob.core.windows.net:443
+          proxy.golang.org:443
+          pypi.org:443
+          raw.githubusercontent.com:443
+          registry-1.docker.io:443
+          registry.npmjs.org:443
+          release-assets.githubusercontent.com:443
+          releases.astral.sh:443
+          results-receiver.actions.githubusercontent.com:443
+          storage.googleapis.com:443
 
     - name: Check CI and docs status for this commit
       env:
@@ -396,7 +460,39 @@ jobs:
     - name: Harden runner
       uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
       with:
-        egress-policy: audit
+        egress-policy: block
+        allowed-endpoints: >
+          *.githubapp.com:443
+          9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
+          agent.api.stepsecurity.io:443
+          api.github.com:443
+          apk.cgr.dev:443
+          auth.docker.io:443
+          check.trivy.dev:443
+          customer-transient-data-277233109775.s3.us-west-2.amazonaws.com:443
+          d-gj2h7tnxlh.execute-api.us-west-2.amazonaws.com:443
+          deb.debian.org:443
+          dhi.io:443
+          files.pythonhosted.org:443
+          get.trivy.dev:443
+          ghcr.io:443
+          github.com:22
+          github.com:443
+          mirror.gcr.io:443
+          pkg-containers.githubusercontent.com:443
+          prod.app-api.stepsecurity.io:443
+          production.cloudflare.docker.com:443
+          production.cloudfront.docker.com:443
+          productionresultssa*.blob.core.windows.net:443
+          proxy.golang.org:443
+          pypi.org:443
+          raw.githubusercontent.com:443
+          registry-1.docker.io:443
+          registry.npmjs.org:443
+          release-assets.githubusercontent.com:443
+          releases.astral.sh:443
+          results-receiver.actions.githubusercontent.com:443
+          storage.googleapis.com:443
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -479,7 +575,39 @@ jobs:
     - name: Harden runner
       uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
       with:
-        egress-policy: audit
+        egress-policy: block
+        allowed-endpoints: >
+          *.githubapp.com:443
+          9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
+          agent.api.stepsecurity.io:443
+          api.github.com:443
+          apk.cgr.dev:443
+          auth.docker.io:443
+          check.trivy.dev:443
+          customer-transient-data-277233109775.s3.us-west-2.amazonaws.com:443
+          d-gj2h7tnxlh.execute-api.us-west-2.amazonaws.com:443
+          deb.debian.org:443
+          dhi.io:443
+          files.pythonhosted.org:443
+          get.trivy.dev:443
+          ghcr.io:443
+          github.com:22
+          github.com:443
+          mirror.gcr.io:443
+          pkg-containers.githubusercontent.com:443
+          prod.app-api.stepsecurity.io:443
+          production.cloudflare.docker.com:443
+          production.cloudfront.docker.com:443
+          productionresultssa*.blob.core.windows.net:443
+          proxy.golang.org:443
+          pypi.org:443
+          raw.githubusercontent.com:443
+          registry-1.docker.io:443
+          registry.npmjs.org:443
+          release-assets.githubusercontent.com:443
+          releases.astral.sh:443
+          results-receiver.actions.githubusercontent.com:443
+          storage.googleapis.com:443
 
     # Always needed: GHCR login for both build-push and imagetools-create.
     - name: Log in to GitHub Container Registry
@@ -661,7 +789,39 @@ jobs:
     - name: Harden runner
       uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
       with:
-        egress-policy: audit
+        egress-policy: block
+        allowed-endpoints: >
+          *.githubapp.com:443
+          9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
+          agent.api.stepsecurity.io:443
+          api.github.com:443
+          apk.cgr.dev:443
+          auth.docker.io:443
+          check.trivy.dev:443
+          customer-transient-data-277233109775.s3.us-west-2.amazonaws.com:443
+          d-gj2h7tnxlh.execute-api.us-west-2.amazonaws.com:443
+          deb.debian.org:443
+          dhi.io:443
+          files.pythonhosted.org:443
+          get.trivy.dev:443
+          ghcr.io:443
+          github.com:22
+          github.com:443
+          mirror.gcr.io:443
+          pkg-containers.githubusercontent.com:443
+          prod.app-api.stepsecurity.io:443
+          production.cloudflare.docker.com:443
+          production.cloudfront.docker.com:443
+          productionresultssa*.blob.core.windows.net:443
+          proxy.golang.org:443
+          pypi.org:443
+          raw.githubusercontent.com:443
+          registry-1.docker.io:443
+          registry.npmjs.org:443
+          release-assets.githubusercontent.com:443
+          releases.astral.sh:443
+          results-receiver.actions.githubusercontent.com:443
+          storage.googleapis.com:443
 
     - name: Checkout code (for compose files)
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -828,7 +988,39 @@ jobs:
     - name: Harden runner
       uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
       with:
-        egress-policy: audit
+        egress-policy: block
+        allowed-endpoints: >
+          *.githubapp.com:443
+          9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
+          agent.api.stepsecurity.io:443
+          api.github.com:443
+          apk.cgr.dev:443
+          auth.docker.io:443
+          check.trivy.dev:443
+          customer-transient-data-277233109775.s3.us-west-2.amazonaws.com:443
+          d-gj2h7tnxlh.execute-api.us-west-2.amazonaws.com:443
+          deb.debian.org:443
+          dhi.io:443
+          files.pythonhosted.org:443
+          get.trivy.dev:443
+          ghcr.io:443
+          github.com:22
+          github.com:443
+          mirror.gcr.io:443
+          pkg-containers.githubusercontent.com:443
+          prod.app-api.stepsecurity.io:443
+          production.cloudflare.docker.com:443
+          production.cloudfront.docker.com:443
+          productionresultssa*.blob.core.windows.net:443
+          proxy.golang.org:443
+          pypi.org:443
+          raw.githubusercontent.com:443
+          registry-1.docker.io:443
+          registry.npmjs.org:443
+          release-assets.githubusercontent.com:443
+          releases.astral.sh:443
+          results-receiver.actions.githubusercontent.com:443
+          storage.googleapis.com:443
 
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
@@ -874,7 +1066,39 @@ jobs:
     - name: Harden runner
       uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
       with:
-        egress-policy: audit
+        egress-policy: block
+        allowed-endpoints: >
+          *.githubapp.com:443
+          9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
+          agent.api.stepsecurity.io:443
+          api.github.com:443
+          apk.cgr.dev:443
+          auth.docker.io:443
+          check.trivy.dev:443
+          customer-transient-data-277233109775.s3.us-west-2.amazonaws.com:443
+          d-gj2h7tnxlh.execute-api.us-west-2.amazonaws.com:443
+          deb.debian.org:443
+          dhi.io:443
+          files.pythonhosted.org:443
+          get.trivy.dev:443
+          ghcr.io:443
+          github.com:22
+          github.com:443
+          mirror.gcr.io:443
+          pkg-containers.githubusercontent.com:443
+          prod.app-api.stepsecurity.io:443
+          production.cloudflare.docker.com:443
+          production.cloudfront.docker.com:443
+          productionresultssa*.blob.core.windows.net:443
+          proxy.golang.org:443
+          pypi.org:443
+          raw.githubusercontent.com:443
+          registry-1.docker.io:443
+          registry.npmjs.org:443
+          release-assets.githubusercontent.com:443
+          releases.astral.sh:443
+          results-receiver.actions.githubusercontent.com:443
+          storage.googleapis.com:443
 
     - name: Check build status
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,39 @@ jobs:
     - name: Harden runner
       uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
       with:
-        egress-policy: audit
+        egress-policy: block
+        allowed-endpoints: >
+          *.githubapp.com:443
+          9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
+          agent.api.stepsecurity.io:443
+          api.github.com:443
+          apk.cgr.dev:443
+          auth.docker.io:443
+          check.trivy.dev:443
+          customer-transient-data-277233109775.s3.us-west-2.amazonaws.com:443
+          d-gj2h7tnxlh.execute-api.us-west-2.amazonaws.com:443
+          deb.debian.org:443
+          dhi.io:443
+          files.pythonhosted.org:443
+          get.trivy.dev:443
+          ghcr.io:443
+          github.com:22
+          github.com:443
+          mirror.gcr.io:443
+          pkg-containers.githubusercontent.com:443
+          prod.app-api.stepsecurity.io:443
+          production.cloudflare.docker.com:443
+          production.cloudfront.docker.com:443
+          productionresultssa*.blob.core.windows.net:443
+          proxy.golang.org:443
+          pypi.org:443
+          raw.githubusercontent.com:443
+          registry-1.docker.io:443
+          registry.npmjs.org:443
+          release-assets.githubusercontent.com:443
+          releases.astral.sh:443
+          results-receiver.actions.githubusercontent.com:443
+          storage.googleapis.com:443
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:


### PR DESCRIPTION
Flips all **7 cd.yml** jobs + the **release.yml** job from `egress-policy: audit` to `block` with an explicit `allowed-endpoints` allowlist. Closes #1361 and #1362.

## How the allowlist was built

The StepSecurity dashboard is no longer available (enterprise trial expired), so the audit data was pulled straight from the **Post Harden runner** step logs via `gh api repos/adamflagg/kindred/actions/jobs/<id>/logs`, parsing the `endpoint called ... domain: X ... :PORT` lines (actual outbound connections with port + process). Aggregated across:

- **6 CD runs** — 1 `schedule` (rebuild-all), 2 `workflow_dispatch` (exercise `smoke-test`), 3 `push` builds
- **5 release runs**

## Changes vs. the draft allowlist in #1361

| Endpoint | Why |
|----------|-----|
| `+ production.cloudfront.docker.com:443` | Docker uses **both** cloudflare + cloudfront CDNs; draft had only cloudflare |
| `+ pypi.org:443` | `uv sync --frozen` still hits the index (the "--frozen skips it" assumption was wrong) |
| `+ raw.githubusercontent.com:443` | re-introduced by a setup action (#1359 thought it was gone) |
| `+ releases.astral.sh:443` | `setup-uv` pulls the uv binary from astral, not GitHub releases |
| `hosted-compute-*.githubapp.com` → `*.githubapp.com:443` | full-label wildcard is documented/supported; isolates the **undocumented** partial-label-glob risk to the one endpoint that needs it |

## Wildcard note

Only **full-label** wildcards (`*.foo.com`) are documented by StepSecurity. The Azure results-storage endpoint shards rotate (`productionresultssa{2,11,...}`), and `*.blob.core.windows.net` would open all of Azure — a non-starter — so `productionresultssa*.blob.core.windows.net` keeps the partial-label form (the exact pattern StepSecurity's own recommended-policy generator emits). `hosted-compute-*` was broadened to `*.githubapp.com` so the runner control-plane is guaranteed allowed regardless.

## Cache caveat (why nothing was pruned)

Several draft entries showed **zero** traffic even in the rebuild-all run — `deb.debian.org`, `proxy.golang.org`, `storage.googleapis.com`, `registry.npmjs.org`, `mirror.gcr.io`, `apk.cgr.dev`. That is **not** evidence they're unneeded: the buildx GHA layer cache, npm cache, and Go module cache serve those on warm runs; they only egress on cold/cache-miss builds. All draft entries are kept.

## Both workflows, one allowlist

`release.yml` is not the clean subset #1362 predicted (it adds `crane` + `git-cliff`, an SSH clone, and npm), but every endpoint it touches is within the CD union — so both share the same 31-entry allowlist.

## Post-merge plan

Block mode logs any blocked domain in the Actions log (visible without the dashboard), so a missed endpoint is self-reporting and patchable:

- [ ] First post-merge CD run on `main` succeeds end-to-end
- [ ] Next release run succeeds (rollback to `audit` if blocked)
- [ ] Watch one Renovate/dependabot CD cycle for blocked endpoints

Closes #1361
Closes #1362

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted network access in build and release workflows to essential endpoints only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->