### PR TITLE
fix(api): guard the three unhardened lodging write races

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -379,8 +379,7 @@ the thing this PR is most likely to get wrong.
 - Scenario gating: no scenario → the board stays exactly as read-only as it is today, with the
   amber CM badge. Mirror `ScenarioContext`'s `isProductionMode`.
 - Merge-as-board-action and reserve/release if they fit; otherwise say so and leave them.
-- **The three unguarded write paths in §8.** Small, mechanical, and their own precedent is five
-  lines away in the same file.
+- ~~The three unguarded write paths in §8.~~ Done separately in **#1927** — do not re-do them.
 
 **Out of scope:** the map (next), `unit_class`/#1907 unless flagging needs it, and any new read
 endpoint — the roster already returns what the board renders.
@@ -652,29 +651,30 @@ git fetch -q && git rev-list --count origin/<branch>..HEAD   # must be 0
 
 ## 8. Open issues
 
-### Live on `main`: three write paths 500 on writes staff are entitled to make
+### CLOSED: the five write paths are all race-guarded
 
-**Unfiled, deliberately** — they are mechanical and belong folded into the drag PR (§4). Written
-down here so they do not rot silently if that PR slips; if it slips more than a week or two,
-file them.
+Left here as the record of a gap that is now shut, because the shape recurs: any find-then-write
+pair in this file races, and the answer is always one of the two existing shapes.
 
-`4b8b541c` fixed a race and a delete hole, each at ONE call site, leaving the identical siblings
-untouched. **CodeRabbit never reviewed that commit** — its incremental pass was still running
-when auto-merge fired. Of the five write paths in `api/services/lodging_write_service.py`:
+This section previously listed three unguarded paths and told you to fold them into the drag PR
+(§4). They were fixed on their own instead, in **#1927**. All five write paths in
+`api/services/lodging_write_service.py` now hold:
 
 | Path | Shape | Handled? |
 |---|---|---|
 | `place_party` create | find→create vs unique index | ✅ race-guarded |
 | `delete_merge` | delete a missing row | ✅ 404-idempotent |
-| `clear_placement` delete | delete between find and delete | ❌ 500 |
-| `set_availability` delete | delete between find and delete | ❌ 500 |
-| `set_availability` create | find→create vs `idx_lodging_avail_unique` | ❌ 500 |
+| `clear_placement` delete | delete between find and delete | ✅ 404-idempotent |
+| `set_availability` delete | delete between find and delete | ✅ 404-idempotent |
+| `set_availability` create | find→create vs `idx_lodging_avail_unique` | ✅ race-guarded |
 
-`idx_lodging_avail_unique` is UNIQUE on `(session, year, scenario, unit)` (`1500000118:100`), so
-**`set_availability` create has exactly the race `place_party` just fixed**: two staff reserving
-the same unit in one scenario, and the loser gets a 500 for a legitimate write. That is the one
-that matters most — the deletes are already narrowed by a preceding find, so their exposure is
-the narrower find-then-delete race. Copy the two existing shapes; do not invent a third.
+Both create-retries also guard their OWN recovery — the re-read and the update inside the except
+block go through `pb_error_to_http` too, because an unwrapped failure there is the same bare 500
+the retry exists to prevent.
+
+**Do not read that as "concurrency is handled."** These guard the write paths, not occupancy:
+two staff can still place different parties into one unit without either write failing. That is
+kindred#1907, and it is a modelling question for the board, not an exception handler.
 
 ### #1923 — the delete guards are blind to draft rows
 

--- a/api/services/lodging_write_service.py
+++ b/api/services/lodging_write_service.py
@@ -95,6 +95,12 @@ class LodgingWriteService:
         error keeps its upstream status rather than becoming a 200 reporting a
         placement that does not exist.
 
