### PR TITLE
chore(ci): set check-latest on setup-go so 1.26.x fetches the patch (GO-2026-5856)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,7 @@ jobs:
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version: '1.26.x'
+        check-latest: true
         cache: true
         cache-dependency-path: pocketbase/go.sum
 
@@ -457,6 +458,7 @@ jobs:
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version: '1.26.x'
+        check-latest: true
         cache: true
         cache-dependency-path: pocketbase/go.sum
 
@@ -482,6 +484,7 @@ jobs:
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version: '1.26.x'
+        check-latest: true
         cache: true
         cache-dependency-path: pocketbase/go.sum
 


### PR DESCRIPTION
## Why

#1809 floated the CI Go toolchain to `1.26.x`, but CI **still fails on GO-2026-5856**. The setup-go log shows why:

```
go-version: 1.26.x
Found in cache @ /opt/hostedtoolcache/go/1.26.4/x64
go version go1.26.4 linux/amd64
```

`actions/setup-go` prefers a **cached** patch that satisfies the range over downloading a newer one. The runners cache `go1.26.4`, so `1.26.x` resolved right back to 1.26.4 and govulncheck kept flagging the `crypto/tls` vuln (fixed in 1.26.5).

## Fix

Add `check-latest: true` to all three setup-go steps. That forces setup-go to consult the `actions/go-versions` manifest and install the newest matching patch — **1.26.5, confirmed present in the manifest**. The float now works as intended, and future 1.26 patch CVEs are picked up automatically.

## Unblocks

This is the actual unblock for the GO-2026-5856 Go Lint failure on **#1806** and **#1808** (rebase them after this lands).

Diff is 3 lines (one `check-latest: true` per setup-go block).