### PR TITLE
refactor(api): use canonical status_id filter for solver attendee fetch (#1790)

### DIFF
--- a/api/services/data_fetcher.py
+++ b/api/services/data_fetcher.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from pocketbase.client import ClientResponseError  # type: ignore[attr-defined]
 
+from api.constants.filters import ACTIVE_ENROLLED_FILTER
 from api.utils.pb_error import pb_error_to_http
 from api.utils.session_metrics import get_person_from_expand, get_session_from_expand
 from bunking.direct_solver import (
@@ -65,7 +66,7 @@ async def fetch_session_data_v2(
         attendees = await asyncio.to_thread(
             client.collection("attendees").get_full_list,
             query_params={
-                "filter": f'({session_relation_filter}) && status = "enrolled" && year = {ctx.year}',
+                "filter": f"({session_relation_filter}) && {ACTIVE_ENROLLED_FILTER} && year = {ctx.year}",
                 "expand": "session",
             },
         )

--- a/tests/unit/api/test_fetch_solver_data_status_filter.py
+++ b/tests/unit/api/test_fetch_solver_data_status_filter.py
@@ -1,0 +1,51 @@
+"""fetch_solver_data must use the canonical status_id filter (#1790).
+
+The attendees table carries both `status` (select string) and `status_id`
+(number). Everywhere else keys enrollment on `status_id = 2` (CLAUDE.md
+invariant #8, shared constant ACTIVE_ENROLLED_FILTER) — the solver input
+fetch was the lone `status = "enrolled"` string read, so a string/numeric
+divergence during sync would silently give the solver a different enrolled
+set than the rest of the system. This test pins the attendees filter to the
+canonical constant.
+"""
+
+import asyncio
+from unittest.mock import Mock
+
+from api.constants.filters import ACTIVE_ENROLLED_FILTER
+from api.services import data_fetcher
+
+
+def test_attendee_fetch_uses_canonical_status_id_filter(monkeypatch):
+    captured: dict[str, dict[str, str]] = {}
+
+    def make_collection(name: str) -> Mock:
+        collection = Mock()
+
+        def get_full_list(query_params=None):
+            captured[name] = query_params or {}
+            return []
+
+        collection.get_full_list = get_full_list
+        return collection
+
+    client = Mock()
+    client.collection.side_effect = make_collection
+
+    ctx = Mock()
+    ctx.session_cm_id = 1000001
+    ctx.year = 2026
+    ctx.related_session_ids = [1000001]
+    ctx.session_relation_filter = "session.cm_id = 1000001"
+    ctx.session_id_filter = "session_id = 1000001"
+
+    async def fake_build_session_context(session_cm_id, year, pb_client):
+        return ctx
+
+    monkeypatch.setattr(data_fetcher, "build_session_context", fake_build_session_context)
+
+    asyncio.run(data_fetcher.fetch_session_data_v2(1000001, year=2026, pb_client=client))
+
+    attendees_filter = captured["attendees"]["filter"]
+    assert ACTIVE_ENROLLED_FILTER in attendees_filter
+    assert 'status = "enrolled"' not in attendees_filter


### PR DESCRIPTION
## Summary

Closes #1790 (Group 79 trailing follow-up from the PR #1792 staff investigation).

`fetch_session_data_v2` (`api/services/data_fetcher.py`) fetched enrolled attendees with the **string** filter `status = "enrolled"` — the lone string read; everywhere else keys enrollment on the canonical numeric `status_id = 2` (CLAUDE.md invariant #8) via the shared `ACTIVE_ENROLLED_FILTER` constant (`api/constants/filters.py`). Swapped to the constant.

- Explicitly **not** a staff bug: staff have no `attendees` row, so either filter excludes them
- No behavior change while `status`/`status_id` stay in sync — this removes the latent divergence risk where the solver's enrolled set could silently differ from the rest of the system

## Test plan

TDD: new `test_fetch_solver_data_status_filter.py` captures the attendees query through a mocked PB client and asserts the filter uses `ACTIVE_ENROLLED_FILTER` and not `status = "enrolled"` — verified failing before the swap. Full pre-push verification green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)