+        The recovery races too: the re-read can fail on its own, and the
+        winner's row can vanish again before the update lands. Both calls live
+        inside the except block, so their failures go through pb_error_to_http
+        as well -- an unwrapped one is a bare ClientResponseError into the
+        catch-all handler, which is the same 500 this guard exists to prevent.
+
         All three targets empty is the TOMBSTONE -- "staff took this party off
         the board in this scenario" -- and is a legitimate row, not a no-op.
         Deleting the row instead would fall through to the CampMinder mirror
@@ -130,16 +136,19 @@ class LodgingWriteService:
             try:
                 record = await self.repository.create_draft_assignment(data)
             except ClientResponseError as exc:
-                raced = await self.repository.find_draft_assignment(
-                    request.year,
-                    session_pb_id,
-                    request.scenario,
-                    request.household_cm_id,
-                    request.person_cm_id,
-                )
-                if raced is None:
-                    raise pb_error_to_http(exc) from exc
-                record = await self.repository.update_draft_assignment(str(raced.id), data)
+                try:
+                    raced = await self.repository.find_draft_assignment(
+                        request.year,
+                        session_pb_id,
+                        request.scenario,
+                        request.household_cm_id,
+                        request.person_cm_id,
+                    )
+                    if raced is None:
+                        raise pb_error_to_http(exc) from exc
+                    record = await self.repository.update_draft_assignment(str(raced.id), data)
+                except ClientResponseError as retry_exc:
+                    raise pb_error_to_http(retry_exc) from retry_exc
         return LodgingWriteResponse(record_id=str(getattr(record, "id", "")))
 
     async def clear_placement(self, request: PlacementDeleteRequest) -> LodgingWriteResponse:
@@ -176,7 +185,7 @@ class LodgingWriteService:
             await self.repository.delete_draft_assignment(str(existing.id))
         except ClientResponseError as exc:
             if exc.status == 404:
-                return LodgingWriteResponse(deleted=False)
+                return LodgingWriteResponse(record_id=str(existing.id), deleted=False)
             raise pb_error_to_http(exc) from exc
         return LodgingWriteResponse(record_id=str(existing.id), deleted=True)
 
@@ -270,7 +279,9 @@ class LodgingWriteService:
         own partial unique index, guarded the identical way -- the loser
         re-reads and updates the winner's row, which is by construction the
         row this call wanted: same session, same year, same scenario, same
-        unit.
+        unit. The recovery's own two calls are guarded the same way
+        place_party's are, for the same reason: a failure inside the except
+        block is the very 500 the block exists to prevent.
         """
         session_pb_id = await self._resolve_session_pb_id(request.year, request.session_cm_id)
 
@@ -285,7 +296,7 @@ class LodgingWriteService:
                 await self.repository.delete_availability(str(existing.id))
             except ClientResponseError as exc:
                 if exc.status == 404:
-                    return LodgingWriteResponse(deleted=False)
+                    return LodgingWriteResponse(record_id=str(existing.id), deleted=False)
                 raise pb_error_to_http(exc) from exc
             return LodgingWriteResponse(record_id=str(existing.id), deleted=True)
 
@@ -304,10 +315,13 @@ class LodgingWriteService:
             try:
                 record = await self.repository.create_availability(data)
             except ClientResponseError as exc:
-                raced = await self.repository.find_availability_override(
-                    request.year, session_pb_id, request.scenario, request.unit_id
-                )
-                if raced is None:
-                    raise pb_error_to_http(exc) from exc
-                record = await self.repository.update_availability(str(raced.id), data)
+                try:
+                    raced = await self.repository.find_availability_override(
+                        request.year, session_pb_id, request.scenario, request.unit_id
+                    )
+                    if raced is None:
+                        raise pb_error_to_http(exc) from exc
+                    record = await self.repository.update_availability(str(raced.id), data)
+                except ClientResponseError as retry_exc:
+                    raise pb_error_to_http(retry_exc) from retry_exc
         return LodgingWriteResponse(record_id=str(getattr(record, "id", "")))

--- a/api/services/lodging_write_service.py
+++ b/api/services/lodging_write_service.py
@@ -151,6 +151,14 @@ class LodgingWriteService:
         Idempotent: no row is a 200 with `deleted: false`, not a 404. The board
         may fire this for a card that was never moved, and a 404 there would be
         an error message about nothing having gone wrong.
+
+        That covers the row never having existed. It does not, by itself,
+        cover the row existing at the find above and vanishing before the
+        delete lands -- two staff clearing the same placement, or a
+        double-click, race the same way the merge delete below does. Exactly
+        as there, ONLY 404 is swallowed: any other PocketBase failure keeps
+        its status through pb_error_to_http, because "the delete was refused"
+        must not read as "there was nothing to delete".
         """
         session_pb_id = await self._resolve_session_pb_id(request.year, request.session_cm_id)
 
