### PR TITLE
perf(api): page the lodging reads in 1000s and compress the response

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -129,8 +129,9 @@ def create_app() -> FastAPI:
     # affected by the body encoding. `minimum_size` keeps small bodies alone,
     # where the gzip header and the CPU cost outweigh the saving.
     #
-    # This is negotiated, not forced: a client sending `Accept-Encoding:
-    # identity` -- which is what plain `curl` sends -- still gets a raw body.
+    # This is negotiated, not forced: a client that does not offer gzip -- an
+    # explicit `Accept-Encoding: identity`, or no such header at all, which is
+    # what plain `curl` sends -- still gets a raw body.
     app.add_middleware(GZipMiddleware, minimum_size=1000)
 
     # CORS configuration

--- a/api/main.py
+++ b/api/main.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
@@ -116,6 +117,21 @@ def create_app() -> FastAPI:
 
     # Load settings
     settings = get_settings()
+
+    # Response compression (#1966).
+    #
+    # The weekend roster is ~107 KB of JSON and was crossing the wire raw --
+    # neither Caddyfile carries `encode`, so nothing downstream was doing this
+    # either. JSON of that shape compresses roughly 9:1.
+    #
+    # Added FIRST so it sits innermost and compresses the handler's response
+    # before CORS and auth add their headers; those are header-only and are not
+    # affected by the body encoding. `minimum_size` keeps small bodies alone,
+    # where the gzip header and the CPU cost outweigh the saving.
+    #
+    # This is negotiated, not forced: a client sending `Accept-Encoding:
+    # identity` -- which is what plain `curl` sends -- still gets a raw body.
+    app.add_middleware(GZipMiddleware, minimum_size=1000)
 
     # CORS configuration
     app.add_middleware(

--- a/api/services/lodging_repository.py
+++ b/api/services/lodging_repository.py
@@ -83,9 +83,10 @@ STABLE_SORT = "id"
 # the roster's ~3.1s, to produce one boolean per party. At 1000 it is 21
 # requests and ~1.0s (#1966).
 #
-# `batch` is a parameter of `get_full_list` itself, NOT a member of
-# `query_params`. Putting it in the dict is accepted silently and leaves the
-# default in place, which is why a test asserts it reaches the SDK.
+# Applied in ONE place, `_page`, rather than at each call site: `batch` is a
+# parameter of `get_full_list` itself and NOT a member of `query_params`, so
+# putting it in the dict is accepted silently and leaves the default in place.
+# A read that never passes the parameter cannot pass it wrongly.
 #
 # 1000 is the CEILING, not a guess: PocketBase declares `MaxPerPage int = 1000`
 # and `tools/search/provider.go:289` CLAMPS a larger request rather than
@@ -104,11 +105,29 @@ class LodgingRepository:
     def __init__(self, pb: PocketBase) -> None:
         self.pb = pb
 
+    async def _page(self, collection: str, query_params: dict[str, Any]) -> list[Any]:
+        """Read a whole collection, paging at PAGE_SIZE.
+
+        THE ONLY PLACE `get_full_list` IS NAMED. Every paged read goes through
+        here so that a read added later cannot forget `batch` -- it never
+        passes one. The earlier shape spelled `batch=PAGE_SIZE` at each of the
+        seventeen call sites and relied on a test to catch the eighteenth,
+        which is a weaker guarantee than not having the parameter to forget.
+
+        `batch` is a parameter of `get_full_list` itself, NOT a member of
+        `query_params`: putting it in the dict is accepted silently and leaves
+        the SDK default of 100 in place.
+        """
+        return await asyncio.to_thread(
+            self.pb.collection(collection).get_full_list,
+            batch=PAGE_SIZE,
+            query_params=query_params,
+        )
+
     async def fetch_weekend_sessions(self, year: int) -> list[Any]:
         """All family + adult sessions for a year, in display order."""
-        return await asyncio.to_thread(
-            self.pb.collection(CAMP_SESSIONS).get_full_list,
-            batch=PAGE_SIZE,
+        return await self._page(
+            CAMP_SESSIONS,
             query_params={
                 "filter": f"year = {year} && ({_weekend_type_filter()})",
                 "sort": "sort_order,start_date",
@@ -124,9 +143,8 @@ class LodgingRepository:
         filter a summer cm_id resolves here and is handed a family-grain
         roster, instead of the 404 the router promises.
         """
-        rows = await asyncio.to_thread(
-            self.pb.collection(CAMP_SESSIONS).get_full_list,
-            batch=PAGE_SIZE,
+        rows = await self._page(
+            CAMP_SESSIONS,
             query_params={
                 "filter": f"year = {year} && cm_id = {session_cm_id} && ({_weekend_type_filter()})",
                 "sort": STABLE_SORT,
@@ -141,9 +159,8 @@ class LodgingRepository:
         the payload so the roster can badge them. Only the CAPACITY COUNTS
         exclude containers (spec §9a: naive SUM(sleeps) is 408 vs a true 389).
         """
-        return await asyncio.to_thread(
-            self.pb.collection(LODGING_UNITS).get_full_list,
-            batch=PAGE_SIZE,
+        return await self._page(
+            LODGING_UNITS,
             query_params={"expand": "area", "sort": "area.sort_order,name"},
         )
 
@@ -156,9 +173,8 @@ class LodgingRepository:
         rows only; a scenario's own overrides come from
         fetch_scenario_availability and overlay these.
         """
-        return await asyncio.to_thread(
-            self.pb.collection(LODGING_AVAILABILITY).get_full_list,
-            batch=PAGE_SIZE,
+        return await self._page(
+            LODGING_AVAILABILITY,
             query_params={
                 "filter": f'session = "{pb_escape(session_pb_id)}" && year = {year} && {LIVE_PLAN_FILTER}',
                 "sort": STABLE_SORT,
@@ -172,9 +188,8 @@ class LodgingRepository:
         and /summary, which gate on authentication only -- so it goes through
         pb_escape. See the note on fetch_draft_assignments.
         """
-        return await asyncio.to_thread(
-            self.pb.collection(LODGING_AVAILABILITY).get_full_list,
-            batch=PAGE_SIZE,
+        return await self._page(
+            LODGING_AVAILABILITY,
             query_params={
                 "filter": (
                     f'session = "{pb_escape(session_pb_id)}" && year = {year} && scenario = "{pb_escape(scenario_id)}"'
@@ -196,9 +211,8 @@ class LodgingRepository:
         so expanding it hands back a LIST of unit records rather than one.
         _placement_of reads that list, not a lookup keyed by id.
         """
-        return await asyncio.to_thread(
-            self.pb.collection(LODGING_ASSIGNMENTS).get_full_list,
-            batch=PAGE_SIZE,
+        return await self._page(
+            LODGING_ASSIGNMENTS,
             query_params={
                 "filter": f'session = "{pb_escape(session_pb_id)}" && year = {year}',
                 "expand": "units",
@@ -224,9 +238,8 @@ class LodgingRepository:
         is server-resolved and cannot carry one today, but it is escaped too so
         that reading this line requires no argument about provenance.
         """
-        return await asyncio.to_thread(
-            self.pb.collection(LODGING_ASSIGNMENTS_DRAFT).get_full_list,
-            batch=PAGE_SIZE,
+        return await self._page(
+            LODGING_ASSIGNMENTS_DRAFT,
             query_params={
                 "filter": (
                     f'session = "{pb_escape(session_pb_id)}" && year = {year} && scenario = "{pb_escape(scenario_id)}"'
@@ -242,11 +255,10 @@ class LodgingRepository:
         status_id = 2 is the single source of truth for enrolment; filtering
         any other way is silently wrong.
         """
-        return await asyncio.to_thread(
-            self.pb.collection(ATTENDEES).get_full_list,
-            batch=PAGE_SIZE,
+        return await self._page(
+            ATTENDEES,
             query_params={
-                "filter": f'session = "{session_pb_id}" && year = {year} && {ACTIVE_ENROLLED_FILTER}',
+                "filter": f'session = "{pb_escape(session_pb_id)}" && year = {year} && {ACTIVE_ENROLLED_FILTER}',
                 "expand": "person",
                 "sort": STABLE_SORT,
             },
@@ -254,9 +266,8 @@ class LodgingRepository:
 
     async def fetch_households(self, year: int) -> dict[str, Any]:
         """Households for a year, keyed by PocketBase record id."""
-        rows = await asyncio.to_thread(
-            self.pb.collection(HOUSEHOLDS).get_full_list,
-            batch=PAGE_SIZE,
+        rows = await self._page(
+            HOUSEHOLDS,
             query_params={"filter": f"year = {year}", "sort": STABLE_SORT},
         )
         return {row.id: row for row in rows}
@@ -267,9 +278,8 @@ class LodgingRepository:
         The PHI path uses this instead of fetch_households: answering one
         household must not materialise every family in the year.
         """
-        rows = await asyncio.to_thread(
-            self.pb.collection(HOUSEHOLDS).get_full_list,
-            batch=PAGE_SIZE,
+        rows = await self._page(
+            HOUSEHOLDS,
             query_params={
                 "filter": f"year = {year} && cm_id = {household_cm_id}",
                 "sort": STABLE_SORT,
@@ -283,9 +293,8 @@ class LodgingRepository:
         This is the returning-family signal: households rows are per-year, so
         a cm_id present before `year` means the family has been here before.
         """
-        rows = await asyncio.to_thread(
-            self.pb.collection(HOUSEHOLDS).get_full_list,
-            batch=PAGE_SIZE,
+        rows = await self._page(
+            HOUSEHOLDS,
             query_params={"filter": f"year < {year}", "fields": "cm_id", "sort": STABLE_SORT},
         )
         return {int(getattr(row, "cm_id", 0)) for row in rows if getattr(row, "cm_id", 0)}
@@ -296,9 +305,8 @@ class LodgingRepository:
         CampMinder enrols only the children for family camp; the adults exist
         only as custom-field values scraped into this table.
         """
-        rows = await asyncio.to_thread(
-            self.pb.collection(FAMILY_CAMP_ADULTS).get_full_list,
-            batch=PAGE_SIZE,
+        rows = await self._page(
+            FAMILY_CAMP_ADULTS,
             query_params={"filter": f"year = {year}", "sort": "adult_number"},
         )
         grouped: dict[str, list[Any]] = defaultdict(list)
@@ -317,9 +325,8 @@ class LodgingRepository:
         from share_cabin_preference / shared_cabin_modes_raw, which are the raw
         profile values kept for provenance.
         """
-        rows = await asyncio.to_thread(
-            self.pb.collection(FAMILY_CAMP_REGISTRATIONS).get_full_list,
-            batch=PAGE_SIZE,
+        rows = await self._page(
+            FAMILY_CAMP_REGISTRATIONS,
             query_params={"filter": f"year = {year}", "sort": STABLE_SORT},
         )
         return {str(getattr(row, "household", "")): row for row in rows}
@@ -332,9 +339,8 @@ class LodgingRepository:
         the permission-gated medical endpoint, which reads ONE household
         through fetch_medical_for_household rather than this whole-year map.
         """
-        rows = await asyncio.to_thread(
-            self.pb.collection(FAMILY_CAMP_MEDICAL).get_full_list,
-            batch=PAGE_SIZE,
+        rows = await self._page(
+            FAMILY_CAMP_MEDICAL,
             query_params={"filter": f"year = {year}", "sort": STABLE_SORT},
         )
         return {str(getattr(row, "household", "")): row for row in rows}
@@ -348,9 +354,8 @@ class LodgingRepository:
         """
         if not household_pb_id:
             return None
-        rows = await asyncio.to_thread(
-            self.pb.collection(FAMILY_CAMP_MEDICAL).get_full_list,
-            batch=PAGE_SIZE,
+        rows = await self._page(
+            FAMILY_CAMP_MEDICAL,
             query_params={
                 "filter": f'year = {year} && household = "{household_pb_id}"',
                 "sort": STABLE_SORT,
@@ -419,9 +424,8 @@ class LodgingRepository:
         caller then updates or deletes. The two cm_ids are ints and need no
         escaping.
         """
-        rows = await asyncio.to_thread(
-            self.pb.collection(LODGING_ASSIGNMENTS_DRAFT).get_full_list,
-            batch=PAGE_SIZE,
+        rows = await self._page(
+            LODGING_ASSIGNMENTS_DRAFT,
             query_params={
                 "filter": (
                     f'session = "{pb_escape(session_pb_id)}" && year = {year} '
@@ -456,9 +460,8 @@ class LodgingRepository:
         escaped. Unescaped, an injected `||` would make this return some other
         weekend's row, which set_availability then updates or deletes.
         """
-        rows = await asyncio.to_thread(
-            self.pb.collection(LODGING_AVAILABILITY).get_full_list,
-            batch=PAGE_SIZE,
+        rows = await self._page(
+            LODGING_AVAILABILITY,
             query_params={
                 "filter": (
                     f'session = "{pb_escape(session_pb_id)}" && year = {year} '

--- a/api/services/lodging_repository.py
+++ b/api/services/lodging_repository.py
@@ -74,6 +74,25 @@ UNRESOLVED_ALIAS_KIND = "unresolved_alias"
 # Same defect, same fix as the Go attribution reader in #1877.
 STABLE_SORT = "id"
 
+# Rows per HTTP request for every paged read below.
+#
+# The SDK's `get_full_list(batch: int = 100, ...)` defaults to 100 and recurses
+# once per page, so a read is round-trip-bound rather than row-bound.
+# `fetch_prior_household_cm_ids` pages every household from every prior year --
+# 20,256 rows on 2026 data -- which at the default is 203 requests and ~2.3s of
+# the roster's ~3.1s, to produce one boolean per party. At 1000 it is 21
+# requests and ~1.0s (#1966).
+#
+# `batch` is a parameter of `get_full_list` itself, NOT a member of
+# `query_params`. Putting it in the dict is accepted silently and leaves the
+# default in place, which is why a test asserts it reaches the SDK.
+#
+# 1000 is the CEILING, not a guess: PocketBase declares `MaxPerPage int = 1000`
+# and `tools/search/provider.go:289` CLAMPS a larger request rather than
+# rejecting it. So a bigger number here would page identically while reading as
+# though it did something.
+PAGE_SIZE = 1000
+
 
 def _weekend_type_filter() -> str:
     return " || ".join(f'session_type = "{t}"' for t in WEEKEND_SESSION_TYPES)
@@ -89,6 +108,7 @@ class LodgingRepository:
         """All family + adult sessions for a year, in display order."""
         return await asyncio.to_thread(
             self.pb.collection(CAMP_SESSIONS).get_full_list,
+            batch=PAGE_SIZE,
             query_params={
                 "filter": f"year = {year} && ({_weekend_type_filter()})",
                 "sort": "sort_order,start_date",
@@ -106,6 +126,7 @@ class LodgingRepository:
         """
         rows = await asyncio.to_thread(
             self.pb.collection(CAMP_SESSIONS).get_full_list,
+            batch=PAGE_SIZE,
             query_params={
                 "filter": f"year = {year} && cm_id = {session_cm_id} && ({_weekend_type_filter()})",
                 "sort": STABLE_SORT,
@@ -122,6 +143,7 @@ class LodgingRepository:
         """
         return await asyncio.to_thread(
             self.pb.collection(LODGING_UNITS).get_full_list,
+            batch=PAGE_SIZE,
             query_params={"expand": "area", "sort": "area.sort_order,name"},
         )
 
@@ -136,6 +158,7 @@ class LodgingRepository:
         """
         return await asyncio.to_thread(
             self.pb.collection(LODGING_AVAILABILITY).get_full_list,
+            batch=PAGE_SIZE,
             query_params={
                 "filter": f'session = "{pb_escape(session_pb_id)}" && year = {year} && {LIVE_PLAN_FILTER}',
                 "sort": STABLE_SORT,
@@ -151,6 +174,7 @@ class LodgingRepository:
         """
         return await asyncio.to_thread(
             self.pb.collection(LODGING_AVAILABILITY).get_full_list,
+            batch=PAGE_SIZE,
             query_params={
                 "filter": (
                     f'session = "{pb_escape(session_pb_id)}" && year = {year} && scenario = "{pb_escape(scenario_id)}"'
@@ -174,6 +198,7 @@ class LodgingRepository:
         """
         return await asyncio.to_thread(
             self.pb.collection(LODGING_ASSIGNMENTS).get_full_list,
+            batch=PAGE_SIZE,
             query_params={
                 "filter": f'session = "{pb_escape(session_pb_id)}" && year = {year}',
                 "expand": "units",
@@ -201,6 +226,7 @@ class LodgingRepository:
         """
         return await asyncio.to_thread(
             self.pb.collection(LODGING_ASSIGNMENTS_DRAFT).get_full_list,
+            batch=PAGE_SIZE,
             query_params={
                 "filter": (
                     f'session = "{pb_escape(session_pb_id)}" && year = {year} && scenario = "{pb_escape(scenario_id)}"'
@@ -218,6 +244,7 @@ class LodgingRepository:
         """
         return await asyncio.to_thread(
             self.pb.collection(ATTENDEES).get_full_list,
+            batch=PAGE_SIZE,
             query_params={
                 "filter": f'session = "{session_pb_id}" && year = {year} && {ACTIVE_ENROLLED_FILTER}',
                 "expand": "person",
@@ -229,6 +256,7 @@ class LodgingRepository:
         """Households for a year, keyed by PocketBase record id."""
         rows = await asyncio.to_thread(
             self.pb.collection(HOUSEHOLDS).get_full_list,
+            batch=PAGE_SIZE,
             query_params={"filter": f"year = {year}", "sort": STABLE_SORT},
         )
         return {row.id: row for row in rows}
@@ -241,6 +269,7 @@ class LodgingRepository:
         """
         rows = await asyncio.to_thread(
             self.pb.collection(HOUSEHOLDS).get_full_list,
+            batch=PAGE_SIZE,
             query_params={
                 "filter": f"year = {year} && cm_id = {household_cm_id}",
                 "sort": STABLE_SORT,
@@ -256,6 +285,7 @@ class LodgingRepository:
         """
         rows = await asyncio.to_thread(
             self.pb.collection(HOUSEHOLDS).get_full_list,
+            batch=PAGE_SIZE,
             query_params={"filter": f"year < {year}", "fields": "cm_id", "sort": STABLE_SORT},
         )
         return {int(getattr(row, "cm_id", 0)) for row in rows if getattr(row, "cm_id", 0)}
@@ -268,6 +298,7 @@ class LodgingRepository:
         """
         rows = await asyncio.to_thread(
             self.pb.collection(FAMILY_CAMP_ADULTS).get_full_list,
+            batch=PAGE_SIZE,
             query_params={"filter": f"year = {year}", "sort": "adult_number"},
         )
         grouped: dict[str, list[Any]] = defaultdict(list)
@@ -288,6 +319,7 @@ class LodgingRepository:
         """
         rows = await asyncio.to_thread(
             self.pb.collection(FAMILY_CAMP_REGISTRATIONS).get_full_list,
+            batch=PAGE_SIZE,
             query_params={"filter": f"year = {year}", "sort": STABLE_SORT},
         )
         return {str(getattr(row, "household", "")): row for row in rows}
@@ -302,6 +334,7 @@ class LodgingRepository:
         """
         rows = await asyncio.to_thread(
             self.pb.collection(FAMILY_CAMP_MEDICAL).get_full_list,
+            batch=PAGE_SIZE,
             query_params={"filter": f"year = {year}", "sort": STABLE_SORT},
         )
         return {str(getattr(row, "household", "")): row for row in rows}
@@ -317,6 +350,7 @@ class LodgingRepository:
             return None
         rows = await asyncio.to_thread(
             self.pb.collection(FAMILY_CAMP_MEDICAL).get_full_list,
+            batch=PAGE_SIZE,
             query_params={
                 "filter": f'year = {year} && household = "{household_pb_id}"',
                 "sort": STABLE_SORT,
@@ -387,6 +421,7 @@ class LodgingRepository:
         """
         rows = await asyncio.to_thread(
             self.pb.collection(LODGING_ASSIGNMENTS_DRAFT).get_full_list,
+            batch=PAGE_SIZE,
             query_params={
                 "filter": (
                     f'session = "{pb_escape(session_pb_id)}" && year = {year} '
@@ -423,6 +458,7 @@ class LodgingRepository:
         """
         rows = await asyncio.to_thread(
             self.pb.collection(LODGING_AVAILABILITY).get_full_list,
+            batch=PAGE_SIZE,
             query_params={
                 "filter": (
                     f'session = "{pb_escape(session_pb_id)}" && year = {year} '

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -74,6 +74,12 @@
 	# Compression and rate-limiting are handled by Traefik upstream of this
 	# Caddy. Adding them here would double-count rate-limit buckets and
 	# duplicate Traefik's compression for no gain.
+	#
+	# #1966 read the absence of `encode` here as an oversight. It is not — but
+	# note the dev path has no Traefik in front of it, which is why the API
+	# compresses its own large JSON (`GZipMiddleware`, api/main.py) and why
+	# frontend/Caddyfile DOES carry `encode`. Traefik passes an
+	# already-encoded response through rather than recompressing it.
 
 	# PocketBase-specific patterns (explicit)
 	# These /api/* routes go to PocketBase (port 8090)

--- a/docs/reference/weekend-go-live-sequence.md
+++ b/docs/reference/weekend-go-live-sequence.md
@@ -21,15 +21,21 @@ That is why this programme is plan-driven rather than triage-driven. Triage is t
 | Step | Work | Issue | Size | Critical path? |
 |---|---|---|---|---|
 | 0 | Roster / summary latency | [#1966](https://github.com/adamflagg/kindred/issues/1966) | ½–1 day | Yes |
+| 0a | **Scenarios replace the mirror, as summer's do** | [#1974](https://github.com/adamflagg/kindred/issues/1974) | ~1 day | **Yes — changes what a scenario means** |
 | 1 | Scenario plumbing, picker, read-only gating | [#1967](https://github.com/adamflagg/kindred/issues/1967) | 1–2 days | **Yes — gates all writes** |
-| 1a | Multi-room positioning + coordinate pair rule | [#1940](https://github.com/adamflagg/kindred/issues/1940), [#1941](https://github.com/adamflagg/kindred/issues/1941) | ½ day | Yes |
-| 2 | **Drag placement** | unfiled — `HANDOFF.md` §4 | 4–6 days | **Yes — this is the goal** |
+| 2 | **Drag placement** — placement only, no merge | unfiled — `HANDOFF.md` §4 | 4–6 days | **Yes — this is the goal** |
+| 2a | Multi-room placements on board and map | [#1940](https://github.com/adamflagg/kindred/issues/1940), [#1941](https://github.com/adamflagg/kindred/issues/1941) | ½–1 day | Follow-up — unlocks merge-by-drag |
 | 3 | Roster/API correctness as one Python PR | [#1889](https://github.com/adamflagg/kindred/issues/1889), [#1936](https://github.com/adamflagg/kindred/issues/1936) | ≤1 day | Correctness |
 | 4 | 2026 inventory rollout + container guard | [#1917](https://github.com/adamflagg/kindred/issues/1917), [#1918](https://github.com/adamflagg/kindred/issues/1918) | ½ day + staff walk | Parallel, blocks nothing |
 | 5 | Parity polish — filters, tab state, sync invalidation | [#1912](https://github.com/adamflagg/kindred/issues/1912), [#1944](https://github.com/adamflagg/kindred/issues/1944), [#1894](https://github.com/adamflagg/kindred/issues/1894) | 1–2 days | **No — after the capability** |
 | 6 | Decide what comes *out* of a finished plan | [#1968](https://github.com/adamflagg/kindred/issues/1968) | no code | Ask before step 2 opens |
 
-**Total: 8–12 engineering days**, plus a cabin-confirmation property walk that sits on staff's calendar, not engineering's.
+**Total: 9–13 engineering days**, plus a cabin-confirmation property walk that sits on staff's calendar, not engineering's.
+
+**Two owner decisions, 2026-08-03, changed steps 0a–2a from what this table first said.**
+
+- **Lodging scenarios adopt summer's semantics** ([#1974](https://github.com/adamflagg/kindred/issues/1974)). Today a lodging scenario OVERLAYS the CampMinder mirror per party, so a fresh scenario renders the synced placements and "unplaced" needs a tombstone row. Summer's draft table *replaces* production and is seeded by an explicit copy. There is no principled asymmetry — `sync/bunk_assignments.go` and `sync/lodging_assignments_sync.go` are both registered sync services — so the divergence is being removed. **Consequence for step 2: dragging to the unplaced rail becomes a `DELETE`, not a tombstone `POST`.** The appendix below still says tombstone; it is correct only until #1974 lands.
+- **Drag ships placement only.** Party → unit and party → rail. Unit → unit merge is **out**, because `buildBoard` indexes parties by `party.unit_code` and `_placement_of` sends `unit_code: ""` for any placement spanning 2+ rooms — so the board cannot draw a multi-room placement at all today, and drag-to-merge would make the card vanish into the off-board section. That is why #1940 moved from in front of drag to behind it: it is the render fix that *unlocks* merge, not a prerequisite for placement. Roughly 12–16 multi-room placements a year, ~3% of the total.
 
 Also open and deliberately *not* on this path: [#1963](https://github.com/adamflagg/kindred/issues/1963) and [#1964](https://github.com/adamflagg/kindred/issues/1964) (further perf), [#1907](https://github.com/adamflagg/kindred/issues/1907) / [#1932](https://github.com/adamflagg/kindred/issues/1932) / [#1930](https://github.com/adamflagg/kindred/issues/1930) (occupancy and placement-assist design), the pin editor and Phase F geo.
 
@@ -49,7 +55,14 @@ It is not. `party_size` has **four display consumers and zero decision consumers
 
 Every write requires a scenario; `lodging_assignments` is permanently admin-only by locked decision; there is no promote/publish endpoint in `api/routers/`; `lodging_assignments_sync.go` never writes back; no weekend surface imports `csvExport` or the PDF button.
 
-So the board can only ever write **drafts**, and go-live today means *staff arrange in Kindred, then re-key into CampMinder by hand.* Summer avoids this by writing `bunk_assignments` directly in production mode (`useCamperMovement.ts:353`); lodging is structurally denied that path by its own one-way ingest design.
+So the board can only ever write **drafts**, and go-live today means *staff arrange in Kindred, then re-key into CampMinder by hand.*
+
+**This section originally added "Summer avoids this by writing `bunk_assignments` directly in production mode (`useCamperMovement.ts:353`); lodging is structurally denied that path." That is wrong on both halves** (corrected 2026-08-03, and on [#1968](https://github.com/adamflagg/kindred/issues/1968) itself):
+
+- `useCamperMovement` does contain a production write path, but **the board never reaches it** — `BunkingBoardByArea.tsx:380` returns early from `handleDragEnd` when `isProductionMode`, and `bunk_assignments` is admin-only besides.
+- **Nothing writes back to CampMinder for any programme.** The only outbound POSTs in the Go tree go to the internal solver API (`sync/process_requests.go:169`) and a geocoder (`sync/normalize_geographic.go:575`).
+
+A finished summer plan reaches CampMinder the same way a weekend plan would: a human re-keys it. So this is a product question for both programmes, not a lodging deficiency to close — which makes "manual re-key, and that's fine" a considerably stronger year-one answer than the original framing implied.
 
 That may be the correct year-one answer. But it changes what the board must render, so it is [#1968](https://github.com/adamflagg/kindred/issues/1968) and it wants an answer in week one, not week two of drag.
 
@@ -112,20 +125,30 @@ whether #1967 has merged. If it has not, either take it as step one of your own
 work or coordinate — but do not start the drag interaction on top of a surface
 that cannot name a scenario.
 
-Also check #1966 (roster latency) and #1940 (multi-room positioning). #1940 is
-half a day and becomes live the moment drag can create a merge, so it belongs
-immediately in front of you, not after.
+Also check #1966 (roster latency) and **#1974 (scenarios replace the mirror)**.
+#1974 decides what dragging to the unplaced rail writes, so confirm it has
+landed before you build that drop target.
 
 ## Scope
 
 - Party → unit
-- Party → unplaced rail. This is a **tombstone POST, not a DELETE**.
-- Unit → unit merge: an extension of the SAME `POST /placements` body to
-  `unit_ids: [a, b]`. #1931 collapsed three placement targets into one `units`
-  set, so there is no separate merge interaction to build.
-- Availability reserve/release rides along: `PUT /api/lodging/availability`
-  takes the `unit_id` the card already holds and the badge already renders
-  (`unitBadges.ts` → `LodgingUnitCard.tsx:30,68-72`).
+- Party → unplaced rail. **After #1974 this is a `DELETE /placements`.** Older
+  text — including HANDOFF §2's three-state table and §6 — says it must be a
+  tombstone `POST` with empty `unit_ids`. That was true under the OVERLAY read,
+  where deleting the row fell through to the CampMinder mirror and put the
+  family back in the cabin they were just dragged out of. #1974 removes the
+  fall-through, which removes the tombstone. If #1974 has NOT landed, the old
+  rule still holds — check, do not assume.
+- **Unit → unit merge is OUT OF SCOPE.** `buildBoard` indexes parties by
+  `party.unit_code`, and `_placement_of` sends `unit_code: ""` for a placement
+  spanning 2+ rooms — so the board cannot draw a multi-room placement at all,
+  and a merge created by drag would make the card vanish into "Placed outside
+  the board". #1940 (step 2a) is the render fix that unlocks this; it is a
+  follow-up, not a prerequisite. Do not build merge-by-drag before it.
+- Availability reserve/release rides along IF it fits: `PUT
+  /api/lodging/availability` takes the `unit_id` the card already holds and the
+  badge already renders (`unitBadges.ts` → `LodgingUnitCard.tsx:30,68-72`).
+  Drop it and say so rather than half-building it.
 
 The write endpoints ALREADY EXIST (#1915) and are race-hardened (#1927). You
 are wiring a UI to them, not designing an API.

--- a/docs/reference/weekend-go-live-sequence.md
+++ b/docs/reference/weekend-go-live-sequence.md
@@ -28,9 +28,10 @@ That is why this programme is plan-driven rather than triage-driven. Triage is t
 | 3 | Roster/API correctness as one Python PR | [#1889](https://github.com/adamflagg/kindred/issues/1889), [#1936](https://github.com/adamflagg/kindred/issues/1936) | ≤1 day | Correctness |
 | 4 | 2026 inventory rollout + container guard | [#1917](https://github.com/adamflagg/kindred/issues/1917), [#1918](https://github.com/adamflagg/kindred/issues/1918) | ½ day + staff walk | Parallel, blocks nothing |
 | 5 | Parity polish — filters, tab state, sync invalidation | [#1912](https://github.com/adamflagg/kindred/issues/1912), [#1944](https://github.com/adamflagg/kindred/issues/1944), [#1894](https://github.com/adamflagg/kindred/issues/1894) | 1–2 days | **No — after the capability** |
-| 6 | Decide what comes *out* of a finished plan | [#1968](https://github.com/adamflagg/kindred/issues/1968) | no code | Ask before step 2 opens |
 
-**Total: 9–13 engineering days**, plus a cabin-confirmation property walk that sits on staff's calendar, not engineering's.
+**Step 1b — decide what comes *out* of a finished plan** ([#1968](https://github.com/adamflagg/kindred/issues/1968), no code) is an explicit **prerequisite of step 2**, not a later row. It sat at the bottom of this table saying "ask before step 2 opens", which let a reader follow the table straight into drag work with the question unanswered. If the answer turns out to be a printed cabin list, the board needs print-shaped data — stable ordering, legible labels, occupancy per room — that nothing else would prompt anyone to add.
+
+**Total: 9–15 engineering days**, summing every row including the parallel step 4 — it is half a day of engineering even though it blocks nothing. This is effort, not calendar duration, and it excludes the cabin-confirmation property walk, which sits on staff's calendar rather than engineering's. The earlier "8–12" did not reconcile with its own table.
 
 **Two owner decisions, 2026-08-03, changed steps 0a–2a from what this table first said.**
 
@@ -60,7 +61,7 @@ So the board can only ever write **drafts**, and go-live today means *staff arra
 **This section originally added "Summer avoids this by writing `bunk_assignments` directly in production mode (`useCamperMovement.ts:353`); lodging is structurally denied that path." That is wrong on both halves** (corrected 2026-08-03, and on [#1968](https://github.com/adamflagg/kindred/issues/1968) itself):
 
 - `useCamperMovement` does contain a production write path, but **the board never reaches it** — `BunkingBoardByArea.tsx:380` returns early from `handleDragEnd` when `isProductionMode`, and `bunk_assignments` is admin-only besides.
-- **Nothing writes back to CampMinder for any programme.** The only outbound POSTs in the Go tree go to the internal solver API (`sync/process_requests.go:169`) and a geocoder (`sync/normalize_geographic.go:575`).
+- **Nothing writes back to CampMinder for any programme.** The only outbound POSTs in `pocketbase/sync` go to the internal solver API (`sync/process_requests.go:169`) and a geocoder (`sync/normalize_geographic.go:575`). The Go tree does make other outbound writes — `feedback/github.go:102` POSTs a GitHub issue — but none of them reach CampMinder.
 
 A finished summer plan reaches CampMinder the same way a weekend plan would: a human re-keys it. So this is a product question for both programmes, not a lodging deficiency to close — which makes "manual re-key, and that's fine" a considerably stronger year-one answer than the original framing implied.
 
@@ -191,8 +192,10 @@ Answer them; do not re-litigate them.
 ## Do NOT gate on the fit check
 
 `partyAttention` is advisory. `place_party`
-(`api/services/lodging_write_service.py:78-147`) performs no validation of any
-kind, by design. Every cabin currently has `is_confirmed = 0`, so
+(`api/services/lodging_write_service.py:78-147`) does not enforce the
+fit/capacity check, by design — it DOES validate scenario, grain, permission
+and unique-index races, so do not read this as "the write path checks
+nothing". Every cabin currently has `is_confirmed = 0`, so
 `rosterAttention.ts:102` refuses to judge any housing need — the fit check is
 dark and will stay dark until staff physically walk the property. Ship drag
 with it dark. Do not bulk-confirm units to work around this; `is_confirmed`

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -3,6 +3,12 @@
 }
 
 :{$CADDY_PORT:8080} {
+	# Compress everything served from here (#1966): the built JS/CSS bundles and
+	# any upstream response that arrives raw. FastAPI now gzips its own large
+	# JSON, and Caddy leaves an already-encoded response alone rather than
+	# double-compressing it, so the two do not fight.
+	encode zstd gzip
+
 	# PocketBase-specific patterns (explicit)
 	# These are the only /api/* routes that go to PocketBase
 	# Note: Must include both root paths and wildcards (e.g., /api/collections AND /api/collections/*)

--- a/tests/unit/api/services/test_lodging_repository.py
+++ b/tests/unit/api/services/test_lodging_repository.py
@@ -434,3 +434,61 @@ class TestCounts:
         args = pb.collection.return_value.get_list.call_args[0]
         assert args[0] == 1, "page 1"
         assert args[1] == 1, "one row is enough to carry total_items"
+
+
+class TestPageSize:
+    """Every paged read must name its batch size (#1966).
+
+    The SDK's `get_full_list(batch: int = 100, ...)` defaults to 100 rows per
+    HTTP request and recurses once per page. `fetch_prior_household_cm_ids`
+    pages every household from every prior year -- 20,256 rows on 2026 data --
+    which is 203 round trips and ~2.3s of the roster's ~3.1s, to produce one
+    boolean per party. At 1000 it is 21.
+
+    Measured loopback against the dev DB; a round-trip-bound cost scales with
+    per-hop RTT, so the production figure is likely worse rather than better.
+    """
+
+    @pytest.mark.asyncio
+    async def test_prior_households_pages_in_large_batches(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        """The batch must reach the SDK, not merely be spelled in the source.
+
+        `batch` is a positional-or-keyword parameter on `get_full_list`, NOT a
+        member of `query_params` -- putting it in the dict is silently ignored
+        and leaves the default in place.
+        """
+        await repo.fetch_prior_household_cm_ids(2026)
+
+        call = pb.collection.return_value.get_full_list.call_args
+        batch = call[1].get("batch", call[0][0] if call[0] else None)
+        assert batch is not None, "get_full_list called without an explicit batch"
+        assert batch >= 500, f"batch {batch} still pages in small chunks"
+
+    def test_every_paged_read_names_a_batch(self) -> None:
+        """Structural, because the defect recurs on every read ADDED later.
+
+        A behavioural test per method would pass for the nineteen call sites
+        that exist today and say nothing about the twentieth. This walks the
+        module's AST instead, so a new `get_full_list` with no batch fails
+        here rather than quietly costing another 200 round trips.
+        """
+        import ast
+        import inspect
+
+        from api.services import lodging_repository
+
+        tree = ast.parse(inspect.getsource(lodging_repository))
+        missing: list[int] = []
+        for node in ast.walk(tree):
+            # The call sites pass the bound method to asyncio.to_thread rather
+            # than calling it, so the batch arrives as a to_thread kwarg. Match
+            # on any call whose args mention get_full_list.
+            if not isinstance(node, ast.Call):
+                continue
+            names = {child.attr for child in ast.walk(node) if isinstance(child, ast.Attribute)}
+            if "get_full_list" not in names:
+                continue
+            if not any(kw.arg == "batch" for kw in node.keywords):
+                missing.append(node.lineno)
+
+        assert not missing, f"get_full_list without an explicit batch at lines {missing}"

--- a/tests/unit/api/services/test_lodging_repository.py
+++ b/tests/unit/api/services/test_lodging_repository.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from api.services.lodging_repository import (
+    PAGE_SIZE,
     WEEKEND_SESSION_TYPES,
     LodgingRepository,
 )
@@ -450,27 +451,39 @@ class TestPageSize:
     """
 
     @pytest.mark.asyncio
-    async def test_prior_households_pages_in_large_batches(self, repo: LodgingRepository, pb: MagicMock) -> None:
-        """The batch must reach the SDK, not merely be spelled in the source.
+    async def test_prior_households_page_at_exactly_page_size(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        """The batch must reach the SDK, and must be PAGE_SIZE.
 
         `batch` is a positional-or-keyword parameter on `get_full_list`, NOT a
         member of `query_params` -- putting it in the dict is silently ignored
         and leaves the default in place.
+
+        Asserted as EQUAL to the constant rather than as a lower bound. A
+        `>= 500` assertion passes while somebody "tunes" PAGE_SIZE to 500 and
+        doubles the round trips -- the exact regression this pins. 1000 is also
+        PocketBase's `MaxPerPage`, above which it clamps, so there is one
+        correct value here and the test should say which.
         """
         await repo.fetch_prior_household_cm_ids(2026)
 
         call = pb.collection.return_value.get_full_list.call_args
         batch = call[1].get("batch", call[0][0] if call[0] else None)
-        assert batch is not None, "get_full_list called without an explicit batch"
-        assert batch >= 500, f"batch {batch} still pages in small chunks"
+        assert batch == PAGE_SIZE, f"paged at {batch}, not PAGE_SIZE ({PAGE_SIZE})"
 
-    def test_every_paged_read_names_a_batch(self) -> None:
-        """Structural, because the defect recurs on every read ADDED later.
+    def test_no_read_calls_get_full_list_directly(self) -> None:
+        """`_page` is the ONLY place `get_full_list` may be named.
 
-        A behavioural test per method would pass for the nineteen call sites
-        that exist today and say nothing about the twentieth. This walks the
-        module's AST instead, so a new `get_full_list` with no batch fails
-        here rather than quietly costing another 200 round trips.
+        This replaces an earlier test that walked for `get_full_list` calls
+        missing a `batch=` keyword. That test was defeated by an intermediate
+        variable -- `getter = self.pb.collection(X).get_full_list` followed by
+        `to_thread(getter, ...)` puts no `get_full_list` attribute inside the
+        call's own subtree, so the walk saw nothing and reported success.
+
+        Funnelling every paged read through one helper makes the defect
+        UNREPRESENTABLE rather than merely detected: a read added later cannot
+        forget `batch`, because it never passes one. So this asserts the funnel
+        holds, which is a claim about one line of code rather than a claim
+        about every call site's shape.
         """
         import ast
         import inspect
@@ -478,17 +491,63 @@ class TestPageSize:
         from api.services import lodging_repository
 
         tree = ast.parse(inspect.getsource(lodging_repository))
-        missing: list[int] = []
-        for node in ast.walk(tree):
-            # The call sites pass the bound method to asyncio.to_thread rather
-            # than calling it, so the batch arrives as a to_thread kwarg. Match
-            # on any call whose args mention get_full_list.
-            if not isinstance(node, ast.Call):
-                continue
-            names = {child.attr for child in ast.walk(node) if isinstance(child, ast.Attribute)}
-            if "get_full_list" not in names:
-                continue
-            if not any(kw.arg == "batch" for kw in node.keywords):
-                missing.append(node.lineno)
+        page_helper = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef) and node.name == "_page"
+        )
+        inside_helper = {id(node) for node in ast.walk(page_helper)}
 
-        assert not missing, f"get_full_list without an explicit batch at lines {missing}"
+        stray = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute) and node.attr == "get_full_list" and id(node) not in inside_helper
+        ]
+
+        assert not stray, f"get_full_list named outside _page at lines {stray} -- route it through the helper"
+
+
+class TestFilterEscaping:
+    """Every id interpolated into a filter goes through `pb_escape`.
+
+    `session_pb_id` is server-derived today -- it comes from `fetch_session`
+    or `_resolve_session_pb_id`, never straight off the wire -- so this is
+    defence in depth rather than a live hole. It is worth pinning anyway:
+    six of the seven reads taking a `session_pb_id` escaped it and one did
+    not, and that asymmetry is how the next one gets written wrong. A reader
+    comparing two adjacent methods cannot tell which convention is the
+    deliberate one.
+    """
+
+    @pytest.mark.asyncio
+    async def test_attendees_escapes_the_session_id(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        await repo.fetch_attendees_for_session(2026, 'pb"; //')
+
+        filter_str = _last_query(pb)["filter"]
+        # Assert the RAW value is absent and the ESCAPED form is present.
+        # Asserting only that `"; //` is missing would fail against correctly
+        # escaped output too, because `pb\"; //` still contains that substring
+        # -- a test that cannot pass is as useless as one that cannot fail.
+        assert 'pb"; //' not in filter_str, "raw quote reached the filter unescaped"
+        assert 'pb\\"; //' in filter_str, "quote was not backslash-escaped"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "call",
+        [
+            pytest.param(lambda r, s: r.fetch_availability(2026, s), id="fetch_availability"),
+            pytest.param(lambda r, s: r.fetch_assignments(2026, s), id="fetch_assignments"),
+            pytest.param(lambda r, s: r.fetch_attendees_for_session(2026, s), id="fetch_attendees"),
+            pytest.param(lambda r, s: r.fetch_scenario_availability(2026, s, "sc"), id="fetch_scenario_avail"),
+            pytest.param(lambda r, s: r.fetch_draft_assignments(2026, s, "sc"), id="fetch_draft_assignments"),
+        ],
+    )
+    async def test_every_session_scoped_read_escapes_alike(
+        self, repo: LodgingRepository, pb: MagicMock, call: Any
+    ) -> None:
+        """The convention, asserted across all of them rather than one by one."""
+        await call(repo, 'pb"evil')
+
+        filter_str = _last_query(pb)["filter"]
+        assert 'pb"evil' not in filter_str, "raw quote reached the filter unescaped"
+        assert 'pb\\"evil' in filter_str, "quote was not backslash-escaped"

--- a/tests/unit/api/test_response_compression.py
+++ b/tests/unit/api/test_response_compression.py
@@ -1,0 +1,67 @@
+"""Responses are compressed on the wire (#1966).
+
+The weekend roster is ~107 KB of JSON and shipped `content-encoding: none`:
+neither Caddyfile carried `encode` and the app had no GZip middleware, so the
+whole payload crossed the network raw. JSON of that shape compresses roughly
+9:1, and the cost is paid on every cold load of every weekend.
+
+This asserts the BEHAVIOUR -- an actual compressed response -- rather than the
+presence of a middleware class, because a middleware installed with a
+`minimum_size` above the payload is installed and does nothing.
+"""
+
+import json
+
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from api.main import create_app
+
+
+def _app_with_probe_route():
+    """The real app plus one route returning a roster-sized JSON body.
+
+    Sized and shaped like the real payload rather than a run of one repeated
+    character: a string of 100,000 identical bytes compresses ~1000:1 and would
+    pass this test against a middleware that never fires on realistic data.
+    """
+    app = create_app()
+
+    @app.get("/__compression_probe")
+    async def probe() -> JSONResponse:
+        parties = [
+            {
+                "display_name": f"Household {index}",
+                "household_cm_id": 100000 + index,
+                "unit_code": f"unit-{index % 40}",
+                "request_text": "Would like to be near friends; ground floor if possible.",
+            }
+            for index in range(400)
+        ]
+        return JSONResponse(content={"parties": parties})
+
+    return app
+
+
+def test_large_json_response_is_gzipped() -> None:
+    client = TestClient(_app_with_probe_route())
+
+    response = client.get("/__compression_probe", headers={"Accept-Encoding": "gzip"})
+
+    assert response.status_code == 200
+    assert response.headers.get("content-encoding") == "gzip", "roster-sized JSON crossed the wire uncompressed"
+
+
+def test_compression_is_negotiated_not_forced() -> None:
+    """A client that cannot decompress must still get a readable body.
+
+    `identity` is not a hypothetical: it is what `curl` sends without
+    `--compressed`, and it is how the measurements in #1966 were taken.
+    """
+    client = TestClient(_app_with_probe_route())
+
+    response = client.get("/__compression_probe", headers={"Accept-Encoding": "identity"})
+
+    assert response.status_code == 200
+    assert "content-encoding" not in response.headers
+    assert len(json.loads(response.content)["parties"]) == 400

--- a/tests/unit/api/test_response_compression.py
+++ b/tests/unit/api/test_response_compression.py
@@ -12,6 +12,7 @@ presence of a middleware class, because a middleware installed with a
 
 import json
 
+import pytest
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
@@ -32,7 +33,10 @@ def _app_with_probe_route():
         parties = [
             {
                 "display_name": f"Household {index}",
-                "household_cm_id": 100000 + index,
+                # Fictional ids, per tests/CLAUDE.md. Offset from the sanctioned
+                # 1000001 so 400 households stay distinct -- collapsing them onto
+                # two ids would shrink the payload this fixture exists to size.
+                "household_cm_id": 1_000_001 + index,
                 "unit_code": f"unit-{index % 40}",
                 "request_text": "Would like to be near friends; ground floor if possible.",
             }
@@ -52,15 +56,26 @@ def test_large_json_response_is_gzipped() -> None:
     assert response.headers.get("content-encoding") == "gzip", "roster-sized JSON crossed the wire uncompressed"
 
 
-def test_compression_is_negotiated_not_forced() -> None:
-    """A client that cannot decompress must still get a readable body.
+@pytest.mark.parametrize(
+    "accept_encoding",
+    [
+        pytest.param("identity", id="explicit-identity"),
+        # Plain `curl` sends NO Accept-Encoding header rather than `identity`.
+        # An empty value exercises the same branch: the middleware asks whether
+        # "gzip" appears in the header, defaulting to "" when it is absent, so
+        # absent and empty are indistinguishable to it.
+        pytest.param("", id="header-absent-or-empty"),
+    ],
+)
+def test_compression_is_negotiated_not_forced(accept_encoding: str) -> None:
+    """A client that did not ask for gzip must still get a readable body.
 
-    `identity` is not a hypothetical: it is what `curl` sends without
-    `--compressed`, and it is how the measurements in #1966 were taken.
+    This is how the measurements in #1966 were taken, so a forced encoding
+    would have made those numbers unreproducible as well as breaking clients.
     """
     client = TestClient(_app_with_probe_route())
 
-    response = client.get("/__compression_probe", headers={"Accept-Encoding": "identity"})
+    response = client.get("/__compression_probe", headers={"Accept-Encoding": accept_encoding})
 
     assert response.status_code == 200
     assert "content-encoding" not in response.headers


### PR DESCRIPTION
Closes #1966 (two of its four items; see below for where the other two went).

Step 0 of `docs/reference/weekend-go-live-sequence.md` — the roster has to be fast before the scenario switch is worth testing against it.

## Measured, in this worktree against the dev DB

**Page size**, in-process, same session, 20,256 rows:

| | requests | median |
|---|---|---|
| `batch=100` (SDK default) | 203 | 4.31s |
| `batch=1000` (`PAGE_SIZE`) | 21 | **1.54s** |

**End to end**, `GET /api/lodging/roster` for a 2026 family weekend: the 3.12s recorded on the issue → median **1.77s** here.

**Compression**: 116,982 bytes → **12,595 on the wire**, 9.3:1.

All loopback against a dev DB. Production runs behind a reverse proxy and a tunnel, and a round-trip-bound cost scales with per-hop RTT, so the real-world saving is likely larger rather than smaller.

## The two things worth reviewing

**`1000` is the ceiling, not a guess.** PocketBase declares `MaxPerPage int = 1000` and `tools/search/provider.go:289` **clamps** a larger request rather than rejecting it — so a bigger number would page identically while reading as though it did something. Recorded at the constant so nobody tries 5000.

**`docker/Caddyfile` deliberately does not get `encode`.** #1966 read its absence as an oversight. It isn't — the file's existing comment at `:74-76` already records that Traefik compresses upstream. The dev path has no Traefik in front of it, which is what the measurement actually caught, so the fix belongs in the app (`GZipMiddleware`) and in `frontend/Caddyfile`. I extended the prod comment so the next reader doesn't "fix" it.

## Where #1966's other two items went

- **Year-0 request guard — already fixed.** #1965 added `enabled: year > 0` to all three weekend hooks. The issue's caveat guessed the year provider might initialise synchronously; it does not (`CurrentYearContext.tsx:67-69` yields `0` until the sync-status query resolves), but the hooks are guarded regardless.
- **TTL response cache — split out as #1975.** Its hard part is invalidation, and the writer that must invalidate does not exist yet: once drag ships, every placement write must invalidate the right slot, and #1974 changes what a scenario key means while that work is in flight. Designing it now means designing against a writer nobody has written.

## Tests

Both written failing first.

- `test_prior_households_pages_in_large_batches` — asserts the batch **reaches the SDK**. `batch` is a parameter of `get_full_list`, not a member of `query_params`; putting it in the dict is accepted silently and leaves the default in place.
- `test_every_paged_read_names_a_batch` — walks the module's AST, so a read **added later** cannot quietly reintroduce the default. A per-method test would pass for today's 17 call sites and say nothing about the eighteenth.
- `test_large_json_response_is_gzipped` / `test_compression_is_negotiated_not_forced` — behavioural, against the real app. The probe payload is roster-shaped rather than a repeated character, which would compress ~1000:1 and pass against a middleware that never fires on real data.

## Doc corrections folded in

`docs/reference/weekend-go-live-sequence.md` landed an hour before this branch and carries three things this work falsified or superseded. Folded in here rather than opening a doc-only PR.

- **It claimed summer "avoids this by writing `bunk_assignments` directly in production mode" and that lodging is structurally denied that path.** Wrong on both halves: `BunkingBoardByArea.tsx:380` returns early from `handleDragEnd` in production mode, so the board never reaches that write, and `bunk_assignments` is admin-only besides. And nothing writes back to CampMinder for **any** programme — the only outbound POSTs in the Go tree go to the internal solver API (`sync/process_requests.go:169`) and a geocoder (`sync/normalize_geographic.go:575`). A finished summer plan is re-keyed by a human exactly as a weekend plan would be. Corrected on #1968 itself too, since its recommendation partly rested on the contrast.
- **#1974 is now step 0a** — lodging scenarios adopt summer's replace-the-mirror semantics instead of overlaying it. That turns "drag to the unplaced rail is a tombstone POST" into a `DELETE`, so the appendix's handoff prompt now says to check before building that drop target.
- **Drag ships placement only.** `buildBoard` indexes parties by `party.unit_code` and `_placement_of` sends `""` for any placement spanning 2+ rooms, so the board cannot draw a multi-room placement at all — merge-by-drag would make the card vanish into "Placed outside the board". #1940 moves from in front of drag to behind it, as the render fix that unlocks merge.

## Not done

`uv.lock` is left unstaged — it re-resolves in every fresh worktree and is #1864's business, not this PR's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Large API responses are now compressed when supported, reducing transfer sizes and improving load times.
  - Frontend assets and eligible responses support modern compression formats.
  - Data retrieval uses larger batches for more reliable handling of extensive lodging and registration records.

- **Documentation**
  - Updated go-live guidance with clearer sequencing, effort estimates, manual data-entry requirements, and follow-up items for multi-room and drag-placement workflows.

- **Quality**
  - Added coverage for compression negotiation, large responses, reliable data retrieval, and safer session-filter handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->