### PR TITLE
feat(sync): per-session upload breakdown + trigger tag (#1686)

### DIFF
--- a/api/routers/internal.py
+++ b/api/routers/internal.py
@@ -18,6 +18,7 @@ from bunking.geo_normalizer.normalizer import normalize_values
 from bunking.logging_config import TRACE, get_logger
 from bunking.sync.bunk_request_processor.data.repositories import SessionRepository
 from bunking.sync.bunk_request_processor.process_requests import (
+    TriggerType,
     load_configuration,
     process_bunk_requests,
 )
@@ -77,7 +78,7 @@ class ProcessRequestsRequest(BaseModel):
     debug: bool = False
     trace: bool = False
     collect_traces: bool = False
-    trigger: str = "manual"
+    trigger: TriggerType = "manual"
 
 
 class ProcessRequestsResponse(BaseModel):
@@ -103,7 +104,7 @@ async def run_process_requests(
     debug: bool,
     trace: bool,
     collect_traces: bool = False,
-    trigger: str = "manual",
+    trigger: TriggerType = "manual",
 ) -> dict[str, Any]:
     """Run the bunk request processor. Extracted for testability."""
     # Configure logging level (same as process_requests.py CLI)

--- a/api/routers/internal.py
+++ b/api/routers/internal.py
@@ -77,6 +77,7 @@ class ProcessRequestsRequest(BaseModel):
     debug: bool = False
     trace: bool = False
     collect_traces: bool = False
+    trigger: str = "manual"
 
 
 class ProcessRequestsResponse(BaseModel):
@@ -102,6 +103,7 @@ async def run_process_requests(
     debug: bool,
     trace: bool,
     collect_traces: bool = False,
+    trigger: str = "manual",
 ) -> dict[str, Any]:
     """Run the bunk request processor. Extracted for testability."""
     # Configure logging level (same as process_requests.py CLI)
@@ -140,6 +142,7 @@ async def run_process_requests(
         source_fields=validated_fields,
         debug=debug,
         collect_traces=collect_traces,
+        trigger=trigger,
     )
 
 
@@ -166,6 +169,7 @@ async def process_requests(body: ProcessRequestsRequest) -> JSONResponse:
             debug=body.debug,
             trace=body.trace,
             collect_traces=body.collect_traces,
+            trigger=body.trigger,
         )
 
         stats = result.get("statistics", {})

--- a/bunking/sync/bunk_request_processor/debug/retention.py
+++ b/bunking/sync/bunk_request_processor/debug/retention.py
@@ -27,12 +27,24 @@ def cleanup_old_runs(pb: Any) -> int:
     cutoff = datetime.now(UTC) - timedelta(days=MAX_AGE_DAYS)
     cutoff_iso = cutoff.strftime("%Y-%m-%d %H:%M:%S")
 
+    # Determine the single newest upload run — exempt from both time- and count-based
+    # deletion so the per-session "what's new" summary always has a run to read.
+    # Single-row fetch via get_list (page 1, per_page 1); get_full_list would
+    # paginate the entire trigger='upload' history every cleanup.
+    upload_page = pb.collection("debug_pipeline_runs").get_list(
+        1, 1, query_params={"filter": "trigger = 'upload'", "sort": "-created"}
+    )
+    newest_upload_id: str | None = upload_page.items[0].id if upload_page.items else None
+
     to_delete: list[Any] = []
 
     # Time-based: fetch unpinned runs older than cutoff directly via PB filter
     expired_runs = pb.collection("debug_pipeline_runs").get_full_list(
         query_params={"filter": f'pinned = false && created < "{cutoff_iso}"', "sort": "-created"}
     )
+    # Exempt the newest upload run from time-based deletion
+    if newest_upload_id is not None:
+        expired_runs = [r for r in expired_runs if r.id != newest_upload_id]
     to_delete.extend(expired_runs)
     expired_ids = {r.id for r in expired_runs}
 
@@ -50,6 +62,9 @@ def cleanup_old_runs(pb: Any) -> int:
     if len(remaining_unpinned) > MAX_RUNS:
         # remaining_unpinned is sorted -created, so tail is oldest
         excess = remaining_unpinned[MAX_RUNS:]
+        # Exempt the newest upload run from count-based deletion
+        if newest_upload_id is not None:
+            excess = [r for r in excess if r.id != newest_upload_id]
         to_delete.extend(excess)
 
     # Deduplicate

--- a/bunking/sync/bunk_request_processor/debug/retention.py
+++ b/bunking/sync/bunk_request_processor/debug/retention.py
@@ -4,6 +4,9 @@ Dual policy (whichever triggers first):
 - Time-based: delete runs older than MAX_AGE_DAYS
 - Count-based: delete oldest runs when total exceeds MAX_RUNS
 - Pinned runs exempt from both
