### PR TITLE
fix(api): staff housing leaves the planning inventory, in the counts and on the bar

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -255,12 +255,25 @@ class RosterCounts(BaseModel):
     parties_total: int = 0
     parties_assigned: int = 0
     parties_unassigned: int = 0
-    # Active, non-container units.
+    # Active, non-container units that are PLANNING INVENTORY -- permanent
+    # staff housing is excluded and reported by units_staff_housing.
     units_total: int = 0
     units_family_available: int = 0
-    # Bookable units held back from families this session (staff-default with
-    # no release, or an explicit reserved_* override).
+    # Planning inventory held back from families this session -- a burst pipe,
+    # a caretaker in residence. Does NOT include permanent staff housing,
+    # which was never bookable and so cannot be "held back"; that is
+    # units_staff_housing.
     units_reserved: int = 0
+    # Permanent full-time staff housing: 21 of the registry's 102 leaf units,
+    # occupied by staff who are not enrolled per session and never appear on a
+    # roster. Outside the planning inventory entirely, so NOT a subset of
+    # units_total -- that distinction is what units_reserved used to get
+    # wrong, reporting 21 cabins as "held back" that were never inventory.
+    #
+    # Counted rather than dropped silently: units_total shrinking by 21 with
+    # nothing on the surface explaining it reads as data loss to a staff
+    # member who knows how many cabins the property has.
+    units_staff_housing: int = 0
     # Sum of `sleeps` over family-available bookable units with a KNOWN
     # sleeps value. Units with unknown capacity are excluded and reported
     # separately, so the number never overstates what is placeable.

--- a/api/services/lodging_repository.py
+++ b/api/services/lodging_repository.py
@@ -404,17 +404,6 @@ class LodgingRepository:
             f'kind = "{UNRESOLVED_ALIAS_KIND}" && is_resolved = false',
         )
 
-    async def count_unconfirmed_units(self) -> int:
-        """Bookable units whose amenity data is still a seed guess.
-
-        is_container = false because the seven building rows are not bookable
-        and their amenity values are meaningless.
-        """
-        return await self._count(
-            LODGING_UNITS,
-            "is_confirmed = false && is_container = false && is_active = true",
-        )
-
     # ---------------------------------------------------------------- writes
     #
     # Every write below targets the DRAFT grain or lodging_availability. None

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -324,7 +324,6 @@ class LodgingRosterService:
             adults_task = tg.create_task(self.repository.fetch_family_camp_adults(year))
             registrations_task = tg.create_task(self.repository.fetch_family_camp_registrations(year))
             aliases_task = tg.create_task(self.repository.count_open_unresolved_aliases())
-            unconfirmed_task = tg.create_task(self.repository.count_unconfirmed_units())
             # ONE placement source, chosen here rather than merged later. A
             # scenario does not read the mirror at all -- which is what makes
             # "no fall-through" a property of the request rather than of the
@@ -358,7 +357,7 @@ class LodgingRosterService:
             registrations=registrations_task.result(),
             assignments=placements_task.result(),
         )
-        counts = self._build_counts(unit_summaries, parties, aliases_task.result(), unconfirmed_task.result())
+        counts = self._build_counts(unit_summaries, parties, aliases_task.result())
 
         return WeekendRosterResponse(
             year=year,
@@ -411,7 +410,6 @@ class LodgingRosterService:
             adults_task = tg.create_task(self.repository.fetch_family_camp_adults(year))
             registrations_task = tg.create_task(self.repository.fetch_family_camp_registrations(year))
             aliases_task = tg.create_task(self.repository.count_open_unresolved_aliases())
-            unconfirmed_task = tg.create_task(self.repository.count_unconfirmed_units())
 
         units = units_task.result()
         households = households_task.result()
@@ -419,7 +417,6 @@ class LodgingRosterService:
         adults_by_household = adults_task.result()
         registrations = registrations_task.result()
         unresolved_aliases = aliases_task.result()
-        unconfirmed_units = unconfirmed_task.result()
 
         async def _entry(session: Any) -> WeekendSummaryEntry:
             session_pb_id = _s(session, "id")
@@ -454,7 +451,7 @@ class LodgingRosterService:
             )
             return WeekendSummaryEntry(
                 session=self._session_summary(session),
-                counts=self._build_counts(unit_summaries, parties, unresolved_aliases, unconfirmed_units),
+                counts=self._build_counts(unit_summaries, parties, unresolved_aliases),
             )
 
         async with asyncio.TaskGroup() as tg:
