### PR TITLE
feat(solver,frontend): decouple allow_overflow from locked bunks

### DIFF
--- a/api/services/solver_runner.py
+++ b/api/services/solver_runner.py
@@ -199,13 +199,17 @@ async def run_solver_task_v2(
             )
             solver_input.lock_groups_data = lock_groups
 
+        # Overflow flag applies on every solve (Stream A): full solves can opt
+        # into 13-cap as an escape valve for INFEASIBLE rosters, not just
+        # partial re-solves with locked cabins.
+        solver_input.allow_overflow = allow_overflow
+
         # Partial cabin re-solve (#1609): freeze the selected cabins' current rosters.
         # Resolve occupants from existing_assignments BEFORE any respect_locks clearing so
         # the cabin lock is independent of the friend-group toggle.
         if locked_bunk_cm_ids:
             assignment_pairs = [(a.person_cm_id, a.bunk_cm_id) for a in solver_input.existing_assignments]
             solver_input.locked_bunks = resolve_locked_bunk_occupants(locked_bunk_cm_ids, assignment_pairs)
-            solver_input.allow_overflow = allow_overflow
 
         # If respect_locks is disabled, clear existing assignments and group locks
         # so the solver is free to reassign all campers from scratch

--- a/frontend/src/components/OptimizeBunksButton.test.tsx
+++ b/frontend/src/components/OptimizeBunksButton.test.tsx
@@ -23,8 +23,9 @@ function openDropdown() {
 }
 
 describe('OptimizeBunksButton — partial re-solve controls', () => {
-  // A. lockedCount=0 → main button text is "Optimize"; dropdown has NO "Allow up to 13" and NO scope line
-  it('A: shows "Optimize" when lockedCount=0 and dropdown has no overflow controls', () => {
+  // A. lockedCount=0 → main button text is "Optimize"; dropdown shows overflow
+  //    checkbox (Stream A — overflow available on every solve) but NO scope line.
+  it('A: shows "Optimize" when lockedCount=0; dropdown has overflow checkbox but no scope line', () => {
     render(<OptimizeBunksButton {...makeProps({ lockedCount: 0, unlockedCount: 0 })} />)
 
     // Main button text
@@ -33,8 +34,10 @@ describe('OptimizeBunksButton — partial re-solve controls', () => {
     // Open the dropdown
     openDropdown()
 
-    // No overflow checkbox and no scope line
-    expect(screen.queryByText(/allow up to 13/i)).not.toBeInTheDocument()
+    // Overflow checkbox IS present even with no locked bunks (Stream A)
+    expect(screen.getByText(/allow up to 13 per cabin/i)).toBeInTheDocument()
+
+    // Scope line still absent when nothing is locked
     expect(screen.queryByText(/locked \d+ · re-solving \d+/i)).not.toBeInTheDocument()
   })
 
@@ -64,6 +67,32 @@ describe('OptimizeBunksButton — partial re-solve controls', () => {
         {...makeProps({
           lockedCount: 3,
           unlockedCount: 5,
+          allowOverflow: false,
+          onAllowOverflowChange,
+        })}
+      />
+    )
+
+    openDropdown()
+
+    const overflowLabel = screen.getByText(/allow up to 13 per cabin/i)
+    const overflowCheckbox = overflowLabel
+      .closest('label')!
+      .querySelector('input[type="checkbox"]')!
+    fireEvent.click(overflowCheckbox)
+
+    expect(onAllowOverflowChange).toHaveBeenCalledWith(true)
+  })
+
+  // E. With lockedCount=0, clicking the overflow checkbox still calls onAllowOverflowChange(true)
+  //    (Stream A — overflow toggle works on full solves too).
+  it('E: clicking overflow checkbox calls onAllowOverflowChange(true) when lockedCount=0', () => {
+    const onAllowOverflowChange = vi.fn()
+    render(
+      <OptimizeBunksButton
+        {...makeProps({
+          lockedCount: 0,
+          unlockedCount: 0,
           allowOverflow: false,
           onAllowOverflowChange,
         })}

--- a/frontend/src/components/OptimizeBunksButton.tsx
+++ b/frontend/src/components/OptimizeBunksButton.tsx
@@ -139,7 +139,7 @@ export interface OptimizeBunksButtonProps {
   lockedCount?: number
   /** Number of unlocked cabins that will be re-solved */
   unlockedCount?: number
-  /** Whether to allow up to 13 campers per cabin during partial re-solve */
+  /** Whether to allow up to 13 campers per cabin */
   allowOverflow?: boolean
   /** Callback when allowOverflow toggle changes */
   onAllowOverflowChange?: (value: boolean) => void

--- a/frontend/src/components/OptimizeBunksButton.tsx
+++ b/frontend/src/components/OptimizeBunksButton.tsx
@@ -380,28 +380,26 @@ export default function OptimizeBunksButton({
                 </label>
               </div>
 
-              {/* Partial re-solve controls — only when cabins are locked */}
+              {/* Overflow checkbox — available on every solve (Stream A) */}
+              <div className="border-border border-t px-4 py-2.5">
+                <label className="flex cursor-pointer items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={allowOverflow}
+                    onChange={(e) => onAllowOverflowChange?.(e.target.checked)}
+                    className="accent-primary h-3.5 w-3.5 rounded"
+                  />
+                  <span className="text-muted-foreground text-xs">Allow up to 13 per cabin</span>
+                </label>
+              </div>
+
+              {/* Partial re-solve scope line — only when cabins are locked */}
               {lockedCount > 0 && (
-                <>
-                  <div className="border-border border-t px-4 py-2.5">
-                    <label className="flex cursor-pointer items-center gap-2">
-                      <input
-                        type="checkbox"
-                        checked={allowOverflow}
-                        onChange={(e) => onAllowOverflowChange?.(e.target.checked)}
-                        className="accent-primary h-3.5 w-3.5 rounded"
-                      />
-                      <span className="text-muted-foreground text-xs">
-                        Allow up to 13 per cabin
-                      </span>
-                    </label>
-                  </div>
-                  <div className="border-border border-t px-4 py-2">
-                    <p className="text-muted-foreground text-xs">
-                      {`Locked ${lockedCount} · Re-solving ${unlockedCount}`}
-                    </p>
-                  </div>
-                </>
+                <div className="border-border border-t px-4 py-2">
+                  <p className="text-muted-foreground text-xs">
+                    {`Locked ${lockedCount} · Re-solving ${unlockedCount}`}
+                  </p>
+                </div>
               )}
 
               {/* Footer hint */}

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -169,9 +169,7 @@ export default function SessionView() {
     fetchWithAuth,
     respectLocks,
     lockedBunkCmIds: lockedBunkCmIdsArray,
-    // Suppress overflow when nothing is locked in scope: stale-session locks
-    // would otherwise keep allowOverflow=true for a full (not partial) solve.
-    allowOverflow: lockedCount > 0 ? allowOverflow : false,
+    allowOverflow,
   })
 
   const { data: campers = [] } = useSessionCampers({

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -18,6 +18,7 @@ import {
   useBunkRequestsCount,
   useLockedBunks,
   useResetPartialResolveOnSessionChange,
+  useResetAllowOverflowOnUnlock,
 } from '../hooks/session'
 import { scopeLockedToBunks } from '../hooks/session/scopeLockedToBunks'
 import SolverProgressModal, { useSolverProgress } from './SolverProgressModal'
@@ -253,9 +254,14 @@ export default function SessionView() {
     }
   }, [session?.id, setLockGroupSessionPbId])
 
-  // Partial-resolve lock state is per-session; clear it when the session changes so
-  // stale locks/overflow never leak into a different session's solve (#1609).
+  // Locks and overflow are per-session ephemeral state; clear both when the
+  // session changes so they never leak into a different session's solve (#1609).
   useResetPartialResolveOnSessionChange(selectedSession, unlockAll, setAllowOverflow)
+
+  // When the user unlocks the last bunk in scope (lockedCount >0 → 0), reset
+  // overflow so a partial-re-solve opt-in doesn't silently carry into the
+  // next full solve. Toggling overflow at lockedCount=0 still sticks.
+  useResetAllowOverflowOnUnlock(lockedCount, setAllowOverflow)
 
   // #1310 — feed in-session campers into RequestReviewPanel as the seed for
   // its personMap. The panel only needs cm_id + first/last name + grade for

--- a/frontend/src/hooks/session/index.ts
+++ b/frontend/src/hooks/session/index.ts
@@ -50,3 +50,5 @@ export {
 export { useLockedBunks, type UseLockedBunksResult } from './useLockedBunks'
 
 export { useResetPartialResolveOnSessionChange } from './useResetPartialResolveOnSessionChange'
+
+export { useResetAllowOverflowOnUnlock } from './useResetAllowOverflowOnUnlock'

--- a/frontend/src/hooks/session/scopeLockedToBunks.test.ts
+++ b/frontend/src/hooks/session/scopeLockedToBunks.test.ts
@@ -6,7 +6,6 @@
  *  2. In-scope ids (present in bunks) are kept.
  *  3. Empty locked set → empty result.
  *  4. All stale → empty result.
- *  5. Overflow-gate derivation: overflow is suppressed when filteredLockedCount = 0.
  */
 import { describe, it, expect } from 'vitest'
 import { scopeLockedToBunks } from './scopeLockedToBunks'
@@ -47,23 +46,5 @@ describe('scopeLockedToBunks', () => {
     const locked = new Set([1000001]) as ReadonlySet<number>
     const result = scopeLockedToBunks(locked, bunks)
     expect(result).not.toBe(locked)
-  })
-
-  it('overflow-gate: filteredCount > 0 → allowOverflow passes through', () => {
-    // Caller pattern: lockedCount > 0 ? allowOverflow : false
-    const locked = new Set([1000001]) as ReadonlySet<number>
-    const result = scopeLockedToBunks(locked, bunks)
-    const filteredCount = result.size
-    const effectiveOverflow = filteredCount > 0 ? true : false
-    expect(effectiveOverflow).toBe(true)
-  })
-
-  it('overflow-gate: filteredCount = 0 → allowOverflow suppressed to false', () => {
-    // All ids are stale → no locks in scope → overflow must be false
-    const locked = new Set([9999]) as ReadonlySet<number>
-    const result = scopeLockedToBunks(locked, bunks)
-    const filteredCount = result.size
-    const effectiveOverflow = filteredCount > 0 ? true : false
-    expect(effectiveOverflow).toBe(false)
   })
 })

--- a/frontend/src/hooks/session/useResetAllowOverflowOnUnlock.test.ts
+++ b/frontend/src/hooks/session/useResetAllowOverflowOnUnlock.test.ts
@@ -1,0 +1,66 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useResetAllowOverflowOnUnlock } from './useResetAllowOverflowOnUnlock'
+
+describe('useResetAllowOverflowOnUnlock', () => {
+  it('does not reset on initial mount when lockedCount is 0 — user may have toggled overflow before locking anything', () => {
+    const setAllowOverflow = vi.fn()
+    renderHook(({ lockedCount }) => useResetAllowOverflowOnUnlock(lockedCount, setAllowOverflow), {
+      initialProps: { lockedCount: 0 },
+    })
+    expect(setAllowOverflow).not.toHaveBeenCalled()
+  })
+
+  it('does not reset on initial mount when lockedCount is >0', () => {
+    const setAllowOverflow = vi.fn()
+    renderHook(({ lockedCount }) => useResetAllowOverflowOnUnlock(lockedCount, setAllowOverflow), {
+      initialProps: { lockedCount: 3 },
+    })
+    expect(setAllowOverflow).not.toHaveBeenCalled()
+  })
+
+  it('does not reset when lockedCount transitions 0 -> N (locking starts)', () => {
+    const setAllowOverflow = vi.fn()
+    const { rerender } = renderHook(
+      ({ lockedCount }) => useResetAllowOverflowOnUnlock(lockedCount, setAllowOverflow),
+      { initialProps: { lockedCount: 0 } }
+    )
+    rerender({ lockedCount: 2 })
+    expect(setAllowOverflow).not.toHaveBeenCalled()
+  })
+
+  it('does not reset when lockedCount changes between two >0 values', () => {
+    const setAllowOverflow = vi.fn()
+    const { rerender } = renderHook(
+      ({ lockedCount }) => useResetAllowOverflowOnUnlock(lockedCount, setAllowOverflow),
+      { initialProps: { lockedCount: 2 } }
+    )
+    rerender({ lockedCount: 5 })
+    rerender({ lockedCount: 1 })
+    expect(setAllowOverflow).not.toHaveBeenCalled()
+  })
+
+  it('resets to false when lockedCount transitions >0 -> 0 (last bunk unlocked)', () => {
+    const setAllowOverflow = vi.fn()
+    const { rerender } = renderHook(
+      ({ lockedCount }) => useResetAllowOverflowOnUnlock(lockedCount, setAllowOverflow),
+      { initialProps: { lockedCount: 3 } }
+    )
+    rerender({ lockedCount: 0 })
+    expect(setAllowOverflow).toHaveBeenCalledTimes(1)
+    expect(setAllowOverflow).toHaveBeenCalledWith(false)
+  })
+
+  it('does not re-trigger when lockedCount stays at 0 after a reset', () => {
+    const setAllowOverflow = vi.fn()
+    const { rerender } = renderHook(
+      ({ lockedCount }) => useResetAllowOverflowOnUnlock(lockedCount, setAllowOverflow),
+      { initialProps: { lockedCount: 1 } }
+    )
+    rerender({ lockedCount: 0 })
+    expect(setAllowOverflow).toHaveBeenCalledTimes(1)
+    rerender({ lockedCount: 0 })
+    expect(setAllowOverflow).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/hooks/session/useResetAllowOverflowOnUnlock.ts
+++ b/frontend/src/hooks/session/useResetAllowOverflowOnUnlock.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Resets `allowOverflow` to false on the >0 → 0 lockedCount transition
+ * (the user just unlocked the last bunk in scope). Preserves the user's
+ * toggle in every other case — staying at 0, 0 → N, or N → M — so flipping
+ * overflow on at lockedCount=0 sticks across full solves.
+ */
+export function useResetAllowOverflowOnUnlock(
+  lockedCount: number,
+  setAllowOverflow: (v: boolean) => void
+) {
+  const prevLockedCountRef = useRef(lockedCount)
+  useEffect(() => {
+    const prev = prevLockedCountRef.current
+    prevLockedCountRef.current = lockedCount
+    if (prev > 0 && lockedCount === 0) {
+      setAllowOverflow(false)
+    }
+  }, [lockedCount, setAllowOverflow])
+}

--- a/tests/unit/api/test_solver_runner_respect_locks.py
+++ b/tests/unit/api/test_solver_runner_respect_locks.py
@@ -1,6 +1,11 @@
 import inspect
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+import api.services.solver_runner as sr_module
 from api.services.solver_runner import run_solver_task_v2
+from bunking.models_v2 import DirectSolverInput
 
 
 def test_run_solver_task_v2_accepts_respect_locks():
@@ -18,3 +23,97 @@ def test_run_solver_task_v2_accepts_partial_resolve_params():
     assert sig.parameters["locked_bunk_cm_ids"].default is None
     assert "allow_overflow" in sig.parameters
     assert sig.parameters["allow_overflow"].default is False
+
+
+class TestAllowOverflowPropagation:
+    """allow_overflow must reach solver_input on every code path (Stream A)."""
+
+    @pytest.fixture
+    def mock_solver_input(self):
+        return DirectSolverInput(persons=[], requests=[], bunks=[])
+
+    def _setup_mocks(self, mock_solver_input):
+        mock_runs: dict[str, dict[str, object]] = {}
+        patches = {
+            "fetch_session_data_v2": patch.object(sr_module, "fetch_session_data_v2", new_callable=AsyncMock),
+            "fetch_historical_bunking": patch.object(sr_module, "fetch_historical_bunking", new_callable=AsyncMock),
+            "prepare_direct_solver_input": patch.object(sr_module, "prepare_direct_solver_input"),
+            "fetch_lock_groups": patch.object(sr_module, "fetch_lock_groups", new_callable=AsyncMock),
+            "ConfigLoader": patch.object(sr_module, "ConfigLoader"),
+            "DirectBunkingSolver": patch.object(sr_module, "DirectBunkingSolver"),
+            "PocketBase": patch.object(sr_module, "PocketBase"),
+            "get_settings": patch.object(sr_module, "get_settings"),
+            "solver_runs": patch.object(sr_module, "solver_runs", mock_runs),
+        }
+        return patches, mock_runs
+
+    def _configure_mocks(self, mocks, mock_solver_input):
+        mocks["fetch_session_data_v2"].return_value = ([], [], [], [], [])
+        mocks["fetch_historical_bunking"].return_value = []
+        mocks["prepare_direct_solver_input"].return_value = mock_solver_input
+
+        mock_pb_instance = MagicMock()
+        mock_pb_instance.collection.return_value.auth_with_password.return_value = {}
+        mock_pb_instance.collection.return_value.create.return_value = MagicMock(id="pb_record_123")
+        mocks["PocketBase"].return_value = mock_pb_instance
+
+        mocks["ConfigLoader"].get_instance.return_value = MagicMock()
+
+        mock_solver = MagicMock()
+        mock_result = MagicMock()
+        mock_result.assignments = []
+        mock_result.stats = {"status": "OPTIMAL", "solve_time": 5.0}
+        mock_result.satisfied_requests = {}
+        mock_solver.solve.return_value = mock_result
+        mocks["DirectBunkingSolver"].return_value = mock_solver
+
+        mocks["get_settings"].return_value = MagicMock(
+            pocketbase_admin_email="admin@camp.local",
+            pocketbase_admin_password="pass",
+        )
+
+    @pytest.mark.asyncio
+    async def test_allow_overflow_propagates_without_locked_bunks(self, mock_solver_input):
+        """allow_overflow=True must reach solver_input.allow_overflow even when
+        locked_bunk_cm_ids is None (Stream A — full-solve overflow path)."""
+        patches, mock_runs = self._setup_mocks(mock_solver_input)
+
+        with (
+            patches["fetch_session_data_v2"] as m1,
+            patches["fetch_historical_bunking"] as m2,
+            patches["prepare_direct_solver_input"] as m3,
+            patches["fetch_lock_groups"] as m4,
+            patches["ConfigLoader"] as m5,
+            patches["DirectBunkingSolver"] as m6,
+            patches["PocketBase"] as m7,
+            patches["get_settings"] as m8,
+            patches["solver_runs"],
+        ):
+            mocks = {
+                "fetch_session_data_v2": m1,
+                "fetch_historical_bunking": m2,
+                "prepare_direct_solver_input": m3,
+                "fetch_lock_groups": m4,
+                "ConfigLoader": m5,
+                "DirectBunkingSolver": m6,
+                "PocketBase": m7,
+                "get_settings": m8,
+            }
+            self._configure_mocks(mocks, mock_solver_input)
+            mock_runs["test_run"] = {"status": "pending"}
+
+            await sr_module.run_solver_task_v2(
+                run_id="test_run",
+                session_cm_id=100,
+                year=2026,
+                time_limit=60,
+                locked_bunk_cm_ids=None,
+                allow_overflow=True,
+            )
+
+            # DirectBunkingSolver is invoked with `input_data=solver_input` — that's
+            # the captured DirectSolverInput post-mutation. allow_overflow must
+            # reflect the parameter passed to run_solver_task_v2.
+            assert mocks["DirectBunkingSolver"].call_count == 1
+            passed_input = mocks["DirectBunkingSolver"].call_args.kwargs["input_data"]
+            assert passed_input.allow_overflow is True


### PR DESCRIPTION
## Summary

- Hoists `solver_input.allow_overflow = allow_overflow` out of the `if locked_bunk_cm_ids:` gate in `api/services/solver_runner.py` so the flag is honored on every solve.
- Splits the optimize-dropdown gated block in `OptimizeBunksButton.tsx`: the "Allow up to 13 per cabin" checkbox renders unconditionally; the "Locked N · Re-solving M" scope line stays gated on `lockedCount > 0`.
- Drops the `lockedCount > 0 ? allowOverflow : false` suppression in `SessionView.tsx` and the two `overflow-gate` tests in `scopeLockedToBunks.test.ts` that encoded the old behavior.

## Why

Stream B (#1696) made the solver always require every working-set camper to be placed; rosters that can't fit under hard constraints now return INFEASIBLE. The 13-cap "allow overflow" toggle is the escape valve, but it was only visible/effective when at least one cabin was locked (the partial re-solve workflow). Stream A makes the toggle available on any solve.

## Tradeoff

Enabling overflow on a full solve can produce uneven 13/13/11/10/13 distributions. Stream C will fix this with lex-minimized overflow (only flip a bunk to 13 when no 12-cap placement exists). This PR is intentionally the intermediate state — Stream C is a separate future PR.

## Test plan

- [x] New `TestAllowOverflowPropagation::test_allow_overflow_propagates_without_locked_bunks` asserts the flag reaches `solver_input.allow_overflow` with `locked_bunk_cm_ids=None`. Mirrors the established `TestSolverRunnerPocketBaseSave` patching pattern.
- [x] Rewrote `OptimizeBunksButton` test A — overflow checkbox IS present at `lockedCount=0`, scope line is NOT.
- [x] Added `OptimizeBunksButton` test E — clicking checkbox calls handler at `lockedCount=0`.
- [x] Deleted 2 obsolete `overflow-gate` tests from `scopeLockedToBunks.test.ts` (5 tests remain, was 7).
- [x] Pre-push verification clean: 5364 Python tests pass, prettier/eslint/tsc/vitest all green.

## Out of scope

- Lex-minimized overflow (Stream C)
- Per-camper attribution for overflow decisions (Stream C+)
- Broader diagnostics for single-stuck-camper infeasibility (separate future stream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Overflow option in the optimization dropdown is now always available.
  * Added session behavior to automatically reset the overflow setting when the last locked bunk is unlocked.

* **Bug Fixes**
  * Overflow preference is reliably passed to the solver for full optimizations (no locked bunks).

* **Tests**
  * Updated and added tests verifying dropdown behavior, overflow propagation, and the reset-on-unlock behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->