### PR TITLE
refactor(pb)!: allocation_default becomes inventory_class

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -119,7 +119,10 @@ class LodgingUnitSummary(BaseModel):
     # A building/grouping row. Present in the payload so the map and board
     # can draw the building, but excluded from every capacity count.
     is_container: bool = False
-    allocation_default: str = ""
+    # The unit's ROLE: whether it is planning inventory at all. Carried a
+    # "default" name until 1500000136, which implied an override -- and the
+    # override is a rare per-weekend exception rather than the point.
+    inventory_class: str = ""
     # None when no lodging_availability row exists for this unit this weekend,
     # i.e. the unit's ROLE decides. None and False are different answers and
     # must not be flattened into one: False is "closed this weekend".
@@ -290,7 +293,7 @@ class RosterCounts(BaseModel):
     beds_family_available: int = 0
     units_capacity_unknown: int = 0
     units_unconfirmed: int = 0
-    # Units created without an explicit allocation_default. They match
+    # Units created without an explicit inventory_class. They match
     # neither row of the availability table; surfaced rather than hidden.
     units_missing_allocation: int = 0
     # Cabin strings the ingest could not map to a unit, still awaiting triage.

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -255,7 +255,7 @@ def _is_planning_inventory(unit: LodgingUnitSummary) -> bool:
     weekend is still inventory and is reported by `units_reserved`. Permanent
     staff housing was never inventory, so it cannot be "held back".
     """
-    return unit.allocation_default != "staff_default" or unit.is_family_available
+    return unit.inventory_class != "staff_default" or unit.is_family_available
 
 
 class LodgingRosterService:
@@ -496,7 +496,7 @@ class LodgingRosterService:
             code = _s(unit, "code")
             group = _s(unit, "bathroom_group")
             area = (getattr(unit, "expand", None) or {}).get("area")
-            allocation_default = _s(unit, "allocation_default")
+            inventory_class = _s(unit, "inventory_class")
             override = override_by_unit.get(_s(unit, "id"))
             summaries.append(
                 LodgingUnitSummary(
@@ -534,10 +534,10 @@ class LodgingRosterService:
                     is_confirmed=_b(unit, "is_confirmed"),
                     is_active=_b(unit, "is_active"),
                     is_container=_b(unit, "is_container"),
-                    allocation_default=allocation_default,
+                    inventory_class=inventory_class,
                     family_available_override=override,
                     reason=reason_by_unit.get(_s(unit, "id"), ""),
-                    is_family_available=is_family_available(allocation_default, override),
+                    is_family_available=is_family_available(inventory_class, override),
                     map_x=map_x,
                     map_y=map_y,
                 )
@@ -870,6 +870,6 @@ class LodgingRosterService:
             # unit is already here with its is_confirmed, so the second answer
             # bought nothing but a chance to disagree, and one fetch.
             units_unconfirmed=sum(1 for u in bookable if not u.is_confirmed),
-            units_missing_allocation=sum(1 for u in bookable if not u.allocation_default),
+            units_missing_allocation=sum(1 for u in bookable if not u.inventory_class),
             unresolved_aliases=unresolved_aliases,
         )

--- a/api/services/lodging_rules.py
+++ b/api/services/lodging_rules.py
@@ -45,7 +45,7 @@ def unit_capacity(sleeps: int | None) -> int | None:
     return int(sleeps)
 
 
-def is_family_available(allocation_default: str, override: bool | None) -> bool:
+def is_family_available(inventory_class: str, override: bool | None) -> bool:
     """Whether this unit can take a family this weekend, in exactly one place.
 
     | base          | override | family-available |
@@ -71,14 +71,14 @@ def is_family_available(allocation_default: str, override: bool | None) -> bool:
     falsy test.
 
     A unit created through the admin UI without an explicit
