### PR TITLE
feat(sync,api,frontend): flag the lodging board on share eligibility, not the registration gate

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -53,6 +53,25 @@ SharePreference = Literal["no_share", "maybe_mutual", "yes_share", "unknown"]
 # with each other.
 ProximityKind = Literal["near", "with", "similar_ages"]
 
+# The RESOLVED verdict the board places on, from
+# family_camp_registrations.share_eligibility. Not the same question as
+# SharePreference above: that is the registration answer alone, while this
+# resolves it against the later Family Camp information form, which staff treat
+# as authoritative.
+#
+#   open     -- staff may match with any other open party
+#   named    -- only with the partner the household named, if mutual
+#   declined -- answered, and the answer was no
+#   unknown  -- silent on BOTH forms; places as no-share, but is a different
+#               fact from declining and must never be rendered as one
+ShareEligibility = Literal["open", "named", "declined", "unknown"]
+
+# Which form produced the eligibility above. "registration" means the
+# authoritative form's share question was unanswered and the verdict fell back
+# to the registration gate, so it is PROVISIONAL -- the surface should be able
+# to say so rather than presenting a fallback as settled.
+ShareEligibilitySource = Literal["form", "registration", "none"]
+
 PartyGrain = Literal["household", "person"]
 EffectiveBathroom = Literal["unknown", "none", "private", "shared"]
 
@@ -144,6 +163,16 @@ class ShareRequestSummary(BaseModel):
     # True when there is request text but no resolution of the named families to
     # households. Always true in slice 1 when text is present.
     needs_resolution: bool = False
