### PR TITLE
feat(frontend): draw a multi-room party on every room it holds

### DIFF
--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -296,15 +296,18 @@ export function LodgingBoard({
               })
             )}
 
-            {/* A merge carries no unit code, and an assignment can name a
-              container or a unit absent from the payload. Those parties ARE
+            {/* An assignment can name a container, a unit absent from the
+              payload, or a merge whose every room is missing. Those parties ARE
               placed, so the queue would be a lie — and dropping them would make
               the board quietly disagree with the roster.
 
-              They are still draggable, and that is the point: dragging one
-              onto a room COLLAPSES the placement to that room, which is how a
-              multi-room party gets a card again. That is not merge-by-drag —
-              creating a merge needs #1940 first. */}
+              A merge whose rooms resolve is NOT here: since #1940 it is drawn
+              across each of them. What is left is the genuinely undrawable.
+
+              They are still draggable, and that is the point: dragging one onto
+              a room COLLAPSES the placement to that room. That is still not
+              merge-by-drag — creating a merge from the board is its own
+              decision. */}
             {board.offBoard.length > 0 && (
               <section>
                 <h3 className="text-muted-foreground mb-2 flex items-center gap-1.5 text-[11px] font-bold tracking-wider uppercase">

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -290,6 +290,107 @@ describe('buildBoard — where each party lands', () => {
   })
 })
 
