### PR TITLE
feat(sync): turn on the lodging assignment ingest (lodging ingest Phase B2)

### DIFF
--- a/frontend/src/components/admin/SyncTab.tsx
+++ b/frontend/src/components/admin/SyncTab.tsx
@@ -21,6 +21,7 @@ import { useUnifiedSync } from '../../hooks/useUnifiedSync'
 import { useProcessRequests } from '../../hooks/useProcessRequests'
 import { useCamperHistorySync } from '../../hooks/useCamperHistorySync'
 import { useFamilyCampDerivedSync } from '../../hooks/useFamilyCampDerivedSync'
+import { useLodgingAssignmentsSync } from '../../hooks/useLodgingAssignmentsSync'
 import { useStaffSkillsSync } from '../../hooks/useStaffSkillsSync'
 import { useFinancialAidApplicationsSync } from '../../hooks/useFinancialAidApplicationsSync'
 import { useHouseholdDemographicsSync } from '../../hooks/useHouseholdDemographicsSync'
@@ -82,6 +83,7 @@ export function SyncTab() {
   const processRequests = useProcessRequests()
   const camperHistorySync = useCamperHistorySync()
   const familyCampDerivedSync = useFamilyCampDerivedSync()
+  const lodgingAssignmentsSync = useLodgingAssignmentsSync()
   const staffSkillsSync = useStaffSkillsSync()
   const faApplicationsSync = useFinancialAidApplicationsSync()
   const householdDemographicsSync = useHouseholdDemographicsSync()
@@ -182,6 +184,9 @@ export function SyncTab() {
           break
         case 'family_camp_derived':
           familyCampDerivedSync.mutate(syncYear)
+          break
+        case 'lodging_assignments':
+          lodgingAssignmentsSync.mutate(syncYear)
           break
         case 'staff_skills':
           staffSkillsSync.mutate(syncYear)

--- a/frontend/src/components/admin/syncTypes.ts
+++ b/frontend/src/components/admin/syncTypes.ts
@@ -209,6 +209,13 @@ export const YEAR_SYNC_TYPES = [
     phase: 'transform' as SyncPhase,
   },
   {
+    id: 'lodging_assignments',
+    name: 'Lodging Assignments',
+    icon: BedDouble,
+    color: 'text-amber-600',
+    phase: 'transform' as SyncPhase,
+  },
+  {
     id: 'staff_skills',
     name: 'Staff Skills',
     icon: Sparkles,

--- a/frontend/src/hooks/useLodgingAssignmentsSync.ts
+++ b/frontend/src/hooks/useLodgingAssignmentsSync.ts
@@ -1,0 +1,10 @@
+import { createSyncMutation } from './createSyncMutation'
+
+/**
+ * Hook for running the lodging assignment ingest.
+ */
+export const useLodgingAssignmentsSync = createSyncMutation<number>({
+  endpoint: (year) => `/api/custom/sync/lodging-assignments?year=${year}`,
+  displayName: 'Lodging Assignments',
+  alreadyRunningMessage: 'Lodging Assignments sync is already running.',
+})

--- a/frontend/src/hooks/useRunIndividualSync.ts
+++ b/frontend/src/hooks/useRunIndividualSync.ts
@@ -27,6 +27,7 @@ export const SYNC_TYPE_NAMES: Record<string, string> = {
   camper_history: 'Camper History', // Computed retention metrics
   financial_transactions: 'Financial Transactions', // Year-scoped financial data
   family_camp_derived: 'Weekend Programs Derived', // Computed from custom values
+  lodging_assignments: 'Lodging Assignments', // Derived from the cabin custom fields
   staff_skills: 'Staff Skills', // Derived from person_custom_values Skills- fields
   financial_aid_applications: 'FA Applications', // Derived from person_custom_values FA- fields
   household_demographics: 'Household Demographics', // Computed from HH- fields

--- a/frontend/src/hooks/useSyncCompletionToasts.ts
+++ b/frontend/src/hooks/useSyncCompletionToasts.ts
@@ -31,6 +31,7 @@ const SYNC_DISPLAY_NAMES: Record<string, string> = {
   // Transform phase (derived tables)
   camper_history: 'Camper History',
   family_camp_derived: 'Weekend Programs',
+  lodging_assignments: 'Lodging Assignments',
   staff_skills: 'Staff Skills',
   financial_aid_applications: 'FA Applications',
   household_demographics: 'Demographics',

--- a/frontend/src/hooks/useSyncStatusAPI.ts
+++ b/frontend/src/hooks/useSyncStatusAPI.ts
@@ -72,6 +72,7 @@ export interface SyncStatusResponse {
   // Transform phase (derived tables)
   camper_history: SyncStatus
   family_camp_derived: SyncStatus
+  lodging_assignments: SyncStatus
   staff_skills: SyncStatus
   financial_aid_applications: SyncStatus
   household_demographics: SyncStatus

--- a/pocketbase/pb_migrations/1500000124_lodging_session_durable_key.js
+++ b/pocketbase/pb_migrations/1500000124_lodging_session_durable_key.js
@@ -1,0 +1,96 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: stop lodging rows cascading away with a camp_session, and give them
+ * a durable CampMinder key. Resolves kindred#1879.
+ *
+ * THE CASCADE
+ *
+ * camp_sessions rows are orphan-deleted by SessionsSync: it marks every session
+ * CampMinder returned, then deletes local rows it did not see. lodging_merges,
+ * lodging_availability and lodging_assignments each held a `session` relation
+ * with cascadeDelete true, so a session disappearing from one API response took
+ * every dependent row with it -- no error, no recovery, and only a routine
+ * "deleted orphaned record" line about the SESSION to show for it. That
+ * contradicts the work queue's own contract in 1500000122: never a silent drop.
+ *
+ * Scope of the exposure, measured rather than assumed: orphan deletion is
+ * YEAR-SCOPED. sessions.go builds "year = N" and passes that same filter to
+ * DeleteOrphans, so a 2026 sync can only delete 2026 rows. Historical years were
+ * never at risk. What remains is the current sync year, where a successful but
+ * truncated CampMinder response still counts as success -- DeleteOrphans skips
+ * only on an outright sync FAILURE, and has no minimum-count guard.
+ *
+ * The fix is one flag, because `session` is already required on all three.
+ * PocketBase blocks deleting a record behind a REQUIRED relation, but only while
+ * cascadeDelete is false; with it true, it cascades instead. Flipping it turns
+ * silent data loss into an HTTP 400 the sessions sync reports. The cost is real
+ * and intended: a genuinely cancelled weekend now fails orphan cleanup until a
+ * human clears its lodging rows. The sync cannot tell "cancelled" apart from
+ * "absent from this response", and those deserve different answers.
+ *
+ * THE DURABLE KEY
+ *
+ * camp_sessions is unique on (cm_id, year), so every YEAR gets its own row: a
+ * program that runs in 2025, skips 2026 and returns in 2027 comes back with a
+ * different PocketBase record id. A PB relation therefore cannot express any
+ * cross-year question -- "same cabin as last year", or year-over-year occupancy
+ * -- because the id it points at is scoped to one season. session_cm_id sits
+ * beside the relation as the stable identity, per CLAUDE.md section 1: cross-table
+ * relationships use CampMinder IDs. The relation stays for convenience joins.
+ *
+ * required true on the three placement tables: all four tables are empty today
+ * (nothing writes them until plan Task 11), so there is nothing to backfill, and
+ * requiring it means the assignment sync fails loudly rather than writing rows
+ * that cannot survive a session being recreated.
+ *
+ * lodging_assignment_history gets the column too but NOT the requirement, and its
+ * relation keeps cascadeDelete false with required false. That asymmetry is
+ * deliberate and predates this migration: the audit trail is meant to outlive its
+ * session, blanking `session` rather than vanishing. Until now that left a
+ * surviving row unable to say which weekend it described; session_cm_id is what
+ * finally makes the audit trail self-contained.
+ *
+ * PocketBase v0.23 syntax: fields.add(new Field({...})) on an existing
+ * collection. A bare add({...}) silently does nothing.
+ */
+
+migrate((app) => {
+  // The three placement tables: break the cascade, add the durable key.
+  for (const name of ["lodging_merges", "lodging_availability", "lodging_assignments"]) {
+    const col = app.findCollectionByNameOrId(name);
+
+    const rel = col.fields.getByName("session");
+    if (rel) {
+      rel.cascadeDelete = false;
+    }
+
+    col.fields.add(new Field({
+      type: "number", name: "session_cm_id", required: true, presentable: false,
+      min: 1, max: null, onlyInt: true
+    }));
+    app.save(col);
+  }
+
+  // The audit trail. Optional, because its `session` relation is optional by
+  // design -- a history row is expected to outlive the session it references.
+  const history = app.findCollectionByNameOrId("lodging_assignment_history");
+  history.fields.add(new Field({
+    type: "number", name: "session_cm_id", required: false, presentable: false,
+    min: null, max: null, onlyInt: true
+  }));
+  app.save(history);
+}, (app) => {
+  for (const name of ["lodging_merges", "lodging_availability", "lodging_assignments"]) {
+    const col = app.findCollectionByNameOrId(name);
+    const rel = col.fields.getByName("session");
+    if (rel) {
+      rel.cascadeDelete = true;
+    }
+    col.fields.removeByName("session_cm_id");
+    app.save(col);
+  }
+
+  const history = app.findCollectionByNameOrId("lodging_assignment_history");
+  history.fields.removeByName("session_cm_id");
+  app.save(history);
+});

--- a/pocketbase/pb_migrations/1500000124_lodging_session_durable_key.js
+++ b/pocketbase/pb_migrations/1500000124_lodging_session_durable_key.js
@@ -59,10 +59,15 @@ migrate((app) => {
   for (const name of ["lodging_merges", "lodging_availability", "lodging_assignments"]) {
     const col = app.findCollectionByNameOrId(name);
 
+    // No guard: a missing `session` is the one state this migration must never
+    // shrug at. Its whole purpose is to clear cascadeDelete on that field, so
+    // skipping quietly would report success while leaving kindred#1879's silent
+    // data loss fully in place.
     const rel = col.fields.getByName("session");
-    if (rel) {
-      rel.cascadeDelete = false;
+    if (!rel) {
+      throw new Error(`${name}: expected an existing "session" relation field`);
     }
+    rel.cascadeDelete = false;
 
     col.fields.add(new Field({
       type: "number", name: "session_cm_id", required: true, presentable: false,
@@ -83,9 +88,10 @@ migrate((app) => {
   for (const name of ["lodging_merges", "lodging_availability", "lodging_assignments"]) {
     const col = app.findCollectionByNameOrId(name);
     const rel = col.fields.getByName("session");
-    if (rel) {
-      rel.cascadeDelete = true;
+    if (!rel) {
+      throw new Error(`${name}: expected an existing "session" relation field`);
     }
+    rel.cascadeDelete = true;
     col.fields.removeByName("session_cm_id");
     app.save(col);
   }

--- a/pocketbase/pb_migrations/1500000125_lodging_issue_kinds_drops.js
+++ b/pocketbase/pb_migrations/1500000125_lodging_issue_kinds_drops.js
@@ -1,0 +1,68 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: two more lodging_ingest_issues.kind values, for the drops the
+ * ingest could previously only log.
+ *
+ * lodging_ingest_issues.kind is a SELECT, so PocketBase rejects any value not
+ * listed here -- the Go constants in lodging_issues.go are not the constraint,
+ * this list is. Spec 6.2 ("every historical value must resolve to a unit or
+ * appear in an unresolved-alias report. Zero silent drops") needs both:
+ *
+ * - unknown_party: the household or person row the custom value hangs off does
+ *   not exist for the sync year, so there is no CampMinder id to key a
+ *   placement on. The ingest counted the value before discovering this, which
+ *   means it also suppressed the field_zero_values warning -- the observation
+ *   was invisible in every direction.
+ *
+ * - write_failed: the value resolved and attributed cleanly, then the write
+ *   lost. Stats.Errors and a log line carried it, but Stats is never persisted
+ *   and logs rotate, so by morning the value was accounted for nowhere.
+ *
+ * Both are year-scoped like every other kind and dedup on the same six columns
+ * (idx_lodging_issues_dedup, migration 1500000122), so a backfill hitting the
+ * same broken household 400 times still queues one row.
+ *
+ * PocketBase v0.23 syntax: mutate the existing field in place and save. There
+ * is no fields.add() here -- the field already exists and re-adding it would
+ * drop the stored values.
+ */
+
+const kindsBefore = [
+  "unresolved_alias",
+  "ambiguous_alias",
+  "ambiguous_session",
+  "no_session",
+  "field_zero_values"
+];
+
+const kindsAfter = kindsBefore.concat(["unknown_party", "write_failed"]);
+
+migrate((app) => {
+  const col = app.findCollectionByNameOrId("lodging_ingest_issues");
+  const kind = col.fields.getByName("kind");
+  if (!kind) {
+    throw new Error('lodging_ingest_issues: expected an existing "kind" select field');
+  }
+  kind.values = kindsAfter;
+  app.save(col);
+}, (app) => {
+  // Rows carrying a kind this migration introduced would fail validation against
+  // the narrowed list, so they go first. Deleting them is correct rather than
+  // lossy: down-migrating means reverting to an ingest that never produced them.
+  const doomed = app.findRecordsByFilter(
+    "lodging_ingest_issues",
+    'kind = "unknown_party" || kind = "write_failed"',
+    "", 0, 0
+  );
+  for (const rec of doomed) {
+    app.delete(rec);
+  }
+
+  const col = app.findCollectionByNameOrId("lodging_ingest_issues");
+  const kind = col.fields.getByName("kind");
+  if (!kind) {
+    throw new Error('lodging_ingest_issues: expected an existing "kind" select field');
+  }
+  kind.values = kindsBefore;
+  app.save(col);
+});

--- a/pocketbase/sync/api.go
+++ b/pocketbase/sync/api.go
@@ -417,6 +417,14 @@ func InitializeSyncService(app *pocketbase.PocketBase, e *core.ServeEvent) error
 			return handleFamilyCampDerivedSync(e, scheduler)
 		}))
 
+	// Lodging assignments sync
+	// Derives lodging_assignments from the CampMinder cabin custom fields
+	// Accepts required ?year=YYYY parameter
+	e.Router.POST("/api/custom/sync/lodging-assignments",
+		requirePermission("bunking.manage", func(e *core.RequestEvent) error {
+			return handleLodgingAssignmentsSync(e, scheduler)
+		}))
+
 	// Staff skills sync
 	// Extracts Skills- fields from person_custom_values into normalized table
 	// Accepts required ?year=YYYY parameter
@@ -919,6 +927,7 @@ func handleSyncStatus(e *core.RequestEvent, scheduler *Scheduler) error {
 		"camper_history",              // Computed camper denorm with retention metrics
 		"financial_transactions",      // Year-scoped financial data (depends on sessions, persons, households)
 		"family_camp_derived",         // Computed from person_custom_values, household_custom_values
+		"lodging_assignments",         // Derived: cabin custom fields -> lodging assignments
 		"staff_skills",                // Derived: staff skills extraction
 		"financial_aid_applications",  // Derived: FA applications computation
 		"household_demographics",      // Derived: household demographics computation
@@ -1980,6 +1989,73 @@ func handleFamilyCampDerivedSync(e *core.RequestEvent, scheduler *Scheduler) err
 
 	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Family camp derived computation started",
+		"status":   "started",
+		"syncType": syncType,
+		"year":     year,
+		"dry_run":  dryRun,
+	})
+}
+
+// handleLodgingAssignmentsSync handles the lodging assignment ingest endpoint.
+// Accepts a required ?year=YYYY parameter and an optional ?dry_run=true.
+func handleLodgingAssignmentsSync(e *core.RequestEvent, scheduler *Scheduler) error {
+	orchestrator := scheduler.GetOrchestrator()
+	syncType := serviceNameLodgingAssignments
+
+	if orchestrator.IsRunning(syncType) {
+		return e.JSON(http.StatusConflict, map[string]any{
+			"error":    "Lodging assignment ingest already in progress",
+			"status":   "running",
+			"syncType": syncType,
+		})
+	}
+
+	yearParam := e.Request.URL.Query().Get("year")
+	if yearParam == "" {
+		return e.JSON(http.StatusBadRequest, map[string]any{
+			"error": "Missing required year parameter. Use ?year=YYYY",
+		})
+	}
+	year, err := strconv.Atoi(yearParam)
+	if err != nil || year < 2017 || year > 2050 {
+		return e.JSON(http.StatusBadRequest, map[string]any{
+			"error": "Invalid year parameter. Must be between 2017 and 2050.",
+		})
+	}
+
+	dryRunParam := e.Request.URL.Query().Get("dry_run")
+	dryRun := dryRunParam == boolTrueStr || dryRunParam == "1"
+
+	service, ok := orchestrator.GetService(syncType).(*LodgingAssignmentsSync)
+	if !ok || service == nil {
+		return e.JSON(http.StatusInternalServerError, map[string]any{
+			"error": "Lodging assignments sync service not found",
+		})
+	}
+	service.Year = year
+	service.DryRun = dryRun
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+		defer cancel()
+
+		slog.Info("Starting lodging_assignments ingest", "year", year, "dry_run", dryRun)
+		if err := orchestrator.RunSingleSync(ctx, syncType); err != nil {
+			slog.Error("Lodging assignment ingest failed", "year", year, "error", err)
+			return
+		}
+		stats := service.GetStats()
+		slog.Info("Lodging assignment ingest completed",
+			"year", year,
+			"created", stats.Created,
+			"updated", stats.Updated,
+			"skipped", stats.Skipped,
+			"errors", stats.Errors,
+		)
+	}()
+
+	return e.JSON(http.StatusOK, map[string]any{
+		"message":  "Lodging assignment ingest started",
 		"status":   "started",
 		"syncType": syncType,
 		"year":     year,

--- a/pocketbase/sync/lodging_assignments_sync.go
+++ b/pocketbase/sync/lodging_assignments_sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -33,6 +34,15 @@ type LodgingAssignmentsSync struct {
 
 	resolver *AliasResolver
 	issues   *IssueRecorder
+
+	// Party-size indexes, built once per run. partySize used to query per
+	// household: a filtered scan of persons (28k rows) plus a full paged scan of
+	// family_camp_adults (10k rows) for EVERY observed cabin value. At ~700
+	// households a 2024 backfill did not finish inside a ten-minute timeout.
+	// Three scans up front make it linear.
+	personsByHouseholdCMID  map[int][]*core.Record
+	enrolledByPersonSession map[string]int // "<personPBID>|<sessionPBID>" -> count
+	adultsByHouseholdPBID   map[string]int
 }
 
 // NewLodgingAssignmentsSync builds the service. Year 0 means "resolve from the
@@ -91,6 +101,10 @@ func (s *LodgingAssignmentsSync) Sync(ctx context.Context) error {
 
 	now := time.Now().UTC()
 	counts := map[int]int{}
+
+	if idxErr := s.buildPartySizeIndexes(year); idxErr != nil {
+		return idxErr
+	}
 
 	if hhErr := s.syncHouseholdGrain(ctx, year, fieldTargets, counts, now); hhErr != nil {
 		return hhErr
@@ -168,8 +182,13 @@ func (s *LodgingAssignmentsSync) syncHouseholdGrain(
 		return err
 	}
 
+	defIDs := defIDsForTarget(fieldTargets, targetCabinAssignmentHousehold)
+	if len(defIDs) == 0 {
+		return nil // the field is unmapped or disabled; nothing to read
+	}
+	params := dbx.Params{}
 	values, err := findAllRecords(s.App, "household_custom_values",
-		fmt.Sprintf("year = %d && value != ''", year))
+		fmt.Sprintf("year = %d && value != '' && %s", year, fieldDefClause(defIDs, params)), params)
 	if err != nil {
 		return err
 	}
@@ -179,9 +198,6 @@ func (s *LodgingAssignmentsSync) syncHouseholdGrain(
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-		}
-		if fieldTargets[v.GetString("field_definition")] != targetCabinAssignmentHousehold {
-			continue
 		}
 		counts[cmIDFamilyCampCabin]++
 
@@ -223,8 +239,13 @@ func (s *LodgingAssignmentsSync) syncPersonGrain(
 		return err
 	}
 
+	defIDs := defIDsForTarget(fieldTargets, targetCabinAssignmentPerson)
+	if len(defIDs) == 0 {
+		return nil // the field is unmapped or disabled; nothing to read
+	}
+	params := dbx.Params{}
 	values, err := findAllRecords(s.App, "person_custom_values",
-		fmt.Sprintf("year = %d && value != ''", year))
+		fmt.Sprintf("year = %d && value != '' && %s", year, fieldDefClause(defIDs, params)), params)
 	if err != nil {
 		return err
 	}
@@ -234,9 +255,6 @@ func (s *LodgingAssignmentsSync) syncPersonGrain(
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-		}
-		if fieldTargets[v.GetString("field_definition")] != targetCabinAssignmentPerson {
-			continue
 		}
 		counts[cmIDReportableFamilyCampCabin]++
 
@@ -257,6 +275,42 @@ func (s *LodgingAssignmentsSync) syncPersonGrain(
 		})
 	}
 	return nil
+}
+
+// defIDsForTarget returns the custom_field_defs PB ids mapped to one target
+// column, sorted so the generated filter is deterministic.
+func defIDsForTarget(fieldTargets map[string]string, target string) []string {
+	out := make([]string, 0, 2)
+	for defID, t := range fieldTargets {
+		if t == target {
+			out = append(out, defID)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+// fieldDefClause renders a parenthesised OR of field_definition equalities and
+// registers the bound parameters.
+//
+// This filtering has to happen in SQL, not in Go. person_custom_values holds
+// 1.6M rows -- 181k for a single year -- while at most two field definitions are
+// ever mapped, so reading the year and discarding the rest paged through
+// hundreds of thousands of rows via LIMIT/OFFSET, whose cost grows with the
+// offset. Scoping the query to the mapped definitions turns that into a few
+// hundred rows.
+//
+// The ids are PocketBase record ids rather than user input, but they stay
+// parameterised anyway: the cost is nil and the habit is what keeps an
+// apostrophe-bearing value from becoming a syntax error elsewhere in this file.
+func fieldDefClause(defIDs []string, params dbx.Params) string {
+	clauses := make([]string, 0, len(defIDs))
+	for i, id := range defIDs {
+		name := fmt.Sprintf("fd%d", i)
+		params[name] = id
+		clauses = append(clauses, "field_definition = {:"+name+"}")
+	}
+	return "(" + strings.Join(clauses, " || ") + ")"
 }
 
 // ingestContext is one observed cabin value, ready to resolve and attribute.
@@ -335,11 +389,7 @@ func (s *LodgingAssignmentsSync) ingestValue(in *ingestContext) {
 	}
 	input.UnitID, input.MergeID = unitID, mergeID
 
-	size, err := s.partySize(in, attr.SessionID)
-	if err != nil {
-		slog.Error("Computing party size", "raw", in.Raw, "error", err)
-	}
-	input.PartySize = size
+	input.PartySize = s.partySize(in, attr.SessionID)
 
 	if s.DryRun {
 		return
@@ -545,51 +595,80 @@ func (s *LodgingAssignmentsSync) recordHistory(
 	})
 }
 
+// buildPartySizeIndexes loads everything partySize needs in three scans.
+//
+// persons and attendees are hard requirements -- a wrong party size is a wrong
+// cabin capacity. The adults table is not: party_size is a display
+// denormalisation, and a child count alone is more useful to the board than
+// failing the whole ingest because that table is missing or unreadable, so a
+// failure there warns and leaves the index empty.
+func (s *LodgingAssignmentsSync) buildPartySizeIndexes(year int) error {
+	persons, err := findAllRecords(s.App, "persons", fmt.Sprintf("year = %d", year))
+	if err != nil {
+		return fmt.Errorf("indexing persons for party size: %w", err)
+	}
+	s.personsByHouseholdCMID = make(map[int][]*core.Record)
+	for _, p := range persons {
+		if hh := p.GetInt("household_id"); hh > 0 {
+			s.personsByHouseholdCMID[hh] = append(s.personsByHouseholdCMID[hh], p)
+		}
+	}
+
+	attendees, err := findAllRecords(s.App, "attendees",
+		fmt.Sprintf("year = %d && status_id = %d", year, statusIDActiveEnrolled))
+	if err != nil {
+		return fmt.Errorf("indexing attendees for party size: %w", err)
+	}
+	s.enrolledByPersonSession = make(map[string]int, len(attendees))
+	for _, a := range attendees {
+		s.enrolledByPersonSession[a.GetString("person")+"|"+a.GetString("session")]++
+	}
+
+	s.adultsByHouseholdPBID = make(map[string]int)
+	adults, err := findAllRecords(s.App, "family_camp_adults", fmt.Sprintf("year = %d", year))
+	if err != nil {
+		slog.Warn("Adult index unavailable; party sizes will cover children only",
+			"year", year, "error", err)
+		return nil //nolint:nilerr // see the doc comment
+	}
+	for _, a := range adults {
+		if hh := a.GetString("household"); hh != "" {
+			s.adultsByHouseholdPBID[hh]++
+		}
+	}
+	return nil
+}
+
 // partySize counts the people this placement has to hold: actively enrolled
 // persons for the session plus, at household grain, the accompanying adults
 // CampMinder does not enroll (they exist only as custom-field values, scraped
 // into family_camp_adults).
-func (s *LodgingAssignmentsSync) partySize(in *ingestContext, sessionID string) (int, error) {
+func (s *LodgingAssignmentsSync) partySize(in *ingestContext, sessionID string) int {
 	if in.PersonCMID > 0 {
-		return 1, nil
-	}
-	persons, err := findAllRecords(s.App, "persons",
-		fmt.Sprintf("year = %d && household_id = %d", in.Year, in.HouseholdCMID))
-	if err != nil {
-		return 0, err
-	}
-	enrolled := 0
-	for _, p := range persons {
-		rows, findErr := s.App.FindRecordsByFilter("attendees",
-			"person = {:p} && session = {:s} && status_id = {:st}", "", 1, 0, dbx.Params{
-				"p": p.Id, "s": sessionID, "st": statusIDActiveEnrolled,
-			})
-		if findErr != nil {
-			return 0, fmt.Errorf("counting attendees: %w", findErr)
-		}
-		enrolled += len(rows)
+		return 1
 	}
 
-	adults, err := findAllRecords(s.App, "family_camp_adults",
-		fmt.Sprintf("year = %d", in.Year))
-	if err != nil {
-		// Deliberate swallow: party_size is a display denormalisation, and a
-		// child count alone is more useful to the board than failing the whole
-		// ingest because the adults table is missing or unreadable.
-		slog.Warn("Adult count unavailable; party size covers children only",
-			"household_cm_id", in.HouseholdCMID, "error", err)
-		return enrolled, nil //nolint:nilerr // see above
-	}
-	adultCount := 0
-	for _, a := range adults {
-		for _, p := range persons {
-			if a.GetString("household") == p.GetString("household") && p.GetString("household") != "" {
-				adultCount++
-				break
-			}
+	enrolled := 0
+	householdPBIDs := make(map[string]bool, 1)
+	for _, p := range s.personsByHouseholdCMID[in.HouseholdCMID] {
+		// One bed per person: a duplicate attendee row for the same person and
+		// weekend is a data anomaly, not a second occupant, so this counts people
+		// with an enrolment rather than enrolment rows.
+		if s.enrolledByPersonSession[p.Id+"|"+sessionID] > 0 {
+			enrolled++
+		}
+		if hh := p.GetString("household"); hh != "" {
+			householdPBIDs[hh] = true
 		}
 	}
-	return enrolled + adultCount, nil
+
+	// Counted over the household's DISTINCT PocketBase ids, so an adult is
+	// counted once however many enrolled children share that household.
+	adultCount := 0
+	for hh := range householdPBIDs {
+		adultCount += s.adultsByHouseholdPBID[hh]
+	}
+	return enrolled + adultCount
 }
 
 // cmIDsByPBID maps a collection's PB record id -> its CampMinder id for one
@@ -622,17 +701,26 @@ func (s *LodgingAssignmentsSync) valueCountsByCMID(year int, fieldTargets map[st
 		cmIDByPBID[d.Id] = d.GetInt("cm_id")
 	}
 
+	// Scoped to the mapped definitions for the same reason as the grain scans:
+	// counting a prior year must not page through 181k person_custom_values rows.
+	defIDs := make([]string, 0, len(fieldTargets))
+	for defID := range fieldTargets {
+		defIDs = append(defIDs, defID)
+	}
+	if len(defIDs) == 0 {
+		return out, nil
+	}
+	slices.Sort(defIDs)
+
 	for _, collection := range []string{"household_custom_values", "person_custom_values"} {
-		rows, findErr := findAllRecords(s.App, collection, fmt.Sprintf("year = %d && value != ''", year))
+		params := dbx.Params{}
+		rows, findErr := findAllRecords(s.App, collection,
+			fmt.Sprintf("year = %d && value != '' && %s", year, fieldDefClause(defIDs, params)), params)
 		if findErr != nil {
 			return out, findErr
 		}
 		for _, r := range rows {
-			defPBID := r.GetString("field_definition")
-			if _, mapped := fieldTargets[defPBID]; !mapped {
-				continue
-			}
-			out[cmIDByPBID[defPBID]]++
+			out[cmIDByPBID[r.GetString("field_definition")]]++
 		}
 	}
 	return out, nil

--- a/pocketbase/sync/lodging_assignments_sync.go
+++ b/pocketbase/sync/lodging_assignments_sync.go
@@ -96,6 +96,10 @@ func (s *LodgingAssignmentsSync) Sync(ctx context.Context) error {
 		return hhErr
 	}
 
+	if personErr := s.syncPersonGrain(ctx, year, fieldTargets, counts, now); personErr != nil {
+		return personErr
+	}
+
 	if s.DryRun {
 		slog.Info("Dry run - computed but not writing", "year", year)
 		s.SyncSuccessful = true
@@ -159,7 +163,7 @@ func (s *LodgingAssignmentsSync) syncHouseholdGrain(
 	if err != nil {
 		return fmt.Errorf("building household session index: %w", err)
 	}
-	householdCMIDs, err := s.householdCMIDsByPBID(year)
+	householdCMIDs, err := s.cmIDsByPBID("households", year)
 	if err != nil {
 		return err
 	}
@@ -195,6 +199,61 @@ func (s *LodgingAssignmentsSync) syncHouseholdGrain(
 			Candidates:    sessionIndex[hhCMID],
 			LastUpdated:   lastUpdated,
 			Now:           now,
+		})
+	}
+	return nil
+}
+
+// syncPersonGrain ingests "Reportable Family Camp Cabin" -- partition
+// ["Camper","Adult"], person_custom_values, adult weekends.
+//
+// Measured against 2024/2025: every one of these values whose person has an
+// active enrolment is enrolled in an `adult` session and none in a `family` one,
+// so the candidate set is adult sessions. The handful with no enrolment at all
+// (5 in 2024, 4 in 2025) fall through to a no_session queue item.
+func (s *LodgingAssignmentsSync) syncPersonGrain(
+	ctx context.Context, year int, fieldTargets map[string]string, counts map[int]int, now time.Time,
+) error {
+	sessionIndex, err := BuildPersonSessionIndex(s.App, year, []string{sessionTypeAdult})
+	if err != nil {
+		return fmt.Errorf("building person session index: %w", err)
+	}
+	personCMIDs, err := s.cmIDsByPBID("persons", year)
+	if err != nil {
+		return err
+	}
+
+	values, err := findAllRecords(s.App, "person_custom_values",
+		fmt.Sprintf("year = %d && value != ''", year))
+	if err != nil {
+		return err
+	}
+
+	for _, v := range values {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		if fieldTargets[v.GetString("field_definition")] != targetCabinAssignmentPerson {
+			continue
+		}
+		counts[cmIDReportableFamilyCampCabin]++
+
+		personCMID := personCMIDs[v.GetString("person")]
+		if personCMID == 0 {
+			continue // person row missing for this year; nothing to key on
+		}
+
+		lastUpdated, _ := ParseCampMinderTimestamp(v.GetString("last_updated"))
+		s.ingestValue(&ingestContext{
+			Year:        year,
+			Raw:         v.GetString("value"),
+			SourceField: fieldNameReportableFamilyCampCabin,
+			PersonCMID:  personCMID,
+			Candidates:  sessionIndex[personCMID],
+			LastUpdated: lastUpdated,
+			Now:         now,
 		})
 	}
 	return nil
@@ -533,11 +592,13 @@ func (s *LodgingAssignmentsSync) partySize(in *ingestContext, sessionID string) 
 	return enrolled + adultCount, nil
 }
 
-// householdCMIDsByPBID maps households PB record id -> CampMinder id, because
-// household_custom_values.household is a PB relation while every cross-table
-// key in this project is a CampMinder id.
-func (s *LodgingAssignmentsSync) householdCMIDsByPBID(year int) (map[string]int, error) {
-	records, err := findAllRecords(s.App, "households", fmt.Sprintf("year = %d", year))
+// cmIDsByPBID maps a collection's PB record id -> its CampMinder id for one
+// year. Both custom-value tables address their party by PB relation
+// (household_custom_values.household, person_custom_values.person) while every
+// cross-table key in this project is a CampMinder id, so each grain needs this
+// translation before it can key an assignment.
+func (s *LodgingAssignmentsSync) cmIDsByPBID(collection string, year int) (map[string]int, error) {
+	records, err := findAllRecords(s.App, collection, fmt.Sprintf("year = %d", year))
 	if err != nil {
 		return nil, err
 	}

--- a/pocketbase/sync/lodging_assignments_sync.go
+++ b/pocketbase/sync/lodging_assignments_sync.go
@@ -151,10 +151,14 @@ func (s *LodgingAssignmentsSync) Sync(ctx context.Context) error {
 	}
 
 	s.SyncSuccessful = true
-	if s.Stats.Created > 0 || s.Stats.Updated > 0 || s.Stats.Deleted > 0 {
-		if err := s.forceWALCheckpoint(); err != nil {
-			slog.Warn("WAL checkpoint failed", "error", err)
-		}
+	// Unconditional, unlike the sibling derived syncs that gate on
+	// Stats.Created/Updated/Deleted. Those counters only track assignment rows,
+	// and this job has three other writers that never touch them: writeHistory
+	// for unresolved placements, the work-queue Flush above, and
+	// UpsertFieldMappingStatus, which writes a row per source field on every run
+	// whatever it found. Reaching this line therefore means the database changed.
+	if err := s.forceWALCheckpoint(); err != nil {
+		slog.Warn("WAL checkpoint failed", "error", err)
 	}
 
 	slog.Info("Lodging assignment ingest completed",
@@ -203,7 +207,16 @@ func (s *LodgingAssignmentsSync) syncHouseholdGrain(
 
 		hhCMID := householdCMIDs[v.GetString("household")]
 		if hhCMID == 0 {
-			continue // household row missing for this year; nothing to key on
+			// No CampMinder id to key a placement on. The value was still
+			// observed, and counts[] above has already counted it, so dropping
+			// it here would hide it from the field_zero_values warning too.
+			s.issues.Record(Issue{
+				Kind:        issueUnknownParty,
+				RawValue:    v.GetString("value"),
+				SourceField: fieldNameFamilyCampCabin,
+				Year:        year,
+			})
+			continue
 		}
 
 		lastUpdated, _ := ParseCampMinderTimestamp(v.GetString("last_updated"))
@@ -260,7 +273,15 @@ func (s *LodgingAssignmentsSync) syncPersonGrain(
 
 		personCMID := personCMIDs[v.GetString("person")]
 		if personCMID == 0 {
-			continue // person row missing for this year; nothing to key on
+			// See the household-grain twin above: counted, unkeyable, and so
+			// invisible to every other signal unless it is queued here.
+			s.issues.Record(Issue{
+				Kind:        issueUnknownParty,
+				RawValue:    v.GetString("value"),
+				SourceField: fieldNameReportableFamilyCampCabin,
+				Year:        year,
+			})
+			continue
 		}
 
 		lastUpdated, _ := ParseCampMinderTimestamp(v.GetString("last_updated"))
@@ -359,7 +380,19 @@ func (s *LodgingAssignmentsSync) ingestValue(in *ingestContext) {
 	// old_unit / new_unit are TEXT for exactly this reason.
 	label := in.Raw
 	if res.Resolved {
-		label = strings.Join(res.UnitCodes, "+")
+		label = unitLabel(res.UnitCodes)
+	}
+
+	// Everything above this line computes; everything below it writes. The guard
+	// belongs here and not further down because two of the write paths are
+	// upstream of the placement itself: recordHistory inserts into
+	// lodging_assignment_history, and placementFor -> EnsureMerge inserts into
+	// lodging_merges. A guard placed just before upsertAssignment honors
+	// DryRun's "compute but do not write" for one table and breaks it for two.
+	// The work queue is unaffected either way -- Record is in-memory, and Sync
+	// returns before Flush on a dry run.
+	if s.DryRun {
+		return
 	}
 
 	if !res.Resolved {
@@ -385,19 +418,36 @@ func (s *LodgingAssignmentsSync) ingestValue(in *ingestContext) {
 	if err != nil {
 		slog.Error("Materializing merge", "raw", in.Raw, "error", err)
 		s.Stats.Errors++
+		s.recordWriteFailure(in)
 		return
 	}
 	input.UnitID, input.MergeID = unitID, mergeID
 
 	input.PartySize = s.partySize(in, attr.SessionID)
 
-	if s.DryRun {
-		return
-	}
 	if err := s.upsertAssignment(&input, in.Now); err != nil {
 		slog.Error("Upserting lodging assignment", "raw", in.Raw, "error", err)
 		s.Stats.Errors++
+		s.recordWriteFailure(in)
 	}
+}
+
+// recordWriteFailure queues a value the ingest resolved and attributed but could
+// not persist.
+//
+// Stats.Errors and the log line already record it, but Stats is never written
+// anywhere and the log rotates, so without this the value is accounted for
+// nowhere the morning after -- the silent drop spec 6.2 rules out, arrived at by
+// a different route than an unmapped string.
+func (s *LodgingAssignmentsSync) recordWriteFailure(in *ingestContext) {
+	s.issues.Record(Issue{
+		Kind:          issueWriteFailed,
+		RawValue:      in.Raw,
+		SourceField:   in.SourceField,
+		Year:          in.Year,
+		HouseholdCMID: in.HouseholdCMID,
+		PersonCMID:    in.PersonCMID,
+	})
 }
 
 // placementFor turns a resolution into the one placement column it belongs in.
@@ -440,9 +490,18 @@ func (s *LodgingAssignmentsSync) upsertAssignment(in *assignmentInput, now time.
 		return nil
 	}
 
-	oldLabel := ""
+	// Snapshot BEFORE the rec.Set calls below. rec aliases existing on the update
+	// path, so every Set mutates the record the comparison would read -- a
+	// changed-check written against existing after the Sets compares the new
+	// payload with itself and concludes nothing changed, every time.
+	oldLabel, oldUnit, oldMerge, oldSource := "", "", "", ""
+	oldPartySize := 0
 	if existing != nil {
 		oldLabel = s.labelOf(existing)
+		oldUnit = existing.GetString("unit")
+		oldMerge = existing.GetString("merge")
+		oldSource = existing.GetString("source")
+		oldPartySize = existing.GetInt("party_size")
 	}
 
 	rec := existing
@@ -468,7 +527,19 @@ func (s *LodgingAssignmentsSync) upsertAssignment(in *assignmentInput, now time.
 	rec.Set("party_size", in.PartySize)
 	rec.Set("source", sourceCampMinderSync)
 
-	if oldLabel == in.NewUnitLabel && !isNew {
+	// The label answers "did this party MOVE"; it does not answer "did anything
+	// change". party_size is recomputed every run from enrolment and the adults
+	// table, both of which move independently of the cabin string, so skipping
+	// on the label alone discards a corrected occupancy count for as long as the
+	// household stays put -- and buildPartySizeIndexes exists precisely because
+	// a wrong party size is a wrong cabin capacity.
+	changed := isNew ||
+		oldLabel != in.NewUnitLabel ||
+		oldUnit != in.UnitID ||
+		oldMerge != in.MergeID ||
+		oldPartySize != in.PartySize ||
+		oldSource != sourceCampMinderSync
+	if !changed {
 		s.Stats.Skipped++
 		return nil
 	}
@@ -479,6 +550,13 @@ func (s *LodgingAssignmentsSync) upsertAssignment(in *assignmentInput, now time.
 		s.Stats.Created++
 	} else {
 		s.Stats.Updated++
+	}
+
+	// History is a record of MOVES. A party-size correction in the same cabin is
+	// not one, and appending a row for it would fill the audit trail with
+	// old_unit == new_unit noise.
+	if !isNew && oldLabel == in.NewUnitLabel {
+		return nil
 	}
 
 	return s.writeHistory(&historyInput{
@@ -544,7 +622,22 @@ func (s *LodgingAssignmentsSync) labelOf(rec *core.Record) string {
 	for _, id := range merge.GetStringSlice("member_units") {
 		codes = append(codes, s.resolver.UnitCode(id))
 	}
-	return strings.Join(codes, "+")
+	return unitLabel(codes)
+}
+
+// unitLabel renders member unit codes as a placement label.
+//
+// The sort is what makes the label comparable. A merge is keyed on the member
+// SET, not the slice -- unitSetKey sorts, so two aliases naming the same rooms
+// in different orders resolve to ONE merge row, which then keeps whichever
+// order created it. Joining in stored order would make the label of that shared
+// row depend on which alias was seen first, so the same placement would read as
+// a move on the next run: a re-save and a history row for a household that never
+// left its cabin.
+func unitLabel(codes []string) string {
+	sorted := slices.Clone(codes)
+	slices.Sort(sorted)
+	return strings.Join(sorted, "+")
 }
 
 type historyInput struct {

--- a/pocketbase/sync/lodging_assignments_sync.go
+++ b/pocketbase/sync/lodging_assignments_sync.go
@@ -1,0 +1,589 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+const serviceNameLodgingAssignments = "lodging_assignments"
+
+// sourceCampMinderSync labels rows this ingest wrote, so the Plan 3 board can
+// distinguish them from staff placements.
+const sourceCampMinderSync = "campminder_sync"
+
+// LodgingAssignmentsSync derives lodging_assignments from the two CampMinder
+// cabin custom fields.
+//
+// Like family_camp_derived it calls no external API: it reads
+// household_custom_values / person_custom_values / attendees / persons /
+// camp_sessions and the lodging registry, all from PocketBase.
+type LodgingAssignmentsSync struct {
+	App            core.App
+	Year           int  // 0 = current year from env
+	DryRun         bool // compute but do not write
+	Debug          bool
+	Stats          Stats
+	SyncSuccessful bool
+
+	resolver *AliasResolver
+	issues   *IssueRecorder
+}
+
+// NewLodgingAssignmentsSync builds the service. Year 0 means "resolve from the
+// CAMPMINDER_SEASON_ID env var at Sync time".
+func NewLodgingAssignmentsSync(app core.App) *LodgingAssignmentsSync {
+	return &LodgingAssignmentsSync{App: app}
+}
+
+// Name returns the orchestrator's identifier for this job.
+func (s *LodgingAssignmentsSync) Name() string { return serviceNameLodgingAssignments }
+
+// GetStats returns the counters from the most recent Sync.
+func (s *LodgingAssignmentsSync) GetStats() Stats { return s.Stats }
+
+// SetDebug enables verbose logging (the orchestrator's Debuggable interface).
+func (s *LodgingAssignmentsSync) SetDebug(debug bool) { s.Debug = debug }
+
+// SetYear sets the year to compute (the orchestrator's YearSetter interface).
+func (s *LodgingAssignmentsSync) SetYear(year int) { s.Year = year }
+
+func (s *LodgingAssignmentsSync) debugLog(msg string, args ...any) {
+	if s.Debug {
+		slog.Info(msg, args...)
+	}
+}
+
+// Sync computes and writes lodging assignments for one year.
+func (s *LodgingAssignmentsSync) Sync(ctx context.Context) error {
+	s.Stats = Stats{}
+	s.SyncSuccessful = false
+
+	year := s.Year
+	if year == 0 {
+		var err error
+		year, err = ParseSeasonYear()
+		if err != nil {
+			return fmt.Errorf("year resolution failed: %w", err)
+		}
+	}
+	if year < 2017 || year > 2050 {
+		return fmt.Errorf("invalid year %d: must be between 2017 and 2050", year)
+	}
+
+	slog.Info("Starting lodging assignment ingest", "year", year, "dry_run", s.DryRun)
+
+	var err error
+	if s.resolver, err = NewAliasResolver(s.App); err != nil {
+		return fmt.Errorf("building alias resolver: %w", err)
+	}
+	s.issues = NewIssueRecorder(s.App, year)
+
+	fieldTargets, err := LodgingFieldDefIDs(s.App)
+	if err != nil {
+		return fmt.Errorf("loading source field mappings: %w", err)
+	}
+
+	now := time.Now().UTC()
+	counts := map[int]int{}
+
+	if hhErr := s.syncHouseholdGrain(ctx, year, fieldTargets, counts, now); hhErr != nil {
+		return hhErr
+	}
+
+	if s.DryRun {
+		slog.Info("Dry run - computed but not writing", "year", year)
+		s.SyncSuccessful = true
+		return nil
+	}
+
+	priorCounts, err := s.valueCountsByCMID(year-1, fieldTargets)
+	if err != nil {
+		return err
+	}
+
+	// Spec 4.4's passive warning: a mapped field that saw values last year and
+	// none this year. It is a warning and never an auto-disable -- a form that
+	// has not been sent yet looks exactly like a retired field, and inferring
+	// retirement would have silently dropped FAM CAMP-Share Comments.
+	for _, f := range lodgingSourceFields {
+		if counts[f.CMID] == 0 && priorCounts[f.CMID] > 0 {
+			s.issues.Record(Issue{
+				Kind:        issueFieldZeroValues,
+				RawValue:    f.Name,
+				SourceField: f.Name,
+				Year:        year,
+			})
+		}
+	}
+
+	issuesCreated, issuesUpdated, err := s.issues.Flush(now)
+	if err != nil {
+		return fmt.Errorf("flushing ingest issues: %w", err)
+	}
+	s.debugLog("Work queue flushed", "created", issuesCreated, "updated", issuesUpdated)
+
+	if err := UpsertFieldMappingStatus(s.App, year, counts, priorCounts); err != nil {
+		return fmt.Errorf("updating field mapping status: %w", err)
+	}
+
+	s.SyncSuccessful = true
+	if s.Stats.Created > 0 || s.Stats.Updated > 0 || s.Stats.Deleted > 0 {
+		if err := s.forceWALCheckpoint(); err != nil {
+			slog.Warn("WAL checkpoint failed", "error", err)
+		}
+	}
+
+	slog.Info("Lodging assignment ingest completed",
+		"year", year,
+		"created", s.Stats.Created,
+		"updated", s.Stats.Updated,
+		"skipped", s.Stats.Skipped,
+		"errors", s.Stats.Errors,
+		"queued_issues", issuesCreated+issuesUpdated,
+	)
+	return nil
+}
+
+// syncHouseholdGrain ingests "Family Camp Cabin" -- partition ["Family"], one
+// value per household per YEAR, family sessions only.
+func (s *LodgingAssignmentsSync) syncHouseholdGrain(
+	ctx context.Context, year int, fieldTargets map[string]string, counts map[int]int, now time.Time,
+) error {
+	sessionIndex, err := BuildHouseholdSessionIndex(s.App, year, []string{sessionTypeFamily})
+	if err != nil {
+		return fmt.Errorf("building household session index: %w", err)
+	}
+	householdCMIDs, err := s.householdCMIDsByPBID(year)
+	if err != nil {
+		return err
+	}
+
+	values, err := findAllRecords(s.App, "household_custom_values",
+		fmt.Sprintf("year = %d && value != ''", year))
+	if err != nil {
+		return err
+	}
+
+	for _, v := range values {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		if fieldTargets[v.GetString("field_definition")] != targetCabinAssignmentHousehold {
+			continue
+		}
+		counts[cmIDFamilyCampCabin]++
+
+		hhCMID := householdCMIDs[v.GetString("household")]
+		if hhCMID == 0 {
+			continue // household row missing for this year; nothing to key on
+		}
+
+		lastUpdated, _ := ParseCampMinderTimestamp(v.GetString("last_updated"))
+		s.ingestValue(&ingestContext{
+			Year:          year,
+			Raw:           v.GetString("value"),
+			SourceField:   fieldNameFamilyCampCabin,
+			HouseholdCMID: hhCMID,
+			Candidates:    sessionIndex[hhCMID],
+			LastUpdated:   lastUpdated,
+			Now:           now,
+		})
+	}
+	return nil
+}
+
+// ingestContext is one observed cabin value, ready to resolve and attribute.
+type ingestContext struct {
+	Year          int
+	Raw           string
+	SourceField   string
+	HouseholdCMID int
+	PersonCMID    int
+	Candidates    []SessionWindow
+	LastUpdated   time.Time
+	Now           time.Time
+}
+
+// ingestValue resolves, attributes, and writes one observed cabin value.
+// Every failure path queues a work item; none drops the value and none errors
+// out of the run.
+func (s *LodgingAssignmentsSync) ingestValue(in *ingestContext) {
+	res := s.resolver.Resolve(in.Raw, in.Year)
+	if !res.Resolved {
+		kind := issueUnresolvedAlias
+		if res.Ambiguous {
+			kind = issueAmbiguousAlias
+		}
+		s.issues.Record(Issue{
+			Kind: kind, RawValue: in.Raw, SourceField: in.SourceField, Year: in.Year,
+		})
+	}
+
+	attr := AttributeSession(in.Candidates, in.LastUpdated)
+	if attr.Reason != attrSingleSession {
+		s.issues.Record(Issue{
+			Kind:             attr.Reason,
+			RawValue:         in.Raw,
+			SourceField:      in.SourceField,
+			Year:             in.Year,
+			HouseholdCMID:    in.HouseholdCMID,
+			PersonCMID:       in.PersonCMID,
+			SuggestedSession: attr.BestGuess,
+			CandidateCMIDs:   attr.CandidateCMIDs(),
+		})
+		return // flag, do not guess (spec 3.6)
+	}
+
+	// History records the OBSERVED label whether or not it resolved --
+	// old_unit / new_unit are TEXT for exactly this reason.
+	label := in.Raw
+	if res.Resolved {
+		label = strings.Join(res.UnitCodes, "+")
+	}
+
+	if !res.Resolved {
+		// Nothing to point a placement at, but the observation is preserved in
+		// history and the string is already in the work queue.
+		if err := s.recordHistory(in, attr.SessionID, attr.SessionCMID(), label); err != nil {
+			slog.Error("Recording unresolved-placement history", "raw", in.Raw, "error", err)
+			s.Stats.Errors++
+		}
+		return
+	}
+
+	input := assignmentInput{
+		SessionID:     attr.SessionID,
+		SessionCMID:   attr.SessionCMID(),
+		Year:          in.Year,
+		HouseholdCMID: in.HouseholdCMID,
+		PersonCMID:    in.PersonCMID,
+		SourceField:   in.SourceField,
+		NewUnitLabel:  label,
+	}
+	unitID, mergeID, err := s.placementFor(res, input.SessionID, input.SessionCMID, in.Year, in.Raw)
+	if err != nil {
+		slog.Error("Materializing merge", "raw", in.Raw, "error", err)
+		s.Stats.Errors++
+		return
+	}
+	input.UnitID, input.MergeID = unitID, mergeID
+
+	size, err := s.partySize(in, attr.SessionID)
+	if err != nil {
+		slog.Error("Computing party size", "raw", in.Raw, "error", err)
+	}
+	input.PartySize = size
+
+	if s.DryRun {
+		return
+	}
+	if err := s.upsertAssignment(&input, in.Now); err != nil {
+		slog.Error("Upserting lodging assignment", "raw", in.Raw, "error", err)
+		s.Stats.Errors++
+	}
+}
+
+// placementFor turns a resolution into the one placement column it belongs in.
+// A multi-room alias is materialized as a merge row; a single room points
+// straight at the unit. Exactly one of the two is ever non-empty, which is what
+// ValidateAssignmentGrain then checks.
+func (s *LodgingAssignmentsSync) placementFor(
+	res AliasResolution, sessionID string, sessionCMID, year int, raw string,
+) (unitID, mergeID string, err error) {
+	if !res.IsMerge() {
+		return res.UnitIDs[0], "", nil
+	}
+	mergeID, err = EnsureMerge(s.App, sessionID, sessionCMID, year, "", res.UnitIDs, raw)
+	if err != nil {
+		return "", "", err
+	}
+	return "", mergeID, nil
+}
+
+// upsertAssignment writes the placement and appends a history row when the
+// observed label differs from what is stored.
+//
+// A staff_touched row is left untouched: a human moved that party on the board
+// and CampMinder must not undo it. staff_touched is one-way and GUI-written.
+func (s *LodgingAssignmentsSync) upsertAssignment(in *assignmentInput, now time.Time) error {
+	if err := ValidateAssignmentGrain(AssignmentGrain{
+		HouseholdCMID: in.HouseholdCMID, PersonCMID: in.PersonCMID,
+		UnitID: in.UnitID, MergeID: in.MergeID,
+	}); err != nil {
+		return fmt.Errorf("refusing to write an illegal assignment: %w", err)
+	}
+
+	existing, err := s.findAssignment(in)
+	if err != nil {
+		return err
+	}
+
+	if existing != nil && existing.GetBool("staff_touched") {
+		s.Stats.Skipped++
+		return nil
+	}
+
+	oldLabel := ""
+	if existing != nil {
+		oldLabel = s.labelOf(existing)
+	}
+
+	rec := existing
+	isNew := rec == nil
+	if isNew {
+		col, findErr := s.App.FindCollectionByNameOrId("lodging_assignments")
+		if findErr != nil {
+			return fmt.Errorf("finding lodging_assignments: %w", findErr)
+		}
+		rec = core.NewRecord(col)
+		rec.Set("session", in.SessionID)
+		// Required (migration 1500000124). PocketBase's Set on a column that does
+		// not exist is a silent no-op, so a schema that has not caught up shows up
+		// as a required-field validation error here rather than as a wrong row.
+		rec.Set("session_cm_id", in.SessionCMID)
+		rec.Set("year", in.Year)
+		rec.Set("household_cm_id", in.HouseholdCMID)
+		rec.Set("person_cm_id", in.PersonCMID)
+		rec.Set("staff_touched", false)
+	}
+	rec.Set("unit", in.UnitID)
+	rec.Set("merge", in.MergeID)
+	rec.Set("party_size", in.PartySize)
+	rec.Set("source", sourceCampMinderSync)
+
+	if oldLabel == in.NewUnitLabel && !isNew {
+		s.Stats.Skipped++
+		return nil
+	}
+	if err := s.App.Save(rec); err != nil {
+		return fmt.Errorf("saving assignment: %w", err)
+	}
+	if isNew {
+		s.Stats.Created++
+	} else {
+		s.Stats.Updated++
+	}
+
+	return s.writeHistory(&historyInput{
+		HouseholdCMID: in.HouseholdCMID, PersonCMID: in.PersonCMID,
+		SessionID: in.SessionID, SessionCMID: in.SessionCMID, Year: in.Year,
+		OldUnit: oldLabel, NewUnit: in.NewUnitLabel,
+		SourceField: in.SourceField, Now: now,
+	})
+}
+
+// assignmentInput is one resolved placement ready to write.
+type assignmentInput struct {
+	SessionID     string
+	SessionCMID   int
+	Year          int
+	HouseholdCMID int
+	PersonCMID    int
+	UnitID        string
+	MergeID       string
+	PartySize     int
+	SourceField   string
+	NewUnitLabel  string
+}
+
+func (s *LodgingAssignmentsSync) findAssignment(in *assignmentInput) (*core.Record, error) {
+	// scenario = the empty string is the live plan, written as a literal: a BOUND
+	// empty parameter matches nothing in PocketBase, so binding it here would miss
+	// the row every run and insert a duplicate. Note `> 0` is not used on the party
+	// ids because both are compared to a known value, but never write `!= ''`
+	// against these columns: PocketBase numbers are NUMERIC DEFAULT 0 NOT NULL and
+	// SQLite treats 0-vs-empty-string inequality as TRUE, which would match every
+	// row of the other grain.
+	const filter = "session = {:session} && year = {:year} && scenario = '' && " +
+		"household_cm_id = {:hh} && person_cm_id = {:person}"
+	rows, err := s.App.FindRecordsByFilter("lodging_assignments", filter, "", 1, 0, dbx.Params{
+		"session": in.SessionID, "year": in.Year,
+		"hh": in.HouseholdCMID, "person": in.PersonCMID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("looking up assignment: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	return rows[0], nil
+}
+
+// labelOf renders an existing assignment's placement the same way ingestValue
+// renders an observed one, so the two are comparable.
+func (s *LodgingAssignmentsSync) labelOf(rec *core.Record) string {
+	if unitID := rec.GetString("unit"); unitID != "" {
+		return s.resolver.UnitCode(unitID)
+	}
+	mergeID := rec.GetString("merge")
+	if mergeID == "" {
+		return ""
+	}
+	merge, err := s.App.FindRecordById("lodging_merges", mergeID)
+	if err != nil {
+		return ""
+	}
+	codes := make([]string, 0, 2)
+	for _, id := range merge.GetStringSlice("member_units") {
+		codes = append(codes, s.resolver.UnitCode(id))
+	}
+	return strings.Join(codes, "+")
+}
+
+type historyInput struct {
+	HouseholdCMID int
+	PersonCMID    int
+	SessionID     string
+	SessionCMID   int
+	Year          int
+	OldUnit       string
+	NewUnit       string
+	SourceField   string
+	Now           time.Time
+}
+
+func (s *LodgingAssignmentsSync) writeHistory(in *historyInput) error {
+	col, err := s.App.FindCollectionByNameOrId("lodging_assignment_history")
+	if err != nil {
+		return fmt.Errorf("finding lodging_assignment_history: %w", err)
+	}
+	rec := core.NewRecord(col)
+	rec.Set("household_cm_id", in.HouseholdCMID)
+	rec.Set("person_cm_id", in.PersonCMID)
+	rec.Set("session", in.SessionID)
+	// Optional here, unlike the placement tables, because a history row is meant
+	// to outlive its session with `session` blanked. This is the column that lets
+	// such a row still name the weekend it described.
+	rec.Set("session_cm_id", in.SessionCMID)
+	rec.Set("year", in.Year)
+	rec.Set("old_unit", in.OldUnit)
+	rec.Set("new_unit", in.NewUnit)
+	rec.Set("detected_at", in.Now.Format("2006-01-02 15:04:05.000Z"))
+	rec.Set("source_field", in.SourceField)
+	if err := s.App.Save(rec); err != nil {
+		return fmt.Errorf("saving history: %w", err)
+	}
+	return nil
+}
+
+// recordHistory logs an observation that has no resolvable placement.
+func (s *LodgingAssignmentsSync) recordHistory(
+	in *ingestContext, sessionID string, sessionCMID int, label string,
+) error {
+	return s.writeHistory(&historyInput{
+		HouseholdCMID: in.HouseholdCMID, PersonCMID: in.PersonCMID,
+		SessionID: sessionID, SessionCMID: sessionCMID, Year: in.Year,
+		OldUnit: "", NewUnit: label,
+		SourceField: in.SourceField, Now: in.Now,
+	})
+}
+
+// partySize counts the people this placement has to hold: actively enrolled
+// persons for the session plus, at household grain, the accompanying adults
+// CampMinder does not enroll (they exist only as custom-field values, scraped
+// into family_camp_adults).
+func (s *LodgingAssignmentsSync) partySize(in *ingestContext, sessionID string) (int, error) {
+	if in.PersonCMID > 0 {
+		return 1, nil
+	}
+	persons, err := findAllRecords(s.App, "persons",
+		fmt.Sprintf("year = %d && household_id = %d", in.Year, in.HouseholdCMID))
+	if err != nil {
+		return 0, err
+	}
+	enrolled := 0
+	for _, p := range persons {
+		rows, findErr := s.App.FindRecordsByFilter("attendees",
+			"person = {:p} && session = {:s} && status_id = {:st}", "", 1, 0, dbx.Params{
+				"p": p.Id, "s": sessionID, "st": statusIDActiveEnrolled,
+			})
+		if findErr != nil {
+			return 0, fmt.Errorf("counting attendees: %w", findErr)
+		}
+		enrolled += len(rows)
+	}
+
+	adults, err := findAllRecords(s.App, "family_camp_adults",
+		fmt.Sprintf("year = %d", in.Year))
+	if err != nil {
+		// Deliberate swallow: party_size is a display denormalisation, and a
+		// child count alone is more useful to the board than failing the whole
+		// ingest because the adults table is missing or unreadable.
+		slog.Warn("Adult count unavailable; party size covers children only",
+			"household_cm_id", in.HouseholdCMID, "error", err)
+		return enrolled, nil //nolint:nilerr // see above
+	}
+	adultCount := 0
+	for _, a := range adults {
+		for _, p := range persons {
+			if a.GetString("household") == p.GetString("household") && p.GetString("household") != "" {
+				adultCount++
+				break
+			}
+		}
+	}
+	return enrolled + adultCount, nil
+}
+
+// householdCMIDsByPBID maps households PB record id -> CampMinder id, because
+// household_custom_values.household is a PB relation while every cross-table
+// key in this project is a CampMinder id.
+func (s *LodgingAssignmentsSync) householdCMIDsByPBID(year int) (map[string]int, error) {
+	records, err := findAllRecords(s.App, "households", fmt.Sprintf("year = %d", year))
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]int, len(records))
+	for _, r := range records {
+		out[r.Id] = r.GetInt("cm_id")
+	}
+	return out, nil
+}
+
+// valueCountsByCMID counts observed values per source field for a year, feeding
+// spec 4.4's passive "0 values in 2026, 171 in 2025" warning.
+func (s *LodgingAssignmentsSync) valueCountsByCMID(year int, fieldTargets map[string]string) (map[int]int, error) {
+	out := map[int]int{}
+	defs, err := findAllRecords(s.App, "custom_field_defs", "")
+	if err != nil {
+		return out, err
+	}
+	cmIDByPBID := make(map[string]int, len(defs))
+	for _, d := range defs {
+		cmIDByPBID[d.Id] = d.GetInt("cm_id")
+	}
+
+	for _, collection := range []string{"household_custom_values", "person_custom_values"} {
+		rows, findErr := findAllRecords(s.App, collection, fmt.Sprintf("year = %d && value != ''", year))
+		if findErr != nil {
+			return out, findErr
+		}
+		for _, r := range rows {
+			defPBID := r.GetString("field_definition")
+			if _, mapped := fieldTargets[defPBID]; !mapped {
+				continue
+			}
+			out[cmIDByPBID[defPBID]]++
+		}
+	}
+	return out, nil
+}
+
+func (s *LodgingAssignmentsSync) forceWALCheckpoint() error {
+	db := s.App.DB()
+	if db == nil {
+		return fmt.Errorf("unable to get database connection")
+	}
+	if _, err := db.NewQuery("PRAGMA wal_checkpoint(FULL)").Execute(); err != nil {
+		return fmt.Errorf("WAL checkpoint failed: %w", err)
+	}
+	return nil
+}

--- a/pocketbase/sync/lodging_assignments_sync_test.go
+++ b/pocketbase/sync/lodging_assignments_sync_test.go
@@ -346,3 +346,116 @@ func TestLodgingAssignmentsSyncMaterialisesMerges(t *testing.T) {
 		t.Errorf("merge session_cm_id = %d, want %d", merges[0].GetInt("session_cm_id"), cmIDFamilyCamp1)
 	}
 }
+
+// cmIDWomensWeekend is the adult weekend the person-grain tests place people in.
+const cmIDWomensWeekend = 1335115
+
+const testAdultSessionStart = "2025-10-16 07:00:00.000Z"
+const testAdultSessionEnd = "2025-10-19 07:00:00.000Z"
+
+// TestLodgingAssignmentsSyncPersonGrain: adult weekends enroll real persons, so
+// the placement keys on person_cm_id and household_cm_id stays 0.
+func TestLodgingAssignmentsSyncPersonGrain(t *testing.T) {
+	app := newLodgingTestApp(t)
+	womens := addSession(t, app, cmIDWomensWeekend, "Women's Weekend", "adult",
+		testAdultSessionStart, testAdultSessionEnd, 2025)
+	unit := addUnit(t, app, "river-c")
+	addAlias(t, app, "River C", []string{unit}, 0, 0)
+	def := addFieldDef(t, app, cmIDReportableFamilyCampCabin, fieldNameReportableFamilyCampCabin)
+
+	hh := addHousehold(t, app, 9001, 2025)
+	emma := addPerson(t, app, 5001, 9001, 2025, hh)
+	addAttendee(t, app, emma, womens, 5001, 2, 2025)
+	addPersonValue(t, app, emma, def, "River C", testLastUpdated, 2025)
+
+	s := NewLodgingAssignmentsSync(app)
+	s.Year = 2025
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	rows, _ := app.FindRecordsByFilter("lodging_assignments", "", "", 0, 0)
+	if len(rows) != 1 {
+		t.Fatalf("assignments = %d, want 1", len(rows))
+	}
+	if rows[0].GetInt("person_cm_id") != 5001 {
+		t.Errorf("person_cm_id = %d, want 5001", rows[0].GetInt("person_cm_id"))
+	}
+	if rows[0].GetInt("household_cm_id") != 0 {
+		t.Errorf("household_cm_id = %d; the XOR requires 0 on a person row",
+			rows[0].GetInt("household_cm_id"))
+	}
+	if rows[0].GetInt("party_size") != 1 {
+		t.Errorf("party_size = %d, want 1 for an individual", rows[0].GetInt("party_size"))
+	}
+	if rows[0].GetInt("session_cm_id") != cmIDWomensWeekend {
+		t.Errorf("session_cm_id = %d, want %d", rows[0].GetInt("session_cm_id"), cmIDWomensWeekend)
+	}
+}
+
+// TestLodgingAssignmentsSyncPersonGrainManyPerSession is the case Plan 1's
+// pre-flight fix exists for: several individuals in one adult weekend. Had the
+// unique index predicate compared against the empty string instead of using
+// `> 0`, every person row (household_cm_id = 0) would have collided and only
+// ONE could exist.
+func TestLodgingAssignmentsSyncPersonGrainManyPerSession(t *testing.T) {
+	app := newLodgingTestApp(t)
+	womens := addSession(t, app, cmIDWomensWeekend, "Women's Weekend", "adult",
+		testAdultSessionStart, testAdultSessionEnd, 2025)
+	unit := addUnit(t, app, "river-c")
+	addAlias(t, app, "River C", []string{unit}, 0, 0)
+	def := addFieldDef(t, app, cmIDReportableFamilyCampCabin, fieldNameReportableFamilyCampCabin)
+	hh := addHousehold(t, app, 9001, 2025)
+
+	for i, cmID := range []int{5001, 5002, 5003} {
+		p := addPerson(t, app, cmID, 9001+i, 2025, hh)
+		addAttendee(t, app, p, womens, cmID, 2, 2025)
+		addPersonValue(t, app, p, def, "River C", testLastUpdated, 2025)
+	}
+
+	s := NewLodgingAssignmentsSync(app)
+	s.Year = 2025
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	rows, _ := app.FindRecordsByFilter("lodging_assignments", "", "", 0, 0)
+	if len(rows) != 3 {
+		t.Errorf("assignments = %d, want 3 (one per individual)", len(rows))
+	}
+}
+
+// TestLodgingAssignmentsSyncPersonGrainNoEnrolment: 5 (2024) and 4 (2025)
+// Reportable Family Camp Cabin values belong to persons with no active
+// enrollment. Queue them; never drop them.
+func TestLodgingAssignmentsSyncPersonGrainNoEnrolment(t *testing.T) {
+	app := newLodgingTestApp(t)
+	addSession(t, app, cmIDWomensWeekend, "Women's Weekend", "adult",
+		testAdultSessionStart, testAdultSessionEnd, 2025)
+	unit := addUnit(t, app, "river-c")
+	addAlias(t, app, "River C", []string{unit}, 0, 0)
+	def := addFieldDef(t, app, cmIDReportableFamilyCampCabin, fieldNameReportableFamilyCampCabin)
+
+	hh := addHousehold(t, app, 9001, 2025)
+	noah := addPerson(t, app, 5003, 9001, 2025, hh)
+	// No attendee row at all -- cancelled before the season.
+	addPersonValue(t, app, noah, def, "River C", testLastUpdated, 2025)
+
+	s := NewLodgingAssignmentsSync(app)
+	s.Year = 2025
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	rows, _ := app.FindRecordsByFilter("lodging_assignments", "", "", 0, 0)
+	if len(rows) != 0 {
+		t.Errorf("assignments = %d, want 0 without an enrolment", len(rows))
+	}
+	issues, _ := app.FindRecordsByFilter("lodging_ingest_issues", "", "", 0, 0)
+	if len(issues) != 1 || issues[0].GetString("kind") != issueNoSession {
+		t.Fatalf("expected 1 no_session item, got %d", len(issues))
+	}
+	if issues[0].GetInt("person_cm_id") != 5003 {
+		t.Errorf("person_cm_id = %d on the queue item, want 5003", issues[0].GetInt("person_cm_id"))
+	}
+}

--- a/pocketbase/sync/lodging_assignments_sync_test.go
+++ b/pocketbase/sync/lodging_assignments_sync_test.go
@@ -499,3 +499,218 @@ func TestLodgingAssignmentsRegisteredEverywhere(t *testing.T) {
 		t.Error("lodging_assignments missing from SyncJobToCollections; its sheets would never be skipped")
 	}
 }
+
+// TestLodgingAssignmentsSyncDryRunWritesNothing: DryRun's contract is "compute
+// but do not write". Two of ingestValue's write paths sit UPSTREAM of the
+// placement write -- recordHistory for a string no alias covers, and
+// placementFor -> EnsureMerge for a multi-room alias -- so a guard placed just
+// before upsertAssignment leaves rows behind in two tables it never mentions.
+func TestLodgingAssignmentsSyncDryRunWritesNothing(t *testing.T) {
+	app := newLodgingTestApp(t)
+	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
+		testSessionStart, testSessionEnd, 2025)
+	t1 := addUnit(t, app, "gt-tioga-1")
+	t2 := addUnit(t, app, "gt-tioga-2")
+	addAlias(t, app, "Golden Triangle - Tioga 1and2", []string{t1, t2}, 0, 0)
+	cabinDef := addFieldDef(t, app, cmIDFamilyCampCabin, fieldNameFamilyCampCabin)
+
+	// Household on a two-room alias: reaches EnsureMerge.
+	hh := addHousehold(t, app, 9001, 2025)
+	emma := addPerson(t, app, 5001, 9001, 2025, hh)
+	addAttendee(t, app, emma, sess, 5001, 2, 2025)
+	addHouseholdValue(t, app, hh, cabinDef, "Golden Triangle - Tioga 1and2", testLastUpdated, 2025)
+
+	// Household on a string no alias covers: reaches recordHistory.
+	hh2 := addHousehold(t, app, 9002, 2025)
+	liam := addPerson(t, app, 5002, 9002, 2025, hh2)
+	addAttendee(t, app, liam, sess, 5002, 2, 2025)
+	addHouseholdValue(t, app, hh2, cabinDef, "Tuolumne 7", testLastUpdated, 2025)
+
+	s := NewLodgingAssignmentsSync(app)
+	s.Year = 2025
+	s.DryRun = true
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	for _, collection := range []string{
+		"lodging_assignments", "lodging_assignment_history",
+		"lodging_merges", "lodging_ingest_issues",
+	} {
+		rows, err := app.FindRecordsByFilter(collection, "", "", 0, 0)
+		if err != nil {
+			t.Fatalf("reading %s: %v", collection, err)
+		}
+		if len(rows) != 0 {
+			t.Errorf("dry run wrote %d rows to %s; want 0", len(rows), collection)
+		}
+	}
+}
+
+// TestLodgingAssignmentsSyncUpdatesPartySizeInSameCabin: party_size is
+// recomputed every run, so a household that gains an occupant without changing
+// cabin must still have the new count persisted. The label is the MOVE
+// detector; it is not the change detector.
+func TestLodgingAssignmentsSyncUpdatesPartySizeInSameCabin(t *testing.T) {
+	app := newLodgingTestApp(t)
+	seedOneWeekendHousehold(t, app)
+
+	s := NewLodgingAssignmentsSync(app)
+	s.Year = 2025
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+	rows, _ := app.FindRecordsByFilter("lodging_assignments", "", "", 0, 0)
+	if len(rows) != 1 {
+		t.Fatalf("assignments = %d, want 1", len(rows))
+	}
+	if got := rows[0].GetInt("party_size"); got != 4 {
+		t.Fatalf("party_size = %d, want 4 (2 children + 2 adults)", got)
+	}
+
+	// A third accompanying adult joins. The cabin string is untouched.
+	households, _ := app.FindRecordsByFilter("households", "cm_id = 9001", "", 1, 0)
+	if len(households) != 1 {
+		t.Fatalf("households = %d, want 1", len(households))
+	}
+	addFamilyCampAdult(t, app, households[0].Id, 2025, 3, "Olivia Martinez")
+
+	s2 := NewLodgingAssignmentsSync(app)
+	s2.Year = 2025
+	if err := s2.Sync(context.Background()); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	rows, _ = app.FindRecordsByFilter("lodging_assignments", "", "", 0, 0)
+	if len(rows) != 1 {
+		t.Fatalf("assignments after second sync = %d, want 1", len(rows))
+	}
+	if got := rows[0].GetInt("party_size"); got != 5 {
+		t.Errorf("party_size = %d, want 5 -- the recomputed size was discarded", got)
+	}
+	// Same cabin, so this is not a move and must not append a history row.
+	hist, _ := app.FindRecordsByFilter("lodging_assignment_history", "", "", 0, 0)
+	if len(hist) != 1 {
+		t.Errorf("history rows = %d, want 1; a party-size change is not a move", len(hist))
+	}
+}
+
+// TestLodgingAssignmentsSyncQueuesUnknownHousehold: spec 6.2 is "zero silent
+// drops". A cabin value whose household row is absent for the sync year has no
+// CampMinder id to key a placement on, but skipping it outright loses the
+// observation entirely -- and because the value is counted before the skip, even
+// the field_zero_values warning stays quiet.
+func TestLodgingAssignmentsSyncQueuesUnknownHousehold(t *testing.T) {
+	app := newLodgingTestApp(t)
+	addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
+		testSessionStart, testSessionEnd, 2025)
+	unit := addUnit(t, app, "ridge-a")
+	addAlias(t, app, "Ridge A", []string{unit}, 0, 0)
+	cabinDef := addFieldDef(t, app, cmIDFamilyCampCabin, fieldNameFamilyCampCabin)
+
+	// The household row is scoped to 2024, so the 2025 lookup cannot see it.
+	hh := addHousehold(t, app, 9001, 2024)
+	addHouseholdValue(t, app, hh, cabinDef, "Ridge A", testLastUpdated, 2025)
+
+	s := NewLodgingAssignmentsSync(app)
+	s.Year = 2025
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("a missing household must not fail the sync: %v", err)
+	}
+
+	issues, _ := app.FindRecordsByFilter("lodging_ingest_issues", "", "", 0, 0)
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 work-queue item for the unkeyable value, got %d", len(issues))
+	}
+	if issues[0].GetString("kind") != issueUnknownParty {
+		t.Errorf("kind = %q, want %q", issues[0].GetString("kind"), issueUnknownParty)
+	}
+	if issues[0].GetString("raw_value") != "Ridge A" {
+		t.Errorf("raw_value = %q; the verbatim string must survive", issues[0].GetString("raw_value"))
+	}
+}
+
+// TestLodgingAssignmentsSyncQueuesUnknownPerson: the person-grain twin of
+// TestLodgingAssignmentsSyncQueuesUnknownHousehold.
+func TestLodgingAssignmentsSyncQueuesUnknownPerson(t *testing.T) {
+	app := newLodgingTestApp(t)
+	addSession(t, app, cmIDWomensWeekend, "Women's Weekend", "adult",
+		testAdultSessionStart, testAdultSessionEnd, 2025)
+	unit := addUnit(t, app, "ridge-a")
+	addAlias(t, app, "Ridge A", []string{unit}, 0, 0)
+	reportableDef := addFieldDef(t, app, cmIDReportableFamilyCampCabin, fieldNameReportableFamilyCampCabin)
+
+	// The person row is scoped to 2024, so the 2025 lookup cannot see it.
+	hh := addHousehold(t, app, 9001, 2024)
+	ava := addPerson(t, app, 5001, 9001, 2024, hh)
+	addPersonValue(t, app, ava, reportableDef, "Ridge A", testLastUpdated, 2025)
+
+	s := NewLodgingAssignmentsSync(app)
+	s.Year = 2025
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("a missing person must not fail the sync: %v", err)
+	}
+
+	issues, _ := app.FindRecordsByFilter("lodging_ingest_issues", "", "", 0, 0)
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 work-queue item for the unkeyable value, got %d", len(issues))
+	}
+	if issues[0].GetString("kind") != issueUnknownParty {
+		t.Errorf("kind = %q, want %q", issues[0].GetString("kind"), issueUnknownParty)
+	}
+}
+
+// TestLodgingAssignmentsSyncMergeLabelIgnoresMemberOrder: EnsureMerge keys a
+// merge on the member SET (unitSetKey sorts), so two aliases naming the same two
+// rooms in different orders share ONE merge row. The placement label has to be
+// canonical for the same reason -- an order-sensitive label would read as a move
+// on every run, re-saving the assignment and appending a history row for a
+// household that never left its cabin.
+func TestLodgingAssignmentsSyncMergeLabelIgnoresMemberOrder(t *testing.T) {
+	app := newLodgingTestApp(t)
+	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
+		testSessionStart, testSessionEnd, 2025)
+	t1 := addUnit(t, app, "gt-tioga-1")
+	t2 := addUnit(t, app, "gt-tioga-2")
+	addAlias(t, app, "Golden Triangle - Tioga 1and2", []string{t1, t2}, 0, 0)
+	// The same two rooms, named the other way round. Staff type both.
+	addAlias(t, app, "Golden Triangle - Tioga 2and1", []string{t2, t1}, 0, 0)
+	cabinDef := addFieldDef(t, app, cmIDFamilyCampCabin, fieldNameFamilyCampCabin)
+
+	hh := addHousehold(t, app, 9001, 2025)
+	emma := addPerson(t, app, 5001, 9001, 2025, hh)
+	addAttendee(t, app, emma, sess, 5001, 2, 2025)
+	valueID := addHouseholdValue(t, app, hh, cabinDef,
+		"Golden Triangle - Tioga 1and2", testLastUpdated, 2025)
+
+	s := NewLodgingAssignmentsSync(app)
+	s.Year = 2025
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+
+	// CampMinder now carries the other spelling of the same two rooms.
+	rec, err := app.FindRecordById("household_custom_values", valueID)
+	if err != nil {
+		t.Fatalf("reloading the custom value: %v", err)
+	}
+	rec.Set("value", "Golden Triangle - Tioga 2and1")
+	if saveErr := app.Save(rec); saveErr != nil {
+		t.Fatalf("updating the custom value: %v", saveErr)
+	}
+
+	s2 := NewLodgingAssignmentsSync(app)
+	s2.Year = 2025
+	if err := s2.Sync(context.Background()); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	merges, _ := app.FindRecordsByFilter("lodging_merges", "", "", 0, 0)
+	if len(merges) != 1 {
+		t.Errorf("merges = %d, want 1; the same room set must not fork a second merge", len(merges))
+	}
+	hist, _ := app.FindRecordsByFilter("lodging_assignment_history", "", "", 0, 0)
+	if len(hist) != 1 {
+		t.Errorf("history rows = %d, want 1; reordering the members is not a move", len(hist))
+	}
+}

--- a/pocketbase/sync/lodging_assignments_sync_test.go
+++ b/pocketbase/sync/lodging_assignments_sync_test.go
@@ -1,0 +1,348 @@
+package sync
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+const testLastUpdated = "2025-05-16T09:14:03.1234567+00:00"
+
+// seedOneWeekendHousehold builds the 98% case: household 9001 with two enrolled
+// children at one family weekend, one cabin value, and two accompanying adults.
+func seedOneWeekendHousehold(t *testing.T, app core.App) (sessionID, unitID string) {
+	t.Helper()
+	sessionID = addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
+		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
+	unitID = addUnit(t, app, "ridge-a")
+	addAlias(t, app, "Ridge A", []string{unitID}, 0, 0)
+
+	cabinDef := addFieldDef(t, app, cmIDFamilyCampCabin, fieldNameFamilyCampCabin)
+	hh := addHousehold(t, app, 9001, 2025)
+	emma := addPerson(t, app, 5001, 9001, 2025, hh)
+	liam := addPerson(t, app, 5002, 9001, 2025, hh)
+	addAttendee(t, app, emma, sessionID, 5001, 2, 2025)
+	addAttendee(t, app, liam, sessionID, 5002, 2, 2025)
+	addFamilyCampAdult(t, app, hh, 2025, 1, "Noah Smith")
+	addFamilyCampAdult(t, app, hh, 2025, 2, "Emma Johnson")
+	addHouseholdValue(t, app, hh, cabinDef, "Ridge A", testLastUpdated, 2025)
+	return sessionID, unitID
+}
+
+func TestLodgingAssignmentsSyncName(t *testing.T) {
+	s := NewLodgingAssignmentsSync(nil)
+	if s.Name() != serviceNameLodgingAssignments {
+		t.Errorf("Name() = %q, want %q", s.Name(), serviceNameLodgingAssignments)
+	}
+}
+
+// TestLodgingAssignmentsSyncHouseholdGrain: the whole happy path end to end.
+func TestLodgingAssignmentsSyncHouseholdGrain(t *testing.T) {
+	app := newLodgingTestApp(t)
+	sessionID, unitID := seedOneWeekendHousehold(t, app)
+
+	s := NewLodgingAssignmentsSync(app)
+	s.Year = 2025
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	rows, err := app.FindRecordsByFilter("lodging_assignments", "", "", 0, 0)
+	if err != nil {
+		t.Fatalf("find assignments: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 assignment, got %d", len(rows))
+	}
+	got := rows[0]
+	if got.GetInt("household_cm_id") != 9001 {
+		t.Errorf("household_cm_id = %d, want 9001", got.GetInt("household_cm_id"))
+	}
+	if got.GetInt("person_cm_id") != 0 {
+		t.Errorf("person_cm_id = %d; the dual-grain XOR requires 0 here", got.GetInt("person_cm_id"))
+	}
+	if got.GetString("unit") != unitID {
+		t.Errorf("unit = %q, want %q", got.GetString("unit"), unitID)
+	}
+	if got.GetString("merge") != "" {
+		t.Error("merge is set on a single-room placement")
+	}
+	if got.GetString("session") != sessionID {
+		t.Errorf("session = %q, want %q", got.GetString("session"), sessionID)
+	}
+	// The durable cross-year key (migration 1500000124). It is `required`, so a
+	// writer that omits it does not write a 0 -- it fails validation outright.
+	if got.GetInt("session_cm_id") != cmIDFamilyCamp1 {
+		t.Errorf("session_cm_id = %d, want %d", got.GetInt("session_cm_id"), cmIDFamilyCamp1)
+	}
+	if got.GetString("source") != "campminder_sync" {
+		t.Errorf("source = %q, want campminder_sync", got.GetString("source"))
+	}
+	// 2 enrolled children + 2 accompanying adults.
+	if got.GetInt("party_size") != 4 {
+		t.Errorf("party_size = %d, want 4 (2 children + 2 adults)", got.GetInt("party_size"))
+	}
+
+	hist, err := app.FindRecordsByFilter("lodging_assignment_history", "", "", 0, 0)
+	if err != nil {
+		t.Fatalf("find history: %v", err)
+	}
+	if len(hist) != 1 {
+		t.Fatalf("expected 1 history row for the first observation, got %d", len(hist))
+	}
+	if hist[0].GetString("old_unit") != "" || hist[0].GetString("new_unit") != "ridge-a" {
+		t.Errorf("history = (%q -> %q), want ('' -> 'ridge-a')",
+			hist[0].GetString("old_unit"), hist[0].GetString("new_unit"))
+	}
+	if hist[0].GetString("source_field") != fieldNameFamilyCampCabin {
+		t.Errorf("history source_field = %q", hist[0].GetString("source_field"))
+	}
+	// The audit trail is meant to outlive its session, so it carries the durable
+	// key too -- otherwise a surviving row cannot say which weekend it described.
+	if hist[0].GetInt("session_cm_id") != cmIDFamilyCamp1 {
+		t.Errorf("history session_cm_id = %d, want %d", hist[0].GetInt("session_cm_id"), cmIDFamilyCamp1)
+	}
+}
+
+// TestLodgingAssignmentsSyncIsIdempotent: a second run must not duplicate the
+// assignment or append a spurious history row.
+func TestLodgingAssignmentsSyncIsIdempotent(t *testing.T) {
+	app := newLodgingTestApp(t)
+	seedOneWeekendHousehold(t, app)
+
+	for pass := 0; pass < 2; pass++ {
+		s := NewLodgingAssignmentsSync(app)
+		s.Year = 2025
+		if err := s.Sync(context.Background()); err != nil {
+			t.Fatalf("pass %d: %v", pass, err)
+		}
+	}
+
+	rows, _ := app.FindRecordsByFilter("lodging_assignments", "", "", 0, 0)
+	if len(rows) != 1 {
+		t.Errorf("assignments after two passes = %d, want 1", len(rows))
+	}
+	hist, _ := app.FindRecordsByFilter("lodging_assignment_history", "", "", 0, 0)
+	if len(hist) != 1 {
+		t.Errorf("history rows after two passes = %d, want 1 (nothing changed)", len(hist))
+	}
+}
+
+// TestLodgingAssignmentsSyncAppendsHistoryOnChange: this is the mechanism spec
+// 3.6 relies on to recover multi-weekend households whose earlier assignment
+// CampMinder overwrote.
+func TestLodgingAssignmentsSyncAppendsHistoryOnChange(t *testing.T) {
+	app := newLodgingTestApp(t)
+	seedOneWeekendHousehold(t, app)
+	ridgeB := addUnit(t, app, "ridge-b")
+	addAlias(t, app, "Ridge B", []string{ridgeB}, 0, 0)
+
+	s := NewLodgingAssignmentsSync(app)
+	s.Year = 2025
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+
+	// Staff move the household in CampMinder.
+	vals, _ := app.FindRecordsByFilter("household_custom_values", "", "", 0, 0)
+	vals[0].Set("value", "Ridge B")
+	vals[0].Set("last_updated", "2025-05-18T11:02:44.0000000+00:00")
+	if err := app.Save(vals[0]); err != nil {
+		t.Fatalf("update value: %v", err)
+	}
+
+	s2 := NewLodgingAssignmentsSync(app)
+	s2.Year = 2025
+	if err := s2.Sync(context.Background()); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	rows, _ := app.FindRecordsByFilter("lodging_assignments", "", "", 0, 0)
+	if len(rows) != 1 {
+		t.Fatalf("assignments = %d, want 1 (moved, not duplicated)", len(rows))
+	}
+	if rows[0].GetString("unit") != ridgeB {
+		t.Error("assignment did not move to ridge-b")
+	}
+
+	hist, _ := app.FindRecordsByFilter("lodging_assignment_history", "", "-created", 0, 0)
+	if len(hist) != 2 {
+		t.Fatalf("history rows = %d, want 2", len(hist))
+	}
+	var sawMove bool
+	for _, h := range hist {
+		if h.GetString("old_unit") == "ridge-a" && h.GetString("new_unit") == "ridge-b" {
+			sawMove = true
+		}
+	}
+	if !sawMove {
+		t.Error("no history row records the ridge-a -> ridge-b move")
+	}
+}
+
+// TestLodgingAssignmentsSyncRespectsStaffTouched: a placement a human moved on
+// the board is not reverted by the next CampMinder sync.
+func TestLodgingAssignmentsSyncRespectsStaffTouched(t *testing.T) {
+	app := newLodgingTestApp(t)
+	seedOneWeekendHousehold(t, app)
+	ridgeB := addUnit(t, app, "ridge-b")
+	addAlias(t, app, "Ridge B", []string{ridgeB}, 0, 0)
+
+	s := NewLodgingAssignmentsSync(app)
+	s.Year = 2025
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+
+	rows, _ := app.FindRecordsByFilter("lodging_assignments", "", "", 0, 0)
+	rows[0].Set("staff_touched", true)
+	rows[0].Set("unit", ridgeB)
+	if err := app.Save(rows[0]); err != nil {
+		t.Fatalf("simulate staff move: %v", err)
+	}
+
+	s2 := NewLodgingAssignmentsSync(app)
+	s2.Year = 2025
+	if err := s2.Sync(context.Background()); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	after, _ := app.FindRecordsByFilter("lodging_assignments", "", "", 0, 0)
+	if after[0].GetString("unit") != ridgeB {
+		t.Error("the sync reverted a staff-touched placement")
+	}
+	if s2.GetStats().Skipped < 1 {
+		t.Errorf("Skipped = %d, want at least 1 for the staff-touched row", s2.GetStats().Skipped)
+	}
+}
+
+// TestLodgingAssignmentsSyncQueuesUnresolvedAlias: "Tuolumne 7" has no alias row
+// -- one of four such strings in the real 2022/2023 data. It must become a work
+// queue item and must not be dropped, and must not stop the run.
+func TestLodgingAssignmentsSyncQueuesUnresolvedAlias(t *testing.T) {
+	app := newLodgingTestApp(t)
+	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
+		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
+	cabinDef := addFieldDef(t, app, cmIDFamilyCampCabin, fieldNameFamilyCampCabin)
+	hh := addHousehold(t, app, 9001, 2025)
+	emma := addPerson(t, app, 5001, 9001, 2025, hh)
+	addAttendee(t, app, emma, sess, 5001, 2, 2025)
+	addHouseholdValue(t, app, hh, cabinDef, "Tuolumne 7", testLastUpdated, 2025)
+
+	s := NewLodgingAssignmentsSync(app)
+	s.Year = 2025
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("an unresolved alias must not fail the sync: %v", err)
+	}
+
+	rows, _ := app.FindRecordsByFilter("lodging_assignments", "", "", 0, 0)
+	if len(rows) != 0 {
+		t.Errorf("an unresolvable string produced %d assignments; expected 0", len(rows))
+	}
+	issues, _ := app.FindRecordsByFilter("lodging_ingest_issues", "", "", 0, 0)
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 work-queue item, got %d", len(issues))
+	}
+	if issues[0].GetString("kind") != issueUnresolvedAlias {
+		t.Errorf("kind = %q, want %q", issues[0].GetString("kind"), issueUnresolvedAlias)
+	}
+	if issues[0].GetString("raw_value") != "Tuolumne 7" {
+		t.Errorf("raw_value = %q; the verbatim string must survive", issues[0].GetString("raw_value"))
+	}
+	// History still records the observation, using the raw string, so the fact
+	// that this household WAS assigned somewhere is not lost.
+	hist, _ := app.FindRecordsByFilter("lodging_assignment_history", "", "", 0, 0)
+	if len(hist) != 1 || hist[0].GetString("new_unit") != "Tuolumne 7" {
+		t.Error("an unresolvable placement left no history trace")
+	}
+}
+
+// TestLodgingAssignmentsSyncQueuesAmbiguousSession: 6-10 households a year
+// attend more than one weekend against one CampMinder value. Spec 3.6 says flag
+// them for manual entry.
+func TestLodgingAssignmentsSyncQueuesAmbiguousSession(t *testing.T) {
+	app := newLodgingTestApp(t)
+	fc1 := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
+		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
+	winter := addSession(t, app, cmIDWinterFamily, "Winter Family Camp", "family",
+		"2025-12-21 08:00:00.000Z", "2025-12-23 08:00:00.000Z", 2025)
+	unit := addUnit(t, app, "ridge-a")
+	addAlias(t, app, "Ridge A", []string{unit}, 0, 0)
+	cabinDef := addFieldDef(t, app, cmIDFamilyCampCabin, fieldNameFamilyCampCabin)
+
+	hh := addHousehold(t, app, 9001, 2025)
+	emma := addPerson(t, app, 5001, 9001, 2025, hh)
+	addAttendee(t, app, emma, fc1, 5001, 2, 2025)
+	addAttendee(t, app, emma, winter, 5001, 2, 2025)
+	addHouseholdValue(t, app, hh, cabinDef, "Ridge A", "2025-12-15T10:00:00.0000000+00:00", 2025)
+
+	s := NewLodgingAssignmentsSync(app)
+	s.Year = 2025
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	rows, _ := app.FindRecordsByFilter("lodging_assignments", "", "", 0, 0)
+	if len(rows) != 0 {
+		t.Errorf("an ambiguous household produced %d assignments; spec 3.6 says flag, don't guess", len(rows))
+	}
+	issues, _ := app.FindRecordsByFilter("lodging_ingest_issues", "", "", 0, 0)
+	if len(issues) != 1 || issues[0].GetString("kind") != issueAmbiguousSession {
+		t.Fatalf("expected 1 ambiguous_session item, got %d", len(issues))
+	}
+	if issues[0].GetString("suggested_session") != winter {
+		t.Errorf("suggested_session = %q, want the Winter session (value edited 15 Dec)",
+			issues[0].GetString("suggested_session"))
+	}
+	if issues[0].GetInt("household_cm_id") != 9001 {
+		t.Error("the queue item does not identify the household")
+	}
+}
+
+// TestLodgingAssignmentsSyncMaterialisesMerges: "Golden Triangle - Tioga 1and2"
+// resolves to two units, so the placement points at a merge, never at one room.
+func TestLodgingAssignmentsSyncMaterialisesMerges(t *testing.T) {
+	app := newLodgingTestApp(t)
+	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
+		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
+	t1 := addUnit(t, app, "gt-tioga-1")
+	t2 := addUnit(t, app, "gt-tioga-2")
+	addAlias(t, app, "Golden Triangle - Tioga 1and2", []string{t1, t2}, 0, 0)
+	cabinDef := addFieldDef(t, app, cmIDFamilyCampCabin, fieldNameFamilyCampCabin)
+
+	hh := addHousehold(t, app, 9001, 2025)
+	emma := addPerson(t, app, 5001, 9001, 2025, hh)
+	addAttendee(t, app, emma, sess, 5001, 2, 2025)
+	addHouseholdValue(t, app, hh, cabinDef, "Golden Triangle - Tioga 1and2", testLastUpdated, 2025)
+
+	s := NewLodgingAssignmentsSync(app)
+	s.Year = 2025
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	rows, _ := app.FindRecordsByFilter("lodging_assignments", "", "", 0, 0)
+	if len(rows) != 1 {
+		t.Fatalf("assignments = %d, want 1", len(rows))
+	}
+	if rows[0].GetString("merge") == "" {
+		t.Error("merge is empty on a two-room placement")
+	}
+	if rows[0].GetString("unit") != "" {
+		t.Error("unit is set alongside merge; the XOR forbids that")
+	}
+
+	merges, _ := app.FindRecordsByFilter("lodging_merges", "", "", 0, 0)
+	if len(merges) != 1 {
+		t.Fatalf("merges = %d, want 1", len(merges))
+	}
+	if len(merges[0].GetStringSlice("member_units")) != 2 {
+		t.Errorf("merge has %d members, want 2", len(merges[0].GetStringSlice("member_units")))
+	}
+	// lodging_merges.session_cm_id is required too, so a merge materialized
+	// without it never saves at all -- this asserts the value, not just the save.
+	if merges[0].GetInt("session_cm_id") != cmIDFamilyCamp1 {
+		t.Errorf("merge session_cm_id = %d, want %d", merges[0].GetInt("session_cm_id"), cmIDFamilyCamp1)
+	}
+}

--- a/pocketbase/sync/lodging_assignments_sync_test.go
+++ b/pocketbase/sync/lodging_assignments_sync_test.go
@@ -459,3 +459,43 @@ func TestLodgingAssignmentsSyncPersonGrainNoEnrolment(t *testing.T) {
 		t.Errorf("person_cm_id = %d on the queue item, want 5003", issues[0].GetInt("person_cm_id"))
 	}
 }
+
+// TestLodgingAssignmentsRegisteredEverywhere: a job registered in some places
+// but not others is the single most common defect when adding a sync
+// (docs/architecture/sync-layer.md's own "Common Mistakes" table). Each miss is
+// silent -- the job simply never runs, or the GUI shows "idle" forever.
+func TestLodgingAssignmentsRegisteredEverywhere(t *testing.T) {
+	var inMeta bool
+	for _, m := range syncJobMeta {
+		if m.ID == serviceNameLodgingAssignments {
+			inMeta = true
+			if m.Phase != PhaseTransform {
+				t.Errorf("phase = %v, want PhaseTransform", m.Phase)
+			}
+		}
+	}
+	if !inMeta {
+		t.Error("lodging_assignments missing from syncJobMeta")
+	}
+
+	daily := getDailySyncJobs()
+	posDerived, posLodging := -1, -1
+	for i, id := range daily {
+		switch id {
+		case serviceNameFamilyCampDerived:
+			posDerived = i
+		case serviceNameLodgingAssignments:
+			posLodging = i
+		}
+	}
+	if posLodging < 0 {
+		t.Fatal("lodging_assignments missing from getDailySyncJobs; it would never run in the daily sync")
+	}
+	if posLodging < posDerived {
+		t.Error("lodging_assignments runs before family_camp_derived; it depends on the same source data")
+	}
+
+	if _, ok := SyncJobToCollections[serviceNameLodgingAssignments]; !ok {
+		t.Error("lodging_assignments missing from SyncJobToCollections; its sheets would never be skipped")
+	}
+}

--- a/pocketbase/sync/lodging_fields.go
+++ b/pocketbase/sync/lodging_fields.go
@@ -41,7 +41,10 @@ const (
 // key -- resolution goes through the cm_ids above. They exist as constants only
 // because the same literals appear in family_camp_derived.go's name-routed
 // switch, and goconst counts a third occurrence as drift waiting to happen.
-const fieldNameFamilyCampCabin = "Family Camp Cabin"
+const (
+	fieldNameFamilyCampCabin           = "Family Camp Cabin"
+	fieldNameReportableFamilyCampCabin = "Reportable Family Camp Cabin"
+)
 
 // lodgingSourceField is one CampMinder custom field the lodging ingest reads.
 type lodgingSourceField struct {
@@ -56,7 +59,7 @@ type lodgingSourceField struct {
 var lodgingSourceFields = []lodgingSourceField{
 	{CMID: cmIDFamilyCampCabin, Name: fieldNameFamilyCampCabin,
 		Target: targetCabinAssignmentHousehold, Grain: grainHousehold},
-	{CMID: cmIDReportableFamilyCampCabin, Name: "Reportable Family Camp Cabin",
+	{CMID: cmIDReportableFamilyCampCabin, Name: fieldNameReportableFamilyCampCabin,
 		Target: targetCabinAssignmentPerson, Grain: grainPerson},
 }
 

--- a/pocketbase/sync/lodging_grain_test.go
+++ b/pocketbase/sync/lodging_grain_test.go
@@ -68,12 +68,18 @@ func TestValidateAssignmentGrain(t *testing.T) {
 // invariant has no database backing.
 func TestAssignmentGrainIllegalStatesReallySaveInPocketBase(t *testing.T) {
 	app := newLodgingTestApp(t)
-	sess := addSession(t, app, 1309514, "Family Camp 1", "family",
+	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
 
 	// Neither party, no placement: the emptiest illegal row there is.
+	//
+	// session and session_cm_id are supplied only because migration 1500000124
+	// makes them required, which is a separate invariant PocketBase DOES enforce.
+	// Leaving session_cm_id out would fail this test on that column instead, and
+	// the grain question -- the one thing it exists to answer -- would go untested.
 	id := saveRecord(t, app, "lodging_assignments", map[string]any{
-		"session": sess, "year": 2025, "source": "campminder_sync",
+		"session": sess, "session_cm_id": cmIDFamilyCamp1, "year": 2025,
+		"source": "campminder_sync",
 	})
 	if id == "" {
 		t.Fatal("expected PocketBase to accept the row (that is the point of this test)")

--- a/pocketbase/sync/lodging_issues.go
+++ b/pocketbase/sync/lodging_issues.go
@@ -26,6 +26,19 @@ const (
 	issueNoSession = "no_session"
 	// Spec 4.4's passive warning: a mapped field saw zero values this year.
 	issueFieldZeroValues = "field_zero_values"
+	// The household or person row the value hangs off does not exist for this
+	// year, so there is no CampMinder id to key a placement on. Skipping the
+	// value outright would be a silent drop, which spec 6.2 forbids -- and the
+	// value is counted before the skip, so even the field_zero_values warning
+	// stays quiet. Queue it instead: the fix is upstream, in whichever sync
+	// should have produced the missing row.
+	issueUnknownParty = "unknown_party"
+	// The placement resolved and attributed cleanly but could not be persisted
+	// -- a merge that would not materialize, or an assignment the database
+	// refused. Stats.Errors and the log already carry this, but neither is
+	// durable or queryable, so the value would otherwise vanish once the log
+	// rotates.
+	issueWriteFailed = "write_failed"
 )
 
 // Issue is one work-queue item. Zero-valued HouseholdCMID / PersonCMID mean "not

--- a/pocketbase/sync/lodging_merges.go
+++ b/pocketbase/sync/lodging_merges.go
@@ -36,8 +36,14 @@ func unitSetKey(unitIDs []string) string {
 //
 // An empty scenario means the session's live plan, matching how PocketBase
 // stores an unset relation: TEXT, NOT NULL, defaulting to the empty string.
+//
+// sessionCMID is the session's CampMinder id and is REQUIRED by
+// lodging_merges.session_cm_id (migration 1500000124). It is passed in rather
+// than looked up so it comes from the same attribution that chose sessionID;
+// deriving it here would let the relation and the durable key disagree.
 func EnsureMerge(
-	app core.App, sessionID string, year int, scenario string, unitIDs []string, displayName string,
+	app core.App, sessionID string, sessionCMID, year int,
+	scenario string, unitIDs []string, displayName string,
 ) (string, error) {
 	// member_units is minSelect 2, maxSelect 20 (migration 1500000118). Checking
 	// both here gives a call-site error naming the member count, instead of a
@@ -71,6 +77,7 @@ func EnsureMerge(
 	}
 	rec := core.NewRecord(col)
 	rec.Set("session", sessionID)
+	rec.Set("session_cm_id", sessionCMID)
 	rec.Set("year", year)
 	rec.Set("scenario", scenario)
 	rec.Set("member_units", unitIDs)

--- a/pocketbase/sync/lodging_merges_test.go
+++ b/pocketbase/sync/lodging_merges_test.go
@@ -14,15 +14,15 @@ const testSessionEnd = "2025-05-26 07:00:00.000Z"
 // backfill run would create another merge row for the same two rooms.
 func TestEnsureMergeIsIdempotent(t *testing.T) {
 	app := newLodgingTestApp(t)
-	sess := addSession(t, app, 1309514, "Family Camp 1", "family", testSessionStart, testSessionEnd, 2025)
+	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family", testSessionStart, testSessionEnd, 2025)
 	tioga1 := addUnit(t, app, "gt-tioga-1")
 	tioga2 := addUnit(t, app, "gt-tioga-2")
 
-	first, err := EnsureMerge(app, sess, 2025, "", []string{tioga1, tioga2}, "Tioga")
+	first, err := EnsureMerge(app, sess, cmIDFamilyCamp1, 2025, "", []string{tioga1, tioga2}, "Tioga")
 	if err != nil {
 		t.Fatalf("EnsureMerge first: %v", err)
 	}
-	second, err := EnsureMerge(app, sess, 2025, "", []string{tioga1, tioga2}, "Tioga")
+	second, err := EnsureMerge(app, sess, cmIDFamilyCamp1, 2025, "", []string{tioga1, tioga2}, "Tioga")
 	if err != nil {
 		t.Fatalf("EnsureMerge second: %v", err)
 	}
@@ -44,15 +44,15 @@ func TestEnsureMergeIsIdempotent(t *testing.T) {
 // SET of members and not the slice.
 func TestEnsureMergeIgnoresMemberOrder(t *testing.T) {
 	app := newLodgingTestApp(t)
-	sess := addSession(t, app, 1309514, "Family Camp 1", "family", testSessionStart, testSessionEnd, 2025)
+	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family", testSessionStart, testSessionEnd, 2025)
 	a := addUnit(t, app, "gt-tenaya-1")
 	b := addUnit(t, app, "gt-tenaya-2")
 
-	first, err := EnsureMerge(app, sess, 2025, "", []string{a, b}, "Tenaya")
+	first, err := EnsureMerge(app, sess, cmIDFamilyCamp1, 2025, "", []string{a, b}, "Tenaya")
 	if err != nil {
 		t.Fatalf("EnsureMerge: %v", err)
 	}
-	second, err := EnsureMerge(app, sess, 2025, "", []string{b, a}, "Tenaya")
+	second, err := EnsureMerge(app, sess, cmIDFamilyCamp1, 2025, "", []string{b, a}, "Tenaya")
 	if err != nil {
 		t.Fatalf("EnsureMerge reversed: %v", err)
 	}
@@ -66,21 +66,21 @@ func TestEnsureMergeIgnoresMemberOrder(t *testing.T) {
 // because a merge is one weekend's arrangement, not a permanent building change.
 func TestEnsureMergeIsPerSessionAndScenario(t *testing.T) {
 	app := newLodgingTestApp(t)
-	sessA := addSession(t, app, 1309514, "Family Camp 1", "family", testSessionStart, testSessionEnd, 2025)
-	sessB := addSession(t, app, 1309519, "Family Camp 6", "family",
+	sessA := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family", testSessionStart, testSessionEnd, 2025)
+	sessB := addSession(t, app, cmIDFamilyCamp6, "Family Camp 6", "family",
 		"2025-09-18 07:00:00.000Z", "2025-09-21 07:00:00.000Z", 2025)
 	u1 := addUnit(t, app, "gt-tioga-1")
 	u2 := addUnit(t, app, "gt-tioga-2")
 
-	live, err := EnsureMerge(app, sessA, 2025, "", []string{u1, u2}, "Tioga")
+	live, err := EnsureMerge(app, sessA, cmIDFamilyCamp1, 2025, "", []string{u1, u2}, "Tioga")
 	if err != nil {
 		t.Fatalf("live merge: %v", err)
 	}
-	otherSession, err := EnsureMerge(app, sessB, 2025, "", []string{u1, u2}, "Tioga")
+	otherSession, err := EnsureMerge(app, sessB, cmIDFamilyCamp6, 2025, "", []string{u1, u2}, "Tioga")
 	if err != nil {
 		t.Fatalf("other-session merge: %v", err)
 	}
-	scenario, err := EnsureMerge(app, sessA, 2025, "scn_abc", []string{u1, u2}, "Tioga")
+	scenario, err := EnsureMerge(app, sessA, cmIDFamilyCamp1, 2025, "scn_abc", []string{u1, u2}, "Tioga")
 	if err != nil {
 		t.Fatalf("scenario merge: %v", err)
 	}
@@ -98,13 +98,13 @@ func TestEnsureMergeIsPerSessionAndScenario(t *testing.T) {
 // validation failure deep inside the backfill.
 func TestEnsureMergeRejectsFewerThanTwoMembers(t *testing.T) {
 	app := newLodgingTestApp(t)
-	sess := addSession(t, app, 1309514, "Family Camp 1", "family", testSessionStart, testSessionEnd, 2025)
+	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family", testSessionStart, testSessionEnd, 2025)
 	only := addUnit(t, app, "ridge-a")
 
-	if _, err := EnsureMerge(app, sess, 2025, "", []string{only}, "Ridge A"); err == nil {
+	if _, err := EnsureMerge(app, sess, cmIDFamilyCamp1, 2025, "", []string{only}, "Ridge A"); err == nil {
 		t.Error("EnsureMerge accepted a single-member merge; member_units has minSelect 2")
 	}
-	if _, err := EnsureMerge(app, sess, 2025, "", nil, ""); err == nil {
+	if _, err := EnsureMerge(app, sess, cmIDFamilyCamp1, 2025, "", nil, ""); err == nil {
 		t.Error("EnsureMerge accepted an empty member set")
 	}
 }
@@ -115,14 +115,14 @@ func TestEnsureMergeRejectsFewerThanTwoMembers(t *testing.T) {
 // error deep inside the backfill instead of at the call site.
 func TestEnsureMergeRejectsMoreThanMaxMembers(t *testing.T) {
 	app := newLodgingTestApp(t)
-	sess := addSession(t, app, 1309514, "Family Camp 1", "family", testSessionStart, testSessionEnd, 2025)
+	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family", testSessionStart, testSessionEnd, 2025)
 
 	tooMany := make([]string, 0, maxMergeMembers+1)
 	for i := range maxMergeMembers + 1 {
 		tooMany = append(tooMany, addUnit(t, app, fmt.Sprintf("unit-%02d", i)))
 	}
 
-	_, err := EnsureMerge(app, sess, 2025, "", tooMany, "Oversized")
+	_, err := EnsureMerge(app, sess, cmIDFamilyCamp1, 2025, "", tooMany, "Oversized")
 	if err == nil {
 		t.Fatalf("EnsureMerge accepted %d members; member_units has maxSelect %d",
 			len(tooMany), maxMergeMembers)

--- a/pocketbase/sync/lodging_phi_test.go
+++ b/pocketbase/sync/lodging_phi_test.go
@@ -1,0 +1,51 @@
+package sync
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLodgingCollectionsAreNeverExported guards the claim SyncJobToCollections
+// makes about the lodging ingest: its entry exists so the export-skip
+// optimisation knows which collections the job writes, NOT because any of them
+// is exported.
+//
+// The distinction matters because the two lists look interchangeable and are
+// not. SyncJobToCollections is a write manifest; GetReadableYearExports is a
+// publish list that ships rows to Google Sheets. lodging_assignments and
+// lodging_assignment_history carry per-household and per-person placement --
+// who slept where -- which is exactly the shape of data family_camp_medical is
+// deliberately kept out of the publish list for.
+//
+// Without this test the invariant is a comment, and the failure mode is silent:
+// a future lodging-board export lands in GetReadableYearExports, nothing goes
+// red, and placement data reaches a spreadsheet.
+func TestLodgingCollectionsAreNeverExported(t *testing.T) {
+	exported := map[string]string{}
+	for _, cfg := range GetReadableYearExports() {
+		exported[cfg.Collection] = "GetReadableYearExports"
+	}
+	for _, cfg := range GetReadableGlobalExports() {
+		exported[cfg.Collection] = "GetReadableGlobalExports"
+	}
+
+	for collection, where := range exported {
+		if strings.HasPrefix(collection, "lodging_") {
+			t.Errorf("%s exports %q; lodging collections carry placement data and must not ship to Sheets",
+				where, collection)
+		}
+	}
+
+	// The write manifest is the other half of the claim: every collection the
+	// ingest writes has to be listed there, or the export-skip optimisation
+	// silently misses it.
+	written, ok := SyncJobToCollections[serviceNameLodgingAssignments]
+	if !ok {
+		t.Fatal("lodging_assignments missing from SyncJobToCollections")
+	}
+	for _, collection := range written {
+		if where, isExported := exported[collection]; isExported {
+			t.Errorf("%s is both written by the ingest and exported by %s", collection, where)
+		}
+	}
+}

--- a/pocketbase/sync/lodging_session_attribution.go
+++ b/pocketbase/sync/lodging_session_attribution.go
@@ -41,6 +41,27 @@ type Attribution struct {
 	BestGuess  string
 }
 
+// SessionCMID returns the attributed session's CampMinder id, or 0 when nothing
+// was attributed.
+//
+// The placement tables require this column (migration 1500000124): camp_sessions
+// is unique on (cm_id, year), so its PB record id is scoped to one season and
+// cannot carry a cross-year question. Reading the id off the matching candidate
+// rather than re-querying keeps the pair consistent -- an assignment whose
+// session_cm_id disagreed with its session relation would be worse than either
+// alone.
+func (a Attribution) SessionCMID() int {
+	if a.SessionID == "" {
+		return 0
+	}
+	for _, c := range a.Candidates {
+		if c.ID == a.SessionID {
+			return c.CMID
+		}
+	}
+	return 0
+}
+
 // CandidateCMIDs returns the candidate session CampMinder ids, for the queue item.
 func (a Attribution) CandidateCMIDs() []int {
 	out := make([]int, 0, len(a.Candidates))

--- a/pocketbase/sync/lodging_session_attribution.go
+++ b/pocketbase/sync/lodging_session_attribution.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/core"
 )
 
@@ -235,11 +236,11 @@ func loadPersonHouseholdCMIDs(app core.App, year int) (map[int]int, error) {
 // a one-weekend one, so an ambiguous_session becomes a CONFIDENT WRONG
 // attribution once Task 11 starts writing assignments. `id` is unique and
 // immutable, so it is a stable page key.
-func findAllRecords(app core.App, collection, filter string) ([]*core.Record, error) {
+func findAllRecords(app core.App, collection, filter string, params ...dbx.Params) ([]*core.Record, error) {
 	const perPage = 500
 	var all []*core.Record
 	for page := 1; ; page++ {
-		batch, err := app.FindRecordsByFilter(collection, filter, "id", perPage, (page-1)*perPage)
+		batch, err := app.FindRecordsByFilter(collection, filter, "id", perPage, (page-1)*perPage, params...)
 		if err != nil {
 			return nil, fmt.Errorf("querying %s page %d: %w", collection, page, err)
 		}

--- a/pocketbase/sync/lodging_session_cascade_test.go
+++ b/pocketbase/sync/lodging_session_cascade_test.go
@@ -1,0 +1,148 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+)
+
+// newCascadeProbeApp builds camp_sessions plus one placement table whose session
+// relation is configured exactly as migration 1500000124 leaves it: required,
+// with cascadeDelete off.
+func newCascadeProbeApp(t *testing.T, cascade bool) (app core.App, sessionID, assignmentID string) {
+	t.Helper()
+	created, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	// Cleanup is on the concrete *tests.TestApp, not on the core.App interface
+	// the named result is typed as.
+	t.Cleanup(created.Cleanup)
+	app = created
+
+	sessions := core.NewBaseCollection("camp_sessions")
+	sessions.Fields.Add(&core.NumberField{Name: "cm_id"})
+	sessions.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(sessions); err != nil {
+		t.Fatalf("save camp_sessions: %v", err)
+	}
+
+	placements := core.NewBaseCollection("lodging_assignments")
+	placements.Fields.Add(&core.RelationField{
+		Name: "session", CollectionId: sessions.Id, MaxSelect: 1,
+		Required: true, CascadeDelete: cascade,
+	})
+	placements.Fields.Add(&core.NumberField{Name: "session_cm_id", Required: true})
+	placements.Fields.Add(&core.NumberField{Name: "household_cm_id"})
+	if err := app.Save(placements); err != nil {
+		t.Fatalf("save lodging_assignments: %v", err)
+	}
+
+	sess := core.NewRecord(sessions)
+	sess.Set("cm_id", 1309514)
+	sess.Set("year", 2025)
+	if err := app.Save(sess); err != nil {
+		t.Fatalf("save session: %v", err)
+	}
+
+	assign := core.NewRecord(placements)
+	assign.Set("session", sess.Id)
+	assign.Set("session_cm_id", 1309514)
+	assign.Set("household_cm_id", 9001)
+	if err := app.Save(assign); err != nil {
+		t.Fatalf("save assignment: %v", err)
+	}
+	return app, sess.Id, assign.Id
+}
+
+// TestSessionDeleteIsBlockedWhileAssignmentsExist is the kindred#1879 fix, proved
+// rather than assumed.
+//
+// SessionsSync orphan-deletes camp_sessions rows CampMinder did not return this
+// run. With cascadeDelete on, that quietly removed every assignment for the
+// weekend. Because `session` is REQUIRED, turning the cascade off makes
+// PocketBase refuse the parent delete instead -- the sync reports an error and
+// no lodging row is lost.
+func TestSessionDeleteIsBlockedWhileAssignmentsExist(t *testing.T) {
+	app, sessionID, assignID := newCascadeProbeApp(t, false)
+
+	sess, err := app.FindRecordById("camp_sessions", sessionID)
+	if err != nil {
+		t.Fatalf("find session: %v", err)
+	}
+	if delErr := app.Delete(sess); delErr == nil {
+		t.Fatal("PocketBase allowed deleting a session that still has an assignment; " +
+			"cascadeDelete=false on a REQUIRED relation is supposed to block it")
+	}
+
+	// The assignment must still be there, still pointing at its session.
+	got, err := app.FindRecordById("lodging_assignments", assignID)
+	if err != nil {
+		t.Fatalf("assignment disappeared despite the delete being refused: %v", err)
+	}
+	if got.GetString("session") != sessionID {
+		t.Errorf("assignment.session = %q, want %q", got.GetString("session"), sessionID)
+	}
+	if got.GetInt("session_cm_id") != 1309514 {
+		t.Errorf("session_cm_id = %d, want 1309514", got.GetInt("session_cm_id"))
+	}
+}
+
+// TestSessionDeleteCascadesWhenCascadeIsOn documents the behavior the migration
+// moves away from. If this ever stops passing, PocketBase changed its cascade
+// semantics and the reasoning behind 1500000124 needs revisiting.
+func TestSessionDeleteCascadesWhenCascadeIsOn(t *testing.T) {
+	app, sessionID, assignID := newCascadeProbeApp(t, true)
+
+	sess, err := app.FindRecordById("camp_sessions", sessionID)
+	if err != nil {
+		t.Fatalf("find session: %v", err)
+	}
+	if err := app.Delete(sess); err != nil {
+		t.Fatalf("delete session: %v", err)
+	}
+
+	if _, err := app.FindRecordById("lodging_assignments", assignID); err == nil {
+		t.Error("expected the assignment to have been cascaded away; " +
+			"if it survived, the premise of kindred#1879 no longer holds")
+	}
+}
+
+// TestSessionCMIDSurvivesAcrossYears pins why the durable key exists at all.
+//
+// camp_sessions is unique on (cm_id, year), so a program that runs, skips a year
+// and returns gets a DIFFERENT PocketBase record id each season. Any cross-year
+// question -- "same cabin as last year" -- can only be joined on the CampMinder
+// id, which is why session_cm_id sits beside the relation instead of replacing it.
+func TestSessionCMIDSurvivesAcrossYears(t *testing.T) {
+	app, _, _ := newCascadeProbeApp(t, false)
+
+	sessions, err := app.FindCollectionByNameOrId("camp_sessions")
+	if err != nil {
+		t.Fatalf("find camp_sessions: %v", err)
+	}
+	// The same program, two seasons apart.
+	revived := core.NewRecord(sessions)
+	revived.Set("cm_id", 1309514)
+	revived.Set("year", 2027)
+	if saveErr := app.Save(revived); saveErr != nil {
+		t.Fatalf("save revived session: %v", saveErr)
+	}
+
+	rows, err := app.FindRecordsByFilter("camp_sessions", "cm_id = 1309514", "year", 0, 0)
+	if err != nil {
+		t.Fatalf("find by cm_id: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows for one program across two years, got %d", len(rows))
+	}
+	if rows[0].Id == rows[1].Id {
+		t.Fatal("the two seasons share a record id; the fixture is wrong")
+	}
+	// Same CampMinder identity, different PB ids: exactly the case a relation
+	// cannot express and session_cm_id can.
+	if rows[0].GetInt("cm_id") != rows[1].GetInt("cm_id") {
+		t.Error("cm_id differs across years; it is supposed to be the stable identity")
+	}
+}

--- a/pocketbase/sync/lodging_testsupport_test.go
+++ b/pocketbase/sync/lodging_testsupport_test.go
@@ -7,6 +7,16 @@ import (
 	"github.com/pocketbase/pocketbase/tests"
 )
 
+// CampMinder ids for the fixture sessions. Shared across the lodging tests
+// because session_cm_id is a required column on the placement tables, so a
+// session's cm id is now asserted as often as its PB record id -- and the two
+// disagreeing is exactly the bug the durable key exists to prevent.
+const (
+	cmIDFamilyCamp1  = 1309514
+	cmIDFamilyCamp6  = 1309519
+	cmIDWinterFamily = 1354939
+)
+
 // newLodgingTestApp returns a throwaway PocketBase app carrying every collection
 // the lodging ingest reads or writes, shaped like production's.
 //
@@ -58,6 +68,16 @@ func newLodgingTestApp(t *testing.T) core.App {
 	attendees.Fields.Add(&core.NumberField{Name: "year"})
 	saveCollection(t, app, attendees)
 
+	// Accompanying adults, scraped from custom-field values rather than enrolled.
+	// CampMinder enrolls only the children for family camp, so party_size is wrong
+	// without this table.
+	adults := core.NewBaseCollection("family_camp_adults")
+	adults.Fields.Add(&core.RelationField{Name: "household", CollectionId: households.Id, MaxSelect: 1})
+	adults.Fields.Add(&core.NumberField{Name: "year"})
+	adults.Fields.Add(&core.NumberField{Name: "adult_number"})
+	adults.Fields.Add(&core.TextField{Name: "name"})
+	saveCollection(t, app, adults)
+
 	hcv := core.NewBaseCollection("household_custom_values")
 	hcv.Fields.Add(&core.RelationField{Name: "household", CollectionId: households.Id, MaxSelect: 1})
 	hcv.Fields.Add(&core.RelationField{Name: "field_definition", CollectionId: defs.Id, MaxSelect: 1})
@@ -94,6 +114,10 @@ func newLodgingTestApp(t *testing.T) core.App {
 
 	merges := core.NewBaseCollection("lodging_merges")
 	merges.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	// Required, mirroring migration 1500000124. PocketBase treats an unset number
+	// as 0 and a required number rejects 0, so a writer that forgets this column
+	// fails loudly here instead of only in production.
+	merges.Fields.Add(&core.NumberField{Name: "session_cm_id", Required: true, OnlyInt: true})
 	merges.Fields.Add(&core.NumberField{Name: "year"})
 	merges.Fields.Add(&core.TextField{Name: "scenario"})
 	merges.Fields.Add(&core.RelationField{Name: "member_units", CollectionId: units.Id, MaxSelect: 20})
@@ -103,6 +127,8 @@ func newLodgingTestApp(t *testing.T) core.App {
 
 	assignments := core.NewBaseCollection("lodging_assignments")
 	assignments.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	// Required, mirroring migration 1500000124. See the merges note above.
+	assignments.Fields.Add(&core.NumberField{Name: "session_cm_id", Required: true, OnlyInt: true})
 	assignments.Fields.Add(&core.NumberField{Name: "year"})
 	assignments.Fields.Add(&core.RelationField{Name: "unit", CollectionId: units.Id, MaxSelect: 1})
 	assignments.Fields.Add(&core.RelationField{Name: "merge", CollectionId: merges.Id, MaxSelect: 1})
@@ -120,6 +146,11 @@ func newLodgingTestApp(t *testing.T) core.App {
 	history.Fields.Add(&core.NumberField{Name: "household_cm_id"})
 	history.Fields.Add(&core.NumberField{Name: "person_cm_id"})
 	history.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	// Optional here, unlike the placement tables: migration 1500000124 leaves the
+	// audit trail's session relation nullable so a history row outlives its
+	// session, and session_cm_id is what lets that surviving row still name the
+	// weekend it described.
+	history.Fields.Add(&core.NumberField{Name: "session_cm_id", OnlyInt: true})
 	history.Fields.Add(&core.NumberField{Name: "year"})
 	history.Fields.Add(&core.TextField{Name: "old_unit"})
 	history.Fields.Add(&core.TextField{Name: "new_unit"})
@@ -243,9 +274,24 @@ func addAlias(t *testing.T, app core.App, aliasString string, unitIDs []string, 
 	})
 }
 
-// NOTE: addHouseholdValue / addPersonValue belong here too, but their first
-// consumer is Task 11 (the household-grain sync), which ships in the B2 PR.
-// Adding them now would leave two permanently-unused helpers in this PR, and the
-// `unused` linter fails the pre-push hook on them. B2 appends them to this file
-// alongside the code that calls them. The custom-values collections themselves
-// are already built by newLodgingTestApp above, so nothing else has to move.
+// addFamilyCampAdult records one accompanying adult. These people are never
+// enrolled in CampMinder -- they exist only as custom-field values -- so they are
+// invisible to attendees and have to be counted separately for party_size.
+func addFamilyCampAdult(t *testing.T, app core.App, householdPBID string, year, adultNumber int, name string) {
+	t.Helper()
+	saveRecord(t, app, "family_camp_adults", map[string]any{
+		"household": householdPBID, "year": year, "adult_number": adultNumber, "name": name,
+	})
+}
+
+// addHouseholdValue stores one household custom-field answer. lastUpdated is
+// CampMinder's raw .NET DateTimeOffset string, not a PocketBase date.
+func addHouseholdValue(
+	t *testing.T, app core.App, householdPBID, fieldDefPBID, value, lastUpdated string, year int,
+) string {
+	t.Helper()
+	return saveRecord(t, app, "household_custom_values", map[string]any{
+		"household": householdPBID, "field_definition": fieldDefPBID,
+		"value": value, "last_updated": lastUpdated, "year": year,
+	})
+}

--- a/pocketbase/sync/lodging_testsupport_test.go
+++ b/pocketbase/sync/lodging_testsupport_test.go
@@ -113,7 +113,13 @@ func newLodgingTestApp(t *testing.T) core.App {
 	saveCollection(t, app, aliases)
 
 	merges := core.NewBaseCollection("lodging_merges")
-	merges.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	// Required, mirroring production. cascadeDelete=false only blocks deleting
+	// the parent session while the relation is REQUIRED (migration 1500000124),
+	// so a fixture that leaves it optional can save detached placement rows that
+	// production rejects -- and would pass a test for the very bug #1879 was.
+	merges.Fields.Add(&core.RelationField{
+		Name: "session", CollectionId: sessions.Id, MaxSelect: 1, Required: true,
+	})
 	// Required, mirroring migration 1500000124. PocketBase treats an unset number
 	// as 0 and a required number rejects 0, so a writer that forgets this column
 	// fails loudly here instead of only in production.
@@ -126,7 +132,10 @@ func newLodgingTestApp(t *testing.T) core.App {
 	saveCollection(t, app, merges)
 
 	assignments := core.NewBaseCollection("lodging_assignments")
-	assignments.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	// Required, mirroring production. See the merges note above.
+	assignments.Fields.Add(&core.RelationField{
+		Name: "session", CollectionId: sessions.Id, MaxSelect: 1, Required: true,
+	})
 	// Required, mirroring migration 1500000124. See the merges note above.
 	assignments.Fields.Add(&core.NumberField{Name: "session_cm_id", Required: true, OnlyInt: true})
 	assignments.Fields.Add(&core.NumberField{Name: "year"})

--- a/pocketbase/sync/lodging_testsupport_test.go
+++ b/pocketbase/sync/lodging_testsupport_test.go
@@ -284,6 +284,18 @@ func addFamilyCampAdult(t *testing.T, app core.App, householdPBID string, year, 
 	})
 }
 
+// addPersonValue stores one person custom-field answer. Same shape as
+// addHouseholdValue; the person grain is where adult weekends live.
+func addPersonValue(
+	t *testing.T, app core.App, personPBID, fieldDefPBID, value, lastUpdated string, year int,
+) string {
+	t.Helper()
+	return saveRecord(t, app, "person_custom_values", map[string]any{
+		"person": personPBID, "field_definition": fieldDefPBID,
+		"value": value, "last_updated": lastUpdated, "year": year,
+	})
+}
+
 // addHouseholdValue stores one household custom-field answer. lastUpdated is
 // CampMinder's raw .NET DateTimeOffset string, not a PocketBase date.
 func addHouseholdValue(

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -80,6 +80,7 @@ var syncJobMeta = []JobMeta{
 	// Transform phase - PocketBase → PocketBase
 	{"camper_history", PhaseTransform, "Compute camper history from attendees"},
 	{"family_camp_derived", PhaseTransform, "Compute family camp tables from custom values"},
+	{"lodging_assignments", PhaseTransform, "Derive lodging assignments from CampMinder cabin fields"},
 	{"staff_skills", PhaseTransform, "Extract staff skills from person_custom_values"},
 	{"financial_aid_applications", PhaseTransform, "Extract FA applications from person_custom_values"},
 	{"household_demographics", PhaseTransform, "Compute household demographics from custom values"},
@@ -165,7 +166,7 @@ func GetDefaultUnifiedSyncJobs(includeCustomValues bool) []string {
 	// Transform phase: Always run using existing custom values data
 	// (same as daily sync behavior)
 	jobs = append(jobs,
-		"camper_history", "family_camp_derived", "staff_skills",
+		"camper_history", "family_camp_derived", "lodging_assignments", "staff_skills",
 		"financial_aid_applications", "household_demographics",
 		"camper_dietary", "camper_transportation", "quest_registrations",
 		"staff_applications", "staff_vehicle_info", "normalize_geographic",
@@ -719,6 +720,7 @@ func getDailySyncJobs() []string {
 		// New enrollments, session changes, etc. are reflected immediately.
 		"camper_history",
 		"family_camp_derived",
+		"lodging_assignments", // Derived: cabin custom fields -> lodging_assignments (+ history)
 		"staff_skills",
 		"financial_aid_applications",
 		"household_demographics",
@@ -1238,6 +1240,11 @@ func (o *Orchestrator) RunSyncWithOptions(ctx context.Context, opts Options) err
 		familyCampDerivedSync := NewFamilyCampDerivedSync(o.app)
 		familyCampDerivedSync.Year = opts.Year
 		o.RegisterService("family_camp_derived", familyCampDerivedSync)
+
+		// Lodging assignments (derived from the cabin custom fields)
+		lodgingAssignmentsSync := NewLodgingAssignmentsSync(o.app)
+		lodgingAssignmentsSync.Year = opts.Year
+		o.RegisterService("lodging_assignments", lodgingAssignmentsSync)
 
 		// Staff skills (derived from person_custom_values Skills- fields)
 		staffSkillsSync := NewStaffSkillsSync(o.app)
@@ -1812,6 +1819,9 @@ func (o *Orchestrator) InitializeSyncServices() error {
 
 	// Family camp derived tables (computes from custom values - on-demand)
 	o.RegisterService("family_camp_derived", NewFamilyCampDerivedSync(o.app))
+
+	// Lodging assignments (derived from the cabin custom fields - on-demand)
+	o.RegisterService("lodging_assignments", NewLodgingAssignmentsSync(o.app))
 
 	// Staff skills (derived from person_custom_values Skills- fields)
 	o.RegisterService("staff_skills", NewStaffSkillsSync(o.app))

--- a/pocketbase/sync/orchestrator_test.go
+++ b/pocketbase/sync/orchestrator_test.go
@@ -2402,7 +2402,7 @@ func TestRunSyncWithOptionsPhaseOrdering(t *testing.T) {
 			"session_groups", "sessions", "attendees", "persons",
 			"bunks", "bunk_plans", "bunk_assignments", "staff", "financial_transactions",
 			// Transform phase (same order as RunDailySync)
-			"camper_history", "family_camp_derived", "staff_skills",
+			"camper_history", "family_camp_derived", "lodging_assignments", "staff_skills",
 			"financial_aid_applications", "household_demographics",
 			"camper_dietary", "camper_transportation", "quest_registrations",
 			"staff_applications", "staff_vehicle_info", "normalize_geographic",

--- a/pocketbase/sync/table_exporter.go
+++ b/pocketbase/sync/table_exporter.go
@@ -55,7 +55,14 @@ var SyncJobToCollections = map[string][]string{
 	"household_custom_values": {"household_custom_values"},
 	"session_groups":          {"session_groups"},
 	// Derived tables
-	"family_camp_derived":        {"family_camp_adults", "family_camp_registrations", "family_camp_medical"},
+	"family_camp_derived": {"family_camp_adults", "family_camp_registrations", "family_camp_medical"},
+	// Assignment ingest. Present so the export-skip optimisation knows which
+	// collections this job writes -- NOT an export. None of these collections
+	// appears in GetReadableYearExports(), and lodging_phi_test.go asserts that.
+	"lodging_assignments": {
+		"lodging_assignments", "lodging_assignment_history",
+		"lodging_merges", "lodging_ingest_issues",
+	},
 	"staff_skills":               {"staff_skills"},
 	"financial_aid_applications": {"financial_aid_applications"},
 	"household_demographics":     {"household_demographics"},

--- a/scripts/dev/verify-lodging-backfill.sh
+++ b/scripts/dev/verify-lodging-backfill.sh
@@ -45,8 +45,14 @@ for year in "${YEARS[@]}"; do
     queued AS (
       SELECT DISTINCT raw_value AS raw FROM lodging_ingest_issues WHERE year = $year
     ),
+    -- lower(trim(...)) mirrors aliasLookupKey in lodging_alias_resolver.go
+    -- exactly: the resolver matches on strings.ToLower(strings.TrimSpace(raw)),
+    -- so comparing byte-for-byte here reports values that DO resolve as silent
+    -- drops. Inner whitespace stays significant because the resolver keeps it.
+    -- The queued comparison below is deliberately left verbatim -- raw_value
+    -- stores the string exactly as CampMinder gave it.
     resolved AS (
-      SELECT DISTINCT a.alias_string AS raw
+      SELECT DISTINCT lower(trim(a.alias_string)) AS raw
         FROM lodging_unit_aliases a
         WHERE (a.valid_from_year = 0 OR a.valid_from_year <= $year)
           AND (a.valid_to_year   = 0 OR a.valid_to_year   >= $year)
@@ -54,7 +60,7 @@ for year in "${YEARS[@]}"; do
     SELECT group_concat('[' || obs.raw || ']', ' ')
       FROM obs
       LEFT JOIN queued   ON queued.raw   = obs.raw
-      LEFT JOIN resolved ON resolved.raw = obs.raw
+      LEFT JOIN resolved ON resolved.raw = lower(trim(obs.raw))
       WHERE queued.raw IS NULL AND resolved.raw IS NULL
     ")
 

--- a/scripts/dev/verify-lodging-backfill.sh
+++ b/scripts/dev/verify-lodging-backfill.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Spec 6.2: "every historical value must resolve to a unit or appear in an
+# unresolved-alias report. Zero silent drops."
+#
+# Reconciles, per year, the distinct cabin strings observed in the two source
+# fields against what the ingest accounted for -- either an assignment row or a
+# lodging_ingest_issues row. Anything in neither set is a silent drop.
+#
+# Usage: verify-lodging-backfill.sh <db-path> [year ...]     (default: 2024 2025)
+set -euo pipefail
+
+DB=${1:?usage: verify-lodging-backfill.sh <db-path> [year ...]}
+shift || true
+YEARS=("$@")
+[[ ${#YEARS[@]} -gt 0 ]] || YEARS=(2024 2025)
+
+[[ -f "$DB" ]] || { echo "error: no database at $DB" >&2; exit 2; }
+
+fail=0
+note() { echo "FAIL: $*" >&2; fail=1; }
+
+for year in "${YEARS[@]}"; do
+  observed=$(sqlite3 "$DB" "
+    SELECT COUNT(DISTINCT v.value) FROM household_custom_values v
+      JOIN custom_field_defs d ON d.id = v.field_definition
+      WHERE d.cm_id = 218072 AND v.year = $year AND v.value <> ''
+    ")
+  observed_person=$(sqlite3 "$DB" "
+    SELECT COUNT(DISTINCT v.value) FROM person_custom_values v
+      JOIN custom_field_defs d ON d.id = v.field_definition
+      WHERE d.cm_id = 223823 AND v.year = $year AND v.value <> ''
+    ")
+
+  # Strings that produced neither an assignment nor a queue item.
+  unaccounted=$(sqlite3 "$DB" "
+    WITH obs AS (
+      SELECT DISTINCT v.value AS raw FROM household_custom_values v
+        JOIN custom_field_defs d ON d.id = v.field_definition
+        WHERE d.cm_id = 218072 AND v.year = $year AND v.value <> ''
+      UNION
+      SELECT DISTINCT v.value FROM person_custom_values v
+        JOIN custom_field_defs d ON d.id = v.field_definition
+        WHERE d.cm_id = 223823 AND v.year = $year AND v.value <> ''
+    ),
+    queued AS (
+      SELECT DISTINCT raw_value AS raw FROM lodging_ingest_issues WHERE year = $year
+    ),
+    resolved AS (
+      SELECT DISTINCT a.alias_string AS raw
+        FROM lodging_unit_aliases a
+        WHERE (a.valid_from_year = 0 OR a.valid_from_year <= $year)
+          AND (a.valid_to_year   = 0 OR a.valid_to_year   >= $year)
+    )
+    SELECT group_concat('[' || obs.raw || ']', ' ')
+      FROM obs
+      LEFT JOIN queued   ON queued.raw   = obs.raw
+      LEFT JOIN resolved ON resolved.raw = obs.raw
+      WHERE queued.raw IS NULL AND resolved.raw IS NULL
+    ")
+
+  assigned=$(sqlite3 "$DB" "SELECT COUNT(*) FROM lodging_assignments WHERE year = $year")
+  issues=$(sqlite3 "$DB" "SELECT COUNT(*) FROM lodging_ingest_issues WHERE year = $year")
+  hist=$(sqlite3 "$DB" "SELECT COUNT(*) FROM lodging_assignment_history WHERE year = $year")
+
+  echo "$year: ${observed} distinct household strings, ${observed_person} person, " \
+       "${assigned} assignments, ${issues} queue items, ${hist} history rows"
+
+  if [[ -n "$unaccounted" ]]; then
+    note "$year: strings accounted for by neither an assignment nor the work queue: $unaccounted"
+  fi
+
+  # Did the ingest actually run? The check above asks whether each observed
+  # string COULD resolve, which an alias row alone satisfies -- so a year whose
+  # strings are all mapped passes it even with the ingest never run and every
+  # value dropped. That is the exact false-green this gate exists to catch, so
+  # assert the output side too: observed values and nothing written at all means
+  # no run, not a clean one. A real run producing no assignments still queues
+  # its reasons, so only the both-zero case is unreachable when it has run.
+  if [[ $((observed + observed_person)) -gt 0 && "$assigned" -eq 0 && "$issues" -eq 0 ]]; then
+    note "$year: cabin values observed but no assignments AND no queue items -- the ingest has not run"
+  fi
+
+  # An assignment must never point at nothing. Optional relations orphan
+  # silently in PocketBase (spec 9a.1), so check rather than assume.
+  orphans=$(sqlite3 "$DB" "
+    SELECT COUNT(*) FROM lodging_assignments a
+      WHERE a.year = $year
+        AND (a.unit = '' OR a.unit IS NULL)
+        AND (a.merge = '' OR a.merge IS NULL)
+    ")
+  [[ "$orphans" -eq 0 ]] || note "$year: $orphans assignments point at neither a unit nor a merge"
+
+  # The dual-grain XOR has no database backing (spec 9a.2).
+  bad_grain=$(sqlite3 "$DB" "
+    SELECT COUNT(*) FROM lodging_assignments
+      WHERE year = $year
+        AND ((household_cm_id > 0 AND person_cm_id > 0)
+          OR (household_cm_id = 0 AND person_cm_id = 0))
+    ")
+  [[ "$bad_grain" -eq 0 ]] || note "$year: $bad_grain assignments violate the household/person XOR"
+done
+
+[[ "$fail" -eq 0 ]] || exit 1
+echo "verify-lodging-backfill: OK"

--- a/scripts/dev/verify-lodging-schema.sh
+++ b/scripts/dev/verify-lodging-schema.sh
@@ -142,9 +142,15 @@ for c in lodging_ingest_issues lodging_field_mappings; do
   [[ "$n" -eq 1 ]] || note "collection $c missing"
 done
 
+# Pinned exactly, and in order: kind is a SELECT, so this list -- not the Go
+# constants in lodging_issues.go -- is what PocketBase validates writes against.
+# A constant added on the Go side without the matching migration fails at save
+# time in production and nowhere else, because the test fixture models kind as a
+# plain text field. unknown_party and write_failed arrived in 1500000125.
 ik=$(field_prop lodging_ingest_issues kind values || true)
-[[ "$ik" == '["unresolved_alias","ambiguous_alias","ambiguous_session","no_session","field_zero_values"]' ]] \
-  || note "lodging_ingest_issues.kind values are $ik"
+want_ik='["unresolved_alias","ambiguous_alias","ambiguous_session","no_session","field_zero_values","unknown_party","write_failed"]'
+[[ "$ik" == "$want_ik" ]] \
+  || note "lodging_ingest_issues.kind values are $ik, want $want_ik"
 
 # The dedup index is what keeps a 472-row backfill from writing 472 issue rows.
 # Assert its COLUMNS, not just its name: an index that keeps the name but loses a
@@ -196,9 +202,28 @@ done
 # returning after a gap comes back with a different PB record id. Cross-year
 # questions ("same cabin as last year") can only be joined on the CampMinder id,
 # which is why the durable key sits beside the relation rather than replacing it.
+#
+# The required-ness is asymmetric on purpose and has to be checked, not assumed:
+# the three placement tables require the durable key so the assignment sync fails
+# loudly rather than writing rows that cannot survive a session being recreated,
+# while lodging_assignment_history leaves it optional because an audit row is
+# meant to outlive its session. A migration flipping either way would otherwise
+# pass this verifier in silence.
 for c in lodging_merges lodging_availability lodging_assignments lodging_assignment_history; do
   [[ "$(field_prop "$c" session_cm_id onlyInt || true)" == "1" ]] \
     || note "$c.session_cm_id missing or not onlyInt (see kindred#1879)"
+
+  # PocketBase renders this as a JSON boolean, so json_extract yields 1/0 -- but
+  # a false is sometimes omitted from the serialized field entirely, which comes
+  # back empty. Treat empty as false rather than as a mismatch.
+  req_cm=$(field_prop "$c" session_cm_id required || true)
+  if [[ "$c" == "lodging_assignment_history" ]]; then
+    [[ "$req_cm" == "0" || "$req_cm" == "false" || -z "$req_cm" ]] \
+      || note "$c.session_cm_id required is '$req_cm'; the audit trail must outlive its session (see kindred#1879)"
+  else
+    [[ "$req_cm" == "1" || "$req_cm" == "true" ]] \
+      || note "$c.session_cm_id required is '$req_cm', want required (see kindred#1879)"
+  fi
 done
 
 if [[ "$fail" -ne 0 ]]; then echo "verify-lodging-schema: FAILED" >&2; exit 1; fi

--- a/scripts/dev/verify-lodging-schema.sh
+++ b/scripts/dev/verify-lodging-schema.sh
@@ -177,5 +177,29 @@ fn=$(field_prop lodging_field_mappings field_name max || true)
 ra=$(field_prop lodging_ingest_issues resolved_alias cascadeDelete || true)
 [[ "$ra" == "0" || "$ra" == "false" ]] || note "lodging_ingest_issues.resolved_alias cascadeDelete is '$ra' (expected false)"
 
+# kindred#1879: a camp_session vanishing from one CampMinder response must never
+# silently take its lodging rows with it. Orphan deletion is year-scoped
+# (sessions.go builds "year = N" and passes it to DeleteOrphans), so the exposure
+# is the CURRENT sync year only -- but within that year the loss is total and
+# silent. session is required on all three, so cascadeDelete = false makes
+# PocketBase refuse the parent delete with a 400 instead of cascading.
+for c in lodging_merges lodging_availability lodging_assignments; do
+  casc=$(field_prop "$c" session cascadeDelete || true)
+  [[ "$casc" == "0" || "$casc" == "false" ]] \
+    || note "$c.session cascadeDelete is '$casc' (expected false; see kindred#1879)"
+  req=$(field_prop "$c" session required || true)
+  [[ "$req" == "1" || "$req" == "true" ]] \
+    || note "$c.session required is '$req' -- cascadeDelete=false only blocks the delete while the relation is required"
+done
+
+# Each YEAR gets its own camp_sessions row (unique on cm_id + year), so a program
+# returning after a gap comes back with a different PB record id. Cross-year
+# questions ("same cabin as last year") can only be joined on the CampMinder id,
+# which is why the durable key sits beside the relation rather than replacing it.
+for c in lodging_merges lodging_availability lodging_assignments lodging_assignment_history; do
+  [[ "$(field_prop "$c" session_cm_id onlyInt || true)" == "1" ]] \
+    || note "$c.session_cm_id missing or not onlyInt (see kindred#1879)"
+done
+
 if [[ "$fail" -ne 0 ]]; then echo "verify-lodging-schema: FAILED" >&2; exit 1; fi
 echo "verify-lodging-schema: OK ($js_migs js migrations applied)"


### PR DESCRIPTION
Closes #1879. Lodging ingest **Phase B2**: the schema prerequisite plus the `lodging_assignments` sync itself — both grains, registered, and validated against the real database.

Builds on Phase B1 (#1877), which shipped the primitives this composes.

---

## 1. Schema prerequisite — the session cascade (#1879)

`camp_sessions` rows are orphan-deleted by `SessionsSync`, and `lodging_merges`, `lodging_availability` and `lodging_assignments` each held a `session` relation with `cascadeDelete: true`. A session missing from one CampMinder response took every dependent row with it — no error, no recovery, and only a routine `deleted orphaned record` line about the *session* to show for it. That contradicts `1500000122`'s own header contract: *never a silent drop*.

**Scope, measured rather than assumed.** Orphan deletion is year-scoped: `sessions.go:65` builds `filter := fmt.Sprintf("year = %d", year)` and passes that same filter into `DeleteOrphans`, so a 2026 sync can only ever delete 2026 rows. **Historical years were never at risk** — an earlier draft of this analysis overstated the blast radius. What remains is the current sync year, where `DeleteOrphans` skips only on an outright sync *failure* and has no minimum-count guard, so a successful-but-truncated response still counts as success.

**The fix is one flag.** `session` is already `required: true` on all three tables. PocketBase refuses to delete a record behind a required relation, but only while `cascadeDelete` is false; with it true, it cascades instead. Flipping it converts silent data loss into an HTTP 400 the sessions sync reports. The cost is real and intended: a genuinely cancelled weekend now fails orphan cleanup until a human clears its lodging rows, because the sync cannot tell "cancelled" from "absent from this response".

**`session_cm_id` comes with it.** `camp_sessions` is unique on `(cm_id, year)`, so every year gets its own row — a program that runs in 2025, skips 2026 and returns in 2027 comes back with a *different* PocketBase record id. No relation can answer a cross-year question. It is **required** on the three placement tables (all empty at migration time, so nothing to backfill) and **optional** on `lodging_assignment_history`, whose relation is optional by design so the audit trail outlives its session — this is what finally lets a surviving history row say which weekend it described.

## 2. The ingest — household grain, person grain, history

- **Household grain** reads `Family Camp Cabin` (`household_custom_values`), resolves it through the temporal alias table, attributes it to a family weekend, and writes `lodging_assignments` plus a `lodging_assignment_history` row whenever the observed placement changes. History is what recovers the multi-weekend households whose earlier assignment CampMinder overwrote.
- **Person grain** reads `Reportable Family Camp Cabin` for adult weekends, keyed on `person_cm_id` with `household_cm_id` left 0 — the shape the dual-grain XOR requires. Includes a regression test for many individuals in one weekend, the exact case Plan 1's `> 0` index predicate exists to permit.
- **Unresolvable strings and ambiguous households become work-queue items, never assignments.** Spec §3.6 asks for manual entry there, and a wrong cabin on the board is worse than a blank one. An unresolvable string still leaves a history row carrying the verbatim value, so the fact that a household *was* placed somewhere survives.
- **`staff_touched` rows are skipped.** A human moved that party on the board; CampMinder must not undo it.

## 3. A latent bug this surfaced

**`EnsureMerge` was already broken on this branch.** The migration in §1 made `session_cm_id` required on `lodging_merges`, but `EnsureMerge` — written in B1, before that migration — never set it, so every merge materialisation would have failed at save time in production. Its B1 tests passed only because the Go-built test fixtures did not carry the column.

Fixed by threading the id down from the attribution that chose the session, rather than re-deriving it, so the relation and the durable key cannot disagree. The fixtures now mirror the migration's exact required/optional split, so a writer that forgets the column fails in tests instead of only in production.

## 4. Registration

Registered at every site a derived sync needs: job meta, the historical transform list, the daily `orderedJobs`, both service registrations, the API route, the status-types list, its handler, the export-skip collection map, and six frontend files. A test asserts the meta / daily / export-map registrations, because a job registered in some places but not others fails silently — it simply never runs, or the GUI shows idle forever.

`orchestrator_test.go`'s `expectedOrder` pins the unified job list exhaustively and is a real registration site the sync-layer checklist omits.

`SyncJobToCollections` gets an entry but `GetReadableYearExports` does not: the map only powers the export-skip optimisation, and no lodging collection is ever written to Google Sheets.

## 5. Performance — the ingest could not finish a backfill

Found by running the new gate against the real 716MB database rather than a fixture. A 2024 backfill **had not finished after ten minutes**, having written 695 rows. Two quadratic paths:

- `partySize` queried per household: a filtered scan of `persons` (28,610 rows) plus a full paged scan of `family_camp_adults` (9,961) for every observed cabin value, ~700 times a year. Now three indexes built once per run.
- The grain scans and the prior-year counter pulled a whole year of custom values and discarded all but the mapped fields in Go. `person_custom_values` holds **1.6M rows**, 181k for a single year, against at most two mapped field definitions — and `findAllRecords` pages with `LIMIT/OFFSET`, whose cost grows with the offset. `field_definition` now goes into the SQL.

**Result: 2024 and 2025 together now take 7.4 seconds**, down from one year not completing in 600.

## 6. Validation gate (spec §6.2)

`scripts/dev/verify-lodging-backfill.sh` reconciles the distinct observed cabin strings per year against assignments plus queue items and fails on anything in neither. It also checks two invariants the database does not enforce: that no assignment points at neither a unit nor a merge (optional relations orphan silently), and that none violates the household/person XOR.

One deviation from the plan, deliberate: the alias-coverage check alone would pass a year whose strings are all mapped **even with the ingest never run and every value dropped** — the exact false green the gate exists to catch. It now also asserts the output side.

**Measured against the real database, not fixtures:**

| | 2024 | 2025 |
|---|---|---|
| assignments (household / person) | 453 / 242 | 405 / 236 |
| `ambiguous_session` | 14 | 9 |
| `no_session` | 14 | 57 |
| `unresolved_alias` | **0** | **0** |
| errors | 0 | 0 |

Household-grain counts land within a few rows of the design-time predictions (~456 / ~411). Zero `unresolved_alias` for 2024–25 is expected — all four documented unmapped strings are pre-2024, and a 2022/23 run reproduces exactly those four, occurrence counts and household/person split included. A second pass creates nothing and skips all 1,336, so idempotency holds outside the fixtures too.

## 7. What this does not include

**Task 15 (the Wawona alias reconcile) is rejected, not deferred.** Spec §9a note 8 recommended pointing the pre-2025 alias at `merge{front, back}` on the evidence that 2024 peaked at 7 people in one household. The owner has confirmed the building is let **whole or split depending on the session**, so that reads one session's arrangement as a permanent mapping. `lodging_unit_aliases` has a *year* window and no session dimension, so it structurally cannot express this; per-session arrangement is what `lodging_merges` is for, set by staff in the Plan 3 GUI.

Known residual, deliberately left: the pre-2025 alias still resolves to a row with `is_container = 1`, which every capacity query excludes, so historical assignments pointing there are invisible to availability counts. The fix is per-session merges, not a different alias.

Phase C (the request layer and PHI containment) is #1878.

## Verification

`go test ./sync/` green, `golangci-lint` 0 issues, `gofmt` clean, `go build ./...` clean. Frontend: `tsc --noEmit` clean, `eslint` 0 errors, 4,836 Vitest tests pass. All three lodging harnesses green, plus the new backfill gate. Full pre-push suite passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Lodging Assignments synchronization for individual years and scheduled sync runs.
  * Added sync status, progress notifications, and conflict handling for lodging assignments.
  * Preserved lodging placement records when sessions are removed, maintaining stable cross-year session identity.

* **Bug Fixes**
  * Improved assignment updates for party-size, placement, and source corrections.
  * Added tracking for unknown parties and failed writes.
  * Dry runs now avoid database changes.

* **Validation**
  * Added checks for backfill consistency, orphaned assignments, and invalid lodging data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->