### PR TITLE
fix(sync): let a household blocker outrank another member's opt-out

### DIFF
--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -700,15 +700,12 @@ func (s *FamilyCampDerivedSync) processRegistrations(
 			reg.needsAccommodation = reg.needsAccommodation || parseBoolFieldValue(v.value)
 		case fieldFamCampOptOutVIP, fieldAdultOptOut:
 			optedOut := parseBoolFieldValue(v.value)
-			// NOTE (kindred#1874): this OR is retained deliberately, and it is
-			// fail-UNSAFE. Household members disagree -- 3 households in 2025 --
-			// and one member's "Yes, please register regardless of cabin type"
-			// ORs over another's "No, I am only able to attend with this
-			// accommodation in place", collapsing a blocker into a warning.
-			// opt_out_vip is therefore NOT the blocker gate and must never be
-			// read as one. accommodationIsMandatory below is the honest signal:
-			// it is set from any ANSWERED, non-opted-out value, so a conflict
-			// surfaces as mandatory rather than being collapsed away.
+			// Accumulated with OR here and then RESOLVED against the blocker in
+			// the finalization pass below (kindred#1874). Both steps are needed:
+			// this one cannot see the rest of the household, so on its own it
+			// let one member's "Yes, please register regardless of cabin type"
+			// override another's "No, I am only able to attend with this
+			// accommodation in place" -- 3 households a year.
 			reg.optOutVIP = reg.optOutVIP || optedOut
 			// "Yes, please register regardless of cabin type" (90 values) means
 			// the family will come anyway, so the need is a warning. "No, I am
@@ -744,6 +741,25 @@ func (s *FamilyCampDerivedSync) processRegistrations(
 	// Convert to slice
 	var result []*registrationData
 	for _, reg := range regMap {
+		// A blocker anywhere in the household outranks another member's opt-out
+		// (kindred#1874). Resolving it here rather than in the switch is what
+		// makes it order-independent: the switch sees one member at a time and
+		// cannot know a later one will answer blocker, so a running OR gave a
+		// different answer depending on which member CampMinder returned first.
+		//
+		// The two columns are a three-state answer wearing two booleans, and
+		// this is what keeps them mutually exclusive:
+		//
+		//	accommodationIsMandatory  -> some member cannot attend without it
+		//	optOutVIP                 -> answered, and the family will come anyway
+		//	both false                -> nobody answered
+		//
+		// Collapsing toward the blocker is the fail-SAFE direction. The reverse
+		// reads as "this family will cope" when someone said they cannot attend.
+		if reg.accommodationIsMandatory {
+			reg.optOutVIP = false
+		}
+
 		// Only include if has some data
 		if reg.cabinAssignment != "" || reg.shareCabinPreference != "" ||
 			reg.sharedCabinModesRaw != "" || reg.arrivalETA != "" ||
@@ -753,9 +769,9 @@ func (s *FamilyCampDerivedSync) processRegistrations(
 			reg.wantsNear || reg.wantsWith ||
 			reg.needsPrivateBathroom || reg.needsPower || reg.hasInfant ||
 			// accommodationIsMandatory belongs here for the same reason as the
-			// rest, and more so: opt_out_vip's OR is fail-unsafe, so this is the
-			// only honest blocker signal. A household whose only answer is the
-			// blocker was the one row that got dropped before it was written.
+			// rest, and more so: it is the blocker signal, and a household whose
+			// only answer is the blocker was the one row that got dropped before
+			// it was written.
 			reg.accommodationIsMandatory {
 			result = append(result, reg)
 		}

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -1614,6 +1614,15 @@ func TestProcessRegistrationsBoolFieldsOrAcrossPersons(t *testing.T) {
 	// Defect 2's field. CampMinder stores the whole option sentence here, so
 	// this also proves the sentence parser reaches the column and not just
 	// parseBoolFieldValue's unit test.
+	// This used to pair an opt-out with a blocker and assert the opt-out won.
+	// That fixture was the kindred#1874 conflict, and the blocker now wins it --
+	// see TestProcessRegistrationsOptOutLosesToABlockerInTheSameHousehold, which
+	// covers that case in both member orders.
+	//
+	// The property this subtest exists for is narrower and still holds: the arm
+	// accumulates across BOTH field names rather than assigning, so a second
+	// member cannot clobber the first. Two agreeing members prove that without
+	// depending on how a disagreement resolves.
 	t.Run("opt out VIP reads Adult-Opt Out and the sentence values", func(t *testing.T) {
 		regs := s.processRegistrations(nil, []customValueEntry{
 			{
@@ -1624,14 +1633,17 @@ func TestProcessRegistrationsBoolFieldsOrAcrossPersons(t *testing.T) {
 			{
 				householdPBID: "hh_chen",
 				fieldName:     "FAM CAMP-Opt Out VIP",
-				value:         "No, I am only able to attend with this accommodation in place",
+				value:         "Yes, please register regardless of cabin type",
 			},
 		})
 		if len(regs) != 1 {
 			t.Fatalf("expected 1 registration, got %d", len(regs))
 		}
 		if !regs[0].optOutVIP {
-			t.Error("Adult-Opt Out=Yes did not survive a later No; arm is assigning, not ORing")
+			t.Error("Adult-Opt Out=Yes did not reach the column; the arm is not reading both field names")
+		}
+		if regs[0].accommodationIsMandatory {
+			t.Error("two opt-outs and no blocker must not be mandatory")
 		}
 	})
 
@@ -1905,6 +1917,52 @@ func TestProcessRegistrationsOptOutMakesTheNeedAWarning(t *testing.T) {
 	}
 	if regs[0].accommodationIsMandatory {
 		t.Error("an opted-out accommodation is a warning, not a blocker")
+	}
+}
+
+// TestProcessRegistrationsOptOutLosesToABlockerInTheSameHousehold is kindred#1874.
+//
+// The two columns are a three-state answer wearing two booleans, and they must
+// stay mutually exclusive: a blocker anywhere in the household outranks another
+// member's "I'll come anyway". A plain OR over optedOut collapsed the blocker
+// into a warning for the 3 households a year whose members disagree, which is
+// the fail-UNSAFE direction -- it reads as "this family will cope" when someone
+// said they cannot attend without the accommodation.
+//
+// Order is varied because a running OR is order-sensitive and a finalization
+// pass is not; asserting only one order would pass on a fix that works by luck.
+func TestProcessRegistrationsOptOutLosesToABlockerInTheSameHousehold(t *testing.T) {
+	ts := time.Date(2025, 4, 21, 0, 0, 0, 0, time.UTC)
+	const optOut = "Yes, please register regardless of cabin type"
+	const blocker = "No, I am only able to attend with this accommodation in place"
+
+	for _, tc := range []struct {
+		name   string
+		first  string
+		second string
+	}{
+		{"opt-out answered first", optOut, blocker},
+		{"blocker answered first", blocker, optOut},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewFamilyCampDerivedSync(nil)
+			regs := s.processRegistrations(nil, []customValueEntry{
+				{householdPBID: "hh_garcia", fieldName: "FAM CAMP-Opt Out VIP",
+					value: tc.first, lastUpdated: ts},
+				{householdPBID: "hh_garcia", fieldName: "Adult-Opt Out",
+					value: tc.second, lastUpdated: ts},
+			})
+			if len(regs) != 1 {
+				t.Fatalf("registrations = %d, want 1", len(regs))
+			}
+			if !regs[0].accommodationIsMandatory {
+				t.Error("a blocker in the household must survive another member's opt-out")
+			}
+			if regs[0].optOutVIP {
+				t.Error("opt_out_vip must be false once any member answered blocker; " +
+					"the two are mutually exclusive by construction")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #1874 — the one item left open when Phase C merged.

## The defect

`opt_out_vip` aggregated with a plain OR across household members, so one member's *"Yes, please register regardless of cabin type"* overrode another's *"No, I am only able to attend with this accommodation in place"*. About **3 households a year** disagree, and the collapse ran the fail-**unsafe** way — the board read *this family will cope* when someone had said they cannot attend without the accommodation.

## Why fix the aggregation rather than retire the column

The column was carrying a comment saying it is *not* the blocker gate and *must never be read as one*, with `accommodation_is_mandatory` holding the real signal. That works, but a column documented as wrong is a trap for whoever reads it next.

Retiring it was the other option, and it loses something real: `accommodation_is_mandatory = false` conflates **nobody answered** with **everyone said they'll come anyway**. Those are different for triage — the second is a family with a genuine need who will tolerate it unmet; the first is a blank. `opt_out_vip` is the only thing separating them.

So the bug is the aggregation, not the column.

## The fix

A blocker anywhere in the household now clears `opt_out_vip`, in the **finalization pass** rather than the switch arm. That placement is the point: the switch sees one member at a time and cannot know a later one will answer blocker, which is why a running OR gave a different answer depending on the order CampMinder happened to return members in.

The two booleans are now mutually exclusive by construction and read as one three-state answer:

| State | Meaning |
|---|---|
| `accommodation_is_mandatory` | some member cannot attend without it |
| `opt_out_vip` | answered, and the family will come anyway |
| both false | nobody answered |

Collapsing toward the blocker is the fail-safe direction. The "never read this as the gate" warning is gone, because it is no longer true.

## One existing test changed, deliberately

A subtest paired an opt-out with a blocker and asserted the opt-out won. **That fixture was the #1874 conflict** — it encoded the defect.

Its stated intent is narrower: proving the arm accumulates across both field names rather than assigning (`"arm is assigning, not ORing"`). It now uses two *agreeing* members, which proves that property without depending on how a disagreement resolves, and additionally asserts the pair stays non-mandatory.

The conflict case moves to `TestProcessRegistrationsOptOutLosesToABlockerInTheSameHousehold`, which runs it in **both member orders** — a running OR is order-sensitive and a finalization pass is not, so asserting one order would pass on a fix that works by luck. Verified failing in both orders before the change.

## Verification

`go test ./sync/` green, `golangci-lint run ./sync/...` 0 issues, `gofmt` clean, `go build ./...` clean. New test observed red for the stated reason before the implementation.

Data columns are unchanged — this is a derived value recomputed on every sync, so no migration and no backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
