### PR TITLE
feat(frontend): a family card marks a household that wrote a request

### DIFF
--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -226,6 +226,33 @@ describe('FamilyCard — what it shows', () => {
     )
     expect(screen.getByText('Wants to share')).toBeInTheDocument()
   })
+
+  it('marks a household that wrote a request, without saying what it says', () => {
+    // The marker only — kindred#2016. The panel carries the words; the card
+    // carries the fact that words exist. `muted`, not `need`/`warn`: this is
+    // not a problem, so it must not read as one.
+    render(
+      <FamilyCard
+        party={party({
+          share: {
+            preference: 'yes_share',
+            proximity: [],
+            request_text: 'Some fictional household request text.',
+            needs_resolution: false,
+          },
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    const chip = screen.getByText('Wrote a request')
+    expect(chip).toBeInTheDocument()
+    expect(screen.queryByText(/fictional household request text/)).not.toBeInTheDocument()
+  })
+
+  it('stays silent when the household left no request', () => {
+    render(<FamilyCard party={party()} onOpen={vi.fn()} />)
+    expect(screen.queryByText('Wrote a request')).not.toBeInTheDocument()
+  })
 })
 
 describe('FamilyCard — spec §3.8, what must stay off it', () => {

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -23,9 +23,16 @@
  * `FamilyCard.test.tsx` pins all three as ABSENCES, because each is exactly
  * the kind of thing a later session adds back helpfully.
  *
+ * kindred#2016 adds one thing back, deliberately short of the words: a
+ * "Wrote a request" chip keyed on `request_text` being non-empty. It is a
+ * marker, not a preview — no clipped text, no character count — so it does
+ * not reopen the exposure the bullet above measured. The words themselves
+ * stay on `FamilyDetailsPanel`.
+ *
  * What IS here: the household name, the party size, the children with their
- * ages — ages are the entire point of a "similar ages" match — and the housing
- * chips the fit check actually judges.
+ * ages — ages are the entire point of a "similar ages" match — the housing
+ * chips the fit check actually judges, and the fact (not the content) that a
+ * request was written.
  */
 import { useDraggable } from '@dnd-kit/core'
 import { Repeat, Users } from 'lucide-react'
@@ -110,6 +117,11 @@ function FamilyCardBody({
   // view — a chip showing one *or* the other loses them.
   const wantsToShare = proximity.includes('with') || proximity.includes('similar_ages')
   const wantsNear = proximity.includes('near')
+  // The marker only (spec §3.8 keeps the words themselves off — see the file
+  // doc comment). `tone="muted"`, not `need`/`warn`: this says a household
+  // wrote something, not that anything is wrong or unresolved — that is
+  // `needs_resolution`'s own meaning, and it stays off the card too.
+  const hasRequestText = (party.share?.request_text ?? '').length > 0
 
   return (
     <>
@@ -173,6 +185,7 @@ function FamilyCardBody({
         {/* NEAR and WITH are different requests: NEAR is satisfied by map
             distance between units, WITH by putting both in one room. */}
         {wantsNear && <Chip label="Near another family" tone="muted" />}
+        {hasRequestText && <Chip label="Wrote a request" tone="muted" />}
 
         {party.is_returning === true && (
           <span className="text-forest-700 dark:text-forest-300 inline-flex items-center gap-0.5 text-xs font-semibold">


### PR DESCRIPTION
Closes #2016.

Today the only way to discover which families left a lodging request is to open every panel in turn — 62 of them. This adds one chip so that is answerable at a glance.

## Deliberately a marker, not a preview

The owner ruled against putting the request text on the card, tested against a mockup of four variants on real data. Recording the reasoning here because the obvious follow-up suggestion is "why not show a snippet":

- median 60 characters but **p90 228 and max 680**, so card height would vary about 5×;
- the field is joined from three sources and duplicates heavily — one real request is the same sentence four times;
- the median request is a **list of other families' names**, i.e. the `needs_resolution` case, so the card would show raw material rather than an answer;
- the long tail is health, sleep and mobility narrative, on a surface used on a shared screen.

Clipping to one line was the runner-up and was rejected because on semicolon-joined text the first fragment is not the important one.

So: the *fact* that a request exists, never the content. The words stay on `FamilyDetailsPanel`.

## Tone choice

`tone="muted"`, not `need` or `warn`.

`CHIP_TONE` reads backwards from intuition — `need` is amber and `warn` is red — and either would assert something this chip must not: that the request is unmet or that something is wrong. Being unresolved is `needs_resolution`'s own meaning, and that stays off the card too. `muted` says only "this household wrote something", which is exactly the claim.

## The regression guard still holds

`FamilyCard.test.tsx` carries an explicit guard that the card never prints the request text. The chip is additive and does not trip it — that guard is the reason this is a chip at all, so it passing is the load-bearing check, not an incidental one.

## Verification

- `npx vitest run src/components/weekend/FamilyCard.test.tsx` → **1 file / 30 tests passed, exit 0**, including the never-prints-the-text guard
- Full pre-push chain green on push

⚠️ Note for reviewers: several agent worktrees were running suites concurrently on this machine, so a local full-suite run may show unrelated timeout failures. They are load artefacts — affected specs pass in isolation, and a clean full run on an idle box is green (411 files / 5862 tests). CI's sharded runners are the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)