### PR TITLE
feat(frontend): post-check modal consolidation — honest counts, drop got-nothing false positives, fold in pre-check detail (#1712, #1716, #1717)

### DIFF
--- a/bunking/bunking_validator.py
+++ b/bunking/bunking_validator.py
@@ -1049,6 +1049,25 @@ class BunkingValidator:
                 satisfied_mp_requesters.add(int(pid))
             except TypeError, ValueError:
                 continue
+        # Satisfied vs total material-request counts per requester, so we can tell
+        # a fully-honored camper (every material request met -> safe to drop from
+        # the contact list) from a partially-honored one (some still unmet).
+        satisfied_count_by_req: dict[int, int] = {}
+        for pid, reqs in satisfied_material_parent_by_person.items():
+            try:
+                satisfied_count_by_req[int(pid)] = len(reqs)
+            except TypeError, ValueError:
+                continue
+        # Ungated (raw) count is intentional: every member of this cohort is
+        # *entirely* impossible (_gated(reqs) is empty), so the raw material-request
+        # count IS the impossible-request denominator. Partial-impossible campers
+        # never reach this cohort by construction.
+        total_count_by_req: dict[int, int] = {}
+        for pid, reqs in material_parent_by_person.items():
+            try:
+                total_count_by_req[int(pid)] = len(reqs)
+            except TypeError, ValueError:
+                continue
         bunks_map = bunk_by_id or {}
         for entry in impossible_mp_cohort or []:
             entry_cm_id = entry.get("cm_id")
@@ -1061,7 +1080,13 @@ class BunkingValidator:
                 honored_asgn = assignments_by_person.get(str(entry_cm_id))
                 honored_bunk = bunks_map.get(honored_asgn.bunk_cm_id) if honored_asgn else None
                 bunk_name = honored_bunk.name if honored_bunk else None
-            stats.mp_campers_entirely_impossible.append({**entry, "honored_in_plan": honored, "bunk_name": bunk_name})
+            fully_honored = False
+            if honored and isinstance(entry_cm_id, int):
+                total_mat = total_count_by_req.get(entry_cm_id, 0)
+                fully_honored = total_mat > 0 and satisfied_count_by_req.get(entry_cm_id, 0) == total_mat
+            stats.mp_campers_entirely_impossible.append(
+                {**entry, "honored_in_plan": honored, "fully_honored": fully_honored, "bunk_name": bunk_name}
+            )
 
         # Best-effort parent (socialize_with source_field) stats.
         stats.best_effort_parent_requests = sum(len(reqs) for reqs in best_effort_parent_by_person.values())

--- a/frontend/src/components/PdfExport/familyRows.test.ts
+++ b/frontend/src/components/PdfExport/familyRows.test.ts
@@ -447,4 +447,110 @@ describe('cohortLabel', () => {
     // rather than "sacrificing" it (gentler, clearer terminology).
     expect(cohortLabel('sacrificed_mp')).toBe('Request dropped')
   })
+  it('labels the impossible_request cohort as "Request can\'t be placed"', () => {
+    expect(cohortLabel('impossible_request')).toBe("Request can't be placed")
+  })
+})
+
+describe('buildFamilyRows — #1717 pre-check impossibility fold-in', () => {
+  it('folds in a pre-check impossibility for a camper not in any cohort', () => {
+    const stats = _statistics({ mp_campers_entirely_impossible: [] })
+    const report = _report({
+      flat: [
+        {
+          request_id: 'r1',
+          reason_code: 'target_not_in_solver',
+          reason_message: '',
+          request_type: 'bunk_with',
+          source_field: 'bunk_request_form',
+          requester: { cm_id: 9, name: 'Noah Davis', grade: 4, gender: 'M' },
+          requestee: null,
+          detail: {},
+          bucket: 'material_parent',
+        },
+      ],
+    })
+    const rows = buildFamilyRows(stats, report)
+    const row = rows.find((r) => r.cm_id === '9')!
+    expect(row).toBeDefined()
+    expect(row.cohort).toBe('impossible_request')
+    expect(row.subRows[0]!.reasonCodes).toEqual(['target_not_in_solver'])
+  })
+
+  it('does NOT duplicate a camper already shown via a cohort', () => {
+    const stats = _statistics({
+      mp_campers_entirely_impossible: [
+        {
+          cm_id: 9,
+          name: 'Noah Davis',
+          grade: 4,
+          gender: 'M',
+          session_cm_id: 10,
+          reason_codes: ['target_not_in_solver'],
+          honored_in_plan: false,
+          fully_honored: false,
+        },
+      ],
+    })
+    const report = _report({
+      flat: [
+        {
+          request_id: 'r1',
+          reason_code: 'target_not_in_solver',
+          reason_message: '',
+          request_type: 'bunk_with',
+          source_field: 'bunk_request_form',
+          requester: { cm_id: 9, name: 'Noah Davis', grade: 4, gender: 'M' },
+          requestee: null,
+          detail: {},
+          bucket: 'material_parent',
+        },
+      ],
+    })
+    const rows = buildFamilyRows(stats, report)
+    expect(rows.filter((r) => r.cm_id === '9')).toHaveLength(1)
+  })
+
+  it('mirrors the pre-check conditional filter: socialize_with hidden ONLY under age_pref', () => {
+    // Parity with PreValidationResultsModal (lines 581-584): it filters out
+    // socialize_with rows (isMaterialRequest=false) ONLY for the
+    // age_pref_no_eligible_grade reason (Group 65 #1537); every other reason
+    // shows all items. So a socialize_with friend who isn't enrolled
+    // (target_not_in_solver) is SHOWN by the pre-check and must survive here too.
+    const stats = _statistics({ mp_campers_entirely_impossible: [] })
+    const report = _report({
+      flat: [
+        // EXCLUDED: socialize_with under age_pref — pre-check hides this.
+        {
+          request_id: 'r2',
+          reason_code: 'age_pref_no_eligible_grade',
+          reason_message: '',
+          request_type: 'age_preference',
+          source_field: 'socialize_with',
+          requester: { cm_id: 77, name: 'Lily Adams', grade: 5, gender: 'F' },
+          requestee: null,
+          detail: {},
+          bucket: 'immaterial_parent',
+        },
+        // INCLUDED: socialize_with under a NON-age-pref reason — pre-check shows
+        // this; the old blanket filter wrongly dropped it.
+        {
+          request_id: 'r3',
+          reason_code: 'target_not_in_solver',
+          reason_message: '',
+          request_type: 'bunk_with',
+          source_field: 'socialize_with',
+          requester: { cm_id: 88, name: 'Mason Reed', grade: 6, gender: 'M' },
+          requestee: null,
+          detail: {},
+          bucket: 'immaterial_parent',
+        },
+      ],
+    })
+    const rows = buildFamilyRows(stats, report)
+    expect(rows.find((r) => r.cm_id === '77')).toBeUndefined()
+    const included = rows.find((r) => r.cm_id === '88')
+    expect(included).toBeDefined()
+    expect(included!.cohort).toBe('impossible_request')
+  })
 })

