### PR TITLE
fix(sync): preserve hard staff/manual not_bunk_with separation through request dedup

### DIFF
--- a/api/routers/requests.py
+++ b/api/routers/requests.py
@@ -252,17 +252,17 @@ async def merge_requests(
             detail="All requests must be in the same session to merge",
         )
 
-    # Guard: a manual merge must not downgrade a hard not_bunk_with separation.
-    # Folding a HARD_MNT NBW (staff_not_bunk_with / manual) into a non-hard NBW
-    # (parent / notes) silently weakens an unconditional separation — mirror the
-    # auto-dedup partition (deduplicator.py) and refuse it here too.
+    # Guard: a hard staff/manual "do not bunk with" and a parent/notes "do not
+    # bunk with" for the same pair are kept as SEPARATE rows (mirrors the
+    # auto-dedup partition in deduplicator.py) so the hard separation is always
+    # preserved. Refuse a manual merge that would collapse them.
     if would_downgrade_hard_separation(requests_to_merge):
         raise HTTPException(
             status_code=400,
             detail=(
                 "Cannot merge a hard staff/manual 'do not bunk with' request with a "
-                "parent or notes request: merging would downgrade the hard separation. "
-                "Keep them as separate rows."
+                "parent or notes 'do not bunk with' for the same pair: they are kept "
+                "as separate rows to preserve the hard separation."
             ),
         )
 

--- a/api/routers/requests.py
+++ b/api/routers/requests.py
@@ -14,6 +14,7 @@ from bunking.auth_middleware import AuthUser
 from bunking.logging_config import get_logger
 from bunking.rbac.dependencies import require_permission
 from bunking.rbac.permissions import Permission
+from bunking.satisfaction.request_registry import would_downgrade_hard_separation
 from bunking.sync.bunk_request_processor.core.models import (
     BunkRequest,
     RequestType,
@@ -249,6 +250,20 @@ async def merge_requests(
         raise HTTPException(
             status_code=400,
             detail="All requests must be in the same session to merge",
+        )
+
+    # Guard: a manual merge must not downgrade a hard not_bunk_with separation.
+    # Folding a HARD_MNT NBW (staff_not_bunk_with / manual) into a non-hard NBW
+    # (parent / notes) silently weakens an unconditional separation — mirror the
+    # auto-dedup partition (deduplicator.py) and refuse it here too.
+    if would_downgrade_hard_separation(requests_to_merge):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Cannot merge a hard staff/manual 'do not bunk with' request with a "
+                "parent or notes request: merging would downgrade the hard separation. "
+                "Keep them as separate rows."
+            ),
         )
 
     # Find the request to keep

--- a/bunking/satisfaction/request_registry.py
+++ b/bunking/satisfaction/request_registry.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from bunking.sync.bunk_request_processor.core.models import RequestType
 from bunking.sync.bunk_request_processor.shared.constants import SourceField
@@ -181,7 +181,20 @@ def is_hard_separation(source_field: str, request_type: str) -> bool:
 
 class _SourcedRequest(Protocol):
     source_field: str
-    request_type: str
+    request_type: Any  # str or RequestType enum — normalised via _rtype_str()
+
+
+def _rtype_str(request_type: object) -> str:
+    """Normalise a request_type to its string value.
+
+    Accepts plain ``str`` (used in SimpleNamespace test fixtures) and enum
+    instances that carry a ``.value`` attribute (``RequestType`` from
+    ``bunk_request_processor.core.models``).
+    """
+    if isinstance(request_type, str):
+        return request_type
+    value = getattr(request_type, "value", None)
+    return value if isinstance(value, str) else str(request_type)
 
 
 def would_downgrade_hard_separation(requests: Iterable[_SourcedRequest]) -> bool:
