### PR TITLE
fix(pb): unblock config writes — superuser bypass + backfill preferred_bonus

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -67,7 +67,7 @@ reviews:
 
     - path: "pocketbase/**/*.go"
       instructions: |
-        Go 1.26+ codebase (pocketbase/go.mod declares `go 1.26.3`). Idiomatic baseline:
+        Go 1.26+ codebase (pocketbase/go.mod declares `go 1.26.4`). Idiomatic baseline:
         - `any` (not `interface{}`); `map[string]any` (not `map[string]interface{}`)
         - `slices`, `maps`, `cmp` packages over legacy `sort.*`
         - `min`/`max`/`clear` builtins; `cmp.Or` for first-non-zero
@@ -77,7 +77,7 @@ reviews:
         - `math/rand/v2` (already adopted); `crypto/rand` for jitter
         - `testing/synctest` for time-dependent tests
         Logging contract: the `logging` package installs the default slog handler via `slog.SetDefault` at init — direct `slog.Info(...)` / `slog.Error(...)` / etc. calls are the correct pattern. There is no `logging.Info` wrapper. Do NOT flag direct `slog.*` calls as "bypasses logging contract" — that's a false positive.
-        Do NOT suggest `encoding/json/v2` — still `GOEXPERIMENT=jsonv2`-gated as of Go 1.26.3 and not subject to the Go 1 compatibility promise. The codebase deliberately uses `encoding/json` until v2 is GA.
+        Do NOT suggest `encoding/json/v2` — still `GOEXPERIMENT=jsonv2`-gated as of Go 1.26.4 and not subject to the Go 1 compatibility promise. The codebase deliberately uses `encoding/json` until v2 is GA.
         Domain invariant: cross-table relationships use CampMinder IDs (`cm_id`, `person_id`), never PocketBase record IDs. All CampMinder-derived tables include a required `year` field; year filtering must use `CAMPMINDER_SEASON_ID` from env.
 
     - path: "pocketbase/pb_migrations/*.js"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
-        go-version: '1.26.3'
+        go-version: '1.26.4'
         cache: true
         cache-dependency-path: pocketbase/go.sum
 
@@ -456,7 +456,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
-        go-version: '1.26.3'
+        go-version: '1.26.4'
         cache: true
         cache-dependency-path: pocketbase/go.sum
 
@@ -481,7 +481,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
-        go-version: '1.26.3'
+        go-version: '1.26.4'
         cache: true
         cache-dependency-path: pocketbase/go.sum
 

--- a/docker/Dockerfile.caddy
+++ b/docker/Dockerfile.caddy
@@ -21,7 +21,7 @@ RUN npm run build
 # =============================================================================
 # Stage 2: Build healthcheck binary
 # =============================================================================
-FROM golang:1.26.3-alpine AS healthcheck-builder
+FROM golang:1.26.4-alpine AS healthcheck-builder
 
 WORKDIR /build
 COPY docker/healthcheck/ ./

--- a/docker/Dockerfile.pocketbase
+++ b/docker/Dockerfile.pocketbase
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o pocketbase .
 # =============================================================================
 # Stage 2: Build healthcheck binary
 # =============================================================================
