### PR TITLE
fix(scripts): rebuild pocketbase in the verify harness instead of trusting it

### DIFF
--- a/scripts/dev/lib/pb-harness.sh
+++ b/scripts/dev/lib/pb-harness.sh
@@ -24,6 +24,7 @@
 #
 # Public API:
 #   pb_harness_require_tools [extra tools...]
+#   pb_harness_build_binary <go_pkg_dir> <out_path>
 #   pb_harness_pick_port
 #   pb_harness_install_trap [extra cleanup command]
 #   pb_harness_boot <pb_bin> <db_dir> <migrations_dir> <log_path>
@@ -50,6 +51,52 @@ pb_harness_require_tools() {
     command -v "$cmd" >/dev/null 2>&1 \
       || { echo "error: required command '$cmd' not found" >&2; exit 2; }
   done
+}
+
+# pb_harness_build_binary <go_pkg_dir> <out_path>
+#
+# Builds <go_pkg_dir> to <out_path>, so a verify run always exercises the tree
+# it is checking rather than whatever was compiled last.
+#
+# Existence is not freshness, and that gap is not obvious: `go build ./...` --
+# the documented Go gate, and what the pre-push hook runs -- compiles into the
+# build cache and rewrites no `-o` target, so nothing in the normal loop
+# refreshes a checked-in `pocketbase/pocketbase`. The callers used to assert
+# only that the file was present, which makes a forgotten rebuild produce a
+# PASS about a binary that predates the change under test. A false FAIL is
+# self-limiting because someone investigates; the false PASS is why this
+# exists (kindred#1922).
+#
+# go build is incremental, so on an unchanged tree this costs approximately
+# nothing.
+#
+# Exits 2 -- harness error, not assertion failure -- if go is missing or the
+# build fails, echoing the compiler's own output so the exit code is
+# actionable. Same contract as pb_harness_require_tools.
+pb_harness_build_binary() {
+  local pkg_dir="$1" out="$2"
+
+  # Checked here rather than in pb_harness_require_tools' default list so the
+  # dependency travels with the function that actually needs it.
+  command -v go >/dev/null 2>&1 \
+    || { echo "error: required command 'go' not found" >&2; exit 2; }
+
+  # The build runs from inside $pkg_dir, so a relative -o would land there
+  # instead of where the caller meant -- and the caller would then boot
+  # whatever was already at its intended path, which is the stale-artifact bug
+  # this function exists to close, arriving by a different route.
+  [[ "$out" == /* ]] \
+    || { echo "error: pb_harness_build_binary: output path '$out' must be absolute" >&2; exit 2; }
+
+  local build_log
+  build_log=$(mktemp -t pb-harness-build-XXXX)
+  if ! ( cd "$pkg_dir" && go build -o "$out" . ) > "$build_log" 2>&1; then
+    echo "error: could not build $pkg_dir -> $out" >&2
+    cat "$build_log" >&2
+    rm -f "$build_log"
+    exit 2
+  fi
+  rm -f "$build_log"
 }
 
 # pb_harness_pick_port

--- a/scripts/dev/test-pb-harness.sh
+++ b/scripts/dev/test-pb-harness.sh
@@ -174,7 +174,7 @@ PATH="$SANDBOX_NO_GO" bash -c "source '$LIB'; pb_harness_build_binary '$FIXTURE_
   >/dev/null 2>"$SCRATCH/t6.err"
 rc=$?
 set -e
-if [[ $rc -eq 2 ]] && grep -q "go" "$SCRATCH/t6.err"; then
+if [[ $rc -eq 2 ]] && grep -q "required command 'go' not found" "$SCRATCH/t6.err"; then
   echo "PASS: missing go -> exit 2, names go"
 else
   echo "FAIL: missing go expected exit 2 naming go, got rc=$rc; stderr:" >&2
@@ -223,6 +223,39 @@ if [[ $rc -eq 2 ]] && [[ ! -e "$FIXTURE_SRC/relative-bin" ]]; then
 else
   echo "FAIL: expected exit 2 and no binary, got rc=$rc; stderr:" >&2
   cat "$SCRATCH/t8.err" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 9: verify-lodging-schema.sh propagates the build contract (exit 2) when go is missing ==="
+# The mirror of TESTS 3/4 for the build dependency. Those pin that a missing
+# TOOL reaches the caller as exit 2; kindred#1922 gave the two lodging scripts
+# a second way to be unrunnable -- no Go toolchain -- and a contract nothing
+# asserts is a contract that drifts. Exits before any build or boot, so this
+# costs the same as tests 3/4.
+set +e
+PATH="$SANDBOX_NO_GO" "$SCHEMA_SCRIPT" >/dev/null 2>"$SCRATCH/t9.err"
+rc=$?
+set -e
+if [[ $rc -eq 2 ]] && grep -q "required command 'go' not found" "$SCRATCH/t9.err"; then
+  echo "PASS: verify-lodging-schema.sh with go missing -> exit 2"
+else
+  echo "FAIL: expected exit 2 naming go, got $rc; stderr:" >&2
+  cat "$SCRATCH/t9.err" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 10: verify-lodging-seed.sh propagates the build contract (exit 2) when go is missing ==="
+set +e
+PATH="$SANDBOX_NO_GO" "$SEED_SCRIPT" >/dev/null 2>"$SCRATCH/t10.err"
+rc=$?
+set -e
+if [[ $rc -eq 2 ]] && grep -q "required command 'go' not found" "$SCRATCH/t10.err"; then
+  echo "PASS: verify-lodging-seed.sh with go missing -> exit 2"
+else
+  echo "FAIL: expected exit 2 naming go, got $rc; stderr:" >&2
+  cat "$SCRATCH/t10.err" >&2
   exit 1
 fi
 

--- a/scripts/dev/test-pb-harness.sh
+++ b/scripts/dev/test-pb-harness.sh
@@ -109,5 +109,122 @@ else
   exit 1
 fi
 
+# --- pb_harness_build_binary (kindred#1922) ---------------------------------
+#
+# The harness used to assert only that the binary EXISTED. `go build ./...`
+# (what pre-push runs) populates the build cache without rewriting
+# pocketbase/pocketbase, so a verify run could boot an arbitrarily old binary
+# and report PASS about a tree it never compiled. These three tests pin the
+# rebuild, and pin that a build problem is a harness error (2), not an
+# assertion failure (1).
+#
+# A throwaway one-file Go module stands in for pocketbase itself: it makes the
+# staleness assertion OBSERVABLE (the binary's own output changes when the
+# source does) and keeps the test at build-a-hello-world cost rather than
+# build-all-of-PocketBase cost.
+FIXTURE_SRC="$SCRATCH/gomod"
+FIXTURE_BIN="$SCRATCH/fixture-bin"
+mkdir -p "$FIXTURE_SRC"
+cat > "$FIXTURE_SRC/go.mod" <<'EOF'
+module pbharnessfixture
+
+go 1.21
+EOF
+
+# write_fixture <printed string> -- rewrite the fixture's only source file.
+write_fixture() {
+  cat > "$FIXTURE_SRC/main.go" <<EOF
+package main
+
+import "fmt"
+
+func main() { fmt.Println("$1") }
+EOF
+}
+
+echo
+echo "=== TEST 5: pb_harness_build_binary rebuilds a stale binary ==="
+write_fixture v1
+( cd "$FIXTURE_SRC" && go build -o "$FIXTURE_BIN" . )
+[[ "$("$FIXTURE_BIN")" == "v1" ]] || { echo "FAIL: fixture setup did not produce v1" >&2; exit 1; }
+
+# The binary on disk is now older than its source -- exactly the state a
+# rebased-onto-new-Go-source tree is in.
+write_fixture v2
+set +e
+bash -c "source '$LIB'; pb_harness_build_binary '$FIXTURE_SRC' '$FIXTURE_BIN'" \
+  >"$SCRATCH/t5.out" 2>"$SCRATCH/t5.err"
+rc=$?
+set -e
+actual=$("$FIXTURE_BIN" 2>/dev/null || true)
+if [[ $rc -eq 0 && "$actual" == "v2" ]]; then
+  echo "PASS: stale binary rebuilt from current source"
+else
+  echo "FAIL: expected rc=0 and rebuilt binary printing v2, got rc=$rc printing '$actual'; stderr:" >&2
+  cat "$SCRATCH/t5.err" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 6: pb_harness_build_binary exits 2 (not 127) when go is missing ==="
+SANDBOX_NO_GO="$SCRATCH/no-go"
+build_sandbox "$SANDBOX_NO_GO" go
+set +e
+PATH="$SANDBOX_NO_GO" bash -c "source '$LIB'; pb_harness_build_binary '$FIXTURE_SRC' '$FIXTURE_BIN'" \
+  >/dev/null 2>"$SCRATCH/t6.err"
+rc=$?
+set -e
+if [[ $rc -eq 2 ]] && grep -q "go" "$SCRATCH/t6.err"; then
+  echo "PASS: missing go -> exit 2, names go"
+else
+  echo "FAIL: missing go expected exit 2 naming go, got rc=$rc; stderr:" >&2
+  cat "$SCRATCH/t6.err" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 7: pb_harness_build_binary exits 2 and surfaces the compiler error on a broken tree ==="
+# A build failure means "cannot run the check", not "the check failed" -- so it
+# must not be mistakable for an assertion failure, and the compiler's own
+# message has to reach the operator or the exit code says nothing actionable.
+cat > "$FIXTURE_SRC/main.go" <<'EOF'
+package main
+
+func main() { this is not go }
+EOF
+set +e
+bash -c "source '$LIB'; pb_harness_build_binary '$FIXTURE_SRC' '$FIXTURE_BIN'" \
+  >/dev/null 2>"$SCRATCH/t7.err"
+rc=$?
+set -e
+if [[ $rc -eq 2 ]] && grep -q "main.go" "$SCRATCH/t7.err"; then
+  echo "PASS: build failure -> exit 2, compiler output surfaced"
+else
+  echo "FAIL: broken source expected exit 2 quoting main.go, got rc=$rc; stderr:" >&2
+  cat "$SCRATCH/t7.err" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 8: pb_harness_build_binary refuses a relative output path ==="
+# The build runs from inside <go_pkg_dir>, so a relative -o lands next to the
+# source instead of where the caller meant -- and the caller then boots
+# whatever WAS at its intended path. That is this issue's own failure mode
+# (a green run about the wrong artifact) reintroduced by a different route,
+# so it fails loudly rather than building somewhere surprising.
+write_fixture v3
+set +e
+bash -c "source '$LIB'; pb_harness_build_binary '$FIXTURE_SRC' 'relative-bin'" \
+  >/dev/null 2>"$SCRATCH/t8.err"
+rc=$?
+set -e
+if [[ $rc -eq 2 ]] && [[ ! -e "$FIXTURE_SRC/relative-bin" ]]; then
+  echo "PASS: relative output path -> exit 2, nothing built"
+else
+  echo "FAIL: expected exit 2 and no binary, got rc=$rc; stderr:" >&2
+  cat "$SCRATCH/t8.err" >&2
+  exit 1
+fi
+
 echo
 echo "All tests passed."

--- a/scripts/dev/verify-consolidation.sh
+++ b/scripts/dev/verify-consolidation.sh
@@ -78,8 +78,7 @@ pb_apply() {
 }
 
 echo ">> building pocketbase binary..."
-( cd "$REPO_ROOT/pocketbase" && go build -o "$SCRATCH/pocketbase" . ) > "$SCRATCH/build.log" 2>&1 \
-  || { echo "pocketbase build failed; log:"; cat "$SCRATCH/build.log"; exit 2; }
+pb_harness_build_binary "$REPO_ROOT/pocketbase" "$SCRATCH/pocketbase"
 
 # Each DB lives under its own slot directory so pb_harness_boot's symlink
 # target ($parent_dir/pb_migrations) is unique per call. Without this, both

--- a/scripts/dev/verify-lodging-schema.sh
+++ b/scripts/dev/verify-lodging-schema.sh
@@ -27,7 +27,11 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 PB_BIN="$REPO_ROOT/pocketbase/pocketbase"
 MIG_DIR="$REPO_ROOT/pocketbase/pb_migrations"
 
-[[ -x "$PB_BIN" ]] || { echo "error: $PB_BIN missing; run: cd pocketbase && go build -o pocketbase ." >&2; exit 2; }
+# Rebuild rather than assert existence: a stale binary would let this report
+# PASS against a Go model-level guard that no longer exists in the source.
+# Incremental, so it is near-free on an unchanged tree. See kindred#1922.
+echo ">> building pocketbase binary..."
+pb_harness_build_binary "$REPO_ROOT/pocketbase" "$PB_BIN"
 
 SCRATCH=$(mktemp -d)
 # shellcheck disable=SC2016  # deliberate: $SCRATCH expands when the trap fires, not here

--- a/scripts/dev/verify-lodging-seed.sh
+++ b/scripts/dev/verify-lodging-seed.sh
@@ -37,7 +37,13 @@ PB_BIN="$REPO_ROOT/pocketbase/pocketbase"
 MIG_DIR="$REPO_ROOT/pocketbase/pb_migrations"
 REGISTRY="$REPO_ROOT/config/lodging_registry.json"
 
-[[ -x "$PB_BIN" ]] || { echo "error: $PB_BIN missing; run: cd pocketbase && go build -o pocketbase ." >&2; exit 2; }
+# Rebuild rather than assert existence. This is the script the staleness bug
+# was found through: the boot loader was present in the source and absent from
+# the binary, and the run reported "no lodging_units rows — the boot loader did
+# not run". The same hole produces a false PASS, which nobody investigates.
+# See kindred#1922.
+echo ">> building pocketbase binary..."
+pb_harness_build_binary "$REPO_ROOT/pocketbase" "$PB_BIN"
 
 if [[ ! -f "$REGISTRY" ]]; then
   echo "error: $REGISTRY missing — the private registry lives in kindred-local." >&2


### PR DESCRIPTION
Closes #1922.

## The defect

`verify-lodging-schema.sh` and `verify-lodging-seed.sh` asserted the binary **existed** and never that it was **current**:

```bash
[[ -x "$PB_BIN" ]] || { echo "error: $PB_BIN missing; run: cd pocketbase && go build -o pocketbase ." >&2; exit 2; }
```

`go build ./...` — the documented Go gate, and what the pre-push hook runs — compiles into the build cache and rewrites no `-o` target. So `pocketbase/pocketbase` is only ever as fresh as the last explicit `go build -o pocketbase .`, which nothing in the normal loop performs.

The false FAIL is how this was found and it is self-limiting, because someone investigates. **The false PASS is the reason to fix it:** break the boot loader, forget to rebuild, and `verify-lodging-seed.sh` still boots the old binary, still finds the registry rows, still prints OK.

## One correction to the issue

It says all three callers are affected. **Only two are.** `verify-consolidation.sh:81` already built its own binary into a scratch dir, so it was never stale.

That matters for the fix shape: deriving the package dir from `dirname "$pb_bin"` inside `pb_harness_boot` — the obvious reading of "put it in the boot function" — would have made consolidation try to `go build` inside `$SCRATCH`, which has no Go module. So the rebuild is its own function taking an explicit package dir, and consolidation moves onto it as well. That removes the third inline copy, the same consolidation #1868 did for the boot logic.

## The fix

`pb_harness_build_binary <go_pkg_dir> <out_path>` in `scripts/dev/lib/pb-harness.sh`. `go build` is incremental, so on an unchanged tree it costs approximately nothing.

- Build problems exit **2** (cannot run), not 1 (assertion failed) — matching `pb_harness_require_tools`.
- The compiler's own output is echoed, so the exit code is actionable.
- `go` is checked inside this function rather than added to `pb_harness_require_tools`' default list, so the dependency travels with the code that needs it.
- **The output path must be absolute**, and that is enforced. The build runs from inside the package dir, so a relative `-o` would land next to the source while the caller boots whatever was already at its intended path — this same bug arriving by a different route.

## Tests

Four new cases in `scripts/dev/test-pb-harness.sh`, written before the implementation and confirmed failing (`rc=127`, binary still reporting its old output). A throwaway one-file Go module stands in for pocketbase so the staleness assertion is **observable** — the binary's own output changes when its source does — at hello-world build cost rather than build-all-of-PocketBase cost.

| Test | Asserts |
|---|---|
| 5 | a stale binary is rebuilt from current source |
| 6 | missing `go` → exit 2, with the guard's own message |
| 7 | broken source → exit 2, compiler error surfaced |
| 8 | relative output path → exit 2, nothing built |
| 9, 10 | both verify scripts propagate the go-absence contract |

Tests 9/10 mirror the existing 3/4 for the build dependency: #1922 gives the two lodging scripts a second way to be unrunnable, and covering only the lib function left the propagation to the callers unasserted. Both exit before any build or boot, so they cost what 3/4 cost.

**Test 6 was mutation-checked and initially failed the check.** As first written it grepped for `"go"`, which the bare `go build` failure also satisfies — `go: command not found` lands in the surfaced build log, and `rc` is 2 either way — so it passed with the explicit `command -v go` guard deleted. It now greps the guard's own message. That distinction is the point of having a separate guard: without it, a missing toolchain is reported as a broken tree. With the guard removed, 6/9/10 fail and everything else still passes.

## Verified, not assumed

A **real Go binary** printing `STALE BINARY` planted at `pocketbase/pocketbase`, then:

```
$ bash scripts/dev/verify-lodging-seed.sh
>> building pocketbase binary...
verify-lodging-seed: OK (114 units, 141 aliases)          exit 0
```

Also green: `verify-lodging-schema.sh` with the binary deleted outright (`OK (96 js migrations applied)`), `verify-consolidation.sh` end to end (`schemas match`), all 8 harness tests, and the pre-push shellcheck command verbatim.

One incidental finding worth recording: `go build -o` refuses to overwrite a target that is not a Go object file, so if `pocketbase/pocketbase` is ever a stray text file the run exits 2 with that message rather than proceeding. Correct behaviour for a "cannot run" condition.

## Acceptance

- [x] A stale `pocketbase/pocketbase` cannot affect a verify run's result
- [x] The rebuild lives in `pb-harness.sh`, shared by all three callers
- [x] A build failure exits 2 (cannot run), not 1 (assertion failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)