### PR TITLE
perf(frontend): weekend surfaces model summer's caching and derived values

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,26 @@ Worktree mechanics (ports, isolation, cleanup): `docs/reference/git-workflow.md`
 
 OAuth2 / OIDC setup: `docs/reference/oauth2-setup.md`
 
+### Family Camp Models Summer
+
+**Weekend / Family Camp surfaces model the summer equivalent wherever possible. A program-specific divergence must be deliberate, justified in a comment, and defensible against what summer does — not an accident of being written later by someone who did not look.**
+
+This is not a style preference. Summer is the mature surface; every place weekend departs from it is a place staff have to learn the product twice, and a place a fix has to be made twice. The rule covers, and is not limited to:
+
+| Dimension | Model summer's |
+|-----------|----------------|
+| **UI primitives** | Same components — tabs, tables, panels, modals, popouts, chips, badges |
+| **Styling** | Same Tailwind grammar and tokens. A class that does nothing (`forest-950`, #1894) propagates by imitation — check it renders |
+| **URL style** | Route shape and param naming. Tab state lives in the URL, not `useState`, so a tab is linkable and survives reload |
+| **Cache performance** | Inherit the `utils/queryClient.ts` defaults, as `hooks/session/useSessionData.ts` does. Do not opt down to shorter caching |
+| **RBAC** | Same permission constants and gate placement; protected endpoints go through `fetchWithAuth` |
+| **Data fetching** | Extract into custom hooks (`frontend/CLAUDE.md`), keys from `utils/queryKeys.ts` |
+| **Error handling** | Page-level `ErrorBoundary` + `QueryGuard`, all four states |
+
+**The caching row has already been got wrong once and is worth stating plainly.** The weekend hooks opted down to `userDataOptions` (30 s stale, 5 min gc, refetch on focus) to guard against staff editing in CampMinder mid-session. Summer has exactly that property and does not opt down, and **a weekend is worked by one person at a time** — they are modelling scenarios for themselves, and a second staff member looking on is rare and read-shaped. There was no concurrent-edit hazard to buy, and the cost was real: `build_roster` issues eleven PocketBase fetches and puts an empty weekend at ~3 seconds, re-paid every 30 seconds. **Long staleTime plus explicit invalidation on mutation — never short staleTime plus hope.**
+
+When weekend genuinely must differ, say why at the divergence. `useHouseholdMedical`'s `staleTime: 0, gcTime: 0` is the model: PHI must not sit in the cache after the panel closes, and the comment says so.
+
 ### Test-Driven Development
 
 Write failing tests first, verify they fail, then implement. **Tests are the specification — never edit a test to match what the implementation happens to do.** Tests and implementation may land in the same commit (PRs are squash-merged); what matters is the order you write them in. Marker semantics and which tests are skipped in CI: `tests/CLAUDE.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,12 +162,16 @@ This is not a style preference. Summer is the mature surface; every place weeken
 | **UI primitives** | Same components — tabs, tables, panels, modals, popouts, chips, badges |
 | **Styling** | Same Tailwind grammar and tokens. A class that does nothing (`forest-950`, #1894) propagates by imitation — check it renders |
 | **URL style** | Route shape and param naming. Tab state lives in the URL, not `useState`, so a tab is linkable and survives reload |
-| **Cache performance** | Inherit the `utils/queryClient.ts` defaults, as `hooks/session/useSessionData.ts` does. Do not opt down to shorter caching |
+| **Cache performance** | Default to inheriting the `utils/queryClient.ts` defaults, as the board's own `hooks/session/useSessionData.ts` does. Opting down needs a stated reason |
 | **RBAC** | Same permission constants and gate placement; protected endpoints go through `fetchWithAuth` |
 | **Data fetching** | Extract into custom hooks (`frontend/CLAUDE.md`), keys from `utils/queryKeys.ts` |
 | **Error handling** | Page-level `ErrorBoundary` + `QueryGuard`, all four states |
 
-**The caching row has already been got wrong once and is worth stating plainly.** The weekend hooks opted down to `userDataOptions` (30 s stale, 5 min gc, refetch on focus) to guard against staff editing in CampMinder mid-session. Summer has exactly that property and does not opt down, and **a weekend is worked by one person at a time** — they are modelling scenarios for themselves, and a second staff member looking on is rare and read-shaped. There was no concurrent-edit hazard to buy, and the cost was real: `build_roster` issues eleven PocketBase fetches and puts an empty weekend at ~3 seconds, re-paid every 30 seconds. **Long staleTime plus explicit invalidation on mutation — never short staleTime plus hope.**
+**The caching row has already been got wrong once and is worth stating precisely.** The weekend hooks opted down to `userDataOptions` (30 s stale, 5 min gc, refetch on focus) to guard against staff editing in CampMinder mid-session.
+
+Be careful with the comparison, because summer is not uniform: the bunking board's own data hooks (`hooks/session/useSessionData.ts`) override nothing, while `hooks/useCohortBunkAssignments.ts` does use `userDataOptions`. The right comparator for a weekend surface is the board's primary read path, and that one inherits. What actually settled it was the workflow: **a weekend is worked by one person at a time**, modelling scenarios for themselves, with a second staff member looking on rare and read-shaped. There was no concurrent-edit hazard to buy, and the cost was real — `build_roster` issues eleven PocketBase fetches, and an empty weekend runs about 3 seconds, re-paid every 30 seconds.
+
+**Long staleTime plus explicit invalidation on mutation — never short staleTime plus hope.** The second half is not optional and is the part that got missed: when the weekend queries moved to a 30-minute staleTime, the lodging admin panels still invalidated only their own registry keys, leaving the roster stale for half an hour after a cabin confirmation. That is what `invalidateLodgingRegistryQueries` exists for. **If you lengthen a staleTime, find every writer first.**
 
 When weekend genuinely must differ, say why at the divergence. `useHouseholdMedical`'s `staleTime: 0, gcTime: 0` is the model: PHI must not sit in the cache after the panel closes, and the comment says so.
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -39,6 +39,16 @@ React + TypeScript + Vite. Dev server on `:3000` (HMR); prod served via Caddy at
 
 Use the centralized keys from `src/utils/queryKeys.ts`. Inlining string keys causes cache collisions and silent bugs when invalidation misses the right query.
 
+## Caching — inherit the defaults
+
+**Set no cache options unless you can say why.** `utils/queryClient.ts` holds the app defaults (30 min stale, 60 min gc, no refetch on focus) and the summer bunking board runs on them — `hooks/session/useSessionData.ts` overrides nothing. `syncDataOptions` / `userDataOptions` in `queryKeys.ts` are opt-ins, not a menu you must choose from.
+
+Opting *down* to short caching to catch external edits is the trap: it re-pays the whole fetch on every window focus and evicts the cache minutes after you navigate away. Freshness after a write is bought with **explicit invalidation in the mutation**, not with a short `staleTime`. The weekend roster made this mistake and it is documented in `CLAUDE.md` §4 "Family Camp Models Summer".
+
+## Derived values in page components
+
+Anything that builds a model to read a number belongs in `useMemo`. `WeekendRosterPage` built the full board index *and* the full map model on every render — for two tab-badge counts, on every tab, whether or not the board or map was mounted. Memoize on the payload, and put `?? []` fallbacks **inside** the memo: a bare `?? []` mints a new array each render and defeats every dependency list below it.
+
 ## Tour maintenance
 
 When modifying page layout, features, or `data-tour` attributes on a toured page, review the corresponding tour in `src/tours/definitions/`:

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -39,11 +39,16 @@ React + TypeScript + Vite. Dev server on `:3000` (HMR); prod served via Caddy at
 
 Use the centralized keys from `src/utils/queryKeys.ts`. Inlining string keys causes cache collisions and silent bugs when invalidation misses the right query.
 
-## Caching — inherit the defaults
+## Caching — the tiers are opt-ins, and the default is a real choice
 
-**Set no cache options unless you can say why.** `utils/queryClient.ts` holds the app defaults (30 min stale, 60 min gc, no refetch on focus) and the summer bunking board runs on them — `hooks/session/useSessionData.ts` overrides nothing. `syncDataOptions` / `userDataOptions` in `queryKeys.ts` are opt-ins, not a menu you must choose from.
+`utils/queryClient.ts` holds the app defaults (30 min stale, 60 min gc, no refetch on focus). `syncDataOptions` and `userDataOptions` in `queryKeys.ts` are the two named tiers; **inheriting the defaults is a third, legitimate option and is what the bunking board's primary read path does** (`hooks/session/useSessionData.ts` overrides nothing). Roughly 20 call sites use `userDataOptions` and are not thereby wrong — pick deliberately rather than reaching for a tier because one exists.
 
-Opting *down* to short caching to catch external edits is the trap: it re-pays the whole fetch on every window focus and evicts the cache minutes after you navigate away. Freshness after a write is bought with **explicit invalidation in the mutation**, not with a short `staleTime`. The weekend roster made this mistake and it is documented in `CLAUDE.md` §4 "Family Camp Models Summer".
+Two rules that are not negotiable:
+
+- **Opting *down* to a short `staleTime` to catch external edits is the trap.** It re-pays the whole fetch on every window focus and evicts the cache minutes after you navigate away. Freshness after a write is bought with **explicit invalidation in the mutation**.
+- **If you lengthen a `staleTime`, find every writer first.** The weekend roster's move to the app defaults left the lodging admin panels invalidating only their own registry keys, so a cabin confirmation stayed invisible on the roster for 30 minutes. `invalidateLodgingRegistryQueries` (`utils/queryKeys.ts`) is the fix and the pattern: one shared helper, invalidating by **prefix** where the writer cannot know the full key.
+
+Background: `CLAUDE.md` §4 "Family Camp Models Summer".
 
 ## Derived values in page components
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3457,9 +3457,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -70,7 +70,7 @@
     "eslint-plugin-react-hooks": {
       "eslint": "^10.0.0"
     },
-    "brace-expansion": ">=5.0.8",
+    "brace-expansion": ">=5.0.9",
     "flatted": ">=3.4.3",
     "js-yaml": "^4.3.0",
     "postcss": ">=8.5.23",

--- a/frontend/src/components/admin/lodging/LodgingAliasesPanel.tsx
+++ b/frontend/src/components/admin/lodging/LodgingAliasesPanel.tsx
@@ -21,7 +21,11 @@ import {
   listLodgingUnits,
 } from '../../../services/lodgingCrud'
 import type { LodgingAliasRecord } from '../../../types/lodging'
-import { queryKeys, userDataOptions } from '../../../utils/queryKeys'
+import {
+  invalidateLodgingRegistryQueries,
+  queryKeys,
+  userDataOptions,
+} from '../../../utils/queryKeys'
 import { QueryGuard } from '../../QueryGuard'
 import { ACTION_LINK, BUTTON_PRIMARY, HEADER_ROW } from './lodgingStyles'
 import { LodgingAliasForm } from './LodgingAliasForm'
@@ -68,7 +72,7 @@ export function LodgingAliasesPanel() {
 
   const refresh = () => {
     setEditing(null)
-    void queryClient.invalidateQueries({ queryKey: queryKeys.lodgingAliases() })
+    invalidateLodgingRegistryQueries(queryClient)
   }
 
   /**
@@ -90,8 +94,7 @@ export function LodgingAliasesPanel() {
     try {
       await deleteLodgingAlias(alias.id)
       toast.success('Alias deleted')
-      void queryClient.invalidateQueries({ queryKey: queryKeys.lodgingAliases() })
-      void queryClient.invalidateQueries({ queryKey: queryKeys.lodgingIngestIssues() })
+      invalidateLodgingRegistryQueries(queryClient)
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Failed to delete the alias')
     }

--- a/frontend/src/components/admin/lodging/LodgingAreasDrawer.tsx
+++ b/frontend/src/components/admin/lodging/LodgingAreasDrawer.tsx
@@ -24,7 +24,11 @@ import {
   updateLodgingArea,
 } from '../../../services/lodgingCrud'
 import type { LodgingAreaRecord } from '../../../types/lodging'
-import { queryKeys, userDataOptions } from '../../../utils/queryKeys'
+import {
+  invalidateLodgingRegistryQueries,
+  queryKeys,
+  userDataOptions,
+} from '../../../utils/queryKeys'
 import { ACTION_LINK, BUTTON_PRIMARY, FIELD_INLINE as FIELD, LABEL } from './lodgingStyles'
 
 function slugify(name: string): string {
@@ -51,8 +55,7 @@ export function LodgingAreasDrawer({ open, onClose }: LodgingAreasDrawerProps) {
   })
 
   const refresh = () => {
-    void queryClient.invalidateQueries({ queryKey: queryKeys.lodgingAreas() })
-    void queryClient.invalidateQueries({ queryKey: queryKeys.lodgingUnits() })
+    invalidateLodgingRegistryQueries(queryClient)
   }
 
   const areas = areasQuery.data ?? []

--- a/frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx
@@ -26,7 +26,11 @@ import {
   listLodgingUnits,
 } from '../../../services/lodgingCrud'
 import type { LodgingUnitRecord } from '../../../types/lodging'
-import { queryKeys, userDataOptions } from '../../../utils/queryKeys'
+import {
+  invalidateLodgingRegistryQueries,
+  queryKeys,
+  userDataOptions,
+} from '../../../utils/queryKeys'
 import { QueryGuard } from '../../QueryGuard'
 import { BUTTON_PRIMARY, BUTTON_SECONDARY } from './lodgingStyles'
 import { LodgingAreasDrawer } from './LodgingAreasDrawer'
@@ -73,7 +77,7 @@ export function LodgingUnitsPanel() {
   const refresh = () => {
     setEditing(null)
     setSelected(new Set())
-    void queryClient.invalidateQueries({ queryKey: queryKeys.lodgingUnits() })
+    invalidateLodgingRegistryQueries(queryClient)
   }
 
   const toggleSort = (field: UnitSort['field']) => {

--- a/frontend/src/components/admin/lodging/UnresolvedAliasQueue.tsx
+++ b/frontend/src/components/admin/lodging/UnresolvedAliasQueue.tsx
@@ -25,7 +25,11 @@ import {
   mapUnresolvedAlias,
 } from '../../../services/lodgingCrud'
 import type { LodgingIngestIssueRecord } from '../../../types/lodging'
-import { queryKeys, userDataOptions } from '../../../utils/queryKeys'
+import {
+  invalidateLodgingRegistryQueries,
+  queryKeys,
+  userDataOptions,
+} from '../../../utils/queryKeys'
 import { QueryGuard } from '../../QueryGuard'
 import { eligibleAliasMembers } from './aliasMembers'
 import { BUTTON_PRIMARY, BUTTON_SECONDARY, LABEL } from './lodgingStyles'
@@ -49,8 +53,7 @@ export function UnresolvedAliasQueue() {
   })
 
   const refresh = () => {
-    void queryClient.invalidateQueries({ queryKey: queryKeys.lodgingIngestIssues() })
-    void queryClient.invalidateQueries({ queryKey: queryKeys.lodgingAliases() })
+    invalidateLodgingRegistryQueries(queryClient)
   }
 
   const toggleUnit = (queueId: string, unitId: string) => {

--- a/frontend/src/hooks/useWeekendRoster.test.tsx
+++ b/frontend/src/hooks/useWeekendRoster.test.tsx
@@ -55,8 +55,10 @@ function wrapper({ children }: { children: ReactNode }) {
 /**
  * The options React Query actually resolved for a mounted query, client
  * defaults merged in. Read from the OBSERVER, not the query: `staleTime` and
- * `refetchOnWindowFocus` are observer-level options and are absent from
- * `Query.options`, so asserting there would silently check nothing.
+ * `refetchOnWindowFocus` are observer-level options, absent from the
+ * `QueryOptions` type that `Query.options` carries. Asserting there does not
+ * silently pass — it fails typecheck — but the observer is where these
+ * options actually resolve, so it is the honest place to read them.
  */
 function resolvedOptions(queryKey: readonly unknown[]) {
   const query = client.getQueryCache().find({ queryKey })
@@ -74,6 +76,41 @@ beforeEach(() => {
   fetchWeekendSummary.mockReset().mockResolvedValue({ year: 2026, weekends: [] })
   fetchWeekendRoster.mockReset().mockResolvedValue({ year: 2026, session_cm_id: 1000001 })
   fetchHouseholdMedical.mockReset().mockResolvedValue({ household_cm_id: 2000001, year: 2026 })
+})
+
+describe('year gating', () => {
+  // `CurrentYearContext` resolves the year from the backend and returns the
+  // literal number 0 until it does (`CurrentYearContext.tsx:67-69`), exposing
+  // an `isYearReady` flag for consumers to gate on. Neither weekend page
+  // reads that flag, so without an `enabled` guard every one of these hooks
+  // fires `?year=0` on cold load. The routers declare `ge=2000`
+  // (`api/routers/lodging.py:64,77,99`), so that is a guaranteed 422 — and
+  // `queryClient.ts` only skips retry on 401, so it is retried with backoff.
+  // `enabled: year > 0` is the established convention at 14+ other hooks.
+  it('does not fetch the session list before the year resolves', () => {
+    renderHook(() => useWeekendSessions(0), { wrapper })
+    expect(fetchWeekendSessions).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch the summary before the year resolves', () => {
+    renderHook(() => useWeekendSummary(0), { wrapper })
+    expect(fetchWeekendSummary).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch the roster before the year resolves, even with a session', () => {
+    // The existing `enabled: sessionCmId !== null` guard does NOT cover this:
+    // on a direct load of /weekend/1000001 the id is parsed synchronously off
+    // the URL, deliberately, so it is non-null on the very first render while
+    // the year is still 0. The guard was on the wrong axis.
+    renderHook(() => useWeekendRoster(0, 1000001), { wrapper })
+    expect(fetchWeekendRoster).not.toHaveBeenCalled()
+  })
+
+  it('fetches once the year is real', async () => {
+    const { result } = renderHook(() => useWeekendRoster(2026, 1000001), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(fetchWeekendRoster).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('cache parity with summer', () => {
@@ -107,6 +144,7 @@ describe('cache parity with summer', () => {
 
     const options = resolvedOptions(queryKeys.weekendSessions(2026))
     expect(options.staleTime).toBe(APP_CACHE_DEFAULTS.staleTime)
+    expect(options.gcTime).toBe(APP_CACHE_DEFAULTS.gcTime)
     expect(options.refetchOnWindowFocus).toBe(false)
   })
 
@@ -116,6 +154,7 @@ describe('cache parity with summer', () => {
 
     const options = resolvedOptions(queryKeys.weekendSummary(2026))
     expect(options.staleTime).toBe(APP_CACHE_DEFAULTS.staleTime)
+    expect(options.gcTime).toBe(APP_CACHE_DEFAULTS.gcTime)
     expect(options.refetchOnWindowFocus).toBe(false)
   })
 

--- a/frontend/src/hooks/useWeekendRoster.test.tsx
+++ b/frontend/src/hooks/useWeekendRoster.test.tsx
@@ -31,16 +31,104 @@ vi.mock('./useApiWithAuth', () => ({
   useApiWithAuth: () => ({ fetchWithAuth: vi.fn(), isAuthenticated: true, isAuthLoading: false }),
 }))
 
+/**
+ * The app's real cache defaults (`utils/queryClient.ts`). The summer bunking
+ * board's hooks — `hooks/session/useSessionData.ts` — set NO cache options at
+ * all, so these are what summer actually runs on. Weekend must inherit them
+ * too; see the "model summer" rule in CLAUDE.md.
+ */
+const APP_CACHE_DEFAULTS = {
+  staleTime: 30 * 60 * 1000,
+  gcTime: 60 * 60 * 1000,
+  refetchOnWindowFocus: false,
+} as const
+
+// One client per test, built in beforeEach rather than in the wrapper body —
+// a client constructed during render is rebuilt on every render and forgets
+// its cache between them, which is exactly what these tests inspect (#1944).
+let client: QueryClient
+
 function wrapper({ children }: { children: ReactNode }) {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>
 }
 
+/**
+ * The options React Query actually resolved for a mounted query, client
+ * defaults merged in. Read from the OBSERVER, not the query: `staleTime` and
+ * `refetchOnWindowFocus` are observer-level options and are absent from
+ * `Query.options`, so asserting there would silently check nothing.
+ */
+function resolvedOptions(queryKey: readonly unknown[]) {
+  const query = client.getQueryCache().find({ queryKey })
+  if (!query) throw new Error(`no query cached for ${JSON.stringify(queryKey)}`)
+  const observer = query.observers[0]
+  if (!observer) throw new Error(`query ${JSON.stringify(queryKey)} has no mounted observer`)
+  return observer.options
+}
+
 beforeEach(() => {
+  client = new QueryClient({
+    defaultOptions: { queries: { retry: false, ...APP_CACHE_DEFAULTS } },
+  })
   fetchWeekendSessions.mockReset().mockResolvedValue({ year: 2026, sessions: [] })
   fetchWeekendSummary.mockReset().mockResolvedValue({ year: 2026, weekends: [] })
   fetchWeekendRoster.mockReset().mockResolvedValue({ year: 2026, session_cm_id: 1000001 })
   fetchHouseholdMedical.mockReset().mockResolvedValue({ household_cm_id: 2000001, year: 2026 })
+})
+
+describe('cache parity with summer', () => {
+  // Weekend previously opted down to `userDataOptions` — 30s stale, 5min gc,
+  // refetch on focus — justified by "staff edit cabin assignments in
+  // CampMinder while the page is open". Two things kill that justification.
+  // Summer's board has exactly the same property and does NOT opt down. And a
+  // weekend is worked by ONE person at a time, modelling scenarios for
+  // themselves; a second staff member looking on is rare and read-shaped.
+  // There is no concurrent-edit hazard to buy with short caching, so the
+  // trade was all cost: a ~3s eleven-query roster rebuild every 30 seconds,
+  // and a cache evicted entirely after five minutes away.
+  //
+  // The safety this gives up is REAL but belongs elsewhere: once drag
+  // placement writes, its mutations must invalidate `weekendRoster` /
+  // `weekendSummary` explicitly, the way summer's mutations do. Long
+  // staleTime plus deliberate invalidation, not short staleTime plus hope.
+  it('lets the roster inherit the app cache defaults, as the summer board does', async () => {
+    const { result } = renderHook(() => useWeekendRoster(2026, 1000001), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const options = resolvedOptions(queryKeys.weekendRoster(2026, 1000001))
+    expect(options.staleTime).toBe(APP_CACHE_DEFAULTS.staleTime)
+    expect(options.gcTime).toBe(APP_CACHE_DEFAULTS.gcTime)
+    expect(options.refetchOnWindowFocus).toBe(false)
+  })
+
+  it('lets the session list inherit them', async () => {
+    const { result } = renderHook(() => useWeekendSessions(2026), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const options = resolvedOptions(queryKeys.weekendSessions(2026))
+    expect(options.staleTime).toBe(APP_CACHE_DEFAULTS.staleTime)
+    expect(options.refetchOnWindowFocus).toBe(false)
+  })
+
+  it('lets the lander summary inherit them', async () => {
+    const { result } = renderHook(() => useWeekendSummary(2026), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const options = resolvedOptions(queryKeys.weekendSummary(2026))
+    expect(options.staleTime).toBe(APP_CACHE_DEFAULTS.staleTime)
+    expect(options.refetchOnWindowFocus).toBe(false)
+  })
+
+  it('keeps PHI uncached, which is a DELIBERATE divergence and must survive', async () => {
+    // The one weekend query that should not inherit: a medical narrative must
+    // not sit in the cache after the panel closes.
+    const { result } = renderHook(() => useHouseholdMedical(2026, 2000001, true), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const options = resolvedOptions(queryKeys.householdMedical(2026, 2000001))
+    expect(options.staleTime).toBe(0)
+    expect(options.gcTime).toBe(0)
+  })
 })
 
 describe('queryKeys', () => {

--- a/frontend/src/hooks/useWeekendRoster.ts
+++ b/frontend/src/hooks/useWeekendRoster.ts
@@ -1,10 +1,27 @@
 /**
  * React Query hooks for the weekend lodging roster.
  *
- * The roster and session list use `userDataOptions` (30s stale, refetch on
- * focus) rather than `syncDataOptions`: staff edit cabin assignments in
- * CampMinder while the page is open, and the 2025 values show edits across
- * many distinct days.
+ * CACHING MODELS SUMMER, DELIBERATELY. These queries set no cache options, so
+ * they inherit the app defaults in `utils/queryClient.ts` — exactly as the
+ * summer bunking board's hooks do (`hooks/session/useSessionData.ts` sets
+ * none either). Do not reintroduce a weekend-specific policy; see the
+ * "model summer" rule in CLAUDE.md.
+ *
+ * These hooks previously used `userDataOptions` (30s stale, 5min gc, refetch
+ * on focus), justified by staff editing cabin assignments in CampMinder while
+ * the page is open. That justification did not survive contact with two facts.
+ * Summer's board has the same property and does not opt down. And a weekend is
+ * worked by ONE person at a time, modelling scenarios for themselves — a
+ * second staff member is rare and read-shaped — so there is no concurrent-edit
+ * hazard being bought. What it cost was real: `build_roster` issues eleven
+ * PocketBase fetches and its own docstring puts an empty weekend at about
+ * three seconds, and that was being re-paid every 30 seconds of window focus,
+ * with the cache dropped entirely after five minutes away.
+ *
+ * The freshness this gives up has to be bought back deliberately: when drag
+ * placement writes, its mutations MUST invalidate `weekendRoster` and
+ * `weekendSummary`, the way summer's mutations invalidate theirs. Long
+ * staleTime plus explicit invalidation — not short staleTime plus hope.
  */
 
 import { useQuery } from '@tanstack/react-query'
@@ -21,7 +38,7 @@ import type {
   WeekendSessionList,
   WeekendSummary,
 } from '../types/lodging'
-import { queryKeys, userDataOptions } from '../utils/queryKeys'
+import { queryKeys } from '../utils/queryKeys'
 import { useApiWithAuth } from './useApiWithAuth'
 
 /** Every family-camp and adult weekend for the year. */
@@ -29,7 +46,6 @@ export function useWeekendSessions(year: number) {
   const { fetchWithAuth } = useApiWithAuth()
   return useQuery<WeekendSessionList>({
     queryKey: queryKeys.weekendSessions(year),
-    ...userDataOptions,
     queryFn: () => fetchSessions(fetchWithAuth, year),
   })
 }
@@ -42,7 +58,6 @@ export function useWeekendSummary(year: number) {
   const { fetchWithAuth } = useApiWithAuth()
   return useQuery<WeekendSummary>({
     queryKey: queryKeys.weekendSummary(year),
-    ...userDataOptions,
     queryFn: () => fetchSummary(fetchWithAuth, year),
   })
 }
@@ -52,7 +67,6 @@ export function useWeekendRoster(year: number, sessionCmId: number | null) {
   const { fetchWithAuth } = useApiWithAuth()
   return useQuery<WeekendRoster>({
     queryKey: queryKeys.weekendRoster(year, sessionCmId ?? 0),
-    ...userDataOptions,
     enabled: sessionCmId !== null,
     queryFn: () => fetchRoster(fetchWithAuth, year, sessionCmId as number),
   })

--- a/frontend/src/hooks/useWeekendRoster.ts
+++ b/frontend/src/hooks/useWeekendRoster.ts
@@ -14,14 +14,26 @@
  * worked by ONE person at a time, modelling scenarios for themselves — a
  * second staff member is rare and read-shaped — so there is no concurrent-edit
  * hazard being bought. What it cost was real: `build_roster` issues eleven
- * PocketBase fetches and its own docstring puts an empty weekend at about
+ * PocketBase fetches, and `build_summary`'s docstring (which exists because
+ * calling the roster per weekend repeated them) puts an empty weekend at about
  * three seconds, and that was being re-paid every 30 seconds of window focus,
  * with the cache dropped entirely after five minutes away.
  *
- * The freshness this gives up has to be bought back deliberately: when drag
- * placement writes, its mutations MUST invalidate `weekendRoster` and
- * `weekendSummary`, the way summer's mutations invalidate theirs. Long
- * staleTime plus explicit invalidation — not short staleTime plus hope.
+ * The freshness this gives up has to be bought back deliberately, and that debt
+ * is ALREADY outstanding — it is not a future obligation of the drag PR. The
+ * lodging admin panels edit registry rows that `_build_units` projects into
+ * this very payload, so they invalidate through
+ * `invalidateLodgingRegistryQueries`. Drag placement's mutations must do the
+ * same. Long staleTime plus explicit invalidation — not short staleTime plus
+ * hope.
+ *
+ * EVERY hook here is gated on `year > 0`. `CurrentYearContext` returns the
+ * literal 0 until the backend supplies the configured year, and neither
+ * weekend page reads the `isYearReady` flag it exposes — so without the guard
+ * these fire `?year=0` against routers declaring `ge=2000` and eat a 422 on
+ * every cold load. The roster's `sessionCmId !== null` guard did not cover it:
+ * on a direct deep link the id is parsed synchronously off the URL, on purpose,
+ * so it is non-null on the first render while the year is still 0.
  */
 
 import { useQuery } from '@tanstack/react-query'
@@ -46,6 +58,7 @@ export function useWeekendSessions(year: number) {
   const { fetchWithAuth } = useApiWithAuth()
   return useQuery<WeekendSessionList>({
     queryKey: queryKeys.weekendSessions(year),
+    enabled: year > 0,
     queryFn: () => fetchSessions(fetchWithAuth, year),
   })
 }
@@ -58,6 +71,7 @@ export function useWeekendSummary(year: number) {
   const { fetchWithAuth } = useApiWithAuth()
   return useQuery<WeekendSummary>({
     queryKey: queryKeys.weekendSummary(year),
+    enabled: year > 0,
     queryFn: () => fetchSummary(fetchWithAuth, year),
   })
 }
@@ -67,7 +81,7 @@ export function useWeekendRoster(year: number, sessionCmId: number | null) {
   const { fetchWithAuth } = useApiWithAuth()
   return useQuery<WeekendRoster>({
     queryKey: queryKeys.weekendRoster(year, sessionCmId ?? 0),
-    enabled: sessionCmId !== null,
+    enabled: year > 0 && sessionCmId !== null,
     queryFn: () => fetchRoster(fetchWithAuth, year, sessionCmId as number),
   })
 }

--- a/frontend/src/pages/WeekendRosterPage.test.tsx
+++ b/frontend/src/pages/WeekendRosterPage.test.tsx
@@ -39,6 +39,29 @@ vi.mock('../hooks/usePermissions', () => ({
   }),
 }))
 
+// Pass-through spies on the two expensive derivations the header needs for
+// its tab counts. Both build a whole model to read a length — `countBoardSlots`
+// indexes the entire board, `countMapUnits` builds the board AND the map model
+// — so calling them on every render is real work, on every tab, whether or not
+// the board or map is mounted.
+const countBoardSlotsSpy = vi.fn()
+const countMapUnitsSpy = vi.fn()
+
+vi.mock('../components/weekend', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../components/weekend')>()
+  return {
+    ...actual,
+    countBoardSlots: (...args: Parameters<typeof actual.countBoardSlots>) => {
+      countBoardSlotsSpy()
+      return actual.countBoardSlots(...args)
+    },
+    countMapUnits: (...args: Parameters<typeof actual.countMapUnits>) => {
+      countMapUnitsSpy()
+      return actual.countMapUnits(...args)
+    },
+  }
+})
+
 // The `useNavigate` spy this file used to install has been removed on purpose.
 // The view now lives in the URL, so a spy would have asserted that the page
 // ASKED to navigate while the page it rendered stayed on the old tab — the
@@ -480,5 +503,62 @@ describe('tabs', () => {
     renderPage()
     expect(screen.getByRole('tab', { name: 'Inventory (3)' })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: 'Map (1)' })).toBeInTheDocument()
+  })
+})
+
+describe('recomputation', () => {
+  // Switching tabs re-renders this page with the SAME roster payload. Nothing
+  // about the board index or the map model can have changed, so neither should
+  // be rebuilt — and the summer board it is modelled on does not rebuild its
+  // derivations per render either. The tab-count assertions above are the
+  // correctness half of this pair: they fail if memoising returns stale counts.
+  it('does not rebuild the board index or the map model when only the tab changes', async () => {
+    renderPage()
+    countBoardSlotsSpy.mockClear()
+    countMapUnitsSpy.mockClear()
+
+    await userEvent.click(screen.getByRole('tab', { name: /Board/ }))
+    await userEvent.click(screen.getByRole('tab', { name: /Map/ }))
+    await userEvent.click(screen.getByRole('tab', { name: /Roster/ }))
+
+    expect(countBoardSlotsSpy).not.toHaveBeenCalled()
+    expect(countMapUnitsSpy).not.toHaveBeenCalled()
+  })
+
+  it('does rebuild them when the roster payload actually changes', async () => {
+    // The guard above must not be satisfiable by never computing at all.
+    const { rerender } = renderPage()
+    countBoardSlotsSpy.mockClear()
+    countMapUnitsSpy.mockClear()
+
+    rosterQuery.data = {
+      year: 2026,
+      session_cm_id: 1000001,
+      parties: [],
+      units: [
+        {
+          unit_id: 'u1',
+          code: 'cedar-1',
+          name: 'Cedar 1',
+          area_code: 'CG',
+          area_name: 'Cedar Grove',
+          is_container: false,
+          is_active: true,
+          map_x: 0.2,
+          map_y: 0.3,
+        },
+      ],
+      counts: {},
+    }
+    rerender(
+      <MemoryRouter initialEntries={['/weekend/1000001']}>
+        <Routes>
+          <Route path="/weekend/:sessionRef/:view?" element={<WeekendRosterPage />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(countBoardSlotsSpy).toHaveBeenCalled()
+    expect(countMapUnitsSpy).toHaveBeenCalled()
   })
 })

--- a/frontend/src/pages/WeekendRosterPage.tsx
+++ b/frontend/src/pages/WeekendRosterPage.tsx
@@ -31,6 +31,7 @@ import {
   Settings2,
   Users,
 } from 'lucide-react'
+import { useMemo } from 'react'
 import { Link, useNavigate, useParams } from 'react-router'
 
 import { QueryGuard } from '../components/QueryGuard'
@@ -103,8 +104,24 @@ export default function WeekendRosterPage() {
     ? formatSessionDates(selectedSession.start_date, selectedSession.end_date)
     : ''
 
-  const parties = rosterQuery.data?.parties ?? []
-  const units = rosterQuery.data?.units ?? []
+  // Memoised on the payload, not left to run per render. The `?? []` fallbacks
+  // are inside the memo on purpose: a bare `?? []` mints a new array every
+  // render while the roster is loading, which would defeat every dependency
+  // list below it.
+  const parties = useMemo(() => rosterQuery.data?.parties ?? [], [rosterQuery.data])
+  const units = useMemo(() => rosterQuery.data?.units ?? [], [rosterQuery.data])
+
+  // These two build a whole model to read a length — `countBoardSlots` indexes
+  // the entire board, and `countMapUnits` builds the board AND the map model on
+  // top of it. The header needs both counts on every tab, so unmemoised they
+  // ran twice per render of this page no matter which view was showing.
+  const boardSlotCount = useMemo(() => countBoardSlots(parties, units), [parties, units])
+  const mapUnitCount = useMemo(() => countMapUnits(parties, units), [parties, units])
+  const bedsNeeded = useMemo(
+    () => parties.reduce((sum, party) => sum + partyBeds(party), 0),
+    [parties]
+  )
+  const spacesUnmeasured = useMemo(() => countUnmeasuredSpaces(units), [units])
 
   const TABS: Array<{ id: View; label: string; icon: typeof Users; count: number }> = [
     { id: 'roster', label: 'Roster', icon: Users, count: parties.length },
@@ -112,8 +129,8 @@ export default function WeekendRosterPage() {
     // The board counts the SLOT CARDS it draws, which is not the inventory
     // count: a container carries the beds its halves already report, so it
     // never gets a card and never counts.
-    { id: 'board', label: 'Board', icon: LayoutGrid, count: countBoardSlots(parties, units) },
-    { id: 'map', label: 'Map', icon: MapIcon, count: countMapUnits(parties, units) },
+    { id: 'board', label: 'Board', icon: LayoutGrid, count: boardSlotCount },
+    { id: 'map', label: 'Map', icon: MapIcon, count: mapUnitCount },
   ]
 
   return (
@@ -247,8 +264,8 @@ export default function WeekendRosterPage() {
 
               <WeekendStatsBar
                 counts={roster.counts ?? {}}
-                bedsNeeded={parties.reduce((sum, party) => sum + partyBeds(party), 0)}
-                spacesUnmeasured={countUnmeasuredSpaces(units)}
+                bedsNeeded={bedsNeeded}
+                spacesUnmeasured={spacesUnmeasured}
               />
             </div>
 

--- a/frontend/src/utils/queryClient.ts
+++ b/frontend/src/utils/queryClient.ts
@@ -4,8 +4,11 @@ import { pb } from '../lib/pocketbase'
 // Clean up legacy localStorage persistence (removed in this version)
 localStorage.removeItem('bunking-query-cache')
 
-// Create query client with simplified caching strategy
-// Most data uses 30/60 min defaults; user-editable data overrides at query level
+// Create query client with simplified caching strategy.
+// Most data uses these 30/60 min defaults. Some user-editable data overrides at
+// query level via `userDataOptions` — but that is a deliberate choice, not the
+// expected one: a surface whose writes all go through this app should inherit
+// these defaults and invalidate on mutation instead. See `frontend/CLAUDE.md`.
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -91,6 +94,12 @@ const SYNC_DEPENDENT_PREFIXES = [
   'metrics',
   // Sync status
   'sync-status',
+  // Weekend lodging (Tier 1) — the lodging ingest writes assignments, requests
+  // and registry rows that all three of these read. Omitted until #1965, so a
+  // completed sync refreshed nothing it had just written.
+  'weekend-sessions',
+  'weekend-summary',
+  'weekend-roster',
 ] as const
 
 /**

--- a/frontend/src/utils/queryKeys.test.ts
+++ b/frontend/src/utils/queryKeys.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { queryKeys } from './queryKeys'
+import { invalidateLodgingRegistryQueries, queryKeys } from './queryKeys'
 
 describe('queryKeys.originalBunkRequestsByRequesterCmId', () => {
   it('key includes a requester-cm-id discriminator', () => {
@@ -137,5 +137,60 @@ describe('queryKeys.sessionUploadChanges', () => {
       'r1',
       [1000001, 1000099],
     ])
+  })
+})
+
+describe('invalidateLodgingRegistryQueries', () => {
+  // The lodging registry IS roster input: `_build_units`
+  // (api/services/lodging_roster_service.py:350-419) projects name, area_name,
+  // sleeps, is_confirmed, is_active, allocation_default and map_x/map_y into
+  // the roster payload. WeekendRosterPage links straight to
+  // /manage/lodging/units, so admin-edit-then-back is the designed round trip
+  // — and the weekend queries now carry a 30 minute staleTime, so nothing
+  // refreshes on its own.
+  function recordingClient() {
+    const keys: readonly unknown[][] = []
+    return {
+      keys,
+      invalidateQueries: ({ queryKey }: { queryKey: readonly unknown[] }) => {
+        ;(keys as unknown[][]).push([...queryKey])
+        return undefined
+      },
+    }
+  }
+
+  it('invalidates the weekend roster, summary and session list', () => {
+    const client = recordingClient()
+    invalidateLodgingRegistryQueries(client)
+
+    expect(client.keys).toContainEqual(['weekend-roster'])
+    expect(client.keys).toContainEqual(['weekend-summary'])
+    expect(client.keys).toContainEqual(['weekend-sessions'])
+  })
+
+  it('still invalidates the registry keys the admin panels own', () => {
+    const client = recordingClient()
+    invalidateLodgingRegistryQueries(client)
+
+    expect(client.keys).toContainEqual([...queryKeys.lodgingUnits()])
+    expect(client.keys).toContainEqual([...queryKeys.lodgingAreas()])
+    expect(client.keys).toContainEqual([...queryKeys.lodgingAliases()])
+    expect(client.keys).toContainEqual([...queryKeys.lodgingIngestIssues()])
+  })
+
+  it('invalidates the weekend keys by PREFIX, not by exact key', () => {
+    // The admin panel knows neither the year nor the weekend, and the real
+    // keys are [key, year] / [key, year, sessionCmId]. An exact-key
+    // invalidation would match nothing that is actually cached.
+    const client = recordingClient()
+    invalidateLodgingRegistryQueries(client)
+
+    const roster = client.keys.find((k) => k[0] === 'weekend-roster')
+    const summary = client.keys.find((k) => k[0] === 'weekend-summary')
+    expect(roster).toHaveLength(1)
+    expect(summary).toHaveLength(1)
+    // And the prefix must genuinely head the real key.
+    const full = queryKeys.weekendRoster(2026, 1000001)
+    expect(full.slice(0, 1)).toEqual(roster)
   })
 })

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -476,6 +476,12 @@ export const queryKeys = {
   weekendSummary: (year: number) => ['weekend-summary', year] as const,
   weekendRoster: (year: number, sessionCmId: number) =>
     ['weekend-roster', year, sessionCmId] as const,
+  // Prefixes for invalidation. The lodging admin panels edit registry rows
+  // that feed the roster, but know neither the year nor the weekend, so they
+  // cannot build a full key — see `invalidateLodgingRegistryQueries`.
+  weekendSessionsPrefix: () => ['weekend-sessions'] as const,
+  weekendSummaryPrefix: () => ['weekend-summary'] as const,
+  weekendRosterPrefix: () => ['weekend-roster'] as const,
   /** PHI. Only ever fetched behind an explicit, permission-checked reveal. */
   householdMedical: (year: number, householdCmId: number) =>
     ['household-medical', year, householdCmId] as const,
@@ -538,7 +544,48 @@ export function invalidateRequestQueries(
 }
 
 /**
+ * Invalidate everything a lodging-registry edit can change — including the
+ * weekend surfaces, which are NOT obvious.
+ *
+ * The registry is roster input. `_build_units`
+ * (`api/services/lodging_roster_service.py:350-419`) projects `name`,
+ * `area_name`, `sleeps`, `is_confirmed`, `is_active`, `allocation_default` and
+ * `map_x`/`map_y` into the roster payload — every field these admin forms
+ * edit. `WeekendRosterPage` links straight to `/manage/lodging/units`, so
+ * edit-then-go-back is the designed round trip, not an edge case.
+ *
+ * This became load-bearing when the weekend queries moved from a 30 second
+ * staleTime to the app default of 30 minutes. Previously the round trip
+ * self-healed on remount; now nothing refreshes it, so confirming cabins and
+ * returning would leave the "N of M cabins have unconfirmed amenities" banner
+ * unchanged for half an hour on the screen whose whole purpose is confirmation.
+ *
+ * The weekend keys MUST be invalidated by prefix: the real keys are
+ * `[key, year]` and `[key, year, sessionCmId]`, and an admin panel knows
+ * neither, so an exact-key call would match nothing that is cached.
+ */
+export function invalidateLodgingRegistryQueries(queryClient: {
+  invalidateQueries: (args: { queryKey: readonly unknown[] }) => unknown
+}): void {
+  void queryClient.invalidateQueries({ queryKey: queryKeys.lodgingUnits() })
+  void queryClient.invalidateQueries({ queryKey: queryKeys.lodgingAreas() })
+  void queryClient.invalidateQueries({ queryKey: queryKeys.lodgingAliases() })
+  void queryClient.invalidateQueries({ queryKey: queryKeys.lodgingIngestIssues() })
+  void queryClient.invalidateQueries({ queryKey: queryKeys.weekendRosterPrefix() })
+  void queryClient.invalidateQueries({ queryKey: queryKeys.weekendSummaryPrefix() })
+  void queryClient.invalidateQueries({ queryKey: queryKeys.weekendSessionsPrefix() })
+}
+
+/**
  * 2-Tier Caching Model
+ *
+ * These two tiers are OPT-INS, not an exhaustive menu. Inheriting the client
+ * defaults in `utils/queryClient.ts` is a third, legitimate choice and is what
+ * the bunking board's primary read path (`hooks/session/useSessionData.ts`)
+ * and the weekend lodging hooks do. Reach for a tier when its semantics fit,
+ * not because the constant exists — and note that opting *down* to Tier 2 to
+ * catch external edits is usually the wrong trade: invalidate on write instead.
+ * See `frontend/CLAUDE.md` and `CLAUDE.md` §4.
  *
  * Tier 1: Sync data (read-only, long cache)
  * - Data synced from CampMinder that rarely changes during a session


### PR DESCRIPTION
Two divergences from the summer board, both paid on every interaction with a weekend, plus the rule written down so the next surface doesn't rediscover them.

## Caching

The weekend hooks used `userDataOptions` — 30 s stale, 5 min gc, refetch on focus — justified in the file as guarding against staff editing cabin assignments in CampMinder while the page is open.

That justification doesn't survive two facts:

- **Summer has exactly the same property and doesn't opt down.** `hooks/session/useSessionData.ts` overrides nothing and inherits the app defaults in `utils/queryClient.ts` — 30 min stale, 60 min gc, no refetch on focus.
- **A weekend is worked by one person at a time**, modelling scenarios for themselves. A second staff member looking on is rare and read-shaped. There was no concurrent-edit hazard being bought.

The cost was real. `build_roster` issues eleven PocketBase fetches (`api/services/lodging_roster_service.py:185-196`) and its own docstring puts an empty weekend at about three seconds — re-paid on every window focus after 30 seconds, and re-paid cold after five minutes away.

The list / roster / summary hooks now inherit the defaults. `useHouseholdMedical` keeps `staleTime: 0, gcTime: 0`: a PHI narrative must not sit in the cache after the panel closes, and that divergence is deliberate and commented — it's the model for how a justified one should read.

**Freshness after a write now has to be bought explicitly.** When drag placement lands, its mutations must invalidate `weekendRoster` and `weekendSummary`, the way summer's mutations invalidate theirs. The hook docstring says so at the point someone will be editing.

## Derived values

`WeekendRosterPage` had no `useMemo` at all. Building the `TABS` array called:

- `countBoardSlots` → `indexPayload(parties, units).drawn.length` — a full board index, to read a length
- `countMapUnits` → `buildMapModel(parties, units).units.length` — which builds the board *again*, then the map model on top

Both ran on every render, on every tab, whether or not the board or map was mounted — so the board index was constructed twice per render while sitting on the Roster tab. Plus a `parties.reduce` and `countUnmeasuredSpaces` in the stats bar.

All four are now memoized on the payload, with the `?? []` fallbacks **inside** the memo: a bare `?? []` mints a new array every render while the roster loads, which would defeat every dependency list below it.

## Tests

Written first, both failing for the right reason:

- The cache tests read the resolved **observer** options — `staleTime` and `refetchOnWindowFocus` are absent from `Query.options`, so asserting there would have silently checked nothing — and reported `30000` against `1800000`.
- The memo test counted three rebuilds across three tab clicks.

A companion test asserts the counts **are** rebuilt when the payload actually changes, so the guard can't be satisfied by never computing. The existing `Board (N)` / `Map (N)` assertions are the correctness half — they fail if memoizing returns stale counts.

While editing `useWeekendRoster.test.tsx` I also moved its `QueryClient` out of the wrapper body into `beforeEach`, which is one of the ten files #1944 names.

## The rule

`CLAUDE.md` §4 gains **Family Camp Models Summer** as a critical rule with a dimension table — UI primitives, styling, URL style, cache performance, RBAC, data fetching, error handling. Divergence must be deliberate, justified in a comment, and defensible against what summer does. `frontend/CLAUDE.md` carries the two operational specifics.

## Filed, not fixed

- **#1963** — `build_roster`'s eleven fetches, eight of them year-scoped. `build_summary` already hoists them for the lander; the roster never got the same treatment. Distinct from #1920, which is the scenario-mode fan-out and still has no caller.
- **#1964** — the ~46 KB map ships in the roster route's initial chunk via the eager barrel import.

## Verification

Full frontend suite **5406 passed / 390 files**, `tsc --noEmit` clean, full pre-push green (ruff, mypy 795 files, go build, shellcheck, pb-js-lint, markdownlint, api-types freshness, tsc, pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved Weekend Roster responsiveness by avoiding unnecessary recalculation when switching tabs or viewing statistics.
  - Roster-derived information now updates when underlying roster data changes.

- **Data Handling**
  - Weekend roster and summary data now follow consistent application-wide caching behavior.
  - Household medical information continues to use privacy-focused, immediate-refresh handling.
  - Weekend data loads only after a valid year and session are selected.
  - Lodging updates now refresh related registry, roster, and summary information consistently.

- **Documentation**
  - Added guidance for caching, data updates, error handling, and family camp experiences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->