### PR TITLE
feat(ci): add dependency floor-staleness guard + bump stale floors

### DIFF
--- a/.github/workflows/dep-staleness.yml
+++ b/.github/workflows/dep-staleness.yml
@@ -1,9 +1,10 @@
 name: Dependency Staleness
 
-# Proactively surfaces dependency floors that are a MAJOR version (or more) behind
-# the latest published release -- the "croniter pattern" (shipped as >=2.0.0 while
-# the ecosystem moved to 6.x). Dependabot only files these as throttled individual
-# major-bump PRs, so a stale floor picked at implementation time can sit unnoticed.
+# Proactively surfaces dependency floors that have fallen behind the latest published
+# release -- a MAJOR version (or more) for 1.x+ packages, or a large minor gap for 0.x.
+# The canonical case is the "croniter pattern" (shipped as >=2.0.0 while the ecosystem
+# moved to 6.x). Dependabot only files these as throttled individual major-bump PRs,
+# so a stale floor picked at implementation time can sit unnoticed.
 #
 # Warn-only: the check never fails. It posts a job-summary table and inline
 # ::warning:: annotations. It is NOT a required status check.
@@ -14,6 +15,7 @@ on:
     - cron: '0 13 * * 1'
   workflow_dispatch:
   # On PRs that touch a manifest — catches a stale floor the moment it is added.
+  # Also self-references the checker and workflow so changes to them re-run here.
   pull_request:
     paths:
       - 'pyproject.toml'
@@ -21,6 +23,8 @@ on:
       - 'frontend/package.json'
       - 'package.json'
       - 'pocketbase/package.json'
+      - 'scripts/ci/check_dep_staleness.py'
+      - '.github/workflows/dep-staleness.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/dep-staleness.yml
+++ b/.github/workflows/dep-staleness.yml
@@ -1,0 +1,51 @@
+name: Dependency Staleness
+
+# Proactively surfaces dependency floors that are a MAJOR version (or more) behind
+# the latest published release -- the "croniter pattern" (shipped as >=2.0.0 while
+# the ecosystem moved to 6.x). Dependabot only files these as throttled individual
+# major-bump PRs, so a stale floor picked at implementation time can sit unnoticed.
+#
+# Warn-only: the check never fails. It posts a job-summary table and inline
+# ::warning:: annotations. It is NOT a required status check.
+
+on:
+  # Weekly sweep — Mondays 13:00 UTC, after the 06:00 ET Dependabot run.
+  schedule:
+    - cron: '0 13 * * 1'
+  workflow_dispatch:
+  # On PRs that touch a manifest — catches a stale floor the moment it is added.
+  pull_request:
+    paths:
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'frontend/package.json'
+      - 'package.json'
+      - 'pocketbase/package.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dep-staleness-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  floor-staleness:
+    name: Floor Staleness Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+
+    - name: Setup Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      with:
+        python-version-file: '.python-version'
+
+    # Pure-stdlib script (urllib + tomllib) — no dependency install needed.
+    - name: Check dependency floor staleness
+      run: python scripts/ci/check_dep_staleness.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
     # Web framework
     "fastapi>=0.136.1",
-    "uvicorn[standard]>=0.46.0",
+    "uvicorn[standard]>=0.48.0",
     "python-multipart>=0.0.28",
     # Database
     "pocketbase>=0.17.1",
