### PR TITLE
feat(frontend): read-only Family Camp lodging board

### DIFF
--- a/frontend/src/components/BunkingBoardByArea.clickoutside.test.tsx
+++ b/frontend/src/components/BunkingBoardByArea.clickoutside.test.tsx
@@ -13,6 +13,31 @@
 import { describe, it, expect } from 'vitest'
 import { shouldKeepPanelsOpen } from '../utils/clickoutsidePredicate'
 
+describe('weekend lodging board click-outside predicate', () => {
+  it('keeps the family details panel open on a click inside it', () => {
+    // Not every click inside the panel lands on a button — the request-text
+    // blockquote and the children list are plain text, and dismissing on
+    // those would make the panel feel broken.
+    const panel = document.createElement('div')
+    panel.setAttribute('data-panel', 'family-details')
+    const text = document.createElement('blockquote')
+    panel.appendChild(text)
+    document.body.appendChild(panel)
+    expect(shouldKeepPanelsOpen({ ctrlKey: false, metaKey: false, target: text })).toBe(true)
+    panel.remove()
+  })
+
+  it('keeps panels open when the click lands on a family card', () => {
+    const card = document.createElement('div')
+    card.setAttribute('data-family-card', '')
+    const name = document.createElement('span')
+    card.appendChild(name)
+    document.body.appendChild(card)
+    expect(shouldKeepPanelsOpen({ ctrlKey: false, metaKey: false, target: name })).toBe(true)
+    card.remove()
+  })
+})
+
 describe('BunkingBoardByArea click-outside predicate', () => {
   it('keeps panels open on Ctrl+click', () => {
     const target = document.createElement('div')

--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -1,0 +1,284 @@
+/**
+ * The family card is the board's atom — a household of mixed ages, not a
+ * camper.
+ *
+ * The load-bearing tests here are the ABSENCES. Spec §3.8 keeps three things
+ * off the card, each for a measured reason, and each is the kind of thing a
+ * later session would helpfully add back:
+ *
+ *   - request text: 12 of 232 contain health vocabulary including a named
+ *     diagnosis, and the roster's PHI exposure was accepted for opening ONE
+ *     row at a time, not for printing it across 62 cards at once;
+ *   - the medical affordance: true for 62 of 62 parties;
+ *   - `needs_resolution`: true for 44 of 62.
+ *
+ * A flag that is always on is not a flag.
+ *
+ * Fictional data throughout.
+ */
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import { FamilyCard } from './FamilyCard'
+
+function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
+  return {
+    grain: 'household',
+    household_cm_id: 101,
+    display_name: 'Johnson',
+    adults: [{ adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' }],
+    children: [
+      { person_cm_id: 9001, display_name: 'Noah Johnson', age: 8, grade: 3 },
+      { person_cm_id: 9002, display_name: 'Ava Johnson', age: 5, grade: 0 },
+    ],
+    party_size: 4,
+    unit_code: 'cedar-1',
+    unit_name: 'Cedar 1',
+    is_merged_slot: false,
+    arrival_eta: '',
+    is_returning: false,
+    ...overrides,
+  }
+}
+
+function confirmedUnit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
+  return {
+    unit_id: 'u1',
+    code: 'cedar-1',
+    name: 'Cedar 1',
+    area_code: 'CG',
+    area_name: 'Cedar Grove',
+    sleeps: 5,
+    bathroom: 'shared',
+    bathroom_group: '',
+    near_bathhouse: false,
+    has_power: false,
+    has_ac: false,
+    has_fridge: false,
+    is_accessible: false,
+    is_confirmed: true,
+    is_active: true,
+    is_container: false,
+    allocation_default: 'family_pool',
+    reservation_state: null,
+    is_family_available: true,
+    map_x: 0.5,
+    map_y: 0.5,
+    ...overrides,
+  }
+}
+
+const REQUEST_TEXT = 'Please put us near the Garcia family, and we need a ground-floor room.'
+
+describe('FamilyCard — what it shows', () => {
+  it('names the household and its size', () => {
+    render(<FamilyCard party={party()} onOpen={vi.fn()} />)
+    expect(screen.getByText('Johnson')).toBeInTheDocument()
+    expect(screen.getByText('4')).toBeInTheDocument()
+  })
+
+  it('shows children with ages, which is the entire point of a similar-ages match', () => {
+    render(<FamilyCard party={party()} onOpen={vi.fn()} />)
+    expect(screen.getByText(/Noah/)).toBeInTheDocument()
+    expect(screen.getByText(/8/)).toBeInTheDocument()
+    expect(screen.getByText(/Ava/)).toBeInTheDocument()
+    expect(screen.getByText(/5/)).toBeInTheDocument()
+  })
+
+  it('omits an age it does not have rather than inventing one', () => {
+    render(
+      <FamilyCard
+        party={party({
+          children: [{ person_cm_id: 9001, display_name: 'Noah', age: null, grade: null }],
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/Noah/)).toBeInTheDocument()
+    expect(screen.queryByText(/Noah \(0\)/)).not.toBeInTheDocument()
+  })
+
+  it('chips the housing needs the fit check judges', () => {
+    render(
+      <FamilyCard
+        party={party({ flags: { needs_power: true, needs_private_bathroom: true } })}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Power')).toBeInTheDocument()
+    expect(screen.getByText('Private bathroom')).toBeInTheDocument()
+  })
+
+  it('marks a mandatory accommodation, which outranks placement', () => {
+    render(
+      <FamilyCard
+        party={party({ flags: { needs_accommodation: true, accommodation_is_mandatory: true } })}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Accommodation required')).toBeInTheDocument()
+  })
+
+  it('marks a returning household', () => {
+    render(<FamilyCard party={party({ is_returning: true })} onOpen={vi.fn()} />)
+    expect(screen.getByText('Returning')).toBeInTheDocument()
+  })
+
+  it('says the fit is unverified rather than judging against an unconfirmed cabin', () => {
+    // `has_power: false` on an unconfirmed row means "nobody has said". 0 of
+    // 93 units are confirmed today, so this is the normal verdict.
+    render(
+      <FamilyCard
+        party={party({ flags: { needs_power: true } })}
+        unit={confirmedUnit({ is_confirmed: false })}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Fit not verified')).toBeInTheDocument()
+  })
+
+  it('says the cabin does not fit only once the cabin is confirmed', () => {
+    render(
+      <FamilyCard
+        party={party({ flags: { needs_power: true } })}
+        unit={confirmedUnit({ has_power: false })}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.getByText('No power')).toBeInTheDocument()
+  })
+
+  it('marks the party that declined sharing when it is in a flagged slot', () => {
+    render(
+      <FamilyCard
+        party={party({
+          share: {
+            preference: 'no_share',
+            proximity: [],
+            request_text: '',
+            needs_resolution: false,
+          },
+        })}
+        sharedSlot={true}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Declined sharing')).toBeInTheDocument()
+  })
+
+  it('does not call a party out for declining when it has the room to itself', () => {
+    render(
+      <FamilyCard
+        party={party({
+          share: {
+            preference: 'no_share',
+            proximity: [],
+            request_text: '',
+            needs_resolution: false,
+          },
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.queryByText('Declined sharing')).not.toBeInTheDocument()
+  })
+
+  it('shows a share request as one chip covering both `with` and `similar_ages`', () => {
+    // `similar_ages` ACCOMPANIES `with`; a chip showing one or the other drops
+    // 22 households out of any "wants to share" view.
+    render(
+      <FamilyCard
+        party={party({
+          share: {
+            preference: 'yes_share',
+            proximity: ['with', 'similar_ages'],
+            request_text: '',
+            needs_resolution: false,
+          },
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Wants to share')).toBeInTheDocument()
+  })
+
+  it('shows a similar-ages request even without an explicit `with`', () => {
+    render(
+      <FamilyCard
+        party={party({
+          share: {
+            preference: 'yes_share',
+            proximity: ['similar_ages'],
+            request_text: '',
+            needs_resolution: false,
+          },
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Wants to share')).toBeInTheDocument()
+  })
+})
+
+describe('FamilyCard — spec §3.8, what must stay off it', () => {
+  it('never prints request text on the card', () => {
+    // THE regression guard. 12 of 232 request texts carry health vocabulary
+    // including a named diagnosis; the roster's accepted exposure was one row
+    // at a time, not 62 cards at once. It lives on the detail panel.
+    render(
+      <FamilyCard
+        party={party({
+          share: {
+            preference: 'yes_share',
+            proximity: ['with'],
+            request_text: REQUEST_TEXT,
+            needs_resolution: true,
+          },
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.queryByText(REQUEST_TEXT)).not.toBeInTheDocument()
+    expect(screen.queryByText(new RegExp('ground-floor'))).not.toBeInTheDocument()
+  })
+
+  it('never offers the medical affordance, which is true for 62 of 62 parties', () => {
+    render(
+      <FamilyCard party={party({ flags: { has_medical_narrative: true } })} onOpen={vi.fn()} />
+    )
+    expect(screen.queryByText(/Medical/i)).not.toBeInTheDocument()
+  })
+
+  it('never shows `needs_resolution`, which is true for 44 of 62', () => {
+    render(
+      <FamilyCard
+        party={party({
+          share: {
+            preference: 'yes_share',
+            proximity: [],
+            request_text: '',
+            needs_resolution: true,
+          },
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.queryByText(/Needs resolution/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('FamilyCard — opening the detail panel', () => {
+  it('calls back with the party when clicked', async () => {
+    const onOpen = vi.fn()
+    render(<FamilyCard party={party()} onOpen={onOpen} />)
+    await userEvent.click(screen.getByRole('button', { name: /Johnson/ }))
+    expect(onOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('is a real button, so it is reachable by keyboard', () => {
+    render(<FamilyCard party={party()} onOpen={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /Johnson/ })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -1,0 +1,161 @@
+/**
+ * The board's atom: a household party of mixed ages.
+ *
+ * NOT a camper. The summer board's `CamperCard` sits inside a tall bunk column
+ * beside 10–14 siblings-in-cabin; this sits alone, or beside one other party,
+ * in a room. The topology differs as much as the domain does, which is why
+ * this is a new component rather than a branch inside the 849-line
+ * `BunkingBoardByArea.tsx`.
+ *
+ * ## Three things stay OFF this card (spec §3.8), each measured
+ *
+ * - **Request text.** 12 of 232 request texts contain health vocabulary
+ *   including a named diagnosis. HANDOFF §8 accepted that exposure on the
+ *   roster, where you open ONE row to read ONE household; printing it across
+ *   62 simultaneously-visible cards is a materially louder exposure than that
+ *   decision covered. It lives on `FamilyDetailsPanel`, one click away —
+ *   which is what makes this a deferral rather than a loss.
+ * - **The medical affordance.** `has_medical_narrative` is true for 62 of 62
+ *   parties. A flag that is always on is not a flag.
+ * - **`needs_resolution`.** True for 44 of 62. Same reason.
+ *
+ * `FamilyCard.test.tsx` pins all three as ABSENCES, because each is exactly
+ * the kind of thing a later session adds back helpfully.
+ *
+ * What IS here: the household name, the party size, the children with their
+ * ages — ages are the entire point of a "similar ages" match — and the housing
+ * chips the fit check actually judges.
+ */
+import { Repeat, Users } from 'lucide-react'
+import { Fragment } from 'react'
+
+import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import { ATTENTION_LABEL, partyAttention } from './rosterAttention'
+
+export interface FamilyCardProps {
+  party: RosterPartyRow
+  /** The cabin it sits in, when one resolves. Undefined on the rail. */
+  unit?: LodgingUnitRow | undefined
+  /**
+   * Whether another party is in the same room. Declining to share is the
+   * ordinary answer and contradicts nothing on its own — it only becomes
+   * worth saying when somebody else is in the room (spec §11).
+   */
+  sharedSlot?: boolean
+  /** Rail cards sit on the page background rather than inside a slot. */
+  onRail?: boolean
+  onOpen: (party: RosterPartyRow) => void
+}
+
+type ChipTone = 'need' | 'warn' | 'share' | 'quiet' | 'muted'
+
+const CHIP_TONE: Record<ChipTone, string> = {
+  need: 'bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-300',
+  warn: 'bg-red-100 text-red-800 dark:bg-red-950/50 dark:text-red-300',
+  share: 'bg-forest-100 text-forest-800 dark:bg-forest-950/50 dark:text-forest-300',
+  quiet: 'border-border text-muted-foreground border border-dashed',
+  muted: 'bg-muted text-muted-foreground',
+}
+
+function Chip({ label, tone }: { label: string; tone: ChipTone }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-semibold whitespace-nowrap ${CHIP_TONE[tone]}`}
+    >
+      {label}
+    </span>
+  )
+}
+
+/** How many people the party brings. */
+function partySize(party: RosterPartyRow): number {
+  const reported = party.party_size ?? 0
+  if (reported > 0) return reported
+  return (party.adults?.length ?? 0) + (party.children?.length ?? 0)
+}
+
+export function FamilyCard({
+  party,
+  unit,
+  sharedSlot = false,
+  onRail = false,
+  onOpen,
+}: FamilyCardProps) {
+  const flags = party.flags ?? {}
+  const children = party.children ?? []
+  const attention = partyAttention(party, unit)
+  const proximity = party.share?.proximity ?? []
+  // `similar_ages` ACCOMPANIES `with`; it never replaces it. One chip covering
+  // both is what keeps 22 households from dropping out of a "wants to share"
+  // view — a chip showing one *or* the other loses them.
+  const wantsToShare = proximity.includes('with') || proximity.includes('similar_ages')
+  const wantsNear = proximity.includes('near')
+
+  return (
+    <button
+      type="button"
+      data-family-card
+      onClick={() => {
+        onOpen(party)
+      }}
+      className={`group border-border hover:border-primary/50 focus-visible:ring-ring flex w-full flex-col gap-1 rounded-lg border px-2 py-1.5 text-left transition-colors focus-visible:ring-2 focus-visible:outline-none ${
+        onRail ? 'bg-card' : 'bg-background'
+      }`}
+    >
+      <span className="flex items-baseline gap-1.5">
+        <span className="text-foreground text-[13px] leading-tight font-semibold">
+          {party.display_name}
+        </span>
+        <span className="text-muted-foreground ml-auto inline-flex items-center gap-0.5 text-[11px] tabular-nums">
+          <Users className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+          {partySize(party)}
+        </span>
+      </span>
+
+      {children.length > 0 && (
+        <span className="text-muted-foreground text-[11px] leading-snug">
+          {children.map((child, index) => (
+            <Fragment key={String(child.person_cm_id ?? index)}>
+              {index > 0 && ' · '}
+              {/* An age we do not have is omitted, never rendered as 0. */}
+              <span>
+                {child.age === null || child.age === undefined
+                  ? child.display_name
+                  : `${String(child.display_name)} (${String(child.age)})`}
+              </span>
+            </Fragment>
+          ))}
+        </span>
+      )}
+
+      <span className="flex flex-wrap gap-1">
+        {/* The needs a cabin field can actually answer — the same two the fit
+            check judges. `needs_accommodation` names no specific amenity, so
+            it is carried by the verdict chip below instead of duplicated. */}
+        {flags.needs_private_bathroom === true && <Chip label="Private bathroom" tone="need" />}
+        {flags.needs_power === true && <Chip label="Power" tone="need" />}
+
+        {attention.level === 'required' && <Chip label={ATTENTION_LABEL.required} tone="warn" />}
+        {attention.level === 'unmet' && <Chip label={attention.reason} tone="warn" />}
+        {attention.level === 'unverified' && (
+          <Chip label={ATTENTION_LABEL.unverified} tone="quiet" />
+        )}
+
+        {sharedSlot && party.share?.preference === 'no_share' && (
+          <Chip label="Declined sharing" tone="warn" />
+        )}
+        {wantsToShare && <Chip label="Wants to share" tone="share" />}
+        {/* NEAR and WITH are different requests: NEAR is satisfied by map
+            distance between units, WITH by putting both in one room. */}
+        {wantsNear && <Chip label="Near another family" tone="muted" />}
+
+        {party.is_returning === true && (
+          <span className="text-forest-700 dark:text-forest-300 inline-flex items-center gap-0.5 text-[10px] font-semibold">
+            <Repeat className="h-2.5 w-2.5 flex-shrink-0" aria-hidden="true" />
+            Returning
+          </span>
+        )}
+      </span>
+    </button>
+  )
+}

--- a/frontend/src/components/weekend/FamilyDetailsPanel.test.tsx
+++ b/frontend/src/components/weekend/FamilyDetailsPanel.test.tsx
@@ -31,8 +31,17 @@ vi.mock('../../hooks/useWeekendRoster', () => ({
   useHouseholdMedical: () => ({ data: undefined, isLoading: false, error: null }),
 }))
 
+// One client per TEST, built outside the render path. Constructing it inside
+// the wrapper body rebuilds it on every render, discarding the cache and
+// starting a fresh loading pass underneath assertions that already resolved.
+// Same fix as `admin/lodging/LodgingUnitsPanel.test.tsx`.
+let client: QueryClient
+
+beforeEach(() => {
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+})
+
 function wrapper({ children }: { children: ReactNode }) {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>
 }
 

--- a/frontend/src/components/weekend/FamilyDetailsPanel.test.tsx
+++ b/frontend/src/components/weekend/FamilyDetailsPanel.test.tsx
@@ -1,0 +1,258 @@
+/**
+ * The detail panel is what makes §3.8's omissions a DEFERRAL rather than a
+ * loss — request text and the medical narrative are one click away, not gone.
+ *
+ * It mirrors `CamperDetailsPanel`'s interaction contract and reuses none of
+ * its 1442 camper-coupled lines.
+ *
+ * Fictional data throughout.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import { FamilyDetailsPanel } from './FamilyDetailsPanel'
+
+const isAdmin = { value: true }
+
+vi.mock('../../hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    isAdmin: isAdmin.value,
+    permissions: [],
+    hasPermission: () => isAdmin.value,
+    hasAnyPermission: () => isAdmin.value,
+  }),
+}))
+
+vi.mock('../../hooks/useWeekendRoster', () => ({
+  useHouseholdMedical: () => ({ data: undefined, isLoading: false, error: null }),
+}))
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+const REQUEST_TEXT = 'We would like to be near the Garcia family if there is room.'
+
+function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
+  return {
+    grain: 'household',
+    household_cm_id: 101,
+    display_name: 'Johnson',
+    adults: [
+      { adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' },
+      { adult_number: 2, display_name: 'David Johnson', relationship: 'Father' },
+    ],
+    children: [{ person_cm_id: 9001, display_name: 'Noah Johnson', age: 8, grade: 3 }],
+    party_size: 3,
+    unit_code: 'cedar-1',
+    unit_name: 'Cedar 1',
+    is_merged_slot: false,
+    arrival_eta: 'Friday 6pm',
+    is_returning: true,
+    share: {
+      preference: 'yes_share',
+      proximity: ['with'],
+      request_text: REQUEST_TEXT,
+      needs_resolution: false,
+    },
+    flags: { has_medical_narrative: true },
+    ...overrides,
+  }
+}
+
+function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
+  return {
+    unit_id: 'u1',
+    code: 'cedar-1',
+    name: 'Cedar 1',
+    area_code: 'CG',
+    area_name: 'Cedar Grove',
+    sleeps: 5,
+    bathroom: 'shared',
+    bathroom_group: '',
+    near_bathhouse: false,
+    has_power: false,
+    has_ac: false,
+    has_fridge: false,
+    is_accessible: false,
+    is_confirmed: false,
+    is_active: true,
+    is_container: false,
+    allocation_default: 'family_pool',
+    reservation_state: null,
+    is_family_available: true,
+    map_x: 0.5,
+    map_y: 0.5,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  isAdmin.value = true
+})
+
+describe('FamilyDetailsPanel — the content the card omits', () => {
+  it('shows the verbatim request text, one click from the board', () => {
+    render(<FamilyDetailsPanel party={party()} year={2026} onClose={vi.fn()} />, { wrapper })
+    expect(screen.getByText(REQUEST_TEXT)).toBeInTheDocument()
+  })
+
+  it('offers the medical reveal, which the card never does', () => {
+    render(<FamilyDetailsPanel party={party()} year={2026} onClose={vi.fn()} />, { wrapper })
+    expect(screen.getByRole('button', { name: /medical detail/i })).toBeInTheDocument()
+  })
+
+  it('does not offer the medical reveal for an adult-weekend party', () => {
+    // A person-grain party has no household, so there is nothing to look a
+    // narrative up by and the reveal could only ever fail.
+    render(
+      <FamilyDetailsPanel
+        party={party({
+          grain: 'person',
+          household_cm_id: 0,
+          person_cm_id: 5001,
+          adults: [],
+          children: [],
+        })}
+        year={2026}
+        onClose={vi.fn()}
+      />,
+      { wrapper }
+    )
+    expect(screen.queryByRole('button', { name: /medical detail/i })).not.toBeInTheDocument()
+  })
+})
+
+describe('FamilyDetailsPanel — household identity', () => {
+  it('names the household', () => {
+    render(<FamilyDetailsPanel party={party()} year={2026} onClose={vi.fn()} />, { wrapper })
+    expect(screen.getByRole('heading', { name: 'Johnson' })).toBeInTheDocument()
+  })
+
+  it('lists adults with their relationships', () => {
+    render(<FamilyDetailsPanel party={party()} year={2026} onClose={vi.fn()} />, { wrapper })
+    expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
+    expect(screen.getByText('Mother')).toBeInTheDocument()
+    expect(screen.getByText('David Johnson')).toBeInTheDocument()
+  })
+
+  it('lists children with ages and grades', () => {
+    render(<FamilyDetailsPanel party={party()} year={2026} onClose={vi.fn()} />, { wrapper })
+    expect(screen.getByText('Noah Johnson')).toBeInTheDocument()
+    expect(screen.getByText(/Age 8/)).toBeInTheDocument()
+  })
+
+  it('reports party size, arrival and returning status', () => {
+    render(<FamilyDetailsPanel party={party()} year={2026} onClose={vi.fn()} />, { wrapper })
+    expect(screen.getByText(/Friday 6pm/)).toBeInTheDocument()
+    expect(screen.getByText('Returning')).toBeInTheDocument()
+  })
+})
+
+describe('FamilyDetailsPanel — current placement', () => {
+  it('names the unit and its area', () => {
+    render(<FamilyDetailsPanel party={party()} unit={unit()} year={2026} onClose={vi.fn()} />, {
+      wrapper,
+    })
+    expect(screen.getByText('Cedar 1')).toBeInTheDocument()
+    expect(screen.getByText('Cedar Grove')).toBeInTheDocument()
+  })
+
+  it('says a merged slot is a merge', () => {
+    render(
+      <FamilyDetailsPanel
+        party={party({ unit_code: '', unit_name: 'Cedar 3 + Cedar 4', is_merged_slot: true })}
+        year={2026}
+        onClose={vi.fn()}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByText('Cedar 3 + Cedar 4')).toBeInTheDocument()
+    expect(screen.getByText('Merged')).toBeInTheDocument()
+  })
+
+  it('says an unplaced party has no cabin yet', () => {
+    render(
+      <FamilyDetailsPanel
+        party={party({ unit_code: '', unit_name: '' })}
+        year={2026}
+        onClose={vi.fn()}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByText('No cabin yet')).toBeInTheDocument()
+  })
+
+  it('reports the fit verdict', () => {
+    render(
+      <FamilyDetailsPanel
+        party={party({ flags: { needs_power: true } })}
+        unit={unit()}
+        year={2026}
+        onClose={vi.fn()}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByText('Fit not verified')).toBeInTheDocument()
+  })
+})
+
+describe('FamilyDetailsPanel — interaction contract', () => {
+  it('marks itself so the board click-outside handler can spare it', () => {
+    const { container } = render(
+      <FamilyDetailsPanel party={party()} year={2026} onClose={vi.fn()} />,
+      { wrapper }
+    )
+    expect(container.querySelector('[data-panel="family-details"]')).toBeInTheDocument()
+  })
+
+  it('lays a click-outside catcher over the page', () => {
+    const { container } = render(
+      <FamilyDetailsPanel party={party()} year={2026} onClose={vi.fn()} />,
+      { wrapper }
+    )
+    expect(container.querySelector('.pointer-events-none.fixed.inset-0')).toBeInTheDocument()
+  })
+
+  it('closes on the close button', async () => {
+    const onClose = vi.fn()
+    render(<FamilyDetailsPanel party={party()} year={2026} onClose={onClose} />, { wrapper })
+    await userEvent.click(screen.getByRole('button', { name: /close panel/i }))
+    // The slide-out animation runs first; jsdom fires animationend only when
+    // driven, so the close is requested rather than immediate.
+    expect(screen.getByTestId('family-details-panel')).toHaveClass('animate-slide-out-right')
+  })
+
+  it('drops the overlay chrome in embedded mode, so the map can reuse it', () => {
+    // One component, both surfaces — a second implementation is exactly what
+    // this prop exists to prevent.
+    const { container } = render(
+      <FamilyDetailsPanel party={party()} year={2026} embedded={true} onClose={vi.fn()} />,
+      { wrapper }
+    )
+    expect(container.querySelector('.pointer-events-none.fixed.inset-0')).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Johnson' })).toBeInTheDocument()
+  })
+
+  it('closes immediately in embedded mode, where there is no slide-out', async () => {
+    const onClose = vi.fn()
+    render(<FamilyDetailsPanel party={party()} year={2026} embedded={true} onClose={onClose} />, {
+      wrapper,
+    })
+    await userEvent.click(screen.getByRole('button', { name: /close panel/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs the exit animation when the parent requests a close', () => {
+    render(
+      <FamilyDetailsPanel party={party()} year={2026} requestClose={true} onClose={vi.fn()} />,
+      { wrapper }
+    )
+    expect(screen.getByTestId('family-details-panel')).toHaveClass('animate-slide-out-right')
+  })
+})

--- a/frontend/src/components/weekend/FamilyDetailsPanel.tsx
+++ b/frontend/src/components/weekend/FamilyDetailsPanel.tsx
@@ -1,0 +1,290 @@
+/**
+ * Everything the family card omits (spec §3.9).
+ *
+ * This is what makes §3.8's three omissions a DEFERRAL rather than a loss —
+ * the request text and the medical narrative are one click away, not gone.
+ * Request text is unchanged in REACH, only in placement: it already renders on
+ * the roster row through the same `ShareRequestPanel`. Moving it here rather
+ * than onto 62 simultaneously-visible cards is the whole of the narrowing.
+ *
+ * **Mirror the contract, not the code.** `CamperDetailsPanel` is 1442 lines and
+ * deeply camper-coupled — bunk requests, satisfaction buckets, AG collapse,
+ * camper journeys. None of it is reused. What is copied is the interaction
+ * shape the board already implements: `{ onClose, requestClose, embedded }`,
+ * `requestClose` driving an animated close, the `pointer-events-none fixed
+ * inset-0 z-[59]` click-outside layer, and `shouldKeepPanelsOpen` for
+ * dismissal.
+ *
+ * **One component, both surfaces.** The map (Step 6) opens this same panel
+ * embedded; a second implementation is exactly what `embedded` exists to
+ * prevent.
+ */
+import { Clock, Home, Repeat, Users, X } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+
+import type {
+  AccessibilityFlags,
+  LodgingUnitRow,
+  RosterPartyRow,
+  ShareRequest,
+} from '../../types/lodging'
+import { AccessibilityFlagList } from './AccessibilityFlagList'
+import { ATTENTION_LABEL, partyAttention } from './rosterAttention'
+import { ShareRequestPanel } from './ShareRequestPanel'
+
+export interface FamilyDetailsPanelProps {
+  party: RosterPartyRow
+  /** The cabin it sits in, when one resolves. Undefined for a merge. */
+  unit?: LodgingUnitRow | undefined
+  year: number
+  /** Rendered inline (the map's sidebar) rather than as a slide-in overlay. */
+  embedded?: boolean
+  /** Parent-driven animated close, as the summer board does. */
+  requestClose?: boolean
+  onClose: () => void
+}
+
+/** An unanswered request, used when the payload omits the block entirely. */
+const NO_SHARE_REQUEST: ShareRequest = {
+  preference: 'unknown',
+  preference_raw: '',
+  proximity: [],
+  request_text: '',
+  needs_resolution: false,
+}
+
+const NO_FLAGS: AccessibilityFlags = {
+  needs_private_bathroom: false,
+  needs_power: false,
+  needs_accommodation: false,
+  accommodation_is_mandatory: false,
+  has_infant: false,
+  has_medical_narrative: false,
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="flex flex-col gap-1.5">
+      <h3 className="text-muted-foreground text-[11px] font-bold tracking-wider uppercase">
+        {title}
+      </h3>
+      {children}
+    </section>
+  )
+}
+
+export function FamilyDetailsPanel({
+  party,
+  unit,
+  year,
+  embedded = false,
+  requestClose = false,
+  onClose,
+}: FamilyDetailsPanelProps) {
+  const [isClosing, setIsClosing] = useState(false)
+  const exiting = requestClose || isClosing
+
+  const handleClose = useCallback(() => {
+    // Embedded has no slide-out to run, so waiting for an animation that never
+    // fires would leave the panel stuck open.
+    if (embedded) onClose()
+    else setIsClosing(true)
+  }, [embedded, onClose])
+
+  const handleAnimationEnd = useCallback(
+    (event: React.AnimationEvent) => {
+      if (!exiting) return
+      // jsdom reports an empty animationName; allow it so tests can drive the
+      // same path the browser takes.
+      const name = event.animationName || ''
+      if (name.length === 0 || name.includes('Out')) onClose()
+    },
+    [exiting, onClose]
+  )
+
+  useEffect(() => {
+    if (embedded || isClosing) return
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') handleClose()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [embedded, isClosing, handleClose])
+
+  const adults = party.adults ?? []
+  const children = party.children ?? []
+  const isHousehold = party.grain === 'household'
+  // A person-grain party has no household, and the API sends 0 rather than
+  // omitting the field. `null` says "nothing to look up", so the medical
+  // reveal is not offered where it could only ever 404.
+  const householdCmId = isHousehold ? (party.household_cm_id ?? 0) : 0
+  const attention = partyAttention(party, unit)
+  const isPlaced = (party.unit_name ?? '').length > 0
+  const partySize = party.party_size ?? adults.length + children.length
+
+  const body = (
+    <div className="flex flex-col gap-4 p-4">
+      <Section title="Placement">
+        <div className="flex flex-wrap items-center gap-2">
+          <Home className="text-muted-foreground h-4 w-4 flex-shrink-0" aria-hidden="true" />
+          {isPlaced ? (
+            <span className="text-foreground text-sm font-medium">{party.unit_name}</span>
+          ) : (
+            <span className="text-muted-foreground text-sm italic">No cabin yet</span>
+          )}
+          {party.is_merged_slot === true && (
+            <span
+              title="Two rooms combined into one slot"
+              className="bg-muted text-muted-foreground rounded-full px-2 py-0.5 text-xs font-semibold"
+            >
+              Merged
+            </span>
+          )}
+          {unit?.area_name !== undefined && unit.area_name.length > 0 && (
+            <span className="text-muted-foreground text-xs">{unit.area_name}</span>
+          )}
+        </div>
+        {/* 0 of 93 units are confirmed today, so "unverified" is the honest
+            verdict for every constrained party — not a bug to route around. */}
+        {attention.level !== 'settled' && attention.level !== 'unplaced' && (
+          <p className="text-muted-foreground flex flex-wrap items-baseline gap-1.5 text-xs">
+            <span className="font-medium">{ATTENTION_LABEL[attention.level]}</span>
+            {attention.reason.length > 0 && <span>{attention.reason}</span>}
+          </p>
+        )}
+      </Section>
+
+      <Section title="Party">
+        <div className="text-muted-foreground flex flex-wrap items-center gap-3 text-xs">
+          <span className="inline-flex items-center gap-1">
+            <Users className="h-3.5 w-3.5" aria-hidden="true" />
+            {`${String(partySize)} ${partySize === 1 ? 'person' : 'people'}`}
+          </span>
+          {(party.arrival_eta ?? '').length > 0 && (
+            <span className="inline-flex items-center gap-1">
+              <Clock className="h-3.5 w-3.5" aria-hidden="true" />
+              {party.arrival_eta}
+            </span>
+          )}
+          {party.is_returning === true && (
+            <span className="text-forest-700 dark:text-forest-300 inline-flex items-center gap-1 font-semibold">
+              <Repeat className="h-3.5 w-3.5" aria-hidden="true" />
+              Returning
+            </span>
+          )}
+        </div>
+
+        {isHousehold && adults.length > 0 && (
+          <ul className="flex flex-col gap-0.5" role="list">
+            {adults.map((adult, index) => (
+              <li
+                key={`${String(adult.adult_number ?? index)}-${String(adult.display_name)}`}
+                className="flex flex-wrap items-baseline gap-2 text-sm"
+              >
+                <span className="text-foreground">{adult.display_name}</span>
+                {(adult.relationship ?? '').length > 0 && (
+                  <span className="text-muted-foreground text-xs">{adult.relationship}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {children.length > 0 && (
+          <ul className="flex flex-col gap-0.5" role="list">
+            {children.map((child, index) => (
+              <li
+                key={String(child.person_cm_id ?? index)}
+                className="flex flex-wrap items-baseline gap-2 text-sm"
+              >
+                <span className="text-foreground">{child.display_name}</span>
+                <span className="text-muted-foreground text-xs">
+                  {/* An age or grade we do not have is omitted, never zero. */}
+                  {[
+                    child.age === null || child.age === undefined ? '' : `Age ${String(child.age)}`,
+                    child.grade === null || child.grade === undefined || child.grade === 0
+                      ? ''
+                      : `Grade ${String(child.grade)}`,
+                  ]
+                    .filter((part) => part.length > 0)
+                    .join(' · ')}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Section>
+
+      <Section title="Share request">
+        <ShareRequestPanel share={party.share ?? NO_SHARE_REQUEST} />
+      </Section>
+
+      <Section title="Housing needs">
+        <AccessibilityFlagList
+          flags={party.flags ?? NO_FLAGS}
+          householdCmId={householdCmId > 0 ? householdCmId : null}
+          year={year}
+        />
+      </Section>
+    </div>
+  )
+
+  const header = (
+    <div className="from-forest-700 via-forest-800 to-forest-900 flex flex-shrink-0 items-start gap-3 bg-gradient-to-br p-4 text-white">
+      <div className="min-w-0 flex-1">
+        <h2 className="truncate text-lg font-bold">{party.display_name}</h2>
+        <p className="text-forest-100 mt-0.5 text-xs">
+          {isHousehold ? 'Household' : 'Adult weekend guest'}
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={handleClose}
+        aria-label="Close panel"
+        className="-mr-1 rounded-lg p-1.5 transition-colors hover:bg-white/10"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  )
+
+  if (embedded) {
+    return (
+      <div
+        data-panel="family-details"
+        data-testid="family-details-panel"
+        className="bg-card shadow-lodge-lg flex h-full flex-col overflow-hidden rounded-2xl"
+      >
+        {header}
+        <div className="flex-1 overflow-y-auto">{body}</div>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {/* Click-outside layer, as the summer board lays over the page. */}
+      <div
+        data-testid="family-panel-backdrop"
+        className="pointer-events-none fixed inset-0 z-[59]"
+        onClick={handleClose}
+        aria-hidden="true"
+      />
+      <div
+        data-panel="family-details"
+        data-testid="family-details-panel"
+        role="dialog"
+        aria-label={`${String(party.display_name)} details`}
+        className={`bg-card shadow-lodge-xl border-border fixed top-0 right-0 bottom-0 z-[60] flex w-[26rem] max-w-full flex-col border-l ${
+          exiting ? 'animate-slide-out-right' : 'animate-slide-in-right'
+        }`}
+        onAnimationEnd={handleAnimationEnd}
+      >
+        {header}
+        <div className="flex-1 overflow-y-auto">{body}</div>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/components/weekend/LodgingBoard.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.test.tsx
@@ -11,7 +11,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import { LodgingBoard } from './LodgingBoard'
@@ -29,8 +29,17 @@ vi.mock('../../hooks/useWeekendRoster', () => ({
   useHouseholdMedical: () => ({ data: undefined, isLoading: false, error: null }),
 }))
 
+// One client per TEST, built outside the render path. Constructing it inside
+// the wrapper body rebuilds it on every render, discarding the cache and
+// starting a fresh loading pass underneath assertions that already resolved.
+// Same fix as `admin/lodging/LodgingUnitsPanel.test.tsx`.
+let client: QueryClient
+
+beforeEach(() => {
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+})
+
 function wrapper({ children }: { children: ReactNode }) {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>
 }
 

--- a/frontend/src/components/weekend/LodgingBoard.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.test.tsx
@@ -1,0 +1,269 @@
+/**
+ * The board tab: an unplaced rail beside area-grouped sections of slot cards.
+ *
+ * With no scenario this is a CampMinder MIRROR and read-only, and the surface
+ * has to say so — otherwise a staff member reasonably reads a board as
+ * something they can move things on.
+ *
+ * Fictional data throughout.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import { LodgingBoard } from './LodgingBoard'
+
+vi.mock('../../hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    isAdmin: true,
+    permissions: [],
+    hasPermission: () => true,
+    hasAnyPermission: () => true,
+  }),
+}))
+
+vi.mock('../../hooks/useWeekendRoster', () => ({
+  useHouseholdMedical: () => ({ data: undefined, isLoading: false, error: null }),
+}))
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
+  return {
+    unit_id: 'u1',
+    code: 'cedar-1',
+    name: 'Cedar 1',
+    area_code: 'CG',
+    area_name: 'Cedar Grove',
+    sleeps: 5,
+    bathroom: 'shared',
+    bathroom_group: '',
+    near_bathhouse: false,
+    has_power: false,
+    has_ac: false,
+    has_fridge: false,
+    is_accessible: false,
+    is_confirmed: false,
+    is_active: true,
+    is_container: false,
+    allocation_default: 'family_pool',
+    reservation_state: null,
+    is_family_available: true,
+    map_x: 0.5,
+    map_y: 0.5,
+    ...overrides,
+  }
+}
+
+function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
+  return {
+    grain: 'household',
+    household_cm_id: 101,
+    display_name: 'Johnson',
+    adults: [{ adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' }],
+    children: [{ person_cm_id: 9001, display_name: 'Noah Johnson', age: 8, grade: 3 }],
+    party_size: 3,
+    unit_code: '',
+    unit_name: '',
+    is_merged_slot: false,
+    arrival_eta: '',
+    is_returning: false,
+    ...overrides,
+  }
+}
+
+describe('LodgingBoard — layout', () => {
+  it('draws one section per area', () => {
+    render(
+      <LodgingBoard
+        parties={[]}
+        units={[
+          unit(),
+          unit({
+            unit_id: 'u2',
+            code: 'ridge-1',
+            name: 'Ridge 1',
+            area_code: 'NR',
+            area_name: 'North Ridge',
+          }),
+        ]}
+        year={2026}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByRole('heading', { name: /Cedar Grove/ })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /North Ridge/ })).toBeInTheDocument()
+  })
+
+  it('collapses an area section', async () => {
+    render(<LodgingBoard parties={[]} units={[unit()]} year={2026} />, { wrapper })
+    expect(screen.getByText('Cedar 1')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /Cedar Grove/ }))
+    expect(screen.queryByText('Cedar 1')).not.toBeInTheDocument()
+  })
+
+  it('puts unplaced families in the rail', () => {
+    render(<LodgingBoard parties={[party()]} units={[unit()]} year={2026} />, { wrapper })
+    const rail = screen.getByRole('complementary', { name: /unplaced/i })
+    expect(within(rail).getByText('Johnson')).toBeInTheDocument()
+  })
+
+  it('admits on the surface that the rail ranking is half-uncomputable', () => {
+    // §3.7 wanted "a share request whose partner is not yet placed" too. No
+    // request names are resolved to households (spec §7.3, unbuilt), so the
+    // partner leg does not exist and the surface must not imply it does.
+    render(<LodgingBoard parties={[party()]} units={[unit()]} year={2026} />, { wrapper })
+    const rail = screen.getByRole('complementary', { name: /unplaced/i })
+    expect(within(rail).getByText(/mandatory accommodation only/i)).toBeInTheDocument()
+  })
+
+  it('says so when nobody is waiting', () => {
+    render(
+      <LodgingBoard
+        parties={[party({ unit_code: 'cedar-1', unit_name: 'Cedar 1' })]}
+        units={[unit()]}
+        year={2026}
+      />,
+      { wrapper }
+    )
+    const rail = screen.getByRole('complementary', { name: /unplaced/i })
+    expect(within(rail).getByText(/Everyone has a cabin/i)).toBeInTheDocument()
+  })
+})
+
+describe('LodgingBoard — it is a mirror, and says so', () => {
+  it('carries the amber CM badge', () => {
+    render(<LodgingBoard parties={[]} units={[unit()]} year={2026} />, { wrapper })
+    expect(screen.getByText(/CampMinder mirror/i)).toBeInTheDocument()
+  })
+
+  it('says it is read-only', () => {
+    render(<LodgingBoard parties={[]} units={[unit()]} year={2026} />, { wrapper })
+    expect(screen.getByText(/read-only/i)).toBeInTheDocument()
+  })
+
+  it('offers nothing draggable', () => {
+    const { container } = render(
+      <LodgingBoard
+        parties={[party({ unit_code: 'cedar-1', unit_name: 'Cedar 1' })]}
+        units={[unit()]}
+        year={2026}
+      />,
+      { wrapper }
+    )
+    expect(container.querySelector('[draggable="true"]')).toBeNull()
+  })
+})
+
+describe('LodgingBoard — the consent flag', () => {
+  function sharedBoard() {
+    return render(
+      <LodgingBoard
+        parties={[
+          party({
+            unit_code: 'cedar-1',
+            unit_name: 'Cedar 1',
+            share: {
+              preference: 'no_share',
+              proximity: [],
+              request_text: '',
+              needs_resolution: false,
+            },
+          }),
+          party({
+            household_cm_id: 102,
+            display_name: 'Garcia',
+            unit_code: 'cedar-1',
+            unit_name: 'Cedar 1',
+            share: {
+              preference: 'yes_share',
+              proximity: ['with'],
+              request_text: '',
+              needs_resolution: false,
+            },
+          }),
+        ]}
+        units={[unit()]}
+        year={2026}
+      />,
+      { wrapper }
+    )
+  }
+
+  it('surfaces the one real sharing conflict on the slot', () => {
+    sharedBoard()
+    expect(screen.getByText(/said no to sharing/i)).toBeInTheDocument()
+  })
+
+  it('summarises the flag count at the top of the board', () => {
+    sharedBoard()
+    expect(screen.getByText(/1 shared cabin needs a look/i)).toBeInTheDocument()
+  })
+
+  it('says nothing when there is nothing to flag', () => {
+    render(<LodgingBoard parties={[]} units={[unit()]} year={2026} />, { wrapper })
+    expect(screen.queryByText(/needs a look/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('LodgingBoard — nobody disappears', () => {
+  it('lists a party placed on something the board cannot draw', () => {
+    // A merge has no unit code, so there is no card for it. Dropping the
+    // party would make the board quietly disagree with the roster.
+    render(
+      <LodgingBoard
+        parties={[party({ unit_code: '', unit_name: 'Cedar 3 + Cedar 4', is_merged_slot: true })]}
+        units={[unit()]}
+        year={2026}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByText(/Placed outside the board/i)).toBeInTheDocument()
+    expect(screen.getByText('Johnson')).toBeInTheDocument()
+  })
+
+  it('does not draw that section when everything fits on the board', () => {
+    render(<LodgingBoard parties={[party()]} units={[unit()]} year={2026} />, { wrapper })
+    expect(screen.queryByText(/Placed outside the board/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('LodgingBoard — the detail panel', () => {
+  it('opens on a family card and shows the request text the card withheld', async () => {
+    render(
+      <LodgingBoard
+        parties={[
+          party({
+            unit_code: 'cedar-1',
+            unit_name: 'Cedar 1',
+            share: {
+              preference: 'yes_share',
+              proximity: ['with'],
+              request_text: 'Hoping for a cabin near the creek.',
+              needs_resolution: false,
+            },
+          }),
+        ]}
+        units={[unit()]}
+        year={2026}
+      />,
+      { wrapper }
+    )
+    expect(screen.queryByText('Hoping for a cabin near the creek.')).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /Johnson/ }))
+    expect(screen.getByText('Hoping for a cabin near the creek.')).toBeInTheDocument()
+  })
+})
+
+describe('LodgingBoard — an empty registry', () => {
+  it('explains an empty board instead of rendering nothing', () => {
+    render(<LodgingBoard parties={[]} units={[]} year={2026} />, { wrapper })
+    expect(screen.getByText(/No lodging units in the registry yet/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -1,0 +1,228 @@
+/**
+ * The weekend lodging board — read-only (spec §10, "C1").
+ *
+ * With no scenario this is a CampMinder MIRROR, exactly as the summer board is
+ * read-only for everyone in production mode (`ScenarioContext`'s
+ * `isProductionMode`). The amber CM badge says so on the surface, because a
+ * board that looks draggable and is not is worse than a list.
+ *
+ * Layout is §3.7: an unplaced rail on the left, then one collapsible section
+ * per area, each a WRAPPING GRID of slot cards. Not summer's columns — a
+ * summer bunk column is tall because it holds 10–14 campers, and 82 rooms
+ * cannot be 82 columns.
+ *
+ * Dragging is C2 and needs Phase B's draft tables, which do not exist yet.
+ * Nothing here writes.
+ */
+import { ChevronDown, ChevronRight, Info, TriangleAlert } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+
+import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import { shouldKeepPanelsOpen } from '../../utils/clickoutsidePredicate'
+import { buildBoard } from './boardLayout'
+import { FamilyCard } from './FamilyCard'
+import { FamilyDetailsPanel } from './FamilyDetailsPanel'
+import { LodgingUnitCard } from './LodgingUnitCard'
+
+export interface LodgingBoardProps {
+  parties: RosterPartyRow[]
+  units: LodgingUnitRow[]
+  year: number
+}
+
+/** Stable identity for a party across renders. */
+function partyKey(party: RosterPartyRow): string {
+  return `${party.grain}-${String(party.household_cm_id ?? party.person_cm_id ?? party.display_name)}`
+}
+
+export function LodgingBoard({ parties, units, year }: LodgingBoardProps) {
+  const board = buildBoard(parties, units)
+  const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set())
+  const [selected, setSelected] = useState<RosterPartyRow | null>(null)
+  const [requestClose, setRequestClose] = useState(false)
+
+  const unitsByCode = new Map(units.map((unit) => [unit.code, unit]))
+
+  const openParty = useCallback((party: RosterPartyRow) => {
+    setRequestClose(false)
+    setSelected(party)
+  }, [])
+
+  const closePanel = useCallback(() => {
+    setSelected(null)
+    setRequestClose(false)
+  }, [])
+
+  // Clicking dead space dismisses the panel, using the same shared predicate
+  // the summer board uses so the two behaviours cannot drift.
+  useEffect(() => {
+    if (selected === null) return
+    const handler = (event: MouseEvent) => {
+      if (shouldKeepPanelsOpen(event)) return
+      setRequestClose(true)
+    }
+    // A microtask's delay, so the click that opened the panel is not the click
+    // that closes it.
+    const timeoutId = setTimeout(() => {
+      document.addEventListener('click', handler)
+    }, 0)
+    return () => {
+      clearTimeout(timeoutId)
+      document.removeEventListener('click', handler)
+    }
+  }, [selected])
+
+  const toggleArea = (key: string) => {
+    setCollapsed((current) => {
+      const next = new Set(current)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-amber-400/50 bg-amber-100 px-2.5 py-1 text-xs font-semibold text-amber-800 dark:bg-amber-950/50 dark:text-amber-300">
+          <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden="true" />
+          CM — CampMinder mirror, read-only
+        </span>
+        {board.flaggedCount > 0 && (
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-2.5 py-1 text-xs font-semibold text-amber-800 dark:bg-amber-950/50 dark:text-amber-300">
+            <TriangleAlert className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+            {board.flaggedCount === 1
+              ? '1 shared cabin needs a look'
+              : `${String(board.flaggedCount)} shared cabins need a look`}
+          </span>
+        )}
+      </div>
+
+      <div className="card-lodge grid grid-cols-1 overflow-hidden lg:grid-cols-[240px_minmax(0,1fr)]">
+        <aside
+          aria-label="Unplaced parties"
+          className="bg-muted/30 border-border/60 flex flex-col gap-2 border-b p-3 lg:border-r lg:border-b-0"
+        >
+          <div className="flex items-baseline justify-between gap-2">
+            <h3 className="font-display text-foreground text-sm font-bold">Unplaced</h3>
+            <span className="text-muted-foreground text-xs tabular-nums">
+              {board.unplaced.length}
+            </span>
+          </div>
+
+          {board.unplaced.length === 0 ? (
+            <p className="text-muted-foreground text-xs italic">Everyone has a cabin.</p>
+          ) : (
+            <div className="flex flex-col gap-1.5">
+              {board.unplaced.map((party) => (
+                <FamilyCard key={partyKey(party)} party={party} onRail={true} onOpen={openParty} />
+              ))}
+            </div>
+          )}
+
+          {/* §3.7 also wanted "a share request whose partner is not yet
+              placed". That leg DOES NOT EXIST — no request names are resolved
+              to households (spec §7.3, unbuilt) — so the surface admits it
+              rather than implying a completeness it does not have. */}
+          <p className="text-muted-foreground/80 mt-1 text-[11px] leading-snug">
+            Ranked on a mandatory accommodation only. Ranking by an unplaced share partner needs
+            request names resolved to households, which is not built yet.
+          </p>
+        </aside>
+
+        <div className="flex flex-col gap-5 p-3">
+          {board.areas.length === 0 ? (
+            <p className="text-muted-foreground text-sm">
+              No lodging units in the registry yet. Add them in Manage → Family Camp Lodging.
+            </p>
+          ) : (
+            board.areas.map((area) => {
+              const isCollapsed = collapsed.has(area.key)
+              return (
+                <section key={area.key}>
+                  <h3 className="mb-2">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        toggleArea(area.key)
+                      }}
+                      aria-expanded={!isCollapsed}
+                      className="group flex w-full items-center gap-2 text-left"
+                    >
+                      {isCollapsed ? (
+                        <ChevronRight className="text-muted-foreground h-3.5 w-3.5 flex-shrink-0" />
+                      ) : (
+                        <ChevronDown className="text-muted-foreground h-3.5 w-3.5 flex-shrink-0" />
+                      )}
+                      {/* Area colour is a SECONDARY channel (§3.10). This dot
+                          and the card's top edge carry it; the heading below
+                          does the actual grouping, so nothing depends on
+                          telling violet from rose. */}
+                      <span
+                        className="h-2 w-2 flex-shrink-0 rounded-full"
+                        style={{ backgroundColor: area.hue }}
+                        aria-hidden="true"
+                      />
+                      <span className="text-muted-foreground group-hover:text-foreground text-[11px] font-bold tracking-wider uppercase transition-colors">
+                        {area.name}
+                      </span>
+                      <span className="text-muted-foreground/70 text-[11px] tabular-nums">
+                        {`${String(area.slots.length)} rooms · ${String(area.partyCount)} families`}
+                      </span>
+                      <span className="bg-border/70 ml-1 h-px flex-1" aria-hidden="true" />
+                    </button>
+                  </h3>
+
+                  {!isCollapsed && (
+                    <div className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] items-start gap-2.5">
+                      {area.slots.map((slot) => (
+                        <LodgingUnitCard
+                          key={slot.unit.unit_id}
+                          slot={slot}
+                          hue={area.hue}
+                          onOpenParty={openParty}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </section>
+              )
+            })
+          )}
+
+          {/* A merge carries no unit code, and an assignment can name a
+              container or a unit absent from the payload. Those parties ARE
+              placed, so the rail would be a lie — and dropping them would make
+              the board quietly disagree with the roster. */}
+          {board.offBoard.length > 0 && (
+            <section>
+              <h3 className="text-muted-foreground mb-2 flex items-center gap-1.5 text-[11px] font-bold tracking-wider uppercase">
+                <Info className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+                Placed outside the board
+              </h3>
+              <p className="text-muted-foreground mb-2 text-xs">
+                Assigned to a merged slot or to a room the board does not draw a card for.
+              </p>
+              <div className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] items-start gap-2.5">
+                {board.offBoard.map((party) => (
+                  <FamilyCard key={partyKey(party)} party={party} onOpen={openParty} />
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
+      </div>
+
+      {selected !== null && (
+        <FamilyDetailsPanel
+          key={partyKey(selected)}
+          party={selected}
+          unit={unitsByCode.get(selected.unit_code ?? '')}
+          year={year}
+          requestClose={requestClose}
+          onClose={closePanel}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * A slot card. One unit, holding nothing, one party, or occasionally two.
+ *
+ * Not a summer bunk column: a bunk column is tall because it holds 10–14
+ * campers. 82 rooms cannot be 82 columns.
+ *
+ * Fictional data throughout.
+ */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import type { BoardSlot } from './boardLayout'
+import { LodgingUnitCard } from './LodgingUnitCard'
+
+function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
+  return {
+    unit_id: 'u1',
+    code: 'cedar-1',
+    name: 'Cedar 1',
+    area_code: 'CG',
+    area_name: 'Cedar Grove',
+    sleeps: 5,
+    bathroom: 'shared',
+    bathroom_group: '',
+    near_bathhouse: false,
+    has_power: false,
+    has_ac: false,
+    has_fridge: false,
+    is_accessible: false,
+    is_confirmed: false,
+    is_active: true,
+    is_container: false,
+    allocation_default: 'family_pool',
+    reservation_state: null,
+    is_family_available: true,
+    map_x: 0.5,
+    map_y: 0.5,
+    ...overrides,
+  }
+}
+
+function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
+  return {
+    grain: 'household',
+    household_cm_id: 101,
+    display_name: 'Johnson',
+    adults: [{ adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' }],
+    children: [{ person_cm_id: 9001, display_name: 'Noah Johnson', age: 8, grade: 3 }],
+    party_size: 3,
+    unit_code: 'cedar-1',
+    unit_name: 'Cedar 1',
+    is_merged_slot: false,
+    arrival_eta: '',
+    is_returning: false,
+    ...overrides,
+  }
+}
+
+function slot(overrides: Partial<BoardSlot> = {}): BoardSlot {
+  return { unit: unit(), parties: [], consent: null, ...overrides }
+}
+
+describe('LodgingUnitCard', () => {
+  it('names the unit', () => {
+    render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
+    expect(screen.getByText('Cedar 1')).toBeInTheDocument()
+  })
+
+  it('renders unknown capacity as an em dash, never as zero', () => {
+    // `null` is UNKNOWN. The API already maps PocketBase's stored 0 to null,
+    // and "sleeps 0" is a lie about a cabin nobody has measured.
+    render(
+      <LodgingUnitCard
+        slot={slot({ unit: unit({ sleeps: null }) })}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('—')).toBeInTheDocument()
+    expect(screen.queryByText('0')).not.toBeInTheDocument()
+  })
+
+  it('shows how many spaces the unit sleeps when it is known', () => {
+    render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
+    expect(screen.getByTitle(/Sleeps 5/)).toBeInTheDocument()
+  })
+
+  it('says an empty unit is empty', () => {
+    render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
+    expect(screen.getByText('Empty')).toBeInTheDocument()
+  })
+
+  it('renders the families it holds', () => {
+    render(
+      <LodgingUnitCard
+        slot={slot({ parties: [party(), party({ household_cm_id: 102, display_name: 'Garcia' })] })}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Johnson')).toBeInTheDocument()
+    expect(screen.getByText('Garcia')).toBeInTheDocument()
+  })
+
+  it('says two parties are sharing', () => {
+    render(
+      <LodgingUnitCard
+        slot={slot({ parties: [party(), party({ household_cm_id: 102, display_name: 'Garcia' })] })}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('2 families')).toBeInTheDocument()
+  })
+
+  it('flags a shared unit where a family said no', () => {
+    render(
+      <LodgingUnitCard
+        slot={slot({
+          parties: [party(), party({ household_cm_id: 102, display_name: 'Garcia' })],
+          consent: { declinedCount: 1, reason: '1 family said no to sharing' },
+        })}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('1 family said no to sharing')).toBeInTheDocument()
+  })
+
+  it('badges a staff hold rather than hiding the room', () => {
+    // Staff reason about adjacency; hiding a held room makes the site look
+    // smaller than it is.
+    render(
+      <LodgingUnitCard
+        slot={slot({
+          unit: unit({ reservation_state: 'reserved_staff', is_family_available: false }),
+        })}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Cedar 1')).toBeInTheDocument()
+    expect(screen.getByText('Staff')).toBeInTheDocument()
+  })
+
+  it('carries the area hue on its top edge as a secondary channel', () => {
+    // §3.10 — eight hues is at the limit of distinguishability, so this is
+    // decoration over a layout that already groups by section header.
+    const { container } = render(
+      <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />
+    )
+    const card = container.querySelector('[data-unit-card]')
+    expect(card).toHaveStyle({ borderTopColor: 'hsl(160 45% 42%)' })
+  })
+
+  it('marks an inactive unit that still holds someone', () => {
+    render(
+      <LodgingUnitCard
+        slot={slot({ unit: unit({ is_active: false }), parties: [party()] })}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Inactive')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -1,0 +1,124 @@
+/**
+ * One slot on the board: a room, whoever is in it, and whether that is a
+ * problem.
+ *
+ * A slot, not a column. A summer bunk column is tall because it holds 10–14
+ * campers; a lodging unit holds nothing, one party, or — three times in the
+ * whole of 2026 — two parties who agreed to share. 82 rooms cannot be 82
+ * columns, so these are small cards in a wrapping grid.
+ *
+ * The card asserts nothing it cannot support. `sleeps: null` means UNKNOWN and
+ * renders as an em dash: the API already maps PocketBase's stored 0 to null,
+ * and "sleeps 0" would be a lie about a cabin nobody has measured.
+ */
+import { Bath, Plug, Snowflake, TriangleAlert, Users } from 'lucide-react'
+
+import type { RosterPartyRow } from '../../types/lodging'
+import type { BoardSlot } from './boardLayout'
+import { FamilyCard } from './FamilyCard'
+import { reservationBadge } from './unitBadges'
+
+export interface LodgingUnitCardProps {
+  slot: BoardSlot
+  /** The area's colour — a SECONDARY channel (§3.10), never the only one. */
+  hue: string
+  onOpenParty: (party: RosterPartyRow) => void
+}
+
+export function LodgingUnitCard({ slot, hue, onOpenParty }: LodgingUnitCardProps) {
+  const { unit, parties, consent } = slot
+  const badge = reservationBadge(unit)
+  const capacityKnown = unit.sleeps !== null && unit.sleeps !== undefined
+  const isShared = parties.length > 1
+
+  return (
+    <div
+      data-unit-card
+      data-unit-code={unit.code}
+      style={{ borderTopColor: hue }}
+      className={`bg-card flex flex-col gap-2 rounded-xl border border-t-[3px] p-2.5 ${
+        consent
+          ? 'border-amber-400 ring-1 ring-amber-400/40 dark:border-amber-500'
+          : 'border-border'
+      } ${parties.length === 0 ? 'bg-muted/25 border-dashed' : ''}`}
+    >
+      <div className="flex items-baseline gap-1.5">
+        <span className="text-foreground truncate text-[13px] font-semibold">{unit.name}</span>
+        <span
+          title={capacityKnown ? `Sleeps ${String(unit.sleeps)}` : 'Capacity not recorded'}
+          className="text-muted-foreground ml-auto text-[11px] tabular-nums"
+        >
+          {capacityKnown ? String(unit.sleeps) : '—'}
+        </span>
+      </div>
+
+      <div className="text-muted-foreground flex flex-wrap items-center gap-1.5 text-[11px]">
+        {unit.bathroom === 'private' && (
+          <span className="inline-flex items-center gap-0.5">
+            <Bath className="h-3 w-3" aria-hidden="true" /> Private
+          </span>
+        )}
+        {unit.bathroom === 'shared' && (
+          <span className="inline-flex items-center gap-0.5">
+            <Bath className="h-3 w-3" aria-hidden="true" /> Shared
+          </span>
+        )}
+        {unit.has_power === true && <Plug className="h-3 w-3" aria-label="Power" />}
+        {unit.has_ac === true && <Snowflake className="h-3 w-3" aria-label="Air conditioning" />}
+        {badge && (
+          <span className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${badge.className}`}>
+            {badge.label}
+          </span>
+        )}
+        {/* A deactivated room only reaches the board when somebody is still in
+            it — hiding it would drop them. */}
+        {unit.is_active === false && (
+          <span className="rounded-full bg-slate-200 px-1.5 py-0.5 text-[10px] font-medium text-slate-800 dark:bg-slate-800 dark:text-slate-200">
+            Inactive
+          </span>
+        )}
+      </div>
+
+      {isShared && (
+        <span
+          className={`inline-flex w-fit items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold ${
+            consent
+              ? 'bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-300'
+              : 'bg-muted text-muted-foreground'
+          }`}
+        >
+          {consent ? (
+            <TriangleAlert className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+          ) : (
+            <Users className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+          )}
+          {`${String(parties.length)} families`}
+        </span>
+      )}
+
+      {/* Spec §11: a household answered `no_share` and is sharing anyway. On
+          2026 data this fires exactly once, and that one case is real. */}
+      {consent && (
+        <p className="text-[11px] font-medium text-amber-700 dark:text-amber-400">
+          {consent.reason}
+        </p>
+      )}
+
+      {parties.length === 0 ? (
+        <p className="text-muted-foreground py-1 text-center text-[11px] italic">Empty</p>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {parties.map((party) => (
+            <FamilyCard
+              key={`${party.grain}-${String(party.household_cm_id ?? party.person_cm_id ?? party.display_name)}`}
+              party={party}
+              unit={unit}
+              sharedSlot={isShared}
+              onOpen={onOpenParty}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/weekend/UnitInventoryPanel.tsx
+++ b/frontend/src/components/weekend/UnitInventoryPanel.tsx
@@ -9,34 +9,10 @@
 import { Bath, Plug, Snowflake } from 'lucide-react'
 
 import type { LodgingUnitRow } from '../../types/lodging'
+import { reservationBadge } from './unitBadges'
 
 export interface UnitInventoryPanelProps {
   units: LodgingUnitRow[]
-}
-
-function reservationBadge(unit: LodgingUnitRow): { label: string; className: string } | null {
-  const staff = {
-    label: 'Staff',
-    className: 'bg-violet-100 text-violet-800 dark:bg-violet-950/40 dark:text-violet-300',
-  }
-  if (unit.is_container === true) {
-    return { label: 'Building', className: 'bg-muted text-muted-foreground' }
-  }
-  if (unit.reservation_state === 'reserved_staff') return staff
-  if (unit.reservation_state === 'reserved_other') {
-    return {
-      label: 'Held',
-      className: 'bg-slate-200 text-slate-800 dark:bg-slate-800 dark:text-slate-200',
-    }
-  }
-  if (unit.reservation_state === 'released_to_family') {
-    return {
-      label: 'Released',
-      className: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300',
-    }
-  }
-  if (unit.allocation_default === 'staff_default') return staff
-  return null
 }
 
 function UnitRow({

--- a/frontend/src/components/weekend/UnitInventoryPanel.tsx
+++ b/frontend/src/components/weekend/UnitInventoryPanel.tsx
@@ -62,7 +62,7 @@ export function UnitInventoryPanel({ units }: UnitInventoryPanelProps) {
     return (
       <div className="card-lodge p-4">
         <p className="text-muted-foreground text-sm">
-          No lodging units in the registry yet. Add them in Admin → Family Camp Lodging.
+          No lodging units in the registry yet. Add them in Manage → Family Camp Lodging.
         </p>
       </div>
     )

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -1,0 +1,345 @@
+/**
+ * The board's layout is a pure function over the roster payload, so the
+ * decisions that matter — which units get a card, where each party lands,
+ * what raises the consent flag — are testable without rendering anything.
+ *
+ * Fictional data throughout.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import { AREA_HUES, buildBoard, countBoardSlots } from './boardLayout'
+
+function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
+  return {
+    unit_id: 'u1',
+    code: 'cedar-1',
+    name: 'Cedar 1',
+    area_code: 'CG',
+    area_name: 'Cedar Grove',
+    sleeps: 5,
+    bathroom: 'shared',
+    bathroom_group: '',
+    near_bathhouse: false,
+    has_power: false,
+    has_ac: false,
+    has_fridge: false,
+    is_accessible: false,
+    is_confirmed: false,
+    is_active: true,
+    is_container: false,
+    allocation_default: 'family_pool',
+    reservation_state: null,
+    is_family_available: true,
+    map_x: 0.5,
+    map_y: 0.5,
+    ...overrides,
+  }
+}
+
+function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
+  return {
+    grain: 'household',
+    household_cm_id: 101,
+    display_name: 'Johnson',
+    adults: [{ adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' }],
+    children: [{ person_cm_id: 9001, display_name: 'Noah Johnson', age: 8, grade: 3 }],
+    party_size: 3,
+    unit_code: '',
+    unit_name: '',
+    is_merged_slot: false,
+    arrival_eta: '',
+    is_returning: false,
+    ...overrides,
+  }
+}
+
+describe('buildBoard — which units get a card', () => {
+  it('gives every leaf unit a card', () => {
+    const board = buildBoard(
+      [],
+      [unit(), unit({ unit_id: 'u2', code: 'cedar-2', name: 'Cedar 2' })]
+    )
+    const slots = board.areas.flatMap((area) => area.slots)
+    expect(slots.map((slot) => slot.unit.code)).toEqual(['cedar-1', 'cedar-2'])
+  })
+
+  it('never gives a container a card, because its halves already carry the beds', () => {
+    const board = buildBoard(
+      [],
+      [unit(), unit({ unit_id: 'u2', code: 'cedar-3', name: 'Cedar 3', is_container: true })]
+    )
+    const slots = board.areas.flatMap((area) => area.slots)
+    expect(slots.map((slot) => slot.unit.code)).toEqual(['cedar-1'])
+  })
+
+  it('drops a deactivated unit that nobody is in', () => {
+    const board = buildBoard(
+      [],
+      [unit(), unit({ unit_id: 'u2', code: 'cedar-2', name: 'Cedar 2', is_active: false })]
+    )
+    const slots = board.areas.flatMap((area) => area.slots)
+    expect(slots.map((slot) => slot.unit.code)).toEqual(['cedar-1'])
+  })
+
+  it('keeps a deactivated unit that still holds a party, so nobody vanishes', () => {
+    const board = buildBoard(
+      [party({ unit_code: 'cedar-2', unit_name: 'Cedar 2' })],
+      [unit(), unit({ unit_id: 'u2', code: 'cedar-2', name: 'Cedar 2', is_active: false })]
+    )
+    const slots = board.areas.flatMap((area) => area.slots)
+    expect(slots.map((slot) => slot.unit.code)).toEqual(['cedar-1', 'cedar-2'])
+    expect(board.offBoard).toHaveLength(0)
+  })
+})
+
+describe('countBoardSlots — the tab count is the card count', () => {
+  it('agrees with the board about a plain weekend', () => {
+    const units = [unit(), unit({ unit_id: 'u2', code: 'cedar-2', is_container: true })]
+    expect(countBoardSlots([], units)).toBe(
+      buildBoard([], units).areas.flatMap((a) => a.slots).length
+    )
+  })
+
+  it('agrees with the board about a deactivated room that still holds a party', () => {
+    // The two predicates have to be the same one, or the tab promises a
+    // number of cards the board does not draw.
+    const units = [unit(), unit({ unit_id: 'u2', code: 'cedar-2', is_active: false })]
+    const parties = [party({ unit_code: 'cedar-2', unit_name: 'Cedar 2' })]
+    expect(countBoardSlots(parties, units)).toBe(
+      buildBoard(parties, units).areas.flatMap((a) => a.slots).length
+    )
+    expect(countBoardSlots(parties, units)).toBe(2)
+  })
+})
+
+describe('buildBoard — where each party lands', () => {
+  it('puts a placed party on its own unit', () => {
+    const board = buildBoard([party({ unit_code: 'cedar-1', unit_name: 'Cedar 1' })], [unit()])
+    const slot = board.areas[0]?.slots[0]
+    expect(slot?.parties.map((p) => p.display_name)).toEqual(['Johnson'])
+    expect(board.unplaced).toHaveLength(0)
+  })
+
+  it('puts an unplaced party on the rail', () => {
+    const board = buildBoard([party()], [unit()])
+    expect(board.unplaced.map((p) => p.display_name)).toEqual(['Johnson'])
+    expect(board.areas[0]?.slots[0]?.parties).toHaveLength(0)
+  })
+
+  it('holds two sharing parties in one slot', () => {
+    const board = buildBoard(
+      [
+        party({ unit_code: 'cedar-1', unit_name: 'Cedar 1' }),
+        party({
+          household_cm_id: 102,
+          display_name: 'Garcia',
+          unit_code: 'cedar-1',
+          unit_name: 'Cedar 1',
+        }),
+      ],
+      [unit()]
+    )
+    expect(board.areas[0]?.slots[0]?.parties.map((p) => p.display_name)).toEqual([
+      'Johnson',
+      'Garcia',
+    ])
+  })
+
+  it('accounts for a party on a merged slot rather than dropping it', () => {
+    // A merge carries no unit_code (the API sends the merge display name
+    // instead), so there is no card to put it on. It is PLACED, though, so
+    // the rail would be a lie.
+    const board = buildBoard(
+      [party({ unit_code: '', unit_name: 'Cedar 3 + Cedar 4', is_merged_slot: true })],
+      [unit()]
+    )
+    expect(board.unplaced).toHaveLength(0)
+    expect(board.offBoard.map((p) => p.display_name)).toEqual(['Johnson'])
+  })
+
+  it('accounts for a party assigned straight to a container', () => {
+    const board = buildBoard(
+      [party({ unit_code: 'cedar-block', unit_name: 'Cedar Block' })],
+      [
+        unit(),
+        unit({ unit_id: 'u2', code: 'cedar-block', name: 'Cedar Block', is_container: true }),
+      ]
+    )
+    expect(board.unplaced).toHaveLength(0)
+    expect(board.offBoard.map((p) => p.display_name)).toEqual(['Johnson'])
+  })
+
+  it('accounts for a party whose unit code is not in the payload', () => {
+    const board = buildBoard([party({ unit_code: 'gone', unit_name: 'Gone' })], [unit()])
+    expect(board.offBoard.map((p) => p.display_name)).toEqual(['Johnson'])
+  })
+
+  it('loses nobody: every party is on a slot, the rail or the off-board list', () => {
+    const parties = [
+      party({ unit_code: 'cedar-1', unit_name: 'Cedar 1' }),
+      party({ household_cm_id: 102, display_name: 'Garcia' }),
+      party({
+        household_cm_id: 103,
+        display_name: 'Chen',
+        unit_name: 'A merge',
+        is_merged_slot: true,
+      }),
+    ]
+    const board = buildBoard(parties, [unit()])
+    const placed = board.areas.flatMap((area) => area.slots).flatMap((slot) => slot.parties)
+    expect(placed.length + board.unplaced.length + board.offBoard.length).toBe(parties.length)
+  })
+})
+
+describe('buildBoard — the unplaced rail ranks on the one signal it has', () => {
+  it('lifts a mandatory accommodation to the top', () => {
+    const board = buildBoard(
+      [
+        party({ display_name: 'Adams' }),
+        party({
+          household_cm_id: 102,
+          display_name: 'Zhang',
+          flags: { accommodation_is_mandatory: true, needs_accommodation: true },
+        }),
+      ],
+      [unit()]
+    )
+    expect(board.unplaced.map((p) => p.display_name)).toEqual(['Zhang', 'Adams'])
+  })
+
+  it('falls back to name order, since the partner leg is uncomputable', () => {
+    const board = buildBoard(
+      [party({ display_name: 'Zhang' }), party({ household_cm_id: 102, display_name: 'Adams' })],
+      [unit()]
+    )
+    expect(board.unplaced.map((p) => p.display_name)).toEqual(['Adams', 'Zhang'])
+  })
+})
+
+describe('buildBoard — consent flagging (spec §11)', () => {
+  function shared(gates: Array<'no_share' | 'maybe_mutual' | 'yes_share' | 'unknown'>) {
+    return buildBoard(
+      gates.map((preference, index) =>
+        party({
+          household_cm_id: 200 + index,
+          display_name: `H${String(index)}`,
+          unit_code: 'cedar-1',
+          unit_name: 'Cedar 1',
+          share: { preference, proximity: [], request_text: '', needs_resolution: false },
+        })
+      ),
+      [unit()]
+    )
+  }
+
+  it('flags a shared unit where one party said no', () => {
+    const slot = shared(['no_share', 'yes_share']).areas[0]?.slots[0]
+    expect(slot?.consent).not.toBeNull()
+    expect(slot?.consent?.declinedCount).toBe(1)
+  })
+
+  it('does not flag two parties who both agreed', () => {
+    expect(shared(['maybe_mutual', 'yes_share']).areas[0]?.slots[0]?.consent).toBeNull()
+  })
+
+  it('does not flag a blank gate — that is deferred to C2, and C1 flags only on an explicit no', () => {
+    expect(shared(['unknown', 'yes_share']).areas[0]?.slots[0]?.consent).toBeNull()
+  })
+
+  it('does not flag maybe + maybe — also deferred to C2', () => {
+    expect(shared(['maybe_mutual', 'maybe_mutual']).areas[0]?.slots[0]?.consent).toBeNull()
+  })
+
+  it('does not flag a party who declined sharing and got a room to itself', () => {
+    // Declining is the normal answer. It only contradicts anything when
+    // somebody else is in the room.
+    expect(shared(['no_share']).areas[0]?.slots[0]?.consent).toBeNull()
+  })
+
+  it('counts both when two parties in one room each said no', () => {
+    expect(shared(['no_share', 'no_share']).areas[0]?.slots[0]?.consent?.declinedCount).toBe(2)
+  })
+
+  it('reports how many slots are flagged across the whole board', () => {
+    expect(shared(['no_share', 'yes_share']).flaggedCount).toBe(1)
+    expect(shared(['yes_share', 'yes_share']).flaggedCount).toBe(0)
+  })
+})
+
+describe('buildBoard — area grouping and colour', () => {
+  it('groups units into one section per area', () => {
+    const board = buildBoard(
+      [],
+      [
+        unit(),
+        unit({
+          unit_id: 'u2',
+          code: 'ridge-1',
+          name: 'Ridge 1',
+          area_code: 'NR',
+          area_name: 'North Ridge',
+        }),
+        unit({ unit_id: 'u3', code: 'cedar-2', name: 'Cedar 2' }),
+      ]
+    )
+    expect(board.areas.map((area) => area.name)).toEqual(['Cedar Grove', 'North Ridge'])
+    expect(board.areas[0]?.slots).toHaveLength(2)
+  })
+
+  it('keeps two areas apart when they share a blank code but not a name', () => {
+    // The API sends `area_code: ""` for anything it cannot resolve, so
+    // bucketing on the code alone silently merges them.
+    const board = buildBoard(
+      [],
+      [
+        unit({ area_code: '', area_name: 'Cedar Grove' }),
+        unit({ unit_id: 'u2', code: 'ridge-1', area_code: '', area_name: 'North Ridge' }),
+      ]
+    )
+    expect(board.areas.map((area) => area.name)).toEqual(['Cedar Grove', 'North Ridge'])
+  })
+
+  it('gives each area a distinct hue, and the same one every time', () => {
+    const units = [
+      unit(),
+      unit({ unit_id: 'u2', code: 'ridge-1', area_code: 'NR', area_name: 'North Ridge' }),
+      unit({ unit_id: 'u3', code: 'bend-1', area_code: 'RB', area_name: 'River Bend' }),
+    ]
+    const first = buildBoard([], units)
+    const again = buildBoard([], [...units].reverse())
+    const hues = first.areas.map((area) => area.hue)
+    expect(new Set(hues).size).toBe(3)
+    expect(again.areas.map((area) => area.hue)).toEqual(hues)
+  })
+
+  it('never runs out of hues', () => {
+    const units = Array.from({ length: AREA_HUES.length + 3 }, (_, index) =>
+      unit({
+        unit_id: `u${String(index)}`,
+        code: `c${String(index)}`,
+        area_code: `A${String(index)}`,
+        area_name: `Area ${String(index).padStart(2, '0')}`,
+      })
+    )
+    const board = buildBoard([], units)
+    expect(board.areas).toHaveLength(AREA_HUES.length + 3)
+    expect(board.areas.every((area) => area.hue.length > 0)).toBe(true)
+  })
+
+  it('counts the parties in each area', () => {
+    const board = buildBoard(
+      [
+        party({ unit_code: 'cedar-1', unit_name: 'Cedar 1' }),
+        party({
+          household_cm_id: 102,
+          display_name: 'Garcia',
+          unit_code: 'cedar-1',
+          unit_name: 'Cedar 1',
+        }),
+      ],
+      [unit(), unit({ unit_id: 'u2', code: 'ridge-1', area_code: 'NR', area_name: 'North Ridge' })]
+    )
+    expect(board.areas.map((area) => area.partyCount)).toEqual([2, 0])
+  })
+})

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, expect, it } from 'vitest'
 
-import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import type { LodgingUnitRow, RosterPartyRow, SharePreferenceValue } from '../../types/lodging'
 import { AREA_HUES, buildBoard, countBoardSlots } from './boardLayout'
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
@@ -218,7 +218,7 @@ describe('buildBoard — the unplaced rail ranks on the one signal it has', () =
 })
 
 describe('buildBoard — consent flagging (spec §11)', () => {
-  function shared(gates: Array<'no_share' | 'maybe_mutual' | 'yes_share' | 'unknown'>) {
+  function shared(gates: SharePreferenceValue[]) {
     return buildBoard(
       gates.map((preference, index) =>
         party({

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -1,0 +1,247 @@
+/**
+ * The board's layout, as a pure function over the roster payload.
+ *
+ * A unit is a SLOT, not a column. A summer bunk column is tall because it
+ * holds 10–14 campers; a lodging unit holds nothing, one party, or — 3 times
+ * in 2026 — two parties who agreed to share. 82 rooms cannot be 82 columns,
+ * so the board is a wrapping grid of small cards and the arrangement work is
+ * all here rather than in JSX.
+ *
+ * Two invariants this file exists to hold:
+ *
+ * 1. **Containers never get a card.** A building row carries the beds its
+ *    halves already report; drawing it double-counts them (408 against a true
+ *    389). Owner-confirmed.
+ * 2. **No party is ever dropped.** A party can be placed somewhere the board
+ *    structurally cannot draw — a merge carries no `unit_code` at all, and an
+ *    assignment can name a container or a unit absent from the payload. Those
+ *    go to `offBoard`, never to the unplaced rail (they ARE placed) and never
+ *    to nowhere. `buildBoard` is total: every input party comes out in exactly
+ *    one of slots / unplaced / offBoard.
+ */
+import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+
+/**
+ * Area colour, §3.10 — a SECONDARY channel.
+ *
+ * Eight hues is at the limit of distinguishability, so nothing may depend on
+ * telling violet from rose: the section headers do the actual grouping and
+ * this degrades to decoration. Mid-lightness on purpose, so one value reads on
+ * both the light and the dark card.
+ */
+export const AREA_HUES = [
+  'hsl(160 45% 42%)',
+  'hsl(38 75% 50%)',
+  'hsl(196 55% 45%)',
+  'hsl(92 40% 40%)',
+  'hsl(268 38% 56%)',
+  'hsl(220 48% 55%)',
+  'hsl(348 52% 55%)',
+  'hsl(24 42% 46%)',
+] as const
+
+/** A shared unit where somebody's recorded answer contradicts the placement. */
+export interface ConsentFlag {
+  /** How many of the unit's parties answered an explicit `no_share`. */
+  declinedCount: number
+  /** Ready to render beside the slot. Never PHI. */
+  reason: string
+}
+
+/** One unit card: the room, whoever is in it, and whether that is a problem. */
+export interface BoardSlot {
+  unit: LodgingUnitRow
+  parties: RosterPartyRow[]
+  consent: ConsentFlag | null
+}
+
+export interface BoardArea {
+  /** Area code and name together — see `areaKey`. */
+  key: string
+  name: string
+  hue: string
+  slots: BoardSlot[]
+  partyCount: number
+}
+
+export interface BoardModel {
+  areas: BoardArea[]
+  /** Not placed anywhere. Ranked; see `rankUnplaced`. */
+  unplaced: RosterPartyRow[]
+  /** Placed, but on something the board cannot draw a card for. */
+  offBoard: RosterPartyRow[]
+  flaggedCount: number
+}
+
+/**
+ * Bucket key for an area.
+ *
+ * Keyed on the code AND the name because the code alone is not unique: the
+ * API sends `area_code: ""` for anything it cannot resolve, so two differently
+ * named areas would share a bucket and the second one's name would be
+ * silently discarded along with its heading.
+ */
+function areaKey(unit: LodgingUnitRow): string {
+  return `${unit.area_code ?? ''}::${unit.area_name ?? ''}`
+}
+
+function areaName(unit: LodgingUnitRow): string {
+  const name = unit.area_name ?? ''
+  return name.length > 0 ? name : 'Unassigned area'
+}
+
+/**
+ * Consent flagging, spec §11.
+ *
+ * Fires on an EXPLICIT `no_share` only. Whether `maybe_mutual` + `maybe_mutual`
+ * counts as mutual, and whether a blank gate (45 of 452 for 2026) counts as
+ * consent, are deferred to C2 — neither occurs in placed data, so they change
+ * nothing until staff drag a card.
+ *
+ * Declining is the ordinary answer and contradicts nothing on its own; it only
+ * becomes a defect when somebody else is in the room.
+ *
+ * WHAT THE FLAG ACTUALLY MEANS, measured on 2026 rather than assumed. It fires
+ * exactly once, on the unit spec §11 predicted. But §11 calls that case "a
+ * family that said no is sharing with strangers", and that is FALSE: §11
+ * checked surnames, billing addresses and phone numbers, and never read the two
+ * request texts. Each household names the other by name, one of them marking it
+ * "(priority)". The placement is mutual, reciprocated and deliberate.
+ *
+ * So this flags a household whose recorded GATE contradicts that household's
+ * OWN request text — not a placement error. That is still worth surfacing, and
+ * the flag's wording reports only the recorded answer for exactly that reason.
+ * Resolving request names to households would let C2 suppress it, and that is
+ * spec §7.3, unbuilt. Meanwhile the design already resolves it the honest way:
+ * the card flags, and one click shows the request text that explains it.
+ */
+export function consentFlag(parties: RosterPartyRow[]): ConsentFlag | null {
+  if (parties.length < 2) return null
+  const declinedCount = parties.filter((party) => party.share?.preference === 'no_share').length
+  if (declinedCount === 0) return null
+  return {
+    declinedCount,
+    reason:
+      declinedCount === 1
+        ? '1 family said no to sharing'
+        : `${String(declinedCount)} families said no to sharing`,
+  }
+}
+
+/**
+ * Rank the unplaced rail.
+ *
+ * §3.7 wanted a mandatory accommodation OR "a share request whose partner is
+ * not yet placed". The partner leg DOES NOT EXIST: no request names are
+ * resolved to households (spec §7.3, unbuilt). So this ranks on the
+ * accommodation alone, and the rail says so on the surface rather than
+ * implying a completeness it does not have.
+ */
+function rankUnplaced(parties: RosterPartyRow[]): RosterPartyRow[] {
+  return [...parties].sort((a, b) => {
+    const aMandatory = a.flags?.accommodation_is_mandatory === true
+    const bMandatory = b.flags?.accommodation_is_mandatory === true
+    if (aMandatory !== bMandatory) return aMandatory ? -1 : 1
+    return (a.display_name ?? '').localeCompare(b.display_name ?? '')
+  })
+}
+
+/**
+ * Index a payload into the pieces both the board and its tab count need.
+ *
+ * `drawn` is the ONE definition of which units get a card. The tab count and
+ * the board read it through the same function on purpose — two copies of the
+ * predicate is how a tab starts promising a number of cards the board does not
+ * draw.
+ */
+function indexPayload(parties: RosterPartyRow[], units: LodgingUnitRow[]) {
+  // Every leaf unit can hold a party, including a deactivated one — the
+  // registry can be edited out from under a live assignment.
+  const leafByCode = new Map<string, LodgingUnitRow>()
+  for (const unit of units) {
+    if (unit.is_container === true) continue
+    leafByCode.set(unit.code, unit)
+  }
+
+  const partiesByCode = new Map<string, RosterPartyRow[]>()
+  const unplaced: RosterPartyRow[] = []
+  const offBoard: RosterPartyRow[] = []
+
+  for (const party of parties) {
+    const isPlaced = (party.unit_name ?? '').length > 0
+    if (!isPlaced) {
+      unplaced.push(party)
+      continue
+    }
+    // A merge carries no unit code — the API sends the merge's display name
+    // instead — so there is no card to put it on, but it is placed all the
+    // same and the rail would be a lie.
+    const code = party.unit_code ?? ''
+    const unit = code.length > 0 ? leafByCode.get(code) : undefined
+    if (unit === undefined) {
+      offBoard.push(party)
+      continue
+    }
+    const bucket = partiesByCode.get(code)
+    if (bucket) bucket.push(party)
+    else partiesByCode.set(code, [party])
+  }
+
+  // A deactivated room is not bookable, so it clutters the board — unless
+  // somebody is still in it, in which case hiding it would drop them.
+  const drawn = [...leafByCode.values()].filter(
+    (unit) => unit.is_active !== false || (partiesByCode.get(unit.code)?.length ?? 0) > 0
+  )
+
+  return { drawn, partiesByCode, unplaced, offBoard }
+}
+
+export function buildBoard(parties: RosterPartyRow[], units: LodgingUnitRow[]): BoardModel {
+  const { drawn, partiesByCode, unplaced, offBoard } = indexPayload(parties, units)
+
+  const buckets = new Map<string, { name: string; slots: BoardSlot[]; partyCount: number }>()
+  let flaggedCount = 0
+  for (const unit of drawn) {
+    const slotParties = partiesByCode.get(unit.code) ?? []
+    const consent = consentFlag(slotParties)
+    if (consent) flaggedCount += 1
+
+    const key = areaKey(unit)
+    const bucket = buckets.get(key) ?? { name: areaName(unit), slots: [], partyCount: 0 }
+    bucket.slots.push({ unit, parties: slotParties, consent })
+    bucket.partyCount += slotParties.length
+    buckets.set(key, bucket)
+  }
+
+  // Sorted so a hue is stable for an area regardless of the payload's unit
+  // order — the map (Step 6) and the board must agree about which area is
+  // which colour, and both read this.
+  const orderedKeys = [...buckets.keys()].sort((a, b) => {
+    const left = buckets.get(a)?.name ?? ''
+    const right = buckets.get(b)?.name ?? ''
+    return left.localeCompare(right)
+  })
+
+  const areas: BoardArea[] = orderedKeys.map((key, index) => {
+    const bucket = buckets.get(key)
+    return {
+      key,
+      name: bucket?.name ?? '',
+      hue: AREA_HUES[index % AREA_HUES.length] ?? AREA_HUES[0],
+      slots: bucket?.slots ?? [],
+      partyCount: bucket?.partyCount ?? 0,
+    }
+  })
+
+  return { areas, unplaced: rankUnplaced(unplaced), offBoard, flaggedCount }
+}
+
+/**
+ * How many slot cards the board will draw — what the Board tab counts.
+ *
+ * Shares `indexPayload` with `buildBoard` so the tab cannot promise a number
+ * of cards the board does not draw.
+ */
+export function countBoardSlots(parties: RosterPartyRow[], units: LodgingUnitRow[]): number {
+  return indexPayload(parties, units).drawn.length
+}

--- a/frontend/src/components/weekend/index.ts
+++ b/frontend/src/components/weekend/index.ts
@@ -1,6 +1,12 @@
 export { AccessibilityFlagList } from './AccessibilityFlagList'
+export { AREA_HUES, buildBoard, consentFlag, countBoardSlots } from './boardLayout'
+export type { BoardArea, BoardModel, BoardSlot, ConsentFlag } from './boardLayout'
+export { FamilyCard } from './FamilyCard'
+export { FamilyDetailsPanel } from './FamilyDetailsPanel'
 export { HouseholdRosterRow } from './HouseholdRosterRow'
 export { HouseholdRosterTable } from './HouseholdRosterTable'
+export { LodgingBoard } from './LodgingBoard'
+export { LodgingUnitCard } from './LodgingUnitCard'
 export {
   ATTENTION_LABEL,
   ATTENTION_ORDER,
@@ -14,6 +20,8 @@ export type { AttentionLevel, AttentionSection, PartyAttention } from './rosterA
 export { formatSessionDates } from './sessionDates'
 export { SharePreferenceChip } from './SharePreferenceChip'
 export { ShareRequestPanel } from './ShareRequestPanel'
+export { reservationBadge } from './unitBadges'
+export type { UnitBadge } from './unitBadges'
 export { UnitInventoryPanel } from './UnitInventoryPanel'
 export { WeekendStatsBar } from './WeekendStatsBar'
 export { shortWeekendName, splitWeekendName } from './weekendNames'

--- a/frontend/src/components/weekend/unitBadges.ts
+++ b/frontend/src/components/weekend/unitBadges.ts
@@ -1,0 +1,40 @@
+/**
+ * How a unit's availability is badged, shared by the inventory list and the
+ * board's slot cards so the two cannot drift.
+ *
+ * Reserved units are BADGED, not hidden (spec §3.7): staff reason about
+ * adjacency, and hiding a held room would make the site look smaller than it
+ * is. Container rows are labelled so nobody mistakes a whole-building
+ * aggregate for a bookable room.
+ */
+import type { LodgingUnitRow } from '../../types/lodging'
+
+export interface UnitBadge {
+  label: string
+  className: string
+}
+
+export function reservationBadge(unit: LodgingUnitRow): UnitBadge | null {
+  const staff = {
+    label: 'Staff',
+    className: 'bg-violet-100 text-violet-800 dark:bg-violet-950/40 dark:text-violet-300',
+  }
+  if (unit.is_container === true) {
+    return { label: 'Building', className: 'bg-muted text-muted-foreground' }
+  }
+  if (unit.reservation_state === 'reserved_staff') return staff
+  if (unit.reservation_state === 'reserved_other') {
+    return {
+      label: 'Held',
+      className: 'bg-slate-200 text-slate-800 dark:bg-slate-800 dark:text-slate-200',
+    }
+  }
+  if (unit.reservation_state === 'released_to_family') {
+    return {
+      label: 'Released',
+      className: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300',
+    }
+  }
+  if (unit.allocation_default === 'staff_default') return staff
+  return null
+}

--- a/frontend/src/pages/WeekendRosterPage.test.tsx
+++ b/frontend/src/pages/WeekendRosterPage.test.tsx
@@ -229,5 +229,68 @@ describe('tabs', () => {
     renderPage()
     expect(screen.getByRole('tab', { name: 'Roster (0)' })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: 'Inventory (0)' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Board (0)' })).toBeInTheDocument()
+  })
+
+  it('opens the board on its own tab', async () => {
+    rosterQuery.data = {
+      year: 2026,
+      session_cm_id: 1000001,
+      parties: [],
+      counts: {},
+      units: [
+        {
+          unit_id: 'u1',
+          code: 'ridge-a',
+          name: 'Ridge A',
+          area_code: 'RIDGE',
+          area_name: 'Ridge Side',
+          sleeps: 5,
+          is_confirmed: true,
+          is_container: false,
+          is_active: true,
+          is_family_available: true,
+        },
+      ],
+    }
+    renderPage()
+
+    await userEvent.click(screen.getByRole('tab', { name: /Board/ }))
+    expect(screen.getByText(/CampMinder mirror/i)).toBeInTheDocument()
+    expect(screen.getByText('Ridge A')).toBeInTheDocument()
+  })
+
+  it('counts the slot cards the board draws, not the building rows', () => {
+    // A container carries the beds its halves already report; giving it a
+    // card would double-count them, so it never gets one and never counts.
+    rosterQuery.data = {
+      year: 2026,
+      session_cm_id: 1000001,
+      parties: [],
+      counts: {},
+      units: [
+        {
+          unit_id: 'u1',
+          code: 'ridge-a',
+          name: 'Ridge A',
+          area_code: 'RIDGE',
+          area_name: 'Ridge Side',
+          is_container: false,
+          is_active: true,
+        },
+        {
+          unit_id: 'u2',
+          code: 'ridge-block',
+          name: 'Ridge Block',
+          area_code: 'RIDGE',
+          area_name: 'Ridge Side',
+          is_container: true,
+          is_active: true,
+        },
+      ],
+    }
+    renderPage()
+    expect(screen.getByRole('tab', { name: 'Board (1)' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Inventory (2)' })).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/WeekendRosterPage.tsx
+++ b/frontend/src/pages/WeekendRosterPage.tsx
@@ -18,16 +18,18 @@
  * the Go ingest so every surface sees the correction at once.
  */
 import { Listbox, ListboxButton, ListboxOption, ListboxOptions } from '@headlessui/react'
-import { ArrowLeft, ChevronDown, Home, Settings2, Users } from 'lucide-react'
+import { ArrowLeft, ChevronDown, Home, LayoutGrid, Settings2, Users } from 'lucide-react'
 import { useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router'
 
 import { QueryGuard } from '../components/QueryGuard'
 import { Permission } from '../constants/permissions'
 import {
+  countBoardSlots,
   countUnmeasuredSpaces,
   formatSessionDates,
   HouseholdRosterTable,
+  LodgingBoard,
   partyBeds,
   shortWeekendName,
   sortWeekendsByDate,
@@ -38,7 +40,7 @@ import { useCurrentYear } from '../hooks/useCurrentYear'
 import { usePermissions } from '../hooks/usePermissions'
 import { useWeekendRoster, useWeekendSessions } from '../hooks/useWeekendRoster'
 
-type View = 'roster' | 'inventory'
+type View = 'roster' | 'inventory' | 'board'
 
 export default function WeekendRosterPage() {
   const { sessionCmId } = useParams<{ sessionCmId: string }>()
@@ -66,6 +68,10 @@ export default function WeekendRosterPage() {
   const TABS: Array<{ id: View; label: string; icon: typeof Users; count: number }> = [
     { id: 'roster', label: 'Roster', icon: Users, count: parties.length },
     { id: 'inventory', label: 'Inventory', icon: Home, count: units.length },
+    // The board counts the SLOT CARDS it draws, which is not the inventory
+    // count: a container carries the beds its halves already report, so it
+    // never gets a card and never counts.
+    { id: 'board', label: 'Board', icon: LayoutGrid, count: countBoardSlots(parties, units) },
   ]
 
   return (
@@ -198,10 +204,12 @@ export default function WeekendRosterPage() {
               id={`weekend-panel-${view}`}
               aria-labelledby={`weekend-tab-${view}`}
             >
-              {view === 'roster' ? (
+              {view === 'roster' && (
                 <HouseholdRosterTable parties={parties} year={currentYear} units={units} />
-              ) : (
-                <UnitInventoryPanel units={units} />
+              )}
+              {view === 'inventory' && <UnitInventoryPanel units={units} />}
+              {view === 'board' && (
+                <LodgingBoard parties={parties} units={units} year={currentYear} />
               )}
             </div>
           </>

--- a/frontend/src/utils/clickoutsidePredicate.ts
+++ b/frontend/src/utils/clickoutsidePredicate.ts
@@ -1,9 +1,10 @@
 /**
- * Predicate used by BunkingBoardByArea's global click-outside handler to decide
+ * Predicate used by the boards' global click-outside handlers to decide
  * whether a click should dismiss the side panels (CamperDetailsPanel /
- * LockGroupPanel). Returns true iff the click should NOT trigger dismiss.
+ * LockGroupPanel on the summer board, FamilyDetailsPanel on the weekend
+ * lodging board). Returns true iff the click should NOT trigger dismiss.
  *
- * Shared between the live handler and its unit test so the two cannot drift.
+ * Shared between the live handlers and its unit test so they cannot drift.
  */
 export function shouldKeepPanelsOpen(e: {
   ctrlKey: boolean
@@ -18,7 +19,7 @@ export function shouldKeepPanelsOpen(e: {
   if (!target || typeof target.closest !== 'function') return false
 
   const isOnPanel = target.closest(
-    '[data-panel="camper-details"], [data-panel="lock-group"], [data-panel="lock-action-bar"], [data-panel="lock-group-picker"]'
+    '[data-panel="camper-details"], [data-panel="family-details"], [data-panel="lock-group"], [data-panel="lock-action-bar"], [data-panel="lock-group-picker"]'
   )
   const isOnFloatingBadge = target.closest('[data-floating-badge]')
   const isInteractive = target.closest(
@@ -26,7 +27,7 @@ export function shouldKeepPanelsOpen(e: {
   )
   const isContextMenu = target.closest('[data-context-menu]')
   const isModal = target.closest('[role="dialog"]')
-  const isCard = target.closest('[data-camper-card], [data-bunk-card]')
+  const isCard = target.closest('[data-camper-card], [data-bunk-card], [data-family-card]')
 
   return Boolean(
     isOnPanel ?? isOnFloatingBadge ?? isInteractive ?? isContextMenu ?? isModal ?? isCard


### PR DESCRIPTION
Adds a **Board** tab to the weekend view, beside Roster and Inventory. With no scenario this is a CampMinder mirror, read-only, and badged as one.

Frontend-only — `/api/lodging/roster` already returns everything the board renders. **Zero migrations, zero new endpoints, zero Go, zero Python.**

## What's in it

| | |
|---|---|
| `boardLayout.ts` | The arrangement as a pure function over the roster payload |
| `LodgingUnitCard` / `FamilyCard` | New components, not conditionals inside the 849-line camper-coupled board |
| `FamilyDetailsPanel` | Slide-in, with an `embedded` mode so the map opens this panel rather than a second implementation |
| Consent flagging | A shared unit where a household's recorded gate says `no_share` |

Area-grouped collapsible sections, each a wrapping grid of slot cards; an unplaced rail on the left; area colour as a secondary channel on the card top edge and the section dot.

**Leaf units only — a container never gets a card.** A building row carries the beds its halves already report, so drawing it double-counts them.

**Nobody is dropped.** A merge carries no `unit_code`, and an assignment can name a container or a unit absent from the payload. Those parties are placed, so the rail would be a lie — they get an explicit "placed outside the board" list instead. A test asserts the three buckets sum to the input.

## Three things stay off the family card

Each measured, each pinned by a test as an **absence**, because each is the kind of thing a later change adds back helpfully:

- **Request text** — 12 of 232 request texts contain health vocabulary including a named diagnosis. The accepted exposure was opening one roster row at a time; printing it across 62 simultaneously-visible cards is materially louder. It lives on the detail panel, one click away.
- **The medical affordance** — true for 62 of 62 parties. A flag that is always on is not a flag.
- **`needs_resolution`** — true for 44 of 62. Same reason.

## The unplaced rail admits what it cannot compute

Ranking wants a mandatory accommodation *or* a share request whose partner is unplaced. The second leg does not exist — no request names are resolved to households yet. It ranks on the accommodation alone and says so on the surface rather than implying a completeness it does not have.

## Verified in a browser on real data

Not just in tests. On the largest weekend:

- **82 slot cards** across **8 area sections** — matching the 82 non-container rooms exactly
- **62 family cards** — 56 placed + 6 on the rail, every party accounted for
- **1 consent flag**, on the unit the design predicted
- Unknown capacity renders as an em dash, never `0`; staff holds are badged, not hidden
- Clicking a family opens the panel with housing needs, share request and the verbatim request text

## One finding that corrects the design note

The flag fires on the predicted unit — but the reasoning recorded for it was that two unrelated households were sharing without consent, checked against surnames, billing addresses and phone numbers. **Reading the two request texts falsifies that:** each household names the other, one marking it as its priority. The placement is mutual, reciprocated and deliberate.

So the rule surfaces a household whose recorded gate contradicts **its own request text**, not a placement error. That is still worth a staff look, and the flag's wording reports only the recorded answer for exactly that reason. Suppressing it needs request names resolved to households, which is unbuilt. Meanwhile the design already resolves it the honest way: the card flags, and one click shows the request text that explains it. This is recorded in the code comment where the next change will read it.

## Out of scope

Dragging and any write (needs the draft tables, which do not exist), the map, and the `unit_class` field.

## Tests

Full frontend suite green: **5258 passing**, 90 of them new. Type-check clean; the registry-in-source guard passes.

Screenshots are pseudonymised before capture — the repo is public, so household, child, unit and area names in them are fictional. Layout, counts and the flag are the real render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

