### PR TITLE
build(frontend): the Vite config loads cleanly under the native config loader

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -27,7 +27,7 @@ interface BrandingConfig {
 }
 
 // Load default branding
-const defaultBrandingPath = resolve(__dirname, '../config/branding.json')
+const defaultBrandingPath = resolve(import.meta.dirname, '../config/branding.json')
 let defaultBranding: BrandingConfig = {
   camp_name: 'Kindred',
   camp_name_short: 'Kindred',
@@ -50,7 +50,7 @@ if (existsSync(defaultBrandingPath)) {
 // Load local branding overrides
 let localBranding: Partial<BrandingConfig> = {}
 const useDefaultBranding = process.env.USE_DEFAULT_BRANDING === 'true'
-const brandingPath = resolve(__dirname, '../config/branding.local.json')
+const brandingPath = resolve(import.meta.dirname, '../config/branding.local.json')
 
 if (useDefaultBranding) {
   console.log('ℹ️  USE_DEFAULT_BRANDING=true - using default branding (no local overrides)')
@@ -88,7 +88,7 @@ function serveLocalAssets(): Plugin {
   return {
     name: 'serve-local-assets',
     configureServer(server) {
-      const localDir = resolve(__dirname, '../local')
+      const localDir = resolve(import.meta.dirname, '../local')
 
       // Serve files directly to avoid CORS middleware issues with re-routed requests
       server.middlewares.use('/local', (req, res, next) => {
@@ -289,7 +289,7 @@ const baseConfig: UserConfig = {
 // Contains private FQDNs, HMR settings, CORS origins
 // Falls back gracefully if not available (gitignored, doesn't exist in CI)
 
-const localConfigPath = resolve(__dirname, 'vite.config.local.ts')
+const localConfigPath = resolve(import.meta.dirname, 'vite.config.local.ts')
 let localConfig: UserConfig = {}
 
 if (existsSync(localConfigPath)) {
@@ -297,7 +297,7 @@ if (existsSync(localConfigPath)) {
     // Dynamic import is async, but Vite supports top-level await in config
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore - File is gitignored; may not exist at compile time
-    const { localConfig: imported } = await import('./vite.config.local')
+    const { localConfig: imported } = await import('./vite.config.local.ts')
     localConfig = imported
     console.log('✓ Loaded local Vite configuration from vite.config.local.ts')
   } catch {


### PR DESCRIPTION
## What

Every dev start and every build printed a Vite 8 warning block that the config uses features `configLoader: 'native'` cannot support — a loader "planned to become the default in a future major version of Vite". Three items were listed; two of them are in this repo.

- **`__dirname` → `import.meta.dirname`** (4 sites). Vite's bundle loader defines both names to the same injected constant (`__vite_injected_original_dirname`), so this is behaviour-identical today and correct under native ESM tomorrow.
- **`await import('./vite.config.local')` → `'./vite.config.local.ts'`.** Native ESM resolution does not do extensionless resolution. The `existsSync` guard above it already spelled the extension out; only the import specifier was missing it.

The third warning — the local override file being parsed as CommonJS — comes from a file that lives in the private `kindred-local` repo and is fixed there (a `frontend/package.json` declaring `"type": "module"`, plus a `server.hmr.*` → `server.ws.*` migration for a separate Vite 8 deprecation).

Nothing here changes runtime behaviour. It is forward-compatibility only.

## Verification

`vite build` before: the four-line warning block. After: gone, and the config still reports

```
✓ Loaded local branding from config/branding.local.json
✓ Loaded local Vite configuration from vite.config.local.ts
```

so both `resolve()` call sites and the dynamic import still find their targets.

- `vite build` — clean, no warnings
- `tsc -p tsconfig.node.json --noEmit` (the project that includes `vite.config.ts`) — clean
- `tsc -p tsconfig.json --noEmit` — clean
- `eslint vite.config.ts` — clean
- pre-push suite (mypy, type-check, ruff, go build, 5999 pytest) — green

## Note for reviewers

`frontend/scripts/dev.js` and `frontend/scripts/generate-api-types.js` also mention `__dirname`, but they derive it themselves from `import.meta.url` in ordinary ESM modules. They are not the Vite config and are not affected by this loader change, so they are deliberately untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)