### PR TITLE
fix(api): return solver memory to the OS — subprocess solves + bounded solver_runs

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -9,6 +9,7 @@ This module provides:
 """
 
 import asyncio
+from datetime import UTC, datetime
 from typing import Any
 
 from bunking.graph.graph_cache_manager import GraphCacheManager
@@ -122,12 +123,43 @@ metrics_cache = MetricsCache(ttl_seconds=7200, max_size=200)
 # In-memory storage for solver runs (in production, use Redis or a database)
 solver_runs: dict[str, dict[str, Any]] = {}
 
+# Completed/failed runs stay readable in-memory for the frontend's status
+# polling, but the dict must not grow unboundedly (prod swap incident
+# 2026-06-12): each retained run holds full results + diagnostics. 50
+# comfortably exceeds any realistic sweep size.
+MAX_TERMINAL_SOLVER_RUNS = 50
+
+_TERMINAL_STATUSES = frozenset({"completed", "failed"})
+_EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+
+
+def prune_solver_runs() -> int:
+    """Evict the oldest terminal runs above the cap; returns the eviction count.
+
+    pending/running entries are never touched — the single-flight guards and
+    the frontend's status polling depend on them being present.
+    """
+    terminal = [
+        (run_id, run.get("completed_at") or _EPOCH)
+        for run_id, run in solver_runs.items()
+        if run.get("status") in _TERMINAL_STATUSES
+    ]
+    excess = len(terminal) - MAX_TERMINAL_SOLVER_RUNS
+    if excess <= 0:
+        return 0
+    terminal.sort(key=lambda item: item[1])
+    for run_id, _ in terminal[:excess]:
+        solver_runs.pop(run_id, None)
+    logger.info(f"Pruned {excess} terminal solver runs from memory (cap {MAX_TERMINAL_SOLVER_RUNS})")
+    return excess
+
 
 # ========================================
 # ID Translation Cache
 # ========================================
 
 __all__ = [
+    "MAX_TERMINAL_SOLVER_RUNS",
     "IDLookupCache",
     "auth_state",
     "authenticate_pb",
@@ -138,6 +170,7 @@ __all__ = [
     "metrics_cache",
     "pb",
     "pb_url",
+    "prune_solver_runs",
     "solver_runs",
     "start_pb_token_refresh",
 ]

--- a/api/services/solve_executor.py
+++ b/api/services/solve_executor.py
@@ -9,10 +9,16 @@ in-process path (`solve_and_diagnose`) remains available behind the
 SOLVER_SUBPROCESS kill-switch.
 """
 
+import asyncio
+import multiprocessing
+from collections.abc import Callable
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 from dataclasses import asdict, dataclass
+from functools import partial
 from typing import Any
 
-from bunking.config import ConfigLoader
+from bunking.config import ConfigLoader, StaticConfigService
 from bunking.logging_config import get_logger
 from bunking.models_v2 import DirectSolverInput, DirectSolverOutput
 from bunking.solver import DirectBunkingSolver
@@ -112,3 +118,52 @@ def solve_and_diagnose(
         logger.error(f"Failed to run infeasibility analysis: {e}", exc_info=True)
 
     return outcome
+
+
+class SolverProcessDiedError(RuntimeError):
+    """The solver child process terminated without returning (likely OOM-killed)."""
+
+
+def _child_entry(
+    solver_input: DirectSolverInput,
+    time_limit: int,
+    debug_constraints: dict[str, Any] | None,
+    config_values: dict[str, Any],
+) -> SolveOutcome:
+    """Top-level spawn target: rebuild config from the snapshot, solve, return."""
+    config_service = StaticConfigService(config_values)
+    return solve_and_diagnose(solver_input, time_limit, debug_constraints, config_service)
+
+
+async def run_solve_in_subprocess(
+    solver_input: DirectSolverInput,
+    time_limit: int,
+    debug_constraints: dict[str, Any] | None,
+    config_values: dict[str, Any],
+    _entry: Callable[[DirectSolverInput, int, dict[str, Any] | None, dict[str, Any]], SolveOutcome] = _child_entry,
+) -> SolveOutcome:
+    """Execute one solve in a fresh spawn worker that exits after the task.
+
+    ``max_tasks_per_child=1`` IS the memory fix: the worker process dies after
+    the solve, returning the CP-SAT arena high-water mark to the OS. Spawn (not
+    fork): forking a threaded uvicorn process is unsafe, and max_tasks_per_child
+    requires a non-fork context anyway. The ~2-4 s import cost per solve is
+    noise against 30-300 s solve budgets.
+
+    ``_entry`` is injectable for tests only — production always uses
+    ``_child_entry``.
+    """
+    ctx = multiprocessing.get_context("spawn")
+    executor = ProcessPoolExecutor(max_workers=1, max_tasks_per_child=1, mp_context=ctx)
+    try:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            executor, partial(_entry, solver_input, time_limit, debug_constraints, config_values)
+        )
+    except BrokenProcessPool as e:
+        raise SolverProcessDiedError(
+            "Solver child process died before returning a result — likely OOM-killed. "
+            "The API process itself is unaffected; this run is recorded as failed."
+        ) from e
+    finally:
+        executor.shutdown(wait=False, cancel_futures=False)

--- a/api/services/solve_executor.py
+++ b/api/services/solve_executor.py
@@ -1,0 +1,114 @@
+"""Run a CP-SAT solve (and its failure diagnostics) as one pure compute unit.
+
+The OR-Tools arena high-water mark never returns to the OS from a long-lived
+process (glibc), so every heavy solve permanently ratchets the API container's
+RSS — the prod swap incident of 2026-06-12. The compute block here is designed
+to execute in a throwaway spawn worker (`run_solve_in_subprocess`) that exits
+after one task and hands the entire footprint back to the kernel; the
+in-process path (`solve_and_diagnose`) remains available behind the
+SOLVER_SUBPROCESS kill-switch.
+"""
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from bunking.config import ConfigLoader
+from bunking.logging_config import get_logger
+from bunking.models_v2 import DirectSolverInput, DirectSolverOutput
+from bunking.solver import DirectBunkingSolver
+from bunking.solver.diagnostics import resolve_localization
+from bunking.solver.feasibility import localize_hard_mso_infeasibility
+from bunking.solver.impossibility import filter_immaterial_requests
+
+logger = get_logger(__name__)
+
+# Mirrors the literals previously inlined in run_solver_task_v2.
+INFEASIBILITY_ANALYSIS_TIME_LIMIT_SECONDS = 10
+IIS_PROBE_TIME_LIMIT_SECONDS = 5
+
+
+@dataclass
+class SolveOutcome:
+    """Picklable bundle of everything one solve produced.
+
+    ``result is None`` means the solve failed/was infeasible; the diagnostic
+    fields are then populated on a best-effort basis (None = that analysis
+    step did not run or failed — matching the legacy key-absent semantics in
+    ``solver_runs``).
+    """
+
+    result: DirectSolverOutput | None
+    impossibility_report: dict[str, Any] | None = None
+    infeasibility_cause: str | None = None
+    parent_paramount_iis: dict[str, Any] | None = None
+    localization: dict[str, Any] | None = None
+
+
+def solve_and_diagnose(
+    solver_input: DirectSolverInput,
+    time_limit: int,
+    debug_constraints: dict[str, Any] | None,
+    config_service: ConfigLoader,
+) -> SolveOutcome:
+    """Run the solver; on failure, run the full diagnostic chain.
+
+    Pure compute: no PocketBase access, no ``solver_runs`` writes — safe to
+    execute in a child process. Logic transplanted verbatim from
+    run_solver_task_v2 (orchestrator-diagnosis short-circuit, impossibility
+    report capture, parent_paramount IIS localization).
+    """
+    logger.info("Creating DirectBunkingSolver instance")
+    if debug_constraints:
+        logger.info(f"DEBUG MODE: Constraints disabled: {list(debug_constraints.keys())}")
+    solver = DirectBunkingSolver(
+        input_data=solver_input,
+        config_service=config_service,
+        debug_constraints=debug_constraints or {},
+    )
+
+    result = solver.solve(time_limit_seconds=time_limit)
+
+    # Stream C: orchestrator returns an empty-assignments DirectSolverOutput
+    # with infeasibility_diagnosis on INFEASIBLE (instead of None) so the
+    # diagnosis travels with the result. Convert here so the failure path
+    # below handles it; surface the diagnosis directly (avoids the redundant
+    # find_infeasibility_cause call).
+    orchestrator_diagnosis: str | None = None
+    if result is not None and not result.assignments and result.infeasibility_diagnosis is not None:
+        orchestrator_diagnosis = result.infeasibility_diagnosis
+        result = None
+
+    if result is not None:
+        return SolveOutcome(result=result)
+
+    outcome = SolveOutcome(result=None)
+    logger.warning("Solver failed - running infeasibility analysis...")
+
+    # Surface the already-computed impossibility report (#1638). The solver
+    # holds it; immaterial-filter it to match the pre-validate surface.
+    try:
+        outcome.impossibility_report = asdict(filter_immaterial_requests(solver.impossibility_report))
+    except Exception as e:
+        logger.error(f"Failed to capture impossibility report: {e}", exc_info=True)
+
+    try:
+        if orchestrator_diagnosis is not None:
+            cause = orchestrator_diagnosis
+            logger.info(f"Using orchestrator-supplied diagnosis: {cause}")
+        else:
+            cause = solver.find_infeasibility_cause(time_limit_seconds=INFEASIBILITY_ANALYSIS_TIME_LIMIT_SECONDS)
+            logger.error(f"Infeasibility analysis result: {cause}")
+        outcome.infeasibility_cause = cause
+
+        # If parent_paramount is the cause, localize the conflict to
+        # specific campers (see docs/architecture/solver-internals.md).
+        if isinstance(cause, str) and "parent_paramount" in cause:
+            iis = localize_hard_mso_infeasibility(solver_input, config_service, IIS_PROBE_TIME_LIMIT_SECONDS)
+            logger.error(f"Hard-MSO IIS localization: {iis}")
+            outcome.parent_paramount_iis = iis
+            # Name-resolve for the frontend (#1638).
+            outcome.localization = resolve_localization(iis, solver_input.person_by_cm_id)
+    except Exception as e:
+        logger.error(f"Failed to run infeasibility analysis: {e}", exc_info=True)
+
+    return outcome