@@ -191,7 +204,7 @@ def would_downgrade_hard_separation(requests: Iterable[_SourcedRequest]) -> bool
     Mirrors the auto-dedup partition: only fires when the set holds 2+
     not_bunk_with requests spanning the hard / non-hard boundary.
     """
-    nbw = [r for r in requests if str(r.request_type) == _NBW]
+    nbw = [r for r in requests if _rtype_str(r.request_type) == _NBW]
     if len(nbw) < 2:
         return False
     has_hard = any(is_hard_separation(r.source_field, _NBW) for r in nbw)

--- a/bunking/satisfaction/request_registry.py
+++ b/bunking/satisfaction/request_registry.py
@@ -26,9 +26,10 @@ import (raises if a source's rows disagree).
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from bunking.sync.bunk_request_processor.core.models import RequestType
 from bunking.sync.bunk_request_processor.shared.constants import SourceField
@@ -165,6 +166,37 @@ def report_group_for(source_field: str) -> RequestBucket:
 def rule_for(source_field: str, request_type: str) -> SolverRule:
     """Solver rule for a combo. SCAFFOLD — no consumer reads this yet."""
     return classify(source_field, request_type).rule
+
+
+def is_hard_separation(source_field: str, request_type: str) -> bool:
+    """True iff the combo is a HARD_MNT (unconditional) separation.
+
+    Wraps `rule_for`; off-axis combos not in the registry are treated as not hard.
+    """
+    try:
+        return rule_for(source_field, request_type) == SolverRule.HARD_MNT
+    except ValueError:
+        return False
+
+
+class _SourcedRequest(Protocol):
+    source_field: str
+    request_type: str
+
+
+def would_downgrade_hard_separation(requests: Iterable[_SourcedRequest]) -> bool:
+    """True iff merging this set would fold a HARD_MNT not_bunk_with into a
+    non-hard one — silently downgrading an unconditional separation.
+
+    Mirrors the auto-dedup partition: only fires when the set holds 2+
+    not_bunk_with requests spanning the hard / non-hard boundary.
+    """
+    nbw = [r for r in requests if str(r.request_type) == _NBW]
+    if len(nbw) < 2:
+        return False
+    has_hard = any(is_hard_separation(r.source_field, _NBW) for r in nbw)
+    has_non_hard = any(not is_hard_separation(r.source_field, _NBW) for r in nbw)
+    return has_hard and has_non_hard
 
 
 def weight_key_for(source_field: str, request_type: str) -> str | None:

--- a/bunking/satisfaction/request_registry.py
+++ b/bunking/satisfaction/request_registry.py
@@ -164,7 +164,9 @@ def report_group_for(source_field: str) -> RequestBucket:
 
 
 def rule_for(source_field: str, request_type: str) -> SolverRule:
-    """Solver rule for a combo. SCAFFOLD — no consumer reads this yet."""
+    """Solver rule for a combo. Consumed via `is_hard_separation` by the
+    dedup partition (`deduplicator.py`) and the merge guard
+    (`would_downgrade_hard_separation`)."""
     return classify(source_field, request_type).rule
 
 

--- a/bunking/sync/bunk_request_processor/processing/deduplicator.py
+++ b/bunking/sync/bunk_request_processor/processing/deduplicator.py
@@ -18,6 +18,10 @@ logger = get_logger(__name__)
 # Materiality model: admin authority / material parent intent > staff exclusion >
 # staff observation > immaterial parent input. Higher number = higher priority.
 # confidence_score breaks ties within rank.
+# NBW exception: this table does NOT decide hard vs. soft not_bunk_with merges —
+# those are partitioned by hardness before the tiebreak (see the "hard_mnt" slot
+# in deduplicate_batch), so a parent BUNK_REQUEST_FORM never absorbs a hard
+# STAFF_NOT_BUNK_WITH for the same pair despite outranking it here.
 SOURCE_FIELD_PRIORITY = {
     SourceField.MANUAL: 4,  # admin-UI staff entry (tied with bunk_with — both top-tier positive intent)
     SourceField.BUNK_REQUEST_FORM: 4,  # material parent
@@ -83,8 +87,10 @@ class DuplicateGroup:
 
     primary: BunkRequest
     duplicates: list[BunkRequest]
-    # Key: (requester_cm_id, requested_cm_id, request_type, source_field, year, session_cm_id)
-    # source_field is always "" — cross-field deduplication is intentional
+    # Key: (requester_cm_id, requested_cm_id, request_type, source_slot, year, session_cm_id)
+    # source_slot is "" for cross-field deduplication (intentional), except hard
+    # not_bunk_with rows (staff/manual) use "hard_mnt" to stay partitioned — see
+    # deduplicate_batch.
     duplicate_key: tuple[int, int | None, RequestType, str, int, int]
 
 

--- a/bunking/sync/bunk_request_processor/processing/deduplicator.py
+++ b/bunking/sync/bunk_request_processor/processing/deduplicator.py
@@ -146,11 +146,31 @@ class Deduplicator:
                 # Note: The DB unique constraint DOES include source_field. This in-batch
                 # dedup intentionally excludes it to merge cross-field duplicates before
                 # saving.
+                #
+                # NBW exception: a HARD_MNT separation (staff_not_bunk_with / manual) must
+                # NOT merge into a non-hard NBW (parent bunk_request_form = HARD_MSO, notes
+                # = SOFT) — display-priority would pick the parent source and silently
+                # downgrade the unconditional separation. Partition NBW dedup by hardness so
+                # the hard row survives independently. Hard rows still merge with each other
+                # (same "hard_mnt" slot); everything else merges as before.
+                #
+                # Late import to avoid circular dependency:
+                #   bunking.satisfaction.request_registry
+                #     → bunking.sync.bunk_request_processor.core.models
+                #     → bunking.sync.bunk_request_processor (package __init__)
+                #     → bunking.sync.bunk_request_processor.processing.deduplicator
+                from bunking.satisfaction.request_registry import is_hard_separation  # noqa: PLC0415
+
+                source_slot = ""
+                if request.request_type == RequestType.NOT_BUNK_WITH and is_hard_separation(
+                    request.source_field, request.request_type.value
+                ):
+                    source_slot = "hard_mnt"
                 key = (
                     request.requester_cm_id,
                     request.requested_cm_id,
                     request.request_type,
-                    "",  # Empty string placeholder to maintain tuple structure
+                    source_slot,
                     request.year,
                     request.session_cm_id,
                 )

--- a/bunking/sync/bunk_request_processor/processing/deduplicator.py
+++ b/bunking/sync/bunk_request_processor/processing/deduplicator.py
@@ -118,6 +118,13 @@ class Deduplicator:
         Returns:
             DeduplicationResult with kept requests and statistics
         """
