### PR TITLE
refactor(sync): formalize duplicate RequestType enums (#1314)

### DIFF
--- a/bunking/models.py
+++ b/bunking/models.py
@@ -6,6 +6,17 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_seriali
 
 
 class RequestType(Enum):
+    """Types of bunk requests (solver/scenario layer).
+
+    Deliberately duplicated with
+    ``bunking.sync.bunk_request_processor.core.models.RequestType``: the sync
+    pipeline's domain core is kept free of this Pydantic-adjacent module, so the
+    two enums are separate by design rather than accident. They must stay in
+    lockstep — the value that crosses the layer boundary is the string, not the
+    class. ``tests/unit/sync/bunk_request_processor/core/test_request_type_contract.py``
+    fails CI if the members or base class drift; add new members to both sides.
+    """
+
     BUNK_WITH = "bunk_with"
     NOT_BUNK_WITH = "not_bunk_with"
     AGE_PREFERENCE = "age_preference"

--- a/bunking/sync/bunk_request_processor/core/models.py
+++ b/bunking/sync/bunk_request_processor/core/models.py
@@ -19,7 +19,15 @@ from ..shared.constants import (
 
 
 class RequestType(Enum):
-    """Types of bunk requests"""
+    """Types of bunk requests (sync-pipeline domain layer).
+
+    Deliberately duplicated with ``bunking.models.RequestType``: this domain
+    core stays free of upstream (solver/Pydantic) dependencies, so the enum is
+    redefined here rather than imported. The two must stay in lockstep — the
+    value that crosses the layer boundary is the string, not the class.
+    ``tests/unit/sync/bunk_request_processor/core/test_request_type_contract.py``
+    fails CI if the members or base class drift; add new members to both sides.
+    """
 
     BUNK_WITH = "bunk_with"
     NOT_BUNK_WITH = "not_bunk_with"


### PR DESCRIPTION
## What

Resolves the consolidate-vs-formalize decision in #1314 in favor of **formalizing** the intentional duplication of the two `RequestType` enums.

- `bunking/models.py` — solver/scenario layer (Pydantic-adjacent)
- `bunking/sync/bunk_request_processor/core/models.py` — sync-pipeline domain core (deliberately dependency-free)

Both hold the same three members. They're separate **by design**: the sync domain layer is a hexagonal boundary that must not pull in solver/Pydantic dependencies. Consolidating to a shared module would erode that boundary purely to DRY up three stable string members that have never drifted.

## Change

Documentation only — no behavior change. Adds a docstring at each `RequestType` definition explaining the deliberate duplication, cross-referencing the other enum, and pointing at the existing contract test.

The enforcement mechanism already exists: `tests/unit/sync/bunk_request_processor/core/test_request_type_contract.py` (from #1246) fails CI if the members or base class drift. This PR makes the *decision* explicit at the code so it isn't re-litigated.

## Why not consolidate

Three stable members, zero drift in the project's history, drift already a hard CI failure. Option A (shared module) spends a new module + cross-layer imports for negligible DRY benefit. Revisit A only if the enum grows past ~5 members or a third consumer appears.

## Verification

- `ruff format --check` / `ruff check` — clean
- `mypy` — 776 source files, no issues
- Contract test passes; full mockable pre-push suite green (5620 passed)

Closes #1314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer notes about a shared request-type list used across parts of the system.
  * Documented that these values must stay aligned, helping prevent mismatches between workflows.
  * Clarified that automated checks will flag any drift early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->