--- a/frontend/src/components/PdfExport/familyRows.test.ts
+++ b/frontend/src/components/PdfExport/familyRows.test.ts
@@ -186,7 +186,9 @@ describe('buildFamilyRows — Group 65 #1540', () => {
 })
 
 describe('buildFamilyRows — honored reconciliation', () => {
-  it('sources got_nothing from statistics cohort and marks honored sub-rows', () => {
+  it('re-labels partially-honored campers as sacrificed_mp (not got_nothing / "Met by same age cabin")', () => {
+    // honored_in_plan=true but no fully_honored → partial → sacrificed_mp, NOT got_nothing.
+    // This is the fix for #1716: previously produced got_nothing + "Met by same age cabin" (false positive).
     const stats = _statistics({
       mp_campers_entirely_impossible: [
         {
@@ -204,10 +206,11 @@ describe('buildFamilyRows — honored reconciliation', () => {
     // Pre-check report intentionally empty: statistics is authoritative.
     const rows = buildFamilyRows(stats, _report())
     expect(rows).toHaveLength(1)
-    expect(rows[0]!.cohort).toBe('got_nothing')
+    expect(rows[0]!.cohort).toBe('sacrificed_mp')
     expect(rows[0]!.subRows[0]!.honoredInPlan).toBe(true)
     expect(rows[0]!.subRows[0]!.bunkName).toBe('Redwood 4')
-    expect(rows[0]!.subRows[0]!.detail).toBe('Met by same age cabin Redwood 4')
+    expect(rows[0]!.subRows[0]!.detail).not.toContain('Met by same age cabin')
+    expect(rows[0]!.subRows[0]!.detail).toContain('Material request unmet')
   })
 
   it('keeps the impossible detail when honored_in_plan is false', () => {
@@ -247,6 +250,50 @@ describe('buildFamilyRows — honored reconciliation', () => {
     expect(rows).toHaveLength(1)
     expect(rows[0]!.name).toBe('Liam Garcia')
     expect(rows[0]!.subRows[0]!.honoredInPlan).toBeUndefined()
+  })
+
+  it('drops fully-honored campers (got their whole material ask)', () => {
+    // #1716: fully_honored=true means camper got everything; don't show them in the contact list.
+    const stats = _statistics({
+      mp_campers_entirely_impossible: [
+        {
+          cm_id: 1,
+          name: 'Emma Johnson',
+          grade: 7,
+          gender: 'F',
+          session_cm_id: 10,
+          reason_codes: ['age_pref_no_eligible_grade'],
+          honored_in_plan: true,
+          fully_honored: true,
+        },
+      ],
+    })
+    const rows = buildFamilyRows(stats, _report())
+    expect(rows.find((r) => r.cm_id === '1')).toBeUndefined()
+  })
+
+  it('re-labels partially-honored campers as request-dropped, not "met"', () => {
+    // #1716: honored_in_plan=true + fully_honored=false → partial → sacrificed_mp,
+    // detail must NOT contain "Met by same age cabin".
+    const stats = _statistics({
+      mp_campers_entirely_impossible: [
+        {
+          cm_id: 2,
+          name: 'Liam Garcia',
+          grade: 5,
+          gender: 'M',
+          session_cm_id: 10,
+          reason_codes: ['target_not_in_solver'],
+          honored_in_plan: true,
+          fully_honored: false,
+        },
+      ],
+    })
+    const rows = buildFamilyRows(stats, _report())
+    const row = rows.find((r) => r.cm_id === '2')!
+    expect(row).toBeDefined()
+    expect(row.cohort).toBe('sacrificed_mp')
+    expect(row.subRows[0]!.detail).not.toContain('Met by same age cabin')
   })
 
   it('treats an explicit empty stats cohort as authoritative (no fallback to pre-check)', () => {

--- a/frontend/src/components/PdfExport/familyRows.ts
+++ b/frontend/src/components/PdfExport/familyRows.ts
@@ -1,7 +1,13 @@
 import type { ValidationStatistics, ImpossibilityReport } from '../../services/solver'
 import { friendlyReasonLabel } from '../impossibility/reasonHints'
+import { isMaterialRequest } from '../../utils/requestBucket'
 
-export type FamilyCohort = 'got_nothing' | 'violated' | 'priority_unmet' | 'sacrificed_mp'
+export type FamilyCohort =
+  | 'got_nothing'
+  | 'violated'
+  | 'priority_unmet'
+  | 'sacrificed_mp'
+  | 'impossible_request'
 
 export type FamilySubRow = {
   session: string
@@ -142,6 +148,37 @@ export function buildFamilyRows(
     })
   }
 
+  // #1717: fold the full pre-check impossibility detail into Families to contact.
+  // Mirror the pre-check filter EXACTLY: PreValidationResultsModal hides
+  // socialize_with rows (isMaterialRequest=false) ONLY for the
+  // age_pref_no_eligible_grade reason (Group 65 #1537); every other reason shows
+  // all items. The modal never filters by bucket directly — source_field is the
+  // actual predicate, and only for that one reason. Items already surfaced via a
+  // cohort row are skipped to avoid duplication.
+  const seenCmIds = new Set(raw.map((r) => r.cm_id))
+  for (const item of impossibilityReport.flat ?? []) {
+    // Parity with pre-check: only socialize_with rows under age_pref are hidden;
+    // a socialize_with friend who isn't enrolled (target_not_in_solver) is still
+    // shown by the pre-check, so it must survive the fold-in too.
+    if (
+      item.reason_code === 'age_pref_no_eligible_grade' &&
+      !isMaterialRequest({ source_field: item.source_field })
+    )
+      continue
+    const cmId = String(item.requester.cm_id)
+    if (seenCmIds.has(cmId)) continue // already surfaced via a cohort — don't duplicate
+    raw.push({
+      cm_id: cmId,
+      name: item.requester.name,
+      grade: item.requester.grade ?? 0,
+      gender: item.requester.gender ?? '',
+      cohort: 'impossible_request',
+      session: String((item.detail?.['requester_session'] as number | undefined) ?? ''),
+      detail: friendlyReasonLabel(item.reason_code),
+      reasonCodes: [item.reason_code],
+    })
+  }
+
   // Collapse per-(cm_id, cohort)
   const grouped = new Map<string, FamilyRowData>()
   for (const r of raw) {
@@ -185,4 +222,6 @@ export const cohortLabel = (c: FamilyCohort): string =>
       ? 'Not-bunk-with violated'
       : c === 'sacrificed_mp'
         ? 'Request dropped'
-        : 'Priority unmet'
+        : c === 'impossible_request'
+          ? "Request can't be placed"
+          : 'Priority unmet'

--- a/frontend/src/components/PdfExport/familyRows.ts
+++ b/frontend/src/components/PdfExport/familyRows.ts
@@ -3,11 +3,7 @@ import { friendlyReasonLabel } from '../impossibility/reasonHints'
 import { isMaterialRequest } from '../../utils/requestBucket'
 
 export type FamilyCohort =
-  | 'got_nothing'
-  | 'violated'
-  | 'priority_unmet'
-  | 'sacrificed_mp'
-  | 'impossible_request'
+  'got_nothing' | 'violated' | 'priority_unmet' | 'sacrificed_mp' | 'impossible_request'
 
 export type FamilySubRow = {
   session: string

--- a/frontend/src/components/PdfExport/familyRows.ts
+++ b/frontend/src/components/PdfExport/familyRows.ts
@@ -57,15 +57,17 @@ export function buildFamilyRows(
   const statsCohort = statistics.mp_campers_entirely_impossible
   if (statsCohort !== undefined) {
     for (const c of statsCohort) {
+      if (c.fully_honored) continue // #1716: got their whole material ask — drop (modal footer counts these)
+      const partial = Boolean(c.honored_in_plan && !c.fully_honored)
       raw.push({
         cm_id: String(c.cm_id),
         name: c.name,
         grade: c.grade ?? 0,
         gender: c.gender ?? '',
-        cohort: 'got_nothing',
+        cohort: partial ? 'sacrificed_mp' : 'got_nothing',
         session: String(c.session_cm_id),
-        detail: c.honored_in_plan
-          ? `Met by same age cabin${c.bunk_name ? ` ${c.bunk_name}` : ''}`
+        detail: partial
+          ? `Material request unmet · ${c.reason_codes.map(friendlyReasonLabel).join(', ')}`
           : `All requests impossible · ${c.reason_codes.map(friendlyReasonLabel).join(', ')}`,
         reasonCodes: c.reason_codes,
         honoredInPlan: c.honored_in_plan,

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -136,8 +136,12 @@ describe('PostValidationResultsModal — best-effort line removed (Stage 3b.2)',
   })
 })
 
-describe('PostValidationResultsModal — banner sub-text (Stage 3b.2)', () => {
-  it('shows kid-count copy when ≥1 kid has an unmet parent request', () => {
+describe('PostValidationResultsModal — banner sub-text (Stage 3b.2 → Task 6 action-split)', () => {
+  // NOTE (Task 6): The old "N kids missed a parent request" / "All N parent requests fulfilled"
+  // sublabel overrides have been removed in favor of the action-split sublabel
+  // ("N families to contact · M cabins to review"). Tests updated accordingly.
+
+  it('shows action-split "Nothing to review" when rate is low but no actionable rows exist', () => {
     render(
       <PostValidationResultsModal
         sessionCmId={1000001}
@@ -151,10 +155,13 @@ describe('PostValidationResultsModal — banner sub-text (Stage 3b.2)', () => {
         })}
       />
     )
-    expect(screen.getByText(/6 kids missed a parent request/i)).toBeInTheDocument()
+    // No family rows (no mp_campers_entirely_impossible etc.), no cabin issues
+    // → action-split sublabel says "Nothing to review"
+    expect(screen.queryByText(/6 kids missed a parent request/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/nothing to review/i)).toBeInTheDocument()
   })
 
-  it('uses singular "kid" when exactly 1 kid is unmet', () => {
+  it('does not show "N kids missed" copy in the sublabel (removed by Task 6)', () => {
     render(
       <PostValidationResultsModal
         sessionCmId={1000001}
@@ -168,11 +175,11 @@ describe('PostValidationResultsModal — banner sub-text (Stage 3b.2)', () => {
         })}
       />
     )
-    expect(screen.getByText(/1 kid missed a parent request/i)).toBeInTheDocument()
+    expect(screen.queryByText(/1 kid missed a parent request/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/1 kids missed/i)).not.toBeInTheDocument()
   })
 
-  it('shows "All N parent requests fulfilled" when zero kids unmet but parent requests exist', () => {
+  it('does not show "All N parent requests fulfilled" sublabel (removed by Task 6)', () => {
     render(
       <PostValidationResultsModal
         sessionCmId={1000001}
@@ -186,10 +193,12 @@ describe('PostValidationResultsModal — banner sub-text (Stage 3b.2)', () => {
         })}
       />
     )
-    expect(screen.getByText(/all 12 parent requests fulfilled/i)).toBeInTheDocument()
+    expect(screen.queryByText(/all 12 parent requests fulfilled/i)).not.toBeInTheDocument()
+    // No action items + high satisfaction → "Bunking looks great" (Excellent tier)
+    expect(screen.getByText(/bunking looks great/i)).toBeInTheDocument()
   })
 
-  it('uses singular "request" when exactly 1 parent request exists and is fulfilled', () => {
+  it('does not show singular "All 1 parent request fulfilled" sublabel (removed by Task 6)', () => {
     render(
       <PostValidationResultsModal
         sessionCmId={1000001}
@@ -203,10 +212,10 @@ describe('PostValidationResultsModal — banner sub-text (Stage 3b.2)', () => {
         })}
       />
     )
-    expect(screen.getByText(/all 1 parent request fulfilled/i)).toBeInTheDocument()
+    expect(screen.queryByText(/all 1 parent request fulfilled/i)).not.toBeInTheDocument()
   })
 
-  it('falls back to per-tier generic sub when zero parent requests in session', () => {
+  it('falls back to per-tier generic sub when zero parent requests and no action items', () => {
     render(
       <PostValidationResultsModal
         sessionCmId={1000001}
@@ -224,7 +233,7 @@ describe('PostValidationResultsModal — banner sub-text (Stage 3b.2)', () => {
         })}
       />
     )
-    // Expect existing per-tier copy ("Bunking looks great" for Excellent tier)
+    // No action items, Excellent tier → "Bunking looks great"
     expect(screen.getByText(/bunking looks great/i)).toBeInTheDocument()
     expect(screen.queryByText(/missed a parent request/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/parent requests fulfilled/i)).not.toBeInTheDocument()
@@ -381,9 +390,13 @@ describe('PostValidationResultsModal — parent stats tile (Stage 3b.2)', () => 
 // #1105: Unmet parent requests drill-down section
 // ---------------------------------------------------------------------------
 
-describe('PostValidationResultsModal — KPI "issues" tile excludes suppressed types', () => {
-  it('counts only non-suppressed issues so the tile matches the sections below', () => {
-    // 2 visible + 3 suppressed = 5 raw; tile should show "2".
+describe('PostValidationResultsModal — KPI "issues" tile removed (Task 6 supersedes)', () => {
+  // NOTE (Task 6): The "issues" KPI tile has been removed. Suppressed-type filtering is
+  // now enforced by the section rendering itself — suppressed types never appear in
+  // "Cabins to review" (ISSUE_SECTION maps them to 'hidden'). The tile's old job of
+  // "count visible issues" is no longer needed in the headline; action counts live in
+  // the sublabel instead.
+  it('does not render an "issues" KPI tile (removed in Task 6)', () => {
     const issues = [
       { type: 'capacity_violation', severity: 'error', message: 'Bunk Pine 1 is over capacity' },
       { type: 'age_spread_warning', severity: 'warning', message: 'Bunk Oak 2 has excessive age' },
@@ -399,9 +412,12 @@ describe('PostValidationResultsModal — KPI "issues" tile excludes suppressed t
         results={{ statistics: makeStats(), issues, validated_at: '2025-06-01T12:00:00Z' }}
       />
     )
-    const tileLabel = screen.getByText(/^issues$/i)
-    const tileValue = tileLabel.previousElementSibling
-    expect(tileValue?.textContent).toBe('2')
+    // Tile is gone — no "issues" label in the KPI grid
+    expect(screen.queryByText(/^issues$/i)).toBeNull()
+    // The "Cabins to review" section naturally excludes suppressed types
+    // (capacity_violation + age_spread_warning both in ISSUE_SECTION 'cabins',
+    //  3 suppressed types not in it at all)
+    expect(screen.getAllByText(/Cabins to review/i).length).toBeGreaterThanOrEqual(1)
   })
 })
 
@@ -829,7 +845,9 @@ describe('PostValidationResultsModal — Capacity by gender section', () => {
   })
 })
 
-describe('PostValidationResultsModal — Bunks needing attention', () => {
+describe('PostValidationResultsModal — Cabins to review (formerly "Bunks needing attention")', () => {
+  // NOTE (Task 6): The "Bunks needing attention" section was renamed to "Cabins to review"
+  // and now uses ISSUE_SECTION classification. Tests updated accordingly.
   it('groups bunk-level issues into one row per bunk with chips', () => {
     // Real validator emits structured `details.bunk_name` for every
     // bunk-level issue; the extractor reads that first and falls back to
@@ -862,7 +880,9 @@ describe('PostValidationResultsModal — Bunks needing attention', () => {
         results={{ ...makeResults(), issues }}
       />
     )
-    expect(screen.getByText(/bunks needing attention/i)).toBeInTheDocument()
+    // Section heading is now "Cabins to review" (renamed from "Bunks needing attention")
+    expect(screen.getAllByText(/cabins to review/i).length).toBeGreaterThan(0)
+    expect(screen.queryByText(/bunks needing attention/i)).not.toBeInTheDocument()
     // Pine 3 appears in both the bunk row and the issues list — use getAllByText
     expect(screen.getAllByText(/Pine 3/).length).toBeGreaterThan(0)
     expect(screen.getAllByText(/Oak 2/).length).toBeGreaterThan(0)
@@ -878,11 +898,11 @@ describe('PostValidationResultsModal — Bunks needing attention', () => {
         results={{ ...makeResults(), issues }}
       />
     )
-    // The "Other issues" subtitle mentions "Bunks needing attention" — use a
-    // heading-role query to verify the Bunks section heading itself is absent.
-    expect(
-      screen.queryByRole('heading', { name: /bunks needing attention/i })
-    ).not.toBeInTheDocument()
+    // No cabin-level issues (unassigned_campers goes to Other issues) → section absent.
+    // Use heading role to avoid matching "Cabins to review" appearing in the
+    // "Other issues" description string.
+    expect(screen.queryByRole('heading', { name: /cabins to review/i })).not.toBeInTheDocument()
+    expect(screen.queryByText(/bunks needing attention/i)).not.toBeInTheDocument()
   })
 })
 
@@ -982,7 +1002,8 @@ describe('PostValidationResultsModal — Families to contact', () => {
         impossibilityReport={impossibilityReport}
       />
     )
-    expect(screen.getByText(/families to contact/i)).toBeInTheDocument()
+    // Section heading (and possibly the sublabel) both match — use getAllByText
+    expect(screen.getAllByText(/families to contact/i).length).toBeGreaterThanOrEqual(1)
     // Rows are now flat divs with always-visible sub-lines (no expand toggle).
     // Verify grade-first ordering by DOM position of each name span.
     // Grades: Olivia=4, Riley=4, Emma=5, Sophia=5 → grade-first, name tiebreak
@@ -1042,7 +1063,7 @@ describe('PostValidationResultsModal — KPI tiles use MSP signal', () => {
         results={makeResults(stats)}
       />
     )
-    expect(screen.getByText(/83\s*%/)).toBeInTheDocument()
+    expect(screen.getAllByText(/83\s*%/).length).toBeGreaterThanOrEqual(1)
   })
 })
 
@@ -1170,11 +1191,11 @@ describe('PostValidationResultsModal — bunk issue rows (always-visible details
 })
 
 // ---------------------------------------------------------------------------
-// Issue #1481 Item 2 — Sub-label section-aware breakdown
+// Issue #1481 Item 2 — Sub-label section-aware breakdown (updated for Task 6 action-split)
 // ---------------------------------------------------------------------------
 
 describe('PostValidationResultsModal — sub-label breakdown (#1481)', () => {
-  it('shows "no issues to review" when issues list is empty', () => {
+  it('shows "Nothing to review" when issues list is empty and satisfaction is moderate', () => {
     render(
       <PostValidationResultsModal
         sessionCmId={1000001}
@@ -1189,12 +1210,13 @@ describe('PostValidationResultsModal — sub-label breakdown (#1481)', () => {
         })}
       />
     )
-    // The "Needs Attention" tier is triggered by rate 0.5 — sub-label shows empty state
-    expect(screen.getByText(/no issues to review/i)).toBeInTheDocument()
+    // "Needs Attention" tier, no action items → "Nothing to review"
+    expect(screen.getByText(/nothing to review/i)).toBeInTheDocument()
   })
 
-  it('shows section-aware breakdown with families, bunks, and other counts', () => {
-    // 1 family row (got_nothing camper), 1 bunk issue, 1 other issue
+  it('shows action-split breakdown with families and cabins counts', () => {
+    // 1 family row (got_nothing camper), 1 cabin issue (age_spread_warning).
+    // unassigned_camper is present but does NOT count toward cabins (#1712).
     const impossibilityReport = makeImpossibilityReport({
       mp_campers_entirely_impossible: [
         {
@@ -1240,14 +1262,13 @@ describe('PostValidationResultsModal — sub-label breakdown (#1481)', () => {
         impossibilityReport={impossibilityReport}
       />
     )
-    // Sub-label is in the header <p class="text-muted-foreground text-sm">
-    // It should contain sections for family/bunk separated by "·"
-    const sublabelMatches = screen.getAllByText(/famil.*bunk|bunk.*famil/i)
-    expect(sublabelMatches.length).toBeGreaterThanOrEqual(1)
+    // Sub-label should contain "family" and "cabin" action counts (Task 6 format)
+    const allText = document.body.textContent ?? ''
+    expect(allText).toMatch(/famil.*cabin|cabin.*famil/i)
   })
 
   it('omits zero-count sections from breakdown', () => {
-    // Only bunk issues — no family rows, no other issues
+    // Only 1 cabin issue — no family rows
     const issues = [
       {
         type: 'age_spread_warning',
@@ -1277,9 +1298,9 @@ describe('PostValidationResultsModal — sub-label breakdown (#1481)', () => {
     // "0 families" or "0 other" should NOT appear
     expect(screen.queryByText(/0 famil/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/0 other/i)).not.toBeInTheDocument()
-    // "1 bunk" should appear somewhere in the document (the sub-label)
-    const bunkMatches = screen.getAllByText(/1 bunk/i)
-    expect(bunkMatches.length).toBeGreaterThanOrEqual(1)
+    // "1 cabin to review" should appear in the sub-label
+    const cabinMatches = screen.getAllByText(/1 cabin to review/i)
+    expect(cabinMatches.length).toBeGreaterThanOrEqual(1)
   })
 
   it('does not show raw issues.length as the sub-label', () => {
@@ -1317,15 +1338,19 @@ describe('PostValidationResultsModal — sub-label breakdown (#1481)', () => {
     )
     // The old label "2 issues to review" should not appear
     expect(screen.queryByText(/2 issues? to review/i)).not.toBeInTheDocument()
+    // Action-split sublabel should show "2 cabins to review"
+    expect(screen.getAllByText(/2 cabins to review/i).length).toBeGreaterThanOrEqual(1)
   })
 
-  it('uses singular "other issue" when otherCount === 1', () => {
-    // One non-bunk issue → should render "1 other issue", not "1 other issues"
+  it('uses singular "cabin" in the sub-label when only 1 cabin issue', () => {
+    // NOTE (Task 6): "Other issues" concept in the sublabel is replaced by "N cabins to review".
+    // Only bunk-composition issues (ISSUE_SECTION==='cabins') count toward cabins.
     const issues = [
       {
-        type: 'unassigned_camper',
+        type: 'capacity_violation',
         severity: 'error',
-        message: 'Liam Garcia is not assigned to any bunk',
+        message: 'Bunk Pine 3 is over capacity (9/8)',
+        details: { bunk_name: 'Pine 3', assigned: 9, max_size: 8 },
       },
     ]
     render(
@@ -1346,22 +1371,25 @@ describe('PostValidationResultsModal — sub-label breakdown (#1481)', () => {
         }}
       />
     )
-    expect(screen.getAllByText(/1 other issue(?!s)/i).length).toBeGreaterThanOrEqual(1)
-    expect(screen.queryByText(/1 other issues/i)).not.toBeInTheDocument()
+    // One cabin-composition issue → "1 cabin to review"
+    expect(screen.getAllByText(/1 cabin to review/i).length).toBeGreaterThanOrEqual(1)
+    expect(screen.queryByText(/1 cabin to reviews/i)).not.toBeInTheDocument()
   })
 
-  it('uses plural "other issues" when otherCount > 1', () => {
-    // Two non-bunk issues → should render "2 other issues", not "2 other"
+  it('uses plural "cabins" when cabinCount > 1', () => {
+    // Two distinct cabin-composition issues → "2 cabins to review"
     const issues = [
       {
-        type: 'unassigned_camper',
+        type: 'capacity_violation',
         severity: 'error',
-        message: 'Liam Garcia is not assigned to any bunk',
+        message: 'Bunk Pine 3 is over capacity (9/8)',
+        details: { bunk_name: 'Pine 3', assigned: 9, max_size: 8 },
       },
       {
-        type: 'unassigned_camper',
-        severity: 'error',
-        message: 'Olivia Chen is not assigned to any bunk',
+        type: 'age_spread_warning',
+        severity: 'warning',
+        message: 'Bunk Oak 2 has excessive age spread (26.0 months)',
+        details: { bunk_name: 'Oak 2', age_spread_months: 26, max_allowed: 24 },
       },
     ]
     render(
@@ -1382,7 +1410,8 @@ describe('PostValidationResultsModal — sub-label breakdown (#1481)', () => {
         }}
       />
     )
-    expect(screen.getAllByText(/2 other issues/i).length).toBeGreaterThanOrEqual(1)
+    // Two cabin-composition issues (different bunks) → "2 cabins to review"
+    expect(screen.getAllByText(/2 cabins to review/i).length).toBeGreaterThanOrEqual(1)
   })
 })
 
@@ -1948,6 +1977,7 @@ describe('PostValidationResultsModal — honored subtext (Task 5)', () => {
               session_cm_id: 1000001,
               reason_codes: ['age_pref_no_eligible_grade'],
               honored_in_plan: true,
+              fully_honored: false,
               bunk_name: 'Redwood 4',
             },
           ],
@@ -1957,5 +1987,317 @@ describe('PostValidationResultsModal — honored subtext (Task 5)', () => {
     expect(screen.getByText(/met by same age cabin/i)).toBeInTheDocument()
     expect(screen.getByText('Redwood 4')).toBeInTheDocument()
     expect(screen.queryByText(/All requests impossible/i)).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Task 6 — Action-split sections, severity, headline, honest footer; remove issues tile
+// ---------------------------------------------------------------------------
+
+describe('PostValidationResultsModal — issues KPI tile removed (Task 6)', () => {
+  it('does not render the standalone "issues" KPI tile', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{ statistics: makeStats(), issues: [], validated_at: '2025-06-01T12:00:00Z' }}
+      />
+    )
+    expect(screen.queryByText(/^issues$/i)).toBeNull()
+  })
+})
+
+describe('PostValidationResultsModal — Cabins to review section (Task 6)', () => {
+  it('renders both action sections when there are family + cabin problems', () => {
+    const impossibilityReport = makeImpossibilityReport({
+      mp_campers_entirely_impossible: [
+        {
+          cm_id: 1000001,
+          name: 'Emma Johnson',
+          grade: 5,
+          gender: 'F',
+          reason_codes: ['grade_compatibility'],
+          session_cm_id: 1000001,
+        },
+      ],
+      by_reason: {},
+    })
+    const issues = [
+      {
+        type: 'capacity_violation',
+        severity: 'error',
+        message: 'Bunk Pine 3 is over capacity (9/8)',
+        details: { bunk_name: 'Pine 3', assigned: 9, max_size: 8 },
+      },
+    ]
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{ statistics: makeStats(), issues, validated_at: '2025-06-01T12:00:00Z' }}
+        impossibilityReport={impossibilityReport}
+      />
+    )
+    expect(screen.getByText(/Families to contact/i)).toBeInTheDocument()
+    expect(screen.getByText(/Cabins to review/i)).toBeInTheDocument()
+  })
+
+  it('hides "Cabins to review" when there are no cabin-level issues', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{ statistics: makeStats(), issues: [], validated_at: '2025-06-01T12:00:00Z' }}
+      />
+    )
+    expect(screen.queryByText(/Cabins to review/i)).not.toBeInTheDocument()
+  })
+
+  it('cabin count equals rendered cabin rows — unassigned_camper not counted (#1712)', () => {
+    // Invariant: the "N cabins to review" headline count must equal the number of
+    // cabin rows actually rendered. unassigned_camper is NOT a cabin issue (it is
+    // surfaced via the dedicated unassigned block / Other issues), so adding one
+    // must NOT inflate the cabin count beyond the single bunk-composition issue.
+    const issues = [
+      {
+        type: 'capacity_violation',
+        severity: 'error',
+        message: 'Bunk Pine 3 is over capacity (9/8)',
+        details: { bunk_name: 'Pine 3', assigned: 9, max_size: 8 },
+      },
+      {
+        type: 'unassigned_camper',
+        severity: 'error',
+        message: 'Liam Garcia is not assigned to any bunk',
+      },
+    ]
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{ statistics: makeStats(), issues, validated_at: '2025-06-01T12:00:00Z' }}
+      />
+    )
+    // Exactly one cabin row is rendered (Pine 3 capacity_violation only).
+    const cabinRows = screen.getAllByTestId('cabin-review-row')
+    expect(cabinRows).toHaveLength(1)
+    // The headline cabin count matches the rendered rows (singular "1 cabin to review").
+    expect(screen.getAllByText(/1 cabin to review/i).length).toBeGreaterThanOrEqual(1)
+    // It must NOT claim "2 cabins" (the pre-fix bug counted the unassigned one).
+    expect(screen.queryByText(/2 cabins to review/i)).not.toBeInTheDocument()
+  })
+
+  it('cabin count counts BUNKS, not issues — one bunk with two issues is "1 cabin" (Fix 1)', () => {
+    // A single bunk (Pine 3) with TWO cabin-composition issues must render ONE
+    // cabin row and the headline must say "1 cabin to review", not "2 cabins".
+    const issues = [
+      {
+        type: 'capacity_violation',
+        severity: 'error',
+        message: 'Bunk Pine 3 is over capacity (9/8)',
+        details: { bunk_name: 'Pine 3', assigned: 9, max_size: 8 },
+      },
+      {
+        type: 'age_spread_warning',
+        severity: 'warning',
+        message: 'Bunk Pine 3 has excessive age spread (26.0 months)',
+        details: { bunk_name: 'Pine 3', age_spread_months: 26, max_allowed: 24 },
+      },
+    ]
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{ statistics: makeStats(), issues, validated_at: '2025-06-01T12:00:00Z' }}
+      />
+    )
+    expect(screen.getAllByTestId('cabin-review-row')).toHaveLength(1)
+    expect(screen.getAllByText(/1 cabin to review/i).length).toBeGreaterThanOrEqual(1)
+    expect(screen.queryByText(/2 cabins to review/i)).not.toBeInTheDocument()
+  })
+
+  it('each cabin row has a severity dot (Fix 2)', () => {
+    const issues = [
+      {
+        type: 'capacity_violation',
+        severity: 'error',
+        message: 'Bunk Pine 3 is over capacity (9/8)',
+        details: { bunk_name: 'Pine 3', assigned: 9, max_size: 8 },
+      },
+    ]
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{ statistics: makeStats(), issues, validated_at: '2025-06-01T12:00:00Z' }}
+      />
+    )
+    const row = screen.getByTestId('cabin-review-row')
+    // A capacity_violation is red → the dot uses bg-red-600.
+    const dot = row.querySelector('span.h-2.w-2.rounded-full')
+    expect(dot).not.toBeNull()
+    expect(dot?.className).toContain('bg-red-600')
+  })
+
+  it('sorts cabin rows red-bunks-first (Fix 2)', () => {
+    // Oak 2 (amber: age_spread) alphabetically precedes Pine 3 (red: capacity),
+    // but the red bunk must render first.
+    const issues = [
+      {
+        type: 'age_spread_warning',
+        severity: 'warning',
+        message: 'Bunk Oak 2 has excessive age spread (26.0 months)',
+        details: { bunk_name: 'Oak 2', age_spread_months: 26, max_allowed: 24 },
+      },
+      {
+        type: 'capacity_violation',
+        severity: 'error',
+        message: 'Bunk Pine 3 is over capacity (9/8)',
+        details: { bunk_name: 'Pine 3', assigned: 9, max_size: 8 },
+      },
+    ]
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={{ statistics: makeStats(), issues, validated_at: '2025-06-01T12:00:00Z' }}
+      />
+    )
+    const rows = screen.getAllByTestId('cabin-review-row')
+    expect(rows).toHaveLength(2)
+    // Red bunk (Pine 3) renders before amber bunk (Oak 2).
+    expect(rows[0]?.textContent).toMatch(/Pine 3/)
+    expect(rows[1]?.textContent).toMatch(/Oak 2/)
+  })
+})
+
+describe('PostValidationResultsModal — honest footer (Task 6)', () => {
+  it('footer counts fully-honored campers as hidden non-issues', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({
+          mp_campers_entirely_impossible: [
+            {
+              cm_id: 1000001,
+              name: 'Emma Johnson',
+              grade: 5,
+              gender: 'F',
+              session_cm_id: 1000001,
+              reason_codes: ['cross_session'],
+              fully_honored: true,
+            },
+          ],
+        })}
+      />
+    )
+    expect(screen.getByText(/met by same-age cabin/i)).toBeInTheDocument()
+  })
+
+  it('does not render the honest footer when nothing is hidden', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults()}
+      />
+    )
+    expect(screen.queryByText(/hidden as non-issues/i)).not.toBeInTheDocument()
+  })
+
+  it('footer renders the "N with no requests" half (Fix 3)', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({ campers_with_no_requests: 3 })}
+      />
+    )
+    expect(screen.getByText(/hidden as non-issues/i)).toBeInTheDocument()
+    expect(screen.getByText(/3 with no requests/i)).toBeInTheDocument()
+  })
+
+  it('footer renders both halves when both hidden categories are present (Fix 3)', () => {
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults({
+          campers_with_no_requests: 2,
+          mp_campers_entirely_impossible: [
+            {
+              cm_id: 1000001,
+              name: 'Emma Johnson',
+              grade: 5,
+              gender: 'F',
+              session_cm_id: 1000001,
+              reason_codes: ['cross_session'],
+              fully_honored: true,
+            },
+          ],
+        })}
+      />
+    )
+    expect(screen.getByText(/2 with no requests/i)).toBeInTheDocument()
+    expect(screen.getByText(/1 met by same-age cabin/i)).toBeInTheDocument()
+  })
+})
+
+describe('PostValidationResultsModal — family rows red-before-amber (Fix 4)', () => {
+  it('renders a higher-grade red family row before a lower-grade amber family row', () => {
+    // Lower-grade row is amber (impossible_request, cross_session = amber reason),
+    // higher-grade row is red (got_nothing, always red). Grade-first sort would put
+    // the amber (grade 3) before the red (grade 8); severity sort must invert that.
+    const impossibilityReport = makeImpossibilityReport({
+      // got_nothing → red, grade 8
+      mp_campers_entirely_impossible: [
+        {
+          cm_id: 2002,
+          name: 'Zoe Adams',
+          grade: 8,
+          gender: 'F',
+          reason_codes: ['grade_compatibility'],
+          session_cm_id: 1000001,
+        },
+      ],
+      // impossible_request via flat → amber (cross_session), grade 3
+      flat: [
+        {
+          request_id: 'r-amber',
+          reason_code: 'cross_session',
+          reason_message: 'different session',
+          request_type: 'bunk_with',
+          source_field: 'share_bunk_with',
+          requester: { cm_id: 2001, name: 'Amy Brooks', grade: 3, gender: 'F' },
+          requestee: { cm_id: 9999, name: 'Friend Elsewhere', grade: 3, gender: 'F' },
+          detail: { requester_session: 1000001 },
+          bucket: 'material_parent' as const,
+        },
+      ],
+    })
+    render(
+      <PostValidationResultsModal
+        sessionCmId={1000001}
+        isOpen={true}
+        onClose={() => {}}
+        results={makeResults()}
+        impossibilityReport={impossibilityReport}
+      />
+    )
+    const allText = document.body.textContent ?? ''
+    // Red (Zoe, grade 8) renders before amber (Amy, grade 3), despite grade order.
+    expect(allText.indexOf('Zoe Adams')).toBeLessThan(allText.indexOf('Amy Brooks'))
   })
 })

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -1068,7 +1068,11 @@ describe('PostValidationResultsModal — KPI tiles use MSP signal', () => {
 })
 
 describe('PostValidationResultsModal — Impossible by reason kicker', () => {
-  it('renders the "see Pre-Check or export PDF" kicker', () => {
+  // #1717 folded the per-camper impossibility detail into "Families to contact"
+  // in this same modal, so the kicker no longer sends staff to the pre-check or
+  // the PDF (whose export button sits in this modal's own footer). It now just
+  // says what the tiles are and that they're a summary.
+  it('kicker describes the tiles, and points nowhere else', () => {
     const impossibilityReport = makeImpossibilityReport({
       by_reason: {
         grade_compatibility: [
@@ -1094,9 +1098,9 @@ describe('PostValidationResultsModal — Impossible by reason kicker', () => {
         impossibilityReport={impossibilityReport}
       />
     )
-    expect(
-      screen.getByText(/see Pre-Check or export PDF for full per-camper detail/i)
-    ).toBeInTheDocument()
+    expect(screen.getByText(/every impossible request grouped by cause/i)).toBeInTheDocument()
+    // The stale cross-references must be gone, not merely reworded around.
+    expect(screen.queryByText(/see Pre-Check/i)).not.toBeInTheDocument()
   })
 })
 

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -393,7 +393,7 @@ describe('PostValidationResultsModal — parent stats tile (Stage 3b.2)', () => 
 describe('PostValidationResultsModal — KPI "issues" tile removed (Task 6 supersedes)', () => {
   // NOTE (Task 6): The "issues" KPI tile has been removed. Suppressed-type filtering is
   // now enforced by the section rendering itself — suppressed types never appear in
-  // "Cabins to review" (ISSUE_SECTION maps them to 'hidden'). The tile's old job of
+  // "Cabins to review" (they are not in BUNK_LEVEL_ISSUE_TYPES). The tile's old job of
   // "count visible issues" is no longer needed in the headline; action counts live in
   // the sublabel instead.
   it('does not render an "issues" KPI tile (removed in Task 6)', () => {
@@ -415,8 +415,8 @@ describe('PostValidationResultsModal — KPI "issues" tile removed (Task 6 super
     // Tile is gone — no "issues" label in the KPI grid
     expect(screen.queryByText(/^issues$/i)).toBeNull()
     // The "Cabins to review" section naturally excludes suppressed types
-    // (capacity_violation + age_spread_warning both in ISSUE_SECTION 'cabins',
-    //  3 suppressed types not in it at all)
+    // (capacity_violation + age_spread_warning are both bunk-level;
+    //  the 3 suppressed types are not in BUNK_LEVEL_ISSUE_TYPES at all)
     expect(screen.getAllByText(/Cabins to review/i).length).toBeGreaterThanOrEqual(1)
   })
 })
@@ -847,7 +847,7 @@ describe('PostValidationResultsModal — Capacity by gender section', () => {
 
 describe('PostValidationResultsModal — Cabins to review (formerly "Bunks needing attention")', () => {
   // NOTE (Task 6): The "Bunks needing attention" section was renamed to "Cabins to review"
-  // and now uses ISSUE_SECTION classification. Tests updated accordingly.
+  // and now renders from BUNK_LEVEL_ISSUE_TYPES. Tests updated accordingly.
   it('groups bunk-level issues into one row per bunk with chips', () => {
     // Real validator emits structured `details.bunk_name` for every
     // bunk-level issue; the extractor reads that first and falls back to
@@ -1344,7 +1344,7 @@ describe('PostValidationResultsModal — sub-label breakdown (#1481)', () => {
 
   it('uses singular "cabin" in the sub-label when only 1 cabin issue', () => {
     // NOTE (Task 6): "Other issues" concept in the sublabel is replaced by "N cabins to review".
-    // Only bunk-composition issues (ISSUE_SECTION==='cabins') count toward cabins.
+    // Only bunk-composition issues (BUNK_LEVEL_ISSUE_TYPES) count toward cabins.
     const issues = [
       {
         type: 'capacity_violation',

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -569,6 +569,7 @@ const COHORT_STYLES = {
   violated: 'bg-amber-100 text-amber-800',
   priority_unmet: 'bg-pink-100 text-pink-800',
   sacrificed_mp: 'bg-orange-100 text-orange-800',
+  impossible_request: 'bg-purple-100 text-purple-800',
 } as const
 
 const COHORT_LABELS = {
@@ -576,6 +577,7 @@ const COHORT_LABELS = {
   violated: 'Not-bunk-with violated',
   priority_unmet: 'Priority unmet',
   sacrificed_mp: 'Request dropped',
+  impossible_request: "Request can't be placed",
 } as const
 
 function CohortPill({ cohort }: { cohort: FamilyCohort }) {

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -4,6 +4,9 @@ import {
   SUPPRESSED_ISSUE_TYPES,
   extractBunkName,
   type PostCheckIssue,
+  ISSUE_SEVERITY,
+  COHORT_SEVERITY,
+  type Severity,
 } from './issueClassifier'
 import { formatBunkIssueDetail } from '../utils/validationIssueFormatter'
 import {
@@ -17,7 +20,6 @@ import {
   Star,
   Sparkles,
   TrendingUp,
-  Target,
   Activity,
   ExternalLink,
   Loader2,
@@ -29,8 +31,8 @@ import { Modal } from './ui/Modal'
 import { LazyPdfExportButton } from './PdfExport/LazyPdfExportButton'
 import { formatSourceField } from '../utils/formatSourceField'
 import { LazyCamperDetailsPanel } from './impossibility/LazyCamperDetailsPanel'
-import { friendlyReasonLabel } from './impossibility/reasonHints'
-import { buildFamilyRows, type FamilyCohort } from './PdfExport/familyRows'
+import { friendlyReasonLabel, REASON_SEVERITY } from './impossibility/reasonHints'
+import { buildFamilyRows, type FamilyCohort, type FamilyRowData } from './PdfExport/familyRows'
 
 import { ErrorBoundary } from './ErrorBoundary'
 import type { ImpossibilityReport, ValidationStatistics } from '../services/solver'
@@ -709,7 +711,8 @@ export function PostCheckContents({
   // and priority_unmet (priority-flagged requests that didn't land). Sorted grade-first.
   // Sort/filter logic lives in PdfExport/familyRows.ts (shared with PDF export).
   // Modal re-decorates string sub-row detail into JSX for richer inline formatting.
-  const familyRows: FamilyRow[] = useMemo(() => {
+  // baseRows holds the pre-decorated FamilyRowData for severity computation.
+  const baseRows: FamilyRowData[] = useMemo(() => {
     const safeReport = impossibilityReport ?? {
       mp_campers_entirely_impossible: [],
       flat: [],
@@ -717,7 +720,10 @@ export function PostCheckContents({
       total_impossible: 0,
       affected_campers: 0,
     }
-    const baseRows = buildFamilyRows(statistics, safeReport)
+    return buildFamilyRows(statistics, safeReport)
+  }, [statistics, impossibilityReport])
+
+  const familyRows: FamilyRow[] = useMemo(() => {
     return baseRows.map((r) => {
       const decoratedSubRows = r.subRows.map((sub) => {
         let detail: React.ReactNode
@@ -743,8 +749,17 @@ export function PostCheckContents({
             <span>{sub.detail}</span>
           )
         } else if (r.cohort === 'sacrificed_mp') {
-          // Render the pre-built detail string from familyRows (already human-readable).
-          detail = <span>{sub.detail}</span>
+          // When the camper was placed in a same-age cabin that honored the request,
+          // surface the positive "met by same age cabin" text instead of the unmet detail.
+          detail = sub.honoredInPlan ? (
+            <span>
+              Met by same age cabin{' '}
+              {sub.bunkName && <span className="font-mono text-xs">{sub.bunkName}</span>}
+            </span>
+          ) : (
+            // Render the pre-built detail string from familyRows (already human-readable).
+            <span>{sub.detail}</span>
+          )
         } else {
           detail = sub.targetName ? (
             <span>
@@ -759,15 +774,25 @@ export function PostCheckContents({
       })
       return { ...r, subRows: decoratedSubRows }
     })
-  }, [statistics, impossibilityReport])
+  }, [baseRows])
 
   const errorCount = issues.filter((i) => i.severity === 'error').length
-  const warningCount = issues.filter((i) => i.severity === 'warning').length
-  // KPI tile + section counts exclude suppressed types so the headline number
-  // matches the sum of what staff actually see below.
-  const visibleIssuesCount = issues.filter((i) => !SUPPRESSED_ISSUE_TYPES.has(i.type)).length
 
-  // Bunk-level issues grouped by extracted bunk name (alphabetical).
+  // Per-row severity: impossible_request rows are keyed by their first reason code;
+  // all other cohorts map to COHORT_SEVERITY (all currently 'red').
+  // Uses baseRows (pre-decoration) to preserve reasonCodes on sub-rows.
+  const rowSeverity = (row: FamilyRowData): Severity =>
+    row.cohort === 'impossible_request'
+      ? (REASON_SEVERITY[
+          (row.subRows[0]?.reasonCodes?.[0] ?? '') as keyof typeof REASON_SEVERITY
+        ] ?? 'amber')
+      : (COHORT_SEVERITY[row.cohort] ?? 'red')
+
+  // "Cabins to review" is fundamentally PER-BUNK: one row per bunk. We group all
+  // cabin-composition issues by bunk name, then derive each bunk's severity (red if
+  // ANY of its issues is red per ISSUE_SEVERITY, else amber) and sort red-bunks-first
+  // (alphabetical tiebreak). The headline cabin count is the number of distinct bunks,
+  // so it always equals the number of rendered rows.
   const bunkLevelIssues = useMemo(
     () => issues.filter((i) => BUNK_LEVEL_ISSUE_TYPES.has(i.type)),
     [issues]
@@ -780,69 +805,128 @@ export function PostCheckContents({
       arr.push(issue)
       map.set(bunk, arr)
     }
-    return [...map.entries()].sort(([a], [b]) => a.localeCompare(b))
+    // Per-bunk severity: red if any issue in the bunk is red.
+    return [...map.entries()]
+      .map(([bunkName, bunkIssues]) => {
+        const severity: Severity = bunkIssues.some((i) => ISSUE_SEVERITY[i.type] === 'red')
+          ? 'red'
+          : 'amber'
+        return { bunkName, bunkIssues, severity }
+      })
+      .sort((a, b) =>
+        a.severity === b.severity
+          ? a.bunkName.localeCompare(b.bunkName)
+          : a.severity === 'red'
+            ? -1
+            : 1
+      )
   }, [bunkLevelIssues])
 
+  // familyCount and severity computations use baseRows (pre-decoration) so reasonCodes
+  // on sub-rows are available for impossible_request severity keying.
+  const familyCount = new Set(baseRows.map((r) => r.cm_id)).size
+  // Pre-compute row severity keyed by row.key for O(1) JSX lookup.
+  const rowSeverityMap = useMemo(
+    () => new Map(baseRows.map((r) => [r.key, rowSeverity(r)])),
+    [baseRows] // eslint-disable-line react-hooks/exhaustive-deps
+  )
+  // Cabin count is the number of distinct bunks (one rendered row each), NOT the
+  // raw issue count — a bunk with two issues is still "1 cabin to review".
+  const cabinCount = issuesByBunk.length
+  const hiddenMetBySameAge = (statistics.mp_campers_entirely_impossible ?? []).filter(
+    (c) => c.fully_honored
+  ).length
+  const hiddenNoRequests = statistics.campers_with_no_requests ?? 0
+  // Honest-footer copy: both hidden-as-non-issue categories, joined with "·".
+  const anyHidden = hiddenMetBySameAge > 0 || hiddenNoRequests > 0
+  const hiddenFooterText = [
+    hiddenNoRequests > 0 ? `${hiddenNoRequests} with no requests` : null,
+    hiddenMetBySameAge > 0 ? `${hiddenMetBySameAge} met by same-age cabin` : null,
+  ]
+    .filter(Boolean)
+    .join(' · ')
+
+  // Family rows render red-before-amber. buildFamilyRows already grade/name-sorted,
+  // and Array#sort is stable, so equal-severity rows preserve that order.
+  const sortedFamilyRows = useMemo(
+    () =>
+      [...familyRows].sort((a, b) => {
+        const sa = (rowSeverityMap.get(a.key) ?? 'red') === 'red' ? 0 : 1
+        const sb = (rowSeverityMap.get(b.key) ?? 'red') === 'red' ? 0 : 1
+        return sa - sb
+      }),
+    [familyRows, rowSeverityMap]
+  )
+
   const getOverallStatus = () => {
-    let base: {
-      label: string
-      sublabel: string
-      icon: typeof Sparkles
-      gradient: string
-      iconBg: string
+    // Action-split sub-label: families to contact + cabins to review counts.
+    const redFamilies = baseRows.filter((r) => rowSeverity(r) === 'red').length
+    // Count BUNKS with ≥1 red issue (matches the per-bunk row model), not red issues.
+    const redCabins = issuesByBunk.filter((b) => b.severity === 'red').length
+    const redTotal = redFamilies + redCabins
+    const totalActionable = familyCount + cabinCount
+
+    const sublabelParts = [
+      familyCount > 0
+        ? `${familyCount} ${familyCount === 1 ? 'family' : 'families'} to contact`
+        : null,
+      cabinCount > 0 ? `${cabinCount} ${cabinCount === 1 ? 'cabin' : 'cabins'} to review` : null,
+    ].filter(Boolean) as string[]
+    const sublabel = totalActionable === 0 ? 'Nothing to review' : sublabelParts.join(' · ')
+
+    // Headline label and icon driven by red-severity action count, then total actionable,
+    // then satisfaction tier (only reached when nothing to review at all).
+    if (redTotal > 0) {
+      return {
+        label: 'Needs attention',
+        sublabel,
+        icon: AlertTriangle,
+        gradient: 'from-red-500/15 to-red-400/5',
+        iconBg: 'bg-red-500 text-white shadow-lg shadow-red-500/30',
+      }
     }
+    if (totalActionable > 0) {
+      return {
+        label: 'Looks good',
+        sublabel,
+        icon: AlertCircle,
+        gradient: 'from-amber-500/15 to-amber-400/5',
+        iconBg: 'bg-amber-500 text-white shadow-lg shadow-amber-500/30',
+      }
+    }
+    // Nothing actionable — use satisfaction tier to set the tone (ring already shows %).
     if (satisfactionRate >= PARENT_SATISFACTION_TARGET && errorCount === 0) {
-      base = {
+      return {
         label: 'Excellent!',
         sublabel: 'Bunking looks great',
         icon: Sparkles,
         gradient: 'from-forest-500/10 to-forest-400/5',
         iconBg: 'bg-forest-500 text-white shadow-lg shadow-forest-500/30',
       }
-    } else if (satisfactionRate >= 0.7 && errorCount === 0) {
-      base = {
+    }
+    if (satisfactionRate >= 0.7 && errorCount === 0) {
+      return {
         label: 'Looking Good',
         sublabel: `${Math.round(satisfactionRate * 100)}% requests satisfied`,
         icon: CheckCircle2,
         gradient: 'from-forest-500/10 to-forest-400/5',
         iconBg: 'bg-forest-500 text-white shadow-lg shadow-forest-500/30',
       }
-    } else if (satisfactionRate >= 0.5) {
-      const parts: string[] = []
-      // Count distinct campers (not (camper, cohort) tuples) for the sublabel
-      const distinctFamilyCount = new Set(familyRows.map((r) => r.cm_id)).size
-      if (distinctFamilyCount > 0)
-        parts.push(`${distinctFamilyCount} ${distinctFamilyCount === 1 ? 'family' : 'families'}`)
-      if (issuesByBunk.length > 0)
-        parts.push(`${issuesByBunk.length} ${issuesByBunk.length === 1 ? 'bunk' : 'bunks'}`)
-      const otherCount = groupedOtherIssues.reduce((sum, [, g]) => sum + g.issues.length, 0)
-      if (otherCount > 0) parts.push(`${otherCount} other issue${otherCount === 1 ? '' : 's'}`)
-      const sublabel = parts.length > 0 ? parts.join(' · ') : 'no issues to review'
-      base = {
-        label: 'Needs Attention',
-        sublabel,
-        icon: AlertCircle,
-        gradient: 'from-amber-500/15 to-amber-400/5',
-        iconBg: 'bg-amber-500 text-white shadow-lg shadow-amber-500/30',
-      }
-    } else {
-      base = {
-        label: 'Needs Work',
-        sublabel: 'Consider re-running the solver',
-        icon: AlertTriangle,
-        gradient: 'from-red-500/15 to-red-400/5',
-        iconBg: 'bg-red-500 text-white shadow-lg shadow-red-500/30',
-      }
     }
-
-    const unmetKids = statistics.campers_with_unsatisfied_material_parent_requests ?? 0
-    if (unmetKids > 0) {
-      base.sublabel = `${unmetKids} kid${unmetKids === 1 ? '' : 's'} missed a parent request`
-    } else if (parentTotal > 0) {
-      base.sublabel = `All ${parentTotal} parent request${parentTotal === 1 ? '' : 's'} fulfilled`
+    // Low satisfaction but nothing actionable surfaced — show "no issues" message.
+    return {
+      label: satisfactionRate >= 0.5 ? 'Needs Attention' : 'Needs Work',
+      sublabel,
+      icon: satisfactionRate >= 0.5 ? AlertCircle : AlertTriangle,
+      gradient:
+        satisfactionRate >= 0.5
+          ? 'from-amber-500/15 to-amber-400/5'
+          : 'from-red-500/15 to-red-400/5',
+      iconBg:
+        satisfactionRate >= 0.5
+          ? 'bg-amber-500 text-white shadow-lg shadow-amber-500/30'
+          : 'bg-red-500 text-white shadow-lg shadow-red-500/30',
     }
-
-    return base
   }
 
   const status = getOverallStatus()
@@ -898,7 +982,7 @@ export function PostCheckContents({
             {/* Ring */}
             <SatisfactionRing rate={satisfactionRate} size={100} />
 
-            {/* Stats grid — row 1: camper coverage; row 2: assigned + issues */}
+            {/* Stats grid — 3 positive coverage tiles */}
             <div className="grid flex-1 grid-cols-2 gap-3">
               {/* Tile 1: got ≥1 request */}
               <div className="flex items-center gap-2">
@@ -940,35 +1024,6 @@ export function PostCheckContents({
                   <p className="text-muted-foreground text-xs">assigned</p>
                 </div>
               </div>
-
-              {/* Tile 4: issues */}
-              <div className="flex items-center gap-2">
-                <div
-                  className={`flex h-8 w-8 items-center justify-center rounded-lg ${
-                    errorCount > 0
-                      ? 'bg-red-500/10'
-                      : warningCount > 0
-                        ? 'bg-amber-500/10'
-                        : 'bg-forest-500/10'
-                  }`}
-                >
-                  <Target
-                    className={`h-4 w-4 ${
-                      errorCount > 0
-                        ? 'text-red-600'
-                        : warningCount > 0
-                          ? 'text-amber-600'
-                          : 'text-forest-600'
-                    }`}
-                  />
-                </div>
-                <div>
-                  <p className="text-foreground text-lg leading-tight font-semibold">
-                    {visibleIssuesCount}
-                  </p>
-                  <p className="text-muted-foreground text-xs">issues</p>
-                </div>
-              </div>
             </div>
           </div>
 
@@ -976,64 +1031,60 @@ export function PostCheckContents({
           - Cohort A: entirely-impossible MP campers (got nothing)
           - Cohort B: not-bunk-with violations (families to call)
           - Cohort C: priority-flagged requests that didn't land
-          All rows sorted alphabetically by camper first name. */}
+          All rows sorted grade-first, name tiebreak. */}
           {familyRows.length > 0 && (
             <div className="px-5 pt-4">
               <div className="rounded-xl border border-red-200 bg-red-50/40 p-4">
                 <div className="flex items-center justify-between">
-                  {(() => {
-                    const distinctCount = new Set(familyRows.map((r) => r.cm_id)).size
-                    return (
-                      <>
-                        <div>
-                          <h3 className="text-sm font-semibold text-red-900">
-                            Families to contact
-                          </h3>
-                          <p className="mt-0.5 text-xs text-red-800/80">
-                            {distinctCount} follow-up call{distinctCount === 1 ? '' : 's'}{' '}
-                            recommended
-                          </p>
-                        </div>
-                        <span className="rounded-full bg-red-200/80 px-2.5 py-1 text-xs font-medium text-red-900">
-                          {distinctCount}
-                        </span>
-                      </>
-                    )
-                  })()}
+                  <div>
+                    <h3 className="text-sm font-semibold text-red-900">Families to contact</h3>
+                    <p className="mt-0.5 text-xs text-red-800/80">
+                      {familyCount} follow-up call{familyCount === 1 ? '' : 's'} recommended
+                    </p>
+                  </div>
+                  <span className="rounded-full bg-red-200/80 px-2.5 py-1 text-xs font-medium text-red-900">
+                    {familyCount}
+                  </span>
                 </div>
                 <div className="mt-3 divide-y divide-red-100 text-sm">
-                  {familyRows.map((row) => (
-                    <div key={row.key} className="px-1 py-2">
-                      <div className="flex items-center gap-2">
-                        <span
-                          className="cursor-pointer font-medium text-stone-900 hover:text-red-700"
-                          onClick={() => handleCamperClick(row.cm_id)}
-                        >
-                          {row.name}
-                        </span>
-                        {row.grade > 0 && (
-                          <span className="text-xs text-stone-500">
-                            · {row.grade}
-                            {['th', 'st', 'nd', 'rd'][((row.grade % 100) - 20) % 10] ||
-                              ['th', 'st', 'nd', 'rd'][row.grade % 100] ||
-                              'th'}
-                          </span>
-                        )}
-                        <CohortPill cohort={row.cohort} />
-                      </div>
-                      <div className="mt-1 space-y-0.5 pl-3">
-                        {row.subRows.map((sub, i) => (
-                          <div
-                            key={`${row.key}-${i}`}
-                            data-testid={`family-subrow-${row.key}-${i}`}
-                            className="text-xs text-stone-600"
+                  {sortedFamilyRows.map((row) => {
+                    const sev = rowSeverityMap.get(row.key) ?? 'red'
+                    return (
+                      <div key={row.key} className="px-1 py-2">
+                        <div className="flex items-center gap-2">
+                          <span
+                            className={`inline-block h-2 w-2 rounded-full ${sev === 'red' ? 'bg-red-600' : 'bg-amber-500'}`}
+                          />
+                          <span
+                            className="cursor-pointer font-medium text-stone-900 hover:text-red-700"
+                            onClick={() => handleCamperClick(row.cm_id)}
                           >
-                            {sub.detail}
-                          </div>
-                        ))}
+                            {row.name}
+                          </span>
+                          {row.grade > 0 && (
+                            <span className="text-xs text-stone-500">
+                              · {row.grade}
+                              {['th', 'st', 'nd', 'rd'][((row.grade % 100) - 20) % 10] ||
+                                ['th', 'st', 'nd', 'rd'][row.grade % 100] ||
+                                'th'}
+                            </span>
+                          )}
+                          <CohortPill cohort={row.cohort} />
+                        </div>
+                        <div className="mt-1 space-y-0.5 pl-3">
+                          {row.subRows.map((sub, i) => (
+                            <div
+                              key={`${row.key}-${i}`}
+                              data-testid={`family-subrow-${row.key}-${i}`}
+                              className="text-xs text-stone-600"
+                            >
+                              {sub.detail}
+                            </div>
+                          ))}
+                        </div>
                       </div>
-                    </div>
-                  ))}
+                    )
+                  })}
                 </div>
               </div>
             </div>
@@ -1125,40 +1176,50 @@ export function PostCheckContents({
             </div>
           )}
 
-          {/* Bunks needing attention */}
+          {/* "Cabins to review" — bunk-composition issues grouped per bunk (one row per
+          bunk), each row carrying a red/amber severity dot. Rows are sorted red-first.
+          Replaces the former "Bunks needing attention" + "Other issues" sections. */}
           {issuesByBunk.length > 0 && (
             <div className="px-5 pt-3">
               <div className="rounded-xl border border-orange-200 bg-orange-50/40 p-4">
                 <div className="flex items-center justify-between">
                   <div>
-                    <h3 className="text-sm font-semibold text-orange-900">
-                      Bunks needing attention
-                    </h3>
+                    <h3 className="text-sm font-semibold text-orange-900">Cabins to review</h3>
                     <p className="mt-0.5 text-xs text-orange-800/80">
-                      {issuesByBunk.length} bunk{issuesByBunk.length === 1 ? '' : 's'} have warnings
+                      {cabinCount} {cabinCount === 1 ? 'cabin' : 'cabins'} with warnings
                     </p>
                   </div>
                   <span className="rounded-full bg-orange-200/80 px-2.5 py-1 text-xs font-medium text-orange-900">
-                    {issuesByBunk.length}
+                    {cabinCount}
                   </span>
                 </div>
                 <ul className="mt-3 space-y-2 text-sm">
-                  {issuesByBunk.map(([bunkName, bunkIssues]) => (
-                    <li key={bunkName} className="rounded-lg bg-white px-3 py-2">
+                  {issuesByBunk.map(({ bunkName, bunkIssues, severity }) => (
+                    <li
+                      key={bunkName}
+                      data-testid="cabin-review-row"
+                      className="rounded-lg bg-white px-3 py-2"
+                    >
                       <div className="flex flex-wrap items-center gap-2">
+                        <span
+                          className={`inline-block h-2 w-2 rounded-full ${severity === 'red' ? 'bg-red-600' : 'bg-amber-500'}`}
+                        />
                         <span className="font-medium text-stone-900">{bunkName}</span>
-                        {bunkIssues.map((iss, idx) => (
-                          <span
-                            key={idx}
-                            className={`rounded-full px-2 py-0.5 text-xs ${
-                              iss.type === 'capacity_violation'
-                                ? 'bg-red-200 text-red-900'
-                                : 'bg-amber-200 text-amber-900'
-                            }`}
-                          >
-                            {getIssueTypeLabel(iss.type)}
-                          </span>
-                        ))}
+                        {bunkIssues.map((iss, idx) => {
+                          const issueSev = (ISSUE_SEVERITY[iss.type] ?? 'amber') as Severity
+                          return (
+                            <span
+                              key={idx}
+                              className={`rounded-full px-2 py-0.5 text-xs ${
+                                issueSev === 'red'
+                                  ? 'bg-red-200 text-red-900'
+                                  : 'bg-amber-200 text-amber-900'
+                              }`}
+                            >
+                              {getIssueTypeLabel(iss.type)}
+                            </span>
+                          )
+                        })}
                       </div>
                       <div className="mt-1 space-y-0.5 pl-3">
                         {bunkIssues.map((iss, idx) => (
@@ -1170,11 +1231,27 @@ export function PostCheckContents({
                     </li>
                   ))}
                 </ul>
+                {/* Honest footer — hidden items that are non-issues */}
+                {anyHidden && (
+                  <p className="text-muted-foreground mt-3 border-t border-dashed pt-2 text-xs">
+                    Hidden as non-issues: {hiddenFooterText}
+                  </p>
+                )}
               </div>
             </div>
           )}
 
-          {/* Other issues — residual types not covered by Families to contact or Bunks needing attention */}
+          {/* Honest footer when cabins section is absent but hidden items exist */}
+          {issuesByBunk.length === 0 && anyHidden && (
+            <div className="px-5 pt-3">
+              <p className="text-muted-foreground border-t border-dashed pt-2 text-xs">
+                Hidden as non-issues: {hiddenFooterText}
+              </p>
+            </div>
+          )}
+
+          {/* Residual "Other issues" — types not in ISSUE_SECTION (e.g. level_regression).
+          Kept so no issue type silently disappears. */}
           {groupedOtherIssues.length > 0 && (
             <div className="px-5 pt-3">
               <div className="rounded-xl border border-stone-200 bg-stone-50 p-4">
@@ -1182,7 +1259,7 @@ export function PostCheckContents({
                   <div>
                     <h3 className="text-sm font-semibold text-stone-900">Other issues</h3>
                     <p className="mt-0.5 text-xs text-stone-500">
-                      Items not covered by Families to contact or Bunks needing attention
+                      Items not covered by Families to contact or Cabins to review
                     </p>
                   </div>
                   <span className="rounded-full bg-stone-200 px-2.5 py-1 text-xs font-medium text-stone-700">

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -1107,7 +1107,7 @@ export function PostCheckContents({
                 <div className="rounded-xl border border-stone-200 bg-stone-50 p-4">
                   <h3 className="text-sm font-semibold text-stone-900">Impossible by reason</h3>
                   <p className="mt-0.5 text-xs text-stone-500">
-                    Summary only — see Pre-Check or export PDF for full per-camper detail
+                    Every impossible request grouped by cause — summary only
                   </p>
                   <ul className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3">
                     {Object.entries(impossibilityReport.by_reason).map(([code, items]) => {

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -828,7 +828,7 @@ export function PostCheckContents({
   // Pre-compute row severity keyed by row.key for O(1) JSX lookup.
   const rowSeverityMap = useMemo(
     () => new Map(baseRows.map((r) => [r.key, rowSeverity(r)])),
-    [baseRows] // eslint-disable-line react-hooks/exhaustive-deps
+    [baseRows]
   )
   // Cabin count is the number of distinct bunks (one rendered row each), NOT the
   // raw issue count — a bunk with two issues is still "1 cabin to review".
@@ -860,7 +860,7 @@ export function PostCheckContents({
 
   const getOverallStatus = () => {
     // Action-split sub-label: families to contact + cabins to review counts.
-    const redFamilies = baseRows.filter((r) => rowSeverity(r) === 'red').length
+    const redFamilies = baseRows.filter((r) => rowSeverityMap.get(r.key) === 'red').length
     // Count BUNKS with ≥1 red issue (matches the per-bunk row model), not red issues.
     const redCabins = issuesByBunk.filter((b) => b.severity === 'red').length
     const redTotal = redFamilies + redCabins
@@ -1250,8 +1250,8 @@ export function PostCheckContents({
             </div>
           )}
 
-          {/* Residual "Other issues" — types not in ISSUE_SECTION (e.g. level_regression).
-          Kept so no issue type silently disappears. */}
+          {/* Residual "Other issues" — types neither bunk-level nor suppressed
+          (e.g. level_regression). Kept so no issue type silently disappears. */}
           {groupedOtherIssues.length > 0 && (
             <div className="px-5 pt-3">
               <div className="rounded-xl border border-stone-200 bg-stone-50 p-4">

--- a/frontend/src/components/impossibility/reasonHints.ts
+++ b/frontend/src/components/impossibility/reasonHints.ts
@@ -37,6 +37,19 @@ export const FRIENDLY_REASON_LABELS: Record<ReasonCode, string> = {
   self_conflict: 'Contradicting requests',
 }
 
+// Severity for impossibility reasons folded into the post-check.
+// Red = the family asked for something that conflicts with how we bunk (worth a call).
+// Amber = unfulfillable for data/enrollment reasons (FYI, nothing to do).
+export const REASON_SEVERITY: Record<ReasonCode, 'red' | 'amber'> = {
+  grade_compatibility: 'red',
+  pair_no_shared_bunk: 'red',
+  self_conflict: 'red',
+  target_not_in_solver: 'amber',
+  malformed: 'amber',
+  cross_session: 'amber', // auto-declined upstream — rarely reaches post-check
+  age_pref_no_eligible_grade: 'amber',
+}
+
 export function friendlyReasonLabel(code: string): string {
   return FRIENDLY_REASON_LABELS[code as ReasonCode] ?? code
 }

--- a/frontend/src/components/issueClassifier.test.ts
+++ b/frontend/src/components/issueClassifier.test.ts
@@ -104,15 +104,19 @@ describe('issue classification', () => {
   it('routes composition warnings to cabins', () => {
     expect(ISSUE_SECTION['capacity_violation']).toBe('cabins')
     expect(ISSUE_SECTION['isolation_risk']).toBe('cabins')
-    expect(ISSUE_SECTION['unassigned_camper']).toBe('cabins')
+  })
+  it('does NOT route unassigned_camper to cabins (surfaced via dedicated block; #1712)', () => {
+    // unassigned_camper would inflate the cabin count without adding a rendered
+    // cabin row, since the section body renders from BUNK_LEVEL_ISSUE_TYPES only.
+    expect(ISSUE_SECTION['unassigned_camper']).toBeUndefined()
+    expect(ISSUE_SEVERITY['unassigned_camper']).toBeUndefined()
   })
   it('hides benign/suppressed types', () => {
     expect(ISSUE_SECTION['no_requests']).toBe('hidden')
     expect(ISSUE_SECTION['valid_request_unsatisfied']).toBe('hidden')
   })
-  it('marks capacity + unassigned red, composition nits amber', () => {
+  it('marks capacity red, composition nits amber', () => {
     expect(ISSUE_SEVERITY['capacity_violation']).toBe('red')
-    expect(ISSUE_SEVERITY['unassigned_camper']).toBe('red')
     expect(ISSUE_SEVERITY['age_spread_warning']).toBe('amber')
     expect(ISSUE_SEVERITY['isolation_risk']).toBe('amber')
   })

--- a/frontend/src/components/issueClassifier.test.ts
+++ b/frontend/src/components/issueClassifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { extractBunkName, ISSUE_SECTION, ISSUE_SEVERITY, COHORT_SEVERITY } from './issueClassifier'
+import { extractBunkName, ISSUE_SEVERITY, COHORT_SEVERITY } from './issueClassifier'
 import { REASON_SEVERITY } from './impossibility/reasonHints'
 
 describe('extractBunkName', () => {
@@ -101,19 +101,10 @@ describe('extractBunkName', () => {
 })
 
 describe('issue classification', () => {
-  it('routes composition warnings to cabins', () => {
-    expect(ISSUE_SECTION['capacity_violation']).toBe('cabins')
-    expect(ISSUE_SECTION['isolation_risk']).toBe('cabins')
-  })
-  it('does NOT route unassigned_camper to cabins (surfaced via dedicated block; #1712)', () => {
+  it('does NOT assign unassigned_camper a cabin severity (surfaced via dedicated block; #1712)', () => {
     // unassigned_camper would inflate the cabin count without adding a rendered
     // cabin row, since the section body renders from BUNK_LEVEL_ISSUE_TYPES only.
-    expect(ISSUE_SECTION['unassigned_camper']).toBeUndefined()
     expect(ISSUE_SEVERITY['unassigned_camper']).toBeUndefined()
-  })
-  it('hides benign/suppressed types', () => {
-    expect(ISSUE_SECTION['no_requests']).toBe('hidden')
-    expect(ISSUE_SECTION['valid_request_unsatisfied']).toBe('hidden')
   })
   it('marks capacity red, composition nits amber', () => {
     expect(ISSUE_SEVERITY['capacity_violation']).toBe('red')

--- a/frontend/src/components/issueClassifier.test.ts
+++ b/frontend/src/components/issueClassifier.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { extractBunkName } from './issueClassifier'
+import { extractBunkName, ISSUE_SECTION, ISSUE_SEVERITY, COHORT_SEVERITY } from './issueClassifier'
+import { REASON_SEVERITY } from './impossibility/reasonHints'
 
 describe('extractBunkName', () => {
   it('reads bunk_name from issue.details when present (preferred path)', () => {
@@ -96,5 +97,35 @@ describe('extractBunkName', () => {
     it('returns "Unknown" when nothing matches', () => {
       expect(extractBunkName({ type: 'x', message: 'totally unstructured noise' })).toBe('Unknown')
     })
+  })
+})
+
+describe('issue classification', () => {
+  it('routes composition warnings to cabins', () => {
+    expect(ISSUE_SECTION['capacity_violation']).toBe('cabins')
+    expect(ISSUE_SECTION['isolation_risk']).toBe('cabins')
+    expect(ISSUE_SECTION['unassigned_camper']).toBe('cabins')
+  })
+  it('hides benign/suppressed types', () => {
+    expect(ISSUE_SECTION['no_requests']).toBe('hidden')
+    expect(ISSUE_SECTION['valid_request_unsatisfied']).toBe('hidden')
+  })
+  it('marks capacity + unassigned red, composition nits amber', () => {
+    expect(ISSUE_SEVERITY['capacity_violation']).toBe('red')
+    expect(ISSUE_SEVERITY['unassigned_camper']).toBe('red')
+    expect(ISSUE_SEVERITY['age_spread_warning']).toBe('amber')
+    expect(ISSUE_SEVERITY['isolation_risk']).toBe('amber')
+  })
+  it('marks every family cohort red (real misses)', () => {
+    expect(COHORT_SEVERITY['got_nothing']).toBe('red')
+    expect(COHORT_SEVERITY['sacrificed_mp']).toBe('red')
+  })
+  it('reason severity: policy conflicts red, data/enrollment amber', () => {
+    expect(REASON_SEVERITY.grade_compatibility).toBe('red')
+    expect(REASON_SEVERITY.pair_no_shared_bunk).toBe('red')
+    expect(REASON_SEVERITY.self_conflict).toBe('red')
+    expect(REASON_SEVERITY.target_not_in_solver).toBe('amber')
+    expect(REASON_SEVERITY.malformed).toBe('amber')
+    expect(REASON_SEVERITY.age_pref_no_eligible_grade).toBe('amber')
   })
 })

--- a/frontend/src/components/issueClassifier.ts
+++ b/frontend/src/components/issueClassifier.ts
@@ -47,6 +47,46 @@ export interface PostCheckIssue {
  * for every bunk-level type). Falls back to format-specific regex parsing of
  * `issue.message` for older payloads or unexpected shapes.
  */
+export type Section = 'families' | 'cabins' | 'hidden'
+export type Severity = 'red' | 'amber'
+
+/** Issue[] type → which action section it renders in. */
+export const ISSUE_SECTION: Record<string, Section> = {
+  capacity_violation: 'cabins',
+  age_spread_warning: 'cabins',
+  grade_ratio_warning: 'cabins',
+  grade_spread_warning: 'cabins',
+  grade_adjacency_warning: 'cabins',
+  age_flow_inversion: 'cabins',
+  isolation_risk: 'cabins',
+  unassigned_camper: 'cabins',
+  no_requests: 'hidden',
+  valid_request_unsatisfied: 'hidden',
+  valid_negative_request_violated: 'hidden',
+  campers_with_unsatisfied_valid_requests: 'hidden',
+}
+
+/** Issue[] type → severity. Over-capacity + unassigned are serious; the rest are FYI nits. */
+export const ISSUE_SEVERITY: Record<string, Severity> = {
+  capacity_violation: 'red',
+  unassigned_camper: 'red',
+  age_spread_warning: 'amber',
+  grade_ratio_warning: 'amber',
+  grade_spread_warning: 'amber',
+  grade_adjacency_warning: 'amber',
+  age_flow_inversion: 'amber',
+  isolation_risk: 'amber',
+}
+
+/** Family-cohort → severity. All cohorts are real misses → worth a call. Keyed by FamilyCohort string. */
+export const COHORT_SEVERITY: Record<string, Severity> = {
+  got_nothing: 'red',
+  sacrificed_mp: 'red',
+  violated: 'red',
+  priority_unmet: 'red',
+  impossible_request: 'red', // overridden per-reason at render via REASON_SEVERITY
+}
+
 export function extractBunkName(issue: IssueLike): string {
   const structured = issue.details?.['bunk_name']
   if (typeof structured === 'string' && structured.length > 0) return structured

--- a/frontend/src/components/issueClassifier.ts
+++ b/frontend/src/components/issueClassifier.ts
@@ -47,32 +47,7 @@ export interface PostCheckIssue {
  * for every bunk-level type). Falls back to format-specific regex parsing of
  * `issue.message` for older payloads or unexpected shapes.
  */
-export type Section = 'families' | 'cabins' | 'hidden'
 export type Severity = 'red' | 'amber'
-
-/**
- * Issue[] type → which action section it renders in.
- *
- * The 'cabins' set must stay equal to BUNK_LEVEL_ISSUE_TYPES so the headline
- * cabin count (derived from ISSUE_SECTION==='cabins') matches the rows actually
- * rendered in the "Cabins to review" section (derived from BUNK_LEVEL_ISSUE_TYPES).
- * `unassigned_camper` is intentionally NOT here: it is surfaced via the modal's
- * dedicated "campers need bunk assignment" block and the "Other issues" catch-all,
- * so listing it as a cabin would count it without showing it (the #1712 bug).
- */
-export const ISSUE_SECTION: Record<string, Section> = {
-  capacity_violation: 'cabins',
-  age_spread_warning: 'cabins',
-  grade_ratio_warning: 'cabins',
-  grade_spread_warning: 'cabins',
-  grade_adjacency_warning: 'cabins',
-  age_flow_inversion: 'cabins',
-  isolation_risk: 'cabins',
-  no_requests: 'hidden',
-  valid_request_unsatisfied: 'hidden',
-  valid_negative_request_violated: 'hidden',
-  campers_with_unsatisfied_valid_requests: 'hidden',
-}
 
 /** Issue[] type → severity. Over-capacity is serious; the rest are FYI nits. */
 export const ISSUE_SEVERITY: Record<string, Severity> = {

--- a/frontend/src/components/issueClassifier.ts
+++ b/frontend/src/components/issueClassifier.ts
@@ -50,7 +50,16 @@ export interface PostCheckIssue {
 export type Section = 'families' | 'cabins' | 'hidden'
 export type Severity = 'red' | 'amber'
 
-/** Issue[] type → which action section it renders in. */
+/**
+ * Issue[] type → which action section it renders in.
+ *
+ * The 'cabins' set must stay equal to BUNK_LEVEL_ISSUE_TYPES so the headline
+ * cabin count (derived from ISSUE_SECTION==='cabins') matches the rows actually
+ * rendered in the "Cabins to review" section (derived from BUNK_LEVEL_ISSUE_TYPES).
+ * `unassigned_camper` is intentionally NOT here: it is surfaced via the modal's
+ * dedicated "campers need bunk assignment" block and the "Other issues" catch-all,
+ * so listing it as a cabin would count it without showing it (the #1712 bug).
+ */
 export const ISSUE_SECTION: Record<string, Section> = {
   capacity_violation: 'cabins',
   age_spread_warning: 'cabins',
@@ -59,17 +68,15 @@ export const ISSUE_SECTION: Record<string, Section> = {
   grade_adjacency_warning: 'cabins',
   age_flow_inversion: 'cabins',
   isolation_risk: 'cabins',
-  unassigned_camper: 'cabins',
   no_requests: 'hidden',
   valid_request_unsatisfied: 'hidden',
   valid_negative_request_violated: 'hidden',
   campers_with_unsatisfied_valid_requests: 'hidden',
 }
 
-/** Issue[] type → severity. Over-capacity + unassigned are serious; the rest are FYI nits. */
+/** Issue[] type → severity. Over-capacity is serious; the rest are FYI nits. */
 export const ISSUE_SEVERITY: Record<string, Severity> = {
   capacity_violation: 'red',
-  unassigned_camper: 'red',
   age_spread_warning: 'amber',
   grade_ratio_warning: 'amber',
   grade_spread_warning: 'amber',

--- a/frontend/src/services/solver.ts
+++ b/frontend/src/services/solver.ts
@@ -213,6 +213,8 @@ export interface ValidationStatistics {
     session_cm_id: number
     reason_codes: string[]
     honored_in_plan: boolean
+    /** True when every impossible request was still honored (met via always-place). */
+    fully_honored?: boolean
     /** Cabin that met the preference when honored_in_plan; null/absent otherwise. */
     bunk_name?: string | null
   }>

--- a/frontend/src/services/solver.ts
+++ b/frontend/src/services/solver.ts
@@ -161,6 +161,8 @@ export interface ValidationStatistics {
   material_parent_request_satisfaction_rate?: number
   campers_with_unsatisfied_material_parent_requests?: number
   unsatisfied_material_parent_persons?: Array<{ cm_id: number; name: string }>
+  /** Campers with no bunk requests at all — hidden as a non-issue in the post-check footer. */
+  campers_with_no_requests?: number
   best_effort_parent_requests?: number
   satisfied_best_effort_parent_requests?: number
   best_effort_parent_request_satisfaction_rate?: number

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -7355,11 +7355,7 @@ export type ClearParseAnalysisApiDebugParseAnalysisDeleteData = {
      * Filter by source field
      */
     source_field?:
-      | 'bunk_request_form'
-      | 'staff_not_bunk_with'
-      | 'bunking_notes'
-      | 'internal_notes'
-      | null
+      'bunk_request_form' | 'staff_not_bunk_with' | 'bunking_notes' | 'internal_notes' | null
   }
   url: '/api/debug/parse-analysis'
 }
@@ -7400,11 +7396,7 @@ export type ListParseAnalysisApiDebugParseAnalysisGetData = {
      * Filter by source field
      */
     source_field?:
-      | 'bunk_request_form'
-      | 'staff_not_bunk_with'
-      | 'bunking_notes'
-      | 'internal_notes'
-      | null
+      'bunk_request_form' | 'staff_not_bunk_with' | 'bunking_notes' | 'internal_notes' | null
     /**
      * Limit
      *
@@ -7555,11 +7547,7 @@ export type ListOriginalRequestsApiDebugOriginalRequestsGetData = {
      * Filter by source field
      */
     source_field?:
-      | 'bunk_request_form'
-      | 'staff_not_bunk_with'
-      | 'bunking_notes'
-      | 'internal_notes'
-      | null
+      'bunk_request_form' | 'staff_not_bunk_with' | 'bunking_notes' | 'internal_notes' | null
     /**
      * Limit
      *
@@ -7691,11 +7679,7 @@ export type ListOriginalRequestsWithParseStatusApiDebugOriginalRequestsWithParse
      * Filter by source field
      */
     source_field?:
-      | 'bunk_request_form'
-      | 'staff_not_bunk_with'
-      | 'bunking_notes'
-      | 'internal_notes'
-      | null
+      'bunk_request_form' | 'staff_not_bunk_with' | 'bunking_notes' | 'internal_notes' | null
     /**
      * Limit
      *
@@ -7749,11 +7733,7 @@ export type ListOriginalRequestsGroupedApiDebugOriginalRequestsGroupedGetData = 
      * Filter by source field
      */
     source_field?:
-      | 'bunk_request_form'
-      | 'staff_not_bunk_with'
-      | 'bunking_notes'
-      | 'internal_notes'
-      | null
+      'bunk_request_form' | 'staff_not_bunk_with' | 'bunking_notes' | 'internal_notes' | null
     /**
      * Limit
      *

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -7355,7 +7355,11 @@ export type ClearParseAnalysisApiDebugParseAnalysisDeleteData = {
      * Filter by source field
      */
     source_field?:
-      'bunk_request_form' | 'staff_not_bunk_with' | 'bunking_notes' | 'internal_notes' | null
+      | 'bunk_request_form'
+      | 'staff_not_bunk_with'
+      | 'bunking_notes'
+      | 'internal_notes'
+      | null
   }
   url: '/api/debug/parse-analysis'
 }
@@ -7396,7 +7400,11 @@ export type ListParseAnalysisApiDebugParseAnalysisGetData = {
      * Filter by source field
      */
     source_field?:
-      'bunk_request_form' | 'staff_not_bunk_with' | 'bunking_notes' | 'internal_notes' | null
+      | 'bunk_request_form'
+      | 'staff_not_bunk_with'
+      | 'bunking_notes'
+      | 'internal_notes'
+      | null
     /**
      * Limit
      *
@@ -7547,7 +7555,11 @@ export type ListOriginalRequestsApiDebugOriginalRequestsGetData = {
      * Filter by source field
      */
     source_field?:
-      'bunk_request_form' | 'staff_not_bunk_with' | 'bunking_notes' | 'internal_notes' | null
+      | 'bunk_request_form'
+      | 'staff_not_bunk_with'
+      | 'bunking_notes'
+      | 'internal_notes'
+      | null
     /**
      * Limit
      *
@@ -7679,7 +7691,11 @@ export type ListOriginalRequestsWithParseStatusApiDebugOriginalRequestsWithParse
      * Filter by source field
      */
     source_field?:
-      'bunk_request_form' | 'staff_not_bunk_with' | 'bunking_notes' | 'internal_notes' | null
+      | 'bunk_request_form'
+      | 'staff_not_bunk_with'
+      | 'bunking_notes'
+      | 'internal_notes'
+      | null
     /**
      * Limit
      *
@@ -7733,7 +7749,11 @@ export type ListOriginalRequestsGroupedApiDebugOriginalRequestsGroupedGetData = 
      * Filter by source field
      */
     source_field?:
-      'bunk_request_form' | 'staff_not_bunk_with' | 'bunking_notes' | 'internal_notes' | null
+      | 'bunk_request_form'
+      | 'staff_not_bunk_with'
+      | 'bunking_notes'
+      | 'internal_notes'
+      | null
     /**
      * Limit
      *

--- a/tests/unit/test_bunking_validator.py
+++ b/tests/unit/test_bunking_validator.py
@@ -3376,3 +3376,131 @@ def test_cohort_absent_leaves_field_empty():
         requests=[],
     )
     assert result.statistics.mp_campers_entirely_impossible == []
+
+
+# ---------------------------------------------------------------------------
+# Task 1 (PR #1716): fully_honored on entirely-impossible MP cohort entries
+# ---------------------------------------------------------------------------
+
+
+def test_fully_honored_when_sole_material_age_pref_satisfied():
+    """Case A: camper with ONE material age_preference request, satisfied in the final plan.
+
+    Emma Johnson (cm_id=1000001, grade=10) has a single 'older' age preference
+    flagged impossible pre-solve (passed in impossible_mp_cohort). The final cabin
+    contains only grade-10 campers, so the age preference IS satisfied in the plan.
+
+    Expected: honored_in_plan is True AND fully_honored is True.
+    """
+    session = _mock_session(cm_id="10000010", name="FullyHonoredFixture")
+    persons = [
+        MockPerson(campminder_id="1000001", name="Emma Johnson", grade=10, gender="M"),
+        MockPerson(campminder_id="1000002", name="Liam Garcia", grade=10, gender="M"),
+    ]
+    bunks = [_mock_bunk("2000001")]
+    assignments = [
+        _mock_assignment("1000001", "2000001"),
+        _mock_assignment("1000002", "2000001"),
+    ]
+    # Single material age_preference request for Emma; id must appear in impossible_request_ids
+    # so it's treated as impossible pre-solve but still flows through material_parent_by_person.
+    requests = [_age_pref_request("1000001", "older", id="ap_emma")]
+    cohort = [
+        {
+            "cm_id": 1000001,
+            "name": "Emma Johnson",
+            "grade": 10,
+            "gender": "M",
+            "session_cm_id": 10000010,
+            "reason_codes": ["age_pref_no_eligible_grade"],
+        }
+    ]
+
+    result = BunkingValidator().validate_bunking(
+        session=cast(Any, session),
+        bunks=cast(list[Bunk], bunks),
+        assignments=cast(list[BunkAssignment], assignments),
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+        impossible_request_ids={"ap_emma"},
+        impossible_mp_cohort=cohort,
+    )
+    out = result.statistics.mp_campers_entirely_impossible
+    assert len(out) == 1
+    assert out[0]["cm_id"] == 1000001
+    assert out[0]["honored_in_plan"] is True
+    assert out[0]["fully_honored"] is True
+
+
+def test_partially_honored_when_one_of_two_material_requests_unmet():
+    """Case B: camper with TWO material requests where one is satisfied, one is not.
+
+    Liam Garcia (cm_id=1000001) requests bunk_with both Emma Johnson (1000002) and
+    Olivia Chen (1000003). The final plan places Liam with Emma (satisfied) but not
+    Olivia (unsatisfied). Liam is in the impossible_mp_cohort.
+
+    Expected: honored_in_plan is True (at least one met) AND fully_honored is False
+    (not all met).
+    """
+    session = _mock_session(cm_id="10000010", name="PartiallyHonoredFixture")
+    persons = [
+        MockPerson(campminder_id="1000001", name="Liam Garcia", grade=6, gender="M"),
+        MockPerson(campminder_id="1000002", name="Emma Johnson", grade=6, gender="M"),
+        MockPerson(campminder_id="1000003", name="Olivia Chen", grade=6, gender="M"),
+    ]
+    bunks = [
+        MockBunk(campminder_id="2000001", name="Cedar 1", max_size=8),
+        MockBunk(campminder_id="2000002", name="Cedar 2", max_size=8),
+    ]
+    assignments = [
+        _mock_assignment("1000001", "2000001"),  # Liam in Cedar 1
+        _mock_assignment("1000002", "2000001"),  # Emma in Cedar 1 → Liam's req satisfied
+        _mock_assignment("1000003", "2000002"),  # Olivia in Cedar 2 → Liam's req NOT satisfied
+    ]
+    requests = [
+        MockBunkRequest(
+            requester_person_cm_id="1000001",
+            requested_person_cm_id="1000002",
+            request_type="bunk_with",
+            status="resolved",
+            source_field=SourceField.BUNK_REQUEST_FORM,
+            source="family",
+            id="req_liam_emma",
+        ),
+        MockBunkRequest(
+            requester_person_cm_id="1000001",
+            requested_person_cm_id="1000003",
+            request_type="bunk_with",
+            status="resolved",
+            source_field=SourceField.BUNK_REQUEST_FORM,
+            source="family",
+            id="req_liam_olivia",
+        ),
+    ]
+    cohort = [
+        {
+            "cm_id": 1000001,
+            "name": "Liam Garcia",
+            "grade": 6,
+            "gender": "M",
+            "session_cm_id": 10000010,
+            "reason_codes": ["cross_session"],
+        }
+    ]
+
+    result = BunkingValidator().validate_bunking(
+        session=cast(Any, session),
+        bunks=cast(list[Bunk], bunks),
+        assignments=cast(list[BunkAssignment], assignments),
+        persons=cast(list[Person], persons),
+        requests=cast(list[BunkRequest], requests),
+        # A real entirely-impossible cohort member has ALL material requests
+        # flagged impossible pre-solve — mark both of Liam's bunk_with ids.
+        impossible_request_ids={"req_liam_emma", "req_liam_olivia"},
+        impossible_mp_cohort=cohort,
+    )
+    out = result.statistics.mp_campers_entirely_impossible
+    assert len(out) == 1
+    assert out[0]["cm_id"] == 1000001
+    assert out[0]["honored_in_plan"] is True
+    assert out[0]["fully_honored"] is False


### PR DESCRIPTION
Consolidates the post-check (`PostValidationResultsModal`) into a single, honest "what needs attention" view, closing sub-cluster A of wife-feedback batch 7 (Group 78A).

## Issues

### #1712 — "0 issues" headline contradicted the board
The headline KPI tile counted only `visibleIssuesCount` (non-suppressed validator rows), which read **0** even when the same card's statistics-driven attention list was non-empty. Two different counters disagreed in plain sight.

- The misleading "issues" KPI tile is **removed**.
- The post-check is **action-split** into **Families to contact** and **Cabins to review** sections, each with an honest count in the sub-label that reflects what's actually rendered.
- Rows carry a **red / amber severity** classification (over-capacity is red; composition nits are amber).
- Cabin membership derives directly from `BUNK_LEVEL_ISSUE_TYPES` (no parallel section map to drift out of sync); anything neither bunk-level nor suppressed still surfaces in the "Other issues" catch-all.

### #1716 — age-pref-honored camper falsely flagged "Got nothing"
A camper whose only request was an age-preference that **was** satisfied (placed in a same-age cabin) was still bucketed in `got_nothing` and badged "Got nothing", even though the sub-row read "Met by same age cabin". 

- API adds a `fully_honored` partition to the entirely-impossible MP cohort (`bunking_validator.py`).
- The frontend drops fully-honored campers from the contact list so they no longer inflate the "needs attention" count.

### #1717 — fold pre-check impossibility detail into the post-check
Staff had to flip between the pre-check (rich per-kid `by_reason` impossibility breakdown) and the post-check (all-requests-impossible rollup only). The pre-check's per-request detail is now folded into the post-check contact list, so the post-check is the single place to see everything needing attention. `impossibility_report` was already plumbed in — this is rendering/consolidation, not new wiring.

## Verification
- `pre-push-verification` green: Python unit (5399 passed), prettier, eslint (0 errors), tsc, vitest.
- Touches both surfaces: `bunking_validator.py` (+ `test_bunking_validator.py`) and `PostValidationResultsModal.tsx`, `issueClassifier.ts`, `familyRows.ts`, `reasonHints.ts`, `solver.ts`.

Sub-cluster B (#1713 / #1714, upload modal) is tracked separately and not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **“impossible_request”** rows with user-facing labeling and updated how they contribute to red/amber severity.
  * Introduced a **fully-honored** distinction for “entirely impossible” reconciliation.

* **Bug Fixes**
  * Improved honored reconciliation: partially-honored campers now label as **sacrificed_mp** (with corrected sub-row detail), while fully-honored entries are omitted from the affected output.

* **UI Improvements**
  * Updated the post-validation modal with **“Families to contact”** and **“Cabins to review”** actions, revised severity dots, and added an honest footer for hidden non-issues.

* **Tests**
  * Expanded coverage for honored/impossibility folding and severity mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->