### PR TITLE
test(scripts): the apply script's --year default resolves from the season env var

### DIFF
--- a/tests/unit/scripts/test_apply_lodging_inventory.py
+++ b/tests/unit/scripts/test_apply_lodging_inventory.py
@@ -1,10 +1,13 @@
 """The apply script must never mix two seasons' unit rows."""
 
+import json
+from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 import pytest
 
-from scripts.dev.apply_lodging_inventory import plan_updates
+from scripts.dev.apply_lodging_inventory import main, plan_updates
 
 
 def test_plan_updates_matches_within_one_year() -> None:
@@ -41,3 +44,52 @@ def test_fetch_units_filters_by_year(monkeypatch: pytest.MonkeyPatch) -> None:
     params = captured["params"]
     assert isinstance(params, dict)
     assert "year = 2027" in str(params.get("filter", ""))
+
+
+def _drive_main(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, extra: list[str]) -> list[int]:
+    """Run `main` with the network stubbed and report the year it fetched.
+
+    The `--year` default is resolved by argparse inside `main`, so the only
+    faithful way to see it is to let `main` run and watch what reaches the
+    fetch. A helper tested in isolation would prove the year is computed, not
+    that the parser hands it to `_fetch_units` — which is the half that breaks.
+    """
+    seen: list[int] = []
+
+    def fake_fetch(_base: str, _token: str, year: int) -> dict[str, dict[str, Any]]:
+        seen.append(year)
+        return {}
+
+    monkeypatch.setattr("scripts.dev.apply_lodging_inventory._auth", lambda *_a, **_k: "tok")
+    monkeypatch.setattr("scripts.dev.apply_lodging_inventory._fetch_units", fake_fetch)
+
+    # The real registry is a symlink into the private kindred-local repo and is
+    # absent in CI, so the test brings its own empty one.
+    registry = tmp_path / "lodging_registry.json"
+    registry.write_text(json.dumps({"units": []}))
+
+    rc = main(["--registry", str(registry), "--password", "x", *extra])
+    assert rc == 0
+    return seen
+
+
+def test_the_year_defaults_to_the_campminder_season_env_var(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("CAMPMINDER_SEASON_ID", "2031")
+    assert _drive_main(monkeypatch, tmp_path, []) == [2031]
+
+
+def test_the_year_falls_back_to_the_calendar_year_when_the_env_is_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No season configured means the clock, not a hardcoded year."""
+    monkeypatch.delenv("CAMPMINDER_SEASON_ID", raising=False)
+    before = datetime.now().year
+    seen = _drive_main(monkeypatch, tmp_path, [])
+    # A window, not an equality: the run must not flake across midnight on 31 Dec.
+    assert seen[0] in {before, datetime.now().year}
+
+
+def test_an_explicit_year_flag_beats_the_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The operator's flag is the whole reason the season is not read directly."""
+    monkeypatch.setenv("CAMPMINDER_SEASON_ID", "2031")
+    assert _drive_main(monkeypatch, tmp_path, ["--year", "2033"]) == [2033]


### PR DESCRIPTION
## Summary

`scripts/dev/apply_lodging_inventory.py`'s `--year` argument resolves its default from `CAMPMINDER_SEASON_ID` with a calendar-year fallback (`argparse` line ~320). Nothing exercised that resolution — only the explicit-`--year` path was covered.

Since #2029 made the boot loader bootstrap-only (create-if-absent, never rewrites), this script is now the **only** deliberate file-to-database path for a season that already has rows, so a silently broken default is load-bearing in a way it wasn't before.

## Changes

Adds three tests to the existing `tests/unit/scripts/test_apply_lodging_inventory.py` (the file #2029 created for `--year` scoping):

- `test_the_year_defaults_to_the_campminder_season_env_var` — `CAMPMINDER_SEASON_ID` set → that year is used
- `test_the_year_falls_back_to_the_calendar_year_when_the_env_is_unset` — env absent → falls back to `datetime.now().year`
- `test_an_explicit_year_flag_beats_the_environment` — `--year` flag overrides the env var

All three drive `main(...)` end-to-end with `_auth` and `_fetch_units` monkeypatched (the idiom already used for `_fetch_units_filters_by_year` in the same file, and for the twin script `confirm_lodging_units.py`), since the `argparse default=` expression only proves itself when the parser actually runs — a helper tested in isolation would prove a year gets computed, not that the parser hands it to the fetch.

Closes #2031

## Mutation check (TDD substitute — this behavior already worked, so there is no honest red phase for new code)

Temporarily changed the production default to `default=2000` and reran:

```
$ uv run pytest tests/unit/scripts/test_apply_lodging_inventory.py -v
...
test_the_year_defaults_to_the_campminder_season_env_var FAILED
  assert [2000] == [2031]
test_the_year_falls_back_to_the_calendar_year_when_the_env_is_unset FAILED
  assert 2000 in {2026}
test_an_explicit_year_flag_beats_the_environment PASSED
test_plan_updates_matches_within_one_year PASSED
test_fetch_units_filters_by_year PASSED
3 passed, 2 failed, exit=1
```

Exactly the two env-resolution tests broke; the explicit-flag test and the two pre-existing tests stayed green. Reverted the mutation (`git checkout scripts/dev/apply_lodging_inventory.py`) and confirmed:

```
$ uv run pytest tests/unit/scripts/test_apply_lodging_inventory.py -v
5 passed
exit=0
```

`git status` after revert showed only the test file modified.

## Test plan

- [x] `uv run pytest tests/unit/scripts/test_apply_lodging_inventory.py -v` — 5 passed
- [x] Mutation check (above) — red on the two new env-resolution tests, green on revert
- [x] `SKIP_POCKETBASE_TESTS=true uv run pytest tests/ -n auto` — 6010 passed, 41 skipped (pre-existing, unrelated PocketBase/DB-dependent skips)
- [x] `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy .` — clean
- [x] Pre-push hooks (ruff, go build, pb-js-lint, shellcheck, markdownlint, api-types-freshness, mypy, full pytest, type-check) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for selecting the lodging inventory year from the configured season.
  * Verified fallback to the current calendar year when no season is configured.
  * Confirmed that an explicitly provided year takes precedence over the configured season.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->