### PR TITLE
test(frontend): pin that changing Allocation live re-narrows the parent unit picker

### DIFF
--- a/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
@@ -380,6 +380,74 @@ describe('LodgingUnitForm — parent picker safety', () => {
   })
 })
 
+/**
+ * `UnitIdentityFields` takes `inventoryClass` as a prop, live off the
+ * Allocation select, rather than reading `unit.inventory_class` off the
+ * record — see that prop's own docstring. The only reason to thread it live
+ * is so the Parent unit picker re-narrows the instant a staffer flips
+ * Allocation, without a save and a reopen. `unitTree.test.ts` covers
+ * `parentCandidates` itself against both allocation values, but nothing
+ * before this rendered the form and drove the select — so the wiring that is
+ * the entire justification for the prop was untested.
+ */
+describe('LodgingUnitForm — the parent picker reflects a live allocation change', () => {
+  it('re-narrows the Parent unit options the moment Allocation changes, with no save and no remount', async () => {
+    const room: LodgingUnitRecord = {
+      ...UNIT,
+      id: 'room1',
+      name: 'Alpine Room',
+      code: 'alpine-room',
+      parent_unit: '',
+      inventory_class: 'family_pool',
+      is_container: false,
+    }
+    const guestBuilding: LodgingUnitRecord = {
+      ...UNIT,
+      id: 'guest_building',
+      name: 'Guest Lodge',
+      code: 'guest-lodge',
+      is_container: true,
+      inventory_class: 'family_pool',
+    }
+    const staffBuilding: LodgingUnitRecord = {
+      ...UNIT,
+      id: 'staff_building',
+      name: 'Staff Quarters',
+      code: 'staff-quarters',
+      is_container: true,
+      inventory_class: 'staff_default',
+    }
+    const user = userEvent.setup()
+
+    render(
+      <LodgingUnitForm
+        areas={AREAS}
+        units={[room, guestBuilding, staffBuilding]}
+        year={2026}
+        unit={room}
+        onSaved={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    // Held onto across the change below, not re-queried — a remount would
+    // detach this reference rather than update it.
+    const parentSelect = screen.getByLabelText<HTMLSelectElement>('Parent unit')
+    // A room still marked for guests is not offered the staff building.
+    expect([...parentSelect.options].map((o) => o.value)).toEqual(['', 'guest_building'])
+
+    await user.selectOptions(screen.getByLabelText('Allocation'), 'staff_default')
+
+    // Same render, no save, no remount — the picker widens to include the
+    // staff building the instant Allocation flips to "Held for staff".
+    expect([...parentSelect.options].map((o) => o.value)).toEqual([
+      '',
+      'guest_building',
+      'staff_building',
+    ])
+  })
+})
+
 describe('LodgingUnitForm — beds', () => {
   it('shows the suggested occupancy from the bed inventory', async () => {
     const user = userEvent.setup()


### PR DESCRIPTION
## What

Renders `LodgingUnitForm` with a mix of guest and staff containers, switches Allocation live from "Available to guests" to "Held for staff" (no save, no remount), and asserts the Parent unit picker's options actually re-narrow.

Closes #2045.

## Why

`UnitIdentityFields` receives `inventoryClass` as a prop for exactly one stated reason, in its own docstring: a staffer who has just switched a room to staff housing should see staff buildings offered in the Parent unit picker straight away, not after a save and a reopen.

`parentCandidates` (in `unitTree.ts`) is unit-tested against both allocation values, but nothing rendered the form and drove the select — so the wiring between the two, which is the entire justification for threading the prop live, was untested. A refactor that read `unit.inventory_class` off the record instead of the live select prop would have kept every existing test green while silently reintroducing the save-and-reopen behavior the prop exists to avoid.

## Mutation check

Per the issue, I mutated `LodgingUnitForm.tsx` to pass `unit?.inventory_class ?? 'family_pool'` (off the record) instead of the live `inventoryClass` state to `UnitIdentityFields`, confirmed the new test goes RED, then reverted.

**Mutation applied** (`frontend/src/components/admin/lodging/LodgingUnitForm.tsx`):
```diff
-        inventoryClass={inventoryClass}
+        inventoryClass={unit?.inventory_class ?? 'family_pool'}
```

**Result — RED:**
```
$ npx vitest run src/components/admin/lodging/LodgingUnitForm.test.tsx -t "re-narrows the Parent unit options" ; echo exit=$?

PASS (0) FAIL (1) skipped (60)

1. LodgingUnitForm — the parent picker reflects a live allocation change re-narrows the Parent unit options the moment Allocation changes, with no save and no remount
   AssertionError: expected [ '', 'guest_building' ] to deeply equal [ '', 'guest_building', …(1) ]
       at .../LodgingUnitForm.test.tsx:443:59
exit=1
```

Mutation reverted; `git diff --stat` after revert shows only the test file changed.

## Verification

```
$ cd frontend && npx vitest run src/components/admin/lodging ; echo exit=$?
PASS (223) FAIL (0)
exit=0

$ cd frontend && npm run type-check ; echo exit=$?
exit=0
```

Full `npx vitest run` (411 files) hit 13 unrelated timeouts under heavy machine contention (load average 66–90 on a 12-core box from several other agents' worktrees running vitest/tsc/go concurrently, `Test timed out in 5000ms`). None of the timeouts were the new test. Re-ran all 13 previously-timed-out files in isolation once contention eased: **273/273 passed, exit=0**.

Pre-push hook (go-build, ruff-check, pb-js-lint, shellcheck, markdownlint, api-types-freshness, mypy, pytest 6007 passed/41 skipped, type-check): all green.

Lint: `./node_modules/.bin/eslint src/components/admin/lodging/LodgingUnitForm.test.tsx` — exit 0.
