### PR TITLE
refactor(pb): flatten ignored options:{} field wrappers (zero behavior change)

### DIFF
--- a/.claude/skills/pre-push-verification/scripts/verify.sh
+++ b/.claude/skills/pre-push-verification/scripts/verify.sh
@@ -299,9 +299,12 @@ if $HAS_MIGRATIONS; then
         # `options: [ ... ]` arrays (e.g. select-option values in config.js) are
         # legitimate and must NOT be flagged — same object-vs-array distinction
         # the eslint no-restricted-syntax rule makes.
-        if grep -n 'options\s*:\s*{' "$file" | grep -v '//.*options' | grep -q .; then
+        # Filter only full-line `//` comments. grep -n prefixes each hit with
+        # `LINENUM:`, so anchor on that prefix; a bare `^[[:space:]]*//` would
+        # never match. Keeps real `options: {` hits that carry an inline comment.
+        if grep -n 'options\s*:\s*{' "$file" | grep -vE '^[0-9]+:[[:space:]]*//' | grep -q .; then
             echo "    Found 'options: {}' field wrapper (v0.23+ anti-pattern): $file"
-            grep -n 'options\s*:\s*{' "$file" | grep -v '//.*options' | head -5 | while read -r line; do
+            grep -n 'options\s*:\s*{' "$file" | grep -vE '^[0-9]+:[[:space:]]*//' | head -5 | while read -r line; do
                 echo "      $line"
             done
             OPTIONS_OK=false