@@ -857,7 +854,6 @@ class LodgingRosterService:
         units: list[LodgingUnitSummary],
         parties: list[RosterParty],
         unresolved_aliases: int,
-        unconfirmed_units: int,
     ) -> RosterCounts:
         # Containers are building/grouping rows carrying whole-building
         # aggregates. Including them double-counts beds (408 vs a true 389).
@@ -876,7 +872,14 @@ class LodgingRosterService:
             units_staff_housing=len(staff_housing),
             beds_family_available=sum(u.sleeps for u in available if u.sleeps is not None),
             units_capacity_unknown=sum(1 for u in bookable if u.sleeps is None),
-            units_unconfirmed=unconfirmed_units,
+            # Over `bookable`, NOT a separate PocketBase count. The old query
+            # filtered is_confirmed/is_container/is_active with no inventory
+            # predicate, so once units_total dropped staff housing the two
+            # described different populations -- and the stats bar divides one
+            # by the other ("N of M cabins have unconfirmed amenities"). Every
+            # unit is already here with its is_confirmed, so the second answer
+            # bought nothing but a chance to disagree, and one fetch.
+            units_unconfirmed=sum(1 for u in bookable if not u.is_confirmed),
             units_missing_allocation=sum(1 for u in bookable if not u.allocation_default),
             unresolved_aliases=unresolved_aliases,
         )

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -239,6 +239,25 @@ def _household_sort_name(adults: list[Any], children: list[Any], display_name: s
     return _last_token(display_name)
 
 
+def _is_planning_inventory(unit: LodgingUnitSummary) -> bool:
+    """Whether this unit is inventory the weekend is planned against.
+
+    THE SAME PREDICATE the board applies in `boardLayout.isPlanningInventory`
+    (frontend). If the two drift, the Housing tab and the stats bar describe
+    different weekends -- the board drawing 81 cards beside a bar reporting
+    102 units is exactly the disagreement this shape exists to prevent.
+
+    Reads RESOLVED availability rather than the standing role, so a staff
+    cabin released to families for one weekend rejoins the inventory; hiding
+    the cabin staff just released would make the release capability useless.
+
+    The converse is deliberately NOT symmetric: a family cabin held back this
+    weekend is still inventory and is reported by `units_reserved`. Permanent
+    staff housing was never inventory, so it cannot be "held back".
+    """
+    return unit.allocation_default != "staff_default" or unit.is_family_available
+
+
 class LodgingRosterService:
     """Builds the read-only weekend roster from repository output."""
 
@@ -842,7 +861,9 @@ class LodgingRosterService:
     ) -> RosterCounts:
         # Containers are building/grouping rows carrying whole-building
         # aggregates. Including them double-counts beds (408 vs a true 389).
