### PR TITLE
style(frontend)!: the family lodging board adopts summer's chrome, type scale and grid

### DIFF
--- a/docs/reference/lodging-board-vs-summer.md
+++ b/docs/reference/lodging-board-vs-summer.md
@@ -1,0 +1,322 @@
+# The family lodging board, measured against summer
+
+A working comparison of the weekend/family lodging board
+(`frontend/src/components/weekend/`) against the summer bunking board
+(`frontend/src/components/`), row by row, under CLAUDE.md §4 **"Family Camp
+Models Summer"**.
+
+This is a **working document**, not a changelog. Rewrite the status column as
+rows close; do not append history. It exists so the next session does not
+re-measure what has already been measured, and does not re-open decisions that
+have already been settled with a reason.
+
+Every number here was measured in a browser at a **1600px viewport**, where the
+board area is **1188px**, against the real 2026 registry: 82 rooms, 8 areas, 62
+parties, 28 empty rooms. Numbers are restated when the layout changes underneath
+them — several already have been.
+
+**Read `frontend/CLAUDE.md` and CLAUDE.md §4 first.** This document assumes
+both.
+
+---
+
+## Why measure at all
+
+Two of the findings below could not have been reached by reading code, and both
+had already been asserted wrongly from a careful reading:
+
+- `hover:shadow-lodge-lg` **does nothing**, on this board or summer's. See
+  kindred#2027.
+- Widening the grid does **not** unwrap the amenity row, though it looks like
+  it must.
+
+Assert nothing about rendered output without rendering it. jsdom parses no
+Tailwind, so a `toHaveStyle` assertion on a Tailwind class passes against an
+empty string and proves nothing — pin **classes** in vitest and measure
+**computed values** in a browser.
+
+---
+
+## 1. Card chrome and geometry — CLOSED
+
+| Dimension  | Summer                   | Family                       | Status           |
+| ---------- | ------------------------ | ---------------------------- | ---------------- |
+| Base class | `.card-lodge`            | `.card-lodge`                | done             |
+| Radius     | `rounded-2xl` (16px)     | same                         | done             |
+| Border     | `border-2 border-border` | same, + `border-t-[3px]` hue | done             |
+| Shadow     | two-layer lodge          | same                         | done             |
+| Padding    | `p-4` (16px)             | `p-4`                        | done             |
+| Row rhythm | `mb-3` (12px)            | `gap-3`                      | done             |
+| Hover      | `.card-lodge:hover`      | `.card-lodge:hover`          | done — see below |
+
+**Hover is deliberately NOT matched class-for-class.** `BunkCard` carries
+`hover:shadow-lodge-lg`; this card does not, and `LodgingUnitCard.test.tsx` pins
+that as an absence.
+
+`.shadow-lodge-sm` / `.shadow-lodge` / `.shadow-lodge-lg` / `.shadow-lodge-xl`
+are hand-written rules inside `@layer utilities` in `index.css`, not Tailwind v4
+`@utility` declarations. Tailwind cannot build a variant from a plain CSS class,
+so it emits nothing for `hover:shadow-lodge-*`. A sweep of all 3,373 loaded
+rules found **no selector matching `hover.*shadow-lodge`**. Nine usages across
+the codebase are inert, plus three of an undefined `shadow-lodge-md`. Filed as
+**kindred#2027**.
+
+Both cards' hover lift comes entirely from `.card-lodge:hover`, whose shadow
+(`0 12px 32px`) is the deeper of the two anyway.
+
+> When sweeping `document.styleSheets`, test `selectorText` **before** recursing
+> into `cssRules`. Under nested-CSS support `CSSStyleRule.cssRules` is a truthy
+> empty list, so an `if (r.cssRules) … else if (r.selectorText)` walk silently
+> visits zero style rules. That produced a false negative on the first pass here.
+
+## 2. Type scale — CLOSED
+
+Summer uses three steps of the stock scale. The family board was built on
+arbitrary bracket literals whose **largest** size was smaller than summer's
+**body**.
+
+| Slot               | Summer           | Family before | Family now |
+| ------------------ | ---------------- | ------------- | ---------- |
+| Unit title         | `text-lg` (18px) | `text-[13px]` | `text-lg`  |
+| Capacity figure    | `text-sm`        | `text-[11px]` | `text-sm`  |
+| Card body          | `text-sm`        | `text-[11px]` | `text-sm`  |
+| Badges, chips      | `text-xs`        | `text-[10px]` | `text-xs`  |
+| Occupant name      | `text-sm`        | `text-[13px]` | `text-sm`  |
+| Occupant secondary | `text-xs`        | `text-[11px]` | `text-xs`  |
+
+The occupant card steps **down** from the unit card, as `CamperCard` does from
+`BunkCard`. It does not inherit the unit card's body size, or the household name
+would print as large as the room holding it.
+
+`UnitAvailabilityControl` renders inside the card and is part of its scale — a
+10px pill in a 14px meta row is the same bug. A sweep test fails on any
+`text-[Npx]` anywhere inside either card, because a single arbitrary size left
+on a nested row is invisible in a spot check and is how the two scales diverged
+in the first place.
+
+**The typeface was the larger half of this row, and it is not a size at all.**
+`index.css` sets `h1, h2, h3 { font-family: var(--font-display) }` — Fraunces,
+`-0.02em`, `ss01`/`ss02`. Summer titles its bunk in an `<h3>` and gets it; this
+card used a `<span>` and rendered the same 18px in the body sans. The tag was
+doing typographic work, not only semantic work. Now `<h3>`, measured at
+18px/600/−0.27px with `ss01`+`ss02` on all 82 cards. `text-lg` is a utility and
+outranks the base rule's `text-2xl md:text-3xl`, so only the face and tracking
+carry over.
+
+## 3. What the card reports — OPEN
+
+| Row                  | Summer                           | Family                          | Status             |
+| -------------------- | -------------------------------- | ------------------------------- | ------------------ |
+| Occupancy figure     | `{occupancy}/{capacity}`         | bare `sleeps`, `—` when unknown | open — package B   |
+| Colour ramp          | 4 stops                          | none                            | open — package B   |
+| Utilization bar      | `BunkUtilizationBar`             | absent                          | open — package B   |
+| Over-capacity chrome | `border-destructive/50 border-2` | none                            | open — package B   |
+| Empty state wording  | "Drop campers here"              | "Drop families here" / "Empty"  | **done**           |
+| Empty state geometry | `py-8 text-center`               | `py-1`                          | open — package A   |
+| Occupant well        | `min-h-[100px]`                  | none                            | open — package A   |
+| Actions              | 2×2 `btn-ghost` grid             | one inline pill                 | open — see below   |
+| Warnings block       | `BunkWarnings`                   | consent line only               | **keep divergent** |
+
+**Empty state wording is conditional on `canPlace`.** Without a scenario or
+without `bunking.manage` there is nothing to drop, so the invitation would name
+an action the reader cannot take. Summer renders _nothing at all_ in production
+mode; these cards are small enough that a blank body reads as broken rather than
+read-only, so the state is stated instead.
+
+**Actions probably should not be ported.** Three of summer's four have no family
+analogue — there is no swap, no social graph and no lock concept for lodging.
+CSV export is the only one that may genuinely be wanted. Treat this row as a
+decision, not a build.
+
+**`BunkWarnings` stays divergent.** Summer's four hazards — age gap, grade
+ratio, grade count, over capacity — have no family analogue.
+
+## 4. Occupant card — PARTIALLY OPEN
+
+| Dimension      | Summer `CamperCard`                 | Family `FamilyCard`       | Status      |
+| -------------- | ----------------------------------- | ------------------------- | ----------- |
+| Name size      | `text-sm`                           | `text-sm`                 | done        |
+| Secondary size | `text-xs`                           | `text-xs`                 | done        |
+| Radius         | `rounded-xl` (12px)                 | `rounded-lg` (8px)        | open        |
+| Border         | `border-2`                          | `border` (1px)            | open        |
+| Padding        | `p-2.5`                             | `px-2 py-1.5`             | open        |
+| Background     | gender-tinted                       | neutral                   | no analogue |
+| Hover          | `hover:shadow-lodge` (inert, #2027) | `hover:border-primary/50` | open        |
+
+**Gender tint has no family analogue** — a party is mixed by definition. Giving
+this card a colour channel would mean choosing a _different_ fact to encode
+(share eligibility, fit verdict). That is a design question, not a true-up, and
+should not be smuggled in under §4.
+
+## 5. Grid and row layout — ONE ROW OPEN
+
+| Dimension     | Summer                       | Family                          | Status            |
+| ------------- | ---------------------------- | ------------------------------- | ----------------- |
+| Columns       | `grid-cols-1 sm:2 lg:3 xl:4` | `minmax(280px,1fr)` → 4 @ 288px | **done**          |
+| Gap           | `gap-3` (12px)               | `gap-3`                         | **done**          |
+| Row alignment | default `stretch`            | `items-start`                   | open — package A  |
+| Grouping      | flat, area is a filter       | collapsible section per area    | **keep** — see §6 |
+
+Summer sets columns by breakpoint; this board sets a minimum width and lets
+`auto-fill` decide. Different mechanism, same result at the sizes that matter,
+and the width-driven form degrades better across the range of viewports staff
+actually use.
+
+**What `minmax(280px)` bought,** over `minmax(200px)` (5 columns at 228px):
+
+- truncated unit titles **12 of 82 → 2**. An 18px title had ~180px to work with
+  at 228px once padding and the capacity figure were out. The two survivors are
+  a pair of rooms whose names differ in their last character.
+- amenity-row free space on its last line: median **153px → 213px**, 25th
+  percentile **115px → 175px**. Roughly one more indicator chip per card, which
+  is why the change was wanted — more indicators are coming.
+- cost: board height **5172px → 5754px**, +11% scroll. That is what one fewer
+  column means.
+
+**Widening does NOT reduce how often the amenity row wraps.** 28 / 29 / 25 cards
+sit at one, two and three lines at _both_ widths. The wrapping is structural:
+`UnitAvailabilityControl` gives its stored-reason line and its open form
+`w-full`, so each takes its own line however wide the card is. Anyone wanting a
+denser amenity row must change that control, not the grid.
+
+## 6. Deliberate divergences — SETTLED, do not "fix"
+
+**Per-area collapsible sections.** Keep — but not for the reason originally
+recorded.
+
+`BunkingBoardByArea` groups by **gender** (boys / girls / all-gender) and
+`selectedArea === 'all'` concatenates all three into one flat grid. Summer's
+areas are _mutually exclusive by rule_ — a boy cannot go in a girls' bunk — so
+the other two are illegal destinations and a filter hides nothing usable.
+
+Family areas are **geography, and every area is a legal destination for every
+family**. Adopting summer's filter would hide 74 usable rooms to show 8. That
+copies the widget while discarding the reason it works. §4 asks for the
+reasoning to transfer, not the control.
+
+The earlier justification — "82 rooms across 8 areas need grouping where
+summer's ~40 bunks don't" — argued from volume. Volume argues for chunking, not
+for _this_ chunking. The semantic argument is the load-bearing one.
+
+Measured cost of sectioning, for the record: **24 card rows against a flat 21**
+at four columns, plus 8 headings and 7 inter-section gaps, plus **18 empty slots
+in partial last rows**. Roughly 20% of board height. Area distribution is even —
+18 / 13 / 13 / 10 / 8 / 7 / 7 / 6, median 8.5, no degenerate single-room areas —
+so the sections carry real weight rather than fragmenting into noise.
+
+**The wrapping grid of small cards, not tall columns.** A summer bunk column is
+tall because it holds 10–14 campers; a lodging unit holds nothing, one party, or
+occasionally two. `boardLayout.ts`'s header explains this. Do not make family
+cards summer-height.
+
+**The area hue stripe** (`border-t-[3px]` plus the section dot) is §3.10 and must
+survive any chrome change. It is an inline `borderTopColor`, so it outranks
+`.card-lodge`'s `border-border` and its `border-primary/50` hover. There is a
+test pinning it.
+
+Note the coupling: `boardLayout.ts` justifies the eight-hue ramp as decorative
+_because_ "the section headers do the actual grouping". **Sections and hue stand
+or fall together.** Removing the sections obliges you to delete the hue or
+re-justify it against §3.10.
+
+---
+
+## Remaining work, grouped as it should be built
+
+### Package A — slot shape
+
+`items-start` (§5) + empty-state geometry + occupant well (§3). **One change,
+three edits.** No decisions required; blocked only on sequencing.
+
+Deleting `items-start` alone makes things _worse_, and this is the trap:
+
+- Grid row height already equals the tallest card in that row. Removing
+  `items-start` does not reclaim a pixel — it relocates the whitespace from
+  outside the card border to inside it.
+- Current dead space is **3,034px across 24 rows** (per row, the sum of every
+  card's shortfall against its row's tallest).
+- Card heights at four columns: **0 parties → 139px flat, all 28 of them**;
+  1 party → 168–268px, median 188; 2 parties → 305–357px, only 3 cards.
+- So stretch alone yields 28 empty cards blown up to 200–357px with the word
+  "Empty" pinned to the top edge at `py-1`.
+
+Summer gets away with stretch because its empties read as intentional drop
+zones — `py-8 text-center` inside a `min-h-[100px]` well — on cards that are
+uniformly tall to begin with. Do all three, or none.
+
+### Package B — occupancy
+
+Occupancy figure + colour ramp + utilization bar + over-capacity chrome (§3).
+The only item on any table that is **not** a mechanical port. Four real
+decisions:
+
+1. **There is no occupancy value.** `BoardSlot` is `{unit, parties, consent}`.
+   Derive it as the sum of `party_size ?? adults + children`; that helper is
+   currently private inside `FamilyCard` and needs lifting into `boardLayout.ts`.
+2. **A merged party is drawn on every room it holds** (since #2010; one party
+   currently spans two cards). Sum naively and a 4-person party reads `4/4` on
+   _both_ rooms — the board would claim 8 people in 8 beds where there are 4.
+   Needs a rule: split across rooms, attribute to one, or say "shared across 2
+   rooms".
+3. **6 of 82 units have no capacity at all**, rendering `—`, because
+   `sleeps: null` means unmeasured rather than zero. A percentage-of-capacity
+   ramp cannot colour those six, and the bar has no width for them. Summer never
+   hits this; its `defaultCapacity` is a hardcoded 12 that always exists.
+4. **Summer's ramp is tuned to a denominator of 12.** Family denominators are
+   real and small. A room that sleeps 2 jumps green → orange the moment a second
+   person arrives, with no useful gradient between. Decide whether the ramp earns
+   its place at these sizes, or whether the bare `2/5` figure is the whole story.
+
+Also: summer's over-capacity chrome is `border-destructive/50 border-2`, and
+this card's border already carries two channels — area hue on top, amber for
+consent all round. A third claimant needs somewhere else to live.
+
+### Package C — findability, and why the sections survive
+
+Not a table row, but it is what the sections get blamed for.
+
+Summer does not solve "where can this camper go?" with layout either. It solves
+it during the drag: `BunkCard` applies `pointer-events-none opacity-40` to every
+invalid bunk the moment a camper is picked up. `LodgingUnitCard` indicates
+nothing — it deliberately accepts every drop, for a good reason stated in its
+comment (fit is advisory; no cabin is confirmed until staff walk the property).
+
+**Declining to refuse a drop is not the same as declining to indicate fit.**
+Dimming poor fits without blocking them is summer's own pattern and squarely
+§4. Build that and the sections stop being load-bearing for search — which is
+the only job they are bad at.
+
+Related: **collapse state is `useState`** (`LodgingBoard.tsx`), so it resets on
+reload and is not linkable. Collapsing 7 of 8 areas _is_ the filter, and it
+evaporates. §4's URL-state rule applies for the same reason it applies to tabs.
+
+---
+
+## How to re-measure
+
+The dev server for this work runs on `:3135` with `AUTH_MODE=bypass`. Board with
+real placements: `/weekend/fc1`. Drive it with `dev-browser` — Playwright pages,
+so `setViewportSize`, not `setViewport`, and pass `--timeout` above the 30s
+default.
+
+```js
+const cards = [...document.querySelectorAll("[data-unit-card]")];
+// arbitrary font sizes anywhere inside a card — should be []
+[
+  ...new Set(
+    cards
+      .flatMap((c) => [c, ...c.querySelectorAll("*")])
+      .flatMap((e) => [...e.classList])
+      .filter((k) => /^text-\[\d+px\]$/.test(k)),
+  ),
+];
+// truncated unit titles
+cards
+  .map((c) => c.querySelector("h3"))
+  .filter((t) => t.scrollWidth > t.clientWidth).length;
+```
+
+`docs/architecture/lodging-occupancy.md` covers the occupancy data model that
+package B has to sit on. `docs/reference/lodging-registry.md` covers where the
+unit names come from and why they are not in this repository — **no unit names
+in this document either.**

--- a/docs/reference/lodging-board-vs-summer.md
+++ b/docs/reference/lodging-board-vs-summer.md
@@ -11,9 +11,10 @@ re-measure what has already been measured, and does not re-open decisions that
 have already been settled with a reason.
 
 Every number here was measured in a browser at a **1600px viewport**, where the
-board area is **1188px**, against the real 2026 registry: 82 rooms, 8 areas, 62
-parties, 28 empty rooms. Numbers are restated when the layout changes underneath
-them — several already have been.
+board area is **1188px**. Against the 2026 registry **after #2040**: **76
+cards** across 8 areas, 62 parties, 52 occupied cards, 24 empty, 4 rooms with no
+recorded capacity. Numbers are restated when the layout changes underneath them
+— several already have been, twice.
 
 **Read `frontend/CLAUDE.md` and CLAUDE.md §4 first.** This document assumes
 both.
@@ -22,18 +23,29 @@ both.
 
 ## Why measure at all
 
-Two of the findings below could not have been reached by reading code, and both
-had already been asserted wrongly from a careful reading:
+Three findings here could not have been reached by reading code, and each had
+already been asserted wrongly from a careful reading first:
 
 - `hover:shadow-lodge-lg` **does nothing**, on this board or summer's. See
   kindred#2027.
-- Widening the grid does **not** unwrap the amenity row, though it looks like
-  it must.
+- Widening the grid does **not** unwrap the amenity row, though it looks like it
+  must.
+- Dropping `items-start` **reclaims no space at all** — the grid row is already
+  as tall as its tallest card, so it relocates whitespace rather than removing
+  it.
 
 Assert nothing about rendered output without rendering it. jsdom parses no
 Tailwind, so a `toHaveStyle` assertion on a Tailwind class passes against an
 empty string and proves nothing — pin **classes** in vitest and measure
 **computed values** in a browser.
+
+> Two dev-browser traps, both of which produced a false result here. **Probe
+> handles go stale**: grabbing `page.$$(…)` once and clicking across a React
+> re-render reports nonsense, and twice looked like a bug in the code under
+> test. **Re-query before every click.** And when sweeping
+> `document.styleSheets`, test `selectorText` **before** recursing into
+> `cssRules` — under nested-CSS support `CSSStyleRule.cssRules` is a truthy
+> empty list, so the obvious walk silently visits zero style rules.
 
 ---
 
@@ -64,11 +76,6 @@ the codebase are inert, plus three of an undefined `shadow-lodge-md`. Filed as
 Both cards' hover lift comes entirely from `.card-lodge:hover`, whose shadow
 (`0 12px 32px`) is the deeper of the two anyway.
 
-> When sweeping `document.styleSheets`, test `selectorText` **before** recursing
-> into `cssRules`. Under nested-CSS support `CSSStyleRule.cssRules` is a truthy
-> empty list, so an `if (r.cssRules) … else if (r.selectorText)` walk silently
-> visits zero style rules. That produced a false negative on the first pass here.
-
 ## 2. Type scale — CLOSED
 
 Summer uses three steps of the stock scale. The family board was built on
@@ -90,32 +97,31 @@ would print as large as the room holding it.
 
 `UnitAvailabilityControl` renders inside the card and is part of its scale — a
 10px pill in a 14px meta row is the same bug. A sweep test fails on any
-`text-[Npx]` anywhere inside either card, because a single arbitrary size left
-on a nested row is invisible in a spot check and is how the two scales diverged
-in the first place.
+`text-[Npx]` anywhere inside either card, because a single arbitrary size left on
+a nested row is invisible in a spot check and is how the two scales diverged in
+the first place.
 
 **The typeface was the larger half of this row, and it is not a size at all.**
 `index.css` sets `h1, h2, h3 { font-family: var(--font-display) }` — Fraunces,
 `-0.02em`, `ss01`/`ss02`. Summer titles its bunk in an `<h3>` and gets it; this
 card used a `<span>` and rendered the same 18px in the body sans. The tag was
 doing typographic work, not only semantic work. Now `<h3>`, measured at
-18px/600/−0.27px with `ss01`+`ss02` on all 82 cards. `text-lg` is a utility and
-outranks the base rule's `text-2xl md:text-3xl`, so only the face and tracking
-carry over.
+18px/600/−0.27px with `ss01`+`ss02`. `text-lg` is a utility and outranks the base
+rule's `text-2xl md:text-3xl`, so only the face and tracking carry over.
 
-## 3. What the card reports — OPEN
+## 3. What the card reports — ONE ROW OPEN
 
-| Row                  | Summer                           | Family                          | Status             |
-| -------------------- | -------------------------------- | ------------------------------- | ------------------ |
-| Occupancy figure     | `{occupancy}/{capacity}`         | bare `sleeps`, `—` when unknown | open — package B   |
-| Colour ramp          | 4 stops                          | none                            | open — package B   |
-| Utilization bar      | `BunkUtilizationBar`             | absent                          | open — package B   |
-| Over-capacity chrome | `border-destructive/50 border-2` | none                            | open — package B   |
-| Empty state wording  | "Drop campers here"              | "Drop families here" / "Empty"  | **done**           |
-| Empty state geometry | `py-8 text-center`               | `py-1`                          | open — package A   |
-| Occupant well        | `min-h-[100px]`                  | none                            | open — package A   |
-| Actions              | 2×2 `btn-ghost` grid             | one inline pill                 | open — see below   |
-| Warnings block       | `BunkWarnings`                   | consent line only               | **keep divergent** |
+| Row                    | Summer                           | Family                         | Status                           |
+| ---------------------- | -------------------------------- | ------------------------------ | -------------------------------- |
+| Occupancy figure       | `{occupancy}/{capacity}`         | `{occupancy}/{capacity}`       | **done**                         |
+| Over-capacity emphasis | `border-destructive/50 border-2` | `text-destructive` + chip      | **done, differently**            |
+| Colour ramp            | 4 stops                          | none                           | **closed — will not build**      |
+| Utilization bar        | `BunkUtilizationBar`             | none                           | **closed — will not build**      |
+| Empty state wording    | "Drop campers here"              | "Drop families here" / "Empty" | done                             |
+| Empty state geometry   | `py-8 text-center`               | centred in the well            | done                             |
+| Occupant well          | `min-h-[100px]`                  | `min-h-[100px] flex-1`         | done                             |
+| Actions                | 2×2 `btn-ghost` grid             | one inline pill                | **open — decision, not a build** |
+| Warnings block         | `BunkWarnings`                   | consent line only              | keep divergent                   |
 
 **Empty state wording is conditional on `canPlace`.** Without a scenario or
 without `bunking.manage` there is nothing to drop, so the invitation would name
@@ -123,61 +129,128 @@ an action the reader cannot take. Summer renders _nothing at all_ in production
 mode; these cards are small enough that a blank body reads as broken rather than
 read-only, so the state is stated instead.
 
-**Actions probably should not be ported.** Three of summer's four have no family
-analogue — there is no swap, no social graph and no lock concept for lodging.
-CSV export is the only one that may genuinely be wanted. Treat this row as a
-decision, not a build.
+**The ramp and the bar are closed as WILL NOT BUILD, not as pending.** Summer's
+ramp is a percentage of a fixed capacity of 12 and has five distinguishable
+states. Family rooms average about five beds and plenty sleep two, where the same
+ramp is a binary wearing four colours — green on the first occupant, orange on
+the second. The card's border already carries the area hue (§3.10) and the amber
+consent edge, so a third channel would compete for one surface. What is kept is
+the figure and **one** emphasis state, for the only actionable case; two cards
+qualify on 2026 data.
 
-**`BunkWarnings` stays divergent.** Summer's four hazards — age gap, grade
-ratio, grade count, over capacity — have no family analogue.
+Consequently the over-capacity emphasis is `text-destructive` on the figure plus
+a chip, **not** summer's border treatment. See §6 on why the border is full.
 
-## 4. Occupant card — PARTIALLY OPEN
+**Actions should probably not be ported.** Three of summer's four have no family
+analogue — there is no roster swap, no social graph and no lock concept for
+lodging. CSV export is the only survivor, and a room holds one party, so the
+useful export is an area or the whole board. If it is wanted, it belongs on the
+area header or a board toolbar, not the card. Treat this row as a decision to
+close, not a build.
 
-| Dimension      | Summer `CamperCard`                 | Family `FamilyCard`       | Status      |
-| -------------- | ----------------------------------- | ------------------------- | ----------- |
-| Name size      | `text-sm`                           | `text-sm`                 | done        |
-| Secondary size | `text-xs`                           | `text-xs`                 | done        |
-| Radius         | `rounded-xl` (12px)                 | `rounded-lg` (8px)        | open        |
-| Border         | `border-2`                          | `border` (1px)            | open        |
-| Padding        | `p-2.5`                             | `px-2 py-1.5`             | open        |
-| Background     | gender-tinted                       | neutral                   | no analogue |
-| Hover          | `hover:shadow-lodge` (inert, #2027) | `hover:border-primary/50` | open        |
+**`BunkWarnings` stays divergent.** Summer's four hazards — age gap, grade ratio,
+grade count, over capacity — have no family analogue. Over capacity is the
+exception and is handled by the emphasis state above.
+
+### The occupancy numerator is knowingly wrong
+
+`party_size` counts the household's **listed** adults rather than the attending
+ones. **kindred#1925** is the fix and carries the data investigation: the errors
+run in **both** directions and the worst cases are under-counts. Two structural
+causes have their own issues — #1946 (rows with no name in any column) and #1947
+(a second adults field that overlaps unpredictably).
+
+Building on it anyway was a deliberate call, on the grounds that the board
+**already** prints this number on every `FamilyCard`. Summing it onto the room
+creates no new class of error, but it does make an existing one more
+consequential, because a room reading full is trusted in a way a household
+reading 6 is not.
+
+`partySize` therefore lives in `boardLayout.ts` as the **one** definition — it
+was private to `FamilyCard`, which was fine while the card was the only thing
+counting people — so #1925 is one edit rather than a hunt. Both read sites say so
+in a comment.
+
+### Spanning withholds the verdict, not the figure
+
+Since #2010 a party holding several rooms is drawn on **each** of them, and #2040
+deliberately left that rule alone. So the same people can appear on more than one
+card, with no per-room breakdown to divide them by.
+
+`slotOccupancy` returns `spanWidth`, and a non-zero value withholds the
+over-capacity claim while keeping the figure. Counting the party in full rather
+than dropping it is the safer of the two errors: it over-states, which reads as
+"look at this", where counting only wholly-contained parties would under-state
+and read as "room for more" — the permissive direction `occupiedLeafCodes` exists
+to close. A `Spans N rooms` chip stops the bare figure reading as a fault.
+
+**Measured after #2040: ZERO parties span cards, down from one.** Combining a
+whole-let building rolls them onto a single card, and prod will combine more.
+Owner-confirmed that a straddling household is never joined in one of its rooms
+by a second family, so such a card holds exactly one party — the figure is that
+family's size, not an aggregate. This is a guard on a reachable-but-empty state,
+which is the kind that rots undetected, so it is tested.
+
+## 4. Occupant card — CLOSED
+
+| Dimension      | Summer `CamperCard`                 | Family `FamilyCard`       | Status                       |
+| -------------- | ----------------------------------- | ------------------------- | ---------------------------- |
+| Name size      | `text-sm`                           | `text-sm`                 | done                         |
+| Secondary size | `text-xs`                           | `text-xs`                 | done                         |
+| Radius         | `rounded-xl` (12px)                 | `rounded-xl`              | done                         |
+| Border         | `border-2`                          | `border-2`                | done                         |
+| Padding        | `p-2.5`                             | `p-2.5`                   | done                         |
+| Background     | gender-tinted                       | neutral                   | **closed — no analogue**     |
+| Hover          | `hover:shadow-lodge` (inert, #2027) | `hover:border-primary/50` | **closed — family is ahead** |
+| Overflow       | `overflow-hidden`                   | none                      | **closed — deliberate**      |
 
 **Gender tint has no family analogue** — a party is mixed by definition. Giving
 this card a colour channel would mean choosing a _different_ fact to encode
-(share eligibility, fit verdict). That is a design question, not a true-up, and
-should not be smuggled in under §4.
+(share eligibility, fit verdict). That is a design question and must not be
+smuggled in under §4.
 
-## 5. Grid and row layout — ONE ROW OPEN
+**The hover row resolves in the family board's favour.** Summer's is one of the
+nine inert classes in #2027 and renders nothing; `hover:border-primary/50` works.
+Copying summer here would be copying a no-op.
 
-| Dimension     | Summer                       | Family                          | Status            |
-| ------------- | ---------------------------- | ------------------------------- | ----------------- |
-| Columns       | `grid-cols-1 sm:2 lg:3 xl:4` | `minmax(280px,1fr)` → 4 @ 288px | **done**          |
-| Gap           | `gap-3` (12px)               | `gap-3`                         | **done**          |
-| Row alignment | default `stretch`            | `items-start`                   | open — package A  |
-| Grouping      | flat, area is a filter       | collapsible section per area    | **keep** — see §6 |
+**`overflow-hidden` is deliberately not copied.** `CamperCard` needs it to clip
+an absolutely-positioned gradient at its foot; this card has no such element, so
+the class would be cargo.
+
+## 5. Grid and row layout — CLOSED
+
+| Dimension     | Summer                       | Family                         | Status            |
+| ------------- | ---------------------------- | ------------------------------ | ----------------- |
+| Columns       | `grid-cols-1 sm:2 lg:3 xl:4` | `minmax(280px,1fr)` → 4 @288px | done              |
+| Gap           | `gap-3` (12px)               | `gap-3`                        | done              |
+| Row alignment | default `stretch`            | `stretch`                      | done              |
+| Grouping      | flat, area is a filter       | collapsible section per area   | **keep** — see §6 |
 
 Summer sets columns by breakpoint; this board sets a minimum width and lets
 `auto-fill` decide. Different mechanism, same result at the sizes that matter,
-and the width-driven form degrades better across the range of viewports staff
-actually use.
+and the width-driven form degrades better across the viewports staff use.
 
 **What `minmax(280px)` bought,** over `minmax(200px)` (5 columns at 228px):
 
 - truncated unit titles **12 of 82 → 2**. An 18px title had ~180px to work with
-  at 228px once padding and the capacity figure were out. The two survivors are
-  a pair of rooms whose names differ in their last character.
+  at 228px once padding and the capacity figure were out.
 - amenity-row free space on its last line: median **153px → 213px**, 25th
   percentile **115px → 175px**. Roughly one more indicator chip per card, which
-  is why the change was wanted — more indicators are coming.
-- cost: board height **5172px → 5754px**, +11% scroll. That is what one fewer
-  column means.
+  is why the change was wanted.
+- cost: **+11% scroll**.
 
 **Widening does NOT reduce how often the amenity row wraps.** 28 / 29 / 25 cards
-sit at one, two and three lines at _both_ widths. The wrapping is structural:
+sat at one, two and three lines at _both_ widths. The wrapping is structural:
 `UnitAvailabilityControl` gives its stored-reason line and its open form
 `w-full`, so each takes its own line however wide the card is. Anyone wanting a
 denser amenity row must change that control, not the grid.
+
+**Row alignment could not be fixed alone.** Dropping `items-start` reclaims
+nothing — the row is already as tall as its tallest card, so stretch relocates
+whitespace from outside the card border to inside it. Landed together with the
+`min-h-[100px]` well and a centred invitation: dead space within rows **3,034px →
+0**, no ragged row, at a cost of **+7.9%** board height. The whitespace was never
+reclaimed; it was absorbed.
 
 ## 6. Deliberate divergences — SETTLED, do not "fix"
 
@@ -191,18 +264,38 @@ the other two are illegal destinations and a filter hides nothing usable.
 
 Family areas are **geography, and every area is a legal destination for every
 family**. Adopting summer's filter would hide 74 usable rooms to show 8. That
-copies the widget while discarding the reason it works. §4 asks for the
-reasoning to transfer, not the control.
+copies the widget while discarding the reason it works. §4 asks for the reasoning
+to transfer, not the control.
 
-The earlier justification — "82 rooms across 8 areas need grouping where
-summer's ~40 bunks don't" — argued from volume. Volume argues for chunking, not
-for _this_ chunking. The semantic argument is the load-bearing one.
+The earlier justification — "82 rooms across 8 areas need grouping where summer's
+~40 bunks don't" — argued from volume. Volume argues for chunking, not for _this_
+chunking. The semantic argument is the load-bearing one.
 
 Measured cost of sectioning, for the record: **24 card rows against a flat 21**
 at four columns, plus 8 headings and 7 inter-section gaps, plus **18 empty slots
-in partial last rows**. Roughly 20% of board height. Area distribution is even —
-18 / 13 / 13 / 10 / 8 / 7 / 7 / 6, median 8.5, no degenerate single-room areas —
+in partial last rows** — roughly 20% of board height. Area distribution is even
+(18 / 13 / 13 / 10 / 8 / 7 / 7 / 6, median 8.5, no degenerate single-room areas),
 so the sections carry real weight rather than fragmenting into noise.
+
+**Collapse state lives in the URL** (`?closed=GT&closed=HC`), not `useState`.
+Collapsing seven of eight areas _is_ the filter this board was said to lack, and
+in component state it evaporated on every reload. §4's URL-state rule applies for
+the same reason it applies to tabs. A query **param**, not a path segment: the
+view is already a segment because it selects _what_ you are looking at; this
+modifies how that view is arranged.
+
+The token is **generated** (`areaTokens`), not read from the registry's
+`area_code`, which is hand-entered and ragged — two letters for some areas, four
+for others. **Two characters is not always enough**, which is why `areaTokens`
+takes the whole set rather than one area at a time: on the 2026 registry two
+areas both reduce to the same pair of initials, and both first words share their
+first two letters. The colliding group — and only that group — deepens a letter
+at a time until distinct, leaving every other token, and every link already
+holding one, alone.
+
+Repeated entries rather than a comma list: `URLSearchParams` percent-encodes a
+comma, and a link somebody can read is most of the point. Sorted, so one set of
+collapsed areas always produces one URL; dropped entirely when empty.
 
 **The wrapping grid of small cards, not tall columns.** A summer bunk column is
 tall because it holds 10–14 campers; a lodging unit holds nothing, one party, or
@@ -219,85 +312,75 @@ _because_ "the section headers do the actual grouping". **Sections and hue stand
 or fall together.** Removing the sections obliges you to delete the hue or
 re-justify it against §3.10.
 
+**The card border is full.** Area hue on top, amber for consent all round. That is
+why over-capacity took a text colour and a chip rather than summer's
+`border-destructive/50`, and why any future state needs somewhere else to live.
+
 ---
 
-## Remaining work, grouped as it should be built
+## What #2040 and #2029 settled
 
-### Package A — slot shape
+Both merged while this branch was in flight. Neither is optional reading before
+touching occupancy or the draw level.
 
-`items-start` (§5) + empty-state geometry + occupant well (§3). **One change,
-three edits.** No decisions required; blocked only on sequencing.
+**#2040 — a whole-let building draws as one card.** A merge is a **promotion to
+the parent**: the card is the container's own registry row carrying its measured
+whole-house `sleeps`, which is **not** the sum of its rooms (one building records
+7 against rooms summing to 6). _Never re-derive it_ — an earlier draft of §3
+proposed exactly that and was wrong. It also gave this board `unitLevel.ts`
+(`coveredCodes`, `drawnUnits`, `representingCodes`) and `overlappingPartyKeys` /
+`occupiedLeafCodes`, which `slotOccupancy` reads rather than re-deriving
+containment. #2040 records what re-deriving costs: the overlap rule was fixed at
+the slot level and came straight back one level down in `FamilyCard`, because the
+second copy had not been told.
 
-Deleting `items-start` alone makes things _worse_, and this is the trap:
+**#2029 — the registry records its season.** Year scoping is server-side and
+admin-side. The board's read shape is **unchanged**: `LodgingUnitRow` is an alias
+for the generated `LodgingUnitSummary`, and `types/lodging.test.ts`'s
+`Required<LodgingUnitRow>` fixture compiles with no `year` field. It also removed
+the weekend Inventory tab, so the board now reads Housing / Roster / Map.
 
-- Grid row height already equals the tallest card in that row. Removing
-  `items-start` does not reclaim a pixel — it relocates the whitespace from
-  outside the card border to inside it.
-- Current dead space is **3,034px across 24 rows** (per row, the sum of every
-  card's shortfall against its row's tallest).
-- Card heights at four columns: **0 parties → 139px flat, all 28 of them**;
-  1 party → 168–268px, median 188; 2 parties → 305–357px, only 3 cards.
-- So stretch alone yields 28 empty cards blown up to 200–357px with the word
-  "Empty" pinned to the top edge at `py-1`.
+---
 
-Summer gets away with stretch because its empties read as intentional drop
-zones — `py-8 text-center` inside a `min-h-[100px]` well — on cards that are
-uniformly tall to begin with. Do all three, or none.
+## Remaining work
 
-### Package B — occupancy
+### Findability — the one substantive item left
 
-Occupancy figure + colour ramp + utilization bar + over-capacity chrome (§3).
-The only item on any table that is **not** a mechanical port. Four real
-decisions:
-
-1. **There is no occupancy value.** `BoardSlot` is `{unit, parties, consent}`.
-   Derive it as the sum of `party_size ?? adults + children`; that helper is
-   currently private inside `FamilyCard` and needs lifting into `boardLayout.ts`.
-2. **A merged party is drawn on every room it holds** (since #2010; one party
-   currently spans two cards). Sum naively and a 4-person party reads `4/4` on
-   _both_ rooms — the board would claim 8 people in 8 beds where there are 4.
-   Needs a rule: split across rooms, attribute to one, or say "shared across 2
-   rooms".
-3. **6 of 82 units have no capacity at all**, rendering `—`, because
-   `sleeps: null` means unmeasured rather than zero. A percentage-of-capacity
-   ramp cannot colour those six, and the bar has no width for them. Summer never
-   hits this; its `defaultCapacity` is a hardcoded 12 that always exists.
-4. **Summer's ramp is tuned to a denominator of 12.** Family denominators are
-   real and small. A room that sleeps 2 jumps green → orange the moment a second
-   person arrives, with no useful gradient between. Decide whether the ramp earns
-   its place at these sizes, or whether the bare `2/5` figure is the whole story.
-
-Also: summer's over-capacity chrome is `border-destructive/50 border-2`, and
-this card's border already carries two channels — area hue on top, amber for
-consent all round. A third claimant needs somewhere else to live.
-
-### Package C — findability, and why the sections survive
-
-Not a table row, but it is what the sections get blamed for.
-
-Summer does not solve "where can this camper go?" with layout either. It solves
-it during the drag: `BunkCard` applies `pointer-events-none opacity-40` to every
+Summer does not solve "where can this camper go?" with layout. It solves it
+during the drag: `BunkCard` applies `pointer-events-none opacity-40` to every
 invalid bunk the moment a camper is picked up. `LodgingUnitCard` indicates
 nothing — it deliberately accepts every drop, for a good reason stated in its
 comment (fit is advisory; no cabin is confirmed until staff walk the property).
 
 **Declining to refuse a drop is not the same as declining to indicate fit.**
-Dimming poor fits without blocking them is summer's own pattern and squarely
-§4. Build that and the sections stop being load-bearing for search — which is
-the only job they are bad at.
+Dimming poor fits without blocking them is summer's own pattern and squarely §4.
+It is also what keeps the per-area sections defensible: sections are bad at
+search, and this removes the need to search. The well built for §3 is where the
+reason goes ("Sleeps 2", "No power").
 
-Related: **collapse state is `useState`** (`LodgingBoard.tsx`), so it resets on
-reload and is not linkable. Collapsing 7 of 8 areas _is_ the filter, and it
-evaporates. §4's URL-state rule applies for the same reason it applies to tabs.
+The uniform slot shape made this _more_ urgent, not less: every empty card is now
+an identically well-formed target, so they are harder to tell apart at a glance
+than when they were ragged.
+
+### Closing §3's actions row
+
+A documentation decision, not a build. See §3.
 
 ---
 
 ## How to re-measure
 
 The dev server for this work runs on `:3135` with `AUTH_MODE=bypass`. Board with
-real placements: `/weekend/fc1`. Drive it with `dev-browser` — Playwright pages,
-so `setViewportSize`, not `setViewport`, and pass `--timeout` above the 30s
-default.
+real placements: `/weekend/fc1/housing`.
+
+**Vite needs `.env` exported at launch**, not just `VITE_DISABLE_AUTH=true` — the
+bypass path reads `POCKETBASE_ADMIN_EMAIL`/`POCKETBASE_ADMIN_PASSWORD` through
+`vite.config.ts`, and a bare `npm run dev` lands on an authentication error.
+Source `.env` first, or use `scripts/start_dev.sh`.
+
+Drive it with `dev-browser` — Playwright pages, so `setViewportSize`, not
+`setViewport`, and pass `--timeout` above the 30s default. Re-query element
+handles before every click; see the warning at the top.
 
 ```js
 const cards = [...document.querySelectorAll("[data-unit-card]")];
@@ -314,9 +397,12 @@ const cards = [...document.querySelectorAll("[data-unit-card]")];
 cards
   .map((c) => c.querySelector("h3"))
   .filter((t) => t.scrollWidth > t.clientWidth).length;
+// occupancy figures, over-capacity cards, spanning cards
+cards.map((c) => c.querySelector('[title*="placed"]')?.textContent.trim());
+cards.filter((c) => c.innerText.includes("Over capacity")).length;
+cards.filter((c) => /Spans \d+ rooms/.test(c.innerText)).length;
 ```
 
-`docs/architecture/lodging-occupancy.md` covers the occupancy data model that
-package B has to sit on. `docs/reference/lodging-registry.md` covers where the
-unit names come from and why they are not in this repository — **no unit names
-in this document either.**
+`docs/architecture/lodging-occupancy.md` covers the occupancy data model.
+`docs/reference/lodging-registry.md` covers where the unit names come from and
+why they are not in this repository — **no unit names in this document either.**

--- a/docs/reference/lodging-board-vs-summer.md
+++ b/docs/reference/lodging-board-vs-summer.md
@@ -33,6 +33,15 @@ already been asserted wrongly from a careful reading first:
 - Dropping `items-start` **reclaims no space at all** — the grid row is already
   as tall as its tallest card, so it relocates whitespace rather than removing
   it.
+- **A sweep test is only as good as what the render mounts.** The `text-[Npx]`
+  sweep in `LodgingUnitCard.test.tsx` calls itself load-bearing and covers
+  "anywhere inside the card", but its render did not pass `canMerge`, so the
+  merge and split controls never mounted and kept `text-[10px]` through the
+  whole migration. Nothing failed; §2 was marked CLOSED on a sweep that was
+  blind to two live controls in ordinary use. A coverage assertion that
+  enumerates elements is worth more than the sweep it guards — the sweep now
+  asserts the two buttons are present by role, so a prop rename fails loudly
+  instead of silently re-narrowing it.
 
 Assert nothing about rendered output without rendering it. jsdom parses no
 Tailwind, so a `toHaveStyle` assertion on a Tailwind class passes against an
@@ -82,24 +91,29 @@ Summer uses three steps of the stock scale. The family board was built on
 arbitrary bracket literals whose **largest** size was smaller than summer's
 **body**.
 
-| Slot               | Summer           | Family before | Family now |
-| ------------------ | ---------------- | ------------- | ---------- |
-| Unit title         | `text-lg` (18px) | `text-[13px]` | `text-lg`  |
-| Capacity figure    | `text-sm`        | `text-[11px]` | `text-sm`  |
-| Card body          | `text-sm`        | `text-[11px]` | `text-sm`  |
-| Badges, chips      | `text-xs`        | `text-[10px]` | `text-xs`  |
-| Occupant name      | `text-sm`        | `text-[13px]` | `text-sm`  |
-| Occupant secondary | `text-xs`        | `text-[11px]` | `text-xs`  |
+| Slot                | Summer           | Family before | Family now |
+| ------------------- | ---------------- | ------------- | ---------- |
+| Unit title          | `text-lg` (18px) | `text-[13px]` | `text-lg`  |
+| Capacity figure     | `text-sm`        | `text-[11px]` | `text-sm`  |
+| Card body           | `text-sm`        | `text-[11px]` | `text-sm`  |
+| Badges, chips       | `text-xs`        | `text-[10px]` | `text-xs`  |
+| Occupant name       | `text-sm`        | `text-[13px]` | `text-sm`  |
+| Occupant secondary  | `text-xs`        | `text-[11px]` | `text-xs`  |
+| Merge / split pills | —                | `text-[10px]` | `text-xs`  |
 
 The occupant card steps **down** from the unit card, as `CamperCard` does from
 `BunkCard`. It does not inherit the unit card's body size, or the household name
 would print as large as the room holding it.
 
-`UnitAvailabilityControl` renders inside the card and is part of its scale — a
-10px pill in a 14px meta row is the same bug. A sweep test fails on any
-`text-[Npx]` anywhere inside either card, because a single arbitrary size left on
-a nested row is invisible in a spot check and is how the two scales diverged in
-the first place.
+`UnitAvailabilityControl` and #2040's merge/split controls render inside the
+card and are part of its scale — a 10px pill in a 14px meta row is the same bug,
+and all three sat at 10px until the sweep was made to render them. Measured
+live with 25 controls mounted: every one is 12px, matching the chips beside
+them, and the card sweep returns empty. A sweep test fails on any arbitrary
+size anywhere inside either card — including variant-prefixed and rem/em forms
+(`sm:text-[11px]`, `text-[0.75rem]`), though arbitrary _colours_ stay out of
+scope — because a single arbitrary size left on a nested row is invisible in a
+spot check and is how the two scales diverged in the first place.
 
 **The typeface was the larger half of this row, and it is not a size at all.**
 `index.css` sets `h1, h2, h3 { font-family: var(--font-display) }` — Fraunces,

--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -333,6 +333,51 @@ describe('FamilyCardPreview — the drag overlay', () => {
  *
  * Classes, not computed style: jsdom parses no Tailwind.
  */
+describe('FamilyCard — summer’s occupant-card geometry', () => {
+  /*
+   * `CamperCard` is `rounded-xl border-2 p-2.5`. This card was `rounded-lg`,
+   * a 1px border and `px-2 py-1.5` -- which read as a table row sitting inside
+   * a card, the same criticism that started this exercise, one level down.
+   *
+   * `overflow-hidden` is deliberately NOT copied. `CamperCard` needs it to
+   * clip an absolutely-positioned gradient at its foot; this card has no such
+   * element, so the class would be cargo.
+   */
+  it('wears CamperCard’s radius, border and padding', () => {
+    const { container } = render(<FamilyCard party={party()} onOpen={vi.fn()} />)
+    const card = container.querySelector('[data-family-card]')
+    expect(card).toHaveClass('rounded-xl')
+    expect(card).toHaveClass('border-2')
+    expect(card).toHaveClass('p-2.5')
+  })
+
+  it('drops the row-shaped chrome it replaces', () => {
+    // Left alongside the new classes these fight them: `rounded-lg` loses the
+    // corner, and `px-2 py-1.5` beats `p-2.5` on the axes it sets.
+    const { container } = render(<FamilyCard party={party()} onOpen={vi.fn()} />)
+    const card = container.querySelector('[data-family-card]')
+    expect(card).not.toHaveClass('rounded-lg')
+    expect(card).not.toHaveClass('px-2')
+    expect(card).not.toHaveClass('py-1.5')
+  })
+
+  it('carries the same geometry into the drag overlay', () => {
+    /*
+     * Shared frame, so this passes for free -- and fails the moment somebody
+     * hand-rolls a second one.
+     *
+     * The overlay is a plain `div` and carries no `data-family-card`: it must
+     * not call `useDraggable`, and marking it as a card invites a future
+     * selector to treat it as one. Assert on the rendered root instead.
+     */
+    const { container } = render(<FamilyCardPreview party={party()} />)
+    const overlay = container.firstElementChild
+    expect(overlay).toHaveClass('rounded-xl')
+    expect(overlay).toHaveClass('border-2')
+    expect(overlay).toHaveClass('p-2.5')
+  })
+})
+
 describe('FamilyCard — summer’s type scale', () => {
   function arbitraryTextSizes(container: HTMLElement): string[] {
     const card = container.querySelector('[data-family-card]')

--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -321,3 +321,73 @@ describe('FamilyCardPreview — the drag overlay', () => {
     expect(screen.getByText(/Noah Johnson \(8\)/)).toBeInTheDocument()
   })
 })
+
+/*
+ * The occupant card's own scale, which is NOT the unit card's.
+ *
+ * Summer's `CamperCard` sits inside a `BunkCard` and steps down from it:
+ * `text-sm` name over `text-xs` secondary, where the bunk title above is
+ * `text-lg`. So a `FamilyCard` inside a `LodgingUnitCard` steps down the same
+ * way — it does not inherit the unit card's body size, or the household name
+ * would print as large as the room name holding it.
+ *
+ * Classes, not computed style: jsdom parses no Tailwind.
+ */
+describe('FamilyCard — summer’s type scale', () => {
+  function arbitraryTextSizes(container: HTMLElement): string[] {
+    const card = container.querySelector('[data-family-card]')
+    if (!card) throw new Error('no card rendered')
+    return [card, ...card.querySelectorAll('*')]
+      .flatMap((el) => Array.from(el.classList))
+      .filter((cls) => /^text-\[\d+px\]$/.test(cls))
+  }
+
+  it('uses the stock scale everywhere, with no arbitrary pixel sizes left', () => {
+    const { container } = render(
+      <FamilyCard
+        party={party({
+          is_returning: true,
+          flags: { needs_private_bathroom: true, needs_power: true },
+          share: { proximity: ['with', 'near'], eligibility: 'named', answers_conflict: true },
+        })}
+        unit={confirmedUnit()}
+        sharedSlot
+        onOpen={vi.fn()}
+      />
+    )
+    expect(arbitraryTextSizes(container)).toEqual([])
+  })
+
+  it('names the household at summer’s CamperCard name size', () => {
+    render(<FamilyCard party={party()} onOpen={vi.fn()} />)
+    expect(screen.getByTestId('family-card-name')).toHaveClass('text-sm')
+  })
+
+  it('sets the children line one step below the name, as summer does', () => {
+    render(<FamilyCard party={party()} onOpen={vi.fn()} />)
+    // Each child gets its own `<span>`, so walk up one to the line that holds
+    // them all — asserting on the inner span would pin nothing, since the size
+    // is set on the line.
+    const line = screen.getByText(/Noah Johnson \(8\)/).parentElement
+    expect(line).toHaveTextContent('Ava Johnson (5)')
+    expect(line).toHaveClass('text-xs')
+  })
+
+  it('sets chips at summer’s meta size', () => {
+    render(
+      <FamilyCard
+        party={party({ flags: { needs_power: true } })}
+        unit={confirmedUnit()}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Power')).toHaveClass('text-xs')
+  })
+
+  it('carries the same scale into the drag overlay', () => {
+    // The overlay shares `FamilyCardBody`, so this passes for free — which is
+    // the point. It fails the moment somebody hand-rolls a second body.
+    render(<FamilyCardPreview party={party()} />)
+    expect(screen.getByTestId('family-card-name')).toHaveClass('text-sm')
+  })
+})

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -78,7 +78,7 @@ const CHIP_TONE: Record<ChipTone, string> = {
 function Chip({ label, tone }: { label: string; tone: ChipTone }) {
   return (
     <span
-      className={`inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-semibold whitespace-nowrap ${CHIP_TONE[tone]}`}
+      className={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-semibold whitespace-nowrap ${CHIP_TONE[tone]}`}
     >
       {label}
     </span>
@@ -123,18 +123,18 @@ function FamilyCardBody({
       <span className="flex items-baseline gap-1.5">
         <span
           data-testid="family-card-name"
-          className="text-foreground text-[13px] leading-tight font-semibold"
+          className="text-foreground text-sm leading-tight font-semibold"
         >
           {party.display_name}
         </span>
-        <span className="text-muted-foreground ml-auto inline-flex items-center gap-0.5 text-[11px] tabular-nums">
+        <span className="text-muted-foreground ml-auto inline-flex items-center gap-0.5 text-xs tabular-nums">
           <Users className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
           {partySize(party)}
         </span>
       </span>
 
       {children.length > 0 && (
-        <span className="text-muted-foreground text-[11px] leading-snug">
+        <span className="text-muted-foreground text-xs leading-snug">
           {children.map((child, index) => (
             <Fragment key={String(child.person_cm_id ?? index)}>
               {index > 0 && ' · '}
@@ -182,7 +182,7 @@ function FamilyCardBody({
         {wantsNear && <Chip label="Near another family" tone="muted" />}
 
         {party.is_returning === true && (
-          <span className="text-forest-700 dark:text-forest-300 inline-flex items-center gap-0.5 text-[10px] font-semibold">
+          <span className="text-forest-700 dark:text-forest-300 inline-flex items-center gap-0.5 text-xs font-semibold">
             <Repeat className="h-2.5 w-2.5 flex-shrink-0" aria-hidden="true" />
             Returning
           </span>

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -192,9 +192,20 @@ function FamilyCardBody({
   )
 }
 
-/** The card's own frame, shared by the real card and the drag overlay. */
+/**
+ * The card's own frame, shared by the real card and the drag overlay.
+ *
+ * `rounded-xl border-2 p-2.5` is `CamperCard`'s geometry exactly (CLAUDE.md
+ * §4). At `rounded-lg`, a 1px border and `px-2 py-1.5` this read as a table
+ * row sitting inside a card -- the same criticism that opened this whole
+ * exercise, one level down.
+ *
+ * `overflow-hidden` is deliberately NOT copied across. `CamperCard` needs it
+ * to clip an absolutely-positioned gradient at its foot; this card has no such
+ * element, so the class would be cargo.
+ */
 const CARD_FRAME =
-  'group border-border flex w-full flex-col gap-1 rounded-lg border px-2 py-1.5 text-left'
+  'group border-border flex w-full flex-col gap-1 rounded-xl border-2 p-2.5 text-left'
 
 export function FamilyCard({
   party,

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -32,7 +32,7 @@ import { Repeat, Users } from 'lucide-react'
 import { Fragment } from 'react'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
-import { SHARE_WORDING, shareWordingChip } from './boardLayout'
+import { partySize, SHARE_WORDING, shareWordingChip } from './boardLayout'
 import { partyKey } from './partyKey'
 import { ATTENTION_LABEL, partyAttention } from './rosterAttention'
 
@@ -83,13 +83,6 @@ function Chip({ label, tone }: { label: string; tone: ChipTone }) {
       {label}
     </span>
   )
-}
-
-/** How many people the party brings. */
-function partySize(party: RosterPartyRow): number {
-  const reported = party.party_size ?? 0
-  if (reported > 0) return reported
-  return (party.adults?.length ?? 0) + (party.children?.length ?? 0)
 }
 
 /**

--- a/frontend/src/components/weekend/LodgingBoard.availability.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.availability.test.tsx
@@ -13,6 +13,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
+import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
@@ -60,8 +61,15 @@ beforeEach(() => {
   client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 })
 
+// The board reads its collapsed areas from the query string, so it needs a
+// router. `MemoryRouter` rather than a real one, so no `?closed=` written by
+// one test can leak into the next.
 function wrapper({ children }: { children: ReactNode }) {
-  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/weekend/fc1/housing']}>{children}</MemoryRouter>
+    </QueryClientProvider>
+  )
 }
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {

--- a/frontend/src/components/weekend/LodgingBoard.drag.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.drag.test.tsx
@@ -16,6 +16,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render } from '@testing-library/react'
 import type { ReactNode } from 'react'
+import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
@@ -89,8 +90,15 @@ beforeEach(() => {
   client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 })
 
+// The board reads its collapsed areas from the query string, so it needs a
+// router. `MemoryRouter` rather than a real one, so no `?closed=` written by
+// one test can leak into the next.
 function wrapper({ children }: { children: ReactNode }) {
-  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/weekend/fc1/housing']}>{children}</MemoryRouter>
+    </QueryClientProvider>
+  )
 }
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {

--- a/frontend/src/components/weekend/LodgingBoard.merge.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.merge.test.tsx
@@ -15,6 +15,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
+import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LodgingUnitRow } from '../../types/lodging'
@@ -95,8 +96,15 @@ beforeEach(() => {
   client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 })
 
+// The board reads its collapsed areas from the query string, so it needs a
+// router. `MemoryRouter` rather than a real one, so no `?closed=` written by
+// one test can leak into the next.
 function wrapper({ children }: { children: ReactNode }) {
-  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/weekend/fc1/housing']}>{children}</MemoryRouter>
+    </QueryClientProvider>
+  )
 }
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {

--- a/frontend/src/components/weekend/LodgingBoard.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.test.tsx
@@ -178,6 +178,27 @@ describe('LodgingBoard — layout', () => {
     }
   })
 
+  it('lets the cards fill their row instead of hanging from the top', () => {
+    /*
+     * `items-start` left a short card at its natural height with page
+     * background showing below it, which is why the board read as broken
+     * rather than empty. Board-wide that was 3,034px of gap across 24 rows.
+     *
+     * Removing it reclaims nothing on its own -- the row is already as tall as
+     * its tallest card -- so this only works alongside the occupant well in
+     * `LodgingUnitCard`, which is what makes a stretched empty card look
+     * deliberate. The two are one change; see the well tests.
+     */
+    const { container } = render(<LodgingBoard parties={[]} units={[unit()]} year={2026} />, {
+      wrapper,
+    })
+    const grids = [...container.querySelectorAll('[data-unit-card]')].map((c) => c.parentElement)
+    expect(grids.length).toBeGreaterThan(0)
+    for (const grid of grids) {
+      expect(grid).not.toHaveClass('items-start')
+    }
+  })
+
   it('collapses an area section', async () => {
     render(<LodgingBoard parties={[]} units={[unit()]} year={2026} />, { wrapper })
     expect(screen.getByText('Cedar 1')).toBeInTheDocument()

--- a/frontend/src/components/weekend/LodgingBoard.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.test.tsx
@@ -125,6 +125,46 @@ function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
 }
 
 describe('LodgingBoard — layout', () => {
+  /**
+   * A party placed on a unit the payload does not contain, which is one of the
+   * three routes into `board.offBoard` (see `boardLayout.ts`'s invariant 2).
+   * Without one the off-board section never renders at all, and the layout
+   * tests below silently checked a single grid while claiming to check both.
+   */
+  const strandedParty = party({
+    household_cm_id: 103,
+    display_name: 'Okafor',
+    sort_name: 'Okafor',
+    unit_code: 'ghost-1',
+    unit_name: 'Ghost 1',
+  })
+
+  /**
+   * EVERY grid that has to agree on the layout: the per-area card grids and
+   * the off-board family grid.
+   *
+   * The off-board one cannot be reached through `[data-unit-card]` — it holds
+   * `FamilyCard`s, which carry no such attribute — so selecting only through
+   * that attribute could never have covered it, however many parties a test
+   * passed. It is scoped through its own section heading rather than a bare
+   * `[data-family-card]` lookup, because occupant cards inside unit cards
+   * carry that attribute too and their well is not one of these grids.
+   */
+  function layoutGrids(container: HTMLElement): HTMLElement[] {
+    const unitGrids = [...container.querySelectorAll('[data-unit-card]')].map(
+      (card) => card.parentElement
+    )
+    const section = screen
+      .getByRole('heading', { name: /Placed outside the board/ })
+      .closest('section')
+    const offBoardCard = section?.querySelector('[data-family-card]')
+    const grids = [...unitGrids, offBoardCard?.parentElement]
+    // Both kinds present, or the assertions below are vacuous for one of them.
+    expect(unitGrids.length).toBeGreaterThan(0)
+    expect(offBoardCard).not.toBeNull()
+    return grids.filter((grid): grid is HTMLElement => grid !== null && grid !== undefined)
+  }
+
   it('draws one section per area', () => {
     render(
       <LodgingBoard
@@ -160,12 +200,11 @@ describe('LodgingBoard — layout', () => {
      *
      * Classes, not computed style — jsdom parses no Tailwind.
      */
-    const { container } = render(<LodgingBoard parties={[]} units={[unit()]} year={2026} />, {
-      wrapper,
-    })
-    const grids = [...container.querySelectorAll('[data-unit-card]')].map((c) => c.parentElement)
-    expect(grids.length).toBeGreaterThan(0)
-    for (const grid of grids) {
+    const { container } = render(
+      <LodgingBoard parties={[strandedParty]} units={[unit()]} year={2026} />,
+      { wrapper }
+    )
+    for (const grid of layoutGrids(container)) {
       expect(grid).toHaveClass('gap-3')
       expect(grid).not.toHaveClass('gap-2.5')
     }
@@ -194,12 +233,11 @@ describe('LodgingBoard — layout', () => {
      * Cost is 11% more scroll (board 5172px → 5754px), which is what fewer
      * columns means.
      */
-    const { container } = render(<LodgingBoard parties={[]} units={[unit()]} year={2026} />, {
-      wrapper,
-    })
-    const grids = [...container.querySelectorAll('[data-unit-card]')].map((c) => c.parentElement)
-    expect(grids.length).toBeGreaterThan(0)
-    for (const grid of grids) {
+    const { container } = render(
+      <LodgingBoard parties={[strandedParty]} units={[unit()]} year={2026} />,
+      { wrapper }
+    )
+    for (const grid of layoutGrids(container)) {
       expect(grid).toHaveClass('grid-cols-[repeat(auto-fill,minmax(280px,1fr))]')
       expect(grid).not.toHaveClass('grid-cols-[repeat(auto-fill,minmax(200px,1fr))]')
     }
@@ -216,12 +254,11 @@ describe('LodgingBoard — layout', () => {
      * `LodgingUnitCard`, which is what makes a stretched empty card look
      * deliberate. The two are one change; see the well tests.
      */
-    const { container } = render(<LodgingBoard parties={[]} units={[unit()]} year={2026} />, {
-      wrapper,
-    })
-    const grids = [...container.querySelectorAll('[data-unit-card]')].map((c) => c.parentElement)
-    expect(grids.length).toBeGreaterThan(0)
-    for (const grid of grids) {
+    const { container } = render(
+      <LodgingBoard parties={[strandedParty]} units={[unit()]} year={2026} />,
+      { wrapper }
+    )
+    for (const grid of layoutGrids(container)) {
       expect(grid).not.toHaveClass('items-start')
     }
   })

--- a/frontend/src/components/weekend/LodgingBoard.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.test.tsx
@@ -144,6 +144,40 @@ describe('LodgingBoard — layout', () => {
     }
   })
 
+  it('sizes columns so summer’s four fit, not five', () => {
+    /*
+     * `minmax(280px)` rather than `minmax(200px)`. Measured on the real board
+     * at a 1600px viewport, where the grid gets 1188px: 200px auto-fills to
+     * FIVE columns at 228px, 280px to FOUR at 288px — which is summer's
+     * `xl:grid-cols-4` arrived at from the other direction.
+     *
+     * Two things bought, both measured:
+     *   - truncated unit titles fall from 12 of 82 to 2, since an 18px title
+     *     has only ~180px to work with at 228px once padding and the capacity
+     *     figure are out;
+     *   - the amenity row gains ~60px of free space on its last line (median
+     *     153px → 213px, 25th percentile 115px → 175px), which is roughly one
+     *     more indicator chip on every card.
+     *
+     * It does NOT reduce how often that row wraps — 28/29/25 cards at one,
+     * two and three lines at BOTH widths. The wrapping is structural, not a
+     * width problem: `UnitAvailabilityControl` gives its reason line and its
+     * open form `w-full`, so they take their own line whatever the card is.
+     *
+     * Cost is 11% more scroll (board 5172px → 5754px), which is what fewer
+     * columns means.
+     */
+    const { container } = render(<LodgingBoard parties={[]} units={[unit()]} year={2026} />, {
+      wrapper,
+    })
+    const grids = [...container.querySelectorAll('[data-unit-card]')].map((c) => c.parentElement)
+    expect(grids.length).toBeGreaterThan(0)
+    for (const grid of grids) {
+      expect(grid).toHaveClass('grid-cols-[repeat(auto-fill,minmax(280px,1fr))]')
+      expect(grid).not.toHaveClass('grid-cols-[repeat(auto-fill,minmax(200px,1fr))]')
+    }
+  })
+
   it('collapses an area section', async () => {
     render(<LodgingBoard parties={[]} units={[unit()]} year={2026} />, { wrapper })
     expect(screen.getByText('Cedar 1')).toBeInTheDocument()

--- a/frontend/src/components/weekend/LodgingBoard.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.test.tsx
@@ -120,6 +120,30 @@ describe('LodgingBoard — layout', () => {
     expect(screen.getByRole('heading', { name: /North Ridge/ })).toBeInTheDocument()
   })
 
+  it('spaces the card grid on summer’s gap-3', () => {
+    /*
+     * `BunkingBoardByArea` lays its bunks out at `gap-3` (12px); this board
+     * ran at `gap-2.5` (10px). Two pixels, but it is the same grammar
+     * mismatch as the type scale was — summer uses the stock scale and this
+     * board reached for a half-step beside it (CLAUDE.md §4).
+     *
+     * Both grids, not one: the off-board section is the same grid of the same
+     * cards, and a 2px disagreement between the two is the kind of thing that
+     * survives for a year because nobody sees them adjacent.
+     *
+     * Classes, not computed style — jsdom parses no Tailwind.
+     */
+    const { container } = render(<LodgingBoard parties={[]} units={[unit()]} year={2026} />, {
+      wrapper,
+    })
+    const grids = [...container.querySelectorAll('[data-unit-card]')].map((c) => c.parentElement)
+    expect(grids.length).toBeGreaterThan(0)
+    for (const grid of grids) {
+      expect(grid).toHaveClass('gap-3')
+      expect(grid).not.toHaveClass('gap-2.5')
+    }
+  })
+
   it('collapses an area section', async () => {
     render(<LodgingBoard parties={[]} units={[unit()]} year={2026} />, { wrapper })
     expect(screen.getByText('Cedar 1')).toBeInTheDocument()

--- a/frontend/src/components/weekend/LodgingBoard.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.test.tsx
@@ -12,6 +12,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
+import { MemoryRouter, useLocation } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
@@ -47,8 +48,34 @@ beforeEach(() => {
   client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 })
 
+// The board reads its collapsed areas from the query string, so it needs a
+// router. `MemoryRouter` rather than a real one: these tests assert on the
+// location, and a shared history between tests would leak `?closed=` forward.
 function wrapper({ children }: { children: ReactNode }) {
-  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/weekend/fc1/housing']}>{children}</MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+/** Renders the live query string, so a test can read what a click wrote. */
+function LocationProbe() {
+  const location = useLocation()
+  return <output data-testid="search">{location.search}</output>
+}
+
+function routerWrapper(initialEntry: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={[initialEntry]}>
+          {children}
+          <LocationProbe />
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+  }
 }
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
@@ -230,6 +257,116 @@ describe('LodgingBoard — layout', () => {
     )
     await userEvent.click(screen.getByRole('button', { name: /0 unplaced parties/i }))
     expect(screen.getByText(/Everyone has a cabin/i)).toBeInTheDocument()
+  })
+})
+
+describe('LodgingBoard — collapsed areas live in the URL', () => {
+  /*
+   * CLAUDE.md §4: tab state lives in the URL so it is linkable and survives a
+   * reload. Collapse is not a tab, but it is the same claim -- collapsing
+   * seven of eight areas IS the filter this board was said to lack, and held
+   * in `useState` it evaporated on every reload. The board is 6,208px tall
+   * since the slot-shape change, so collapsing is now how you keep one area on
+   * screen.
+   *
+   * A query param, not a path segment: the view is already a segment
+   * (`/weekend/:ref/:view`) because it selects WHAT you are looking at. This
+   * modifies how that view is arranged, which is what a query string is for.
+   */
+  it('opens with an area already collapsed when the URL says so', () => {
+    render(<LodgingBoard parties={[]} units={[unit()]} year={2026} />, {
+      wrapper: routerWrapper('/weekend/fc1/housing?closed=CG'),
+    })
+    expect(screen.getByRole('heading', { name: /Cedar Grove/ })).toBeInTheDocument()
+    expect(screen.queryByText('Cedar 1')).not.toBeInTheDocument()
+  })
+
+  it('writes the area token when one is collapsed', async () => {
+    render(<LodgingBoard parties={[]} units={[unit()]} year={2026} />, {
+      wrapper: routerWrapper('/weekend/fc1/housing'),
+    })
+    await userEvent.click(screen.getByRole('button', { name: /Cedar Grove/ }))
+    expect(screen.getByTestId('search')).toHaveTextContent('closed=CG')
+  })
+
+  it('drops the parameter entirely when the last area is reopened', async () => {
+    // Rather than leaving `?closed=` hanging on the URL, which is noise in a
+    // link and reads as though something is still filtered.
+    render(<LodgingBoard parties={[]} units={[unit()]} year={2026} />, {
+      wrapper: routerWrapper('/weekend/fc1/housing?closed=CG'),
+    })
+    await userEvent.click(screen.getByRole('button', { name: /Cedar Grove/ }))
+    expect(screen.getByTestId('search')).not.toHaveTextContent('closed')
+  })
+
+  it('keeps every other query parameter it found', async () => {
+    // The board does not own the query string. Rebuilding it from scratch
+    // would silently drop whatever else a caller had put there.
+    render(<LodgingBoard parties={[]} units={[unit()]} year={2026} />, {
+      wrapper: routerWrapper('/weekend/fc1/housing?scenario=7'),
+    })
+    await userEvent.click(screen.getByRole('button', { name: /Cedar Grove/ }))
+    expect(screen.getByTestId('search')).toHaveTextContent('scenario=7')
+    expect(screen.getByTestId('search')).toHaveTextContent('closed=CG')
+  })
+
+  it('keeps both areas collapsed when two are closed in turn', async () => {
+    /*
+     * Nothing covered more than one collapsed area, and a browser check that
+     * LOOKED like it had found a bug here is what surfaced the gap. (It had
+     * not — the probe reused stale DOM handles across a re-render.) The risk
+     * is real regardless: the second write has to merge with the first rather
+     * than replace it.
+     */
+    render(
+      <LodgingBoard
+        parties={[]}
+        units={[
+          unit(),
+          unit({
+            unit_id: 'u2',
+            code: 'ridge-1',
+            name: 'Ridge 1',
+            area_code: 'NR',
+            area_name: 'North Ridge',
+          }),
+        ]}
+        year={2026}
+      />,
+      { wrapper: routerWrapper('/weekend/fc1/housing') }
+    )
+    await userEvent.click(screen.getByRole('button', { name: /Cedar Grove/ }))
+    await userEvent.click(screen.getByRole('button', { name: /North Ridge/ }))
+
+    expect(screen.queryByText('Cedar 1')).not.toBeInTheDocument()
+    expect(screen.queryByText('Ridge 1')).not.toBeInTheDocument()
+    // Repeated entries, not a comma list: `URLSearchParams` would encode the
+    // comma and the URL would stop being readable.
+    expect(screen.getByTestId('search')).toHaveTextContent('closed=CG&closed=NR')
+    expect(screen.getByTestId('search')).not.toHaveTextContent('%2C')
+  })
+
+  it('collapses only the area that was clicked', async () => {
+    render(
+      <LodgingBoard
+        parties={[]}
+        units={[
+          unit(),
+          unit({
+            unit_id: 'u2',
+            code: 'ridge-1',
+            name: 'Ridge 1',
+            area_code: 'NR',
+            area_name: 'North Ridge',
+          }),
+        ]}
+        year={2026}
+      />,
+      { wrapper: routerWrapper('/weekend/fc1/housing') }
+    )
+    await userEvent.click(screen.getByRole('button', { name: /Cedar Grove/ }))
+    expect(screen.queryByText('Cedar 1')).not.toBeInTheDocument()
+    expect(screen.getByText('Ridge 1')).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -100,7 +100,11 @@ export function LodgingBoard({
   sessionCmId = 0,
   canManage = false,
 }: LodgingBoardProps) {
-  const board = buildBoard(parties, units)
+  // Memoised for the sake of `tokens` below, which depends on `board.areas`:
+  // rebuilt every render, that array is a fresh identity each time and the
+  // dependency never matches, so the memo reads as though it caches while
+  // re-running `areaTokens` on every keystroke elsewhere in the tree.
+  const board = useMemo(() => buildBoard(parties, units), [parties, units])
   const [searchParams, setSearchParams] = useSearchParams()
   /*
    * Which areas are collapsed, read from the query string rather than held in

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -376,7 +376,7 @@ export function LodgingBoard({
                     </h3>
 
                     {!isCollapsed && (
-                      <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] items-start gap-3">
+                      <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-3">
                         {area.slots.map((slot) => (
                           <LodgingUnitCard
                             key={slot.unit.unit_id}
@@ -442,7 +442,7 @@ export function LodgingBoard({
                 <p className="text-muted-foreground mb-2 text-xs">
                   Assigned to a merged slot or to a room the board does not draw a card for.
                 </p>
-                <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] items-start gap-3">
+                <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-3">
                   {board.offBoard.map((party) => (
                     <FamilyCard
                       key={partyKey(party)}

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -376,7 +376,7 @@ export function LodgingBoard({
                     </h3>
 
                     {!isCollapsed && (
-                      <div className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] items-start gap-3">
+                      <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] items-start gap-3">
                         {area.slots.map((slot) => (
                           <LodgingUnitCard
                             key={slot.unit.unit_id}
@@ -442,7 +442,7 @@ export function LodgingBoard({
                 <p className="text-muted-foreground mb-2 text-xs">
                   Assigned to a merged slot or to a room the board does not draw a card for.
                 </p>
-                <div className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] items-start gap-3">
+                <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] items-start gap-3">
                   {board.offBoard.map((party) => (
                     <FamilyCard
                       key={partyKey(party)}

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -42,13 +42,14 @@ import {
 } from '@dnd-kit/core'
 import { ChevronDown, ChevronRight, Info, TriangleAlert } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router'
 
 import { useDismissOnDeadSpace } from '../../hooks/useDismissOnDeadSpace'
 import { useLodgingPlacement } from '../../hooks/useLodgingPlacement'
 import { useUnitAvailability } from '../../hooks/useUnitAvailability'
 import { useUnitMerge } from '../../hooks/useUnitMerge'
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
-import { buildBoard } from './boardLayout'
+import { areaTokens, buildBoard } from './boardLayout'
 import { mergeDragUnit, resolveDrop, resolveMergeDrop } from './dragPlacement'
 import { FamilyCard, FamilyCardPreview } from './FamilyCard'
 import { FamilyDetailsPanel } from './FamilyDetailsPanel'
@@ -80,6 +81,17 @@ export interface LodgingBoardProps {
   canManage?: boolean
 }
 
+/**
+ * Where the collapsed areas live in the URL, one entry per area:
+ * `?closed=GT&closed=HC`.
+ *
+ * REPEATED rather than a comma list, which was the first shape tried.
+ * `URLSearchParams` percent-encodes a comma, so `?closed=GT,HC` reaches the
+ * address bar as `?closed=GT%2CHC` — and a link somebody can actually read is
+ * most of the point of moving this out of `useState`.
+ */
+const CLOSED_PARAM = 'closed'
+
 export function LodgingBoard({
   parties,
   units,
@@ -89,7 +101,25 @@ export function LodgingBoard({
   canManage = false,
 }: LodgingBoardProps) {
   const board = buildBoard(parties, units)
-  const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set())
+  const [searchParams, setSearchParams] = useSearchParams()
+  /*
+   * Which areas are collapsed, read from the query string rather than held in
+   * `useState` (CLAUDE.md §4: state worth arranging is worth being able to
+   * return to). Collapsing seven of eight areas IS the filter this board was
+   * said to lack — and held in component state it evaporated on every reload,
+   * so it was never worth arranging in the first place.
+   *
+   * A query PARAM, not a path segment. The view is already a segment
+   * (`/weekend/:ref/:view`) because it selects what you are looking at; this
+   * modifies how that view is arranged, which is what a query string is for.
+   */
+  // Derived from the whole set, because a two-character token is not always
+  // unique — see `areaTokens`.
+  const tokens = useMemo(() => areaTokens(board.areas), [board.areas])
+  const collapsed = useMemo<ReadonlySet<string>>(
+    () => new Set(searchParams.getAll(CLOSED_PARAM)),
+    [searchParams]
+  )
   const [selected, setSelected] = useState<RosterPartyRow | null>(null)
   const [requestClose, setRequestClose] = useState(false)
   const [dragging, setDragging] = useState<RosterPartyRow | null>(null)
@@ -277,13 +307,30 @@ export function LodgingBoard({
     setRequestClose(true)
   })
 
-  const toggleArea = (key: string) => {
-    setCollapsed((current) => {
-      const next = new Set(current)
-      if (next.has(key)) next.delete(key)
-      else next.add(key)
-      return next
-    })
+  const toggleArea = (token: string) => {
+    setSearchParams(
+      (previous) => {
+        // Built FROM the existing params, never from scratch: the board does
+        // not own the query string, and rebuilding it would silently drop
+        // whatever else a caller had put there.
+        const next = new URLSearchParams(previous)
+        const closed = new Set(next.getAll(CLOSED_PARAM))
+        if (closed.has(token)) closed.delete(token)
+        else closed.add(token)
+        // Cleared and rewritten, because `set` would collapse the repeated
+        // entries down to one. Sorted, so the same set of collapsed areas
+        // always produces the same URL whatever order they were clicked in —
+        // two people comparing links should not see a difference that is not
+        // there. An empty set drops the parameter rather than leaving
+        // `?closed=` hanging, which reads as though something is still hidden.
+        next.delete(CLOSED_PARAM)
+        for (const area of [...closed].sort()) next.append(CLOSED_PARAM, area)
+        return next
+      },
+      // REPLACE, as the tab strip does. Pushing would turn Back into
+      // "un-collapse one area", seven times, before it leaves the page.
+      { replace: true }
+    )
   }
 
   return (
@@ -339,14 +386,15 @@ export function LodgingBoard({
               </p>
             ) : (
               board.areas.map((area) => {
-                const isCollapsed = collapsed.has(area.key)
+                const token = tokens.get(area.key) ?? area.key
+                const isCollapsed = collapsed.has(token)
                 return (
                   <section key={area.key}>
                     <h3 className="mb-2">
                       <button
                         type="button"
                         onClick={() => {
-                          toggleArea(area.key)
+                          toggleArea(token)
                         }}
                         aria-expanded={!isCollapsed}
                         className="group flex w-full items-center gap-2 text-left"

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -376,7 +376,7 @@ export function LodgingBoard({
                     </h3>
 
                     {!isCollapsed && (
-                      <div className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] items-start gap-2.5">
+                      <div className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] items-start gap-3">
                         {area.slots.map((slot) => (
                           <LodgingUnitCard
                             key={slot.unit.unit_id}
@@ -442,7 +442,7 @@ export function LodgingBoard({
                 <p className="text-muted-foreground mb-2 text-xs">
                   Assigned to a merged slot or to a room the board does not draw a card for.
                 </p>
-                <div className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] items-start gap-2.5">
+                <div className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] items-start gap-3">
                   {board.offBoard.map((party) => (
                     <FamilyCard
                       key={partyKey(party)}

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -162,53 +162,6 @@ describe('LodgingUnitCard', () => {
     expect(card).toHaveStyle({ borderTopColor: 'hsl(160 45% 42%)' })
   })
 
-  /*
-   * CLAUDE.md §4, "Family Camp Models Summer": same UI primitives, same
-   * Tailwind grammar. Summer's `BunkCard` is a `.card-lodge` at `p-4`; this
-   * card hand-rolled `bg-card rounded-xl border p-2.5` instead, which is why
-   * it read as a table row rather than a card — no shadow, no hover lift, and
-   * a padding less than two thirds of summer's.
-   *
-   * Pinned as classes rather than computed style on purpose: jsdom parses no
-   * Tailwind, so a computed-style assertion here would pass against an empty
-   * string and prove nothing (see `reference_frontend_source_grep_tests`).
-   */
-  it('wears the shared lodge card chrome, as summer’s BunkCard does', () => {
-    const { container } = render(
-      <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />
-    )
-    const card = container.querySelector('[data-unit-card]')
-    // The shared component class — shadow, 2px border, rounded-2xl, hover
-    // lift — rather than a second hand-rolled copy of roughly the same thing.
-    expect(card).toHaveClass('card-lodge')
-    // And NOT the hand-rolled chrome it replaces. Left in place alongside
-    // `card-lodge` these fight it: `rounded-xl` loses the corner radius and
-    // `border` resets the 2px edge back to 1px.
-    expect(card).not.toHaveClass('rounded-xl')
-  })
-
-  it('pads to summer’s p-4 rather than its own p-2.5', () => {
-    const { container } = render(
-      <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />
-    )
-    const card = container.querySelector('[data-unit-card]')
-    expect(card).toHaveClass('p-4')
-    expect(card).not.toHaveClass('p-2.5')
-  })
-
-  it('keeps the area hue winning over the card-lodge border colour', () => {
-    // `.card-lodge` sets `border-border` on all four sides and repaints them
-    // `border-primary/50` on hover. The hue is an inline style, which beats
-    // both — this pins that the chrome swap did not silently cost §3.10 its
-    // secondary channel, on hover or otherwise.
-    const { container } = render(
-      <LodgingUnitCard slot={slot()} hue="hsl(38 75% 50%)" onOpenParty={vi.fn()} />
-    )
-    const card = container.querySelector('[data-unit-card]')
-    expect(card).toHaveStyle({ borderTopColor: 'hsl(38 75% 50%)' })
-    expect(card).toHaveClass('border-t-[3px]')
-  })
-
   it('keys two adult-weekend individuals in one room apart', () => {
     // An adult weekend enrols PEOPLE, and the API sends `household_cm_id = 0`
     // for them rather than omitting it — Pydantic `int = 0`. A `??` chain
@@ -476,5 +429,184 @@ describe('LodgingUnitCard — the per-party sharing chip follows ROOM overlap, n
       />
     )
     expect(screen.getAllByText('Did not request sharing')).toHaveLength(2)
+  })
+})
+
+/*
+ * CLAUDE.md §4, "Family Camp Models Summer": *same Tailwind grammar and
+ * tokens*, not a parallel one. Summer's `BunkCard` is `text-lg` title,
+ * `text-sm` body, `text-xs` meta — three steps of the stock scale. This card
+ * was built on `text-[13px]` / `text-[11px]` / `text-[10px]`, an arbitrary
+ * scale whose LARGEST size is smaller than summer's BODY.
+ *
+ * Pinned as classes rather than computed style throughout: jsdom parses no
+ * Tailwind, so `toHaveStyle({ fontSize: … })` on a Tailwind class passes
+ * against an empty string and proves nothing.
+ */
+describe('LodgingUnitCard — summer’s type scale', () => {
+  /**
+   * Every arbitrary-pixel font size anywhere inside the card.
+   *
+   * The sweep is the load-bearing test and the per-element ones below are its
+   * documentation: a single `text-[11px]` left on a nested row is invisible in
+   * a spot check and is exactly how the two scales diverged in the first
+   * place. `UnitAvailabilityControl` renders INSIDE this card and is swept
+   * with it — a 10px pill sitting in a 12px meta row is the same bug.
+   */
+  function arbitraryTextSizes(container: HTMLElement): string[] {
+    const card = container.querySelector('[data-unit-card]')
+    if (!card) throw new Error('no card rendered')
+    return [card, ...card.querySelectorAll('*')]
+      .flatMap((el) => Array.from(el.classList))
+      .filter((cls) => /^text-\[\d+px\]$/.test(cls))
+  }
+
+  it('uses the stock scale everywhere, with no arbitrary pixel sizes left', () => {
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({
+          unit: unit({ is_active: false, bathroom: 'private', has_power: true, has_ac: true }),
+          parties: [party(), party({ household_cm_id: 102, display_name: 'Garcia' })],
+          consent: {
+            declinedCount: 1,
+            unansweredCount: 0,
+            conflictCount: 0,
+            reason: 'One household declined sharing',
+          },
+        })}
+        hue="hsl(160 45% 42%)"
+        canSetAvailability
+        onSetAvailability={vi.fn()}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(arbitraryTextSizes(container)).toEqual([])
+  })
+
+  it('leaves no arbitrary pixel sizes on an empty slot either', () => {
+    // The empty state is its own branch and carried its own `text-[11px]`.
+    const { container } = render(
+      <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />
+    )
+    expect(arbitraryTextSizes(container)).toEqual([])
+  })
+
+  it('titles the unit at summer’s text-lg', () => {
+    render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
+    expect(screen.getByText('Cedar 1')).toHaveClass('text-lg')
+  })
+
+  it('titles the unit in a heading, which is what carries the display face', () => {
+    /*
+     * Not cosmetic and not merely semantic. `index.css` sets
+     * `h1, h2, h3 { font-family: var(--font-display) }` — Fraunces, with
+     * `-0.02em` tracking and `ss01`/`ss02` on. Summer's `BunkCard` titles its
+     * bunk in an `<h3>` and gets that face; this card used a `<span>` and got
+     * the body sans instead. Same 18px, different typeface, which is why the
+     * two boards still did not look alike after the sizes matched.
+     *
+     * Pinned as a ROLE rather than a tag name: the font comes from the element
+     * being a heading, so that is the thing that must not regress.
+     */
+    render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
+    expect(screen.getByRole('heading', { name: 'Cedar 1', level: 3 })).toBeInTheDocument()
+  })
+
+  it('sets the capacity figure at summer’s body size', () => {
+    // Summer prints `{occupancy}/{capacity}` at `text-sm`. The figure is the
+    // second thing read on the card; at 11px it read as a footnote.
+    render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
+    expect(screen.getByTitle('Sleeps 5')).toHaveClass('text-sm')
+  })
+
+  it('sets the consent line at body size, not meta size', () => {
+    render(
+      <LodgingUnitCard
+        slot={slot({
+          parties: [party(), party({ household_cm_id: 102, display_name: 'Garcia' })],
+          consent: {
+            declinedCount: 1,
+            unansweredCount: 0,
+            conflictCount: 0,
+            reason: 'One household declined sharing',
+          },
+        })}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('One household declined sharing')).toHaveClass('text-sm')
+  })
+
+  it('sets the empty state at body size', () => {
+    render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
+    expect(screen.getByText('Empty')).toHaveClass('text-sm')
+  })
+
+  it('sets badges and the shared-slot chip at summer’s meta size', () => {
+    render(
+      <LodgingUnitCard
+        slot={slot({
+          unit: unit({ is_active: false }),
+          parties: [party(), party({ household_cm_id: 102, display_name: 'Garcia' })],
+        })}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Inactive')).toHaveClass('text-xs')
+    expect(screen.getByText('2 families')).toHaveClass('text-xs')
+  })
+})
+
+describe('LodgingUnitCard — summer’s chrome, the rest of it', () => {
+  it('does not copy BunkCard’s inert hover class', () => {
+    /*
+     * `BunkCard` carries `hover:shadow-lodge-lg`, and trueing this card up
+     * against it means copying that — except the class does nothing.
+     * `.shadow-lodge-*` are hand-written rules inside `@layer utilities`, not
+     * Tailwind `@utility` declarations, so v4 generates no `hover:` variant
+     * for them; a browser sweep of all 3,373 loaded rules found no selector
+     * matching `hover.*shadow-lodge`. The hover lift both cards actually get
+     * comes from `.card-lodge:hover`, whose shadow (`0 12px 32px`) is the
+     * deeper of the two anyway.
+     *
+     * Pinned as an ABSENCE because the next person to read the two class
+     * strings side by side will see the gap and close it, exactly as this
+     * session nearly did. A dead class spreading by imitation is the
+     * `forest-950` failure CLAUDE.md §4 cites (#1894).
+     */
+    const { container } = render(
+      <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />
+    )
+    expect(container.querySelector('[data-unit-card]')).not.toHaveClass('hover:shadow-lodge-lg')
+    // The chrome that DOES carry the hover, so this test fails loudly if the
+    // card ever stops being a `.card-lodge` rather than silently passing.
+    expect(container.querySelector('[data-unit-card]')).toHaveClass('card-lodge')
+  })
+
+  it('spaces its rows on summer’s 12px rhythm', () => {
+    // Summer separates header / bar / roster with `mb-3` (12px) and the
+    // campers inside with `space-y-2` (8px). This card ran everything at a
+    // flat 8px, so the title did not separate from the amenity row.
+    const { container } = render(
+      <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />
+    )
+    const card = container.querySelector('[data-unit-card]')
+    expect(card).toHaveClass('gap-3')
+    expect(card).not.toHaveClass('gap-2')
+  })
+
+  it('spaces two parties on summer’s 8px roster rhythm', () => {
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ parties: [party(), party({ household_cm_id: 102, display_name: 'Garcia' })] })}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    const roster = container.querySelector('[data-family-card]')?.parentElement
+    expect(roster).toHaveClass('gap-2')
+    expect(roster).not.toHaveClass('gap-1.5')
   })
 })

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -88,9 +88,26 @@ describe('LodgingUnitCard', () => {
     expect(screen.getByTitle(/Sleeps 5/)).toBeInTheDocument()
   })
 
-  it('says an empty unit is empty', () => {
+  it('invites a drop into an empty unit while placement is live', () => {
+    // Summer's wording, in family vocabulary: `BunkCard` says "Drop campers
+    // here". The card's job in an empty slot is to be a target, and "Empty"
+    // described the state without offering the action.
+    render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" canPlace onOpenParty={vi.fn()} />)
+    expect(screen.getByText('Drop families here')).toBeInTheDocument()
+  })
+
+  it('says an empty unit is empty when nothing can be dropped', () => {
+    /*
+     * Without a scenario, or without `bunking.manage`, there is nothing to
+     * drop and no way to drop it — so the invitation would name an action the
+     * reader cannot take. Summer reaches the same conclusion and renders
+     * NOTHING in production mode (`BunkCard`: `!isProductionMode && …`); these
+     * cards are small enough that a blank body reads as a broken card rather
+     * than a read-only one, so the state gets stated instead.
+     */
     render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
     expect(screen.getByText('Empty')).toBeInTheDocument()
+    expect(screen.queryByText('Drop families here')).not.toBeInTheDocument()
   })
 
   it('renders the families it holds', () => {

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -576,6 +576,66 @@ describe('LodgingUnitCard — summer’s type scale', () => {
   })
 })
 
+describe('LodgingUnitCard — the occupant well', () => {
+  /*
+   * Summer's `BunkCard` holds its campers in a `min-h-[100px]` well. This card
+   * had no well at all: the empty state was a 4px-padded line, so an empty
+   * room was 139px against an occupied median of 188px and a two-party card of
+   * up to 357px.
+   *
+   * The well is what makes dropping `items-start` survivable. Grid row height
+   * already equals the tallest card in the row, so stretching does not reclaim
+   * a pixel — it moves the whitespace inside the card border. Without a well
+   * that grows and an invitation that centres in it, stretch just produces 28
+   * blown-up empty boxes with the message pinned to the top edge.
+   */
+  function well(container: HTMLElement): HTMLElement | null {
+    const card = container.querySelector('[data-unit-card]')
+    const occupant = card?.querySelector('[data-family-card]')
+    if (occupant) return occupant.parentElement
+    // Empty slot: the invitation is the well's only child.
+    return card?.querySelector('p.italic')?.parentElement ?? null
+  }
+
+  it('gives an empty slot a well that grows with the row', () => {
+    const { container } = render(
+      <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />
+    )
+    expect(well(container)).toHaveClass('min-h-[100px]')
+    expect(well(container)).toHaveClass('flex-1')
+  })
+
+  it('gives an occupied slot the same well, so rows agree', () => {
+    // Same element in both branches on purpose. Two wells drift.
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ parties: [party()] })}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(well(container)).toHaveClass('min-h-[100px]')
+    expect(well(container)).toHaveClass('flex-1')
+  })
+
+  it('centres the invitation in the well rather than pinning it to the top', () => {
+    /*
+     * A deliberate divergence, stated because §4 requires it. Summer
+     * top-aligns its message under `py-8`, which reads fine because a bunk
+     * card is uniformly tall. These cards stretch across a 139–357px range, so
+     * a top-aligned message in a tall empty card sits 130px above its own
+     * floor. `m-auto` on the sole child of a flex column centres it both ways.
+     */
+    const { container } = render(
+      <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" canPlace onOpenParty={vi.fn()} />
+    )
+    const invitation = screen.getByText('Drop families here')
+    expect(invitation).toHaveClass('m-auto')
+    expect(invitation).not.toHaveClass('py-1')
+    expect(container.querySelector('[data-unit-card]')).toBeInTheDocument()
+  })
+})
+
 describe('LodgingUnitCard — summer’s chrome, the rest of it', () => {
   it('does not copy BunkCard’s inert hover class', () => {
     /*

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -70,8 +70,15 @@ describe('LodgingUnitCard', () => {
   })
 
   it('renders unknown capacity as an em dash, never as zero', () => {
-    // `null` is UNKNOWN. The API already maps PocketBase's stored 0 to null,
-    // and "sleeps 0" is a lie about a cabin nobody has measured.
+    /*
+     * `null` is UNKNOWN. The API already maps PocketBase's stored 0 to null,
+     * and "sleeps 0" is a lie about a cabin nobody has measured.
+     *
+     * The figure became `occupancy/capacity`, so the em dash is now the
+     * DENOMINATOR rather than the whole string. The claim is unchanged and is
+     * the point of the second assertion: an empty unmeasured room reads
+     * `0/—`, never `0/0`.
+     */
     render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ sleeps: null }) })}
@@ -79,8 +86,8 @@ describe('LodgingUnitCard', () => {
         onOpenParty={vi.fn()}
       />
     )
-    expect(screen.getByText('—')).toBeInTheDocument()
-    expect(screen.queryByText('0')).not.toBeInTheDocument()
+    expect(screen.getByText('0/—')).toBeInTheDocument()
+    expect(screen.queryByText('0/0')).not.toBeInTheDocument()
   })
 
   it('shows how many spaces the unit sleeps when it is known', () => {
@@ -533,7 +540,10 @@ describe('LodgingUnitCard — summer’s type scale', () => {
     // Summer prints `{occupancy}/{capacity}` at `text-sm`. The figure is the
     // second thing read on the card; at 11px it read as a footnote.
     render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
-    expect(screen.getByTitle('Sleeps 5')).toHaveClass('text-sm')
+    // Matched loosely: the title gained the occupancy count alongside the
+    // capacity. What this test pins is the SIZE of that element, not its
+    // wording — the wording has its own tests.
+    expect(screen.getByTitle(/Sleeps 5/)).toHaveClass('text-sm')
   })
 
   it('sets the consent line at body size, not meta size', () => {
@@ -573,6 +583,134 @@ describe('LodgingUnitCard — summer’s type scale', () => {
     )
     expect(screen.getByText('Inactive')).toHaveClass('text-xs')
     expect(screen.getByText('2 families')).toHaveClass('text-xs')
+  })
+})
+
+describe('LodgingUnitCard — how full the room is', () => {
+  /*
+   * The corner figure was CAPACITY, so the card looked identical whether the
+   * room was empty or full — the one functional gap the styling work left.
+   *
+   * Summer prints `{occupancy}/{capacity}` and backs it with a four-stop
+   * colour ramp and a utilization bar. NEITHER is ported, deliberately.
+   * Summer's ramp is a percentage of a fixed capacity of 12 and has five
+   * distinguishable states; family rooms average about five beds and plenty
+   * sleep two, where the ramp is a binary wearing four colours. The card's
+   * border already carries the area hue (§3.10) and the amber consent edge,
+   * so a third channel would be competing for one surface. What is kept is
+   * the figure and ONE emphasis state, for the only actionable case.
+   */
+  it('says how many are in the room, not just what it sleeps', () => {
+    render(
+      <LodgingUnitCard
+        slot={slot({ parties: [party({ party_size: 3 })] })}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('3/5')).toBeInTheDocument()
+  })
+
+  it('distinguishes an empty room from a full one', () => {
+    // The whole point: before this, both rendered "5".
+    render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
+    expect(screen.getByText('0/5')).toBeInTheDocument()
+  })
+
+  it('marks a room holding more people than it sleeps', () => {
+    render(
+      <LodgingUnitCard
+        slot={slot({ unit: unit({ sleeps: 4 }), parties: [party({ party_size: 6 })] })}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('6/4')).toHaveClass('text-destructive')
+    expect(screen.getByText('Over capacity')).toBeInTheDocument()
+  })
+
+  it('leaves a room within capacity unmarked', () => {
+    render(
+      <LodgingUnitCard
+        slot={slot({ parties: [party({ party_size: 5 })] })}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('5/5')).not.toHaveClass('text-destructive')
+    expect(screen.queryByText('Over capacity')).not.toBeInTheDocument()
+  })
+
+  it('never calls an unmeasured room over capacity', () => {
+    // No denominator, so there is nothing to be over. Judging it would be the
+    // same lie as printing its capacity as 0.
+    render(
+      <LodgingUnitCard
+        slot={slot({ unit: unit({ sleeps: null }), parties: [party({ party_size: 9 })] })}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('9/—')).toBeInTheDocument()
+    expect(screen.queryByText('Over capacity')).not.toBeInTheDocument()
+  })
+
+  it('withholds the verdict when a household also holds a room off this card', () => {
+    /*
+     * The building is drawn SPLIT and one household holds both rooms, so it is
+     * drawn on each (#2010, which #2040 left alone). Six people against this
+     * room's three beds is not something anyone can support: there is no
+     * per-room breakdown to divide by. The figure stands as an upper bound and
+     * the CLAIM is withheld — a family spread across two rooms it needs is not
+     * over anything.
+     */
+    const house = unit({ code: 'house', name: 'Aspen House', is_container: true, sleeps: 7 })
+    const r1 = unit({ code: 'r1', unit_id: 'u2', name: 'Aspen 1', parent_code: 'house', sleeps: 3 })
+    const r2 = unit({ code: 'r2', unit_id: 'u3', name: 'Aspen 2', parent_code: 'house', sleeps: 3 })
+    render(
+      <LodgingUnitCard
+        slot={slot({
+          unit: r1,
+          parties: [party({ party_size: 6, unit_code: '', unit_codes: ['r1', 'r2'] })],
+        })}
+        units={[house, r1, r2]}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('6/3')).not.toHaveClass('text-destructive')
+    expect(screen.queryByText('Over capacity')).not.toBeInTheDocument()
+  })
+
+  it('says the household spans rooms, so the figure is not read as a fault', () => {
+    // Without this the bare `6/3` reads as overfull whether or not it is
+    // coloured, which is worse than showing nothing.
+    const house = unit({ code: 'house', name: 'Aspen House', is_container: true, sleeps: 7 })
+    const r1 = unit({ code: 'r1', unit_id: 'u2', name: 'Aspen 1', parent_code: 'house', sleeps: 3 })
+    const r2 = unit({ code: 'r2', unit_id: 'u3', name: 'Aspen 2', parent_code: 'house', sleeps: 3 })
+    render(
+      <LodgingUnitCard
+        slot={slot({
+          unit: r1,
+          parties: [party({ party_size: 6, unit_code: '', unit_codes: ['r1', 'r2'] })],
+        })}
+        units={[house, r1, r2]}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Spans 2 rooms')).toBeInTheDocument()
+  })
+
+  it('says nothing about spanning on an ordinary room', () => {
+    render(
+      <LodgingUnitCard
+        slot={slot({ parties: [party()] })}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.queryByText(/Spans/)).not.toBeInTheDocument()
   })
 })
 

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -162,6 +162,53 @@ describe('LodgingUnitCard', () => {
     expect(card).toHaveStyle({ borderTopColor: 'hsl(160 45% 42%)' })
   })
 
+  /*
+   * CLAUDE.md §4, "Family Camp Models Summer": same UI primitives, same
+   * Tailwind grammar. Summer's `BunkCard` is a `.card-lodge` at `p-4`; this
+   * card hand-rolled `bg-card rounded-xl border p-2.5` instead, which is why
+   * it read as a table row rather than a card — no shadow, no hover lift, and
+   * a padding less than two thirds of summer's.
+   *
+   * Pinned as classes rather than computed style on purpose: jsdom parses no
+   * Tailwind, so a computed-style assertion here would pass against an empty
+   * string and prove nothing (see `reference_frontend_source_grep_tests`).
+   */
+  it('wears the shared lodge card chrome, as summer’s BunkCard does', () => {
+    const { container } = render(
+      <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />
+    )
+    const card = container.querySelector('[data-unit-card]')
+    // The shared component class — shadow, 2px border, rounded-2xl, hover
+    // lift — rather than a second hand-rolled copy of roughly the same thing.
+    expect(card).toHaveClass('card-lodge')
+    // And NOT the hand-rolled chrome it replaces. Left in place alongside
+    // `card-lodge` these fight it: `rounded-xl` loses the corner radius and
+    // `border` resets the 2px edge back to 1px.
+    expect(card).not.toHaveClass('rounded-xl')
+  })
+
+  it('pads to summer’s p-4 rather than its own p-2.5', () => {
+    const { container } = render(
+      <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />
+    )
+    const card = container.querySelector('[data-unit-card]')
+    expect(card).toHaveClass('p-4')
+    expect(card).not.toHaveClass('p-2.5')
+  })
+
+  it('keeps the area hue winning over the card-lodge border colour', () => {
+    // `.card-lodge` sets `border-border` on all four sides and repaints them
+    // `border-primary/50` on hover. The hue is an inline style, which beats
+    // both — this pins that the chrome swap did not silently cost §3.10 its
+    // secondary channel, on hover or otherwise.
+    const { container } = render(
+      <LodgingUnitCard slot={slot()} hue="hsl(38 75% 50%)" onOpenParty={vi.fn()} />
+    )
+    const card = container.querySelector('[data-unit-card]')
+    expect(card).toHaveStyle({ borderTopColor: 'hsl(38 75% 50%)' })
+    expect(card).toHaveClass('border-t-[3px]')
+  })
+
   it('keys two adult-weekend individuals in one room apart', () => {
     // An adult weekend enrols PEOPLE, and the API sends `household_cm_id = 0`
     // for them rather than omitting it — Pydantic `int = 0`. A `??` chain

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -480,16 +480,36 @@ describe('LodgingUnitCard — summer’s type scale', () => {
   function arbitraryTextSizes(container: HTMLElement): string[] {
     const card = container.querySelector('[data-unit-card]')
     if (!card) throw new Error('no card rendered')
-    return [card, ...card.querySelectorAll('*')]
-      .flatMap((el) => Array.from(el.classList))
-      .filter((cls) => /^text-\[\d+px\]$/.test(cls))
+    return (
+      [card, ...card.querySelectorAll('*')]
+        .flatMap((el) => Array.from(el.classList))
+        // Variant prefixes and rem/em too, not just a bare `text-[Npx]`: a
+        // `sm:text-[11px]` is the same divergence wearing a breakpoint, and the
+        // narrower pattern is what let the merge and split pills through once
+        // already. Arbitrary COLOURS stay out of scope — `[^\]]+` would sweep
+        // `text-[#fff]`, which is not a scale problem.
+        .filter((cls) => /^(?:[\w-]+:)*text-\[\d+(?:\.\d+)?(?:px|rem|em)\]$/.test(cls))
+    )
   }
 
   it('uses the stock scale everywhere, with no arbitrary pixel sizes left', () => {
     const { container } = render(
       <LodgingUnitCard
         slot={slot({
-          unit: unit({ is_active: false, bathroom: 'private', has_power: true, has_ac: true }),
+          // `parent_code` + container + combined are what MOUNT the merge and
+          // split pills; without them this sweep silently checked a card that
+          // had neither, and both kept a `text-[10px]` through the whole
+          // type-scale migration. The assertions below are the guard: a sweep
+          // that stops rendering an element must fail, not quietly narrow.
+          unit: unit({
+            is_active: false,
+            bathroom: 'private',
+            has_power: true,
+            has_ac: true,
+            parent_code: 'cedar-house',
+            is_container: true,
+            is_combined: true,
+          }),
           parties: [party(), party({ household_cm_id: 102, display_name: 'Garcia' })],
           consent: {
             declinedCount: 1,
@@ -501,9 +521,14 @@ describe('LodgingUnitCard — summer’s type scale', () => {
         hue="hsl(160 45% 42%)"
         canSetAvailability
         onSetAvailability={vi.fn()}
+        canMerge
+        onMerge={vi.fn()}
+        onSplit={vi.fn()}
         onOpenParty={vi.fn()}
       />
     )
+    expect(screen.getByRole('button', { name: /Merge Cedar 1/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Split Cedar 1/ })).toBeInTheDocument()
     expect(arbitraryTextSizes(container)).toEqual([])
   })
 

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -366,7 +366,19 @@ export function LodgingUnitCard({
       )}
 
       {parties.length === 0 ? (
-        <p className="text-muted-foreground py-1 text-center text-sm italic">Empty</p>
+        /* Summer's wording in family vocabulary — `BunkCard` says "Drop
+           campers here". An empty slot's job is to be a target, and "Empty"
+           described the state without offering the action.
+
+           Only while placement is live, though. Without a scenario or without
+           `bunking.manage` there is nothing to drop, so the invitation would
+           name an action the reader cannot take. Summer renders NOTHING at all
+           in production mode; these cards are small enough that a blank body
+           reads as broken rather than read-only, so the state is stated
+           instead. */
+        <p className="text-muted-foreground py-1 text-center text-sm italic">
+          {canPlace ? 'Drop families here' : 'Empty'}
+        </p>
       ) : (
         <div className="flex flex-col gap-2">
           {parties.map((party) => (

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -186,10 +186,23 @@ export function LodgingUnitCard({
       data-unit-code={unit.code}
       ref={setCardRef}
       style={{ borderTopColor: hue }}
-      className={`bg-card flex flex-col gap-2 rounded-xl border border-t-[3px] p-2.5 transition-colors ${
-        consent
-          ? 'border-amber-400 ring-1 ring-amber-400/40 dark:border-amber-500'
-          : 'border-border'
+      /*
+       * `.card-lodge` is summer's card chrome, not a lookalike — the same
+       * class `BunkCard` wears (CLAUDE.md §4, "Family Camp Models Summer").
+       * It carries `bg-card`, `rounded-2xl`, a 2px border, the two-layer
+       * lodge shadow and the hover lift. This card used to hand-roll
+       * `bg-card rounded-xl border`, which is the same idea minus the shadow
+       * and the hover — so it read as a table row rather than a card.
+       *
+       * ORDER MATTERS BELOW. `.card-lodge` lives in `@layer components`, so
+       * every utility here outranks it whatever the string order: the amber
+       * consent edge, the empty-slot wash and the drop-target ring all still
+       * land. The hue top edge is an inline style and outranks both, which is
+       * what keeps §3.10's secondary channel through `card-lodge`'s own
+       * `border-border` and its `border-primary/50` hover.
+       */
+      className={`card-lodge flex flex-col gap-2 border-t-[3px] p-4 ${
+        consent ? 'border-amber-400 ring-1 ring-amber-400/40 dark:border-amber-500' : ''
       } ${parties.length === 0 ? 'bg-muted/25 border-dashed' : ''} ${
         isUnitOver || isMergeOver ? 'border-primary ring-primary/50 bg-primary/5 ring-2' : ''
       } ${

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -365,23 +365,44 @@ export function LodgingUnitCard({
         <p className="text-sm font-medium text-amber-700 dark:text-amber-400">{consent.reason}</p>
       )}
 
-      {parties.length === 0 ? (
-        /* Summer's wording in family vocabulary — `BunkCard` says "Drop
-           campers here". An empty slot's job is to be a target, and "Empty"
-           described the state without offering the action.
+      {/*
+        The occupant well — summer's `min-h-[100px]`, and ONE element across
+        both branches. Two wells drift; this one cannot.
 
-           Only while placement is live, though. Without a scenario or without
-           `bunking.manage` there is nothing to drop, so the invitation would
-           name an action the reader cannot take. Summer renders NOTHING at all
-           in production mode; these cards are small enough that a blank body
-           reads as broken rather than read-only, so the state is stated
-           instead. */
-        <p className="text-muted-foreground py-1 text-center text-sm italic">
-          {canPlace ? 'Drop families here' : 'Empty'}
-        </p>
-      ) : (
-        <div className="flex flex-col gap-2">
-          {parties.map((party) => (
+        `flex-1` is what makes dropping the grid's `items-start` survivable.
+        A grid row is already as tall as its tallest card, so stretching the
+        cards reclaims no space at all — it moves the whitespace from outside
+        the card border to inside it. Without a well that absorbs the extra
+        height, stretch just yields 28 blown-up empty cards with the message
+        pinned to the top edge, which is worse than the raggedness it fixes.
+
+        `min-h-[100px]` earns its place separately: it lifts an empty card off
+        its 139px floor toward the 188px occupied median, so rows start closer
+        together before stretch has to do anything.
+      */}
+      <div className="flex min-h-[100px] flex-1 flex-col gap-2">
+        {parties.length === 0 ? (
+          /* Summer's wording in family vocabulary — `BunkCard` says "Drop
+             campers here". An empty slot's job is to be a target, and "Empty"
+             described the state without offering the action.
+
+             Only while placement is live, though. Without a scenario or
+             without `bunking.manage` there is nothing to drop, so the
+             invitation would name an action the reader cannot take. Summer
+             renders NOTHING at all in production mode; these cards are small
+             enough that a blank body reads as broken rather than read-only, so
+             the state is stated instead.
+
+             `m-auto` CENTRES it, where summer top-aligns under `py-8`. A
+             deliberate divergence (§4): summer's bunk cards are uniformly
+             tall, so a top-aligned message always sits near its own floor.
+             These stretch across a 139–357px range, where the same message
+             would hang 130px above the bottom of a tall empty card. */
+          <p className="text-muted-foreground m-auto text-center text-sm italic">
+            {canPlace ? 'Drop families here' : 'Empty'}
+          </p>
+        ) : (
+          parties.map((party) => (
             <FamilyCard
               key={partyKey(party)}
               party={party}
@@ -390,9 +411,9 @@ export function LodgingUnitCard({
               isDraggable={canPlace}
               onOpen={onOpenParty}
             />
-          ))}
-        </div>
-      )}
+          ))
+        )}
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -348,7 +348,7 @@ export function LodgingUnitCard({
             onClick={() => {
               onMerge?.(unit)
             }}
-            className="border-border text-muted-foreground hover:text-foreground hover:border-foreground/30 inline-flex cursor-grab items-center gap-0.5 rounded-full border px-1.5 py-0.5 text-[10px] font-medium active:cursor-grabbing disabled:opacity-40"
+            className="border-border text-muted-foreground hover:text-foreground hover:border-foreground/30 inline-flex cursor-grab items-center gap-0.5 rounded-full border px-1.5 py-0.5 text-xs font-medium active:cursor-grabbing disabled:opacity-40"
           >
             <Merge className="h-3 w-3" aria-hidden="true" />
             Merge
@@ -374,7 +374,7 @@ export function LodgingUnitCard({
               onClick={() => {
                 onSplit(unit)
               }}
-              className="border-border text-muted-foreground hover:text-foreground hover:border-foreground/30 inline-flex items-center gap-0.5 rounded-full border px-1.5 py-0.5 text-[10px] font-medium disabled:opacity-40"
+              className="border-border text-muted-foreground hover:text-foreground hover:border-foreground/30 inline-flex items-center gap-0.5 rounded-full border px-1.5 py-0.5 text-xs font-medium disabled:opacity-40"
             >
               <Split className="h-3 w-3" aria-hidden="true" />
               Split

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -200,8 +200,22 @@ export function LodgingUnitCard({
        * land. The hue top edge is an inline style and outranks both, which is
        * what keeps §3.10's secondary channel through `card-lodge`'s own
        * `border-border` and its `border-primary/50` hover.
+       *
+       * NO `hover:shadow-lodge-lg` HERE, though `BunkCard` carries one. That
+       * class is inert: `.shadow-lodge-*` are hand-written rules in `@layer
+       * utilities`, not Tailwind `@utility` declarations, so v4 emits no
+       * `hover:` variant of them — verified in the browser, where no selector
+       * matching `hover.*shadow-lodge` exists in any of the 3,373 loaded
+       * rules. Summer's hover lift comes entirely from `.card-lodge:hover`,
+       * which this card already has. Copying the class would have propagated
+       * a no-op by imitation, which is the `forest-950` failure (#1894) that
+       * CLAUDE.md §4 names by name.
+       *
+       * `gap-3` is summer's 12px row rhythm (`BunkCard` separates header, bar
+       * and roster with `mb-3`). This ran at a flat 8px, which left the title
+       * sitting on top of the amenity row.
        */
-      className={`card-lodge flex flex-col gap-2 border-t-[3px] p-4 ${
+      className={`card-lodge flex flex-col gap-3 border-t-[3px] p-4 ${
         consent ? 'border-amber-400 ring-1 ring-amber-400/40 dark:border-amber-500' : ''
       } ${parties.length === 0 ? 'bg-muted/25 border-dashed' : ''} ${
         isUnitOver || isMergeOver ? 'border-primary ring-primary/50 bg-primary/5 ring-2' : ''
@@ -214,16 +228,29 @@ export function LodgingUnitCard({
       }`}
     >
       <div className="flex items-baseline gap-1.5">
-        <span className="text-foreground truncate text-[13px] font-semibold">{unit.name}</span>
+        {/* Summer's scale, not a parallel one (CLAUDE.md §4): `text-lg` title
+            over `text-sm` body over `text-xs` meta, the same three steps
+            `BunkCard` uses. This card was built on `text-[13px]` /
+            `text-[11px]` / `text-[10px]`, whose LARGEST size was smaller than
+            summer's body.
+
+            An `<h3>`, as `BunkCard` titles its bunk, and the tag is doing
+            typographic work rather than only semantic: `index.css` gives
+            `h1, h2, h3` the display face (Fraunces, `-0.02em`, `ss01`/`ss02`).
+            As a `<span>` this title rendered the same 18px in the body sans,
+            which is why the boards still read differently once the sizes
+            matched. `text-lg` is a utility and outranks the base rule's
+            `text-2xl md:text-3xl`, so only the face and tracking carry over. */}
+        <h3 className="text-foreground truncate text-lg font-semibold">{unit.name}</h3>
         <span
           title={capacityKnown ? `Sleeps ${String(unit.sleeps)}` : 'Capacity not recorded'}
-          className="text-muted-foreground ml-auto text-[11px] tabular-nums"
+          className="text-muted-foreground ml-auto text-sm tabular-nums"
         >
           {capacityKnown ? String(unit.sleeps) : '—'}
         </span>
       </div>
 
-      <div className="text-muted-foreground flex flex-wrap items-center gap-1.5 text-[11px]">
+      <div className="text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm">
         {unit.bathroom === 'private' && (
           <span className="inline-flex items-center gap-0.5">
             <Bath className="h-3 w-3" aria-hidden="true" /> Private
@@ -237,14 +264,14 @@ export function LodgingUnitCard({
         {unit.has_power === true && <Plug className="h-3 w-3" aria-label="Power" />}
         {unit.has_ac === true && <Snowflake className="h-3 w-3" aria-label="Air conditioning" />}
         {badge && (
-          <span className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${badge.className}`}>
+          <span className={`rounded-full px-1.5 py-0.5 text-xs font-medium ${badge.className}`}>
             {badge.label}
           </span>
         )}
         {/* A deactivated room only reaches the board when somebody is still in
             it — hiding it would drop them. */}
         {unit.is_active === false && (
-          <span className="rounded-full bg-slate-200 px-1.5 py-0.5 text-[10px] font-medium text-slate-800 dark:bg-slate-800 dark:text-slate-200">
+          <span className="rounded-full bg-slate-200 px-1.5 py-0.5 text-xs font-medium text-slate-800 dark:bg-slate-800 dark:text-slate-200">
             Inactive
           </span>
         )}
@@ -317,7 +344,7 @@ export function LodgingUnitCard({
 
       {isShared && (
         <span
-          className={`inline-flex w-fit items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold ${
+          className={`inline-flex w-fit items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold ${
             consent
               ? 'bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-300'
               : 'bg-muted text-muted-foreground'
@@ -335,15 +362,13 @@ export function LodgingUnitCard({
       {/* Spec §11: a household answered `no_share` and is sharing anyway. On
           2026 data this fires exactly once, and that one case is real. */}
       {consent && (
-        <p className="text-[11px] font-medium text-amber-700 dark:text-amber-400">
-          {consent.reason}
-        </p>
+        <p className="text-sm font-medium text-amber-700 dark:text-amber-400">{consent.reason}</p>
       )}
 
       {parties.length === 0 ? (
-        <p className="text-muted-foreground py-1 text-center text-[11px] italic">Empty</p>
+        <p className="text-muted-foreground py-1 text-center text-sm italic">Empty</p>
       ) : (
-        <div className="flex flex-col gap-1.5">
+        <div className="flex flex-col gap-2">
           {parties.map((party) => (
             <FamilyCard
               key={partyKey(party)}

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -15,7 +15,7 @@ import { useDraggable, useDroppable } from '@dnd-kit/core'
 import { Bath, Merge, Plug, Snowflake, Split, TriangleAlert, Users } from 'lucide-react'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
-import { overlappingPartyKeys, type BoardSlot } from './boardLayout'
+import { overlappingPartyKeys, slotOccupancy, type BoardSlot } from './boardLayout'
 import { isValidMergeTarget, mergeDragId, unitDroppableId } from './dragPlacement'
 import { FamilyCard } from './FamilyCard'
 import { partyKey } from './partyKey'
@@ -121,6 +121,20 @@ export function LodgingUnitCard({
   const { unit, parties, consent } = slot
   const badge = reservationBadge(unit)
   const capacityKnown = unit.sleeps !== null && unit.sleeps !== undefined
+  /*
+   * How full the room is. The corner figure used to be CAPACITY alone, so the
+   * card read identically whether the room was empty or full.
+   *
+   * `spanWidth` is why this is not simply a sum. A party holding several rooms
+   * is drawn on each of them (#2010, which #2040 left alone), so the same
+   * people appear on more than one card and no per-room split exists to divide
+   * them by. The count still stands — over-stating reads as "look at this",
+   * where dropping the party would read as "room for more" — but the
+   * over-capacity CLAIM is withheld, because a household spread across two
+   * rooms it needs is not over anything.
+   */
+  const { occupants, spanWidth } = slotOccupancy(slot, units)
+  const overCapacity = capacityKnown && spanWidth === 0 && occupants > (unit.sleeps ?? 0)
   // The "N families" count chip below: a true statement about the CARD
   // regardless of which rooms anyone actually holds, so it stays keyed on
   // the card's whole party count.
@@ -243,10 +257,18 @@ export function LodgingUnitCard({
             `text-2xl md:text-3xl`, so only the face and tracking carry over. */}
         <h3 className="text-foreground truncate text-lg font-semibold">{unit.name}</h3>
         <span
-          title={capacityKnown ? `Sleeps ${String(unit.sleeps)}` : 'Capacity not recorded'}
-          className="text-muted-foreground ml-auto text-sm tabular-nums"
+          title={
+            capacityKnown
+              ? `Sleeps ${String(unit.sleeps)} · ${String(occupants)} placed`
+              : `Capacity not recorded · ${String(occupants)} placed`
+          }
+          className={`ml-auto text-sm tabular-nums ${
+            overCapacity ? 'text-destructive font-semibold' : 'text-muted-foreground'
+          }`}
         >
-          {capacityKnown ? String(unit.sleeps) : '—'}
+          {/* An unmeasured room keeps the em dash as its DENOMINATOR. `0/0`
+              would be the same lie the em dash exists to refuse. */}
+          {`${String(occupants)}/${capacityKnown ? String(unit.sleeps) : '—'}`}
         </span>
       </div>
 
@@ -266,6 +288,24 @@ export function LodgingUnitCard({
         {badge && (
           <span className={`rounded-full px-1.5 py-0.5 text-xs font-medium ${badge.className}`}>
             {badge.label}
+          </span>
+        )}
+        {/* The only actionable capacity state, and the only one summer's
+            four-stop ramp carries that survives at these denominators — a
+            room that sleeps two goes green to orange on its second occupant,
+            which is a binary wearing four colours. */}
+        {overCapacity && (
+          <span className="rounded-full bg-red-100 px-1.5 py-0.5 text-xs font-medium text-red-800 dark:bg-red-950/50 dark:text-red-300">
+            Over capacity
+          </span>
+        )}
+        {/* Without this the bare figure reads as overfull whether or not it is
+            coloured, which is worse than showing nothing. It says the count
+            belongs to a placement wider than this card, not that the room is
+            in trouble. */}
+        {spanWidth > 0 && (
+          <span className="border-border text-muted-foreground rounded-full border px-1.5 py-0.5 text-xs font-medium">
+            {`Spans ${String(spanWidth)} rooms`}
           </span>
         )}
         {/* A deactivated room only reaches the board when somebody is still in

--- a/frontend/src/components/weekend/UnitAvailabilityControl.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.tsx
@@ -73,7 +73,7 @@ export function UnitAvailabilityControl({
     unit.family_available_override !== null &&
     unit.family_available_override !== undefined &&
     storedReason !== '' ? (
-      <span className="text-muted-foreground w-full text-[11px] italic">{storedReason}</span>
+      <span className="text-muted-foreground w-full text-sm italic">{storedReason}</span>
     ) : null
 
   if (action === null || !canManage) return explanation
@@ -114,10 +114,10 @@ export function UnitAvailabilityControl({
               setReason(event.target.value)
               setWantsReason(false)
             }}
-            className="border-border bg-background text-foreground placeholder:text-muted-foreground/60 focus:border-primary/50 focus:ring-primary/10 w-full rounded-md border px-1.5 py-1 text-[11px] focus:ring-2 focus:outline-none aria-[invalid=true]:border-amber-500"
+            className="border-border bg-background text-foreground placeholder:text-muted-foreground/60 focus:border-primary/50 focus:ring-primary/10 w-full rounded-md border px-1.5 py-1 text-sm focus:ring-2 focus:outline-none aria-[invalid=true]:border-amber-500"
           />
           {wantsReason && reason.trim() === '' && (
-            <span className="text-[10px] font-medium text-amber-700 dark:text-amber-400">
+            <span className="text-xs font-medium text-amber-700 dark:text-amber-400">
               Say why, so next week&rsquo;s staff can act on it.
             </span>
           )}
@@ -125,14 +125,14 @@ export function UnitAvailabilityControl({
             <button
               type="submit"
               disabled={isSaving}
-              className="bg-primary text-primary-foreground rounded-md px-2 py-0.5 text-[11px] font-medium disabled:opacity-40"
+              className="bg-primary text-primary-foreground rounded-md px-2 py-0.5 text-xs font-medium disabled:opacity-40"
             >
               {action.label}
             </button>
             <button
               type="button"
               onClick={close}
-              className="text-muted-foreground hover:text-foreground rounded-md px-1.5 py-0.5 text-[11px]"
+              className="text-muted-foreground hover:text-foreground rounded-md px-1.5 py-0.5 text-xs"
             >
               Cancel
             </button>
@@ -158,7 +158,7 @@ export function UnitAvailabilityControl({
           }
           onSubmit({ familyAvailable: action.familyAvailable, reason: '' })
         }}
-        className="border-border text-muted-foreground hover:text-foreground hover:border-foreground/30 rounded-full border px-1.5 py-0.5 text-[10px] font-medium disabled:opacity-40"
+        className="border-border text-muted-foreground hover:text-foreground hover:border-foreground/30 rounded-full border px-1.5 py-0.5 text-xs font-medium disabled:opacity-40"
       >
         {action.label}
       </button>

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -13,7 +13,7 @@ import type {
   ShareEligibilityValue,
   SharePreferenceValue,
 } from '../../types/lodging'
-import { AREA_HUES, areaTokens, buildBoard, countBoardSlots } from './boardLayout'
+import { AREA_HUES, areaTokens, buildBoard, countBoardSlots, slotOccupancy } from './boardLayout'
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
   return {
@@ -69,6 +69,114 @@ function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
     ...overrides,
   }
 }
+
+describe('slotOccupancy — how many people the card can account for', () => {
+  /*
+   * The corner figure was CAPACITY, so a card looked identical whether the
+   * room was empty or full. This is the numerator that fixes that.
+   *
+   * THE NUMERATOR IS KNOWN TO BE WRONG, and #1925 is the fix. `party_size`
+   * counts the household's LISTED adults rather than the attending ones, and
+   * a data investigation there found the errors run in BOTH directions, with
+   * the worst cases under-counts. It is already displayed per household on
+   * every `FamilyCard`; summing it onto the room does not create a new class
+   * of error, but it does make an existing one more consequential, because a
+   * room reading full is trusted in a way a household reading 6 is not. This
+   * is deliberately the ONE place that computes it, so #1925 has one edit.
+   *
+   * SPANNING is the other half. Since #2010 a party holding several rooms is
+   * drawn on each of them, and #2040 deliberately left that rule alone. When
+   * a party occupies leaves this card does not draw, the room-level count is
+   * not knowable — there is no per-room breakdown to divide, and inventing
+   * one is what `sleeps: null` renders an em dash to avoid. So the count
+   * stands as an upper bound and the OVER-CAPACITY VERDICT is withheld:
+   * a number with a marker is context, "over capacity" is a claim.
+   *
+   * Measured on the 2026 registry after #2040: zero parties span cards, down
+   * from one. Combining is what removed it, and prod will combine more. This
+   * is a guard on a reachable-but-empty state, which is exactly the kind that
+   * rots undetected — hence tested.
+   */
+  it('sums the parties in the room', () => {
+    const slot = {
+      unit: unit(),
+      parties: [party({ party_size: 3 }), party({ party_size: 2 })],
+      consent: null,
+    }
+    expect(slotOccupancy(slot, [unit()])).toEqual({ occupants: 5, spanWidth: 0 })
+  })
+
+  it('counts an empty room as nobody, not as unknown', () => {
+    expect(slotOccupancy({ unit: unit(), parties: [], consent: null }, [unit()])).toEqual({
+      occupants: 0,
+      spanWidth: 0,
+    })
+  })
+
+  it('falls back to the named people when party_size is unset', () => {
+    // One adult and one child in the fixture. A `party_size` of 0 is "not
+    // stated", not "nobody" — the same reading `FamilyCard` has always used.
+    const slot = { unit: unit(), parties: [party({ party_size: 0 })], consent: null }
+    expect(slotOccupancy(slot, [unit()]).occupants).toBe(2)
+  })
+
+  it('counts a party that named a room beneath this combined card', () => {
+    // The card is the building; the placement named a room in it. Covered, so
+    // nothing spans — this is the case #2040 made the common one.
+    const house = unit({
+      code: 'house',
+      name: 'Aspen House',
+      is_container: true,
+      is_combined: true,
+      sleeps: 7,
+    })
+    const r1 = unit({ code: 'r1', unit_id: 'u2', name: 'Aspen 1', parent_code: 'house', sleeps: 3 })
+    const r2 = unit({ code: 'r2', unit_id: 'u3', name: 'Aspen 2', parent_code: 'house', sleeps: 3 })
+    const slot = {
+      unit: house,
+      parties: [party({ party_size: 6, unit_code: 'r1' })],
+      consent: null,
+    }
+    expect(slotOccupancy(slot, [house, r1, r2])).toEqual({ occupants: 6, spanWidth: 0 })
+  })
+
+  it('marks the card when a party also holds a room it does not draw', () => {
+    // The building is drawn SPLIT and one household holds both rooms, so it
+    // is drawn on each. Six people against this room's three beds is not a
+    // verdict anyone can support; `spanWidth` is what withholds it.
+    const house = unit({ code: 'house', name: 'Aspen House', is_container: true, sleeps: 7 })
+    const r1 = unit({ code: 'r1', unit_id: 'u2', name: 'Aspen 1', parent_code: 'house', sleeps: 3 })
+    const r2 = unit({ code: 'r2', unit_id: 'u3', name: 'Aspen 2', parent_code: 'house', sleeps: 3 })
+    const spanning = party({ party_size: 6, unit_code: '', unit_codes: ['r1', 'r2'] })
+    expect(
+      slotOccupancy({ unit: r1, parties: [spanning], consent: null }, [house, r1, r2])
+    ).toEqual({
+      occupants: 6,
+      spanWidth: 2,
+    })
+  })
+
+  it('marks the card when a container placement fans down onto it', () => {
+    // A placement naming the building, with the building drawn split. #2040
+    // fans it onto every drawn descendant, so the same six people appear on
+    // both rooms.
+    const house = unit({ code: 'house', name: 'Aspen House', is_container: true, sleeps: 7 })
+    const r1 = unit({ code: 'r1', unit_id: 'u2', name: 'Aspen 1', parent_code: 'house', sleeps: 3 })
+    const r2 = unit({ code: 'r2', unit_id: 'u3', name: 'Aspen 2', parent_code: 'house', sleeps: 3 })
+    const onBuilding = party({ party_size: 6, unit_code: 'house' })
+    expect(
+      slotOccupancy({ unit: r1, parties: [onBuilding], consent: null }, [house, r1, r2]).spanWidth
+    ).toBe(2)
+  })
+
+  it('degrades to raw codes when the registry is not supplied', () => {
+    // `LodgingUnitCard` defaults `units` to `[]`. A leaf card whose party
+    // names that leaf must still be covered, or every card would look as
+    // though it spanned.
+    const slot = { unit: unit(), parties: [party({ unit_code: 'cedar-1' })], consent: null }
+    expect(slotOccupancy(slot, []).spanWidth).toBe(0)
+  })
+})
 
 describe('areaTokens — the URL shorthand for each area', () => {
   /*

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -13,7 +13,7 @@ import type {
   ShareEligibilityValue,
   SharePreferenceValue,
 } from '../../types/lodging'
-import { AREA_HUES, buildBoard, countBoardSlots } from './boardLayout'
+import { AREA_HUES, areaTokens, buildBoard, countBoardSlots } from './boardLayout'
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
   return {
@@ -69,6 +69,81 @@ function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
     ...overrides,
   }
 }
+
+describe('areaTokens — the URL shorthand for each area', () => {
+  /*
+   * Collapse state lives in the query string, so each area needs a short token
+   * for it. `BoardArea.key` cannot serve: it is `code::name`, which needs
+   * escaping and puts the camp's area names in a URL that gets pasted around.
+   *
+   * The registry's own `area_code` cannot serve either, and that was the first
+   * attempt. It is hand-entered and ragged -- two letters for some areas, four
+   * for others -- so the URL read as though the codes meant different things.
+   * Generating the shorthand makes every area two characters and removes a
+   * dependency on a field nothing else in the board reads.
+   *
+   * TWO CHARACTERS IS NOT ALWAYS ENOUGH, which is the whole reason this takes
+   * the full set rather than one area at a time. On the 2026 registry
+   * "Ridge Side" and "River Side" both reduce to RS. No pure function of a
+   * single name can separate them, so the colliding pair -- and only that pair
+   * -- deepens until it is distinct.
+   */
+  function areasNamed(...names: string[]) {
+    return names.map((name, index) => ({ key: `A${String(index)}::${name}`, name }))
+  }
+
+  it('takes the initials of a two-word area', () => {
+    const tokens = areaTokens(areasNamed('Cedar Grove'))
+    expect(tokens.get('A0::Cedar Grove')).toBe('CG')
+  })
+
+  it('takes the first two letters of a one-word area', () => {
+    const tokens = areaTokens(areasNamed('Manzanitas'))
+    expect(tokens.get('A0::Manzanitas')).toBe('MA')
+  })
+
+  it('deepens a colliding pair until the two are distinct', () => {
+    // Both are R + S, and both first words start "Ri", so it takes three
+    // letters of the first word to tell them apart.
+    const tokens = areaTokens(areasNamed('Ridge Side', 'River Side'))
+    expect(tokens.get('A0::Ridge Side')).toBe('RIDS')
+    expect(tokens.get('A1::River Side')).toBe('RIVS')
+  })
+
+  it('leaves every other area on two characters when one pair collides', () => {
+    // The deepening is scoped to the group that clashed. An area that was
+    // never ambiguous must not have its links broken by an unrelated one.
+    const tokens = areaTokens(
+      areasNamed('Ridge Side', 'River Side', 'Ridge Yurts', 'Health Center')
+    )
+    expect(tokens.get('A2::Ridge Yurts')).toBe('RY')
+    expect(tokens.get('A3::Health Center')).toBe('HC')
+  })
+
+  it('gives every area on the real registry shape a distinct token', () => {
+    const names = [
+      'Golden Triangle',
+      'Health Center',
+      'Manzanitas',
+      'Ridge Side',
+      'Ridge Yurts',
+      'River Side',
+      'Tawonga Village',
+      'Tuolumne Heights',
+    ]
+    const tokens = areaTokens(areasNamed(...names))
+    expect(tokens.size).toBe(names.length)
+    expect(new Set(tokens.values()).size).toBe(names.length)
+  })
+
+  it('still yields a token for an area with no usable name', () => {
+    // `areaName` labels this one "Unassigned area" before it gets here, but a
+    // token generator that can return an empty string would drop the area out
+    // of the URL entirely.
+    const tokens = areaTokens(areasNamed(''))
+    expect(tokens.get('A0::')).toBeTruthy()
+  })
+})
 
 describe('buildBoard — which units get a card', () => {
   it('gives every leaf unit a card', () => {

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -166,6 +166,85 @@ export interface ConsentFlag {
   reason: string
 }
 
+/**
+ * One area's shorthand at a given depth: initials for a multi-word name,
+ * leading letters for a single word. Depth 1 is the two-character form.
+ */
+function shorthand(name: string, depth: number): string {
+  const words = name.split(/[^A-Za-z0-9]+/).filter((word) => word.length > 0)
+  if (words.length === 0) return 'XX'
+  const first = words[0] ?? ''
+  const second = words[1]
+  if (second === undefined) return first.slice(0, Math.max(2, depth + 1)).toUpperCase()
+  return (first.slice(0, depth) + second.charAt(0)).toUpperCase()
+}
+
+/** How far `shorthand` will deepen before falling back to a numeric suffix. */
+const MAX_TOKEN_DEPTH = 6
+
+/**
+ * A short, URL-safe token per area, keyed by `BoardArea.key`.
+ *
+ * Collapse state lives in the query string (`?closed=GT&closed=HC`), so each
+ * area needs a name that survives a URL. `key` cannot do it — it is
+ * `code::name`, which needs escaping and puts the camp's own area names into a
+ * link that gets pasted into tickets and chat.
+ *
+ * The registry's `area_code` cannot do it either, and that was the first
+ * attempt. It is hand-entered and ragged — two letters for some areas, four
+ * for others — so the URL read as though the widths meant something. Deriving
+ * the token instead makes every area two characters and drops a dependency on
+ * a field nothing else on this board reads.
+ *
+ * WHY THIS TAKES THE WHOLE SET. Two characters is not always enough, and no
+ * pure function of one name can fix that: on the 2026 registry "Ridge Side"
+ * and "River Side" both reduce to RS, and both first words begin "Ri". So the
+ * colliding group — and only that group — deepens a letter at a time until its
+ * members are distinct, leaving every other area's token, and every link
+ * already holding it, untouched.
+ *
+ * Stability: a token depends on its own name and on the names it clashes with,
+ * never on position or on the number of areas. Adding an unrelated area cannot
+ * move it. Adding one that clashes can, which is the honest cost of a short
+ * token and is why the deepening is deterministic rather than first-come.
+ */
+export function areaTokens(
+  areas: ReadonlyArray<Pick<BoardArea, 'key' | 'name'>>
+): Map<string, string> {
+  // Sorted by key so the last-resort suffix below is stable across payload
+  // orders, exactly as the hue assignment is.
+  const ordered = [...areas].sort((left, right) => left.key.localeCompare(right.key))
+  const depths = new Map(ordered.map((area) => [area.key, 1]))
+
+  for (let round = 0; round < MAX_TOKEN_DEPTH; round++) {
+    const claimants = new Map<string, string[]>()
+    for (const area of ordered) {
+      const token = shorthand(area.name, depths.get(area.key) ?? 1)
+      claimants.set(token, [...(claimants.get(token) ?? []), area.key])
+    }
+    const clashing = [...claimants.values()].filter((keys) => keys.length > 1)
+    if (clashing.length === 0) break
+    for (const keys of clashing) {
+      for (const key of keys) depths.set(key, (depths.get(key) ?? 1) + 1)
+    }
+  }
+
+  // Two names that are identical after stripping punctuation would still tie
+  // at every depth. A numeric suffix is the floor, so a token is never blank
+  // and never duplicated.
+  const taken = new Set<string>()
+  const tokens = new Map<string, string>()
+  for (const area of ordered) {
+    const base = shorthand(area.name, depths.get(area.key) ?? 1)
+    let token = base
+    let suffix = 2
+    while (taken.has(token)) token = `${base}${String(suffix++)}`
+    taken.add(token)
+    tokens.set(area.key, token)
+  }
+  return tokens
+}
+
 /** One unit card: the room, whoever is in it, and whether that is a problem. */
 export interface BoardSlot {
   unit: LodgingUnitRow

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -102,6 +102,93 @@ function occupiedLeafCodes(
 }
 
 /**
+ * How many people a party brings.
+ *
+ * THE ONE DEFINITION. It used to live privately inside `FamilyCard`, which was
+ * fine while the card was the only thing that counted people; the moment a
+ * ROOM counts them too, two copies is how the household total and the room
+ * total start disagreeing.
+ *
+ * `party_size` is KNOWN WRONG and #1925 is the fix: it counts the household's
+ * LISTED adults rather than the attending ones, and that issue's data
+ * investigation found the errors run in BOTH directions, with the worst cases
+ * under-counts. This is deliberately the single place it is read, so that fix
+ * is one edit rather than a hunt.
+ *
+ * A reported 0 means NOT STATED, not "nobody" — hence the fall back to the
+ * people actually named.
+ */
+export function partySize(party: RosterPartyRow): number {
+  const reported = party.party_size ?? 0
+  if (reported > 0) return reported
+  return (party.adults?.length ?? 0) + (party.children?.length ?? 0)
+}
+
+/** What a card can say about how full it is. */
+export interface SlotOccupancy {
+  /**
+   * People this card accounts for. An UPPER BOUND when `spanWidth > 0` — see
+   * below.
+   */
+  occupants: number
+  /**
+   * 0 when every party here is wholly inside this card; otherwise how many
+   * rooms the widest straddling party holds.
+   *
+   * Non-zero withholds the over-capacity verdict. Since #2010 a party holding
+   * several rooms is drawn on EACH of them, and #2040 deliberately left that
+   * rule alone, so the same six people appear on two cards. There is no
+   * per-room breakdown to divide them by — `party_size` is one number for the
+   * household — and inventing a split is precisely what `sleeps: null`
+   * rendering an em dash exists to refuse.
+   *
+   * Counting the party in full rather than dropping it is the safer of the two
+   * errors: it over-states, which reads as "look at this", where counting only
+   * the wholly-contained parties would under-state and read as "room for more".
+   * `occupiedLeafCodes` names that direction — failing permissive is what this
+   * surface exists to close.
+   *
+   * Withholding only the VERDICT, rather than the figure, is the distinction:
+   * a number carrying a marker is context, while "over capacity" is a claim,
+   * and a household legitimately spread across two rooms it needs is not over
+   * anything.
+   *
+   * Measured on the 2026 registry after #2040: ZERO parties span cards, down
+   * from one, because combining a whole-let building rolls them onto a single
+   * card. Owner-confirmed that a straddling household is never joined in one
+   * of its rooms by a second family, so in practice such a card holds exactly
+   * one party. This is a guard on a reachable-but-currently-empty state.
+   */
+  spanWidth: number
+}
+
+/**
+ * Who this card holds, and whether it can speak for all of them.
+ *
+ * Reads `coveredCodes` and `occupiedLeafCodes` — the same two primitives
+ * `overlappingPartyKeys` uses — rather than re-deriving "is this party inside
+ * this card". #2040 records what re-deriving costs: the overlap rule was fixed
+ * at the slot level and immediately came back one level down in `FamilyCard`,
+ * because the second copy had not been told.
+ */
+export function slotOccupancy(slot: BoardSlot, units: LodgingUnitRow[]): SlotOccupancy {
+  const unitsByCode = new Map(units.map((unit) => [unit.code, unit]))
+  const covered = new Set(coveredCodes(slot.unit, units))
+  let occupants = 0
+  let spanWidth = 0
+  for (const party of slot.parties) {
+    occupants += partySize(party)
+    const leaves = occupiedLeafCodes(party, units, unitsByCode)
+    // `some`, not `every`: a party naming its own room AND the building above
+    // it expands to a superset, and any single uncovered leaf is enough to say
+    // this card cannot speak for the whole placement.
+    const straddles = [...leaves].some((leaf) => !covered.has(leaf))
+    if (straddles) spanWidth = Math.max(spanWidth, leaves.size)
+  }
+  return { occupants, spanWidth }
+}
+
+/**
  * Area colour, §3.10 — a SECONDARY channel.
  *
  * Eight hues is at the limit of distinguishability, so nothing may depend on


### PR DESCRIPTION
## Why

CLAUDE.md §4, **"Family Camp Models Summer"**, says weekend surfaces model the summer equivalent and that any divergence must be deliberate, justified, and defensible. The lodging board had drifted on card chrome, type scale, typeface and grid — not by decision, but by having been written later by someone who did not look.

This closes two of the six comparison tables completely and most of a third. It is styling only: no data, no API, no behaviour beyond one conditional string.

## What changed

**Card chrome.** `.card-lodge` — the same class `BunkCard` wears — in place of a hand-rolled `bg-card rounded-xl border p-2.5` that was the same idea minus the shadow, the hover and a third of the padding. Padding to `p-4`, row rhythm to `gap-3` (summer's 12px `mb-3`).

**Type scale.** Every size on the card was an arbitrary bracket literal — `text-[13px]` title, `text-[11px]` body, `text-[10px]` meta — where summer uses three steps of the stock scale. The family board's *largest* text was smaller than summer's *body*. Now `text-lg` / `text-sm` / `text-xs` throughout, including `UnitAvailabilityControl`, which renders inside the card and had a 10px pill sitting in what is now a 14px meta row. The occupant card steps *down* from the unit card as `CamperCard` does from `BunkCard`, rather than inheriting its body size.

**The typeface, which was the larger half of that and is not a size at all.** `index.css` gives `h1, h2, h3` the display face — Fraunces, `-0.02em`, `ss01`/`ss02`. Summer titles its bunk in an `<h3>` and gets it; this card used a `<span>` and rendered the same 18px in the body sans. That is why the two boards still did not look alike once the sizes agreed. Now an `<h3>`, measured at 18px/600/−0.27px with `ss01`+`ss02` across all 82 cards.

**Grid.** `minmax(200px)` auto-filled to five columns at 228px; `minmax(280px)` gives four at 288px, which is summer's `xl:grid-cols-4` reached from the other direction. Gap `gap-2.5` → `gap-3`.

**Empty slot.** "Drop families here" — summer's wording in family vocabulary — but only while placement is live. Without a scenario or without `bunking.manage` there is nothing to drop, so the invitation would name an action the reader cannot take; it says "Empty" then. Summer renders nothing at all in production mode, but these cards are small enough that a blank body reads as broken rather than read-only.

**`docs/reference/lodging-board-vs-summer.md`** — the comparison itself, six tables, every row, with what is closed, what is open, and what is deliberately divergent and why. A working document: rewrite the status column as rows close rather than appending history.

## Measured, at a 1600px viewport

| | Before | After |
|---|---|---|
| Card padding / radius | 10px / 12px | 16px / 16px |
| Title | 13px, body sans | **18px, Fraunces + `ss01`/`ss02`** |
| Arbitrary `text-[Npx]` across 82 cards | 10 distinct | **0** |
| Columns | 5 @ 228px | **4 @ 288px** |
| Truncated unit titles | 12 of 82 | **2** |
| Amenity-row free space (median / p25) | 153 / 115px | **213 / 175px** |
| Board height | 5172px | 5754px (+11%) |

The amenity-row headroom is the point of the grid change — roughly one more indicator chip per card, with more indicators coming. The +11% scroll is what one fewer column costs and there is no way around it.

## Two things the code could not tell us

Both had already been asserted wrongly from a careful reading, which is the argument for measuring rather than reading.

**`hover:shadow-lodge-lg` does nothing** — here or on summer. `.shadow-lodge-*` are hand-written rules inside `@layer utilities`, not Tailwind v4 `@utility` declarations, so no `hover:` variant is ever emitted. A sweep of all 3,373 loaded rules found no selector matching `hover.*shadow-lodge`. I added the class copying `BunkCard`, measured, and backed it out; `LodgingUnitCard.test.tsx` now pins the **absence**, because the next reader comparing class strings will see the gap and helpfully close it. A dead class spreading by imitation is the `forest-950` failure (#1894) §4 names by name. Filed separately as **#2027** — nine inert usages plus three of an undefined `shadow-lodge-md`.

**Widening the grid does not unwrap the amenity row.** 28/29/25 cards sit at one, two and three lines at *both* widths. The wrapping is structural: `UnitAvailabilityControl` gives its reason line and its open form `w-full`. Anyone wanting a denser amenity row has to change that control, not the grid. I predicted otherwise; the test and the doc record the correction.

## Deliberately not done

**`items-start` stays.** Removing it does not reclaim a pixel — grid row height already equals the tallest card in the row, so stretch relocates whitespace from outside the card border to inside it. With 28 empty cards at a flat 139px and 2-party cards at 305–357px, stretch *alone* yields 28 blown-up empty boxes with "Empty" pinned to the top edge. It needs summer's `min-h-[100px]` well and centred `py-8` empty state in the same change. Documented as package A.

**Occupancy, the ramp and the utilization bar** are not here. `BoardSlot` carries no occupancy; a merged party is drawn on every room it holds (since #2010), so a naive sum would claim 8 people in 8 beds where there are 4; six units have no capacity at all; and summer's ramp is tuned to a fixed denominator of 12 rather than real per-room numbers. Four decisions, not a port. Documented as package B.

**Per-area sections stay**, and the doc corrects why. Summer's "area" is *gender*, and it filters because the other areas are illegal destinations for that camper. Family areas are geography and every one is a legal destination — adopting summer's filter would hide 74 usable rooms to show 8, copying the widget while discarding the reason it works.

## Verification

- 468 weekend tests green; full frontend suite 5717 green; `tsc`, eslint, prettier clean.
- Every test written first and verified failing — 18 new across `LodgingUnitCard`, `FamilyCard` and `LodgingBoard`.
- Classes pinned in vitest, computed values measured in a browser: jsdom parses no Tailwind, so a `toHaveStyle` assertion on a Tailwind class passes against an empty string and proves nothing.
- The area hue (§3.10) verified intact through the chrome change on hover and at rest; its test still passes.
- No unit names in the doc, per `docs/reference/lodging-registry.md`.

## Breaking

Marked `!` for the visual change only — four columns instead of five, and 11% more scroll on the housing board. No API or data contract moves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated lodging cards with clearer typography, spacing, badges, occupancy details, and shared visual styling.
  * Improved empty-unit messaging and over-capacity indicators.
  * Increased card minimum widths and grid spacing for a more readable responsive layout.
  * Added URL-synchronized area collapse state that preserves board selections.
  * Standardized family-card and availability-control text sizing.

* **Documentation**
  * Added a detailed comparison of family lodging and summer bunking boards, including layout, occupancy display, styling, and remaining considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->