### PR TITLE
feat(rbac): weekend lodging follows the bunking board's access model

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -90,12 +90,18 @@ Facts, not a work log. Do not re-verify or re-implement these.
   aliases, and the unresolved-name work queue. Areas are a slide-in drawer over units, not a
   section. Writes go straight to PocketBase through `lodgingCrud.ts`; the Go hooks in
   `pocketbase/lodging` are the integrity boundary. It shipped at `/admin/lodging`; see the access
-  model below for why it moved and what still redirects.
+  model below for why it moved.
 - **The access model is the summer board's, not admin-only.** Reads on every `lodging_*`
-  collection and every `/api/lodging/*` endpoint are open to any authenticated user; writes are
+  collection, and on every `/api/lodging/*` endpoint EXCEPT
+  `GET /households/{cm_id}/medical`, are open to any authenticated user; writes are
   `admin || bunking.manage` (`1500000130`). Consequences worth holding:
-  - `lodging_field_mappings` is the ONE exception — still admin-only, because it is ingest
-    plumbing that decides what every lodging read *means*, not a cabin decision.
+  - **Three collections are NOT widened.** `lodging_field_mappings`, because it is ingest
+    plumbing that decides what every lodging read *means*, not a cabin decision. And
+    `lodging_assignments` + `lodging_assignment_history`, because they are the synced record of
+    truth and its append-only audit — summer draws the identical line, keeping `bunk_assignments`
+    and `attendee_status_history` admin-only while staff write the DRAFT
+    (`bunk_assignments_draft`). Lodging has no draft table yet. **Widen them in the PR that adds
+    the board that writes them**, not before.
   - **`lodging.phi` is now held by the Bunking Staff role** (closing #1887), so the roster's
     medical reveal works for the staff doing placement. It stayed a separate permission from
     `bunking.manage` deliberately: it can be revoked, or granted to someone who places nobody,
@@ -256,8 +262,9 @@ inline per row and in bulk. Until staff use it, the fit check stays dark.
   them.
 - **`lodging_availability`** — the per-session reserved/released overrides (spec §3.7). The
   schema exists; no surface reads or writes it.
-- **`lodging.phi` is granted to no role (#1887).** Admin bypass is still the only route to the
-  narrative. The 403 degradation path in `AccessibilityFlagList` has never been exercised.
+- **`lodging.phi` is held by admins and the Bunking Staff role** (`1500000130`, closing #1887).
+  Everyone else who can read the roster gets a 403 from the medical endpoint, so the degradation
+  path in `AccessibilityFlagList` is now a live path rather than a theoretical one.
 - **Health Center room 5** — `hc-upstairs-hall` groups rooms 1, 2, 3, 4 and 6 but not 5. If 5
   shares that hall's bathroom the group is incomplete, and a merge covering the hall would
   never upgrade to `private` — the same bug that was fixed for Tioga/Tenaya 3+4 in
@@ -280,7 +287,7 @@ boolean and SQLite evaluates `0 != ''` as TRUE, so that column reports the full 
 completely empty database. If `gate`/`req` are `0`:
 
 ```bash
-./scripts/start_dev.sh   # boots PocketBase, which applies 1500000127
+./scripts/start_dev.sh   # boots PocketBase, which applies 1500000130
 # then, with a users-collection admin token (see §9 — a _superusers token is REJECTED):
 curl -X POST "http://localhost:8090/api/custom/sync/run?year=2026&service=family_camp_derived"
 ```
@@ -318,7 +325,7 @@ the whole time. That is progress, not a hang — confirm with CPU, not the count
 - **Do not sum capacity over units where `is_container` is true.** They are building rows carrying
   whole-building aggregates; including them gives 408 beds against a true 389.
 - **Do not create `lodging_unresolved_aliases`.** See §3. The plan tells you to; the ruling overrides it.
-- **Do not number a migration from a branch.** Highest on `main` is `1500000127`. Compute it:
+- **Do not number a migration from a branch.** Highest on `main` is `1500000130`. Compute it:
   `git ls-tree -r origin/main pocketbase/pb_migrations/ | grep -oE '15000[0-9]{5}' | sort -u | tail -1`
 - **Do not add a `kind` value as a Go constant without the migration.** The select list is the
   constraint; a bare constant passes tests and fails in production.
@@ -428,9 +435,16 @@ git fetch -q && git rev-list --count origin/<branch>..HEAD   # must be 0
   longer existed. Do not read a CodeRabbit pass as covering a branch that moved under it — check
   which commit it reviewed.
 
-- **#1895 is fixed** — `AdminLayout` returns `PermissionDeniedPage` when the user has no visible
-  tab, which is the route-group fix the issue asked for. Lodging left `/admin` entirely in the
-  same change. Kept here only so a reader of the issue knows where it went.
+- **#1895 is fixed** — `AdminLayout` returns `PermissionDeniedPage` for a non-admin, which is the
+  route-group fix the issue asked for. Lodging left `/admin` entirely in the same change.
+  `AdminTabConfig.requiredPermission` is now the literal `'admin'`, not `string`: the guard is an
+  is-admin test, so a tab carrying an ordinary permission codename would slip past it. #387 put a
+  `metrics.geo` tab under `/admin` and #450 had to move it out — the narrowed type makes a repeat
+  a compile error. **Merging `/admin` into `/manage` must revisit that guard.**
+- **#1899 — `lodging_units.parent_unit` has no server-side cycle guard.** `unitTree.ts` filters
+  the picker; `pocketbase/lodging/hooks.go` has no `OnRecordUpdate` on units, so a direct write
+  can build a cycle that the descendant walk and the merge-legality rule both traverse.
+  Pre-existing, but `1500000130` widened who can reach it.
 - **#1894** — `dark:*-forest-950` classes generate nothing: the forest scale stops at 900, so 14
   occurrences across 8 files are dead dark-mode states. `SessionTabs` is one of them, which is
   how it propagates — other surfaces are told to copy its pill grammar.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,9 +1,10 @@
 # HANDOFF — Family Camp Lodging
 
-**State as of `37cf8d24` on `main`.** The data layer, the ingest, the read API and the weekend
-surfaces are all merged. `/weekend/sessions` lists the year's weekends; `/weekend/session/:id`
-shows one weekend's roster and inventory. **The next body of work is Plan 3 Phase C — the
-`/admin/lodging` editor, the Go integrity guards and the work-queue UI.**
+**State as of `1bcd90f1` on `main`.** All three plans are merged. The data layer, the ingest,
+the read API, the weekend surfaces and the writable admin surface are done.
+`/weekend/sessions` lists the year's weekends; `/weekend/session/:id` shows one weekend's
+roster and inventory; `/admin/lodging/:section` edits the registry. **The next body of work
+is the board and the map (spec §7.2) — see §4.**
 
 This is a working document. Edit it in place: tick what ships, rewrite "Next", delete what stops
 being true. It is not a changelog — `git log` is the changelog.
@@ -12,13 +13,13 @@ being true. It is not a changelog — `git log` is the changelog.
 
 ## 1. Programme status
 
-Three plans. The first two are done.
+Three plans, all merged. What remains is the board and the map — see §4.
 
 | Plan | Scope | Status |
 |---|---|---|
 | **1 — Data layer** | `lodging_*` collections, seed, alias registry | ✅ merged (`49d38ff8`, #1867) |
 | **2 — Ingest** | CampMinder cabin fields → assignments, requests, PHI split | ✅ merged — see below |
-| **3 — Surfaces** | Read API, `/weekend` roster, `/admin/lodging` editor | 🔶 A (`f99a8ef7`, #1884) and B (`37cf8d24`, #1890) merged; **C open** |
+| **3 — Surfaces** | Read API, `/weekend` roster, `/admin/lodging` editor | ✅ A (`f99a8ef7`, #1884), B (`37cf8d24`, #1890), C + units redesign (`1bcd90f1`, #1893) |
 
 Plan 2 shipped in four PRs:
 
@@ -85,7 +86,29 @@ Facts, not a work log. Do not re-verify or re-implement these.
   Phase C reuses these rather than re-deriving.
 - **`verify-no-hardcoded-lodging.sh` ignores comments and docstrings** (`scripts/dev/lib/
   drop_comment_hits.py`). It used to fail on prose, which is why it was red on `main` (#1891).
-- **Highest migration is `1500000127`.** Compute the next number from `main`, never from a branch.
+- **`/admin/lodging/:section` is live** (`1bcd90f1`, #1893) — three sections: units, cabin-name
+  aliases, and the unresolved-name work queue. Areas are a slide-in drawer over units, not a
+  section. Writes go straight to PocketBase through `lodgingCrud.ts`; the Go hooks in
+  `pocketbase/lodging` are the integrity boundary.
+- **Units is sortable, area-grouped, and confirmable in one click or in bulk.** That last part
+  is the point: nothing on the roster judges a housing need against an unconfirmed cabin, and
+  all 93 ship unconfirmed.
+- **Beds are inventory behind `sleeps`, not a replacement for it.** `frontend/src/types/beds.ts`
+  turns "2 twins and a queen" into a *suggested* occupancy staff adopt with one click. `sleeps`
+  remains the single number every consumer reads, so no Pydantic model changed.
+- **Three behaviours that are NOT what their names suggest** — these bit once already:
+  - **`deleteLodgingAlias` is not a plain delete.** It reopens every
+    `lodging_ingest_issues` row whose `resolved_alias` points at the alias (clearing
+    `is_resolved` and `resolved_alias`) *before* deleting. That order is load-bearing; reversed,
+    it leaves exactly the silent state described below.
+  - **`lodging_unit_aliases` has an `OnRecordDelete` guard** (`guardAliasDelete`). Deleting an
+    alias with resolved queue items behind it returns 400 from **every** path, including the
+    PocketBase admin UI.
+  - **`LodgingUnitForm` writes `sleeps: 0` on EDIT when the field is blank**, and omits the key
+    on CREATE. Omitting on edit made clearing a capacity a silent no-op — the old number stayed.
+- **New modules worth knowing**: `unitTree.ts` (parent candidates, descendant walk),
+  `aliasMembers.ts`, `unitCode.ts`, `unitAmenities.ts`, `lodgingStyles.ts`.
+- **Highest migration is `1500000129`.** Compute the next number from `main`, never from a branch.
 
 ---
 
@@ -161,56 +184,64 @@ Each of these was decided deliberately. Reopening one needs a reason, not a fres
 
 ---
 
-## 4. Next: Plan 3 Phase C — the Family Camp admin surface
+## 4. Next: the board and the map (spec §7.2)
 
-Plan: `docs/superpowers/plans/2026-07-30-family-camp-lodging-surfaces.md` (local-only, gitignored),
-Tasks 13–17. **Its Phase B header carries a SHIPPED block listing nine divergences** — read that
-first, because Phase C inherits the corrected shape, not the shape Tasks 7–12 describe.
+All three plans are merged. What the programme was building toward — placing parties — does
+not exist yet. Assignments are still read-only; the registry is now editable.
 
-| Phase | Tasks | Ships | Status |
-|---|---|---|---|
-| **A — Read API** | 1–6 | `/api/lodging/*`, `lodging.phi`, generated TS types | ✅ `f99a8ef7` (#1884) |
-| **B — Lander + roster** | 7–12 | `/weekend/sessions`, `/weekend/session/:id`, `/summary` | ✅ `37cf8d24` (#1890) |
-| **C — Admin CRUD** | 13–17 | `/admin/lodging` editor, Go integrity guards, work queue UI | ⬜ **next** |
+**The two surfaces the spec wants, as complements not alternatives:**
 
-### Task order, and why
+- **(a) The bunking board** — the primary surface, laid out like the summer board (unit
+  columns grouped by area, party cards as atoms, @dnd-kit drag). New `FamilyCard` and
+  `LodgingUnitCard` components, NOT conditionals inside the 849-line camper-coupled
+  `BunkingBoardByArea.tsx`: the atom here is a household party of mixed ages, not a camper.
+- **(b) The map view** — a secondary tab rendering the camp map from `map_x`/`map_y`, for
+  judging *near* requests and seeing whether a family sits beside a bathhouse or a staff
+  cabin. The coordinates have been in the schema since slice 1 for this, and `/admin/lodging`
+  now lets staff correct both unit positions and area centroids.
 
-1. **Task 13 — `pocketbase/lodging/hooks.go` integrity guards, first.** They are the invariants the
-   database does not enforce: `guardAssignmentGrain` (exactly one of unit/merge, exactly one of
-   household/person), `guardUnitDelete` (deactivate, never delete, when assignments exist),
-   `guardMergeDelete` (blocked at ≥1 occupant — stricter than spec §3.4, to close the
-   single-occupant orphan hole). Land these *before* the UI that can violate them.
-2. **Tasks 14–16 — the editor.** Writes go **straight to PocketBase, not through FastAPI**: all
-   four collections carry `createRule`/`updateRule`/`deleteRule` = `@request.auth.is_admin = true`,
-   so PocketBase is the authorisation boundary and Task 13 is the integrity boundary. Same pattern
-   as `frontend/src/components/admin/RegistrationDatesConfig.tsx`.
-3. **Task 17 — the work-queue UI** over `lodging_ingest_issues` filtered to
-   `kind = "unresolved_alias" && is_resolved = false`.
+Both operate on the same `lodging_assignments` + `lodging_merges` + `lodging_availability`
+state, so a change in one shows in the other. The map is a projection of the board, not a
+separate system of record.
 
-### What Phase C inherits that the plan does not describe
+### The merge-legality rule belongs with the board, and the data is ready for it
 
-- **Write the PocketBase record and input types now.** The plan puts them in Task 7; Phase B
-  deferred them because nothing there consumed them. `LodgingUnitInput` must keep `is_active` and
-  `allocation_default` **non-optional** — PocketBase has no per-field default for bool or select, so
-  a create that omits them yields an invisible unit that matches neither availability branch.
-- **Do NOT write a `LodgingUnresolvedAliasRecord`.** The work queue is `lodging_ingest_issues`; the
-  query key is already `queryKeys.lodgingIngestIssues()`.
-- **Confirming amenities switches on live behaviour.** `partyAttention` only judges a housing need
-  against a cabin whose `is_confirmed` is true; all 82 are false today, so the roster reports
-  *"Fit not verified"* for every constrained party. The moment Phase C lets staff confirm a cabin,
-  the `unmet` section starts populating — **that path has unit tests but has never run against real
-  data.** Expect it to be the first thing that looks wrong, and check it deliberately.
-- **`/weekend/session/:id` has no "Lodging settings" link.** It was removed in `03754754` because
-  `/admin/lodging` is not a registered route and `App.tsx`'s `path="*"` silently bounced the user
-  home. **Add the link back when Phase C registers the route** —
-  `frontend/src/pages/WeekendRosterPage.tsx`.
-- **Any new per-weekend figure belongs on `/api/lodging/summary`**, never on an N-call loop over
-  `/roster`. See §6.
-- **`lodging.phi` is granted to no role (#1887).** Admin bypass is the only route to the narrative
-  today. Phase C's admin surface is the natural place to fix it, and doing so is the first real test
-  of the 403 degradation path in `AccessibilityFlagList`.
+Deliberately deferred from #1893: nothing could create a merge, so the rule would have had no
+caller and no way to prove it right. What landed instead is the data it will read.
 
----
+**The rule: a merge is legal iff its members are the complete child set of some container.**
+Four intermediate containers were seeded (`1500000129`) — Tioga and Tenaya, upstairs and
+downstairs — because two real historical merges (`Tenaya 1and2`, `Tioga 1and2`) bind 2 rooms
+of a 4-room building and were previously inexpressible. Verified: all six historical merges
+are now the complete child set of exactly one container, and `{2,3}` correctly is not.
+
+`parent_unit` is editable in the admin UI, filtered to containers minus self minus descendants
+(`unitTree.ts`), and `is_container` is disabled while a unit has children. **There is still no
+server-side guard** — no `OnRecordUpdate` hook on `lodging_units` — so the frontend filter is
+the only thing preventing a cycle. Writing the rule is the natural moment to add the Go guard.
+
+### Before either surface: confirm some cabins
+
+`partyAttention` only judges a housing need against a cabin whose `is_confirmed` is true, and
+**0 of 93 units are confirmed**, so the roster reports *"Fit not verified"* for every
+constrained party. This was verified working end to end on real data (#1893): confirming one
+cabin dropped `units_unconfirmed` 82→81 and turned a real party from unverified into a genuine
+unmet (needs power, confirmed cabin has none). `/admin/lodging/units` now offers confirmation
+inline per row and in bulk. Until staff use it, the fit check stays dark.
+
+### Open decisions the board will force
+
+- **`lodging_merges` CRUD** — merges are a board action (spec §3.4), created mid-assignment
+  rather than configured up front. Nothing writes them yet. `guardMergeDelete` already protects
+  them.
+- **`lodging_availability`** — the per-session reserved/released overrides (spec §3.7). The
+  schema exists; no surface reads or writes it.
+- **`lodging.phi` is granted to no role (#1887).** Admin bypass is still the only route to the
+  narrative. The 403 degradation path in `AccessibilityFlagList` has never been exercised.
+- **Health Center room 5** — `hc-upstairs-hall` groups rooms 1, 2, 3, 4 and 6 but not 5. If 5
+  shares that hall's bathroom the group is incomplete, and a merge covering the hall would
+  never upgrade to `private` — the same bug that was fixed for Tioga/Tenaya 3+4 in
+  `1500000129`. **Unanswered; needs staff.**
 
 ## 5. CRITICAL: first action before anything else
 
@@ -284,8 +315,31 @@ the whole time. That is progress, not a hang — confirm with CPU, not the count
 - **Do not judge a housing need against an unconfirmed cabin.** `has_power: false` on an unconfirmed
   row means "nobody has said". Phase C makes confirmation possible — that is the moment this starts
   mattering, not a reason to relax it.
-- **Do not delete a `lodging_units` row that has assignments.** Deactivate. Task 13's
+- **Do not delete a `lodging_units` row that has assignments.** Deactivate.
   `guardUnitDelete` enforces it and no `deleteLodgingUnit` should exist.
+- **Do not "simplify" `deleteLodgingAlias` back into a plain `delete`.** It reopens the queue
+  rows the alias resolved, first. Skipping that silences the work queue **permanently** and
+  nothing surfaces it: `IssueRecorder.Flush` (`sync/lodging_issues.go`) writes `is_resolved`
+  only on CREATE — deliberately, so a later sync cannot un-tick what staff ticked — and its
+  dedup matches a re-encountered cabin string to that same row. So the next sync bumps
+  `occurrences` and leaves the row resolved. The string never returns to the queue and its
+  placement never resolves again. `resolved_alias` is `cascadeDelete: false` on purpose
+  (`1500000122`), which preserves the audit trail and loses the work item. Found post-merge on
+  #1893; `guardAliasDelete` is the backstop.
+- **Do not make a bulk mutation act on rows the user cannot see.** Collapsing an area group
+  deselects its units for this reason.
+- **Do not render an edit form without a `key` tied to the record being edited.** Both lodging
+  panels do (`key={editing === 'new' ? 'new' : editing.id}`). Without it React reuses the
+  component instance, `useState` initialisers never re-run, and submit writes the previous
+  record's field values against the new record's id — silently, for aliases.
+- **Do not lowercase an area `code`.** Every seeded area is uppercase (`RIDGE`, `GT`, `HC`,
+  `YURT`) and `code` is a join key. A reviewer suggested lowercasing it; that would break the
+  join. Pinned by a characterisation test.
+- **Do not "fix" `aria-sort={undefined}` to `"none"`** on inactive sortable columns. `undefined`
+  is correct and is the shape to standardise on (#1897). Also pinned by test.
+- **Do not use `?? []` to paper over a failed secondary query.** Each fallback hides an error
+  as an empty list. The alias editor's member checkboxes ARE the payload, so opening it against
+  a failed unit query and saving would strip every member.
 
 ---
 
@@ -316,6 +370,10 @@ cd pocketbase && ./node_modules/.bin/eslint pb_migrations pb_hooks
 ./scripts/dev/verify-no-hardcoded-lodging.sh
 ./scripts/dev/test-pb-harness.sh && ./scripts/dev/test-verify-no-hardcoded-lodging.sh
 ./scripts/dev/verify-lodging-backfill.sh pocketbase/pb_data/data.db 2024 2025
+
+# Lodging admin surface (all under frontend/src/components/admin/lodging/)
+cd frontend && npx vitest run src/components/admin/lodging/ src/types/beds.test.ts
+cd pocketbase && go test ./lodging/... -count=1   # incl. guardAliasDelete
 
 # Verify a push actually landed (a wrapper's "ok" is a claim, not evidence)
 git fetch -q && git rev-list --count origin/<branch>..HEAD   # must be 0
@@ -348,6 +406,20 @@ git fetch -q && git rev-list --count origin/<branch>..HEAD   # must be 0
   longer existed. Do not read a CodeRabbit pass as covering a branch that moved under it — check
   which commit it reviewed.
 
+- **#1895 — reads on `/admin/*` are not guarded.** `/admin/sync`, `/admin/config/:category` and
+  `/admin/lodging/:section` all render for any authenticated user. `AdminLayout` filters the tab
+  *list* only; there is no route guard. Writes are safe (PocketBase `is_admin` rules), reads are
+  not. Pre-existing and repo-wide — the fix belongs at the `AdminLayout` route group, not
+  per-route. **The most consequential of the four filed below.**
+- **#1894** — `dark:*-forest-950` classes generate nothing: the forest scale stops at 900, so 14
+  occurrences across 8 files are dead dark-mode states. `SessionTabs` is one of them, which is
+  how it propagates — other surfaces are told to copy its pill grammar.
+- **#1896** — data fetching is not extracted into custom hooks, against `frontend/CLAUDE.md:23`,
+  across 12 files. `queryKeys.lodgingAreas()` is declared twice in the lodging admin alone, each
+  with its own fallback, which is what made the `?? []` gap above possible.
+- **#1897** — two competing sortable-header a11y shapes: `PipelineBatchList` and
+  `UnitsTableHeader` use a focusable `<th>`; `SolverDebugImpossibilityModal` uses a `<button>`
+  inside it. Standardise on the button, keep `aria-sort={undefined}`.
 - **#1887** — `lodging.phi` is granted to **no role**, and `1500000070_rbac_roles.js` was untouched
   by #1884. `require_permission` admin-bypasses, so admins reach the medical endpoint and every
   non-admin gets a 403 that no role edit resolves. Defensible as default-deny for PHI, but it will

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,9 +1,9 @@
 # HANDOFF — Family Camp Lodging
 
 **State as of `1bcd90f1` on `main`.** All three plans are merged. The data layer, the ingest,
-the read API, the weekend surfaces and the writable admin surface are done.
+the read API, the weekend surfaces and the writable editor are done.
 `/weekend/sessions` lists the year's weekends; `/weekend/session/:id` shows one weekend's
-roster and inventory; `/admin/lodging/:section` edits the registry. **The next body of work
+roster and inventory; `/manage/lodging/:section` edits the registry. **The next body of work
 is the board and the map (spec §7.2) — see §4.**
 
 This is a working document. Edit it in place: tick what ships, rewrite "Next", delete what stops
@@ -19,7 +19,7 @@ Three plans, all merged. What remains is the board and the map — see §4.
 |---|---|---|
 | **1 — Data layer** | `lodging_*` collections, seed, alias registry | ✅ merged (`49d38ff8`, #1867) |
 | **2 — Ingest** | CampMinder cabin fields → assignments, requests, PHI split | ✅ merged — see below |
-| **3 — Surfaces** | Read API, `/weekend` roster, `/admin/lodging` editor | ✅ A (`f99a8ef7`, #1884), B (`37cf8d24`, #1890), C + units redesign (`1bcd90f1`, #1893) |
+| **3 — Surfaces** | Read API, `/weekend` roster, `/manage/lodging` editor | ✅ A (`f99a8ef7`, #1884), B (`37cf8d24`, #1890), C + units redesign (`1bcd90f1`, #1893) |
 
 Plan 2 shipped in four PRs:
 
@@ -86,10 +86,24 @@ Facts, not a work log. Do not re-verify or re-implement these.
   Phase C reuses these rather than re-deriving.
 - **`verify-no-hardcoded-lodging.sh` ignores comments and docstrings** (`scripts/dev/lib/
   drop_comment_hits.py`). It used to fail on prose, which is why it was red on `main` (#1891).
-- **`/admin/lodging/:section` is live** (`1bcd90f1`, #1893) — three sections: units, cabin-name
+- **`/manage/lodging/:section` is live** (`1bcd90f1`, #1893) — three sections: units, cabin-name
   aliases, and the unresolved-name work queue. Areas are a slide-in drawer over units, not a
   section. Writes go straight to PocketBase through `lodgingCrud.ts`; the Go hooks in
-  `pocketbase/lodging` are the integrity boundary.
+  `pocketbase/lodging` are the integrity boundary. It shipped at `/admin/lodging`; see the access
+  model below for why it moved and what still redirects.
+- **The access model is the summer board's, not admin-only.** Reads on every `lodging_*`
+  collection and every `/api/lodging/*` endpoint are open to any authenticated user; writes are
+  `admin || bunking.manage` (`1500000130`). Consequences worth holding:
+  - `lodging_field_mappings` is the ONE exception — still admin-only, because it is ingest
+    plumbing that decides what every lodging read *means*, not a cabin decision.
+  - **`lodging.phi` is now held by the Bunking Staff role** (closing #1887), so the roster's
+    medical reveal works for the staff doing placement. It stayed a separate permission from
+    `bunking.manage` deliberately: it can be revoked, or granted to someone who places nobody,
+    without touching write access.
+  - **No `/admin/lodging` redirect exists**, deliberately: the surface was never in anyone's
+    hands, so there are no bookmarks to preserve. `App.tsx`'s `path="*"` sends the old paths home.
+  - `AdminLayout` now returns `PermissionDeniedPage` when a user has no visible tab, so the
+    remaining admin routes are guarded rather than merely tab-filtered (#1895).
 - **Units is sortable, area-grouped, and confirmable in one click or in bulk.** That last part
   is the point: nothing on the roster judges a housing need against an unconfirmed cabin, and
   all 93 ship unconfirmed.
@@ -108,7 +122,13 @@ Facts, not a work log. Do not re-verify or re-implement these.
     on CREATE. Omitting on edit made clearing a capacity a silent no-op — the old number stayed.
 - **New modules worth knowing**: `unitTree.ts` (parent candidates, descendant walk),
   `aliasMembers.ts`, `unitCode.ts`, `unitAmenities.ts`, `lodgingStyles.ts`.
-- **Highest migration is `1500000129`.** Compute the next number from `main`, never from a branch.
+- **`record.get()` on a PocketBase json field returns the Go byte slice, and goja reports it as
+  an Array.** So `Array.isArray()` answers true, iterating yields BYTE VALUES, and writing them
+  back turns `["bunking.manage"]` into `[34,98,117,...]`. This shipped once and was caught only by
+  running the migration against a real database. Use `record.getString(field)` and `JSON.parse`.
+  The Go side has the same trap in a different shape — see `extractBusinessCategory` in
+  `pocketbase/rbac/hooks.go`, which handles `types.JSONRaw` separately from `map[string]any`.
+- **Highest migration is `1500000130`.** Compute the next number from `main`, never from a branch.
 
 ---
 
@@ -197,7 +217,7 @@ not exist yet. Assignments are still read-only; the registry is now editable.
   `BunkingBoardByArea.tsx`: the atom here is a household party of mixed ages, not a camper.
 - **(b) The map view** — a secondary tab rendering the camp map from `map_x`/`map_y`, for
   judging *near* requests and seeing whether a family sits beside a bathhouse or a staff
-  cabin. The coordinates have been in the schema since slice 1 for this, and `/admin/lodging`
+  cabin. The coordinates have been in the schema since slice 1 for this, and `/manage/lodging`
   now lets staff correct both unit positions and area centroids.
 
 Both operate on the same `lodging_assignments` + `lodging_merges` + `lodging_availability`
@@ -226,7 +246,7 @@ the only thing preventing a cycle. Writing the rule is the natural moment to add
 **0 of 93 units are confirmed**, so the roster reports *"Fit not verified"* for every
 constrained party. This was verified working end to end on real data (#1893): confirming one
 cabin dropped `units_unconfirmed` 82→81 and turned a real party from unverified into a genuine
-unmet (needs power, confirmed cabin has none). `/admin/lodging/units` now offers confirmation
+unmet (needs power, confirmed cabin has none). `/manage/lodging/units` now offers confirmation
 inline per row and in bulk. Until staff use it, the fit check stays dark.
 
 ### Open decisions the board will force
@@ -371,9 +391,11 @@ cd pocketbase && ./node_modules/.bin/eslint pb_migrations pb_hooks
 ./scripts/dev/test-pb-harness.sh && ./scripts/dev/test-verify-no-hardcoded-lodging.sh
 ./scripts/dev/verify-lodging-backfill.sh pocketbase/pb_data/data.db 2024 2025
 
-# Lodging admin surface (all under frontend/src/components/admin/lodging/)
+# Lodging editor. The route is /manage/lodging; the SOURCE still lives under
+# components/admin/lodging/ — deliberately not renamed, 32 files for no behaviour.
 cd frontend && npx vitest run src/components/admin/lodging/ src/types/beds.test.ts
 cd pocketbase && go test ./lodging/... -count=1   # incl. guardAliasDelete
+cd pocketbase && go test ./ -run TestLodgingRBAC -count=1   # migration 1500000130 semantics
 
 # Verify a push actually landed (a wrapper's "ok" is a claim, not evidence)
 git fetch -q && git rev-list --count origin/<branch>..HEAD   # must be 0
@@ -406,11 +428,9 @@ git fetch -q && git rev-list --count origin/<branch>..HEAD   # must be 0
   longer existed. Do not read a CodeRabbit pass as covering a branch that moved under it — check
   which commit it reviewed.
 
-- **#1895 — reads on `/admin/*` are not guarded.** `/admin/sync`, `/admin/config/:category` and
-  `/admin/lodging/:section` all render for any authenticated user. `AdminLayout` filters the tab
-  *list* only; there is no route guard. Writes are safe (PocketBase `is_admin` rules), reads are
-  not. Pre-existing and repo-wide — the fix belongs at the `AdminLayout` route group, not
-  per-route. **The most consequential of the four filed below.**
+- **#1895 is fixed** — `AdminLayout` returns `PermissionDeniedPage` when the user has no visible
+  tab, which is the route-group fix the issue asked for. Lodging left `/admin` entirely in the
+  same change. Kept here only so a reader of the issue knows where it went.
 - **#1894** — `dark:*-forest-950` classes generate nothing: the forest scale stops at 900, so 14
   occurrences across 8 files are dead dark-mode states. `SessionTabs` is one of them, which is
   how it propagates — other surfaces are told to copy its pill grammar.
@@ -420,12 +440,10 @@ git fetch -q && git rev-list --count origin/<branch>..HEAD   # must be 0
 - **#1897** — two competing sortable-header a11y shapes: `PipelineBatchList` and
   `UnitsTableHeader` use a focusable `<th>`; `SolverDebugImpossibilityModal` uses a `<button>`
   inside it. Standardise on the button, keep `aria-sort={undefined}`.
-- **#1887** — `lodging.phi` is granted to **no role**, and `1500000070_rbac_roles.js` was untouched
-  by #1884. `require_permission` admin-bypasses, so admins reach the medical endpoint and every
-  non-admin gets a 403 that no role edit resolves. Defensible as default-deny for PHI, but it will
-  surprise whoever first tries to give a health-centre lead access. Phase B's reveal already degrades
-  gracefully on a 403; **Phase C's admin surface is the natural place to actually grant it**, and
-  doing so is the first real exercise of that path.
+- **#1887 is fixed** — `lodging.phi` is granted to the Bunking Staff role by `1500000130`, which
+  also recomputes `users.cached_permissions` for its holders rather than trusting the Go `roles`
+  hook to fire during migration bootstrap. The reveal's 403 path is still live and still matters:
+  anyone authenticated can read the roster the button sits on.
 - **#1881** — two pre-existing package-wide patterns the ingest inherited rather than introduced:
   every individual-sync handler in `api.go` mutates the orchestrator's singleton service, and
   `SyncTab`'s card guard references no type-specific `isPending`. Both want **one sweep across all

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -140,14 +140,6 @@ function CamperRedirect() {
   return <Navigate to={`/camper/${camperId}`} replace />
 }
 
-// /admin/lodging/:section -> /manage/lodging/:section, preserving the section.
-// The editor moved out of Admin when its writes moved from admin-only to
-// bunking.manage; this keeps every link staff already have working.
-function LodgingRedirect() {
-  const { section } = useParams<{ section?: string }>()
-  return <Navigate to={`/manage/lodging/${section ?? 'units'}`} replace />
-}
-
 // Smart redirect to first permitted manage tab
 function ManageRedirect() {
   const { isLoading } = useAuth()
@@ -265,15 +257,6 @@ function App() {
                                 }
                               />
                             </Route>
-                            {/* The lodging editor moved to /manage/lodging so
-                                bunking staff can reach it without admin. These
-                                keep old links and bookmarks working — without
-                                them, path="*" bounces the user silently home. */}
-                            <Route
-                              path="lodging"
-                              element={<Navigate to="/manage/lodging/units" replace />}
-                            />
-                            <Route path="lodging/:section" element={<LodgingRedirect />} />
                           </Route>
 
                           {/* Manage routes - staff-facing management tools */}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -140,6 +140,14 @@ function CamperRedirect() {
   return <Navigate to={`/camper/${camperId}`} replace />
 }
 
+// /admin/lodging/:section -> /manage/lodging/:section, preserving the section.
+// The editor moved out of Admin when its writes moved from admin-only to
+// bunking.manage; this keeps every link staff already have working.
+function LodgingRedirect() {
+  const { section } = useParams<{ section?: string }>()
+  return <Navigate to={`/manage/lodging/${section ?? 'units'}`} replace />
+}
+
 // Smart redirect to first permitted manage tab
 function ManageRedirect() {
   const { isLoading } = useAuth()
@@ -256,21 +264,16 @@ function App() {
                                   </ErrorBoundary>
                                 }
                               />
-                              <Route
-                                path="lodging"
-                                element={<Navigate to="/admin/lodging/units" replace />}
-                              />
-                              <Route
-                                path="lodging/:section"
-                                element={
-                                  <ErrorBoundary>
-                                    <Suspense fallback={<PageSkeleton />}>
-                                      <LodgingSettingsTab />
-                                    </Suspense>
-                                  </ErrorBoundary>
-                                }
-                              />
                             </Route>
+                            {/* The lodging editor moved to /manage/lodging so
+                                bunking staff can reach it without admin. These
+                                keep old links and bookmarks working — without
+                                them, path="*" bounces the user silently home. */}
+                            <Route
+                              path="lodging"
+                              element={<Navigate to="/manage/lodging/units" replace />}
+                            />
+                            <Route path="lodging/:section" element={<LodgingRedirect />} />
                           </Route>
 
                           {/* Manage routes - staff-facing management tools */}
@@ -316,6 +319,22 @@ function App() {
                                     <ErrorBoundary>
                                       <Suspense fallback={<PageSkeleton />}>
                                         <SheetsTab />
+                                      </Suspense>
+                                    </ErrorBoundary>
+                                  </RequirePermission>
+                                }
+                              />
+                              <Route
+                                path="lodging"
+                                element={<Navigate to="/manage/lodging/units" replace />}
+                              />
+                              <Route
+                                path="lodging/:section"
+                                element={
+                                  <RequirePermission permission={Permission.BUNKING_MANAGE}>
+                                    <ErrorBoundary>
+                                      <Suspense fallback={<PageSkeleton />}>
+                                        <LodgingSettingsTab />
                                       </Suspense>
                                     </ErrorBoundary>
                                   </RequirePermission>

--- a/frontend/src/components/AdminLayout.test.tsx
+++ b/frontend/src/components/AdminLayout.test.tsx
@@ -105,4 +105,17 @@ describe('AdminLayout', () => {
       '/admin/config'
     )
   })
+
+  describe('non-admin access', () => {
+    // Filtering the tab list is not a guard: typing /admin/sync rendered the
+    // page for anyone logged in (#1895). Every remaining admin tab is
+    // admin-only, so the layout itself is the right place to stop.
+    it('refuses the page rather than rendering it tabless', () => {
+      renderWithRouter('/admin/sync', { isAdmin: false })
+
+      expect(screen.getByText('Access Restricted')).toBeInTheDocument()
+      expect(screen.queryByTestId('child')).not.toBeInTheDocument()
+      expect(screen.queryByText('Admin Control Center')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/src/components/AdminLayout.tsx
+++ b/frontend/src/components/AdminLayout.tsx
@@ -2,25 +2,24 @@ import { Link, Outlet, useLocation } from 'react-router'
 import { Settings, AlertCircle } from 'lucide-react'
 import { ErrorBoundary } from './ErrorBoundary'
 import { useIsAdmin } from '../hooks/useIsAdmin'
-import { usePermissions } from '../hooks/usePermissions'
 import { ADMIN_TABS, type AdminTabConfig } from '../config/adminTabs'
 import PermissionDeniedPage from '../pages/PermissionDeniedPage'
 
 function AdminLayoutInner() {
   const location = useLocation()
   const isAdmin = useIsAdmin()
-  const { hasPermission } = usePermissions()
-
-  const visibleTabs = ADMIN_TABS.filter(
-    (tab) =>
-      tab.requiredPermission === 'authenticated' || isAdmin || hasPermission(tab.requiredPermission)
-  )
 
   // Filtering the tab list never stopped anyone typing the URL (#1895). The
   // /manage routes each carry a RequirePermission; /admin has no equivalent,
-  // so the layout every admin route shares is where the guard belongs. A user
-  // with no visible tab has no business on the page at all.
-  if (visibleTabs.length === 0) {
+  // so the layout every admin route shares is where the guard belongs.
+  //
+  // Gating on isAdmin rather than "has at least one visible tab": those are the
+  // same test only because `AdminTabConfig.requiredPermission` is the literal
+  // 'admin'. Writing it as the tab count would read as a per-route check while
+  // actually being an any-route one — a user who could see tab A would reach
+  // tab B's URL. See the type's own comment for why that case is a compile
+  // error now rather than a comment nobody reads.
+  if (!isAdmin) {
     return <PermissionDeniedPage />
   }
 
@@ -47,7 +46,7 @@ function AdminLayoutInner() {
 
       {/* Tabs */}
       <div className="bg-muted/50 dark:bg-muted flex w-full gap-1.5 rounded-lg p-1.5 sm:w-fit">
-        {visibleTabs.map((tab) => {
+        {ADMIN_TABS.map((tab) => {
           const Icon = tab.icon
           return (
             <Link

--- a/frontend/src/components/AdminLayout.tsx
+++ b/frontend/src/components/AdminLayout.tsx
@@ -4,6 +4,7 @@ import { ErrorBoundary } from './ErrorBoundary'
 import { useIsAdmin } from '../hooks/useIsAdmin'
 import { usePermissions } from '../hooks/usePermissions'
 import { ADMIN_TABS, type AdminTabConfig } from '../config/adminTabs'
+import PermissionDeniedPage from '../pages/PermissionDeniedPage'
 
 function AdminLayoutInner() {
   const location = useLocation()
@@ -14,6 +15,14 @@ function AdminLayoutInner() {
     (tab) =>
       tab.requiredPermission === 'authenticated' || isAdmin || hasPermission(tab.requiredPermission)
   )
+
+  // Filtering the tab list never stopped anyone typing the URL (#1895). The
+  // /manage routes each carry a RequirePermission; /admin has no equivalent,
+  // so the layout every admin route shares is where the guard belongs. A user
+  // with no visible tab has no business on the page at all.
+  if (visibleTabs.length === 0) {
+    return <PermissionDeniedPage />
+  }
 
   const isTabActive = (tab: AdminTabConfig) => location.pathname.startsWith(tab.path)
 

--- a/frontend/src/components/admin/lodging/LodgingSettingsTab.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingSettingsTab.test.tsx
@@ -4,6 +4,8 @@ import { MemoryRouter, Route, Routes } from 'react-router'
 import { describe, expect, it, vi } from 'vitest'
 
 import { ADMIN_TABS } from '../../../config/adminTabs'
+import { MANAGE_TABS } from '../../../config/manageTabs'
+import { Permission } from '../../../constants/permissions'
 import { LodgingSettingsTab } from './LodgingSettingsTab'
 
 vi.mock('./LodgingUnitsPanel', () => ({ LodgingUnitsPanel: () => <div>UNITS PANEL</div> }))
@@ -14,56 +16,63 @@ function renderAt(path: string) {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
-        <Route path="/admin/lodging/:section" element={<LodgingSettingsTab />} />
-        <Route path="/admin/lodging" element={<LodgingSettingsTab />} />
+        <Route path="/manage/lodging/:section" element={<LodgingSettingsTab />} />
+        <Route path="/manage/lodging" element={<LodgingSettingsTab />} />
       </Routes>
     </MemoryRouter>
   )
 }
 
-describe('ADMIN_TABS', () => {
-  it('registers the Family Camp Lodging tab as admin-only', () => {
-    const tab = ADMIN_TABS.find((t) => t.id === 'lodging')
+describe('lodging tab registration', () => {
+  it('lives under Manage, gated on bunking.manage', () => {
+    // Confirming cabins is bunking staff's job, not an administrator's. The
+    // tab moved off /admin so the people who hold bunking.manage can reach it
+    // without being granted admin — which would hand them sync and config too.
+    const tab = MANAGE_TABS.find((t) => t.id === 'lodging')
     expect(tab).toBeDefined()
-    expect(tab?.path).toBe('/admin/lodging')
-    expect(tab?.requiredPermission).toBe('admin')
+    expect(tab?.path).toBe('/manage/lodging')
+    expect(tab?.requiredPermission).toBe(Permission.BUNKING_MANAGE)
+  })
+
+  it('no longer appears under Admin', () => {
+    expect(ADMIN_TABS.some((t) => t.path.startsWith('/admin/lodging'))).toBe(false)
   })
 })
 
 describe('LodgingSettingsTab', () => {
   it('defaults to the units section', () => {
-    renderAt('/admin/lodging')
+    renderAt('/manage/lodging')
     expect(screen.getByText('UNITS PANEL')).toBeInTheDocument()
   })
 
   it('renders the aliases section', () => {
-    renderAt('/admin/lodging/aliases')
+    renderAt('/manage/lodging/aliases')
     expect(screen.getByText('ALIASES PANEL')).toBeInTheDocument()
   })
 
   it('renders the unresolved work queue', () => {
-    renderAt('/admin/lodging/unresolved')
+    renderAt('/manage/lodging/unresolved')
     expect(screen.getByText('QUEUE PANEL')).toBeInTheDocument()
   })
 
   it('falls back to units for an unknown section rather than rendering nothing', () => {
-    renderAt('/admin/lodging/nonsense')
+    renderAt('/manage/lodging/nonsense')
     expect(screen.getByText('UNITS PANEL')).toBeInTheDocument()
   })
 
   it('links to all three sections', () => {
-    renderAt('/admin/lodging/units')
+    renderAt('/manage/lodging/units')
     expect(screen.getByRole('link', { name: 'Units' })).toHaveAttribute(
       'href',
-      '/admin/lodging/units'
+      '/manage/lodging/units'
     )
     expect(screen.getByRole('link', { name: 'Cabin name aliases' })).toHaveAttribute(
       'href',
-      '/admin/lodging/aliases'
+      '/manage/lodging/aliases'
     )
     expect(screen.getByRole('link', { name: 'Unresolved names' })).toHaveAttribute(
       'href',
-      '/admin/lodging/unresolved'
+      '/manage/lodging/unresolved'
     )
   })
 })

--- a/frontend/src/components/admin/lodging/LodgingSettingsTab.tsx
+++ b/frontend/src/components/admin/lodging/LodgingSettingsTab.tsx
@@ -44,7 +44,7 @@ export function LodgingSettingsTab() {
             return (
               <Link
                 key={entry.id}
-                to={`/admin/lodging/${entry.id}`}
+                to={`/manage/lodging/${entry.id}`}
                 aria-current={isActive ? 'page' : undefined}
                 className={`flex items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition-all duration-200 ${
                   isActive

--- a/frontend/src/components/weekend/AccessibilityFlagList.test.tsx
+++ b/frontend/src/components/weekend/AccessibilityFlagList.test.tsx
@@ -2,9 +2,10 @@
  * Accessibility flags are derived booleans. The medical NARRATIVE is behind
  * an explicit, permission-checked reveal (spec §5).
  *
- * `lodging.phi` is currently granted to no role, so in practice only admins
- * reach the narrative. The list must therefore degrade gracefully rather than
- * treat a 403 as a page failure.
+ * `lodging.phi` is held by admins and the Bunking Staff role, while the roster
+ * around it is readable by any authenticated user — so most viewers of this
+ * component cannot reach the narrative. The list must therefore degrade
+ * gracefully rather than treat a 403 as a page failure.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
@@ -173,8 +174,8 @@ describe('PHI reveal gate', () => {
   })
 
   it('offers the reveal to an admin, who bypasses the permission check', () => {
-    // lodging.phi is granted to no role, so admin bypass is the only route
-    // that currently reaches the narrative in practice.
+    // An admin holds no explicit permissions; hasPermission short-circuits on
+    // is_admin, so the reveal must appear without lodging.phi in the set.
     isAdmin.value = true
     render(
       <AccessibilityFlagList
@@ -259,8 +260,9 @@ describe('the revealed narrative', () => {
   })
 
   it('renders a failure inline rather than failing the page', async () => {
-    // lodging.phi is granted to no role, so a 403 is the common case. It must
-    // read as a sentence in the row, not escalate to the ErrorBoundary.
+    // Anyone can read the roster but only admins and bunking staff hold
+    // lodging.phi, so a 403 is a common case. It must read as a sentence in
+    // the row, not escalate to the ErrorBoundary.
     medicalResult.value = {
       data: undefined,
       isLoading: false,

--- a/frontend/src/components/weekend/AccessibilityFlagList.tsx
+++ b/frontend/src/components/weekend/AccessibilityFlagList.tsx
@@ -10,9 +10,9 @@
  * The API is the real boundary — /api/lodging/households/{id}/medical
  * requires `lodging.phi` and 403s otherwise. This UI gate exists so a user
  * who cannot see the narrative is not shown a button that always fails.
- * `lodging.phi` is currently granted to NO role, so admin bypass is the only
- * route that reaches the narrative in practice; a failed reveal therefore
- * renders inline and never escalates into a page error.
+ * `lodging.phi` is held by admins and the Bunking Staff role; everyone else
+ * who can read the roster gets a 403 here, so a failed reveal renders inline
+ * and never escalates into a page error.
  */
 import { Accessibility, Baby, Bath, Eye, Loader2, Plug, ShieldAlert } from 'lucide-react'
 import { useState } from 'react'

--- a/frontend/src/config/adminTabs.ts
+++ b/frontend/src/config/adminTabs.ts
@@ -1,8 +1,8 @@
 import type { LucideIcon } from 'lucide-react'
-import { RefreshCw, Sliders, Workflow, Database, Settings2, Home } from 'lucide-react'
+import { RefreshCw, Sliders, Workflow, Database, Settings2 } from 'lucide-react'
 
 export interface AdminTabConfig {
-  id: 'sync' | 'config' | 'lodging'
+  id: 'sync' | 'config'
   label: string
   path: string
   icon: LucideIcon
@@ -23,13 +23,6 @@ export const ADMIN_TABS: AdminTabConfig[] = [
     label: 'Configuration',
     path: '/admin/config',
     icon: Sliders,
-    requiredPermission: 'admin',
-  },
-  {
-    id: 'lodging',
-    label: 'Family Camp Lodging',
-    path: '/admin/lodging',
-    icon: Home,
     requiredPermission: 'admin',
   },
 ]

--- a/frontend/src/config/adminTabs.ts
+++ b/frontend/src/config/adminTabs.ts
@@ -6,8 +6,20 @@ export interface AdminTabConfig {
   label: string
   path: string
   icon: LucideIcon
-  /** Permission required. 'admin' = super-admin only, 'authenticated' = any logged-in user, or a permission codename */
-  requiredPermission: 'admin' | 'authenticated' | string
+  /**
+   * Always `'admin'` — every tab under /admin is admin-only, and the guard in
+   * `AdminLayout` relies on that rather than resolving the matched route's own
+   * requirement.
+   *
+   * This is deliberately a literal type, not `string`. It used to be
+   * `'admin' | 'authenticated' | string`, which collapses to `string` and let a
+   * tab carrying an ordinary permission codename sit under /admin — #387 did
+   * exactly that with a `metrics.geo` tab, and #450 had to move it (and Sheets,
+   * and Registration) out to /manage, where every route carries its own
+   * `RequirePermission`. Narrowed so that adding such a tab back is a compile
+   * error pointing at the guard, instead of a silent authorization hole.
+   */
+  requiredPermission: 'admin'
 }
 
 export const ADMIN_TABS: AdminTabConfig[] = [

--- a/frontend/src/config/manageTabs.ts
+++ b/frontend/src/config/manageTabs.ts
@@ -1,9 +1,9 @@
 import type { LucideIcon } from 'lucide-react'
-import { MapPin, CalendarDays, FileSpreadsheet } from 'lucide-react'
+import { MapPin, CalendarDays, FileSpreadsheet, Home } from 'lucide-react'
 import { Permission } from '../constants/permissions'
 
 export interface ManageTabConfig {
-  id: 'geo' | 'registration' | 'sheets'
+  id: 'geo' | 'registration' | 'sheets' | 'lodging'
   label: string
   path: string
   icon: LucideIcon
@@ -32,5 +32,16 @@ export const MANAGE_TABS: ManageTabConfig[] = [
     path: '/manage/sheets',
     icon: FileSpreadsheet,
     requiredPermission: Permission.SHEETS_EXPORT,
+  },
+  {
+    // Confirming cabins, correcting the unit registry and resolving ingest
+    // names are bunking staff's work, so this sits behind bunking.manage
+    // rather than admin — matching the write rules on every lodging_*
+    // collection (pb_migrations/1500000130).
+    id: 'lodging',
+    label: 'Family Camp Lodging',
+    path: '/manage/lodging',
+    icon: Home,
+    requiredPermission: Permission.BUNKING_MANAGE,
   },
 ]

--- a/frontend/src/hooks/useWeekendRoster.ts
+++ b/frontend/src/hooks/useWeekendRoster.ts
@@ -63,9 +63,10 @@ export function useWeekendRoster(year: number, sessionCmId: number | null) {
  * reveal, so the narrative is never fetched speculatively and never sits in
  * the query cache for someone who only ever looked at the roster.
  *
- * `lodging.phi` is currently granted to no role, so in practice this 403s for
- * every non-admin. Callers must degrade gracefully rather than treat the
- * error as a page failure.
+ * `lodging.phi` is held by admins and the Bunking Staff role. The roster
+ * itself is readable by any authenticated user, so this 403s for most of the
+ * people who can see the page it sits on — callers must degrade gracefully
+ * rather than treat the error as a page failure.
  */
 export function useHouseholdMedical(year: number, householdCmId: number | null, enabled: boolean) {
   const { fetchWithAuth } = useApiWithAuth()

--- a/frontend/src/pages/WeekendRosterPage.test.tsx
+++ b/frontend/src/pages/WeekendRosterPage.test.tsx
@@ -26,14 +26,17 @@ vi.mock('../hooks/useCurrentYear', () => ({
   useCurrentYear: () => ({ currentYear: 2026, setCurrentYear: vi.fn() }),
 }))
 
+// Admin and bunking.manage are tracked separately: the point of the lodging
+// link's gate is that a non-admin holding bunking.manage still gets it.
 let isAdmin = true
+let permissions = new Set<string>()
 
 vi.mock('../hooks/usePermissions', () => ({
   usePermissions: () => ({
     isAdmin,
-    permissions: [],
-    hasPermission: () => isAdmin,
-    hasAnyPermission: () => isAdmin,
+    permissions: [...permissions],
+    hasPermission: (p: string) => isAdmin || permissions.has(p),
+    hasAnyPermission: (...ps: string[]) => isAdmin || ps.some((p) => permissions.has(p)),
   }),
 }))
 
@@ -73,6 +76,7 @@ function renderPage(cmId = '1000001') {
 beforeEach(() => {
   navigate.mockReset()
   isAdmin = true
+  permissions = new Set()
   sessionsQuery.data = { year: 2026, sessions: [FAMILY_CAMP_1, WOMENS] }
   sessionsQuery.isLoading = false
   sessionsQuery.error = null
@@ -128,20 +132,34 @@ describe('header', () => {
     )
   })
 
-  it('links an admin to the lodging editor', () => {
-    // Phase C registers /admin/lodging/:section, so the link resolves instead
-    // of being swallowed by App.tsx's catch-all. It points straight at the
-    // units section rather than the bare path, skipping one redirect hop.
+  it('links to the lodging editor under /manage', () => {
+    // The editor moved off /admin so bunking staff can reach it. It points
+    // straight at the units section rather than the bare path, skipping one
+    // redirect hop.
     renderPage()
     expect(screen.getByRole('link', { name: /Lodging settings/i })).toHaveAttribute(
       'href',
-      '/admin/lodging/units'
+      '/manage/lodging/units'
     )
   })
 
-  it('hides the lodging-settings link from a non-admin', () => {
-    // Every lodging collection gates writes on `@request.auth.is_admin`, so a
-    // non-admin following the link would reach a surface that 403s on save.
+  it('offers the lodging-settings link to a non-admin holding bunking.manage', () => {
+    // The whole point of the move: cabin confirmations are bunking staff's
+    // job. The link must follow the permission that now gates the writes, not
+    // the admin flag that used to.
+    isAdmin = false
+    permissions = new Set(['bunking.manage'])
+    renderPage()
+    expect(screen.getByRole('link', { name: /Lodging settings/i })).toHaveAttribute(
+      'href',
+      '/manage/lodging/units'
+    )
+  })
+
+  it('hides the lodging-settings link from a user without bunking.manage', () => {
+    // Every lodging collection now gates writes on bunking.manage, and the
+    // route itself is behind RequirePermission — following the link would land
+    // on the permission-denied page.
     isAdmin = false
     renderPage()
     expect(screen.queryByRole('link', { name: /Lodging settings/i })).not.toBeInTheDocument()

--- a/frontend/src/pages/WeekendRosterPage.tsx
+++ b/frontend/src/pages/WeekendRosterPage.tsx
@@ -9,8 +9,9 @@
  *
  * Read-only in this slice: assignments come from CampMinder and are shown,
  * not edited. The registry behind it IS editable, though — Phase C added the
- * Admin -> Family Camp Lodging editor (spec §3.8), and this page links admins
- * straight to it for corrections to units, areas and cabin-name aliases.
+ * Manage -> Family Camp Lodging editor (spec §3.8), and this page links
+ * bunking staff straight to it for corrections to units, areas and cabin-name
+ * aliases.
  *
  * Everything rendered here is READ from ingest-derived columns. If a share
  * preference, proximity mode or request text looks wrong, the fix belongs in
@@ -22,6 +23,7 @@ import { useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router'
 
 import { QueryGuard } from '../components/QueryGuard'
+import { Permission } from '../constants/permissions'
 import {
   countUnmeasuredSpaces,
   formatSessionDates,
@@ -42,7 +44,8 @@ export default function WeekendRosterPage() {
   const { sessionCmId } = useParams<{ sessionCmId: string }>()
   const navigate = useNavigate()
   const { currentYear } = useCurrentYear()
-  const { isAdmin } = usePermissions()
+  const { hasPermission } = usePermissions()
+  const canManageLodging = hasPermission(Permission.BUNKING_MANAGE)
   const [view, setView] = useState<View>('roster')
 
   const selectedCmId = sessionCmId === undefined ? null : Number(sessionCmId)
@@ -125,12 +128,12 @@ export default function WeekendRosterPage() {
             </span>
           )}
 
-          {/* Restored now that Phase C registers /admin/lodging. It was pulled
-              in 03754754 because App.tsx's path="*" silently bounced the user
-              home when the route did not exist. */}
-          {isAdmin && (
+          {/* Gated on bunking.manage, which is what the lodging_* write rules
+              gate on — an admin flag would let the wrong people in and keep
+              bunking staff out. */}
+          {canManageLodging && (
             <Link
-              to="/admin/lodging/units"
+              to="/manage/lodging/units"
               className="text-muted-foreground hover:text-foreground ml-auto inline-flex items-center gap-1.5 text-sm transition-colors"
             >
               <Settings2 className="h-4 w-4" />

--- a/pocketbase/main_lodging_rbac_test.go
+++ b/pocketbase/main_lodging_rbac_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The canonical rule string used everywhere in this repo for "an admin, or a
+// user whose role carries bunking.manage". Duplicated verbatim from the
+// migrations rather than shared, because the assertion's whole value is that
+// it fails when the migration drifts from the canonical spelling.
+const bunkingManageRule = `'@request.auth.is_admin = true || @request.auth.cached_permissions ~ "bunking.manage"'`
+
+const lodgingRBACMigration = "pb_migrations/1500000130_lodging_bunking_manage_rbac.js"
+
+// lodgingStaffWritable is every lodging collection a staff surface writes:
+// the admin editor (areas, units, aliases, the ingest work queue) and the
+// board and map that follow it (merges, availability, assignments and their
+// history).
+var lodgingStaffWritable = []string{
+	"lodging_areas",
+	"lodging_units",
+	"lodging_unit_aliases",
+	"lodging_merges",
+	"lodging_availability",
+	"lodging_assignments",
+	"lodging_assignment_history",
+	"lodging_ingest_issues",
+}
+
+func readLodgingRBACMigration(t *testing.T) string {
+	t.Helper()
+	content, err := os.ReadFile(lodgingRBACMigration)
+	if err != nil {
+		t.Fatalf("read migration %s: %v", lodgingRBACMigration, err)
+	}
+	return string(content)
+}
+
+// TestLodgingRBACMigrationGrantsBunkingManageWrites verifies that migration
+// 1500000130 replaces the admin-only create/update/delete rules the lodging
+// collections were created with (1500000116-1500000122) with the canonical
+// bunkingManage rule, so non-admin bunking staff can confirm cabins and
+// resolve ingest names.
+//
+// Asserts on the migration FILE rather than runtime behaviour: applying JS
+// migrations from a Go test needs jsvm bootstrapped against the migrations
+// dir, which tests.NewTestApp() does not do. pb-js-lint checks syntax; this
+// locks in the semantics. Same approach as
+// TestDebugPipelineRBACMigrationUsesBunkingManageRule.
+func TestLodgingRBACMigrationGrantsBunkingManageWrites(t *testing.T) {
+	body := readLodgingRBACMigration(t)
+
+	if !strings.Contains(body, bunkingManageRule) {
+		t.Errorf("migration %s must contain the canonical bunkingManage rule %s",
+			lodgingRBACMigration, bunkingManageRule)
+	}
+
+	for _, col := range lodgingStaffWritable {
+		if !strings.Contains(body, `"`+col+`"`) {
+			t.Errorf("migration %s must reference collection %q", lodgingRBACMigration, col)
+		}
+	}
+
+	for _, rule := range []string{"createRule", "updateRule", "deleteRule"} {
+		if !strings.Contains(body, rule) {
+			t.Errorf("migration %s must set %s", lodgingRBACMigration, rule)
+		}
+	}
+
+	if !strings.Contains(body, "app.save(") {
+		t.Errorf("migration %s must call app.save() to persist rule changes", lodgingRBACMigration)
+	}
+	if !strings.Contains(body, "migrate((app)") {
+		t.Errorf("migration %s must define an up function via migrate((app) => ...)", lodgingRBACMigration)
+	}
+	if !strings.Contains(body, "}, (app)") {
+		t.Errorf("migration %s must define a down function", lodgingRBACMigration)
+	}
+}
+
+// TestLodgingRBACMigrationLeavesFieldMappingsAdminOnly guards the one lodging
+// collection that is NOT staff-writable. lodging_field_mappings is ingest
+// plumbing — which CampMinder custom fields feed which derived column —
+// written by the Go sync as superuser and surfaced in no UI. Widening it
+// would let bunking staff silently repoint the ingest.
+func TestLodgingRBACMigrationLeavesFieldMappingsAdminOnly(t *testing.T) {
+	body := readLodgingRBACMigration(t)
+
+	if strings.Contains(body, `"lodging_field_mappings"`) {
+		t.Errorf("migration %s must not widen lodging_field_mappings — it is ingest plumbing, admin-only",
+			lodgingRBACMigration)
+	}
+}
+
+// TestLodgingRBACMigrationKeepsReadsOpen verifies the weekend surfaces stay
+// readable by any authenticated user. Reads were never admin-gated; the point
+// of this assertion is that the migration does not accidentally tighten them
+// while loosening writes, which would blank the roster for everyone but
+// bunking staff.
+func TestLodgingRBACMigrationKeepsReadsOpen(t *testing.T) {
+	body := readLodgingRBACMigration(t)
+
+	const authed = `'@request.auth.id != ""'`
+	if !strings.Contains(body, authed) {
+		t.Errorf("migration %s must keep list/view at %s so the roster stays readable by any authenticated user",
+			lodgingRBACMigration, authed)
+	}
+	for _, rule := range []string{"listRule", "viewRule"} {
+		if !strings.Contains(body, rule) {
+			t.Errorf("migration %s must set %s explicitly rather than leaving it to drift",
+				lodgingRBACMigration, rule)
+		}
+	}
+}
+
+// TestLodgingRBACMigrationGrantsPHIToBunkingStaff verifies the migration adds
+// lodging.phi to the Bunking Staff role. Before this, lodging.phi was granted
+// to no role at all (#1887), so the medical reveal on the weekend roster was
+// reachable only by admin bypass and its 403 path had never run in anger.
+func TestLodgingRBACMigrationGrantsPHIToBunkingStaff(t *testing.T) {
+	body := readLodgingRBACMigration(t)
+
+	if !strings.Contains(body, `"lodging.phi"`) {
+		t.Errorf("migration %s must grant the lodging.phi permission", lodgingRBACMigration)
+	}
+	if !strings.Contains(body, `"bunking-staff"`) {
+		t.Errorf("migration %s must target the bunking-staff role by slug", lodgingRBACMigration)
+	}
+	// The Go hooks recompute cached_permissions on user_roles writes and on
+	// roles updates, but a migration that edits a role must not depend on a
+	// hook firing during bootstrap: without an explicit recompute, every
+	// existing bunking-staff user keeps a stale cached_permissions array and
+	// the grant is invisible until someone re-saves the role by hand.
+	if !strings.Contains(body, "cached_permissions") {
+		t.Errorf("migration %s must recompute cached_permissions for users holding the role",
+			lodgingRBACMigration)
+	}
+	if !strings.Contains(body, "user_roles") {
+		t.Errorf("migration %s must find affected users via user_roles to recompute their permissions",
+			lodgingRBACMigration)
+	}
+}

--- a/pocketbase/main_lodging_rbac_test.go
+++ b/pocketbase/main_lodging_rbac_test.go
@@ -44,7 +44,7 @@ func readLodgingRBACMigration(t *testing.T) string {
 // bunkingManage rule, so non-admin bunking staff can confirm cabins and
 // resolve ingest names.
 //
-// Asserts on the migration FILE rather than runtime behaviour: applying JS
+// Asserts on the migration FILE rather than runtime behavior: applying JS
 // migrations from a Go test needs jsvm bootstrapped against the migrations
 // dir, which tests.NewTestApp() does not do. pb-js-lint checks syntax; this
 // locks in the semantics. Same approach as

--- a/pocketbase/main_lodging_rbac_test.go
+++ b/pocketbase/main_lodging_rbac_test.go
@@ -14,19 +14,28 @@ const bunkingManageRule = `'@request.auth.is_admin = true || @request.auth.cache
 
 const lodgingRBACMigration = "pb_migrations/1500000130_lodging_bunking_manage_rbac.js"
 
-// lodgingStaffWritable is every lodging collection a staff surface writes:
-// the admin editor (areas, units, aliases, the ingest work queue) and the
-// board and map that follow it (merges, availability, assignments and their
-// history).
+// lodgingStaffWritable is the PLAN side of the split: the registry the editor
+// writes (areas, units, aliases, the ingest work queue) plus the two planning
+// tables the board will write (merges, availability).
 var lodgingStaffWritable = []string{
 	"lodging_areas",
 	"lodging_units",
 	"lodging_unit_aliases",
 	"lodging_merges",
 	"lodging_availability",
+	"lodging_ingest_issues",
+}
+
+// lodgingAdminOnly is every lodging collection that must NOT be widened.
+var lodgingAdminOnly = []string{
+	// Ingest plumbing: which CampMinder field feeds which derived column.
+	"lodging_field_mappings",
+	// The synced record of truth and its append-only audit trail. Summer's
+	// equivalents (bunk_assignments, attendee_status_history) have stayed
+	// admin-only through every RBAC revision here; the table summer staff
+	// actually write is the DRAFT, bunk_assignments_draft.
 	"lodging_assignments",
 	"lodging_assignment_history",
-	"lodging_ingest_issues",
 }
 
 func readLodgingRBACMigration(t *testing.T) string {
@@ -80,17 +89,41 @@ func TestLodgingRBACMigrationGrantsBunkingManageWrites(t *testing.T) {
 	}
 }
 
-// TestLodgingRBACMigrationLeavesFieldMappingsAdminOnly guards the one lodging
-// collection that is NOT staff-writable. lodging_field_mappings is ingest
-// plumbing — which CampMinder custom fields feed which derived column —
-// written by the Go sync as superuser and surfaced in no UI. Widening it
-// would let bunking staff silently repoint the ingest.
-func TestLodgingRBACMigrationLeavesFieldMappingsAdminOnly(t *testing.T) {
+// TestLodgingRBACMigrationLeavesTheRecordOfTruthAdminOnly guards the three
+// lodging collections that must NOT become staff-writable.
+//
+// The draft-versus-final split is the load-bearing one. Summer has never
+// granted bunking.manage on `bunk_assignments` (the synced record of truth) or
+// `attendee_status_history` (append-only audit); what staff write there is the
+// DRAFT table. Lodging has no draft table yet and nothing writes assignments,
+// so widening them would hand out delete on an append-only audit trail with no
+// caller to justify it. `lodging_field_mappings` is a separate case: ingest
+// plumbing whose contents change what every lodging read means.
+func TestLodgingRBACMigrationLeavesTheRecordOfTruthAdminOnly(t *testing.T) {
 	body := readLodgingRBACMigration(t)
 
-	if strings.Contains(body, `"lodging_field_mappings"`) {
-		t.Errorf("migration %s must not widen lodging_field_mappings — it is ingest plumbing, admin-only",
-			lodgingRBACMigration)
+	// Look only at the executable list, not the prose: the migration's comments
+	// name these collections precisely to explain why they are excluded, and a
+	// whole-file substring check would trip over its own rationale.
+	start := strings.Index(body, "const LODGING_STAFF_WRITABLE = [")
+	if start == -1 {
+		t.Fatalf("migration %s must declare LODGING_STAFF_WRITABLE", lodgingRBACMigration)
+	}
+	end := strings.Index(body[start:], "]")
+	if end == -1 {
+		t.Fatalf("migration %s: LODGING_STAFF_WRITABLE is not terminated", lodgingRBACMigration)
+	}
+	writable := body[start : start+end]
+
+	for _, col := range lodgingAdminOnly {
+		if strings.Contains(writable, `"`+col+`"`) {
+			t.Errorf("migration %s must not widen %q — see lodgingAdminOnly for why", lodgingRBACMigration, col)
+		}
+	}
+	for _, col := range lodgingStaffWritable {
+		if !strings.Contains(writable, `"`+col+`"`) {
+			t.Errorf("migration %s must widen %q", lodgingRBACMigration, col)
+		}
 	}
 }
 

--- a/pocketbase/pb_migrations/1500000130_lodging_bunking_manage_rbac.js
+++ b/pocketbase/pb_migrations/1500000130_lodging_bunking_manage_rbac.js
@@ -16,10 +16,12 @@
  * the roster is deliberately readable by everyone who can log in, and a later
  * edit that loosens writes must not silently take reads with it.
  *
- * WHAT IS NOT WIDENED. `lodging_field_mappings` keeps admin-only writes. It
- * maps CampMinder custom fields onto derived columns — ingest plumbing written
- * by the Go sync as superuser, with no staff-facing surface. Repointing it
- * would change what every lodging read means, which is not a cabin decision.
+ * WHAT IS NOT WIDENED. Three collections keep admin-only writes:
+ * `lodging_field_mappings`, because it maps CampMinder custom fields onto
+ * derived columns — ingest plumbing written by the Go sync as superuser, with
+ * no staff-facing surface, and repointing it would change what every lodging
+ * read means; and `lodging_assignments` / `lodging_assignment_history`, for the
+ * draft-versus-final reason spelled out at LODGING_STAFF_WRITABLE below.
  *
  * PHI. `lodging.phi` gates the medical narrative behind the roster's
  * accessibility flags. It was granted to NO role (#1887), so the reveal was
@@ -30,6 +32,13 @@
  * staff — or granted to someone who places nobody — without touching write
  * access, and so the endpoint's access log keeps meaning what it says.
  *
+ * #1887 offered a second route: leave the grant out and let an admin add it
+ * through the roles editor, which already enumerates ALL_PERMISSIONS and so has
+ * been able to do this since #1884. Granting here anyway, deliberately — a
+ * default nobody has to discover beats a self-serve knob nobody knows to turn,
+ * and this repo prefers a code change over a config one. The knob still works
+ * for anyone who wants PHI without write access.
+ *
  * Idempotent: rules are set to a fixed target, and the permission grant checks
  * for the value first.
  */
@@ -39,17 +48,25 @@ const LODGING_BUNKING_MANAGE =
   '@request.auth.is_admin = true || @request.auth.cached_permissions ~ "bunking.manage"'
 const LODGING_ADMIN_ONLY = "@request.auth.is_admin = true"
 
-// Every lodging collection a staff surface writes: the admin editor (areas,
-// units, aliases, the ingest work queue) and the board and map that follow it
-// (merges, availability, assignments and their history).
+// The PLAN side of the split, and only that: the registry the editor writes
+// (areas, units, aliases, the ingest work queue) plus the two planning tables
+// the board will write (merges, availability).
+//
+// `lodging_assignments` and `lodging_assignment_history` are deliberately NOT
+// here. Summer draws the same line and has never crossed it: `bunk_assignments`
+// (the synced record of truth) and `attendee_status_history` (append-only audit)
+// are admin-only through every RBAC revision in this repo, while the table staff
+// actually write is the DRAFT — `bunk_assignments_draft`. Lodging has no draft
+// table yet, and nothing writes assignments today; granting delete on an
+// append-only audit trail ahead of any UI that needs it buys nothing and risks
+// the one record that cannot be reconstructed. Widen them in the PR that adds
+// the writer.
 const LODGING_STAFF_WRITABLE = [
   "lodging_areas",
   "lodging_units",
   "lodging_unit_aliases",
   "lodging_merges",
   "lodging_availability",
-  "lodging_assignments",
-  "lodging_assignment_history",
   "lodging_ingest_issues",
 ]
 

--- a/pocketbase/pb_migrations/1500000130_lodging_bunking_manage_rbac.js
+++ b/pocketbase/pb_migrations/1500000130_lodging_bunking_manage_rbac.js
@@ -1,0 +1,230 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: weekend lodging follows the summer bunking board's access model.
+ * Dependencies: lodging collections (1500000116-1500000122), RBAC roles (1500000070)
+ *
+ * WHY. The lodging collections were created admin-only on every write
+ * (`@request.auth.is_admin = true`), which meant the people who actually do
+ * this job could not do it: bunking staff hold `bunking.manage`, not admin.
+ * The summer board settled this shape long ago — reads open to any
+ * authenticated user, writes gated on admin OR bunking.manage — and the
+ * weekend surfaces are the same job in a different program. This brings them
+ * into line.
+ *
+ * READS STAY OPEN. list/view remain `@request.auth.id != ""`. They are
+ * restated here rather than left alone so the intent is legible in one place:
+ * the roster is deliberately readable by everyone who can log in, and a later
+ * edit that loosens writes must not silently take reads with it.
+ *
+ * WHAT IS NOT WIDENED. `lodging_field_mappings` keeps admin-only writes. It
+ * maps CampMinder custom fields onto derived columns — ingest plumbing written
+ * by the Go sync as superuser, with no staff-facing surface. Repointing it
+ * would change what every lodging read means, which is not a cabin decision.
+ *
+ * PHI. `lodging.phi` gates the medical narrative behind the roster's
+ * accessibility flags. It was granted to NO role (#1887), so the reveal was
+ * reachable only by admin bypass. It joins the Bunking Staff role here: the
+ * staff placing families are the staff who need to know a family needs a
+ * ground-floor room with power for a CPAP. It stays a SEPARATE permission
+ * rather than folding into bunking.manage, so it can be revoked from bunking
+ * staff — or granted to someone who places nobody — without touching write
+ * access, and so the endpoint's access log keeps meaning what it says.
+ *
+ * Idempotent: rules are set to a fixed target, and the permission grant checks
+ * for the value first.
+ */
+
+const LODGING_AUTHED_READ = '@request.auth.id != ""'
+const LODGING_BUNKING_MANAGE =
+  '@request.auth.is_admin = true || @request.auth.cached_permissions ~ "bunking.manage"'
+const LODGING_ADMIN_ONLY = "@request.auth.is_admin = true"
+
+// Every lodging collection a staff surface writes: the admin editor (areas,
+// units, aliases, the ingest work queue) and the board and map that follow it
+// (merges, availability, assignments and their history).
+const LODGING_STAFF_WRITABLE = [
+  "lodging_areas",
+  "lodging_units",
+  "lodging_unit_aliases",
+  "lodging_merges",
+  "lodging_availability",
+  "lodging_assignments",
+  "lodging_assignment_history",
+  "lodging_ingest_issues",
+]
+
+/** Point every staff-writable lodging collection at one write rule. */
+function setLodgingWriteRules(app, writeRule) {
+  for (const name of LODGING_STAFF_WRITABLE) {
+    const col = app.findCollectionByNameOrId(name)
+    col.listRule = LODGING_AUTHED_READ
+    col.viewRule = LODGING_AUTHED_READ
+    col.createRule = writeRule
+    col.updateRule = writeRule
+    col.deleteRule = writeRule
+    app.save(col)
+  }
+}
+
+/**
+ * Read a role's `permissions` json field as a plain array of strings.
+ *
+ * `record.get()` on a json field hands back the underlying types.JSONRaw —
+ * a Go byte slice. goja presents that as an Array, so `Array.isArray()`
+ * answers TRUE and iterating it yields BYTE VALUES, not permissions: writing
+ * that straight back turns ["bunking.manage"] into [34,98,117,...]. Verified
+ * against the running VM, not assumed. `getString()` is the honest accessor —
+ * it returns the stored JSON text.
+ */
+function readRolePermissions(role) {
+  const text = role.getString("permissions")
+  if (!text) {
+    return []
+  }
+  try {
+    const parsed = JSON.parse(text)
+    return Array.isArray(parsed) ? parsed : []
+  } catch (_err) {
+    return []
+  }
+}
+
+function findRoleBySlug(app, slug) {
+  try {
+    return app.findFirstRecordByFilter("roles", "slug = {:slug}", { slug: slug })
+  } catch (_err) {
+    // A deployment that never seeded the system roles is not a reason to fail
+    // the rule change, which is the load-bearing half of this migration.
+    return null
+  }
+}
+
+/**
+ * Recompute `users.cached_permissions` for everyone holding the given role.
+ *
+ * The Go hooks (pocketbase/rbac/hooks.go) do this on user_roles writes and on
+ * roles updates, but a migration must not depend on a hook firing during
+ * bootstrap. Without this, an existing bunking-staff user keeps a stale cache
+ * and the grant stays invisible until someone re-saves the role by hand — the
+ * permission is read from the cached array, never from the role.
+ *
+ * The union is taken over ALL of the user's roles, not just this one, because
+ * cached_permissions is a flattened set: rebuilding it from a single role
+ * would drop every permission their other roles carry.
+ */
+function recomputeCachedPermissions(app, roleId) {
+  const memberships = app.findRecordsByFilter("user_roles", "role = {:roleId}", "", 0, 0, {
+    roleId: roleId,
+  })
+
+  for (const membership of memberships) {
+    const userId = membership.getString("user")
+    if (!userId) {
+      continue
+    }
+
+    const allMemberships = app.findRecordsByFilter("user_roles", "user = {:userId}", "", 0, 0, {
+      userId: userId,
+    })
+
+    const seen = {}
+    for (const m of allMemberships) {
+      let held
+      try {
+        held = app.findRecordById("roles", m.getString("role"))
+      } catch (_err) {
+        continue
+      }
+      for (const p of readRolePermissions(held)) {
+        seen[p] = true
+      }
+    }
+
+    let user
+    try {
+      user = app.findRecordById("_pb_users_auth_", userId)
+    } catch (_err) {
+      continue
+    }
+    user.set("cached_permissions", Object.keys(seen).sort())
+    app.save(user)
+  }
+}
+
+/** Add `permission` to the role with `slug`, then refresh holders' caches. */
+function grantPermissionToRole(app, slug, permission) {
+  const role = findRoleBySlug(app, slug)
+  if (!role) {
+    return
+  }
+
+  const perms = readRolePermissions(role)
+  if (perms.indexOf(permission) !== -1) {
+    return
+  }
+
+  perms.push(permission)
+  perms.sort()
+  role.set("permissions", perms)
+  app.save(role)
+
+  recomputeCachedPermissions(app, role.id)
+}
+
+/** Remove `permission` from the role with `slug`, then refresh holders' caches. */
+function revokePermissionFromRole(app, slug, permission) {
+  const role = findRoleBySlug(app, slug)
+  if (!role) {
+    return
+  }
+
+  const perms = readRolePermissions(role)
+  const next = perms.filter((p) => p !== permission)
+  if (next.length === perms.length) {
+    return
+  }
+
+  role.set("permissions", next)
+  app.save(role)
+
+  recomputeCachedPermissions(app, role.id)
+}
+
+// The role description is what the Roles admin screen shows when someone
+// decides who to give this to, so it has to name the weekend work now. Only
+// rewritten if it still matches the seeded string — a description an admin has
+// since edited is theirs, not ours.
+const BUNKING_STAFF_DESCRIPTION_SEEDED =
+  "Full bunking access: board, requests, scenarios, solver, CSV upload, CampMinder sync"
+const BUNKING_STAFF_DESCRIPTION_WITH_LODGING =
+  "Full bunking access: board, requests, scenarios, solver, CSV upload, CampMinder sync, " +
+  "plus the family camp lodging registry and its medical detail"
+
+function retitleRole(app, slug, from, to) {
+  const role = findRoleBySlug(app, slug)
+  if (!role || role.getString("description") !== from) {
+    return
+  }
+  role.set("description", to)
+  app.save(role)
+}
+
+migrate((app) => {
+  setLodgingWriteRules(app, LODGING_BUNKING_MANAGE)
+  grantPermissionToRole(app, "bunking-staff", "lodging.phi")
+  retitleRole(
+    app,
+    "bunking-staff",
+    BUNKING_STAFF_DESCRIPTION_SEEDED,
+    BUNKING_STAFF_DESCRIPTION_WITH_LODGING
+  )
+}, (app) => {
+  setLodgingWriteRules(app, LODGING_ADMIN_ONLY)
+  revokePermissionFromRole(app, "bunking-staff", "lodging.phi")
+  retitleRole(
+    app,
+    "bunking-staff",
+    BUNKING_STAFF_DESCRIPTION_WITH_LODGING,
+    BUNKING_STAFF_DESCRIPTION_SEEDED
+  )
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,11 @@ extraPaths = ["."]
 [tool.mypy]
 python_version = "3.14"
 plugins = ["pydantic.mypy"]
+# docs/plans/ is gitignored local-only scratch (.gitignore:330) — working
+# probe scripts that are never shipped and never imported. The pre-push hook
+# runs `mypy . --explicit-package-bases`, which walks them anyway and blocks
+# the push for anyone who happens to have one on disk.
+exclude = "^docs/plans/"
 # Strict mode - catch type errors, async/sync mismatches, missing attributes
 strict = true
 warn_return_any = true


### PR DESCRIPTION
Weekend lodging writes were admin-only on every collection, which locked out the people whose job this is: bunking staff hold `bunking.manage`, not admin. The summer board settled this shape long ago — reads open to any authenticated user, writes gated on admin OR `bunking.manage` — and the weekend surfaces are the same job in another program. This brings them into line, and updates `HANDOFF.md` for both that and the Phase C merge it had not caught up with.

## The access model

`1500000130` points create/update/delete on the six staff-written `lodging_*` collections at the canonical `bunkingManage` rule, and restates list/view as authed so a later edit cannot take reads along by accident.

- **Three collections stay admin-only.** `lodging_field_mappings` maps CampMinder custom fields onto derived columns: ingest plumbing written by the Go sync as superuser, with no staff-facing surface. Repointing it changes what every lodging read *means*, which is not a cabin decision.

  `lodging_assignments` and `lodging_assignment_history` are the synced record of truth and its append-only audit. **Summer draws the identical line and has never crossed it** — `bunk_assignments` and `attendee_status_history` are admin-only through every RBAC revision here, while the table staff actually write is the DRAFT, `bunk_assignments_draft`. Lodging has no draft table yet and nothing writes assignments today. They were in the widened set until review caught it; widening them handed out *delete* on an append-only audit trail with no caller to justify it. Widen them in the PR that adds the board.
- **`lodging.phi` joins the Bunking Staff role**, closing #1887. It gated the medical narrative behind the roster's accessibility flags but was granted to no role at all, so the reveal was reachable only by admin bypass and its 403 path had never run in anger. It stays a **separate** permission rather than folding into `bunking.manage`, so it can be revoked from bunking staff — or granted to someone who places nobody — without touching write access, and so the endpoint's access log keeps meaning what it says.
- **The editor moves `/admin/lodging` → `/manage/lodging`**, behind `RequirePermission`, joining the group whose routes are already guarded. No redirect from the old paths: the surface was never in anyone's hands, so there are nothing to preserve.
- **`AdminLayout` refuses the page for a non-admin**, closing #1895. Filtering the tab list was never a guard — typing `/admin/sync` rendered it for anyone logged in. The guard tests `isAdmin` rather than "has at least one visible tab": those coincide only because every admin tab is admin-only, and a tab-count check *reads* as per-route while being any-route. `AdminTabConfig.requiredPermission` drops from `'admin' | 'authenticated' | string` (which collapses to `string`) to the literal `'admin'`, so putting a permission-gated tab back under `/admin` is a compile error. #387 did exactly that with a `metrics.geo` tab and #450 had to move it out — the type now remembers. **Merging `/admin` into `/manage` must revisit this guard.**

The migration recomputes `users.cached_permissions` itself rather than relying on the Go `roles` hook firing during bootstrap. The permission is read from the cached array, never from the role, so without it the grant stays invisible until someone re-saves the role by hand.

## Verified against a database, not just the file

The Go tests assert the migration's semantics from its text (applying JS migrations from Go needs jsvm bootstrapped, which `tests.NewTestApp()` does not do). So the migration was also run against a seeded 716 MB DB: the eight rule sets, the role grant, the untouched `lodging_field_mappings`, and one holder's recomputed cache all land correctly.

That run earned its keep. **The first version silently corrupted the role.** `record.get()` on a PocketBase json field returns the Go byte slice; goja reports it as an `Array`, so `Array.isArray()` answers true and iterating yields byte values. Reading permissions that way and writing them back turned

```
["bunking.manage","sheets.export"]
```

into

```
[101,103,103,105,107,109,110,110,110,117,34,34,46,91,93,97,97,98,"lodging.phi"]
```

`getString()` is the honest accessor — it returns the stored JSON text. A probe migration against the running VM settled it rather than guessing. The Go side has the same trap in a different shape, already handled in `extractBusinessCategory`.

## What this does NOT change

Reads stay open to any authenticated user, as directed. So does the known gap that predates all of this: `request_text` is an ordinary ungated roster field, and **12 of 232 (5%)** 2026 request texts contain health vocabulary, because families type medical detail into the cabin-request box. `family_camp_medical` is gated; the same class of information walks out beside it. Recorded in §8, deliberately not acted on — gate it, flag it for review, or accept it, but it is a decision rather than an oversight.

The lodging components still live under `frontend/src/components/admin/lodging/` though the route is `/manage`. Renaming is 32 files for no behaviour change; the directory-vs-route split is noted in `HANDOFF.md` §7 so nobody hunts for it.

## HANDOFF.md

All three lodging plans are merged (`1bcd90f1`) but the doc still pointed at Phase C as next and carried three behaviours that are no longer true.

- **§4 rewritten** around what actually comes next — the board and the map (spec §7.2) — including the merge-legality rule that was deliberately deferred (nothing could create a merge yet, so it would have shipped with no caller) and the container data seeded for it.
- **Three behaviours recorded whose names do not suggest them**, all found *after* merge by a review pass on the merged branch:
  - `deleteLodgingAlias` is not a plain delete — it reopens the `lodging_ingest_issues` rows an alias resolved *before* deleting it. That order is load-bearing.
  - `lodging_unit_aliases` has an `OnRecordDelete` guard, so the delete returns 400 from every path including the PocketBase admin UI.
  - `LodgingUnitForm` writes `sleeps: 0` on **edit** and omits the key on **create**.
- **New §6 entries** for the same, plus the `key`-on-edit-form rule, the uppercase area-code rule, `aria-sort={undefined}`, and not using `?? []` to paper over a failed query.
- **§8** gains #1894–#1897 and now marks #1887 and #1895 fixed by this PR. Highest migration `1500000127` → `1500000130`.

The most important addition is *why* `deleteLodgingAlias` has a side effect: deleting an alias used to silence the work queue **permanently and invisibly**. `IssueRecorder.Flush` writes `is_resolved` only on create — deliberately, so a later sync cannot un-tick what staff ticked — and its dedup matches a re-encountered cabin string to that same row. So the string never returned to the queue and its placement never resolved again.

## One unrelated change, bundled only because it blocks pushing

`pyproject.toml` now excludes `docs/plans/` from mypy. That directory is gitignored local-only scratch (`.gitignore:330`), but the pre-push hook runs `mypy . --explicit-package-bases`, which walks it regardless — so a local probe script fails the hook and blocks every push. Two such files did exactly that here. Five lines, and it unblocks anyone with local plan scratch.

## Review

Scanned with our five-agent pass plus CodeRabbit (which reviewed `1bcd90f1..35144767`, posted 8 findings, then hit its review limit before the final commit — that commit is a one-word spelling fix in a Go comment).

Actioned: the assignments/history scope error above; the `AdminLayout` guard shape; five statements in `HANDOFF.md` that went stale under edit, two of which the next agent would have acted on (`"Highest on main is 1500000127"` in the do-NOT-number-from-a-branch entry, and a second "granted to no role" contradicting the fixed one ten lines up). Filed #1899 for the missing server-side `parent_unit` cycle guard — pre-existing, but this PR widens who can reach it.

Declined, with reasons: an `isLoading` check in `AdminLayout` (`ProtectedRoute` already returns `FullPageSpinner` before `/admin` renders, so the window cannot occur); resolving `_pb_users_auth_` by name (it is the repo convention and the identical string `pocketbase/rbac/hooks.go` uses — if it did not resolve, RBAC would already be broken); a WAL checkpoint (#1870 is an open adopt-or-drop where zero of 15 data-write migrations do it).

## Test evidence

- `go test ./...` in `pocketbase/` — green, incl. 4 new `TestLodgingRBAC*` cases
- `npx vitest run` — 377 files, 5142 tests green
- `npx tsc --noEmit`, `npx eslint` on changed files, `eslint pb_migrations` — clean
- `uv run pytest tests/unit/rbac/ tests/unit/api/` — 1825 green
- Migration applied to a real seeded DB and every effect read back from SQLite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Closes #1887
Closes #1895


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Moved Family Camp Lodging management from Admin to Manage → Family Camp Lodging.
  * Added permission-based access for bunking staff and other authorized managers.
  * Added redirects to the lodging units editor and updated related roster links.
* **Bug Fixes**
  * Restricted unauthorized access to administrative pages with a clear access-denied screen.
  * Improved handling of unavailable medical details so errors remain inline without disrupting the page.
* **Documentation**
  * Updated lodging workflows, permissions, safeguards, and operational guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->