### PR TITLE
docs(sync): add lodging handoff and close two sync-checklist gaps

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,180 @@
+# HANDOFF — Family Camp Lodging
+
+**State as of `dc9437e9` on `main`.** The lodging **data layer** and **ingest** are complete and
+merged. The **surfaces** (read API, roster page, admin CRUD) are not started — that is the next
+body of work.
+
+This is a working document. Edit it in place: tick what ships, rewrite "Next", delete what stops
+being true. It is not a changelog — `git log` is the changelog.
+
+---
+
+## 1. Programme status
+
+Three plans. The first two are done.
+
+| Plan | Scope | Status |
+|---|---|---|
+| **1 — Data layer** | `lodging_*` collections, seed, alias registry | ✅ merged (`49d38ff8`, #1867) |
+| **2 — Ingest** | CampMinder cabin fields → assignments, requests, PHI split | ✅ merged — see below |
+| **3 — Surfaces** | Read API, `/weekend` roster, `/admin/lodging` editor | ⬜ **not started** |
+
+Plan 2 shipped in four PRs:
+
+| Phase | Tasks | Commit | What |
+|---|---|---|---|
+| A — source-field correctness | 1–3 | `78ef6d8d` (#1872) | four silently-broken columns in `family_camp_derived.go` |
+| B1 — ingest primitives | 4–10 | `2b28e0fa` (#1877) | work queue, alias resolver, merges, session attribution, grain guard |
+| B2 — ingest on | 11–14 | `0cf6420b` (#1880) | both grains, history, job registration, backfill gate |
+| C — request layer + PHI | 16–19 | `b3fa243d` (#1878) | household-grain collapse, housing flags, PHI containment |
+
+Task 15 was **rejected**, not deferred — see §3.
+
+---
+
+## 2. What is live on `main`
+
+Facts, not a work log. Do not re-verify or re-implement these.
+
+- **The lodging assignment ingest runs as a registered sync job** (`lodging_assignments`, transform
+  phase, after `family_camp_derived`). API route, status list, orchestrator registration, daily
+  `orderedJobs`, export-skip map and six frontend files are all wired.
+- **Both grains ingest.** Household grain from `Family Camp Cabin`; person grain (adult weekends)
+  from `Reportable Family Camp Cabin`. Placements resolve through the temporal alias table, attribute
+  to a weekend, and append `lodging_assignment_history` on change.
+- **Unresolvable and ambiguous inputs become work-queue rows, never assignments.**
+  `lodging_ingest_issues.kind` is a **7-value select**: `unresolved_alias`, `ambiguous_alias`,
+  `ambiguous_session`, `no_session`, `field_zero_values`, `unknown_party`, `write_failed`.
+  The Go constants are *not* the constraint — the migration's select list is, and
+  `verify-lodging-schema.sh` pins it exactly.
+- **Backfill is validated end to end against real data.** 2024+2025 in ~7s, 1336 assignments, zero
+  errors, idempotent on a second pass. `scripts/dev/verify-lodging-backfill.sh` is the gate.
+- **The request layer is household-grain.** Request fields are person-partition, so a household with
+  two enrolled children stores the same answer twice; it is collapsed before anything reads it.
+- **Housing flags are derived and PHI-free**: `needs_private_bathroom`, `needs_power`,
+  `accommodation_is_mandatory`, `has_infant`. The narrative behind them lives only in
+  `family_camp_medical`, which is admin-gated on all five rules and absent from every export config.
+- **Highest migration is `1500000126`.** Compute the next number from `main`, never from a branch.
+
+---
+
+## 3. Decisions locked
+
+Each of these was decided deliberately. Reopening one needs a reason, not a fresh read of the code.
+
+- **The ingest work queue is ONE collection: `lodging_ingest_issues`.** Plan 3's draft defines its own
+  `lodging_unresolved_aliases`. **Do not create it.** Plan 2's model is a superset (it carries `kind`,
+  `candidate_session_cm_ids`, `suggested_session`) and is the sole producer; the admin UI only reads
+  and resolves. Plan 3's Phase A Task 1 migration for that collection must be **deleted**, and its
+  work queue pointed at `lodging_ingest_issues` filtered to `kind = "unresolved_alias"`.
+- **The Wawona / Doctor's House alias reconcile is rejected** (Plan 2 Task 15, spec §9a note 8). The
+  building is let whole *or* split depending on the session's housing needs — staff-confirmed. An
+  alias has a *year* window and no session dimension, so it structurally cannot express that.
+  Per-session arrangement is what `lodging_merges` is for. Do not re-derive this from occupancy
+  numbers; the 2024 peak of 7 in one household is one session's arrangement, not a rule.
+- **`opt_out_vip` and `accommodation_is_mandatory` are one three-state answer** (`dc9437e9`, #1874):
+  mandatory → some member cannot attend without it; opt-out → answered and the family will come
+  anyway; both false → nobody answered. A blocker anywhere in the household clears the opt-out, in a
+  finalization pass rather than the per-member switch, because the switch cannot see a later member.
+- **`SyncJobToCollections` membership is not an export.** It powers only the export-skip
+  optimisation. No `lodging_*` collection is exported to Sheets, and `lodging_phi_test.go` asserts it.
+- **Known exposure, recorded not fixed:** `person_custom_values` / `household_custom_values` *are*
+  exported to Sheets with names and raw values, so PHI narrative already reaches Sheets through the
+  raw tables. Predates this work; staff may depend on the sheet. Narrowing it is an owner decision.
+
+---
+
+## 4. Next: Plan 3 — Surfaces
+
+Plan: `docs/superpowers/plans/2026-07-30-family-camp-lodging-surfaces.md` (local-only, gitignored).
+
+Three independently shippable PRs, in order:
+
+| Phase | Tasks | Ships | Depends on |
+|---|---|---|---|
+| **A — Read API** | 1–6 | `/api/lodging/*`, `lodging.phi` permission, regenerated TS types. No UI change. | `main` |
+| **B — Roster page** | 7–12 | `/weekend` roster replacing the placeholder. | Phase A merged |
+| **C — Admin CRUD** | 13–17 | `/admin/lodging` editor, Go integrity guards, work queue UI. | Phase B |
+
+Do not start B before A merges — B imports TypeScript generated from A's Pydantic models.
+
+### ⚠️ The plan's own "Branch base" section is stale
+
+It says Plan 1 is *"PR #1867, still OPEN"* and *"the `lodging_*` collections do not exist on `main`"*,
+and tells you to branch off `feature/family-camp-lodging`. **All of that is false now.** #1867 merged,
+along with three more lodging PRs. Branch Phase A off **`main`**. That worktree and branch are gone.
+
+Treat the rest of the plan's Global Constraints as current — they were verified empirically and the
+failure modes they describe are silent ones.
+
+---
+
+## 5. CRITICAL: first action before anything else
+
+Confirm the schema Plan 3 reads actually exists, before writing a line against it:
+
+```bash
+cd "$(git rev-parse --show-toplevel)/pocketbase" && go build -o pocketbase . && \
+  timeout 25 ./pocketbase serve --http=127.0.0.1:8988 --dir=./pb_data >/dev/null 2>&1
+sqlite3 pocketbase/pb_data/data.db \
+  "SELECT name FROM _collections WHERE name LIKE 'lodging_%' ORDER BY name;"
+```
+
+Expect all seven: `lodging_areas`, `lodging_assignment_history`, `lodging_assignments`,
+`lodging_availability`, `lodging_field_mappings`, `lodging_ingest_issues`, `lodging_merges`,
+`lodging_unit_aliases`, `lodging_units`. If `lodging_ingest_issues` is missing, migrations have not
+applied — fix that before anything else, because Plan 3 Task 1 will otherwise "helpfully" create a
+duplicate work-queue collection that §3 forbids.
+
+---
+
+## 6. What you should NOT do
+
+- **Do not create `lodging_unresolved_aliases`.** See §3. The plan tells you to; the ruling overrides it.
+- **Do not number a migration from a branch.** Highest on `main` is `1500000126`. Compute it:
+  `git ls-tree -r origin/main pocketbase/pb_migrations/ | grep -oE '15000[0-9]{5}' | sort -u | tail -1`
+- **Do not add a `kind` value as a Go constant without the migration.** The select list is the
+  constraint; a bare constant passes tests and fails in production.
+- **Do not read `opt_out_vip` as the blocker gate.** `accommodation_is_mandatory` is the gate.
+- **Do not add any `lodging_*` collection to `GetReadableYearExports()` / `GetReadableGlobalExports()`,
+  and never log a `family_camp_medical` text field.** `lodging_phi_test.go` fails on both, deliberately.
+- **Do not "simplify" `> 0` predicates or the `eqOrEmpty` helper.** SQLite evaluates `0 != ''` as TRUE,
+  and a bound empty-string parameter matches nothing — both silent.
+- **Do not run `golangci-lint` only at the end of a phase.** Per task. Several lint failures reached
+  push time in this programme precisely because it was deferred.
+- **Do not commit `docs/superpowers/**` or `docs/plans/**`.** Gitignored, local-only, public repo.
+
+---
+
+## 7. Useful one-liners
+
+```bash
+# Go gates — per task, not per phase
+cd pocketbase && go test ./sync/ -count=1 && gofmt -l sync/ && go build ./...
+rtk proxy golangci-lint run ./sync/...
+
+# JS migrations (npm run lint gives a FALSE failure under rtk)
+cd pocketbase && ./node_modules/.bin/eslint pb_migrations pb_hooks
+
+# Lodging harnesses
+./scripts/dev/verify-lodging-schema.sh && ./scripts/dev/verify-lodging-seed.sh
+./scripts/dev/verify-no-hardcoded-lodging.sh
+./scripts/dev/verify-lodging-backfill.sh pocketbase/pb_data/data.db 2024 2025
+
+# Verify a push actually landed (a wrapper's "ok" is a claim, not evidence)
+git fetch -q && git rev-list --count origin/<branch>..HEAD   # must be 0
+```
+
+---
+
+## 8. Open issues
+
+- **#1881** — two pre-existing package-wide patterns the ingest inherited rather than introduced:
+  every individual-sync handler in `api.go` mutates the orchestrator's singleton service, and
+  `SyncTab`'s card guard references no type-specific `isPending`. Both want **one sweep across all
+  sync types** — fixing them for lodging alone would leave the package inconsistent.
+- **#1864** — spurious `uv.lock` re-resolution dirties every fresh worktree. Discard it; `main`'s
+  lockfile is authoritative.
+- **Untested error branches on `main`** — `write_failed` queueing and the unconditional WAL
+  checkpoint landed without direct tests. A stub `core.App` whose `Save` errors on the assignments
+  collection would cover the first, which is the one with real behaviour behind it.

--- a/docs/architecture/sync-layer.md
+++ b/docs/architecture/sync-layer.md
@@ -51,8 +51,19 @@ When implementing a new sync job, ALL of these steps must be completed. Missing 
 | `RunDailySync()` orderedJobs | Add job ID string in correct position (respects dependencies) |
 | `RunSyncWithOptions()` servicesToRun | Add to default services list for historical syncs |
 | `RunSyncWithOptions()` re-registration | Add `NewXxxSync(o.app, yearClient)` call in historical re-registration block (~line 815) |
+| `syncJobMeta` | Add a `{id, Phase, description}` entry — this is what drives phase grouping and the status UI |
 
 **Common mistake**: Registering the service but forgetting to add to `orderedJobs` - job won't run in daily sync!
+
+### 2b. Orchestrator Test (`orchestrator_test.go`) — REQUIRED, and easy to miss
+
+`TestRunSyncWithOptionsPhaseOrdering` pins the unified job list **exhaustively** via its
+`expectedOrder` slice. A new job that is registered correctly everywhere else still fails the suite
+with a job-count mismatch (`expected 22 jobs, got 23`) until it is added there, in the same position
+as in `orderedJobs`.
+
+This is a genuine registration site, not a test that "happens to break" — it is the only thing
+asserting the daily and historical lists stay in step.
 
 ### 3. API Endpoint (`api.go`)
 
@@ -107,6 +118,12 @@ For jobs with other custom parameters (session, etc.), similar pattern applies.
 | `sync/table_exporter.go` | Add entry to `SyncJobToCollections` map (required for export skip optimization) |
 
 **Export skip optimization**: When a sync job has no changes (Created=0, Updated=0, Deleted=0, Errors=0), its corresponding sheet export is skipped. The `SyncJobToCollections` map links sync job names to their PocketBase collections so the export system knows which sheets can be skipped.
+
+**The two rows above are independent.** A job may need a `SyncJobToCollections` entry and **no**
+export config at all — that is the correct shape for anything writing data that must never reach a
+spreadsheet. `lodging_assignments` is the worked example: it is in the map so the skip optimisation
+knows what it writes, and deliberately absent from `GetReadableYearExports()`, with
+`sync/lodging_phi_test.go` asserting that membership in the map never implies an export.
 
 Example for a new `widgets` sync that populates the `widgets` table:
 ```go


### PR DESCRIPTION
Adds `HANDOFF.md` for the family camp lodging programme, and closes two gaps in the "Adding a New Sync Job" checklist that this programme found by hitting them.

## Why a committed handoff doc

The three lodging plans live in `docs/superpowers/`, which is **gitignored and local-only**. Every decision "baked into the plan" over the last four PRs was therefore undurable — it existed on one machine and nowhere else.

That is not hypothetical. Plan 3's own *Branch base* section currently reads:

> Plan 1 is **PR #1867, still OPEN** … The `lodging_*` collections do **not** exist on `main`. Branch Phase A off `feature/family-camp-lodging`.

All of it was true when written. None of it is now — #1867 merged, three more lodging PRs merged after it, and that worktree and branch are deleted. An agent following it would branch off something that no longer exists and then re-create schema that is already live.

`HANDOFF.md` is a **working document**, not a changelog: edit in place, tick what ships, rewrite "Next". `git log` is the changelog.

### What it records

- Programme status — Plans 1 and 2 merged (four PRs, with commits); Plan 3 not started
- What is live on `main`, phrased as facts so the next agent doesn't re-verify or un-fix it
- **Decisions locked**, which is the load-bearing part:
  - the ingest work queue is **one** collection, and Plan 3 must **not** create its own `lodging_unresolved_aliases`
  - the Wawona alias reconcile is **rejected** — the building is let whole *or* split per session, so an alias (year window, no session dimension) structurally cannot express it
  - `opt_out_vip` + `accommodation_is_mandatory` are one three-state answer
  - `SyncJobToCollections` membership is not an export
  - the pre-existing raw-custom-values PHI exposure, recorded as an owner decision
- A CRITICAL first action with an exact command and pass/fail criterion
- A don't-list where each item would silently regress shipped work

## Checklist gaps in `sync-layer.md`

Both verified against the tree rather than taken from a plan's claim:

**`orchestrator_test.go` is a registration site.** `TestRunSyncWithOptionsPhaseOrdering` pins the unified job list *exhaustively*, so a job registered correctly everywhere else still fails the suite with a count mismatch until it is added there. The checklist never mentioned it. Documented as §2b, framed as a registration step rather than a test that happens to break.

**`SyncJobToCollections` and the export config are independent.** §8 listed them as two rows of one action, which reads as "do both". A job can need the map entry and *no* export at all — the correct shape for data that must never reach a spreadsheet. `lodging_assignments` is now the worked example, with a pointer to the test asserting map membership never implies an export.

I checked the related claim that the checklist lists a nonexistent `scheduler.go` step — it does not, so nothing to fix there.

## Verification

Docs only — no code paths touched. markdownlint runs on both files via the pre-commit hook; commitlint clean. No PII, no private URLs, no real names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
