### PR TITLE
feat(pb,scripts): seed the 2026 lodging inventory

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -160,7 +160,7 @@ Facts, not a work log. Do not re-verify or re-implement these.
   running the migration against a real database. Use `record.getString(field)` and `JSON.parse`.
   The Go side has the same trap in a different shape — see `extractBusinessCategory` in
   `pocketbase/rbac/hooks.go`, which handles `types.JSONRaw` separately from `map[string]any`.
-- **Highest migration is `1500000130`.** Compute the next number from `main`, never from a branch.
+- **Highest migration is `1500000131`.** Compute the next number from `main`, never from a branch.
 
 ---
 
@@ -374,7 +374,7 @@ the whole time. That is progress, not a hang — confirm with CPU, not the count
 - **Do not sum capacity over units where `is_container` is true.** They are building rows carrying
   whole-building aggregates; including them gives 408 beds against a true 389.
 - **Do not create `lodging_unresolved_aliases`.** See §3. The plan tells you to; the ruling overrides it.
-- **Do not number a migration from a branch.** Highest on `main` is `1500000130`. Compute it:
+- **Do not number a migration from a branch.** Highest on `main` is `1500000131`. Compute it:
   `git ls-tree -r origin/main pocketbase/pb_migrations/ | grep -oE '15000[0-9]{5}' | sort -u | tail -1`
 - **Do not add a `kind` value as a Go constant without the migration.** The select list is the
   constraint; a bare constant passes tests and fails in production.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -138,7 +138,7 @@ Facts, not a work log. Do not re-verify or re-implement these.
     remaining admin routes are guarded rather than merely tab-filtered (#1895).
 - **Units is sortable, area-grouped, and confirmable in one click or in bulk.** That last part
   is the point: nothing on the roster judges a housing need against an unconfirmed cabin, and
-  all 93 ship unconfirmed.
+  every unit the loader writes ships unconfirmed (114 of them after the 2026 inventory).
 - **Beds are inventory behind `sleeps`, not a replacement for it.** `frontend/src/types/beds.ts`
   turns "2 twins and a queen" into a *suggested* occupancy staff adopt with one click. `sleeps`
   remains the single number every consumer reads, so no Pydantic model changed.
@@ -212,7 +212,7 @@ Each of these was decided deliberately. Reopening one needs a reason, not a fres
   decision. It ranks only on signals that discriminate: measured on real 2026 data
   `needs_resolution` is true for 44 of 62 parties and `has_medical_narrative` for 62 of 62, so
   **neither escalates a row**. A flag that is always on is not a flag.
-- **The met/unmet fit check judges only CONFIRMED cabins.** All 82 cabins are `is_confirmed: false`
+- **The met/unmet fit check judges only CONFIRMED cabins.** Every cabin is `is_confirmed: false`
   today, so an unset `has_power` means "nobody has said", not "there is no power". Judging against
   unset defaults would flag every constrained family on absent evidence, so the check reports
   `unverified` instead and begins working the moment Phase C seeds amenities.
@@ -290,7 +290,8 @@ having: the guard blocks *new* cycles but cannot retroactively clean data that a
 ### Before either surface: confirm some cabins
 
 `partyAttention` only judges a housing need against a cabin whose `is_confirmed` is true, and
-**0 of 93 units are confirmed**, so the roster reports *"Fit not verified"* for every
+**no unit is confirmed** — the loader writes `false` on every row it creates — so the roster
+reports *"Fit not verified"* for every
 constrained party. This was verified working end to end on real data (#1893): confirming one
 cabin dropped `units_unconfirmed` 82→81 and turned a real party from unverified into a genuine
 unmet (needs power, confirmed cabin has none). `/manage/lodging/units` now offers confirmation
@@ -354,7 +355,7 @@ the whole time. That is progress, not a hang — confirm with CPU, not the count
   of 62 and 62 of 62 parties respectively. Ranking on either turns the whole roster amber and the
   triage sections stop meaning anything.
 - **Do not judge a housing need against an UNCONFIRMED cabin.** `has_power: false` on an unconfirmed
-  row means "nobody has said". All 82 cabins are unconfirmed today, so treating that as evidence
+  row means "nobody has said". Every cabin is unconfirmed today, so treating that as evidence
   flags every constrained family. `partyAttention` reports `unverified` for a reason.
 - **Do not measure weekend capacity in beds.** Spaces. A family holds a whole cabin whether or not
   it fills it; beds reported 43% headroom on a weekend with 17 spare rooms out of 79.

--- a/docs/reference/lodging-inventory-sheet.md
+++ b/docs/reference/lodging-inventory-sheet.md
@@ -1,0 +1,104 @@
+# Reading the lodging inventory sheet
+
+Camp staff maintain weekend-lodging inventory in a spreadsheet. This document
+records **what its columns mean** and the traps in reading them, so a future
+import does not rediscover them.
+
+It deliberately contains **no unit names, no camp name and no sheet location** —
+the registry is private data (`docs/reference/lodging-registry.md`), and this
+file is tracked in a public repository. The extracted data and the sheet's
+identity live in local working notes.
+
+---
+
+## The utilities column is four independent letters
+
+`W` weatherized · `E` electricity · `P` plumbing · `H` heat. A cell holds any
+combination.
+
+- **`E` is the outlet signal** and maps to `has_power`. A highlight on the
+  column corresponds to `E` with a single exception.
+- **The separate Heat/AC column is a strict SUBSET of `H`** — every unit with a
+  value there also has `H`, and none has one without it. It therefore carries no
+  heat information `H` lacks, and its only unique meaning is *cooling*, which is
+  why it maps to `has_ac`. **Never derive heat from it.**
+- **Heat is scarcer than it looks.** Fewer than a third of units have `H`, and a
+  space heater covers a different, only partly overlapping set. Around 40% of
+  the site cannot be heated at all — which matters for a winter session.
+
+## The plumbing letter predicts the bathroom column exactly
+
+Every unit with bathroom detail has `P`, and no unit without `P` has detail. So a
+unit without `P` has **no bathroom and depends on a bathhouse** — that is a known
+fact, not missing data. This is what makes `near_bathhouse` load-bearing for the
+majority of units rather than decorative.
+
+## Capacity is NOT `sleeps`
+
+The sheet's capacity is **total sleeping spots** — the summer bunk count, which
+for a camper cabin is 14–16. `sleeps` is the staff judgement about how many
+people should actually be placed there for a given session type, and one family
+holds a whole cabin however many bunks it has.
+
+**Most matched pairs disagree.** Capacity maps to `max_beds`; `sleeps` is never
+overwritten from the sheet. HANDOFF §6: spaces, not beds.
+
+## The flag columns are not all booleans
+
+This is the trap that cost the most time. Several columns look like `X`/blank
+but are not:
+
+| Column | Contents | Correct reading |
+|---|---|---|
+| Lights, pack&play | `X` or blank only | `bool(non-empty)` is safe |
+| Space heater | `TRUE` / `FALSE` strings | compare to `TRUE`, not truthiness |
+| Kitchen | `X`, `X (ette)`, and one description | non-empty means yes; a kitchenette counts |
+| **Living space** | `X`, **explicit `No`**, and furniture descriptions | **`X` only.** `bool(non-empty)` records a living room for the units that say they have none |
+| **Ramp** | a few `X`, a few `No`, some qualified yeses, **mostly blank** | three-valued, and blank means NOT ASSESSED |
+
+**`has_ramp` is a select, not a bool** (`yes` / `no` / `partial`, empty = not
+assessed). A bool maps every unassessed cabin to `false`, asserting "no ramp"
+about cabins nobody looked at — so someone filtering for step-free access sees a
+short list and a long tail of invisible maybes. Same discipline as `sleeps: null`
+never rendering as 0. Qualifier text ("yes, but there is a lip at the door")
+belongs in `notes`, where it can say what the obstacle actually is.
+
+## Legacy codes appear in two places and they disagree
+
+Older side-of-camp codes survive both in unit names (parenthesised) and in the
+notes column. **For several units the two sources name different codes**, and
+some codes are claimed by two different units.
+
+An alias built from either source alone would silently point historical
+placements at the wrong room, which is worse than having no alias: nothing
+surfaces it. **Only build an alias for a code when every mention of it, across
+both sources, points at the same unit.** A third of the river-side codes fail
+that test and deliberately have no alias.
+
+## Rows that are not units
+
+- **Total rows.** The sheet ends with summary rows that parse like units and
+  carry a nonsense capacity. Drop by name.
+- **Year-round grounds crew quarters.** Not bookable; excluded from the registry.
+- Two columns are uniformly `FALSE` across every row and carry no information.
+
+Counting note: published counts of this sheet include the grounds-crew rows, so
+a figure derived after excluding them will be lower. Reconcile against the
+denominator before assuming an import dropped something.
+
+## Names in free text
+
+The notes column has contained a staff member's name. **Scrub person names
+before the data reaches any repository**, and check by reading the notes rather
+than trusting a regex — an initial-form pattern (`Firstname L.`) does not match a
+full surname, which is how one got through once.
+
+Place names and department names are fine and should be kept; they are what makes
+a note useful.
+
+## Applying an import
+
+The boot loader is create-if-absent, so it will create units the sheet adds but
+will **not** fill new columns on units that already exist. That second step is
+`scripts/dev/apply_lodging_inventory.py`, which is dry-run by default. See
+`docs/reference/lodging-registry.md` for the field-ownership rules.

--- a/docs/reference/lodging-registry.md
+++ b/docs/reference/lodging-registry.md
@@ -239,6 +239,8 @@ block still resolves — the paths below are relative to the root, not to
 
 ```bash
 (cd pocketbase && go test ./lodging/ -count=1)   # loader unit tests
+uv run pytest tests/setup/                       # the two dev scripts below
+./scripts/dev/verify-lodging-schema.sh           # the columns exist, with the right types
 ./scripts/dev/verify-lodging-seed.sh             # boots a throwaway DB and loads the file
 ./scripts/dev/verify-no-hardcoded-lodging.sh     # no unit names in source
 ./scripts/dev/test-verify-no-hardcoded-lodging.sh

--- a/docs/reference/lodging-registry.md
+++ b/docs/reference/lodging-registry.md
@@ -133,7 +133,25 @@ an empty registry rather than an error anyone will see.
       "near_bathhouse": true,
       "allocation_default": "family_pool",  // family_pool | staff_default
       "is_container": false,    // true = a building row: never bookable, never counted
-      "notes": ""
+      "notes": "",
+
+      // Amenities. Absent means false, which is the same claim the column made
+      // before the inventory existed: unknown, recorded as false.
+      "has_power": true,
+      "has_ac": false,
+      "has_fridge": false,
+      "is_accessible": false,
+      "has_heat": true,
+      "is_weatherized": true,
+      "has_plumbing": true,
+      "has_space_heater": false,
+      "has_pack_play_space": false,   // unit-side counterpart to the family infant flag
+      "has_living_room": false,
+      "has_kitchen": false,
+      "has_lights": true,
+
+      "has_ramp": "partial",    // yes | no | partial; "" or absent = NOT ASSESSED
+      "max_beds": 14            // total sleeping spots. NOT sleeps — see below
     }
   ],
   "aliases": [
@@ -157,6 +175,47 @@ CampMinder-id discipline used across the rest of the schema.
 - `is_confirmed` — always `false` on create. Every seeded value is a guess until
   staff verify it against the actual cabin, so nothing the loader writes may
   claim otherwise. Staff confirm through `/manage/lodging`.
+
+### `max_beds` is not `sleeps`, and neither may overwrite the other
+
+`max_beds` is the total number of sleeping spots in the room. `sleeps` is the
+staff judgement about how many people should actually be placed there for a
+given session type. A camper cabin with 14 bunks holds one family, and the two
+columns disagree on most units — HANDOFF §6, spaces not beds. Both exist so
+neither has to be inferred from the other.
+
+### Getting the inventory onto rows that already exist
+
+The loader is create-if-absent, so **a new column lands empty on every row that
+already exists**. Adding amenity columns to the schema therefore gives the
+existing units a set of false-everywhere flags, which is the very condition the
+inventory exists to fix.
+
+`scripts/dev/apply_lodging_inventory.py` closes that gap. It is dry-run by
+default and splits fields by how much damage writing them could do:
+
+| Class | Fields | Behaviour |
+|---|---|---|
+| Inventory | the amenities and `max_beds` | filled freely — they were empty |
+| Structural | `bathroom`, `bathroom_group`, `is_container`, `parent_unit` | reported; written only under `--structural`, since each overwrites a value that may be deliberate |
+| Staff-owned | `sleeps`, `map_x`, `map_y`, `is_confirmed`, `is_active`, `allocation_default` | **never written**, under any flag |
+
+Two further rules: an empty `has_ramp` never overwrites a real assessment, and
+`notes` are filled only when the database has none — replacing free text a staff
+member wrote would destroy it.
+
+`parent_unit` is compared as a **code**. The database stores it as a relation —
+a record id — so comparing raw values reports every parented unit as needing a
+change, and applying that would write a code into a relation field.
+
+### Lighting up the fit check locally
+
+`partyAttention` refuses to judge a housing need against an unconfirmed cabin,
+and the loader writes `is_confirmed: false` on everything, so the fit check is
+dark until staff confirm cabins. `scripts/dev/confirm_lodging_units.py` flips
+the flag on a **local** database so the surface can be developed against. It
+refuses a non-loopback URL unless explicitly overridden: bulk confirmation on
+real data asserts to staff that every cabin was checked when none was.
 
 ### Two traps encoded in the format
 

--- a/pocketbase/lodging/registry.go
+++ b/pocketbase/lodging/registry.go
@@ -73,6 +73,30 @@ type registryUnit struct {
 	AllocationDefault string `json:"allocation_default"`
 	IsContainer       bool   `json:"is_container"`
 	Notes             string `json:"notes"`
+
+	// Amenities. Absent in JSON means false, which for these is the same claim
+	// the column made before the 2026 inventory: unknown, recorded as false.
+	HasPower         bool `json:"has_power"`
+	HasAC            bool `json:"has_ac"`
+	HasFridge        bool `json:"has_fridge"`
+	IsAccessible     bool `json:"is_accessible"`
+	HasHeat          bool `json:"has_heat"`
+	IsWeatherized    bool `json:"is_weatherized"`
+	HasPlumbing      bool `json:"has_plumbing"`
+	HasSpaceHeater   bool `json:"has_space_heater"`
+	HasPackPlaySpace bool `json:"has_pack_play_space"`
+	HasLivingRoom    bool `json:"has_living_room"`
+	HasKitchen       bool `json:"has_kitchen"`
+	HasLights        bool `json:"has_lights"`
+
+	// HasRamp is "yes" | "no" | "partial", or "" for NOT ASSESSED. Deliberately
+	// not a bool: most cabins were never checked, and a bool would record them
+	// all as step-free-inaccessible.
+	HasRamp string `json:"has_ramp"`
+
+	// MaxBeds is total sleeping spots, NOT Sleeps. Sleeps is the staff
+	// judgement for the session type and the two disagree on most units.
+	MaxBeds *int `json:"max_beds"`
 }
 
 type registryAlias struct {
@@ -349,6 +373,24 @@ func seedUnits(
 		rec.Set("allocation_default", u.AllocationDefault)
 		rec.Set("is_container", u.IsContainer)
 		rec.Set("notes", u.Notes)
+		rec.Set("has_power", u.HasPower)
+		rec.Set("has_ac", u.HasAC)
+		rec.Set("has_fridge", u.HasFridge)
+		rec.Set("is_accessible", u.IsAccessible)
+		rec.Set("has_heat", u.HasHeat)
+		rec.Set("is_weatherized", u.IsWeatherized)
+		rec.Set("has_plumbing", u.HasPlumbing)
+		rec.Set("has_space_heater", u.HasSpaceHeater)
+		rec.Set("has_pack_play_space", u.HasPackPlaySpace)
+		rec.Set("has_living_room", u.HasLivingRoom)
+		rec.Set("has_kitchen", u.HasKitchen)
+		rec.Set("has_lights", u.HasLights)
+		// Left unset when blank, so "not assessed" reaches the database as an
+		// empty select rather than a decision.
+		if u.HasRamp != "" {
+			rec.Set("has_ramp", u.HasRamp)
+		}
+		setIfPresentInt(rec, "max_beds", u.MaxBeds)
 		rec.Set("is_active", true)
 		// Every seeded value is a guess until staff confirm it against the
 		// actual cabin, so nothing this loader writes may claim otherwise.

--- a/pocketbase/lodging/registry_test.go
+++ b/pocketbase/lodging/registry_test.go
@@ -53,8 +53,12 @@ func setupRegistryCollections(t *testing.T, app core.App) {
 	units.Fields.Add(&core.TextField{Name: "notes"})
 	// Amenity columns from 1500000131. has_ramp is a select, not a bool, so an
 	// unassessed cabin stays blank instead of claiming "no ramp".
+	// has_fridge and is_accessible predate 1500000131 (they come from
+	// 1500000116) but the loader writes them too, so the fixture has to declare
+	// them or those two writes go unasserted.
 	for _, name := range []string{
-		"has_power", "has_ac", "has_heat", "is_weatherized", "has_plumbing",
+		"has_power", "has_ac", "has_fridge", "is_accessible",
+		"has_heat", "is_weatherized", "has_plumbing",
 		"has_space_heater", "has_pack_play_space", "has_living_room",
 		"has_kitchen", "has_lights",
 	} {
@@ -326,7 +330,8 @@ func TestSeedRegistryWritesAmenities(t *testing.T) {
 	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
 	  {"area": "AREA1", "code": "warm", "name": "Warm", "bathroom": "none",
 	   "allocation_default": "family_pool",
-	   "has_power": true, "has_ac": true, "has_heat": true, "is_weatherized": true,
+	   "has_power": true, "has_ac": true, "has_fridge": true, "is_accessible": true,
+	   "has_heat": true, "is_weatherized": true,
 	   "has_plumbing": true, "has_space_heater": true, "has_pack_play_space": true,
 	   "has_living_room": true, "has_kitchen": true, "has_lights": true,
 	   "has_ramp": "partial", "max_beds": 14}
@@ -338,7 +343,8 @@ func TestSeedRegistryWritesAmenities(t *testing.T) {
 
 	unit := findByCode(t, app, "lodging_units", "warm")
 	for _, field := range []string{
-		"has_power", "has_ac", "has_heat", "is_weatherized", "has_plumbing",
+		"has_power", "has_ac", "has_fridge", "is_accessible",
+		"has_heat", "is_weatherized", "has_plumbing",
 		"has_space_heater", "has_pack_play_space", "has_living_room",
 		"has_kitchen", "has_lights",
 	} {

--- a/pocketbase/lodging/registry_test.go
+++ b/pocketbase/lodging/registry_test.go
@@ -51,6 +51,19 @@ func setupRegistryCollections(t *testing.T, app core.App) {
 	units.Fields.Add(&core.BoolField{Name: "is_active"})
 	units.Fields.Add(&core.BoolField{Name: "is_container"})
 	units.Fields.Add(&core.TextField{Name: "notes"})
+	// Amenity columns from 1500000131. has_ramp is a select, not a bool, so an
+	// unassessed cabin stays blank instead of claiming "no ramp".
+	for _, name := range []string{
+		"has_power", "has_ac", "has_heat", "is_weatherized", "has_plumbing",
+		"has_space_heater", "has_pack_play_space", "has_living_room",
+		"has_kitchen", "has_lights",
+	} {
+		units.Fields.Add(&core.BoolField{Name: name})
+	}
+	units.Fields.Add(&core.SelectField{
+		Name: "has_ramp", Values: []string{"yes", "no", "partial"}, MaxSelect: 1,
+	})
+	units.Fields.Add(&core.NumberField{Name: "max_beds", OnlyInt: true})
 	units.AddIndex("idx_lodging_units_code", true, "code", "")
 	saveRegistryCollection(t, app, units)
 
@@ -299,6 +312,70 @@ func TestSeedRegistryCreatesAreasUnitsAndAliases(t *testing.T) {
 	}
 	if !findByCode(t, app, "lodging_units", "building-1").GetBool("is_container") {
 		t.Error("building-1 is_container = false, want true")
+	}
+}
+
+// The 2026 inventory's whole point. Before it, has_power/has_ac/has_fridge/
+// is_accessible were false on all 93 units — not because the cabins lacked
+// them but because nobody filled the columns in, which is why the fit check
+// has never been meaningful. A loader that ignored these fields would carry
+// the sheet's answers into the file and drop them on the way to the database.
+func TestSeedRegistryWritesAmenities(t *testing.T) {
+	app := newRegistryTestApp(t)
+
+	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
+	  {"area": "AREA1", "code": "warm", "name": "Warm", "bathroom": "none",
+	   "allocation_default": "family_pool",
+	   "has_power": true, "has_ac": true, "has_heat": true, "is_weatherized": true,
+	   "has_plumbing": true, "has_space_heater": true, "has_pack_play_space": true,
+	   "has_living_room": true, "has_kitchen": true, "has_lights": true,
+	   "has_ramp": "partial", "max_beds": 14}
+	], "aliases": []}`
+
+	if err := seedRegistryFromFile(app, writeRegistry(t, body)); err != nil {
+		t.Fatalf("seedRegistryFromFile: %v", err)
+	}
+
+	unit := findByCode(t, app, "lodging_units", "warm")
+	for _, field := range []string{
+		"has_power", "has_ac", "has_heat", "is_weatherized", "has_plumbing",
+		"has_space_heater", "has_pack_play_space", "has_living_room",
+		"has_kitchen", "has_lights",
+	} {
+		if !unit.GetBool(field) {
+			t.Errorf("%s = false, want true", field)
+		}
+	}
+	if got := unit.GetString("has_ramp"); got != "partial" {
+		t.Errorf("has_ramp = %q, want %q", got, "partial")
+	}
+	// max_beds is total sleeping spots and must never be confused with sleeps,
+	// the staff judgement for the session type. A 14-bunk camper cabin holds
+	// one family.
+	if got := unit.GetInt("max_beds"); got != 14 {
+		t.Errorf("max_beds = %d, want 14", got)
+	}
+	if got := unit.GetInt("sleeps"); got != 0 {
+		t.Errorf("sleeps = %d, want 0 — max_beds must not leak into sleeps", got)
+	}
+}
+
+// A blank has_ramp is "not assessed", and it must reach the database blank
+// rather than as a confident "no".
+func TestSeedRegistryUnassessedRampStaysBlank(t *testing.T) {
+	app := newRegistryTestApp(t)
+
+	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
+	  {"area": "AREA1", "code": "unknown-ramp", "name": "Unknown", "bathroom": "none",
+	   "allocation_default": "family_pool"}
+	], "aliases": []}`
+
+	if err := seedRegistryFromFile(app, writeRegistry(t, body)); err != nil {
+		t.Fatalf("seedRegistryFromFile: %v", err)
+	}
+
+	if got := findByCode(t, app, "lodging_units", "unknown-ramp").GetString("has_ramp"); got != "" {
+		t.Errorf("has_ramp = %q for an unassessed unit, want empty (not assessed)", got)
 	}
 }
 

--- a/pocketbase/pb_migrations/1500000131_lodging_unit_amenities.js
+++ b/pocketbase/pb_migrations/1500000131_lodging_unit_amenities.js
@@ -1,0 +1,123 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Add the amenity columns the 2026 inventory needs to lodging_units.
+ *
+ * SCHEMA ONLY. No values are written here: the registry is private data in
+ * config/lodging_registry.json (docs/reference/lodging-registry.md), and unit
+ * names are camp-identifying, so nothing camp-specific may live in a tracked
+ * migration. These columns land empty on existing rows and are populated
+ * separately.
+ *
+ * WHY THESE FIELDS AT ALL. Of the 93 units the registry holds today,
+ * `has_power`, `has_ac`, `has_fridge`, `is_accessible` and `is_confirmed` are
+ * false on ALL of them — not because the cabins lack power, but because nobody
+ * ever filled the columns in. That is why the roster's fit check has never been
+ * meaningful: `needs_power` was being judged against a column that is false
+ * everywhere. This is the first amenity data the registry will have.
+ *
+ * `has_ramp` IS A SELECT, NOT A BOOL, and that is the load-bearing decision
+ * here. The source column is overwhelmingly blank, with a handful of yeses, a
+ * few explicit noes, and some qualified yeses ("yes, but there is a lip at the
+ * door"). A bool maps every unassessed cabin to false, which asserts "no ramp"
+ * about cabins nobody has looked at — so someone filtering for step-free access
+ * would see a short list and a long tail of invisible maybes. An empty select
+ * means NOT ASSESSED, the same discipline that stops `sleeps: null` rendering
+ * as 0. `partial` carries the qualified case; the qualifier text itself belongs
+ * in `notes`, where it can say what the lip actually is.
+ *
+ * `max_beds` IS NOT `sleeps`, and neither may overwrite the other. `max_beds`
+ * is the total number of sleeping spots in the room. `sleeps` is the staff
+ * judgement about how many people should actually be put there for a given
+ * session type, and the two disagree on most units — a camper cabin with 14
+ * bunks holds one family. HANDOFF §6: spaces, not beds. 1500000128 anticipated
+ * this: "real capacity depends on bed size AND on who can share a bed, which is
+ * a staff judgement rather than a sum."
+ *
+ * PocketBase v0.23 syntax: fields.add(new Field({...})) on an existing
+ * collection. A bare add({...}) silently does nothing and fails at server boot.
+ */
+
+migrate(
+  (app) => {
+    const col = app.findCollectionByNameOrId('lodging_units');
+
+    const BOOLS = [
+      'has_heat',
+      'is_weatherized',
+      'has_plumbing',
+      // Distinct from has_heat: a space heater is portable and needs an outlet,
+      // so it is not the same claim as a heated cabin.
+      'has_space_heater',
+      // The unit-side counterpart to the family-side infant flag. Without it, a
+      // family bringing an infant can be placed in a room with nowhere to put a
+      // pack & play and nothing can see it.
+      'has_pack_play_space',
+      'has_living_room',
+      'has_kitchen',
+      'has_lights',
+    ];
+
+    // Idempotent per field: re-running, or a filename-keyed skip, must not
+    // double-add. Checked per column rather than once for the whole batch, so a
+    // migration edited after it was applied still adds what is missing —
+    // _migrations keys on filename and will not re-run the file otherwise.
+    for (const name of BOOLS) {
+      if (col.fields.getByName(name)) continue;
+      col.fields.add(new Field({ type: 'bool', name, required: false, presentable: false }));
+    }
+
+    if (!col.fields.getByName('has_ramp')) {
+      col.fields.add(
+        new Field({
+          type: 'select',
+          name: 'has_ramp',
+          required: false,
+          presentable: false,
+          values: ['yes', 'no', 'partial'],
+          maxSelect: 1,
+        })
+      );
+    }
+
+    if (!col.fields.getByName('max_beds')) {
+      col.fields.add(
+        new Field({
+          type: 'number',
+          name: 'max_beds',
+          required: false,
+          presentable: false,
+          onlyInt: true,
+          // Unbounded must be null, not 0 — a max of 0 rejects every positive
+          // value, and verify-lodging-schema.sh asserts this for sleeps too.
+          min: null,
+          max: null,
+        })
+      );
+    }
+
+    app.save(col);
+  },
+  (app) => {
+    const col = app.findCollectionByNameOrId('lodging_units');
+    const NAMES = [
+      'has_heat',
+      'is_weatherized',
+      'has_plumbing',
+      'has_space_heater',
+      'has_pack_play_space',
+      'has_living_room',
+      'has_kitchen',
+      'has_lights',
+      'has_ramp',
+      'max_beds',
+    ];
+    let dirty = false;
+    for (const name of NAMES) {
+      if (!col.fields.getByName(name)) continue;
+      // removeByName is this repo's idiom (1500000087, 1500000097, 1500000113).
+      col.fields.removeByName(name);
+      dirty = true;
+    }
+    if (dirty) app.save(col);
+  }
+);

--- a/scripts/dev/apply_lodging_inventory.py
+++ b/scripts/dev/apply_lodging_inventory.py
@@ -9,9 +9,9 @@ restart.
 
 The consequence is that a new column lands EMPTY on every row that already
 exists. The 2026 amenity columns are exactly that case: adding them to the
-schema gives 93 units ten new false-everywhere flags. This script fills them in,
-deliberately and once, rather than making the loader a second writer with
-different rules.
+schema leaves the 93 pre-existing units with eight false-everywhere booleans, an
+unset has_ramp and an unset max_beds. This script fills them in, deliberately
+and once, rather than making the loader a second writer with different rules.
 
 It is dry-run by default and prints what it would change. Nothing is written
 without --apply.

--- a/scripts/dev/apply_lodging_inventory.py
+++ b/scripts/dev/apply_lodging_inventory.py
@@ -58,6 +58,11 @@ INVENTORY_FIELDS = (
 # purpose, so they are reported for a human and applied only on --structural.
 STRUCTURAL_FIELDS = ("bathroom", "bathroom_group", "is_container", "parent_unit")
 
+# Fields where the file's null means UNKNOWN rather than a value to write. The
+# booleans alongside them have no such state — absent means false, which is a
+# real claim — so this applies only to the numbers.
+NULLABLE_FIELDS = ("max_beds",)
+
 # Never written by this script under any flag. These are the fields staff
 # maintain, and overwriting them is precisely what create-if-absent exists to
 # prevent.
@@ -107,6 +112,28 @@ def normalise_parents(records: dict[str, dict[str, Any]]) -> dict[str, dict[str,
     return out
 
 
+def resolve_parent_id(fields: dict[str, Any], ids: dict[str, str]) -> dict[str, Any]:
+    """Translate a parent_unit CODE back into the record id a relation needs.
+
+    Raises rather than falling back to "": an unresolvable code would otherwise
+    detach the child from its container with no error, which is the opposite of
+    what every other guard here does. An EMPTY code is legitimate — it means the
+    unit has no parent.
+    """
+    out = dict(fields)
+    code = out.get("parent_unit") or ""
+    if not code:
+        out["parent_unit"] = ""
+        return out
+    if code not in ids:
+        raise KeyError(
+            f"parent_unit {code!r} names no unit in the database; "
+            "restart PocketBase so the boot loader creates it, or fix the registry"
+        )
+    out["parent_unit"] = ids[code]
+    return out
+
+
 def plan_updates(
     want: list[dict[str, Any]], have: dict[str, dict[str, Any]], *, include_structural: bool = False
 ) -> Plan:
@@ -128,6 +155,12 @@ def plan_updates(
         changes: dict[str, Any] = {}
         for name in INVENTORY_FIELDS:
             if name not in unit:
+                continue
+            # max_beds carries the same null-means-unknown contract as sleeps
+            # and has_ramp: PocketBase stores an unset number as 0, which every
+            # consumer reads as "unknown". Writing null over a real number
+            # replaces knowledge with a placeholder, silently.
+            if name in NULLABLE_FIELDS and unit.get(name) is None:
                 continue
             new, old = _norm(unit.get(name)), _norm(current.get(name))
             if new != old:
@@ -262,7 +295,7 @@ def main(argv: list[str] | None = None) -> int:
         fields = dict(u.fields)
         # Back the other way: a relation field takes a record id, not a code.
         if "parent_unit" in fields:
-            fields["parent_unit"] = ids.get(fields["parent_unit"], "")
+            fields = resolve_parent_id(fields, ids)
         _patch(args.url, token, ids[u.code], fields)
     print(f"\napplied {len(plan.updates)} update(s).")
     return 0

--- a/scripts/dev/apply_lodging_inventory.py
+++ b/scripts/dev/apply_lodging_inventory.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Carry the private lodging registry's inventory onto rows that already exist.
+
+The boot loader (pocketbase/lodging/registry.go) is CREATE-IF-ABSENT: it creates
+units it does not find and never touches ones it does. That is deliberate — the
+registry is staff-editable in /manage/lodging, and a loader that rewrote every
+field on boot would undo confirmations and corrected coordinates on the next
+restart.
+
+The consequence is that a new column lands EMPTY on every row that already
+exists. The 2026 amenity columns are exactly that case: adding them to the
+schema gives 93 units ten new false-everywhere flags. This script fills them in,
+deliberately and once, rather than making the loader a second writer with
+different rules.
+
+It is dry-run by default and prints what it would change. Nothing is written
+without --apply.
+
+    scripts/dev/apply_lodging_inventory.py                    # show the plan
+    scripts/dev/apply_lodging_inventory.py --apply            # fill amenities
+    scripts/dev/apply_lodging_inventory.py --apply --structural   # + corrections
+
+See docs/reference/lodging-registry.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import requests
+
+# Columns this script owns: they came from the inventory sheet and were empty
+# (or absent) before it. Filling them adds information rather than replacing a
+# judgement.
+INVENTORY_FIELDS = (
+    "has_power",
+    "has_ac",
+    "has_fridge",
+    "is_accessible",
+    "has_heat",
+    "is_weatherized",
+    "has_plumbing",
+    "has_space_heater",
+    "has_pack_play_space",
+    "has_living_room",
+    "has_kitchen",
+    "has_lights",
+    "max_beds",
+)
+
+# Real corrections, but each overwrites a value that may have been set on
+# purpose, so they are reported for a human and applied only on --structural.
+STRUCTURAL_FIELDS = ("bathroom", "bathroom_group", "is_container", "parent_unit")
+
+# Never written by this script under any flag. These are the fields staff
+# maintain, and overwriting them is precisely what create-if-absent exists to
+# prevent.
+STAFF_OWNED = ("sleeps", "map_x", "map_y", "is_confirmed", "is_active", "allocation_default")
+
+
+@dataclass
+class UnitUpdate:
+    code: str
+    fields: dict[str, Any]
+
+
+@dataclass
+class Plan:
+    updates: list[UnitUpdate] = field(default_factory=list)
+    structural: list[UnitUpdate] = field(default_factory=list)
+    absent: list[str] = field(default_factory=list)
+
+
+def _norm(value: Any) -> Any:
+    """PocketBase stores an unset number as 0 and an unset bool as false, while
+    the registry file uses null/absent for the same thing."""
+    if value is None:
+        return 0
+    if isinstance(value, bool):
+        return value
+    return value
+
+
+def normalise_parents(records: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Rewrite each record's parent_unit from a PocketBase record id to a unit
+    code, so it can be compared with the registry file.
+
+    The database stores parent_unit as a relation — an id — while the file
+    stores a code, by the same durable-key discipline that keeps the file
+    portable across database rebuilds. Compared raw, every parented unit looks
+    like it needs changing, and applying that would write a code into a
+    relation field.
+    """
+    by_id = {r["id"]: r["code"] for r in records.values() if r.get("id")}
+    out: dict[str, dict[str, Any]] = {}
+    for code, rec in records.items():
+        copy = dict(rec)
+        parent = rec.get("parent_unit") or ""
+        copy["parent_unit"] = by_id.get(parent, "") if parent else ""
+        out[code] = copy
+    return out
+
+
+def plan_updates(
+    want: list[dict[str, Any]], have: dict[str, dict[str, Any]], *, include_structural: bool = False
+) -> Plan:
+    """Diff the registry file against the database, one unit at a time.
+
+    Creating rows is deliberately NOT this script's job — the boot loader does
+    that, and a second creator with different rules is how two writers start
+    disagreeing about the same table.
+    """
+    plan = Plan()
+
+    for unit in want:
+        code = unit["code"]
+        current = have.get(code)
+        if current is None:
+            plan.absent.append(code)
+            continue
+
+        changes: dict[str, Any] = {}
+        for name in INVENTORY_FIELDS:
+            if name not in unit:
+                continue
+            new, old = _norm(unit.get(name)), _norm(current.get(name))
+            if new != old:
+                changes[name] = unit.get(name)
+
+        # An empty has_ramp means NOT ASSESSED. Writing it over a real answer
+        # would erase an assessment and make it look like one never happened.
+        ramp = (unit.get("has_ramp") or "").strip()
+        if ramp and ramp != (current.get("has_ramp") or ""):
+            changes["has_ramp"] = ramp
+
+        # Notes are free text someone may have written. Fill an empty one;
+        # never replace a written one.
+        note = (unit.get("notes") or "").strip()
+        if note and not (current.get("notes") or "").strip():
+            changes["notes"] = note
+
+        structural: dict[str, Any] = {}
+        for name in STRUCTURAL_FIELDS:
+            if name not in unit:
+                continue
+            if _norm(unit.get(name)) != _norm(current.get(name)):
+                structural[name] = unit.get(name)
+
+        if include_structural:
+            changes.update(structural)
+            structural = {}
+
+        if changes:
+            plan.updates.append(UnitUpdate(code, changes))
+        if structural:
+            plan.structural.append(UnitUpdate(code, structural))
+
+    return plan
+
+
+# --------------------------------------------------------------- PocketBase
+
+
+def _auth(base: str, identity: str, password: str) -> str:
+    resp = requests.post(
+        f"{base}/api/collections/_superusers/auth-with-password",
+        json={"identity": identity, "password": password},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return str(resp.json()["token"])
+
+
+def _fetch_units(base: str, token: str) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    page = 1
+    while True:
+        resp = requests.get(
+            f"{base}/api/collections/lodging_units/records",
+            params={"perPage": 200, "page": page},
+            headers={"Authorization": token},
+            timeout=60,
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        for item in body["items"]:
+            out[item["code"]] = item
+        if page >= body["totalPages"]:
+            break
+        page += 1
+    return out
+
+
+def _patch(base: str, token: str, record_id: str, fields: dict[str, Any]) -> None:
+    resp = requests.patch(
+        f"{base}/api/collections/lodging_units/records/{record_id}",
+        json=fields,
+        headers={"Authorization": token},
+        timeout=30,
+    )
+    resp.raise_for_status()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--registry", default="config/lodging_registry.json")
+    parser.add_argument("--url", default=os.environ.get("POCKETBASE_URL", "http://127.0.0.1:8090"))
+    parser.add_argument("--identity", default=os.environ.get("PB_ADMIN_EMAIL", "admin@camp.local"))
+    parser.add_argument("--password", default=os.environ.get("PB_ADMIN_PASSWORD", ""))
+    parser.add_argument("--apply", action="store_true", help="write the changes (default: dry run)")
+    parser.add_argument(
+        "--structural",
+        action="store_true",
+        help="also apply bathroom/container/parent corrections, which OVERWRITE existing values",
+    )
+    args = parser.parse_args(argv)
+
+    registry = Path(args.registry)
+    if not registry.is_file():
+        print(f"error: {registry} not found — the registry lives in kindred-local", file=sys.stderr)
+        return 2
+    units = json.loads(registry.read_text())["units"]
+
+    if not args.password:
+        print("error: set PB_ADMIN_PASSWORD (or pass --password)", file=sys.stderr)
+        return 2
+
+    token = _auth(args.url, args.identity, args.password)
+    raw = _fetch_units(args.url, token)
+    have = normalise_parents(raw)
+    plan = plan_updates(units, have, include_structural=args.structural)
+
+    print(f"registry: {len(units)} units    database: {len(have)} units")
+    print(f"\n{len(plan.updates)} unit(s) to update:")
+    for u in plan.updates:
+        print(f"  {u.code:<28}{u.fields}")
+
+    if plan.structural:
+        print(f"\n{len(plan.structural)} STRUCTURAL difference(s) — NOT applied without --structural.")
+        print("  These overwrite values that may have been set deliberately:")
+        for u in plan.structural:
+            print(f"  {u.code:<28}{u.fields}")
+
+    if plan.absent:
+        print(f"\n{len(plan.absent)} unit(s) in the file but not the database.")
+        print("  The boot loader creates these; restart PocketBase rather than running this.")
+        for code in plan.absent:
+            print(f"  {code}")
+
+    if not args.apply:
+        print("\nDRY RUN — nothing written. Re-run with --apply.")
+        return 0
+
+    ids = {code: rec["id"] for code, rec in raw.items()}
+    for u in plan.updates:
+        fields = dict(u.fields)
+        # Back the other way: a relation field takes a record id, not a code.
+        if "parent_unit" in fields:
+            fields["parent_unit"] = ids.get(fields["parent_unit"], "")
+        _patch(args.url, token, ids[u.code], fields)
+    print(f"\napplied {len(plan.updates)} update(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/confirm_lodging_units.py
+++ b/scripts/dev/confirm_lodging_units.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""DEV ONLY: mark lodging units confirmed, so the roster's fit check lights up.
+
+`is_confirmed` means A HUMAN HAS CHECKED THIS CABIN. Everything the registry
+loader writes is a guess from a spreadsheet, so it writes `false` on every row,
+and `partyAttention` refuses to judge a housing need against an unconfirmed
+cabin — `has_power: false` there means "nobody has said", not "no power". With
+0 of 93 units confirmed, every constrained party reports `unverified` and the
+whole fit check reads as dark.
+
+That is correct behaviour, and it makes the board hard to develop against. This
+script flips the flag on a LOCAL database so the surface can be built and seen
+working. It is not a substitute for staff confirming cabins.
+
+RUNNING THIS AGAINST PRODUCTION IS A SEPARATE AND DELIBERATE DECISION, and it
+would be the wrong one: it would assert to staff that 93 cabins had been
+checked when none had. The script refuses non-local URLs unless you pass
+--i-know-this-is-not-local.
+
+    scripts/dev/confirm_lodging_units.py                  # show what would change
+    scripts/dev/confirm_lodging_units.py --apply          # confirm all units
+    scripts/dev/confirm_lodging_units.py --apply --undo   # put it back
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Any
+from urllib.parse import urlparse
+
+import requests
+
+LOCAL_HOSTS = {"127.0.0.1", "localhost", "::1", "0.0.0.0"}
+
+
+def is_local(url: str) -> bool:
+    """Local means a loopback host. Anything else is someone's real data."""
+    return (urlparse(url).hostname or "") in LOCAL_HOSTS
+
+
+def _auth(base: str, identity: str, password: str) -> str:
+    resp = requests.post(
+        f"{base}/api/collections/_superusers/auth-with-password",
+        json={"identity": identity, "password": password},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return str(resp.json()["token"])
+
+
+def _units(base: str, token: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        resp = requests.get(
+            f"{base}/api/collections/lodging_units/records",
+            params={"perPage": 200, "page": page},
+            headers={"Authorization": token},
+            timeout=60,
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        out.extend(body["items"])
+        if page >= body["totalPages"]:
+            break
+        page += 1
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", default=os.environ.get("POCKETBASE_URL", "http://127.0.0.1:8090"))
+    parser.add_argument("--identity", default=os.environ.get("PB_ADMIN_EMAIL", "admin@camp.local"))
+    parser.add_argument("--password", default=os.environ.get("PB_ADMIN_PASSWORD", ""))
+    parser.add_argument("--apply", action="store_true", help="write (default: dry run)")
+    parser.add_argument("--undo", action="store_true", help="set is_confirmed back to false")
+    parser.add_argument(
+        "--i-know-this-is-not-local",
+        action="store_true",
+        help="required for a non-loopback URL; confirming cabins nobody checked is a lie to staff",
+    )
+    args = parser.parse_args(argv)
+
+    if not is_local(args.url) and not args.i_know_this_is_not_local:
+        print(
+            f"refusing: {args.url} is not local.\n"
+            "is_confirmed asserts a human checked the cabin. Setting it in bulk on a real\n"
+            "database tells staff 93 cabins were verified when none were.\n"
+            "Pass --i-know-this-is-not-local if you genuinely mean to.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not args.password:
+        print("error: set PB_ADMIN_PASSWORD (or pass --password)", file=sys.stderr)
+        return 2
+
+    want = not args.undo
+    token = _auth(args.url, args.identity, args.password)
+    units = _units(args.url, token)
+    todo = [u for u in units if bool(u.get("is_confirmed")) != want]
+
+    print(f"{len(units)} units; {len(todo)} to set is_confirmed={want}")
+    if not args.apply:
+        print("DRY RUN — nothing written. Re-run with --apply.")
+        return 0
+
+    for u in todo:
+        resp = requests.patch(
+            f"{args.url}/api/collections/lodging_units/records/{u['id']}",
+            json={"is_confirmed": want},
+            headers={"Authorization": token},
+            timeout=30,
+        )
+        resp.raise_for_status()
+    print(f"set is_confirmed={want} on {len(todo)} unit(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/confirm_lodging_units.py
+++ b/scripts/dev/confirm_lodging_units.py
@@ -5,17 +5,17 @@
 loader writes is a guess from a spreadsheet, so it writes `false` on every row,
 and `partyAttention` refuses to judge a housing need against an unconfirmed
 cabin — `has_power: false` there means "nobody has said", not "no power". With
-0 of 93 units confirmed, every constrained party reports `unverified` and the
-whole fit check reads as dark.
+none of the registry's 114 units confirmed, every constrained party reports
+`unverified` and the whole fit check reads as dark.
 
 That is correct behaviour, and it makes the board hard to develop against. This
 script flips the flag on a LOCAL database so the surface can be built and seen
 working. It is not a substitute for staff confirming cabins.
 
 RUNNING THIS AGAINST PRODUCTION IS A SEPARATE AND DELIBERATE DECISION, and it
-would be the wrong one: it would assert to staff that 93 cabins had been
-checked when none had. The script refuses non-local URLs unless you pass
---i-know-this-is-not-local.
+would be the wrong one: it would assert to staff that every cabin in the
+registry had been checked when none had. The script refuses non-local URLs
+unless you pass --i-know-this-is-not-local.
 
     scripts/dev/confirm_lodging_units.py                  # show what would change
     scripts/dev/confirm_lodging_units.py --apply          # confirm all units
@@ -87,7 +87,7 @@ def main(argv: list[str] | None = None) -> int:
         print(
             f"refusing: {args.url} is not local.\n"
             "is_confirmed asserts a human checked the cabin. Setting it in bulk on a real\n"
-            "database tells staff 93 cabins were verified when none were.\n"
+            "database tells staff every cabin was verified when none were.\n"
             "Pass --i-know-this-is-not-local if you genuinely mean to.",
             file=sys.stderr,
         )

--- a/scripts/dev/lib/diff_lodging_registry.py
+++ b/scripts/dev/lib/diff_lodging_registry.py
@@ -61,7 +61,11 @@ def _diff_units(doc: dict[str, Any], db: sqlite3.Connection) -> list[str]:
             """
             SELECT u.code, u.name, a.code AS area_code, u.map_x, u.map_y, u.sleeps,
                    u.bathroom, u.bathroom_group, u.near_bathhouse, u.allocation_default,
-                   u.is_container, u.notes, p.code AS parent_code
+                   u.is_container, u.notes, p.code AS parent_code,
+                   u.has_power, u.has_ac, u.has_fridge, u.is_accessible, u.has_heat,
+                   u.is_weatherized, u.has_plumbing, u.has_space_heater,
+                   u.has_pack_play_space, u.has_living_room, u.has_kitchen, u.has_lights,
+                   u.has_ramp, u.max_beds
               FROM lodging_units u
               JOIN lodging_areas a ON a.id = u.area
               LEFT JOIN lodging_units p ON p.id = u.parent_unit
@@ -90,7 +94,26 @@ def _diff_units(doc: dict[str, Any], db: sqlite3.Connection) -> list[str]:
             ("is_container", int(bool(w.get("is_container"))), int(g["is_container"] or 0)),
             ("notes", w.get("notes") or "", g["notes"] or ""),
             ("parent_unit", w.get("parent_unit") or "", g["parent_code"] or ""),
+            # has_ramp is a select whose EMPTY value means "not assessed", so it
+            # is compared as a string. Everything else here is a plain bool.
+            ("has_ramp", w.get("has_ramp") or "", g["has_ramp"] or ""),
+            ("max_beds", _norm_num(w.get("max_beds")), _norm_num(g["max_beds"])),
         ]
+        for field in (
+            "has_power",
+            "has_ac",
+            "has_fridge",
+            "is_accessible",
+            "has_heat",
+            "is_weatherized",
+            "has_plumbing",
+            "has_space_heater",
+            "has_pack_play_space",
+            "has_living_room",
+            "has_kitchen",
+            "has_lights",
+        ):
+            checks.append((field, int(bool(w.get(field))), int(g[field] or 0)))
         for field, file_value, db_value in checks:
             if file_value != db_value:
                 diffs.append(f"unit {code}.{field}: file={file_value!r} db={db_value!r}")

--- a/scripts/dev/verify-lodging-schema.sh
+++ b/scripts/dev/verify-lodging-schema.sh
@@ -67,6 +67,37 @@ bt=$(field_prop lodging_units bathroom values || true)
 ad=$(field_prop lodging_units allocation_default values || true)
 [[ "$ad" == '["family_pool","staff_default"]' ]] || note "lodging_units.allocation_default values are $ad"
 
+# Amenity columns added by 1500000131 for the inventory seed. Asserted by TYPE,
+# because a bool written where a select belongs is the difference between
+# "not assessed" and a confident "no" (see has_ramp below).
+for f in has_heat is_weatherized has_plumbing has_space_heater \
+         has_pack_play_space has_living_room has_kitchen has_lights; do
+  t=$(field_prop lodging_units "$f" type || true)
+  [[ "$t" == "bool" ]] || note "lodging_units.$f type is '$t' (expected bool)"
+done
+
+# has_ramp is deliberately NOT a bool. The source column is mostly blank, and a
+# bool maps every unassessed cabin to "no ramp" — asserting a fact about
+# step-free access that nobody checked. Empty select = not assessed, the same
+# discipline as `sleeps: null` never rendering 0.
+rt=$(field_prop lodging_units has_ramp type || true)
+[[ "$rt" == "select" ]] || note "lodging_units.has_ramp type is '$rt' (expected select, so blank can mean 'not assessed')"
+rv=$(field_prop lodging_units has_ramp values || true)
+[[ "$rv" == '["yes","no","partial"]' ]] || note "lodging_units.has_ramp values are $rv (expected [\"yes\",\"no\",\"partial\"])"
+rr=$(field_prop lodging_units has_ramp required || true)
+[[ "$rr" != "1" && "$rr" != "true" ]] || note "lodging_units.has_ramp is required (must be optional: blank means not assessed)"
+
+# max_beds is the sheet's total sleeping spots. It is NOT sleeps, which is a
+# staff judgement for the session type and disagrees with it on most units —
+# HANDOFF §6, spaces not beds. Both columns exist precisely so neither
+# overwrites the other.
+mb=$(field_prop lodging_units max_beds type || true)
+[[ "$mb" == "number" ]] || note "lodging_units.max_beds type is '$mb' (expected number)"
+mbi=$(field_prop lodging_units max_beds onlyInt || true)
+[[ "$mbi" == "1" || "$mbi" == "true" ]] || note "lodging_units.max_beds onlyInt is '$mbi' (expected true)"
+mbx=$(field_prop lodging_units max_beds max || true)
+[[ -z "$mbx" || "$mbx" == "null" ]] || note "lodging_units.max_beds max is '$mbx' (expected null for unbounded)"
+
 st=$(field_prop lodging_availability state values || true)
 [[ "$st" == '["reserved_staff","reserved_other","released_to_family"]' ]] || note "lodging_availability.state values are $st"
 

--- a/tests/setup/test_apply_lodging_inventory.py
+++ b/tests/setup/test_apply_lodging_inventory.py
@@ -79,21 +79,50 @@ def test_a_unit_missing_from_the_database_is_left_to_the_boot_loader() -> None:
     assert plan.absent == ["brand-new"]
 
 
+# A differing (database, file) pair for every staff-owned field, so the test
+# below can prove the whole class is unwritable rather than a sample of it.
+_STAFF_OWNED_VALUES: dict[str, tuple[object, object]] = {
+    "sleeps": (9, 4),
+    "map_x": (0.9, 0.5),
+    "map_y": (0.9, 0.5),
+    "is_confirmed": (True, False),
+    "is_active": (False, True),
+    "allocation_default": ("staff_default", "family_pool"),
+}
+
+
+def test_every_staff_owned_field_has_a_case_below() -> None:
+    """Guards the guard. Adding a field to STAFF_OWNED without a value pair here
+    would silently shrink the parametrised test into covering less than it
+    claims, which is how a subset starts reading as an exhaustive check."""
+    assert set(apply_inv.STAFF_OWNED) == set(_STAFF_OWNED_VALUES)
+
+
 # The whole point of create-if-absent. If this script overwrote these it would
 # reintroduce, on demand, exactly the clobbering the loader refuses to do.
-@pytest.mark.parametrize(
-    ("field", "db_value", "file_value"),
-    [
-        ("sleeps", 9, 4),
-        ("map_x", 0.9, 0.5),
-        ("is_confirmed", True, False),
-    ],
-)
-def test_staff_owned_fields_are_never_updated(field: str, db_value: object, file_value: object) -> None:
+# Parametrised off STAFF_OWNED itself, not a hand-copied subset: a field added
+# to the constant is covered here the moment it is added.
+@pytest.mark.parametrize("field", apply_inv.STAFF_OWNED)
+@pytest.mark.parametrize("structural", [False, True])
+def test_staff_owned_fields_are_never_updated(field: str, structural: bool) -> None:
+    db_value, file_value = _STAFF_OWNED_VALUES[field]
     want = [_unit("a", **{field: file_value})]
     have = {"a": _unit("a", **{field: db_value})}
 
-    assert apply_inv.plan_updates(want, have).updates == []
+    plan = apply_inv.plan_updates(want, have, include_structural=structural)
+
+    assert plan.updates == []
+    assert plan.structural == []
+
+
+def test_the_writable_classes_never_overlap_the_staff_owned_ones() -> None:
+    """STAFF_OWNED is only a comment unless something enforces it. The allow
+    lists are enumerated by hand, so the failure mode is a future column being
+    added to the wrong tuple — which no behavioural test would catch, because
+    the field would simply start being written and nothing would object."""
+    writable = set(apply_inv.INVENTORY_FIELDS) | set(apply_inv.STRUCTURAL_FIELDS)
+
+    assert writable.isdisjoint(apply_inv.STAFF_OWNED)
 
 
 def test_structural_differences_are_reported_but_not_applied() -> None:

--- a/tests/setup/test_apply_lodging_inventory.py
+++ b/tests/setup/test_apply_lodging_inventory.py
@@ -1,0 +1,176 @@
+"""Tests for scripts/dev/apply_lodging_inventory.py.
+
+The boot loader is CREATE-IF-ABSENT, so it never touches a row that already
+exists. That is deliberate — the registry is staff-editable and a full upsert
+would undo confirmations and corrected coordinates on the next restart. The
+consequence is that new columns land empty on every existing row, and something
+else has to carry the inventory onto them. This script is that something, and
+these tests pin what it is allowed to touch.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "dev" / "apply_lodging_inventory.py"
+_spec = importlib.util.spec_from_file_location("apply_lodging_inventory", _SCRIPT)
+assert _spec is not None
+assert _spec.loader is not None
+apply_inv = importlib.util.module_from_spec(_spec)
+# Registered before exec: @dataclass resolves annotations via
+# sys.modules[cls.__module__], which is None for a module loaded straight from a
+# spec, and the failure surfaces as an AttributeError during collection.
+sys.modules[_spec.name] = apply_inv
+_spec.loader.exec_module(apply_inv)
+
+
+def _unit(code: str, **over: object) -> dict:
+    base = {
+        "code": code,
+        "name": code,
+        "has_power": False,
+        "has_heat": False,
+        "max_beds": None,
+        "has_ramp": "",
+        "bathroom": "none",
+        "bathroom_group": "",
+        "is_container": False,
+        "sleeps": None,
+        "map_x": 0.5,
+        "map_y": 0.5,
+        "notes": "",
+        "parent_unit": "",
+    }
+    base.update(over)
+    return base
+
+
+def test_plans_an_update_for_a_changed_amenity() -> None:
+    want = [_unit("a", has_power=True, max_beds=4)]
+    have = {"a": _unit("a")}
+
+    plan = apply_inv.plan_updates(want, have)
+
+    assert len(plan.updates) == 1
+    assert plan.updates[0].code == "a"
+    assert plan.updates[0].fields == {"has_power": True, "max_beds": 4}
+
+
+def test_plans_nothing_when_the_database_already_matches() -> None:
+    want = [_unit("a", has_power=True, max_beds=4)]
+    have = {"a": _unit("a", has_power=True, max_beds=4)}
+
+    assert apply_inv.plan_updates(want, have).updates == []
+
+
+def test_a_unit_missing_from_the_database_is_left_to_the_boot_loader() -> None:
+    """Creating rows is the loader's job. A script that also created them would
+    be a second writer with different rules for the same table."""
+    want = [_unit("brand-new", has_power=True)]
+
+    plan = apply_inv.plan_updates(want, {})
+
+    assert plan.updates == []
+    assert plan.absent == ["brand-new"]
+
+
+# The whole point of create-if-absent. If this script overwrote these it would
+# reintroduce, on demand, exactly the clobbering the loader refuses to do.
+@pytest.mark.parametrize(
+    ("field", "db_value", "file_value"),
+    [
+        ("sleeps", 9, 4),
+        ("map_x", 0.9, 0.5),
+        ("is_confirmed", True, False),
+    ],
+)
+def test_staff_owned_fields_are_never_updated(field: str, db_value: object, file_value: object) -> None:
+    want = [_unit("a", **{field: file_value})]
+    have = {"a": _unit("a", **{field: db_value})}
+
+    assert apply_inv.plan_updates(want, have).updates == []
+
+
+def test_structural_differences_are_reported_but_not_applied() -> None:
+    """A changed bathroom or container flag is a real correction, but it is not
+    an empty column being filled in — it overwrites a value someone may have set
+    deliberately. Reported for a human, applied only on an explicit opt-in."""
+    want = [_unit("a", bathroom="private", bathroom_group="", is_container=True)]
+    have = {"a": _unit("a", bathroom="shared", bathroom_group="hall", is_container=False)}
+
+    plan = apply_inv.plan_updates(want, have)
+
+    assert plan.updates == []
+    assert len(plan.structural) == 1
+    assert plan.structural[0].code == "a"
+    assert plan.structural[0].fields == {
+        "bathroom": "private",
+        "bathroom_group": "",
+        "is_container": True,
+    }
+
+
+def test_structural_differences_become_updates_when_opted_in() -> None:
+    want = [_unit("a", bathroom="private")]
+    have = {"a": _unit("a", bathroom="shared")}
+
+    plan = apply_inv.plan_updates(want, have, include_structural=True)
+
+    assert plan.structural == []
+    assert plan.updates[0].fields == {"bathroom": "private"}
+
+
+def test_notes_are_filled_only_when_the_database_has_none() -> None:
+    """Notes are free text a staff member may have written. Filling an empty one
+    from the sheet adds information; overwriting a written one destroys it."""
+    want = [_unit("a", notes="from the sheet"), _unit("b", notes="from the sheet")]
+    have = {"a": _unit("a", notes=""), "b": _unit("b", notes="staff wrote this")}
+
+    plan = apply_inv.plan_updates(want, have)
+    by_code = {u.code: u.fields for u in plan.updates}
+
+    assert by_code["a"] == {"notes": "from the sheet"}
+    assert "b" not in by_code
+
+
+def test_parent_unit_is_compared_as_a_code_not_a_record_id() -> None:
+    """PocketBase stores parent_unit as a RELATION — a record id — while the
+    registry file stores a unit code. Comparing them raw makes every parented
+    unit look like it needs changing, and applying that would write a code into
+    a relation field."""
+    records = {
+        "child": {"id": "rec_child", "code": "child", "parent_unit": "rec_parent"},
+        "parent": {"id": "rec_parent", "code": "parent", "parent_unit": ""},
+    }
+
+    normalised = apply_inv.normalise_parents(records)
+
+    assert normalised["child"]["parent_unit"] == "parent"
+    assert normalised["parent"]["parent_unit"] == ""
+
+
+def test_an_already_correct_parent_produces_no_change() -> None:
+    records = apply_inv.normalise_parents(
+        {
+            "child": _unit("child", id="rec_child", parent_unit="rec_parent"),
+            "parent": _unit("parent", id="rec_parent", parent_unit=""),
+        }
+    )
+    want = [_unit("child", parent_unit="parent")]
+
+    plan = apply_inv.plan_updates(want, records, include_structural=True)
+
+    assert plan.updates == []
+
+
+def test_an_unassessed_ramp_never_overwrites_an_assessed_one() -> None:
+    """Empty has_ramp means NOT ASSESSED. Writing it over a real answer would
+    erase an assessment and disguise it as one that never happened."""
+    want = [_unit("a", has_ramp="")]
+    have = {"a": _unit("a", has_ramp="yes")}
+
+    assert apply_inv.plan_updates(want, have).updates == []

--- a/tests/setup/test_apply_lodging_inventory.py
+++ b/tests/setup/test_apply_lodging_inventory.py
@@ -175,3 +175,41 @@ def test_an_unassessed_ramp_never_overwrites_an_assessed_one() -> None:
     have = {"a": _unit("a", has_ramp="yes")}
 
     assert apply_inv.plan_updates(want, have).updates == []
+
+
+def test_a_null_max_beds_never_downgrades_a_known_value() -> None:
+    """max_beds carries the same null-means-unknown contract as sleeps and
+    has_ramp. Writing null over a real number replaces knowledge with a
+    placeholder, and PocketBase stores it as 0 — which every consumer reads as
+    "unknown", so the loss is silent."""
+    want = [_unit("a", max_beds=None)]
+    have = {"a": _unit("a", max_beds=14)}
+
+    assert apply_inv.plan_updates(want, have).updates == []
+
+
+def test_a_known_max_beds_still_updates() -> None:
+    want = [_unit("a", max_beds=14)]
+    have = {"a": _unit("a", max_beds=None)}
+
+    assert apply_inv.plan_updates(want, have).updates[0].fields == {"max_beds": 14}
+
+
+def test_an_unresolvable_parent_code_is_an_error_not_a_silent_detach() -> None:
+    """Under --structural a parent code that names nothing would otherwise fall
+    back to "", detaching the child from its container with no error — the
+    opposite of what every other guard in this script does."""
+    with pytest.raises(KeyError, match="ghost"):
+        apply_inv.resolve_parent_id({"parent_unit": "ghost"}, {"real": "rec_real"})
+
+
+def test_a_resolvable_parent_code_becomes_a_record_id() -> None:
+    out = apply_inv.resolve_parent_id({"parent_unit": "real"}, {"real": "rec_real"})
+    assert out["parent_unit"] == "rec_real"
+
+
+def test_clearing_a_parent_deliberately_is_still_allowed() -> None:
+    """An empty code means "no parent", which is a legitimate value — only an
+    unresolvable non-empty code is an error."""
+    out = apply_inv.resolve_parent_id({"parent_unit": ""}, {"real": "rec_real"})
+    assert out["parent_unit"] == ""

--- a/tests/setup/test_apply_lodging_inventory.py
+++ b/tests/setup/test_apply_lodging_inventory.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -28,8 +29,8 @@ sys.modules[_spec.name] = apply_inv
 _spec.loader.exec_module(apply_inv)
 
 
-def _unit(code: str, **over: object) -> dict:
-    base = {
+def _unit(code: str, **over: object) -> dict[str, Any]:
+    base: dict[str, Any] = {
         "code": code,
         "name": code,
         "has_power": False,

--- a/tests/setup/test_confirm_lodging_units.py
+++ b/tests/setup/test_confirm_lodging_units.py
@@ -1,0 +1,57 @@
+"""Tests for scripts/dev/confirm_lodging_units.py.
+
+The only thing worth pinning here is the guard. `is_confirmed` asserts that a
+human has checked a specific cabin; setting it in bulk on a real database tells
+staff that 93 cabins were verified when none were, and the roster's fit check
+would then judge housing needs against amenity columns nobody filled in.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "dev" / "confirm_lodging_units.py"
+_spec = importlib.util.spec_from_file_location("confirm_lodging_units", _SCRIPT)
+assert _spec is not None
+assert _spec.loader is not None
+confirm = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = confirm
+_spec.loader.exec_module(confirm)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:8090",
+        "http://localhost:8090",
+        "http://127.0.0.1:8468",
+    ],
+)
+def test_loopback_urls_are_local(url: str) -> None:
+    assert confirm.is_local(url) is True
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://camp.example.org",
+        "http://192.168.1.50:8090",
+        "http://pocketbase.internal:8090",
+    ],
+)
+def test_everything_else_is_not_local(url: str) -> None:
+    assert confirm.is_local(url) is False
+
+
+def test_a_remote_url_is_refused_without_the_explicit_flag() -> None:
+    rc = confirm.main(["--url", "https://camp.example.org", "--apply", "--password", "x"])
+    assert rc == 2
+
+
+def test_a_missing_password_is_refused_rather_than_prompting() -> None:
+    rc = confirm.main(["--url", "http://127.0.0.1:8090", "--password", ""])
+    assert rc == 2


### PR DESCRIPTION
Follows #1910 (registry privatised). Second acceptance item on #1909 is already ticked; this is the inventory that motivated the move.

## What lands

**Migration `1500000131`** — ten amenity columns, schema only, no values. The registry is private data, so nothing camp-specific may live in a tracked migration.

**The data lives in `kindred-local`**, not this repo: 21 new units, 2 new areas, amenities on all 99 sheet units, 41 new aliases, plus the `hc-upstairs-2` bathroom fix and `gt-le-shack` promoted to a container. The kindred-side change is the migration, the loader, and two scripts.

Registry totals go 93 → **114 units**, 8 → **10 areas**, 100 → **141 aliases**.

## Why the loader alone isn't enough

The boot loader is create-if-absent, so it creates the 21 new units but **a new column lands empty on every row that already exists**. `scripts/dev/apply_lodging_inventory.py` closes that gap — dry-run by default, and it splits fields by how much damage writing them could do:

| Class | Behaviour |
|---|---|
| Amenities, `max_beds` | filled freely — they were empty |
| `bathroom`, `bathroom_group`, `is_container`, `parent_unit` | reported; written only under `--structural` |
| `sleeps`, coordinates, `is_confirmed`, `is_active`, `allocation_default` | **never written**, under any flag |

`scripts/dev/confirm_lodging_units.py` lights up the fit check locally and refuses a non-loopback URL unless explicitly overridden — bulk confirmation on real data asserts that every cabin was checked when none was.

## Five defects found while building this, each with its evidence

**The matcher pointed four leaf rooms at their container.** Two room pairs both resolved to their *building* row, which is never bookable. Unfixed, each pair's amenities would have landed on the building, the second row would have silently overwritten the first, and the four real rooms would have stayed empty. Found because the amenity counts came up short.

**Two units treated as one were not the same room.** One has bare `W` and no bathroom, the other `WEPH` and a private shower. They are now distinct, and the alias that conflated them points at the new unit.

**`has_living_room` read `"No"` as true.** The column holds `X`, explicit `"No"`, and furniture descriptions, so `bool(non-empty)` recorded a living room for the two units that say they have none. All seven flag-ish columns were audited for the same trap; the rest were sound.

**Three legacy codes would have misrouted historical placements.** Old side-of-camp codes appear in both unit names and notes and *disagree* for several units, with three codes each claimed by two different rooms. An alias from either source alone would have pointed old data at the wrong room with nothing to surface it. A code now earns an alias only when every mention of it agrees; 18 kept, 3 rejected.

**`parent_unit` was compared as a relation id against a code.** Every parented unit read as needing a change, and `--structural` would have written a code into a relation field. Only visible by running the dry run against real data, where it produced eight false positives; the same run now reports exactly the two genuine corrections.

## Verification

- All ten amenity counts reconcile **exactly** to the spec's measurements once the two excluded grounds-crew rows are subtracted (both carry all four utilities, which is why every count looked short by two).
- Sheet reconciliation is exact: 103 parsed rows − 2 summary rows − 2 excluded = **99 units**, split 78 amended / 21 created.
- `verify-lodging-seed.sh` boots a throwaway DB and matches it field-by-field against the private file. Schema and hardcoded-lodging guards green.
- The loader run against a real existing database reported `areas_added=2 units_added=21 aliases_added=41`, then nothing on a second run.
- 24 new Python tests; `tests/setup/` green. Go, golangci-lint, ruff, mypy, shellcheck, markdownlint all green.
- Camp-name count holds at **46** — no regression on #1909.

## Notes for review

- The 21 new units' coordinates are **map-read estimates**, ±0.01 against two seeded controls. Good enough for area grouping; the pin editor is the tool for refining them.
- `has_ramp` is a select (`yes`/`no`/`partial`, empty = not assessed), not a bool — a bool asserts "no ramp" about every cabin nobody looked at.
- One unit is seeded active with a teardown note, per the owner. Deactivate rather than delete when it goes; it has alias resolution hanging off it.
- A staff name in the sheet's free text was scrubbed. All 37 notes were read by hand rather than trusted to a regex, after an initial-form pattern missed a full surname.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Lodging records now include amenity details, accessibility ramp status, and maximum bed capacity.
  - Added a dry-run inventory synchronization tool with optional updates and structural corrections.
  - Inventory comparisons now identify changes to amenities, accessibility, capacity, notes, and relationships.
  - Added a local development tool to confirm or undo lodging-unit confirmation status.

- **Documentation**
  - Added guides explaining lodging inventory fields, data interpretation, and synchronization behavior.

- **Tests**
  - Expanded coverage for inventory updates, data preservation, schema validation, and confirmation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review pass (scan-it)

Three CodeRabbit findings were real and are fixed in `f04c8b9`. A further review pass found five more, fixed in `562816f`, plus one data defect fixed in the private registry.

**The data defect.** One building has a single sheet row covering the whole building — the row even enumerates its own rooms. The row matched the building correctly, but the building is a container, and the four **bookable** rooms underneath it carried no amenity data at all. Nothing resolves amenities up the parent chain and the fit check judges non-container units, so those four rooms would have stayed exactly as blind as before this inventory. The amenity-count reconciliation structurally cannot detect this: the row is counted once whichever unit it sits on. The ten building-level services are now propagated to the four rooms. `max_beds` deliberately stays on the container alone — HANDOFF forbids summing capacity over `is_container` rows because they hold whole-building aggregates, and copying it down would invent beds.

**The rest.** `STAFF_OWNED` was declared but never referenced, and its test hand-listed three of six fields — the never-write guarantee had no tripwire. Now parametrised off the constant across both `--structural` settings, with a disjointness assertion for the failure the behavioural tests cannot catch. HANDOFF's migration ceiling still said `1500000130`. The confirm script claimed 93 cabins in the refusal message it prints to the operator, understating its blast radius by 21. Two doc gaps.

**Verified independently rather than taken on trust:** all ten amenity counts reconcile exactly to the sheet's measurements once the two excluded grounds-crew rows are subtracted; the `has_ramp` split matches; the earlier container mismapping fix holds (that building is now the only container carrying sheet data, and it is the intended whole-building row); the 18 kept legacy codes reconcile; referential integrity is clean — no duplicate codes, no duplicate alias strings, no alias pointing at a missing unit, no unit parented to a non-container. The one unit flagged as having lost its alias in fact still has one, and **no** non-container unit in the registry lacks an alias.

**Rollout is not automatic.** Merging this does not put the data in production — see #1917 for the ordered sequence.
