### PR TITLE
chore(deps): restore flatted, postcss and undici bumps dropped by group supersede

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4681,9 +4681,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -6072,9 +6072,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
-      "integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -7148,9 +7148,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,8 +71,10 @@
       "eslint": "^10.0.0"
     },
     "brace-expansion": ">=5.0.8",
-    "flatted": ">=3.4.2",
-    "js-yaml": "^4.3.0"
+    "flatted": ">=3.4.3",
+    "js-yaml": "^4.3.0",
+    "postcss": ">=8.5.23",
+    "undici": ">=7.29.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
Restores three dependency bumps that were closed without ever landing.

## What happened

Merging the `npm-all` group PR (#1859) caused Dependabot to close every individual npm PR for `/frontend` as superseded. Two of them genuinely were — the group contained their bumps. Three were not:

| PR | Bump | In the group? | On `main` after merge |
|----|------|---------------|----------------------|
| #1848 | react-router 8.2.0 → 8.3.0 | ✅ yes | 8.3.0 ✅ |
| #1851 | brace-expansion 5.0.7 → 5.0.8 | ✅ yes (added manually) | 5.0.8 ✅ |
| #1849 | flatted 3.4.2 → **3.4.3** | ❌ no | **3.4.2** ❌ |
| #1850 | postcss 8.5.21 → **8.5.23** | ❌ no | **8.5.21** ❌ |
| #1852 | undici 7.28.0 → **7.29.0** | ❌ no | **7.28.0** ❌ |

Group supersede is by *ecosystem + directory*, not by whether the group actually carried the change — so those three were dropped silently. Dependabot would re-file them eventually; this closes the gap now rather than waiting for the next scheduled run.

## Approach

All three are transitive (none appear in `dependencies` or `devDependencies`), so they get `overrides` entries rather than dependency bumps — the same pattern already used for `js-yaml`, `brace-expansion` and `flatted`.

`flatted` already had an override at `>=3.4.2`. That floor is precisely why it resolved back to 3.4.2 after the group's lockfile regeneration, so it's raised to `>=3.4.3`.

## Verification

From a fresh `npm ci` against the regenerated lockfile:

```
flatted   -> 3.4.3
postcss   -> 8.5.23
undici    -> 7.29.0

type-check    exit=0
format:check  exit=0
lint          exit=0   (0 errors)
npm audit     exit=0   (0 vulnerabilities)
vitest        exit=0
build         exit=0
```

The production build is included deliberately — `postcss` is a build-time dependency, so a lockfile-only check wouldn't have exercised it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
