### PR TITLE
style(frontend): reformat under prettier 3.9.4 to unblock dependabot Frontend Lint

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -70,7 +70,7 @@
         "jsdom": "^29.1.1",
         "pdf-parse": "^2.4.5",
         "pocketbase-typegen": "^1.5.0",
-        "prettier": "^3.5.3",
+        "prettier": "^3.9.4",
         "prettier-plugin-tailwindcss": "^0.8.0",
         "react-is": "^19.2.6",
         "typescript": "^6.0.2",
@@ -1456,9 +1456,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1476,9 +1473,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1496,9 +1490,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1516,9 +1507,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1536,9 +1524,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1976,9 +1961,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1994,9 +1976,6 @@
       "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2014,9 +1993,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2032,9 +2008,6 @@
       "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2052,9 +2025,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2070,9 +2040,6 @@
       "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2301,9 +2268,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2319,9 +2283,6 @@
       "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2339,9 +2300,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2357,9 +2315,6 @@
       "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5465,9 +5420,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5487,9 +5439,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -5511,9 +5460,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5533,9 +5479,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -6221,9 +6164,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -94,7 +94,7 @@
     "jsdom": "^29.1.1",
     "pdf-parse": "^2.4.5",
     "pocketbase-typegen": "^1.5.0",
-    "prettier": "^3.5.3",
+    "prettier": "^3.9.4",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "react-is": "^19.2.6",
     "typescript": "^6.0.2",

