### PR TITLE
docs(docs): track docstring presence (pydocstyle D) linting row; supersede #919

### DIFF
--- a/docs/reference/modernization-backlog.md
+++ b/docs/reference/modernization-backlog.md
@@ -107,6 +107,29 @@ These survived the regex pass in the previous (pre-§a/§b/§c) audit before bei
 
 Survey scope: features added in Python 3.10–3.14. Re-run Part A after toolchain bumps to 3.15+.
 
+### Open linting row — docstring presence (pydocstyle `D` subset) — supersedes #919
+
+> A code-quality lint track, **separate from the closed 3.10–3.14 language-idiom audit above.** Tracked under §1 because ruff-rule expansion is repo-wide `ruff.toml` work (cf. `PLC0415` in #1575); the language-idiom closeout is unaffected.
+
+**Why #919 is closed, not worked as written.** CodeRabbit's docstring pre-merge check is already **off** (`.coderabbit.yaml` → `pre_merge_checks.docstrings.mode: "off"`, "not a gate we want CR enforcing"), so #919's "⚠️ on every PR until resolved" premise is dead. Its "56.52% vs 80%" was also a measurement artifact — a bare `interrogate .` walks stale `.claude/worktrees/*/.venv/site-packages` and drags the number to ~48%. Scoped to git-tracked source, real **presence** coverage is **~77%** (`interrogate`, default counting). We do **not** chase an arbitrary coverage %; adopt a curated ruff `D` subset instead.
+
+**Measured `D` surface** (`ruff check --select D --statistics bunking api campminder scripts`, 2026-05-29): **1,651** violations, but only ~190 are *missing* docstrings — the rest format docstrings that already exist.
+
+| Bucket | Count | Codes |
+|---|---|---|
+| Format of *existing* docstrings | ~1,340 | D413 476 · D400 332 · D415 332 · D212 146 · D209 57 · D205 35 · D401 34 · D200 17 · … (685 auto-fixable) |
+| **Missing presence** | ~190 | D101 class **67** · D102 method 46 · D107 init 45 · D103 func **12** · D104 pkg **12** · D105 magic 8 · D100 module **1** |
+| Param docs | 23 | D417 |
+
+**§a — enable (high-value presence only).** Add to `ruff.toml` `[lint] select`: `D100` (module), `D101` (public class), `D103` (public function), `D104` (package). ~**92** missing across those four — a bounded one-time sweep of *domain-meaningful* docstrings (solver constraints, satisfaction policy, request pipeline), not filler. Selecting the four codes explicitly pulls in **zero** format rules and sidesteps the D203/D211 + D212/D213 convention conflicts (no `convention =` needed). `[lint.per-file-ignores]`: add `D1` to the existing `tests/**/*.py` and `scripts/**/*.py` entries.
+
+**§b — surveyed, deliberately skipped** (low value / filler-inducing; matches #919's own "non-obvious behavior, not trivial wrappers" bar):
+- `D102` (every public method, 46), `D107` (`__init__`, 45), `D105` (magic, 8) — the mypy-strict typed signature already documents these; enforcing yields `"Initialize the processor."` noise.
+- `D417` (document every param, 23) — high friction, restates the typed signature.
+- D2xx/D4xx format rules (~1,340) — pure style. *Optional* throwaway `ruff check --select D --fix` of the 685 auto-fixable for consistency; **not** gated, not part of this row.
+
+**Execution (one PR).** Write the ~92 §a docstrings + add the four codes to `select` + the two `per-file-ignores`; verify `ruff check --select D100,D101,D103,D104` is clean. Ratchets via the existing ruff pre-push + CI — **no new tooling** (no `interrogate` gate). Split the sweep by package if it gets large.
+
 ---
 
 ## 2. Go — closed at 1.26 (May 2026)

--- a/docs/reference/modernization-backlog.md
+++ b/docs/reference/modernization-backlog.md
@@ -121,14 +121,14 @@ Survey scope: features added in Python 3.10–3.14. Re-run Part A after toolchai
 | **Missing presence** | ~190 | D101 class **67** · D102 method 46 · D107 init 45 · D103 func **12** · D104 pkg **12** · D105 magic 8 · D100 module **1** |
 | Param docs | 23 | D417 |
 
-**§a — enable (high-value presence only).** Add to `ruff.toml` `[lint] select`: `D100` (module), `D101` (public class), `D103` (public function), `D104` (package). ~**92** missing across those four — a bounded one-time sweep of *domain-meaningful* docstrings (solver constraints, satisfaction policy, request pipeline), not filler. Selecting the four codes explicitly pulls in **zero** format rules and sidesteps the D203/D211 + D212/D213 convention conflicts (no `convention =` needed). `[lint.per-file-ignores]`: add `D1` to the existing `tests/**/*.py` and `scripts/**/*.py` entries.
+**§a — enable (high-value presence only).** Add to `ruff.toml` `[lint] select`: `D100` (module), `D101` (public class), `D103` (public function), `D104` (package). ~**92** missing across those four — a bounded one-time sweep of *domain-meaningful* docstrings (solver constraints, satisfaction policy, request pipeline), not filler. Selecting the four codes explicitly pulls in **zero** format rules and sidesteps the D203/D211 + D212/D213 convention conflicts (no `convention =` needed). `[lint.per-file-ignores]`: add `D1` to the existing `tests/**/*.py`, `scripts/**/*.py`, and `api/services/test_*.py` (co-located tests) entries — the last is its own glob, not covered by `tests/**/*.py`, and its public `def test_*` functions would otherwise trip `D103`.
 
 **§b — surveyed, deliberately skipped** (low value / filler-inducing; matches #919's own "non-obvious behavior, not trivial wrappers" bar):
 - `D102` (every public method, 46), `D107` (`__init__`, 45), `D105` (magic, 8) — the mypy-strict typed signature already documents these; enforcing yields `"Initialize the processor."` noise.
 - `D417` (document every param, 23) — high friction, restates the typed signature.
 - D2xx/D4xx format rules (~1,340) — pure style. *Optional* throwaway `ruff check --select D --fix` of the 685 auto-fixable for consistency; **not** gated, not part of this row.
 
-**Execution (one PR).** Write the ~92 §a docstrings + add the four codes to `select` + the two `per-file-ignores`; verify `ruff check --select D100,D101,D103,D104` is clean. Ratchets via the existing ruff pre-push + CI — **no new tooling** (no `interrogate` gate). Split the sweep by package if it gets large.
+**Execution (one PR).** Write the ~92 §a docstrings + add the four codes to `select` + the three `per-file-ignores`; verify `ruff check --select D100,D101,D103,D104` is clean. Ratchets via the existing ruff pre-push + CI — **no new tooling** (no `interrogate` gate). Split the sweep by package if it gets large.
 
 ---
 


### PR DESCRIPTION
## What

Adds an **open linting row** to `docs/reference/modernization-backlog.md` §1 (Python) capturing the decision on docstring coverage, and closes #919 in favor of it.

## Why #919 is closed, not worked as written

- **The CodeRabbit gate is already off.** `.coderabbit.yaml` sets `pre_merge_checks.docstrings.mode: "off"` ("not a gate we want CR enforcing"), so #919's "⚠️ on every PR until resolved" premise no longer holds.
- **The "57% vs 80%" number was a measurement artifact.** A bare `interrogate .` walks stale `.claude/worktrees/*/.venv/site-packages` and reports ~48%. Scoped to git-tracked source, real **presence** coverage is **~77%**.
- The genuine gap is small and concentrated: ~**92** missing module / public-class / public-function / package docstrings (D100/D101/D103/D104), not a coverage percentage.

## The row (curated ruff `D` subset)

Instead of chasing a coverage % or enabling full pydocstyle:

- **§a enable:** `D100`, `D101`, `D103`, `D104` — bounded one-time sweep of ~92 domain-meaningful docstrings, then gated forever by the **existing** ruff pre-push + CI (no new tooling, no `interrogate` gate). `per-file-ignores` for `tests/**` and `scripts/**`.
- **§b skip:** `D102`/`D107`/`D105` (filler on typed signatures), `D417` (param docs), and the ~1,340 D2xx/D4xx **format** rules on docstrings that already exist (685 auto-fixable; optional throwaway `--fix`, not gated).

Measured surface: `ruff check --select D --statistics bunking api campminder scripts` → 1,651 violations, only ~190 of which are *missing* docstrings.

Docs-only change. The actual `ruff.toml` edit + docstring sweep is a future PR tracked by this row.

Closes #919

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an “Open linting row — docstring presence” to the modernization backlog with a staged plan: enable a small set of high-value docstring checks, ignore checks for tests and scripts, explicitly skip lower-value rules, treat other docstring-format rules as optional cleanup, and include a single-PR checklist for rollout via CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->