### PR TITLE
fix(frontend): a unit with four-decimal map coordinates can be saved again

### DIFF
--- a/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
@@ -640,13 +640,26 @@ describe('LodgingUnitForm — map coordinates', () => {
     expect(y.validity.stepMismatch).toBe(false)
   })
 
-  it('still refuses a coordinate outside the 0–1 fraction of the image', () => {
-    // Loosening `step` must not loosen the range: these are a fraction of the
+  it('still refuses a coordinate outside the 0–1 fraction of the image', async () => {
+    // Loosening `step` must not loosen the RANGE: these are a fraction of the
     // map image, and the column itself is min 0 / max 1.
+    //
+    // Asserted through the validity state rather than the attributes, because
+    // `min="0"` being spelled correctly is not the property that matters — the
+    // browser acting on it is, and that is the same mechanism `step` broke.
+    // Both axes, since they are separate inputs that have already drifted once.
+    const user = userEvent.setup()
     renderUnit({ ...UNIT, map_x: 0.4389, map_y: 0.3311 })
 
     const x = screen.getByLabelText<HTMLInputElement>('Map X')
-    expect(x).toHaveAttribute('min', '0')
-    expect(x).toHaveAttribute('max', '1')
+    const y = screen.getByLabelText<HTMLInputElement>('Map Y')
+
+    await user.clear(x)
+    await user.type(x, '2')
+    expect(x.validity.rangeOverflow).toBe(true)
+
+    await user.clear(y)
+    await user.type(y, '-1')
+    expect(y.validity.rangeUnderflow).toBe(true)
   })
 })

--- a/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
@@ -611,3 +611,42 @@ describe('LodgingUnitForm — an undeliverable code', () => {
     expect(payload.code).toBe('north-wing')
   })
 })
+
+describe('LodgingUnitForm — map coordinates', () => {
+  const renderUnit = (unit: LodgingUnitRecord) =>
+    render(
+      <LodgingUnitForm
+        areas={AREAS}
+        units={[unit]}
+        unit={unit}
+        onSaved={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+  it('accepts the four-decimal coordinates the placement tool actually stores', () => {
+    // 62 of the 114 units carry map coordinates to FOUR places. A `step` of
+    // 0.001 makes every one of them a stepMismatch, and the browser then
+    // refuses to submit the WHOLE form — so a staffer cannot confirm amenities
+    // on one of those cabins without first hand-truncating a coordinate they
+    // never meant to touch, silently moving the unit on the map.
+    renderUnit({ ...UNIT, map_x: 0.4389, map_y: 0.3311 })
+
+    const x = screen.getByLabelText<HTMLInputElement>('Map X')
+    const y = screen.getByLabelText<HTMLInputElement>('Map Y')
+
+    expect(x).toHaveValue(0.4389)
+    expect(x.validity.stepMismatch).toBe(false)
+    expect(y.validity.stepMismatch).toBe(false)
+  })
+
+  it('still refuses a coordinate outside the 0–1 fraction of the image', () => {
+    // Loosening `step` must not loosen the range: these are a fraction of the
+    // map image, and the column itself is min 0 / max 1.
+    renderUnit({ ...UNIT, map_x: 0.4389, map_y: 0.3311 })
+
+    const x = screen.getByLabelText<HTMLInputElement>('Map X')
+    expect(x).toHaveAttribute('min', '0')
+    expect(x).toHaveAttribute('max', '1')
+  })
+})

--- a/frontend/src/components/admin/lodging/UnitMapFields.tsx
+++ b/frontend/src/components/admin/lodging/UnitMapFields.tsx
@@ -5,6 +5,17 @@
  * is where "is this family next to a bathhouse" gets answered (spec §7.2b).
  * Blank means unplaced, and an unplaced unit submits no coordinate at all
  * rather than pinning itself to the map's top-left corner.
+ *
+ * `step="any"` IS THE FIX FOR A REAL BUG, not a loosening. A numeric `step`
+ * makes the browser reject any value that is not a multiple of it, and that
+ * rejection blocks submission of the WHOLE form. These coordinates come from a
+ * placement pass, not from typing: 62 of the 114 units carry four decimal
+ * places, so a step of 0.001 made the majority of units unsavable — a staffer
+ * could not confirm a cabin's amenities without first truncating a coordinate
+ * they never meant to touch, which silently moves the unit on the map.
+ *
+ * `min`/`max` stay: the range is a real constraint the column shares, and it
+ * is the precision grid that was wrong, never the bounds.
  */
 import { FIELD, LABEL, SECTION } from './lodgingStyles'
 
@@ -28,7 +39,7 @@ export function UnitMapFields({ value, onChange }: UnitMapFieldsProps) {
         <input
           className={FIELD}
           type="number"
-          step="0.001"
+          step="any"
           min={0}
           max={1}
           value={value.x}
@@ -44,7 +55,7 @@ export function UnitMapFields({ value, onChange }: UnitMapFieldsProps) {
         <input
           className={FIELD}
           type="number"
-          step="0.001"
+          step="any"
           min={0}
           max={1}
           value={value.y}


### PR DESCRIPTION
## The bug

`UnitMapFields` set `step="0.001"` on both coordinate inputs. A numeric `step` makes the browser reject any value that isn't a multiple of it, and that rejection blocks submission of the **whole form** — not just the field.

The coordinates come from a placement pass, not from typing, and they're stored to four decimals:

| Decimal places in `map_x` | Units |
|---|---:|
| 1 | 3 |
| 2 | 10 |
| 3 | 39 |
| **4** | **62** |

So **62 of 114 units could not be saved from the edit form at all** — every `ridge-*` cabin among them (`0.4389`, `0.3311`…). Confirming a cabin's amenities first required hand-truncating a coordinate nobody meant to touch, which silently moves the unit on the map.

Found by hitting it on one unit in local dev. The query says it's on the majority.

## The fix

`step="any"`, which removes the precision grid.

`min`/`max` stay. The 0–1 range is a real constraint the column shares (`min: 0, max: 1, onlyInt: false` in `1500000116`) — it was never the bounds that were wrong, only the grid imposed on top of them.

## Testing

jsdom implements the same constraint validation the browser does, so this is testable directly rather than by asserting on the attribute:

```js
expect(x).toHaveValue(0.4389)
expect(x.validity.stepMismatch).toBe(false)   // was true
```

A second test pins `min`/`max`, so a future "fix" that loosens the range along with the step fails.

**Mutation-checked** — restoring the numeric step, and dropping `min`/`max` while fixing step, each fail their own test and nothing else.

Full lodging suite green (155), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Map coordinate fields now accept values with more than three decimal places.
  * Coordinate inputs continue to enforce values between 0 and 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->