--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -76,22 +76,20 @@ vi.mock('../contexts/AuthContext', () => ({
 
 // Configurable mock for getSatisfiedRequestInfo — overridden in alert tests.
 // Default returns empty CamperSatisfaction so existing tests are unaffected.
-let mockGetSatisfiedRequestInfo = vi.fn(
-  (personCmId: number): CamperSatisfaction => ({
-    person_cm_id: personCmId,
-    per_request: [] as PerRequestStatus[],
-    counted_totals: {
-      material_parent: { satisfied: 0, total: 0 },
-      staff: { satisfied: 0, total: 0 },
-    },
-    immaterial: { satisfied: 0, total: 0 },
-    flags: {
-      parent_min_one_violation: false,
-      staff_unsatisfied_alert: false,
-      has_any_counted_request: false,
-    },
-  })
-)
+let mockGetSatisfiedRequestInfo = vi.fn((personCmId: number): CamperSatisfaction => ({
+  person_cm_id: personCmId,
+  per_request: [] as PerRequestStatus[],
+  counted_totals: {
+    material_parent: { satisfied: 0, total: 0 },
+    staff: { satisfied: 0, total: 0 },
+  },
+  immaterial: { satisfied: 0, total: 0 },
+  flags: {
+    parent_min_one_violation: false,
+    staff_unsatisfied_alert: false,
+    has_any_counted_request: false,
+  },
+}))
 
 // Mock useBunkRequestContext — CamperDetailsPanel uses getSatisfiedRequestInfo
 // from BunkRequestProvider to derive the unsatisfied-requests alert in parity

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -486,8 +486,7 @@ export default function CamperDetailsPanel({
             const primaryAttendee = sortedAttendees[0]
             if (!primaryAttendee) return null
             const primaryExpand = primaryAttendee.expand as
-              | { session?: ExpandedSession }
-              | undefined
+              { session?: ExpandedSession } | undefined
             const session = primaryExpand?.session
 
             let bunkName = null
@@ -502,8 +501,7 @@ export default function CamperDetailsPanel({
                   })
                 if (assignments.length > 0 && assignments[0]) {
                   const assignmentExpand = assignments[0].expand as
-                    | { bunk?: ExpandedBunk }
-                    | undefined
+                    { bunk?: ExpandedBunk } | undefined
                   bunkName = assignmentExpand?.bunk?.name ?? null
                 }
               } catch {

--- a/frontend/src/components/RequirePermission.tsx
+++ b/frontend/src/components/RequirePermission.tsx
@@ -4,8 +4,7 @@ import { FullPageSpinner } from './FullPageSpinner'
 import PermissionDeniedPage from '../pages/PermissionDeniedPage'
 
 type RequirePermissionProps = { children: React.ReactNode } & (
-  | { permission: string; anyOf?: never }
-  | { permission?: never; anyOf: string[] }
+  { permission: string; anyOf?: never } | { permission?: never; anyOf: string[] }
 )
 
 export const RequirePermission = (props: RequirePermissionProps) => {

--- a/frontend/src/components/SocialNetworkGraph.tsx
+++ b/frontend/src/components/SocialNetworkGraph.tsx
@@ -519,8 +519,7 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
     // Detached on cleanup so the long-lived shared worker doesn't keep a
     // closure reference to a destroyed cy.
     let pendingWorkerListener:
-      | ((event: MessageEvent<LayoutWorkerOutput & { token?: number }>) => void)
-      | null = null
+      ((event: MessageEvent<LayoutWorkerOutput & { token?: number }>) => void) | null = null
 
     void addAllElements().then(() => {
       if (cancelled || !cyRef.current || cyRef.current !== cy || cy.destroyed()) return

--- a/frontend/src/components/admin/SessionConfigTable.tsx
+++ b/frontend/src/components/admin/SessionConfigTable.tsx
@@ -182,11 +182,7 @@ export function SessionConfigTable() {
   }, [thresholdRecords])
 
   type EditableField =
-    | 'min_grade'
-    | 'max_grade'
-    | 'capacity_override'
-    | 'participant_goal'
-    | 'session_fee'
+    'min_grade' | 'max_grade' | 'capacity_override' | 'participant_goal' | 'session_fee'
 
   const handleChange = (rowKey: string, field: EditableField, value: string) => {
     setRows((prev) =>

--- a/frontend/src/components/debug/types.ts
+++ b/frontend/src/components/debug/types.ts
@@ -3,10 +3,7 @@
  */
 
 export type SourceFieldType =
-  | 'bunk_request_form'
-  | 'staff_not_bunk_with'
-  | 'bunking_notes'
-  | 'internal_notes'
+  'bunk_request_form' | 'staff_not_bunk_with' | 'bunking_notes' | 'internal_notes'
 
 export interface ParsedIntent {
   request_type: string

--- a/frontend/src/components/graph/graphInteractions.ts
+++ b/frontend/src/components/graph/graphInteractions.ts
@@ -63,14 +63,12 @@ export function adjustLabelPositions(cy: Core): void {
           if (other.node.id() === node.id()) continue
 
           // Check if rectangles overlap
-          if (
-            !(
-              labelRight < other.left ||
-              labelLeft > other.right ||
-              labelBottom < other.top ||
-              labelTop > other.bottom
-            )
-          ) {
+          if (!(
+            labelRight < other.left ||
+            labelLeft > other.right ||
+            labelBottom < other.top ||
+            labelTop > other.bottom
+          )) {
             collision = true
             offsetY += 15 // Move down
             break

--- a/frontend/src/components/metrics/CancellationGenderChart.tsx
+++ b/frontend/src/components/metrics/CancellationGenderChart.tsx
@@ -13,11 +13,7 @@ import { getGenderColor } from './genderColors'
 
 // Prior status color variants derived from gender base color
 type PriorStatus =
-  | 'was_enrolled'
-  | 'was_waitlisted'
-  | 'was_applied'
-  | 'other_prior_status'
-  | 'unknown'
+  'was_enrolled' | 'was_waitlisted' | 'was_applied' | 'other_prior_status' | 'unknown'
 
 const PRIOR_STATUS_LABELS: Record<PriorStatus, string> = {
   was_enrolled: 'Was Enrolled',

--- a/frontend/src/components/metrics/CssVerticalGroupedBarChart.tsx
+++ b/frontend/src/components/metrics/CssVerticalGroupedBarChart.tsx
@@ -37,8 +37,7 @@ export interface CssVerticalGroupedBarChartProps {
   yAxisFormat?: ((tick: number) => string) | undefined
   rotateLabels?: boolean
   renderTooltip?:
-    | ((item: Record<string, unknown>, series: GroupedBarSeries[]) => ReactNode)
-    | undefined
+    ((item: Record<string, unknown>, series: GroupedBarSeries[]) => ReactNode) | undefined
   onBarClick?: ((item: Record<string, unknown>, seriesKey: string) => void) | undefined
   className?: string
   /** Override default inter-group gap (px) computed by calculateColumnSizing */

--- a/frontend/src/components/metrics/CssVerticalStackedBarChart.tsx
+++ b/frontend/src/components/metrics/CssVerticalStackedBarChart.tsx
@@ -44,8 +44,7 @@ interface CssVerticalStackedBarChartProps {
   showTotalLabel?: boolean
   labelFormat?: ((item: Record<string, unknown>) => string) | undefined
   renderTooltip?:
-    | ((item: Record<string, unknown>, segments: VerticalStackedSegment[]) => ReactNode)
-    | undefined
+    ((item: Record<string, unknown>, segments: VerticalStackedSegment[]) => ReactNode) | undefined
   rotateLabels?: boolean
   onBarClick?: ((item: Record<string, unknown>) => void) | undefined
   className?: string

--- a/frontend/src/components/pipeline-debug/types.ts
+++ b/frontend/src/components/pipeline-debug/types.ts
@@ -313,13 +313,7 @@ export interface PipelineSummaryFilters {
 // =============================================================================
 
 export type PipelinePhase =
-  | 'pre_phase1'
-  | 'phase1'
-  | 'validation'
-  | 'phase2'
-  | 'historical'
-  | 'phase3'
-  | 'post_pipeline'
+  'pre_phase1' | 'phase1' | 'validation' | 'phase2' | 'historical' | 'phase3' | 'post_pipeline'
 
 /** Canonical ordering of pipeline phases, used by canvas and page. */
 export const PHASE_ORDER: PipelinePhase[] = [
@@ -357,11 +351,7 @@ export type PipelineStage =
   | 'dedup_save'
 
 export type StageGroup =
-  | 'pre_processing'
-  | 'ai_parse'
-  | 'validation'
-  | 'resolution'
-  | 'finalization'
+  'pre_processing' | 'ai_parse' | 'validation' | 'resolution' | 'finalization'
 
 /** Maps each granular stage back to its parent PipelinePhase for trace data access and re-runs. */
 export const STAGE_TO_PHASE: Record<PipelineStage, PipelinePhase> = {

--- a/frontend/src/hooks/session/useSolverOperations.test.ts
+++ b/frontend/src/hooks/session/useSolverOperations.test.ts
@@ -188,8 +188,7 @@ describe('solver result statistics', () => {
     }
 
     const validation = solverStats['request_validation'] as
-      | { impossible_requests?: number }
-      | undefined
+      { impossible_requests?: number } | undefined
     const hasImpossibleRequests =
       validation?.impossible_requests && validation.impossible_requests > 0
 

--- a/frontend/src/hooks/useScenarioList.test.ts
+++ b/frontend/src/hooks/useScenarioList.test.ts
@@ -42,8 +42,7 @@ describe('useScenarioList', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
     const callArg = mockGetFullList.mock.calls[0]?.[0] as
-      | { filter?: string; expand?: string }
-      | undefined
+      { filter?: string; expand?: string } | undefined
     expect(callArg?.filter).toContain('year = 2026')
     expect(callArg?.expand).toBe('session')
   })

--- a/frontend/src/hooks/useSessionList.test.ts
+++ b/frontend/src/hooks/useSessionList.test.ts
@@ -47,8 +47,7 @@ describe('useSessionList', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
     const callArg = mockGetFullList.mock.calls[0]?.[0] as
-      | { filter?: string; sort?: string }
-      | undefined
+      { filter?: string; sort?: string } | undefined
     expect(callArg?.filter).toBeDefined()
     expect(callArg?.filter).toContain('year = 2026')
     expect(callArg?.filter).toContain('session_type = "main"')
@@ -123,8 +122,7 @@ describe('useSessionList', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(mockCollection).toHaveBeenCalledWith('attendees')
     const attendeesCallArg = attendeesGetFullList.mock.calls[0]?.[0] as
-      | { filter?: string; fields?: string }
-      | undefined
+      { filter?: string; fields?: string } | undefined
     expect(attendeesCallArg?.filter).toContain('year = 2026')
     expect(attendeesCallArg?.filter).toContain('status_id = 2')
   })

--- a/frontend/src/pages/metrics/trends/TrendsOverview.tsx
+++ b/frontend/src/pages/metrics/trends/TrendsOverview.tsx
@@ -57,8 +57,7 @@ function buildGroupedChartData(
   // Access breakdown arrays via unknown cast to avoid strict type narrowing
   const getBreakdown = (yearData: YearEnrollment): Array<Record<string, unknown>> | undefined =>
     (yearData as unknown as Record<string, unknown>)[breakdownKey] as
-      | Array<Record<string, unknown>>
-      | undefined
+      Array<Record<string, unknown>> | undefined
 
   // Collect all categories and their totals
   const categoryTotals = new Map<string, number>()

--- a/frontend/src/services/debug.ts
+++ b/frontend/src/services/debug.ts
@@ -77,10 +77,7 @@ export interface ClearAnalysisResponse {
 }
 
 export type SourceFieldType =
-  | 'bunk_request_form'
-  | 'staff_not_bunk_with'
-  | 'bunking_notes'
-  | 'internal_notes'
+  'bunk_request_form' | 'staff_not_bunk_with' | 'bunking_notes' | 'internal_notes'
 
 export interface ParseAnalysisFilters {
   session_cm_id?: number | undefined

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -7355,11 +7355,7 @@ export type ClearParseAnalysisApiDebugParseAnalysisDeleteData = {
      * Filter by source field
      */
     source_field?:
-      | 'bunk_request_form'
-      | 'staff_not_bunk_with'
-      | 'bunking_notes'
-      | 'internal_notes'
-      | null
+      'bunk_request_form' | 'staff_not_bunk_with' | 'bunking_notes' | 'internal_notes' | null
   }
   url: '/api/debug/parse-analysis'
 }
@@ -7400,11 +7396,7 @@ export type ListParseAnalysisApiDebugParseAnalysisGetData = {
      * Filter by source field
      */
     source_field?:
-      | 'bunk_request_form'
-      | 'staff_not_bunk_with'
-      | 'bunking_notes'
-      | 'internal_notes'
-      | null
+      'bunk_request_form' | 'staff_not_bunk_with' | 'bunking_notes' | 'internal_notes' | null
     /**
      * Limit
      *
@@ -7555,11 +7547,7 @@ export type ListOriginalRequestsApiDebugOriginalRequestsGetData = {
      * Filter by source field
      */
     source_field?:
-      | 'bunk_request_form'
-      | 'staff_not_bunk_with'
-      | 'bunking_notes'
-      | 'internal_notes'
-      | null
+      'bunk_request_form' | 'staff_not_bunk_with' | 'bunking_notes' | 'internal_notes' | null
     /**
      * Limit
      *
@@ -7691,11 +7679,7 @@ export type ListOriginalRequestsWithParseStatusApiDebugOriginalRequestsWithParse
      * Filter by source field
      */
     source_field?:
-      | 'bunk_request_form'
-      | 'staff_not_bunk_with'
-      | 'bunking_notes'
-      | 'internal_notes'
-      | null
+      'bunk_request_form' | 'staff_not_bunk_with' | 'bunking_notes' | 'internal_notes' | null
     /**
      * Limit
      *
@@ -7749,11 +7733,7 @@ export type ListOriginalRequestsGroupedApiDebugOriginalRequestsGroupedGetData = 
      * Filter by source field
      */
     source_field?:
-      | 'bunk_request_form'
-      | 'staff_not_bunk_with'
-      | 'bunking_notes'
-      | 'internal_notes'
-      | null
+      'bunk_request_form' | 'staff_not_bunk_with' | 'bunking_notes' | 'internal_notes' | null
     /**
      * Limit
      *

--- a/frontend/src/types/pocketbase-types.ts
+++ b/frontend/src/types/pocketbase-types.ts
@@ -1670,9 +1670,9 @@ export type CollectionResponses = {
 type ProcessCreateAndUpdateFields<T> = Omit<
   {
     // Omit AutoDate fields
-    [K in keyof T as Extract<T[K], IsoAutoDateString> extends never
-      ? K
-      : never]: T[K] extends infer U // Convert FileNameString to File
+    [
+      K in keyof T as Extract<T[K], IsoAutoDateString> extends never ? K : never
+    ]: T[K] extends infer U // Convert FileNameString to File
       ? U extends FileNameString | FileNameString[]
         ? U extends any[]
           ? File[]


### PR DESCRIPTION
## Problem

The **Dependabot Lock File Fix-up** workflow runs `rm package-lock.json && npm install --package-lock-only` on every dependabot PR. That floats `prettier` from `^3.5.3` — committed on `main` as **3.8.4** — up to **3.9.4**, whose formatting rules flag 18 pre-existing files. Result: **Frontend Lint reds every dependabot PR** while `main` stays green (it still runs 3.8.4).

## Fix

Bump `prettier` to **3.9.4** on `main` and reformat the affected files so `main` and the floated dependabot builds format identically. Caret range kept (`^3.9.4`) — no pin.

Only whitespace/formatting changes; no logic touched.

## Verification

- `npm run format:check` — All matched files use Prettier code style
- eslint, tsc, vitest — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the code formatter version used by the frontend.
  * Cleaned up type formatting across several frontend components and shared types for consistency.

* **Tests**
  * Reworked several test mocks and type assertions without changing test behavior.

* **Bug Fixes**
  * Improved type handling in graph and worker-related code paths to better match expected data shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->