--- a/.claude/skills/pre-push-verification/scripts/verify.sh
+++ b/.claude/skills/pre-push-verification/scripts/verify.sh
@@ -295,9 +295,13 @@ if $HAS_MIGRATIONS; then
     while IFS= read -r file; do
         [[ -z "$file" ]] && continue
         [[ "$file" != pocketbase/pb_migrations/*.js ]] && continue
-        if grep -n 'options\s*:' "$file" | grep -v '//.*options' | grep -q .; then
-            echo "    Found 'options:' wrapper (v0.23+ anti-pattern): $file"
-            grep -n 'options\s*:' "$file" | grep -v '//.*options' | head -5 | while read -r line; do
+        # Match only the object-form field wrapper `options: {`. Seed-data
+        # `options: [ ... ]` arrays (e.g. select-option values in config.js) are
+        # legitimate and must NOT be flagged — same object-vs-array distinction
+        # the eslint no-restricted-syntax rule makes.
+        if grep -n 'options\s*:\s*{' "$file" | grep -v '//.*options' | grep -q .; then
+            echo "    Found 'options: {}' field wrapper (v0.23+ anti-pattern): $file"
+            grep -n 'options\s*:\s*{' "$file" | grep -v '//.*options' | head -5 | while read -r line; do
                 echo "      $line"
             done
             OPTIONS_OK=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,7 +233,7 @@ Worktree mechanics (ports, isolation, cleanup): `docs/reference/git-workflow.md`
 
 ### PocketBase Migrations
 
-> **MANDATORY:** Read `docs/reference/pocketbase-migrations.md` before writing ANY migration. PocketBase v0.23+ changed field property syntax — using the old `options: {}` wrapper pattern causes silent data truncation.
+> **MANDATORY:** Read `docs/reference/pocketbase-migrations.md` before writing ANY migration. PocketBase v0.23+ changed field property syntax — the old `options: {}` wrapper is silently ignored, so fields fall back to PB defaults (text capped at 5000 chars, not your declared value) and over-cap writes are rejected.
 
 **Numbering rule:** New migrations MUST use a number greater than the highest filename in `pocketbase/pb_migrations/` on `origin/main`. Do not fill numbering gaps left by past consolidations.
 

--- a/docs/reference/pocketbase-migrations.md
+++ b/docs/reference/pocketbase-migrations.md
@@ -1,6 +1,6 @@
 # PocketBase Migration Patterns (v0.23.0+) — READ THIS FIRST
 
-> **MANDATORY**: Before writing ANY PocketBase migration, you MUST review this section. PocketBase v0.23+ changed how field properties are defined. Using the old `options: {}` wrapper pattern will cause fields to use DEFAULT values (e.g., 5000 char limit for text) even if you specify different values. This causes silent data truncation bugs that are hard to diagnose.
+> **MANDATORY**: Before writing ANY PocketBase migration, you MUST review this section. PocketBase v0.23+ changed how field properties are defined. The old `options: {}` wrapper pattern is silently ignored — the field uses PB's DEFAULT cap (5000 chars for text, 1 MB for json) instead of your declared value. PB then REJECTS over-cap writes with a validation error (it does NOT truncate), so the live schema silently diverges from what the migration says — a hard-to-diagnose integrity bug.
 
 ## Field Type Reference (v0.23+ Syntax)
 
@@ -159,14 +159,14 @@ migrate((app) => {
 
 | Wrong | Right | Consequence of Wrong |
 |-------|-------|---------------------|
-| `options: { min: 0, max: 100000 }` for text | `min: 0, max: 100000` (direct) | Silent 5000 char limit, data truncation |
+| `options: { min: 0, max: 100000 }` for text | `min: 0, max: 100000` (direct) | Silent 5000-char default cap; over-cap writes rejected (declared limit never applied) |
 | `options: { values: [...] }` for select | `values: [...]` (direct) | Empty enum, validation fails |
 | `collectionId` inside `options: {}` | `collectionId` as direct property | Relation breaks |
 | `collection.fields.push({...})` | `collection.fields.add(new Field({...}))` | Field not added |
 | Hardcoded collection IDs | `app.findCollectionByNameOrId("name").id` | Breaks on fresh DB |
 | `for...of` on fields | Index-based `for` loop | "object is not iterable" error |
 | `return app.save()` | `app.save()` (no return needed) | May cause issues |
-| `min: null, max: null` for text | `min: 0, max: 0` (0 = unlimited for text) | N/A — both work for text fields |
+| `min: null, max: null` for text | `min: 0, max: 0` (0 → PB default 5000-char cap, NOT unlimited) | N/A — both normalize to the 5000 default for text |
 | `min: 0, max: 0` for number | `min: null, max: null` (null = no limit for number) | `max: 0` enforced as literal maximum of 0, rejects all positive values |
 
 ## Migration Checklist

--- a/pocketbase/CLAUDE.md
+++ b/pocketbase/CLAUDE.md
@@ -14,7 +14,7 @@ Go service: SQLite DB, auth, CampMinder sync. Entry: `main.go`. Module: `github.
 
 ## Migrations — read before writing any
 
-**MANDATORY:** `docs/reference/pocketbase-migrations.md`. PocketBase v0.23 changed field property syntax; using the old `options: {}` wrapper causes **silent data truncation**.
+**MANDATORY:** `docs/reference/pocketbase-migrations.md`. PocketBase v0.23 changed field property syntax; the old `options: {}` wrapper is **silently ignored** — fields fall back to PB defaults (text→5000 chars, json→1 MB) instead of your declared values, and over-cap writes are rejected (not truncated).
 
 ### Numbering rule
 

--- a/pocketbase/eslint.config.js
+++ b/pocketbase/eslint.config.js
@@ -27,6 +27,14 @@ export default [
       }],
       'no-undef': 'error',
       'no-console': 'off',
+      // PB v0.23+ ignores the options:{} field wrapper — the declared constraint
+      // is silently dropped and the field falls back to PB's default cap. Declare
+      // field constraints (max/min/pattern/maxSize) inline on the field object.
+      // Keyed on ObjectExpression so seed-data `options: [...]` arrays are NOT flagged.
+      'no-restricted-syntax': ['error', {
+        selector: "Property[key.name='options'][value.type='ObjectExpression']",
+        message: "PB v0.23+ ignores the options:{} field wrapper (declared constraint silently dropped). Declare field constraints (max/min/pattern/maxSize) inline on the field object instead.",
+      }],
     }
   },
   {

--- a/pocketbase/pb_migrations/1500000001_person_tag_defs.js
+++ b/pocketbase/pb_migrations/1500000001_person_tag_defs.js
@@ -27,12 +27,7 @@ migrate((app) => {
         type: "text",
         name: "name",
         required: true,
-        presentable: true,
-        options: {
-          min: 1,
-          max: 200,
-          pattern: ""
-        }
+        presentable: true
       },
       {
         type: "bool",
@@ -50,12 +45,7 @@ migrate((app) => {
         type: "text",
         name: "last_updated_utc",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: null,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "autodate",

--- a/pocketbase/pb_migrations/1500000002_custom_field_defs.js
+++ b/pocketbase/pb_migrations/1500000002_custom_field_defs.js
@@ -35,12 +35,7 @@ migrate((app) => {
         type: "text",
         name: "name",
         required: true,
-        presentable: true,
-        options: {
-          min: 1,
-          max: 500,
-          pattern: ""
-        }
+        presentable: true
       },
       {
         type: "select",

--- a/pocketbase/pb_migrations/1500000004_divisions.js
+++ b/pocketbase/pb_migrations/1500000004_divisions.js
@@ -34,23 +34,13 @@ migrate((app) => {
         type: "text",
         name: "name",
         required: true,
-        presentable: true,
-        options: {
-          min: 1,
-          max: 200,
-          pattern: ""
-        }
+        presentable: true
       },
       {
         type: "text",
         name: "description",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: 1000,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "number",

--- a/pocketbase/pb_migrations/1500000005_session_groups.js
+++ b/pocketbase/pb_migrations/1500000005_session_groups.js
@@ -34,23 +34,13 @@ migrate((app) => {
         type: "text",
         name: "name",
         required: true,
-        presentable: true,
-        options: {
-          min: null,
-          max: null,
-          pattern: ""
-        }
+        presentable: true
       },
       {
         type: "text",
         name: "description",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: null,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "bool",

--- a/pocketbase/pb_migrations/1500000006_bunks.js
+++ b/pocketbase/pb_migrations/1500000006_bunks.js
@@ -32,12 +32,7 @@ migrate((app) => {
         type: "text",
         name: "name",
         required: true,
-        presentable: true,
-        options: {
-          min: null,
-          max: null,
-          pattern: ""
-        }
+        presentable: true
       },
       {
         type: "number",
@@ -52,12 +47,7 @@ migrate((app) => {
         type: "text",
         name: "gender",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: 10,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "bool",

--- a/pocketbase/pb_migrations/1500000007_staff_program_areas.js
+++ b/pocketbase/pb_migrations/1500000007_staff_program_areas.js
@@ -35,12 +35,7 @@ migrate((app) => {
         type: "text",
         name: "name",
         required: true,
-        presentable: true,
-        options: {
-          min: 1,
-          max: 500,
-          pattern: ""
-        }
+        presentable: true
       },
       {
         type: "autodate",

--- a/pocketbase/pb_migrations/1500000008_staff_org_categories.js
+++ b/pocketbase/pb_migrations/1500000008_staff_org_categories.js
@@ -36,12 +36,7 @@ migrate((app) => {
         type: "text",
         name: "name",
         required: true,
-        presentable: true,
-        options: {
-          min: 1,
-          max: 500,
-          pattern: ""
-        }
+        presentable: true
       },
       {
         type: "autodate",

--- a/pocketbase/pb_migrations/1500000009_financial_categories.js
+++ b/pocketbase/pb_migrations/1500000009_financial_categories.js
@@ -36,12 +36,7 @@ migrate((app) => {
         type: "text",
         name: "name",
         required: false,
-        presentable: true,
-        options: {
-          min: null,
-          max: 500,
-          pattern: ""
-        }
+        presentable: true
       },
       {
         type: "bool",

--- a/pocketbase/pb_migrations/1500000010_payment_methods.js
+++ b/pocketbase/pb_migrations/1500000010_payment_methods.js
@@ -36,12 +36,7 @@ migrate((app) => {
         type: "text",
         name: "name",
         required: false,
-        presentable: true,
-        options: {
-          min: null,
-          max: 200,
-          pattern: ""
-        }
+        presentable: true
       },
       {
         type: "autodate",

--- a/pocketbase/pb_migrations/1500000011_config.js
+++ b/pocketbase/pb_migrations/1500000011_config.js
@@ -18,63 +18,37 @@ migrate((app) => {
         name: "category",
         type: "text",
         required: true,
-        presentable: false,
-        options: {
-          min: null,
-          max: 100,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         name: "subcategory",
         type: "text",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: 100,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         name: "config_key",
         type: "text",
         required: true,
-        presentable: true,
-        options: {
-          min: null,
-          max: 255,
-          pattern: ""
-        }
+        presentable: true
       },
       {
         name: "value",
         type: "json",
         required: true,
-        presentable: false,
-        options: {
-          maxSize: 2000000
-        }
+        presentable: false
       },
       {
         name: "metadata",
         type: "json",
         required: false,
-        presentable: false,
-        options: {
-          maxSize: 2000000
-        }
+        presentable: false
       },
       {
         name: "description",
         type: "text",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: 1000,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "autodate",
@@ -101,8 +75,7 @@ migrate((app) => {
     viewRule: '@request.auth.id != ""',
     createRule: '@request.auth.is_admin = true || @request.auth.cached_permissions ~ "registration.manage"',
     updateRule: '@request.auth.is_admin = true || @request.auth.cached_permissions ~ "registration.manage"',
-    deleteRule: '@request.auth.is_admin = true',
-    options: {}
+    deleteRule: '@request.auth.is_admin = true'
   });
 
   app.save(collection);

--- a/pocketbase/pb_migrations/1500000012_config_sections.js
+++ b/pocketbase/pb_migrations/1500000012_config_sections.js
@@ -18,34 +18,19 @@ migrate((app) => {
         name: "section_key",
         type: "text",
         required: true,
-        presentable: true,
-        options: {
-          min: null,
-          max: 100,
-          pattern: ""
-        }
+        presentable: true
       },
       {
         name: "title",
         type: "text",
         required: true,
-        presentable: false,
-        options: {
-          min: null,
-          max: 255,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         name: "description",
         type: "text",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: 1000,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         name: "display_order",
@@ -87,8 +72,7 @@ migrate((app) => {
     viewRule: '@request.auth.is_admin = true',
     createRule: '@request.auth.is_admin = true',
     updateRule: '@request.auth.is_admin = true',
-    deleteRule: '@request.auth.is_admin = true',
-    options: {}
+    deleteRule: '@request.auth.is_admin = true'
   });
 
   app.save(collection);

--- a/pocketbase/pb_migrations/1500000013_camp_sessions.js
+++ b/pocketbase/pb_migrations/1500000013_camp_sessions.js
@@ -35,12 +35,7 @@ migrate((app) => {
         type: "text",
         name: "name",
         required: true,
-        presentable: true,
-        options: {
-          min: null,
-          max: null,
-          pattern: ""
-        }
+        presentable: true
       },
       {
         type: "number",
@@ -55,21 +50,13 @@ migrate((app) => {
         type: "date",
         name: "start_date",
         required: true,
-        presentable: false,
-        options: {
-          min: "",
-          max: ""
-        }
+        presentable: false
       },
       {
         type: "date",
         name: "end_date",
         required: true,
-        presentable: false,
-        options: {
-          min: "",
-          max: ""
-        }
+        presentable: false
       },
       {
         type: "select",
@@ -92,12 +79,7 @@ migrate((app) => {
         type: "text",
         name: "description",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: null,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "bool",

--- a/pocketbase/pb_migrations/1500000014_staff_positions.js
+++ b/pocketbase/pb_migrations/1500000014_staff_positions.js
@@ -37,12 +37,7 @@ migrate((app) => {
         type: "text",
         name: "name",
         required: true,
-        presentable: true,
-        options: {
-          min: 1,
-          max: 500,
-          pattern: ""
-        }
+        presentable: true
       },
       {
         type: "relation",

--- a/pocketbase/pb_migrations/1500000017_bunk_plans.js
+++ b/pocketbase/pb_migrations/1500000017_bunk_plans.js
@@ -62,23 +62,13 @@ migrate((app) => {
         name: "name",
         type: "text",
         required: true,
-        presentable: false,
-        options: {
-          min: null,
-          max: null,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         name: "code",
         type: "text",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: null,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         name: "year",

--- a/pocketbase/pb_migrations/1500000018_bunk_requests.js
+++ b/pocketbase/pb_migrations/1500000018_bunk_requests.js
@@ -27,36 +27,21 @@ migrate((app) => {
         name: "requester_id",
         type: "number",
         required: true,
-        unique: false,
-        options: {
-          min: null,
-          max: null,
-          noDecimal: false
-        }
+        unique: false
       },
       // Target person (optional for age preferences)
       {
         name: "requestee_id",
         type: "number",
         required: false,
-        unique: false,
-        options: {
-          min: null,
-          max: null,
-          noDecimal: false
-        }
+        unique: false
       },
       // Target person name before resolution
       {
         name: "requested_person_name",
         type: "text",
         required: false,
-        unique: false,
-        options: {
-          min: null,
-          max: 200,
-          pattern: ""
-        }
+        unique: false
       },
       // Type of request
       {
@@ -119,70 +104,42 @@ migrate((app) => {
         name: "original_text",
         type: "text",
         required: false,
-        unique: false,
-        options: {
-          min: null,
-          max: 500,
-          pattern: ""
-        }
+        unique: false
       },
       // AI confidence score
       {
         name: "confidence_score",
         type: "number",
         required: false,
-        unique: false,
-        options: {
-          min: 0,
-          max: 1,
-          noDecimal: false
-        }
+        unique: false
       },
       // Confidence level description
       {
         name: "confidence_level",
         type: "text",
         required: false,
-        unique: false,
-        options: {
-          min: null,
-          max: 50,
-          pattern: ""
-        }
+        unique: false
       },
       // Detailed confidence explanation
       {
         name: "confidence_explanation",
         type: "json",
         required: false,
-        unique: false,
-        options: {
-          maxSize: 2000000
-        }
+        unique: false
       },
       // Parsing notes
       {
         name: "parse_notes",
         type: "text",
         required: false,
-        unique: false,
-        options: {
-          min: null,
-          max: 500,
-          pattern: ""
-        }
+        unique: false
       },
       // Manual resolution notes
       {
         name: "resolution_notes",
         type: "text",
         required: false,
-        unique: false,
-        options: {
-          min: null,
-          max: 500,
-          pattern: ""
-        }
+        unique: false
       },
       // Is this a reciprocal request?
       {
@@ -196,30 +153,21 @@ migrate((app) => {
         name: "keywords_found",
         type: "json",
         required: false,
-        unique: false,
-        options: {
-          maxSize: 2000000
-        }
+        unique: false
       },
       // Phase 1 AI reasoning details
       {
         name: "ai_p1_reasoning",
         type: "json",
         required: false,
-        unique: false,
-        options: {
-          maxSize: 2000000
-        }
+        unique: false
       },
       // Phase 3 AI reasoning details
       {
         name: "ai_p3_reasoning",
         type: "json",
         required: false,
-        unique: false,
-        options: {
-          maxSize: 2000000
-        }
+        unique: false
       },
       // Was this parsed by AI?
       {
@@ -233,12 +181,7 @@ migrate((app) => {
         name: "source_field",
         type: "text",
         required: true,
-        unique: false,
-        options: {
-          min: null,
-          max: 100,
-          pattern: ""
-        }
+        unique: false
       },
       // Position in the CSV field (1-based)
       {
@@ -255,12 +198,7 @@ migrate((app) => {
         name: "source_detail",
         type: "text",
         required: false,
-        unique: false,
-        options: {
-          min: null,
-          max: 200,
-          pattern: ""
-        }
+        unique: false
       },
       // Requires manual review flag
       {
@@ -274,46 +212,28 @@ migrate((app) => {
         name: "manual_review_reason",
         type: "text",
         required: false,
-        unique: false,
-        options: {
-          min: null,
-          max: 200,
-          pattern: ""
-        }
+        unique: false
       },
       // Additional metadata
       {
         name: "metadata",
         type: "json",
         required: false,
-        unique: false,
-        options: {
-          maxSize: 2000000
-        }
+        unique: false
       },
       // For age preference requests - the target preference
       {
         name: "age_preference_target",
         type: "text",
         required: false,
-        unique: false,
-        options: {
-          min: null,
-          max: 50,
-          pattern: ""
-        }
+        unique: false
       },
       // Conflict group ID for related requests
       {
         name: "conflict_group_id",
         type: "text",
         required: false,
-        unique: false,
-        options: {
-          min: null,
-          max: 100,
-          pattern: ""
-        }
+        unique: false
       },
       // Requires family decision
       {
@@ -362,10 +282,7 @@ migrate((app) => {
         name: "source_fields",
         type: "json",
         required: false,
-        unique: false,
-        options: {
-          maxSize: 2000000
-        }
+        unique: false
       },
       {
         type: "autodate",

--- a/pocketbase/pb_migrations/1500000020_original_bunk_requests.js
+++ b/pocketbase/pb_migrations/1500000020_original_bunk_requests.js
@@ -65,33 +65,19 @@ migrate((app) => {
         type: "text",
         name: "content",
         required: true,
-        presentable: false,
-        options: {
-          min: null,
-          max: null,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "text",
         name: "content_hash",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: 32,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "date",
         name: "processed",
         required: false,
-        presentable: false,
-        options: {
-          min: "",
-          max: ""
-        }
+        presentable: false
       },
       {
         type: "autodate",

--- a/pocketbase/pb_migrations/1500000021_saved_scenarios.js
+++ b/pocketbase/pb_migrations/1500000021_saved_scenarios.js
@@ -27,23 +27,13 @@ migrate((app) => {
         type: "text",
         name: "name",
         required: true,
-        presentable: false,
-        options: {
-          min: null,
-          max: 100,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "text",
         name: "description",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: 500,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "relation",
@@ -74,10 +64,7 @@ migrate((app) => {
         type: "json",
         name: "metadata",
         required: false,
-        presentable: false,
-        options: {
-          maxSize: 2000000
-        }
+        presentable: false
       },
       {
         type: "autodate",

--- a/pocketbase/pb_migrations/1500000023_solver_runs.js
+++ b/pocketbase/pb_migrations/1500000023_solver_runs.js
@@ -28,23 +28,13 @@ migrate((app) => {
         type: "text",
         name: "session",
         required: true,
-        presentable: false,
-        options: {
-          min: null,
-          max: 100,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "text",
         name: "run_id",
         required: true,
-        presentable: false,
-        options: {
-          min: null,
-          max: 100,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "select",
@@ -58,95 +48,61 @@ migrate((app) => {
         type: "number",
         name: "progress",
         required: false,
-        presentable: false,
-        options: {
-          min: 0,
-          max: 100,
-          noDecimal: false
-        }
+        presentable: false
       },
       {
         type: "date",
         name: "started_at",
         required: false,
-        presentable: false,
-        options: {
-          min: "",
-          max: ""
-        }
+        presentable: false
       },
       {
         type: "date",
         name: "completed_at",
         required: false,
-        presentable: false,
-        options: {
-          min: "",
-          max: ""
-        }
+        presentable: false
       },
       {
         type: "json",
         name: "logs",
         required: false,
-        presentable: false,
-        options: {
-          maxSize: 2000000
-        }
+        presentable: false
       },
       {
         type: "json",
         name: "error",
         required: false,
-        presentable: false,
-        options: {
-          maxSize: 2000000
-        }
+        presentable: false
       },
       {
         type: "json",
         name: "result",
         required: false,
-        presentable: false,
-        options: {
-          maxSize: 2000000
-        }
+        presentable: false
       },
       {
         type: "json",
         name: "details",
         required: false,
-        presentable: false,
-        options: {
-          maxSize: 2000000
-        }
+        presentable: false
       },
       {
         type: "json",
         name: "request_data",
         required: false,
-        presentable: false,
-        options: {
-          maxSize: 2000000
-        }
+        presentable: false
       },
       {
         type: "json",
         name: "assignment_counts",
         required: false,
-        presentable: false,
-        options: {
-          maxSize: 2000000
-        }
+        presentable: false
       },
       {
         type: "json",
         name: "stats",
         required: false,
-        presentable: false,
-        options: {
-          maxSize: 2000000
-        }
+        presentable: false
       },
       {
         type: "relation",
@@ -162,23 +118,13 @@ migrate((app) => {
         type: "text",
         name: "run_type",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: 50,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "text",
         name: "triggered_by",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: 100,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "number",

--- a/pocketbase/pb_migrations/1500000024_locked_groups.js
+++ b/pocketbase/pb_migrations/1500000024_locked_groups.js
@@ -41,14 +41,7 @@ migrate((app) => {
         type: "text",
         name: "name",
         required: false,
-        presentable: true,
-        options: {
-          autogeneratePattern: "",
-          min: 0,
-          max: 0,
-          pattern: "",
-          primaryKey: false
-        }
+        presentable: true
       },
       {
         type: "relation",
@@ -73,23 +66,13 @@ migrate((app) => {
         type: "text",
         name: "color",
         required: true,
-        presentable: false,
-        options: {
-          min: 1,
-          max: 20,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "text",
         name: "created_by",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: 255,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "autodate",

--- a/pocketbase/pb_migrations/1500000025_locked_group_members.js
+++ b/pocketbase/pb_migrations/1500000025_locked_group_members.js
@@ -51,12 +51,7 @@ migrate((app) => {
         type: "text",
         name: "added_by",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: 255,
-          pattern: ""
-        }
+        presentable: false
       }
     ],
     indexes: [

--- a/pocketbase/pb_migrations/1500000026_bunk_request_sources.js
+++ b/pocketbase/pb_migrations/1500000026_bunk_request_sources.js
@@ -67,24 +67,14 @@ migrate((app) => {
         type: "text",
         name: "source_field",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: 100,
-          pattern: ""
-        }
+        presentable: false
       },
       // AI parse notes from the original bunk_request when merging
       {
         type: "text",
         name: "parse_notes",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: 5000,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "autodate",

--- a/pocketbase/pb_migrations/1500000027_debug_parse_results.js
+++ b/pocketbase/pb_migrations/1500000027_debug_parse_results.js
@@ -54,19 +54,13 @@ migrate((app) => {
         type: "json",
         name: "parsed_intents",
         required: false,
-        presentable: false,
-        options: {
-          maxSize: 2000000
-        }
+        presentable: false
       },
       {
         type: "json",
         name: "ai_raw_response",
         required: false,
-        presentable: false,
-        options: {
-          maxSize: 2000000
-        }
+        presentable: false
       },
       {
         type: "number",
@@ -81,12 +75,7 @@ migrate((app) => {
         type: "text",
         name: "prompt_version",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: 50,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "number",
@@ -107,12 +96,7 @@ migrate((app) => {
         type: "text",
         name: "error_message",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: 5000,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "autodate",

--- a/pocketbase/pb_migrations/1500000030_staff.js
+++ b/pocketbase/pb_migrations/1500000030_staff.js
@@ -148,31 +148,19 @@ migrate((app) => {
         type: "date",
         name: "hire_date",
         required: false,
-        presentable: false,
-        options: {
-          min: "",
-          max: ""
-        }
+        presentable: false
       },
       {
         type: "date",
         name: "employment_start_date",
         required: false,
-        presentable: false,
-        options: {
-          min: "",
-          max: ""
-        }
+        presentable: false
       },
       {
         type: "date",
         name: "employment_end_date",
         required: false,
-        presentable: false,
-        options: {
-          min: "",
-          max: ""
-        }
+        presentable: false
       },
 
       // Contract tracking
@@ -180,31 +168,19 @@ migrate((app) => {
         type: "date",
         name: "contract_in_date",
         required: false,
-        presentable: false,
-        options: {
-          min: "",
-          max: ""
-        }
+        presentable: false
       },
       {
         type: "date",
         name: "contract_out_date",
         required: false,
-        presentable: false,
-        options: {
-          min: "",
-          max: ""
-        }
+        presentable: false
       },
       {
         type: "date",
         name: "contract_due_date",
         required: false,
-        presentable: false,
-        options: {
-          min: "",
-          max: ""
-        }
+        presentable: false
       },
 
       // Other fields

--- a/pocketbase/pb_migrations/1500000031_financial_transactions.js
+++ b/pocketbase/pb_migrations/1500000031_financial_transactions.js
@@ -70,41 +70,25 @@ migrate((app) => {
         type: "date",
         name: "post_date",
         required: false,
-        presentable: false,
-        options: {
-          min: "",
-          max: ""
-        }
+        presentable: false
       },
       {
         type: "date",
         name: "effective_date",
         required: false,
-        presentable: false,
-        options: {
-          min: "",
-          max: ""
-        }
+        presentable: false
       },
       {
         type: "date",
         name: "service_start_date",
         required: false,
-        presentable: false,
-        options: {
-          min: "",
-          max: ""
-        }
+        presentable: false
       },
       {
         type: "date",
         name: "service_end_date",
         required: false,
-        presentable: false,
-        options: {
-          min: "",
-          max: ""
-        }
+        presentable: false
       },
 
       // Reversal tracking
@@ -118,11 +102,7 @@ migrate((app) => {
         type: "date",
         name: "reversal_date",
         required: false,
-        presentable: false,
-        options: {
-          min: "",
-          max: ""
-        }
+        presentable: false
       },
 
       // Financial category relation
@@ -142,34 +122,19 @@ migrate((app) => {
         type: "text",
         name: "description",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: 1000,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "text",
         name: "transaction_note",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: 2000,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "text",
         name: "gl_account_note",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: 500,
-          pattern: ""
-        }
+        presentable: false
       },
 
       // Amounts
@@ -206,23 +171,13 @@ migrate((app) => {
         type: "text",
         name: "recognition_gl_account_id",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: 100,
-          pattern: ""
-        }
+        presentable: false
       },
       {
         type: "text",
         name: "deferral_gl_account_id",
         required: false,
-        presentable: false,
-        options: {
-          min: null,
-          max: 100,
-          pattern: ""
-        }
+        presentable: false
       },
 
       // Payment method relation


### PR DESCRIPTION
## What

PocketBase v0.23+ (we run v0.38.2) silently ignores the legacy `options:{}` field wrapper, so 24 migration files declared field constraints that **never applied** — those fields have always run at PB's defaults. This strips the wrappers so the migration source matches the live schema, adds a lint guard to prevent recurrence, and corrects the docs.

**Zero behavior change.** We write *nothing* in place of each wrapper; PB materializes the same defaults, so the stored `_collections` schema is byte-identical. Proven empirically:

```
$ scripts/dev/verify-consolidation.sh pb_migrations <origin/main baseline>
schemas match
```

## Why it's safe in prod

These migrations already ran; PB tracks them in `_migrations` by filename and won't re-apply on a content edit. Editing the files affects only a *from-scratch* build — and the harness proves that build is schema-identical to today.

## Changes

1. **Flatten 96 `options:{}` wrappers across 24 files** — strip the wrapper, preserve top-level props verbatim, add no constraint keys. Per the verified PB v0.38.2 field semantics, the dropped declarations were all running at PB defaults already (text→5000-char cap, json→1 MB, numbers/dates unconstrained). Numbers correctly omit `min`/`max` (never `0`, which is a literal bound).
2. **ESLint guard** (`no-restricted-syntax` on `Property[key.name='options'][value.type='ObjectExpression']`) so the wrapper can't silently eat a constraint again. Keyed on object-value so legitimate seed-data `options: [...]` arrays are not flagged.
3. **Doc corrections** — both `CLAUDE.md` files + the migrations reference said the wrapper causes "silent data **truncation**." It doesn't: the constraint is silently dropped → field uses PB's default cap, and over-cap writes are **rejected** (validation error), never truncated. Also fixed an internal contradiction in the reference doc ("`max: 0` = unlimited for text" → it's the 5000 default).
4. **Pre-push tooling fix** — the migration anti-pattern check grepped for any `options:`, false-flagging seed-data `options: [...]` arrays. Tightened to the object-form wrapper only.

## Verification

- `verify-consolidation.sh` (flattened vs `origin/main`): **schemas match**
- `pb-js-lint` (with new rule): green · `go build ./...`: clean
- Full pre-push suite green (5454 passed, mypy/tsc/ruff/shellcheck/markdownlint)

Closes #1257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified migration guidance: newer PocketBase silently ignores legacy wrapper syntax, so fields now fall back to platform defaults (affecting length/size/validation behavior).

* **Refactor**
  * Removed deprecated field-configuration patterns from migrations so schemas rely on platform defaults.
  * Updated linting to detect and forbid the obsolete wrapper pattern in migration files.

* **Chores**
  * Tightened pre-push verification to reduce false positives and limit printed matches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamflagg/kindred/pull/1715?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->