-    `allocation_default` stores "" and matches neither base row. We treat "" as
+    `inventory_class` stores "" and matches neither base row. We treat "" as
     family_pool so the unit is at least visible, and the roster reports it
     separately via RosterCounts.units_missing_allocation rather than hiding
     the gap.
     """
     if override is not None:
         return override
-    return allocation_default != "staff_default"
+    return inventory_class != "staff_default"
 
 
 def effective_bathroom(

--- a/docs/architecture/lodging-occupancy.md
+++ b/docs/architecture/lodging-occupancy.md
@@ -114,7 +114,7 @@ rule: it blocks legitimate work and teaches staff to ignore warnings.
 
 ## What is not yet modelled
 
-- `lodging_units` has no shareability field. `allocation_default`
+- `lodging_units` has no shareability field. `inventory_class`
   (`family_pool` / `staff_default`) describes who a unit is *reserved for*, not
   how many parties may occupy it.
 - `lodging_availability` carries a per-unit `family_available` boolean per

--- a/docs/reference/lodging-registry.md
+++ b/docs/reference/lodging-registry.md
@@ -131,7 +131,7 @@ an empty registry rather than an error anyone will see.
       "bathroom_group": "grp-1",// units sharing one bathroom; "" for none
       "parent_unit": "bldg-1",  // unit CODE of the containing building, or ""
       "near_bathhouse": true,
-      "allocation_default": "family_pool",  // family_pool | staff_default
+      "inventory_class": "family_pool",  // family_pool | staff_default
       "is_container": false,    // true = a building row: never bookable, never counted
       "notes": "",
 
@@ -198,7 +198,7 @@ default and splits fields by how much damage writing them could do:
 |---|---|---|
 | Inventory | the amenities and `max_beds` | filled freely — they were empty |
 | Structural | `bathroom`, `bathroom_group`, `is_container`, `parent_unit` | reported; written only under `--structural`, since each overwrites a value that may be deliberate |
-| Staff-owned | `sleeps`, `map_x`, `map_y`, `is_confirmed`, `is_active`, `allocation_default` | **never written**, under any flag |
+| Staff-owned | `sleeps`, `map_x`, `map_y`, `is_confirmed`, `is_active`, `inventory_class` | **never written**, under any flag |
 
 Two further rules: an empty `has_ramp` never overwrites a real assessment, and
 `notes` are filled only when the database has none — replacing free text a staff

--- a/frontend/src/components/admin/lodging/LodgingAliasForm.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingAliasForm.test.tsx
@@ -43,7 +43,7 @@ function fixtureUnit(over: Partial<LodgingUnitRecord> & { id: string }): Lodging
     has_ac: false,
     has_fridge: false,
     is_accessible: false,
-    allocation_default: 'family_pool',
+    inventory_class: 'family_pool',
     is_confirmed: false,
     is_active: true,
     is_container: false,

--- a/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
@@ -1,5 +1,5 @@
 /**
- * A unit created without an explicit is_active / allocation_default is
+ * A unit created without an explicit is_active / inventory_class is
  * invisible AND unclassifiable — PocketBase has no per-field default for
  * bool or select. The form must never let that happen.
  */
@@ -45,7 +45,7 @@ const UNIT: LodgingUnitRecord = {
   has_ac: false,
   has_fridge: false,
   is_accessible: false,
-  allocation_default: 'family_pool',
+  inventory_class: 'family_pool',
   is_confirmed: false,
   is_active: true,
   is_container: false,
@@ -53,7 +53,7 @@ const UNIT: LodgingUnitRecord = {
 }
 
 describe('LodgingUnitForm — create', () => {
-  it('submits is_active true and an explicit allocation_default', async () => {
+  it('submits is_active true and an explicit inventory_class', async () => {
     createLodgingUnit.mockResolvedValue({ id: 'u1' })
     const onSaved = vi.fn()
     const user = userEvent.setup()
@@ -68,7 +68,7 @@ describe('LodgingUnitForm — create', () => {
     })
     const [payload] = createLodgingUnit.mock.calls[0] as [LodgingUnitInput]
     expect(payload.is_active).toBe(true)
-    expect(payload.allocation_default).toBe('family_pool')
+    expect(payload.inventory_class).toBe('family_pool')
     expect(onSaved).toHaveBeenCalled()
   })
 

--- a/frontend/src/components/admin/lodging/LodgingUnitForm.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitForm.tsx
@@ -8,10 +8,10 @@
  * TWO THINGS THIS FORM EXISTS TO GET RIGHT (the third, `sleeps`, is in
  * `UnitCapacityFields`; the bathroom vocabulary is in `unitAmenities`):
  *
- * 1. is_active and allocation_default are ALWAYS submitted. PocketBase has
+ * 1. is_active and inventory_class are ALWAYS submitted. PocketBase has
  *    no per-field default for bool or select, and `required: true` on a bool
  *    means "must be true", so neither can be required in the schema. A create
- *    that omits them yields `is_active = false, allocation_default = ''`:
+ *    that omits them yields `is_active = false, inventory_class = ''`:
  *    a unit no list query returns, which also matches neither branch of the
  *    family-availability rules.
  *
@@ -29,7 +29,7 @@ import toast from 'react-hot-toast'
 import { createLodgingUnit, updateLodgingUnit } from '../../../services/lodgingCrud'
 import { normaliseBeds } from '../../../types/beds'
 import type {
-  AllocationDefaultValue,
+  InventoryClassValue,
   LodgingAreaRecord,
   LodgingUnitInput,
   LodgingUnitRecord,
@@ -74,8 +74,8 @@ export function LodgingUnitForm({ areas, units, unit, onSaved, onCancel }: Lodgi
     x: unit ? String(unit.map_x) : '',
     y: unit ? String(unit.map_y) : '',
   })
-  const [allocation, setAllocation] = useState<AllocationDefaultValue>(
-    unit?.allocation_default === 'staff_default' ? 'staff_default' : 'family_pool'
+  const [inventoryClass, setInventoryClass] = useState<InventoryClassValue>(
+    unit?.inventory_class === 'staff_default' ? 'staff_default' : 'family_pool'
   )
   const [isActive, setIsActive] = useState(unit ? unit.is_active : true)
   const [isContainer, setIsContainer] = useState(unit?.is_container ?? false)
@@ -109,7 +109,7 @@ export function LodgingUnitForm({ areas, units, unit, onSaved, onCancel }: Lodgi
       parent_unit: identity.parent_unit,
       // Never omitted — see the header comment.
       is_active: isActive,
-      allocation_default: allocation,
+      inventory_class: inventoryClass,
       is_container: isContainer,
       notes,
       beds: capacity.beds,
@@ -155,13 +155,13 @@ export function LodgingUnitForm({ areas, units, unit, onSaved, onCancel }: Lodgi
 
       <label className="text-sm">
         <span className={LABEL}>Allocation</span>
-        {/* No blank option: an empty allocation_default matches neither
+        {/* No blank option: an empty inventory_class matches neither
             branch of the family-availability rules. */}
         <select
           className={FIELD}
-          value={allocation}
+          value={inventoryClass}
           onChange={(e) => {
-            setAllocation(e.target.value as AllocationDefaultValue)
+            setInventoryClass(e.target.value as InventoryClassValue)
           }}
         >
           <option value="family_pool">Available to guests</option>

--- a/frontend/src/components/admin/lodging/LodgingUnitRow.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitRow.tsx
@@ -70,7 +70,7 @@ export function LodgingUnitRow({
         )}
       </td>
       <td className="py-1.5">
-        {unit.allocation_default === 'staff_default' ? 'Held for staff' : 'Available to guests'}
+        {unit.inventory_class === 'staff_default' ? 'Held for staff' : 'Available to guests'}
       </td>
       <td className="py-1.5">
         <div className="flex flex-wrap items-center gap-1.5">

--- a/frontend/src/components/admin/lodging/LodgingUnitsPanel.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitsPanel.test.tsx
@@ -45,7 +45,7 @@ function fixtureUnit(over: Record<string, unknown>) {
     has_ac: false,
     has_fridge: false,
     is_accessible: false,
-    allocation_default: 'family_pool',
+    inventory_class: 'family_pool',
     is_confirmed: false,
     is_active: true,
     is_container: false,

--- a/frontend/src/components/admin/lodging/UnresolvedAliasQueue.test.tsx
+++ b/frontend/src/components/admin/lodging/UnresolvedAliasQueue.test.tsx
@@ -25,7 +25,7 @@ function unitFixture(over: Record<string, unknown>) {
     has_ac: false,
     has_fridge: false,
     is_accessible: false,
-    allocation_default: 'family_pool',
+    inventory_class: 'family_pool',
     is_confirmed: true,
     is_active: true,
     is_container: false,

--- a/frontend/src/components/admin/lodging/unitSort.test.ts
+++ b/frontend/src/components/admin/lodging/unitSort.test.ts
@@ -26,7 +26,7 @@ function unit(over: Partial<LodgingUnitRecord> & { id: string }): LodgingUnitRec
     has_ac: false,
     has_fridge: false,
     is_accessible: false,
-    allocation_default: 'family_pool',
+    inventory_class: 'family_pool',
     is_confirmed: false,
     is_active: true,
     is_container: false,

--- a/frontend/src/components/admin/lodging/unitSort.ts
+++ b/frontend/src/components/admin/lodging/unitSort.ts
@@ -12,14 +12,14 @@
 import type { LodgingAreaRecord, LodgingUnitRecord } from '../../../types/lodging'
 
 export interface UnitSortColumn {
-  field: 'name' | 'code' | 'sleeps' | 'allocation_default' | 'is_confirmed'
+  field: 'name' | 'code' | 'sleeps' | 'inventory_class' | 'is_confirmed'
   label: string
 }
 
 export const UNIT_SORT_COLUMNS: readonly UnitSortColumn[] = [
   { field: 'name', label: 'Unit' },
   { field: 'sleeps', label: 'Sleeps' },
-  { field: 'allocation_default', label: 'Allocation' },
+  { field: 'inventory_class', label: 'Allocation' },
   { field: 'is_confirmed', label: 'Status' },
 ] as const
 
@@ -47,8 +47,8 @@ function sortKey(unit: LodgingUnitRecord, field: UnitSortField): string | number
     case 'sleeps':
       // 0 is UNKNOWN, never zero capacity.
       return unit.sleeps > 0 ? unit.sleeps : null
-    case 'allocation_default':
-      return unit.allocation_default
+    case 'inventory_class':
+      return unit.inventory_class
     case 'is_confirmed':
       // Unconfirmed first ascending: that is the outstanding work, and the
       // roster cannot judge a housing need against an unconfirmed cabin.

--- a/frontend/src/components/admin/lodging/unitTree.test.ts
+++ b/frontend/src/components/admin/lodging/unitTree.test.ts
@@ -28,7 +28,7 @@ function unit(over: Partial<LodgingUnitRecord> & { id: string }): LodgingUnitRec
     has_ac: false,
     has_fridge: false,
     is_accessible: false,
-    allocation_default: 'family_pool',
+    inventory_class: 'family_pool',
     is_confirmed: false,
     is_active: true,
     is_container: false,

--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -61,7 +61,7 @@ function confirmedUnit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow 
     is_confirmed: true,
     is_active: true,
     is_container: false,
-    allocation_default: 'family_pool',
+    inventory_class: 'family_pool',
     family_available_override: null,
     reason: '',
     is_family_available: true,

--- a/frontend/src/components/weekend/FamilyDetailsPanel.test.tsx
+++ b/frontend/src/components/weekend/FamilyDetailsPanel.test.tsx
@@ -124,7 +124,7 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     is_confirmed: false,
     is_active: true,
     is_container: false,
-    allocation_default: 'family_pool',
+    inventory_class: 'family_pool',
     family_available_override: null,
     reason: '',
     is_family_available: true,

--- a/frontend/src/components/weekend/LodgingBoard.availability.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.availability.test.tsx
@@ -76,7 +76,7 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     is_confirmed: false,
     is_active: true,
     is_container: false,
-    allocation_default: 'family_pool',
+    inventory_class: 'family_pool',
     family_available_override: null,
     reason: '',
     is_family_available: true,

--- a/frontend/src/components/weekend/LodgingBoard.drag.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.drag.test.tsx
@@ -105,7 +105,7 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     is_confirmed: false,
     is_active: true,
     is_container: false,
-    allocation_default: 'family_pool',
+    inventory_class: 'family_pool',
     family_available_override: null,
     reason: '',
     is_family_available: true,

--- a/frontend/src/components/weekend/LodgingBoard.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.test.tsx
@@ -69,7 +69,7 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     is_confirmed: false,
     is_active: true,
     is_container: false,
-    allocation_default: 'family_pool',
+    inventory_class: 'family_pool',
     family_available_override: null,
     reason: '',
     is_family_available: true,

--- a/frontend/src/components/weekend/LodgingMap.test.tsx
+++ b/frontend/src/components/weekend/LodgingMap.test.tsx
@@ -90,7 +90,7 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     is_confirmed: false,
     is_active: true,
     is_container: false,
-    allocation_default: 'family_pool',
+    inventory_class: 'family_pool',
     family_available_override: null,
     reason: '',
     is_family_available: true,
@@ -449,7 +449,7 @@ describe('LodgingMap', () => {
 
   it('renders a mixed staff/family cluster the same shape regardless of member order', () => {
     // Close enough (2px apart on the 1000px jsdom fallback canvas) to cluster
-    // into one mark. Mixing allocation_default is the case that flips with
+    // into one mark. Mixing inventory_class is the case that flips with
     // whichever row the database happens to return first if the mark reads
     // its shape off `members[0]` instead of the whole cluster.
     const staffMix = [
@@ -459,7 +459,7 @@ describe('LodgingMap', () => {
         code: 'staff-a',
         map_x: 0.502,
         map_y: 0.5,
-        allocation_default: 'staff_default',
+        inventory_class: 'staff_default',
       }),
     ]
     const shapeOf = (units: LodgingUnitRow[]) => {
@@ -707,7 +707,7 @@ describe('LodgingMap highlight controls', () => {
     name: 'Cedar 2',
     map_x: 0.7,
     map_y: 0.2,
-    allocation_default: 'staff_default',
+    inventory_class: 'staff_default',
   })
 
   it('draws empty rooms by default', () => {

--- a/frontend/src/components/weekend/LodgingMap.tsx
+++ b/frontend/src/components/weekend/LodgingMap.tsx
@@ -721,10 +721,10 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
               // the old code — meant the shape flipped with whichever row the
               // database happened to return first.
               const allStaff = cluster.members.every(
-                (member) => member.item.unit.allocation_default === 'staff_default'
+                (member) => member.item.unit.inventory_class === 'staff_default'
               )
               const anyStaff = cluster.members.some(
-                (member) => member.item.unit.allocation_default === 'staff_default'
+                (member) => member.item.unit.inventory_class === 'staff_default'
               )
               // Hue has the same order-dependence risk. Cross-area clusters
               // are 0 on the current registry — clustering is proximity-based

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -31,7 +31,7 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     is_confirmed: false,
     is_active: true,
     is_container: false,
-    allocation_default: 'family_pool',
+    inventory_class: 'family_pool',
     family_available_override: null,
     reason: '',
     is_family_available: true,
@@ -141,7 +141,7 @@ describe('LodgingUnitCard', () => {
     render(
       <LodgingUnitCard
         slot={slot({
-          unit: unit({ allocation_default: 'staff_default', is_family_available: false }),
+          unit: unit({ inventory_class: 'staff_default', is_family_available: false }),
         })}
         hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}

--- a/frontend/src/components/weekend/MapUnitPopover.test.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.test.tsx
@@ -27,7 +27,7 @@ function row(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     is_confirmed: false,
     is_active: true,
     is_container: false,
-    allocation_default: 'family_pool',
+    inventory_class: 'family_pool',
     family_available_override: null,
     reason: '',
     is_family_available: true,

--- a/frontend/src/components/weekend/MapUnitPopover.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.tsx
@@ -101,7 +101,7 @@ function DetailCard({ units, hue, onOpenParty }: MapUnitPopoverProps) {
 
   const tags: string[] = []
   if (unit.near_bathhouse) tags.push('near bathhouse')
-  if (unit.allocation_default === 'staff_default') tags.push('staff-default')
+  if (unit.inventory_class === 'staff_default') tags.push('staff-default')
   if (parties.length > 1) tags.push(`shared by ${String(parties.length)}`)
 
   return (
@@ -304,7 +304,7 @@ function FootprintGrid({ units, hue, onOpenParty }: MapUnitPopoverProps) {
               }
             : {
                 borderColor: hue,
-                borderStyle: entry.unit.allocation_default === 'staff_default' ? 'dashed' : 'solid',
+                borderStyle: entry.unit.inventory_class === 'staff_default' ? 'dashed' : 'solid',
               }
           const className = `min-w-[2.5rem] truncate rounded border px-1.5 py-1 text-xs font-semibold ${
             first ? 'text-white' : 'bg-card text-muted-foreground'

--- a/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
@@ -32,7 +32,7 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     is_confirmed: false,
     is_active: true,
     is_container: false,
-    allocation_default: 'family_pool',
+    inventory_class: 'family_pool',
     family_available_override: null,
     reason: '',
     is_family_available: true,
@@ -46,7 +46,7 @@ const STAFF_CABIN = unit({
   unit_id: 'u2',
   code: 'aspen-lodge',
   name: 'Aspen Lodge',
-  allocation_default: 'staff_default',
+  inventory_class: 'staff_default',
   is_family_available: false,
 })
 

--- a/frontend/src/components/weekend/UnitInventoryPanel.test.tsx
+++ b/frontend/src/components/weekend/UnitInventoryPanel.test.tsx
@@ -27,7 +27,7 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     is_confirmed: true,
     is_active: true,
     is_container: false,
-    allocation_default: 'family_pool',
+    inventory_class: 'family_pool',
     family_available_override: null,
     reason: '',
     is_family_available: true,
@@ -55,7 +55,7 @@ describe('UnitInventoryPanel', () => {
             unit_id: 'u2',
             code: 'aspen-lodge',
             name: 'Aspen Lodge',
-            allocation_default: 'staff_default',
+            inventory_class: 'staff_default',
             is_family_available: false,
           }),
         ]}
@@ -74,7 +74,7 @@ describe('UnitInventoryPanel', () => {
             unit_id: 'u2',
             code: 'le-shack',
             name: 'Le Shack',
-            allocation_default: 'staff_default',
+            inventory_class: 'staff_default',
             is_family_available: false,
           }),
         ]}
@@ -108,7 +108,7 @@ describe('UnitInventoryPanel', () => {
       <UnitInventoryPanel
         units={[
           unit({
-            allocation_default: 'staff_default',
+            inventory_class: 'staff_default',
             family_available_override: true,
             is_family_available: true,
           }),
@@ -243,7 +243,7 @@ describe('UnitInventoryPanel — releasing a staff cabin', () => {
     unit_id: 'u2',
     code: 'aspen-lodge',
     name: 'Aspen Lodge',
-    allocation_default: 'staff_default' as const,
+    inventory_class: 'staff_default' as const,
     is_family_available: false,
   }
 

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -33,7 +33,7 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     is_confirmed: false,
     is_active: true,
     is_container: false,
-    allocation_default: 'family_pool',
+    inventory_class: 'family_pool',
     family_available_override: null,
     reason: '',
     is_family_available: true,
@@ -48,7 +48,7 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
  * family-available. 21 of the property's 102 leaf units are these.
  */
 function staffUnit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
-  return unit({ allocation_default: 'staff_default', is_family_available: false, ...overrides })
+  return unit({ inventory_class: 'staff_default', is_family_available: false, ...overrides })
 }
 
 function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -276,7 +276,7 @@ function consentReason(
  * reserved units are badged, not hidden.
  */
 function isPlanningInventory(unit: LodgingUnitRow): boolean {
-  return unit.allocation_default !== 'staff_default' || unit.is_family_available === true
+  return unit.inventory_class !== 'staff_default' || unit.is_family_available === true
 }
 
 function indexPayload(parties: RosterPartyRow[], units: LodgingUnitRow[]) {

--- a/frontend/src/components/weekend/dragPlacement.test.ts
+++ b/frontend/src/components/weekend/dragPlacement.test.ts
@@ -36,7 +36,7 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     is_confirmed: false,
     is_active: true,
     is_container: false,
-    allocation_default: 'family_pool',
+    inventory_class: 'family_pool',
     family_available_override: null,
     reason: '',
     is_family_available: true,

--- a/frontend/src/components/weekend/mapModel.test.ts
+++ b/frontend/src/components/weekend/mapModel.test.ts
@@ -25,7 +25,7 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     is_confirmed: false,
     is_active: true,
     is_container: false,
-    allocation_default: 'family_pool',
+    inventory_class: 'family_pool',
     family_available_override: null,
     reason: '',
     is_family_available: true,
@@ -121,14 +121,14 @@ describe('buildMapModel', () => {
   /**
    * Permanent staff housing: held for staff AND not released this weekend.
    *
-   * Setting only `allocation_default` is not enough — `unit()` defaults
+   * Setting only `inventory_class` is not enough — `unit()` defaults
    * `is_family_available: true`, which satisfies `isPlanningInventory`'s OR
    * clause and leaves the unit drawn. Every earlier staff fixture in the map
    * suite made exactly that mistake, which is why none of them could see the
    * board exclusion reaching the map.
    */
   function staffUnit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
-    return unit({ allocation_default: 'staff_default', is_family_available: false, ...overrides })
+    return unit({ inventory_class: 'staff_default', is_family_available: false, ...overrides })
   }
 
   it('drops staff housing, because the map is a projection of the board', () => {

--- a/frontend/src/components/weekend/unitBadges.test.ts
+++ b/frontend/src/components/weekend/unitBadges.test.ts
@@ -37,7 +37,7 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     is_confirmed: false,
     is_active: true,
     is_container: false,
-    allocation_default: 'family_pool',
+    inventory_class: 'family_pool',
     family_available_override: null,
     reason: '',
     is_family_available: true,
@@ -75,7 +75,7 @@ describe('reservationBadge', () => {
 
   it('badges permanent staff housing as staff', () => {
     const badge = reservationBadge(
-      unit({ allocation_default: 'staff_default', is_family_available: false })
+      unit({ inventory_class: 'staff_default', is_family_available: false })
     )
 
     expect(badge?.label).toBe('Staff')
@@ -87,7 +87,7 @@ describe('reservationBadge', () => {
   it('badges a staff cabin opened to families for this weekend', () => {
     const badge = reservationBadge(
       unit({
-        allocation_default: 'staff_default',
+        inventory_class: 'staff_default',
         family_available_override: true,
         is_family_available: true,
       })
@@ -115,7 +115,7 @@ describe('reservationBadge', () => {
     // no row is ordinary staff housing, not a release.
     const badge = reservationBadge(
       unit({
-        allocation_default: 'staff_default',
+        inventory_class: 'staff_default',
         family_available_override: null,
         is_family_available: false,
       })
@@ -164,7 +164,7 @@ describe('availabilityAction', () => {
     // Rare and explicit, not absent. One season of data corroborates that staff
     // cabins are never released; it does not prove it, so the capability stays.
     expect(
-      availabilityAction(unit({ allocation_default: 'staff_default', is_family_available: false }))
+      availabilityAction(unit({ inventory_class: 'staff_default', is_family_available: false }))
     ).toEqual({ kind: 'release', label: 'Release', familyAvailable: true, needsReason: true })
   })
 
@@ -182,7 +182,7 @@ describe('availabilityAction', () => {
     expect(
       availabilityAction(
         unit({
-          allocation_default: 'staff_default',
+          inventory_class: 'staff_default',
           family_available_override: true,
           is_family_available: true,
         })
@@ -199,7 +199,7 @@ describe('availabilityAction', () => {
     expect(
       availabilityAction(
         unit({
-          allocation_default: 'staff_default',
+          inventory_class: 'staff_default',
           family_available_override: false,
           is_family_available: false,
         })

--- a/frontend/src/components/weekend/unitBadges.ts
+++ b/frontend/src/components/weekend/unitBadges.ts
@@ -37,20 +37,20 @@ export function reservationBadge(unit: LodgingUnitRow): UnitBadge | null {
   // different answers, and `!override` collapses them into one.
   //
   // A staff cabin opened to families for this weekend.
-  if (unit.allocation_default === 'staff_default' && unit.family_available_override === true) {
+  if (unit.inventory_class === 'staff_default' && unit.family_available_override === true) {
     return {
       label: 'Released',
       className: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300',
     }
   }
   // A family cabin closed for this weekend -- a burst pipe, a caretaker.
-  if (unit.allocation_default !== 'staff_default' && unit.family_available_override === false) {
+  if (unit.inventory_class !== 'staff_default' && unit.family_available_override === false) {
     return {
       label: 'Held',
       className: 'bg-slate-200 text-slate-800 dark:bg-slate-800 dark:text-slate-200',
     }
   }
-  if (unit.allocation_default === 'staff_default') return staff
+  if (unit.inventory_class === 'staff_default') return staff
   return null
 }
 
@@ -91,7 +91,7 @@ export function availabilityAction(unit: LodgingUnitRow): AvailabilityAction | n
   if (unit.family_available_override !== null && unit.family_available_override !== undefined) {
     return { kind: 'clear', label: 'Clear', familyAvailable: null, needsReason: false }
   }
-  if (unit.allocation_default === 'staff_default') {
+  if (unit.inventory_class === 'staff_default') {
     return { kind: 'release', label: 'Release', familyAvailable: true, needsReason: true }
   }
   return { kind: 'hold', label: 'Hold', familyAvailable: false, needsReason: true }

--- a/frontend/src/services/lodgingCrud.test.ts
+++ b/frontend/src/services/lodgingCrud.test.ts
@@ -3,9 +3,9 @@
  *
  * The load-bearing assertion here is the unit-create payload. PocketBase has
  * no per-field default for bool or select, and `required: true` on a bool
- * means "must be true", so neither is_active nor allocation_default can be
+ * means "must be true", so neither is_active nor inventory_class can be
  * marked required in the schema. A create that omits them yields
- * `is_active = false, allocation_default = ''` — a unit invisible to every
+ * `is_active = false, inventory_class = ''` — a unit invisible to every
  * list query that also matches neither branch of the availability rules.
  *
  * The work queue is `lodging_ingest_issues`, NOT the `lodging_unresolved_aliases`
@@ -61,18 +61,18 @@ describe('listLodgingUnits', () => {
 })
 
 describe('createLodgingUnit', () => {
-  it('always sends is_active and an explicit allocation_default', async () => {
+  it('always sends is_active and an explicit inventory_class', async () => {
     await createLodgingUnit({
       area: 'area_1',
       name: 'Ridge N',
       code: 'ridge-n',
       is_active: true,
-      allocation_default: 'family_pool',
+      inventory_class: 'family_pool',
     })
 
     const [payload] = create.mock.calls[0] as [Partial<LodgingUnitRecord>]
     expect(payload.is_active).toBe(true)
-    expect(payload.allocation_default).toBe('family_pool')
+    expect(payload.inventory_class).toBe('family_pool')
   })
 
   it('defaults a missing is_container to false rather than omitting it', async () => {
@@ -81,13 +81,13 @@ describe('createLodgingUnit', () => {
       name: 'Ridge N',
       code: 'ridge-n',
       is_active: true,
-      allocation_default: 'staff_default',
+      inventory_class: 'staff_default',
     })
 
     const [payload] = create.mock.calls[0] as [Partial<LodgingUnitRecord>]
     expect(payload.is_container).toBe(false)
     expect(payload.is_confirmed).toBe(false)
-    expect(payload.allocation_default).toBe('staff_default')
+    expect(payload.inventory_class).toBe('staff_default')
   })
 })
 

--- a/frontend/src/services/lodgingCrud.ts
+++ b/frontend/src/services/lodgingCrud.ts
@@ -99,7 +99,7 @@ export async function listLodgingUnits(): Promise<LodgingUnitRecord[]> {
 /**
  * Create a unit.
  *
- * `is_active` and `allocation_default` are ALWAYS written, and `is_container`
+ * `is_active` and `inventory_class` are ALWAYS written, and `is_container`
  * and `is_confirmed` default to false explicitly. PocketBase has no per-field
  * default for bool or select, so anything omitted here lands as `false` / `''`:
  * a unit that no list query returns and that matches neither branch of the
@@ -110,7 +110,7 @@ export async function createLodgingUnit(input: LodgingUnitInput): Promise<Lodgin
   return pb.collection(UNITS).create<LodgingUnitRecord>({
     ...input,
     is_active: input.is_active,
-    allocation_default: input.allocation_default,
+    inventory_class: input.inventory_class,
     is_container: input.is_container ?? false,
     is_confirmed: input.is_confirmed ?? false,
   })

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -1926,9 +1926,9 @@ export type LodgingUnitSummary = {
    */
   is_container?: boolean
   /**
-   * Allocation Default
+   * Inventory Class
    */
-  allocation_default?: string
+  inventory_class?: string
   /**
    * Family Available Override
    */

--- a/frontend/src/types/lodging.test.ts
+++ b/frontend/src/types/lodging.test.ts
@@ -113,7 +113,7 @@ const _exhaustiveLodgingUnit: Required<LodgingUnitRow> = {
   is_confirmed: true,
   is_active: true,
   is_container: false,
-  allocation_default: 'family_pool',
+  inventory_class: 'family_pool',
   family_available_override: null,
   reason: '',
   is_family_available: true,

--- a/frontend/src/types/lodging.ts
+++ b/frontend/src/types/lodging.ts
@@ -156,12 +156,17 @@ interface PocketBaseRecordBase {
 export type BathroomStoredValue = 'none' | 'private' | 'shared' | ''
 
 /**
- * Whether a unit defaults to the family pool or is held for staff.
+ * Whether a unit is family pool or permanent staff housing.
+ *
+ * A ROLE, not a default. Called `AllocationDefaultValue` until 1500000136:
+ * "default" implied an override, and the override is a rare per-weekend
+ * exception rather than the point — the value says whether a unit is planning
+ * inventory at all.
  *
  * `''` is storable but not meaningful — it matches neither branch of the
  * availability rules, which is why `LodgingUnitInput` excludes it.
  */
-export type AllocationDefaultValue = 'family_pool' | 'staff_default'
+export type InventoryClassValue = 'family_pool' | 'staff_default'
 
 /** A named zone of the site. */
 export interface LodgingAreaRecord extends PocketBaseRecordBase {
@@ -196,7 +201,7 @@ export interface LodgingUnitRecord extends PocketBaseRecordBase {
   has_ac: boolean
   has_fridge: boolean
   is_accessible: boolean
-  allocation_default: AllocationDefaultValue | ''
+  inventory_class: InventoryClassValue | ''
   /**
    * Whether staff have actually verified this row's amenities.
    *
@@ -273,11 +278,11 @@ export type LodgingAreaInput = Pick<
 /**
  * Unit create/update payload.
  *
- * `is_active` and `allocation_default` are REQUIRED here on purpose.
+ * `is_active` and `inventory_class` are REQUIRED here on purpose.
  * PocketBase has no per-field default for bool or select, and `required: true`
  * on a bool means "must be true", so neither can be marked required in the
  * schema. A create that omits them yields `is_active = false,
- * allocation_default = ''` — a unit invisible to every list query that also
+ * inventory_class = ''` — a unit invisible to every list query that also
  * matches neither branch of the availability rules. Making them non-optional
  * here means the compiler catches the omission instead of the database
  * swallowing it.
@@ -287,7 +292,7 @@ export interface LodgingUnitInput {
   name: string
   code: string
   is_active: boolean
-  allocation_default: AllocationDefaultValue
+  inventory_class: InventoryClassValue
   parent_unit?: string
   map_x?: number
   map_y?: number

--- a/frontend/src/utils/queryKeys.test.ts
+++ b/frontend/src/utils/queryKeys.test.ts
@@ -143,7 +143,7 @@ describe('queryKeys.sessionUploadChanges', () => {
 describe('invalidateLodgingRegistryQueries', () => {
   // The lodging registry IS roster input: `_build_units`
   // (api/services/lodging_roster_service.py:350-419) projects name, area_name,
-  // sleeps, is_confirmed, is_active, allocation_default and map_x/map_y into
+  // sleeps, is_confirmed, is_active, inventory_class and map_x/map_y into
   // the roster payload. WeekendRosterPage links straight to
   // /manage/lodging/units, so admin-edit-then-back is the designed round trip
   // — and the weekend queries now carry a 30 minute staleTime, so nothing

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -557,7 +557,7 @@ export function invalidateRequestQueries(
  *
  * The registry is roster input. `_build_units`
  * (`api/services/lodging_roster_service.py:350-419`) projects `name`,
- * `area_name`, `sleeps`, `is_confirmed`, `is_active`, `allocation_default` and
+ * `area_name`, `sleeps`, `is_confirmed`, `is_active`, `inventory_class` and
  * `map_x`/`map_y` into the roster payload — every field these admin forms
  * edit. `WeekendRosterPage` links straight to `/manage/lodging/units`, so
  * edit-then-go-back is the designed round trip, not an edge case.

--- a/pocketbase/lodging/registry.go
+++ b/pocketbase/lodging/registry.go
@@ -65,14 +65,14 @@ type registryUnit struct {
 	// Sleeps is null when never observed. PocketBase number columns are
 	// `NUMERIC DEFAULT 0 NOT NULL`, so an unset value stores as 0 and
 	// consumers read 0 as UNKNOWN, not "zero capacity".
-	Sleeps            *int   `json:"sleeps"`
-	Bathroom          string `json:"bathroom"`
-	BathroomGroup     string `json:"bathroom_group"`
-	ParentUnit        string `json:"parent_unit"` // unit code, or "" for a top-level row
-	NearBathhouse     bool   `json:"near_bathhouse"`
-	AllocationDefault string `json:"allocation_default"`
-	IsContainer       bool   `json:"is_container"`
-	Notes             string `json:"notes"`
+	Sleeps         *int   `json:"sleeps"`
+	Bathroom       string `json:"bathroom"`
+	BathroomGroup  string `json:"bathroom_group"`
+	ParentUnit     string `json:"parent_unit"` // unit code, or "" for a top-level row
+	NearBathhouse  bool   `json:"near_bathhouse"`
+	InventoryClass string `json:"inventory_class"`
+	IsContainer    bool   `json:"is_container"`
+	Notes          string `json:"notes"`
 
 	// Amenities. Absent in JSON means false, which for these is the same claim
 	// the column made before the 2026 inventory: unknown, recorded as false.
@@ -370,7 +370,7 @@ func seedUnits(
 		rec.Set("bathroom", u.Bathroom)
 		rec.Set("bathroom_group", u.BathroomGroup)
 		rec.Set("near_bathhouse", u.NearBathhouse)
-		rec.Set("allocation_default", u.AllocationDefault)
+		rec.Set("inventory_class", u.InventoryClass)
 		rec.Set("is_container", u.IsContainer)
 		rec.Set("notes", u.Notes)
 		rec.Set("has_power", u.HasPower)

--- a/pocketbase/lodging/registry_test.go
+++ b/pocketbase/lodging/registry_test.go
@@ -45,7 +45,7 @@ func setupRegistryCollections(t *testing.T, app core.App) {
 	units.Fields.Add(&core.TextField{Name: "bathroom_group"})
 	units.Fields.Add(&core.BoolField{Name: "near_bathhouse"})
 	units.Fields.Add(&core.SelectField{
-		Name: "allocation_default", Values: []string{"family_pool", "staff_default"}, MaxSelect: 1,
+		Name: "inventory_class", Values: []string{"family_pool", "staff_default"}, MaxSelect: 1,
 	})
 	units.Fields.Add(&core.BoolField{Name: "is_confirmed"})
 	units.Fields.Add(&core.BoolField{Name: "is_active"})
@@ -151,15 +151,15 @@ const fixtureRegistry = `{
   "units": [
     {"area": "AREA1", "code": "child-a", "name": "Child A", "map_x": 0.51, "map_y": 0.26,
      "sleeps": 4, "bathroom": "shared", "bathroom_group": "grp-1", "parent_unit": "building-1",
-     "near_bathhouse": true, "allocation_default": "family_pool", "is_container": false,
+     "near_bathhouse": true, "inventory_class": "family_pool", "is_container": false,
      "notes": "a note"},
     {"area": "AREA1", "code": "building-1", "name": "Building One", "map_x": 0.5, "map_y": 0.25,
      "sleeps": null, "bathroom": "none", "bathroom_group": "", "parent_unit": "",
-     "near_bathhouse": false, "allocation_default": "family_pool", "is_container": true,
+     "near_bathhouse": false, "inventory_class": "family_pool", "is_container": true,
      "notes": ""},
     {"area": "AREA1", "code": "child-b", "name": "Child B", "map_x": 0.52, "map_y": 0.27,
      "sleeps": 2, "bathroom": "shared", "bathroom_group": "grp-1", "parent_unit": "building-1",
-     "near_bathhouse": false, "allocation_default": "staff_default", "is_container": false,
+     "near_bathhouse": false, "inventory_class": "staff_default", "is_container": false,
      "notes": ""}
   ],
   "aliases": [
@@ -298,8 +298,8 @@ func TestSeedRegistryCreatesAreasUnitsAndAliases(t *testing.T) {
 	if !child.GetBool("near_bathhouse") {
 		t.Error("unit near_bathhouse = false, want true")
 	}
-	if got := child.GetString("allocation_default"); got != "family_pool" {
-		t.Errorf("unit allocation_default = %q, want family_pool", got)
+	if got := child.GetString("inventory_class"); got != "family_pool" {
+		t.Errorf("unit inventory_class = %q, want family_pool", got)
 	}
 	if got := child.GetString("notes"); got != "a note" {
 		t.Errorf("unit notes = %q, want %q", got, "a note")
@@ -329,7 +329,7 @@ func TestSeedRegistryWritesAmenities(t *testing.T) {
 
 	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
 	  {"area": "AREA1", "code": "warm", "name": "Warm", "bathroom": "none",
-	   "allocation_default": "family_pool",
+	   "inventory_class": "family_pool",
 	   "has_power": true, "has_ac": true, "has_fridge": true, "is_accessible": true,
 	   "has_heat": true, "is_weatherized": true,
 	   "has_plumbing": true, "has_space_heater": true, "has_pack_play_space": true,
@@ -373,7 +373,7 @@ func TestSeedRegistryUnassessedRampStaysBlank(t *testing.T) {
 
 	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
 	  {"area": "AREA1", "code": "unknown-ramp", "name": "Unknown", "bathroom": "none",
-	   "allocation_default": "family_pool"}
+	   "inventory_class": "family_pool"}
 	], "aliases": []}`
 
 	if err := seedRegistryFromFile(app, writeRegistry(t, body)); err != nil {
@@ -591,7 +591,7 @@ func TestSeedRegistryUnknownAreaCodeIsAnError(t *testing.T) {
 
 	body := `{"areas": [], "units": [
 	  {"area": "NOPE", "code": "orphan", "name": "Orphan", "bathroom": "none",
-	   "allocation_default": "family_pool"}
+	   "inventory_class": "family_pool"}
 	], "aliases": []}`
 
 	err := seedRegistryFromFile(app, writeRegistry(t, body))
@@ -608,7 +608,7 @@ func TestSeedRegistryUnknownParentCodeIsAnError(t *testing.T) {
 
 	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
 	  {"area": "AREA1", "code": "orphan", "name": "Orphan", "parent_unit": "nope",
-	   "bathroom": "none", "allocation_default": "family_pool"}
+	   "bathroom": "none", "inventory_class": "family_pool"}
 	], "aliases": []}`
 
 	if err := seedRegistryFromFile(app, writeRegistry(t, body)); err == nil {
@@ -623,7 +623,7 @@ func TestSeedRegistryUnknownAliasMemberIsAnError(t *testing.T) {
 
 	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
 	  {"area": "AREA1", "code": "real", "name": "Real", "bathroom": "none",
-	   "allocation_default": "family_pool"}
+	   "inventory_class": "family_pool"}
 	], "aliases": [
 	  {"alias_string": "Broken", "member_units": ["real", "ghost"]}
 	]}`
@@ -643,9 +643,9 @@ func TestSeedRegistrySameAliasStringDifferentWindowsBothLand(t *testing.T) {
 
 	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
 	  {"area": "AREA1", "code": "old", "name": "Old", "bathroom": "none",
-	   "allocation_default": "family_pool"},
+	   "inventory_class": "family_pool"},
 	  {"area": "AREA1", "code": "new", "name": "New", "bathroom": "none",
-	   "allocation_default": "family_pool"}
+	   "inventory_class": "family_pool"}
 	], "aliases": [
 	  {"alias_string": "Renamed", "member_units": ["old"],
 	   "valid_from_year": null, "valid_to_year": 2024},
@@ -682,9 +682,9 @@ func TestSeedRegistryDuplicateUnitCodeIsAnError(t *testing.T) {
 
 	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
 	  {"area": "AREA1", "code": "twin", "name": "First", "bathroom": "none",
-	   "allocation_default": "family_pool"},
+	   "inventory_class": "family_pool"},
 	  {"area": "AREA1", "code": "twin", "name": "Second", "bathroom": "none",
-	   "allocation_default": "family_pool"}
+	   "inventory_class": "family_pool"}
 	], "aliases": []}`
 
 	err := seedRegistryFromFile(app, writeRegistry(t, body))
@@ -722,7 +722,7 @@ func TestSeedRegistryDuplicateAliasWindowIsAnError(t *testing.T) {
 
 	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
 	  {"area": "AREA1", "code": "real", "name": "Real", "bathroom": "none",
-	   "allocation_default": "family_pool"}
+	   "inventory_class": "family_pool"}
 	], "aliases": [
 	  {"alias_string": "Same", "member_units": ["real"], "valid_from_year": 2025},
 	  {"alias_string": "Same", "member_units": ["real"], "valid_from_year": 2025}

--- a/pocketbase/pb_migrations/1500000136_lodging_inventory_class_rename.js
+++ b/pocketbase/pb_migrations/1500000136_lodging_inventory_class_rename.js
@@ -1,0 +1,47 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+/**
+ * Migration: lodging_units.allocation_default becomes inventory_class
+ *
+ * After 1500000135 the column is a ROLE, not a default. "Default" implied an
+ * override, and the override is now a rare per-weekend exception rather than
+ * the point: the column says whether a unit is planning inventory at all.
+ *
+ * RENAMED IN PLACE, never removed and re-added. All 114 rows in production
+ * carry a value (92 family_pool, 22 staff_default) and a remove-and-add would
+ * drop every one of them -- silently, because nothing reads the column through
+ * a filter that would error on the missing name.
+ *
+ * The select's `values` are untouched: family_pool / staff_default keep their
+ * meaning, only the question the column answers is renamed.
+ */
+
+/**
+ * Renames a field in place, keeping its ID so PocketBase emits
+ * `ALTER TABLE ... RENAME COLUMN` rather than a drop-and-recreate.
+ *
+ * The `if (!field) return` guard is not decoration: editing an already-applied
+ * migration silently skips it (`_migrations` keys on filename), so every add
+ * and rename in this codebase is written idempotent.
+ *
+ * @param {core.App} app
+ * @param {string} collectionName
+ * @param {string} from
+ * @param {string} to
+ */
+function renameField(app, collectionName, from, to) {
+  const col = app.findCollectionByNameOrId(collectionName);
+  const field = col.fields.getByName(from);
+  if (!field) return; // idempotent: already renamed
+  field.name = to;
+  app.save(col);
+}
+
+migrate(
+  (app) => {
+    renameField(app, "lodging_units", "allocation_default", "inventory_class");
+  },
+  (app) => {
+    renameField(app, "lodging_units", "inventory_class", "allocation_default");
+  }
+);

--- a/scripts/dev/apply_lodging_inventory.py
+++ b/scripts/dev/apply_lodging_inventory.py
@@ -66,7 +66,7 @@ NULLABLE_FIELDS = ("max_beds",)
 # Never written by this script under any flag. These are the fields staff
 # maintain, and overwriting them is precisely what create-if-absent exists to
 # prevent.
-STAFF_OWNED = ("sleeps", "map_x", "map_y", "is_confirmed", "is_active", "allocation_default")
+STAFF_OWNED = ("sleeps", "map_x", "map_y", "is_confirmed", "is_active", "inventory_class")
 
 
 @dataclass

--- a/scripts/dev/lib/diff_lodging_registry.py
+++ b/scripts/dev/lib/diff_lodging_registry.py
@@ -60,7 +60,7 @@ def _diff_units(doc: dict[str, Any], db: sqlite3.Connection) -> list[str]:
         for r in db.execute(
             """
             SELECT u.code, u.name, a.code AS area_code, u.map_x, u.map_y, u.sleeps,
