### PR TITLE
feat(frontend): default compare to Changes Table + trim upload-status string

### DIFF
--- a/frontend/src/layouts/AppLayout.test.tsx
+++ b/frontend/src/layouts/AppLayout.test.tsx
@@ -300,21 +300,23 @@ describe('AppLayout requests upload label', () => {
     }))
   }
 
-  it('uses upload time and absolute+relative wording when metadata is present', () => {
+  it('uses upload time with relative-only wording in the label (#1706)', () => {
     mockWithUpload('BunkRequests_2026-04-04.csv')
     renderAppLayout()
 
     const label = screen.getByText(/Requests uploaded/)
     expect(label).toBeInTheDocument()
-    // Absolute date (date-fns "MMM d" — locale-independent month abbrev)
-    expect(label.textContent).toMatch(/Apr 4/)
-    // Relative phrase ("ago" suffix)
+    // Relative phrase ("ago" suffix) is what's shown inline
     expect(label.textContent).toMatch(/ago/)
+    // #1706: the absolute date must NOT appear in the visible label — rendering
+    // both the full timestamp and the relative phrase made the header status
+    // string too long. The absolute time moves to the tooltip instead.
+    expect(label.textContent).not.toMatch(/Apr 4/)
     // Should NOT use the sync end_time wording when upload metadata exists
     expect(screen.queryByText(/Requests synced/)).not.toBeInTheDocument()
   })
 
-  it('exposes the original CSV filename via tooltip', () => {
+  it('exposes the original CSV filename and absolute upload time via tooltip (#1706)', () => {
     mockWithUpload('BunkRequests_2026-04-04.csv')
     renderAppLayout()
     const label = screen.getByText(/Requests uploaded/)
@@ -322,6 +324,8 @@ describe('AppLayout requests upload label', () => {
     expect(tooltipHost).not.toBeNull()
     const title = tooltipHost?.getAttribute('title') ?? ''
     expect(title).toContain('BunkRequests_2026-04-04.csv')
+    // Absolute date preserved in the tooltip now that it's out of the label
+    expect(title).toMatch(/Apr 4/)
   })
 
   it('falls back to "Requests synced" wording when upload metadata is missing', () => {

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -466,18 +466,17 @@ export const AppLayout = () => {
                     {syncStatus._bunk_requests_upload?.uploaded_at ? (
                       <span
                         className="flex items-center gap-1.5 whitespace-nowrap"
-                        title={`${syncStatus._bunk_requests_upload.filename} • ${buildSyncTooltip(
+                        title={`Uploaded ${format(
+                          new Date(syncStatus._bunk_requests_upload.uploaded_at),
+                          'MMM d, h:mm a'
+                        )} • ${syncStatus._bunk_requests_upload.filename} • ${buildSyncTooltip(
                           'bunk requests',
                           syncStatus.bunk_requests ?? { status: 'idle' }
                         )}`}
                       >
                         <Clock className="h-3 w-3" />
+                        {/* #1706: relative-only inline; absolute time lives in the tooltip */}
                         Requests uploaded{' '}
-                        {format(
-                          new Date(syncStatus._bunk_requests_upload.uploaded_at),
-                          'MMM d, h:mm a'
-                        )}
-                        {' · '}
                         {formatDistanceToNow(
                           new Date(syncStatus._bunk_requests_upload.uploaded_at),
                           { addSuffix: true }

--- a/frontend/src/pages/ScenarioComparisonPage.test.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.test.tsx
@@ -8,6 +8,8 @@ import {
   ValidationSection,
   getExportButtonLabel,
   getExportButtonTitle,
+  DEFAULT_VIEW_MODE,
+  VIEW_MODE_TABS,
   type ValidationResult,
   type ValidationStatistics,
 } from './ScenarioComparisonPage'
@@ -415,6 +417,21 @@ describe('getExportButtonTitle', () => {
 
   it('returns all tooltip when changeFilter is "all"', () => {
     expect(getExportButtonTitle('all')).toBe('Export all campers to CSV')
+  })
+})
+
+// ─── #1703: compare defaults to the Changes Table view, tabs swapped ─────────
+// Staff land on the differences-only view first (the all-bunks Split View is a
+// toggle). Both views are empty until a comparison scenario is chosen, so no
+// special empty-state handling is needed.
+describe('#1703 compare default view + tab order', () => {
+  it('defaults to the "changes" (Changes Table) view, not "split"', () => {
+    expect(DEFAULT_VIEW_MODE).toBe('changes')
+  })
+
+  it('orders the view-mode tabs with Changes Table first, Split View second', () => {
+    expect(VIEW_MODE_TABS.map((t) => t.mode)).toEqual(['changes', 'split'])
+    expect(VIEW_MODE_TABS.map((t) => t.label)).toEqual(['Changes Table', 'Split View'])
   })
 })
 

--- a/frontend/src/pages/ScenarioComparisonPage.tsx
+++ b/frontend/src/pages/ScenarioComparisonPage.tsx
@@ -21,6 +21,7 @@ import {
   Percent,
   Table2,
   Download,
+  type LucideIcon,
 } from 'lucide-react'
 import clsx from 'clsx'
 import { Listbox, ListboxButton, ListboxOptions, ListboxOption } from '@headlessui/react'
@@ -186,6 +187,21 @@ export interface ValidationResult {
 type ViewMode = 'split' | 'changes'
 type ChangeFilter = 'all' | 'moved' | 'newly-assigned' | 'newly-unassigned'
 
+/**
+ * #1703: staff land on the differences-only "Changes Table" view by default;
+ * the all-bunks "Split View" is the secondary toggle. Both views are empty
+ * until a comparison scenario is selected, so no empty-state handling differs
+ * between them.
+ */
+export const DEFAULT_VIEW_MODE: ViewMode = 'changes'
+
+/** View-mode tabs, ordered Changes Table first (the default), Split View second. */
+// eslint-disable-next-line react-refresh/only-export-components -- exported for tests
+export const VIEW_MODE_TABS: Array<{ mode: ViewMode; icon: LucideIcon; label: string }> = [
+  { mode: 'changes', icon: Table2, label: 'Changes Table' },
+  { mode: 'split', icon: LayoutGrid, label: 'Split View' },
+]
+
 /** Returns the export button label that matches the active change filter. */
 // eslint-disable-next-line react-refresh/only-export-components -- pure utility, exported for tests
 export function getExportButtonLabel(filter: 'moved' | 'all'): string {
@@ -224,7 +240,7 @@ export default function ScenarioComparisonPage() {
   // State for scenario selection
   const [leftScenarioId, setLeftScenarioId] = useState<string>('production')
   const [rightScenarioId, setRightScenarioId] = useState<string>('')
-  const [viewMode, setViewMode] = useState<ViewMode>('split')
+  const [viewMode, setViewMode] = useState<ViewMode>(DEFAULT_VIEW_MODE)
   const [changeFilter, setChangeFilter] = useState<ChangeFilter>('all')
   const [selectedBunkArea, setSelectedBunkArea] = useState<BunkArea>('all')
 
@@ -689,20 +705,9 @@ export default function ScenarioComparisonPage() {
               </div>
             </div>
 
-            {/* View mode toggle */}
+            {/* View mode toggle — Changes Table first (default), then Split View (#1703) */}
             <div className="flex items-center gap-2 rounded-xl bg-white/10 p-1">
-              {[
-                {
-                  mode: 'split' as ViewMode,
-                  icon: LayoutGrid,
-                  label: 'Split View',
-                },
-                {
-                  mode: 'changes' as ViewMode,
-                  icon: Table2,
-                  label: 'Changes Table',
-                },
-              ].map(({ mode, icon: Icon, label }) => (
+              {VIEW_MODE_TABS.map(({ mode, icon: Icon, label }) => (
                 <button
                   key={mode}
                   onClick={() => setViewMode(mode)}


### PR DESCRIPTION
Two scoped wife-feedback batch-6 (Group 77) frontend fixes on the session bunking surfaces.

## #1703 — Compare defaults to the Changes Table view
The scenario-comparison page now lands on the differences-only **Changes Table** view by default instead of the full all-bunks **Split View**, and the two view-mode tabs are reordered so Changes Table comes first. Staff comparing two scenarios care about what *moved*, so that's the sensible default; Split View remains a one-click toggle.

- Default + tab config hoisted to exported `DEFAULT_VIEW_MODE` / `VIEW_MODE_TABS` constants in `ScenarioComparisonPage.tsx` for unit testing.
- Both views are empty until a comparison scenario is chosen, so no empty-state handling differs between them.

## #1706 — Trim the "Requests uploaded" header status string
The header status rendered **both** the absolute timestamp and the relative phrase (`May 28, 9:44 PM · 1 minute ago`), which combined with the transient CSV-matching indicator to overflow the header. It now shows the **relative phrase only**, matching its `Assignments synced …` sibling. The absolute upload time moves into the existing hover tooltip (alongside the filename and sync detail).

## Tests (TDD)
- `ScenarioComparisonPage.test.tsx` — asserts `DEFAULT_VIEW_MODE === 'changes'` and tab order `[Changes Table, Split View]`.
- `AppLayout.test.tsx` — flips the existing "absolute+relative wording" spec to **relative-only in the label, absolute in the tooltip**.
- Wrote failing tests first, verified red, then implemented to green. Full pre-push suite passes (prettier, eslint, tsc, vitest, mypy, pytest, go-build).

Closes #1703
Closes #1706

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Upload label now displays relative time only, with absolute date moved to tooltip for clarity.
  * Default scenario comparison view changed to "Changes Table" with tabs reordered accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1708?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->