+describe('buildBoard — a party across several rooms', () => {
+  /** Two rooms of one building, same area, both drawable. */
+  const twoRooms = [unit(), unit({ unit_id: 'u2', code: 'cedar-2', name: 'Cedar 2' })]
+
+  /**
+   * `unit_codes` is the authority on a multi-room placement — `unit_code` is
+   * deliberately `''` there, so it is the only field that survives the merge.
+   * Same definition `occupiedCodes` uses in `dragPlacement.ts`.
+   */
+  function merged(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
+    return party({
+      unit_code: '',
+      unit_name: 'Cedar 1 + Cedar 2',
+      unit_codes: ['cedar-1', 'cedar-2'],
+      is_merged_slot: true,
+      ...overrides,
+    })
+  }
+
+  it('draws the party on every room it holds, not on the off-board rail', () => {
+    const board = buildBoard([merged()], twoRooms)
+
+    expect(board.offBoard).toHaveLength(0)
+    expect(board.areas[0]?.slots.map((slot) => slot.parties.map((p) => p.display_name))).toEqual([
+      ['Johnson'],
+      ['Johnson'],
+    ])
+  })
+
+  it('counts a family holding four rooms as one family, not four', () => {
+    const fourRooms = [
+      unit(),
+      unit({ unit_id: 'u2', code: 'cedar-2', name: 'Cedar 2' }),
+      unit({ unit_id: 'u3', code: 'cedar-3', name: 'Cedar 3' }),
+      unit({ unit_id: 'u4', code: 'cedar-4', name: 'Cedar 4' }),
+    ]
+    const board = buildBoard(
+      [merged({ unit_codes: ['cedar-1', 'cedar-2', 'cedar-3', 'cedar-4'] })],
+      fourRooms
+    )
+
+    // The header reads "N rooms · M families". Four rooms, one family.
+    expect(board.areas[0]?.slots).toHaveLength(4)
+    expect(board.areas[0]?.partyCount).toBe(1)
+  })
+
+  it('prefers unit_codes over a stale unit_code', () => {
+    const board = buildBoard([merged({ unit_code: 'cedar-1' })], twoRooms)
+
+    const drawnOn = board.areas[0]?.slots
+      .filter((slot) => slot.parties.length > 0)
+      .map((slot) => slot.unit.code)
+    expect(drawnOn).toEqual(['cedar-1', 'cedar-2'])
+  })
+
+  it('keeps a party on the rooms that resolve when one code is missing', () => {
+    // Hiding a placed family because one room fell out of the payload is
+    // strictly worse than drawing it in the rooms we do know about.
+    const board = buildBoard([merged({ unit_codes: ['cedar-1', 'gone'] })], twoRooms)
+
+    expect(board.offBoard).toHaveLength(0)
+    expect(board.areas[0]?.slots.filter((slot) => slot.parties.length > 0)).toHaveLength(1)
+  })
+
+  it('still rails a merge that resolves to no room at all', () => {
+    const board = buildBoard([merged({ unit_codes: [] })], twoRooms)
+
+    expect(board.unplaced).toHaveLength(0)
+    expect(board.offBoard.map((p) => p.display_name)).toEqual(['Johnson'])
+  })
+
+  it('does not flag a family alone in its own rooms as a shared cabin', () => {
+    // `consentFlag` needs two parties in one slot. One family across two rooms
+    // is one party in each, and nothing to ask staff about.
+    expect(buildBoard([merged()], twoRooms).flaggedCount).toBe(0)
+  })
+
+  it('loses nobody, and counts each party once however many rooms it holds', () => {
+    const parties = [
+      merged(),
+      party({ household_cm_id: 102, display_name: 'Garcia' }),
+      party({
+        household_cm_id: 103,
+        display_name: 'Chen',
+        unit_code: 'cedar-2',
+        unit_name: 'Cedar 2',
+      }),
+    ]
+    const board = buildBoard(parties, twoRooms)
+
+    const placed = new Set(
+      board.areas
+        .flatMap((area) => area.slots)
+        .flatMap((slot) => slot.parties)
+        .map((p) => p.display_name)
+    )
+    const railed = [...board.unplaced, ...board.offBoard].map((p) => p.display_name)
+    expect(placed.size + railed.length).toBe(parties.length)
+  })
+})
+
 describe('buildBoard — consent flagging on ELIGIBILITY, not the gate', () => {
   /** A shared unit whose parties carry the given resolved eligibilities. */
   function shared(

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -13,11 +13,15 @@
  *    halves already report; drawing it double-counts them (408 against a true
  *    389). Owner-confirmed.
  * 2. **No party is ever dropped.** A party can be placed somewhere the board
- *    structurally cannot draw — a merge carries no `unit_code` at all, and an
- *    assignment can name a container or a unit absent from the payload. Those
- *    go to `offBoard`, never to the unplaced corner queue (they ARE placed) and
- *    never to nowhere. `buildBoard` is total: every input party comes out in
- *    exactly one of slots / unplaced / offBoard.
+ *    structurally cannot draw — an assignment naming a container, a unit absent
+ *    from the payload, or a merge whose every room is missing. Those go to
+ *    `offBoard`, never to the unplaced corner queue (they ARE placed) and never
+ *    to nowhere. `buildBoard` is total: every input party comes out in exactly
+ *    one of slots / unplaced / offBoard.
+ *
+ *    "Exactly one" is about the CATEGORY, not the slot. A party holding several
+ *    rooms is drawn on each of them, which is why an area's family count reads
+ *    distinct `partyKey`s rather than slot entries.
  */
 import type { LodgingUnitRow, RosterPartyRow, ShareEligibilityValue } from '../../types/lodging'
 import { partyKey } from './partyKey'

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -20,6 +20,25 @@
  *    exactly one of slots / unplaced / offBoard.
  */
 import type { LodgingUnitRow, RosterPartyRow, ShareEligibilityValue } from '../../types/lodging'
+import { partyKey } from './partyKey'
+
+/**
+ * The leaf codes a party currently occupies.
+ *
+ * `unit_codes` is the authority — it is the only field that survives a
+ * multi-room placement, where `unit_code` is deliberately `''`. The fallback
+ * exists for a payload predating that field rather than as a second opinion.
+ *
+ * Lives here, beside the grouping that consumes it, because `dragPlacement`
+ * reads it too and two answers would let the board draw one thing while a drop
+ * resolved against another.
+ */
+export function occupiedCodes(party: RosterPartyRow): string[] {
+  const codes = party.unit_codes ?? []
+  if (codes.length > 0) return codes
+  const single = party.unit_code ?? ''
+  return single.length > 0 ? [single] : []
+}
 
 /**
  * Area colour, §3.10 — a SECONDARY channel.
@@ -298,18 +317,24 @@ function indexPayload(parties: RosterPartyRow[], units: LodgingUnitRow[]) {
       unplaced.push(party)
       continue
     }
-    // A merge carries no unit code — the API sends the merge's display name
-    // instead — so there is no card to put it on, but it is placed all the
-    // same and the rail would be a lie.
-    const code = party.unit_code ?? ''
-    const unit = code.length > 0 ? leafByCode.get(code) : undefined
-    if (unit === undefined) {
+    // An unresolvable code is dropped rather than disqualifying the whole
+    // placement. A room missing from the payload should cost the family that
+    // room, not hide the family.
+    const codes = occupiedCodes(party).filter((code) => leafByCode.has(code))
+    // Placed, but on nothing this board can draw — a container, or a name the
+    // payload has no unit for. There is no card to put it on, but it IS placed
+    // and the unplaced rail would be a lie.
+    if (codes.length === 0) {
       offBoard.push(party)
       continue
     }
-    const bucket = partiesByCode.get(code)
-    if (bucket) bucket.push(party)
-    else partiesByCode.set(code, [party])
+    // A party holding several rooms appears on each of them. That is the point:
+    // rooms it occupies rendered empty is what sent staff to the wrong cabin.
+    for (const code of codes) {
+      const bucket = partiesByCode.get(code)
+      if (bucket) bucket.push(party)
+      else partiesByCode.set(code, [party])
+    }
   }
 
   // A deactivated room is not bookable, and staff housing was never planning
@@ -327,7 +352,10 @@ function indexPayload(parties: RosterPartyRow[], units: LodgingUnitRow[]) {
 export function buildBoard(parties: RosterPartyRow[], units: LodgingUnitRow[]): BoardModel {
   const { drawn, partiesByCode, unplaced, offBoard } = indexPayload(parties, units)
 
-  const buckets = new Map<string, { name: string; slots: BoardSlot[]; partyCount: number }>()
+  // `partyKeys` rather than a running total: a family holding four rooms sits
+  // on four slots, and the header says "families", not cards. Counting the
+  // slot entries would report four families standing where one is.
+  const buckets = new Map<string, { name: string; slots: BoardSlot[]; partyKeys: Set<string> }>()
   let flaggedCount = 0
   for (const unit of drawn) {
     const slotParties = partiesByCode.get(unit.code) ?? []
@@ -335,9 +363,13 @@ export function buildBoard(parties: RosterPartyRow[], units: LodgingUnitRow[]): 
     if (consent) flaggedCount += 1
 
     const key = areaKey(unit)
-    const bucket = buckets.get(key) ?? { name: areaName(unit), slots: [], partyCount: 0 }
+    const bucket = buckets.get(key) ?? {
+      name: areaName(unit),
+      slots: [],
+      partyKeys: new Set<string>(),
+    }
     bucket.slots.push({ unit, parties: slotParties, consent })
-    bucket.partyCount += slotParties.length
+    for (const slotParty of slotParties) bucket.partyKeys.add(partyKey(slotParty))
     buckets.set(key, bucket)
   }
 
@@ -357,7 +389,7 @@ export function buildBoard(parties: RosterPartyRow[], units: LodgingUnitRow[]): 
       name: bucket?.name ?? '',
       hue: AREA_HUES[index % AREA_HUES.length] ?? AREA_HUES[0],
       slots: bucket?.slots ?? [],
-      partyCount: bucket?.partyCount ?? 0,
+      partyCount: bucket?.partyKeys.size ?? 0,
     }
   })
 

--- a/frontend/src/components/weekend/dragPlacement.ts
+++ b/frontend/src/components/weekend/dragPlacement.ts
@@ -23,6 +23,7 @@
  * not carry, a container row, and a party carrying neither CampMinder id.
  */
 import type { LodgingUnitRow, RosterPartyRow, WeekendRoster } from '../../types/lodging'
+import { occupiedCodes } from './boardLayout'
 import { partyKey } from './partyKey'
 
 /**
@@ -90,20 +91,6 @@ export function partyGrainBody(party: RosterPartyRow): PartyGrainBody {
 /** Placed-ness, defined exactly as `buildBoard` defines it. Two answers here would split the board. */
 function isPlaced(party: RosterPartyRow): boolean {
   return (party.unit_name ?? '').length > 0
-}
-
-/**
- * The leaf codes a party currently occupies.
- *
- * `unit_codes` is the authority — it is the only field that survives a
- * multi-room placement, where `unit_code` is deliberately `''`. The fallback
- * exists for a payload predating that field rather than as a second opinion.
- */
-function occupiedCodes(party: RosterPartyRow): string[] {
-  const codes = party.unit_codes ?? []
-  if (codes.length > 0) return codes
-  const single = party.unit_code ?? ''
-  return single.length > 0 ? [single] : []
 }
 
 export interface ResolveDropArgs {

--- a/frontend/src/components/weekend/index.ts
+++ b/frontend/src/components/weekend/index.ts
@@ -12,7 +12,7 @@ export type { LodgingMapProps } from './LodgingMap'
 export { LodgingUnitCard } from './LodgingUnitCard'
 export { MapUnitPopover } from './MapUnitPopover'
 export { MedicalNarrative } from './MedicalNarrative'
-export { buildMapModel, countMapUnits, hasCoordinates, resolvePartyUnits } from './mapModel'
+export { buildMapModel, countMapUnits, hasCoordinates } from './mapModel'
 export type { MapModel, MapUnit, OffMapEntry, OffMapReason } from './mapModel'
 export { partyKey } from './partyKey'
 export {

--- a/frontend/src/components/weekend/mapModel.test.ts
+++ b/frontend/src/components/weekend/mapModel.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import { AREA_HUES } from './boardLayout'
-import { buildMapModel, countMapUnits, hasCoordinates, resolvePartyUnits } from './mapModel'
+import { buildMapModel, countMapUnits, hasCoordinates } from './mapModel'
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
   return {
@@ -94,26 +94,6 @@ describe('hasCoordinates', () => {
 
   it('accepts a genuine zero on one axis only', () => {
     expect(hasCoordinates(unit({ map_x: 0, map_y: 0.5 }))).toBe(true)
-  })
-})
-
-describe('resolvePartyUnits', () => {
-  const byCode = new Map([['cedar-1', unit()]])
-
-  it('returns nothing for an unplaced party', () => {
-    expect(resolvePartyUnits(party(), byCode)).toEqual([])
-  })
-
-  it('returns the one unit a placed party occupies', () => {
-    const got = resolvePartyUnits(party({ unit_code: 'cedar-1', unit_name: 'Cedar 1' }), byCode)
-    expect(got.map((u) => u.code)).toEqual(['cedar-1'])
-  })
-
-  it('returns nothing for a merged slot, which carries no unit code', () => {
-    // This is the ONLY place a party becomes units. When the API grows
-    // `unit_codes`, this function changes and nothing else does.
-    const merged = party({ unit_code: '', unit_name: 'Cedar 1 + Cedar 2', is_merged_slot: true })
-    expect(resolvePartyUnits(merged, byCode)).toEqual([])
   })
 })
 

--- a/frontend/src/components/weekend/mapModel.ts
+++ b/frontend/src/components/weekend/mapModel.ts
@@ -83,33 +83,6 @@ export function hasCoordinates(unit: LodgingUnitRow): boolean {
   return !(x === 0 && y === 0)
 }
 
-/**
- * The units a party occupies.
- *
- * NOT YET WIRED IN, deliberately. `buildMapModel` gets its party-to-unit
- * grouping from `buildBoard`, which groups on `unit_code` inside
- * `boardLayout.ts` — a file this PR must not edit. So today this function has
- * no caller but its own tests, and it is exported as the seam for one specific
- * change: when `RosterParty.unit_codes` lands (accepted by the merge-collapse
- * branch), a party can occupy SEVERAL rooms, `buildBoard`'s single-code
- * grouping stops being sufficient for positioning, and the map resolves units
- * here instead. Kept rather than deleted because that consumer is accepted and
- * in flight — unlike a seam whose consumer was cancelled, which should go.
- *
- * Do NOT hand-write `unit_codes` onto the row type ahead of the generated
- * types: a hand-written shape is how a surface starts silently disagreeing with
- * the API it reads.
- */
-export function resolvePartyUnits(
-  party: RosterPartyRow,
-  unitsByCode: Map<string, LodgingUnitRow>
-): LodgingUnitRow[] {
-  const code = party.unit_code ?? ''
-  if (code.length === 0) return []
-  const unit = unitsByCode.get(code)
-  return unit ? [unit] : []
-}
-
 function offMapReason(party: RosterPartyRow): OffMapReason {
   return party.is_merged_slot === true ? 'merged-slot' : 'not-on-board'
 }

--- a/frontend/src/components/weekend/mapModel.ts
+++ b/frontend/src/components/weekend/mapModel.ts
@@ -16,7 +16,12 @@ import { buildBoard, type ConsentFlag } from './boardLayout'
 
 /** Why the map cannot draw a party the board can. */
 export type OffMapReason =
-  /** On a merged slot, which carries no unit code and so no coordinate. */
+  /**
+   * On a merged slot the board could not resolve — every room it names is
+   * missing from the payload, so there is no coordinate to pin it to. A merge
+   * whose rooms DO resolve never reaches here: since #1940 it is drawn across
+   * each of them, and only off-board parties are given a reason at all.
+   */
   | 'merged-slot'
   /** The board could not draw it either — a container, or a unit not in the payload. */
   | 'not-on-board'

--- a/frontend/src/pages/WeekendRosterPage.test.tsx
+++ b/frontend/src/pages/WeekendRosterPage.test.tsx
@@ -225,9 +225,12 @@ describe('header', () => {
     await userEvent.click(screen.getByRole('button', { name: /Family Camp 1/ }))
     await userEvent.click(await screen.findByRole('option', { name: "Women's Weekend" }))
     // ANCHORED: `/weekend/ww` is a prefix of every tab under that weekend, so
-    // an unanchored match cannot tell the roster from the map and would pass
+    // an unanchored match cannot tell one tab from another and would pass
     // whatever the tab-carrying test below asserts.
-    expect(screen.getByTestId('location')).toHaveTextContent(/^\/weekend\/ww\/roster$/)
+    //
+    // `housing` because the switch carries the tab you are on, and this page
+    // opened on the default.
+    expect(screen.getByTestId('location')).toHaveTextContent(/^\/weekend\/ww\/housing$/)
   })
 
   it('stays on the tab you are looking at when you switch weekends', async () => {
@@ -345,10 +348,13 @@ describe('the view in the URL', () => {
     expect(screen.getByText('Ridge A')).toBeInTheDocument()
   })
 
-  it('opens the roster when the URL names no view', () => {
+  it('opens Housing when the URL names no view', () => {
+    // The tab strip already leads with Housing, as summer leads with Bunks.
+    // Landing on the second tab made the lead tab a click away from the thing
+    // staff came to do.
     rosterQuery.data = ONE_UNIT
     renderPage()
-    expect(screen.getByRole('tab', { name: /Roster/ })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('tab', { name: /Housing/ })).toHaveAttribute('aria-selected', 'true')
   })
 
   it('puts the chosen view in the URL', async () => {
@@ -382,27 +388,36 @@ describe('the view in the URL', () => {
     expect(screen.getByTestId('location')).toHaveTextContent('/weekend/sessions')
   })
 
-  it('falls back to the roster when the URL names a view that does not exist', () => {
+  it('falls back to Housing when the URL names a view that does not exist', () => {
     // A stale bookmark, or a typo. Rendering nothing would read as a broken
-    // page; the roster is the honest default.
+    // page; the landing view is the honest default. Same constant as the
+    // no-segment case — deliberately, so a typo cannot land somewhere a fresh
+    // visit never would.
     rosterQuery.data = ONE_UNIT
     renderPage('1000001', 'gantt')
-    expect(screen.getByRole('tab', { name: /Roster/ })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('tab', { name: /Housing/ })).toHaveAttribute('aria-selected', 'true')
   })
 
-  it('no longer answers to `board`, the segment Housing replaced', () => {
-    // The rename took the URL with it, deliberately and without a redirect —
-    // this surface is young enough that a stale link is cheaper than a
-    // permanent alias. Pinned so the fallback is a DECISION rather than
-    // something discovered later by a staff member with a bookmark.
+  it('still does not answer to `board`, though the default now lands where it pointed', () => {
+    // The rename took the URL with it, deliberately and without a redirect.
+    //
+    // ASSERTING THE RENDERED TAB WOULD NO LONGER TEST THIS. `board` is an
+    // unrecognised segment, so it falls to the default — and the default is now
+    // Housing, the very tab `board` used to name. A tab assertion would pass
+    // whether or not an alias existed, which is a test that pins nothing.
+    //
+    // What still tells them apart is the URL: an alias would rewrite it to
+    // `/housing`, and a fallback leaves the stale segment exactly where the
+    // bookmark put it. That a stale link now lands on the right content is a
+    // happy side effect of the default, not a route.
     rosterQuery.data = ONE_UNIT
     renderPage('1000001', 'board')
-    expect(screen.getByRole('tab', { name: /Roster/ })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByTestId('location')).toHaveTextContent('/weekend/1000001/board')
   })
 })
 
 describe('tabs', () => {
-  it('opens on the roster and offers the inventory beside it', async () => {
+  it('opens on Housing and offers the inventory beside it', async () => {
     rosterQuery.data = {
       year: 2026,
       session_cm_id: 1000001,
@@ -424,12 +439,14 @@ describe('tabs', () => {
     }
     renderPage()
 
-    expect(screen.getByRole('tab', { name: /Roster/ })).toHaveAttribute('aria-selected', 'true')
-    // The inventory is a tab away, not further down the same scroll.
-    expect(screen.queryByText('Ridge A')).not.toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /Housing/ })).toHaveAttribute('aria-selected', 'true')
+    // The inventory is a tab away, not further down the same scroll. Housing
+    // names the same unit, so the unit name no longer tells the two apart —
+    // the panel's own heading does.
+    expect(screen.queryByText('Lodging inventory')).not.toBeInTheDocument()
 
     await userEvent.click(screen.getByRole('tab', { name: /Inventory/ }))
-    expect(screen.getByText('Ridge A')).toBeInTheDocument()
+    expect(screen.getByText('Lodging inventory')).toBeInTheDocument()
   })
 
   it('leads with Housing and counts what each tab holds, as summer does', () => {

--- a/frontend/src/pages/WeekendRosterPage.tsx
+++ b/frontend/src/pages/WeekendRosterPage.tsx
@@ -78,7 +78,16 @@ const VIEWS: View[] = ['housing', 'roster', 'map', 'inventory']
  * roster is what you actually came to look at. Revisit when weekends become
  * editable.
  */
-const DEFAULT_VIEW: View = 'roster'
+/**
+ * Housing, not the roster: the tab strip already leads with it, as summer's
+ * leads with Bunks, and placing families is what staff open a weekend to do.
+ * Landing on the second tab put the lead tab one click away from the work.
+ *
+ * `parseView` uses this for an unrecognised segment as well as a missing one,
+ * deliberately — a typo should land where a fresh visit lands, not somewhere
+ * else again.
+ */
+const DEFAULT_VIEW: View = 'housing'
 
 /**
  * The view is a URL segment, as the analytics sub-navs are — `/analytics/

--- a/frontend/src/pages/WeekendRosterPage.tsx
+++ b/frontend/src/pages/WeekendRosterPage.tsx
@@ -63,21 +63,18 @@ import type { LodgingUnitRow } from '../types/lodging'
  * COMPONENT stays `LodgingBoard`, exactly as summer's Bunks tab renders
  * `BunkingBoardByArea`: the board is still a board internally.
  *
- * The rename took the URL with it and left no alias, so a `/board` link now
- * falls back to the roster. Deliberate — the surface is young, and a permanent
- * redirect for a segment that lived a few weeks is a cost paid forever.
+ * The rename took the URL with it and left no alias, so a `/board` link just
+ * falls through to `DEFAULT_VIEW`. Deliberate — the surface is young, and a
+ * permanent redirect for a segment that lived a few weeks is a cost paid
+ * forever. That the default is now Housing, the very tab `board` used to name,
+ * is a happy accident rather than a route: the URL is left exactly as the
+ * bookmark wrote it.
  */
 type View = 'roster' | 'inventory' | 'housing' | 'map'
 
 /** Tab order. `DEFAULT_VIEW` is a separate choice — see below. */
 const VIEWS: View[] = ['housing', 'roster', 'map', 'inventory']
 
-/**
- * NOT the first tab, deliberately. Summer opens on its board because the board
- * is where its work happens; a weekend's placements are still read-only, so the
- * roster is what you actually came to look at. Revisit when weekends become
- * editable.
- */
 /**
  * Housing, not the roster: the tab strip already leads with it, as summer's
  * leads with Bunks, and placing families is what staff open a weekend to do.


### PR DESCRIPTION
Closes #1940.

## The bug

A family holding a whole building was drawn **nowhere**. `indexPayload` grouped on the single `unit_code`, which a merge deliberately sends as `''`, so the placement fell to the "Placed outside the board" rail — while every room it occupied rendered as an **empty, droppable card**.

The count was the visible symptom; the empty rooms were the expensive one. An area with four rooms held by one family and six held by six others read as `12 rooms · 6 families`, with the two largest families invisible and six occupied rooms looking available.

Roughly 12–16 multi-room placements a year.

## What changed

`unit_codes` is the authority on a multi-room placement, and `dragPlacement` has read it since drag shipped — only the render path had not caught up. `occupiedCodes` moves into `boardLayout` and both read one definition, the same reason `isPlaced` already carries a comment about two answers splitting the board.

- **An unresolvable code is dropped, not disqualifying.** A room missing from the payload costs the family that room; it does not hide the family. A merge resolving to no room at all still rails, unchanged.
- **`partyCount` counts distinct `partyKey`s**, not slot entries — the area header says "families", and a family in four rooms is one family. Mutation-checked: reverting it to a running total fails the test.
- **Room count untouched.** It counts drawn rooms, honest either way.
- **`flaggedCount` needs no change.** `consentFlag` requires two parties in a slot, so a family alone in its own rooms cannot flag. It does gain a true positive — a merged party can now *be* the second party in a genuinely shared room, which it structurally could not before.
- **The map gets this for free.** `buildMapModel` derives from `buildBoard`.

## `resolvePartyUnits` deleted

It was the declared seam for this change, but its docstring assumed the map would resolve units itself. Since `buildMapModel` derives from `buildBoard`, fixing the shared grouping covers both surfaces and the seam never gains its caller. Leaving it dangling a second time would be worse than the first.

## Also: the default tab is Housing

The tab strip already leads with Housing, as summer leads with Bunks — but the page opened on Roster, putting the lead tab one click from the work.

One test changes what it asserts, deliberately. `board` (the segment Housing replaced) is unrecognised, so it falls through to the default — which is now the very tab it used to name. A tab assertion there would pass whether or not an alias existed. It now asserts the **URL is not rewritten**, which is what still distinguishes a fallback from a route.

## Verification

- `npx vitest run` — **405 files, 5632 tests, all passing**
- `npx tsc --noEmit` — clean
- `eslint` on changed files — 0 errors. The one `dragPlacement` warning is pre-existing on `main` (line 213 there)
- Pre-push: ruff, mypy (796 files), go build, api-types freshness, full pytest — all green

## Not in this PR

- #1982 (credit a whole-house merge as a private bathroom) — unblocked by this, but a separate decision about what `settled` means
- #2007 / #2008 / #2009 — the `parent_unit` payload field and the whole-building signal and count that ride on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Housing is now the default weekend roster view.
  * Weekend switching preserves the active view, while invalid or missing views fall back to Housing.
  * Multi-room party placements now render across all resolved rooms and remain accurately counted once.

* **Bug Fixes**
  * Improved handling of partially resolved and off-board assignments.
  * Prevented stale room data from overriding current multi-room placement information.
  * Corrected false shared-cabin indicators and party counts across roster areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->