-                   u.bathroom, u.bathroom_group, u.near_bathhouse, u.allocation_default,
+                   u.bathroom, u.bathroom_group, u.near_bathhouse, u.inventory_class,
                    u.is_container, u.notes, p.code AS parent_code,
                    u.has_power, u.has_ac, u.has_fridge, u.is_accessible, u.has_heat,
                    u.is_weatherized, u.has_plumbing, u.has_space_heater,
@@ -90,7 +90,7 @@ def _diff_units(doc: dict[str, Any], db: sqlite3.Connection) -> list[str]:
             ("bathroom", w.get("bathroom") or "", g["bathroom"] or ""),
             ("bathroom_group", w.get("bathroom_group") or "", g["bathroom_group"] or ""),
             ("near_bathhouse", int(bool(w.get("near_bathhouse"))), int(g["near_bathhouse"] or 0)),
-            ("allocation_default", w.get("allocation_default") or "", g["allocation_default"] or ""),
+            ("inventory_class", w.get("inventory_class") or "", g["inventory_class"] or ""),
             ("is_container", int(bool(w.get("is_container"))), int(g["is_container"] or 0)),
             ("notes", w.get("notes") or "", g["notes"] or ""),
             ("parent_unit", w.get("parent_unit") or "", g["parent_code"] or ""),