+- The single newest trigger='upload' run is exempt from both, so the per-session
+  "what's new" summary always has a run to read. Because this exemption is applied
+  without re-trimming, up to MAX_RUNS + 1 unpinned runs may survive a cleanup cycle.
 - Atomic: deleting a run also deletes its traces and summaries
   (summaries cascade-delete via trace relation, but traces need explicit deletion)
 """

--- a/bunking/sync/bunk_request_processor/debug/trace_collector.py
+++ b/bunking/sync/bunk_request_processor/debug/trace_collector.py
@@ -33,9 +33,10 @@ logger = get_logger(__name__)
 class TraceCollector:
     """Collects per-request trace data during pipeline execution."""
 
-    def __init__(self, run_id: str = "", enabled: bool = True) -> None:
+    def __init__(self, run_id: str = "", enabled: bool = True, trigger: str = "manual") -> None:
         self.run_id = run_id
         self.enabled = enabled
+        self.trigger = trigger
         self._traces: dict[str, TraceData] = {}
         self._trace_metadata: dict[str, dict[str, Any]] = {}
 
@@ -229,6 +230,8 @@ class TraceCollector:
                     "force": run_meta.get("force", False),
                     "trace_count": len(self._traces),
                     "status_breakdown": status_breakdown,
+                    "trigger": self.trigger,
+                    "session_breakdown": self._compute_session_breakdown(),
                     "pinned": False,
                 }
             )

--- a/bunking/sync/bunk_request_processor/debug/trace_collector.py
+++ b/bunking/sync/bunk_request_processor/debug/trace_collector.py
@@ -327,7 +327,7 @@ class TraceCollector:
             return "skipped"
         trace_status = "resolved"
         for br in trace_data.disposition.final_bunk_requests:
-            status = br.status.lower()
+            status = (br.status or "").lower()
             if status == "pending":
                 return "pending"  # highest priority — short-circuit
             elif status == "declined" and trace_status != "pending":

--- a/bunking/sync/bunk_request_processor/debug/trace_collector.py
+++ b/bunking/sync/bunk_request_processor/debug/trace_collector.py
@@ -314,27 +314,48 @@ class TraceCollector:
 
         return str(run_record.id)
 
+    def _resolve_trace_status(self, trace_data: TraceData) -> str:
+        """Return the most significant status for a single trace.
+
+        Priority order (highest to lowest): pending > declined > deduped > resolved.
+        A trace with no final bunk requests is considered 'skipped'.
+        """
+        if not trace_data.disposition.final_bunk_requests:
+            return "skipped"
+        trace_status = "resolved"
+        for br in trace_data.disposition.final_bunk_requests:
+            status = br.status.lower()
+            if status == "pending":
+                return "pending"  # highest priority — short-circuit
+            elif status == "declined" and trace_status != "pending":
+                trace_status = "declined"
+            elif status == "deduped" and trace_status not in ("pending", "declined"):
+                trace_status = "deduped"
+        return trace_status
+
     def _compute_status_breakdown(self) -> dict[str, int]:
         breakdown: dict[str, int] = {"resolved": 0, "pending": 0, "declined": 0, "skipped": 0, "deduped": 0}
         for trace_data in self._traces.values():
-            if not trace_data.disposition.final_bunk_requests:
-                breakdown["skipped"] += 1
-                continue
-            # Determine the most significant status across all requests in this trace.
-            # Priority: pending > declined > deduped > resolved (pending is most actionable).
-            trace_status = "resolved"
-            for br in trace_data.disposition.final_bunk_requests:
-                status = br.status.lower()
-                if status == "pending":
-                    trace_status = "pending"
-                    break  # pending is highest priority, no need to check further
-                elif status == "declined" and trace_status != "pending":
-                    trace_status = "declined"
-                elif status == "deduped" and trace_status not in ("pending", "declined"):
-                    trace_status = "deduped"
+            trace_status = self._resolve_trace_status(trace_data)
             if trace_status in breakdown:
                 breakdown[trace_status] += 1
         return breakdown
+
+    def _compute_session_breakdown(self) -> dict[str, dict[str, int]]:
+        """Return per-session status counts, keyed by str(session_cm_id).
+
+        Each value has the same shape as _compute_status_breakdown():
+        {"resolved": n, "pending": n, "declined": n, "skipped": n, "deduped": n}.
+        """
+        result: dict[str, dict[str, int]] = {}
+        for key, trace_data in self._traces.items():
+            session_cm_id = str(self._trace_metadata.get(key, {}).get("session_cm_id", 0))
+            if session_cm_id not in result:
+                result[session_cm_id] = {"resolved": 0, "pending": 0, "declined": 0, "skipped": 0, "deduped": 0}
+            trace_status = self._resolve_trace_status(trace_data)
+            if trace_status in result[session_cm_id]:
+                result[session_cm_id][trace_status] += 1
+        return result
 
 
 class NoOpTraceCollector(TraceCollector):

--- a/bunking/sync/bunk_request_processor/process_requests.py
+++ b/bunking/sync/bunk_request_processor/process_requests.py
@@ -75,6 +75,7 @@ async def process_bunk_requests(
     force: bool = False,
     debug: bool = False,
     collect_traces: bool = False,
+    trigger: str = "manual",
 ) -> dict[str, Any]:
     """Process bunk requests from a data source.
 
