### PR TITLE
refactor(frontend): weekend tabs stay mounted across a switch, so the map keeps its viewport

### DIFF
--- a/frontend/src/pages/WeekendRosterPage.codeSplitting.test.tsx
+++ b/frontend/src/pages/WeekendRosterPage.codeSplitting.test.tsx
@@ -162,7 +162,23 @@ describe('code splitting (#1964)', () => {
     // a lazy one has only started the dynamic import and is still waiting
     // on its microtask to settle.
     expect(screen.queryByText('Ridge A')).not.toBeInTheDocument()
-    expect(screen.getByTestId('lodging-view-loading')).toBeInTheDocument()
+
+    // EXACTLY one fallback, not "at least one" (`getAllByTestId`, not
+    // `getByTestId` — #2059 review) — this is what pins #2059's `openedViews`
+    // gate on `Activity`. Map was never opened here, but `Activity`'s hidden
+    // mode still mounts hidden content — so an UNGATED `Activity` around all
+    // three panels would start Map's dynamic import on this SAME render too,
+    // and Map's chunk is just as fresh as the board's here, so it shows ITS
+    // OWN loading fallback rather than resolved content. A `map-canvas`-
+    // absence check alone can't tell that apart from the correctly-gated
+    // case (both are simply "not there yet"); the COUNT can, and it does so
+    // whether this test runs as part of the whole file or isolated via `-t`
+    // — either way this is Housing's (and, if ungated, Map's) first-ever
+    // render in this file.
+    expect(screen.getAllByTestId('lodging-view-loading')).toHaveLength(1)
+    // Map was never opened at all — kept alongside the count above as a
+    // second, independent signal for the same gate.
+    expect(screen.queryByTestId('map-canvas')).not.toBeInTheDocument()
 
     expect(await screen.findByText('Ridge A')).toBeInTheDocument()
   })

--- a/frontend/src/pages/WeekendRosterPage.test.tsx
+++ b/frontend/src/pages/WeekendRosterPage.test.tsx
@@ -730,16 +730,18 @@ describe('tab component state survives switching (#2004)', () => {
     expect(screen.getByText('1.4×')).toBeInTheDocument()
   })
 
-  it('never mounts a tab that has not been opened, so its chunk is never requested', () => {
-    // The trap #2004 calls out by name: `Activity` still commits HIDDEN
-    // content (that's what lets a return to it skip the Suspense fallback),
-    // so wrapping every panel in it unconditionally would fetch the Map AND
-    // Housing chunks on first paint no matter which tab is showing —
-    // silently undoing #2057's code-split. Landing on Housing (the
-    // default) must leave Map unmounted.
-    renderPage()
-    expect(screen.queryByTestId('map-canvas')).not.toBeInTheDocument()
-  })
+  // The chunk-eagerness guard used to live here as "never mounts a tab that
+  // has not been opened" — but with ~15 earlier tests in this file already
+  // warming `React.lazy`'s cache, a `map-canvas`-absence check on a WARM
+  // render can't distinguish "correctly gated" from "ungated but still
+  // mid-flight," and in an ISOLATED `-t` run (cold, but nothing to compare
+  // against) it can't either: `map-canvas` is absent either way before the
+  // dynamic import settles (kindred#2059 review). Moved to
+  // `WeekendRosterPage.codeSplitting.test.tsx`, which already exists to hold
+  // exactly this kind of first-ever-render assertion, and strengthened there
+  // to count Suspense fallbacks (1 gated, 2 ungated) rather than checking
+  // content presence — a count catches the mutant in a fresh render even
+  // when neither chunk has resolved yet.
 
   it('wires each tab to its own always-present tabpanel id, with no collisions', async () => {
     // All three panels exist simultaneously once all three have been
@@ -762,5 +764,20 @@ describe('tab component state survives switching (#2004)', () => {
       expect(panel).not.toBeNull()
       expect(panel).toHaveAttribute('role', 'tabpanel')
     }
+  })
+
+  it('exposes exactly one tabpanel to the accessibility tree, even once all three have been opened', async () => {
+    // `Activity` sets `display:none` on the panel's CHILDREN when hidden —
+    // not on the `role="tabpanel"` container itself, which stays mounted and
+    // visible the moment a tab has ever been opened. Without `hidden` on the
+    // container, a screen reader user would find all three panels (two of
+    // them empty) instead of the one actually showing, and `aria-controls`
+    // from an unselected tab would point at a live, exposed region.
+    renderPage()
+    await userEvent.click(screen.getByRole('tab', { name: /Roster/ }))
+    await userEvent.click(screen.getByRole('tab', { name: /Map/ }))
+    await screen.findByTestId('map-canvas')
+
+    expect(screen.getAllByRole('tabpanel')).toHaveLength(1)
   })
 })

