### PR TITLE
fix(frontend): announce the capacity advisory, not just draw it

### DIFF
--- a/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
@@ -479,6 +479,57 @@ describe('LodgingUnitForm — capacity flag', () => {
     expect(screen.getByRole('button', { name: 'Use suggested' })).toBeInTheDocument()
   })
 
+  it('keeps the live region mounted even with nothing to announce', () => {
+    // THE LOAD-BEARING ONE. A live region is only announced when its contents
+    // change while it is ALREADY in the document. Rendering the region and its
+    // text together — the obvious one-liner — is missed by several screen
+    // readers, so the region has to outlive the advisory it carries. A unit
+    // with nothing to say is exactly the state a staffer is in just BEFORE
+    // typing the number that creates the conflict.
+    renderUnit({ ...BUNKED, sleeps: 3 })
+
+    const region = screen.getByRole('status')
+    expect(region).toBeInTheDocument()
+    expect(region).toHaveAttribute('aria-live', 'polite')
+    expect(region).toHaveTextContent('')
+  })
+
+  it('announces the conflict rather than only drawing it', () => {
+    // Focus stays in the Sleeps field when this appears, so without a live
+    // region a screen-reader user is never told. The flag's whole job is to be
+    // noticed; drawing it in amber does that for one class of user only.
+    renderUnit(CONFLICTED)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Beds account for 4, but sleeps says 8.')
+  })
+
+  it('announces the suggestion too', () => {
+    renderUnit({ ...BUNKED, sleeps: 0 })
+
+    expect(screen.getByRole('status')).toHaveTextContent(/Suggested: sleeps 4/i)
+  })
+
+  it('carries the conflict once, not as a second hidden copy', () => {
+    // The other obvious implementation is an sr-only duplicate beside the
+    // visible text. It makes anyone navigating the form linearly meet the same
+    // sentence twice, so the region WRAPS the visible text instead.
+    renderUnit(CONFLICTED)
+
+    expect(screen.getAllByText(/beds account for 4/i)).toHaveLength(1)
+  })
+
+  it('leaves the conflict readable on mount, not only when it changes', () => {
+    // A live region announces on CHANGE and never on mount. Hiding the visible
+    // text in favour of an sr-only announcement therefore reports an ALREADY
+    // conflicting unit to nobody — the staffer who opens the form rather than
+    // creating the conflict by typing gets silence and an invisible warning.
+    renderUnit(CONFLICTED)
+
+    const text = screen.getByText(/beds account for 4, but sleeps says 8/i)
+    expect(text).not.toHaveAttribute('aria-hidden')
+    expect(screen.getByRole('status')).toContainElement(text)
+  })
+
   it('never shows the sheet capacity, which is not a corroborating number', () => {
     // The Master Housing `Capacity` column agrees with the bed count on only
     // 42 of the 88 units carrying both, and sits BELOW the physical bed count

--- a/frontend/src/components/admin/lodging/UnitCapacityFields.tsx
+++ b/frontend/src/components/admin/lodging/UnitCapacityFields.tsx
@@ -70,31 +70,48 @@ export function UnitCapacityFields({
             onChange({ ...value, beds })
           }}
         />
-        {flag.kind === 'suggestion' && (
-          <div className="text-muted-foreground mt-1.5 flex items-center gap-2 text-xs">
-            <span>Suggested: sleeps {flag.derived}</span>
-            <button
-              type="button"
-              onClick={() => {
-                onChange({ ...value, sleeps: String(flag.derived) })
-              }}
-              className="text-primary font-medium hover:underline"
-            >
-              Use suggested
-            </button>
-          </div>
-        )}
+        {/* ALWAYS MOUNTED, and that is the whole point: a live region is only
+            announced when its contents change while it is ALREADY in the
+            document. Rendering the region together with its text — the obvious
+            one-liner — is missed by several screen readers, so this one has to
+            outlive the advisory it carries.
 
-        {/* Deliberately no button. Settling this means knowing whether there
-            is a mattress on the floor, which is a walk to the cabin, not a
-            click — and half of these are +1, where the likeliest explanation
-            is a family doubling up and the staff number being right. So it
-            states both numbers and asks nothing. */}
-        {flag.kind === 'conflict' && (
-          <p className="mt-1.5 text-xs text-amber-700 dark:text-amber-400">
-            Beds account for {flag.derived}, but sleeps says {flag.sleeps}.
-          </p>
-        )}
+            It WRAPS the visible text rather than duplicating it into an
+            sr-only copy. Two copies would be read twice by anyone navigating
+            the form linearly, and hiding the visible one is worse still: a
+            region announces on CHANGE, never on mount, so a form opened on an
+            existing conflict would then report it to nobody at all.
+
+            The button lives inside, which is the one compromise. Keeping it
+            out would mean breaking the text and its action onto separate rows;
+            the cost is that the announcement ends with the control's label. */}
+        <div role="status" aria-live="polite">
+          {flag.kind === 'suggestion' && (
+            <div className="text-muted-foreground mt-1.5 flex items-center gap-2 text-xs">
+              <span>Suggested: sleeps {flag.derived}</span>
+              <button
+                type="button"
+                onClick={() => {
+                  onChange({ ...value, sleeps: String(flag.derived) })
+                }}
+                className="text-primary font-medium hover:underline"
+              >
+                Use suggested
+              </button>
+            </div>
+          )}
+
+          {/* Deliberately no button. Settling this means knowing whether there
+              is a mattress on the floor, which is a walk to the cabin, not a
+              click — and half of these are +1, where the likeliest explanation
+              is a family doubling up and the staff number being right. So it
+              states both numbers and asks nothing. */}
+          {flag.kind === 'conflict' && (
+            <p className="mt-1.5 text-xs text-amber-700 dark:text-amber-400">
+              Beds account for {flag.derived}, but sleeps says {flag.sleeps}.
+            </p>
+          )}
+        </div>
 
         {/* The Master Housing sheet's `Capacity` column is deliberately NOT
             shown beside these. It reads as a corroborating third number and is


### PR DESCRIPTION
## The gap

The capacity conflict and suggestion are plain elements React inserts as state changes. Focus stays in the Sleeps field and no element the user occupies changes, so assistive technology has nothing to report.

> A staffer editing a unit types `8` into Sleeps. "Beds account for 4, but sleeps says 8" appears an inch below their cursor. Focus never moved, so nothing is spoken. They tab to Save and commit a number the beds cannot account for — having been "warned."

Pre-existing: the suggestion line has carried this since #2006, and the conflict added in #2014 inherited it.

## Why the obvious fixes are both wrong

This is the whole reason the diff isn't a one-liner.

**`role="status"` on the conditionally-rendered paragraph** inserts the region *and* its text in the same commit. A live region is announced when its contents change while it is **already in the document**, so several screen readers miss this entirely. The region has to outlive the advisory it carries.

**An `sr-only` duplicate beside the visible text** is met twice by anyone navigating the form linearly. And hiding the visible copy in favour of the announcement is worse still — a region announces on *change*, never on *mount*, so a form **opened** on an existing conflict would report it to nobody at all. That one I wrote, caught, and reverted; it's now pinned by a test.

## What this does

A permanently-mounted region that **wraps** the visible advisory rather than duplicating it:

```tsx
<div role="status" aria-live="polite">
  {flag.kind === 'suggestion' && (…)}
  {flag.kind === 'conflict' && (…)}
</div>
```

One copy of the text, present on mount, announced on change. Matches the pattern already used six times in this codebase, closest to `GraphFilterStatus.tsx:22`.

The "Use suggested" button sits inside the region — the one compromise. Keeping it out would break the text and its action onto separate rows, and the cost is only that the announcement ends with the control's label.

## Testing

Four cases, each written failing first:

- **the load-bearing one** — the region stays mounted with *nothing* to announce, which is exactly the state a staffer is in just before typing the number that creates the conflict
- the conflict and the suggestion each reach the region
- the conflict appears **once**, not as a second hidden copy
- the visible conflict is not `aria-hidden`, so a form opened on an existing conflict is still readable

**Mutation-checked** — three ways of getting this wrong, each caught by its own test and nothing else:

| Mutation | Caught by |
|---|---|
| no live region (today's `main`) | 4 tests |
| region rendered only when there's something to say | the load-bearing test, alone |
| `sr-only` duplicate instead of wrapping | the duplication + on-mount tests |

Full lodging suite green, `tsc --noEmit` clean.

## Not verified

Not tested against a real screen reader. The reasoning is from ARIA semantics plus the fact that nothing in the current markup is *capable* of announcing anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)