--- a/api/services/solver_runner.py
+++ b/api/services/solver_runner.py
@@ -18,7 +18,7 @@ from bunking.logging_config import get_logger
 from pocketbase import PocketBase
 
 from ..constants.collections import CAMP_SESSIONS, SOLVER_RUNS, SUPERUSERS
-from ..dependencies import pb_url, solver_runs
+from ..dependencies import pb_url, prune_solver_runs, solver_runs
 from ..settings import get_settings
 from .data_fetcher import (
     fetch_historical_bunking,
@@ -367,6 +367,7 @@ async def run_solver_task_v2(
             logger.error(f"Traceback: {traceback.format_exc()}")
 
         logger.info(f"Solver run {run_id} completed successfully")
+        prune_solver_runs()
 
     except Exception as e:
         logger.error(f"Solver run {run_id} failed: {e}", exc_info=True)
@@ -402,3 +403,4 @@ async def run_solver_task_v2(
             await _persist_run_record(task_pb, run_id, failure_payload, sweep_id=sweep_id)
         except Exception:  # noqa: S110 — intentional silent handling
             pass
+        prune_solver_runs()

--- a/api/services/solver_runner.py
+++ b/api/services/solver_runner.py
@@ -8,18 +8,13 @@ Main + AG sessions are automatically fetched together via get_related_session_id
 import asyncio
 import json
 import traceback
-from dataclasses import asdict
 from datetime import UTC, datetime
 from typing import Any
 
 from pocketbase.errors import ClientResponseError
 
-from bunking.config import ConfigLoader
-from bunking.direct_solver import DirectBunkingSolver
+from bunking.config import ConfigLoader, snapshot_config
 from bunking.logging_config import get_logger
-from bunking.solver.diagnostics import resolve_localization
-from bunking.solver.feasibility import localize_hard_mso_infeasibility
-from bunking.solver.impossibility import filter_immaterial_requests
 from pocketbase import PocketBase
 
 from ..constants.collections import CAMP_SESSIONS, SOLVER_RUNS, SUPERUSERS
@@ -32,6 +27,7 @@ from .data_fetcher import (
     prepare_direct_solver_input,
 )
 from .run_tagging import build_run_details, compose_minimal_run_details
+from .solve_executor import run_solve_in_subprocess, solve_and_diagnose
 
 logger = get_logger(__name__)
 
@@ -234,70 +230,37 @@ async def run_solver_task_v2(
                 actual_value = config_service.get_str(key)
                 logger.info(f"Config {key} is now: {actual_value}")
 
-        # Run solver (main + AG sessions are automatically fetched together)
-        logger.info("Creating DirectBunkingSolver instance")
-        if debug_constraints:
-            logger.info(f"DEBUG MODE: Constraints disabled: {list(debug_constraints.keys())}")
-        solver = DirectBunkingSolver(
-            input_data=solver_input, config_service=config_service, debug_constraints=debug_constraints or {}
-        )
+        # Run solver (main + AG sessions are automatically fetched together).
+        # The compute block (solve + failure diagnostics) lives in
+        # solve_executor; by default it executes in a throwaway spawn child so
+        # the CP-SAT memory high-water mark returns to the OS when the run
+        # ends (prod swap incident 2026-06-12). SOLVER_SUBPROCESS=false falls
+        # back to the legacy in-thread path — still off the event loop, which
+        # must stay responsive for status polls / health checks.
+        if settings.solver_subprocess:
+            config_values = snapshot_config(config_service)
+            logger.info(f"Running solver in subprocess ({len(config_values)} config keys snapshotted)")
+            outcome = await run_solve_in_subprocess(solver_input, time_limit, debug_constraints, config_values)
+        else:
+            logger.info("Running solver in-thread (SOLVER_SUBPROCESS disabled)")
+            outcome = await asyncio.to_thread(
+                solve_and_diagnose, solver_input, time_limit, debug_constraints, config_service
+            )
 
-        # The OR-Tools solver is synchronous and CPU-bound — running it
-        # directly on the event loop blocks every other request to this
-        # uvicorn worker (status polls, /health, the container HEALTHCHECK
-        # probe) for the full solve duration. Offload to a thread so the
-        # event loop stays responsive.
-        result = await asyncio.to_thread(solver.solve, time_limit_seconds=time_limit)
-
-        # Stream C: orchestrator returns an empty-assignments DirectSolverOutput
-        # with infeasibility_diagnosis on INFEASIBLE (instead of None) so the
-        # diagnosis travels with the result. Convert here so the existing
-        # failure path handles it; surface the diagnosis directly (avoid the
-        # redundant find_infeasibility_cause call below).
-        orchestrator_diagnosis: str | None = None
-        if result is not None and not result.assignments and result.infeasibility_diagnosis is not None:
-            orchestrator_diagnosis = result.infeasibility_diagnosis
-            result = None
-
-        if result is None:
-            # Try to identify the cause of infeasibility
-            logger.warning("Solver failed - running infeasibility analysis...")
-
-            # Surface the already-computed impossibility report (#1638). The solver
-            # holds it; immaterial-filter it to match the pre-validate surface.
-            try:
-                solver_runs[run_id]["impossibility_report"] = asdict(
-                    filter_immaterial_requests(solver.impossibility_report)
-                )
-            except Exception as e:
-                logger.error(f"Failed to capture impossibility report: {e}", exc_info=True)
-
-            try:
-                if orchestrator_diagnosis is not None:
-                    cause = orchestrator_diagnosis
-                    logger.info(f"Using orchestrator-supplied diagnosis: {cause}")
-                else:
-                    cause = await asyncio.to_thread(solver.find_infeasibility_cause, time_limit_seconds=10)
-                    logger.error(f"Infeasibility analysis result: {cause}")
-                solver_runs[run_id]["infeasibility_cause"] = cause
-
-                # If parent_paramount is the cause, localize the conflict to
-                # specific campers (see docs/architecture/solver-internals.md).
-                if isinstance(cause, str) and "parent_paramount" in cause:
-                    iis = await asyncio.to_thread(
-                        localize_hard_mso_infeasibility,
-                        solver_input,
-                        config_service,
-                        5,  # time_limit_seconds per probe
-                    )
-                    logger.error(f"Hard-MSO IIS localization: {iis}")
-                    solver_runs[run_id]["parent_paramount_iis"] = iis
-                    # Name-resolve for the frontend (#1638).
-                    solver_runs[run_id]["localization"] = resolve_localization(iis, solver_input.person_by_cm_id)
-            except Exception as e:
-                logger.error(f"Failed to run infeasibility analysis: {e}", exc_info=True)
-
+        if outcome.result is None:
+            # Diagnostics are best-effort: absent fields stay absent in
+            # solver_runs, matching the legacy key-absent semantics (#1638).
+            if outcome.impossibility_report is not None:
+                solver_runs[run_id]["impossibility_report"] = outcome.impossibility_report
+            if outcome.infeasibility_cause is not None:
+                solver_runs[run_id]["infeasibility_cause"] = outcome.infeasibility_cause
+            if outcome.parent_paramount_iis is not None:
+                solver_runs[run_id]["parent_paramount_iis"] = outcome.parent_paramount_iis
+            if outcome.localization is not None:
+                solver_runs[run_id]["localization"] = outcome.localization
             raise ValueError("Solver failed to find a solution")
+
+        result = outcome.result
 
         # Build bunk name map for results
         bunk_cm_to_name = {b.campminder_id: b.name for b in solver_input.bunks}

--- a/api/settings.py
+++ b/api/settings.py
@@ -113,6 +113,16 @@ class Settings(BaseSettings):
             )
         return v
 
+    # === Solver Execution ===
+    solver_subprocess: bool = Field(
+        default=True,
+        description=(
+            "Run CP-SAT solves in a throwaway child process so the solve's memory "
+            "high-water mark returns to the OS. SOLVER_SUBPROCESS=false is the "
+            "emergency kill-switch back to the legacy in-thread solve (no release needed)."
+        ),
+    )
+
     # === CORS Configuration ===
     # Note: Use str type for env var parsing, convert to list via property
     allowed_origins_str: str = Field(

--- a/bunking/config/__init__.py
+++ b/bunking/config/__init__.py
@@ -27,6 +27,7 @@ from .errors import (
 )
 from .loader import ConfigLoader
 from .schema import CONFIG_SCHEMA, get_all_required_keys
+from .static_service import StaticConfigService, snapshot_config
 from .types import ConfigKey, ConfigType
 
 __all__ = [
@@ -40,7 +41,9 @@ __all__ = [
     "ConfigType",
     "DatabaseUnavailableError",
     "MissingKeyError",
+    "StaticConfigService",
     "UnknownKeyError",
     "ValidationError",
     "get_all_required_keys",
+    "snapshot_config",
 ]

--- a/bunking/config/static_service.py
+++ b/bunking/config/static_service.py
@@ -1,0 +1,60 @@
+"""Read-only, snapshot-backed config service for solver child processes.
+
+A CP-SAT solve runs in a throwaway child process (api/services/solve_executor.py).
+ConfigLoader cannot cross that pickle boundary (it owns a PocketBase client), so
+the parent snapshots every readable CONFIG_SCHEMA value and the child wraps the
+plain dict in this service. Subclasses ConfigLoader so every ``config: ConfigLoader``
+annotation in the solver keeps working; deliberately skips ConfigLoader.__init__ —
+no PB client, no singleton interaction, no cache TTL.
+"""
+
+from typing import Any
+
+from .errors import MissingKeyError, UnknownKeyError
+from .loader import ConfigLoader
+from .schema import CONFIG_SCHEMA
+
+
+def snapshot_config(loader: ConfigLoader) -> dict[str, Any]:
+    """Export every readable CONFIG_SCHEMA value to a plain picklable dict.
+
+    Absent keys (optional, unseeded) are omitted; StaticConfigService.get raises
+    MissingKeyError for them, so typed-getter defaults engage exactly as they
+    would against the live loader. Env overrides are baked in here (loader.get
+    resolves env first) — the child sees the parent's effective config.
+    """
+    values: dict[str, Any] = {}
+    for key in CONFIG_SCHEMA:
+        try:
+            values[key] = loader.get(key)
+        except MissingKeyError:
+            continue
+    return values
+
+
+class StaticConfigService(ConfigLoader):
+    """ConfigLoader-compatible reads over a frozen snapshot dict."""
+
+    def __init__(self, values: dict[str, Any]) -> None:
+        # Intentionally no super().__init__(): no PB client, no cache machinery.
+        # Parent attributes (_pb, _cache, ...) stay unset; the only inherited
+        # code paths that touch them are writes/health checks, overridden below.
+        self._values = dict(values)
+
+    def get(self, key: str) -> Any:
+        if key not in CONFIG_SCHEMA:
+            raise UnknownKeyError(f"Unknown config key: '{key}'")
+        if key not in self._values:
+            raise MissingKeyError(f"Config key '{key}' absent from snapshot")
+        return self._values[key]
+
+    def update_config(self, key: str, value: str | int | float) -> None:
+        raise NotImplementedError("StaticConfigService is read-only")
+
+    def health_check(self) -> dict[str, Any]:
+        return {
+            "status": "healthy",
+            "database_connected": False,
+            "static_snapshot": True,
+            "keys": len(self._values),
+        }

--- a/tests/config/test_static_service.py
+++ b/tests/config/test_static_service.py
@@ -1,0 +1,84 @@
+"""StaticConfigService: snapshot-backed, read-only ConfigLoader stand-in.
+
+The solver child process (api/services/solve_executor.py) cannot carry a live
+ConfigLoader across the pickle boundary, so the parent snapshots CONFIG_SCHEMA
+values into a plain dict and the child wraps them in StaticConfigService.
+"""
+
+from typing import Any
+
+import pytest
+
+from bunking.config.errors import MissingKeyError, UnknownKeyError
+from bunking.config.loader import ConfigLoader
+from bunking.config.schema import CONFIG_SCHEMA
+from bunking.config.static_service import StaticConfigService, snapshot_config
+
+A_SCHEMA_KEY = next(iter(CONFIG_SCHEMA))
+
+
+class TestStaticConfigService:
+    def test_is_a_config_loader(self) -> None:
+        svc = StaticConfigService({})
+        assert isinstance(svc, ConfigLoader)
+
+    def test_get_returns_snapshot_value(self) -> None:
+        svc = StaticConfigService({A_SCHEMA_KEY: 42})
+        assert svc.get(A_SCHEMA_KEY) == 42
+
+    def test_get_unknown_key_raises(self) -> None:
+        svc = StaticConfigService({})
+        with pytest.raises(UnknownKeyError):
+            svc.get("nonsense.key")
+
+    def test_get_absent_key_raises_missing(self) -> None:
+        svc = StaticConfigService({})
+        with pytest.raises(MissingKeyError):
+            svc.get(A_SCHEMA_KEY)
+
+    def test_typed_getter_funnels_through_get(self) -> None:
+        svc = StaticConfigService({A_SCHEMA_KEY: 7})
+        assert svc.get_int(A_SCHEMA_KEY) == 7
+
+    def test_typed_getter_default_engages_for_absent_key(self) -> None:
+        svc = StaticConfigService({})
+        assert svc.get_int(A_SCHEMA_KEY, default=99) == 99
+
+    def test_update_config_raises(self) -> None:
+        svc = StaticConfigService({A_SCHEMA_KEY: 1})
+        with pytest.raises(NotImplementedError):
+            svc.update_config(A_SCHEMA_KEY, 2)
+
+    def test_snapshot_input_is_copied(self) -> None:
+        values = {A_SCHEMA_KEY: 1}
+        svc = StaticConfigService(values)
+        values[A_SCHEMA_KEY] = 2
+        assert svc.get(A_SCHEMA_KEY) == 1
+
+
+class _FakeLoader:
+    """Duck-typed loader: snapshot_config only calls .get(key)."""
+
+    def __init__(self, value: Any = 5, missing: set[str] | None = None) -> None:
+        self._value = value
+        self._missing = missing or set()
+
+    def get(self, key: str) -> Any:
+        if key in self._missing:
+            raise MissingKeyError(key)
+        return self._value
+
+
+class TestSnapshotConfig:
+    def test_snapshot_covers_all_schema_keys(self) -> None:
+        values = snapshot_config(_FakeLoader())  # type: ignore[arg-type]
+        assert set(values) == set(CONFIG_SCHEMA)
+
+    def test_snapshot_omits_missing_keys(self) -> None:
+        values = snapshot_config(_FakeLoader(missing={A_SCHEMA_KEY}))  # type: ignore[arg-type]
+        assert A_SCHEMA_KEY not in values
+        assert len(values) == len(CONFIG_SCHEMA) - 1
+
+    def test_snapshot_round_trip(self) -> None:
+        svc = StaticConfigService(snapshot_config(_FakeLoader(value=5)))  # type: ignore[arg-type]
+        assert svc.get_int(A_SCHEMA_KEY) == 5

--- a/tests/unit/api/services/test_solve_executor.py
+++ b/tests/unit/api/services/test_solve_executor.py
@@ -1,0 +1,104 @@
+"""solve_executor: pure solve+diagnose logic and the SolveOutcome bundle.
+
+The diagnostic chain here is transplanted from run_solver_task_v2 — these tests
+freeze that behavior at the new boundary: orchestrator-diagnosis short-circuit,
+impossibility-report capture, parent_paramount IIS gating, exception tolerance.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import api.services.solve_executor as sx
+from bunking.models_v2 import DirectSolverInput
+
+
+def _minimal_input() -> DirectSolverInput:
+    return DirectSolverInput(persons=[], requests=[], bunks=[])
+
+
+def _mock_result(assignments: list[Any], diagnosis: str | None = None) -> MagicMock:
+    result = MagicMock()
+    result.assignments = assignments
+    result.infeasibility_diagnosis = diagnosis
+    return result
+
+
+class TestSolveAndDiagnose:
+    def test_success_returns_result_only(self) -> None:
+        result = _mock_result([MagicMock()])
+        with patch.object(sx, "DirectBunkingSolver") as solver_cls:
+            solver_cls.return_value.solve.return_value = result
+            outcome = sx.solve_and_diagnose(_minimal_input(), 60, None, MagicMock())
+        assert outcome.result is result
+        assert outcome.impossibility_report is None
+        assert outcome.infeasibility_cause is None
+        assert outcome.parent_paramount_iis is None
+        assert outcome.localization is None
+
+    def test_solver_receives_inputs(self) -> None:
+        solver_input = _minimal_input()
+        config = MagicMock()
+        debug = {"age_spread": True}
+        with patch.object(sx, "DirectBunkingSolver") as solver_cls:
+            solver_cls.return_value.solve.return_value = _mock_result([MagicMock()])
+            sx.solve_and_diagnose(solver_input, 120, debug, config)
+        solver_cls.assert_called_once_with(input_data=solver_input, config_service=config, debug_constraints=debug)
+        solver_cls.return_value.solve.assert_called_once_with(time_limit_seconds=120)
+
+    def test_orchestrator_diagnosis_short_circuits_cause_analysis(self) -> None:
+        result = _mock_result([], diagnosis="Locked group spans 36 months")
+        with (
+            patch.object(sx, "DirectBunkingSolver") as solver_cls,
+            patch.object(sx, "filter_immaterial_requests"),
+            patch.object(sx, "asdict", return_value={"impossible": 1}),
+        ):
+            solver_cls.return_value.solve.return_value = result
+            outcome = sx.solve_and_diagnose(_minimal_input(), 60, None, MagicMock())
+        assert outcome.result is None
+        assert outcome.infeasibility_cause == "Locked group spans 36 months"
+        solver_cls.return_value.find_infeasibility_cause.assert_not_called()
+        assert outcome.impossibility_report == {"impossible": 1}
+
+    def test_none_result_runs_cause_analysis(self) -> None:
+        with (
+            patch.object(sx, "DirectBunkingSolver") as solver_cls,
+            patch.object(sx, "filter_immaterial_requests"),
+            patch.object(sx, "asdict", return_value={}),
+        ):
+            solver_cls.return_value.solve.return_value = None
+            solver_cls.return_value.find_infeasibility_cause.return_value = "capacity"
+            outcome = sx.solve_and_diagnose(_minimal_input(), 60, None, MagicMock())
+        assert outcome.result is None
+        assert outcome.infeasibility_cause == "capacity"
+        assert outcome.parent_paramount_iis is None
+        assert outcome.localization is None
+
+    def test_parent_paramount_triggers_iis_and_localization(self) -> None:
+        config = MagicMock()
+        with (
+            patch.object(sx, "DirectBunkingSolver") as solver_cls,
+            patch.object(sx, "filter_immaterial_requests"),
+            patch.object(sx, "asdict", return_value={}),
+            patch.object(sx, "localize_hard_mso_infeasibility", return_value={"iis": True}) as loc,
+            patch.object(sx, "resolve_localization", return_value={"campers": []}) as resolve,
+        ):
+            solver_cls.return_value.solve.return_value = None
+            solver_cls.return_value.find_infeasibility_cause.return_value = "parent_paramount conflict"
+            solver_input = _minimal_input()
+            outcome = sx.solve_and_diagnose(solver_input, 60, None, config)
+        assert outcome.parent_paramount_iis == {"iis": True}
+        assert outcome.localization == {"campers": []}
+        loc.assert_called_once_with(solver_input, config, sx.IIS_PROBE_TIME_LIMIT_SECONDS)
+        resolve.assert_called_once()
+
+    def test_analysis_exception_tolerated(self) -> None:
+        with (
+            patch.object(sx, "DirectBunkingSolver") as solver_cls,
+            patch.object(sx, "asdict", side_effect=RuntimeError("boom")),
+        ):
+            solver_cls.return_value.solve.return_value = None
+            solver_cls.return_value.find_infeasibility_cause.side_effect = RuntimeError("boom2")
+            outcome = sx.solve_and_diagnose(_minimal_input(), 60, None, MagicMock())
+        assert outcome.result is None
+        assert outcome.impossibility_report is None
+        assert outcome.infeasibility_cause is None

--- a/tests/unit/api/services/test_solve_executor.py
+++ b/tests/unit/api/services/test_solve_executor.py
@@ -5,11 +5,14 @@ freeze that behavior at the new boundary: orchestrator-diagnosis short-circuit,
 impossibility-report capture, parent_paramount IIS gating, exception tolerance.
 """
 
+import os
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import api.services.solve_executor as sx
-from bunking.models_v2 import DirectSolverInput
+from bunking.models_v2 import DirectSolverInput, DirectSolverOutput
 
 
 def _minimal_input() -> DirectSolverInput:
@@ -102,3 +105,41 @@ class TestSolveAndDiagnose:
         assert outcome.result is None
         assert outcome.impossibility_report is None
         assert outcome.infeasibility_cause is None
+
+
+def _pid_probe_entry(
+    solver_input: DirectSolverInput,
+    time_limit: int,
+    debug_constraints: dict[str, Any] | None,
+    config_values: dict[str, Any],
+) -> sx.SolveOutcome:
+    """Module-level so the spawn context can pickle it by reference."""
+    out = DirectSolverOutput(
+        assignments=[],
+        stats={"child_pid": os.getpid(), "echo": config_values.get("k")},
+    )
+    return sx.SolveOutcome(result=out)
+
+
+def _suicidal_entry(
+    solver_input: DirectSolverInput,
+    time_limit: int,
+    debug_constraints: dict[str, Any] | None,
+    config_values: dict[str, Any],
+) -> sx.SolveOutcome:
+    """Simulates an OOM kill: the worker vanishes without returning."""
+    os._exit(3)
+
+
+class TestRunSolveInSubprocess:
+    @pytest.mark.asyncio
+    async def test_executes_in_child_process_and_pickles_back(self) -> None:
+        outcome = await sx.run_solve_in_subprocess(_minimal_input(), 5, None, {"k": "v"}, _entry=_pid_probe_entry)
+        assert outcome.result is not None
+        assert outcome.result.stats["child_pid"] != os.getpid()
+        assert outcome.result.stats["echo"] == "v"
+
+    @pytest.mark.asyncio
+    async def test_dead_child_raises_solver_process_died(self) -> None:
+        with pytest.raises(sx.SolverProcessDiedError):
+            await sx.run_solve_in_subprocess(_minimal_input(), 5, None, {}, _entry=_suicidal_entry)

--- a/tests/unit/api/test_settings_solver_subprocess.py
+++ b/tests/unit/api/test_settings_solver_subprocess.py
@@ -1,0 +1,14 @@
+"""SOLVER_SUBPROCESS kill-switch: defaults on; env var reverts to in-thread solves."""
+
+import pytest
+
+from api.settings import Settings
+
+
+class TestSolverSubprocessFlag:
+    def test_defaults_to_true(self) -> None:
+        assert Settings(_env_file=None).solver_subprocess is True
+
+    def test_env_override_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SOLVER_SUBPROCESS", "false")
+        assert Settings(_env_file=None).solver_subprocess is False

--- a/tests/unit/api/test_solver_runner_diagnostics.py
+++ b/tests/unit/api/test_solver_runner_diagnostics.py
@@ -1,9 +1,15 @@
-"""run_solver_task_v2 surfaces diagnostics on the result-is-None failure path (#1638)."""
+"""run_solver_task_v2 surfaces diagnostics on the result-is-None failure path (#1638).
+
+Runs with SOLVER_SUBPROCESS off so the REAL solve_and_diagnose executes
+in-process — keeping this an end-to-end runner+executor diagnostics test
+(the solver itself and the IIS probe are mocked at the executor module).
+"""
 
 import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import api.services.solve_executor as sx_module
 import api.services.solver_runner as sr_module
 from bunking.solver.impossibility import ImpossibilityReport
 
@@ -36,15 +42,20 @@ def test_failure_branch_stores_localization_and_impossibility_report() -> None:
         patch.object(sr_module, "fetch_historical_bunking", new_callable=AsyncMock) as m_hist,
         patch.object(sr_module, "prepare_direct_solver_input", return_value=mock_solver_input),
         patch.object(sr_module, "ConfigLoader") as m_config,
-        patch.object(sr_module, "DirectBunkingSolver", return_value=mock_solver),
+        patch.object(sx_module, "DirectBunkingSolver", return_value=mock_solver),
         patch.object(sr_module, "PocketBase") as m_pb,
-        patch.object(sr_module, "get_settings"),
-        patch.object(sr_module, "localize_hard_mso_infeasibility", return_value=fake_iis),
+        patch.object(sr_module, "get_settings") as m_settings,
+        patch.object(sx_module, "localize_hard_mso_infeasibility", return_value=fake_iis),
         patch.object(sr_module, "solver_runs", mock_runs),
     ):
         m_fetch.return_value = ([], [], [], [], [])
         m_hist.return_value = []
         m_config.get_instance.return_value = MagicMock()
+        # Gate off: route through the real in-thread solve_and_diagnose so this
+        # stays an integration test of runner + executor diagnostics.
+        m_settings.return_value = MagicMock(
+            pocketbase_admin_email="x", pocketbase_admin_password="x", solver_subprocess=False
+        )
         m_pb.return_value.collection.return_value.auth_with_password.return_value = {}
 
         asyncio.run(sr_module.run_solver_task_v2(run_id, 1000001, 2026, 5))

--- a/tests/unit/api/test_solver_runner_event_loop.py
+++ b/tests/unit/api/test_solver_runner_event_loop.py
@@ -6,10 +6,10 @@ event loop, starving GET /api/solver/run/{uuid}, GET /health, and the
 container HEALTHCHECK probe — which surfaced as Cloudflare 524s on the
 frontend's status poll.
 
-The fix is to offload `solver.solve(...)` (and the failure-path
-`solver.find_infeasibility_cause(...)`) to a worker thread via
+The fix is to offload the compute block (now `solve_and_diagnose`, the
+SOLVER_SUBPROCESS=false in-thread fallback) to a worker thread via
 `asyncio.to_thread` so the event loop stays responsive while the solver
-runs.
+runs. The default subprocess path offloads by construction.
 """
 
 import asyncio
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import api.services.solver_runner as sr_module
+from api.services.solve_executor import SolveOutcome
 from bunking.models_v2 import DirectSolverInput
 
 
@@ -37,7 +38,7 @@ def _patches(mock_runs: dict[str, dict[str, object]], solver_input: DirectSolver
         patch.object(sr_module, "fetch_historical_bunking", new_callable=AsyncMock, return_value=[]),
         patch.object(sr_module, "prepare_direct_solver_input", return_value=solver_input),
         patch.object(sr_module, "ConfigLoader"),
-        patch.object(sr_module, "DirectBunkingSolver"),
+        patch.object(sr_module, "solve_and_diagnose"),
         patch.object(sr_module, "PocketBase"),
         patch.object(sr_module, "get_settings"),
         patch.object(sr_module, "solver_runs", mock_runs),
@@ -71,12 +72,12 @@ async def test_solver_solve_does_not_block_event_loop() -> None:
     solve_start = 0.0
     solve_end = 0.0
 
-    def blocking_solve(**_kwargs: object) -> MagicMock:
+    def blocking_solve(*_args: object) -> SolveOutcome:
         nonlocal solve_start, solve_end
         solve_start = time.monotonic()
         time.sleep(solve_duration)
         solve_end = time.monotonic()
-        return _build_mock_result()
+        return SolveOutcome(result=_build_mock_result())
 
     patches = _patches(mock_runs, solver_input)
     contexts = [p.start() for p in patches]
@@ -94,9 +95,7 @@ async def test_solver_solve_does_not_block_event_loop() -> None:
 
         mock_cfg.get_instance.return_value = MagicMock()
 
-        mock_solver = MagicMock()
-        mock_solver.solve.side_effect = blocking_solve
-        mock_solver_cls.return_value = mock_solver
+        mock_solver_cls.side_effect = blocking_solve
 
         mock_pb = MagicMock()
         mock_pb.collection.return_value.create.return_value = MagicMock(id="rec_1")
@@ -105,6 +104,9 @@ async def test_solver_solve_does_not_block_event_loop() -> None:
         mock_settings.return_value = MagicMock(
             pocketbase_admin_email="admin@camp.local",
             pocketbase_admin_password="pass",
+            # The in-thread fallback is the path that must not block the loop;
+            # the subprocess path offloads by construction (run_in_executor).
+            solver_subprocess=False,
         )
 
         tick_timestamps: list[float] = []
@@ -133,7 +135,7 @@ async def test_solver_solve_does_not_block_event_loop() -> None:
             except asyncio.CancelledError:
                 pass
 
-        assert mock_solver.solve.called, "Mocked solver.solve was never invoked"
+        assert mock_solver_cls.called, "Mocked solve_and_diagnose was never invoked"
         assert solve_start > 0, "blocking_solve did not record solve_start"
         assert solve_end > solve_start, "blocking_solve did not record solve_end after solve_start"
 

--- a/tests/unit/api/test_solver_runner_frozen_input.py
+++ b/tests/unit/api/test_solver_runner_frozen_input.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import api.services.solver_runner as sr_module
+from api.services.solve_executor import SolveOutcome
 from bunking.models_v2 import (
     DirectBunkAssignment,
     DirectSolverInput,
@@ -41,7 +42,7 @@ def _patch_solver_pipeline():
         "prepare_direct_solver_input": patch.object(sr_module, "prepare_direct_solver_input"),
         "fetch_lock_groups": patch.object(sr_module, "fetch_lock_groups", new_callable=AsyncMock),
         "ConfigLoader": patch.object(sr_module, "ConfigLoader"),
-        "DirectBunkingSolver": patch.object(sr_module, "DirectBunkingSolver"),
+        "solve_and_diagnose": patch.object(sr_module, "solve_and_diagnose"),
         "PocketBase": patch.object(sr_module, "PocketBase"),
         "get_settings": patch.object(sr_module, "get_settings"),
     }
@@ -62,7 +63,7 @@ async def test_frozen_input_not_mutated_when_respect_locks_false() -> None:
         patches["prepare_direct_solver_input"],
         patches["fetch_lock_groups"],
         patches["ConfigLoader"] as cfg,
-        patches["DirectBunkingSolver"] as solver_cls,
+        patches["solve_and_diagnose"] as solver_cls,
         patches["PocketBase"] as pb_cls,
         patches["get_settings"] as settings,
         patch.object(sr_module, "solver_runs", mock_runs),
@@ -72,16 +73,16 @@ async def test_frozen_input_not_mutated_when_respect_locks_false() -> None:
         mock_pb.collection.return_value.auth_with_password.return_value = {}
         mock_pb.collection.return_value.create.return_value = MagicMock(id="pb_rec")
         pb_cls.return_value = mock_pb
-        settings.return_value = MagicMock(pocketbase_admin_email="x", pocketbase_admin_password="x")
+        settings.return_value = MagicMock(
+            pocketbase_admin_email="x", pocketbase_admin_password="x", solver_subprocess=False
+        )
 
         # Make solver "succeed" trivially
-        mock_solver = MagicMock()
         mock_result = MagicMock()
         mock_result.assignments = []
         mock_result.stats = {"status": "OPTIMAL"}
         mock_result.satisfied_requests = {}
-        mock_solver.solve.return_value = mock_result
-        solver_cls.return_value = mock_solver
+        solver_cls.return_value = SolveOutcome(result=mock_result)
 
         await sr_module.run_solver_task_v2(
             run_id="t1",

--- a/tests/unit/api/test_solver_runner_lock_groups.py
+++ b/tests/unit/api/test_solver_runner_lock_groups.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import api.services.solver_runner as sr_module
+from api.services.solve_executor import SolveOutcome
 from bunking.models_v2 import DirectSolverInput
 
 
@@ -30,7 +31,7 @@ class TestSolverRunnerLockGroups:
             patch.object(sr_module, "prepare_direct_solver_input") as mock_prepare,
             patch.object(sr_module, "fetch_lock_groups", new_callable=AsyncMock) as mock_lock_groups,
             patch.object(sr_module, "ConfigLoader") as mock_config_cls,
-            patch.object(sr_module, "DirectBunkingSolver") as mock_solver_cls,
+            patch.object(sr_module, "solve_and_diagnose") as mock_solver_cls,
             patch.object(sr_module, "PocketBase") as mock_pb_cls,
             patch.object(sr_module, "get_settings") as mock_settings,
             patch.object(sr_module, "solver_runs", mock_runs),
@@ -47,17 +48,16 @@ class TestSolverRunnerLockGroups:
             mock_config = MagicMock()
             mock_config_cls.get_instance.return_value = mock_config
 
-            mock_solver = MagicMock()
             mock_result = MagicMock()
             mock_result.assignments = []
             mock_result.stats = {}
             mock_result.satisfied_requests = {}
-            mock_solver.solve.return_value = mock_result
-            mock_solver_cls.return_value = mock_solver
+            mock_solver_cls.return_value = SolveOutcome(result=mock_result)
 
             mock_settings.return_value = MagicMock(
                 pocketbase_admin_email="admin@camp.local",
                 pocketbase_admin_password="pass",
+                solver_subprocess=False,
             )
 
             # Pre-populate solver_runs dict
@@ -92,7 +92,7 @@ class TestSolverRunnerLockGroups:
             patch.object(sr_module, "prepare_direct_solver_input") as mock_prepare,
             patch.object(sr_module, "fetch_lock_groups", new_callable=AsyncMock) as mock_lock_groups,
             patch.object(sr_module, "ConfigLoader") as mock_config_cls,
-            patch.object(sr_module, "DirectBunkingSolver") as mock_solver_cls,
+            patch.object(sr_module, "solve_and_diagnose") as mock_solver_cls,
             patch.object(sr_module, "PocketBase") as mock_pb_cls,
             patch.object(sr_module, "get_settings") as mock_settings,
             patch.object(sr_module, "solver_runs", mock_runs),
@@ -108,17 +108,16 @@ class TestSolverRunnerLockGroups:
             mock_config = MagicMock()
             mock_config_cls.get_instance.return_value = mock_config
 
-            mock_solver = MagicMock()
             mock_result = MagicMock()
             mock_result.assignments = []
             mock_result.stats = {}
             mock_result.satisfied_requests = {}
-            mock_solver.solve.return_value = mock_result
-            mock_solver_cls.return_value = mock_solver
+            mock_solver_cls.return_value = SolveOutcome(result=mock_result)
 
             mock_settings.return_value = MagicMock(
                 pocketbase_admin_email="admin@camp.local",
                 pocketbase_admin_password="pass",
+                solver_subprocess=False,
             )
 
             mock_runs["test_run"] = {"status": "pending"}

--- a/tests/unit/api/test_solver_runner_pb_save.py
+++ b/tests/unit/api/test_solver_runner_pb_save.py
@@ -843,7 +843,6 @@ class TestFailedRunPersistsDetails:
             mock_pb_instance.collection.return_value.create.return_value = MagicMock(id="pb_record")
             m7.return_value = mock_pb_instance
             m5.get_instance.return_value = MagicMock()
-            mock_solver = MagicMock()
             mock_result = MagicMock()
             mock_result.assignments = []
             mock_result.stats = {"status": "OPTIMAL"}

--- a/tests/unit/api/test_solver_runner_pb_save.py
+++ b/tests/unit/api/test_solver_runner_pb_save.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import api.services.solver_runner as sr_module
+from api.services.solve_executor import SolveOutcome
 from bunking.models_v2 import DirectSolverInput
 
 
@@ -33,7 +34,7 @@ class TestSolverRunnerPocketBaseSave:
             "prepare_direct_solver_input": patch.object(sr_module, "prepare_direct_solver_input"),
             "fetch_lock_groups": patch.object(sr_module, "fetch_lock_groups", new_callable=AsyncMock),
             "ConfigLoader": patch.object(sr_module, "ConfigLoader"),
-            "DirectBunkingSolver": patch.object(sr_module, "DirectBunkingSolver"),
+            "solve_and_diagnose": patch.object(sr_module, "solve_and_diagnose"),
             "PocketBase": patch.object(sr_module, "PocketBase"),
             "get_settings": patch.object(sr_module, "get_settings"),
             "solver_runs": patch.object(sr_module, "solver_runs", mock_runs),
@@ -54,7 +55,6 @@ class TestSolverRunnerPocketBaseSave:
         mock_config = MagicMock()
         mocks["ConfigLoader"].get_instance.return_value = mock_config
 
-        mock_solver = MagicMock()
         if solver_succeeds:
             mock_result = MagicMock()
             mock_result.assignments = []
@@ -62,14 +62,14 @@ class TestSolverRunnerPocketBaseSave:
             mock_result.satisfied_requests = {}
             mock_result.infeasibility_diagnosis = None
             mock_result.overflow_used = 0
-            mock_solver.solve.return_value = mock_result
+            mocks["solve_and_diagnose"].return_value = SolveOutcome(result=mock_result)
         else:
-            mock_solver.solve.side_effect = ValueError("Solver failed to find a solution")
-        mocks["DirectBunkingSolver"].return_value = mock_solver
+            mocks["solve_and_diagnose"].side_effect = ValueError("Solver failed to find a solution")
 
         mocks["get_settings"].return_value = MagicMock(
             pocketbase_admin_email="admin@camp.local",
             pocketbase_admin_password="pass",
+            solver_subprocess=False,
         )
 
         return mock_pb_instance
@@ -85,7 +85,7 @@ class TestSolverRunnerPocketBaseSave:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"] as m4,
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
             patches["solver_runs"],
@@ -96,7 +96,7 @@ class TestSolverRunnerPocketBaseSave:
                 "prepare_direct_solver_input": m3,
                 "fetch_lock_groups": m4,
                 "ConfigLoader": m5,
-                "DirectBunkingSolver": m6,
+                "solve_and_diagnose": m6,
                 "PocketBase": m7,
                 "get_settings": m8,
             }
@@ -128,7 +128,7 @@ class TestSolverRunnerPocketBaseSave:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"] as m4,
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
             patches["solver_runs"],
@@ -139,7 +139,7 @@ class TestSolverRunnerPocketBaseSave:
                 "prepare_direct_solver_input": m3,
                 "fetch_lock_groups": m4,
                 "ConfigLoader": m5,
-                "DirectBunkingSolver": m6,
+                "solve_and_diagnose": m6,
                 "PocketBase": m7,
                 "get_settings": m8,
             }
@@ -174,7 +174,7 @@ class TestSolverRunnerPocketBaseSave:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"] as m4,
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
             patches["solver_runs"],
@@ -185,7 +185,7 @@ class TestSolverRunnerPocketBaseSave:
                 "prepare_direct_solver_input": m3,
                 "fetch_lock_groups": m4,
                 "ConfigLoader": m5,
-                "DirectBunkingSolver": m6,
+                "solve_and_diagnose": m6,
                 "PocketBase": m7,
                 "get_settings": m8,
             }
@@ -215,7 +215,7 @@ class TestSolverRunnerPocketBaseSave:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"] as m4,
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
             patches["solver_runs"],
@@ -226,13 +226,13 @@ class TestSolverRunnerPocketBaseSave:
                 "prepare_direct_solver_input": m3,
                 "fetch_lock_groups": m4,
                 "ConfigLoader": m5,
-                "DirectBunkingSolver": m6,
+                "solve_and_diagnose": m6,
                 "PocketBase": m7,
                 "get_settings": m8,
             }
             mock_pb = self._configure_mocks(mocks, mock_solver_input)
             # Override the default overflow_used=0 to prove it's plumbed through.
-            m6.return_value.solve.return_value.overflow_used = 3
+            m6.return_value.result.overflow_used = 3
             mock_runs["test_run"] = {"status": "pending"}
 
             await sr_module.run_solver_task_v2(
@@ -259,7 +259,7 @@ class TestSolverRunnerPocketBaseSave:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"] as m4,
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
             patches["solver_runs"],
@@ -270,12 +270,12 @@ class TestSolverRunnerPocketBaseSave:
                 "prepare_direct_solver_input": m3,
                 "fetch_lock_groups": m4,
                 "ConfigLoader": m5,
-                "DirectBunkingSolver": m6,
+                "solve_and_diagnose": m6,
                 "PocketBase": m7,
                 "get_settings": m8,
             }
             self._configure_mocks(mocks, mock_solver_input)
-            m6.return_value.solve.return_value.overflow_used = 2
+            m6.return_value.result.overflow_used = 2
             mock_runs["test_run"] = {"status": "pending"}
 
             await sr_module.run_solver_task_v2(
@@ -301,7 +301,7 @@ class TestSolverRunnerPocketBaseSave:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"] as m4,
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
             patches["solver_runs"],
@@ -312,14 +312,14 @@ class TestSolverRunnerPocketBaseSave:
                 "prepare_direct_solver_input": m3,
                 "fetch_lock_groups": m4,
                 "ConfigLoader": m5,
-                "DirectBunkingSolver": m6,
+                "solve_and_diagnose": m6,
                 "PocketBase": m7,
                 "get_settings": m8,
             }
             mock_pb = self._configure_mocks(mocks, mock_solver_input)
             # Simulate a break-glass result: assignments present, break_glass_used True.
-            m6.return_value.solve.return_value.assignments = [MagicMock(person_cm_id=1, bunk_cm_id=10)]
-            m6.return_value.solve.return_value.break_glass_used = True
+            m6.return_value.result.assignments = [MagicMock(person_cm_id=1, bunk_cm_id=10)]
+            m6.return_value.result.break_glass_used = True
             mock_runs["test_run"] = {"status": "pending"}
 
             await sr_module.run_solver_task_v2(
@@ -346,7 +346,7 @@ class TestSolverRunnerPocketBaseSave:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"] as m4,
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
             patches["solver_runs"],
@@ -357,14 +357,14 @@ class TestSolverRunnerPocketBaseSave:
                 "prepare_direct_solver_input": m3,
                 "fetch_lock_groups": m4,
                 "ConfigLoader": m5,
-                "DirectBunkingSolver": m6,
+                "solve_and_diagnose": m6,
                 "PocketBase": m7,
                 "get_settings": m8,
             }
             self._configure_mocks(mocks, mock_solver_input)
             # Simulate a break-glass result: assignments present, break_glass_used True.
-            m6.return_value.solve.return_value.assignments = [MagicMock(person_cm_id=1, bunk_cm_id=10)]
-            m6.return_value.solve.return_value.break_glass_used = True
+            m6.return_value.result.assignments = [MagicMock(person_cm_id=1, bunk_cm_id=10)]
+            m6.return_value.result.break_glass_used = True
             mock_runs["test_run"] = {"status": "pending"}
 
             await sr_module.run_solver_task_v2(
@@ -390,7 +390,7 @@ class TestSolverRunnerPocketBaseSave:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"] as m4,
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
             patches["solver_runs"],
@@ -401,7 +401,7 @@ class TestSolverRunnerPocketBaseSave:
                 "prepare_direct_solver_input": m3,
                 "fetch_lock_groups": m4,
                 "ConfigLoader": m5,
-                "DirectBunkingSolver": m6,
+                "solve_and_diagnose": m6,
                 "PocketBase": m7,
                 "get_settings": m8,
             }
@@ -430,7 +430,7 @@ class TestSolverRunnerPocketBaseSave:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"] as m4,
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
             patches["solver_runs"],
@@ -441,7 +441,7 @@ class TestSolverRunnerPocketBaseSave:
                 "prepare_direct_solver_input": m3,
                 "fetch_lock_groups": m4,
                 "ConfigLoader": m5,
-                "DirectBunkingSolver": m6,
+                "solve_and_diagnose": m6,
                 "PocketBase": m7,
                 "get_settings": m8,
             }
@@ -470,7 +470,7 @@ class TestSolverRunnerPocketBaseSave:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"] as m4,
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
             patches["solver_runs"],
@@ -481,7 +481,7 @@ class TestSolverRunnerPocketBaseSave:
                 "prepare_direct_solver_input": m3,
                 "fetch_lock_groups": m4,
                 "ConfigLoader": m5,
-                "DirectBunkingSolver": m6,
+                "solve_and_diagnose": m6,
                 "PocketBase": m7,
                 "get_settings": m8,
             }
@@ -510,7 +510,7 @@ class TestSolverRunnerPocketBaseSave:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"] as m4,
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
             patches["solver_runs"],
@@ -521,7 +521,7 @@ class TestSolverRunnerPocketBaseSave:
                 "prepare_direct_solver_input": m3,
                 "fetch_lock_groups": m4,
                 "ConfigLoader": m5,
-                "DirectBunkingSolver": m6,
+                "solve_and_diagnose": m6,
                 "PocketBase": m7,
                 "get_settings": m8,
             }
@@ -550,7 +550,7 @@ class TestSolverRunnerPocketBaseSave:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"] as m4,
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
             patches["solver_runs"],
@@ -561,7 +561,7 @@ class TestSolverRunnerPocketBaseSave:
                 "prepare_direct_solver_input": m3,
                 "fetch_lock_groups": m4,
                 "ConfigLoader": m5,
-                "DirectBunkingSolver": m6,
+                "solve_and_diagnose": m6,
                 "PocketBase": m7,
                 "get_settings": m8,
             }
@@ -600,7 +600,7 @@ class TestSolverRunnerPocketBaseSave:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"] as m4,
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
             patches["solver_runs"],
@@ -611,7 +611,7 @@ class TestSolverRunnerPocketBaseSave:
                 "prepare_direct_solver_input": m3,
                 "fetch_lock_groups": m4,
                 "ConfigLoader": m5,
-                "DirectBunkingSolver": m6,
+                "solve_and_diagnose": m6,
                 "PocketBase": m7,
                 "get_settings": m8,
             }
@@ -645,7 +645,7 @@ class TestSolverRunnerPocketBaseSave:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"] as m4,
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
             patches["solver_runs"],
@@ -656,7 +656,7 @@ class TestSolverRunnerPocketBaseSave:
                 "prepare_direct_solver_input": m3,
                 "fetch_lock_groups": m4,
                 "ConfigLoader": m5,
-                "DirectBunkingSolver": m6,
+                "solve_and_diagnose": m6,
                 "PocketBase": m7,
                 "get_settings": m8,
             }
@@ -700,7 +700,7 @@ class TestFailedRunPersistsDetails:
             "prepare_direct_solver_input": patch.object(sr_module, "prepare_direct_solver_input"),
             "fetch_lock_groups": patch.object(sr_module, "fetch_lock_groups", new_callable=AsyncMock),
             "ConfigLoader": patch.object(sr_module, "ConfigLoader"),
-            "DirectBunkingSolver": patch.object(sr_module, "DirectBunkingSolver"),
+            "solve_and_diagnose": patch.object(sr_module, "solve_and_diagnose"),
             "PocketBase": patch.object(sr_module, "PocketBase"),
             "get_settings": patch.object(sr_module, "get_settings"),
             "solver_runs": patch.object(sr_module, "solver_runs", mock_runs),
@@ -721,7 +721,7 @@ class TestFailedRunPersistsDetails:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"],
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
             patches["solver_runs"],
@@ -734,15 +734,12 @@ class TestFailedRunPersistsDetails:
             mock_pb_instance.collection.return_value.create.return_value = MagicMock(id="pb_record")
             m7.return_value = mock_pb_instance
             m5.get_instance.return_value = MagicMock()
-            mock_solver = MagicMock()
-            # Stream C orchestrator returns an empty-assignments output carrying
-            # the diagnosis (instead of raising) — solver_runner converts it.
-            infeasible_result = MagicMock()
-            infeasible_result.assignments = []
-            infeasible_result.infeasibility_diagnosis = diagnosis
-            mock_solver.solve.return_value = infeasible_result
-            m6.return_value = mock_solver
-            m8.return_value = MagicMock(pocketbase_admin_email="x", pocketbase_admin_password="x")
+            # Stream C: solve_and_diagnose surfaces the orchestrator's diagnosis
+            # as the outcome's infeasibility_cause (result=None → failure path).
+            m6.return_value = SolveOutcome(result=None, infeasibility_cause=diagnosis)
+            m8.return_value = MagicMock(
+                pocketbase_admin_email="x", pocketbase_admin_password="x", solver_subprocess=False
+            )
 
             mock_runs["prod_run"] = {"status": "pending"}
 
@@ -771,7 +768,7 @@ class TestFailedRunPersistsDetails:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"],
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
             patches["solver_runs"],
@@ -787,10 +784,10 @@ class TestFailedRunPersistsDetails:
             mock_pb_instance.collection.return_value.get_first_list_item.return_value = MagicMock(id="pre_created_id")
             m7.return_value = mock_pb_instance
             m5.get_instance.return_value = MagicMock()
-            mock_solver = MagicMock()
-            mock_solver.solve.side_effect = ValueError("simulated solver failure")
-            m6.return_value = mock_solver
-            m8.return_value = MagicMock(pocketbase_admin_email="x", pocketbase_admin_password="x")
+            m6.side_effect = ValueError("simulated solver failure")
+            m8.return_value = MagicMock(
+                pocketbase_admin_email="x", pocketbase_admin_password="x", solver_subprocess=False
+            )
 
             mock_runs["sweep_child"] = {"status": "pending"}
 
@@ -832,7 +829,7 @@ class TestFailedRunPersistsDetails:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"],
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
             patches["solver_runs"],
@@ -853,9 +850,10 @@ class TestFailedRunPersistsDetails:
             mock_result.satisfied_requests = {}
             mock_result.infeasibility_diagnosis = None
             mock_result.overflow_used = 0
-            mock_solver.solve.return_value = mock_result
-            m6.return_value = mock_solver
-            m8.return_value = MagicMock(pocketbase_admin_email="x", pocketbase_admin_password="x")
+            m6.return_value = SolveOutcome(result=mock_result)
+            m8.return_value = MagicMock(
+                pocketbase_admin_email="x", pocketbase_admin_password="x", solver_subprocess=False
+            )
 
             mock_runs["t1"] = {"status": "pending"}
 
@@ -897,7 +895,7 @@ class TestFailedRunPersistsDetails:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"],
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
             patches["solver_runs"],
@@ -915,10 +913,10 @@ class TestFailedRunPersistsDetails:
             mock_pb_instance.collection.return_value.get_first_list_item.return_value = MagicMock(id="pre_created_id")
             m7.return_value = mock_pb_instance
             m5.get_instance.return_value = MagicMock()
-            mock_solver = MagicMock()
-            mock_solver.solve.side_effect = ValueError("simulated solver failure")
-            m6.return_value = mock_solver
-            m8.return_value = MagicMock(pocketbase_admin_email="x", pocketbase_admin_password="x")
+            m6.side_effect = ValueError("simulated solver failure")
+            m8.return_value = MagicMock(
+                pocketbase_admin_email="x", pocketbase_admin_password="x", solver_subprocess=False
+            )
 
             mock_runs["sweep_child"] = {"status": "pending"}
 
@@ -961,7 +959,7 @@ class TestFailedRunPersistsDetails:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"],
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
             patches["solver_runs"],
@@ -975,10 +973,10 @@ class TestFailedRunPersistsDetails:
             mock_pb_instance.collection.return_value.create.return_value = MagicMock(id="pb_record")
             m7.return_value = mock_pb_instance
             m5.get_instance.return_value = MagicMock()
-            mock_solver = MagicMock()
-            mock_solver.solve.side_effect = ValueError("boom")
-            m6.return_value = mock_solver
-            m8.return_value = MagicMock(pocketbase_admin_email="x", pocketbase_admin_password="x")
+            m6.side_effect = ValueError("boom")
+            m8.return_value = MagicMock(
+                pocketbase_admin_email="x", pocketbase_admin_password="x", solver_subprocess=False
+            )
 
             mock_runs["prod_run"] = {"status": "pending"}
 
@@ -1014,7 +1012,7 @@ class TestFailedRunPersistsDetails:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"],
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
             patches["solver_runs"],
@@ -1027,10 +1025,10 @@ class TestFailedRunPersistsDetails:
             mock_pb_instance.collection.return_value.create.return_value = MagicMock(id="pb_record")
             m7.return_value = mock_pb_instance
             m5.get_instance.return_value = MagicMock()
-            mock_solver = MagicMock()
-            mock_solver.solve.side_effect = ValueError("boom")
-            m6.return_value = mock_solver
-            m8.return_value = MagicMock(pocketbase_admin_email="x", pocketbase_admin_password="x")
+            m6.side_effect = ValueError("boom")
+            m8.return_value = MagicMock(
+                pocketbase_admin_email="x", pocketbase_admin_password="x", solver_subprocess=False
+            )
 
             mock_runs["prod_run"] = {"status": "pending"}
 

--- a/tests/unit/api/test_solver_runner_subprocess_gate.py
+++ b/tests/unit/api/test_solver_runner_subprocess_gate.py
@@ -72,6 +72,7 @@ async def test_gate_on_snapshots_config_and_runs_subprocess() -> None:
     snap.assert_called_once()
     sub.assert_awaited_once()
     in_thread.assert_not_called()
+    assert sub.await_args is not None
     assert sub.await_args.args[3] == {"k": 1}  # snapshot crosses the boundary
     assert mock_runs["r1"]["status"] == "completed"
     assert mock_runs["r1"]["results"]["assignments"] == {}

--- a/tests/unit/api/test_solver_runner_subprocess_gate.py
+++ b/tests/unit/api/test_solver_runner_subprocess_gate.py
@@ -1,0 +1,137 @@
+"""run_solver_task_v2 routes compute through the subprocess executor.
+
+Gate semantics: settings.solver_subprocess=True (default) → config snapshot +
+run_solve_in_subprocess; False (SOLVER_SUBPROCESS kill-switch) → legacy
+in-thread solve_and_diagnose with the live ConfigLoader. Failure outcomes map
+onto the same solver_runs keys the diagnostics frontend reads (#1638/#1656).
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import api.services.solver_runner as sr_module
+from api.services.solve_executor import SolveOutcome
+from bunking.models_v2 import DirectSolverInput
+
+
+def _mock_result() -> MagicMock:
+    result = MagicMock()
+    result.assignments = []
+    result.stats = {"status": "OPTIMAL"}
+    result.satisfied_requests = {}
+    result.overflow_used = 0
+    result.break_glass_used = False
+    result.infeasibility_diagnosis = None
+    return result
+
+
+def _base_patches(mock_runs: dict[str, dict[str, Any]], *, subprocess_on: bool) -> dict[str, Any]:
+    solver_input = DirectSolverInput(persons=[], requests=[], bunks=[])
+    settings = MagicMock(
+        pocketbase_admin_email="admin@camp.local",
+        pocketbase_admin_password="pass",
+        solver_subprocess=subprocess_on,
+    )
+    return {
+        "fetch": patch.object(
+            sr_module, "fetch_session_data_v2", new_callable=AsyncMock, return_value=([], [], [], [], [])
+        ),
+        "hist": patch.object(sr_module, "fetch_historical_bunking", new_callable=AsyncMock, return_value=[]),
+        "prep": patch.object(sr_module, "prepare_direct_solver_input", return_value=solver_input),
+        "config": patch.object(sr_module, "ConfigLoader"),
+        "pb": patch.object(sr_module, "PocketBase"),
+        "settings": patch.object(sr_module, "get_settings", return_value=settings),
+        "runs": patch.object(sr_module, "solver_runs", mock_runs),
+        "tag": patch.object(sr_module, "build_run_details", new_callable=AsyncMock, return_value={}),
+    }
+
+
+@pytest.mark.asyncio
+async def test_gate_on_snapshots_config_and_runs_subprocess() -> None:
+    mock_runs: dict[str, dict[str, Any]] = {"r1": {}}
+    patches = _base_patches(mock_runs, subprocess_on=True)
+    outcome = SolveOutcome(result=_mock_result())
+    with (
+        patches["fetch"],
+        patches["hist"],
+        patches["prep"],
+        patches["config"],
+        patches["pb"] as pb_cls,
+        patches["settings"],
+        patches["runs"],
+        patches["tag"],
+        patch.object(sr_module, "snapshot_config", return_value={"k": 1}) as snap,
+        patch.object(sr_module, "run_solve_in_subprocess", new_callable=AsyncMock, return_value=outcome) as sub,
+        patch.object(sr_module, "solve_and_diagnose") as in_thread,
+    ):
+        pb_cls.return_value.collection.return_value.create.return_value = MagicMock(id="rec_1")
+        await sr_module.run_solver_task_v2(run_id="r1", session_cm_id=1, year=2026, time_limit=60)
+
+    snap.assert_called_once()
+    sub.assert_awaited_once()
+    in_thread.assert_not_called()
+    assert sub.await_args.args[3] == {"k": 1}  # snapshot crosses the boundary
+    assert mock_runs["r1"]["status"] == "completed"
+    assert mock_runs["r1"]["results"]["assignments"] == {}
+
+
+@pytest.mark.asyncio
+async def test_gate_off_runs_in_thread_with_live_config() -> None:
+    mock_runs: dict[str, dict[str, Any]] = {"r1": {}}
+    patches = _base_patches(mock_runs, subprocess_on=False)
+    outcome = SolveOutcome(result=_mock_result())
+    with (
+        patches["fetch"],
+        patches["hist"],
+        patches["prep"],
+        patches["config"] as config_cls,
+        patches["pb"] as pb_cls,
+        patches["settings"],
+        patches["runs"],
+        patches["tag"],
+        patch.object(sr_module, "run_solve_in_subprocess", new_callable=AsyncMock) as sub,
+        patch.object(sr_module, "solve_and_diagnose", return_value=outcome) as in_thread,
+    ):
+        pb_cls.return_value.collection.return_value.create.return_value = MagicMock(id="rec_1")
+        await sr_module.run_solver_task_v2(run_id="r1", session_cm_id=1, year=2026, time_limit=60)
+
+    sub.assert_not_awaited()
+    in_thread.assert_called_once()
+    # The live (singleton) ConfigLoader is what reaches the in-thread path.
+    assert in_thread.call_args.args[3] is config_cls.get_instance.return_value
+    assert mock_runs["r1"]["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_failure_outcome_maps_to_solver_runs_keys() -> None:
+    mock_runs: dict[str, dict[str, Any]] = {"r1": {}}
+    patches = _base_patches(mock_runs, subprocess_on=True)
+    outcome = SolveOutcome(
+        result=None,
+        impossibility_report={"total_impossible": 2},
+        infeasibility_cause="The parent_paramount conflict",
+        parent_paramount_iis={"singleton_critical_cms": [1001]},
+        localization={"campers": [{"cm_id": 1001}]},
+    )
+    with (
+        patches["fetch"],
+        patches["hist"],
+        patches["prep"],
+        patches["config"],
+        patches["pb"] as pb_cls,
+        patches["settings"],
+        patches["runs"],
+        patches["tag"],
+        patch.object(sr_module, "snapshot_config", return_value={}),
+        patch.object(sr_module, "run_solve_in_subprocess", new_callable=AsyncMock, return_value=outcome),
+    ):
+        pb_cls.return_value.collection.return_value.create.return_value = MagicMock(id="rec_1")
+        await sr_module.run_solver_task_v2(run_id="r1", session_cm_id=1, year=2026, time_limit=60)
+
+    assert mock_runs["r1"]["status"] == "failed"
+    assert mock_runs["r1"]["impossibility_report"] == {"total_impossible": 2}
+    assert mock_runs["r1"]["infeasibility_cause"] == "The parent_paramount conflict"
+    assert mock_runs["r1"]["parent_paramount_iis"] == {"singleton_critical_cms": [1001]}
+    assert mock_runs["r1"]["localization"] == {"campers": [{"cm_id": 1001}]}

--- a/tests/unit/api/test_solver_runner_sweep_update.py
+++ b/tests/unit/api/test_solver_runner_sweep_update.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock, _patch, patch
 import pytest
 
 import api.services.solver_runner as sr_module
+from api.services.solve_executor import SolveOutcome
 from bunking.models_v2 import DirectSolverInput
 
 
@@ -31,7 +32,7 @@ def _patches() -> dict[str, _patch[Any]]:
         "prepare_direct_solver_input": patch.object(sr_module, "prepare_direct_solver_input"),
         "fetch_lock_groups": patch.object(sr_module, "fetch_lock_groups", new_callable=AsyncMock),
         "ConfigLoader": patch.object(sr_module, "ConfigLoader"),
-        "DirectBunkingSolver": patch.object(sr_module, "DirectBunkingSolver"),
+        "solve_and_diagnose": patch.object(sr_module, "solve_and_diagnose"),
         "PocketBase": patch.object(sr_module, "PocketBase"),
         "get_settings": patch.object(sr_module, "get_settings"),
     }
@@ -65,7 +66,6 @@ def _configure_solver(mocks: dict[str, Any], solver_input: DirectSolverInput, su
     mocks["fetch_historical_bunking"].return_value = []
     mocks["prepare_direct_solver_input"].return_value = solver_input
     mocks["ConfigLoader"].get_instance.return_value = MagicMock()
-    mock_solver = MagicMock()
     if succeeds:
         result = MagicMock()
         result.assignments = []
@@ -73,12 +73,11 @@ def _configure_solver(mocks: dict[str, Any], solver_input: DirectSolverInput, su
         result.satisfied_requests = {}
         result.infeasibility_diagnosis = None
         result.overflow_used = 0
-        mock_solver.solve.return_value = result
+        mocks["solve_and_diagnose"].return_value = SolveOutcome(result=result)
     else:
-        mock_solver.solve.side_effect = ValueError("solver blew up")
-    mocks["DirectBunkingSolver"].return_value = mock_solver
+        mocks["solve_and_diagnose"].side_effect = ValueError("solver blew up")
     mocks["get_settings"].return_value = MagicMock(
-        pocketbase_admin_email="admin@camp.local", pocketbase_admin_password="pass"
+        pocketbase_admin_email="admin@camp.local", pocketbase_admin_password="pass", solver_subprocess=False
     )
 
 
@@ -95,7 +94,7 @@ class TestSweepChildUpdatesPreCreatedRow:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"] as m4,
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
         ):
@@ -105,7 +104,7 @@ class TestSweepChildUpdatesPreCreatedRow:
                 "prepare_direct_solver_input": m3,
                 "fetch_lock_groups": m4,
                 "ConfigLoader": m5,
-                "DirectBunkingSolver": m6,
+                "solve_and_diagnose": m6,
                 "PocketBase": m7,
                 "get_settings": m8,
             }
@@ -144,7 +143,7 @@ class TestSweepChildUpdatesPreCreatedRow:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"] as m4,
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
         ):
@@ -154,7 +153,7 @@ class TestSweepChildUpdatesPreCreatedRow:
                 "prepare_direct_solver_input": m3,
                 "fetch_lock_groups": m4,
                 "ConfigLoader": m5,
-                "DirectBunkingSolver": m6,
+                "solve_and_diagnose": m6,
                 "PocketBase": m7,
                 "get_settings": m8,
             }
@@ -188,7 +187,7 @@ class TestSweepChildUpdatesPreCreatedRow:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"] as m4,
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
         ):
@@ -198,7 +197,7 @@ class TestSweepChildUpdatesPreCreatedRow:
                 "prepare_direct_solver_input": m3,
                 "fetch_lock_groups": m4,
                 "ConfigLoader": m5,
-                "DirectBunkingSolver": m6,
+                "solve_and_diagnose": m6,
                 "PocketBase": m7,
                 "get_settings": m8,
             }
@@ -238,7 +237,7 @@ class TestSweepChildUpdatesPreCreatedRow:
             patches["prepare_direct_solver_input"] as m3,
             patches["fetch_lock_groups"] as m4,
             patches["ConfigLoader"] as m5,
-            patches["DirectBunkingSolver"] as m6,
+            patches["solve_and_diagnose"] as m6,
             patches["PocketBase"] as m7,
             patches["get_settings"] as m8,
         ):
