### PR TITLE
feat(frontend): per-session upload what's-new chip + modal (#1686)

### DIFF
--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -387,6 +387,9 @@ export default function SessionView() {
           camperCount={campers.length}
           requestCount={bunkRequestsCount}
           canManage={canManage}
+          sessionCmId={session.cm_id || 0}
+          agSessionCmIds={agSessions.map((s) => s.cm_id)}
+          sessionName={session.name}
         />
 
         {/* Contextual Bar - Area filter + Stats (Bunks tab only) */}

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -387,7 +387,7 @@ export default function SessionView() {
           camperCount={campers.length}
           requestCount={bunkRequestsCount}
           canManage={canManage}
-          sessionCmId={session.cm_id || 0}
+          sessionCmId={session.cm_id ?? undefined}
           agSessionCmIds={agSessions.map((s) => s.cm_id)}
           sessionName={session.name}
         />

--- a/frontend/src/components/session/SessionLastUploadChip.test.tsx
+++ b/frontend/src/components/session/SessionLastUploadChip.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../hooks/session/useLastUploadSummary', () => ({ useLastUploadSummary: vi.fn() }))
+vi.mock('./SessionUploadChangesModal', () => ({
+  default: () => <div data-testid="changes-modal" />,
+}))
+import { useLastUploadSummary } from '../../hooks/session/useLastUploadSummary'
+import SessionLastUploadChip from './SessionLastUploadChip'
+
+const set = (v: unknown) => (useLastUploadSummary as ReturnType<typeof vi.fn>).mockReturnValue(v)
+
+describe('SessionLastUploadChip', () => {
+  it('renders nothing when session slice is null', () => {
+    set({
+      runId: 'r1',
+      finishedAt: 't',
+      global: { total: 5, autoMatched: 5, needReview: 0 },
+      session: null,
+    })
+    const { container } = render(
+      <SessionLastUploadChip sessionCmId={1} agSessionCmIds={[]} sessionName="Session 2" />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when runId is null', () => {
+    set({
+      runId: null,
+      finishedAt: null,
+      global: null,
+      session: { total: 3, autoMatched: 3, needReview: 0 },
+    })
+    const { container } = render(
+      <SessionLastUploadChip sessionCmId={1} agSessionCmIds={[]} sessionName="Session 2" />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows count; omits review segment when needReview=0', () => {
+    set({
+      runId: 'r1',
+      finishedAt: 't',
+      global: null,
+      session: { total: 14, autoMatched: 14, needReview: 0 },
+    })
+    render(<SessionLastUploadChip sessionCmId={1} agSessionCmIds={[]} sessionName="Session 2" />)
+    expect(screen.getByText(/14 new/)).toBeInTheDocument()
+    expect(screen.queryByText(/review/i)).not.toBeInTheDocument()
+  })
+
+  it('shows review segment when needReview>0', () => {
+    set({
+      runId: 'r1',
+      finishedAt: 't',
+      global: null,
+      session: { total: 14, autoMatched: 11, needReview: 3 },
+    })
+    render(<SessionLastUploadChip sessionCmId={1} agSessionCmIds={[]} sessionName="Session 2" />)
+    expect(screen.getByText(/3 review/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/session/SessionLastUploadChip.tsx
+++ b/frontend/src/components/session/SessionLastUploadChip.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react'
+import { Download } from 'lucide-react'
+import { useLastUploadSummary } from '../../hooks/session/useLastUploadSummary'
+import SessionUploadChangesModal from './SessionUploadChangesModal'
+
+interface Props {
+  sessionCmId: number | undefined
+  agSessionCmIds: number[]
+  sessionName: string
+}
+
+export default function SessionLastUploadChip({ sessionCmId, agSessionCmIds, sessionName }: Props) {
+  const { runId, session } = useLastUploadSummary(sessionCmId, agSessionCmIds)
+  const [open, setOpen] = useState(false)
+
+  if (!session || !runId) return null
+
+  const cmIds = [sessionCmId, ...agSessionCmIds].filter((k): k is number => typeof k === 'number')
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="ml-auto flex items-center gap-1.5 rounded-lg border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-sm text-emerald-800 hover:bg-emerald-100 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300"
+        aria-label="View last upload changes for this session"
+      >
+        <Download className="h-3.5 w-3.5" aria-hidden="true" />
+        <span className="font-semibold">{session.total} new</span>
+        {session.needReview > 0 && (
+          <span className="font-semibold text-amber-700 dark:text-amber-400">
+            · ⚠ {session.needReview} review
+          </span>
+        )}
+      </button>
+      {open && (
+        <SessionUploadChangesModal
+          runId={runId}
+          sessionCmIds={cmIds}
+          sessionName={sessionName}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/session/SessionTabs.test.tsx
+++ b/frontend/src/components/session/SessionTabs.test.tsx
@@ -1,7 +1,11 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import SessionTabs, { createTabs } from './SessionTabs'
+
+vi.mock('./SessionLastUploadChip', () => ({
+  default: () => <div data-testid="last-upload-chip" />,
+}))
 
 describe('SessionTabs', () => {
   describe('createTabs', () => {
@@ -104,6 +108,23 @@ describe('SessionTabs', () => {
         expect(screen.getByRole('navigation')).toBeInTheDocument()
         unmount()
       })
+    })
+
+    it('renders the last-upload chip when session props are provided', () => {
+      render(
+        <MemoryRouter>
+          <SessionTabs
+            sessionId="2"
+            activeTab="bunks"
+            camperCount={69}
+            requestCount={45}
+            sessionCmId={1000001}
+            agSessionCmIds={[]}
+            sessionName="Session 2"
+          />
+        </MemoryRouter>
+      )
+      expect(screen.getByTestId('last-upload-chip')).toBeInTheDocument()
     })
 
     describe('canManage permission gating', () => {

--- a/frontend/src/components/session/SessionTabs.tsx
+++ b/frontend/src/components/session/SessionTabs.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router'
 import { Home, Users, Link2, UsersRound, type LucideIcon } from 'lucide-react'
 import type { ValidTab } from '../../utils/sessionUtils'
+import SessionLastUploadChip from './SessionLastUploadChip'
 
 export interface TabItem {
   id: ValidTab
@@ -29,6 +30,9 @@ interface SessionTabsProps {
   camperCount: number
   requestCount: number
   canManage?: boolean
+  sessionCmId?: number
+  agSessionCmIds?: number[]
+  sessionName?: string
 }
 
 export default function SessionTabs({
@@ -37,6 +41,9 @@ export default function SessionTabs({
   camperCount,
   requestCount,
   canManage = true,
+  sessionCmId,
+  agSessionCmIds,
+  sessionName,
 }: SessionTabsProps) {
   const tabs = createTabs({ camperCount, requestCount }).filter(
     (tab) => tab.id !== 'requests' || canManage
@@ -44,7 +51,7 @@ export default function SessionTabs({
 
   return (
     <nav className="border-border/50 border-b py-2">
-      <div className="flex flex-wrap gap-1.5">
+      <div className="flex flex-wrap items-center gap-1.5">
         {tabs.map((tab) => {
           const Icon = tab.icon
           return (
@@ -62,6 +69,13 @@ export default function SessionTabs({
             </Link>
           )
         })}
+        {sessionName !== undefined && (
+          <SessionLastUploadChip
+            sessionCmId={sessionCmId}
+            agSessionCmIds={agSessionCmIds ?? []}
+            sessionName={sessionName}
+          />
+        )}
       </div>
     </nav>
   )

--- a/frontend/src/components/session/SessionUploadChangesModal.test.tsx
+++ b/frontend/src/components/session/SessionUploadChangesModal.test.tsx
@@ -1,10 +1,11 @@
 import { render, screen } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { ReactNode } from 'react'
 
+const auth = vi.hoisted(() => ({ isAuthLoading: false }))
 vi.mock('../../hooks/useApiWithAuth', () => ({
-  useApiWithAuth: () => ({ fetchWithAuth: vi.fn() }),
+  useApiWithAuth: () => ({ fetchWithAuth: vi.fn(), isAuthLoading: auth.isAuthLoading }),
 }))
 vi.mock('../../services/sessionUploadChanges', () => ({ fetchSessionUploadChanges: vi.fn() }))
 import { fetchSessionUploadChanges } from '../../services/sessionUploadChanges'
@@ -16,7 +17,28 @@ const wrapper = ({ children }: { children: ReactNode }) => (
 const mock = (rows: unknown) =>
   (fetchSessionUploadChanges as ReturnType<typeof vi.fn>).mockResolvedValue(rows)
 
+beforeEach(() => {
+  vi.clearAllMocks()
+  auth.isAuthLoading = false
+})
+
 describe('SessionUploadChangesModal', () => {
+  it('does not fetch while auth is still loading (frontend/CLAUDE.md auth gate)', async () => {
+    auth.isAuthLoading = true
+    mock([])
+    render(
+      <SessionUploadChangesModal
+        runId="r1"
+        sessionCmIds={[1000001]}
+        sessionName="Session 2"
+        onClose={() => {}}
+      />,
+      { wrapper }
+    )
+    await Promise.resolve()
+    expect(fetchSessionUploadChanges).not.toHaveBeenCalled()
+  })
+
   it('groups by camper and sorts needs-review first', async () => {
     mock([
       {

--- a/frontend/src/components/session/SessionUploadChangesModal.test.tsx
+++ b/frontend/src/components/session/SessionUploadChangesModal.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, it, expect, vi } from 'vitest'
+import type { ReactNode } from 'react'
+
+vi.mock('../../hooks/useApiWithAuth', () => ({
+  useApiWithAuth: () => ({ fetchWithAuth: vi.fn() }),
+}))
+vi.mock('../../services/sessionUploadChanges', () => ({ fetchSessionUploadChanges: vi.fn() }))
+import { fetchSessionUploadChanges } from '../../services/sessionUploadChanges'
+import SessionUploadChangesModal from './SessionUploadChangesModal'
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+)
+const mock = (rows: unknown) =>
+  (fetchSessionUploadChanges as ReturnType<typeof vi.fn>).mockResolvedValue(rows)
+
+describe('SessionUploadChangesModal', () => {
+  it('groups by camper and sorts needs-review first', async () => {
+    mock([
+      {
+        requester_cm_id: 1,
+        requester_name: 'Emma Johnson',
+        target_name: 'Olivia Chen',
+        request_type: 'bunk_with',
+        final_status: 'resolved',
+        session_cm_id: 1,
+      },
+      {
+        requester_cm_id: 2,
+        requester_name: 'Noah Smith',
+        target_name: 'Ethan',
+        request_type: 'not_bunk_with',
+        final_status: 'pending',
+        session_cm_id: 1,
+      },
+    ])
+    render(
+      <SessionUploadChangesModal
+        runId="r1"
+        sessionCmIds={[1]}
+        sessionName="Session 2"
+        onClose={() => {}}
+      />,
+      { wrapper }
+    )
+    const names = await screen.findAllByTestId('camper-group-name')
+    expect(names[0]).toHaveTextContent('Noah Smith') // pending sorted first
+    expect(screen.getByText(/needs review/i)).toBeInTheDocument()
+    expect(screen.getByText(/auto-matched/i)).toBeInTheDocument()
+  })
+
+  it('shows empty state when no rows', async () => {
+    mock([])
+    render(
+      <SessionUploadChangesModal
+        runId="r1"
+        sessionCmIds={[1]}
+        sessionName="Session 2"
+        onClose={() => {}}
+      />,
+      { wrapper }
+    )
+    expect(await screen.findByText(/no new requests/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/session/SessionUploadChangesModal.tsx
+++ b/frontend/src/components/session/SessionUploadChangesModal.tsx
@@ -25,7 +25,7 @@ export default function SessionUploadChangesModal({
   sessionName,
   onClose,
 }: Props) {
-  const { fetchWithAuth } = useApiWithAuth()
+  const { fetchWithAuth, isAuthLoading } = useApiWithAuth()
 
   const {
     data: rows = [],
@@ -34,6 +34,7 @@ export default function SessionUploadChangesModal({
   } = useQuery({
     queryKey: queryKeys.sessionUploadChanges(runId, sessionCmIds),
     queryFn: () => fetchSessionUploadChanges(runId, sessionCmIds, fetchWithAuth),
+    enabled: !isAuthLoading,
   })
 
   const byCamper = new Map<number, { name: string; rows: UploadChangeRow[] }>()

--- a/frontend/src/components/session/SessionUploadChangesModal.tsx
+++ b/frontend/src/components/session/SessionUploadChangesModal.tsx
@@ -6,6 +6,7 @@ import {
   fetchSessionUploadChanges,
   type UploadChangeRow,
 } from '../../services/sessionUploadChanges'
+import { queryKeys } from '../../utils/queryKeys'
 
 interface Props {
   runId: string
@@ -31,7 +32,7 @@ export default function SessionUploadChangesModal({
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ['sessionUploadChanges', runId, sessionCmIds],
+    queryKey: queryKeys.sessionUploadChanges(runId, sessionCmIds),
     queryFn: () => fetchSessionUploadChanges(runId, sessionCmIds, fetchWithAuth),
   })
 

--- a/frontend/src/components/session/SessionUploadChangesModal.tsx
+++ b/frontend/src/components/session/SessionUploadChangesModal.tsx
@@ -1,0 +1,96 @@
+import { useQuery } from '@tanstack/react-query'
+import { Loader2 } from 'lucide-react'
+import Modal from '../ui/Modal'
+import { useApiWithAuth } from '../../hooks/useApiWithAuth'
+import {
+  fetchSessionUploadChanges,
+  type UploadChangeRow,
+} from '../../services/sessionUploadChanges'
+
+interface Props {
+  runId: string
+  sessionCmIds: number[]
+  sessionName: string
+  onClose: () => void
+}
+
+function isReview(r: UploadChangeRow): boolean {
+  return r.final_status === 'pending'
+}
+
+export default function SessionUploadChangesModal({
+  runId,
+  sessionCmIds,
+  sessionName,
+  onClose,
+}: Props) {
+  const { fetchWithAuth } = useApiWithAuth()
+
+  const {
+    data: rows = [],
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['sessionUploadChanges', runId, sessionCmIds],
+    queryFn: () => fetchSessionUploadChanges(runId, sessionCmIds, fetchWithAuth),
+  })
+
+  const byCamper = new Map<number, { name: string; rows: UploadChangeRow[] }>()
+  for (const r of rows) {
+    const g = byCamper.get(r.requester_cm_id) ?? { name: r.requester_name, rows: [] }
+    g.rows.push(r)
+    byCamper.set(r.requester_cm_id, g)
+  }
+  const groups = [...byCamper.entries()]
+    .map(([cmId, g]) => ({ cmId, ...g }))
+    .sort((a, b) => {
+      const ar = a.rows.some(isReview) ? 0 : 1
+      const br = b.rows.some(isReview) ? 0 : 1
+      return ar - br
+    })
+
+  const isEmpty = !isLoading && !isError && groups.length === 0
+
+  return (
+    <Modal isOpen onClose={onClose} title={`What's new — ${sessionName}`} size="md" scrollable>
+      {isLoading && (
+        <div className="text-muted-foreground flex items-center justify-center gap-2 py-12">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading…
+        </div>
+      )}
+      {isError && <p className="text-destructive py-4 text-sm">Couldn't load upload changes.</p>}
+      {isEmpty && (
+        <p className="text-muted-foreground py-4 text-sm">No new requests for this session.</p>
+      )}
+      {!isLoading &&
+        !isError &&
+        groups.map((g) => (
+          <div key={g.cmId} className="mt-3">
+            <div data-testid="camper-group-name" className="text-sm font-bold">
+              {g.name}
+            </div>
+            {g.rows.map((r, i) => (
+              <div
+                key={i}
+                className="border-border/60 dark:border-border/40 flex items-center gap-2 border-b py-1.5 pl-6 text-sm"
+              >
+                <span className="flex-1">
+                  {r.target_name} · {r.request_type}
+                </span>
+                {isReview(r) ? (
+                  <span className="rounded-full border border-amber-200 bg-amber-50 px-2 text-xs font-bold text-amber-700 dark:border-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
+                    ⚠ needs review
+                  </span>
+                ) : (
+                  <span className="rounded-full border border-emerald-200 bg-emerald-50 px-2 text-xs font-bold text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300">
+                    ✓ auto-matched
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        ))}
+    </Modal>
+  )
+}

--- a/frontend/src/hooks/session/useLastUploadSummary.test.tsx
+++ b/frontend/src/hooks/session/useLastUploadSummary.test.tsx
@@ -3,7 +3,10 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { ReactNode } from 'react'
 
-vi.mock('../useApiWithAuth', () => ({ useApiWithAuth: () => ({ fetchWithAuth: vi.fn() }) }))
+const auth = vi.hoisted(() => ({ isAuthLoading: false }))
+vi.mock('../useApiWithAuth', () => ({
+  useApiWithAuth: () => ({ fetchWithAuth: vi.fn(), isAuthLoading: auth.isAuthLoading }),
+}))
 vi.mock('../../services/csvPipelineStatus', async () => {
   const actual = await vi.importActual<typeof import('../../services/csvPipelineStatus')>(
     '../../services/csvPipelineStatus'
@@ -28,9 +31,27 @@ const mockRun = (v: unknown) =>
 
 beforeEach(() => {
   vi.clearAllMocks()
+  auth.isAuthLoading = false
 })
 
 describe('useLastUploadSummary', () => {
+  it('does not fetch while auth is still loading (frontend/CLAUDE.md auth gate)', async () => {
+    auth.isAuthLoading = true
+    mockRun({
+      run_id: 'r1',
+      created: 't',
+      status_breakdown: { resolved: 5, pending: 0, declined: 0 },
+      session_breakdown: { '1000001': { resolved: 5, pending: 0, declined: 0 } },
+    })
+    const { result } = renderHook(() => useLastUploadSummary(1000001, []), {
+      wrapper: makeWrapper(),
+    })
+    // Let any (incorrectly) enabled query microtask flush.
+    await Promise.resolve()
+    expect(fetchLatestUploadRun).not.toHaveBeenCalled()
+    expect(result.current.runId).toBeNull()
+  })
+
   it('returns all-null while data is loading / no run returned', async () => {
     mockRun(null)
     const { result } = renderHook(() => useLastUploadSummary(1000001, []), {

--- a/frontend/src/hooks/session/useLastUploadSummary.test.tsx
+++ b/frontend/src/hooks/session/useLastUploadSummary.test.tsx
@@ -1,0 +1,143 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+
+vi.mock('../useApiWithAuth', () => ({ useApiWithAuth: () => ({ fetchWithAuth: vi.fn() }) }))
+vi.mock('../../services/csvPipelineStatus', async () => {
+  const actual = await vi.importActual<typeof import('../../services/csvPipelineStatus')>(
+    '../../services/csvPipelineStatus'
+  )
+  return { ...actual, fetchLatestUploadRun: vi.fn() }
+})
+
+import { fetchLatestUploadRun } from '../../services/csvPipelineStatus'
+import { useLastUploadSummary } from './useLastUploadSummary'
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+}
+
+const mockRun = (v: unknown) =>
+  (fetchLatestUploadRun as ReturnType<typeof vi.fn>).mockResolvedValue(v)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useLastUploadSummary', () => {
+  it('returns all-null while data is loading / no run returned', async () => {
+    mockRun(null)
+    const { result } = renderHook(() => useLastUploadSummary(1000001, []), {
+      wrapper: makeWrapper(),
+    })
+    await waitFor(() => expect(result.current.runId).toBeNull())
+    expect(result.current.finishedAt).toBeNull()
+    expect(result.current.global).toBeNull()
+    expect(result.current.session).toBeNull()
+  })
+
+  it('sums session cm_id + AG keys', async () => {
+    mockRun({
+      run_id: 'r1',
+      created: 't',
+      status_breakdown: { resolved: 20, pending: 3, declined: 1 },
+      session_breakdown: {
+        '1000001': { resolved: 8, pending: 2, declined: 0 },
+        '1000099': { resolved: 3, pending: 1, declined: 0 }, // AG-linked
+        '1000002': { resolved: 9, pending: 0, declined: 1 },
+      },
+    })
+    const { result } = renderHook(() => useLastUploadSummary(1000001, [1000099]), {
+      wrapper: makeWrapper(),
+    })
+    await waitFor(() => expect(result.current.session).not.toBeNull())
+    // 1000001: resolved 8, pending 2, declined 0 → autoMatched 8, needReview 2
+    // 1000099: resolved 3, pending 1, declined 0 → autoMatched 3, needReview 1
+    // sum: resolved 11, pending 3, declined 0 → autoMatched 11, needReview 3, total 14
+    expect(result.current.session).toEqual({ total: 14, autoMatched: 11, needReview: 3 })
+    // global: resolved 20, pending 3, declined 1 → autoMatched 21, needReview 3, total 24
+    expect(result.current.global).toEqual({ total: 24, autoMatched: 21, needReview: 3 })
+    expect(result.current.runId).toBe('r1')
+    expect(result.current.finishedAt).toBe('t')
+  })
+
+  it('returns null session slice when the session has no entries in session_breakdown', async () => {
+    mockRun({
+      run_id: 'r1',
+      created: 't',
+      status_breakdown: { resolved: 5, pending: 0, declined: 0 },
+      session_breakdown: { '1000002': { resolved: 5, pending: 0, declined: 0 } },
+    })
+    const { result } = renderHook(() => useLastUploadSummary(1000001, []), {
+      wrapper: makeWrapper(),
+    })
+    await waitFor(() => expect(result.current.runId).toBe('r1'))
+    expect(result.current.session).toBeNull()
+  })
+
+  it('returns null session when summed total is 0', async () => {
+    mockRun({
+      run_id: 'r1',
+      created: 't',
+      status_breakdown: { resolved: 5, pending: 0, declined: 0 },
+      session_breakdown: { '1000001': { resolved: 0, pending: 0, declined: 0 } },
+    })
+    const { result } = renderHook(() => useLastUploadSummary(1000001, []), {
+      wrapper: makeWrapper(),
+    })
+    await waitFor(() => expect(result.current.runId).toBe('r1'))
+    expect(result.current.session).toBeNull()
+  })
+
+  it('uses only sessionCmId when agSessionCmIds is empty', async () => {
+    mockRun({
+      run_id: 'r2',
+      created: 'ts2',
+      status_breakdown: { resolved: 10, pending: 1, declined: 2 },
+      session_breakdown: {
+        '1000001': { resolved: 6, pending: 1, declined: 2 },
+      },
+    })
+    const { result } = renderHook(() => useLastUploadSummary(1000001, []), {
+      wrapper: makeWrapper(),
+    })
+    await waitFor(() => expect(result.current.runId).toBe('r2'))
+    // resolved 6, pending 1, declined 2 → autoMatched 8, needReview 1, total 9
+    expect(result.current.session).toEqual({ total: 9, autoMatched: 8, needReview: 1 })
+  })
+
+  it('returns null session when sessionCmId is undefined', async () => {
+    mockRun({
+      run_id: 'r3',
+      created: 'ts3',
+      status_breakdown: { resolved: 5, pending: 0, declined: 0 },
+      session_breakdown: { '1000001': { resolved: 5, pending: 0, declined: 0 } },
+    })
+    const { result } = renderHook(() => useLastUploadSummary(undefined, []), {
+      wrapper: makeWrapper(),
+    })
+    await waitFor(() => expect(result.current.runId).toBe('r3'))
+    expect(result.current.session).toBeNull()
+  })
+
+  it('handles missing session_breakdown gracefully', async () => {
+    mockRun({
+      run_id: 'r4',
+      created: 'ts4',
+      status_breakdown: { resolved: 5, pending: 2, declined: 0 },
+      // no session_breakdown field
+    })
+    const { result } = renderHook(() => useLastUploadSummary(1000001, []), {
+      wrapper: makeWrapper(),
+    })
+    await waitFor(() => expect(result.current.runId).toBe('r4'))
+    expect(result.current.global).toEqual({ total: 7, autoMatched: 5, needReview: 2 })
+    expect(result.current.session).toBeNull()
+  })
+})

--- a/frontend/src/hooks/session/useLastUploadSummary.ts
+++ b/frontend/src/hooks/session/useLastUploadSummary.ts
@@ -1,0 +1,59 @@
+import { useQuery } from '@tanstack/react-query'
+import { useApiWithAuth } from '../useApiWithAuth'
+import {
+  fetchLatestUploadRun,
+  countsFromStatusBreakdown,
+  type UploadCounts,
+} from '../../services/csvPipelineStatus'
+import { queryKeys } from '../../utils/queryKeys'
+
+export interface LastUploadSummary {
+  runId: string | null
+  finishedAt: string | null
+  global: UploadCounts | null
+  session: UploadCounts | null
+}
+
+/**
+ * Returns the latest CSV-upload run's global + per-session "what's new" counts.
+ *
+ * The bunks page aggregates a session WITH its related AG (all-gender) sessions,
+ * which have distinct `session_cm_id`s — so this hook sums the viewed session's
+ * cm_id PLUS its AG session cm_ids out of `session_breakdown`.
+ *
+ * Returns `session: null` when none of those keys are present or the summed
+ * total is 0 (this drives "hide the chip when nothing new").
+ */
+export function useLastUploadSummary(
+  sessionCmId: number | undefined,
+  agSessionCmIds: number[] = []
+): LastUploadSummary {
+  const { fetchWithAuth } = useApiWithAuth()
+  const { data } = useQuery({
+    queryKey: queryKeys.lastUploadSummary(),
+    queryFn: () => fetchLatestUploadRun(fetchWithAuth),
+    staleTime: 30_000,
+  })
+
+  if (!data) return { runId: null, finishedAt: null, global: null, session: null }
+
+  const global = countsFromStatusBreakdown(data.status_breakdown)
+
+  const keys = [sessionCmId, ...agSessionCmIds].filter((k): k is number => typeof k === 'number')
+  const sb = data.session_breakdown ?? {}
+  const acc = { resolved: 0, pending: 0, declined: 0 }
+  let hit = false
+  for (const k of keys) {
+    const slice = sb[String(k)]
+    if (slice) {
+      hit = true
+      acc.resolved += slice.resolved
+      acc.pending += slice.pending
+      acc.declined += slice.declined
+    }
+  }
+  const sessionCounts = countsFromStatusBreakdown(acc)
+  const session = hit && sessionCounts.total > 0 ? sessionCounts : null
+
+  return { runId: data.run_id, finishedAt: data.created, global, session }
+}

--- a/frontend/src/hooks/session/useLastUploadSummary.ts
+++ b/frontend/src/hooks/session/useLastUploadSummary.ts
@@ -28,11 +28,12 @@ export function useLastUploadSummary(
   sessionCmId: number | undefined,
   agSessionCmIds: number[] = []
 ): LastUploadSummary {
-  const { fetchWithAuth } = useApiWithAuth()
+  const { fetchWithAuth, isAuthLoading } = useApiWithAuth()
   const { data } = useQuery({
     queryKey: queryKeys.lastUploadSummary(),
     queryFn: () => fetchLatestUploadRun(fetchWithAuth),
     staleTime: 30_000,
+    enabled: !isAuthLoading,
   })
 
   if (!data) return { runId: null, finishedAt: null, global: null, session: null }

--- a/frontend/src/services/csvPipelineStatus.test.ts
+++ b/frontend/src/services/csvPipelineStatus.test.ts
@@ -3,6 +3,8 @@ import {
   derivePhase,
   fetchSyncStatus,
   fetchLatestDebugRun,
+  countsFromStatusBreakdown,
+  fetchLatestUploadRun,
   type SyncJobStatus,
   type DebugPipelineRun,
 } from './csvPipelineStatus'
@@ -544,6 +546,59 @@ describe('fetchLatestDebugRun', () => {
     expect(res?.status_breakdown.resolved).toBe(200)
     expect(res?.status_breakdown.pending).toBe(12)
     expect(res?.status_breakdown.declined).toBe(8)
+  })
+})
+
+describe('countsFromStatusBreakdown', () => {
+  it('maps resolved+declined→autoMatched, pending→needReview', () => {
+    expect(countsFromStatusBreakdown({ resolved: 10, pending: 3, declined: 1 })).toEqual({
+      total: 14,
+      autoMatched: 11,
+      needReview: 3,
+    })
+  })
+})
+
+describe('fetchLatestUploadRun', () => {
+  it("filters trigger='upload' and requests session_breakdown", async () => {
+    const fetchWithAuth = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            run_id: 'r1',
+            created: 't',
+            status_breakdown: { resolved: 1, pending: 0, declined: 0 },
+            session_breakdown: {},
+          },
+        ],
+      }),
+    })
+    const run = await fetchLatestUploadRun(fetchWithAuth)
+    const url = fetchWithAuth.mock.calls[0]![0] as string
+    expect(url).toContain("trigger='upload'")
+    expect(url).toContain('session_breakdown')
+    expect(run?.run_id).toBe('r1')
+  })
+  it('returns null on non-ok response', async () => {
+    const fetchWithAuth = vi.fn().mockResolvedValue({ ok: false })
+    expect(await fetchLatestUploadRun(fetchWithAuth)).toBeNull()
+  })
+  it('returns null when status_breakdown is malformed (non-numeric counts)', async () => {
+    const fetchWithAuth = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            run_id: 'run-bad',
+            created: 't',
+            status_breakdown: { resolved: 'five', pending: 0, declined: 0 },
+            session_breakdown: {},
+          },
+        ],
+      }),
+    })
+    expect(await fetchLatestUploadRun(fetchWithAuth)).toBeNull()
   })
 })
 

--- a/frontend/src/services/csvPipelineStatus.test.ts
+++ b/frontend/src/services/csvPipelineStatus.test.ts
@@ -600,6 +600,49 @@ describe('fetchLatestUploadRun', () => {
     })
     expect(await fetchLatestUploadRun(fetchWithAuth)).toBeNull()
   })
+
+  it('drops malformed session_breakdown slices so counts never go NaN downstream', async () => {
+    const fetchWithAuth = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            run_id: 'r1',
+            created: 't',
+            status_breakdown: { resolved: 9, pending: 2, declined: 0 },
+            session_breakdown: {
+              '1000001': { resolved: 8, pending: 2, declined: 0 }, // valid
+              '1000002': { resolved: 'x', pending: 1, declined: 0 }, // malformed slice
+            },
+          },
+        ],
+      }),
+    })
+    const run = await fetchLatestUploadRun(fetchWithAuth)
+    expect(run?.session_breakdown).toEqual({
+      '1000001': { resolved: 8, pending: 2, declined: 0 },
+    })
+  })
+
+  it('preserves a well-formed session_breakdown unchanged', async () => {
+    const fetchWithAuth = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            run_id: 'r1',
+            created: 't',
+            status_breakdown: { resolved: 5, pending: 1, declined: 0 },
+            session_breakdown: { '1000001': { resolved: 5, pending: 1, declined: 0 } },
+          },
+        ],
+      }),
+    })
+    const run = await fetchLatestUploadRun(fetchWithAuth)
+    expect(run?.session_breakdown).toEqual({
+      '1000001': { resolved: 5, pending: 1, declined: 0 },
+    })
+  })
 })
 
 describe('derivePhase with production status_breakdown shape', () => {

--- a/frontend/src/services/csvPipelineStatus.ts
+++ b/frontend/src/services/csvPipelineStatus.ts
@@ -17,6 +17,8 @@ export interface DebugPipelineRun {
     pending: number
     declined: number
   }
+  trigger?: 'upload' | 'scheduled' | 'manual'
+  session_breakdown?: Record<string, { resolved: number; pending: number; declined: number }>
 }
 
 export type PipelinePhase =
@@ -133,15 +135,29 @@ export function derivePhase(
   return { phase: 'idle' }
 }
 
+export interface UploadCounts {
+  total: number
+  autoMatched: number
+  needReview: number
+}
+
+export function countsFromStatusBreakdown(b: {
+  resolved: number
+  pending: number
+  declined: number
+}): UploadCounts {
+  const autoMatched = b.resolved + b.declined
+  const needReview = b.pending
+  return { total: autoMatched + needReview, autoMatched, needReview }
+}
+
 function doneFromDebug(d: DebugPipelineRun): PipelinePhase {
-  const { resolved, pending, declined } = d.status_breakdown
-  const autoMatched = resolved + declined
-  const needReview = pending
+  const counts = countsFromStatusBreakdown(d.status_breakdown)
   return {
     phase: 'done',
     runId: d.run_id,
     finishedAt: d.created,
-    counts: { total: autoMatched + needReview, autoMatched, needReview },
+    counts,
   }
 }
 
@@ -232,4 +248,28 @@ export async function fetchLatestDebugRun(
     created: first.created,
     status_breakdown: { resolved: sb.resolved, pending: sb.pending, declined: sb.declined },
   }
+}
+
+export async function fetchLatestUploadRun(
+  fetchWithAuth: FetchWithAuth
+): Promise<DebugPipelineRun | null> {
+  const res = await fetchWithAuth(
+    "/api/collections/debug_pipeline_runs/records?filter=trigger='upload'&sort=-created&perPage=1&fields=run_id,created,status_breakdown,session_breakdown"
+  )
+  if (!res.ok) return null
+  const data = (await res.json()) as RawDebugListResponse
+  const first = data.items[0]
+  if (!first) return null
+  // Guard against malformed rows (schema mismatch, partial write). Without
+  // this, countsFromStatusBreakdown would compute NaN counts downstream.
+  const sb = first.status_breakdown
+  if (
+    !sb ||
+    typeof sb.resolved !== 'number' ||
+    typeof sb.pending !== 'number' ||
+    typeof sb.declined !== 'number'
+  ) {
+    return null
+  }
+  return first as DebugPipelineRun
 }

--- a/frontend/src/services/csvPipelineStatus.ts
+++ b/frontend/src/services/csvPipelineStatus.ts
@@ -219,8 +219,33 @@ type RawDebugListResponse = {
       pending?: unknown
       declined?: unknown
     }
-    session_breakdown?: Record<string, { resolved: number; pending: number; declined: number }>
+    // PB returns the JSON field as-is, so slice fields are validated at runtime
+    // (mirrors status_breakdown above) rather than trusted from the type.
+    session_breakdown?: Record<
+      string,
+      { resolved?: unknown; pending?: unknown; declined?: unknown }
+    >
   }>
+}
+
+// Keep only well-formed slices so a malformed entry can't propagate NaN into
+// the per-session counts that countsFromStatusBreakdown sums downstream.
+function sanitizeSessionBreakdown(
+  raw: RawDebugListResponse['items'][number]['session_breakdown']
+): DebugPipelineRun['session_breakdown'] {
+  if (!raw) return undefined
+  const out: Record<string, { resolved: number; pending: number; declined: number }> = {}
+  for (const [key, slice] of Object.entries(raw)) {
+    if (
+      slice &&
+      typeof slice.resolved === 'number' &&
+      typeof slice.pending === 'number' &&
+      typeof slice.declined === 'number'
+    ) {
+      out[key] = { resolved: slice.resolved, pending: slice.pending, declined: slice.declined }
+    }
+  }
+  return out
 }
 
 export async function fetchLatestDebugRun(
@@ -272,5 +297,12 @@ export async function fetchLatestUploadRun(
   ) {
     return null
   }
-  return first as DebugPipelineRun
+  const run: DebugPipelineRun = {
+    run_id: first.run_id,
+    created: first.created,
+    status_breakdown: { resolved: sb.resolved, pending: sb.pending, declined: sb.declined },
+  }
+  const sessionBreakdown = sanitizeSessionBreakdown(first.session_breakdown)
+  if (sessionBreakdown) run.session_breakdown = sessionBreakdown
+  return run
 }

--- a/frontend/src/services/csvPipelineStatus.ts
+++ b/frontend/src/services/csvPipelineStatus.ts
@@ -219,6 +219,7 @@ type RawDebugListResponse = {
       pending?: unknown
       declined?: unknown
     }
+    session_breakdown?: Record<string, { resolved: number; pending: number; declined: number }>
   }>
 }
 

--- a/frontend/src/services/sessionUploadChanges.test.ts
+++ b/frontend/src/services/sessionUploadChanges.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest'
+import { fetchSessionUploadChanges, type UploadChangeRow } from './sessionUploadChanges'
+
+describe('fetchSessionUploadChanges', () => {
+  it('filters by run_id and all session cm_ids', async () => {
+    const fetchWithAuth = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            requester_cm_id: 1,
+            requester_name: 'Emma Johnson',
+            target_name: 'Olivia Chen',
+            request_type: 'bunk_with',
+            final_status: 'resolved',
+            session_cm_id: 1000001,
+          },
+        ],
+      }),
+    })
+    const rows: UploadChangeRow[] = await fetchSessionUploadChanges(
+      'r1',
+      [1000001, 1000099],
+      fetchWithAuth
+    )
+    const call = fetchWithAuth.mock.calls[0]
+    const url = decodeURIComponent((call?.[0] ?? '') as string)
+    expect(url).toContain("run_id = 'r1'")
+    expect(url).toContain('session_cm_id = 1000001')
+    expect(url).toContain('session_cm_id = 1000099')
+    expect(rows[0]?.requester_name).toBe('Emma Johnson')
+  })
+
+  it('returns [] for empty sessionCmIds (no query)', async () => {
+    const fetchWithAuth = vi.fn()
+    expect(await fetchSessionUploadChanges('r1', [], fetchWithAuth)).toEqual([])
+    expect(fetchWithAuth).not.toHaveBeenCalled()
+  })
+
+  it('returns [] on non-ok response', async () => {
+    const fetchWithAuth = vi.fn().mockResolvedValue({ ok: false })
+    expect(await fetchSessionUploadChanges('r1', [1000001], fetchWithAuth)).toEqual([])
+  })
+})

--- a/frontend/src/services/sessionUploadChanges.ts
+++ b/frontend/src/services/sessionUploadChanges.ts
@@ -19,6 +19,8 @@ export async function fetchSessionUploadChanges(
   const filter = encodeURIComponent(`run_id = '${runId}' && (${sessionClause})`)
   const fields =
     'requester_cm_id,requester_name,target_name,request_type,final_status,session_cm_id'
+  // perPage=500 is a deliberate ceiling with no pagination — a session
+  // realistically produces ≤~100 new requests; >500 would silently truncate.
   const res = await fetchWithAuth(
     `/api/collections/debug_pipeline_summary/records?filter=${filter}&perPage=500&fields=${fields}`
   )

--- a/frontend/src/services/sessionUploadChanges.ts
+++ b/frontend/src/services/sessionUploadChanges.ts
@@ -1,0 +1,28 @@
+import type { FetchWithAuth } from './csvPipelineStatus'
+
+export interface UploadChangeRow {
+  requester_cm_id: number
+  requester_name: string
+  target_name: string
+  request_type: string
+  final_status: string
+  session_cm_id: number
+}
+
+export async function fetchSessionUploadChanges(
+  runId: string,
+  sessionCmIds: number[],
+  fetchWithAuth: FetchWithAuth
+): Promise<UploadChangeRow[]> {
+  if (sessionCmIds.length === 0) return []
+  const sessionClause = sessionCmIds.map((id) => `session_cm_id = ${id}`).join(' || ')
+  const filter = encodeURIComponent(`run_id = '${runId}' && (${sessionClause})`)
+  const fields =
+    'requester_cm_id,requester_name,target_name,request_type,final_status,session_cm_id'
+  const res = await fetchWithAuth(
+    `/api/collections/debug_pipeline_summary/records?filter=${filter}&perPage=500&fields=${fields}`
+  )
+  if (!res.ok) return []
+  const data = (await res.json()) as { items?: UploadChangeRow[] }
+  return data.items ?? []
+}

--- a/frontend/src/utils/queryKeys.test.ts
+++ b/frontend/src/utils/queryKeys.test.ts
@@ -120,3 +120,22 @@ describe('queryKeys.postCheck', () => {
     expect(full.slice(0, prefix.length)).toEqual([...prefix])
   })
 })
+
+describe('queryKeys.sessionUploadChanges', () => {
+  // Mirrors cohortBunkAssignments / campersForSession: array key segments are
+  // sorted so cache identity is stable regardless of caller-supplied order
+  // ([sessionCmId, ...agSessionCmIds] order can vary as AG links change).
+  it('is order-independent: same ids in different order produce equal keys', () => {
+    const a = queryKeys.sessionUploadChanges('r1', [1000001, 1000099])
+    const b = queryKeys.sessionUploadChanges('r1', [1000099, 1000001])
+    expect(a).toEqual(b)
+  })
+
+  it('pins the key shape: [sessionUploadChanges, runId, sortedIds]', () => {
+    expect(queryKeys.sessionUploadChanges('r1', [1000099, 1000001])).toEqual([
+      'sessionUploadChanges',
+      'r1',
+      [1000001, 1000099],
+    ])
+  })
+})

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -87,6 +87,8 @@ export const queryKeys = {
   syncStatusForService: (service: string) => ['sync-status', service] as const,
   csvPipelineStatus: () => ['csv-pipeline-status'] as const,
   lastUploadSummary: () => ['lastUploadSummary'] as const,
+  sessionUploadChanges: (runId: string, sessionCmIds: number[]) =>
+    ['sessionUploadChanges', runId, sessionCmIds] as const,
 
   // Users (Tier 2 - user data)
   users: () => ['users'] as const,

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -87,8 +87,10 @@ export const queryKeys = {
   syncStatusForService: (service: string) => ['sync-status', service] as const,
   csvPipelineStatus: () => ['csv-pipeline-status'] as const,
   lastUploadSummary: () => ['lastUploadSummary'] as const,
+  // sessionCmIds is sorted so cache identity is stable regardless of the
+  // caller's [sessionCmId, ...agSessionCmIds] order (matches cohortBunkAssignments).
   sessionUploadChanges: (runId: string, sessionCmIds: number[]) =>
-    ['sessionUploadChanges', runId, sessionCmIds] as const,
+    ['sessionUploadChanges', runId, sessionCmIds.toSorted((a, b) => a - b)] as const,
 
   // Users (Tier 2 - user data)
   users: () => ['users'] as const,

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -86,6 +86,7 @@ export const queryKeys = {
   syncStatus: () => ['sync-status'] as const,
   syncStatusForService: (service: string) => ['sync-status', service] as const,
   csvPipelineStatus: () => ['csv-pipeline-status'] as const,
+  lastUploadSummary: () => ['lastUploadSummary'] as const,
 
   // Users (Tier 2 - user data)
   users: () => ['users'] as const,


### PR DESCRIPTION
## What

The user-facing half of #1686 (**part 3 of 3**) — a persistent per-session "what's new since last upload" summary on the bunks page. Builds on PR #1691 (backend `trigger` + `session_breakdown`).

- **`useLastUploadSummary(sessionCmId, agSessionCmIds)`** — reads the latest `trigger='upload'` run, returns global + per-session counts. Sums the session's cm_id **plus its AG-linked session cm_ids** out of `session_breakdown`; returns `null` for the session slice when nothing new (drives the hide rule).
- **`SessionLastUploadChip`** — far right of the session tab-nav row (`📥 N new · ⚠ M review`). Hidden when nothing new for the session; the `⚠ review` segment only shows when needs-review > 0 (green-only otherwise).
- **`SessionUploadChangesModal`** — click the chip → impacted campers/requests for that session, grouped by camper, needs-review sorted to the top, status chips (⚠ needs review / ✓ auto-matched). All loading/error/empty/success states handled.
- Service layer: `fetchLatestUploadRun` + shared `countsFromStatusBreakdown` helper (`autoMatched=resolved+declined`, `needReview=pending`); `fetchSessionUploadChanges` queries `debug_pipeline_summary` by `run_id` + session cm_id(s).

The chip's counted sessions and the modal's queried sessions use the identical filter expression, so the drill-down always matches the headline counts.

## Testing (TDD)

- Service: fetcher filter/fields + malformed-row guard; counts mapping; changes-service PB filter spacing + empty/error guards.
- Hook: AG-session aggregation; null-slice when no entries or zero total; no-run → all null.
- Modal: group-by-camper, needs-review-first sort, all query states.
- Chip: hide when null/no-run, green-only when needReview=0, review segment when >0.
- `SessionTabs` mounts the chip; existing callers unaffected (props optional).
- Full mockable suite green; type-check clean.

Query keys centralized in `queryKeys.ts`; `fetchWithAuth` via `useApiWithAuth` throughout. Closes #1686.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a last upload status indicator in session tabs that displays the count of recent changes.
  * Added an upload changes modal that displays grouped upload requests with their review status (pending or auto-matched).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1692?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->