--- a/scripts/dev/verify-lodging-schema.sh
+++ b/scripts/dev/verify-lodging-schema.sh
@@ -70,10 +70,21 @@ bt=$(field_prop lodging_units bathroom values || true)
 
 # 1500000136 renamed allocation_default. After 1500000135 the column is a ROLE,
 # not a default: "default" implied an override, and the override became a rare
-# per-weekend exception rather than the point. Asserted BOTH ways, because a
-# remove-and-add satisfies the first half while silently dropping all 114 values
-# — the new name is present either way, so only the old name's absence
-# distinguishes a rename from a drop-and-recreate.
+# per-weekend exception rather than the point.
+#
+# Both halves are asserted — new name present, old name gone — but be clear
+# about what that does NOT establish. This script runs against a FRESH, EMPTY
+# database, so a remove-and-add would satisfy both assertions exactly as an
+# in-place rename does, while discarding every stored value. Nothing here can
+# tell the two apart, and no assertion added to this script could: with no rows,
+# there is nothing to preserve.
+#
+# Value preservation is verified where rows actually exist, and that check
+# belongs to the migration's author rather than to this file: apply 1500000136
+# to a populated database and re-count by class before and after. Independently,
+# verify-lodging-seed.sh loads the private registry into a throwaway DB and
+# diffs it against the file field by field, which is what pins the JSON key, the
+# Go struct tag and the column name to each other.
 ic=$(field_prop lodging_units inventory_class values || true)
 [[ "$ic" == '["family_pool","staff_default"]' ]] || note "lodging_units.inventory_class values are $ic"
 old_ad=$(field_prop lodging_units allocation_default name || true)