@@ -248,7 +247,7 @@ class TestSweepChildUpdatesPreCreatedRow:
                 "prepare_direct_solver_input": m3,
                 "fetch_lock_groups": m4,
                 "ConfigLoader": m5,
-                "DirectBunkingSolver": m6,
+                "solve_and_diagnose": m6,
                 "PocketBase": m7,
                 "get_settings": m8,
             }

--- a/tests/unit/api/test_solver_runs_pruning.py
+++ b/tests/unit/api/test_solver_runs_pruning.py
@@ -1,0 +1,68 @@
+"""Bounded retention for the in-memory solver_runs dict.
+
+Every completed/failed run used to stay in the module-level dict forever —
+unbounded growth in a long-lived API process (prod swap incident 2026-06-12).
+prune_solver_runs caps terminal entries; in-flight runs are never evicted
+(single-flight guards and frontend polling depend on them).
+"""
+
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from api.dependencies import MAX_TERMINAL_SOLVER_RUNS, prune_solver_runs, solver_runs
+
+
+@pytest.fixture(autouse=True)
+def _clean_solver_runs() -> Iterator[None]:
+    solver_runs.clear()
+    yield
+    solver_runs.clear()
+
+
+def _seed(n_terminal: int, n_running: int = 0) -> None:
+    base = datetime(2026, 6, 1, tzinfo=UTC)
+    for i in range(n_terminal):
+        solver_runs[f"t{i}"] = {"status": "completed", "completed_at": base + timedelta(minutes=i)}
+    for i in range(n_running):
+        solver_runs[f"r{i}"] = {"status": "running"}
+
+
+class TestPruneSolverRuns:
+    def test_under_cap_no_eviction(self) -> None:
+        _seed(MAX_TERMINAL_SOLVER_RUNS)
+        assert prune_solver_runs() == 0
+        assert len(solver_runs) == MAX_TERMINAL_SOLVER_RUNS
+
+    def test_over_cap_evicts_oldest_terminal_first(self) -> None:
+        _seed(MAX_TERMINAL_SOLVER_RUNS + 3)
+        assert prune_solver_runs() == 3
+        assert "t0" not in solver_runs
+        assert "t1" not in solver_runs
+        assert "t2" not in solver_runs
+        assert f"t{MAX_TERMINAL_SOLVER_RUNS + 2}" in solver_runs
+
+    def test_in_flight_never_evicted(self) -> None:
+        _seed(MAX_TERMINAL_SOLVER_RUNS + 2, n_running=5)
+        prune_solver_runs()
+        running = [r for r in solver_runs.values() if r["status"] == "running"]
+        assert len(running) == 5
+
+    def test_pending_never_evicted(self) -> None:
+        _seed(MAX_TERMINAL_SOLVER_RUNS + 1)
+        solver_runs["p0"] = {"status": "pending"}
+        prune_solver_runs()
+        assert "p0" in solver_runs
+
+    def test_failed_counts_as_terminal(self) -> None:
+        _seed(MAX_TERMINAL_SOLVER_RUNS)
+        solver_runs["f0"] = {"status": "failed", "completed_at": datetime(2026, 1, 1, tzinfo=UTC)}
+        assert prune_solver_runs() == 1
+        assert "f0" not in solver_runs  # oldest terminal entry
+
+    def test_missing_completed_at_treated_as_oldest(self) -> None:
+        _seed(MAX_TERMINAL_SOLVER_RUNS)
+        solver_runs["weird"] = {"status": "completed"}
+        prune_solver_runs()
+        assert "weird" not in solver_runs


