### PR TITLE
refactor(solver,pb): collapse grade_ratio + age_grade_flow to constants (Phase 2)

### DIFF
--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -18,6 +18,7 @@ from bunking.satisfaction.predicate import is_request_satisfied
 from bunking.solver.constants import (
     DEFAULT_BUNK_CAPACITY,
     MAX_AGE_SPREAD_MONTHS,
+    MAX_SINGLE_GRADE_PERCENTAGE,
     MAX_UNIQUE_GRADES_PER_BUNK,
 )
 from bunking.solver.constraints.helpers import extract_bunk_level, get_level_order
@@ -1155,7 +1156,7 @@ class BunkingValidator:
         Note: AG (All-Gender) bunks are exempt from grade ratio checks since they
         intentionally have mixed ages/grades.
         """
-        max_percentage = 67  # Maximum percentage of any single grade in a bunk
+        max_percentage = MAX_SINGLE_GRADE_PERCENTAGE  # max % of any single grade in a bunk
 
         for bunk in bunks:
             # Skip AG bunks - they intentionally have mixed ages/grades

--- a/bunking/config/loader.py
+++ b/bunking/config/loader.py
@@ -381,14 +381,16 @@ class ConfigLoader:
             UnknownKeyError: If the resolved key is not in CONFIG_SCHEMA.
             MissingKeyError: If the required key is absent from the database.
         """
-        weight_mappings = {
-            # level_progression removed - uses no_regression_penalty via constraint module
-            # must_satisfy_one removed in Stage 4 (#1379) - replaced by hard MP constraint
-            # grade_spread removed in Phase 2 - replaced by hard MAX_UNIQUE_GRADES_PER_BUNK constant
-            # age_spread removed in Phase 2 - replaced by hard MAX_AGE_SPREAD_MONTHS constant
-            "age_grade_flow": "constraint.age_grade_flow.weight",
-            "grade_cohesion": "constraint.grade_cohesion.weight",
-        }
+        # Every prior mapping has been collapsed to a constant (or deleted as an
+        # orphan) across Phases 1-2. The mechanism is retained: any name falls
+        # through to ``constraint.<name>.weight`` and fails loudly if absent.
+        #   level_progression  - uses no_regression_penalty via constraint module
+        #   must_satisfy_one   - Stage 4 (#1379) hard MP constraint
+        #   grade_spread       - hard MAX_UNIQUE_GRADES_PER_BUNK constant
+        #   age_spread         - hard MAX_AGE_SPREAD_MONTHS constant
+        #   age_grade_flow     - AGE_GRADE_FLOW_WEIGHT constant
+        #   grade_cohesion     - orphan key, deleted (no consumer ever existed)
+        weight_mappings: dict[str, str] = {}
 
         key = weight_mappings.get(constraint_name, f"constraint.{constraint_name}.weight")
         return self.get_int(key)