--- a/scripts/dev/verify-lodging-schema.sh
+++ b/scripts/dev/verify-lodging-schema.sh
@@ -68,8 +68,17 @@ done
 bt=$(field_prop lodging_units bathroom values || true)
 [[ "$bt" == '["none","private","shared"]' ]] || note "lodging_units.bathroom values are $bt (expected [\"none\",\"private\",\"shared\"])"
 
-ad=$(field_prop lodging_units allocation_default values || true)
-[[ "$ad" == '["family_pool","staff_default"]' ]] || note "lodging_units.allocation_default values are $ad"
+# 1500000136 renamed allocation_default. After 1500000135 the column is a ROLE,
+# not a default: "default" implied an override, and the override became a rare
+# per-weekend exception rather than the point. Asserted BOTH ways, because a
+# remove-and-add satisfies the first half while silently dropping all 114 values
+# — the new name is present either way, so only the old name's absence
+# distinguishes a rename from a drop-and-recreate.
+ic=$(field_prop lodging_units inventory_class values || true)
+[[ "$ic" == '["family_pool","staff_default"]' ]] || note "lodging_units.inventory_class values are $ic"
+old_ad=$(field_prop lodging_units allocation_default name || true)
+[[ -z "$old_ad" ]] \
+  || note "lodging_units still carries allocation_default; 1500000136 renames it to inventory_class"
 
 # Amenity columns added by 1500000131 for the inventory seed. Asserted by TYPE,
 # because a bool written where a select belongs is the difference between