-FROM golang:1.26.3-alpine AS healthcheck-builder
+FROM golang:1.26.4-alpine AS healthcheck-builder
 
 WORKDIR /build
 COPY docker/healthcheck/ ./

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.26.3
+go 1.26.4
 
 use (
 	./docker/healthcheck

--- a/pocketbase/go.mod
+++ b/pocketbase/go.mod
@@ -1,6 +1,6 @@
 module github.com/camp/kindred/pocketbase
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/pocketbase/dbx v1.12.0

--- a/pocketbase/pb_migrations/1500000115_seed_age_spread_preferred_bonus.js
+++ b/pocketbase/pb_migrations/1500000115_seed_age_spread_preferred_bonus.js
@@ -1,0 +1,75 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+/**
+ * Backfill the kept ``constraint.age_spread.preferred_bonus`` config row.
+ *
+ * Root cause: this key was introduced (required=True, no code default) by
+ * standalone migration ``1500000098_age_spread_preferred_threshold.js`` (#1021,
+ * 2026-04-27), which is the only migration that INSERTS it into an existing DB.
+ * Consolidation #1275 (2026-05-10) deleted 098 and folded its seed into the
+ * from-scratch canonical seed ``1500000011_config.js``. Migration 011 had long
+ * since been applied in prod, so editing it never re-runs — and any DB that did
+ * not apply 098 during its 13-day lifetime never received the row. The later
+ * solver-config-it cleanup (``1500000107_drop_age_spread_orphan_configs.js``)
+ * correctly KEEPS preferred_bonus but adds no "ensure it exists" step.
+ *
+ * Result: ``ConfigLoader`` raises "Required config key
+ * 'constraint.age_spread.preferred_bonus' not found in database" and the solver
+ * cannot run. This migration self-heals such DBs and protects any other env
+ * that missed 098.
+ *
+ * The seeded value/metadata mirror exactly what a fresh ``1500000011`` install
+ * produces for this key, so the admin GUI treats the backfilled row identically.
+ *
+ * Idempotent: on a healthy DB (row already present) this is a no-op.
+ *
+ * Down: intentionally a NO-OP. This is a corrective backfill of a REQUIRED key,
+ * not a net-new feature row — deleting it on rollback would re-introduce the
+ * exact "config key not found" outage this migration fixes.
+ */
+migrate(
+  (app) => {
+    let existing
+    try {
+      existing = app.findFirstRecordByFilter(
+        "config",
+        `category = "constraint" && subcategory = "age_spread" && config_key = "preferred_bonus"`,
+      )
+    } catch {
+      existing = null
+    }
+    if (existing) return
+
+    const configCollection = app.findCollectionByNameOrId("config")
+    const record = new Record(configCollection)
+    record.set("category", "constraint")
+    record.set("subcategory", "age_spread")
+    record.set("config_key", "preferred_bonus")
+    record.set("value", 500)
+    record.set(
+      "description",
+      "Bonus weight for cabins whose age spread is within the preferred threshold",
+    )
+    record.set("metadata", {
+      data_type: "integer",
+      source: "default_config",
+      default_value: 500,
+      min_value: 0,
+      max_value: 10000,
+      friendly_name: "Preferred Age Spread Bonus",
+      tooltip:
+        "Objective bonus for each cabin within the preferred age spread. Higher = solver tries harder to form tight age groups.",
+      section: "age-grade",
+      // Only key remaining in the age-grade section after Age Spread Phase 2.
+      display_order: 1,
+      business_category: "solver",
+      component_type: "slider",
+      component_config: { min: 0, max: 10000, step: 100, showValue: true },
+    })
+    app.save(record)
+  },
+  (_app) => {
+    // No-op: see header. preferred_bonus is a required solver config; removing
+    // it on rollback would re-break the solver.
+  },
+)

--- a/pocketbase/rbac/hooks.go
+++ b/pocketbase/rbac/hooks.go
@@ -91,8 +91,45 @@ func extractBusinessCategory(raw any) string {
 	return cat
 }
 
+// configWriteDecision is the authorization outcome for a config write, extracted
+// as a pure value so the policy can be unit-tested without a request harness.
+type configWriteDecision int
+
+const (
+	configWriteAllow configWriteDecision = iota
+	configWriteDenyMissingPermission
+	configWriteDenyWrongCategory
+	configWriteDenyCategoryMutation
+)
+
+// decideConfigWrite is the pure authorization policy for a config write.
+//
+// Superusers (PocketBase _/ admin dashboard) and admins bypass every check.
+// Non-admins need registration.manage AND may only touch registration-category
+// configs — both on the existing record and in the incoming body (newCategory),
+// the latter preventing category mutation. newCategory == "" means the body did
+// not change the category.
+func decideConfigWrite(
+	isSuperuser, isAdmin, hasRegistrationManage bool,
+	existingCategory, newCategory string,
+) configWriteDecision {
+	if isSuperuser || isAdmin {
+		return configWriteAllow
+	}
+	if !hasRegistrationManage {
+		return configWriteDenyMissingPermission
+	}
+	if !isRegistrationConfig(existingCategory) {
+		return configWriteDenyWrongCategory
+	}
+	if newCategory != "" && !isRegistrationConfig(newCategory) {
+		return configWriteDenyCategoryMutation
+	}
+	return configWriteAllow
+}
+
 // guardConfigWrite ensures non-admin users can only write registration-category configs.
-// Admin users bypass this check (they can write any config).
+// Superusers and admin users bypass this check (they can write any config).
 // Non-admin users with registration.manage can only write configs where
 // metadata.business_category is "registration" — both on the existing record
 // AND in the incoming request body (to prevent category mutation).
@@ -101,31 +138,33 @@ func guardConfigWrite(e *core.RecordRequestEvent) error {
 		return apis.NewUnauthorizedError("Authentication required", nil)
 	}
 
-	// Admin bypass
-	if e.Auth.GetBool("is_admin") {
-		return e.Next() //nolint:wrapcheck // standard PocketBase hook pattern
-	}
-
-	// Non-admin must have registration.manage permission
-	if !slices.Contains(e.Auth.GetStringSlice("cached_permissions"), permRegistrationManage) {
-		return apis.NewForbiddenError("Missing registration.manage permission", nil)
-	}
-
-	// Check the existing record's business_category
-	if extractBusinessCategory(e.Record.Get("metadata")) != categoryRegistration {
-		return apis.NewForbiddenError("Admin access required for this config category", nil)
-	}
-
-	// Also check the incoming request body to prevent category mutation
-	info, err := e.RequestInfo()
-	if err == nil && info != nil && info.Body != nil {
+	// Pull the incoming body's business_category (if any) to detect mutation.
+	newCategory := ""
+	if info, err := e.RequestInfo(); err == nil && info != nil && info.Body != nil {
 		if newMeta, ok := info.Body["metadata"]; ok {
-			if newCat := extractBusinessCategory(newMeta); newCat != "" && newCat != categoryRegistration {
-				return apis.NewForbiddenError("Cannot change config category", nil)
-			}
+			newCategory = extractBusinessCategory(newMeta)
 		}
 	}
 
+	switch decideConfigWrite(
+		e.Auth.IsSuperuser(),
+		e.Auth.GetBool("is_admin"),
+		slices.Contains(e.Auth.GetStringSlice("cached_permissions"), permRegistrationManage),
+		extractBusinessCategory(e.Record.Get("metadata")),
+		newCategory,
+	) {
+	case configWriteDenyMissingPermission:
+		return apis.NewForbiddenError("Missing registration.manage permission", nil)
+	case configWriteDenyWrongCategory:
+		return apis.NewForbiddenError("Admin access required for this config category", nil)
+	case configWriteDenyCategoryMutation:
+		return apis.NewForbiddenError("Cannot change config category", nil)
+	case configWriteAllow:
+		return e.Next() //nolint:wrapcheck // standard PocketBase hook pattern
+	}
+
+	// Unreachable: decideConfigWrite returns one of the cases above. Required by
+	// the compiler because the switch deliberately has no default.
 	return e.Next() //nolint:wrapcheck // standard PocketBase hook pattern
 }
 

--- a/pocketbase/rbac/hooks_test.go
+++ b/pocketbase/rbac/hooks_test.go
@@ -4,6 +4,85 @@ import (
 	"testing"
 )
 
+func TestDecideConfigWrite(t *testing.T) {
+	tests := []struct {
+		name                  string
+		isSuperuser           bool
+		isAdmin               bool
+		hasRegistrationManage bool
+		existingCategory      string
+		newCategory           string
+		want                  configWriteDecision
+	}{
+		{
+			// Regression: a PocketBase superuser writing config via the _/ admin
+			// dashboard has neither is_admin nor cached_permissions, so without an
+			// explicit bypass it was wrongly denied "Missing registration.manage".
+			name:        "superuser bypasses all checks",
+			isSuperuser: true,
+			want:        configWriteAllow,
+		},
+		{
+			name:             "superuser without admin/permission on a solver config is still allowed",
+			isSuperuser:      true,
+			existingCategory: "solver",
+			want:             configWriteAllow,
+		},
+		{
+			name:             "admin bypasses all checks",
+			isAdmin:          true,
+			existingCategory: "solver",
+			want:             configWriteAllow,
+		},
+		{
+			name:             "non-admin without registration.manage is denied",
+			existingCategory: "registration",
+			want:             configWriteDenyMissingPermission,
+		},
+		{
+			name:                  "registration.manage on a registration config is allowed",
+			hasRegistrationManage: true,
+			existingCategory:      "registration",
+			want:                  configWriteAllow,
+		},
+		{
+			name:                  "registration.manage on a non-registration config is denied",
+			hasRegistrationManage: true,
+			existingCategory:      "solver",
+			want:                  configWriteDenyWrongCategory,
+		},
+		{
+			name:                  "registration.manage mutating category is denied",
+			hasRegistrationManage: true,
+			existingCategory:      "registration",
+			newCategory:           "solver",
+			want:                  configWriteDenyCategoryMutation,
+		},
+		{
+			name:                  "registration.manage same-category update is allowed",
+			hasRegistrationManage: true,
+			existingCategory:      "registration",
+			newCategory:           "registration",
+			want:                  configWriteAllow,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := decideConfigWrite(
+				tt.isSuperuser,
+				tt.isAdmin,
+				tt.hasRegistrationManage,
+				tt.existingCategory,
+				tt.newCategory,
+			)
+			if got != tt.want {
+				t.Errorf("decideConfigWrite() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFlattenPermissions(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

Two related `config`-collection fixes. Together they restore the ability to configure and run the solver in environments where it currently fails (the solver errors with `Required config key 'constraint.age_spread.preferred_bonus' not found in database`, and the admin dashboard can't add the missing row).

### 1. Superuser bypass on config writes

`guardConfigWrite` (`pocketbase/rbac/hooks.go`) denied PocketBase **superusers** (the `_/` admin dashboard) with `Missing registration.manage permission`. Superusers authenticate via `_superusers` and have neither `is_admin` nor `cached_permissions`; PocketBase `OnRecord*Request` hooks still fire for them even though collection API *rules* are bypassed — so the hook fell through to the `registration.manage` denial.

Fix: extract the authorization policy into a pure, unit-tested `decideConfigWrite(...)` and add an `IsSuperuser()` bypass alongside the existing admin bypass. Behavior for every existing path (admin, `registration.manage` holder, category-mutation guard, missing permission) is unchanged — pinned by `TestDecideConfigWrite`.

### 2. Backfill the kept `constraint.age_spread.preferred_bonus` row

This key is `required=True` with no code default. Its **only** "insert into an existing DB" migration was standalone `1500000098_age_spread_preferred_threshold.js` (#1021). Consolidation #1275 deleted 098 and folded its seed into the canonical from-scratch seed `1500000011_config.js`. Since 011 had long been applied in existing DBs, editing it never re-runs — so any DB that didn't apply 098 during its 13-day lifetime never received the row. The later solver-config cleanup (`1500000107`) correctly **keeps** `preferred_bonus` but adds no "ensure it exists" step.

New migration `1500000115_seed_age_spread_preferred_bonus.js` idempotently backfills the row, mirroring a fresh 011 install exactly (`value=500`, `business_category=solver`, `section=age-grade`, slider `min=0/max=10000/step=100`). The down-migration is a deliberate **no-op** — deleting a required solver key on rollback would re-introduce the outage.

> Blast radius note: of the three files #1275 consolidated away, only 098 seeded a still-required key, so this is the only key exposed. Every other required key is in the original 011 (applied at install) or in a still-present standalone migration.

## Test plan

- [x] **TDD (Go):** added `TestDecideConfigWrite` (8 cases incl. the superuser regression), confirmed it fails to compile against the old code (red), then implemented (green). `go test ./rbac/` passes.
- [x] **Migration, end-to-end:** snapshotted a real seeded DB, deleted the `preferred_bonus` row to simulate the broken state, ran `migrate up` → `Applied 1500000115...`, row restored as `constraint/age_spread/preferred_bonus = 500` with the exact fresh-install metadata. Re-running is a clean no-op (still one row) — idempotent.
- [x] `go build ./...`, `gofmt`, `golangci-lint run ./rbac/...` (0 issues), `eslint` on the migration — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backfilled a missing configuration key for age-spread preferred bonus to prevent solver failures when the key was absent.

* **Refactor**
  * Centralized and simplified config-write authorization logic into a decision-based flow for clearer permission handling.

* **Tests**
  * Added table-driven tests covering the new config-write decision logic across authorization scenarios.

* **Chores**
  * Bumped Go toolchain references across CI, tooling, and build-stage images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
---

### Also folded in: Go 1.26.3 → 1.26.4 (stdlib CVE fix)

govulncheck was reding Go Lint repo-wide on two stdlib CVEs published 2026-06-02 (`GO-2026-5037` crypto/x509, `GO-2026-5039` net/textproto), both fixed in go1.26.4. Bumped every functional pin (go.mod, go.work, ci.yml setup-go ×3, both Dockerfile builder stages, .coderabbit.yaml citation). Verified locally: `govulncheck ./...` → "No vulnerabilities found." Historical `docs/reference/modernization-backlog.md` left at 1.26.3 by design.

### scan-it follow-ups (deferred, not actioned here)

Two pre-existing, codebase-scope findings were filed for separate analysis rather than expanding this PR:
- #1731 — migrations swallow all errors in `findFirstRecordByFilter` lookups (repo-wide convention question)
- #1732 — config-write RBAC guard category-mutation check fails open on empty `business_category` (pre-existing, low impact)