@@ -164,7 +172,12 @@ class LodgingWriteService:
         if existing is None:
             return LodgingWriteResponse(deleted=False)
 
-        await self.repository.delete_draft_assignment(str(existing.id))
+        try:
+            await self.repository.delete_draft_assignment(str(existing.id))
+        except ClientResponseError as exc:
+            if exc.status == 404:
+                return LodgingWriteResponse(deleted=False)
+            raise pb_error_to_http(exc) from exc
         return LodgingWriteResponse(record_id=str(existing.id), deleted=True)
 
     async def create_merge(self, request: MergeWriteRequest) -> LodgingWriteResponse:
@@ -241,6 +254,23 @@ class LodgingWriteService:
         of a row is what "whatever the live plan says" is spelled as. Writing
         an override that happens to agree with the live plan would pin the unit
         against a later change to it.
+
+        Both the delete and the create below race the same way the placement
+        writes do, and are guarded the same two ways.
+
+        The delete: the find above sees the row, but it can vanish before the
+        delete reaches PocketBase -- two staff releasing the same unit, or a
+        double-click. ONLY 404 is swallowed, exactly as clear_placement's
+        delete is; any other failure keeps its status through pb_error_to_http.
+
+        The create: `idx_lodging_avail_unique` is UNIQUE on (session, year,
+        scenario, unit), so two staff reserving the same unit in the same
+        scenario both find no override, both create, and the index rejects
+        the loser. That is exactly the race place_party guards on the draft's
+        own partial unique index, guarded the identical way -- the loser
+        re-reads and updates the winner's row, which is by construction the
+        row this call wanted: same session, same year, same scenario, same
+        unit.
         """
         session_pb_id = await self._resolve_session_pb_id(request.year, request.session_cm_id)
 
@@ -251,7 +281,12 @@ class LodgingWriteService:
         if request.state is None:
             if existing is None:
                 return LodgingWriteResponse(deleted=False)
-            await self.repository.delete_availability(str(existing.id))
+            try:
+                await self.repository.delete_availability(str(existing.id))
+            except ClientResponseError as exc:
+                if exc.status == 404:
+                    return LodgingWriteResponse(deleted=False)
+                raise pb_error_to_http(exc) from exc
             return LodgingWriteResponse(record_id=str(existing.id), deleted=True)
 
         data: dict[str, Any] = {
@@ -266,5 +301,13 @@ class LodgingWriteService:
         if existing is not None:
             record = await self.repository.update_availability(str(existing.id), data)
         else:
-            record = await self.repository.create_availability(data)
+            try:
+                record = await self.repository.create_availability(data)
+            except ClientResponseError as exc:
+                raced = await self.repository.find_availability_override(
+                    request.year, session_pb_id, request.scenario, request.unit_id
+                )
+                if raced is None:
+                    raise pb_error_to_http(exc) from exc
+                record = await self.repository.update_availability(str(raced.id), data)
         return LodgingWriteResponse(record_id=str(getattr(record, "id", "")))

--- a/tests/unit/api/routers/test_lodging_endpoints.py
+++ b/tests/unit/api/routers/test_lodging_endpoints.py
@@ -677,6 +677,11 @@ class TestPlacementWrites:
 
         assert response.status_code == 200, response.text
         assert response.json()["deleted"] is False
+        # The id IS known here -- the find above returned it -- so it is
+        # reported, exactly as delete_merge's own 404 branch reports the id it
+        # was handed. Only the row-never-existed case has no id to give, and
+        # that case must stay distinguishable from this one.
+        assert response.json()["record_id"] == "draft_1"
 
     def test_a_placement_delete_failure_that_is_not_a_race_still_errors(self, mock_pb: MagicMock) -> None:
         """Only "already gone" is swallowed. A 403 or a 500 from PocketBase is