### PR DESCRIPTION
## Summary

Fixes the prod swap ratchet (2026-06-12 incident): every heavy CP-SAT solve session permanently raised kindred-api's RSS (+410 MB observed in one 10-min Beszel bucket; idle stretches flat), until the 1.9 GB VPS started paging and staff felt after-idle slowness on every request.

### Fix 1 — solve in a throwaway child process
- New `api/services/solve_executor.py`: the entire compute block (solve + failure diagnostics: impossibility report, `find_infeasibility_cause`, hard-MSO IIS probes, localization) now runs as one pure function `solve_and_diagnose` returning a picklable `SolveOutcome`.
- `run_solve_in_subprocess` executes it in a spawn-context `ProcessPoolExecutor(max_workers=1, max_tasks_per_child=1)` — the worker exits after one solve, so the OR-Tools arena high-water mark goes back to the kernel instead of ratcheting the API container forever.
- Config crosses the pickle boundary as a snapshot: `snapshot_config` exports every readable `CONFIG_SCHEMA` value; the child wraps it in `StaticConfigService` (a read-only `ConfigLoader` subclass, no PB client) — the solve sees exactly the config the parent validated, and the child needs no PocketBase connection at all.
- Bonus hardening: a solve that exhausts the box now gets the **child** OOM-killed; the parent catches `BrokenProcessPool` → `SolverProcessDiedError` and records a failed run instead of the whole API dying.
- **Kill-switch:** `SOLVER_SUBPROCESS=false` env var reverts to the legacy in-thread solve — no release needed.

