### PR TITLE
fix(scripts): scope the lodging registry guard past comments and docstrings

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,9 +1,9 @@
 # HANDOFF — Family Camp Lodging
 
-**State as of `abfdbe90` on `main`, with Plan 3 Phase B in review as PR #1890.** The data layer,
-the ingest and the read API are merged. Phase B — the `/weekend` lander and roster — is written,
-green and pushed, but **not merged**: it is in review, a scan agent is applying fixes to the same
-branch, and §4 is how you pick it up.
+**State as of `37cf8d24` on `main`.** The data layer, the ingest, the read API and the weekend
+surfaces are all merged. `/weekend/sessions` lists the year's weekends; `/weekend/session/:id`
+shows one weekend's roster and inventory. **The next body of work is Plan 3 Phase C — the
+`/admin/lodging` editor, the Go integrity guards and the work-queue UI.**
 
 This is a working document. Edit it in place: tick what ships, rewrite "Next", delete what stops
 being true. It is not a changelog — `git log` is the changelog.
@@ -18,7 +18,7 @@ Three plans. The first two are done.
 |---|---|---|
 | **1 — Data layer** | `lodging_*` collections, seed, alias registry | ✅ merged (`49d38ff8`, #1867) |
 | **2 — Ingest** | CampMinder cabin fields → assignments, requests, PHI split | ✅ merged — see below |
-| **3 — Surfaces** | Read API, `/weekend` roster, `/admin/lodging` editor | 🔶 A merged (`f99a8ef7`, #1884); **B in review (#1890)**; C open |
+| **3 — Surfaces** | Read API, `/weekend` roster, `/admin/lodging` editor | 🔶 A (`f99a8ef7`, #1884) and B (`37cf8d24`, #1890) merged; **C open** |
 
 Plan 2 shipped in four PRs:
 
@@ -70,6 +70,21 @@ Facts, not a work log. Do not re-verify or re-implement these.
   from `WeekendRosterResponse` to prove no PHI field is reachable. `PHI_FIELD_NAMES` has **eight**
   entries and a test pins it against Go's `phiColumns`, because the two guard different exits —
   Go keeps PHI out of exports and logs, Python keeps it out of API payloads.
+- **The weekend surfaces are live** (Phase B, `37cf8d24`): `/weekend/sessions` lander,
+  `/weekend/session/:sessionCmId` roster with Roster/Inventory tabs, and
+  `GET /api/lodging/summary?year=` — one batched read returning every weekend with its
+  `RosterCounts`. `/summary` exists because `/roster` makes eleven fetches of which **eight are
+  year-scoped**, so filling a lander weekend-by-weekend repeated that work N times; a weekend with
+  zero parties still cost ~3s. Measured: twelve weekends in one 4.0s / 5.9 KB call.
+- **`/summary` and `/roster` cannot disagree.** The batch runs the same
+  `_build_units` / `_build_parties` / `_build_counts` helpers, and
+  `TestBuildSummary::test_counts_match_what_the_roster_reports_for_the_same_weekend` asserts it.
+- **Shared weekend helpers live in `frontend/src/components/weekend/`**: `rosterAttention.ts`
+  (triage + `countUnmeasuredSpaces`), `weekendStatus.ts` (lifecycle + chronological sort),
+  `weekendNames.ts` (colon split), `sessionDates.ts` (PocketBase datetime → "May 22–25, 2026").
+  Phase C reuses these rather than re-deriving.
+- **`verify-no-hardcoded-lodging.sh` ignores comments and docstrings** (`scripts/dev/lib/
+  drop_comment_hits.py`). It used to fail on prose, which is why it was red on `main` (#1891).
 - **Highest migration is `1500000127`.** Compute the next number from `main`, never from a branch.
 
 ---
@@ -136,78 +151,72 @@ Each of these was decided deliberately. Reopening one needs a reason, not a fres
   pickers and keeps "Memorial Day Weekend" for the lander row. Lossless — inventing abbreviations
   is how a UI starts disagreeing with CampMinder about what a session is called.
 - **Lander counts come from `/api/lodging/summary`, never from N roster calls.** See §4.
+- **Contracts corrected in review (`03754754`), easy to mis-remember:**
+  `AccessibilityFlagListProps.householdCmId` is `number | null` — `null` means "no household to
+  look up" and suppresses the PHI reveal entirely, rather than requesting `/households/0/medical`.
+  `partyAttention`'s `unverified` reason lists only needs a confirmed cabin has *not* answered.
+  `UnitInventoryPanel` buckets areas on `` `${area_code}::${area_name}` `` because the API sends
+  `area_code: ""` for anything it cannot resolve. Neither weekend page passes `emptyMessage` to
+  `QueryGuard` — the nested components carry the real empty states.
 
 ---
 
-## 4. Next: intake Phase B's review, then Plan 3 Phase C
+## 4. Next: Plan 3 Phase C — the Family Camp admin surface
 
-Plan: `docs/superpowers/plans/2026-07-30-family-camp-lodging-surfaces.md` (local-only, gitignored).
-Its Phase B header carries a **SHIPPED** block listing nine ways the delivered work diverges from
-Tasks 7-12 — read that before treating the task list as the record.
+Plan: `docs/superpowers/plans/2026-07-30-family-camp-lodging-surfaces.md` (local-only, gitignored),
+Tasks 13–17. **Its Phase B header carries a SHIPPED block listing nine divergences** — read that
+first, because Phase C inherits the corrected shape, not the shape Tasks 7–12 describe.
 
 | Phase | Tasks | Ships | Status |
 |---|---|---|---|
-| **A — Read API** | 1-6 | `/api/lodging/*`, `lodging.phi`, generated TS types | ✅ `f99a8ef7` (#1884) |
-| **B — Lander + roster** | 7-12 | `/weekend/sessions`, `/weekend/session/:id`, `/api/lodging/summary` | 🔶 **in review, PR #1890** |
-| **C — Admin CRUD** | 13-17 | `/admin/lodging` editor, Go integrity guards, work queue UI | ⬜ after B merges |
+| **A — Read API** | 1–6 | `/api/lodging/*`, `lodging.phi`, generated TS types | ✅ `f99a8ef7` (#1884) |
+| **B — Lander + roster** | 7–12 | `/weekend/sessions`, `/weekend/session/:id`, `/summary` | ✅ `37cf8d24` (#1890) |
+| **C — Admin CRUD** | 13–17 | `/admin/lodging` editor, Go integrity guards, work queue UI | ⬜ **next** |
 
-### Your job, in order
+### Task order, and why
 
-1. **Intake the scan agent's fixes.** A scan agent is working the same branch and worktree. Its
-   catches so far are real bugs in Phase B's code, not style: `UnitInventoryPanel` bucketed areas on
-   `area_code` alone, so two areas both carrying `code: ""` collided and the second one's name was
-   silently dropped; and `partyAttention` dragged already-answered needs back into the `unverified`
-   reason, so a cabin the registry confirms *has* power could read "Power" as outstanding. Expect
-   more of that shape. Re-run the suites after taking them (§7) — several of these live in pure
-   helpers with dense tests, so a bad fix fails loudly rather than silently.
-2. **Review the work against the plan AND the owner's GUI direction.** The plan is the weaker of
-   the two here: it predates both the ingest request layer and any look at the summer surfaces. The
-   owner's direction, gathered over the session, is in §3 under "Locked by Phase B" — spaces not
-   beds, triage not listing, extend summer's visual language rather than invent one. Where the plan
-   and §3 disagree, §3 wins.
-3. **After #1890 merges, start Phase C** (Tasks 13-17): `pocketbase/lodging/hooks.go` integrity
-   guards, then the `/admin/lodging` editor, then the work-queue UI over
-   `lodging_ingest_issues`.
+1. **Task 13 — `pocketbase/lodging/hooks.go` integrity guards, first.** They are the invariants the
+   database does not enforce: `guardAssignmentGrain` (exactly one of unit/merge, exactly one of
+   household/person), `guardUnitDelete` (deactivate, never delete, when assignments exist),
+   `guardMergeDelete` (blocked at ≥1 occupant — stricter than spec §3.4, to close the
+   single-occupant orphan hole). Land these *before* the UI that can violate them.
+2. **Tasks 14–16 — the editor.** Writes go **straight to PocketBase, not through FastAPI**: all
+   four collections carry `createRule`/`updateRule`/`deleteRule` = `@request.auth.is_admin = true`,
+   so PocketBase is the authorisation boundary and Task 13 is the integrity boundary. Same pattern
+   as `frontend/src/components/admin/RegistrationDatesConfig.tsx`.
+3. **Task 17 — the work-queue UI** over `lodging_ingest_issues` filtered to
+   `kind = "unresolved_alias" && is_resolved = false`.
 
 ### What Phase C inherits that the plan does not describe
 
-- **`GET /api/lodging/summary?year=` exists.** Built because the lander needs per-weekend counts and
-  `/roster` is a composed read dominated by year-scoped work — eight of its eleven fetches are
-  identical for every weekend, so a weekend with **zero parties still cost ~3s**. Measured: twelve
-  weekends in one **4.0s / 5.9 KB** call against 12 x ~3s and ~1.2 MB. Its counts come from the same
-  `_build_units` / `_build_parties` / `_build_counts` helpers `/roster` uses, and
-  `TestBuildSummary::test_counts_match_what_the_roster_reports_for_the_same_weekend` asserts the two
-  agree. **Any new per-weekend figure belongs on this endpoint, not on a per-weekend roster call.**
-- **`frontend/src/components/weekend/` is the shared surface**: `rosterAttention.ts` (triage +
-  `countUnmeasuredSpaces`), `weekendStatus.ts` (lifecycle + chronological sort), `weekendNames.ts`
-  (colon split), `sessionDates.ts` (PocketBase datetime -> "May 22-25, 2026"), plus the components.
-  Phase C's admin UI should reuse these rather than re-deriving.
-- **The PocketBase record/input types the plan puts in Task 7 were deferred to Phase C** — nothing
-  in Phase B consumes them; only Task 14's `lodgingCrud.ts` does. Write them there, and do **not**
-  write a `LodgingUnresolvedAliasRecord`: the work queue is `lodging_ingest_issues`.
-- **`lodging.phi` is still granted to no role (#1887).** Admin bypass is the only route to the
-  narrative. Phase C's role editor is the natural place to fix it.
+- **Write the PocketBase record and input types now.** The plan puts them in Task 7; Phase B
+  deferred them because nothing there consumed them. `LodgingUnitInput` must keep `is_active` and
+  `allocation_default` **non-optional** — PocketBase has no per-field default for bool or select, so
+  a create that omits them yields an invisible unit that matches neither availability branch.
+- **Do NOT write a `LodgingUnresolvedAliasRecord`.** The work queue is `lodging_ingest_issues`; the
+  query key is already `queryKeys.lodgingIngestIssues()`.
+- **Confirming amenities switches on live behaviour.** `partyAttention` only judges a housing need
+  against a cabin whose `is_confirmed` is true; all 82 are false today, so the roster reports
+  *"Fit not verified"* for every constrained party. The moment Phase C lets staff confirm a cabin,
+  the `unmet` section starts populating — **that path has unit tests but has never run against real
+  data.** Expect it to be the first thing that looks wrong, and check it deliberately.
+- **`/weekend/session/:id` has no "Lodging settings" link.** It was removed in `03754754` because
+  `/admin/lodging` is not a registered route and `App.tsx`'s `path="*"` silently bounced the user
+  home. **Add the link back when Phase C registers the route** —
+  `frontend/src/pages/WeekendRosterPage.tsx`.
+- **Any new per-weekend figure belongs on `/api/lodging/summary`**, never on an N-call loop over
+  `/roster`. See §6.
+- **`lodging.phi` is granted to no role (#1887).** Admin bypass is the only route to the narrative
+  today. Phase C's admin surface is the natural place to fix it, and doing so is the first real test
+  of the 403 degradation path in `AccessibilityFlagList`.
 
 ---
 
 ## 5. CRITICAL: first action before anything else
 
-**Two gates, in this order.**
-
-**(a) The branch is shared. Check for work that is not yours before touching anything.**
-
-```bash
-cd ~/kindred-worktrees/lodging-roster
-git status --short                       # scan agent's fixes may be UNCOMMITTED here
-git fetch -q && git log --oneline -5 origin/feature/lodging-roster
-```
-
-Uncommitted files in that worktree are the scan agent's. **Do not `git add -A`** — stage only what
-you changed, or you will sweep their in-progress work into your commit.
-
-**(b) The request columns the roster renders are EMPTY until a sync runs.** Schema-only on any
-database that has not run `family_camp_derived` since #1878. Build against that and every party
-renders unknown/unflagged, and the API looks broken while working exactly as designed.
+**The columns and rows Phase C edits are EMPTY until a sync runs.** On any database that has not run
+`family_camp_derived` since #1878, the request columns are schema-only and the roster renders every
+party unknown/unflagged — the API looks broken while working exactly as designed.
 
 ```bash
 sqlite3 pocketbase/pb_data/data.db \
@@ -215,18 +224,18 @@ sqlite3 pocketbase/pb_data/data.db \
      FROM family_camp_registrations WHERE year >= 2025 GROUP BY year;"
 ```
 
-Only `gate` and `req` are meaningful there. **Do not add `SUM(wants_near!='')`** — `wants_near` is a
-boolean and SQLite evaluates `0 != ''` as TRUE, so that column reports the full row count on an
-empty database. If `gate`/`req` are `0`:
+Only `gate` and `req` are meaningful. **Do not add `SUM(wants_near!='')`** — `wants_near` is a
+boolean and SQLite evaluates `0 != ''` as TRUE, so that column reports the full row count on a
+completely empty database. If `gate`/`req` are `0`:
 
 ```bash
 ./scripts/start_dev.sh   # boots PocketBase, which applies 1500000127
+# then, with a users-collection admin token (see §9 — a _superusers token is REJECTED):
 curl -X POST "http://localhost:8090/api/custom/sync/run?year=2026&service=family_camp_derived"
 ```
 
-That endpoint needs a **users**-collection admin token, not a `_superusers` one, and FastAPI needs a
-`Bearer` prefix — see the memory pointer in §9. The job takes **~8-10 minutes per year** and reports
-`status: "running"` with a zero summary the whole time; that is progress, not a hang.
+The job takes **~8–10 minutes per year** and reports `status: "running"` with an all-zero summary
+the whole time. That is progress, not a hang — confirm with CPU, not the counters.
 
 ---
 
@@ -270,8 +279,13 @@ That endpoint needs a **users**-collection admin token, not a `_superusers` one,
 - **Do not run `golangci-lint` only at the end of a phase.** Per task. Several lint failures reached
   push time in this programme precisely because it was deferred.
 - **Do not commit `docs/superpowers/**` or `docs/plans/**`.** Gitignored, local-only, public repo.
-- **Do not `git add -A` in the lodging-roster worktree while the scan agent is working it.** Stage
-  the paths you touched.
+- **Do not re-add unit names to application source to make a rule readable.** The guard now ignores
+  comments and docstrings, so prose is fine; a string literal, list or map is not (spec §3.8).
+- **Do not judge a housing need against an unconfirmed cabin.** `has_power: false` on an unconfirmed
+  row means "nobody has said". Phase C makes confirmation possible — that is the moment this starts
+  mattering, not a reason to relax it.
+- **Do not delete a `lodging_units` row that has assignments.** Deactivate. Task 13's
+  `guardUnitDelete` enforces it and no `deleteLodgingUnit` should exist.
 
 ---
 
@@ -311,6 +325,8 @@ git fetch -q && git rev-list --count origin/<branch>..HEAD   # must be 0
 
 ## 8. Open issues
 
+- **#1891 is fixed** — `verify-no-hardcoded-lodging.sh` now ignores comments and docstrings and is
+  green on a clean `main`. Kept here only so a reader of the issue knows where it went.
 - **Free text carries PHI the boundary does not cover.** Families type medical detail into the
   *cabin-request* box: across 2026 family weekends, **12 of 232 request texts (5%)** contain health
   vocabulary, including at least one named diagnosis with the accommodation it requires. That text
@@ -320,19 +336,24 @@ git fetch -q && git rev-list --count origin/<branch>..HEAD   # must be 0
 - **`has_medical_narrative` is true for every household** (62 of 62 in 2026; 870 medical rows, 648
   with dietary/allergy text). Accurate, but it means the medical affordance appears on every row and
   therefore signals nothing. Worth deciding whether the flag should mean something narrower.
-- **Phase B was never verified in a browser after its last two commits.** The summer-language pass,
-  the lander, the route change, the `Listbox` and the batched endpoint are covered by tests and by
-  direct API measurement, but the lander has never been rendered. Boot the worktree stack and look
-  before merging.
+- **Phase B was never verified in a browser after its last three commits.** It is merged and green,
+  but nobody has *looked* at the lander, the Listbox switcher or the stats bar — they are covered by
+  tests and by direct API measurement only. Worth ten minutes with `./scripts/start_dev.sh` before
+  building Phase C on top of them.
 - **The summer campers tab was never mined.** `/summer/session/:id/campers` (`CampersView`) is the
   closest analogue to the roster table and likely has filter/sort affordances worth copying. Traced
   as far as the component and stopped.
+- **CodeRabbit reviewed #1890 only up to `2451582e`, three commits behind HEAD.** It never saw the
+  stats bar, the summer-language rewrite or the batched endpoint, and two files it did review no
+  longer existed. Do not read a CodeRabbit pass as covering a branch that moved under it — check
+  which commit it reviewed.
 
 - **#1887** — `lodging.phi` is granted to **no role**, and `1500000070_rbac_roles.js` was untouched
   by #1884. `require_permission` admin-bypasses, so admins reach the medical endpoint and every
   non-admin gets a 403 that no role edit resolves. Defensible as default-deny for PHI, but it will
-  surprise whoever first tries to give a health-centre lead access. **Phase B should assume the
-  narrative reveal is admin-only in practice** and degrade gracefully when the call 403s.
+  surprise whoever first tries to give a health-centre lead access. Phase B's reveal already degrades
+  gracefully on a 403; **Phase C's admin surface is the natural place to actually grant it**, and
+  doing so is the first real exercise of that path.
 - **#1881** — two pre-existing package-wide patterns the ingest inherited rather than introduced:
   every individual-sync handler in `api.go` mutates the orchestrator's singleton service, and
   `SyncTab`'s card guard references no type-specific `isPending`. Both want **one sweep across all

--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -35,7 +35,7 @@ function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
     household_cm_id: 2000001,
     person_cm_id: 0,
     display_name: 'The Johnson Family',
-    adults: [{ adult_number: 1, display_name: 'Olivia Johnson', relationship: 'Parent' }],
+    adults: [{ adult_number: 1, display_name: 'Samuel Johnson', relationship: 'Parent' }],
     children: [{ person_cm_id: 1000001, display_name: 'Emma Johnson', age: 9, grade: 4 }],
     party_size: 2,
     unit_code: '',
@@ -145,7 +145,7 @@ describe('HouseholdRosterTable', () => {
     render(<HouseholdRosterTable parties={[party()]} year={2026} />, { wrapper })
     expect(screen.getByText('The Johnson Family')).toBeInTheDocument()
     expect(screen.getByText('1 adult · 1 child')).toBeInTheDocument()
-    expect(screen.getByText('Olivia Johnson')).toBeInTheDocument()
+    expect(screen.getByText('Samuel Johnson')).toBeInTheDocument()
     expect(screen.getByText('Emma Johnson (9)')).toBeInTheDocument()
   })
 
@@ -156,11 +156,11 @@ describe('HouseholdRosterTable', () => {
           party({
             adults: [
               { adult_number: 1, display_name: 'Olivia Chen', relationship: 'Parent' },
-              { adult_number: 2, display_name: 'Noah Chen', relationship: 'Parent' },
+              { adult_number: 2, display_name: 'Liam Garcia', relationship: 'Parent' },
             ],
             children: [
-              { person_cm_id: 1000001, display_name: 'Emma Chen', age: 9, grade: 4 },
-              { person_cm_id: 1000003, display_name: 'Liam Chen', age: 7, grade: 2 },
+              { person_cm_id: 1000001, display_name: 'Olivia Chen', age: 9, grade: 4 },
+              { person_cm_id: 1000003, display_name: 'Liam Garcia', age: 7, grade: 2 },
             ],
             party_size: 4,
           }),

--- a/frontend/src/components/weekend/rosterAttention.test.ts
+++ b/frontend/src/components/weekend/rosterAttention.test.ts
@@ -29,7 +29,7 @@ function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
     household_cm_id: 2000001,
     person_cm_id: 0,
     display_name: 'The Johnson Family',
-    adults: [{ adult_number: 1, display_name: 'Olivia Johnson', relationship: 'Parent' }],
+    adults: [{ adult_number: 1, display_name: 'Samuel Johnson', relationship: 'Parent' }],
     children: [{ person_cm_id: 1000001, display_name: 'Emma Johnson', age: 9, grade: 4 }],
     party_size: 2,
     unit_code: 'ridge-a',
@@ -207,9 +207,9 @@ describe('partyBeds', () => {
     const withoutSize = party({
       adults: [
         { adult_number: 1, display_name: 'Olivia Chen' },
-        { adult_number: 2, display_name: 'Noah Chen' },
+        { adult_number: 2, display_name: 'Liam Garcia' },
       ],
-      children: [{ person_cm_id: 1, display_name: 'Emma Chen' }],
+      children: [{ person_cm_id: 1, display_name: 'Olivia Chen' }],
     })
     delete withoutSize.party_size
     expect(partyBeds(withoutSize)).toBe(3)

--- a/scripts/dev/lib/drop_comment_hits.py
+++ b/scripts/dev/lib/drop_comment_hits.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Drop grep hits that sit in a comment or a docstring.
+
+Spec 3.8 forbids the lodging registry from living in source. A registry lives
+in *code* -- string literals, lists, maps. Prose that names a unit to explain a
+rule is documentation, and failing on it made the guard red on `main` for a
+docstring at `api/services/lodging_rules.py` (kindred#1891), which opened
+Phase C on a failure that was not Phase C's.
+
+Reads `path:lineno:text` on stdin (grep -In output, repo-relative) and writes
+through only the hits that land on a code line.
+
+SCOPE, honestly stated, matching the guard this serves:
+  * Python uses the real tokenizer, so comments and docstrings are exact.
+  * C-style files (.go/.js/.ts/.tsx) use a character scan that tracks string
+    and block-comment state. It understands quotes well enough not to mistake
+    "https://example/Tuolumne" for a comment, but it is not a parser.
+  * A file that will not parse or read is treated as ALL CODE, so its hits
+    survive. A guard that goes quiet because a file is malformed is worse than
+    one that reports a line you have to read.
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import sys
+import tokenize
+from pathlib import Path
+
+C_STYLE_SUFFIXES = {".go", ".js", ".jsx", ".ts", ".tsx"}
+
+
+def _python_noncode_lines(source: str) -> set[int]:
+    """Line numbers occupied by a comment or a docstring."""
+    noncode: set[int] = set()
+
+    try:
+        for token in tokenize.generate_tokens(io.StringIO(source).readline):
+            if token.type == tokenize.COMMENT:
+                noncode.update(range(token.start[0], token.end[0] + 1))
+    except Exception:
+        # Deliberately broad, and deliberately NOT a parenthesized tuple of
+        # TokenError/IndentationError/SyntaxError: this file is run by the
+        # guard's bare `python3`, which may predate 3.14, while ruff formats
+        # it for the repo's 3.14 target and rewrites a tuple into the
+        # bare-comma form that older interpreters reject. Any tokenize failure
+        # means the same thing anyway -- we learned nothing, so keep every hit.
+        return set()
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return noncode
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        body = getattr(node, "body", None)
+        if not body:
+            continue
+        first = body[0]
+        # A docstring is a bare string expression in first position. Any other
+        # string literal is data and stays in scope.
+        if (
+            isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+            and first.end_lineno is not None
+        ):
+            noncode.update(range(first.lineno, first.end_lineno + 1))
+
+    return noncode
+
+
+def _c_style_noncode_lines(source: str) -> set[int]:
+    """Line numbers wholly given over to `//` or `/* */` comments.
+
+    A line counts as non-code only if everything on it outside a comment is
+    whitespace, so `const x = "Tuolumne" // note` still reports.
+    """
+    noncode: set[int] = set()
+    in_block = False
+    in_string: str | None = None
+
+    for lineno, line in enumerate(source.splitlines(), start=1):
+        code_chars: list[str] = []
+        index = 0
+        while index < len(line):
+            char = line[index]
+            pair = line[index : index + 2]
+
+            if in_block:
+                if pair == "*/":
+                    in_block = False
+                    index += 2
+                    continue
+                index += 1
+                continue
+
+            if in_string is not None:
+                code_chars.append(char)
+                if char == "\\":
+                    index += 2
+                    continue
+                if char == in_string:
+                    in_string = None
+                index += 1
+                continue
+
+            if char in "\"'`":
+                in_string = char
+                code_chars.append(char)
+                index += 1
+                continue
+
+            if pair == "//":
+                break  # rest of the line is comment
+            if pair == "/*":
+                in_block = True
+                index += 2
+                continue
+
+            code_chars.append(char)
+            index += 1
+
+        if not "".join(code_chars).strip():
+            noncode.add(lineno)
+
+    return noncode
+
+
+def noncode_lines(path: Path) -> set[int]:
+    try:
+        source = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return set()
+
+    if path.suffix == ".py":
+        return _python_noncode_lines(source)
+    if path.suffix in C_STYLE_SUFFIXES:
+        return _c_style_noncode_lines(source)
+    return set()
+
+
+def main() -> int:
+    cache: dict[str, set[int]] = {}
+    for raw in sys.stdin:
+        hit = raw.rstrip("\n")
+        if not hit:
+            continue
+        parts = hit.split(":", 2)
+        if len(parts) < 3 or not parts[1].isdigit():
+            # Not a path:lineno:text hit -- pass it through rather than eat it.
+            print(hit)
+            continue
+        path, lineno = parts[0], int(parts[1])
+        if path not in cache:
+            cache[path] = noncode_lines(Path(path))
+        if lineno not in cache[path]:
+            print(hit)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/test-verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/test-verify-no-hardcoded-lodging.sh
@@ -38,9 +38,12 @@ if [[ -e "$JS_PROBE" || -e "$PY_PROBE" ]]; then
   exit 1
 fi
 
-echo "=== TEST 1: needles in application source should exit 1 and name file:line ==="
-echo '// leak: Tuolumne' > "$JS_PROBE"
-echo '# leak: Manzanita' > "$PY_PROBE"
+echo "=== TEST 1: needles in application CODE should exit 1 and name file:line ==="
+# Probes are code, not comments: spec 3.8 forbids the registry living in
+# source, and a registry lives in string literals. Comments are covered by
+# TEST 4, which requires the opposite result.
+echo 'const UNITS = ["Tuolumne 1"]' > "$JS_PROBE"
+echo 'UNITS = ["Manzanita 3"]' > "$PY_PROBE"
 
 set +e
 OUT=$("$GUARD_SCRIPT" 2>&1)
@@ -88,7 +91,7 @@ echo "=== TEST 3: probe filenames matching the guard's own test-file exclusion m
 TESTNAME_PROBE="$REPO_ROOT/pocketbase/pb_hooks/leak_probe_kindred1869_test.js"
 cleanup2() { rm -f "$TESTNAME_PROBE"; }
 trap 'cleanup2; cleanup' EXIT INT TERM
-echo '// leak: Tuolumne' > "$TESTNAME_PROBE"
+echo 'const UNITS = ["Tuolumne 1"]' > "$TESTNAME_PROBE"
 set +e
 OUT=$("$GUARD_SCRIPT" 2>&1)
 rc=$?
@@ -98,6 +101,44 @@ if [[ $rc -eq 0 ]]; then
   echo "PASS: confirmed a _test.js-named probe is excluded (exit 0) -- do not name real probes this way"
 else
   echo "FAIL: expected the _test.js-named probe to be silently excluded (exit 0), got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 4: needles in comments and docstrings should NOT fail the guard ==="
+# kindred#1891: the guard failed on api/services/lodging_rules.py, whose
+# docstring names two units to explain why merging changes bathroom privacy.
+# That is prose about a rule, not the registry living in code -- and because
+# HANDOFF tells the next agent to run this gate, it opened Phase C on a red
+# that was not theirs.
+cat > "$PY_PROBE" <<'PROBE'
+"""Module docstring naming Tuolumne 1 and Tuolumne 2 to explain a rule."""
+
+
+def rule() -> str:
+    """Wawona is a container row, which is why it is excluded.
+
+    Tioga 1 and Tioga 2 are each shared until merged.
+    """
+    # Manzanita is mentioned here in a comment, deliberately.
+    return "ok"
+PROBE
+cat > "$JS_PROBE" <<'PROBE'
+// Le Shack is staff-default; this comment explains why.
+/* Half Dome and El Cap are container rows.
+   Bayit too. */
+module.exports = { ok: true }
+PROBE
+set +e
+OUT=$("$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+rm -f "$JS_PROBE" "$PY_PROBE"
+if [[ $rc -eq 0 ]]; then
+  echo "PASS: prose in comments and docstrings does not trip the guard"
+else
+  echo "FAIL: expected exit 0 for comment/docstring-only mentions, got $rc" >&2
   echo "$OUT" >&2
   exit 1
 fi

--- a/scripts/dev/verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/verify-no-hardcoded-lodging.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 # Preflight BEFORE the first git call — checking for git after invoking it is
 # pointless, since the missing binary would already have exited 127.
-for cmd in git grep; do
+for cmd in git grep python3; do
   command -v "$cmd" >/dev/null 2>&1 || { echo "error: required command '$cmd' not found" >&2; exit 2; }
 done
 
@@ -39,6 +39,15 @@ HITS=$(grep -rInE "$NEEDLES" \
   pocketbase/ api/ bunking/ frontend/src/ 2>/dev/null \
   | grep -v '_test\.\|\.test\.\|/tests\?/' \
   | grep -v 'frontend/src/data/cityGeo\.ts\|frontend/src/data/schoolGeo\.ts' || true)
+
+# Prose that names a unit to explain a rule is documentation, not the registry
+# living in code. Dropping comment and docstring hits is what makes this guard
+# green on a clean `main`: it failed on a docstring in lodging_rules.py, which
+# opened Phase C on a red that was not Phase C's (kindred#1891). A file that
+# cannot be parsed is treated as all code, so its hits survive.
+if [[ -n "$HITS" ]]; then
+  HITS=$(printf '%s\n' "$HITS" | python3 "$REPO_ROOT/scripts/dev/lib/drop_comment_hits.py")
+fi
 # cityGeo.ts / schoolGeo.ts are unrelated city/school geocoding lookup tables
 # (a different feature) that coincidentally contain place-name substrings
 # ("Manzanita, OR", "El Capitan, AZ", "Wawona, CA", "Tuolumne City, CA") — not


### PR DESCRIPTION
Closes #1891.

## The guard was red on `main`

`./scripts/dev/verify-no-hardcoded-lodging.sh` exited 1 on a clean tree. The hit was a **docstring** at `api/services/lodging_rules.py:83`, naming two units to explain why merging changes bathroom privacy — prose about a rule, not the registry living in code.

It matters beyond tidiness: `HANDOFF.md` §7 points the next agent straight at that gate, so Phase C would have opened on a failure that wasn't Phase C's.

## The fix

`scripts/dev/lib/drop_comment_hits.py` filters grep hits down to code lines.

- **Python** uses the real tokenizer, so comments and docstrings are exact. A docstring is a bare string expression in first position; any *other* string literal is data and stays in scope, so a genuine hardcoded list still fails.
- **C-style** files use a character scan tracking string and block-comment state — enough not to mistake `"https://example/Tuolumne"` for a comment, and a line only counts as non-code if everything outside the comment is whitespace, so `const x = "Tuolumne" // note` still reports.
- **A file that won't parse is treated as all code**, so its hits survive. A guard that goes quiet on malformed input is worse than one that reports a line you have to read.

## The harness probes were the wrong shape

`TEST 1` and `TEST 3` planted `// leak: Tuolumne` and `# leak: Manzanita` — *comments*, which is now exactly what the guard must ignore. A probe that doesn't resemble a real leak proves nothing, so they became real code (`const UNITS = ["Tuolumne 1"]`). New `TEST 4` pins the #1891 case: a module docstring, a function docstring, a `#` comment and a `/* */` block all naming units must **not** trip the guard.

Verified failing first — `TEST 2` (clean tree) reproduced #1891 inside the harness before the fix landed.

## Fixture names

`'Olivia Johnson'`, `'Noah Chen'`, `'Emma Chen'` and `'Liam Chen'` were fictional but outside `tests/CLAUDE.md`'s documented five, and #1884 changed identical strings. Normalised onto the approved set; the household adult becomes `Samuel Johnson` so it doesn't collide with the `Emma Johnson` child in `getByText`.

Worth stating plainly: this is **consistency housekeeping, not a privacy fix**. The names were never real, and the wider repo already carries a much larger fictional population in shared mocks — so the "one greppable set" argument for it is weaker than it first looks. Scoped to the two weekend test files; `src/test/mockData.ts` deliberately untouched.

## HANDOFF rewritten for Phase C

Status moved to `37cf8d24`; Phase B's shipped surfaces recorded as fact; §4 reordered so **Task 13's Go integrity guards land before the editor that can violate them**. It also writes down the six contract changes review introduced in `03754754` — `householdCmId: number | null`, the shortened `unverified` reason, `${area_code}::${area_name}` bucketing, `WeekendSessionPicker` deleted, no `emptyMessage` on either QueryGuard, and the removed `/admin/lodging` link that needs adding back when Phase C registers the route.

Flagged for whoever picks it up: **confirming a cabin's amenities switches on live behaviour.** `partyAttention` only judges a housing need against a confirmed cabin, and all 82 are unconfirmed today, so the roster reports "Fit not verified" for every constrained party. The `unmet` path has unit tests but has never run against real data.

## Verification

- `./scripts/dev/test-verify-no-hardcoded-lodging.sh` — 4/4, exit 0
- `./scripts/dev/verify-no-hardcoded-lodging.sh` — **green on a clean tree**
- 4991 frontend tests, ruff clean, shellcheck clean, `scripts/dev/test-pb-harness.sh` green
- The filter is parsed by the system `python3` the guard actually invokes, not just uv's 3.14 — ruff formats for the repo's 3.14 target and rewrites a parenthesized `except` tuple into the bare-comma form that older interpreters reject, so the broad `except` there is deliberate and commented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project handoff guidance to reflect completed weekend surfaces, upcoming work, and current implementation constraints.

* **Chores**
  * Improved lodging-name validation to distinguish real code from comments and documentation while preserving detection in unparseable files.
  * Added clearer prerequisite checks and diagnostic output for validation failures.

* **Tests**
  * Expanded validation coverage for code, string literals, comments, and docstrings.
  * Refreshed roster test data for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->