### PR TITLE
fix(frontend): post-upload banner width — compact done-state chip (#1686)

### DIFF
--- a/frontend/src/components/CsvPipelineIndicator.test.tsx
+++ b/frontend/src/components/CsvPipelineIndicator.test.tsx
@@ -80,7 +80,7 @@ describe('CsvPipelineIndicator', () => {
     expect(screen.getByText(/Matching CSV requests/i)).toBeInTheDocument()
   })
 
-  it('renders done state with mapped counts', () => {
+  it('renders done state with compact chip summary', () => {
     setData({
       phase: 'done',
       runId: 'r1',
@@ -88,9 +88,11 @@ describe('CsvPipelineIndicator', () => {
       counts: { total: 28, autoMatched: 22, needReview: 6 },
     })
     render(<CsvPipelineIndicator />)
-    expect(
-      screen.getByText(/Done .*: 28 new or updated requests, 22 auto-matched, 6 need review/)
-    ).toBeInTheDocument()
+    expect(screen.getByText(/Import complete/i)).toBeInTheDocument()
+    expect(screen.queryByText(/new or updated requests,/i)).not.toBeInTheDocument()
+    const chip = screen.getByText(/Import complete/i)
+    expect(chip).toHaveTextContent(/28 new/i)
+    expect(chip).toHaveTextContent(/6 review/i)
   })
 
   it('omits "need review" from button label when needReview is zero', () => {
@@ -101,10 +103,8 @@ describe('CsvPipelineIndicator', () => {
       counts: { total: 22, autoMatched: 22, needReview: 0 },
     })
     render(<CsvPipelineIndicator />)
-    expect(
-      screen.getByText(/Done .*: 22 new or updated requests, 22 auto-matched$/)
-    ).toBeInTheDocument()
-    expect(screen.queryByText(/need review/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/Import complete/i)).toBeInTheDocument()
+    expect(screen.queryByText(/review/i)).not.toBeInTheDocument()
   })
 
   it('omits "need review" from completion toast when needReview is zero', () => {
@@ -192,7 +192,7 @@ describe('CsvPipelineIndicator', () => {
       counts: { total: 1, autoMatched: 1, needReview: 0 },
     })
     render(<CsvPipelineIndicator />)
-    expect(screen.getByText(/Done .*: 1 new or updated request/)).toBeInTheDocument()
+    expect(screen.getByText(/Import complete/i)).toBeInTheDocument()
   })
 
   it('clicking × stores current runId in dismissed-key and hides indicator', () => {

--- a/frontend/src/components/CsvPipelineIndicator.tsx
+++ b/frontend/src/components/CsvPipelineIndicator.tsx
@@ -77,12 +77,8 @@ export default function CsvPipelineIndicator() {
           <>
             <CheckCircle className="h-3 w-3 text-green-600" aria-hidden="true" />
             <span>
-              Done {formatTimestamp(data.finishedAt)}: {data.counts.total} new or updated{' '}
-              {data.counts.total === 1 ? 'request' : 'requests'}, {data.counts.autoMatched}{' '}
-              auto-matched
-              {data.counts.needReview > 0
-                ? `, ${data.counts.needReview} need${data.counts.needReview === 1 ? 's' : ''} review`
-                : ''}
+              Import complete · {data.counts.total} new
+              {data.counts.needReview > 0 ? <> · ⚠ {data.counts.needReview} review</> : null}
             </span>
           </>
         )}


### PR DESCRIPTION
## What

Collapses the CSV pipeline **done-state** banner (`CsvPipelineIndicator`) from a long `whitespace-nowrap` sentence to a compact chip:

`✓ Import complete · {total} new[ · ⚠ {needReview} review]`

The full breakdown (total / auto-matched / needs-review / timestamp) is unchanged in the existing click popover, so no information is lost. The `· ⚠ N review` segment is omitted when `needReview === 0`.

## Why

Reported by primary staff (kindred-feedback#58): at 1442×837 the long done-state text overflowed the top nav and clipped on the left edge. This is **part 1 of #1686** — the smallest, fully independent slice. The per-session "what's new" summary (chip + modal on the bunks page) follows in two subsequent PRs.

## Testing

- Added/updated Vitest cases in `CsvPipelineIndicator.test.tsx`: compact form renders (not the old sentence), and the review segment is omitted at `needReview=0`. Count assertions bound to the chip element.
- 16/16 tests pass; `tsc --noEmit` clean; eslint clean.
- Pre-push gates all green (mypy, full mockable pytest 5366 passed, type-check, lint).

Part 1 of #1686.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improved UI**
  * CSV import completion message now displays "Import complete" with item counts for clearer feedback
  * Simplified completion message by removing timestamp and detailed count details

* **Tests**
  * Updated tests to verify the new completion message format

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->