### PR TITLE
fix(sync): family camp source-field correctness (lodging ingest Phase A)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,6 +54,11 @@ linters:
       extra-words:
         - typo: "cancelled"
           correction: "cancelled"
+        # CampMinder ships a custom field literally named "Housing Accomodation"
+        # (one m) alongside the correctly-spelled "Housing Accommodation". Both
+        # are real field names we must match on, so the typo is data, not a bug.
+        - typo: "accomodation"
+          correction: "accomodation"
     lll:
       line-length: 120
     nakedret:

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -269,13 +269,24 @@ func (s *FamilyCampDerivedSync) loadFieldDefinitions(_ context.Context) (map[str
 	}
 
 	for _, record := range records {
-		name := record.GetString("name")
+		name := normalizeFieldName(record.GetString("name"))
 		if isFamilyCampField(name) {
 			result[record.Id] = name
 		}
 	}
 
 	return result, nil
+}
+
+// normalizeFieldName trims a CampMinder custom-field display name.
+//
+// CampMinder does not validate these names, and at least one shipped field
+// carries a trailing space: "Family Camp-Physician " (cm_id 39680). Every
+// lookup in this file compares field names by exact string equality, so an
+// untrimmed name silently matches nothing. Trim once, at the load boundary,
+// so every downstream comparison is against a canonical name.
+func normalizeFieldName(name string) string {
+	return strings.TrimSpace(name)
 }
 
 // isFamilyCampField checks if a field name is related to family camp

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -270,12 +270,35 @@ func (s *FamilyCampDerivedSync) loadFieldDefinitions(_ context.Context) (map[str
 
 	for _, record := range records {
 		name := normalizeFieldName(record.GetString("name"))
-		if isFamilyCampField(name) {
+		if isFamilyCampField(name) || extraFieldCMIDs[record.GetInt("cm_id")] {
 			result[record.Id] = name
 		}
 	}
 
 	return result, nil
+}
+
+// extraFieldCMIDs lists source fields the family-camp NAME heuristic cannot see,
+// matched on custom_field_defs.cm_id per spec 4.4 ("Source fields are matched on
+// custom_field_defs.cm_id, not the user-editable display name").
+//
+// Two reasons a field lands here: it dropped the "Family Camp" prefix in a later
+// generation (Housing Accommodation succeeded FAM Camp-Accommodation in 2025), or
+// CampMinder spelled it inconsistently (Housing Accomodation, one m, is the
+// Adult-partition twin of Housing Accommodation). Names are comments; the ids
+// are the contract.
+var extraFieldCMIDs = map[int]bool{
+	274057: true, // Housing Accommodation        (Camper) — successor to FAM Camp-Accommodation
+	274055: true, // Housing Accomodation  (sic)  (Adult)
+	274058: true, // Housing Accommodation-Yes    (Camper)
+	274059: true, // Housing-Bathroom             (Camper) — PHI narrative, spec 5
+	274053: true, // Adult-Bathroom               (Adult)
+	274054: true, // Bathroom-Yes                 (Adult)  — PHI narrative, spec 5
+	256933: true, // Adult-CPAP                   (Adult)
+	257248: true, // Adult-Infant                 (Adult)
+	256935: true, // Adult-Opt Out                (Adult)
+	274133: true, // Shared-request               (Camper) — request free text, spec 4.1
+	206286: true, // COVID-19 Bunking Requests    (Camper) — 2nd request detail, misleading legacy name
 }
 
 // normalizeFieldName trims a CampMinder custom-field display name.
@@ -576,6 +599,10 @@ func (s *FamilyCampDerivedSync) processRegistrations(
 			if reg.specialOccasions == "" {
 				reg.specialOccasions = v.value
 			}
+		// Retired after 2024 (645 values that year, 0 since) and no successor
+		// exists. Kept because spec 4.4 forbids auto-inferring retirement and
+		// because this plan backfills 2024. lodging_field_mappings carries the
+		// passive "0 values this year" warning instead.
 		case "Family Camp-Goals Attending":
 			if reg.goals == "" {
 				reg.goals = v.value
@@ -584,10 +611,15 @@ func (s *FamilyCampDerivedSync) processRegistrations(
 			if reg.notes == "" {
 				reg.notes = v.value
 			}
-		case "FAM Camp-Accommodation":
-			reg.needsAccommodation = parseBoolFieldValue(v.value)
-		case "FAM CAMP-Opt Out VIP":
-			reg.optOutVIP = parseBoolFieldValue(v.value)
+		// Three generations of the same question. FAM Camp-Accommodation retired
+		// after 2024 (5 values in 2025, 0 in 2026); Housing Accommodation is the
+		// Camper successor and Housing Accomodation (one m) the Adult twin. Any
+		// "yes" among them means the household needs an accommodation, so this
+		// arm ORs rather than first-wins.
+		case "FAM Camp-Accommodation", "Housing Accommodation", "Housing Accomodation":
+			reg.needsAccommodation = reg.needsAccommodation || parseBoolFieldValue(v.value)
+		case "FAM CAMP-Opt Out VIP", "Adult-Opt Out":
+			reg.optOutVIP = reg.optOutVIP || parseBoolFieldValue(v.value)
 		}
 	}
 

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -285,8 +285,14 @@ func (s *FamilyCampDerivedSync) loadFieldDefinitions(_ context.Context) (map[str
 // Two reasons a field lands here: it dropped the "Family Camp" prefix in a later
 // generation (Housing Accommodation succeeded FAM Camp-Accommodation in 2025), or
 // CampMinder spelled it inconsistently (Housing Accomodation, one m, is the
-// Adult-partition twin of Housing Accommodation). Names are comments; the ids
-// are the contract.
+// Adult-partition twin of Housing Accommodation).
+//
+// Scope: these ids govern only whether a definition is ADMITTED into the field
+// map, so admission survives a rename. Semantic routing downstream still
+// switches on the display name, so a rename in CampMinder would silently stop
+// an answer reaching its column — the same failure this allowlist exists to
+// fix. Closing that half needs the cm_id-keyed registry in lodging_fields.go
+// (Phase B); until it lands, the names below are load-bearing, not decorative.
 var extraFieldCMIDs = map[int]bool{
 	274057: true, // Housing Accommodation        (Camper) — successor to FAM Camp-Accommodation
 	274055: true, // Housing Accomodation  (sic)  (Adult)
@@ -304,10 +310,12 @@ var extraFieldCMIDs = map[int]bool{
 // normalizeFieldName trims a CampMinder custom-field display name.
 //
 // CampMinder does not validate these names, and at least one shipped field
-// carries a trailing space: "Family Camp-Physician " (cm_id 39680). Every
-// lookup in this file compares field names by exact string equality, so an
-// untrimmed name silently matches nothing. Trim once, at the load boundary,
-// so every downstream comparison is against a canonical name.
+// carries a trailing space: "Family Camp-Physician " (cm_id 39680). The
+// switch and map lookups in this file compare field names by exact string
+// equality (the substring checks in isFamilyCampField and processAdults are
+// unaffected), so an untrimmed name silently matches nothing. Trim once, at
+// the load boundary, so every downstream comparison is against a canonical
+// name.
 func normalizeFieldName(name string) string {
 	return strings.TrimSpace(name)
 }
@@ -601,8 +609,9 @@ func (s *FamilyCampDerivedSync) processRegistrations(
 			}
 		// Retired after 2024 (645 values that year, 0 since) and no successor
 		// exists. Kept because spec 4.4 forbids auto-inferring retirement and
-		// because this plan backfills 2024. lodging_field_mappings carries the
-		// passive "0 values this year" warning instead.
+		// because this plan backfills 2024. The passive "0 values this year"
+		// warning will live in lodging_field_mappings, a collection Phase B
+		// adds — it does not exist yet.
 		case "Family Camp-Goals Attending":
 			if reg.goals == "" {
 				reg.goals = v.value
@@ -793,6 +802,10 @@ func extractAdultNumberFromField(fieldName string) int {
 // Anchoring on the leading word rather than the whole string is what makes both
 // shapes work. It must stay an anchor and not a substring search: "No, yes is
 // not my answer" and "Not yes" are both false, and "Yesterday" is not a yes.
+//
+// The bare tokens "yes", "y", "true" and "1" also return true, so plain-answer
+// fields (FAM Camp-Accommodation and both Housing Accommodation spellings all
+// store a bare "Yes"/"No") work unchanged.
 func parseBoolFieldValue(value string) bool {
 	lower := strings.ToLower(strings.TrimSpace(value))
 	switch lower {

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -750,10 +750,40 @@ func extractAdultNumberFromField(fieldName string) int {
 	return 0
 }
 
-// parseBoolFieldValue parses boolean values from custom field strings
+// parseBoolFieldValue parses boolean values from custom field strings.
+//
+// CampMinder single-select fields store the FULL option text, not a token, so a
+// yes/no question can arrive as a whole sentence:
+//
+//	"Yes, please register regardless of cabin type"          -> true
+//	"No, I am only able to attend with this accommodation..."  -> false
+//
+// Anchoring on the leading word rather than the whole string is what makes both
+// shapes work. It must stay an anchor and not a substring search: "No, yes is
+// not my answer" and "Not yes" are both false, and "Yesterday" is not a yes.
 func parseBoolFieldValue(value string) bool {
 	lower := strings.ToLower(strings.TrimSpace(value))
-	return lower == boolYes || lower == boolTrueStr || lower == "1"
+	switch lower {
+	case boolYes, boolTrueStr, "1", "y":
+		return true
+	case "":
+		return false
+	}
+
+	// Leading-token match: "yes" followed by a separator, never mid-word.
+	const yesPrefix = boolYes
+	if !strings.HasPrefix(lower, yesPrefix) {
+		return false
+	}
+	rest := lower[len(yesPrefix):]
+	if rest == "" {
+		return true
+	}
+	switch rest[0] {
+	case ' ', ',', '.', ';', ':', '-', '(':
+		return true
+	}
+	return false
 }
 
 // ============================================================================

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -1,10 +1,14 @@
 package sync
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 // Test data constants
@@ -1295,4 +1299,87 @@ func extractRegistrationsFromHouseholds(values []testHouseholdCustomValue) map[i
 	}
 
 	return result
+}
+
+// ============================================================================
+// Source-field correctness (spec 4.4) - these call the PRODUCTION functions
+// ============================================================================
+
+// newFieldDefsTestApp returns a throwaway PocketBase app with a custom_field_defs
+// collection shaped like production's (cm_id + name), pre-populated with the
+// given (cm_id, name) pairs. Names are stored VERBATIM - PocketBase preserves
+// leading and trailing whitespace in text fields.
+func newFieldDefsTestApp(t *testing.T, defs map[int]string) core.App {
+	t.Helper()
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	col := core.NewBaseCollection("custom_field_defs")
+	col.Fields.Add(&core.NumberField{Name: "cm_id"})
+	col.Fields.Add(&core.TextField{Name: "name"})
+	if err := app.Save(col); err != nil {
+		t.Fatalf("save custom_field_defs: %v", err)
+	}
+	for cmID, name := range defs {
+		r := core.NewRecord(col)
+		r.Set("cm_id", cmID)
+		r.Set("name", name)
+		if err := app.Save(r); err != nil {
+			t.Fatalf("save field def %d: %v", cmID, err)
+		}
+	}
+	return app
+}
+
+// TestLoadFieldDefinitionsTrimsNames is a regression test for the trailing-space
+// defect. CampMinder ships "Family Camp-Physician " (cm_id 39680) with a trailing
+// space, while processMedical looks it up as "Family Camp-Physician". Before the
+// fix the exact-match lookup missed every Physician answer ever recorded.
+func TestLoadFieldDefinitionsTrimsNames(t *testing.T) {
+	app := newFieldDefsTestApp(t, map[int]string{
+		39680: "Family Camp-Physician ", // trailing space, verbatim from CampMinder
+		39681: "Family Camp-Physician If Yes",
+		36526: "Family Camp-Goals Attending",
+	})
+
+	s := NewFamilyCampDerivedSync(app)
+	got, err := s.loadFieldDefinitions(context.Background())
+	if err != nil {
+		t.Fatalf("loadFieldDefinitions: %v", err)
+	}
+
+	want := map[string]bool{
+		"Family Camp-Physician":        true,
+		"Family Camp-Physician If Yes": true,
+		"Family Camp-Goals Attending":  true,
+	}
+	for _, name := range got {
+		if !want[name] {
+			t.Errorf("loadFieldDefinitions returned %q; expected a trimmed name", name)
+		}
+		delete(want, name)
+	}
+	for missing := range want {
+		t.Errorf("loadFieldDefinitions did not return %q", missing)
+	}
+}
+
+// TestNormalizeFieldName pins the trimming rule itself so callers other than
+// loadFieldDefinitions (see lodging_fields.go) can rely on it.
+func TestNormalizeFieldName(t *testing.T) {
+	cases := map[string]string{
+		"Family Camp-Physician ":   "Family Camp-Physician",
+		" Family Camp Cabin":       "Family Camp Cabin",
+		"\tFAM CAMP-Shared Cabin ": "FAM CAMP-Shared Cabin",
+		"Family Camp Cabin":        "Family Camp Cabin",
+		"":                         "",
+	}
+	for in, want := range cases {
+		if got := normalizeFieldName(in); got != want {
+			t.Errorf("normalizeFieldName(%q) = %q, want %q", in, got, want)
+		}
+	}
 }

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 
 	"github.com/pocketbase/pocketbase/core"
-	"github.com/pocketbase/pocketbase/tests"
+	// Aliased: this file has several local table-driven `tests` variables that
+	// would shadow the package name (gocritic importShadow).
+	pbtests "github.com/pocketbase/pocketbase/tests"
 )
 
 // Test data constants
@@ -1325,7 +1327,7 @@ func extractRegistrationsFromHouseholds(values []testHouseholdCustomValue) map[i
 // leading and trailing whitespace in text fields.
 func newFieldDefsTestApp(t *testing.T, defs map[int]string) core.App {
 	t.Helper()
-	app, err := tests.NewTestApp()
+	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatalf("NewTestApp: %v", err)
 	}
@@ -1395,5 +1397,87 @@ func TestNormalizeFieldName(t *testing.T) {
 		if got := normalizeFieldName(in); got != want {
 			t.Errorf("normalizeFieldName(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+// TestLoadFieldDefinitionsIncludesCMIDAllowlist covers the retired-field defect.
+// "Housing Accommodation" (cm_id 274057) succeeded "FAM Camp-Accommodation"
+// (223999) in 2025, but its NAME matches none of the family-camp substrings that
+// isFamilyCampField tests, so the name heuristic alone cannot reach it. Spec 4.4
+// requires matching on cm_id for exactly this reason: display names are
+// user-editable and CampMinder's own spelling is inconsistent ("Housing
+// Accomodation", one m, is the Adult-partition twin).
+func TestLoadFieldDefinitionsIncludesCMIDAllowlist(t *testing.T) {
+	app := newFieldDefsTestApp(t, map[int]string{
+		223999: "FAM Camp-Accommodation", // retired but kept for 2023/2024 backfill
+		274057: "Housing Accommodation",  // Camper successor, name heuristic misses it
+		274055: "Housing Accomodation",   // Adult twin, CampMinder's own typo
+		274133: "Shared-request",         // request-layer free text (spec 4.1)
+		206286: "COVID-19 Bunking Requests",
+		34140:  "CA-Register for Family Camp", // matched by the NAME heuristic
+		999999: "SVI-Vehicle Make",            // unrelated: must NOT be loaded
+	})
+
+	s := NewFamilyCampDerivedSync(app)
+	got, err := s.loadFieldDefinitions(context.Background())
+	if err != nil {
+		t.Fatalf("loadFieldDefinitions: %v", err)
+	}
+
+	loaded := make(map[string]bool, len(got))
+	for _, name := range got {
+		loaded[name] = true
+	}
+
+	for _, want := range []string{
+		"FAM Camp-Accommodation",
+		"Housing Accommodation",
+		"Housing Accomodation",
+		"Shared-request",
+		"COVID-19 Bunking Requests",
+		"CA-Register for Family Camp",
+	} {
+		if !loaded[want] {
+			t.Errorf("loadFieldDefinitions did not load %q", want)
+		}
+	}
+	if loaded["SVI-Vehicle Make"] {
+		t.Error("loadFieldDefinitions loaded an unrelated field; the allowlist is too wide")
+	}
+}
+
+// TestProcessRegistrationsAccommodationSuccessor proves the successor field
+// actually reaches the needs_accommodation column, not merely the field map.
+func TestProcessRegistrationsAccommodationSuccessor(t *testing.T) {
+	s := NewFamilyCampDerivedSync(nil)
+
+	// 2026-shaped input: only the successor field is answered.
+	personValues := []customValueEntry{
+		{householdPBID: "hh_emma", fieldName: "Housing Accommodation", value: "Yes"},
+	}
+	regs := s.processRegistrations(nil, personValues)
+	if len(regs) != 1 {
+		t.Fatalf("expected 1 registration, got %d", len(regs))
+	}
+	if !regs[0].needsAccommodation {
+		t.Error("Housing Accommodation=Yes did not set needsAccommodation")
+	}
+
+	// 2024-shaped input: only the retired field is answered. Still works.
+	legacy := []customValueEntry{
+		{householdPBID: "hh_liam", fieldName: "FAM Camp-Accommodation", value: "Yes"},
+	}
+	legacyRegs := s.processRegistrations(nil, legacy)
+	if len(legacyRegs) != 1 || !legacyRegs[0].needsAccommodation {
+		t.Error("retired FAM Camp-Accommodation stopped working; 2024 backfill would lose it")
+	}
+
+	// Adult partition, CampMinder's own misspelling.
+	adult := []customValueEntry{
+		{householdPBID: "hh_noah", fieldName: "Housing Accomodation", value: "Yes"},
+	}
+	adultRegs := s.processRegistrations(nil, adult)
+	if len(adultRegs) != 1 || !adultRegs[0].needsAccommodation {
+		t.Error("Housing Accomodation (one m) did not set needsAccommodation")
 	}
 }

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -1384,7 +1384,8 @@ func TestLoadFieldDefinitionsTrimsNames(t *testing.T) {
 }
 
 // TestNormalizeFieldName pins the trimming rule itself so callers other than
-// loadFieldDefinitions (see lodging_fields.go) can rely on it.
+// loadFieldDefinitions can rely on it — Phase B's lodging_fields.go registry
+// will be the second one. That file does not exist yet.
 func TestNormalizeFieldName(t *testing.T) {
 	cases := map[string]string{
 		"Family Camp-Physician ":   "Family Camp-Physician",
@@ -1480,4 +1481,84 @@ func TestProcessRegistrationsAccommodationSuccessor(t *testing.T) {
 	if len(adultRegs) != 1 || !adultRegs[0].needsAccommodation {
 		t.Error("Housing Accomodation (one m) did not set needsAccommodation")
 	}
+}
+
+// TestProcessRegistrationsBoolFieldsOrAcrossPersons pins the OR aggregation
+// itself, which is the behavior that changed when these two arms stopped
+// assigning and started ORing.
+//
+// The "No" deliberately comes LAST in every case: under the previous
+// last-wins assignment each of these would collapse to false, so a passing
+// run proves the OR is real rather than incidental. processRegistrations
+// iterates person values, and a household has several people, so disagreement
+// between household members is the normal case, not an edge case.
+func TestProcessRegistrationsBoolFieldsOrAcrossPersons(t *testing.T) {
+	s := NewFamilyCampDerivedSync(nil)
+
+	t.Run("accommodation ORs across household members", func(t *testing.T) {
+		regs := s.processRegistrations(nil, []customValueEntry{
+			{householdPBID: "hh_johnson", fieldName: "Housing Accommodation", value: "Yes"},
+			{householdPBID: "hh_johnson", fieldName: "Housing Accommodation", value: "No"},
+		})
+		if len(regs) != 1 {
+			t.Fatalf("expected 1 registration, got %d", len(regs))
+		}
+		if !regs[0].needsAccommodation {
+			t.Error("a later No overwrote an earlier Yes; the arm is assigning, not ORing")
+		}
+	})
+
+	t.Run("accommodation ORs across field generations", func(t *testing.T) {
+		regs := s.processRegistrations(nil, []customValueEntry{
+			{householdPBID: "hh_garcia", fieldName: "Housing Accommodation", value: "Yes"},
+			{householdPBID: "hh_garcia", fieldName: "Housing Accomodation", value: "No"},
+			{householdPBID: "hh_garcia", fieldName: "FAM Camp-Accommodation", value: "No"},
+		})
+		if len(regs) != 1 || !regs[0].needsAccommodation {
+			t.Error("a Yes on one generation was lost to a No on another")
+		}
+	})
+
+	// Defect 2's field. CampMinder stores the whole option sentence here, so
+	// this also proves the sentence parser reaches the column and not just
+	// parseBoolFieldValue's unit test.
+	t.Run("opt out VIP reads Adult-Opt Out and the sentence values", func(t *testing.T) {
+		regs := s.processRegistrations(nil, []customValueEntry{
+			{
+				householdPBID: "hh_chen",
+				fieldName:     "Adult-Opt Out",
+				value:         "Yes, please register regardless of cabin type",
+			},
+			{
+				householdPBID: "hh_chen",
+				fieldName:     "FAM CAMP-Opt Out VIP",
+				value:         "No, I am only able to attend with this accommodation in place",
+			},
+		})
+		if len(regs) != 1 {
+			t.Fatalf("expected 1 registration, got %d", len(regs))
+		}
+		if !regs[0].optOutVIP {
+			t.Error("Adult-Opt Out=Yes did not survive a later No; arm is assigning, not ORing")
+		}
+	})
+
+	// The softer reading must stay opt-in: an all-No household is a blocker,
+	// not a warning (spec 4.5).
+	t.Run("all-No household does not opt out", func(t *testing.T) {
+		regs := s.processRegistrations(nil, []customValueEntry{
+			{
+				householdPBID: "hh_riley",
+				fieldName:     "FAM CAMP-Opt Out VIP",
+				value:         "No, I am only able to attend with this accommodation in place",
+			},
+			{householdPBID: "hh_riley", fieldName: "Housing Accommodation", value: "Yes"},
+		})
+		if len(regs) != 1 {
+			t.Fatalf("expected 1 registration, got %d", len(regs))
+		}
+		if regs[0].optOutVIP {
+			t.Error("optOutVIP set true with no affirmative answer")
+		}
+	})
 }

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -321,18 +321,24 @@ func TestMedicalDeduplicationByHousehold(t *testing.T) {
 	}
 }
 
-// TestBoolFieldParsing tests parsing of boolean custom field values
+// TestBoolFieldParsing exercises the PRODUCTION parseBoolFieldValue. The previous
+// version of this test called a byte-identical local copy, which is why the
+// sentence-prefixed cases below went undetected: fixing production code could
+// not have made the old test fail.
 func TestBoolFieldParsing(t *testing.T) {
 	tests := []struct {
 		value    string
 		expected bool
 	}{
+		// Plain answers (FAM Camp-Accommodation, Housing Accommodation,
+		// FAM CAMP-bathroom all store bare "Yes" / "No").
 		{"Yes", true},
 		{"yes", true},
 		{"YES", true},
 		{"True", true},
 		{"true", true},
 		{"1", true},
+		{"y", true},
 		{"No", false},
 		{"no", false},
 		{"NO", false},
@@ -341,14 +347,28 @@ func TestBoolFieldParsing(t *testing.T) {
 		{"0", false},
 		{"", false},
 		{"N/A", false},
-		{"Maybe", false}, // Non-standard values treated as false
+		{"Maybe", false},
+		// Sentence-prefixed answers. CampMinder stores the whole option text for
+		// single-select fields; FAM CAMP-Opt Out VIP has exactly these two values.
+		{"Yes, please register regardless of cabin type", true},
+		{"No, I am only able to attend with this accommodation in place", false},
+		// Spacing and casing variants of the same shape.
+		{"yes, please register regardless of cabin type", true},
+		{"  Yes, please register regardless of cabin type  ", true},
+		{"Yes - I need this", true},
+		{"Yes I need this", true},
+		// Must NOT match: "yes" appearing anywhere other than the leading token.
+		{"Not yes", false},
+		{"Maybe yes, maybe no", false},
+		{"No, yes is not my answer", false},
+		{"Yesterday", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.value, func(t *testing.T) {
-			result := parseBoolField(tt.value)
+			result := parseBoolFieldValue(tt.value)
 			if result != tt.expected {
-				t.Errorf("parseBoolField(%q) = %v, want %v", tt.value, result, tt.expected)
+				t.Errorf("parseBoolFieldValue(%q) = %v, want %v", tt.value, result, tt.expected)
 			}
 		})
 	}
@@ -751,12 +771,6 @@ func aggregateMedicalByHousehold(values []testPersonCustomValue) map[int]*testMe
 	}
 
 	return result
-}
-
-// parseBoolField parses boolean values from custom field strings
-func parseBoolField(value string) bool {
-	lower := strings.ToLower(strings.TrimSpace(value))
-	return lower == boolYes || lower == boolTrueStr || lower == "1"
 }
 
 // ============================================================================
@@ -1292,9 +1306,9 @@ func extractRegistrationsFromHouseholds(values []testHouseholdCustomValue) map[i
 		case "Family Camp-Anything else":
 			reg.Notes = v.Value
 		case "FAM Camp-Accommodation":
-			reg.NeedsAccommodation = parseBoolField(v.Value)
+			reg.NeedsAccommodation = parseBoolFieldValue(v.Value)
 		case "FAM CAMP-Opt Out VIP":
-			reg.OptOutVIP = parseBoolField(v.Value)
+			reg.OptOutVIP = parseBoolFieldValue(v.Value)
 		}
 	}
 


### PR DESCRIPTION
Plan 2 (family-camp lodging ingest) **Phase A** — fixes four broken columns in `pocketbase/sync/family_camp_derived.go`. No new schema, no registry dependency, no behaviour to turn on: these take effect on the next daily sync.

Each defect was confirmed by direct query against the real dev database before any code changed.

## The four defects

| # | Column | Defect | Blast radius |
|---|---|---|---|
| 1 | `family_camp_medical.physician_info` | CampMinder ships `Family Camp-Physician ` (cm_id 39680) with a **trailing space**; every lookup compares field names by exact equality. | Every Physician answer since 2017 silently dropped — 689 values in 2025, 328 in 2026. |
| 2 | `family_camp_registrations.opt_out_vip` | `parseBoolFieldValue` did whole-string equality against `yes`/`true`/`1`, but the field stores the entire option sentence. | 100% of 129 values parsed `false` — not merely empty, **confidently wrong**. |
| 3 | `family_camp_registrations.needs_accommodation` | Read only the retired `FAM Camp-Accommodation`; the successor `Housing Accommodation` is invisible to the family-camp *name* heuristic. | Empty since 2025 while **653 values** were recorded in 2026. |
| 4 | `family_camp_registrations.goals` | Retired `Family Camp-Goals Attending` — 645 values in 2024, none since, no successor. | Documented and kept (see below), not deleted. |

Query evidence for #2 — exactly two distinct values, neither equal to `yes`:

```
90|[Yes, please register regardless of cabin type]
39|[No, I am only able to attend with this accommodation in place]
```

## Why 18 existing unit tests missed all four

`family_camp_derived_test.go` tested **local copies** of the production functions. `parseBoolField` in the test file was a byte-identical re-implementation of the production `parseBoolFieldValue`, and the test exercised the copy — so fixing production code could not have made any test fail.

Every test added here calls the production function. The local copy is deleted, and its two remaining callers now point at the production one.

## Changes

- **`normalizeFieldName`** — trims at the load boundary, so every downstream exact-match comparison is against a canonical name. Five other untrimmed CampMinder fields benefit incidentally.
- **`parseBoolFieldValue`** — anchors on the leading token instead of matching the whole string. Stays an anchor, not a substring search: `Not yes`, `Yesterday` and `No, yes is not my answer` all remain `false`.
- **`extraFieldCMIDs`** — a cm_id allowlist, per spec §4.4 (*source fields are matched on `custom_field_defs.cm_id`, not the user-editable display name*). This is the only way to reach `Housing Accommodation`, whose name contains none of the family-camp substrings, and its Adult twin `Housing Accomodation` — CampMinder's own one-`m` typo, which nobody should encode as a name rule.
- The accommodation arm now **ORs** across all three generations rather than first-wins, so any `yes` counts.

**Retired fields stay mapped.** Spec §4.4 forbids auto-inferring retirement — a field with zero values this year may simply have a form that hasn't been sent yet — and the 2024 backfill still reads them. The passive "0 values this year" warning lands later, in Phase B.

## Two lint fixes the plan did not anticipate

- The `pocketbase/tests` import is aliased `pbtests`: this file already has three local table-driven `tests` variables that shadow the package name (gocritic `importShadow`).
- `misspell` gains an `extra-words` entry for `accomodation`, matching the existing `cancelled` precedent — the typo is an external system's field name, so it is data, not a bug.

## Verification

- `go test ./sync/ -count=1` green; full `go test ./...` green across all 10 packages.
- `golangci-lint run ./sync/...` — 0 issues. `gofmt` clean, `go vet` clean.
- All three lodging harnesses still green (`verify-lodging-schema`, `verify-lodging-seed`, `verify-no-hardcoded-lodging`).
- Full pre-push suite passed: ruff, pb-js-lint, shellcheck, markdownlint, go-build, api-types-freshness, mypy, tsc, and 5622 pytest tests.

Each fix followed the plan's TDD order — failing test written and observed failing for the stated reason before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved family-camp data processing by recognizing additional legacy and successor field names.
  * Correctly handles extra whitespace and varied yes/no response formats.
  * More reliably combines accommodation and VIP opt-out information across available fields.
  * Preserves support for retired fields and historical data during synchronization.

* **Tests**
  * Added regression coverage for field-name normalization, legacy mappings, and expanded boolean formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->