### PR TITLE
chore(config): CodeRabbit reviews become opt-in, and a wrong issue body gets fixed

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -31,10 +31,28 @@ reviews:
     issue_assessment:
       mode: "off"
 
-  # We don't open drafts (see CLAUDE.md global-preferences). No need to auto-review them.
-  # Default behavior is to only auto-review PRs targeting the default branch — opt in to
-  # all base branches so stacked PRs (e.g. `feature/foo` → `feature/foo-parent`) get reviews.
+  # AUTO-REVIEW IS OFF, DELIBERATELY. Reviews are opt-in per PR via an
+  # `@coderabbitai review` comment.
+  #
+  # Why: the plan enforces a ROLLING volume limit, not a per-window quota that
+  # resets on a clock. On 2026-08-06 a batch of twelve PRs went up inside an
+  # hour and ten of them came back with a rate-limit notice instead of a review
+  # — and a rate-limit notice is indistinguishable from "this PR is clean"
+  # unless you read the comment body. Six hours later the limit had only
+  # partially recovered. So auto-review does not spend the quota evenly, it
+  # spends it on whichever PRs happen to be first, which is uncorrelated with
+  # which PRs are worth reviewing.
+  #
+  # Opting in puts the quota where it is pointed. `scripts/../.claude/skills/scan-it`
+  # asks per PR whether to use CodeRabbit and posts the comment when the answer
+  # is yes.
+  #
+  # `base_branches: [".*"]` is retained BECAUSE it is still load-bearing for
+  # stacked PRs: a manually-triggered review on a PR targeting another feature
+  # branch would otherwise be declined. drafts stays false — we don't open
+  # drafts (see CLAUDE.md global-preferences).
   auto_review:
+    enabled: false
     drafts: false
     base_branches:
       - ".*"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,23 @@ Be careful with the comparison, because summer is not uniform: the bunking board
 
 When weekend genuinely must differ, say why at the divergence. `useHouseholdMedical`'s `staleTime: 0, gcTime: 0` is the model: PHI must not sit in the cache after the panel closes, and the comment says so.
 
+### A Wrong Issue Body Gets Fixed, Not Worked Around
+
+**When you find an issue body that is wrong — a renamed symbol, a moved line number, a stale count, a proposed fix that would not compile or would cause harm — edit the issue body. Do not merely note it in a PR, a comment, or a triage doc.**
+
+The body is what the next reader implements from. A correction that lives anywhere else does not travel: the next agent opens the issue, follows it, and reproduces the mistake. Two concrete cases from this repo: a proposed fix on #1889 would have re-introduced the class #1875 had just fixed, and a #1925-derived "delete blank rows" would have erased 136 real adults.
+
+The failure mode is systemic, not occasional. A 2026-08-06 sweep of all 70 open issues found **40 of 69 bodies stale** — overwhelmingly not wrong *premises* but wrong *identifiers*, because issues filed from inside a PR are written against a tree a sibling PR has already moved.
+
+**What to do:**
+
+- Fix the body in place with `gh issue edit <N> --body-file …`, and say what changed and why in a comment so the edit is auditable.
+- Keep the original reasoning when it is still sound — correct the identifiers, do not rewrite the argument.
+- If the *approach* is obsolete rather than the details, say so at the top of the body rather than silently leaving a plan nobody should follow (`#1218`'s one-shot re-inventory, `#1766`'s routing, `#1484`'s non-compiling hook signatures).
+- If an issue turns out to be already shipped, close it with the commit as evidence — `#2007` sat open through two triage passes after shipping in #2040, and was recommended as the *next thing to build*.
+
+**Never implement a Group 84 / lodging issue from its body alone.** Verify against the tree and the data first.
+
 ### Test-Driven Development
 
 Write failing tests first, verify they fail, then implement. **Tests are the specification — never edit a test to match what the implementation happens to do.** Tests and implementation may land in the same commit (PRs are squash-merged); what matters is the order you write them in. Marker semantics and which tests are skipped in CI: `tests/CLAUDE.md`.


### PR DESCRIPTION
Two independent changes, both learned from the 2026-08-06 twelve-PR batch.

## 1. CodeRabbit auto-review off

`auto_review.enabled: false`. Reviews are now opt-in per PR via an `@coderabbitai review` comment.

**Why.** The plan enforces a **rolling volume limit**, not a per-window quota that resets on a clock. Twelve PRs went up inside an hour; **ten came back with a rate-limit notice instead of a review**, two got reviewed. Six hours later the limit had only partially recovered — one of three manually-triggered reviews was still declined.

The failure is silent, which is the real problem: a rate-limit notice is indistinguishable from *"this PR is clean"* unless you parse the comment body. And auto-review spends the quota on whichever PR happened to be opened first, which is uncorrelated with which PR is worth reviewing. Of the two that did get through, one found a real Major a11y bug.

**`base_branches: [".*"]` is retained deliberately** — it is still load-bearing for stacked PRs, where a manually-triggered review on a PR targeting another feature branch would otherwise be declined.

The `scan-it` skill now asks per PR whether to spend CodeRabbit on it and posts the trigger when the answer is yes. Its installed-or-not probe is unchanged, since some repos have no CodeRabbit at all and there the question is moot.

## 2. A wrong issue body gets fixed, not worked around

New `CLAUDE.md` §4 rule.

A sweep of all 70 open issues found **40 of 69 bodies stale** — overwhelmingly wrong *identifiers* (renamed symbols, moved line numbers, drifted counts) rather than wrong premises, because issues filed from inside a PR are written against a tree a sibling PR has already moved.

The body is what the next reader implements from, so a correction recorded only in a PR comment or a gitignored triage doc **does not travel** — the next agent opens the issue, follows it, and reproduces the mistake. Two concrete near-misses in this repo: a proposed fix on #1889 would have re-introduced the class #1875 had just fixed, and a #1925-derived "delete blank rows" would have erased 136 real adults.

Five bodies found actively misleading in this sweep are being corrected in place separately.

## Verification

Config and docs only — no code paths touched. `commitlint` and the pre-commit hooks pass; nothing else applies.