### PR TITLE
test(pb): guard against a whole-building inventory row stranding its rooms

### DIFF
--- a/docs/reference/weekend-go-live-sequence.md
+++ b/docs/reference/weekend-go-live-sequence.md
@@ -20,14 +20,18 @@ That is why this programme is plan-driven rather than triage-driven. Triage is t
 
 | Step | Work | Issue | Size | Critical path? |
 |---|---|---|---|---|
-| 0 | Roster / summary latency | [#1966](https://github.com/adamflagg/kindred/issues/1966) | ½–1 day | Yes |
+| 0 | Roster / summary latency — **DONE** | [#1966](https://github.com/adamflagg/kindred/issues/1966) | ½–1 day (spent) | Was yes; closed 2026-08-03 by PR #1976 |
 | 0a | **Scenarios replace the mirror, as summer's do** | [#1974](https://github.com/adamflagg/kindred/issues/1974) | ~1 day | **Yes — changes what a scenario means** |
 | 1 | Scenario plumbing, picker, read-only gating | [#1967](https://github.com/adamflagg/kindred/issues/1967) | 1–2 days | **Yes — gates all writes** |
 | 2 | **Drag placement** — placement only, no merge | unfiled — `HANDOFF.md` §4 | 4–6 days | **Yes — this is the goal** |
-| 2a | Multi-room placements on board and map | [#1940](https://github.com/adamflagg/kindred/issues/1940), [#1941](https://github.com/adamflagg/kindred/issues/1941) | ½–1 day | Follow-up — unlocks merge-by-drag |
+| 2a | Multi-room placements on board and map | [#1940](https://github.com/adamflagg/kindred/issues/1940), [#1941](https://github.com/adamflagg/kindred/issues/1941), [#1982](https://github.com/adamflagg/kindred/issues/1982) | ½–1 day | Follow-up — unlocks merge-by-drag |
 | 3 | Roster/API correctness as one Python PR | [#1889](https://github.com/adamflagg/kindred/issues/1889), [#1936](https://github.com/adamflagg/kindred/issues/1936) | ≤1 day | Correctness |
 | 4 | 2026 inventory rollout + container guard | [#1917](https://github.com/adamflagg/kindred/issues/1917), [#1918](https://github.com/adamflagg/kindred/issues/1918) | ½ day + staff walk | Parallel, blocks nothing |
 | 5 | Parity polish — filters, tab state, sync invalidation | [#1912](https://github.com/adamflagg/kindred/issues/1912), [#1944](https://github.com/adamflagg/kindred/issues/1944), [#1894](https://github.com/adamflagg/kindred/issues/1894) | 1–2 days | **No — after the capability** |
+
+**Step 2a gained a third issue, and it is the only newly-filed work that is order-specific.** [#1982](https://github.com/adamflagg/kindred/issues/1982) — the fit check settles `needs_private_bathroom` by reading the assigned unit's own `bathroom` field (`rosterAttention.ts:51-55`), and a merged placement resolves to no single unit, so `partyAttention` reports `unverified`. The result is that the one placement which physically delivers a private bathroom — a household holding every room in a building — is the one the board can never credit. The rule the registry already supports is exclusivity: a party satisfies the need when its units cover every member of that `bathroom_group`. It is gated on #1940 for the same reason as the rest of 2a (a merged party carries no unit codes until that lands), but it is a **separate decision** — it changes what `settled` means for a merge, so it should be taken deliberately rather than folded in.
+
+**Nothing else filed since this doc was written belongs in the sequence.** #1922 (verify-harness staleness, merged) was never on the path. #1963 / #1964 remain deliberately off it. The post-rollout guard now recorded on #1917 — stop `apply_lodging_inventory.py` overwriting units staff have confirmed — is a **follow-up to step 4, not a prerequisite**: the hazard does not exist until confirmations do, and it is tracked in that issue's own acceptance list rather than here.
 
 **Step 1b — decide what comes *out* of a finished plan** ([#1968](https://github.com/adamflagg/kindred/issues/1968), no code) is an explicit **prerequisite of step 2**, not a later row. It sat at the bottom of this table saying "ask before step 2 opens", which let a reader follow the table straight into drag work with the question unanswered. If the answer turns out to be a printed cabin list, the board needs print-shaped data — stable ordering, legible labels, occupancy per room — that nothing else would prompt anyone to add.
 

--- a/pocketbase/lodging/registry_inventory_test.go
+++ b/pocketbase/lodging/registry_inventory_test.go
@@ -1,0 +1,301 @@
+package lodging
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Guards the class found reviewing kindred#1914 (see kindred#1918): a
+// whole-building inventory row stranding its rooms on the container.
+//
+// The inventory sheet lists ROOMS, so most buildings arrive as several rows and
+// each lands on the room it describes. But a building can arrive as a single
+// whole-building row. That row matches the building, which is a CONTAINER, and
+// the match is correct -- there is no per-room row to target. What is missing is
+// the next step: the amenity data stops at the container and the bookable rooms
+// underneath it stay empty.
+//
+// It matters because containers are never bookable, nothing resolves amenities
+// up the parent chain (lodging_roster_service.py reads them straight off the
+// unit), and the fit check judges non-container units. So every room in that
+// building reports has_power:false meaning "nobody has said" -- the exact
+// blindness the inventory exists to end. Worse, it is invisible until staff
+// confirm the cabins, at which point rosterAttention.ts stops reading false as
+// "unknown" and starts reading it as "we checked, there is none".
+//
+// Counting cannot see it. Reconciling amenity totals against the sheet counts
+// each row exactly once whether it sits on the container or on the rooms, so
+// the totals reconcile perfectly either way -- in #1914 all ten counts
+// reconciled and the defect was present. verify-lodging-seed.sh cannot see it
+// either: it asserts the database matches the registry file, and the file was
+// self-consistently wrong.
+
+// inventoryAmenities reports which amenity flags the row carries.
+//
+// This is deliberately the amenity half of apply_lodging_inventory.py's
+// INVENTORY_FIELDS -- the fields the inventory sheet supplies -- and
+// deliberately EXCLUDES MaxBeds and Sleeps. A container carrying capacity is
+// the intended whole-building aggregate, so a guard keyed on "the container has
+// data" would flag the legitimate case. Bathroom and BathroomGroup are excluded
+// for the same reason: they are structural, not sheet amenities.
+func inventoryAmenities(u *registryUnit) []string {
+	flags := []struct {
+		name string
+		set  bool
+	}{
+		{"has_power", u.HasPower},
+		{"has_ac", u.HasAC},
+		{"has_fridge", u.HasFridge},
+		{"is_accessible", u.IsAccessible},
+		{"has_heat", u.HasHeat},
+		{"is_weatherized", u.IsWeatherized},
+		{"has_plumbing", u.HasPlumbing},
+		{"has_space_heater", u.HasSpaceHeater},
+		{"has_pack_play_space", u.HasPackPlaySpace},
+		{"has_living_room", u.HasLivingRoom},
+		{"has_kitchen", u.HasKitchen},
+		{"has_lights", u.HasLights},
+	}
+
+	var set []string
+	for _, f := range flags {
+		if f.set {
+			set = append(set, f.name)
+		}
+	}
+	// HasRamp is a string, where empty means NOT ASSESSED rather than false.
+	if u.HasRamp != "" {
+		set = append(set, "has_ramp")
+	}
+	return set
+}
+
+type strandedContainer struct {
+	Code      string
+	Amenities []string
+	Leaves    []string
+}
+
+// findStrandedContainers returns every container carrying amenity data whose
+// non-container descendants carry none.
+//
+// That shape has no legitimate reading: either the data belongs on the rooms,
+// or it is shared and belongs on both. A container with no bookable descendants
+// at all is not flagged -- there is nothing for the data to have failed to
+// reach.
+func findStrandedContainers(units []registryUnit) []strandedContainer {
+	// Pointers into `units` rather than copies: registryUnit is 208 bytes and
+	// golangci-lint's gocritic flags the by-value walk, which pre-push does not
+	// run and CI does.
+	byCode := make(map[string]*registryUnit, len(units))
+	children := make(map[string][]string, len(units))
+	for i := range units {
+		u := &units[i]
+		byCode[u.Code] = u
+		if u.ParentUnit != "" {
+			children[u.ParentUnit] = append(children[u.ParentUnit], u.Code)
+		}
+	}
+
+	// A container's children can themselves be containers -- a building whose
+	// rooms sit under per-floor containers is a real shape in the registry, and
+	// a single-level check would miss it entirely. `seen` guards a malformed
+	// parent cycle; validateRegistry does not reject one, and an unguarded walk
+	// would hang the suite rather than fail it.
+	var leavesOf func(code string, seen map[string]bool) []string
+	leavesOf = func(code string, seen map[string]bool) []string {
+		if seen[code] {
+			return nil
+		}
+		seen[code] = true
+
+		var leaves []string
+		for _, child := range children[code] {
+			if byCode[child].IsContainer {
+				leaves = append(leaves, leavesOf(child, seen)...)
+				continue
+			}
+			leaves = append(leaves, child)
+		}
+		return leaves
+	}
+
+	var stranded []strandedContainer
+	for i := range units {
+		u := &units[i]
+		if !u.IsContainer {
+			continue
+		}
+		amenities := inventoryAmenities(u)
+		if len(amenities) == 0 {
+			continue
+		}
+
+		leaves := leavesOf(u.Code, map[string]bool{})
+		if len(leaves) == 0 {
+			continue
+		}
+
+		received := false
+		for _, leaf := range leaves {
+			if len(inventoryAmenities(byCode[leaf])) > 0 {
+				received = true
+				break
+			}
+		}
+		if !received {
+			stranded = append(stranded, strandedContainer{
+				Code: u.Code, Amenities: amenities, Leaves: leaves,
+			})
+		}
+	}
+	return stranded
+}
+
+func TestFindStrandedContainersFlagsAWholeBuildingRowItsRoomsNeverReceived(t *testing.T) {
+	units := []registryUnit{
+		{Code: "house", Name: "House", IsContainer: true},
+		{Code: "house-a", Name: "House A", ParentUnit: "house"},
+		{Code: "house-b", Name: "House B", ParentUnit: "house"},
+	}
+	units[0].HasPower = true
+	units[0].HasHeat = true
+
+	got := findStrandedContainers(units)
+	if len(got) != 1 || got[0].Code != "house" {
+		t.Fatalf("expected the container to be flagged, got %+v", got)
+	}
+	if len(got[0].Leaves) != 2 {
+		t.Errorf("expected both rooms reported as starved, got %v", got[0].Leaves)
+	}
+}
+
+func TestFindStrandedContainersAllowsACapacityOnlyAggregate(t *testing.T) {
+	// The intended shape: the container carries the whole-building bed count and
+	// the rooms carry the amenities. A guard keyed on capacity would flag this.
+	beds := 7
+	units := []registryUnit{
+		{Code: "house", Name: "House", IsContainer: true, MaxBeds: &beds},
+		{Code: "house-a", Name: "House A", ParentUnit: "house"},
+		{Code: "house-b", Name: "House B", ParentUnit: "house"},
+	}
+	units[1].HasPower = true
+	units[2].HasPower = true
+
+	if got := findStrandedContainers(units); len(got) != 0 {
+		t.Fatalf("capacity-only container with amenity-bearing rooms must not be flagged, got %+v", got)
+	}
+}
+
+func TestFindStrandedContainersTreatsCapacityAsNotAnAmenity(t *testing.T) {
+	// The sharp version of the case above. There, the rooms carry amenities, so
+	// the guard short-circuits on "a room received the data" and never has to
+	// decide whether capacity counts -- it passes either way, which makes it
+	// worthless as a check on that rule.
+	//
+	// Here nothing downstream carries anything, so the ONLY thing keeping the
+	// container unflagged is that MaxBeds and Sleeps are excluded from the
+	// amenity set. Rooms nobody has inventoried yet are a different and far
+	// broader condition than a whole-building row that failed to reach them.
+	beds, sleeps := 7, 7
+	units := []registryUnit{
+		{Code: "house", Name: "House", IsContainer: true, MaxBeds: &beds, Sleeps: &sleeps},
+		{Code: "house-a", Name: "House A", ParentUnit: "house"},
+		{Code: "house-b", Name: "House B", ParentUnit: "house"},
+	}
+
+	if got := findStrandedContainers(units); len(got) != 0 {
+		t.Fatalf("capacity is a whole-building aggregate, not amenity data, got %+v", got)
+	}
+}
+
+func TestFindStrandedContainersWalksNestedContainers(t *testing.T) {
+	// building -> per-floor containers -> rooms. A single-level check sees only
+	// the floor containers, finds no non-container children carrying data on the
+	// building itself, and reports nothing.
+	units := []registryUnit{
+		{Code: "house", Name: "House", IsContainer: true},
+		{Code: "house-up", Name: "House Upstairs", ParentUnit: "house", IsContainer: true},
+		{Code: "house-1", Name: "House 1", ParentUnit: "house-up"},
+		{Code: "house-2", Name: "House 2", ParentUnit: "house-up"},
+	}
+	units[0].HasKitchen = true
+
+	got := findStrandedContainers(units)
+	if len(got) != 1 || got[0].Code != "house" {
+		t.Fatalf("expected the outer container flagged through its floor container, got %+v", got)
+	}
+	if len(got[0].Leaves) != 2 {
+		t.Errorf("expected the two rooms two levels down, got %v", got[0].Leaves)
+	}
+}
+
+func TestFindStrandedContainersIgnoresAContainerWithNoRooms(t *testing.T) {
+	units := []registryUnit{{Code: "house", Name: "House", IsContainer: true}}
+	units[0].HasPower = true
+
+	if got := findStrandedContainers(units); len(got) != 0 {
+		t.Fatalf("a container with no descendants has nothing to strand, got %+v", got)
+	}
+}
+
+func TestFindStrandedContainersPassesWhenOneRoomCarriesTheData(t *testing.T) {
+	// Partial is not this defect. One room carrying the data means the row
+	// reached the rooms; whether every sibling should have it too is a data
+	// question staff own, not a structural one.
+	units := []registryUnit{
+		{Code: "house", Name: "House", IsContainer: true},
+		{Code: "house-a", Name: "House A", ParentUnit: "house"},
+		{Code: "house-b", Name: "House B", ParentUnit: "house"},
+	}
+	units[0].HasPower = true
+	units[1].HasPower = true
+
+	if got := findStrandedContainers(units); len(got) != 0 {
+		t.Fatalf("one amenity-bearing room is enough, got %+v", got)
+	}
+}
+
+func TestFindStrandedContainersToleratesAParentCycle(t *testing.T) {
+	// validateRegistry does not reject a cycle. An unguarded descendant walk
+	// would hang the suite rather than fail it, which is the worse failure.
+	units := []registryUnit{
+		{Code: "a", Name: "A", IsContainer: true, ParentUnit: "b"},
+		{Code: "b", Name: "B", IsContainer: true, ParentUnit: "a"},
+	}
+	units[0].HasPower = true
+
+	_ = findStrandedContainers(units) // must terminate
+}
+
+func TestPrivateRegistryHasNoStrandedContainers(t *testing.T) {
+	// Runs against the real file when kindred-local is linked, and skips
+	// cleanly otherwise -- the same graceful degradation SeedRegistry and
+	// verify-lodging-seed.sh already have for a clone without the private repo.
+	path := filepath.Join("..", "..", "config", "lodging_registry.json")
+	data, err := os.ReadFile(path) //nolint:gosec // G304: fixed path to local config
+	if err != nil {
+		if os.IsNotExist(err) {
+			t.Skip("private lodging registry absent; run scripts/setup/setup-local-config.sh")
+		}
+		t.Fatalf("reading %s: %v", path, err)
+	}
+
+	var doc registryDoc
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	if len(doc.Units) == 0 {
+		t.Fatalf("%s parsed to zero units", path)
+	}
+
+	for _, s := range findStrandedContainers(doc.Units) {
+		t.Errorf(
+			"container %q carries %v while none of its %d bookable rooms (%v) carry any: "+
+				"a whole-building inventory row landed on the container and never reached the rooms",
+			s.Code, s.Amenities, len(s.Leaves), s.Leaves,
+		)
+	}
+}


### PR DESCRIPTION
Closes #1918. Carries the go-live sequence doc update as a second commit, per the "no standalone PR for doc corrections" rule.

## The defect class

The inventory sheet lists **rooms**, so most buildings arrive as several rows and each lands on the room it describes. A building that arrives as one **whole-building row** matches the building — which is a *container*. That match is correct; there is no per-room row to target. What is missing is the next step: the amenity data stops at the container and the bookable rooms underneath stay empty.

One instance existed and was fixed in the private registry before #1914 merged. This is the class, which nothing detected.

## Why nothing caught it

- **Counting is structurally blind.** Reconciling amenity totals against the sheet counts the row exactly once whether it lands on the container or the rooms, so the totals reconcile perfectly either way. In #1914 all ten counts reconciled *and the defect was present*.
- **`verify-lodging-seed.sh` cannot see it either.** It asserts the database matches the registry file, and the file was self-consistently wrong.

## Why it is worse than it looks

Containers are never bookable, nothing resolves amenities up the parent chain (`lodging_roster_service.py` reads them straight off the unit), and the fit check judges non-container units. So every room in that building reports `has_power: false` meaning *"nobody has said"*.

That is invisible today, because `rosterAttention.ts` gates on `is_confirmed` and reports `unverified`. **It becomes harmful at exactly the moment the data is supposed to become trustworthy**: when staff walk the property and confirm cabins, `false` stops reading as "unknown" and starts reading as "we checked, there is none" — striking real beds off the board for a household that needs power. The walk confirms the *cabin*; it does not backfill amenities from the sheet.

## The guard

`findStrandedContainers` — a container carrying amenity data whose non-container descendants carry none. Test-only by design: this is a data-shape check, and a boot loader that refused to start over one would be a worse failure than the thing it detects.

**Keyed on amenity flags, never capacity.** A container carrying `max_beds` or `sleeps` is the intended whole-building aggregate; a guard keyed on "the container has data" would flag the legitimate case. The amenity set is deliberately the amenity half of `apply_lodging_inventory.py`'s `INVENTORY_FIELDS`, so the two agree on what the sheet supplies.

Nested containers are walked (a building whose children are themselves per-floor containers is a real shape), with a cycle guard — `validateRegistry` does not reject a parent cycle, and an unguarded walk would hang the suite rather than fail it.

## Every assertion mutation-checked

Two were worthless as first written. Both are fixed here rather than shipped:

- **The capacity case passed with `max_beds` counted as an amenity.** Its rooms carried data, so the walk short-circuited on "a room received it" and never reached the capacity question. A second test drops the room data, leaving the exclusion as the only thing keeping the container unflagged.
- **A `leaves = nil` sentinel doubled as "no leaves"**, so the childless guard was dead code — deleting it changed nothing. An explicit `received` flag replaces it.

Six mutations, each failing exactly one test:

| Mutation | Test that fails |
|---|---|
| nested recursion removed | `WalksNestedContainers` |
| `max_beds` counted as an amenity | `TreatsCapacityAsNotAnAmenity` |
| childless guard removed | `IgnoresAContainerWithNoRooms` |
| one-room-suffices break removed | `PassesWhenOneRoomCarriesTheData` |
| `if !received` → `if false` | `FlagsAWholeBuildingRow...` |
| leaf amenities forced empty | `PrivateRegistryHasNoStrandedContainers` |

That last one matters most: it proves the real-registry test can actually fail rather than quietly skipping.

## Verified

- `go test ./lodging/` green (full package, 33s); the private-registry test **runs**, not skips — confirmed by `-v` showing PASS rather than SKIP, and it asserts a non-zero unit count so an empty parse fails
- Skips cleanly when the private registry is absent, matching `SeedRegistry` and `verify-lodging-seed.sh`
- `golangci-lint run ./lodging/...` → 0 issues. It initially flagged `gocritic` `hugeParam` / `rangeValCopy` on the 208-byte struct; **pre-push does not run golangci-lint, CI does**, so this would otherwise have been a CI round-trip

## Second commit — go-live sequence doc

Step 0 (#1966) closed via PR #1976 but was still listed as critical path; size is retained as "(spent)" so the table still sums to its stated total. Step 2a gains #1982. Everything else filed since is explicitly recorded as *not* belonging in the sequence, including #1917's new post-rollout guard, which is a follow-up rather than a prerequisite.

Trial-merged clean against the in-flight lodging-scenarios branch, which edits different hunks of the same file.

## Acceptance

- [x] Fails on a fixture where a container holds amenity flags and its leaves hold none
- [x] Passes for a container holding only `max_beds` with amenity-bearing leaves
- [x] Nested containers handled
- [x] Runs green against the current registry, skips cleanly when absent
- [x] A container with no children is not flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the weekend go-live sequence to reflect completed work and add the latest decision point.
  * Clarified which items belong in the sequence and which inventory safeguard is a follow-up rather than a prerequisite.

* **Quality Improvements**
  * Expanded validation for lodging inventory data, including nested listings, incomplete information, capacity-only records, and unusual data relationships.
  * Added checks to help identify inventory details that may not appear on bookable rooms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->