### PR TITLE
fix(security): bump locked pip to 26.1.2 and drop resolved pip CVE ignores

### DIFF
--- a/.pip-audit-ignore
+++ b/.pip-audit-ignore
@@ -4,7 +4,4 @@
 # Format: CVE-ID  # reason — added YYYY-MM-DD, remove by YYYY-MM-DD
 
 CVE-2026-4539  # pygments ReDoS in AdlLexer (archetype.py) — local-only, no upstream fix yet — added 2026-03-24, remove by 2026-04-24
-CVE-2026-3219  # pip handles concatenated tar/ZIP files as ZIP — install-time only, no fix released yet — added 2026-04-25, remove by 2026-05-25
-CVE-2026-6357  # pip self-update import-deferral race; fixed in pip 26.1, system pip not yet bumped — added 2026-05-05, remove by 2026-06-05
 PYSEC-2025-183  # pyjwt weak-key advisory, disputed by supplier (key length is the application's choice); no fix version published — added 2026-05-20, remove by 2026-06-20
-PYSEC-2026-196  # pip installs console_scripts/gui_scripts to an unsanitized resolved path (entry points can land outside the install dir); fixed in pip 26.1.2, system pip not yet bumped — added 2026-06-10, remove by 2026-07-10

--- a/uv.lock
+++ b/uv.lock
@@ -1162,11 +1162,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316, upload-time = "2026-04-26T21:00:05.406Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804, upload-time = "2026-04-26T21:00:03.194Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

pip 26.1 (transitive dep of pip-audit via pip-api) is flagged by PYSEC-2026-196, which fails the `Security audit (pip-audit)` CI step on every dependabot branch created before the temporary ignore landed in #1751. This fixes the CVE properly instead of carrying the ignore:

- `uv lock --upgrade-package pip` → pip **26.1 → 26.1.2** (the advisory's fix version)
- Remove the three pip ignore lines from `.pip-audit-ignore` that no longer flag at 26.1.2:
  - **PYSEC-2026-196** (entry-point path sanitization — fixed in 26.1.2)
  - **CVE-2026-6357** (self-update race — fixed in 26.1, stale since #1722-era bump)
  - **CVE-2026-3219** (concatenated tar/ZIP — verified no longer reported at 26.1.2)
- The two non-pip ignores (pygments CVE-2026-4539, pyjwt PYSEC-2025-183) remain.

## Test plan

- [x] `uv run pip-audit` with CI's exact ignore-loop: **No known vulnerabilities found**
- [x] Same result with only the two remaining ignores

After this merges, the six open dependabot PRs (#1735–#1741) will be recreated so their branches pick up a green audit base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security advisory ignore configuration to remove outdated temporary entries and refresh the active security advisory management list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->