--- a/scripts/dev/verify-lodging-seed.sh
+++ b/scripts/dev/verify-lodging-seed.sh
@@ -104,7 +104,7 @@ n=$(q "SELECT COUNT(*) FROM lodging_units c JOIN lodging_units p ON c.parent_uni
 n=$(q "SELECT COUNT(*) FROM lodging_units WHERE is_container = 1")
 [[ "$n" -ge 1 ]] || note "expected at least one container unit, got $n"
 
-n=$(q "SELECT COUNT(*) FROM lodging_units WHERE allocation_default = 'staff_default'")
+n=$(q "SELECT COUNT(*) FROM lodging_units WHERE inventory_class = 'staff_default'")
 [[ "$n" -ge 1 ]] || note "expected at least one staff_default unit"
 
 # Every alias must resolve to at least one unit. A member set that came out

--- a/tests/setup/test_apply_lodging_inventory.py
+++ b/tests/setup/test_apply_lodging_inventory.py
@@ -87,7 +87,7 @@ _STAFF_OWNED_VALUES: dict[str, tuple[object, object]] = {
     "map_y": (0.9, 0.5),
     "is_confirmed": (True, False),
     "is_active": (False, True),
-    "allocation_default": ("staff_default", "family_pool"),
+    "inventory_class": ("staff_default", "family_pool"),
 }
 
 

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -36,7 +36,7 @@ def _unit(
     *,
     sleeps: int = 0,
     is_container: bool = False,
-    allocation_default: str = "family_pool",
+    inventory_class: str = "family_pool",
     is_active: bool = True,
     is_confirmed: bool = True,
     bathroom: str = "none",
@@ -50,7 +50,7 @@ def _unit(
         name=name,
         sleeps=sleeps,
         is_container=is_container,
-        allocation_default=allocation_default,
+        inventory_class=inventory_class,
         is_active=is_active,
         is_confirmed=is_confirmed,
         bathroom=bathroom,
@@ -490,7 +490,7 @@ class TestUnitsAndCounts:
             fetch_session=FAMILY_SESSION,
             fetch_units=[
                 _unit("u1", "ridge-a", "Ridge A", sleeps=5),
-                _unit("u2", "le-shack", "Le Shack", sleeps=4, allocation_default="staff_default"),
+                _unit("u2", "le-shack", "Le Shack", sleeps=4, inventory_class="staff_default"),
             ],
             fetch_availability=[_rec(unit="u1", family_available=False, note="Program director")],
         )
@@ -527,7 +527,7 @@ class TestUnitsAndCounts:
             fetch_session=FAMILY_SESSION,
             fetch_units=[
                 _unit("u1", "ridge-a", "Ridge A", sleeps=5),
-                _unit("u2", "aspen-lodge", "Aspen Lodge", allocation_default="staff_default"),
+                _unit("u2", "aspen-lodge", "Aspen Lodge", inventory_class="staff_default"),
             ],
         )
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
@@ -545,7 +545,7 @@ class TestUnitsAndCounts:
             fetch_session=FAMILY_SESSION,
             fetch_units=[
                 _unit("u1", "ridge-a", "Ridge A", sleeps=5),
-                _unit("u2", "aspen-lodge", "Aspen Lodge", sleeps=4, allocation_default="staff_default"),
+                _unit("u2", "aspen-lodge", "Aspen Lodge", sleeps=4, inventory_class="staff_default"),
             ],
             fetch_availability=[_rec(unit="u2", family_available=True, note="")],
         )
