### PR TITLE
fix(deps): pin js-yaml past CVE-2026-59870 without a major bump

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5067,9 +5067,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -72,7 +72,7 @@
     },
     "brace-expansion": ">=5.0.9",
     "flatted": ">=3.4.4",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "postcss": ">=8.5.25",
     "undici": ">=7.29.0"
   },


### PR DESCRIPTION
**Unblocks #2052, #2057, #2058 and #2060**, none of which touch dependencies.

## What broke

`npm audit --audit-level=high` went red repo-wide on four high-severity advisories. All four are one root cause:

```
@hey-api/openapi-ts@0.99.0
└─┬ @hey-api/json-schema-ref-parser@1.4.4
  └── js-yaml@4.3.0        ← CVE-2026-59870
```

CVE-2026-59870 is quadratic CPU consumption in `!!omap` resolution. The other three advisories (`@hey-api/openapi-ts`, `@hey-api/json-schema-ref-parser`, `@hey-api/shared`) are just the chain reporting the same thing.

**Frontend Lint fails on the audit step, not on eslint.** ESLint reports **0 errors** and 371 pre-existing warnings, which do not fail the job. Worth stating because the check name points the wrong way.

## Why not npm's suggested fix

`npm audit` proposes `@hey-api/openapi-ts@0.97.0` and flags it `isSemVerMajor`. It isn't needed.

The advisory range is `>=4.0.0 <4.3.1`, and **4.3.1 exists** — so the fix *was* backported to the 4.x line, despite the advisory title reading "fix not backported". The override already said `^4.3.0`, which permits 4.3.1; only the lockfile was holding it at 4.3.0.

## Why `^4.3.1` and not `>=4.3.1`

I tried `>=4.3.1` first. It resolves to **js-yaml 5.2.3** — a major bump sitting inside the api-types generation toolchain, for zero additional security benefit. Pinned to the 4.x line instead, matching the `flatted` / `postcss` / `undici` entries already in this `overrides` block.

## Verification

| Check | Result |
|---|---|
| `npm audit --audit-level=high` | **0 vulnerabilities** |
| resolved version | `js-yaml@4.3.1` |
| `npm ci` | ok |
| `npm run generate:api-types` | ok, **no drift** in `src/types/` — the generator that consumes js-yaml is healthy |
| pre-push chain | mypy, type-check, pytest all green |

Four lines across two files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the YAML parsing dependency to a newer compatible version.
  * Improves reliability and incorporates the latest available fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->