### PR TITLE
fix(solver): AG-skip placement pre-checks + age-pref impossibility false positives (#1752)

### DIFF
--- a/bunking/solver/constraints/age_preference.py
+++ b/bunking/solver/constraints/age_preference.py
@@ -24,6 +24,7 @@ from bunking.logging_config import get_logger
 from bunking.sync.bunk_request_processor.core.models import RequestType
 
 from .base import SolverContext
+from .helpers import is_ag_session
 
 if TYPE_CHECKING:
     from bunking.models_v2 import DirectBunkRequest
@@ -259,6 +260,11 @@ class AgePreferenceImpossibility(HardConstraintImpossibility):
         session = ctx.person_session.get(req.requester_person_cm_id)
         if session is None:
             return None
+        # AG enrollment sessions have exactly one cabin — there is no assignment
+        # decision, so placement-derived pre-checks don't apply. Mirrors the
+        # is_ag_session_bunk skips in grade_spread/grade_ratio/cabin_occupancy.
+        if is_ag_session(ctx.bunks_by_session.get(session, [])):
+            return None
         # grade=0 is the "unknown grade" sentinel set by data_fetcher when the
         # source record has no grade. Refuse to call impossible on either side
         # without real grades — defer to the solver rather than emit a spurious
@@ -287,30 +293,37 @@ class AgePreferenceImpossibility(HardConstraintImpossibility):
                 },
             )
         grades = [p.grade for p in same_gender_peers]
-        if target == "older" and max(grades) <= requester.grade:
+        pool_min, pool_max = min(grades), max(grades)
+        # An all-same-grade pool satisfies either direction (canonical semantics
+        # in bunking/utils/age_preference.py: "older" passes with no younger
+        # bunkmates, "younger" passes with no older) — so only flag when peers
+        # exist on the wrong side of the requester and none on the requested side.
+        if target == "older" and pool_max <= requester.grade and pool_min < requester.grade:
             return ImpossibilityReason(
                 code="age_pref_no_eligible_grade",
                 message=(
                     f"Camper is at grade {requester.grade}; no older same-gender "
-                    f"peer exists in session {session} (pool max: {max(grades)})."
+                    f"peer exists in session {session} (pool: {pool_min}-{pool_max})."
                 ),
                 detail={
                     "direction": "older",
                     "requester_grade": requester.grade,
-                    "pool_max_grade": max(grades),
+                    "pool_min_grade": pool_min,
+                    "pool_max_grade": pool_max,
                 },
             )
-        if target == "younger" and min(grades) >= requester.grade:
+        if target == "younger" and pool_min >= requester.grade and pool_max > requester.grade:
             return ImpossibilityReason(
                 code="age_pref_no_eligible_grade",
                 message=(
                     f"Camper is at grade {requester.grade}; no younger same-gender "
-                    f"peer exists in session {session} (pool min: {min(grades)})."
+                    f"peer exists in session {session} (pool: {pool_min}-{pool_max})."
                 ),
                 detail={
                     "direction": "younger",
                     "requester_grade": requester.grade,
-                    "pool_min_grade": min(grades),
+                    "pool_min_grade": pool_min,
+                    "pool_max_grade": pool_max,
                 },
             )
         return None

--- a/bunking/solver/constraints/age_preference.py
+++ b/bunking/solver/constraints/age_preference.py
@@ -27,7 +27,7 @@ from .base import SolverContext
 from .helpers import is_ag_session
 
 if TYPE_CHECKING:
-    from bunking.models_v2 import DirectBunkRequest
+    from bunking.models_v2 import DirectBunk, DirectBunkRequest
 
 logger = get_logger(__name__)
 
@@ -53,12 +53,16 @@ def add_age_preference_satisfaction_vars(
     docs/reference/solver-config-decisions.md) will be the right home for any
     future non-MP modeling.
 
-    AG sessions build nothing at all: AG cabin membership is enrollment-driven
-    (everyone in the AG session lands in its cabin), so preferences don't
-    drive AG placement. Building vars here would let parent_paramount turn an
-    MP age_preference into a hard must-satisfy-one over per-bunk cleanliness —
-    while the AG-skipping impossibility pre-check (check_request below) never
-    records such a request as impossible — risking an undiagnosed INFEASIBLE.
+    Requests from AG-session campers build nothing at all: AG cabin membership
+    is enrollment-driven (everyone in the AG session lands in its cabin), so
+    preferences don't drive AG placement. Building vars here would let
+    parent_paramount turn an MP age_preference into a hard must-satisfy-one
+    over per-bunk cleanliness — while the AG-skipping impossibility pre-check
+    (check_request below) never records such a request as impossible — risking
+    an undiagnosed INFEASIBLE. The skip is scoped to the REQUESTER'S OWN
+    session: a production solve bundles a main session with its related AG
+    session (solver_runner fetches them together), so ``ctx.bunks`` mixes
+    non-AG and AG bunks and a whole-solve check would never fire.
 
     Args:
         ctx: Solver context with model, assignments, and mappings
