### PR TITLE
fix(rbac): decode JSON config metadata + correct the config-write category guard (#1732)

### DIFF
--- a/pocketbase/rbac/hooks.go
+++ b/pocketbase/rbac/hooks.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tools/types"
 )
 
 // flattenPermissions takes permission arrays from multiple roles,
@@ -80,29 +81,35 @@ func recomputeUserPermissions(app *pocketbase.PocketBase, userID string) error {
 
 const permRegistrationManage = "registration.manage"
 
-// extractBusinessCategory extracts metadata.business_category from a raw value.
-// PocketBase decodes JSON fields into map[string]any, so a direct assertion suffices.
+// extractBusinessCategory reads metadata.business_category from a raw config
+// metadata value. The representation differs by source: Record.Get on a json
+// field returns a types.JSONRaw ([]byte), while a parsed request body yields a
+// map[string]any — handle both. Returns "" if the value is absent, unparseable,
+// or has no business_category key.
 func extractBusinessCategory(raw any) string {
-	cat, _ := extractBusinessCategoryWithPresence(raw)
+	var m map[string]any
+	switch v := raw.(type) {
+	case map[string]any:
+		m = v
+	case types.JSONRaw:
+		if len(v) == 0 {
+			return ""
+		}
+		if err := json.Unmarshal(v, &m); err != nil {
+			return ""
+		}
+	case []byte:
+		if len(v) == 0 {
+			return ""
+		}
+		if err := json.Unmarshal(v, &m); err != nil {
+			return ""
+		}
+	default:
+		return ""
+	}
+	cat, _ := m["business_category"].(string)
 	return cat
-}
-
-// extractBusinessCategoryWithPresence extracts metadata.business_category from a
-// raw value and reports whether the business_category key was present at all.
-// The presence flag lets the write policy tell an explicit empty string
-// (business_category: "", a category mutation) apart from a true omission
-// (the key absent, leaving the category untouched).
-func extractBusinessCategoryWithPresence(raw any) (string, bool) {
-	m, ok := raw.(map[string]any)
-	if !ok {
-		return "", false
-	}
-	v, present := m["business_category"]
-	if !present {
-		return "", false
-	}
-	cat, _ := v.(string)
-	return cat, present
 }
 
 // configWriteDecision is the authorization outcome for a config write, extracted
@@ -119,14 +126,19 @@ const (
 // decideConfigWrite is the pure authorization policy for a config write.
 //
 // Superusers (PocketBase _/ admin dashboard) and admins bypass every check.
-// Non-admins need registration.manage AND may only touch registration-category
-// configs — both on the existing record and in the incoming body (newCategory),
-// the latter preventing category mutation. newCategory == "" means the body did
-// not change the category.
+// A non-admin needs registration.manage AND may only write registration-category
+// configs, enforced on two categories:
+//   - originalCategory — the STORED value. For updates it must be "registration",
+//     so a non-admin can't edit a solver config (or relabel one to "registration"
+//     in the same write to gain access). Empty/ignored for creates.
+//   - resultCategory — the value that will be SAVED (post-body). It must be
+//     "registration" in all cases, so the config can't be moved out of the
+//     registration bucket by setting another category, blanking it, or dropping
+//     the metadata key.
 func decideConfigWrite(
 	isSuperuser, isAdmin, hasRegistrationManage bool,
-	existingCategory, newCategory string,
-	newCategoryProvided, bodyReadable bool,
+	originalCategory, resultCategory string,
+	isCreate bool,
 ) configWriteDecision {
 	if isSuperuser || isAdmin {
 		return configWriteAllow
@@ -134,58 +146,50 @@ func decideConfigWrite(
 	if !hasRegistrationManage {
 		return configWriteDenyMissingPermission
 	}
-	if !isRegistrationConfig(existingCategory) {
+	// Eligibility (updates only): the stored row must already be a registration
+	// config. Creates have no stored row, so this is governed by the result check.
+	if !isCreate && !isRegistrationConfig(originalCategory) {
 		return configWriteDenyWrongCategory
 	}
-	// Fail closed: if the request body couldn't be read we can't verify the
-	// write isn't mutating the category, so deny it for this non-admin user.
-	if !bodyReadable {
-		return configWriteDenyCategoryMutation
-	}
-	// An explicitly provided category that isn't "registration" is a mutation
-	// away from the registration bucket. newCategoryProvided distinguishes an
-	// explicit blanking (business_category: "", denied) from a true omission
-	// (key absent, category left untouched, allowed) — the empty string alone
-	// can't tell those apart, which was the #1732 fail-open.
-	if newCategoryProvided && !isRegistrationConfig(newCategory) {
+	// The resulting row must remain (or, for creates, be) a registration config.
+	if !isRegistrationConfig(resultCategory) {
+		if isCreate {
+			return configWriteDenyWrongCategory
+		}
 		return configWriteDenyCategoryMutation
 	}
 	return configWriteAllow
 }
 
-// guardConfigWrite ensures non-admin users can only write registration-category configs.
-// Superusers and admin users bypass this check (they can write any config).
-// Non-admin users with registration.manage can only write configs where
-// metadata.business_category is "registration" — both on the existing record
-// AND in the incoming request body (to prevent category mutation).
-func guardConfigWrite(e *core.RecordRequestEvent) error {
+// guardConfigWrite ensures non-admin users can only write registration-category
+// configs. Superusers and admin users bypass this check (they can write any
+// config). Non-admin users with registration.manage can only write configs whose
+// metadata.business_category is "registration" — evaluated on the stored record
+// (eligibility) and on the resulting post-body record (to prevent category
+// mutation). isCreate is true for OnRecordCreateRequest, where there is no stored
+// record yet.
+//
+// e.Record already has the request body applied (PocketBase's form.Load runs
+// before this request hook), so e.Record.Get reads the resulting state that will
+// be saved, and e.Record.Original() reads the untouched stored state.
+func guardConfigWrite(e *core.RecordRequestEvent, isCreate bool) error {
 	if e.Auth == nil {
 		return apis.NewUnauthorizedError("Authentication required", nil)
 	}
 
-	// Pull the incoming body's business_category (if any) to detect mutation.
-	// bodyReadable stays false if RequestInfo() errors, so a non-admin write we
-	// can't inspect fails closed rather than silently skipping the mutation check.
-	newCategory := ""
-	newCategoryProvided := false
-	bodyReadable := false
-	if info, err := e.RequestInfo(); err == nil && info != nil {
-		bodyReadable = true
-		if info.Body != nil {
-			if newMeta, ok := info.Body["metadata"]; ok {
-				newCategory, newCategoryProvided = extractBusinessCategoryWithPresence(newMeta)
-			}
-		}
+	originalCategory := ""
+	if !isCreate {
+		originalCategory = extractBusinessCategory(e.Record.Original().Get("metadata"))
 	}
+	resultCategory := extractBusinessCategory(e.Record.Get("metadata"))
 
 	switch decideConfigWrite(
 		e.Auth.IsSuperuser(),
 		e.Auth.GetBool("is_admin"),
 		slices.Contains(e.Auth.GetStringSlice("cached_permissions"), permRegistrationManage),
-		extractBusinessCategory(e.Record.Get("metadata")),
-		newCategory,
-		newCategoryProvided,
-		bodyReadable,
+		originalCategory,
+		resultCategory,
+		isCreate,
 	) {
 	case configWriteDenyMissingPermission:
 		return apis.NewForbiddenError("Missing registration.manage permission", nil)
@@ -242,8 +246,12 @@ func RegisterHooks(app *pocketbase.PocketBase) {
 
 	// Guard config writes: non-admin users with registration.manage can only
 	// write to configs with business_category = "registration"
-	app.OnRecordCreateRequest("config").BindFunc(guardConfigWrite)
-	app.OnRecordUpdateRequest("config").BindFunc(guardConfigWrite)
+	app.OnRecordCreateRequest("config").BindFunc(func(e *core.RecordRequestEvent) error {
+		return guardConfigWrite(e, true)
+	})
+	app.OnRecordUpdateRequest("config").BindFunc(func(e *core.RecordRequestEvent) error {
+		return guardConfigWrite(e, false)
+	})
 
 	// Invalidate FastAPI metrics cache when registration config changes
 	registerConfigHooks(app)

--- a/pocketbase/rbac/hooks.go
+++ b/pocketbase/rbac/hooks.go
@@ -83,12 +83,26 @@ const permRegistrationManage = "registration.manage"
 // extractBusinessCategory extracts metadata.business_category from a raw value.
 // PocketBase decodes JSON fields into map[string]any, so a direct assertion suffices.
 func extractBusinessCategory(raw any) string {
+	cat, _ := extractBusinessCategoryWithPresence(raw)
+	return cat
+}
+
+// extractBusinessCategoryWithPresence extracts metadata.business_category from a
+// raw value and reports whether the business_category key was present at all.
+// The presence flag lets the write policy tell an explicit empty string
+// (business_category: "", a category mutation) apart from a true omission
+// (the key absent, leaving the category untouched).
+func extractBusinessCategoryWithPresence(raw any) (string, bool) {
 	m, ok := raw.(map[string]any)
 	if !ok {
-		return ""
+		return "", false
 	}
-	cat, _ := m["business_category"].(string)
-	return cat
+	v, present := m["business_category"]
+	if !present {
+		return "", false
+	}
+	cat, _ := v.(string)
+	return cat, present
 }
 
 // configWriteDecision is the authorization outcome for a config write, extracted
@@ -112,6 +126,7 @@ const (
 func decideConfigWrite(
 	isSuperuser, isAdmin, hasRegistrationManage bool,
 	existingCategory, newCategory string,
+	newCategoryProvided, bodyReadable bool,
 ) configWriteDecision {
 	if isSuperuser || isAdmin {
 		return configWriteAllow
@@ -122,7 +137,17 @@ func decideConfigWrite(
 	if !isRegistrationConfig(existingCategory) {
 		return configWriteDenyWrongCategory
 	}
-	if newCategory != "" && !isRegistrationConfig(newCategory) {
+	// Fail closed: if the request body couldn't be read we can't verify the
+	// write isn't mutating the category, so deny it for this non-admin user.
+	if !bodyReadable {
+		return configWriteDenyCategoryMutation
+	}
+	// An explicitly provided category that isn't "registration" is a mutation
+	// away from the registration bucket. newCategoryProvided distinguishes an
+	// explicit blanking (business_category: "", denied) from a true omission
+	// (key absent, category left untouched, allowed) — the empty string alone
+	// can't tell those apart, which was the #1732 fail-open.
+	if newCategoryProvided && !isRegistrationConfig(newCategory) {
 		return configWriteDenyCategoryMutation
 	}
 	return configWriteAllow
@@ -139,10 +164,17 @@ func guardConfigWrite(e *core.RecordRequestEvent) error {
 	}
 
 	// Pull the incoming body's business_category (if any) to detect mutation.
+	// bodyReadable stays false if RequestInfo() errors, so a non-admin write we
+	// can't inspect fails closed rather than silently skipping the mutation check.
 	newCategory := ""
-	if info, err := e.RequestInfo(); err == nil && info != nil && info.Body != nil {
-		if newMeta, ok := info.Body["metadata"]; ok {
-			newCategory = extractBusinessCategory(newMeta)
+	newCategoryProvided := false
+	bodyReadable := false
+	if info, err := e.RequestInfo(); err == nil && info != nil {
+		bodyReadable = true
+		if info.Body != nil {
+			if newMeta, ok := info.Body["metadata"]; ok {
+				newCategory, newCategoryProvided = extractBusinessCategoryWithPresence(newMeta)
+			}
 		}
 	}
 
@@ -152,6 +184,8 @@ func guardConfigWrite(e *core.RecordRequestEvent) error {
 		slices.Contains(e.Auth.GetStringSlice("cached_permissions"), permRegistrationManage),
 		extractBusinessCategory(e.Record.Get("metadata")),
 		newCategory,
+		newCategoryProvided,
+		bodyReadable,
 	) {
 	case configWriteDenyMissingPermission:
 		return apis.NewForbiddenError("Missing registration.manage permission", nil)

--- a/pocketbase/rbac/hooks_test.go
+++ b/pocketbase/rbac/hooks_test.go
@@ -2,7 +2,50 @@ package rbac
 
 import (
 	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
 )
+
+// TestExtractBusinessCategoryReadsRealRecordMetadata exercises the runtime path
+// the pure decideConfigWrite tests bypass: reading metadata.business_category off
+// an actual *core.Record. Record.Get on a json field returns types.JSONRaw
+// ([]byte), NOT a map[string]any — the original extractBusinessCategory asserted
+// map[string]any and silently returned "", which made guardConfigWrite deny
+// EVERY non-admin config write (existingCategory was always ""). This test locks
+// in that extractBusinessCategory decodes the real stored/post-body value.
+func TestExtractBusinessCategoryReadsRealRecordMetadata(t *testing.T) {
+	collection := core.NewBaseCollection("config")
+	collection.Fields.Add(&core.JSONField{Name: "metadata"})
+
+	newRecordWithMetadata := func(meta any) *core.Record {
+		rec := core.NewRecord(collection)
+		rec.Set("metadata", meta)
+		return rec
+	}
+
+	cases := []struct {
+		name string
+		meta any
+		want string
+	}{
+		{"json object with category", map[string]any{"business_category": "registration"}, "registration"},
+		{"json object without category key", map[string]any{"friendly_name": "x"}, ""},
+		{"empty metadata", map[string]any{}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := newRecordWithMetadata(tc.meta)
+			if got := extractBusinessCategory(rec.Get("metadata")); got != tc.want {
+				t.Fatalf("extractBusinessCategory(record.Get(%q)) = %q, want %q", "metadata", got, tc.want)
+			}
+		})
+	}
+
+	// The decoded-map path (e.g. a request body value) must still work.
+	if got := extractBusinessCategory(map[string]any{"business_category": "solver"}); got != "solver" {
+		t.Fatalf("extractBusinessCategory(map) = %q, want %q", got, "solver")
+	}
+}
 
 func TestDecideConfigWrite(t *testing.T) {
 	tests := []struct {
@@ -10,110 +53,93 @@ func TestDecideConfigWrite(t *testing.T) {
 		isSuperuser           bool
 		isAdmin               bool
 		hasRegistrationManage bool
-		existingCategory      string
-		newCategory           string
-		newCategoryProvided   bool
-		bodyReadable          bool
+		originalCategory      string // stored category (empty for creates)
+		resultCategory        string // post-body category that will be saved
+		isCreate              bool
 		want                  configWriteDecision
 	}{
 		{
 			// Regression: a PocketBase superuser writing config via the _/ admin
 			// dashboard has neither is_admin nor cached_permissions, so without an
 			// explicit bypass it was wrongly denied "Missing registration.manage".
-			name:         "superuser bypasses all checks",
-			isSuperuser:  true,
-			bodyReadable: true,
-			want:         configWriteAllow,
+			name:        "superuser bypasses all checks",
+			isSuperuser: true,
+			want:        configWriteAllow,
 		},
 		{
-			name:             "superuser without admin/permission on a solver config is still allowed",
-			isSuperuser:      true,
-			existingCategory: "solver",
-			bodyReadable:     true,
-			want:             configWriteAllow,
-		},
-		{
-			name:             "admin bypasses all checks",
+			name:             "admin bypasses all checks on a solver config",
 			isAdmin:          true,
-			existingCategory: "solver",
-			bodyReadable:     true,
+			originalCategory: "solver",
+			resultCategory:   "solver",
 			want:             configWriteAllow,
-		},
-		{
-			// Admins bypass before the fail-closed body check, so an unreadable
-			// body must not affect them.
-			name:         "admin allowed even when request body is unreadable",
-			isAdmin:      true,
-			bodyReadable: false,
-			want:         configWriteAllow,
 		},
 		{
 			name:             "non-admin without registration.manage is denied",
-			existingCategory: "registration",
-			bodyReadable:     true,
+			originalCategory: "registration",
+			resultCategory:   "registration",
 			want:             configWriteDenyMissingPermission,
 		},
 		{
-			name:                  "registration.manage on a registration config is allowed",
+			name:                  "registration.manage editing a registration config is allowed",
 			hasRegistrationManage: true,
-			existingCategory:      "registration",
-			bodyReadable:          true,
+			originalCategory:      "registration",
+			resultCategory:        "registration",
 			want:                  configWriteAllow,
 		},
 		{
-			name:                  "registration.manage on a non-registration config is denied",
+			// Eligibility: the STORED category must be registration. Reading the
+			// original (not the post-body) value blocks relabelling a solver
+			// config to "registration" in the same PATCH to gain edit access.
+			name:                  "registration.manage editing a solver config is denied",
 			hasRegistrationManage: true,
-			existingCategory:      "solver",
-			bodyReadable:          true,
+			originalCategory:      "solver",
+			resultCategory:        "solver",
 			want:                  configWriteDenyWrongCategory,
 		},
 		{
-			name:                  "registration.manage mutating category is denied",
+			name:                  "registration.manage relabelling a solver config to registration is denied",
 			hasRegistrationManage: true,
-			existingCategory:      "registration",
-			newCategory:           "solver",
-			newCategoryProvided:   true,
-			bodyReadable:          true,
+			originalCategory:      "solver",
+			resultCategory:        "registration",
+			want:                  configWriteDenyWrongCategory,
+		},
+		{
+			name:                  "registration.manage mutating category to solver is denied",
+			hasRegistrationManage: true,
+			originalCategory:      "registration",
+			resultCategory:        "solver",
 			want:                  configWriteDenyCategoryMutation,
 		},
 		{
-			name:                  "registration.manage same-category update is allowed",
+			// #1732: blanking the category — whether by sending business_category:""
+			// or by omitting it under json-replace semantics — yields an empty
+			// resulting category and must be denied.
+			name:                  "registration.manage blanking category is denied",
 			hasRegistrationManage: true,
-			existingCategory:      "registration",
-			newCategory:           "registration",
-			newCategoryProvided:   true,
-			bodyReadable:          true,
+			originalCategory:      "registration",
+			resultCategory:        "",
+			want:                  configWriteDenyCategoryMutation,
+		},
+		{
+			name:                  "registration.manage creating a registration config is allowed",
+			hasRegistrationManage: true,
+			resultCategory:        "registration",
+			isCreate:              true,
 			want:                  configWriteAllow,
 		},
 		{
-			// #1732: an explicit business_category:"" is a mutation away from
-			// "registration" and must be denied, not silently allowed.
-			name:                  "registration.manage blanking category (explicit empty) is denied",
+			name:                  "registration.manage creating a solver config is denied",
 			hasRegistrationManage: true,
-			existingCategory:      "registration",
-			newCategory:           "",
-			newCategoryProvided:   true,
-			bodyReadable:          true,
-			want:                  configWriteDenyCategoryMutation,
+			resultCategory:        "solver",
+			isCreate:              true,
+			want:                  configWriteDenyWrongCategory,
 		},
 		{
-			// A true omission (no business_category in the body) leaves the
-			// category untouched and stays allowed.
-			name:                  "registration.manage omitting category is allowed",
+			name:                  "registration.manage creating a category-less config is denied",
 			hasRegistrationManage: true,
-			existingCategory:      "registration",
-			newCategoryProvided:   false,
-			bodyReadable:          true,
-			want:                  configWriteAllow,
-		},
-		{
-			// #1732: if the request body can't be read we cannot verify the write
-			// isn't mutating the category, so a non-admin write fails closed.
-			name:                  "registration.manage with unreadable body is denied (fail closed)",
-			hasRegistrationManage: true,
-			existingCategory:      "registration",
-			bodyReadable:          false,
-			want:                  configWriteDenyCategoryMutation,
+			resultCategory:        "",
+			isCreate:              true,
+			want:                  configWriteDenyWrongCategory,
 		},
 	}
 
@@ -123,10 +149,9 @@ func TestDecideConfigWrite(t *testing.T) {
 				tt.isSuperuser,
 				tt.isAdmin,
 				tt.hasRegistrationManage,
-				tt.existingCategory,
-				tt.newCategory,
-				tt.newCategoryProvided,
-				tt.bodyReadable,
+				tt.originalCategory,
+				tt.resultCategory,
+				tt.isCreate,
 			)
 			if got != tt.want {
 				t.Errorf("decideConfigWrite() = %v, want %v", got, tt.want)

--- a/pocketbase/rbac/hooks_test.go
+++ b/pocketbase/rbac/hooks_test.go
@@ -12,43 +12,59 @@ func TestDecideConfigWrite(t *testing.T) {
 		hasRegistrationManage bool
 		existingCategory      string
 		newCategory           string
+		newCategoryProvided   bool
+		bodyReadable          bool
 		want                  configWriteDecision
 	}{
 		{
 			// Regression: a PocketBase superuser writing config via the _/ admin
 			// dashboard has neither is_admin nor cached_permissions, so without an
 			// explicit bypass it was wrongly denied "Missing registration.manage".
-			name:        "superuser bypasses all checks",
-			isSuperuser: true,
-			want:        configWriteAllow,
+			name:         "superuser bypasses all checks",
+			isSuperuser:  true,
+			bodyReadable: true,
+			want:         configWriteAllow,
 		},
 		{
 			name:             "superuser without admin/permission on a solver config is still allowed",
 			isSuperuser:      true,
 			existingCategory: "solver",
+			bodyReadable:     true,
 			want:             configWriteAllow,
 		},
 		{
 			name:             "admin bypasses all checks",
 			isAdmin:          true,
 			existingCategory: "solver",
+			bodyReadable:     true,
 			want:             configWriteAllow,
+		},
+		{
+			// Admins bypass before the fail-closed body check, so an unreadable
+			// body must not affect them.
+			name:         "admin allowed even when request body is unreadable",
+			isAdmin:      true,
+			bodyReadable: false,
+			want:         configWriteAllow,
 		},
 		{
 			name:             "non-admin without registration.manage is denied",
 			existingCategory: "registration",
+			bodyReadable:     true,
 			want:             configWriteDenyMissingPermission,
 		},
 		{
 			name:                  "registration.manage on a registration config is allowed",
 			hasRegistrationManage: true,
 			existingCategory:      "registration",
+			bodyReadable:          true,
 			want:                  configWriteAllow,
 		},
 		{
 			name:                  "registration.manage on a non-registration config is denied",
 			hasRegistrationManage: true,
 			existingCategory:      "solver",
+			bodyReadable:          true,
 			want:                  configWriteDenyWrongCategory,
 		},
 		{
@@ -56,6 +72,8 @@ func TestDecideConfigWrite(t *testing.T) {
 			hasRegistrationManage: true,
 			existingCategory:      "registration",
 			newCategory:           "solver",
+			newCategoryProvided:   true,
+			bodyReadable:          true,
 			want:                  configWriteDenyCategoryMutation,
 		},
 		{
@@ -63,7 +81,39 @@ func TestDecideConfigWrite(t *testing.T) {
 			hasRegistrationManage: true,
 			existingCategory:      "registration",
 			newCategory:           "registration",
+			newCategoryProvided:   true,
+			bodyReadable:          true,
 			want:                  configWriteAllow,
+		},
+		{
+			// #1732: an explicit business_category:"" is a mutation away from
+			// "registration" and must be denied, not silently allowed.
+			name:                  "registration.manage blanking category (explicit empty) is denied",
+			hasRegistrationManage: true,
+			existingCategory:      "registration",
+			newCategory:           "",
+			newCategoryProvided:   true,
+			bodyReadable:          true,
+			want:                  configWriteDenyCategoryMutation,
+		},
+		{
+			// A true omission (no business_category in the body) leaves the
+			// category untouched and stays allowed.
+			name:                  "registration.manage omitting category is allowed",
+			hasRegistrationManage: true,
+			existingCategory:      "registration",
+			newCategoryProvided:   false,
+			bodyReadable:          true,
+			want:                  configWriteAllow,
+		},
+		{
+			// #1732: if the request body can't be read we cannot verify the write
+			// isn't mutating the category, so a non-admin write fails closed.
+			name:                  "registration.manage with unreadable body is denied (fail closed)",
+			hasRegistrationManage: true,
+			existingCategory:      "registration",
+			bodyReadable:          false,
+			want:                  configWriteDenyCategoryMutation,
 		},
 	}
 
@@ -75,6 +125,8 @@ func TestDecideConfigWrite(t *testing.T) {
 				tt.hasRegistrationManage,
 				tt.existingCategory,
 				tt.newCategory,
+				tt.newCategoryProvided,
+				tt.bodyReadable,
 			)
 			if got != tt.want {
 				t.Errorf("decideConfigWrite() = %v, want %v", got, tt.want)


### PR DESCRIPTION
## What

Fixes the config-write authorization guard in `pocketbase/rbac/hooks.go`. Started from #1732 (a claimed fail-*open* on blanked `business_category`) but a deep scan revealed the guard's real, pre-existing defect and a couple of related holes. This is the corrected fix.

## Root cause (pre-existing, more serious than #1732)

The guard read the category via `extractBusinessCategory(e.Record.Get("metadata"))`. But `Record.Get` on a **json** field returns `types.JSONRaw` (`[]byte`), not `map[string]any` — the old code type-asserted `map[string]any`, which **always failed and returned `""`**. So `existingCategory` was *always* empty and the guard returned `configWriteDenyWrongCategory` for **every non-admin config write**, regardless of category. `registration.manage` was effectively non-functional, and #1732's fail-open couldn't actually occur (the write was denied up front). The pure-function unit tests hand-passed strings, so they never exercised this seam.

## Fix

1. **Decode the real value** — `extractBusinessCategory` now handles `types.JSONRaw`/`[]byte` (unmarshal) as well as `map[string]any`.
2. **Correct policy** — `decideConfigWrite` now takes `originalCategory` (stored), `resultCategory` (post-body, i.e. what will be saved), and `isCreate`:
   - **Updates:** the **stored** category must be `registration` — blocks editing a solver config *and* relabeling one to `registration` in the same PATCH to gain access (a real escalation the naive fix would miss).
   - **All writes:** the **resulting** category must stay `registration` — blocks setting another category, blanking it (`""`), or dropping the key under json-replace semantics.
   - Reading post-body state (`e.Record`, which already has the body applied via `form.Load`) instead of parsing the request body removes the `RequestInfo()` fail-open concern entirely and closes the omit-under-replace blanking hole.
3. `guardConfigWrite` reads `e.Record.Original()` for eligibility and the post-body `e.Record` for the result; bound per create/update.

## Verification (TDD)

- **Seam test** over a real `*core.Record` (`Record.Get` → `types.JSONRaw`) — verified **red** against the old map-only assertion (returns `""`), green after the decode fix. This is the runtime path the old tests bypassed.
- Policy cases: eligibility (solver config denied), relabel-escalation denied, category mutation/blanking denied, create allowed only for registration category, admin/superuser bypass.
- `go build ./...`, full `rbac` suite, `golangci-lint` — all clean.

## CI note

CI's `Go Lint` job currently fails repo-wide on **GO-2026-5856** (`crypto/tls` stdlib vuln, fixed in go1.26.5) because CI pins go1.26.4. That's unrelated to this change and is fixed by #1809 (floats CI Go to `1.26.x`). This PR goes green once #1809 lands and this branch is updated.

Closes #1732