### PR TITLE
fix(scripts): the lodging index check compares a column set, not a column order

### DIFF
--- a/scripts/dev/lib/pb-harness.sh
+++ b/scripts/dev/lib/pb-harness.sh
@@ -232,9 +232,14 @@ pb_harness_boot() {
 #
 # Reads pragma_index_info rather than substring-matching the stored CREATE
 # INDEX text; the two traps that rules out are documented at the call site.
-# The aggregate ORDER BY needs SQLite 3.44+; on older sqlite3 it is a syntax
-# error, so the result is empty and the caller FAILs loudly rather than
-# silently comparing garbage.
+#
+# Deliberately NOT `group_concat(name ORDER BY name)`: that ordered-aggregate
+# form needs SQLite 3.44+ and is a parse error ("near ORDER: syntax error")
+# on Debian bookworm's stock sqlite3 (3.40) and Ubuntu 22.04's (3.37). There
+# is no fallback for that error -- under a caller's `set -euo pipefail`, the
+# failing command substitution aborts the whole script, skipping every
+# assertion after it, not just this one. Sorting the subquery instead of the
+# aggregate call gets the same column-SET result on every sqlite3 version.
 pb_harness_index_columns() {
-  sqlite3 "$1" "SELECT group_concat(name ORDER BY name) FROM pragma_index_info('$2');"
+  sqlite3 "$1" "SELECT group_concat(name) FROM (SELECT name FROM pragma_index_info('$2') ORDER BY name);"
 }

--- a/scripts/dev/lib/pb-harness.sh
+++ b/scripts/dev/lib/pb-harness.sh
@@ -28,6 +28,7 @@
 #   pb_harness_pick_port
 #   pb_harness_install_trap [extra cleanup command]
 #   pb_harness_boot <pb_bin> <db_dir> <migrations_dir> <log_path>
+#   pb_harness_index_columns <db_path> <index_name>
 # See each function's header comment below for details.
 
 # PID of the currently-running background `pocketbase serve`, if any. Internal
@@ -215,4 +216,25 @@ pb_harness_boot() {
     cat "$log" >&2
     exit 2
   fi
+}
+
+# pb_harness_index_columns <db_path> <index_name>
+#
+# Prints the columns an index covers as a comma-joined list sorted by name --
+# a SET, not a sequence. Callers assert what an index KEYS ON; column order is
+# a query-planner concern no caller here is entitled to pin. kindred#2032: a
+# `(year, code)` index enforces exactly the uniqueness a `(code, year)` one
+# does, and the only single-column filter the lodging code issues is
+# `year = {:y}` (lodging/rollforward.go x3), which the reversed order would
+# serve BETTER -- so failing on order would block a change that is at worst
+# neutral, and a comment justifying the current order would be asserting a
+# rationale the query sites contradict.
+#
+# Reads pragma_index_info rather than substring-matching the stored CREATE
+# INDEX text; the two traps that rules out are documented at the call site.
+# The aggregate ORDER BY needs SQLite 3.44+; on older sqlite3 it is a syntax
+# error, so the result is empty and the caller FAILs loudly rather than
+# silently comparing garbage.
+pb_harness_index_columns() {
+  sqlite3 "$1" "SELECT group_concat(name ORDER BY name) FROM pragma_index_info('$2');"
 }

--- a/scripts/dev/test-pb-harness.sh
+++ b/scripts/dev/test-pb-harness.sh
@@ -288,4 +288,25 @@ else
 fi
 
 echo
+echo "=== TEST 12: pb_harness_index_columns avoids the version-gated ordered-aggregate form (kindred#2048) ==="
+# group_concat(name ORDER BY name) is an ORDERED AGGREGATE -- a SQLite 3.44+
+# feature. It is a parse error ("near ORDER: syntax error") on Debian
+# bookworm's stock sqlite3 (3.40.1) and Ubuntu 22.04's (3.37), confirmed
+# against a real bookworm sqlite3 binary. Under this repo's own
+# set -euo pipefail, `cols=$(pb_harness_index_columns ...)` failing aborts
+# verify-lodging-schema.sh mid-run -- every RBAC/rule/migration assertion
+# after it silently never runs, and the operator sees a bare SQLite error
+# instead of a `note`.
+#
+# This repo's dev sqlite3 is itself 3.44+, so the parse error can't be
+# reproduced by calling the function here -- this pins the SQL text instead,
+# against reintroducing the ordered-aggregate form.
+if grep -vE '^\s*#' "$LIB" | grep -qE 'group_concat\([^)]*ORDER BY'; then
+  echo "FAIL: pb_harness_index_columns uses an ordered aggregate; parse error on sqlite3 < 3.44 (Debian bookworm ships 3.40)" >&2
+  exit 1
+else
+  echo "PASS: pb_harness_index_columns avoids the version-gated ordered-aggregate form"
+fi
+
+echo
 echo "All tests passed."

--- a/scripts/dev/test-pb-harness.sh
+++ b/scripts/dev/test-pb-harness.sh
@@ -260,4 +260,32 @@ else
 fi
 
 echo
+echo "=== TEST 11: pb_harness_index_columns reports a column SET, order-independently (kindred#2032) ==="
+# (code, year) and (year, code) enforce identical uniqueness, so the verifier
+# must not distinguish them -- the pre-#2032 query returned 'year,code' for the
+# reversed index and the caller false-FAILed. The single-column index is the
+# mutation guard: a "fix" that returned a constant, or that ignored the index's
+# actual columns, would pass the first two assertions and fail this one.
+IDXDB="$SCRATCH/index-order.db"
+sqlite3 "$IDXDB" "
+  CREATE TABLE fwd(code TEXT, year INT);
+  CREATE UNIQUE INDEX idx_fwd_code ON fwd(\`code\`, \`year\`);
+  CREATE TABLE rev(code TEXT, year INT);
+  CREATE UNIQUE INDEX idx_rev_code ON rev(\`year\`, \`code\`);
+  CREATE TABLE solo(code TEXT, year INT);
+  CREATE UNIQUE INDEX idx_solo_code ON solo(\`year\`);
+"
+set +e
+fwd=$(bash -c "source '$LIB'; pb_harness_index_columns '$IDXDB' idx_fwd_code" 2>/dev/null)
+rev=$(bash -c "source '$LIB'; pb_harness_index_columns '$IDXDB' idx_rev_code" 2>/dev/null)
+solo=$(bash -c "source '$LIB'; pb_harness_index_columns '$IDXDB' idx_solo_code" 2>/dev/null)
+set -e
+if [[ "$fwd" == "code,year" && "$rev" == "code,year" && "$solo" == "year" ]]; then
+  echo "PASS: both column orders report 'code,year'; a single-column index stays distinguishable"
+else
+  echo "FAIL: expected fwd='code,year' rev='code,year' solo='year'; got fwd='$fwd' rev='$rev' solo='$solo'" >&2
+  exit 1
+fi
+
+echo
 echo "All tests passed."

--- a/scripts/dev/verify-lodging-schema.sh
+++ b/scripts/dev/verify-lodging-schema.sh
@@ -398,9 +398,13 @@ for table in lodging_units lodging_areas; do
   # PocketBase pretty-prints a multi-column list across lines --
   # `(\n  \`code\`,\n  \`year\`\n)` -- so even a literal '(`code`, `year`)'
   # match on one line never fires. pragma_index_info sidesteps both.
-  cols=$(sqlite3 "$DB" "SELECT group_concat(name) FROM pragma_index_info('$idx');")
+  #
+  # The comparison is against a column SET: pb_harness_index_columns sorts, so
+  # (year, code) passes too. Order is not this check's business -- see
+  # kindred#2032 and that function's header.
+  cols=$(pb_harness_index_columns "$DB" "$idx")
   [[ "$cols" == "code,year" ]] \
-    || note "$idx is not composite on (code, year): columns are '$cols'"
+    || note "$idx does not key on {code, year}: columns are '$cols'"
 
   # ...and separately, that it is UNIQUE. pragma_index_info answers only which
   # columns an index spans, so a plain (code, year) index satisfies the check


### PR DESCRIPTION
## Summary

`verify-lodging-schema.sh` asserted `pragma_index_info` output equals the literal string `"code,year"`. That check is order-sensitive, but the index it's checking doesn't need to be: `(code, year)` and `(year, code)` enforce the exact same UNIQUE constraint (one row per building per season), so a functionally-equivalent `(year, code)` index would false-FAIL the verifier.

**Why normalise the column set instead of pinning the order with a justifying comment (the issue's second option):** the only single-column filter against these tables in the codebase is `year = {:y}`, at three sites in `pocketbase/lodging/rollforward.go`. That's the sole place column order could matter for prefix usability, and it would be served *better* by `(year, code)` than by the currently-pinned `(code, year)`. Writing a comment asserting a performance rationale for the pinned order would be asserting something the code's own query sites contradict — so this PR normalises the comparison to a column set instead.

## Changes

- `scripts/dev/lib/pb-harness.sh` — new `pb_harness_index_columns <db_path> <index_name>` helper, returning `pragma_index_info` columns sorted by name (a set, not a sequence). Added to the file's "Public API" list.
- `scripts/dev/verify-lodging-schema.sh` — the index-shape assertion now calls `pb_harness_index_columns` instead of inlining `group_concat(name)`, so `(year, code)` passes alongside `(code, year)`.
- `scripts/dev/test-pb-harness.sh` — new TEST 11, added to the harness's existing shell-test suite. Builds a scratch DB with a forward-order index, a reverse-order index, and a single-column index, and asserts the helper reports `code,year` / `code,year` / `year` respectively — the single-column case is the mutation guard against a fix that just returns a constant.

No Go, Python, or frontend files change.

## Test plan

- [x] TDD: wrote TEST 11 first, confirmed it failed (`FAIL: ... got fwd='' rev='' solo=''`, `exit=1`) before the helper existed
- [x] Implemented the helper + call-site change, reran: all 11 tests pass, `exit=0`
- [x] Mutation-check: temporarily dropped `ORDER BY name` from the helper, reran — TEST 11 correctly failed with `rev='year,code'` (proves the test exercises the sort, not just presence of the function); restored and reconfirmed green
- [x] `shellcheck --severity=warning` on all three touched files — exit 0, no findings
- [x] Full end-to-end `./scripts/dev/verify-lodging-schema.sh` (boots real PocketBase, applies real migrations against the current `(code, year)` index) — still `OK (103 js migrations applied)`, exit 0

Closes #2032

🤖 Generated with [Claude Code](https://claude.com/claude-code)