### PR TITLE
fix(pb): the unit-year guard covers lodging_units itself

### DIFF
--- a/pocketbase/CLAUDE.md
+++ b/pocketbase/CLAUDE.md
@@ -84,7 +84,7 @@ Format: `2026-01-06T14:05:52Z [pocketbase] LEVEL message key=value...`. `LOG_LEV
 1. **Sync order matters:** sessions → attendees → persons → bunks → plans → assignments → requests
 2. **Year-aware:** sync filters by `CAMPMINDER_SEASON_ID` env var (set in `.env`; see "Year invariant" above)
 3. **Sessions 1–4 run sequentially** with independent history
-4. **WAL checkpoint required** after database modifications
+4. **WAL checkpoint required** after database modifications — this scopes to the Go sync layer (e.g. `forceWALCheckpoint()` in `family_camp_derived.go`); migrations don't need their own, since `runHistorySync` in `main.go` checkpoints on every boot after migrations apply (see `pb_migrations/*.js` in `.coderabbit.yaml`)
 5. **Family-camp data syncs alongside summer data** — summer-camp views must filter `session_type` against the configured valid-summer-session-types list
 
 See `docs/architecture/sync-layer.md` before adding or modifying sync jobs.

--- a/pocketbase/lodging/hooks.go
+++ b/pocketbase/lodging/hooks.go
@@ -80,6 +80,28 @@ type yearScopedRef struct {
 // wireHooks binds only to the collections it can actually find, so a table
 // that is absent in an older environment -- or removed in a future one --
 // logs a warning instead of taking the boot down.
+//
+// SCOPE: this guard is one-directional. It checks the row being written
+// against the OUTGOING relations listed in its own entry above; it never
+// re-checks rows elsewhere that point back AT the thing just written. Two
+// gaps follow, both residual as of kindred#2039, not regressions:
+//
+//   - lodging_areas is a valid TARGET above (lodging_units.area resolves into
+//     it) but is not itself a key in this map, so it carries no binding at
+//     all. A superuser or bunking.manage PATCH that edits an existing area
+//     row's own `year` in place hits no check, and every lodging_units row
+//     already pointing at that area -- written for whatever year it was
+//     created -- is now silently cross-season.
+//   - Editing a lodging_units row's own `year` is checked against that row's
+//     OWN area/parent_unit, but nothing re-validates the rows that point AT
+//     it: lodging_availability, lodging_assignments,
+//     lodging_assignments_draft, lodging_slot_merges. Those keep whatever
+//     year they were written with, now possibly disagreeing with the unit's
+//     new one.
+//
+// Closing either gap means cascading to every DEPENDENT row on a parent's
+// write, not validating only the row under write -- a materially bigger
+// change than this guard makes anywhere else, so it is not done here.
 var yearScopedRefs = map[string][]yearScopedRef{
 	collectionAvailability:     {{field: "unit", target: collectionUnits}},
 	collectionAssignments:      {{field: "units", target: collectionUnits}},

--- a/pocketbase/lodging/hooks.go
+++ b/pocketbase/lodging/hooks.go
@@ -38,6 +38,7 @@ import (
 
 const (
 	collectionUnits            = "lodging_units"
+	collectionAreas            = "lodging_areas"
 	collectionAssignments      = "lodging_assignments"
 	collectionAssignmentsDraft = "lodging_assignments_draft"
 	collectionAliases          = "lodging_unit_aliases"
@@ -46,28 +47,48 @@ const (
 	collectionSlotMerges       = "lodging_slot_merges"
 )
 
-// yearScopedUnitRefs are the collections that carry BOTH a year of their own
-// and a relation into lodging_units. Once units are year-scoped (1500000141
-// gives lodging_units its own `year`, making (code, year) a distinct record)
-// those two years can disagree -- a 2027 row pointing at a 2026 building -- a
-// state that was unrepresentable before and that nothing in the database
-// prevents.
+// yearScopedRef is one relation the year guard follows: the field to read on
+// the row, and the collection its ids resolve in. A SLICE of these rather than
+// a field->collection map, because map iteration is randomized and
+// lodging_units is the first entry carrying two relations -- a row cross-year
+// on both would otherwise name a different field on every run.
+type yearScopedRef struct {
+	field  string
+	target string
+}
+
+// yearScopedRefs are the collections carrying BOTH a year of their own and a
+// relation into a year-scoped registry table. Once the registry is year-scoped
+// (1500000141 gives lodging_units AND lodging_areas their own `year`, making
+// (code, year) a distinct record) those two years can disagree -- a 2027 row
+// pointing at a 2026 building -- a state that was unrepresentable before and
+// that nothing in the database prevents.
+//
+// lodging_units is here as of kindred#2039 and is the odd one out twice over:
+// it is both a referencing and a referenced table, and its `area` resolves in
+// lodging_areas rather than in itself. Neither of its relations is reachable
+// cross-year from the Kindred UI -- both pickers are fed year-scoped lists
+// (unitTree.ts, and the area select from the year-scoped areas query) -- but
+// 1500000130 widened create/update on lodging_units to bunking.manage, so the
+// admin UI and a direct REST write both reach it.
 //
 // lodging_assignment_history is deliberately absent: it stores old_unit /
 // new_unit as TEXT so an unresolvable historical string is still recorded
 // (1500000119). It cannot express this bug and must not be given a relation
 // to "fix" it.
 //
-// lodging_slot_merges does not exist in this worktree -- it belongs to a
-// parallel branch (migration 1500000139) that has not merged yet. It is
-// listed here anyway so the guard starts covering it automatically the moment
-// that migration lands; wireHooks skips whatever collection it cannot find
-// rather than failing the boot over it.
-var yearScopedUnitRefs = map[string][]string{
-	collectionAvailability:     {"unit"},
-	collectionAssignments:      {"units"},
-	collectionAssignmentsDraft: {"units"},
-	collectionSlotMerges:       {"unit"},
+// wireHooks binds only to the collections it can actually find, so a table
+// that is absent in an older environment -- or removed in a future one --
+// logs a warning instead of taking the boot down.
+var yearScopedRefs = map[string][]yearScopedRef{
+	collectionAvailability:     {{field: "unit", target: collectionUnits}},
+	collectionAssignments:      {{field: "units", target: collectionUnits}},
+	collectionAssignmentsDraft: {{field: "units", target: collectionUnits}},
+	collectionSlotMerges:       {{field: "unit", target: collectionUnits}},
+	collectionUnits: {
+		{field: "area", target: collectionAreas},
+		{field: "parent_unit", target: collectionUnits},
+	},
 }
 
 // RegisterHooks wires the lodging integrity guards onto the app.
@@ -89,11 +110,10 @@ func wireHooks(app core.App) {
 	app.OnRecordUpdate(collectionUnits).BindFunc(guardUnitParentCycle)
 	app.OnRecordAfterUpdateSuccess(collectionIngestIssues).BindFunc(replayOnResolve)
 
-	// Bind only to collections that actually exist. lodging_slot_merges
-	// belongs to a migration that has not landed in every environment yet
-	// (see yearScopedUnitRefs), and a future table removal must not take the
-	// boot down either -- so this checks, rather than assumes, before binding.
-	for name := range yearScopedUnitRefs {
+	// Bind only to collections that actually exist -- a future table removal
+	// must not take the boot down, so this checks rather than assumes before
+	// binding (see yearScopedRefs).
+	for name := range yearScopedRefs {
 		if _, err := app.FindCollectionByNameOrId(name); err != nil {
 			// app.Logger(), not the package-level slog: the latter's default
 			// handler writes to stderr, invisible to captureStdout (the only
@@ -118,17 +138,17 @@ func wireHooks(app core.App) {
 	}
 }
 
-// guardUnitYear refuses a row whose own year disagrees with any unit it
-// names, for every collection in yearScopedUnitRefs.
+// guardUnitYear refuses a row whose own year disagrees with any registry row
+// it names, for every collection in yearScopedRefs.
 //
 // A multi-valued relation (`units`, maxSelect 20, added to the placement
 // tables by 1500000134 when lodging_merges was folded in) has every element
 // checked, not just the first -- it is the column lodging_assignments_sync.go
 // writes, and therefore exactly the one a stale alias resolution would
 // corrupt. GetStringSlice reads a single relation (`unit`) as a one-element
-// slice, so one loop over yearScopedUnitRefs[collection] covers both shapes.
+// slice, so one loop over yearScopedRefs[collection] covers both shapes.
 func guardUnitYear(app core.App, rec *core.Record) error {
-	fields, watched := yearScopedUnitRefs[rec.Collection().Name]
+	refs, watched := yearScopedRefs[rec.Collection().Name]
 	if !watched {
 		return nil
 	}
@@ -137,16 +157,30 @@ func guardUnitYear(app core.App, rec *core.Record) error {
 		return nil // required elsewhere; not this guard's complaint to make
 	}
 
-	for _, field := range fields {
-		for _, id := range rec.GetStringSlice(field) {
-			unit, err := app.FindRecordById(collectionUnits, id)
-			if err != nil {
-				return fmt.Errorf("resolving %s %q: %w", field, id, err)
+	for _, ref := range refs {
+		for _, id := range rec.GetStringSlice(ref.field) {
+			// A row cannot disagree with ITSELF about its own year, and
+			// lodging_units is the only table that can name itself
+			// (parent_unit is a self-relation). Two failures without this:
+			// on update FindRecordById returns the STORED row, so editing a
+			// self-parented row's year would be refused naming the row itself;
+			// on create the id is autogenerated inside e.Next(), AFTER this
+			// runs, so an explicitly-self-parenting create resolves to a row
+			// that does not exist yet and fails with a lookup error instead.
+			// Inert everywhere else: GetStringSlice never yields an empty id,
+			// so this never accidentally matches a blank rec.Id on create.
+			if id == rec.Id {
+				continue
 			}
-			if unitYear := unit.GetInt("year"); unitYear != rowYear {
+			target, err := app.FindRecordById(ref.target, id)
+			if err != nil {
+				return fmt.Errorf("resolving %s %q: %w", ref.field, id, err)
+			}
+			if targetYear := target.GetInt("year"); targetYear != rowYear {
 				return fmt.Errorf(
-					"%s row is for year %d but names unit %q from year %d",
-					rec.Collection().Name, rowYear, unit.GetString("code"), unitYear)
+					"%s row is for year %d but its %s relation names %q from year %d",
+					rec.Collection().Name, rowYear, ref.field,
+					target.GetString("code"), targetYear)
 			}
 		}
 	}

--- a/pocketbase/lodging/hooks_test.go
+++ b/pocketbase/lodging/hooks_test.go
@@ -1196,6 +1196,39 @@ func TestGuardUnitYearRejectsACrossYearRow(t *testing.T) {
 	}
 }
 
+// TestGuardUnitYearRejectsACrossYearRowOnUpdate is the SAME rejection as the
+// test above, driven through OnRecordUpdate instead of OnRecordCreate.
+//
+// wireHooks binds guardUnitYear to both (hooks.go), but until this test every
+// case exercised only create. The update path is the one that matters
+// operationally: a row is written in its own season and only later re-pointed
+// at a unit, which is the write a staff edit actually makes. The two bindings
+// share an identical closure body today, so this cannot catch a divergence in
+// behaviour -- it catches the binding going missing, which is a one-line edit
+// away and would otherwise be silent (kindred#2035).
+func TestGuardUnitYearRejectsACrossYearRowOnUpdate(t *testing.T) {
+	app := newHooksTestApp(t)
+	same := seedUnit(t, app, "test-unit-a", 2027)
+	stale := seedUnit(t, app, "test-unit-b", 2026)
+
+	rec := core.NewRecord(mustCollection(t, app, "lodging_availability"))
+	rec.Set("year", 2027)
+	rec.Set("unit", same)
+	rec.Set("session", seedSession(t, app))
+	if err := app.Save(rec); err != nil {
+		t.Fatalf("seeding a consistent 2027 row: %v", err)
+	}
+
+	rec.Set("unit", stale)
+	err := app.Save(rec)
+	if err == nil {
+		t.Fatal("re-pointed a 2027 row at a 2026 unit; want a refusal")
+	}
+	if !strings.Contains(err.Error(), "year") {
+		t.Errorf("error does not name the problem: %v", err)
+	}
+}
+
 // TestGuardUnitYearChecksEveryMemberOfTheMultiRelation is the multi-relation
 // case, and the one that matters more: `units` (maxSelect 20) is what
 // 1500000134 gave lodging_assignments and lodging_assignments_draft when it

--- a/pocketbase/lodging/hooks_test.go
+++ b/pocketbase/lodging/hooks_test.go
@@ -34,6 +34,22 @@ import (
 func setupCollections(t *testing.T, app core.App) {
 	t.Helper()
 
+	// lodging_areas exists here only because guardUnitYear follows
+	// lodging_units.area into it (1500000141 gave BOTH tables a year).
+	// `code` is what the guard's error message prints, so it is not optional
+	// decoration.
+	areas := core.NewBaseCollection("lodging_areas")
+	areas.Fields.Add(&core.TextField{Name: "code", Required: true})
+	areas.Fields.Add(&core.TextField{Name: "name", Required: true})
+	areas.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(areas); err != nil {
+		t.Fatalf("save lodging_areas: %v", err)
+	}
+	areasCol, areasErr := app.FindCollectionByNameOrId("lodging_areas")
+	if areasErr != nil {
+		t.Fatalf("find lodging_areas: %v", areasErr)
+	}
+
 	units := core.NewBaseCollection("lodging_units")
 	units.Fields.Add(&core.TextField{Name: "code", Required: true})
 	units.Fields.Add(&core.TextField{Name: "name", Required: true})
@@ -43,6 +59,13 @@ func setupCollections(t *testing.T, app core.App) {
 	// left optional here, as elsewhere in this fixture, so newUnit's callers
 	// that predate the year dimension are not forced to supply one).
 	units.Fields.Add(&core.NumberField{Name: "year"})
+	// OPTIONAL here, REQUIRED in production (1500000116). Every fixture helper
+	// in this file predates the area dimension and creates units without one;
+	// making this required would fail ~20 tests for a reason none of them is
+	// about. Same reasoning as `year` above.
+	units.Fields.Add(&core.RelationField{
+		Name: "area", CollectionId: areasCol.Id, MaxSelect: 1,
+	})
 	// Self-relation. CollectionId is set after the first Save, below, because
 	// the collection has no id until it exists.
 	if err := app.Save(units); err != nil {
@@ -240,6 +263,21 @@ func seedUnit(t *testing.T, app core.App, code string, year int) string {
 	r.Set("year", year)
 	if err := app.Save(r); err != nil {
 		t.Fatalf("seed unit %q year %d: %v", code, year, err)
+	}
+	return r.Id
+}
+
+// seedArea creates a lodging_areas row for the given year and returns its id --
+// the lodging_areas twin of seedUnit, for the guardUnitYear cases that need a
+// unit and its area to disagree about the season.
+func seedArea(t *testing.T, app core.App, code string, year int) string {
+	t.Helper()
+	r := core.NewRecord(mustCollection(t, app, "lodging_areas"))
+	r.Set("code", code)
+	r.Set("name", "Test Area A")
+	r.Set("year", year)
+	if err := app.Save(r); err != nil {
+		t.Fatalf("seed area %q year %d: %v", code, year, err)
 	}
 	return r.Id
 }
@@ -1204,7 +1242,7 @@ func TestGuardUnitYearRejectsACrossYearRow(t *testing.T) {
 // operationally: a row is written in its own season and only later re-pointed
 // at a unit, which is the write a staff edit actually makes. The two bindings
 // share an identical closure body today, so this cannot catch a divergence in
-// behaviour -- it catches the binding going missing, which is a one-line edit
+// behavior -- it catches the binding going missing, which is a one-line edit
 // away and would otherwise be silent (kindred#2035).
 func TestGuardUnitYearRejectsACrossYearRowOnUpdate(t *testing.T) {
 	app := newHooksTestApp(t)
@@ -1278,19 +1316,21 @@ func TestGuardUnitYearAllowsAMatchingRow(t *testing.T) {
 }
 
 // TestGuardUnitYearSkipsAnAbsentCollection pins that wiring the guard cannot
-// take the boot down over lodging_slot_merges, which belongs to a parallel
-// branch (migration 1500000139) that has not merged into this worktree.
-// yearScopedUnitRefs names it as one of the four tables to guard, but
-// setupCollections -- deliberately, matching the real schema this worktree
-// carries -- never creates it. wireHooks has to look before it binds, skip
-// what it does not find, and say so, rather than letting
-// app.OnRecordCreate(name) panic or error deep inside PocketBase's own
-// binding machinery.
+// take the boot down over a collection that is missing. lodging_slot_merges
+// has in fact merged (1500000139, 1500000140), but setupCollections never
+// creates it -- this fixture stops at the tables the guard's other tests
+// actually need, and lodging_slot_merges is not one of them. yearScopedRefs
+// names it as one of the tables to guard regardless, so wireHooks has to look
+// before it binds, skip what it does not find, and say so, rather than
+// letting app.OnRecordCreate(name) panic or error deep inside PocketBase's
+// own binding machinery.
 //
-// This also doubles as the reason the guard automatically starts covering
-// lodging_slot_merges the moment that migration lands: nothing here special-
-// cases the collection by name, only by whether FindCollectionByNameOrId
-// succeeds.
+// This also doubles as the reason the guard would automatically start
+// covering lodging_slot_merges the moment this fixture grows the collection:
+// nothing here special-cases the name, only whether FindCollectionByNameOrId
+// succeeds. Until then, guard coverage on lodging_slot_merges itself is
+// untested (kindred#2039 follow-up) -- closing that gap means adding the
+// collection to setupCollections, not touching this test.
 func TestGuardUnitYearSkipsAnAbsentCollection(t *testing.T) {
 	app, err := tests.NewTestAppWithConfig(core.BaseAppConfig{
 		EncryptionEnv: "pb_test_env",
@@ -1309,5 +1349,158 @@ func TestGuardUnitYearSkipsAnAbsentCollection(t *testing.T) {
 
 	if !strings.Contains(output, "lodging_slot_merges") {
 		t.Fatalf("expected a warning naming the absent collection, got: %q", output)
+	}
+}
+
+// TestGuardUnitYearRejectsACrossYearArea is the first of the two relations
+// lodging_units carries that guardUnitYear did not previously follow, because
+// the guard resolved every id it checked against lodging_units and `area`
+// points at a different table (kindred#2039).
+//
+// A 2027 room filed under 2026's area is silent in the worst way: Manage drops
+// it into "No area" (unitSort.ts groupUnitsByArea), which someone would
+// eventually notice, but the roster's `area` expand resolves the 2026 row and
+// renders the wrong name and the wrong sort_order on the board and the map with
+// no error anywhere.
+func TestGuardUnitYearRejectsACrossYearArea(t *testing.T) {
+	app := newHooksTestApp(t)
+	area2026 := seedArea(t, app, "test-area-a", 2026)
+
+	rec := core.NewRecord(mustCollection(t, app, "lodging_units"))
+	rec.Set("code", "test-unit-a")
+	rec.Set("name", "Test Building A")
+	rec.Set("year", 2027)
+	rec.Set("area", area2026)
+
+	err := app.Save(rec)
+	if err == nil {
+		t.Fatal("saved a 2027 unit filed under a 2026 area; want a refusal")
+	}
+	if !strings.Contains(err.Error(), "year") {
+		t.Errorf("error does not name the problem: %v", err)
+	}
+}
+
+// TestGuardUnitYearRejectsACrossYearParentUnit drives the SELF-relation, and
+// does it through an UPDATE on purpose: a unit is created in its own season and
+// only later re-parented, which is the write that actually produces the bug.
+// A cross-year parent puts 2027 rooms inside a 2026 building, so the container
+// tree spans seasons and directChildren attaches across the boundary.
+//
+// The assertion is on "year", not merely on non-nil: guardUnitParentCycle also
+// runs on this save, and its refusal ("That parent would create a loop in the
+// unit tree.") says nothing about years -- so a test that accepted any error
+// would pass against a guard that never looked at the season at all.
+func TestGuardUnitYearRejectsACrossYearParentUnit(t *testing.T) {
+	app := newHooksTestApp(t)
+	parent2026 := seedUnit(t, app, "test-unit-a", 2026)
+	childID := seedUnit(t, app, "test-unit-b", 2027)
+
+	child, err := app.FindRecordById(collectionUnits, childID)
+	if err != nil {
+		t.Fatalf("reloading the child unit: %v", err)
+	}
+	child.Set("parent_unit", parent2026)
+
+	saveErr := app.Save(child)
+	if saveErr == nil {
+		t.Fatal("re-parented a 2027 room under a 2026 building; want a refusal")
+	}
+	if !strings.Contains(saveErr.Error(), "year") {
+		t.Errorf("error does not name the problem: %v", saveErr)
+	}
+}
+
+// TestGuardUnitYearAllowsAUnitWhoseParentAndAreaShareItsYear is the positive
+// control for the lodging_units coverage. Without it, a guard that refused
+// EVERY write to lodging_units would pass both refusal tests above -- and
+// lodging_units is the one table where that mistake would be catastrophic
+// rather than merely wrong, because it is the table the roll-forward writes.
+func TestGuardUnitYearAllowsAUnitWhoseParentAndAreaShareItsYear(t *testing.T) {
+	app := newHooksTestApp(t)
+	area := seedArea(t, app, "test-area-a", 2027)
+	parent := seedUnit(t, app, "test-unit-a", 2027)
+
+	rec := core.NewRecord(mustCollection(t, app, "lodging_units"))
+	rec.Set("code", "test-unit-b")
+	rec.Set("name", "Test Building B")
+	rec.Set("year", 2027)
+	rec.Set("area", area)
+	rec.Set("parent_unit", parent)
+
+	if err := app.Save(rec); err != nil {
+		t.Fatalf("refused a consistent unit: %v", err)
+	}
+}
+
+// TestGuardUnitYearIgnoresAnEmptyParentUnit pins the COMMON case, which is the
+// one an optional relation makes easy to break silently: every top-level
+// building has no parent at all.
+//
+// GetStringSlice is what makes this work -- a MaxSelect:1 relation reads as a
+// string, and ToUniqueStringSlice returns an EMPTY slice for "" rather than a
+// one-element slice holding it, so the loop body never runs and FindRecordById
+// is never called with an empty id. That is a property of PocketBase, not of
+// this file, so it gets a test rather than a comment.
+//
+// MUTATION-CHECK: replace the inner loop with an unconditional
+// app.FindRecordById(ref.target, rec.GetString(ref.field)) and this test goes
+// red with `resolving parent_unit ""`, while every other test here stays green.
+func TestGuardUnitYearIgnoresAnEmptyParentUnit(t *testing.T) {
+	app := newHooksTestApp(t)
+	area := seedArea(t, app, "test-area-a", 2027)
+
+	rec := core.NewRecord(mustCollection(t, app, "lodging_units"))
+	rec.Set("code", "test-unit-a")
+	rec.Set("name", "Test Building A")
+	rec.Set("year", 2027)
+	rec.Set("area", area)
+	// parent_unit deliberately unset: a top-level building.
+
+	if err := app.Save(rec); err != nil {
+		t.Fatalf("refused a top-level unit with no parent: %v", err)
+	}
+}
+
+// TestGuardUnitYearSkipsAUnitsSelfReference pins that the guard does not
+// compare a row against ITSELF, which lodging_units is the only table that can
+// do -- it is both the referencing and the referenced table.
+//
+// The self-parented row is staged BEFORE wireHooks, standing in for data
+// written when no guard existed: guardUnitParentCycle refuses to CREATE the
+// link (HasParentCycle returns true when unitID == parentID) but its diff gate
+// lets a pre-existing one through untouched, so this state is reachable and
+// permanent. Editing such a row's year is then the trap: FindRecordById returns
+// the STORED row, whose year is the OLD one, and the guard rejects the write
+// naming the row itself as the offending unit.
+//
+// MUTATION-CHECK: delete the `if id == rec.Id { continue }` line in
+// guardUnitYear and this test goes red; nothing else does.
+func TestGuardUnitYearSkipsAUnitsSelfReference(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	defer app.Cleanup()
+
+	setupCollections(t, app)
+	u := newUnit(t, app, "test-unit-a", "Test Building A")
+	u.Set("parent_unit", u.Id)
+	if seedErr := app.Save(u); seedErr != nil {
+		t.Fatalf("staging the self-parented row: %v", seedErr)
+	}
+
+	wireHooks(app)
+
+	// Re-read, so Original() holds the stored parent and guardUnitParentCycle's
+	// diff gate sees an unchanged parent_unit -- the same reason
+	// TestAnEditThatLeavesParentUnitAloneSurvivesAPreExistingCycle reloads.
+	stored, err := app.FindRecordById(collectionUnits, u.Id)
+	if err != nil {
+		t.Fatalf("reloading the unit: %v", err)
+	}
+	stored.Set("year", 2027)
+	if err := app.Save(stored); err != nil {
+		t.Fatalf("a row must not be refused for disagreeing with itself: %v", err)
 	}
 }

--- a/pocketbase/lodging/rollforward_test.go
+++ b/pocketbase/lodging/rollforward_test.go
@@ -405,3 +405,30 @@ func TestApplyRollForwardRetryAfterAFailureLinksParents(t *testing.T) {
 			got, parent.Id)
 	}
 }
+
+// TestApplyRollForwardSurvivesTheUnitYearGuard is the reason kindred#2039 is
+// safe to ship. Extending guardUnitYear to lodging_units means the guard now
+// fires on every write the roll-forward makes, inside its transaction, and the
+// roll-forward is the only thing in the system that writes a whole season's
+// worth of `area` and `parent_unit` at once.
+//
+// It passes by construction today -- copyUnits resolves `area` into the TARGET
+// year and leaves parent_unit unset, and relinkParents resolves the parent by
+// (code, targetYear), so every write is same-year. This test exists so that
+// stops being something a future reader has to re-derive from rollforward.go.
+//
+// GREEN BEFORE AND AFTER kindred#2039: a regression guard, not a red-first test.
+func TestApplyRollForwardSurvivesTheUnitYearGuard(t *testing.T) {
+	app := newRollForwardTestApp(t)
+	seedYear(t, app, 2026)
+
+	wireHooks(app)
+
+	plan, err := ApplyRollForward(app, 2026, 2027)
+	if err != nil {
+		t.Fatalf("the year guard refused the roll-forward: %v", err)
+	}
+	if plan.UnitsToCreate == 0 {
+		t.Fatal("the roll-forward created no units; the assertion above is vacuous")
+	}
+}


### PR DESCRIPTION
## Summary

- **#2039** — `guardUnitYear` now covers `lodging_units` itself, following both `area` (into `lodging_areas`) and `parent_unit` (a self-relation) instead of only the four placement/availability tables that point *at* units.
- **#2035** — a new test drives `guardUnitYear` through `OnRecordUpdate`, not only `OnRecordCreate`.
- **#1870** — `pocketbase/CLAUDE.md`'s "WAL checkpoint required" line is now scoped to the sync layer, matching the decision already applied to `.coderabbit.yaml` in #1903.

## #2039 details

`guardUnitYear` watched four tables (`lodging_availability`, `lodging_assignments`, `lodging_assignments_draft`, `lodging_slot_merges`) for a row whose own `year` disagreed with the unit it named — but never `lodging_units` itself. A 2027 room could name a 2026 `area` or a 2026 `parent_unit` with no error anywhere: Manage would drop it into "No area", and the roster's `area` expand would silently resolve the wrong season's name and `sort_order`.

The refs table moved from `map[string][]string` to a slice of `{field, target}` structs (`yearScopedRefs`), because Go map iteration order is randomized and `lodging_units` is the first entry carrying **two** relations — a row cross-year on both would otherwise name a different field on every test/prod run.

`lodging_units` is the odd one out twice over: it's both a referencing and a referenced table (`parent_unit` is a self-relation), and `area` resolves into `lodging_areas` rather than into itself. A self-skip (`if id == rec.Id { continue }`) handles the self-relation case — without it, editing a **legacy** self-parented row's year (data written before `guardUnitParentCycle` existed; its diff gate lets an already-self-parented row's *other* edits through untouched) would be refused, naming the row as the offending relation.

**Correction to the issue body:** #2039 cites migration `1500000140` as the one that year-scoped the registry. At HEAD (`9b99c220`), `1500000140` is `lodging_slot_merges_scenario_optional.js` — the year-scoping migration is **`1500000141_lodging_registry_year.js`**, which gives both `lodging_units` and `lodging_areas` their own `year` and re-indexes both on `(code, year)`. `hooks.go`/`hooks_test.go` already cited 141 correctly.

### Mutation-check 1 — update binding (closes #2035)

Deleted `hooks.go`'s `OnRecordUpdate` binding block for the year-scoped tables and re-ran the full `TestGuardUnitYear*` set (re-run against the final tree; corrects an earlier version of this section that pasted only a 5-test partial run):

```
$ go test ./lodging/ -run TestGuardUnitYear -count=1 -v
--- PASS: TestGuardUnitYearRejectsACrossYearRow
--- FAIL: TestGuardUnitYearRejectsACrossYearRowOnUpdate
    hooks_test.go:1263: re-pointed a 2027 row at a 2026 unit; want a refusal
--- PASS: TestGuardUnitYearChecksEveryMemberOfTheMultiRelation
--- PASS: TestGuardUnitYearAllowsAMatchingRow
--- PASS: TestGuardUnitYearSkipsAnAbsentCollection
--- PASS: TestGuardUnitYearRejectsACrossYearArea
--- FAIL: TestGuardUnitYearRejectsACrossYearParentUnit
    hooks_test.go:1407: re-parented a 2027 room under a 2026 building; want a refusal
--- PASS: TestGuardUnitYearAllowsAUnitWhoseParentAndAreaShareItsYear
--- PASS: TestGuardUnitYearIgnoresAnEmptyParentUnit
--- PASS: TestGuardUnitYearSkipsAUnitsSelfReference
FAIL
```

Two tests fail, not one: `TestGuardUnitYearRejectsACrossYearParentUnit` also exercises the update path (it re-saves an already-created child unit via `app.Save`, same as the row-level update test), so it reds too when the `OnRecordUpdate` binding is gone. The other eight stay green. Restored the block, re-ran, all green.

### Mutation-check 2 — self-skip (part of #2039)

Deleted the `if id == rec.Id { continue }` line and re-ran:

```
$ go test ./lodging/ -run TestGuardUnitYear -count=1 -v
--- PASS: TestGuardUnitYearRejectsACrossYearRow
--- PASS: TestGuardUnitYearRejectsACrossYearRowOnUpdate
--- PASS: TestGuardUnitYearChecksEveryMemberOfTheMultiRelation
--- PASS: TestGuardUnitYearAllowsAMatchingRow
--- PASS: TestGuardUnitYearSkipsAnAbsentCollection
--- PASS: TestGuardUnitYearRejectsACrossYearArea
--- PASS: TestGuardUnitYearRejectsACrossYearParentUnit
--- PASS: TestGuardUnitYearAllowsAUnitWhoseParentAndAreaShareItsYear
--- PASS: TestGuardUnitYearIgnoresAnEmptyParentUnit
--- FAIL: TestGuardUnitYearSkipsAUnitsSelfReference
    hooks_test.go:1504: a row must not be refused for disagreeing with itself: Lodging_units row is for year 2027 but its parent_unit relation names "test-unit-a" from year 2026.
FAIL
```

Only `TestGuardUnitYearSkipsAUnitsSelfReference` failed; every other test, including the two positive controls, stayed green. Restored the line, re-ran, all green.

### Also fixed: a stale comment

`TestGuardUnitYearSkipsAnAbsentCollection`'s doc comment claimed `lodging_slot_merges` "has not merged yet" — false as of `1500000139`/`1500000140`, both at HEAD. The test still validly pins the skip path (the *fixture* just doesn't create that collection), so only the comment changed, not the test body or assertion.

### Follow-up not done here

The fixture gap above means `lodging_slot_merges`'s own guard coverage is untested (`setupCollections` never creates that collection). Closing it means adding the collection to the fixture — a separate, larger change, out of scope here.

**Review follow-up: the guard's scope is one-directional, and residual, not a regression.** `guardUnitYear` only checks the row being written against its own outgoing relations (the entries in `yearScopedRefs`). Two gaps follow from that: editing an existing `lodging_areas` row's own `year` in place hits no binding at all (`lodging_areas` is a valid target above but not itself a key in the map), leaving every `lodging_units` row already pointing at it silently cross-season; and editing a `lodging_units` row's own `year` is checked against that row's area/parent_unit, but does not re-check the rows that point AT it (`lodging_availability`, `lodging_assignments`, `lodging_assignments_draft`, `lodging_slot_merges`). Closing either means cascading to every dependent row on a parent's write, not validating only the row under write — out of scope for this PR. Documented in the `yearScopedRefs` doc comment (`hooks.go`); tracking issue to follow.

## Verification

- `go build ./...` — clean
- `go test ./lodging/ -count=1` — all green (including the 9 `TestGuardUnitYear*` cases and the new roll-forward regression guard)
- `go test ./...` — 100% packages passing (`lodging` 110.6s, `sync` 283.9s, rest fast)
- `golangci-lint run ./lodging/...` — `No issues found`, `exit=0` (not in pre-push, run explicitly)
- `./scripts/dev/verify-lodging-schema.sh` — real `pocketbase serve` boot against a throwaway DB, all 103 JS migrations applied cleanly with the new hook wiring (`TestApp` in the Go suite skips `Start()`, so this is the check that actually proves the binary boots)
- Full pre-push suite (ruff, markdownlint, shellcheck, pb-js-lint, go-build, api-types-freshness, mypy, pytest, tsc): all green, `6007 passed, 41 skipped` (all pre-existing/expected skips per `tests/CLAUDE.md`)
- Pushed and confirmed landed: `git fetch -q && git rev-list --count origin/feature/lodging-unit-year-guard..HEAD` → `0`

**Unrelated pre-existing issue noticed, not caused by this branch:** `./scripts/dev/verify-lodging-seed.sh` fails with "no lodging_units rows — the boot loader did not run" both with and without this PR's changes (confirmed by stashing this diff and re-running against the committed baseline). Not a regression from this work; flagging for awareness.

## Test plan

- [x] `TestGuardUnitYearRejectsACrossYearRowOnUpdate` (closes #2035)
- [x] `TestGuardUnitYearRejectsACrossYearArea`
- [x] `TestGuardUnitYearRejectsACrossYearParentUnit`
- [x] `TestGuardUnitYearAllowsAUnitWhoseParentAndAreaShareItsYear` (positive control)
- [x] `TestGuardUnitYearIgnoresAnEmptyParentUnit`
- [x] `TestGuardUnitYearSkipsAUnitsSelfReference`
- [x] `TestApplyRollForwardSurvivesTheUnitYearGuard` (regression guard — green before and after, not red-first)

Closes #2039.
Closes #2035.
Closes #1870.

<sub>Listed one per line deliberately: GitHub'''s closing-issue parser only reads the first number in a comma-joined `Closes #a, #b, #c` list, so the comma form silently under-links the rest.</sub>




---

The two residual gaps named in the new `SCOPE:` block are tracked as **#2067** — including the three candidate shapes (cascade on write / refuse to re-season in place / detect rather than prevent).
