### PR TITLE
docs(solver): check in Q2 2026 solver optimization roadmap

### DIFF
--- a/docs/reference/solver-roadmap.md
+++ b/docs/reference/solver-roadmap.md
@@ -1,0 +1,1433 @@
+# Solver Optimization Roadmap — Q2 2026
+
+Tracked reference doc capturing four parallel streams of solver work that
+emerged from the May 2026 stuck-core investigation. Each stream gets a
+dedicated GitHub issue; specs and plans live in `docs/superpowers/` (local
+only) once individual streams are picked up.
+
+> **Updated 2026-05-20 (post-#1553, post-#1550/#1552, post-Stream-3-Phase-A).**
+> Age Spread Phase 2 shipped as #1553 (hard 24-mo cap with edge-bunk escape
+> hatch); #1142 Phase 2 + 3 (#1550, #1552) collapsed bucket/rule/multiplier
+> maps into a single `(source, type)` registry and routed objective
+> multipliers through `weight_for`. **Business-rules-vs-magnitudes review is
+> fully resolved**: Δ1 closed as-moot (both spread penalties gone, ratio/
+> occupancy collapse to Δ2 which is itself closed), Δ2 closed not-planned
+> after enrollment analysis (5/6 main-session cohorts already average ≥10,
+> current per-spot penalty earns its keep). **Stream 3 (#1381) Phase A
+> executed**: `presolve_compression_ratio = 0.938` → Phase C closed-as-moot;
+> Phase B in flight as **open PR #1555** (closes #1381 on merge). The
+> `soft_constraints_by_module` spinoff was already resolved by #1547
+> (2026-05-19); its UI follow-up to surface `soft_constraint_penalty_by_module`
+> is in flight as **open PR #1559**. No tracked planned work remains; Stream 6
+> substreams 6a–6f stay incremental and unfiled until a real need surfaces.
+
+> **Why this doc exists.** The May 12 investigation surfaced four
+> distinct improvements at once (camp-policy fix, observability gap,
+> variable-count attack surface, objective tuning). The investigation
+> chat was lost to API errors before any of them was specced, and the
+> follow-up agent rediscovered a false-positive "bug" because the
+> rationale wasn't preserved anywhere durable. This doc is the
+> persistent memory so future agents (and the human) don't have to
+> reconstruct context from incomplete signals.
+
+---
+
+## Status & phased sequencing
+
+> Supersedes the original "Suggested order" section. The Stream sections
+> below are the detailed *what / why / how* reference; this section is the
+> dependency-ordered *when*, with issue numbers. Updated 2026-05-17.
+
+### Work item → issue → status
+
+| Work item | Issue | PR | Status |
+|---|---|---|---|
+| Stream 1 — Stage 4 hard MSO | #1379 | #1391 | ✅ shipped 2026-05-14 |
+| Stream 2 Tier 1 — debug metrics | #1380 | #1385 | ✅ shipped 2026-05-13 |
+| Stream 2 Tier 1 — per-`RequestBucket` split | #1388 | #1425 | ✅ shipped 2026-05-14 |
+| Stream 5 — IIS infeasibility localization | (in #1379) | #1391 | ✅ shipped 2026-05-14 |
+| Stream 6 — pre-check impossibility framework | (in #1379) | #1391 | ✅ shipped 2026-05-14 |
+| Sat-var unification | #1395 | #1427 | ✅ shipped 2026-05-14 |
+| Stream 6 substream — entirely-impossible MP campers in pre-check + "Acceptable" denominator fix | #1428 | #1429 | ✅ shipped 2026-05-14 |
+| Stream 2 Tier 2 — plateau-diagnostic metrics | none (spec in-doc) | #1436 | ✅ shipped 2026-05-14 |
+| Golden sat-var ↔ predicate alignment test | #1398 | #1434 | ✅ shipped 2026-05-14 (Option 2 — bunk_with/not_bunk_with only) |
+| Retire `solution.calculate_satisfied_requests` | #1397 | #1438 | ✅ shipped 2026-05-15 |
+| Stream 4 — mutual-request boost | #1382 | #1523 | ✅ shipped 2026-05-18 (Phase 3) |
+| Stream 3 — variable-count attack surface | #1381 | #1555 (open) | ⏬ Phase A done 2026-05-20 (ratio 0.938 → close Phase C); **Phase B in PR #1555** (awaiting merge), closes #1381 |
+| Penalty-driven MP-coverage investigation | #1396 | — | ✅ closed not-planned 2026-05-17 (Phase-2 bound-trajectory chart shows the plateau directly; counterfactuals moot) |
+| Audit `direct_solver` for hand-rolled impossibility logic | #1426 | — | ✅ closed 2026-05-17 — audit deliverable at `docs/plans/audit-1426-impossibility.md` (local); no remaining hand-rolled logic to migrate |
+| Consolidate parallel solver models (`bunking/models.py` vs `bunking/models_v2.py`) | #1451 | — | ✅ closed not-planned 2026-05-17 — see "Parked — V1/V2 models consolidation" section below |
+| Schematize `grade_spread.max_spread` | #1424 | — | ✅ closed 2026-05-18 — folded into Grade Spread Phase 2 cleanup (per `solver-config-decisions.md`) |
+| Schematize/remove `negative_requests.hard_constraint_threshold` (dead `not_bunk_with` hard branch) | #1432 | #1455 | ✅ shipped 2026-05-15 (folded into priority-field deletion) |
+| age_preference `sat_var` built-but-discarded + non-MP age_preference unmodeled | #1433 | #1466 | ✅ shipped 2026-05-15 |
+| Separate red "totally impossible MP campers" chip on Solver Debug pre-check button | #1440 | #1465 | ✅ shipped 2026-05-15 |
+| Make camper names click-through in impossibility modals + replace "fix parent input" copy | #1441 | #1464 | ✅ shipped 2026-05-16 |
+| Exclude impossible requests from `all_camper_rate` ("Optimized") + surface in post-check modal | #1442 | #1463, #1464 | ✅ shipped 2026-05-15 |
+| Validator-side parity (post-check denominator gating) | #1520 | (this PR) | ✅ shipped 2026-05-18 — narrow tactical path; V1/V2 consolidation still deferred |
+| Retire dead `DirectSolverOutput.analysis` path | #1437 | #1453 | ✅ shipped 2026-05-15 |
+| Tighten `request_validation_summary` to a `RequestValidationSummary` TypedDict | #1386 | #1487 | ✅ shipped 2026-05-18 |
+| Remove unreachable per-bunk branch in `age_preference` sat-var builder | #1467 | — | ✅ shipped 2026-05-16 |
+| Thread config through penalty accessors in evaluators | #1332 | — | ✅ shipped 2026-05-18 |
+| Objective sensitivity analysis doc + reproducible script | none (spec in-doc) | #1529 | ✅ shipped 2026-05-18 — `docs/reference/objective-sensitivity.md` + `scripts/analyze_objective_sensitivity.py` |
+| Business-rules-vs-magnitudes review — batch 1 (Δ3 `share_bunk_with` 1.5→1.75, Δ4 equalize `internal_notes` 0.8→1.0, B-class fallback drift) | none (spec in `solver-config-decisions.md`) | #1533 | ✅ shipped 2026-05-18 — post-merge S4 sweep showed obj +0.03–0.33%, gap tightened across all budgets, satisfaction stable |
+| Business-rules-vs-magnitudes review — Δ1 (penalty re-rank: spreads top, ratio middle, occupancy bottom) | none (spec in `solver-config-decisions.md`) | — | ✅ **closed as-moot 2026-05-20** — both spread penalties are gone (age_spread fully hard via #1553; grade_spread never fires); only ratio/occupancy remain, and Δ2 converts occupancy to a bonus anyway — re-ranking a penalty you're about to dissolve is churn; fold intent into Δ2 |
+| Business-rules-vs-magnitudes review — Δ2 (`cabin_min_occupancy` penalty → bonus reshape, mirror `age_spread_preferred_bonus`) | none (spec in `solver-config-decisions.md`) | — | ✅ **closed not-planned 2026-05-20** — enrollment data (5/6 main-session cohorts avg 10.67–12.0; only S3 boys at 9.75) confirms staff preference for ≥10 is largely met today; current per-spot penalty actively keeps bunks off the 8-floor (0 bunks at 8 across all 2026 drafts, 5 at 9, 47 at ≥10). Reshape to bonus is purely cosmetic relabeling; behavioral identity is the right call. Leave as-is. |
+| `soft_constraints_by_module` reports vars-created not fires-honored | #1532 | #1547 | ✅ shipped 2026-05-19 — also added new `soft_constraint_penalty_by_module` (weighted penalty per bucket) alongside the now-fixed fires count |
+| Frontend follow-up — surface `soft_constraint_penalty_by_module` in SolverDebugPage drill-down | — | #1559 (open) | ⏬ in flight (awaiting merge) — adds a parallel "Soft constraint penalty by module" chip row in `DrillDownDrawer.tsx` |
+| Stream 6 substreams 6a–6f | unfiled | — | ⬜ incremental |
+| Age Spread Phase 2 — hard 24-mo cap with edge-bunk escape hatch | — | #1553 | ✅ shipped 2026-05-20 — unblocks business-rules Δ1 |
+| #1142 Phase 2 — collapse bucket/rule/multiplier maps into (source,type) registry | #1142 | #1550 | ✅ shipped 2026-05-20 |
+| #1142 Phase 3 — route objective multipliers through registry `weight_for` | #1142 | #1552 | ✅ shipped 2026-05-20 |
+
+Work-item PRs use `Closes #N` in the body so the issue auto-closes on merge,
+where a tracking issue exists. Phase 2 (Tier 2 metrics) shipped without a
+tracking issue — its full spec lived in the Stream 2 section and the PR
+(#1436) carried it directly.
+
+### Phases
+
+**Phase 0 — Foundation (DONE).** Stage 4 hard MSO (#1391), Tier 1 metrics +
+bucket split (#1385 / #1425), IIS localization & impossibility framework
+(#1391), sat-var unification (#1427). The S2 model is roughly half its
+pre-#1391 size; MP coverage is 100% of solver-actionable campers.
+
+**Phase 1 — Pre-check honesty (DONE — #1428 / PR #1429, shipped 2026-05-14).**
+`target_not_in_solver` promoted to a registered predicate (closes the last
+pre-validate ↔ solver drift), `mp_campers_entirely_impossible` derived
+rollup as single source of truth, camper-level surfacing in the pre-validate
+modal, and the "Acceptable" metric denominator fixed to exclude
+structurally-impossible campers.
+
+**Phase 2 — Tier 2 metrics (DONE — #1436, shipped 2026-05-14).** Scoped to
+three plateau-diagnostic metrics only: **best-bound trajectory, LP root gap,
+presolve compression ratio.** *Not* the full Tier 2 list — per-sub-solver
+wall time / symmetry flag / domain-size distribution defer until a specific
+question demands them (the dropped PR3 badges are the cautionary tale:
+num_branches / num_conflicts turned out to be noise). Rationale: the
+remaining solver problem is the **plateau** — `objective_value` flattens by
+~60 s and only the *bound* moves after; Tier 1 cannot distinguish
+"converging slowly" from "stuck", best-bound trajectory can. Phase 2
+hard-unblocks Phase 4 and makes Phase 3 measurable. **No tracking issue** —
+the three-metric spec lived in the Stream 2 section below, so the
+implementation PR carried it directly rather than re-deriving from a filed
+issue. (Tier 2 was orphaned when #1380 ("Tier 1 + Tier 2") closed on Tier 1
+alone; the remaining Tier 2/Tier 3 metrics stay tracked in the Stream 2
+tables and are picked up only when a specific question demands them.)
+
+**Phase 3 — Mutual-request boost (SHIPPED — Stream 4 / #1382, PR #1523, 2026-05-18).**
+Highest-leverage plateau intervention: reshapes the objective toward
+reciprocated pairs so that when Stage 4's hard constraint binds, it
+preferentially honors mutual requests. Well-scoped (~80–120 LOC). Phase 2's
+best-bound trajectory is in place, so the post-merge sweep can be evaluated
+against a real "converging vs. stuck" signal rather than just final objective
+shuffle.
+
+**Phase 4 — Compound & consolidate (mostly resolved).** Stream 3
+variable-count attack (#1381), re-scoped 2026-05-18, executed 2026-05-20:
+
+- **Phase A** ✅ done 2026-05-20 — S2 compression ratio measured at 0.938
+  (presolve eliminates ~6%). Model is already tight; Phase C closed-as-moot.
+- **Phase B** ⏬ in flight — PR #1555 (drop `req_satisfied` for impossible
+  requests). One-line sourcing change in `add_objective` to iterate
+  `self.possible_requests` instead of `self.input.requests_by_person`.
+  Closes #1381 on merge.
+- **Phase C** ❌ closed-as-moot — 6% compression headroom doesn't justify the
+  11-module foundational refactor.
+
+Original lever 3b is moot (eaten by #1395), 3c shipped via Stream 1, and 3d/3f
+deferred per the re-scope rationale table. Stream 6 substreams 6a–6f remain
+incremental and unfiled.
+
+**Parallel / immediate (not gated):** #1398 golden alignment test shipped in
+#1434 (2026-05-14); #1397 retire-`calculate_satisfied_requests` shipped in
+#1438 (2026-05-15). #1424 (`grade_spread.max_spread` schematize) remains a
+small standalone cleanup that can land anytime.
+
+---
+
+## Investigation context (one paragraph)
+
+After PR #1364 shipped (`refactor(solver)`: dropped 3 dead `must_satisfy_one`
+toggles and the orphan `add_age_preference_penalties` function), a sweep was
+run with `must_satisfy_one.penalty` bumped from 100,000 → 287,600. The bump
+improved MP coverage modestly (S2: `mp_camper_rate` 92.07% → 95.73% at 600s
+budget; `unsatisfied_material_parent_unmet` 9 → 6) but a semi-stable
+"stuck-core" cohort of 6–7 campers per session continues to get zero parent
+requests honored across runs. Investigation traced this to a structural
+mismatch: per-camper soft penalty competes with multi-kid cluster benefits
+that the solver can win locally even with a large global penalty waiting.
+All four streams below address the underlying model in different ways.
+
+**Baseline metrics to remember** (S2 sweep, post-PR-#1364, 287,600 MSO
+penalty, 600s budget):
+
+- 193 persons, 17 bunks
+- 11,657 model variables (5,561 booleans + 2,456 integers + ~3,640
+  auxiliary)
+- 23,644 model constraints (21,922 linear, 1,022 bool_and, 684 bool_or,
+  16 lin_max)
+- 51 `OnlyEnforceIf` usages across 10 constraint files
+- 326 MP requests / 504 total requests
+- 164 MP-having campers; `unsatisfied_no_possible = 0`
+- 4 `impossible_requests` (all data-quality artifacts: synthetic
+  cm_ids from unresolvable names + cross-session targets)
+- Gap 4.76% at 600s, FEASIBLE (not OPTIMAL)
+
+---
+
+## Stream 1 — Stage 4: Hard Must-Satisfy-One Constraint
+
+**Status:** Shipped in #1391 (2026-05-13). The motivation, "why hard works,"
+safety gate, and risks below remain accurate. The "Surprising side-effect:
+model simplification" section was wrong in its model-size math — see the
+inline note in that section for the corrected version. Follow-ups #1395,
+\#1396, \#1397, \#1398 capture the remaining work surfaced during
+implementation.
+
+### Motivation
+
+Camp policy: every camper with at least one Material-Parent (MP) request
+must have one honored. Today this is modeled as a soft constraint with
+penalty 287,600 (formerly 100,000). The penalty fires once globally per
+camper when their entire MP-request set fails, but each local solver
+move only sees the immediate trade — moving a popular kid out of a
+cluster trips multiple grade-spread (3,000) / grade-ratio (5,000) /
+age-grade-flow (300) penalties, totalling 15,000–25,000 of *local* cost.
+The 287,600 *global* threat doesn't propagate strongly into local moves.
+
+Result: a stable cohort of single-MP-request kids whose one friend is in
+someone else's cluster never gets their request honored, regardless of
+penalty magnitude (within reasonable ranges). Bumping further has
+diminishing returns and risks distorting other objective signals.
+
+### Why hard works where higher soft doesn't
+
+A hard constraint (`sum(MP_satisfied[loner]) >= 1`) is a structural
+property of CP-SAT's feasible region. The solver cannot produce *any*
+solution that violates it; the LP relaxation prunes friend-X-elsewhere
+branches at every node. There is no "trade-off" to lose locally.
+
+### Model simplification — original hypothesis vs. shipped reality
+
+**Original hypothesis (incorrect as written).** The soft MSO at
+`bunking/solver/constraints/must_satisfy.py:126-135` (pre-rename) looked
+like this per MP-having camper:
+
+```python
+violation = ctx.model.NewBoolVar(...)                                # +1 BoolVar
+ctx.model.Add(sum(all_sat_vars) == 0).OnlyEnforceIf(violation)       # +1 reified linear
+ctx.model.Add(sum(all_sat_vars) >= 1).OnlyEnforceIf(violation.Not()) # +1 reified linear
+ctx.soft_constraint_violations[...] = (violation, penalty)            # +1 objective term
+```
+
+The roadmap predicted collapsing to:
+
+```python
+ctx.model.Add(sum(all_sat_vars) >= 1)                                # +1 plain linear
+```
+
+…and removing 164 BoolVars / 328 reified linears / 164 objective terms
+from S2.
+
+> **Reality (#1391):** the `all_sat_vars` produced by the pre-#1391
+> `add_bunk_request_satisfaction_vars` used **one-way `OnlyEnforceIf`
+> implications**. The solver could set `sat_var = 1` freely without
+> forcing actual co-placement. A hard `sum(all_sat_vars) >= 1` over them
+> would be vacuously satisfiable. The now-deleted soft `must_satisfy.py`
+> summed over these falsifiable vars — meaning the 287,600 penalty was
+> almost certainly operationally inert (the 95.73% MP coverage came from
+> cluster constraints emergently placing friends, not the penalty).
+> **Correction (#1395):** the objective itself was *never* falsifiable —
+> `add_objective` has always built its own bidirectional `req_satisfied_*`
+> vars and never consumed `add_bunk_request_satisfaction_vars`. That helper
+> was orphaned when #1391 deleted `must_satisfy.py` and is removed in #1395,
+> which unifies the objective's and parent_paramount's sat vars into one
+> shared `request_satisfied_vars` map. See #1396 for the investigation issue.
+>
+> **What shipped** in #1391: hard constraint uses a bidirectional
+> per-request sat var via `ctx.person_bunk_assignment` (matches the
+> encoding `add_objective` uses at `direct_solver.py:663-714`) for
+> bunk_with / not_bunk_with, plus the existing per-(request, bunk)
+> `person_in_clean_bunk` forcing indicators exposed from
+> `add_age_preference_satisfaction_vars` for age_preference. One
+> bidirectional sat var + two reified linears per MP bunk request;
+> zero new vars for age_preference. Net S2 model effect: roughly
+> neutral vs. the soft baseline (−164 violation BoolVars, +~250
+> MP-specific sat vars, +~500 reified linears, +164 plain linears,
+> −164 objective terms). #1395 will eliminate the ~250 duplicate sat
+> vars by unifying with the objective's set.
+
+### Safety gate
+
+The authoritative input-property metric for "camper's entire MP set is
+structurally impossible" is `mp_set_entirely_impossible_count` (added
+in #1429). The legacy `unsatisfied_no_possible` field is a *post-solve
+outcome* that varies with budget — see **#1527** for the misnomer
+investigation and proposed rename/delete. The gate itself is enforced
+upstream by `_validate_requests` in `direct_solver.py`, which classifies
+a request as impossible when any of the following holds:
+
+- `target_not_in_solver` — requestee absent from `person_idx_map`
+- `cross_session` — `bunk_with` across sessions (boundary forbids)
+- `malformed` — `bunk_with`/`not_bunk_with` with no `requested_person_cm_id`
+- `pair_no_shared_bunk` — `bunk_with` where the requester and target
+  have no gender-compatible same-session bunk (added 2026-05-13 after
+  PR #1391's Taste 1 INFEASIBLE; cross-gender `bunk_with` slipped past
+  the prior gate and the hard MP constraint then forced impossible
+  co-placement). `not_bunk_with` with no shared bunk is trivially
+  satisfied and remains `possible`.
+- `age_pref_no_eligible_grade` — `age_preference` at the same-gender
+  grade bound in the wrong direction. Per camp staff policy: if a
+  camper is the oldest grade of their gender in the session and
+  prefers older (or youngest and prefers younger), the preference is
+  moot — there are no peers to be older/younger than them. Marking
+  impossible upstream is what allows the hard MP constraint to bind
+  cleanly for everyone else. Bounds are derived from the actual
+  same-gender camper pool in the session (scan-the-pool fallback;
+  the follow-up issue to tie this to admin-GUI-configured min/max
+  grades will swap the source without changing the call site).
+
+**Defensive pattern when adding the hard constraint:**
+
+```python
+for person_cm_id, possible_reqs in possible_requests.items():
+    mp_possible = [r for r in possible_reqs if is_material_parent(r)]
+    if mp_possible:  # only enforce when ≥1 possible MP exists
+        model.Add(sum(satisfaction_vars[r.id] for r in mp_possible) >= 1)
+```
+
+If a future sweep returns `unsatisfied_no_possible > 0`, those campers
+are skipped (the constraint isn't added for them) and surfaced via
+`mp_set_entirely_impossible` for staff review. The 4 current S2
+`impossible_requests` (synthetic IDs from unresolvable names) are spread
+across kids who ALSO have viable MP alternatives, so the constraint
+still applies to those kids.
+
+**Pair-feasibility scope today:** gender + session. Group locks,
+AG-eligibility quirks, and other pre-fixed-assignment conflicts are
+NOT yet checked. If a future failure mode emerges from one of those,
+extend `_pair_has_shared_bunk` rather than adding a new reason.
+
+### Code refs (post-#1391)
+
+- `bunking/solver/constraints/parent_paramount.py` — hard MP constraint (renamed from `must_satisfy.py`)
+- `bunking/solver/constraints/bunk_requests.py` — `get_or_create_request_sat_var`, the canonical bidirectional sat-var builder (post-#1395; replaced the orphaned one-way `add_bunk_request_satisfaction_vars`)
+- `bunking/solver/direct_solver.py:643-714` — bidirectional objective-side sat var encoding (template for #1391's hard path)
+- `bunking/solver/direct_solver.py:355-438` — `_validate_requests`, impossibility classification
+- `bunking/solver/direct_solver.py:1215-` — `_check_must_satisfy_one_violations` (post-solve diagnostic, ERROR severity under hard MSO)
+- `bunking/solver/feasibility.py:193-205` — `unsatisfied_no_possible` computation
+- `bunking/solver/constraints/base.py` — `SolverContext` including `mp_set_entirely_impossible`
+- `bunking/satisfaction/bucket.py` — `is_material_parent_request` (source-field bucket classifier)
+- Camp policy source: `wife-feedback-2026-04-scoreboard.md` Stage 4 sketch (local doc)
+
+### Risks (small, in decreasing order)
+
+1. **MP-request-rate could drop slightly** while MP-camper-rate rises.
+   Forcing 1 MP per loner may break a cluster that was efficiently
+   satisfying multiple MPs for fewer campers. Camp accepts this trade
+   per policy.
+2. **Solve-time impact unclear** — hard MSO should *speed up* the solve
+   in theory (smaller model, fewer reified constraints, simpler
+   objective), but CP-SAT's heuristics may interact unpredictably.
+   Benchmark required.
+3. **`impossible_requests` could spike** if upstream resolution
+   regresses. Pre-solve filter logs a warning if any camper would be
+   skipped; that warning is the data-quality alert.
+
+### Out of scope
+
+- Promoting OTHER soft constraints to hard (grade_spread, age_spread,
+  cabin_minimum_occupancy). Those are tunable trade-offs by design.
+- Multi-MP minimum (≥2 MP honored per camper). Camp policy is ≥1.
+
+### GitHub issue
+
+Tracking: #1379 (closed by #1391 on 2026-05-13).
+
+### Follow-ups surfaced during #1391 implementation
+
+- **#1395** — `refactor(solver): unify bunk-request sat vars + remove the orphaned one-way helper`. Behaviour-neutral cleanup: deleted the orphaned one-way `add_bunk_request_satisfaction_vars` (dead since #1391 removed `must_satisfy.py`), added the canonical bidirectional `get_or_create_request_sat_var`, and unified `add_objective` + `parent_paramount` onto one shared `request_satisfied_vars` map (~250 fewer duplicate BoolVars on S2). The "free money" framing was stale — the objective was never falsifiable; see the Stream 1 "Reality (#1391)" correction above.
+- **#1396** — `investigation: was historical MP coverage actually penalty-driven?` Three counterfactual experiments to determine whether the 95.73% pre-Stage-4 MP rate came from the soft penalty or from cluster constraints emergently placing friends.
+- **#1397** — `refactor(solver): retire solution.calculate_satisfied_requests + audit calculate_field_level_stats`. Shipped 2026-05-15 in PR #1438: `solution.py` reduced from ~187 lines to a thin shim; satisfaction computation delegated through a new `bunking/satisfaction/batch.py` helper; `calculate_field_level_stats` deleted.
+- **#1398** — `test(solver): golden alignment test between solve-time sat vars and post-solve predicate`. Shipped 2026-05-14 in PR #1434 (Option 2 — bunk_with/not_bunk_with only; age_preference deferred behind #1433).
+- **#1424** — `refactor(solver): schematize constraint.grade_spread.max_spread`. The key is read in 4 sites but absent from `CONFIG_SCHEMA`; each read leans on a `default=` to swallow the `UnknownKeyError`. Either schematize it or replace with a named constant.
+
+---
+
+## Stream 2 — Solver Debug Metrics Expansion (Tier 1 + Tier 2)
+
+**Status:** Tier 1 **shipped** — #1380 / PR #1385 (core metrics) and #1388 /
+PR #1425 (per-`RequestBucket` split). Tier 2 — **shipped** in PR #1436
+(2026-05-14). Scoped to three plateau-diagnostic metrics: best-bound
+trajectory, LP root gap, presolve compression ratio. Implemented **without a
+tracking issue** — Tier 2 was orphaned when #1380 ("Tier 1 + Tier 2") closed
+on Tier 1 alone, and the three-metric spec lived here, so the PR carried it
+directly. The rest of the Tier 2 table and the Tier 3 list below stay
+tracked here and defer until a specific question demands them.
+
+### Motivation
+
+The solver-runs dashboard currently shows: `num_booleans`,
+`num_integer_variables`, `model_num_variables`, `model_num_constraints`,
+constraint-type breakdown, `num_branches`, `num_conflicts`,
+`solution_strategy`. These are counts, not diagnostics. They tell you
+"how big is the model" but not "what's expensive", "is the LP tight",
+or "is the solver actually making progress".
+
+Three concrete cases where current metrics fail:
+
+1. The **Stage 4** simplification (Stream 1) drops 164 reified
+   constraints to 164 plain constraints. Current metrics don't
+   distinguish reified from plain, so the win is invisible.
+2. The **variable-count attack surface** (Stream 3) saves BoolVars by
+   sparser modeling. Without a per-source breakdown, the impact is
+   hard to attribute.
+3. The current "FEASIBLE not OPTIMAL" status with `gap = 4.76%` doesn't
+   distinguish "the solver is converging but ran out of time" from
+   "the solver hit a flat plateau and isn't making progress". A
+   best-bound trajectory would.
+
+### Tier 1 — High signal, low effort
+
+| Metric | Source | Why useful |
+|---|---|---|
+| Reified linear constraint count | `model.Proto().constraints[i].enforcement_literal` non-empty | Direct measure of model complexity; the Stage 4 simplification cuts this by 164 |
+| Soft constraint count (by module) | `len(ctx.soft_constraint_violations)` grouped by key prefix | 4 modules populate this dict: `must_satisfy_*`, `grade_ratio_*`, `level_regression_*`, `age_spread_b*`. Visible Stage 4 impact = 164 from `must_satisfy_*` → 0 |
+| Max linear coefficient (big-M proxy) | scan `model.Proto().constraints[*].linear.coeffs` | Values >100K signal big-M modeling weakness; the 287,600 MSO penalty is the current outlier |
+| Request density histogram | precompute from `requests_by_person` | "How many MP requests per camper" distribution; single-MP-request kids are the stuck-core cohort |
+| Impossible-request breakdown | `direct_solver.py:_validate_requests` already computes this; expose per-reason counts | Currently shown as a single number (4); split into: "target not in solver" / "cross-session" / "malformed" |
+
+### Tier 2 — Useful diagnostics
+
+| Metric | Source | Why useful |
+|---|---|---|
+| LP root gap | `solver.SolutionInfo()` or response proto | Gap *before* B&B started; tells you LP relaxation quality independent of time budget |
+| Best-bound trajectory | per-solution callback recording `BestObjectiveBound()` over time | Slope reveals "converging" vs "stuck on plateau" |
+| Per-sub-solver wall time | CP-SAT response proto `subsolvers` field | Which LNS strategies found best solutions; helps tune `num_workers` |
+| Pre-solve compression ratio | model size pre/post `model.Validate()` + presolve | Currently 9,750 → 5,561 booleans (~43% compression). Worth tracking. |
+| Symmetry detection flag | response proto | Did CP-SAT find/apply symmetry? |
+| Domain size distribution | scan IntVar domains | Wide domains = harder problem; tightening is a future lever |
+
+### Tier 3 — Advanced (likely defer)
+
+- Restart count, conflict-learning stats, LP iterations
+- Free variable count post-presolve
+- Constraint-graph density (variables-per-constraint)
+
+### Code refs
+
+- `bunking/solver/direct_solver.py:174-177` — current `num_*` capture
+- `bunking/solver/direct_solver.py:801-804` — None-defaults for failed solves
+- `api/services/solver_runner.py` — how stats reach `solver_runs.stats`
+- `frontend/src/pages/SolverDebug.tsx` (or equivalent) — dashboard
+- CP-SAT proto: `ortools.sat.cp_model_pb2.CpSolverResponse`
+
+### Order vs other streams
+
+**Ship FIRST.** Metrics are read-only, low-risk, and they're the
+measurement scaffold for Stage 4 and Stream 3. Landing Stream 2 before
+Stream 1 means the Stage 4 simplification is *visible* in the
+dashboard the moment it merges. Landing it before Stream 3 means
+variable-count savings are attributable.
+
+### Risks
+
+1. CP-SAT response-proto fields are not always available in older
+   ortools versions. Verify against pinned version (`ortools` in
+   `pyproject.toml`).
+2. Some metrics (per-sub-solver wall time, best-bound trajectory)
+   require capture during solve, not just post-solve. Adds callback
+   complexity.
+
+### GitHub issue
+
+Tier 1: #1380 (closed by #1385) + #1388 (closed by #1425). Tier 2: no tracking
+issue — implemented as Phase 2 directly from the spec above (see Phase 2 in
+"Status & phased sequencing"). The deferred Tier 2/Tier 3 metrics remain
+tracked in the tables above; file issues if/when a specific question
+prioritizes them.
+
+---
+
+## Stream 3 — Variable-Count Attack Surface
+
+**Status:** Re-scoped 2026-05-18 after Phase 0 (Stream 1 hard MSO),
+Phase 1 (pre-check honesty), and the sat-var unification in #1427
+removed roughly half the model bulk. The original spec is preserved
+below with strikethrough; the live re-scope is in **"Re-scope
+(2026-05-18)"** before the legacy section.
+
+### Re-scope (2026-05-18)
+
+#### What changed
+
+The 2026-05-15 verification sweep showed S2 model size collapsed from
+**11,657 → 5,215 variables (−55%)** and **23,644 → 12,060 constraints
+(−49%)** after #1427's sat-var unification. The roadmap's original
+"5,561 booleans post-presolve, 9,750 pre-presolve" baseline is stale,
+and several of the original levers were eaten in the process:
+
+- Lever 3b (`both_in_bunk`) — **moot**, removed in #1395 (orphaned by
+  #1391)
+- Lever 3c (hard MSO) — **shipped** as Stream 1 (#1391)
+- The ~250 duplicate MP sat vars from the original spec — **gone**
+  via #1427's `request_satisfied_vars` unification
+
+The original compound-impact framing (**5,561 → ~3,000, −46%**) was
+predicated on 3a + 3b + Stream 1 together. With 3b moot and Stream 1
+shipped, lever 3a is the **only remaining mechanical lever of size**,
+and even its real value depends on a number nobody has measured yet:
+the **current** pre-presolve count post-#1427. Phase 2's
+`presolve_compression_ratio` metric (#1436) was built to answer
+exactly this.
+
+#### Phased re-scope
+
+**Phase A — Measure before modeling (~30 min, no code change).** Read
+the most recent S2 `solver_runs.stats.presolve_compression_ratio`
+from PB. Three branches:
+
+- **Ratio ≥ 0.3** (presolve eliminates ≥30%): lever 3a is worth the
+  foundational-layer touch. Proceed to Phase C.
+- **Ratio 0.15–0.3**: judgment call — fewer BoolVars to save, but
+  also smaller cleanup. Defer pending a real performance complaint.
+- **Ratio < 0.15** (model already tight): Stream 3 collapses to Phase
+  B only, and the rest of #1381 closes as "no remaining attack
+  surface." File a closing comment with the ratio number.
+
+This is not a tracked sub-issue — it's a sub-30-min `gh pr view`
+moment whoever picks Stream 3 up does first.
+
+> **Note on metric semantics.** `presolve_compression_ratio` is computed
+> as **post / pre** booleans (`observability.py:97`). The branches above
+> are phrased as "presolve eliminates ≥X%", which translates to: ratio
+> ≤ 0.70 → Phase C; 0.70–0.85 → judgment; > 0.85 → close.
+
+#### Phase A — result (2026-05-20)
+
+Pulled the three most recent successful S2 runs (run_47ac60a08222,
+run_27f79acf2ecb, run_7569a893d185) from the local main PB. All three
+report:
+
+- `presolve_compression_ratio = 0.938` (post=4,607 / pre≈4,912 booleans)
+- presolve eliminates **~6.2%** of booleans
+- `model_num_variables = 5,183`, `lp_root_gap ≈ 0.041`
+
+**Verdict: model is already tight.** #1391 (hard MSO) and #1427 (sat-var
+unification) collapsed the original 43%-compression baseline (9,750 →
+5,561) down to a 6% headroom. **Phase C is moot** — the foundational-layer
+touch can't be justified by a 6% reduction, especially against the cost
+of updating 11 constraint modules and writing new gender-mismatch test
+fixtures. Phase B remains worth shipping on its own merits.
+
+**Phase B — Lever 3e warmup (small PR, any time).** Drop
+`req_satisfied` BoolVars for requests already in
+`impossibility_report.flat` (the per-request set is now the canonical
+post-#1429 source of truth). Tiny — ~10 LOC plus a test, no risk,
+behaviour-neutral since impossible requests already don't contribute
+to the objective. Worth shipping whether or not we proceed to 3a; it
+also establishes a clean "missing key → 0" pattern that Phase C will
+need at scale.
+
+**Phase C — Lever 3a (sparse `person_in_bunk` + `person_bunk_assignment`),
+conditional on Phase A.** Refactor
+`direct_solver.py:_create_assignment_variables` to skip cross-gender
+and cross-session (person, bunk) pairs at model-build. **11 constraint
+modules** consume `ctx.assignments[(p, b)]` directly via tuple-key
+access and will all need either a `.get(...)` guard or a range-filter
+update to handle missing keys; the readers are:
+`age_grade_flow.py`, `age_preference.py`, `age_spread.py`,
+`cabin_capacity.py`, `cabin_occupancy.py`, `gender.py`,
+`grade_adjacency.py`, `grade_ratio.py`, `grade_spread.py`,
+`group_locks.py`, `level_progression.py`. Gender constraint becomes
+mostly a no-op (the forced-zero cases never get created); residual
+gender enforcement stays for unknown-gender persons. Estimated savings
+on S2: ~1,640 BoolVars cross-gender plus whatever cross-session pairs
+exist in multi-session mode (related sessions). Risk: foundational
+modeling layer; new test fixtures required for gender-mismatch paths
+because today's tests pass trivially against the dense-then-forced-zero
+encoding.
+
+#### Dropped from scope (with rationale)
+
+| # | Status | Rationale |
+|---|---|---|
+| 3b | **Closed** | `both_in_bunk` removed by #1395; no sparse-encoding lever exists on a structure that no longer exists. |
+| 3c | **Shipped** | Hard MSO landed in #1391 (Stream 1 / Phase 0). |
+| 3d | **Deferred** | Fixed-assignment pass for 1-bunk-eligible campers overlaps with Stream 6b (group_locks impossibility) and the per-session value is unclear without measurement. Reassess after Phase A if AG-only / grade-locked camper counts justify the orchestration work. |
+| 3f | **Deferred** | `grade_ratio` bool_and → `AddAllowedAssignments` is a risky modeling rewrite with no concrete evidence the chains are the bottleneck. The Phase 2 best-bound trajectory shows the plateau is **bound movement**, not branching cost, so the case for tighter LP relaxation here is weak. File a separate issue if a future plateau analysis points back at grade_ratio specifically. |
+
+#### Why not just close Stream 3?
+
+Phase 0 + Phase 1 + #1427 ate enough that the burden of proof has
+flipped: Stream 3 used to be "obvious win," now it's "show me the
+compression ratio first." That's a meaningful re-scope, not a
+cancellation — Phase A is cheap, Phase B is tiny and worth doing
+either way, and Phase C remains the largest single-PR opportunity if
+the metric supports it. Closing the issue without Phase A would mean
+shipping #1381 on stale numbers.
+
+#### GitHub issue
+
+#1381 stays open; this section IS the re-scope referenced in the
+status table. No sub-issues filed — Phases A/B/C are intentionally
+inline-only until Phase A's number forces a decision (per
+[memory: don't file speculative-refactor issues]).
+
+---
+
+### Original spec (preserved for historical context)
+
+> The text below is the pre-2026-05-18 version of Stream 3 and is
+> retained so the original sizing math, lever inventory, and risk
+> framing remain traceable. Everything live is in the re-scope above.
+
+#### Motivation (original)
+
+For S2 (193 persons × 17 bunks), the pre-presolve model would have
+~9,750 boolean variables. CP-SAT presolve compresses to 5,561 (~43%
+reduction). The compression suggests substantial redundancy in the
+model as written — many variables are immediately fixed or implied
+and have to be eliminated by presolve effort rather than never being
+created in the first place.
+
+Reducing model size at *build time* (rather than relying on presolve
+to eliminate junk) yields:
+
+- Smaller working memory
+- Faster presolve
+- Tighter LP relaxation
+- Clearer model when debugging
+
+#### Boolean variable bulk (estimated, S2, ORIGINAL — pre-#1427)
+
+| Source | Pre-presolve count | Code ref |
+|---|---|---|
+| `person_in_bunk[p, b]` — one per (person, bunk) | 193 × 17 = 3,281 | `direct_solver.py:_create_assignment_variables` |
+| ~~`both_in_bunk[req, b]` — one per BUNK_WITH request per bunk~~ | ~~311 × 17 = 5,287~~ | ~~`constraints/bunk_requests.py:add_bunk_request_satisfaction_vars`~~ — pre-#1391 only; the helper was orphaned when #1391 deleted `must_satisfy.py` and removed entirely in #1395. No `both_in_bunk` vars exist in the live model. |
+| `req_satisfied[r]` — one per request | 504 | `constraints/bunk_requests.py`, `age_preference.py` |
+| ~~`must_satisfy_violation[p]` — one per MP camper~~ | ~~164~~ | ~~`constraints/must_satisfy.py`~~ (removed in #1391; the ~250 bidirectional MP sat vars it was replaced by were unified with the objective's set into one shared `request_satisfied_vars` map in #1395) |
+| Constraint-internal indicators (grade_ratio, age_spread, level_progression, grade_adjacency) | ~500 | various |
+| **Total before presolve** | **~9,750** | |
+| **Post-presolve (reported)** | **5,561** | |
+
+#### Levers, ranked by leverage (ORIGINAL)
+
+| # | Lever | Estimated savings | Risk | Effort |
+|---|---|---|---|---|
+| 3a | **Sparse `person_in_bunk` — gender filter at model-build time** | −~1,640 BoolVars for S2 (50% of 3,281) | Low — `person_idx_map` already gender-aware upstream | Modest PR |
+| ~~3b~~ | ~~**Sparse `both_in_bunk` — eligibility intersect**~~ — **moot:** `both_in_bunk` was orphaned by #1391 and removed by #1395. The live sat-var encoding is `person_bunk_assignment`-based (one BoolVar per request, no per-bunk fan-out). | — | — | — |
+| 3c | **Hard MSO** (Stream 1) | −164 BoolVars | Already covered by Stream 1 | — |
+| 3d | **Pre-solve fixed-assignment pass** for 1-bunk-eligible campers (e.g., AG-only, grade-locked) | −17 BoolVars per such camper | Low | Small PR |
+| 3e | **Drop `req_satisfied` for already-impossible requests** | −~4 per session (small) | None | Tiny |
+| 3f | **Convert `grade_ratio` bool_and chains to `AddAllowedAssignments`** (CP-SAT table constraints are tighter than `bool_and`) | Possibly significant, hard to estimate without prototyping | Medium — modeling rewrite | Medium PR |
+
+#### Compound impact (ORIGINAL)
+
+Stages 3a + 3b + Stream 1 (hard MSO) together could reduce booleans
+from **5,561 → ~3,000** (−46%) on S2, with corresponding linear
+constraint reductions. S4 (303 persons × 26 bunks) compounds higher.
+
+> Re-scope note: with 3b moot and Stream 1 shipped, the compound case
+> reduces to lever 3a alone — see the re-scope above.
+
+#### Why 3a is the single best lever (ORIGINAL — still mostly true)
+
+Camp bunks are single-gender. Currently the model creates a BoolVar
+for "girl placed in boys' bunk" for every (F-person, M-bunk) pair —
+all forced to 0 by the gender constraint, but they exist until
+presolve. Limiting `person_in_bunk` creation to (person, eligible_bunk)
+pairs at model-build time eliminates the largest single source of
+pre-presolve redundancy.
+
+#### Code refs (ORIGINAL — `bunk_requests.py` ref stale)
+
+- `bunking/solver/direct_solver.py:_create_assignment_variables` —
+  source of the 3,281 BoolVars
+- ~~`bunking/solver/constraints/bunk_requests.py` — `both_in_bunk` /
+  `separated` loops~~ — gone post-#1395; replaced by the canonical
+  `get_or_create_request_sat_var` builder
+- `bunking/solver/direct_solver.py:_validate_requests` (lines
+  355-438) — impossibility classification already provides the
+  filter list for 3e
+
+#### Risks (ORIGINAL — still applies to Phase C)
+
+1. Refactoring `_create_assignment_variables` touches the foundational
+   modeling layer. Many downstream functions assume the `assignments`
+   dict is dense `(person_idx, bunk_idx)` → BoolVar. Sparse model
+   requires "missing key → forbidden" treatment everywhere it's read.
+2. Test coverage for the constraint modules is good but doesn't
+   exhaustively cover gender mismatches (because the existing model
+   creates the BoolVar and the gender constraint forces it to 0 —
+   the test passes trivially). Need new test fixtures.
+
+#### Out of scope (ORIGINAL — unchanged)
+
+- Custom CP-SAT search-strategy injection. Stays with default workers
+  for now.
+- Wholesale switch from CP-SAT to LP-based solver. Out of scope
+  permanently for this codebase.
+
+#### GitHub issue
+
+#1381. Re-scope is the section above this one.
+
+---
+
+## Stream 4 — Mutual-Request Boost (PR-D)
+
+**Status:** Newly promoted to high priority per the May 12
+investigation. Originally tagged "Stage 5" in the wife-feedback
+scoreboard.
+
+### Motivation
+
+The stuck-core cohort analysis (13-run S2 sweep) showed most failing
+single-MP-request campers have a one-directional request: kid A wants
+kid B, but kid B's family didn't reciprocate. The solver sees A's
+request worth `share_bunk_with × first_request_multiplier = 1.5 × 10
+= 15` and B's competing cluster requests at similar weights. With no
+mutual reinforcement, B follows the cluster.
+
+When mutual requests DO exist (both families name each other),
+they're identified post-hoc by the satisfaction logic but get no
+extra weight in the objective. A bonus weight when both directions
+are present would naturally favor those pairings during solve.
+
+### Mechanism (sketch)
+
+In `score_evaluator.py` (or wherever per-request weights are
+calculated), detect mutual pairs:
+
+```python
+def is_mutual_bunk_with(request, all_requests_by_person):
+    if request.request_type != "bunk_with":
+        return False
+    other_id = request.requested_person_cm_id
+    other_requests = all_requests_by_person.get(other_id, [])
+    return any(
+        r.request_type == "bunk_with"
+        and r.requested_person_cm_id == request.requester_id
+        for r in other_requests
+    )
+```
+
+Then in the objective term:
+
+```python
+weight = base_weight * source_multiplier
+if is_mutual_bunk_with(request, all_requests_by_person):
+    weight *= MUTUAL_BOOST_MULTIPLIER  # e.g., 2.0
+```
+
+### Why this complements (doesn't compete with) Stream 1
+
+Stage 4 hard MSO *forces* ≥1 MP per camper but the solver still
+chooses *which* MP. Mutual-boost makes mutual pairs more attractive
+for that choice, so when Stage 4 binds, it preferentially honors
+mutual requests. The two stack: hard MSO enforces coverage breadth;
+mutual-boost steers WHICH request gets honored.
+
+### Estimated impact
+
+Hard to predict precisely without running it. Mutual pairs are
+probably 30–50% of the request graph; boosting their weight 2× could
+shift many borderline cluster placements. Best measured empirically
+once the metrics PR is in.
+
+### Code refs
+
+- `bunking/solver/score_evaluator.py` — current weight calculation
+  (verify location)
+- `bunking/solver/objective_evaluator.py` — objective term assembly
+- `bunking/satisfaction/predicate.py` — canonical satisfaction logic
+  (post-#1158)
+- Memory ref: `feedback_priority_dimensions_independent.md` (don't
+  collapse coincident keys)
+
+### Configuration knob
+
+Add `objective.mutual_request_boost = 2.0` to admin GUI. Defaults to
+2.0 if not set; tunable per camp.
+
+### Risks
+
+1. Symmetry concern — if A→B mutual and C→D mutual, the boost is
+   symmetric so it doesn't break anything, but worth verifying
+   model symmetry is unchanged.
+2. Edge case — A names "B" by string-match, AI resolves to
+   `requestee_id=42`. B names "A" by string-match, AI resolves to
+   `requestee_id=99`. If A's `requester_id` is 99 and B's is 42,
+   mutuality is detected. But if string matches are asymmetric (one
+   side has lower confidence), the resolution layer might mark only
+   one direction `status='resolved'` and the other `status='pending'`.
+   Test fixture needed.
+
+### Out of scope
+
+- Detecting mutual NOT_BUNK_WITH (symmetric by definition; not the
+  same problem).
+- Triple-mutual (A→B→C→A) cycle detection. Pair-level is enough.
+
+### GitHub issue
+
+#1382. **Shipped** in PR #1523 (2026-05-18) as Phase 3.
+
+---
+
+## Stream 5 — Infeasibility Localization for Hard Constraints
+
+**Status:** Shipped in #1391 as a debug-mode diagnostic on the failure
+path.
+
+### Motivation
+
+Stream 1 (Stage 4 hard MSO) introduced a class of failure the prior
+Stream 2 metrics can't diagnose: **INFEASIBLE returns where the cause is
+a subset of the hard MP constraints that can't be jointly satisfied.**
+Tier 1/2 metrics target *feasible-but-suboptimal* solves (best-bound
+trajectory, LP gap, pre-solve compression). On INFEASIBLE the solver
+exits in presolve and those metrics yield no signal.
+
+The existing `find_infeasibility_cause` in `feasibility.py` does
+constraint-type-level isolation — it identifies which constraint
+*module* causes infeasibility (e.g. "parent_paramount" vs "gender").
+That's not granular enough when parent_paramount has 95 individual
+constraints and we need to know *which campers* are unsatisfiable.
+
+### Mechanism
+
+After `find_infeasibility_cause` identifies `parent_paramount` as the
+cause, `localize_hard_mso_infeasibility` runs a two-pass IIS search:
+
+1. **Singleton isolation** — for each MP-hard-constrained camper, solve
+   with that camper's hard constraint skipped. Any camper whose alone-
+   removal restores feasibility is reported as singleton-critical.
+2. **Deletion filter** — if no singleton works, start with all hard MP
+   constraints skipped (feasible by construction) and re-enforce them
+   one at a time. Each camper whose re-addition flips feasibility →
+   infeasibility is part of the minimal correction set.
+
+The result is recorded in the in-memory `solver_runs[run_id]` under
+`parent_paramount_iis` and logged at ERROR level. The `stats` JSON
+column on the `solver_runs` PB record carries it forward to the
+debug dashboard.
+
+Cost: ~`time_limit_seconds × N` solves where N is the
+MP-hard-constrained camper count. Each solve typically returns
+INFEASIBLE in presolve (<0.1s), so 95 candidates ≈ 10s. Bounded by
+`max_candidates=200` to keep pathological sessions from runaway cost.
+
+### Why this is its own stream
+
+Tier 1/2 (Stream 2) are *model-shape* and *feasible-solve-progress*
+metrics. Stream 5 is *post-failure root-cause-localization*. Same
+"observability" umbrella, but different solve states and different
+implementation surface. Keeping them as separate streams avoids
+stuffing the Stream 2 doc with diagnostics that only ever fire on
+INFEASIBLE.
+
+### Code refs
+
+- `bunking/solver/feasibility.py:localize_hard_mso_infeasibility`
+- `bunking/solver/constraints/parent_paramount.py` — honors
+  `ctx.mp_skip_cms` for the IIS probe
+- `bunking/solver/constraints/base.py:SolverContext.mp_skip_cms`
+- `api/services/solver_runner.py` — invokes localization after
+  `find_infeasibility_cause` flags parent_paramount
+
+### Risks
+
+1. ~10s extra wall time on INFEASIBLE runs. Acceptable since INFEASIBLE
+   already returns a fast 0.1s solve + 1–2s analyzer. Localization only
+   fires when the analyzer specifically blames `parent_paramount`.
+2. Deletion filter finds *a* minimal MCS, not *the* minimum MCS — if
+   the IIS structure has multiple minimal sets, order of iteration
+   determines which one we report. Acceptable for staff-facing
+   diagnostics; not for formal model verification.
+
+### Out of scope
+
+- CP-SAT assumptions API (`model.AddAssumption` +
+  `solver.SufficientAssumptionsForInfeasibility`). Native IIS support
+  but requires rewriting parent_paramount's constraint emission to be
+  per-camper-toggleable via assumptions. Deferred unless localization
+  performance becomes a bottleneck.
+- Auto-soft-fallback. The localizer tells us *which* campers can't be
+  honored; the architectural decision of whether to gracefully
+  degrade those to soft MSO is a separate question.
+
+---
+
+## Stream 6 — Pre-Check Impossibility Detection Framework
+
+**Status:** Framework + initial predicates shipping alongside Stage 4 hard
+MSO in #1391. Substreams below extend the registry as additional hard
+constraints land or surface gaps are identified.
+
+### Motivation
+
+Stream 1 made unmet MP requests infeasible rather than soft-degradable.
+Stream 5 (IIS Localization) tells us which campers cause it after the
+fact. But the conflict surfaced in Taste 1 — reciprocal `bunk_with`
+across a 2-grade gap — was knowable *before* the solver ran. The
+`_validate_requests` impossibility classifier in `direct_solver.py`
+didn't check grade compatibility; neither did the user-facing
+`/solver/pre-validate` endpoint at `api/routers/solver.py`.
+
+Worse, the two paths had drifted: `pre_validate_solver` does its own
+hand-rolled impossibility logic that misses `cross_session`,
+`pair_no_shared_bunk` (gender), and `age_pref_no_eligible_grade` —
+all checks that *do* exist in `direct_solver._validate_requests`.
+Staff could click "Pre-Check" on the bunking board, see "all clear",
+then run the solver and hit INFEASIBLE.
+
+### Mechanism
+
+A single `bunking/solver/impossibility.py` module owns classification.
+Each hard constraint module registers a `HardConstraintImpossibility`
+predicate exposing up to three optional layers:
+
+- `check_request(req, ctx)` — request-local (malformed, missing target)
+- `check_pair(req, ctx)` — pair-local (gender, grade gap, session boundary)
+- `check_cluster(component_cms, ctx)` — cluster-local (over-spread chain,
+  oversized connected component)
+
+`validate_impossibility(input_data, config) → ImpossibilityReport` runs
+all registered predicates and returns a structured report. Both
+`pre_validate_solver` and `DirectBunkingSolver._validate_requests` call
+this shared function; legacy hand-rolled paths in both are deleted.
+
+A registry discipline test (`tests/unit/solver/impossibility/test_registry.py`)
+asserts every constraint module marked `hard=True` has a matching
+predicate registered. Adding a new hard constraint without one fails CI.
+
+### Predicates in #1391
+
+| Predicate | Layer | Status |
+|---|---|---|
+| `SessionBoundaryImpossibility` | pair | Relocated from `pre_validate_solver` |
+| `GenderImpossibility` | pair | Relocated from `_validate_requests` |
+| `MalformedRequestImpossibility` | request | Relocated from `_validate_requests` |
+| `AgePreferenceImpossibility` | request | Relocated from `_validate_requests` |
+| `GradeCompatibilityImpossibility` | pair + cluster | **NEW** — fixes Taste 1 reciprocal `bunk_with` across grades |
+| `BunkCapacityImpossibility` | cluster | **NEW** — reciprocal `bunk_with` chains > max bunk capacity |
+| `TargetNotInSolverImpossibility` | request | **Added #1429** — promoted from a hand-rolled `_validate_requests` fallback; closes the last pre-validate ↔ solver drift |
+
+`POST /api/solver/pre-validate` response gains a structured
+`impossibility_report` field replacing the legacy
+`statistics.unsatisfiable_requests`. `PreValidationResultsModal` reads
+the new shape and renders both the staff-friendly prose **and** the
+reason-coded detail tables for every viewer — the originally-spec'd
+"`BUNKING_DEBUG` permission" gate never landed (no such permission
+exists in the codebase as of 2026-05-15). The split-view design is
+deferred until a real need for admin-only detail surfaces; the
+detail-table-only path is reachable via the SolverDebugPage chip
+which opens `SolverDebugImpossibilityModal` (the debug variant).
+
+### Why this is its own stream
+
+Stream 5 is *post-failure* root-cause attribution within a single
+constraint module. Stream 6 is *pre-solve* structural rejection of
+requests that can never satisfy ANY hard constraint. Different solve
+states, different surfaces, complementary. Stream 5 fires when the
+solver returns INFEASIBLE despite passing pre-check; Stream 6 catches
+the bulk of cases before the solver runs at all.
+
+### Code refs
+
+- `bunking/solver/impossibility.py` — new shared module
+- `bunking/solver/constraints/grade_spread.py` + `grade_adjacency.py` —
+  contribute to `GradeCompatibilityImpossibility`
+- `bunking/solver/direct_solver.py:_validate_requests` — gutted to delegate
+- `api/routers/solver.py:pre_validate_solver` — gutted to delegate
+- `frontend/src/components/PreValidationResultsModal.tsx` — extended renderer
+- `frontend/src/components/PreValidateRequestsButton.tsx` — existing entry
+- `frontend/src/pages/summer/SolverDebugPage/SweepPanel.tsx` — new debug entry
+
+### Risks
+
+1. **API shape change** — `statistics.unsatisfiable_requests` removed in
+   the same PR. Modal updated together. No external consumers documented.
+2. **Drift between predicates and constraint modules** — mitigated by
+   `test_registry.py`; a `hard=True` constraint without a predicate fails CI.
+3. **Predicate over-eager flagging** silently drops a request from both
+   objective and MSO. Each predicate ships with negative tests (passes on
+   valid cases).
+
+### Deferred substreams
+
+**Stream 6a — `level_progression` impossibility predicate.** If a
+`bunk_with` requestee is locked by level progression to a bunk the
+requester cannot enter (also by progression), the request is impossible.
+Requires mapping level rules to per-camper allowed-bunk sets. Code ref:
+`bunking/solver/constraints/level_progression.py`. Effort: medium.
+
+**Stream 6b — `group_locks` impossibility predicate.** A `bunk_with` into
+a full locked group (no room) is impossible. A `not_bunk_with` between
+two campers already locked together is also impossible. Code ref:
+`bunking/solver/constraints/group_locks.py`. Effort: small.
+
+**Stream 6c — Per-bunk grade range predicates.** Today's
+`GradeCompatibilityImpossibility` uses the global `max_grade_range`. If
+per-bunk grade ranges become hard constraints (some bunks naturally hold
+narrower bands), the predicate needs to additionally verify *some* bunk's
+per-bunk range accepts both pair members. Blocked on per-bunk grade range
+becoming a hard constraint. Effort: medium.
+
+**Stream 6d — Cohort census (demand > supply).** Pre-solve O(N) pass that
+detects (gender, age-band) cohorts where MP demand exceeds bunk supply
+(e.g., 30 g8-F campers all with MP `clean(grade=8)` but only 2 g8-F
+bunks of capacity 12). Produces a new impossibility category
+`cohort_overcommit` (cluster-shape finding). Effort: medium.
+
+**Stream 6e — "Open request" navigational link (staff UX).** Each
+impossibility row in the staff modal links to the request in
+`RequestReviewPanel` filtered to that request. Strictly navigational;
+staff decides any action. Effort: tiny. Risk: navigation breaks if the
+request review filter API changes.
+
+**Stream 6f — Solver-probe-based fallback for unclassified requests.**
+For the residual subset of requests not classified by any static
+predicate, run a CP-SAT probe ("force this request, drop all others,
+check feasibility") as insurance against drift. ~0.1s per probe; only
+runs on the residual 5-10%. Effort: medium. Mitigated today by
+`test_registry.py`; consider only if drift becomes a real issue.
+
+**Stream 6g — entirely-impossible MP camper pre-check visibility (shipped).**
+Promoted `target_not_in_solver` from a hand-rolled `_validate_requests` fallback
+to a registered `TargetNotInSolverImpossibility` predicate (closing the
+pre-validate ↔ `_validate_requests` drift). Added a derived
+`ImpossibilityReport.mp_campers_entirely_impossible` field computed in
+`validate_impossibility` — single source of truth; `parent_paramount` and
+`_validate_requests` consume it instead of re-deriving. Surfaced in the
+`/solver/pre-validate` response and both impossibility modals as a camper-level
+"will get zero parent requests honored" section. Also fixed the `mp_camper_rate`
+("Acceptable") denominator to count only campers with ≥1 *possible* MP request,
+and fixed a latent bug where `feasibility.py` read `mp_set_entirely_impossible`
+before it was populated. Audit follow-up: #1426.
+
+### GitHub issues
+
+Framework + initial predicates shipped in #1391. Stream 6g (above) shipped
+in #1429 (closes #1428); #1426 tracks the audit follow-up. Substreams 6a–6f
+remain unfiled; file as separate issues if/when prioritized.
+
+---
+
+## Suggested order
+
+Superseded by **"Status & phased sequencing"** near the top of this doc
+(Phases 0–4 with issue numbers). The original rationale, preserved:
+
+- **Metrics first** — Streams 1/3/4 all produce changes worth measuring;
+  without observability their wins are invisible or unattributable. (Held:
+  Tier 1 shipped before Stage 4; Tier 2 now gates Phase 4.)
+- **Stage 4 before mutual-boost** — Stage 4 enforces coverage, mutual-boost
+  steers *which* request gets it; the "which" question is only meaningful
+  once coverage is guaranteed. (Held: Phase 3 follows Phase 0.)
+- **Variable-attack last** — largest LOC, touches foundational modeling.
+  (Held + sharpened: #1391 + #1427 already ate most of its blast radius —
+  re-scope in Phase 4.)
+
+---
+
+## Parked — V1/V2 models consolidation (was #1451)
+
+`bunking/models.py` (V1, 416 lines) and `bunking/models_v2.py` (V2, 151 lines)
+both alive against different surfaces. #1451 closed **not-planned** on
+2026-05-17: no end-to-end verification harness exists today to confirm a V1→V2
+migration would be behavior-neutral across the live validator + scenarios
+paths. File now so we don't re-discover the same smell each domain.
+
+### What's alive where (verified 2026-05-17)
+
+| Surface | Live models source | Notes |
+|---|---|---|
+| `DirectBunkingSolver` (production solver) | **V2** (`DirectBunkRequest`, `DirectPerson`, `DirectBunk`, `DirectBunkAssignment`, `DirectSolverInput`, `DirectSolverOutput`, `HistoricalBunkingRecord`) | Touched by `api/services/solver_runner.py`, `api/services/data_fetcher.py`. This is the path the streams above all target. |
+| `POST /api/validate-bunking` (mounted `api/main.py:140`) | **V1** (`Bunk`, `BunkAssignment`, `BunkRequest`, `Person`, `Session`) via `bunking_validator.BunkingValidator` | Live FastAPI endpoint; generated frontend client at `frontend/src/types/api-generated/types.gen.ts:5545,6219`. Post-solve satisfaction analysis against historical bunking, not solving. |
+| `POST /api/scenarios` + 6 sibling routes (mounted `api/main.py:142`) | **V1** (same model set) | Live FastAPI endpoints; full set documented in `frontend/src/types/.openapi-schema.json:540-1033`. Scenario CRUD + score + analyze + solve + clear. |
+| `RequestType` enum (shared symbol) | V1 — re-used by sync tests, solver constraint tests, frontend test mocks | Three test files import only the enum, suggesting at minimum it should be promoted out of V1 into a shared location. |
+| `HistoricalBunkingRecord` — duplicated 3 ways | V1 dataclass at `bunking_validator.py:53`, V2 pydantic at `models_v2.py:98`, plus V1 module surface | Same name, three definitions, different consumers — exactly the drift the original issue warned about, now concrete. |
+
+### Why parked rather than executed
+
+The migration path is plausible (validator-only types stay near the validator, scenario routes likely re-export V2 shapes through their own API schemas), but it's a multi-PR refactor touching three live surfaces — solver, validator endpoint, scenarios endpoints — and **there is no integration-level "solver pass"** (full validator + scenarios + solve round-trip against a snapshotted input) that would catch silent regressions from a model swap. Pydantic field-constraint drift is exactly the failure mode that slips through unit tests; the original issue's 1-5 vs 1-10 `priority` example was caught by code-review eyeballing, not CI. Note: that specific drift is now **moot** — PR #1455 (#1432) deleted `bunk_requests.priority` outright, leaving a no-op validator stub at `models.py:59-64`.
+
+### Pick-up criteria
+
+Revisit when **any** of these become true:
+
+- An integration test exists that round-trips the live `/validate-bunking` + `/scenarios/*` surface and would catch a behavior-equivalent model swap.
+- A non-cosmetic drift between V1 and V2 (a new constraint, a new field with diverging validators) causes a real bug. The drift becomes the forcing function.
+- The larger solver tech-debt refactor (the pass that absorbed #1426's audit doc — see `docs/plans/audit-1426-impossibility.md`) is started — V1/V2 consolidation folds in naturally with the impossibility-predicate cleanup.
+
+Until one of these triggers, the priority-deletion-style per-domain cleanup (Phase 1.5 via `solver-config-it`) handles V1-side fields as they're individually retired (priority already gone via #1455). The duplication shrinks on its own as each domain wraps.
+
+### First drift instance observed (2026-05-18) — RESOLVED narrow
+
+Post-#1442 (solver-side impossibility gating), the post-check modal showed
+~92% (152/166) where the solver-side JSON showed ~97% (151/155) for the same
+solve. Root cause: `bunking/bunking_validator.py:789-795` (V1 path) computed
+`material_parent_requests` independently from raw resolved requests and never
+gated on the impossibility report. Filed as **#1520** and shipped 2026-05-18
+on the **narrow tactical** path: validator gained an `impossible_request_ids`
+kwarg, `api/routers/validation.py` computes it via the same
+`fetch_session_data_v2` → `prepare_direct_solver_input` →
+`validate_impossibility` path `pre_validate_solver` uses, and threads IDs to
+the validator. Validator stays V1-pure; issue listings (per-camper warnings)
+stay ungated by design. **V1/V2 consolidation deferred** — the narrow path
+restores parity now and the structural divergence remains as a future trigger
+when a non-cosmetic field-validator drift surfaces.
+
+**Known overhead introduced by #1520.** `api/routers/validation.py` now does
+a parallel V2 fetch (`fetch_session_data_v2`) alongside its existing V1
+fetches — same PB collections (attendees, bunks, requests, assignments,
+bunk_plans) pulled twice with different shapes. Roughly **5 extra PB
+`get_full_list` round-trips per `/api/validate-bunking` call**. On a typical
+S2-sized session that's on the order of 100–500ms additional latency,
+dominated by PB call latency, not by `validate_impossibility` itself (which
+runs predicates over an in-memory list and is sub-ms).
+
+Two optimization paths if the overhead bites:
+
+- **Short-term — frontend passes precomputed IDs.** The post-check modal
+  already has a `preCheckQuery` that fetches `/api/solver/pre-validate` and
+  caches the impossibility report. Threading `impossible_request_ids` through
+  `ValidateBunkingRequest` lets the route skip the recompute when the caller
+  provides them. Validator keeps the route-side compute as a fallback so
+  legacy/scripted callers stay correct. Small change, no V1/V2 reshape.
+- **Long-term — V1/V2 validation route consolidation.** Refactor
+  `validation.py` to fetch via `fetch_session_data_v2` exclusively; the
+  validator either stays V1 behind a V2→V1 adapter or migrates to V2 directly.
+  This is the parked V1/V2 consolidation work — the #1520 fix doesn't trigger
+  it (the narrow path restored parity), but if the validation route gains
+  another structurally similar concern it becomes the forcing function.
+
+Neither is filed today. The overhead hasn't been measured in production yet;
+file if SolverDebug page latency or staff-modal-perceived lag actually
+regresses.
+
+---
+
+## Cross-references
+
+- `bunking/solver/direct_solver.py` — main solver entry
+- `bunking/solver/constraints/` — constraint modules
+- `bunking/solver/feasibility.py` — pre-solve validation
+- `bunking/satisfaction/{bucket,aggregate,predicate}.py` — canonical
+  post-#1158 satisfaction logic
+- `api/services/solver_runner.py` — task orchestration
+- `docs/reference/solver-config-decisions.md` (gitignored) — local
+  Phase 1.5 cleanup planning artifact
+- Wife-feedback scoreboard (local doc) — Stage 4 sketch context
+
+---
+
+## Update log
+
+- **2026-05-13** — Doc created. All four streams documented; GitHub
+  issues filed in companion commits.
+- **2026-05-13** — Stream 2 (metrics) shipped in #1385.
+- **2026-05-13** — Stream 1 (Stage 4 hard MSO) shipped in #1391.
+  Implementation surfaced that the soft sat vars used one-way
+  `OnlyEnforceIf` implications, so the roadmap's "−164 BoolVars / −164
+  reified" simplification math was wrong as written. The corrected
+  math (model approximately neutral vs soft baseline) is in the Stream
+  1 "Model simplification" section above. Four follow-up issues
+  filed: #1395 (sat var unification), #1396 (penalty-driven
+  investigation), #1397 (`solution.py` cleanup), #1398 (golden
+  alignment test).
+- **2026-05-13** — Stage 4 follow-up bundled into #1391: Taste 1
+  produced INFEASIBLE on first real-data run because cross-gender
+  `bunk_with` MP requests slipped past the safety gate. Widened
+  `_validate_requests` with a new `pair_no_shared_bunk` impossibility
+  reason (gender + session check via `_pair_has_shared_bunk`). Added
+  `parent_paramount` toggle to `feasibility.py`'s analyzer
+  `constraint_types` list — without it the analyzer mis-diagnoses
+  "gender" as the cause when hard MP is the real culprit.
+- **2026-05-13** — Second Stage 4 follow-up in #1391: Taste 1 still
+  INFEASIBLE because MP `age_preference` requests at the same-gender
+  grade bound (e.g. grade-6 boy prefers older in a max-grade-6-boys
+  session) were treated as "possible" by `_validate_requests` and
+  forced the hard MP constraint to fire when no satisfying bunk
+  composition exists. Camp policy: at-bound preferences in the wrong
+  direction are moot ("too bad, impossible"). Added
+  `age_pref_no_eligible_grade` reason and `_session_grade_bounds_for_gender`
+  helper. Bounds derived from the same-gender camper pool today; a
+  follow-up issue tracks tying this to admin-GUI grade configuration.
+- **2026-05-13** — Stream 5 (Infeasibility Localization) shipped in
+  #1391. Taste 1 INFEASIBLE persisted past both gate-widening fixes
+  (only knocked 3 of 98 candidates into `mp_set_entirely_impossible`).
+  Tier 1/2 metrics aren't the right tool for INFEASIBLE diagnostics —
+  they target FEASIBLE-but-suboptimal solves. Added an IIS-style
+  localization pass that fires on `parent_paramount`-caused
+  infeasibility: singleton isolation then deletion filter, reporting
+  the minimal correction set of campers whose hard MP constraints
+  can't be jointly satisfied. Output goes to logs and the
+  `parent_paramount_iis` field on `solver_runs.stats`.
+- **2026-05-13** — Stream 6 (Pre-Check Impossibility Detection
+  Framework) scoped and bundling into #1391. IIS on Taste 1 returned
+  a 2-camper MCS: a reciprocal `bunk_with` across a 2-grade gap (g3 ↔
+  g5). Each alone is satisfiable, the pair isn't. Singleton isolation
+  missed because removing either still leaves the other's MP forcing
+  co-placement. The pair-feasibility gate (`_pair_has_shared_bunk`)
+  only checks session + gender, not grade compatibility — exactly the
+  drift Stream 6 fixes. New `bunking/solver/impossibility.py` module
+  with per-constraint predicate registry; both `pre_validate_solver`
+  and `DirectBunkingSolver._validate_requests` delegate to it.
+  `GradeCompatibilityImpossibility` (pair + cluster) catches
+  that case pre-solve. API response `impossibility_report` replaces
+  legacy `statistics.unsatisfiable_requests`. `PreValidationResultsModal`
+  extended with staff-friendly prose vs admin-detail views. Substreams
+  6a–6f (level_progression, group_locks, per-bunk grade range, cohort
+  census, "open request" link, solver-probe fallback) deferred.
+- **2026-05-14** — #1395 shipped: bunk-request sat-var unification. Deleted
+  the orphaned one-way `add_bunk_request_satisfaction_vars` (dead since
+  #1391 removed `must_satisfy.py`), added the canonical bidirectional
+  `get_or_create_request_sat_var`, and unified `add_objective` +
+  `parent_paramount` onto one shared `request_satisfied_vars` map.
+  Behaviour-neutral (both prior encodings were already honest bidirectional
+  comparisons); the win is ~250 fewer duplicate BoolVars on S2. Corrected
+  the Stream 1 "Reality" note (the objective was never falsifiable) and the
+  Stream 3 table / lever 3b (`both_in_bunk` no longer exists in the live model).
+- **2026-05-14** — #1388 shipped (PR #1425): Tier 1 solver stats split by
+  `RequestBucket` (MP / IMP / staff) — per-bucket `request_density_histogram`
+  and `impossible_by_reason`.
+- **2026-05-14** — Stream 6g shipped: `target_not_in_solver` promoted to a
+  registered predicate; `mp_campers_entirely_impossible` rollup added to
+  `ImpossibilityReport`; `mp_camper_rate` denominator corrected. Filed #1426 to
+  audit `direct_solver` for other hand-rolled impossibility logic.
+- **2026-05-14** — Added "Status & phased sequencing" section (Phases 0–4 +
+  issue map) and retired the stale "Suggested order" table. Reconciled the
+  Stream 2/3/4 "GitHub issue" lines with filed issue numbers. Flagged Tier 2
+  as unfiled (orphaned when #1380 closed on Tier 1 alone).
+- **2026-05-14** — #1398 in review (PR #1434): golden sat-var ↔ predicate
+  alignment test. Scoped to Option 2 — asserts agreement for every entry in
+  `request_satisfied_vars` (the shared bidirectional `bunk_with`/`not_bunk_with`
+  sat var, i.e. the complete output of `get_or_create_request_sat_var` and the
+  surface #1427 changed). `age_preference` is out of scope: digging into #1398
+  found its solve-time `sat_var` is one-way encoded *and* discarded by its only
+  caller — no faithful var to align against. Two dead-code findings filed:
+  #1432 (`negative_requests.hard_constraint_threshold` unschematized + the
+  `not_bunk_with` hard branch unreachable since real priorities are 1–4) and
+  #1433 (age_preference `sat_var` built-but-discarded; non-MP age_preference
+  unmodeled by the solver — confirm intent). #1433 is the prerequisite for ever
+  extending #1398's alignment test to `age_preference`.
+- **2026-05-14** — #1429 merged (closes #1428): Phase 1 (pre-check honesty)
+  complete — Stream 6g shipped, #1426 (`direct_solver` impossibility audit)
+  now unblocked. Phase 2 (Tier 2 plateau metrics) started **without a
+  tracking issue** — the three-metric spec (best-bound trajectory, LP root
+  gap, presolve compression ratio) is fully captured in the Stream 2 section,
+  so the PR carries it directly. The remaining Tier 2/Tier 3 metrics stay
+  tracked in the Stream 2 tables. Worktree: `tier2-plateau-metrics`.
+- **2026-05-14** — #1434 merged (closes #1398): golden sat-var ↔ predicate
+  alignment test landed (Option 2 scope — bunk_with/not_bunk_with only). The
+  drift-defense net for #1427's unified sat-var encoding is now in CI.
+  age_preference coverage stays deferred behind #1433.
+- **2026-05-14** — #1436 merged: **Phase 2 (Tier 2 plateau-diagnostic
+  metrics) shipped.** Added `bunking/solver/observability.py`, extended
+  `callbacks.py` to record best-bound samples during solve, surfaced in the
+  SolverDebugPage as a new `BoundTrajectoryChart`, plus `metricRegistry`,
+  per-run drill-down rows for LP root gap and presolve compression ratio, and
+  new columns in `SolverRunsTable`. **Phase 3 (Stream 4 mutual-request boost,
+  #1382) is now the next build** — Phase 2's best-bound trajectory is the
+  measurement signal that lets us tell "boost broke the plateau" from
+  "boost shuffled local optima".
+- **2026-05-15** — #1438 merged (closes #1397): `solution.calculate_satisfied_requests`
+  retired; `calculate_field_level_stats` deleted; satisfaction computation
+  routed through a new `bunking/satisfaction/batch.py` helper. `solution.py`
+  shrunk from ~187 lines to a thin shim — behaviour-neutral cleanup.
+- **2026-05-15** — Post-Phase-2 verification sweep against v5.4.0 prod baseline.
+  S2 (Session 2) model size collapsed from 11,657 → 5,215 variables (−55%) and
+  23,644 → 12,060 constraints (−49%) — mostly #1427's sat-var unification (much
+  bigger than the original "~250 dup BoolVars" framing; the reified-linear
+  cascades that fed them dropped too). Gap tightens dramatically on the same
+  budget (60 s: 5.95% → 3.80%; 300 s: 5.49% → 0.95%). Objective stays parked in
+  the 160K–163K range — the plateau pattern Phase 2's bound-trajectory chart was
+  built to make visible. `mp_camper_rate` ("Acceptable") jumped 98 → 100% (the
+  #1429 denominator fix excluding the 3 entirely-impossible MP campers from S2,
+  not a real coverage change). Three follow-up issues filed during the
+  verification: **#1440** (separate red chip for totally-impossible-MP campers
+  on the SolverDebugPage pre-check button), **#1441** (camper-name click-through
+  + replace vague "fix parent input" copy in both impossibility modals; also
+  noted: yellow names aren't currently click-through either, contrary to a
+  passing assumption — scoped both red and yellow in the issue), **#1442**
+  (mirror #1429's denominator fix on `all_camper_rate` "Optimized", plus carry
+  the impossibility roster forward into `PostValidationResultsModal` so staff
+  can see *who* didn't get fulfilled once the rate goes to 100%). Also corrected
+  the Stream 6 doc: the "`BUNKING_DEBUG` permission for admin-only detail
+  tables" never landed; the modal renders the same view for everyone today.
+- **2026-05-17** — #1451 (V1/V2 models consolidation) closed not-planned;
+  finding parked in the new "Parked — V1/V2 models consolidation" section
+  above. Both `models.py` and `models_v2.py` confirmed alive against
+  different surfaces (solver vs. validator endpoint + scenarios endpoints);
+  `HistoricalBunkingRecord` is defined three times. Original 1-5 vs 1-10
+  `priority` drift example is now moot (deleted via PR #1455). Refactor
+  deferred until an integration-level solver-pass test exists or a
+  non-cosmetic drift forces the issue.
+- **2026-05-18** — Stocktake against actual GitHub state. The cleanup wave
+  flagged on 2026-05-15 all shipped or closed: **#1432** in #1455 (folded
+  into priority-field deletion), **#1433** in #1466 (bidirectional
+  age_preference sat var), **#1440** in #1465, **#1441** in #1464, **#1442**
+  in #1463/#1464, **#1424** closed not-planned, **#1426** closed with audit
+  deliverable at `docs/plans/audit-1426-impossibility.md` (no remaining
+  hand-rolled impossibility logic), **#1396** closed not-planned (Phase-2
+  bound-trajectory chart visualizes the plateau directly; the original
+  counterfactual experiments were superseded). Additional solver follow-ups
+  merged in the same window that weren't tracked here: **#1437** (retire
+  dead `DirectSolverOutput.analysis` path, PR #1453), **#1386** (tighten
+  `request_validation_summary` to a TypedDict, PR #1487), **#1467** (remove
+  unreachable per-bunk branch in `age_preference` sat-var builder), and
+  **#1332** (thread config through penalty accessors). Table at the top of
+  this doc updated; only **Stream 4 (#1382 — Phase 3, mutual-request boost)**
+  and **Stream 3 (#1381 — Phase 4)** remain genuinely open. Stream 4 is the
+  next build. Also today: filed **#1520** after observing the first drift
+  instance — `bunking_validator.py` doesn't gate the post-check denominator
+  on impossibility, producing 92% (validator) vs 97% (solver) on the same
+  run. Logged in the V1/V2 Parked section as candidate trigger.
+- **2026-05-18** — **Stream 4 (#1382, mutual-request boost) shipped in
+  PR #1523** — Phase 3 complete. Boost detects reciprocated `bunk_with`
+  pairs and applies a configurable `objective.mutual_request_boost`
+  multiplier in `score_evaluator`; symmetric so model symmetry is
+  preserved. Phase 2's best-bound trajectory is the post-merge
+  measurement signal. **Phase 4 (Stream 3 / #1381, variable-count attack
+  surface, re-scope first)** is the next build — lever 3a (sparse
+  `person_in_bunk` gender filter) is the main remaining win since #1391
+  + #1427 already ate `both_in_bunk`.
+- **2026-05-18** — **#1520 (validator-side parity) shipped** on the
+  narrow tactical path. `bunking_validator.validate_bunking()` gained an
+  `impossible_request_ids: set[str] | None` kwarg; aggregate counters
+  (`material_parent_*`, `staff_*`, `total_*`, `mp_campers_*`) gate on it
+  so post-check denominators match the solver-side gating from #1463.
+  `api/routers/validation.py` computes the set via the same
+  `fetch_session_data_v2` → `prepare_direct_solver_input` →
+  `validate_impossibility` path `pre_validate_solver` uses. Issue
+  listings stay ungated by design — per-camper warnings still surface
+  every unmet request. The first-drift entry in the V1/V2 Parked
+  section is now resolved; V1/V2 consolidation remains deferred until
+  a non-cosmetic field-validator drift forces it.
+- **2026-05-18** — **Phase 3 measured impact (S4, session 1235406).**
+  Cross-SHA sweep: v5.5.0 prod (1×, no boost — SHA `ec49e204`) vs.
+  current main (5× boost). Both at 30/60/180 s budgets, 304 persons,
+  26 bunks, ~373 MP requests, 200/204 MP campers (4-camper enrollment
+  delta from PR #1515).
+
+  | Budget | v5.5.0 MP req rate | main 5× MP req rate | Δ | v5.5.0 gap | 5× gap |
+  |---|---|---|---|---|---|
+  | 30 s | 280/377 = 74.27% | 349/373 = 93.6% | **+19.3 pp** | 68.78% | 2.04% |
+  | 60 s | 325/377 = 86.21% | 356/373 = 95.4% | **+9.2 pp** | 14.71% | 1.40% |
+  | 180 s | 351/377 = 93.10% | 355/373 = 95.2% | +2.1 pp | 4.09% | 1.00% |
+
+  MP campers: **204/204 (100%) at every v5.5.0 budget** too — hard MSO
+  from #1391 was already saturated pre-boost on S4. The boost moves
+  *request-level* coverage, not camper-level.
+
+  **Headline:** boost is primarily a **convergence accelerator**, not a
+  ceiling-raiser. v5.5.0 reaches 93.10% MP at 180 s; current main 5×
+  reaches 93.6% at 30 s — Phase 3 compresses 180 s of v5.5.0 work into
+  30 s on the harder bed. Production-relevant budgets (30-60 s) see
+  the largest gains; long budgets converge to the same ceiling.
+
+  **Mechanism:** LP root gap collapsed **74.10% → 4.09%** at 30 s under
+  the boost-shaped objective. LP relaxation tightness explains most of
+  the speedup — solver enters its first solution near the basin.
+  `num_solutions_found = 1` across all 6 runs; boost doesn't help
+  the solver explore multiple incumbents (that's a Phase 4 lever).
+
+  Side-finding: `unsatisfied_no_possible` trajectory 12 → 3 → 1 across
+  budgets revealed the metric is a post-solve outcome, not an input
+  property — filed as #1527.
+
+  **Saturated-bed caveat:** S2 (session 1235404, 192×17) is at ceiling
+  for the boost (323/344 = 93.9% from 30 s budget onward at both 2× and
+  5×; residual 21 unmet are partial-tails of multi-MP campers, none
+  mutual). S4 is the right bed for any future coverage-moving lever.
+- **2026-05-18** — Objective sensitivity analysis shipped (#1529):
+  `docs/reference/objective-sensitivity.md` compiles per-request weights,
+  per-constraint penalty inventory, and per-archetype threshold ratios from
+  one place. `scripts/analyze_objective_sensitivity.py` regenerates the
+  three tables; `tests/unit/scripts/test_analyze_objective_sensitivity.py`
+  locks every magnitude. Drives the business-rules-vs-magnitudes review
+  recorded in `solver-config-decisions.md` (gitignored, local-only).
+- **2026-05-18** — Business-rules-vs-magnitudes review opened off the back
+  of #1529. Eight deltas surfaced against staff's stated priority stack;
+  four actionable (Δ1–Δ4), three confirmed-correct (Δ5, Δ7, Δ8), one
+  noted-not-actionable (Δ6). Spinoff: `soft_constraints_by_module` reports
+  vars-created not fires-honored (vars resolve to 0 in the final solution
+  for most reified penalties — the metric reads as a violation count but
+  isn't). Filed locally; not yet a GitHub issue.
+- **2026-05-18** — Business-rules batch 1 shipped (#1533): Δ3 raises
+  `objective.source_multipliers.share_bunk_with` 1.5 → 1.75 so MP one-way
+  `bunk_with` (700 at slot 0; 1400 mutual) sits strictly above staff
+  `not_bunk_with` (600); Δ4 raises `internal_notes` 0.8 → 1.0 so both note
+  sources tie at 400. Adjacent: B-class evaluator/seed-drift fixed in
+  `score_evaluator.py` + `objective_evaluator.py` (production never tripped
+  the fallbacks because CONFIG_SCHEMA requires the keys; the fix is
+  code-readability only). Post-merge local sweep on S4 (1235406, 30/60/180 s):
+  obj +0.03–0.33% across budgets, gap *tightened* at every budget
+  (2.04→1.73, 1.40→1.03, 1.00→0.98), satisfied-request count stable in
+  533–545 band. No regression; "tail tax" got marginally steeper as
+  intended (post-180 s satisfies 542 vs pre 545 but at higher obj — solver
+  prefers fewer high-weight placements over more low-weight ones).
+- **2026-05-18** — Business-rules Δ1 (penalty re-rank: spreads > ratio >
+  occupancy) **deferred**. Post-batch-1 analysis showed only `age_spread`
+  and `grade_ratio` are behaviorally live — `grade_spread` runs hard in
+  prod (penalty never fires) and `cabin_min_occupancy` is reshaped by Δ2.
+  But age_spread itself is queued for hard-ceiling collapse in the Age
+  Spread Phase 2 PR, which would moot any penalty value bumped here.
+  Decision: wait for the soft→hard collapses to ship, then re-evaluate
+  what the live penalty surface needs.
+- **2026-05-20** — **Age Spread Phase 2 shipped (#1553)**: hard 24-mo cap
+  with edge-bunk escape hatch. **Δ1 (penalty re-rank) is now unblocked** —
+  the soft→hard collapse it was waiting on is live; re-rank now operates on
+  the live hard-constraint surface only. Also shipped: **#1142 Phase 2**
+  (#1550) collapsed bucket/rule/multiplier maps into a single `(source,
+  type)` registry, and **#1142 Phase 3** (#1552) routed all objective
+  multipliers through `weight_for`. Table updated; Δ1 promoted from
+  DEFERRED to OPEN.
+- **2026-05-20** — **Δ1 closed as-moot.** #1553 made `age_spread` fully
+  hard (no soft component — the edge-bunk escape hatch is an MSO
+  feasibility carveout, not a tunable penalty). `grade_spread` never
+  fires in prod. Both spread signals are gone from the penalty surface,
+  eliminating the "spreads top" motivation entirely. The only surviving
+  piece — `cabin_min_occupancy` below `grade_ratio` — is superseded by
+  Δ2, which converts occupancy to a bonus and removes it from the penalty
+  ranking. Re-ranking before Δ2 would be pure churn; intent folded into
+  Δ2.
+- **2026-05-20** — **Δ2 closed not-planned.** Enrollment analysis against
+  the local main DB for 2026: 5 of 6 main-session gender cohorts average
+  10.67–12.00 campers/bunk; only S3 boys (78/8 = 9.75) is below preferred.
+  Realized bunk-size distribution across all 2026 scenario drafts: zero
+  bunks at the 8-floor, 5 at 9, 47 at ≥10 (90%). Staff confirmed they do
+  prefer ≥10 — current per-spot penalty is actively keeping bunks off
+  the floor and earning its keep. Reshape to bonus would be cosmetic
+  relabeling at best; risk of regressing the 9→8 nudge isn't worth it.
+  Leave the constraint as-is.
+- **2026-05-20** — **Stream 3 Phase A executed; Phase C closed-as-moot.**
+  Pulled the three most recent successful S2 runs from local main PB
+  (`run_47ac60a08222`, `run_27f79acf2ecb`, `run_7569a893d185`). All three
+  report `presolve_compression_ratio = 0.938` — presolve eliminates ~6.2%
+  of the 4,912-boolean pre-presolve count. The original Stream 3 hypothesis
+  of "43% compression = lots of redundancy" (pre-#1391/#1427 baseline) is
+  stale; hard MSO + sat-var unification already collapsed the headroom.
+  Phase C (sparse `person_in_bunk` + `person_bunk_assignment`, 11 constraint
+  modules, new gender-mismatch fixtures) cannot be justified against a 6%
+  win. Phase B (lever 3e — drop `req_satisfied` for impossible requests)
+  remains the only Stream 3 work; closes #1381 on merge.
+- **2026-05-20** — **Stale spinoff entry retired.** The
+  `soft_constraints_by_module` reporting fix actually shipped as #1532 in
+  PR #1547 on 2026-05-19 (one day after the prior roadmap update, hence
+  missed). The corrected metric counts fires-honored via `solver.Value(var)`
+  in `_bucket_soft_constraint_violations`; #1547 also added a new
+  `soft_constraint_penalty_by_module` field (weighted penalty per bucket)
+  that ships in the API response. Frontend currently displays the
+  fires-count in `SolverDebugPage/DrillDownDrawer.tsx` but does NOT yet
+  surface the penalty-weighted view — small follow-up to wire that in.
+- **2026-05-20** — **Open PR #1559 wires the penalty-weighted view through
+  the SolverDebugPage drill-down.** Adds `SolverRunStats.soft_constraint_
+  penalty_by_module` type, `RunSummary` pass-through with omit-when-empty,
+  and a parallel rose-tinted chip row next to the existing amber
+  fires-count row in `DrillDownDrawer.tsx`. Admin-only debug surface; not
+  end-user-facing.


### PR DESCRIPTION
Checks in the solver optimization roadmap that had been living as an untracked local doc, so the context is shared and survives worktree churn.

## What
Adds `docs/reference/solver-roadmap.md` (reference doc, no code changes). Captures:
- Phased sequencing of Streams 1–6 (hard must-satisfy-one, debug-metrics expansion, variable-count attack surface, mutual-request boost, infeasibility localization, pre-check impossibility framework)
- Work-item → issue → status table + Phase A results
- Parked V1/V2 consolidation rationale

## Why
The May 12 solver investigation surfaced several parallel improvement streams; the rationale was previously only in a local file, easy to lose. Tracking it in-repo keeps it durable and discoverable.

Docs-only — no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive solver optimization reference documentation covering workstreams, status tracking, phased sequencing, and timeline updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1684?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->