@@ -823,6 +828,85 @@ class TestPlacementWrites:
 
         assert response.status_code == 400
         mock_pb.collection.return_value.update.assert_not_called()
+
+    def test_a_failed_re_read_after_a_lost_placement_race_keeps_its_status(self, mock_pb: MagicMock) -> None:
+        """The recovery races too.
+
+        The create loses the race, and then the re-read that decides whether it
+        raced fails on its own -- PocketBase refuses it, or goes down between
+        the two calls. That call is inside the except block, so leaving it
+        unwrapped puts a bare ClientResponseError into the catch-all handler in
+        api/main.py: a 500, which is the precise outcome this whole guard
+        exists to remove. The retry's own failures go through pb_error_to_http
+        exactly as the create's do.
+        """
+        reads: list[list[Any]] = [[]]
+
+        def staged(**kwargs: Any) -> list[Any]:
+            query_filter = kwargs.get("query_params", {}).get("filter", "")
+            if "cm_id = 1000001" in query_filter:
+                return _session_lookup(**kwargs)
+            if reads:
+                return reads.pop(0)
+            raise ClientResponseError("forbidden", status=403, data={}, url="", is_abort=False, original_error=None)
+
+        with patch("api.routers.lodging.pb", mock_pb):
+            client = _write_client(_manage_user(), mock_pb)
+            mock_pb.collection.return_value.get_full_list.side_effect = staged
+            mock_pb.collection.return_value.create.side_effect = ClientResponseError(
+                "unique constraint", status=400, data={}, url="", is_abort=False, original_error=None
+            )
+            response = client.post(
+                "/api/lodging/placements",
+                json={
+                    "year": 2026,
+                    "session_cm_id": 1000001,
+                    "scenario": "scn_1",
+                    "household_cm_id": 2000001,
+                    "unit_id": "u1",
+                },
+            )
+
+        # Pinned, not `>= 400`: a 500 would also satisfy that, and a 500 is the
+        # exact thing this guard rules out.
+        assert response.status_code == 403
+
+    def test_a_failed_update_after_a_lost_placement_race_keeps_its_status(self, mock_pb: MagicMock) -> None:
+        """The winner's row is found, then the update onto it fails.
+
+        The narrowest window of the three: the create lost, the re-read found
+        the winner's row, and the update failed anyway -- the winner deleted it
+        again, or PocketBase refused. Unwrapped that is the same bare 500.
+        """
+        reads: list[list[Any]] = [[], [_rec(id="draft_raced")]]
+
+        def staged(**kwargs: Any) -> list[Any]:
+            query_filter = kwargs.get("query_params", {}).get("filter", "")
+            if "cm_id = 1000001" in query_filter:
+                return _session_lookup(**kwargs)
+            return reads.pop(0) if reads else []
+
+        with patch("api.routers.lodging.pb", mock_pb):
+            client = _write_client(_manage_user(), mock_pb)
+            mock_pb.collection.return_value.get_full_list.side_effect = staged
+            mock_pb.collection.return_value.create.side_effect = ClientResponseError(
+                "unique constraint", status=400, data={}, url="", is_abort=False, original_error=None
+            )
+            mock_pb.collection.return_value.update.side_effect = ClientResponseError(
+                "forbidden", status=403, data={}, url="", is_abort=False, original_error=None
+            )
+            response = client.post(
+                "/api/lodging/placements",
+                json={
+                    "year": 2026,
+                    "session_cm_id": 1000001,
+                    "scenario": "scn_1",
+                    "household_cm_id": 2000001,
+                    "unit_id": "u1",
+                },
+            )
+
+        assert response.status_code == 403
 
     def test_an_unknown_weekend_is_404_not_500(self, mock_pb: MagicMock) -> None:
         with patch("api.routers.lodging.pb", mock_pb):