+        # Late import to avoid circular dependency:
+        #   bunking.satisfaction.request_registry
+        #     → bunking.sync.bunk_request_processor.core.models
+        #     → bunking.sync.bunk_request_processor (package __init__)
+        #     → bunking.sync.bunk_request_processor.processing.deduplicator
+        from bunking.satisfaction.request_registry import is_hard_separation  # noqa: PLC0415
+
         # Group requests by duplicate key
         request_groups: dict[tuple[int, int | None, RequestType, str, int, int], list[BunkRequest]] = {}
 
@@ -153,14 +160,6 @@ class Deduplicator:
                 # downgrade the unconditional separation. Partition NBW dedup by hardness so
                 # the hard row survives independently. Hard rows still merge with each other
                 # (same "hard_mnt" slot); everything else merges as before.
-                #
-                # Late import to avoid circular dependency:
-                #   bunking.satisfaction.request_registry
-                #     → bunking.sync.bunk_request_processor.core.models
-                #     → bunking.sync.bunk_request_processor (package __init__)
-                #     → bunking.sync.bunk_request_processor.processing.deduplicator
-                from bunking.satisfaction.request_registry import is_hard_separation  # noqa: PLC0415
-
                 source_slot = ""
                 if request.request_type == RequestType.NOT_BUNK_WITH and is_hard_separation(
                     request.source_field, request.request_type.value

--- a/tests/unit/api/test_requests_merge_guard.py
+++ b/tests/unit/api/test_requests_merge_guard.py
@@ -1,0 +1,125 @@
+"""Router-level wiring tests for the NBW hard-separation merge guard.
+
+The pure predicate (`would_downgrade_hard_separation`) is unit-tested in
+tests/unit/bunking/satisfaction/test_request_registry.py. These tests assert
+the ENDPOINT wiring: `merge_requests` calls the predicate and raises 400 when a
+hard staff/manual not_bunk_with would be collapsed with a parent/notes
+not_bunk_with for the same pair, while a safe two-parent NBW merge is NOT
+blocked.
+
+The endpoint is an `async def`; we drive it directly via `asyncio.run(...)`,
+leaving the `user` param as its `Depends(...)` default (the guard never reads
+`user`). Module-level repository factories are monkeypatched to return Mocks so
+no PocketBase / network calls occur.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from fastapi import HTTPException
+
+import api.routers.requests as requests_router
+from api.routers.requests import MergeRequestsRequest, merge_requests
+
+
+def _nbw_record(
+    record_id: str,
+    source_field: str,
+    *,
+    requester_cm_id: int = 100,
+    requested_cm_id: int = 200,
+    session_cm_id: int = 1000002,
+    year: int = 2025,
+    confidence_score: float = 0.9,
+) -> SimpleNamespace:
+    """Fabricate a not_bunk_with bunk_request record with every field
+    `merge_requests` reads."""
+    return SimpleNamespace(
+        id=record_id,
+        requester_cm_id=requester_cm_id,
+        requested_cm_id=requested_cm_id,
+        session_cm_id=session_cm_id,
+        year=year,
+        request_type="not_bunk_with",
+        source_field=source_field,
+        source_fields=None,
+        confidence_score=confidence_score,
+        metadata={},
+        parse_notes=None,
+    )
+
+
+def _patch_repos(monkeypatch: pytest.MonkeyPatch, records: dict[str, SimpleNamespace]) -> tuple[Mock, Mock]:
+    """Monkeypatch the module-level repo factories; return (request_repo, source_link_repo) Mocks.
+
+    `get_by_id` resolves from the `records` map. Downstream mutation methods are
+    mocked generously so the negative test can run to completion.
+    """
+    request_repo = Mock()
+    request_repo.get_by_id.side_effect = lambda rid: records.get(rid)
+    request_repo.update_for_merge.return_value = None
+    request_repo.soft_delete_for_merge.return_value = True
+
+    source_link_repo = Mock()
+    # ensure_source_link_exists() short-circuits to True when this is truthy,
+    # so it never touches the global `pb`. A Mock() return value is truthy.
+    source_link_repo.get_sources_for_request.return_value = ["existing-link"]
+    source_link_repo.transfer_all_sources.return_value = None
+
+    monkeypatch.setattr(requests_router, "get_request_repository", lambda: request_repo)
+    monkeypatch.setattr(requests_router, "get_source_link_repository", lambda: source_link_repo)
+    return request_repo, source_link_repo
+
+
+_GUARD_MSG = "kept as separate rows to preserve the hard separation"
+
+
+def test_merge_blocks_parent_plus_staff_nbw(monkeypatch: pytest.MonkeyPatch) -> None:
+    """parent bunk_request_form NBW + staff_not_bunk_with NBW for the same pair
+    must be refused at the guard with a 400 carrying the guard message."""
+    records = {
+        "r1": _nbw_record("r1", "bunk_request_form", confidence_score=0.95),
+        "r2": _nbw_record("r2", "staff_not_bunk_with", confidence_score=0.80),
+    }
+    _patch_repos(monkeypatch, records)
+
+    body = MergeRequestsRequest(
+        request_ids=["r1", "r2"],
+        keep_target_from="r1",
+        final_type="not_bunk_with",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(merge_requests(body))
+
+    assert exc_info.value.status_code == 400
+    assert _GUARD_MSG in exc_info.value.detail
+
+
+def test_merge_allows_two_parent_nbw(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two parent bunk_request_form NBW records (both non-hard) must NOT trip the
+    guard — a safe merge proceeds without the guard's 400."""
+    records = {
+        "r1": _nbw_record("r1", "bunk_request_form", confidence_score=0.95),
+        "r2": _nbw_record("r2", "bunk_request_form", confidence_score=0.80),
+    }
+    _patch_repos(monkeypatch, records)
+
+    body = MergeRequestsRequest(
+        request_ids=["r1", "r2"],
+        keep_target_from="r1",
+        final_type="not_bunk_with",
+    )
+
+    # The guard must NOT fire for two non-hard parent NBW rows. If it (wrongly)
+    # raised, the detail would carry _GUARD_MSG; surface that as a clear failure.
+    try:
+        result = asyncio.run(merge_requests(body))
+    except HTTPException as exc:  # pragma: no cover - only on regression
+        guard_fired = _GUARD_MSG in exc.detail
+        pytest.fail(f"merge_requests raised HTTPException (guard_fired={guard_fired}): {exc.status_code} {exc.detail}")
+
+    # Completed without the guard firing — that's the contract.
+    assert result.merged_request_id == "r1"

--- a/tests/unit/bunking/satisfaction/test_request_registry.py
+++ b/tests/unit/bunking/satisfaction/test_request_registry.py
@@ -261,3 +261,64 @@ def test_every_weight_key_has_a_default() -> None:
 
     keys = {rc.weight_key for rc in request_registry._REGISTRY.values() if rc.weight_key is not None}
     assert keys <= set(request_registry._WEIGHT_DEFAULTS)
+
+
+from types import SimpleNamespace
+
+from bunking.satisfaction.request_registry import (
+    is_hard_separation,
+    would_downgrade_hard_separation,
+)
+
+
+class TestIsHardSeparation:
+    def test_staff_not_bunk_with_is_hard(self):
+        assert is_hard_separation(SourceField.STAFF_NOT_BUNK_WITH, "not_bunk_with") is True
+
+    def test_manual_not_bunk_with_is_hard(self):
+        assert is_hard_separation(SourceField.MANUAL, "not_bunk_with") is True
+
+    def test_parent_not_bunk_with_is_not_hard(self):
+        assert is_hard_separation(SourceField.BUNK_REQUEST_FORM, "not_bunk_with") is False
+
+    def test_notes_not_bunk_with_is_not_hard(self):
+        assert is_hard_separation(SourceField.BUNKING_NOTES, "not_bunk_with") is False
+        assert is_hard_separation(SourceField.INTERNAL_NOTES, "not_bunk_with") is False
+
+    def test_off_axis_combo_is_not_hard(self):
+        assert is_hard_separation(SourceField.SOCIALIZE_WITH, "not_bunk_with") is False
+
+
+def _r(source_field: str, request_type: str = "not_bunk_with") -> SimpleNamespace:
+    return SimpleNamespace(source_field=source_field, request_type=request_type)
+
+
+class TestWouldDowngradeHardSeparation:
+    def test_parent_plus_staff_nbw_downgrades(self):
+        assert (
+            would_downgrade_hard_separation([_r(SourceField.BUNK_REQUEST_FORM), _r(SourceField.STAFF_NOT_BUNK_WITH)])
+            is True
+        )
+
+    def test_parent_plus_manual_nbw_downgrades(self):
+        assert would_downgrade_hard_separation([_r(SourceField.BUNK_REQUEST_FORM), _r(SourceField.MANUAL)]) is True
+
+    def test_two_parent_nbw_no_downgrade(self):
+        assert (
+            would_downgrade_hard_separation([_r(SourceField.BUNK_REQUEST_FORM), _r(SourceField.BUNK_REQUEST_FORM)])
+            is False
+        )
+
+    def test_two_hard_nbw_no_downgrade(self):
+        assert would_downgrade_hard_separation([_r(SourceField.STAFF_NOT_BUNK_WITH), _r(SourceField.MANUAL)]) is False
+
+    def test_single_request_no_downgrade(self):
+        assert would_downgrade_hard_separation([_r(SourceField.STAFF_NOT_BUNK_WITH)]) is False
+
+    def test_non_nbw_requests_ignored(self):
+        assert (
+            would_downgrade_hard_separation(
+                [_r(SourceField.BUNK_REQUEST_FORM, "bunk_with"), _r(SourceField.STAFF_NOT_BUNK_WITH)]
+            )
+            is False
+        )

--- a/tests/unit/bunking/solver/constraints/test_staff_separation.py
+++ b/tests/unit/bunking/solver/constraints/test_staff_separation.py
@@ -214,6 +214,22 @@ def _age_pref(request_id: str, requester: int, source_field: str = "bunk_request
     )
 
 
+def test_parent_and_staff_nbw_coexist_separation_still_hard():
+    """Post-fix deduped shape: a parent HARD_MSO NBW and a staff HARD_MNT NBW for
+    the SAME pair both survive. The staff row must still force separation."""
+    from bunking.solver.constraints.staff_separation import add_staff_separation_constraints
+
+    ctx = _two_girls_two_bunks(
+        [
+            _nbw("n_parent", 100, 200, "bunk_request_form"),
+            _nbw("n_staff", 100, 200, "staff_not_bunk_with"),
+        ]
+    )
+    add_staff_separation_constraints(ctx)
+    _force_together(ctx, 100, 200)
+    assert is_infeasible(cp_model.CpSolver().Solve(ctx.model))
+
+
 def test_carveout_fires_when_sole_real_mp_is_bunk_with_and_age_pref_suppressed():
     """#1664: suppressed form age_preference does NOT inflate _possible_mp_count.
 

--- a/tests/unit/sync/bunk_request_processor/processing/test_deduplicator.py
+++ b/tests/unit/sync/bunk_request_processor/processing/test_deduplicator.py
@@ -546,7 +546,7 @@ class TestSimplifiedSourcePriority:
         """Create a Deduplicator without repository (batch-only dedup)"""
         return Deduplicator()
 
-    def test_family_over_staff_tiebreaker(self):
+    def test_parent_nbw_does_not_absorb_staff_nbw(self):
         """NBW hard-separation partition: parent bunk_request_form NBW and
         staff_not_bunk_with NBW for the same pair stay SEPARATE (not merged).
 
@@ -554,7 +554,6 @@ class TestSimplifiedSourcePriority:
         staff HARD_MNT was silently downgraded to parent HARD_MSO). The fix
         partitions dedup by hardness so both rows survive independently.
 
