### PR TITLE
test(pb,sync): year-scoping test-guard follow-ups from PR #2029 review

### DIFF
--- a/pocketbase/lodging/registry_test.go
+++ b/pocketbase/lodging/registry_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/tests"
+	"github.com/pocketbase/pocketbase/tools/types"
 )
 
 // setupRegistryCollections builds lodging_areas, lodging_units and
@@ -31,8 +32,12 @@ func setupRegistryCollections(t *testing.T, app core.App) {
 	// tightened twin, lodging_testsupport_test.go:114): PocketBase's Set on a
 	// column that does not exist is a silent no-op, so a fixture that forgot
 	// this column would resolve every season against a row stored at year 0
-	// instead of failing loudly here.
-	areas.Fields.Add(&core.NumberField{Name: "year", Required: true, OnlyInt: true})
+	// instead of failing loudly here. Min/Max mirror the same migration's
+	// `min: 2010, max: 2100`.
+	areas.Fields.Add(&core.NumberField{
+		Name: "year", Required: true, OnlyInt: true,
+		Min: types.Pointer(2010.0), Max: types.Pointer(2100.0),
+	})
 	// Composite (code, year), matching production's 1500000141: code alone is
 	// no longer unique once a row exists per season.
 	areas.AddIndex("idx_lodging_areas_code", true, "code, year", "")
@@ -81,7 +86,10 @@ func setupRegistryCollections(t *testing.T, app core.App) {
 	})
 	units.Fields.Add(&core.NumberField{Name: "max_beds", OnlyInt: true})
 	// Required, same reason as lodging_areas' year field above.
-	units.Fields.Add(&core.NumberField{Name: "year", Required: true, OnlyInt: true})
+	units.Fields.Add(&core.NumberField{
+		Name: "year", Required: true, OnlyInt: true,
+		Min: types.Pointer(2010.0), Max: types.Pointer(2100.0),
+	})
 	// Composite (code, year), matching production's 1500000141.
 	units.AddIndex("idx_lodging_units_code", true, "code, year", "")
 	saveRegistryCollection(t, app, units)
@@ -142,11 +150,16 @@ func countRecords(t *testing.T, app core.App, collection string) int {
 	return len(recs)
 }
 
