### PR TITLE
chore(security): ignore pip PYSEC-2026-196 in pip-audit

### DIFF
--- a/.pip-audit-ignore
+++ b/.pip-audit-ignore
@@ -7,3 +7,4 @@ CVE-2026-4539  # pygments ReDoS in AdlLexer (archetype.py) — local-only, no up
 CVE-2026-3219  # pip handles concatenated tar/ZIP files as ZIP — install-time only, no fix released yet — added 2026-04-25, remove by 2026-05-25
 CVE-2026-6357  # pip self-update import-deferral race; fixed in pip 26.1, system pip not yet bumped — added 2026-05-05, remove by 2026-06-05
 PYSEC-2025-183  # pyjwt weak-key advisory, disputed by supplier (key length is the application's choice); no fix version published — added 2026-05-20, remove by 2026-06-20
+PYSEC-2026-196  # pip installs console_scripts/gui_scripts to an unsanitized resolved path (entry points can land outside the install dir); fixed in pip 26.1.2, system pip not yet bumped — added 2026-06-10, remove by 2026-07-10


### PR DESCRIPTION
## What

Add `PYSEC-2026-196` to `.pip-audit-ignore`.

## Why

`pip-audit` in the Python Lint CI job started failing on a fresh advisory in the **system pip** (`PYSEC-2026-196`): pip installs `console_scripts`/`gui_scripts` to an unsanitized resolved path, so entry points can land outside the install directory. It's fixed in **pip 26.1.2**, but the CI runner's pip is not yet bumped, so the scan reds **every open PR and `main`** with no code change.

This mirrors the existing temporary pip entries (`CVE-2026-3219`, `CVE-2026-6357`) — a dated, remove-by ignore until the runner pip is bumped. Install-time/runner-only; no impact on shipped code.

## Verification

- Line added in the existing `CVE-ID  # reason — added … remove by …` format.
- Unblocks the required `CI Summary` check across all PRs and `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new temporary CVE advisory ignore entry to the dependency security configuration with accompanying documentation and metadata. The entry is scheduled for removal on July 10, 2026. This change is part of ongoing dependency management and vulnerability tracking procedures to maintain security standards across the application and all dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->