@@ -582,7 +582,7 @@ class TestUnitsAndCounts:
         repo = _repo(
             fetch_session=FAMILY_SESSION,
             fetch_units=[
-                _unit("u1", "manzanita-7", "New Trailer (Manzanitas)", sleeps=4, allocation_default="staff_default")
+                _unit("u1", "manzanita-7", "New Trailer (Manzanitas)", sleeps=4, inventory_class="staff_default")
             ],
             fetch_availability=[_rec(unit="u1", family_available=True, note="")],
         )
@@ -627,7 +627,7 @@ class TestUnitsAndCounts:
             fetch_session=FAMILY_SESSION,
             fetch_units=[
                 _unit("u1", "ridge-a", "Ridge A", sleeps=5, is_confirmed=True),
-                _unit("u2", "aspen-lodge", "Aspen Lodge", allocation_default="staff_default"),
+                _unit("u2", "aspen-lodge", "Aspen Lodge", inventory_class="staff_default"),
             ],
             count_unconfirmed_units=1,
         )

--- a/tests/unit/api/services/test_lodging_rules.py
+++ b/tests/unit/api/services/test_lodging_rules.py
@@ -47,7 +47,7 @@ class TestIsFamilyAvailable:
     """
 
     @pytest.mark.parametrize(
-        ("allocation_default", "override", "expected"),
+        ("inventory_class", "override", "expected"),
         [
             ("family_pool", None, True),
             ("family_pool", False, False),  # burst pipe
@@ -63,9 +63,9 @@ class TestIsFamilyAvailable:
         ],
     )
     def test_the_override_wins_and_the_role_decides_without_one(
-        self, allocation_default: str, override: bool | None, expected: bool
+        self, inventory_class: str, override: bool | None, expected: bool
     ) -> None:
-        assert is_family_available(allocation_default, override) is expected
+        assert is_family_available(inventory_class, override) is expected
 
     def test_false_is_a_decision_and_not_an_absent_override(self) -> None:
         """`False` and `None` are different answers on a family_pool unit.


