### PR TITLE
fix(frontend): the weekend Roster row opens FamilyDetailsPanel

### DIFF
--- a/frontend/src/components/weekend/HouseholdRosterRow.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterRow.tsx
@@ -33,6 +33,13 @@ export interface HouseholdRosterRowProps {
   showRequests: boolean
   /** The assigned cabin, when it resolves. Undefined for a merged slot. */
   unit?: LodgingUnitRow | undefined
+  /**
+   * Opens `FamilyDetailsPanel` for this row's party (kindred#1996). The row
+   * itself stays chips-only per kindred#1889 — this only routes to where the
+   * narrative and request text already live, the same way `FamilyCard`
+   * routes to the identical panel on Housing and Map.
+   */
+  onOpen: (party: RosterPartyRow) => void
 }
 
 /** An unanswered request, used when the payload omits the block entirely. */
@@ -79,7 +86,7 @@ function composition(party: RosterPartyRow): string {
   return parts.join(' · ')
 }
 
-export function HouseholdRosterRow({ party, showRequests, unit }: HouseholdRosterRowProps) {
+export function HouseholdRosterRow({ party, showRequests, unit, onOpen }: HouseholdRosterRowProps) {
   const isAssigned = (party.unit_name ?? '').length > 0
   const attention = partyAttention(party, unit)
   const adults = party.adults ?? []
@@ -87,7 +94,20 @@ export function HouseholdRosterRow({ party, showRequests, unit }: HouseholdRoste
   const showAdults = party.grain === 'household'
 
   return (
-    <tr className="border-border/40 hover:bg-muted/30 border-b align-top transition-colors">
+    <tr
+      role="button"
+      tabIndex={0}
+      onClick={() => {
+        onOpen(party)
+      }}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          onOpen(party)
+        }
+      }}
+      className="border-border/40 hover:bg-muted/30 focus-visible:ring-ring cursor-pointer border-b align-top transition-colors focus-visible:ring-2 focus-visible:outline-none"
+    >
       <td className={`border-l-[3px] py-3 pr-4 pl-3 ${RAIL[attention.level]}`}>
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
           <span className="text-foreground text-sm font-semibold">{party.display_name}</span>

--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -334,6 +334,25 @@ describe('HouseholdRosterTable — the row opens FamilyDetailsPanel (kindred#199
     expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
   })
 
