### PR TITLE
refactor(pb,security): move the lodging registry out of tracked source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -322,6 +322,7 @@ config/branding.local.json
 config/staff_list.json
 config/nicknames_override.json
 config/sheets_sharing.local.json
+config/lodging_registry.json
 local
 CLAUDE.local.md
 scripts/vault.config

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ See `/docs`:
 - `architecture/` — sync-layer, bunk-request-pipeline, session-types, metrics-module, data-model, solver-internals
 - `guides/` — solver-configuration, csv-preparation, request-management, troubleshooting, docker-deployment
 - `api/` — solver-api, response-examples
-- `reference/` — cli-commands, issue-triage, pocketbase-migrations, tables, commit-conventions, git-workflow, oauth2-setup
+- `reference/` — cli-commands, issue-triage, pocketbase-migrations, tables, commit-conventions, git-workflow, oauth2-setup, lodging-registry
 
 Harness improvements roadmap: `docs/reference/claude-harness-improvements.md`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ Worktree mechanics (ports, isolation, cleanup): `docs/reference/git-workflow.md`
 
 **Environment secrets** load from `.env` via `start_dev.sh`.
 
-**Private files** (branding, staff lists, assets) live in the private `kindred-local` repo: `config/branding.local.json`, `config/staff_list.json`, `local/assets/`, `CLAUDE.local.md`, `frontend/vite.config.local.ts`, `scripts/vault.config`, `docs/camp/`. Local dev symlinks them via `scripts/setup/setup-local-config.sh`; CI/CD clones via deploy key. Without them the system falls back to generic "Kindred" branding.
+**Private files** (branding, staff lists, assets) live in the private `kindred-local` repo: `config/branding.local.json`, `config/staff_list.json`, `config/lodging_registry.json`, `local/assets/`, `CLAUDE.local.md`, `frontend/vite.config.local.ts`, `scripts/vault.config`, `docs/camp/`. Local dev symlinks them via `scripts/setup/setup-local-config.sh`; CI/CD clones via deploy key. Without them the system falls back to generic "Kindred" branding.
 
 **Never use real personal information** in code, tests, comments, docs, commits, issues, or PRs — real camper/family/staff names, schools, or CampMinder IDs. Use the fictional set (list and examples in `tests/CLAUDE.md`), `{camp_name}` placeholders instead of hardcoded camp names, and generic session IDs. This applies to public artifacts most of all: a name that reaches a GitHub issue or PR body is a real privacy leak.
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -387,6 +387,16 @@ the whole time. That is progress, not a hang — confirm with CPU, not the count
 - **Do not commit `docs/superpowers/**` or `docs/plans/**`.** Gitignored, local-only, public repo.
 - **Do not re-add unit names to application source to make a rule readable.** The guard now ignores
   comments and docstrings, so prose is fine; a string literal, list or map is not (spec §3.8).
+- **Do not seed registry data in a migration — including a migration that READS the private file.**
+  The registry lives in `config/lodging_registry.json` (kindred-local) and loads on boot;
+  `docs/reference/lodging-registry.md` is the contract. `_migrations` keys on filename and applies
+  once, so a migration reading an absent private file in CI would be recorded as applied and never
+  re-run when the file appeared — a silently empty registry. `verify-no-hardcoded-lodging.sh` now
+  scans `pb_migrations/` for exactly this.
+- **Do not make the boot loader overwrite existing rows.** It is create-if-absent on purpose: the
+  registry is staff-editable, so a full upsert would undo confirmations and corrected coordinates on
+  the next restart. The flip side is that it will NOT backfill a new field onto rows that already
+  exist — that needs its own one-off, and assuming otherwise is how an inventory update lands empty.
 - **Do not judge a housing need against an unconfirmed cabin.** `has_power: false` on an unconfirmed
   row means "nobody has said". Phase C makes confirmation possible — that is the moment this starts
   mattering, not a reason to relax it.

--- a/docs/reference/lodging-registry.md
+++ b/docs/reference/lodging-registry.md
@@ -1,0 +1,184 @@
+# The lodging registry
+
+The weekend-lodging unit registry — areas, units and the alias strings that map
+CampMinder's free-text cabin fields onto them — is **private data**, not source.
+It lives in `config/lodging_registry.json`, carried in the private
+`kindred-local` repo, and is loaded into PocketBase on every boot.
+
+This document is the contract: the file format, what the loader does and does
+not do, and how to verify it. It deliberately contains **no unit names** — that
+is the whole point of the arrangement.
+
+---
+
+## Why the registry is private
+
+This repository is public. The registry names the camp's buildings, and several
+unit names contain the camp's own name, so seeding it into `pb_migrations/`
+published it. Tracked as **#1909**.
+
+The trigger was scale: a 2026 inventory seed would have added roughly five times
+the existing exposure. Moving 30 literals once was cheaper than moving 160
+later.
+
+`scripts/dev/verify-no-hardcoded-lodging.sh` already encoded *"the registry is
+DATA, not code"*. This extends it to *private* data, and the guard now scans
+`pb_migrations/` too — with the data gone from the seed migrations, skipping
+that directory would leave a hole exactly where a future seed would land.
+
+## Why a boot loader and not a migration
+
+`_migrations` keys on **filename** and applies once.
+
+A migration that read `config/lodging_registry.json` would run in CI, find no
+file (CI has no private config), do nothing, and be **recorded as applied**. It
+would never run again — so the day the file appeared, the registry would stay
+silently empty. This repository has been bitten by filename-keying before.
+
+So the loader runs on the `OnServe` hook in `pocketbase/main.go`, beside
+`runHistorySync`. Every boot re-reads the file, which means a file that appears
+later still takes effect.
+
+**Absent file is not an error.** A clone without `kindred-local` boots normally
+with an empty registry and a log line — the same graceful degradation
+`branding.local.json` has. An unreadable or malformed file logs a warning and
+leaves the registry alone rather than taking the service down.
+
+## Loader semantics: create-if-absent, never update
+
+`pocketbase/lodging/registry.go` creates rows that do not exist and **leaves
+existing rows completely alone**.
+
+This is not a full upsert, deliberately. The registry is staff-editable in
+`/manage/lodging`: coordinates get corrected, capacities get adjusted, cabins
+get confirmed. A loader that rewrote every field on boot would silently undo all
+of that on the next restart.
+
+The same reasoning covers `parent_unit`: a parent staff cleared deliberately
+stays cleared. Only rows the loader itself created in the current run get their
+parent wired.
+
+Two consequences worth knowing:
+
+- On every database that the old seed migrations already populated — including
+  production — the loader is an exact no-op.
+- **Adding a field to an existing row is not something this loader will do.**
+  Extending the registry with new columns on rows that already exist needs its
+  own backfill; the file alone will not apply them.
+
+Parent wiring is two-pass, so a unit may name a parent that appears later in the
+file.
+
+## Path resolution
+
+First match wins:
+
+| Path | Context |
+|---|---|
+| `/app/config/lodging_registry.json` | Docker |
+| `./config/lodging_registry.json` | run from the repo root |
+| `../config/lodging_registry.json` | run from `pocketbase/` |
+
+`scripts/setup/setup-local-config.sh` symlinks the file in from `kindred-local`,
+and `scripts/worktree/new.sh` does the same for a new worktree.
+
+> **Note:** `docker/Dockerfile.pocketbase` does not currently copy `config/` into
+> the image, so a **from-scratch production database** would boot with an empty
+> registry. Existing production rows are unaffected — they were created by the
+> seed migrations and nothing removes them. Worth fixing before anyone rebuilds
+> production from migrations alone.
+
+## File format
+
+```jsonc
+{
+  "_notes": [
+    "Free prose about the registry. Ignored by the loader.",
+    "Camp-specific knowledge lives here, beside the data it describes,",
+    "rather than in a tracked comment."
+  ],
+  "areas": [
+    {
+      "code": "AREA1",          // unique, uppercase; a join key — never lowercase it
+      "name": "Display Name",
+      "map_x": 0.5,             // normalised 0-1 on the camp map canvas
+      "map_y": 0.25,
+      "sort_order": 1
+    }
+  ],
+  "units": [
+    {
+      "area": "AREA1",          // area CODE, not an id
+      "code": "unit-a",         // unique
+      "name": "Display Name",
+      "map_x": 0.51,
+      "map_y": 0.26,
+      "sleeps": 4,              // null = unknown; see below
+      "bathroom": "shared",     // none | private | shared
+      "bathroom_group": "grp-1",// units sharing one bathroom; "" for none
+      "parent_unit": "bldg-1",  // unit CODE of the containing building, or ""
+      "near_bathhouse": true,
+      "allocation_default": "family_pool",  // family_pool | staff_default
+      "is_container": false,    // true = a building row: never bookable, never counted
+      "notes": ""
+    }
+  ],
+  "aliases": [
+    {
+      "alias_string": "As CampMinder stores it",  // VERBATIM — do not trim
+      "member_units": ["unit-a"],                 // unit CODEs; 2+ denotes a merge
+      "valid_from_year": null,                    // null = unbounded
+      "valid_to_year": null
+    }
+  ]
+}
+```
+
+Everything references everything else by **code**, never by PocketBase id. That
+is what lets the file survive a database rebuild, and it matches the
+CampMinder-id discipline used across the rest of the schema.
+
+### Fields the loader sets itself
+
+- `is_active` — always `true` on create.
+- `is_confirmed` — always `false` on create. Every seeded value is a guess until
+  staff verify it against the actual cabin, so nothing the loader writes may
+  claim otherwise. Staff confirm through `/manage/lodging`.
+
+### Two traps encoded in the format
+
+**`null` numbers become `0`, and `0` means UNKNOWN.** PocketBase number columns
+are `NUMERIC DEFAULT 0 NOT NULL`, so an unset value stores as `0` — there is no
+NULL to read back. A `sleeps` of `0` therefore means "never observed", not "zero
+capacity", and the API maps it to `null` on the way out. Never render it as 0.
+
+**An unbounded alias window is `0`, not NULL.** The unique index is
+`(alias_string, valid_from_year)`, and an unset `valid_from_year` is stored as
+`0`. Idempotency has to look for `0`; a check against `null` would match nothing
+and a re-run would re-insert and die on the index. Two rows may legitimately
+share an `alias_string` when their year windows differ — that is how a rename is
+recorded.
+
+## Verifying
+
+```bash
+cd pocketbase && go test ./lodging/ -count=1     # loader unit tests
+./scripts/dev/verify-lodging-seed.sh             # boots a throwaway DB and loads the file
+./scripts/dev/verify-no-hardcoded-lodging.sh     # no unit names in source
+./scripts/dev/test-verify-no-hardcoded-lodging.sh
+```
+
+`verify-lodging-seed.sh` asserts the **database matches the file**, field by
+field, rather than hardcoding expected contents — hardcoding them would
+reproduce in this public repo precisely the strings the private file exists to
+keep out of it. It needs `config/lodging_registry.json` present and exits 2
+without it.
+
+## History
+
+The registry was seeded by migrations `1500000120` (areas + units),
+`1500000121` (aliases) and `1500000129` (intermediate containers and a
+bathroom-group fix). Those files still exist, emptied to no-ops: `_migrations`
+keys on filename, so every database that already applied them keeps both the row
+and the data it created, and PocketBase will not re-run an edited file. A fresh
+database gets the registry from the boot loader instead.

--- a/docs/reference/lodging-registry.md
+++ b/docs/reference/lodging-registry.md
@@ -75,20 +75,33 @@ First match wins:
 
 | Path | Context |
 |---|---|
-| `/app/config/lodging_registry.json` | Docker |
+| `/config/lodging_registry.json` | Docker — where `docker-compose.yml` mounts the private config directory |
+| `/app/config/lodging_registry.json` | Docker, alternate layout; matches `pocketbase/google/branding.go` |
 | `./config/lodging_registry.json` | run from the repo root |
 | `../config/lodging_registry.json` | run from `pocketbase/` |
 
 `scripts/setup/setup-local-config.sh` symlinks the file in from `kindred-local`,
 and `scripts/worktree/new.sh` does the same for a new worktree.
 
-> **Note:** `docker/Dockerfile.pocketbase` does not currently copy `config/` into
-> the image, so a **from-scratch production database** would boot with an empty
-> registry. Existing production rows are unaffected — they were created by the
-> seed migrations and nothing removes them. Worth fixing before anyone rebuilds
-> production from migrations alone.
+> **Note:** `docker/Dockerfile.pocketbase` does not copy `config/` into the
+> image — in production the file arrives through the compose mount
+> (`${APPDATA_DIR}/kindred/config` → `/config`), not through the build. Drop
+> `lodging_registry.json` into that host directory and a from-scratch
+> production database picks it up on boot; leave it out and production boots
+> with an empty registry.
+>
+> The absolute candidates are listed first deliberately. The runtime image sets
+> no `WORKDIR`, so the container runs from `/` and the *relative* `./config`
+> candidate resolves to `/config` as well — which means the loader would appear
+> to work in production while depending on a coincidence that any future
+> `WORKDIR` would silently break.
 
 ## File format
+
+The block below is annotated for documentation. **The loader uses Go's
+`encoding/json`, which rejects `//` comments** — strip them from the real file.
+A file that fails to parse is a logged warning, not a crash, so the symptom is
+an empty registry rather than an error anyone will see.
 
 ```jsonc
 {
@@ -161,8 +174,12 @@ recorded.
 
 ## Verifying
 
+Run from the repository root. The `cd` is in a subshell so the rest of the
+block still resolves — the paths below are relative to the root, not to
+`pocketbase/`.
+
 ```bash
-cd pocketbase && go test ./lodging/ -count=1     # loader unit tests
+(cd pocketbase && go test ./lodging/ -count=1)   # loader unit tests
 ./scripts/dev/verify-lodging-seed.sh             # boots a throwaway DB and loads the file
 ./scripts/dev/verify-no-hardcoded-lodging.sh     # no unit names in source
 ./scripts/dev/test-verify-no-hardcoded-lodging.sh

--- a/pocketbase/lodging/registry.go
+++ b/pocketbase/lodging/registry.go
@@ -21,6 +21,17 @@ const registryFileName = "lodging_registry.json"
 // Overridden in tests.
 var registryBasePath = "."
 
+// registryAbsoluteRoots are the absolute directories searched before the
+// working-directory-relative candidates. Overridden in tests.
+//
+// `/config` is where docker-compose.yml mounts the private config directory.
+// The relative `./config` candidate below happens to resolve to the same place
+// today, because the runtime image sets no WORKDIR and so runs from `/` — but
+// relying on that coincidence means any future WORKDIR silently breaks the only
+// candidate that fires, and main.go only warns. Naming it absolutely removes
+// the dependency on the working directory entirely.
+var registryAbsoluteRoots = []string{"/config", "/app/config"}
+
 // registryDoc is the on-disk shape of config/lodging_registry.json.
 //
 // Areas, units and aliases reference each other by CODE, never by PocketBase
