### PR TITLE
test(frontend): name the assertion in the roll-forward preview-bypass mutation check

### DIFF
--- a/frontend/src/components/admin/lodging/SeasonRollForwardPanel.test.tsx
+++ b/frontend/src/components/admin/lodging/SeasonRollForwardPanel.test.tsx
@@ -138,7 +138,15 @@ describe('SeasonRollForwardPanel', () => {
         skipped_codes: ['test-unit-a'],
       },
     })
-    expect(await screen.findByRole('button', { name: /nothing to carry forward/i })).toBeDisabled()
+    // Found by "forward" -- the word every state of this button renders
+    // ("Carrying forward…", "Carry N forward", "Nothing to carry forward") --
+    // rather than by "nothing to carry forward" itself. That exact phrase is
+    // what `nothingToCarry` controls, so anchoring the query on it would make
+    // a broken condition disappear as "button not found" instead of naming
+    // the property the assertions below actually pin.
+    const applyButton = await screen.findByRole('button', { name: /forward/i })
+    expect(applyButton).toHaveTextContent(/nothing to carry forward/i)
+    expect(applyButton).toBeDisabled()
   })
 
   it('names the units it left alone', async () => {


### PR DESCRIPTION
## Summary

Closes #2036.

The "disables apply when there is nothing to create" test in `SeasonRollForwardPanel.test.tsx` located the apply button by the exact label `nothingToCarry` controls (`/nothing to carry forward/i`). A mutation that broke that condition made the button never render with that text, so `findByRole` crashed with an element-not-found error instead of failing a named assertion — the crash names no contract, leaving the next reader to reconstruct intent from the surrounding code.

## Fix

Find the button by `/forward/i` instead — a word present in every state it renders (`Carrying forward…` / `Carry N forward` / `Nothing to carry forward`) — then assert its text content and disabled state explicitly:

```tsx
const applyButton = await screen.findByRole('button', { name: /forward/i })
expect(applyButton).toHaveTextContent(/nothing to carry forward/i)
expect(applyButton).toBeDisabled()
```

**Why a regex matcher, not `data-testid`:** every other query in this test file locates elements by `role` + accessible-name regex (`findByRole('button', { name: /carry.*forward/i })`, `/details/i`, `/carrying forward/i`, etc.) — zero `data-testid` usage in this file. A broader regex that survives all three button states keeps the file's existing convention and needed no change to the component.

## Verification: crash before, named assertion after

Mutated `nothingToCarry` in `SeasonRollForwardPanel.tsx` (`!(preview !== undefined && toCreate === 0)`) to simulate a broken condition, ran the test against the **old** query, then against the **new** one, then reverted the mutation.

**Before (old query, mutated source) — crash:**
```
FAIL  src/components/admin/lodging/SeasonRollForwardPanel.test.tsx > SeasonRollForwardPanel > disables apply when there is nothing to create
TestingLibraryElementError: Unable to find role="button" and name `/nothing to carry forward/i`
 ❯ waitForWrapper node_modules/@testing-library/dom/dist/wait-for.js:163:27
 ❯ src/components/admin/lodging/SeasonRollForwardPanel.test.tsx:141:25
```

**After (new query, same mutated source) — named assertion:**
```
FAIL  src/components/admin/lodging/SeasonRollForwardPanel.test.tsx > SeasonRollForwardPanel > disables apply when there is nothing to create
Error: expect(element).toHaveTextContent()

Expected element to have text content:
  /nothing to carry forward/i
Received:
  Carry 0 forward
 ❯ src/components/admin/lodging/SeasonRollForwardPanel.test.tsx:148:25
```

Source mutation reverted before committing (`git diff` shows only the test file changed).

## Test plan

- [x] `npx vitest run src/components/admin/lodging/SeasonRollForwardPanel.test.tsx` — 11/11 pass
- [x] `npx vitest run` (full suite) — SeasonRollForwardPanel.test.tsx not among the failures (the 33 failures present are pre-existing timeouts from concurrent worktree test runs sharing CPU, unrelated to this change)
- [x] `npm run type-check` — clean
- [x] `./node_modules/.bin/eslint src/components/admin/lodging/SeasonRollForwardPanel.test.tsx src/components/admin/lodging/SeasonRollForwardPanel.tsx` — clean
- [x] Pre-push hooks (ruff, go build, shellcheck, pb-js-lint, markdownlint, mypy, tsc, full pytest — 6007 passed) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)