### PR TITLE
feat(metrics): count summer-window SCIT/TLI years toward Summers at Camp (#1599)

### DIFF
--- a/api/utils/session_metrics.py
+++ b/api/utils/session_metrics.py
@@ -57,9 +57,9 @@ SESSION_LENGTH_ORDER: dict[str, int] = {
     "unknown": 4,
 }
 
-# Session types that count toward "summers at camp" / "years as camper"
-# Used for metrics calculations: "Summers at Camp", "First Summer Year".
-# Quest counts toward camper history to match CampMinder's years_at_camp.
+# Non-teen summer types that count UNCONDITIONALLY toward "summers at camp" /
+# "years as camper". Used for the computed "Summers at Camp" / "First Summer Year"
+# metrics. Quest is included to match CampMinder's years_at_camp.
 #
 # Includes:
 # - main: Standard sessions (Session 1, 2, 3, 4)
@@ -68,9 +68,11 @@ SESSION_LENGTH_ORDER: dict[str, int] = {
 # - quest: Quest adventure programs (child-oriented, counts toward years at camp)
 #
 # Excludes:
-# - family: Family camp (adult-focused)
-# - scit: SCIT teen program (different program)
-# - tli: Teen Leadership Initiative (different program)
+# - family: Family camp (adult-focused) — never counts
+# NOTE: SCIT/TLI are intentionally NOT in this tuple, but they DO count toward
+# "summers at camp" when within the summer window — admitted separately (with a
+# window gate the tuple can't express) in compute_summer_metrics(), per #1599.
+# CampMinder's years_at_camp counts teen years, and this metric mirrors it.
 SUMMER_PROGRAM_SESSION_TYPES = ("main", "embedded", "ag", "quest")
 
 # Summer teen programs: SCIT (CIT+SIT) and TLI. NOT a default-included cohort —
@@ -378,6 +380,21 @@ def resolve_duration_sessions(sessions: dict[int, Any], duration: str | None) ->
     return matching
 
 
+def _summer_record_year(record: Any, session: Any | None) -> int | None:
+    """Year a record belongs to: the record's ``year`` if set, else the session's start year."""
+    record_year = getattr(record, "year", None)
+    if record_year:
+        return int(record_year)
+    if session is not None:
+        start_date = getattr(session, "start_date", None)
+        if start_date:
+            try:
+                return int(str(start_date).split("-")[0])
+            except ValueError, IndexError:
+                return None
+    return None
+
+
 def compute_summer_metrics(
     enrollment_history: list[Any],
     person_ids: set[int],
@@ -385,6 +402,16 @@ def compute_summer_metrics(
     """Compute summer enrollment metrics from history.
 
     Shared logic used by both registration and retention services.
+
+    Counts the distinct years a person had a summer enrollment. Non-teen summer
+    types (``SUMMER_PROGRAM_SESSION_TYPES``) always count; SCIT/TLI count too,
+    but only when the session falls inside that year's summer window (#1599) — so
+    off-season teen sessions (fall Family-Camp CIT, Feb L.A. Trip) are excluded.
+    This keeps the computed metric aligned with CampMinder's ``years_at_camp``,
+    which counts teen years. Each year's window is derived from that year's
+    ``main`` sessions present in the history (always present in production — every
+    summer that runs teen programs also runs main camp); if a year's window can't
+    be derived, its teen sessions are conservatively excluded.
 
     Args:
         enrollment_history: List of attendee records with session expansion.
@@ -395,54 +422,59 @@ def compute_summer_metrics(
         - summer_years_by_person: person_id -> count of distinct summer years
         - first_year_by_person: person_id -> first summer enrollment year
     """
-    # Group records by person_id
+    # Pass 1: derive each year's summer window from that year's main sessions.
+    main_sessions_by_year: dict[int, dict[int, Any]] = {}
+    for record in enrollment_history:
+        session = get_session_from_expand(record)
+        if not session or getattr(session, "session_type", None) != "main":
+            continue
+        year = _summer_record_year(record, session)
+        if year is None:
+            continue
+        cm_id = getattr(session, "cm_id", None)
+        key = int(cm_id) if cm_id is not None else id(session)
+        main_sessions_by_year.setdefault(year, {})[key] = session
+    summer_window_by_year: dict[int, tuple[str, str] | None] = {
+        year: get_summer_window(sessions) for year, sessions in main_sessions_by_year.items()
+    }
+
+    # Pass 2: group qualifying records by person. Non-teen summer types count
+    # unconditionally; teen types (SCIT/TLI) are summer-window-gated.
     by_person: dict[int, list[Any]] = {}
     for record in enrollment_history:
         pid = getattr(record, "person_id", None)
         if pid is None or pid not in person_ids:
             continue
 
-        # Filter to summer session types
         session = get_session_from_expand(record)
         if not session:
             continue
 
         session_type = getattr(session, "session_type", None)
-        if session_type not in SUMMER_PROGRAM_SESSION_TYPES:
+        if session_type in SUMMER_PROGRAM_SESSION_TYPES:
+            pass
+        elif session_type in SUMMER_TEEN_TYPES:
+            year = _summer_record_year(record, session)
+            window = summer_window_by_year.get(year) if year is not None else None
+            if not is_summer_teen_session(session, window):
+                continue
+        else:
             continue
 
-        if pid not in by_person:
-            by_person[pid] = []
-        by_person[pid].append(record)
+        by_person.setdefault(pid, []).append(record)
 
-    # Compute aggregations
+    # Aggregate: count distinct years per person.
     summer_years_by_person: dict[int, int] = {}
     first_year_by_person: dict[int, int] = {}
 
     for pid, records in by_person.items():
-        # Summer years: count distinct years from session start_date or record year
         years: set[int] = set()
         for r in records:
-            # Try to get year from record first
-            record_year = getattr(r, "year", None)
-            if record_year:
-                years.add(int(record_year))
-                continue
-
-            # Fall back to session start_date
-            session = get_session_from_expand(r)
-            if session:
-                start_date = getattr(session, "start_date", None)
-                if start_date:
-                    try:
-                        year_str = str(start_date).split("-")[0]
-                        years.add(int(year_str))
-                    except ValueError, IndexError:
-                        pass
+            year = _summer_record_year(r, get_session_from_expand(r))
+            if year is not None:
+                years.add(year)
 
         summer_years_by_person[pid] = len(years)
-
-        # First summer year: min year
         if years:
             first_year_by_person[pid] = min(years)
 

--- a/tests/unit/api/test_session_metrics.py
+++ b/tests/unit/api/test_session_metrics.py
@@ -123,7 +123,9 @@ class TestSummerProgramSessionTypesConstant:
         assert "training" not in SUMMER_PROGRAM_SESSION_TYPES
 
     def test_constant_excludes_tli_sessions(self) -> None:
-        """TLI (Teen Leadership Initiative) sessions should NOT be included."""
+        """TLI is NOT in this unconditional tuple. It still counts toward summers
+        at camp via the separate summer-window gate in compute_summer_metrics
+        (#1599) — see TestTeenSummersAtCamp."""
         from api.utils.session_metrics import SUMMER_PROGRAM_SESSION_TYPES
 
         assert "tli" not in SUMMER_PROGRAM_SESSION_TYPES
@@ -1098,7 +1100,9 @@ def test_display_types_include_teens():
 
 
 def test_summer_program_types_still_exclude_teens():
-    """Per #1599, 'summers at camp' stays main+quest — teens NOT added here."""
+    """Teens stay OUT of the unconditional tuple — they need the summer-window gate,
+    which tuple membership can't express. They still count toward summers at camp
+    via that gate in compute_summer_metrics (#1599); see TestTeenSummersAtCamp."""
     assert {"scit", "tli"}.isdisjoint(SUMMER_PROGRAM_SESSION_TYPES)
 
 
@@ -1118,3 +1122,175 @@ def test_resolver_still_window_gates_after_display_change():
     }
     assert resolve_cohort_session_ids(sessions, None) == {10, 16, 12}
     assert resolve_cohort_session_ids(sessions, ["scit", "tli"]) == {12}
+
+
+# ============================================================================
+# #1599: summer-window SCIT/TLI years count toward Summers at Camp
+# ============================================================================
+
+
+class TestTeenSummersAtCamp:
+    """#1599: summer-window SCIT/TLI years count toward computed Summers at Camp.
+
+    CampMinder's authoritative ``years_at_camp`` was empirically confirmed to
+    count teen (SCIT/TLI) years, and the computed metric is the corrected
+    stand-in for it — so summer-window teen years must count, otherwise a teen
+    camper is undercounted in the very chart meant to fix bad tenure data.
+
+    Off-season teen sessions (fall Family-Camp CIT, Feb L.A. Trip) do NOT count:
+    "a summer at camp" means physically at the site in summer. They are excluded
+    via the summer-window gate (``is_summer_teen_session``).
+
+    Each year's summer window is derived from that year's ``main`` sessions
+    present in the history. In production this is always available — every
+    summer that runs teen programs also runs main camp.
+    """
+
+    def test_summer_scit_year_counts(self) -> None:
+        """A summer-window SCIT year counts as a summer at camp."""
+        from api.utils.session_metrics import compute_summer_metrics
+
+        main_2024 = create_mock_session(1, "Session 1", 2024, "main", "2024-06-15", "2024-07-05")
+        main_2025 = create_mock_session(2, "Session 1", 2025, "main", "2025-06-15", "2025-07-05")  # window anchor
+        scit_2025 = create_mock_session(3, "SCIT", 2025, "scit", "2025-06-20", "2025-06-27")  # summer teen
+
+        history = [
+            create_mock_attendee(201, 1, session=main_2024, year=2024),
+            create_mock_attendee(201, 3, session=scit_2025, year=2025),
+            create_mock_attendee(999, 2, session=main_2025, year=2025),  # anchor defines 2025 summer window
+        ]
+        summer_years, first_year = compute_summer_metrics(history, {201})
+
+        assert summer_years[201] == 2  # 2024 main + 2025 summer SCIT
+        assert first_year[201] == 2024
+
+    def test_summer_tli_year_counts(self) -> None:
+        """A summer-window TLI year counts as a summer at camp."""
+        from api.utils.session_metrics import compute_summer_metrics
+
+        main_2024 = create_mock_session(1, "Session 1", 2024, "main", "2024-06-15", "2024-07-05")
+        # 2025 summer window spans Sessions 1-4 (Jun 15 - Aug 10), as in production
+        main_2025_early = create_mock_session(2, "Session 1", 2025, "main", "2025-06-15", "2025-07-05")
+        main_2025_late = create_mock_session(5, "Session 4", 2025, "main", "2025-07-20", "2025-08-10")
+        tli_2025 = create_mock_session(3, "TLI", 2025, "tli", "2025-07-10", "2025-07-20")  # mid-summer teen
+
+        history = [
+            create_mock_attendee(202, 1, session=main_2024, year=2024),
+            create_mock_attendee(202, 3, session=tli_2025, year=2025),
+            create_mock_attendee(999, 2, session=main_2025_early, year=2025),  # window anchors
+            create_mock_attendee(999, 5, session=main_2025_late, year=2025),
+        ]
+        summer_years, first_year = compute_summer_metrics(history, {202})
+
+        assert summer_years[202] == 2
+        assert first_year[202] == 2024
+
+    def test_offseason_scit_only_year_excluded(self) -> None:
+        """A fall Family-Camp CIT (SCIT) with no summer presence does NOT count."""
+        from api.utils.session_metrics import compute_summer_metrics
+
+        main_2024 = create_mock_session(1, "Session 1", 2024, "main", "2024-06-15", "2024-07-05")
+        main_2025 = create_mock_session(2, "Session 1", 2025, "main", "2025-06-15", "2025-07-05")  # window anchor
+        scit_fall = create_mock_session(3, "Family Camp CIT", 2025, "scit", "2025-09-12", "2025-09-15")  # off-season
+
+        history = [
+            create_mock_attendee(301, 1, session=main_2024, year=2024),
+            create_mock_attendee(301, 3, session=scit_fall, year=2025),
+            create_mock_attendee(999, 2, session=main_2025, year=2025),  # anchor
+        ]
+        summer_years, first_year = compute_summer_metrics(history, {301})
+
+        assert summer_years[301] == 1  # only 2024; fall SCIT outside summer window
+        assert first_year[301] == 2024
+
+    def test_offseason_tli_la_trip_excluded(self) -> None:
+        """A Feb Teen L.A. Trip (TLI) with no summer presence does NOT count."""
+        from api.utils.session_metrics import compute_summer_metrics
+
+        main_2024 = create_mock_session(1, "Session 1", 2024, "main", "2024-06-15", "2024-07-05")
+        main_2025 = create_mock_session(2, "Session 1", 2025, "main", "2025-06-15", "2025-07-05")  # window anchor
+        tli_feb = create_mock_session(3, "Teen L.A. Trip", 2025, "tli", "2025-02-15", "2025-02-18")  # off-season
+
+        history = [
+            create_mock_attendee(302, 1, session=main_2024, year=2024),
+            create_mock_attendee(302, 3, session=tli_feb, year=2025),
+            create_mock_attendee(999, 2, session=main_2025, year=2025),  # anchor
+        ]
+        summer_years, first_year = compute_summer_metrics(history, {302})
+
+        assert summer_years[302] == 1  # only 2024; Feb trip outside summer window
+        assert first_year[302] == 2024
+
+    def test_first_summer_year_unaffected_by_teen(self) -> None:
+        """Teens age up, so their earliest year is always a camper year — first_summer_year unchanged."""
+        from api.utils.session_metrics import compute_summer_metrics
+
+        main_2022 = create_mock_session(1, "Session 1", 2022, "main", "2022-06-15", "2022-07-05")
+        main_2023 = create_mock_session(2, "Session 1", 2023, "main", "2023-06-15", "2023-07-05")
+        main_2025 = create_mock_session(3, "Session 1", 2025, "main", "2025-06-15", "2025-07-05")  # window anchor
+        scit_2025 = create_mock_session(4, "SCIT", 2025, "scit", "2025-06-20", "2025-06-27")
+
+        history = [
+            create_mock_attendee(303, 1, session=main_2022, year=2022),
+            create_mock_attendee(303, 2, session=main_2023, year=2023),
+            create_mock_attendee(303, 4, session=scit_2025, year=2025),
+            create_mock_attendee(999, 3, session=main_2025, year=2025),  # anchor
+        ]
+        summer_years, first_year = compute_summer_metrics(history, {303})
+
+        assert summer_years[303] == 3  # 2022, 2023, 2025
+        assert first_year[303] == 2022  # teen year does not move the floor
+
+    def test_teen_only_camper_counts_summer_window(self) -> None:
+        """A camper whose only enrollments are summer-window SCIT still accrues summers."""
+        from api.utils.session_metrics import compute_summer_metrics
+
+        main_2024 = create_mock_session(1, "Session 1", 2024, "main", "2024-06-15", "2024-07-05")  # anchor
+        main_2025 = create_mock_session(2, "Session 1", 2025, "main", "2025-06-15", "2025-07-05")  # anchor
+        scit_2024 = create_mock_session(3, "SCIT", 2024, "scit", "2024-06-20", "2024-06-27")
+        scit_2025 = create_mock_session(4, "SCIT", 2025, "scit", "2025-06-20", "2025-06-27")
+
+        history = [
+            create_mock_attendee(304, 3, session=scit_2024, year=2024),
+            create_mock_attendee(304, 4, session=scit_2025, year=2025),
+            create_mock_attendee(999, 1, session=main_2024, year=2024),  # anchors
+            create_mock_attendee(999, 2, session=main_2025, year=2025),
+        ]
+        summer_years, first_year = compute_summer_metrics(history, {304})
+
+        assert summer_years[304] == 2
+        assert first_year[304] == 2024
+
+    def test_concurrent_main_and_summer_scit_count_once(self) -> None:
+        """Main + summer SCIT in the same year is still one summer."""
+        from api.utils.session_metrics import compute_summer_metrics
+
+        main_2025 = create_mock_session(1, "Session 1", 2025, "main", "2025-06-15", "2025-07-05")
+        scit_2025 = create_mock_session(2, "SCIT", 2025, "scit", "2025-06-20", "2025-06-27")
+
+        history = [
+            create_mock_attendee(305, 1, session=main_2025, year=2025),
+            create_mock_attendee(305, 2, session=scit_2025, year=2025),
+        ]
+        summer_years, first_year = compute_summer_metrics(history, {305})
+
+        assert summer_years[305] == 1
+        assert first_year[305] == 2025
+
+    def test_teen_year_without_main_anchor_excluded(self) -> None:
+        """Conservative fallback: if a year's summer window can't be derived (no main
+        sessions in the history that year), teen sessions are not counted. In production
+        the main anchor is always present; this guards the gate's None-window branch."""
+        from api.utils.session_metrics import compute_summer_metrics
+
+        main_2024 = create_mock_session(1, "Session 1", 2024, "main", "2024-06-15", "2024-07-05")
+        scit_2025 = create_mock_session(2, "SCIT", 2025, "scit", "2025-06-20", "2025-06-27")  # no main 2025 anchor
+
+        history = [
+            create_mock_attendee(306, 1, session=main_2024, year=2024),
+            create_mock_attendee(306, 2, session=scit_2025, year=2025),
+        ]
+        summer_years, first_year = compute_summer_metrics(history, {306})
+
+        assert summer_years[306] == 1  # 2025 SCIT unverifiable as summer -> excluded
+        assert first_year[306] == 2024


### PR DESCRIPTION
Resolves #1599.

## Decision (data-driven)
An empirical spot-check of `camper_history` (36,496 rows, 2017–2026) confirmed that CampMinder's authoritative `years_at_camp` **counts teen (SCIT/TLI) years and excludes family/adult/b'mitzvah**:
- 147/177 full-tenure teen campers had `years_at_camp` == summer∪teen-year union; **0** matched summer-only.
- Of the 27 who also had a family-only year (the disambiguator), 25 counted teen but **excluded** the family year.

Our computed "Summers at Camp" metric is the corrected stand-in for `years_at_camp` (same chart slot, falls back to it when absent — the schema docstrings call `years_at_camp` "potentially incorrect"). But it was **dropping** teen years, so a SCIT/TLI camper was undercounted in the very chart meant to fix bad tenure data.

## Change
`compute_summer_metrics` now counts SCIT/TLI years, **summer-window-gated** via the existing `get_summer_window`/`is_summer_teen_session` helpers:
- A teen session counts only when it overlaps that year's main-camp window — so off-season teen programs (fall Family-Camp CIT, Feb L.A. Trip) are **excluded**. "A summer at camp" = physically at the site in summer.
- Each year's window is derived from that year's `main` sessions present in the history (always present in production — every summer that runs teen programs runs main camp). If a year's window can't be derived, teen sessions are conservatively excluded.
- Auto-applies to all historical years on read — **no backfill/migration**.

`SUMMER_PROGRAM_SESSION_TYPES` stays the 4 unconditional non-teen types (a tuple can't express a window gate); teens are admitted on a separate gated path, mirroring `resolve_cohort_session_ids`. `first_summer_year` is unaffected — teens age up, so their earliest year is always a camper year.

## Tests (TDD)
New `TestTeenSummersAtCamp` (8 cases): summer SCIT/TLI count; off-season SCIT (fall CIT) and TLI (Feb trip) excluded; `first_summer_year` floor unchanged; teen-only camper counted; concurrent main+SCIT dedups to one year; no-anchor conservative exclusion. Updated two constant-guard test docstrings (assertions unchanged — teens stay out of the *tuple*, the reason changed).

Verification: full mockable unit suite **5317 passed**; ruff + mypy clean. (Note: `tests/unit/api/` metrics suites are not run by CI — verified locally.)

Consumers reviewed/unaffected: `registration_service`, `retention_service`, `retention_trends_service`, `drilldown_service`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of summer session counting for teen programs, ensuring special program types (SCIT/TLI) are correctly attributed to the appropriate summer window based on their dates.

* **Tests**
  * Added comprehensive test coverage for teen summer session counting across various scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1690?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->