@@ -48,7 +48,7 @@ dependencies = [
     "PyJWT[crypto]>=2.13.0",
     # CLI & utilities
     "typer>=0.25.1",
-    "rich>=13.0.0",
+    "rich>=15.0.0",
     "tqdm>=4.67.3",
     # Scheduling
     "APScheduler>=3.11.2",
@@ -57,7 +57,7 @@ dependencies = [
     "openpyxl>=3.1.5",
     "pypdf>=6.10.2",
     # System
-    "psutil>=5.9.0",
+    "psutil>=7.2.2",
     "rapidfuzz>=3.14.3",
     # Phonetic & fuzzy matching
     "jellyfish>=1.2.1",

--- a/scripts/ci/check_dep_staleness.py
+++ b/scripts/ci/check_dep_staleness.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Proactive dependency floor-staleness checker (warn-only CI guard).
+
+Compares every declared dependency floor against the latest version published on
+its registry and flags floors that are one or more MAJOR versions behind -- the
+"croniter pattern": shipped as ``croniter>=2.0.0`` while the ecosystem had moved
+to 6.x. Dependabot only surfaces these as throttled individual major-bump PRs, so
+a stale floor picked at implementation time can sit unnoticed for weeks. This
+check makes the gap visible on every manifest-touching PR and on a weekly cron.
+
+Scope: PyPI (``pyproject.toml`` ``>=`` floors) and npm (``package.json`` ``^``/``~``
+ranges). Go modules use semantic-import-versioning -- a new major is a new import
+path you adopt deliberately -- so there is no "stale floor" to detect there.
+
+Warn-only: the checker always exits 0. It reports via stdout, ``::warning::``
+annotations, and ``$GITHUB_STEP_SUMMARY``. It never blocks a merge.
+
+Usage:
+    python scripts/ci/check_dep_staleness.py                 # scan repo manifests (network)
+    python scripts/ci/check_dep_staleness.py --from-json -   # classify rows from stdin (offline)
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import os
+import re
+import sys
+import tomllib
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HTTP_TIMEOUT = 20
+
+SEVERITY_HIGH = "high"
+SEVERITY_MEDIUM = "medium"
+SEVERITY_OK = "ok"
+SEVERITY_UNKNOWN = "unknown"
+SEVERITY_AHEAD = "ahead"
+
+# 0.x packages have no "major" in the usual sense and churn fast; only flag a
+# genuinely large minor gap to avoid drowning the signal in 0.x noise.
+ZEROX_MINOR_MEDIUM = 5
+ZEROX_MINOR_HIGH = 10
+
+# npm manifests scanned in repo mode (first occurrence of a package wins).
+NPM_MANIFESTS = ("frontend/package.json", "package.json", "pocketbase/package.json")
+
+
+# --------------------------------------------------------------------------- #
+# Version math (pure)
+# --------------------------------------------------------------------------- #
+
+
+def parse_version(value: str) -> tuple[int, int, int] | None:
+    """Return ``(major, minor, patch)`` from a version string, or ``None``.
+
+    Tolerates a leading ``v`` and trailing segments (e.g. PyPI type-stub date
+    suffixes like ``7.2.2.20260408`` -> ``(7, 2, 2)``).
+    """
+    match = re.match(r"^\s*v?(\d+)(?:\.(\d+))?(?:\.(\d+))?", value.strip())
+    if not match:
+        return None
+    return (int(match.group(1)), int(match.group(2) or 0), int(match.group(3) or 0))
+
+
+def classify_gap(floor: str, latest: str | None) -> tuple[str, str]:
+    """Classify how far a declared ``floor`` is behind ``latest``.
+
+    Returns ``(severity, human_label)``.
+    """
+    if latest is None or latest.startswith("ERR"):
+        return (SEVERITY_UNKNOWN, "registry lookup failed")
+
+    floor_v = parse_version(floor)
+    latest_v = parse_version(latest)
+    if floor_v is None or latest_v is None:
+        return (SEVERITY_UNKNOWN, "unparseable version")
+
+    # 0.x on both sides: compare the minor segment.
+    if floor_v[0] == 0 and latest_v[0] == 0:
+        gap = latest_v[1] - floor_v[1]
+        if gap < 0:
+            return (SEVERITY_AHEAD, "floor ahead of latest")
+        if gap >= ZEROX_MINOR_HIGH:
+            return (SEVERITY_HIGH, f"{gap} 0.x-minors behind")
+        if gap >= ZEROX_MINOR_MEDIUM:
+            return (SEVERITY_MEDIUM, f"{gap} 0.x-minors behind")
+        return (SEVERITY_OK, f"{gap} 0.x-minors behind")
+
+    major_gap = latest_v[0] - floor_v[0]
+    if major_gap < 0:
+        return (SEVERITY_AHEAD, "floor ahead of latest")
+    if major_gap == 0:
+        return (SEVERITY_OK, "current major")
+    if major_gap == 1:
+        return (SEVERITY_MEDIUM, "1 major behind")
+    return (SEVERITY_HIGH, f"{major_gap} majors behind")
+
+
+# --------------------------------------------------------------------------- #
+# Manifest parsing (pure)
+# --------------------------------------------------------------------------- #
+
+_PYPI_SPEC = re.compile(r"^([A-Za-z0-9._-]+)(?:\[[^\]]*\])?\s*>=\s*([0-9][\w.]*)")
+_NPM_SPEC = re.compile(r"^[\^~]?v?([0-9][\w.]*)$")
+
+
+def parse_pypi_floors(pyproject: dict[str, Any]) -> list[tuple[str, str]]:
+    """Extract ``(name, floor)`` from a parsed ``pyproject.toml`` (main + groups)."""
+    specs: list[str] = list(pyproject.get("project", {}).get("dependencies", []))
+    for group in pyproject.get("dependency-groups", {}).values():
+        specs += [s for s in group if isinstance(s, str)]
+
+    out: list[tuple[str, str]] = []
+    for spec in specs:
+        match = _PYPI_SPEC.match(spec)
+        if match:
+            out.append((match.group(1), match.group(2)))
+    return out
+
+
+def parse_npm_floors(package_json: dict[str, Any]) -> list[tuple[str, str]]:
+    """Extract ``(name, floor)`` from a parsed ``package.json`` (deps + devDeps)."""
+    out: list[tuple[str, str]] = []
+    for section in ("dependencies", "devDependencies"):
+        for name, spec in package_json.get(section, {}).items():
+            match = _NPM_SPEC.match(str(spec))
+            if match:
+                out.append((name, match.group(1)))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Registry lookups (network)
+# --------------------------------------------------------------------------- #
+
+
+def _fetch_json(url: str) -> Any:
+    request = urllib.request.Request(url, headers={"User-Agent": "kindred-dep-staleness/1.0"})
+    with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT) as response:
+        return json.load(response)
+
+
+def fetch_latest(eco: str, name: str) -> str | None:
+    """Return the latest published version for ``name`` on ``eco`` (or ``ERR:...``)."""
+    try:
+        if eco == "pypi":
+            data = _fetch_json(f"https://pypi.org/pypi/{urllib.parse.quote(name)}/json")
+            return str(data["info"]["version"])
+        quoted = urllib.parse.quote(name, safe="@/")
+        return str(_fetch_json(f"https://registry.npmjs.org/{quoted}/latest")["version"])
+    except Exception as exc:
+        return f"ERR:{type(exc).__name__}"
+
+
+# --------------------------------------------------------------------------- #
+# Evaluation + reporting (pure)
+# --------------------------------------------------------------------------- #
+
+_SORT_ORDER = {
+    SEVERITY_HIGH: 0,
+    SEVERITY_MEDIUM: 1,
+    SEVERITY_AHEAD: 2,
+    SEVERITY_UNKNOWN: 3,
+    SEVERITY_OK: 4,
+}
+
+
+def evaluate(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Annotate ``{eco,name,floor,latest}`` rows with ``severity`` and ``label``."""
+    evaluated: list[dict[str, Any]] = []
+    for row in rows:
+        severity, label = classify_gap(row["floor"], row.get("latest"))
+        evaluated.append({**row, "severity": severity, "label": label})
+    evaluated.sort(key=lambda r: (_SORT_ORDER.get(r["severity"], 9), r["eco"], r["name"].lower()))
+    return evaluated
+
+
+def _is_flagged(severity: str) -> bool:
+    return severity in (SEVERITY_HIGH, SEVERITY_MEDIUM)
+
+
+def render_summary(rows: list[dict[str, Any]]) -> str:
+    """Render a Markdown report of flagged rows (for ``$GITHUB_STEP_SUMMARY``)."""
+    flagged = [r for r in rows if _is_flagged(r["severity"])]
+    lines = ["## Dependency floor staleness", ""]
+    if not flagged:
+        lines.append(f"✅ No stale floors — all {len(rows)} declared deps are within one major of latest.")
+        return "\n".join(lines) + "\n"
+
+    lines += [
+        f"⚠️ {len(flagged)} of {len(rows)} declared floors are a major version (or more) behind latest.",
+        "",
+        "| Severity | Eco | Package | Floor | Latest | Gap |",
+        "|----------|-----|---------|-------|--------|-----|",
+    ]
+    badge = {SEVERITY_HIGH: "🔴 high", SEVERITY_MEDIUM: "🟡 med"}
+    for r in flagged:
+        lines.append(
+            f"| {badge.get(r['severity'], r['severity'])} | {r['eco']} | `{r['name']}` "
+            f"| {r['floor']} | {r['latest']} | {r['label']} |"
+        )
+    lines += [
+        "",
+        "_Floors are `>=` (PyPI) / `^`~`~` (npm); a stale floor usually means the lock "
+        "already resolved higher but the declared minimum was never revisited._",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def collect_repo_rows(root: Path) -> list[dict[str, Any]]:
+    """Collect ``{eco,name,floor}`` rows from the repo's manifests (no network)."""
+    rows: list[dict[str, Any]] = []
+
+    pyproject_path = root / "pyproject.toml"
+    if pyproject_path.exists():
+        pyproject = tomllib.loads(pyproject_path.read_text())
+        for name, floor in parse_pypi_floors(pyproject):
+            rows.append({"eco": "pypi", "name": name, "floor": floor})
+
+    seen_npm: set[str] = set()
+    for manifest in NPM_MANIFESTS:
+        path = root / manifest
+        if not path.exists():
+            continue
+        package_json = json.loads(path.read_text())
+        for name, floor in parse_npm_floors(package_json):
+            if name in seen_npm:
+                continue
+            seen_npm.add(name)
+            rows.append({"eco": "npm", "name": name, "floor": floor})
+    return rows
+
+
+def _emit(rows: list[dict[str, Any]]) -> int:
+    """Print the report + GitHub annotations, write the step summary. Always 0."""
+    flagged = [r for r in rows if _is_flagged(r["severity"])]
+
+    print(f"{'SEV':<8} {'ECO':<5} {'PACKAGE':<34} {'FLOOR':<14} {'LATEST':<14} GAP")
+    print("-" * 92)
+    for r in rows:
+        if _is_flagged(r["severity"]) or r["severity"] in (SEVERITY_UNKNOWN, SEVERITY_AHEAD):
+            print(
+                f"{r['severity']:<8} {r['eco']:<5} {r['name']:<34} {r['floor']:<14} "
+                f"{r.get('latest')!s:<14} {r['label']}"
+            )
+
+    for r in flagged:
+        # GitHub annotation -> visible inline on the workflow run.
+        print(
+            f"::warning title=Stale dependency floor::{r['name']} ({r['eco']}) floor "
+            f"{r['floor']} is {r['label']} (latest {r['latest']})"
+        )
+
+    summary = render_summary(rows)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(summary)
+
+    print(f"\n{len(flagged)} flagged of {len(rows)} declared deps.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--from-json",
+        metavar="PATH",
+        help="Read pre-resolved [{eco,name,floor,latest}] rows from PATH ('-' for stdin) "
+        "and classify them offline, instead of scanning manifests and hitting registries.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.from_json:
+        raw = sys.stdin.read() if args.from_json == "-" else Path(args.from_json).read_text()
+        rows = evaluate(json.loads(raw))
+        return _emit(rows)
+
+    declared = collect_repo_rows(REPO_ROOT)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=12) as pool:
+        latest = list(pool.map(lambda r: fetch_latest(r["eco"], r["name"]), declared))
+    for row, version in zip(declared, latest, strict=True):
+        row["latest"] = version
+    return _emit(evaluate(declared))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_dep_staleness.py
+++ b/scripts/ci/check_dep_staleness.py
@@ -2,9 +2,11 @@
 """Proactive dependency floor-staleness checker (warn-only CI guard).
 
 Compares every declared dependency floor against the latest version published on
-its registry and flags floors that are one or more MAJOR versions behind -- the
-"croniter pattern": shipped as ``croniter>=2.0.0`` while the ecosystem had moved
-to 6.x. Dependabot only surfaces these as throttled individual major-bump PRs, so
+its registry and flags floors that have fallen behind -- one or more MAJOR versions
+for a 1.x+ package, or a large MINOR gap for a 0.x package (which has no "major" to
+speak of). The canonical case is the "croniter pattern": shipped as ``croniter>=2.0.0``
+while the ecosystem had moved to 6.x. Dependabot only surfaces these as throttled
+individual major-bump PRs, so
 a stale floor picked at implementation time can sit unnoticed for weeks. This
 check makes the gap visible on every manifest-touching PR and on a weekly cron.
 
@@ -48,7 +50,8 @@ SEVERITY_AHEAD = "ahead"
 ZEROX_MINOR_MEDIUM = 5
 ZEROX_MINOR_HIGH = 10
 
-# npm manifests scanned in repo mode (first occurrence of a package wins).
+# npm manifests scanned in repo mode (deduped per (name, floor), so divergent
+# floors for the same package across manifests are each reported).
 NPM_MANIFESTS = ("frontend/package.json", "package.json", "pocketbase/package.json")
 
 
@@ -189,13 +192,21 @@ def _is_flagged(severity: str) -> bool:
 def render_summary(rows: list[dict[str, Any]]) -> str:
     """Render a Markdown report of flagged rows (for ``$GITHUB_STEP_SUMMARY``)."""
     flagged = [r for r in rows if _is_flagged(r["severity"])]
+    unknown = [r for r in rows if r["severity"] == SEVERITY_UNKNOWN]
     lines = ["## Dependency floor staleness", ""]
     if not flagged:
-        lines.append(f"✅ No stale floors — all {len(rows)} declared deps are within one major of latest.")
+        if unknown:
+            # No flags, but lookups failed -- staleness is indeterminate, not clear.
+            lines.append(
+                f"⚠️ {len(unknown)} of {len(rows)} registry lookups failed — "
+                "staleness could not be determined for those deps."
+            )
+        else:
+            lines.append(f"✅ No stale floors — all {len(rows)} declared deps are within one major of latest.")
         return "\n".join(lines) + "\n"
 
     lines += [
-        f"⚠️ {len(flagged)} of {len(rows)} declared floors are a major version (or more) behind latest.",
+        f"⚠️ {len(flagged)} of {len(rows)} declared floors are behind latest (see the Gap column).",
         "",
         "| Severity | Eco | Package | Floor | Latest | Gap |",
         "|----------|-----|---------|-------|--------|-----|",
@@ -206,9 +217,11 @@ def render_summary(rows: list[dict[str, Any]]) -> str:
             f"| {badge.get(r['severity'], r['severity'])} | {r['eco']} | `{r['name']}` "
             f"| {r['floor']} | {r['latest']} | {r['label']} |"
         )
+    if unknown:
+        lines += ["", f"_{len(unknown)} registry lookup(s) failed — those deps were not evaluated._"]
     lines += [
         "",
-        "_Floors are `>=` (PyPI) / `^`~`~` (npm); a stale floor usually means the lock "
+        "_Floors are `>=` (PyPI) / `^`/`~` (npm); a stale floor usually means the lock "
         "already resolved higher but the declared minimum was never revisited._",
     ]
     return "\n".join(lines) + "\n"
@@ -224,16 +237,18 @@ def collect_repo_rows(root: Path) -> list[dict[str, Any]]:
         for name, floor in parse_pypi_floors(pyproject):
             rows.append({"eco": "pypi", "name": name, "floor": floor})
 
-    seen_npm: set[str] = set()
+    # Dedup on (name, floor): identical pins across manifests collapse to one row,
+    # but a divergent (possibly stale) floor in a later manifest is still reported.
+    seen_npm: set[tuple[str, str]] = set()
     for manifest in NPM_MANIFESTS:
         path = root / manifest
         if not path.exists():
             continue
         package_json = json.loads(path.read_text())
         for name, floor in parse_npm_floors(package_json):
-            if name in seen_npm:
+            if (name, floor) in seen_npm:
                 continue
-            seen_npm.add(name)
+            seen_npm.add((name, floor))
             rows.append({"eco": "npm", "name": name, "floor": floor})
     return rows
 

--- a/tests/unit/scripts/test_check_dep_staleness.py
+++ b/tests/unit/scripts/test_check_dep_staleness.py
@@ -192,3 +192,60 @@ def test_cli_emits_github_warning_annotations():
     rows = [{"eco": "pypi", "name": "psutil", "floor": "5.9.0", "latest": "7.2.2"}]
     _, out, _ = run_cli(rows)
     assert "::warning" in out  # surfaced as a GitHub annotation
+
+
+# --------------------------- render_summary ---------------------------
+
+
+def test_render_summary_no_false_all_clear_when_all_lookups_failed():
+    # If every registry lookup failed, staleness is indeterminate -- the summary
+    # must NOT claim an all-clear (regression guard for the false-green bug).
+    rows = mod.evaluate(
+        [
+            {"eco": "pypi", "name": "rich", "floor": "13.0.0", "latest": "ERR:URLError"},
+            {"eco": "pypi", "name": "psutil", "floor": "5.9.0", "latest": None},
+        ]
+    )
+    summary = mod.render_summary(rows)
+    assert "No stale floors" not in summary
+    assert "lookup" in summary.lower()  # surfaces that lookups failed
+
+
+def test_render_summary_clean_run_still_reports_all_clear():
+    rows = mod.evaluate([{"eco": "npm", "name": "react", "floor": "19.2.4", "latest": "19.2.7"}])
+    summary = mod.render_summary(rows)
+    assert "No stale floors" in summary
+
+
+def test_render_summary_zerox_flagged_not_described_as_major():
+    # A 0.x package flagged on a large MINOR gap must not be called a major-version gap.
+    rows = mod.evaluate([{"eco": "npm", "name": "somepkg", "floor": "0.17.1", "latest": "0.30.0"}])
+    summary = mod.render_summary(rows)
+    assert "somepkg" in summary
+    assert "major version" not in summary.lower()
+
+
+# --------------------------- collect_repo_rows (npm dedup) ---------------------------
+
+
+def _write_manifest(path: Path, deps: dict[str, str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"dependencies": deps}))
+
+
+def test_collect_repo_rows_reports_divergent_npm_floors(tmp_path):
+    # Same package, different floors across manifests: the later (possibly stale)
+    # floor must NOT be hidden by a repo-wide name-only dedup.
+    _write_manifest(tmp_path / "frontend" / "package.json", {"eslint": "^10.4.0"})
+    _write_manifest(tmp_path / "pocketbase" / "package.json", {"eslint": "^9.0.0"})
+    rows = mod.collect_repo_rows(tmp_path)
+    eslint_floors = {r["floor"] for r in rows if r["name"] == "eslint"}
+    assert eslint_floors == {"10.4.0", "9.0.0"}
+
+
+def test_collect_repo_rows_dedupes_identical_npm_floors(tmp_path):
+    # Identical (name, floor) across manifests is redundant -- report it once.
+    _write_manifest(tmp_path / "frontend" / "package.json", {"eslint": "^10.4.0"})
+    _write_manifest(tmp_path / "pocketbase" / "package.json", {"eslint": "^10.4.0"})
+    rows = mod.collect_repo_rows(tmp_path)
+    assert sum(1 for r in rows if r["name"] == "eslint") == 1

--- a/tests/unit/scripts/test_check_dep_staleness.py
+++ b/tests/unit/scripts/test_check_dep_staleness.py
@@ -1,0 +1,194 @@
+"""Tests for the dependency floor-staleness checker.
+
+The checker compares each declared dependency floor (`pyproject.toml` `>=`,
+`package.json` `^`/`~`) against the latest version published on its registry and
+flags floors that are one or more MAJOR versions behind -- the croniter pattern
+(`>=2.0.0` while the latest is 6.x). Network lookups are exercised offline via the
+`--from-json` CLI contract; the classification math is unit-tested directly.
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+SCRIPT_PATH = Path(__file__).parents[3] / "scripts" / "ci" / "check_dep_staleness.py"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_dep_staleness", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_module()
+
+
+def run_cli(rows: list[dict[str, str]], extra: list[str] | None = None) -> tuple[int, str, str]:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--from-json", "-", *(extra or [])],
+        input=json.dumps(rows),
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+# --------------------------- parse_version ---------------------------
+
+
+def test_parse_version_three_segments():
+    assert mod.parse_version("2.0.0") == (2, 0, 0)
+    assert mod.parse_version("15.0.0") == (15, 0, 0)
+
+
+def test_parse_version_partial_segments():
+    assert mod.parse_version("9.15") == (9, 15, 0)
+    assert mod.parse_version("15") == (15, 0, 0)
+
+
+def test_parse_version_zerox():
+    assert mod.parse_version("0.46.0") == (0, 46, 0)
+
+
+def test_parse_version_date_suffixed_pypi_stub():
+    # types-* packages carry a trailing date segment; only the first three count.
+    assert mod.parse_version("7.2.2.20260408") == (7, 2, 2)
+
+
+def test_parse_version_v_prefix():
+    assert mod.parse_version("v1.2.3") == (1, 2, 3)
+
+
+def test_parse_version_unparseable():
+    assert mod.parse_version("not-a-version") is None
+    assert mod.parse_version("*") is None
+
+
+# --------------------------- classify_gap ---------------------------
+
+
+def test_classify_major_behind_is_high():
+    # The cases this guard exists to catch.
+    assert mod.classify_gap("2.0.0", "6.2.2")[0] == mod.SEVERITY_HIGH  # croniter
+    assert mod.classify_gap("5.9.0", "7.2.2")[0] == mod.SEVERITY_HIGH  # psutil
+    assert mod.classify_gap("13.0.0", "15.0.0")[0] == mod.SEVERITY_HIGH  # rich
+
+
+def test_classify_one_major_behind_is_medium():
+    assert mod.classify_gap("6.0.0", "7.1.0")[0] == mod.SEVERITY_MEDIUM  # pytest-cov
+
+
+def test_classify_current_major_is_ok():
+    assert mod.classify_gap("19.2.4", "19.2.7")[0] == mod.SEVERITY_OK
+    assert mod.classify_gap("3.9.0", "3.14.0")[0] == mod.SEVERITY_OK
+
+
+def test_classify_zerox_small_minor_gap_is_ok():
+    # 0.x packages move fast; a couple of minors behind is not "behind the curve".
+    assert mod.classify_gap("0.46.0", "0.48.0")[0] == mod.SEVERITY_OK
+
+
+def test_classify_zerox_large_minor_gap_is_flagged():
+    sev, _ = mod.classify_gap("0.17.1", "0.30.0")
+    assert sev in (mod.SEVERITY_MEDIUM, mod.SEVERITY_HIGH)
+
+
+def test_classify_floor_ahead_of_latest():
+    assert mod.classify_gap("3.0.0", "2.9.0")[0] == mod.SEVERITY_AHEAD
+
+
+def test_classify_unknown_latest():
+    assert mod.classify_gap("1.0.0", None)[0] == mod.SEVERITY_UNKNOWN
+    assert mod.classify_gap("1.0.0", "ERR:boom")[0] == mod.SEVERITY_UNKNOWN
+
+
+def test_classify_label_mentions_majors():
+    _, label = mod.classify_gap("2.0.0", "6.2.2")
+    assert "4" in label
+    assert "major" in label.lower()
+
+
+# --------------------------- manifest parsing ---------------------------
+
+
+def test_parse_pypi_floors_extracts_name_and_floor():
+    pyproject = {
+        "project": {
+            "dependencies": [
+                "croniter>=2.0.0",
+                "uvicorn[standard]>=0.46.0",
+                "PyJWT[crypto]>=2.13.0",
+            ]
+        },
+        "dependency-groups": {"dev": ["pytest>=9.0.3"]},
+    }
+    floors = dict(mod.parse_pypi_floors(pyproject))
+    assert floors["croniter"] == "2.0.0"
+    assert floors["uvicorn"] == "0.46.0"  # extras stripped
+    assert floors["PyJWT"] == "2.13.0"
+    assert floors["pytest"] == "9.0.3"  # dev group included
+
+
+def test_parse_pypi_floors_skips_non_floor_specs():
+    pyproject = {"project": {"dependencies": ["somepkg==1.2.3", "another"]}}
+    assert mod.parse_pypi_floors(pyproject) == []
+
+
+def test_parse_npm_floors_strips_range_prefix():
+    package_json = {
+        "dependencies": {"react": "^19.2.4", "leaflet": "~1.9.4"},
+        "devDependencies": {"vite": "^8.0.14"},
+    }
+    floors = dict(mod.parse_npm_floors(package_json))
+    assert floors["react"] == "19.2.4"
+    assert floors["leaflet"] == "1.9.4"
+    assert floors["vite"] == "8.0.14"
+
+
+def test_parse_npm_floors_skips_non_semver_specs():
+    package_json = {
+        "dependencies": {
+            "x": "*",
+            "y": "workspace:*",
+            "z": "github:user/repo",
+        }
+    }
+    assert mod.parse_npm_floors(package_json) == []
+
+
+# --------------------------- CLI contract (warn-only) ---------------------------
+
+
+def test_cli_flags_stale_floor_in_output():
+    rows = [
+        {"eco": "pypi", "name": "croniter", "floor": "2.0.0", "latest": "6.2.2"},
+        {"eco": "pypi", "name": "rich", "floor": "13.0.0", "latest": "15.0.0"},
+    ]
+    _, out, _ = run_cli(rows)
+    assert "croniter" in out
+    assert "rich" in out
+
+
+def test_cli_is_warn_only_exit_zero_even_when_stale():
+    rows = [{"eco": "pypi", "name": "croniter", "floor": "2.0.0", "latest": "6.2.2"}]
+    code, _, _ = run_cli(rows)
+    assert code == 0, "warn-mode checker must never fail CI"
+
+
+def test_cli_clean_input_exit_zero():
+    rows = [{"eco": "npm", "name": "react", "floor": "19.2.4", "latest": "19.2.7"}]
+    code, out, _ = run_cli(rows)
+    assert code == 0
+    assert "react" not in out or "0 " in out  # not flagged
+
+
+def test_cli_emits_github_warning_annotations():
+    rows = [{"eco": "pypi", "name": "psutil", "floor": "5.9.0", "latest": "7.2.2"}]
+    _, out, _ = run_cli(rows)
+    assert "::warning" in out  # surfaced as a GitHub annotation

--- a/uv.lock
+++ b/uv.lock
@@ -761,7 +761,7 @@ requires-dist = [
     { name = "ortools", specifier = ">=9.15.6755" },
     { name = "pandas", specifier = ">=3.0.3" },
     { name = "pocketbase", specifier = ">=0.17.1" },
-    { name = "psutil", specifier = ">=5.9.0" },
+    { name = "psutil", specifier = ">=7.2.2" },
     { name = "pydantic", specifier = ">=2.7.0" },
     { name = "pydantic-settings", specifier = ">=2.14.1" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.13.0" },
@@ -771,11 +771,11 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rapidfuzz", specifier = ">=3.14.3" },
     { name = "requests", specifier = ">=2.33.1" },
-    { name = "rich", specifier = ">=13.0.0" },
+    { name = "rich", specifier = ">=15.0.0" },
     { name = "tqdm", specifier = ">=4.67.3" },
     { name = "typer", specifier = ">=0.25.1" },
     { name = "tzdata", specifier = ">=2026.2" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.46.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.48.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1878,15 +1878,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.46.0"
+version = "0.48.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Why

Following up on croniter (#1725): we shipped `croniter>=2.0.0` while the ecosystem had moved to 6.x, and the stale floor sat unnoticed for a long time. Root cause: our Dependabot groups are `update-types: [minor, patch]` only, so **major** floor-bumps arrive only as *individual* PRs, throttled by `open-pull-requests-limit: 5` and crowded out by the grouped minor/patch PRs. Nothing reconciles a `>=` floor against what the lock already resolved — so a floor picked stale at implementation time is invisible until Dependabot's slow individual lane gets to it.

This adds a **proactive** check so the gap surfaces immediately, and fixes the cases that have no open Dependabot PR yet.

## Audit result

A repo-wide sweep (PyPI + npm + Go + Docker) found the staleness is **entirely on the Python side**:

| Package | Floor | Latest | Gap | Running (lock) | Status |
|---|---|---|---|---|---|
| croniter | `>=2.0.0` | 6.2.2 | 4 majors | 6.2.2 | existing PR #1725 |
| rich | `>=13.0.0` | 15.0.0 | **2 majors** | 15.0.0 | **fixed here** |
| psutil | `>=5.9.0` | 7.2.2 | **2 majors** | 7.2.2 | **fixed here** |
| pytest-cov | `>=6.0.0` | 7.1.0 | 1 major | 7.1.0 | existing PR #1724 |
| uvicorn | `>=0.46.0` | 0.48.0 | 2 minors | **0.46.0** ⚠️ | **fixed here** (lock was behind) |

- **Go** is clean — semantic-import-versioning means a new major is a new import path you adopt deliberately, so there's no "stale floor" concept (probed `robfig/cron/v4`, `dbx/v2`, etc. — all 404).
- **npm** (frontend/root/pocketbase) is clean — every floor is current-major.
- **Docker** base images are current.

## Changes

**Fix (this PR's scope):** bump `rich`/`psutil`/`uvicorn` floors to match the locked versions (floor == lock == latest). `rich`/`psutil` were already resolved to latest in `uv.lock` — the floor was just stale and noise-generating; `uvicorn` was actually running 2 minors behind, so this also moves the lock `0.46.0 → 0.48.0`. croniter (#1725) and pytest-cov (#1724) are left to their existing Dependabot PRs.

**Guard (warn-only — never blocks a merge):**
- `scripts/ci/check_dep_staleness.py` — pure-stdlib checker (urllib + tomllib, no deps to install) comparing each PyPI `>=` / npm `^`/`~` floor against the live registry latest. Reports via stdout, `::warning::` annotations, and `$GITHUB_STEP_SUMMARY`.
- `.github/workflows/dep-staleness.yml` — weekly cron + on any manifest-touching PR (catches a stale floor the moment it's added) + `workflow_dispatch`. **Not** a required status check.
- `tests/unit/scripts/test_check_dep_staleness.py` — version math, manifest parsing, and the offline `--from-json` CLI contract (22 tests).

## Testing

- `pytest tests/unit/scripts/test_check_dep_staleness.py` — 22 passed
- Full pre-push verification: ruff, mypy, full unit suite (5419 passed), actionlint + zizmor (clean) on the new workflow
- Live run reproduces the audit table above and exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped minimum runtime dependency versions: uvicorn[standard], rich, and psutil.
* **New Features**
  * Added a warn-only dependency staleness CI check that runs weekly, on relevant pull requests, and manually; it posts a summary and emits inline warnings but does not fail builds.
* **Tests**
  * Added extensive unit tests for the staleness checker’s parsing, classification, reporting, and CLI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->