+
+    # What the board actually places on. `preference` above stays the raw
+    # registration answer because it is what a staff member sees when asked why
+    # a household is flagged; this is the resolved verdict, and where the two
+    # forms disagree the later one wins.
+    eligibility: ShareEligibility = "unknown"
+    eligibility_source: ShareEligibilitySource = "none"
+    # The two forms point opposite ways -- a staff-review signal, not a
+    # placement rule. Measured at 7.5% of form answerers for 2026.
+    answers_conflict: bool = False
 
 
 class AccessibilityFlagSummary(BaseModel):

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -25,6 +25,8 @@ from api.schemas.lodging import (
     ProximityKind,
     RosterCounts,
     RosterParty,
+    ShareEligibility,
+    ShareEligibilitySource,
     SharePreference,
     ShareRequestSummary,
     WeekendRosterResponse,
@@ -49,6 +51,11 @@ logger = get_logger(__name__)
 # An empty column means nobody answered; it renders as "unknown" and is never
 # coerced into permission to pair.
 _GATE_VALUES: frozenset[str] = frozenset({"no_share", "maybe_mutual", "yes_share"})
+# "unknown" / "none" are deliberately absent: they are what an unrecognised or
+# empty column FALLS BACK to, so accepting them here would be redundant and
+# would hide a value drifting out of the migration's select list.
+_ELIGIBILITY_VALUES: frozenset[str] = frozenset({"open", "named", "declined"})
+_ELIGIBILITY_SOURCE_VALUES: frozenset[str] = frozenset({"form", "registration"})
 
 
 class SessionNotFoundError(LookupError):
@@ -632,6 +639,24 @@ class LodgingRosterService:
             proximity.append("similar_ages")
 
         request_text = _s(registration, "request_text")
+
+        # Read, never re-derived. The two share questions are resolved once, in
+        # the Go ingest, for the same reason `preference` is: doing it here
+        # would fork a rule that has already been wrong twice. An unpopulated
+        # column falls to "unknown"/"none", which places as no-share -- the
+        # safe direction, and the honest one on a database whose
+        # family_camp_derived has not re-run.
+        raw_eligibility = _s(registration, "share_eligibility")
+        eligibility = cast(
+            ShareEligibility,
+            raw_eligibility if raw_eligibility in _ELIGIBILITY_VALUES else "unknown",
+        )
+        raw_source = _s(registration, "share_eligibility_source")
+        eligibility_source = cast(
+            ShareEligibilitySource,
+            raw_source if raw_source in _ELIGIBILITY_SOURCE_VALUES else "none",
+        )
+
         return ShareRequestSummary(
             preference=preference,
             preference_raw=_s(registration, "share_cabin_preference"),
@@ -639,6 +664,9 @@ class LodgingRosterService:
             request_text=request_text,
             # Slice 1 resolves no names, so any free text is outstanding work.
             needs_resolution=bool(request_text),
+            eligibility=eligibility,
+            eligibility_source=eligibility_source,
+            answers_conflict=_b(registration, "share_answers_conflict"),
         )
 
     def _build_flags(self, registration: Any, medical_record: Any) -> AccessibilityFlagSummary:

--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -150,7 +150,9 @@ describe('FamilyCard — what it shows', () => {
     expect(screen.getByText('No power')).toBeInTheDocument()
   })
 
-  it('marks the party that declined sharing when it is in a flagged slot', () => {
+  it('marks the party that did not request sharing when it is in a flagged slot', () => {
+    // Keyed off the RESOLVED verdict, not the registration gate: the gate is
+    // superseded wherever the Family Camp form answered.
     render(
       <FamilyCard
         party={party({
@@ -159,13 +161,16 @@ describe('FamilyCard — what it shows', () => {
             proximity: [],
             request_text: '',
             needs_resolution: false,
+            eligibility: 'declined',
+            eligibility_source: 'form',
+            answers_conflict: false,
           },
         })}
         sharedSlot={true}
         onOpen={vi.fn()}
       />
     )
-    expect(screen.getByText('Declined sharing')).toBeInTheDocument()
+    expect(screen.getByText('Did not request sharing')).toBeInTheDocument()
   })
 
   it('does not call a party out for declining when it has the room to itself', () => {

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -141,9 +141,18 @@ export function FamilyCard({
           <Chip label={ATTENTION_LABEL.unverified} tone="quiet" />
         )}
 
-        {sharedSlot && party.share?.preference === 'no_share' && (
-          <Chip label="Declined sharing" tone="warn" />
+        {/* Keyed off the RESOLVED verdict, not the registration gate. The gate
+            is superseded wherever the Family Camp form answered, so a household
+            that said no at registration and then named a partner is legitimately
+            placed — chipping it "declined" repeats at card level exactly the
+            false positive the slot flag was moved off the gate to avoid.
+            Wording matches the slot: the form has no refusal option. */}
+        {sharedSlot && party.share?.eligibility === 'declined' && (
+          <Chip label="Did not request sharing" tone="warn" />
         )}
+        {/* 16 households for 2026 carry disagreeing answers. Shown on the card
+            as well as the slot, so a party sitting alone still surfaces one. */}
+        {party.share?.answers_conflict === true && <Chip label="Answers disagree" tone="warn" />}
         {wantsToShare && <Chip label="Wants to share" tone="share" />}
         {/* NEAR and WITH are different requests: NEAR is satisfied by map
             distance between units, WITH by putting both in one room. */}

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -30,6 +30,7 @@ import { Repeat, Users } from 'lucide-react'
 import { Fragment } from 'react'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import { SHARE_WORDING, shareWordingChip } from './boardLayout'
 import { ATTENTION_LABEL, partyAttention } from './rosterAttention'
 
 export interface FamilyCardProps {
@@ -148,11 +149,13 @@ export function FamilyCard({
             false positive the slot flag was moved off the gate to avoid.
             Wording matches the slot: the form has no refusal option. */}
         {sharedSlot && party.share?.eligibility === 'declined' && (
-          <Chip label="Did not request sharing" tone="warn" />
+          <Chip label={shareWordingChip(SHARE_WORDING.declined)} tone="warn" />
         )}
         {/* 16 households for 2026 carry disagreeing answers. Shown on the card
             as well as the slot, so a party sitting alone still surfaces one. */}
-        {party.share?.answers_conflict === true && <Chip label="Answers disagree" tone="warn" />}
+        {party.share?.answers_conflict === true && (
+          <Chip label={shareWordingChip(SHARE_WORDING.conflict)} tone="warn" />
+        )}
         {wantsToShare && <Chip label="Wants to share" tone="share" />}
         {/* NEAR and WITH are different requests: NEAR is satisfied by map
             distance between units, WITH by putting both in one room. */}

--- a/frontend/src/components/weekend/LodgingBoard.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.test.tsx
@@ -216,7 +216,7 @@ describe('LodgingBoard — the consent flag', () => {
     // Exact text, not a regex: FamilyCard also renders a "Declined sharing"
     // chip for the party itself, and a loose match cannot tell the slot's
     // flag from the card's chip.
-    expect(screen.getByText('1 family declined sharing')).toBeInTheDocument()
+    expect(screen.getByText('1 family did not request sharing')).toBeInTheDocument()
   })
 
   it('summarises the flag count at the top of the board', () => {

--- a/frontend/src/components/weekend/LodgingBoard.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.test.tsx
@@ -183,6 +183,9 @@ describe('LodgingBoard — the consent flag', () => {
               proximity: [],
               request_text: '',
               needs_resolution: false,
+              eligibility: 'declined',
+              eligibility_source: 'form',
+              answers_conflict: false,
             },
           }),
           party({
@@ -195,6 +198,9 @@ describe('LodgingBoard — the consent flag', () => {
               proximity: ['with'],
               request_text: '',
               needs_resolution: false,
+              eligibility: 'open',
+              eligibility_source: 'form',
+              answers_conflict: false,
             },
           }),
         ]}
@@ -207,7 +213,10 @@ describe('LodgingBoard — the consent flag', () => {
 
   it('surfaces the one real sharing conflict on the slot', () => {
     sharedBoard()
-    expect(screen.getByText(/said no to sharing/i)).toBeInTheDocument()
+    // Exact text, not a regex: FamilyCard also renders a "Declined sharing"
+    // chip for the party itself, and a loose match cannot tell the slot's
+    // flag from the card's chip.
+    expect(screen.getByText('1 family declined sharing')).toBeInTheDocument()
   })
 
   it('summarises the flag count at the top of the board', () => {

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -122,14 +122,15 @@ describe('LodgingUnitCard', () => {
           consent: {
             declinedCount: 1,
             unansweredCount: 0,
-            reason: '1 family declined sharing',
+            conflictCount: 0,
+            reason: '1 family did not request sharing',
           },
         })}
         hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
-    expect(screen.getByText('1 family declined sharing')).toBeInTheDocument()
+    expect(screen.getByText('1 family did not request sharing')).toBeInTheDocument()
   })
 
   it('badges a staff hold rather than hiding the room', () => {

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -114,18 +114,22 @@ describe('LodgingUnitCard', () => {
     expect(screen.getByText('2 families')).toBeInTheDocument()
   })
 
-  it('flags a shared unit where a family said no', () => {
+  it('flags a shared unit where a family declined', () => {
     render(
       <LodgingUnitCard
         slot={slot({
           parties: [party(), party({ household_cm_id: 102, display_name: 'Garcia' })],
-          consent: { declinedCount: 1, reason: '1 family said no to sharing' },
+          consent: {
+            declinedCount: 1,
+            unansweredCount: 0,
+            reason: '1 family declined sharing',
+          },
         })}
         hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
-    expect(screen.getByText('1 family said no to sharing')).toBeInTheDocument()
+    expect(screen.getByText('1 family declined sharing')).toBeInTheDocument()
   })
 
   it('badges a staff hold rather than hiding the room', () => {

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -224,7 +224,11 @@ describe('buildBoard — the unplaced rail ranks on the one signal it has', () =
 
 describe('buildBoard — consent flagging on ELIGIBILITY, not the gate', () => {
   /** A shared unit whose parties carry the given resolved eligibilities. */
-  function shared(values: ShareEligibilityValue[], gate: SharePreferenceValue = 'unknown') {
+  function shared(
+    values: ShareEligibilityValue[],
+    gate: SharePreferenceValue = 'unknown',
+    conflicts: boolean[] = []
+  ) {
     return buildBoard(
       values.map((eligibility, index) =>
         party({
@@ -239,7 +243,7 @@ describe('buildBoard — consent flagging on ELIGIBILITY, not the gate', () => {
             needs_resolution: false,
             eligibility,
             eligibility_source: 'form',
-            answers_conflict: false,
+            answers_conflict: conflicts[index] ?? false,
           },
         })
       ),
@@ -266,13 +270,66 @@ describe('buildBoard — consent flagging on ELIGIBILITY, not the gate', () => {
 
   it('flags an UNANSWERED party separately from one that declined', () => {
     // Same placement default, different fact and different staff action:
-    // chase the form vs respect the answer. Reporting "said no" about a family
+    // chase the form vs respect the answer. Reporting a refusal about a family
     // that answered nothing is a claim staff cannot defend to that family.
     const slot = shared(['unknown', 'open']).areas[0]?.slots[0]
     expect(slot?.consent).not.toBeNull()
     expect(slot?.consent?.unansweredCount).toBe(1)
     expect(slot?.consent?.declinedCount).toBe(0)
-    expect(slot?.consent?.reason).not.toContain('declined')
+    expect(slot?.consent?.reason).toMatch(/(hasn't|haven't) answered/)
+    expect(slot?.consent?.reason).not.toContain('request sharing')
+  })
+
+  it('never claims a family REFUSED, because the form has no refusal option', () => {
+    // The four live options are NEAR / "No requests" / WITH-named /
+    // WITH-similar. There is no "we do not want to share", so `declined` is
+    // always the ABSENCE of a WITH token -- and 106 of 165 form-declined
+    // households for 2026 had actually asked to be housed NEAR someone.
+    // Telling staff they "declined" is a claim those families did not make.
+    const reason = shared(['declined', 'open']).areas[0]?.slots[0]?.consent?.reason ?? ''
+    expect(reason).toContain('did not request sharing')
+    expect(reason).not.toMatch(/declined|said no|refused/i)
+  })
+
+  it('flags a recorded ANSWER CONFLICT, so the 16 households carrying one are visible', () => {
+    // The two forms point opposite ways. Not a placement rule -- a
+    // staff-review signal -- so it flags even when everyone is shareable.
+    const slot = shared(['named', 'named'], 'no_share', [true, false]).areas[0]?.slots[0]
+    expect(slot?.consent).not.toBeNull()
+    expect(slot?.consent?.conflictCount).toBe(1)
+    expect(slot?.consent?.declinedCount).toBe(0)
+    expect(slot?.consent?.reason).toContain('disagree')
+  })
+
+  it('does not flag a shared unit whose parties are all consenting and consistent', () => {
+    expect(shared(['open', 'named'], 'yes_share').areas[0]?.slots[0]?.consent).toBeNull()
+  })
+
+  it('does NOT judge an adult-weekend unit — there is no share question to judge', () => {
+    // Adult weekends have no share fields at all (partition ["Camper"], no
+    // Adult-Share field), and _build_person_parties attaches no share data. A
+    // null here means NOT CHECKED, not "nothing found".
+    const board = buildBoard(
+      [
+        party({
+          grain: 'person',
+          person_cm_id: 501,
+          household_cm_id: 0,
+          unit_code: 'cedar-1',
+          unit_name: 'Cedar 1',
+        }),
+        party({
+          grain: 'person',
+          person_cm_id: 502,
+          household_cm_id: 0,
+          unit_code: 'cedar-1',
+          unit_name: 'Cedar 1',
+        }),
+      ],
+      [unit()]
+    )
+    expect(board.areas[0]?.slots[0]?.consent).toBeNull()
+    expect(board.flaggedCount).toBe(0)
   })
 
   it('does not flag a party who declined and got a room to itself', () => {

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -7,7 +7,12 @@
  */
 import { describe, expect, it } from 'vitest'
 
-import type { LodgingUnitRow, RosterPartyRow, SharePreferenceValue } from '../../types/lodging'
+import type {
+  LodgingUnitRow,
+  RosterPartyRow,
+  ShareEligibilityValue,
+  SharePreferenceValue,
+} from '../../types/lodging'
 import { AREA_HUES, buildBoard, countBoardSlots } from './boardLayout'
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
@@ -217,53 +222,87 @@ describe('buildBoard — the unplaced rail ranks on the one signal it has', () =
   })
 })
 
-describe('buildBoard — consent flagging (spec §11)', () => {
-  function shared(gates: SharePreferenceValue[]) {
+describe('buildBoard — consent flagging on ELIGIBILITY, not the gate', () => {
+  /** A shared unit whose parties carry the given resolved eligibilities. */
+  function shared(values: ShareEligibilityValue[], gate: SharePreferenceValue = 'unknown') {
     return buildBoard(
-      gates.map((preference, index) =>
+      values.map((eligibility, index) =>
         party({
           household_cm_id: 200 + index,
           display_name: `H${String(index)}`,
           unit_code: 'cedar-1',
           unit_name: 'Cedar 1',
-          share: { preference, proximity: [], request_text: '', needs_resolution: false },
+          share: {
+            preference: gate,
+            proximity: [],
+            request_text: '',
+            needs_resolution: false,
+            eligibility,
+            eligibility_source: 'form',
+            answers_conflict: false,
+          },
         })
       ),
       [unit()]
     )
   }
 
-  it('flags a shared unit where one party said no', () => {
-    const slot = shared(['no_share', 'yes_share']).areas[0]?.slots[0]
+  it('flags a shared unit where one party declined', () => {
+    const slot = shared(['declined', 'open']).areas[0]?.slots[0]
     expect(slot?.consent).not.toBeNull()
     expect(slot?.consent?.declinedCount).toBe(1)
   })
 
-  it('does not flag two parties who both agreed', () => {
-    expect(shared(['maybe_mutual', 'yes_share']).areas[0]?.slots[0]?.consent).toBeNull()
+  it('does not flag two parties who are both open to a staff match', () => {
+    expect(shared(['open', 'open']).areas[0]?.slots[0]?.consent).toBeNull()
   })
 
-  it('does not flag a blank gate — that is deferred to C2, and C1 flags only on an explicit no', () => {
-    expect(shared(['unknown', 'yes_share']).areas[0]?.slots[0]?.consent).toBeNull()
+  it('does not flag two NAMED parties — mutuality is unverifiable, so the panel shows the names', () => {
+    // Resolving request names to households is spec §7.3 and unbuilt. Flagging
+    // every named pair would fire on the legitimate case, which is the majority
+    // of eligible households (35 of 41 for 2026).
+    expect(shared(['named', 'named']).areas[0]?.slots[0]?.consent).toBeNull()
   })
 
-  it('does not flag maybe + maybe — also deferred to C2', () => {
-    expect(shared(['maybe_mutual', 'maybe_mutual']).areas[0]?.slots[0]?.consent).toBeNull()
+  it('flags an UNANSWERED party separately from one that declined', () => {
+    // Same placement default, different fact and different staff action:
+    // chase the form vs respect the answer. Reporting "said no" about a family
+    // that answered nothing is a claim staff cannot defend to that family.
+    const slot = shared(['unknown', 'open']).areas[0]?.slots[0]
+    expect(slot?.consent).not.toBeNull()
+    expect(slot?.consent?.unansweredCount).toBe(1)
+    expect(slot?.consent?.declinedCount).toBe(0)
+    expect(slot?.consent?.reason).not.toContain('declined')
   })
 
-  it('does not flag a party who declined sharing and got a room to itself', () => {
-    // Declining is the normal answer. It only contradicts anything when
-    // somebody else is in the room.
-    expect(shared(['no_share']).areas[0]?.slots[0]?.consent).toBeNull()
+  it('does not flag a party who declined and got a room to itself', () => {
+    // Declining is the ordinary answer. It contradicts nothing until somebody
+    // else is in the room.
+    expect(shared(['declined']).areas[0]?.slots[0]?.consent).toBeNull()
   })
 
-  it('counts both when two parties in one room each said no', () => {
-    expect(shared(['no_share', 'no_share']).areas[0]?.slots[0]?.consent?.declinedCount).toBe(2)
+  it('counts both when two parties in one room each declined', () => {
+    expect(shared(['declined', 'declined']).areas[0]?.slots[0]?.consent?.declinedCount).toBe(2)
+  })
+
+  it('IGNORES the registration gate: a no_share gate resolved to named is legitimate', () => {
+    // 3 households for 2026 said no at registration and then named a partner
+    // on the authoritative form. The old gate-based rule flagged every one of
+    // them.
+    expect(shared(['named', 'named'], 'no_share').areas[0]?.slots[0]?.consent).toBeNull()
+  })
+
+  it('IGNORES the registration gate: a yes_share gate resolved to declined still flags', () => {
+    // The direction the old rule was blind to, and the larger one — 12
+    // households said yes at registration then declined on the form, plus 39
+    // more from maybe_mutual. The board read them as permissive.
+    const slot = shared(['declined', 'open'], 'yes_share').areas[0]?.slots[0]
+    expect(slot?.consent?.declinedCount).toBe(1)
   })
 
   it('reports how many slots are flagged across the whole board', () => {
-    expect(shared(['no_share', 'yes_share']).flaggedCount).toBe(1)
-    expect(shared(['yes_share', 'yes_share']).flaggedCount).toBe(0)
+    expect(shared(['declined', 'open']).flaggedCount).toBe(1)
+    expect(shared(['open', 'open']).flaggedCount).toBe(0)
   })
 })
 

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -19,7 +19,7 @@
  *    to nowhere. `buildBoard` is total: every input party comes out in exactly
  *    one of slots / unplaced / offBoard.
  */
-import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import type { LodgingUnitRow, RosterPartyRow, ShareEligibilityValue } from '../../types/lodging'
 
 /**
  * Area colour, §3.10 — a SECONDARY channel.
@@ -39,6 +39,31 @@ export const AREA_HUES = [
   'hsl(348 52% 55%)',
   'hsl(24 42% 46%)',
 ] as const
+
+/**
+ * Staff-facing wording for the share verdict, defined ONCE.
+ *
+ * These phrasings are load-bearing, not cosmetic. The Family Camp form has no
+ * refusal option, so `declined` is the absence of a share request rather than a
+ * recorded "no" — 106 of 165 form-declined households for 2026 had asked to be
+ * housed NEAR someone. Saying they "declined" puts a claim in a staff member's
+ * mouth that the family never made.
+ *
+ * The slot flag and the card chip render the same concepts, so they read from
+ * here rather than each holding their own literal: a correction applied to one
+ * copy and not the other is exactly how the wrong wording comes back.
+ */
+export const SHARE_WORDING = {
+  /** Sentence fragment: "N families <…>". */
+  declined: 'did not request sharing',
+  /** Sentence fragment: "N families' two <…>". */
+  conflict: 'answers disagree',
+} as const
+
+/** The same phrase as a standalone chip label. One source, two positions. */
+export function shareWordingChip(phrase: string): string {
+  return phrase.charAt(0).toUpperCase() + phrase.slice(1)
+}
 
 /** A shared unit holding somebody who did not consent to sharing it. */
 export interface ConsentFlag {
@@ -151,19 +176,29 @@ export function consentFlag(parties: RosterPartyRow[]): ConsentFlag | null {
     // Absent eligibility is UNKNOWN, never open. These columns are written by
     // family_camp_derived, so they are empty until it re-runs, and empty must
     // fall to the side that does not consent.
-    switch (party.share?.eligibility ?? 'unknown') {
+    const eligibility: ShareEligibilityValue = party.share?.eligibility ?? 'unknown'
+    switch (eligibility) {
       case 'declined':
         declinedCount += 1
         break
       case 'unknown':
         unansweredCount += 1
         break
-      default:
-        // `open` and `named` both consent to sharing. `named` is not verified
-        // mutual -- that needs request names resolved to households (spec
-        // §7.3, unbuilt) -- so the panel shows the names and staff judge.
-        // Flagging it would fire on the majority of eligible households.
+      case 'open':
+      case 'named':
+        // Both consent to sharing. `named` is not verified mutual — that needs
+        // request names resolved to households (spec §7.3, unbuilt) — so the
+        // panel shows the names and staff judge. Flagging it would fire on the
+        // majority of eligible households.
         break
+      default: {
+        // Exhaustiveness guard. An implicit default would route a NEW
+        // eligibility value into the consenting arm above — failing permissive,
+        // which is the exact direction this whole surface exists to close.
+        // A fifth value must break the build, not silently consent.
+        const unhandled: never = eligibility
+        throw new Error(`Unhandled share eligibility: ${String(unhandled)}`)
+      }
     }
   }
 
@@ -192,8 +227,8 @@ function consentReason(
   if (declinedCount > 0) {
     parts.push(
       declinedCount === 1
-        ? '1 family did not request sharing'
-        : `${String(declinedCount)} families did not request sharing`
+        ? `1 family ${SHARE_WORDING.declined}`
+        : `${String(declinedCount)} families ${SHARE_WORDING.declined}`
     )
   }
   if (unansweredCount > 0) {
@@ -206,8 +241,8 @@ function consentReason(
   if (conflictCount > 0) {
     parts.push(
       conflictCount === 1
-        ? "1 family's two answers disagree"
-        : `${String(conflictCount)} families' two answers disagree`
+        ? `1 family's two ${SHARE_WORDING.conflict}`
+        : `${String(conflictCount)} families' two ${SHARE_WORDING.conflict}`
     )
   }
   return parts.join(', ')

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -51,6 +51,12 @@ export interface ConsentFlag {
    * is a claim staff cannot defend to that household.
    */
   unansweredCount: number
+  /**
+   * Parties whose two forms point opposite ways. A staff-review signal, not a
+   * placement rule — it fires even when everyone in the slot is shareable,
+   * because the disagreement is the thing worth a human look.
+   */
+  conflictCount: number
   /** Ready to render beside the slot. Never PHI. */
   reason: string
 }
@@ -98,29 +104,34 @@ function areaName(unit: LodgingUnitRow): string {
 }
 
 /**
- * Consent flagging, spec §11.
+ * Consent flagging, on the resolved ELIGIBILITY rather than the registration
+ * gate.
  *
- * Fires on an EXPLICIT `no_share` only. Whether `maybe_mutual` + `maybe_mutual`
- * counts as mutual, and whether a blank gate (45 of 452 for 2026) counts as
- * consent, are deferred to C2 — neither occurs in placed data, so they change
- * nothing until staff drag a card.
+ * Share intent lives in two CampMinder fields asked at different times. Staff
+ * treat the later Family Camp information form as authoritative, and the Go
+ * ingest resolves the two into one verdict — see DeriveShareEligibility. This
+ * function reads that verdict and never re-derives it.
  *
- * Declining is the ordinary answer and contradicts nothing on its own; it only
- * becomes a defect when somebody else is in the room.
+ * WHY NOT THE GATE. `share_cabin_gate` is the registration answer alone, and
+ * flagging on it was wrong in both directions on 2026 data: 1 household said no
+ * at registration and then named a partner on the form (flagged, though
+ * legitimately placed), while 51 said yes-or-maybe and then declined on the
+ * form (silent, and read as permissive). The silent direction is ~17x the noisy
+ * one, which is why it moved.
  *
- * WHAT THE FLAG ACTUALLY MEANS, measured on 2026 rather than assumed. It fires
- * exactly once, on the unit spec §11 predicted. But §11 calls that case "a
- * family that said no is sharing with strangers", and that is FALSE: §11
- * checked surnames, billing addresses and phone numbers, and never read the two
- * request texts. Each household names the other by name, one of them marking it
- * "(priority)". The placement is mutual, reciprocated and deliberate.
+ * WORDING IS LOAD-BEARING. The form has no "we do not want to share" option —
+ * the four live choices are NEAR / "No requests" / WITH-named /
+ * WITH-similarly-aged — so `declined` is always the ABSENCE of a WITH token,
+ * never a recorded refusal. 106 of 165 form-declined households for 2026 had
+ * asked to be housed NEAR someone. Saying they "declined" would put a claim in
+ * a staff member's mouth that the family never made; "did not request sharing"
+ * is true of all of them.
  *
- * So this flags a household whose recorded GATE contradicts that household's
- * OWN request text — not a placement error. That is still worth surfacing, and
- * the flag's wording reports only the recorded answer for exactly that reason.
- * Resolving request names to households would let C2 suppress it, and that is
- * spec §7.3, unbuilt. Meanwhile the design already resolves it the honest way:
- * the card flags, and one click shows the request text that explains it.
+ * `named` does not flag. Mutuality needs request names resolved to households
+ * (spec §7.3, unbuilt), and `named` is most of the eligible pool, so flagging
+ * it would fire mostly on the legitimate case. The panel shows the names and
+ * staff judge — which is the resolution C1 already settled on after §11's
+ * own claim about the one flagged unit turned out to be false.
  */
 export function consentFlag(parties: RosterPartyRow[]): ConsentFlag | null {
   if (parties.length < 2) return null
@@ -134,7 +145,9 @@ export function consentFlag(parties: RosterPartyRow[]): ConsentFlag | null {
 
   let declinedCount = 0
   let unansweredCount = 0
+  let conflictCount = 0
   for (const party of parties) {
+    if (party.share?.answers_conflict === true) conflictCount += 1
     // Absent eligibility is UNKNOWN, never open. These columns are written by
     // family_camp_derived, so they are empty until it re-runs, and empty must
     // fall to the side that does not consent.
@@ -154,18 +167,33 @@ export function consentFlag(parties: RosterPartyRow[]): ConsentFlag | null {
     }
   }
 
-  if (declinedCount === 0 && unansweredCount === 0) return null
-  return { declinedCount, unansweredCount, reason: consentReason(declinedCount, unansweredCount) }
+  if (declinedCount === 0 && unansweredCount === 0 && conflictCount === 0) return null
+  return {
+    declinedCount,
+    unansweredCount,
+    conflictCount,
+    reason: consentReason(declinedCount, unansweredCount, conflictCount),
+  }
 }
 
-/** Wording for a consent flag. Reports only what was recorded. */
-function consentReason(declinedCount: number, unansweredCount: number): string {
+/**
+ * Wording for a consent flag. Reports only what was RECORDED.
+ *
+ * "did not request sharing" rather than "declined": the form has no refusal
+ * option, so this state is the absence of a share request, and most of the
+ * households in it asked to be housed near someone instead.
+ */
+function consentReason(
+  declinedCount: number,
+  unansweredCount: number,
+  conflictCount: number
+): string {
   const parts: string[] = []
   if (declinedCount > 0) {
     parts.push(
       declinedCount === 1
-        ? '1 family declined sharing'
-        : `${String(declinedCount)} families declined sharing`
+        ? '1 family did not request sharing'
+        : `${String(declinedCount)} families did not request sharing`
     )
   }
   if (unansweredCount > 0) {
@@ -173,6 +201,13 @@ function consentReason(declinedCount: number, unansweredCount: number): string {
       unansweredCount === 1
         ? "1 family hasn't answered the cabin form"
         : `${String(unansweredCount)} families haven't answered the cabin form`
+    )
+  }
+  if (conflictCount > 0) {
+    parts.push(
+      conflictCount === 1
+        ? "1 family's two answers disagree"
+        : `${String(conflictCount)} families' two answers disagree`
     )
   }
   return parts.join(', ')

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -40,10 +40,17 @@ export const AREA_HUES = [
   'hsl(24 42% 46%)',
 ] as const
 
-/** A shared unit where somebody's recorded answer contradicts the placement. */
+/** A shared unit holding somebody who did not consent to sharing it. */
 export interface ConsentFlag {
-  /** How many of the unit's parties answered an explicit `no_share`. */
+  /** Parties whose resolved answer declines sharing. */
   declinedCount: number
+  /**
+   * Parties silent on BOTH forms. Counted separately from `declinedCount`
+   * because the remedy differs — chase the form rather than move the family —
+   * and because reporting "declined" about a household that answered nothing
+   * is a claim staff cannot defend to that household.
+   */
+  unansweredCount: number
   /** Ready to render beside the slot. Never PHI. */
   reason: string
 }
@@ -117,15 +124,58 @@ function areaName(unit: LodgingUnitRow): string {
  */
 export function consentFlag(parties: RosterPartyRow[]): ConsentFlag | null {
   if (parties.length < 2) return null
-  const declinedCount = parties.filter((party) => party.share?.preference === 'no_share').length
-  if (declinedCount === 0) return null
-  return {
-    declinedCount,
-    reason:
-      declinedCount === 1
-        ? '1 family said no to sharing'
-        : `${String(declinedCount)} families said no to sharing`,
+
+  // Adult weekends have NO share question at all -- the fields are partition
+  // ["Camper"] and no Adult-Share field exists -- so a person-grain party
+  // carries no answer to judge. Returning null here is not "no problem found";
+  // it is "not checked", and the board says so rather than rendering a clean
+  // slot that was never examined.
+  if (parties.some((party) => party.grain === 'person')) return null
+
+  let declinedCount = 0
+  let unansweredCount = 0
+  for (const party of parties) {
+    // Absent eligibility is UNKNOWN, never open. These columns are written by
+    // family_camp_derived, so they are empty until it re-runs, and empty must
+    // fall to the side that does not consent.
+    switch (party.share?.eligibility ?? 'unknown') {
+      case 'declined':
+        declinedCount += 1
+        break
+      case 'unknown':
+        unansweredCount += 1
+        break
+      default:
+        // `open` and `named` both consent to sharing. `named` is not verified
+        // mutual -- that needs request names resolved to households (spec
+        // §7.3, unbuilt) -- so the panel shows the names and staff judge.
+        // Flagging it would fire on the majority of eligible households.
+        break
+    }
   }
+
+  if (declinedCount === 0 && unansweredCount === 0) return null
+  return { declinedCount, unansweredCount, reason: consentReason(declinedCount, unansweredCount) }
+}
+
+/** Wording for a consent flag. Reports only what was recorded. */
+function consentReason(declinedCount: number, unansweredCount: number): string {
+  const parts: string[] = []
+  if (declinedCount > 0) {
+    parts.push(
+      declinedCount === 1
+        ? '1 family declined sharing'
+        : `${String(declinedCount)} families declined sharing`
+    )
+  }
+  if (unansweredCount > 0) {
+    parts.push(
+      unansweredCount === 1
+        ? "1 family hasn't answered the cabin form"
+        : `${String(unansweredCount)} families haven't answered the cabin form`
+    )
+  }
+  return parts.join(', ')
 }
 
 /**

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -5545,6 +5545,18 @@ export type ShareRequestSummary = {
    * Needs Resolution
    */
   needs_resolution?: boolean
+  /**
+   * Eligibility
+   */
+  eligibility?: 'open' | 'named' | 'declined' | 'unknown'
+  /**
+   * Eligibility Source
+   */
+  eligibility_source?: 'form' | 'registration' | 'none'
+  /**
+   * Answers Conflict
+   */
+  answers_conflict?: boolean
 }
 
 /**

--- a/frontend/src/types/lodging.ts
+++ b/frontend/src/types/lodging.ts
@@ -84,6 +84,31 @@ export type SharePreferenceValue = NonNullable<ShareRequestSummary['preference']
  */
 export type ProximityKindValue = NonNullable<ShareRequestSummary['proximity']>[number]
 
+/**
+ * The RESOLVED verdict the board places on — not the same question as
+ * `SharePreferenceValue`, which is the registration answer alone.
+ *
+ * Share intent lives in two CampMinder fields asked at different times, and
+ * staff treat the later Family Camp information form as authoritative. The Go
+ * ingest resolves them; this is the result.
+ *
+ * `unknown` means silent on BOTH forms. It places as no-share, but it is a
+ * different fact from `declined` and must never be rendered as one — saying
+ * "this family said no" about a family that answered nothing is a statement
+ * staff cannot defend to that family.
+ */
+export type ShareEligibilityValue = NonNullable<ShareRequestSummary['eligibility']>
+
+/**
+ * Which form produced the eligibility.
+ *
+ * `registration` means the authoritative form's share question was unanswered
+ * and the verdict fell back to the registration gate, so it is PROVISIONAL.
+ * Roughly half of returned forms skip that question, so this is the common
+ * case, not an edge one.
+ */
+export type ShareEligibilitySourceValue = NonNullable<ShareRequestSummary['eligibility_source']>
+
 /** `unknown` means the amenity was never recorded, NOT "no bathroom". */
 export type BathroomValue = NonNullable<LodgingUnitSummary['bathroom']>
 

--- a/pocketbase/pb_migrations/1500000133_family_camp_share_eligibility.js
+++ b/pocketbase/pb_migrations/1500000133_family_camp_share_eligibility.js
@@ -1,0 +1,100 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: family_camp_registrations share eligibility
+ *
+ * Adds the verdict the lodging board places on, replacing a rule that read the
+ * WRONG FIELD.
+ *
+ * Share intent lives in TWO CampMinder fields, asked at different times:
+ *
+ *   FAM CAMP-Share Cabins  (240877, single-select)  registration, early
+ *   FAM CAMP-Shared Cabin  (263379, MULTI-select)   Family Camp info form, later
+ *
+ * Staff treat the later form as authoritative (stated 2026-08-02). The board
+ * was flagging on share_cabin_gate, which is derived from the REGISTRATION
+ * field alone -- NormalizeShareGate requires a leading no/maybe/yes token and
+ * none of the later form's option sentences have one, so that column is 100%
+ * registration and always has been.
+ *
+ * Measured on 2026 family-camp attendees, the old rule was wrong BOTH ways:
+ *
+ *   - 3 households said no at registration, then named a partner on the form.
+ *     Legitimately placed; the board flagged them.
+ *   - 12 said yes at registration then declined on the form, plus 39 more from
+ *     maybe_mutual. The board was SILENT and handed staff a clean card. This is
+ *     the dangerous direction and it is ~10x the first.
+ *
+ * WHY THREE COLUMNS RATHER THAN ONE
+ *
+ * share_eligibility is the verdict. share_eligibility_source records whether it
+ * came from the form or fell back to registration, because a fallback verdict
+ * is PROVISIONAL and the surface should say so. share_answers_conflict marks a
+ * hard contradiction between the two forms, which staff review -- it is not
+ * derivable downstream, because the raw modes column is deliberately not
+ * exposed to the API and re-parsing it in a consumer is what the one-writer
+ * rule exists to prevent.
+ *
+ * share_cabin_gate is UNCHANGED and stays. It is the registration answer, it is
+ * what a staff member sees when asked why a household is flagged, and it is the
+ * fallback input. Nothing that reads it needs to change.
+ *
+ * "unknown" is NOT a default of open, and it is a separate value from
+ * "declined" on purpose: they place identically and mean different things, so
+ * merging them would report "this family said no" about a family that answered
+ * nothing. partyAttention already draws this line between "unverified" and
+ * "unmet"; HANDOFF section 6 makes it a rule.
+ *
+ * These are SELECT fields, not text. The select list is the constraint -- a Go
+ * constant alone passes tests and fails in production (HANDOFF section 6).
+ *
+ * BACKFILL: none here, deliberately. These columns are written by
+ * family_camp_derived, which must be re-run per year to populate them. A
+ * migration cannot compute them: the inputs are person-partition custom values
+ * that need the collapse. Until the sync runs the columns are empty, and empty
+ * reads as "unknown" -- which is the safe direction, since unknown never
+ * consents.
+ *
+ * PocketBase v0.23 syntax: fields.add(new Field({...})) on an existing
+ * collection, properties DIRECT rather than inside options{}. A bare
+ * add({...}) silently does nothing. addField() is a no-op when the column
+ * exists, because PB records an applied migration by FILENAME -- a later edit
+ * to this file would never re-run, and `Set` on a missing column is a silent
+ * no-op that simply never persists.
+ */
+
+/**
+ * Adds a field unless the collection already has one by that name.
+ * @param {core.Collection} collection
+ * @param {core.Field} field
+ */
+function addField(collection, field) {
+  if (!collection.fields.getByName(field.name)) {
+    collection.fields.add(field);
+  }
+}
+
+migrate((app) => {
+  const regs = app.findCollectionByNameOrId("family_camp_registrations");
+
+  addField(regs, new Field({
+    type: "select", name: "share_eligibility", required: false, presentable: false,
+    values: ["open", "named", "declined", "unknown"], maxSelect: 1
+  }));
+
+  addField(regs, new Field({
+    type: "select", name: "share_eligibility_source", required: false, presentable: false,
+    values: ["form", "registration", "none"], maxSelect: 1
+  }));
+
+  addField(regs, new Field({
+    type: "bool", name: "share_answers_conflict", required: false, presentable: false
+  }));
+
+  app.save(regs);
+}, (app) => {
+  const regs = app.findCollectionByNameOrId("family_camp_registrations");
+  regs.fields.removeByName("share_eligibility");
+  regs.fields.removeByName("share_eligibility_source");
+  regs.fields.removeByName("share_answers_conflict");
+  app.save(regs);
+});

--- a/pocketbase/pb_migrations/1500000133_family_camp_share_eligibility.js
+++ b/pocketbase/pb_migrations/1500000133_family_camp_share_eligibility.js
@@ -22,7 +22,7 @@
  *     Legitimately placed; the board flagged them.
  *   - 12 said yes at registration then declined on the form, plus 39 more from
  *     maybe_mutual. The board was SILENT and handed staff a clean card. This is
- *     the dangerous direction and it is ~10x the first.
+ *     the dangerous direction and it is ~17x the first (51 against 3).
  *
  * WHY THREE COLUMNS RATHER THAN ONE
  *

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -119,6 +119,16 @@ type registrationData struct {
 	requestSourceField string
 	requestLastUpdated time.Time
 
+	// The RESOLVED share verdict the board places on, and its provenance.
+	// shareCabinGate above is the registration answer only; the Family Camp
+	// information form outranks it wherever both were answered, which is why
+	// these are separate columns rather than a reinterpretation of the gate.
+	// shareAnswersConflict marks the two forms pointing opposite ways -- a
+	// staff-review signal, not a placement rule. See DeriveShareEligibility.
+	shareEligibility       string
+	shareEligibilitySource string
+	shareAnswersConflict   bool
+
 	// Derived accessibility flags. Spec 5.3: the board shows a flag, never the
 	// narrative -- that lives in family_camp_medical.
 	needsPrivateBathroom     bool
@@ -876,6 +886,9 @@ func (s *FamilyCampDerivedSync) applyHouseholdRequests(
 		reg.requestText = req.RequestText
 		reg.requestSourceField = req.SourceField
 		reg.requestLastUpdated = req.LastUpdated
+		reg.shareEligibility = req.ShareEligibility
+		reg.shareEligibilitySource = req.ShareEligibilitySource
+		reg.shareAnswersConflict = req.ShareAnswersConflict
 	}
 }
 
@@ -1231,7 +1244,10 @@ func (s *FamilyCampDerivedSync) registrationNeedsUpdate(existing *core.Record, r
 		existing.GetBool("needs_private_bathroom") != reg.needsPrivateBathroom ||
 		existing.GetBool("needs_power") != reg.needsPower ||
 		existing.GetBool("accommodation_is_mandatory") != reg.accommodationIsMandatory ||
-		existing.GetBool("has_infant") != reg.hasInfant
+		existing.GetBool("has_infant") != reg.hasInfant ||
+		existing.GetString("share_eligibility") != reg.shareEligibility ||
+		existing.GetString("share_eligibility_source") != reg.shareEligibilitySource ||
+		existing.GetBool("share_answers_conflict") != reg.shareAnswersConflict
 }
 
 // setRegistrationRequestFields writes the household-grain request layer and the
@@ -1250,6 +1266,12 @@ func setRegistrationRequestFields(record *core.Record, reg *registrationData) {
 	record.Set("needs_power", reg.needsPower)
 	record.Set("accommodation_is_mandatory", reg.accommodationIsMandatory)
 	record.Set("has_infant", reg.hasInfant)
+	// The board's placement verdict. share_cabin_gate above stays the raw
+	// REGISTRATION answer; this is the resolved one, and the Family Camp
+	// information form outranks the gate wherever both were answered.
+	record.Set("share_eligibility", reg.shareEligibility)
+	record.Set("share_eligibility_source", reg.shareEligibilitySource)
+	record.Set("share_answers_conflict", reg.shareAnswersConflict)
 }
 
 // formatRequestStamp renders requestLastUpdated for the PocketBase date column.

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -1225,6 +1225,11 @@ func (s *FamilyCampDerivedSync) adultNeedsUpdate(existing *core.Record, adult *a
 
 // registrationNeedsUpdate checks if a registration record needs updating
 func (s *FamilyCampDerivedSync) registrationNeedsUpdate(existing *core.Record, reg *registrationData) bool {
+	// Compared in the same normalised form applyRegistrationFields WRITES, or
+	// every household with no request values would look changed on every pass:
+	// the struct holds "" while the row holds "unknown".
+	normalizedEligibility, normalizedSource := NormalizeShareEligibility(
+		reg.shareEligibility, reg.shareEligibilitySource)
 	return existing.GetString("cabin_assignment") != reg.cabinAssignment ||
 		existing.GetString("share_cabin_preference") != reg.shareCabinPreference ||
 		existing.GetString("shared_cabin_modes_raw") != reg.sharedCabinModesRaw ||
@@ -1245,8 +1250,8 @@ func (s *FamilyCampDerivedSync) registrationNeedsUpdate(existing *core.Record, r
 		existing.GetBool("needs_power") != reg.needsPower ||
 		existing.GetBool("accommodation_is_mandatory") != reg.accommodationIsMandatory ||
 		existing.GetBool("has_infant") != reg.hasInfant ||
-		existing.GetString("share_eligibility") != reg.shareEligibility ||
-		existing.GetString("share_eligibility_source") != reg.shareEligibilitySource ||
+		existing.GetString("share_eligibility") != normalizedEligibility ||
+		existing.GetString("share_eligibility_source") != normalizedSource ||
 		existing.GetBool("share_answers_conflict") != reg.shareAnswersConflict
 }
 
@@ -1269,8 +1274,14 @@ func setRegistrationRequestFields(record *core.Record, reg *registrationData) {
 	// The board's placement verdict. share_cabin_gate above stays the raw
 	// REGISTRATION answer; this is the resolved one, and the Family Camp
 	// information form outranks the gate wherever both were answered.
-	record.Set("share_eligibility", reg.shareEligibility)
-	record.Set("share_eligibility_source", reg.shareEligibilitySource)
+	//
+	// Normalised so the column has exactly ONE spelling per state: a household
+	// with no request values at all never reaches the collapse, and writing its
+	// zero value would store "" beside "unknown" for the same meaning.
+	eligibility, eligibilitySource := NormalizeShareEligibility(
+		reg.shareEligibility, reg.shareEligibilitySource)
+	record.Set("share_eligibility", eligibility)
+	record.Set("share_eligibility_source", eligibilitySource)
 	record.Set("share_answers_conflict", reg.shareAnswersConflict)
 }
 

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -1225,7 +1225,7 @@ func (s *FamilyCampDerivedSync) adultNeedsUpdate(existing *core.Record, adult *a
 
 // registrationNeedsUpdate checks if a registration record needs updating
 func (s *FamilyCampDerivedSync) registrationNeedsUpdate(existing *core.Record, reg *registrationData) bool {
-	// Compared in the same normalised form applyRegistrationFields WRITES, or
+	// Compared in the same normalised form setRegistrationRequestFields WRITES, or
 	// every household with no request values would look changed on every pass:
 	// the struct holds "" while the row holds "unknown".
 	normalizedEligibility, normalizedSource := NormalizeShareEligibility(

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -2033,3 +2033,41 @@ func TestProcessMedicalRoutesNarrativeToTheAdminGatedTable(t *testing.T) {
 		}
 	}
 }
+
+// TestRegistrationNeedsUpdateIgnoresTheUnknownSpelling pins the normalisation
+// on the COMPARE path, which is what stops an endless rewrite.
+//
+// A household with no request values at all keeps Go's zero value "" on the
+// struct, while setRegistrationRequestFields writes "unknown" to the row. If
+// only the write normalised, every such household would compare unequal on
+// every pass and be re-saved forever -- 35 rows on 2026 alone. Verified by hand
+// against a real sync (a third pass touched 0 rows); this pins it.
+func TestRegistrationNeedsUpdateIgnoresTheUnknownSpelling(t *testing.T) {
+	col := core.NewBaseCollection("family_camp_registrations")
+	col.Fields.Add(&core.TextField{Name: "share_eligibility"})
+	col.Fields.Add(&core.TextField{Name: "share_eligibility_source"})
+	col.Fields.Add(&core.BoolField{Name: "share_answers_conflict"})
+
+	existing := core.NewRecord(col)
+	existing.Set("share_eligibility", "unknown")
+	existing.Set("share_eligibility_source", "none")
+
+	s := &FamilyCampDerivedSync{}
+
+	// The struct never reached the collapse, so it holds "". The row holds the
+	// normalised spelling. Those are the SAME state and must not read as a
+	// change.
+	unwritten := &registrationData{}
+	if s.registrationNeedsUpdate(existing, unwritten) {
+		t.Error("an unwritten verdict must compare equal to the stored \"unknown\", or the sync rewrites it forever")
+	}
+
+	// A genuine change still registers.
+	changed := &registrationData{
+		shareEligibility:       "open",
+		shareEligibilitySource: "form",
+	}
+	if !s.registrationNeedsUpdate(existing, changed) {
+		t.Error("a real verdict change must still be detected")
+	}
+}

--- a/pocketbase/sync/lodging_requests.go
+++ b/pocketbase/sync/lodging_requests.go
@@ -197,6 +197,25 @@ func DeriveShareEligibility(
 	return shareEligibilityUnknown, shareSourceNone, false
 }
 
+// NormalizeShareEligibility gives an unwritten verdict its explicit spelling.
+//
+// A household with NO request-field values at all never gets a bucket in
+// CollapseToHouseholdGrain, so its derived fields keep Go's zero value and the
+// column would store "" rather than "unknown" -- two spellings of one state.
+// Measured on 2026 after a real family_camp_derived run: 35 rows "" against 2
+// rows "unknown", so `WHERE share_eligibility = 'unknown'` would silently miss
+// 35 households.
+//
+// Every consumer already reads "" as unknown, which is precisely what makes
+// this latent rather than visible: the column looks fine until somebody
+// filters on it. Same shape as kindred#1921.
+func NormalizeShareEligibility(eligibility, source string) (string, string) {
+	if eligibility == "" {
+		return shareEligibilityUnknown, shareSourceNone
+	}
+	return eligibility, source
+}
+
 // PersonRequestValue is one person-partition request value, already carrying the
 // household it belongs to.
 type PersonRequestValue struct {

--- a/pocketbase/sync/lodging_requests.go
+++ b/pocketbase/sync/lodging_requests.go
@@ -163,8 +163,11 @@ func ParseSharedCabinModes(raw string) (near, with, similarAges bool) {
 // maybe_mutual resolving into anything is the answer arriving, not a conflict --
 // counting refinements would put a third of respondents in the review queue
 // instead of the measured 7.5%.
+// anySiblingDeclined reports whether ANY of the household's person-partition
+// gate answers normalised to no_share, regardless of which one winsGate picked.
+// It is consulted only on the fallback path -- see below.
 func DeriveShareEligibility(
-	gate string, formAnswered, wantsWith, wantsSimilarAges bool,
+	gate string, formAnswered, wantsWith, wantsSimilarAges, anySiblingDeclined bool,
 ) (eligibility, source string, conflict bool) {
 	if formAnswered {
 		switch {
@@ -177,11 +180,33 @@ func DeriveShareEligibility(
 		default:
 			eligibility = shareEligibilityDeclined
 		}
-		conflict = (gate == gateNoShare && wantsWith) || (gate == gateYesShare && !wantsWith)
+		// Keyed off the VERDICT, not off wantsWith. The two agree today only
+		// because ParseSharedCabinModes guarantees similarAges implies with,
+		// and that invariant lives in another function whose own comment says
+		// it exists because staff reword these sentences. If it ever broke,
+		// keying off wantsWith would fail PERMISSIVELY -- reporting no conflict
+		// for a no_share gate sitting against an open verdict.
+		conflict = (gate == gateNoShare && eligibility != shareEligibilityDeclined) ||
+			(gate == gateYesShare && eligibility == shareEligibilityDeclined)
 		return eligibility, shareSourceForm, conflict
 	}
 
-	// Fallback. One answer cannot contradict anything, so conflict stays false.
+	// FALLBACK. One answer cannot contradict anything, so conflict stays false.
+	//
+	// A recorded decline anywhere in the household outranks a later permissive
+	// sibling answer. winsGate resolves the gate by newest-wins with no
+	// fail-safe direction, which is right for a display column and wrong for a
+	// consent verdict: measured on 2026, 4 households would otherwise fall back
+	// to `open` off a sibling's recorded no_share. Same shape as the household
+	// blocker that clears opt_out_vip in family_camp_derived.
+	//
+	// Deliberately NOT applied when the form answered -- the form is
+	// authoritative, and letting an old sibling gate override it would invert
+	// the whole precedence rule.
+	if anySiblingDeclined {
+		return shareEligibilityDeclined, shareSourceRegistration, false
+	}
+
 	switch gate {
 	case gateYesShare:
 		return shareEligibilityOpen, shareSourceRegistration, false
@@ -275,6 +300,9 @@ func CollapseToHouseholdGrain(values []PersonRequestValue) map[string]*Household
 		// silence is not. This is the only thing separating declined from
 		// unknown, so it tracks value PRESENCE, not parsed modes.
 		formAnswered bool
+		// Whether ANY sibling's gate answer normalised to no_share, regardless
+		// of which one winsGate picked. The fallback fails safe on this.
+		sawDeclineGate bool
 	}
 
 	byHousehold := make(map[string]*accumulator)
@@ -313,7 +341,13 @@ func CollapseToHouseholdGrain(values []PersonRequestValue) map[string]*Household
 
 		switch v.FieldName {
 		case fieldShareCabinsRegistration, fieldSharedCabinForm:
-			if gate := NormalizeShareGate(value); gate != "" && winsGate(a.gateAt, a.gateField, v) {
+			gate := NormalizeShareGate(value)
+			// Recorded BEFORE winsGate picks a winner: a decline that loses on
+			// recency is still a decline the household stated.
+			if gate == gateNoShare {
+				a.sawDeclineGate = true
+			}
+			if gate != "" && winsGate(a.gateAt, a.gateField, v) {
 				a.req.Gate = gate
 				a.gateAt = v.LastUpdated
 				a.gateField = v.FieldName
@@ -348,7 +382,8 @@ func CollapseToHouseholdGrain(values []PersonRequestValue) map[string]*Household
 		// real request survives another's "No requests" -- which is the
 		// correct reading and the reason most such combinations exist.
 		a.req.ShareEligibility, a.req.ShareEligibilitySource, a.req.ShareAnswersConflict =
-			DeriveShareEligibility(a.req.Gate, a.formAnswered, a.req.WantsWith, a.req.WantsSimilarAges)
+			DeriveShareEligibility(
+				a.req.Gate, a.formAnswered, a.req.WantsWith, a.req.WantsSimilarAges, a.sawDeclineGate)
 		out[hh] = a.req
 	}
 	return out

--- a/pocketbase/sync/lodging_requests.go
+++ b/pocketbase/sync/lodging_requests.go
@@ -234,7 +234,7 @@ func DeriveShareEligibility(
 // Every consumer already reads "" as unknown, which is precisely what makes
 // this latent rather than visible: the column looks fine until somebody
 // filters on it. Same shape as kindred#1921.
-func NormalizeShareEligibility(eligibility, source string) (string, string) {
+func NormalizeShareEligibility(eligibility, source string) (normalizedEligibility, normalizedSource string) {
 	if eligibility == "" {
 		return shareEligibilityUnknown, shareSourceNone
 	}

--- a/pocketbase/sync/lodging_requests.go
+++ b/pocketbase/sync/lodging_requests.go
@@ -17,6 +17,24 @@ const (
 	gateYesShare    = "yes_share"
 )
 
+// Share ELIGIBILITY is the question the board actually asks -- "may these two
+// parties be in one cabin" -- and it is NOT the gate above.
+//
+// The gate is the REGISTRATION answer. Staff treat the later Family Camp
+// information form as authoritative (stated 2026-08-02), so the gate is a
+// fallback consulted only when that form's share question has no answer. See
+// DeriveShareEligibility.
+const (
+	shareEligibilityOpen     = "open"     // staff may match with any other open party
+	shareEligibilityNamed    = "named"    // only with the named partner, if mutual
+	shareEligibilityDeclined = "declined" // answered; do not share
+	shareEligibilityUnknown  = "unknown"  // silent on BOTH forms; never consent
+
+	shareSourceForm         = "form"         // the Family Camp information form answered
+	shareSourceRegistration = "registration" // provisional: fell back to the gate
+	shareSourceNone         = "none"         // nothing to read
+)
+
 // Source field display names, used for precedence and provenance. Matching is on
 // cm_id upstream (spec 4.4); these labels only travel with the values.
 const (
@@ -119,6 +137,66 @@ func ParseSharedCabinModes(raw string) (near, with, similarAges bool) {
 	return near, with, similarAges
 }
 
+// DeriveShareEligibility resolves the two share questions into the one verdict
+// the board places on, plus where it came from and whether the two answers
+// disagree.
+//
+// PRECEDENCE, staff-stated 2026-08-02: the Family Camp information form wins.
+// The registration gate is a coarse early filter -- it even told families so in
+// 2024, in an option sentence reading "you will have an opportunity to request
+// specific families closer to the start of the program" -- and it is consulted
+// ONLY when the form's share question has no answer.
+//
+// formAnswered is the PRESENCE of a "FAM CAMP-Shared Cabin" value, not whether
+// that value asked for anything. It is what separates "declined" from "never
+// answered", and it matters: the form is returned by 88% of households but its
+// share question is skipped by roughly half of them, so an absent answer is
+// usually a skipped question rather than a missing form.
+//
+// Only WITH options make a party shareable. NEAR is a SEPARATE AXIS -- its
+// option text is "House my family NEAR a specific family", explicitly not in my
+// cabin -- and it reaches this function as wantsWith=false. 298 households
+// across 2025-2026 selected NEAR alone, so reading it as consent would make the
+// largest cohort on the board look shareable.
+//
+// A conflict is a HARD contradiction only: the two forms point opposite ways.
+// maybe_mutual resolving into anything is the answer arriving, not a conflict --
+// counting refinements would put a third of respondents in the review queue
+// instead of the measured 7.5%.
+func DeriveShareEligibility(
+	gate string, formAnswered, wantsWith, wantsSimilarAges bool,
+) (eligibility, source string, conflict bool) {
+	if formAnswered {
+		switch {
+		case wantsSimilarAges:
+			// Open SUPERSETS named: a household that will take a staff match
+			// is not narrowed by also having named someone.
+			eligibility = shareEligibilityOpen
+		case wantsWith:
+			eligibility = shareEligibilityNamed
+		default:
+			eligibility = shareEligibilityDeclined
+		}
+		conflict = (gate == gateNoShare && wantsWith) || (gate == gateYesShare && !wantsWith)
+		return eligibility, shareSourceForm, conflict
+	}
+
+	// Fallback. One answer cannot contradict anything, so conflict stays false.
+	switch gate {
+	case gateYesShare:
+		return shareEligibilityOpen, shareSourceRegistration, false
+	case gateMaybeMutual:
+		// "Maybe, I am open to sharing ... if a specific family that I know
+		// wants to" is consent to a NAMED partner, never to a staff match. It
+		// arrives with no names attached, so these are eligible in principle
+		// and unmatchable in practice until somebody else names them.
+		return shareEligibilityNamed, shareSourceRegistration, false
+	case gateNoShare:
+		return shareEligibilityDeclined, shareSourceRegistration, false
+	}
+	return shareEligibilityUnknown, shareSourceNone, false
+}
+
 // PersonRequestValue is one person-partition request value, already carrying the
 // household it belongs to.
 type PersonRequestValue struct {
@@ -143,6 +221,14 @@ type HouseholdRequest struct {
 	RequestText      string
 	SourceField      string
 	LastUpdated      time.Time
+
+	// The board's verdict and its provenance -- see DeriveShareEligibility.
+	// ShareEligibility is what placement reads; Gate above stays the raw
+	// registration answer, kept because it is what a staff member sees when
+	// asked why a household is flagged.
+	ShareEligibility       string
+	ShareEligibilitySource string
+	ShareAnswersConflict   bool
 }
 
 // CollapseToHouseholdGrain implements spec 4.2, which is mandatory: the request
@@ -165,6 +251,11 @@ func CollapseToHouseholdGrain(values []PersonRequestValue) map[string]*Household
 		textParts []string
 		gateAt    time.Time
 		gateField string
+		// Whether the Family Camp form's share question was answered AT ALL,
+		// independent of what it asked for. "No requests" is an answer;
+		// silence is not. This is the only thing separating declined from
+		// unknown, so it tracks value PRESENCE, not parsed modes.
+		formAnswered bool
 	}
 
 	byHousehold := make(map[string]*accumulator)
@@ -210,6 +301,7 @@ func CollapseToHouseholdGrain(values []PersonRequestValue) map[string]*Household
 				a.req.SourceField = v.FieldName
 			}
 			if v.FieldName == fieldSharedCabinForm {
+				a.formAnswered = true
 				near, with, similarAges := ParseSharedCabinModes(value)
 				a.req.WantsNear = a.req.WantsNear || near
 				a.req.WantsWith = a.req.WantsWith || with
@@ -231,6 +323,13 @@ func CollapseToHouseholdGrain(values []PersonRequestValue) map[string]*Household
 	out := make(map[string]*HouseholdRequest, len(byHousehold))
 	for hh, a := range byHousehold {
 		a.req.RequestText = strings.Join(a.textParts, "; ")
+		// Derived last, because it reads the collapsed modes: the form fields
+		// are person-partition, and siblings DO disagree (11 households in
+		// 2025, 5 in 2026). ParseSharedCabinModes ORs them, so one child's
+		// real request survives another's "No requests" -- which is the
+		// correct reading and the reason most such combinations exist.
+		a.req.ShareEligibility, a.req.ShareEligibilitySource, a.req.ShareAnswersConflict =
+			DeriveShareEligibility(a.req.Gate, a.formAnswered, a.req.WantsWith, a.req.WantsSimilarAges)
 		out[hh] = a.req
 	}
 	return out

--- a/pocketbase/sync/lodging_requests_test.go
+++ b/pocketbase/sync/lodging_requests_test.go
@@ -410,7 +410,7 @@ func TestDeriveShareEligibility(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			gotEligibility, gotSource, gotConflict := DeriveShareEligibility(
-				tc.gate, tc.formAnswered, tc.wantsWith, tc.similarAges)
+				tc.gate, tc.formAnswered, tc.wantsWith, tc.similarAges, false)
 			if gotEligibility != tc.eligibility {
 				t.Errorf("eligibility = %q, want %q", gotEligibility, tc.eligibility)
 			}
@@ -434,7 +434,7 @@ func TestDeriveShareEligibility(t *testing.T) {
 // and must not suppress one either -- 29 households selected both.
 func TestDeriveShareEligibilityIgnoresNearOnly(t *testing.T) {
 	// NEAR alone reaches this function as "form answered, wants_with false".
-	got, source, conflict := DeriveShareEligibility(gateMaybeMutual, true, false, false)
+	got, source, conflict := DeriveShareEligibility(gateMaybeMutual, true, false, false, false)
 	if got != shareEligibilityDeclined {
 		t.Errorf("NEAR-only eligibility = %q, want %q", got, shareEligibilityDeclined)
 	}
@@ -446,7 +446,7 @@ func TestDeriveShareEligibilityIgnoresNearOnly(t *testing.T) {
 	}
 
 	// WITH + NEAR together: the share request survives the proximity request.
-	got, _, _ = DeriveShareEligibility("", true, true, false)
+	got, _, _ = DeriveShareEligibility("", true, true, false, false)
 	if got != shareEligibilityNamed {
 		t.Errorf("WITH+NEAR eligibility = %q, want %q", got, shareEligibilityNamed)
 	}
@@ -527,5 +527,100 @@ func TestNormalizeShareEligibilityGivesUnknownOneSpelling(t *testing.T) {
 			t.Errorf("NormalizeShareEligibility(%q, %q) = (%q, %q), want unchanged",
 				tc.eligibility, tc.source, gotEligibility, gotSource)
 		}
+	}
+}
+
+// TestDeriveShareEligibilityConflictTracksTheVerdict keys the conflict flag off
+// the VERDICT rather than off wantsWith directly.
+//
+// Both spellings agree today, because ParseSharedCabinModes guarantees
+// similarAges implies with. But DeriveShareEligibility is exported and takes
+// the two booleans independently, so nothing here enforces that invariant --
+// and the invariant lives in a different function whose own comment says it
+// exists precisely because staff reword these option sentences.
+//
+// The failure mode if it ever broke is the PERMISSIVE one: a gate of no_share
+// against a form answer of open would report conflict=false, hiding exactly
+// the disagreement staff need to see.
+func TestDeriveShareEligibilityConflictTracksTheVerdict(t *testing.T) {
+	// similarAges WITHOUT with -- the state ParseSharedCabinModes prevents.
+	// Reached directly, the verdict is open, so a no_share gate conflicts.
+	_, _, conflict := DeriveShareEligibility(gateNoShare, true, false, true, false)
+	if !conflict {
+		t.Error("no_share gate against an open verdict is a conflict, whatever wantsWith says")
+	}
+
+	// And the mirror: a yes_share gate against an open verdict is agreement.
+	_, _, conflict = DeriveShareEligibility(gateYesShare, true, false, true, false)
+	if conflict {
+		t.Error("yes_share gate against an open verdict agrees")
+	}
+}
+
+// TestDeriveShareEligibilityFallbackFailsSafeOnASiblingDecline stops the
+// registration fallback resolving to a MORE permissive verdict than one of the
+// household's own answers.
+//
+// The request fields are person-partition, so siblings can disagree, and
+// winsGate resolves the gate by newest-wins with no fail-safe direction.
+// Measured on 2026: 30 households have disagreeing sibling gates, 6 have a
+// newest yes_share over a sibling no_share, and 4 of those have no form answer
+// -- so they would fall back to `open`, off a recorded no_share.
+//
+// Same fail-safe shape the household blocker uses for opt_out_vip: a decline
+// anywhere in the household outranks a later permissive answer. Deliberately
+// scoped to the FALLBACK only -- when the authoritative form answered, it wins,
+// which is the whole precedence rule.
+func TestDeriveShareEligibilityFallbackFailsSafeOnASiblingDecline(t *testing.T) {
+	for _, gate := range []string{gateYesShare, gateMaybeMutual} {
+		eligibility, source, conflict := DeriveShareEligibility(gate, false, false, false, true)
+		if eligibility != shareEligibilityDeclined {
+			t.Errorf("gate %q with a declining sibling = %q, want %q",
+				gate, eligibility, shareEligibilityDeclined)
+		}
+		if source != shareSourceRegistration {
+			t.Errorf("gate %q: source = %q, want %q", gate, source, shareSourceRegistration)
+		}
+		if conflict {
+			t.Errorf("gate %q: a fallback reads one form, so it cannot conflict", gate)
+		}
+	}
+
+	// The form still wins. A declining sibling does NOT override an answered
+	// form -- that would invert the precedence rule.
+	eligibility, source, _ := DeriveShareEligibility(gateNoShare, true, true, false, true)
+	if eligibility != shareEligibilityNamed || source != shareSourceForm {
+		t.Errorf("form answer = (%q, %q), want (%q, %q) -- the form outranks a sibling gate",
+			eligibility, source, shareEligibilityNamed, shareSourceForm)
+	}
+}
+
+// TestCollapseCarriesASiblingDeclineIntoTheFallback proves the signal above is
+// actually computed from the household's values rather than being a parameter
+// nothing supplies.
+func TestCollapseCarriesASiblingDeclineIntoTheFallback(t *testing.T) {
+	const noShare = "No, we would prefer not to share a camper cabin."
+	const yesShare = "Yes, I would like to share a large camper cabin with a family that I " +
+		"request or with a family with similarly aged kid(s) that I can meet at Camp."
+	older := time.Now().Add(-time.Hour)
+	newer := time.Now()
+
+	// One child declined; a later sibling answer says yes. Newest wins the
+	// GATE, but the verdict must not become shareable off that.
+	out := CollapseToHouseholdGrain([]PersonRequestValue{
+		{HouseholdKey: hhA, FieldName: fieldShareCabinsRegistration, Value: noShare, LastUpdated: older},
+		{HouseholdKey: hhA, FieldName: fieldShareCabinsRegistration, Value: yesShare, LastUpdated: newer},
+	})
+
+	a := out[hhA]
+	if a == nil {
+		t.Fatal("household A missing from collapse")
+	}
+	if a.Gate != gateYesShare {
+		t.Errorf("gate = %q, want %q -- winsGate is unchanged by this", a.Gate, gateYesShare)
+	}
+	if a.ShareEligibility != shareEligibilityDeclined {
+		t.Errorf("eligibility = %q, want %q -- a recorded decline outranks a later yes in the fallback",
+			a.ShareEligibility, shareEligibilityDeclined)
 	}
 }

--- a/pocketbase/sync/lodging_requests_test.go
+++ b/pocketbase/sync/lodging_requests_test.go
@@ -497,3 +497,35 @@ func TestCollapseCarriesShareEligibility(t *testing.T) {
 		t.Error("B has only one answer, so it cannot conflict with anything")
 	}
 }
+
+// TestNormalizeShareEligibilityGivesUnknownOneSpelling closes a latent filter
+// bug found by running the real sync rather than by reading the code.
+//
+// A household with NO request-field values at all never gets a bucket in
+// CollapseToHouseholdGrain, so its derived fields stay at Go's zero value and
+// the column stores "" instead of "unknown" -- two spellings of one state.
+// Measured on 2026 after a real family_camp_derived run: 35 rows "" against 2
+// rows "unknown", so `WHERE share_eligibility = 'unknown'` would silently miss
+// 35 households. Every consumer already reads "" as unknown, which is exactly
+// what makes this latent rather than visible -- the same shape as kindred#1921.
+func TestNormalizeShareEligibilityGivesUnknownOneSpelling(t *testing.T) {
+	eligibility, source := NormalizeShareEligibility("", "")
+	if eligibility != shareEligibilityUnknown || source != shareSourceNone {
+		t.Errorf("unwritten verdict = (%q, %q), want (%q, %q)",
+			eligibility, source, shareEligibilityUnknown, shareSourceNone)
+	}
+
+	// A real verdict passes through untouched, source included.
+	for _, tc := range []struct{ eligibility, source string }{
+		{shareEligibilityOpen, shareSourceForm},
+		{shareEligibilityNamed, shareSourceRegistration},
+		{shareEligibilityDeclined, shareSourceForm},
+		{shareEligibilityUnknown, shareSourceNone},
+	} {
+		gotEligibility, gotSource := NormalizeShareEligibility(tc.eligibility, tc.source)
+		if gotEligibility != tc.eligibility || gotSource != tc.source {
+			t.Errorf("NormalizeShareEligibility(%q, %q) = (%q, %q), want unchanged",
+				tc.eligibility, tc.source, gotEligibility, gotSource)
+		}
+	}
+}

--- a/pocketbase/sync/lodging_requests_test.go
+++ b/pocketbase/sync/lodging_requests_test.go
@@ -336,3 +336,164 @@ func TestCollapseSeparatesHouseholds(t *testing.T) {
 		t.Error("request text bled across households")
 	}
 }
+
+// TestDeriveShareEligibility pins the precedence rule staff stated on
+// 2026-08-02: the Family Camp information form is authoritative, and the
+// registration gate is consulted ONLY when the form's share question has no
+// answer.
+//
+// Both directions of override are load-bearing and both were wrong before this
+// existed. Measured on 2026 family-camp attendees:
+//
+//   - registration no_share + form WITH   -> shareable. 3 households the old
+//     gate-only flag reported as a violation, each having named a partner.
+//   - registration yes_share + form NEAR  -> NOT shareable. 12 households the
+//     old flag was silent about, plus 39 more from maybe_mutual.
+//
+// The second direction is the dangerous one: it reads as permissive, so the
+// board hands staff a clean card for a household that declined.
+//
+// Not answering is never consent. A household silent on BOTH forms is
+// unknown -- which places as no-share but is a different fact from declining,
+// exactly as partyAttention separates "unverified" from "unmet".
+func TestDeriveShareEligibility(t *testing.T) {
+	cases := []struct {
+		name         string
+		gate         string
+		formAnswered bool
+		wantsWith    bool
+		similarAges  bool
+		eligibility  string
+		source       string
+		conflict     bool
+	}{
+		// --- Form answered: the gate is IGNORED for the verdict. ---
+		{"form open, gate silent", "", true, true, true, shareEligibilityOpen, shareSourceForm, false},
+		{"form named, gate silent", "", true, true, false, shareEligibilityNamed, shareSourceForm, false},
+		{"form declined, gate silent", "", true, false, false, shareEligibilityDeclined, shareSourceForm, false},
+
+		// The 3 households: said no at registration, then named a partner.
+		{"gate no_share overridden by form WITH", gateNoShare, true, true, false,
+			shareEligibilityNamed, shareSourceForm, true},
+		// The 12 households: said yes at registration, then declined on the form.
+		{"gate yes_share overridden by form decline", gateYesShare, true, false, false,
+			shareEligibilityDeclined, shareSourceForm, true},
+
+		// maybe_mutual resolving into anything is the answer ARRIVING, not a
+		// conflict. Counting it as one puts a third of respondents in the
+		// review queue instead of 7.5%.
+		{"maybe_mutual to declined is a refinement", gateMaybeMutual, true, false, false,
+			shareEligibilityDeclined, shareSourceForm, false},
+		{"maybe_mutual to open is a refinement", gateMaybeMutual, true, true, true,
+			shareEligibilityOpen, shareSourceForm, false},
+		// Agreement is never a conflict.
+		{"gate yes_share agreeing with form", gateYesShare, true, true, true,
+			shareEligibilityOpen, shareSourceForm, false},
+		{"gate no_share agreeing with form", gateNoShare, true, false, false,
+			shareEligibilityDeclined, shareSourceForm, false},
+
+		// --- Form NOT answered: fall back to registration. ---
+		{"fallback yes_share", gateYesShare, false, false, false,
+			shareEligibilityOpen, shareSourceRegistration, false},
+		{"fallback maybe_mutual", gateMaybeMutual, false, false, false,
+			shareEligibilityNamed, shareSourceRegistration, false},
+		{"fallback no_share", gateNoShare, false, false, false,
+			shareEligibilityDeclined, shareSourceRegistration, false},
+		{"silent on both forms", "", false, false, false,
+			shareEligibilityUnknown, shareSourceNone, false},
+
+		// A fallback can never conflict: there is only one answer to read.
+		{"fallback never conflicts", gateNoShare, false, false, false,
+			shareEligibilityDeclined, shareSourceRegistration, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotEligibility, gotSource, gotConflict := DeriveShareEligibility(
+				tc.gate, tc.formAnswered, tc.wantsWith, tc.similarAges)
+			if gotEligibility != tc.eligibility {
+				t.Errorf("eligibility = %q, want %q", gotEligibility, tc.eligibility)
+			}
+			if gotSource != tc.source {
+				t.Errorf("source = %q, want %q", gotSource, tc.source)
+			}
+			if gotConflict != tc.conflict {
+				t.Errorf("conflict = %v, want %v", gotConflict, tc.conflict)
+			}
+		})
+	}
+}
+
+// TestDeriveShareEligibilityIgnoresNearOnly is the single biggest cohort and
+// the easiest to get wrong: NEAR is proximity, not sharing. Its option text is
+// "House my family NEAR a specific family" -- explicitly not in my cabin.
+// 298 households across 2025-2026 selected NEAR alone, and reading it as a
+// share request would make the largest group on the board look shareable.
+//
+// NEAR is a SEPARATE AXIS, so it is expressible alongside a real share request
+// and must not suppress one either -- 29 households selected both.
+func TestDeriveShareEligibilityIgnoresNearOnly(t *testing.T) {
+	// NEAR alone reaches this function as "form answered, wants_with false".
+	got, source, conflict := DeriveShareEligibility(gateMaybeMutual, true, false, false)
+	if got != shareEligibilityDeclined {
+		t.Errorf("NEAR-only eligibility = %q, want %q", got, shareEligibilityDeclined)
+	}
+	if source != shareSourceForm {
+		t.Errorf("NEAR-only source = %q, want %q", source, shareSourceForm)
+	}
+	if conflict {
+		t.Error("NEAR-only after maybe_mutual is a refinement, not a conflict")
+	}
+
+	// WITH + NEAR together: the share request survives the proximity request.
+	got, _, _ = DeriveShareEligibility("", true, true, false)
+	if got != shareEligibilityNamed {
+		t.Errorf("WITH+NEAR eligibility = %q, want %q", got, shareEligibilityNamed)
+	}
+}
+
+// TestCollapseCarriesShareEligibility proves the derivation reaches the
+// household-grain result the surfaces read, rather than being a loose helper
+// nothing calls. formAnswered is the presence of the modes field, which is
+// what separates "declined" from "never answered".
+func TestCollapseCarriesShareEligibility(t *testing.T) {
+	const withNamed = "Share a cabin WITH a specific family that I know (please include names " +
+		"below and ensure that the request is mutual)."
+	const noShare = "No, we would prefer not to share a camper cabin."
+	now := time.Now()
+
+	out := CollapseToHouseholdGrain([]PersonRequestValue{
+		{HouseholdKey: hhA, FieldName: fieldShareCabinsRegistration, Value: noShare, LastUpdated: now},
+		{HouseholdKey: hhA, FieldName: fieldSharedCabinForm, Value: withNamed, LastUpdated: now},
+		// hhB answered registration only -- the fallback path.
+		{HouseholdKey: hhB, FieldName: fieldShareCabinsRegistration, Value: noShare, LastUpdated: now},
+	})
+
+	a := out[hhA]
+	if a == nil {
+		t.Fatal("household A missing from collapse")
+	}
+	if a.ShareEligibility != shareEligibilityNamed {
+		t.Errorf("A eligibility = %q, want %q", a.ShareEligibility, shareEligibilityNamed)
+	}
+	if a.ShareEligibilitySource != shareSourceForm {
+		t.Errorf("A source = %q, want %q", a.ShareEligibilitySource, shareSourceForm)
+	}
+	if !a.ShareAnswersConflict {
+		t.Error("A said no at registration then named a partner: that is a recorded conflict")
+	}
+
+	b := out[hhB]
+	if b == nil {
+		t.Fatal("household B missing from collapse")
+	}
+	if b.ShareEligibility != shareEligibilityDeclined {
+		t.Errorf("B eligibility = %q, want %q", b.ShareEligibility, shareEligibilityDeclined)
+	}
+	if b.ShareEligibilitySource != shareSourceRegistration {
+		t.Errorf("B source = %q, want %q", b.ShareEligibilitySource, shareSourceRegistration)
+	}
+	if b.ShareAnswersConflict {
+		t.Error("B has only one answer, so it cannot conflict with anything")
+	}
+}

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -987,3 +987,119 @@ class TestBuildSummary:
 
         assert summary.weekends == []
         assert repo.fetch_units.await_count == 0
+
+
+class TestShareEligibility:
+    """The board places on ELIGIBILITY, not on the registration gate.
+
+    Share intent lives in two CampMinder fields asked at different times, and
+    staff treat the later Family Camp information form as authoritative. The
+    resolution is done once, in the Go ingest, so this layer only READS it --
+    the same one-writer rule that keeps `preference` from being recomputed.
+
+    Measured on 2026 family-camp attendees, reading the gate instead of the
+    eligibility is wrong both ways: 3 households said no at registration then
+    named a partner (flagged though legitimate), and 51 said yes-or-maybe then
+    declined on the form (silent, and read as permissive).
+    """
+
+    @pytest.mark.asyncio
+    async def test_eligibility_is_read_not_derived_from_the_gate(self) -> None:
+        """A no_share gate with a form WITH answer is SHAREABLE.
+
+        The gate stays visible as `preference` because it is what a staff
+        member sees when asked why a household is flagged, but it must not
+        drive placement.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_attendees_for_session=[_child()],
+            fetch_households={"hh_1": _household()},
+            fetch_family_camp_registrations={
+                "hh_1": _rec(
+                    share_cabin_gate="no_share",
+                    wants_with=True,
+                    share_eligibility="named",
+                    share_eligibility_source="form",
+                    share_answers_conflict=True,
+                )
+            },
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        share = roster.parties[0].share
+        assert share.preference == "no_share", "the raw gate stays visible"
+        assert share.eligibility == "named", "the form outranks the gate"
+        assert share.eligibility_source == "form"
+        assert share.answers_conflict is True
+
+    @pytest.mark.asyncio
+    async def test_registration_fallback_is_marked_provisional(self) -> None:
+        """No form answer falls back to the gate, and says that it did.
+
+        The fallback verdict is provisional -- the household has not answered
+        the authoritative question -- so the surface must be able to tell the
+        two apart rather than presenting both as settled.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_attendees_for_session=[_child()],
+            fetch_households={"hh_1": _household()},
+            fetch_family_camp_registrations={
+                "hh_1": _rec(
+                    share_cabin_gate="maybe_mutual",
+                    share_eligibility="named",
+                    share_eligibility_source="registration",
+                    share_answers_conflict=False,
+                )
+            },
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        share = roster.parties[0].share
+        assert share.eligibility == "named"
+        assert share.eligibility_source == "registration"
+        assert share.answers_conflict is False
+
+    @pytest.mark.asyncio
+    async def test_absent_columns_read_as_unknown_never_as_open(self) -> None:
+        """An unpopulated column is UNKNOWN, which never consents.
+
+        These columns are written by family_camp_derived, so on any database
+        that has not re-run it they are empty. Empty must fall to the safe
+        side: `unknown` places as no-share. Defaulting to `open` would let the
+        board green-light every household on a stale database.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_attendees_for_session=[_child()],
+            fetch_households={"hh_1": _household()},
+            fetch_family_camp_registrations={"hh_1": _rec(share_cabin_gate="")},
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        share = roster.parties[0].share
+        assert share.eligibility == "unknown"
+        assert share.eligibility_source == "none"
+        assert share.answers_conflict is False
+
+    @pytest.mark.asyncio
+    async def test_adult_weekend_parties_carry_no_eligibility(self) -> None:
+        """Adult weekends have no share question AT ALL, so nothing is claimed.
+
+        The fields are partition ["Camper"] and no Adult-Share field exists;
+        28 of 29 adult-only households are blank on registration and none
+        answered the form. A person-grain party therefore gets the default
+        summary, and `unknown` is the honest value -- the board must not read
+        a household's family-camp answers onto an adult attendee, since those
+        may belong to a different weekend and different people.
+        """
+        repo = _repo(
+            fetch_session=ADULT_SESSION,
+            fetch_attendees_for_session=[_child()],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000002)
+
+        share = roster.parties[0].share
+        assert share.eligibility == "unknown"
+        assert share.eligibility_source == "none"


### PR DESCRIPTION
The board's consent flag reads `share_cabin_gate`. That column is derived **entirely from the registration form** — `NormalizeShareGate` requires a leading no/maybe/yes token, and none of the later Family Camp information form's option sentences have one, so the tie-break naming the form as winner has never fired.

Staff treat the **later form as authoritative**. Measured on 2026 family-camp attendees, reading the gate is wrong in both directions:

| | Households | Board before this PR |
|---|---|---|
| Said `no_share`, then **named a partner** on the form | 1 | **flags** — false positive |
| Said `no_share`, then chose **open** (similarly-aged) on the form | 3 | **flags** — false positive |
| Said `yes_share`, then **declined** on the form | 12 | **silent** |
| Said `maybe_mutual`, then **declined** on the form | 39 | **silent** |

The silent direction is **~17×** the noisy one (51 against 3), and it reads as *permissive* — the board hands staff a clean card for a household that declined. That is why this lands **before** the drag PR, which is what makes shares easy to create.

## The model

Two independent axes. **NEAR is not sharing** — its option text is *"House my family NEAR a specific family"*, explicitly not in my cabin, and it is the single largest cohort.

Precedence: **form wins; registration is the fallback; silence on both is `unknown`.**

| Eligibility | 2026 attendees | Meaning |
|---|---|---|
| `open` | 19 | staff may match with any other open party |
| `named` | 78 | only with the named partner, if mutual |
| `declined` | 282 | did not request sharing |
| `unknown` | **2** | silent on both forms |

**The registration fallback is what makes this usable.** Without it, 173 of the 381 attendee households would be `unknown` — the form is returned by ~88% of households but its share question is skipped by roughly half of them. With it, `unknown` is **2**.

## Decisions worth reviewing

- **The form has no refusal option.** The four live choices are NEAR / "No requests" / WITH-named / WITH-similarly-aged, so `declined` is always the *absence* of a WITH token. **106 of 165** form-declined households had asked to be housed NEAR someone — so the surface says *"did not request sharing"*, never "declined". Wording is single-sourced between the slot flag and the card chip.
- **`declined` and `unanswered` are separate counts.** Same placement default, different fact and different remedy (respect it vs chase the form).
- **`named` pairs do not flag.** Mutuality needs request names resolved to households (spec §7.3, unbuilt), and `named` is most of the eligible pool — flagging it would fire mostly on the legitimate case. The panel shows the names; staff judge.
- **The fallback fails safe.** `winsGate` resolves the gate newest-wins with no fail-safe direction — right for a display column, wrong for a consent verdict. A recorded decline anywhere in the household now outranks a later permissive sibling answer (4 households would otherwise have resolved to `open`). Scoped to the fallback only; `winsGate` itself is untouched and still deserves its own issue.
- **Adult weekends are excluded, not silently clean.** They have no share question at all — fields are partition `["Camper"]`, no `Adult-Share` field exists, and `_build_person_parties` attaches no share data. `consentFlag` returns `null`, meaning *not checked*.
- **An absent column reads as `unknown`, never `open`**, and the eligibility switch has a `never` guard so a future value breaks the build rather than silently consenting.
- **`share_cabin_gate` is unchanged and stays.** It is what a staff member sees when asked why a household is flagged, and it is the fallback input.

## Shape

- `1500000133` adds `share_eligibility`, `share_eligibility_source`, `share_answers_conflict`. Select fields — the select list is the constraint.
- `DeriveShareEligibility` in `pocketbase/sync/lodging_requests.go`, wired through `CollapseToHouseholdGrain`.
- `ShareRequestSummary` gains three read-only fields; the service reads, never re-derives.
- `consentFlag` re-pointed; conflicts surface on both the slot flag and the card chip.

**No backfill** — `family_camp_derived` must re-run per year to populate these.

## Verification

**Run against real data, not just green tests.** `family_camp_derived` was executed for 2026 on a real database:

- Output reproduces the cohort analysis the derivation was written from (table above).
- **Idempotent** — a third pass touched 0 rows and `MAX(updated)` did not move.
- The run **found a bug reading the code would not have**: 35 rows stored `''` where 2 stored `'unknown'` — one state, two spellings, so `WHERE share_eligibility='unknown'` silently missed 35 households. Fixed, including the compare-path normalisation that would otherwise have rewritten those rows on every sync forever.

Gates: Go `./sync/` suite + `go build` + gofmt; 1811 `tests/unit/api/`; `mypy . --explicit-package-bases` clean over 794 files; ruff clean; full frontend suite; `tsc --noEmit` clean; eslint 0 errors; `verify-no-hardcoded-lodging.sh` exit `0` (real exit code, not a pipeline tail).

Design doc and full measurements are local-only (`docs/superpowers/specs/`, gitignored).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer cabin-sharing statuses for open, named, declined, and unanswered requests.
  * Sharing decisions now prioritize completed form responses, using registration preferences only when forms are unanswered.
  * Added indicators when registration and form responses conflict.
* **Bug Fixes**
  * Improved consent and lodging-board messaging to distinguish declined responses from unanswered forms.
  * Prevented unrelated person-level lodging requests from affecting family sharing eligibility.
* **Tests**
  * Expanded coverage for sharing decisions, conflicts, fallbacks, and consent indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->