### PR TITLE
feat(pb): family camp lodging registry data layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -332,3 +332,9 @@ docs/reference/solver-config-decisions.md
 # Synthetic no-PII seed fixture (issue #1623) — committed test data, not local config.
 # Override the repo-wide *.json ignore for the manifest; the .db.gz is not matched by *.db.
 !tests/fixtures/synthetic_pb/MANIFEST.json
+
+# Camp facility documents (site maps, floor plans) are private — this repo is public.
+# "2026 Map of Camp.pdf" is the source the lodging registry's map_x/map_y coordinates
+# were extracted from, and it lives at the repo root during that work. Ignore root-level
+# PDFs so a stray `git add -A` cannot publish a real facility layout. See CLAUDE.md §4.
+/*.pdf

--- a/pocketbase/pb_migrations/1500000116_lodging_areas_units.js
+++ b/pocketbase/pb_migrations/1500000116_lodging_areas_units.js
@@ -1,0 +1,105 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: lodging_areas + lodging_units
+ *
+ * Canonical registry of weekend-program housing. Seeded by 1500000120 but fully
+ * editable in the Family Camp admin UI — no unit list lives in source code.
+ *
+ * lodging_units holds ATOMIC rooms. Merges (e.g. "Tenaya 1and2") are separate
+ * rows in lodging_merges, not parent activations, because merges are frequently
+ * partial (2 of a 4-room building).
+ *
+ * bathroom is none|private|shared. "none" means no bathroom with respect to your
+ * housing — a bathhouse walk is "none". private-vs-shared depends on merge state,
+ * so bathroom_group identifies the set of units sharing one bathroom: a merge
+ * covering an entire group upgrades the slot's effective bathroom to private.
+ */
+
+migrate((app) => {
+  const areas = new Collection({
+    type: "base",
+    name: "lodging_areas",
+    listRule: '@request.auth.id != ""',
+    viewRule: '@request.auth.id != ""',
+    createRule: '@request.auth.is_admin = true',
+    updateRule: '@request.auth.is_admin = true',
+    deleteRule: '@request.auth.is_admin = true',
+    fields: [
+      { type: "text", name: "name", required: true, presentable: true, min: 1, max: 100, pattern: "" },
+      { type: "text", name: "code", required: true, presentable: false, min: 1, max: 20, pattern: "" },
+      { type: "number", name: "map_x", required: false, presentable: false, min: 0, max: 1, onlyInt: false },
+      { type: "number", name: "map_y", required: false, presentable: false, min: 0, max: 1, onlyInt: false },
+      { type: "number", name: "sort_order", required: false, presentable: false, min: null, max: null, onlyInt: true },
+      { type: "autodate", name: "created", required: false, presentable: false, onCreate: true, onUpdate: false },
+      { type: "autodate", name: "updated", required: false, presentable: false, onCreate: true, onUpdate: true }
+    ],
+    indexes: [
+      "CREATE UNIQUE INDEX `idx_lodging_areas_code` ON `lodging_areas` (`code`)"
+    ]
+  });
+  app.save(areas);
+
+  const areasCol = app.findCollectionByNameOrId("lodging_areas");
+
+  const units = new Collection({
+    type: "base",
+    name: "lodging_units",
+    listRule: '@request.auth.id != ""',
+    viewRule: '@request.auth.id != ""',
+    createRule: '@request.auth.is_admin = true',
+    updateRule: '@request.auth.is_admin = true',
+    deleteRule: '@request.auth.is_admin = true',
+    fields: [
+      {
+        type: "relation", name: "area", required: true, presentable: false,
+        collectionId: areasCol.id, cascadeDelete: false, minSelect: null, maxSelect: 1
+      },
+      { type: "text", name: "name", required: true, presentable: true, min: 1, max: 200, pattern: "" },
+      { type: "text", name: "code", required: true, presentable: false, min: 1, max: 100, pattern: "" },
+      // Self-relation: the building a room belongs to. Display/adjacency only —
+      // NOT merge state. collectionId is patched below, after the collection exists.
+      { type: "number", name: "map_x", required: false, presentable: false, min: 0, max: 1, onlyInt: false },
+      { type: "number", name: "map_y", required: false, presentable: false, min: 0, max: 1, onlyInt: false },
+      { type: "number", name: "sleeps", required: false, presentable: false, min: null, max: null, onlyInt: true },
+      {
+        type: "select", name: "bathroom", required: false, presentable: false,
+        values: ["none", "private", "shared"], maxSelect: 1
+      },
+      { type: "text", name: "bathroom_group", required: false, presentable: false, min: 0, max: 100, pattern: "" },
+      { type: "bool", name: "near_bathhouse", required: false, presentable: false },
+      { type: "bool", name: "has_power", required: false, presentable: false },
+      { type: "bool", name: "has_ac", required: false, presentable: false },
+      { type: "bool", name: "has_fridge", required: false, presentable: false },
+      { type: "bool", name: "is_accessible", required: false, presentable: false },
+      {
+        type: "select", name: "allocation_default", required: false, presentable: false,
+        values: ["family_pool", "staff_default"], maxSelect: 1
+      },
+      // false = value is a seed guess (from historical peak occupancy), not staff-verified.
+      { type: "bool", name: "is_confirmed", required: false, presentable: false },
+      { type: "bool", name: "is_active", required: false, presentable: false },
+      // max 4000 deliberately, NOT 5000: 5000 is PocketBase's silent default, so
+      // the harness uses "max != 5000" to prove the options:{} trap was avoided.
+      { type: "text", name: "notes", required: false, presentable: false, min: 0, max: 4000, pattern: "" },
+      { type: "autodate", name: "created", required: false, presentable: false, onCreate: true, onUpdate: false },
+      { type: "autodate", name: "updated", required: false, presentable: false, onCreate: true, onUpdate: true }
+    ],
+    indexes: [
+      "CREATE UNIQUE INDEX `idx_lodging_units_code` ON `lodging_units` (`code`)",
+      "CREATE INDEX `idx_lodging_units_area` ON `lodging_units` (`area`)",
+      "CREATE INDEX `idx_lodging_units_bathroom_group` ON `lodging_units` (`bathroom_group`)"
+    ]
+  });
+  app.save(units);
+
+  // Add the self-relation now that lodging_units has an id.
+  const unitsCol = app.findCollectionByNameOrId("lodging_units");
+  unitsCol.fields.add(new Field({
+    type: "relation", name: "parent_unit", required: false, presentable: false,
+    collectionId: unitsCol.id, cascadeDelete: false, minSelect: null, maxSelect: 1
+  }));
+  app.save(unitsCol);
+}, (app) => {
+  app.delete(app.findCollectionByNameOrId("lodging_units"));
+  app.delete(app.findCollectionByNameOrId("lodging_areas"));
+});

