### PR TITLE
feat(frontend): default 'show other bunks' cross-scope toggle on (#1745)

### DIFF
--- a/frontend/src/components/BunkSocialGraphModal.test.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.test.tsx
@@ -12,7 +12,11 @@
  * The helper unit tests plus TypeScript checking provide sufficient coverage.
  */
 import { describe, expect, it } from 'vitest'
-import { buildBunksFilter, extractBunkCmIdsFromPlans } from './BunkSocialGraphModal'
+import {
+  DEFAULT_SHOW_CROSS_SCOPE_EDGES,
+  buildBunksFilter,
+  extractBunkCmIdsFromPlans,
+} from './BunkSocialGraphModal'
 import { extractSortKey, getBunkType } from '../utils/bunkNaming'
 
 // ─── Inline simulation of sessionBunks derivation ────────────────────────────
@@ -93,6 +97,18 @@ describe('extractBunkCmIdsFromPlans', () => {
 // logical bunk, leaving allBunks/sessionBunks with adjacent duplicate-cm_id
 // entries. Navigation then silently no-ops when wrap lands on a same-cm_id-
 // different-year row (the "right arrow not rotating" symptom).
+
+// ─── 'Show other bunks' cross-scope default (#1745) ──────────────────────────
+// Staff want cross-bunk request connections visible by default in the bunk
+// graph, rather than ticking the "Show other bunks" checkbox each time. The
+// toggle's initial state is hoisted to an exported constant so the default is
+// unit-testable without standing up cytoscape / React providers.
+
+describe("'Show other bunks' cross-scope default (#1745)", () => {
+  it('defaults ON so cross-bunk connections show without ticking the box', () => {
+    expect(DEFAULT_SHOW_CROSS_SCOPE_EDGES).toBe(true)
+  })
+})
 
 describe('buildBunksFilter', () => {
   it('always includes a year clause', () => {

--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -160,6 +160,12 @@ export const extractBunkCmIdsFromPlans = (
   ),
 ]
 
+// Initial state of the "Show other bunks" (cross-scope edges) toggle. Staff
+// want cross-bunk request connections visible by default rather than ticking
+// the box on every open (#1745). Exported so the default is unit-testable
+// without rendering cytoscape.
+export const DEFAULT_SHOW_CROSS_SCOPE_EDGES = true
+
 export default function BunkSocialGraphModal({
   bunkCmId,
   bunkName,
@@ -177,7 +183,9 @@ export default function BunkSocialGraphModal({
   const scenarioId = currentScenario?.id ?? null
   const [selectedCamperId, setSelectedCamperId] = useState<string | null>(null)
   const [showLegend, setShowLegend] = useState<boolean>(false)
-  const [showCrossScopeEdges, setShowCrossScopeEdges] = useState<boolean>(false)
+  const [showCrossScopeEdges, setShowCrossScopeEdges] = useState<boolean>(
+    DEFAULT_SHOW_CROSS_SCOPE_EDGES
+  )
 
   // Fetch bunk graph data. The query key and the in-memory graph cache both
   // include scenarioId AND showCrossScopeEdges so scenario-sourced graphs and


### PR DESCRIPTION
## What

Make the **"Show other bunks"** toggle in the bunk graph modal default to **on**, so staff see cross-bunk request connections immediately instead of ticking the box on every open.

Reported by primary staff (kindred-feedback#70): *"Can 'show other bunks' be the default here?"* on `/summer/session/{id}/bunks`.

## Change

- Hoist the toggle's initial state into an exported `DEFAULT_SHOW_CROSS_SCOPE_EDGES = true` constant in `BunkSocialGraphModal.tsx`, and drive `useState` from it.
- This matches the existing `DEFAULT_VIEW_MODE` pattern — the default becomes unit-testable without standing up cytoscape/React providers.

No persistence involved (plain `useState`), so this is purely the initial-open default. Users can still toggle it off per-session as before.

## Test (TDD)

- Added a failing unit test asserting `DEFAULT_SHOW_CROSS_SCOPE_EDGES === true` (red), then implemented the constant (green).
- The existing `buildBunkGraphElements` cross-scope tests (which pass the flag explicitly) are unaffected.

## Verification

- `npm run type-check` — clean (both tsconfigs)
- `eslint` on changed files — 0 errors
- `vitest` `BunkSocialGraphModal.test.tsx` + `BunkSocialGraphModal.crossScope.test.ts` — 26 pass, 0 fail
- Full pre-push suite (mypy, ruff, pytest 5601 items, type-check) — green

Closes #1745

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The social graph modal now shows cross-bunk connections by default when opened.
  * The “Show other bunks” option starts enabled, so more graph relationships appear immediately.
* **Bug Fixes**
  * Updated tests to verify the default graph setting stays enabled on load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->