### PR TITLE
feat(frontend): legend and highlight controls on the lodging map

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -622,8 +622,10 @@ function App() {
                                 </ErrorBoundary>
                               }
                             />
+                            {/* `:view?` is optional so existing links to a bare
+                                /weekend/session/:id still open, on the roster. */}
                             <Route
-                              path="session/:sessionCmId"
+                              path="session/:sessionCmId/:view?"
                               element={
                                 <ErrorBoundary>
                                   <Suspense fallback={<PageSkeleton />}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -624,9 +624,11 @@ function App() {
                             />
                             {/* `:sessionRef` is a readable slug (fc1, ww, mw) or
                                 a CampMinder id; `:view?` is optional so a bare
-                                weekend link opens on the roster. Declared AFTER
-                                the static children above, which therefore keep
-                                winning the match. */}
+                                weekend link opens on the roster. The static
+                                children keep winning the match by RANKING, not
+                                by order — React Router scores a literal segment
+                                above a `:param` one, so moving this route makes
+                                no difference either way. */}
                             <Route
                               path=":sessionRef/:view?"
                               element={

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -622,10 +622,13 @@ function App() {
                                 </ErrorBoundary>
                               }
                             />
-                            {/* `:view?` is optional so existing links to a bare
-                                /weekend/session/:id still open, on the roster. */}
+                            {/* `:sessionRef` is a readable slug (fc1, ww, mw) or
+                                a CampMinder id; `:view?` is optional so a bare
+                                weekend link opens on the roster. Declared AFTER
+                                the static children above, which therefore keep
+                                winning the match. */}
                             <Route
-                              path="session/:sessionCmId/:view?"
+                              path=":sessionRef/:view?"
                               element={
                                 <ErrorBoundary>
                                   <Suspense fallback={<PageSkeleton />}>

--- a/frontend/src/components/weekend/LodgingMap.test.tsx
+++ b/frontend/src/components/weekend/LodgingMap.test.tsx
@@ -553,6 +553,17 @@ describe('LodgingMap legend', () => {
     expect(legend).toHaveTextContent(/capacity unknown/i)
   })
 
+  it('says what colour and mark size encode, not only shape', () => {
+    // Shape and the blue dot were keyed; hue and size were not. Hue drives the
+    // fill, the border, the shared ring AND the area tint, and a cluster's mark
+    // grows with what is under it — five of the seven channels are colour or
+    // size, so keying only the shapes explains the smaller half of the mark.
+    render(<LodgingMap parties={[]} units={UNITS} year={2026} />)
+    const legend = screen.getByTestId('map-legend')
+    expect(legend).toHaveTextContent(/area colour/i)
+    expect(legend).toHaveTextContent(/bigger mark, more rooms/i)
+  })
+
   it('counts the containers it deliberately did not draw', () => {
     // The 408-vs-389 double count lives in the PR body and nowhere the user can
     // see it. A room count alone reads as "19 rooms are missing".

--- a/frontend/src/components/weekend/LodgingMap.test.tsx
+++ b/frontend/src/components/weekend/LodgingMap.test.tsx
@@ -522,3 +522,125 @@ describe('LodgingMap', () => {
     expect(top).toBeLessThan(980)
   })
 })
+
+/**
+ * The legend and the highlight controls, as approved in the mockup.
+ *
+ * The mark carries seven encoding channels and no text. Without a key, the blue
+ * dot answering "is this family beside a bathhouse" — one of the two questions
+ * the surface exists for — is an unexplained dot.
+ */
+describe('LodgingMap legend', () => {
+  it('says what each mark channel means', () => {
+    render(<LodgingMap parties={[]} units={UNITS} year={2026} />)
+    const legend = screen.getByTestId('map-legend')
+    expect(legend).toHaveTextContent(/empty/i)
+    expect(legend).toHaveTextContent(/one party/i)
+    expect(legend).toHaveTextContent(/shared/i)
+    expect(legend).toHaveTextContent(/staff-default/i)
+    expect(legend).toHaveTextContent(/near bathhouse/i)
+    expect(legend).toHaveTextContent(/capacity unknown/i)
+  })
+
+  it('counts the containers it deliberately did not draw', () => {
+    // The 408-vs-389 double count lives in the PR body and nowhere the user can
+    // see it. A room count alone reads as "19 rooms are missing".
+    const withContainer = [
+      ...UNITS,
+      unit({ unit_id: 'u3', code: 'cedar-house', name: 'Cedar House', is_container: true }),
+    ]
+    render(<LodgingMap parties={[]} units={withContainer} year={2026} />)
+    const legend = screen.getByTestId('map-legend')
+    expect(legend).toHaveTextContent(/2 rooms/)
+    expect(legend).toHaveTextContent(/1 container not drawn/)
+  })
+
+  it('counts only the multi-room blobs as clusters, not every lone mark', () => {
+    // Two rooms on the same coordinate are one blob until you zoom in, and the
+    // count is the only thing that says the other room is under there.
+    // THE THIRD ROOM IS THE TEST: with only the stacked pair, "clusters" and
+    // "clusters with more than one member" are both 1 and the assertion cannot
+    // tell a correct count from a count of every mark on the map.
+    const stacked = [
+      unit({ unit_id: 'u1', code: 'a', name: 'A', map_x: 0.5, map_y: 0.5 }),
+      unit({ unit_id: 'u2', code: 'b', name: 'B', map_x: 0.5, map_y: 0.5 }),
+      unit({ unit_id: 'u3', code: 'c', name: 'C', map_x: 0.1, map_y: 0.9 }),
+    ]
+    render(<LodgingMap parties={[]} units={stacked} year={2026} />)
+    expect(screen.getByTestId('map-legend')).toHaveTextContent(/1 cluster at this zoom/)
+  })
+})
+
+describe('LodgingMap highlight controls', () => {
+  const BATH = unit({ unit_id: 'u1', code: 'cedar-1', name: 'Cedar 1', near_bathhouse: true })
+  const STAFF = unit({
+    unit_id: 'u2',
+    code: 'cedar-2',
+    name: 'Cedar 2',
+    map_x: 0.7,
+    map_y: 0.2,
+    allocation_default: 'staff_default',
+  })
+
+  it('draws empty rooms by default', () => {
+    render(<LodgingMap parties={[PLACED]} units={UNITS} year={2026} />)
+    expect(screen.getAllByTestId('map-mark')).toHaveLength(2)
+  })
+
+  it('hides empty rooms when the empty-rooms toggle is cleared', async () => {
+    render(<LodgingMap parties={[PLACED]} units={UNITS} year={2026} />)
+    await userEvent.click(screen.getByLabelText('Empty rooms'))
+    const marks = screen.getAllByTestId('map-mark')
+    expect(marks).toHaveLength(1)
+    expect(marks[0]).toHaveAttribute('title', expect.stringContaining('Cedar 1'))
+  })
+
+  it('dims the rooms with no bathhouse when near-bathhouse highlighting is on', async () => {
+    render(<LodgingMap parties={[]} units={[BATH, STAFF]} year={2026} />)
+    await userEvent.click(screen.getByLabelText('Near-bathhouse'))
+    expect(screen.getByTitle(/Cedar 1/)).toHaveStyle({ opacity: '1' })
+    expect(screen.getByTitle(/Cedar 2/)).toHaveStyle({ opacity: '0.22' })
+  })
+
+  it('dims the rooms with no staff cabin when staff highlighting is on', async () => {
+    render(<LodgingMap parties={[]} units={[BATH, STAFF]} year={2026} />)
+    await userEvent.click(screen.getByLabelText('Staff cabins'))
+    expect(screen.getByTitle(/Cedar 2/)).toHaveStyle({ opacity: '1' })
+    expect(screen.getByTitle(/Cedar 1/)).toHaveStyle({ opacity: '0.22' })
+  })
+
+  it('leaves every mark at full strength when no highlight is on', () => {
+    render(<LodgingMap parties={[]} units={[BATH, STAFF]} year={2026} />)
+    expect(screen.getByTitle(/Cedar 1/)).toHaveStyle({ opacity: '1' })
+    expect(screen.getByTitle(/Cedar 2/)).toHaveStyle({ opacity: '1' })
+  })
+
+  it('tints areas only once the area tint is switched on', async () => {
+    // Off by default: the background labels its own areas, and a tint over an
+    // illustration fights it. On demand it answers "where does this area end".
+    render(<LodgingMap parties={[]} units={UNITS} year={2026} />)
+    expect(screen.queryAllByTestId('map-area-tint')).toHaveLength(0)
+    await userEvent.click(screen.getByLabelText('Area tint'))
+    expect(screen.getAllByTestId('map-area-tint')).toHaveLength(1)
+  })
+
+  it('shows the fade percentage and follows the slider', () => {
+    // Asserting only the initial 25% would pass against a hardcoded string.
+    render(<LodgingMap parties={[]} units={UNITS} year={2026} />)
+    expect(screen.getByTestId('map-fade-value')).toHaveTextContent('25%')
+    fireEvent.change(screen.getByLabelText(/fade map/i), { target: { value: '60' } })
+    expect(screen.getByTestId('map-fade-value')).toHaveTextContent('60%')
+  })
+
+  it('says how to zoom, pan and open a pin', () => {
+    // Wheel-zoom and drag-pan have no affordance of their own. Without this
+    // line the map reads as a static picture.
+    render(<LodgingMap parties={[]} units={UNITS} year={2026} />)
+    expect(screen.getByText(/scroll to zoom/i)).toBeInTheDocument()
+  })
+
+  it('labels the fit control in words, not only for screen readers', () => {
+    render(<LodgingMap parties={[]} units={UNITS} year={2026} />)
+    expect(screen.getByRole('button', { name: /fit all/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/weekend/LodgingMap.test.tsx
+++ b/frontend/src/components/weekend/LodgingMap.test.tsx
@@ -166,6 +166,17 @@ describe('LodgingMap', () => {
     expect(screen.getByText('Cedar 1')).toBeInTheDocument()
   })
 
+  it('puts the unplaced rail on the same side as the board puts it', () => {
+    // LodgingBoard renders `lg:grid-cols-[240px_minmax(0,1fr)]` with the rail
+    // first. The map had it last, so switching tabs threw the rail across the
+    // screen and the unplaced list moved out from under the cursor.
+    render(<LodgingMap parties={[]} units={UNITS} year={2026} />)
+    const rail = screen.getByTestId('map-unplaced-rail')
+    const canvas = screen.getByTestId('map-canvas')
+    // DOCUMENT_POSITION_FOLLOWING: the canvas comes after the rail.
+    expect(rail.compareDocumentPosition(canvas) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
   it('lists an unplaced party on the unplaced rail', () => {
     render(<LodgingMap parties={[party({ display_name: 'Silva' })]} units={UNITS} year={2026} />)
     // Scoped to the rail, matching the off-map assertion below. An unscoped
@@ -597,14 +608,14 @@ describe('LodgingMap highlight controls', () => {
 
   it('dims the rooms with no bathhouse when near-bathhouse highlighting is on', async () => {
     render(<LodgingMap parties={[]} units={[BATH, STAFF]} year={2026} />)
-    await userEvent.click(screen.getByLabelText('Near-bathhouse'))
+    await userEvent.click(screen.getByRole('radio', { name: 'Near bathhouse' }))
     expect(screen.getByTitle(/Cedar 1/)).toHaveStyle({ opacity: '1' })
     expect(screen.getByTitle(/Cedar 2/)).toHaveStyle({ opacity: '0.22' })
   })
 
   it('dims the rooms with no staff cabin when staff highlighting is on', async () => {
     render(<LodgingMap parties={[]} units={[BATH, STAFF]} year={2026} />)
-    await userEvent.click(screen.getByLabelText('Staff cabins'))
+    await userEvent.click(screen.getByRole('radio', { name: 'Staff cabins' }))
     expect(screen.getByTitle(/Cedar 2/)).toHaveStyle({ opacity: '1' })
     expect(screen.getByTitle(/Cedar 1/)).toHaveStyle({ opacity: '0.22' })
   })
@@ -613,6 +624,40 @@ describe('LodgingMap highlight controls', () => {
     render(<LodgingMap parties={[]} units={[BATH, STAFF]} year={2026} />)
     expect(screen.getByTitle(/Cedar 1/)).toHaveStyle({ opacity: '1' })
     expect(screen.getByTitle(/Cedar 2/)).toHaveStyle({ opacity: '1' })
+  })
+
+  it('lets one highlight replace the other rather than competing with it', async () => {
+    // As two checkboxes these ANDed, so ticking both dimmed nearly everything
+    // and read as a filter that had eaten the map. They answer two different
+    // questions about the same marks; only one can be asked at a time.
+    render(<LodgingMap parties={[]} units={[BATH, STAFF]} year={2026} />)
+    await userEvent.click(screen.getByRole('radio', { name: 'Near bathhouse' }))
+    await userEvent.click(screen.getByRole('radio', { name: 'Staff cabins' }))
+
+    expect(screen.getByRole('radio', { name: 'Near bathhouse' })).not.toBeChecked()
+    // The staff answer, whole — not the empty intersection of both questions.
+    expect(screen.getByTitle(/Cedar 2/)).toHaveStyle({ opacity: '1' })
+  })
+
+  it('turns every highlight off again', async () => {
+    render(<LodgingMap parties={[]} units={[BATH, STAFF]} year={2026} />)
+    await userEvent.click(screen.getByRole('radio', { name: 'Staff cabins' }))
+    await userEvent.click(screen.getByRole('radio', { name: 'No highlight' }))
+    expect(screen.getByTitle(/Cedar 1/)).toHaveStyle({ opacity: '1' })
+    expect(screen.getByTitle(/Cedar 2/)).toHaveStyle({ opacity: '1' })
+  })
+
+  it('keeps area tint and empty rooms independent of the highlight', async () => {
+    // These two do not compete with anything: one is a backdrop, the other
+    // changes which rooms exist on the map at all.
+    render(<LodgingMap parties={[PLACED]} units={UNITS} year={2026} />)
+    await userEvent.click(screen.getByRole('radio', { name: 'Near bathhouse' }))
+    await userEvent.click(screen.getByLabelText('Area tint'))
+    await userEvent.click(screen.getByLabelText('Empty rooms'))
+
+    expect(screen.getByRole('radio', { name: 'Near bathhouse' })).toBeChecked()
+    expect(screen.getByLabelText('Area tint')).toBeChecked()
+    expect(screen.getAllByTestId('map-mark')).toHaveLength(1)
   })
 
   it('tints areas only once the area tint is switched on', async () => {

--- a/frontend/src/components/weekend/LodgingMap.tsx
+++ b/frontend/src/components/weekend/LodgingMap.tsx
@@ -332,11 +332,21 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
   // Counted off what was actually drawn, never off a second predicate — a
   // legend that disagrees with the map is worse than no legend.
   const clusterCount = clusters.filter((cluster) => cluster.members.length > 1).length
-  // Rooms the payload HAS, not rooms currently shown: this number's job is to
-  // account for the units, and a count that moved when you hid the empties
-  // would stop reconciling against the Inventory tab.
+  // Rooms the payload HAS, not rooms currently shown: a count that moved when
+  // you hid the empties would stop accounting for the units at all.
+  //
+  // NOT the Inventory tab's number, and deliberately so — `countMapUnits`'
+  // docstring says why: Inventory counts every unit, this counts the POSITIONED
+  // bookable ones. The remainder is not silently dropped; containers are the
+  // next figure along, and unpositioned rooms have their own line above the
+  // map. Three numbers, because they answer three questions.
   const roomCount = model.units.length
   const containerCount = units.filter((unit) => unit.is_container).length
+  // The hues actually on this map, never a fixed palette: a swatch that did
+  // not match what the marks are wearing would be a second source of truth for
+  // the registry's colours. Capped so a lineup with many areas does not turn
+  // the key into a colour chart.
+  const legendHues = [...new Set(model.units.map((mapUnit) => mapUnit.hue))].slice(0, 4)
 
   // SORTED: cluster membership is order-invariant but the member ARRAY order is
   // not, and an unsorted key would change identity across renders, remounting
@@ -496,9 +506,10 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
 
             <span aria-hidden="true" className="bg-border mx-1 h-5 w-px" />
 
-            {/* Real checkboxes, and the only keyboard-reachable controls on this
-                surface. The marks cannot be — see the note at the top of the
-                file — so these must not be re-invented as divs. */}
+            {/* Real checkboxes. These and the radios below are the whole of
+                what a keyboard can reach here — the marks cannot be, see the
+                note at the top of the file — so neither may be re-invented as
+                divs. */}
             <label className="text-muted-foreground inline-flex cursor-pointer items-center gap-1.5">
               <input
                 type="checkbox"
@@ -924,6 +935,37 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
               <span className="text-foreground font-bold">?</span>
               <dt className="sr-only">Question mark</dt>
               <dd>capacity unknown (never 0)</dd>
+            </div>
+            {/* Hue is the channel with the widest reach — fill, border, shared
+                ring and the area tint all take it — and it was the one thing
+                on the mark with no key at all. The swatches are the registry's
+                own colours, so this stays generic however the areas are named
+                and never spells one out. */}
+            <div className="flex items-center gap-1.5">
+              <span aria-hidden="true" className="flex items-center gap-0.5">
+                {legendHues.map((legendHue) => (
+                  <span
+                    key={legendHue}
+                    style={{ backgroundColor: legendHue }}
+                    className="h-3 w-3 rounded-full"
+                  />
+                ))}
+              </span>
+              <dt className="sr-only">Mark colour</dt>
+              <dd>area colour</dd>
+            </div>
+            {/* A cluster's mark GROWS with what is under it and wears the
+                count on its face. Without this, a big numbered mark reads as
+                importance rather than as "there are more of them here". */}
+            <div className="flex items-center gap-1.5">
+              <span
+                aria-hidden="true"
+                className="bg-muted-foreground/70 border-muted-foreground/70 grid h-4 w-4 place-items-center rounded-full border-2 text-[8px] font-bold text-white"
+              >
+                3
+              </span>
+              <dt className="sr-only">Bigger numbered mark</dt>
+              <dd>bigger mark, more rooms under it</dd>
             </div>
             <div className="ml-auto flex items-center gap-1.5">
               <dt className="sr-only">Counts</dt>

--- a/frontend/src/components/weekend/LodgingMap.tsx
+++ b/frontend/src/components/weekend/LodgingMap.tsx
@@ -89,6 +89,21 @@ const DIMMED_OPACITY = 0.22
 /** Breathing room around an area's tint box, in screen pixels. */
 const TINT_PADDING_PX = 20
 
+/**
+ * Which question the marks are answering. At most one at a time.
+ *
+ * Area tint and Empty rooms are NOT in here and stay checkboxes: a tint is a
+ * backdrop and the empty toggle changes which rooms are on the map at all, so
+ * neither competes with a highlight or with the other.
+ */
+type Highlight = 'none' | 'bathhouse' | 'staff'
+
+const HIGHLIGHTS: Array<{ id: Highlight; label: string }> = [
+  { id: 'none', label: 'No highlight' },
+  { id: 'bathhouse', label: 'Near bathhouse' },
+  { id: 'staff', label: 'Staff cabins' },
+]
+
 /** Half of the popover's `max-w-[15rem]` (240px), padded a bit. Clamping the
  *  anchor at least this far from each edge keeps the box on-screen. Height
  *  is content-dependent (a detail card is shorter than a multi-room
@@ -176,13 +191,17 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
   const [size, setSize] = useState({ width: 0, height: 0 })
   const [imageFailed, setImageFailed] = useState(false)
   const [fade, setFade] = useState(DEFAULT_FADE)
-  // Empty rooms are DRAWN by default and the other three are OFF by default:
-  // the map's job at rest is the whole site, and every one of these is a
-  // question you arrive with rather than one the surface should ask for you.
+  // Empty rooms are DRAWN by default and nothing is highlighted at rest: the
+  // map's job when you arrive is the whole site, and each control below is a
+  // question you bring to it rather than one the surface should ask for you.
   const [showEmpty, setShowEmpty] = useState(true)
-  const [highlightBathhouse, setHighlightBathhouse] = useState(false)
-  const [highlightStaff, setHighlightStaff] = useState(false)
   const [areaTint, setAreaTint] = useState(false)
+  // ONE CHOICE, not two booleans. As independent checkboxes these ANDed, so
+  // ticking both dimmed everything that was not near a bathhouse AND beside
+  // staff — an intersection nobody asked for, which read as a filter that had
+  // eaten the map. They are two questions about the same marks, and the
+  // control now says so.
+  const [highlight, setHighlight] = useState<Highlight>('none')
   // TWO keys, not one. A click PINS the peek and a dwell only borrows it, so
   // the pointer leaving a mark must close a dwell-opened peek without
   // touching one the user deliberately pinned. Collapsing them into a single
@@ -361,7 +380,69 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
         )}
       </div>
 
-      <div className="card-lodge grid grid-cols-1 overflow-hidden lg:grid-cols-[minmax(0,1fr)_280px]">
+      <div className="card-lodge grid grid-cols-1 overflow-hidden lg:grid-cols-[280px_minmax(0,1fr)]">
+        <aside className="bg-muted/30 border-border/60 flex flex-col gap-3 border-b p-3 lg:border-r lg:border-b-0">
+          {selected ? (
+            <FamilyDetailsPanel
+              key={partyKey(selected)}
+              party={selected}
+              unit={unitsByCode.get(selected.unit_code ?? '')}
+              year={year}
+              embedded={true}
+              onClose={() => {
+                setSelected(null)
+              }}
+            />
+          ) : (
+            <>
+              <div data-testid="map-unplaced-rail" className="flex flex-col gap-2">
+                <div className="flex items-baseline justify-between gap-2">
+                  <h3 className="font-display text-foreground text-sm font-bold">Unplaced</h3>
+                  <span className="text-muted-foreground text-xs tabular-nums">
+                    {model.unplaced.length}
+                  </span>
+                </div>
+                {model.unplaced.length === 0 ? (
+                  <p className="text-muted-foreground text-xs italic">Everyone has a cabin.</p>
+                ) : (
+                  model.unplaced.map((party) => (
+                    <FamilyCard
+                      key={partyKey(party)}
+                      party={party}
+                      onRail={true}
+                      onOpen={openParty}
+                    />
+                  ))
+                )}
+              </div>
+
+              <div data-testid="map-offmap-rail" className="flex flex-col gap-2">
+                <div className="flex items-baseline justify-between gap-2">
+                  <h3 className="font-display text-foreground text-sm font-bold">
+                    Placed, off the map
+                  </h3>
+                  <span className="text-muted-foreground text-xs tabular-nums">
+                    {model.offMap.length}
+                  </span>
+                </div>
+                {model.offMap.length === 0 ? (
+                  <p className="text-muted-foreground text-xs italic">
+                    Everyone placed is on the map.
+                  </p>
+                ) : (
+                  model.offMap.map((entry) => (
+                    <FamilyCard
+                      key={partyKey(entry.party)}
+                      party={entry.party}
+                      onRail={true}
+                      onOpen={openParty}
+                    />
+                  ))
+                )}
+              </div>
+            </>
+          )}
+        </aside>
         <div className="flex flex-col gap-2 p-3">
           <div className="flex flex-wrap items-center gap-2 text-xs">
             <button
@@ -431,26 +512,6 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
             <label className="text-muted-foreground inline-flex cursor-pointer items-center gap-1.5">
               <input
                 type="checkbox"
-                checked={highlightBathhouse}
-                onChange={(event) => {
-                  setHighlightBathhouse(event.target.checked)
-                }}
-              />
-              Near-bathhouse
-            </label>
-            <label className="text-muted-foreground inline-flex cursor-pointer items-center gap-1.5">
-              <input
-                type="checkbox"
-                checked={highlightStaff}
-                onChange={(event) => {
-                  setHighlightStaff(event.target.checked)
-                }}
-              />
-              Staff cabins
-            </label>
-            <label className="text-muted-foreground inline-flex cursor-pointer items-center gap-1.5">
-              <input
-                type="checkbox"
                 checked={showEmpty}
                 onChange={(event) => {
                   setShowEmpty(event.target.checked)
@@ -461,6 +522,33 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
               />
               Empty rooms
             </label>
+
+            {/* RADIOS, not checkboxes. The control's shape is the explanation:
+                a checkbox promises the options combine, and these cannot —
+                answering both at once leaves an intersection that reads as a
+                filter with a bug in it. */}
+            <fieldset className="contents">
+              <legend className="sr-only">Highlight</legend>
+              <span aria-hidden="true" className="bg-border mx-1 h-5 w-px" />
+              <span className="text-muted-foreground">Highlight</span>
+              {HIGHLIGHTS.map((option) => (
+                <label
+                  key={option.id}
+                  className="text-muted-foreground inline-flex cursor-pointer items-center gap-1.5"
+                >
+                  <input
+                    type="radio"
+                    name="map-highlight"
+                    value={option.id}
+                    checked={highlight === option.id}
+                    onChange={() => {
+                      setHighlight(option.id)
+                    }}
+                  />
+                  {option.label}
+                </label>
+              ))}
+            </fieldset>
 
             <span className="text-muted-foreground ml-auto tabular-nums">{view.k.toFixed(1)}×</span>
           </div>
@@ -659,12 +747,11 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
               const bathhouse = cluster.members.some(
                 (member) => member.item.unit.near_bathhouse === true
               )
-              // Both highlights are ANDed, so turning on two asks "which cabins
-              // are near a bathhouse AND beside staff" rather than lighting up
-              // the union and answering neither. `some`, matching the mark's own
-              // semantics: a cluster containing one bathhouse-adjacent room IS
-              // an answer to where the bathhouses are.
-              const dimmed = (highlightBathhouse && !bathhouse) || (highlightStaff && !anyStaff)
+              // `some`, matching the mark's own semantics: a cluster holding
+              // one bathhouse-adjacent room IS part of the answer to where the
+              // bathhouses are.
+              const dimmed =
+                (highlight === 'bathhouse' && !bathhouse) || (highlight === 'staff' && !anyStaff)
               // A room nobody has measured, findable at a glance. `sleeps: 0`
               // is treated as unknown alongside null — the API maps 0 to None
               // today, but a 0 arriving here must never render as a capacity.
@@ -860,68 +947,6 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
             you want while comparing two families across the site.
             `key` is load-bearing: without it React reuses the instance across
             selections and `useState` initialisers never re-run. */}
-        <aside className="bg-muted/30 border-border/60 flex flex-col gap-3 border-t p-3 lg:border-t-0 lg:border-l">
-          {selected ? (
-            <FamilyDetailsPanel
-              key={partyKey(selected)}
-              party={selected}
-              unit={unitsByCode.get(selected.unit_code ?? '')}
-              year={year}
-              embedded={true}
-              onClose={() => {
-                setSelected(null)
-              }}
-            />
-          ) : (
-            <>
-              <div data-testid="map-unplaced-rail" className="flex flex-col gap-2">
-                <div className="flex items-baseline justify-between gap-2">
-                  <h3 className="font-display text-foreground text-sm font-bold">Unplaced</h3>
-                  <span className="text-muted-foreground text-xs tabular-nums">
-                    {model.unplaced.length}
-                  </span>
-                </div>
-                {model.unplaced.length === 0 ? (
-                  <p className="text-muted-foreground text-xs italic">Everyone has a cabin.</p>
-                ) : (
-                  model.unplaced.map((party) => (
-                    <FamilyCard
-                      key={partyKey(party)}
-                      party={party}
-                      onRail={true}
-                      onOpen={openParty}
-                    />
-                  ))
-                )}
-              </div>
-
-              <div data-testid="map-offmap-rail" className="flex flex-col gap-2">
-                <div className="flex items-baseline justify-between gap-2">
-                  <h3 className="font-display text-foreground text-sm font-bold">
-                    Placed, off the map
-                  </h3>
-                  <span className="text-muted-foreground text-xs tabular-nums">
-                    {model.offMap.length}
-                  </span>
-                </div>
-                {model.offMap.length === 0 ? (
-                  <p className="text-muted-foreground text-xs italic">
-                    Everyone placed is on the map.
-                  </p>
-                ) : (
-                  model.offMap.map((entry) => (
-                    <FamilyCard
-                      key={partyKey(entry.party)}
-                      party={entry.party}
-                      onRail={true}
-                      onOpen={openParty}
-                    />
-                  ))
-                )}
-              </div>
-            </>
-          )}
-        </aside>
       </div>
     </div>
   )

--- a/frontend/src/components/weekend/LodgingMap.tsx
+++ b/frontend/src/components/weekend/LodgingMap.tsx
@@ -38,7 +38,7 @@ import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import { FamilyCard } from './FamilyCard'
 import { FamilyDetailsPanel } from './FamilyDetailsPanel'
 import { indexUnitsByCode } from './rosterAttention'
-import { clusterByProximity, type Cluster } from './mapClustering'
+import { clusterByProximity, type Cluster, type Placed } from './mapClustering'
 import { buildMapModel, type MapUnit } from './mapModel'
 import { CONSENT_AMBER, CONSENT_PHRASE, MapUnitPopover } from './MapUnitPopover'
 import {
@@ -76,6 +76,19 @@ const DWELL_MS = 400
 /** The bathhouse dot. Blue, and not one of the eight area hues. */
 const BATHHOUSE_BLUE = '#2563eb'
 
+/**
+ * A highlight DIMS what does not match rather than hiding it.
+ *
+ * "Which cabins are near a bathhouse" is only half the question — the other
+ * half is where they sit relative to everything else, and removing the rest
+ * throws that away. Low enough to recede, high enough that the dimmed marks
+ * still read as a site plan.
+ */
+const DIMMED_OPACITY = 0.22
+
+/** Breathing room around an area's tint box, in screen pixels. */
+const TINT_PADDING_PX = 20
+
 /** Half of the popover's `max-w-[15rem]` (240px), padded a bit. Clamping the
  *  anchor at least this far from each edge keeps the box on-screen. Height
  *  is content-dependent (a detail card is shorter than a multi-room
@@ -83,6 +96,56 @@ const BATHHOUSE_BLUE = '#2563eb'
  *  better a small unnecessary gap than a clipped popover. */
 const POPOVER_HALF_WIDTH = 130
 const POPOVER_HALF_HEIGHT = 110
+
+interface TintBox {
+  areaName: string
+  hue: string
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+/**
+ * A translucent box around each area's rooms, in SCREEN space so it pans and
+ * zooms with them.
+ *
+ * A bounding box, not a hull: areas genuinely overlap where they abut, and a
+ * box that says "roughly here" is honest about that in a way a tight polygon
+ * would not be. Areas with a single room on screen are skipped — one pin has
+ * no extent to describe.
+ */
+function areaTintBoxes(placed: Array<Placed<MapUnit>>): TintBox[] {
+  const byArea = new Map<string, Array<Placed<MapUnit>>>()
+  for (const entry of placed) {
+    // `area_name` is optional on the generated row type. Rooms without one are
+    // left untinted rather than pooled under a shared blank key, which would
+    // draw one box spanning two rooms that have nothing to do with each other.
+    const areaName = entry.item.unit.area_name
+    if (areaName === undefined || areaName.length === 0) continue
+    const existing = byArea.get(areaName)
+    if (existing) existing.push(entry)
+    else byArea.set(areaName, [entry])
+  }
+
+  const boxes: TintBox[] = []
+  for (const [areaName, members] of byArea) {
+    if (members.length < 2) continue
+    const xs = members.map((member) => member.x)
+    const ys = members.map((member) => member.y)
+    const left = Math.min(...xs)
+    const top = Math.min(...ys)
+    boxes.push({
+      areaName,
+      hue: members[0]?.item.hue ?? '',
+      left: left - TINT_PADDING_PX,
+      top: top - TINT_PADDING_PX,
+      width: Math.max(...xs) - left + TINT_PADDING_PX * 2,
+      height: Math.max(...ys) - top + TINT_PADDING_PX * 2,
+    })
+  }
+  return boxes
+}
 
 export interface LodgingMapProps {
   parties: RosterPartyRow[]
@@ -113,6 +176,13 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
   const [size, setSize] = useState({ width: 0, height: 0 })
   const [imageFailed, setImageFailed] = useState(false)
   const [fade, setFade] = useState(DEFAULT_FADE)
+  // Empty rooms are DRAWN by default and the other three are OFF by default:
+  // the map's job at rest is the whole site, and every one of these is a
+  // question you arrive with rather than one the surface should ask for you.
+  const [showEmpty, setShowEmpty] = useState(true)
+  const [highlightBathhouse, setHighlightBathhouse] = useState(false)
+  const [highlightStaff, setHighlightStaff] = useState(false)
+  const [areaTint, setAreaTint] = useState(false)
   // TWO keys, not one. A click PINS the peek and a dwell only borrows it, so
   // the pointer leaving a mark must close a dwell-opened peek without
   // touching one the user deliberately pinned. Collapsing them into a single
@@ -226,12 +296,28 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
     // reference rather than reattaching on every render.
   }, [closePeek])
 
-  const placed = model.units.map((mapUnit) => {
+  // FILTERED BEFORE CLUSTERING, and that ordering is the point: hiding empty
+  // rooms also dissolves the clusters they were padding, so what is left is a
+  // map of the occupied site rather than the same blobs with holes in them.
+  const drawn = showEmpty
+    ? model.units
+    : model.units.filter((mapUnit) => mapUnit.parties.length > 0)
+  const placed = drawn.map((mapUnit) => {
     const base = basePosition(mapUnit.x, mapUnit.y, width, height)
     const screen = screenPosition(base, view)
     return { item: mapUnit, x: screen.x, y: screen.y }
   })
   const clusters = clusterByProximity(placed)
+  const tintBoxes = areaTint ? areaTintBoxes(placed) : []
+
+  // Counted off what was actually drawn, never off a second predicate — a
+  // legend that disagrees with the map is worse than no legend.
+  const clusterCount = clusters.filter((cluster) => cluster.members.length > 1).length
+  // Rooms the payload HAS, not rooms currently shown: this number's job is to
+  // account for the units, and a count that moved when you hid the empties
+  // would stop reconciling against the Inventory tab.
+  const roomCount = model.units.length
+  const containerCount = units.filter((unit) => unit.is_container).length
 
   // SORTED: cluster membership is order-invariant but the member ARRAY order is
   // not, and an unsorted key would change identity across renders, remounting
@@ -301,10 +387,10 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
             <button
               type="button"
               onClick={resetView}
-              className="border-border text-muted-foreground hover:text-foreground hover:border-primary/50 rounded-lg border p-1.5 transition-colors"
-              aria-label="Fit the whole map"
+              className="border-border text-muted-foreground hover:text-foreground hover:border-primary/50 inline-flex items-center gap-1.5 rounded-lg border px-2 py-1.5 transition-colors"
             >
               <Maximize2 className="h-4 w-4" />
+              Fit all
             </button>
             <label className="text-muted-foreground ml-2 inline-flex items-center gap-1.5">
               Fade map
@@ -319,7 +405,63 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
                 }}
                 className="w-20"
               />
+              <span
+                data-testid="map-fade-value"
+                className="text-foreground font-semibold tabular-nums"
+              >
+                {fade}%
+              </span>
             </label>
+
+            <span aria-hidden="true" className="bg-border mx-1 h-5 w-px" />
+
+            {/* Real checkboxes, and the only keyboard-reachable controls on this
+                surface. The marks cannot be — see the note at the top of the
+                file — so these must not be re-invented as divs. */}
+            <label className="text-muted-foreground inline-flex cursor-pointer items-center gap-1.5">
+              <input
+                type="checkbox"
+                checked={areaTint}
+                onChange={(event) => {
+                  setAreaTint(event.target.checked)
+                }}
+              />
+              Area tint
+            </label>
+            <label className="text-muted-foreground inline-flex cursor-pointer items-center gap-1.5">
+              <input
+                type="checkbox"
+                checked={highlightBathhouse}
+                onChange={(event) => {
+                  setHighlightBathhouse(event.target.checked)
+                }}
+              />
+              Near-bathhouse
+            </label>
+            <label className="text-muted-foreground inline-flex cursor-pointer items-center gap-1.5">
+              <input
+                type="checkbox"
+                checked={highlightStaff}
+                onChange={(event) => {
+                  setHighlightStaff(event.target.checked)
+                }}
+              />
+              Staff cabins
+            </label>
+            <label className="text-muted-foreground inline-flex cursor-pointer items-center gap-1.5">
+              <input
+                type="checkbox"
+                checked={showEmpty}
+                onChange={(event) => {
+                  setShowEmpty(event.target.checked)
+                  // The hidden rooms take their peek with them; leaving it open
+                  // would strand a popover over a mark that no longer exists.
+                  closePeek()
+                }}
+              />
+              Empty rooms
+            </label>
+
             <span className="text-muted-foreground ml-auto tabular-nums">{view.k.toFixed(1)}×</span>
           </div>
 
@@ -454,6 +596,24 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
               </p>
             )}
 
+            {/* UNDER the marks and inert: a tint that could swallow a click
+                would cost the surface its only interaction. */}
+            {tintBoxes.map((box) => (
+              <div
+                key={box.areaName}
+                data-testid="map-area-tint"
+                aria-hidden="true"
+                style={{
+                  left: box.left,
+                  top: box.top,
+                  width: box.width,
+                  height: box.height,
+                  backgroundColor: box.hue,
+                }}
+                className="pointer-events-none absolute rounded-2xl opacity-15"
+              />
+            ))}
+
             {clusters.map((cluster) => {
               const key = clusterKey(cluster)
               const first = cluster.members[0]?.item
@@ -499,6 +659,12 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
               const bathhouse = cluster.members.some(
                 (member) => member.item.unit.near_bathhouse === true
               )
+              // Both highlights are ANDed, so turning on two asks "which cabins
+              // are near a bathhouse AND beside staff" rather than lighting up
+              // the union and answering neither. `some`, matching the mark's own
+              // semantics: a cluster containing one bathhouse-adjacent room IS
+              // an answer to where the bathhouses are.
+              const dimmed = (highlightBathhouse && !bathhouse) || (highlightStaff && !anyStaff)
               // A room nobody has measured, findable at a glance. `sleeps: 0`
               // is treated as unknown alongside null — the API maps 0 to None
               // today, but a 0 arriving here must never render as a capacity.
@@ -551,7 +717,14 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
                     // a pinned one belongs to the user, not to the cursor.
                     setDwellKey((current) => (current === key ? null : current))
                   }}
-                  style={{ left: cluster.x, top: cluster.y }}
+                  style={{
+                    left: cluster.x,
+                    top: cluster.y,
+                    // Set EXPLICITLY at full strength rather than left unstyled,
+                    // so "nothing is dimmed" is an assertable state rather than
+                    // the absence of one.
+                    opacity: dimmed ? DIMMED_OPACITY : 1,
+                  }}
                   className="absolute -translate-x-1/2 -translate-y-1/2 cursor-pointer"
                 >
                   <span
@@ -614,7 +787,69 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
                 />
               </div>
             )}
+
+            {/* Wheel-zoom and drag-pan have no affordance of their own, and a
+                full-bleed illustration reads as a static picture until someone
+                says otherwise. Inert, so it can never eat a drag that starts
+                on top of it. */}
+            <p className="text-muted-foreground bg-card/90 border-border pointer-events-none absolute bottom-2 left-2 rounded-md border px-2 py-1 text-[11px]">
+              scroll to zoom · drag to pan · click a pin for detail
+            </p>
           </div>
+
+          {/* The mark has seven encoding channels and no text of its own. Its
+              `title` says the same things in words, but only one mark at a time
+              and only on hover — which is no help at all to someone scanning
+              for the blue dots. */}
+          <dl
+            data-testid="map-legend"
+            className="text-muted-foreground flex flex-wrap items-center gap-x-4 gap-y-1.5 text-[11px]"
+          >
+            <div className="flex items-center gap-1.5">
+              <span className="border-muted-foreground/70 h-3 w-3 rounded-full border-2 bg-transparent" />
+              <dt className="sr-only">Hollow mark</dt>
+              <dd>empty</dd>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="bg-muted-foreground/70 border-muted-foreground/70 h-3 w-3 rounded-full border-2" />
+              <dt className="sr-only">Solid mark</dt>
+              <dd>one party</dd>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="bg-muted-foreground/70 border-muted-foreground/70 h-3 w-3 rounded-full border-2 ring-2 ring-current ring-offset-1" />
+              <dt className="sr-only">Ringed mark</dt>
+              <dd>shared</dd>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="border-muted-foreground/70 h-3 w-3 rounded-[3px] border-2 border-dashed" />
+              <dt className="sr-only">Dashed square</dt>
+              <dd>staff-default</dd>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span
+                style={{ backgroundColor: BATHHOUSE_BLUE }}
+                className="h-2 w-2 rounded-full ring-1 ring-white"
+              />
+              <dt className="sr-only">Blue dot</dt>
+              <dd>near bathhouse</dd>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="text-foreground font-bold">?</span>
+              <dt className="sr-only">Question mark</dt>
+              <dd>capacity unknown (never 0)</dd>
+            </div>
+            <div className="ml-auto flex items-center gap-1.5">
+              <dt className="sr-only">Counts</dt>
+              <dd className="tabular-nums">
+                <b className="text-foreground font-semibold">{roomCount}</b>{' '}
+                {roomCount === 1 ? 'room' : 'rooms'} ·{' '}
+                <b className="text-foreground font-semibold">{containerCount}</b>{' '}
+                {containerCount === 1 ? 'container' : 'containers'} not drawn ·{' '}
+                <b className="text-foreground font-semibold">{clusterCount}</b>{' '}
+                {clusterCount === 1 ? 'cluster' : 'clusters'} at this zoom
+              </dd>
+            </div>
+          </dl>
         </div>
 
         {/* EMBEDDED, not an overlay. FamilyDetailsPanel's own docstring: "The map

--- a/frontend/src/components/weekend/index.ts
+++ b/frontend/src/components/weekend/index.ts
@@ -29,8 +29,14 @@ export { reservationBadge } from './unitBadges'
 export type { UnitBadge } from './unitBadges'
 export { UnitInventoryPanel } from './UnitInventoryPanel'
 export { WeekendStatsBar } from './WeekendStatsBar'
-export { shortWeekendName, splitWeekendName } from './weekendNames'
-export type { WeekendName } from './weekendNames'
+export {
+  resolveWeekendRef,
+  shortWeekendName,
+  splitWeekendName,
+  weekendRef,
+  weekendSlug,
+} from './weekendNames'
+export type { AddressableWeekend, WeekendName } from './weekendNames'
 export {
   calendarKey,
   groupWeekends,

--- a/frontend/src/components/weekend/weekendNames.test.ts
+++ b/frontend/src/components/weekend/weekendNames.test.ts
@@ -93,12 +93,31 @@ describe('weekendSlug', () => {
   it('gives back nothing for a name with no letters or digits to abbreviate', () => {
     expect(weekendSlug('   ')).toBe('')
   })
+
+  it('keeps a shared token rather than slugging to bare digits', () => {
+    // Dropping the token from "JFAM 10" leaves `10`, and `resolveWeekendRef`
+    // reads a run of digits as a CampMinder id — so that URL would not resolve
+    // back to the weekend that produced it. The token earns its place here for
+    // the same reason it is dropped everywhere else: it is what makes the
+    // address an address.
+    expect(weekendSlug('JFAM 10')).toBe('j10')
+  })
+
+  it('gives back nothing for a name that abbreviates to digits alone', () => {
+    // The numeric space belongs to CampMinder ids. A slug that cannot be told
+    // apart from one is not an address, and '' is how a caller is told so.
+    expect(weekendSlug('2026')).toBe('')
+  })
 })
 
-const FC1 = { session_cm_id: 1309514, name: 'Family Camp 1: Memorial Day Weekend' }
-const WOMENS = { session_cm_id: 1335115, name: "Women's Weekend" }
+const FC1 = { session_cm_id: 1000001, name: 'Family Camp 1: Memorial Day Weekend' }
+const WOMENS = { session_cm_id: 1000002, name: "Women's Weekend" }
 /** Same slug as WOMENS ('ww'). Hypothetical, and the point of the guard. */
-const WINTER = { session_cm_id: 1379004, name: 'Winter Weekend' }
+const WINTER = { session_cm_id: 1000003, name: 'Winter Weekend' }
+/** Slugs to bare digits once the shared token is dropped — see `weekendSlug`. */
+const JFAM_10 = { session_cm_id: 1000004, name: 'JFAM 10' }
+/** Nothing to abbreviate but digits, so it has no slug at all. */
+const YEAR_ONLY = { session_cm_id: 1000005, name: '2026' }
 
 describe('weekendRef', () => {
   it('addresses a weekend by its slug when that slug is unique', () => {
@@ -108,8 +127,22 @@ describe('weekendRef', () => {
   it('falls back to the CampMinder id when two weekends share a slug', () => {
     // An ambiguous slug that resolved to whichever row sorted first would open
     // the wrong weekend, which is worse than an ugly URL.
-    expect(weekendRef(WOMENS, [FC1, WOMENS, WINTER])).toBe('1335115')
-    expect(weekendRef(WINTER, [FC1, WOMENS, WINTER])).toBe('1379004')
+    expect(weekendRef(WOMENS, [FC1, WOMENS, WINTER])).toBe('1000002')
+    expect(weekendRef(WINTER, [FC1, WOMENS, WINTER])).toBe('1000003')
+  })
+
+  it('falls back to the CampMinder id when a name has no slug to give', () => {
+    expect(weekendRef(YEAR_ONLY, [FC1, YEAR_ONLY])).toBe('1000005')
+  })
+
+  it('emits nothing a run of digits could be mistaken for', () => {
+    // THE ROUND TRIP IS THE TEST: whatever `weekendRef` emits, the URL hands
+    // straight back to `resolveWeekendRef`, and a slug of `10` came back as a
+    // CampMinder-id lookup that matched nothing.
+    for (const session of [JFAM_10, YEAR_ONLY]) {
+      const ref = weekendRef(session, [FC1, JFAM_10, YEAR_ONLY])
+      expect(resolveWeekendRef([FC1, JFAM_10, YEAR_ONLY], ref)).toEqual(session)
+    }
   })
 })
 
@@ -121,7 +154,7 @@ describe('resolveWeekendRef', () => {
   it('finds one by CampMinder id, which is what an ambiguous slug falls back to', () => {
     // Not for old links — there is no back-compat obligation here. This is the
     // other half of `weekendRef`'s collision guard: what it emits, this reads.
-    expect(resolveWeekendRef([FC1, WOMENS], '1335115')).toEqual(WOMENS)
+    expect(resolveWeekendRef([FC1, WOMENS], '1000002')).toEqual(WOMENS)
   })
 
   it('refuses to guess when a slug is ambiguous', () => {

--- a/frontend/src/components/weekend/weekendNames.test.ts
+++ b/frontend/src/components/weekend/weekendNames.test.ts
@@ -1,10 +1,17 @@
 /**
  * CampMinder joins a weekend's identity and its description with a colon.
- * Splitting is lossless; abbreviating would not be.
+ * Splitting is lossless; abbreviating would not be — which is why the slug
+ * below is an ADDRESS and never a label. See the note in weekendNames.ts.
  */
 import { describe, expect, it } from 'vitest'
 
-import { shortWeekendName, splitWeekendName } from './weekendNames'
+import {
+  resolveWeekendRef,
+  shortWeekendName,
+  splitWeekendName,
+  weekendRef,
+  weekendSlug,
+} from './weekendNames'
 
 describe('splitWeekendName', () => {
   it('splits identity from description at the colon', () => {
@@ -57,5 +64,72 @@ describe('shortWeekendName', () => {
     expect(shortWeekendName('Family Camp 7: Jewish Families of Color Weekend')).toBe(
       'Family Camp 7'
     )
+  })
+})
+
+describe('weekendSlug', () => {
+  it('abbreviates to initials and keeps a trailing number', () => {
+    expect(weekendSlug('Family Camp 1: Memorial Day Weekend')).toBe('fc1')
+    expect(weekendSlug('Family Camp 10')).toBe('fc10')
+  })
+
+  it('ignores the punctuation CampMinder names carry', () => {
+    expect(weekendSlug("Women's Weekend")).toBe('ww')
+    expect(weekendSlug('Ready, Set, Camp')).toBe('rsc')
+  })
+
+  it('drops a program token that many weekends share', () => {
+    // A token on half the lineup tells you nothing about WHICH weekend, so it
+    // is noise in an address. Winter Family Camp, not JFAM Winter Family Camp.
+    expect(weekendSlug('JFAM Winter Family Camp')).toBe('wfc')
+  })
+
+  it('reads only the identity, never the description after the colon', () => {
+    // Otherwise every JFAM weekend would slug identically.
+    expect(weekendSlug('Family Camp 3: JFAM Weekend (w/ kids 10 and under)')).toBe('fc3')
+    expect(weekendSlug('Family Camp 5: JFAM Weekend (w/ kids 10 and under)')).toBe('fc5')
+  })
+
+  it('gives back nothing for a name with no letters or digits to abbreviate', () => {
+    expect(weekendSlug('   ')).toBe('')
+  })
+})
+
+const FC1 = { session_cm_id: 1309514, name: 'Family Camp 1: Memorial Day Weekend' }
+const WOMENS = { session_cm_id: 1335115, name: "Women's Weekend" }
+/** Same slug as WOMENS ('ww'). Hypothetical, and the point of the guard. */
+const WINTER = { session_cm_id: 1379004, name: 'Winter Weekend' }
+
+describe('weekendRef', () => {
+  it('addresses a weekend by its slug when that slug is unique', () => {
+    expect(weekendRef(FC1, [FC1, WOMENS])).toBe('fc1')
+  })
+
+  it('falls back to the CampMinder id when two weekends share a slug', () => {
+    // An ambiguous slug that resolved to whichever row sorted first would open
+    // the wrong weekend, which is worse than an ugly URL.
+    expect(weekendRef(WOMENS, [FC1, WOMENS, WINTER])).toBe('1335115')
+    expect(weekendRef(WINTER, [FC1, WOMENS, WINTER])).toBe('1379004')
+  })
+})
+
+describe('resolveWeekendRef', () => {
+  it('finds the weekend a slug names', () => {
+    expect(resolveWeekendRef([FC1, WOMENS], 'fc1')).toEqual(FC1)
+  })
+
+  it('finds one by CampMinder id, which is what an ambiguous slug falls back to', () => {
+    // Not for old links — there is no back-compat obligation here. This is the
+    // other half of `weekendRef`'s collision guard: what it emits, this reads.
+    expect(resolveWeekendRef([FC1, WOMENS], '1335115')).toEqual(WOMENS)
+  })
+
+  it('refuses to guess when a slug is ambiguous', () => {
+    expect(resolveWeekendRef([FC1, WOMENS, WINTER], 'ww')).toBeUndefined()
+  })
+
+  it('finds nothing for a reference that names no weekend', () => {
+    expect(resolveWeekendRef([FC1, WOMENS], 'zz')).toBeUndefined()
+    expect(resolveWeekendRef([FC1, WOMENS], undefined)).toBeUndefined()
   })
 })

--- a/frontend/src/components/weekend/weekendNames.ts
+++ b/frontend/src/components/weekend/weekendNames.ts
@@ -40,3 +40,107 @@ export function splitWeekendName(name: string): WeekendName {
 export function shortWeekendName(name: string): string {
   return splitWeekendName(name).short
 }
+
+/**
+ * Program tokens that appear across many weekends.
+ *
+ * They say what KIND of weekend it is, never which one, so they are noise in
+ * an address — a slug's whole job is to tell two weekends apart. A hardcoded
+ * constant rather than a config row: it changes about as often as the camp's
+ * program lineup does, and a PR is the right amount of ceremony for that.
+ *
+ * Matched case-insensitively against whole words, so a weekend named only by
+ * a shared token still slugs to something (see `weekendSlug`).
+ */
+const SHARED_PROGRAM_TOKENS = new Set(['jfam'])
+
+/**
+ * A weekend's ADDRESS: `fc1`, `ww`, `mw`, `rsc`.
+ *
+ * THIS IS NOT A DISPLAY NAME, and the distinction is the whole reason it is
+ * allowed to exist. The note at the top of this file argues against inventing
+ * abbreviations because a UI that does starts disagreeing with CampMinder
+ * about what a session is CALLED — every title, picker and tab still renders
+ * `splitWeekendName`'s output verbatim. A URL is not a label; it is how staff
+ * type and share a weekend, and `/weekend/fc1/map` is one they can say out
+ * loud where `/weekend/session/1309514/map` is not.
+ *
+ * Initials of the identity, with a trailing number kept whole — "Family Camp
+ * 10" must not collide with "Family Camp 1". Read from the identity only, so
+ * the description after the colon cannot drag every JFAM weekend onto one slug.
+ *
+ * Returns '' when a name has nothing to abbreviate. Callers must treat that as
+ * "not addressable" rather than as a slug; `weekendRef` does.
+ */
+export function weekendSlug(name: string): string {
+  const words = shortWeekendName(name)
+    // An apostrophe sits INSIDE a word, so it is deleted rather than treated as
+    // a separator. Splitting on it turns "Women's Weekend" into three words and
+    // slugs it `wsw`.
+    .replace(/['’]/g, '')
+    // Every other mark IS a separator: "Ready, Set, Camp" is three words.
+    // Digits survive because they are the identity.
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter((word) => word.length > 0)
+
+  const meaningful = words.filter((word) => !SHARED_PROGRAM_TOKENS.has(word.toLowerCase()))
+  // A weekend named ONLY by shared tokens keeps them: a slug of '' would make
+  // it unaddressable, which is worse than one that reads oddly.
+  const kept = meaningful.length > 0 ? meaningful : words
+
+  return kept
+    .map((word, index) => {
+      // The trailing number is the identity — "Family Camp 1" is fc1, not fc1
+      // truncated from something. Only at the end: a number in the middle is
+      // part of a description that got this far.
+      const isLast = index === kept.length - 1
+      if (isLast && /^\p{N}+$/u.test(word)) return word
+      return word.slice(0, 1)
+    })
+    .join('')
+    .toLowerCase()
+}
+
+/** The minimum a weekend must carry to be addressed. */
+export interface AddressableWeekend {
+  session_cm_id: number
+  name: string
+}
+
+/**
+ * What to put in a URL for this weekend.
+ *
+ * The slug when it is unique among the weekends given, and the CampMinder id
+ * when it is not. An ambiguous slug that resolved to whichever row sorted
+ * first would open the WRONG weekend, and a URL that lies about which weekend
+ * you are looking at is worse than an ugly one.
+ */
+export function weekendRef(session: AddressableWeekend, sessions: AddressableWeekend[]): string {
+  const slug = weekendSlug(session.name)
+  if (slug.length === 0) return String(session.session_cm_id)
+  const sharing = sessions.filter((other) => weekendSlug(other.name) === slug)
+  return sharing.length === 1 ? slug : String(session.session_cm_id)
+}
+
+/**
+ * The weekend a URL reference names, by slug or by CampMinder id.
+ *
+ * Undefined rather than a guess when a slug is ambiguous — the same judgement
+ * `weekendRef` makes when it declines to emit one.
+ */
+export function resolveWeekendRef(
+  sessions: AddressableWeekend[],
+  ref: string | undefined
+): AddressableWeekend | undefined {
+  if (ref === undefined || ref.length === 0) return undefined
+
+  if (/^\p{N}+$/u.test(ref)) {
+    const id = Number(ref)
+    return sessions.find((session) => session.session_cm_id === id)
+  }
+
+  const matches = sessions.filter((session) => weekendSlug(session.name) === ref.toLowerCase())
+  return matches.length === 1 ? matches[0] : undefined
+}

--- a/frontend/src/components/weekend/weekendNames.ts
+++ b/frontend/src/components/weekend/weekendNames.ts
@@ -55,6 +55,26 @@ export function shortWeekendName(name: string): string {
 const SHARED_PROGRAM_TOKENS = new Set(['jfam'])
 
 /**
+ * A run of digits and nothing else — the shape `resolveWeekendRef` reads as a
+ * CampMinder id. A slug that matches this is not distinguishable from one.
+ */
+const DIGITS_ONLY = /^\p{N}+$/u
+
+function initials(words: string[]): string {
+  return words
+    .map((word, index) => {
+      // The trailing number is the identity — "Family Camp 1" is fc1, not fc1
+      // truncated from something. Only at the end: a number in the middle is
+      // part of a description that got this far.
+      const isLast = index === words.length - 1
+      if (isLast && DIGITS_ONLY.test(word)) return word
+      return word.slice(0, 1)
+    })
+    .join('')
+    .toLowerCase()
+}
+
+/**
  * A weekend's ADDRESS: `fc1`, `ww`, `mw`, `rsc`.
  *
  * THIS IS NOT A DISPLAY NAME, and the distinction is the whole reason it is
@@ -63,14 +83,15 @@ const SHARED_PROGRAM_TOKENS = new Set(['jfam'])
  * about what a session is CALLED — every title, picker and tab still renders
  * `splitWeekendName`'s output verbatim. A URL is not a label; it is how staff
  * type and share a weekend, and `/weekend/fc1/map` is one they can say out
- * loud where `/weekend/session/1309514/map` is not.
+ * loud where `/weekend/1000001/map` is not.
  *
  * Initials of the identity, with a trailing number kept whole — "Family Camp
  * 10" must not collide with "Family Camp 1". Read from the identity only, so
  * the description after the colon cannot drag every JFAM weekend onto one slug.
  *
- * Returns '' when a name has nothing to abbreviate. Callers must treat that as
- * "not addressable" rather than as a slug; `weekendRef` does.
+ * Returns '' when a name has nothing to abbreviate INTO AN ADDRESS. Callers
+ * must treat that as "not addressable" rather than as a slug; `weekendRef`
+ * does.
  */
 export function weekendSlug(name: string): string {
   const words = shortWeekendName(name)
@@ -86,21 +107,18 @@ export function weekendSlug(name: string): string {
     .filter((word) => word.length > 0)
 
   const meaningful = words.filter((word) => !SHARED_PROGRAM_TOKENS.has(word.toLowerCase()))
+  const dropped = initials(meaningful)
   // A weekend named ONLY by shared tokens keeps them: a slug of '' would make
-  // it unaddressable, which is worse than one that reads oddly.
-  const kept = meaningful.length > 0 ? meaningful : words
+  // it unaddressable, which is worse than one that reads oddly. The SAME
+  // escape hatch covers a slug left as bare digits — "JFAM 10" without its
+  // token is `10`, which `resolveWeekendRef` reads as a CampMinder id, so the
+  // URL would not resolve back to the weekend that emitted it. Keeping the
+  // token gives `j10`, which does.
+  const slug = meaningful.length > 0 && !DIGITS_ONLY.test(dropped) ? dropped : initials(words)
 
-  return kept
-    .map((word, index) => {
-      // The trailing number is the identity — "Family Camp 1" is fc1, not fc1
-      // truncated from something. Only at the end: a number in the middle is
-      // part of a description that got this far.
-      const isLast = index === kept.length - 1
-      if (isLast && /^\p{N}+$/u.test(word)) return word
-      return word.slice(0, 1)
-    })
-    .join('')
-    .toLowerCase()
+  // Nothing but digits to work with even then: the numeric space belongs to
+  // CampMinder ids, so this weekend has no address of its own to offer.
+  return DIGITS_ONLY.test(slug) ? '' : slug
 }
 
 /** The minimum a weekend must carry to be addressed. */
@@ -113,9 +131,12 @@ export interface AddressableWeekend {
  * What to put in a URL for this weekend.
  *
  * The slug when it is unique among the weekends given, and the CampMinder id
- * when it is not. An ambiguous slug that resolved to whichever row sorted
- * first would open the WRONG weekend, and a URL that lies about which weekend
- * you are looking at is worse than an ugly one.
+ * when it is not — or when `weekendSlug` declines to give one at all. An
+ * ambiguous slug that resolved to whichever row sorted first would open the
+ * WRONG weekend, and a URL that lies about which weekend you are looking at is
+ * worse than an ugly one.
+ *
+ * Whatever this emits, `resolveWeekendRef` must read back as the same weekend.
  */
 export function weekendRef(session: AddressableWeekend, sessions: AddressableWeekend[]): string {
   const slug = weekendSlug(session.name)
@@ -136,7 +157,9 @@ export function resolveWeekendRef(
 ): AddressableWeekend | undefined {
   if (ref === undefined || ref.length === 0) return undefined
 
-  if (/^\p{N}+$/u.test(ref)) {
+  // The same shape `weekendSlug` refuses to emit, so a slug can never land
+  // here and be mistaken for an id.
+  if (DIGITS_ONLY.test(ref)) {
     const id = Number(ref)
     return sessions.find((session) => session.session_cm_id === id)
   }

--- a/frontend/src/pages/WeekendRosterPage.test.tsx
+++ b/frontend/src/pages/WeekendRosterPage.test.tsx
@@ -7,14 +7,13 @@
  */
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Route, Routes } from 'react-router'
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import WeekendRosterPage from './WeekendRosterPage'
 
 const sessionsQuery = { data: undefined as unknown, isLoading: false, error: null as Error | null }
 const rosterQuery = { data: undefined as unknown, isLoading: false, error: null as Error | null }
-const navigate = vi.fn()
 
 vi.mock('../hooks/useWeekendRoster', () => ({
   useWeekendSessions: () => sessionsQuery,
@@ -40,10 +39,11 @@ vi.mock('../hooks/usePermissions', () => ({
   }),
 }))
 
-vi.mock('react-router', async () => {
-  const actual = await vi.importActual<typeof import('react-router')>('react-router')
-  return { ...actual, useNavigate: () => navigate }
-})
+// The `useNavigate` spy this file used to install has been removed on purpose.
+// The view now lives in the URL, so a spy would have asserted that the page
+// ASKED to navigate while the page it rendered stayed on the old tab — the
+// exact disagreement these tests exist to catch. A real MemoryRouter plus a
+// location probe asserts where the app actually ended up.
 
 const FAMILY_CAMP_1 = {
   session_id: 'sess_1',
@@ -63,18 +63,37 @@ const WOMENS = {
   end_date: '2026-10-18 07:00:00.000Z',
 }
 
-function renderPage(cmId = '1000001') {
+function LocationProbe() {
+  const location = useLocation()
+  const navigate = useNavigate()
+  return (
+    <>
+      <div data-testid="location">{location.pathname}</div>
+      <button
+        type="button"
+        onClick={() => {
+          void navigate(-1)
+        }}
+      >
+        probe-back
+      </button>
+    </>
+  )
+}
+
+function renderPage(cmId = '1000001', view = '') {
+  const path = `/weekend/session/${cmId}${view === '' ? '' : `/${view}`}`
   return render(
-    <MemoryRouter initialEntries={[`/weekend/session/${cmId}`]}>
+    <MemoryRouter initialEntries={[path]}>
       <Routes>
-        <Route path="/weekend/session/:sessionCmId" element={<WeekendRosterPage />} />
+        <Route path="/weekend/session/:sessionCmId/:view?" element={<WeekendRosterPage />} />
       </Routes>
+      <LocationProbe />
     </MemoryRouter>
   )
 }
 
 beforeEach(() => {
-  navigate.mockReset()
   isAdmin = true
   permissions = new Set()
   sessionsQuery.data = { year: 2026, sessions: [FAMILY_CAMP_1, WOMENS] }
@@ -114,7 +133,7 @@ describe('header', () => {
     renderPage()
     await userEvent.click(screen.getByRole('button', { name: /Family Camp 1/ }))
     await userEvent.click(await screen.findByRole('option', { name: "Women's Weekend" }))
-    expect(navigate).toHaveBeenCalledWith('/weekend/session/1000002')
+    expect(screen.getByTestId('location')).toHaveTextContent('/weekend/session/1000002')
   })
 
   it('orders the picker by date, not by CampMinder sort_order', async () => {
@@ -184,6 +203,83 @@ describe('query states', () => {
     rosterQuery.error = new Error('boom')
     renderPage()
     expect(screen.getByText(/Failed to load weekend roster data: boom/i)).toBeInTheDocument()
+  })
+})
+
+describe('the view in the URL', () => {
+  const ONE_UNIT = {
+    year: 2026,
+    session_cm_id: 1000001,
+    parties: [],
+    counts: {},
+    units: [
+      {
+        unit_id: 'u1',
+        code: 'ridge-a',
+        name: 'Ridge A',
+        area_code: 'RIDGE',
+        area_name: 'Ridge Side',
+        sleeps: 5,
+        is_confirmed: true,
+        is_container: false,
+        is_family_available: true,
+      },
+    ],
+  }
+
+  it('opens the view the URL names, so a tab can be linked and reloaded', () => {
+    rosterQuery.data = ONE_UNIT
+    renderPage('1000001', 'inventory')
+    expect(screen.getByRole('tab', { name: /Inventory/ })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByText('Ridge A')).toBeInTheDocument()
+  })
+
+  it('opens the roster when the URL names no view', () => {
+    rosterQuery.data = ONE_UNIT
+    renderPage()
+    expect(screen.getByRole('tab', { name: /Roster/ })).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('puts the chosen view in the URL', async () => {
+    rosterQuery.data = ONE_UNIT
+    renderPage()
+    await userEvent.click(screen.getByRole('tab', { name: /Inventory/ }))
+    expect(screen.getByTestId('location')).toHaveTextContent('/weekend/session/1000001/inventory')
+  })
+
+  it('replaces rather than stacks, so Back leaves the weekend', async () => {
+    // Four tabs and a habit of clicking through them turns Back into a tour of
+    // the tabs you already saw. The weekend is the destination; the tab is not.
+    //
+    // ASSERTING THE FINAL URL WOULD NOT TEST THIS — it is identical whether the
+    // tab pushed or replaced. Only going Back tells them apart, which needs a
+    // real entry BEHIND the weekend to come back to.
+    rosterQuery.data = ONE_UNIT
+    render(
+      <MemoryRouter
+        initialEntries={['/weekend/sessions', '/weekend/session/1000001']}
+        initialIndex={1}
+      >
+        <Routes>
+          <Route path="/weekend/session/:sessionCmId/:view?" element={<WeekendRosterPage />} />
+        </Routes>
+        <LocationProbe />
+      </MemoryRouter>
+    )
+
+    await userEvent.click(screen.getByRole('tab', { name: /Board/ }))
+    await userEvent.click(screen.getByRole('tab', { name: /Map/ }))
+    await userEvent.click(screen.getByRole('button', { name: 'probe-back' }))
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/weekend/sessions')
+  })
+
+  it('falls back to the roster when the URL names a view that does not exist', () => {
+    // A stale bookmark, or a typo. Rendering nothing would read as a broken
+    // page; the roster is the honest default.
+    rosterQuery.data = ONE_UNIT
+    renderPage('1000001', 'gantt')
+    expect(screen.getByRole('tab', { name: /Roster/ })).toHaveAttribute('aria-selected', 'true')
   })
 })
 

--- a/frontend/src/pages/WeekendRosterPage.test.tsx
+++ b/frontend/src/pages/WeekendRosterPage.test.tsx
@@ -81,12 +81,12 @@ function LocationProbe() {
   )
 }
 
-function renderPage(cmId = '1000001', view = '') {
-  const path = `/weekend/session/${cmId}${view === '' ? '' : `/${view}`}`
+function renderPage(ref = '1000001', view = '') {
+  const path = `/weekend/${ref}${view === '' ? '' : `/${view}`}`
   return render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
-        <Route path="/weekend/session/:sessionCmId/:view?" element={<WeekendRosterPage />} />
+        <Route path="/weekend/:sessionRef/:view?" element={<WeekendRosterPage />} />
       </Routes>
       <LocationProbe />
     </MemoryRouter>
@@ -133,7 +133,7 @@ describe('header', () => {
     renderPage()
     await userEvent.click(screen.getByRole('button', { name: /Family Camp 1/ }))
     await userEvent.click(await screen.findByRole('option', { name: "Women's Weekend" }))
-    expect(screen.getByTestId('location')).toHaveTextContent('/weekend/session/1000002')
+    expect(screen.getByTestId('location')).toHaveTextContent('/weekend/ww')
   })
 
   it('orders the picker by date, not by CampMinder sort_order', async () => {
@@ -206,6 +206,34 @@ describe('query states', () => {
   })
 })
 
+describe('addressing a weekend by slug', () => {
+  it('opens the weekend a slug names', () => {
+    renderPage('fc1')
+    expect(screen.getByRole('button', { name: /Family Camp 1/ })).toBeInTheDocument()
+  })
+
+  it('keeps the slug when moving between tabs', async () => {
+    renderPage('fc1')
+    await userEvent.click(screen.getByRole('tab', { name: /Map/ }))
+    expect(screen.getByTestId('location')).toHaveTextContent('/weekend/fc1/map')
+  })
+
+  it('waits for the weekend list before calling a slug unknown', () => {
+    // A slug cannot be resolved without the list, so deciding early would flash
+    // "Weekend not found" on every load of a perfectly good link.
+    sessionsQuery.data = undefined
+    sessionsQuery.isLoading = true
+    rosterQuery.data = undefined
+    renderPage('fc1')
+    expect(screen.queryByRole('button', { name: /Weekend not found/ })).not.toBeInTheDocument()
+  })
+
+  it('says so once the list has loaded and the slug still names nothing', () => {
+    renderPage('zz')
+    expect(screen.getByRole('button', { name: /Weekend not found/ })).toBeInTheDocument()
+  })
+})
+
 describe('the view in the URL', () => {
   const ONE_UNIT = {
     year: 2026,
@@ -244,7 +272,7 @@ describe('the view in the URL', () => {
     rosterQuery.data = ONE_UNIT
     renderPage()
     await userEvent.click(screen.getByRole('tab', { name: /Inventory/ }))
-    expect(screen.getByTestId('location')).toHaveTextContent('/weekend/session/1000001/inventory')
+    expect(screen.getByTestId('location')).toHaveTextContent('/weekend/1000001/inventory')
   })
 
   it('replaces rather than stacks, so Back leaves the weekend', async () => {
@@ -256,12 +284,9 @@ describe('the view in the URL', () => {
     // real entry BEHIND the weekend to come back to.
     rosterQuery.data = ONE_UNIT
     render(
-      <MemoryRouter
-        initialEntries={['/weekend/sessions', '/weekend/session/1000001']}
-        initialIndex={1}
-      >
+      <MemoryRouter initialEntries={['/weekend/sessions', '/weekend/fc1']} initialIndex={1}>
         <Routes>
-          <Route path="/weekend/session/:sessionCmId/:view?" element={<WeekendRosterPage />} />
+          <Route path="/weekend/:sessionRef/:view?" element={<WeekendRosterPage />} />
         </Routes>
         <LocationProbe />
       </MemoryRouter>

--- a/frontend/src/pages/WeekendRosterPage.test.tsx
+++ b/frontend/src/pages/WeekendRosterPage.test.tsx
@@ -1,5 +1,5 @@
 /**
- * /weekend/session/:sessionCmId — one weekend's roster.
+ * /weekend/:sessionRef/:view? — one weekend's roster.
  *
  * The weekend comes from the URL now, as a summer session does. Choosing
  * between weekends belongs to the lander; this page's title doubles as the
@@ -133,7 +133,20 @@ describe('header', () => {
     renderPage()
     await userEvent.click(screen.getByRole('button', { name: /Family Camp 1/ }))
     await userEvent.click(await screen.findByRole('option', { name: "Women's Weekend" }))
-    expect(screen.getByTestId('location')).toHaveTextContent('/weekend/ww')
+    // ANCHORED: `/weekend/ww` is a prefix of every tab under that weekend, so
+    // an unanchored match cannot tell the roster from the map and would pass
+    // whatever the tab-carrying test below asserts.
+    expect(screen.getByTestId('location')).toHaveTextContent(/^\/weekend\/ww\/roster$/)
+  })
+
+  it('stays on the tab you are looking at when you switch weekends', async () => {
+    // Comparing one view across two weekends is the reason to switch from
+    // inside a weekend rather than from the lander. Dropping back to the
+    // roster every time makes the switcher useless for exactly that.
+    renderPage('fc1', 'map')
+    await userEvent.click(screen.getByRole('button', { name: /Family Camp 1/ }))
+    await userEvent.click(await screen.findByRole('option', { name: "Women's Weekend" }))
+    expect(screen.getByTestId('location')).toHaveTextContent(/^\/weekend\/ww\/map$/)
   })
 
   it('orders the picker by date, not by CampMinder sort_order', async () => {

--- a/frontend/src/pages/WeekendRosterPage.tsx
+++ b/frontend/src/pages/WeekendRosterPage.tsx
@@ -136,7 +136,12 @@ export default function WeekendRosterPage() {
             <Listbox
               value={selectedSession ? weekendRef(selectedSession, sessions) : ''}
               onChange={(value: string) => {
-                void navigate(`/weekend/${value}`)
+                // CARRIES THE TAB. Switching weekends from inside one is how
+                // you compare the same view across two of them; landing back
+                // on the roster every time is what makes you use the lander
+                // instead. PUSH, unlike the tabs: the weekend is the
+                // destination, so Back belongs to it.
+                void navigate(`/weekend/${value}/${view}`)
               }}
             >
               <div className="relative">

--- a/frontend/src/pages/WeekendRosterPage.tsx
+++ b/frontend/src/pages/WeekendRosterPage.tsx
@@ -1,5 +1,9 @@
 /**
- * /weekend/session/:sessionCmId — one weekend's lodging roster.
+ * /weekend/:sessionRef/:view? — one weekend's lodging roster.
+ *
+ * The reference is a readable slug (`fc1`, `ww`, `mw`) falling back to the
+ * CampMinder id when two weekends would slug alike; the view is a path
+ * segment so a tab can be linked and reloaded. See `weekendNames.ts`.
  *
  * Laid out as the summer session view is, one program over: a title that is
  * itself the session switcher, a sticky pill-tab nav, a contextual stats bar,
@@ -40,9 +44,11 @@ import {
   LodgingBoard,
   LodgingMap,
   partyBeds,
+  resolveWeekendRef,
   shortWeekendName,
   sortWeekendsByDate,
   UnitInventoryPanel,
+  weekendRef,
   WeekendStatsBar,
 } from '../components/weekend'
 import { useCurrentYear } from '../hooks/useCurrentYear'
@@ -68,20 +74,30 @@ function parseView(segment: string | undefined): View {
 }
 
 export default function WeekendRosterPage() {
-  const { sessionCmId, view: viewParam } = useParams<{ sessionCmId: string; view: string }>()
+  const { sessionRef, view: viewParam } = useParams<{ sessionRef: string; view: string }>()
   const navigate = useNavigate()
   const { currentYear } = useCurrentYear()
   const { hasPermission } = usePermissions()
   const canManageLodging = hasPermission(Permission.BUNKING_MANAGE)
   const view = parseView(viewParam)
 
-  const selectedCmId = sessionCmId === undefined ? null : Number(sessionCmId)
   const sessionsQuery = useWeekendSessions(currentYear)
-  const rosterQuery = useWeekendRoster(currentYear, selectedCmId)
-
   // Chronological, as the summer session picker is — CampMinder's sort_order
   // is manual and does not track the calendar.
   const sessions = sortWeekendsByDate(sessionsQuery.data?.sessions ?? [])
+
+  // A NUMERIC reference resolves without the list; a slug cannot. Reading the
+  // number directly keeps the roster fetch off the back of the sessions fetch,
+  // which would otherwise be a waterfall on every load.
+  const numericRef = /^\d+$/.test(sessionRef ?? '') ? Number(sessionRef) : null
+  const resolved = resolveWeekendRef(sessions, sessionRef)
+  const selectedCmId = resolved?.session_cm_id ?? numericRef
+  const rosterQuery = useWeekendRoster(currentYear, selectedCmId)
+
+  // A slug with no list yet is UNRESOLVED, not unknown — but the title's
+  // existing `sessionsQuery.isLoading` branch already says "Loading weekends…"
+  // in exactly that gap, so there is nothing more to add here.
+
   const selectedSession = sessions.find((session) => session.session_cm_id === selectedCmId)
   const dates = selectedSession
     ? formatSessionDates(selectedSession.start_date, selectedSession.end_date)
@@ -118,9 +134,9 @@ export default function WeekendRosterPage() {
           <div className="flex flex-shrink-0 items-center gap-2">
             <Home className="text-primary h-5 w-5 flex-shrink-0 sm:h-6 sm:w-6" />
             <Listbox
-              value={selectedCmId === null ? '' : String(selectedCmId)}
+              value={selectedSession ? weekendRef(selectedSession, sessions) : ''}
               onChange={(value: string) => {
-                void navigate(`/weekend/session/${value}`)
+                void navigate(`/weekend/${value}`)
               }}
             >
               <div className="relative">
@@ -136,7 +152,7 @@ export default function WeekendRosterPage() {
                   {sessions.map((session) => (
                     <ListboxOption
                       key={session.session_cm_id}
-                      value={String(session.session_cm_id)}
+                      value={weekendRef(session, sessions)}
                       className="listbox-option py-1.5"
                     >
                       {shortWeekendName(session.name)}
@@ -204,7 +220,7 @@ export default function WeekendRosterPage() {
                           // of the tabs you just left; the weekend is the
                           // destination, the tab is where you are standing in
                           // it.
-                          void navigate(`/weekend/session/${sessionCmId ?? ''}/${tab.id}`, {
+                          void navigate(`/weekend/${sessionRef ?? ''}/${tab.id}`, {
                             replace: true,
                           })
                         }}

--- a/frontend/src/pages/WeekendRosterPage.tsx
+++ b/frontend/src/pages/WeekendRosterPage.tsx
@@ -27,7 +27,6 @@ import {
   Settings2,
   Users,
 } from 'lucide-react'
-import { useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router'
 
 import { QueryGuard } from '../components/QueryGuard'
@@ -52,13 +51,29 @@ import { useWeekendRoster, useWeekendSessions } from '../hooks/useWeekendRoster'
 
 type View = 'roster' | 'inventory' | 'board' | 'map'
 
+const VIEWS: View[] = ['roster', 'inventory', 'board', 'map']
+
+const DEFAULT_VIEW: View = 'roster'
+
+/**
+ * The view is a URL segment, as the analytics sub-navs are — `/analytics/
+ * retention/flow`, not a query string. A tab held only in `useState` cannot be
+ * linked, survive a reload, or be reopened where you left it.
+ *
+ * An unrecognised segment falls back rather than rendering nothing: it arrives
+ * from a stale bookmark or a typo, and a blank panel reads as a broken page.
+ */
+function parseView(segment: string | undefined): View {
+  return VIEWS.find((candidate) => candidate === segment) ?? DEFAULT_VIEW
+}
+
 export default function WeekendRosterPage() {
-  const { sessionCmId } = useParams<{ sessionCmId: string }>()
+  const { sessionCmId, view: viewParam } = useParams<{ sessionCmId: string; view: string }>()
   const navigate = useNavigate()
   const { currentYear } = useCurrentYear()
   const { hasPermission } = usePermissions()
   const canManageLodging = hasPermission(Permission.BUNKING_MANAGE)
-  const [view, setView] = useState<View>('roster')
+  const view = parseView(viewParam)
 
   const selectedCmId = sessionCmId === undefined ? null : Number(sessionCmId)
   const sessionsQuery = useWeekendSessions(currentYear)
@@ -184,7 +199,14 @@ export default function WeekendRosterPage() {
                         aria-selected={view === tab.id}
                         aria-controls={`weekend-panel-${tab.id}`}
                         onClick={() => {
-                          setView(tab.id)
+                          // REPLACE, not push. Four tabs and a habit of
+                          // clicking through them would turn Back into a tour
+                          // of the tabs you just left; the weekend is the
+                          // destination, the tab is where you are standing in
+                          // it.
+                          void navigate(`/weekend/session/${sessionCmId ?? ''}/${tab.id}`, {
+                            replace: true,
+                          })
                         }}
                         className={`flex items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition-all duration-200 ${
                           view === tab.id

--- a/frontend/src/pages/WeekendSessionList.test.tsx
+++ b/frontend/src/pages/WeekendSessionList.test.tsx
@@ -89,11 +89,15 @@ describe('header', () => {
 })
 
 describe('rows', () => {
-  it('links each weekend to its roster', () => {
+  it('links each weekend to its roster by readable slug, not CampMinder id', () => {
     render(<WeekendSessionList />, { wrapper })
     expect(screen.getByRole('link', { name: /Family Camp 1/ })).toHaveAttribute(
       'href',
-      '/weekend/session/1000001'
+      '/weekend/fc1'
+    )
+    expect(screen.getByRole('link', { name: /Women's Weekend/ })).toHaveAttribute(
+      'href',
+      '/weekend/ww'
     )
   })
 

--- a/frontend/src/pages/WeekendSessionList.tsx
+++ b/frontend/src/pages/WeekendSessionList.tsx
@@ -30,6 +30,7 @@ import {
   formatSessionDates,
   groupWeekends,
   splitWeekendName,
+  weekendRef,
   todayKey,
 } from '../components/weekend'
 import type { WeekendStatus } from '../components/weekend'
@@ -105,10 +106,17 @@ function StatusSectionHeader({ status, count }: { status: WeekendStatus; count: 
 
 function WeekendRow({
   session,
+  siblings,
   status,
   stats,
 }: {
   session: WeekendSession
+  /**
+   * Every weekend in the year, not just this row's group — `weekendRef` can
+   * only tell a slug is unique by seeing all of them, and a collision that
+   * spans two groups is exactly the one a per-group check would miss.
+   */
+  siblings: WeekendSession[]
   status: WeekendStatus
   /**
    * Always present in practice — the counts arrive with the sessions in one
@@ -124,7 +132,7 @@ function WeekendRow({
 
   return (
     <Link
-      to={`/weekend/session/${String(session.session_cm_id)}`}
+      to={`/weekend/${weekendRef(session, siblings)}`}
       className={`group hover:bg-forest-50/50 dark:hover:bg-forest-800/40 block transition-all duration-200 ${
         isCompleted ? 'opacity-70 hover:opacity-100' : ''
       }`}
@@ -322,6 +330,7 @@ export default function WeekendSessionList() {
                       >
                         <WeekendRow
                           session={session}
+                          siblings={sessions}
                           status={status}
                           stats={statsByCmId.get(session.session_cm_id)}
                         />


### PR DESCRIPTION
Restores the legend and the highlight toggles from the approved map mockup. #1939 shipped the map without either, and this is where they went: the design doc turned the mockup's legend into §6.3 "Visual encoding" — a table specifying the grammar, not a rendered key — and never mentioned the toggles at all. The plan therefore never asked for them, so nothing downstream had anything to compare against.

The result was seven encoding channels on a 16px mark with nothing on screen explaining any of them. The blue dot answering *does this family sit beside a bathhouse* is one of the two questions §1 names as the surface's reason to exist, and it shipped as an unexplained dot.

## What's added

- **Legend** for all six channels — hollow/solid/ringed, dashed square, blue dot, `?` — plus the counts: `N rooms · M containers not drawn · K clusters at this zoom`. The container figure is where the 408-vs-389 double count becomes visible to someone who has not read the PR that caused it.
- **Four toggles**: Area tint, Near-bathhouse, Staff cabins, Empty rooms. First three default off; empty rooms are drawn by default.
- **Fade percentage readout**, the `scroll to zoom · drag to pan · click a pin for detail` hint, and a visible **Fit all** label rather than an icon carrying only an `aria-label`.

## Two decisions worth reviewing

- **Highlights dim, they don't hide.** Half of "which cabins are near a bathhouse" is where they sit relative to everything else, and removing the rest throws that away. Both highlights AND rather than union, so turning on two asks a narrower question instead of lighting up more of the map.
- **Empty rooms are filtered BEFORE clustering.** Hiding them dissolves the blobs they were padding, rather than leaving the same blobs with holes in them. The legend's room count is deliberately *not* filtered — it accounts for the payload, so it stays reconcilable against the Inventory tab.

## Deliberately not included

- **The expand-mode select and the dwell slider.** Both were mockup instrumentation for tuning the interaction, and the design doc resolved them to fixed values (click + hover, 400ms). Shipping a `dwell 0–1200ms` slider in the product would be shipping the workbench.
- **The mockup gated the blue dot behind its Near-bathhouse checkbox.** Kept always-visible here, which is what #1939 shipped — hiding it by default would be a regression.

## Testing

12 new tests. Every one **mutation-checked**: break the code, confirm that test and only that test fails. Two were caught non-discriminating this way and strengthened — the cluster count needed a third lone room to distinguish "multi-room blobs" from "every mark", and the fade readout needed to follow the slider rather than assert its initial value.

Full suite 390 files / 5370 tests / exit 0; type-check clean; eslint 0 errors; `verify-no-hardcoded-lodging.sh` exit 0. Legend labels are all generic grammar terms — no camp-identifying strings, per spec §13.

**Not visually verified by me.** The worktree stack runs OIDC and the reviewer was logged into it; flipping it to bypass mode mid-session to take a screenshot wasn't worth the disruption. Needs an eyeball on `:3122` before merge — particularly the legend's wrap behaviour at narrow widths and whether the area tint reads as intended over the illustration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lodging map controls to filter empty rooms and highlight bathhouses or staff cabins.
  * Added area tinting, adjustable map fade, clearer interaction guidance, and an enhanced legend with symbols and counts.
  * Added a visible “Fit all” control and improved off-map lodging layout.
  * Weekend rosters now use readable, shareable links with URL-selected views, numeric fallback links, and invalid-view fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up from review (second commit)

**The highlight checkboxes were misleading.** Near-bathhouse and Staff cabins ANDed, so ticking both dimmed everything not near a bathhouse *and* beside staff — an intersection nobody asked for, which read as a filter that had eaten the map. A checkbox promises the options combine and these cannot. Now a radio group: **No highlight / Near bathhouse / Staff cabins**. Area tint and Empty rooms stay checkboxes and stay independent — a tint is a backdrop, the empty toggle changes which rooms are on the map at all, so neither competes with anything.

**The view is now a URL segment** — `/weekend/session/:id/:view?`, following the analytics sub-navs rather than inventing a query param. A tab in `useState` cannot be linked, survive a reload, or reopen where you left it. The segment is optional so bare links still open on the roster, and an unrecognised segment falls back rather than rendering a blank panel. Tabs **replace** rather than push, so Back leaves the weekend instead of touring the tabs you just left.

**The unplaced rail moved to the left**, matching `LodgingBoard`. Switching between Board and Map threw the rail across the screen.

`WeekendRosterPage.test.tsx` no longer mocks `useNavigate`. With the view in the URL a spy would assert the page *asked* to navigate while the panel it rendered stayed put — the exact disagreement these tests exist to catch. Real `MemoryRouter` plus a location probe now.

Mutation-checked again; one test was caught asserting nothing — the final URL after a tab click is identical whether it pushed or replaced, so proving `replace` needs a real history entry behind the weekend and a Back that lands on it.

**Known gap:** the rail-side test asserts DOM order, which is what decides the grid column. jsdom performs no layout, so the `lg:grid-cols-[280px_minmax(0,1fr)]` template itself is unasserted — a wrong template would still place the rail first in the DOM.

---

## Readable weekend URLs (third commit)

`/weekend/fc1/map` rather than `/weekend/1000001/map` — the slug is what staff already say out loud.

Derived rather than tabulated: initials of the weekend's identity, with a trailing number kept whole. Across the real 2026 lineup that gives `rsc`, `fc1`–`fc8`, `ww`, `mw`, `wfc` — no collisions.

- **The anti-abbreviation note in `weekendNames.ts` still stands, for display.** It is about a UI disagreeing with CampMinder over what a session is *called*; every title, picker and tab still renders `splitWeekendName` verbatim. A URL is an address, not a label.
- **A shared program token is dropped from the slug.** It appears across half the lineup, so it says what *kind* of weekend it is and never which one — noise in an address. One hardcoded set, changed by PR.
- **An ambiguous slug is not addressable** — `weekendRef` emits the CampMinder id for both weekends instead. Resolving to whichever row sorted first would open the *wrong* weekend. `resolveWeekendRef` reads ids for that reason alone; there is no back-compat obligation here and none is claimed.
- **A numeric reference resolves without the session list**, so the roster fetch does not queue behind the sessions fetch on every load. A slug necessarily waits, and the title's existing loading branch covers that gap rather than flashing "Weekend not found".



---

## Review fixes (fourth commit)

**Three real CampMinder session ids were in the tracked source** — the URL example in `weekendNames.ts` and the `weekendRef` fixtures. Replaced with the generic ids `tests/CLAUDE.md` pins fixtures to, which `WeekendSessionList.test.tsx` on this same branch was already using. This PR body carried one too; it has been scrubbed.

**A slug of bare digits could not be read back.** Dropping the shared program token from a name like `JFAM 10` left `10`, and `resolveWeekendRef` reads a run of digits as a CampMinder id — so `weekendRef` emitted an address resolving to no weekend at all, the exact failure its own docstring says it exists to prevent. The token now stays when dropping it would leave digits alone (`j10`), and a name with nothing but digits to abbreviate gets no slug, which `weekendRef` already handles by falling back to the id. `DIGITS_ONLY` is one constant shared by the emitter and the reader so the two cannot drift.

**The legend keyed the shapes and skipped the colour.** Hue drives the fill, the border, the shared ring and the area tint, and a cluster's mark grows with what is under it — five of the seven channels the legend's own comment claims, keyed by neither. The swatches are read off the model rather than a fixed palette, so they cannot disagree with the marks.

**The weekend switcher dropped you back to the roster.** The view used to be `useState` on a component that stayed mounted across a switch, so the tab survived; as a URL segment it did not. Comparing one view across two weekends is the reason to switch from inside a weekend at all.

Four comments corrected: the room count claimed to reconcile against the Inventory tab, which it does not and `countMapUnits`' own docstring says so; "the only keyboard-reachable controls" predates the radios beside them; the route comment credited declaration order where React Router ranks by segment specificity; the roster test's header still named the old route.

**Deliberately not fixed:** old `/weekend/session/:id` links stay broken — not worth a redirect for three days of links on a surface staff reach from the lander. Moving `SHARED_PROGRAM_TOKENS` into the `config` table was declined; a slug token list is not runtime solver config, and the constant's comment argues the case.

Every new test mutation-checked — each guard broken in turn, and only the test pinning it fails. Full suite 390 files / 5400 tests / exit 0; tsc clean; eslint 0 errors; `verify-no-hardcoded-lodging.sh` exit 0.
