### PR TITLE
fix(sync): trim CampMinder field display names before routing

### DIFF
--- a/pocketbase/sync/camper_dietary.go
+++ b/pocketbase/sync/camper_dietary.go
@@ -205,7 +205,7 @@ func (s *CamperDietarySync) loadFieldDefinitions(_ context.Context) (map[string]
 	}
 
 	for _, record := range records {
-		name := record.GetString("name")
+		name := normalizeFieldName(record.GetString("name"))
 		if isCamperDietaryField(name) {
 			result[record.Id] = name
 		}

--- a/pocketbase/sync/camper_dietary_test.go
+++ b/pocketbase/sync/camper_dietary_test.go
@@ -1,12 +1,51 @@
 package sync
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/pocketbase/pocketbase/core"
 )
+
+// TestCamperDietaryLoadFieldDefinitionsTrimsNames is a regression test for
+// kindred#1873: loadFieldDefinitions stored CampMinder display names verbatim,
+// so a trailing space (as shipped for staff_applications' three fields) would
+// have made isCamperDietaryField's exact-match admission miss the field
+// entirely. No untrimmed name exists in this table today, but nothing
+// prevents CampMinder from adding one -- this pins the fix so a future
+// occurrence is caught here instead of live.
+func TestCamperDietaryLoadFieldDefinitionsTrimsNames(t *testing.T) {
+	app := newFieldDefsTestApp(t, map[int]string{
+		1: "Family Medical-Dietary Needs ", // trailing space
+		2: "Family Medical-Additional",     // already clean, must be unaffected
+	})
+
+	s := NewCamperDietarySync(app)
+	got, err := s.loadFieldDefinitions(context.Background())
+	if err != nil {
+		t.Fatalf("loadFieldDefinitions: %v", err)
+	}
+
+	want := map[string]bool{
+		"Family Medical-Dietary Needs": true,
+		"Family Medical-Additional":    true,
+	}
+	for _, name := range got {
+		if !want[name] {
+			t.Errorf("loadFieldDefinitions returned %q; expected a trimmed name", name)
+		}
+		delete(want, name)
+	}
+	for missing := range want {
+		t.Errorf("loadFieldDefinitions did not return %q", missing)
+	}
+
+	if col := MapDietaryFieldToColumn("Family Medical-Dietary Needs"); col != colHasDietaryNeeds {
+		t.Errorf("MapDietaryFieldToColumn(%q) = %q, want %q", "Family Medical-Dietary Needs", col, colHasDietaryNeeds)
+	}
+}
 
 // TestCamperDietarySync_Name verifies the service name is correct
 func TestCamperDietarySync_Name(t *testing.T) {

--- a/pocketbase/sync/camper_transportation.go
+++ b/pocketbase/sync/camper_transportation.go
@@ -215,7 +215,7 @@ func (s *CamperTransportationSync) loadFieldDefinitions(_ context.Context) (map[
 	}
 
 	for _, record := range records {
-		name := record.GetString("name")
+		name := normalizeFieldName(record.GetString("name"))
 		if isCamperTransportationField(name) {
 			result[record.Id] = name
 			s.DebugLog("Found transportation field definition", "name", name, "pb_id", record.Id)

--- a/pocketbase/sync/camper_transportation_test.go
+++ b/pocketbase/sync/camper_transportation_test.go
@@ -1,10 +1,48 @@
 package sync
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 )
+
+// TestCamperTransportationLoadFieldDefinitionsTrimsNames is a regression test
+// for kindred#1873. isCamperTransportationField admits by "BUS-" prefix, which
+// a trailing space would not defeat, but MapTransportationFieldToColumn
+// exact-matches the trimmed literal downstream -- so an untrimmed name would
+// be admitted into the map and then silently fail to route. No untrimmed name
+// exists in this table today; this pins the fix against a future one.
+func TestCamperTransportationLoadFieldDefinitionsTrimsNames(t *testing.T) {
+	app := newFieldDefsTestApp(t, map[int]string{
+		1: "BUS-who is dropping off ", // trailing space
+		2: "BUS-to camp",              // already clean, must be unaffected
+	})
+
+	s := NewCamperTransportationSync(app)
+	got, err := s.loadFieldDefinitions(context.Background())
+	if err != nil {
+		t.Fatalf("loadFieldDefinitions: %v", err)
+	}
+
+	want := map[string]bool{
+		"BUS-who is dropping off": true,
+		"BUS-to camp":             true,
+	}
+	for _, name := range got {
+		if !want[name] {
+			t.Errorf("loadFieldDefinitions returned %q; expected a trimmed name", name)
+		}
+		delete(want, name)
+	}
+	for missing := range want {
+		t.Errorf("loadFieldDefinitions did not return %q", missing)
+	}
+
+	if col := MapTransportationFieldToColumn("BUS-who is dropping off"); col != colDropoffName {
+		t.Errorf("MapTransportationFieldToColumn(%q) = %q, want %q", "BUS-who is dropping off", col, colDropoffName)
+	}
+}
 
 // TestCamperTransportationSync_Name verifies the service name is correct
 func TestCamperTransportationSync_Name(t *testing.T) {

--- a/pocketbase/sync/financial_aid_applications.go
+++ b/pocketbase/sync/financial_aid_applications.go
@@ -272,7 +272,7 @@ func (s *FinancialAidApplicationsSync) loadFieldDefinitions(_ context.Context) (
 	}
 
 	for _, record := range records {
-		name := record.GetString("name")
+		name := normalizeFieldName(record.GetString("name"))
 		if isFAFieldName(name) {
 			result[record.Id] = name
 		}

--- a/pocketbase/sync/financial_aid_applications_test.go
+++ b/pocketbase/sync/financial_aid_applications_test.go
@@ -1,9 +1,50 @@
 package sync
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
+
+// TestFinancialAidApplicationsLoadFieldDefinitionsTrimsNames is a regression
+// test for kindred#1873. isFAFieldName admits "FA-" fields by prefix, which a
+// trailing space would not defeat, but mapFieldToApplication exact-matches the
+// trimmed literal downstream -- so an untrimmed name would be admitted into
+// the map and then silently fail to route. No untrimmed name exists in this
+// table today; this pins the fix against a future one.
+func TestFinancialAidApplicationsLoadFieldDefinitionsTrimsNames(t *testing.T) {
+	app := newFieldDefsTestApp(t, map[int]string{
+		1: "FA-Contact Parent Name ", // trailing space
+		2: "FA-Contact Parent Email", // already clean, must be unaffected
+	})
+
+	s := NewFinancialAidApplicationsSync(app)
+	got, err := s.loadFieldDefinitions(context.Background())
+	if err != nil {
+		t.Fatalf("loadFieldDefinitions: %v", err)
+	}
+
+	want := map[string]bool{
+		"FA-Contact Parent Name":  true,
+		"FA-Contact Parent Email": true,
+	}
+	for _, name := range got {
+		if !want[name] {
+			t.Errorf("loadFieldDefinitions returned %q; expected a trimmed name", name)
+		}
+		delete(want, name)
+	}
+	for missing := range want {
+		t.Errorf("loadFieldDefinitions did not return %q", missing)
+	}
+
+	app2 := &faApplicationData{}
+	s.mapFieldToApplication(app2, "FA-Contact Parent Name", "Emma Johnson")
+	if app2.contactFirstName != "Emma Johnson" {
+		t.Errorf("mapFieldToApplication did not route %q, contactFirstName = %q",
+			"FA-Contact Parent Name", app2.contactFirstName)
+	}
+}
 
 // TestFinancialAidApplicationsSync_Name verifies the service name is correct
 func TestFinancialAidApplicationsSync_Name(t *testing.T) {

--- a/pocketbase/sync/household_demographics.go
+++ b/pocketbase/sync/household_demographics.go
@@ -272,7 +272,7 @@ func (s *HouseholdDemographicsSync) loadFieldDefinitions(_ context.Context) (map
 	}
 
 	for _, record := range records {
-		name := record.GetString("name")
+		name := normalizeFieldName(record.GetString("name"))
 		// Include HH- prefixed fields (person level) and household-level fields we care about
 		if isHouseholdDemographicsField(name) {
 			result[record.Id] = name

--- a/pocketbase/sync/household_demographics_test.go
+++ b/pocketbase/sync/household_demographics_test.go
@@ -1,11 +1,58 @@
 package sync
 
 import (
+	"context"
 	"testing"
 )
 
 // Test constants for fictional data
 const testCongregation = "Temple Beth El"
+
+// TestHouseholdDemographicsLoadFieldDefinitionsTrimsNames is a regression test
+// for kindred#1873. HH- prefixed fields are admitted by prefix, which a
+// trailing space would not defeat, but MapHHFieldToColumn exact-matches the
+// trimmed literal downstream -- so an untrimmed name would be admitted into
+// the map and then silently fail to route. The household-level fields
+// ("Center", "Custody Issues", "Board") are admitted by exact match, so an
+// untrimmed name there would fail admission itself. No untrimmed name exists
+// in this table today; this pins the fix against a future one.
+func TestHouseholdDemographicsLoadFieldDefinitionsTrimsNames(t *testing.T) {
+	app := newFieldDefsTestApp(t, map[int]string{
+		1: "HH-Family Description ", // trailing space
+		2: "Board ",                 // trailing space, exact-match admission
+		3: "HH-Military",            // already clean, must be unaffected
+	})
+
+	s := NewHouseholdDemographicsSync(app)
+	got, err := s.loadFieldDefinitions(context.Background())
+	if err != nil {
+		t.Fatalf("loadFieldDefinitions: %v", err)
+	}
+
+	want := map[string]bool{
+		"HH-Family Description": true,
+		"Board":                 true,
+		"HH-Military":           true,
+	}
+	for _, name := range got {
+		if !want[name] {
+			t.Errorf("loadFieldDefinitions returned %q; expected a trimmed name", name)
+		}
+		delete(want, name)
+	}
+	for missing := range want {
+		t.Errorf("loadFieldDefinitions did not return %q", missing)
+	}
+
+	const wantFamilyDescriptionCol = "family_description"
+	if col := MapHHFieldToColumn("HH-Family Description"); col != wantFamilyDescriptionCol {
+		t.Errorf("MapHHFieldToColumn(%q) = %q, want %q", "HH-Family Description", col, wantFamilyDescriptionCol)
+	}
+	const wantBoardMemberCol = "board_member"
+	if col := MapHouseholdFieldToColumn("Board"); col != wantBoardMemberCol {
+		t.Errorf("MapHouseholdFieldToColumn(%q) = %q, want %q", "Board", col, wantBoardMemberCol)
+	}
+}
 
 // ============================================================================
 // Service Identity Tests

--- a/pocketbase/sync/quest_registrations.go
+++ b/pocketbase/sync/quest_registrations.go
@@ -253,7 +253,7 @@ func (s *QuestRegistrationsSync) loadFieldDefinitions(_ context.Context) (map[st
 	}
 
 	for _, record := range records {
-		name := record.GetString("name")
+		name := normalizeFieldName(record.GetString("name"))
 		if isQuestRegistrationField(name) {
 			result[record.Id] = name
 		}

--- a/pocketbase/sync/quest_registrations_test.go
+++ b/pocketbase/sync/quest_registrations_test.go
@@ -1,10 +1,48 @@
 package sync
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 )
+
+// TestQuestRegistrationsLoadFieldDefinitionsTrimsNames is a regression test
+// for kindred#1873. isQuestRegistrationField admits by prefix, which a
+// trailing space would not defeat, but MapQuestFieldToColumn exact-matches
+// the trimmed literal downstream -- so an untrimmed name would be admitted
+// into the map and then silently fail to route. No untrimmed name exists in
+// this table today; this pins the fix against a future one.
+func TestQuestRegistrationsLoadFieldDefinitionsTrimsNames(t *testing.T) {
+	app := newFieldDefsTestApp(t, map[int]string{
+		1: "Q-Why come? ",           // trailing space
+		2: "Quest-Parent Signature", // already clean, must be unaffected
+	})
+
+	s := NewQuestRegistrationsSync(app)
+	got, err := s.loadFieldDefinitions(context.Background())
+	if err != nil {
+		t.Fatalf("loadFieldDefinitions: %v", err)
+	}
+
+	want := map[string]bool{
+		"Q-Why come?":            true,
+		"Quest-Parent Signature": true,
+	}
+	for _, name := range got {
+		if !want[name] {
+			t.Errorf("loadFieldDefinitions returned %q; expected a trimmed name", name)
+		}
+		delete(want, name)
+	}
+	for missing := range want {
+		t.Errorf("loadFieldDefinitions did not return %q", missing)
+	}
+
+	if col := MapQuestFieldToColumn("Q-Why come?"); col != colWhyCome {
+		t.Errorf("MapQuestFieldToColumn(%q) = %q, want %q", "Q-Why come?", col, colWhyCome)
+	}
+}
 
 // TestQuestRegistrationsSync_Name verifies the service name is correct
 func TestQuestRegistrationsSync_Name(t *testing.T) {

--- a/pocketbase/sync/staff_applications.go
+++ b/pocketbase/sync/staff_applications.go
@@ -227,7 +227,7 @@ func (s *StaffApplicationsSync) loadFieldDefinitions(_ context.Context) (map[str
 	}
 
 	for _, record := range records {
-		name := record.GetString("name")
+		name := normalizeFieldName(record.GetString("name"))
 		if isStaffApplicationField(name) {
 			result[record.Id] = name
 		}

--- a/pocketbase/sync/staff_applications_test.go
+++ b/pocketbase/sync/staff_applications_test.go
@@ -1,8 +1,59 @@
 package sync
 
 import (
+	"context"
 	"testing"
 )
+
+// TestStaffApplicationsLoadFieldDefinitionsTrimsNames is a regression test for
+// kindred#1873: CampMinder ships "App-I responded to my stress ", "App-Someone
+// whose work I " and "App-My closest friend at camp " with a trailing space,
+// while MapStaffAppFieldToColumn exact-matches the trimmed literal. Before the
+// fix, loadFieldDefinitions stored the untrimmed name, so the switch never
+// matched and 3,492 answers across the three columns were silently dropped.
+func TestStaffApplicationsLoadFieldDefinitionsTrimsNames(t *testing.T) {
+	app := newFieldDefsTestApp(t, map[int]string{
+		1: "App-I responded to my stress ",  // trailing space, verbatim from CampMinder
+		2: "App-Someone whose work I ",      // trailing space, verbatim from CampMinder
+		3: "App-My closest friend at camp ", // trailing space, verbatim from CampMinder
+		4: "App-Why Tawonga?",               // already clean, must be unaffected
+	})
+
+	s := NewStaffApplicationsSync(app)
+	got, err := s.loadFieldDefinitions(context.Background())
+	if err != nil {
+		t.Fatalf("loadFieldDefinitions: %v", err)
+	}
+
+	want := map[string]bool{
+		"App-I responded to my stress":  true,
+		"App-Someone whose work I":      true,
+		"App-My closest friend at camp": true,
+		"App-Why Tawonga?":              true,
+	}
+	for _, name := range got {
+		if !want[name] {
+			t.Errorf("loadFieldDefinitions returned %q; expected a trimmed name", name)
+		}
+		delete(want, name)
+	}
+	for missing := range want {
+		t.Errorf("loadFieldDefinitions did not return %q", missing)
+	}
+
+	// The whole point: the trimmed names must round-trip through the routing
+	// switch, which is what silently dropped the three fields before the fix.
+	routingCases := map[string]string{
+		"App-I responded to my stress":  "stress_response",
+		"App-Someone whose work I":      "someone_admire",
+		"App-My closest friend at camp": "closest_friend",
+	}
+	for name, wantCol := range routingCases {
+		if gotCol := MapStaffAppFieldToColumn(name); gotCol != wantCol {
+			t.Errorf("MapStaffAppFieldToColumn(%q) = %q, want %q", name, gotCol, wantCol)
+		}
+	}
+}
 
 // TestStaffApplicationsServiceName verifies the service name constant
 func TestStaffApplicationsServiceName(t *testing.T) {

--- a/pocketbase/sync/staff_skills.go
+++ b/pocketbase/sync/staff_skills.go
@@ -310,7 +310,7 @@ func (s *StaffSkillsSync) loadSkillDefinitions(_ context.Context) ([]skillDefini
 	}
 
 	for _, record := range records {
-		name := record.GetString("name")
+		name := normalizeFieldName(record.GetString("name"))
 
 		// Filter: must be Skills- field with Staff partition
 		if !strings.HasPrefix(name, "Skills-") {

--- a/pocketbase/sync/staff_skills_test.go
+++ b/pocketbase/sync/staff_skills_test.go
@@ -1,15 +1,92 @@
 package sync
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
 )
 
 // testLastName is a standard test last name (testFirstName is defined in persons_test.go)
 const testLastName = "Johnson"
+
+// newSkillDefsTestApp returns a throwaway PocketBase app with a
+// custom_field_defs collection shaped like production's (cm_id + name +
+// partition), pre-populated with the given (cm_id, name) pairs, each tagged
+// with the Staff partition. Names are stored VERBATIM -- PocketBase preserves
+// leading and trailing whitespace in text fields.
+func newSkillDefsTestApp(t *testing.T, defs map[int]string) core.App {
+	t.Helper()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	col := core.NewBaseCollection("custom_field_defs")
+	col.Fields.Add(&core.NumberField{Name: "cm_id"})
+	col.Fields.Add(&core.TextField{Name: "name"})
+	col.Fields.Add(&core.SelectField{
+		Name:      "partition",
+		Values:    []string{"None", "Family", "Alumnus", "Staff", "Camper", "Parent", "Adult"},
+		MaxSelect: 7,
+	})
+	if err := app.Save(col); err != nil {
+		t.Fatalf("save custom_field_defs: %v", err)
+	}
+	for cmID, name := range defs {
+		r := core.NewRecord(col)
+		r.Set("cm_id", cmID)
+		r.Set("name", name)
+		r.Set("partition", []string{"Staff"})
+		if err := app.Save(r); err != nil {
+			t.Fatalf("save field def %d: %v", cmID, err)
+		}
+	}
+	return app
+}
+
+// TestStaffSkillsLoadSkillDefinitionsTrimsNames is a regression test for
+// kindred#1873. loadSkillDefinitions admits by "Skills-" prefix, which a
+// trailing space would not defeat, but it is the derived skill string
+// (name with the prefix stripped) that gets written to staff_skills.skill_name
+// -- an untrimmed source name would silently carry the trailing space into
+// that column. No untrimmed name exists in this table today; this pins the
+// fix against a future one.
+func TestStaffSkillsLoadSkillDefinitionsTrimsNames(t *testing.T) {
+	app := newSkillDefsTestApp(t, map[int]string{
+		1: "Skills-Archery ", // trailing space
+		2: "Skills-Riflery",  // already clean, must be unaffected
+	})
+
+	s := NewStaffSkillsSync(app)
+	got, err := s.loadSkillDefinitions(context.Background())
+	if err != nil {
+		t.Fatalf("loadSkillDefinitions: %v", err)
+	}
+
+	want := map[string]string{
+		"Skills-Archery": "Archery",
+		"Skills-Riflery": "Riflery",
+	}
+	for _, def := range got {
+		wantSkill, ok := want[def.name]
+		if !ok {
+			t.Errorf("loadSkillDefinitions returned %q; expected a trimmed name", def.name)
+			continue
+		}
+		if def.skill != wantSkill {
+			t.Errorf("loadSkillDefinitions(%q).skill = %q, want %q", def.name, def.skill, wantSkill)
+		}
+		delete(want, def.name)
+	}
+	for missing := range want {
+		t.Errorf("loadSkillDefinitions did not return %q", missing)
+	}
+}
 
 // TestStaffSkillsSync_Name verifies the service name is correct
 func TestStaffSkillsSync_Name(t *testing.T) {

--- a/pocketbase/sync/staff_vehicle_info.go
+++ b/pocketbase/sync/staff_vehicle_info.go
@@ -187,7 +187,7 @@ func (s *StaffVehicleInfoSync) loadFieldDefinitions(_ context.Context) (map[stri
 	}
 
 	for _, record := range records {
-		name := record.GetString("name")
+		name := normalizeFieldName(record.GetString("name"))
 		if isStaffVehicleInfoField(name) {
 			result[record.Id] = name
 		}

--- a/pocketbase/sync/staff_vehicle_info_test.go
+++ b/pocketbase/sync/staff_vehicle_info_test.go
@@ -1,9 +1,47 @@
 package sync
 
 import (
+	"context"
 	"fmt"
 	"testing"
 )
+
+// TestStaffVehicleInfoLoadFieldDefinitionsTrimsNames is a regression test for
+// kindred#1873. isStaffVehicleInfoField admits by "SVI-"/"SVI " prefix, which
+// a trailing space would not defeat, but MapSVIFieldToColumnImpl exact-matches
+// the trimmed literal downstream -- so an untrimmed name would be admitted
+// into the map and then silently fail to route. No untrimmed name exists in
+// this table today; this pins the fix against a future one.
+func TestStaffVehicleInfoLoadFieldDefinitionsTrimsNames(t *testing.T) {
+	app := newFieldDefsTestApp(t, map[int]string{
+		1: "SVI-are you driving to camp ", // trailing space
+		2: "SVI-which friend",             // already clean, must be unaffected
+	})
+
+	s := NewStaffVehicleInfoSync(app)
+	got, err := s.loadFieldDefinitions(context.Background())
+	if err != nil {
+		t.Fatalf("loadFieldDefinitions: %v", err)
+	}
+
+	want := map[string]bool{
+		"SVI-are you driving to camp": true,
+		"SVI-which friend":            true,
+	}
+	for _, name := range got {
+		if !want[name] {
+			t.Errorf("loadFieldDefinitions returned %q; expected a trimmed name", name)
+		}
+		delete(want, name)
+	}
+	for missing := range want {
+		t.Errorf("loadFieldDefinitions did not return %q", missing)
+	}
+
+	if col := MapSVIFieldToColumnImpl("SVI-are you driving to camp"); col != colDrivingToCamp {
+		t.Errorf("MapSVIFieldToColumnImpl(%q) = %q, want %q", "SVI-are you driving to camp", col, colDrivingToCamp)
+	}
+}
 
 // TestStaffVehicleInfoServiceName verifies the service name constant
 func TestStaffVehicleInfoServiceName(t *testing.T) {


### PR DESCRIPTION
## Summary

CampMinder ships some custom-field display names with a trailing space (e.g. `App-I responded to my stress `). Every sync service in `pocketbase/sync/` that builds a field-name map for routing reads that display name with `record.GetString("name")` and later exact-matches the *trimmed* literal in a switch/map lookup. An untrimmed name silently fails to match, and the answer is dropped.

`staff_applications.go` hit this live: `stress_response`, `someone_admire` and `closest_friend` have been empty since introduction — 3,492 answers across the three columns, verified against the dev database. This is the same defect PR #1872 already fixed for `Family Camp-Physician` in `family_camp_derived.go`, which is where `normalizeFieldName` was introduced.

## Changes

- `staff_applications.go` — call the existing shared `normalizeFieldName` helper (package `sync`, from #1872) at the field-definition load boundary. This is the fix for the live bug.
- Same latent pattern fixed in the 7 other files the issue flagged: `camper_dietary.go`, `camper_transportation.go`, `quest_registrations.go`, `household_demographics.go`, `staff_skills.go`, `staff_vehicle_info.go`, `financial_aid_applications.go`. No untrimmed name currently hits any of these — CampMinder's field names are free text and unvalidated, so nothing prevents the next one.

## Note on scope

`staff_skills.go` doesn't build a `field_definition PB ID -> name` map like the others — it derives a skill name by stripping the `Skills-` prefix and writes that directly to `staff_skills.skill_name`. An untrimmed source name wouldn't miss a routing switch (there isn't one), but it would silently carry a trailing space into the stored skill name. Trimming at the same load boundary fixes both symptoms consistently.

## Test plan

- [x] Failing test written first for each of the 8 files, confirmed to fail for the stated reason (untrimmed name either missing admission entirely, or admitted but not surviving the downstream routing switch), then fixed and confirmed passing.
- [x] `go test ./sync/ -count=1` — full package passes
- [x] `gofmt -l sync/` — clean
- [x] `go build ./...` — clean
- [x] `golangci-lint run ./sync/...` — 0 issues
- [x] Pre-push hooks (mypy, tsc, go build, ruff, full pytest suite) — all green

Fixes #1873

🤖 Generated with [Claude Code](https://claude.com/claude-code)