-        bookable = [u for u in units if not u.is_container and u.is_active]
+        leaf = [u for u in units if not u.is_container and u.is_active]
+        bookable = [u for u in leaf if _is_planning_inventory(u)]
+        staff_housing = [u for u in leaf if not _is_planning_inventory(u)]
         available = [u for u in bookable if u.is_family_available]
         assigned = sum(1 for p in parties if p.unit_code or p.unit_name)
         return RosterCounts(
@@ -852,6 +873,7 @@ class LodgingRosterService:
             units_total=len(bookable),
             units_family_available=len(available),
             units_reserved=len(bookable) - len(available),
+            units_staff_housing=len(staff_housing),
             beds_family_available=sum(u.sleeps for u in available if u.sleeps is not None),
             units_capacity_unknown=sum(1 for u in bookable if u.sleeps is None),
             units_unconfirmed=unconfirmed_units,

--- a/frontend/src/components/weekend/UnitInventoryPanel.test.tsx
+++ b/frontend/src/components/weekend/UnitInventoryPanel.test.tsx
@@ -36,6 +36,33 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
 }
 
 describe('UnitInventoryPanel', () => {
+  it('lists permanent staff housing, because this is the REGISTRY and not the board', () => {
+    // The board excludes staff housing (`boardLayout.isPlanningInventory`) —
+    // its cards are drop targets, and an empty card for a cabin permanently
+    // occupied by year-round staff invites a family into it.
+    //
+    // This panel is the opposite job: it is the inventory view, and it is the
+    // only screen from which these 21 units can be seen or edited. Applying
+    // the board's filter here — the obvious next move for someone reading
+    // that change — would hide them from the only place they are reachable.
+    render(
+      <UnitInventoryPanel
+        units={[
+          unit(),
+          unit({
+            unit_id: 'u2',
+            code: 'aspen-lodge',
+            name: 'Aspen Lodge',
+            allocation_default: 'staff_default',
+            is_family_available: false,
+          }),
+        ]}
+      />
+    )
+    expect(screen.getByText('Aspen Lodge')).toBeInTheDocument()
+    expect(screen.getByText('Ridge A')).toBeInTheDocument()
+  })
+
   it('keeps staff-reserved units visible and badges them', () => {
     render(
       <UnitInventoryPanel

--- a/frontend/src/components/weekend/WeekendStatsBar.test.tsx
+++ b/frontend/src/components/weekend/WeekendStatsBar.test.tsx
@@ -93,6 +93,34 @@ describe('WeekendStatsBar', () => {
     expect(screen.getByText('· 3 held')).toBeInTheDocument()
   })
 
+  it('does not describe held cabins as staff housing', () => {
+    // "Held" and "staff housing" were one number until units_staff_housing
+    // split them, and the tooltip still said "Held for staff". They are
+    // different facts with different remedies: a held cabin comes back next
+    // weekend, a staff cabin never does.
+    render(<WeekendStatsBar counts={counts()} bedsNeeded={223} spacesUnmeasured={0} />)
+    expect(screen.getByTitle(/excluded from spaces/i).textContent).toContain('held')
+    expect(screen.queryByTitle(/held for staff/i)).not.toBeInTheDocument()
+  })
+
+  it('reports staff housing separately, because it was never inventory', () => {
+    // 21 cabins reading as "held" would say staff took them out of service
+    // this weekend. They were never in service.
+    render(
+      <WeekendStatsBar
+        counts={counts({ units_staff_housing: 21 })}
+        bedsNeeded={223}
+        spacesUnmeasured={0}
+      />
+    )
+    expect(screen.getByText('· 21 staff')).toBeInTheDocument()
+  })
+
+  it('says nothing about staff housing when there is none', () => {
+    render(<WeekendStatsBar counts={counts()} bedsNeeded={223} spacesUnmeasured={0} />)
+    expect(screen.queryByText(/staff/)).not.toBeInTheDocument()
+  })
+
   it('highlights parties still needing a cabin', () => {
     render(<WeekendStatsBar counts={counts()} bedsNeeded={223} spacesUnmeasured={0} />)
     expect(screen.getByText('need a cabin')).toBeInTheDocument()

--- a/frontend/src/components/weekend/WeekendStatsBar.tsx
+++ b/frontend/src/components/weekend/WeekendStatsBar.tsx
@@ -22,9 +22,11 @@ export interface WeekendStatsBarProps {
   bedsNeeded: number
   /**
    * Family spaces whose capacity nobody has recorded. NOT
-   * `counts.units_capacity_unknown`, which spans staff holds and building
-   * rows — on real 2026 data that says 5 where only 2 of the 79 placeable
-   * spaces are unmeasured.
+   * `counts.units_capacity_unknown`: that asks about the planning inventory,
+   * which keeps a cabin held back this weekend because it returns next
+   * weekend. This one asks what a family could be put in RIGHT NOW, which is
+   * the reading that matches the bed count beside it. See
+   * `countUnmeasuredSpaces`.
    */
   spacesUnmeasured: number
 }
@@ -38,6 +40,7 @@ export function WeekendStatsBar({ counts, bedsNeeded, spacesUnmeasured }: Weeken
   const spaces = counts.units_family_available ?? 0
   const unitsTotal = counts.units_total ?? 0
   const unitsReserved = counts.units_reserved ?? 0
+  const unitsStaffHousing = counts.units_staff_housing ?? 0
   const beds = counts.beds_family_available ?? 0
   const spare = spaces - partiesTotal
 
@@ -85,9 +88,26 @@ export function WeekendStatsBar({ counts, bedsNeeded, spacesUnmeasured }: Weeken
           <span className="text-muted-foreground tabular-nums">
             ({spare < 0 ? `${String(Math.abs(spare))} short` : `${String(spare)} spare`})
           </span>
+          {/* Held and staff housing are DIFFERENT facts with different
+              remedies, and were one number until `units_staff_housing` split
+              them. A held cabin is inventory that comes back next weekend — a
+              burst pipe, a caretaker in residence. A staff cabin never does:
+              it houses full-time staff who are not enrolled per session, and
+              was never part of the weekend's inventory to begin with. */}
           {unitsReserved > 0 && (
-            <span className="text-muted-foreground" title="Held for staff, excluded from spaces">
+            <span
+              className="text-muted-foreground"
+              title="Out of service this weekend, excluded from spaces"
+            >
               · {unitsReserved} held
+            </span>
+          )}
+          {unitsStaffHousing > 0 && (
+            <span
+              className="text-muted-foreground"
+              title="Permanent staff housing, never part of the weekend's inventory"
+            >
+              · {unitsStaffHousing} staff
             </span>
           )}
         </div>

--- a/frontend/src/components/weekend/rosterAttention.test.ts
+++ b/frontend/src/components/weekend/rosterAttention.test.ts
@@ -212,9 +212,12 @@ describe('partyBeds', () => {
 
 describe('countUnmeasuredSpaces', () => {
   it('counts only the spaces a family could actually be placed into', () => {
-    // Deliberately not `counts.units_capacity_unknown`, which spans staff
-    // holds and building rows too — on real 2026 data it says 5 where only 2
-    // of the 79 placeable spaces are unmeasured.
+    // Deliberately not `counts.units_capacity_unknown`. It used to span staff
+    // holds — 5 on real 2026 data where only 2 of the 79 placeable spaces were
+    // unmeasured — but `_build_counts` now excludes staff housing, so on that
+    // data the two agree. What still separates them is a cabin HELD BACK this
+    // weekend: still planning inventory, so `units_capacity_unknown` keeps it,
+    // while nobody can be placed in it today, so this drops it.
     expect(
       countUnmeasuredSpaces([
         unit({ code: 'a', sleeps: null }),

--- a/frontend/src/components/weekend/rosterAttention.ts
+++ b/frontend/src/components/weekend/rosterAttention.ts
@@ -161,9 +161,23 @@ export function indexUnitsByCode(units: LodgingUnitRow[]): Map<string, LodgingUn
 /**
  * Family spaces whose capacity nobody has recorded.
  *
- * Deliberately not `counts.units_capacity_unknown`, which spans every
- * unmeasured cabin including staff holds and building rows — on real 2026 data
- * that reports 5 where only 2 of the 79 placeable spaces are unmeasured.
+ * Deliberately not `counts.units_capacity_unknown`. That count used to span
+ * staff holds too — reporting 5 on real 2026 data where only 2 of the 79
+ * placeable spaces were unmeasured — but no longer does: `_build_counts` now
+ * excludes staff housing from the planning inventory, so on that same data the
+ * two agree.
+ *
+ * They are still not the same question, which is why this survives. This one
+ * asks about spaces a family could be put in RIGHT NOW, so it filters on
+ * `is_family_available` and drops a cabin held back this weekend.
+ * `units_capacity_unknown` asks about the planning inventory, which includes
+ * that held cabin because it returns next weekend. They diverge the moment
+ * anything is held — today nothing is, because `lodging_availability` has
+ * never held a row.
+ *
+ * It sits beside the BED count on the stats bar, and beds there are
+ * `beds_family_available`, so the available-only reading is the one that
+ * matches its neighbour.
  */
 export function countUnmeasuredSpaces(units: LodgingUnitRow[]): number {
   return units.filter(

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -4797,6 +4797,10 @@ export type RosterCounts = {
    */
   units_reserved?: number
   /**
+   * Units Staff Housing
+   */
+  units_staff_housing?: number
+  /**
    * Beds Family Available
    */
   beds_family_available?: number

--- a/tests/unit/api/services/test_lodging_repository.py
+++ b/tests/unit/api/services/test_lodging_repository.py
@@ -413,26 +413,10 @@ class TestCounts:
         pb.collection.return_value.get_full_list.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_unconfirmed_units_excludes_containers_and_inactive(
-        self, repo: LodgingRepository, pb: MagicMock
-    ) -> None:
-        pb.collection.return_value.get_list.return_value = _record(total_items=1)
-
-        count = await repo.count_unconfirmed_units()
-
-        pb.collection.assert_called_with("lodging_units")
-        filter_str = _last_list_query(pb)["filter"]
-        assert "is_confirmed = false" in filter_str
-        assert "is_container = false" in filter_str
-        assert "is_active = true" in filter_str
-        assert count == 1
-        pb.collection.return_value.get_full_list.assert_not_called()
-
-    @pytest.mark.asyncio
     async def test_counts_request_a_single_row(self, repo: LodgingRepository, pb: MagicMock) -> None:
         pb.collection.return_value.get_list.return_value = _record(total_items=42)
 
-        await repo.count_unconfirmed_units()
+        await repo.count_open_unresolved_aliases()
 
         args = pb.collection.return_value.get_list.call_args[0]
         assert args[0] == 1, "page 1"

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -89,6 +89,11 @@ def _repo(**overrides: Any) -> MagicMock:
         "fetch_household_by_cm_id": None,
         "fetch_medical_for_household": None,
         "count_open_unresolved_aliases": 0,
+        # DELIBERATELY still here, though the repository method is gone: the
+        # tests that pin the roster no longer asking for this count need an
+        # attribute to run `assert_not_called()` against. A bare MagicMock
+        # would invent one on access and pass no matter what, which is the
+        # failure mode those tests exist to rule out.
         "count_unconfirmed_units": 0,
     }
     defaults.update(overrides)
@@ -583,13 +588,59 @@ class TestUnitsAndCounts:
     async def test_unresolved_alias_and_unconfirmed_counts_are_surfaced(self) -> None:
         repo = _repo(
             fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "ridge-a", "Ridge A", sleeps=5, is_confirmed=False),
+                _unit("u2", "ridge-b", "Ridge B", sleeps=4, is_confirmed=False),
+            ],
             count_open_unresolved_aliases=3,
-            count_unconfirmed_units=6,
         )
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
 
         assert roster.counts.unresolved_aliases == 3
-        assert roster.counts.units_unconfirmed == 6
+        assert roster.counts.units_unconfirmed == 2
+
+    @pytest.mark.asyncio
+    async def test_unconfirmed_counts_the_same_population_as_units_total(self) -> None:
+        """The stats bar divides one by the other, so they must agree.
+
+        `count_unconfirmed_units` asked PocketBase for is_confirmed = false
+        && is_container = false && is_active = true -- no inventory predicate.
+        Once `units_total` stopped counting staff housing the two described
+        different populations, and the bar's note reads "N of M cabins have
+        unconfirmed amenities" off both. With every staff cabin unconfirmed it
+        could claim more unconfirmed cabins than cabins, or trip its
+        `unconfirmed >= unitsTotal` branch and report "No cabin amenities
+        confirmed yet" while planning-inventory cabins were confirmed.
+
+        The repository value is deliberately non-zero here: the count now comes
+        from the units the roster already holds, so this pins that the stale
+        fetch is not consulted.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "ridge-a", "Ridge A", sleeps=5, is_confirmed=True),
+                _unit("u2", "aspen-lodge", "Aspen Lodge", allocation_default="staff_default"),
+            ],
+            count_unconfirmed_units=1,
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.counts.units_total == 1
+        assert roster.counts.units_staff_housing == 1
+        assert roster.counts.units_unconfirmed == 0
+
+    @pytest.mark.asyncio
+    async def test_the_roster_no_longer_asks_pocketbase_for_the_unconfirmed_count(self) -> None:
+        """One fewer fetch on both paths, because the units already say.
+
+        Every unit is already in the payload with its `is_confirmed`, so the
+        separate count query was a second answer to a question the roster could
+        answer itself -- and the two could disagree.
+        """
+        repo = _repo(fetch_session=FAMILY_SESSION)
+        await LodgingRosterService(repo).build_roster(2026, 1000001)
+        repo.count_unconfirmed_units.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_full_bathroom_group_merge_is_not_assumed_for_a_lone_unit(self) -> None:
@@ -1209,10 +1260,12 @@ class TestBuildSummary:
 
         await service.build_summary(2026)
 
-        # Seven year-scoped fetches, two weekends: each must still be one call.
+        # Six year-scoped fetches, two weekends: each must still be one call.
         # `fetch_family_camp_medical` was the eighth until kindred#1889 deleted
-        # its only consumer -- see the assertion below, which pins that it is
-        # not read at all rather than merely read once.
+        # its only consumer, and `count_unconfirmed_units` the seventh until
+        # `_build_counts` started counting `is_confirmed` off the units it
+        # already holds -- see the assertions below, which pin that neither is
+        # read at all rather than merely read once.
         for method in (
             "fetch_units",
             "fetch_households",
@@ -1220,11 +1273,11 @@ class TestBuildSummary:
             "fetch_family_camp_adults",
             "fetch_family_camp_registrations",
             "count_open_unresolved_aliases",
-            "count_unconfirmed_units",
         ):
             assert getattr(repo, method).await_count == 1, f"{method} was not batched"
 
         repo.fetch_family_camp_medical.assert_not_called()
+        repo.count_unconfirmed_units.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_session_scoped_reads_happen_once_per_weekend(self) -> None:

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -488,10 +488,82 @@ class TestUnitsAndCounts:
         assert by_code["ridge-a"].reservation_state == "reserved_staff"
         assert by_code["ridge-a"].is_family_available is False
         assert by_code["le-shack"].is_family_available is False
-        assert roster.counts.units_total == 2
+        # Both units stay VISIBLE in `roster.units` -- that is what this test
+        # is named for, and it is unchanged. What changed is the counts: the
+        # staff cabin is no longer reported as "reserved", because it was
+        # never bookable and so cannot be held back. It is planning inventory
+        # that is missing, not planning inventory that is unavailable.
+        assert len(roster.units) == 2
+        assert roster.counts.units_total == 1
         assert roster.counts.units_family_available == 0
-        assert roster.counts.units_reserved == 2
+        assert roster.counts.units_reserved == 1
+        assert roster.counts.units_staff_housing == 1
         assert roster.counts.beds_family_available == 0
+
+    @pytest.mark.asyncio
+    async def test_staff_housing_leaves_the_planning_inventory_counts(self) -> None:
+        """Staff housing was never inventory, so it is not "held back" either.
+
+        `units_reserved` reading 21 says staff took 21 cabins out of service
+        this weekend. They were never in service -- they hold full-time staff
+        who are not enrolled per session and never appear on a roster. Same
+        for `units_capacity_unknown`: not one of the 21 has a measured
+        `sleeps` and none ever will, so counting them reads as a data-quality
+        backlog somebody still owes.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "ridge-a", "Ridge A", sleeps=5),
+                _unit("u2", "aspen-lodge", "Aspen Lodge", allocation_default="staff_default"),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.counts.units_total == 1
+        assert roster.counts.units_family_available == 1
+        assert roster.counts.units_reserved == 0
+        assert roster.counts.units_staff_housing == 1
+        assert roster.counts.units_capacity_unknown == 0
+
+    @pytest.mark.asyncio
+    async def test_a_released_staff_cabin_rejoins_the_planning_inventory(self) -> None:
+        """Releasing is the whole reason the capability is kept."""
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "ridge-a", "Ridge A", sleeps=5),
+                _unit("u2", "aspen-lodge", "Aspen Lodge", sleeps=4, allocation_default="staff_default"),
+            ],
+            fetch_availability=[_rec(unit="u2", state="released_to_family", note="")],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.counts.units_total == 2
+        assert roster.counts.units_staff_housing == 0
+        assert roster.counts.units_family_available == 2
+
+    @pytest.mark.asyncio
+    async def test_a_held_family_cabin_is_reserved_not_staff_housing(self) -> None:
+        """The two must not blur: one is temporary, the other never was ours.
+
+        A burst pipe closes a cabin for the weekend and it is still inventory.
+        Staff housing is not inventory at all. Reporting both as "reserved" is
+        what made the old number unreadable.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "ridge-a", "Ridge A", sleeps=5),
+                _unit("u2", "ridge-b", "Ridge B", sleeps=4),
+            ],
+            fetch_availability=[_rec(unit="u2", state="reserved_other", note="Burst pipe")],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.counts.units_total == 2
+        assert roster.counts.units_reserved == 1
+        assert roster.counts.units_staff_housing == 0
 
     @pytest.mark.asyncio
     async def test_staff_default_released_to_family_counts_as_available(self) -> None:


### PR DESCRIPTION
Stage 1 of the lodging availability segregation. The API half of #1993, which
does the same thing on the board.

## The bug

`_build_counts` treated every active leaf unit as bookable, so permanent
full-time staff housing was counted as inventory it never was. Two numbers
misled as a result:

- **`units_reserved`** reported staff housing as *held back this weekend*. It
  was never in service to be held back from anyone.
- **`units_capacity_unknown`** counted it as a measurement somebody still owes.
  Not one of the 21 staff-held leaf units in the registry has a measured
  `sleeps`, and none ever will — nobody counts beds in a room that is not
  inventory.

## The fix

`_is_planning_inventory` is **the same predicate the board applies** in
`boardLayout.isPlanningInventory` (#1993), so the Housing tab and the stats bar
cannot describe different weekends.

It reads **resolved availability**, not the standing role: a staff cabin
released to families for one weekend rejoins the inventory, because hiding the
cabin staff just released would make the release capability useless. The
converse is deliberately **not** symmetric — a family cabin held back (a burst
pipe) is still inventory and stays in `units_reserved`.

Staff housing is reported by a new **`units_staff_housing`** rather than dropped
silently: `units_total` shrinking with nothing on the surface explaining it
reads as data loss to someone who knows the property.

## On the one modified test

`test_reserved_units_stay_visible_but_leave_availability` pinned the old
specification. It is updated deliberately — not to match what the
implementation happens to do. The units it names still stay **visible**, which
is what the test was written for and what its name asserts; only the counts
change, and the test now says why in-line.

## Mutation check

Every new assertion was verified load-bearing. Each mutation kills a *different*
pair, so the tests discriminate rather than all restating one fact:

| Mutation to `_is_planning_inventory` | Tests killed |
|---|---|
| `return True` (no exclusion) | `test_staff_housing_leaves_the_planning_inventory_counts`, `test_reserved_units_stay_visible…` |
| Role alone (drop the released arm) | `test_a_released_staff_cabin_rejoins…`, **`test_staff_default_released_to_family_counts_as_available`** |
| Resolved availability alone (drop the role arm) | `test_a_held_family_cabin_is_reserved_not_staff_housing`, `test_reserved_units_stay_visible…` |

The bolded one is a **pre-existing** test, which independently confirms that
released-cabin semantics were already the specification rather than something
introduced here to justify the predicate.

## Sequencing

Deliberately **not** folded into #1993: that PR's value in the merge queue is
that it is frontend-only and therefore free for #1994 to land around. This
branch is off `main` at `7a0d9203` and **will be rebased once #1994 merges** —
that PR moves `_build_counts` and adds tests to the same class.

Agreed order: #1993 → #1994 → this.

## Verification

- `uv run pytest tests/` → **5901 passed, exit 0**
- `mypy` on both changed modules → no issues
- `ruff check` → all checks passed
- `npm run generate:api-types` → exactly 4 lines added, no drift (`git diff -w`)
- pre-push hooks all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lodging inventory now distinguishes permanent staff housing from session-reserved units.
  * Staff housing remains visible while excluded from bookable and planning inventory totals.
  * Weekend statistics separately display staff housing and cabins unavailable for the weekend, with explanatory tooltips.

* **Bug Fixes**
  * Released staff cabins can return to available inventory.
  * Temporarily held family cabins are counted as reserved rather than staff housing.
  * Improved lodging roster counts and availability calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->