--- a/bunking/config/schema.py
+++ b/bunking/config/schema.py
@@ -26,21 +26,10 @@ CONFIG_SCHEMA: dict[str, ConfigKey] = {
     # =========================================================================
     # SOLVER CONSTRAINTS - Grade Ratio
     # =========================================================================
-    "constraint.grade_ratio.max_percentage": ConfigKey(
-        key="constraint.grade_ratio.max_percentage",
-        config_type=ConfigType.INT,
-        required=True,
-        description="Maximum percentage of cabin that can be same grade",
-        min_value=0,
-        max_value=100,
-    ),
-    "constraint.grade_ratio.penalty": ConfigKey(
-        key="constraint.grade_ratio.penalty",
-        config_type=ConfigType.INT,
-        required=True,
-        description="Penalty for exceeding grade ratio limit",
-        min_value=0,
-    ),
+    # Phase 2 cleanup: constraint.grade_ratio.{max_percentage, penalty} were
+    # collapsed into bunking/solver/constants.py — MAX_SINGLE_GRADE_PERCENTAGE
+    # (=67) and GRADE_RATIO_PENALTY (=5000). Neither was ever tuned at runtime;
+    # the validator's parallel literal 67 now imports the same constant.
     # =========================================================================
     # SOLVER CONSTRAINTS - Grade Adjacency (HARD CONSTRAINT - no config needed)
     # =========================================================================
@@ -115,20 +104,11 @@ CONFIG_SCHEMA: dict[str, ConfigKey] = {
     # =========================================================================
     # SOLVER CONSTRAINTS - Age/Grade Flow
     # =========================================================================
-    "constraint.age_grade_flow.weight": ConfigKey(
-        key="constraint.age_grade_flow.weight",
-        config_type=ConfigType.INT,
-        required=True,
-        description="Weight for age/grade flow objective",
-        min_value=0,
-    ),
-    "constraint.grade_cohesion.weight": ConfigKey(
-        key="constraint.grade_cohesion.weight",
-        config_type=ConfigType.INT,
-        required=True,
-        description="Weight for keeping same-grade campers together",
-        min_value=0,
-    ),
+    # Phase 2 cleanup: constraint.age_grade_flow.weight was collapsed into
+    # AGE_GRADE_FLOW_WEIGHT (=300) in bunking/solver/constants.py (never tuned).
+    # constraint.grade_cohesion.weight was a confirmed orphan — no constraint
+    # module, evaluator, validator, or frontend ever read it — and was deleted
+    # outright (no constant).
     # Phase 2 cleanup (Grade Spread): constraint.grade_spread.{mode, penalty}
     # were removed in favor of MAX_UNIQUE_GRADES_PER_BUNK (=2) in
     # bunking/solver/constants.py. The soft constraint path was deleted; solver

--- a/bunking/solver/constants.py
+++ b/bunking/solver/constants.py
@@ -41,6 +41,16 @@ hatch via ``EDGE_AGE_OVERFLOW_PENALTY`` so a hard MSO chain into the top
 cabin remains feasible. ``constraint.age_spread.preferred_bonus`` is KEPT
 in the config as the lone tunable knob in this domain.
 
+Grade ratio + age/grade flow (Phase 2): collapsed four PB config rows — none
+ever tuned at runtime (live config DB: all four ``updated == created``) — into
+the three constants below. ``constraint.grade_ratio.max_percentage`` →
+``MAX_SINGLE_GRADE_PERCENTAGE`` (also dedups the parallel hardcode of ``67`` in
+``bunking_validator.py``); ``constraint.grade_ratio.penalty`` →
+``GRADE_RATIO_PENALTY``; ``constraint.age_grade_flow.weight`` →
+``AGE_GRADE_FLOW_WEIGHT``. The fourth, ``constraint.grade_cohesion.weight``, was
+a confirmed orphan (no constraint module, evaluator, validator, or frontend ever
+read it) and was deleted outright — no constant.
+
 If per-bunk variance is ever needed (e.g., a smaller specialty cabin), add a
 real ``max_size`` integer column on the ``bunks`` PocketBase collection with a
 sync path that populates it. That's a feature, not a refactor.
@@ -117,6 +127,29 @@ exceeds MAX_AGE_SPREAD_MONTHS. Not exposed as a config knob — fires only when 
 constraint (MSO, locked group) leaves no other option. Set above the typical soft-objective
 gains the solver would otherwise chase (bunk-with weights are in the hundreds to low
 thousands), so overflow never happens for non-structural reasons."""
+
+MAX_SINGLE_GRADE_PERCENTAGE = 67
+"""Soft cap: a multi-grade non-AG bunk is penalized when any single grade
+exceeds this percentage of the cabin. Read by the solver soft constraint
+(``grade_ratio.py``) and the board-side validator
+(``bunking_validator.py:_validate_grade_ratios``), which previously carried its
+own parallel literal ``67``. With grade_spread now a hard 2-unique-grades cap,
+this keeps a 2-grade bunk from going lopsided (e.g. 90/10). Never tuned at
+runtime; change via code PR if lopsided-bunk warnings become a recurring
+concern."""
+
+GRADE_RATIO_PENALTY = 5000
+"""Soft penalty per (grade × bunk) when ``MAX_SINGLE_GRADE_PERCENTAGE`` is
+exceeded. Sits in the soft-penalty band below the hard constraints — a real
+secondary penalty, not measured against any hard miss. Never tuned at runtime."""
+
+AGE_GRADE_FLOW_WEIGHT = 300
+"""Objective bonus weight nudging each camper toward the bunk whose target
+average grade best matches theirs (cross-bunk grade distribution shaping).
+Read by both the solver objective (``age_grade_flow.py``) and the post-solve
+mirror (``objective_evaluator._calculate_age_grade_flow``) — same constant so
+the displayed score can't drift from what the solver optimized. Bonus-only, no
+infeasibility risk. Never tuned at runtime."""
 
 # Partial cabin re-solve (#1609): per-assigned-camper bonus applied ONLY in partial
 # mode so the relaxed `<= 1` cardinality places everyone there's room for instead of

--- a/bunking/solver/constraints/age_grade_flow.py
+++ b/bunking/solver/constraints/age_grade_flow.py
@@ -18,6 +18,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 from bunking.logging_config import get_logger
+from bunking.solver.constants import AGE_GRADE_FLOW_WEIGHT
 
 from ..bunk_ordering import get_bunk_rank
 from .base import SolverContext
@@ -41,10 +42,8 @@ def add_age_grade_flow_objective(ctx: SolverContext, objective_terms: list[Any])
         ctx: Solver context with model, assignments, and mappings
         objective_terms: List to append bonus terms to
     """
-    # Check if age/grade flow is enabled in config
-    grade_target_weight = ctx.config.get_soft_constraint_weight("age_grade_flow")
-    if grade_target_weight <= 0:
-        return
+    # Hardcoded bonus weight (never tuned at runtime; > 0 so the path always runs).
+    grade_target_weight = AGE_GRADE_FLOW_WEIGHT
 
     logger.debug(f"Adding target grade distribution incentives (weight: {grade_target_weight})")
 

--- a/bunking/solver/constraints/grade_ratio.py
+++ b/bunking/solver/constraints/grade_ratio.py
@@ -2,7 +2,7 @@
 Grade Ratio Constraints - Limit single grade dominance in bunks.
 
 This is a soft constraint that penalizes bunks where a single grade
-makes up more than the configured percentage (default 67%) of the cabin.
+makes up more than ``MAX_SINGLE_GRADE_PERCENTAGE`` (67%) of the cabin.
 """
 
 from collections import defaultdict
@@ -10,7 +10,7 @@ from collections import defaultdict
 from ortools.sat.python import cp_model
 
 from bunking.logging_config import get_logger
-from bunking.solver.constants import DEFAULT_BUNK_CAPACITY
+from bunking.solver.constants import DEFAULT_BUNK_CAPACITY, GRADE_RATIO_PENALTY, MAX_SINGLE_GRADE_PERCENTAGE
 
 from .base import SolverContext
 from .helpers import get_eligible_campers_for_bunk, is_ag_session_bunk, should_exempt_edge_bunk_from_ratio
@@ -21,8 +21,9 @@ logger = get_logger(__name__)
 def add_grade_ratio_constraints(ctx: SolverContext) -> None:
     """Add soft constraints for grade ratio percentage within bunks.
 
-    Creates a penalty when a single grade makes up more than the configured
-    percentage (default 67%) of a cabin when the cabin has more than one grade.
+    Creates a penalty when a single grade makes up more than
+    ``MAX_SINGLE_GRADE_PERCENTAGE`` (67%) of a cabin when the cabin has more
+    than one grade.
 
     OPTIMIZED: Only considers campers eligible for each bunk,
     respecting session and gender boundaries.
@@ -31,10 +32,10 @@ def add_grade_ratio_constraints(ctx: SolverContext) -> None:
         logger.info("Grade ratio constraints DISABLED via debug settings")
         return
 
-    max_percentage = ctx.config.get_constraint("grade_ratio", "max_percentage", default=67) / 100.0
+    max_percentage = MAX_SINGLE_GRADE_PERCENTAGE / 100.0
 
-    # Get penalty weight for violations
-    penalty_weight = ctx.config.get_constraint("grade_ratio", "penalty", default=5000)
+    # Penalty weight for violations (hardcoded constant — never tuned at runtime).
+    penalty_weight = GRADE_RATIO_PENALTY
 
     # Standard capacity for edge exemption threshold calculation.
     # Hardcoded constant (Phase 2 cabin-capacity cleanup); previously read

--- a/bunking/solver/objective_evaluator.py
+++ b/bunking/solver/objective_evaluator.py
@@ -26,7 +26,7 @@ from bunking.config import ConfigLoader
 from bunking.logging_config import get_logger
 from bunking.satisfaction import weight_for
 from bunking.solver.bunk_ordering import get_bunk_rank
-from bunking.solver.constants import PREFERRED_BUNK_OCCUPANCY
+from bunking.solver.constants import AGE_GRADE_FLOW_WEIGHT, PREFERRED_BUNK_OCCUPANCY
 from bunking.solver.direct_solver import (
     BASE_REQUEST_WEIGHT,
     FIRST_REQUEST_MULTIPLIER,
@@ -293,10 +293,9 @@ class ObjectiveEvaluator:
 
         Exactly mirrors add_age_grade_flow_objective() logic.
         """
-        grade_target_weight = self.config.get_soft_constraint_weight("age_grade_flow")
-
-        if grade_target_weight <= 0:
-            return 0, {"enabled": False}
+        # Hardcoded bonus weight — same constant the solver objective reads, so
+        # the displayed score can't drift from what was optimized.
+        grade_target_weight = AGE_GRADE_FLOW_WEIGHT
 
         total_bonus = 0
         details: dict[str, Any] = {"enabled": True, "weight": grade_target_weight, "by_group": {}}

--- a/pocketbase/pb_migrations/1500000011_config.js
+++ b/pocketbase/pb_migrations/1500000011_config.js
@@ -182,8 +182,8 @@ migrate((app) => {
     // removed in Age Spread Phase 2 (collapsed to MAX_AGE_SPREAD_MONTHS and
     // PREFERRED_AGE_SPREAD_MONTHS). Only the bonus knob remains.
     'constraint.age_spread.preferred_bonus': 'Preferred Age Spread Bonus',
-    'constraint.grade_ratio.max_percentage': 'Max Single Grade Percentage',
-    'constraint.grade_ratio.penalty': 'Grade Ratio Violation Penalty',
+    // grade_ratio.{max_percentage, penalty} removed in Phase 2 — hardcoded as
+    // MAX_SINGLE_GRADE_PERCENTAGE / GRADE_RATIO_PENALTY in bunking/solver/constants.py.
 
     // Constraint Settings - Cabin Minimum Occupancy (Phase 2: min/preferred/
     // enabled/force_all_used collapsed to constants in bunking/solver/constants.py)
@@ -193,9 +193,8 @@ migrate((app) => {
     'constraint.level_progression.no_regression': 'Prevent Level Regression',
     'constraint.level_progression.no_regression_penalty': 'Regression Penalty',
 
-    // Constraint Settings - Flow & Cohesion
-    'constraint.age_grade_flow.weight': 'Age/Grade Flow Weight',
-    'constraint.grade_cohesion.weight': 'Grade Cohesion Weight',
+    // Flow & Cohesion removed in Phase 2 — age_grade_flow.weight hardcoded as
+    // AGE_GRADE_FLOW_WEIGHT; grade_cohesion.weight deleted (orphan, no consumer).
 
     // Objective Settings - Source Multipliers
     'objective.source_multipliers.share_bunk_with': 'Parent Request Importance',
@@ -247,8 +246,7 @@ migrate((app) => {
     // removed in Age Spread Phase 2 (collapsed to MAX_AGE_SPREAD_MONTHS and
     // PREFERRED_AGE_SPREAD_MONTHS).
     'constraint.age_spread.preferred_bonus': 'Objective bonus for each cabin within the preferred age spread. Higher = solver tries harder to form tight age groups.',
-    'constraint.grade_ratio.max_percentage': 'Maximum percentage of cabin that can be from a single grade',
-    'constraint.grade_ratio.penalty': 'Penalty weight for exceeding grade ratio limit',
+    // grade_ratio.{max_percentage, penalty} removed in Phase 2 (hardcoded constants).
 
     // Constraint Settings - Cabin Minimum Occupancy (Phase 2: only the
     // penalty weight is tunable; thresholds are constants in code)
@@ -258,9 +256,7 @@ migrate((app) => {
     'constraint.level_progression.no_regression': 'Prevent returning campers from being placed in lower level bunks than previous year',
     'constraint.level_progression.no_regression_penalty': 'Penalty weight for placing camper in lower level than previous year',
 
-    // Constraint Settings - Flow & Cohesion
-    'constraint.age_grade_flow.weight': 'Bonus weight for placing campers in bunks matching their target grade. Uses distribution-based targeting (not pairwise).',
-    'constraint.grade_cohesion.weight': 'Keep same grades together in adjacent cabins',
+    // Flow & Cohesion removed in Phase 2 (age_grade_flow hardcoded; grade_cohesion deleted).
 
     // Objective Settings - Source Multipliers
     'objective.source_multipliers.share_bunk_with': 'Weight multiplier for parent bunk requests (higher = more important)',
@@ -310,8 +306,7 @@ migrate((app) => {
     // spread.max_age_months + constraint.age_spread.{penalty, preferred_months}
     // removed in Age Spread Phase 2.
     'constraint.age_spread.preferred_bonus': 'age-grade',
-    'constraint.grade_ratio.max_percentage': 'age-grade',
-    'constraint.grade_ratio.penalty': 'age-grade',
+    // grade_ratio.{max_percentage, penalty} removed in Phase 2 (hardcoded constants).
     // Cabin Minimum Occupancy
     'constraint.cabin_minimum_occupancy.penalty': 'cabin-occupancy',
 
@@ -319,9 +314,8 @@ migrate((app) => {
     'constraint.level_progression.no_regression': 'level-progression',
     'constraint.level_progression.no_regression_penalty': 'level-progression',
 
-    // Flow & Cohesion
-    'constraint.age_grade_flow.weight': 'flow-cohesion',
-    'constraint.grade_cohesion.weight': 'flow-cohesion',
+    // Flow & Cohesion section removed in Phase 2 — age_grade_flow hardcoded,
+    // grade_cohesion deleted (orphan). The flow-cohesion section is dropped.
 
     // Request Weighting
     'objective.source_multipliers.share_bunk_with': 'request-weighting',
@@ -580,18 +574,9 @@ migrate((app) => {
   // Configuration definitions with metadata
   const configDefinitions = {
     // Constraint configurations
-    "constraint.grade_ratio.max_percentage": {
-      value: 67,
-      description: "Maximum percentage of any single grade in a multi-grade cabin",
-      min: 50,
-      max: 100
-    },
-    "constraint.grade_ratio.penalty": {
-      value: 5000,
-      description: "Penalty for grade ratio violations",
-      min: 0,
-      max: 50000
-    },
+    // constraint.grade_ratio.{max_percentage, penalty} removed in Phase 2 —
+    // hardcoded as MAX_SINGLE_GRADE_PERCENTAGE (67) / GRADE_RATIO_PENALTY (5000)
+    // in bunking/solver/constants.py. Neither was ever tuned at runtime.
 
     // Cabin minimum occupancy (Phase 2: only the penalty weight is tunable;
     // hard floor and preferred target are constants in bunking/solver/constants.py)
@@ -649,18 +634,9 @@ migrate((app) => {
       min: 0,
       max: 10000
     },
-    "constraint.age_grade_flow.weight": {
-      value: 300,
-      description: "Weight for age-grade flow constraint",
-      min: 0,
-      max: 10000
-    },
-    "constraint.grade_cohesion.weight": {
-      value: 5,
-      description: "Weight for grade cohesion in cabins",
-      min: 0,
-      max: 100
-    },
+    // constraint.age_grade_flow.weight removed in Phase 2 — hardcoded as
+    // AGE_GRADE_FLOW_WEIGHT (300). constraint.grade_cohesion.weight was a
+    // confirmed orphan (no consumer ever existed) and was deleted outright.
     // constraint.grade_spread.{mode, penalty} removed in Phase 2 cleanup.
     // Solver enforces MAX_UNIQUE_GRADES_PER_BUNK as a hard constraint; no
     // soft-mode toggle and no penalty knob.

--- a/pocketbase/pb_migrations/1500000012_config_sections.js
+++ b/pocketbase/pb_migrations/1500000012_config_sections.js
@@ -121,13 +121,10 @@ migrate((app) => {
       display_order: 6,
       expanded_by_default: false
     },
-    {
-      section_key: "flow-cohesion",
-      title: "Cabin Flow & Cohesion",
-      description: "Encourage logical cabin arrangements",
-      display_order: 7,
-      expanded_by_default: false
-    },
+    // "flow-cohesion" section removed in Grade Ratio Phase 2 — its only members
+    // (age_grade_flow.weight, grade_cohesion.weight) were hardcoded/deleted, so
+    // the section is empty. Drop migration 1500000112 removes the row from
+    // already-migrated DBs.
     {
       section_key: "request-weighting",
       title: "Request Source Importance",

--- a/pocketbase/pb_migrations/1500000112_drop_grade_ratio_config.js
+++ b/pocketbase/pb_migrations/1500000112_drop_grade_ratio_config.js
@@ -1,0 +1,184 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: drop the four dead Grade Ratio / Age-Grade Flow config rows and the
+ * now-empty "flow-cohesion" config_sections row.
+ *
+ * Phase 2 (Grade Ratio domain) collapsed — none ever tuned at runtime (live
+ * config DB: all four ``updated == created``):
+ *  - ``constraint.grade_ratio.max_percentage`` → ``MAX_SINGLE_GRADE_PERCENTAGE`` (67)
+ *  - ``constraint.grade_ratio.penalty``        → ``GRADE_RATIO_PENALTY`` (5000)
+ *  - ``constraint.age_grade_flow.weight``      → ``AGE_GRADE_FLOW_WEIGHT`` (300)
+ *  - ``constraint.grade_cohesion.weight``      → DELETED (confirmed orphan; no
+ *    constraint module, evaluator, validator, or frontend ever read it)
+ *
+ * into ``bunking/solver/constants.py``. The validator's parallel literal 67 now
+ * imports ``MAX_SINGLE_GRADE_PERCENTAGE``.
+ *
+ * The "flow-cohesion" config_sections row held only the two now-gone keys, so it
+ * is dropped too (an empty collapsible header otherwise lingers in the admin GUI).
+ *
+ * Idempotent: re-running after rows are gone is a no-op (findFirstRecordByFilter
+ * throws on no match; we swallow only the lookup, not the delete).
+ *
+ * Down-migration restores the four config rows with their original seeded values
+ * + metadata and re-creates the flow-cohesion section, so a rollback restores the
+ * pre-cleanup state and the admin GUI re-recognizes the rows.
+ */
+migrate(
+  (app) => {
+    // All four keys are 3-part (category=constraint, non-null subcategory).
+    const targets = [
+      { subcategory: "grade_ratio", config_key: "max_percentage" },
+      { subcategory: "grade_ratio", config_key: "penalty" },
+      { subcategory: "age_grade_flow", config_key: "weight" },
+      { subcategory: "grade_cohesion", config_key: "weight" },
+    ]
+    for (const t of targets) {
+      let record
+      try {
+        record = app.findFirstRecordByFilter(
+          "config",
+          `category = "constraint" && subcategory = "${t.subcategory}" && config_key = "${t.config_key}"`,
+        )
+      } catch {
+        // already gone — ignore (findFirstRecordByFilter throws on no match)
+      }
+      // Delete runs OUTSIDE the catch so real delete errors (permissions, FK,
+      // runtime) surface instead of being silently swallowed.
+      if (record) app.delete(record)
+    }
+
+    // Drop the now-empty "flow-cohesion" config_sections row.
+    let section
+    try {
+      section = app.findFirstRecordByFilter("config_sections", 'section_key = "flow-cohesion"')
+    } catch {
+      // already gone — ignore
+    }
+    if (section) app.delete(section)
+  },
+  (app) => {
+    // Down: re-create the four config rows with original seeded values + metadata
+    // from 1500000011_config.js so rollback restores the pre-cleanup state.
+    const configCollection = app.findCollectionByNameOrId("config")
+    const seeds = [
+      {
+        subcategory: "grade_ratio",
+        config_key: "max_percentage",
+        value: 67,
+        description: "Maximum percentage of any single grade in a multi-grade cabin",
+        metadata: {
+          data_type: "integer",
+          source: "default_config",
+          default_value: 67,
+          min_value: 50,
+          max_value: 100,
+          friendly_name: "Max Single Grade Percentage",
+          tooltip: "Maximum percentage of cabin that can be from a single grade",
+          section: "age-grade",
+          business_category: "solver",
+          component_type: "slider",
+          component_config: { min: 0, max: 100, step: 1, showValue: true, suffix: "%" },
+        },
+      },
+      {
+        subcategory: "grade_ratio",
+        config_key: "penalty",
+        value: 5000,
+        description: "Penalty for grade ratio violations",
+        metadata: {
+          data_type: "integer",
+          source: "default_config",
+          default_value: 5000,
+          min_value: 0,
+          max_value: 50000,
+          friendly_name: "Grade Ratio Violation Penalty",
+          tooltip: "Penalty weight for exceeding grade ratio limit",
+          section: "age-grade",
+          business_category: "solver",
+          component_type: "slider",
+          component_config: { min: 0, max: 10000, step: 100, showValue: true },
+        },
+      },
+      {
+        subcategory: "age_grade_flow",
+        config_key: "weight",
+        value: 300,
+        description: "Weight for age-grade flow constraint",
+        metadata: {
+          data_type: "integer",
+          source: "default_config",
+          default_value: 300,
+          min_value: 0,
+          max_value: 10000,
+          friendly_name: "Age/Grade Flow Weight",
+          tooltip:
+            "Bonus weight for placing campers in bunks matching their target grade. Uses distribution-based targeting (not pairwise).",
+          section: "flow-cohesion",
+          business_category: "solver",
+          component_type: "slider",
+          component_config: { min: 0, max: 10, step: 0.1, showValue: true, precision: 1 },
+        },
+      },
+      {
+        subcategory: "grade_cohesion",
+        config_key: "weight",
+        value: 5,
+        description: "Weight for grade cohesion in cabins",
+        metadata: {
+          data_type: "integer",
+          source: "default_config",
+          default_value: 5,
+          min_value: 0,
+          max_value: 100,
+          friendly_name: "Grade Cohesion Weight",
+          tooltip: "Keep same grades together in adjacent cabins",
+          section: "flow-cohesion",
+          business_category: "solver",
+          component_type: "slider",
+          component_config: { min: 0, max: 10, step: 0.1, showValue: true, precision: 1 },
+        },
+      },
+    ]
+
+    for (const seed of seeds) {
+      let existing
+      try {
+        existing = app.findFirstRecordByFilter(
+          "config",
+          `category = "constraint" && subcategory = "${seed.subcategory}" && config_key = "${seed.config_key}"`,
+        )
+      } catch {
+        existing = null
+      }
+      if (existing) continue
+
+      const record = new Record(configCollection)
+      record.set("category", "constraint")
+      record.set("subcategory", seed.subcategory)
+      record.set("config_key", seed.config_key)
+      record.set("value", seed.value)
+      record.set("description", seed.description)
+      record.set("metadata", seed.metadata)
+      app.save(record)
+    }
+
+    // Re-create the flow-cohesion section (original values from 1500000012).
+    let existingSection
+    try {
+      existingSection = app.findFirstRecordByFilter("config_sections", 'section_key = "flow-cohesion"')
+    } catch {
+      existingSection = null
+    }
+    if (!existingSection) {
+      const sectionsCollection = app.findCollectionByNameOrId("config_sections")
+      const section = new Record(sectionsCollection)
+      section.set("section_key", "flow-cohesion")
+      section.set("title", "Cabin Flow & Cohesion")
+      section.set("description", "Encourage logical cabin arrangements")
+      section.set("display_order", 7)
+      section.set("expanded_by_default", false)
+      app.save(section)
+    }
+  },
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,8 +158,6 @@ TEST_CONFIG = {
     # Spread validation
     "spread.max_age_months": 24,
     # Solver constraints
-    "constraint.grade_ratio.max_percentage": 67,
-    "constraint.grade_ratio.penalty": 1000,
     "constraint.age_spread.penalty": 1500,
     "constraint.must_satisfy_one.penalty": 100000,
     "constraint.level_progression.no_regression": 1,
@@ -168,8 +166,8 @@ TEST_CONFIG = {
     "constraint.cabin_capacity.standard": 12,
     "constraint.cabin_capacity.mode": "hard",
     "constraint.cabin_capacity.penalty": 3000,
-    "constraint.age_grade_flow.weight": 10,
-    "constraint.grade_cohesion.weight": 5,
+    # grade_ratio.{max_percentage, penalty}, age_grade_flow.weight, and
+    # grade_cohesion.weight removed in Grade Ratio Phase 2 (hardcoded/deleted).
     # Objective function weights
     "objective.source_multipliers.share_bunk_with": 1.75,
     "objective.source_multipliers.do_not_share_with": 1.5,
@@ -234,8 +232,7 @@ class MockConfigLoader:
     def get_soft_constraint_weight(self, constraint_name: str) -> int:
         weight_mappings = {
             # level_progression removed - uses no_regression_penalty, not progression_weight
-            "age_grade_flow": "constraint.age_grade_flow.weight",
-            "grade_cohesion": "constraint.grade_cohesion.weight",
+            # age_grade_flow / grade_cohesion removed in Grade Ratio Phase 2
             "age_spread": "constraint.age_spread.penalty",
             "must_satisfy_one": "constraint.must_satisfy_one.penalty",
         }

--- a/tests/unit/bunking/solver/conftest.py
+++ b/tests/unit/bunking/solver/conftest.py
@@ -10,6 +10,7 @@ from typing import Any, cast
 import pytest
 from ortools.sat.python import cp_model
 
+from bunking.config.errors import UnknownKeyError
 from bunking.models import RequestType
 from bunking.models_v2 import (
     DirectBunk,
@@ -112,6 +113,10 @@ class MinimalConfigLoader:
             # ``constraint.<name>.weight`` and fail loudly) is retained.
         }
         key = weight_mappings.get(constraint_name, f"constraint.{constraint_name}.weight")
+        # Mirror production: a missing key raises rather than silently returning
+        # 0, so a config-key regression can't slip through a constraint test.
+        if self.get(key) is None:
+            raise UnknownKeyError(f"Unknown config key: '{key}'")
         return self.get_int(key)
 
 

--- a/tests/unit/bunking/solver/conftest.py
+++ b/tests/unit/bunking/solver/conftest.py
@@ -54,11 +54,10 @@ class MinimalConfigLoader:
             "constraint.cabin_capacity.max": 14,
             "constraint.cabin_capacity.standard": 12,
             "constraint.cabin_capacity.penalty": 3000,
-            "constraint.grade_ratio.max_percentage": 67,
-            "constraint.grade_ratio.penalty": 1000,
+            # grade_ratio.{max_percentage, penalty} + age_grade_flow.weight
+            # removed in Grade Ratio Phase 2 (hardcoded constants).
             "constraint.age_spread.preferred_bonus": 0,
             "constraint.must_satisfy_one.penalty": 100000,
-            "constraint.age_grade_flow.weight": 10,
         }
         if overrides:
             self._defaults.update(overrides)
@@ -106,11 +105,11 @@ class MinimalConfigLoader:
         keep this dict in sync so test code can't silently pass on a key
         that production now resolves to ``UnknownKeyError``.
         """
-        weight_mappings = {
-            # age_spread, grade_spread, must_satisfy_one removed in Phase 2 —
-            # see ``bunking/config/loader.py`` for the production mapping.
-            "age_grade_flow": "constraint.age_grade_flow.weight",
-            "grade_cohesion": "constraint.grade_cohesion.weight",
+        weight_mappings: dict[str, str] = {
+            # age_spread, grade_spread, must_satisfy_one, age_grade_flow, and
+            # grade_cohesion all removed in Phase 2 — see ``bunking/config/loader.py``
+            # for the production mapping. The mechanism (fall through to
+            # ``constraint.<name>.weight`` and fail loudly) is retained.
         }
         key = weight_mappings.get(constraint_name, f"constraint.{constraint_name}.weight")
         return self.get_int(key)

--- a/tests/unit/bunking/solver/test_minimal_config_loader.py
+++ b/tests/unit/bunking/solver/test_minimal_config_loader.py
@@ -1,0 +1,21 @@
+"""Tests for the ``MinimalConfigLoader`` test double in ``conftest``.
+
+The mock must mirror production ``ConfigLoader.get_soft_constraint_weight``,
+which falls through to ``constraint.<name>.weight`` and raises
+``UnknownKeyError`` when that key is absent. A silent ``0`` would let a
+config-key regression pass unnoticed in constraint tests.
+"""
+
+import pytest
+
+from bunking.config.errors import UnknownKeyError
+
+from .conftest import MinimalConfigLoader
+
+
+def test_soft_constraint_weight_fails_loudly_on_unknown_key() -> None:
+    """An unmapped constraint resolves to ``constraint.<name>.weight`` and raises."""
+    loader = MinimalConfigLoader()
+
+    with pytest.raises(UnknownKeyError):
+        loader.get_soft_constraint_weight("age_grade_flow")

--- a/tests/unit/solver/test_grade_ratio_constant.py
+++ b/tests/unit/solver/test_grade_ratio_constant.py
@@ -1,0 +1,200 @@
+"""Pin the single source of truth for grade_ratio + age_grade_flow.
+
+Phase 2 (Grade Ratio domain) collapsed four PB config rows — none ever tuned at
+runtime (live config DB: all four ``updated == created``) — into hardcoded
+constants in ``bunking.solver.constants``:
+
+1. ``constraint.grade_ratio.max_percentage`` → ``MAX_SINGLE_GRADE_PERCENTAGE`` (67).
+   Dedups the parallel hardcode of ``67`` in ``bunking_validator.py``.
+2. ``constraint.grade_ratio.penalty`` → ``GRADE_RATIO_PENALTY`` (5000).
+3. ``constraint.age_grade_flow.weight`` → ``AGE_GRADE_FLOW_WEIGHT`` (300).
+4. ``constraint.grade_cohesion.weight`` → DELETED outright (confirmed orphan:
+   no constraint module, evaluator, validator, or frontend ever read it; only a
+   dead ``loader.py`` weight-mapping entry referenced the key).
+
+These tests make sure no consumer drifts back to reading a config key.
+"""
+
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SEED_MIGRATION = REPO_ROOT / "pocketbase" / "pb_migrations" / "1500000011_config.js"
+SECTIONS_MIGRATION = REPO_ROOT / "pocketbase" / "pb_migrations" / "1500000012_config_sections.js"
+DROP_MIGRATION = REPO_ROOT / "pocketbase" / "pb_migrations" / "1500000112_drop_grade_ratio_config.js"
+
+
+def _strip_js_comments(raw: str) -> str:
+    """Drop // line comments and /* */ block comments so historical breadcrumbs
+    naming a removed key don't count as live references."""
+    no_line = re.sub(r"//[^\n]*", "", raw)
+    return re.sub(r"/\*.*?\*/", "", no_line, flags=re.DOTALL)
+
+
+# --------------------------------------------------------------------------
+# Constants
+# --------------------------------------------------------------------------
+
+
+def test_constant_values() -> None:
+    """The three hardcoded values match the never-tuned seed values."""
+    from bunking.solver.constants import (
+        AGE_GRADE_FLOW_WEIGHT,
+        GRADE_RATIO_PENALTY,
+        MAX_SINGLE_GRADE_PERCENTAGE,
+    )
+
+    assert MAX_SINGLE_GRADE_PERCENTAGE == 67
+    assert GRADE_RATIO_PENALTY == 5000
+    assert AGE_GRADE_FLOW_WEIGHT == 300
+
+
+# --------------------------------------------------------------------------
+# Solver constraint modules read the constants, not config keys
+# --------------------------------------------------------------------------
+
+
+def test_grade_ratio_module_imports_constants() -> None:
+    """grade_ratio reads the constants, not ``get_constraint("grade_ratio", ...)``."""
+    from bunking.solver.constraints import grade_ratio as module
+
+    source = inspect.getsource(module)
+
+    assert 'get_constraint("grade_ratio"' not in source, (
+        "grade_ratio still reads grade_ratio config keys via get_constraint"
+    )
+    assert "MAX_SINGLE_GRADE_PERCENTAGE" in source
+    assert "GRADE_RATIO_PENALTY" in source
+
+
+def test_age_grade_flow_module_uses_constant() -> None:
+    """age_grade_flow reads ``AGE_GRADE_FLOW_WEIGHT``, not the soft-weight accessor."""
+    from bunking.solver.constraints import age_grade_flow as module
+
+    source = inspect.getsource(module)
+
+    assert 'get_soft_constraint_weight("age_grade_flow")' not in source, (
+        "age_grade_flow still reads the config key via get_soft_constraint_weight"
+    )
+    assert "AGE_GRADE_FLOW_WEIGHT" in source
+
+
+def test_objective_evaluator_age_grade_flow_uses_constant() -> None:
+    """The post-solve evaluator mirror reads the same constant (no drift)."""
+    from bunking.solver.objective_evaluator import ObjectiveEvaluator
+
+    source = inspect.getsource(ObjectiveEvaluator._calculate_age_grade_flow)
+
+    assert 'get_soft_constraint_weight("age_grade_flow")' not in source, (
+        "objective_evaluator still reads age_grade_flow via get_soft_constraint_weight"
+    )
+    assert "AGE_GRADE_FLOW_WEIGHT" in source
+
+
+# --------------------------------------------------------------------------
+# Loader weight-mappings drop the two dead entries
+# --------------------------------------------------------------------------
+
+
+def test_loader_weight_mappings_drop_age_grade_flow_and_grade_cohesion() -> None:
+    """No mapping for age_grade_flow / grade_cohesion — both are hardcoded/deleted.
+
+    The method itself stays (its fall-through-and-fail contract is exercised by
+    ``tests/config/test_loader.py``); only the two dead entries are removed.
+    """
+    from bunking.config.loader import ConfigLoader
+
+    source = inspect.getsource(ConfigLoader.get_soft_constraint_weight)
+    assert '"age_grade_flow"' not in source, "loader weight_mappings still references age_grade_flow"
+    assert '"grade_cohesion"' not in source, "loader weight_mappings still references grade_cohesion"
+
+
+# --------------------------------------------------------------------------
+# Validator uses the constant instead of a parallel literal 67
+# --------------------------------------------------------------------------
+
+
+def test_validator_grade_ratio_uses_constant() -> None:
+    """BunkingValidator's grade-ratio check imports the constant, not a literal 67."""
+    from bunking.bunking_validator import BunkingValidator
+
+    source = inspect.getsource(BunkingValidator._validate_grade_ratios)
+    assert "MAX_SINGLE_GRADE_PERCENTAGE" in source, (
+        "validator should import MAX_SINGLE_GRADE_PERCENTAGE, not hardcode 67"
+    )
+    assert "max_percentage = 67" not in source, "validator still hardcodes the literal 67"
+
+
+# --------------------------------------------------------------------------
+# Schema drops all four keys
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "deleted_key",
+    [
+        "constraint.grade_ratio.max_percentage",
+        "constraint.grade_ratio.penalty",
+        "constraint.age_grade_flow.weight",
+        "constraint.grade_cohesion.weight",
+    ],
+)
+def test_schema_drops_four_keys(deleted_key: str) -> None:
+    from bunking.config.schema import CONFIG_SCHEMA
+
+    assert deleted_key not in CONFIG_SCHEMA
+
+
+# --------------------------------------------------------------------------
+# Seed migration drops all four keys (live quoted entries only)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "deleted_key",
+    [
+        "constraint.grade_ratio.max_percentage",
+        "constraint.grade_ratio.penalty",
+        "constraint.age_grade_flow.weight",
+        "constraint.grade_cohesion.weight",
+    ],
+)
+def test_seed_migration_drops_four_keys(deleted_key: str) -> None:
+    cleaned = _strip_js_comments(SEED_MIGRATION.read_text(encoding="utf-8"))
+    for quote in ('"', "'"):
+        assert f"{quote}{deleted_key}{quote}" not in cleaned, f"seed migration still has a live {deleted_key} entry"
+
+
+def test_age_grade_flow_kept_keys_absent_but_age_spread_bonus_remains() -> None:
+    """Sanity: the lone-tunable from the Age Spread domain is untouched."""
+    from bunking.config.schema import CONFIG_SCHEMA
+
+    assert "constraint.age_spread.preferred_bonus" in CONFIG_SCHEMA
+
+
+# --------------------------------------------------------------------------
+# flow-cohesion section is removed (it had only the two now-gone keys)
+# --------------------------------------------------------------------------
+
+
+def test_config_sections_seed_drops_flow_cohesion() -> None:
+    cleaned = _strip_js_comments(SECTIONS_MIGRATION.read_text(encoding="utf-8"))
+    assert "flow-cohesion" not in cleaned, "config_sections seed still defines the flow-cohesion section (now empty)"
+
+
+# --------------------------------------------------------------------------
+# Drop migration cleans already-migrated DBs
+# --------------------------------------------------------------------------
+
+
+def test_drop_migration_exists_and_targets_keys_and_section() -> None:
+    assert DROP_MIGRATION.exists(), "drop migration 1500000112_drop_grade_ratio_config.js missing"
+    raw = DROP_MIGRATION.read_text(encoding="utf-8")
+    # Subcategory + config_key targets for the four config rows.
+    for sub in ("grade_ratio", "age_grade_flow", "grade_cohesion"):
+        assert sub in raw, f"drop migration does not target subcategory {sub}"
+    # The empty flow-cohesion section row is removed too.
+    assert "flow-cohesion" in raw, "drop migration does not remove the flow-cohesion section row"

--- a/tests/unit/solver/test_grade_ratio_constant.py
+++ b/tests/unit/solver/test_grade_ratio_constant.py
@@ -63,7 +63,7 @@ def test_grade_ratio_module_imports_constants() -> None:
 
     source = inspect.getsource(module)
 
-    assert 'get_constraint("grade_ratio"' not in source, (
+    assert re.search(r"get_constraint\(\s*['\"]grade_ratio['\"]", source) is None, (
         "grade_ratio still reads grade_ratio config keys via get_constraint"
     )
     assert "MAX_SINGLE_GRADE_PERCENTAGE" in source
@@ -76,7 +76,7 @@ def test_age_grade_flow_module_uses_constant() -> None:
 
     source = inspect.getsource(module)
 
-    assert 'get_soft_constraint_weight("age_grade_flow")' not in source, (
+    assert re.search(r"get_soft_constraint_weight\(\s*['\"]age_grade_flow['\"]", source) is None, (
         "age_grade_flow still reads the config key via get_soft_constraint_weight"
     )
     assert "AGE_GRADE_FLOW_WEIGHT" in source
@@ -88,7 +88,7 @@ def test_objective_evaluator_age_grade_flow_uses_constant() -> None:
 
     source = inspect.getsource(ObjectiveEvaluator._calculate_age_grade_flow)
 
-    assert 'get_soft_constraint_weight("age_grade_flow")' not in source, (
+    assert re.search(r"get_soft_constraint_weight\(\s*['\"]age_grade_flow['\"]", source) is None, (
         "objective_evaluator still reads age_grade_flow via get_soft_constraint_weight"
     )
     assert "AGE_GRADE_FLOW_WEIGHT" in source
@@ -108,8 +108,12 @@ def test_loader_weight_mappings_drop_age_grade_flow_and_grade_cohesion() -> None
     from bunking.config.loader import ConfigLoader
 
     source = inspect.getsource(ConfigLoader.get_soft_constraint_weight)
-    assert '"age_grade_flow"' not in source, "loader weight_mappings still references age_grade_flow"
-    assert '"grade_cohesion"' not in source, "loader weight_mappings still references grade_cohesion"
+    assert re.search(r"['\"]age_grade_flow['\"]", source) is None, (
+        "loader weight_mappings still references age_grade_flow"
+    )
+    assert re.search(r"['\"]grade_cohesion['\"]", source) is None, (
+        "loader weight_mappings still references grade_cohesion"
+    )
 
 
 # --------------------------------------------------------------------------
@@ -192,9 +196,19 @@ def test_config_sections_seed_drops_flow_cohesion() -> None:
 
 def test_drop_migration_exists_and_targets_keys_and_section() -> None:
     assert DROP_MIGRATION.exists(), "drop migration 1500000112_drop_grade_ratio_config.js missing"
-    raw = DROP_MIGRATION.read_text(encoding="utf-8")
+    # Strip comments so the header docstring (which names every key) can't satisfy
+    # these asserts — only executable target/seed entries should count.
+    cleaned = _strip_js_comments(DROP_MIGRATION.read_text(encoding="utf-8"))
     # Subcategory + config_key targets for the four config rows.
-    for sub in ("grade_ratio", "age_grade_flow", "grade_cohesion"):
-        assert sub in raw, f"drop migration does not target subcategory {sub}"
+    for sub, cfg_key in (
+        ("grade_ratio", "max_percentage"),
+        ("grade_ratio", "penalty"),
+        ("age_grade_flow", "weight"),
+        ("grade_cohesion", "weight"),
+    ):
+        assert re.search(
+            rf'subcategory:\s*"{sub}"\s*,\s*config_key:\s*"{cfg_key}"',
+            cleaned,
+        ), f"drop migration does not target {sub}.{cfg_key}"
     # The empty flow-cohesion section row is removed too.
-    assert "flow-cohesion" in raw, "drop migration does not remove the flow-cohesion section row"
+    assert 'section_key = "flow-cohesion"' in cleaned, "drop migration does not remove the flow-cohesion section row"


### PR DESCRIPTION
## Grade Ratio domain — solver-config Phase 2

Resolves the **Grade Ratio + Grade Cohesion + Age/Grade Flow** domain of the solver/admin-config cleanup ([#1218](https://github.com/adamflagg/kindred/issues/1218)). This domain was tabled pending the three upstream hard-collapse PRs (Cabin Min Occ #1331, Age Spread #1553, Grade Spread #1536) — all now shipped, so it was un-tabled and re-validated.

### Why these collapse
The live config DB shows **all four keys never GUI-tuned** (`updated == created` at seed). Calibration across all 183 config rows: 36 carry post-seed edits, but every one is runtime *data* (`budget.*`, `registration.*`, `session_availability.*`) — **zero `constraint.*` solver knobs have ever been tuned**. Matches the established hardcode-unless-tuned pattern from the prior Phase 2 PRs.

### Changes

**Hardcode** to `bunking/solver/constants.py`:
| Key | Constant | Value |
|---|---|---|
| `constraint.grade_ratio.max_percentage` | `MAX_SINGLE_GRADE_PERCENTAGE` | 67 |
| `constraint.grade_ratio.penalty` | `GRADE_RATIO_PENALTY` | 5000 |
| `constraint.age_grade_flow.weight` | `AGE_GRADE_FLOW_WEIGHT` | 300 |

**Delete** `constraint.grade_cohesion.weight` — confirmed orphan; no constraint module, evaluator, validator, or frontend ever read it (only a dead `loader.py` weight-mapping).

**Also:**
- Dedup the parallel literal `67` in `bunking_validator._validate_grade_ratios` (now imports the constant — second source of `67` eliminated).
- Drop both dead `get_soft_constraint_weight` mappings; the method's fall-through-and-fail contract is retained (still exercised by `tests/config/test_loader.py`).
- The post-solve `objective_evaluator` mirror reads the same `AGE_GRADE_FLOW_WEIGHT` constant, so the displayed score can't drift from what the solver optimized.
- Delete the now-empty `flow-cohesion` config_sections row (its only two members are gone).

### Why neither key went dead under the hard collapses
grade_spread is now a hard 2-unique-grades cap, so `grade_ratio`'s remaining job is keeping a 2-grade bunk from going lopsided (e.g. 90/10) — still a live secondary penalty. `age_grade_flow` is an orthogonal cross-bunk distribution bonus, also still live. Both are HARDCODE (not DELETE).

### Not needed
- **No feasibility-warning hook** — no hard-constraint change in this domain.
- **No `score_evaluator` coverage fix** — settled by precedent: #1536 deleted its grade_spread block and #1553 omitted age_spread, so a narrow headline score is intentional.

### Migration
`1500000112_drop_grade_ratio_config.js` drops the four config rows + flow-cohesion section from already-migrated DBs (base migrations `1500000011`/`1500000012` edited for fresh DBs). **Verified up/down round-trip against a real DB**: up deletes exactly the 4 rows + section; down restores all rows with correct values + metadata and re-creates the section; `age_spread.preferred_bonus` (the kept tunable) untouched.

### Test plan
- New `tests/unit/solver/test_grade_ratio_constant.py` (TDD spec, written first, verified red→green) — 17 tests pinning the constants, the read-site swaps, schema/seed/section removal, and the drop migration.
- Full mockable suite: **5372 passed**. mypy, ruff, pb-js-lint, type-check all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated grade-ratio and age/grade-flow tuning into fixed solver constants and removed related admin config knobs.
  * Age/grade flow incentive is now always applied, improving bunk assignment behavior.
* **Migrations**
  * Database seeds and UI metadata cleaned up to drop the removed constraint keys and the related section.
* **Tests**
  * New tests added to lock in the constant-driven behavior and migration/seed cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1695?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->