### PR TITLE
refactor(scripts): extract shared PocketBase harness + test coverage (#1868, #1869)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ eggs/
 .eggs/
 lib/
 !frontend/src/lib/
+!scripts/dev/lib/
 lib64/
 parts/
 sdist/

--- a/scripts/dev/lib/pb-harness.sh
+++ b/scripts/dev/lib/pb-harness.sh
@@ -1,0 +1,171 @@
+# Shared "boot PocketBase against a throwaway DB so JS migrations actually
+# apply" harness. Sourced by verify-consolidation.sh, verify-lodging-schema.sh,
+# and verify-lodging-seed.sh, which previously reimplemented this three times.
+#
+# Not a standalone script (no shebang, not executable) -- it is meant to be
+# `source`d, so a caller's own `set -euo pipefail` and traps apply to it.
+#
+# Why serve-and-kill at all: `pocketbase migrate up` silently skips JS
+# migrations. jsvm captures MigrationsDir at plugin-registration time, before
+# cobra parses CLI flags, so `--migrationsDir` is a no-op -- jsvm always
+# resolves filepath.Join(app.DataDir(), "../pb_migrations"). We exploit this
+# by symlinking <dataDir>/../pb_migrations -> the target migrations dir so
+# jsvm's default resolution lands where we want it.
+#
+# Signal-handling contract: this file traps nothing on its own. A background
+# `pocketbase serve` PID is tracked in _PB_HARNESS_PID while pb_harness_boot
+# runs; callers combine harness cleanup with their own via
+# pb_harness_install_trap, which installs a single `trap ... EXIT INT TERM`
+# that kills the tracked PID from inside the handler. This matters: an
+# earlier version of this harness trapped only EXIT and killed the PID
+# outside the handler, so a SIGINT arriving during the health poll orphaned a
+# `pocketbase serve` bound to an ephemeral port. Fixed once, then had to be
+# fixed again in a second copy before kindred#1868 merged this file.
+#
+# Public API:
+#   pb_harness_require_tools [extra tools...]
+#   pb_harness_pick_port
+#   pb_harness_install_trap [extra cleanup command]
+#   pb_harness_boot <pb_bin> <db_dir> <migrations_dir> <log_path>
+# See each function's header comment below for details.
+
+# PID of the currently-running background `pocketbase serve`, if any. Internal
+# state -- callers should not read or set this directly.
+_PB_HARNESS_PID=""
+
+# pb_harness_require_tools [extra tools...]
+#
+# Exits 2 if git, sqlite3, curl, or python3 (the harness's own dependencies --
+# git for repo-root resolution, sqlite3 to query the resulting DB, curl for
+# the health poll, python3 for ephemeral port selection) or any
+# caller-supplied extra tool isn't on PATH. Normalizes tool absence to exit 2
+# (harness error) rather than a `set -e`-triggered 127 or a caller misreading
+# it as an assertion failure (exit 1).
+#
+# Call this first thing, before the first `git` invocation -- checking after
+# invoking git is pointless, since a missing git would already have exited 127.
+pb_harness_require_tools() {
+  local cmd
+  for cmd in git sqlite3 curl python3 "$@"; do
+    command -v "$cmd" >/dev/null 2>&1 \
+      || { echo "error: required command '$cmd' not found" >&2; exit 2; }
+  done
+}
+
+# pb_harness_pick_port
+# Prints an available ephemeral port on 127.0.0.1 to stdout.
+pb_harness_pick_port() {
+  python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()'
+}
+
+# pb_harness_cleanup
+# Kills the tracked background `pocketbase serve`, if any. Safe to call more
+# than once (idempotent once _PB_HARNESS_PID is cleared). Exposed for callers
+# that want to compose their own trap rather than use pb_harness_install_trap.
+pb_harness_cleanup() {
+  if [[ -n "$_PB_HARNESS_PID" ]]; then
+    kill "$_PB_HARNESS_PID" 2>/dev/null || true
+    wait "$_PB_HARNESS_PID" 2>/dev/null || true
+    _PB_HARNESS_PID=""
+  fi
+}
+
+# pb_harness_install_trap [extra cleanup command]
+#
+# Installs a single `trap ... EXIT INT TERM` that runs pb_harness_cleanup
+# (killing any tracked background PocketBase) followed by an optional
+# caller-supplied cleanup command, e.g. removing a scratch dir:
+#
+#   SCRATCH=$(mktemp -d)
+#   pb_harness_install_trap 'rm -rf "$SCRATCH"'
+#
+# The extra command is stored, not evaluated, at install time -- it is
+# expanded when the trap actually fires, so referencing a variable (like
+# $SCRATCH above) assigned AFTER this call still works, same as a plain
+# `trap '...' EXIT INT TERM`.
+#
+# Calling this more than once replaces the previous trap; it does not chain.
+pb_harness_install_trap() {
+  local extra="${1:-}"
+  # shellcheck disable=SC2064  # deliberate: $extra must expand now (into the
+  # trap command string), while any variables *inside* $extra expand later,
+  # when the trap fires.
+  trap "pb_harness_cleanup; ${extra}" EXIT INT TERM
+}
+
+# pb_harness_boot <pb_bin> <db_dir> <migrations_dir> <log_path>
+#
+# Boots `<pb_bin> serve --automigrate=true` against a throwaway <db_dir>,
+# symlinking <migrations_dir> in via the jsvm default-path trick described
+# above, polls /api/health with a bounded timeout, stops the server, then
+# asserts at least one .js migration landed in _migrations -- the smoke check
+# that catches jsvm loading breakage (if this ever passed with 0, the
+# `migrate up` silent-skip bug documented above would go unnoticed too).
+#
+# On success, sets PB_HARNESS_JS_MIGRATION_COUNT (for callers that want to
+# report it) and leaves <db_dir>/data.db ready to query. Exits 2 -- not a
+# non-zero return -- on boot failure or a failed smoke check, same "harness
+# error, not an assertion failure" contract as pb_harness_require_tools.
+#
+# Health-poll tuning: override via PB_HARNESS_HEALTH_ATTEMPTS (default 200)
+# and PB_HARNESS_HEALTH_INTERVAL (default 0.2), e.g. as a temporary
+# assignment scoped to one call: `PB_HARNESS_HEALTH_ATTEMPTS=100 pb_harness_boot ...`.
+#
+# Caller contract: give each call its own <db_dir> PARENT directory, not one
+# shared across calls -- the migrations symlink lands at
+# dirname(<db_dir>)/pb_migrations, and two calls sharing a parent would
+# clobber each other's symlink target. Call pb_harness_install_trap before
+# calling this, so a signal during the health poll still kills the
+# backgrounded server.
+pb_harness_boot() {
+  local pb_bin="$1" db_dir="$2" mig_dir="$3" log="$4"
+
+  [[ -x "$pb_bin" ]] \
+    || { echo "error: pb_harness_boot: '$pb_bin' not found or not executable" >&2; exit 2; }
+
+  mkdir -p "$db_dir"
+  local hooks_dir
+  hooks_dir=$(mktemp -d "$(dirname "$db_dir")/pb-harness-hooks-XXXX")
+
+  # jsvm's default resolution is <dataDir>/../pb_migrations -- symlink it to
+  # $mig_dir. See the caller contract above re: one db_dir parent per call.
+  ln -sfn "$mig_dir" "$(dirname "$db_dir")/pb_migrations"
+
+  local port
+  port=$(pb_harness_pick_port)
+
+  "$pb_bin" serve --http="127.0.0.1:$port" \
+            --dir "$db_dir" \
+            --hooksDir "$hooks_dir" \
+            --automigrate=true \
+            > "$log" 2>&1 &
+  _PB_HARNESS_PID=$!
+
+  local ok=0
+  for _ in $(seq 1 "${PB_HARNESS_HEALTH_ATTEMPTS:-200}"); do
+    if curl -sf "http://127.0.0.1:$port/api/health" >/dev/null 2>&1; then
+      ok=1; break
+    fi
+    sleep "${PB_HARNESS_HEALTH_INTERVAL:-0.2}"
+  done
+
+  # Stop before querying, so the caller's sqlite3 reads a settled database.
+  # pb_harness_install_trap's EXIT/INT/TERM trap is the safety net for signal
+  # paths; this kill makes it a no-op on the normal path.
+  kill "$_PB_HARNESS_PID" 2>/dev/null || true
+  wait "$_PB_HARNESS_PID" 2>/dev/null || true
+  _PB_HARNESS_PID=""
+
+  if [[ "$ok" -ne 1 ]]; then
+    echo "error: pocketbase serve never came up against $mig_dir; log:" >&2
+    cat "$log" >&2
+    exit 2
+  fi
+
+  PB_HARNESS_JS_MIGRATION_COUNT=$(sqlite3 "$db_dir/data.db" "SELECT COUNT(*) FROM _migrations WHERE file LIKE '%.js'")
+  if [[ "$PB_HARNESS_JS_MIGRATION_COUNT" -lt 1 ]]; then
+    echo "error: smoke check failed — 0 .js entries in _migrations ($db_dir); jsvm migration loading broke" >&2
+    cat "$log" >&2
+    exit 2
+  fi
+}

--- a/scripts/dev/test-pb-harness.sh
+++ b/scripts/dev/test-pb-harness.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Test for scripts/dev/lib/pb-harness.sh
+#
+# Verifies the tool-absence contract from kindred#1869: a required tool
+# missing from PATH must normalize to exit 2 (harness error), not leak a 127
+# from `set -e`/exec failure or get misread by a caller as an assertion
+# failure (exit 1). Follows the sandboxed-PATH pattern established in
+# test-migration-schema-diff.sh's "missing sqlite3" test.
+#
+# Covers pb_harness_require_tools directly, plus verify-lodging-schema.sh and
+# verify-lodging-seed.sh, which (as of kindred#1868) delegate their own
+# tool-absence contract to the shared lib instead of each repeating the
+# check -- so the assertion belongs here, once, rather than being
+# re-implemented per caller.
+
+set -euo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+LIB="$HERE/lib/pb-harness.sh"
+SCHEMA_SCRIPT="$HERE/verify-lodging-schema.sh"
+SEED_SCRIPT="$HERE/verify-lodging-seed.sh"
+
+[[ -f "$LIB" ]] || { echo "FAIL: $LIB missing" >&2; exit 1; }
+for f in "$SCHEMA_SCRIPT" "$SEED_SCRIPT"; do
+  [[ -x "$f" ]] || { echo "FAIL: $f not executable or missing" >&2; exit 1; }
+done
+
+SCRATCH=$(mktemp -d -t pb-harness-test-XXXX)
+trap 'rm -rf "$SCRATCH"' EXIT INT TERM
+
+# Every tool any of the exercised code paths might need before the
+# tool-absence check fires, so a *different* missing tool never masks the one
+# under test. bash/env matter for the two scripts' `#!/usr/bin/env bash`
+# shebang; dirname/basename for their `$(dirname "${BASH_SOURCE[0]}")` setup.
+ALL_TOOLS=(bash env git sqlite3 curl python3 grep sed awk mktemp rm cat mkdir \
+           dirname basename type command ln seq kill wait sleep go jq diff)
+
+# build_sandbox <dir> <excluded tool> -- symlink every tool in ALL_TOOLS into
+# <dir> except <excluded tool>, so PATH=<dir> reproduces "every dependency
+# present except this one" rather than "nothing present".
+build_sandbox() {
+  local dir="$1" exclude="$2" tool src
+  mkdir -p "$dir"
+  for tool in "${ALL_TOOLS[@]}"; do
+    [[ "$tool" == "$exclude" ]] && continue
+    src="$(command -v "$tool" 2>/dev/null || true)"
+    [[ -n "$src" ]] && ln -sf "$src" "$dir/$tool"
+  done
+}
+
+SANDBOX_NO_SQLITE3="$SCRATCH/no-sqlite3"
+build_sandbox "$SANDBOX_NO_SQLITE3" sqlite3
+
+SANDBOX_NO_CURL="$SCRATCH/no-curl"
+build_sandbox "$SANDBOX_NO_CURL" curl
+
+echo "=== TEST 1: pb_harness_require_tools exits 2 (not 127) when sqlite3 is missing ==="
+set +e
+PATH="$SANDBOX_NO_SQLITE3" bash -c "source '$LIB'; pb_harness_require_tools" >/dev/null 2>"$SCRATCH/t1.err"
+rc=$?
+set -e
+if [[ $rc -eq 2 ]] && grep -q "sqlite3" "$SCRATCH/t1.err"; then
+  echo "PASS: missing sqlite3 -> exit 2, names sqlite3"
+else
+  echo "FAIL: missing sqlite3 expected exit 2 naming sqlite3, got rc=$rc; stderr:" >&2
+  cat "$SCRATCH/t1.err" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 2: pb_harness_require_tools exits 2 (not 127) when curl is missing ==="
+set +e
+PATH="$SANDBOX_NO_CURL" bash -c "source '$LIB'; pb_harness_require_tools" >/dev/null 2>"$SCRATCH/t2.err"
+rc=$?
+set -e
+if [[ $rc -eq 2 ]] && grep -q "curl" "$SCRATCH/t2.err"; then
+  echo "PASS: missing curl -> exit 2, names curl"
+else
+  echo "FAIL: missing curl expected exit 2 naming curl, got rc=$rc; stderr:" >&2
+  cat "$SCRATCH/t2.err" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 3: verify-lodging-schema.sh propagates the lib's tool-absence contract (exit 2, not 127) ==="
+set +e
+PATH="$SANDBOX_NO_SQLITE3" "$SCHEMA_SCRIPT" >/dev/null 2>"$SCRATCH/t3.err"
+rc=$?
+set -e
+if [[ $rc -eq 2 ]]; then
+  echo "PASS: verify-lodging-schema.sh with sqlite3 missing -> exit 2"
+else
+  echo "FAIL: expected exit 2, got $rc; stderr:" >&2
+  cat "$SCRATCH/t3.err" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 4: verify-lodging-seed.sh propagates the lib's tool-absence contract (exit 2, not 127) ==="
+set +e
+PATH="$SANDBOX_NO_SQLITE3" "$SEED_SCRIPT" >/dev/null 2>"$SCRATCH/t4.err"
+rc=$?
+set -e
+if [[ $rc -eq 2 ]]; then
+  echo "PASS: verify-lodging-seed.sh with sqlite3 missing -> exit 2"
+else
+  echo "FAIL: expected exit 2, got $rc; stderr:" >&2
+  cat "$SCRATCH/t4.err" >&2
+  exit 1
+fi
+
+echo
+echo "All tests passed."

--- a/scripts/dev/test-verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/test-verify-no-hardcoded-lodging.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Test for verify-no-hardcoded-lodging.sh
+#
+# Verifies the guard actually catches a leak (exit 1, naming file:line) and
+# is quiet on a clean tree (exit 0).
+#
+# Probe filenames are chosen deliberately: they must NOT match `_test.`,
+# `.test.`, or `/tests?/`, because the guard itself excludes any hit whose
+# path matches those patterns (grep -v '_test\.\|\.test\.\|/tests\?/') --
+# meant to skip the guard's own test fixtures, not to be a loophole. A probe
+# planted with one of those names would report a false green regardless of
+# what it contains. This happened once already during review of kindred#1867,
+# which is exactly why this test exists (kindred#1869).
+
+set -euo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+GUARD_SCRIPT="$HERE/verify-no-hardcoded-lodging.sh"
+
+if [[ ! -x "$GUARD_SCRIPT" ]]; then
+  echo "FAIL: $GUARD_SCRIPT not executable or missing" >&2
+  exit 1
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+# Probe paths deliberately avoid the guard's own test-file exclusions (see
+# header above) and sit directly under two of the four scanned trees
+# (pocketbase/pb_hooks -- application JS -- and api -- Python).
+JS_PROBE="$REPO_ROOT/pocketbase/pb_hooks/leak_probe_kindred1869.js"
+PY_PROBE="$REPO_ROOT/api/leak_probe_kindred1869.py"
+
+cleanup() { rm -f "$JS_PROBE" "$PY_PROBE"; }
+trap cleanup EXIT INT TERM
+
+if [[ -e "$JS_PROBE" || -e "$PY_PROBE" ]]; then
+  echo "FAIL: probe path already exists; refusing to clobber" >&2
+  exit 1
+fi
+
+echo "=== TEST 1: needles in application source should exit 1 and name file:line ==="
+echo '// leak: Tuolumne' > "$JS_PROBE"
+echo '# leak: Manzanita' > "$PY_PROBE"
+
+set +e
+OUT=$("$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+
+if [[ $rc -ne 1 ]]; then
+  echo "FAIL: expected exit 1 with needles present, got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+if ! grep -q "pocketbase/pb_hooks/leak_probe_kindred1869.js:1:" <<<"$OUT"; then
+  echo "FAIL: output missing js probe file:line" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+if ! grep -q "api/leak_probe_kindred1869.py:1:" <<<"$OUT"; then
+  echo "FAIL: output missing py probe file:line" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+echo "PASS: both needles detected with file:line, exit 1"
+
+echo
+echo "=== TEST 2: clean tree should exit 0 ==="
+rm -f "$JS_PROBE" "$PY_PROBE"
+set +e
+OUT=$("$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+if [[ $rc -eq 0 ]]; then
+  echo "PASS: clean tree returned 0"
+else
+  echo "FAIL: clean tree expected exit 0, got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 3: probe filenames matching the guard's own test-file exclusion must NOT be used ==="
+# Regression for the false-green this test exists to prevent: a leak file
+# named like a test file is invisible to the guard by design (it exists to
+# skip the guard's OWN fixtures), so asserting that here documents the trap
+# rather than re-discovering it by hand next time.
+TESTNAME_PROBE="$REPO_ROOT/pocketbase/pb_hooks/leak_probe_kindred1869_test.js"
+cleanup2() { rm -f "$TESTNAME_PROBE"; }
+trap 'cleanup2; cleanup' EXIT INT TERM
+echo '// leak: Tuolumne' > "$TESTNAME_PROBE"
+set +e
+OUT=$("$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+rm -f "$TESTNAME_PROBE"
+if [[ $rc -eq 0 ]]; then
+  echo "PASS: confirmed a _test.js-named probe is excluded (exit 0) -- do not name real probes this way"
+else
+  echo "FAIL: expected the _test.js-named probe to be silently excluded (exit 0), got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+
+echo
+echo "All tests passed."

--- a/scripts/dev/verify-consolidation.sh
+++ b/scripts/dev/verify-consolidation.sh
@@ -21,6 +21,10 @@ HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "$HERE/../.." && pwd)
 DIFF_SCRIPT="$HERE/migration-schema-diff.sh"
 
+# shellcheck source=lib/pb-harness.sh
+source "$HERE/lib/pb-harness.sh"
+pb_harness_require_tools
+
 for d in "$PROPOSED_DIR" "$CURRENT_DIR"; do
   if [[ ! -d "$d" ]]; then
     echo "error: $d not a directory" >&2
@@ -28,8 +32,9 @@ for d in "$PROPOSED_DIR" "$CURRENT_DIR"; do
   fi
 done
 
-# Canonicalize to absolute paths so the symlink in pb_apply() resolves
-# correctly regardless of whether the caller passed relative or absolute paths.
+# Canonicalize to absolute paths so the symlink pb_harness_boot creates
+# resolves correctly regardless of whether the caller passed relative or
+# absolute paths.
 PROPOSED_DIR=$(cd "$PROPOSED_DIR" && pwd)
 CURRENT_DIR=$(cd "$CURRENT_DIR" && pwd)
 
@@ -46,77 +51,28 @@ fi
 # Build pocketbase binary once and reuse for both scratch DBs to avoid
 # paying go-build cost twice. Built in scratch dir so it's auto-cleaned.
 SCRATCH=$(mktemp -d -t pb-verify-XXXX)
-trap 'rm -rf "$SCRATCH"' EXIT INT TERM
+# shellcheck disable=SC2016  # deliberate: $SCRATCH expands when the trap fires, not here
+pb_harness_install_trap 'rm -rf "$SCRATCH"'
 
-# Apply all migrations in $mig_dir to a fresh DB at $db_dir via serve-and-kill.
-# Uses PB's real boot path (automigrate=true) which loads JS migrations through
-# the jsvm plugin — this is the only invocation path that actually runs them.
-# Plain `migrate up` silently skips JS migrations (PB v0.37 behavior, observed
-# 2026-05-08 during first consolidation round).
-#
-# IMPORTANT: jsvm.MustRegister() reads MigrationsDir before cobra parses CLI
-# flags (it runs at plugin registration time, not at serve time). Passing
-# --migrationsDir is therefore a no-op for jsvm — jsvm always falls back to
-# its default: filepath.Join(app.DataDir(), "../pb_migrations"). We exploit
-# this by symlinking $db_dir/../pb_migrations -> $mig_dir so the default
-# resolution lands on our scratch copy.
+# Apply all migrations in $mig_dir to a fresh DB at $db_dir via
+# pb_harness_boot, then assert more than just the PB defaults landed.
+# pb_harness_boot's own smoke check only guarantees >=1 .js migration
+# applied; this is a belt-and-suspenders check specific to comparing a
+# "proposed" migration set against reality.
 #
 # Args: <db_dir> <migrations_dir> <log_path>
-# Exits the harness (exit 2) on serve-failure or empty-apply (smoke check).
 pb_apply() {
   local db_dir="$1" mig_dir="$2" log="$3"
-  local hooks_dir
-  # Place hooks_dir under $SCRATCH so the outer EXIT trap reclaims it on every
-  # exit path, including the `exit 2` harness-error branches below.
-  hooks_dir=$(mktemp -d "$SCRATCH/pb-empty-hooks-XXXX")
 
-  # Symlink pb_migrations next to db_dir so jsvm's default path resolution
-  # finds $mig_dir when it computes filepath.Join(app.DataDir(), "../pb_migrations").
-  # Caller is responsible for placing $db_dir under its own parent directory
-  # (not a shared $SCRATCH) so the symlink target doesn't collide between
-  # successive pb_apply() invocations.
-  local parent_dir
-  parent_dir=$(dirname "$db_dir")
-  ln -sfn "$mig_dir" "$parent_dir/pb_migrations"
+  # This harness's own historical timeout (10s) rather than the shared
+  # default (40s) — scoped to just this call, reverts once it returns.
+  PB_HARNESS_HEALTH_ATTEMPTS=100 PB_HARNESS_HEALTH_INTERVAL=0.1 \
+    pb_harness_boot "$SCRATCH/pocketbase" "$db_dir" "$mig_dir" "$log"
 
-  local port
-  port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
-
-  "$SCRATCH/pocketbase" serve --http="127.0.0.1:$port" \
-              --dir "$db_dir" \
-              --hooksDir "$hooks_dir" \
-              --automigrate=true \
-              > "$log" 2>&1 &
-  local pid=$!
-  # Ensure backgrounded PB is cleaned up on every exit path from this function.
-  trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true' RETURN
-
-  local ok=0
-  for _ in $(seq 1 100); do
-    if curl -sf "http://127.0.0.1:$port/api/health" >/dev/null 2>&1; then
-      ok=1; break
-    fi
-    sleep 0.1
-  done
-
-  kill "$pid" 2>/dev/null || true
-  wait "$pid" 2>/dev/null || true
-
-  if [[ "$ok" -ne 1 ]]; then
-    echo "error: pocketbase serve never came up against $mig_dir; log:" >&2
-    cat "$log" >&2
-    exit 2
-  fi
-
-  local coll_count js_mig_count
+  local coll_count
   coll_count=$(sqlite3 "$db_dir/data.db" "SELECT COUNT(*) FROM _collections")
-  js_mig_count=$(sqlite3 "$db_dir/data.db" "SELECT COUNT(*) FROM _migrations WHERE file LIKE '%.js'")
   if [[ "$coll_count" -le "$PB_DEFAULT_COLLECTIONS" ]]; then
     echo "error: smoke check failed — $coll_count collections in $db_dir (expected >$PB_DEFAULT_COLLECTIONS, only PB defaults applied)" >&2
-    exit 2
-  fi
-  if [[ "$js_mig_count" -lt 1 ]]; then
-    echo "error: smoke check failed — 0 .js entries in _migrations ($db_dir); jsvm migration loading broke" >&2
     exit 2
   fi
 }
@@ -125,12 +81,12 @@ echo ">> building pocketbase binary..."
 ( cd "$REPO_ROOT/pocketbase" && go build -o "$SCRATCH/pocketbase" . ) > "$SCRATCH/build.log" 2>&1 \
   || { echo "pocketbase build failed; log:"; cat "$SCRATCH/build.log"; exit 2; }
 
-# Each DB lives under its own slot directory so pb_apply's symlink target
-# ($parent_dir/pb_migrations) is unique per call. Without this, both calls
-# would target $SCRATCH/pb_migrations and the second invocation would clobber
-# the first's symlink. Sequential execution masks the bug today, but the
-# isolation costs nothing and makes the harness robust to future parallelism
-# or PB internals changes.
+# Each DB lives under its own slot directory so pb_harness_boot's symlink
+# target ($parent_dir/pb_migrations) is unique per call. Without this, both
+# calls would target $SCRATCH/pb_migrations and the second invocation would
+# clobber the first's symlink. Sequential execution masks the bug today, but
+# the isolation costs nothing and makes the harness robust to future
+# parallelism or PB internals changes.
 mkdir -p "$SCRATCH/slot_a/db_a" "$SCRATCH/slot_b/db_b"
 
 echo ">> applying PROPOSED migrations to DB-A..."

--- a/scripts/dev/verify-lodging-schema.sh
+++ b/scripts/dev/verify-lodging-schema.sh
@@ -8,20 +8,20 @@
 # execution continues, so a run reports EVERY violation at once rather than
 # stopping at the first — that is what makes the FAIL count usable as progress.
 #
-# Why serve-and-kill: `pocketbase migrate up` silently skips JS migrations.
-# jsvm captures MigrationsDir at plugin-registration time (before flag parsing),
-# so --migrationsDir is a no-op; jsvm always resolves
-# filepath.Join(app.DataDir(), "../pb_migrations"). We symlink that path to the
-# repo's migrations dir. Same technique as scripts/dev/verify-consolidation.sh.
+# Why serve-and-kill, the jsvm symlink trick, and the "0 .js migrations
+# applied" smoke check all live in scripts/dev/lib/pb-harness.sh, shared with
+# scripts/dev/verify-consolidation.sh and scripts/dev/verify-lodging-seed.sh.
 set -euo pipefail
 
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/pb-harness.sh
+source "$HERE/lib/pb-harness.sh"
+
 # Check tools up front so a missing one exits 2 (cannot run) rather than 127
-# midway through, which would read as an assertion failure. Same contract as
-# scripts/dev/migration-schema-diff.sh. git is in the list and the list runs
-# BEFORE the first git call — checking after invoking it would never fire.
-for cmd in git sqlite3 curl python3; do
-  command -v "$cmd" >/dev/null 2>&1 || { echo "error: required command '$cmd' not found" >&2; exit 2; }
-done
+# midway through, which would read as an assertion failure. git is in the
+# list and the list runs BEFORE the first git call — checking after invoking
+# it would never fire.
+pb_harness_require_tools
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 PB_BIN="$REPO_ROOT/pocketbase/pocketbase"
@@ -30,53 +30,15 @@ MIG_DIR="$REPO_ROOT/pocketbase/pb_migrations"
 [[ -x "$PB_BIN" ]] || { echo "error: $PB_BIN missing; run: cd pocketbase && go build -o pocketbase ." >&2; exit 2; }
 
 SCRATCH=$(mktemp -d)
-PB_PID=""
-# Trap INT and TERM as well as EXIT, and kill the background PocketBase from
-# inside the handler. A signal arriving during the up-to-40s health poll would
-# otherwise run only the EXIT handler, deleting $SCRATCH but orphaning a
-# `pocketbase serve` bound to the ephemeral port.
-cleanup() {
-  if [[ -n "$PB_PID" ]]; then
-    kill "$PB_PID" 2>/dev/null || true
-    wait "$PB_PID" 2>/dev/null || true
-  fi
-  rm -rf "$SCRATCH"
-}
-trap cleanup EXIT INT TERM
+# shellcheck disable=SC2016  # deliberate: $SCRATCH expands when the trap fires, not here
+pb_harness_install_trap 'rm -rf "$SCRATCH"'
 
 DB_DIR="$SCRATCH/data/pb_data"
-mkdir -p "$DB_DIR"
-HOOKS_DIR=$(mktemp -d "$SCRATCH/empty-hooks-XXXX")
-# jsvm default resolution: <dataDir>/../pb_migrations
-ln -sfn "$MIG_DIR" "$SCRATCH/data/pb_migrations"
-
-PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
 LOG="$SCRATCH/boot.log"
-
-"$PB_BIN" serve --http="127.0.0.1:$PORT" --dir "$DB_DIR" \
-  --hooksDir "$HOOKS_DIR" --automigrate=true > "$LOG" 2>&1 &
-PB_PID=$!
-
-ok=0
-for _ in $(seq 1 200); do
-  if curl -sf "http://127.0.0.1:$PORT/api/health" >/dev/null 2>&1; then ok=1; break; fi
-  sleep 0.2
-done
-# Stop PocketBase before querying, so sqlite3 reads a settled database. The trap
-# is the safety net for signal paths; this kill makes it a no-op on normal paths.
-kill "$PB_PID" 2>/dev/null || true
-wait "$PB_PID" 2>/dev/null || true
-PB_PID=""
-
-if [[ "$ok" -ne 1 ]]; then
-  echo "error: pocketbase serve never came up; log:" >&2; cat "$LOG" >&2; exit 2
-fi
+pb_harness_boot "$PB_BIN" "$DB_DIR" "$MIG_DIR" "$LOG"
 
 DB="$DB_DIR/data.db"
-js_migs=$(sqlite3 "$DB" "SELECT COUNT(*) FROM _migrations WHERE file LIKE '%.js'")
-if [[ "$js_migs" -lt 1 ]]; then
-  echo "error: 0 .js migrations applied — jsvm loading broke" >&2; cat "$LOG" >&2; exit 2
-fi
+js_migs="$PB_HARNESS_JS_MIGRATION_COUNT"
 
 fail=0
 note() { echo "FAIL: $*" >&2; fail=1; }

--- a/scripts/dev/verify-lodging-seed.sh
+++ b/scripts/dev/verify-lodging-seed.sh
@@ -1,18 +1,21 @@
 #!/usr/bin/env bash
 # Asserts the lodging seed produced the expected rows. Applies migrations to a
-# throwaway DB using the same serve-and-kill technique as
-# scripts/dev/verify-lodging-schema.sh (see that file for why).
+# throwaway DB via scripts/dev/lib/pb-harness.sh (see that file for the
+# serve-and-kill technique and why it's needed), shared with
+# scripts/dev/verify-consolidation.sh and scripts/dev/verify-lodging-schema.sh.
 #
 # Exit codes: 0 = all assertions passed. 1 = one or more assertions FAILED.
 # 2 = could not run the check at all. Assertions aggregate rather than
 # short-circuit; see verify-lodging-schema.sh.
 set -euo pipefail
 
-# Missing tool must exit 2 (cannot run), not 127 midway. Same contract as
-# scripts/dev/migration-schema-diff.sh. Runs BEFORE the first git call.
-for cmd in git sqlite3 curl python3; do
-  command -v "$cmd" >/dev/null 2>&1 || { echo "error: required command '$cmd' not found" >&2; exit 2; }
-done
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/pb-harness.sh
+source "$HERE/lib/pb-harness.sh"
+
+# Missing tool must exit 2 (cannot run), not 127 midway. Runs BEFORE the
+# first git call.
+pb_harness_require_tools
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 PB_BIN="$REPO_ROOT/pocketbase/pocketbase"
@@ -21,27 +24,12 @@ MIG_DIR="$REPO_ROOT/pocketbase/pb_migrations"
 [[ -x "$PB_BIN" ]] || { echo "error: $PB_BIN missing; run: cd pocketbase && go build -o pocketbase ." >&2; exit 2; }
 
 SCRATCH=$(mktemp -d)
-PB_PID=""
-# EXIT INT TERM, with the kill inside the handler — a signal during the health
-# poll would otherwise orphan a `pocketbase serve` on the ephemeral port.
-cleanup() {
-  if [[ -n "$PB_PID" ]]; then
-    kill "$PB_PID" 2>/dev/null || true
-    wait "$PB_PID" 2>/dev/null || true
-  fi
-  rm -rf "$SCRATCH"
-}
-trap cleanup EXIT INT TERM
+# shellcheck disable=SC2016  # deliberate: $SCRATCH expands when the trap fires, not here
+pb_harness_install_trap 'rm -rf "$SCRATCH"'
 
-DB_DIR="$SCRATCH/data/pb_data"; mkdir -p "$DB_DIR"
-HOOKS_DIR=$(mktemp -d "$SCRATCH/empty-hooks-XXXX")
-ln -sfn "$MIG_DIR" "$SCRATCH/data/pb_migrations"
-PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
-"$PB_BIN" serve --http="127.0.0.1:$PORT" --dir "$DB_DIR" --hooksDir "$HOOKS_DIR" --automigrate=true > "$SCRATCH/boot.log" 2>&1 &
-PB_PID=$!
-ok=0; for _ in $(seq 1 200); do curl -sf "http://127.0.0.1:$PORT/api/health" >/dev/null 2>&1 && { ok=1; break; }; sleep 0.2; done
-kill "$PB_PID" 2>/dev/null || true; wait "$PB_PID" 2>/dev/null || true; PB_PID=""
-[[ "$ok" -eq 1 ]] || { echo "error: serve never came up" >&2; cat "$SCRATCH/boot.log" >&2; exit 2; }
+DB_DIR="$SCRATCH/data/pb_data"
+LOG="$SCRATCH/boot.log"
+pb_harness_boot "$PB_BIN" "$DB_DIR" "$MIG_DIR" "$LOG"
 
 DB="$DB_DIR/data.db"
 fail=0; note() { echo "FAIL: $*" >&2; fail=1; }


### PR DESCRIPTION
## Summary

Two paired issues, one PR (per #1869: "if the harness extraction lands first, the tool-absence assertions belong to the extracted lib's test rather than being repeated per caller").

- **#1868**: `verify-consolidation.sh`, `verify-lodging-schema.sh`, and `verify-lodging-seed.sh` each independently re-implemented "boot PocketBase against a throwaway DB so JS migrations actually apply" (ephemeral port, the jsvm `pb_migrations` symlink trick, background `serve` with signal-safe cleanup, health poll, "0 .js migrations applied" smoke check). The signal-handling fix (`trap EXIT INT TERM` with cleanup *inside* the handler — otherwise a SIGINT during the health poll orphans a `pocketbase serve` on the ephemeral port) had already been applied twice in two separate copies. Extracted to `scripts/dev/lib/pb-harness.sh`, sourced by all three; callers now keep only their own assertions.
- **#1869**: the three lodging verify scripts added in #1867 shipped without the `test-*.sh` companion that `verify-consolidation.sh`/`migration-schema-diff.sh` already carry. Added:
  - `test-verify-no-hardcoded-lodging.sh` — plants a needle in `pocketbase/pb_hooks/*.js` and `api/*.py`, asserts exit 1 with `file:line`; clean tree exits 0; also asserts (as its own regression test) that a probe named like the guard's own test-file exclusion is correctly invisible to it, which produced a false green during review of #1867.
  - `test-pb-harness.sh` — asserts the tool-absence contract now centralized in the lib: a required tool missing from `PATH` normalizes to exit 2, not a leaked 127, for `pb_harness_require_tools` directly and for the two lodging scripts that delegate to it.

None of these scripts are wired into CI or lefthook — they're manual dev harnesses. This is maintainability, not correctness.

## Test plan

- [x] `shellcheck` clean on every script touched or added
- [x] All three verify scripts (`verify-consolidation.sh`, `verify-lodging-schema.sh`, `verify-lodging-seed.sh`) actually run and pass post-refactor
- [x] Existing `test-verify-consolidation.sh` (5/5) and `test-migration-schema-diff.sh` (7/7) still pass unchanged
- [x] New `test-verify-no-hardcoded-lodging.sh` and `test-pb-harness.sh` pass, and were confirmed to fail red when the thing they check was deliberately broken (guard's exit-1 path stubbed out; `pb_harness_require_tools`'s exit-2 stubbed out) — reverted after confirming
- [x] Full pre-push suite green (go build, ruff, pb-js-lint, shellcheck, markdownlint, api-types-freshness, mypy, tsc, pytest 5622 passed)

Fixes kindred#1868
Fixes kindred#1869

🤖 Generated with [Claude Code](https://claude.com/claude-code)