### PR TITLE
docs(config): drop the commit-scope table, point at commitlint config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,32 +68,7 @@ Full reference: `/docs/reference/cli-commands.md`. Per-surface test invocations 
 
 Format: `type(scope): description` — breaking changes: `feat(api)!: description`
 
-| Scope | Area |
-|-------|------|
-| `frontend` | React, hooks, pages, styles |
-| `api` | FastAPI, Python backend |
-| `sync` | Go sync, CampMinder |
-| `pb` | PocketBase schema, migrations |
-| `solver` | OR-Tools solver |
-| `docker` | Dockerfiles, compose |
-| `ci` | GitHub Actions |
-| `auth` | Authentication, OAuth, permissions |
-| `google` | Google Sheets/Drive API |
-| `logging` | Logging configuration |
-| `release` | Release scripts, versioning |
-| `config` | Configuration files, incl. agent config (CLAUDE.md, skills) |
-| `tests` | Test infrastructure (distinct from the `test:` type) |
-| `scripts` | Dev/utility scripts |
-| `deps` | Dependencies |
-| `deps-dev` | Dev dependency updates |
-| `docs` | Documentation files in `docs/` |
-| `security` | Security hardening, CVE fixes |
-| `metrics` | Analytics, dashboards, statistics |
-| `graph` | Social network graph features |
-| `rbac` | Roles, permissions, access control |
-| `data` | Data models, schema changes |
-
-Scope is **required** and enforced by commitlint — `commitlint.config.js` is the source of truth for both scopes and types. Which `type` to use: `docs/reference/commit-conventions.md`
+Scope is **required** and enforced by commitlint, which rejects the commit if you get it wrong. `commitlint.config.js` is the source of truth — read its `scope-enum` and `type-enum` rather than trusting a copy here, which is how this file previously drifted five scopes out of date. Which `type` to use: `docs/reference/commit-conventions.md`
 
 Commit at logical checkpoints, not micro-commits. Never sweep others' changes into your commits — check `git status` first.
 


### PR DESCRIPTION
## Summary

Removes the 25-line commit-scope table from root `CLAUDE.md` and replaces it with a pointer to `commitlint.config.js`.

## Why

The table duplicated `scope-enum` in `commitlint.config.js`, which is the **actual** gate — commitlint rejects a bad scope regardless of what `CLAUDE.md` claims. The table was never enforcement, only a convenience copy that could lie about what the gate accepts.

It did exactly that. The table had drifted **five scopes out of date** — `auth`, `logging`, `release`, `config`, and `tests` were all valid and all missing. The drift surfaced only when a commit was rejected for an "empty" scope that commitlint actually allows.

Syncing the copy (done in #1861) fixes that instance. Deleting it fixes the class.

## What stays

Everything non-derivable. The replacement line notes the past drift so the table doesn't get helpfully reintroduced later:

> Scope is **required** and enforced by commitlint, which rejects the commit if you get it wrong. `commitlint.config.js` is the source of truth — read its `scope-enum` and `type-enum` rather than trusting a copy here, which is how this file previously drifted five scopes out of date.

## Scope of this change

Deliberately narrow. Two other blocks were considered and **kept**:

- **Git-hooks table** — carries per-stage timings (`<1s`, `~40s`, `~5s`) that `.lefthook.yml` does not contain. Not a duplicate.
- **Tooling versions** — "Python 3.14+" prevents a recurring, specific error (system `python3` is 3.12 and misflags valid 3.14 syntax). Functions as a gotcha, not a manifest dump.

Root `CLAUDE.md`: 190 → 165 lines.

## Test plan
- [x] `markdownlint` passes
- [x] Pre-push hooks pass
- [ ] CI green

Docs-only — no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)