@@ -1079,6 +1163,9 @@ class TestAvailabilityWrites:
 
         assert response.status_code == 200, response.text
         assert response.json()["deleted"] is False
+        # Same as the placement clear above: the find returned the id, so the
+        # response carries it rather than reading like the no-row case.
+        assert response.json()["record_id"] == "avail_1"
 
     def test_an_availability_delete_failure_that_is_not_a_race_still_errors(self, mock_pb: MagicMock) -> None:
         """Only "already gone" is swallowed. A 403 or a 500 from PocketBase is
@@ -1178,3 +1265,75 @@ class TestAvailabilityWrites:
 
         assert response.status_code == 400
         mock_pb.collection.return_value.update.assert_not_called()
+
+    def test_a_failed_re_read_after_a_lost_availability_race_keeps_its_status(self, mock_pb: MagicMock) -> None:
+        """The recovery races too, exactly as the placement upsert's does.
+
+        The create loses to `idx_lodging_avail_unique`, then the re-read that
+        decides whether it raced fails on its own. That call lives inside the
+        except block, so unwrapped it is a bare ClientResponseError into the
+        catch-all handler in api/main.py -- a 500, the outcome this guard is
+        for.
+        """
+        reads: list[list[Any]] = [[]]
+
+        def staged(**kwargs: Any) -> list[Any]:
+            query_filter = kwargs.get("query_params", {}).get("filter", "")
+            if "cm_id = 1000001" in query_filter:
+                return _session_lookup(**kwargs)
+            if reads:
+                return reads.pop(0)
+            raise ClientResponseError("forbidden", status=403, data={}, url="", is_abort=False, original_error=None)
+
+        with patch("api.routers.lodging.pb", mock_pb):
+            client = _write_client(_manage_user(), mock_pb)
+            mock_pb.collection.return_value.get_full_list.side_effect = staged
+            mock_pb.collection.return_value.create.side_effect = ClientResponseError(
+                "unique constraint", status=400, data={}, url="", is_abort=False, original_error=None
+            )
+            response = client.put(
+                "/api/lodging/availability",
+                json={
+                    "year": 2026,
+                    "session_cm_id": 1000001,
+                    "scenario": "scn_1",
+                    "unit_id": "u1",
+                    "state": "reserved_staff",
+                },
+            )
+
+        # Pinned, not `>= 400`: a 500 would also satisfy that, and a 500 is the
+        # exact thing this guard rules out.
+        assert response.status_code == 403
+
+    def test_a_failed_update_after_a_lost_availability_race_keeps_its_status(self, mock_pb: MagicMock) -> None:
+        """The winner's override is found, then the update onto it fails."""
+        reads: list[list[Any]] = [[], [_rec(id="avail_raced")]]
+
+        def staged(**kwargs: Any) -> list[Any]:
+            query_filter = kwargs.get("query_params", {}).get("filter", "")
+            if "cm_id = 1000001" in query_filter:
+                return _session_lookup(**kwargs)
+            return reads.pop(0) if reads else []
+
+        with patch("api.routers.lodging.pb", mock_pb):
+            client = _write_client(_manage_user(), mock_pb)
+            mock_pb.collection.return_value.get_full_list.side_effect = staged
+            mock_pb.collection.return_value.create.side_effect = ClientResponseError(
+                "unique constraint", status=400, data={}, url="", is_abort=False, original_error=None
+            )
+            mock_pb.collection.return_value.update.side_effect = ClientResponseError(
+                "forbidden", status=403, data={}, url="", is_abort=False, original_error=None
+            )
+            response = client.put(
+                "/api/lodging/availability",
+                json={
+                    "year": 2026,
+                    "session_cm_id": 1000001,
+                    "scenario": "scn_1",
+                    "unit_id": "u1",
+                    "state": "reserved_staff",
+                },
+            )
+
+        assert response.status_code == 403