+  it('opens the panel on Space, and stops the row from scrolling the page', () => {
+    // Space's native behavior is "scroll the page a viewport" — the same key
+    // that opens the panel. Without preventDefault(), a staff member tabbing
+    // onto a row on the 62-row roster and pressing Space gets the panel AND
+    // a full-viewport scroll.
+    render(<HouseholdRosterTable year={2026} parties={[party()]} />, { wrapper })
+    const row = screen.getByRole('button', { name: /The Johnson Family/ })
+    row.focus()
+
+    let keydownEvent: KeyboardEvent | undefined
+    row.addEventListener('keydown', (event) => {
+      keydownEvent = event
+    })
+    fireEvent.keyDown(row, { key: ' ' })
+
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+    expect(keydownEvent?.defaultPrevented).toBe(true)
+  })
+
   it('does not remount the panel when switching from one row to another', async () => {
     // Mirrors LodgingBoard's own guard (LodgingBoard.test.tsx): the panel is
     // unkeyed, so switching families updates it in place rather than sliding

--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -4,7 +4,8 @@
  * weekends, where individuals enrol directly).
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -69,7 +70,7 @@ function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
 describe('HouseholdRosterTable', () => {
   it('shows an empty state rather than an empty table', () => {
     // "Households" would be wrong for an adult weekend, which enrols people.
-    render(<HouseholdRosterTable parties={[]} />, { wrapper })
+    render(<HouseholdRosterTable year={2026} parties={[]} />, { wrapper })
     expect(screen.getByText('No one is enrolled for this weekend.')).toBeInTheDocument()
     expect(screen.getByText(/once registrations sync from CampMinder/)).toBeInTheDocument()
   })
@@ -77,6 +78,7 @@ describe('HouseholdRosterTable', () => {
   it('groups by attention, putting parties without a cabin above settled ones', () => {
     render(
       <HouseholdRosterTable
+        year={2026}
         parties={[
           party({ display_name: 'Settled Family', unit_name: 'Ridge A' }),
           party({ display_name: 'Waiting Family', unit_name: '', household_cm_id: 2000002 }),
@@ -96,6 +98,7 @@ describe('HouseholdRosterTable', () => {
     // repeats what the banner already said.
     render(
       <HouseholdRosterTable
+        year={2026}
         parties={[
           party({ display_name: 'One', unit_name: '' }),
           party({ display_name: 'Two', unit_name: '', household_cm_id: 2000002 }),
@@ -111,6 +114,7 @@ describe('HouseholdRosterTable', () => {
     // than no column.
     render(
       <HouseholdRosterTable
+        year={2026}
         parties={[
           party({
             grain: 'person',
@@ -134,6 +138,7 @@ describe('HouseholdRosterTable', () => {
   it('keeps the Requests column when any party answered', () => {
     render(
       <HouseholdRosterTable
+        year={2026}
         parties={[party({ share: { preference: 'yes_share', proximity: ['with'] } })]}
       />,
       { wrapper }
@@ -142,7 +147,7 @@ describe('HouseholdRosterTable', () => {
   })
 
   it('renders adults and children counts for a household party', () => {
-    render(<HouseholdRosterTable parties={[party()]} />, { wrapper })
+    render(<HouseholdRosterTable year={2026} parties={[party()]} />, { wrapper })
     expect(screen.getByText('The Johnson Family')).toBeInTheDocument()
     expect(screen.getByText('1 adult · 1 child')).toBeInTheDocument()
     expect(screen.getByText('Samuel Johnson')).toBeInTheDocument()
@@ -152,6 +157,7 @@ describe('HouseholdRosterTable', () => {
   it('pluralises adults and children correctly', () => {
     render(
       <HouseholdRosterTable
+        year={2026}
         parties={[
           party({
             adults: [
@@ -174,6 +180,7 @@ describe('HouseholdRosterTable', () => {
   it('renders a child of unknown age without a bare parenthesis', () => {
     render(
       <HouseholdRosterTable
+        year={2026}
         parties={[
           party({
             children: [
@@ -188,42 +195,52 @@ describe('HouseholdRosterTable', () => {
   })
 
   it('shows the assigned unit, or "Unassigned" when there is none', () => {
-    const { rerender } = render(<HouseholdRosterTable parties={[party()]} />, {
+    const { rerender } = render(<HouseholdRosterTable year={2026} parties={[party()]} />, {
       wrapper,
     })
     expect(screen.getByText('Unassigned')).toBeInTheDocument()
 
     rerender(
-      <HouseholdRosterTable parties={[party({ unit_code: 'ridge-a', unit_name: 'Ridge A' })]} />
+      <HouseholdRosterTable
+        year={2026}
+        parties={[party({ unit_code: 'ridge-a', unit_name: 'Ridge A' })]}
+      />
     )
     expect(screen.getByText('Ridge A')).toBeInTheDocument()
   })
 
   it('marks a merged slot so staff know two rooms were combined', () => {
     render(
-      <HouseholdRosterTable parties={[party({ unit_name: 'Wawona', is_merged_slot: true })]} />,
+      <HouseholdRosterTable
+        year={2026}
+        parties={[party({ unit_name: 'Wawona', is_merged_slot: true })]}
+      />,
       { wrapper }
     )
     expect(screen.getByText('Merged')).toBeInTheDocument()
   })
 
   it('flags a returning family', () => {
-    render(<HouseholdRosterTable parties={[party({ is_returning: true })]} />, {
+    render(<HouseholdRosterTable year={2026} parties={[party({ is_returning: true })]} />, {
       wrapper,
     })
     expect(screen.getByText('Returning')).toBeInTheDocument()
   })
 
   it('shows the arrival ETA when the family gave one', () => {
-    render(<HouseholdRosterTable parties={[party({ arrival_eta: 'Friday around 4pm' })]} />, {
-      wrapper,
-    })
+    render(
+      <HouseholdRosterTable year={2026} parties={[party({ arrival_eta: 'Friday around 4pm' })]} />,
+      {
+        wrapper,
+      }
+    )
     expect(screen.getByText('Friday around 4pm')).toBeInTheDocument()
   })
 
   it('renders a person-grain party for an adult weekend', () => {
     render(
       <HouseholdRosterTable
+        year={2026}
         parties={[
           party({
             grain: 'person',
@@ -248,6 +265,7 @@ describe('HouseholdRosterTable', () => {
     // request /households/0/medical, so the row says what it knows instead.
     render(
       <HouseholdRosterTable
+        year={2026}
         parties={[
           party({
             grain: 'person',
@@ -278,6 +296,7 @@ describe('HouseholdRosterTable', () => {
     // person cm_id. A key built from only one of them would collapse the rows.
     render(
       <HouseholdRosterTable
+        year={2026}
         parties={[
           party({ household_cm_id: 7, person_cm_id: 0, display_name: 'The Johnson Family' }),
           party({
@@ -293,5 +312,65 @@ describe('HouseholdRosterTable', () => {
     )
     expect(screen.getByText('The Johnson Family')).toBeInTheDocument()
     expect(screen.getByText('Olivia Chen')).toBeInTheDocument()
+  })
+})
+
+describe('HouseholdRosterTable — the row opens FamilyDetailsPanel (kindred#1996)', () => {
+  // kindred#1889 made the row chips-only and moved the medical narrative to
+  // FamilyDetailsPanel — but the row it did that to carried no way back to
+  // the panel at all. These pin the reachability fix, not the panel's own
+  // content, which FamilyDetailsPanel.test.tsx already covers.
+  it('opens the panel when a roster row is clicked', async () => {
+    render(<HouseholdRosterTable year={2026} parties={[party()]} />, { wrapper })
+    await userEvent.click(screen.getByRole('button', { name: /The Johnson Family/ }))
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+    expect(screen.getByTestId('family-panel-backdrop')).toBeInTheDocument()
+  })
+
+  it('opens the panel from the keyboard, not just a pointer click', async () => {
+    render(<HouseholdRosterTable year={2026} parties={[party()]} />, { wrapper })
+    screen.getByRole('button', { name: /The Johnson Family/ }).focus()
+    await userEvent.keyboard('{Enter}')
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+  })
+
+  it('does not remount the panel when switching from one row to another', async () => {
+    // Mirrors LodgingBoard's own guard (LodgingBoard.test.tsx): the panel is
+    // unkeyed, so switching families updates it in place rather than sliding
+    // it out and back in. This is also the row-specific trap the issue calls
+    // out — a naive `<tr>` click handler can read as dead space to
+    // `useDismissOnDeadSpace` and fight the reopen instead of switching.
+    render(
+      <HouseholdRosterTable
+        year={2026}
+        parties={[
+          party({ display_name: 'Johnson Family', household_cm_id: 2000001 }),
+          party({ display_name: 'Chen Family', household_cm_id: 2000002 }),
+        ]}
+      />,
+      { wrapper }
+    )
+    await userEvent.click(screen.getByRole('button', { name: /Johnson Family/ }))
+    const first = screen.getByTestId('family-details-panel')
+
+    await userEvent.click(screen.getByRole('button', { name: /Chen Family/ }))
+    const second = screen.getByTestId('family-details-panel')
+
+    expect(second).toBe(first)
+    expect(second).toHaveTextContent('Chen Family')
+    expect(second).toHaveClass('animate-slide-in-right')
+  })
+
+  it('closes the panel on a dead-space click once the dismissal listener attaches', async () => {
+    render(<HouseholdRosterTable year={2026} parties={[party()]} />, { wrapper })
+    await userEvent.click(screen.getByRole('button', { name: /The Johnson Family/ }))
+    expect(screen.getByTestId('family-details-panel')).toHaveClass('animate-slide-in-right')
+
+    // `useDismissOnDeadSpace` attaches its listener a macrotask after the
+    // panel opens (see its own docstring) — let it, or this would pass for
+    // the wrong reason: nothing listening yet, rather than the guard working.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    fireEvent.click(document.body)
+    expect(screen.getByTestId('family-details-panel')).toHaveClass('animate-slide-out-right')
   })
 })

--- a/frontend/src/components/weekend/HouseholdRosterTable.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.tsx
@@ -8,7 +8,11 @@
  *
  * Read-only in this slice.
  */
+import { useCallback, useState } from 'react'
+
+import { useDismissOnDeadSpace } from '../../hooks/useDismissOnDeadSpace'
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import { FamilyDetailsPanel } from './FamilyDetailsPanel'
 import { HouseholdRosterRow } from './HouseholdRosterRow'
 import { attentionSections, indexUnitsByCode } from './rosterAttention'
 
@@ -20,6 +24,8 @@ export interface HouseholdRosterTableProps {
    * reports as unverified, which is the honest answer.
    */
   units?: LodgingUnitRow[]
+  /** Threads through to `FamilyDetailsPanel`'s medical-narrative fetch (kindred#1996). */
+  year: number
 }
 
 const HEAD_CELL = 'text-muted-foreground pb-2 text-xs font-bold tracking-wider uppercase'
@@ -36,7 +42,29 @@ function hasAnyRequest(parties: RosterPartyRow[]): boolean {
   })
 }
 
-export function HouseholdRosterTable({ parties, units = [] }: HouseholdRosterTableProps) {
+export function HouseholdRosterTable({ parties, units = [], year }: HouseholdRosterTableProps) {
+  // A third `FamilyDetailsPanel` callsite (kindred#1996), wired exactly as
+  // `LodgingBoard` and `LodgingMap` wire the other two — same `selected` /
+  // `requestClose` pair, same `useDismissOnDeadSpace` hookup. The row itself
+  // stays chips-only per kindred#1889; this only gives it somewhere to send
+  // a click.
+  const [selected, setSelected] = useState<RosterPartyRow | null>(null)
+  const [requestClose, setRequestClose] = useState(false)
+
+  const openParty = useCallback((party: RosterPartyRow) => {
+    setRequestClose(false)
+    setSelected(party)
+  }, [])
+
+  const closePanel = useCallback(() => {
+    setSelected(null)
+    setRequestClose(false)
+  }, [])
+
+  useDismissOnDeadSpace(selected !== null, () => {
+    setRequestClose(true)
+  })
+
   if (parties.length === 0) {
     return (
       <div className="dark:bg-card rounded-xl border border-dashed border-stone-300 bg-white p-8 text-center dark:border-stone-600">
@@ -57,46 +85,59 @@ export function HouseholdRosterTable({ parties, units = [] }: HouseholdRosterTab
   const showRequests = hasAnyRequest(parties)
 
   return (
-    <div className="dark:bg-card overflow-x-auto rounded-xl border border-stone-200 bg-white shadow-sm dark:border-stone-700">
-      <table className="w-full min-w-3xl text-left">
-        <thead>
-          <tr className="border-border border-b">
-            <th className={`${HEAD_CELL} pt-4 pl-3`}>Party</th>
-            <th className={`${HEAD_CELL} pt-4`}>Cabin</th>
-            {showRequests && <th className={`${HEAD_CELL} pt-4`}>Requests</th>}
-            <th className={`${HEAD_CELL} pt-4 pr-3`}>Housing needs</th>
-          </tr>
-        </thead>
+    <>
+      <div className="dark:bg-card overflow-x-auto rounded-xl border border-stone-200 bg-white shadow-sm dark:border-stone-700">
+        <table className="w-full min-w-3xl text-left">
+          <thead>
+            <tr className="border-border border-b">
+              <th className={`${HEAD_CELL} pt-4 pl-3`}>Party</th>
+              <th className={`${HEAD_CELL} pt-4`}>Cabin</th>
+              {showRequests && <th className={`${HEAD_CELL} pt-4`}>Requests</th>}
+              <th className={`${HEAD_CELL} pt-4 pr-3`}>Housing needs</th>
+            </tr>
+          </thead>
 
-        {sections.map((section) => (
-          <tbody key={section.level}>
-            {showSectionHeads && (
-              <tr>
-                <th
-                  scope="colgroup"
-                  colSpan={showRequests ? 4 : 3}
-                  className="bg-forest-50/70 dark:bg-forest-900/40 text-forest-800 dark:text-forest-200 border-border/60 border-y px-3 py-2 text-left text-xs font-bold tracking-wider uppercase"
-                >
-                  {section.label}
-                  <span className="text-muted-foreground ml-2 font-semibold normal-case tabular-nums">
-                    {section.parties.length}
-                  </span>
-                </th>
-              </tr>
-            )}
-            {section.parties.map((party) => (
-              // Both grains number independently, so a household cm_id can
-              // equal a person cm_id — the key carries the grain and both ids.
-              <HouseholdRosterRow
-                key={`${party.grain}-${String(party.household_cm_id ?? 0)}-${String(party.person_cm_id ?? 0)}`}
-                party={party}
-                showRequests={showRequests}
-                unit={unitsByCode.get(party.unit_code ?? '')}
-              />
-            ))}
-          </tbody>
-        ))}
-      </table>
-    </div>
+          {sections.map((section) => (
+            <tbody key={section.level}>
+              {showSectionHeads && (
+                <tr>
+                  <th
+                    scope="colgroup"
+                    colSpan={showRequests ? 4 : 3}
+                    className="bg-forest-50/70 dark:bg-forest-900/40 text-forest-800 dark:text-forest-200 border-border/60 border-y px-3 py-2 text-left text-xs font-bold tracking-wider uppercase"
+                  >
+                    {section.label}
+                    <span className="text-muted-foreground ml-2 font-semibold normal-case tabular-nums">
+                      {section.parties.length}
+                    </span>
+                  </th>
+                </tr>
+              )}
+              {section.parties.map((party) => (
+                // Both grains number independently, so a household cm_id can
+                // equal a person cm_id — the key carries the grain and both ids.
+                <HouseholdRosterRow
+                  key={`${party.grain}-${String(party.household_cm_id ?? 0)}-${String(party.person_cm_id ?? 0)}`}
+                  party={party}
+                  showRequests={showRequests}
+                  unit={unitsByCode.get(party.unit_code ?? '')}
+                  onOpen={openParty}
+                />
+              ))}
+            </tbody>
+          ))}
+        </table>
+      </div>
+
+      {selected !== null && (
+        <FamilyDetailsPanel
+          party={selected}
+          unit={unitsByCode.get(selected.unit_code ?? '')}
+          year={year}
+          requestClose={requestClose}
+          onClose={closePanel}
+        />
+      )}
+    </>
   )
 }

--- a/frontend/src/pages/WeekendRosterPage.tsx
+++ b/frontend/src/pages/WeekendRosterPage.tsx
@@ -442,7 +442,7 @@ export default function WeekendRosterPage() {
                 {openedViews.has('roster') && (
                   <Activity mode={view === 'roster' ? 'visible' : 'hidden'}>
                     <ErrorBoundary>
-                      <HouseholdRosterTable parties={parties} units={units} />
+                      <HouseholdRosterTable parties={parties} units={units} year={currentYear} />
                     </ErrorBoundary>
                   </Activity>
                 )}


### PR DESCRIPTION
## What

Gives the weekend Roster tab a route to `FamilyDetailsPanel`. Closes #1996.

`HouseholdRosterRow` had no `onClick`, no `onOpen`, no `role="button"` — its only mentions of the panel were two comments explaining that the medical narrative moved there in #1889. A holder of `lodging.phi` working the Roster tab had no way to open a family's detail panel; they had to switch to Housing or Map and find the family again.

## How

A third `FamilyDetailsPanel` callsite, wired exactly as `LodgingBoard` and `LodgingMap` wire the other two:

- `HouseholdRosterTable` now owns `selected`/`requestClose` state, an `openParty`/`closePanel` pair, and `useDismissOnDeadSpace` — the same shape as the board and map.
- `HouseholdRosterRow`'s `<tr>` gets `role="button"`, `tabIndex={0}`, `onClick`, and `onKeyDown` (Enter/Space) that call the new required `onOpen` prop.
- `HouseholdRosterTable` gains a required `year` prop, threaded from `WeekendRosterPage`'s `currentYear`, since `FamilyDetailsPanel` needs it for the medical-narrative fetch.

**The #1889 ruling stands:** the row itself stays chips-only. Nothing here adds narrative or request text to the row — only a route to where that content already lives.

**Not in scope, and deliberately so:** hoisting the panel to the weekend tab container. Summer renders `CamperDetailsPanel` in five places, so weekend's three `FamilyDetailsPanel` callsites (this one included) are the conservative end of summer's own pattern, not a divergence from it.

## The click-outside trap

`clickoutsidePredicate.ts`'s `shouldKeepPanelsOpen` already names `family-details` and recognizes `role="button"` as an "interactive" exemption. Giving the `<tr>` `role="button"` means a click on the row — including a click on a *different* row while the panel is already open — is recognized the same way a `FamilyCard` click is, so it doesn't fight `useDismissOnDeadSpace` into a spurious close-then-reopen. A test pins this directly: clicking a second row while the panel is open switches the panel in place (same DOM node, no remount), mirroring the existing `LodgingBoard.test.tsx` guard for the same behavior.

## Known conflict

`frontend/src/components/weekend/HouseholdRosterTable.test.tsx` is also touched by PR #2052 (#1944, a `QueryClient`-per-test hygiene sweep). If #2052 merges first, this branch will need a trivial rebase on that file's `QueryClient` setup block.

## Test plan

- [x] New tests in `HouseholdRosterTable.test.tsx` written first and verified failing (row had no `role="button"` yet), then implementation made them pass.
- [x] `npx vitest run src/components/weekend` — 562/562 passing
- [x] `npx vitest run` (full suite) — 5866/5866 passing
- [x] `npm run type-check` — clean
- [x] `./node_modules/.bin/eslint` on changed files — clean
- [x] Pre-push hook (ruff, go build, pb-js-lint, shellcheck, markdownlint, api-types-freshness, mypy, tsc, pytest 6007 passed) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Roster rows can now be opened by clicking or using Enter or Space.
  * Added a family details panel displaying information for the selected household.
  * The details panel can be dismissed by clicking outside it or switching to another roster row.

* **Bug Fixes**
  * Prevented Space-bar activation from causing unintended page scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->