@@ -89,6 +90,7 @@ async def process_bunk_requests(
         force: If True, clear processed flags before fetching (enables reprocessing)
         debug: If True, enable verbose AI parse logging
         collect_traces: If True, enable pipeline trace collection for debugging
+        trigger: What initiated this processing run (e.g. 'manual', 'upload', 'scheduled')
 
     Returns:
         Processing results
@@ -97,7 +99,7 @@ async def process_bunk_requests(
     trace_collector: TraceCollector
     if collect_traces:
         run_id = uuid4().hex
-        trace_collector = TraceCollector(run_id=run_id)
+        trace_collector = TraceCollector(run_id=run_id, trigger=trigger)
     else:
         trace_collector = NoOpTraceCollector()
 

--- a/bunking/sync/bunk_request_processor/process_requests.py
+++ b/bunking/sync/bunk_request_processor/process_requests.py
@@ -11,7 +11,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from bunking.logging_config import TRACE, get_logger
 
@@ -31,6 +31,11 @@ from .shared.constants import ALL_PROCESSING_FIELDS, validate_source_fields
 
 # Setup logging
 logger = get_logger(__name__)
+
+# Run source for a processing run. Mirrors the debug_pipeline_runs.trigger
+# PocketBase select field (see pb_migrations/1500000111). Kept here as the
+# single source of truth so the API boundary and the processor agree.
+TriggerType = Literal["upload", "scheduled", "manual"]
 
 
 def load_configuration() -> dict[str, Any]:
@@ -75,7 +80,7 @@ async def process_bunk_requests(
     force: bool = False,
     debug: bool = False,
     collect_traces: bool = False,
-    trigger: str = "manual",
+    trigger: TriggerType = "manual",
 ) -> dict[str, Any]:
     """Process bunk requests from a data source.
 

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -3277,7 +3277,7 @@ export type ProcessRequestsRequest = {
   /**
    * Trigger
    */
-  trigger?: string
+  trigger?: 'upload' | 'scheduled' | 'manual'
 }
 
 /**

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -3274,6 +3274,10 @@ export type ProcessRequestsRequest = {
    * Collect Traces
    */
   collect_traces?: boolean
+  /**
+   * Trigger
+   */
+  trigger?: string
 }
 
 /**

--- a/pocketbase/pb_migrations/1500000111_debug_runs_trigger_session_breakdown.js
+++ b/pocketbase/pb_migrations/1500000111_debug_runs_trigger_session_breakdown.js
@@ -1,0 +1,37 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: Add trigger + session_breakdown to debug_pipeline_runs
+ *
+ * trigger: select field (upload | scheduled | manual) — identifies what initiated the run.
+ * session_breakdown: json field — per-session map of status counts, populated by Python trace collector.
+ */
+
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("debug_pipeline_runs");
+
+  collection.fields.add(new Field({
+    type: "select",
+    name: "trigger",
+    required: false,
+    presentable: false,
+    values: ["upload", "scheduled", "manual"],
+    maxSelect: 1,
+  }));
+
+  collection.fields.add(new Field({
+    type: "json",
+    name: "session_breakdown",
+    required: false,
+    presentable: false,
+    maxSize: 200000,
+  }));
+
+  app.save(collection);
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("debug_pipeline_runs");
+
+  collection.fields.removeByName("trigger");
+  collection.fields.removeByName("session_breakdown");
+
+  app.save(collection);
+});

--- a/pocketbase/sync/api.go
+++ b/pocketbase/sync/api.go
@@ -862,6 +862,7 @@ func handleBunkRequestsUpload(e *core.RequestEvent, scheduler *Scheduler) error 
 						processor.ClearExisting = true
 						// Always collect pipeline traces for CSV uploads
 						processor.CollectTraces = true
+						processor.Trigger = "upload"
 
 						// Panic recovery — matches /process-requests endpoint pattern
 						defer func() {

--- a/pocketbase/sync/collect_traces_test.go
+++ b/pocketbase/sync/collect_traces_test.go
@@ -197,7 +197,7 @@ func TestCollectTraces_EndToEndFalseViaCallAPIProcessor(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, err := callAPIProcessor(context.Background(), server.URL, apiProcessorRequest{
+	_, err := callAPIProcessor(context.Background(), server.URL, &apiProcessorRequest{
 		Year:          2025,
 		Session:       "all",
 		CollectTraces: false,

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -1223,6 +1223,7 @@ func (o *Orchestrator) RunSyncWithOptions(ctx context.Context, opts Options) err
 		o.RegisterService("bunk_requests", NewBunkRequestsSync(o.app, yearClient))
 		yearProcessor := NewRequestProcessor(o.app)
 		yearProcessor.CollectTraces = true // Always collect traces for scheduled/automated runs
+		yearProcessor.Trigger = "scheduled"
 		o.RegisterService("process_requests", yearProcessor)
 		o.RegisterService("staff", NewStaffSync(o.app, yearClient))
 
@@ -1773,6 +1774,7 @@ func (o *Orchestrator) InitializeSyncServices() error {
 	// Register the request processor (no CampMinder client needed)
 	processor := NewRequestProcessor(o.app)
 	processor.CollectTraces = true // Always collect traces for scheduled/automated runs
+	processor.Trigger = "scheduled"
 	o.RegisterService("process_requests", processor)
 	// Camper history computation (no CampMinder client needed - reads from PocketBase)
 	o.RegisterService("camper_history", NewCamperHistorySync(o.app))

--- a/pocketbase/sync/process_requests.go
+++ b/pocketbase/sync/process_requests.go
@@ -30,6 +30,7 @@ type RequestProcessor struct {
 	Debug         bool     // Enable debug logging in Python processor
 	Trace         bool     // Enable trace logging (very verbose) in Python processor
 	CollectTraces bool     // Enable pipeline trace collection for debug tool
+	Trigger       string   // run source: "upload" | "scheduled" | "manual" (empty = manual)
 }
 
 // NewRequestProcessor creates a new processor
@@ -76,7 +77,7 @@ func (p *RequestProcessor) Sync(ctx context.Context) error {
 	}
 
 	apiURL := getAPIURL()
-	pythonStats, err := callAPIProcessor(ctx, apiURL, apiProcessorRequest{
+	pythonStats, err := callAPIProcessor(ctx, apiURL, &apiProcessorRequest{
 		Year:          yearInt,
 		Session:       p.Session,
 		SourceFields:  p.SourceFields,
@@ -86,6 +87,7 @@ func (p *RequestProcessor) Sync(ctx context.Context) error {
 		Debug:         p.Debug,
 		Trace:         p.Trace,
 		CollectTraces: p.CollectTraces,
+		Trigger:       p.Trigger,
 	})
 	if err != nil {
 		slog.Error("API processing failed", "error", err)
@@ -121,6 +123,7 @@ type apiProcessorRequest struct {
 	Debug         bool     `json:"debug"`
 	Trace         bool     `json:"trace"`
 	CollectTraces bool     `json:"collect_traces"`
+	Trigger       string   `json:"trigger,omitempty"`
 }
 
 // apiProcessorResponse is the JSON response from the process-requests API
@@ -154,7 +157,7 @@ func getProcessRequestsTimeout() time.Duration {
 }
 
 // callAPIProcessor calls the FastAPI process-requests endpoint
-func callAPIProcessor(ctx context.Context, apiURL string, req apiProcessorRequest) (Stats, error) {
+func callAPIProcessor(ctx context.Context, apiURL string, req *apiProcessorRequest) (Stats, error) {
 	bodyBytes, err := json.Marshal(req)
 	if err != nil {
 		return Stats{}, fmt.Errorf("marshaling request: %w", err)

--- a/pocketbase/sync/process_requests_test.go
+++ b/pocketbase/sync/process_requests_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -79,7 +80,7 @@ func TestCallAPIProcessor(t *testing.T) {
 			}))
 			defer server.Close()
 
-			stats, err := callAPIProcessor(context.Background(), server.URL, apiProcessorRequest{
+			stats, err := callAPIProcessor(context.Background(), server.URL, &apiProcessorRequest{
 				Year:    2025,
 				Session: "all",
 			})
@@ -124,7 +125,7 @@ func TestCallAPIProcessor_ForceField(t *testing.T) {
 	}))
 	defer server.Close()
 
-	stats, err := callAPIProcessor(context.Background(), server.URL, apiProcessorRequest{
+	stats, err := callAPIProcessor(context.Background(), server.URL, &apiProcessorRequest{
 		Year:    2025,
 		Session: "1",
 		Force:   true,
@@ -161,7 +162,7 @@ func TestCallAPIProcessor_CollectTracesField(t *testing.T) {
 	}))
 	defer server.Close()
 
-	stats, err := callAPIProcessor(context.Background(), server.URL, apiProcessorRequest{
+	stats, err := callAPIProcessor(context.Background(), server.URL, &apiProcessorRequest{
 		Year:          2025,
 		Session:       "all",
 		CollectTraces: true,
@@ -215,6 +216,28 @@ func TestGetProcessRequestsTimeout(t *testing.T) {
 				t.Errorf("getProcessRequestsTimeout() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestApiProcessorRequestSerializesTrigger verifies that the trigger field is serialized in the JSON body
+func TestApiProcessorRequestSerializesTrigger(t *testing.T) {
+	b, err := json.Marshal(apiProcessorRequest{Year: 2026, Session: "all", Trigger: "upload"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"trigger":"upload"`) {
+		t.Errorf("expected trigger in JSON, got: %s", string(b))
+	}
+}
+
+// TestApiProcessorRequestOmitsEmptyTrigger verifies that an empty trigger is omitted from the JSON body
+func TestApiProcessorRequestOmitsEmptyTrigger(t *testing.T) {
+	b, err := json.Marshal(apiProcessorRequest{Year: 2026, Session: "all"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "trigger") {
+		t.Errorf("empty trigger should be omitted, got: %s", string(b))
 	}
 }
 

--- a/tests/integration/test_internal_process_requests_trigger.py
+++ b/tests/integration/test_internal_process_requests_trigger.py
@@ -1,0 +1,52 @@
+"""
+Integration tests: trigger field forwarding on /api/internal/process-requests.
+
+Verifies that the `trigger` body field is accepted and forwarded to
+`run_process_requests`, with a default of "manual" when omitted.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+client = TestClient(app)
+
+# Minimal mock return value that satisfies the endpoint's result.get() accesses.
+_MOCK_RESULT = {
+    "success": True,
+    "statistics": {
+        "requests_created": 0,
+        "phase2_ambiguous": 0,
+        "phase1_failed": 0,
+        "phase1_successful": 0,
+        "phase1_first_error": None,
+    },
+    "already_processed": 0,
+}
+
+
+def test_trigger_defaults_to_manual():
+    with patch(
+        "api.routers.internal.run_process_requests",
+        new=AsyncMock(return_value=_MOCK_RESULT),
+    ) as m:
+        r = client.post("/api/internal/process-requests", json={"year": 2026, "session": "all"})
+        assert r.status_code == 200
+        assert m.await_args is not None
+        assert m.await_args.kwargs["trigger"] == "manual"
+
+
+def test_trigger_upload_passes_through():
+    with patch(
+        "api.routers.internal.run_process_requests",
+        new=AsyncMock(return_value=_MOCK_RESULT),
+    ) as m:
+        r = client.post(
+            "/api/internal/process-requests",
+            json={"year": 2026, "session": "all", "trigger": "upload"},
+        )
+        assert r.status_code == 200
+        assert m.await_args is not None
+        assert m.await_args.kwargs["trigger"] == "upload"

--- a/tests/unit/api/test_internal_process_requests_trigger.py
+++ b/tests/unit/api/test_internal_process_requests_trigger.py
@@ -1,8 +1,11 @@
 """
-Integration tests: trigger field forwarding on /api/internal/process-requests.
+Tests for trigger field forwarding on /api/internal/process-requests.
 
 Verifies that the `trigger` body field is accepted and forwarded to
 `run_process_requests`, with a default of "manual" when omitted.
+
+Lives under tests/unit/api/ so this dir's conftest applies AUTH_MODE=bypass
+before `api.main` builds its app singleton (avoids xdist auth pollution).
 """
 
 from unittest.mock import AsyncMock, patch

--- a/tests/unit/api/test_internal_process_requests_trigger.py
+++ b/tests/unit/api/test_internal_process_requests_trigger.py
@@ -53,3 +53,22 @@ def test_trigger_upload_passes_through():
         assert r.status_code == 200
         assert m.await_args is not None
         assert m.await_args.kwargs["trigger"] == "upload"
+
+
+def test_invalid_trigger_rejected():
+    """An out-of-range trigger fails fast at the API boundary (422).
+
+    debug_pipeline_runs.trigger is a PocketBase select (upload|scheduled|manual);
+    a value outside that set must be rejected before the processor runs so it can
+    never reach (and silently break) run-record persistence.
+    """
+    with patch(
+        "api.routers.internal.run_process_requests",
+        new=AsyncMock(return_value=_MOCK_RESULT),
+    ) as m:
+        r = client.post(
+            "/api/internal/process-requests",
+            json={"year": 2026, "session": "all", "trigger": "bogus"},
+        )
+        assert r.status_code == 422
+        assert m.await_count == 0  # rejected before the processor is invoked

--- a/tests/unit/sync/bunk_request_processor/debug/test_retention.py
+++ b/tests/unit/sync/bunk_request_processor/debug/test_retention.py
@@ -101,11 +101,12 @@ def _make_pb_mock(
 ) -> MagicMock:
     """Build a PB mock that responds correctly to the new targeted-query retention logic.
 
-    The new cleanup_old_runs makes these calls:
-    1. get_full_list(filter='pinned = false && created < ...')  -> expired_runs
-    2. get_full_list(filter='pinned = false', sort='-created')  -> unpinned_runs
-    3. get_list(1, 1) -> total_count (for pinned count estimation)
-    4. For each run to delete: get_full_list(filter='run_id = "..."') -> traces
+    cleanup_old_runs makes these calls (keyed on method + filter; order-agnostic):
+    1. get_list(1, 1, query_params={trigger='upload'})           -> page.items = [] (no upload runs)
+    2. get_full_list(filter='pinned = false && created < ...')   -> expired_runs
+    3. get_full_list(filter='pinned = false', sort='-created')   -> unpinned_runs
+    4. get_list(1, 1)  (no query_params)                         -> page.total_items = total_count
+    5. For each run to delete: get_full_list(filter='run_id = "..."') -> traces
     """
     pb = MagicMock()
     trace_results = trace_results or {}
@@ -123,13 +124,31 @@ def _make_pb_mock(
 
     pb.collection.side_effect = collection_router
 
-    # get_full_list calls: first expired, then all unpinned
-    runs_collection.get_full_list.side_effect = [expired_runs, unpinned_runs]
+    # get_full_list calls: keyed on filter string so call order doesn't matter
+    def runs_get_full_list(query_params: dict[str, str] | None = None, **kwargs: object) -> list[MagicMock]:
+        f = (query_params or {}).get("filter", "")
+        # Time-based expired query
+        if "created <" in f:
+            return expired_runs
+        # All-unpinned query (count-based)
+        return unpinned_runs
 
-    # get_list call for total count
-    list_result = MagicMock()
-    list_result.total_items = total_count
-    runs_collection.get_list.return_value = list_result
+    runs_collection.get_full_list.side_effect = runs_get_full_list
+
+    # get_list calls: newest-upload single-row fetch (has query_params) vs total-count fetch
+    def runs_get_list(
+        page: int = 1, per_page: int = 30, query_params: dict[str, str] | None = None, **kwargs: object
+    ) -> MagicMock:
+        f = (query_params or {}).get("filter", "")
+        page_result = MagicMock()
+        if "trigger" in f and "upload" in f:
+            page_result.items = []  # no upload runs in most tests
+        else:
+            page_result.total_items = total_count
+            page_result.items = []
+        return page_result
+
+    runs_collection.get_list.side_effect = runs_get_list
 
     # Trace lookups for runs being deleted
     def traces_full_list(query_params: dict[str, str] | None = None, **kwargs: object) -> list[MagicMock]:

--- a/tests/unit/sync/bunk_request_processor/test_retention_upload_exempt.py
+++ b/tests/unit/sync/bunk_request_processor/test_retention_upload_exempt.py
@@ -1,0 +1,174 @@
+"""Tests that the newest upload run is exempt from retention deletion.
+
+The per-session "what's new" summary reads the latest trigger='upload' run.
+Even if many scheduled runs push the upload run past MAX_RUNS or MAX_AGE_DAYS,
+the single most-recent upload run must be preserved.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from bunking.sync.bunk_request_processor.debug.retention import MAX_RUNS, cleanup_old_runs
+
+
+def _run(rid: str, created: str, trigger: str = "scheduled", pinned: bool = False) -> MagicMock:
+    r = MagicMock()
+    r.id = rid
+    r.run_id = rid  # retention code uses run.run_id for trace lookups
+    r.created = created
+    r.trigger = trigger
+    r.pinned = pinned
+    return r
+
+
+def _make_pb(
+    expired_runs: list[MagicMock],
+    unpinned_runs: list[MagicMock],
+    total_count: int,
+    newest_upload: MagicMock | None,
+) -> tuple[MagicMock, list[str]]:
+    """Build a PB mock wired to the real cleanup_old_runs query structure.
+
+    The mock is keyed on method + filter, so call order is irrelevant.
+
+    - debug_pipeline_runs.get_list(1, 1, query_params={trigger='upload'})
+        -> page whose .items is [newest_upload] (or [] when no upload runs)
+    - debug_pipeline_runs.get_list(1, 1)  (no query_params)
+        -> page whose .total_items is total_count (pinned-count estimation)
+    - debug_pipeline_runs.get_full_list(filter='... created < ...')  -> expired_runs
+    - debug_pipeline_runs.get_full_list(filter='pinned = false')     -> unpinned_runs
+    - debug_pipeline_traces.get_full_list(...)                       -> [] (no traces)
+    """
+    pb = MagicMock()
+    deleted: list[str] = []
+
+    runs_col = MagicMock()
+    traces_col = MagicMock()
+
+    def collection_router(name: str) -> MagicMock:
+        if name == "debug_pipeline_runs":
+            return runs_col
+        if name == "debug_pipeline_traces":
+            return traces_col
+        return MagicMock()
+
+    pb.collection.side_effect = collection_router
+
+    def runs_get_full_list(query_params: dict[str, Any] | None = None, **kwargs: object) -> list[MagicMock]:
+        f = (query_params or {}).get("filter", "")
+        # Time-based expired query
+        if "created <" in f:
+            return expired_runs
+        # All-unpinned query (count-based)
+        return unpinned_runs
+
+    runs_col.get_full_list.side_effect = runs_get_full_list
+
+    def runs_get_list(
+        page: int = 1, per_page: int = 30, query_params: dict[str, Any] | None = None, **kwargs: object
+    ) -> MagicMock:
+        f = (query_params or {}).get("filter", "")
+        page_result = MagicMock()
+        if "trigger" in f and "upload" in f:
+            # Newest-upload single-row fetch
+            page_result.items = [newest_upload] if newest_upload else []
+        else:
+            # Total-count fetch (no query_params)
+            page_result.total_items = total_count
+            page_result.items = []
+        return page_result
+
+    runs_col.get_list.side_effect = runs_get_list
+
+    # Track deletes
+    runs_col.delete.side_effect = lambda rid: deleted.append(rid)
+    traces_col.get_full_list.return_value = []  # no traces to worry about
+
+    return pb, deleted
+
+
+class TestNewestUploadRunExemption:
+    def test_newest_upload_run_exempt_from_count_trim(self) -> None:
+        """Upload run survives even when 60 newer scheduled runs push it past MAX_RUNS."""
+        # upload run is older; 60 scheduled runs are all newer
+        upload = _run("upload-old", "2026-05-01T00:00:00Z", trigger="upload")
+        scheduled = [_run(f"s{i}", f"2026-05-{2 + i:02d}T00:00:00Z") for i in range(60)]
+
+        # unpinned sorted newest-first: scheduled (newest) ... upload (oldest)
+        all_unpinned = list(reversed(scheduled)) + [upload]  # newest first
+        total = len(all_unpinned)  # 61 runs, all unpinned
+
+        pb, deleted = _make_pb(
+            expired_runs=[],
+            unpinned_runs=all_unpinned,
+            total_count=total,
+            newest_upload=upload,
+        )
+
+        cleanup_old_runs(pb)
+
+        assert "upload-old" not in deleted, "The newest upload run must be exempt from count-based deletion"
+        # The 11 oldest scheduled runs (beyond MAX_RUNS=50 after upload is protected)
+        # should be deleted; upload itself is safe
+        assert len(deleted) > 0, "Some scheduled runs should still be pruned"
+
+    def test_only_newest_upload_run_is_exempt(self) -> None:
+        """Older upload runs are NOT exempt — only the single most-recent one is."""
+        # Two upload runs: one newer, one older
+        newer_upload = _run("upload-new", "2026-05-20T00:00:00Z", trigger="upload")
+        older_upload = _run("upload-old", "2026-05-01T00:00:00Z", trigger="upload")
+        scheduled = [_run(f"s{i}", f"2026-05-{21 + i:02d}T00:00:00Z") for i in range(60)]
+
+        # sorted newest-first
+        all_unpinned = list(reversed(scheduled)) + [newer_upload, older_upload]
+        total = len(all_unpinned)
+
+        pb, deleted = _make_pb(
+            expired_runs=[],
+            unpinned_runs=all_unpinned,
+            total_count=total,
+            newest_upload=newer_upload,  # only newer_upload is exempt
+        )
+
+        cleanup_old_runs(pb)
+
+        # Newer upload is protected
+        assert "upload-new" not in deleted, "The newest upload run must not be deleted"
+        # Older upload should be pruneable (it's beyond MAX_RUNS=50)
+        assert "upload-old" in deleted, "Older upload runs beyond MAX_RUNS should be pruned"
+
+    def test_exempt_still_applies_when_no_upload_runs_exist(self) -> None:
+        """cleanup_old_runs works normally when there are no upload runs at all."""
+        scheduled = [_run(f"s{i}", f"2026-05-{1 + i:02d}T00:00:00Z") for i in range(MAX_RUNS + 5)]
+        all_unpinned = list(reversed(scheduled))  # newest first
+        total = len(all_unpinned)
+
+        pb, deleted = _make_pb(
+            expired_runs=[],
+            unpinned_runs=all_unpinned,
+            total_count=total,
+            newest_upload=None,
+        )
+
+        result = cleanup_old_runs(pb)
+        assert result == 5, "5 excess scheduled runs should be deleted"
+
+    def test_newest_upload_run_exempt_from_time_based_trim(self) -> None:
+        """Upload run is exempt even when it's old enough to be time-pruned."""
+        # An upload run that is 45 days old (past MAX_AGE_DAYS=30)
+        old_upload = _run("upload-ancient", "2026-04-01T00:00:00Z", trigger="upload")
+        scheduled_recent = [_run(f"s{i}", f"2026-05-{1 + i:02d}T00:00:00Z") for i in range(10)]
+
+        all_unpinned = list(reversed(scheduled_recent)) + [old_upload]
+        total = len(all_unpinned)
+
+        pb, deleted = _make_pb(
+            expired_runs=[old_upload],  # time-based filter would normally catch it
+            unpinned_runs=all_unpinned,
+            total_count=total,
+            newest_upload=old_upload,  # but it's the newest (only) upload run
+        )
+
+        cleanup_old_runs(pb)
+
+        assert "upload-ancient" not in deleted, "The newest upload run must be exempt from time-based deletion too"

--- a/tests/unit/sync/bunk_request_processor/test_trace_collector_run_record.py
+++ b/tests/unit/sync/bunk_request_processor/test_trace_collector_run_record.py
@@ -1,0 +1,159 @@
+"""Tests for TraceCollector persisting trigger + session_breakdown on the run record.
+
+Task 4 of GitHub #1686: wire trigger and session_breakdown into the .create() payload
+written during flush().
+"""
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+from bunking.sync.bunk_request_processor.debug.trace_collector import TraceCollector
+from bunking.sync.bunk_request_processor.debug.trace_models import (
+    DispositionTrace,
+    FinalBunkRequestTrace,
+)
+
+
+def _make_pb_mock() -> MagicMock:
+    """Return a PB client mock that:
+    - Captures the FIRST .create() call's payload in captured_creates[0]
+    - Returns a MagicMock with .id = "x" from every .create()
+    - Returns get_list result with total_items=0 (suppresses retention cleanup)
+    """
+    pb = MagicMock()
+    # get_list used by retention check — needs numeric .total_items
+    pb.collection.return_value.get_list.return_value.total_items = 0
+    pb.collection.return_value.get_list.return_value.items = []
+
+    # create() returns a MagicMock with id attribute
+    create_mock = MagicMock()
+    create_mock.id = "x"
+    pb.collection.return_value.create.return_value = create_mock
+
+    return pb
+
+
+def _seed_one_resolved_trace(tc: TraceCollector, session_cm_id: int = 1000001) -> None:
+    """Seed one resolved trace so flush() has something to write."""
+    tc.record_pre_phase1(
+        key="req-a",
+        action="parsed",
+        original_text="bunk with Emma",
+        requester_cm_id=99999,
+        year=2026,
+        session_cm_id=session_cm_id,
+        source_field="bunk_request_form",
+    )
+    tc.record_disposition(
+        key="req-a",
+        disposition=DispositionTrace(
+            final_bunk_requests=[FinalBunkRequestTrace(status="RESOLVED", request_type="BUNK_WITH")]
+        ),
+    )
+
+
+class TestFlushPersistsTriggerAndSessionBreakdown:
+    """flush() must include trigger + session_breakdown in the run-record .create() payload."""
+
+    def test_trigger_upload_written_to_run_record(self) -> None:
+        """TraceCollector(trigger='upload') → run record payload has trigger='upload'."""
+        tc = TraceCollector(run_id="r1", trigger="upload")
+        _seed_one_resolved_trace(tc, session_cm_id=1000001)
+
+        pb = _make_pb_mock()
+
+        # Capture the first .create() call's payload (the run record)
+        first_payload: dict[str, Any] = {}
+
+        original_create = pb.collection.return_value.create
+
+        call_count = 0
+
+        def capturing_create(payload: dict[str, Any]) -> Any:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                first_payload.update(payload)
+            return original_create.return_value
+
+        pb.collection.return_value.create.side_effect = capturing_create
+
+        asyncio.run(tc.flush(pb, run_metadata={"year": 2026}))
+
+        assert first_payload["trigger"] == "upload"
+        assert "session_breakdown" in first_payload
+        assert first_payload["session_breakdown"]["1000001"]["resolved"] == 1
+
+    def test_default_trigger_is_manual(self) -> None:
+        """TraceCollector without explicit trigger → run record payload has trigger='manual'."""
+        tc = TraceCollector(run_id="r2")
+        _seed_one_resolved_trace(tc, session_cm_id=1000002)
+
+        pb = _make_pb_mock()
+
+        first_payload: dict[str, Any] = {}
+        call_count = 0
+
+        original_create = pb.collection.return_value.create
+
+        def capturing_create(payload: dict[str, Any]) -> Any:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                first_payload.update(payload)
+            return original_create.return_value
+
+        pb.collection.return_value.create.side_effect = capturing_create
+
+        asyncio.run(tc.flush(pb, run_metadata={"year": 2026}))
+
+        assert first_payload["trigger"] == "manual"
+        assert "session_breakdown" in first_payload
+
+    def test_session_breakdown_multiple_sessions(self) -> None:
+        """session_breakdown correctly groups counts across two sessions."""
+        tc = TraceCollector(run_id="r3", trigger="manual")
+
+        # Session 1000001: one RESOLVED
+        _seed_one_resolved_trace(tc, session_cm_id=1000001)
+
+        # Session 1000002: one PENDING
+        tc.record_pre_phase1(
+            key="req-b",
+            action="parsed",
+            original_text="not bunk with Liam",
+            requester_cm_id=88888,
+            year=2026,
+            session_cm_id=1000002,
+            source_field="bunk_request_form",
+        )
+        tc.record_disposition(
+            key="req-b",
+            disposition=DispositionTrace(
+                final_bunk_requests=[FinalBunkRequestTrace(status="PENDING", request_type="NOT_BUNK_WITH")]
+            ),
+        )
+
+        pb = _make_pb_mock()
+
+        first_payload: dict[str, Any] = {}
+        call_count = 0
+        original_create = pb.collection.return_value.create
+
+        def capturing_create(payload: dict[str, Any]) -> Any:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                first_payload.update(payload)
+            return original_create.return_value
+
+        pb.collection.return_value.create.side_effect = capturing_create
+
+        asyncio.run(tc.flush(pb, run_metadata={"year": 2026}))
+
+        bd = first_payload["session_breakdown"]
+        assert bd["1000001"]["resolved"] == 1
+        assert bd["1000001"]["pending"] == 0
+        assert bd["1000002"]["pending"] == 1
+        assert bd["1000002"]["resolved"] == 0

--- a/tests/unit/sync/bunk_request_processor/test_trace_collector_session_breakdown.py
+++ b/tests/unit/sync/bunk_request_processor/test_trace_collector_session_breakdown.py
@@ -1,0 +1,158 @@
+"""Tests for TraceCollector._compute_session_breakdown() and the extracted _resolve_trace_status helper."""
+
+from bunking.sync.bunk_request_processor.debug.trace_collector import TraceCollector
+from bunking.sync.bunk_request_processor.debug.trace_models import (
+    DispositionTrace,
+    FinalBunkRequestTrace,
+)
+
+
+def _seed_trace(
+    tc: TraceCollector,
+    key: str,
+    session_cm_id: int,
+    statuses: list[str],
+) -> None:
+    """Seed a trace with a given session_cm_id and a list of final bunk-request statuses.
+
+    Uses the real seeding API:
+      - record_pre_phase1() sets _trace_metadata[key]["session_cm_id"]
+      - record_disposition() sets disposition.final_bunk_requests with the given statuses
+    If statuses is empty the trace is left with no final_bunk_requests (→ skipped).
+    """
+    tc.record_pre_phase1(
+        key=key,
+        action="parsed",
+        original_text="bunk with Emma",
+        requester_cm_id=99999,
+        year=2025,
+        session_cm_id=session_cm_id,
+        source_field="bunk_request_form",
+    )
+    tc.record_disposition(
+        key=key,
+        disposition=DispositionTrace(
+            final_bunk_requests=[FinalBunkRequestTrace(status=s, request_type="BUNK_WITH") for s in statuses]
+        ),
+    )
+
+
+class TestComputeSessionBreakdown:
+    """_compute_session_breakdown() groups status counts by session_cm_id (as str keys)."""
+
+    def test_basic_grouping_two_sessions(self) -> None:
+        """Two sessions with known statuses are grouped correctly."""
+        tc = TraceCollector(run_id="test-session-breakdown")
+
+        # session 1000001: one RESOLVED + one PENDING
+        _seed_trace(tc, "key-s1-resolved", session_cm_id=1000001, statuses=["RESOLVED"])
+        _seed_trace(tc, "key-s1-pending", session_cm_id=1000001, statuses=["PENDING"])
+
+        # session 1000002: one RESOLVED
+        _seed_trace(tc, "key-s2-resolved", session_cm_id=1000002, statuses=["RESOLVED"])
+
+        breakdown = tc._compute_session_breakdown()
+
+        assert set(breakdown.keys()) == {"1000001", "1000002"}
+
+        s1 = breakdown["1000001"]
+        assert s1 == {"resolved": 1, "pending": 1, "declined": 0, "skipped": 0, "deduped": 0}
+
+        s2 = breakdown["1000002"]
+        assert s2 == {"resolved": 1, "pending": 0, "declined": 0, "skipped": 0, "deduped": 0}
+
+    def test_global_breakdown_still_correct_after_refactor(self) -> None:
+        """_compute_status_breakdown() aggregate is unchanged after the DRY refactor."""
+        tc = TraceCollector(run_id="test-global-unchanged")
+
+        _seed_trace(tc, "key-s1-resolved", session_cm_id=1000001, statuses=["RESOLVED"])
+        _seed_trace(tc, "key-s1-pending", session_cm_id=1000001, statuses=["PENDING"])
+        _seed_trace(tc, "key-s2-resolved", session_cm_id=1000002, statuses=["RESOLVED"])
+
+        global_bd = tc._compute_status_breakdown()
+        assert global_bd["resolved"] == 2
+        assert global_bd["pending"] == 1
+        assert global_bd["declined"] == 0
+        assert global_bd["skipped"] == 0
+        assert global_bd["deduped"] == 0
+
+    def test_skipped_trace_counted_in_session(self) -> None:
+        """A trace with no final_bunk_requests is counted as 'skipped' in its session bucket."""
+        tc = TraceCollector(run_id="test-skipped")
+
+        _seed_trace(tc, "key-skipped", session_cm_id=1000003, statuses=[])  # no final requests → skipped
+
+        breakdown = tc._compute_session_breakdown()
+        assert breakdown["1000003"]["skipped"] == 1
+        assert breakdown["1000003"]["resolved"] == 0
+
+    def test_declined_and_deduped_traces(self) -> None:
+        """DECLINED and DEDUPED statuses are bucketed correctly per session."""
+        tc = TraceCollector(run_id="test-declined-deduped")
+
+        _seed_trace(tc, "key-declined", session_cm_id=2000001, statuses=["DECLINED"])
+        _seed_trace(tc, "key-deduped", session_cm_id=2000001, statuses=["DEDUPED"])
+
+        breakdown = tc._compute_session_breakdown()
+        s = breakdown["2000001"]
+        assert s["declined"] == 1
+        assert s["deduped"] == 1
+        assert s["resolved"] == 0
+        assert s["pending"] == 0
+
+    def test_priority_pending_beats_resolved_within_trace(self) -> None:
+        """A single trace with both RESOLVED and PENDING bunk requests resolves to 'pending'."""
+        tc = TraceCollector(run_id="test-priority-pending")
+
+        # One trace with two bunk requests: one RESOLVED, one PENDING
+        tc.record_pre_phase1(
+            key="mixed",
+            action="parsed",
+            original_text="bunk with Emma and Liam",
+            requester_cm_id=11111,
+            year=2025,
+            session_cm_id=3000001,
+            source_field="bunk_request_form",
+        )
+        tc.record_disposition(
+            key="mixed",
+            disposition=DispositionTrace(
+                final_bunk_requests=[
+                    FinalBunkRequestTrace(status="RESOLVED", request_type="BUNK_WITH"),
+                    FinalBunkRequestTrace(status="PENDING", request_type="BUNK_WITH"),
+                ]
+            ),
+        )
+
+        breakdown = tc._compute_session_breakdown()
+        s = breakdown["3000001"]
+        assert s["pending"] == 1
+        assert s["resolved"] == 0
+
+    def test_empty_collector_returns_empty_dict(self) -> None:
+        """No traces → empty session breakdown dict (not a dict with zero counts)."""
+        tc = TraceCollector(run_id="test-empty")
+        breakdown = tc._compute_session_breakdown()
+        assert breakdown == {}
+
+    def test_session_keys_are_strings(self) -> None:
+        """session_cm_id (int) is stored as str key in the output dict."""
+        tc = TraceCollector(run_id="test-str-keys")
+        _seed_trace(tc, "key-a", session_cm_id=9999999, statuses=["RESOLVED"])
+        breakdown = tc._compute_session_breakdown()
+        # Only the str key is present — confirms session_cm_id is stringified, never left as int.
+        assert set(breakdown.keys()) == {"9999999"}
+
+    def test_missing_metadata_falls_back_to_zero_key(self) -> None:
+        """A disposition recorded for a key never seen by record_pre_phase1 has no metadata,
+        so session_cm_id defaults to 0 and the trace is bucketed under the "0" key."""
+        tc = TraceCollector(run_id="test-missing-meta")
+        tc.record_disposition(
+            key="orphan",
+            disposition=DispositionTrace(
+                final_bunk_requests=[FinalBunkRequestTrace(status="RESOLVED", request_type="BUNK_WITH")]
+            ),
+        )
+        breakdown = tc._compute_session_breakdown()
+        assert "0" in breakdown
+        assert breakdown["0"]["resolved"] == 1

--- a/tests/unit/sync/bunk_request_processor/test_trace_collector_session_breakdown.py
+++ b/tests/unit/sync/bunk_request_processor/test_trace_collector_session_breakdown.py
@@ -4,6 +4,7 @@ from bunking.sync.bunk_request_processor.debug.trace_collector import TraceColle
 from bunking.sync.bunk_request_processor.debug.trace_models import (
     DispositionTrace,
     FinalBunkRequestTrace,
+    TraceData,
 )
 
 
@@ -142,6 +143,19 @@ class TestComputeSessionBreakdown:
         breakdown = tc._compute_session_breakdown()
         # Only the str key is present — confirms session_cm_id is stringified, never left as int.
         assert set(breakdown.keys()) == {"9999999"}
+
+    def test_none_status_does_not_crash(self) -> None:
+        """A final bunk request with status=None must not raise in _resolve_trace_status.
+
+        status is a validated Pydantic str field, so None can only arise via a
+        validation bypass / malformed data. model_construct() simulates that. A
+        None status carries no priority signal, so the trace stays 'resolved'.
+        """
+        tc = TraceCollector(run_id="test-none-status")
+        # status=None is intentionally invalid (field is typed str) to exercise the guard.
+        br = FinalBunkRequestTrace.model_construct(status=None, request_type="BUNK_WITH")  # type: ignore[arg-type]
+        trace = TraceData(disposition=DispositionTrace(final_bunk_requests=[br]))
+        assert tc._resolve_trace_status(trace) == "resolved"
 
     def test_missing_metadata_falls_back_to_zero_key(self) -> None:
         """A disposition recorded for a key never seen by record_pre_phase1 has no metadata,


### PR DESCRIPTION
## What

Backend for the per-session upload "what's new" summary (#1686, **part 2 of 3** — no UI yet). Lets the frontend (PR 3) read what the **most recent CSV upload** brought into a given session.

- **Migration `1500000111`**: adds `trigger` (`upload`|`scheduled`|`manual`) + `session_breakdown` (json) to `debug_pipeline_runs`.
- **Trace collector**: new `_compute_session_breakdown()` (per-session status counts, grouped by `session_cm_id`) sharing a single extracted `_resolve_trace_status()` helper with the existing global breakdown; persists `trigger` + `session_breakdown` on the run record.
- **Trigger plumbing**: `process_bunk_requests` → FastAPI `/api/internal/process-requests` (`ProcessRequestsRequest.trigger`) → Go (`apiProcessorRequest.trigger`, `omitempty`). Upload path tags `"upload"`, nightly cron `"scheduled"`, default `"manual"`.
- **Retention**: the newest `trigger='upload'` run is exempt from both deletion paths, so the persistent per-session summary survives nightly cron churn.

## Why pin to the last *upload*

Both CSV uploads and the nightly cron write pipeline runs. The export is filtered on enrolled (status_id 2), so a cron re-run adds no net-new requests — only de-enrollment removals, which staff don't need surfaced. Pinning to the last upload keeps the summary meaningful and stable overnight.

## Testing (TDD)

- Python: per-session breakdown grouping + status priority; trigger/session_breakdown persistence; default-manual; retention exempts only the single newest upload run.
- Go: `trigger` serializes when set, omitted when empty (so Python's `"manual"` default applies).
- API: endpoint forwards `trigger` (default-manual + explicit-upload).
- Full mockable suite green (5391 passed). A new endpoint test was placed under `tests/unit/api/` (not `tests/integration/`) so the dir's `AUTH_MODE=bypass` conftest applies before `api.main` import — avoids xdist worker auth pollution.

RBAC unchanged — `bunking.manage` already reads `debug_pipeline_*` (#1370). Part 2 of #1686.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trigger tracking to identify process origins (manual, upload, scheduled)
  * Added session-level breakdown reporting for debug runs

* **Improvements**
  * Debug run retention now exempts the newest upload run from deletion policies

* **Tests**
  * Added comprehensive test coverage for trigger handling and session breakdown computation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->