@@ -71,9 +75,9 @@ def add_age_preference_satisfaction_vars(
         requester into a clean bunk and thus satisfies the request. Consumed
         by parent_paramount's hard must-satisfy-one constraint via summation.
     """
-    if is_ag_session(ctx.bunks):
-        logger.info("AG session: skipping age-preference satisfaction vars (enrollment determines cabin)")
-        return {}
+    bunks_by_session: dict[int, list[DirectBunk]] = {}
+    for bunk in ctx.bunks:
+        bunks_by_session.setdefault(bunk.session_cm_id, []).append(bunk)
 
     bunk_has_grade = _build_bunk_has_grade_vars(ctx)
 
@@ -85,6 +89,12 @@ def add_age_preference_satisfaction_vars(
 
         person_idx = ctx.person_idx_map[person_cm_id]
         person = ctx.person_by_cm_id[person_cm_id]
+        if is_ag_session(bunks_by_session.get(person.session_cm_id, [])):
+            logger.debug(
+                f"AG-session camper {person_cm_id}: skipping age-preference "
+                "satisfaction vars (enrollment determines cabin)"
+            )
+            continue
         person_grade = person.grade
 
         for request in requests:

--- a/bunking/solver/constraints/age_preference.py
+++ b/bunking/solver/constraints/age_preference.py
@@ -53,6 +53,13 @@ def add_age_preference_satisfaction_vars(
     docs/reference/solver-config-decisions.md) will be the right home for any
     future non-MP modeling.
 
+    AG sessions build nothing at all: AG cabin membership is enrollment-driven
+    (everyone in the AG session lands in its cabin), so preferences don't
+    drive AG placement. Building vars here would let parent_paramount turn an
+    MP age_preference into a hard must-satisfy-one over per-bunk cleanliness —
+    while the AG-skipping impossibility pre-check (check_request below) never
+    records such a request as impossible — risking an undiagnosed INFEASIBLE.
+
     Args:
         ctx: Solver context with model, assignments, and mappings
         requests_by_person: Dict mapping person_cm_id to their MP age_preference
@@ -64,6 +71,10 @@ def add_age_preference_satisfaction_vars(
         requester into a clean bunk and thus satisfies the request. Consumed
         by parent_paramount's hard must-satisfy-one constraint via summation.
     """
+    if is_ag_session(ctx.bunks):
+        logger.info("AG session: skipping age-preference satisfaction vars (enrollment determines cabin)")
+        return {}
+
     bunk_has_grade = _build_bunk_has_grade_vars(ctx)
 
     forcing_indicators_by_req_id: dict[str, list[cp_model.IntVar]] = {}
@@ -260,9 +271,11 @@ class AgePreferenceImpossibility(HardConstraintImpossibility):
         session = ctx.person_session.get(req.requester_person_cm_id)
         if session is None:
             return None
-        # AG enrollment sessions have exactly one cabin — there is no assignment
-        # decision, so placement-derived pre-checks don't apply. Mirrors the
-        # is_ag_session_bunk skips in grade_spread/grade_ratio/cabin_occupancy.
+        # AG cabin membership is enrollment-driven — everyone in the AG session
+        # lands in its cabin, so there is no preference-driven assignment
+        # decision and placement-derived pre-checks don't apply. Mirrors the
+        # is_ag_session_bunk skips in grade_spread/grade_ratio/cabin_occupancy
+        # and the matching skip in add_age_preference_satisfaction_vars above.
         if is_ag_session(ctx.bunks_by_session.get(session, [])):
             return None
         # grade=0 is the "unknown grade" sentinel set by data_fetcher when the

--- a/bunking/solver/constraints/grade_spread.py
+++ b/bunking/solver/constraints/grade_spread.py
@@ -10,7 +10,7 @@ from bunking.logging_config import get_logger
 from bunking.solver.constants import MAX_UNIQUE_GRADES_PER_BUNK
 
 from .base import SolverContext
-from .helpers import get_eligible_campers_for_bunk, is_ag_session_bunk
+from .helpers import get_eligible_campers_for_bunk, is_ag_session, is_ag_session_bunk
 
 logger = get_logger(__name__)
 
@@ -100,6 +100,18 @@ class GradeCompatibilityImpossibility(HardConstraintImpossibility):
         requester = ctx.person_by_cm_id.get(req.requester_person_cm_id)
         requestee = ctx.person_by_cm_id.get(req.requested_person_cm_id)
         if requester is None or requestee is None:
+            return None
+        # AG bunks are exempt from grade_spread/grade_adjacency (see the
+        # is_ag_session_bunk skips above), so the "cannot co-occupy any bunk"
+        # claim is false for a pair whose shared session is AG — skip it.
+        # Cross-session pairs fall through: SessionBoundaryImpossibility owns
+        # that reason, and the grade gap stays reportable alongside it.
+        session = ctx.person_session.get(req.requester_person_cm_id)
+        if (
+            session is not None
+            and session == ctx.person_session.get(req.requested_person_cm_id)
+            and is_ag_session(ctx.bunks_by_session.get(session, []))
+        ):
             return None
         max_gap = self._max_gap()
         gap = abs(requester.grade - requestee.grade)

--- a/bunking/solver/constraints/grade_spread.py
+++ b/bunking/solver/constraints/grade_spread.py
@@ -82,6 +82,8 @@ class GradeCompatibilityImpossibility(HardConstraintImpossibility):
 
     Pair: if |a.grade - b.grade| > (MAX_UNIQUE_GRADES_PER_BUNK - 1), the pair
     cannot co-occupy ANY bunk satisfying grade_spread + grade_adjacency.
+    Exception: pairs sharing an AG session are skipped — AG bunks are exempt
+    from both constraints, so the claim doesn't hold there (see check_pair).
     """
 
     name = "grade_compatibility"

--- a/bunking/solver/constraints/helpers.py
+++ b/bunking/solver/constraints/helpers.py
@@ -65,9 +65,12 @@ def is_ag_session_bunk(bunk: DirectBunk) -> bool:
 def is_ag_session(bunks: list[DirectBunk]) -> bool:
     """Check if a session's bunks are all AG cabins.
 
-    An AG enrollment session has exactly one cabin, so there is no assignment
-    decision to make — everyone enrolled lands in that cabin. Placement-derived
-    checks (grade spread, age-preference pools, …) don't apply there.
+    AG cabin membership is enrollment-driven: everyone enrolled in an AG
+    session lands in its cabin, so there is no preference-driven assignment
+    decision. Placement-derived checks (grade spread, age-preference pools, …)
+    and preference modeling don't apply there. The check is session-typed, not
+    cabin-counted — it holds even when a plan pairs several AG cabins to one
+    session cm_id (#1800).
     """
     return bool(bunks) and all(is_ag_session_bunk(b) for b in bunks)
 

--- a/bunking/solver/constraints/helpers.py
+++ b/bunking/solver/constraints/helpers.py
@@ -62,6 +62,16 @@ def is_ag_session_bunk(bunk: DirectBunk) -> bool:
     return "AG" in bunk.name.upper()
 
 
+def is_ag_session(bunks: list[DirectBunk]) -> bool:
+    """Check if a session's bunks are all AG cabins.
+
+    An AG enrollment session has exactly one cabin, so there is no assignment
+    decision to make — everyone enrolled lands in that cabin. Placement-derived
+    checks (grade spread, age-preference pools, …) don't apply there.
+    """
+    return bool(bunks) and all(is_ag_session_bunk(b) for b in bunks)
+
+
 def calculate_edge_extreme_threshold(standard_capacity: int, max_percentage: float) -> int:
     """Calculate threshold for edge bunk exemption from existing config values.
 

--- a/bunking/solver/constraints/parent_paramount.py
+++ b/bunking/solver/constraints/parent_paramount.py
@@ -26,6 +26,15 @@ Mechanism:
 Campers whose every MP request is impossible (filtered out of
 ``ctx.possible_requests``) are recorded in
 ``ctx.mp_set_entirely_impossible`` and skipped.
+
+Deliberate exception — AG-session campers: age_preference requests from
+campers in AG sessions have no solver representation at all
+(``add_age_preference_satisfaction_vars`` skips them; AG cabin membership is
+enrollment-driven, so preferences don't drive AG placement). Such requests are
+possible and material yet build no forcing vars, so a camper whose only MP
+requests are AG age_preferences gets no hard constraint here — by design, not
+by omission. The post-solve diagnostic excludes them from the
+``material_parent_unmet`` alarm for the same reason.
 """
 
 from __future__ import annotations
@@ -190,10 +199,13 @@ def add_must_satisfy_one_request_constraints(ctx: SolverContext) -> None:
             constraints_added += 1
             continue
 
-        # No forcing vars built. Entirely-impossible MP campers are already
-        # recorded in ctx.mp_set_entirely_impossible by _validate_requests
-        # (single source of truth: validate_impossibility) — nothing to derive
-        # here. Campers with no MP requests at all also land here harmlessly.
+        # No forcing vars built. Three cases land here: entirely-impossible MP
+        # campers (already recorded in ctx.mp_set_entirely_impossible by
+        # _validate_requests; single source of truth: validate_impossibility),
+        # campers with no MP requests at all, and AG-session campers whose MP
+        # requests are all age_preference (deliberately unenforced — no solver
+        # representation; see the module docstring and
+        # add_age_preference_satisfaction_vars). All are harmless by design.
         logger.debug(f"Camper {person_cm_id}: no forcing vars built — no hard constraint added")
 
     # Step 4: end-of-build logging

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -1623,7 +1623,10 @@ class DirectBunkingSolver:
         # enrollment-driven (see add_age_preference_satisfaction_vars), so
         # parent_paramount never tries to enforce them. Excluding them from the
         # material_parent_unmet trigger keeps mp_constraint_bug_signal a true
-        # "hard constraint failed to bind" alarm.
+        # "hard constraint failed to bind" alarm, and excluding them from the
+        # met/total rate counters keeps the denominators to requests the solver
+        # actually has a path to satisfy (same principle as the impossibility
+        # gate above).
         session_bunks: dict[int, list[DirectBunk]] = {}
         for bunk in self.bunks:
             session_bunks.setdefault(bunk.session_cm_id, []).append(bunk)
@@ -1656,10 +1659,18 @@ class DirectBunkingSolver:
             satisfied_ids_for_person: set[str] = set(all_satisfied.get(person_cm_id, []))
 
             resolved_mp = [
-                r for r in resolved_requests if r.id in self.material_request_ids and r.id not in yielded_request_ids
+                r
+                for r in resolved_requests
+                if r.id in self.material_request_ids
+                and r.id not in yielded_request_ids
+                and r.id not in ag_suppressed_request_ids
             ]
             resolved_possible_mp = [r for r in resolved_mp if r.id not in impossible_request_ids]
-            resolved_possible = [r for r in resolved_requests if r.id not in impossible_request_ids]
+            resolved_possible = [
+                r
+                for r in resolved_requests
+                if r.id not in impossible_request_ids and r.id not in ag_suppressed_request_ids
+            ]
 
             # Request-level "Optimized" (MP) rate.
             mp_requests_total += len(resolved_possible_mp)

--- a/bunking/solver/direct_solver.py
+++ b/bunking/solver/direct_solver.py
@@ -16,6 +16,7 @@ from ortools.sat.python import cp_model
 from bunking.config import ConfigLoader
 from bunking.logging_config import get_logger
 from bunking.models_v2 import (
+    DirectBunk,
     DirectBunkAssignment,
     DirectBunkRequest,
     DirectSolverInput,
@@ -43,6 +44,7 @@ from .constraints.grade_adjacency import add_grade_adjacency_constraints
 from .constraints.grade_ratio import add_grade_ratio_constraints
 from .constraints.grade_spread import add_grade_spread_constraints
 from .constraints.group_locks import add_group_lock_constraints
+from .constraints.helpers import is_ag_session
 from .constraints.level_progression import add_level_progression_constraints
 from .constraints.overflow_minimization import add_overflow_minimization_objective
 from .constraints.parent_paramount import add_must_satisfy_one_request_constraints
@@ -1616,6 +1618,26 @@ class DirectBunkingSolver:
         # classify as STAFF (never in material_request_ids), so no exclusion needed.
         yielded_request_ids: set[str] = {y["nbw_request_id"] for y in self.parent_nbw_yields}
 
+        # AG-session age_preference requests are possible and material but have
+        # no solver representation by design — AG cabin membership is
+        # enrollment-driven (see add_age_preference_satisfaction_vars), so
+        # parent_paramount never tries to enforce them. Excluding them from the
+        # material_parent_unmet trigger keeps mp_constraint_bug_signal a true
+        # "hard constraint failed to bind" alarm.
+        session_bunks: dict[int, list[DirectBunk]] = {}
+        for bunk in self.bunks:
+            session_bunks.setdefault(bunk.session_cm_id, []).append(bunk)
+        ag_session_ids = {sid for sid, bunks in session_bunks.items() if is_ag_session(bunks)}
+        ag_suppressed_request_ids: set[str] = set()
+        if ag_session_ids:
+            for requests in self.input.requests_by_person.values():
+                for r in requests:
+                    if r.request_type != "age_preference":
+                        continue
+                    requester = self.input.person_by_cm_id.get(r.requester_person_cm_id)
+                    if requester is not None and requester.session_cm_id in ag_session_ids:
+                        ag_suppressed_request_ids.add(r.id)
+
         for person_cm_id, requests in self.input.requests_by_person.items():
             # Frozen locked-roster campers are removed from the working set, so
             # they have no row in person_to_bunk; skip them. The must-place
@@ -1670,7 +1692,12 @@ class DirectBunkingSolver:
 
             resolved_possible = [r for r in self.possible_requests.get(person_cm_id, []) if r.status == "resolved"]
             resolved_possible_count[person_cm_id] = len(resolved_possible)
-            if any(r.id in self.material_request_ids and r.id not in yielded_request_ids for r in resolved_possible):
+            if any(
+                r.id in self.material_request_ids
+                and r.id not in yielded_request_ids
+                and r.id not in ag_suppressed_request_ids
+                for r in resolved_possible
+            ):
                 material_parent_unmet.append(person_cm_id)
             else:
                 other_unmet.append(person_cm_id)

--- a/frontend/src/components/BunkSocialGraphModal.test.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.test.tsx
@@ -12,6 +12,8 @@
  * The helper unit tests plus TypeScript checking provide sufficient coverage.
  */
 import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
 import {
   DEFAULT_SHOW_CROSS_SCOPE_EDGES,
   buildBunksFilter,
@@ -190,5 +192,18 @@ describe('sessionBunks derivation — sort order', () => {
     ]
     const result = deriveSessionBunks(bunks, 2)
     expect(result.map((b) => b.name)).toEqual(['B-1', 'B-2', 'B-3'])
+  })
+})
+
+// ─── Cross-scope legend label (#1752 addendum) ────────────────────────────────
+
+describe('cross-scope legend label', () => {
+  it('labels ghost nodes honestly for unassigned targets, not just "In another bunk"', () => {
+    // Ghost nodes derive from the session graph, so a cross-scope target can be
+    // unassigned (GhostNode.bunk_name is nullable) — the legend entry must not
+    // claim every violet node is "In another bunk". Source-content assertion:
+    // the legend is inline JSX behind cytoscape/provider setup (see header note).
+    const source = readFileSync(resolve(__dirname, './BunkSocialGraphModal.tsx'), 'utf-8')
+    expect(source).toContain('In another bunk / unassigned')
   })
 })

--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -737,7 +737,7 @@ export default function BunkSocialGraphModal({
                                   borderColor: CROSS_SCOPE_NODE_COLOR,
                                 }}
                               ></div>
-                              <span>In another bunk</span>
+                              <span>In another bunk / unassigned</span>
                             </div>
                           )}
                         </div>

--- a/frontend/src/components/PreValidationResultsModal.test.tsx
+++ b/frontend/src/components/PreValidationResultsModal.test.tsx
@@ -112,7 +112,7 @@ describe('PreValidationResultsModal — staff modal updates (D1-D5)', () => {
     expect(screen.getByText(/heads up/i)).toBeInTheDocument()
   })
 
-  it('renders "Wants older — already at top grade" subtext for age_pref_no_eligible_grade older case', () => {
+  it('renders "Wants older — no older peers in this session" subtext for age_pref_no_eligible_grade older case', () => {
     const results = {
       valid: false,
       errors: [],
@@ -137,7 +137,12 @@ describe('PreValidationResultsModal — staff modal updates (D1-D5)', () => {
               request_type: 'age_preference',
               requester: { name: 'Olivia Chen', cm_id: 1, grade: 6, gender: 'F' },
               requestee: null,
-              detail: { direction: 'older', requester_grade: 6, pool_max_grade: 6 },
+              detail: {
+                direction: 'older',
+                requester_grade: 6,
+                pool_min_grade: 4,
+                pool_max_grade: 6,
+              },
               bucket: 'material_parent' as const,
             },
           ],
@@ -156,7 +161,59 @@ describe('PreValidationResultsModal — staff modal updates (D1-D5)', () => {
     )
 
     expect(screen.getByText(/Wants older/)).toBeInTheDocument()
-    expect(screen.getByText(/already at oldest grade/)).toBeInTheDocument()
+    expect(screen.getByText(/no older peers in this session/)).toBeInTheDocument()
+  })
+
+  it('renders "Wants younger — no younger peers in this session" subtext for age_pref_no_eligible_grade younger case', () => {
+    const results = {
+      valid: false,
+      errors: [],
+      warnings: [],
+      statistics: {
+        total_campers: 10,
+        total_bunks: 2,
+        total_capacity: 20,
+        total_requests: 5,
+        campers_with_requests: 8,
+        campers_without_requests: 2,
+      },
+      impossibility_report: makeImpossibilityReport({
+        total_impossible: 1,
+        affected_campers: 1,
+        by_reason: {
+          age_pref_no_eligible_grade: [
+            {
+              request_id: 'br_age_y',
+              reason_code: 'age_pref_no_eligible_grade',
+              reason_message: 'no younger peer',
+              request_type: 'age_preference',
+              requester: { name: 'Olivia Chen', cm_id: 1, grade: 9, gender: 'F' },
+              requestee: null,
+              detail: {
+                direction: 'younger',
+                requester_grade: 9,
+                pool_min_grade: 9,
+                pool_max_grade: 10,
+              },
+              bucket: 'material_parent' as const,
+            },
+          ],
+        },
+        flat: [],
+      }),
+    }
+    render(
+      <PreValidationResultsModal
+        sessionCmId={1000001}
+        isOpen
+        onClose={() => {}}
+        results={results}
+        sessionLookup={() => 'Session'}
+      />
+    )
+
+    expect(screen.getByText(/Wants younger/)).toBeInTheDocument()
+    expect(screen.getByText(/no younger peers in this session/)).toBeInTheDocument()
   })
 
   it('renders cross_session subtext with sessionLookup-resolved session name', () => {
@@ -709,7 +766,10 @@ describe('PreValidationResultsModal — per-reason hint copy', () => {
     ['grade_compatibility', 'grade gap too wide — confirm priority with the family'],
     ['cross_session', 'requested friend is in a different session — confirm intent'],
     ['pair_no_shared_bunk', 'cross-gender request — confirm with the family'],
-    ['age_pref_no_eligible_grade', 'at the youngest/oldest grade — preference is moot'],
+    [
+      'age_pref_no_eligible_grade',
+      'no peers in the requested direction — preference cannot be met',
+    ],
     ['malformed', 'request is missing a name — needs parent resubmission'],
     // self_conflict is emitted by bunking/solver/constraints/self_conflict.py
     // and shows up in FRIENDLY_REASON_LABELS already; needs a hint too so a

--- a/frontend/src/components/PreValidationResultsModal.test.tsx
+++ b/frontend/src/components/PreValidationResultsModal.test.tsx
@@ -768,7 +768,7 @@ describe('PreValidationResultsModal — per-reason hint copy', () => {
     ['pair_no_shared_bunk', 'cross-gender request — confirm with the family'],
     [
       'age_pref_no_eligible_grade',
-      'no peers in the requested direction — preference cannot be met',
+      'no peers in the requested direction — preference may not be met',
     ],
     ['malformed', 'request is missing a name — needs parent resubmission'],
     // self_conflict is emitted by bunking/solver/constraints/self_conflict.py

--- a/frontend/src/components/PreValidationResultsModal.tsx
+++ b/frontend/src/components/PreValidationResultsModal.tsx
@@ -245,17 +245,19 @@ function renderSubtext(
 
     case 'age_pref_no_eligible_grade': {
       const dir = item.detail?.['direction'] as 'older' | 'younger' | undefined
+      // Describe the session pool, not a camp-wide grade position — in
+      // narrow-grade sessions "already at oldest grade" reads false (#1752).
       if (dir === 'older' && item.detail?.['pool_max_grade'] !== undefined) {
         return (
           <div className="text-xs text-stone-600">
-            <strong>Wants older</strong> — already at oldest grade
+            <strong>Wants older</strong> — no older peers in this session
           </div>
         )
       }
       if (dir === 'younger' && item.detail?.['pool_min_grade'] !== undefined) {
         return (
           <div className="text-xs text-stone-600">
-            <strong>Wants younger</strong> — already at youngest grade
+            <strong>Wants younger</strong> — no younger peers in this session
           </div>
         )
       }

--- a/frontend/src/components/impossibility/reasonHints.ts
+++ b/frontend/src/components/impossibility/reasonHints.ts
@@ -22,7 +22,7 @@ export const REASON_HINTS: Record<ReasonCode, string> = {
   grade_compatibility: 'grade gap too wide — confirm priority with the family',
   cross_session: 'requested friend is in a different session — confirm intent',
   pair_no_shared_bunk: 'cross-gender request — confirm with the family',
-  age_pref_no_eligible_grade: 'at the youngest/oldest grade — preference is moot',
+  age_pref_no_eligible_grade: 'no peers in the requested direction — preference cannot be met',
   malformed: 'request is missing a name — needs parent resubmission',
   self_conflict: 'contradicting requests — confirm which preference the family meant',
 }

--- a/frontend/src/components/impossibility/reasonHints.ts
+++ b/frontend/src/components/impossibility/reasonHints.ts
@@ -22,7 +22,7 @@ export const REASON_HINTS: Record<ReasonCode, string> = {
   grade_compatibility: 'grade gap too wide — confirm priority with the family',
   cross_session: 'requested friend is in a different session — confirm intent',
   pair_no_shared_bunk: 'cross-gender request — confirm with the family',
-  age_pref_no_eligible_grade: 'no peers in the requested direction — preference cannot be met',
+  age_pref_no_eligible_grade: 'no peers in the requested direction — preference may not be met',
   malformed: 'request is missing a name — needs parent resubmission',
   self_conflict: 'contradicting requests — confirm which preference the family meant',
 }

--- a/tests/unit/solver/impossibility/test_age_preference.py
+++ b/tests/unit/solver/impossibility/test_age_preference.py
@@ -220,9 +220,10 @@ def test_all_strictly_older_pool_wants_younger_still_fires(mock_config):
 
 
 def test_ag_session_skips_age_preference_check(mock_config):
-    """AG enrollment sessions have exactly one cabin — no assignment decision
-    exists, so placement-derived pre-checks don't apply (#1752). Mirrors the
-    is_ag_session_bunk skips in grade_spread/grade_ratio/cabin_occupancy."""
+    """AG cabin membership is enrollment-driven — everyone in the AG session
+    lands in its cabin, so placement-derived pre-checks don't apply (#1752).
+    Mirrors the is_ag_session_bunk skips in grade_spread/grade_ratio/
+    cabin_occupancy."""
     requester = make_person(1, session=100, gender="F", grade=10)
     p_same = make_person(2, session=100, gender="F", grade=10)
     p_older = make_person(3, session=100, gender="F", grade=11)
@@ -236,6 +237,31 @@ def test_ag_session_skips_age_preference_check(mock_config):
     )
     ag_bunk = make_bunk(10, session=100, gender="AG", name="AG Cabin 3")
     input_data = make_input([requester, p_same, p_older], [ag_bunk], [req])
+    ctx = _build_context(input_data, mock_config)
+
+    assert PREDICATE.check_request(req, ctx) is None
+
+
+def test_multi_bunk_ag_session_skips_age_preference_check(mock_config):
+    """A single AG session can carry several AG cabins (#1800's plan-level
+    pairing) — the skip is session-typed, not cabin-counted, because AG
+    placement is enrollment-driven either way."""
+    requester = make_person(1, session=100, gender="F", grade=10)
+    p_same = make_person(2, session=100, gender="F", grade=10)
+    p_older = make_person(3, session=100, gender="F", grade=11)
+    req = make_request(
+        "r1",
+        requester=1,
+        requestee=None,
+        request_type="age_preference",
+        age_preference_target="younger",
+        session=100,
+    )
+    ag_bunks = [
+        make_bunk(10, session=100, gender="AG", name="AG Cabin 3"),
+        make_bunk(20, session=100, gender="AG", name="AG Cabin 4"),
+    ]
+    input_data = make_input([requester, p_same, p_older], ag_bunks, [req])
     ctx = _build_context(input_data, mock_config)
 
     assert PREDICATE.check_request(req, ctx) is None

--- a/tests/unit/solver/impossibility/test_age_preference.py
+++ b/tests/unit/solver/impossibility/test_age_preference.py
@@ -111,6 +111,136 @@ def test_age_pref_skips_check_when_requester_grade_is_unknown(mock_config):
     assert PREDICATE.check_request(req, ctx) is None
 
 
+def test_all_same_grade_pool_wants_younger_is_satisfiable(mock_config):
+    """Pool entirely at the requester's grade: an all-equal bunk satisfies
+    'younger' per the canonical semantics (has younger OR no older), so the
+    pre-check must not flag it (#1752 false positive)."""
+    requester = make_person(1, session=100, gender="F", grade=10)
+    peers = [make_person(i, session=100, gender="F", grade=10) for i in (2, 3, 4)]
+    req = make_request(
+        "r1",
+        requester=1,
+        requestee=None,
+        request_type="age_preference",
+        age_preference_target="younger",
+        session=100,
+    )
+    input_data = make_input([requester, *peers], [make_bunk(10, session=100, gender="F")], [req])
+    ctx = _build_context(input_data, mock_config)
+
+    assert PREDICATE.check_request(req, ctx) is None
+
+
+def test_all_same_grade_pool_wants_older_is_satisfiable(mock_config):
+    """Symmetric to the 'younger' case: all-equal bunk satisfies 'older'
+    (has older OR no younger)."""
+    requester = make_person(1, session=100, gender="F", grade=6)
+    peers = [make_person(i, session=100, gender="F", grade=6) for i in (2, 3)]
+    req = make_request(
+        "r1",
+        requester=1,
+        requestee=None,
+        request_type="age_preference",
+        age_preference_target="older",
+        session=100,
+    )
+    input_data = make_input([requester, *peers], [make_bunk(10, session=100, gender="F")], [req])
+    ctx = _build_context(input_data, mock_config)
+
+    assert PREDICATE.check_request(req, ctx) is None
+
+
+def test_same_and_older_pool_wants_younger_fires_with_pool_bounds(mock_config):
+    """Same-grade + older peers, no younger: satisfaction depends on landing an
+    all-same-grade bunk, so the risk warning stays — and the detail must carry
+    BOTH pool bounds so the frontend can describe the pool."""
+    requester = make_person(1, session=100, gender="F", grade=10)
+    p_same = make_person(2, session=100, gender="F", grade=10)
+    p_older = make_person(3, session=100, gender="F", grade=11)
+    req = make_request(
+        "r1",
+        requester=1,
+        requestee=None,
+        request_type="age_preference",
+        age_preference_target="younger",
+        session=100,
+    )
+    input_data = make_input([requester, p_same, p_older], [make_bunk(10, session=100, gender="F")], [req])
+    ctx = _build_context(input_data, mock_config)
+
+    reason = PREDICATE.check_request(req, ctx)
+    assert reason is not None
+    assert reason.code == "age_pref_no_eligible_grade"
+    assert reason.detail["pool_min_grade"] == 10
+    assert reason.detail["pool_max_grade"] == 11
+
+
+def test_same_and_younger_pool_wants_older_fires_with_pool_bounds(mock_config):
+    """Mirror of the younger risk case: same-grade + younger peers, no older."""
+    requester = make_person(1, session=100, gender="F", grade=5)
+    p_same = make_person(2, session=100, gender="F", grade=5)
+    p_younger = make_person(3, session=100, gender="F", grade=4)
+    req = make_request(
+        "r1",
+        requester=1,
+        requestee=None,
+        request_type="age_preference",
+        age_preference_target="older",
+        session=100,
+    )
+    input_data = make_input([requester, p_same, p_younger], [make_bunk(10, session=100, gender="F")], [req])
+    ctx = _build_context(input_data, mock_config)
+
+    reason = PREDICATE.check_request(req, ctx)
+    assert reason is not None
+    assert reason.code == "age_pref_no_eligible_grade"
+    assert reason.detail["pool_min_grade"] == 4
+    assert reason.detail["pool_max_grade"] == 5
+
+
+def test_all_strictly_older_pool_wants_younger_still_fires(mock_config):
+    """Every peer strictly older: genuinely impossible (any bunk has older,
+    none younger) — the warning must survive the boundary fix."""
+    requester = make_person(1, session=100, gender="F", grade=9)
+    peers = [make_person(i, session=100, gender="F", grade=10) for i in (2, 3)]
+    req = make_request(
+        "r1",
+        requester=1,
+        requestee=None,
+        request_type="age_preference",
+        age_preference_target="younger",
+        session=100,
+    )
+    input_data = make_input([requester, *peers], [make_bunk(10, session=100, gender="F")], [req])
+    ctx = _build_context(input_data, mock_config)
+
+    reason = PREDICATE.check_request(req, ctx)
+    assert reason is not None
+    assert reason.code == "age_pref_no_eligible_grade"
+
+
+def test_ag_session_skips_age_preference_check(mock_config):
+    """AG enrollment sessions have exactly one cabin — no assignment decision
+    exists, so placement-derived pre-checks don't apply (#1752). Mirrors the
+    is_ag_session_bunk skips in grade_spread/grade_ratio/cabin_occupancy."""
+    requester = make_person(1, session=100, gender="F", grade=10)
+    p_same = make_person(2, session=100, gender="F", grade=10)
+    p_older = make_person(3, session=100, gender="F", grade=11)
+    req = make_request(
+        "r1",
+        requester=1,
+        requestee=None,
+        request_type="age_preference",
+        age_preference_target="younger",
+        session=100,
+    )
+    ag_bunk = make_bunk(10, session=100, gender="AG", name="AG Cabin 3")
+    input_data = make_input([requester, p_same, p_older], [ag_bunk], [req])
+    ctx = _build_context(input_data, mock_config)
+
+    assert PREDICATE.check_request(req, ctx) is None
+
+
 def test_age_pref_ignores_peers_with_unknown_grade(mock_config):
     """Peers whose grade is 0 (unknown) should not be treated as 'younger than everyone'."""
     requester = make_person(1, session=100, gender="F", grade=5)

--- a/tests/unit/solver/impossibility/test_grade_compatibility.py
+++ b/tests/unit/solver/impossibility/test_grade_compatibility.py
@@ -119,3 +119,17 @@ def test_grade_compatibility_no_cluster_check_emitted(mock_config):
         assert item.reason_code != "cluster_grade_compatibility", (
             f"cluster_grade_compatibility should be deleted, got {item}"
         )
+
+
+def test_ag_session_pair_wide_gap_not_flagged(mock_config):
+    """AG bunks are exempt from grade_spread + grade_adjacency (see
+    is_ag_session_bunk skips), so the 'cannot co-occupy ANY bunk' claim is
+    false for a pair in an AG session — the predicate must skip it (#1752)."""
+    p1 = make_person(1, session=100, gender="F", grade=6)
+    p2 = make_person(2, session=100, gender="M", grade=10)
+    req = make_request("r1", requester=1, requestee=2, session=100)
+    ag_bunk = make_bunk(10, session=100, gender="AG", name="AG Cabin 3")
+    input_data = make_input([p1, p2], [ag_bunk], [req])
+    ctx = _build_context(input_data, mock_config)
+
+    assert PREDICATE.check_pair(req, ctx) is None

--- a/tests/unit/solver/test_age_preference_ag_satvars.py
+++ b/tests/unit/solver/test_age_preference_ag_satvars.py
@@ -1,0 +1,168 @@
+"""AG sessions get no age-preference solver representation (#1752 follow-up).
+
+AG cabin membership is enrollment-driven: everyone in AG session X lands in
+that session's AG cabin. Preferences don't drive AG placement, so
+``add_age_preference_satisfaction_vars`` must build nothing for AG sessions —
+no sat var, no forcing indicators. Otherwise ``parent_paramount`` would turn
+an MP age_preference request into a hard must-satisfy-one constraint over
+per-bunk cleanliness vars that AG bunks (unlike grade_spread/grade_adjacency/
+cabin_occupancy, which exempt AG bunks per-bunk) never opt out of — risking
+INFEASIBLE with no diagnostic, since the impossibility pre-check also skips
+AG sessions and so never records the request as impossible.
+"""
+
+from collections.abc import Generator
+from typing import Any, ClassVar
+from unittest.mock import MagicMock
+
+import pytest
+
+from bunking.config import ConfigLoader
+from bunking.solver.constraints.age_preference import add_age_preference_satisfaction_vars
+from bunking.solver.direct_solver import DirectBunkingSolver
+from tests.unit.solver.impossibility.conftest import (
+    make_bunk,
+    make_input,
+    make_person,
+    make_request,
+)
+
+
+class _PenaltyStubLoader:
+    """Penalty accessors that read via ``ConfigLoader.get_instance()`` need a
+    real-ish object (mirrors test_impossible_request_no_sat_var.py)."""
+
+    _values: ClassVar[dict[str, int]] = {
+        "constraint.cabin_minimum_occupancy.penalty": 0,
+        "constraint.grade_spread.penalty": 0,
+    }
+
+    def get_int(self, key: str, default: int | None = None) -> int:
+        v = self._values.get(key)
+        return int(v) if v is not None else (default if default is not None else 0)
+
+    def get_float(self, key: str, default: float | None = None) -> float:
+        v = self._values.get(key)
+        return float(v) if v is not None else (default if default is not None else 0.0)
+
+
+@pytest.fixture
+def mock_config() -> Generator[Any]:
+    cfg = MagicMock()
+
+    def _get_constraint(constraint_type: str, param: str, default: Any = None) -> Any:
+        if constraint_type == "grade_spread" and param == "max_spread":
+            return 2
+        return default if default is not None else 0
+
+    def _get_int(key: str, default: Any = None) -> Any:
+        return default if default is not None else 0
+
+    def _get_float(key: str, default: Any = None) -> Any:
+        return default if default is not None else 0.0
+
+    def _get_str(key: str, default: Any = None) -> Any:
+        if "grade_spread.mode" in key:
+            return "hard"
+        return default if default is not None else ""
+
+    def _get_bool(key: str, default: Any = None) -> Any:
+        return default if default is not None else False
+
+    def _get_priority(priority_type: str, subtype: str = "default") -> int:
+        return 4
+
+    def _get_soft_constraint_weight(constraint_name: str) -> int:
+        return 0
+
+    cfg.get_constraint.side_effect = _get_constraint
+    cfg.get_int.side_effect = _get_int
+    cfg.get_float.side_effect = _get_float
+    cfg.get_str.side_effect = _get_str
+    cfg.get_bool.side_effect = _get_bool
+    cfg.get_priority.side_effect = _get_priority
+    cfg.get_soft_constraint_weight.side_effect = _get_soft_constraint_weight
+
+    with ConfigLoader.use(_PenaltyStubLoader()):  # type: ignore[arg-type]
+        yield cfg
+
+
+def _ag_age_pref_fixture() -> tuple[Any, Any]:
+    """Multi-bunk AG session (the #1800 shape: several AG cabins paired to one
+    session cm_id) with an MP age_preference request that has a non-trivial
+    satisfaction condition (an older peer exists for a 'younger' preference)."""
+    requester = make_person(1, session=100, gender="F", grade=6)
+    p_younger = make_person(2, session=100, gender="F", grade=5)
+    p_older = make_person(3, session=100, gender="F", grade=7)
+    req = make_request(
+        "agr1",
+        requester=1,
+        requestee=None,
+        request_type="age_preference",
+        age_preference_target="younger",
+        source_field="bunk_request_form",  # MATERIAL_PARENT bucket
+        session=100,
+    )
+    bunks = [
+        make_bunk(10, session=100, gender="AG", name="AG Cabin 3"),
+        make_bunk(20, session=100, gender="AG", name="AG Cabin 4"),
+    ]
+    return make_input([requester, p_younger, p_older], bunks, [req]), req
+
+
+def test_ag_session_builds_no_age_pref_sat_vars(mock_config: Any) -> None:
+    """Direct unit: the helper returns no forcing indicators and registers no
+    sat var for a request whose solve context is an AG session."""
+    input_data, req = _ag_age_pref_fixture()
+    solver = DirectBunkingSolver(input_data, config_service=mock_config)
+    ctx = solver._build_solver_context()
+
+    forcing = add_age_preference_satisfaction_vars(ctx, {1: [req]})
+
+    assert forcing == {}
+    assert req.id not in ctx.request_satisfied_vars
+
+
+def test_ag_session_mp_age_pref_produces_no_model_vars(mock_config: Any) -> None:
+    """End-to-end through add_constraints (which runs parent_paramount): no
+    ``age_req_<id>_*`` variable may appear in the model proto for an AG
+    session — the request has no solver representation at all."""
+    input_data, req = _ag_age_pref_fixture()
+    solver = DirectBunkingSolver(input_data, config_service=mock_config)
+
+    solver.add_constraints()
+    solver.add_objective()
+
+    var_names = [v.name for v in solver.model.Proto().variables]
+    age_vars = [n for n in var_names if f"age_req_{req.id}" in n]
+    assert age_vars == [], f"AG session built age-preference solver vars: {age_vars}"
+
+
+def test_non_ag_session_still_builds_age_pref_sat_vars(mock_config: Any) -> None:
+    """Control: the AG guard must not over-fire — a regular session's MP
+    age_preference request still gets its sat var and forcing indicators."""
+    requester = make_person(1, session=100, gender="F", grade=6)
+    p_younger = make_person(2, session=100, gender="F", grade=5)
+    p_older = make_person(3, session=100, gender="F", grade=7)
+    req = make_request(
+        "agr2",
+        requester=1,
+        requestee=None,
+        request_type="age_preference",
+        age_preference_target="younger",
+        source_field="bunk_request_form",
+        session=100,
+    )
+    bunks = [
+        make_bunk(10, session=100, gender="F"),
+        make_bunk(20, session=100, gender="F"),
+    ]
+    input_data = make_input([requester, p_younger, p_older], bunks, [req])
+    solver = DirectBunkingSolver(input_data, config_service=mock_config)
+    ctx = solver._build_solver_context()
+
+    forcing = add_age_preference_satisfaction_vars(ctx, {1: [req]})
+
+    assert req.id in forcing
+    assert forcing[req.id] != []
+    assert req.id in ctx.request_satisfied_vars

--- a/tests/unit/solver/test_age_preference_ag_satvars.py
+++ b/tests/unit/solver/test_age_preference_ag_satvars.py
@@ -253,3 +253,38 @@ def test_unsatisfied_ag_age_pref_not_flagged_material_parent_unmet(mock_config: 
         f"AG camper falsely flagged material_parent_unmet: {material}"
     )
     assert solver.request_validation_summary["mp_constraint_bug_signal"] == 0
+
+
+def test_ag_age_pref_excluded_from_rate_denominators(mock_config: Any) -> None:
+    """The met/total rate metrics gate their denominators on "requests the
+    solver actually has a path to satisfy" — AG age_preferences have no solver
+    representation by design, so they must not drag the rates down. The
+    main-session camper's request in the same solve still counts."""
+    ag_req = _ag_age_req()  # camper 1 (AG, grade 6) wants younger — unenforced
+    main_req = _main_age_req()  # camper 4 (main, grade 6) wants younger
+    input_data = _combined_main_ag_input([ag_req, main_req])
+    solver = DirectBunkingSolver(input_data, config_service=mock_config)
+
+    # AG camper 1 shares a cabin with older camper 3 → predicate-unsatisfied.
+    # Main camper 4 shares bunk 30 with younger camper 5 only → satisfied.
+    assignments = [
+        DirectBunkAssignment(person_cm_id=1, session_cm_id=AG_SESSION, bunk_cm_id=10, year=2026),
+        DirectBunkAssignment(person_cm_id=2, session_cm_id=AG_SESSION, bunk_cm_id=20, year=2026),
+        DirectBunkAssignment(person_cm_id=3, session_cm_id=AG_SESSION, bunk_cm_id=10, year=2026),
+        DirectBunkAssignment(person_cm_id=4, session_cm_id=MAIN_SESSION, bunk_cm_id=30, year=2026),
+        DirectBunkAssignment(person_cm_id=5, session_cm_id=MAIN_SESSION, bunk_cm_id=30, year=2026),
+        DirectBunkAssignment(person_cm_id=6, session_cm_id=MAIN_SESSION, bunk_cm_id=40, year=2026),
+    ]
+
+    solver._check_must_satisfy_one_violations(assignments)
+
+    summary = solver.request_validation_summary
+    # Only the main-session request counts — in every denominator.
+    assert summary["mp_requests_total"] == 1
+    assert summary["mp_requests_satisfied"] == 1
+    assert summary["mp_campers_total"] == 1
+    assert summary["mp_campers_satisfied"] == 1
+    assert summary["all_requests_total"] == 1
+    assert summary["all_requests_satisfied"] == 1
+    assert summary["all_campers_total"] == 1
+    assert summary["all_campers_satisfied"] == 1

--- a/tests/unit/solver/test_age_preference_ag_satvars.py
+++ b/tests/unit/solver/test_age_preference_ag_satvars.py
@@ -1,14 +1,29 @@
-"""AG sessions get no age-preference solver representation (#1752 follow-up).
+"""AG-session campers get no age-preference solver representation (#1752 follow-up).
 
 AG cabin membership is enrollment-driven: everyone in AG session X lands in
 that session's AG cabin. Preferences don't drive AG placement, so
-``add_age_preference_satisfaction_vars`` must build nothing for AG sessions —
-no sat var, no forcing indicators. Otherwise ``parent_paramount`` would turn
-an MP age_preference request into a hard must-satisfy-one constraint over
-per-bunk cleanliness vars that AG bunks (unlike grade_spread/grade_adjacency/
-cabin_occupancy, which exempt AG bunks per-bunk) never opt out of — risking
-INFEASIBLE with no diagnostic, since the impossibility pre-check also skips
-AG sessions and so never records the request as impossible.
+``add_age_preference_satisfaction_vars`` must build nothing for requests from
+AG-session campers — no sat var, no forcing indicators. Otherwise
+``parent_paramount`` would turn an MP age_preference into a hard
+must-satisfy-one constraint over per-bunk cleanliness vars that AG bunks
+(unlike grade_spread/grade_adjacency/cabin_occupancy, which exempt AG bunks
+per-bunk) never opt out of — risking INFEASIBLE with no diagnostic, since the
+impossibility pre-check also skips AG sessions and so never records the
+request as impossible.
+
+CRITICAL SCOPING NOTE: production solves are never AG-only. A main session and
+its related AG session are fetched together into ONE DirectSolverInput
+(api/services/solver_runner.py: "Main + AG sessions are automatically fetched
+together via get_related_session_ids"), so ``ctx.bunks`` mixes non-AG and AG
+bunks. The skip must therefore be scoped per requester's own session — a
+whole-solve ``is_ag_session(ctx.bunks)`` check would never fire in the
+combined topology. The fixtures here use the combined main+AG shape for
+exactly that reason.
+
+The post-solve diagnostic must agree: an AG camper's unsatisfied MP
+age_preference is deliberately unenforced, so it must not trip
+``material_parent_unmet`` / ``mp_constraint_bug_signal`` (the "hard constraint
+failed to bind" alarm).
 """
 
 from collections.abc import Generator
@@ -18,6 +33,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from bunking.config import ConfigLoader
+from bunking.models_v2 import DirectBunkAssignment
 from bunking.solver.constraints.age_preference import add_age_preference_satisfaction_vars
 from bunking.solver.direct_solver import DirectBunkingSolver
 from tests.unit.solver.impossibility.conftest import (
@@ -26,6 +42,9 @@ from tests.unit.solver.impossibility.conftest import (
     make_person,
     make_request,
 )
+
+AG_SESSION = 100
+MAIN_SESSION = 200
 
 
 class _PenaltyStubLoader:
@@ -87,82 +106,150 @@ def mock_config() -> Generator[Any]:
         yield cfg
 
 
-def _ag_age_pref_fixture() -> tuple[Any, Any]:
-    """Multi-bunk AG session (the #1800 shape: several AG cabins paired to one
-    session cm_id) with an MP age_preference request that has a non-trivial
-    satisfaction condition (an older peer exists for a 'younger' preference)."""
-    requester = make_person(1, session=100, gender="F", grade=6)
-    p_younger = make_person(2, session=100, gender="F", grade=5)
-    p_older = make_person(3, session=100, gender="F", grade=7)
-    req = make_request(
+def _combined_main_ag_input(requests: list[Any]) -> Any:
+    """The production topology: one solve holding a main session's non-AG bunks
+    AND its related AG session's cabins (several — the #1800 shape).
+
+    AG session 100: campers 1 (grade 6), 2 (grade 5), 3 (grade 7).
+    Main session 200: campers 4 (grade 6), 5 (grade 5), 6 (grade 7).
+    """
+    persons = [
+        make_person(1, session=AG_SESSION, gender="F", grade=6),
+        make_person(2, session=AG_SESSION, gender="F", grade=5),
+        make_person(3, session=AG_SESSION, gender="F", grade=7),
+        make_person(4, session=MAIN_SESSION, gender="F", grade=6),
+        make_person(5, session=MAIN_SESSION, gender="F", grade=5),
+        make_person(6, session=MAIN_SESSION, gender="F", grade=7),
+    ]
+    bunks = [
+        make_bunk(10, session=AG_SESSION, gender="AG", name="AG Cabin 3"),
+        make_bunk(20, session=AG_SESSION, gender="AG", name="AG Cabin 4"),
+        make_bunk(30, session=MAIN_SESSION, gender="F"),
+        make_bunk(40, session=MAIN_SESSION, gender="F"),
+    ]
+    return make_input(persons, bunks, requests)
+
+
+def _ag_age_req() -> Any:
+    return make_request(
         "agr1",
         requester=1,
         requestee=None,
         request_type="age_preference",
         age_preference_target="younger",
         source_field="bunk_request_form",  # MATERIAL_PARENT bucket
-        session=100,
+        session=AG_SESSION,
     )
-    bunks = [
-        make_bunk(10, session=100, gender="AG", name="AG Cabin 3"),
-        make_bunk(20, session=100, gender="AG", name="AG Cabin 4"),
-    ]
-    return make_input([requester, p_younger, p_older], bunks, [req]), req
 
 
-def test_ag_session_builds_no_age_pref_sat_vars(mock_config: Any) -> None:
-    """Direct unit: the helper returns no forcing indicators and registers no
-    sat var for a request whose solve context is an AG session."""
-    input_data, req = _ag_age_pref_fixture()
+def _main_age_req() -> Any:
+    return make_request(
+        "mainr1",
+        requester=4,
+        requestee=None,
+        request_type="age_preference",
+        age_preference_target="younger",
+        source_field="bunk_request_form",
+        session=MAIN_SESSION,
+    )
+
+
+def test_ag_camper_in_combined_solve_builds_no_sat_vars(mock_config: Any) -> None:
+    """Direct unit: in the combined main+AG solve, a request from an AG-session
+    camper gets no forcing indicators and no sat var — the skip must key off the
+    requester's own session, not the whole solve's bunk list."""
+    ag_req = _ag_age_req()
+    input_data = _combined_main_ag_input([ag_req])
     solver = DirectBunkingSolver(input_data, config_service=mock_config)
     ctx = solver._build_solver_context()
 
-    forcing = add_age_preference_satisfaction_vars(ctx, {1: [req]})
+    forcing = add_age_preference_satisfaction_vars(ctx, {1: [ag_req]})
 
     assert forcing == {}
-    assert req.id not in ctx.request_satisfied_vars
+    assert ag_req.id not in ctx.request_satisfied_vars
 
 
-def test_ag_session_mp_age_pref_produces_no_model_vars(mock_config: Any) -> None:
-    """End-to-end through add_constraints (which runs parent_paramount): no
-    ``age_req_<id>_*`` variable may appear in the model proto for an AG
-    session — the request has no solver representation at all."""
-    input_data, req = _ag_age_pref_fixture()
+def test_main_camper_in_combined_solve_still_builds_sat_vars(mock_config: Any) -> None:
+    """Control: the AG skip must not over-fire — a main-session camper in the
+    same combined solve still gets a sat var and forcing indicators."""
+    main_req = _main_age_req()
+    input_data = _combined_main_ag_input([main_req])
+    solver = DirectBunkingSolver(input_data, config_service=mock_config)
+    ctx = solver._build_solver_context()
+
+    forcing = add_age_preference_satisfaction_vars(ctx, {4: [main_req]})
+
+    assert main_req.id in forcing
+    assert forcing[main_req.id] != []
+    assert main_req.id in ctx.request_satisfied_vars
+
+
+def test_combined_solve_no_model_vars_for_ag_request(mock_config: Any) -> None:
+    """End-to-end through add_constraints (which runs parent_paramount): the AG
+    camper's request leaves no ``age_req_<id>_*`` trace in the model proto,
+    while the main-session camper's request still does."""
+    ag_req = _ag_age_req()
+    main_req = _main_age_req()
+    input_data = _combined_main_ag_input([ag_req, main_req])
     solver = DirectBunkingSolver(input_data, config_service=mock_config)
 
     solver.add_constraints()
     solver.add_objective()
 
     var_names = [v.name for v in solver.model.Proto().variables]
-    age_vars = [n for n in var_names if f"age_req_{req.id}" in n]
-    assert age_vars == [], f"AG session built age-preference solver vars: {age_vars}"
+    ag_vars = [n for n in var_names if f"age_req_{ag_req.id}" in n]
+    main_vars = [n for n in var_names if f"age_req_{main_req.id}" in n]
+    assert ag_vars == [], f"AG-session camper's request built solver vars: {ag_vars}"
+    assert main_vars != [], "main-session camper's request lost its solver representation"
 
 
-def test_non_ag_session_still_builds_age_pref_sat_vars(mock_config: Any) -> None:
-    """Control: the AG guard must not over-fire — a regular session's MP
-    age_preference request still gets its sat var and forcing indicators."""
-    requester = make_person(1, session=100, gender="F", grade=6)
-    p_younger = make_person(2, session=100, gender="F", grade=5)
-    p_older = make_person(3, session=100, gender="F", grade=7)
-    req = make_request(
-        "agr2",
-        requester=1,
-        requestee=None,
-        request_type="age_preference",
-        age_preference_target="younger",
-        source_field="bunk_request_form",
-        session=100,
-    )
-    bunks = [
-        make_bunk(10, session=100, gender="F"),
-        make_bunk(20, session=100, gender="F"),
+def test_standalone_ag_solve_builds_no_sat_vars(mock_config: Any) -> None:
+    """The standalone all-AG shape (an AG session solved by itself) skips too."""
+    ag_req = _ag_age_req()
+    persons = [
+        make_person(1, session=AG_SESSION, gender="F", grade=6),
+        make_person(3, session=AG_SESSION, gender="F", grade=7),
     ]
-    input_data = make_input([requester, p_younger, p_older], bunks, [req])
-    solver = DirectBunkingSolver(input_data, config_service=mock_config)
+    bunks = [
+        make_bunk(10, session=AG_SESSION, gender="AG", name="AG Cabin 3"),
+        make_bunk(20, session=AG_SESSION, gender="AG", name="AG Cabin 4"),
+    ]
+    solver = DirectBunkingSolver(make_input(persons, bunks, [ag_req]), config_service=mock_config)
     ctx = solver._build_solver_context()
 
-    forcing = add_age_preference_satisfaction_vars(ctx, {1: [req]})
+    forcing = add_age_preference_satisfaction_vars(ctx, {1: [ag_req]})
 
-    assert req.id in forcing
-    assert forcing[req.id] != []
-    assert req.id in ctx.request_satisfied_vars
+    assert forcing == {}
+    assert ag_req.id not in ctx.request_satisfied_vars
+
+
+def test_unsatisfied_ag_age_pref_not_flagged_material_parent_unmet(mock_config: Any) -> None:
+    """Post-solve: an AG camper whose sole MP request is an age_preference the
+    final cabin roster doesn't satisfy is deliberately unenforced — it must not
+    land in material_parent_unmet or trip mp_constraint_bug_signal."""
+    ag_req = _ag_age_req()  # camper 1 (grade 6) wants younger
+    input_data = _combined_main_ag_input([ag_req])
+    solver = DirectBunkingSolver(input_data, config_service=mock_config)
+
+    # Precondition: the AG pre-check skip classifies the request possible.
+    assert [r.id for r in solver.possible_requests.get(1, [])] == ["agr1"]
+    assert solver.impossible_requests.get(1, []) == []
+
+    # Enrollment-driven placement: camper 1 shares the AG cabin with older
+    # camper 3 (grade 7) → "younger" unsatisfied per the canonical predicate.
+    assignments = [
+        DirectBunkAssignment(person_cm_id=1, session_cm_id=AG_SESSION, bunk_cm_id=10, year=2026),
+        DirectBunkAssignment(person_cm_id=2, session_cm_id=AG_SESSION, bunk_cm_id=20, year=2026),
+        DirectBunkAssignment(person_cm_id=3, session_cm_id=AG_SESSION, bunk_cm_id=10, year=2026),
+        DirectBunkAssignment(person_cm_id=4, session_cm_id=MAIN_SESSION, bunk_cm_id=30, year=2026),
+        DirectBunkAssignment(person_cm_id=5, session_cm_id=MAIN_SESSION, bunk_cm_id=30, year=2026),
+        DirectBunkAssignment(person_cm_id=6, session_cm_id=MAIN_SESSION, bunk_cm_id=40, year=2026),
+    ]
+
+    solver._check_must_satisfy_one_violations(assignments)
+
+    material = solver.constraint_logger.violations.get("must_satisfy_one_material_parent_unmet", [])
+    assert all("(ID: 1)" not in v["details"] for v in material), (
+        f"AG camper falsely flagged material_parent_unmet: {material}"
+    )
+    assert solver.request_validation_summary["mp_constraint_bug_signal"] == 0


### PR DESCRIPTION
## Summary

Fixes #1752 — root-caused during the Group 79 triage walkthrough (camper specifics in private mirror kindred-feedback#75): a 10th grader in an **AG 9th–10th cabin-session** was flagged "Wants younger — already at youngest grade". Three agreed scope items (see issue comments):

### 1. AG-skip placement pre-checks

An AG enrollment session has exactly one cabin — there is no assignment decision — so placement-derived impossibility pre-checks don't apply. New shared helper `is_ag_session()` (mirrors the `is_ag_session_bunk` skips already in `grade_spread`/`grade_ratio`/`cabin_occupancy`), applied to:

- **`AgePreferenceImpossibility`** — the #1752 case disappears
- **`GradeCompatibilityImpossibility`** — audit finding: its "cannot co-occupy ANY bunk satisfying grade_spread + grade_adjacency" claim is **false** for same-session AG pairs, since AG bunks are exempt from both constraints

Audited the rest of the registry: `gender`/`pair_no_shared_bunk` was already AG-aware; `session_boundary`, `target_not_in_solver`, `malformed`, `self_conflict` intentionally keep firing (session-membership / data-quality facts, true regardless of cabin count).

### 2. Non-AG boundary fix

An all-same-grade pool satisfies either direction per the canonical semantics (`bunking/utils/age_preference.py`: "older" passes with no younger bunkmates, "younger" passes with no older) — the old `>=`/`<=` boundary flagged that shape as impossible. The predicate now fires only when peers exist on the wrong side and none on the requested side; the risk warning for mixed same+wrong-side pools is preserved. Detail carries both pool bounds in both branches.

### 3. Honest wording

- Modal subtext describes the session pool — "**Wants younger** — no younger peers in this session" — instead of asserting a camp-wide grade position ("already at youngest grade"), which read as false in narrow-grade sessions
- `reasonHints` action copy updated to match
- Graph legend labels cross-scope ghosts "In another bunk / unassigned" (#1746 follow-up: ghosts derive from the session graph, so a target can be unassigned)

## Test plan

TDD — all tests written and verified failing before implementation:

- `test_age_preference.py`: AG-session skip; all-same-grade pool satisfiable both directions; mixed-pool risk warning survives with both pool bounds; all-strictly-older still fires
- `test_grade_compatibility.py`: same-session AG pair with wide gap not flagged
- `PreValidationResultsModal.test.tsx`: new wording both directions; hint copy
- `BunkSocialGraphModal.test.tsx`: legend label source assertion
- Full pre-push verification green (5463 Python unit + frontend prettier/eslint/tsc/vitest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved age-preference validation so same-grade peer groups are no longer incorrectly marked impossible.
  * AG enrollment sessions now skip age/grade pre-checks, avoiding false mismatch warnings.
  * Updated on-screen messages to say “no older/younger peers in this session” and “no peers in the requested direction.”

* **Tests**
  * Expanded coverage for grade-boundary cases, AG sessions, and updated validation message wording.

* **Style**
  * Refreshed the bunk graph legend to read “In another bunk / unassigned.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->