### PR TITLE
fix(sync): treat negative-hash unresolved ids as unresolved in validation gates

### DIFF
--- a/bunking/sync/bunk_request_processor/validation/rules/self_reference.py
+++ b/bunking/sync/bunk_request_processor/validation/rules/self_reference.py
@@ -45,8 +45,11 @@ class SelfReferenceRule(ValidationRule):
                 return result
 
         # For requests with no resolved target person,
-        # check if the raw target name matches requester's name
-        if not request.requested_cm_id and "raw_target_name" in request.metadata:
+        # check if the raw target name matches requester's name.
+        # Unresolved targets carry either None (age preferences) or a negative-hash
+        # id (named-but-unresolved, via generate_unresolved_person_id) — both mean
+        # "no real CM ID", so treat id < 0 as unresolved (#1683).
+        if (request.requested_cm_id is None or request.requested_cm_id < 0) and "raw_target_name" in request.metadata:
             raw_name = request.metadata.get("raw_target_name", "").strip().lower()
             requester_name = request.metadata.get("requester_full_name", "").strip().lower()
 

--- a/bunking/sync/bunk_request_processor/validation/rules/session_compatibility.py
+++ b/bunking/sync/bunk_request_processor/validation/rules/session_compatibility.py
@@ -54,8 +54,11 @@ class SessionCompatibilityRule(ValidationRule):
         """
         result = ValidationResult(is_valid=True)
 
-        # Skip validation when there is no resolved target (missing id or age preference)
-        if not request.requested_cm_id:
+        # Skip validation when there is no resolved target. Unresolved targets carry
+        # either None (age preferences) or a negative-hash id (named-but-unresolved,
+        # via generate_unresolved_person_id) — a negative id cannot exist in
+        # `attendees`, so treat id < 0 as unresolved and skip the lookup (#1683).
+        if request.requested_cm_id is None or request.requested_cm_id < 0:
             return result
 
         # Get sessions for both people

--- a/tests/unit/sync/bunk_request_processor/orchestrator/test_self_reference_handling.py
+++ b/tests/unit/sync/bunk_request_processor/orchestrator/test_self_reference_handling.py
@@ -29,6 +29,9 @@ from bunking.sync.bunk_request_processor.core.models import (
     RequestStatus,
     RequestType,
 )
+from bunking.sync.bunk_request_processor.orchestrator.orchestrator import (
+    generate_unresolved_person_id,
+)
 
 
 def _create_mock_pocketbase():
@@ -335,15 +338,14 @@ class TestFirstNameAmbiguityHandling:
         pb = _create_mock_pocketbase()
         orchestrator = RequestOrchestrator(pb=pb, year=2025)
 
-        # Simulate a first-name-only unresolvable request
+        # Simulate a first-name-only unresolvable request, production-faithfully (#1683):
+        # a named-but-unresolved request gets a deterministic negative-hash id from
+        # generate_unresolved_person_id — NOT None (only AGE_PREFERENCE gets None). The
+        # raw-name self-reference path must treat that truthy negative id as unresolved.
         requests = [
             _create_bunk_request(
                 requester_cm_id=100,
-                # requested_cm_id=None drives the raw-name self-reference path directly.
-                # In production an unresolved *named* request gets a negative-hash id
-                # (not None), which currently bypasses that check — see #1683. None is
-                # used here intentionally to exercise the first-name-ambiguity detection.
-                requested_cm_id=None,
+                requested_cm_id=generate_unresolved_person_id("Emma"),
                 metadata={
                     "raw_target_name": "Emma",  # First name only
                     "requester_first_name": "Emma",

--- a/tests/unit/sync/bunk_request_processor/validation/rules/test_self_reference.py
+++ b/tests/unit/sync/bunk_request_processor/validation/rules/test_self_reference.py
@@ -355,5 +355,82 @@ class TestSelfReferenceNicknameMatching:
         assert result.is_valid
 
 
+class TestSelfReferenceUnresolvedNegativeId:
+    """Tests for #1683: the raw-name self-reference check must treat
+    named-but-unresolved requests (negative-hash ``requested_cm_id``) as
+    unresolved.
+
+    In production, only AGE_PREFERENCE requests get ``requested_cm_id=None``;
+    a named-but-unresolved request is assigned a deterministic negative-hash id
+    by ``generate_unresolved_person_id`` (range -1,000,000 .. -1,000,000,000).
+    The old ``if not request.requested_cm_id`` gate treated that truthy negative
+    id as resolved, so the raw-name + first-name-ambiguity detection never ran
+    in production. These fixtures use a production-faithful negative id.
+    """
+
+    # A representative negative-hash id (must be < 0, in the unresolved range).
+    UNRESOLVED_ID = -1_000_123
+
+    @pytest.fixture
+    def rule(self):
+        return SelfReferenceRule()
+
+    @pytest.fixture
+    def base_request(self):
+        return BunkRequest(
+            requester_cm_id=12345,
+            requested_cm_id=self.UNRESOLVED_ID,
+            request_type=RequestType.BUNK_WITH,
+            session_cm_id=1000002,
+            is_first_requested=False,
+            confidence_score=0.0,
+            source_field="bunk_request_form",
+            csv_position=0,
+            year=2025,
+            status=RequestStatus.PENDING,
+            metadata={},
+        )
+
+    def test_negative_hash_full_name_match_flagged(self, rule, base_request):
+        """An unresolved named request whose raw name equals the requester's
+        full name is self-referential, even though its id is a truthy negative."""
+        base_request.metadata = {
+            "raw_target_name": "Emma Johnson",
+            "requester_full_name": "Emma Johnson",
+        }
+
+        result = rule.validate(base_request)
+
+        assert not result.is_valid
+        assert result.metadata["self_ref_type"] == "full_name_match"
+
+    def test_negative_hash_unresolvable_first_name_flagged(self, rule, base_request):
+        """A first-name-only unresolved request matching the requester's first
+        name with no session peers is flagged unresolvable_first_name."""
+        base_request.metadata = {
+            "raw_target_name": "Emma",
+            "requester_first_name": "Emma",
+            "requester_full_name": "Emma Johnson",
+            "session_peers_with_same_first_name": 0,
+        }
+
+        result = rule.validate(base_request)
+
+        assert not result.is_valid
+        assert result.metadata["self_ref_type"] == "unresolvable_first_name"
+
+    def test_negative_hash_different_names_passes(self, rule, base_request):
+        """An unresolved named request targeting a different person stays valid."""
+        base_request.metadata = {
+            "raw_target_name": "Liam Garcia",
+            "requester_full_name": "Emma Johnson",
+        }
+
+        result = rule.validate(base_request)
+
+        assert result.is_valid
+        assert len(result.errors) == 0
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/sync/bunk_request_processor/validation/rules/test_session_compatibility.py
+++ b/tests/unit/sync/bunk_request_processor/validation/rules/test_session_compatibility.py
@@ -121,6 +121,19 @@ class TestSessionCompatibilityRule:
         assert len(result.errors) == 0
         mock_attendee_repo.get_by_person_and_year.assert_not_called()
 
+    def test_negative_hash_unresolved_skips_lookup(self, rule, base_request, mock_attendee_repo):
+        """#1683: a named-but-unresolved request carries a truthy negative-hash
+        ``requested_cm_id`` that cannot exist in ``attendees``. It must be treated
+        like an unresolved target and skip the session/attendee lookup entirely,
+        not query for an id that can never match."""
+        base_request.requested_cm_id = -1_000_123  # negative-hash unresolved id
+
+        result = rule.validate(base_request)
+
+        assert result.is_valid
+        assert len(result.errors) == 0
+        mock_attendee_repo.get_by_person_and_year.assert_not_called()
+
     def test_missing_requester_session_warning(self, rule, base_request, mock_attendee_repo):
         """Test warning when requester session not found"""
         mock_attendee_repo.get_by_person_and_year.side_effect = [


### PR DESCRIPTION
Closes #1683.

## Problem

Two validation rules gated on a falsy `requested_cm_id` (`if not request.requested_cm_id`). Only `AGE_PREFERENCE` requests get `None`; named-but-unresolved requests get a **truthy negative-hash** id from `generate_unresolved_person_id` (range `-1,000,000` .. `-1,000,000,000`). Those gates silently excluded the negative-id case.

- **`self_reference.py`** — the raw-name self-reference check was **unreachable in production**. Its two branches are mutually exclusive: `AGE_PREFERENCE` satisfies `not requested_cm_id` but has no `raw_target_name`; an unresolved named request has `raw_target_name` but a truthy negative id. A parent who writes their own child's unresolvable name was never flagged.
- **`session_compatibility.py`** — unresolved requests still proceeded to the attendee/session lookup with an id that cannot exist in `attendees`.

Not a regression — surfaced during the #1682 review (`is_placeholder` removal, which was behavior-preserving). The old `is_placeholder` flag had the same blind spot.

## Fix

Both gates now treat `id is None or id < 0` as unresolved. This matches the **established negative-hash invariant already enforced** elsewhere in the pipeline — `target_enrollment_reconcile.py:93` (`if not requestee or requestee < 0`) and `target_decline.py` (per the `target_decline_negative_id_backfill.py` heal script). `generate_unresolved_person_id` is the sole producer of negative ids, and it always returns a value `≤ -1,000,000`.

## Tests (TDD)

Written failing first, then implemented:

- `TestSelfReferenceUnresolvedNegativeId` — full-name match + unresolvable-first-name flagged with a production-faithful negative id; different-name sanity case stays valid.
- `test_negative_hash_unresolved_skips_lookup` — a negative-id request skips the attendee lookup entirely.
- The orchestrator `test_first_name_only_ambiguity_kept_for_review` fixture now uses `generate_unresolved_person_id("Emma")` instead of the production-impossible `None` (acceptance criterion: production-faithful fixtures).

Full bunk-request-processor suite: 1958 passed. Pre-push: 5407 tests + ruff/mypy/tsc/eslint all green. Fictional names only.

## Acceptance criteria

- [x] Unresolved named requests that match the requester are flagged self-referential.
- [x] Unresolved (negative-hash) requests skip the session-compatibility attendee lookup.
- [x] Test fixtures use negative-hash ids (not `None`) for unresolved named `BUNK_WITH` requests.
- [x] Fictional names only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation accuracy for pending requests by implementing stricter checks to identify unresolved request scenarios.
  * Enhanced self-reference detection and session compatibility validation to more accurately distinguish between resolved and unresolved targets.

* **Tests**
  * Added comprehensive test coverage for unresolved request handling in validation rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->