### PR TITLE
feat(frontend): the weekend board can hold a cabin back, and release one

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -360,9 +360,15 @@ class WeekendSummaryResponse(BaseModel):
 
 
 class ScenarioWriteRequest(BaseModel):
-    """Common shape of every lodging write: one weekend, one scenario.
+    """Common shape of every lodging write that names a PLAN: one weekend, one scenario.
 
-    `scenario` is REQUIRED and non-empty on all of them. With no scenario the
+    Not every lodging write. `AvailabilityWriteRequest` deliberately does not
+    extend this, because availability is a fact about the weekend rather than
+    about the plan -- a burst pipe closes a cabin in every scenario for that
+    weekend -- and inheriting from here is exactly what left that endpoint
+    uncallable and its table empty (1500000135).
+
+    `scenario` is REQUIRED and non-empty on the writes that do extend it. With no scenario the
     board is the CampMinder mirror and is read-only for everyone -- summer
     encodes the identical rule in `ScenarioContext`'s `isProductionMode`, which
     disables every drop target. An endpoint accepting a scenario-less write

--- a/docs/reference/weekend-go-live-sequence.md
+++ b/docs/reference/weekend-go-live-sequence.md
@@ -62,9 +62,11 @@ It is not. `party_size` has **four display consumers and zero decision consumers
 
 ### "Live" is undefined, and the architecture cannot currently deliver its usual meaning
 
-Every write requires a scenario; `lodging_assignments` is permanently admin-only by locked decision; there is no promote/publish endpoint in `api/routers/`; `lodging_assignments_sync.go` never writes back; no weekend surface imports `csvExport` or the PDF button.
+Every **placement** write requires a scenario; `lodging_assignments` is permanently admin-only by locked decision; there is no promote/publish endpoint in `api/routers/`; `lodging_assignments_sync.go` never writes back; no weekend surface imports `csvExport` or the PDF button.
 