@@ -84,11 +95,14 @@ type registryAlias struct {
 // Absent file is not an error: a clone without kindred-local boots with an
 // empty registry and a log line, the same graceful degradation branding has.
 func SeedRegistry(app core.App) error {
-	candidates := []string{
-		"/app/config/" + registryFileName,                                 // Docker production
+	candidates := make([]string, 0, len(registryAbsoluteRoots)+2)
+	for _, root := range registryAbsoluteRoots {
+		candidates = append(candidates, filepath.Join(root, registryFileName)) // Docker
+	}
+	candidates = append(candidates,
 		filepath.Join(registryBasePath, "config", registryFileName),       // from the repo root
 		filepath.Join(registryBasePath, "..", "config", registryFileName), // from pocketbase/
-	}
+	)
 
 	for _, path := range candidates {
 		if _, err := os.Stat(path); err != nil {
@@ -124,6 +138,13 @@ func seedRegistryFromFile(app core.App, path string) error {
 		return fmt.Errorf("parsing lodging registry %s: %w", path, parseErr)
 	}
 
+	// Whole-file checks first, so a bad file is rejected having written
+	// nothing. Doing this per-row mid-load would leave the registry half
+	// applied, and the codes are also what the passes below assume are unique.
+	if validErr := validateRegistry(&doc); validErr != nil {
+		return fmt.Errorf("invalid lodging registry %s: %w", path, validErr)
+	}
+
 	areaIDs, areasAdded, err := seedAreas(app, doc.Areas)
 	if err != nil {
 		return err
@@ -148,6 +169,113 @@ func seedRegistryFromFile(app core.App, path string) error {
 
 	slog.Info("lodging registry loaded", "path", path,
 		"areas_added", areasAdded, "units_added", unitsAdded, "aliases_added", aliasesAdded)
+	return nil
+}
+
+// validateRegistry checks the file against itself: no duplicate keys, and every
+// cross-reference resolvable within the file.
+//
+// The reference checks live here rather than mid-load because the loader's
+// "row already exists -> skip" is how idempotency works, which leaves it unable
+// to tell a re-run from a code duplicated inside one file. A duplicate would
+// otherwise be dropped in silence — the one malformed input that did not fail
+// loudly — while its parent_unit could still be applied to the row the first
+// entry created, merging two entries into one row.
+func validateRegistry(doc *registryDoc) error {
+	areaCodes, err := validateAreaCodes(doc.Areas)
+	if err != nil {
+		return err
+	}
+	unitCodes, err := validateUnitCodes(doc.Units)
+	if err != nil {
+		return err
+	}
+	if err := validateUnitReferences(doc.Units, areaCodes, unitCodes); err != nil {
+		return err
+	}
+	return validateAliases(doc.Aliases, unitCodes)
+}
+
+func validateAreaCodes(areas []registryArea) (map[string]bool, error) {
+	codes := make(map[string]bool, len(areas))
+	for _, a := range areas {
+		if a.Code == "" {
+			return nil, errors.New("an area has an empty code")
+		}
+		if codes[a.Code] {
+			return nil, fmt.Errorf("area code %q appears more than once", a.Code)
+		}
+		codes[a.Code] = true
+	}
+	return codes, nil
+}
+
+func validateUnitCodes(units []registryUnit) (map[string]bool, error) {
+	codes := make(map[string]bool, len(units))
+	for i := range units {
+		u := &units[i]
+		if u.Code == "" {
+			return nil, errors.New("a unit has an empty code")
+		}
+		if codes[u.Code] {
+			return nil, fmt.Errorf("unit code %q appears more than once", u.Code)
+		}
+		codes[u.Code] = true
+	}
+	return codes, nil
+}
+
+// validateUnitReferences runs after the full code set is known, so a unit may
+// name a parent declared later in the file.
+func validateUnitReferences(units []registryUnit, areaCodes, unitCodes map[string]bool) error {
+	for i := range units {
+		u := &units[i]
+		if !areaCodes[u.Area] {
+			return fmt.Errorf("unit %q names area %q, which the registry file does not define", u.Code, u.Area)
+		}
+		if u.ParentUnit == u.Code {
+			return fmt.Errorf("unit %q names itself as its parent", u.Code)
+		}
+		if u.ParentUnit != "" && !unitCodes[u.ParentUnit] {
+			return fmt.Errorf("unit %q names parent %q, which the registry file does not define", u.Code, u.ParentUnit)
+		}
+	}
+	return nil
+}
+
+// validateAliases keys duplicates on (alias_string, valid_from_year) — the pair
+// the unique index keys on, with an unbounded window stored as 0. Two rows
+// sharing a string with different windows is how a rename is recorded, and
+// stays legal.
+func validateAliases(aliases []registryAlias, unitCodes map[string]bool) error {
+	type aliasKey struct {
+		s string
+		y int
+	}
+	seen := make(map[aliasKey]bool, len(aliases))
+	for _, a := range aliases {
+		if a.AliasString == "" {
+			return errors.New("an alias has an empty alias_string")
+		}
+		fromYear := 0
+		if a.ValidFromYear != nil {
+			fromYear = *a.ValidFromYear
+		}
+		key := aliasKey{a.AliasString, fromYear}
+		if seen[key] {
+			return fmt.Errorf("alias %q with valid_from_year %d appears more than once", a.AliasString, fromYear)
+		}
+		seen[key] = true
+
+		if len(a.MemberUnits) == 0 {
+			return fmt.Errorf("alias %q has no member units", a.AliasString)
+		}
+		for _, code := range a.MemberUnits {
+			if !unitCodes[code] {
+				return fmt.Errorf("alias %q names unit %q, which the registry file does not define", a.AliasString, code)
+			}
+		}
+	}
 	return nil
 }
 
@@ -234,11 +362,36 @@ func seedUnits(
 	return added, createdCodes, nil
 }
 
+// wireUnitParents runs after every unit exists, so a unit may name a parent
+// declared later in the file.
+//
+// It wires a row when THIS run created either end of the link, and only over an
+// empty parent_unit. Both halves matter:
+//
+//   - Gating on the child alone left a deleted-and-recreated container with
+//     nothing in it. Deleting a container in /manage/lodging nulls its
+//     children's parent_unit; the next boot recreates the container, having
+//     thereby decided the row should exist, but the children were untouched
+//     this run and stayed orphaned with no error to say so.
+//   - Never overwriting a parent that is already set is what keeps this
+//     create-if-absent rather than an upsert. A parent staff cleared while the
+//     container still exists is a decision, not damage: neither end was created
+//     this run, so nothing here touches it.
 func wireUnitParents(app core.App, units []registryUnit, createdCodes map[string]bool) error {
 	// Indexed for the same reason as seedUnits above.
 	for i := range units {
 		u := &units[i]
-		if u.ParentUnit == "" {
+		if u.ParentUnit == "" || (!createdCodes[u.Code] && !createdCodes[u.ParentUnit]) {
+			continue
+		}
+
+		rec, err := findByUniqueCode(app, "lodging_units", u.Code)
+		if err != nil {
+			return err
+		}
+		// validateRegistry proved both codes are in the file and seedUnits
+		// created everything missing, so a nil here is not a bad file.
+		if rec == nil || rec.GetString("parent_unit") != "" {
 			continue
 		}
 
@@ -247,19 +400,10 @@ func wireUnitParents(app core.App, units []registryUnit, createdCodes map[string
 			return err
 		}
 		if parent == nil {
-			return fmt.Errorf("unit %q names parent %q, which the registry file does not define", u.Code, u.ParentUnit)
-		}
-		if !createdCodes[u.Code] {
-			continue
+			return fmt.Errorf("unit %q names parent %q, which is in the file but missing from the database",
+				u.Code, u.ParentUnit)
 		}
 
-		rec, err := findByUniqueCode(app, "lodging_units", u.Code)
-		if err != nil {
-			return err
-		}
-		if rec == nil || rec.GetString("parent_unit") == parent.Id {
-			continue
-		}
 		rec.Set("parent_unit", parent.Id)
 		if err := app.Save(rec); err != nil {
 			return fmt.Errorf("wiring parent of lodging unit %q: %w", u.Code, err)
@@ -301,9 +445,12 @@ func seedAliases(app core.App, aliases []registryAlias) (added int, err error) {
 				return 0, err
 			}
 			// Saving a short member list would quietly turn a merge into a
-			// smaller one, so an unknown code stops the load.
+			// smaller one, so a missing member stops the load. validateRegistry
+			// already proved the code is in the file, so this is a database
+			// that lost a row seedUnits created moments ago.
 			if unit == nil {
-				return 0, fmt.Errorf("alias %q names unit %q, which the registry file does not define", a.AliasString, code)
+				return 0, fmt.Errorf("alias %q names unit %q, which is in the file but missing from the database",
+					a.AliasString, code)
 			}
 			memberIDs = append(memberIDs, unit.Id)
 		}

--- a/pocketbase/lodging/registry.go
+++ b/pocketbase/lodging/registry.go
@@ -1,0 +1,359 @@
+package lodging
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// registryFileName is the private registry data file, carried in the
+// kindred-local repo and symlinked into config/ by
+// scripts/setup/setup-local-config.sh.
+const registryFileName = "lodging_registry.json"
+
+// registryBasePath is the base for the relative candidate paths below.
+// Overridden in tests.
+var registryBasePath = "."
+
+// registryDoc is the on-disk shape of config/lodging_registry.json.
+//
+// Areas, units and aliases reference each other by CODE, never by PocketBase
+// id — the same durable-key discipline the rest of this codebase uses, and the
+// only thing that lets the file survive a database rebuild.
+type registryDoc struct {
+	// Notes is camp-specific prose about the registry (naming history, units
+	// that look missing but are not). It travels with the data rather than
+	// with the code, because it names units and the repo is public. Unused by
+	// the loader; present so the file can carry its own documentation.
+	Notes   []string        `json:"_notes"`
+	Areas   []registryArea  `json:"areas"`
+	Units   []registryUnit  `json:"units"`
+	Aliases []registryAlias `json:"aliases"`
+}
+
+type registryArea struct {
+	Code      string   `json:"code"`
+	Name      string   `json:"name"`
+	MapX      *float64 `json:"map_x"`
+	MapY      *float64 `json:"map_y"`
+	SortOrder *int     `json:"sort_order"`
+}
+
+type registryUnit struct {
+	Area string   `json:"area"` // area code
+	Code string   `json:"code"`
+	Name string   `json:"name"`
+	MapX *float64 `json:"map_x"`
+	MapY *float64 `json:"map_y"`
+	// Sleeps is null when never observed. PocketBase number columns are
+	// `NUMERIC DEFAULT 0 NOT NULL`, so an unset value stores as 0 and
+	// consumers read 0 as UNKNOWN, not "zero capacity".
+	Sleeps            *int   `json:"sleeps"`
+	Bathroom          string `json:"bathroom"`
+	BathroomGroup     string `json:"bathroom_group"`
+	ParentUnit        string `json:"parent_unit"` // unit code, or "" for a top-level row
+	NearBathhouse     bool   `json:"near_bathhouse"`
+	AllocationDefault string `json:"allocation_default"`
+	IsContainer       bool   `json:"is_container"`
+	Notes             string `json:"notes"`
+}
+
+type registryAlias struct {
+	AliasString string   `json:"alias_string"`
+	MemberUnits []string `json:"member_units"` // unit codes; 2+ denotes a merge
+	// Null means unbounded. PocketBase stores that as 0, never NULL, which is
+	// also what the (alias_string, valid_from_year) unique index sees.
+	ValidFromYear *int `json:"valid_from_year"`
+	ValidToYear   *int `json:"valid_to_year"`
+}
+
+// SeedRegistry loads the private lodging registry into the database.
+//
+// It is deliberately NOT a migration. `_migrations` keys on filename and
+// applies once, so a migration that read an absent kindred-local file in CI
+// would be recorded as applied and never re-run when the file later appeared —
+// a silently empty registry. Running on every boot instead means the file
+// appearing later still takes effect.
+//
+// Absent file is not an error: a clone without kindred-local boots with an
+// empty registry and a log line, the same graceful degradation branding has.
+func SeedRegistry(app core.App) error {
+	candidates := []string{
+		"/app/config/" + registryFileName,                                 // Docker production
+		filepath.Join(registryBasePath, "config", registryFileName),       // from the repo root
+		filepath.Join(registryBasePath, "..", "config", registryFileName), // from pocketbase/
+	}
+
+	for _, path := range candidates {
+		if _, err := os.Stat(path); err != nil {
+			continue
+		}
+		return seedRegistryFromFile(app, path)
+	}
+
+	slog.Info("lodging registry file not found; registry left as-is",
+		"looked_for", registryFileName)
+	return nil
+}
+
+// seedRegistryFromFile is CREATE-IF-ABSENT, not a full upsert.
+//
+// The registry is staff-editable in /manage/lodging — coordinates get
+// corrected, cabins get confirmed. A loader that rewrote every field on boot
+// would silently undo that on the next restart. Skipping rows that already
+// exist also makes this an exact no-op on every database the seed migrations
+// already populated, which is every database that exists today.
+func seedRegistryFromFile(app core.App, path string) error {
+	data, err := os.ReadFile(path) //nolint:gosec // G304: path is from trusted local config
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			slog.Info("lodging registry file not found; registry left as-is", "path", path)
+			return nil
+		}
+		return fmt.Errorf("reading lodging registry %s: %w", path, err)
+	}
+
+	var doc registryDoc
+	if parseErr := json.Unmarshal(data, &doc); parseErr != nil {
+		return fmt.Errorf("parsing lodging registry %s: %w", path, parseErr)
+	}
+
+	areaIDs, areasAdded, err := seedAreas(app, doc.Areas)
+	if err != nil {
+		return err
+	}
+
+	unitsAdded, createdCodes, err := seedUnits(app, doc.Units, areaIDs)
+	if err != nil {
+		return err
+	}
+
+	// Second pass: wire parents now that every code has an id. Only rows this
+	// run created are wired — a parent staff cleared deliberately must stay
+	// cleared, same reason the field values above are left alone.
+	if wireErr := wireUnitParents(app, doc.Units, createdCodes); wireErr != nil {
+		return wireErr
+	}
+
+	aliasesAdded, err := seedAliases(app, doc.Aliases)
+	if err != nil {
+		return err
+	}
+
+	slog.Info("lodging registry loaded", "path", path,
+		"areas_added", areasAdded, "units_added", unitsAdded, "aliases_added", aliasesAdded)
+	return nil
+}
+
+func seedAreas(app core.App, areas []registryArea) (ids map[string]string, added int, err error) {
+	col, err := app.FindCollectionByNameOrId("lodging_areas")
+	if err != nil {
+		return nil, 0, fmt.Errorf("lodging_areas collection: %w", err)
+	}
+
+	ids = make(map[string]string, len(areas))
+	for _, a := range areas {
+		rec, err := findByUniqueCode(app, "lodging_areas", a.Code)
+		if err != nil {
+			return nil, 0, err
+		}
+		if rec == nil {
+			rec = core.NewRecord(col)
+			rec.Set("code", a.Code)
+			rec.Set("name", a.Name)
+			setIfPresentFloat(rec, "map_x", a.MapX)
+			setIfPresentFloat(rec, "map_y", a.MapY)
+			setIfPresentInt(rec, "sort_order", a.SortOrder)
+			if err := app.Save(rec); err != nil {
+				return nil, 0, fmt.Errorf("saving lodging area %q: %w", a.Code, err)
+			}
+			added++
+		}
+		ids[a.Code] = rec.Id
+	}
+	return ids, added, nil
+}
+
+func seedUnits(
+	app core.App, units []registryUnit, areaIDs map[string]string,
+) (added int, createdCodes map[string]bool, err error) {
+	col, err := app.FindCollectionByNameOrId("lodging_units")
+	if err != nil {
+		return 0, nil, fmt.Errorf("lodging_units collection: %w", err)
+	}
+
+	createdCodes = make(map[string]bool)
+	// Indexed rather than ranged by value: registryUnit is wide enough that
+	// copying one per iteration is a gocritic rangeValCopy finding.
+	for i := range units {
+		u := &units[i]
+		rec, err := findByUniqueCode(app, "lodging_units", u.Code)
+		if err != nil {
+			return 0, nil, err
+		}
+		if rec != nil {
+			continue
+		}
+
+		// `area` is a REQUIRED relation, so an unknown code has to fail here
+		// with the code in the message rather than as an opaque save error.
+		areaID, ok := areaIDs[u.Area]
+		if !ok {
+			return 0, nil, fmt.Errorf("unit %q names area %q, which the registry file does not define", u.Code, u.Area)
+		}
+
+		rec = core.NewRecord(col)
+		rec.Set("area", areaID)
+		rec.Set("code", u.Code)
+		rec.Set("name", u.Name)
+		setIfPresentFloat(rec, "map_x", u.MapX)
+		setIfPresentFloat(rec, "map_y", u.MapY)
+		setIfPresentInt(rec, "sleeps", u.Sleeps)
+		rec.Set("bathroom", u.Bathroom)
+		rec.Set("bathroom_group", u.BathroomGroup)
+		rec.Set("near_bathhouse", u.NearBathhouse)
+		rec.Set("allocation_default", u.AllocationDefault)
+		rec.Set("is_container", u.IsContainer)
+		rec.Set("notes", u.Notes)
+		rec.Set("is_active", true)
+		// Every seeded value is a guess until staff confirm it against the
+		// actual cabin, so nothing this loader writes may claim otherwise.
+		rec.Set("is_confirmed", false)
+		if err := app.Save(rec); err != nil {
+			return 0, nil, fmt.Errorf("saving lodging unit %q: %w", u.Code, err)
+		}
+		added++
+		createdCodes[u.Code] = true
+	}
+	return added, createdCodes, nil
+}
+
+func wireUnitParents(app core.App, units []registryUnit, createdCodes map[string]bool) error {
+	// Indexed for the same reason as seedUnits above.
+	for i := range units {
+		u := &units[i]
+		if u.ParentUnit == "" {
+			continue
+		}
+
+		parent, err := findByUniqueCode(app, "lodging_units", u.ParentUnit)
+		if err != nil {
+			return err
+		}
+		if parent == nil {
+			return fmt.Errorf("unit %q names parent %q, which the registry file does not define", u.Code, u.ParentUnit)
+		}
+		if !createdCodes[u.Code] {
+			continue
+		}
+
+		rec, err := findByUniqueCode(app, "lodging_units", u.Code)
+		if err != nil {
+			return err
+		}
+		if rec == nil || rec.GetString("parent_unit") == parent.Id {
+			continue
+		}
+		rec.Set("parent_unit", parent.Id)
+		if err := app.Save(rec); err != nil {
+			return fmt.Errorf("wiring parent of lodging unit %q: %w", u.Code, err)
+		}
+	}
+	return nil
+}
+
+func seedAliases(app core.App, aliases []registryAlias) (added int, err error) {
+	col, err := app.FindCollectionByNameOrId("lodging_unit_aliases")
+	if err != nil {
+		return 0, fmt.Errorf("lodging_unit_aliases collection: %w", err)
+	}
+
+	for _, a := range aliases {
+		// The unique index is (alias_string, valid_from_year), and an
+		// unbounded window is stored as 0 rather than NULL — so idempotency
+		// has to look for 0, not for null, or a re-run re-inserts and dies on
+		// the index.
+		fromYear := 0
+		if a.ValidFromYear != nil {
+			fromYear = *a.ValidFromYear
+		}
+
+		existing, err := findFirst(app, "lodging_unit_aliases",
+			"alias_string = {:s} && valid_from_year = {:y}",
+			map[string]any{"s": a.AliasString, "y": fromYear})
+		if err != nil {
+			return 0, err
+		}
+		if existing != nil {
+			continue
+		}
+
+		memberIDs := make([]string, 0, len(a.MemberUnits))
+		for _, code := range a.MemberUnits {
+			unit, err := findByUniqueCode(app, "lodging_units", code)
+			if err != nil {
+				return 0, err
+			}
+			// Saving a short member list would quietly turn a merge into a
+			// smaller one, so an unknown code stops the load.
+			if unit == nil {
+				return 0, fmt.Errorf("alias %q names unit %q, which the registry file does not define", a.AliasString, code)
+			}
+			memberIDs = append(memberIDs, unit.Id)
+		}
+
+		rec := core.NewRecord(col)
+		rec.Set("alias_string", a.AliasString)
+		rec.Set("member_units", memberIDs)
+		setIfPresentInt(rec, "valid_from_year", a.ValidFromYear)
+		setIfPresentInt(rec, "valid_to_year", a.ValidToYear)
+		if err := app.Save(rec); err != nil {
+			return 0, fmt.Errorf("saving lodging alias %q: %w", a.AliasString, err)
+		}
+		added++
+	}
+	return added, nil
+}
+
+func findByUniqueCode(app core.App, collection, code string) (*core.Record, error) {
+	return findFirst(app, collection, "code = {:c}", map[string]any{"c": code})
+}
+
+// findFirst returns (nil, nil) when nothing matches, and a real error
+// otherwise. PocketBase returns sql.ErrNoRows verbatim for "no match", so a
+// bare `err != nil -> not found` would read a malformed filter or a locked
+// database as "not seeded yet", insert a duplicate, and die on the unique
+// index with the actual cause hidden.
+func findFirst(
+	app core.App, collection, filter string, params map[string]any,
+) (*core.Record, error) {
+	rec, err := app.FindFirstRecordByFilter(collection, filter, params)
+	if err == nil {
+		return rec, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return nil, fmt.Errorf("querying %s: %w", collection, err)
+}
+
+func setIfPresentFloat(rec *core.Record, field string, v *float64) {
+	if v != nil {
+		rec.Set(field, *v)
+	}
+}
+
+// setIfPresentInt leaves the field unset when v is nil, so PocketBase's
+// `NUMERIC DEFAULT 0 NOT NULL` stores 0 — which is what "unknown" looks like
+// in this schema.
+func setIfPresentInt(rec *core.Record, field string, v *int) {
+	if v != nil {
+		rec.Set(field, *v)
+	}
+}

--- a/pocketbase/lodging/registry_test.go
+++ b/pocketbase/lodging/registry_test.go
@@ -1,0 +1,577 @@
+package lodging
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+)
+
+// setupRegistryCollections builds lodging_areas, lodging_units and
+// lodging_unit_aliases with the fields the loader writes, shaped like
+// production's (1500000116, 1500000117).
+//
+// The select fields carry their real value lists and the unique indexes are
+// real: a loader that wrote an invalid `bathroom`, or that re-inserted an alias
+// on a second run, must fail here rather than only in production.
+func setupRegistryCollections(t *testing.T, app core.App) {
+	t.Helper()
+
+	areas := core.NewBaseCollection("lodging_areas")
+	areas.Fields.Add(&core.TextField{Name: "name", Required: true})
+	areas.Fields.Add(&core.TextField{Name: "code", Required: true})
+	areas.Fields.Add(&core.NumberField{Name: "map_x"})
+	areas.Fields.Add(&core.NumberField{Name: "map_y"})
+	areas.Fields.Add(&core.NumberField{Name: "sort_order", OnlyInt: true})
+	areas.AddIndex("idx_lodging_areas_code", true, "code", "")
+	saveRegistryCollection(t, app, areas)
+
+	units := core.NewBaseCollection("lodging_units")
+	units.Fields.Add(&core.RelationField{
+		Name: "area", CollectionId: areas.Id, MaxSelect: 1, Required: true,
+	})
+	units.Fields.Add(&core.TextField{Name: "name", Required: true})
+	units.Fields.Add(&core.TextField{Name: "code", Required: true})
+	units.Fields.Add(&core.NumberField{Name: "map_x"})
+	units.Fields.Add(&core.NumberField{Name: "map_y"})
+	units.Fields.Add(&core.NumberField{Name: "sleeps", OnlyInt: true})
+	units.Fields.Add(&core.SelectField{
+		Name: "bathroom", Values: []string{"none", "private", "shared"}, MaxSelect: 1,
+	})
+	units.Fields.Add(&core.TextField{Name: "bathroom_group"})
+	units.Fields.Add(&core.BoolField{Name: "near_bathhouse"})
+	units.Fields.Add(&core.SelectField{
+		Name: "allocation_default", Values: []string{"family_pool", "staff_default"}, MaxSelect: 1,
+	})
+	units.Fields.Add(&core.BoolField{Name: "is_confirmed"})
+	units.Fields.Add(&core.BoolField{Name: "is_active"})
+	units.Fields.Add(&core.BoolField{Name: "is_container"})
+	units.Fields.Add(&core.TextField{Name: "notes"})
+	units.AddIndex("idx_lodging_units_code", true, "code", "")
+	saveRegistryCollection(t, app, units)
+
+	// Self-relation: needs the collection's own id, so it lands after the
+	// first save — same as production (1500000116).
+	units.Fields.Add(&core.RelationField{Name: "parent_unit", CollectionId: units.Id, MaxSelect: 1})
+	saveRegistryCollection(t, app, units)
+
+	aliases := core.NewBaseCollection("lodging_unit_aliases")
+	aliases.Fields.Add(&core.TextField{Name: "alias_string", Required: true})
+	aliases.Fields.Add(&core.RelationField{Name: "member_units", CollectionId: units.Id, MaxSelect: 20})
+	aliases.Fields.Add(&core.NumberField{Name: "valid_from_year", OnlyInt: true})
+	aliases.Fields.Add(&core.NumberField{Name: "valid_to_year", OnlyInt: true})
+	aliases.AddIndex("idx_lodging_alias_string_from", true, "alias_string, valid_from_year", "")
+	saveRegistryCollection(t, app, aliases)
+}
+
+func saveRegistryCollection(t *testing.T, app core.App, col *core.Collection) {
+	t.Helper()
+	if err := app.Save(col); err != nil {
+		t.Fatalf("save collection %s: %v", col.Name, err)
+	}
+}
+
+func newRegistryTestApp(t *testing.T) core.App {
+	t.Helper()
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+	setupRegistryCollections(t, app)
+	return app
+}
+
+// writeRegistry drops a registry file into a temp dir and returns its path.
+func writeRegistry(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "lodging_registry.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+	return path
+}
+
+func countRecords(t *testing.T, app core.App, collection string) int {
+	t.Helper()
+	recs, err := app.FindAllRecords(collection)
+	if err != nil {
+		t.Fatalf("FindAllRecords(%s): %v", collection, err)
+	}
+	return len(recs)
+}
+
+func findByCode(t *testing.T, app core.App, collection, code string) *core.Record {
+	t.Helper()
+	rec, err := app.FindFirstRecordByFilter(collection, "code = {:c}", map[string]any{"c": code})
+	if err != nil {
+		t.Fatalf("find %s code=%s: %v", collection, code, err)
+	}
+	return rec
+}
+
+// captureLogs redirects slog to a buffer for the duration of the test.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return buf
+}
+
+// A minimal but structurally complete registry: one area, a container with two
+// children (the second declared BEFORE its parent, so two-pass wiring is
+// exercised), and one single-member plus one multi-member alias.
+const fixtureRegistry = `{
+  "areas": [
+    {"code": "AREA1", "name": "First Area", "map_x": 0.5, "map_y": 0.25, "sort_order": 1}
+  ],
+  "units": [
+    {"area": "AREA1", "code": "child-a", "name": "Child A", "map_x": 0.51, "map_y": 0.26,
+     "sleeps": 4, "bathroom": "shared", "bathroom_group": "grp-1", "parent_unit": "building-1",
+     "near_bathhouse": true, "allocation_default": "family_pool", "is_container": false,
+     "notes": "a note"},
+    {"area": "AREA1", "code": "building-1", "name": "Building One", "map_x": 0.5, "map_y": 0.25,
+     "sleeps": null, "bathroom": "none", "bathroom_group": "", "parent_unit": "",
+     "near_bathhouse": false, "allocation_default": "family_pool", "is_container": true,
+     "notes": ""},
+    {"area": "AREA1", "code": "child-b", "name": "Child B", "map_x": 0.52, "map_y": 0.27,
+     "sleeps": 2, "bathroom": "shared", "bathroom_group": "grp-1", "parent_unit": "building-1",
+     "near_bathhouse": false, "allocation_default": "staff_default", "is_container": false,
+     "notes": ""}
+  ],
+  "aliases": [
+    {"alias_string": "Child A", "member_units": ["child-a"],
+     "valid_from_year": null, "valid_to_year": null},
+    {"alias_string": "Building One", "member_units": ["child-a", "child-b"],
+     "valid_from_year": 2025, "valid_to_year": null}
+  ]
+}`
+
+// withRegistryBasePath points the path resolution at a temp tree for one test.
+func withRegistryBasePath(t *testing.T, base string) {
+	t.Helper()
+	prev := registryBasePath
+	registryBasePath = base
+	t.Cleanup(func() { registryBasePath = prev })
+}
+
+// SeedRegistry is what main.go actually calls, so its path resolution needs
+// covering too: the loader finding nothing because it looked in the wrong place
+// is indistinguishable, from the outside, from a clone with no private config.
+func TestSeedRegistryResolvesConfigUnderTheWorkingDirectory(t *testing.T) {
+	app := newRegistryTestApp(t)
+
+	base := t.TempDir()
+	if err := os.Mkdir(filepath.Join(base, "config"), 0o750); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(base, "config", "lodging_registry.json"), []byte(fixtureRegistry), 0o600,
+	); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+	withRegistryBasePath(t, base)
+
+	if err := SeedRegistry(app); err != nil {
+		t.Fatalf("SeedRegistry: %v", err)
+	}
+	if n := countRecords(t, app, "lodging_units"); n != 3 {
+		t.Errorf("got %d units, want 3 — the file under ./config was not found", n)
+	}
+}
+
+// A clone without kindred-local: nothing on any candidate path.
+func TestSeedRegistryWithNoConfigAnywhereIsANoOp(t *testing.T) {
+	app := newRegistryTestApp(t)
+	logs := captureLogs(t)
+	withRegistryBasePath(t, t.TempDir())
+
+	if err := SeedRegistry(app); err != nil {
+		t.Fatalf("no config anywhere should not be an error, got: %v", err)
+	}
+	if n := countRecords(t, app, "lodging_units"); n != 0 {
+		t.Errorf("created %d units with no registry file, want 0", n)
+	}
+	if !bytes.Contains(logs.Bytes(), []byte("lodging registry")) {
+		t.Errorf("no registry file logged nothing; got:\n%s", logs.String())
+	}
+}
+
+func TestSeedRegistryAbsentFileIsANoOp(t *testing.T) {
+	app := newRegistryTestApp(t)
+	logs := captureLogs(t)
+
+	missing := filepath.Join(t.TempDir(), "does_not_exist.json")
+	if err := seedRegistryFromFile(app, missing); err != nil {
+		t.Fatalf("absent file should not be an error, got: %v", err)
+	}
+
+	if n := countRecords(t, app, "lodging_units"); n != 0 {
+		t.Errorf("absent file created %d units, want 0", n)
+	}
+	if n := countRecords(t, app, "lodging_areas"); n != 0 {
+		t.Errorf("absent file created %d areas, want 0", n)
+	}
+	// Graceful degradation has to be visible, or an empty registry looks like
+	// a working one. Same contract branding already has.
+	if !bytes.Contains(logs.Bytes(), []byte("lodging registry")) {
+		t.Errorf("absent file logged nothing about the registry; got:\n%s", logs.String())
+	}
+}
+
+func TestSeedRegistryCreatesAreasUnitsAndAliases(t *testing.T) {
+	app := newRegistryTestApp(t)
+
+	if err := seedRegistryFromFile(app, writeRegistry(t, fixtureRegistry)); err != nil {
+		t.Fatalf("seedRegistryFromFile: %v", err)
+	}
+
+	if n := countRecords(t, app, "lodging_areas"); n != 1 {
+		t.Errorf("got %d areas, want 1", n)
+	}
+	if n := countRecords(t, app, "lodging_units"); n != 3 {
+		t.Errorf("got %d units, want 3", n)
+	}
+	if n := countRecords(t, app, "lodging_unit_aliases"); n != 2 {
+		t.Errorf("got %d aliases, want 2", n)
+	}
+
+	area := findByCode(t, app, "lodging_areas", "AREA1")
+	if got := area.GetString("name"); got != "First Area" {
+		t.Errorf("area name = %q, want %q", got, "First Area")
+	}
+	if got := area.GetFloat("map_x"); got != 0.5 {
+		t.Errorf("area map_x = %v, want 0.5", got)
+	}
+	if got := area.GetInt("sort_order"); got != 1 {
+		t.Errorf("area sort_order = %d, want 1", got)
+	}
+
+	child := findByCode(t, app, "lodging_units", "child-a")
+	if got := child.GetString("name"); got != "Child A" {
+		t.Errorf("unit name = %q, want %q", got, "Child A")
+	}
+	if got := child.GetString("area"); got != area.Id {
+		t.Errorf("unit area = %q, want the area record id %q", got, area.Id)
+	}
+	if got := child.GetInt("sleeps"); got != 4 {
+		t.Errorf("unit sleeps = %d, want 4", got)
+	}
+	if got := child.GetString("bathroom"); got != "shared" {
+		t.Errorf("unit bathroom = %q, want shared", got)
+	}
+	if got := child.GetString("bathroom_group"); got != "grp-1" {
+		t.Errorf("unit bathroom_group = %q, want grp-1", got)
+	}
+	if !child.GetBool("near_bathhouse") {
+		t.Error("unit near_bathhouse = false, want true")
+	}
+	if got := child.GetString("allocation_default"); got != "family_pool" {
+		t.Errorf("unit allocation_default = %q, want family_pool", got)
+	}
+	if got := child.GetString("notes"); got != "a note" {
+		t.Errorf("unit notes = %q, want %q", got, "a note")
+	}
+	if !child.GetBool("is_active") {
+		t.Error("seeded unit is_active = false, want true")
+	}
+	// Every seeded value is a guess until staff say otherwise (1500000120).
+	if child.GetBool("is_confirmed") {
+		t.Error("seeded unit is_confirmed = true, want false")
+	}
+	if child.GetBool("is_container") {
+		t.Error("child-a is_container = true, want false")
+	}
+	if !findByCode(t, app, "lodging_units", "building-1").GetBool("is_container") {
+		t.Error("building-1 is_container = false, want true")
+	}
+}
+
+func TestSeedRegistryWiresParentDeclaredAfterChild(t *testing.T) {
+	app := newRegistryTestApp(t)
+
+	if err := seedRegistryFromFile(app, writeRegistry(t, fixtureRegistry)); err != nil {
+		t.Fatalf("seedRegistryFromFile: %v", err)
+	}
+
+	building := findByCode(t, app, "lodging_units", "building-1")
+	// child-a is listed BEFORE building-1 in the file: a single-pass loader
+	// would have no id to point at and would leave the relation empty.
+	for _, code := range []string{"child-a", "child-b"} {
+		if got := findByCode(t, app, "lodging_units", code).GetString("parent_unit"); got != building.Id {
+			t.Errorf("%s parent_unit = %q, want %q", code, got, building.Id)
+		}
+	}
+	if got := building.GetString("parent_unit"); got != "" {
+		t.Errorf("building-1 parent_unit = %q, want empty", got)
+	}
+}
+
+// An unset `sleeps` must land as PocketBase's 0, which consumers read as
+// UNKNOWN. The JSON carries null; a loader that coerced null to a real 0
+// through some other path would be indistinguishable here, but a loader that
+// rejected null or wrote garbage would not.
+func TestSeedRegistryNullSleepsStoresZero(t *testing.T) {
+	app := newRegistryTestApp(t)
+
+	if err := seedRegistryFromFile(app, writeRegistry(t, fixtureRegistry)); err != nil {
+		t.Fatalf("seedRegistryFromFile: %v", err)
+	}
+
+	if got := findByCode(t, app, "lodging_units", "building-1").GetInt("sleeps"); got != 0 {
+		t.Errorf("null sleeps stored as %d, want 0 (unknown)", got)
+	}
+}
+
+// PocketBase stores an unset number as 0, never NULL. An alias whose window is
+// unbounded must therefore be written and re-found as 0 — the trap 1500000121
+// documents, and the reason a re-run would otherwise die on the unique index.
+func TestSeedRegistryUnboundedAliasYearsStoreZero(t *testing.T) {
+	app := newRegistryTestApp(t)
+
+	if err := seedRegistryFromFile(app, writeRegistry(t, fixtureRegistry)); err != nil {
+		t.Fatalf("seedRegistryFromFile: %v", err)
+	}
+
+	unbounded, err := app.FindFirstRecordByFilter(
+		"lodging_unit_aliases", "alias_string = {:s}", map[string]any{"s": "Child A"},
+	)
+	if err != nil {
+		t.Fatalf("find alias: %v", err)
+	}
+	if got := unbounded.GetInt("valid_from_year"); got != 0 {
+		t.Errorf("unbounded valid_from_year = %d, want 0", got)
+	}
+	if got := unbounded.GetInt("valid_to_year"); got != 0 {
+		t.Errorf("unbounded valid_to_year = %d, want 0", got)
+	}
+
+	bounded, err := app.FindFirstRecordByFilter(
+		"lodging_unit_aliases", "alias_string = {:s}", map[string]any{"s": "Building One"},
+	)
+	if err != nil {
+		t.Fatalf("find bounded alias: %v", err)
+	}
+	if got := bounded.GetInt("valid_from_year"); got != 2025 {
+		t.Errorf("bounded valid_from_year = %d, want 2025", got)
+	}
+}
+
+func TestSeedRegistryAliasMembersResolveToUnitIDs(t *testing.T) {
+	app := newRegistryTestApp(t)
+
+	if err := seedRegistryFromFile(app, writeRegistry(t, fixtureRegistry)); err != nil {
+		t.Fatalf("seedRegistryFromFile: %v", err)
+	}
+
+	merge, err := app.FindFirstRecordByFilter(
+		"lodging_unit_aliases", "alias_string = {:s}", map[string]any{"s": "Building One"},
+	)
+	if err != nil {
+		t.Fatalf("find alias: %v", err)
+	}
+
+	want := []string{
+		findByCode(t, app, "lodging_units", "child-a").Id,
+		findByCode(t, app, "lodging_units", "child-b").Id,
+	}
+	got := merge.GetStringSlice("member_units")
+	if len(got) != len(want) {
+		t.Fatalf("member_units = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("member_units[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestSeedRegistryIsIdempotent(t *testing.T) {
+	app := newRegistryTestApp(t)
+	path := writeRegistry(t, fixtureRegistry)
+
+	if err := seedRegistryFromFile(app, path); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	if err := seedRegistryFromFile(app, path); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+
+	if n := countRecords(t, app, "lodging_areas"); n != 1 {
+		t.Errorf("after two runs: %d areas, want 1", n)
+	}
+	if n := countRecords(t, app, "lodging_units"); n != 3 {
+		t.Errorf("after two runs: %d units, want 3", n)
+	}
+	if n := countRecords(t, app, "lodging_unit_aliases"); n != 2 {
+		t.Errorf("after two runs: %d aliases, want 2", n)
+	}
+}
+
+// The registry is staff-editable in /manage/lodging. A loader that rewrote
+// every field on boot would silently undo a confirmation or a corrected
+// coordinate on the next restart, which is why this is create-if-absent and
+// not a full upsert.
+func TestSeedRegistryPreservesStaffEdits(t *testing.T) {
+	app := newRegistryTestApp(t)
+	path := writeRegistry(t, fixtureRegistry)
+
+	if err := seedRegistryFromFile(app, path); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+
+	edited := findByCode(t, app, "lodging_units", "child-a")
+	edited.Set("sleeps", 9)
+	edited.Set("is_confirmed", true)
+	edited.Set("map_x", 0.9)
+	edited.Set("notes", "staff corrected this")
+	if err := app.Save(edited); err != nil {
+		t.Fatalf("save staff edit: %v", err)
+	}
+
+	if err := seedRegistryFromFile(app, path); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+
+	after := findByCode(t, app, "lodging_units", "child-a")
+	if got := after.GetInt("sleeps"); got != 9 {
+		t.Errorf("sleeps = %d after re-seed, want the staff value 9", got)
+	}
+	if !after.GetBool("is_confirmed") {
+		t.Error("is_confirmed reverted to false, want the staff value true")
+	}
+	if got := after.GetFloat("map_x"); got != 0.9 {
+		t.Errorf("map_x = %v after re-seed, want the staff value 0.9", got)
+	}
+	if got := after.GetString("notes"); got != "staff corrected this" {
+		t.Errorf("notes = %q after re-seed, want the staff value", got)
+	}
+}
+
+// A parent_unit staff cleared deliberately must not be silently re-wired on the
+// next boot, for the same reason as the field edits above.
+func TestSeedRegistryDoesNotRewireAnExistingParent(t *testing.T) {
+	app := newRegistryTestApp(t)
+	path := writeRegistry(t, fixtureRegistry)
+
+	if err := seedRegistryFromFile(app, path); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+
+	detached := findByCode(t, app, "lodging_units", "child-b")
+	detached.Set("parent_unit", "")
+	if err := app.Save(detached); err != nil {
+		t.Fatalf("clear parent: %v", err)
+	}
+
+	if err := seedRegistryFromFile(app, path); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+
+	if got := findByCode(t, app, "lodging_units", "child-b").GetString("parent_unit"); got != "" {
+		t.Errorf("parent_unit = %q after re-seed, want it left cleared", got)
+	}
+}
+
+func TestSeedRegistryMalformedJSONErrorsWithoutWriting(t *testing.T) {
+	app := newRegistryTestApp(t)
+
+	err := seedRegistryFromFile(app, writeRegistry(t, `{"areas": [ NOT JSON`))
+	if err == nil {
+		t.Fatal("malformed JSON returned nil, want an error")
+	}
+	if n := countRecords(t, app, "lodging_areas"); n != 0 {
+		t.Errorf("malformed JSON created %d areas, want 0", n)
+	}
+}
+
+// A unit naming an area that is not in the file is a broken registry, not a
+// unit to create area-less: `area` is a REQUIRED relation, so the alternative
+// is a save that fails deep in the loop with no useful message.
+func TestSeedRegistryUnknownAreaCodeIsAnError(t *testing.T) {
+	app := newRegistryTestApp(t)
+
+	body := `{"areas": [], "units": [
+	  {"area": "NOPE", "code": "orphan", "name": "Orphan", "bathroom": "none",
+	   "allocation_default": "family_pool"}
+	], "aliases": []}`
+
+	err := seedRegistryFromFile(app, writeRegistry(t, body))
+	if err == nil {
+		t.Fatal("unknown area code returned nil, want an error")
+	}
+	if n := countRecords(t, app, "lodging_units"); n != 0 {
+		t.Errorf("unknown area code created %d units, want 0", n)
+	}
+}
+
+func TestSeedRegistryUnknownParentCodeIsAnError(t *testing.T) {
+	app := newRegistryTestApp(t)
+
+	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
+	  {"area": "AREA1", "code": "orphan", "name": "Orphan", "parent_unit": "nope",
+	   "bathroom": "none", "allocation_default": "family_pool"}
+	], "aliases": []}`
+
+	if err := seedRegistryFromFile(app, writeRegistry(t, body)); err == nil {
+		t.Fatal("unknown parent code returned nil, want an error")
+	}
+}
+
+// An alias pointing at a unit code the file does not define would otherwise
+// save with a short member list — a merge quietly missing a room.
+func TestSeedRegistryUnknownAliasMemberIsAnError(t *testing.T) {
+	app := newRegistryTestApp(t)
+
+	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
+	  {"area": "AREA1", "code": "real", "name": "Real", "bathroom": "none",
+	   "allocation_default": "family_pool"}
+	], "aliases": [
+	  {"alias_string": "Broken", "member_units": ["real", "ghost"]}
+	]}`
+
+	if err := seedRegistryFromFile(app, writeRegistry(t, body)); err == nil {
+		t.Fatal("unknown alias member returned nil, want an error")
+	}
+	if n := countRecords(t, app, "lodging_unit_aliases"); n != 0 {
+		t.Errorf("unknown alias member created %d aliases, want 0", n)
+	}
+}
+
+// Two alias rows may share a string when their windows differ (a rename), so
+// idempotency has to key on the pair the unique index keys on.
+func TestSeedRegistrySameAliasStringDifferentWindowsBothLand(t *testing.T) {
+	app := newRegistryTestApp(t)
+
+	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
+	  {"area": "AREA1", "code": "old", "name": "Old", "bathroom": "none",
+	   "allocation_default": "family_pool"},
+	  {"area": "AREA1", "code": "new", "name": "New", "bathroom": "none",
+	   "allocation_default": "family_pool"}
+	], "aliases": [
+	  {"alias_string": "Renamed", "member_units": ["old"],
+	   "valid_from_year": null, "valid_to_year": 2024},
+	  {"alias_string": "Renamed", "member_units": ["new"],
+	   "valid_from_year": 2025, "valid_to_year": null}
+	]}`
+	path := writeRegistry(t, body)
+
+	if err := seedRegistryFromFile(app, path); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	if n := countRecords(t, app, "lodging_unit_aliases"); n != 2 {
+		t.Fatalf("got %d aliases, want 2 (one per window)", n)
+	}
+	if err := seedRegistryFromFile(app, path); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if n := countRecords(t, app, "lodging_unit_aliases"); n != 2 {
+		t.Errorf("after two runs: %d aliases, want 2", n)
+	}
+}

--- a/pocketbase/lodging/registry_test.go
+++ b/pocketbase/lodging/registry_test.go
@@ -161,6 +161,15 @@ func withRegistryBasePath(t *testing.T, base string) {
 	t.Cleanup(func() { registryBasePath = prev })
 }
 
+// withRegistryAbsoluteRoots swaps the absolute candidate directories, which are
+// otherwise unreachable from a test that cannot write to / or /app.
+func withRegistryAbsoluteRoots(t *testing.T, roots []string) {
+	t.Helper()
+	prev := registryAbsoluteRoots
+	registryAbsoluteRoots = roots
+	t.Cleanup(func() { registryAbsoluteRoots = prev })
+}
+
 // SeedRegistry is what main.go actually calls, so its path resolution needs
 // covering too: the loader finding nothing because it looked in the wrong place
 // is indistinguishable, from the outside, from a clone with no private config.
@@ -573,5 +582,139 @@ func TestSeedRegistrySameAliasStringDifferentWindowsBothLand(t *testing.T) {
 	}
 	if n := countRecords(t, app, "lodging_unit_aliases"); n != 2 {
 		t.Errorf("after two runs: %d aliases, want 2", n)
+	}
+}
+
+// --- file-level validation -------------------------------------------------
+//
+// The loader's "row already exists -> skip" is how idempotency works across
+// runs. That makes it structurally unable to tell a re-run from a code
+// duplicated INSIDE one file, so a duplicate is dropped with no error and no
+// log line -- while an unknown area, parent or alias member all hard-fail.
+// The file is hand-maintained, so the slip is realistic and the silence is the
+// bug. Validation runs before any write, so a bad file changes nothing.
+
+func TestSeedRegistryDuplicateUnitCodeIsAnError(t *testing.T) {
+	app := newRegistryTestApp(t)
+
+	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
+	  {"area": "AREA1", "code": "twin", "name": "First", "bathroom": "none",
+	   "allocation_default": "family_pool"},
+	  {"area": "AREA1", "code": "twin", "name": "Second", "bathroom": "none",
+	   "allocation_default": "family_pool"}
+	], "aliases": []}`
+
+	err := seedRegistryFromFile(app, writeRegistry(t, body))
+	if err == nil {
+		t.Fatal("duplicate unit code returned nil, want an error")
+	}
+	if n := countRecords(t, app, "lodging_units"); n != 0 {
+		t.Errorf("duplicate unit code created %d units, want 0 (validation precedes writes)", n)
+	}
+}
+
+func TestSeedRegistryDuplicateAreaCodeIsAnError(t *testing.T) {
+	app := newRegistryTestApp(t)
+
+	body := `{"areas": [
+	  {"code": "AREA1", "name": "First"},
+	  {"code": "AREA1", "name": "Second"}
+	], "units": [], "aliases": []}`
+
+	err := seedRegistryFromFile(app, writeRegistry(t, body))
+	if err == nil {
+		t.Fatal("duplicate area code returned nil, want an error")
+	}
+	if n := countRecords(t, app, "lodging_areas"); n != 0 {
+		t.Errorf("duplicate area code created %d areas, want 0", n)
+	}
+}
+
+// Two alias rows may legitimately share a string when their windows differ,
+// so the duplicate check has to key on the pair the unique index keys on --
+// the same pair TestSeedRegistrySameAliasStringDifferentWindowsBothLand
+// requires to stay legal.
+func TestSeedRegistryDuplicateAliasWindowIsAnError(t *testing.T) {
+	app := newRegistryTestApp(t)
+
+	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
+	  {"area": "AREA1", "code": "real", "name": "Real", "bathroom": "none",
+	   "allocation_default": "family_pool"}
+	], "aliases": [
+	  {"alias_string": "Same", "member_units": ["real"], "valid_from_year": 2025},
+	  {"alias_string": "Same", "member_units": ["real"], "valid_from_year": 2025}
+	]}`
+
+	err := seedRegistryFromFile(app, writeRegistry(t, body))
+	if err == nil {
+		t.Fatal("duplicate (alias_string, valid_from_year) returned nil, want an error")
+	}
+	if n := countRecords(t, app, "lodging_unit_aliases"); n != 0 {
+		t.Errorf("duplicate alias created %d aliases, want 0", n)
+	}
+}
+
+// --- parent wiring ---------------------------------------------------------
+
+// Deleting a container in /manage/lodging nulls its children's parent_unit as
+// a side effect. The loader then recreates the container -- so it has already
+// decided the row should exist -- but wiring gated only on "the CHILD was
+// created this run" left those children permanently orphaned: a restored
+// building with nothing in it, and no error to say so.
+//
+// This is distinct from TestSeedRegistryDoesNotRewireAnExistingParent, where
+// the container was never deleted and the cleared parent is a staff decision
+// the loader must respect.
+func TestSeedRegistryRewiresChildrenOfARecreatedContainer(t *testing.T) {
+	app := newRegistryTestApp(t)
+	path := writeRegistry(t, fixtureRegistry)
+
+	if err := seedRegistryFromFile(app, path); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+
+	container := findByCode(t, app, "lodging_units", "building-1")
+	if err := app.Delete(container); err != nil {
+		t.Fatalf("delete container: %v", err)
+	}
+
+	if err := seedRegistryFromFile(app, path); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+
+	recreated := findByCode(t, app, "lodging_units", "building-1")
+	for _, code := range []string{"child-a", "child-b"} {
+		if got := findByCode(t, app, "lodging_units", code).GetString("parent_unit"); got != recreated.Id {
+			t.Errorf("%s.parent_unit = %q after the container was recreated, want %q",
+				code, got, recreated.Id)
+		}
+	}
+}
+
+// --- path resolution -------------------------------------------------------
+
+// The absolute candidates must be found on their own merit. In the production
+// image the container's working directory is "/", which makes the RELATIVE
+// "./config" candidate coincidentally equal the real "/config" mount -- so a
+// future WORKDIR would silently break the only candidate that actually fires.
+func TestSeedRegistryResolvesAbsoluteConfigRoot(t *testing.T) {
+	app := newRegistryTestApp(t)
+
+	absRoot := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(absRoot, registryFileName), []byte(fixtureRegistry), 0o600,
+	); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+	withRegistryAbsoluteRoots(t, []string{absRoot})
+	// Point the relative candidates at an empty tree, so only the absolute
+	// root can satisfy this.
+	withRegistryBasePath(t, t.TempDir())
+
+	if err := SeedRegistry(app); err != nil {
+		t.Fatalf("SeedRegistry: %v", err)
+	}
+	if n := countRecords(t, app, "lodging_units"); n != 3 {
+		t.Errorf("got %d units, want 3 — the absolute config root was not searched", n)
 	}
 }

--- a/pocketbase/main.go
+++ b/pocketbase/main.go
@@ -139,6 +139,25 @@ func main() {
 		return e.Next()
 	})
 
+	// Lodging registry loader. The unit registry is camp-identifying private
+	// data carried in kindred-local, not source, so it cannot be seeded by a
+	// migration: `_migrations` keys on filename and applies once, so a
+	// migration that read an absent private file in CI would be recorded as
+	// applied and never re-run when the file later appeared — a silently empty
+	// registry. Running on every boot means a file that shows up later still
+	// takes effect. Absent file is a logged no-op, the same graceful
+	// degradation branding has. See docs/reference/lodging-registry.md.
+	//
+	// Warn rather than fail: a clone without the private config must still
+	// boot, and an unreadable registry should not take the whole service down.
+	// The log line is the signal that the registry is empty on purpose.
+	app.OnServe().BindFunc(func(e *core.ServeEvent) error {
+		if err := lodging.SeedRegistry(e.App); err != nil {
+			slog.Warn("lodging registry load failed", "err", err)
+		}
+		return e.Next()
+	})
+
 	// Config initialization now handled by migrations
 
 	// ---------------------------------------------------------------

--- a/pocketbase/pb_migrations/1500000116_lodging_areas_units.js
+++ b/pocketbase/pb_migrations/1500000116_lodging_areas_units.js
@@ -2,8 +2,10 @@
 /**
  * Migration: lodging_areas + lodging_units
  *
- * Canonical registry of weekend-program housing. Seeded by 1500000120 but fully
- * editable in the Family Camp admin UI — no unit list lives in source code.
+ * Canonical registry of weekend-program housing. Populated on boot from the
+ * private config/lodging_registry.json (docs/reference/lodging-registry.md),
+ * and fully editable in the Family Camp admin UI — no unit list lives in
+ * source code. 1500000120 seeded it until the data moved out of this repo.
  *
  * lodging_units holds ATOMIC rooms. Merges (e.g. "Tenaya 1and2") are separate
  * rows in lodging_merges, not parent activations, because merges are frequently

--- a/pocketbase/pb_migrations/1500000120_seed_lodging_registry.js
+++ b/pocketbase/pb_migrations/1500000120_seed_lodging_registry.js
@@ -1,257 +1,39 @@
 /// <reference path="../pb_data/types.d.ts" />
 /**
- * Seed: lodging_areas + lodging_units
+ * Seed: lodging_areas + lodging_units — DATA REMOVED, see below.
  *
- * Coordinates are label positions from the 2026 camp map, normalised to 0-1 on
- * its 792x612 canvas. `sleeps` is seeded from observed PEAK occupancy across
- * 2024-2025 assignments and is a GUESS — every row is written with
- * is_confirmed: false so the UI can flag unverified values. PocketBase number
- * fields are `NUMERIC DEFAULT 0 NOT NULL`, so an unset `sleeps` stores as 0,
- * not null — consumers must treat 0 as "unknown", not "zero capacity".
+ * This migration originally carried the entire unit registry as literals. The
+ * repository is public and the registry is camp-identifying, so the data moved
+ * to `config/lodging_registry.json` — private, carried in the kindred-local
+ * repo — and is loaded on every boot by `pocketbase/lodging/registry.go`.
+ * Format, semantics and the loader's contract: `docs/reference/lodging-registry.md`.
+ * The camp-specific notes that used to head this file (naming history, rooms
+ * that look missing but are not) travelled with the data, into that file's
+ * `_notes` block.
  *
- * Map notes worth preserving:
- *  - Ridge Side cabins are bare letters A-M on the map; River Side are v-prefixed
- *    vA-vM. The "v" is shorthand added when boys'/girls' side were renamed to
- *    Ridge/River (both start with R). 13 cabins per side.
- *  - Manzanita 6 does NOT exist — the map shows M1-M5 and M7.
- *  - Health Center Upstairs is 1-6; 2 is real but unused in 2024-25, so sleeps is null.
- *  - Tawonga Village is the canonical name (matches the map). "Teen Village" is
- *    an alias used by the family-camp field. TV5 subdivides into 5a/5b.
- *  - Wawona is the OLD Doctor's House (Golden Triangle), renamed in 2025, and
- *    splits Front(1)/Back(2). The bare "Doctor's House" is the NEWER building at
- *    the Health Center. They are distinct and were occupied simultaneously in
- *    2022, 2023 and 2024.
+ * WHY A BOOT LOADER AND NOT A FILE-READING MIGRATION. `_migrations` keys on
+ * FILENAME and applies once. A migration that read an absent private file in
+ * CI would be recorded as applied and never re-run when the file later
+ * appeared — a silently empty registry.
  *
- * This seed is idempotent: it skips any unit whose code already exists, so it is
- * safe on a database where an earlier partial run happened.
+ * WHY THIS FILE STAYS, EMPTY. `_migrations` keying on filename cuts both ways:
+ * every database that has already applied this row keeps it, and PocketBase
+ * will not re-run an edited file. So the rows this migration created on
+ * existing databases — including production — are untouched by emptying it.
+ * A FRESH database gets its registry from the boot loader instead. Deleting
+ * the file would work too (the OnServe history-sync would reconcile it away),
+ * but keeping it preserves the numbering record.
+ *
+ * The down() is empty for the same reason it has to be: it used to truncate
+ * both registry tables, which is not this migration's to undo now that it
+ * creates nothing.
  */
 
-migrate((app) => {
-  // Idempotency lookup. findFirstRecordByFilter returns sql.ErrNoRows verbatim
-  // when nothing matches (core/record_query.go:454, v0.39.9), which surfaces here
-  // as "sql: no rows in result set" — that is the "not seeded yet" signal.
-  //
-  // ANY other error (malformed filter, DB lock, closed connection) is real. A bare
-  // `catch { return null }` would treat it as "not seeded", insert a duplicate, and
-  // die on the unique index with validation_not_unique — hiding the actual cause.
-  // So: rethrow anything that is not the not-found case.
-  const findSeeded = (collection, filter, params) => {
-    try {
-      return app.findFirstRecordByFilter(collection, filter, params);
-    } catch (e) {
-      if (String(e).indexOf("no rows in result set") === -1) throw e;
-      return null;
-    }
-  };
-
-  // Building/grouping rows — never bookable, never counted toward capacity.
-  const CONTAINER_CODES = ["gt-kitty", "gt-tenaya", "gt-tioga", "gt-clouds-rest", "gt-wawona", "hc-downstairs", "tawonga-village-5"];
-
-  const AREAS = [
-    { code: "RIDGE", name: "Ridge Side", x: 0.5000, y: 0.2900, sort: 1 },
-    { code: "RIVER", name: "River Side", x: 0.4900, y: 0.7000, sort: 2 },
-    { code: "YURT",  name: "Ridge Yurts", x: 0.2900, y: 0.3100, sort: 3 },
-    { code: "GT",    name: "Golden Triangle", x: 0.7800, y: 0.6300, sort: 4 },
-    { code: "HC",    name: "Health Center", x: 0.7294, y: 0.5747, sort: 5 },
-    { code: "TV",    name: "Tawonga Village", x: 0.6900, y: 0.2200, sort: 6 },
-    { code: "MANZ",  name: "Manzanitas", x: 0.4700, y: 0.1900, sort: 7 },
-    { code: "TUOL",  name: "Tuolumne Heights", x: 0.1000, y: 0.6400, sort: 8 }
-  ];
-
-  const areasCol = app.findCollectionByNameOrId("lodging_areas");
-  const areaIds = {};
-  for (let i = 0; i < AREAS.length; i++) {
-    const a = AREAS[i];
-    let rec = findSeeded("lodging_areas", "code = {:c}", { c: a.code });
-    if (!rec) {
-      rec = new Record(areasCol);
-      rec.set("code", a.code);
-      rec.set("name", a.name);
-      rec.set("map_x", a.x);
-      rec.set("map_y", a.y);
-      rec.set("sort_order", a.sort);
-      app.save(rec);
-    }
-    areaIds[a.code] = rec.id;
+migrate(
+  () => {
+    // no-op: the registry loads from config/lodging_registry.json on boot.
+  },
+  () => {
+    // no-op: this migration no longer creates anything to revert.
   }
-
-  // Bathhouse label positions from the map, used to seed near_bathhouse.
-  const BATHHOUSES = [
-    [0.4992, 0.3266], // Ridgeside
-    [0.5374, 0.6811], // Central
-    [0.1509, 0.6427], // Staff
-    [0.6500, 0.2379]  // Tawonga Village
-  ];
-  const NEAR_BH = 0.09; // normalised-canvas radius; tune later against actuals
-
-  function nearBathhouse(x, y) {
-    for (let i = 0; i < BATHHOUSES.length; i++) {
-      const dx = x - BATHHOUSES[i][0];
-      const dy = y - BATHHOUSES[i][1];
-      if (Math.sqrt(dx * dx + dy * dy) <= NEAR_BH) return true;
-    }
-    return false;
-  }
-
-  // [area, name, code, x, y, sleeps, bathroom, bathroom_group, parent_code, allocation]
-  // sleeps = observed peak people 2024-2025; null here means never observed,
-  // which the loop below leaves unset — PocketBase then stores it as 0 (its
-  // NUMERIC NOT NULL default), so consumers must treat 0 as "unknown", not
-  // "zero capacity".
-  const UNITS = [
-    // --- Ridge Side (bare letters on the map) ---
-    ["RIDGE", "Ridge A", "ridge-a", 0.4389, 0.3311, 5, "none", "", "", "family_pool"],
-    ["RIDGE", "Ridge B", "ridge-b", 0.4151, 0.3462, 5, "none", "", "", "family_pool"],
-    ["RIDGE", "Ridge C", "ridge-c", 0.3960, 0.3177, 5, "none", "", "", "family_pool"],
-    ["RIDGE", "Ridge D", "ridge-d", 0.3823, 0.2872, 8, "none", "", "", "family_pool"],
-    ["RIDGE", "Ridge E", "ridge-e", 0.4138, 0.2591, 8, "none", "", "", "family_pool"],
-    ["RIDGE", "Ridge F", "ridge-f", 0.4395, 0.2695, 8, "none", "", "", "family_pool"],
-    ["RIDGE", "Ridge G", "ridge-g", 0.4645, 0.2773, 9, "none", "", "", "family_pool"],
-    ["RIDGE", "Ridge H", "ridge-h", 0.5199, 0.2911, 9, "none", "", "", "family_pool"],
-    ["RIDGE", "Ridge I", "ridge-i", 0.5481, 0.2856, 9, "none", "", "", "family_pool"],
-    ["RIDGE", "Ridge J", "ridge-j", 0.5692, 0.2869, 5, "none", "", "", "family_pool"],
-    ["RIDGE", "Ridge K", "ridge-k", 0.5949, 0.2880, 5, "none", "", "", "family_pool"],
-    ["RIDGE", "Ridge L", "ridge-l", 0.6218, 0.2894, 8, "none", "", "", "family_pool"],
-    ["RIDGE", "Ridge M", "ridge-m", 0.6505, 0.2982, 5, "none", "", "", "family_pool"],
-    // --- River Side (vA-vM on the map) ---
-    ["RIVER", "River A", "river-a", 0.5924, 0.7035, 6, "none", "", "", "family_pool"],
-    ["RIVER", "River B", "river-b", 0.5665, 0.7133, 5, "none", "", "", "family_pool"],
-    ["RIVER", "River C", "river-c", 0.5317, 0.7078, 5, "none", "", "", "family_pool"],
-    ["RIVER", "River D", "river-d", 0.5070, 0.6734, 9, "none", "", "", "family_pool"],
-    ["RIVER", "River E", "river-e", 0.4819, 0.6459, 8, "none", "", "", "family_pool"],
-    ["RIVER", "River F", "river-f", 0.4525, 0.6404, 6, "none", "", "", "family_pool"],
-    ["RIVER", "River G", "river-g", 0.4216, 0.6455, 7, "none", "", "", "family_pool"],
-    ["RIVER", "River H", "river-h", 0.4116, 0.6785, 8, "none", "", "", "family_pool"],
-    ["RIVER", "River I", "river-i", 0.4357, 0.6898, 4, "none", "", "", "family_pool"],
-    ["RIVER", "River J", "river-j", 0.4865, 0.7029, 8, "none", "", "", "family_pool"],
-    ["RIVER", "River K", "river-k", 0.5006, 0.7382, 6, "none", "", "", "family_pool"],
-    ["RIVER", "River L", "river-l", 0.5339, 0.7576, 4, "none", "", "", "family_pool"],
-    ["RIVER", "River M", "river-m", 0.5702, 0.7605, 5, "none", "", "", "family_pool"],
-    // --- Ridge Yurts ---
-    ["YURT", "Ridge Yurt 1", "ridge-yurt-1", 0.3374, 0.2951, 4, "none", "", "", "family_pool"],
-    ["YURT", "Ridge Yurt 2", "ridge-yurt-2", 0.3186, 0.3186, 4, "none", "", "", "family_pool"],
-    ["YURT", "Ridge Yurt 3", "ridge-yurt-3", 0.2977, 0.3442, 4, "none", "", "", "family_pool"],
-    ["YURT", "Ridge Yurt 4", "ridge-yurt-4", 0.2684, 0.3575, 4, "none", "", "", "family_pool"],
-    ["YURT", "Ridge Yurt 5", "ridge-yurt-5", 0.2483, 0.2986, 3, "none", "", "", "family_pool"],
-    ["YURT", "Ridge Yurt 6", "ridge-yurt-6", 0.2691, 0.2693, 4, "none", "", "", "family_pool"],
-    ["YURT", "Ridge Yurt 7", "ridge-yurt-7", 0.2833, 0.2987, 4, "none", "", "", "family_pool"],
-    // --- Tuolumne Heights ---
-    ["TUOL", "Tuolumne 1", "tuolumne-1", 0.1046, 0.6029, 4, "none", "", "", "family_pool"],
-    ["TUOL", "Tuolumne 2", "tuolumne-2", 0.1081, 0.6705, 3, "none", "", "", "family_pool"],
-    ["TUOL", "Tuolumne 3", "tuolumne-3", 0.0784, 0.6724, 2, "none", "", "", "family_pool"],
-    ["TUOL", "Tuolumne 4", "tuolumne-4", 0.0741, 0.6411, 4, "none", "", "", "family_pool"],
-    ["TUOL", "Tuolumne 5", "tuolumne-5", 0.0801, 0.5926, 4, "none", "", "", "family_pool"],
-    ["TUOL", "Tuolumne 6", "tuolumne-6", 0.1023, 0.5700, 3, "none", "", "", "family_pool"],
-    ["TUOL", "Tuolumne 7", "tuolumne-7", 0.1338, 0.7324, null, "none", "", "", "family_pool"],
-    // --- Manzanitas (no 6 — absent from the map) ---
-    ["MANZ", "Manzanita 1", "manzanita-1", 0.4632, 0.2234, 4, "none", "", "", "family_pool"],
-    ["MANZ", "Manzanita 2", "manzanita-2", 0.4694, 0.1974, 5, "none", "", "", "family_pool"],
-    ["MANZ", "Manzanita 3", "manzanita-3", 0.4339, 0.1806, 5, "none", "", "", "family_pool"],
-    ["MANZ", "Manzanita 4", "manzanita-4", 0.4562, 0.1543, 4, "none", "", "", "family_pool"],
-    ["MANZ", "Manzanita 5", "manzanita-5", 0.4808, 0.1717, 4, "none", "", "", "family_pool"],
-    ["MANZ", "Manzanita 7", "manzanita-7", 0.5389, 0.1765, 4, "none", "", "", "family_pool"],
-    // --- Tawonga Village (TV5 subdivides into 5a/5b) ---
-    ["TV", "Tawonga Village 1", "tawonga-village-1", 0.6835, 0.2575, 8, "none", "", "", "family_pool"],
-    ["TV", "Tawonga Village 2", "tawonga-village-2", 0.7252, 0.2458, 9, "none", "", "", "family_pool"],
-    ["TV", "Tawonga Village 3", "tawonga-village-3", 0.7012, 0.2251, 7, "none", "", "", "family_pool"],
-    ["TV", "Tawonga Village 4", "tawonga-village-4", 0.6948, 0.1916, 8, "none", "", "", "family_pool"],
-    ["TV", "Tawonga Village 5", "tawonga-village-5", 0.6510, 0.1782, null, "none", "", "", "family_pool"],
-    ["TV", "Tawonga Village 5a", "tawonga-village-5a", 0.6480, 0.1760, 4, "none", "tv-5", "tawonga-village-5", "family_pool"],
-    ["TV", "Tawonga Village 5b", "tawonga-village-5b", 0.6540, 0.1805, 4, "none", "tv-5", "tawonga-village-5", "family_pool"],
-    // --- Golden Triangle ---
-    ["GT", "El Cap", "gt-el-cap", 0.8735, 0.5879, 6, "none", "", "", "family_pool"],
-    ["GT", "Half Dome", "gt-half-dome", 0.8790, 0.5940, 7, "none", "", "", "family_pool"],
-    ["GT", "Kitty", "gt-kitty", 0.6381, 0.6327, null, "none", "", "", "family_pool"],
-    ["GT", "Kitty 2", "gt-kitty-2", 0.6350, 0.6300, 4, "none", "", "gt-kitty", "family_pool"],
-    ["GT", "Kitty 3", "gt-kitty-3", 0.6412, 0.6355, 4, "none", "", "gt-kitty", "family_pool"],
-    ["GT", "Tenaya", "gt-tenaya", 0.8813, 0.6274, null, "none", "", "", "family_pool"],
-    ["GT", "Tenaya 1", "gt-tenaya-1", 0.8760, 0.6230, 5, "shared", "gt-tenaya-12", "gt-tenaya", "family_pool"],
-    ["GT", "Tenaya 2", "gt-tenaya-2", 0.8800, 0.6260, 5, "shared", "gt-tenaya-12", "gt-tenaya", "family_pool"],
-    ["GT", "Tenaya 3", "gt-tenaya-3", 0.8840, 0.6295, 5, "shared", "", "gt-tenaya", "family_pool"],
-    ["GT", "Tenaya 4", "gt-tenaya-4", 0.8880, 0.6330, 4, "shared", "", "gt-tenaya", "family_pool"],
-    ["GT", "Tioga", "gt-tioga", 0.8206, 0.7127, null, "none", "", "", "family_pool"],
-    ["GT", "Tioga 1", "gt-tioga-1", 0.8150, 0.7080, 5, "shared", "gt-tioga-12", "gt-tioga", "family_pool"],
-    ["GT", "Tioga 2", "gt-tioga-2", 0.8190, 0.7110, 4, "shared", "gt-tioga-12", "gt-tioga", "family_pool"],
-    ["GT", "Tioga 3", "gt-tioga-3", 0.8230, 0.7145, 4, "shared", "", "gt-tioga", "family_pool"],
-    ["GT", "Tioga 4", "gt-tioga-4", 0.8270, 0.7180, 5, "shared", "", "gt-tioga", "family_pool"],
-    ["GT", "Clouds Rest", "gt-clouds-rest", 0.7087, 0.6620, 7, "none", "", "", "family_pool"],
-    ["GT", "Clouds Rest Loft", "gt-clouds-rest-loft", 0.7060, 0.6590, 2, "shared", "gt-clouds-rest", "gt-clouds-rest", "family_pool"],
-    ["GT", "Clouds Rest Side Room", "gt-clouds-rest-side", 0.7100, 0.6640, 2, "shared", "gt-clouds-rest", "gt-clouds-rest", "family_pool"],
-    ["GT", "Clouds Rest Back Room", "gt-clouds-rest-back", 0.7120, 0.6660, 1, "shared", "gt-clouds-rest", "gt-clouds-rest", "family_pool"],
-    ["GT", "Clouds Rest Laundry Room", "gt-clouds-rest-laundry", 0.7140, 0.6680, 1, "shared", "gt-clouds-rest", "gt-clouds-rest", "family_pool"],
-    // Wawona = the OLD Doctor's House, renamed 2025. Front(1)/Back(2).
-    ["GT", "Wawona", "gt-wawona", 0.7591, 0.6007, 7, "none", "", "", "family_pool"],
-    ["GT", "Wawona Front", "gt-wawona-front", 0.7560, 0.5980, 3, "shared", "gt-wawona", "gt-wawona", "family_pool"],
-    ["GT", "Wawona Back", "gt-wawona-back", 0.7620, 0.6035, 3, "shared", "gt-wawona", "gt-wawona", "family_pool"],
-    ["GT", "Lofty", "gt-lofty", 0.6724, 0.6322, null, "none", "", "", "staff_default"],
-    ["GT", "Le Shack", "gt-le-shack", 0.8554, 0.6791, null, "none", "", "", "staff_default"],
-    // --- Health Center ---
-    ["HC", "Health Center Upstairs 1", "hc-upstairs-1", 0.7270, 0.5700, 4, "shared", "hc-upstairs-hall", "", "family_pool"],
-    ["HC", "Health Center Upstairs 2", "hc-upstairs-2", 0.7280, 0.5715, null, "shared", "hc-upstairs-hall", "", "family_pool"],
-    ["HC", "Health Center Upstairs 3", "hc-upstairs-3", 0.7290, 0.5730, 8, "shared", "hc-upstairs-hall", "", "family_pool"],
-    ["HC", "Health Center Upstairs 4", "hc-upstairs-4", 0.7300, 0.5745, 4, "shared", "hc-upstairs-hall", "", "family_pool"],
-    ["HC", "Health Center Upstairs 5", "hc-upstairs-5", 0.7310, 0.5760, 4, "private", "", "", "family_pool"],
-    ["HC", "Health Center Upstairs 6", "hc-upstairs-6", 0.7320, 0.5775, 6, "shared", "hc-upstairs-hall", "", "family_pool"],
-    ["HC", "Health Center Downstairs", "hc-downstairs", 0.7294, 0.5820, 5, "none", "", "", "family_pool"],
-    ["HC", "Health Center Downstairs A", "hc-downstairs-a", 0.7280, 0.5810, 2, "shared", "hc-downstairs", "hc-downstairs", "family_pool"],
-    ["HC", "Health Center Downstairs B", "hc-downstairs-b", 0.7310, 0.5835, 2, "shared", "hc-downstairs", "hc-downstairs", "family_pool"],
-    // The NEWER Doctor's House. Reaches 2 households in one weekend, so it has
-    // >=2 rooms — room list unknown, see spec open item 4.
-    ["HC", "Doctor's House", "hc-doctors-house", 0.7350, 0.5700, 6, "private", "", "", "family_pool"],
-    ["HC", "Bayit", "hc-bayit", 0.7072, 0.5500, null, "none", "", "", "staff_default"]
-  ];
-
-  const unitsCol = app.findCollectionByNameOrId("lodging_units");
-  const unitIds = {};
-
-  // Pass 1: create every unit without parent_unit (parents may appear later).
-  for (let i = 0; i < UNITS.length; i++) {
-    const u = UNITS[i];
-    let rec = findSeeded("lodging_units", "code = {:c}", { c: u[2] });
-    if (!rec) {
-      rec = new Record(unitsCol);
-      rec.set("area", areaIds[u[0]]);
-      rec.set("name", u[1]);
-      rec.set("code", u[2]);
-      rec.set("map_x", u[3]);
-      rec.set("map_y", u[4]);
-      if (u[5] !== null) rec.set("sleeps", u[5]);
-      rec.set("bathroom", u[6]);
-      rec.set("bathroom_group", u[7]);
-      rec.set("near_bathhouse", nearBathhouse(u[3], u[4]));
-      rec.set("allocation_default", u[9]);
-      rec.set("is_confirmed", false);
-      rec.set("is_active", true);
-      rec.set("is_container", CONTAINER_CODES.indexOf(u[2]) !== -1);
-      app.save(rec);
-    }
-    unitIds[u[2]] = rec.id;
-  }
-
-  // Pass 2: wire parent_unit now that every code has an id.
-  for (let i = 0; i < UNITS.length; i++) {
-    const u = UNITS[i];
-    if (!u[8]) continue;
-    const rec = app.findFirstRecordByFilter("lodging_units", "code = {:c}", { c: u[2] });
-    if (!rec.get("parent_unit")) {
-      rec.set("parent_unit", unitIds[u[8]]);
-      app.save(rec);
-    }
-  }
-}, (app) => {
-  // Truncates both registry tables. That is correct for a revert of THIS
-  // migration, because it is the only thing that populates them — but note it
-  // also removes any rows staff added by hand afterwards. Use an explicit large
-  // limit: a 0 limit is version-dependent in the JSVM binding and can return
-  // nothing, silently making the down a no-op.
-  //
-  // Delete units before areas: units hold a required relation to areas.
-  const units = app.findRecordsByFilter("lodging_units", "id != ''", "", 100000, 0);
-  for (let i = 0; i < units.length; i++) {
-    app.delete(units[i]);
-  }
-  const areas = app.findRecordsByFilter("lodging_areas", "id != ''", "", 100000, 0);
-  for (let i = 0; i < areas.length; i++) {
-    app.delete(areas[i]);
-  }
-});
+);

--- a/pocketbase/pb_migrations/1500000121_seed_lodging_aliases.js
+++ b/pocketbase/pb_migrations/1500000121_seed_lodging_aliases.js
@@ -1,195 +1,27 @@
 /// <reference path="../pb_data/types.d.ts" />
 /**
- * Seed: lodging_unit_aliases
+ * Seed: lodging_unit_aliases — DATA REMOVED, see 1500000120's header.
  *
- * Every distinct cabin string observed 2022-2026 in:
- *   - "Family Camp Cabin"            (partition ["Family"],  household_custom_values)
- *   - "Reportable Family Camp Cabin" (partition ["Camper","Adult"], person_custom_values)
+ * The alias rows were every distinct cabin string observed 2022-2026 in the
+ * two CampMinder custom fields the lodging ingest reads. Those strings name
+ * the camp's buildings, so they moved with the rest of the registry into the
+ * private `config/lodging_registry.json` (`aliases`), loaded on boot by
+ * `pocketbase/lodging/registry.go`. See `docs/reference/lodging-registry.md`.
  *
- * Temporal windows record two renames that happened in 2025:
- *   "Golden Triangle - Doctor's House" (<=2024) -> "Golden Triangle - Wawona" (2025+)
- *   "Health Center - Doctor's House"   (<=2024) -> "Doctor's House"           (2025+)
- * Both buildings existed simultaneously in 2022-2024, so they are distinct units.
+ * The two 2025 renames the year windows encode, the equivalence between the
+ * family-side and adult-side field vocabularies, and the warning that the
+ * strings are verbatim (one contains a real double space — do not trim) are
+ * recorded in that file's `_notes`, beside the data they describe.
  *
- * "Teen Village N" (family field) and "Tawonga Village N" (adult field) are the
- * SAME six units: identical numbering including the unusual 5a/5b split, and they
- * never appear in the same field. Tawonga Village is canonical (matches the map).
- *
- * Multi-member aliases denote merges, materialised as lodging_merges rows by the
- * Plan 2 backfill. Strings are verbatim — the double space in
- * "Health Center Downstairs  - Room A" is real. Do not trim.
- *
- * Idempotent: skips any (alias_string, valid_from_year) that already exists.
+ * Emptied rather than deleted, and the down() emptied with it, for the reasons
+ * in 1500000120.
  */
 
-migrate((app) => {
-  // Idempotency lookup. findFirstRecordByFilter returns sql.ErrNoRows verbatim
-  // when nothing matches (core/record_query.go:454, v0.39.9), which surfaces here
-  // as "sql: no rows in result set" — that is the "not seeded yet" signal.
-  //
-  // ANY other error (malformed filter, DB lock, closed connection) is real. A bare
-  // `catch { return null }` would treat it as "not seeded", insert a duplicate, and
-  // die on the unique index with validation_not_unique — hiding the actual cause.
-  // So: rethrow anything that is not the not-found case.
-  const findSeeded = (collection, filter, params) => {
-    try {
-      return app.findFirstRecordByFilter(collection, filter, params);
-    } catch (e) {
-      if (String(e).indexOf("no rows in result set") === -1) throw e;
-      return null;
-    }
-  };
-
-  // [alias_string, [unit_codes], valid_from_year, valid_to_year]
-  // null year = no bound.
-  const ALIASES = [
-    // --- straightforward one-to-one, all years ---
-    ["Ridge A", ["ridge-a"], null, null],
-    ["Ridge B", ["ridge-b"], null, null],
-    ["Ridge C", ["ridge-c"], null, null],
-    ["Ridge D", ["ridge-d"], null, null],
-    ["Ridge E", ["ridge-e"], null, null],
-    ["Ridge F", ["ridge-f"], null, null],
-    ["Ridge G", ["ridge-g"], null, null],
-    ["Ridge H", ["ridge-h"], null, null],
-    ["Ridge I", ["ridge-i"], null, null],
-    ["Ridge J", ["ridge-j"], null, null],
-    ["Ridge K", ["ridge-k"], null, null],
-    ["Ridge L", ["ridge-l"], null, null],
-    ["Ridge M", ["ridge-m"], null, null],
-    ["River A", ["river-a"], null, null],
-    ["River B", ["river-b"], null, null],
-    ["River C", ["river-c"], null, null],
-    ["River D", ["river-d"], null, null],
-    ["River E", ["river-e"], null, null],
-    ["River F", ["river-f"], null, null],
-    ["River G", ["river-g"], null, null],
-    ["River H", ["river-h"], null, null],
-    ["River I", ["river-i"], null, null],
-    ["River J", ["river-j"], null, null],
-    ["River K", ["river-k"], null, null],
-    ["River L", ["river-l"], null, null],
-    ["River M", ["river-m"], null, null],
-    ["Ridge Yurt 1", ["ridge-yurt-1"], null, null],
-    ["Ridge Yurt 2", ["ridge-yurt-2"], null, null],
-    ["Ridge Yurt 3", ["ridge-yurt-3"], null, null],
-    ["Ridge Yurt 4", ["ridge-yurt-4"], null, null],
-    ["Ridge Yurt 5", ["ridge-yurt-5"], null, null],
-    ["Ridge Yurt 6", ["ridge-yurt-6"], null, null],
-    ["Ridge Yurt 7", ["ridge-yurt-7"], null, null],
-    ["Tuolumne 1", ["tuolumne-1"], null, null],
-    ["Tuolumne 2", ["tuolumne-2"], null, null],
-    ["Tuolumne 3", ["tuolumne-3"], null, null],
-    ["Tuolumne 4", ["tuolumne-4"], null, null],
-    ["Tuolumne 5", ["tuolumne-5"], null, null],
-    ["Tuolumne 6", ["tuolumne-6"], null, null],
-    ["Manzanita 1", ["manzanita-1"], null, null],
-    ["Manzanita 2", ["manzanita-2"], null, null],
-    ["Manzanita 3", ["manzanita-3"], null, null],
-    ["Manzanita 4", ["manzanita-4"], null, null],
-    ["Manzanita 5", ["manzanita-5"], null, null],
-    ["Manzanita 7", ["manzanita-7"], null, null],
-    ["New Trailer (Manzanitas)", ["manzanita-7"], null, null],
-    // --- Teen Village (family field) == Tawonga Village (adult field) ---
-    ["Teen Village 1", ["tawonga-village-1"], null, null],
-    ["Teen Village 2", ["tawonga-village-2"], null, null],
-    ["Teen Village 3", ["tawonga-village-3"], null, null],
-    ["Teen Village 4", ["tawonga-village-4"], null, null],
-    ["Teen Village 5a", ["tawonga-village-5a"], null, null],
-    ["Teen Village 5b", ["tawonga-village-5b"], null, null],
-    ["Tawonga Village 1", ["tawonga-village-1"], null, null],
-    ["Tawonga Village 2", ["tawonga-village-2"], null, null],
-    ["Tawonga Village 3", ["tawonga-village-3"], null, null],
-    ["Tawonga Village 4", ["tawonga-village-4"], null, null],
-    ["Tawonga Village 5a", ["tawonga-village-5a"], null, null],
-    ["Tawonga Village 5b", ["tawonga-village-5b"], null, null],
-    // --- Golden Triangle ---
-    ["Golden Triangle - El Cap", ["gt-el-cap"], null, null],
-    ["Golden Triangle - Half Dome", ["gt-half-dome"], null, null],
-    ["Golden Triangle - Kitty 2", ["gt-kitty-2"], null, null],
-    ["Golden Triangle - Kitty 3", ["gt-kitty-3"], null, null],
-    ["Golden Triangle - Tenaya 1", ["gt-tenaya-1"], null, null],
-    ["Golden Triangle - Tenaya 2", ["gt-tenaya-2"], null, null],
-    ["Golden Triangle - Tenaya 3", ["gt-tenaya-3"], null, null],
-    ["Golden Triangle - Tenaya 4", ["gt-tenaya-4"], null, null],
-    ["Golden Triangle - Tioga 1", ["gt-tioga-1"], null, null],
-    ["Golden Triangle - Tioga 2", ["gt-tioga-2"], null, null],
-    ["Golden Triangle - Tioga 3", ["gt-tioga-3"], null, null],
-    ["Golden Triangle - Tioga 4", ["gt-tioga-4"], null, null],
-    ["Golden Triangle - Cloud's Rest", ["gt-clouds-rest"], null, null],
-    ["Golden Triangle - Cloud's Rest (Loft)", ["gt-clouds-rest-loft"], null, null],
-    ["Golden Triangle - Cloud's Rest (Side room)", ["gt-clouds-rest-side"], null, null],
-    ["Golden Triangle - Cloud's Rest (Back room)", ["gt-clouds-rest-back"], null, null],
-    ["Golden Triangle - Cloud's Rest (Laundry room)", ["gt-clouds-rest-laundry"], null, null],
-    // --- merges (2+ members) ---
-    ["Golden Triangle - Tenaya 1and2", ["gt-tenaya-1", "gt-tenaya-2"], null, null],
-    ["Golden Triangle - Tioga 1and2", ["gt-tioga-1", "gt-tioga-2"], null, null],
-    ["Health Center - Downstairs 1and2", ["hc-downstairs-a", "hc-downstairs-b"], null, null],
-    ["Health Center Downstairs", ["hc-downstairs-a", "hc-downstairs-b"], null, null],
-    // --- Wawona: the old GT Doctor's House, renamed 2025 ---
-    ["Golden Triangle - Doctor's House", ["gt-wawona"], null, 2024],
-    ["Golden Triangle - Wawona", ["gt-wawona-front", "gt-wawona-back"], 2025, null],
-    ["Golden Triangle - Wawona Front", ["gt-wawona-front"], null, null],
-    ["Golden Triangle - Wawona Back", ["gt-wawona-back"], null, null],
-    ["Golden Triangle - Wawona (Front)", ["gt-wawona-front"], null, null],
-    ["Golden Triangle - Wawona (Back)", ["gt-wawona-back"], null, null],
-    // --- Doctor's House: the newer HC building ---
-    ["Health Center - Doctor's House", ["hc-doctors-house"], null, 2024],
-    ["Doctor's House", ["hc-doctors-house"], 2025, null],
-    // --- Health Center rooms; A/B replaced 1/2 ---
-    ["Health Center - Upstairs 1", ["hc-upstairs-1"], null, null],
-    ["Health Center - Upstairs 2", ["hc-upstairs-2"], null, null],
-    ["Health Center - Upstairs 3", ["hc-upstairs-3"], null, null],
-    ["Health Center - Upstairs 4", ["hc-upstairs-4"], null, null],
-    ["Health Center - Upstairs 5", ["hc-upstairs-5"], null, null],
-    ["Health Center - Upstairs 6", ["hc-upstairs-6"], null, null],
-    ["Health Center - Downstairs 1", ["hc-downstairs-a"], null, 2024],
-    ["Health Center - Downstairs 2", ["hc-downstairs-b"], null, 2024],
-    ["Health Center - Downstairs A", ["hc-downstairs-a"], null, null],
-    ["Health Center - Downstairs B", ["hc-downstairs-b"], null, null],
-    // Verbatim double space, as stored in CampMinder. Do not trim.
-    ["Health Center Downstairs  - Room A", ["hc-downstairs-a"], null, null],
-    ["Health Center Downstairs  - Room B", ["hc-downstairs-b"], null, null],
-    ["Tawonga Village 5", ["tawonga-village-5a", "tawonga-village-5b"], null, null]
-  ];
-
-  const aliasCol = app.findCollectionByNameOrId("lodging_unit_aliases");
-
-  for (let i = 0; i < ALIASES.length; i++) {
-    const a = ALIASES[i];
-
-    // An unbounded window is stored as 0, NOT null. PocketBase declares number
-    // columns `NUMERIC DEFAULT 0 NOT NULL`, and `min: 2000` does NOT reject an
-    // unset optional field — both verified empirically against this collection:
-    // POSTing an alias with no valid_from_year returns `"valid_from_year": 0`.
-    // Filtering on `= null` would therefore never match, so a re-run would
-    // re-insert and die on the unique index with validation_not_unique.
-    const wantYear = a[2] === null ? 0 : a[2];
-    const existing = findSeeded(
-      "lodging_unit_aliases",
-      "alias_string = {:s} && valid_from_year = {:y}",
-      { s: a[0], y: wantYear }
-    );
-    if (existing) continue;
-
-    const memberIds = [];
-    for (let j = 0; j < a[1].length; j++) {
-      const u = app.findFirstRecordByFilter("lodging_units", "code = {:c}", { c: a[1][j] });
-      memberIds.push(u.id);
-    }
-
-    const rec = new Record(aliasCol);
-    rec.set("alias_string", a[0]);
-    rec.set("member_units", memberIds);
-    if (a[2] !== null) rec.set("valid_from_year", a[2]);
-    if (a[3] !== null) rec.set("valid_to_year", a[3]);
-    app.save(rec);
+migrate(
+  () => {
+    // no-op: aliases load from config/lodging_registry.json on boot.
+  },
+  () => {
+    // no-op: this migration no longer creates anything to revert.
   }
-}, (app) => {
-  // Explicit large limit — a 0 limit is version-dependent in the JSVM binding
-  // and can return nothing, silently making the down a no-op.
-  const rows = app.findRecordsByFilter("lodging_unit_aliases", "id != ''", "", 100000, 0);
-  for (let i = 0; i < rows.length; i++) {
-    app.delete(rows[i]);
-  }
-});
+);

--- a/pocketbase/pb_migrations/1500000129_seed_lodging_containers.js
+++ b/pocketbase/pb_migrations/1500000129_seed_lodging_containers.js
@@ -1,177 +1,33 @@
 /// <reference path="../pb_data/types.d.ts" />
 /**
- * Seed the intermediate containers that make PARTIAL merges expressible, and
- * fix two missing bathroom groups.
+ * Seed: intermediate containers + two bathroom-group fixes — DATA REMOVED,
+ * see 1500000120's header.
  *
- * WHY. A merge binds a set of atomic rooms into one bookable slot. History
- * proves six real merges; two of them are partial — `Tenaya 1and2` and
- * `Tioga 1and2` each bind 2 rooms of a 4-room building. The unit tree was flat
- * (one container per building, all rooms as direct children), so neither could
- * be described as "the complete child set of a container". This inserts the
- * missing middle level:
+ * This migration inserted a middle level into the unit tree so that PARTIAL
+ * merges (two rooms of a four-room building) are describable, and backfilled
+ * the bathroom_group that one of each pair was missing — without which merging
+ * that pair left the slot scored `shared`, so a family with a medical
+ * private-bathroom need would not be matched to it despite the physical
+ * outcome being identical to the pair that did carry a group.
  *
- *   Tioga (container)
- *   |-- Tioga Upstairs (container)   <- new
- *   |   |-- Tioga 1
- *   |   +-- Tioga 2
- *   +-- Tioga Downstairs (container) <- new
- *       |-- Tioga 3
- *       +-- Tioga 4
+ * Both the container rows and the corrected groups are camp-identifying, so
+ * they moved into the private `config/lodging_registry.json` — the containers
+ * as ordinary `units` entries with `is_container: true`, the corrected groups
+ * as the affected rooms' `bathroom_group` values. The staff-confirmed floorplan
+ * that justifies the split is recorded in that file's `_notes`.
  *
- * ...and the same for Tenaya. Merging {1,2}, {3,4} or all four is then each
- * the complete child set of exactly one container; {2,3} is not, which is
- * correct — those were never a room pairing.
+ * A fresh database therefore gets these rows already shaped correctly from the
+ * boot loader, in one pass, rather than created flat and then repaired.
  *
- * THE LAYOUT, staff-confirmed. Rooms 1 and 2 are bedrooms inside one upstairs
- * apartment that also has a shared bathroom, living room and kitchen — a
- * normal house floorplan. Rooms 3 and 4 are individual bedrooms off a
- * downstairs lobby, and the third door off that lobby is their shared
- * bathroom. So BOTH pairs share a bathroom; what differs is how much living
- * space an unmerged split imposes on two families, which is why the container
- * carries the description and the bedrooms stay bedrooms.
- *
- * THE BATHROOM FIX. Only the 1+2 pairs carried a bathroom_group. Per spec
- * §3.2.1 a `shared` unit upgrades to `private` only when a merge covers every
- * member of its group, and a `shared` unit with NO group can never upgrade at
- * all. So merging 3+4 left the slot reading `shared`, and a family with a
- * medical private-bathroom need would not be matched to it — the same physical
- * outcome as merging 1+2, scored differently purely because of absent data.
- *
- * Containers are never bookable and never counted (is_container true), so
- * these four rows add no capacity. They deliberately carry no `sleeps`: a
- * container's capacity is its children's, and summing over containers is a
- * known way to overstate the site (408 beds against a true 389).
- *
- * Idempotent: every insert and update checks current state first.
+ * Emptied rather than deleted, and the down() emptied with it, for the reasons
+ * in 1500000120.
  */
 
 migrate(
-  (app) => {
-    const findUnit = (code) => {
-      try {
-        return app.findFirstRecordByFilter('lodging_units', 'code = {:code}', { code });
-      } catch (e) {
-        // findFirstRecordByFilter returns sql.ErrNoRows verbatim when nothing
-        // matches. Anything else (malformed filter, DB lock) is real and must
-        // not be swallowed into a "not seeded yet" signal.
-        if (String(e).indexOf('no rows in result set') === -1) throw e;
-        return null;
-      }
-    };
-
-    const collection = app.findCollectionByNameOrId('lodging_units');
-
-    // [intermediate code, display name, parent building code, [child codes],
-    //  bathroom_group to ensure on those children, shared-space note]
-    const GROUPS = [
-      [
-        'gt-tioga-upstairs',
-        'Tioga Upstairs',
-        'gt-tioga',
-        ['gt-tioga-1', 'gt-tioga-2'],
-        'gt-tioga-12',
-        'Two bedrooms in one apartment sharing a bathroom, living room and kitchen.',
-      ],
-      [
-        'gt-tioga-downstairs',
-        'Tioga Downstairs',
-        'gt-tioga',
-        ['gt-tioga-3', 'gt-tioga-4'],
-        'gt-tioga-34',
-        'Two bedrooms off a shared entry lobby; the bathroom is the third door off that lobby.',
-      ],
-      [
-        'gt-tenaya-upstairs',
-        'Tenaya Upstairs',
-        'gt-tenaya',
-        ['gt-tenaya-1', 'gt-tenaya-2'],
-        'gt-tenaya-12',
-        'Two bedrooms in one apartment sharing a bathroom, living room and kitchen.',
-      ],
-      [
-        'gt-tenaya-downstairs',
-        'Tenaya Downstairs',
-        'gt-tenaya',
-        ['gt-tenaya-3', 'gt-tenaya-4'],
-        'gt-tenaya-34',
-        'Two bedrooms off a shared entry lobby; the bathroom is the third door off that lobby.',
-      ],
-    ];
-
-    for (const [code, name, buildingCode, childCodes, bathroomGroup, note] of GROUPS) {
-      const building = findUnit(buildingCode);
-      if (!building) continue; // building absent on this DB; nothing to nest under
-
-      let container = findUnit(code);
-      if (!container) {
-        container = new Record(collection);
-        container.set('code', code);
-        container.set('name', name);
-        container.set('area', building.get('area'));
-        container.set('parent_unit', building.id);
-        container.set('is_container', true);
-        // Never bookable, so allocation is irrelevant, but the column has no
-        // per-field default and an empty select matches neither availability
-        // branch. Mirror the building rather than leaving it blank.
-        container.set('allocation_default', building.get('allocation_default') || 'family_pool');
-        container.set('is_active', true);
-        container.set('is_confirmed', false);
-        container.set('bathroom', 'none');
-        container.set('notes', note);
-        container.set('map_x', building.get('map_x'));
-        container.set('map_y', building.get('map_y'));
-        app.save(container);
-      }
-
-      for (const childCode of childCodes) {
-        const child = findUnit(childCode);
-        if (!child) continue;
-        let dirty = false;
-        if (child.get('parent_unit') !== container.id) {
-          child.set('parent_unit', container.id);
-          dirty = true;
-        }
-        if (!child.get('bathroom_group')) {
-          child.set('bathroom_group', bathroomGroup);
-          dirty = true;
-        }
-        if (dirty) app.save(child);
-      }
-    }
+  () => {
+    // no-op: containers load from config/lodging_registry.json on boot.
   },
-  (app) => {
-    // Down: re-parent the rooms onto their building, drop the containers, and
-    // clear only the bathroom groups this migration introduced. The 1+2 groups
-    // predate it and must survive.
-    const findUnit = (code) => {
-      try {
-        return app.findFirstRecordByFilter('lodging_units', 'code = {:code}', { code });
-      } catch (e) {
-        if (String(e).indexOf('no rows in result set') === -1) throw e;
-        return null;
-      }
-    };
-
-    const UNDO = [
-      ['gt-tioga-upstairs', 'gt-tioga', ['gt-tioga-1', 'gt-tioga-2'], null],
-      ['gt-tioga-downstairs', 'gt-tioga', ['gt-tioga-3', 'gt-tioga-4'], 'gt-tioga-34'],
-      ['gt-tenaya-upstairs', 'gt-tenaya', ['gt-tenaya-1', 'gt-tenaya-2'], null],
-      ['gt-tenaya-downstairs', 'gt-tenaya', ['gt-tenaya-3', 'gt-tenaya-4'], 'gt-tenaya-34'],
-    ];
-
-    for (const [code, buildingCode, childCodes, groupToClear] of UNDO) {
-      const building = findUnit(buildingCode);
-      for (const childCode of childCodes) {
-        const child = findUnit(childCode);
-        if (!child) continue;
-        if (building) child.set('parent_unit', building.id);
-        if (groupToClear && child.get('bathroom_group') === groupToClear) {
-          child.set('bathroom_group', '');
-        }
-        app.save(child);
-      }
-      const container = findUnit(code);
-      if (container) app.delete(container);
-    }
+  () => {
+    // no-op: this migration no longer creates anything to revert.
   }
 );

--- a/scripts/dev/lib/diff_lodging_registry.py
+++ b/scripts/dev/lib/diff_lodging_registry.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Diff a PocketBase database's lodging registry against the private registry file.
+
+Used by scripts/dev/verify-lodging-seed.sh. Prints one line per difference to
+stderr and exits 1 if any are found, 0 if the database reproduces the file
+exactly.
+
+This exists because the registry is private data (kindred-local), so the
+verifier cannot hardcode what it expects to find without reproducing in a
+public repo the strings the private file exists to keep out of it. Comparing
+against the file is also stricter than the fixed counts it replaced: it catches
+a dropped unit, a mangled coordinate and a short alias member set, none of
+which a row count sees.
+
+Usage: diff_lodging_registry.py <registry.json> <data.db>
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from typing import Any
+
+
+def _norm_num(value: object) -> float:
+    """PocketBase stores an unset number as 0, never NULL, and the file uses
+    null for the same thing, so both normalise to 0.0. Round because SQLite
+    round-trips floats."""
+    if not isinstance(value, (int, float)):
+        return 0.0
+    return round(float(value), 6)
+
+
+def _diff_areas(doc: dict[str, Any], db: sqlite3.Connection) -> list[str]:
+    diffs: list[str] = []
+    want = {a["code"]: a for a in doc.get("areas", [])}
+    got = {r["code"]: r for r in db.execute("SELECT code, name, map_x, map_y, sort_order FROM lodging_areas")}
+
+    for code in sorted(set(want) - set(got)):
+        diffs.append(f"area {code}: in file, missing from database")
+    for code in sorted(set(got) - set(want)):
+        diffs.append(f"area {code}: in database, missing from file")
+
+    for code in sorted(set(want) & set(got)):
+        w, g = want[code], got[code]
+        if w["name"] != g["name"]:
+            diffs.append(f"area {code}.name: file={w['name']!r} db={g['name']!r}")
+        for field in ("map_x", "map_y", "sort_order"):
+            if _norm_num(w.get(field)) != _norm_num(g[field]):
+                diffs.append(f"area {code}.{field}: file={w.get(field)!r} db={g[field]!r}")
+    return diffs
+
+
+def _diff_units(doc: dict[str, Any], db: sqlite3.Connection) -> list[str]:
+    diffs: list[str] = []
+    want = {u["code"]: u for u in doc.get("units", [])}
+    got = {
+        r["code"]: r
+        for r in db.execute(
+            """
+            SELECT u.code, u.name, a.code AS area_code, u.map_x, u.map_y, u.sleeps,
+                   u.bathroom, u.bathroom_group, u.near_bathhouse, u.allocation_default,
+                   u.is_container, u.notes, p.code AS parent_code
+              FROM lodging_units u
+              JOIN lodging_areas a ON a.id = u.area
+              LEFT JOIN lodging_units p ON p.id = u.parent_unit
+            """
+        )
+    }
+
+    for code in sorted(set(want) - set(got)):
+        diffs.append(f"unit {code}: in file, missing from database")
+    for code in sorted(set(got) - set(want)):
+        diffs.append(f"unit {code}: in database, missing from file")
+
+    for code in sorted(set(want) & set(got)):
+        w, g = want[code], got[code]
+        checks: list[tuple[str, object, object]] = [
+            ("name", w["name"], g["name"]),
+            ("area", w["area"], g["area_code"]),
+            ("map_x", _norm_num(w.get("map_x")), _norm_num(g["map_x"])),
+            ("map_y", _norm_num(w.get("map_y")), _norm_num(g["map_y"])),
+            # 0 is UNKNOWN, which is what the file's null becomes on the way in.
+            ("sleeps", _norm_num(w.get("sleeps")), _norm_num(g["sleeps"])),
+            ("bathroom", w.get("bathroom") or "", g["bathroom"] or ""),
+            ("bathroom_group", w.get("bathroom_group") or "", g["bathroom_group"] or ""),
+            ("near_bathhouse", int(bool(w.get("near_bathhouse"))), int(g["near_bathhouse"] or 0)),
+            ("allocation_default", w.get("allocation_default") or "", g["allocation_default"] or ""),
+            ("is_container", int(bool(w.get("is_container"))), int(g["is_container"] or 0)),
+            ("notes", w.get("notes") or "", g["notes"] or ""),
+            ("parent_unit", w.get("parent_unit") or "", g["parent_code"] or ""),
+        ]
+        for field, file_value, db_value in checks:
+            if file_value != db_value:
+                diffs.append(f"unit {code}.{field}: file={file_value!r} db={db_value!r}")
+    return diffs
+
+
+def _diff_aliases(doc: dict[str, Any], db: sqlite3.Connection) -> list[str]:
+    diffs: list[str] = []
+    # An unbounded window is stored as 0, never NULL, and the unique index is
+    # (alias_string, valid_from_year) — so that pair is the identity here too.
+    want = {(a["alias_string"], int(a.get("valid_from_year") or 0)): a for a in doc.get("aliases", [])}
+    got = {
+        (r["alias_string"], int(r["valid_from_year"] or 0)): r
+        for r in db.execute(
+            """
+            SELECT al.alias_string, al.valid_from_year, al.valid_to_year,
+                   (SELECT group_concat(u.code)
+                      FROM json_each(al.member_units) je
+                      JOIN lodging_units u ON u.id = je.value) AS members
+              FROM lodging_unit_aliases al
+            """
+        )
+    }
+
+    for key in sorted(set(want) - set(got)):
+        diffs.append(f"alias {key}: in file, missing from database")
+    for key in sorted(set(got) - set(want)):
+        diffs.append(f"alias {key}: in database, missing from file")
+
+    for key in sorted(set(want) & set(got)):
+        w, g = want[key], got[key]
+        if _norm_num(w.get("valid_to_year")) != _norm_num(g["valid_to_year"]):
+            diffs.append(f"alias {key}.valid_to_year: file={w.get('valid_to_year')!r} db={g['valid_to_year']!r}")
+        # json_each preserves the stored order, and member order is meaningful
+        # only in that a merge must contain exactly the right rooms.
+        want_members = sorted(w.get("member_units") or [])
+        db_members = sorted((g["members"] or "").split(",")) if g["members"] else []
+        if want_members != db_members:
+            diffs.append(f"alias {key}.member_units: file={want_members} db={db_members}")
+    return diffs
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(f"usage: {argv[0]} <registry.json> <data.db>", file=sys.stderr)
+        return 2
+
+    registry_path, db_path = argv[1], argv[2]
+    with open(registry_path, encoding="utf-8") as handle:
+        doc = json.load(handle)
+
+    # Read-only: this runs against a throwaway database the harness has already
+    # stopped, but opening it read-write would create a -wal beside it.
+    db = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    db.row_factory = sqlite3.Row
+    try:
+        diffs = _diff_areas(doc, db) + _diff_units(doc, db) + _diff_aliases(doc, db)
+    finally:
+        db.close()
+
+    if diffs:
+        print(f"{len(diffs)} difference(s) between {registry_path} and the database:", file=sys.stderr)
+        for diff in diffs:
+            print(f"  {diff}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/dev/test-verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/test-verify-no-hardcoded-lodging.sh
@@ -172,4 +172,32 @@ fi
 echo "PASS: a unit list in pb_migrations/ is caught"
 
 echo
+echo "=== TEST 6: a failed scan must exit 2, not report a clean tree ==="
+# kindred#1867 flagged this on this script and it shipped unfixed: grep exits 2
+# on an unreadable or missing search root, but stderr went to /dev/null and the
+# pipeline ended in `|| true`, so the guard printed OK on a scan that never
+# ran. A privacy tripwire that false-greens is worse than no tripwire, because
+# the green is what gets trusted.
+set +e
+OUT=$(LODGING_SCAN_ROOTS="definitely_not_a_real_directory_kindred1909/" "$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+if [[ $rc -ne 2 ]]; then
+  echo "FAIL: expected exit 2 when the scan root is missing, got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+if ! grep -q 'the scan did not run' <<<"$OUT"; then
+  echo "FAIL: exit 2 but no explanation that the scan did not run" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+if grep -q 'verify-no-hardcoded-lodging: OK' <<<"$OUT"; then
+  echo "FAIL: a failed scan still printed OK" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+echo "PASS: a failed scan exits 2 and says so"
+
+echo
 echo "All tests passed."

--- a/scripts/dev/test-verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/test-verify-no-hardcoded-lodging.sh
@@ -144,4 +144,32 @@ else
 fi
 
 echo
+echo "=== TEST 5: a unit list in a MIGRATION should exit 1 ==="
+# The registry used to live in pb_migrations/, so the guard used to skip that
+# directory entirely. Now that the data lives in the private
+# config/lodging_registry.json, the exclusion would be a hole in exactly the
+# place a future seed would land -- this asserts it is gone. Prose in a
+# migration is still fine; TEST 4 covers that, and this probe is a literal.
+MIG_PROBE="$REPO_ROOT/pocketbase/pb_migrations/9999999999_leak_probe_kindred1909.js"
+cleanup3() { rm -f "$MIG_PROBE"; }
+trap 'cleanup3; cleanup' EXIT INT TERM
+echo 'const UNITS = ["Tuolumne 1", "Manzanita 3"]' > "$MIG_PROBE"
+set +e
+OUT=$("$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+rm -f "$MIG_PROBE"
+if [[ $rc -ne 1 ]]; then
+  echo "FAIL: expected exit 1 for a unit list in pb_migrations/, got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+if ! grep -q "9999999999_leak_probe_kindred1909.js:1:" <<<"$OUT"; then
+  echo "FAIL: output missing migration probe file:line" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+echo "PASS: a unit list in pb_migrations/ is caught"
+
+echo
 echo "All tests passed."

--- a/scripts/dev/verify-lodging-seed.sh
+++ b/scripts/dev/verify-lodging-seed.sh
@@ -67,6 +67,12 @@ q() { sqlite3 "$DB" "$1"; }
 n=$(q "SELECT COUNT(*) FROM lodging_units")
 if [[ "$n" -eq 0 ]]; then
   note "no lodging_units rows — the boot loader did not run (see $LOG)"
+  # Stop here rather than aggregating. Every check below compares against the
+  # file, so an empty database fails all of them: the one line that explains
+  # WHY would arrive buried under a per-row diff for every area, unit and
+  # alias in the registry.
+  echo "verify-lodging-seed: FAILED" >&2
+  exit 1
 fi
 
 # --- the database matches the private registry file, field by field ---

--- a/scripts/dev/verify-lodging-seed.sh
+++ b/scripts/dev/verify-lodging-seed.sh
@@ -1,12 +1,27 @@
 #!/usr/bin/env bash
-# Asserts the lodging seed produced the expected rows. Applies migrations to a
-# throwaway DB via scripts/dev/lib/pb-harness.sh (see that file for the
-# serve-and-kill technique and why it's needed), shared with
-# scripts/dev/verify-consolidation.sh and scripts/dev/verify-lodging-schema.sh.
+# Asserts the lodging registry loads. Applies migrations to a throwaway DB via
+# scripts/dev/lib/pb-harness.sh (see that file for the serve-and-kill technique
+# and why it's needed), shared with scripts/dev/verify-consolidation.sh and
+# scripts/dev/verify-lodging-schema.sh.
+#
+# The registry is PRIVATE DATA, not source: it lives in
+# config/lodging_registry.json (kindred-local) and is loaded on boot by the Go
+# loader in pocketbase/lodging/registry.go. See
+# docs/reference/lodging-registry.md.
+#
+# So this script no longer hardcodes what the registry contains — doing that
+# would reproduce in a public repo exactly the strings the private file exists
+# to keep out of it. Instead it asserts the DATABASE MATCHES THE FILE, field by
+# field, which is both leak-free and stricter than the counts it replaces: it
+# catches a unit the loader dropped, a coordinate it mangled, and an alias
+# whose member set came out short.
+#
+# The invariants that do not name anything are still asserted directly.
 #
 # Exit codes: 0 = all assertions passed. 1 = one or more assertions FAILED.
-# 2 = could not run the check at all. Assertions aggregate rather than
-# short-circuit; see verify-lodging-schema.sh.
+# 2 = could not run the check at all (missing tool, missing binary, or no
+# private registry file — a clone without kindred-local cannot run this).
+# Assertions aggregate rather than short-circuit; see verify-lodging-schema.sh.
 set -euo pipefail
 
 HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -20,8 +35,19 @@ pb_harness_require_tools
 REPO_ROOT=$(git rev-parse --show-toplevel)
 PB_BIN="$REPO_ROOT/pocketbase/pocketbase"
 MIG_DIR="$REPO_ROOT/pocketbase/pb_migrations"
+REGISTRY="$REPO_ROOT/config/lodging_registry.json"
 
 [[ -x "$PB_BIN" ]] || { echo "error: $PB_BIN missing; run: cd pocketbase && go build -o pocketbase ." >&2; exit 2; }
+
+if [[ ! -f "$REGISTRY" ]]; then
+  echo "error: $REGISTRY missing — the private registry lives in kindred-local." >&2
+  echo "       Run scripts/setup/setup-local-config.sh, or skip this check." >&2
+  exit 2
+fi
+
+# The loader resolves ./config/ relative to the working directory, so the
+# harness's `pocketbase serve` has to be started from the repo root.
+cd "$REPO_ROOT"
 
 SCRATCH=$(mktemp -d)
 # shellcheck disable=SC2016  # deliberate: $SCRATCH expands when the trap fires, not here
@@ -35,81 +61,45 @@ DB="$DB_DIR/data.db"
 fail=0; note() { echo "FAIL: $*" >&2; fail=1; }
 q() { sqlite3 "$DB" "$1"; }
 
-[[ "$(q "SELECT COUNT(*) FROM lodging_areas")" -eq 8 ]] || note "expected 8 areas, got $(q "SELECT COUNT(*) FROM lodging_areas")"
+# --- the registry loaded at all ---
+# A structural floor, so an empty database fails here with a clear message
+# rather than as a wall of per-row diffs below.
+n=$(q "SELECT COUNT(*) FROM lodging_units")
+if [[ "$n" -eq 0 ]]; then
+  note "no lodging_units rows — the boot loader did not run (see $LOG)"
+fi
 
-# Per-area unit counts, from the map.
-while IFS='|' read -r code want; do
-  got=$(q "SELECT COUNT(*) FROM lodging_units u JOIN lodging_areas a ON u.area = a.id WHERE a.code = '$code'")
-  [[ "$got" -eq "$want" ]] || note "area $code has $got units, expected $want"
-done <<'EOF'
-RIDGE|13
-RIVER|13
-YURT|7
-TUOL|7
-MANZ|6
-TV|7
-# GT gained 4 intermediate containers in 1500000129 (Tioga/Tenaya
-# upstairs+downstairs) so partial merges are expressible. Containers are
-# never bookable and never counted — this is a structural row count.
-GT|29
-HC|11
-EOF
+# --- the database matches the private registry file, field by field ---
+if ! python3 "$HERE/lib/diff_lodging_registry.py" "$REGISTRY" "$DB"; then
+  note "database does not match $REGISTRY (differences above)"
+fi
+
+# --- invariants that name nothing ---
 
 # Every unit needs a map position, or the map view and adjacency are impossible.
 n=$(q "SELECT COUNT(*) FROM lodging_units WHERE map_x IS NULL OR map_x = 0")
 [[ "$n" -eq 0 ]] || note "$n units have no map_x"
 
-# Every sleeps value is a guess -> nothing may claim to be confirmed.
+# Every sleeps value is a guess -> nothing the loader writes may claim to be confirmed.
 n=$(q "SELECT COUNT(*) FROM lodging_units WHERE is_confirmed = 1")
 [[ "$n" -eq 0 ]] || note "$n units marked is_confirmed, expected 0 (all seeds are guesses)"
 
-# Known-good spot checks.
-[[ "$(q "SELECT bathroom FROM lodging_units WHERE code = 'hc-upstairs-5'")" == "private" ]] || note "hc-upstairs-5 should be private"
-[[ "$(q "SELECT bathroom_group FROM lodging_units WHERE code = 'hc-upstairs-3'")" == "hc-upstairs-hall" ]] || note "hc-upstairs-3 should be in hc-upstairs-hall"
-[[ "$(q "SELECT bathroom FROM lodging_units WHERE code = 'ridge-a'")" == "none" ]] || note "ridge-a should be none"
-[[ "$(q "SELECT COUNT(*) FROM lodging_units WHERE code = 'manzanita-6'")" -eq 0 ]] || note "manzanita-6 must NOT exist (absent from the map)"
-[[ "$(q "SELECT COUNT(*) FROM lodging_units WHERE code = 'hc-upstairs-2'")" -eq 1 ]] || note "hc-upstairs-2 must exist (real but unused)"
-[[ "$(q "SELECT COUNT(*) FROM lodging_units WHERE code = 'tuolumne-7'")" -eq 1 ]] || note "tuolumne-7 must exist"
+# Container rows (buildings) are never bookable rooms, and every unit with a
+# parent must hang off one.
+n=$(q "SELECT COUNT(*) FROM lodging_units c JOIN lodging_units p ON c.parent_unit = p.id WHERE p.is_container = 0")
+[[ "$n" -eq 0 ]] || note "$n units have a non-container parent"
 
-# Wawona's children must point at it, and it must be a distinct building from Doctor's House.
-[[ "$(q "SELECT COUNT(*) FROM lodging_units c JOIN lodging_units p ON c.parent_unit = p.id WHERE p.code = 'gt-wawona'")" -eq 2 ]] || note "gt-wawona should have 2 children"
-[[ "$(q "SELECT COUNT(*) FROM lodging_units WHERE code IN ('gt-wawona','hc-doctors-house')")" -eq 2 ]] || note "gt-wawona and hc-doctors-house must both exist as distinct units"
+n=$(q "SELECT COUNT(*) FROM lodging_units WHERE is_container = 1")
+[[ "$n" -ge 1 ]] || note "expected at least one container unit, got $n"
 
 n=$(q "SELECT COUNT(*) FROM lodging_units WHERE allocation_default = 'staff_default'")
 [[ "$n" -ge 1 ]] || note "expected at least one staff_default unit"
 
-# --- aliases ---
-[[ "$(q "SELECT COUNT(*) FROM lodging_unit_aliases")" -ge 90 ]] || note "expected >=90 aliases, got $(q "SELECT COUNT(*) FROM lodging_unit_aliases")"
-
-# alias_string -> expected member unit codes (comma-joined, sorted)
-alias_members() {
-  # Several alias strings contain an apostrophe ("Doctor's House", "Cloud's
-  # Rest") — double it for the SQL string literal, or the query is a syntax
-  # error rather than a legitimate empty-result failure.
-  local esc="${1//\'/\'\'}"
-  q "SELECT group_concat(code) FROM (SELECT u.code FROM lodging_unit_aliases al, json_each(al.member_units) je JOIN lodging_units u ON u.id = je.value WHERE al.alias_string = '$esc' ORDER BY u.code)"
-}
-
-[[ "$(alias_members "Golden Triangle - Doctor's House")" == "gt-wawona" ]] || note "GT Doctor's House should resolve to gt-wawona, got $(alias_members "Golden Triangle - Doctor's House")"
-[[ "$(alias_members "Health Center - Doctor's House")" == "hc-doctors-house" ]] || note "HC Doctor's House should resolve to hc-doctors-house"
-[[ "$(alias_members "Doctor's House")" == "hc-doctors-house" ]] || note "bare Doctor's House should resolve to hc-doctors-house"
-[[ "$(alias_members "Teen Village 1")" == "tawonga-village-1" ]] || note "Teen Village 1 should alias Tawonga Village 1"
-[[ "$(alias_members "Tawonga Village 1")" == "tawonga-village-1" ]] || note "Tawonga Village 1 should alias itself"
-# Multi-member aliases denote merges.
-[[ "$(alias_members "Golden Triangle - Tenaya 1and2")" == "gt-tenaya-1,gt-tenaya-2" ]] || note "Tenaya 1and2 should have 2 members"
-[[ "$(alias_members "Golden Triangle - Tioga 1and2")" == "gt-tioga-1,gt-tioga-2" ]] || note "Tioga 1and2 should have 2 members"
-[[ "$(alias_members "Health Center - Downstairs 1and2")" == "hc-downstairs-a,hc-downstairs-b" ]] || note "Downstairs 1and2 should have 2 members"
-# The double-space string really is in the data — do not trim it.
-[[ "$(alias_members "Health Center Downstairs  - Room A")" == "hc-downstairs-a" ]] || note "double-space Room A alias missing"
-
-# Container rows (buildings) must never be countable/bookable rooms themselves,
-# and every leaf room's parent must itself be a container.
-# 1500000129 added 4 intermediate containers (Tioga/Tenaya upstairs +
-# downstairs), so 7 building-level containers becomes 11.
-n=$(q "SELECT COUNT(*) FROM lodging_units WHERE is_container = 1")
-[[ "$n" -eq 11 ]] || note "expected 11 container units, got $n"
-n=$(q "SELECT COUNT(*) FROM lodging_units c JOIN lodging_units p ON c.parent_unit = p.id WHERE p.is_container = 0")
-[[ "$n" -eq 0 ]] || note "$n units have a non-container parent"
+# Every alias must resolve to at least one unit. A member set that came out
+# empty is a silently broken alias: the ingest reads it as unresolvable and
+# the placement it described never lands.
+n=$(q "SELECT COUNT(*) FROM lodging_unit_aliases WHERE member_units IS NULL OR json_array_length(member_units) = 0")
+[[ "$n" -eq 0 ]] || note "$n aliases have no member units"
 
 if [[ "$fail" -ne 0 ]]; then echo "verify-lodging-seed: FAILED" >&2; exit 1; fi
-echo "verify-lodging-seed: OK"
+echo "verify-lodging-seed: OK ($(q "SELECT COUNT(*) FROM lodging_units") units, $(q "SELECT COUNT(*) FROM lodging_unit_aliases") aliases)"

--- a/scripts/dev/verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/verify-no-hardcoded-lodging.sh
@@ -40,12 +40,34 @@ NEEDLES="Ridge Yurt|Tawonga Village|Manzanita|Tuolumne|Cloud'?s Rest|Wawona|Half
 #   pb_public/ — gitignored build output; the minified frontend bundle embeds
 #                the same city/school geo tables and matches "Kitty"/"Tioga" as
 #                ordinary US place names
-HITS=$(grep -rInE "$NEEDLES" \
+# Scan roots, overridable ONLY so the test suite can point the guard at a
+# missing directory and assert it fails rather than reporting a clean scan.
+read -r -a SCAN_ROOTS <<<"${LODGING_SCAN_ROOTS:-pocketbase/ api/ bunking/ frontend/src/}"
+
+# Capture grep's OWN status before the filter pipeline swallows it. grep exits
+# 0 for matches, 1 for none, and >=2 when the scan itself failed — an
+# unreadable or missing search root. The old form sent stderr to /dev/null and
+# ended in `|| true`, so a status-2 run produced no hits and printed OK: a
+# guard reporting clean on a scan that never happened. Flagged on this script
+# in kindred#1867 and asserted by TEST 6 in test-verify-no-hardcoded-lodging.sh.
+grep_status=0
+RAW=$(grep -rInE "$NEEDLES" \
   --include='*.go' --include='*.py' --include='*.ts' --include='*.tsx' --include='*.js' \
   --exclude-dir=pb_public --exclude-dir=node_modules \
-  pocketbase/ api/ bunking/ frontend/src/ 2>/dev/null \
-  | grep -v '_test\.\|\.test\.\|/tests\?/' \
-  | grep -v 'frontend/src/data/cityGeo\.ts\|frontend/src/data/schoolGeo\.ts' || true)
+  "${SCAN_ROOTS[@]}" 2>&1) || grep_status=$?
+
+if [[ "$grep_status" -ge 2 ]]; then
+  echo "error: grep exited $grep_status — the scan did not run, so this is NOT a clean result:" >&2
+  printf '%s\n' "$RAW" >&2
+  exit 2
+fi
+
+HITS=""
+if [[ -n "$RAW" ]]; then
+  HITS=$(printf '%s\n' "$RAW" \
+    | grep -v '_test\.\|\.test\.\|/tests\?/' \
+    | grep -v 'frontend/src/data/cityGeo\.ts\|frontend/src/data/schoolGeo\.ts' || true)
+fi
 
 # Prose that names a unit to explain a rule is documentation, not the registry
 # living in code. Dropping comment and docstring hits is what makes this guard

--- a/scripts/dev/verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/verify-no-hardcoded-lodging.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
-# Spec 3.8: the lodging registry is DATA, not code. Unit and alias lists may
-# exist only in seed migrations.
+# Spec 3.8: the lodging registry is DATA, not code. It now lives in exactly one
+# place — the private config/lodging_registry.json, carried in kindred-local
+# and loaded on boot (docs/reference/lodging-registry.md).
+#
+# It used to live in pb_migrations/, which is why this guard used to skip that
+# directory. It no longer does: with the data gone from the seed migrations,
+# that exclusion was a hole in precisely the place a future seed would land.
+# Prose in a migration is still fine — comments are dropped below — but a unit
+# list in a migration is now a failure, same as in any other source file.
 #
 # SCOPE, honestly stated: this is a tripwire, not a proof. It greps for a
 # REPRESENTATIVE SAMPLE of distinctive unit strings (NEEDLES below) — not the
@@ -27,15 +34,15 @@ cd "$REPO_ROOT"
 NEEDLES="Ridge Yurt|Tawonga Village|Manzanita|Tuolumne|Cloud'?s Rest|Wawona|Half Dome|El Cap|Bayit|Tenaya|Tioga|Le Shack|Lofty|Kitty|Doctor's House"
 
 # --include='*.js' matters: pocketbase/pb_hooks/ is application JavaScript and
-# would otherwise go unscanned entirely. But scanning .js drags in two kinds of
-# legitimate non-source noise, both excluded by directory rather than by file:
-#   pb_migrations/ — where the registry data is SUPPOSED to live (spec 3.8)
-#   pb_public/     — gitignored build output; the minified frontend bundle
-#                    embeds the same city/school geo tables and matches
-#                    "Kitty"/"Tioga" as ordinary US place names
+# pocketbase/pb_migrations/ is where the registry used to live, so both have to
+# be scanned. One directory is still excluded, and by directory rather than by
+# file:
+#   pb_public/ — gitignored build output; the minified frontend bundle embeds
+#                the same city/school geo tables and matches "Kitty"/"Tioga" as
+#                ordinary US place names
 HITS=$(grep -rInE "$NEEDLES" \
   --include='*.go' --include='*.py' --include='*.ts' --include='*.tsx' --include='*.js' \
-  --exclude-dir=pb_migrations --exclude-dir=pb_public --exclude-dir=node_modules \
+  --exclude-dir=pb_public --exclude-dir=node_modules \
   pocketbase/ api/ bunking/ frontend/src/ 2>/dev/null \
   | grep -v '_test\.\|\.test\.\|/tests\?/' \
   | grep -v 'frontend/src/data/cityGeo\.ts\|frontend/src/data/schoolGeo\.ts' || true)

--- a/scripts/setup/setup-local-config.sh
+++ b/scripts/setup/setup-local-config.sh
@@ -19,6 +19,10 @@ ln -sfr "$LOCAL_REPO/CLAUDE.local.md" "$REPO_ROOT/CLAUDE.local.md"
 ln -sfr "$LOCAL_REPO/config/branding.local.json" "$REPO_ROOT/config/branding.local.json"
 ln -sfr "$LOCAL_REPO/config/staff_list.json" "$REPO_ROOT/config/staff_list.json"
 ln -sfr "$LOCAL_REPO/config/nicknames_override.json" "$REPO_ROOT/config/nicknames_override.json"
+# The weekend-lodging unit registry. Camp-identifying data, so it lives here
+# rather than in pb_migrations/; PocketBase loads it on boot and degrades to an
+# empty registry when it is absent. See docs/reference/lodging-registry.md.
+ln -sfr "$LOCAL_REPO/config/lodging_registry.json" "$REPO_ROOT/config/lodging_registry.json"
 ln -sfr "$LOCAL_REPO/config/sheets_sharing.local.json" "$REPO_ROOT/config/sheets_sharing.local.json"
 ln -sfr "$LOCAL_REPO/frontend/vite.config.local.ts" "$REPO_ROOT/frontend/vite.config.local.ts"
 ln -sfr "$LOCAL_REPO/scripts/vault.config" "$REPO_ROOT/scripts/vault.config"

--- a/scripts/worktree/new.sh
+++ b/scripts/worktree/new.sh
@@ -272,6 +272,10 @@ if [ -d "$LOCAL_REPO" ]; then
     # Symlinked: dev-only files (not in Docker build context)
     ln -sfr "$LOCAL_REPO/CLAUDE.local.md" "$WORKTREE_DIR/CLAUDE.local.md"
     ln -sfr "$LOCAL_REPO/config/sheets_sharing.local.json" "$WORKTREE_DIR/config/sheets_sharing.local.json"
+    # The weekend-lodging unit registry, read at boot by PocketBase. Symlinked
+    # rather than copied so a worktree tracks kindred-local as the registry
+    # grows. See docs/reference/lodging-registry.md.
+    ln -sfr "$LOCAL_REPO/config/lodging_registry.json" "$WORKTREE_DIR/config/lodging_registry.json"
     ln -sfr "$LOCAL_REPO/frontend/vite.config.local.ts" "$WORKTREE_DIR/frontend/vite.config.local.ts"
     ln -sfr "$LOCAL_REPO/scripts/vault.config" "$WORKTREE_DIR/scripts/vault.config"
     rm -rf "$WORKTREE_DIR/docs/camp"


### PR DESCRIPTION
Closes the first acceptance item on #1909.

The repo is public and the lodging registry is camp-identifying — unit names and historical alias strings are **30 of the 76** camp-name occurrences that issue tracks. A 2026 inventory seed would have added roughly five times that, so the data moves now, ahead of the seed rather than after it.

## What changes

The registry becomes private data in `config/lodging_registry.json`, carried in `kindred-local` beside `branding.local.json` and `staff_list.json`, and loads on boot via `pocketbase/lodging/registry.go`. Migrations `1500000120`, `1500000121` and `1500000129` keep their prose and become no-ops.

Format and contract: `docs/reference/lodging-registry.md`.

## Three decisions worth reviewing

**It is a boot hook, not a migration — including not a migration that reads the file.** `_migrations` keys on *filename* and applies once. A migration reading an absent private file in CI would be recorded as applied and never re-run when the file later appeared: a silently empty registry. `verify-no-hardcoded-lodging.sh` now scans `pb_migrations/` so this cannot be reintroduced by accident.

**Create-if-absent, not a full upsert.** The registry is staff-editable in `/manage/lodging`, so a loader that rewrote every field on boot would undo confirmations and corrected coordinates on the next restart. Two consequences:

- It is an exact no-op on every database the seed migrations already populated, **production included** — those rows stay, since PocketBase will not re-run an edited migration file.
- It will **not** backfill a new field onto rows that already exist. Adding amenity columns to existing units needs its own one-off; the file alone won't apply them. Flagging this for the inventory PR that follows.

**`verify-lodging-seed.sh` is rewritten rather than patched.** Its previous assertions named units and aliases directly — literals of the very strings the private file exists to keep out of a public repo, so patching the count would have left the leak. It now asserts the database matches the file field by field (`scripts/dev/lib/diff_lodging_registry.py`), which carries zero literals and is stricter than the row counts it replaces: it catches a dropped unit, a mangled coordinate and a short alias member set.

## Where the prose went

`1500000120`'s header recorded real knowledge. It split rather than being deleted: format-level semantics (0-means-unknown, normalised coordinates, the unbounded-year trap) into the tracked `docs/reference/lodging-registry.md`; camp-specific facts into the private file's `_notes`, beside the data they describe, since a tracked doc reproducing them would reopen what this PR closes.

## Evidence

- The extracted file **reproduces the seeded database exactly** — all 93 units, 100 aliases, 8 areas, every field compared.
- A fresh database built from migrations plus the boot loader matches the file (`verify-lodging-seed.sh`: OK).
- Booting twice against the same database adds `areas_added=0 units_added=0 aliases_added=0`.
- A tree without the private file boots healthy: 0 units and `lodging registry file not found; registry left as-is`.
- Staff edits survive a re-seed; a deliberately cleared `parent_unit` stays cleared. Both pinned by tests that were mutation-checked against the naive implementation.
- All seven dependent test files green; full mockable suite 5745 passed.
- **Camp-name occurrences: 76 -> 46**, leaving only the three clusters #1909 records as remaining (CampMinder field vocabulary, de-branding tests, the guard's own `NEEDLES`).

## Deliberately not in this PR

- **`docker/Dockerfile.pocketbase` copies no `config/`**, so a from-scratch *production* database would boot with an empty registry. Existing production rows are unaffected and CD's integration tests use the committed synthetic database, so nothing breaks today — but it is worth fixing before anyone rebuilds production from migrations alone.
- Unit names remain in explanatory comments in the *schema* migrations (`1500000116`/`117`/`118`), untouched here. Those are prose, which the guard permits by design, and none carry the camp name.
- The 2026 inventory seed, the new amenity fields and the alias additions are the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Lodging areas, units, parent relationships, and aliases now load automatically when the application starts.
  - Initial data is created only when missing, preserving staff updates and existing relationships.
  - Added support for nullable values and time-limited aliases.

- **Bug Fixes**
  - Improved validation and error reporting for malformed registry data and unknown references.
  - Added checks to detect differences between configured lodging data and stored records.

- **Documentation**
  - Added guidance for managing the private lodging registry and its loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->