-func findByCode(t *testing.T, app core.App, collection, code string) *core.Record {
+// findByCode looks up a row by (code, year). Since migration 1500000141, code
+// is unique only per (code, year), so a code-only filter can silently return
+// another season's row -- the year parameter is required, not optional, so
+// there is exactly one lookup shape in this file and it is the correct one.
+func findByCode(t *testing.T, app core.App, collection, code string, year int) *core.Record {
 	t.Helper()
-	rec, err := app.FindFirstRecordByFilter(collection, "code = {:c}", map[string]any{"c": code})
+	rec, err := app.FindFirstRecordByFilter(collection,
+		"code = {:c} && year = {:y}", map[string]any{"c": code, "y": year})
 	if err != nil {
-		t.Fatalf("find %s code=%s: %v", collection, code, err)
+		t.Fatalf("find %s code=%s year=%d: %v", collection, code, year, err)
 	}
 	return rec
 }
@@ -288,7 +301,7 @@ func TestSeedRegistryCreatesAreasUnitsAndAliases(t *testing.T) {
 		t.Errorf("got %d aliases, want 2", n)
 	}
 
-	area := findByCode(t, app, "lodging_areas", "AREA1")
+	area := findByCode(t, app, "lodging_areas", "AREA1", testYear)
 	if got := area.GetString("name"); got != "First Area" {
 		t.Errorf("area name = %q, want %q", got, "First Area")
 	}
@@ -299,7 +312,7 @@ func TestSeedRegistryCreatesAreasUnitsAndAliases(t *testing.T) {
 		t.Errorf("area sort_order = %d, want 1", got)
 	}
 
-	child := findByCode(t, app, "lodging_units", "child-a")
+	child := findByCode(t, app, "lodging_units", "child-a", testYear)
 	if got := child.GetString("name"); got != "Child A" {
 		t.Errorf("unit name = %q, want %q", got, "Child A")
 	}
@@ -334,7 +347,7 @@ func TestSeedRegistryCreatesAreasUnitsAndAliases(t *testing.T) {
 	if child.GetBool("is_container") {
 		t.Error("child-a is_container = true, want false")
 	}
-	if !findByCode(t, app, "lodging_units", "building-1").GetBool("is_container") {
+	if !findByCode(t, app, "lodging_units", "building-1", testYear).GetBool("is_container") {
 		t.Error("building-1 is_container = false, want true")
 	}
 }
@@ -361,7 +374,7 @@ func TestSeedRegistryWritesAmenities(t *testing.T) {
 		t.Fatalf("seedRegistryFromFile: %v", err)
 	}
 
-	unit := findByCode(t, app, "lodging_units", "warm")
+	unit := findByCode(t, app, "lodging_units", "warm", testYear)
 	for _, field := range []string{
 		"has_power", "has_ac", "has_fridge", "is_accessible",
 		"has_heat", "is_weatherized", "has_plumbing",
@@ -413,12 +426,12 @@ func TestSeedRegistryWritesDefaultCombined(t *testing.T) {
 		t.Fatalf("seedRegistryFromFile: %v", err)
 	}
 
-	if got := findByCode(t, app, "lodging_units", "whole-let").GetBool("default_combined"); !got {
+	if got := findByCode(t, app, "lodging_units", "whole-let", testYear).GetBool("default_combined"); !got {
 		t.Errorf("default_combined = %v for a unit the file marks true, want true", got)
 	}
 	// Absent means false — "draw the children", the behavior before the
 	// column existed. A container used purely for grouping carries no let.
-	if got := findByCode(t, app, "lodging_units", "grouping").GetBool("default_combined"); got {
+	if got := findByCode(t, app, "lodging_units", "grouping", testYear).GetBool("default_combined"); got {
 		t.Errorf("default_combined = %v for a unit with no key, want false", got)
 	}
 }
@@ -437,7 +450,7 @@ func TestSeedRegistryUnassessedRampStaysBlank(t *testing.T) {
 		t.Fatalf("seedRegistryFromFile: %v", err)
 	}
 
-	if got := findByCode(t, app, "lodging_units", "unknown-ramp").GetString("has_ramp"); got != "" {
+	if got := findByCode(t, app, "lodging_units", "unknown-ramp", testYear).GetString("has_ramp"); got != "" {
 		t.Errorf("has_ramp = %q for an unassessed unit, want empty (not assessed)", got)
 	}
 }
@@ -449,11 +462,11 @@ func TestSeedRegistryWiresParentDeclaredAfterChild(t *testing.T) {
 		t.Fatalf("seedRegistryFromFile: %v", err)
 	}
 
-	building := findByCode(t, app, "lodging_units", "building-1")
+	building := findByCode(t, app, "lodging_units", "building-1", testYear)
 	// child-a is listed BEFORE building-1 in the file: a single-pass loader
 	// would have no id to point at and would leave the relation empty.
 	for _, code := range []string{"child-a", "child-b"} {
-		if got := findByCode(t, app, "lodging_units", code).GetString("parent_unit"); got != building.Id {
+		if got := findByCode(t, app, "lodging_units", code, testYear).GetString("parent_unit"); got != building.Id {
 			t.Errorf("%s parent_unit = %q, want %q", code, got, building.Id)
 		}
 	}
@@ -473,7 +486,7 @@ func TestSeedRegistryNullSleepsStoresZero(t *testing.T) {
 		t.Fatalf("seedRegistryFromFile: %v", err)
 	}
 
-	if got := findByCode(t, app, "lodging_units", "building-1").GetInt("sleeps"); got != 0 {
+	if got := findByCode(t, app, "lodging_units", "building-1", testYear).GetInt("sleeps"); got != 0 {
 		t.Errorf("null sleeps stored as %d, want 0 (unknown)", got)
 	}
 }
@@ -527,8 +540,8 @@ func TestSeedRegistryAliasMembersResolveToUnitIDs(t *testing.T) {
 	}
 
 	want := []string{
-		findByCode(t, app, "lodging_units", "child-a").Id,
-		findByCode(t, app, "lodging_units", "child-b").Id,
+		findByCode(t, app, "lodging_units", "child-a", testYear).Id,
+		findByCode(t, app, "lodging_units", "child-b", testYear).Id,
 	}
 	got := merge.GetStringSlice("member_units")
 	if len(got) != len(want) {
@@ -575,7 +588,7 @@ func TestSeedRegistryPreservesStaffEdits(t *testing.T) {
 		t.Fatalf("first run: %v", err)
 	}
 
-	edited := findByCode(t, app, "lodging_units", "child-a")
+	edited := findByCode(t, app, "lodging_units", "child-a", testYear)
 	edited.Set("sleeps", 9)
 	edited.Set("is_confirmed", true)
 	edited.Set("map_x", 0.9)
@@ -588,7 +601,7 @@ func TestSeedRegistryPreservesStaffEdits(t *testing.T) {
 		t.Fatalf("second run: %v", err)
 	}
 
-	after := findByCode(t, app, "lodging_units", "child-a")
+	after := findByCode(t, app, "lodging_units", "child-a", testYear)
 	if got := after.GetInt("sleeps"); got != 9 {
 		t.Errorf("sleeps = %d after re-seed, want the staff value 9", got)
 	}
@@ -613,7 +626,7 @@ func TestSeedRegistryDoesNotRewireAnExistingParent(t *testing.T) {
 		t.Fatalf("first run: %v", err)
 	}
 
-	detached := findByCode(t, app, "lodging_units", "child-b")
+	detached := findByCode(t, app, "lodging_units", "child-b", testYear)
 	detached.Set("parent_unit", "")
 	if err := app.Save(detached); err != nil {
 		t.Fatalf("clear parent: %v", err)
@@ -623,7 +636,7 @@ func TestSeedRegistryDoesNotRewireAnExistingParent(t *testing.T) {
 		t.Fatalf("second run: %v", err)
 	}
 
-	if got := findByCode(t, app, "lodging_units", "child-b").GetString("parent_unit"); got != "" {
+	if got := findByCode(t, app, "lodging_units", "child-b", testYear).GetString("parent_unit"); got != "" {
 		t.Errorf("parent_unit = %q after re-seed, want it left cleared", got)
 	}
 }
@@ -813,7 +826,7 @@ func TestSeedRegistryRewiresChildrenOfARecreatedContainer(t *testing.T) {
 		t.Fatalf("first run: %v", err)
 	}
 
-	container := findByCode(t, app, "lodging_units", "building-1")
+	container := findByCode(t, app, "lodging_units", "building-1", testYear)
 	if err := app.Delete(container); err != nil {
 		t.Fatalf("delete container: %v", err)
 	}
@@ -822,9 +835,9 @@ func TestSeedRegistryRewiresChildrenOfARecreatedContainer(t *testing.T) {
 		t.Fatalf("second run: %v", err)
 	}
 
-	recreated := findByCode(t, app, "lodging_units", "building-1")
+	recreated := findByCode(t, app, "lodging_units", "building-1", testYear)
 	for _, code := range []string{"child-a", "child-b"} {
-		if got := findByCode(t, app, "lodging_units", code).GetString("parent_unit"); got != recreated.Id {
+		if got := findByCode(t, app, "lodging_units", code, testYear).GetString("parent_unit"); got != recreated.Id {
 			t.Errorf("%s.parent_unit = %q after the container was recreated, want %q",
 				code, got, recreated.Id)
 		}
@@ -926,6 +939,86 @@ func TestFindByCodeAndYearIgnoresOtherYears(t *testing.T) {
 	}
 	if rec != nil {
 		t.Errorf("found a 2026 row when asking for 2027: %s", rec.Id)
+	}
+}
+
+// TestFindByCodeIsScopedToItsYear guards the findByCode test helper itself.
+// Since migration 1500000141, code is unique only per (code, year), so a
+// lookup that ignores year can return another season's row instead of the
+// caller's. Both seasons share the code here so a regression to a code-only
+// filter would not just occasionally pick the wrong row -- FindFirstRecordByFilter
+// has no defined tie-break order, so the two assertions below would either both
+// read the SAME row (failing the id-distinctness check) or read one correctly
+// and one wrong, unpredictably. Asserting each year's row by its own "year"
+// field, rather than by id equality with something seeded once, is what makes
+// a regression here fail loudly instead of flaking.
+func TestFindByCodeIsScopedToItsYear(t *testing.T) {
+	app := newRegistryTestApp(t)
+
+	if err := seedRegistryFromFile(app, writeRegistry(t, fixtureRegistry), 2026); err != nil {
+		t.Fatalf("seed 2026: %v", err)
+	}
+	if err := seedRegistryFromFile(app, writeRegistry(t, fixtureRegistry), 2027); err != nil {
+		t.Fatalf("seed 2027: %v", err)
+	}
+
+	rec2026 := findByCode(t, app, "lodging_units", "child-a", 2026)
+	rec2027 := findByCode(t, app, "lodging_units", "child-a", 2027)
+
+	if rec2026.Id == rec2027.Id {
+		t.Fatalf("the same row was returned for both years: %s", rec2026.Id)
+	}
+	if got := rec2026.GetInt("year"); got != 2026 {
+		t.Errorf("row fetched for 2026 has year = %d, want 2026", got)
+	}
+	if got := rec2027.GetInt("year"); got != 2027 {
+		t.Errorf("row fetched for 2027 has year = %d, want 2027", got)
+	}
+}
+
+// TestRegistryFixtureRejectsYearOutsideProductionRange guards the fixture's
+// own year fields against production (migration 1500000141: min 2010, max
+// 2100). Both lodging_units and lodging_areas already carry Required and
+// OnlyInt here; without Min/Max too, a test could store year: 1 and pass on
+// data the real database would reject.
+func TestRegistryFixtureRejectsYearOutsideProductionRange(t *testing.T) {
+	app := newRegistryTestApp(t)
+
+	area, err := app.FindCollectionByNameOrId("lodging_areas")
+	if err != nil {
+		t.Fatalf("find collection lodging_areas: %v", err)
+	}
+	unit, err := app.FindCollectionByNameOrId("lodging_units")
+	if err != nil {
+		t.Fatalf("find collection lodging_units: %v", err)
+	}
+
+	// The unit case needs an area to point at.
+	if err := seedRegistryFromFile(app, writeRegistry(t, fixtureRegistry), testYear); err != nil {
+		t.Fatalf("seedRegistryFromFile: %v", err)
+	}
+	areaID := findByCode(t, app, "lodging_areas", "AREA1", testYear).Id
+
+	cases := []struct {
+		label      string
+		collection *core.Collection
+		values     map[string]any
+	}{
+		{"area below min (2010)", area, map[string]any{"code": "range-check", "name": "range-check", "year": 2009}},
+		{"area above max (2100)", area, map[string]any{"code": "range-check", "name": "range-check", "year": 2101}},
+		{"unit below min (2010)", unit, map[string]any{
+			"code": "range-check", "name": "range-check", "area": areaID, "year": 2009,
+		}},
+	}
+
+	for _, c := range cases {
+		rec := core.NewRecord(c.collection)
+		for k, v := range c.values {
+			rec.Set(k, v)
+		}
+		if err := app.Save(rec); err == nil {
+			t.Errorf("%s: saved; want the fixture to refuse it like production does", c.label)
+		}
 	}
 }
 

--- a/pocketbase/sync/lodging_alias_resolver_test.go
+++ b/pocketbase/sync/lodging_alias_resolver_test.go
@@ -48,41 +48,64 @@ func TestAliasResolverUnboundedWindows(t *testing.T) {
 // across camp, and nothing downstream would notice.
 func TestAliasResolverRespectsRenameWindows(t *testing.T) {
 	app := newLodgingTestApp(t)
-	// gtWawona is queried at 2023 (inside its window) and hcDoctors at 2025
-	// (inside its own), so each needs a row at exactly the year it is resolved
-	// against. gtFront/gtBack are never resolved directly in this test -- only
-	// named as members of an alias nothing here calls Resolve on -- so their
-	// year is unconstrained; 2025 matches the rename they stand in for.
-	gtWawona := addUnit(t, app, "gt-wawona", 2023)
+	// Every building here gets a row in EVERY year the test resolves against,
+	// including the years its own alias window excludes. A rename retires the
+	// STRING, not the building, and the registry is year-scoped (migration
+	// 1500000141), so a house that survives a season has a distinct row, and
+	// id, every year it stands. Skipping the out-of-window years would let
+	// Resolve's missing-row gate answer "unresolved" before covers() is ever
+	// consulted -- the window assertions below would then still pass with the
+	// window checks deleted, which is exactly what they exist to catch.
+	years := []int{2022, 2023, 2024, 2025}
+	gtWawonaByYear := make(map[int]string, len(years))
+	hcDoctorsByYear := make(map[int]string, len(years))
+	for _, year := range years {
+		gtWawonaByYear[year] = addUnit(t, app, "gt-wawona", year)
+		hcDoctorsByYear[year] = addUnit(t, app, "hc-doctors-house", year)
+	}
+	// The 2025 split of the Golden Triangle house into two lettable rooms.
+	// Never resolved directly here -- only named as members of an alias nothing
+	// in this test calls Resolve on -- so 2025 alone is enough.
 	gtFront := addUnit(t, app, "gt-wawona-front", 2025)
 	gtBack := addUnit(t, app, "gt-wawona-back", 2025)
-	hcDoctors := addUnit(t, app, "hc-doctors-house", 2025)
 
-	addAlias(t, app, "Golden Triangle - Doctor's House", []string{gtWawona}, 0, 2024)
+	// An alias stores whichever season's ids existed when it was authored and is
+	// never re-pointed; Resolve threads stored id -> code -> requested year.
+	addAlias(t, app, "Golden Triangle - Doctor's House", []string{gtWawonaByYear[2023]}, 0, 2024)
 	addAlias(t, app, "Golden Triangle - Wawona", []string{gtFront, gtBack}, 2025, 0)
-	addAlias(t, app, "Health Center - Doctor's House", []string{hcDoctors}, 0, 2024)
-	addAlias(t, app, "Doctor's House", []string{hcDoctors}, 2025, 0)
+	addAlias(t, app, "Health Center - Doctor's House", []string{hcDoctorsByYear[2023]}, 0, 2024)
+	addAlias(t, app, "Doctor's House", []string{hcDoctorsByYear[2025]}, 2025, 0)
 
 	r, err := NewAliasResolver(app)
 	if err != nil {
 		t.Fatalf("NewAliasResolver: %v", err)
 	}
 
-	// In window.
+	// In window, both retired strings.
 	if got := r.Resolve("Golden Triangle - Doctor's House", 2023); !got.Resolved ||
-		got.UnitIDs[0] != gtWawona {
+		got.UnitIDs[0] != gtWawonaByYear[2023] {
 		t.Errorf("2023 GT Doctor's House: %+v", got)
 	}
+	if got := r.Resolve("Health Center - Doctor's House", 2023); !got.Resolved ||
+		got.UnitIDs[0] != hcDoctorsByYear[2023] {
+		t.Errorf("2023 HC Doctor's House: %+v", got)
+	}
 	// Out of window on the high side -- the string was retired, so it must NOT
-	// silently fall through to the Health Center row of the same shape.
+	// silently fall through to the Health Center row of the same shape. Both
+	// buildings have a 2025 row, so only the window can refuse these.
 	if got := r.Resolve("Golden Triangle - Doctor's House", 2025); got.Resolved {
 		t.Errorf("2025 GT Doctor's House resolved to %v; the window ends at 2024", got.UnitCodes)
 	}
-	// Out of window on the low side.
+	if got := r.Resolve("Health Center - Doctor's House", 2025); got.Resolved {
+		t.Errorf("2025 HC Doctor's House resolved to %v; the window ends at 2024", got.UnitCodes)
+	}
+	// Out of window on the low side. hc-doctors-house has a 2024 row, so only
+	// the window can refuse this.
 	if got := r.Resolve("Doctor's House", 2024); got.Resolved {
 		t.Errorf("2024 bare Doctor's House resolved to %v; the window starts at 2025", got.UnitCodes)
 	}
-	if got := r.Resolve("Doctor's House", 2025); !got.Resolved || got.UnitIDs[0] != hcDoctors {
+	if got := r.Resolve("Doctor's House", 2025); !got.Resolved ||
+		got.UnitIDs[0] != hcDoctorsByYear[2025] {
 		t.Errorf("2025 bare Doctor's House: %+v", got)
 	}
 }

--- a/pocketbase/sync/lodging_alias_resolver_test.go
+++ b/pocketbase/sync/lodging_alias_resolver_test.go
@@ -81,6 +81,18 @@ func TestAliasResolverRespectsRenameWindows(t *testing.T) {
 		t.Fatalf("NewAliasResolver: %v", err)
 	}
 
+	// In window at the start of the span too -- valid_from_year is unbounded
+	// (0), so 2022 (the year the buildings actually opened, per the doc comment
+	// above) must resolve exactly like 2023 does. Also what makes the 2022 rows
+	// created above load-bearing instead of dead fixture weight.
+	if got := r.Resolve("Golden Triangle - Doctor's House", 2022); !got.Resolved ||
+		got.UnitIDs[0] != gtWawonaByYear[2022] {
+		t.Errorf("2022 GT Doctor's House: %+v", got)
+	}
+	if got := r.Resolve("Health Center - Doctor's House", 2022); !got.Resolved ||
+		got.UnitIDs[0] != hcDoctorsByYear[2022] {
+		t.Errorf("2022 HC Doctor's House: %+v", got)
+	}
 	// In window, both retired strings.
 	if got := r.Resolve("Golden Triangle - Doctor's House", 2023); !got.Resolved ||
 		got.UnitIDs[0] != gtWawonaByYear[2023] {
@@ -89,6 +101,17 @@ func TestAliasResolverRespectsRenameWindows(t *testing.T) {
 	if got := r.Resolve("Health Center - Doctor's House", 2023); !got.Resolved ||
 		got.UnitIDs[0] != hcDoctorsByYear[2023] {
 		t.Errorf("2023 HC Doctor's House: %+v", got)
+	}
+	// The valid_to_year boundary itself is INCLUSIVE: the window "0..2024" still
+	// covers 2024, not just years strictly before it. This is the half-closed
+	// gap the lower bound already had coverage for and the upper bound did not.
+	if got := r.Resolve("Golden Triangle - Doctor's House", 2024); !got.Resolved ||
+		got.UnitIDs[0] != gtWawonaByYear[2024] {
+		t.Errorf("2024 GT Doctor's House (inclusive upper boundary): %+v", got)
+	}
+	if got := r.Resolve("Health Center - Doctor's House", 2024); !got.Resolved ||
+		got.UnitIDs[0] != hcDoctorsByYear[2024] {
+		t.Errorf("2024 HC Doctor's House (inclusive upper boundary): %+v", got)
 	}
 	// Out of window on the high side -- the string was retired, so it must NOT
 	// silently fall through to the Health Center row of the same shape. Both

--- a/pocketbase/sync/lodging_requests_test.go
+++ b/pocketbase/sync/lodging_requests_test.go
@@ -84,6 +84,36 @@ func TestCollapseNoRequestsDoesNotVetoTheGate(t *testing.T) {
 	}
 }
 
+// TestCollapseSiblingDisagreementSurvivesANoRequestsSibling pins spec 4.2's
+// household-grain collapse against silently losing a real request. The Family
+// Camp information form is answered per child, and siblings sometimes
+// disagree -- 11 households in 2025, 5 in 2026. One child's genuine "Share a
+// cabin WITH" request must survive a sibling's "No requests": ORing the modes
+// together, rather than last-wins or requiring agreement, is what makes most
+// observed "No requests + real request" combinations exist at all (design
+// doc §10).
+func TestCollapseSiblingDisagreementSurvivesANoRequestsSibling(t *testing.T) {
+	ts := time.Date(2025, 4, 21, 17, 51, 0, 0, time.UTC)
+	const withNamed = "Share a cabin WITH a specific family that I know (please include names " +
+		"below and ensure that the request is mutual)."
+
+	// Emma Garcia named a family on her own form answer; her sibling Liam's
+	// record carries the modes field's own no-preference option -- silence,
+	// not a decline.
+	got := CollapseToHouseholdGrain([]PersonRequestValue{
+		{HouseholdKey: hhA, FieldName: fieldSharedCabinForm, Value: withNamed, LastUpdated: ts},
+		{HouseholdKey: hhA, FieldName: fieldSharedCabinForm, Value: "No requests", LastUpdated: ts},
+	})
+
+	if !got[hhA].WantsWith {
+		t.Error("WantsWith = false; a sibling's real request must survive another sibling's \"No requests\"")
+	}
+	if got[hhA].ShareEligibility != shareEligibilityNamed {
+		t.Errorf("ShareEligibility = %q, want %q -- the real request must still resolve to a verdict",
+			got[hhA].ShareEligibility, shareEligibilityNamed)
+	}
+}
+
 // TestCollapseDoesNotStampUnrelatedFields: request_last_updated is the column
 // spec 4.1 designates for resolving a form-vs-registration conflict, so it has
 // to mean "when the request was last touched". applyHouseholdRequests feeds

--- a/pocketbase/sync/lodging_testsupport_fixture_test.go
+++ b/pocketbase/sync/lodging_testsupport_fixture_test.go
@@ -1,0 +1,67 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// TestLodgingUnitsFixtureRejectsDuplicateCodeYear guards the sync package's
+// own lodging_units fixture against a shape production migration 1500000141
+// makes impossible: two rows sharing (code, year). Without a composite unique
+// index a test can seed a collision the real database would refuse -- this
+// already bit once during the branch that added year scoping, and it only
+// surfaced because lodging/registry_test.go's twin fixture carries the index;
+// this package's did not.
+func TestLodgingUnitsFixtureRejectsDuplicateCodeYear(t *testing.T) {
+	app := newLodgingTestApp(t)
+	addUnit(t, app, "dup-code", 2026)
+
+	col, err := app.FindCollectionByNameOrId("lodging_units")
+	if err != nil {
+		t.Fatalf("find collection lodging_units: %v", err)
+	}
+	dup := core.NewRecord(col)
+	dup.Set("code", "dup-code")
+	dup.Set("name", "dup-code")
+	dup.Set("is_active", true)
+	dup.Set("is_container", false)
+	dup.Set("year", 2026)
+	if err := app.Save(dup); err == nil {
+		t.Fatal("saved a second lodging_units row sharing (code, year) 2026; " +
+			"want the unique index to refuse it like production does")
+	}
+}
+
+// TestLodgingUnitsFixtureRejectsYearOutsideProductionRange guards the year
+// field's Min/Max/OnlyInt against production (migration 1500000141: min 2010,
+// max 2100, onlyInt true). The fixture already marks year Required; without
+// the range too, a test can store year: 1 or year: 2025.5 and pass on data
+// the real database would reject.
+func TestLodgingUnitsFixtureRejectsYearOutsideProductionRange(t *testing.T) {
+	app := newLodgingTestApp(t)
+	col, err := app.FindCollectionByNameOrId("lodging_units")
+	if err != nil {
+		t.Fatalf("find collection lodging_units: %v", err)
+	}
+
+	cases := []struct {
+		label string
+		year  any
+	}{
+		{"below min (2010)", 2009},
+		{"above max (2100)", 2101},
+		{"non-integer", 2025.5},
+	}
+	for _, c := range cases {
+		rec := core.NewRecord(col)
+		rec.Set("code", "range-check")
+		rec.Set("name", "range-check")
+		rec.Set("is_active", true)
+		rec.Set("is_container", false)
+		rec.Set("year", c.year)
+		if err := app.Save(rec); err == nil {
+			t.Errorf("%s: saved year=%v; want the fixture to refuse it like production does", c.label, c.year)
+		}
+	}
+}

--- a/pocketbase/sync/lodging_testsupport_test.go
+++ b/pocketbase/sync/lodging_testsupport_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/tests"
+	"github.com/pocketbase/pocketbase/tools/types"
 )
 
 // CampMinder ids for the fixture sessions. Shared across the lodging tests
@@ -110,8 +111,18 @@ func newLodgingTestApp(t *testing.T) core.App {
 	// Required, mirroring migration 1500000141. PocketBase's Set on a column
 	// that does not exist is a silent no-op, so a fixture that forgot this
 	// column would resolve every year against a unit stored at year 0 --
-	// exactly the failure this field exists to catch loudly, here.
-	units.Fields.Add(&core.NumberField{Name: "year", Required: true})
+	// exactly the failure this field exists to catch loudly, here. Min/Max/
+	// OnlyInt mirror the same migration's `min: 2010, max: 2100, onlyInt:
+	// true` -- without them a test can store year: 1 or year: 2025.5 and pass
+	// on data the real database would reject.
+	units.Fields.Add(&core.NumberField{
+		Name: "year", Required: true, OnlyInt: true,
+		Min: types.Pointer(2010.0), Max: types.Pointer(2100.0),
+	})
+	// Composite (code, year), matching production's 1500000141: code alone is
+	// no longer unique once a row exists per season. Without this a test can
+	// seed two rows sharing (code, year), a shape production refuses.
+	units.AddIndex("idx_lodging_units_code", true, "code, year", "")
 	saveCollection(t, app, units)
 
 	// parent_unit is a self-relation, so it needs the collection's own id --


### PR DESCRIPTION
## Summary

Four test-only deferred-minors from the `2026-08-04-lodging-year-scoping` final review (PR #2029). No production code changes — every commit touches only `_test.go` files.

- #2030 — `findByCode` test helper is now year-scoped (was code-only, latent risk of reading another season's row)
- #2033 — both lodging fixtures now enforce production's `(code, year)` uniqueness and year range (2010–2100)
- #2034 — the rename-window alias fixture now resolves inside its own alias windows
- #2015 — a real sibling share request now has a test proving it survives another sibling's "No requests"

## The one thing worth reading closely: #2034

The issue as filed described a cosmetic fixture inconsistency ("the hc-doctors-house fixture contradicts its own 0..2024 alias window"). Investigating it turned up something bigger: **`covers()` in `lodging_alias_resolver.go` — the year-window enforcement that PR #2029 made the resolver's entire reason for existing — was asserted by *zero* tests before this PR.**

`covers()` could be replaced wholesale with `return true` and the entire `pocketbase/sync` package still passed. Deleting only the `ValidFromYear` guard: passed. Deleting only the `ValidToYear` guard: passed. The fixture incoherence the issue flagged was the *cause*: every "must NOT resolve" assertion in `TestAliasResolverRespectsRenameWindows` was satisfied by `Resolve`'s missing-row gate (no unit row existed that year) rather than by the window gate ever running. `hc-doctors-house` had no 2024 row, so `Resolve("Doctor's House", 2024)` returned unresolved for the wrong reason — not because the window starts at 2025, but because there was nothing to find at all.

Fixed by giving every building a row in every year the test resolves against, including years its own alias window excludes — modeling that a rename retires the *string*, not the building. See the commit for the full before/after mutation transcripts.

## Mutation-check transcripts (all four; each broken, confirmed red, then restored)

### #2030 — findByCode ignoring year
```
$ go test ./lodging/... -run TestFindByCodeIsScopedToItsYear -v
--- FAIL: TestFindByCodeIsScopedToItsYear
    registry_test.go:961: the same row was returned for both years: yzo2mwxpfa3epz6
```

### #2033a — sync fixture missing the (code, year) unique index
```
$ go test ./sync/... -run TestLodgingUnitsFixtureRejectsDuplicateCodeYear -v
--- FAIL: TestLodgingUnitsFixtureRejectsDuplicateCodeYear
    lodging_testsupport_fixture_test.go:31: saved a second lodging_units row sharing (code, year) 2026;
    want the unique index to refuse it like production does
```

### #2033b — sync fixture missing Min/Max/OnlyInt on year
```
$ go test ./sync/... -run TestLodgingUnitsFixtureRejectsYearOutsideProductionRange -v
--- FAIL: TestLodgingUnitsFixtureRejectsYearOutsideProductionRange
    lodging_testsupport_fixture_test.go:64: below min (2010): saved year=2009
    lodging_testsupport_fixture_test.go:64: above max (2100): saved year=2101
    lodging_testsupport_fixture_test.go:64: non-integer: saved year=2025.5
```

### #2033c — registry fixture missing Min/Max on year (both lodging_areas.year and lodging_units.year)
```
$ go test ./lodging/... -run TestRegistryFixtureRejectsYearOutsideProductionRange -v
--- FAIL: TestRegistryFixtureRejectsYearOutsideProductionRange
    registry_test.go:1017: area below min (2010): saved; want the fixture to refuse it like production does
    registry_test.go:1017: area above max (2100): saved; want the fixture to refuse it like production does
    registry_test.go:1017: unit below min (2010): saved; want the fixture to refuse it like production does
```

### #2034 — covers() year-window guards deleted
```
$ go test ./sync/ -run TestAliasResolverRespectsRenameWindows -v      # ValidFromYear guard deleted
--- FAIL: TestAliasResolverRespectsRenameWindows
    lodging_alias_resolver_test.go:105: 2024 bare Doctor's House resolved to [hc-doctors-house];
    the window starts at 2025

$ go test ./sync/ -run TestAliasResolverRespectsRenameWindows -v      # ValidToYear guard deleted
--- FAIL: TestAliasResolverRespectsRenameWindows
    lodging_alias_resolver_test.go:97: 2025 GT Doctor's House resolved to [gt-wawona]; the window ends at 2024
    lodging_alias_resolver_test.go:100: 2025 HC Doctor's House resolved to [hc-doctors-house]; the window ends at 2024
```

### #2034 addendum (review follow-up) — the ValidToYear boundary was still unpinned

Review on this PR caught that #2034's own fix left one edge unasserted: `covers()`
already treats `valid_to_year` as *inclusive* (`year > a.ValidToYear`, not `>=`), but
nothing exercised year == the boundary itself. Only the lower bound
(`valid_from_year`, unbounded-low 2022 case) had that kind of edge coverage.

Added two more assertions to `TestAliasResolverRespectsRenameWindows`: 2022 (using the
2022 fixture rows that were previously created but never resolved against — dead
weight the review also flagged) and 2024 (the `valid_to_year` boundary itself, which
must still resolve).

```
$ go test ./sync/ -run TestAliasResolverRespectsRenameWindows -v      # > changed to >= (boundary now exclusive)
--- FAIL: TestAliasResolverRespectsRenameWindows
    lodging_alias_resolver_test.go:110: 2024 GT Doctor's House (inclusive upper boundary): {...}
    lodging_alias_resolver_test.go:114: 2024 HC Doctor's House (inclusive upper boundary): {...}
```
Reverted the mutation; `lodging_alias_resolver.go` is unchanged by this PR -- the fix
is test-only, pinning behavior `covers()` already had.


### #2015 — the household-grain OR replaced with last-wins
```
$ go test ./sync/... -run TestCollapseSiblingDisagreementSurvivesANoRequestsSibling -v
--- FAIL: TestCollapseSiblingDisagreementSurvivesANoRequestsSibling
    lodging_requests_test.go:109: WantsWith = false; a sibling's real request must survive
    another sibling's "No requests"
    lodging_requests_test.go:112: ShareEligibility = "declined", want "named" -- the real request
    must still resolve to a verdict
```

## Verification

- `go build ./...` — clean
- `gofmt -l .` — clean
- `go test ./... -count=1` (full `pocketbase` module) — all packages `ok`, including `lodging` (57s) and `sync` (181s)
- `golangci-lint run ./...` — 0 issues
- Full pre-push suite (ruff, go build, pb-js-lint, shellcheck, markdownlint, mypy, pytest 6007 passed, tsc) — all green

## Test plan

- [x] All four failing tests written and verified red before their fix
- [x] All four mutation checks performed (break the invariant, confirm red, restore) — transcripts above
- [x] Full `pocketbase` module test suite green
- [x] `golangci-lint run ./...` clean
- [x] Full pre-push hook suite green (ran as part of `git push`)

Closes #2030.
Closes #2033.
Closes #2034.
Closes #2015.