### PR DESCRIPTION
Stage 4 of 4 — the last of the weekend lodging availability work. Stages 1–3 (#1993, #1995, #2001, #2002) are merged.

Closes #2000

## Why

After 1500000135 the column is a **role**, not a default. "Default" implies an override, and the override is now a rare per-weekend exception rather than the point: the column says whether a unit is planning inventory at all.

## The migration

`1500000136` renames **in place** via `col.fields.getByName()`, which keeps the field's ID so PocketBase emits `ALTER TABLE ... RENAME COLUMN`. Remove-and-add would have dropped every value silently — there are no filters naming this column, so nothing would have reported it.

Verified against the prod-seeded dev DB (114 rows):

| | before | after |
|---|---|---|
| `family_pool` | 92 | 92 |
| `staff_default` | 22 | 22 |

Old column confirmed gone. Kept the `if (!field) return` idempotency guard — editing an already-applied migration silently skips it, since `_migrations` keys on filename.

## Order of the sweep, and why the Go fixtures went first

Go fixtures build their own schema and never read `pb_migrations/`, so a stale `rec.Set()` on a renamed column is a **silent no-op** with no filter to error on it (kindred#1921). Renaming `registry_test.go` first made that failure loud before the source moved — it failed with `inventory_class = "", want family_pool`, which is exactly the production bug this ordering exists to catch.

Then `api/` → regenerate types → `frontend/`. The generated `types.gen.ts` diff is 2 lines and was produced by `npm run generate:api-types`, not hand-edited.

## Also in scope

- TS alias `AllocationDefaultValue` → `InventoryClassValue`, plus the local form state that read it.
- Both dev verifiers: `verify-lodging-schema.sh` (now asserts the new name present and the old one absent) and `verify-lodging-seed.sh`. **Correction from review:** an earlier version of this PR described the schema verifier as proving the rename preserved values. It does not, and cannot — it runs against a fresh, empty DB, where a remove-and-add satisfies both assertions exactly as a rename does. Preservation is established by the populated-DB check in the table above and by `verify-lodging-seed.sh`; the comment in the script now says so.
- `scripts/dev/apply_lodging_inventory.py`, `scripts/dev/lib/diff_lodging_registry.py`, and the two docs that name the column.
- **A matching commit in the private `kindred-local` registry** (114 keys). Without it the next inventory apply writes nothing and does not error. `SeedRegistry` is create-if-absent, so existing rows are unaffected by the ordering of the two commits; the exposure is limited to a newly added unit.

## Verification

| Check | Result |
|---|---|
| `verify-lodging-schema.sh` | OK (98 js migrations) |
| `verify-lodging-seed.sh` (end-to-end: private JSON → Go tag → migrated column, field-by-field) | OK (114 units, 141 aliases) |
| `pytest tests/` | 5932 passed, 23 skipped |
| `vitest run` | 5628 passed (405 files) |
| `tsc --noEmit` / `eslint src` / `npm run lint` | clean (0 errors) |
| `mypy api/` | Success, 83 files |
| `go build ./...` / `go test ./...` | pass |
| final `grep allocation_default` (go/py/ts/tsx, excl. generated) | **empty** |

## Deliberately NOT renamed

- `pb_migrations/1500000116_*.js` keeps the old name — applied migrations are frozen, and 1500000136 is what carries the change forward. The final grep excludes `.js` for this reason.
- `RosterCounts.units_missing_allocation` — a different field, and renaming it is an unrelated API break.
- The user-facing "Allocation" column header and form label — copy, not identifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Renamed the lodging classification field from `allocation_default` to `inventory_class` across lodging management, availability, sorting, maps, badges, and roster displays.
  * Existing staff and family availability behavior remains unchanged.
  * Database migration preserves existing classifications while applying the new field name.

* **Documentation**
  * Updated lodging architecture and registry references to describe inventory classification and supported values.

* **Tests**
  * Updated coverage and fixtures for the renamed classification field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
