### PR TITLE
fix(sync,api): clear cancelled campers from draft assignments + checker counts

### DIFF
--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -327,6 +327,10 @@ class BunkingValidator:
         # Request satisfaction reads the FULL set — its missing-person fallback
         # keeps detail rows from dropping during a sync gap.
         assignments_by_person = {a.person_cm_id: a for a in assignments}
+        # Active-only view for checks that judge a camper's own placement (e.g.
+        # level regression): a cancelled camper's stale row must not surface as a
+        # finding, same as occupancy.
+        active_assignments_by_person = {a.person_cm_id: a for a in active_assignments}
         # Occupancy, capacity, and spread checks read the active-enrolled subset
         # so cancelled campers don't inflate counts or trip spread warnings.
         assignments_by_bunk = defaultdict(list)
@@ -382,7 +386,7 @@ class BunkingValidator:
         # Validate level progression (regression detection) - NEW
         if historical_bunking:
             self._validate_level_progression(
-                bunks, assignments_by_person, person_by_id, historical_bunking, stats, issues
+                bunks, active_assignments_by_person, person_by_id, historical_bunking, stats, issues
             )
 
         # Validate age/grade flow (younger kids in lower bunks) - NEW

--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -295,16 +295,47 @@ class BunkingValidator:
         issues: list[ValidationIssue] = []
         stats = ValidationStatistics()
 
+        # Split out assignments for campers who are no longer actively enrolled.
+        # ``persons`` is the active-enrolled set (status_id=2); a saved scenario's
+        # draft can still hold rows for campers who cancelled after it was built.
+        # Counting those stale rows inflates per-bunk occupancy, capacity_by_gender,
+        # and assigned_campers (and drives unassigned negative). We exclude them
+        # from all occupancy/spread math below — but keep them in the
+        # request-satisfaction lookup, which has its own missing-person fallback
+        # (a transient sync gap must not silently drop request detail rows; see
+        # ``unsatisfied_material_parent_detail``). The next sync's orphan sweep
+        # removes the stale rows at the source. Surfaced as an INFO issue.
+        active_ids = {p.campminder_id for p in persons}
+        active_assignments = [a for a in assignments if a.person_cm_id in active_ids]
+        stale_assignments = [a for a in assignments if a.person_cm_id not in active_ids]
+        if stale_assignments:
+            issues.append(
+                ValidationIssue(
+                    severity=ValidationSeverity.INFO,
+                    type="stale_assignments",
+                    message=(
+                        f"{len(stale_assignments)} assigned campers are no longer enrolled "
+                        f"and were excluded from capacity counts"
+                    ),
+                    details={"count": len(stale_assignments)},
+                    affected_ids=[a.person_cm_id for a in stale_assignments][:10],
+                )
+            )
+
         # Create lookup structures
         person_by_id = {p.campminder_id: p for p in persons}
+        # Request satisfaction reads the FULL set — its missing-person fallback
+        # keeps detail rows from dropping during a sync gap.
         assignments_by_person = {a.person_cm_id: a for a in assignments}
+        # Occupancy, capacity, and spread checks read the active-enrolled subset
+        # so cancelled campers don't inflate counts or trip spread warnings.
         assignments_by_bunk = defaultdict(list)
-        for assignment in assignments:
+        for assignment in active_assignments:
             assignments_by_bunk[assignment.bunk_cm_id].append(assignment)
 
         # Basic statistics
         stats.total_campers = len(persons)
-        stats.assigned_campers = len(assignments)
+        stats.assigned_campers = len(active_assignments)
         stats.unassigned_campers = stats.total_campers - stats.assigned_campers
 
         # Check for unassigned campers