--- a/pocketbase/pb_migrations/1500000116_lodging_areas_units.js
+++ b/pocketbase/pb_migrations/1500000116_lodging_areas_units.js
@@ -56,8 +56,8 @@ migrate((app) => {
       },
       { type: "text", name: "name", required: true, presentable: true, min: 1, max: 200, pattern: "" },
       { type: "text", name: "code", required: true, presentable: false, min: 1, max: 100, pattern: "" },
-      // Self-relation: the building a room belongs to. Display/adjacency only —
-      // NOT merge state. collectionId is patched below, after the collection exists.
+      // NOTE: parent_unit is NOT declared here. It is a self-relation, so it needs
+      // this collection's own id — added after app.save(units) below.
       { type: "number", name: "map_x", required: false, presentable: false, min: 0, max: 1, onlyInt: false },
       { type: "number", name: "map_y", required: false, presentable: false, min: 0, max: 1, onlyInt: false },
       { type: "number", name: "sleeps", required: false, presentable: false, min: null, max: null, onlyInt: true },
@@ -98,7 +98,11 @@ migrate((app) => {
   });
   app.save(units);
 
-  // Add the self-relation now that lodging_units has an id.
+  // parent_unit: the building a room belongs to. Display/adjacency grouping only
+  // — NOT merge state (merges are explicit member sets in lodging_merges, because
+  // they are frequently partial). Added here rather than in the field list above
+  // because a self-relation needs the collection's own id, which only exists once
+  // app.save(units) has run.
   const unitsCol = app.findCollectionByNameOrId("lodging_units");
   unitsCol.fields.add(new Field({
     type: "relation", name: "parent_unit", required: false, presentable: false,

--- a/pocketbase/pb_migrations/1500000116_lodging_areas_units.js
+++ b/pocketbase/pb_migrations/1500000116_lodging_areas_units.js
@@ -78,6 +78,12 @@ migrate((app) => {
       // false = value is a seed guess (from historical peak occupancy), not staff-verified.
       { type: "bool", name: "is_confirmed", required: false, presentable: false },
       { type: "bool", name: "is_active", required: false, presentable: false },
+      // true = a building/grouping row that must never be booked or counted
+      // toward capacity (e.g. gt-tenaya, the building containing gt-tenaya-1..4).
+      // false = an ordinary bookable room. PocketBase's default for an unset
+      // bool is false, which is the safe default for units staff add later
+      // through the admin UI.
+      { type: "bool", name: "is_container", required: false, presentable: false },
       // max 4000 deliberately, NOT 5000: 5000 is PocketBase's silent default, so
       // the harness uses "max != 5000" to prove the options:{} trap was avoided.
       { type: "text", name: "notes", required: false, presentable: false, min: 0, max: 4000, pattern: "" },

--- a/pocketbase/pb_migrations/1500000117_lodging_unit_aliases.js
+++ b/pocketbase/pb_migrations/1500000117_lodging_unit_aliases.js
@@ -1,0 +1,51 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: lodging_unit_aliases
+ *
+ * Maps historical free-text cabin strings onto units. TEMPORAL, because renames
+ * happened mid-history: "Golden Triangle - Doctor's House" (2022-24) became
+ * "Golden Triangle - Wawona" (2025+), while "Health Center - Doctor's House"
+ * (2022-24) became the bare "Doctor's House" (2025+).
+ *
+ * member_units is MULTI-valued so one table covers both cases: a single member
+ * resolves to an atomic room; 2+ members denote a merge (see lodging_merges),
+ * which backfill materialises as a merge row. e.g. "Tenaya 1and2" -> {Tenaya 1, Tenaya 2}.
+ */
+
+migrate((app) => {
+  const unitsCol = app.findCollectionByNameOrId("lodging_units");
+
+  const aliases = new Collection({
+    type: "base",
+    name: "lodging_unit_aliases",
+    listRule: '@request.auth.id != ""',
+    viewRule: '@request.auth.id != ""',
+    createRule: '@request.auth.is_admin = true',
+    updateRule: '@request.auth.is_admin = true',
+    deleteRule: '@request.auth.is_admin = true',
+    fields: [
+      // Verbatim as it appears in the CampMinder custom field, including any
+      // double spaces (e.g. "Health Center Downstairs  - Room A"). Do not trim.
+      { type: "text", name: "alias_string", required: true, presentable: true, min: 1, max: 300, pattern: "" },
+      {
+        type: "relation", name: "member_units", required: true, presentable: false,
+        collectionId: unitsCol.id, cascadeDelete: false, minSelect: 1, maxSelect: 20
+      },
+      { type: "number", name: "valid_from_year", required: false, presentable: false, min: 2000, max: 2100, onlyInt: true },
+      { type: "number", name: "valid_to_year", required: false, presentable: false, min: 2000, max: 2100, onlyInt: true },
+      { type: "text", name: "source_field", required: false, presentable: false, min: 0, max: 200, pattern: "" },
+      { type: "text", name: "notes", required: false, presentable: false, min: 0, max: 2000, pattern: "" },
+      { type: "autodate", name: "created", required: false, presentable: false, onCreate: true, onUpdate: false },
+      { type: "autodate", name: "updated", required: false, presentable: false, onCreate: true, onUpdate: true }
+    ],
+    indexes: [
+      // Same string can map differently in different year windows, so the unique
+      // key includes valid_from_year.
+      "CREATE UNIQUE INDEX `idx_lodging_alias_string_from` ON `lodging_unit_aliases` (`alias_string`, `valid_from_year`)",
+      "CREATE INDEX `idx_lodging_alias_string` ON `lodging_unit_aliases` (`alias_string`)"
+    ]
+  });
+  app.save(aliases);
+}, (app) => {
+  app.delete(app.findCollectionByNameOrId("lodging_unit_aliases"));
+});

--- a/pocketbase/pb_migrations/1500000118_lodging_merges_availability.js
+++ b/pocketbase/pb_migrations/1500000118_lodging_merges_availability.js
@@ -91,7 +91,13 @@ migrate((app) => {
     ],
     indexes: [
       "CREATE INDEX `idx_lodging_avail_session_year` ON `lodging_availability` (`session`, `year`)",
-      "CREATE INDEX `idx_lodging_avail_unit` ON `lodging_availability` (`unit`)"
+      "CREATE INDEX `idx_lodging_avail_unit` ON `lodging_availability` (`unit`)",
+      // At most one override per unit per session/scenario. Without this, a unit
+      // could hold both a reserved_staff row and a released_to_family row for the
+      // same (session, year, scenario), making "is this unit family-available?"
+      // non-deterministic. No WHERE predicate is needed: scenario is
+      // `TEXT DEFAULT '' NOT NULL`, so live (scenario-less) rows key on '' naturally.
+      "CREATE UNIQUE INDEX `idx_lodging_avail_unique` ON `lodging_availability` (`session`, `year`, `scenario`, `unit`)"
     ]
   });
   app.save(availability);

--- a/pocketbase/pb_migrations/1500000118_lodging_merges_availability.js
+++ b/pocketbase/pb_migrations/1500000118_lodging_merges_availability.js
@@ -1,0 +1,101 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: lodging_merges + lodging_availability
+ *
+ * lodging_merges binds an explicit SET of atomic units into one bookable slot
+ * for one weekend. Member sets rather than parent/child toggles because merges
+ * are frequently partial: "Tenaya 1and2" merges 2 rooms of a 4-room building,
+ * which a parent-activation model cannot express.
+ *
+ * Merges are created MID-ASSIGNMENT as a board action (select adjacent rooms,
+ * drop the party), not pre-configured. scenario is nullable: null = the session's
+ * live plan. Two scenarios of one weekend may merge differently.
+ *
+ * lodging_availability locks units out of the family pool, in both directions:
+ *   family_pool   + reserved_staff/reserved_other  -> not family-available
+ *   staff_default + (no row)                       -> not family-available
+ *   staff_default + released_to_family             -> family-available
+ * reserved_other covers maintenance and out-of-service so those are not
+ * misfiled as staff housing.
+ */
+
+migrate((app) => {
+  const unitsCol = app.findCollectionByNameOrId("lodging_units");
+  const sessionsCol = app.findCollectionByNameOrId("camp_sessions");
+  const scenariosCol = app.findCollectionByNameOrId("saved_scenarios");
+
+  const merges = new Collection({
+    type: "base",
+    name: "lodging_merges",
+    listRule: '@request.auth.id != ""',
+    viewRule: '@request.auth.id != ""',
+    createRule: '@request.auth.is_admin = true',
+    updateRule: '@request.auth.is_admin = true',
+    deleteRule: '@request.auth.is_admin = true',
+    fields: [
+      {
+        type: "relation", name: "session", required: true, presentable: false,
+        collectionId: sessionsCol.id, cascadeDelete: true, minSelect: null, maxSelect: 1
+      },
+      { type: "number", name: "year", required: true, presentable: false, min: 2010, max: 2100, onlyInt: true },
+      {
+        type: "relation", name: "scenario", required: false, presentable: false,
+        collectionId: scenariosCol.id, cascadeDelete: true, minSelect: null, maxSelect: 1
+      },
+      {
+        type: "relation", name: "member_units", required: true, presentable: false,
+        collectionId: unitsCol.id, cascadeDelete: false, minSelect: 2, maxSelect: 20
+      },
+      { type: "text", name: "display_name", required: false, presentable: true, min: 0, max: 200, pattern: "" },
+      { type: "number", name: "capacity_override", required: false, presentable: false, min: null, max: null, onlyInt: true },
+      { type: "text", name: "created_by", required: false, presentable: false, min: 0, max: 200, pattern: "" },
+      { type: "autodate", name: "created", required: false, presentable: false, onCreate: true, onUpdate: false },
+      { type: "autodate", name: "updated", required: false, presentable: false, onCreate: true, onUpdate: true }
+    ],
+    indexes: [
+      "CREATE INDEX `idx_lodging_merges_session_year` ON `lodging_merges` (`session`, `year`)",
+      "CREATE INDEX `idx_lodging_merges_scenario` ON `lodging_merges` (`scenario`)"
+    ]
+  });
+  app.save(merges);
+
+  const availability = new Collection({
+    type: "base",
+    name: "lodging_availability",
+    listRule: '@request.auth.id != ""',
+    viewRule: '@request.auth.id != ""',
+    createRule: '@request.auth.is_admin = true',
+    updateRule: '@request.auth.is_admin = true',
+    deleteRule: '@request.auth.is_admin = true',
+    fields: [
+      {
+        type: "relation", name: "session", required: true, presentable: false,
+        collectionId: sessionsCol.id, cascadeDelete: true, minSelect: null, maxSelect: 1
+      },
+      { type: "number", name: "year", required: true, presentable: false, min: 2010, max: 2100, onlyInt: true },
+      {
+        type: "relation", name: "scenario", required: false, presentable: false,
+        collectionId: scenariosCol.id, cascadeDelete: true, minSelect: null, maxSelect: 1
+      },
+      {
+        type: "relation", name: "unit", required: true, presentable: false,
+        collectionId: unitsCol.id, cascadeDelete: true, minSelect: null, maxSelect: 1
+      },
+      {
+        type: "select", name: "state", required: true, presentable: false,
+        values: ["reserved_staff", "reserved_other", "released_to_family"], maxSelect: 1
+      },
+      { type: "text", name: "note", required: false, presentable: false, min: 0, max: 2000, pattern: "" },
+      { type: "autodate", name: "created", required: false, presentable: false, onCreate: true, onUpdate: false },
+      { type: "autodate", name: "updated", required: false, presentable: false, onCreate: true, onUpdate: true }
+    ],
+    indexes: [
+      "CREATE INDEX `idx_lodging_avail_session_year` ON `lodging_availability` (`session`, `year`)",
+      "CREATE INDEX `idx_lodging_avail_unit` ON `lodging_availability` (`unit`)"
+    ]
+  });
+  app.save(availability);
+}, (app) => {
+  app.delete(app.findCollectionByNameOrId("lodging_availability"));
+  app.delete(app.findCollectionByNameOrId("lodging_merges"));
+});

--- a/pocketbase/pb_migrations/1500000119_lodging_assignments.js
+++ b/pocketbase/pb_migrations/1500000119_lodging_assignments.js
@@ -66,17 +66,20 @@ migrate((app) => {
       "CREATE INDEX `idx_lodging_assign_session_year` ON `lodging_assignments` (`session`, `year`)",
       "CREATE INDEX `idx_lodging_assign_household` ON `lodging_assignments` (`household_cm_id`, `year`)",
       "CREATE INDEX `idx_lodging_assign_person` ON `lodging_assignments` (`person_cm_id`, `year`)",
-      // One live (scenario-less) row per household per session, and per person.
+      // One row per household per session per scenario, and per person. scenario
+      // is a KEY COLUMN (not a predicate filter), so uniqueness holds both for the
+      // live plan (scenario = '') and INSIDE each saved scenario independently —
+      // scenario planning is exactly where a stray duplicate is most likely and
+      // least visible, so it gets the same guarantee as the live plan.
       //
       // The predicates MUST use `> 0`, not `!= ''`. PocketBase declares number
       // fields as `NUMERIC DEFAULT 0 NOT NULL`, so an unset household_cm_id is 0
       // — and SQLite evaluates `0 != ''` as TRUE (numeric-vs-text comparison).
       // With `!= ''` the household index would capture every person-grain row
       // (all household_cm_id = 0) and collide them, permitting only ONE adult
-      // assignment per session. Relations are `TEXT DEFAULT '' NOT NULL`, so
-      // `scenario = ''` is correct for "the live plan".
-      "CREATE UNIQUE INDEX `idx_lodging_assign_hh_live` ON `lodging_assignments` (`session`, `year`, `household_cm_id`) WHERE `household_cm_id` > 0 AND `scenario` = ''",
-      "CREATE UNIQUE INDEX `idx_lodging_assign_person_live` ON `lodging_assignments` (`session`, `year`, `person_cm_id`) WHERE `person_cm_id` > 0 AND `scenario` = ''"
+      // assignment per session.
+      "CREATE UNIQUE INDEX `idx_lodging_assign_hh_live` ON `lodging_assignments` (`session`, `year`, `household_cm_id`, `scenario`) WHERE `household_cm_id` > 0",
+      "CREATE UNIQUE INDEX `idx_lodging_assign_person_live` ON `lodging_assignments` (`session`, `year`, `person_cm_id`, `scenario`) WHERE `person_cm_id` > 0"
     ]
   });
   app.save(assignments);

--- a/pocketbase/pb_migrations/1500000119_lodging_assignments.js
+++ b/pocketbase/pb_migrations/1500000119_lodging_assignments.js
@@ -100,7 +100,11 @@ migrate((app) => {
       // TEXT, not relations: an unresolvable historical string is still recorded.
       { type: "text", name: "old_unit", required: false, presentable: false, min: 0, max: 300, pattern: "" },
       { type: "text", name: "new_unit", required: false, presentable: false, min: 0, max: 300, pattern: "" },
-      { type: "text", name: "detected_at", required: true, presentable: false, min: 1, max: 50, pattern: "" },
+      // `date`, not `text` — matches attendee_status_history.detected_at
+      // (1500000057_attendee_status_history.js:83-90), the collection this
+      // deliberately mirrors. Using text would lose PB's date validation and
+      // would surface as an untyped string in the generated OpenAPI/TS types.
+      { type: "date", name: "detected_at", required: true, presentable: false, min: "", max: "" },
       { type: "text", name: "source_field", required: false, presentable: false, min: 0, max: 200, pattern: "" },
       { type: "autodate", name: "created", required: false, presentable: false, onCreate: true, onUpdate: false }
     ],

--- a/pocketbase/pb_migrations/1500000119_lodging_assignments.js
+++ b/pocketbase/pb_migrations/1500000119_lodging_assignments.js
@@ -1,0 +1,117 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: lodging_assignments + lodging_assignment_history
+ *
+ * DUAL GRAIN. Exactly one of household_cm_id / person_cm_id is set, and a
+ * person-row OVERRIDES its household's row. That one rule covers all three cases:
+ *   - family camp        -> household rows (94% of the work)
+ *   - adult weekends     -> person rows (individuals into shared cabins)
+ *   - a grandparent placed apart from their family -> household row + one person override
+ * Keyed on CampMinder IDs per the project-wide rule, not PB relations.
+ *
+ * Either unit (an atomic room) or merge (a merged slot) is set, not both.
+ *
+ * History is append-only and mirrors attendee_status_history's shape
+ * (detected_at / old_* / new_* / session / year). It exists because CampMinder
+ * stores ONE cabin value per household per YEAR: a household attending two
+ * weekends has its first assignment overwritten. History reconstructs both, and
+ * works for two future weekends too. old_unit/new_unit are TEXT, not relations,
+ * so an unresolvable historical string is still recorded rather than dropped.
+ */
+
+migrate((app) => {
+  const unitsCol = app.findCollectionByNameOrId("lodging_units");
+  const mergesCol = app.findCollectionByNameOrId("lodging_merges");
+  const sessionsCol = app.findCollectionByNameOrId("camp_sessions");
+  const scenariosCol = app.findCollectionByNameOrId("saved_scenarios");
+
+  const assignments = new Collection({
+    type: "base",
+    name: "lodging_assignments",
+    listRule: '@request.auth.id != ""',
+    viewRule: '@request.auth.id != ""',
+    createRule: '@request.auth.is_admin = true',
+    updateRule: '@request.auth.is_admin = true',
+    deleteRule: '@request.auth.is_admin = true',
+    fields: [
+      {
+        type: "relation", name: "session", required: true, presentable: false,
+        collectionId: sessionsCol.id, cascadeDelete: true, minSelect: null, maxSelect: 1
+      },
+      { type: "number", name: "year", required: true, presentable: false, min: 2010, max: 2100, onlyInt: true },
+      {
+        type: "relation", name: "unit", required: false, presentable: false,
+        collectionId: unitsCol.id, cascadeDelete: false, minSelect: null, maxSelect: 1
+      },
+      {
+        type: "relation", name: "merge", required: false, presentable: false,
+        collectionId: mergesCol.id, cascadeDelete: false, minSelect: null, maxSelect: 1
+      },
+      {
+        type: "relation", name: "scenario", required: false, presentable: false,
+        collectionId: scenariosCol.id, cascadeDelete: true, minSelect: null, maxSelect: 1
+      },
+      { type: "number", name: "household_cm_id", required: false, presentable: false, min: null, max: null, onlyInt: true },
+      { type: "number", name: "person_cm_id", required: false, presentable: false, min: null, max: null, onlyInt: true },
+      { type: "number", name: "party_size", required: false, presentable: false, min: null, max: null, onlyInt: true },
+      {
+        type: "select", name: "source", required: false, presentable: false,
+        values: ["campminder_sync", "jotform_sync", "staff_manual"], maxSelect: 1
+      },
+      { type: "bool", name: "staff_touched", required: false, presentable: false },
+      { type: "autodate", name: "created", required: false, presentable: false, onCreate: true, onUpdate: false },
+      { type: "autodate", name: "updated", required: false, presentable: false, onCreate: true, onUpdate: true }
+    ],
+    indexes: [
+      "CREATE INDEX `idx_lodging_assign_session_year` ON `lodging_assignments` (`session`, `year`)",
+      "CREATE INDEX `idx_lodging_assign_household` ON `lodging_assignments` (`household_cm_id`, `year`)",
+      "CREATE INDEX `idx_lodging_assign_person` ON `lodging_assignments` (`person_cm_id`, `year`)",
+      // One live (scenario-less) row per household per session, and per person.
+      //
+      // The predicates MUST use `> 0`, not `!= ''`. PocketBase declares number
+      // fields as `NUMERIC DEFAULT 0 NOT NULL`, so an unset household_cm_id is 0
+      // — and SQLite evaluates `0 != ''` as TRUE (numeric-vs-text comparison).
+      // With `!= ''` the household index would capture every person-grain row
+      // (all household_cm_id = 0) and collide them, permitting only ONE adult
+      // assignment per session. Relations are `TEXT DEFAULT '' NOT NULL`, so
+      // `scenario = ''` is correct for "the live plan".
+      "CREATE UNIQUE INDEX `idx_lodging_assign_hh_live` ON `lodging_assignments` (`session`, `year`, `household_cm_id`) WHERE `household_cm_id` > 0 AND `scenario` = ''",
+      "CREATE UNIQUE INDEX `idx_lodging_assign_person_live` ON `lodging_assignments` (`session`, `year`, `person_cm_id`) WHERE `person_cm_id` > 0 AND `scenario` = ''"
+    ]
+  });
+  app.save(assignments);
+
+  const history = new Collection({
+    type: "base",
+    name: "lodging_assignment_history",
+    listRule: '@request.auth.id != ""',
+    viewRule: '@request.auth.id != ""',
+    createRule: '@request.auth.is_admin = true',
+    updateRule: '@request.auth.is_admin = true',
+    deleteRule: '@request.auth.is_admin = true',
+    fields: [
+      { type: "number", name: "household_cm_id", required: false, presentable: false, min: null, max: null, onlyInt: true },
+      { type: "number", name: "person_cm_id", required: false, presentable: false, min: null, max: null, onlyInt: true },
+      {
+        type: "relation", name: "session", required: false, presentable: false,
+        collectionId: sessionsCol.id, cascadeDelete: false, minSelect: null, maxSelect: 1
+      },
+      { type: "number", name: "year", required: true, presentable: false, min: 2010, max: 2100, onlyInt: true },
+      // TEXT, not relations: an unresolvable historical string is still recorded.
+      { type: "text", name: "old_unit", required: false, presentable: false, min: 0, max: 300, pattern: "" },
+      { type: "text", name: "new_unit", required: false, presentable: false, min: 0, max: 300, pattern: "" },
+      { type: "text", name: "detected_at", required: true, presentable: false, min: 1, max: 50, pattern: "" },
+      { type: "text", name: "source_field", required: false, presentable: false, min: 0, max: 200, pattern: "" },
+      { type: "autodate", name: "created", required: false, presentable: false, onCreate: true, onUpdate: false }
+    ],
+    indexes: [
+      "CREATE INDEX `idx_lodging_hist_household_year` ON `lodging_assignment_history` (`household_cm_id`, `year`)",
+      "CREATE INDEX `idx_lodging_hist_person_year` ON `lodging_assignment_history` (`person_cm_id`, `year`)",
+      "CREATE INDEX `idx_lodging_hist_session` ON `lodging_assignment_history` (`session`, `year`)"
+    ]
+  });
+  app.save(history);
+}, (app) => {
+  app.delete(app.findCollectionByNameOrId("lodging_assignment_history"));
+  app.delete(app.findCollectionByNameOrId("lodging_assignments"));
+});

--- a/pocketbase/pb_migrations/1500000119_lodging_assignments.js
+++ b/pocketbase/pb_migrations/1500000119_lodging_assignments.js
@@ -11,6 +11,14 @@
  *
  * Either unit (an atomic room) or merge (a merged slot) is set, not both.
  *
+ * !! NEITHER XOR IS ENFORCED BY THIS SCHEMA. !! Both pairs are optional fields,
+ * there is no CHECK constraint, and the partial unique indexes below only dedupe
+ * WITHIN a grain — they do not reject a row with both set or neither. All three
+ * illegal states are accepted by the DB today (verified live). This is deliberate
+ * per spec 3.5/9a: the invariant lives above the database. The consequence is that
+ * it is guaranteed NOWHERE until Plan 2 adds tests and Plan 3 adds write-path
+ * guards. Do not read the two rules above as storage guarantees.
+ *
  * History is append-only and mirrors attendee_status_history's shape
  * (detected_at / old_* / new_* / session / year). It exists because CampMinder
  * stores ONE cabin value per household per YEAR: a household attending two

--- a/pocketbase/pb_migrations/1500000120_seed_lodging_registry.js
+++ b/pocketbase/pb_migrations/1500000120_seed_lodging_registry.js
@@ -1,0 +1,241 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Seed: lodging_areas + lodging_units
+ *
+ * Coordinates are label positions from the 2026 camp map, normalised to 0-1 on
+ * its 792x612 canvas. `sleeps` is seeded from observed PEAK occupancy across
+ * 2024-2025 assignments and is a GUESS — every row is written with
+ * is_confirmed: false so the UI can flag unverified values.
+ *
+ * Map notes worth preserving:
+ *  - Ridge Side cabins are bare letters A-M on the map; River Side are v-prefixed
+ *    vA-vM. The "v" is shorthand added when boys'/girls' side were renamed to
+ *    Ridge/River (both start with R). 13 cabins per side.
+ *  - Manzanita 6 does NOT exist — the map shows M1-M5 and M7.
+ *  - Health Center Upstairs is 1-6; 2 is real but unused in 2024-25, so sleeps is null.
+ *  - Tawonga Village is the canonical name (matches the map). "Teen Village" is
+ *    an alias used by the family-camp field. TV5 subdivides into 5a/5b.
+ *  - Wawona is the OLD Doctor's House (Golden Triangle), renamed in 2025, and
+ *    splits Front(1)/Back(2). The bare "Doctor's House" is the NEWER building at
+ *    the Health Center. They are distinct and were occupied simultaneously in
+ *    2022, 2023 and 2024.
+ *
+ * This seed is idempotent: it skips any unit whose code already exists, so it is
+ * safe on a database where an earlier partial run happened.
+ */
+
+migrate((app) => {
+  const AREAS = [
+    { code: "RIDGE", name: "Ridge Side", x: 0.5000, y: 0.2900, sort: 1 },
+    { code: "RIVER", name: "River Side", x: 0.4900, y: 0.7000, sort: 2 },
+    { code: "YURT",  name: "Ridge Yurts", x: 0.2900, y: 0.3100, sort: 3 },
+    { code: "GT",    name: "Golden Triangle", x: 0.7800, y: 0.6300, sort: 4 },
+    { code: "HC",    name: "Health Center", x: 0.7294, y: 0.5747, sort: 5 },
+    { code: "TV",    name: "Tawonga Village", x: 0.6900, y: 0.2200, sort: 6 },
+    { code: "MANZ",  name: "Manzanitas", x: 0.4700, y: 0.1900, sort: 7 },
+    { code: "TUOL",  name: "Tuolumne Heights", x: 0.1000, y: 0.6400, sort: 8 }
+  ];
+
+  const areasCol = app.findCollectionByNameOrId("lodging_areas");
+  const areaIds = {};
+  for (let i = 0; i < AREAS.length; i++) {
+    const a = AREAS[i];
+    let rec;
+    try {
+      rec = app.findFirstRecordByFilter("lodging_areas", "code = {:c}", { c: a.code });
+    } catch (_e) {
+      rec = null;
+    }
+    if (!rec) {
+      rec = new Record(areasCol);
+      rec.set("code", a.code);
+      rec.set("name", a.name);
+      rec.set("map_x", a.x);
+      rec.set("map_y", a.y);
+      rec.set("sort_order", a.sort);
+      app.save(rec);
+    }
+    areaIds[a.code] = rec.id;
+  }
+
+  // Bathhouse label positions from the map, used to seed near_bathhouse.
+  const BATHHOUSES = [
+    [0.4992, 0.3266], // Ridgeside
+    [0.5374, 0.6811], // Central
+    [0.1509, 0.6427], // Staff
+    [0.6500, 0.2379]  // Tawonga Village
+  ];
+  const NEAR_BH = 0.09; // normalised-canvas radius; tune later against actuals
+
+  function nearBathhouse(x, y) {
+    for (let i = 0; i < BATHHOUSES.length; i++) {
+      const dx = x - BATHHOUSES[i][0];
+      const dy = y - BATHHOUSES[i][1];
+      if (Math.sqrt(dx * dx + dy * dy) <= NEAR_BH) return true;
+    }
+    return false;
+  }
+
+  // [area, name, code, x, y, sleeps, bathroom, bathroom_group, parent_code, allocation]
+  // sleeps = observed peak people 2024-2025; null = never observed.
+  const UNITS = [
+    // --- Ridge Side (bare letters on the map) ---
+    ["RIDGE", "Ridge A", "ridge-a", 0.4389, 0.3311, 5, "none", "", "", "family_pool"],
+    ["RIDGE", "Ridge B", "ridge-b", 0.4151, 0.3462, 5, "none", "", "", "family_pool"],
+    ["RIDGE", "Ridge C", "ridge-c", 0.3960, 0.3177, 5, "none", "", "", "family_pool"],
+    ["RIDGE", "Ridge D", "ridge-d", 0.3823, 0.2872, 8, "none", "", "", "family_pool"],
+    ["RIDGE", "Ridge E", "ridge-e", 0.4138, 0.2591, 8, "none", "", "", "family_pool"],
+    ["RIDGE", "Ridge F", "ridge-f", 0.4395, 0.2695, 8, "none", "", "", "family_pool"],
+    ["RIDGE", "Ridge G", "ridge-g", 0.4645, 0.2773, 9, "none", "", "", "family_pool"],
+    ["RIDGE", "Ridge H", "ridge-h", 0.5199, 0.2911, 9, "none", "", "", "family_pool"],
+    ["RIDGE", "Ridge I", "ridge-i", 0.5481, 0.2856, 9, "none", "", "", "family_pool"],
+    ["RIDGE", "Ridge J", "ridge-j", 0.5692, 0.2869, 5, "none", "", "", "family_pool"],
+    ["RIDGE", "Ridge K", "ridge-k", 0.5949, 0.2880, 5, "none", "", "", "family_pool"],
+    ["RIDGE", "Ridge L", "ridge-l", 0.6218, 0.2894, 8, "none", "", "", "family_pool"],
+    ["RIDGE", "Ridge M", "ridge-m", 0.6505, 0.2982, 5, "none", "", "", "family_pool"],
+    // --- River Side (vA-vM on the map) ---
+    ["RIVER", "River A", "river-a", 0.5924, 0.7035, 6, "none", "", "", "family_pool"],
+    ["RIVER", "River B", "river-b", 0.5665, 0.7133, 5, "none", "", "", "family_pool"],
+    ["RIVER", "River C", "river-c", 0.5317, 0.7078, 5, "none", "", "", "family_pool"],
+    ["RIVER", "River D", "river-d", 0.5070, 0.6734, 9, "none", "", "", "family_pool"],
+    ["RIVER", "River E", "river-e", 0.4819, 0.6459, 8, "none", "", "", "family_pool"],
+    ["RIVER", "River F", "river-f", 0.4525, 0.6404, 6, "none", "", "", "family_pool"],
+    ["RIVER", "River G", "river-g", 0.4216, 0.6455, 7, "none", "", "", "family_pool"],
+    ["RIVER", "River H", "river-h", 0.4116, 0.6785, 8, "none", "", "", "family_pool"],
+    ["RIVER", "River I", "river-i", 0.4357, 0.6898, 4, "none", "", "", "family_pool"],
+    ["RIVER", "River J", "river-j", 0.4865, 0.7029, 8, "none", "", "", "family_pool"],
+    ["RIVER", "River K", "river-k", 0.5006, 0.7382, 6, "none", "", "", "family_pool"],
+    ["RIVER", "River L", "river-l", 0.5339, 0.7576, 4, "none", "", "", "family_pool"],
+    ["RIVER", "River M", "river-m", 0.5702, 0.7605, 5, "none", "", "", "family_pool"],
+    // --- Ridge Yurts ---
+    ["YURT", "Ridge Yurt 1", "ridge-yurt-1", 0.3374, 0.2951, 4, "none", "", "", "family_pool"],
+    ["YURT", "Ridge Yurt 2", "ridge-yurt-2", 0.3186, 0.3186, 4, "none", "", "", "family_pool"],
+    ["YURT", "Ridge Yurt 3", "ridge-yurt-3", 0.2977, 0.3442, 4, "none", "", "", "family_pool"],
+    ["YURT", "Ridge Yurt 4", "ridge-yurt-4", 0.2684, 0.3575, 4, "none", "", "", "family_pool"],
+    ["YURT", "Ridge Yurt 5", "ridge-yurt-5", 0.2483, 0.2986, 3, "none", "", "", "family_pool"],
+    ["YURT", "Ridge Yurt 6", "ridge-yurt-6", 0.2691, 0.2693, 4, "none", "", "", "family_pool"],
+    ["YURT", "Ridge Yurt 7", "ridge-yurt-7", 0.2833, 0.2987, 4, "none", "", "", "family_pool"],
+    // --- Tuolumne Heights ---
+    ["TUOL", "Tuolumne 1", "tuolumne-1", 0.1046, 0.6029, 4, "none", "", "", "family_pool"],
+    ["TUOL", "Tuolumne 2", "tuolumne-2", 0.1081, 0.6705, 3, "none", "", "", "family_pool"],
+    ["TUOL", "Tuolumne 3", "tuolumne-3", 0.0784, 0.6724, 2, "none", "", "", "family_pool"],
+    ["TUOL", "Tuolumne 4", "tuolumne-4", 0.0741, 0.6411, 4, "none", "", "", "family_pool"],
+    ["TUOL", "Tuolumne 5", "tuolumne-5", 0.0801, 0.5926, 4, "none", "", "", "family_pool"],
+    ["TUOL", "Tuolumne 6", "tuolumne-6", 0.1023, 0.5700, 3, "none", "", "", "family_pool"],
+    ["TUOL", "Tuolumne 7", "tuolumne-7", 0.1338, 0.7324, null, "none", "", "", "family_pool"],
+    // --- Manzanitas (no 6 — absent from the map) ---
+    ["MANZ", "Manzanita 1", "manzanita-1", 0.4632, 0.2234, 4, "none", "", "", "family_pool"],
+    ["MANZ", "Manzanita 2", "manzanita-2", 0.4694, 0.1974, 5, "none", "", "", "family_pool"],
+    ["MANZ", "Manzanita 3", "manzanita-3", 0.4339, 0.1806, 5, "none", "", "", "family_pool"],
+    ["MANZ", "Manzanita 4", "manzanita-4", 0.4562, 0.1543, 4, "none", "", "", "family_pool"],
+    ["MANZ", "Manzanita 5", "manzanita-5", 0.4808, 0.1717, 4, "none", "", "", "family_pool"],
+    ["MANZ", "Manzanita 7", "manzanita-7", 0.5389, 0.1765, 4, "none", "", "", "family_pool"],
+    // --- Tawonga Village (TV5 subdivides into 5a/5b) ---
+    ["TV", "Tawonga Village 1", "tawonga-village-1", 0.6835, 0.2575, 8, "none", "", "", "family_pool"],
+    ["TV", "Tawonga Village 2", "tawonga-village-2", 0.7252, 0.2458, 9, "none", "", "", "family_pool"],
+    ["TV", "Tawonga Village 3", "tawonga-village-3", 0.7012, 0.2251, 7, "none", "", "", "family_pool"],
+    ["TV", "Tawonga Village 4", "tawonga-village-4", 0.6948, 0.1916, 8, "none", "", "", "family_pool"],
+    ["TV", "Tawonga Village 5", "tawonga-village-5", 0.6510, 0.1782, null, "none", "", "", "family_pool"],
+    ["TV", "Tawonga Village 5a", "tawonga-village-5a", 0.6480, 0.1760, 4, "none", "tv-5", "tawonga-village-5", "family_pool"],
+    ["TV", "Tawonga Village 5b", "tawonga-village-5b", 0.6540, 0.1805, 4, "none", "tv-5", "tawonga-village-5", "family_pool"],
+    // --- Golden Triangle ---
+    ["GT", "El Cap", "gt-el-cap", 0.8735, 0.5879, 6, "none", "", "", "family_pool"],
+    ["GT", "Half Dome", "gt-half-dome", 0.8790, 0.5940, 7, "none", "", "", "family_pool"],
+    ["GT", "Kitty", "gt-kitty", 0.6381, 0.6327, null, "none", "", "", "family_pool"],
+    ["GT", "Kitty 2", "gt-kitty-2", 0.6350, 0.6300, 4, "none", "", "gt-kitty", "family_pool"],
+    ["GT", "Kitty 3", "gt-kitty-3", 0.6412, 0.6355, 4, "none", "", "gt-kitty", "family_pool"],
+    ["GT", "Tenaya", "gt-tenaya", 0.8813, 0.6274, null, "none", "", "", "family_pool"],
+    ["GT", "Tenaya 1", "gt-tenaya-1", 0.8760, 0.6230, 5, "shared", "gt-tenaya-12", "gt-tenaya", "family_pool"],
+    ["GT", "Tenaya 2", "gt-tenaya-2", 0.8800, 0.6260, 5, "shared", "gt-tenaya-12", "gt-tenaya", "family_pool"],
+    ["GT", "Tenaya 3", "gt-tenaya-3", 0.8840, 0.6295, 5, "shared", "", "gt-tenaya", "family_pool"],
+    ["GT", "Tenaya 4", "gt-tenaya-4", 0.8880, 0.6330, 4, "shared", "", "gt-tenaya", "family_pool"],
+    ["GT", "Tioga", "gt-tioga", 0.8206, 0.7127, null, "none", "", "", "family_pool"],
+    ["GT", "Tioga 1", "gt-tioga-1", 0.8150, 0.7080, 5, "shared", "gt-tioga-12", "gt-tioga", "family_pool"],
+    ["GT", "Tioga 2", "gt-tioga-2", 0.8190, 0.7110, 4, "shared", "gt-tioga-12", "gt-tioga", "family_pool"],
+    ["GT", "Tioga 3", "gt-tioga-3", 0.8230, 0.7145, 4, "shared", "", "gt-tioga", "family_pool"],
+    ["GT", "Tioga 4", "gt-tioga-4", 0.8270, 0.7180, 5, "shared", "", "gt-tioga", "family_pool"],
+    ["GT", "Clouds Rest", "gt-clouds-rest", 0.7087, 0.6620, 7, "none", "", "", "family_pool"],
+    ["GT", "Clouds Rest Loft", "gt-clouds-rest-loft", 0.7060, 0.6590, 2, "shared", "gt-clouds-rest", "gt-clouds-rest", "family_pool"],
+    ["GT", "Clouds Rest Side Room", "gt-clouds-rest-side", 0.7100, 0.6640, 2, "shared", "gt-clouds-rest", "gt-clouds-rest", "family_pool"],
+    ["GT", "Clouds Rest Back Room", "gt-clouds-rest-back", 0.7120, 0.6660, 1, "shared", "gt-clouds-rest", "gt-clouds-rest", "family_pool"],
+    ["GT", "Clouds Rest Laundry Room", "gt-clouds-rest-laundry", 0.7140, 0.6680, 1, "shared", "gt-clouds-rest", "gt-clouds-rest", "family_pool"],
+    // Wawona = the OLD Doctor's House, renamed 2025. Front(1)/Back(2).
+    ["GT", "Wawona", "gt-wawona", 0.7591, 0.6007, 7, "none", "", "", "family_pool"],
+    ["GT", "Wawona Front", "gt-wawona-front", 0.7560, 0.5980, 3, "shared", "gt-wawona", "gt-wawona", "family_pool"],
+    ["GT", "Wawona Back", "gt-wawona-back", 0.7620, 0.6035, 3, "shared", "gt-wawona", "gt-wawona", "family_pool"],
+    ["GT", "Lofty", "gt-lofty", 0.6724, 0.6322, null, "none", "", "", "staff_default"],
+    ["GT", "Le Shack", "gt-le-shack", 0.8554, 0.6791, null, "none", "", "", "staff_default"],
+    // --- Health Center ---
+    ["HC", "Health Center Upstairs 1", "hc-upstairs-1", 0.7270, 0.5700, 4, "shared", "hc-upstairs-hall", "", "family_pool"],
+    ["HC", "Health Center Upstairs 2", "hc-upstairs-2", 0.7280, 0.5715, null, "shared", "hc-upstairs-hall", "", "family_pool"],
+    ["HC", "Health Center Upstairs 3", "hc-upstairs-3", 0.7290, 0.5730, 8, "shared", "hc-upstairs-hall", "", "family_pool"],
+    ["HC", "Health Center Upstairs 4", "hc-upstairs-4", 0.7300, 0.5745, 4, "shared", "hc-upstairs-hall", "", "family_pool"],
+    ["HC", "Health Center Upstairs 5", "hc-upstairs-5", 0.7310, 0.5760, 4, "private", "", "", "family_pool"],
+    ["HC", "Health Center Upstairs 6", "hc-upstairs-6", 0.7320, 0.5775, 6, "shared", "hc-upstairs-hall", "", "family_pool"],
+    ["HC", "Health Center Downstairs", "hc-downstairs", 0.7294, 0.5820, 5, "none", "", "", "family_pool"],
+    ["HC", "Health Center Downstairs A", "hc-downstairs-a", 0.7280, 0.5810, 2, "shared", "hc-downstairs", "hc-downstairs", "family_pool"],
+    ["HC", "Health Center Downstairs B", "hc-downstairs-b", 0.7310, 0.5835, 2, "shared", "hc-downstairs", "hc-downstairs", "family_pool"],
+    // The NEWER Doctor's House. Reaches 2 households in one weekend, so it has
+    // >=2 rooms — room list unknown, see spec open item 4.
+    ["HC", "Doctor's House", "hc-doctors-house", 0.7350, 0.5700, 6, "private", "", "", "family_pool"],
+    ["HC", "Bayit", "hc-bayit", 0.7072, 0.5500, null, "none", "", "", "staff_default"]
+  ];
+
+  const unitsCol = app.findCollectionByNameOrId("lodging_units");
+  const unitIds = {};
+
+  // Pass 1: create every unit without parent_unit (parents may appear later).
+  for (let i = 0; i < UNITS.length; i++) {
+    const u = UNITS[i];
+    let rec;
+    try {
+      rec = app.findFirstRecordByFilter("lodging_units", "code = {:c}", { c: u[2] });
+    } catch (_e) {
+      rec = null;
+    }
+    if (!rec) {
+      rec = new Record(unitsCol);
+      rec.set("area", areaIds[u[0]]);
+      rec.set("name", u[1]);
+      rec.set("code", u[2]);
+      rec.set("map_x", u[3]);
+      rec.set("map_y", u[4]);
+      if (u[5] !== null) rec.set("sleeps", u[5]);
+      rec.set("bathroom", u[6]);
+      rec.set("bathroom_group", u[7]);
+      rec.set("near_bathhouse", nearBathhouse(u[3], u[4]));
+      rec.set("allocation_default", u[9]);
+      rec.set("is_confirmed", false);
+      rec.set("is_active", true);
+      app.save(rec);
+    }
+    unitIds[u[2]] = rec.id;
+  }
+
+  // Pass 2: wire parent_unit now that every code has an id.
+  for (let i = 0; i < UNITS.length; i++) {
+    const u = UNITS[i];
+    if (!u[8]) continue;
+    const rec = app.findFirstRecordByFilter("lodging_units", "code = {:c}", { c: u[2] });
+    if (!rec.get("parent_unit")) {
+      rec.set("parent_unit", unitIds[u[8]]);
+      app.save(rec);
+    }
+  }
+}, (app) => {
+  // Truncates both registry tables. That is correct for a revert of THIS
+  // migration, because it is the only thing that populates them — but note it
+  // also removes any rows staff added by hand afterwards. Use an explicit large
+  // limit: a 0 limit is version-dependent in the JSVM binding and can return
+  // nothing, silently making the down a no-op.
+  //
+  // Delete units before areas: units hold a required relation to areas.
+  const units = app.findRecordsByFilter("lodging_units", "id != ''", "", 100000, 0);
+  for (let i = 0; i < units.length; i++) {
+    app.delete(units[i]);
+  }
+  const areas = app.findRecordsByFilter("lodging_areas", "id != ''", "", 100000, 0);
+  for (let i = 0; i < areas.length; i++) {
+    app.delete(areas[i]);
+  }
+});

--- a/pocketbase/pb_migrations/1500000120_seed_lodging_registry.js
+++ b/pocketbase/pb_migrations/1500000120_seed_lodging_registry.js
@@ -27,6 +27,23 @@
  */
 
 migrate((app) => {
+  // Idempotency lookup. findFirstRecordByFilter returns sql.ErrNoRows verbatim
+  // when nothing matches (core/record_query.go:454, v0.39.9), which surfaces here
+  // as "sql: no rows in result set" — that is the "not seeded yet" signal.
+  //
+  // ANY other error (malformed filter, DB lock, closed connection) is real. A bare
+  // `catch { return null }` would treat it as "not seeded", insert a duplicate, and
+  // die on the unique index with validation_not_unique — hiding the actual cause.
+  // So: rethrow anything that is not the not-found case.
+  const findSeeded = (collection, filter, params) => {
+    try {
+      return app.findFirstRecordByFilter(collection, filter, params);
+    } catch (e) {
+      if (String(e).indexOf("no rows in result set") === -1) throw e;
+      return null;
+    }
+  };
+
   // Building/grouping rows — never bookable, never counted toward capacity.
   const CONTAINER_CODES = ["gt-kitty", "gt-tenaya", "gt-tioga", "gt-clouds-rest", "gt-wawona", "hc-downstairs", "tawonga-village-5"];
 
@@ -45,12 +62,7 @@ migrate((app) => {
   const areaIds = {};
   for (let i = 0; i < AREAS.length; i++) {
     const a = AREAS[i];
-    let rec;
-    try {
-      rec = app.findFirstRecordByFilter("lodging_areas", "code = {:c}", { c: a.code });
-    } catch (_e) {
-      rec = null;
-    }
+    let rec = findSeeded("lodging_areas", "code = {:c}", { c: a.code });
     if (!rec) {
       rec = new Record(areasCol);
       rec.set("code", a.code);
@@ -195,12 +207,7 @@ migrate((app) => {
   // Pass 1: create every unit without parent_unit (parents may appear later).
   for (let i = 0; i < UNITS.length; i++) {
     const u = UNITS[i];
-    let rec;
-    try {
-      rec = app.findFirstRecordByFilter("lodging_units", "code = {:c}", { c: u[2] });
-    } catch (_e) {
-      rec = null;
-    }
+    let rec = findSeeded("lodging_units", "code = {:c}", { c: u[2] });
     if (!rec) {
       rec = new Record(unitsCol);
       rec.set("area", areaIds[u[0]]);

--- a/pocketbase/pb_migrations/1500000120_seed_lodging_registry.js
+++ b/pocketbase/pb_migrations/1500000120_seed_lodging_registry.js
@@ -5,7 +5,9 @@
  * Coordinates are label positions from the 2026 camp map, normalised to 0-1 on
  * its 792x612 canvas. `sleeps` is seeded from observed PEAK occupancy across
  * 2024-2025 assignments and is a GUESS — every row is written with
- * is_confirmed: false so the UI can flag unverified values.
+ * is_confirmed: false so the UI can flag unverified values. PocketBase number
+ * fields are `NUMERIC DEFAULT 0 NOT NULL`, so an unset `sleeps` stores as 0,
+ * not null — consumers must treat 0 as "unknown", not "zero capacity".
  *
  * Map notes worth preserving:
  *  - Ridge Side cabins are bare letters A-M on the map; River Side are v-prefixed
@@ -25,6 +27,9 @@
  */
 
 migrate((app) => {
+  // Building/grouping rows — never bookable, never counted toward capacity.
+  const CONTAINER_CODES = ["gt-kitty", "gt-tenaya", "gt-tioga", "gt-clouds-rest", "gt-wawona", "hc-downstairs", "tawonga-village-5"];
+
   const AREAS = [
     { code: "RIDGE", name: "Ridge Side", x: 0.5000, y: 0.2900, sort: 1 },
     { code: "RIVER", name: "River Side", x: 0.4900, y: 0.7000, sort: 2 },
@@ -77,7 +82,10 @@ migrate((app) => {
   }
 
   // [area, name, code, x, y, sleeps, bathroom, bathroom_group, parent_code, allocation]
-  // sleeps = observed peak people 2024-2025; null = never observed.
+  // sleeps = observed peak people 2024-2025; null here means never observed,
+  // which the loop below leaves unset — PocketBase then stores it as 0 (its
+  // NUMERIC NOT NULL default), so consumers must treat 0 as "unknown", not
+  // "zero capacity".
   const UNITS = [
     // --- Ridge Side (bare letters on the map) ---
     ["RIDGE", "Ridge A", "ridge-a", 0.4389, 0.3311, 5, "none", "", "", "family_pool"],
@@ -207,6 +215,7 @@ migrate((app) => {
       rec.set("allocation_default", u[9]);
       rec.set("is_confirmed", false);
       rec.set("is_active", true);
+      rec.set("is_container", CONTAINER_CODES.indexOf(u[2]) !== -1);
       app.save(rec);
     }
     unitIds[u[2]] = rec.id;

--- a/pocketbase/pb_migrations/1500000121_seed_lodging_aliases.js
+++ b/pocketbase/pb_migrations/1500000121_seed_lodging_aliases.js
@@ -1,0 +1,183 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Seed: lodging_unit_aliases
+ *
+ * Every distinct cabin string observed 2022-2026 in:
+ *   - "Family Camp Cabin"            (partition ["Family"],  household_custom_values)
+ *   - "Reportable Family Camp Cabin" (partition ["Camper","Adult"], person_custom_values)
+ *
+ * Temporal windows record two renames that happened in 2025:
+ *   "Golden Triangle - Doctor's House" (<=2024) -> "Golden Triangle - Wawona" (2025+)
+ *   "Health Center - Doctor's House"   (<=2024) -> "Doctor's House"           (2025+)
+ * Both buildings existed simultaneously in 2022-2024, so they are distinct units.
+ *
+ * "Teen Village N" (family field) and "Tawonga Village N" (adult field) are the
+ * SAME six units: identical numbering including the unusual 5a/5b split, and they
+ * never appear in the same field. Tawonga Village is canonical (matches the map).
+ *
+ * Multi-member aliases denote merges, materialised as lodging_merges rows by the
+ * Plan 2 backfill. Strings are verbatim — the double space in
+ * "Health Center Downstairs  - Room A" is real. Do not trim.
+ *
+ * Idempotent: skips any (alias_string, valid_from_year) that already exists.
+ */
+
+migrate((app) => {
+  // [alias_string, [unit_codes], valid_from_year, valid_to_year]
+  // null year = no bound.
+  const ALIASES = [
+    // --- straightforward one-to-one, all years ---
+    ["Ridge A", ["ridge-a"], null, null],
+    ["Ridge B", ["ridge-b"], null, null],
+    ["Ridge C", ["ridge-c"], null, null],
+    ["Ridge D", ["ridge-d"], null, null],
+    ["Ridge E", ["ridge-e"], null, null],
+    ["Ridge F", ["ridge-f"], null, null],
+    ["Ridge G", ["ridge-g"], null, null],
+    ["Ridge H", ["ridge-h"], null, null],
+    ["Ridge I", ["ridge-i"], null, null],
+    ["Ridge J", ["ridge-j"], null, null],
+    ["Ridge K", ["ridge-k"], null, null],
+    ["Ridge L", ["ridge-l"], null, null],
+    ["Ridge M", ["ridge-m"], null, null],
+    ["River A", ["river-a"], null, null],
+    ["River B", ["river-b"], null, null],
+    ["River C", ["river-c"], null, null],
+    ["River D", ["river-d"], null, null],
+    ["River E", ["river-e"], null, null],
+    ["River F", ["river-f"], null, null],
+    ["River G", ["river-g"], null, null],
+    ["River H", ["river-h"], null, null],
+    ["River I", ["river-i"], null, null],
+    ["River J", ["river-j"], null, null],
+    ["River K", ["river-k"], null, null],
+    ["River L", ["river-l"], null, null],
+    ["River M", ["river-m"], null, null],
+    ["Ridge Yurt 1", ["ridge-yurt-1"], null, null],
+    ["Ridge Yurt 2", ["ridge-yurt-2"], null, null],
+    ["Ridge Yurt 3", ["ridge-yurt-3"], null, null],
+    ["Ridge Yurt 4", ["ridge-yurt-4"], null, null],
+    ["Ridge Yurt 5", ["ridge-yurt-5"], null, null],
+    ["Ridge Yurt 6", ["ridge-yurt-6"], null, null],
+    ["Ridge Yurt 7", ["ridge-yurt-7"], null, null],
+    ["Tuolumne 1", ["tuolumne-1"], null, null],
+    ["Tuolumne 2", ["tuolumne-2"], null, null],
+    ["Tuolumne 3", ["tuolumne-3"], null, null],
+    ["Tuolumne 4", ["tuolumne-4"], null, null],
+    ["Tuolumne 5", ["tuolumne-5"], null, null],
+    ["Tuolumne 6", ["tuolumne-6"], null, null],
+    ["Manzanita 1", ["manzanita-1"], null, null],
+    ["Manzanita 2", ["manzanita-2"], null, null],
+    ["Manzanita 3", ["manzanita-3"], null, null],
+    ["Manzanita 4", ["manzanita-4"], null, null],
+    ["Manzanita 5", ["manzanita-5"], null, null],
+    ["Manzanita 7", ["manzanita-7"], null, null],
+    ["New Trailer (Manzanitas)", ["manzanita-7"], null, null],
+    // --- Teen Village (family field) == Tawonga Village (adult field) ---
+    ["Teen Village 1", ["tawonga-village-1"], null, null],
+    ["Teen Village 2", ["tawonga-village-2"], null, null],
+    ["Teen Village 3", ["tawonga-village-3"], null, null],
+    ["Teen Village 4", ["tawonga-village-4"], null, null],
+    ["Teen Village 5a", ["tawonga-village-5a"], null, null],
+    ["Teen Village 5b", ["tawonga-village-5b"], null, null],
+    ["Tawonga Village 1", ["tawonga-village-1"], null, null],
+    ["Tawonga Village 2", ["tawonga-village-2"], null, null],
+    ["Tawonga Village 3", ["tawonga-village-3"], null, null],
+    ["Tawonga Village 4", ["tawonga-village-4"], null, null],
+    ["Tawonga Village 5a", ["tawonga-village-5a"], null, null],
+    ["Tawonga Village 5b", ["tawonga-village-5b"], null, null],
+    // --- Golden Triangle ---
+    ["Golden Triangle - El Cap", ["gt-el-cap"], null, null],
+    ["Golden Triangle - Half Dome", ["gt-half-dome"], null, null],
+    ["Golden Triangle - Kitty 2", ["gt-kitty-2"], null, null],
+    ["Golden Triangle - Kitty 3", ["gt-kitty-3"], null, null],
+    ["Golden Triangle - Tenaya 1", ["gt-tenaya-1"], null, null],
+    ["Golden Triangle - Tenaya 2", ["gt-tenaya-2"], null, null],
+    ["Golden Triangle - Tenaya 3", ["gt-tenaya-3"], null, null],
+    ["Golden Triangle - Tenaya 4", ["gt-tenaya-4"], null, null],
+    ["Golden Triangle - Tioga 1", ["gt-tioga-1"], null, null],
+    ["Golden Triangle - Tioga 2", ["gt-tioga-2"], null, null],
+    ["Golden Triangle - Tioga 3", ["gt-tioga-3"], null, null],
+    ["Golden Triangle - Tioga 4", ["gt-tioga-4"], null, null],
+    ["Golden Triangle - Cloud's Rest", ["gt-clouds-rest"], null, null],
+    ["Golden Triangle - Cloud's Rest (Loft)", ["gt-clouds-rest-loft"], null, null],
+    ["Golden Triangle - Cloud's Rest (Side room)", ["gt-clouds-rest-side"], null, null],
+    ["Golden Triangle - Cloud's Rest (Back room)", ["gt-clouds-rest-back"], null, null],
+    ["Golden Triangle - Cloud's Rest (Laundry room)", ["gt-clouds-rest-laundry"], null, null],
+    // --- merges (2+ members) ---
+    ["Golden Triangle - Tenaya 1and2", ["gt-tenaya-1", "gt-tenaya-2"], null, null],
+    ["Golden Triangle - Tioga 1and2", ["gt-tioga-1", "gt-tioga-2"], null, null],
+    ["Health Center - Downstairs 1and2", ["hc-downstairs-a", "hc-downstairs-b"], null, null],
+    ["Health Center Downstairs", ["hc-downstairs-a", "hc-downstairs-b"], null, null],
+    // --- Wawona: the old GT Doctor's House, renamed 2025 ---
+    ["Golden Triangle - Doctor's House", ["gt-wawona"], null, 2024],
+    ["Golden Triangle - Wawona", ["gt-wawona-front", "gt-wawona-back"], 2025, null],
+    ["Golden Triangle - Wawona Front", ["gt-wawona-front"], null, null],
+    ["Golden Triangle - Wawona Back", ["gt-wawona-back"], null, null],
+    ["Golden Triangle - Wawona (Front)", ["gt-wawona-front"], null, null],
+    ["Golden Triangle - Wawona (Back)", ["gt-wawona-back"], null, null],
+    // --- Doctor's House: the newer HC building ---
+    ["Health Center - Doctor's House", ["hc-doctors-house"], null, 2024],
+    ["Doctor's House", ["hc-doctors-house"], 2025, null],
+    // --- Health Center rooms; A/B replaced 1/2 ---
+    ["Health Center - Upstairs 1", ["hc-upstairs-1"], null, null],
+    ["Health Center - Upstairs 2", ["hc-upstairs-2"], null, null],
+    ["Health Center - Upstairs 3", ["hc-upstairs-3"], null, null],
+    ["Health Center - Upstairs 4", ["hc-upstairs-4"], null, null],
+    ["Health Center - Upstairs 5", ["hc-upstairs-5"], null, null],
+    ["Health Center - Upstairs 6", ["hc-upstairs-6"], null, null],
+    ["Health Center - Downstairs 1", ["hc-downstairs-a"], null, 2024],
+    ["Health Center - Downstairs 2", ["hc-downstairs-b"], null, 2024],
+    ["Health Center - Downstairs A", ["hc-downstairs-a"], null, null],
+    ["Health Center - Downstairs B", ["hc-downstairs-b"], null, null],
+    // Verbatim double space, as stored in CampMinder. Do not trim.
+    ["Health Center Downstairs  - Room A", ["hc-downstairs-a"], null, null],
+    ["Health Center Downstairs  - Room B", ["hc-downstairs-b"], null, null],
+    ["Tawonga Village 5", ["tawonga-village-5a", "tawonga-village-5b"], null, null]
+  ];
+
+  const aliasCol = app.findCollectionByNameOrId("lodging_unit_aliases");
+
+  for (let i = 0; i < ALIASES.length; i++) {
+    const a = ALIASES[i];
+
+    // An unbounded window is stored as 0, NOT null. PocketBase declares number
+    // columns `NUMERIC DEFAULT 0 NOT NULL`, and `min: 2000` does NOT reject an
+    // unset optional field — both verified empirically against this collection:
+    // POSTing an alias with no valid_from_year returns `"valid_from_year": 0`.
+    // Filtering on `= null` would therefore never match, so a re-run would
+    // re-insert and die on the unique index with validation_not_unique.
+    const wantYear = a[2] === null ? 0 : a[2];
+    let existing;
+    try {
+      existing = app.findFirstRecordByFilter(
+        "lodging_unit_aliases",
+        "alias_string = {:s} && valid_from_year = {:y}",
+        { s: a[0], y: wantYear }
+      );
+    } catch (_e) {
+      existing = null;
+    }
+    if (existing) continue;
+
+    const memberIds = [];
+    for (let j = 0; j < a[1].length; j++) {
+      const u = app.findFirstRecordByFilter("lodging_units", "code = {:c}", { c: a[1][j] });
+      memberIds.push(u.id);
+    }
+
+    const rec = new Record(aliasCol);
+    rec.set("alias_string", a[0]);
+    rec.set("member_units", memberIds);
+    if (a[2] !== null) rec.set("valid_from_year", a[2]);
+    if (a[3] !== null) rec.set("valid_to_year", a[3]);
+    app.save(rec);
+  }
+}, (app) => {
+  // Explicit large limit — a 0 limit is version-dependent in the JSVM binding
+  // and can return nothing, silently making the down a no-op.
+  const rows = app.findRecordsByFilter("lodging_unit_aliases", "id != ''", "", 100000, 0);
+  for (let i = 0; i < rows.length; i++) {
+    app.delete(rows[i]);
+  }
+});

--- a/pocketbase/pb_migrations/1500000121_seed_lodging_aliases.js
+++ b/pocketbase/pb_migrations/1500000121_seed_lodging_aliases.js
@@ -23,6 +23,23 @@
  */
 
 migrate((app) => {
+  // Idempotency lookup. findFirstRecordByFilter returns sql.ErrNoRows verbatim
+  // when nothing matches (core/record_query.go:454, v0.39.9), which surfaces here
+  // as "sql: no rows in result set" — that is the "not seeded yet" signal.
+  //
+  // ANY other error (malformed filter, DB lock, closed connection) is real. A bare
+  // `catch { return null }` would treat it as "not seeded", insert a duplicate, and
+  // die on the unique index with validation_not_unique — hiding the actual cause.
+  // So: rethrow anything that is not the not-found case.
+  const findSeeded = (collection, filter, params) => {
+    try {
+      return app.findFirstRecordByFilter(collection, filter, params);
+    } catch (e) {
+      if (String(e).indexOf("no rows in result set") === -1) throw e;
+      return null;
+    }
+  };
+
   // [alias_string, [unit_codes], valid_from_year, valid_to_year]
   // null year = no bound.
   const ALIASES = [
@@ -148,16 +165,11 @@ migrate((app) => {
     // Filtering on `= null` would therefore never match, so a re-run would
     // re-insert and die on the unique index with validation_not_unique.
     const wantYear = a[2] === null ? 0 : a[2];
-    let existing;
-    try {
-      existing = app.findFirstRecordByFilter(
-        "lodging_unit_aliases",
-        "alias_string = {:s} && valid_from_year = {:y}",
-        { s: a[0], y: wantYear }
-      );
-    } catch (_e) {
-      existing = null;
-    }
+    const existing = findSeeded(
+      "lodging_unit_aliases",
+      "alias_string = {:s} && valid_from_year = {:y}",
+      { s: a[0], y: wantYear }
+    );
     if (existing) continue;
 
     const memberIds = [];

--- a/scripts/dev/verify-lodging-schema.sh
+++ b/scripts/dev/verify-lodging-schema.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Applies pocketbase/pb_migrations to a throwaway DB and asserts the lodging
+# schema. Exits non-zero with a specific message on the first failure.
+#
+# Why serve-and-kill: `pocketbase migrate up` silently skips JS migrations.
+# jsvm captures MigrationsDir at plugin-registration time (before flag parsing),
+# so --migrationsDir is a no-op; jsvm always resolves
+# filepath.Join(app.DataDir(), "../pb_migrations"). We symlink that path to the
+# repo's migrations dir. Same technique as scripts/dev/verify-consolidation.sh.
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+PB_BIN="$REPO_ROOT/pocketbase/pocketbase"
+MIG_DIR="$REPO_ROOT/pocketbase/pb_migrations"
+
+[[ -x "$PB_BIN" ]] || { echo "error: $PB_BIN missing; run: cd pocketbase && go build -o pocketbase ." >&2; exit 2; }
+
+SCRATCH=$(mktemp -d)
+trap 'rm -rf "$SCRATCH"' EXIT
+
+DB_DIR="$SCRATCH/data/pb_data"
+mkdir -p "$DB_DIR"
+HOOKS_DIR=$(mktemp -d "$SCRATCH/empty-hooks-XXXX")
+# jsvm default resolution: <dataDir>/../pb_migrations
+ln -sfn "$MIG_DIR" "$SCRATCH/data/pb_migrations"
+
+PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+LOG="$SCRATCH/boot.log"
+
+"$PB_BIN" serve --http="127.0.0.1:$PORT" --dir "$DB_DIR" \
+  --hooksDir "$HOOKS_DIR" --automigrate=true > "$LOG" 2>&1 &
+PID=$!
+
+ok=0
+for _ in $(seq 1 200); do
+  if curl -sf "http://127.0.0.1:$PORT/api/health" >/dev/null 2>&1; then ok=1; break; fi
+  sleep 0.2
+done
+kill "$PID" 2>/dev/null || true
+wait "$PID" 2>/dev/null || true
+
+if [[ "$ok" -ne 1 ]]; then
+  echo "error: pocketbase serve never came up; log:" >&2; cat "$LOG" >&2; exit 2
+fi
+
+DB="$DB_DIR/data.db"
+js_migs=$(sqlite3 "$DB" "SELECT COUNT(*) FROM _migrations WHERE file LIKE '%.js'")
+if [[ "$js_migs" -lt 1 ]]; then
+  echo "error: 0 .js migrations applied — jsvm loading broke" >&2; cat "$LOG" >&2; exit 2
+fi
+
+fail=0
+note() { echo "FAIL: $*" >&2; fail=1; }
+
+for c in lodging_areas lodging_units lodging_unit_aliases lodging_merges \
+         lodging_availability lodging_assignments lodging_assignment_history; do
+  n=$(sqlite3 "$DB" "SELECT COUNT(*) FROM _collections WHERE name = '$c'")
+  [[ "$n" -eq 1 ]] || note "collection $c missing"
+done
+
+# field_limit <collection> <field> <json-path> <expected>
+field_prop() {
+  sqlite3 "$DB" "SELECT json_extract(value, '\$.$3') FROM _collections, json_each(_collections.fields) WHERE _collections.name = '$1' AND json_extract(value, '\$.name') = '$2'"
+}
+
+# Guard against the options:{} trap — a silently-ignored max shows up as 5000.
+for f in name code notes; do
+  v=$(field_prop lodging_units "$f" max || true)
+  [[ -n "$v" && "$v" != "5000" ]] || note "lodging_units.$f max is '$v' (expected an explicit non-default limit; 5000 means options:{} was ignored)"
+done
+
+bt=$(field_prop lodging_units bathroom values || true)
+[[ "$bt" == '["none","private","shared"]' ]] || note "lodging_units.bathroom values are $bt (expected [\"none\",\"private\",\"shared\"])"
+
+ad=$(field_prop lodging_units allocation_default values || true)
+[[ "$ad" == '["family_pool","staff_default"]' ]] || note "lodging_units.allocation_default values are $ad"
+
+st=$(field_prop lodging_availability state values || true)
+[[ "$st" == '["reserved_staff","reserved_other","released_to_family"]' ]] || note "lodging_availability.state values are $st"
+
+# Unbounded numbers must be null, not 0 (0 would reject positive values).
+for spec in "lodging_units:sleeps" "lodging_merges:capacity_override"; do
+  col=${spec%%:*}; fld=${spec##*:}
+  mx=$(field_prop "$col" "$fld" max || true)
+  [[ -z "$mx" || "$mx" == "null" ]] || note "$col.$fld max is '$mx' (expected null for unbounded)"
+done
+
+# Merges bind 2+ units, so member_units must be multi-select.
+ms=$(field_prop lodging_merges member_units maxSelect || true)
+[[ -n "$ms" && "$ms" != "1" ]] || note "lodging_merges.member_units maxSelect is '$ms' (expected >1 or null)"
+ms=$(field_prop lodging_unit_aliases member_units maxSelect || true)
+[[ -n "$ms" && "$ms" != "1" ]] || note "lodging_unit_aliases.member_units maxSelect is '$ms' (expected >1 or null)"
+
+# Dual-grain uniqueness: the live-row partial indexes must gate on `> 0`, never
+# on `!= ''`. PocketBase numbers are `NUMERIC DEFAULT 0 NOT NULL` and SQLite
+# evaluates `0 != ''` as TRUE, so `!= ''` would capture every person-grain row
+# (household_cm_id = 0), collide them, and permit only ONE adult assignment per
+# session. This assertion exists because that bug was caught in review.
+for idx in idx_lodging_assign_hh_live idx_lodging_assign_person_live; do
+  sql=$(sqlite3 "$DB" "SELECT COALESCE(sql,'') FROM sqlite_master WHERE type='index' AND name='$idx'")
+  if [[ -z "$sql" ]]; then
+    note "index $idx missing"
+  elif [[ "$sql" == *"!= ''"* ]]; then
+    note "index $idx uses \"!= ''\" — must be \"> 0\" (0 != '' is TRUE in SQLite; see plan Task 5)"
+  elif [[ "$sql" != *"> 0"* ]]; then
+    note "index $idx predicate lacks \"> 0\": $sql"
+  fi
+done
+
+if [[ "$fail" -ne 0 ]]; then echo "verify-lodging-schema: FAILED" >&2; exit 1; fi
+echo "verify-lodging-schema: OK ($js_migs js migrations applied)"

--- a/scripts/dev/verify-lodging-schema.sh
+++ b/scripts/dev/verify-lodging-schema.sh
@@ -16,7 +16,19 @@ MIG_DIR="$REPO_ROOT/pocketbase/pb_migrations"
 [[ -x "$PB_BIN" ]] || { echo "error: $PB_BIN missing; run: cd pocketbase && go build -o pocketbase ." >&2; exit 2; }
 
 SCRATCH=$(mktemp -d)
-trap 'rm -rf "$SCRATCH"' EXIT
+PB_PID=""
+# Trap INT and TERM as well as EXIT, and kill the background PocketBase from
+# inside the handler. A signal arriving during the up-to-40s health poll would
+# otherwise run only the EXIT handler, deleting $SCRATCH but orphaning a
+# `pocketbase serve` bound to the ephemeral port.
+cleanup() {
+  if [[ -n "$PB_PID" ]]; then
+    kill "$PB_PID" 2>/dev/null || true
+    wait "$PB_PID" 2>/dev/null || true
+  fi
+  rm -rf "$SCRATCH"
+}
+trap cleanup EXIT INT TERM
 
 DB_DIR="$SCRATCH/data/pb_data"
 mkdir -p "$DB_DIR"
@@ -29,15 +41,18 @@ LOG="$SCRATCH/boot.log"
 
 "$PB_BIN" serve --http="127.0.0.1:$PORT" --dir "$DB_DIR" \
   --hooksDir "$HOOKS_DIR" --automigrate=true > "$LOG" 2>&1 &
-PID=$!
+PB_PID=$!
 
 ok=0
 for _ in $(seq 1 200); do
   if curl -sf "http://127.0.0.1:$PORT/api/health" >/dev/null 2>&1; then ok=1; break; fi
   sleep 0.2
 done
-kill "$PID" 2>/dev/null || true
-wait "$PID" 2>/dev/null || true
+# Stop PocketBase before querying, so sqlite3 reads a settled database. The trap
+# is the safety net for signal paths; this kill makes it a no-op on normal paths.
+kill "$PB_PID" 2>/dev/null || true
+wait "$PB_PID" 2>/dev/null || true
+PB_PID=""
 
 if [[ "$ok" -ne 1 ]]; then
   echo "error: pocketbase serve never came up; log:" >&2; cat "$LOG" >&2; exit 2
@@ -58,7 +73,8 @@ for c in lodging_areas lodging_units lodging_unit_aliases lodging_merges \
   [[ "$n" -eq 1 ]] || note "collection $c missing"
 done
 
-# field_limit <collection> <field> <json-path> <expected>
+# field_prop <collection> <field> <json-path> — prints the property value, or
+# empty string if the collection or field is absent. Callers compare the result.
 field_prop() {
   sqlite3 "$DB" "SELECT json_extract(value, '\$.$3') FROM _collections, json_each(_collections.fields) WHERE _collections.name = '$1' AND json_extract(value, '\$.name') = '$2'"
 }

--- a/scripts/dev/verify-lodging-schema.sh
+++ b/scripts/dev/verify-lodging-schema.sh
@@ -15,16 +15,17 @@
 # repo's migrations dir. Same technique as scripts/dev/verify-consolidation.sh.
 set -euo pipefail
 
+# Check tools up front so a missing one exits 2 (cannot run) rather than 127
+# midway through, which would read as an assertion failure. Same contract as
+# scripts/dev/migration-schema-diff.sh. git is in the list and the list runs
+# BEFORE the first git call — checking after invoking it would never fire.
+for cmd in git sqlite3 curl python3; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "error: required command '$cmd' not found" >&2; exit 2; }
+done
+
 REPO_ROOT=$(git rev-parse --show-toplevel)
 PB_BIN="$REPO_ROOT/pocketbase/pocketbase"
 MIG_DIR="$REPO_ROOT/pocketbase/pb_migrations"
-
-# Check tools up front so a missing one exits 2 (cannot run) rather than 127
-# midway through, which would read as an assertion failure. Same contract as
-# scripts/dev/migration-schema-diff.sh.
-for cmd in sqlite3 curl python3; do
-  command -v "$cmd" >/dev/null 2>&1 || { echo "error: required command '$cmd' not found" >&2; exit 2; }
-done
 
 [[ -x "$PB_BIN" ]] || { echo "error: $PB_BIN missing; run: cd pocketbase && go build -o pocketbase ." >&2; exit 2; }
 

--- a/scripts/dev/verify-lodging-schema.sh
+++ b/scripts/dev/verify-lodging-schema.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # Applies pocketbase/pb_migrations to a throwaway DB and asserts the lodging
-# schema. Exits non-zero with a specific message on the first failure.
+# schema.
+#
+# Exit codes: 0 = all assertions passed. 1 = one or more assertions FAILED.
+# 2 = could not run the check at all (missing tool/binary, PocketBase never
+# booted). Assertions do NOT short-circuit: note() records a failure and
+# execution continues, so a run reports EVERY violation at once rather than
+# stopping at the first — that is what makes the FAIL count usable as progress.
 #
 # Why serve-and-kill: `pocketbase migrate up` silently skips JS migrations.
 # jsvm captures MigrationsDir at plugin-registration time (before flag parsing),
@@ -12,6 +18,13 @@ set -euo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 PB_BIN="$REPO_ROOT/pocketbase/pocketbase"
 MIG_DIR="$REPO_ROOT/pocketbase/pb_migrations"
+
+# Check tools up front so a missing one exits 2 (cannot run) rather than 127
+# midway through, which would read as an assertion failure. Same contract as
+# scripts/dev/migration-schema-diff.sh.
+for cmd in sqlite3 curl python3; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "error: required command '$cmd' not found" >&2; exit 2; }
+done
 
 [[ -x "$PB_BIN" ]] || { echo "error: $PB_BIN missing; run: cd pocketbase && go build -o pocketbase ." >&2; exit 2; }
 
@@ -113,7 +126,7 @@ ms=$(field_prop lodging_unit_aliases member_units maxSelect || true)
 # (household_cm_id = 0), collide them, and permit only ONE adult assignment per
 # session. This assertion exists because that bug was caught in review.
 for idx in idx_lodging_assign_hh_live idx_lodging_assign_person_live; do
-  sql=$(sqlite3 "$DB" "SELECT COALESCE(sql,'') FROM sqlite_master WHERE type='index' AND name='$idx'")
+  sql=$(sqlite3 "$DB" "SELECT COALESCE(sql,'') FROM sqlite_master WHERE type='index' AND name='$idx'" || true)
   if [[ -z "$sql" ]]; then
     note "index $idx missing"
   elif [[ "$sql" == *"!= ''"* ]]; then

--- a/scripts/dev/verify-lodging-seed.sh
+++ b/scripts/dev/verify-lodging-seed.sh
@@ -2,11 +2,22 @@
 # Asserts the lodging seed produced the expected rows. Applies migrations to a
 # throwaway DB using the same serve-and-kill technique as
 # scripts/dev/verify-lodging-schema.sh (see that file for why).
+#
+# Exit codes: 0 = all assertions passed. 1 = one or more assertions FAILED.
+# 2 = could not run the check at all. Assertions aggregate rather than
+# short-circuit; see verify-lodging-schema.sh.
 set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 PB_BIN="$REPO_ROOT/pocketbase/pocketbase"
 MIG_DIR="$REPO_ROOT/pocketbase/pb_migrations"
+
+# Missing tool must exit 2 (cannot run), not 127 midway. Same contract as
+# scripts/dev/migration-schema-diff.sh.
+for cmd in sqlite3 curl python3; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "error: required command '$cmd' not found" >&2; exit 2; }
+done
+
 [[ -x "$PB_BIN" ]] || { echo "error: $PB_BIN missing; run: cd pocketbase && go build -o pocketbase ." >&2; exit 2; }
 
 SCRATCH=$(mktemp -d)

--- a/scripts/dev/verify-lodging-seed.sh
+++ b/scripts/dev/verify-lodging-seed.sh
@@ -8,15 +8,15 @@
 # short-circuit; see verify-lodging-schema.sh.
 set -euo pipefail
 
+# Missing tool must exit 2 (cannot run), not 127 midway. Same contract as
+# scripts/dev/migration-schema-diff.sh. Runs BEFORE the first git call.
+for cmd in git sqlite3 curl python3; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "error: required command '$cmd' not found" >&2; exit 2; }
+done
+
 REPO_ROOT=$(git rev-parse --show-toplevel)
 PB_BIN="$REPO_ROOT/pocketbase/pocketbase"
 MIG_DIR="$REPO_ROOT/pocketbase/pb_migrations"
-
-# Missing tool must exit 2 (cannot run), not 127 midway. Same contract as
-# scripts/dev/migration-schema-diff.sh.
-for cmd in sqlite3 curl python3; do
-  command -v "$cmd" >/dev/null 2>&1 || { echo "error: required command '$cmd' not found" >&2; exit 2; }
-done
 
 [[ -x "$PB_BIN" ]] || { echo "error: $PB_BIN missing; run: cd pocketbase && go build -o pocketbase ." >&2; exit 2; }
 

--- a/scripts/dev/verify-lodging-seed.sh
+++ b/scripts/dev/verify-lodging-seed.sh
@@ -100,5 +100,12 @@ alias_members() {
 # The double-space string really is in the data — do not trim it.
 [[ "$(alias_members "Health Center Downstairs  - Room A")" == "hc-downstairs-a" ]] || note "double-space Room A alias missing"
 
+# Container rows (buildings) must never be countable/bookable rooms themselves,
+# and every leaf room's parent must itself be a container.
+n=$(q "SELECT COUNT(*) FROM lodging_units WHERE is_container = 1")
+[[ "$n" -eq 7 ]] || note "expected 7 container units, got $n"
+n=$(q "SELECT COUNT(*) FROM lodging_units c JOIN lodging_units p ON c.parent_unit = p.id WHERE p.is_container = 0")
+[[ "$n" -eq 0 ]] || note "$n units have a non-container parent"
+
 if [[ "$fail" -ne 0 ]]; then echo "verify-lodging-seed: FAILED" >&2; exit 1; fi
 echo "verify-lodging-seed: OK"

--- a/scripts/dev/verify-lodging-seed.sh
+++ b/scripts/dev/verify-lodging-seed.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Asserts the lodging seed produced the expected rows. Applies migrations to a
+# throwaway DB using the same serve-and-kill technique as
+# scripts/dev/verify-lodging-schema.sh (see that file for why).
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+PB_BIN="$REPO_ROOT/pocketbase/pocketbase"
+MIG_DIR="$REPO_ROOT/pocketbase/pb_migrations"
+[[ -x "$PB_BIN" ]] || { echo "error: $PB_BIN missing; run: cd pocketbase && go build -o pocketbase ." >&2; exit 2; }
+
+SCRATCH=$(mktemp -d)
+PB_PID=""
+# EXIT INT TERM, with the kill inside the handler — a signal during the health
+# poll would otherwise orphan a `pocketbase serve` on the ephemeral port.
+cleanup() {
+  if [[ -n "$PB_PID" ]]; then
+    kill "$PB_PID" 2>/dev/null || true
+    wait "$PB_PID" 2>/dev/null || true
+  fi
+  rm -rf "$SCRATCH"
+}
+trap cleanup EXIT INT TERM
+
+DB_DIR="$SCRATCH/data/pb_data"; mkdir -p "$DB_DIR"
+HOOKS_DIR=$(mktemp -d "$SCRATCH/empty-hooks-XXXX")
+ln -sfn "$MIG_DIR" "$SCRATCH/data/pb_migrations"
+PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+"$PB_BIN" serve --http="127.0.0.1:$PORT" --dir "$DB_DIR" --hooksDir "$HOOKS_DIR" --automigrate=true > "$SCRATCH/boot.log" 2>&1 &
+PB_PID=$!
+ok=0; for _ in $(seq 1 200); do curl -sf "http://127.0.0.1:$PORT/api/health" >/dev/null 2>&1 && { ok=1; break; }; sleep 0.2; done
+kill "$PB_PID" 2>/dev/null || true; wait "$PB_PID" 2>/dev/null || true; PB_PID=""
+[[ "$ok" -eq 1 ]] || { echo "error: serve never came up" >&2; cat "$SCRATCH/boot.log" >&2; exit 2; }
+
+DB="$DB_DIR/data.db"
+fail=0; note() { echo "FAIL: $*" >&2; fail=1; }
+q() { sqlite3 "$DB" "$1"; }
+
+[[ "$(q "SELECT COUNT(*) FROM lodging_areas")" -eq 8 ]] || note "expected 8 areas, got $(q "SELECT COUNT(*) FROM lodging_areas")"
+
+# Per-area unit counts, from the map.
+while IFS='|' read -r code want; do
+  got=$(q "SELECT COUNT(*) FROM lodging_units u JOIN lodging_areas a ON u.area = a.id WHERE a.code = '$code'")
+  [[ "$got" -eq "$want" ]] || note "area $code has $got units, expected $want"
+done <<'EOF'
+RIDGE|13
+RIVER|13
+YURT|7
+TUOL|7
+MANZ|6
+TV|7
+GT|25
+HC|11
+EOF
+
+# Every unit needs a map position, or the map view and adjacency are impossible.
+n=$(q "SELECT COUNT(*) FROM lodging_units WHERE map_x IS NULL OR map_x = 0")
+[[ "$n" -eq 0 ]] || note "$n units have no map_x"
+
+# Every sleeps value is a guess -> nothing may claim to be confirmed.
+n=$(q "SELECT COUNT(*) FROM lodging_units WHERE is_confirmed = 1")
+[[ "$n" -eq 0 ]] || note "$n units marked is_confirmed, expected 0 (all seeds are guesses)"
+
+# Known-good spot checks.
+[[ "$(q "SELECT bathroom FROM lodging_units WHERE code = 'hc-upstairs-5'")" == "private" ]] || note "hc-upstairs-5 should be private"
+[[ "$(q "SELECT bathroom_group FROM lodging_units WHERE code = 'hc-upstairs-3'")" == "hc-upstairs-hall" ]] || note "hc-upstairs-3 should be in hc-upstairs-hall"
+[[ "$(q "SELECT bathroom FROM lodging_units WHERE code = 'ridge-a'")" == "none" ]] || note "ridge-a should be none"
+[[ "$(q "SELECT COUNT(*) FROM lodging_units WHERE code = 'manzanita-6'")" -eq 0 ]] || note "manzanita-6 must NOT exist (absent from the map)"
+[[ "$(q "SELECT COUNT(*) FROM lodging_units WHERE code = 'hc-upstairs-2'")" -eq 1 ]] || note "hc-upstairs-2 must exist (real but unused)"
+[[ "$(q "SELECT COUNT(*) FROM lodging_units WHERE code = 'tuolumne-7'")" -eq 1 ]] || note "tuolumne-7 must exist"
+
+# Wawona's children must point at it, and it must be a distinct building from Doctor's House.
+[[ "$(q "SELECT COUNT(*) FROM lodging_units c JOIN lodging_units p ON c.parent_unit = p.id WHERE p.code = 'gt-wawona'")" -eq 2 ]] || note "gt-wawona should have 2 children"
+[[ "$(q "SELECT COUNT(*) FROM lodging_units WHERE code IN ('gt-wawona','hc-doctors-house')")" -eq 2 ]] || note "gt-wawona and hc-doctors-house must both exist as distinct units"
+
+n=$(q "SELECT COUNT(*) FROM lodging_units WHERE allocation_default = 'staff_default'")
+[[ "$n" -ge 1 ]] || note "expected at least one staff_default unit"
+
+if [[ "$fail" -ne 0 ]]; then echo "verify-lodging-seed: FAILED" >&2; exit 1; fi
+echo "verify-lodging-seed: OK"

--- a/scripts/dev/verify-lodging-seed.sh
+++ b/scripts/dev/verify-lodging-seed.sh
@@ -76,5 +76,29 @@ n=$(q "SELECT COUNT(*) FROM lodging_units WHERE is_confirmed = 1")
 n=$(q "SELECT COUNT(*) FROM lodging_units WHERE allocation_default = 'staff_default'")
 [[ "$n" -ge 1 ]] || note "expected at least one staff_default unit"
 
+# --- aliases ---
+[[ "$(q "SELECT COUNT(*) FROM lodging_unit_aliases")" -ge 90 ]] || note "expected >=90 aliases, got $(q "SELECT COUNT(*) FROM lodging_unit_aliases")"
+
+# alias_string -> expected member unit codes (comma-joined, sorted)
+alias_members() {
+  # Several alias strings contain an apostrophe ("Doctor's House", "Cloud's
+  # Rest") — double it for the SQL string literal, or the query is a syntax
+  # error rather than a legitimate empty-result failure.
+  local esc="${1//\'/\'\'}"
+  q "SELECT group_concat(code) FROM (SELECT u.code FROM lodging_unit_aliases al, json_each(al.member_units) je JOIN lodging_units u ON u.id = je.value WHERE al.alias_string = '$esc' ORDER BY u.code)"
+}
+
+[[ "$(alias_members "Golden Triangle - Doctor's House")" == "gt-wawona" ]] || note "GT Doctor's House should resolve to gt-wawona, got $(alias_members "Golden Triangle - Doctor's House")"
+[[ "$(alias_members "Health Center - Doctor's House")" == "hc-doctors-house" ]] || note "HC Doctor's House should resolve to hc-doctors-house"
+[[ "$(alias_members "Doctor's House")" == "hc-doctors-house" ]] || note "bare Doctor's House should resolve to hc-doctors-house"
+[[ "$(alias_members "Teen Village 1")" == "tawonga-village-1" ]] || note "Teen Village 1 should alias Tawonga Village 1"
+[[ "$(alias_members "Tawonga Village 1")" == "tawonga-village-1" ]] || note "Tawonga Village 1 should alias itself"
+# Multi-member aliases denote merges.
+[[ "$(alias_members "Golden Triangle - Tenaya 1and2")" == "gt-tenaya-1,gt-tenaya-2" ]] || note "Tenaya 1and2 should have 2 members"
+[[ "$(alias_members "Golden Triangle - Tioga 1and2")" == "gt-tioga-1,gt-tioga-2" ]] || note "Tioga 1and2 should have 2 members"
+[[ "$(alias_members "Health Center - Downstairs 1and2")" == "hc-downstairs-a,hc-downstairs-b" ]] || note "Downstairs 1and2 should have 2 members"
+# The double-space string really is in the data — do not trim it.
+[[ "$(alias_members "Health Center Downstairs  - Room A")" == "hc-downstairs-a" ]] || note "double-space Room A alias missing"
+
 if [[ "$fail" -ne 0 ]]; then echo "verify-lodging-seed: FAILED" >&2; exit 1; fi
 echo "verify-lodging-seed: OK"

--- a/scripts/dev/verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/verify-no-hardcoded-lodging.sh
@@ -1,16 +1,35 @@
 #!/usr/bin/env bash
 # Spec 3.8: the lodging registry is DATA, not code. Unit and alias lists may
-# exist only in seed migrations. This guard fails if a unit name leaks into
-# application source.
+# exist only in seed migrations.
+#
+# SCOPE, honestly stated: this is a tripwire, not a proof. It greps for a
+# REPRESENTATIVE SAMPLE of distinctive unit strings (NEEDLES below) — not the
+# full ~90-unit registry, which would be both unmaintainable and prone to
+# false positives on ordinary words ("Ridge A", "Kitty"). A leak of a unit name
+# that is not in NEEDLES will pass. Treat a green run as "the obvious cases are
+# clean", not "no unit name exists in source".
 set -euo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 
-# Distinctive unit strings that must never appear outside seed migrations.
-NEEDLES='Ridge Yurt|Tawonga Village|Manzanita|Tuolumne|Clouds Rest|Wawona|Half Dome|El Cap'
+for cmd in git grep; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "error: required command '$cmd' not found" >&2; exit 2; }
+done
 
+# Distinctive unit strings that must never appear outside seed migrations.
+# Double-quoted so "Doctor's House" can carry its apostrophe.
+NEEDLES="Ridge Yurt|Tawonga Village|Manzanita|Tuolumne|Clouds Rest|Wawona|Half Dome|El Cap|Bayit|Tenaya|Tioga|Le Shack|Lofty|Kitty|Doctor's House"
+
+# --include='*.js' matters: pocketbase/pb_hooks/ is application JavaScript and
+# would otherwise go unscanned entirely. But scanning .js drags in two kinds of
+# legitimate non-source noise, both excluded by directory rather than by file:
+#   pb_migrations/ — where the registry data is SUPPOSED to live (spec 3.8)
+#   pb_public/     — gitignored build output; the minified frontend bundle
+#                    embeds the same city/school geo tables and matches
+#                    "Kitty"/"Tioga" as ordinary US place names
 HITS=$(grep -rInE "$NEEDLES" \
-  --include='*.go' --include='*.py' --include='*.ts' --include='*.tsx' \
+  --include='*.go' --include='*.py' --include='*.ts' --include='*.tsx' --include='*.js' \
+  --exclude-dir=pb_migrations --exclude-dir=pb_public --exclude-dir=node_modules \
   pocketbase/ api/ bunking/ frontend/src/ 2>/dev/null \
   | grep -v '_test\.\|\.test\.\|/tests\?/' \
   | grep -v 'frontend/src/data/cityGeo\.ts\|frontend/src/data/schoolGeo\.ts' || true)

--- a/scripts/dev/verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/verify-no-hardcoded-lodging.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Spec 3.8: the lodging registry is DATA, not code. Unit and alias lists may
+# exist only in seed migrations. This guard fails if a unit name leaks into
+# application source.
+set -euo pipefail
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+# Distinctive unit strings that must never appear outside seed migrations.
+NEEDLES='Ridge Yurt|Tawonga Village|Manzanita|Tuolumne|Clouds Rest|Wawona|Half Dome|El Cap'
+
+HITS=$(grep -rInE "$NEEDLES" \
+  --include='*.go' --include='*.py' --include='*.ts' --include='*.tsx' \
+  pocketbase/ api/ bunking/ frontend/src/ 2>/dev/null \
+  | grep -v '_test\.\|\.test\.\|/tests\?/' \
+  | grep -v 'frontend/src/data/cityGeo\.ts\|frontend/src/data/schoolGeo\.ts' || true)
+# cityGeo.ts / schoolGeo.ts are unrelated city/school geocoding lookup tables
+# (a different feature) that coincidentally contain place-name substrings
+# ("Manzanita, OR", "El Capitan, AZ", "Wawona, CA", "Tuolumne City, CA") — not
+# the lodging registry. Excluded to keep this guard meaningful.
+
+if [[ -n "$HITS" ]]; then
+  echo "FAIL: lodging unit names found in application source (spec 3.8 — registry is data, not code):" >&2
+  echo "$HITS" >&2
+  exit 1
+fi
+echo "verify-no-hardcoded-lodging: OK"

--- a/scripts/dev/verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/verify-no-hardcoded-lodging.sh
@@ -9,16 +9,22 @@
 # that is not in NEEDLES will pass. Treat a green run as "the obvious cases are
 # clean", not "no unit name exists in source".
 set -euo pipefail
-REPO_ROOT=$(git rev-parse --show-toplevel)
-cd "$REPO_ROOT"
 
+# Preflight BEFORE the first git call — checking for git after invoking it is
+# pointless, since the missing binary would already have exited 127.
 for cmd in git grep; do
   command -v "$cmd" >/dev/null 2>&1 || { echo "error: required command '$cmd' not found" >&2; exit 2; }
 done
 
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
 # Distinctive unit strings that must never appear outside seed migrations.
 # Double-quoted so "Doctor's House" can carry its apostrophe.
-NEEDLES="Ridge Yurt|Tawonga Village|Manzanita|Tuolumne|Clouds Rest|Wawona|Half Dome|El Cap|Bayit|Tenaya|Tioga|Le Shack|Lofty|Kitty|Doctor's House"
+# "Cloud'?s Rest" matches both spellings on purpose: the canonical unit name is
+# "Clouds Rest" (1500000120) but every historical alias string is "Cloud's Rest"
+# with the apostrophe (1500000121), and a leak could copy either.
+NEEDLES="Ridge Yurt|Tawonga Village|Manzanita|Tuolumne|Cloud'?s Rest|Wawona|Half Dome|El Cap|Bayit|Tenaya|Tioga|Le Shack|Lofty|Kitty|Doctor's House"
 
 # --include='*.js' matters: pocketbase/pb_hooks/ is application JavaScript and
 # would otherwise go unscanned entirely. But scanning .js drags in two kinds of


### PR DESCRIPTION
## Summary

Creates and seeds the canonical lodging registry for weekend programming — family camps and adult weekends. Plan 1 of 3 for the family camp module: schema and seed only, with no readers yet.

## Collections

- `lodging_areas`, `lodging_units` — atomic rooms with map coordinates and nullable staff-filled amenities
- `lodging_unit_aliases` — temporal mapping of historical free-text cabin strings onto units, so a mid-history building rename resolves correctly on both sides
- `lodging_merges` — arbitrary member sets bound into one bookable slot, per session and scenario
- `lodging_availability` — staff and other reservations, locking units out of the family pool and releasing staff-default units into it
- `lodging_assignments`, `lodging_assignment_history` — dual-grain placements (household or person, person overriding household) plus an append-only history

## Seed

8 areas and 89 units positioned from the 2026 camp map. Capacities are inferred from observed 2024/2025 peak occupancy and are all marked `is_confirmed: false` pending staff review. 100 alias rows cover every cabin string observed 2022–2026, including two buildings that swapped names in 2025.

## Verification

Three new harnesses, all green:

- `scripts/dev/verify-lodging-schema.sh` — applies migrations to a throwaway database and asserts collections, field limits and index predicates, guarding against the PocketBase v0.23 `options: {}` trap
- `scripts/dev/verify-lodging-seed.sh` — asserts seed counts and spot checks
- `scripts/dev/verify-no-hardcoded-lodging.sh` — asserts no unit name leaks into application source, since the registry is data and not code

Note: `pocketbase migrate up` silently skips JS migrations, so these harnesses use the serve-and-kill technique already documented in `scripts/dev/verify-consolidation.sh`.

## Notes for review

- Uniqueness is enforced per scenario as well as for the live plan, and the partial index predicates use `> 0` rather than `!= ''` — PocketBase numbers are `NUMERIC DEFAULT 0 NOT NULL` and SQLite treats `0 != ''` as true, so the wrong predicate would have collapsed every person-grain row together.
- `is_container` marks the 7 building rows that group other units; capacity queries must exclude them or they contribute 19 phantom beds.
- Unset numeric fields store as `0`, never null. Treat `sleeps = 0` as unknown rather than zero capacity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lodging infrastructure for weekend-program housing, including areas/units, historical unit aliases, availability tracking, merged bookable units, and assignment + assignment history.
  * Seeded the 2026 lodging registry and alias data, including parent/child unit relationships.
* **Bug Fixes**
  * Improved seeding idempotency to better distinguish “not yet seeded” from real query/database errors.
* **Tests**
  * Added/strengthened dev verification scripts that validate generated schema, seed integrity, relationships, and guard against hardcoded lodging values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->