--- a/frontend/src/pages/WeekendRosterPage.test.tsx
+++ b/frontend/src/pages/WeekendRosterPage.test.tsx
@@ -688,3 +688,79 @@ describe('recomputation', () => {
     expect(countMapUnitsSpy).toHaveBeenCalled()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Component state across a tab switch (#2004)
+// ---------------------------------------------------------------------------
+//
+// The three tabs used to render behind a bare `&&`, so switching away
+// UNMOUNTED whichever one you had just left — and with it, any state that
+// tab's own components held (the map's pan/zoom, the roster's scroll
+// position). `SessionView.tsx` solves the same problem with
+// `<Activity mode=…>`, which keeps a tab's subtree mounted — hidden, not
+// gone — once it has been opened.
+describe('tab component state survives switching (#2004)', () => {
+  it('keeps a tab mounted, not torn down, once it has been opened', async () => {
+    renderPage()
+    await userEvent.click(screen.getByRole('tab', { name: /Map/ }))
+    expect(await screen.findByTestId('map-canvas')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('tab', { name: /Roster/ }))
+    // A bare `&&` would have removed the map from the DOM here. Under
+    // `Activity` it stays — hidden, not gone.
+    expect(screen.getByTestId('map-canvas')).toBeInTheDocument()
+  })
+
+  it('survives a tab switch away and back with the map zoom intact', async () => {
+    renderPage()
+    await userEvent.click(screen.getByRole('tab', { name: /Map/ }))
+    await screen.findByTestId('map-canvas')
+    expect(screen.getByText('1.0×')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Zoom in' }))
+    expect(screen.getByText('1.4×')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('tab', { name: /Roster/ }))
+    await userEvent.click(screen.getByRole('tab', { name: /Map/ }))
+
+    // A remount would reset to the identity viewport (1.0×). Seeing 1.4×
+    // still on screen proves the SAME LodgingMap instance came back, not a
+    // fresh one — exactly the acceptance criterion #2004 states: "Map
+    // pan/zoom survives a tab switch away and back."
+    expect(screen.getByText('1.4×')).toBeInTheDocument()
+  })
+
+  it('never mounts a tab that has not been opened, so its chunk is never requested', () => {
+    // The trap #2004 calls out by name: `Activity` still commits HIDDEN
+    // content (that's what lets a return to it skip the Suspense fallback),
+    // so wrapping every panel in it unconditionally would fetch the Map AND
+    // Housing chunks on first paint no matter which tab is showing —
+    // silently undoing #2057's code-split. Landing on Housing (the
+    // default) must leave Map unmounted.
+    renderPage()
+    expect(screen.queryByTestId('map-canvas')).not.toBeInTheDocument()
+  })
+
+  it('wires each tab to its own always-present tabpanel id, with no collisions', async () => {
+    // All three panels exist simultaneously once all three have been
+    // opened — the exact shape `Activity` produces, and the one a single
+    // dynamic `weekend-panel-${view}` id could not have served without
+    // either three elements colliding on one id or two tabs'
+    // `aria-controls` dangling.
+    renderPage()
+    await userEvent.click(screen.getByRole('tab', { name: /Roster/ }))
+    await userEvent.click(screen.getByRole('tab', { name: /Map/ }))
+    await screen.findByTestId('map-canvas')
+
+    const tabs = screen.getAllByRole('tab')
+    const controlledIds = tabs.map((tab) => tab.getAttribute('aria-controls'))
+
+    expect(new Set(controlledIds).size).toBe(controlledIds.length)
+    for (const id of controlledIds) {
+      expect(id).toBeTruthy()
+      const panel = document.getElementById(id ?? '')
+      expect(panel).not.toBeNull()
+      expect(panel).toHaveAttribute('role', 'tabpanel')
+    }
+  })
+})

--- a/frontend/src/pages/WeekendRosterPage.tsx
+++ b/frontend/src/pages/WeekendRosterPage.tsx
@@ -25,7 +25,7 @@
  * the Go ingest so every surface sees the correction at once.
  */
 import { Home, Map as MapIcon, Users } from 'lucide-react'
-import { lazy, Suspense, useEffect, useMemo } from 'react'
+import { Activity, lazy, Suspense, useEffect, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
 
 import { ErrorBoundary } from '../components/ErrorBoundary'
@@ -189,6 +189,41 @@ export default function WeekendRosterPage() {
   )
   const spacesUnmeasured = useMemo(() => countUnmeasuredSpaces(units), [units])
 
+  /**
+   * A view is added the first time it becomes active and never removed —
+   * mirroring what `<Activity mode="hidden">` itself does below: once a tab
+   * has been opened, it stays mounted rather than being torn down and
+   * rebuilt on every switch away (#2004).
+   *
+   * Adjusted DURING render, not in a `useEffect` — the "storing information
+   * from previous renders" pattern the React docs give for exactly this
+   * shape (https://react.dev/reference/react/useState#storing-information-from-previous-renders):
+   * deriving state from a prop that just changed, without paying for an
+   * extra commit-then-effect-then-rerender round trip that would flash the
+   * newly-opened tab's panel empty for a frame first. `renderedView` is
+   * ONLY here to notice that `view` changed since the last render — it is
+   * not read anywhere else. A `useRef` mutated during render was the first
+   * draft; `react-hooks/refs` correctly flags reading a ref's value during
+   * render as unsafe, so this uses the state-based version of the same
+   * pattern instead.
+   *
+   * GATING ON THIS, rather than wrapping all three panels in `Activity`
+   * unconditionally, is what keeps a never-opened tab from paying for its
+   * lazy chunk: `Activity`'s hidden mode still mounts and commits hidden
+   * content (that is the point — it is what lets a return to it skip the
+   * fallback), so an ungated `Activity` around `LodgingBoard`/`LodgingMap`
+   * would fetch BOTH chunks on first paint no matter which tab is showing,
+   * silently undoing the code-split #2057 built.
+   */
+  const [openedViews, setOpenedViews] = useState<Set<View>>(() => new Set([view]))
+  const [renderedView, setRenderedView] = useState(view)
+  if (view !== renderedView) {
+    setRenderedView(view)
+    if (!openedViews.has(view)) {
+      setOpenedViews(new Set(openedViews).add(view))
+    }
+  }
+
   // Housing first, as summer leads with Bunks.
   const TABS: Array<{ id: View; label: string; icon: typeof Users; count: number }> = [
     // Counts the SLOT CARDS the board draws, not the raw unit count: a
@@ -334,55 +369,79 @@ export default function WeekendRosterPage() {
                 )}
             </div>
 
-            <div
-              className="pt-4"
-              role="tabpanel"
-              id={`weekend-panel-${view}`}
-              aria-labelledby={`weekend-tab-${view}`}
-            >
-              {/* `view` gates all three, so at most one is ever mounted —
-                  "loading the board must not hold up the map" describes a
-                  race that cannot happen here. What each boundary IS for:
-                  scoping a crash to its own tab. A 404'd chunk (stale
-                  deployment) throws inside its Suspense, and without an
-                  ErrorBoundary here it keeps going past this whole panel to
-                  the route-level one in App.tsx, blanking the header,
-                  scenario picker and tab strip along with it — taking the
-                  OTHER two tabs down with the one that broke. Wrapping each
-                  view keeps the other two switchable, `ErrorBoundary`'s
-                  default fallback supplies the retry, and it doubles as the
-                  chunk-load-error / stale-deployment handling every other
-                  lazy boundary in this app gets (`ErrorBoundary.tsx`). */}
-              {view === 'roster' && (
-                <ErrorBoundary>
-                  <HouseholdRosterTable parties={parties} units={units} />
-                </ErrorBoundary>
-              )}
-              {/* The board takes the scenario, the weekend and the manage
-                  permission because it WRITES now (#1989) — main's note that
-                  drag placement "is what earns plumbing it back down" is
-                  this. The map still takes only what it renders. */}
-              {view === 'housing' && (
-                <ErrorBoundary>
-                  <Suspense fallback={<TabLoadingFallback />}>
-                    <LodgingBoard
-                      parties={parties}
-                      units={units}
-                      year={currentYear}
-                      scenario={scenario}
-                      sessionCmId={selectedCmId ?? 0}
-                      canManage={canManageLodging}
-                    />
-                  </Suspense>
-                </ErrorBoundary>
-              )}
-              {view === 'map' && (
-                <ErrorBoundary>
-                  <Suspense fallback={<TabLoadingFallback />}>
-                    <LodgingMap parties={parties} units={units} year={currentYear} />
-                  </Suspense>
-                </ErrorBoundary>
-              )}
+            {/* THREE STATIC PANELS, not one panel whose id follows `view`.
+                Under `Activity` all three subtrees stay mounted at once, so a
+                single dynamic id would either collide across the three (all
+                three claiming `weekend-panel-${view}` — impossible, there is
+                only one `view`) or leave two tabs' `aria-controls` pointing at
+                an id that only the third panel currently wears. Each tab's
+                `aria-controls` (above) targets one of these three fixed ids,
+                which exist for the lifetime of the page.
+
+                Each panel ALSO gets its own `ErrorBoundary`, inside the
+                `Activity` so it guards the panel's actual content rather than
+                the visibility mechanism around it. Reason it has to be
+                per-panel rather than one shared boundary: once a tab has been
+                opened, `Activity` keeps it mounted — hidden, not torn down —
+                so a crash in a BACKGROUND tab (its chunk still loading while
+                the user has already switched away) would otherwise climb to
+                the route-level boundary in App.tsx and blank the header,
+                scenario picker and tab strip along with the two tabs that
+                never broke. `ErrorBoundary`'s default fallback supplies the
+                retry — the ONLY way back for a panel that already crashed,
+                since `Activity` no longer remounts it on a tab switch. */}
+            <div className="pt-4">
+              <div role="tabpanel" id="weekend-panel-housing" aria-labelledby="weekend-tab-housing">
+                {/* The board takes the scenario, the weekend and the manage
+                    permission because it WRITES now (#1989) — main's note that
+                    drag placement "is what earns plumbing it back down" is
+                    this. The map still takes only what it renders.
+
+                    Each is its own Suspense boundary, not one wrapping the
+                    whole panel: `Activity` keeps a previously-opened tab
+                    mounted (just hidden) rather than unmounting it on switch,
+                    so the board's chunk can genuinely still be loading in the
+                    background at the same moment the map's Suspense starts —
+                    one loading must not hold up the other. */}
+                {openedViews.has('housing') && (
+                  <Activity mode={view === 'housing' ? 'visible' : 'hidden'}>
+                    <ErrorBoundary>
+                      <Suspense fallback={<TabLoadingFallback />}>
+                        <LodgingBoard
+                          parties={parties}
+                          units={units}
+                          year={currentYear}
+                          scenario={scenario}
+                          sessionCmId={selectedCmId ?? 0}
+                          canManage={canManageLodging}
+                        />
+                      </Suspense>
+                    </ErrorBoundary>
+                  </Activity>
+                )}
+              </div>
+
+              <div role="tabpanel" id="weekend-panel-roster" aria-labelledby="weekend-tab-roster">
+                {openedViews.has('roster') && (
+                  <Activity mode={view === 'roster' ? 'visible' : 'hidden'}>
+                    <ErrorBoundary>
+                      <HouseholdRosterTable parties={parties} units={units} />
+                    </ErrorBoundary>
+                  </Activity>
+                )}
+              </div>
+
+              <div role="tabpanel" id="weekend-panel-map" aria-labelledby="weekend-tab-map">
+                {openedViews.has('map') && (
+                  <Activity mode={view === 'map' ? 'visible' : 'hidden'}>
+                    <ErrorBoundary>
+                      <Suspense fallback={<TabLoadingFallback />}>
+                        <LodgingMap parties={parties} units={units} year={currentYear} />
+                      </Suspense>
+                    </ErrorBoundary>
+                  </Activity>
+                )}
+              </div>
             </div>
           </>
         )}

--- a/frontend/src/pages/WeekendRosterPage.tsx
+++ b/frontend/src/pages/WeekendRosterPage.tsx
@@ -200,12 +200,13 @@ export default function WeekendRosterPage() {
    * shape (https://react.dev/reference/react/useState#storing-information-from-previous-renders):
    * deriving state from a prop that just changed, without paying for an
    * extra commit-then-effect-then-rerender round trip that would flash the
-   * newly-opened tab's panel empty for a frame first. `renderedView` is
-   * ONLY here to notice that `view` changed since the last render — it is
-   * not read anywhere else. A `useRef` mutated during render was the first
-   * draft; `react-hooks/refs` correctly flags reading a ref's value during
-   * render as unsafe, so this uses the state-based version of the same
-   * pattern instead.
+   * newly-opened tab's panel empty for a frame first. `openedViews.has(view)`
+   * is already self-terminating — once `view` has been added, the condition
+   * is false on the very next render, so it doubles as its own "did this
+   * change since last render" check with nothing extra to track. (An earlier
+   * draft kept a separate `renderedView` state purely to notice the change;
+   * that state read nothing else and existed only to gate a call that already
+   * gates itself, so it's gone.)
    *
    * GATING ON THIS, rather than wrapping all three panels in `Activity`
    * unconditionally, is what keeps a never-opened tab from paying for its
@@ -216,12 +217,8 @@ export default function WeekendRosterPage() {
    * silently undoing the code-split #2057 built.
    */
   const [openedViews, setOpenedViews] = useState<Set<View>>(() => new Set([view]))
-  const [renderedView, setRenderedView] = useState(view)
-  if (view !== renderedView) {
-    setRenderedView(view)
-    if (!openedViews.has(view)) {
-      setOpenedViews(new Set(openedViews).add(view))
-    }
+  if (!openedViews.has(view)) {
+    setOpenedViews(new Set(openedViews).add(view))
   }
 
   // Housing first, as summer leads with Bunks.
@@ -378,6 +375,16 @@ export default function WeekendRosterPage() {
                 `aria-controls` (above) targets one of these three fixed ids,
                 which exist for the lifetime of the page.
 
+                Each container also carries `hidden={view !== id}`. `Activity`
+                sets `display:none` on the panel's CHILDREN when hidden, not
+                on this container — so without it, every panel that has ever
+                been opened stays exposed to the accessibility tree at once
+                (a screen reader would land in an empty region for a tab that
+                isn't selected). The native `hidden` attribute nests OVER
+                `Activity`'s own display toggle rather than replacing it, so
+                state preservation is untouched; it only controls what's
+                exposed, not what's mounted.
+
                 Each panel ALSO gets its own `ErrorBoundary`, inside the
                 `Activity` so it guards the panel's actual content rather than
                 the visibility mechanism around it. Reason it has to be
@@ -391,7 +398,12 @@ export default function WeekendRosterPage() {
                 retry — the ONLY way back for a panel that already crashed,
                 since `Activity` no longer remounts it on a tab switch. */}
             <div className="pt-4">
-              <div role="tabpanel" id="weekend-panel-housing" aria-labelledby="weekend-tab-housing">
+              <div
+                role="tabpanel"
+                id="weekend-panel-housing"
+                aria-labelledby="weekend-tab-housing"
+                hidden={view !== 'housing'}
+              >
                 {/* The board takes the scenario, the weekend and the manage
                     permission because it WRITES now (#1989) — main's note that
                     drag placement "is what earns plumbing it back down" is
@@ -421,7 +433,12 @@ export default function WeekendRosterPage() {
                 )}
               </div>
 
-              <div role="tabpanel" id="weekend-panel-roster" aria-labelledby="weekend-tab-roster">
+              <div
+                role="tabpanel"
+                id="weekend-panel-roster"
+                aria-labelledby="weekend-tab-roster"
+                hidden={view !== 'roster'}
+              >
                 {openedViews.has('roster') && (
                   <Activity mode={view === 'roster' ? 'visible' : 'hidden'}>
                     <ErrorBoundary>
@@ -431,7 +448,12 @@ export default function WeekendRosterPage() {
                 )}
               </div>
 
-              <div role="tabpanel" id="weekend-panel-map" aria-labelledby="weekend-tab-map">
+              <div
+                role="tabpanel"
+                id="weekend-panel-map"
+                aria-labelledby="weekend-tab-map"
+                hidden={view !== 'map'}
+              >
                 {openedViews.has('map') && (
                   <Activity mode={view === 'map' ? 'visible' : 'hidden'}>
                     <ErrorBoundary>


### PR DESCRIPTION
## Summary

The three weekend tabs (Housing, Roster, Map) rendered behind a bare `&&`, so switching away **unmounted** whichever tab you had just left — and with it, any component state that tab held. The lodging map's pan/zoom was the sharpest case: a staff member who had zoomed in to place a family lost that position on every glance at another tab. Summer's `SessionView.tsx` solves the same problem with `<Activity mode=…>`; weekend never followed, which is a CLAUDE.md §4 "Family Camp Models Summer" gap.

- Split the single `role="tabpanel"` div (whose `id` followed `view`) into **three static panels with fixed, distinct ids** — each wired to its own tab's `aria-controls`. Under `Activity`, all three subtrees can be mounted simultaneously, so the old single-dynamic-id shape would either collide across the three panels or leave two tabs' `aria-controls` pointing at nothing.
- Wrapped each panel's content in `<Activity mode={view === id ? 'visible' : 'hidden'}>`, gated on whether that tab has **ever been opened**, tracked in `openedViews` and adjusted during render (React's "storing information from previous renders" pattern — no `useEffect`, no extra flash). `Activity`'s hidden mode still mounts and commits hidden content (that's what lets a return to a tab skip the Suspense fallback), so an *ungated* `Activity` around the lazily-loaded `LodgingBoard`/`LodgingMap` would fetch both chunks on first paint regardless of which tab is active — silently undoing #2057's code-split. Gating on "opened at least once" keeps a never-visited tab's chunk unrequested while letting a visited one stay mounted and stateful.

Stacked on #2057 (`feature/weekend-lazy-routes`), **rebased onto that PR's own review-fix commit** (barrel re-exports removed, `mapModel.ts` pinned to its own chunk, per-tabpanel `ErrorBoundary` added). GitHub will retarget this PR to `main` automatically once #2057 merges.

Closes #2004.

## Review round 2

Independent review found three issues once `Activity` was actually exercised:

- **Minor 1 — all three tabpanel containers stayed in the accessibility tree.** `Activity` sets `display:none` on the panel's *children* when hidden, not on the `role="tabpanel"` container that wraps it — so once all three tabs had ever been opened, `queryAllByRole('tabpanel')` returned **3**, not 1, and a screen-reader user landed in two empty regions along with the one actually showing. CodeRabbit flagged this independently too. Fixed with `hidden={view !== id}` directly on each container — it nests OVER `Activity`'s own display toggle (state preservation untouched) and only controls what's *exposed*. New regression test: `exposes exactly one tabpanel to the accessibility tree, even once all three have been opened` — asserts `getAllByRole('tabpanel')` has length 1 after opening all three tabs. Verified red (3, not 1) against the pre-fix tree, green after.
- **Minor 2 — the chunk-eagerness guard was vacuous outside a whole-file run.** The original `never mounts a tab that has not been opened` test passed against an **ungated** `Activity` mutant when run alone (`-t "never mounts"`): cold, `map-canvas` is absent whether or not the panel actually mounted — a content-presence check can't distinguish "correctly gated" from "still loading" on a first-ever render. It only reded in the whole-file run because ~15 earlier tests had already warmed `React.lazy`'s cache. Fixed by moving the assertion into `WeekendRosterPage.codeSplitting.test.tsx` (which already exists and documents this exact cold-render trap) and rewriting it to **count Suspense fallbacks**: the correctly-gated implementation shows exactly one (`lodging-view-loading`, Housing's) on Housing's default render; an ungated mutant shows two, because Map's `Activity` starts its own dynamic import on the same render and is just as fresh. `getAllByTestId(...).toHaveLength(1)`, not `getByTestId`, so it fails cleanly instead of throwing an unrelated "multiple elements" error. Verified against the same ungated mutant (all three `openedViews.has(id) &&` gates replaced with `true &&`) in **both** invocation modes — whole-file and isolated `-t` — both now fail with `expected length 1 but got 2`; reverted, both green.
- **Minor 3 — the PR body's RED claim was false.** It said "all four new tests fail against the pre-fix code." Re-verified against the actual pre-#2059 implementation (checked out `75fdbc94` + the original test file from `a771fb6a`): **3 failed, 1 passed** — and the one that passed was `never mounts a tab that has not been opened`, the only test covering this PR's headline risk (that's Minor 2, above). Corrected here rather than restated as fixed, since the fourth test no longer exists in its original form — it's now the fallback-count assertion in `codeSplitting.test.tsx`, verified against the ungated mutant instead of the pre-#2059 baseline.
- **Nit — `renderedView` was redundant.** `openedViews.has(view)` is already self-terminating (false again the render after `view` is added), so the separate `renderedView` state that existed purely to notice `view` had changed was gating a call that already gates itself. Removed; the suite stayed green and it saves one render-phase re-invocation per tab switch. Its doc comment (which described a role it no longer had) is corrected to explain the simplified pattern instead.

## Test plan

- [x] `exposes exactly one tabpanel to the accessibility tree, even once all three have been opened` (new, moved fix): red (3 panels exposed) against pre-fix tree, green after `hidden={view !== id}`.
- [x] `paints a fallback for the housing board first…` (`codeSplitting.test.tsx`, strengthened): asserts `getAllByTestId('lodging-view-loading')` has length 1. Verified against an ungated `openedViews.has(id) && → true &&` mutant — fails with `expected length 1 but got 2` in **both** a whole-file run and isolated `-t "paints a fallback for the housing board"`; reverted, green.
- [x] `keeps a tab mounted, not torn down, once it has been opened` — unchanged, still passes.
- [x] `survives a tab switch away and back with the map zoom intact` — unchanged, still passes.
- [x] `wires each tab to its own always-present tabpanel id, with no collisions` — unchanged, still passes (queries by id, not by role, so unaffected by the new `hidden` attribute).
- [x] Rebased cleanly onto #2057's review-fix commit; one real conflict (the tabpanel JSX block), resolved by hand to combine #2057's `ErrorBoundary`-per-panel with #2059's three-static-panel `Activity` structure — the "loading the board must not hold up the map" Suspense-independence comment, which #2057's OWN review called impossible under bare `&&`, is genuinely true again here: `Activity` keeps a previously-opened tab's Suspense running in the background while another tab's Suspense starts fresh.
- [x] `cd frontend && npx vitest run` — 413 files, 5873 tests, exit 0.
- [x] `cd frontend && npm run type-check` — exit 0.
- [x] `cd frontend && npm run build` — exit 0; `LodgingBoard-*.js`/`LodgingMap-*.js` remain their own chunks.
- [x] `./node_modules/.bin/eslint <changed files>` — 0 errors (pre-existing `import()`-type-annotation warnings only, same pattern already in the files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #2004.