--- a/pocketbase/sync/stranded_assignment_cleanup.go
+++ b/pocketbase/sync/stranded_assignment_cleanup.go
@@ -11,24 +11,27 @@ import (
 
 const serviceNameStrandedAssignmentCleanup = "stranded_assignment_cleanup"
 
-// msgStrandedProd is the Warn message for the observe-only production audit.
+// msgOrphanProd is the Warn message for the observe-only production audit.
 // Hoisted to a const to keep the call site within the line-length limit.
-const msgStrandedProd = "stranded_assignment_cleanup: stranded production assignments detected — " +
-	"not deleted (bunk_assignments sync owns prod cleanup)"
+const msgOrphanProd = "stranded_assignment_cleanup: orphaned production assignments detected " +
+	"(bunk lost its plan or camper no longer enrolled) — not deleted (bunk_assignments sync owns prod cleanup)"
 
 // strandedCandidate is the minimal projection of an assignment row needed for
-// stranded-detection — decoupled from *core.Record so the detection logic is
-// unit-testable without a database.
+// orphan-detection — decoupled from *core.Record so the detection logic is
+// unit-testable without a database. BunkID drives bunk-stranding (the bunk lost
+// its plan); PersonID drives enrollment-orphaning (the camper cancelled).
 type strandedCandidate struct {
 	RecordID  string
 	SessionID string
 	BunkID    string
+	PersonID  string
 }
 
-// strandedPairKey builds the composite key used to test whether a (session, bunk)
-// pair has a surviving bunk_plan. Both args are PocketBase record IDs.
-func strandedPairKey(sessionID, bunkID string) string {
-	return sessionID + ":" + bunkID
+// strandedPairKey builds the composite key used to test membership of a
+// (session, X) pair — X is a bunk for plan validity, or a person for enrollment.
+// Both args are PocketBase record IDs.
+func strandedPairKey(sessionID, otherID string) string {
+	return sessionID + ":" + otherID
 }
 
 // findStrandedAssignments returns the candidates whose (session, bunk) pair is
@@ -56,11 +59,82 @@ func findStrandedAssignments(
 	return stranded
 }
 
-// StrandedAssignmentCleanupSync silently auto-unassigns scenario draft assignments whose
-// bunk no longer has a bunk_plan for their session — left stranded when staff
-// reorganize a session's bunk plan — and audits production for the same.
-// Runs as the final step of the sync orchestrator. PocketBase-only — no
-// CampMinder client.
+// findEnrollmentOrphans returns the candidates whose (session, person) pair is
+// absent from enrolledPairs — i.e. the camper is no longer actively enrolled
+// (status_id=2) in that session. Candidates with no person are skipped.
+// Candidates whose session is absent from enrolledSessions are also skipped: a
+// session with zero enrolled attendees is unreliable (attendees may have failed
+// to sync), so sweeping its drafts would null every assignment for the session.
+// Mirrors findStrandedAssignments — the same guard shape, keyed on the camper
+// instead of the bunk.
+func findEnrollmentOrphans(
+	enrolledSessions, enrolledPairs map[string]bool,
+	candidates []strandedCandidate,
+) []strandedCandidate {
+	orphans := []strandedCandidate{}
+	for _, c := range candidates {
+		if c.PersonID == "" {
+			continue
+		}
+		if !enrolledSessions[c.SessionID] {
+			continue
+		}
+		if !enrolledPairs[strandedPairKey(c.SessionID, c.PersonID)] {
+			orphans = append(orphans, c)
+		}
+	}
+	return orphans
+}
+
+// dedupeByRecordID merges candidate slices, keeping the first occurrence of each
+// RecordID — a row flagged by both passes (bunk gone AND camper cancelled) is
+// handled once.
+func dedupeByRecordID(groups ...[]strandedCandidate) []strandedCandidate {
+	seen := make(map[string]bool)
+	merged := []strandedCandidate{}
+	for _, g := range groups {
+		for _, c := range g {
+			if seen[c.RecordID] {
+				continue
+			}
+			seen[c.RecordID] = true
+			merged = append(merged, c)
+		}
+	}
+	return merged
+}
+
+// loadEnrolledAttendeeSets returns (enrolledSessions, enrolledPairs) built from
+// status_id=2 attendees for the year. On query failure it records the error and
+// returns empty maps — the enrollment-orphan pass then becomes a no-op via its
+// per-session guard (fail closed: never sweep on enrollment we couldn't read).
+func loadEnrolledAttendeeSets(app core.App, year int, stats *Stats) (enrolledSessions, enrolledPairs map[string]bool) {
+	enrolledSessions = make(map[string]bool)
+	enrolledPairs = make(map[string]bool)
+	attendees, err := app.FindRecordsByFilter("attendees", fmt.Sprintf("year = %d && status_id = 2", year), "", 0, 0)
+	if err != nil {
+		stats.Errors++
+		slog.Error("stranded_assignment_cleanup: query attendees (enrollment pass skipped)", "error", err)
+		return enrolledSessions, enrolledPairs
+	}
+	for _, a := range attendees {
+		sessionID := a.GetString("session")
+		enrolledSessions[sessionID] = true
+		enrolledPairs[strandedPairKey(sessionID, a.GetString("person"))] = true
+	}
+	return enrolledSessions, enrolledPairs
+}
+
+// StrandedAssignmentCleanupSync silently auto-unassigns scenario draft assignments
+// that no longer make sense, for either of two reasons:
+//   - the bunk no longer has a bunk_plan for their session (staff reorganized
+//     the session's bunk plan), or
+//   - the camper is no longer actively enrolled (status_id=2) in that session
+//     (they cancelled/withdrew after the scenario was built).
+//
+// It nulls bunk + bunk_plan on those drafts and audits production for the same
+// (observe-only). Runs as the final step of the sync orchestrator — after
+// attendees sync, so enrollment is current. PocketBase-only — no CampMinder client.
 type StrandedAssignmentCleanupSync struct {
 	App   core.App
 	Year  int
@@ -105,15 +179,18 @@ func (s *StrandedAssignmentCleanupSync) Sync(_ context.Context) error {
 }
 
 // reconcileStrandedAssignments is the integration logic:
-//  1. Build the valid (session, bunk) set, plus the set of sessions that have
-//     at least one bunk_plan, from bunk_plans for the year.
+//  1. Build the valid (session, bunk) set + planned-session set from bunk_plans,
+//     and the enrolled (session, person) set + enrolled-session set from
+//     status_id=2 attendees, for the year.
 //  2. GATE: if there are zero bunk_plans for the year, the plan set is
 //     unreliable (bunk_plans sync failed or never ran) — skip entirely. The
-//     same guard applies per session: a session with zero bunk_plans is left
-//     untouched, so a partial sync can't sweep an entire session's drafts.
-//  3. Sweep bunk_assignments_draft: null bunk + bunk_plan on stranded rows so
-//     the camper falls back into the Unassigned pool.
-//  4. Audit bunk_assignments (production): log stranded rows — but do NOT
+//     same per-session guard protects both passes: a session with zero
+//     bunk_plans (or zero enrolled attendees) is left untouched, so a partial
+//     sync can't sweep an entire session's drafts.
+//  3. Sweep bunk_assignments_draft: null bunk + bunk_plan on rows that are
+//     bunk-stranded OR enrollment-orphaned, so the camper falls back into the
+//     Unassigned pool (a cancelled camper falls out of the scenario entirely).
+//  4. Audit bunk_assignments (production): log flagged rows — but do NOT
 //     delete. The bunk_assignments sync's own deleteOrphans() owns prod.
 func reconcileStrandedAssignments(app core.App, year int, stats *Stats) error {
 	yearFilter := fmt.Sprintf("year = %d", year)
@@ -136,6 +213,8 @@ func reconcileStrandedAssignments(app core.App, year int, stats *Stats) error {
 		plannedSessions[sessionID] = true
 	}
 
+	enrolledSessions, enrolledPairs := loadEnrolledAttendeeSets(app, year, stats)
+
 	// --- Draft sweep ---
 	drafts, err := app.FindRecordsByFilter(
 		"bunk_assignments_draft",
@@ -148,23 +227,25 @@ func reconcileStrandedAssignments(app core.App, year int, stats *Stats) error {
 	}
 	draftByID := make(map[string]*core.Record, len(drafts))
 	draftCandidates := make([]strandedCandidate, 0, len(drafts))
-	// Validity is derived from the (session, bunk) pair, NOT the draft's own
+	// Bunk validity is derived from the (session, bunk) pair, NOT the draft's own
 	// bunk_plan relation: that relation is non-authoritative and may dangle
 	// (point at a since-deleted plan) even when the bunk is still planned. A
-	// draft whose bunk is still planned is left untouched here, stale
-	// bunk_plan and all.
+	// draft whose bunk is still planned and whose camper is still enrolled is
+	// left untouched here, stale bunk_plan and all.
 	for _, d := range drafts {
 		draftByID[d.Id] = d
 		draftCandidates = append(draftCandidates, strandedCandidate{
 			RecordID:  d.Id,
 			SessionID: d.GetString("session"),
 			BunkID:    d.GetString("bunk"),
+			PersonID:  d.GetString("person"),
 		})
 	}
 	strandedDrafts := findStrandedAssignments(validPairs, plannedSessions, draftCandidates)
+	orphanDrafts := findEnrollmentOrphans(enrolledSessions, enrolledPairs, draftCandidates)
 
 	writes := 0
-	for _, c := range strandedDrafts {
+	for _, c := range dedupeByRecordID(strandedDrafts, orphanDrafts) {
 		rec := draftByID[c.RecordID]
 		rec.Set("bunk", "")
 		rec.Set("bunk_plan", "")
@@ -196,16 +277,20 @@ func reconcileStrandedAssignments(app core.App, year int, stats *Stats) error {
 				RecordID:  p.Id,
 				SessionID: p.GetString("session"),
 				BunkID:    p.GetString("bunk"),
+				PersonID:  p.GetString("person"),
 			})
 		}
 		strandedProd := findStrandedAssignments(validPairs, plannedSessions, prodCandidates)
-		stats.ProdAuditWarnings = len(strandedProd)
-		if len(strandedProd) > 0 {
-			pairs := make([]string, len(strandedProd))
-			for i, c := range strandedProd {
-				pairs[i] = fmt.Sprintf("%s(session=%s,bunk=%s)", c.RecordID, c.SessionID, c.BunkID)
+		orphanProd := findEnrollmentOrphans(enrolledSessions, enrolledPairs, prodCandidates)
+		flaggedProd := dedupeByRecordID(strandedProd, orphanProd)
+		stats.ProdAuditWarnings = len(flaggedProd)
+		if len(flaggedProd) > 0 {
+			recs := make([]string, len(flaggedProd))
+			for i, c := range flaggedProd {
+				recs[i] = fmt.Sprintf("%s(session=%s,bunk=%s,person=%s)", c.RecordID, c.SessionID, c.BunkID, c.PersonID)
 			}
-			slog.Warn(msgStrandedProd, "year", year, "count", len(strandedProd), "records", pairs)
+			slog.Warn(msgOrphanProd, "year", year,
+				"count", len(flaggedProd), "stranded", len(strandedProd), "orphaned", len(orphanProd), "records", recs)
 		}
 	}
 
@@ -219,6 +304,7 @@ func reconcileStrandedAssignments(app core.App, year int, stats *Stats) error {
 	slog.Info("stranded_assignment_cleanup complete",
 		"year", year,
 		"stranded_drafts", len(strandedDrafts),
+		"orphaned_drafts", len(orphanDrafts),
 		"drafts_swept", stats.Updated,
 		"errors", stats.Errors,
 	)

--- a/pocketbase/sync/stranded_assignment_cleanup.go
+++ b/pocketbase/sync/stranded_assignment_cleanup.go
@@ -243,9 +243,12 @@ func reconcileStrandedAssignments(app core.App, year int, stats *Stats) error {
 	}
 	strandedDrafts := findStrandedAssignments(validPairs, plannedSessions, draftCandidates)
 	orphanDrafts := findEnrollmentOrphans(enrolledSessions, enrolledPairs, draftCandidates)
+	// Deduplicated once so the sweep count and the log agree: a draft flagged by
+	// both passes is swept once, not double-counted.
+	draftsToSweep := dedupeByRecordID(strandedDrafts, orphanDrafts)
 
 	writes := 0
-	for _, c := range dedupeByRecordID(strandedDrafts, orphanDrafts) {
+	for _, c := range draftsToSweep {
 		rec := draftByID[c.RecordID]
 		rec.Set("bunk", "")
 		rec.Set("bunk_plan", "")
@@ -303,6 +306,7 @@ func reconcileStrandedAssignments(app core.App, year int, stats *Stats) error {
 
 	slog.Info("stranded_assignment_cleanup complete",
 		"year", year,
+		"flagged_drafts", len(draftsToSweep),
 		"stranded_drafts", len(strandedDrafts),
 		"orphaned_drafts", len(orphanDrafts),
 		"drafts_swept", stats.Updated,

--- a/pocketbase/sync/stranded_assignment_cleanup_test.go
+++ b/pocketbase/sync/stranded_assignment_cleanup_test.go
@@ -32,6 +32,29 @@ func TestFindStrandedAssignments(t *testing.T) {
 	}
 }
 
+func TestFindEnrollmentOrphans(t *testing.T) {
+	enrolledPairs := map[string]bool{
+		strandedPairKey("sess1", "p1"): true,
+	}
+	// Only sess1 has enrolled attendees; sess2 has none (its attendees failed to sync).
+	enrolledSessions := map[string]bool{"sess1": true}
+	candidates := []strandedCandidate{
+		{RecordID: "r1", SessionID: "sess1", PersonID: "p1"}, // enrolled - kept
+		{RecordID: "r2", SessionID: "sess1", PersonID: "p2"}, // cancelled - orphan
+		{RecordID: "r3", SessionID: "sess1", PersonID: ""},   // no person - skipped
+		{RecordID: "r4", SessionID: "sess2", PersonID: "p9"}, // session has zero enrolled - skipped
+	}
+
+	orphans := findEnrollmentOrphans(enrolledSessions, enrolledPairs, candidates)
+
+	if len(orphans) != 1 {
+		t.Fatalf("want 1 orphan, got %d: %+v", len(orphans), orphans)
+	}
+	if orphans[0].RecordID != "r2" {
+		t.Errorf("want [r2], got [%s]", orphans[0].RecordID)
+	}
+}
+
 // setupStrandedCollections builds the minimal schema the reconciler touches.
 func setupStrandedCollections(t *testing.T, app core.App) {
 	t.Helper()
@@ -91,6 +114,15 @@ func setupStrandedCollections(t *testing.T, app core.App) {
 	prod.Fields.Add(&core.NumberField{Name: "year"})
 	if err := app.Save(prod); err != nil {
 		t.Fatalf("create bunk_assignments: %v", err)
+	}
+
+	attendees := core.NewBaseCollection("attendees")
+	attendees.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})
+	attendees.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	attendees.Fields.Add(&core.NumberField{Name: "status_id"})
+	attendees.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(attendees); err != nil {
+		t.Fatalf("create attendees: %v", err)
 	}
 }
 
@@ -426,5 +458,133 @@ func TestStrandedAssignmentCleanup_ProdQueryErrorIsCountedNotFatal(t *testing.T)
 	}
 	if svc.WasSuccessful() {
 		t.Error("WasSuccessful() should be false when Stats.Errors > 0")
+	}
+}
+
+func TestStrandedAssignmentCleanup_SweepsEnrollmentOrphanDraft(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupStrandedCollections(t, app)
+
+	sess := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 100, "year": 2026})
+	bunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 1, "name": "G-Bet", "year": 2026})
+	cancelled := saveRec(t, app, "persons", map[string]any{"cm_id": 9001})
+	enrolled := saveRec(t, app, "persons", map[string]any{"cm_id": 9002})
+	// Bunk IS planned for the session, so the draft is NOT bunk-stranded — the
+	// only thing wrong is the camper's enrollment.
+	plan := saveRec(t, app, "bunk_plans", map[string]any{"bunk": bunk.Id, "session": sess.Id, "year": 2026})
+	// cancelled camper has a non-enrolled attendee row; an enrolled peer keeps
+	// the session's enrolled set non-empty so the per-session guard passes.
+	saveRec(t, app, "attendees", map[string]any{"person": cancelled.Id, "session": sess.Id, "status_id": 32, "year": 2026})
+	saveRec(t, app, "attendees", map[string]any{"person": enrolled.Id, "session": sess.Id, "status_id": 2, "year": 2026})
+	scenario := saveRec(t, app, "saved_scenarios", map[string]any{"name": "April", "session": sess.Id, "year": 2026})
+	draft := saveRec(t, app, "bunk_assignments_draft", map[string]any{
+		"scenario": scenario.Id, "person": cancelled.Id, "session": sess.Id,
+		"bunk": bunk.Id, "bunk_plan": plan.Id, "year": 2026,
+	})
+
+	svc := NewStrandedAssignmentCleanupSync(app)
+	svc.SetYear(2026)
+	if err = svc.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	got, err := app.FindRecordById("bunk_assignments_draft", draft.Id)
+	if err != nil {
+		t.Fatalf("reload draft: %v", err)
+	}
+	if got.GetString("bunk") != "" {
+		t.Errorf("want bunk cleared for cancelled camper, got %q", got.GetString("bunk"))
+	}
+	if got.GetString("bunk_plan") != "" {
+		t.Errorf("want bunk_plan cleared for cancelled camper, got %q", got.GetString("bunk_plan"))
+	}
+}
+
+func TestStrandedAssignmentCleanup_EnrollmentGateSkipsPerSession(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupStrandedCollections(t, app)
+
+	// Session A has enrolled attendees; session B has none (its attendees failed
+	// to sync). The per-session guard must protect session B's drafts from being
+	// nulled as "orphans" — a zero-enrolled session is unreliable, not authoritative.
+	sessA := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 100, "year": 2026})
+	sessB := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 200, "year": 2026})
+	bunkA := saveRec(t, app, "bunks", map[string]any{"cm_id": 1, "name": "A-1", "year": 2026})
+	bunkB := saveRec(t, app, "bunks", map[string]any{"cm_id": 2, "name": "B-1", "year": 2026})
+	personA := saveRec(t, app, "persons", map[string]any{"cm_id": 9001})
+	personB := saveRec(t, app, "persons", map[string]any{"cm_id": 9002})
+	// Both sessions have valid bunk plans, so neither draft is bunk-stranded.
+	saveRec(t, app, "bunk_plans", map[string]any{"bunk": bunkA.Id, "session": sessA.Id, "year": 2026})
+	planB := saveRec(t, app, "bunk_plans", map[string]any{"bunk": bunkB.Id, "session": sessB.Id, "year": 2026})
+	// Only session A has an enrolled attendee.
+	saveRec(t, app, "attendees", map[string]any{"person": personA.Id, "session": sessA.Id, "status_id": 2, "year": 2026})
+	scenario := saveRec(t, app, "saved_scenarios", map[string]any{"name": "April", "session": sessB.Id, "year": 2026})
+	// A draft in session B for a person with no enrolled attendee there. It must
+	// NOT be swept — session B's empty enrolled set is unreliable.
+	draftB := saveRec(t, app, "bunk_assignments_draft", map[string]any{
+		"scenario": scenario.Id, "person": personB.Id, "session": sessB.Id,
+		"bunk": bunkB.Id, "bunk_plan": planB.Id, "year": 2026,
+	})
+
+	svc := NewStrandedAssignmentCleanupSync(app)
+	svc.SetYear(2026)
+	if err = svc.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	got, err := app.FindRecordById("bunk_assignments_draft", draftB.Id)
+	if err != nil {
+		t.Fatalf("reload draft: %v", err)
+	}
+	if got.GetString("bunk") != bunkB.Id {
+		t.Errorf("per-session enrollment gate failed — session-B draft swept despite zero enrolled (bunk=%q)",
+			got.GetString("bunk"))
+	}
+}
+
+func TestStrandedAssignmentCleanup_EnrollmentOrphanProdAudit(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupStrandedCollections(t, app)
+
+	sess := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 100, "year": 2026})
+	bunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 1, "name": "G-Bet", "year": 2026})
+	cancelled := saveRec(t, app, "persons", map[string]any{"cm_id": 9001})
+	enrolled := saveRec(t, app, "persons", map[string]any{"cm_id": 9002})
+	// Bunk is planned (not bunk-stranded); the prod row is only enrollment-orphaned.
+	saveRec(t, app, "bunk_plans", map[string]any{"bunk": bunk.Id, "session": sess.Id, "year": 2026})
+	saveRec(t, app, "attendees", map[string]any{"person": cancelled.Id, "session": sess.Id, "status_id": 32, "year": 2026})
+	saveRec(t, app, "attendees", map[string]any{"person": enrolled.Id, "session": sess.Id, "status_id": 2, "year": 2026})
+	prodRow := saveRec(t, app, "bunk_assignments", map[string]any{
+		"person": cancelled.Id, "session": sess.Id, "bunk": bunk.Id, "year": 2026,
+	})
+
+	svc := NewStrandedAssignmentCleanupSync(app)
+	svc.SetYear(2026)
+	if err = svc.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	if svc.Stats.ProdAuditWarnings != 1 {
+		t.Errorf("want ProdAuditWarnings=1 for enrollment-orphaned prod row, got %d", svc.Stats.ProdAuditWarnings)
+	}
+	// Prod row must NOT be cleared (observe-only).
+	got, err := app.FindRecordById("bunk_assignments", prodRow.Id)
+	if err != nil {
+		t.Fatalf("prod row was deleted by the reconciler: %v", err)
+	}
+	if got.GetString("bunk") != bunk.Id {
+		t.Errorf("prod row bunk must not be cleared (observe-only), got %q", got.GetString("bunk"))
 	}
 }

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -242,6 +242,57 @@ class TestBunkingValidator:
         assert result.statistics.bunks_at_capacity == 1
         assert result.statistics.bunks_over_capacity == 0
 
