### PR TITLE
feat(sync): lodging ingest primitives (lodging ingest Phase B1)

### DIFF
--- a/pocketbase/pb_migrations/1500000122_lodging_ingest_support.js
+++ b/pocketbase/pb_migrations/1500000122_lodging_ingest_support.js
@@ -20,6 +20,18 @@
  * counts behind its passive warning ("0 values in 2026, 171 in 2025"). The
  * mapping itself lives in Go (sync/lodging_fields.go): a new source field needs
  * a new target column, so it is a code change either way.
+ *
+ * lodging_field_mappings has NO `year` field, on purpose. The project-wide year
+ * invariant covers CampMinder-derived data tables; this is a per-field admin
+ * switch keyed to custom_field_defs.cm_id, and custom_field_defs itself carries
+ * no year and is unique on cm_id alone (migration 1500000002). The sibling
+ * registry tables are shaped the same way -- lodging_areas, lodging_units and
+ * lodging_unit_aliases have no year either, while the year-scoped placement
+ * tables (lodging_merges, lodging_availability, lodging_assignments) all do, as
+ * does lodging_ingest_issues below. Scoping the unique index per year would
+ * drop a human's is_enabled = false at every season rollover, which is exactly
+ * what spec 4.4 forbids. The year dimension this table does need is carried by
+ * last_seen_year / last_seen_count / prior_year_count.
  */
 
 migrate((app) => {

--- a/pocketbase/pb_migrations/1500000122_lodging_ingest_support.js
+++ b/pocketbase/pb_migrations/1500000122_lodging_ingest_support.js
@@ -1,0 +1,134 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: lodging_ingest_issues + lodging_field_mappings
+ *
+ * lodging_ingest_issues is the work queue spec 3.8 requires: "When ingest meets
+ * a cabin string with no alias, it records it and surfaces it in admin settings
+ * with a one-click 'map this to a unit' action. Never a silent drop, never a
+ * crash." It has to be a separate collection because
+ * lodging_unit_aliases.member_units is required with minSelect 1, so a
+ * placeholder row for an unmapped string cannot be inserted there (spec 9a.5).
+ *
+ * It also carries the two attribution failures, which are drops of the same kind:
+ *   ambiguous_session - household attends 2+ weekends and CampMinder holds one
+ *                       cabin value for the year (6-10 households per year)
+ *   no_session        - a cabin value whose household has no active enrolment
+ *                       (53 such values in 2025)
+ *
+ * lodging_field_mappings holds ONLY the human-set status spec 4.4 asks for
+ * ("leaves the mapping active until a human disables it") plus the observed
+ * counts behind its passive warning ("0 values in 2026, 171 in 2025"). The
+ * mapping itself lives in Go (sync/lodging_fields.go): a new source field needs
+ * a new target column, so it is a code change either way.
+ */
+
+migrate((app) => {
+  const sessionsCol = app.findCollectionByNameOrId("camp_sessions");
+  const aliasesCol = app.findCollectionByNameOrId("lodging_unit_aliases");
+
+  const issues = new Collection({
+    type: "base",
+    name: "lodging_ingest_issues",
+    listRule: '@request.auth.id != ""',
+    viewRule: '@request.auth.id != ""',
+    createRule: "@request.auth.is_admin = true",
+    updateRule: "@request.auth.is_admin = true",
+    deleteRule: "@request.auth.is_admin = true",
+    fields: [
+      {
+        type: "select", name: "kind", required: true, presentable: false,
+        values: [
+          "unresolved_alias",
+          "ambiguous_alias",
+          "ambiguous_session",
+          "no_session",
+          "field_zero_values"
+        ],
+        maxSelect: 1
+      },
+      // Verbatim source string. 500 rather than 300 so a truncated request text
+      // still fits; alias_string itself is capped at 300 upstream.
+      { type: "text", name: "raw_value", required: false, presentable: true, min: 0, max: 500, pattern: "" },
+      { type: "text", name: "source_field", required: false, presentable: false, min: 0, max: 200, pattern: "" },
+      { type: "number", name: "year", required: true, presentable: false, min: 2010, max: 2100, onlyInt: true },
+      { type: "number", name: "household_cm_id", required: false, presentable: false, min: null, max: null, onlyInt: true },
+      { type: "number", name: "person_cm_id", required: false, presentable: false, min: null, max: null, onlyInt: true },
+      // For ambiguous_session: the last_updated heuristic's best guess. Advisory
+      // only -- no assignment row is written until a human confirms it.
+      {
+        type: "relation", name: "suggested_session", required: false, presentable: false,
+        collectionId: sessionsCol.id, cascadeDelete: false, minSelect: null, maxSelect: 1
+      },
+      { type: "json", name: "candidate_session_cm_ids", required: false, presentable: false, maxSize: 20000 },
+      { type: "number", name: "occurrences", required: false, presentable: false, min: null, max: null, onlyInt: true },
+      // Set by the Plan 3 admin UI when staff resolve an unresolved_alias item by
+      // mapping the string to a unit: it points at the lodging_unit_aliases row
+      // that action created. resolution_note alone loses that link, so "which
+      // alias fixed this?" becomes unanswerable a season later.
+      // Null for every other kind. cascadeDelete false -- deleting the alias must
+      // not delete the audit trail of it having been created.
+      {
+        type: "relation", name: "resolved_alias", required: false, presentable: false,
+        collectionId: aliasesCol.id, cascadeDelete: false, minSelect: null, maxSelect: 1
+      },
+      { type: "date", name: "first_seen", required: false, presentable: false, min: "", max: "" },
+      { type: "date", name: "last_seen", required: false, presentable: false, min: "", max: "" },
+      // Staff tick this rather than deleting the row, so the queue keeps a record
+      // of what was fixed. Ingest never sets it back to false, and never writes
+      // resolved_alias either -- both belong to the Plan 3 admin UI.
+      { type: "bool", name: "is_resolved", required: false, presentable: false },
+      { type: "text", name: "resolution_note", required: false, presentable: false, min: 0, max: 2000, pattern: "" },
+      { type: "autodate", name: "created", required: false, presentable: false, onCreate: true, onUpdate: false },
+      { type: "autodate", name: "updated", required: false, presentable: false, onCreate: true, onUpdate: true }
+    ],
+    indexes: [
+      "CREATE INDEX `idx_lodging_issues_year_kind` ON `lodging_ingest_issues` (`year`, `kind`)",
+      "CREATE INDEX `idx_lodging_issues_open` ON `lodging_ingest_issues` (`is_resolved`, `year`)",
+      // One row per distinct problem, with an occurrences counter, instead of one
+      // row per affected record. Backfilling 2022 hits "River Side - R1" five
+      // times; that is one queue item, not five.
+      // household_cm_id / person_cm_id are 0 for whole-string issues like
+      // unresolved_alias, which collapses them correctly. No WHERE predicate:
+      // every key column is NOT NULL by PocketBase's own column defaults.
+      "CREATE UNIQUE INDEX `idx_lodging_issues_dedup` ON `lodging_ingest_issues` " +
+        "(`year`, `kind`, `raw_value`, `source_field`, `household_cm_id`, `person_cm_id`)"
+    ]
+  });
+  app.save(issues);
+
+  const mappings = new Collection({
+    type: "base",
+    name: "lodging_field_mappings",
+    listRule: '@request.auth.id != ""',
+    viewRule: '@request.auth.id != ""',
+    createRule: "@request.auth.is_admin = true",
+    updateRule: "@request.auth.is_admin = true",
+    deleteRule: "@request.auth.is_admin = true",
+    fields: [
+      // custom_field_defs.cm_id. Spec 4.4: source fields are matched on cm_id,
+      // never on the user-editable display name.
+      { type: "number", name: "field_cm_id", required: true, presentable: true, min: 1, max: null, onlyInt: true },
+      // Snapshot of the display name at last sync, for the admin UI only.
+      { type: "text", name: "field_name", required: false, presentable: false, min: 0, max: 200, pattern: "" },
+      { type: "text", name: "target", required: false, presentable: false, min: 0, max: 100, pattern: "" },
+      // NOTE: `required: true` on a PocketBase bool means "must be true", and PB
+      // has no per-field default, so an unset bool stores as false. The sync
+      // therefore CREATES every row with is_enabled explicitly true and never
+      // writes this field again -- only a human turns a mapping off (spec 4.4).
+      { type: "bool", name: "is_enabled", required: false, presentable: false },
+      { type: "number", name: "last_seen_year", required: false, presentable: false, min: null, max: null, onlyInt: true },
+      { type: "number", name: "last_seen_count", required: false, presentable: false, min: null, max: null, onlyInt: true },
+      { type: "number", name: "prior_year_count", required: false, presentable: false, min: null, max: null, onlyInt: true },
+      { type: "text", name: "note", required: false, presentable: false, min: 0, max: 2000, pattern: "" },
+      { type: "autodate", name: "created", required: false, presentable: false, onCreate: true, onUpdate: false },
+      { type: "autodate", name: "updated", required: false, presentable: false, onCreate: true, onUpdate: true }
+    ],
+    indexes: [
+      "CREATE UNIQUE INDEX `idx_lodging_field_map_cmid` ON `lodging_field_mappings` (`field_cm_id`)"
+    ]
+  });
+  app.save(mappings);
+}, (app) => {
+  app.delete(app.findCollectionByNameOrId("lodging_field_mappings"));
+  app.delete(app.findCollectionByNameOrId("lodging_ingest_issues"));
+});

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -574,7 +574,7 @@ func (s *FamilyCampDerivedSync) processRegistrations(
 
 		reg := regMap[v.householdPBID]
 
-		if v.fieldName == "Family Camp Cabin" && reg.cabinAssignment == "" {
+		if v.fieldName == fieldNameFamilyCampCabin && reg.cabinAssignment == "" {
 			reg.cabinAssignment = v.value
 		}
 	}

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -610,8 +610,8 @@ func (s *FamilyCampDerivedSync) processRegistrations(
 		// Retired after 2024 (645 values that year, 0 since) and no successor
 		// exists. Kept because spec 4.4 forbids auto-inferring retirement and
 		// because this plan backfills 2024. The passive "0 values this year"
-		// warning will live in lodging_field_mappings, a collection Phase B
-		// adds — it does not exist yet.
+		// warning lives in lodging_field_mappings (migration 1500000122), which
+		// UpsertFieldMappingStatus in lodging_fields.go populates.
 		case "Family Camp-Goals Attending":
 			if reg.goals == "" {
 				reg.goals = v.value

--- a/pocketbase/sync/lodging_alias_resolver.go
+++ b/pocketbase/sync/lodging_alias_resolver.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/pocketbase/pocketbase/core"
@@ -111,7 +112,11 @@ func (r *AliasResolver) Resolve(raw string, year int) AliasResolution {
 	case 0:
 		return out
 	case 1:
-		out.UnitIDs = matches[0].MemberUnitIDs
+		// Cloned, not aliased: the slice header inside matches[0] shares its
+		// backing array with the resolver's own byString map, so handing it
+		// straight out lets any caller that sorts in place permute the stored
+		// member list for the rest of the run.
+		out.UnitIDs = slices.Clone(matches[0].MemberUnitIDs)
 		out.UnitCodes = make([]string, 0, len(out.UnitIDs))
 		for _, id := range out.UnitIDs {
 			out.UnitCodes = append(out.UnitCodes, r.unitCode[id])

--- a/pocketbase/sync/lodging_alias_resolver.go
+++ b/pocketbase/sync/lodging_alias_resolver.go
@@ -1,0 +1,132 @@
+package sync
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// aliasRow is one lodging_unit_aliases record, flattened.
+type aliasRow struct {
+	ID            string
+	AliasString   string
+	MemberUnitIDs []string
+	// ValidFromYear / ValidToYear are PocketBase number columns, declared
+	// NUMERIC DEFAULT 0 NOT NULL. An unset bound stores as 0, never NULL --
+	// 94 of the 100 seeded rows are unbounded on both sides -- so 0 means
+	// "no bound" and must never be compared as a real year.
+	ValidFromYear int
+	ValidToYear   int
+}
+
+func (a aliasRow) covers(year int) bool {
+	if a.ValidFromYear > 0 && year < a.ValidFromYear {
+		return false
+	}
+	if a.ValidToYear > 0 && year > a.ValidToYear {
+		return false
+	}
+	return true
+}
+
+// AliasResolution is the outcome of resolving one raw cabin string for one year.
+// Resolved=false with Ambiguous=false means "no alias covers this" -- a work
+// queue item, not an error.
+type AliasResolution struct {
+	Raw       string
+	UnitIDs   []string
+	UnitCodes []string
+	Resolved  bool
+	Ambiguous bool
+}
+
+// IsMerge reports whether the alias denotes a merge of two or more atomic rooms.
+func (r AliasResolution) IsMerge() bool { return len(r.UnitIDs) >= 2 }
+
+// AliasResolver resolves raw cabin strings through lodging_unit_aliases,
+// honoring each row's year window. Built once per sync run and read many times.
+type AliasResolver struct {
+	byString map[string][]aliasRow
+	unitCode map[string]string
+}
+
+// NewAliasResolver loads the unit and alias tables into memory. Build one per
+// sync run: the tables are small (89 units, 100 aliases) and Resolve is called
+// once per observed cabin value.
+func NewAliasResolver(app core.App) (*AliasResolver, error) {
+	r := &AliasResolver{
+		byString: make(map[string][]aliasRow),
+		unitCode: make(map[string]string),
+	}
+
+	units, err := app.FindRecordsByFilter("lodging_units", "", "", 0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("loading lodging_units: %w", err)
+	}
+	for _, u := range units {
+		r.unitCode[u.Id] = u.GetString("code")
+	}
+
+	aliases, err := app.FindRecordsByFilter("lodging_unit_aliases", "", "", 0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("loading lodging_unit_aliases: %w", err)
+	}
+	for _, a := range aliases {
+		row := aliasRow{
+			ID:            a.Id,
+			AliasString:   a.GetString("alias_string"),
+			MemberUnitIDs: a.GetStringSlice("member_units"),
+			ValidFromYear: a.GetInt("valid_from_year"),
+			ValidToYear:   a.GetInt("valid_to_year"),
+		}
+		key := aliasLookupKey(row.AliasString)
+		r.byString[key] = append(r.byString[key], row)
+	}
+	return r, nil
+}
+
+// aliasLookupKey normalises outer whitespace and case only.
+//
+// Inner spacing stays significant: the seed stores strings verbatim and one of
+// them, "Health Center Downstairs  - Room A", genuinely carries a double space.
+// Collapsing inner runs would merge it with a single-space variant that means
+// the same room today but need not tomorrow.
+func aliasLookupKey(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// Resolve maps a raw cabin string onto units for a given year.
+func (r *AliasResolver) Resolve(raw string, year int) AliasResolution {
+	out := AliasResolution{Raw: raw}
+
+	var matches []aliasRow
+	for _, row := range r.byString[aliasLookupKey(raw)] {
+		if row.covers(year) {
+			matches = append(matches, row)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return out
+	case 1:
+		out.UnitIDs = matches[0].MemberUnitIDs
+		out.UnitCodes = make([]string, 0, len(out.UnitIDs))
+		for _, id := range out.UnitIDs {
+			out.UnitCodes = append(out.UnitCodes, r.unitCode[id])
+		}
+		out.Resolved = len(out.UnitIDs) > 0
+		return out
+	default:
+		// Two rows whose windows both contain this year. The seed contains no
+		// such pair, but the Plan 3 admin UI can create one: the unique index is
+		// on (alias_string, valid_from_year), not on alias_string alone. Picking
+		// one arbitrarily would place households in a cabin nobody chose.
+		out.Ambiguous = true
+		return out
+	}
+}
+
+// UnitCode returns a unit's stable code, or "" if the id is unknown.
+func (r *AliasResolver) UnitCode(unitID string) string { return r.unitCode[unitID] }

--- a/pocketbase/sync/lodging_alias_resolver_test.go
+++ b/pocketbase/sync/lodging_alias_resolver_test.go
@@ -1,7 +1,7 @@
 package sync
 
 import (
-	"sort"
+	"slices"
 	"testing"
 )
 
@@ -89,15 +89,12 @@ func TestAliasResolverMergeDenotingAlias(t *testing.T) {
 	if !got.Resolved || !got.IsMerge() {
 		t.Fatalf("expected a resolved merge, got %+v", got)
 	}
-	ids := append([]string{}, got.UnitIDs...)
-	sort.Strings(ids)
-	want := []string{tioga1, tioga2}
-	sort.Strings(want)
+	ids := slices.Sorted(slices.Values(got.UnitIDs))
+	want := slices.Sorted(slices.Values([]string{tioga1, tioga2}))
 	if ids[0] != want[0] || ids[1] != want[1] {
 		t.Errorf("UnitIDs = %v, want %v", ids, want)
 	}
-	codes := append([]string{}, got.UnitCodes...)
-	sort.Strings(codes)
+	codes := slices.Sorted(slices.Values(got.UnitCodes))
 	if codes[0] != "gt-tioga-1" || codes[1] != "gt-tioga-2" {
 		t.Errorf("UnitCodes = %v", codes)
 	}

--- a/pocketbase/sync/lodging_alias_resolver_test.go
+++ b/pocketbase/sync/lodging_alias_resolver_test.go
@@ -1,0 +1,186 @@
+package sync
+
+import (
+	"sort"
+	"testing"
+)
+
+// TestAliasResolverUnboundedWindows: PocketBase stores an unset year bound as 0,
+// not NULL. 94 of the 100 seeded alias rows are unbounded, so a resolver that
+// reads 0 as a real lower bound resolves almost nothing.
+func TestAliasResolverUnboundedWindows(t *testing.T) {
+	app := newLodgingTestApp(t)
+	ridgeA := addUnit(t, app, "ridge-a")
+	addAlias(t, app, "Ridge A", []string{ridgeA}, 0, 0)
+
+	r, err := NewAliasResolver(app)
+	if err != nil {
+		t.Fatalf("NewAliasResolver: %v", err)
+	}
+
+	for _, year := range []int{2017, 2022, 2025, 2026, 2030} {
+		got := r.Resolve("Ridge A", year)
+		if !got.Resolved {
+			t.Errorf("year %d: unbounded alias did not resolve", year)
+		}
+		if len(got.UnitIDs) != 1 || got.UnitIDs[0] != ridgeA {
+			t.Errorf("year %d: UnitIDs = %v, want [%s]", year, got.UnitIDs, ridgeA)
+		}
+		if got.IsMerge() {
+			t.Errorf("year %d: single-member alias reported as a merge", year)
+		}
+	}
+}
+
+// TestAliasResolverRespectsRenameWindows is the load-bearing case. Both
+// Doctor's Houses existed 2022-2024; the Golden Triangle one was renamed Wawona
+// in 2025. Resolving either side into the other silently relocates a household
+// across camp, and nothing downstream would notice.
+func TestAliasResolverRespectsRenameWindows(t *testing.T) {
+	app := newLodgingTestApp(t)
+	gtWawona := addUnit(t, app, "gt-wawona")
+	gtFront := addUnit(t, app, "gt-wawona-front")
+	gtBack := addUnit(t, app, "gt-wawona-back")
+	hcDoctors := addUnit(t, app, "hc-doctors-house")
+
+	addAlias(t, app, "Golden Triangle - Doctor's House", []string{gtWawona}, 0, 2024)
+	addAlias(t, app, "Golden Triangle - Wawona", []string{gtFront, gtBack}, 2025, 0)
+	addAlias(t, app, "Health Center - Doctor's House", []string{hcDoctors}, 0, 2024)
+	addAlias(t, app, "Doctor's House", []string{hcDoctors}, 2025, 0)
+
+	r, err := NewAliasResolver(app)
+	if err != nil {
+		t.Fatalf("NewAliasResolver: %v", err)
+	}
+
+	// In window.
+	if got := r.Resolve("Golden Triangle - Doctor's House", 2023); !got.Resolved ||
+		got.UnitIDs[0] != gtWawona {
+		t.Errorf("2023 GT Doctor's House: %+v", got)
+	}
+	// Out of window on the high side -- the string was retired, so it must NOT
+	// silently fall through to the Health Center row of the same shape.
+	if got := r.Resolve("Golden Triangle - Doctor's House", 2025); got.Resolved {
+		t.Errorf("2025 GT Doctor's House resolved to %v; the window ends at 2024", got.UnitCodes)
+	}
+	// Out of window on the low side.
+	if got := r.Resolve("Doctor's House", 2024); got.Resolved {
+		t.Errorf("2024 bare Doctor's House resolved to %v; the window starts at 2025", got.UnitCodes)
+	}
+	if got := r.Resolve("Doctor's House", 2025); !got.Resolved || got.UnitIDs[0] != hcDoctors {
+		t.Errorf("2025 bare Doctor's House: %+v", got)
+	}
+}
+
+// TestAliasResolverMergeDenotingAlias: 2+ members means the string denotes a
+// merge of that many rooms (spec 3.4). Six seeded aliases are of this shape.
+func TestAliasResolverMergeDenotingAlias(t *testing.T) {
+	app := newLodgingTestApp(t)
+	tioga1 := addUnit(t, app, "gt-tioga-1")
+	tioga2 := addUnit(t, app, "gt-tioga-2")
+	addAlias(t, app, "Golden Triangle - Tioga 1and2", []string{tioga1, tioga2}, 0, 0)
+
+	r, err := NewAliasResolver(app)
+	if err != nil {
+		t.Fatalf("NewAliasResolver: %v", err)
+	}
+
+	got := r.Resolve("Golden Triangle - Tioga 1and2", 2025)
+	if !got.Resolved || !got.IsMerge() {
+		t.Fatalf("expected a resolved merge, got %+v", got)
+	}
+	ids := append([]string{}, got.UnitIDs...)
+	sort.Strings(ids)
+	want := []string{tioga1, tioga2}
+	sort.Strings(want)
+	if ids[0] != want[0] || ids[1] != want[1] {
+		t.Errorf("UnitIDs = %v, want %v", ids, want)
+	}
+	codes := append([]string{}, got.UnitCodes...)
+	sort.Strings(codes)
+	if codes[0] != "gt-tioga-1" || codes[1] != "gt-tioga-2" {
+		t.Errorf("UnitCodes = %v", codes)
+	}
+}
+
+// TestAliasResolverUnresolvedIsNotAnError: four strings observed 2022-2023 have
+// no alias row at all -- "Ridge 2", "River Side - R1", "River Side - R2",
+// "Tuolumne 7". They must come back unresolved, with the raw string preserved,
+// and must not panic or error.
+func TestAliasResolverUnresolvedIsNotAnError(t *testing.T) {
+	app := newLodgingTestApp(t)
+	addUnit(t, app, "ridge-a")
+
+	r, err := NewAliasResolver(app)
+	if err != nil {
+		t.Fatalf("NewAliasResolver: %v", err)
+	}
+
+	for _, raw := range []string{"Ridge 2", "River Side - R1", "River Side - R2", "Tuolumne 7"} {
+		got := r.Resolve(raw, 2022)
+		if got.Resolved {
+			t.Errorf("%q unexpectedly resolved to %v", raw, got.UnitCodes)
+		}
+		if got.Raw != raw {
+			t.Errorf("Raw = %q, want %q -- the verbatim string must survive for the work queue", got.Raw, raw)
+		}
+		if len(got.UnitIDs) != 0 {
+			t.Errorf("%q returned units %v while unresolved", raw, got.UnitIDs)
+		}
+	}
+}
+
+// TestAliasResolverToleratesWhitespaceAndCase: the seed stores strings verbatim,
+// including the real double space in "Health Center Downstairs  - Room A", but
+// CampMinder values are hand-entered. Lookup normalises case and outer
+// whitespace; inner spacing stays significant because the seed relies on it.
+func TestAliasResolverToleratesWhitespaceAndCase(t *testing.T) {
+	app := newLodgingTestApp(t)
+	dsA := addUnit(t, app, "hc-downstairs-a")
+	addAlias(t, app, "Health Center Downstairs  - Room A", []string{dsA}, 0, 0)
+
+	r, err := NewAliasResolver(app)
+	if err != nil {
+		t.Fatalf("NewAliasResolver: %v", err)
+	}
+
+	for _, probe := range []string{
+		"Health Center Downstairs  - Room A",
+		"  Health Center Downstairs  - Room A  ",
+		"health center downstairs  - room a",
+	} {
+		if got := r.Resolve(probe, 2025); !got.Resolved {
+			t.Errorf("%q did not resolve", probe)
+		}
+	}
+	// Single space is a DIFFERENT string; collapsing inner whitespace would make
+	// the seeded double-space row and a hypothetical single-space row collide.
+	if got := r.Resolve("Health Center Downstairs - Room A", 2025); got.Resolved {
+		t.Error("single-space variant resolved; inner spacing must stay significant")
+	}
+}
+
+// TestAliasResolverFlagsOverlappingWindows: the Plan 3 admin UI can add a second
+// row for the same string with a different valid_from_year -- the unique index
+// is on (alias_string, valid_from_year), not alias_string alone. Overlapping
+// windows are a data problem for staff, not something to resolve arbitrarily.
+func TestAliasResolverFlagsOverlappingWindows(t *testing.T) {
+	app := newLodgingTestApp(t)
+	a := addUnit(t, app, "ridge-a")
+	b := addUnit(t, app, "ridge-b")
+	addAlias(t, app, "Ridge A", []string{a}, 0, 0)
+	addAlias(t, app, "Ridge A", []string{b}, 2024, 0)
+
+	r, err := NewAliasResolver(app)
+	if err != nil {
+		t.Fatalf("NewAliasResolver: %v", err)
+	}
+
+	got := r.Resolve("Ridge A", 2025)
+	if got.Resolved {
+		t.Error("an ambiguous alias must not resolve")
+	}
+	if !got.Ambiguous {
+		t.Error("Ambiguous flag not set; the caller cannot tell this apart from 'no alias'")
+	}
+}

--- a/pocketbase/sync/lodging_fields.go
+++ b/pocketbase/sync/lodging_fields.go
@@ -1,0 +1,178 @@
+package sync
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// Grain of a source field: whether its values key on a household or a person.
+const (
+	grainHousehold = "household"
+	grainPerson    = "person"
+)
+
+// Target columns produced by the lodging ingest.
+const (
+	targetCabinAssignmentHousehold = "cabin_assignment_household"
+	targetCabinAssignmentPerson    = "cabin_assignment_person"
+)
+
+// CampMinder custom-field ids for the lodging sources.
+//
+// Spec 4.4: "Source fields are matched on custom_field_defs.cm_id, NOT the
+// user-editable display name." Staff can and do rename these in CampMinder; the
+// names below are documentation, the ids are the contract. Verified against
+// custom_field_defs on 2026-07-30.
+const (
+	// Household grain: partition ["Family"], lives in household_custom_values.
+	// One value per household per YEAR -- which is exactly why session
+	// attribution has to be derived rather than read.
+	cmIDFamilyCampCabin = 218072 // "Family Camp Cabin"
+
+	// Person grain: partition ["Camper","Adult"], lives in person_custom_values.
+	// Verified: in 2024 and 2025 every one of these values that maps to an active
+	// enrollment maps to an `adult` session, never a `family` one.
+	cmIDReportableFamilyCampCabin = 223823 // "Reportable Family Camp Cabin"
+)
+
+// Display names of the source fields. These are documentation, not the matching
+// key -- resolution goes through the cm_ids above. They exist as constants only
+// because the same literals appear in family_camp_derived.go's name-routed
+// switch, and goconst counts a third occurrence as drift waiting to happen.
+const fieldNameFamilyCampCabin = "Family Camp Cabin"
+
+// lodgingSourceField is one CampMinder custom field the lodging ingest reads.
+type lodgingSourceField struct {
+	CMID   int
+	Name   string // display name at time of writing; documentation only
+	Target string
+	Grain  string
+}
+
+// lodgingSourceFields is the assignment-source registry. Phase C appends the
+// request-layer fields to it.
+var lodgingSourceFields = []lodgingSourceField{
+	{CMID: cmIDFamilyCampCabin, Name: fieldNameFamilyCampCabin,
+		Target: targetCabinAssignmentHousehold, Grain: grainHousehold},
+	{CMID: cmIDReportableFamilyCampCabin, Name: "Reportable Family Camp Cabin",
+		Target: targetCabinAssignmentPerson, Grain: grainPerson},
+}
+
+// LodgingFieldDefIDs maps custom_field_defs PB record id -> target column, for
+// every registered source field that exists in this database and has not been
+// disabled by a human in lodging_field_mappings.
+//
+// Returning PB ids rather than names is deliberate: household_custom_values and
+// person_custom_values store field_definition as a PB relation, so this is the
+// key the value rows actually carry.
+func LodgingFieldDefIDs(app core.App) (map[string]string, error) {
+	disabled, err := disabledFieldCMIDs(app)
+	if err != nil {
+		return nil, err
+	}
+
+	byCMID := make(map[int]string, len(lodgingSourceFields))
+	for _, f := range lodgingSourceFields {
+		if disabled[f.CMID] {
+			continue
+		}
+		byCMID[f.CMID] = f.Target
+	}
+
+	defs, err := app.FindRecordsByFilter("custom_field_defs", "", "", 0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("loading custom_field_defs: %w", err)
+	}
+
+	result := make(map[string]string, len(byCMID))
+	for _, d := range defs {
+		if target, ok := byCMID[d.GetInt("cm_id")]; ok {
+			result[d.Id] = target
+		}
+	}
+	return result, nil
+}
+
+// disabledFieldCMIDs reads the human-set off switches. A missing row means
+// enabled: spec 4.4 keeps a mapping active until somebody turns it off.
+func disabledFieldCMIDs(app core.App) (map[int]bool, error) {
+	rows, err := app.FindRecordsByFilter("lodging_field_mappings", "", "", 0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("loading lodging_field_mappings: %w", err)
+	}
+	disabled := make(map[int]bool)
+	for _, r := range rows {
+		if !r.GetBool("is_enabled") {
+			disabled[r.GetInt("field_cm_id")] = true
+		}
+	}
+	return disabled, nil
+}
+
+// UpsertFieldMappingStatus records this year's observed value count per source
+// field, and the previous year's, so the admin UI can show spec 4.4's passive
+// warning ("0 values in 2026, 171 in 2025").
+//
+// It NEVER writes is_enabled on an existing row. Auto-inferring retirement would
+// have silently dropped "FAM CAMP-Share Comments", which had 0 values in 2023,
+// 112 in 2024, 171 in 2025 and 0 in 2026 and is still live. New rows are created
+// with is_enabled explicitly true, because PocketBase has no per-field default
+// for a bool and an unset one stores as false.
+func UpsertFieldMappingStatus(app core.App, year int, counts, priorCounts map[int]int) error {
+	col, err := app.FindCollectionByNameOrId("lodging_field_mappings")
+	if err != nil {
+		return fmt.Errorf("finding lodging_field_mappings: %w", err)
+	}
+
+	names, err := fieldNamesByCMID(app)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range lodgingSourceFields {
+		existing, findErr := app.FindRecordsByFilter(
+			"lodging_field_mappings", "field_cm_id = "+strconv.Itoa(f.CMID), "", 1, 0)
+		if findErr != nil {
+			return fmt.Errorf("finding mapping %d: %w", f.CMID, findErr)
+		}
+
+		var rec *core.Record
+		if len(existing) > 0 {
+			rec = existing[0]
+		} else {
+			rec = core.NewRecord(col)
+			rec.Set("field_cm_id", f.CMID)
+			rec.Set("is_enabled", true)
+		}
+
+		name := names[f.CMID]
+		if name == "" {
+			name = f.Name
+		}
+		rec.Set("field_name", name)
+		rec.Set("target", f.Target)
+		rec.Set("last_seen_year", year)
+		rec.Set("last_seen_count", counts[f.CMID])
+		rec.Set("prior_year_count", priorCounts[f.CMID])
+
+		if err := app.Save(rec); err != nil {
+			return fmt.Errorf("saving mapping %d: %w", f.CMID, err)
+		}
+	}
+	return nil
+}
+
+// fieldNamesByCMID snapshots the current display names for the admin UI.
+func fieldNamesByCMID(app core.App) (map[int]string, error) {
+	defs, err := app.FindRecordsByFilter("custom_field_defs", "", "", 0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("loading custom_field_defs: %w", err)
+	}
+	names := make(map[int]string, len(defs))
+	for _, d := range defs {
+		names[d.GetInt("cm_id")] = normalizeFieldName(d.GetString("name"))
+	}
+	return names, nil
+}

--- a/pocketbase/sync/lodging_fields.go
+++ b/pocketbase/sync/lodging_fields.go
@@ -153,9 +153,17 @@ func UpsertFieldMappingStatus(app core.App, year int, counts, priorCounts map[in
 		}
 		rec.Set("field_name", name)
 		rec.Set("target", f.Target)
-		rec.Set("last_seen_year", year)
-		rec.Set("last_seen_count", counts[f.CMID])
-		rec.Set("prior_year_count", priorCounts[f.CMID])
+
+		// last_seen_* means MOST RECENT, and the sync is year-parameterised, so
+		// Task 14's 2024/2025 backfill runs AFTER the current season has synced.
+		// Writing the backfill year's counts over the current ones would make
+		// spec 4.4's passive warning describe the wrong season. An older run
+		// still refreshes the name and target snapshot, but not the counters.
+		if year >= rec.GetInt("last_seen_year") {
+			rec.Set("last_seen_year", year)
+			rec.Set("last_seen_count", counts[f.CMID])
+			rec.Set("prior_year_count", priorCounts[f.CMID])
+		}
 
 		if err := app.Save(rec); err != nil {
 			return fmt.Errorf("saving mapping %d: %w", f.CMID, err)

--- a/pocketbase/sync/lodging_fields_test.go
+++ b/pocketbase/sync/lodging_fields_test.go
@@ -1,0 +1,113 @@
+package sync
+
+import (
+	"strconv"
+	"testing"
+)
+
+// TestLodgingSourceFieldsAreUnique guards the registry itself: two entries with
+// the same cm_id would make LodgingFieldDefIDs non-deterministic, and
+// lodging_field_mappings has a UNIQUE index on field_cm_id that would reject the
+// second row at sync time rather than at review time.
+func TestLodgingSourceFieldsAreUnique(t *testing.T) {
+	seenCMID := map[int]string{}
+	for _, f := range lodgingSourceFields {
+		if prev, dup := seenCMID[f.CMID]; dup {
+			t.Errorf("cm_id %d is registered twice: %q and %q", f.CMID, prev, f.Name)
+		}
+		seenCMID[f.CMID] = f.Name
+		if f.Target == "" {
+			t.Errorf("%q (cm_id %d) has no target", f.Name, f.CMID)
+		}
+		if f.Grain != grainHousehold && f.Grain != grainPerson {
+			t.Errorf("%q (cm_id %d) has grain %q; want %q or %q",
+				f.Name, f.CMID, f.Grain, grainHousehold, grainPerson)
+		}
+	}
+}
+
+// TestLodgingFieldDefIDsMapsByCMID proves resolution goes through cm_id, not the
+// display name (spec 4.4). The fixture renames a field to something the name
+// would never match; the mapping must still be found.
+func TestLodgingFieldDefIDsMapsByCMID(t *testing.T) {
+	app := newLodgingTestApp(t)
+
+	cabinDefID := addFieldDef(t, app, cmIDFamilyCampCabin, "Renamed By Staff In 2027")
+	reportableDefID := addFieldDef(t, app, cmIDReportableFamilyCampCabin, "Reportable Family Camp Cabin")
+	addFieldDef(t, app, 999999, "SVI-Vehicle Make") // unrelated
+
+	got, err := LodgingFieldDefIDs(app)
+	if err != nil {
+		t.Fatalf("LodgingFieldDefIDs: %v", err)
+	}
+
+	if got[cabinDefID] != targetCabinAssignmentHousehold {
+		t.Errorf("cabin field mapped to %q, want %q", got[cabinDefID], targetCabinAssignmentHousehold)
+	}
+	if got[reportableDefID] != targetCabinAssignmentPerson {
+		t.Errorf("reportable field mapped to %q, want %q", got[reportableDefID], targetCabinAssignmentPerson)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected exactly 2 mapped defs, got %d: %v", len(got), got)
+	}
+}
+
+// TestLodgingFieldDefIDsHonoursDisabledMapping covers spec 4.4's human override:
+// a mapping stays active until a person turns it off, and once off the sync must
+// stop reading that field.
+func TestLodgingFieldDefIDsHonoursDisabledMapping(t *testing.T) {
+	app := newLodgingTestApp(t)
+	cabinDefID := addFieldDef(t, app, cmIDFamilyCampCabin, "Family Camp Cabin")
+
+	saveRecord(t, app, "lodging_field_mappings", map[string]any{
+		"field_cm_id": cmIDFamilyCampCabin,
+		"is_enabled":  false,
+		"note":        "turned off by staff while the 2027 form is rebuilt",
+	})
+
+	got, err := LodgingFieldDefIDs(app)
+	if err != nil {
+		t.Fatalf("LodgingFieldDefIDs: %v", err)
+	}
+	if _, present := got[cabinDefID]; present {
+		t.Error("a disabled mapping was still returned; spec 4.4 says a human disable must take effect")
+	}
+}
+
+// TestUpsertFieldMappingStatusIsIdempotentAndNeverAutoDisables covers the other
+// half of spec 4.4: "Retirement is never auto-inferred. A field with zero values
+// this year may simply have a form that hasn't been sent yet."
+func TestUpsertFieldMappingStatusIsIdempotentAndNeverAutoDisables(t *testing.T) {
+	app := newLodgingTestApp(t)
+	addFieldDef(t, app, cmIDFamilyCampCabin, "Family Camp Cabin")
+
+	// Year with zero values for the cabin field, 464 the year before.
+	counts := map[int]int{cmIDFamilyCampCabin: 0}
+	prior := map[int]int{cmIDFamilyCampCabin: 464}
+
+	for i := 0; i < 2; i++ {
+		if err := UpsertFieldMappingStatus(app, 2026, counts, prior); err != nil {
+			t.Fatalf("UpsertFieldMappingStatus pass %d: %v", i, err)
+		}
+	}
+
+	rows, err := app.FindRecordsByFilter("lodging_field_mappings",
+		"field_cm_id = "+strconv.Itoa(cmIDFamilyCampCabin), "", 0, 0)
+	if err != nil {
+		t.Fatalf("find mappings: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected exactly 1 mapping row after two passes, got %d", len(rows))
+	}
+	r := rows[0]
+	if !r.GetBool("is_enabled") {
+		t.Error("zero values this year auto-disabled the mapping; spec 4.4 forbids that")
+	}
+	if r.GetInt("last_seen_count") != 0 || r.GetInt("prior_year_count") != 464 {
+		t.Errorf("counts wrong: last_seen=%d prior=%d, want 0 and 464",
+			r.GetInt("last_seen_count"), r.GetInt("prior_year_count"))
+	}
+	if r.GetString("field_name") != "Family Camp Cabin" {
+		t.Errorf("field_name = %q, want %q", r.GetString("field_name"), "Family Camp Cabin")
+	}
+}

--- a/pocketbase/sync/lodging_fields_test.go
+++ b/pocketbase/sync/lodging_fields_test.go
@@ -111,3 +111,80 @@ func TestUpsertFieldMappingStatusIsIdempotentAndNeverAutoDisables(t *testing.T) 
 		t.Errorf("field_name = %q, want %q", r.GetString("field_name"), "Family Camp Cabin")
 	}
 }
+
+// TestUpsertFieldMappingStatusDoesNotRegressOnOlderYearBackfill: Task 14
+// backfills 2024 and 2025 AFTER the current season has already synced, and the
+// sync is year-parameterised (`sync/run?year=2024`). Writing the backfill year's
+// counts over the current ones makes spec 4.4's passive warning describe the
+// wrong season -- "0 values in 2024" where staff expect "0 values in 2026, 171
+// in 2025". last_seen_* means MOST RECENT, so an older run must leave it alone.
+func TestUpsertFieldMappingStatusDoesNotRegressOnOlderYearBackfill(t *testing.T) {
+	app := newLodgingTestApp(t)
+	addFieldDef(t, app, cmIDFamilyCampCabin, "Family Camp Cabin")
+
+	// The current season's daily sync: no values yet this year, 171 last year.
+	if err := UpsertFieldMappingStatus(app, 2026,
+		map[int]int{cmIDFamilyCampCabin: 0}, map[int]int{cmIDFamilyCampCabin: 171}); err != nil {
+		t.Fatalf("current-year pass: %v", err)
+	}
+
+	// Task 14's backfill, run afterwards. Its counts belong to 2024.
+	if err := UpsertFieldMappingStatus(app, 2024,
+		map[int]int{cmIDFamilyCampCabin: 464}, map[int]int{cmIDFamilyCampCabin: 645}); err != nil {
+		t.Fatalf("backfill pass: %v", err)
+	}
+
+	rows, err := app.FindRecordsByFilter("lodging_field_mappings",
+		"field_cm_id = "+strconv.Itoa(cmIDFamilyCampCabin), "", 0, 0)
+	if err != nil {
+		t.Fatalf("find mappings: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 mapping row, got %d", len(rows))
+	}
+	r := rows[0]
+	if r.GetInt("last_seen_year") != 2026 {
+		t.Errorf("last_seen_year = %d, want 2026 (a 2024 backfill must not rewind it)",
+			r.GetInt("last_seen_year"))
+	}
+	if r.GetInt("last_seen_count") != 0 {
+		t.Errorf("last_seen_count = %d, want 0 (2026's count, not the backfill's)",
+			r.GetInt("last_seen_count"))
+	}
+	if r.GetInt("prior_year_count") != 171 {
+		t.Errorf("prior_year_count = %d, want 171 (2025's count, not 2023's)",
+			r.GetInt("prior_year_count"))
+	}
+}
+
+// TestUpsertFieldMappingStatusAdvancesOnNewerYear is the other half: a LATER
+// year must still move the counters, or the warning freezes at whatever season
+// happened to run first.
+func TestUpsertFieldMappingStatusAdvancesOnNewerYear(t *testing.T) {
+	app := newLodgingTestApp(t)
+	addFieldDef(t, app, cmIDFamilyCampCabin, "Family Camp Cabin")
+
+	if err := UpsertFieldMappingStatus(app, 2025,
+		map[int]int{cmIDFamilyCampCabin: 171}, map[int]int{cmIDFamilyCampCabin: 112}); err != nil {
+		t.Fatalf("2025 pass: %v", err)
+	}
+	if err := UpsertFieldMappingStatus(app, 2026,
+		map[int]int{cmIDFamilyCampCabin: 0}, map[int]int{cmIDFamilyCampCabin: 171}); err != nil {
+		t.Fatalf("2026 pass: %v", err)
+	}
+
+	rows, err := app.FindRecordsByFilter("lodging_field_mappings",
+		"field_cm_id = "+strconv.Itoa(cmIDFamilyCampCabin), "", 0, 0)
+	if err != nil {
+		t.Fatalf("find mappings: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 mapping row, got %d", len(rows))
+	}
+	if got := rows[0].GetInt("last_seen_year"); got != 2026 {
+		t.Errorf("last_seen_year = %d, want 2026", got)
+	}
+	if got := rows[0].GetInt("prior_year_count"); got != 171 {
+		t.Errorf("prior_year_count = %d, want 171", got)
+	}
+}

--- a/pocketbase/sync/lodging_grain.go
+++ b/pocketbase/sync/lodging_grain.go
@@ -1,0 +1,59 @@
+package sync
+
+import "errors"
+
+// The dual-grain invariant (spec 3.5): exactly one party identifier and exactly
+// one placement per assignment row.
+//
+// PocketBase enforces none of it. lodging_assignments.unit and .merge are both
+// optional relations, and household_cm_id / person_cm_id are both optional
+// numbers, so every illegal shape below saves with a 200. Plan 1 kept the
+// invariant above the database deliberately -- a partial unique index cannot
+// express "exactly one of these two" -- which makes this function the only place
+// it exists at all.
+var (
+	ErrGrainNoParty        = errors.New("assignment has neither household_cm_id nor person_cm_id")
+	ErrGrainBothParties    = errors.New("assignment has both household_cm_id and person_cm_id")
+	ErrGrainNoPlacement    = errors.New("assignment has neither unit nor merge")
+	ErrGrainBothPlacements = errors.New("assignment has both unit and merge")
+)
+
+// AssignmentGrain is the identity half of a lodging_assignments row.
+type AssignmentGrain struct {
+	HouseholdCMID int
+	PersonCMID    int
+	UnitID        string
+	MergeID       string
+}
+
+// ValidateAssignmentGrain returns nil only for the two legal shapes:
+//
+//	household + unit | household + merge   -> family camp
+//	person    + unit | person    + merge   -> adult weekends, or one person
+//	                                          pulled out of their household's row
+//
+// Note the party test compares against 0, never against the empty string.
+// PocketBase number columns are NUMERIC DEFAULT 0 NOT NULL so an unset id is 0,
+// and SQLite evaluates a number-vs-empty-string inequality as TRUE -- the same
+// trap that would have collapsed every person-grain row onto
+// household_cm_id = 0 in Plan 1's unique indexes.
+func ValidateAssignmentGrain(g AssignmentGrain) error {
+	hasHousehold := g.HouseholdCMID > 0
+	hasPerson := g.PersonCMID > 0
+	switch {
+	case !hasHousehold && !hasPerson:
+		return ErrGrainNoParty
+	case hasHousehold && hasPerson:
+		return ErrGrainBothParties
+	}
+
+	hasUnit := g.UnitID != ""
+	hasMerge := g.MergeID != ""
+	switch {
+	case !hasUnit && !hasMerge:
+		return ErrGrainNoPlacement
+	case hasUnit && hasMerge:
+		return ErrGrainBothPlacements
+	}
+	return nil
+}

--- a/pocketbase/sync/lodging_grain_test.go
+++ b/pocketbase/sync/lodging_grain_test.go
@@ -1,0 +1,81 @@
+package sync
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestValidateAssignmentGrain covers every state the database accepts but the
+// design forbids. PocketBase enforces none of these: lodging_assignments.unit
+// and .merge are both optional relations and household_cm_id / person_cm_id are
+// both optional numbers, so all four illegal shapes save with a 200. This
+// function is the only place the invariant exists.
+func TestValidateAssignmentGrain(t *testing.T) {
+	cases := []struct {
+		name string
+		in   AssignmentGrain
+		want error
+	}{
+		{
+			name: "household into an atomic room (family camp, ~94% of rows)",
+			in:   AssignmentGrain{HouseholdCMID: 9001, UnitID: "u_ridge_a"},
+		},
+		{
+			name: "person into a merged slot (an adult weekend placement)",
+			in:   AssignmentGrain{PersonCMID: 5001, MergeID: "m_tioga_12"},
+		},
+		{
+			name: "neither party",
+			in:   AssignmentGrain{UnitID: "u_ridge_a"},
+			want: ErrGrainNoParty,
+		},
+		{
+			name: "both parties",
+			in:   AssignmentGrain{HouseholdCMID: 9001, PersonCMID: 5001, UnitID: "u_ridge_a"},
+			want: ErrGrainBothParties,
+		},
+		{
+			name: "no placement",
+			in:   AssignmentGrain{HouseholdCMID: 9001},
+			want: ErrGrainNoPlacement,
+		},
+		{
+			name: "both placements",
+			in:   AssignmentGrain{HouseholdCMID: 9001, UnitID: "u_ridge_a", MergeID: "m_tioga_12"},
+			want: ErrGrainBothPlacements,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateAssignmentGrain(tc.in)
+			if tc.want == nil {
+				if err != nil {
+					t.Fatalf("ValidateAssignmentGrain(%+v) = %v, want nil", tc.in, err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("ValidateAssignmentGrain(%+v) = %v, want %v", tc.in, err, tc.want)
+			}
+		})
+	}
+}
+
+// TestAssignmentGrainIllegalStatesReallySaveInPocketBase documents WHY the guard
+// exists rather than trusting the schema. If PocketBase ever starts rejecting
+// these, this test fails and the guard can be reconsidered -- but until then the
+// invariant has no database backing.
+func TestAssignmentGrainIllegalStatesReallySaveInPocketBase(t *testing.T) {
+	app := newLodgingTestApp(t)
+	sess := addSession(t, app, 1309514, "Family Camp 1", "family",
+		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
+
+	// Neither party, no placement: the emptiest illegal row there is.
+	id := saveRecord(t, app, "lodging_assignments", map[string]any{
+		"session": sess, "year": 2025, "source": "campminder_sync",
+	})
+	if id == "" {
+		t.Fatal("expected PocketBase to accept the row (that is the point of this test)")
+	}
+}

--- a/pocketbase/sync/lodging_issues.go
+++ b/pocketbase/sync/lodging_issues.go
@@ -1,0 +1,202 @@
+package sync
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// Work-queue kinds. These strings must match lodging_ingest_issues.kind's select
+// values exactly (migration 1500000122); PocketBase rejects anything else.
+const (
+	// A cabin string with no alias row covering this year.
+	issueUnresolvedAlias = "unresolved_alias"
+	// Two or more alias rows whose year windows both contain this year, so the
+	// string resolves to more than one thing. Only reachable via the Plan 3
+	// admin UI, which can add overlapping windows the seed does not.
+	issueAmbiguousAlias = "ambiguous_alias"
+	// The household or person attends more than one weekend and CampMinder holds
+	// a single cabin value for the year. Spec 3.6 calls this out as the honest
+	// limit of backfill: flag it, do not guess.
+	issueAmbiguousSession = "ambiguous_session"
+	// A cabin value whose household or person has no active enrolment in a
+	// family/adult session that year -- cancelled, waitlisted, or in progress.
+	issueNoSession = "no_session"
+	// Spec 4.4's passive warning: a mapped field saw zero values this year.
+	issueFieldZeroValues = "field_zero_values"
+)
+
+// Issue is one work-queue item. Zero-valued HouseholdCMID / PersonCMID mean "not
+// specific to one party" and collapse the item across parties -- an unmapped
+// cabin string is one thing to fix, however many households hit it.
+type Issue struct {
+	Kind          string
+	RawValue      string
+	SourceField   string
+	Year          int
+	HouseholdCMID int
+	PersonCMID    int
+	// SuggestedSession is a camp_sessions PB record id, advisory only. No
+	// assignment row is ever written from it.
+	SuggestedSession string
+	CandidateCMIDs   []int
+}
+
+func (i *Issue) dedupKey() string {
+	return fmt.Sprintf("%d\x00%s\x00%s\x00%s\x00%d\x00%d",
+		i.Year, i.Kind, i.RawValue, i.SourceField, i.HouseholdCMID, i.PersonCMID)
+}
+
+type pendingIssue struct {
+	issue       Issue
+	occurrences int
+}
+
+// IssueRecorder accumulates work-queue items in memory and writes them once, so
+// a backfill that meets the same unmapped string 472 times produces one row with
+// occurrences=472 rather than 472 rows.
+type IssueRecorder struct {
+	app     core.App
+	year    int
+	pending map[string]*pendingIssue
+	order   []string // insertion order, so Flush is deterministic
+}
+
+// NewIssueRecorder returns a recorder that accumulates work-queue items for one
+// year. Call Flush once at the end of the run to write them.
+func NewIssueRecorder(app core.App, year int) *IssueRecorder {
+	return &IssueRecorder{
+		app:     app,
+		year:    year,
+		pending: make(map[string]*pendingIssue),
+	}
+}
+
+// Record adds one observation. Repeated identical observations increment the
+// occurrence count rather than queueing another item.
+//
+// Issue is passed by value on purpose: callers build one inline per observation
+// and the recorder keeps its own copy. Nothing here is hot path.
+//
+//nolint:gocritic // hugeParam, see above
+func (r *IssueRecorder) Record(i Issue) {
+	if i.Year == 0 {
+		i.Year = r.year
+	}
+	key := i.dedupKey()
+	if p, ok := r.pending[key]; ok {
+		p.occurrences++
+		// Later observations may carry a suggestion the first did not.
+		if p.issue.SuggestedSession == "" {
+			p.issue.SuggestedSession = i.SuggestedSession
+		}
+		return
+	}
+	r.pending[key] = &pendingIssue{issue: i, occurrences: 1}
+	r.order = append(r.order, key)
+}
+
+// CountOf returns the total observations recorded for a kind, across items.
+func (r *IssueRecorder) CountOf(kind string) int {
+	total := 0
+	for _, p := range r.pending {
+		if p.issue.Kind == kind {
+			total += p.occurrences
+		}
+	}
+	return total
+}
+
+// Flush upserts every accumulated item. occurrences is SET to what this run
+// observed rather than added to, so re-running the sync is idempotent.
+// is_resolved is written only on create -- once staff tick an item, a later sync
+// must not un-tick it.
+func (r *IssueRecorder) Flush(now time.Time) (created, updated int, err error) {
+	col, err := r.app.FindCollectionByNameOrId("lodging_ingest_issues")
+	if err != nil {
+		return 0, 0, fmt.Errorf("finding lodging_ingest_issues: %w", err)
+	}
+	stamp := now.UTC().Format("2006-01-02 15:04:05.000Z")
+
+	for _, key := range r.order {
+		p := r.pending[key]
+		existing, findErr := r.findExisting(&p.issue)
+		if findErr != nil {
+			return created, updated, findErr
+		}
+
+		rec := existing
+		isNew := rec == nil
+		if isNew {
+			rec = core.NewRecord(col)
+			rec.Set("kind", p.issue.Kind)
+			rec.Set("raw_value", p.issue.RawValue)
+			rec.Set("source_field", p.issue.SourceField)
+			rec.Set("year", p.issue.Year)
+			rec.Set("household_cm_id", p.issue.HouseholdCMID)
+			rec.Set("person_cm_id", p.issue.PersonCMID)
+			rec.Set("first_seen", stamp)
+			rec.Set("is_resolved", false)
+		}
+		rec.Set("occurrences", p.occurrences)
+		rec.Set("last_seen", stamp)
+		rec.Set("suggested_session", p.issue.SuggestedSession)
+		rec.Set("candidate_session_cm_ids", p.issue.CandidateCMIDs)
+
+		if saveErr := r.app.Save(rec); saveErr != nil {
+			return created, updated, fmt.Errorf("saving issue %q: %w", p.issue.RawValue, saveErr)
+		}
+		if isNew {
+			created++
+		} else {
+			updated++
+		}
+	}
+	return created, updated, nil
+}
+
+// eqOrEmpty renders a text-column equality clause into filter, registering a
+// bound parameter unless the value is empty.
+//
+// Two traps in one helper, both verified against a live PocketBase:
+//
+//   - A bound parameter whose value is the EMPTY STRING matches nothing. For a
+//     row whose scenario is the empty string, `scenario = {:sc}` with sc="" returns
+//     0 rows, while the same comparison written as a bare SQL literal returns it.
+//     So empty values have to be literals.
+//   - Everything else must stay parameterised. Real cabin strings contain
+//     apostrophes ("Golden Triangle - Doctor's House"), and interpolating one
+//     into a quoted SQL literal is a syntax error, not a miss -- the exact bug
+//     that left Plan 1's alias verifier unable to pass no matter what was seeded.
+func eqOrEmpty(column, paramName, value string, params dbx.Params) string {
+	if value == "" {
+		return column + " = ''"
+	}
+	params[paramName] = value
+	return column + " = {:" + paramName + "}"
+}
+
+// findExisting looks the item up on the same six columns as
+// idx_lodging_issues_dedup.
+func (r *IssueRecorder) findExisting(i *Issue) (*core.Record, error) {
+	params := dbx.Params{
+		"year":   i.Year,
+		"hh":     i.HouseholdCMID,
+		"person": i.PersonCMID,
+	}
+	filter := "year = {:year} && household_cm_id = {:hh} && person_cm_id = {:person} && " +
+		eqOrEmpty("kind", "kind", i.Kind, params) + " && " +
+		eqOrEmpty("raw_value", "raw", i.RawValue, params) + " && " +
+		eqOrEmpty("source_field", "field", i.SourceField, params)
+
+	rows, err := r.app.FindRecordsByFilter("lodging_ingest_issues", filter, "", 1, 0, params)
+	if err != nil {
+		return nil, fmt.Errorf("looking up issue %q: %w", i.RawValue, err)
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	return rows[0], nil
+}

--- a/pocketbase/sync/lodging_issues.go
+++ b/pocketbase/sync/lodging_issues.go
@@ -142,8 +142,17 @@ func (r *IssueRecorder) Flush(now time.Time) (created, updated int, err error) {
 		}
 		rec.Set("occurrences", p.occurrences)
 		rec.Set("last_seen", stamp)
-		rec.Set("suggested_session", p.issue.SuggestedSession)
-		rec.Set("candidate_session_cm_ids", p.issue.CandidateCMIDs)
+		// The advisory fields are only overwritten when this run actually
+		// produced them. Record preserves the first non-empty suggestion within a
+		// run; blanking a stored one here would undo that across runs, and a
+		// re-run whose last_updated stops parsing would silently strip an open
+		// queue item of its one-click confirmation.
+		if isNew || p.issue.SuggestedSession != "" {
+			rec.Set("suggested_session", p.issue.SuggestedSession)
+		}
+		if isNew || len(p.issue.CandidateCMIDs) > 0 {
+			rec.Set("candidate_session_cm_ids", p.issue.CandidateCMIDs)
+		}
 
 		if saveErr := r.app.Save(rec); saveErr != nil {
 			return created, updated, fmt.Errorf("saving issue %q: %w", p.issue.RawValue, saveErr)

--- a/pocketbase/sync/lodging_issues.go
+++ b/pocketbase/sync/lodging_issues.go
@@ -166,10 +166,12 @@ func (r *IssueRecorder) Flush(now time.Time) (created, updated int, err error) {
 //     row whose scenario is the empty string, `scenario = {:sc}` with sc="" returns
 //     0 rows, while the same comparison written as a bare SQL literal returns it.
 //     So empty values have to be literals.
-//   - Everything else must stay parameterised. Real cabin strings contain
-//     apostrophes ("Golden Triangle - Doctor's House"), and interpolating one
-//     into a quoted SQL literal is a syntax error, not a miss -- the exact bug
-//     that left Plan 1's alias verifier unable to pass no matter what was seeded.
+//   - Everything else must stay parameterised. Several real cabin strings carry
+//     an apostrophe, and interpolating one into a quoted SQL literal is a syntax
+//     error rather than a miss -- the exact bug that left Plan 1's alias verifier
+//     unable to pass no matter what was seeded. (The strings themselves are not
+//     quoted here: verify-no-hardcoded-lodging.sh forbids unit names in
+//     application source, comments included. See lodging_issues_test.go.)
 func eqOrEmpty(column, paramName, value string, params dbx.Params) string {
 	if value == "" {
 		return column + " = ''"

--- a/pocketbase/sync/lodging_issues_test.go
+++ b/pocketbase/sync/lodging_issues_test.go
@@ -1,0 +1,169 @@
+package sync
+
+import (
+	"testing"
+	"time"
+)
+
+var testNow = time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+
+// TestIssueKindsMatchTheMigration keeps the Go constants in step with
+// lodging_ingest_issues.kind's select values (migration 1500000122). PocketBase
+// rejects any other string at save time, so a typo here surfaces as a failed
+// sync rather than a compile error. It also gives every constant a reader --
+// golangci-lint runs with `unused` enabled and would otherwise flag the ones no
+// code path has reached yet.
+func TestIssueKindsMatchTheMigration(t *testing.T) {
+	want := []string{
+		"unresolved_alias",
+		"ambiguous_alias",
+		"ambiguous_session",
+		"no_session",
+		"field_zero_values",
+	}
+	got := []string{
+		issueUnresolvedAlias,
+		issueAmbiguousAlias,
+		issueAmbiguousSession,
+		issueNoSession,
+		issueFieldZeroValues,
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("kind %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestIssueRecorderCollapsesRepeats mirrors the real 2022 backfill: the cabin
+// string "River Side - R1" appears on five different households and has no alias
+// row. That is ONE thing for staff to fix, so it must be one queue item with an
+// occurrence count -- not five rows to wade through.
+func TestIssueRecorderCollapsesRepeats(t *testing.T) {
+	app := newLodgingTestApp(t)
+	r := NewIssueRecorder(app, 2022)
+
+	for _, hh := range []int{9001, 9002, 9003, 9004, 9005} {
+		r.Record(Issue{
+			Kind:        issueUnresolvedAlias,
+			RawValue:    "River Side - R1",
+			SourceField: fieldNameFamilyCampCabin,
+			Year:        2022,
+			// Deliberately 0: an unmapped STRING is not a per-household problem,
+			// so the dedup key must collapse across households.
+			HouseholdCMID: 0,
+		})
+		_ = hh
+	}
+
+	if got := r.CountOf(issueUnresolvedAlias); got != 5 {
+		t.Errorf("CountOf = %d, want 5 (occurrences, not rows)", got)
+	}
+
+	created, updated, err := r.Flush(testNow)
+	if err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if created != 1 || updated != 0 {
+		t.Errorf("Flush = (%d created, %d updated), want (1, 0)", created, updated)
+	}
+
+	rows, err := app.FindRecordsByFilter("lodging_ingest_issues", "", "", 0, 0)
+	if err != nil {
+		t.Fatalf("find issues: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 issue row, got %d", len(rows))
+	}
+	if rows[0].GetInt("occurrences") != 5 {
+		t.Errorf("occurrences = %d, want 5", rows[0].GetInt("occurrences"))
+	}
+	if rows[0].GetBool("is_resolved") {
+		t.Error("a newly recorded issue must start unresolved")
+	}
+}
+
+// TestIssueRecorderFlushIsIdempotent: re-running the sync must not double the
+// counts or add rows. occurrences is SET to what this run observed, not added to.
+func TestIssueRecorderFlushIsIdempotent(t *testing.T) {
+	app := newLodgingTestApp(t)
+
+	for pass := 0; pass < 2; pass++ {
+		r := NewIssueRecorder(app, 2022)
+		r.Record(Issue{Kind: issueUnresolvedAlias, RawValue: "Ridge 2",
+			SourceField: fieldNameFamilyCampCabin, Year: 2022})
+		r.Record(Issue{Kind: issueUnresolvedAlias, RawValue: "Ridge 2",
+			SourceField: fieldNameFamilyCampCabin, Year: 2022})
+		r.Record(Issue{Kind: issueUnresolvedAlias, RawValue: "Ridge 2",
+			SourceField: fieldNameFamilyCampCabin, Year: 2022})
+		r.Record(Issue{Kind: issueUnresolvedAlias, RawValue: "Ridge 2",
+			SourceField: fieldNameFamilyCampCabin, Year: 2022})
+		created, updated, err := r.Flush(testNow)
+		if err != nil {
+			t.Fatalf("pass %d Flush: %v", pass, err)
+		}
+		if pass == 0 && (created != 1 || updated != 0) {
+			t.Errorf("pass 0: (%d, %d), want (1, 0)", created, updated)
+		}
+		if pass == 1 && (created != 0 || updated != 1) {
+			t.Errorf("pass 1: (%d, %d), want (0, 1)", created, updated)
+		}
+	}
+
+	rows, err := app.FindRecordsByFilter("lodging_ingest_issues", "", "", 0, 0)
+	if err != nil {
+		t.Fatalf("find issues: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row after two passes, got %d", len(rows))
+	}
+	if rows[0].GetInt("occurrences") != 4 {
+		t.Errorf("occurrences = %d, want 4 (set, not accumulated)", rows[0].GetInt("occurrences"))
+	}
+}
+
+// TestIssueRecorderKeepsPerHouseholdIssuesSeparate: an ambiguous_session IS a
+// per-household problem, so two households must produce two rows even though the
+// raw value and source field are identical.
+func TestIssueRecorderKeepsPerHouseholdIssuesSeparate(t *testing.T) {
+	app := newLodgingTestApp(t)
+	r := NewIssueRecorder(app, 2025)
+
+	r.Record(Issue{Kind: issueAmbiguousSession, RawValue: "Ridge A",
+		SourceField: fieldNameFamilyCampCabin, Year: 2025, HouseholdCMID: 9001,
+		CandidateCMIDs: []int{1309514, 1354939}})
+	r.Record(Issue{Kind: issueAmbiguousSession, RawValue: "Ridge A",
+		SourceField: fieldNameFamilyCampCabin, Year: 2025, HouseholdCMID: 9002,
+		CandidateCMIDs: []int{1309514, 1354939}})
+
+	created, _, err := r.Flush(testNow)
+	if err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if created != 2 {
+		t.Errorf("created = %d, want 2 (one per household)", created)
+	}
+}
+
+// TestIssueRecorderHandlesApostrophes: real cabin strings contain apostrophes
+// ("Golden Triangle - Doctor's House", "Golden Triangle - Cloud's Rest"). A
+// filter built by string concatenation would be a syntax error here, which is
+// exactly the class of bug that made Plan 1's alias verifier unable to pass.
+func TestIssueRecorderHandlesApostrophes(t *testing.T) {
+	app := newLodgingTestApp(t)
+	r := NewIssueRecorder(app, 2024)
+	r.Record(Issue{Kind: issueUnresolvedAlias, RawValue: "Golden Triangle - Doctor's House",
+		SourceField: fieldNameFamilyCampCabin, Year: 2024})
+
+	if _, _, err := r.Flush(testNow); err != nil {
+		t.Fatalf("Flush with an apostrophe in raw_value: %v", err)
+	}
+
+	rows, err := app.FindRecordsByFilter("lodging_ingest_issues", "", "", 0, 0)
+	if err != nil {
+		t.Fatalf("find issues: %v", err)
+	}
+	if len(rows) != 1 || rows[0].GetString("raw_value") != "Golden Triangle - Doctor's House" {
+		t.Errorf("apostrophe string round-tripped as %q", rows[0].GetString("raw_value"))
+	}
+}

--- a/pocketbase/sync/lodging_issues_test.go
+++ b/pocketbase/sync/lodging_issues_test.go
@@ -43,7 +43,8 @@ func TestIssueRecorderCollapsesRepeats(t *testing.T) {
 	app := newLodgingTestApp(t)
 	r := NewIssueRecorder(app, 2022)
 
-	for _, hh := range []int{9001, 9002, 9003, 9004, 9005} {
+	// Five different households hit the same unmapped string.
+	for range 5 {
 		r.Record(Issue{
 			Kind:        issueUnresolvedAlias,
 			RawValue:    "River Side - R1",
@@ -53,7 +54,6 @@ func TestIssueRecorderCollapsesRepeats(t *testing.T) {
 			// so the dedup key must collapse across households.
 			HouseholdCMID: 0,
 		})
-		_ = hh
 	}
 
 	if got := r.CountOf(issueUnresolvedAlias); got != 5 {
@@ -145,6 +145,48 @@ func TestIssueRecorderKeepsPerHouseholdIssuesSeparate(t *testing.T) {
 	}
 }
 
+// TestIssueRecorderFlushKeepsAnEarlierSuggestion: Record deliberately preserves
+// the first non-empty SuggestedSession ("later observations may carry a
+// suggestion the first did not"), so Flush must not undo that across runs. A
+// re-run whose last_updated stops parsing produces no suggestion; writing that
+// emptiness over an open queue item takes its one-click confirmation with it.
+func TestIssueRecorderFlushKeepsAnEarlierSuggestion(t *testing.T) {
+	app := newLodgingTestApp(t)
+	sess := addSession(t, app, 1309514, "Family Camp 1", "family",
+		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
+
+	first := NewIssueRecorder(app, 2025)
+	first.Record(Issue{Kind: issueAmbiguousSession, RawValue: "Ridge A",
+		SourceField: fieldNameFamilyCampCabin, Year: 2025, HouseholdCMID: 9001,
+		SuggestedSession: sess, CandidateCMIDs: []int{1309514, 1354939}})
+	if _, _, err := first.Flush(testNow); err != nil {
+		t.Fatalf("first Flush: %v", err)
+	}
+
+	// The same item next run, but the timestamp no longer parses, so there is
+	// nothing to base a suggestion on.
+	second := NewIssueRecorder(app, 2025)
+	second.Record(Issue{Kind: issueAmbiguousSession, RawValue: "Ridge A",
+		SourceField: fieldNameFamilyCampCabin, Year: 2025, HouseholdCMID: 9001,
+		CandidateCMIDs: []int{1309514, 1354939}})
+	if _, updated, err := second.Flush(testNow); err != nil {
+		t.Fatalf("second Flush: %v", err)
+	} else if updated != 1 {
+		t.Fatalf("second Flush updated %d rows, want 1", updated)
+	}
+
+	rows, err := app.FindRecordsByFilter("lodging_ingest_issues", "", "", 0, 0)
+	if err != nil {
+		t.Fatalf("find issues: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 issue row, got %d", len(rows))
+	}
+	if got := rows[0].GetString("suggested_session"); got != sess {
+		t.Errorf("suggested_session = %q, want %q -- a run with no suggestion must not blank the stored one", got, sess)
+	}
+}
+
 // TestIssueRecorderHandlesApostrophes: real cabin strings contain apostrophes
 // ("Golden Triangle - Doctor's House", "Golden Triangle - Cloud's Rest"). A
 // filter built by string concatenation would be a syntax error here, which is
@@ -163,7 +205,10 @@ func TestIssueRecorderHandlesApostrophes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("find issues: %v", err)
 	}
-	if len(rows) != 1 || rows[0].GetString("raw_value") != "Golden Triangle - Doctor's House" {
-		t.Errorf("apostrophe string round-tripped as %q", rows[0].GetString("raw_value"))
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 issue row, got %d", len(rows))
+	}
+	if got := rows[0].GetString("raw_value"); got != "Golden Triangle - Doctor's House" {
+		t.Errorf("apostrophe string round-tripped as %q", got)
 	}
 }

--- a/pocketbase/sync/lodging_merges.go
+++ b/pocketbase/sync/lodging_merges.go
@@ -2,7 +2,7 @@ package sync
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/pocketbase/dbx"
@@ -13,12 +13,16 @@ import (
 // board can tell them apart from ones staff created by dropping a party.
 const mergeCreatedBySync = "campminder_sync"
 
+// maxMergeMembers mirrors lodging_merges.member_units maxSelect (migration
+// 1500000118). Kept in step by scripts/dev/verify-lodging-schema.sh.
+const maxMergeMembers = 20
+
 // unitSetKey gives a member set an order-independent identity. PocketBase
 // returns relation ids in storage order, which is not a guaranteed ordering, so
 // comparing slices directly would treat {a,b} and {b,a} as different merges.
 func unitSetKey(unitIDs []string) string {
-	sorted := append([]string(nil), unitIDs...)
-	sort.Strings(sorted)
+	sorted := slices.Clone(unitIDs)
+	slices.Sort(sorted)
 	return strings.Join(sorted, "\x00")
 }
 
@@ -35,8 +39,11 @@ func unitSetKey(unitIDs []string) string {
 func EnsureMerge(
 	app core.App, sessionID string, year int, scenario string, unitIDs []string, displayName string,
 ) (string, error) {
-	if len(unitIDs) < 2 {
-		return "", fmt.Errorf("merge needs at least 2 member units, got %d", len(unitIDs))
+	// member_units is minSelect 2, maxSelect 20 (migration 1500000118). Checking
+	// both here gives a call-site error naming the member count, instead of a
+	// PocketBase validation failure surfacing from app.Save deep in a backfill.
+	if len(unitIDs) < 2 || len(unitIDs) > maxMergeMembers {
+		return "", fmt.Errorf("merge needs between 2 and %d member units, got %d", maxMergeMembers, len(unitIDs))
 	}
 
 	// eqOrEmpty, not a bound parameter: a bound "" matches NOTHING in PocketBase,

--- a/pocketbase/sync/lodging_merges.go
+++ b/pocketbase/sync/lodging_merges.go
@@ -1,0 +1,76 @@
+package sync
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// mergeCreatedBySync labels merge rows this ingest materializes, so the Plan 3
+// board can tell them apart from ones staff created by dropping a party.
+const mergeCreatedBySync = "campminder_sync"
+
+// unitSetKey gives a member set an order-independent identity. PocketBase
+// returns relation ids in storage order, which is not a guaranteed ordering, so
+// comparing slices directly would treat {a,b} and {b,a} as different merges.
+func unitSetKey(unitIDs []string) string {
+	sorted := append([]string(nil), unitIDs...)
+	sort.Strings(sorted)
+	return strings.Join(sorted, "\x00")
+}
+
+// EnsureMerge returns the id of the lodging_merges row binding exactly unitIDs
+// for (session, year, scenario), creating it if absent.
+//
+// Deduplication lives here rather than in an index because a merge's identity is
+// a SET of member units, which SQLite cannot express as a unique index. Without
+// it, each backfill run would create a fresh merge row for the same two rooms
+// and the board would show duplicate slots.
+//
+// An empty scenario means the session's live plan, matching how PocketBase
+// stores an unset relation: TEXT, NOT NULL, defaulting to the empty string.
+func EnsureMerge(
+	app core.App, sessionID string, year int, scenario string, unitIDs []string, displayName string,
+) (string, error) {
+	if len(unitIDs) < 2 {
+		return "", fmt.Errorf("merge needs at least 2 member units, got %d", len(unitIDs))
+	}
+
+	// eqOrEmpty, not a bound parameter: a bound "" matches NOTHING in PocketBase,
+	// so the live plan (an empty scenario) would never find its own merge row and
+	// every run would create another one. Verified against a live PocketBase.
+	params := dbx.Params{"session": sessionID, "year": year}
+	filter := "session = {:session} && year = {:year} && " +
+		eqOrEmpty("scenario", "scenario", scenario, params)
+
+	existing, err := app.FindRecordsByFilter("lodging_merges", filter, "", 0, 0, params)
+	if err != nil {
+		return "", fmt.Errorf("loading merges for session %s: %w", sessionID, err)
+	}
+
+	want := unitSetKey(unitIDs)
+	for _, m := range existing {
+		if unitSetKey(m.GetStringSlice("member_units")) == want {
+			return m.Id, nil
+		}
+	}
+
+	col, err := app.FindCollectionByNameOrId("lodging_merges")
+	if err != nil {
+		return "", fmt.Errorf("finding lodging_merges: %w", err)
+	}
+	rec := core.NewRecord(col)
+	rec.Set("session", sessionID)
+	rec.Set("year", year)
+	rec.Set("scenario", scenario)
+	rec.Set("member_units", unitIDs)
+	rec.Set("display_name", displayName)
+	rec.Set("created_by", mergeCreatedBySync)
+	if err := app.Save(rec); err != nil {
+		return "", fmt.Errorf("creating merge for session %s: %w", sessionID, err)
+	}
+	return rec.Id, nil
+}

--- a/pocketbase/sync/lodging_merges_test.go
+++ b/pocketbase/sync/lodging_merges_test.go
@@ -1,6 +1,8 @@
 package sync
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -104,5 +106,31 @@ func TestEnsureMergeRejectsFewerThanTwoMembers(t *testing.T) {
 	}
 	if _, err := EnsureMerge(app, sess, 2025, "", nil, ""); err == nil {
 		t.Error("EnsureMerge accepted an empty member set")
+	}
+}
+
+// TestEnsureMergeRejectsMoreThanMaxMembers: member_units is minSelect 2,
+// maxSelect 20 (migration 1500000118). The lower bound is already guarded; the
+// upper one has to be too, or an oversized set fails as a PocketBase validation
+// error deep inside the backfill instead of at the call site.
+func TestEnsureMergeRejectsMoreThanMaxMembers(t *testing.T) {
+	app := newLodgingTestApp(t)
+	sess := addSession(t, app, 1309514, "Family Camp 1", "family", testSessionStart, testSessionEnd, 2025)
+
+	tooMany := make([]string, 0, maxMergeMembers+1)
+	for i := range maxMergeMembers + 1 {
+		tooMany = append(tooMany, addUnit(t, app, fmt.Sprintf("unit-%02d", i)))
+	}
+
+	_, err := EnsureMerge(app, sess, 2025, "", tooMany, "Oversized")
+	if err == nil {
+		t.Fatalf("EnsureMerge accepted %d members; member_units has maxSelect %d",
+			len(tooMany), maxMergeMembers)
+	}
+	// PocketBase would also reject this at save time, but only after the lookup
+	// query has run and with an error that names the field rather than the count.
+	// Assert OUR guard fired, or this test would pass with the guard deleted.
+	if !strings.Contains(err.Error(), "member units") {
+		t.Errorf("error was %q; want the call-site member-count guard, not a PocketBase validation error", err)
 	}
 }

--- a/pocketbase/sync/lodging_merges_test.go
+++ b/pocketbase/sync/lodging_merges_test.go
@@ -1,0 +1,108 @@
+package sync
+
+import (
+	"testing"
+)
+
+const testSessionStart = "2025-05-23 07:00:00.000Z"
+const testSessionEnd = "2025-05-26 07:00:00.000Z"
+
+// TestEnsureMergeIsIdempotent: lodging_merges has no unique index on the member
+// set (a set is not indexable), so without application-level dedup every
+// backfill run would create another merge row for the same two rooms.
+func TestEnsureMergeIsIdempotent(t *testing.T) {
+	app := newLodgingTestApp(t)
+	sess := addSession(t, app, 1309514, "Family Camp 1", "family", testSessionStart, testSessionEnd, 2025)
+	tioga1 := addUnit(t, app, "gt-tioga-1")
+	tioga2 := addUnit(t, app, "gt-tioga-2")
+
+	first, err := EnsureMerge(app, sess, 2025, "", []string{tioga1, tioga2}, "Tioga")
+	if err != nil {
+		t.Fatalf("EnsureMerge first: %v", err)
+	}
+	second, err := EnsureMerge(app, sess, 2025, "", []string{tioga1, tioga2}, "Tioga")
+	if err != nil {
+		t.Fatalf("EnsureMerge second: %v", err)
+	}
+	if first != second {
+		t.Errorf("EnsureMerge returned two ids (%s, %s) for one member set", first, second)
+	}
+
+	rows, err := app.FindRecordsByFilter("lodging_merges", "", "", 0, 0)
+	if err != nil {
+		t.Fatalf("find merges: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("expected 1 merge row, got %d", len(rows))
+	}
+}
+
+// TestEnsureMergeIgnoresMemberOrder: PocketBase returns relation ids in storage
+// order, which is not guaranteed stable, so the identity of a merge must be the
+// SET of members and not the slice.
+func TestEnsureMergeIgnoresMemberOrder(t *testing.T) {
+	app := newLodgingTestApp(t)
+	sess := addSession(t, app, 1309514, "Family Camp 1", "family", testSessionStart, testSessionEnd, 2025)
+	a := addUnit(t, app, "gt-tenaya-1")
+	b := addUnit(t, app, "gt-tenaya-2")
+
+	first, err := EnsureMerge(app, sess, 2025, "", []string{a, b}, "Tenaya")
+	if err != nil {
+		t.Fatalf("EnsureMerge: %v", err)
+	}
+	second, err := EnsureMerge(app, sess, 2025, "", []string{b, a}, "Tenaya")
+	if err != nil {
+		t.Fatalf("EnsureMerge reversed: %v", err)
+	}
+	if first != second {
+		t.Errorf("member order changed the merge identity: %s vs %s", first, second)
+	}
+}
+
+// TestEnsureMergeIsPerSessionAndScenario: spec 3.4 makes merges scenario-scoped
+// so two plans for the same weekend can merge differently, and per-session
+// because a merge is one weekend's arrangement, not a permanent building change.
+func TestEnsureMergeIsPerSessionAndScenario(t *testing.T) {
+	app := newLodgingTestApp(t)
+	sessA := addSession(t, app, 1309514, "Family Camp 1", "family", testSessionStart, testSessionEnd, 2025)
+	sessB := addSession(t, app, 1309519, "Family Camp 6", "family",
+		"2025-09-18 07:00:00.000Z", "2025-09-21 07:00:00.000Z", 2025)
+	u1 := addUnit(t, app, "gt-tioga-1")
+	u2 := addUnit(t, app, "gt-tioga-2")
+
+	live, err := EnsureMerge(app, sessA, 2025, "", []string{u1, u2}, "Tioga")
+	if err != nil {
+		t.Fatalf("live merge: %v", err)
+	}
+	otherSession, err := EnsureMerge(app, sessB, 2025, "", []string{u1, u2}, "Tioga")
+	if err != nil {
+		t.Fatalf("other-session merge: %v", err)
+	}
+	scenario, err := EnsureMerge(app, sessA, 2025, "scn_abc", []string{u1, u2}, "Tioga")
+	if err != nil {
+		t.Fatalf("scenario merge: %v", err)
+	}
+
+	if live == otherSession {
+		t.Error("one merge row was shared across two sessions")
+	}
+	if live == scenario {
+		t.Error("the live plan and a scenario shared one merge row")
+	}
+}
+
+// TestEnsureMergeRejectsFewerThanTwoMembers: lodging_merges.member_units has
+// minSelect 2. Catching it here gives a useful error instead of a PocketBase
+// validation failure deep inside the backfill.
+func TestEnsureMergeRejectsFewerThanTwoMembers(t *testing.T) {
+	app := newLodgingTestApp(t)
+	sess := addSession(t, app, 1309514, "Family Camp 1", "family", testSessionStart, testSessionEnd, 2025)
+	only := addUnit(t, app, "ridge-a")
+
+	if _, err := EnsureMerge(app, sess, 2025, "", []string{only}, "Ridge A"); err == nil {
+		t.Error("EnsureMerge accepted a single-member merge; member_units has minSelect 2")
+	}
+	if _, err := EnsureMerge(app, sess, 2025, "", nil, ""); err == nil {
+		t.Error("EnsureMerge accepted an empty member set")
+	}
+}

--- a/pocketbase/sync/lodging_session_attribution.go
+++ b/pocketbase/sync/lodging_session_attribution.go
@@ -1,0 +1,248 @@
+package sync
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// statusIDActiveEnrolled is CampMinder's "active enrolled" attendee status.
+// Every lodging query filters on it; any other status is not attending.
+const statusIDActiveEnrolled = 2
+
+// Attribution reasons. attrAmbiguousSession and attrNoSession are also
+// lodging_ingest_issues.kind values, so they must stay in step with
+// migration 1500000122's select list.
+const (
+	attrSingleSession    = "single_session"
+	attrAmbiguousSession = issueAmbiguousSession
+	attrNoSession        = issueNoSession
+)
+
+// SessionWindow is one weekend's identity and date range.
+type SessionWindow struct {
+	ID    string // camp_sessions PB record id
+	CMID  int
+	Name  string
+	Start time.Time
+	End   time.Time
+}
+
+// Attribution is the result of pinning one cabin value to one weekend.
+// SessionID is set only when attribution is unambiguous; BestGuess is advisory
+// and exists so the work queue can offer a one-click confirmation.
+type Attribution struct {
+	SessionID  string
+	Candidates []SessionWindow
+	Reason     string
+	BestGuess  string
+}
+
+// CandidateCMIDs returns the candidate session CampMinder ids, for the queue item.
+func (a Attribution) CandidateCMIDs() []int {
+	out := make([]int, 0, len(a.Candidates))
+	for _, c := range a.Candidates {
+		out = append(out, c.CMID)
+	}
+	return out
+}
+
+// ParseCampMinderTimestamp parses the value in
+// household_custom_values.last_updated / person_custom_values.last_updated.
+//
+// That column is TEXT, not a PocketBase date, and carries CampMinder's raw .NET
+// DateTimeOffset: "2025-04-21T17:51:11.5964281+00:00" -- seven fractional digits
+// and an explicit offset. Go's RFC3339 layout accepts both. The package's
+// ParseDate helper (date_utils.go:30) does NOT have a format for it and would
+// return "" with only a slog.Warn, so every attribution would lose its timestamp
+// without anything failing.
+func ParseCampMinderTimestamp(s string) (time.Time, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, false
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, true
+	}
+	// PocketBase's own stored layout, in case a value is ever normalised on write.
+	if t, err := time.Parse("2006-01-02 15:04:05.000Z", s); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}
+
+// LoadSessionWindows returns every camp_sessions row for the year whose
+// session_type is in sessionTypes, keyed by PB record id.
+func LoadSessionWindows(app core.App, year int, sessionTypes []string) (map[string]SessionWindow, error) {
+	quoted := make([]string, 0, len(sessionTypes))
+	for _, st := range sessionTypes {
+		quoted = append(quoted, "session_type = '"+st+"'")
+	}
+	// Session types are package constants, never user input, so inlining them is
+	// safe here. Note the spaces around every operator -- PocketBase's filter
+	// parser silently returns wrong results without them.
+	filter := fmt.Sprintf("year = %d && (%s)", year, strings.Join(quoted, " || "))
+
+	records, err := app.FindRecordsByFilter("camp_sessions", filter, "", 0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("loading camp_sessions for %d: %w", year, err)
+	}
+
+	out := make(map[string]SessionWindow, len(records))
+	for _, r := range records {
+		out[r.Id] = SessionWindow{
+			ID:   r.Id,
+			CMID: r.GetInt("cm_id"),
+			Name: r.GetString("name"),
+			// start_date and end_date are PocketBase DATE fields stored as
+			// "2025-05-23 07:00:00.000Z" -- a layout that matches none of
+			// date_utils.go's DateFormats, so GetDateTime is the only correct read.
+			Start: r.GetDateTime("start_date").Time(),
+			End:   r.GetDateTime("end_date").Time(),
+		}
+	}
+	return out, nil
+}
+
+// BuildHouseholdSessionIndex maps household CampMinder id -> the distinct
+// sessions that household is actively enrolled in.
+//
+// Path: attendees (status_id = 2) -> persons.household_id -> camp_sessions.
+// Two enrolled siblings at one weekend are ONE household-weekend, so the result
+// is deduplicated by session.
+func BuildHouseholdSessionIndex(app core.App, year int, sessionTypes []string) (map[int][]SessionWindow, error) {
+	return buildSessionIndex(app, year, sessionTypes, true)
+}
+
+// BuildPersonSessionIndex maps person CampMinder id -> that person's actively
+// enrolled sessions. Used for adult weekends, which enroll real persons.
+func BuildPersonSessionIndex(app core.App, year int, sessionTypes []string) (map[int][]SessionWindow, error) {
+	return buildSessionIndex(app, year, sessionTypes, false)
+}
+
+func buildSessionIndex(
+	app core.App, year int, sessionTypes []string, byHousehold bool,
+) (map[int][]SessionWindow, error) {
+	windows, err := LoadSessionWindows(app, year, sessionTypes)
+	if err != nil {
+		return nil, err
+	}
+
+	personToHousehold, err := loadPersonHouseholdCMIDs(app, year)
+	if err != nil {
+		return nil, err
+	}
+
+	filter := fmt.Sprintf("year = %d && status_id = %d", year, statusIDActiveEnrolled)
+	attendees, err := findAllRecords(app, "attendees", filter)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]bool) // "<key>|<sessionID>"
+	result := make(map[int][]SessionWindow)
+	for _, a := range attendees {
+		window, ok := windows[a.GetString("session")]
+		if !ok {
+			continue // not a family/adult session
+		}
+
+		key := a.GetInt("person_id")
+		if byHousehold {
+			key = personToHousehold[key]
+		}
+		if key == 0 {
+			continue
+		}
+
+		dedup := fmt.Sprintf("%d|%s", key, window.ID)
+		if seen[dedup] {
+			continue
+		}
+		seen[dedup] = true
+		result[key] = append(result[key], window)
+	}
+
+	for key := range result {
+		sort.Slice(result[key], func(i, j int) bool {
+			return result[key][i].Start.Before(result[key][j].Start)
+		})
+	}
+	return result, nil
+}
+
+// loadPersonHouseholdCMIDs maps person CampMinder id -> household CampMinder id.
+// Both are CampMinder ids per the project-wide rule; persons.household is the PB
+// relation and persons.household_id the CampMinder one.
+func loadPersonHouseholdCMIDs(app core.App, year int) (map[int]int, error) {
+	records, err := findAllRecords(app, "persons", fmt.Sprintf("year = %d && household_id > 0", year))
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[int]int, len(records))
+	for _, r := range records {
+		out[r.GetInt("cm_id")] = r.GetInt("household_id")
+	}
+	return out, nil
+}
+
+// findAllRecords pages through a collection, matching the paging shape the other
+// derived syncs in this package use.
+func findAllRecords(app core.App, collection, filter string) ([]*core.Record, error) {
+	const perPage = 500
+	var all []*core.Record
+	for page := 1; ; page++ {
+		batch, err := app.FindRecordsByFilter(collection, filter, "", perPage, (page-1)*perPage)
+		if err != nil {
+			return nil, fmt.Errorf("querying %s page %d: %w", collection, page, err)
+		}
+		all = append(all, batch...)
+		if len(batch) < perPage {
+			return all, nil
+		}
+	}
+}
+
+// AttributeSession pins one cabin value to one weekend.
+//
+// candidates must be sorted by Start ascending (BuildHouseholdSessionIndex and
+// BuildPersonSessionIndex both guarantee that).
+//
+// With one candidate the answer is certain. With none there is nothing to
+// attribute to. With several, CampMinder's single per-year value cannot say
+// which weekend it describes, so this returns a SUGGESTION and no assignment:
+// spec 3.6 requires flagging those 6-10 households a year for manual entry, and
+// a wrong cabin on the board is worse than a blank one.
+//
+// The suggestion is the earliest session starting on or after lastUpdated --
+// staff edit the value shortly before the weekend it applies to, which held for
+// all six ambiguous 2025 households. A value edited after every weekend has
+// ended suggests the last one.
+func AttributeSession(candidates []SessionWindow, lastUpdated time.Time) Attribution {
+	switch len(candidates) {
+	case 0:
+		return Attribution{Reason: attrNoSession}
+	case 1:
+		return Attribution{
+			SessionID:  candidates[0].ID,
+			Candidates: candidates,
+			Reason:     attrSingleSession,
+		}
+	}
+
+	out := Attribution{Candidates: candidates, Reason: attrAmbiguousSession}
+	if lastUpdated.IsZero() {
+		return out
+	}
+	for _, c := range candidates {
+		if !c.Start.Before(lastUpdated) {
+			out.BestGuess = c.ID
+			return out
+		}
+	}
+	out.BestGuess = candidates[len(candidates)-1].ID
+	return out
+}

--- a/pocketbase/sync/lodging_session_attribution.go
+++ b/pocketbase/sync/lodging_session_attribution.go
@@ -2,7 +2,7 @@ package sync
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -55,10 +55,15 @@ func (a Attribution) CandidateCMIDs() []int {
 //
 // That column is TEXT, not a PocketBase date, and carries CampMinder's raw .NET
 // DateTimeOffset: "2025-04-21T17:51:11.5964281+00:00" -- seven fractional digits
-// and an explicit offset. Go's RFC3339 layout accepts both. The package's
-// ParseDate helper (date_utils.go:30) does NOT have a format for it and would
-// return "" with only a slog.Warn, so every attribution would lose its timestamp
-// without anything failing.
+// and an explicit offset. Go's RFC3339 layout accepts both.
+//
+// The package's ParseDate helper (date_utils.go) does parse this format -- its
+// DateFormats list leads with time.RFC3339 and time.Parse tolerates any number
+// of fractional-second digits. It is the wrong tool here for a different reason:
+// it returns a STRING formatted "2006-01-02 15:04:05Z", truncated to whole
+// seconds, and AttributeSession needs a time.Time to compare against session
+// start dates. Parsing here keeps the value typed and keeps the sub-second
+// precision ParseDate's round-trip would drop.
 func ParseCampMinderTimestamp(s string) (time.Time, bool) {
 	s = strings.TrimSpace(s)
 	if s == "" {
@@ -77,6 +82,12 @@ func ParseCampMinderTimestamp(s string) (time.Time, bool) {
 // LoadSessionWindows returns every camp_sessions row for the year whose
 // session_type is in sessionTypes, keyed by PB record id.
 func LoadSessionWindows(app core.App, year int, sessionTypes []string) (map[string]SessionWindow, error) {
+	// No types means no sessions. Falling through would build `year = N && ()`,
+	// which is a filter-parse error rather than the empty result a caller expects.
+	if len(sessionTypes) == 0 {
+		return map[string]SessionWindow{}, nil
+	}
+
 	quoted := make([]string, 0, len(sessionTypes))
 	for _, st := range sessionTypes {
 		quoted = append(quoted, "session_type = '"+st+"'")
@@ -131,9 +142,14 @@ func buildSessionIndex(
 		return nil, err
 	}
 
-	personToHousehold, err := loadPersonHouseholdCMIDs(app, year)
-	if err != nil {
-		return nil, err
+	// Only the household index needs the person -> household mapping, and
+	// building it is a full paged scan of persons for the year.
+	var personToHousehold map[int]int
+	if byHousehold {
+		personToHousehold, err = loadPersonHouseholdCMIDs(app, year)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	filter := fmt.Sprintf("year = %d && status_id = %d", year, statusIDActiveEnrolled)
@@ -167,8 +183,8 @@ func buildSessionIndex(
 	}
 
 	for key := range result {
-		sort.Slice(result[key], func(i, j int) bool {
-			return result[key][i].Start.Before(result[key][j].Start)
+		slices.SortFunc(result[key], func(a, b SessionWindow) int {
+			return a.Start.Compare(b.Start)
 		})
 	}
 	return result, nil
@@ -191,11 +207,18 @@ func loadPersonHouseholdCMIDs(app core.App, year int) (map[int]int, error) {
 
 // findAllRecords pages through a collection, matching the paging shape the other
 // derived syncs in this package use.
+//
+// The sort is not cosmetic. LIMIT/OFFSET over an unsorted result set lets SQLite
+// return a different row order per query, which silently skips or duplicates
+// rows past page 1 -- and a skipped attendee turns a two-weekend household into
+// a one-weekend one, so an ambiguous_session becomes a CONFIDENT WRONG
+// attribution once Task 11 starts writing assignments. `id` is unique and
+// immutable, so it is a stable page key.
 func findAllRecords(app core.App, collection, filter string) ([]*core.Record, error) {
 	const perPage = 500
 	var all []*core.Record
 	for page := 1; ; page++ {
-		batch, err := app.FindRecordsByFilter(collection, filter, "", perPage, (page-1)*perPage)
+		batch, err := app.FindRecordsByFilter(collection, filter, "id", perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying %s page %d: %w", collection, page, err)
 		}

--- a/pocketbase/sync/lodging_session_attribution_test.go
+++ b/pocketbase/sync/lodging_session_attribution_test.go
@@ -7,9 +7,11 @@ import (
 
 // TestParseCampMinderTimestamp pins the exact shape custom-value last_updated
 // arrives in. It is a TEXT column carrying CampMinder's raw .NET DateTimeOffset
-// -- seven fractional digits and a +00:00 offset. The package's own ParseDate
-// helper (date_utils.go) has no format for it and would return "" with only a
-// slog.Warn, silently costing every attribution its timestamp.
+// -- seven fractional digits and a +00:00 offset.
+//
+// ParseDate (date_utils.go) also parses this format; what it cannot do is hand
+// back a time.Time. It returns a whole-second string, and AttributeSession
+// compares against session start dates, so the typed parse is the point.
 func TestParseCampMinderTimestamp(t *testing.T) {
 	got, ok := ParseCampMinderTimestamp("2025-04-21T17:51:11.5964281+00:00")
 	if !ok {

--- a/pocketbase/sync/lodging_session_attribution_test.go
+++ b/pocketbase/sync/lodging_session_attribution_test.go
@@ -1,0 +1,206 @@
+package sync
+
+import (
+	"testing"
+	"time"
+)
+
+// TestParseCampMinderTimestamp pins the exact shape custom-value last_updated
+// arrives in. It is a TEXT column carrying CampMinder's raw .NET DateTimeOffset
+// -- seven fractional digits and a +00:00 offset. The package's own ParseDate
+// helper (date_utils.go) has no format for it and would return "" with only a
+// slog.Warn, silently costing every attribution its timestamp.
+func TestParseCampMinderTimestamp(t *testing.T) {
+	got, ok := ParseCampMinderTimestamp("2025-04-21T17:51:11.5964281+00:00")
+	if !ok {
+		t.Fatal("failed to parse the CampMinder last_updated format")
+	}
+	if got.UTC().Format("2006-01-02 15:04") != "2025-04-21 17:51" {
+		t.Errorf("parsed to %s", got.UTC())
+	}
+
+	if _, ok := ParseCampMinderTimestamp(""); ok {
+		t.Error("empty string reported as parsed")
+	}
+	if _, ok := ParseCampMinderTimestamp("not a date"); ok {
+		t.Error("garbage reported as parsed")
+	}
+}
+
+// TestLoadSessionWindowsReadsDateFields: camp_sessions.start_date is a
+// PocketBase DATE field, stored as "2025-05-23 07:00:00.000Z". That layout
+// matches none of date_utils.go's DateFormats -- verified by running all eight
+// against it -- so it must be read via GetDateTime, not ParseDate.
+func TestLoadSessionWindowsReadsDateFields(t *testing.T) {
+	app := newLodgingTestApp(t)
+	addSession(t, app, 1309514, "Family Camp 1", "family",
+		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
+	addSession(t, app, 1335115, "Women's Weekend", "adult",
+		"2025-10-16 07:00:00.000Z", "2025-10-19 07:00:00.000Z", 2025)
+	addSession(t, app, 1235404, "Session 2", "summer",
+		"2025-06-25 07:00:00.000Z", "2025-07-10 07:00:00.000Z", 2025)
+
+	got, err := LoadSessionWindows(app, 2025, []string{"family"})
+	if err != nil {
+		t.Fatalf("LoadSessionWindows: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 family session, got %d", len(got))
+	}
+	for _, w := range got {
+		if w.CMID != 1309514 {
+			t.Errorf("CMID = %d, want 1309514", w.CMID)
+		}
+		if w.Start.UTC().Format("2006-01-02") != "2025-05-23" {
+			t.Errorf("Start = %s; the date field did not parse", w.Start.UTC())
+		}
+		if w.End.UTC().Format("2006-01-02") != "2025-05-26" {
+			t.Errorf("End = %s", w.End.UTC())
+		}
+	}
+}
+
+// TestBuildHouseholdSessionIndexUsesActiveEnrolmentOnly: status_id = 2 is
+// "active enrolled". Any other status is not attending, and counting them would
+// manufacture ambiguity where there is none.
+func TestBuildHouseholdSessionIndexUsesActiveEnrolmentOnly(t *testing.T) {
+	app := newLodgingTestApp(t)
+	fc1 := addSession(t, app, 1309514, "Family Camp 1", "family",
+		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
+	fc6 := addSession(t, app, 1309519, "Family Camp 6", "family",
+		"2025-09-18 07:00:00.000Z", "2025-09-21 07:00:00.000Z", 2025)
+
+	hh := addHousehold(t, app, 9001, 2025)
+	emma := addPerson(t, app, 5001, 9001, 2025, hh)
+	addAttendee(t, app, emma, fc1, 5001, 2, 2025) // active
+	addAttendee(t, app, emma, fc6, 5001, 5, 2025) // cancelled
+
+	idx, err := BuildHouseholdSessionIndex(app, 2025, []string{"family"})
+	if err != nil {
+		t.Fatalf("BuildHouseholdSessionIndex: %v", err)
+	}
+	if len(idx[9001]) != 1 {
+		t.Fatalf("household 9001 has %d sessions, want 1 (the cancelled one must not count)", len(idx[9001]))
+	}
+	if idx[9001][0].CMID != 1309514 {
+		t.Errorf("got session %d, want 1309514", idx[9001][0].CMID)
+	}
+}
+
+// TestBuildHouseholdSessionIndexDedupesSiblings: two enrolled children in one
+// household attending the same weekend is ONE household-weekend, not two.
+func TestBuildHouseholdSessionIndexDedupesSiblings(t *testing.T) {
+	app := newLodgingTestApp(t)
+	fc1 := addSession(t, app, 1309514, "Family Camp 1", "family",
+		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
+
+	hh := addHousehold(t, app, 9001, 2025)
+	emma := addPerson(t, app, 5001, 9001, 2025, hh)
+	liam := addPerson(t, app, 5002, 9001, 2025, hh)
+	addAttendee(t, app, emma, fc1, 5001, 2, 2025)
+	addAttendee(t, app, liam, fc1, 5002, 2, 2025)
+
+	idx, err := BuildHouseholdSessionIndex(app, 2025, []string{"family"})
+	if err != nil {
+		t.Fatalf("BuildHouseholdSessionIndex: %v", err)
+	}
+	if len(idx[9001]) != 1 {
+		t.Errorf("two siblings at one weekend produced %d session entries, want 1", len(idx[9001]))
+	}
+}
+
+// TestAttributeSessionSingle: the 98% case.
+func TestAttributeSessionSingle(t *testing.T) {
+	only := SessionWindow{ID: "s1", CMID: 1309514, Name: "Family Camp 1",
+		Start: time.Date(2025, 5, 23, 7, 0, 0, 0, time.UTC),
+		End:   time.Date(2025, 5, 26, 7, 0, 0, 0, time.UTC)}
+
+	got := AttributeSession([]SessionWindow{only}, time.Time{})
+	if got.Reason != attrSingleSession {
+		t.Errorf("Reason = %q, want %q", got.Reason, attrSingleSession)
+	}
+	if got.SessionID != "s1" {
+		t.Errorf("SessionID = %q, want s1", got.SessionID)
+	}
+}
+
+// TestAttributeSessionNone: 53 cabin values in 2025 belong to households with no
+// active family enrolment. They are queue items, not drops and not errors.
+func TestAttributeSessionNone(t *testing.T) {
+	got := AttributeSession(nil, time.Time{})
+	if got.Reason != attrNoSession {
+		t.Errorf("Reason = %q, want %q", got.Reason, attrNoSession)
+	}
+	if got.SessionID != "" {
+		t.Errorf("SessionID = %q; nothing may be attributed with no candidate", got.SessionID)
+	}
+}
+
+// TestAttributeSessionAmbiguousSuggestsButDoesNotAssign reproduces a real 2025
+// household: enrolled in Family Camp 1 (May 23), Family Camp 5 (Sep 11), Family
+// Camp 6 (Sep 18) and Winter Family Camp (Dec 21), with one cabin value last
+// edited 10 September -- the day before Family Camp 5.
+//
+// Spec 3.6 says flag these for manual entry rather than guess, so SessionID
+// stays empty and only BestGuess carries the heuristic.
+func TestAttributeSessionAmbiguousSuggestsButDoesNotAssign(t *testing.T) {
+	mk := func(id string, cmID int, month, day int) SessionWindow {
+		return SessionWindow{ID: id, CMID: cmID,
+			Start: time.Date(2025, time.Month(month), day, 7, 0, 0, 0, time.UTC),
+			End:   time.Date(2025, time.Month(month), day+3, 7, 0, 0, 0, time.UTC)}
+	}
+	candidates := []SessionWindow{
+		mk("s1", 1309514, 5, 23),
+		mk("s5", 1334831, 9, 11),
+		mk("s6", 1309519, 9, 18),
+		mk("sw", 1354939, 12, 21),
+	}
+	lastUpdated := time.Date(2025, 9, 10, 18, 0, 0, 0, time.UTC)
+
+	got := AttributeSession(candidates, lastUpdated)
+	if got.Reason != attrAmbiguousSession {
+		t.Errorf("Reason = %q, want %q", got.Reason, attrAmbiguousSession)
+	}
+	if got.SessionID != "" {
+		t.Errorf("SessionID = %q; an ambiguous party must not be assigned", got.SessionID)
+	}
+	if got.BestGuess != "s5" {
+		t.Errorf("BestGuess = %q, want s5 (earliest session starting on or after 10 Sep)", got.BestGuess)
+	}
+	if len(got.Candidates) != 4 {
+		t.Errorf("Candidates = %d, want all 4 for the queue item", len(got.Candidates))
+	}
+}
+
+// TestAttributeSessionAmbiguousAfterAllSessions: a value edited after every
+// weekend has ended -- staff tidying records at season close -- suggests the
+// LAST weekend, since that is the one the value most plausibly describes.
+func TestAttributeSessionAmbiguousAfterAllSessions(t *testing.T) {
+	candidates := []SessionWindow{
+		{ID: "s1", CMID: 1309514, Start: time.Date(2025, 5, 23, 7, 0, 0, 0, time.UTC)},
+		{ID: "s3", CMID: 1356527, Start: time.Date(2025, 8, 28, 7, 0, 0, 0, time.UTC)},
+	}
+	got := AttributeSession(candidates, time.Date(2025, 12, 15, 0, 0, 0, 0, time.UTC))
+	if got.BestGuess != "s3" {
+		t.Errorf("BestGuess = %q, want s3 (the last weekend)", got.BestGuess)
+	}
+	if got.SessionID != "" {
+		t.Error("still must not assign")
+	}
+}
+
+// TestAttributeSessionAmbiguousWithoutTimestamp: no timestamp, no suggestion --
+// but still a queue item rather than a drop.
+func TestAttributeSessionAmbiguousWithoutTimestamp(t *testing.T) {
+	candidates := []SessionWindow{
+		{ID: "s1", CMID: 1309514, Start: time.Date(2025, 5, 23, 7, 0, 0, 0, time.UTC)},
+		{ID: "s3", CMID: 1356527, Start: time.Date(2025, 8, 28, 7, 0, 0, 0, time.UTC)},
+	}
+	got := AttributeSession(candidates, time.Time{})
+	if got.Reason != attrAmbiguousSession {
+		t.Errorf("Reason = %q", got.Reason)
+	}
+	if got.BestGuess != "" {
+		t.Errorf("BestGuess = %q; there is nothing to base a guess on", got.BestGuess)
+	}
+}

--- a/pocketbase/sync/lodging_testsupport_test.go
+++ b/pocketbase/sync/lodging_testsupport_test.go
@@ -146,6 +146,13 @@ func newLodgingTestApp(t *testing.T) core.App {
 	issues.Fields.Add(&core.DateField{Name: "last_seen"})
 	issues.Fields.Add(&core.BoolField{Name: "is_resolved"})
 	issues.Fields.Add(&core.TextField{Name: "resolution_note"})
+	// Mirrors idx_lodging_issues_dedup from migration 1500000122. Without it the
+	// Flush tests would only prove findExisting works, and a divergence between
+	// Issue.dedupKey() and the real unique index would pass here then fail in
+	// production. The index is the thing that keeps a 472-row backfill from
+	// writing 472 rows, so the tests have to exercise it.
+	issues.AddIndex("idx_lodging_issues_dedup", true,
+		"year, kind, raw_value, source_field, household_cm_id, person_cm_id", "")
 	saveCollection(t, app, issues)
 
 	mappings := core.NewBaseCollection("lodging_field_mappings")

--- a/pocketbase/sync/lodging_testsupport_test.go
+++ b/pocketbase/sync/lodging_testsupport_test.go
@@ -1,0 +1,244 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+)
+
+// newLodgingTestApp returns a throwaway PocketBase app carrying every collection
+// the lodging ingest reads or writes, shaped like production's.
+//
+// It deliberately builds collections in Go rather than replaying pb_migrations:
+// `pocketbase migrate up` silently skips JS migrations (jsvm captures its
+// MigrationsDir at plugin-registration time, before flag parsing), so a Go test
+// cannot apply them. Schema fidelity against the real migrations is the job of
+// scripts/dev/verify-lodging-schema.sh; these fixtures only need the fields the
+// code under test touches.
+func newLodgingTestApp(t *testing.T) core.App {
+	t.Helper()
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	defs := core.NewBaseCollection("custom_field_defs")
+	defs.Fields.Add(&core.NumberField{Name: "cm_id"})
+	defs.Fields.Add(&core.TextField{Name: "name"})
+	saveCollection(t, app, defs)
+
+	sessions := core.NewBaseCollection("camp_sessions")
+	sessions.Fields.Add(&core.NumberField{Name: "cm_id"})
+	sessions.Fields.Add(&core.TextField{Name: "name"})
+	sessions.Fields.Add(&core.TextField{Name: "session_type"})
+	sessions.Fields.Add(&core.DateField{Name: "start_date"})
+	sessions.Fields.Add(&core.DateField{Name: "end_date"})
+	sessions.Fields.Add(&core.NumberField{Name: "year"})
+	saveCollection(t, app, sessions)
+
+	households := core.NewBaseCollection("households")
+	households.Fields.Add(&core.NumberField{Name: "cm_id"})
+	households.Fields.Add(&core.NumberField{Name: "year"})
+	saveCollection(t, app, households)
+
+	persons := core.NewBaseCollection("persons")
+	persons.Fields.Add(&core.NumberField{Name: "cm_id"})
+	persons.Fields.Add(&core.NumberField{Name: "household_id"})
+	persons.Fields.Add(&core.RelationField{Name: "household", CollectionId: households.Id, MaxSelect: 1})
+	persons.Fields.Add(&core.NumberField{Name: "year"})
+	saveCollection(t, app, persons)
+
+	attendees := core.NewBaseCollection("attendees")
+	attendees.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})
+	attendees.Fields.Add(&core.NumberField{Name: "person_id"})
+	attendees.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	attendees.Fields.Add(&core.NumberField{Name: "status_id"})
+	attendees.Fields.Add(&core.NumberField{Name: "year"})
+	saveCollection(t, app, attendees)
+
+	hcv := core.NewBaseCollection("household_custom_values")
+	hcv.Fields.Add(&core.RelationField{Name: "household", CollectionId: households.Id, MaxSelect: 1})
+	hcv.Fields.Add(&core.RelationField{Name: "field_definition", CollectionId: defs.Id, MaxSelect: 1})
+	hcv.Fields.Add(&core.TextField{Name: "value"})
+	// TEXT, not date: production stores CampMinder's raw .NET timestamp here,
+	// e.g. "2025-04-21T17:51:11.5964281+00:00".
+	hcv.Fields.Add(&core.TextField{Name: "last_updated"})
+	hcv.Fields.Add(&core.NumberField{Name: "year"})
+	saveCollection(t, app, hcv)
+
+	pcv := core.NewBaseCollection("person_custom_values")
+	pcv.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})
+	pcv.Fields.Add(&core.RelationField{Name: "field_definition", CollectionId: defs.Id, MaxSelect: 1})
+	pcv.Fields.Add(&core.TextField{Name: "value"})
+	pcv.Fields.Add(&core.TextField{Name: "last_updated"})
+	pcv.Fields.Add(&core.NumberField{Name: "year"})
+	saveCollection(t, app, pcv)
+
+	units := core.NewBaseCollection("lodging_units")
+	units.Fields.Add(&core.TextField{Name: "name"})
+	units.Fields.Add(&core.TextField{Name: "code"})
+	units.Fields.Add(&core.NumberField{Name: "sleeps"})
+	units.Fields.Add(&core.BoolField{Name: "is_active"})
+	units.Fields.Add(&core.BoolField{Name: "is_container"})
+	saveCollection(t, app, units)
+
+	aliases := core.NewBaseCollection("lodging_unit_aliases")
+	aliases.Fields.Add(&core.TextField{Name: "alias_string"})
+	aliases.Fields.Add(&core.RelationField{Name: "member_units", CollectionId: units.Id, MaxSelect: 20})
+	aliases.Fields.Add(&core.NumberField{Name: "valid_from_year"})
+	aliases.Fields.Add(&core.NumberField{Name: "valid_to_year"})
+	aliases.Fields.Add(&core.TextField{Name: "source_field"})
+	saveCollection(t, app, aliases)
+
+	merges := core.NewBaseCollection("lodging_merges")
+	merges.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	merges.Fields.Add(&core.NumberField{Name: "year"})
+	merges.Fields.Add(&core.TextField{Name: "scenario"})
+	merges.Fields.Add(&core.RelationField{Name: "member_units", CollectionId: units.Id, MaxSelect: 20})
+	merges.Fields.Add(&core.TextField{Name: "display_name"})
+	merges.Fields.Add(&core.TextField{Name: "created_by"})
+	saveCollection(t, app, merges)
+
+	assignments := core.NewBaseCollection("lodging_assignments")
+	assignments.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	assignments.Fields.Add(&core.NumberField{Name: "year"})
+	assignments.Fields.Add(&core.RelationField{Name: "unit", CollectionId: units.Id, MaxSelect: 1})
+	assignments.Fields.Add(&core.RelationField{Name: "merge", CollectionId: merges.Id, MaxSelect: 1})
+	assignments.Fields.Add(&core.TextField{Name: "scenario"})
+	assignments.Fields.Add(&core.NumberField{Name: "household_cm_id"})
+	assignments.Fields.Add(&core.NumberField{Name: "person_cm_id"})
+	assignments.Fields.Add(&core.NumberField{Name: "party_size"})
+	assignments.Fields.Add(&core.TextField{Name: "source"})
+	assignments.Fields.Add(&core.BoolField{Name: "staff_touched"})
+	assignments.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+	assignments.Fields.Add(&core.AutodateField{Name: "updated", OnCreate: true, OnUpdate: true})
+	saveCollection(t, app, assignments)
+
+	history := core.NewBaseCollection("lodging_assignment_history")
+	history.Fields.Add(&core.NumberField{Name: "household_cm_id"})
+	history.Fields.Add(&core.NumberField{Name: "person_cm_id"})
+	history.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	history.Fields.Add(&core.NumberField{Name: "year"})
+	history.Fields.Add(&core.TextField{Name: "old_unit"})
+	history.Fields.Add(&core.TextField{Name: "new_unit"})
+	history.Fields.Add(&core.DateField{Name: "detected_at"})
+	history.Fields.Add(&core.TextField{Name: "source_field"})
+	// Autodate, because tests sort history by "-created". PocketBase's
+	// NewBaseCollection adds only `id`, and sorting on a column that does not
+	// exist returns an ERROR -- which a caller discarding err reads as zero rows.
+	history.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+	saveCollection(t, app, history)
+
+	issues := core.NewBaseCollection("lodging_ingest_issues")
+	issues.Fields.Add(&core.TextField{Name: "kind"})
+	issues.Fields.Add(&core.TextField{Name: "raw_value"})
+	issues.Fields.Add(&core.TextField{Name: "source_field"})
+	issues.Fields.Add(&core.NumberField{Name: "year"})
+	issues.Fields.Add(&core.NumberField{Name: "household_cm_id"})
+	issues.Fields.Add(&core.NumberField{Name: "person_cm_id"})
+	issues.Fields.Add(&core.RelationField{Name: "suggested_session", CollectionId: sessions.Id, MaxSelect: 1})
+	issues.Fields.Add(&core.RelationField{Name: "resolved_alias", CollectionId: aliases.Id, MaxSelect: 1})
+	issues.Fields.Add(&core.JSONField{Name: "candidate_session_cm_ids", MaxSize: 20000})
+	issues.Fields.Add(&core.NumberField{Name: "occurrences"})
+	issues.Fields.Add(&core.DateField{Name: "first_seen"})
+	issues.Fields.Add(&core.DateField{Name: "last_seen"})
+	issues.Fields.Add(&core.BoolField{Name: "is_resolved"})
+	issues.Fields.Add(&core.TextField{Name: "resolution_note"})
+	saveCollection(t, app, issues)
+
+	mappings := core.NewBaseCollection("lodging_field_mappings")
+	mappings.Fields.Add(&core.NumberField{Name: "field_cm_id"})
+	mappings.Fields.Add(&core.TextField{Name: "field_name"})
+	mappings.Fields.Add(&core.TextField{Name: "target"})
+	mappings.Fields.Add(&core.BoolField{Name: "is_enabled"})
+	mappings.Fields.Add(&core.NumberField{Name: "last_seen_year"})
+	mappings.Fields.Add(&core.NumberField{Name: "last_seen_count"})
+	mappings.Fields.Add(&core.NumberField{Name: "prior_year_count"})
+	mappings.Fields.Add(&core.TextField{Name: "note"})
+	saveCollection(t, app, mappings)
+
+	return app
+}
+
+func saveCollection(t *testing.T, app core.App, col *core.Collection) {
+	t.Helper()
+	if err := app.Save(col); err != nil {
+		t.Fatalf("save collection %s: %v", col.Name, err)
+	}
+}
+
+func saveRecord(t *testing.T, app core.App, collection string, values map[string]any) string {
+	t.Helper()
+	col, err := app.FindCollectionByNameOrId(collection)
+	if err != nil {
+		t.Fatalf("find collection %s: %v", collection, err)
+	}
+	r := core.NewRecord(col)
+	for k, v := range values {
+		r.Set(k, v)
+	}
+	if err := app.Save(r); err != nil {
+		t.Fatalf("save %s: %v", collection, err)
+	}
+	return r.Id
+}
+
+func addFieldDef(t *testing.T, app core.App, cmID int, name string) string {
+	t.Helper()
+	return saveRecord(t, app, "custom_field_defs", map[string]any{"cm_id": cmID, "name": name})
+}
+
+// addSession takes start/end in PocketBase's stored date layout,
+// e.g. "2025-05-23 07:00:00.000Z".
+func addSession(t *testing.T, app core.App, cmID int, name, sessionType, start, end string, year int) string {
+	t.Helper()
+	return saveRecord(t, app, "camp_sessions", map[string]any{
+		"cm_id": cmID, "name": name, "session_type": sessionType,
+		"start_date": start, "end_date": end, "year": year,
+	})
+}
+
+func addHousehold(t *testing.T, app core.App, cmID, year int) string {
+	t.Helper()
+	return saveRecord(t, app, "households", map[string]any{"cm_id": cmID, "year": year})
+}
+
+func addPerson(t *testing.T, app core.App, cmID, householdCMID, year int, householdPBID string) string {
+	t.Helper()
+	return saveRecord(t, app, "persons", map[string]any{
+		"cm_id": cmID, "household_id": householdCMID, "household": householdPBID, "year": year,
+	})
+}
+
+func addAttendee(t *testing.T, app core.App, personPBID, sessionPBID string, personCMID, statusID, year int) {
+	t.Helper()
+	saveRecord(t, app, "attendees", map[string]any{
+		"person": personPBID, "person_id": personCMID, "session": sessionPBID,
+		"status_id": statusID, "year": year,
+	})
+}
+
+func addUnit(t *testing.T, app core.App, code string) string {
+	t.Helper()
+	return saveRecord(t, app, "lodging_units", map[string]any{
+		"code": code, "name": code, "is_active": true, "is_container": false,
+	})
+}
+
+// addAlias stores from/to as PocketBase does: 0 means unbounded, never NULL.
+func addAlias(t *testing.T, app core.App, aliasString string, unitIDs []string, from, to int) string {
+	t.Helper()
+	return saveRecord(t, app, "lodging_unit_aliases", map[string]any{
+		"alias_string": aliasString, "member_units": unitIDs,
+		"valid_from_year": from, "valid_to_year": to,
+	})
+}
+
+// NOTE: addHouseholdValue / addPersonValue belong here too, but their first
+// consumer is Task 11 (the household-grain sync), which ships in the B2 PR.
+// Adding them now would leave two permanently-unused helpers in this PR, and the
+// `unused` linter fails the pre-push hook on them. B2 appends them to this file
+// alongside the code that calls them. The custom-values collections themselves
+// are already built by newLodgingTestApp above, so nothing else has to move.

--- a/scripts/dev/verify-lodging-schema.sh
+++ b/scripts/dev/verify-lodging-schema.sh
@@ -137,5 +137,33 @@ for idx in idx_lodging_assign_hh_live idx_lodging_assign_person_live; do
   fi
 done
 
+for c in lodging_ingest_issues lodging_field_mappings; do
+  n=$(sqlite3 "$DB" "SELECT COUNT(*) FROM _collections WHERE name = '$c'")
+  [[ "$n" -eq 1 ]] || note "collection $c missing"
+done
+
+ik=$(field_prop lodging_ingest_issues kind values || true)
+[[ "$ik" == '["unresolved_alias","ambiguous_alias","ambiguous_session","no_session","field_zero_values"]' ]] \
+  || note "lodging_ingest_issues.kind values are $ik"
+
+# The dedup index is what keeps a 472-row backfill from writing 472 issue rows.
+idx=$(sqlite3 "$DB" "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_lodging_issues_dedup'")
+[[ "$idx" -eq 1 ]] || note "idx_lodging_issues_dedup missing"
+
+fm=$(sqlite3 "$DB" "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_lodging_field_map_cmid'")
+[[ "$fm" -eq 1 ]] || note "idx_lodging_field_map_cmid missing"
+
+# Same options:{} trap as above, on the new collections: a silently-ignored max
+# shows up as 5000. raw_value is deliberately 500 (wider than alias_string's 300)
+# so a truncated request text still fits.
+rv=$(field_prop lodging_ingest_issues raw_value max || true)
+[[ "$rv" == "500" ]] || note "lodging_ingest_issues.raw_value max is '$rv' (expected 500)"
+fn=$(field_prop lodging_field_mappings field_name max || true)
+[[ "$fn" == "200" ]] || note "lodging_field_mappings.field_name max is '$fn' (expected 200)"
+
+# Plan 3 links a resolved alias item back to the alias row staff created from it.
+ra=$(field_prop lodging_ingest_issues resolved_alias cascadeDelete || true)
+[[ "$ra" == "0" || "$ra" == "false" ]] || note "lodging_ingest_issues.resolved_alias cascadeDelete is '$ra' (expected false)"
+
 if [[ "$fail" -ne 0 ]]; then echo "verify-lodging-schema: FAILED" >&2; exit 1; fi
 echo "verify-lodging-schema: OK ($js_migs js migrations applied)"

--- a/scripts/dev/verify-lodging-schema.sh
+++ b/scripts/dev/verify-lodging-schema.sh
@@ -147,8 +147,20 @@ ik=$(field_prop lodging_ingest_issues kind values || true)
   || note "lodging_ingest_issues.kind values are $ik"
 
 # The dedup index is what keeps a 472-row backfill from writing 472 issue rows.
+# Assert its COLUMNS, not just its name: an index that keeps the name but loses a
+# key column (dropping `year` would merge every season's queue into one row)
+# passes a name-only check while silently breaking dedup. These six must stay in
+# step with Issue.dedupKey() in sync/lodging_issues.go.
 idx=$(sqlite3 "$DB" "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_lodging_issues_dedup'")
-[[ "$idx" -eq 1 ]] || note "idx_lodging_issues_dedup missing"
+if [[ "$idx" -ne 1 ]]; then
+  note "idx_lodging_issues_dedup missing"
+else
+  dedup_sql=$(sqlite3 "$DB" "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_lodging_issues_dedup'")
+  [[ "$dedup_sql" == *UNIQUE* ]] || note "idx_lodging_issues_dedup is not UNIQUE: $dedup_sql"
+  for col in year kind raw_value source_field household_cm_id person_cm_id; do
+    [[ "$dedup_sql" == *"\`$col\`"* ]] || note "idx_lodging_issues_dedup missing column $col"
+  done
+fi
 
 fm=$(sqlite3 "$DB" "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_lodging_field_map_cmid'")
 [[ "$fm" -eq 1 ]] || note "idx_lodging_field_map_cmid missing"


### PR DESCRIPTION
Plan 2 (family-camp lodging ingest) **Phase B1** — the two support collections plus five pure, unit-tested resolution primitives and the dual-grain guard.

**No sync job, no registration, no behaviour change.** Nothing here runs until B2 wires it up, which is the point of the seam: every piece is a pure function or a schema addition with its own tests, so it is reviewable on correctness alone. B2 is the part that starts writing assignments.

Builds on Phase A (#1872, merged as `78ef6d8d`) and Plan 1's registry (#1867).

## What's here

| Task | Delivers |
|---|---|
| 4 | Migration `1500000122` — `lodging_ingest_issues` (the work queue) and `lodging_field_mappings` (human-set mapping status) |
| 5 | The cm_id-keyed source-field registry + the shared PocketBase test harness |
| 6 | `IssueRecorder` — accumulate-and-upsert, so a backfill hitting one unmapped string 472 times writes one row with `occurrences=472` |
| 7 | `AliasResolver` — temporal alias resolution honouring each row's year window |
| 8 | `EnsureMerge` — find-or-create a merge by exact member set |
| 9 | Session attribution — deriving `(household, session, year)` from a per-year cabin value |
| 10 | `ValidateAssignmentGrain` — the dual-grain XOR the database does not enforce |

## Claims I verified against real data rather than trusting

**The registry's grain assignments.** cm_id **218072** has 1861 values and appears *only* in `household_custom_values`; **223823** has 939 and appears *only* in `person_custom_values`. Zero crossover in either direction, so the household/person split is right. Both display names match their comments exactly, no stray whitespace.

**PocketBase really does accept every illegal grain state.** `TestAssignmentGrainIllegalStatesReallySaveInPocketBase` saves a row with neither party and no placement and asserts it succeeds. That test documents *why* the guard exists — if PocketBase ever starts rejecting these, it fails and the guard can be reconsidered. Until then the invariant has no database backing and `ValidateAssignmentGrain` is the only place it exists.

## Design points worth a reviewer's attention

**Empty scenario is a SQL literal, never a bound parameter.** A bound `""` matches nothing in PocketBase, so the live plan would never find its own merge row and every run would create another. `eqOrEmpty` handles both halves — literal for empty, bound for everything else, because real cabin strings carry apostrophes and interpolating one is a syntax error rather than a miss.

**Year `0` means unbounded, not year zero.** PocketBase number columns are `NUMERIC DEFAULT 0 NOT NULL`, and 94 of the 100 seeded alias rows are unbounded on both sides — reading `0` as a real bound would resolve almost nothing. The windows are load-bearing, not cosmetic: both Doctor's Houses existed 2022–2024 and the Golden Triangle one was renamed in 2025, so cross-resolving would silently relocate a household across camp.

**Ambiguous session attribution gets a suggestion and no assignment row.** ~98% of households attend exactly one weekend and attribute cleanly; 6–10 a year attend several; 53 values in 2025 have no active enrolment at all. None are dropped. Per spec §3.6 the multi-weekend ones are flagged for manual entry — a wrong cabin on the board is worse than a blank one.

**Timestamps are parsed explicitly, not via `ParseDate`.** `last_updated` is a TEXT column holding CampMinder's .NET `DateTimeOffset`. `ParseDate` does parse that format, but it returns a whole-second *string* and `AttributeSession` needs a `time.Time`, so parsing here keeps the value typed and keeps sub-second precision. `camp_sessions` dates are the separate case: their stored layout matches none of `date_utils.go`'s formats and would silently produce a zero time, so they are read via `GetDateTime`.

## Deviations from the plan

- **Two harness helpers deferred to B2.** `addHouseholdValue`/`addPersonValue` have no consumer until Task 11, so shipping them here would leave permanently-unused functions and the `unused` linter fails the pre-push hook. A comment marks where B2 appends them.
- **`"Family Camp Cabin"` became a constant.** The literal now appears in both the registry and the name-routed switch in `family_camp_derived.go`, which crossed goconst's threshold.
- **One verifier assertion added beyond the plan.** Task 4's assertions don't guard the `options:{}` silent-ignore trap, though the file already guards it for `lodging_units`. Added `raw_value max == 500` and `field_name max == 200`; both pass.
- **A doc comment reworded.** `verify-no-hardcoded-lodging.sh` scans comments too, and its needle list is wider than the plan's summary of it — `Doctor's House`, `Bayit`, `Tenaya`, `Tioga`, `Le Shack`, `Lofty` and `Kitty` are in the script but absent from the plan's Global Constraints. The plan's `eqOrEmpty` comment named one; it now makes the same point without it.

## Verification

- 28 new tests, all green. Full `go test ./...` green across all 10 packages.
- `golangci-lint run ./sync/...` — **0 issues**. gofmt and vet clean.
- All three lodging harnesses green: `verify-lodging-schema` (85 migrations), `verify-lodging-seed`, `verify-no-hardcoded-lodging`.
- eslint clean on `pb_migrations`/`pb_hooks`; shellcheck clean.
- Full pre-push suite passed: ruff, pb-js-lint, shellcheck, markdownlint, go-build, api-types-freshness, mypy, tsc, pytest.

Every task followed the plan's TDD order — failing test written and observed failing for the stated reason before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lodging data ingestion support, including alias resolution, field mappings, session attribution, merge handling, and assignment validation.
  * Added tracking for unresolved, ambiguous, and other lodging ingestion issues with deduplication and occurrence counts.
  * Added administrative lodging collections for reviewing ingestion issues and managing field mappings.
  * Improved cabin assignment matching using canonical field identifiers.

* **Bug Fixes**
  * Corrected handling of aliases across case, whitespace, rename periods, and overlapping validity windows.
  * Prevented duplicate merge and issue records during repeated synchronization.

* **Tests**
  * Added comprehensive coverage for lodging ingestion, attribution, aliases, merges, mappings, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