--- a/tests/unit/api/routers/test_lodging_endpoints.py
+++ b/tests/unit/api/routers/test_lodging_endpoints.py
@@ -640,6 +640,75 @@ class TestPlacementWrites:
         assert response.status_code == 200
         mock_pb.collection.return_value.delete.assert_called_once_with("draft_1")
 
+    def test_a_placement_delete_race_is_not_an_error(self, mock_pb: MagicMock) -> None:
+        """The row is found, then vanishes before the delete lands.
+
+        Two staff clearing the same placement, or a double-click: the find
+        above sees the row, but by the time the delete reaches PocketBase
+        another caller has already removed it and PB answers 404. Left alone
+        that is a bare ClientResponseError into the catch-all handler in
+        api/main.py -- a 500 for a clear the board is entitled to make. This
+        is idempotent for the same reason the no-row case already is: a 404
+        here means the same thing "the row was never there" does.
+        """
+
+        def reads(**kwargs: Any) -> list[Any]:
+            query_filter = kwargs.get("query_params", {}).get("filter", "")
+            if 'scenario = "scn_1"' in query_filter:
+                return [_rec(id="draft_1")]
+            return _session_lookup(**kwargs)
+
+        with patch("api.routers.lodging.pb", mock_pb):
+            client = _write_client(_manage_user(), mock_pb)
+            mock_pb.collection.return_value.get_full_list.side_effect = reads
+            mock_pb.collection.return_value.delete.side_effect = ClientResponseError(
+                "not found", status=404, data={}, url="", is_abort=False, original_error=None
+            )
+            response = client.request(
+                "DELETE",
+                "/api/lodging/placements",
+                json={
+                    "year": 2026,
+                    "session_cm_id": 1000001,
+                    "scenario": "scn_1",
+                    "household_cm_id": 2000001,
+                },
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["deleted"] is False
+
+    def test_a_placement_delete_failure_that_is_not_a_race_still_errors(self, mock_pb: MagicMock) -> None:
+        """Only "already gone" is swallowed. A 403 or a 500 from PocketBase is
+        a real failure and must not be reported to the board as a clean no-op."""
+
+        def reads(**kwargs: Any) -> list[Any]:
+            query_filter = kwargs.get("query_params", {}).get("filter", "")
+            if 'scenario = "scn_1"' in query_filter:
+                return [_rec(id="draft_1")]
+            return _session_lookup(**kwargs)
+
+        with patch("api.routers.lodging.pb", mock_pb):
+            client = _write_client(_manage_user(), mock_pb)
+            mock_pb.collection.return_value.get_full_list.side_effect = reads
+            mock_pb.collection.return_value.delete.side_effect = ClientResponseError(
+                "forbidden", status=403, data={}, url="", is_abort=False, original_error=None
+            )
+            response = client.request(
+                "DELETE",
+                "/api/lodging/placements",
+                json={
+                    "year": 2026,
+                    "session_cm_id": 1000001,
+                    "scenario": "scn_1",
+                    "household_cm_id": 2000001,
+                },
+            )
+
+        # Pinned, not `>= 400`: a 500 would also satisfy that, and a 500 is the
+        # precise outcome the idempotency change is supposed to rule out.
+        assert response.status_code == 403
+
     def test_a_write_without_a_scenario_is_refused(self, mock_pb: MagicMock) -> None:
         """No scenario is the read-only CampMinder mirror, for everyone.
 
@@ -973,3 +1042,139 @@ class TestAvailabilityWrites:
 
         assert response.status_code == 200
         mock_pb.collection.return_value.delete.assert_called_once_with("avail_1")
+
+    def test_an_availability_delete_race_is_not_an_error(self, mock_pb: MagicMock) -> None:
+        """The override is found, then vanishes before the delete lands.
+
+        Same race as the placement clear above, on `idx_lodging_avail_unique`
+        instead of the draft's index: the find sees the row, but another
+        caller removes it before this delete reaches PocketBase, which answers
+        404. Left alone that is a bare ClientResponseError into the catch-all
+        handler in api/main.py -- a 500 for a release the board is entitled to
+        make. A 404 here means the same thing the no-row case already does.
+        """
+
+        def reads(**kwargs: Any) -> list[Any]:
+            query_filter = kwargs.get("query_params", {}).get("filter", "")
+            if 'scenario = "scn_1"' in query_filter:
+                return [_rec(id="avail_1")]
+            return _session_lookup(**kwargs)
+
+        with patch("api.routers.lodging.pb", mock_pb):
+            client = _write_client(_manage_user(), mock_pb)
+            mock_pb.collection.return_value.get_full_list.side_effect = reads
+            mock_pb.collection.return_value.delete.side_effect = ClientResponseError(
+                "not found", status=404, data={}, url="", is_abort=False, original_error=None
+            )
+            response = client.put(
+                "/api/lodging/availability",
+                json={
+                    "year": 2026,
+                    "session_cm_id": 1000001,
+                    "scenario": "scn_1",
+                    "unit_id": "u1",
+                    "state": None,
+                },
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["deleted"] is False
+
+    def test_an_availability_delete_failure_that_is_not_a_race_still_errors(self, mock_pb: MagicMock) -> None:
+        """Only "already gone" is swallowed. A 403 or a 500 from PocketBase is
+        a real failure and must not be reported to the board as a clean no-op."""
+
+        def reads(**kwargs: Any) -> list[Any]:
+            query_filter = kwargs.get("query_params", {}).get("filter", "")
+            if 'scenario = "scn_1"' in query_filter:
+                return [_rec(id="avail_1")]
+            return _session_lookup(**kwargs)
+
+        with patch("api.routers.lodging.pb", mock_pb):
+            client = _write_client(_manage_user(), mock_pb)
+            mock_pb.collection.return_value.get_full_list.side_effect = reads
+            mock_pb.collection.return_value.delete.side_effect = ClientResponseError(
+                "forbidden", status=403, data={}, url="", is_abort=False, original_error=None
+            )
+            response = client.put(
+                "/api/lodging/availability",
+                json={
+                    "year": 2026,
+                    "session_cm_id": 1000001,
+                    "scenario": "scn_1",
+                    "unit_id": "u1",
+                    "state": None,
+                },
+            )
+
+        # Pinned, not `>= 400`: a 500 would also satisfy that, and a 500 is the
+        # precise outcome the idempotency change is supposed to rule out.
+        assert response.status_code == 403
+
+    def test_losing_the_availability_upsert_race_updates_instead_of_500ing(self, mock_pb: MagicMock) -> None:
+        """Two staff reserving the same unit in one scenario at the same
+        moment.
+
+        `idx_lodging_avail_unique` is UNIQUE on (session, year, scenario,
+        unit) -- exactly the race `place_party` already guards on the draft's
+        own partial unique index. Both staff find no override, both create,
+        and the index rejects the loser. Left alone that is a bare
+        ClientResponseError into the catch-all handler in api/main.py -- a 500
+        for a reservation the board is entitled to make. The row the winner
+        just wrote is exactly what this call wanted to write, so the loser
+        adopts it and updates.
+        """
+        reads: list[list[Any]] = [[], [_rec(id="avail_raced")]]
+
+        def staged(**kwargs: Any) -> list[Any]:
+            query_filter = kwargs.get("query_params", {}).get("filter", "")
+            if "cm_id = 1000001" in query_filter:
+                return _session_lookup(**kwargs)
+            return reads.pop(0) if reads else []
+
+        with patch("api.routers.lodging.pb", mock_pb):
+            client = _write_client(_manage_user(), mock_pb)
+            mock_pb.collection.return_value.get_full_list.side_effect = staged
+            mock_pb.collection.return_value.create.side_effect = ClientResponseError(
+                "unique constraint", status=400, data={}, url="", is_abort=False, original_error=None
+            )
+            response = client.put(
+                "/api/lodging/availability",
+                json={
+                    "year": 2026,
+                    "session_cm_id": 1000001,
+                    "scenario": "scn_1",
+                    "unit_id": "u1",
+                    "state": "reserved_staff",
+                },
+            )
+
+        assert response.status_code == 200, response.text
+        mock_pb.collection.return_value.update.assert_called_once()
+        assert mock_pb.collection.return_value.update.call_args[0][0] == "avail_raced"
+
+    def test_an_availability_create_failure_that_is_not_a_race_still_errors(self, mock_pb: MagicMock) -> None:
+        """The retry is for a lost race, not a blanket swallow.
+
+        If the re-read still finds no row, the create failed for some other
+        reason and the caller must hear about it with the upstream status
+        rather than a 200 reporting a reservation that does not exist.
+        """
+        with patch("api.routers.lodging.pb", mock_pb):
+            client = _write_client(_manage_user(), mock_pb)
+            mock_pb.collection.return_value.create.side_effect = ClientResponseError(
+                "boom", status=400, data={}, url="", is_abort=False, original_error=None
+            )
+            response = client.put(
+                "/api/lodging/availability",
+                json={
+                    "year": 2026,
+                    "session_cm_id": 1000001,
+                    "scenario": "scn_1",
+                    "unit_id": "u1",
+                    "state": "reserved_staff",
+                },
+            )
+
+        assert response.status_code == 400
+        mock_pb.collection.return_value.update.assert_not_called()


### PR DESCRIPTION
## Summary
`api/services/lodging_write_service.py` has five write paths. `place_party`'s create and `delete_merge` are already race-hardened; three others were not, and each turned a legitimate staff write into a bare 500 via the catch-all exception handler:

- `clear_placement`'s delete — row deleted between find and delete
- `set_availability`'s delete — row deleted between find and delete
- `set_availability`'s create — races `idx_lodging_avail_unique` (UNIQUE on session/year/scenario/unit), the exact same shape `place_party`'s create already guards against on the draft table's own partial unique index

This copies the two existing shapes rather than inventing a third:
- The two deletes now swallow only a 404 raised between the find and the delete, matching `delete_merge`'s idempotency — any other status still surfaces through `pb_error_to_http`.
- `set_availability`'s create now retries as an update when it loses the race against the unique index, matching `place_party`'s upsert-race handling exactly.

## Test plan
- [x] Added 6 failing tests first (`tests/unit/api/routers/test_lodging_endpoints.py`), confirmed each failed with a bare unguarded `ClientResponseError` before implementing
- [x] `uv run pytest tests/unit/api/ -q` — 1813 passed
- [x] `uv run mypy . --explicit-package-bases` — no issues found in 794 source files
- [x] `uv run ruff format api tests && uv run ruff check api tests` — all checks passed
- [x] Full pre-push suite (5814 tests) passed via lefthook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple requests modify or remove lodging placement and availability data simultaneously.
  * Repeated deletion requests now complete safely when the item has already been removed.
  * Concurrent availability updates now resolve consistently instead of creating conflicting records.
  * Errors unrelated to concurrency continue to be reported correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->