### PR TITLE
fix(frontend): a clickable row keeps native row semantics, moving the click into a real button

### DIFF
--- a/frontend/src/components/metrics/geo/GeoDetailList.test.tsx
+++ b/frontend/src/components/metrics/geo/GeoDetailList.test.tsx
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { GeoDetailList } from './GeoDetailList'
 import type { GeoDataItem } from './GeoMap'
 
@@ -111,12 +112,17 @@ describe('GeoDetailList', () => {
     })
   })
 
-  it('triggers drilldown on Enter key press', () => {
+  it('triggers drilldown on Enter key press', async () => {
+    // The affordance is a real `<button>` (kindred#2063), so keyboard
+    // activation is native — a raw `fireEvent.keyDown` no longer does
+    // anything; `userEvent` is what actually simulates a browser's default
+    // key handling for a focused button.
     const onDrilldown = vi.fn()
     render(<GeoDetailList data={cityItems} category="city" onDrilldown={onDrilldown} />)
 
     fireEvent.click(screen.getByText('Cities'))
-    fireEvent.keyDown(screen.getByText(/San Francisco/).closest('tr')!, { key: 'Enter' })
+    screen.getByRole('button', { name: /San Francisco/ }).focus()
+    await userEvent.keyboard('{Enter}')
 
     expect(onDrilldown).toHaveBeenCalledWith({
       type: 'city',
@@ -125,12 +131,13 @@ describe('GeoDetailList', () => {
     })
   })
 
-  it('triggers drilldown on Space key press', () => {
+  it('triggers drilldown on Space key press', async () => {
     const onDrilldown = vi.fn()
     render(<GeoDetailList data={cityItems} category="city" onDrilldown={onDrilldown} />)
 
     fireEvent.click(screen.getByText('Cities'))
-    fireEvent.keyDown(screen.getByText(/San Francisco/).closest('tr')!, { key: ' ' })
+    screen.getByRole('button', { name: /San Francisco/ }).focus()
+    await userEvent.keyboard('[Space]')
 
     expect(onDrilldown).toHaveBeenCalledWith({
       type: 'city',
@@ -147,5 +154,17 @@ describe('GeoDetailList', () => {
     const row = screen.getByText('West').closest('tr')!
     expect(row).not.toHaveAttribute('tabindex')
     expect(row).not.toHaveAttribute('role')
+    // Non-clickable rows (region) get no button at all, not just an inert row.
+    expect(screen.queryByRole('button', { name: 'West' })).not.toBeInTheDocument()
+  })
+
+  it('keeps native row semantics — the table is not collapsed to one row (kindred#2063)', () => {
+    // `role="button"` on the `<tr>` used to override the native `row` role,
+    // so `queryAllByRole('row')` collapsed to 1 (the header alone) and the
+    // cells lost their owning row.
+    render(<GeoDetailList data={cityItems} category="city" />)
+    fireEvent.click(screen.getByText('Cities'))
+
+    expect(screen.getAllByRole('row')).toHaveLength(cityItems.length + 1)
   })
 })

--- a/frontend/src/components/metrics/geo/GeoDetailList.tsx
+++ b/frontend/src/components/metrics/geo/GeoDetailList.tsx
@@ -111,33 +111,35 @@ export function GeoDetailList({
                   if (isSelected) highlightClass = 'bg-primary/10'
                   else if (isClickable) highlightClass = 'hover:bg-muted/30'
 
-                  const rowClass = [
-                    'border-border border-t transition-colors',
-                    isClickable && 'cursor-pointer',
-                    highlightClass,
-                  ]
+                  const rowClass = ['border-border border-t transition-colors', highlightClass]
                     .filter(Boolean)
                     .join(' ')
 
+                  // `role="button"` used to live on the `<tr>` itself,
+                  // overriding the native `row` role — `queryAllByRole('row')`
+                  // collapsed to 1 (the header alone). The affordance is now a
+                  // real `<button>` confined to the name cell instead, which
+                  // keeps row/cell semantics intact and satisfies
+                  // `clickoutsidePredicate`'s `isInteractive` check the same
+                  // way any other `button` does (kindred#2063). A real button
+                  // also gets Enter/Space activation for free — no manual
+                  // `onKeyDown` needed, matching this file's own header
+                  // button just above.
                   return (
-                    <tr
-                      key={item.name}
-                      onClick={handleActivate}
-                      onKeyDown={
-                        isClickable
-                          ? (e: React.KeyboardEvent) => {
-                              if (e.key === 'Enter' || e.key === ' ') {
-                                e.preventDefault()
-                                handleActivate?.()
-                              }
-                            }
-                          : undefined
-                      }
-                      tabIndex={isClickable ? 0 : undefined}
-                      role={isClickable ? 'button' : undefined}
-                      className={rowClass}
-                    >
-                      <td className="text-foreground px-4 py-2">{item.name}</td>
+                    <tr key={item.name} className={rowClass}>
+                      <td className="text-foreground px-4 py-2">
+                        {isClickable ? (
+                          <button
+                            type="button"
+                            onClick={handleActivate}
+                            className="block w-full cursor-pointer text-left"
+                          >
+                            {item.name}
+                          </button>
+                        ) : (
+                          item.name
+                        )}
+                      </td>
                       <td className="text-foreground px-4 py-2 text-right font-medium">
                         {item.count}
                       </td>

--- a/frontend/src/components/weekend/HouseholdRosterRow.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterRow.tsx
@@ -94,70 +94,84 @@ export function HouseholdRosterRow({ party, showRequests, unit, onOpen }: Househ
   const showAdults = party.grain === 'household'
 
   return (
-    <tr
-      role="button"
-      tabIndex={0}
-      onClick={() => {
-        onOpen(party)
-      }}
-      onKeyDown={(event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault()
-          onOpen(party)
-        }
-      }}
-      className="border-border/40 hover:bg-muted/30 focus-visible:ring-ring cursor-pointer border-b align-top transition-colors focus-visible:ring-2 focus-visible:outline-none"
-    >
-      <td className={`border-l-[3px] py-3 pr-4 pl-3 ${RAIL[attention.level]}`}>
-        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-          <span className="text-foreground text-sm font-semibold">{party.display_name}</span>
-          {party.is_returning === true && (
-            <span
-              title="Stayed with us before"
-              className="text-forest-700 dark:text-forest-300 bg-forest-100 dark:bg-forest-900/50 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold"
-            >
-              <Repeat className="h-3 w-3 flex-shrink-0" />
-              Returning
+    // `role="button"` used to live here, overriding the native `row` role —
+    // `queryAllByRole('row')` collapsed to 1 (the header alone) and the four
+    // `<td>` cells lost their owning row (kindred#2063). The affordance now
+    // lives in a real `<button>` inside the first cell instead, which keeps
+    // row/cell semantics intact and still satisfies `clickoutsidePredicate`'s
+    // `isInteractive` check (`button` is already in its selector list).
+    <tr className="border-border/40 border-b align-top">
+      <td className={`border-l-[3px] ${RAIL[attention.level]}`}>
+        {/* Content below stays `<span>`, never `<div>`/`<p>` — a `<button>`'s
+            content model is phrasing content only, the same reason
+            `FamilyCardBody` (this row's card-view counterpart) is spans
+            throughout. Tailwind's `block`/`flex` classes still give each span
+            the same layout its `<div>`/`<p>` had. */}
+        <button
+          type="button"
+          onClick={() => {
+            onOpen(party)
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault()
+              onOpen(party)
+            }
+          }}
+          className="hover:bg-muted/30 focus-visible:ring-ring block w-full cursor-pointer py-3 pr-4 pl-3 text-left transition-colors focus-visible:ring-2 focus-visible:outline-none"
+        >
+          <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <span className="text-foreground text-sm font-semibold">{party.display_name}</span>
+            {party.is_returning === true && (
+              <span
+                title="Stayed with us before"
+                className="text-forest-700 dark:text-forest-300 bg-forest-100 dark:bg-forest-900/50 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold"
+              >
+                <Repeat className="h-3 w-3 flex-shrink-0" />
+                Returning
+              </span>
+            )}
+          </span>
+          {/* Only the two states that name a real failure get words. "No cabin
+              yet" would repeat the Cabin column's "Unassigned", and an
+              unverified need would repeat the chips under Housing needs — the
+              rail and the section heading already carry the state. */}
+          {(attention.level === 'required' || attention.level === 'unmet') && (
+            <span className={`mt-0.5 block text-xs font-medium ${REASON_TONE[attention.level]}`}>
+              {attention.level === 'required' ? 'Accommodation required' : attention.reason}
             </span>
           )}
-        </div>
-        {/* Only the two states that name a real failure get words. "No cabin
-            yet" would repeat the Cabin column's "Unassigned", and an
-            unverified need would repeat the chips under Housing needs — the
-            rail and the section heading already carry the state. */}
-        {(attention.level === 'required' || attention.level === 'unmet') && (
-          <p className={`mt-0.5 text-xs font-medium ${REASON_TONE[attention.level]}`}>
-            {attention.level === 'required' ? 'Accommodation required' : attention.reason}
-          </p>
-        )}
-        <p className="text-muted-foreground mt-1 text-xs tabular-nums">{composition(party)}</p>
-        {/* Members are reference detail, not scanning material — one wrapped
-            line rather than two stacked ones, so 62 rows stay a page. An
-            adult weekend enrols the individual directly, so the party IS the
-            adult and `display_name` above already named them. */}
-        <p className="text-muted-foreground/75 mt-0.5 text-xs leading-snug">
-          {showAdults &&
-            adults.map((adult, index) => (
-              <Fragment
-                key={`${String(adult.adult_number ?? index)}-${String(adult.display_name)}`}
-              >
-                {index > 0 && ', '}
-                {/* Each name is its own element so it stays one text node —
-                    a separator inside the span would split it. */}
-                <span>{adult.display_name}</span>
+          <span className="text-muted-foreground mt-1 block text-xs tabular-nums">
+            {composition(party)}
+          </span>
+          {/* Members are reference detail, not scanning material — one wrapped
+              line rather than two stacked ones, so 62 rows stay a page. An
+              adult weekend enrols the individual directly, so the party IS the
+              adult and `display_name` above already named them. */}
+          <span className="text-muted-foreground/75 mt-0.5 block text-xs leading-snug">
+            {showAdults &&
+              adults.map((adult, index) => (
+                <Fragment
+                  key={`${String(adult.adult_number ?? index)}-${String(adult.display_name)}`}
+                >
+                  {index > 0 && ', '}
+                  {/* Each name is its own element so it stays one text node —
+                      a separator inside the span would split it. */}
+                  <span>{adult.display_name}</span>
+                </Fragment>
+              ))}
+            {children.map((child, index) => (
+              <Fragment key={String(child.person_cm_id ?? index)}>
+                {(index > 0 || (showAdults && adults.length > 0)) && ' · '}
+                <span>
+                  {child.age === null || child.age === undefined
+                    ? child.display_name
+                    : `${String(child.display_name)} (${String(child.age)})`}
+                </span>
               </Fragment>
             ))}
-          {children.map((child, index) => (
-            <Fragment key={String(child.person_cm_id ?? index)}>
-              {(index > 0 || (showAdults && adults.length > 0)) && ' · '}
-              <span>
-                {child.age === null || child.age === undefined
-                  ? child.display_name
-                  : `${String(child.display_name)} (${String(child.age)})`}
-              </span>
-            </Fragment>
-          ))}
-        </p>
+          </span>
+        </button>
       </td>
 
       <td className="py-3 pr-4">

--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -313,6 +313,25 @@ describe('HouseholdRosterTable', () => {
     expect(screen.getByText('The Johnson Family')).toBeInTheDocument()
     expect(screen.getByText('Olivia Chen')).toBeInTheDocument()
   })
+
+  it('renders one table row per party, not collapsed into the header (kindred#2063)', () => {
+    // `role="button"` on the row's own `<tr>` overrides the native `row`
+    // role — `queryAllByRole('row')` had collapsed to 1 (the header alone),
+    // and the four `<td>` cells lost their owning row.
+    render(
+      <HouseholdRosterTable
+        year={2026}
+        parties={[
+          party({ display_name: 'Johnson Family', household_cm_id: 2000001 }),
+          party({ display_name: 'Chen Family', household_cm_id: 2000002 }),
+        ]}
+      />,
+      { wrapper }
+    )
+    // Header row + one row per party. Both parties share an attention
+    // section here, so there is no extra section-heading row to account for.
+    expect(screen.getAllByRole('row')).toHaveLength(3)
+  })
 })
 
 describe('HouseholdRosterTable — the row opens FamilyDetailsPanel (kindred#1996)', () => {


### PR DESCRIPTION
## What broke

`role="button"` on a `<tr>` overrides the native `row` role. Measured on the weekend roster: `queryAllByRole('row')` returned **1** (the header only) instead of one per household, the four `<td>` cells had no owning row, and the row's accessible name collapsed to ~200 characters of concatenated cell text. Table navigation and column-header association were gone.

Two surfaces had this pattern and needed fixing together (fixing one alone would make them diverge, which is the whole reason this was filed as one issue):

- `frontend/src/components/metrics/geo/GeoDetailList.tsx` — since #539
- `frontend/src/components/weekend/HouseholdRosterRow.tsx` — since #2058

## The fix

Kept `<tr>` / `row` semantics on both surfaces. Moved the click affordance into a real `<button>` inside the first cell instead — that preserves both the row structure and a discoverable, native control.

Content inside the button stays `<span>` throughout rather than `<div>`/`<p>`, because a `<button>`'s content model is phrasing content only. That's the same reason `FamilyCardBody` (the row's card-view counterpart) is spans throughout — Tailwind's `block`/`flex` classes still give each span the same layout its `<div>`/`<p>` had.

**`HouseholdRosterRow`** keeps its manual `onKeyDown` (`preventDefault` + call) rather than relying purely on native Enter/Space activation, because the existing raw-`fireEvent` Space test asserts on it directly and jsdom doesn't simulate native button keyboard defaults. Verified this doesn't double-fire `onOpen`: `preventDefault()` in the keydown handler correctly suppresses the synthetic click `userEvent` would otherwise also produce for a real button.

**`GeoDetailList`** drops its manual keydown handler entirely and relies on native `<button>` semantics — matching this same file's own header/expand button, which already does the same. Its two keyboard tests moved from raw `fireEvent.keyDown` (which never simulated native button activation, before or after this change) to `userEvent.keyboard()`.

## The trap this had to avoid

`role="button"` on the `HouseholdRosterRow` `<tr>` was load-bearing for click-outside behavior — `shouldKeepPanelsOpen` (`utils/clickoutsidePredicate.ts`) classifies a click as "interactive" partly by role, which is what stops a click on a second row (while the panel is open) from reading as dead space and fighting `useDismissOnDeadSpace` into a close-then-reopen.

A real `<button>` satisfies the same `isInteractive` check — `button` is already in `clickoutsidePredicate`'s selector list, no change needed there. The existing test that opens the panel from row A, clicks row B, and asserts the panel DOM node is the same node (no remount) stays green unmodified — verified directly, not just by inspection.

## Test changes

Following from the issue's own ruling, not from fitting tests to the implementation:

- `HouseholdRosterTable.test.tsx`: added the issue's own regression guard — `queryAllByRole('row')` returns one row per party plus the header, not 1.
- `GeoDetailList.test.tsx`: same row-count regression guard; the two keyboard-activation tests switched to `userEvent.keyboard()` (raw `fireEvent` can't simulate native button activation in jsdom); the region-row test gained an explicit assertion that non-clickable rows get no button at all, not just an inert `<tr>`.

## Verification

- `npx vitest run` — 414 files / 5898 tests passed
- `npm run type-check` — clean
- `./node_modules/.bin/eslint` on changed files — clean
- Pre-push hook (ruff, go build, shellcheck, pb-js-lint, markdownlint, mypy, tsc, pytest 6010 passed) — all green

Closes #2063.