### PR TITLE
fix(frontend): staff housing is not planning inventory, so the board stops drawing it

### DIFF
--- a/frontend/src/components/weekend/LodgingMap.test.tsx
+++ b/frontend/src/components/weekend/LodgingMap.test.tsx
@@ -686,6 +686,20 @@ describe('LodgingMap legend', () => {
 
 describe('LodgingMap highlight controls', () => {
   const BATH = unit({ unit_id: 'u1', code: 'cedar-1', name: 'Cedar 1', near_bathhouse: true })
+  /**
+   * A staff cabin RELEASED to families, which is why it is still on the map.
+   *
+   * `unit()` defaults `is_family_available: true`, and that is load-bearing
+   * here rather than incidental: the board — and therefore the map, which
+   * projects from it — now excludes staff housing that has NOT been released.
+   * Set `is_family_available: false` on this fixture and every test below
+   * stops finding its mark at all.
+   *
+   * That also means the "Staff cabins" highlight now matches almost nothing
+   * in practice, since released staff cabins are rare and unreleased ones no
+   * longer reach the map. Tracked as its own issue rather than fixed here —
+   * staff asked to review the map's toggles as a set.
+   */
   const STAFF = unit({
     unit_id: 'u2',
     code: 'cedar-2',

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -42,6 +42,14 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
   }
 }
 
+/**
+ * Permanent full-time staff housing — held for staff and therefore not
+ * family-available. 21 of the property's 102 leaf units are these.
+ */
+function staffUnit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
+  return unit({ allocation_default: 'staff_default', is_family_available: false, ...overrides })
+}
+
 function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
   return {
     grain: 'household',
@@ -96,6 +104,72 @@ describe('buildBoard — which units get a card', () => {
     expect(slots.map((slot) => slot.unit.code)).toEqual(['cedar-1', 'cedar-2'])
     expect(board.offBoard).toHaveLength(0)
   })
+
+  it('drops staff housing nobody is in, because it was never planning inventory', () => {
+    // Staff housing is occupied by full-time staff who are not enrolled per
+    // session and never appear on a roster, so the card would always be
+    // empty. Since drag placement shipped every drawn card is an enabled
+    // drop target, so an empty card reads as a room to drop a family into.
+    const board = buildBoard([], [unit(), staffUnit({ unit_id: 'u2', code: 'aspen-lodge' })])
+    const slots = board.areas.flatMap((area) => area.slots)
+    expect(slots.map((slot) => slot.unit.code)).toEqual(['cedar-1'])
+  })
+
+  it('keeps staff housing that still holds a party, so nobody vanishes', () => {
+    // This file's second invariant. A mis-ingested alias or a hand-edited row
+    // can put a party somewhere a display rule would otherwise hide, and no
+    // party may disappear because of a display rule.
+    const board = buildBoard(
+      [party({ unit_code: 'aspen-lodge', unit_name: 'Aspen Lodge' })],
+      [unit(), staffUnit({ unit_id: 'u2', code: 'aspen-lodge', name: 'Aspen Lodge' })]
+    )
+    const slots = board.areas.flatMap((area) => area.slots)
+    expect(slots.map((slot) => slot.unit.code)).toEqual(['cedar-1', 'aspen-lodge'])
+    expect(board.offBoard).toHaveLength(0)
+    expect(board.unplaced).toHaveLength(0)
+  })
+
+  it('keeps a staff cabin released to families for this weekend', () => {
+    // Releasing a staff cabin exists so a family can be housed in it, and
+    // `unitBadges` gives it a "Released" badge to say so. Hiding the cabin
+    // staff just released would make the capability useless, so the
+    // exclusion reads resolved availability, not the standing role alone.
+    const board = buildBoard(
+      [],
+      [
+        unit(),
+        staffUnit({
+          unit_id: 'u2',
+          code: 'aspen-lodge',
+          is_family_available: true,
+          reservation_state: 'released_to_family',
+        }),
+      ]
+    )
+    const slots = board.areas.flatMap((area) => area.slots)
+    expect(slots.map((slot) => slot.unit.code)).toEqual(['cedar-1', 'aspen-lodge'])
+  })
+
+  it('keeps a family cabin held back this weekend, because held rooms are badged not hidden', () => {
+    // A burst pipe takes a room out of service for the weekend; it is still
+    // planning inventory, and `unitBadges` renders "Held" for exactly this
+    // row. Staff reason about adjacency, so hiding it makes the site look
+    // smaller than it is.
+    const board = buildBoard(
+      [],
+      [
+        unit(),
+        unit({
+          unit_id: 'u2',
+          code: 'cedar-2',
+          is_family_available: false,
+          reservation_state: 'reserved_other',
+        }),
+      ]
+    )
+    const slots = board.areas.flatMap((area) => area.slots)
+    expect(slots.map((slot) => slot.unit.code)).toEqual(['cedar-1', 'cedar-2'])
+  })
 })
 
 describe('countBoardSlots — the tab count is the card count', () => {
@@ -111,6 +185,23 @@ describe('countBoardSlots — the tab count is the card count', () => {
     // number of cards the board does not draw.
     const units = [unit(), unit({ unit_id: 'u2', code: 'cedar-2', is_active: false })]
     const parties = [party({ unit_code: 'cedar-2', unit_name: 'Cedar 2' })]
+    expect(countBoardSlots(parties, units)).toBe(
+      buildBoard(parties, units).areas.flatMap((a) => a.slots).length
+    )
+    expect(countBoardSlots(parties, units)).toBe(2)
+  })
+
+  it('agrees with the board about staff housing nobody is in', () => {
+    const units = [unit(), staffUnit({ unit_id: 'u2', code: 'aspen-lodge' })]
+    expect(countBoardSlots([], units)).toBe(
+      buildBoard([], units).areas.flatMap((a) => a.slots).length
+    )
+    expect(countBoardSlots([], units)).toBe(1)
+  })
+
+  it('agrees with the board about staff housing that still holds a party', () => {
+    const units = [unit(), staffUnit({ unit_id: 'u2', code: 'aspen-lodge' })]
+    const parties = [party({ unit_code: 'aspen-lodge', unit_name: 'Aspen Lodge' })]
     expect(countBoardSlots(parties, units)).toBe(
       buildBoard(parties, units).areas.flatMap((a) => a.slots).length
     )

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -256,6 +256,29 @@ function consentReason(
  * predicate is how a tab starts promising a number of cards the board does not
  * draw.
  */
+/**
+ * Whether this unit is inventory the weekend is planned against.
+ *
+ * 21 of the property's 102 leaf units are permanent full-time staff housing
+ * (per the lodging registry), occupied by staff who are not enrolled per
+ * session and so never appear on a roster. None of the 21 has a measured
+ * `sleeps` — nobody has ever counted their beds, because they were never
+ * inventory. Their cards are always empty, and since drag placement every drawn
+ * card is an enabled drop target — an empty card reads as a room a family can
+ * be dropped into, which is how a family lands in an occupied staff cabin.
+ *
+ * Read off RESOLVED availability rather than the standing role, because a
+ * staff cabin can be released to families for one weekend and hiding the
+ * cabin staff just released would make that capability useless. The converse
+ * is deliberately NOT symmetric: a family cabin held back this weekend — a
+ * burst pipe, say — keeps its card and gets a "Held" badge, because it is
+ * still inventory and staff reason about adjacency. See `unitBadges.ts`:
+ * reserved units are badged, not hidden.
+ */
+function isPlanningInventory(unit: LodgingUnitRow): boolean {
+  return unit.allocation_default !== 'staff_default' || unit.is_family_available === true
+}
+
 function indexPayload(parties: RosterPartyRow[], units: LodgingUnitRow[]) {
   // Every leaf unit can hold a party, including a deactivated one — the
   // registry can be edited out from under a live assignment.
@@ -289,10 +312,13 @@ function indexPayload(parties: RosterPartyRow[], units: LodgingUnitRow[]) {
     else partiesByCode.set(code, [party])
   }
 
-  // A deactivated room is not bookable, so it clutters the board — unless
-  // somebody is still in it, in which case hiding it would drop them.
+  // A deactivated room is not bookable, and staff housing was never planning
+  // inventory at all, so both clutter the board — unless somebody is still in
+  // one, in which case hiding it would drop them.
   const drawn = [...leafByCode.values()].filter(
-    (unit) => unit.is_active !== false || (partiesByCode.get(unit.code)?.length ?? 0) > 0
+    (unit) =>
+      (unit.is_active !== false && isPlanningInventory(unit)) ||
+      (partiesByCode.get(unit.code)?.length ?? 0) > 0
   )
 
   return { drawn, partiesByCode, unplaced, offBoard }

--- a/frontend/src/components/weekend/mapModel.test.ts
+++ b/frontend/src/components/weekend/mapModel.test.ts
@@ -117,6 +117,69 @@ describe('resolvePartyUnits', () => {
 })
 
 describe('buildMapModel', () => {
+  /**
+   * Permanent staff housing: held for staff AND not released this weekend.
+   *
+   * Setting only `allocation_default` is not enough — `unit()` defaults
+   * `is_family_available: true`, which satisfies `isPlanningInventory`'s OR
+   * clause and leaves the unit drawn. Every earlier staff fixture in the map
+   * suite made exactly that mistake, which is why none of them could see the
+   * board exclusion reaching the map.
+   */
+  function staffUnit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
+    return unit({ allocation_default: 'staff_default', is_family_available: false, ...overrides })
+  }
+
+  it('drops staff housing, because the map is a projection of the board', () => {
+    // The map inherits the board's exclusion rather than overriding it.
+    //
+    // The design doc (§5.3) originally said the opposite — keep them, marked —
+    // on the reasoning that a map missing part of the property is worse for
+    // orientation. Staff overruled that on 2026-08-04: they know where the
+    // staff cabins are, and they asked for FEWER map toggles, not more marks.
+    // Recorded here rather than only in the spec, because "the map is a pure
+    // projection of the board" is the property that makes the two surfaces
+    // agree, and a future reader is more likely to reach for an override than
+    // to find the ruling.
+    const model = buildMapModel(
+      [],
+      [unit(), staffUnit({ unit_id: 'u2', code: 'aspen-lodge', map_x: 0.7, map_y: 0.2 })]
+    )
+    expect(model.units.map((u) => u.unit.code)).toEqual(['cedar-1'])
+  })
+
+  it('still draws staff housing that holds a party, so nobody vanishes', () => {
+    // The escape hatch reaches the map too. This is the one case where a staff
+    // cabin appears on the map, and it must: hiding it would put a family
+    // nowhere on the surface that answers "where is this family sleeping".
+    const model = buildMapModel(
+      [party({ unit_code: 'aspen-lodge', unit_name: 'Aspen Lodge' })],
+      [unit(), staffUnit({ unit_id: 'u2', code: 'aspen-lodge', map_x: 0.7, map_y: 0.2 })]
+    )
+    expect(model.units.map((u) => u.unit.code)).toEqual(['cedar-1', 'aspen-lodge'])
+    expect(model.offMap).toHaveLength(0)
+    expect(model.unplaced).toHaveLength(0)
+  })
+
+  it('counts what the map draws, staff housing excluded', () => {
+    const units = [
+      unit(),
+      staffUnit({ unit_id: 'u2', code: 'aspen-lodge', map_x: 0.7, map_y: 0.2 }),
+    ]
+    expect(countMapUnits([], units)).toBe(buildMapModel([], units).units.length)
+    expect(countMapUnits([], units)).toBe(1)
+  })
+
+  it('still never draws a container, staff-held or not', () => {
+    // The container rule is not weakened by the staff rule: a building row
+    // carries the beds its halves already report.
+    const model = buildMapModel(
+      [],
+      [unit(), staffUnit({ unit_id: 'u2', code: 'staff-block', is_container: true })]
+    )
+    expect(model.units.map((u) => u.unit.code)).toEqual(['cedar-1'])
+  })
+
   it('never draws a container', () => {
     const model = buildMapModel(
       [],

--- a/frontend/src/components/weekend/mapModel.ts
+++ b/frontend/src/components/weekend/mapModel.ts
@@ -47,11 +47,17 @@ export interface MapModel {
   offMap: OffMapEntry[]
   /**
    * Bookable rooms nobody has positioned, reported HERE — but this is not a
-   * totality guarantee for the payload as a whole. `buildBoard` already drops
-   * an inactive, empty unit before `buildMapModel` ever sees it (see the
-   * `drawn` filter in `boardLayout.ts`), so an unpositioned INACTIVE room
-   * with nobody in it is silently dropped upstream and never reaches this
-   * list.
+   * totality guarantee for the payload as a whole. `buildBoard` drops two
+   * kinds of unit before `buildMapModel` ever sees them (see the `drawn`
+   * filter in `boardLayout.ts`), and an unpositioned one of either kind is
+   * dropped upstream and never reaches this list:
+   *
+   * - an INACTIVE room with nobody in it;
+   * - permanent STAFF HOUSING with nobody in it — staff know where those are
+   *   and asked not to have them on the map.
+   *
+   * Both are deliberate. If you are hunting a cabin that is missing from the
+   * map and not reported here, check those two before suspecting coordinates.
    */
   unpositionedUnits: LodgingUnitRow[]
 }


### PR DESCRIPTION
## The regression

21 of the property's 102 leaf units are permanent full-time staff housing —
occupied by staff who are not enrolled per session, so they never appear on a
roster. Not one of the 21 has a measured `sleeps`; nobody has ever counted
their beds, because they were never inventory.

`boardLayout.indexPayload` filtered on `is_container` and `is_active` but never
on availability, so all 21 drew empty cards.

Before drag placement that was clutter. Since #1990 every drawn card registers
a `useDroppable`, so **an empty card reads as a room to drop a family into** —
a family could be placed into a cabin permanently occupied by year-round staff.
Staff have said these units do not belong on the board at all.

## The fix

`allocation_default` already identifies them exactly, so there is no schema
change here.

The exclusion reads **resolved availability**, not the standing role. A staff
cabin can be released to families for a single weekend, and hiding the cabin
staff just released would make that capability useless — `unitBadges.ts`
already renders a "Released" badge for precisely that row.

The converse is deliberately **not** symmetric: a family cabin held back this
weekend (a burst pipe, say) keeps its card and gets a "Held" badge. It is still
inventory, staff reason about adjacency, and `unitBadges.ts` badges reserved
units rather than hiding them.

Because cards render only from `drawn`, and `useDroppable` lives on the card,
excluding a unit removes the drop-target registration itself rather than just
hiding it visually.

## The invariant

`boardLayout`'s "no party is ever dropped" invariant survives unchanged: a
staff unit that somehow holds a party — a mis-ingested alias, a hand-edited row
— still gets a card, using the same escape hatch the deactivated-unit rule
already uses.

`countBoardSlots` shares `indexPayload`, so the Housing tab count follows
automatically and cannot drift. Asserted rather than assumed.

## Tests

Six added, all mutation-checked rather than assumed to assert something:

| Mutation | Test that dies |
|---|---|
| Filter on role alone (drop the released arm) | keeps a staff cabin released to families |
| Filter on resolved availability alone (drop the role arm) | keeps a family cabin held back this weekend |
| Remove the party escape hatch | keeps staff housing that still holds a party (+ the existing deactivated-unit pair) |

The "drops staff housing nobody is in" pair was verified failing before the
implementation landed.

## Note on the deployed data

The unit registry has not been re-ingested into the dev or main databases —
both hold 93 units with only 3 staff-held leaf rows, against the registry's
114/21. The fix is independent of which is loaded, but the visible effect in
dev today is 3 phantom cards rather than 21.

## Verification

- `npx vitest run` → 400 files, 5567 tests, **exit 0**
- `npx tsc --noEmit` → **exit 0**
- `npx eslint src` → **0 errors**; the two changed files lint clean on their own
- pre-push: ruff, shellcheck, go-build, pb-js-lint, markdownlint, api-types-freshness, mypy, type-check, pytest (5871 passed) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)