### PR TITLE
fix(sync): pair AG bunks to AG sessions by plan, not cabin-number-as-grade

### DIFF
--- a/pocketbase/sync/bunk_plans.go
+++ b/pocketbase/sync/bunk_plans.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/camp/kindred/pocketbase/campminder"
@@ -174,10 +174,14 @@ func (s *BunkPlansSync) loadMappings() error {
 //     always share the same parent session (same bunking board), so a
 //     provisional pairing is display-equivalent before assignments exist —
 //     and camper assignments resolve to each camper's own enrolled AG session
-//     regardless (see findMatchingSession in bunk_assignments.go).
+//     regardless (see findMatchingSession in bunk_assignments.go). Staff
+//     assignments lack enrollments and resolve via bunkPlanBunkToSession, so
+//     they DO trust this pairing — in a multi-AG-session year a staff row can
+//     land on the sibling session (accepted; matches pre-#1749-fix behavior).
 //
 // Only bunks/sessions known to PocketBase participate; returns an empty map
-// when the plan has no AG sessions.
+// when the plan has no AG sessions. An AG session left without any paired
+// bunk gets no bunk_plans rows — the caller warns when that happens.
 func pairAGBunksToSessions(
 	bunkCMIDs, sessionCMIDs []int,
 	bunkNames map[int]string,
@@ -194,7 +198,7 @@ func pairAGBunksToSessions(
 	if len(agSessions) == 0 {
 		return pairing
 	}
-	sort.Ints(agSessions)
+	slices.Sort(agSessions)
 
 	agBunks := make([]int, 0, len(bunkCMIDs))
 	for _, id := range bunkCMIDs {
@@ -202,7 +206,7 @@ func pairAGBunksToSessions(
 			agBunks = append(agBunks, id)
 		}
 	}
-	sort.Ints(agBunks)
+	slices.Sort(agBunks)
 
 	for i, bunkCMID := range agBunks {
 		if i < len(agSessions) {
@@ -330,6 +334,27 @@ func (s *BunkPlansSync) processBunkPlan(planData map[string]any) (int, error) {
 
 	// Decide which AG session each AG bunk belongs to (kindred#1749)
 	agPairing := pairAGBunksToSessions(bunkCMIDs, sessionCMIDs, s.bunkNames, s.sessionInfo)
+
+	// An AG session with no paired AG bunk gets zero bunk_plans rows and drops
+	// out of downstream session resolution (bunkPlanSessionsList) — the same
+	// silent-blackhole shape #1749 fixed. Can't pair what isn't there, so warn.
+	agSessionCount := 0
+	for _, sessionCMID := range sessionCMIDs {
+		if info, ok := s.sessionInfo[sessionCMID]; ok && info.SessionType == "ag" {
+			agSessionCount++
+		}
+	}
+	pairedSessions := make(map[int]bool, len(agPairing))
+	for _, sessionCMID := range agPairing {
+		pairedSessions[sessionCMID] = true
+	}
+	if agSessionCount > len(pairedSessions) {
+		slog.Warn("Plan has more AG sessions than AG bunks; unpaired AG sessions get no bunk_plans rows",
+			"plan_id", int(planID),
+			"plan_name", name,
+			"ag_sessions", agSessionCount,
+			"ag_bunks_paired", len(pairedSessions))
+	}
 
 	// Create a bunk plan for each bunk-session combination
 	for _, bunkCMID := range bunkCMIDs {

--- a/pocketbase/sync/bunk_plans.go
+++ b/pocketbase/sync/bunk_plans.go
@@ -5,8 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"regexp"
-	"strconv"
+	"sort"
 	"strings"
 
 	"github.com/camp/kindred/pocketbase/campminder"
@@ -160,39 +159,73 @@ func (s *BunkPlansSync) loadMappings() error {
 	return nil
 }
 
-// extractGradeRange extracts grade range from a name.
-// Returns (min, max) grade numbers. For single grades, min == max.
-// Returns (0, 0) if no grades found.
-func extractGradeRange(name string) (minGrade, maxGrade int) {
-	// Pattern 1: "X/Y" format (e.g., "9/10", "7/8")
-	slashPattern := regexp.MustCompile(`(\d+)/(\d+)`)
-	if matches := slashPattern.FindStringSubmatch(name); len(matches) >= 3 {
-		minGrade, _ = strconv.Atoi(matches[1])
-		maxGrade, _ = strconv.Atoi(matches[2])
-		return minGrade, maxGrade
+// pairAGBunksToSessions decides which AG session each AG bunk in a plan maps to.
+//
+// CampMinder's plan payload is two flat lists (BunkIDs, SessionIDs) with no
+// per-bunk pairing, so the sync must decide. The AG bunk's cabin number is a
+// physical location in the unit layout (5-6 Eilat, 7-8 Haifa, 9-10 Chalutzim 1
+// — see frontend/src/utils/unitMapping.ts), NOT a grade, so no grade matching
+// is possible (kindred#1749: AG-6 hosting the 7th/8th-grade AG session).
+//
+// Rules:
+//   - one AG session in the plan (every year since 2026): all AG bunks map to it
+//   - multiple AG sessions: deterministic pairing, sorted bunk cm_id ⇄ sorted
+//     session cm_id, leftover bunks onto the last session. Sibling AG sessions
+//     always share the same parent session (same bunking board), so a
+//     provisional pairing is display-equivalent before assignments exist —
+//     and camper assignments resolve to each camper's own enrolled AG session
+//     regardless (see findMatchingSession in bunk_assignments.go).
+//
+// Only bunks/sessions known to PocketBase participate; returns an empty map
+// when the plan has no AG sessions.
+func pairAGBunksToSessions(
+	bunkCMIDs, sessionCMIDs []int,
+	bunkNames map[int]string,
+	sessionInfo map[int]sessionInfoData,
+) map[int]int {
+	agSessions := make([]int, 0, len(sessionCMIDs))
+	for _, id := range sessionCMIDs {
+		if info, ok := sessionInfo[id]; ok && info.SessionType == "ag" {
+			agSessions = append(agSessions, id)
+		}
 	}
 
-	// Pattern 2: "Xth - Yth" or "X & Y" format (e.g., "7th - 9th", "9th & 10th")
-	rangePattern := regexp.MustCompile(`(\d+)(?:st|nd|rd|th)?\s*[-–&]\s*(\d+)(?:st|nd|rd|th)?`)
-	if matches := rangePattern.FindStringSubmatch(name); len(matches) >= 3 {
-		minGrade, _ = strconv.Atoi(matches[1])
-		maxGrade, _ = strconv.Atoi(matches[2])
-		return minGrade, maxGrade
+	pairing := make(map[int]int)
+	if len(agSessions) == 0 {
+		return pairing
 	}
+	sort.Ints(agSessions)
 
-	// Pattern 3: Single number after "AG-" or "AG " (e.g., "AG-8", "AG 10")
-	singlePattern := regexp.MustCompile(`AG[-\s](\d+)`)
-	if matches := singlePattern.FindStringSubmatch(name); len(matches) >= 2 {
-		grade, _ := strconv.Atoi(matches[1])
-		return grade, grade
+	agBunks := make([]int, 0, len(bunkCMIDs))
+	for _, id := range bunkCMIDs {
+		if name, ok := bunkNames[id]; ok && isAGBunk(name) {
+			agBunks = append(agBunks, id)
+		}
 	}
+	sort.Ints(agBunks)
 
-	return 0, 0
+	for i, bunkCMID := range agBunks {
+		if i < len(agSessions) {
+			pairing[bunkCMID] = agSessions[i]
+		} else {
+			pairing[bunkCMID] = agSessions[len(agSessions)-1]
+		}
+	}
+	return pairing
 }
 
-// gradeInRange checks if a grade is within a range (inclusive)
-func gradeInRange(grade, minGrade, maxGrade int) bool {
-	return grade >= minGrade && grade <= maxGrade
+// toCMIDSlice converts a raw JSON ID list ([]any of float64/int) to []int
+func toCMIDSlice(raw []any) []int {
+	ids := make([]int, 0, len(raw))
+	for _, v := range raw {
+		switch n := v.(type) {
+		case float64:
+			ids = append(ids, int(n))
+		case int:
+			ids = append(ids, n)
+		}
+	}
+	return ids
 }
 
 // isAGBunk checks if a bunk is an All-Gender bunk based on its name
@@ -291,18 +324,15 @@ func (s *BunkPlansSync) processBunkPlan(planData map[string]any) (int, error) {
 		return 0, nil
 	}
 
-	// Create a bunk plan for each bunk-session combination
-	for _, bunkIDRaw := range bunkIDs {
-		bunkCMID := 0
-		switch v := bunkIDRaw.(type) {
-		case float64:
-			bunkCMID = int(v)
-		case int:
-			bunkCMID = v
-		default:
-			continue
-		}
+	// Convert raw ID lists up front — the AG pairing needs whole-plan visibility
+	bunkCMIDs := toCMIDSlice(bunkIDs)
+	sessionCMIDs := toCMIDSlice(sessionIDs)
 
+	// Decide which AG session each AG bunk belongs to (kindred#1749)
+	agPairing := pairAGBunksToSessions(bunkCMIDs, sessionCMIDs, s.bunkNames, s.sessionInfo)
+
+	// Create a bunk plan for each bunk-session combination
+	for _, bunkCMID := range bunkCMIDs {
 		// Validate bunk exists
 		if !s.validBunkCMIDs[bunkCMID] {
 			s.DebugLog("Skipping bunk plan: bunk not in PocketBase",
@@ -312,23 +342,9 @@ func (s *BunkPlansSync) processBunkPlan(planData map[string]any) (int, error) {
 			continue
 		}
 
-		// Get bunk name for AG filtering
-		bunkName := s.bunkNames[bunkCMID]
-		bunkIsAG := isAGBunk(bunkName)
-		// Extract bunk grade (e.g., "AG-8" → 8, 8)
-		bunkGradeMin, bunkGradeMax := extractGradeRange(bunkName)
+		bunkIsAG := isAGBunk(s.bunkNames[bunkCMID])
 
-		for _, sessionIDRaw := range sessionIDs {
-			sessionCMID := 0
-			switch v := sessionIDRaw.(type) {
-			case float64:
-				sessionCMID = int(v)
-			case int:
-				sessionCMID = v
-			default:
-				continue
-			}
-
+		for _, sessionCMID := range sessionCMIDs {
 			// Validate session exists
 			if !s.validSessionCMIDs[sessionCMID] {
 				s.DebugLog("Skipping bunk plan: session not in PocketBase",
@@ -339,38 +355,16 @@ func (s *BunkPlansSync) processBunkPlan(planData map[string]any) (int, error) {
 				continue
 			}
 
-			// AG filtering: Only create bunk_plans where bunk and session are compatible
-			// - AG sessions should only have bunk_plans for AG bunks with matching grades
-			// - Non-AG sessions should only have bunk_plans for non-AG bunks
+			// AG filtering: AG sessions take exactly the AG bunk(s) paired to
+			// them by pairAGBunksToSessions; main sessions never take AG bunks
+			// (those reach the board via the AG child session).
 			sessionData := s.sessionInfo[sessionCMID]
-			sessionIsAG := sessionData.SessionType == "ag"
 
-			if sessionIsAG {
-				// AG session: only include AG bunks with matching grades
-				if !bunkIsAG {
-					// Skip non-AG bunk for AG session
+			if sessionData.SessionType == "ag" {
+				if agPairing[bunkCMID] != sessionCMID {
+					// Non-AG bunk, or AG bunk paired to a sibling AG session
 					s.skippedAGPlans++
 					continue
-				}
-				// Both are AG - check if bunk grade is within session's grade range
-				// e.g., AG-8 bunk should match "7th - 9th grades" session (8 is in [7,9])
-				sessionGradeMin, sessionGradeMax := extractGradeRange(sessionData.Name)
-				if bunkGradeMin > 0 && sessionGradeMin > 0 {
-					// Check if bunk's grade overlaps with session's grade range
-					// For single-grade bunks (AG-8), check if grade is in session range
-					if bunkGradeMin == bunkGradeMax {
-						// Single grade bunk - must be within session range
-						if !gradeInRange(bunkGradeMin, sessionGradeMin, sessionGradeMax) {
-							s.skippedAGPlans++
-							continue
-						}
-					} else {
-						// Range bunk - check for any overlap
-						if bunkGradeMax < sessionGradeMin || bunkGradeMin > sessionGradeMax {
-							s.skippedAGPlans++
-							continue
-						}
-					}
 				}
 			} else if sessionData.SessionType == sessionTypeMain && bunkIsAG {
 				// Main session should not include AG bunks (they go through AG sessions)

--- a/pocketbase/sync/bunk_plans_test.go
+++ b/pocketbase/sync/bunk_plans_test.go
@@ -1,8 +1,146 @@
 package sync
 
 import (
+	"reflect"
 	"testing"
 )
+
+// pairAGBunksToSessions: the AG bunk's cabin number is a physical location in
+// the unit layout (5-6 Eilat, 7-8 Haifa, 9-10 Chalutzim 1), NOT a grade.
+// Pairing must never interpret it as one. See kindred#1749: AG-6 hosting the
+// 7th/8th-grade AG session was silently dropped by the old grade heuristic.
+func TestPairAGBunksToSessions_SingleAGSession_AllAGBunksMap(t *testing.T) {
+	// 2026 regression case: Session 2 plan (12424) — AG-6 (51897) must map to
+	// the "7th & 8th grades" AG session even though its cabin number is 6.
+	bunkNames := map[int]string{
+		4261:  "B-1",
+		4262:  "G-1",
+		51897: "AG-6",
+	}
+	sessionInfo := map[int]sessionInfoData{
+		1235404: {Name: "Session 2", SessionType: "main"},
+		1378704: {Name: "All-Gender Cabin-Session 2 (7th & 8th grades)", SessionType: "ag"},
+	}
+
+	got := pairAGBunksToSessions(
+		[]int{4261, 4262, 51897},
+		[]int{1235404, 1378704},
+		bunkNames, sessionInfo,
+	)
+
+	want := map[int]int{51897: 1378704}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("pairAGBunksToSessions() = %v, want %v (cabin number must not be treated as a grade)", got, want)
+	}
+}
+
+func TestPairAGBunksToSessions_NoAGSession_EmptyPairing(t *testing.T) {
+	bunkNames := map[int]string{
+		4259:  "Aleph",
+		51897: "AG-6",
+	}
+	sessionInfo := map[int]sessionInfoData{
+		1356533: {Name: "Session 2a", SessionType: "embedded"},
+	}
+
+	got := pairAGBunksToSessions([]int{4259, 51897}, []int{1356533}, bunkNames, sessionInfo)
+
+	if len(got) != 0 {
+		t.Errorf("pairAGBunksToSessions() = %v, want empty (no AG session in plan)", got)
+	}
+}
+
+func TestPairAGBunksToSessions_TwoAGSessions_DeterministicZip(t *testing.T) {
+	// 2025-shaped case: two AG sessions under one plan, two AG bunks.
+	// Pairing is sorted bunk cm_id ⇄ sorted session cm_id — deterministic,
+	// no grade semantics. Sibling AG sessions share the same parent board, so
+	// the provisional pairing is display-equivalent pre-assignments; camper
+	// assignments later resolve via each camper's own AG enrollment.
+	bunkNames := map[int]string{
+		66366: "AG-10",
+		70109: "AG-8",
+	}
+	sessionInfo := map[int]sessionInfoData{
+		1235404: {Name: "Session 2", SessionType: "main"},
+		1344557: {Name: "All-Gender Cabin-Session 2 (9th & 10th grades)", SessionType: "ag"},
+		1371790: {Name: "All-Gender Cabin-Session 2 (7th - 9th grades)", SessionType: "ag"},
+	}
+
+	want := map[int]int{
+		66366: 1344557, // lowest bunk cm_id → lowest AG session cm_id
+		70109: 1371790,
+	}
+
+	// Result must not depend on input slice order.
+	orderings := [][2][]int{
+		{{66366, 70109}, {1235404, 1344557, 1371790}},
+		{{70109, 66366}, {1371790, 1235404, 1344557}},
+	}
+	for i, o := range orderings {
+		got := pairAGBunksToSessions(o[0], o[1], bunkNames, sessionInfo)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("ordering %d: pairAGBunksToSessions() = %v, want %v", i, got, want)
+		}
+	}
+}
+
+func TestPairAGBunksToSessions_MoreBunksThanSessions_LeftoverToLastSession(t *testing.T) {
+	bunkNames := map[int]string{
+		100: "AG-3",
+		200: "AG-7",
+		300: "AG-11",
+	}
+	sessionInfo := map[int]sessionInfoData{
+		1000: {Name: "AG A", SessionType: "ag"},
+		2000: {Name: "AG B", SessionType: "ag"},
+	}
+
+	got := pairAGBunksToSessions([]int{300, 100, 200}, []int{2000, 1000}, bunkNames, sessionInfo)
+
+	want := map[int]int{
+		100: 1000,
+		200: 2000,
+		300: 2000, // leftover bunk still gets a row — never invisible
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("pairAGBunksToSessions() = %v, want %v", got, want)
+	}
+}
+
+func TestPairAGBunksToSessions_MoreSessionsThanBunks_FirstSessionsPaired(t *testing.T) {
+	bunkNames := map[int]string{100: "AG-5"}
+	sessionInfo := map[int]sessionInfoData{
+		1000: {Name: "AG A", SessionType: "ag"},
+		2000: {Name: "AG B", SessionType: "ag"},
+	}
+
+	got := pairAGBunksToSessions([]int{100}, []int{1000, 2000}, bunkNames, sessionInfo)
+
+	want := map[int]int{100: 1000}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("pairAGBunksToSessions() = %v, want %v", got, want)
+	}
+}
+
+func TestPairAGBunksToSessions_UnknownBunksAndSessions_Ignored(t *testing.T) {
+	// Bunks with no known name and sessions with no metadata (not in PB) must
+	// not participate in pairing.
+	bunkNames := map[int]string{51897: "AG-6"}
+	sessionInfo := map[int]sessionInfoData{
+		1378704: {Name: "All-Gender Cabin-Session 2 (7th & 8th grades)", SessionType: "ag"},
+	}
+
+	got := pairAGBunksToSessions(
+		[]int{51897, 99999},   // 99999: unknown bunk
+		[]int{1378704, 88888}, // 88888: unknown session
+		bunkNames, sessionInfo,
+	)
+
+	want := map[int]int{51897: 1378704}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("pairAGBunksToSessions() = %v, want %v", got, want)
+	}
+}
 
 func TestBunkPlansSync_createBunkPlan_WithIsActive(t *testing.T) {
 	// This test verifies that is_active field is extracted and stored correctly

--- a/pocketbase/sync/bunk_plans_test.go
+++ b/pocketbase/sync/bunk_plans_test.go
@@ -10,25 +10,25 @@ import (
 // Pairing must never interpret it as one. See kindred#1749: AG-6 hosting the
 // 7th/8th-grade AG session was silently dropped by the old grade heuristic.
 func TestPairAGBunksToSessions_SingleAGSession_AllAGBunksMap(t *testing.T) {
-	// 2026 regression case: Session 2 plan (12424) — AG-6 (51897) must map to
-	// the "7th & 8th grades" AG session even though its cabin number is 6.
+	// 2026 regression case: the AG-6 cabin must map to the 7th/8th-grade AG
+	// session even though its cabin number is 6.
 	bunkNames := map[int]string{
-		4261:  "B-1",
-		4262:  "G-1",
-		51897: "AG-6",
+		101: "B-1",
+		102: "G-1",
+		106: "AG-6",
 	}
 	sessionInfo := map[int]sessionInfoData{
-		1235404: {Name: "Session 2", SessionType: "main"},
-		1378704: {Name: "All-Gender Cabin-Session 2 (7th & 8th grades)", SessionType: "ag"},
+		1000001: {Name: "Session 2", SessionType: "main"},
+		1000002: {Name: "All-Gender Cabin-Session 2 (7th & 8th grades)", SessionType: "ag"},
 	}
 
 	got := pairAGBunksToSessions(
-		[]int{4261, 4262, 51897},
-		[]int{1235404, 1378704},
+		[]int{101, 102, 106},
+		[]int{1000001, 1000002},
 		bunkNames, sessionInfo,
 	)
 
-	want := map[int]int{51897: 1378704}
+	want := map[int]int{106: 1000002}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("pairAGBunksToSessions() = %v, want %v (cabin number must not be treated as a grade)", got, want)
 	}
@@ -36,14 +36,14 @@ func TestPairAGBunksToSessions_SingleAGSession_AllAGBunksMap(t *testing.T) {
 
 func TestPairAGBunksToSessions_NoAGSession_EmptyPairing(t *testing.T) {
 	bunkNames := map[int]string{
-		4259:  "Aleph",
-		51897: "AG-6",
+		104: "Aleph",
+		106: "AG-6",
 	}
 	sessionInfo := map[int]sessionInfoData{
-		1356533: {Name: "Session 2a", SessionType: "embedded"},
+		1000003: {Name: "Session 2a", SessionType: "embedded"},
 	}
 
-	got := pairAGBunksToSessions([]int{4259, 51897}, []int{1356533}, bunkNames, sessionInfo)
+	got := pairAGBunksToSessions([]int{104, 106}, []int{1000003}, bunkNames, sessionInfo)
 
 	if len(got) != 0 {
 		t.Errorf("pairAGBunksToSessions() = %v, want empty (no AG session in plan)", got)
@@ -57,24 +57,24 @@ func TestPairAGBunksToSessions_TwoAGSessions_DeterministicZip(t *testing.T) {
 	// the provisional pairing is display-equivalent pre-assignments; camper
 	// assignments later resolve via each camper's own AG enrollment.
 	bunkNames := map[int]string{
-		66366: "AG-10",
-		70109: "AG-8",
+		108: "AG-8",
+		110: "AG-10",
 	}
 	sessionInfo := map[int]sessionInfoData{
-		1235404: {Name: "Session 2", SessionType: "main"},
-		1344557: {Name: "All-Gender Cabin-Session 2 (9th & 10th grades)", SessionType: "ag"},
-		1371790: {Name: "All-Gender Cabin-Session 2 (7th - 9th grades)", SessionType: "ag"},
+		1000001: {Name: "Session 2", SessionType: "main"},
+		1000004: {Name: "All-Gender Cabin-Session 2 (9th & 10th grades)", SessionType: "ag"},
+		1000005: {Name: "All-Gender Cabin-Session 2 (7th - 9th grades)", SessionType: "ag"},
 	}
 
 	want := map[int]int{
-		66366: 1344557, // lowest bunk cm_id → lowest AG session cm_id
-		70109: 1371790,
+		108: 1000004, // lowest bunk cm_id → lowest AG session cm_id
+		110: 1000005,
 	}
 
 	// Result must not depend on input slice order.
 	orderings := [][2][]int{
-		{{66366, 70109}, {1235404, 1344557, 1371790}},
-		{{70109, 66366}, {1371790, 1235404, 1344557}},
+		{{108, 110}, {1000001, 1000004, 1000005}},
+		{{110, 108}, {1000005, 1000001, 1000004}},
 	}
 	for i, o := range orderings {
 		got := pairAGBunksToSessions(o[0], o[1], bunkNames, sessionInfo)
@@ -125,18 +125,18 @@ func TestPairAGBunksToSessions_MoreSessionsThanBunks_FirstSessionsPaired(t *test
 func TestPairAGBunksToSessions_UnknownBunksAndSessions_Ignored(t *testing.T) {
 	// Bunks with no known name and sessions with no metadata (not in PB) must
 	// not participate in pairing.
-	bunkNames := map[int]string{51897: "AG-6"}
+	bunkNames := map[int]string{106: "AG-6"}
 	sessionInfo := map[int]sessionInfoData{
-		1378704: {Name: "All-Gender Cabin-Session 2 (7th & 8th grades)", SessionType: "ag"},
+		1000002: {Name: "All-Gender Cabin-Session 2 (7th & 8th grades)", SessionType: "ag"},
 	}
 
 	got := pairAGBunksToSessions(
-		[]int{51897, 99999},   // 99999: unknown bunk
-		[]int{1378704, 88888}, // 88888: unknown session
+		[]int{106, 99999},     // 99999: unknown bunk
+		[]int{1000002, 88888}, // 88888: unknown session
 		bunkNames, sessionInfo,
 	)
 
-	want := map[int]int{51897: 1378704}
+	want := map[int]int{106: 1000002}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("pairAGBunksToSessions() = %v, want %v", got, want)
 	}


### PR DESCRIPTION
## Problem

Session 2's dashboard showed **187/194 bunked** with nothing visibly missing on the board. The 7-camper delta was the entire **All-Gender Cabin-Session 2 (7th & 8th grades)** arm: zero `bunk_plans` rows, zero `bunk_assignments`, no AG cabin rendered (#1749).

CampMinder was not missing data — its Session 2 plan (12424) contains both the AG session and the AG-6 bunk. The sync alone dropped it: the AG compatibility filter in `bunk_plans.go` parsed the bunk's **cabin number as a grade** (`extractGradeRange("AG-6") → 6`) and required it inside the AG session's grade range ([7,8]) — so the plan row was silently skipped, and the assignments sync (which resolves sessions through the synced plan rows) blackholed every AG-6 assignment behind it.

Staff confirm the AG bunk number is the cabin's **physical location in the unit layout** (5–6 Eilat, 7–8 Haifa, 9–10 Chalutzim 1 — the same scheme as `frontend/src/utils/unitMapping.ts`), not a grade. 2023–2025 only worked because the AG cabins happened to sit in units whose numbers fell inside their sessions' grade ranges.

## Fix

Replace the grade heuristic with `pairAGBunksToSessions` (pure, tested):

- **One AG session in the plan** (every 2026 plan; 12 of 15 parent-years historically): every AG bunk in the plan maps to it. Zero ambiguity, no name parsing.
- **Multiple AG sessions** (3 of 15 parent-years, always exactly two): deterministic pairing — sorted bunk cm_id ⇄ sorted session cm_id, leftover bunks onto the last session — so the cabin **always renders immediately**, before any camper is assigned. Sibling AG sessions share the same parent session (same bunking board), so a provisional pairing is display-equivalent pre-assignments; camper assignments resolve to each camper's own enrolled AG session regardless (`findMatchingSession` in `bunk_assignments.go` already intersects the camper's enrollments with the plan's session list).

`extractGradeRange`/`gradeInRange` are deleted (only caller was the removed block; zero test coverage). The existing "main sessions never take AG bunks" exclusion is preserved.

## Testing (TDD)

- 6 new unit tests for `pairAGBunksToSessions` written first and verified failing (undefined symbol), covering: the 2026 regression case (AG-6 → 7th/8th AG session), no-AG-session plans, the 2025-shaped two-AG-session zip (order-independence asserted), leftover bunks, more-sessions-than-bunks, and unknown-ID filtering.
- Full Go suite: **2258 passed**; `golangci-lint` clean; pre-push green.

## Live verification (worktree against real CampMinder)

- `bunk_plans` sync: **created=1, updated=0, errors=0** — exactly the missing AG-6 → AG-Session-2 row; AG-10/AG-4 pairings unchanged.
- `bunk_assignments` sync: 10 AG-6 assignments flowed in; all 7 enrolled AG-2 campers assigned.
- Session 2 dashboard math: **194/194**.

Closes #1749

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved bunk-plan generation to pair AG bunks with AG sessions in a consistent, deterministic way.
  * Added support for handling extra bunks or sessions by applying clear fallback pairing rules.

* **Bug Fixes**
  * Fixed incorrect AG matching so bunk numbers are no longer treated like grade ranges.
  * Reduced invalid bunk-plan creation by skipping unsupported AG/main-session combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->