### PR TITLE
fix(frontend): a whitespace-only filter reads as active in the floating queue

### DIFF
--- a/frontend/src/components/ui/FloatingQueueBadge.test.tsx
+++ b/frontend/src/components/ui/FloatingQueueBadge.test.tsx
@@ -199,6 +199,60 @@ describe('FloatingQueueBadge — expanded', () => {
   })
 })
 
+describe('FloatingQueueBadge — whitespace-only filter', () => {
+  // A whitespace-only term reads as "no filter" everywhere it is judged.
+  // Four sites in the shell branch on the search term, and they must agree:
+  // the filter predicate, the ESC handler, the header count, and the
+  // empty-state message. Fixing only one leaves the others disagreeing with
+  // what's on screen, which is worse than the original bug.
+
+  it('does not filter the list on a whitespace-only term', async () => {
+    render(<Harness />)
+    await userEvent.click(screen.getByRole('button', { name: /unplaced families/i }))
+    await userEvent.type(screen.getByPlaceholderText(/filter by name/i), '   ')
+    expect(screen.getAllByTestId('row')).toHaveLength(3)
+  })
+
+  it('shows the plain count, not a filtered count, on a whitespace-only term', async () => {
+    render(<Harness />)
+    await userEvent.click(screen.getByRole('button', { name: /unplaced families/i }))
+    await userEvent.type(screen.getByPlaceholderText(/filter by name/i), '   ')
+    expect(screen.getByText('3')).toBeInTheDocument()
+    expect(screen.queryByText('3/3')).not.toBeInTheDocument()
+    expect(screen.queryByText('0/3')).not.toBeInTheDocument()
+  })
+
+  it('closes on the first ESC when the term is whitespace-only, same as if it were empty', async () => {
+    // There's no active filter to clear, so the first press should behave
+    // like the "already empty" case in the ESC test above and close
+    // immediately rather than spending a press clearing an inert space.
+    render(<Harness />)
+    await userEvent.click(screen.getByRole('button', { name: /unplaced families/i }))
+    await userEvent.type(screen.getByPlaceholderText(/filter by name/i), '   ')
+
+    await userEvent.keyboard('{Escape}')
+    expect(screen.queryByTestId('row')).not.toBeInTheDocument()
+  })
+
+  it('quotes the trimmed term in the empty-state message, not the padded raw input', async () => {
+    render(<Harness />)
+    await userEvent.click(screen.getByRole('button', { name: /unplaced families/i }))
+    await userEvent.type(screen.getByPlaceholderText(/filter by name/i), '  zzz  ')
+    const message = screen.getByText(/No families match/)
+    expect(message.textContent).toBe('No families match "zzz"')
+  })
+
+  it('still shows the inline clear button on a whitespace-only term — there is text to clear, even though it is not filtering', async () => {
+    // Deliberately NOT one of the four coupled sites: this button answers
+    // "is there literal text in the box to clear", not "is a filter active",
+    // so it stays keyed to the raw (untrimmed) search term.
+    render(<Harness />)
+    await userEvent.click(screen.getByRole('button', { name: /unplaced families/i }))
+    await userEvent.type(screen.getByPlaceholderText(/filter by name/i), '   ')
+    expect(screen.getByTitle('Clear')).toBeInTheDocument()
+  })
+})
+
 describe('FloatingQueueBadge — drop target', () => {
   // Two separate class decisions off one prop: the popover's border and the
   // list's tint. C2's drag phase builds on both.

--- a/frontend/src/components/ui/FloatingQueueBadge.tsx
+++ b/frontend/src/components/ui/FloatingQueueBadge.tsx
@@ -81,6 +81,13 @@ export function FloatingQueueBadge<T>({
   const popoverRef = useRef<HTMLDivElement>(null)
   const searchInputRef = useRef<HTMLInputElement>(null)
   const [searchTerm, setSearchTerm] = useState('')
+  // A whitespace-only term is not a filter — every site below that judges
+  // "is a filter active" reads this instead of the raw box contents, so a
+  // stray space can't make the count, the list, or the ESC key disagree
+  // about whether anything is actually being searched for. The one
+  // exception is the inline clear button: it answers "is there text to
+  // clear", so it stays keyed to the raw `searchTerm`.
+  const trimmedSearchTerm = searchTerm.trim()
 
   const visible = useMemo(() => {
     const sorted = items.toSorted((a, b) => {
@@ -93,10 +100,10 @@ export function FloatingQueueBadge<T>({
       return 0
     })
 
-    if (!searchTerm) return sorted
-    const term = searchTerm.toLowerCase()
+    if (!trimmedSearchTerm) return sorted
+    const term = trimmedSearchTerm.toLowerCase()
     return sorted.filter((item) => getSearchText(item).toLowerCase().includes(term))
-  }, [items, searchTerm, sortKey, getSearchText])
+  }, [items, trimmedSearchTerm, sortKey, getSearchText])
 
   const handleClickOutside = useCallback(
     (event: MouseEvent) => {
@@ -121,11 +128,11 @@ export function FloatingQueueBadge<T>({
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       if (event.key === 'Escape' && isExpanded) {
-        if (searchTerm) setSearchTerm('')
+        if (trimmedSearchTerm) setSearchTerm('')
         else onClose()
       }
     },
-    [isExpanded, onClose, searchTerm]
+    [isExpanded, onClose, trimmedSearchTerm]
   )
 
   useEffect(() => {
@@ -192,7 +199,7 @@ export function FloatingQueueBadge<T>({
                 <span className="text-muted-foreground ml-1.5 text-sm font-normal">
                   (
                   <span>
-                    {searchTerm
+                    {trimmedSearchTerm
                       ? `${String(visible.length)}/${String(items.length)}`
                       : items.length}
                   </span>
@@ -250,7 +257,7 @@ export function FloatingQueueBadge<T>({
             ) : visible.length === 0 ? (
               <div className="flex h-full flex-col items-center justify-center py-8 text-center">
                 <p className="text-muted-foreground text-sm">
-                  No {noun} match "{searchTerm}"
+                  No {noun} match "{trimmedSearchTerm}"
                 </p>
               </div>
             ) : (


### PR DESCRIPTION
## Summary

Closes #1987. Typing a whitespace-only value into the floating queue's filter box (`FloatingQueueBadge.tsx`, shared by summer's unassigned-campers badge and weekend's unplaced-families badge) made the popover behave as though a real search were running.

The issue named one site (the filter predicate). Verification found **four** coupled sites in the shared shell that all judge "is a filter active" off the raw search box contents, and disagreed once a stray space was typed:

- **Filter predicate** (`visible` `useMemo`) — fell through to filtering on a whitespace-only term, hiding rows that didn't literally contain that whitespace.
- **ESC handler** — treated a whitespace-only term as "something to clear," so the first press cleared an inert space instead of closing the popover.
- **Header count** — showed `N/M` (filtered display) instead of the plain total.
- **Empty-state message** — quoted the raw, padded search text instead of what was actually matched.

Fix: derive one `trimmedSearchTerm` and read it at all four sites instead of the raw `searchTerm`. The inline clear (X) button is **deliberately left** keyed to the raw `searchTerm` — it answers "is there text in the box to clear," not "is a filter active," so a lone space should still be clearable via that button even though it isn't filtering anything.

Both summer and weekend inherit the fix at once, since the shell is shared (see #1984).

## Test plan
- [x] Added failing tests for all four sites first, confirmed red against the pre-fix code (predicate leaks whitespace-only search, count shows `0/3`, ESC needs two presses, empty-state message quotes padded text with extra spaces)
- [x] Added a locking test for the deliberately-unchanged clear button, confirming it stays visible on a whitespace-only term
- [x] `npx vitest run src/components/ui/FloatingQueueBadge.test.tsx` — 26/26 passing
- [x] `npx vitest run` (full frontend suite) — pre-existing/unrelated timeout flakes only (confirmed by re-running the affected files in isolation, where they pass); nothing in `FloatingQueueBadge`
- [x] `npm run type-check` — clean
- [x] `./node_modules/.bin/eslint` on changed files — 0 errors (2 pre-existing warnings on untouched lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)