-So the board can only ever write **drafts**, and go-live today means *staff arrange in Kindred, then re-key into CampMinder by hand.*
+(This said "every write" until [#1998](https://github.com/adamflagg/kindred/issues/1998). Availability writes now require none — `1500000135` deleted the scenario dimension from `lodging_availability`, because a burst pipe closes a cabin in every plan for that weekend. The argument below is unaffected: it is about *placements*, which are still draft-only.)
+
+So the board can only ever write **draft placements**, and go-live today means *staff arrange in Kindred, then re-key into CampMinder by hand.*
 
 **This section originally added "Summer avoids this by writing `bunk_assignments` directly in production mode (`useCamperMovement.ts:353`); lodging is structurally denied that path." That is wrong on both halves** (corrected 2026-08-03, and on [#1968](https://github.com/adamflagg/kindred/issues/1968) itself):
 
@@ -127,12 +129,19 @@ are closed. Trust `docs/reference/issue-triage.md`'s Status cells and the tree.
 
 ## Your blocking prerequisite
 
-**#1967 — weekend scenario plumbing — MUST land before you can write anything.**
-Every lodging write requires `scenario: str = Field(..., min_length=1)`
-(`api/schemas/lodging.py:350`) and no weekend surface selects one yet. Check
-whether #1967 has merged. If it has not, either take it as step one of your own
-work or coordinate — but do not start the drag interaction on top of a surface
-that cannot name a scenario.
+**#1967 — weekend scenario plumbing — MUST land before you can write a placement.**
+Every write that names a *plan* extends `ScenarioWriteRequest`, where `scenario`
+is `Field(..., min_length=1)` (`api/schemas/lodging.py`, and re-grep rather than
+trusting a line number), and no weekend surface selected one yet. Check whether
+#1967 has merged. If it has not, either take it as step one of your own work or
+coordinate — but do not start the drag interaction on top of a surface that
+cannot name a scenario.
+
+**This said "every lodging write" and named a line that has since moved. Both
+were fixed after [#1998](https://github.com/adamflagg/kindred/issues/1998).**
+`AvailabilityWriteRequest` no longer extends `ScenarioWriteRequest`: availability
+is a fact about the weekend rather than about the plan, so holding a cabin back
+needs no scenario and works on the CampMinder mirror.
 
 Also check #1966 (roster latency). **#1974 (scenarios replace the mirror) has
 landed**, so a scenario is a plan of its own, seeded by `POST

--- a/frontend/src/components/weekend/LodgingBoard.availability.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.availability.test.tsx
@@ -89,7 +89,7 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
 function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
   return {
     grain: 'household',
-    household_cm_id: 101,
+    household_cm_id: 1000001,
     person_cm_id: 0,
     display_name: 'Johnson',
     sort_name: 'Johnson',

--- a/frontend/src/components/weekend/LodgingBoard.availability.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.availability.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * The board's availability gate, which is NOT the placement gate.
+ *
+ * Placement needs a scenario: it writes a draft plan. Availability does not —
+ * 1500000135 deleted the dimension because a burst pipe closes a cabin in every
+ * plan for that weekend — so reusing `canPlace` here would put the deleted
+ * dimension back at the UI layer and leave staff looking at the CampMinder
+ * mirror unable to close a cabin at all.
+ *
+ * Fictional data throughout.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import { LodgingBoard } from './LodgingBoard'
+
+vi.mock('../../hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    isAdmin: true,
+    permissions: [],
+    hasPermission: () => true,
+    hasAnyPermission: () => true,
+  }),
+}))
+
+vi.mock('../../hooks/useWeekendRoster', () => ({
+  useHouseholdMedical: () => ({ data: undefined, isLoading: false, error: null }),
+}))
+
+vi.mock('../../hooks/useLodgingPlacement', () => ({
+  useLodgingPlacement: () => ({ move: vi.fn(), isMoving: false }),
+}))
+
+const setAvailability = vi.fn((_intent: unknown) => Promise.resolve())
+let availabilityOptions: unknown[] = []
+let pendingUnitId = ''
+vi.mock('../../hooks/useUnitAvailability', () => ({
+  useUnitAvailability: (...args: unknown[]) => {
+    availabilityOptions.push(args[0])
+    return { setAvailability, pendingUnitId }
+  },
+}))
+
+let client: QueryClient
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  availabilityOptions = []
+  pendingUnitId = ''
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+})
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
+  return {
+    unit_id: 'u1',
+    code: 'cedar-1',
+    name: 'Cedar 1',
+    area_code: 'CG',
+    area_name: 'Cedar Grove',
+    sleeps: 5,
+    bathroom: 'shared',
+    bathroom_group: '',
+    near_bathhouse: false,
+    has_power: false,
+    has_ac: false,
+    has_fridge: false,
+    is_accessible: false,
+    is_confirmed: false,
+    is_active: true,
+    is_container: false,
+    allocation_default: 'family_pool',
+    family_available_override: null,
+    reason: '',
+    is_family_available: true,
+    map_x: 0.5,
+    map_y: 0.5,
+    ...overrides,
+  }
+}
+
+function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
+  return {
+    grain: 'household',
+    household_cm_id: 101,
+    person_cm_id: 0,
+    display_name: 'Johnson',
+    sort_name: 'Johnson',
+    adults: [],
+    children: [],
+    party_size: 3,
+    unit_code: '',
+    unit_name: '',
+    unit_codes: [],
+    is_merged_slot: false,
+    arrival_eta: '',
+    is_returning: false,
+    ...overrides,
+  }
+}
+
+const SCENARIO = 'scn7x2k9qw3mnbv'
+
+function renderBoard(props: Partial<Parameters<typeof LodgingBoard>[0]> = {}) {
+  return render(
+    <LodgingBoard
+      parties={[party()]}
+      units={[unit(), unit({ unit_id: 'u2', code: 'cedar-2', name: 'Cedar 2' })]}
+      year={2026}
+      sessionCmId={1000001}
+      scenario={SCENARIO}
+      canManage={true}
+      {...props}
+    />,
+    { wrapper }
+  )
+}
+
+describe('LodgingBoard — the availability gate', () => {
+  it('offers the control on the CampMinder mirror, where placement is refused', () => {
+    // THE divergence from `canPlace`, and the reason this file exists. A burst
+    // pipe is a fact about the weekend, not about a plan: staff must be able to
+    // record one without first creating a scenario to record it in.
+    renderBoard({ scenario: '' })
+
+    expect(screen.getByRole('button', { name: 'Hold Cedar 1' })).toBeInTheDocument()
+  })
+
+  it('offers no control without bunking.manage', () => {
+    // The same gate as the endpoint, which is `require_permission(BUNKING_MANAGE)`.
+    renderBoard({ canManage: false })
+
+    expect(screen.queryByRole('button', { name: 'Hold Cedar 1' })).not.toBeInTheDocument()
+  })
+
+  it('offers no control without a weekend to write into', () => {
+    // `session_cm_id` is `gt=0` server-side, and the prop defaults to 0 for the
+    // board tests that exercise no writes.
+    renderBoard({ sessionCmId: 0 })
+
+    expect(screen.queryByRole('button', { name: 'Hold Cedar 1' })).not.toBeInTheDocument()
+  })
+
+  it('names the weekend it is writing into', () => {
+    renderBoard()
+
+    expect(availabilityOptions[0]).toEqual({ year: 2026, sessionCmId: 1000001 })
+  })
+})
+
+describe('LodgingBoard — the control becomes a write', () => {
+  it('sends the unit staff clicked, with the reason they typed', async () => {
+    const user = userEvent.setup()
+    renderBoard()
+
+    await user.click(screen.getByRole('button', { name: 'Hold Cedar 2' }))
+    await user.type(screen.getByRole('textbox', { name: /reason/i }), 'Burst pipe')
+    await user.click(screen.getByRole('button', { name: /^hold$/i }))
+
+    expect(setAvailability).toHaveBeenCalledTimes(1)
+    expect(setAvailability).toHaveBeenCalledWith({
+      unitId: 'u2',
+      unitName: 'Cedar 2',
+      familyAvailable: false,
+      reason: 'Burst pipe',
+    })
+  })
+
+  it('waits on the card being written, and only that one', async () => {
+    // 81 cards share one mutation. A bare `isPending` would freeze the whole
+    // board while one cabin is being held.
+    pendingUnitId = 'u1'
+    renderBoard()
+
+    expect(screen.getByRole('button', { name: 'Hold Cedar 1' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Hold Cedar 2' })).toBeEnabled()
+    await Promise.resolve()
+  })
+})

--- a/frontend/src/components/weekend/LodgingBoard.drag.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.drag.test.tsx
@@ -46,6 +46,14 @@ vi.mock('../../hooks/useLodgingPlacement', () => ({
 }))
 let placementOptions: unknown[] = []
 
+// The board also writes availability now. Mocked here only to keep the real
+// hook's `useApiWithAuth` out of a tree with no AuthProvider — this file is
+// about drag, and the availability gate is pinned in
+// `LodgingBoard.availability.test.tsx`.
+vi.mock('../../hooks/useUnitAvailability', () => ({
+  useUnitAvailability: () => ({ setAvailability: vi.fn(), pendingUnitId: '' }),
+}))
+
 /** The last `onDragEnd` the board handed to DndContext. */
 let onDragEnd: ((event: unknown) => void) | undefined
 

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -7,9 +7,12 @@
  * is how it came to assert the mirror over a draft once #1967 shipped a picker:
  * two indicators, only one of them wired up.
  *
- * The board takes no scenario id because it never reads or writes one — the
- * page fetches, and nothing here mutates. Drag placement (#1985) is what earns
- * plumbing it back, along with the writes that need it.
+ * The board reads nothing and writes twice. The page fetches; this component
+ * owns two mutations, and they are gated differently on purpose — drag
+ * placement (#1985) needs a scenario because it writes a draft plan, and
+ * availability (#1999) needs none because a burst pipe closes a cabin in every
+ * plan for that weekend. `canPlace` and `canSetAvailability` below are that
+ * difference, and collapsing them is the mistake to avoid.
  *
  * Layout is §3.7: one collapsible section per area, each a WRAPPING GRID of
  * slot cards. Not summer's columns — a summer bunk column is tall because it

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -39,6 +39,7 @@ import { useCallback, useState } from 'react'
 
 import { useDismissOnDeadSpace } from '../../hooks/useDismissOnDeadSpace'
 import { useLodgingPlacement } from '../../hooks/useLodgingPlacement'
+import { useUnitAvailability } from '../../hooks/useUnitAvailability'
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import { buildBoard } from './boardLayout'
 import { resolveDrop } from './dragPlacement'
@@ -92,7 +93,15 @@ export function LodgingBoard({
   // send `session_cm_id: 0` against a schema declaring `gt=0`.
   const canPlace = canManage && scenario !== '' && sessionCmId > 0
 
+  // TWO conditions, not three, and the missing one is deliberate. Availability
+  // carries no scenario since 1500000135 — a burst pipe closes a cabin in every
+  // plan for that weekend — so reusing `canPlace` here would reintroduce the
+  // deleted dimension at the UI layer: staff looking at the CampMinder mirror,
+  // which is where most of them look, could not close a cabin at all.
+  const canSetAvailability = canManage && sessionCmId > 0
+
   const { move } = useLodgingPlacement({ year, sessionCmId, scenario })
+  const { setAvailability, pendingUnitId } = useUnitAvailability({ year, sessionCmId })
 
   const unitsByCode = new Map(units.map((unit) => [unit.code, unit]))
 
@@ -135,6 +144,21 @@ export function LodgingBoard({
     // surfacing as an unhandled rejection.
     void move(intent).catch(() => undefined)
   }
+
+  const writeAvailability = useCallback(
+    (unit: LodgingUnitRow, write: { familyAvailable: boolean | null; reason: string }) => {
+      // The rejection path is the hook's: it raises the toast. Catching here
+      // keeps the rejected promise from surfacing as an unhandled rejection,
+      // exactly as the drop handler does.
+      void setAvailability({
+        unitId: unit.unit_id,
+        unitName: unit.name,
+        familyAvailable: write.familyAvailable,
+        reason: write.reason,
+      }).catch(() => undefined)
+    },
+    [setAvailability]
+  )
 
   const openParty = useCallback((party: RosterPartyRow) => {
     setRequestClose(false)
@@ -256,6 +280,9 @@ export function LodgingBoard({
                             slot={slot}
                             hue={area.hue}
                             canPlace={canPlace}
+                            canSetAvailability={canSetAvailability}
+                            savingAvailability={pendingUnitId === slot.unit.unit_id}
+                            onSetAvailability={writeAvailability}
                             onOpenParty={openParty}
                           />
                         ))}

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -14,12 +14,19 @@
 import { useDroppable } from '@dnd-kit/core'
 import { Bath, Plug, Snowflake, TriangleAlert, Users } from 'lucide-react'
 
-import type { RosterPartyRow } from '../../types/lodging'
+import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import type { BoardSlot } from './boardLayout'
 import { unitDroppableId } from './dragPlacement'
 import { FamilyCard } from './FamilyCard'
 import { partyKey } from './partyKey'
 import { reservationBadge } from './unitBadges'
+import { UnitAvailabilityControl } from './UnitAvailabilityControl'
+
+/** What the reserve/release control asks the board to write. */
+export interface UnitAvailabilityWrite {
+  familyAvailable: boolean | null
+  reason: string
+}
 
 export interface LodgingUnitCardProps {
   slot: BoardSlot
@@ -27,6 +34,18 @@ export interface LodgingUnitCardProps {
   hue: string
   /** Placement is live: a scenario is selected and the user holds `bunking.manage`. */
   canPlace?: boolean
+  /**
+   * Availability is writable: the user holds `bunking.manage` and a weekend is
+   * selected.
+   *
+   * SEPARATE from `canPlace`, which also requires a scenario. Availability
+   * carries none since 1500000135, so gating it on one would make a burst pipe
+   * unrecordable unless a draft plan happened to be open.
+   */
+  canSetAvailability?: boolean
+  /** True while THIS unit's availability write is in flight. */
+  savingAvailability?: boolean
+  onSetAvailability?: (unit: LodgingUnitRow, write: UnitAvailabilityWrite) => void
   onOpenParty: (party: RosterPartyRow) => void
 }
 
@@ -34,6 +53,9 @@ export function LodgingUnitCard({
   slot,
   hue,
   canPlace = false,
+  canSetAvailability = false,
+  savingAvailability = false,
+  onSetAvailability,
   onOpenParty,
 }: LodgingUnitCardProps) {
   const { unit, parties, consent } = slot
@@ -99,6 +121,19 @@ export function LodgingUnitCard({
             Inactive
           </span>
         )}
+        {/* Beside the badge, because the two report the same fact and a card
+            that says "Held" in one place and offers to hold it in another says
+            two things about one cabin. The control's own children carry
+            `w-full`, so the reason line and the open form wrap onto their own
+            rows inside this wrapping flex. */}
+        <UnitAvailabilityControl
+          unit={unit}
+          canManage={canSetAvailability && onSetAvailability !== undefined}
+          isSaving={savingAvailability}
+          onSubmit={(write) => {
+            onSetAvailability?.(unit, write)
+          }}
+        />
       </div>
 
       {isShared && (

--- a/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * The reserve/release control: the writer this table never had.
+ *
+ * `PUT /api/lodging/availability` shipped with no caller anywhere in the
+ * frontend, which is how `lodging_availability` reached zero rows and a request
+ * model requiring a scenario nobody could supply. This control is the caller.
+ *
+ * Fictional data throughout.
+ */
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { LodgingUnitRow } from '../../types/lodging'
+import { UnitAvailabilityControl } from './UnitAvailabilityControl'
+
+function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
+  return {
+    unit_id: 'u1',
+    code: 'cedar-1',
+    name: 'Cedar 1',
+    area_code: 'CG',
+    area_name: 'Cedar Grove',
+    sleeps: 5,
+    bathroom: 'shared',
+    bathroom_group: '',
+    near_bathhouse: false,
+    has_power: false,
+    has_ac: false,
+    has_fridge: false,
+    is_accessible: false,
+    is_confirmed: false,
+    is_active: true,
+    is_container: false,
+    allocation_default: 'family_pool',
+    family_available_override: null,
+    reason: '',
+    is_family_available: true,
+    map_x: 0.5,
+    map_y: 0.5,
+    ...overrides,
+  }
+}
+
+const STAFF_CABIN = unit({
+  unit_id: 'u2',
+  code: 'aspen-lodge',
+  name: 'Aspen Lodge',
+  allocation_default: 'staff_default',
+  is_family_available: false,
+})
+
+const HELD_CABIN = unit({
+  family_available_override: false,
+  reason: 'Burst pipe',
+  is_family_available: false,
+})
+
+function renderControl(props: Partial<React.ComponentProps<typeof UnitAvailabilityControl>> = {}) {
+  const onSubmit = vi.fn()
+  render(
+    <UnitAvailabilityControl
+      unit={unit()}
+      canManage
+      isSaving={false}
+      onSubmit={onSubmit}
+      {...props}
+    />
+  )
+  return { onSubmit }
+}
+
+describe('UnitAvailabilityControl', () => {
+  it('offers nothing without bunking.manage', () => {
+    // The same gate as the endpoint. A control that 403s on click is worse
+    // than no control: it teaches staff the board is broken.
+    renderControl({ canManage: false })
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('holds a family cabin back for this weekend, with the reason staff gave', async () => {
+    const user = userEvent.setup()
+    const { onSubmit } = renderControl()
+
+    await user.click(screen.getByRole('button', { name: /hold/i }))
+    await user.type(screen.getByRole('textbox', { name: /reason/i }), 'Burst pipe')
+    await user.click(screen.getByRole('button', { name: /^hold$/i }))
+
+    expect(onSubmit).toHaveBeenCalledWith({ familyAvailable: false, reason: 'Burst pipe' })
+  })
+
+  it('releases a staff cabin to families for this weekend', async () => {
+    // Rare and explicit, not absent (spec §3). One season of placements
+    // corroborates that staff cabins are never released; it does not prove it.
+    const user = userEvent.setup()
+    const { onSubmit } = renderControl({ unit: STAFF_CABIN })
+
+    await user.click(screen.getByRole('button', { name: /release/i }))
+    await user.type(screen.getByRole('textbox', { name: /reason/i }), 'Overflow weekend')
+    await user.click(screen.getByRole('button', { name: /^release$/i }))
+
+    expect(onSubmit).toHaveBeenCalledWith({ familyAvailable: true, reason: 'Overflow weekend' })
+  })
+
+  it('will not take a cabin out of service without saying why', async () => {
+    // A row with no reason is the one a staff member cannot act on next week:
+    // they can see the cabin is closed and have no way to learn whether the
+    // pipe has been fixed.
+    const user = userEvent.setup()
+    const { onSubmit } = renderControl()
+
+    await user.click(screen.getByRole('button', { name: /hold/i }))
+    await user.click(screen.getByRole('button', { name: /^hold$/i }))
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('treats blank space as no reason at all', async () => {
+    const user = userEvent.setup()
+    const { onSubmit } = renderControl()
+
+    await user.click(screen.getByRole('button', { name: /hold/i }))
+    await user.type(screen.getByRole('textbox', { name: /reason/i }), '   ')
+    await user.click(screen.getByRole('button', { name: /^hold$/i }))
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('clears an override in one click, writing null rather than a value that agrees', async () => {
+    // `null` DELETES the row. Writing "available" onto a family cabin instead
+    // would pin it against a later change to its role -- the reversal-encoding
+    // failure spec §5.4 rejected, arriving through the UI.
+    const user = userEvent.setup()
+    const { onSubmit } = renderControl({ unit: HELD_CABIN })
+
+    await user.click(screen.getByRole('button', { name: /clear/i }))
+
+    expect(onSubmit).toHaveBeenCalledWith({ familyAvailable: null, reason: '' })
+    expect(screen.queryByRole('textbox', { name: /reason/i })).not.toBeInTheDocument()
+  })
+
+  it('shows why a cabin is held, to whoever is looking', async () => {
+    // The reason exists to be read next week. It is shown WITHOUT
+    // bunking.manage too: knowing a cabin is closed for a burst pipe is not a
+    // write, and the staff member who needs it most may not hold the
+    // permission.
+    renderControl({ unit: HELD_CABIN, canManage: false })
+
+    expect(screen.getByText('Burst pipe')).toBeInTheDocument()
+    await Promise.resolve()
+  })
+
+  it('does not offer a second write while this unit is being written', async () => {
+    const user = userEvent.setup()
+    const { onSubmit } = renderControl({ unit: HELD_CABIN, isSaving: true })
+
+    await user.click(screen.getByRole('button', { name: /clear/i }))
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('offers nothing on a building row', () => {
+    renderControl({ unit: unit({ is_container: true }) })
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('abandons the reason when the form is cancelled', async () => {
+    // Reopening with the last abandoned reason still in the box is how a
+    // burst-pipe note ends up on the wrong cabin.
+    const user = userEvent.setup()
+    renderControl()
+
+    await user.click(screen.getByRole('button', { name: /hold/i }))
+    await user.type(screen.getByRole('textbox', { name: /reason/i }), 'Burst pipe')
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+    await user.click(screen.getByRole('button', { name: /hold/i }))
+
+    expect(screen.getByRole('textbox', { name: /reason/i })).toHaveValue('')
+  })
+})

--- a/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
@@ -103,10 +103,16 @@ describe('UnitAvailabilityControl', () => {
     expect(onSubmit).toHaveBeenCalledWith({ familyAvailable: true, reason: 'Overflow weekend' })
   })
 
-  it('will not take a cabin out of service without saying why', async () => {
+  it('will not take a cabin out of service without saying why, and says so', async () => {
     // A row with no reason is the one a staff member cannot act on next week:
     // they can see the cabin is closed and have no way to learn whether the
     // pipe has been fixed.
+    //
+    // The visible refusal is asserted, not just the absent call. An earlier
+    // version disabled the submit button AND guarded in the handler; deleting
+    // the guard broke no test, because a click on a disabled button never
+    // reaches a handler at all. Two guards masking each other means neither is
+    // pinned — so the button stays live and the refusal is a thing you can see.
     const user = userEvent.setup()
     const { onSubmit } = renderControl()
 
@@ -114,6 +120,20 @@ describe('UnitAvailabilityControl', () => {
     await user.click(screen.getByRole('button', { name: /^hold$/i }))
 
     expect(onSubmit).not.toHaveBeenCalled()
+    expect(screen.getByText(/say why/i)).toBeInTheDocument()
+  })
+
+  it('refuses an empty reason submitted from the keyboard too', async () => {
+    // Enter in the text field is a second way into the same handler, and the
+    // one a staff member typing quickly will actually use.
+    const user = userEvent.setup()
+    const { onSubmit } = renderControl()
+
+    await user.click(screen.getByRole('button', { name: /hold/i }))
+    await user.type(screen.getByRole('textbox', { name: /reason/i }), '{Enter}')
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(screen.getByText(/say why/i)).toBeInTheDocument()
   })
 
   it('treats blank space as no reason at all', async () => {
@@ -125,6 +145,18 @@ describe('UnitAvailabilityControl', () => {
     await user.click(screen.getByRole('button', { name: /^hold$/i }))
 
     expect(onSubmit).not.toHaveBeenCalled()
+    expect(screen.getByText(/say why/i)).toBeInTheDocument()
+  })
+
+  it('takes the refusal back as soon as staff start typing', async () => {
+    const user = userEvent.setup()
+    renderControl()
+
+    await user.click(screen.getByRole('button', { name: /hold/i }))
+    await user.click(screen.getByRole('button', { name: /^hold$/i }))
+    await user.type(screen.getByRole('textbox', { name: /reason/i }), 'B')
+
+    expect(screen.queryByText(/say why/i)).not.toBeInTheDocument()
   })
 
   it('clears an override in one click, writing null rather than a value that agrees', async () => {

--- a/frontend/src/components/weekend/UnitAvailabilityControl.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.tsx
@@ -54,10 +54,12 @@ export function UnitAvailabilityControl({
 }: UnitAvailabilityControlProps) {
   const [reason, setReason] = useState('')
   const [isOpen, setIsOpen] = useState(false)
+  const [wantsReason, setWantsReason] = useState(false)
   const action = availabilityAction(unit)
 
   const close = () => {
     setIsOpen(false)
+    setWantsReason(false)
     // Cleared on the way out, not on the way in: a reason left over from an
     // abandoned edit is how a burst-pipe note ends up on the wrong cabin.
     setReason('')
@@ -85,7 +87,17 @@ export function UnitAvailabilityControl({
           onSubmit={(event) => {
             event.preventDefault()
             const trimmed = reason.trim()
-            if (trimmed === '') return
+            // The ONLY place an empty reason is refused. The submit button is
+            // deliberately NOT disabled while the box is empty: a disabled
+            // button plus a guard here mask each other — deleting either leaves
+            // the other quietly holding the rule, so a test can pin neither,
+            // which is exactly what a surviving mutation caught. An inert
+            // button also explains nothing to the staff member wondering why
+            // their click did nothing.
+            if (trimmed === '') {
+              setWantsReason(true)
+              return
+            }
             onSubmit({ familyAvailable: action.familyAvailable, reason: trimmed })
             close()
           }}
@@ -97,15 +109,22 @@ export function UnitAvailabilityControl({
             value={reason}
             maxLength={500}
             autoFocus
+            aria-invalid={wantsReason && reason.trim() === ''}
             onChange={(event) => {
               setReason(event.target.value)
+              setWantsReason(false)
             }}
-            className="border-border bg-background text-foreground placeholder:text-muted-foreground/60 focus:border-primary/50 focus:ring-primary/10 w-full rounded-md border px-1.5 py-1 text-[11px] focus:ring-2 focus:outline-none"
+            className="border-border bg-background text-foreground placeholder:text-muted-foreground/60 focus:border-primary/50 focus:ring-primary/10 w-full rounded-md border px-1.5 py-1 text-[11px] focus:ring-2 focus:outline-none aria-[invalid=true]:border-amber-500"
           />
+          {wantsReason && reason.trim() === '' && (
+            <span className="text-[10px] font-medium text-amber-700 dark:text-amber-400">
+              Say why, so next week&rsquo;s staff can act on it.
+            </span>
+          )}
           <div className="flex items-center gap-1.5">
             <button
               type="submit"
-              disabled={reason.trim() === '' || isSaving}
+              disabled={isSaving}
               className="bg-primary text-primary-foreground rounded-md px-2 py-0.5 text-[11px] font-medium disabled:opacity-40"
             >
               {action.label}

--- a/frontend/src/components/weekend/UnitAvailabilityControl.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.tsx
@@ -1,0 +1,148 @@
+/**
+ * Holding a cabin back for a weekend, or releasing one to families.
+ *
+ * `PUT /api/lodging/availability` shipped with no caller: `lodging_availability`
+ * has never held a row, and the request model required a scenario nobody could
+ * supply. Landing the model with no writer is how it drifted, so this is the
+ * writer.
+ *
+ * ## One button, not a menu
+ *
+ * `family_available` has three reachable outcomes and a unit is always in
+ * exactly one of them, so `availabilityAction` resolves the single action this
+ * card can offer and the button IS the gate — no modal carrying its own
+ * eligibility logic. Writing a value that AGREES with the unit's role is
+ * deliberately unreachable: it would pin the unit against a later registry
+ * edit while changing nothing staff can see.
+ *
+ * ## Why the reason is required here and not at the schema
+ *
+ * `reason` is `Field("", max_length=500)` server-side, because a row written by
+ * an ingest or a fixture has no author to ask. Through this control there is
+ * always an author, and a cabin taken out of service with no stated reason is
+ * the row a staff member cannot act on next week — they can see it is closed
+ * and have no way to learn whether the pipe has been fixed. Clearing asks for
+ * none: it restores the unit's standing role rather than asserting anything.
+ */
+import { useState } from 'react'
+
+import type { LodgingUnitRow } from '../../types/lodging'
+import { availabilityAction } from './unitBadges'
+
+export interface UnitAvailabilityControlProps {
+  unit: LodgingUnitRow
+  /**
+   * `bunking.manage`, with a weekend selected.
+   *
+   * NOT the board's `canPlace`, which also requires a scenario. Availability
+   * carries no scenario since 1500000135 — a burst pipe closes a cabin in
+   * every plan for that weekend — so requiring one to record it would put the
+   * deleted dimension back at the UI layer, and staff looking at the
+   * CampMinder mirror could not close a cabin at all.
+   */
+  canManage: boolean
+  /** True while THIS unit's write is in flight. */
+  isSaving: boolean
+  onSubmit: (write: { familyAvailable: boolean | null; reason: string }) => void
+}
+
+export function UnitAvailabilityControl({
+  unit,
+  canManage,
+  isSaving,
+  onSubmit,
+}: UnitAvailabilityControlProps) {
+  const [reason, setReason] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
+  const action = availabilityAction(unit)
+
+  const close = () => {
+    setIsOpen(false)
+    // Cleared on the way out, not on the way in: a reason left over from an
+    // abandoned edit is how a burst-pipe note ends up on the wrong cabin.
+    setReason('')
+  }
+
+  // Shown to everyone, including a reader without `bunking.manage`. Knowing a
+  // cabin is closed for a burst pipe is not a write, and the staff member who
+  // needs it most may not hold the permission.
+  const storedReason = unit.reason ?? ''
+  const explanation =
+    unit.family_available_override !== null &&
+    unit.family_available_override !== undefined &&
+    storedReason !== '' ? (
+      <span className="text-muted-foreground w-full text-[11px] italic">{storedReason}</span>
+    ) : null
+
+  if (action === null || !canManage) return explanation
+
+  if (isOpen && action.needsReason) {
+    return (
+      <>
+        {explanation}
+        <form
+          className="flex w-full flex-col gap-1"
+          onSubmit={(event) => {
+            event.preventDefault()
+            const trimmed = reason.trim()
+            if (trimmed === '') return
+            onSubmit({ familyAvailable: action.familyAvailable, reason: trimmed })
+            close()
+          }}
+        >
+          <input
+            type="text"
+            aria-label="Reason"
+            placeholder="Burst pipe, caretaker…"
+            value={reason}
+            maxLength={500}
+            autoFocus
+            onChange={(event) => {
+              setReason(event.target.value)
+            }}
+            className="border-border bg-background text-foreground placeholder:text-muted-foreground/60 focus:border-primary/50 focus:ring-primary/10 w-full rounded-md border px-1.5 py-1 text-[11px] focus:ring-2 focus:outline-none"
+          />
+          <div className="flex items-center gap-1.5">
+            <button
+              type="submit"
+              disabled={reason.trim() === '' || isSaving}
+              className="bg-primary text-primary-foreground rounded-md px-2 py-0.5 text-[11px] font-medium disabled:opacity-40"
+            >
+              {action.label}
+            </button>
+            <button
+              type="button"
+              onClick={close}
+              className="text-muted-foreground hover:text-foreground rounded-md px-1.5 py-0.5 text-[11px]"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </>
+    )
+  }
+
+  return (
+    <>
+      {explanation}
+      <button
+        type="button"
+        disabled={isSaving}
+        // Named for the cabin: eighty-one cards each carrying a button called
+        // "Hold" is unusable with a screen reader.
+        aria-label={`${action.label} ${unit.name}`}
+        onClick={() => {
+          if (action.needsReason) {
+            setIsOpen(true)
+            return
+          }
+          onSubmit({ familyAvailable: action.familyAvailable, reason: '' })
+        }}
+        className="border-border text-muted-foreground hover:text-foreground hover:border-foreground/30 rounded-full border px-1.5 py-0.5 text-[10px] font-medium disabled:opacity-40"
+      >
+        {action.label}
+      </button>
+    </>
+  )
+}

--- a/frontend/src/components/weekend/UnitInventoryPanel.test.tsx
+++ b/frontend/src/components/weekend/UnitInventoryPanel.test.tsx
@@ -3,7 +3,8 @@
  * adjacency and hiding them would make the map lie about the site.
  */
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { LodgingUnitRow } from '../../types/lodging'
 import { UnitInventoryPanel } from './UnitInventoryPanel'
@@ -222,5 +223,85 @@ describe('UnitInventoryPanel', () => {
   it('explains an empty registry instead of rendering a bare panel', () => {
     render(<UnitInventoryPanel units={[]} />)
     expect(screen.getByText(/No lodging units in the registry yet/)).toBeInTheDocument()
+  })
+})
+
+describe('UnitInventoryPanel — releasing a staff cabin', () => {
+  // THE BACKDOOR, and it is deliberately not on the board.
+  //
+  // Releasing permanent staff housing to families is a once-in-several-years
+  // event (owner, 2026-08-04), so it does not earn a place in the weekend's
+  // main flow. But it cannot live on the board AT ALL, which is the part that
+  // is structural rather than a matter of taste: the board draws planning
+  // inventory, `isPlanningInventory` excludes a staff cabin with no override,
+  // and "release" is by definition the operation on a unit that is not yet
+  // inventory. The board card can offer Hold and Clear; Release has nowhere to
+  // stand there. This panel is the registry view and lists all 21 staff units,
+  // so it is the only surface where the action is reachable at all.
+
+  const STAFF = {
+    unit_id: 'u2',
+    code: 'aspen-lodge',
+    name: 'Aspen Lodge',
+    allocation_default: 'staff_default' as const,
+    is_family_available: false,
+  }
+
+  function renderPanel(props: Partial<React.ComponentProps<typeof UnitInventoryPanel>> = {}) {
+    const onSetAvailability = vi.fn()
+    render(
+      <UnitInventoryPanel
+        units={[unit(), unit(STAFF)]}
+        canSetAvailability
+        pendingUnitId=""
+        onSetAvailability={onSetAvailability}
+        {...props}
+      />
+    )
+    return { onSetAvailability }
+  }
+
+  it('offers Release on a staff cabin the board cannot draw a card for', async () => {
+    const user = userEvent.setup()
+    const { onSetAvailability } = renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Release Aspen Lodge' }))
+    await user.type(screen.getByRole('textbox', { name: /reason/i }), 'Staff family away')
+    await user.click(screen.getByRole('button', { name: /^release$/i }))
+
+    expect(onSetAvailability).toHaveBeenCalledTimes(1)
+    expect(onSetAvailability.mock.calls[0]?.[0]).toMatchObject({ unit_id: 'u2' })
+    expect(onSetAvailability.mock.calls[0]?.[1]).toEqual({
+      familyAvailable: true,
+      reason: 'Staff family away',
+    })
+  })
+
+  it('offers Hold on a family cabin here too, so the panel is not a second vocabulary', () => {
+    renderPanel()
+
+    expect(screen.getByRole('button', { name: 'Hold Ridge A' })).toBeInTheDocument()
+  })
+
+  it('offers nothing without bunking.manage', () => {
+    // The same gate as the endpoint and as the board.
+    renderPanel({ canSetAvailability: false })
+
+    expect(screen.queryByRole('button', { name: /release|hold/i })).not.toBeInTheDocument()
+  })
+
+  it('stays read-only when the page passes no handler at all', () => {
+    // The panel renders on surfaces that do not write. A control wired to
+    // nothing is worse than no control.
+    render(<UnitInventoryPanel units={[unit(), unit(STAFF)]} canSetAvailability />)
+
+    expect(screen.queryByRole('button', { name: /release|hold/i })).not.toBeInTheDocument()
+  })
+
+  it('waits on the row being written, and only that one', () => {
+    renderPanel({ pendingUnitId: 'u2' })
+
+    expect(screen.getByRole('button', { name: 'Release Aspen Lodge' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Hold Ridge A' })).toBeEnabled()
   })
 })

--- a/frontend/src/components/weekend/UnitInventoryPanel.tsx
+++ b/frontend/src/components/weekend/UnitInventoryPanel.tsx
@@ -9,18 +9,37 @@
 import { Bath, Plug, Snowflake } from 'lucide-react'
 
 import type { LodgingUnitRow } from '../../types/lodging'
+import type { UnitAvailabilityWrite } from './LodgingUnitCard'
 import { reservationBadge } from './unitBadges'
+import { UnitAvailabilityControl } from './UnitAvailabilityControl'
 
 export interface UnitInventoryPanelProps {
   units: LodgingUnitRow[]
+  /**
+   * `bunking.manage`, with a weekend selected — the board's
+   * `canSetAvailability`, not its `canPlace`.
+   */
+  canSetAvailability?: boolean
+  /** The unit id currently being written, so one row waits and the rest do not. */
+  pendingUnitId?: string
+  onSetAvailability?: (unit: LodgingUnitRow, write: UnitAvailabilityWrite) => void
 }
 
 function UnitRow({
   unit,
   showUnconfirmedBadge,
+  canSetAvailability,
+  pendingUnitId,
+  onSetAvailability,
 }: {
   unit: LodgingUnitRow
   showUnconfirmedBadge: boolean
+  canSetAvailability: boolean
+  pendingUnitId: string
+  // `| undefined` spelled out: the panel passes this straight through, and
+  // `exactOptionalPropertyTypes` distinguishes "absent" from "present and
+  // undefined" at a forwarding boundary.
+  onSetAvailability?: ((unit: LodgingUnitRow, write: UnitAvailabilityWrite) => void) | undefined
 }) {
   const badge = reservationBadge(unit)
   return (
@@ -53,11 +72,29 @@ function UnitRow({
           Unconfirmed
         </span>
       )}
+      {/* The ONLY surface that can offer Release. The board draws planning
+          inventory, and a staff cabin with no override is not inventory yet --
+          which is precisely the set "release" operates on -- so its card can
+          carry Hold and Clear but never Release. Here the whole registry is
+          listed, so every action is reachable. */}
+      <UnitAvailabilityControl
+        unit={unit}
+        canManage={canSetAvailability && onSetAvailability !== undefined}
+        isSaving={pendingUnitId === unit.unit_id}
+        onSubmit={(write) => {
+          onSetAvailability?.(unit, write)
+        }}
+      />
     </li>
   )
 }
 
-export function UnitInventoryPanel({ units }: UnitInventoryPanelProps) {
+export function UnitInventoryPanel({
+  units,
+  canSetAvailability = false,
+  pendingUnitId = '',
+  onSetAvailability,
+}: UnitInventoryPanelProps) {
   if (units.length === 0) {
     return (
       <div className="card-lodge p-4">
@@ -100,7 +137,14 @@ export function UnitInventoryPanel({ units }: UnitInventoryPanelProps) {
           </h3>
           <ul>
             {bucket.units.map((unit) => (
-              <UnitRow key={unit.unit_id} unit={unit} showUnconfirmedBadge={!allUnconfirmed} />
+              <UnitRow
+                key={unit.unit_id}
+                unit={unit}
+                showUnconfirmedBadge={!allUnconfirmed}
+                canSetAvailability={canSetAvailability}
+                pendingUnitId={pendingUnitId}
+                onSetAvailability={onSetAvailability}
+              />
             ))}
           </ul>
         </section>

--- a/frontend/src/components/weekend/unitBadges.test.ts
+++ b/frontend/src/components/weekend/unitBadges.test.ts
@@ -17,7 +17,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { LodgingUnitRow } from '../../types/lodging'
-import { reservationBadge } from './unitBadges'
+import { availabilityAction, reservationBadge } from './unitBadges'
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
   return {
@@ -143,5 +143,87 @@ describe('reservationBadge', () => {
     )
 
     expect(held).toEqual(alsoHeld)
+  })
+})
+
+describe('availabilityAction', () => {
+  // The action lives beside the badge, in the same module, because the card
+  // must not say two things about one cabin: a card badged "Held" offering to
+  // "Hold" it is the drift this prevents.
+
+  it('offers to hold an ordinary family cabin', () => {
+    expect(availabilityAction(unit())).toEqual({
+      kind: 'hold',
+      label: 'Hold',
+      familyAvailable: false,
+      needsReason: true,
+    })
+  })
+
+  it('offers to release permanent staff housing', () => {
+    // Rare and explicit, not absent. One season of data corroborates that staff
+    // cabins are never released; it does not prove it, so the capability stays.
+    expect(
+      availabilityAction(unit({ allocation_default: 'staff_default', is_family_available: false }))
+    ).toEqual({ kind: 'release', label: 'Release', familyAvailable: true, needsReason: true })
+  })
+
+  it('offers to clear a held family cabin, and asks for no reason to do it', () => {
+    // `null` DELETES the row. There is no value meaning "normal": writing one
+    // would pin the unit against a later change to its role.
+    expect(
+      availabilityAction(
+        unit({ family_available_override: false, reason: 'Burst pipe', is_family_available: false })
+      )
+    ).toEqual({ kind: 'clear', label: 'Clear', familyAvailable: null, needsReason: false })
+  })
+
+  it('offers to clear a released staff cabin', () => {
+    expect(
+      availabilityAction(
+        unit({
+          allocation_default: 'staff_default',
+          family_available_override: true,
+          is_family_available: true,
+        })
+      )?.kind
+    ).toBe('clear')
+  })
+
+  it('offers to clear a row that merely agrees with the unit role', () => {
+    // Redundant but storable, and reachable by a hand-edited row rather than
+    // by this control. Clearing it is the only way to stop it pinning the unit
+    // against a later registry edit, so the action must not be withheld just
+    // because the resolved answer looks ordinary.
+    expect(availabilityAction(unit({ family_available_override: true }))?.kind).toBe('clear')
+    expect(
+      availabilityAction(
+        unit({
+          allocation_default: 'staff_default',
+          family_available_override: false,
+          is_family_available: false,
+        })
+      )?.kind
+    ).toBe('clear')
+  })
+
+  it('reads null and false as different answers, exactly as the badge does', () => {
+    // The trap. `unit.family_available_override !== null` is the test; a
+    // truthiness test (`if (unit.family_available_override)`) treats an
+    // ordinary cabin's null and a held cabin's false alike, and whichever way
+    // that branch falls, one of "Hold" or "Clear" becomes unreachable on most
+    // of the board.
+    expect(availabilityAction(unit({ family_available_override: null }))?.kind).toBe('hold')
+    expect(
+      availabilityAction(unit({ family_available_override: false, is_family_available: false }))
+        ?.kind
+    ).toBe('clear')
+  })
+
+  it('offers nothing on a building row', () => {
+    // A container is a whole-building aggregate, not a bookable room. Holding
+    // one would write an availability row against a unit no family can be
+    // placed into, and the board draws no card for it anyway.
+    expect(availabilityAction(unit({ is_container: true }))).toBeNull()
   })
 })

--- a/frontend/src/components/weekend/unitBadges.ts
+++ b/frontend/src/components/weekend/unitBadges.ts
@@ -53,3 +53,46 @@ export function reservationBadge(unit: LodgingUnitRow): UnitBadge | null {
   if (unit.allocation_default === 'staff_default') return staff
   return null
 }
+
+/** Which of the three reachable availability outcomes this unit can move to. */
+export interface AvailabilityAction {
+  kind: 'hold' | 'release' | 'clear'
+  /** The button's label, drawn from the same vocabulary as the badge above. */
+  label: string
+  /** What the write sends. `null` DELETES the row. */
+  familyAvailable: boolean | null
+  /**
+   * A cabin taken out of service with no stated reason is the row a staff
+   * member cannot act on next week. Clearing needs none: it restores the
+   * unit's standing role rather than asserting anything about this weekend.
+   */
+  needsReason: boolean
+}
+
+/**
+ * The one action a unit's card offers, or null if it offers none.
+ *
+ * ONE action, not a menu, because `family_available` has exactly three
+ * reachable outcomes and a unit is always in one of them: it either has an
+ * override to clear, or it has none and can take the one that disagrees with
+ * its role. Writing a value that AGREES with the role is deliberately not
+ * offered — it would pin the unit against a later registry edit while changing
+ * nothing staff can see.
+ *
+ * Lives beside `reservationBadge` so the two cannot drift. A card badged
+ * "Held" that offers to "Hold" it says two things about one cabin.
+ */
+export function availabilityAction(unit: LodgingUnitRow): AvailabilityAction | null {
+  // A container is a whole-building aggregate, never a bookable room.
+  if (unit.is_container === true) return null
+  // `!== null` and not truthiness: null (no row for this weekend) and false
+  // (closed this weekend) are different answers, and collapsing them makes
+  // either "Hold" or "Clear" unreachable across most of the board.
+  if (unit.family_available_override !== null && unit.family_available_override !== undefined) {
+    return { kind: 'clear', label: 'Clear', familyAvailable: null, needsReason: false }
+  }
+  if (unit.allocation_default === 'staff_default') {
+    return { kind: 'release', label: 'Release', familyAvailable: true, needsReason: true }
+  }
+  return { kind: 'hold', label: 'Hold', familyAvailable: false, needsReason: true }
+}

--- a/frontend/src/hooks/useUnitAvailability.test.tsx
+++ b/frontend/src/hooks/useUnitAvailability.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Writing one unit's availability for one weekend.
+ *
+ * The behaviour worth pinning here is the invalidation, and it is NOT the
+ * placement hook's. A placement belongs to one scenario, so `useLodgingPlacement`
+ * invalidates that scenario's roster key. Availability belongs to the WEEKEND —
+ * a burst pipe closes a cabin in every plan for it — so a write made while one
+ * draft is open has to refresh the mirror and every other draft too.
+ *
+ * Fictional data throughout.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { WeekendRoster } from '../types/lodging'
+import { queryKeys } from '../utils/queryKeys'
+import { useUnitAvailability } from './useUnitAvailability'
+
+const setUnitAvailability = vi.fn()
+
+vi.mock('../services/lodgingApi', () => ({
+  setUnitAvailability: (...args: unknown[]) => setUnitAvailability(...args),
+}))
+
+vi.mock('./useApiWithAuth', () => ({
+  useApiWithAuth: () => ({ fetchWithAuth: vi.fn(), isAuthenticated: true, isAuthLoading: false }),
+}))
+
+const toastError = vi.fn()
+const toastSuccess = vi.fn()
+vi.mock('react-hot-toast', () => ({
+  default: {
+    error: (...args: unknown[]) => toastError(...args),
+    success: (...args: unknown[]) => toastSuccess(...args),
+  },
+}))
+
+const YEAR = 2026
+const SESSION = 1000001
+const DRAFT = 'scn7x2k9qw3mnbv'
+
+const HOLD = {
+  unitId: 'u1',
+  unitName: 'Cedar 1',
+  familyAvailable: false as boolean | null,
+  reason: 'Burst pipe',
+}
+
+let client: QueryClient
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+function rosterKey(scenario: string) {
+  return queryKeys.weekendRoster(YEAR, SESSION, scenario)
+}
+
+function seededRoster(): WeekendRoster {
+  return { year: YEAR, session_cm_id: SESSION, parties: [], units: [] } as unknown as WeekendRoster
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  setUnitAvailability.mockResolvedValue({ record_id: 'r1', deleted: false })
+  client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  client.setQueryData(rosterKey(''), seededRoster())
+  client.setQueryData(rosterKey(DRAFT), seededRoster())
+})
+
+function renderAvailability(sessionCmId = SESSION) {
+  return renderHook(() => useUnitAvailability({ year: YEAR, sessionCmId }), { wrapper })
+}
+
+describe('useUnitAvailability', () => {
+  it('sends the weekend, the unit and the explicit boolean', async () => {
+    const { result } = renderAvailability()
+
+    await act(async () => {
+      await result.current.setAvailability(HOLD)
+    })
+
+    expect(setUnitAvailability).toHaveBeenCalledTimes(1)
+    expect(setUnitAvailability.mock.calls[0]?.[1]).toEqual({
+      year: YEAR,
+      sessionCmId: SESSION,
+      unitId: 'u1',
+      familyAvailable: false,
+      reason: 'Burst pipe',
+    })
+  })
+
+  it('refreshes EVERY scenario of the weekend, not just the one on screen', async () => {
+    // The failure this pins is silent. Availability carries no scenario, so a
+    // hold recorded while a draft is open changes the mirror and every other
+    // draft as well — and the weekend queries carry a 30 minute staleTime, so
+    // "stale" means half an hour of a board showing a cabin as open after
+    // staff closed it. Invalidating only the visible key looks correct on the
+    // screen you are looking at, which is why nobody reports it.
+    const { result } = renderAvailability()
+
+    await act(async () => {
+      await result.current.setAvailability(HOLD)
+    })
+
+    await waitFor(() => {
+      expect(client.getQueryState(rosterKey(DRAFT))?.isInvalidated).toBe(true)
+      expect(client.getQueryState(rosterKey(''))?.isInvalidated).toBe(true)
+    })
+  })
+
+  it('names only the unit being written, so one card waits and the rest do not', async () => {
+    // A bare `isPending` would disable the control on all 81 cards while one
+    // cabin is being held.
+    let release: (value: unknown) => void = () => undefined
+    setUnitAvailability.mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve
+      })
+    )
+
+    const { result } = renderAvailability()
+    act(() => {
+      void result.current.setAvailability(HOLD)
+    })
+
+    await waitFor(() => {
+      expect(result.current.pendingUnitId).toBe('u1')
+    })
+
+    await act(async () => {
+      release({ record_id: 'r1', deleted: false })
+      await Promise.resolve()
+    })
+    await waitFor(() => {
+      expect(result.current.pendingUnitId).toBe('')
+    })
+  })
+
+  it('says what a refused write was, rather than leaving the card looking saved', async () => {
+    setUnitAvailability.mockRejectedValue(new Error('Permission required: bunking.manage'))
+
+    const { result } = renderAvailability()
+    await act(async () => {
+      await result.current.setAvailability(HOLD).catch(() => undefined)
+    })
+
+    expect(toastError).toHaveBeenCalledWith('Permission required: bunking.manage')
+  })
+
+  it('refuses to write without a weekend rather than sending session_cm_id 0', async () => {
+    // `sessionCmId` defaults to 0 on the board for the tests that do not
+    // exercise writes, and the schema declares `gt=0`. Refusing here turns a
+    // 422 into a caller bug, the way the placement hook refuses an empty
+    // scenario.
+    const { result } = renderAvailability(0)
+
+    await expect(result.current.setAvailability(HOLD)).rejects.toThrow(/weekend/i)
+    expect(setUnitAvailability).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/hooks/useUnitAvailability.test.tsx
+++ b/frontend/src/hooks/useUnitAvailability.test.tsx
@@ -59,7 +59,7 @@ function rosterKey(scenario: string) {
 }
 
 function seededRoster(): WeekendRoster {
-  return { year: YEAR, session_cm_id: SESSION, parties: [], units: [] } as unknown as WeekendRoster
+  return { year: YEAR, session_cm_id: SESSION, parties: [], units: [] }
 }
 
 beforeEach(() => {

--- a/frontend/src/hooks/useUnitAvailability.ts
+++ b/frontend/src/hooks/useUnitAvailability.ts
@@ -1,0 +1,133 @@
+/**
+ * Holding one cabin back for a weekend, or releasing one to families.
+ *
+ * ## Why this is not `useLodgingPlacement` with a different body
+ *
+ * A placement belongs to a scenario. Availability does not — that is the whole
+ * of 1500000135: a burst pipe closes a cabin in every plan for that weekend, so
+ * the table lost its scenario column and the endpoint takes none. Two things
+ * follow, and both are easy to get wrong by copying the placement hook:
+ *
+ * 1. **The write is not gated on having a scenario selected.** Requiring one
+ *    would put the deleted dimension straight back at the UI layer: staff
+ *    looking at the CampMinder mirror could not record a burst pipe.
+ * 2. **The invalidation is by PREFIX, across every scenario.** The roster key
+ *    carries a scenario (#1967), so invalidating only the visible key leaves
+ *    the mirror and every other draft of the same weekend showing the cabin as
+ *    open. `invalidateLodgingRegistryQueries` is the helper that already
+ *    invalidates `['weekend-roster']`, `['weekend-summary']` and
+ *    `['weekend-sessions']` as prefixes.
+ *
+ * ## Why there is no optimistic layer
+ *
+ * The placement hook has one because dnd-kit drops the card the moment the
+ * pointer is released, so an invalidate-only path rubber-bands it back into
+ * its old cabin for the seconds `build_roster` takes. Nothing here moves under
+ * the pointer: the control disables itself, the toast confirms, and the board
+ * redraws when the roster returns. Patching the cache optimistically would have
+ * to patch every cached scenario of the weekend — the same reason the
+ * invalidation is a prefix — for a click that is not a direct-manipulation
+ * gesture.
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useCallback } from 'react'
+import toast from 'react-hot-toast'
+
+import { setUnitAvailability } from '../services/lodgingApi'
+import { invalidateLodgingRegistryQueries } from '../utils/queryKeys'
+import { useApiWithAuth } from './useApiWithAuth'
+
+export interface UseUnitAvailabilityOptions {
+  year: number
+  /** The weekend. `0` is "no weekend selected" and refuses to write. */
+  sessionCmId: number
+}
+
+/** One unit's availability for this weekend, as the card states it. */
+export interface AvailabilityIntent {
+  unitId: string
+  /** For the confirmation only — the write names the unit by id. */
+  unitName: string
+  /**
+   * `false` holds the unit back, `true` releases it, `null` DELETES the row so
+   * the unit's own role decides again. Never read for truthiness.
+   */
+  familyAvailable: boolean | null
+  /** Required by the card on a hold or a release; `''` when clearing. */
+  reason: string
+}
+
+export interface UseUnitAvailabilityReturn {
+  setAvailability: (intent: AvailabilityIntent) => Promise<void>
+  /**
+   * The unit id currently being written, or `''`.
+   *
+   * Not a bare `isPending`: 81 cards share one hook, and a boolean would
+   * disable the control on all of them while one cabin is being held.
+   */
+  pendingUnitId: string
+}
+
+/** Outcome wording, matching the badge vocabulary in `unitBadges.ts`. */
+function confirmation({ unitName, familyAvailable }: AvailabilityIntent): string {
+  if (familyAvailable === null) return `${unitName} follows its usual role again`
+  return familyAvailable
+    ? `${unitName} is released to families for this weekend`
+    : `${unitName} is held for this weekend`
+}
+
+export function useUnitAvailability({
+  year,
+  sessionCmId,
+}: UseUnitAvailabilityOptions): UseUnitAvailabilityReturn {
+  const { fetchWithAuth } = useApiWithAuth()
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation({
+    mutationFn: async (intent: AvailabilityIntent) => {
+      await setUnitAvailability(fetchWithAuth, {
+        year,
+        sessionCmId,
+        unitId: intent.unitId,
+        familyAvailable: intent.familyAvailable,
+        reason: intent.reason,
+      })
+    },
+
+    onSuccess: (_result, intent) => {
+      toast.success(confirmation(intent))
+    },
+
+    onError: (error) => {
+      toast.error(error.message)
+    },
+
+    // On BOTH outcomes, for the reason the placement hook gives: a failure
+    // here is not a race the server recovered from internally, and
+    // `set_availability`'s own lost-race recovery can fail after the create
+    // landed. Refetching is what makes the board agree with the server either
+    // way.
+    onSettled: () => {
+      invalidateLodgingRegistryQueries(queryClient)
+    },
+  })
+
+  const { mutateAsync } = mutation
+  const setAvailability = useCallback(
+    async (intent: AvailabilityIntent) => {
+      // Refused BEFORE the write, the way the placement hook refuses an empty
+      // scenario. `sessionCmId` defaults to 0 on the board for the tests that
+      // do not exercise writes, and the schema declares `gt=0`.
+      if (sessionCmId <= 0) {
+        throw new Error('Select a weekend before changing availability.')
+      }
+      await mutateAsync(intent)
+    },
+    [mutateAsync, sessionCmId]
+  )
+
+  return {
+    setAvailability,
+    pendingUnitId: mutation.isPending ? mutation.variables.unitId : '',
+  }
+}

--- a/frontend/src/pages/WeekendRosterPage.scenario.test.tsx
+++ b/frontend/src/pages/WeekendRosterPage.scenario.test.tsx
@@ -138,6 +138,16 @@ vi.mock('../hooks/useLodgingPlacement', () => ({
   useLodgingPlacement: () => ({ move: vi.fn(() => Promise.resolve()), isMoving: false }),
 }))
 
+// Same reason, same board: the reserve/release control mounts a real
+// `useMutation` too. Its gate is pinned in
+// `components/weekend/LodgingBoard.availability.test.tsx`.
+vi.mock('../hooks/useUnitAvailability', () => ({
+  useUnitAvailability: () => ({
+    setAvailability: vi.fn(() => Promise.resolve()),
+    pendingUnitId: '',
+  }),
+}))
+
 const toastSuccess = vi.fn()
 const toastError = vi.fn()
 

--- a/frontend/src/pages/WeekendRosterPage.test.tsx
+++ b/frontend/src/pages/WeekendRosterPage.test.tsx
@@ -48,6 +48,16 @@ vi.mock('../hooks/useLodgingPlacement', () => ({
   useLodgingPlacement: () => ({ move: vi.fn(() => Promise.resolve()), isMoving: false }),
 }))
 
+// Same reason, same board: the reserve/release control mounts a real
+// `useMutation` too. Its gate is pinned in
+// `components/weekend/LodgingBoard.availability.test.tsx`.
+vi.mock('../hooks/useUnitAvailability', () => ({
+  useUnitAvailability: () => ({
+    setAvailability: vi.fn(() => Promise.resolve()),
+    pendingUnitId: '',
+  }),
+}))
+
 // The page reads the global ScenarioContext to resolve which plan the roster
 // is being read in (#1967). These tests are about layout and navigation, so
 // the mock stays in production mode throughout — the picker's own behaviour

--- a/frontend/src/pages/WeekendRosterPage.tsx
+++ b/frontend/src/pages/WeekendRosterPage.tsx
@@ -25,7 +25,7 @@
  * the Go ingest so every surface sees the correction at once.
  */
 import { Building2, Home, Map as MapIcon, Users } from 'lucide-react'
-import { useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router'
 
 import { QueryGuard } from '../components/QueryGuard'
@@ -53,7 +53,9 @@ import {
 import { useCurrentYear } from '../hooks/useCurrentYear'
 import { usePermissions } from '../hooks/usePermissions'
 import { useScenario } from '../hooks/useScenario'
+import { useUnitAvailability } from '../hooks/useUnitAvailability'
 import { useWeekendRoster, useWeekendSessions } from '../hooks/useWeekendRoster'
+import type { LodgingUnitRow } from '../types/lodging'
 
 /**
  * `housing`, not `board`. Summer names its board tab after what is being
@@ -111,6 +113,29 @@ export default function WeekendRosterPage() {
   const numericRef = /^\d+$/.test(sessionRef ?? '') ? Number(sessionRef) : null
   const resolved = resolveWeekendRef(sessions, sessionRef)
   const selectedCmId = resolved?.session_cm_id ?? numericRef
+
+  // Availability, for the Housing tab's back door. Takes no scenario, unlike
+  // every other lodging write on this page: a burst pipe closes a cabin in
+  // every plan for that weekend (1500000135). The board mounts its own
+  // instance for the same reason it owns its drag mutation — only one view
+  // renders at a time, so the two never compete.
+  const { setAvailability, pendingUnitId } = useUnitAvailability({
+    year: currentYear,
+    sessionCmId: selectedCmId ?? 0,
+  })
+  const writeAvailability = useCallback(
+    (unit: LodgingUnitRow, write: { familyAvailable: boolean | null; reason: string }) => {
+      // The hook raises the toast on rejection; catching keeps a refused write
+      // from surfacing as an unhandled rejection.
+      void setAvailability({
+        unitId: unit.unit_id,
+        unitName: unit.name,
+        familyAvailable: write.familyAvailable,
+        reason: write.reason,
+      }).catch(() => undefined)
+    },
+    [setAvailability]
+  )
 
   // `useSavedScenarios` filters on `currentSessionId`. Left unset, the picker
   // would offer whatever session summer last looked at — the slot is global.
@@ -306,7 +331,20 @@ export default function WeekendRosterPage() {
               aria-labelledby={`weekend-tab-${view}`}
             >
               {view === 'roster' && <HouseholdRosterTable parties={parties} units={units} />}
-              {view === 'inventory' && <UnitInventoryPanel units={units} />}
+              {/* The Housing tab is where releasing permanent staff housing
+                  lives, and the only place it CAN live: the board draws
+                  planning inventory, and a staff cabin with no override is not
+                  inventory yet. Rare by design -- staff release one perhaps
+                  once in several years -- so it is a back door off the main
+                  flow rather than a control on the board. */}
+              {view === 'inventory' && (
+                <UnitInventoryPanel
+                  units={units}
+                  canSetAvailability={canManageLodging && (selectedCmId ?? 0) > 0}
+                  pendingUnitId={pendingUnitId}
+                  onSetAvailability={writeAvailability}
+                />
+              )}
               {/* The board takes the scenario, the weekend and the manage
                   permission because it WRITES now (#1989) — main's note that
                   drag placement "is what earns plumbing it back down" is this.

--- a/frontend/src/services/lodgingApi.test.ts
+++ b/frontend/src/services/lodgingApi.test.ts
@@ -15,6 +15,7 @@ import {
   fetchWeekendSessions,
   fetchWeekendSummary,
   placeParty,
+  setUnitAvailability,
   unplaceParty,
 } from './lodgingApi'
 
@@ -245,6 +246,87 @@ describe('unplaceParty', () => {
     await expect(
       unplaceParty(mockFetch, { ...WEEKEND, grain: { household_cm_id: 2000001 } })
     ).rejects.toThrow(/No placement to remove/)
+  })
+})
+
+describe('setUnitAvailability', () => {
+  const WEEKEND = { year: 2026, sessionCmId: 1000001, unitId: 'u1' }
+
+  it('PUTs the weekend, the unit and the explicit boolean', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(okResponse({ record_id: 'r1', deleted: false }))
+
+    const result = await setUnitAvailability(mockFetch, {
+      ...WEEKEND,
+      familyAvailable: false,
+      reason: 'Burst pipe',
+    })
+
+    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/lodging/availability')
+    expect(options.method).toBe('PUT')
+    // No scenario. The endpoint takes none since 1500000135, and sending one
+    // would be a 422 against a model that no longer extends ScenarioWriteRequest.
+    expect(JSON.parse(options.body as string)).toEqual({
+      year: 2026,
+      session_cm_id: 1000001,
+      unit_id: 'u1',
+      family_available: false,
+      reason: 'Burst pipe',
+    })
+    expect(result).toEqual({ record_id: 'r1', deleted: false })
+  })
+
+  it('sends a hold as an explicit false, never as a missing field', async () => {
+    // THE trap. `false` and `null` are different answers — false is "closed
+    // this weekend", null DELETES the row and hands the question back to the
+    // unit's role. Any falsy handling on the way out (`|| null`, a spread that
+    // drops it, `familyAvailable ? ... : undefined`) turns "hold this cabin"
+    // into "clear the override", and the write reads as a no-op that staff
+    // only notice when a family arrives at a cabin with no water.
+    const mockFetch = vi.fn().mockResolvedValue(okResponse({ record_id: 'r1', deleted: false }))
+
+    await setUnitAvailability(mockFetch, {
+      ...WEEKEND,
+      familyAvailable: false,
+      reason: 'Burst pipe',
+    })
+
+    const body = JSON.parse((mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string)
+    expect(body).toHaveProperty('family_available')
+    expect(body.family_available).toBe(false)
+  })
+
+  it('clears with an explicit null and reports the row as deleted', async () => {
+    // `null` is how "whatever this unit's role says" is spelled. There is no
+    // value meaning "normal": writing one would pin the unit against a later
+    // change to its role. `deleted` is the caller's only way to tell a cleared
+    // override from a written one.
+    const mockFetch = vi.fn().mockResolvedValue(okResponse({ record_id: '', deleted: true }))
+
+    const result = await setUnitAvailability(mockFetch, {
+      ...WEEKEND,
+      familyAvailable: null,
+      reason: '',
+    })
+
+    const body = JSON.parse((mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string)
+    expect(body.family_available).toBeNull()
+    expect(result.deleted).toBe(true)
+  })
+
+  it('carries the status of a refused write so the card can say why', async () => {
+    // The endpoint is gated on `bunking.manage`. The control is gated on the
+    // same permission, so a 403 here means the token expired mid-session
+    // rather than that the user never had it — which is a different sentence.
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ detail: 'Permission required: bunking.manage' }),
+    })
+
+    await expect(
+      setUnitAvailability(mockFetch, { ...WEEKEND, familyAvailable: true, reason: 'Overflow' })
+    ).rejects.toMatchObject({ status: 403, message: 'Permission required: bunking.manage' })
   })
 })
 

--- a/frontend/src/services/lodgingApi.ts
+++ b/frontend/src/services/lodgingApi.ts
@@ -10,6 +10,7 @@
 import type { PartyGrainBody } from '../components/weekend/dragPlacement'
 import type {
   HouseholdMedical,
+  LodgingWriteResult,
   WeekendRoster,
   WeekendSessionList,
   WeekendSummary,
@@ -200,6 +201,52 @@ export async function unplaceParty(
     body: JSON.stringify(placementBody(base)),
   })
   if (!response.ok) throw await toError(response, 'Failed to unplace the party')
+}
+
+/** Holding one unit back for a weekend, or releasing one to families. */
+export interface AvailabilityWrite {
+  year: number
+  sessionCmId: number
+  /** The unit's PocketBase id, which is what `lodging_availability.unit` relates to. */
+  unitId: string
+  /**
+   * THREE values, not two. `false` closes the unit for this weekend, `true`
+   * opens it, and `null` DELETES the row so the unit's own role decides again.
+   * Nothing here may be read for truthiness: `!familyAvailable` folds a hold
+   * into a clear.
+   */
+  familyAvailable: boolean | null
+  /** Display only — the rule never branches on it. `''` when clearing. */
+  reason: string
+}
+
+/**
+ * Reserve or release one unit for one weekend.
+ *
+ * Takes NO scenario, unlike every other write on this client. Availability is
+ * a fact about the WEEKEND rather than about the plan — a burst pipe closes a
+ * cabin in every scenario for that weekend — so 1500000135 deleted the
+ * dimension and `AvailabilityWriteRequest` stopped extending
+ * `ScenarioWriteRequest`. Requiring one is what left this endpoint with no
+ * caller and the table with no rows.
+ */
+export async function setUnitAvailability(
+  fetchWithAuth: FetchWithAuth,
+  { year, sessionCmId, unitId, familyAvailable, reason }: AvailabilityWrite
+): Promise<LodgingWriteResult> {
+  const response = await fetchWithAuth(`${API_BASE}/availability`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      year,
+      session_cm_id: sessionCmId,
+      unit_id: unitId,
+      family_available: familyAvailable,
+      reason,
+    }),
+  })
+  if (!response.ok) throw await toError(response, 'Failed to update availability')
+  return response.json() as Promise<LodgingWriteResult>
 }
 
 /**

--- a/frontend/src/types/lodging.ts
+++ b/frontend/src/types/lodging.ts
@@ -21,6 +21,7 @@ import type {
   AccessibilityFlagSummary,
   HouseholdMedicalResponse,
   LodgingUnitSummary,
+  LodgingWriteResponse,
   PartyAdult,
   PartyChild,
   RosterCounts,
@@ -62,6 +63,14 @@ export type HouseholdMedical = HouseholdMedicalResponse
 export type PartyAdultRow = PartyAdult
 /** An enrolled child on a household party. */
 export type PartyChildRow = PartyChild
+/**
+ * What a lodging write did.
+ *
+ * `deleted` is not decoration: clearing an availability override is spelled as
+ * the ABSENCE of a row, so a cleared override and a written one are the same
+ * 200 and differ only here.
+ */
+export type LodgingWriteResult = LodgingWriteResponse
 
 // ── Derived unions ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #1999

Stage 3 of the lodging availability segregation. Stage 2 (#2001) landed the model — `lodging_availability` without its scenario dimension, an explicit `family_available` boolean, and a callable `PUT /api/lodging/availability`. It had no caller. Landing a model with no writer is how that table reached zero rows and an uncallable endpoint in the first place, so this is the writer.

## What it adds

- **`setUnitAvailability` in `services/lodgingApi.ts`** — the FastAPI client, taking `fetchWithAuth` as its first parameter like every other function in that file. (Not `lodgingCrud.ts`, which talks to PocketBase through the JS SDK; this endpoint is FastAPI, gated on `bunking.manage`.)
- **`hooks/useUnitAvailability.ts`** — the mutation, with a confirmation toast and invalidation.
- **`availabilityAction(unit)` in `unitBadges.ts`** — which of the three reachable outcomes a unit can move to, living beside `reservationBadge` so a card cannot say two things about one cabin.
- **`UnitAvailabilityControl`** on the unit card, beside the badge reporting the same fact.

| Card state | Action | Writes |
|---|---|---|
| Family cabin, no override | Hold | `family_available: false` + reason |
| Staff cabin, no override | Release | `family_available: true` + reason |
| Either, with an override | Clear | `family_available: null` — deletes the row |

The reason is required on hold and release, and absent on clear. A cabin taken out of service with no stated reason is the row a staff member cannot act on next week.

## One deliberate divergence, flagged

**The control is NOT gated on the board's `canPlace`.** `canPlace` is `canManage && scenario !== '' && sessionCmId > 0` — it requires a scenario. Availability carries none: that is the whole of #1998. Reusing `canPlace` would put the deleted dimension straight back at the UI layer, and staff looking at the CampMinder mirror — which is where most of them look — could not record a burst pipe at all. The gate is `canManage && sessionCmId > 0`, threaded from the same source, with the reasoning stated at the divergence and pinned by a test that fails if someone "simplifies" it back.

Its consequence is the other divergence from the placement hook: **invalidation is by prefix, across every scenario.** The roster key carries a scenario (#1967), so invalidating only the visible key would leave the mirror and every other draft of the weekend showing the cabin as open — for the full 30 minute staleTime. `invalidateLodgingRegistryQueries` already invalidates the three weekend prefixes, so this calls it rather than growing a fourth path.

## Also folded in

Two claims in `docs/reference/weekend-go-live-sequence.md` that #2001 made false — "every write requires a scenario", and a stale anchor asserting the same about `AvailabilityWriteRequest`. Per `CLAUDE.local.md` these ride along rather than taking a standalone PR. `ScenarioWriteRequest`'s own docstring still opened "Common shape of every lodging write", which is the sentence that shaped the original mistake; it now says which writes it is the shape of. `npm run generate:api-types` produces no diff — that base class is not published.

## Mutation checks

Each mutation was run, the named test confirmed dead, then restored.

| Mutation | Test that died |
|---|---|
| `family_available: familyAvailable \|\| null` in the client | "sends a hold as an explicit false" + the body test |
| Invalidate the visible roster key only (copying the placement hook) | "refreshes EVERY scenario of the weekend" |
| `canSetAvailability = canPlace` | "offers the control on the CampMinder mirror" |
| `canSetAvailability = canManage` | "offers no control without a weekend to write into" |
| `canSetAvailability = sessionCmId > 0` | "offers no control without bunking.manage" |
| Truthiness instead of `!== null` on the override | three `availabilityAction` cases |
| Clear writes `false` instead of `null` | the clear cases on both the action and the control |

**One mutation survived, and it found a real gap.** Deleting the empty-reason guard from the submit handler broke nothing — the submit button was also `disabled` while the box was empty, and a click on a disabled button never reaches a handler. Two guards masking each other means a test can pin neither. Fixed by making the handler the single enforcement point: the button stays live, and an empty submit now produces a visible refusal instead of an inert click that explains nothing. Re-checked, and deleting the guard now kills four tests.

## Verification

- `npx vitest run` — 5623 passed, 405 files, exit 0
- `npx tsc --noEmit` — clean
- `npx eslint src` — 0 errors (367 pre-existing warnings, two fewer than before)
- `uv run pytest tests/` — 5932 passed, 23 skipped, exit 0
- `uv run mypy api/` — clean; `ruff check` / `ruff format --check` — clean
- Pre-push hooks all green, including `api-types-freshness`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round (added after the first push)

A code review caught that **Release could never render for the units it exists for.** The board draws planning inventory, `isPlanningInventory` excludes a `staff_default` unit with no override, and "release" is by definition the operation on a unit that is not yet inventory — so the board card can carry Hold and Clear but never Release. Confirmed empirically: rendering an unreleased, empty staff cabin through the real `buildBoard` finds no Release button, while one that already holds a party does — exactly backwards, since a cabin with a family already in it is the one case you don't need the button.

That was a category error in the plan's Task 9, which put all three actions on one surface without noticing one of them acts on precisely the set that surface excludes.

**Fix: the Housing tab is the back door.** `UnitInventoryPanel` is the registry view, already lists every staff unit (with a guard test pinning that it must), and already renders the same badge, so `UnitAvailabilityControl` drops in beside it unchanged. The board keeps Hold and Clear for family cabins where staff actually work.

Releasing permanent staff housing is a once-in-several-years event, so it is deliberately off the main flow rather than a control on the board — but it is reachable in the product rather than requiring a hand-edited row.

Rejected alternative: an escape hatch in `boardLayout`'s `drawn` filter. It would reverse an explicit owner ruling, put every staff card back on the board, and — since `useDroppable` is disabled only on `!canPlace` — make them live drop targets again whenever a scenario is open, reviving the phantom-drop-target bug this plan exists to close.

Also in this round: the `LodgingBoard` module docstring still claimed "nothing here mutates" while the board now owns two mutations, and a test fixture used a household id outside the set `tests/CLAUDE.md` specifies.

New mutation checks, each confirmed to kill the named test and then restored:

| Mutation | Test that died |
|---|---|
| Drop the handler check from the panel's gate | "stays read-only when the page passes no handler at all" |
| Drop the permission check from the panel's gate | "offers nothing without bunking.manage" |

Re-verified after: vitest 5628 passed / 405 files, tsc clean, eslint 0 errors, exit 0 throughout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added weekend-level availability controls for lodging units.
  * Users can hold, release, or clear availability overrides with required reasons and inline validation.
  * Availability status and reasons appear on lodging unit cards.
  * Availability updates work independently of placement scenarios and track saving per unit.

* **Documentation**
  * Clarified scenario requirements for placement writes versus availability updates.
  * Updated go-live guidance for availability management and manual CampMinder re-keying.

* **Tests**
  * Added coverage for permissions, validation, updates, pending states, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->