-        Test name preserved for CI stability; original rationale was FAMILY > STAFF (#1088).
         Cross-source merge still applies to other request types (bunk_with, etc.).
         """
         family_request = BunkRequest(

--- a/tests/unit/sync/bunk_request_processor/processing/test_deduplicator.py
+++ b/tests/unit/sync/bunk_request_processor/processing/test_deduplicator.py
@@ -547,13 +547,15 @@ class TestSimplifiedSourcePriority:
         return Deduplicator()
 
     def test_family_over_staff_tiebreaker(self):
-        """Test that bunk_with (material parent, rank 4) outranks not_bunk_with
-        (staff exclusion, rank 3) in dedup tiebreak (#1142 materiality model).
+        """NBW hard-separation partition: parent bunk_request_form NBW and
+        staff_not_bunk_with NBW for the same pair stay SEPARATE (not merged).
 
-        When same (requester, requestee, type, session, year) appears in both
-        bunk_with and not_bunk_with source_fields, bunk_with wins — material
-        parent intent is the highest-rank source_field. Test name preserved
-        for CI stability; original rationale was FAMILY > STAFF (#1088).
+        Before the 2026-05-27 fix this test asserted 1 kept row (the bug:
+        staff HARD_MNT was silently downgraded to parent HARD_MSO). The fix
+        partitions dedup by hardness so both rows survive independently.
+
+        Test name preserved for CI stability; original rationale was FAMILY > STAFF (#1088).
+        Cross-source merge still applies to other request types (bunk_with, etc.).
         """
         family_request = BunkRequest(
             requester_cm_id=12345,
@@ -586,11 +588,12 @@ class TestSimplifiedSourcePriority:
         deduplicator = Deduplicator()
         result = deduplicator.deduplicate_batch([family_request, staff_request])
 
-        # Family wins even with staff having a different source_field (source > confidence)
-        assert len(result.kept_requests) == 1
-        assert source_from_field(result.kept_requests[0].source_field) == "family"
-        assert result.kept_requests[0].source_field == "bunk_request_form"
-        assert result.statistics["duplicates_removed"] == 1
+        # Both survive: hard staff separation must not be downgraded to parent's HARD_MSO.
+        assert len(result.kept_requests) == 2
+        kept_fields = {r.source_field for r in result.kept_requests}
+        assert SourceField.STAFF_NOT_BUNK_WITH in kept_fields
+        assert "bunk_request_form" in kept_fields
+        assert result.statistics["duplicates_removed"] == 0
 
     def test_confidence_tiebreaker_same_source(self):
         """Test that confidence is tiebreaker when sources are equal.
@@ -1599,6 +1602,59 @@ class TestNotBunkWithHardSeparationPartition:
         kept_fields = {r.source_field for r in result.kept_requests}
         assert SourceField.STAFF_NOT_BUNK_WITH in kept_fields, "hard staff row must survive"
         assert SourceField.BUNK_REQUEST_FORM in kept_fields, "parent row must survive"
+
+    def test_manual_and_parent_nbw_kept_separate(self, deduplicator):
+        result = deduplicator.deduplicate_batch(
+            [
+                self._nbw(SourceField.BUNK_REQUEST_FORM, confidence=0.95),
+                self._nbw(SourceField.MANUAL, confidence=0.80),
+            ]
+        )
+        assert len(result.kept_requests) == 2
+        kept_fields = {r.source_field for r in result.kept_requests}
+        assert SourceField.MANUAL in kept_fields
+        assert SourceField.BUNK_REQUEST_FORM in kept_fields
+
+    def test_parent_and_notes_nbw_still_merge(self, deduplicator):
+        result = deduplicator.deduplicate_batch(
+            [
+                self._nbw(SourceField.BUNK_REQUEST_FORM, confidence=0.95),
+                self._nbw(SourceField.BUNKING_NOTES, confidence=0.80),
+            ]
+        )
+        assert len(result.kept_requests) == 1, "parent + soft note NBW must still merge"
+        assert result.kept_requests[0].source_field == SourceField.BUNK_REQUEST_FORM
+
+    def test_two_staff_nbw_still_merge(self, deduplicator):
+        result = deduplicator.deduplicate_batch(
+            [
+                self._nbw(SourceField.STAFF_NOT_BUNK_WITH, confidence=0.90),
+                self._nbw(SourceField.STAFF_NOT_BUNK_WITH, confidence=0.70),
+            ]
+        )
+        assert len(result.kept_requests) == 1
+        assert result.kept_requests[0].source_field == SourceField.STAFF_NOT_BUNK_WITH
+
+    def test_bunk_with_cross_source_unchanged(self, deduplicator):
+        def _bw(source_field: str, confidence: float) -> BunkRequest:
+            return BunkRequest(
+                requester_cm_id=100,
+                requested_cm_id=200,
+                request_type=RequestType.BUNK_WITH,
+                session_cm_id=1000002,
+                is_first_requested=False,
+                confidence_score=confidence,
+                source_field=source_field,
+                csv_position=0,
+                year=2025,
+                status=RequestStatus.RESOLVED,
+                metadata={},
+            )
+
+        result = deduplicator.deduplicate_batch(
+            [_bw(SourceField.BUNK_REQUEST_FORM, 0.95), _bw(SourceField.BUNKING_NOTES, 0.80)]
+        )
+        assert len(result.kept_requests) == 1
 
 
 if __name__ == "__main__":

--- a/tests/unit/sync/bunk_request_processor/processing/test_deduplicator.py
+++ b/tests/unit/sync/bunk_request_processor/processing/test_deduplicator.py
@@ -1562,5 +1562,44 @@ class TestFamilyParamountTiebreak:
         assert source_from_field(dropped[0].source_field) == "staff"
 
 
+class TestNotBunkWithHardSeparationPartition:
+    """NBW dedup must not fold a HARD_MNT (staff_not_bunk_with/manual) row into a
+    non-hard (parent/notes) row — that silently downgrades an unconditional
+    separation. See 2026-05-27-nbw-hard-separation-dedup-guard spec."""
+
+    @pytest.fixture
+    def deduplicator(self):
+        return Deduplicator(Mock())
+
+    def _nbw(self, source_field: str, confidence: float = 0.9) -> BunkRequest:
+        return BunkRequest(
+            requester_cm_id=100,
+            requested_cm_id=200,
+            request_type=RequestType.NOT_BUNK_WITH,
+            session_cm_id=1000002,
+            is_first_requested=False,
+            confidence_score=confidence,
+            source_field=source_field,
+            csv_position=0,
+            year=2025,
+            status=RequestStatus.RESOLVED,
+            metadata={},
+        )
+
+    def test_parent_and_staff_nbw_kept_separate(self, deduplicator):
+        result = deduplicator.deduplicate_batch(
+            [
+                self._nbw(SourceField.BUNK_REQUEST_FORM, confidence=0.95),
+                self._nbw(SourceField.STAFF_NOT_BUNK_WITH, confidence=0.80),
+            ]
+        )
+        assert len(result.kept_requests) == 2, (
+            f"parent + staff_not_bunk_with NBW must stay separate, got {len(result.kept_requests)}"
+        )
+        kept_fields = {r.source_field for r in result.kept_requests}
+        assert SourceField.STAFF_NOT_BUNK_WITH in kept_fields, "hard staff row must survive"
+        assert SourceField.BUNK_REQUEST_FORM in kept_fields, "parent row must survive"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

A `not_bunk_with` separation that staff explicitly marked **hard** could be silently downgraded to a soft, conditional preference by the request-dedup step — letting the solver place two campers together when staff (and a parent) explicitly forbade it.

When a parent `bunk_request_form` `not_bunk_with(X,Y)` and a `staff_not_bunk_with(X,Y)` named the same pair, the in-batch dedup key (which deliberately excludes `source_field`) merged them into one row, and the higher display-priority parent source won the survivor. That reclassified the rule from `HARD_MNT` (unconditional separation, enforced per-request by `staff_separation`) to `HARD_MSO` (conditional — only honored as one term in `parent_paramount`'s "satisfy ≥1 material-parent request" disjunction). So whenever X had any other satisfiable material-parent request (almost always), the solver could co-place X and Y for only a soft penalty. Untested before this PR.

## Root cause

`SOURCE_FIELD_PRIORITY` does two unrelated jobs with one ordering: display/material classification (parent > staff — correct) and constraint strength (for negatives, staff `HARD_MNT` is *stronger* than parent `HARD_MSO`). For `not_bunk_with` these point in opposite directions, and dedup let display-priority silently win.

## Fix

Scoped strictly to `request_type == not_bunk_with`:

- **Auto-dedup** (`deduplicator.py`): partition the NBW dedup key by whether the source is `HARD_MNT`, using the registry's own `rule_for(...)` (new `is_hard_separation` predicate). Hard sources (`staff_not_bunk_with`, `manual`) keep their own row; everything else merges as before. A parent + staff NBW now yields two rows — the hard staff row enforces unconditional separation, the parent row keeps its material-parent membership, and staff sees both.
- **Manual-merge endpoint** (`api/routers/requests.py`): the same partition is mirrored — `merge_requests` refuses to collapse a hard NBW with a non-hard NBW for the same pair (HTTP 400, explanatory message). Conservative by design (consistent with auto-dedup).

No schema change (the DB unique index already includes `source_field`). No solver-constraint changes — once both rows survive, existing per-row logic does the right thing.

## Tests (TDD)

- Registry predicates (`is_hard_separation`, `would_downgrade_hard_separation`) — unit.
- Dedup partition + regression guards (manual→2 rows, parent+soft-note→1, two-staff→1, `bunk_with`/`age_preference` unchanged).
- Solver coexistence — parent `HARD_MSO` + staff `HARD_MNT` for the same pair still forces separation.
- Router wiring — merge guard returns 400 on a hard+parent merge, allows a two-parent merge.

Full mockable suite: 5412 passed, 0 failed.

## Context

Surfaced from the #1542 investigation. #1542's three proposed layers (display fan-out, ingest dedup, solver double-weight) were confirmed non-issues; the real defect inside it was this hard-NBW dedup downgrade. (#1542 close to be decided separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed merge validation to prevent collapsing incompatible "do not bunk with" separation rules for the same pair, ensuring staff-managed and parent-managed requests remain as separate records instead of being incorrectly merged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->