+    def test_non_enrolled_assignments_excluded_from_capacity_counts(self, validator, basic_session):
+        """Assignments whose camper is no longer enrolled must not count toward occupancy.
+
+        ``persons`` is the active-enrolled set (status_id=2); ``assignments`` may
+        still reference a camper who has since cancelled, leaving a stale draft
+        row. Counting that row inflates per-bunk occupancy, ``capacity_by_gender``,
+        and ``assigned_campers`` (and drives ``unassigned`` negative). The
+        validator must exclude assignments whose person is absent from ``persons``.
+        """
+        bunk = MockBunk(campminder_id="30001", name="B-1", gender="M")
+        # 12 active-enrolled campers...
+        persons = [MockPerson(campminder_id=f"{10000 + i}", name=f"Camper {i}", age=10, grade=5) for i in range(12)]
+        assignments = [MockBunkAssignment(person_cm_id=f"{10000 + i}", bunk_cm_id="30001") for i in range(12)]
+        # ...plus one stale draft row for a cancelled camper (not in `persons`),
+        # which would push the bunk to 13 if counted.
+        assignments.append(MockBunkAssignment(person_cm_id="19999", bunk_cm_id="30001"))
+
+        result = validator.validate_bunking(
+            session=basic_session,
+            bunks=[bunk],
+            assignments=assignments,
+            persons=persons,
+            requests=[],
+        )
+
+        assert result.statistics.bunks_over_capacity == 0
+        assert result.statistics.bunks_at_capacity == 1
+        assert result.statistics.assigned_campers == 12
+        assert result.statistics.unassigned_campers == 0
+        assert result.statistics.capacity_by_gender["male"]["assigned"] == 12
+
+    def test_non_enrolled_assignments_emit_info_issue(self, validator, basic_session):
+        """Excluded stale assignments surface as an INFO issue so staff see the drift."""
+        bunk = MockBunk(campminder_id="30001", name="B-1", gender="M")
+        persons = [MockPerson(campminder_id=f"{10000 + i}", name=f"Camper {i}", age=10, grade=5) for i in range(12)]
+        assignments = [MockBunkAssignment(person_cm_id=f"{10000 + i}", bunk_cm_id="30001") for i in range(12)]
+        assignments.append(MockBunkAssignment(person_cm_id="19999", bunk_cm_id="30001"))
+
+        result = validator.validate_bunking(
+            session=basic_session,
+            bunks=[bunk],
+            assignments=assignments,
+            persons=persons,
+            requests=[],
+        )
+
+        stale_issue = next((i for i in result.issues if i.type == "stale_assignments"), None)
+        assert stale_issue is not None
+        assert stale_issue.severity == ValidationSeverity.INFO
+        assert stale_issue.details["count"] == 1
+
     def test_validate_request_satisfaction_bunk_with(self, validator, basic_session, basic_bunks, basic_persons):
         """Test satisfaction tracking for bunk_with requests."""
         assignments = [

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -746,6 +746,43 @@ class TestLevelProgressionValidation:
         regression_issues = [i for i in result.issues if i.type == "level_regression"]
         assert len(regression_issues) == 0
 
+    def test_level_regression_skipped_for_non_enrolled_camper(self, validator, session):
+        """A camper no longer enrolled (absent from `persons`) must not trip a
+        level-regression warning, even with a prior-year higher bunk in the same
+        session. Same exclusion the occupancy/capacity checks apply — a cancelled
+        camper's stale draft row should not surface as a regression for staff.
+        """
+        bunks = [
+            MockBunk(campminder_id="20005", name="B-5"),
+            MockBunk(campminder_id="20003", name="B-3"),
+        ]
+        # The only assignee below is no longer enrolled (not in `persons`).
+        persons: list[MockPerson] = []
+        assignments = [
+            MockBunkAssignment(person_cm_id="10001", bunk_cm_id="20003", session_cm_id="1234567"),
+        ]
+        historical = [
+            HistoricalBunkingRecord(
+                person_cm_id=10001,
+                bunk_name="B-5",  # higher level last year, same session → would be a regression
+                year=2024,
+                session_cm_id=1234567,
+            ),
+        ]
+
+        result = validator.validate_bunking(
+            session=session,
+            bunks=bunks,
+            assignments=assignments,
+            persons=persons,
+            requests=[],
+            historical_bunking=historical,
+        )
+
+        regression_issues = [i for i in result.issues if i.type == "level_regression"]
+        assert regression_issues == [], "cancelled camper should not trigger a level regression"
+        assert result.statistics.level_progression["regressed"] == 0
+
 
 class TestNormalizeSourceField:
     """Tests that normalize_source_field derives mappings from canonical SourceField constants.


### PR DESCRIPTION
## Problem

In a saved scenario's post-validation check, cabins showed **over capacity** and the **capacity-by-gender** totals ran high — e.g. three bunks flagged over capacity when only one truly was, and gender counts off by a few. Root cause: the scenario draft still held assignment rows for campers who had **cancelled** (CampMinder `status_id != 2`) after the scenario was built. Nothing cleared those stale rows, and the validator counted every draft row toward occupancy.

## Why it slipped through

Three orphan cleanups exist, split by entity:

| Cleanup | Acts on | Keyed on | Catches |
|---|---|---|---|
| `bunk_requests` purge | requests | enrollment | cancelled requesters' **requests** |
| `reconcile_request_lifecycle` | requests | moved session | requests on wrong session |
| `stranded_assignment_cleanup` | draft assignments | **bunk-plan absence** | drafts whose **bunk** was dropped |

The only cleanup touching draft *assignments* keyed on bunk-plan absence, never enrollment. A cancelled camper whose bunk was still valid fell straight through the gap — the request purge doesn't touch assignments, and the stranded sweep doesn't check enrollment. **Orphaned campers in draft assignments were never cleared.**

## Fix (two complementary parts)

**Root fix (Go) — `stranded_assignment_cleanup`** gains a symmetric *enrollment-orphan* pass alongside the existing bunk-stranding pass. It nulls `bunk` + `bunk_plan` on draft rows for campers no longer enrolled (`status_id != 2`) in their session, and audits production (observe-only, like today). It runs last in the orchestrator, after attendees sync, so enrollment is current. **Same per-session guard** as the bunk path: a session with zero enrolled attendees is skipped (attendees may have failed to sync), so a partial sync can't null a whole session's drafts.

**Defense-in-depth (Python) — `bunking_validator`** excludes non-enrolled assignments from occupancy, `capacity_by_gender`, and assigned/unassigned counts, and surfaces an INFO `stale_assignments` issue so staff see the drift in the window before the next sync sweeps the rows. Request-satisfaction keeps reading the **full** assignment set — its missing-person fallback must not drop detail rows during a transient sync gap.

## Tests (TDD, red first)

- Go: `findEnrollmentOrphans` pure-function unit test; integration tests for sweeping an enrollment-orphan draft, the per-session enrolled-set guard, and observe-only prod audit.
- Python: assignments for non-enrolled campers excluded from capacity counts; the exclusion emits an INFO issue; the two existing material-parent fallback tests still pass (occupancy filtered, request-satisfaction untouched).

All pre-push checks green: ruff, mypy, `go test -race ./...`, golangci-lint, full Python unit suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Capacity, occupancy and assigned/unassigned counts now exclude assignments for non-enrolled campers for accurate reporting.
  * Drafted bunk assignments that lack valid enrollment are no longer treated as bunk-related issues.

* **New Features**
  * Stale assignments are now detected and reported with a capped count in informational issues.

* **Tests**
  * Added unit tests covering stale-assignment handling and enrollment-orphan detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->