### PR TITLE
fix(frontend): case-insensitive PENDING check in upload changes modal

### DIFF
--- a/frontend/src/components/session/SessionUploadChangesModal.test.tsx
+++ b/frontend/src/components/session/SessionUploadChangesModal.test.tsx
@@ -40,13 +40,15 @@ describe('SessionUploadChangesModal', () => {
   })
 
   it('groups by camper and sorts needs-review first', async () => {
+    // debug_pipeline_summary.final_status is stored UPPERCASE by convention
+    // (orchestrator.py: raw_status.upper()), so fixtures must match production.
     mock([
       {
         requester_cm_id: 1,
         requester_name: 'Emma Johnson',
         target_name: 'Olivia Chen',
         request_type: 'bunk_with',
-        final_status: 'resolved',
+        final_status: 'RESOLVED',
         session_cm_id: 1,
       },
       {
@@ -54,7 +56,7 @@ describe('SessionUploadChangesModal', () => {
         requester_name: 'Noah Smith',
         target_name: 'Ethan',
         request_type: 'not_bunk_with',
-        final_status: 'pending',
+        final_status: 'PENDING',
         session_cm_id: 1,
       },
     ])

--- a/frontend/src/components/session/SessionUploadChangesModal.tsx
+++ b/frontend/src/components/session/SessionUploadChangesModal.tsx
@@ -16,7 +16,10 @@ interface Props {
 }
 
 function isReview(r: UploadChangeRow): boolean {
-  return r.final_status === 'pending'
+  // debug_pipeline_summary.final_status is stored UPPERCASE ("PENDING",
+  // "RESOLVED", …) by orchestrator convention; normalize so the case-sensitive
+  // comparison can't silently mislabel every pending row as auto-matched.
+  return r.final_status.toUpperCase() === 'PENDING'
 }
 
 export default function SessionUploadChangesModal({


### PR DESCRIPTION
## Problem

The **"What's new"** upload-changes modal labeled *every* row `✓ auto-matched`, even for sessions whose chip showed `⚠ N review`. The badges and the "needs-review-first" sort were silently wrong.

## Root cause

The chip and the modal read the same statuses from two different places, and only one normalizes case:

| | Source | Review check |
|---|---|---|
| **Chip** (`⚠ N review`) | `debug_pipeline_runs.session_breakdown[cmId].pending` | backend `_resolve_trace_status` → `(br.status or "").lower() == "pending"` ✅ |
| **Modal** (per-row badge) | `debug_pipeline_summary` rows | frontend `isReview`: `r.final_status === 'pending'` ❌ |

`debug_pipeline_summary.final_status` is stored **UPPERCASE by convention** (`orchestrator.py`: `raw_status.upper()` → `"PENDING"`, `"RESOLVED"`, …). The backend lowercases before comparing, so the chip's review count is correct. The modal's case-sensitive `=== 'pending'` never matched `"PENDING"`, so every pending row was mislabeled `auto-matched`, and the review-first sort (same predicate) became a no-op.

## Fix

Normalize the comparison: `r.final_status.toUpperCase() === 'PENDING'`.

## Tests

The existing modal test masked the bug with **lowercase** fixtures that don't match production. Corrected them to UPPERCASE (`'PENDING'`/`'RESOLVED'`) — they fail without the fix (red) and pass with it (green). TDD red→green verified locally; full frontend pre-push (prettier/eslint/tsc/vitest) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with status field handling in session uploads that was preventing correct classification of items requiring review due to case sensitivity in status value comparisons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->