### Fix 2 — bounded `solver_runs` retention
- The module-level dict retained every completed run's config/results/diagnostics forever. `prune_solver_runs()` now evicts the oldest **terminal** (completed/failed) entries above a hardcoded cap of 50, called at both terminal transitions. `pending`/`running` entries are never evicted (single-flight guards and frontend polling depend on them); 50 comfortably exceeds any sweep size, capping the dict at ~5 MB.

### Behavior preserved
- Same `solver_runs` keys, same PB persistence, same failure-path semantics (orchestrator-diagnosis short-circuit, parent_paramount IIS gating) — frozen by the existing runner test suite, whose mocks moved from `DirectBunkingSolver` to the new `solve_and_diagnose`/`run_solve_in_subprocess` seam with assertions unchanged.
- The event-loop-responsiveness regression guard now exercises the in-thread fallback (the subprocess path offloads by construction).

## Test plan
- [x] TDD throughout — every new module/test written red-first
- [x] New: StaticConfigService + snapshot (11), solve_executor logic + real spawn round-trip + dead-child (8), gate wiring (3), settings flag (2), pruning (6)
- [x] Real subprocess test: child PID ≠ parent PID, outcome pickles back, OOM-sim raises `SolverProcessDiedError`
- [x] Full mockable suite: 5555 passed; pre-push verification (ruff, mypy strict, full unit suite): ALL CHECKS PASSED
- [x] Live verification in dev stack (bypass auth, headless browser driving the real UI):
  - Two full Session-2 solves (193 campers, 534 requests, scenario mode) run end-to-end from the bunking board; both completed (89% requests satisfied, results applied, PB rows persisted)
  - Log confirms the new path: `Running solver in subprocess (21 config keys snapshotted)`
  - **API parent process RSS: 188 MB fresh → 223 MB after two solves (VmHWM = VmRSS — no ratchet).** Each solve's CP-SAT footprint (~330–355 MB) lived in a fresh spawn worker that exited on completion; only the 14 MB multiprocessing resource-tracker persists
  - Legacy in-process behavior would have left the parent at ~550+ MB after the same two solves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional subprocess execution mode for CP-SAT solver with in-thread fallback option
  * Introduced configuration snapshot capability for safer multiprocess handling

* **Chores**
  * Implemented memory bounds on completed and failed solver run history
  * Refactored solver execution and failure diagnostics for improved reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
