### PR TITLE
chore(ci): float Go toolchain to 1.26.x for auto stdlib security patches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
-        go-version: '1.26.4'
+        go-version: '1.26.x'
         cache: true
         cache-dependency-path: pocketbase/go.sum
 
@@ -456,7 +456,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
-        go-version: '1.26.4'
+        go-version: '1.26.x'
         cache: true
         cache-dependency-path: pocketbase/go.sum
 
@@ -481,7 +481,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
-        go-version: '1.26.4'
+        go-version: '1.26.x'
         cache: true
         cache-dependency-path: pocketbase/go.sum
 


### PR DESCRIPTION
## Summary
- CI's `Go Lint` job runs `govulncheck` against a pinned `go-version: '1.26.4'` in `.github/workflows/ci.yml`. GO-2026-5856, a `crypto/tls` stdlib vulnerability fixed in go1.26.5, now fails that check on every Go-touching PR since 1.26.4 predates the fix.
- This floats all three `go-version: '1.26.4'` occurrences in `.github/workflows/ci.yml` to `'1.26.x'`, so `setup-go` installs the latest available 1.26 patch release at CI runtime. Future stdlib patch CVEs get picked up automatically without a manual version-bump PR, while the patch-only float keeps minor version bumps (1.27, etc.) deliberate.
- `go.mod` and `go.work` are untouched — those remain minimum-version floors, which is the correct place to pin a lower bound; the CI toolchain float is orthogonal and only affects what `actions/setup-go` installs for lint/test/build jobs.
- This unblocks #1806 and #1808, which both currently fail the same GO-2026-5856 `Go Lint` check.

## Test plan
- [x] `git diff` confirms exactly 3 lines changed in `.github/workflows/ci.yml` (all `'1.26.4'` → `'1.26.x'`)
- [x] No other files touched (`go.mod`, `go.work` left as-is)
- [ ] CI passes on this PR, including `Go Lint` (govulncheck no longer flags GO-2026-5856)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go version used in CI to track the latest 1.26 patch releases automatically.
  * Kept linting, test, and migration smoke test environments aligned with the same Go toolchain version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->