### PR TITLE
fix(ci): suppress zizmor dependabot-cooldown, keeping the 3-day soak

### DIFF
--- a/zizmor.yml
+++ b/zizmor.yml
@@ -48,3 +48,21 @@ rules:
     # verifies the PR was genuinely created by Dependabot
     ignore:
       - dependabot-auto-merge.yml
+
+  dependabot-cooldown:
+    # dependabot.yml sets `cooldown: default-days: 3` on all 7 update blocks.
+    # zizmor wants >= 7. The 3 is deliberate and stays.
+    #
+    # Cooldown trades supply-chain safety (wait out a compromised release
+    # before auto-filing) against CVE remediation latency. This repo's
+    # security-audit CI reads live advisory databases, so a fresh CVE turns
+    # every PR *and* main red until the fix is bumped in — remediation speed
+    # is load-bearing here, and a 7-day floor would hold that gate shut for a
+    # week. On 2026-07-27 two npm advisories blocked the entire frontend PR
+    # queue; the unblock was a same-day bump.
+    #
+    # 7 days is a sound default for a team repo with someone on call. For a
+    # solo-maintained repo where the maintainer *is* the CVE response, the
+    # faster loop is worth more than the extra soak time.
+    ignore:
+      - dependabot.yml


### PR DESCRIPTION
Unblocks every workflow-touching PR — currently #1860 and #1840.

## What broke

`ci.yml` runs `pipx run zizmor` **unpinned**, so CI installs whatever version is newest that day. A recent release added the [`dependabot-cooldown`](https://docs.zizmor.sh/audits/#dependabot-cooldown) audit, which fires when `cooldown.default-days` is below 7:

```
warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates
  --> ./.github/dependabot.yml:55:7
   |
55 |       default-days: 3
   |       ^^^^^^^^^^^^^^^ insufficient default-days configured (less than 7)
```

All 7 update blocks sit at 3, so it fires 7 times, fails at `--min-severity medium`, and takes `Actions Security Lint` → `CI Summary` red.

No code caused this. #1841 is still green only because its check ran on 2026-07-20 against an older zizmor; re-run it today and it fails identically.

## Why suppress rather than raise to 7

The 3-day value is deliberate, and worth keeping.

Cooldown trades supply-chain safety — waiting out a compromised release before auto-filing — against CVE remediation latency. This repo's security-audit CI reads **live** advisory databases, so a newly published CVE turns every PR *and* `main` red until the fix is bumped in. Remediation speed is load-bearing here in a way it isn't in most repos.

A 7-day floor would hold that gate shut for a week. This isn't hypothetical: on 2026-07-27 two npm advisories (GHSA-mh99-v99m-4gvg, GHSA-qwww-vcr4-c8h2) blocked the entire frontend PR queue, and the unblock was a same-day bump — precisely what a 7-day cooldown would have prevented.

7 days is a sound default for a team repo with someone on call. For a solo-maintained repo where the maintainer *is* the CVE response, the faster loop is worth more than the extra soak time.

Suppressed with rationale in `zizmor.yml` alongside the five existing documented ignores, rather than raising `--min-severity`, which would also drop unrelated medium findings.

## Verification

Same zizmor build (v1.28.0), run locally against this repo:

| Config | Result |
|--------|--------|
| `main` | 14 `dependabot-cooldown` findings |
| this branch | `No findings to report. Good job! (19 ignored, 41 suppressed)` — exit 0 |

## Not addressed here

The underlying fragility is that `zizmor` is unpinned, so any release can turn CI red overnight with no commit. `actionlint` on the line above is worse — `bash <(curl -sSL .../actionlint/main/scripts/...)` executes a script fetched from a branch HEAD on every run. Both are worth a separate look; pinning a security linter has its own cost (you stop getting new rules), so it deserves its own decision rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
