### PR TITLE
fix(config): resolve worktree-guard hook by absolute path

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,7 +21,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/worktree-guard.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-guard.sh\""
           }
         ]
       }


### PR DESCRIPTION
## Summary

The `worktree-guard` PreToolUse hook was registered with a **repo-relative** path in `.claude/settings.json`:

```json
"command": ".claude/hooks/worktree-guard.sh"
```

The Bash tool's cwd persists across calls, so whenever it had drifted into a subdirectory (`pocketbase/`, `frontend/`) or outside the repo, the hook couldn't be resolved:

```
/bin/sh: 1: .claude/hooks/worktree-guard.sh: not found
```

A scan of session transcripts found this firing **15 times across 177 `PreToolUse:Bash` invocations (~8%)**.

## Why this mattered

The failure is *non-blocking*, so the guard **silently failed open**. `CLAUDE.md` documents this hook as enforcement — "blocks direct bare-git worktree creation" — but for ~8% of Bash calls it was blocking nothing. And because the script is checked in, it exists in every worktree, so the guard looked perfectly healthy under inspection. The only evidence was a non-blocking error buried in transcript attachments.

Resolving via `$CLAUDE_PROJECT_DIR` makes it cwd-independent. Confirmed supported by the running Claude Code build (2.1.220).

## Verification

Tested against the payload shape the hook actually receives, from both the repo root and a subdirectory:

| Form | cwd | Result |
|---|---|---|
| relative (before) | `pocketbase/` | exit 127, `not found` — **the bug** |
| absolute (after) | `pocketbase/` | exit 2, blocked ✅ |
| absolute (after) | repo root | exit 2, blocked ✅ |
| absolute (after) | benign command | exit 0, allowed ✅ |

## Note for reviewers

While writing this up, the guard blocked its own commit message — the regex `\bgit\b[^|;&]*\bworktree[[:space:]]+add\b` matches the literal string in prose inside a heredoc, not just in an actual command. Harmless (worked around with `git commit -F`), and arguably fail-safe rather than fail-open, but worth knowing it false-positives on documentation. Not addressed here — this PR is the one-line path fix only.

## Test plan

- [x] Bug reproduced with the relative form from a subdirectory
- [x] Fix blocks correctly from subdirectory and repo root
- [x] Fix still allows benign commands
- [x] `settings.json` remains valid JSON
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the worktree safety check by ensuring its hook runs from the project’s configured root path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->