### PR TITLE
feat(sync): auto-decline stale dated staff notes (3+ years old) (#1801)

### DIFF
--- a/bunking/sync/bunk_request_processor/disposition/disposition_rules.py
+++ b/bunking/sync/bunk_request_processor/disposition/disposition_rules.py
@@ -2,10 +2,12 @@
 
 Determines RESOLVED/PENDING/DECLINED for resolved matches.
 Unresolved names (person=None or cm_id<0) are PENDING by definition
-and never reach these rules.
+and never reach these rules — with one exception: stale dated notes
+(#1801) decline even when the name is unresolved, so a 3+ year old
+note can't linger in the review queue.
 
-Rules only apply AFTER resolution (Phase 2 or Phase 3) has identified
-a candidate person. Business gates check enrollment/session.
+Otherwise rules only apply AFTER resolution (Phase 2 or Phase 3) has
+identified a candidate person. Business gates check enrollment/session.
 Resolution quality checks determine auto-resolve vs staff review.
 """
 

--- a/bunking/sync/bunk_request_processor/disposition/disposition_rules.py
+++ b/bunking/sync/bunk_request_processor/disposition/disposition_rules.py
@@ -52,6 +52,7 @@ def determine_disposition(
     session_match: bool = True,
     age_direction: str | None = None,
     auto_resolve_threshold: float = AUTO_RESOLVE_THRESHOLD,
+    is_stale_dated_note: bool = False,
 ) -> Disposition:
     """Apply priority-ordered disposition rules to a resolved match.
 
@@ -60,6 +61,12 @@ def determine_disposition(
     # Requester not attending takes priority over all other rules
     if requester_is_inactive:
         return Disposition(RequestStatus.DECLINED, "requester_not_attending", 0)
+
+    # #1801: a staff-note entry dated 3+ years before the current season is
+    # historical record, not current intent — decline across all request types.
+    # Staff can flip it back to resolved in request management if it still matters.
+    if is_stale_dated_note:
+        return Disposition(RequestStatus.DECLINED, "stale_dated_note", 9)
 
     if request_type == RequestType.AGE_PREFERENCE:
         return _age_preference_rules(age_direction)

--- a/bunking/sync/bunk_request_processor/disposition/stale_note.py
+++ b/bunking/sync/bunk_request_processor/disposition/stale_note.py
@@ -17,9 +17,17 @@ the year signal, not the ranking, was the problem.
 
 When both conventions appear, the newest year wins: a re-entered/confirmed
 old note ("2019 - ... re-confirmed (May 22 2026)") is current intent.
+
+Datestamp caveat: for bunking_notes the orchestrator strips ``STAFFNAME
+(DATETIME)`` signatures via ``parse_multi_staff_notes()`` BEFORE parsing and
+joins entries with ``" | "`` — the signatures survive only as authorship
+timestamps in ``staff_metadata``. Staleness therefore reads BOTH the text
+(entry-split year prefixes, plus any datestamps the stripper missed) and the
+``staff_metadata`` timestamps.
 """
 
 import re
+from typing import Any
 
 from ..shared.constants import NOTES_FIELDS
 
@@ -30,27 +38,63 @@ STALE_NOTE_YEARS = 3
 # Month is an alpha token so bare parenthesised numbers never match.
 _CM_DATESTAMP_RE = re.compile(r"\(\s*[A-Z][a-z]{2,8}\s+\d{1,2}\s+((?:19|20)\d{2})\s+\d{1,2}:\d{2}\s*[AP]M\s*\)")
 
-# Manual year prefix at the very start of the entry: "2019 - ..." / "2021: ...".
-# Anchored so years in prose ("class of 2019") never match.
+# Manual year prefix at the start of an entry: "2019 - ..." / "2021: ...".
+# Anchored per entry so years in prose ("class of 2019") never match.
 _YEAR_PREFIX_RE = re.compile(r"^\s*((?:19|20)\d{2})\s*[-–:]")
+
+# Entry boundaries: raw newlines (internal_notes) or the " | " separator the
+# orchestrator uses when re-joining stripped bunking_notes entries.
+_ENTRY_SPLIT_RE = re.compile(r"\n|\s\|\s")
+
+# Year inside a staff_metadata authorship timestamp, e.g. "May 22 2026  4:04PM".
+_TIMESTAMP_YEAR_RE = re.compile(r"\b((?:19|20)\d{2})\b")
 
 
 def newest_note_year(text: str) -> int | None:
     """Return the newest year detectable in *text*, or None when undated."""
-    years = [int(y) for y in _CM_DATESTAMP_RE.findall(text or "")]
-    prefix_match = _YEAR_PREFIX_RE.match(text or "")
-    if prefix_match:
-        years.append(int(prefix_match.group(1)))
+    text = text or ""
+    years = [int(y) for y in _CM_DATESTAMP_RE.findall(text)]
+    for entry in _ENTRY_SPLIT_RE.split(text):
+        prefix_match = _YEAR_PREFIX_RE.match(entry)
+        if prefix_match:
+            years.append(int(prefix_match.group(1)))
     return max(years) if years else None
 
 
-def is_stale_dated_note(source_field: str, raw_text: str, season_year: int) -> bool:
+def _staff_timestamp_years(staff_metadata: dict[str, Any] | None) -> list[int]:
+    """Years from authorship timestamps the orchestrator stripped into metadata."""
+    if not staff_metadata:
+        return []
+    timestamps = [entry.get("timestamp") for entry in staff_metadata.get("all_staff", [])]
+    if not timestamps and staff_metadata.get("timestamp"):
+        timestamps = [staff_metadata["timestamp"]]
+    years: list[int] = []
+    for ts in timestamps:
+        if ts:
+            years.extend(int(y) for y in _TIMESTAMP_YEAR_RE.findall(str(ts)))
+    return years
+
+
+def is_stale_dated_note(
+    source_field: str,
+    raw_text: str,
+    season_year: int,
+    staff_metadata: dict[str, Any] | None = None,
+) -> bool:
     """True when a staff-note entry's newest detectable year is 3+ years old.
 
     Structured fields (form, dropdown, admin UI) are current-season by
     construction and never stale; undated note entries parse normally.
+    ``staff_metadata`` carries the authorship timestamps stripped from
+    bunking_notes signatures upstream — the newest year across text and
+    timestamps wins.
     """
     if source_field not in NOTES_FIELDS:
         return False
-    year = newest_note_year(raw_text)
-    return year is not None and year <= season_year - STALE_NOTE_YEARS
+    years = _staff_timestamp_years(staff_metadata)
+    text_year = newest_note_year(raw_text)
+    if text_year is not None:
+        years.append(text_year)
+    if not years:
+        return False
+    return max(years) <= season_year - STALE_NOTE_YEARS

--- a/bunking/sync/bunk_request_processor/disposition/stale_note.py
+++ b/bunking/sync/bunk_request_processor/disposition/stale_note.py
@@ -1,0 +1,56 @@
+"""Stale dated-note detection (#1801).
+
+Staff-note fields (bunking_notes / internal_notes) are cumulative history —
+entries accumulate across seasons and carry dates in one of two forms:
+
+- CampMinder-appended entry datestamp: ``AUTHOR (Jul  4 2025  1:58PM)``
+- Manual year-prefix convention: ``2019 - Bunk with younger kids next yr``
+
+An entry whose newest detectable year is ``STALE_NOTE_YEARS``+ before the
+current season is a historical record, not current intent. The disposition
+layer auto-declines such requests (reason ``stale_dated_note``) instead of
+skipping them at parse: the request stays visible in request management,
+where staff flip it back to resolved in one click if the old note still
+matters. This deliberately does NOT touch ``SOURCE_FIELD_PRIORITY`` —
+current-season staff observations still outrank the socialize_with dropdown;
+the year signal, not the ranking, was the problem.
+
+When both conventions appear, the newest year wins: a re-entered/confirmed
+old note ("2019 - ... re-confirmed (May 22 2026)") is current intent.
+"""
+
+import re
+
+from ..shared.constants import NOTES_FIELDS
+
+# "3+ years prior to the current season" — season 2026 declines <= 2023.
+STALE_NOTE_YEARS = 3
+
+# CampMinder entry datestamp suffix, e.g. "(Jul  4 2025  1:58PM)".
+# Month is an alpha token so bare parenthesised numbers never match.
+_CM_DATESTAMP_RE = re.compile(r"\(\s*[A-Z][a-z]{2,8}\s+\d{1,2}\s+((?:19|20)\d{2})\s+\d{1,2}:\d{2}\s*[AP]M\s*\)")
+
+# Manual year prefix at the very start of the entry: "2019 - ..." / "2021: ...".
+# Anchored so years in prose ("class of 2019") never match.
+_YEAR_PREFIX_RE = re.compile(r"^\s*((?:19|20)\d{2})\s*[-–:]")
+
+
+def newest_note_year(text: str) -> int | None:
+    """Return the newest year detectable in *text*, or None when undated."""
+    years = [int(y) for y in _CM_DATESTAMP_RE.findall(text or "")]
+    prefix_match = _YEAR_PREFIX_RE.match(text or "")
+    if prefix_match:
+        years.append(int(prefix_match.group(1)))
+    return max(years) if years else None
+
+
+def is_stale_dated_note(source_field: str, raw_text: str, season_year: int) -> bool:
+    """True when a staff-note entry's newest detectable year is 3+ years old.
+
+    Structured fields (form, dropdown, admin UI) are current-season by
+    construction and never stale; undated note entries parse normally.
+    """
+    if source_field not in NOTES_FIELDS:
+        return False
+    year = newest_note_year(raw_text)
+    return year is not None and year <= season_year - STALE_NOTE_YEARS

--- a/bunking/sync/bunk_request_processor/services/request_builder.py
+++ b/bunking/sync/bunk_request_processor/services/request_builder.py
@@ -248,15 +248,22 @@ class RequestBuilder:
         Returns:
             Tuple of (status, disposition_reason). AGE_PREFERENCE routes through
             disposition rules regardless of resolution — direction alone determines
-            status (#1406). Unresolved names (other request types) return (PENDING, "").
+            status (#1406). Unresolved names (other request types) return (PENDING, ""),
+            except stale dated notes (#1801), which decline even when unresolved.
             Resolved matches go through disposition rules (business gates + quality).
         """
         age_direction = parsed_req.age_preference.value if parsed_req.age_preference else None
 
-        # #1801: staleness is deterministic on the entry text — computed before
-        # the unresolved early-return so a stale note with an unresolvable name
+        # #1801: staleness is deterministic on the entry text plus the authorship
+        # timestamps stripped into staff_metadata upstream — computed before the
+        # unresolved early-return so a stale note with an unresolvable name
         # declines instead of lingering in the review queue.
-        stale = is_stale_dated_note(parsed_req.source_field, parsed_req.raw_text, self.year)
+        stale = is_stale_dated_note(
+            parsed_req.source_field,
+            parsed_req.raw_text,
+            self.year,
+            staff_metadata=parsed_req.metadata.get("staff_metadata"),
+        )
 
         # AGE_PREFERENCE is resolution-independent: disposition_rules._age_preference_rules
         # routes by direction alone. Delegate to avoid duplicating the literals (#1411).
@@ -267,9 +274,16 @@ class RequestBuilder:
             return disposition.status, disposition.reason
 
         person_cm_id = resolution_info.get("person_cm_id")
+        conflict_type = resolution_info.get("conflict_type")
 
         if stale:
-            disposition = determine_disposition(parsed_req.request_type, is_stale_dated_note=stale)
+            # requester_not_attending has priority 0 in disposition_rules —
+            # pass it through so the stale gate can't mask it.
+            disposition = determine_disposition(
+                parsed_req.request_type,
+                requester_is_inactive=conflict_type == "requester_not_attending",
+                is_stale_dated_note=stale,
+            )
             metadata["declined_reason"] = disposition.reason
             return disposition.status, disposition.reason
 
@@ -278,8 +292,6 @@ class RequestBuilder:
             return RequestStatus.PENDING, ""
 
         # Resolved match — apply disposition rules
-        conflict_type = resolution_info.get("conflict_type")
-
         disposition = determine_disposition(
             parsed_req.request_type,
             resolution_method=resolution_info.get("resolution_method", "unknown"),

--- a/bunking/sync/bunk_request_processor/services/request_builder.py
+++ b/bunking/sync/bunk_request_processor/services/request_builder.py
@@ -15,6 +15,7 @@ from ..core.models import (
     RequestType,
 )
 from ..disposition.disposition_rules import determine_disposition
+from ..disposition.stale_note import is_stale_dated_note
 from ..processing.first_request_detector import detect_first_request
 from ..shared.constants import SourceField
 
@@ -252,13 +253,25 @@ class RequestBuilder:
         """
         age_direction = parsed_req.age_preference.value if parsed_req.age_preference else None
 
+        # #1801: staleness is deterministic on the entry text — computed before
+        # the unresolved early-return so a stale note with an unresolvable name
+        # declines instead of lingering in the review queue.
+        stale = is_stale_dated_note(parsed_req.source_field, parsed_req.raw_text, self.year)
+
         # AGE_PREFERENCE is resolution-independent: disposition_rules._age_preference_rules
         # routes by direction alone. Delegate to avoid duplicating the literals (#1411).
         if parsed_req.request_type == RequestType.AGE_PREFERENCE:
-            disposition = determine_disposition(parsed_req.request_type, age_direction=age_direction)
+            disposition = determine_disposition(
+                parsed_req.request_type, age_direction=age_direction, is_stale_dated_note=stale
+            )
             return disposition.status, disposition.reason
 
         person_cm_id = resolution_info.get("person_cm_id")
+
+        if stale:
+            disposition = determine_disposition(parsed_req.request_type, is_stale_dated_note=stale)
+            metadata["declined_reason"] = disposition.reason
+            return disposition.status, disposition.reason
 
         # Unresolved: no person ID, or negative hash-based ID for an unmatched name.
         if person_cm_id is None or person_cm_id < 0:

--- a/frontend/src/utils/dispositionColors.test.ts
+++ b/frontend/src/utils/dispositionColors.test.ts
@@ -384,3 +384,21 @@ describe('self_referential disposition reason (issue #941)', () => {
     expect(getDispositionSortRank('self_referential')).toBe(1)
   })
 })
+
+describe('stale_dated_note disposition (#1801)', () => {
+  it('renders as a declined-family badge', () => {
+    expect(getDispositionClasses('stale_dated_note')).toContain('rose')
+  })
+
+  it('has a friendly display name', () => {
+    expect(formatDispositionReason('stale_dated_note')).toBe('Stale note (3+ yrs old)')
+  })
+
+  it('shows the reason line under a Declined chip', () => {
+    expect(shouldShowReasonInStatus('declined', 'stale_dated_note')).toBe(true)
+  })
+
+  it('sorts with the declined group', () => {
+    expect(getDispositionSortRank('stale_dated_note')).toBe(0)
+  })
+})

--- a/frontend/src/utils/dispositionColors.ts
+++ b/frontend/src/utils/dispositionColors.ts
@@ -53,6 +53,7 @@ export const DECLINED_REASONS = new Set([
   'target_not_attending',
   'target_not_enrolled',
   'requester_not_attending',
+  'stale_dated_note',
 ])
 
 /** Get Tailwind classes for a disposition reason badge. */
@@ -112,6 +113,7 @@ const DISPOSITION_DISPLAY_NAMES: Record<string, string> = {
   target_not_attending: 'Not attending',
   target_not_enrolled: 'Not enrolled',
   requester_not_attending: 'Requester not attending',
+  stale_dated_note: 'Stale note (3+ yrs old)',
 }
 
 /** Format a disposition reason for display using friendly names. */

--- a/tests/unit/sync/bunk_request_processor/disposition/test_disposition_rules.py
+++ b/tests/unit/sync/bunk_request_processor/disposition/test_disposition_rules.py
@@ -1,7 +1,8 @@
 """Tests for post-resolution disposition rules.
 
 Rules only apply to resolved matches (person found). Unresolved names
-are PENDING by definition — handled upstream in request_builder.
+are PENDING by definition — handled upstream in request_builder — with
+one exception: stale dated notes (#1801) decline even when unresolved.
 """
 
 import sys

--- a/tests/unit/sync/bunk_request_processor/disposition/test_disposition_rules.py
+++ b/tests/unit/sync/bunk_request_processor/disposition/test_disposition_rules.py
@@ -270,3 +270,36 @@ class TestRequesterNotAttending:
         )
         assert d.status == RequestStatus.DECLINED
         assert d.reason == "requester_not_attending"
+
+
+class TestStaleDatedNoteGate:
+    """#1801: stale dated staff notes auto-decline across all request types."""
+
+    def test_stale_declines_age_preference(self):
+        d = determine_disposition(RequestType.AGE_PREFERENCE, age_direction="younger", is_stale_dated_note=True)
+        assert d.status == RequestStatus.DECLINED
+        assert d.reason == "stale_dated_note"
+
+    def test_stale_declines_bunk_with_even_on_exact_match(self):
+        d = determine_disposition(
+            RequestType.BUNK_WITH,
+            resolution_method="exact_match",
+            match_confidence=1.0,
+            is_stale_dated_note=True,
+        )
+        assert d.status == RequestStatus.DECLINED
+        assert d.reason == "stale_dated_note"
+
+    def test_stale_declines_not_bunk_with(self):
+        d = determine_disposition(RequestType.NOT_BUNK_WITH, match_confidence=0.95, is_stale_dated_note=True)
+        assert d.status == RequestStatus.DECLINED
+        assert d.reason == "stale_dated_note"
+
+    def test_requester_not_attending_still_wins(self):
+        d = determine_disposition(RequestType.BUNK_WITH, requester_is_inactive=True, is_stale_dated_note=True)
+        assert d.reason == "requester_not_attending"
+
+    def test_default_false_leaves_behavior_unchanged(self):
+        d = determine_disposition(RequestType.AGE_PREFERENCE, age_direction="younger", is_stale_dated_note=False)
+        assert d.status == RequestStatus.RESOLVED
+        assert d.reason == "directional_preference"

--- a/tests/unit/sync/bunk_request_processor/disposition/test_stale_note.py
+++ b/tests/unit/sync/bunk_request_processor/disposition/test_stale_note.py
@@ -10,6 +10,8 @@ Two dating conventions exist in the raw content:
 - Manual year prefix: ``2019 - Bunk with younger kids next yr``
 """
 
+from typing import Any
+
 from bunking.sync.bunk_request_processor.disposition.stale_note import (
     STALE_NOTE_YEARS,
     is_stale_dated_note,
@@ -21,7 +23,7 @@ SEASON = 2026
 
 class TestNewestNoteYear:
     def test_campminder_datestamp_suffix(self):
-        text = "Do not bunk with Liam Garcia. Really didn't get along ASHLEY COSTELLO (Jul  4 2025  1:58PM)"
+        text = "Do not bunk with Liam Garcia. Really didn't get along SAMUEL JOHNSON (Jul  4 2025  1:58PM)"
         assert newest_note_year(text) == 2025
 
     def test_manual_year_prefix(self):
@@ -31,7 +33,7 @@ class TestNewestNoteYear:
         assert newest_note_year("2021: prefers quieter cabins") == 2021
 
     def test_both_conventions_takes_newest(self):
-        text = "2019 - old context, re-confirmed SHOSHIE FLAGG (May 22 2026  4:04PM)"
+        text = "2019 - old context, re-confirmed RILEY SAM (May 22 2026  4:04PM)"
         assert newest_note_year(text) == 2026
 
     def test_multiple_datestamps_takes_newest(self):
@@ -48,6 +50,22 @@ class TestNewestNoteYear:
 
     def test_empty_and_none_safe(self):
         assert newest_note_year("") is None
+
+    def test_multi_entry_newline_takes_newest(self):
+        # internal_notes keeps raw newlines between cumulative entries — a
+        # year prefix on ANY entry must count, newest wins.
+        text = "2019 - separate from older brother\n2025 - update: now fine together"
+        assert newest_note_year(text) == 2025
+
+    def test_multi_entry_pipe_joined_takes_newest(self):
+        # bunking_notes entries are " | "-joined by the orchestrator after
+        # staff-signature stripping (orchestrator._prepare_parse_requests).
+        text = "2019 - old context | 2025 - update: fine now"
+        assert newest_note_year(text) == 2025
+
+    def test_pipe_in_prose_does_not_create_entry(self):
+        # A mid-entry year that isn't at an entry start still must not match.
+        assert newest_note_year("likes trains | class of 2019 vibes") is None
 
 
 class TestIsStaleDatedNote:
@@ -66,14 +84,99 @@ class TestIsStaleDatedNote:
         assert not is_stale_dated_note("bunking_notes", "2024 - separate from cousin", SEASON)
 
     def test_current_season_datestamp_is_not_stale(self):
-        text = "Rising 5th grade confirmed SHOSHIE FLAGG (May 22 2026  4:04PM)"
+        text = "Rising 5th grade confirmed RILEY SAM (May 22 2026  4:04PM)"
         assert not is_stale_dated_note("bunking_notes", text, SEASON)
 
     def test_undated_note_is_not_stale(self):
-        assert not is_stale_dated_note("bunking_notes", "never with Noah Williams", SEASON)
+        assert not is_stale_dated_note("bunking_notes", "never with Olivia Chen", SEASON)
 
     def test_structured_fields_never_stale(self):
         # The gate applies to cumulative staff-note fields only — a form answer
         # or dropdown is current-year by construction.
         assert not is_stale_dated_note("bunk_request_form", "2019 - Emma Johnson", SEASON)
         assert not is_stale_dated_note("socialize_with", "2019 - whatever", SEASON)
+
+
+class TestStaffMetadataYears:
+    """Production bunking_notes lose their CampMinder datestamp suffixes before
+    parsing — the orchestrator strips ``STAFFNAME (DATETIME)`` signatures into
+    staff_metadata. Staleness must read those authorship timestamps too."""
+
+    def test_current_staff_timestamp_protects_old_prefix(self):
+        # "2019 - ... re-confirmed <sig 2026>" arrives stripped; the 2026
+        # authorship timestamp lives only in staff_metadata. Newest year wins.
+        staff_metadata = {
+            "staff_name": "Riley Sam",
+            "timestamp": "May 22 2026  4:04PM",
+            "all_staff": [{"staff": "Riley Sam", "timestamp": "May 22 2026  4:04PM"}],
+        }
+        assert not is_stale_dated_note(
+            "bunking_notes", "2019 - old context, re-confirmed", SEASON, staff_metadata=staff_metadata
+        )
+
+    def test_stale_staff_timestamp_detected_without_text_year(self):
+        # Datestamp-only convention: signature stripped, no year left in text —
+        # the stale year must come from the authorship timestamp.
+        staff_metadata = {
+            "staff_name": "Samuel Johnson",
+            "timestamp": "Jun  1 2020  9:00AM",
+            "all_staff": [{"staff": "Samuel Johnson", "timestamp": "Jun  1 2020  9:00AM"}],
+        }
+        assert is_stale_dated_note(
+            "bunking_notes", "Do not bunk with Liam Garcia", SEASON, staff_metadata=staff_metadata
+        )
+
+    def test_newest_of_multiple_staff_timestamps_wins(self):
+        staff_metadata = {
+            "staff_name": "Riley Sam",
+            "timestamp": "Apr  7 2026 11:14AM",
+            "all_staff": [
+                {"staff": "Samuel Johnson", "timestamp": "Feb  8 2020  1:11PM"},
+                {"staff": "Riley Sam", "timestamp": "Apr  7 2026 11:14AM"},
+            ],
+        }
+        assert not is_stale_dated_note("bunking_notes", "note one | follow-up", SEASON, staff_metadata=staff_metadata)
+
+    def test_no_years_anywhere_is_not_stale(self):
+        assert not is_stale_dated_note(
+            "bunking_notes", "never with Olivia Chen", SEASON, staff_metadata={"all_staff": []}
+        )
+
+
+class TestProductionPipelineShape:
+    """End-to-end regression for #1804 review finding 1: run the REAL
+    orchestrator preprocessing (parse_multi_staff_notes strip + join + staff
+    metadata extraction) and assert staleness on what the pipeline actually
+    produces."""
+
+    @staticmethod
+    def _preprocess(note_text: str) -> tuple[str, dict[str, Any] | None]:
+        # Mirrors orchestrator._prepare_parse_requests for BUNKING_NOTES.
+        from bunking.sync.bunk_request_processor.services.staff_note_parser import (
+            parse_multi_staff_notes,
+        )
+
+        parsed_notes = parse_multi_staff_notes(note_text)
+        request_text = " | ".join(n["content"] for n in parsed_notes if n["content"])
+        staff_entries = [n for n in parsed_notes if n["staff"]]
+        staff_metadata = None
+        if staff_entries:
+            staff_metadata = {
+                "staff_name": staff_entries[-1]["staff"],
+                "timestamp": staff_entries[-1]["timestamp"],
+                "all_staff": [{"staff": n["staff"], "timestamp": n["timestamp"]} for n in staff_entries],
+            }
+        return request_text, staff_metadata
+
+    def test_reconfirmed_old_note_survives_stripping(self):
+        text, staff_metadata = self._preprocess("2019 - old context, re-confirmed RILEY SAM (May 22 2026  4:04PM)")
+        assert "(May 22 2026" not in text  # signature really was stripped
+        assert not is_stale_dated_note("bunking_notes", text, SEASON, staff_metadata=staff_metadata)
+
+    def test_datestamp_only_stale_note_detected_after_stripping(self):
+        text, staff_metadata = self._preprocess("Wants Emma Johnson EMMA JOHNSON (Jun  1 2020  9:00AM)")
+        assert is_stale_dated_note("bunking_notes", text, SEASON, staff_metadata=staff_metadata)
+
+    def test_second_entry_year_prefix_detected_after_join(self):
+        text, staff_metadata = self._preprocess("2019 - separate from older brother\n2025 - update: now fine together")
+        assert not is_stale_dated_note("bunking_notes", text, SEASON, staff_metadata=staff_metadata)

--- a/tests/unit/sync/bunk_request_processor/disposition/test_stale_note.py
+++ b/tests/unit/sync/bunk_request_processor/disposition/test_stale_note.py
@@ -1,0 +1,79 @@
+"""Stale dated-note detection (#1801).
+
+Staff-note fields (bunking_notes / internal_notes) are cumulative history.
+An entry whose newest detectable date is 3+ years before the current season
+must not become current-year intent — it auto-declines (visible in request
+management, one click to re-resolve) rather than silently vanishing.
+
+Two dating conventions exist in the raw content:
+- CampMinder-appended datestamp suffix: ``AUTHOR (Jul  4 2025  1:58PM)``
+- Manual year prefix: ``2019 - Bunk with younger kids next yr``
+"""
+
+from bunking.sync.bunk_request_processor.disposition.stale_note import (
+    STALE_NOTE_YEARS,
+    is_stale_dated_note,
+    newest_note_year,
+)
+
+SEASON = 2026
+
+
+class TestNewestNoteYear:
+    def test_campminder_datestamp_suffix(self):
+        text = "Do not bunk with Liam Garcia. Really didn't get along ASHLEY COSTELLO (Jul  4 2025  1:58PM)"
+        assert newest_note_year(text) == 2025
+
+    def test_manual_year_prefix(self):
+        assert newest_note_year("2019 - Bunk with younger kids next yr") == 2019
+
+    def test_year_prefix_with_colon(self):
+        assert newest_note_year("2021: prefers quieter cabins") == 2021
+
+    def test_both_conventions_takes_newest(self):
+        text = "2019 - old context, re-confirmed SHOSHIE FLAGG (May 22 2026  4:04PM)"
+        assert newest_note_year(text) == 2026
+
+    def test_multiple_datestamps_takes_newest(self):
+        text = "note one (Feb  8 2020  1:11PM) follow-up EMMA JOHNSON (Apr  7 2024 11:14AM)"
+        assert newest_note_year(text) == 2024
+
+    def test_undated_text_returns_none(self):
+        assert newest_note_year("Should not be in a bunk with Olivia Chen.") is None
+
+    def test_bare_year_mid_text_not_detected(self):
+        # A 4-digit number that is neither a prefix nor a datestamp must not
+        # count as a date — years appear in prose ("class of 2019").
+        assert newest_note_year("wants the class of 2019 cabin vibe") is None
+
+    def test_empty_and_none_safe(self):
+        assert newest_note_year("") is None
+
+
+class TestIsStaleDatedNote:
+    def test_old_prefixed_bunking_note_is_stale(self):
+        assert is_stale_dated_note("bunking_notes", "2019 - Bunk with younger kids next yr", SEASON)
+
+    def test_old_datestamped_internal_note_is_stale(self):
+        text = "keep an eye on cabin dynamics LIAM GARCIA (Jun  1 2020  9:00AM)"
+        assert is_stale_dated_note("internal_notes", text, SEASON)
+
+    def test_boundary_exactly_three_years_prior_is_stale(self):
+        assert STALE_NOTE_YEARS == 3
+        assert is_stale_dated_note("bunking_notes", "2023 - separate from cousin", SEASON)
+
+    def test_two_years_prior_is_not_stale(self):
+        assert not is_stale_dated_note("bunking_notes", "2024 - separate from cousin", SEASON)
+
+    def test_current_season_datestamp_is_not_stale(self):
+        text = "Rising 5th grade confirmed SHOSHIE FLAGG (May 22 2026  4:04PM)"
+        assert not is_stale_dated_note("bunking_notes", text, SEASON)
+
+    def test_undated_note_is_not_stale(self):
+        assert not is_stale_dated_note("bunking_notes", "never with Noah Williams", SEASON)
+
+    def test_structured_fields_never_stale(self):
+        # The gate applies to cumulative staff-note fields only — a form answer
+        # or dropdown is current-year by construction.
+        assert not is_stale_dated_note("bunk_request_form", "2019 - Emma Johnson", SEASON)
+        assert not is_stale_dated_note("socialize_with", "2019 - whatever", SEASON)

--- a/tests/unit/sync/bunk_request_processor/services/test_request_builder_services.py
+++ b/tests/unit/sync/bunk_request_processor/services/test_request_builder_services.py
@@ -815,3 +815,59 @@ class TestBuilderPlaceholderInvariant:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestStaleDatedNoteStatus:
+    """#1801: determine_request_status auto-declines stale dated staff notes."""
+
+    @pytest.fixture
+    def builder(self) -> RequestBuilder:
+        return RequestBuilder(
+            temporal_name_cache=None,
+            year=2026,
+            auto_resolve_threshold=0.85,
+        )
+
+    def _parsed(self, **overrides: Any) -> ParsedRequest:
+        base: dict[str, Any] = {
+            "raw_text": "2019 - Bunk with younger kids next yr",
+            "target_name": None,
+            "request_type": RequestType.AGE_PREFERENCE,
+            "age_preference": AgePreference.YOUNGER,
+            "confidence": 0.9,
+            "source_field": "bunking_notes",
+            "csv_position": 1,
+            "metadata": {},
+            "notes": None,
+        }
+        base.update(overrides)
+        return ParsedRequest(**base)
+
+    def test_stale_prefixed_age_preference_declines(self, builder: RequestBuilder) -> None:
+        status, reason = builder.determine_request_status(self._parsed(), {}, {})
+        assert status == RequestStatus.DECLINED
+        assert reason == "stale_dated_note"
+
+    def test_stale_datestamped_bunk_with_declines(self, builder: RequestBuilder) -> None:
+        parsed = self._parsed(
+            raw_text="Wants Emma Johnson EMMA JOHNSON (Jun  1 2020  9:00AM)",
+            target_name="Emma Johnson",
+            request_type=RequestType.BUNK_WITH,
+            age_preference=None,
+        )
+        resolution = {"person_cm_id": 12345, "resolution_method": "exact_match", "confidence": 1.0}
+        status, reason = builder.determine_request_status(parsed, resolution, {})
+        assert status == RequestStatus.DECLINED
+        assert reason == "stale_dated_note"
+
+    def test_recent_dated_note_unaffected(self, builder: RequestBuilder) -> None:
+        parsed = self._parsed(raw_text="2025 - Bunk with younger kids")
+        status, reason = builder.determine_request_status(parsed, {}, {})
+        assert status == RequestStatus.RESOLVED
+        assert reason == "directional_preference"
+
+    def test_structured_source_field_unaffected(self, builder: RequestBuilder) -> None:
+        parsed = self._parsed(source_field="socialize_with")
+        status, reason = builder.determine_request_status(parsed, {}, {})
+        assert status == RequestStatus.RESOLVED
+        assert reason == "directional_preference"

--- a/tests/unit/sync/bunk_request_processor/services/test_request_builder_services.py
+++ b/tests/unit/sync/bunk_request_processor/services/test_request_builder_services.py
@@ -871,3 +871,61 @@ class TestStaleDatedNoteStatus:
         status, reason = builder.determine_request_status(parsed, {}, {})
         assert status == RequestStatus.RESOLVED
         assert reason == "directional_preference"
+
+    def test_requester_not_attending_beats_stale_note(self, builder: RequestBuilder) -> None:
+        # disposition_rules gives requester_not_attending priority 0 — the
+        # stale gate must not mask it at the builder level (#1804 review).
+        parsed = self._parsed(
+            raw_text="2019 - Bunk with younger kids next yr",
+            target_name="Emma Johnson",
+            request_type=RequestType.BUNK_WITH,
+            age_preference=None,
+        )
+        resolution = {
+            "person_cm_id": 12345,
+            "resolution_method": "exact_match",
+            "confidence": 1.0,
+            "conflict_type": "requester_not_attending",
+        }
+        status, reason = builder.determine_request_status(parsed, resolution, {})
+        assert status == RequestStatus.DECLINED
+        assert reason == "requester_not_attending"
+
+    def test_staff_metadata_current_timestamp_not_stale(self, builder: RequestBuilder) -> None:
+        # Production bunking_notes arrive datestamp-stripped; the current-year
+        # authorship timestamp lives in metadata["staff_metadata"] and must
+        # protect an old year prefix from the stale gate (#1804 review).
+        parsed = self._parsed(
+            raw_text="2019 - old context, re-confirmed",
+            metadata={
+                "staff_metadata": {
+                    "staff_name": "Riley Sam",
+                    "timestamp": "May 22 2026  4:04PM",
+                    "all_staff": [{"staff": "Riley Sam", "timestamp": "May 22 2026  4:04PM"}],
+                }
+            },
+        )
+        status, reason = builder.determine_request_status(parsed, {}, {})
+        assert status == RequestStatus.RESOLVED
+        assert reason == "directional_preference"
+
+    def test_staff_metadata_stale_timestamp_declines(self, builder: RequestBuilder) -> None:
+        # Datestamp-only convention: no year survives in the stripped text —
+        # staleness must come from the authorship timestamp.
+        parsed = self._parsed(
+            raw_text="Wants Emma Johnson",
+            target_name="Emma Johnson",
+            request_type=RequestType.BUNK_WITH,
+            age_preference=None,
+            metadata={
+                "staff_metadata": {
+                    "staff_name": "Samuel Johnson",
+                    "timestamp": "Jun  1 2020  9:00AM",
+                    "all_staff": [{"staff": "Samuel Johnson", "timestamp": "Jun  1 2020  9:00AM"}],
+                }
+            },
+        )
+        resolution = {"person_cm_id": 12345, "resolution_method": "exact_match", "confidence": 1.0}
+        status, reason = builder.determine_request_status(parsed, resolution, {})
+        assert status == RequestStatus.DECLINED
+        assert reason == "stale_dated_note"


### PR DESCRIPTION
## Summary

Closes #1801 — implements the decision recorded on the issue (staff visibility over silent skipping; camper specifics in private mirror kindred-feedback#75).

Staff-note fields (`bunking_notes`/`internal_notes`) are cumulative history. CampMinder datestamps each entry (`AUTHOR (Jul  4 2025  1:58PM)`), and older entries carry a manual `"2019 - "` year prefix. An entry whose **newest** detectable year is **3+ years before the current season** was still being parsed into active current-year requests — and `SOURCE_FIELD_PRIORITY` (correctly) ranks staff observations above the `socialize_with` dropdown, so a 2019 note beat a 2026 form answer.

### What it does

- **New deterministic detector** `disposition/stale_note.py`: `newest_note_year()` reads both dating conventions (anchored/structured regexes — years in prose like "class of 2019" never match; newest year wins so a re-confirmed old note stays current); `is_stale_dated_note()` gates on `NOTES_FIELDS` only.
- **Top-precedence disposition rule**: stale → `DECLINED` / `stale_dated_note`, across all request types (only `requester_not_attending` outranks it). Wired in `determine_request_status` **before** the unresolved early-return, so a stale note with an unresolvable name declines instead of lingering in the review queue.
- **Staff visibility preserved**: the request row exists, shows in the request-management tab with a "Stale note (3+ yrs old)" declined badge (`dispositionColors.ts`), and staff can flip it back to resolved in one click — matching the cross-session auto-DECLINE precedent.
- **Deliberately untouched**: `SOURCE_FIELD_PRIORITY`; the AI temporal-supersession filter (same-note "changed minds" conflicts); the Stage 3a same-year direction-conflict both-survive design.

Blast radius in the 2026 data: 6 requests from two notes (a 2018 family note and the 2019 "next yr" note behind #1752's stale "wants younger").

## Test plan

TDD — all written and verified failing first:
- `test_stale_note.py` (14): both dating conventions, newest-wins, prose-year non-matches, boundary (season−3 stale, season−2 not), structured-field exemption
- `test_disposition_rules.py` (+5): gate across all three request types, priority vs `requester_not_attending`, default-off behavior unchanged
- `test_request_builder_services.py` (+4): end-to-end status wiring incl. resolved bunk_with and unaffected recent/structured cases
- `dispositionColors.test.ts` (+4): badge family, label, reason line, sort rank
- Full pre-push verification green (5,476 Python unit + prettier/eslint/tsc/vitest/mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic handling for stale, date-stamped staff notes, including detection of older note years and a clear declined outcome when notes are too old.
  * Updated the app to show a friendly “Stale note (3+ yrs old)” label and proper declined styling for this reason.

* **Bug Fixes**
  * Stale notes are now declined consistently across request types, while newer notes and structured fields continue to behave as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->