### PR TITLE
test(frontend): one QueryClient per test, built in beforeEach

### DIFF
--- a/frontend/src/components/FeedbackModal.test.tsx
+++ b/frontend/src/components/FeedbackModal.test.tsx
@@ -123,10 +123,6 @@ describe('FeedbackModal', () => {
   })
 
   it('resets form state when modal is closed and reopened', () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-    })
-
     const { rerender } = render(
       <QueryClientProvider client={queryClient}>
         <FeedbackModal isOpen={true} onClose={mockOnClose} />

--- a/frontend/src/components/FeedbackModal.test.tsx
+++ b/frontend/src/components/FeedbackModal.test.tsx
@@ -28,10 +28,9 @@ vi.mock('../contexts/AuthContext', () => ({
   useAuth: () => mockAuthState,
 }))
 
+let queryClient: QueryClient
+
 function renderModal(props: { isOpen: boolean; onClose: () => void }) {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-  })
   return render(
     <QueryClientProvider client={queryClient}>
       <FeedbackModal {...props} />
@@ -43,6 +42,9 @@ describe('FeedbackModal', () => {
   const mockOnClose = vi.fn()
 
   beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    })
     vi.clearAllMocks()
     mockAuthState.isLoading = false
     mockAuthState.isAuthenticated = true

--- a/frontend/src/components/session/SessionUploadChangesModal.test.tsx
+++ b/frontend/src/components/session/SessionUploadChangesModal.test.tsx
@@ -11,13 +11,16 @@ vi.mock('../../services/sessionUploadChanges', () => ({ fetchSessionUploadChange
 import { fetchSessionUploadChanges } from '../../services/sessionUploadChanges'
 import SessionUploadChangesModal from './SessionUploadChangesModal'
 
+let client: QueryClient
+
 const wrapper = ({ children }: { children: ReactNode }) => (
-  <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+  <QueryClientProvider client={client}>{children}</QueryClientProvider>
 )
 const mock = (rows: unknown) =>
   (fetchSessionUploadChanges as ReturnType<typeof vi.fn>).mockResolvedValue(rows)
 
 beforeEach(() => {
+  client = new QueryClient()
   vi.clearAllMocks()
   auth.isAuthLoading = false
 })

--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -6,7 +6,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { RosterPartyRow } from '../../types/lodging'
 import { HouseholdRosterTable } from './HouseholdRosterTable'
@@ -24,10 +24,15 @@ vi.mock('../../hooks/useWeekendRoster', () => ({
   useHouseholdMedical: () => ({ data: undefined, isLoading: false, error: null }),
 }))
 
+let client: QueryClient
+
 function wrapper({ children }: { children: ReactNode }) {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>
 }
+
+beforeEach(() => {
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+})
 
 function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
   return {

--- a/frontend/src/hooks/useLinkedAgSession.test.tsx
+++ b/frontend/src/hooks/useLinkedAgSession.test.tsx
@@ -11,12 +11,16 @@ vi.mock('./useCurrentYear', () => ({ useYear: () => 2026 }))
 
 import { useLinkedAgSession } from './useLinkedAgSession'
 
+let qc: QueryClient
+
 function wrapper({ children }: { children: ReactNode }) {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
 }
 
-beforeEach(() => getFullList.mockReset())
+beforeEach(() => {
+  qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  getFullList.mockReset()
+})
 
 describe('useLinkedAgSession', () => {
   it('returns the AG child cm_id when one exists with bunk_plans', async () => {

--- a/frontend/src/hooks/useRunSweep.test.tsx
+++ b/frontend/src/hooks/useRunSweep.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AuthContext } from '../contexts/AuthContext'
 import { postRunSweep } from '../services/solver'
@@ -13,9 +13,10 @@ vi.mock('../services/solver', () => ({
   postCancelSweep: vi.fn(),
 }))
 
+let qc: QueryClient
+let authCtx: ReturnType<typeof createMockAuthContext>
+
 const wrapper = ({ children }: { children: ReactNode }) => {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  const authCtx = createMockAuthContext({ user: createMockUser() })
   return (
     <AuthContext value={authCtx}>
       <QueryClientProvider client={qc}>{children}</QueryClientProvider>
@@ -24,6 +25,11 @@ const wrapper = ({ children }: { children: ReactNode }) => {
 }
 
 const mockPostRunSweep = vi.mocked(postRunSweep)
+
+beforeEach(() => {
+  qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  authCtx = createMockAuthContext({ user: createMockUser() })
+})
 
 describe('useRunSweep', () => {
   it('returns sweep_id and run_ids on success', async () => {

--- a/frontend/src/hooks/useSolverRuns.test.tsx
+++ b/frontend/src/hooks/useSolverRuns.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useSolverRuns } from './useSolverRuns'
 
@@ -39,10 +39,15 @@ vi.mock('../lib/pocketbase', () => ({
   },
 }))
 
+let qc: QueryClient
+
 const wrapper = ({ children }: { children: ReactNode }) => {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
 }
+
+beforeEach(() => {
+  qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+})
 
 describe('useSolverRuns', () => {
   it('passes through pre-parsed stats and details objects from PB', async () => {

--- a/frontend/src/pages/WeekendSessionList.test.tsx
+++ b/frontend/src/pages/WeekendSessionList.test.tsx
@@ -25,8 +25,9 @@ vi.mock('../hooks/useCurrentYear', () => ({
 
 vi.mock('../config/branding', () => ({ getCampNameShort: () => 'Camp' }))
 
+let client: QueryClient
+
 function wrapper({ children }: { children: ReactNode }) {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return (
     <QueryClientProvider client={client}>
       <MemoryRouter>{children}</MemoryRouter>
@@ -53,6 +54,7 @@ const WOMENS = {
 }
 
 beforeEach(() => {
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   summaryQuery.data = {
     year: 2026,
     weekends: [

--- a/frontend/src/pages/summer/SolverDebugPage/SolverDebugPage.test.tsx
+++ b/frontend/src/pages/summer/SolverDebugPage/SolverDebugPage.test.tsx
@@ -3,7 +3,7 @@ import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { MemoryRouter } from 'react-router'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import toast from 'react-hot-toast'
 
@@ -101,14 +101,19 @@ vi.mock('../../../hooks/useApiWithAuth', () => ({
   useApiWithAuth: () => ({ fetchWithAuth: vi.fn() }),
 }))
 
+let client: QueryClient
+
 const wrapper = ({ children }: { children: ReactNode }) => {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return (
-    <QueryClientProvider client={qc}>
+    <QueryClientProvider client={client}>
       <MemoryRouter initialEntries={['/summer/debug/solver']}>{children}</MemoryRouter>
     </QueryClientProvider>
   )
 }
+
+beforeEach(() => {
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+})
 
 afterEach(() => {
   mode = 'empty'


### PR DESCRIPTION
Closes #1944.

Eight frontend test files built their `QueryClient` inconsistently. Six constructed `new QueryClient(...)` **inside the RTL `wrapper` function** passed to `render(ui, { wrapper })`. RTL re-invokes `wrapper` on every explicit `rerender()` call — not on every render the component under test does internally — so a fresh `new QueryClient()` in there hands back an empty cache each time a test calls `rerender()`, silently discarding whatever the cache held before.

`FeedbackModal.test.tsx` was already correct, not part of the six: its `new QueryClient(...)` lived in `renderModal`, a plain helper function invoked once at the top of each test — not a `wrapper` re-run on `rerender()` — so it was already one client per test. It's folded into this sweep anyway, for one construction pattern across the codebase instead of two, and its one remaining local `QueryClient` (in the "resets form state" test) now reuses the same module-level client the rest of the file uses.

Nothing here is a live bug fix — the pattern was inconsistent and fragile rather than actively broken today. Most of these files don't call `rerender()` at all, so the empty-cache-on-rerender failure mode never fires; it becomes a real problem the moment a test's assertions depend on cache state surviving a `rerender()`.

## The correct pattern already existed

Copied verbatim from `weekend/LodgingMap.test.tsx` — a module-level `let client` assigned in `beforeEach`.

## It is 8 files, not the 10 the issue lists

The issue's list conflated *files containing the pattern* with *files needing the fix*. Two of the ten were already correct and are deliberately untouched:

| File | Why skipped |
|---|---|
| `hooks/useWeekendRoster.test.tsx` | Already fixed by #1965; its own comments explain the correct pattern |
| `weekend/AccessibilityFlagList.test.tsx` | No `QueryClient` remains in the file at all |

Two more the issue named — `admin/lodging/LodgingAreasDrawer.test.tsx` and `admin/lodging/LodgingUnitsPanel.test.tsx` — were **already hoisted into `beforeEach`**. Those are the two CodeRabbit flagged during the #1893 review, which the issue itself records as having been fixed while the codebase was never swept. So they needed nothing.

`components/FeedbackModal.test.tsx` was **not** in the issue's list and did need the consistency fold; it came from grepping rather than trusting the list.

## Files changed

- `components/FeedbackModal.test.tsx`
- `components/session/SessionUploadChangesModal.test.tsx`
- `components/weekend/HouseholdRosterTable.test.tsx`
- `hooks/useLinkedAgSession.test.tsx`
- `hooks/useRunSweep.test.tsx`
- `hooks/useSolverRuns.test.tsx`
- `pages/WeekendSessionList.test.tsx`
- `pages/summer/SolverDebugPage/SolverDebugPage.test.tsx`

## Verification

No behaviour change; the suite is green before and after.

- The 8 touched files: **8 files / 60 tests passed, exit 0**
- `npm run type-check`: exit 0
- `eslint` on all 8 (via `./node_modules/.bin/eslint`, not `npx`, which resolves a stale global 6.4.0): exit 0
- Full pre-push chain on push: ruff, go-build, mypy, pb-js-lint, shellcheck, markdownlint, api-types-freshness, pytest, type-check — all green

⚠️ **A full local `vitest run` on this machine reported unrelated timeout failures, and they are load artefacts, not this change.** Ten agent worktrees were running suites concurrently; the same flake class reproduces on files this PR does not touch (`TitleSwitcher.test.tsx` passes standalone and times out under full-suite load), and every affected spec passes in isolation. CI's sharded runners are the arbiter here — this note exists so a reviewer seeing a local red does not attribute it to this diff.

## Note for #1996

`weekend/HouseholdRosterTable.test.tsx` is also touched by #1996 (routing the roster row to `FamilyDetailsPanel`). Whichever merges second will need a trivial rebase on the `QueryClient` setup block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
